### PR TITLE
fixed bug in company-anaconda initilization

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -34,7 +34,7 @@ which require an initialization must be listed explicitly in the list.")
   (use-package company-anaconda
     :if (boundp 'company-backends)
     :defer t
-    :init (add-hook 'python-mode-hook 'company-anaconda)))
+    :init (add-to-list 'company-backends 'company-anaconda)))
 
 (defun python/init-eldoc ()
   (use-package eldoc


### PR DESCRIPTION
Currently sending a python buffer to REPL gives error because `company-anaconda` does not initilized properly. The right way to initialize this package is to add it to `company-backends`, rather than hooking it to `python-mode-hook`, see usage section https://github.com/proofit404/company-anaconda. 
