### PR TITLE
fixed bug #72 and use C-j and C-k in auto-completion

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -272,10 +272,6 @@ DELETE-FUNC when calling CALLBACK.
               (if shadowed (call-interactively shadowed)))))))
       ;; easier toggle for emacs-state
       (evil-set-toggle-key "s-`")
-      ;; moves `evil-insert-digraph' to C-i in order to free up C-k for
-      ;; candidate selection in auto-complete.
-      (define-key evil-insert-state-map (kbd "C-k") nil)
-      (define-key evil-insert-state-map (kbd "C-i") 'evil-insert-digraph)
       ;; escape state with a better key sequence than ESC
       (let* ((seq spacemacs-normal-state-sequence)
              (key (char-to-string (car spacemacs-normal-state-sequence)))
@@ -628,9 +624,9 @@ DELETE-FUNC when calling CALLBACK.
       (ac-config-default)
       (add-to-list 'completion-styles 'initials t)
       (evil-leader/set-key "ta" 'auto-complete-mode)
-      (define-key ac-mode-map (kbd "C-j") 'ac-next)
-      (define-key ac-mode-map (kbd "C-k") 'ac-previous)
-      (define-key ac-mode-map (kbd "<S-tab>") 'ac-previous)
+      (define-key ac-completing-map (kbd "C-j") 'ac-next)
+      (define-key ac-completing-map (kbd "C-k") 'ac-previous)
+      (define-key ac-completing-map (kbd "<S-tab>") 'ac-previous)
       ;; customization
       (setq ac-auto-start 2
             ac-delay 0.


### PR DESCRIPTION
This should fixed https://github.com/syl20bnr/spacemacs/issues/72 . `C-j` and `C-k` in auto-complete should also work.
