### PR TITLE
Swapped melpa.milkbox.net to melpa.org

### DIFF
--- a/core/contribsys.el
+++ b/core/contribsys.el
@@ -2,7 +2,7 @@
 (require 'package)
 (setq package-archives '(("ELPA" . "http://tromey.com/elpa/")
                          ("gnu" . "http://elpa.gnu.org/packages/")
-                         ("melpa" . "http://melpa.milkbox.net/packages/")))
+                         ("melpa" . "http://melpa.org/packages/")))
 (package-initialize)
 (setq warning-minimum-level :error)
 


### PR DESCRIPTION
They have a new domain: http://www.reddit.com/r/emacs/comments/2k2kmv/melpamilkboxnet_is_now_melpaorg/
