### PR TITLE
Intuitive window splitting keybindings

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -957,11 +957,11 @@ Key Binding            |                 Description
 <kbd>SPC w p p</kbd>   | close the current sticky popup window
 <kbd>SPC w r</kbd>     | rotate windows clockwise
 <kbd>SPC w R</kbd>     | rotate windows counter-clockwise
-<kbd>SPC w s</kbd>     | horizontal split
+<kbd>SPC w s</kbd>     | horizontal split (alternatively <kbd>SPC w /</kbd>)
 <kbd>SPC w S</kbd>     | initiate window size micro-state
 <kbd>SPC w u</kbd>     | undo window layout (used to effectively undo a close window)
 <kbd>SPC w U</kbd>     | redo window layout
-<kbd>SPC w v</kbd>     | vertical split
+<kbd>SPC w v</kbd>     | vertical split (alternatively <kbd>SPC w -</kbd>)
 <kbd>SPC w w</kbd>     | cycle and focus between windows
 
 #### Resizing windows

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -145,12 +145,14 @@
   "wo"  'other-frame
   "wr"  'rotate-windows
   "wR"  'rotate-windows-backward
-;; "wv"  'evenly-split-window-below)
+  ;; "wv"  'evenly-split-window-below)
   "ws"  'split-window-below
+  "w-"  'split-window-below
   "wS"  'spacemacs/resize-window-overlay-map
   "wU"  'winner-redo
   "wu"  'winner-undo
   "wv"  'split-window-right
+  "w/"  'split-window-right
   "ww"  'other-window)
 ;; text -----------------------------------------------------------------------
 (evil-leader/set-key


### PR DESCRIPTION
This adds some alternative window splitting bindings that although they are not standard, are totally intuitive and easy to remember. No more do you have to wonder, "what is a vertical split? Is it the orientation of the split line or the stacked windows."

The alternatives are <kbd>w -</kbd> for creating a split line that runs horizontally, like a `-`. 
And <kbd>SPC w /</kbd> for creating a split where the line is vertical, like a `/`, it isn't a pipe because that's hard to type.

I've used bindings like these in tmux for a long time and have loved them, even though I use it maybe once every 3 months I always remember the splitting bindings and which kind of split I will get.
