### PR TITLE
Fancy narrow is prettier than normal narrow

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -39,6 +39,7 @@
     evil-visualstar
     exec-path-from-shell
     expand-region
+    fancy-narrow
     fill-column-indicator
     fish-mode
     flx-ido
@@ -986,6 +987,18 @@ DELETE-FUNC when calling CALLBACK.
     (custom-set-variables
      '(expand-region-contract-fast-key "V")
      '(expand-region-reset-fast-key "r"))))
+
+(defun spacemacs/init-fancy-narrow ()
+  (use-package fancy-narrow
+    :init
+    (setq fancy-narrow-mode t)
+    :config
+    (evil-leader/set-key
+      "nr" 'fancy-narrow-to-region
+      "np" 'fancy-narrow-to-page
+      "nf" 'fancy-narrow-to-defun
+      "nw" 'fancy-widen)
+    ))
 
 (defun spacemacs/init-fill-column-indicator ()
   (setq fci-rule-width 1)


### PR DESCRIPTION
Still has one bug where the bindings are overwritten by keybindings.el.  Is there a way to overwrite those bindings if fancy-narrow is enabled?
