### PR TITLE
Fixes #641

### DIFF
--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -137,7 +137,7 @@
 
       ;; Haskell main editing mode key bindings.
       (defun haskell-hook ()
-        (lambda () (ghc-init))
+        (ghc-init)
         ;; Use advanced indention
         (turn-on-haskell-indentation)
 


### PR DESCRIPTION
`ghc-init` is now correctly called on `haskell-mode` load