### PR TITLE
Use make-hash-table instead of hash table literals

### DIFF
--- a/core/configuration-layer.el
+++ b/core/configuration-layer.el
@@ -43,11 +43,11 @@
 (defvar configuration-layer-layers '()
   "Alist of declared configuration layers.")
 
-(defvar configuration-layer-paths #s(hash-table size 128 data ())
+(defvar configuration-layer-paths (make-hash-table :size 128)
   "Hash table of layers locations. The key is a layer symbol and the value is
 the path for this layer.")
 
-(defvar configuration-layer-all-packages #s(hash-table size 256 data ())
+(defvar configuration-layer-all-packages (make-hash-table :size 256)
   "Hash table of all declared packages in all layers where the key is a package
 symbol and the value is a list of layer symbols responsible for initializing
 and configuring the package.")
@@ -55,7 +55,7 @@ and configuring the package.")
 (defvar configuration-layer-all-packages-sorted '()
   "Sorted list of all package symbols.")
 
-(defvar configuration-layer-all-pre-extensions #s(hash-table size 128 data ())
+(defvar configuration-layer-all-pre-extensions (make-hash-table :size 128)
   "Hash table of all declared pre-extensions in all layers where the key is a
 extension symbol and the value is the layer symbols responsible for initializing
 and configuring the package.")
@@ -63,7 +63,7 @@ and configuring the package.")
 (defvar configuration-layer-all-pre-extensions-sorted '()
   "Sorted list of all pre extensions symbols.")
 
-(defvar configuration-layer-all-post-extensions #s(hash-table size 128 data ())
+(defvar configuration-layer-all-post-extensions (make-hash-table :size 128)
   "Hash table of all declared post-extensions in all layers where the key is a
 extension symbol and the value is the layer symbols responsible for initializing
 and configuring the package.")
@@ -131,7 +131,7 @@ in `configuration-layer-contrib-categories'"
   "Return a hash table where the key is the layer symbol and the value is its
 path."
   (let ((cat-dirs (configuration-layer//get-contrib-category-dirs))
-        (result #s(hash-table size 128 data ())))
+        (result (make-hash-table :size 128)))
     (ht-clear result)
     ;; add spacemacs layer
     (puthash 'spacemacs (expand-file-name user-emacs-directory) result)
@@ -294,7 +294,7 @@ of all excluded packages."
 
 FILE is a string with value `packages' or `extensions'.
 VAR is a string with value `packages', `pre-extensions' or `post-extensions'."
-  (let ((result #s(hash-table size 512 data ())))
+  (let ((result (make-hash-table :size 512)))
     (ht-clear result)
     (dolist (layer layers)
       (let* ((layer-sym (car layer))
@@ -479,7 +479,7 @@ If PRE is non nil then the extension is a pre-extensions."
 (defun configuration-layer//get-packages-dependencies ()
   "Returns a hash map where key is a dependency package symbol and value is
 a list of all packages which depend on it."
-  (let ((result #s(hash-table size 200 data ())))
+  (let ((result (make-hash-table :size 200)))
     (ht-clear result)
     (dolist (pkg package-alist)
       (let* ((pkg-sym (car pkg))

--- a/core/configuration-layer.el
+++ b/core/configuration-layer.el
@@ -132,7 +132,6 @@ in `configuration-layer-contrib-categories'"
 path."
   (let ((cat-dirs (configuration-layer//get-contrib-category-dirs))
         (result (make-hash-table :size 128)))
-    (ht-clear result)
     ;; add spacemacs layer
     (puthash 'spacemacs (expand-file-name user-emacs-directory) result)
     (mapc (lambda (dir)
@@ -295,7 +294,6 @@ of all excluded packages."
 FILE is a string with value `packages' or `extensions'.
 VAR is a string with value `packages', `pre-extensions' or `post-extensions'."
   (let ((result (make-hash-table :size 512)))
-    (ht-clear result)
     (dolist (layer layers)
       (let* ((layer-sym (car layer))
              (dir (plist-get (cdr layer) :dir))
@@ -480,7 +478,6 @@ If PRE is non nil then the extension is a pre-extensions."
   "Returns a hash map where key is a dependency package symbol and value is
 a list of all packages which depend on it."
   (let ((result (make-hash-table :size 200)))
-    (ht-clear result)
     (dolist (pkg package-alist)
       (let* ((pkg-sym (car pkg))
              (deps (configuration-layer//get-package-dependencies pkg-sym)))

--- a/core/configuration-layer.el
+++ b/core/configuration-layer.el
@@ -146,7 +146,7 @@ path."
                   ;; we asume that the user layers must have the final word
                   ;; on configuration choices.
                   (list configuration-layer-private-directory)))
-    (ht-copy result)))
+    result))
 
 (defun configuration-layer//discover-layers-in-dir (dir)
   "Return an alist where the key is a layer symbol and the value is the path
@@ -305,7 +305,7 @@ VAR is a string with value `packages', `pre-extensions' or `post-extensions'."
             (when (boundp packages-var)
               (dolist (pkg (eval packages-var))
                 (puthash pkg (cons layer-sym (ht-get result pkg)) result)))))))
-    (ht-copy result)))
+    result))
 
 (defun configuration-layer/get-packages (layers)
   "Read `layer-packages' lists for all passed LAYERS and return a hash table


### PR DESCRIPTION
It's in general bad style to modify objects created by the reader, and for a good reason.
Consider this function:
```emacs-lisp
(defun foo (x y)
  (let ((ht #s(hash-table size 65 data ())))
    (puthash x y ht)
    ht))
```
Now call it a few times: `(progn (foo 1 2) (foo 3 4))`.
The result will be, perhaps surprisingly, `#s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8 data (1 2 3 4))`. That's right: both calls use the same map.

Now, while this is harmless for functions called once, it's probably best to always use `make-hash-table` and forget about the problem altogether. If sharing is desired, use `defvar`s and/or closures instead.