### PR TITLE
Fix outdated comment

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -134,8 +134,7 @@ before installing the file if the destination already exists."
       (message "%s has been installed." dotfile))))
 
 (defun dotspacemacs/load ()
-  "Load ~/.spacemacs. If it is not found then copy .spacemacs.template to
-~/.spacemacs"
+  "Load ~/.spacemacs if it exists."
   (let ((dotspacemacs (dotspacemacs/location)))
     (if (file-exists-p dotspacemacs) (load dotspacemacs))))
 


### PR DESCRIPTION
I guess the comment of `dotspacemacs/load` is outdated, because the function only loads `~/.spacemacs` if it exists. If not - nothing happens. No copying.