### PR TITLE
bundler support and other fixes

### DIFF
--- a/contrib/lang/ruby/config.el
+++ b/contrib/lang/ruby/config.el
@@ -19,12 +19,13 @@
   "If non nil we'll load support for Rails (haml, features, navigation)")
 
 (setq ruby/key-binding-prefixes
-      '(
+      '(("mrc" . "compile/generate")
         ("mrg" . "goto")
         ("mrf" . "find")
         ("mrr" . "rake")
-        ("mrx" . "run")
-        ("mrc" . "compule/generate")))
+        ("mrR" . "refactoring")
+        ("mrs" . "REPL")
+        ("mrx" . "run")))
 
 (mapc (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))
       ruby/key-binding-prefixes)

--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -1,10 +1,12 @@
 (defvar ruby-packages
   '(
     ;; package rubys go here
-    enh-ruby-mode
+    ruby-mode
+    ruby-tools
     flycheck
     ruby-test-mode
     robe
+    bundler
     yaml-mode))
 
 (when ruby-version-manager
@@ -15,14 +17,12 @@
   (add-to-list 'ruby-packages 'feature-mode)
   (add-to-list 'ruby-packages 'projectile-rails))
 
-(defvar ruby-excluded-packages '(ruby-mode))
-
 (defun ruby/init-rbenv ()
   "Initialize RBENV mode"
   (use-package rbenv
     :defer t
     :init (global-rbenv-mode)
-    :config (add-hook 'enh-ruby-mode-hook
+    :config (add-hook 'ruby-mode-hook
                       (lambda () (rbenv-use-corresponding)))))
 
 (defun ruby/init-rvm ()
@@ -30,18 +30,31 @@
   (use-package rvm
     :defer t
     :init (rvm-use-default)
-    :config (add-hook 'enh-ruby-mode-hook
+    :config (add-hook 'ruby-mode-hook
                       (lambda () (rvm-activate-corresponding-ruby)))))
 
-(defun ruby/init-enh-ruby-mode ()
-  "Initialize Enhanced Ruby Mode"
-  (use-package enh-ruby-mode
+(defun ruby/init-ruby-mode ()
+  "Initialize Ruby Mode"
+  (use-package ruby-mode
     :defer t
-    :mode (("\\(rake\\|thor\\|guard\\|gem\\|cap\\|vagrant\\)file\\'" . enh-ruby-mode)
-           ("\\.\\(rb\\|ru\\|builder\\|rake\\|thor\\|gemspec\\)\\'" . enh-ruby-mode))))
+    :mode (("\\(rake\\|thor\\|guard\\|gem\\|cap\\|vagrant\\|berks\\|pod\\|puppet\\)file\\'" . ruby-mode)
+           ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . ruby-mode))))
 
 (defun ruby/init-flycheck ()
-  (add-hook 'enh-ruby-mode-hook 'flycheck-mode))
+  (add-hook 'ruby-mode-hook 'flycheck-mode))
+
+(defun ruby/init-ruby-tools ()
+  (add-hook 'ruby-mode-hook 'ruby-tools-mode))
+
+(defun ruby/init-bundler ()
+  (use-package bundler
+    :defer t
+    :init (progn
+              (evil-leader/set-key-for-mode 'ruby-mode "mbc" 'bundle-check)
+              (evil-leader/set-key-for-mode 'ruby-mode "mbi" 'bundle-install)
+              (evil-leader/set-key-for-mode 'ruby-mode "mbs" 'bundle-console)
+              (evil-leader/set-key-for-mode 'ruby-mode "mbu" 'bundle-update)
+              (evil-leader/set-key-for-mode 'ruby-mode "mbx" 'bundle-exec))))
 
 (defun ruby/init-projectile-rails ()
   (use-package projectile-rails
@@ -100,20 +113,20 @@
   "Initialize Robe mode"
   (use-package robe
     :defer t
-    :init (add-hook 'enh-ruby-mode-hook 'robe-mode)
+    :init (add-hook 'ruby-mode-hook 'robe-mode)
     :config (progn
               (spacemacs|diminish robe-mode " ♦" " r")
               ;; robe mode specific
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "mgg" 'robe-jump)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "mhd" 'robe-doc)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "mrsr" 'robe-rails-refresh)
+              (evil-leader/set-key-for-mode 'ruby-mode "mgg" 'robe-jump)
+              (evil-leader/set-key-for-mode 'ruby-mode "mhd" 'robe-doc)
+              (evil-leader/set-key-for-mode 'ruby-mode "mrsr" 'robe-rails-refresh)
               ;; inf-ruby-mode
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "mi" 'robe-start)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "msf" 'ruby-send-definition)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "msF" 'ruby-send-definition-and-go)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "msr" 'ruby-send-region)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "msR" 'ruby-send-region-and-go)
-              (evil-leader/set-key-for-mode 'enh-ruby-mode "mss" 'ruby-switch-to-inf))))
+              (evil-leader/set-key-for-mode 'ruby-mode "mi" 'robe-start)
+              (evil-leader/set-key-for-mode 'ruby-mode "msf" 'ruby-send-definition)
+              (evil-leader/set-key-for-mode 'ruby-mode "msF" 'ruby-send-definition-and-go)
+              (evil-leader/set-key-for-mode 'ruby-mode "msr" 'ruby-send-region)
+              (evil-leader/set-key-for-mode 'ruby-mode "msR" 'ruby-send-region-and-go)
+              (evil-leader/set-key-for-mode 'ruby-mode "mss" 'ruby-switch-to-inf))))
 
 (defun ruby/init-yaml-mode ()
   "Initialize YAML mode"


### PR DESCRIPTION

includes the following:
* add bundle and define keybindings
* revert to `ruby-mode` instead of `enh-ruby-mode` as it's more standard, i.e. it doesn't require ruby 1.9.2+
to properly highlight syntax
* fix key binding prefixes
* add ruby-tools mode
* add file types to ruby mode (should fix #458 )