### PR TITLE
Fix guide-key breakage

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1120,9 +1120,9 @@ determine the state to enable when escaping from the insert state.")
             (guide-key-mode -1)
           (guide-key-mode)))
       (evil-leader/set-key "tG" 'spacemacs/toggle-guide-key)
-      (setq guide-key/guide-key-sequence '("C-x"
+      (setq guide-key/guide-key-sequence `("C-x"
                                            "C-c"
-                                           dotspacemacs-leader-key
+                                           ,dotspacemacs-leader-key
                                            "g"
                                            "z"
                                            "C-h")


### PR DESCRIPTION
1958678754 (0.26.0) introduced a customisable variable
`dotspacemacs-leader-key`. Hardcoded instances of the leader were
replaced by references to this variable. An error in this refactoring
has broken guide-key.

This change fixes a bug where the variable name was added to a quoted
list, inserting the symbol and not the variable's value.

After this change, guide-key should display again.
