### PR TITLE
Removed ghci-completion package

### DIFF
--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -4,7 +4,6 @@
     flycheck-haskell
     ghc
     haskell-mode
-    ghci-completion
     ))
 
 ;; Only load company-ghc if company-mode is enabled


### PR DESCRIPTION
- ghci-completion is redundant when using flycheck-haskell
