### PR TITLE
Fix ess autoload hack for use-package 2.0

### DIFF
--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -34,10 +34,10 @@ which require an initialization must be listed explicitly in the list.")
   ;; keybinding)
   (defun load-ess-on-demand ()
     (interactive)
-    (-all? '---truthy? (list
-                        (use-package ess-site)
-                        (use-package ess-R-object-popup)
-                        (use-package ess-R-data-view))))
+    (-all? '---truthy? (-map 'not (list
+                                   (use-package ess-site)
+                                   (use-package ess-R-object-popup)
+                                   (use-package ess-R-data-view)))))
 
   (evil-leader/set-key "ess" 'load-ess-on-demand)
 


### PR DESCRIPTION
This is a fix for the ess autoload hack for use-package 2.0. In 2.0, the
semantics of the returned value have been reversed, so `t` is an
unsuccessfully loaded package, and `nil` is a successfully loaded
package.