### PR TITLE
Diminish subword-mode only in older versions of Emacs

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -458,7 +458,8 @@ which require an initialization must be listed explicitly in the list.")
   (eval-after-load "abbrev"
     '(diminish 'abbrev-mode))
   (eval-after-load "subword"
-    '(diminish 'subword-mode)))
+    '(when (eval-when-compile (version< "24.3.1" emacs-version))
+       (diminish 'subword-mode))))
 
 (defun spacemacs/init-dired+ ()
   (use-package dired+


### PR DESCRIPTION
When invoking `cider-jack-in` I get an error similar to [this one](https://github.com/purcell/emacs.d/issues/138)... Applying the solution that was implemented to fix that issue did the trick.

Emacs version: `GNU Emacs 24.3.1 (x86_64-pc-linux-gnu) of 2013-07-26 on roseapple, modified by Debian`