### PR TITLE
fixes python compile command

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -210,26 +210,21 @@ which require an initialization must be listed explicitly in the list.")
         "Execute a python script in a shell."
         (interactive "P")
         ;; set compile command to buffer-file-name
-        ;; if buffer-file-name exists
-        ;; otherwise error occurs on e.g. org export including python src
         ;; universal argument put compile buffer in comint mode
         (setq universal-argument t)
         (if arg
             (call-interactively 'compile)
-          (unless compile-command
             (setq compile-command (format "python %s" (file-name-nondirectory
-                                                       buffer-file-name))))
+                                                       buffer-file-name)))
           (compile compile-command t)))
 
       (defun spacemacs/python-execute-file-focus (arg)
         "Execute a python script in a shell and switch to the shell buffer in
 `insert state'."
         (interactive "P")
-        ;; set compile command to buffer-file-name
-        ;; if buffer-file-name exists
-        ;; otherwise error occurs on e.g. org export including python src
         (spacemacs/python-execute-file arg)
         (switch-to-buffer-other-window "*compilation*")
+        (end-of-buffer)
         (evil-insert-state))
 
       (evil-leader/set-key-for-mode 'python-mode

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -214,9 +214,12 @@ which require an initialization must be listed explicitly in the list.")
         (setq universal-argument t)
         (if arg
             (call-interactively 'compile)
+
             (setq compile-command (format "python %s" (file-name-nondirectory
                                                        buffer-file-name)))
-          (compile compile-command t)))
+            (compile compile-command t)
+            (with-current-buffer (get-buffer "*compilation*")
+              (inferior-python-mode))))
 
       (defun spacemacs/python-execute-file-focus (arg)
         "Execute a python script in a shell and switch to the shell buffer in


### PR DESCRIPTION
- now sets the compile command correctly if python buffers are switched and compile command was set already
- moves point to end of comint buffer when switching to it, useful if a breakpoint is set

related to issue #805 