### PR TITLE
Cannot hide GUI elements unless in GUI emacs!

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -82,10 +82,12 @@ initialization."
     (setq-default spacemacs--cur-theme default-theme)
     (setq-default spacemacs--cycle-themes (cdr dotspacemacs-themes)))
   ;; removes the GUI elements
-  (unless (or (not (boundp 'tool-bar-mode)) (eq tool-bar-mode -1))
-    (tool-bar-mode -1))
-  (unless (or (not (boundp 'scroll-bar-mode)) (eq scroll-bar-mode -1))
-    (scroll-bar-mode -1))
+  (if window-system
+    (progn 
+      (unless (or (not (boundp 'tool-bar-mode)) (eq tool-bar-mode -1))
+        (tool-bar-mode -1))
+      (unless (or (not (boundp 'scroll-bar-mode)) (eq scroll-bar-mode -1))
+        (scroll-bar-mode -1))))
   ;; tooltips in echo-aera
   (unless (or (not (boundp 'tooltip-mode)) (eq tooltip-mode -1))
     (tooltip-mode -1))


### PR DESCRIPTION
I updated my spacemacs install to 0.100.0 & when I opened a new (terminal) emacs I got a blank screen except for a menu bar across the top, and no vi key behaviour.  I thought this might be an incompatibility with something I configured so I nuked my emacs.d directory and did a completely clean install of 0.100.0, I did not add my changes; after a successful bootstrap I still got a blank buffer. 

I ran `emacs --debug-init` and got the following error:

```
Debugger entered--Lisp error: (void-function tool-bar-mode)
  (tool-bar-mode -1)
  (if (or (not (boundp (quote tool-bar-mode))) (eq tool-bar-mode -1)) nil (tool-bar-mode -1))
  spacemacs/init()
  (progn (load-file (concat user-emacs-directory "core/core-load-paths.el")) (require (quote core-spacemacs)) (require (quote core-configuration-layer)) (spacemacs/init) (configuration-layer/sync) (spacemacs/setup-after-init-hook) (require (quote server)) (if (server-running-p) nil (server-start)))
  (if (spacemacs/emacs-version-ok) (progn (load-file (concat user-emacs-directory "core/core-load-paths.el")) (require (quote core-spacemacs)) (require (quote core-configuration-layer)) (spacemacs/init) (configuration-layer/sync) (spacemacs/setup-after-init-hook) (require (quote server)) (if (server-running-p) nil (server-start))))
  eval-buffer(#<buffer  *load*> nil "/Users/matthewdenner/.emacs.d/init.el" nil t)  ; Reading at buffer position 876
  load-with-code-conversion("/Users/matthewdenner/.emacs.d/init.el" "/Users/matthewdenner/.emacs.d/init.el" t t)
  load("/Users/matthewdenner/.emacs.d/init" t t)
  #[0 "\205\262	\306=\203\307\310Q\202;	\311=\204\307\312Q\202;\313\307\314\315#\203*\316\202;\313\307\314\317#\203:\320\nB\321\202;\316\322\323\322\211#\210\322=\203a\324\325\326\307\327Q!\"\323\322\211#\210\322=\203`\210\203\243\330!\331\232\203\243\332!\211\333P\334!\203}\211\202\210\334!\203\207\202\210\314\262\203\241\335\"\203\237\336\337#\210\340\341!\210\266\f?\205\260\314\323\342\322\211#)\262\207" [init-file-user system-type delayed-warnings-list user-init-file inhibit-default-init inhibit-startup-screen ms-dos "~" "/_emacs" windows-nt "/.emacs" directory-files nil "^\\.emacs\\(\\.elc?\\)?$" "~/.emacs" "^_emacs\\(\\.elc?\\)?$" (initialization "`_emacs' init file is deprecated, please use `.emacs'") "~/_emacs" t load expand-file-name "init" file-name-as-directory "/.emacs.d" file-name-extension "elc" file-name-sans-extension ".el" file-exists-p file-newer-than-file-p message "Warning: %s is newer than %s" sit-for 1 "default"] 7 "\n\n(fn)"]()
  command-line()
  normal-top-level()
```

I think this is because I run with a terminal emacs, not a GUI version on OS X.  I wrapped the GUI element removal behind a `window-system` check and everything looks good so far.