### PR TITLE
Load volatile-highlights-mode

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2462,7 +2462,8 @@ displayed in the mode-line.")
 
 (defun spacemacs/init-volatile-highlights ()
   (use-package volatile-highlights
-    :config
+    :commands volatile-highlights-mode
+    :init
     (progn
       (volatile-highlights-mode t)
       (spacemacs|hide-lighter volatile-highlights-mode))))


### PR DESCRIPTION
Currently it's been switched from being loaded at `:init` -> `:config`

I'm guessing this was done since recently volatile-highlights-mode is no
longer an autoloaded function. If your intention is to keep around
volatile-highlights-mode, you should add it as an autoloaded function
with `:commands` and call it during `:init`.

With the current setup, I don't think the mode is ever enabled.