### PR TITLE
Add better support for persp-projectile

### DIFF
--- a/contrib/perspectives/config.el
+++ b/contrib/perspectives/config.el
@@ -1,0 +1,9 @@
+;;; config.el --- Git Layer configuration File for Spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+(defvar perspective-use-persp-projectile nil
+  "If non nil the helm-projectile-swtich-project command will create a new perspective for each new project.")

--- a/contrib/perspectives/packages.el
+++ b/contrib/perspectives/packages.el
@@ -16,8 +16,8 @@ which require an initialization must be listed explicitly in the list.")
                persp-set-buffer
                persp-kill
                persp-remove-buffer
-               persp-cycle-next
-               persp-cycle-prev
+               ;; persp-cycle-next
+               ;; persp-cycle-prev
                persp-rename
                persp-switch
                projectile-persp-bridge
@@ -58,11 +58,15 @@ which require an initialization must be listed explicitly in the list.")
            (persp-switch ,name)
            (when initialize ,@body)
            (setq persp-last current-perspective)))
+
+      (add-hook 'after-init-hook '(lambda ()
+                                    (persp-rename "@spacemacs")))
       ;; Jump to last perspective
       ;; taken from Magnar Sveen
       (defun custom-persp-last ()
         (interactive)
         (persp-switch (persp-name persp-last)))
+
       ;; (defun persp-cycle-next ()
       ;;   "Cycle throught the available perspectives."
       ;;   (interactive)
@@ -79,7 +83,24 @@ which require an initialization must be listed explicitly in the list.")
       ;;     (cond ((eq 1 list-size) (persp-switch nil))
       ;;           ((< next-pos 0) (persp-switch (nth (- list-size 1) (persp-all-names))))
       ;;           (t (persp-prev)))))
-      (eval-after-load 'persp-projectile
-        '(projectile-persp-bridge helm-projectile))
       )
+    ))
+
+(defun perspectives/init-persp-projectile ()
+  (use-package persp-projectile
+    :config
+    (when perspective-use-persp-projectile
+      (projectile-persp-bridge helm-projectile-switch-project)
+
+      (evil-leader/set-key
+        "ps" 'spacemacs/persp-switch-project)
+
+      (defun spacemacs/persp-switch-project ()
+        (interactive)
+        (evil-leader/set-key
+          "ps" 'helm-projectile-persp-switch-project)
+        (find-file "~/.spacemacs")
+        (helm-projectile-switch-project)
+        (persp-add-buffer "*spacemacs*")
+        (persp-kill "@spacemacs")))
     ))


### PR DESCRIPTION
Now the procedure to have persp-projectile is to first open the
dotspacemacs, or visit any file at startup and then use `SPC p s` to switch projects.

~~This is a BIG issue though, because if you don't visit any file when you do `SPC p s` the helm-projectile projects available is 'empty' for some weird reason, I can't get a backtrace, so if anyone knows sth about this plz PR :P~~

~~I know can withstand the fact that I have to open the dotfile first. (I could make a spacemacs/helm-persp-projectile function that find-file's the dotspacemacs and then runs helm-persp-projectile but that didn't seem like a clean solution. So I'm leaving it like this. If you don't mind that though. I guess it could be alright.~~