### PR TITLE
Fix My Contrib Module's Ag Support

### DIFF
--- a/contrib/trishume/packages.el
+++ b/contrib/trishume/packages.el
@@ -9,6 +9,7 @@
     julia-mode
     helm-ag
     lua-mode
+    ag
     ))
 
 (defun trishume/init-auctex ()
@@ -80,7 +81,7 @@
         (interactive)
         (helm-ag (projectile-project-root)))
       (evil-leader/set-key
-        "pa" 'trishume-helm-ag))))
+        "oa" 'trishume-helm-ag))))
 
 (defun trishume/init-lua-mode ()
   (use-package lua-mode


### PR DESCRIPTION
My contrib module currently crashes the startup sequence because the `<SPC> p a` binding conflicts with the new way projectile is done.

I changed the hotkey to `<SPC> o a`, which is in the unused `o` namespace which I'm using for all my contrib shortcuts. I also added the `ag` module so that the Ag in projectile-commander will work.
