### PR TITLE
[Fix #738] Display all parameters in the top line

### DIFF
--- a/contrib/lang/c-c++/README.md
+++ b/contrib/lang/c-c++/README.md
@@ -21,8 +21,9 @@ scripts.
 
 - Support syntax checking with Clang.
 - Display function or variable definition at the bottom.
-- Display current function cursor is in at the top.
-- Support common refactoring with [semantic-refactor][]. See [this page][demos]
+- Display current function cursor is in at the top. See [this page][stickyfunc-demos]
+for demos in some programming languages.
+- Support common refactoring with [semantic-refactor][]. See [this page][srefactor-demos]
 for demonstration of refactoring features.
 
 **This layer is not fully adapted for Spacemacs, it needs you, C/C++ experts, to
@@ -40,4 +41,5 @@ To use this contribution add it to your `~/.spacemacs`
 
 [CMake]: http://www.cmake.org/
 [semantic-refactor]: https://github.com/tuhdo/semantic-refactor
-[demos]: https://github.com/tuhdo/semantic-refactor/blob/master/srefactor-demos/demos.org
+[srefactor-demos]: https://github.com/tuhdo/semantic-refactor/blob/master/srefactor-demos/demos.org
+[stickyfunc-demos]: https://github.com/tuhdo/semantic-stickyfunc-enhance

--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -15,6 +15,7 @@
     cc-mode
     cmake-mode
     flycheck
+    stickyfunc-enhance
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -31,6 +32,7 @@ which require an initialization must be listed explicitly in the list.")
       (add-to-list 'semantic-default-submodes 'global-semantic-stickyfunc-mode)
       (add-to-list 'semantic-default-submodes 'global-semantic-idle-summary-mode)
       (semantic-mode 1)
+      (require 'stickyfunc-enhance)
       (c-toggle-auto-newline 1)
       (setq srecode-map-save-file (concat spacemacs-cache-directory "srecode-map.el"))
       (setq semanticdb-default-save-directory (concat spacemacs-cache-directory "semanticdb/")))))


### PR DESCRIPTION
This change allows semantic-sticky-func-mode to display parameters that
are scattered in many lines. This is done by overriding the default
semantic-stickyfunc-fetch-stickyline that only fetches the top line of
current semantic scope. The new version uses
semantic-tag-format-prototype to retrieve format string instead.