### PR TITLE
bug fix: electric-indent-mode causes incorrent indentation when adding c...

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -32,8 +32,7 @@ which require an initialization must be listed explicitly in the list.")
 
       (defun python-default ()
         (setq mode-name "Python"
-              tab-width 4
-              electric-indent-local-mode nil)
+              tab-width 4)
         (annotate-pdb)
         (anaconda-mode)
         (eldoc-mode)
@@ -46,7 +45,8 @@ which require an initialization must be listed explicitly in the list.")
         (add-hook 'before-save-hook 'delete-trailing-whitespace))
 
       (add-hook 'python-mode-hook 'python-default)
-      (add-hook 'python-mode-hook 'python-setup-shell))
+      (add-hook 'python-mode-hook 'python-setup-shell)
+      (add-hook 'python-mode-hook 'disable-electric-indent-mode))
     :config
     (progn
       ;; add support for `ahs-range-beginning-of-defun' for python-mode

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -32,6 +32,8 @@
 ;; use only spaces and no tabs
 (setq-default indent-tabs-mode nil)
 (setq default-tab-width 2)
+;; turn on electric-indent-mode for both 24.3 and 24.4
+(electric-indent-mode)
 ;; Text
 (setq longlines-show-hard-newlines t)
 

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -620,3 +620,11 @@ otherwise it is scaled down."
 (defmacro spacemacs//hide-lighter (mode)
   "Diminish MODE name in mode line to LIGHTER."
   `(eval-after-load 'diminish '(diminish ',mode)))
+
+(defun disable-electric-indent-mode ()
+  (if (fboundp 'electric-indent-local-mode)
+      ;; for 24.4
+      (electric-indent-local-mode -1)
+    ;; for 24.3
+    (add-hook 'electric-indent-functions
+              (lambda () 'no-indent) nil 'local)))


### PR DESCRIPTION
...omma after if statement

 I'd like to keep `electric-indent-mode` off for editing python files so that I can control exact indentation without surprise.

example of this bug would be:

```
        while temp and temp.val != value:
            if temp.val > value:
                temp = temp.left
            else:
                temp = temp.right

        if not temp|
```

with `electric-indent-mode` on, typing `:` at cursor will cause last `if` statement indented to within `while` statement, which is not always desired.
