### PR TITLE
Autoload Auctex

### DIFF
--- a/contrib/auctex/README.md
+++ b/contrib/auctex/README.md
@@ -2,10 +2,6 @@
 
 Includes support for Auctex including some bindings, sane defaults, and manual loading for better startup times.
 
-## Manual Loading
-
-In order to load AucTex properly you must use `SPC e l` before opening any TeX files.
-
 ## Company Auctex
 
 Along with other things this layer includes company-auctex, it's only enabled if you also enable my other contrib layer `company-mode`.
@@ -14,7 +10,7 @@ Along with other things this layer includes company-auctex, it's only enabled if
 
 Key Binding         |                 Description
 --------------------|------------------------------------------------------------------
-<kbd>SPC m b  </kbd>| build and view 
+<kbd>SPC m b  </kbd>| build and view
 <kbd>SPC m e  </kbd>| insert LaTeX environment
 <kbd>SPC m c  </kbd>| close LaTeX environment
 <kbd>SPC m i  </kbd>| insert `\item`
@@ -27,7 +23,7 @@ Key Binding         |                 Description
 <kbd>SPC m p s</kbd>| preview section
 <kbd>SPC m p p</kbd>| preview at point
 <kbd>SPC m p f</kbd>| cache preamble for preview
-<kbd>SPC m p c</kbd>| clear previews 
+<kbd>SPC m p c</kbd>| clear previews
 <kbd>SPC m *</kbd>  | TeX documentation, can be very slow
 
 ## Maintainer

--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -7,60 +7,57 @@
   (add-to-list 'auctex-packages 'company-auctex))
 
 (defun auctex/init-auctex ()
-  (defun load-auctex-on-demand ()
-    (interactive)
-    (use-package tex
-      :config
-      (progn
-        (when (member 'company-mode dotspacemacs-configuration-layers)
-          (use-package company-auctex
-            :init (company-auctex-init)))
+  (use-package tex
+    :defer t
+    :config
+    (progn
+      (when (member 'company-mode dotspacemacs-configuration-layers)
+        (use-package company-auctex
+          :init (company-auctex-init)))
 
-        (defun auctex/build-view ()
-          (interactive)
-          (if (buffer-modified-p)
-              (progn
-                (let ((TeX-save-query nil))
-                  (TeX-save-document (TeX-master-file)))
-                (setq build-proc (TeX-command "LaTeX" 'TeX-master-file -1))
-                (set-process-sentinel  build-proc  'auctex/build-sentinel))
-            (TeX-view)))
+      (defun auctex/build-view ()
+        (interactive)
+        (if (buffer-modified-p)
+            (progn
+              (let ((TeX-save-query nil))
+                (TeX-save-document (TeX-master-file)))
+              (setq build-proc (TeX-command "LaTeX" 'TeX-master-file -1))
+              (set-process-sentinel  build-proc  'auctex/build-sentinel))
+          (TeX-view)))
 
-        (defun auctex/build-sentinel (process event)
-          (if (string= event "finished\n")
-              (TeX-view)
-            (message "Errors! Check with C-`")))
+      (defun auctex/build-sentinel (process event)
+        (if (string= event "finished\n")
+            (TeX-view)
+          (message "Errors! Check with C-`")))
 
-        (add-hook 'LaTeX-mode-hook '(lambda () (local-set-key (kbd "H-r") 'auctex/build-view)))
-        (add-hook 'LaTeX-mode-hook 'flyspell-mode)
-        (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
-        (add-hook 'LaTeX-mode-hook 'spacemacs/load-yasnippet)
+      (add-hook 'LaTeX-mode-hook '(lambda () (local-set-key (kbd "H-r") 'auctex/build-view)))
+      (add-hook 'LaTeX-mode-hook 'flyspell-mode)
+      (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
+      (add-hook 'LaTeX-mode-hook 'spacemacs/load-yasnippet)
 
-        (setq spacemacs/key-binding-prefixes '(("mp" . "LaTeX Preview")))
-        (evil-leader/set-key-for-mode 'latex-mode
-          "mb" 'auctex/build-view
-          "me" 'LaTeX-environment
-          "mc" 'LaTeX-close-environment
-          "mi" 'LaTeX-insert-item
-          "mf" 'TeX-font ;; Find a way to rebind tex-fonts
+      (setq spacemacs/key-binding-prefixes '(("mp" . "LaTeX Preview")))
+      (evil-leader/set-key-for-mode 'latex-mode
+        "mb" 'auctex/build-view
+        "me" 'LaTeX-environment
+        "mc" 'LaTeX-close-environment
+        "mi" 'LaTeX-insert-item
+        "mf" 'TeX-font ;; Find a way to rebind tex-fonts
 
-          "mC" 'TeX-command-master
+        "mC" 'TeX-command-master
 
-          "mpr" 'preview-region
-          "mpb" 'preview-buffer
-          "mpd" 'preview-document
-          "mpe" 'preview-environment
-          "mps" 'preview-section
-          "mpp" 'preview-at-point
-          "mpf" 'preview-cache-preamble
-          "mpc" 'preview-clearout
+        "mpr" 'preview-region
+        "mpb" 'preview-buffer
+        "mpd" 'preview-document
+        "mpe" 'preview-environment
+        "mps" 'preview-section
+        "mpp" 'preview-at-point
+        "mpf" 'preview-cache-preamble
+        "mpc" 'preview-clearout
 
-          "mhd" 'TeX-doc ;; TeX-doc is a very slow function
-          )
+        "mhd" 'TeX-doc ;; TeX-doc is a very slow function
+        )
 
-        (setq-default TeX-auto-save t)
-        (setq-default TeX-parse-self t)
-        (setq-default TeX-master nil)
-        (setq-default TeX-PDF-mode t))))
-  (evil-leader/set-key
-    "el" 'load-auctex-on-demand))
+      (setq-default TeX-auto-save t)
+      (setq-default TeX-parse-self t)
+      (setq-default TeX-master nil)
+      (setq-default TeX-PDF-mode t))))


### PR DESCRIPTION
My initial decision to use manual keybinding loading was misguided. All I had to do was add `:defer t` to the auctex `use-package` and now it does its super slow (5-6s) load the first time you open a LaTeX file.