### PR TITLE
Add a link to the use-package macro in README#initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ format in `extensions.el` or `packages.el`:
 )
 ```
 
+It is common to define the body with the [use-package][use-package] macro.
+
 ### Exclusion
 
 It is possible to exclude some packages from `Spacemacs` in a per layer basis.
@@ -1829,3 +1831,4 @@ developers to elisp hackers!
 [Wolfy87]:https://github.com/Wolfy87
 [danielwuz]:https://github.com/danielwuz
 [Jackneill]:https://github.com/Jackneill
+[use-package]: https://github.com/jwiegley/use-package


### PR DESCRIPTION
I felt at quite a loss when I started to define my first package initialization body considering that I had never seen use-package before. Fortunately their README is good, I just didn't know where to look!
