### PR TITLE
[WIP] new keybinding: <SPC> f F for opening the file under point

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1295,6 +1295,7 @@ Key Binding                               |                 Description
 ------------------------------------------|----------------------------------------------------------------
 <kbd>SPC f D</kbd>                        | delete a file and the associated buffer (ask for confirmation)
 <kbd>SPC f f</kbd>                        | open a file using `ido`
+<kbd>SPC f F</kbd>                        | open a file under point
 <kbd>SPC f j</kbd>                        | jump to the current buffer file in dired
 <kbd>SPC f o</kbd>                        | open a file using the default external program
 <kbd>SPC f s</kbd>                        | save a file

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -84,6 +84,7 @@
   "fed" 'find-dotfile
   "fev" 'spacemacs/display-and-copy-version
   "ff" 'ido-find-file
+  "fF" 'helm-find-files
   "fg" 'rgrep
   "fj" 'dired-jump
   "fo" 'spacemacs/open-in-external-app


### PR DESCRIPTION
Usually in VIM this is done with plain gf. But in conjunction with helm,
the behaviour is strange [1], since it doesn't go directly to the file,
but lists all candidates in the directory. So even better than the new
keybinding would be a remap of `gf` to `helm-find-files`.

[1]: https://groups.google.com/forum/#!topic/emacs-helm/Y-RKJGLxNu4