### PR TITLE
Add Window Manipulation micro state

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -849,3 +849,54 @@ If ASCII si not provided then UNICODE is used instead."
      ((system-is-linux) (let ((process-connection-type nil))
                           (start-process "" nil "xdg-open" file-path)))
      )))
+
+
+(defun spacemacs/window-manipulation-micro-state-doc ()
+  "Display a short documentation in the mini buffer."
+  (echo "Window navigation micro-state
+  h,j,k,l to go to left|bottom|top|right
+  H,J,K,L to move windows to to far/very left|bottom|top|right
+  R to Rotate windows
+  c,C to delete current|other window|windows
+  -,/ to split windows bellow|right and focus
+  u,U restore previous|next window configuration
+  o/w other frame|window
+Press any other key to exit."))
+
+(defun spacemacs//on-enter-window-manipulation-micro-state ()
+  "Initialization of window navigation micro-state."
+  (spacemacs/window-manipulation-micro-state-doc))
+
+(defun spacemacs//on-exit-window-manipulation-micro-state ()
+  "Action to perform when exiting window navigation micor-state."
+  ;; restore window navigation key map
+  )
+
+
+(spacemacs|define-micro-state window-manipulation
+  :on-enter (spacemacs//on-enter-window-manipulation-micro-state)
+  :on-exit  (spacemacs//on-exit-window-manipulation-micro-state)
+  :bindings
+  ("h" evil-window-left)
+  ("j" evil-window-down)
+  ("k" evil-window-up)
+  ("l" evil-window-right)
+  ("H" evil-window-move-far-left)
+  ("J" evil-window-move-very-bottom)
+  ("K" evil-window-move-very-top)
+  ("L" evil-window-move-far-right)
+  ("R" rotate-windows)
+  ("c" delete-window)
+  ("C" delete-other-windows)
+  ("-" split-window-below-and-focus)
+  ("/" split-window-right-and-focus)
+  ("u" winner-undo)
+  ("U" winner-redo)
+  ("o" other-frame)
+  ("w" other-window)
+  ;; ("[" spacemacs/shrink-window-horizontally)
+  ;; ("]" spacemacs/enlarge-window-horizontally)
+  ;; ("{" spacemacs/shrink-window)
+  ;; ("}" spacemacs/enlarge-window)
+  ("?" spacemacs/window-manipulation-micro-state)
+  )

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -226,6 +226,7 @@
     (golden-ratio)))
 
 (evil-leader/set-key
+  "w."  'spacemacs/window-manipulation-micro-state
   "w2"  'layout-double-columns
   "w3"  'layout-triple-columns
   "wc"  'delete-window


### PR DESCRIPTION
And keybinded it wo `<kbd>SPC</kbd> w .`.
The micro state uses most of the `<kbd>SPC</kbd> w` map

------------------------------------------
So, after [this](https://www.youtube.com/watch?v=_qZliI1BKzI) video, I decided we made our own window micro state (I believe that we should remove window-resize overlay map and introduce it to it.. but as you see in the commented part of the microstate, they are not used...because the funcitons spacemacs/shrink-window and their similars call again the window-resize overlay :(.... if you want to have it incorporated then we could change it.

I'm using the new macro introduced for generating micro-states and the doc part is done in the old way because it doesn't seem to be completely implemented, feel free to modify it later if you change the micro-state macro.

Also, I belive we should have a conventions on microstates from now on..like a separate file..or sth? 

Anyways, this is my first non-layer contribution, I hope you like it.

lol, hercules