### PR TITLE
Open additional magit commands to the `SPC` bindings

### DIFF
--- a/contrib/git/packages.el
+++ b/contrib/git/packages.el
@@ -129,7 +129,12 @@ implementation."
   (use-package magit
     :defer t
     :init
-    (evil-leader/set-key "gs" 'magit-status)
+    (evil-leader/set-key
+      "gs" 'magit-status
+      "gb" 'magit-blame-mode
+      "gC" 'magit-commit
+      "gl" 'magit-log
+      )
     :config
     (progn
       (spacemacs|hide-lighter magit-auto-revert-mode)


### PR DESCRIPTION
adds `magit-blame`, `magit-commit`, and `magit-log`
