### PR TITLE
Show trailing whitespaces only in programming modes

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -93,7 +93,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
   (tabulated-list-print))
 
 ;; Mouse cursor in terminal mode
-(xterm-mouse-mode 1) 
+(xterm-mouse-mode 1)
 
 ;; ---------------------------------------------------------------------------
 ;; Edit
@@ -103,7 +103,9 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; because it avoids autoloads of elisp modes)
 (setq initial-major-mode 'text-mode)
 ;; whitespace-mode
-(setq-default show-trailing-whitespace nil)
+(add-hook 'prog-mode-hook (lambda ()
+                            (interactive)
+                            (setq show-trailing-whitespace 1)))
 ;; When point is on paranthesis, highlight the matching one
 (show-paren-mode t)
 ;; use only spaces and no tabs


### PR DESCRIPTION
It's convenient to know if trailing whitespace exists and fix it
immediately, so user won't have to fix whitespace error and commit their
change again.

Also remove a trailing space.