### PR TITLE
added yasnippet to python company-mode

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -51,7 +51,7 @@ which require an initialization must be listed explicitly in the list.")
   (use-package company-anaconda
     :if (boundp 'company-backends)
     :defer t
-    :init (add-to-list 'company-backends 'company-anaconda)))
+    :init (add-to-list 'company-backends '(company-anaconda :with company-yasnippet))))
 
 (defun python/init-cython-mode ()
   (use-package cython-mode


### PR DESCRIPTION
added `company-yasnippet` to the company-anaconda mode. @trishume is this how I shoud be doing it? or should I do something like `(add-to-list 'company-backends (company-mode/backend-with-yas '(company-anaconda))`?