### PR TITLE
bind reposition window to z f

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -63,6 +63,7 @@
         - [Vim motions with ace-jump mode](#vim-motions-with-ace-jump-mode)
         - [Window manipulation](#window-manipulation)
             - [Resizing windows](#resizing-windows)
+            - [Reposition window](#reposition-window)
             - [Golden ratio](#golden-ratio)
         - [Buffers and Files](#buffers-and-files)
         - [Ido](#ido)
@@ -956,6 +957,14 @@ Any other key       | leave the micro-state
 The micro-state text in minibuffer display the following information:
 
     [WidthxHeight] Resize window: (H/L) shrink/enlarge horizontally, (J/K) shrink/enlarge vertically
+
+#### Reposition window
+
+Key Binding         | Description
+--------------------|------------------------------------------------------------
+<kbd>z f</kbd>      | Make current function or comments visible
+
+`z f` tries to accommodate current function or comments into window as much as possible.
 
 #### Golden ratio
 

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -604,6 +604,8 @@ determine the state to enable when escaping from the insert state.")
       ;; Make evil-mode up/down operate in screen lines instead of logical lines
       (define-key evil-normal-state-map "j" 'evil-next-visual-line)
       (define-key evil-normal-state-map "k" 'evil-previous-visual-line)
+      ;; Make the current definition and/or comment visible.
+      (define-key evil-normal-state-map "zf" 'reposition-window)
       ;; quick navigation
       (define-key evil-normal-state-map (kbd "L")
         (lambda () (interactive)


### PR DESCRIPTION
As the title suggested. I also updated documentation.

I guess my personal setting deleted trailing spaces in other part of code. Would it be a good idea to hook `delete-trailing-whitespace` to `emacs-lisp-mode`? so that all contributors would agree on whitespaces.
