### PR TITLE
Bind <Leader>wC to `delete-other-windows

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -126,6 +126,7 @@
   "w2"  'layout-double-columns
   "w3"  'layout-triple-columns
   "wc"  'delete-window
+  "wC"  'delete-other-windows
   "wd"  'toggle-current-window-dedication
   "wH"  'evil-window-move-far-left
   "wh"  'evil-window-left


### PR DESCRIPTION
As per the Vim documentation for `CTRL-W_o`:

```
|CTRL-W_o|      CTRL-W o           close all but current window (like |:only|)
```

Since the `<Leader>` bindings for `w` closely mirror `CTRL-W` bindings, it would be nice to maintain `wo` as `delete-other-windows`. To keep `other-frame`, I rebound it to `wO`.
