### PR TITLE
Updated Haskell layer

### DIFF
--- a/contrib/lang/haskell/README.md
+++ b/contrib/lang/haskell/README.md
@@ -3,8 +3,9 @@
 ![logo](haskell.png)
 
 This layer adds support for the [Haskell][] language.
+The layer uses company-ghc for completetion.
 
-**This layer is not adapted for Spacemacs, it needs you, Haskell experts, to
+**This layer is still not fully adapted for Spacemacs, it needs you, Haskell experts, to
 improve it and make it consistent with the Spacemacs experience.**
 
 ## Install
@@ -18,6 +19,80 @@ To use this contribution add it to your `~/.spacemacs`
 ```
 
 ## Key bindings
+
+All Haskell specific bindings are prefixed with <kbd>SPC m</kbd>
+
+### Haskell source code:
+
+#### Haskell commands:
+Top-level commands are prefixed by <kbd>SPC m</kbd>:
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd> SPC m C </kbd>     | compile the current project
+<kbd> SPC m t </kbd>     | gets the type of the identifier under the cursor
+<kbd> SPC m i </kbd>     | gets information for the identifier under the cursor
+<kbd> SPC m b </kbd>     | build the current cabal project 
+<kbd> SPC m u </kbd>     | finds uses of identifier
+<kbd> SPC m g </kbd>     | go to definition or tag
+
+#### Documentation commands:
+Documentation commands are prefixed by <kbd>SPC m h</kbd>
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd> SPC m h d </kbd>     | find or generate Haddock documentation for the identifier under the cursor
+<kbd> SPC m h h </kbd>     | do a Hoogle lookup
+<kbd> SPC m h y </kbd>     | do a Hayoo lookup
+
+
+#### Cabal commands:
+Cabal commands are prefixed by <kbd>SPC m c</kbd>:
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd> SPC m c c</kbd>      | cabal actions
+<kbd> SPC m c v</kbd>      | visit the cabal file
+
+#### Debug commands:
+Debug commands are prefixed by <kbd>SPC m d</kbd>:
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd> SPC m d d </kbd>     | start debug process, needs to be run first
+<kbd> SPC m d b </kbd>     | insert breakpoint at function
+<kbd> SPC m d n </kbd>     | next breakpoint
+<kbd> SPC m d p </kbd>     | previous breakpoint
+<kbd> SPC m d B </kbd>     | delete breakpoint
+<kbd> SPC m d c </kbd>     | continue current process
+<kbd> SPC m d a </kbd>     | abandon current process
+<kbd> SPC m d r </kbd>     | refresh process buffer
+
+#### REPL commands:
+REPL commands are prefixed by <kbd>SPC m s</kbd>:
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd> SPC m s b</kbd>      | load or reload the current buffer into the REPL
+<kbd> SPC m s c</kbd>      | clear the REPL
+<kbd> SPC m s s</kbd>      | show the REPL
+<kbd> SPC m s S</kbd>      | show and switch to the REPL
+
+### Cabal files:
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd>SPC m d</kbd>       | add a dependency to the project
+<kbd>SPC m b</kbd>       | go to benchmark section
+<kbd>SPC m e</kbd>       | go to executable section
+<kbd>SPC m t</kbd>       | go to test-suite section
+<kbd>SPC m m</kbd>       | go to exposed modules
+<kbd>SPC m l</kbd>       | go to libary section
+<kbd>SPC m n</kbd>       | go to next subsection
+<kbd>SPC m p</kbd>       | go to previous subsection
+<kbd>SPC m N</kbd>       | go to next section
+<kbd>SPC m P</kbd>       | go to previous section
+<kbd>SPC m f</kbd>       | find or create source-file under the cursor
 
 **TODO**
 

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -3,9 +3,12 @@
     flycheck
     ghc
     haskell-mode
-    )
-  "List of all packages to install and/or initialize. Built-in packages
-which require an initialization must be listed explicitly in the list.")
+    ghci-completion
+    ))
+
+;; Only load company-ghc if company-mode is enabled
+(when (member 'company-mode dotspacemacs-configuration-layers)
+  (add-to-list 'haskell-packages 'company-ghc))
 
 (defun haskell/init-flycheck ()
   (add-hook 'haskell-mode-hook 'flycheck-mode))
@@ -18,8 +21,9 @@ which require an initialization must be listed explicitly in the list.")
     (progn
       ;; Customization
       (custom-set-variables
-       ;; Use cabal-dev for the GHCi session. Ensures our dependencies are in scope.
-       '(haskell-process-type 'cabal-dev)
+       ;; Use cabal-repl for the GHCi session. Ensures our dependencies are in scope.
+       ;; cabal-dev is deprecated
+       '(haskell-process-type 'cabal-repl)
 
        ;; Use notify.el (if you have it installed) at the end of running
        ;; Cabal commands or generally things worth notifying.
@@ -28,52 +32,105 @@ which require an initialization must be listed explicitly in the list.")
        ;; To enable tags generation on save.
        '(haskell-tags-on-save t)
 
+       ;; Remove annoying error popups
+       '(haskell-interactive-popup-error nil)
+
+       ;; Better import handling
+       '(haskell-process-suggest-remove-import-lines t)
+       '(haskell-process-auto-import-loaded-modules t)
+
        ;; To enable stylish on save.
        '(haskell-stylish-on-save t))
+
+      ;; Make sure company-ghc is properly initialized
+      (autoload 'ghc-init "ghc" nil t)
+      (autoload 'ghc-debug "ghc" nil t)
 
       (add-hook 'haskell-mode-hook 'haskell-hook)
       (add-hook 'haskell-cabal-mode-hook 'haskell-cabal-hook)
 
+      ;; Make "RET" behaviour in REPL saner
+      (evil-define-key 'insert haskell-interactive-mode-map (kbd "RET") 'haskell-interactive-mode-return)
+      (evil-define-key 'normal haskell-interactive-mode-map (kbd "RET") 'haskell-interactive-mode-return)
+
+      ;;;;;;;;; Keybindings ;;;;;;;;;;
+
+      ;; ;; use "mc" as prefix for cabal commands
+      ;; (setq spacemacs/key-binding-prefixes '(("mc" . "cabal")))
+
+      ;; ;; use "ms" as prefix for REPL commands
+      ;; (setq spacemacs/key-binding-prefixes '(("ms" . "Haskell REPL")))
+
+      ;; ;; use "md" as prefix for debug commands
+      ;; (setq spacemacs/key-binding-prefixes '(("md" . "Haskell Debug")))
+
+      ;; ;; use "mh" as prefix for documentation commands
+      ;; (setq spacemacs/key-binding-prefixes '(("mh" . "Haskell Documentation")))
+
+      
+      (evil-leader/set-key-for-mode 'haskell-mode
+        "mC"  'haskell-compile
+        "mt"  'haskell-process-do-type
+        "mi"  'haskell-process-do-info
+        "mb"  'haskell-process-cabal-build
+        "mu"  'haskell-mode-find-uses
+        "mg"  'haskell-mode-jump-to-def-or-tag
+
+        "msb"  'haskell-process-load-or-reload
+        "msc"  'haskell-interactive-mode-clear
+        "mss"  'haskell-interactive-bring
+        "msS"  'haskell-interactive-switch
+
+        "mcc" 'haskell-process-cabal
+        "mcv" 'haskell-cabal-visit-file
+
+        "mhh"  'hoogle
+        "mhy"  'hayoo
+        "mhd"  'inferior-haskell-find-haddock
+
+        "mdd"  'haskell-debug
+        "mdb"  'haskell-debug/break-on-function
+        "mdn"  'haskell-debug/next
+        "mdp"  'haskell-debug/previous
+        "mdB"  'haskell-debug/delete
+        "mdc"  'haskell-debug/continue
+        "mda"  'haskell-debug/abandon
+        "mdr"  'haskell-debug/refresh
+        )
+      ;; Switch back to editor from REPL
+      (evil-leader/set-key-for-mode 'interactive-haskell-mode
+        "msS"  'haskell-interactive-switch
+        )
+
+      ;; Compile
+      (evil-leader/set-key-for-mode 'haskell-cabal
+        "mC"  'haskell-compile
+        )
+
+      ;; Cabal-file bindings
+      (evil-leader/set-key-for-mode 'haskell-cabal-mode
+        "md" 'haskell-cabal-add-dependency
+        "mb" 'haskell-cabal-goto-benchmark-section
+        "me" 'haskell-cabal-goto-executable-section
+        "mt" 'haskell-cabal-goto-test-suite-section
+        "mm" 'haskell-cabal-goto-exposed-modules
+        "ml" 'haskell-cabal-goto-library-section
+        "mn" 'haskell-cabal-next-subsection
+        "mp" 'haskell-cabal-previous-subsection
+        "mN" 'haskell-cabal-next-section
+        "mP" 'haskell-cabal-previous-section
+        "mf" 'haskell-cabal-find-or-create-source-file
+        ;; "m="  'haskell-cabal-subsection-arrange-lines ;; Does a bad job, 'gg=G' works better
+        )
+
       ;; Haskell main editing mode key bindings.
       (defun haskell-hook ()
-        ;; Use simple indentation.
-        (turn-on-haskell-simple-indent)
-        (define-key haskell-mode-map (kbd "<return>") 'haskell-simple-indent-newline-same-col)
-        (define-key haskell-mode-map (kbd "C-<return>") 'haskell-simple-indent-newline-indent)
-
-        ;; Load the current file (and make a session if not already made).
-        (define-key haskell-mode-map [?\C-c ?\C-l] 'haskell-process-load-file)
-        (define-key haskell-mode-map [f5] 'haskell-process-load-file)
-
-        ;; Switch to the REPL.
-        (define-key haskell-mode-map [?\C-c ?\C-z] 'haskell-interactive-switch)
-        ;; “Bring” the REPL, hiding all other windows apart from the source
-        ;; and the REPL.
-        (define-key haskell-mode-map (kbd "C-`") 'haskell-interactive-bring)
-
-        ;; Build the Cabal project.
-        (define-key haskell-mode-map (kbd "C-c C-c") 'haskell-process-cabal-build)
-        ;; Interactively choose the Cabal command to run.
-        (define-key haskell-mode-map (kbd "C-c c") 'haskell-process-cabal)
-
-        ;; Get the type and info of the symbol at point, print it in the
-        ;; message buffer.
-        (define-key haskell-mode-map (kbd "C-c C-t") 'haskell-process-do-type)
-        (define-key haskell-mode-map (kbd "C-c C-i") 'haskell-process-do-info)
-
-        ;; Contextually do clever things on the space key, in particular:
-        ;;   1. Complete imports, letting you choose the module name.
-        ;;   2. Show the type of the symbol after the space.
-        (define-key haskell-mode-map (kbd "SPC") 'haskell-mode-contextual-space)
-
-        ;; Jump to the imports. Keep tapping to jump between import
-        ;; groups. C-u f8 to jump back again.
-        (define-key haskell-mode-map [f8] 'haskell-navigate-imports)
-
-        ;; Jump to the definition of the current symbol.
-        (define-key haskell-mode-map (kbd "M-.") 'haskell-mode-tag-find)
+        (lambda () (ghc-init))
+        ;; Use advanced indention
+        (turn-on-haskell-indentation)
 
         ;; Indent the below lines on columns after the current column.
+        ;; Might need better bindings for spacemacs and OS X
         (define-key haskell-mode-map (kbd "C-<right>")
           (lambda ()
             (interactive)
@@ -86,7 +143,11 @@ which require an initialization must be listed explicitly in the list.")
 
       ;; Useful to have these keybindings for .cabal files, too.
       (defun haskell-cabal-hook ()
-        (define-key haskell-cabal-mode-map (kbd "C-c C-c") 'haskell-process-cabal-build)
-        (define-key haskell-cabal-mode-map (kbd "C-c c") 'haskell-process-cabal)
-        (define-key haskell-cabal-mode-map (kbd "C-`") 'haskell-interactive-bring)
         (define-key haskell-cabal-mode-map [?\C-c ?\C-z] 'haskell-interactive-switch)))))
+
+(defun haskell/init-company-ghc ()
+  (use-package ghc
+    :init 
+    (add-to-list 'company-backends 'company-ghc)
+    (ghc-comp-init)
+    ))


### PR DESCRIPTION
- Uses cabal-repl instead of the deprecated cabal-dev
- Loads company-ghc if company-mode is enabled
- Fixed RET in REPL
- See README.md for keybindings
