### PR TITLE
Contrib JavaScript Layer

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1761,20 +1761,8 @@ Writing python code with spacemacs is supported by python contribution. Please s
 
 ### JavaScript
 
-[js2-mode][] will activate for all `*.js` files, along with
-[tern-auto-complete][] which will provide the best JavaScript
-completion currently available. Just make sure you have the [tern][]
-NPM module installed.
-
-Tern includes the following key bindings:
-
-    Key Binding     |                 Description
---------------------|------------------------------------------------------------
-<kbd>M-.</kbd>      | jump to the definition of the thing under the cursor.
-<kbd>M-,</kbd>      | brings you back to last place you were when you pressed M-..
-<kbd>C-c C-r</kbd>  | rename the variable under the cursor.
-<kbd>C-c C-c</kbd>  | find the type of the thing under the cursor.
-<kbd>C-c C-d</kbd>  | find docs of the thing under the cursor. Press again to open the associated URL (if any).
+More featured JavaScript support is provided by the javascript contribution. Please see
+[javascript contribution][javascript-contrib] documentation for detail.
 
 ### rcirc
 
@@ -1950,9 +1938,7 @@ developers to elisp hackers!
 [issues]: https://github.com/syl20bnr/spacemacs/issues
 [vundle]: https://github.com/gmarik/Vundle.vim
 [anzu]: https://github.com/syohex/emacs-anzu
-[js2-mode]: https://github.com/mooz/js2-mode
-[tern-auto-complete]: https://github.com/marijnh/tern/blob/master/emacs/tern-auto-complete.el
-[tern]: http://ternjs.net/
+[javascript-contrib]: https://github.com/syl20bnr/spacemacs/tree/master/contrib/lang/javascript
 [themes-megapack]: https://github.com/syl20bnr/spacemacs/tree/master/contrib/themes-megapack
 [python-contrib]: https://github.com/syl20bnr/spacemacs/tree/master/contrib/lang/python
 [guide-key]: https://github.com/kai2nenobu/guide-key

