### PR TITLE
Fixes for company-mode for C/C++

### DIFF
--- a/contrib/company-mode/funcs.el
+++ b/contrib/company-mode/funcs.el
@@ -76,7 +76,7 @@
              ;; them past our error filtering
              (setf (flycheck-error-message err)
                    (or (flycheck-error-message err) "no message")))
-           (flycheck-fold-include-errors errors "In file included from")))
+           (flycheck-fold-include-levels errors "In file included from")))
        :modes (c-mode c++-mode)
        :next-checkers ((warning . c/c++-cppcheck)))
      (add-to-list 'flycheck-checkers 'c/c++-company)))

--- a/contrib/company-mode/packages.el
+++ b/contrib/company-mode/packages.el
@@ -58,6 +58,12 @@ so that you don't have 'do' completed to 'downcase' in Ruby"
 
       (spacemacs|diminish company-mode " Ⓒ"))))
 
+(defun company-mode/init-company-c-headers ()
+  (use-package company-c-headers
+    :defer t
+    :init
+    (add-to-list 'company-backends 'company-c-headers)))
+
 (defun company-mode/init-company-tern ()
   (use-package company-tern
     :defer t


### PR DESCRIPTION
Lazily load company-c-headers.  Show include file errors properly (flycheck) in cc-mode.
