### PR TITLE
bind other-frame to SPC w o

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -913,6 +913,7 @@ Key Binding            |                 Description
 <kbd>SPC w L</kbd>     | move window to the right
 <kbd>SPC w m</kbd>     | maximize/minimize a window
 <kbd>SPC w M</kbd>     | maximize/minimize a window, when maximized the buffer is centered
+<kbd>SPC w o</kbd>     | cycle and focus between frames
 <kbd>SPC w p m</kbd>   | open messages buffer in a popup window
 <kbd>SPC w p p</kbd>   | close the current sticky popup window
 <kbd>SPC w r</kbd>     | rotate windows clockwise

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -125,6 +125,7 @@
   "wl"  'evil-window-right
   "wM"  'toggle-maximize-centered-buffer
   "wm"  'toggle-maximize-buffer
+  "wo"  'other-frame
   "wr"  'rotate-windows
   "wR"  'rotate-windows-backward
 ;; "wv"  'evenly-split-window-below)


### PR DESCRIPTION
Bind `other-frame` to `SPC w o` so that user can cycle through frames in a spacemacsen way. See discussion 
https://github.com/syl20bnr/spacemacs/issues/204
