### PR TITLE
Updated haskell-mode bindings

### DIFF
--- a/contrib/lang/haskell/README.md
+++ b/contrib/lang/haskell/README.md
@@ -29,12 +29,11 @@ Top-level commands are prefixed by <kbd>SPC m</kbd>:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m C</kbd>    | compile the current project
 <kbd>SPC m t</kbd>    | gets the type of the identifier under the cursor
 <kbd>SPC m i</kbd>    | gets information for the identifier under the cursor
-<kbd>SPC m b</kbd>    | build the current cabal project
 <kbd>SPC m u</kbd>    | finds uses of identifier
 <kbd>SPC m g</kbd>    | go to definition or tag
+<kbd>SPC m f</kbd>    | format buffer using haskell-stylish
 
 #### Documentation commands:
 Documentation commands are prefixed by <kbd>SPC m h</kbd>
@@ -51,7 +50,9 @@ Cabal commands are prefixed by <kbd>SPC m c</kbd>:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m c c</kbd>  | cabal actions
+<kbd>SPC m c a</kbd>  | cabal actions
+<kbd>SPC m c b</kbd>  | build the current cabal project, i.e. invoke `cabal build`
+<kbd>SPC m c c</kbd>  | compile the current project, i.e. invoke `ghc`
 <kbd>SPC m c v</kbd>  | visit the cabal file
 
 #### Debug commands:
@@ -62,7 +63,7 @@ Debug commands are prefixed by <kbd>SPC m d</kbd>:
 <kbd>SPC m d d </kbd> | start debug process, needs to be run first
 <kbd>SPC m d b </kbd> | insert breakpoint at function
 <kbd>SPC m d n </kbd> | next breakpoint
-<kbd>SPC m d p </kbd> | previous breakpoint
+<kbd>SPC m d N </kbd> | previous breakpoint
 <kbd>SPC m d B </kbd> | delete breakpoint
 <kbd>SPC m d c </kbd> | continue current process
 <kbd>SPC m d a </kbd> | abandon current process

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -1,6 +1,7 @@
 (defvar haskell-packages
   '(
     flycheck
+    flycheck-haskell
     ghc
     haskell-mode
     ghci-completion
@@ -11,7 +12,8 @@
   (add-to-list 'haskell-packages 'company-ghc))
 
 (defun haskell/init-flycheck ()
-  (add-hook 'haskell-mode-hook 'flycheck-mode))
+  ;;(add-hook 'haskell-mode-hook 'flycheck-mode))
+  (add-hook 'flycheck-mode-hook 'flycheck-haskell-setup))
 
 (defun haskell/init-haskell-mode ()
   (require 'haskell-yas)
@@ -39,8 +41,8 @@
        '(haskell-process-suggest-remove-import-lines t)
        '(haskell-process-auto-import-loaded-modules t)
 
-       ;; To enable stylish on save.
-       '(haskell-stylish-on-save t))
+       ;; Disable haskell-stylish on save, it breaks flycheck highlighting
+       '(haskell-stylish-on-save nil))
 
       ;; Make sure company-ghc is properly initialized
       (autoload 'ghc-init "ghc" nil t)
@@ -69,20 +71,21 @@
 
       
       (evil-leader/set-key-for-mode 'haskell-mode
-        "mC"  'haskell-compile
-        "mt"  'haskell-process-do-type
-        "mi"  'haskell-process-do-info
-        "mb"  'haskell-process-cabal-build
-        "mu"  'haskell-mode-find-uses
-        "mg"  'haskell-mode-jump-to-def-or-tag
+        "mt"   'haskell-process-do-type
+        "mi"   'haskell-process-do-info
+        "mu"   'haskell-mode-find-uses
+        "mg"   'haskell-mode-jump-to-def-or-tag
+        "mf"   'haskell-mode-stylish-buffer
 
         "msb"  'haskell-process-load-or-reload
         "msc"  'haskell-interactive-mode-clear
         "mss"  'haskell-interactive-bring
         "msS"  'haskell-interactive-switch
 
-        "mcc" 'haskell-process-cabal
-        "mcv" 'haskell-cabal-visit-file
+        "mca"  'haskell-process-cabal
+        "mcb"  'haskell-process-cabal-build
+        "mcc"  'haskell-compile
+        "mcv"  'haskell-cabal-visit-file
 
         "mhh"  'hoogle
         "mhy"  'hayoo
@@ -91,7 +94,7 @@
         "mdd"  'haskell-debug
         "mdb"  'haskell-debug/break-on-function
         "mdn"  'haskell-debug/next
-        "mdp"  'haskell-debug/previous
+        "mdN"  'haskell-debug/previous
         "mdB"  'haskell-debug/delete
         "mdc"  'haskell-debug/continue
         "mda"  'haskell-debug/abandon


### PR DESCRIPTION
- Fits better with spacemacs conventions
- Check README.md for bindings

Below fixes flycheck for haskell:
- Disabled haskell-stylish on save as it interferes with flycheck errror highlighting
- Added a new binding, `SPC m f` that runs haskell-stylish
