### PR TITLE
Re-enable ahs and auto-load when uninitialized

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1533,17 +1533,17 @@ Navigation between the highlighted symbols can be done with the commands:
 
 Key Binding            | Description
 -----------------------|------------------------------------------------------------
+<kbd>*</kbd>           | initiate navigation micro-state on current symbol and jump forwards
+<kbd>#</kbd>           | initiate navigation micro-state on current symbol and jump backwards
 <kbd>SPC s b</kbd>     | go to the last searched occurrence of the last highlighted symbol
 <kbd>SPC s e</kbd>     | edit all occurrences of the current symbol(*)
-<kbd>SPC s h</kbd>     | initiate navigation micro-state
+<kbd>SPC s h</kbd>     | highlight the current symbol and all its occurrence within the current range
 <kbd>SPC s R</kbd>     | change range to default (`whole buffer`)
 
 In 'Spacemacs' highlight symbol micro-state:
 
 Key Binding   | Description
 --------------|------------------------------------------------------------
-<kbd>*</kbd>  | search next occurrence using evil
-<kbd>#</kbd>  | search previous occurrence using evil
 <kbd>e</kbd>  | edit occurrences (*)
 <kbd>n</kbd>  | go to next occurrence
 <kbd>N</kbd>  | go to previous occurrence


### PR DESCRIPTION
Reverts changes in 418ca0a and c21bd2d to re-enable ahs on `*` and `#`.

Detect when auto-highlight-symbol-mode is in a partially initialized
state for the current buffer and fully initialize it for the current
buffer/major mode.