### PR TITLE
Fix for dotspacemacs-fullscreen-at-startup on windows

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -138,7 +138,8 @@ Can be installed with `brew install trash'."
 (unless (version< emacs-version "24.4")
   (if (and (boundp 'dotspacemacs-fullscreen-at-startup)
            dotspacemacs-fullscreen-at-startup)
-      (toggle-frame-maximized)))
+      (add-hook 'window-setup-hook 'toggle-frame-maximized)))
+
 
 ;; ---------------------------------------------------------------------------
 ;; Session


### PR DESCRIPTION
Added hook to window-setup-hook.  This fixes the issue in Windows, need check with other systems.  Should address #263 
