### PR TITLE
when the shortcut was changed the timemachine description line was not updated

### DIFF
--- a/contrib/git/packages.el
+++ b/contrib/git/packages.el
@@ -160,7 +160,7 @@ which require an initialization must be listed explicitly in the list.")
           (when golden-ratio (golden-ratio-mode))))
 
       (spacemacs|define-micro-state time-machine
-        :doc "[p] [N] previous [n] next [c] current [y] copy hash [q] quit"
+        :doc "[p] [N] previous [n] next [c] current [Y] copy hash [q] quit"
         :on-enter (spacemacs//time-machine-ms-on-enter)
         :on-exit (git-timemachine-quit)
         :persistent t


### PR DESCRIPTION
It still printed "y" in the microstate description line.