### PR TITLE
added noh command to clean up persisted highlighting as vim do by defaul...

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -392,7 +392,8 @@ DELETE-FUNC when calling CALLBACK.
       (use-package evil-search-highlight-persist
         :init
         (global-evil-search-highlight-persist)
-        (evil-leader/set-key "sc" 'evil-search-highlight-persist-remove-all))
+        (evil-leader/set-key "sc" 'evil-search-highlight-persist-remove-all)
+        (evil-ex-define-cmd "noh" 'evil-search-highlight-persist-remove-all))
       ;; add a lisp state
       (use-package evil-lisp-state
         :init
@@ -1365,7 +1366,7 @@ DELETE-FUNC when calling CALLBACK.
 
 (defun spacemacs/init-helm ()
   (use-package helm
-    :idle (helm-mode +1) 
+    :idle (helm-mode +1)
     :defer t
     :init
     (setq helm-split-window-in-side-p nil


### PR DESCRIPTION
I've added an evil command `noh` to clean up highlighting after search.
