### PR TITLE
moved spacemacs/next-error and spacemacs/previous-error to func.el,

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -849,3 +849,19 @@ If ASCII si not provided then UNICODE is used instead."
      ((system-is-linux) (let ((process-connection-type nil))
                           (start-process "" nil "xdg-open" file-path)))
      )))
+
+(defun spacemacs/next-error (&optional n reset)
+  "Dispatch to flycheck or standard emacs error."
+  (interactive "P")
+  (if (and (boundp 'flycheck-mode)
+           (symbol-value flycheck-mode))
+      (call-interactively 'flycheck-next-error)
+    (call-interactively 'next-error)))
+
+(defun spacemacs/previous-error (&optional n reset)
+  "Dispatch to flycheck or standard emacs error."
+  (interactive "P")
+  (if (and (boundp 'flycheck-mode)
+           (symbol-value flycheck-mode))
+      (call-interactively 'flycheck-previous-error)
+    (call-interactively 'previous-error)))

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -72,8 +72,9 @@
   "hdv" 'describe-variable)
 ;; errors ---------------------------------------------------------------------
 (evil-leader/set-key
-  "en" 'next-error
-  "ep" 'previous-error)
+  "en" 'spacemacs/next-error
+  "ep" 'spacemacs/previous-error
+  "eN" 'spacemacs/previous-error)
 ;; find -----------------------------------------------------------------------
 (evil-leader/set-key
   "ff" 'ido-find-file

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -996,29 +996,12 @@ which require an initialization must be listed explicitly in the list.")
         :fringe-bitmap 'my-flycheck-fringe-indicator
         :fringe-face 'flycheck-fringe-info)
 
-      (defun spacemacs/next-error (&optional n reset)
-        "Dispatch to flycheck or standard emacs error."
-        (interactive "P")
-        (if (and (boundp 'flycheck-mode)
-                 (symbol-value flycheck-mode))
-            (call-interactively 'flycheck-next-error)
-          (call-interactively 'next-error)))
-
-      (defun spacemacs/previous-error (&optional n reset)
-        "Dispatch to flycheck or standard emacs error."
-        (interactive "P")
-        (if (and (boundp 'flycheck-mode)
-                 (symbol-value flycheck-mode))
-            (call-interactively 'flycheck-previous-error)
-          (call-interactively 'previous-error)))
 
       ;; key bindings
       (evil-leader/set-key
         "ec" 'flycheck-clear
         "ef" 'flycheck-mode
-        "el" 'flycheck-list-errors
-        "en" 'spacemacs/next-error
-        "eN" 'spacemacs/previous-error))))
+        "el" 'flycheck-list-errors))))
 
 (defun spacemacs/init-flyspell ()
   (use-package flyspell


### PR DESCRIPTION
changed keybindings

- fixes issue #567
- this binds both SPC e N and SPC e p to spacemacs/previous-error. Is this what is expected?