### PR TITLE
enable semantic mode in python contrib by default

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -8,6 +8,7 @@
     flycheck
     pyvenv
     python
+    semantic
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -132,3 +133,6 @@ which require an initialization must be listed explicitly in the list.")
 
 (defun python/init-flycheck ()
   (add-hook 'python-mode-hook 'flycheck-mode))
+
+(defun python/init-semantic ()
+  (semantic-mode 1))


### PR DESCRIPTION
Not sure if this is the right way to fix the problem, so instead of opening an issue, I just made a PR so that we can have some code to discuss.

The problem is that right now, in `python` buffers, `helm-semantic-or-imenu`(bound to `SPC s l`) gives nothings. This is because we neither enabled `semantic-mode` in python buffer nor do we set up `imenu-generic-expression` variable.

The solution is also pretty straightforward: we can either enable `semantic-mode`, as in this PR, or we'll have something like this in `python-hook`:

``` lisp
(setq python-imenu-generic-expression
      '(("Function"  "^[[:space:]]*def[ \n\t]+\\([_A-Za-z0-9]+\\)(" 1)
        ("Class" "^[[:space:]]*class[ \n\t]+\\([A-Z][_A-Za-z0-9]*\\)[[:space:]]*(" 1)))

(setq imenu-generic-expression python-imenu-generic-expression)
```

I prefer the first one, i.e. enable semantic by default. Not only because semantic mode actually parse the source code and therefore gives better results, but also because it has syntax hightlighting in `helm` buffer. But I'm not sure if that's something everyone wants.

Let me know your thought.
