### PR TITLE
user-home-directory taken from home env, not parent path

### DIFF
--- a/core/spacemacs-mode.el
+++ b/core/spacemacs-mode.el
@@ -20,7 +20,7 @@
 
 ;; additional paths
 (defconst user-home-directory
-  (expand-file-name (concat user-emacs-directory "../"))
+  (expand-file-name "~/")
   "User home directory (~/).")
 (defconst spacemacs-directory
   (expand-file-name (concat user-emacs-directory "spacemacs/"))


### PR DESCRIPTION
Can we do this instead?

I generally like to symlink to larger projects from my home directory and this change allows for that. After running `ln -s ~/Workspace/spacemacs ~/.emacs.d`, I can verify that this change works with a symlink on osx.