--- a/contrib/lang/javascript/README.md
+++ b/contrib/lang/javascript/README.md
@@ -1,0 +1,92 @@
+# JavaScript contribution layer for Spacemacs
+
+## Features
+
+- **Smart Code Folding**
+- **Refactoring**
+- **Auto-completion**
+- **Documentation Lookup**
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(defvar dotspacemacs-configuration-layers '(js2-mode)
+  "List of contribution to load."
+)
+```
+
+You will also need to install `tern` to use the auto-completion and
+documentation features:
+
+```shell
+$ npm install -g tern
+```
+
+## Key Bindings
+
+### js2-mode
+
+[Improved JavaScript editing mode for GNU Emacs](https://github.com/mooz/js2-mode).
+
+    Key Binding   |                 Description
+------------------|------------------------------------------------------------
+<SPC> m w         | toggle js2-mode warnings and errors
+<SPC> m z c       | hide element
+<SPC> m z o       | show element
+<SPC> m z r       | show all element
+<SPC> m z e       | toggle hide/show element
+<SPC> m z F       | toggle hide functions
+<SPC> m z C       | toggle hide comments
+
+### js2-refactor
+
+Refactoring is done using [js2-refactor](https://github.com/magnars/js2-refactor.el).  
+Bindings should match the plain emacs assignments.
+
+    Key Binding   |                 Description
+------------------|------------------------------------------------------------
+<SPC> x m j       | move line down, while keeping commas correctly placed
+<SPC> x m k       | move line up, while keeping commas correctly placed
+<SPC> m k         | deletes to the end of the line, but does not cross semantic boundaries
+<SPC> m r 3 i     | converts ternary operator to if-statement
+<SPC> m r a g     | creates a `/* global */` annotation if it is missing, and adds var to point to it
+<SPC> m r a o     | replaces arguments to a function call with an object literal of named arguments
+<SPC> m r b a     | moves the last child out of current function, if-statement, for-loop or while-loop
+<SPC> m r c a     | converts a multiline array to one line
+<SPC> m r c o     | converts a multiline object literal to one line
+<SPC> m r c u     | converts a multiline function to one line (expecting semicolons as statement delimiters)
+<SPC> m r e a     | converts a one line array to multiline
+<SPC> m r e f     | extracts the marked expressions into a new named function
+<SPC> m r e m     | extracts the marked expressions out into a new method in an object literal
+<SPC> m r e o     | converts a one line object literal to multiline
+<SPC> m r e u     | converts a one line function to multiline (expecting semicolons as statement delimiters)
+<SPC> m r e v     | takes a marked expression and replaces it with a var
+<SPC> m r i g     | creates a shortcut for a marked global by injecting it in the wrapping immediately invoked function expression
+<SPC> m r i p     | changes the marked expression to a parameter in a local function
+<SPC> m r i v     | replaces all instances of a variable with its initial value
+<SPC> m r l p     | changes a parameter to a local var in a local function
+<SPC> m r l t     | adds a console.log statement for what is at point (or region)
+<SPC> m r r v     | renames the variable on point and all occurrences in its lexical scope
+<SPC> m r s l     | moves the next statement into current function, if-statement, for-loop, while-loop
+<SPC> m r s s     | splits a `String`
+<SPC> m r s v     | splits a `var` with multiple vars declared into several `var` statements
+<SPC> m r t f     | toggle between function declaration and function expression
+<SPC> m r u w     | replaces the parent statement with the selected region
+<SPC> m r v t     | changes local `var a` to be `this.a` instead
+<SPC> m r w i     | wraps the entire buffer in an immediately invoked function expression
+<SPC> m r w l     | wraps the region in a for-loop
+
+### tern
+
+[Tern](http://ternjs.net/) is used as an auto-completion backend and for documentation features.
+
+    Key Binding   |                 Description
+------------------|------------------------------------------------------------
+<SPC> m .       | jump to the definition of the thing under the cursor
+<SPC> m ,       | brings you back to last place you were when you pressed M-..
+<SPC> m f       | jump to definition for the given name
+<SPC> m c       | rename variable under the cursor using tern
+<SPC> m t       | find the type of the thing under the cursor
+<SPC> m g       | find docs of the thing under the cursor. Press again to open the associated URL (if any)

--- a/contrib/lang/javascript/packages.el
+++ b/contrib/lang/javascript/packages.el
@@ -1,0 +1,111 @@
+(defvar javascript-packages
+  '(
+    js2-mode
+    js2-refactor
+    tern
+    tern-auto-complete
+    )
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defun javascript/init-js2-mode ()
+  (use-package js2-mode
+    :defer t
+    :init (add-to-list 'auto-mode-alist '("\\.js\\'" . js2-mode))
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'js2-mode "m" "major mode")
+
+      (evil-leader/set-key-for-mode 'js2-mode "mw" 'js2-mode-toggle-warnings-and-errors)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mz" "folding")
+      (evil-leader/set-key-for-mode 'js2-mode "mzc" 'js2-mode-hide-element)
+      (evil-leader/set-key-for-mode 'js2-mode "mzo" 'js2-mode-show-element)
+      (evil-leader/set-key-for-mode 'js2-mode "mzr" 'js2-mode-show-all)
+      (evil-leader/set-key-for-mode 'js2-mode "mze" 'js2-mode-toggle-element)
+      (evil-leader/set-key-for-mode 'js2-mode "mzF" 'js2-mode-toggle-hide-functions)
+      (evil-leader/set-key-for-mode 'js2-mode "mzC" 'js2-mode-toggle-hide-comments))))
+
+(defun javascript/init-js2-refactor ()
+  (use-package js2-refactor
+    :defer t
+    :init (eval-after-load 'js2-mode '(require 'js2-refactor))
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mr" "refactor")
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mr3" "ternary")
+      (evil-leader/set-key-for-mode 'js2-mode "mr3i" 'js2r-ternary-to-if)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mra" "add/args")
+      (evil-leader/set-key-for-mode 'js2-mode "mrag" 'js2r-add-to-globals-annotation)
+      (evil-leader/set-key-for-mode 'js2-mode "mrao" 'js2r-arguments-to-object)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrb" "barf")
+      (evil-leader/set-key-for-mode 'js2-mode "mrba" 'js2r-forward-barf)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrc" "contract")
+      (evil-leader/set-key-for-mode 'js2-mode "mrca" 'js2r-contract-array)
+      (evil-leader/set-key-for-mode 'js2-mode "mrco" 'js2r-contract-object)
+      (evil-leader/set-key-for-mode 'js2-mode "mrcu" 'js2r-contract-function)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mre" "expand/extract")
+      (evil-leader/set-key-for-mode 'js2-mode "mrea" 'js2r-expand-array)
+      (evil-leader/set-key-for-mode 'js2-mode "mref" 'js2r-extract-function)
+      (evil-leader/set-key-for-mode 'js2-mode "mrem" 'js2r-extract-method)
+      (evil-leader/set-key-for-mode 'js2-mode "mreo" 'js2r-expand-object)
+      (evil-leader/set-key-for-mode 'js2-mode "mreu" 'js2r-expand-function)
+      (evil-leader/set-key-for-mode 'js2-mode "mrev" 'js2r-extract-var)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mri" "inline/inject/introduct")
+      (evil-leader/set-key-for-mode 'js2-mode "mrig" 'js2r-inject-global-in-iife)
+      (evil-leader/set-key-for-mode 'js2-mode "mrip" 'js2r-introduce-parameter)
+      (evil-leader/set-key-for-mode 'js2-mode "mriv" 'js2r-inline-var)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrl" "localize/log")
+      (evil-leader/set-key-for-mode 'js2-mode "mrlp" 'js2r-localize-parameter)
+      (evil-leader/set-key-for-mode 'js2-mode "mrlt" 'js2r-log-this)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrr" "rename")
+      (evil-leader/set-key-for-mode 'js2-mode "mrrv" 'js2r-rename-var)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrs" "split/slurp")
+      (evil-leader/set-key-for-mode 'js2-mode "mrsl" 'js2r-forward-slurp)
+      (evil-leader/set-key-for-mode 'js2-mode "mrss" 'js2r-split-string)
+      (evil-leader/set-key-for-mode 'js2-mode "mrsv" 'js2r-split-var-declaration)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrt" "toggle")
+      (evil-leader/set-key-for-mode 'js2-mode "mrtf" 'js2r-toggle-function-expression-and-declaration)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mru" "unwrap")
+      (evil-leader/set-key-for-mode 'js2-mode "mruw" 'js2r-unwrap)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrv" "var")
+      (evil-leader/set-key-for-mode 'js2-mode "mrvt" 'js2r-var-to-this)
+
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mrw" "wrap")
+      (evil-leader/set-key-for-mode 'js2-mode "mrwi" 'js2r-wrap-buffer-in-iife)
+      (evil-leader/set-key-for-mode 'js2-mode "mrwl" 'js2r-wrap-in-for-loop)
+
+      (evil-leader/set-key-for-mode 'js2-mode "mk" 'js2r-kill)
+      (evil-leader/set-key-for-mode 'js2-mode "xmj" 'js2r-move-line-down)
+      (evil-leader/set-key-for-mode 'js2-mode "xmk" 'js2r-move-line-up))))
+
+(defun javascript/init-tern ()
+  (use-package tern
+    :defer t
+    :init (add-hook 'js2-mode-hook (lambda () (tern-mode t)))
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mt" "tern")
+      (evil-leader/set-key-for-mode 'js2-mode "m." 'tern-find-definition)
+      (evil-leader/set-key-for-mode 'js2-mode "m," 'tern-pop-find-definition)
+      (evil-leader/set-key-for-mode 'js2-mode "mf" 'tern-find-definition-by-name)
+      (evil-leader/set-key-for-mode 'js2-mode "mc" 'tern-rename-variable)
+      (evil-leader/set-key-for-mode 'js2-mode "mt" 'tern-get-type)
+      (evil-leader/set-key-for-mode 'js2-mode "mg" 'tern-get-docs))))
+
+(defun javascript/init-tern-auto-complete ()
+  (use-package tern-auto-complete
+    :defer t
+    :config (tern-ac-setup)))

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -58,6 +58,14 @@ a key sequence. NAME is a symbol name used as the prefix command."
     (define-prefix-command command)
     (evil-leader/set-key prefix command)))
 
+(defun spacemacs/declare-prefix-for-mode (mode prefix name)
+  "Declare a prefix PREFIX. MODE is the mode in which this prefix command should
+be added. PREFIX is a string describing a key sequence. NAME is a symbol name
+used as the prefix command."
+  (let ((command (intern (concat spacemacs/prefix-command-string name))))
+    (define-prefix-command command)
+    (evil-leader/set-key-for-mode mode prefix command)))
+
 (defun spacemacs/activate-evil-leader-for-maps (map-list)
   "Remove the evil-leader binding from all the maps in MAP-LIST."
   (mapc (lambda (x)

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -67,7 +67,6 @@
     hl-anything
     hy-mode
     ido-vertical-mode
-    js2-mode
     json-mode
     ledger-mode
     less-css-mode
@@ -118,7 +117,6 @@
     string-edit
     subword
     tagedit
-    tern-auto-complete
     undo-tree
     vi-tilde-fringe
     visual-regexp-steroids
@@ -1339,12 +1337,6 @@ determine the state to enable when escaping from the insert state.")
       (add-to-list 'ido-setup-hook 'spacemacs//ido-vertical-define-keys))
       ))
 
-(defun spacemacs/init-js2-mode ()
-  (use-package js2-mode
-    :commands (js2-minor-mode)
-    :init
-    (add-to-list 'auto-mode-alist '("\\.js\\'" . js2-mode))))
-
 (defun spacemacs/init-json-mode ()
   (use-package json-mode
     :defer t))
@@ -1992,14 +1984,6 @@ determine the state to enable when escaping from the insert state.")
       (tagedit-add-experimental-features)
       (add-hook 'html-mode-hook (lambda () (tagedit-mode 1)))
       (spacemacs|diminish tagedit-mode " Ⓣ"))))
-
-(defun spacemacs/init-tern-auto-complete ()
-  (use-package tern-auto-complete
-    :defer t
-    :init
-    (add-hook 'js2-mode-hook (lambda () (tern-mode t)))
-    :config
-    (tern-ac-setup)))
 
 (defun spacemacs/init-undo-tree ()
   (use-package undo-tree


### PR DESCRIPTION
JavaScript changes:
- moved JavaScript/js2-mode into a contrib layer, `javascript`
- added js2-refactor
- changed key bindings to be more spacemacsy

I also created a `spacemacs/declare-prefix-for-mode` function, so you can define prefixes that will disappear when you are in a different mode.

Feel free to tell me if my binding choices are bad. I'm coming from an Emacs background and am not yet used to all the vim conventions.
