### PR TITLE
SPC feh on spacemacs should load custom path

### DIFF
--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -100,10 +100,13 @@
 
 (defun helm-spacemacs//layer-action-open-file (file candidate)
   "Open FILE of the passed CANDIDATE."
-  (let ((path (file-name-as-directory
-               (concat (ht-get configuration-layer-paths
-                               (intern candidate))
-                       candidate))))
+  (let ((path (if (and (equalp file "README.md") (equalp candidate "spacemacs"))
+                  ;; Readme for spacemacs is in the project root
+                  (ht-get configuration-layer-paths (intern candidate))
+                (file-name-as-directory
+                 (concat (ht-get configuration-layer-paths
+                                 (intern candidate))
+                         candidate)))))
     (find-file (concat path file))))
 
 (defun helm-spacemacs//layer-action-open-readme (candidate)


### PR DESCRIPTION
The README.md file for spacemacs is not in the spacemacs directory, but in the project root.  This adds a special case for it.

For issue #698.