### PR TITLE
bond the key R in neotree to neotree-change-root, and updated the docume...

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1372,6 +1372,7 @@ Key Binding                      |                 Description
 <kbd>K</kbd>                     | parent directory, when reaching the root change it to parent directory
 <kbd>l</kbd> or <kbd>RET</kbd>   | expand directory
 <kbd>L</kbd>                     | next sibling
+<kbd>R</kbd>                     | make a directory the root directory
 
 **Note:** The point is automatically set to the first letter of a node for a
 smoother experience.

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1530,6 +1530,7 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
         (define-key evil-motion-state-local-map (kbd "L")   'neotree-select-next-sibling-node)
         (define-key evil-motion-state-local-map (kbd "q")   'neotree-hide)
         (define-key evil-motion-state-local-map (kbd "r")   'neotree-rename-node)
+        (define-key evil-motion-state-local-map (kbd "R")   'neotree-change-root)
         (define-key evil-motion-state-local-map (kbd "s")   'neotree-hidden-file-toggle))
 
       (evil-leader/set-key "ft" 'neotree-toggle))


### PR DESCRIPTION
the `neotree-change-root` function which sets the current directory as a root directory wasn't bond to any key in spacemacs. I've bond it to the key "R".