### PR TITLE
web-mode shortcuts

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -96,3 +96,31 @@ which require an initialization must be listed explicitly in the list.")
 (defun html/init-slim-mode ()
   (use-package slim-mode
     :defer t))
+
+(evil-leader/set-key-for-mode 'web-mode
+  "mgp" 'web-mode-element-parent
+  "mgc" 'web-mode-element-child
+  "mgb" 'web-mode-element-beginning
+  "mgn" 'spacemacs/html-navigation-micro-state
+  "mgs" 'web-mode-element-sibling-next
+  ;; v like 'View'
+  "mvx" 'web-mode-dom-xpath
+  "mve" 'web-mode-dom-errors-show
+  ;; i like 'Item'
+  "mir" 'web-mode-element-rename
+  "miw" 'web-mode-element-wrap
+  "mic" 'web-mode-element-clone
+  "mf" 'web-mode-fold-or-unfold
+  ;; TODO element close would be nice but broken with evil.
+  )
+
+(spacemacs|define-micro-state html-navigation
+  :doc "[N] previous [n] next [s] sibling [p] parent [c] child [q] quit"
+  :persistent t
+  :bindings
+  ("N" web-mode-element-previous)
+  ("n" web-mode-element-next)
+  ("s" web-mode-element-sibling-next)
+  ("p" web-mode-element-parent)
+  ("c" web-mode-element-child)
+  ("q" nil :exit t))

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -39,11 +39,20 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :config
     (progn
+
+      (defun web-mode-micro-state-doc ()
+        "Full documentation for web mode micro-state."
+        "
+  [?] display this help
+  [h] previous [l] next   [L] sibling [k] parent [j] child
+  [c] clone    [d] delete [r] rename  [w] wrap   [p] xpath
+  [q] quit")
+
       (evil-leader/set-key-for-mode 'web-mode
         "mgp" 'web-mode-element-parent
         "mgc" 'web-mode-element-child
         "mgb" 'web-mode-element-beginning
-        "mgn" 'spacemacs/html-navigation-micro-state
+        "m." 'spacemacs/web-mode-micro-state
         "mgs" 'web-mode-element-sibling-next
         "mhp" 'web-mode-dom-xpath
         "meu" 'web-mode-dom-errors-show
@@ -55,15 +64,21 @@ which require an initialization must be listed explicitly in the list.")
         ;; TODO element close would be nice but broken with evil.
         )
 
-      (spacemacs|define-micro-state html-navigation
-        :doc "[h] previous [l] next [L] sibling [k] parent [j] child [q] quit"
+      (spacemacs|define-micro-state web-mode
+        :doc "[?] for help"
         :persistent t
         :bindings
+        ("?" nil :doc (web-mode-micro-state-doc))
         ("h" web-mode-element-previous)
         ("l" web-mode-element-next)
         ("L" web-mode-element-sibling-next)
         ("k" web-mode-element-parent)
         ("j" web-mode-element-child)
+        ("p" web-mode-dom-xpath)
+        ("r" web-mode-element-rename)
+        ("d" web-mode-element-vanish)
+        ("w" web-mode-element-wrap)
+        ("c" web-mode-element-clone)
         ("q" nil :exit t))
       )
     :mode (("\\.phtml\\'"      . web-mode)

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -37,6 +37,35 @@ which require an initialization must be listed explicitly in the list.")
 (defun html/init-web-mode ()
   (use-package web-mode
     :defer t
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'web-mode
+        "mgp" 'web-mode-element-parent
+        "mgc" 'web-mode-element-child
+        "mgb" 'web-mode-element-beginning
+        "mgn" 'spacemacs/html-navigation-micro-state
+        "mgs" 'web-mode-element-sibling-next
+        "mhp" 'web-mode-dom-xpath
+        "meu" 'web-mode-dom-errors-show
+        "mrr" 'web-mode-element-rename
+        "mrd" 'web-mode-element-vanish
+        "mrw" 'web-mode-element-wrap
+        "mrc" 'web-mode-element-clone
+        "mf" 'web-mode-fold-or-unfold
+        ;; TODO element close would be nice but broken with evil.
+        )
+
+      (spacemacs|define-micro-state html-navigation
+        :doc "[h] previous [l] next [L] sibling [k] parent [j] child [q] quit"
+        :persistent t
+        :bindings
+        ("h" web-mode-element-previous)
+        ("l" web-mode-element-next)
+        ("L" web-mode-element-sibling-next)
+        ("k" web-mode-element-parent)
+        ("j" web-mode-element-child)
+        ("q" nil :exit t))
+      )
     :mode (("\\.phtml\\'"      . web-mode)
            ("\\.tpl\\.php\\'"  . web-mode)
            ("\\.html\\'"       . web-mode)
@@ -96,31 +125,3 @@ which require an initialization must be listed explicitly in the list.")
 (defun html/init-slim-mode ()
   (use-package slim-mode
     :defer t))
-
-(evil-leader/set-key-for-mode 'web-mode
-  "mgp" 'web-mode-element-parent
-  "mgc" 'web-mode-element-child
-  "mgb" 'web-mode-element-beginning
-  "mgn" 'spacemacs/html-navigation-micro-state
-  "mgs" 'web-mode-element-sibling-next
-  ;; v like 'View'
-  "mvx" 'web-mode-dom-xpath
-  "mve" 'web-mode-dom-errors-show
-  ;; i like 'Item'
-  "mir" 'web-mode-element-rename
-  "miw" 'web-mode-element-wrap
-  "mic" 'web-mode-element-clone
-  "mf" 'web-mode-fold-or-unfold
-  ;; TODO element close would be nice but broken with evil.
-  )
-
-(spacemacs|define-micro-state html-navigation
-  :doc "[N] previous [n] next [s] sibling [p] parent [c] child [q] quit"
-  :persistent t
-  :bindings
-  ("N" web-mode-element-previous)
-  ("n" web-mode-element-next)
-  ("s" web-mode-element-sibling-next)
-  ("p" web-mode-element-parent)
-  ("c" web-mode-element-child)
-  ("q" nil :exit t))


### PR DESCRIPTION
Based on the discusion from bug #736, I prepared this pull request.

I split the functions to map in 4 categories, helping myself from the grouping on http://web-mode.org and from the function names.

1. G -- navigation
2. V -- view
3. I -- item
4- fold (no category)

for view the natural naming would be D (dom) but it was taken by debugging. I also thought about S (show) but taken for Send to REPL.
for item the natural naming would be E (element) taken by evaluation or maybe T (tag) taken by tests. Item is a poor substitute but I could think of nothing better.

Fold I couldn't fit anywhere and I guess it's ok to have it as toplevel.. Maybe.

I made a navigation micro-state as suggested (great idea!) however I also left most individual motions also as I think sometimes you'll just want to get the parent... Although it's questionable possibly (putting the micro-state already at mg would make it quite ok maybe...).

finally I come from vim and was not familiar with web-mode and have no experience using it, so it's a first idea, I mapped the functions that seemed interesting at first sight, I'm sure the shortcuts will evolve with time.