### PR TITLE
Add keybinding for balance-windows

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -256,7 +256,8 @@
   "wv"  'split-window-right
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
-  "w/"  'split-window-right)
+  "w/"  'split-window-right
+  "w="  'balance-windows)
 ;; text -----------------------------------------------------------------------
 (evil-leader/set-key
   "zx="  'spacemacs/reset-font-size


### PR DESCRIPTION
Normally bound to `C-w =` in Emacs, this commit adds it to Spacemacs as
`SPC w =`.