### PR TITLE
Windows emacs binary path is at distribution directory, need to traverse through bin/ to run debug function

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -1,19 +1,25 @@
 ;; add emacs binary helper functions
-(defun emacs() (interactive)
-  (call-process (concat exec-directory "emacs") nil 0 nil)
+(defun emacsbin-path()
+  (interactive)
+  (concat exec-directory (if (system-is-mswindows) "bin/") "emacs"))
+
+(defun emacs()
+  (interactive)
+  (call-process (emacsbin-path) nil 0 nil)
   (message "Started 'emacs' - it will be ready soon ..."))
 
-(defun emacs-debug-init() (interactive)
-  (call-process (concat exec-directory "emacs") nil 0 nil "--debug-init")
+(defun emacs-debug-init()
+  (interactive)
+  (call-process (emacsbin-path) nil 0 nil "--debug-init")
   (message "Started 'emacs --debug-init' - it will be ready soon ..."))
 
 (defun emacs-reload()
   (interactive)
-  (load-file "~/.emacs.d/init.el")
+  (load-file user-init-file)
   (message ".emacs reloaded successfully"))
 
 (defun emacs-Q() (interactive)
-  (call-process (concat exec-directory "emacs") nil 0 nil "-Q")
+  (call-process (emacsbin-path) nil 0 nil "-Q")
   (message "Started 'emacs -Q' - it will be ready soon ..."))
 
 ;; from https://github.com/cofi/dotfiles/blob/master/emacs.d/config/cofi-util.el#L38
@@ -41,6 +47,9 @@
 (defun system-is-linux ()
   (interactive)
   (string-equal system-type "gnu/linux"))
+(defun system-is-mswindows ()
+  (interactive)
+  (string-equal system-type "windows-nt"))
 
 ;; insert one or several line below without changing current evil state
 (defun evil-insert-line-below (count)


### PR DESCRIPTION
Was having issue where `emacs` and `emacs-debug-init` were not working because emacs path was not consistent across operating systems.  Works in Windows now.
