### PR TITLE
fixed indentation of evil-open-below and evil-open-above in coffee-mode

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1983,3 +1983,19 @@ DELETE-FUNC when calling CALLBACK.
 (defun spacemacs/init-zenburn-theme ()
   (use-package zenburn-theme
     :defer t))
+
+(defun spacemacs/init-coffee-mode ()
+  (use-package coffee-mode
+    :defer t
+    :init
+    (progn
+      (defun spacemacs/coffee-indent ()
+        (if (coffee-line-wants-indent)
+            ;; We need to insert an additional tab because the last line was special.
+            (coffee-insert-spaces (+ (coffee-previous-indent) coffee-tab-width))
+          ;; otherwise keep at the same indentation level
+          (coffee-insert-spaces (coffee-previous-indent)))
+        )
+      ;; indent to right position after `evil-open-blow' and `evil-open-above'
+      (add-hook 'coffee-mode-hook '(lambda () (setq indent-line-function 'spacemacs/coffee-indent)))
+      )))


### PR DESCRIPTION
This is to fix incorrect indentation of a newline after calling `evil-open-below` and `evil-open-above` functions, which are bound to `o` and `O`, respectively.  

Currently, both functions only add one `coffee-tab-width` from beginning of a new line. With this fix, new line is indented according to previous non-empty line.

To clarify what I mean, see below example. `|` indicates cursor position.

``` coffee-mode
if true:
  if true:
    if |true:
```

Currently if I hit `o` in normal state, cursor will position at:

``` coffee-mode
if true:
  if true:
    if true:
  |
```

With this fix, cursor will position at:

``` coffee-mode
if true:
  if true:
    if true:
      |
```

This is also consistent with `coffee-newline-and-indent` function.
