### PR TITLE
Update the README with some absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Quick Install:**
 
-    git clone --recursive http://github.com/syl20bnr/spacemacs .emacs.d
+    git clone --recursive http://github.com/syl20bnr/spacemacs ~/.emacs.d
 
 _Jump to [Install](#install) for more info and [here][CONTRIBUTE.md-PR]
 for contribution guidelines_
@@ -245,7 +245,7 @@ be provided in this read me. _Stay tuned._
 
 ## Install
 
-1) Backup your current `.emacs.d` and clone the repo _with the submodules_:
+1) Backup your current `~/.emacs.d` and clone the repo _with the submodules_:
 
     cd ~
     mv .emacs.d .emacs.bak


### PR DESCRIPTION
The "quick install" line used to suggest the user to `git clone --recursive` into `.emacs.d`. Perhaps is better to make the user clone in `~/.emacs.d` so that they can install Spacemacs whatever their `$(pwd)` is.

I'm committing this since a couple of times I was frustrated that the Spacemacs installation didn't do anything just because I cloned `.emacs.d` somewhere other than `~`.
