### PR TITLE
Feature/python django pyenv

### DIFF
--- a/contrib/lang/python/config.el
+++ b/contrib/lang/python/config.el
@@ -20,7 +20,10 @@
         ("mjs" . "south/syncdb")
         ("mjt" . "test")
         ("mjf" . "files")
-        ("mja" . "fabric")))
+        ("mja" . "fabric")
+
+        ; pyenv/pyenv-mode
+        ("mp" . "pyenv")))
 
 (mapc (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))
       python/key-binding-prefixes)

--- a/contrib/lang/python/config.el
+++ b/contrib/lang/python/config.el
@@ -1,0 +1,26 @@
+;;; packages.el --- Python Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Command prefixes
+
+(setq python/key-binding-prefixes
+      '(; django/pony-mode
+        ("mj" . "django")
+        ("mjr" . "runserver")
+        ("mji" . "shells")
+        ("mjs" . "south/syncdb")
+        ("mjt" . "test")
+        ("mjf" . "files")
+        ("mja" . "fabric")))
+
+(mapc (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))
+      python/key-binding-prefixes)

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -19,6 +19,7 @@
     evil-jumper
     flycheck
     hy-mode
+    pony-mode
     pyvenv
     python
     semantic
@@ -67,6 +68,52 @@ which require an initialization must be listed explicitly in the list.")
 (defun python/init-evil-jumper ()
   (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
     (evil-jumper--push)))
+
+(defun python/init-pony-mode ()
+  (use-package pony-mode
+    :defer t
+    :init (progn
+            (evil-leader/set-key-for-mode 'python-mode
+              ; d*j*ango r*u*nserver
+              "mjru" 'pony-runserver
+              "mjrr" 'pony-restart-server
+              "mjrd" 'pony-stopserver
+              "mjrt" 'pony-temp-server
+              "mjro" 'pony-browser
+
+              ; d*j*ango *i*nteractive
+              "mjis" 'pony-shell
+              "mjid" 'pony-db-shell
+
+              ; d*j*ango *s*outh/*s*yncdb
+              "mjss" 'pony-syncdb
+              "mjsc" 'pony-south-convert
+              "mjsi" 'pony-south-initial
+              "mjsh" 'pony-south-schemamigration
+              "mjsm" 'pony-south-migrate
+
+              ; d*j*ango *t*est
+              "mjtt" 'pony-test
+              "mjto" 'pony-test-open
+              "mjtu" 'pony-test-up
+              "mjtd" 'pony-test-down
+              "mjtg" 'pony-test-goto-err
+
+              ; d*j*ango *m*anage
+              ; not including one-off management commands like "flush" and
+              ; "startapp" even though they're implemented in pony-mode,
+              ; because this is much handier
+              "mjm" 'pony-manage
+
+              ; d*j*ango *f*iles
+              "mjfs" 'pony-goto-settings
+              "mjfc" 'pony-setting
+              "mjft" 'pony-goto-template
+              "mjfr" 'pony-resolve
+
+              ; d*j*ango f*a*bric
+              "mjaf" 'pony-fabric
+              "mjad" 'pony-fabric-deploy))))
 
 (defun python/init-pyvenv ()
   (use-package pyvenv

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -20,6 +20,7 @@
     flycheck
     hy-mode
     pony-mode
+    pyenv-mode
     pyvenv
     python
     semantic
@@ -114,6 +115,14 @@ which require an initialization must be listed explicitly in the list.")
               ; d*j*ango f*a*bric
               "mjaf" 'pony-fabric
               "mjad" 'pony-fabric-deploy))))
+
+(defun python/init-pyenv-mode ()
+  (use-package pyenv-mode
+    :defer t
+    :init (progn
+            (evil-leader/set-key-for-mode
+              "mps" 'pyenv-mode-set
+              "mpu" 'pyenv-mode-unset))))
 
 (defun python/init-pyvenv ()
   (use-package pyvenv

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -120,7 +120,7 @@ which require an initialization must be listed explicitly in the list.")
   (use-package pyenv-mode
     :defer t
     :init (progn
-            (evil-leader/set-key-for-mode
+            (evil-leader/set-key-for-mode 'python-mode
               "mps" 'pyenv-mode-set
               "mpu" 'pyenv-mode-unset))))
 

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -75,7 +75,7 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init (progn
             (evil-leader/set-key-for-mode 'python-mode
-              ; d*j*ango r*u*nserver
+              ; d*j*ango *r*unserver
               "mjru" 'pony-runserver
               "mjrr" 'pony-restart-server
               "mjrd" 'pony-stopserver


### PR DESCRIPTION
Adds `pyenv-mode` (for [pyenv](https://github.com/yyuu/pyenv)) and `pony-mode` (for [Django](https://www.djangoproject.com/)) to the Python layer.

This seems to be mostly working for me, but the config layer isn't setting the prefix captions. I see this done in other layers, is this the right way to do it?