### PR TITLE
ability for the user to specify a picture as a banner

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -25,13 +25,22 @@ Doge special banner can be reachable via `999', `doge' or `random*'.
                  ((eq 'doge dotspacemacs-startup-banner)
                   (spacemacs//get-banner-path 999))
                  ((integerp dotspacemacs-startup-banner)
-                  (spacemacs//get-banner-path dotspacemacs-startup-banner))))
+                  (spacemacs//get-banner-path dotspacemacs-startup-banner))
+                 ((string-match "\\.png\\'" dotspacemacs-startup-banner)
+                  dotspacemacs-startup-banner)))
         (buffer-read-only nil))
     (when banner
       (spacemacs/message (format "Banner: %s" banner))
-      (insert-file-contents banner)
-      (spacemacs//inject-version-in-buffer)
-      (spacemacs/insert-buttons)
+      (if (string-match "\\.png\\'" banner)
+          (progn
+            (insert "   ")
+            (insert-image (create-image banner))
+            (insert (format "%s" spacemacs-version))
+            (insert "\n"))
+        (progn
+          (insert-file-contents banner)
+          (spacemacs//inject-version-in-buffer)))
+        (spacemacs/insert-buttons)
       (spacemacs//redisplay))))
 
 (defun spacemacs//choose-random-banner (&optional all)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -41,7 +41,7 @@ Doge special banner can be reachable via `999', `doge' or `random*'.
           (insert-file-contents banner)
           (spacemacs//inject-version-in-buffer)))
         (spacemacs/insert-buttons)
-      (spacemacs//redisplay))))
+        (spacemacs//redisplay))))
 
 (defun spacemacs//choose-random-banner (&optional all)
   "Return the full path of a banner chosen randomly.


### PR DESCRIPTION
This patch allows the user to specify a picture as banner, they only have to give the path to the picture in their configuration.

I don't know how to center the picture in the display (may not be possible in the spacemacs major mode?).

I put a couple of spaces on the left of the picture because:
* it looks better
* if i don't do it after startup the picture is selected so emacs draws a frame around it and it doesn't look good.

Here's how it looks on my machine:
https://dl.dropboxusercontent.com/u/22600720/Screenshot%20from%202015-03-08%2016%3A59%3A13.png

I took the picture from there:
http://blog.anupamsg.me/2011/09/15/heretical-confessions-of-an-emacs-addict-joy-of-the-vim-text-editor/

I'm not sure about the copyright for that picture though. Anyway the patch only adds the option, does not add any picture to the tree.