### PR TITLE
added file-only and directory-only functions and helm-completion to fasd

### DIFF
--- a/contrib/fasd/README.md
+++ b/contrib/fasd/README.md
@@ -44,9 +44,9 @@ $ brew install fasd
 
 Key Binding                 |                 Description
 ----------------------------|------------------------------------------------------------------
-<kbd>SPC f z z</kbd>        | find a file or directory with fasd
-<kbd>SPC f z d</kbd>        | find a directory with fasd
-<kbd>SPC f z f</kbd>        | find a file with fasd
+<kbd>SPC f a s</kbd>        | find a file or directory with fasd
+<kbd>SPC f a d</kbd>        | find a directory with fasd
+<kbd>SPC f a f</kbd>        | find a file with fasd
 
 [fasd]: https://github.com/clvv/fasd
 [fasd-install]: https://github.com/clvv/fasd#install

--- a/contrib/fasd/README.md
+++ b/contrib/fasd/README.md
@@ -42,10 +42,11 @@ $ brew install fasd
 
 ## Keybindings
 
-Key Binding               |                 Description
---------------------------|------------------------------------------------------------------
-<kbd>SPC f z</kbd>        | find a file or directory with fasd
-<kbd>SPC u SPC f z</kbd>  | find a directory with fasd
+Key Binding                 |                 Description
+----------------------------|------------------------------------------------------------------
+<kbd>SPC f z z</kbd>        | find a file or directory with fasd
+<kbd>SPC f z d</kbd>        | find a directory with fasd
+<kbd>SPC f z f</kbd>        | find a file with fasd
 
 [fasd]: https://github.com/clvv/fasd
 [fasd-install]: https://github.com/clvv/fasd#install

--- a/contrib/fasd/packages.el
+++ b/contrib/fasd/packages.el
@@ -1,7 +1,6 @@
 (defvar fasd-packages
   '(
     fasd
-    ;; package fasds go here
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -9,19 +8,27 @@ which require an initialization must be listed explicitly in the list.")
 (defvar fasd-excluded-packages '()
   "List of packages to exclude.")
 
+(defun fasd-find-file-only ()
+  (interactive)
+  (fasd-find-file -1))
+
+(defun fasd-find-directory-only ()
+  (interactive)
+  (fasd-find-file 1))
+
 (defun fasd/init-fasd ()
   "initializes fasd-emacs and adds a key binding to <SPC f z>"
   (use-package fasd
     :init
     (progn
       (global-fasd-mode 1)
-      (evil-leader/set-key "fz" 'fasd-find-file))))
-;; For each package, define a function fasd/init-<package-fasd>
-;;
-;; (defun fasd/init-my-package ()
-;;   "Initialize my package"
-;;   )
-;;
-;; Often the body of an initialize function uses `use-package'
-;; For more info on `use-package', see readme:
-;; https://github.com/jwiegley/use-package
+      (spacemacs/declare-prefix "fz" "fasd-find")
+      (evil-leader/set-key "fzd" 'fasd-find-directory-only)
+      (evil-leader/set-key "fzf" 'fasd-find-file-only)
+      (evil-leader/set-key "fzz" 'fasd-find-file)
+
+      ;; we will fall back to using the default completing-read function, which is helm once helm is loaded.
+      (setq fasd-completing-read-function 'nil)
+      )
+    )
+  )

--- a/contrib/fasd/packages.el
+++ b/contrib/fasd/packages.el
@@ -22,10 +22,10 @@ which require an initialization must be listed explicitly in the list.")
     :init
     (progn
       (global-fasd-mode 1)
-      (spacemacs/declare-prefix "fz" "fasd-find")
-      (evil-leader/set-key "fzd" 'fasd-find-directory-only)
-      (evil-leader/set-key "fzf" 'fasd-find-file-only)
-      (evil-leader/set-key "fzz" 'fasd-find-file)
+      (spacemacs/declare-prefix "fa" "fasd-find")
+      (evil-leader/set-key "fad" 'fasd-find-directory-only)
+      (evil-leader/set-key "faf" 'fasd-find-file-only)
+      (evil-leader/set-key "fas" 'fasd-find-file)
 
       ;; we will fall back to using the default completing-read function, which is helm once helm is loaded.
       (setq fasd-completing-read-function 'nil)


### PR DESCRIPTION
This changes the completion-function to be the default completion function. I looked around for what the correct helm-completion function should be (as the default completion function is only helm once helm has been loaded, e.g. after `SPC :`) but couldn't find what I was looking for. Should I add something to the dependencies to make this load helm once it is loaded? (also, what is the correct way to do that? I assume it is something to do with use-package?)