### PR TITLE
shortcut for copying the git sha hash from the timemachine micro-state

### DIFF
--- a/contrib/git/packages.el
+++ b/contrib/git/packages.el
@@ -160,7 +160,7 @@ which require an initialization must be listed explicitly in the list.")
           (when golden-ratio (golden-ratio-mode))))
 
       (spacemacs|define-micro-state time-machine
-        :doc "[p] [N] previous [n] next [c] current [q] quit"
+        :doc "[p] [N] previous [n] next [c] current [y] copy hash [q] quit"
         :on-enter (spacemacs//time-machine-ms-on-enter)
         :on-exit (git-timemachine-quit)
         :persistent t
@@ -169,6 +169,7 @@ which require an initialization must be listed explicitly in the list.")
         ("p" git-timemachine-show-previous-revision)
         ("n" git-timemachine-show-next-revision)
         ("N" git-timemachine-show-previous-revision)
+        ("y" git-timemachine-kill-revision)
         ("q" nil :exit t)))))
 
 ;; this mode is not up to date


### PR DESCRIPTION
The timemachine micro-state that was recently added is a great progress, however it only has previous/next/current/quit shortcuts, but for me the point of the time machine is in the ability to copy the git SHA of the currently displayed revision. So I find the revision which caused some change then I can explore further that revision outside of the time machine (author of the change, other files changed...) and send the link to other developers.

it might be even better to somehow open the commit using magit but I don't know how to do it, the ability to copy the git SHA is already pretty handy... and as I said basically a requirement for me.

there are two choices made in this commit: whether to copy the full or shortened SHA (i picked the full), and the key to use to copy (i picked y, the vim standard).