### PR TITLE
Add go-eldoc, go-autocomplete and go-oracle

### DIFF
--- a/contrib/lang/go/README.md
+++ b/contrib/lang/go/README.md
@@ -19,6 +19,8 @@ This layers adds extensive support for go.
 
 Features:
 - gofmt on file save
+- Auto-completion using [go-autocomplete](https://github.com/nsf/gocode/tree/master/emacs)
+- Source analysis using [go-oracle](http://golang.org/s/oracle-user-manual)
 
 ## Install
 
@@ -34,7 +36,7 @@ To use this contribution add it to your `~/.spacemacs`
 
 ## Working with Go
 
-Go commands (start with `m`):
+### Go commands (start with `m`):
 
     Key Binding            |                 Description
 ---------------------------|------------------------------------------------------------
@@ -45,3 +47,22 @@ Go commands (start with `m`):
 <kbd>SPC m p b</kbd>       | go-play buffer
 <kbd>SPC m p r</kbd>       | go-play region
 <kbd>SPC m p d</kbd>       | download go-play snippet
+<kbd>SPC m g</kbd>         | go jump to definition
+
+
+### Go Oracle
+
+    Key Binding            |                 Description
+---------------------------|------------------------------------------------------------
+<kbd>SPC m o o</kbd>       | go-oracle set analysis scope
+<kbd>SPC m o <</kbd>       | go-oracle show possible callers
+<kbd>SPC m o ></kbd>       | go-oracle show call targets
+<kbd>SPC m o c</kbd>       | go-oracle show channel sends/receives
+<kbd>SPC m o d</kbd>       | go-oracle show definition
+<kbd>SPC m o f</kbd>       | go-oracle show free variables
+<kbd>SPC m o g</kbd>       | go-oracle show callgraph
+<kbd>SPC m o i</kbd>       | go-oracle show implements relation
+<kbd>SPC m o p</kbd>       | go-oracle show what the select expression points to
+<kbd>SPC m o r</kbd>       | go-oracle show all references to object
+<kbd>SPC m o s</kbd>       | go-oracle show callstack
+<kbd>SPC m o t</kbd>       | go-oracle describe selected syntax, kind, type and methods

--- a/contrib/lang/go/extensions.el
+++ b/contrib/lang/go/extensions.el
@@ -1,0 +1,45 @@
+(defvar go-pre-extensions
+  '(
+    ;; pre extension gos go here
+    )
+  "List of all extensions to load before the packages.")
+
+(defvar go-post-extensions
+  '(
+    ;; post extension gos go here
+    go-autocomplete
+    go-oracle
+    )
+  "List of all extensions to load after the packages.")
+
+;; For each extension, define a function go/init-<extension-go>
+;;
+;; (defun go/init-my-extension ()
+;;   "Initialize my extension"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package
+(defun go/init-go-autocomplete()
+  (load-file "$GOPATH/src/github.com/nsf/gocode/emacs/go-autocomplete.el")
+)
+
+(defun go/init-go-oracle()
+  (load-file "$GOPATH/src/code.google.com/p/go.tools/cmd/oracle/oracle.el")
+  (add-hook 'go-mode-hook 'go-oracle-mode)
+  (spacemacs|diminish go-oracle-mode " O")
+  (evil-leader/set-key-for-mode 'go-mode
+    "moo" 'go-oracle-set-scope
+    "mo<" 'go-oracle-callers
+    "mo>" 'go-oracle-callees
+    "moc" 'go-oracle-peers
+    "mod" 'go-oracle-definition
+    "mof" 'go-oracle-freevars
+    "mog" 'go-oracle-callgraph
+    "moi" 'go-oracle-implements
+    "mop" 'go-oracle-pointsto
+    "mor" 'go-oracle-referrers
+    "mos" 'go-oracle-callstack
+    "mot" 'go-oracle-describe
+  ))

--- a/contrib/lang/go/packages.el
+++ b/contrib/lang/go/packages.el
@@ -2,6 +2,7 @@
   '(
     flycheck
     go-mode
+    go-eldoc
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -22,7 +23,11 @@ which require an initialization must be listed explicitly in the list.")
         "mpb"  'go-play-buffer
         "mpr"  'go-play-region
         "mpd"  'go-download-play
+        "mg"   'godef-jump
       ))
     :config
     (add-hook 'before-save-hook 'gofmt-before-save)
     ))
+
+(defun go/init-go-eldoc()
+    (add-hook 'go-mode-hook 'go-eldoc-setup))


### PR DESCRIPTION
I have added autocomplete support and go-oracle for go contrib layer.

I don't know if adding load-file with PATH in extension or copy the file and manage in extension folder is better, so please direct me the right way.

The key binding for go-oracle is a little strange (describe is -t, peers is -c) because I followed the original go-oracle binding.