### PR TITLE
Fix for css yasnippet load issue.

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -20,6 +20,7 @@
     scss-mode
     tagedit
     web-mode
+    yasnippet
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -79,3 +80,9 @@ which require an initialization must be listed explicitly in the list.")
       (tagedit-add-experimental-features)
       (add-hook 'html-mode-hook (lambda () (tagedit-mode 1)))
       (spacemacs|diminish tagedit-mode " Ⓣ" " T"))))
+
+(defun html/init-yasnippet ()
+  (use-package yasnippet
+    :defer t
+    :init
+    (add-hook 'css-mode-hook 'spacemacs/load-yasnippet)))


### PR DESCRIPTION
This fixes #532 by adding spacemacs/load-yasnippet to the css-mode-hook.
This fixes both css-mode and scss-mode.