### PR TITLE
Fix powerline separators and make them configurable

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -384,6 +384,7 @@ inserted in the buffer (if it is not read-only)."
       (setq-default powerline-default-separator 'wave)
       (setq-default mode-line-format '("%e" (:eval
           (let* ((active (eq (frame-selected-window) (selected-window)))
+                 (line-face (if active 'mode-line 'mode-line-inactive))
                  (face1 (if active 'powerline-active1 'powerline-inactive1))
                  (face2 (if active 'powerline-active2 'powerline-inactive2))
                  (state-face (if active (spacemacs/current-state-face) face2))
@@ -404,7 +405,7 @@ inserted in the buffer (if it is not read-only)."
                       ;; window number
                       ;; (funcall separator-left state-face face1)
                       (powerline-raw (spacemacs/window-number) state-face)
-                      (funcall separator-right state-face nil)
+                      (funcall separator-right state-face line-face)
                       ;; evil state
                       ;; (powerline-raw evil-mode-line-tag state-face)
                       ;; (funcall separator-right state-face nil)
@@ -414,10 +415,10 @@ inserted in the buffer (if it is not read-only)."
                       (powerline-buffer-id nil 'l)
                       (powerline-raw " " nil)
                       ;; major mode
-                      (funcall separator-left nil face1)
+                      (funcall separator-left line-face face1)
                       (powerline-major-mode face1 'l)
                       (powerline-raw " " face1)
-                      (funcall separator-right face1 nil))
+                      (funcall separator-right face1 line-face))
                       ;; flycheck
                       (if flycheckp
                           (list
@@ -431,9 +432,9 @@ inserted in the buffer (if it is not read-only)."
                       ;; separator between flycheck and minor modes
                       (if (and flycheckp spacemacs-mode-line-minor-modesp)
                           (list
-                           (funcall separator-left nil face1)
+                           (funcall separator-left line-face face1)
                            (powerline-raw "  " face1)
-                           (funcall separator-right face1 nil)))
+                           (funcall separator-right face1 line-face)))
                       ;; minor modes
                       (if spacemacs-mode-line-minor-modesp
                           (list
@@ -442,7 +443,7 @@ inserted in the buffer (if it is not read-only)."
                            (powerline-raw " " nil)))
                       ;; version control
                       (if (or flycheckp spacemacs-mode-line-minor-modesp)
-                          (list (funcall separator-left (if vc-face nil face1) vc-face)))
+                          (list (funcall separator-left (if vc-face line-face face1) vc-face)))
                       (list
                        (powerline-vc vc-face)
                        (powerline-raw " " vc-face)
@@ -451,10 +452,10 @@ inserted in the buffer (if it is not read-only)."
                        (funcall separator-right face2 face1)
                        (powerline-raw " " face1)
                        (powerline-raw "%l:%2c" face1 'r)
-                       (funcall separator-left face1 nil)
+                       (funcall separator-left face1 line-face)
                        (powerline-raw " " nil)
                        (powerline-raw "%p" nil 'r)
-                       (powerline-chamfer-left nil face1)
+                       (powerline-chamfer-left line-face face1)
                        ;; display hud only if necessary
                        (let ((progress (format-mode-line "%p")))
                          (if (string-match "\%" progress)


### PR DESCRIPTION
This fixes #18. Powerline dividers now render at the right height on emacs cocoa, they are still aliased but that can be another PR.

This also allows the powerline separator to be configured by the user using the `powerline-default-separator` variable that is built into powerline.

The problem was that to fix another bug powerline stopped calculating the height of the bar and used the font height for the separators. I think one of the fancy spacemacs things made the bar higher than the font height, causing the separators to be the wrong height. This was fixed by setting the `powerline-height` variable to a reasonable value.

The other changes are unrelated to the bug, they just make the theme use the `powerline-default-separator` variable so that it can be changed by the user. My editor (currently ST3, but that will change soon) also trimmed all trailing whitespace in the file, not a bad thing.

**Edit:** I also fixed the aliasing a bit. See my comment for an updated screenshot.
### Screenshot:

![screen shot 2014-10-18 at 10 54 49 am](https://cloud.githubusercontent.com/assets/887610/4690000/bc3ae2a4-56d6-11e4-9c67-3842c23bbbb7.png)
(taken after height fix but before aliasing fix.)
