### PR TITLE
Declare floobits prefix description

### DIFF
--- a/contrib/floobits/packages.el
+++ b/contrib/floobits/packages.el
@@ -21,6 +21,7 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init
     (progn
+      (spacemacs/declare-prefix "P" "PP/floobits")
 
       (defun spacemacs/floobits-rclocation ()
         "Return the absolute path to the floobits dotfile."


### PR DESCRIPTION
avoids the unhelpful "Prefix Command" when you simply press <SPC> and wait... 