### PR TITLE
Require noflet in scala contrib

### DIFF
--- a/contrib/lang/scala/packages.el
+++ b/contrib/lang/scala/packages.el
@@ -70,6 +70,8 @@ which require an initialization must be listed explicitly in the list.")
        '(scala-indent:align-parameters t)
        '(scala-indent:default-run-on-strategy scala-indent:operator-strategy))
 
+      (require 'noflet)
+
       (defadvice scala-indent:indent-code-line (around retain-trailing-ws activate)
         "Keep trailing-whitespace when indenting."
         (noflet ((scala-lib:delete-trailing-whitespace ()))


### PR DESCRIPTION
`noflet` may not be loaded when scala-mode2 is being configured, meaning an advised function was failing when evaluated.

Resolves #383