### PR TITLE
Don't pair apostrophe in markdown mode

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1850,6 +1850,7 @@ DELETE-FUNC when calling CALLBACK.
                '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
       (sp-pair "[" nil :post-handlers
                '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
+      (sp-local-pair 'markdown-mode "'" nil :actions nil)
       (sp-local-pair 'emacs-lisp-mode "'" nil :actions nil))))
 
 (defun spacemacs/init-smeargle ()


### PR DESCRIPTION
Before making this change typing markdown was annoying since when writing things like "it's fun to use emacs" the `'` would auto-pair, which you don't want when writing English (or any other natural language for that matter).
