### PR TITLE
Open `.spacemacs` dotfile in the same manner as init and contrib.

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -278,6 +278,11 @@ argument takes the kindows rotate backwards."
   (interactive)
   (find-file-existing user-init-file))
 
+(defun find-dotfile ()
+  "Edit the `dotfile', in the current window."
+  (interactive)
+  (find-file-existing contribsys/dotfile-location))
+
 (defun find-spacemacs-file ()
   (interactive)
   "Edit the `file' in the spacemacs base directory, in the current window."

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -62,6 +62,7 @@
   "fei" 'find-user-init-file
   "fes" 'find-spacemacs-file
   "fec" 'find-contrib-file
+  "fed" 'find-dotfile
   "fS" 'evil-write-all
   "fs" 'evil-write
   "fy" 'camdez/show-buffer-file-name)


### PR DESCRIPTION
Added keybindings for opening ~/.spacemacs file
