### PR TITLE
Added markdown keybindings

### DIFF
--- a/contrib/lang/markdown/packages.el
+++ b/contrib/lang/markdown/packages.el
@@ -29,7 +29,74 @@ which require an initialization must be listed explicitly in the list.")
     ;; Don't do terrible things with Github code blocks (```)
     (when (fboundp 'sp-local-pair)
       (sp-local-pair 'markdown-mode "`" nil :actions '(:rem autoskip))
-      (sp-local-pair 'markdown-mode "'" nil :actions nil))))
+      (sp-local-pair 'markdown-mode "'" nil :actions nil))
+    (progn
+      (evil-leader/set-key-for-mode 'markdown-mode
+        ;; Element insertion
+        "mal"   'markdown-insert-link
+        "maL"   'markdown-insert-reference-link-dwim
+        "mau"   'markdown-insert-uri
+        "maf"   'markdown-insert-footnote
+        "maw"   'markdown-insert-wiki-link
+        "mii"   'markdown-insert-image
+        "miI"   'markdown-insert-reference-image
+        "mth"   'markdown-insert-header-dwim
+        "mtH"   'markdown-insert-header-setext-dwim
+        "mt1"   'markdown-insert-header-atx-1
+        "mt2"   'markdown-insert-header-atx-2
+        "mt3"   'markdown-insert-header-atx-3
+        "mt4"   'markdown-insert-header-atx-4
+        "mt5"   'markdown-insert-header-atx-5
+        "mt6"   'markdown-insert-header-atx-6
+        "mt!"   'markdown-insert-header-setext-1
+        "mt@"   'markdown-insert-header-setext-2
+        "mss"   'markdown-insert-bold
+        "mse"   'markdown-insert-italic
+        "msc"   'markdown-insert-code
+        "msb"   'markdown-insert-blockquote
+        "msB"   'markdown-blockquote-region
+        "msp"   'markdown-insert-pre
+        "msP"   'markdown-pre-region
+        "m\""   'markdown-insert-hr
+        ;; Element removal
+        "mk"    'markdown-kill-thing-at-point
+        ;; Promotion, Demotion, Completion, and Cycling
+        "m="    'markdown-promote
+        "m-"    'markdown-demote
+        "m]"    'markdown-complete
+        ;; Following and Jumping
+        "mo"   'markdown-follow-thing-at-point
+        "mj"   'markdown-jump
+        ;; Indentation
+        "m>"   'markdown-indent-region
+        "m<"   'markdown-exdent-region
+        ;; Header navigation
+        "mn"   'outline-next-visible-heading
+        "mp"   'outline-previous-visible-heading
+        "mf"   'outline-forward-same-level
+        "mb"   'outline-backward-same-level
+        "mu"   'outline-up-heading
+        ;; Buffer-wide commands
+        "mcm"  'markdown-other-window
+        "mcp"  'markdown-preview
+        "mce"  'markdown-export
+        "mcv"  'markdown-export-and-preview
+        "mco"  'markdown-open
+        "mcw"  'markdown-kill-ring-save
+        "mcc"  'markdown-check-refs
+        "mcn"  'markdown-cleanup-list-numbers
+        "mc]"  'markdown-complete-buffer
+        ;; List editing
+        "mlk"  'markdown-move-up
+        "mlj"  'markdown-move-down
+        "mlh"  'markdown-promote
+        "mll"  'markdown-demote
+        "mli"  'markdown-insert-list-item
+        ;; Movement
+        "m{"   'markdown-backward-paragraph
+        "m}"   'markdown-forward-paragraph
+        "mN"   'markdown-next-link
+        "mP"   'markdown-previous-link))))
 
 (defun markdown/init-markdown-toc ()
   (use-package markdown-toc


### PR DESCRIPTION
Nearly a direct transcription of the keybindings from `markdown-mode.el`