### PR TITLE
[Fix #591] Enable Semantic support for C/C++; add Srefator

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -15,6 +15,7 @@
     cc-mode
     cmake-mode
     flycheck
+    srefactor
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -24,17 +25,32 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :config
     (progn
-      (add-hook 'c-mode-hook '(lambda () (c-toggle-auto-state t)))
-      (add-hook 'c++-mode-hook '(lambda () (c-toggle-auto-state t))))))
+      (require 'compile)
+      (mapc (lambda (m)
+              (add-to-list 'semantic-default-submodes 'global-semantic-stickyfunc-mode)
+              (add-to-list 'semantic-default-submodes 'global-semantic-idle-summary-mode)
+              (semantic-mode 1)
+              (c-toggle-auto-newline 1))
+            '(c-mode c++-mode)))))
+
+(defun c-c++/init-srefactor ()
+  (use-package srefactor
+    :if (not (version< emacs-version "24.4"))
+    :init
+    (progn
+      (evil-leader/set-key-for-mode 'c-mode
+        "mr" 'srefactor-refactor-at-point)
+      (evil-leader/set-key-for-mode 'c++-mode
+        "mr" 'srefactor-refactor-at-point))))
 
 (defun c-c++/init-cmake-mode ()
-(use-package cmake-mode
-  :defer t
-  :init
-  (setq auto-mode-alist
-        (append '(("CMakeLists\\.txt\\'" . cmake-mode)
-                  ("\\.cmake\\'" . cmake-mode))
-                auto-mode-alist))))
+  (use-package cmake-mode
+    :defer t
+    :init
+    (setq auto-mode-alist
+          (append '(("CMakeLists\\.txt\\'" . cmake-mode)
+                    ("\\.cmake\\'" . cmake-mode))
+                  auto-mode-alist))))
 
 (defun c-c++/init-flycheck ()
   (add-hook 'c-mode-hook 'flycheck-mode)


### PR DESCRIPTION
With Semantic mode enabled, it enables IDE features such as:

- Enable helm-semantic-or-imenu to jump with Semantic instead of Imenu.

- Show function signature of current function point is inside at the
top (with global-semantic-stickyfunc-mode)

- Show function signature of current function at point at the
bottom (with global-semantic-idle-summary-mode).

- Add Srefactor for refactoring using Semantic parser framework.