### PR TITLE
Fix annoying company behaviour in ruby-like languages

### DIFF
--- a/contrib/company-mode/packages.el
+++ b/contrib/company-mode/packages.el
@@ -8,14 +8,22 @@
   '(auto-complete ac-ispell tern-auto-complete auto-complete-clang ensime edts)
   "Packages that use auto-complete that are no longer necessary and might conflict.")
 
+(defvar company-mode/completion-cancel-keywords '("do" "then" "begin" "case")
+  "Keywords on which to cancel completion so that you can use RET to complet without blocking common line endings.")
+
 (defun company-mode/init-company ()
   (use-package company
     :config
     (progn
+      (defun company-mode/keyword-cancel-transformer (candidates)
+        "company frontend that cancels completion when a keyword is typed
+so that you don't have 'do' completed to 'downcase' in Ruby"
+        (if (member company-prefix company-mode/completion-cancel-keywords) '() candidates))
+
       (setq company-idle-delay 0.0
             company-minimum-prefix-length 2
             company-require-match nil
-            company-transformers '(company-sort-by-occurrence)
+            company-transformers '(company-mode/keyword-cancel-transformer company-sort-by-occurrence)
             company-dabbrev-ignore-case nil
             company-dabbrev-downcase nil
             company-tooltip-flip-when-above t
@@ -24,14 +32,14 @@
 
       (global-company-mode 1)
 
-      ; Fix integration of company and yasnippet
+      ;; Fix integration of company and yasnippet
       (define-key company-active-map (kbd "TAB") nil)
       (define-key company-active-map (kbd "<tab>") nil)
       (define-key company-active-map [tab] nil)
 
       (add-hook 'markdown-mode-hook '(lambda () (company-mode -1)))
 
-      ; The default common face is a really ugly underlined thing with a different background.
+      ;; The default common face is a really ugly underlined thing with a different background.
       (custom-set-faces
        '(company-tooltip-common ((t (:inherit company-tooltip :weight bold :underline nil))))
        '(company-tooltip-common-selection ((t (:inherit company-tooltip-selection :weight bold :underline nil)))))
@@ -39,7 +47,7 @@
       (spacemacs//diminish company-mode " Ⓒ"))))
 
 (defun company-mode/init-company-tern ()
-   (use-package company-tern
-     :defer t
-     :config
-     (add-to-list 'company-backends 'company-tern)))
+  (use-package company-tern
+    :defer t
+    :config
+    (add-to-list 'company-backends 'company-tern)))


### PR DESCRIPTION
Currently when trying to type keywords like "do" in Ruby followed by pressing enter for a newline actually selects a company-mode completion and completes to "downcase".

This just adds a company transformer that blocks company from activating on certain keywords that are commonly followed by newlines.

This half fixes #102 but Tab completion option would still be nice.
