### PR TITLE
Use default shell instead of zsh for Multi Term

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1387,8 +1387,6 @@ which require an initialization must be listed explicitly in the list.")
     (evil-leader/set-key "ast" 'multi-term)
     :config
     (progn
-      (setq multi-term-program "/bin/zsh")
-
       (defun term-send-tab ()
         "Send tab in term mode."
         (interactive)


### PR DESCRIPTION
Hi!
First of all, I would like to thank you for your work! I've been using vim for 2 years and tried switching to emacs 3 or 4 times without any luck. And this project finally helped me to do the switch! Thank you so much!

I use fish shell as my primary shell and I want to use it from emacs via multi-term.
At this point ```"/bin/zsh"``` is hardcoded as multi term shell.
I was trying to set ```multi-term-program``` in ```dotspacemacs/config``` and ```dotspacemacs/init``` but it didn't work.
I think setting ```multi-term-program``` to nil would be better than forcing zsh.
From multi term readme:
> “multi-term-program” default is nil, so when create a new terminal buffer, it will try to take the shell path from an environment variable (“SHELL”, “ESHELL”, and finally default to “/bin/sh”). If you failed to create a terminal buffer, make sure setup this option with a valid shell program.