### PR TITLE
resolve key binding conflict in python contrib

### DIFF
--- a/contrib/lang/python/README.md
+++ b/contrib/lang/python/README.md
@@ -89,13 +89,13 @@ Test commands (start with <kbd>m t</kbd> or <kbd>m T</kbd>):
 
 ### Other Python commands
 
-    Key Binding      |                 Description
----------------------|------------------------------------------------------------
-<kbd>SPC m d</kbd>   | quick documentation using anaconda
-<kbd>SPC m D</kbd>   | open documentation in `firefox` using [pylookup][pylookup]
-<kbd>SPC m g</kbd>   | go to definition using `anaconda-mode-goto` (<kbd>C-o</kbd> to jump back)
-<kbd>SPC m t b</kbd> | toggle a breakpoint
-<kbd>SPC m v</kbd>   | activate a virtual environment with [pyvenv][pyvenv]
+    Key Binding       |                 Description
+----------------------|------------------------------------------------------------
+<kbd>SPC m d b</kbd>  | toggle a breakpoint
+<kbd>SPC m h d</kbd>  | quick documentation using anaconda
+<kbd>SPC m h D</kbd>  | open documentation in `firefox` using [pylookup][pylookup]
+<kbd>SPC m g</kbd>    | go to definition using `anaconda-mode-goto` (<kbd>C-o</kbd> to jump back)
+<kbd>SPC m v</kbd>    | activate a virtual environment with [pyvenv][pyvenv]
 
 [anaconda-mode]: https://github.com/proofit404/anaconda-mode
 [pyvenv]: https://github.com/jorgenschaefer/pyvenv

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -132,10 +132,10 @@ which require an initialization must be listed explicitly in the list.")
       (evil-leader/set-key-for-mode 'python-mode
         "mB"  'python-shell-send-buffer-switch
         "mb"  'python-shell-send-buffer
+        "mdb" 'python-toggle-breakpoint
         "mF"  'python-shell-send-defun-switch
         "mf"  'python-shell-send-defun
         "mi"  'python-start-or-switch-repl
-        "mtb" 'python-toggle-breakpoint
         "mR"  'python-shell-send-region-switch
         "mr"  'python-shell-send-region)
 


### PR DESCRIPTION
Bind toggle breakpoint function in python contrib to `SPC m p`. For one thing, there's a conflict due to recent updates in python contrib. Currently `SPC m t b` is used for `launch all tests of the current buffer (same as module)`. For another, toggling a breakpoint is such a frequently used function that I think it deserve a shorter key binding.