### PR TITLE
add compilation support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1635,9 +1635,9 @@ Custom fringe bitmaps:
 
     Key Binding      |                 Description
 ---------------------|------------------------------------------------------------
-<kbd>SPC C</kbd>     | compile
-<kbd>SPC R</kbd>     | recompile
-<kbd>SPC M</kbd>     | use `helm-make` via projectile
+<kbd>SPC c c</kbd>     | use `helm-make` via projectile
+<kbd>SPC c C</kbd>     | compile
+<kbd>SPC c r</kbd>     | recompile
 
 ## Modes
 

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -87,9 +87,9 @@
   "jh" (lambda () (interactive) (push-mark (point)) (evil-beginning-of-line))
   "jl" (lambda () (interactive) (push-mark (point)) (evil-end-of-line)))
 ;; Compilation ----------------------------------------------------------------
-(evil-leader/set-key "C" 'compile)
-(evil-leader/set-key "R" 'recompile)
-(evil-leader/set-key "M" 'helm-make-projectile)
+(evil-leader/set-key "cc" 'helm-make-projectile)
+(evil-leader/set-key "cC" 'compile)
+(evil-leader/set-key "cr" 'recompile)
 ;; narrow & widen -------------------------------------------------------------
 (unless (ht-contains? config-system-all-packages 'fancy-narrow)
   (evil-leader/set-key


### PR DESCRIPTION
```
<kbd>SPC c c</kbd>     use `helm-make` via projectile
<kbd>SPC c C</kbd>    compile
<kbd>SPC c r</kbd>     recompile
```

Oleh was quick on adding the helm-make-projectile feature. Thanks! https://github.com/abo-abo/helm-make/issues/3
