### PR TITLE
Company mode tab optional

### DIFF
--- a/contrib/company-mode/README.md
+++ b/contrib/company-mode/README.md
@@ -25,6 +25,18 @@ Basically, Spacemacs now has better Clang/C++ than any other Emacs config.
 <kbd>C-M-/</kbd>     | filter the company dropdown menu
 <kbd>C-d</kbd>       | open minibuffer with documentation of thing at point in company dropdown
 
+## Settings
+
+To use tab instead of enter to complete your selection, `dotspacemacs/init` set `company-mode/use-tab-instead-of-enter-to-complete` to true, for example:
+```
+(defun dotspacemacs/init ()
+  "User initialization for Spacemacs. This function is called at the very
+ startup."
+  (setq company-mode/use-tab-instead-of-enter-to-complete t)
+  )
+
+```
+
 ## Maintainer
 
 This contrib layer was written by and should be maintained by @trishume, everyone else is

--- a/contrib/company-mode/README.md
+++ b/contrib/company-mode/README.md
@@ -15,6 +15,16 @@ header files and skip the actual problems.
 
 Basically, Spacemacs now has better Clang/C++ than any other Emacs config.
 
+## Key Bindings
+
+    No Debug         |                 Description
+---------------------|------------------------------------------------------------
+<kbd>C-j</kbd>       | go down in company dropdown menu
+<kbd>C-k</kbd>       | go up in company dropdown menu
+<kbd>C-/</kbd>       | search in company dropdown
+<kbd>C-M-/</kbd>     | filter the company dropdown menu
+<kbd>C-d</kbd>       | open minibuffer with documentation of thing at point in company dropdown
+
 ## Maintainer
 
 This contrib layer was written by and should be maintained by @trishume, everyone else is

--- a/contrib/company-mode/packages.el
+++ b/contrib/company-mode/packages.el
@@ -47,6 +47,8 @@ so that you don't have 'do' completed to 'downcase' in Ruby"
       (define-key company-active-map (kbd "<tab>") nil)
       (define-key company-active-map [tab] nil)
 
+      (company-mode/setup-keybindings)
+
       (add-hook 'markdown-mode-hook '(lambda () (company-mode -1)))
 
       ;; The default common face is a really ugly underlined thing with a different background.
@@ -69,3 +71,12 @@ so that you don't have 'do' completed to 'downcase' in Ruby"
     :defer t
     :init
     (add-to-list 'company-backends (company-mode/backend-with-yas 'company-tern))))
+
+(defun company-mode/setup-keybindings ()
+  (progn
+    (define-key company-active-map (kbd "C-j") 'company-select-next)
+    (define-key company-active-map (kbd "C-k") 'company-select-previous)
+    (define-key company-active-map (kbd "C-/") 'company-search-candidates)
+    (define-key company-active-map (kbd "C-M-/") 'company-filter-candidates)
+    (define-key company-active-map (kbd "C-d") 'company-show-doc-buffer)
+    ))


### PR DESCRIPTION
This allows a user to configure whether they want to use enter or tab for completion in company-mode. (this PR also has the last commit I made adding the key bindings, which should probably be merged first). I split the functions into two PR's as I thought they were two orthogonal features. Let me know what you think.