### PR TITLE
Update docs with more information on powerline colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,10 @@ The corresponding feature request for the powerline can be found
 [here][pw-patched-fonts].
 
 5. **Why the powerline colors are not correct on OS X ?**
-This is a known issue with the `emacs` brew formula. It is recommended to use the
-[emacs-mac-port][] built. See the [install OSX section][] for more info on this.
+This is a [known issue][powerline-srgb-issue] as of Emacs 24.4 due to
+`ns-use-srgb-colorspace` defaulting to true. It is recommended to use
+the [emacs-mac-port][] build. See the [install OSX section][] for more
+info on this.
 
 [Twitter]: http://i.imgur.com/tXSoThF.png
 [philosophy]: https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.md#philosophy
@@ -345,3 +347,4 @@ This is a known issue with the `emacs` brew formula. It is recommended to use th
 [Scala]: https://github.com/syl20bnr/spacemacs/blob/master/contrib/lang/scala
 [Clojure]: https://github.com/syl20bnr/spacemacs/blob/master/contrib/lang/clojure
 [C-C++]: https://github.com/syl20bnr/spacemacs/blob/master/contrib/lang/c-c++
+[powerline-srgb-issue]: https://github.com/milkypostman/powerline/issues/54


### PR DESCRIPTION
The powerline color issue is due to the fact that Emacs 24.4 now defaults to using sRGB colorspace on OS X 10.7 and higher, not some "brokeness" with brew's `emacs` build as the previous verbiage seemed to imply; the powerline codebase is still assuming `(setq ns-use-srgb-colorspace nil)` is the default.

This PR adds more information about this so that users may decide whether they want to just set it back to nil, switch to emacs-mac (which has it set to nil anyway), or disable powershell separators. (Turning off srgb colorspace results in washed-out theme colors).

---

Side rant:
I don't agree that the recommended fix for this would be to use `emacs-mac-port` as that basically just gives better trackpad support. IMHO trackpad support does not outweigh the frustrations over default meta/super key bindings, no `server-start` support, or the use of the antiquated carbon api, but I left the recommendation as-is in this PR.
