### PR TITLE
Add vim bindings to git-rebase-mode.

### DIFF
--- a/contrib/git/packages.el
+++ b/contrib/git/packages.el
@@ -14,6 +14,7 @@
   '(
     fringe-helper
     git-messenger
+    git-rebase-mode
     git-timemachine
     gist
     github-browse-file
@@ -128,6 +129,16 @@ which require an initialization must be listed explicitly in the list.")
     :init
     (evil-leader/set-key
       "gm" 'git-messenger:popup-message)))
+
+(defun git/git-rebase-mode ()
+  (use-package git-rebase-mode
+    :defer t
+    :config
+    (progn
+      (add-to-list 'evil-emacs-state-modes 'git-rebase-mode)
+      (spacemacs|evilify 'git-rebase-mode-map)
+      (spacemacs/activate-evil-leader-for-map 'git-rebase-mode-map
+                                              (kbd "Y") 'git-rebase-insert))))
 
 (defun git/init-git-timemachine ()
   (use-package git-timemachine


### PR DESCRIPTION
I noticed while rebasing from magit that currently git-rebase-mode mappings are masked.

Summary:

Use emacs state in git-rebase-mode.

Add leader and evilify.

Add shadowed bindings.