### PR TITLE
Add ESS noweb (knitr/sweave) keybindings

### DIFF
--- a/contrib/lang/ess/README.md
+++ b/contrib/lang/ess/README.md
@@ -37,20 +37,26 @@ Start an `R` inferior REPL process with <kbd>SPC m i</kbd>.
 
 Send code to inferior process commands:
 
-    Key Binding     |                 Description
---------------------|------------------------------------------------------------
-<kbd>SPC m b</kbd>  | send buffer and keep code buffer focused
-<kbd>SPC m B</kbd>  | send buffer and switch to REPL in insert mode
-<kbd>SPC m d</kbd>  | send region or line and step (debug)
-<kbd>SPC m D</kbd>  | send function or paragraph and step (debug)
-<kbd>SPC m l</kbd>  | send line and keep code buffer focused
-<kbd>SPC m L</kbd>  | send line and switch to REPL in insert mode
-<kbd>SPC m r</kbd>  | send region and keep code buffer focused
-<kbd>SPC m R</kbd>  | send region and switch to REPL in insert mode
-<kbd>SPC m t</kbd>  | send thing at point (function) and keep code buffer focused
-<kbd>SPC m T</kbd>  | send thing at point (function) and switch to REPL in insert mode
-<kbd>CTRL+j</kbd>   | next item in REPL history
-<kbd>CTRL+k</kbd>   | previous item in REPL history
+    Key Binding      |                 Description
+---------------------|------------------------------------------------------------
+<kbd>SPC m b</kbd>   | send buffer and keep code buffer focused
+<kbd>SPC m B</kbd>   | send buffer and switch to REPL in insert mode
+<kbd>SPC m c c</kbd> | send knitr/sweave chunk and keep buffer focused
+<kbd>SPC m c C</kbd> | send knitr/sweave chunk and switch to REPL in insert mode
+<kbd>SPC m c d</kbd> | send knitr/sweave chunk and step to next chunk
+<kbd>SPC m c m</kbd> | mark knitr/sweave chunk around point
+<kbd>SPC m c n</kbd> | next knitr/sweave chunk
+<kbd>SPC m c N</kbd> | previous knitr/sweave chunk
+<kbd>SPC m d</kbd>   | send region or line and step (debug)
+<kbd>SPC m D</kbd>   | send function or paragraph and step (debug)
+<kbd>SPC m l</kbd>   | send line and keep code buffer focused
+<kbd>SPC m L</kbd>   | send line and switch to REPL in insert mode
+<kbd>SPC m r</kbd>   | send region and keep code buffer focused
+<kbd>SPC m R</kbd>   | send region and switch to REPL in insert mode
+<kbd>SPC m t</kbd>   | send thing at point (function) and keep code buffer focused
+<kbd>SPC m T</kbd>   | send thing at point (function) and switch to REPL in insert mode
+<kbd>CTRL+j</kbd>    | next item in REPL history
+<kbd>CTRL+k</kbd>    | previous item in REPL history
 
 ### Other R commands
 

--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -44,6 +44,12 @@ which require an initialization must be listed explicitly in the list.")
          "mp" 'ess-R-object-popup
          "mB" 'ess-eval-buffer-and-go
          "mb" 'ess-eval-buffer
+         "mcC" 'ess-eval-chunk-and-go
+         "mcc" 'ess-eval-chunk
+         "mcd" 'ess-eval-chunk-and-step
+         "mcm" 'ess-noweb-mark-chunk
+         "mcN" 'ess-noweb-previous-chunk
+         "mcn" 'ess-noweb-next-chunk
          "mhD" 'ess-eval-function-or-paragraph-and-step
          "mhd" 'ess-eval-region-or-line-and-step
          "mL" 'ess-eval-line-and-go


### PR DESCRIPTION
There are a number of functions included in ESS for dealing with knitr
and sweave "chunks" that are quite handy.

These are the bindings I use, which I humbly recommend for inclusion as
defaults.

The only potential problem that I see with their inclusion is that they
only really make sense in ess-noweb-mode (a minor mode) buffers, but
since evil-leader doesn't seem to like layering keybindings through
minor-modes, adding them to ess-mode is the best solution that I can
come up with for now.