### PR TITLE
bind evil-buffer to SPC b b

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -884,6 +884,7 @@ Buffer manipulation commands (start with `b`):
 
 Key Binding            |                 Description
 -----------------------|----------------------------------------------------------------
+<kbd>SPC b b</kbd>   | quickly switch between current buffer and previous one
 <kbd>SPC b d</kbd>   | delete the current buffer **and** file (ask for confirmation)
 <kbd>SPC b e</kbd>   | erase the content of the buffer (ask for confirmation)
 <kbd>SPC b k</kbd>   | kill the current buffer

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -28,6 +28,7 @@
   "au"  'undo-tree-visualize)
 ;; buffers --------------------------------------------------------------------
 (evil-leader/set-key
+  "bb"  'evil-buffer
   "bd"  'delete-current-buffer-file
   "be"  'spacemacs/safe-erase-buffer
   "bK"  'kill-other-buffers


### PR DESCRIPTION
It would be handy to be able to switch between two buffers quickly. The default key binding of `evil-buffer` `C-^` is not easy to hit.
