### PR TITLE
defvar `git-enable-github-support`

### DIFF
--- a/contrib/git/config.el
+++ b/contrib/git/config.el
@@ -12,6 +12,9 @@
 
 ;; Command prefixes
 
+(defvar git-enable-github-support nil
+  "If non nil enable Github packages.")
+
 (setq git/key-binding-prefixes '(("gh" . "gutter-hunks/highlight")))
 (when git-enable-github-support
   (push (cons "gf" "file") git/key-binding-prefixes)


### PR DESCRIPTION
Git layer will fail to load if there is no this variable