### PR TITLE
contrib(yaml): add yaml layer

### DIFF
--- a/contrib/lang/yaml/README.md
+++ b/contrib/lang/yaml/README.md
@@ -1,0 +1,19 @@
+# YAML contribution layer for Spacemacs
+
+Support for [YAML](http://yaml.org/) in Spacemacs.
+
+## Configuration
+
+If you want the `newline-and-indent` behavior on `RET`, add the following to your configuration:
+
+```
+(add-hook 'yaml-mode-hook
+  '(lambda ()
+    (define-key yaml-mode-map "\C-m" 'newline-and-indent)))
+```
+
+(from the [yaml-mode](https://github.com/yoshiki/yaml-mode) directions)
+
+## Future
+
+ - Ansible support (perhaps with [ansible-doc](https://github.com/lunaryorn/ansible-doc.el) and highlighting for `{{ }}` and `{% %}`)

--- a/contrib/lang/yaml/packages.el
+++ b/contrib/lang/yaml/packages.el
@@ -1,0 +1,16 @@
+;;; extensions.el --- YAML Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+(defvar yaml-packages '(yaml-mode))
+
+(defun yaml/yaml-mode-init ()
+  (use-package yaml-mode
+    :defer t))


### PR DESCRIPTION
From the comment on the commit:

> This is pretty directly extracted from layers that already include`yaml-mode`, but there are situations in which one would want to use yaml directly, instead of an accessory language, such as editing configuration files or writing Salt states or Ansible roles.

If you don't feel this is a good fit for spacemacs, please feel free to reject the PR; I will continue to use it privately and resubmit when I've got around to finishing the features mentioned in the Future section.