### PR TITLE
declare layers should not include hidden dirs

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -162,11 +162,12 @@ for that layer."
   (spacemacs/message "Looking for configuration layers in %s" dir)
   (ignore-errors
     (let ((files (directory-files dir nil nil 'nosort))
-          (filter-out (append configuration-layer-contrib-categories '("." "..")))
+          (filter-out configuration-layer-contrib-categories)
           result '())
       (dolist (f files)
         (when (and (file-directory-p (concat dir f))
-                   (not (member f filter-out)))
+                   (not (member f filter-out))
+                   (not (equalp ?. (aref f 0))))  ;; Remove hidden, traversal
           (spacemacs/message "-> Discovered configuration layer: %s" f)
           (push (cons (intern f) dir) result)))
       result)))


### PR DESCRIPTION
To prevent the .git directory from showing up when hitting "SPC f e h"
it should not be included.  Hiding all hidden directories is likely the
desired behavior, instead of just ignoring ".git".