### PR TITLE
Replace ess-smart-underscore with ess-smart-equals

### DIFF
--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -4,6 +4,7 @@
     ess-R-data-view
     ess-R-object-popup
     ess-smart-equals
+    rainbow-delimiters
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -28,9 +29,6 @@ which require an initialization must be listed explicitly in the list.")
   (eval-after-load "ess-site"
     '(progn
        (add-to-list 'auto-mode-alist '("\\.R$" . R-mode))
-       (add-hook 'ess-mode-hook #'rainbow-delimiters-mode)
-       (add-hook 'ess-mode-hook 'ess-smart-equals-mode)
-       (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode)
        ;; Follow Hadley Wickham's R style guide
        (setq ess-first-continued-statement-offset 2
              ess-continued-statement-offset 0
@@ -56,3 +54,10 @@ which require an initialization must be listed explicitly in the list.")
        (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
        (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
        (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input))))
+
+(defun ess/init-rainbow-delimiters ()
+  (add-hook 'ess-mode-hook #'rainbow-delimiters-mode))
+
+(defun ess/init-ess-smart-equals ()
+  (add-hook 'ess-mode-hook 'ess-smart-equals-mode)
+  (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode))

--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -3,7 +3,7 @@
     ess
     ess-R-data-view
     ess-R-object-popup
-    ess-smart-underscore
+    ess-smart-equals
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -18,7 +18,7 @@ which require an initialization must be listed explicitly in the list.")
   (defun load-ess-on-demand ()
     (interactive)
     (use-package ess-site)
-    (use-package ess-smart-underscore)
+    (use-package ess-smart-equals)
     (use-package ess-R-object-popup)
     (use-package ess-R-data-view)
     )
@@ -27,6 +27,8 @@ which require an initialization must be listed explicitly in the list.")
   ;; R --------------------------------------------------------------------------
   (eval-after-load "ess-site"
     '(progn
+       (add-hook 'ess-mode-hook 'ess-smart-equals-mode)
+       (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode)
        (evil-leader/set-key-for-mode 'ess-mode
          "mi" 'R
          "mp" 'ess-R-object-popup

--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -27,8 +27,16 @@ which require an initialization must be listed explicitly in the list.")
   ;; R --------------------------------------------------------------------------
   (eval-after-load "ess-site"
     '(progn
+       (add-to-list 'auto-mode-alist '("\\.R$" . R-mode))
+       (add-hook 'ess-mode-hook #'rainbow-delimiters-mode)
        (add-hook 'ess-mode-hook 'ess-smart-equals-mode)
        (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode)
+       ;; Follow Hadley Wickham's R style guide
+       (setq ess-first-continued-statement-offset 2
+             ess-continued-statement-offset 0
+             ess-expression-offset 2
+             ess-nuke-trailing-whitespace-p t
+             ess-default-style 'DEFAULT)
        (evil-leader/set-key-for-mode 'ess-mode
          "mi" 'R
          "mp" 'ess-R-object-popup
@@ -45,5 +53,6 @@ which require an initialization must be listed explicitly in the list.")
          "mvp" 'ess-R-dv-pprint
          "mvt" 'ess-R-dv-ctable
          )
+       (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
        (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
        (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input))))


### PR DESCRIPTION
The former was last updated in 2011. For the benefits of the latter, see: https://github.com/genovese/ess-smart-equals

Also added R-mode to auto-mode-alist and rainbow delimiters, for convenience.

One question is how necessary you think the manual loading mechanism is, with use-package and :defer? Could I try making it work simply with use-package like other packages?