### PR TITLE
Fix incorrect example for evil-escape-key-sequence

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -824,7 +824,7 @@ revert back to the popular configuration using `jj` (just for the example
 it is not recommended) add this to your `config` function:
 
 ```elisp
-(defun dotspacemacs/config ()
+(defun dotspacemacs/init ()
   (setq-default evil-escape-key-sequence (kbd "jj"))
 )
 ```


### PR DESCRIPTION
When I followed the example in the documentation, `describe-variable` reflected the updated value ("jj") but spacemacs ignored it and continued to use the default value ("fd").

`evil-escape.el` mentions:

``` elisp
;; The key sequence can be customized with the variable
;; `evil-escape-key-sequence'
;; It must be set before requiring evil-escape.
```

So I tried moving the `setq` to `/init` instead of `/config`. That worked.
