### PR TITLE
dotspacemacs-fullscreen-at-startup

### DIFF
--- a/core/dotspacemacs.el
+++ b/core/dotspacemacs.el
@@ -22,6 +22,9 @@ with `:' and Emacs commands are executed with `<leader> :'.")
   "Guide-key delay in seconds.")
 
 (defvar dotspacemacs-fullscreen-at-startup nil
+  "If non nil the frame put in fullscreen when Emacs starts up (Emacs 24.4+ only).")
+
+(defvar dotspacemacs-maximized-at-startup nil
   "If non nil the frame is maximized when Emacs starts up (Emacs 24.4+ only).")
 
 (defvar dotspacemacs-smooth-scrolling t

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -138,6 +138,9 @@ Can be installed with `brew install trash'."
 (unless (version< emacs-version "24.4")
   (if (and (boundp 'dotspacemacs-fullscreen-at-startup)
            dotspacemacs-fullscreen-at-startup)
+      (toggle-frame-fullscreen))
+  (if (and (boundp 'dotspacemacs-maximized-at-startup)
+           dotspacemacs-maximized-at-startup)
       (toggle-frame-maximized)))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
- dotspacemacs-fullscreen-at-startup now toogles fullscreen, not maximize
- dotspacemacs-maximized-at-startup added, toogles maximized as the old dotspacemacs-fullscreen-at-startup did
- this feelsl like a saner choice of wording, but it will 'break' user's configs
