### PR TITLE
Improve Projectile configuration

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1342,6 +1342,7 @@ which require an initialization must be listed explicitly in the list.")
     :init
     (defconst spacemacs-use-helm-projectile t
       "This variable is only defined if helm-projectile is used.")
+    (setq projectile-switch-project-action 'helm-projectile)
     (evil-leader/set-key
       "/" 'helm-projectile-ag
       "pa" 'helm-projectile-ag
@@ -2008,6 +2009,7 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
     :init
     (progn
       (setq-default projectile-enable-caching t)
+      (setq projectile-sort-order 'recentf)
       (setq projectile-cache-file (concat spacemacs-cache-directory
                                           "projectile.cache"))
       (setq projectile-known-projects-file (concat spacemacs-cache-directory
@@ -2032,10 +2034,10 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
         "pR" 'projectile-regenerate-tags
         "pt" 'projectile-find-tag
         "pT" 'projectile-find-test-file))
-      :config
-      (progn
-        (projectile-global-mode)
-        (spacemacs|hide-lighter projectile-mode))))
+    :config
+    (progn
+      (projectile-global-mode)
+      (spacemacs|hide-lighter projectile-mode))))
 
 (defun spacemacs/init-rainbow-delimiters ()
   (use-package rainbow-delimiters


### PR DESCRIPTION
- Sort files by 'recentf, so that most recently used files are on top
  when projectile-find-file/helm-projectile-find-file is ran.

- Use `helm-projectile` as default action to make it consistent with the
  rest of Helm Projectile. The default action is `projectile-find-file`,
  but it doesn't offer various actions like proper Helm Projectile
  commands, i.e. you cannot open files other window with `C-c o` or
  other frame with `C-c C-o` and user have to manually create
  other window/frame, then switch the opened buffer in that window/frame.