### PR TITLE
Bind <leader>bq for quickly killing this buffer

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -49,6 +49,7 @@
   "bb"  'spacemacs/alternate-buffer ;; switch back and forth between two last buffers
   "TAB" 'spacemacs/alternate-buffer
   "be"  'spacemacs/safe-erase-buffer
+  "bq"  'kill-this-buffer
   "bK"  'kill-other-buffers
   "bk"  'ido-kill-buffer
   "b C-k" 'kill-matching-buffers-rudely


### PR DESCRIPTION
Hey guys, yesterday I found about spacemacs, it feels awesome, and am now looking for it to replace my custom emacs+evil setup.

So, one thing I was very used was to have a quick way to kill the current buffer, so I just added it under the <leader>bq mapping.

Cheers!