### PR TITLE
Fix undo-tree-auto-save-history

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2090,8 +2090,11 @@ determine the state to enable when escaping from the insert state.")
     :idle (global-undo-tree-mode)
     :defer t
     :init
-    (setq undo-tree-history-directory-alist
+    (setq undo-tree-auto-save-history t
+          undo-tree-history-directory-alist
           `(("." . ,(concat spacemacs-cache-directory "undo"))))
+    (unless (file-exists-p (concat spacemacs-cache-directory "undo"))
+        (make-directory (concat spacemacs-cache-directory "undo")))
     (setq undo-tree-visualizer-timestamps t)
     (setq undo-tree-visualizer-diff t)
     :config


### PR DESCRIPTION
Previous commit with undo auto-save did not create the directory so it broke undo.
