### PR TITLE
company-mode: added support for include file completion

### DIFF
--- a/contrib/company-mode/packages.el
+++ b/contrib/company-mode/packages.el
@@ -2,6 +2,7 @@
   '(
     company
     company-tern
+    company-c-headers
     ))
 
 (defvar company-mode-excluded-packages


### PR DESCRIPTION
company-c-headers is required for c-header files completion.

![snapshot1](https://cloud.githubusercontent.com/assets/1227151/5448392/108331aa-84ad-11e4-8121-a4dbbccc2a41.png)
