### PR TITLE
Fix up some use-package forms

### DIFF
--- a/contrib/git/packages.el
+++ b/contrib/git/packages.el
@@ -277,7 +277,7 @@ which require an initialization must be listed explicitly in the list.")
       (define-key magit-status-mode-map (kbd "W") 'magit-toggle-whitespace))))
 
 (defun git/init-magit-gh-pulls ()
-  (use-package magit-gh-pulls ()
+  (use-package magit-gh-pulls
     :if git-enable-github-support
     :defer t
     :init (add-hook 'magit-mode-hook 'turn-on-magit-gh-pulls)

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2492,7 +2492,7 @@ displayed in the mode-line.")
 
 (defun spacemacs/init-volatile-highlights ()
   (use-package volatile-highlights
-    :init
+    :config
     (progn
       (volatile-highlights-mode t)
       (spacemacs|hide-lighter volatile-highlights-mode))))


### PR DESCRIPTION
- The `use-package` for magit-gh-pulls is malformed.
- The one for volatile-highlights attempts to enable the mode too early