### PR TITLE
It's a horrible hack, but ess autoload works.

### DIFF
--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -30,12 +30,62 @@ which require an initialization must be listed explicitly in the list.")
   ;; keybinding)
   (defun load-ess-on-demand ()
     (interactive)
-    (use-package ess-site)
-    (use-package ess-smart-equals)
-    (use-package ess-R-object-popup)
-    (use-package ess-R-data-view)
-    )
+    (-all? '---truthy? (list
+                        (use-package ess-site)
+                        (use-package ess-smart-underscore)
+                        (use-package ess-R-object-popup)
+                        (use-package ess-R-data-view))))
+
   (evil-leader/set-key "ess" 'load-ess-on-demand)
+
+  (use-package ess
+    :defer t
+    :init
+    (progn
+      (setq auto-mode-alist (append
+                             '(("\\.sp\\'"          . S-mode)
+                               ("/R/.*\\.q\\'"      . R-mode)
+                               ("\\.[qsS]\\'"       . S-mode)
+                               ("\\.ssc\\'"         . S-mode)
+                               ("\\.SSC\\'"         . S-mode)
+                               ("\\.[rR]\\'"        . R-mode)
+                               ("\\.[rR]nw\\'"      . Rnw-mode)
+                               ("\\.[sS]nw\\'"      . Snw-mode)
+                               ("\\.[rR]profile\\'" . R-mode)
+                               ("NAMESPACE\\'"      . R-mode)
+                               ("CITATION\\'"       . R-mode)
+                               ("\\.omg\\'"         . omegahat-mode)
+                               ("\\.hat\\'"         . omegahat-mode)
+                               ("\\.lsp\\'"         . XLS-mode)
+                               ("\\.do\\'"          . STA-mode)
+                               ("\\.ado\\'"         . STA-mode)
+                               ("\\.[Ss][Aa][Ss]\\'"        . SAS-mode)
+                               ("\\.[Ss]t\\'"       . S-transcript-mode)
+                               ("\\.Sout"           . S-transcript-mode)
+                               ("\\.[Rr]out"        . R-transcript-mode)
+                               ("\\.Rd\\'"          . Rd-mode)
+                               ("\\.[Bb][Uu][Gg]\\'"         . ess-bugs-mode)
+                               ("\\.[Bb][Oo][Gg]\\'"         . ess-bugs-mode)
+                               ("\\.[Bb][Mm][Dd]\\'"         . ess-bugs-mode)
+                               ("\\.[Jj][Aa][Gg]\\'"         . ess-jags-mode)
+                               ("\\.[Jj][Oo][Gg]\\'"         . ess-jags-mode)
+                               ("\\.[Jj][Mm][Dd]\\'"         . ess-jags-mode))
+                             auto-mode-alist))
+
+      (defun ess/auto-load-hack (mode-symbol)
+        (eval
+         `(defun ,mode-symbol ()
+            "This is a function that will hijack itself with its
+definition from ess. The reason this exists is that ess does
+not play nicely with autoloads"
+            (when (load-ess-on-demand)
+              (,mode-symbol)))))
+
+      (defvar ess/r-modes-list '(R-mode R-transcript-mode Rd-mode Rnw-mode S-mode S-transcript-mode
+                                        SAS-mode STA-mode Snw-mode XLS-mode ess-bugs-mode ess-jags-mode omegahat-mode)
+        "This is the list of modes defined by ess")
+
+      (mapc (lambda (sym) (ess/auto-load-hack sym)) ess/r-modes-list)))
 
   ;; R --------------------------------------------------------------------------
   (eval-after-load "ess-site"


### PR DESCRIPTION
Up to you whether you want to include it.

I whipped it up after seeing #544 

The main problem is that ess does not play nicely with autoload for several reasons. It redefines its own modes several times for S in particular, based on what kind of file it sees. This messes with the autoload function since it expects a symbol to be defined or declared in only one place.

Unti such time as the project makes their stuff autoloadable, you can do something like this, where for each file mode provided by ess, we have a function that redefines itself by loading ess, and calls itself again.