### PR TITLE
fixed bug: evil-terminal-cursor mode doesn't work in iterm2

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -774,7 +774,11 @@ which require an initialization must be listed explicitly in the list.")
 
 (defun spacemacs/init-evil-terminal-cursor-changer ()
   (unless (display-graphic-p)
-    (require 'evil-terminal-cursor-changer)))
+    (require 'evil-terminal-cursor-changer)
+    (setq etcc--evil-insert-state-cursor 'bar) ; ⎸
+    (setq etcc--evil-visual-state-cursor 'box) ; _
+    (setq etcc--evil-emacs-state-cursor 'hbar) ; █
+    ))
 
 (defun spacemacs/init-evil-tutor ()
   (use-package evil-tutor


### PR DESCRIPTION
Three variables need to be setup manually, otherwise `evil-terminal-cursor-changer` doesn't work. I reported this bug to original author, but haven't heard back from him/her. So I'd like to keep this hack in spacemacs to make this package work.