### PR TITLE
bind SPC m to comma

### DIFF
--- a/core/dotspacemacs.el
+++ b/core/dotspacemacs.el
@@ -13,6 +13,9 @@ Paths must have a trailing slash (ie. `~/.mycontribs/')"
 (defvar dotspacemacs-leader-key "SPC"
   "The leader key.")
 
+(defvar dotspacemacs-major-mode-leader-key ","
+  "The leader key for major mode.")
+
 (defvar dotspacemacs-command-key ":"
   "The key used for Evil commands (ex-commands) and Emacs commands (M-x).
 By default the command key is `:' so ex-commands are executed like in Vim

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -79,6 +79,15 @@ a key sequence. NAME is a symbol name used as the prefix command."
   "Remove the evil-leader binding from the passed MAP."
   (spacemacs/activate-evil-leader-for-maps `(,map)))
 
+(defun spacemacs/activate-major-mode-leader ()
+  "Bind major mode key map to `dotspacemacs-major-mode-leader-key'."
+  (setq mode-map (cdr (assoc major-mode evil-leader--mode-maps)))
+  (when mode-map
+    (setq major-mode-map (lookup-key mode-map (kbd "m")))
+    (define-key evil-normal-state-local-map
+      (kbd dotspacemacs-major-mode-leader-key) major-mode-map)
+    ))
+
 (defmacro spacemacs|evilify (map &rest body)
   "Add `hjkl' navigation, search and visual state to MAP and set additional
 bindings contained in BODY."

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -677,7 +677,11 @@ determine the state to enable when escaping from the insert state.")
       ;; experimental: invoke leader with "jk" in insert mode
       (when dotspacemacs-feature-toggle-leader-on-jk
         (key-chord-define evil-insert-state-map (kbd "jk")
-                          evil-leader--default-map)))))
+                          evil-leader--default-map))
+      ;; experimental: map SPC m to ,
+      (when dotspacemacs-major-mode-leader-key
+        (add-hook 'after-change-major-mode-hook 'spacemacs/activate-major-mode-leader))
+        )))
 
 (defun spacemacs/init-evil-lisp-state ()
   (use-package evil-lisp-state


### PR DESCRIPTION
Attempt to bind `SPC m` to `,`, as discussed https://github.com/syl20bnr/spacemacs/issues/283.

The idea is to get key map that corresponds to `SPC m` and map to `,` after major mode changed in a buffer.

Feel free to make any changes you think necessary.
