### PR TITLE
Enable mouse support in terminal mode

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -92,6 +92,9 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
   ;; (tabulated-list-print t)
   (tabulated-list-print))
 
+;; Mouse cursor in terminal mode
+(xterm-mouse-mode 1) 
+
 ;; ---------------------------------------------------------------------------
 ;; Edit
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Sometimes it's easier to use Emacs with a mouse in the terminal.