### PR TITLE
Make `<escape>` quit as much as it possibly can

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -8,6 +8,16 @@
 (define-key isearch-mode-map (kbd "M-S-<return>") 'isearch-repeat-backward)
 
 ;; ---------------------------------------------------------------------------
+;; Make <escape> quit as much as possible
+;; ---------------------------------------------------------------------------
+(define-key minibuffer-local-map (kbd "<escape>") 'keyboard-escape-quit)
+(define-key evil-visual-state-map (kbd "<escape>") 'keyboard-quit)
+(define-key minibuffer-local-ns-map (kbd "<escape>") 'keyboard-escape-quit)
+(define-key minibuffer-local-completion-map (kbd "<escape>") 'keyboard-escape-quit)
+(define-key minibuffer-local-must-match-map (kbd "<escape>") 'keyboard-escape-quit)
+(define-key minibuffer-local-isearch-map (kbd "<escape>") 'keyboard-escape-quit)
+
+;; ---------------------------------------------------------------------------
 ;; evil-leader key bindings
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`evil-escape` does a nice job of escaping things, but some people might be expecting `<escape>` to do the same thing by default. For some things like helm completions minibuffers, `<escape>` has to be pressed three times to close the minibuffer. This makes `<escape>` able to quit most of these kinds of things, and act as close as possible to `C-g`.
