### PR TITLE
clojure: change keybinding for goto 'mgv' -> 'mgg'; update readme

### DIFF
--- a/contrib/lang/clojure/README.md
+++ b/contrib/lang/clojure/README.md
@@ -87,9 +87,10 @@ instructions at the [cider repository][cider_install].
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m g v</kbd>  | goto var
+<kbd>SPC m g g</kbd>  | goto var
 <kbd>SPC m g e</kbd>  | goto error
-<kbd>SPC m g s</kbd>  | goto symbol
+<kbd>SPC m g r</kbd>  | goto resource
+<kbd>SPC m g b</kbd>  | go back
 
 ### REPL
 

--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -74,7 +74,7 @@ which require an initialization must be listed explicitly in the list.")
         "mdd" 'cider-doc
         "mdg" 'cider-grimoire
         "mdj" 'cider-javadoc
-        "mgv" 'cider-jump-to-var
+        "mgg" 'cider-jump-to-var
         "mgr" 'cider-jump-to-resource
         "mge" 'cider-jump-to-compilation-error
         "mgb" 'cider-jump-back


### PR DESCRIPTION
Change clojure mode goto keybinding from 'mgv' to 'mgg'. This conforms better to standard: https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.md#code-navigation

Also updated relevant section in the readme.