### PR TITLE
Disable vim-empty-lines activation under `org-mode`.

### DIFF
--- a/contrib/vim-empty-lines/README.md
+++ b/contrib/vim-empty-lines/README.md
@@ -13,6 +13,13 @@ the fringe. The indicator behaviour with trailing empty lines matches
 
 For details, see the [vim-empty-lines-mode][] repository.
 
+## Known Incompatibilities
+- Company-mode
+When the company completion overlay occurs on the last line of the buffer, the cursor position is bugged. Functionality remains.
+
+- Org-mode
+Weird undocumented bugs with `normal-mode` operators, such as `G` or `o`. Currently disabled for this mode, as functionality breaks.
+
 ## Install
 
 To use this contribution add it to your `~/.spacemacs`.

--- a/contrib/vim-empty-lines/packages.el
+++ b/contrib/vim-empty-lines/packages.el
@@ -12,5 +12,6 @@
                                           erlang-mode-hook
                                           text-mode-hook
                                           ess-mode-hook))
+    (add-hook 'org-mode-hook (lambda () (vim-empty-lines-mode -1)))
     :config
     (spacemacs|hide-lighter vim-empty-lines-mode)))


### PR DESCRIPTION
Add incompatibility documentation to README.