### PR TITLE
"SPC S d" calls ispell-change-dictionary

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -127,6 +127,7 @@
     "nw" 'widen))
 ;; spell check  ---------------------------------------------------------------
 (evil-leader/set-key
+  "Sd" 'ispell-change-dictionary
   "Sn" 'flyspell-goto-next-error)
 ;; toggle ---------------------------------------------------------------------
 (spacemacs|add-toggle fill-column-indicator


### PR DESCRIPTION
For issue #628.

"SPC S d" perform a dictionary change according to the documentation.
    
Left auto-dictionary binding alone as auto-dictionary package is disabled and may be correct behavior if it weren't disabled.
