### PR TITLE
adjust evil-shift-width the same as coffee-tab-width in coffee mode

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1895,5 +1895,6 @@ determine the state to enable when escaping from the insert state.")
           (coffee-insert-spaces (coffee-previous-indent)))
         )
       ;; indent to right position after `evil-open-blow' and `evil-open-above'
-      (add-hook 'coffee-mode-hook '(lambda () (setq indent-line-function 'spacemacs/coffee-indent)))
-      )))
+      (add-hook 'coffee-mode-hook '(lambda ()
+                                     (setq indent-line-function 'spacemacs/coffee-indent
+                                           evil-shift-width coffee-tab-width))))))


### PR DESCRIPTION
`evil-shift-width` in coffee mode should be the same as coffee indentation width, so that `> >` and evil-repeat can shift a line to proper indentation.
