### PR TITLE
Ensime tweaks

### DIFF
--- a/contrib/lang/scala/funcs.el
+++ b/contrib/lang/scala/funcs.el
@@ -81,8 +81,14 @@ point to the position of the join."
   (when (s-matches? (rx (+ (not space)))
                     (buffer-substring (line-beginning-position) (point)))
     (delete-horizontal-space t))
-  (insert ".")
-  (company-complete))
+
+  (cond (company-backend
+         (company-complete-selection)
+         (scala/completing-dot))
+
+        (t
+         (insert ".")
+         (company-complete))))
 
 ;;; Flyspell
 

--- a/contrib/lang/scala/funcs.el
+++ b/contrib/lang/scala/funcs.el
@@ -42,6 +42,13 @@
                       (s-contains? (file-name-nondirectory project-name) bufname)))
                (buffer-list)))))
 
+(defun scala/enable-eldoc ()
+  (setq-local eldoc-documentation-function
+              (lambda ()
+                (when (ensime-connected-p)
+                  (ensime-print-type-at-point))))
+  (eldoc-mode +1))
+
 (defun spacemacs/ensime-refactor-accept ()
   (interactive)
   (funcall continue-refactor)

--- a/contrib/lang/scala/packages.el
+++ b/contrib/lang/scala/packages.el
@@ -29,6 +29,7 @@ which require an initialization must be listed explicitly in the list.")
     :commands (ensime-mode)
     :init
     (progn
+      (add-hook 'ensime-mode-hook 'scala/enable-eldoc)
       (add-hook 'scala-mode-hook 'scala/configure-flyspell)
       (add-hook 'scala-mode-hook 'scala/configure-ensime)
       (add-hook 'scala-mode-hook 'scala/maybe-start-ensime))

--- a/contrib/lang/scala/packages.el
+++ b/contrib/lang/scala/packages.el
@@ -12,6 +12,7 @@
 
 (defvar scala-packages
   '(
+    projectile
     ensime
     sbt-mode
     scala-mode2
@@ -19,13 +20,18 @@
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
 
+(defun scala/init-projectile ()
+  (use-package projectile
+    :defer t))
+
 (defun scala/init-ensime ()
   (use-package ensime
     :commands (ensime-mode)
     :init
     (progn
       (add-hook 'scala-mode-hook 'scala/configure-flyspell)
-      (add-hook 'scala-mode-hook 'scala/configure-ensime))
+      (add-hook 'scala-mode-hook 'scala/configure-ensime)
+      (add-hook 'scala-mode-hook 'scala/maybe-start-ensime))
     :config
     (progn
       (evil-define-key 'insert ensime-mode-map
@@ -109,7 +115,7 @@ which require an initialization must be listed explicitly in the list.")
         "mee"     'ensime-print-errors-at-point
         "mel"     'ensime-show-all-errors-and-warnings
         "mes"     'ensime-stacktrace-switch
-        
+
         "mgg"     'ensime-edit-definition
         "mgi"     'ensime-goto-impl
         "mgt"     'ensime-goto-test

--- a/contrib/lang/scala/packages.el
+++ b/contrib/lang/scala/packages.el
@@ -28,9 +28,19 @@ which require an initialization must be listed explicitly in the list.")
       (add-hook 'scala-mode-hook 'scala/configure-ensime))
     :config
     (progn
-      (evil-define-key 'insert ensime-mode-map (kbd ".") 'scala/completing-dot)
+      (evil-define-key 'insert ensime-mode-map
+        (kbd ".") 'scala/completing-dot
+        (kbd "M-.") 'ensime-edit-definition
+        (kbd "M-,") 'ensime-pop-find-definition-stack)
+
+      (evil-define-key 'normal ensime-mode-map
+        (kbd "M-.") 'ensime-edit-definition
+        (kbd "M-,") 'ensime-pop-find-definition-stack)
 
       (evil-define-key 'normal ensime-popup-buffer-map
+        (kbd "q") 'ensime-popup-buffer-quit-function)
+
+      (evil-define-key 'normal ensime-inspector-mode-map
         (kbd "q") 'ensime-popup-buffer-quit-function)
 
       (evil-define-key 'normal ensime-refactor-info-map


### PR DESCRIPTION
Adds some stuff that's been in my private config for the last month.

* Automatically start ensime server when there is a `.ensime` file in this project
* Bind goto-definition commands to `M-.` and `M-,`, SLIME-style
* Fix an interaction bug when inserting a `.` while completions are being displayed.
* Automatically display types in minibuffer using eldoc