### PR TITLE
Use the new exclusion feature for company contrib

### DIFF
--- a/contrib/company-mode/Readme.md
+++ b/contrib/company-mode/Readme.md
@@ -1,11 +1,7 @@
 # Company Mode
 
-In order to use this you should disable the default `auto-complete` package plus everything that depends on it:
-
-```elisp
-(setq-default dotspacemacs-excluded-packages
-  '(auto-complete ac-ispell tern-auto-complete auto-complete-clang enslime edts))
-```
+This contrib layer switches spacemacs to use company-mode for autocompletion.
+It automatically uninstalls all auto-complete-mode related packages when you include it.
 
 ## Clang Fanciness
 

--- a/contrib/company-mode/packages.el
+++ b/contrib/company-mode/packages.el
@@ -4,6 +4,10 @@
     company-tern
     ))
 
+(defvar company-mode-excluded-packages
+  '(auto-complete ac-ispell tern-auto-complete auto-complete-clang ensime edts)
+  "Packages that use auto-complete that are no longer necessary and might conflict.")
+
 (defun company-mode/init-company ()
   (use-package company
     :config


### PR DESCRIPTION
Removes the readme section about exclusion and adds automatic exclusion to the company-mode contrib.
