### PR TITLE
Add support for helm-dash in dash layer

### DIFF
--- a/contrib/dash/README.md
+++ b/contrib/dash/README.md
@@ -50,20 +50,16 @@ on customizing specific docsets for modes.
 <kbd>SPC d d</kbd>  | Lookup thing at point in Dash
 <kbd>SPC d D</kbd>  | Lookup thing at point in Dash within a specified Docset
 
+### helm-dash
+dash-at-point is linked to the GUI app and is only available for OSX. On linux, 
+[helm-dash](https://github.com/areina/helm-dash) is used instead. It requires no app.
+You can use `dash/helm-dash-docset-newpath` to set the location path of your docsets.
+
 ## TODO
 
 ### Check zeal
 
 [zeal][] is an open source alternative to dash with Emacs integration available.
-
-### Check helm-dash
-
-dash-at-point is linked to the GUI app and is only available for OSX. Another
-project, [helm-dash](https://github.com/areina/helm-dash) is in the works.
-It appears to currently only be available for linux though, but working towards
-mac and windows support. It would be great to supplement or even replace
-dash-at-point considering that it doesn't require paying for the app, and
-integrates with helm.
 
 [dash]: http://kapeli.com/dash
 [dash-at-point]: https://github.com/stanaka/dash-at-point

--- a/contrib/dash/config.el
+++ b/contrib/dash/config.el
@@ -1,0 +1,2 @@
+(defvar dash/helm-dash-docset-newpath ""
+  "Activate docset path")

--- a/contrib/dash/funcs.el
+++ b/contrib/dash/funcs.el
@@ -1,0 +1,9 @@
+(defun dash/activate-package-docsets (root)
+  (progn
+    (setq helm-dash-docsets-path root)
+    (setq helm-dash-common-docsets (helm-dash-installed-docsets))
+
+    (message
+     (format "activated %d docsets from: %s"
+             (length helm-dash-common-docsets) root))
+))

--- a/contrib/dash/packages.el
+++ b/contrib/dash/packages.el
@@ -1,10 +1,13 @@
 (defvar dash-packages
-  '()
+   '()
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
 
 (if (system-is-mac)
     (push 'dash-at-point dash-packages))
+
+(if (system-is-linux)
+    (push 'helm-dash dash-packages))
 
 (defun dash/init-dash-at-point ()
   (use-package dash-at-point
@@ -12,3 +15,14 @@ which require an initialization must be listed explicitly in the list.")
     :init
     (evil-leader/set-key "dd" 'dash-at-point)
     (evil-leader/set-key "dD" 'dash-at-point-with-docset)))
+
+(defun dash/init-helm-dash ()
+  (use-package helm-dash
+    :commands helm-dash
+    :init
+      (evil-leader/set-key "dd" 'helm-dash-at-point)
+      (evil-leader/set-key "dD" 'helm-dash)
+    :config
+    (progn
+      (dash/activate-package-docsets dash/helm-dash-docset-newpath)
+     )))


### PR DESCRIPTION
I am not good at elisp so please review these changes.

I don't know why but the custom function `dash/activate-package-docsets` works ...
If you just `setq helm-dash-docsets-path` for the root it doesn't.
This trick is suggested here: https://github.com/jfeltz/dash-haskell

I don't know what happen if you don't set `dash/helm-dash-docset-newpath`.
Maybe this function should check if `root` is not an empty string and do nothing in that case ?

For information `dash-haskell` is what I use to generate my docset locally.

I hope the PR can serve as a base implementation.

Cheers.