### PR TITLE
contrib/clojure: make fancy symbols opt-in

### DIFF
--- a/contrib/lang/clojure/README.md
+++ b/contrib/lang/clojure/README.md
@@ -33,8 +33,14 @@ This layer adds support for [Clojure][] language using [Cider][].
 
 ### Goodies
 
-- Pretty symbols for anonymous functions and set literals, like
-`(λ [a] (+ a 5))`, `ƒ(+ % 5)`, and `∈{2 4 6}`.
+- Pretty symbols for anonymous functions and set literals, like `(λ [a] (+ a 5))`, `ƒ(+ % 5)`, and `∈{2 4 6}`.
+
+  To enable this feature, add the following snippet to the dotspacemacs/config
+  section of your `~/.spacemacs` file:
+
+  ```elisp
+  (setq spacemacs-clojure-fancify-symbols t)
+  ```
 
 ## Install
 

--- a/contrib/lang/clojure/config.el
+++ b/contrib/lang/clojure/config.el
@@ -1,0 +1,17 @@
+;;; config.el --- Configuration variables specific to
+;;;               the Clojure configuration layer
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar spacemacs-clojure-fancify-symbols nil
+  "If non-nil then replace common clojure keywords like
+   fn and #() by pretty unicode symbols")
+

--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -34,7 +34,8 @@ which require an initialization must be listed explicitly in the list.")
                                         rainbow-delimiters-mode)))
     :config
     (progn
-      (clojure/fancify-symbols)
+      (when spacemacs-clojure-fancify-symbols
+        (clojure/fancify-symbols))
       (evil-leader/set-key-for-mode 'clojure-mode  "mj" 'cider-jack-in))))
 
 (defun clojure/init-cider ()


### PR DESCRIPTION
Fancified symbols in clojure mode should be opt-in; not everyone likes unicode charaters.

This is similar to https://github.com/syl20bnr/spacemacs/pull/498 except:

- this makes the feature opt-in
- I added a bit of documentation.

Merge either 498 or this PR, not both.