### PR TITLE
Removed setting TeX-master variable

### DIFF
--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -60,7 +60,6 @@
 
       (setq-default TeX-auto-save t)
       (setq-default TeX-parse-self t)
-      (setq-default TeX-master nil)
       (setq-default TeX-PDF-mode t))))
 
 (defun auctex/init-evil-matchit ()


### PR DESCRIPTION
In the auctex contrib package, TeX-master was set to nil, which overrode the user's setting from their .spacemacs file as soon as auctex mode was loaded.

The [TeX-master variable](http://www.gnu.org/software/auctex/manual/reftex/Multifile-Documents.html), when set to nil, prompts the user for the location of the file's master. This is helpful for multiple file projects, but it is an unnecessary additional prompt for single files. If the variable is set to t, auctex assumes the master is the file itself, and moves on with compilation.

This setting should be left for the user to specify individually in their .spacemacs file, rather than overwriting the setting to nil.