### PR TITLE
ruby version manager support

### DIFF
--- a/contrib/lang/ruby/README.md
+++ b/contrib/lang/ruby/README.md
@@ -43,6 +43,17 @@ or on the command line:
 $ gem install pry
 ```
 
+## Ruby version manager
+
+This layer supports the use of [RVM][] and [Rbenv][].
+To enable it, set the `ruby-version-manager` var in your `~/.spacemacs`:
+
+```elisp
+(defun dotspacemacs/init ()
+  (setq-default ruby-version-manager 'rbenv)
+)
+```
+
 ## Key bindings
 
 ### enh-ruby-mode
@@ -63,3 +74,5 @@ a couple of useful keybindings:
 
 [enh-ruby-mode]: https://github.com/zenspider/enhanced-ruby-mode
 [robe-mode]: https://github.com/dgutov/robe
+[Rbenv]: https://github.com/sstephenson/rbenv
+[RVM]: https://rvm.io/

--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -1,7 +1,6 @@
 (defvar ruby-packages
   '(
     ;; package rubys go here
-    rbenv
     enh-ruby-mode
     flycheck
     ruby-test-mode
@@ -11,6 +10,12 @@
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
 
+(defvar ruby-version-manager nil
+  "If non nil defines the Ruby version manager (i.e. rbenv, rvm)")
+
+(when ruby-version-manager
+  (add-to-list 'ruby-packages ruby-version-manager))
+
 (defvar ruby-excluded-packages '(ruby-mode))
 
 (defun ruby/init-rbenv ()
@@ -19,7 +24,15 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init (global-rbenv-mode)
     :config (add-hook 'enh-ruby-mode-hook
-          (lambda () (rbenv-use-corresponding)))))
+                      (lambda () (rbenv-use-corresponding)))))
+
+(defun ruby/init-rvm ()
+  "Initialize RVM mode"
+  (use-package rvm
+    :defer t
+    :init (rvm-use-default)
+    :config (add-hook 'enh-ruby-mode-hook
+                      (lambda () (rvm-activate-corresponding-ruby)))))
 
 (defun ruby/init-enh-ruby-mode ()
   "Initialize Enhanced Ruby Mode"


### PR DESCRIPTION
adds support for RVM and Rbenv ruby version managers, by means of the `ruby-version-manager` var.
By default it's set to nil, meaning no version manager support will be loaded.

