### PR TITLE
add 'cider-jump-back keybinding as mgb; remove 'cider-jump

### DIFF
--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -77,7 +77,7 @@ which require an initialization must be listed explicitly in the list.")
         "mgv" 'cider-jump-to-var
         "mgr" 'cider-jump-to-resource
         "mge" 'cider-jump-to-compilation-error
-        "mgs" 'cider-jump
+        "mgb" 'cider-jump-back
         "mtt" 'cider-test-run-tests)
       (when clojure-enable-fancify-symbols 
         (clojure/fancify-symbols 'cider-repl-mode)))))


### PR DESCRIPTION
cider-jump-back is handy
cider-jump is deprecated since cider 0.7.0 and is currently only an alias for cider-jump-var
[https://github.com/clojure-emacs/cider/blob/b661d1019980bb4e4452b4c62b5378f901a33e59/cider-interaction.el]