### PR TITLE
Use correct spacemacs cache directory for irc logs

### DIFF
--- a/contrib/rcirc/packages.el
+++ b/contrib/rcirc/packages.el
@@ -142,9 +142,9 @@ which require an initialization must be listed explicitly in the list.")
           (insert (emms-track-description (emms-playlist-current-selected-track))))
         (define-key rcirc-mode-map (kbd "C-c C-e") 'rcirc/insert-current-emms-track))
 
-      ;; Minimal logging to `~/.rcirc-logs/channel'
+      ;; Minimal logging to `~/.emacs.d/.cache/rcirc-logs/'
       ;; by courtesy of Trent Buck.
-      (setq rcirc-log-directory "~/.emacs/.cache/rcirc-logs/")
+      (setq rcirc-log-directory (concat spacemacs-cache-directory "/rcirc-logs/"))
       (setq rcirc-log-flag t)
       (defun rcirc-write-log (process sender response target text)
         (when rcirc-log-directory


### PR DESCRIPTION
Use `spacemacs-cache-directory` for irc logs, rather than
`~/.emacs/.cache/rcirc-logs` which looks incorrect (`.emacs` vs
`.emacs.d`), and should not be hardcoded.