### PR TITLE
added open file in external application function

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -833,3 +833,14 @@ If ASCII si not provided then UNICODE is used instead."
 (defun current-line ()
   "Return the line at point as a string."
   (buffer-substring (line-beginning-position) (line-end-position)))
+
+(defun spacemacs/open-in-external-app ()
+  "Open current file in external application."
+  (interactive)
+  (let ((file-path (buffer-file-name)))
+    (cond
+     ((system-is-mswindows) (w32-shell-execute "open" (replace-regexp-in-string "/" "\\" file-path)))
+     ((system-is-mac) (shell-command (format "open \"%s\"" file-path)))
+     ((system-is-linux) (let ((process-connection-type nil))
+                          (start-process "" nil "xdg-open" file-path)))
+     )))

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -72,6 +72,7 @@
   "fec" 'find-contrib-file
   "fed" 'find-dotfile
   "fev" 'spacemacs/display-and-copy-version
+  "fo" 'spacemacs/open-in-external-app
   "fS" 'evil-write-all
   "fs" 'evil-write
   "fy" 'show-and-copy-buffer-filename)


### PR DESCRIPTION
Stole from [Stackoverflow](http://stackoverflow.com/questions/25109968/in-emacs-how-to-open-file-in-external-program-without-errors), to open a file in external app, and bind it to `SPC f o` for `file open`. Also see issue https://github.com/syl20bnr/spacemacs/issues/326#issuecomment-67836746