### PR TITLE
Add a feature to toggle transparency

### DIFF
--- a/core/dotspacemacs.el
+++ b/core/dotspacemacs.el
@@ -42,6 +42,16 @@ with `:' and Emacs commands are executed with `<leader> :'.")
   "If non nil the frame is maximized when Emacs starts up (Emacs 24.4+ only).
 Takes effect only if `dotspacemacs-fullscreen-at-startup' is nil.")
 
+(defvar dotspacemacs-active-transparency 90
+  "A value from the range (0..100), in increasing opacity, which describes the
+transparency level of a frame when it's active or selected. Transparency
+can be toggled through `toggle-transparency'.")
+
+(defvar dotspacemacs-inactive-transparency 90
+  "A value from the range (0..100), in increasing opacity, which describes the
+transparency level of a frame when it's inactive or deselected. Transparency
+can be toggled through `toggle-transparency'.")
+
 (defvar dotspacemacs-mode-line-unicode-symbols t
   "If non nil unicode symbols are displayed in the mode-line (eg. for lighters)")
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -44,6 +44,14 @@
  ;; If non nil the frame is maximized when Emacs starts up (Emacs 24.4+ only).
  ;; Takes effect only if `dotspacemacs-fullscreen-at-startup' is nil.
  dotspacemacs-maximized-at-startup nil
+ ;; A value from the range (0..100), in increasing opacity, which describes the
+ ;; transparency level of a frame when it's active or selected. Transparency can
+ ;; be toggled through `toggle-transparency'.
+ dotspacemacs-active-transparency 90
+ ;; A value from the range (0..100), in increasing opacity, which describes the
+ ;; transparency level of a frame when it's inactive or deselected. Transparency
+ ;; can be toggled through `toggle-transparency'.
+ dotspacemacs-inactive-transparency 90
  ;; If non nil unicode symbols are displayed in the mode line (e.g. for lighters)
  dotspacemacs-mode-line-unicode-symbols t
  ;; If non nil smooth scrolling (native-scrolling) is enabled. Smooth scrolling

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -706,6 +706,7 @@ Some UI indicators can be toggled on and off (toggles start with `t`):
 <kbd>SPC t L</kbd>    | toggle visual lines
 <kbd>SPC t M</kbd>    | toggle frame maximize
 <kbd>SPC t n</kbd>    | show the absolute line numbers
+<kbd>SPC t t</kbd>    | toggle frame transparency
 
 ## Mode-line
 

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -216,6 +216,19 @@ the current state and point position."
       (delete-other-windows)
       (bzg-big-fringe-mode 1))))
 
+(defun toggle-transparency ()
+  "Toggle between transparent or opaque display."
+  (interactive)
+  ;; Define alpha if it's nil
+  (if (eq (frame-parameter (selected-frame) 'alpha) nil)
+      (set-frame-parameter (selected-frame) 'alpha '(100 100)))
+  ;; Do the actual toggle
+  (if (/= (cadr (frame-parameter (selected-frame) 'alpha)) 100)
+      (set-frame-parameter (selected-frame) 'alpha '(100 100))
+    (set-frame-parameter (selected-frame) 'alpha
+                         (list dotspacemacs-active-transparency
+                               dotspacemacs-inactive-transparency))))
+
 (defun toggle-triple-double-column-mode ()
   " Toggle between triple columns and double columns mode quickly. "
   (interactive)

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -121,6 +121,7 @@
   "tL" 'visual-line-mode
   "tM" 'toggle-frame-maximized
   "tn" 'global-linum-mode
+  "tt" 'toggle-transparency
   "t SPC" 'whitespace-mode)
 ;; quit -----------------------------------------------------------------------
 (evil-leader/set-key


### PR DESCRIPTION
This sets the initial `alpha` frame parameter so that transparency could
be toggled later on. The level of opacity can be configured from a
user's .spacemacs through the variables `spacemacs-active-transparency`
and `spacemacs-inactive-transparency`.

Here's how it looks like when a transparent emacs is in front of the spacemacs powerline doc:

![screen shot 2014-12-28 at 02 20 17](https://cloud.githubusercontent.com/assets/53690/5561969/8f0aa398-8e38-11e4-8004-0ffb533b011f.jpg)
