### PR TITLE
Execute correct `clear` and `man` behavior in (e)shell

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -127,6 +127,35 @@ When using homebrew, install it using `brew install trash'."
       (toggle-frame-maximized)))
 
 ;; ---------------------------------------------------------------------------
+;; Shell
+;; ---------------------------------------------------------------------------
+(defun shell-comint-input-sender-hook ()
+  "Check certain shell commands.
+Executes the appropriate behavior for certain commands."
+  (setq comint-input-sender 
+        (lambda (proc command)
+          (cond
+           ;; Check for clear command and execute it.
+           ((string-match "^[ \t]*clear[ \t]*$" command)
+            (comint-send-string proc "\n")
+            (erase-buffer))
+           ;; Check for man command and execute it.
+           ((string-match "^[ \t]*man[ \t]*" command)
+            (comint-send-string proc "\n")
+            (setq command (replace-regexp-in-string "^[ \t]*man[ \t]*" "" command))
+            (setq command (replace-regexp-in-string "[ \t]+$" "" command))
+            (funcall 'man command))
+           ;; Send other commands to the default handler.
+           (t (comint-simple-send proc command))))))
+(add-hook 'shell-mode-hook 'shell-comint-input-sender-hook)
+
+(defun eshell/clear ()
+  "Clear contents in eshell."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (erase-buffer)))
+
+;; ---------------------------------------------------------------------------
 ;; Session
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
In `shell`, this is made possible by checking the input and then executing the appropriate behavior. For `eshell`, we only need to define `clear`.
