### PR TITLE
Problems with company-auctex fixed upstream

### DIFF
--- a/contrib/trishume/Readme.md
+++ b/contrib/trishume/Readme.md
@@ -8,13 +8,3 @@ Also adds smooth scrolling and Helm Ag support.
 ## Company Auctex
 
 Along with other things this layer includes company-auctex, it's only enabled if you also enable my other contrib layer `company-mode`.
-The autocompletion it offers is great and almost works, unlike auto-complete-auctex which lags so hard it's worthless.
-
-The problem is the almost. There are a few issues that need to be fixed for it to be nice:
-
-- https://github.com/capitaomorte/yasnippet/issues/537 To allow you to delete expanded macro braces, this will need to be merged.
-- https://github.com/alexeyr/company-auctex/pull/3 For completing environments like `align*` properly, this will need to be merged.
-- https://github.com/alexeyr/company-auctex/issues/4
-
-Currently I've manually applied both of these patches to the folders in my `elpa` directory, which isn't a good solution.
-If the patches aren't merged in a reasonable amount of time I'll add the patched forks/branches as extension submodules.


### PR DESCRIPTION
I had some caveats in the Readme for my contrib layer about company-auctex being a buggy mess. But all those bugs have been fixed upstream thanks to a combination of my pull requests and some fixes in company-mode.

This PR just removes those notes from the readme.
