### PR TITLE
Add More Modes To My Contrib Layer

### DIFF
--- a/contrib/ranger-control/config.el
+++ b/contrib/ranger-control/config.el
@@ -1,2 +1,2 @@
 (evil-leader/set-key
-   "pc" 'ranger-control/projectile-cd)
+   "oc" 'ranger-control/projectile-cd)

--- a/contrib/trishume/config.el
+++ b/contrib/trishume/config.el
@@ -1,0 +1,8 @@
+(dolist (mode '(c++
+                json
+                racket
+                elisp
+                LaTeX
+                yaml))
+  (add-hook (intern (concat (symbol-name mode) "-mode-hook"))
+            'flycheck-mode))

--- a/contrib/trishume/packages.el
+++ b/contrib/trishume/packages.el
@@ -9,6 +9,9 @@
     julia-mode
     helm-ag
     lua-mode
+    racket-mode
+    go-mode
+    yaml-mode
     ag
     ))
 
@@ -86,3 +89,19 @@
 (defun trishume/init-lua-mode ()
   (use-package lua-mode
     :defer t))
+
+(defun trishume/init-go-mode ()
+  (use-package go-mode
+    :defer t))
+
+(defun trishume/init-yaml-mode ()
+  (use-package yaml-mode
+    :defer t))
+
+(defun trishume/init-racket-mode ()
+  (use-package racket-mode
+    :defer t
+    :config
+    (add-hook 'racket-mode-hook
+          '(lambda ()
+             (define-key racket-mode-map (kbd "H-r") 'racket-run)))))


### PR DESCRIPTION
Adds Golang, YAML and Racket modes to my contrib packages. 

Also adds some more languages to flycheck and fixes a ranger-control conflict.
