### PR TITLE
Add more key bindings for ledger-mode

### DIFF
--- a/contrib/finance/README.md
+++ b/contrib/finance/README.md
@@ -30,10 +30,20 @@ To use this contribution add it to your `~/.spacemacs`
 
 ### Ledger
 
-    Key Binding    |                 Description
--------------------|------------------------------------------------------------
-<kbd>SPC m a</kbd> | add a transaction
-<kbd>SPC m d</kbd> | delete current transaction
+    Key Binding      |                 Description
+---------------------|----------------------------------------------------------
+<kbd>SPC m a</kbd>   | add a transaction
+<kbd>SPC m b</kbd>   | edit a post amount with Emacs Calculator mode
+<kbd>SPC m c</kbd>   | toggle 'cleared' flag on transaction or post
+<kbd>SPC m C</kbd>   | sort and align the entire buffer
+<kbd>SPC m d</kbd>   | delete current transaction
+<kbd>SPC m p</kbd>   | display balance at point
+<kbd>SPC m q</kbd>   | align a single transaction's posts
+<kbd>SPC m r</kbd>   | reconcile an account
+<kbd>SPC m R</kbd>   | display a report
+<kbd>SPC m t</kbd>   | append an effective date to a post
+<kbd>SPC m y</kbd>   | set the year for quicker entry
+<kbd>SPC m RET</kbd> | set the month for quicker entry
 
 
 [ledger]: https://github.com/ledger/ledger

--- a/contrib/finance/packages.el
+++ b/contrib/finance/packages.el
@@ -31,5 +31,16 @@ which require an initialization must be listed explicitly in the list.")
     (progn
       (setq ledger-post-amount-alignment-column 62)
       (evil-leader/set-key-for-mode 'ledger-mode
-        "mhd" 'ledger-delete-current-transaction
-        "ma"  'ledger-add-transaction))))
+        "mhd"   'ledger-delete-current-transaction
+        "ma"    'ledger-add-transaction
+        "mb"    'ledger-post-edit-amount
+        "mc"    'ledger-toggle-current
+        "mC"    'ledger-mode-clean-buffer
+        "ml"    'ledger-display-ledger-stats
+        "mp"    'ledger-display-balance-at-point
+        "mq"    'ledger-post-align-xact
+        "mr"    'ledger-reconcile
+        "mR"    'ledger-report
+        "mt"    'ledger-insert-effective-date
+        "my"    'ledger-set-year
+        "m RET" 'ledger-set-month))))


### PR DESCRIPTION
These correlate more or less with the default `C-c` key bindings for ledger-mode. Also includes a correction for the `ledger-delete-current-transaction` key.

I read the Spacemacs conventions, and it does not appear that any of the mode-scoped `m` keys apply to ledger, so I went ahead and created bindings for `mc`, `mt`, etc.

We will probably want to use better mnemonic instead of variations on the Emacs commands, but this is a start.