### PR TITLE
contrib(evernote): change namespace to evernote

### DIFF
--- a/contrib/evernote/packages.el
+++ b/contrib/evernote/packages.el
@@ -1,14 +1,25 @@
-(defvar geeknote-packages
+;;; packages.el --- Evernote Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+(defvar evernote-packages
   '(
     geeknote
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
 
-(defvar geeknote-excluded-packages '()
+(defvar evernote-excluded-packages '()
   "List of packages to exclude.")
 
-(defun geeknote/init-geeknote ()
+(defun evernote/init-geeknote ()
   "Initializes geeknote and adds keybindings for its exposed functionalities."
   (use-package geeknote
     :commands (geeknote-create
@@ -20,8 +31,8 @@ which require an initialization must be listed explicitly in the list.")
     :init
     (progn
       (evil-leader/set-key
-        "agc" 'geeknote-create
-        "age" 'geeknote-edit
-        "agf" 'geeknote-find
-        "ags" 'geeknote-show
-        "agr" 'geeknote-remove))))
+        "aec" 'geeknote-create
+        "aee" 'geeknote-edit
+        "aef" 'geeknote-find
+        "aes" 'geeknote-show
+        "aer" 'geeknote-remove))))


### PR DESCRIPTION
the previous namespace (geeknote) didn't match the layer name, as @syl20bnr pointed out in gitter. This PR fixes it and adds the license header to `packages.el` as well.