### PR TITLE
Added ghci-ng support to haskell layer

### DIFF
--- a/contrib/lang/haskell/README.md
+++ b/contrib/lang/haskell/README.md
@@ -83,6 +83,24 @@ so that the path is added before any layers is loaded.
 Note that `emacs.app` for OS X does not pick up `$PATH` from `~/.bashrc` or
 `~/.zshrc` when launched from outside a terminal.
 
+*** Enabling GHCi-ng support
+[ghci-ng][] adds some nice features to `haskell-mode`, and is supported in Spacemacs by a layer variable:
+
+Follow the instructions to install [ghci-ng][] (remember to add `:set +c` in `~/.ghci`,
+next set the layer variable:
+```elisp
+;; List of configuration layers to load.
+dotspacemacs-configuration-layers '(company-mode (haskell :variables haskell-ghci-ng-support t) git)
+```
+
+Once ghci-ng is enabled, two of the old keybindings are overriden with improved versions from ghci-ng, and a new keybinding available: 
+
+    Key Binding       |                 Description
+----------------------|------------------------------------------------------------
+<kbd>SPC m t</kbd>    | gets the type of the identifier under the cursor or for the active region
+<kbd>SPC m g g</kbd>  | go to definition
+<kbd>SPC m u</kbd>    | finds uses of identifier
+
 ## Key bindings
 
 All Haskell specific bindings are prefixed with <kbd>SPC m</kbd>
@@ -96,8 +114,7 @@ Top-level commands are prefixed by <kbd>SPC m</kbd>:
 ----------------------|------------------------------------------------------------
 <kbd>SPC m t</kbd>    | gets the type of the identifier under the cursor
 <kbd>SPC m i</kbd>    | gets information for the identifier under the cursor
-<kbd>SPC m u</kbd>    | finds uses of identifier
-<kbd>SPC m g</kbd>    | go to definition or tag
+<kbd>SPC m g g</kbd>  | go to definition or tag
 <kbd>SPC m f</kbd>    | format buffer using haskell-stylish
 
 #### Documentation commands:
@@ -164,3 +181,4 @@ REPL commands are prefixed by <kbd>SPC m s</kbd>:
 [cabal]: https://www.haskell.org/cabal/
 [company-ghc]: https://github.com/iquiw/company-ghc
 [hi2]: https://github.com/nilcons/hi2
+[ghci-ng]: https://github.com/chrisdone/ghci-ng

--- a/contrib/lang/haskell/config.el
+++ b/contrib/lang/haskell/config.el
@@ -1,0 +1,14 @@
+;;; config.el --- Haskell Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2015 Bjarke Vad Andersen
+;;
+;; Author: Bjarke Vad Andersen <bjarke.vad90@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+(defvar haskell-ghci-ng-support nil
+  "If non nil ghci-ng support is enabled")

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -32,8 +32,7 @@
     (progn
       ;; Customization
       (custom-set-variables
-       ;; Use cabal-repl for the GHCi session. Ensures our dependencies are in scope.
-       ;; cabal-dev is deprecated
+
        '(haskell-process-type 'auto)
 
        ;; Use notify.el (if you have it installed) at the end of running
@@ -82,7 +81,6 @@
       (evil-leader/set-key-for-mode 'haskell-mode
         "mt"   'haskell-process-do-type
         "mi"   'haskell-process-do-info
-        "mu"   'haskell-mode-find-uses
         "mgg"  'haskell-mode-jump-to-def-or-tag
         "mf"   'haskell-mode-stylish-buffer
 
@@ -109,6 +107,8 @@
         "mda"  'haskell-debug/abandon
         "mdr"  'haskell-debug/refresh
         )
+
+
       ;; Switch back to editor from REPL
       (evil-leader/set-key-for-mode 'interactive-haskell-mode
         "msS"  'haskell-interactive-switch
@@ -155,7 +155,26 @@
 
       ;; Useful to have these keybindings for .cabal files, too.
       (defun haskell-cabal-hook ()
-        (define-key haskell-cabal-mode-map [?\C-c ?\C-z] 'haskell-interactive-switch)))))
+        (define-key haskell-cabal-mode-map [?\C-c ?\C-z] 'haskell-interactive-switch))
+
+      ;;GHCi-ng
+      (defun ghci-ng-setup()
+        (progn
+          ;; haskell-process-type is set to auto, so setup ghci-ng for either case
+          ;; if haskell-process-type == cabal-repl
+          (setq haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans" "--with-ghc=ghci-ng"))
+          ;; if haskell-process-type == GHCi
+          (setq haskell-process-path-ghci "ghci-ng")
+
+          (evil-leader/set-key-for-mode 'haskell-mode
+            "mu"   'haskell-mode-find-uses
+            "mt"   'haskell-mode-show-type-at
+            "mgg"  'haskell-mode-goto-loc
+            ))
+        )
+
+      (if haskell-ghci-ng-support
+          (ghci-ng-setup)))))
 
 (defun haskell/init-company-ghc ()
   (use-package company-ghc


### PR DESCRIPTION
- uses the layer variable `haskell-ghci-ng-support` to enable support

This is a rough outline of what I thought this feature might look like,
and it seems to work very well!
I've updated the readme a bit, but feel free to make changes!