### PR TITLE
use another way to not auto-indent in python mode

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -32,7 +32,9 @@ which require an initialization must be listed explicitly in the list.")
 
       (defun python-default ()
         (setq mode-name "Python"
-              tab-width 4)
+              tab-width 4
+              ;; auto-indent on colon doesn't work well with if statement
+              electric-indent-chars (delq ?: electric-indent-chars))
         (annotate-pdb)
         (anaconda-mode)
         (eldoc-mode)
@@ -42,11 +44,11 @@ which require an initialization must be listed explicitly in the list.")
           (ac-anaconda-setup))
         (when (boundp 'company-backends)
           (add-to-list 'company-backends 'company-anaconda))
-        (add-hook 'before-save-hook 'delete-trailing-whitespace))
+        ;; make C-j work the same way as RET
+        (local-set-key (kbd "C-j") 'newline-and-indent))
 
       (add-hook 'python-mode-hook 'python-default)
-      (add-hook 'python-mode-hook 'python-setup-shell)
-      (add-hook 'python-mode-hook 'disable-electric-indent-mode))
+      (add-hook 'python-mode-hook 'python-setup-shell))
     :config
     (progn
       ;; add support for `ahs-range-beginning-of-defun' for python-mode


### PR DESCRIPTION
Tried out the suggestion here https://github.com/syl20bnr/spacemacs/pull/126, and it works fine. Let's go with this approach, so that people who likes `electric-indent-mode` can have it in python mode(although I can't think of any case so far).

I didn't remove `disable-electric-indent` function that I added in previous PR, let me know if you'd like not to have it anymore.

I also bind `C-j` the same way as `<RET>` key as I find myself use those two key bindings interchangeably, but that's totally something subjective, so feel free to let me know if you don't like it and I can take it out.
