### PR TITLE
(doc) CIDER requires nREPL minimum 0.2.7

### DIFF
--- a/contrib/lang/clojure/README.md
+++ b/contrib/lang/clojure/README.md
@@ -73,7 +73,8 @@ Or set this variable when loading the configuration layer:
 ```clj
 {:user {:plugins [[cider/cider-nrepl "0.9.0-SNAPSHOT"]
                   [refactor-nrepl "0.3.0-SNAPSHOT"]]
-        :dependencies [[alembic "0.3.2"]]}}
+        :dependencies [[alembic "0.3.2"]
+                       [org.clojure/tools.nrepl "0.2.7"]]}}
 ```
 
 #### More details


### PR DESCRIPTION
CIDER requires a minimum nREPL version of 0.2.7 (see clojure-emacs/cider#970)