### PR TITLE
Support for spacemacs/toggle-frame-fullscreen to use non-native fullscreen

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -14,4 +14,4 @@
   (global-set-key (kbd "s-z") 'undo-tree-undo)
   (global-set-key (kbd "s-s") 'save-buffer)
   (global-set-key (kbd "s-Z") 'undo-tree-redo)
-  (global-set-key (kbd "C-s-f") 'toggle-frame-fullscreen))
+  (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen))

--- a/core/dotspacemacs.el
+++ b/core/dotspacemacs.el
@@ -35,6 +35,10 @@ with `:' and Emacs commands are executed with `<leader> :'.")
 (defvar dotspacemacs-guide-key-delay 0.4
   "Guide-key delay in seconds.")
 
+(defvar dotspacemacs-fullscreen-use-non-native nil
+  "If non nil `spacemacs/toggle-fullscreen' will not use native fullscreen. Use
+to disable fullscreen animations in OSX.")
+
 (defvar dotspacemacs-fullscreen-at-startup nil
   "If non nil the frame is fullscreen when Emacs starts up (Emacs 24.4+ only).")
 

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -141,7 +141,7 @@ Can be installed with `brew install trash'."
 ;; Emacs 24.4 new features
 (unless (version< emacs-version "24.4")
   (if dotspacemacs-fullscreen-at-startup
-      (toggle-frame-fullscreen)
+      (spacemacs/toggle-frame-fullscreen)
     (if dotspacemacs-maximized-at-startup
         (add-hook 'window-setup-hook 'toggle-frame-maximized))))
 

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -670,6 +670,14 @@ kill internal buffers too."
 
 )
 
+(defun spacemacs/toggle-frame-fullscreen ()
+  "Respect the `dotspacemacs-fullscreen-use-non-native' variable when
+toggling fullscreen."
+  (interactive)
+  (if dotspacemacs-fullscreen-use-non-native
+      (toggle-frame-fullscreen-non-native)
+    (toggle-frame-fullscreen)))
+
 (defun toggle-fullscreen ()
   "Toggle full screen on X11 and Carbon"
   (interactive)
@@ -683,6 +691,21 @@ kill internal buffers too."
      nil 'fullscreen
      (when (not (frame-parameter nil 'fullscreen)) 'fullscreen)))
    ))
+
+(defun toggle-frame-fullscreen-non-native ()
+  "Toggle full screen non-natively. Uses the `fullboth' frame paramerter
+   rather than `fullscreen'. Useful to fullscreen on OSX w/o animations."
+  (interactive)
+  (modify-frame-parameters
+   nil
+   `((maximized
+      . ,(unless (memq (frame-parameter nil 'fullscreen) '(fullscreen fullboth))
+	   (frame-parameter nil 'fullscreen)))
+     (fullscreen
+      . ,(if (memq (frame-parameter nil 'fullscreen) '(fullscreen fullboth))
+	     (if (eq (frame-parameter nil 'maximized) 'maximized)
+		 'maximized)
+	   'fullboth)))))
 
 ;;; begin scale font micro-state
 

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -117,7 +117,7 @@
 ;; toggle ---------------------------------------------------------------------
 (evil-leader/set-key
   "t8" 'toggle-fill-column-indicator
-  "tF" 'toggle-frame-fullscreen
+  "tF" 'spacemacs/toggle-frame-fullscreen
   "tf" 'fringe-mode
   "tl" 'toggle-truncate-lines
   "tL" 'visual-line-mode


### PR DESCRIPTION
No more fullscreen animations on OS X!

This has been bugging me for a while. The emacs-mac port doesn't use the standard ns-use-native-fullscreen variable, but it does have good support of the `fullboth` frame parameter. 

The body of `toggle-frame-fullscreen-non-native` function body was ripped out of `toggle-frame-fullscreen` in frame.el and has just flipped fullscreen to fullboth. This may be useful for other emacs distros / OSes.

Should be thorough and backwards compatible. Works great for me on OS X.