### PR TITLE
fix company-go loading before go-mode

### DIFF
--- a/contrib/lang/go/packages.el
+++ b/contrib/lang/go/packages.el
@@ -43,6 +43,6 @@ which require an initialization must be listed explicitly in the list.")
  (use-package company-go
    :if (boundp 'company-backends)
    :defer t
-   :init (add-to-list 'company-backends 'company-go)
+   :init (eval-after-load 'go-mode '(add-to-list 'company-backends 'company-go))
   )
 )


### PR DESCRIPTION
company-go requires go-mode and spacemacs load company-go first.

Fixed this by eval loading after go-mode.

Should fix #632 