### PR TITLE
yasnippet layer use custom-set-variables #710

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2386,7 +2386,10 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
                 (let* ((dir (configuration-layer/get-layer-property 'spacemacs :ext-dir))
                        (private-yas-dir (concat configuration-layer-private-directory "snippets"))
                        (yas-dir (concat dir "yasnippet-snippets")))
-                  (setq yas-snippet-dirs (list  private-yas-dir yas-dir))
+                  (setq yas-snippet-dirs
+                        (append (when (boundp 'yas-snippet-dirs)
+                                  yas-snippet-dirs)
+                                (list  private-yas-dir yas-dir)))
                   (yas-global-mode 1)))))
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook


### PR DESCRIPTION
setq is overriding yas-snippet-dirs.  This changes it to custom-set-variables to prevent overriding user define.

I think this is the right way to do if from looking at other sections of the code.  Testing shows it works as expected too.