### PR TITLE
added python compile command

### DIFF
--- a/contrib/lang/python/README.md
+++ b/contrib/lang/python/README.md
@@ -67,6 +67,13 @@ Send code to inferior process commands:
 <kbd>CTRL+j</kbd>     | next item in REPL history
 <kbd>CTRL+k</kbd>     | previous item in REPL history
 
+### Running Python Script in Comint Mode
+
+To run a Python script like you would in the shell
+press <kbd>SPC c C RET</kbd> to start the Python script in
+Comint mode. This is useful when working with multiple Python files
+since the REPL does not reload changes made in other modules.
+
 ### Testing in Python
 
 `Spacemacs` uses [nose][nose] as a test runner. An improved version of

--- a/contrib/lang/python/extensions.el
+++ b/contrib/lang/python/extensions.el
@@ -20,6 +20,7 @@
   '(
     nose
     pylookup
+    python-compile
     ))
 
 ;; Initialize the extensions
@@ -66,3 +67,25 @@
         (setq pylookup-dir (concat dir "/pylookup")
               pylookup-program (concat pylookup-dir "/pylookup.py")
               pylookup-db-file (concat pylookup-dir "/pylookup.db"))))))
+
+(defun python/init-python-compile ()
+   "Initialize Compile command for python buffers"
+   ;; set compile command to buffer-file-name
+   ;; if buffer-file-name exists
+   ;; otherwise error occurs on e.g. org export including python src
+   (add-hook 'python-mode-hook
+           (lambda ()
+             (set (make-local-variable 'compile-command)
+                  (if buffer-file-name
+                      (format "python %s" (file-name-nondirectory buffer-file-name))))))
+
+    (defadvice compile (before ad-compile-smart activate)
+    "Advises `compile' so it sets the argument COMINT to t
+    in `python-mode' files"
+    (when (derived-mode-p major-mode 'python-mode)
+        (save-excursion
+        (save-match-data
+            (goto-char (point-min))
+                ;; set COMINT argument to `t'.
+                (ad-set-arg 1 t)))))
+)


### PR DESCRIPTION

This makes using compile mode in python easier by doing the following:

- automatically changes compile command to
  ```python (buffer-file-name```
  for python buffers
- automatically starts comint mode in python mode to allow interaction
  with debugger

Fixes #805