### PR TITLE
Remove helm-quick-update

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1288,7 +1288,6 @@ determine the state to enable when escaping from the insert state.")
     :defer t
     :init
     (setq helm-split-window-in-side-p nil
-          helm-quick-update t
           helm-bookmark-show-location t
           helm-buffers-fuzzy-matching t
           helm-always-two-windows     t)


### PR DESCRIPTION
It is not needed anymore since helm-candidate-number-limit is
small (less than several thousands). If this is the case, then there's
no difference between quick update and no quick update execution time.
Enabling helm-quick-update makes helm buffer flashing for every entered
character to retrieve new candidate list, which would annoy user.
