### PR TITLE
add basic ruby contrib layer

### DIFF
--- a/contrib/lang/ruby/README.md
+++ b/contrib/lang/ruby/README.md
@@ -1,0 +1,51 @@
+# Ruby contribution layer for Spacemacs
+
+## Description
+
+This layer aims at providing support for the Ruby language using
+[enh-ruby-mode][] and [robe-mode][].
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(defvar dotspacemacs-configuration-layers '(ruby)
+  "List of contribution to load."
+)
+```
+
+In order to take advantage of `robe-mode` you will probably need to
+install the `pry` gem.
+You can do that via your Gemfile:
+
+```ruby
+ gem 'pry'
+```
+
+or on the command line:
+
+```shell
+$ gem install pry
+```
+
+## Key bindings
+
+### enh-ruby-mode
+
+<kbd>SPC m i</kbd> start REPL
+<kbd>SPC m g</kbd> go to definition (robe-jump)
+<kbd>SPC m d</kbd> go to Documentation
+<kbd>SPC m R</kbd> reload environment (Rails)
+
+### ruby-test-mode
+
+ruby-test-mode comes bundled with spacemacs, but this contribution adds
+a couple of useful keybindings:
+
+<kbd>SPC m t f</kbd> run test file
+<kbd>SPC m t p</kbd> run test at pointer
+
+
+[enh-ruby-mode]: https://github.com/zenspider/enhanced-ruby-mode
+[robe-mode]: https://github.com/dgutov/robe

--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -1,0 +1,56 @@
+(defvar ruby-packages
+  '(
+    ;; package rubys go here
+    rbenv
+    enh-ruby-mode
+    ruby-test-mode
+    robe
+    yaml-mode
+    )
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defvar ruby-excluded-packages '(ruby-mode))
+
+(defun ruby/init-rbenv ()
+  "Initialize RBENV mode"
+  (use-package rbenv
+    :init (global-rbenv-mode)
+    :defer t
+    :config (add-hook 'enh-ruby-mode-hook
+          (lambda () (rbenv-use-corresponding)))))
+
+(defun ruby/init-enh-ruby-mode ()
+  "Initialize Enhanced Ruby Mode"
+  (use-package enh-ruby-mode
+    :defer t
+    :mode (("\\(rake\\|thor\\|guard\\|gem\\|cap\\|vagrant\\)file\\'" . enh-ruby-mode)
+           ("\\.\\(rb\\|ru\\|builder\\|rake\\|thor\\|gemspec\\)\\'" . enh-ruby-mode))))
+
+(defun ruby/init-robe ()
+  "Initialize Robe mode"
+  (use-package robe
+    :defer t
+    :init (add-hook 'enh-ruby-mode-hook 'robe-mode)
+    :config (progn (evil-leader/set-key-for-mode 'enh-ruby-mode "mg" 'robe-jump)
+                   (evil-leader/set-key-for-mode 'enh-ruby-mode "md" 'robe-doc)
+                   (evil-leader/set-key-for-mode 'enh-ruby-mode "mR" 'robe-rails-refresh)
+                   (evil-leader/set-key-for-mode 'enh-ruby-mode "mi" 'robe-start))))
+
+(defun ruby/init-yaml-mode ()
+  "Initialize YAML mode"
+  (use-package yaml-mode
+    :config (add-hook 'yaml-mode-hook
+                      '(lambda ()
+                         (define-key yaml-mode-map "\C-m" 'newline-and-indent)))
+    :defer t
+    :mode (("\\.\\(yml\\|yaml\\)\\'" . yaml-mode)
+           ("Procfile\\'" . yaml-mode))))
+
+
+
+(defun ruby/init-ruby-test-mode ()
+  "Define keybindings for ruby test mode"
+  (use-package ruby-test-mode
+    :config (progn (evil-leader/set-key "mtf" 'ruby-test-run)
+                   (evil-leader/set-key "mtp" 'ruby-test-run-at-point))))


### PR DESCRIPTION
this contrib layer does a few things:
1. swaps `ruby-mode` for `enh-ruby-mode`
2. adds `robe-mode` to pilot `inf-ruby` and sets a few convenient keybindings
3. adds a couple of keybindings for `ruby-test-mode`
4. adds support for `rbenv`

It's all pretty basic for now, I hope I'll be able to refine it over time.
