### PR TITLE
Begin cleaning out persistent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ eproject.lst
 .smex-items
 \#*
 .places
+.cache
 eshell/history
 .emacs.desktop
 .emacs.desktop.lock

--- a/init.el
+++ b/init.el
@@ -18,6 +18,11 @@
   (defconst spacemacs-contrib-config-directory
     (expand-file-name (concat user-emacs-directory "contrib/"))
     "Spacemacs contribution layers base directory.")
+  (defconst spacemacs-cache-directory
+    (expand-file-name (concat user-emacs-directory ".cache/"))
+    "Spacemacs storage area for persistent files.")
+  (if (not (file-exists-p spacemacs-cache-directory))
+      (make-directory spacemacs-cache-directory))
   (defconst user-dropbox-directory
     (expand-file-name (concat user-home-directory "Dropbox/"))
     "Dropbox directory.")

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -4,6 +4,7 @@
 
 (ido-mode t)
 (setq ido-enable-flex-matching t) ;; enable fuzzy matching
+(setq ido-save-directory-list-file (concat spacemacs-cache-directory "ido.last"))
 ;; Auto refresh buffers
 (global-auto-revert-mode 1)
 ;; Also auto refresh dired, but be quiet about it
@@ -118,7 +119,21 @@
 ;; Save point position between sessions
 (require 'saveplace)
 (setq-default save-place t)
-(setq save-place-file (expand-file-name ".places" user-emacs-directory))
+(setq save-place-file (concat spacemacs-cache-directory "places"))
+
+;; minibuffer history
+(require 'savehist)
+(setq savehist-file (concat spacemacs-cache-directory "savehist")
+      enable-recursive-minibuffers t ; Allow commands in minibuffers
+      history-length 1000
+      savehist-additional-variables '(search ring regexp-search-ring)
+      savehist-autosave-interval 60)
+(savehist-mode +1)
+
+;; bookmarks
+(setq bookmark-default-file (concat spacemacs-cache-directory "bookmarks"))
+(setq bookmark-save-flag 1) ;; save after every change
+
 ;; keep buffers opened when leaving an emacs client
 (setq server-kill-new-buffers nil)
 ;; increase memory threshold for GC

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1884,8 +1884,9 @@ DELETE-FUNC when calling CALLBACK.
     :defer t
     :config
     (progn
-      (setq recentf-exclude '("~/.emacs.d/.recentf"))
-      (setq recentf-save-file (concat user-emacs-directory "/.recentf"))
+      (setq recentf-exclude '("~/.emacs.d/.cache"))
+      (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
+      (setq recentf-save-file (concat spacemancs-cache-directory "/recentf"))
       (setq recentf-max-saved-items 100)
       (setq recentf-auto-cleanup 'never)
       (setq recentf-auto-save-timer (run-with-idle-timer 600 t 'recentf-save-list)))))
@@ -1975,7 +1976,14 @@ DELETE-FUNC when calling CALLBACK.
 
 (defun spacemacs/init-undo-tree ()
   (use-package undo-tree
+    :idle (global-undo-tree-mode)
     :defer t
+    :init
+    (setq undo-tree-auto-save-history t) ; save undo history between sessions
+    (setq undo-tree-history-directory-alist
+          `(("." . ,(concat spacemacs-cache-directory "undo"))))
+    (setq undo-tree-visualizer-timestamps t)
+    (setq undo-tree-visualizer-diff t)    
     :config
     (spacemacs//hide-lighter undo-tree-mode)))
 


### PR DESCRIPTION
Added some Evil updates and started moving all persistent files to the .cache directory to clean up the root of the repo.  I probably missed some files, but got it started.  

Also sneaked in persistent history for M-x and undo.
