### PR TITLE
Move cider-jack-in back to init-clojure-mode

### DIFF
--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -145,7 +145,6 @@ the focus."
         "msE" 'spacemacs/send-last-sexp-to-repl-focus
         "msf" 'spacemacs/send-function-to-repl
         "msF" 'spacemacs/send-function-to-repl-focus
-        "msi" 'cider-jack-in
         "msn" 'spacemacs/send-ns-form-to-repl
         "msN" 'spacemacs/send-function-to-repl-focus
         "msr" 'spacemacs/send-region-to-repl
@@ -214,7 +213,8 @@ the focus."
     :config
     (progn
       (when clojure-enable-fancify-symbols
-        (clojure/fancify-symbols 'clojure-mode)))))
+        (clojure/fancify-symbols 'clojure-mode))
+      (evil-leader/set-key-for-mode 'clojure-mode "msi" 'cider-jack-in))))
 
 (defun clojure/init-rainbow-delimiters ()
   (if (configuration-layer/package-declaredp 'cider)


### PR DESCRIPTION
This commit reverts the change made in
53ba6c79c804ceaee6b92468c20b41da963019d6 that moved the cider-jack-in
keychord from init-clojure-mode to init-cider.

This needs to be active in Clojure mode as it's the main way for
launching into Cider (it's not meant to be used from within Cider itself
either).