### PR TITLE
Fix find-dotfile function

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -290,7 +290,7 @@ argument takes the kindows rotate backwards."
 (defun find-dotfile ()
   "Edit the `dotfile', in the current window."
   (interactive)
-  (find-file-existing contribsys/dotfile-location))
+  (find-file-existing (contribsys/dotfile-location)))
 
 (defun find-spacemacs-file ()
   (interactive)


### PR DESCRIPTION
The contribsys/dotfile-location function wasn't being evaluated
