### PR TITLE
Use "magit-ido-completing-read" for completion.

### DIFF
--- a/contrib/git/config.el
+++ b/contrib/git/config.el
@@ -2,6 +2,8 @@
   "If non nil the Github packages and extensions are enabled.")
 
 (setq git/key-binding-prefixes '(("gh" . "gutter-hunks/highlight")))
+(setq magit-completing-read-function 'magit-ido-completing-read)
+
 (when git-enable-github-support
   (push (cons "gf" "file") git/key-binding-prefixes)
   (push (cons "gg" "gist") git/key-binding-prefixes))


### PR DESCRIPTION
Provides better completion throughout Magit.
Best used together with: "(setq magit-repo-dirs '("~/git/"))".
