### PR TITLE
Python contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ for contribution guidelines_
             - [Org](#org)
             - [Perforce](#perforce)
             - [Python](#python)
-                - [Inferior REPL process](#inferior-repl-process)
-                - [Testing in Python](#testing-in-python)
-                - [Other Python commands](#other-python-commands)
             - [JavaScript](#javascript)
             - [rcirc](#rcirc)
     - [Tips](#tips)
@@ -710,6 +707,7 @@ eⓅ           | [e-project][e-project] mode
 Ⓢ            | flyspell mode
 (Ⓢ)          | [smartparens][sp] mode
 Ⓨ            | [yasnippet][yasnippet] mode
+(Ⓐ)           | [anaconda-mode][anaconda-mode]
 
 **Note:** in terminal the regular indicators are used instead of the utf-8
 ones.
@@ -1548,55 +1546,7 @@ In `org`, [evil-org-mode][evil-org-mode] is activated.
 
 #### Python
 
-##### Inferior REPL process
-
-Start an iPython inferior REPL process with `<SPC> m i`.
-
-Send code to inferior process commands:
-
-    Key Binding   |                 Description
-------------------|------------------------------------------------------------
-`<SPC> m b`       | send buffer and keep code buffer focused
-`<SPC> m B`       | send buffer and switch to REPL in insert mode
-`<SPC> m f`       | send function and keep code buffer focused
-`<SPC> m F`       | send function and switch to REPL in insert mode
-`<SPC> m r`       | send region and keep code buffer focused
-`<SPC> m R`       | send region and switch to REPL in insert mode
-`CTRL+j`          | next item in REPL history
-`CTRL+k`          | previous item in REPL history
-
-##### Testing in Python
-
-`Spacemacs` uses [nose][nose] as a test runner. An improved version of
-[nose.el][nose.el] is shipped with `Spacemacs`, this version adds:
-- windows support
-- test suite support
-
-The root of the project is detected with a `.git` directory or a `setup.cfg` file.
-
-Test commands (start with `m t` or `m T`):
-
-    No Debug      |                 Description
-------------------|------------------------------------------------------------
-<SPC> m t a       | launch all tests of the project
-<SPC> m t f       | launch the current test under point
-<SPC> m t m       | launch all tests of the current module
-<SPC> m t s       | launch all tests of the current suite
-
-     Debug        |                 Description
-------------------|------------------------------------------------------------
-<SPC> m T a       | launch all tests of the project in debug mode
-<SPC> m T f       | launch the current test under point in debug mode
-<SPC> m T m       | launch all tests of the current module in debug mode
-<SPC> m T s       | launch all tests of the current suite in debug mode
-
-##### Other Python commands
-
-    Key Binding   |                 Description
-------------------|------------------------------------------------------------
-`<SPC> m d`       | open documentation in `firefox` using [pylookup][pylookup]
-`<SPC> m g`       | go to definition using [emacs-jedi][jedi]
-`<SPC> m p`       | add a breakpoint
+Writing python code with spacemacs is supported by python contribution. Please see [python contribution][python-contrib] documentation for detail.
 
 #### JavaScript
 
@@ -1738,6 +1688,7 @@ developers to elisp hackers!
 [tern-auto-complete]: https://github.com/marijnh/tern/blob/master/emacs/tern-auto-complete.el
 [tern]: http://ternjs.net/
 [themes-megapack]: https://github.com/syl20bnr/spacemacs/tree/master/contrib/themes-megapack
+[python-contrib]: https://github.com/syl20bnr/spacemacs/tree/master/contrib/lang/python
 [guide-key]: https://github.com/kai2nenobu/guide-key
 [guide-key-tip]: https://github.com/aki2o/guide-key-tip
 [gitter]: https://gitter.im/syl20bnr/spacemacs
@@ -1750,3 +1701,4 @@ developers to elisp hackers!
 [1st-clayer]: https://github.com/syl20bnr/spacemacs/commit/e802027d75d0c0aed55539b0da2dfa0df94dfd39
 [1st-arctile]: http://oli.me.uk/2014/11/06/spacemacs-emacs-vim/
 [100th-issue]: https://github.com/syl20bnr/spacemacs/pull/100
+[anaconda-mode]: https://github.com/proofit404/anaconda-mode

--- a/contrib/lang/python/README.md
+++ b/contrib/lang/python/README.md
@@ -1,0 +1,93 @@
+# Python contribution layer for Spacemacs
+
+## Features
+
+- **Auto-completion**
+- **Code Navigation**
+- **Virtual Environment**
+- **Documentation Lookup**
+- **Running Tests**
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(defvar dotspacemacs-configuration-layers '(python)
+  "List of contribution to load."
+)
+```
+
+Because spacemacs is using [anaconda-mode][anaconda-mode] as emacs
+interface to `jedi` library, you may need to install jedi in order to
+use code completion. You may install jedi by running following command
+in your python environment:
+
+```shell
+$ pip install jedi
+```
+
+## Key Bindings
+
+### Inferior REPL process
+
+Start an (i)Python inferior REPL process with `<SPC> m i`.  If
+`ipython` is available in system executable search paths, `ipython`
+will be used to launch python shell; otherwise, default `python`
+interpreter will be used.  You may change your system executable
+search path by activating a virtual environment.
+
+Send code to inferior process commands:
+
+    Key Binding   |                 Description
+------------------|------------------------------------------------------------
+`<SPC> m b`       | send buffer and keep code buffer focused
+`<SPC> m B`       | send buffer and switch to REPL in insert mode
+`<SPC> m f`       | send function and keep code buffer focused
+`<SPC> m F`       | send function and switch to REPL in insert mode
+`<SPC> m r`       | send region and keep code buffer focused
+`<SPC> m R`       | send region and switch to REPL in insert mode
+`CTRL+j`          | next item in REPL history
+`CTRL+k`          | previous item in REPL history
+
+### Testing in Python
+
+`Spacemacs` uses [nose][nose] as a test runner. An improved version of
+[nose.el][nose.el] is shipped with `Spacemacs`, this version adds:
+- windows support
+- test suite support
+
+The root of the project is detected with a `.git` directory or a `setup.cfg` file.
+
+Test commands (start with `m t` or `m T`):
+
+    No Debug      |                 Description
+------------------|------------------------------------------------------------
+<SPC> m t a       | launch all tests of the project
+<SPC> m t f       | launch the current test under point
+<SPC> m t m       | launch all tests of the current module
+<SPC> m t s       | launch all tests of the current suite
+
+     Debug        |                 Description
+------------------|------------------------------------------------------------
+<SPC> m T a       | launch all tests of the project in debug mode
+<SPC> m T f       | launch the current test under point in debug mode
+<SPC> m T m       | launch all tests of the current module in debug mode
+<SPC> m T s       | launch all tests of the current suite in debug mode
+
+### Other Python commands
+
+    Key Binding   |                 Description
+------------------|------------------------------------------------------------
+`<SPC> m d`       | open documentation in `firefox` using [pylookup][pylookup]
+`<SPC> m g`       | go to definition using `anaconda-mode-goto` (`C-o` to jump back)
+`<SPC> m p`       | toggle a breakpoint
+`<SPC> m v`       | activate a virtual environment with [pyvenv][pyvenv]
+
+## Screenshots
+
+[anaconda-mode]: https://github.com/proofit404/anaconda-mode
+[pyvenv]: https://github.com/jorgenschaefer/pyvenv
+[pylookup]: https://github.com/tsgates/pylookup
+[nose]: https://github.com/nose-devs/nose/
+[nose.el]: https://github.com/syl20bnr/nose.el

--- a/contrib/lang/python/extensions.el
+++ b/contrib/lang/python/extensions.el
@@ -1,0 +1,54 @@
+;; Extensions are in emacs_paths/extensions
+
+;; Pre extensions are loaded *before* the packages
+(defvar python-pre-extensions
+  '(
+    ))
+
+;; Post extensions are loaded *after* the packages
+(defvar python-post-extensions
+  '(
+    nose
+    pylookup
+    ))
+
+;; Initialize the extensions
+
+(defun python/init-nose ()
+  (use-package nose
+    :commands (nosetests-one
+               nosetests-pdb-one
+               nosetests-all
+               nosetests-pdb-all
+               nosetests-module
+               nosetests-pdb-module
+               nosetests-suite
+               nosetests-pdb-suite)
+    :init
+    (evil-leader/set-key-for-mode 'python-mode
+      "mTf" 'nosetests-pdb-one
+      "mtf" 'nosetests-one
+      "mTa" 'nosetests-pdb-all
+      "mta" 'nosetests-all
+      "mTm" 'nosetests-pdb-module
+      "mtm" 'nosetests-module
+      "mTs" 'nosetests-pdb-suite
+      "mts" 'nosetests-suite)
+    :config
+    (progn
+      (add-to-list 'nose-project-root-files "setup.cfg")
+      (setq nose-use-verbose nil)
+      )))
+
+(defun python/init-pylookup ()
+  (use-package pylookup
+    :commands pylookup-lookup
+    :config
+    (progn
+      (add-to-list 'evil-emacs-state-modes 'pylookup-mode)
+      (evil-add-hjkl-bindings pylookup-mode-map 'emacs)
+      (let* ((layer (assq 'python spacemacs-config-layers))
+             (dir (plist-get (cdr layer) :ext-dir)))
+        (setq pylookup-dir (concat dir "/pylookup")
+              pylookup-program (concat pylookup-dir "/pylookup.py")
+              pylookup-db-file (concat pylookup-dir "/pylookup.db"))))))

--- a/contrib/lang/python/funcs.el
+++ b/contrib/lang/python/funcs.el
@@ -1,0 +1,21 @@
+;; from http://pedrokroger.net/2010/07/configuring-emacs-as-a-python-ide-2/
+(defun annotate-pdb ()
+  "Highlight break point lines."
+  (interactive)
+  (highlight-lines-matching-regexp "import i?pdb")
+  (highlight-lines-matching-regexp "i?pdb.set_trace()"))
+
+(defun python-toggle-breakpoint ()
+  "Add a break point, highlight it."
+  (interactive)
+  (let ((trace (if (executable-find "ipdb")
+                   "import ipdb; ipdb.set_trace()"
+                 "import pdb; pdb.set_trace()"))
+        (line (thing-at-point 'line)))
+    (if (and line (string-match trace line))
+        (kill-whole-line)
+      (progn
+        (back-to-indentation)
+        (insert-string trace)
+        (insert-string "\n")
+        (python-indent-line)))))

--- a/spacemacs/extensions.el
+++ b/spacemacs/extensions.el
@@ -16,9 +16,7 @@
     evil-org-mode
     evil-plugins
     helm-rcirc
-    nose
     o-blog
-    pylookup
     spray
     ))
 
@@ -65,48 +63,9 @@
     :init
     (evil-leader/set-key "irc" 'helm-rcirc-auto-join-channels)))
 
-(defun spacemacs/init-nose ()
-  (use-package nose
-    :commands (nosetests-one
-               nosetests-pdb-one
-               nosetests-all
-               nosetests-pdb-all
-               nosetests-module
-               nosetests-pdb-module
-               nosetests-suite
-               nosetests-pdb-suite)
-    :init
-    (evil-leader/set-key-for-mode 'python-mode
-      "mTf" 'nosetests-pdb-one
-      "mtf" 'nosetests-one
-      "mTa" 'nosetests-pdb-all
-      "mta" 'nosetests-all
-      "mTm" 'nosetests-pdb-module
-      "mtm" 'nosetests-module
-      "mTs" 'nosetests-pdb-suite
-      "mts" 'nosetests-suite)
-    :config
-    (progn
-      (add-to-list 'nose-project-root-files "setup.cfg")
-      (setq nose-use-verbose nil)
-      )))
-
 (defun spacemacs/init-o-blog ()
   (use-package o-blog
     :defer t))
-
-(defun spacemacs/init-pylookup ()
-  (use-package pylookup
-    :commands pylookup-lookup
-    :config
-    (progn
-      (add-to-list 'evil-emacs-state-modes 'pylookup-mode)
-      (evil-add-hjkl-bindings pylookup-mode-map 'emacs)
-      (let* ((layer (assq 'spacemacs spacemacs-config-layers))
-             (dir (plist-get (cdr layer) :ext-dir)))
-        (setq pylookup-dir (concat dir "/pylookup")
-              pylookup-program (concat pylookup-dir "/pylookup.py")
-              pylookup-db-file (concat pylookup-dir "/pylookup.db"))))))
 
 (defun spacemacs/init-revive ()
   (use-package revive

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -69,7 +69,6 @@
     hl-anything
     hy-mode
     ido-vertical-mode
-    jedi
     js2-mode
     json-mode
     ledger-mode
@@ -96,7 +95,6 @@
     powershell-mode
     projectile
     puppet-mode
-    python
     ;; not working well for now
     ;; rainbow-blocks
     rainbow-delimiters
@@ -928,7 +926,6 @@ determine the state to enable when escaping from the insert state.")
                       elixir
                       js
                       json
-                      python
                       ruby
                       scss
                       web))
@@ -1631,87 +1628,6 @@ determine the state to enable when escaping from the insert state.")
         "Find file in project using helm."
         (helm-projectile))
       (spacemacs//hide-lighter projectile-mode))))
-
-(defun spacemacs/init-python ()
-  (use-package python
-    :defer t
-    :init
-    (progn
-      (add-hook 'python-mode-hook
-                '(lambda() (setq mode-name "Python"
-                                 tab-width 4)))
-      ;; from http://pedrokroger.net/2010/07/configuring-emacs-as-a-python-ide-2/
-      (defun annotate-pdb ()
-        "Highlight break point lines."
-        (interactive)
-        (highlight-lines-matching-regexp "import pdb")
-        (highlight-lines-matching-regexp "pdb.set_trace()"))
-      (add-hook 'python-mode-hook 'annotate-pdb)
-      (setq
-       python-shell-interpreter "ipython"
-       ;; python-shell-interpreter-args (if (system-is-mac)
-       ;;                                   "--gui=osx --matplotlib=osx --colors=Linux"
-       ;;                                 (if (system-is-linux)
-       ;;                                     "--gui=wx --matplotlib=wx --colors=Linux"))
-       python-shell-prompt-regexp "In \\[[0-9]+\\]: "
-       python-shell-prompt-output-regexp "Out\\[[0-9]+\\]: "
-       python-shell-completion-setup-code "from IPython.core.completerlib import module_completion"
-       python-shell-completion-module-string-code "';'.join(module_completion('''%s'''))\n"
-       python-shell-completion-string-code "';'.join(get_ipython().Completer.all_completions('''%s'''))\n")
-      (use-package jedi
-        :defer t
-        :init
-        (progn
-          (setq jedi:setup-keys t)
-          (add-hook 'python-mode-hook 'jedi:setup))
-        :config
-        (progn
-          (setq jedi:complete-on-dot t))))
-    :config
-    (progn
-      ;; from http://pedrokroger.net/2010/07/configuring-emacs-as-a-python-ide-2/
-      (defun python-add-breakpoint ()
-        "Add a break point, highlight it and save the buffer."
-        (interactive)
-        (evil-end-of-line)
-        (newline-and-indent)
-        (insert "import pdb; pdb.set_trace()")
-        (save-buffer))
-      ;; add support for `ahs-range-beginning-of-defun' for python-mode
-      (eval-after-load 'auto-highlight-symbol
-        '(add-to-list 'ahs-plugin-bod-modes 'python-mode))
-      (evil-leader/set-key-for-mode 'python-mode
-        "mB"  (lambda ()
-                " Send buffer content to shell and switch to it in insert mode."
-                (interactive)
-                (python-shell-send-buffer)
-                (python-shell-switch-to-shell)
-                (evil-insert-state))
-        "mb"  'python-shell-send-buffer
-        "md"  'pylookup-lookup
-        "mF"  (lambda ()
-                " Send function content to shell and switch to it in insert mode."
-                (interactive)
-                (python-shell-send-defun nil)
-                (python-shell-switch-to-shell)
-                (evil-insert-state))
-        "mf"  'python-shell-send-defun
-        "mg"  'jedi:goto-definition
-        "mi"  (lambda ()
-                " Switch to shell in insert mode."
-                (interactive)
-                (python-shell-switch-to-shell)
-                (evil-insert-state))
-        "mp"  'python-add-breakpoint
-        "mR"  (lambda (start end)
-                " Send region content to shell and switch to it in insert mode."
-                (interactive "r")
-                (python-shell-send-region start end)
-                (python-shell-switch-to-shell)
-                (evil-insert-state))
-        "mr"  'python-shell-send-region)
-      (define-key inferior-python-mode-map (kbd "C-j") 'comint-next-input)
-      (define-key inferior-python-mode-map (kbd "C-k") 'comint-previous-input))))
 
 (defun spacemacs/init-rainbow-blocks ()
   (use-package rainbow-blocks


### PR DESCRIPTION
Not fully complete yet, but just wanna get early feedback from you and whoever interested in making writing python code more pleasure with `spacemacs`.

I've done below items so far(at this point of this PR):
- Moved python related setup in `spacemacs/packages.el` to dedicated contrib
- Use anaconda instead of jedi.
- Added `eldoc` to see realtime documentation whilte coding
- Added `pyvenv` for virtual environment
- move `pylookup` over
- move `nose` over
- setting python shell interpreter and break point based on the availability of `ipython` and `ipdb`
- add README.md

I just have few questions for you here,
- how should I name this contrib? I initially named it `contrib/lang/python/`, but then I realize with that naming convention, I need to call the initialization function `python/init-python`. Concerned about name conflict, I'm currently using name `spacemacs-python`
- what makes the call of adding a package as dependency or extension? I've noticed that currently [`nose`](https://github.com/syl20bnr/spacemacs/tree/master/spacemacs/extensions) package is been added as an extension, but it's also available on melpa. Just wondering in which case I should make a module an extension but not dependancy(from elpa/melpa)

Let me know your thoughts on the changes I've made so far.
