### PR TITLE
Use hippie-expand in place of dabbrev-expand

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -156,6 +156,21 @@ Can be installed with `brew install trash'."
 ;; (add-hook 'window-configuration-change-hook
 ;;           (lambda ()
 ;;             (set-window-margins (car (get-buffer-window-list (current-buffer) nil t)) 0 0)))
+(global-set-key (kbd "M-/") 'hippie-expand) ;; replace dabbrev-expand
+
+(setq
+ hippie-expand-try-functions-list
+ '(try-expand-dabbrev ;; Try to expand word "dynamically", searching the current buffer.
+   try-expand-dabbrev-all-buffers ;; Try to expand word "dynamically", searching all other buffers.
+   try-expand-dabbrev-from-kill ;; Try to expand word "dynamically", searching the kill ring.
+   try-complete-file-name-partially ;; Try to complete text as a file name, as many characters as unique.
+   try-complete-file-name ;; Try to complete text as a file name.
+   try-expand-all-abbrevs ;; Try to expand word before point according to all abbrev tables.
+   try-expand-list ;; Try to complete the current line to an entire line in the buffer.
+   try-expand-line ;; Try to complete the current line to an entire line in the buffer.
+   try-complete-lisp-symbol-partially ;; Try to complete as an Emacs Lisp symbol, as many characters as unique.
+   try-complete-lisp-symbol) ;; Try to complete word as an Emacs Lisp symbol.
+ )
 
 ;; Emacs 24.4 new features
 (unless (version< emacs-version "24.4")


### PR DESCRIPTION
hippie-exapnd is an improved version of dabbrev. It's a superset of
dabbrev-expand, as can be seen in the hippie-expand-try-functions-list.