### PR TITLE
Better smarparens behaviour for braces

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1828,6 +1828,19 @@ DELETE-FUNC when calling CALLBACK.
       (spacemacs//diminish smartparens-mode " (Ⓢ)"))
     :config
     (progn
+      (defun spacemacs/smartparens-pair-newline (id action context)
+        (save-excursion
+          (newline)
+          (indent-according-to-mode)))
+
+      (defun spacemacs/smartparens-pair-newline-and-indent (id action context)
+        (spacemacs/smartparens-pair-newline id action context)
+        (indent-according-to-mode))
+
+      (sp-pair "{" nil :post-handlers
+               '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
+      (sp-pair "[" nil :post-handlers
+               '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
       (sp-local-pair 'emacs-lisp-mode "'" nil :actions nil))))
 
 (defun spacemacs/init-smeargle ()


### PR DESCRIPTION
For curly braced languages like C, currently the brace behaviour is very annoying.

Typing this `int main() {` and hitting enter produces:

``` c
int main() {
|} // | is the cursor
```

With the changes in this PR typing the same thing and hitting enter produces:

``` c
int main() {
    |
}
```

@Wolfy87 I know you use Spacemacs for JS, have you had this problem?
