### PR TITLE
Add support for ace-window and ace-delete-window as a layer

### DIFF
--- a/contrib/ace-window/README.md
+++ b/contrib/ace-window/README.md
@@ -1,0 +1,33 @@
+# Ace-window contribution layer for Spacemacs
+
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+- [Ace-window contribution layer for Spacemacs](#ace-window-contribution-layer-for-spacemacs)
+    - [Description](#description)
+    - [Install](#install)
+    - [Key bindings](#key-bindings)
+
+<!-- markdown-toc end -->
+
+## Description
+
+This layer adds support for [ace-window](https://github.com/abo-abo/ace-window) with a function for [ace-delete-window](https://github.com/abo-abo/ace-window/releases/tag/0.7.0). 
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(ace-window))
+```
+
+## Key bindings
+
+Key Binding   | Description
+--------------|------------------------------------------------------------
+`C-x o`       | run ace-window
+`<SPC> w w`   | run ace-window
+`<SPC> w C`   | run ace-delete-window
+

--- a/contrib/ace-window/extensions.el
+++ b/contrib/ace-window/extensions.el
@@ -1,0 +1,33 @@
+;;; extensions.el --- ace-window Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar ace-window-pre-extensions
+  '(
+    ;; pre extension ace-windows go here
+    )
+  "List of all extensions to load before the packages.")
+
+(defvar ace-window-post-extensions
+  '(
+    ;; post extension ace-windows go here
+    )
+  "List of all extensions to load after the packages.")
+
+;; For each extension, define a function ace-window/init-<extension-ace-window>
+;;
+;; (defun ace-window/init-my-extension ()
+;;   "Initialize my extension"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package

--- a/contrib/ace-window/packages.el
+++ b/contrib/ace-window/packages.el
@@ -1,0 +1,62 @@
+;;; packages.el --- ace-window Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar ace-window-packages
+  '(
+    ;; package ace-windows go here
+    ace-window
+    )
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defvar ace-window-excluded-packages '()
+  "List of packages to exclude.")
+
+;; For each package, define a function ace-window/init-<package-ace-window>
+;;
+;; (defun ace-window/init-my-package ()
+;;   "Initialize my package"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package
+
+(defun ace-window/init-ace-window ()
+  (use-package ace-window
+    :bind ("C-x o" . ace-window)
+    :config (progn
+              ;; Shorter key-binding
+              ;; (global-set-key (kbd "M-o") 'ace-window)
+              (defun ace-delete-window ()
+                "Ace delete window."
+                (interactive)
+                (aw-delete-window
+                 (aw-select " Ace - Delete Window")))
+
+              (defun aw-delete-window (window)
+                "Delete window WINDOW."
+                (let ((frame (window-frame window)))
+                  (when (and (frame-live-p frame)
+                             (not (eq frame (selected-frame))))
+                    (select-frame-set-input-focus (window-frame window)))
+                  (if (= 1 (length (window-list)))
+                      (delete-frame frame)
+                    (if (window-live-p window)
+                        (delete-window window)
+                      (error "Got a dead window %S" window)))))
+              (evil-leader/set-key
+                "ww" 'ace-window
+                "wC" 'ace-delete-window
+                ))
+    )
+  )


### PR DESCRIPTION
Adds ace-window layer which rebinds "C-x o" to ace-window and gives one solution for [#664](https://github.com/syl20bnr/spacemacs/issues/664). Feel free to change the key-bindings. 