### PR TITLE
init.el: setup user-emacs-directory when load

### DIFF
--- a/init.el
+++ b/init.el
@@ -15,6 +15,14 @@
 (defun spacemacs/emacs-version-ok ()
   (version<= spacemacs-min-version emacs-version))
 
+;; Set current spacemacs init.el file-directory as default emacs
+;; config dir, this will help user use following command to testing
+;; spacemacs without breaking their original emacs config:
+;;
+;;    emacs -q -l ~/spacemacs/init.el
+;;
+(setq user-emacs-directory (file-name-directory load-file-name))
+
 (when (spacemacs/emacs-version-ok)
   (load-file (concat user-emacs-directory "core/core-load-paths.el"))
   (require 'core-spacemacs-mode)


### PR DESCRIPTION
user-emacs-directory is defined by emacs when load config, in most case
it's value is ~/.emacs.d. We setup this variable in init.el to make
existing emacs user can test spacemacs by

   emacs -q -l ~/spacemacs/init.el

without change their own ~/.emacs.d config.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>