### PR TITLE
Updated AUCTeX contrib layer with new bindings

### DIFF
--- a/contrib/auctex/Readme.md
+++ b/contrib/auctex/Readme.md
@@ -10,10 +10,25 @@ In order to load AucTex properly you must use `SPC e l` before opening any TeX f
 
 Along with other things this layer includes company-auctex, it's only enabled if you also enable my other contrib layer `company-mode`.
 
-## Other Things
+## Keybindings
 
-This layer binds the key `SPC m b` (and `H-r`) to save the current file, build it and view in your default viewer.
-It also binds `me` and `mc` to create and close environments.
+Key Binding         |                 Description
+--------------------|------------------------------------------------------------------
+<kbd>SPC m b  </kbd>| build and view 
+<kbd>SPC m e  </kbd>| insert LaTeX environment
+<kbd>SPC m c  </kbd>| close LaTeX environment
+<kbd>SPC m i  </kbd>| insert `\item`
+<kbd>SPC m f  </kbd>| insert LaTeX font - full bindings here: [AUCTeX documentation](https://www.gnu.org/software/auctex/manual/auctex/Font-Specifiers.html)
+<kbd>SPC m C  </kbd>| TeX command on master file
+<kbd>SPC m p r <kbd>| preview region
+<kbd>SPC m p b</kbd>| preview buffer
+<kbd>SPC m p d</kbd>| preview document
+<kbd>SPC m p e</kbd>| preview environment
+<kbd>SPC m p s</kbd>| preview section
+<kbd>SPC m p p</kbd>| preview at point
+<kbd>SPC m p f</kbd>| cache preamble for preview
+<kbd>SPC m p c</kbd>| clear previews 
+<kbd>SPC m *</kbd>  | TeX documentation, can be very slow
 
 ## Maintainer
 

--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -36,10 +36,27 @@
         (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
         (add-hook 'LaTeX-mode-hook 'spacemacs/load-yasnippet)
 
+        (setq spacemacs/key-binding-prefixes '(("mp" . "LaTeX Preview")))
         (evil-leader/set-key-for-mode 'latex-mode
           "mb" 'auctex/build-view
           "me" 'LaTeX-environment
-          "mc" 'LaTeX-close-environment)
+          "mc" 'LaTeX-close-environment
+          "mi" 'LaTeX-insert-item
+          "mf" 'TeX-font ;; Find a way to rebind tex-fonts
+
+          "mC" 'TeX-command-master
+
+          "mpr" 'preview-region
+          "mpb" 'preview-buffer
+          "mpd" 'preview-document
+          "mpe" 'preview-environment
+          "mps" 'preview-section
+          "mpp" 'preview-at-point
+          "mpf" 'preview-cache-preamble
+          "mpc" 'preview-clearout
+
+          "m?" 'TeX-doc ;; TeX-doc is a very slow function
+          )
 
         (setq-default TeX-auto-save t)
         (setq-default TeX-parse-self t)


### PR DESCRIPTION
I've added some new bindings to the AUCTeX layer, which are mainly inspired by the default AUCTeX binding.

Uses <kdb>SPC m</kbd> as prefix for all commands, and <kdb>SPC m p</p> for `preview` related commands.
