### PR TITLE
Fix for flycheck-haskell-setup autoload

### DIFF
--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -22,7 +22,7 @@
     shm
     ))
 
-(defun haskell/init-flycheck ()
+(defun haskell/init-flycheck-haskell ()
   (add-hook 'haskell-mode-hook 'flycheck-mode)
   (add-hook 'flycheck-mode-hook 'flycheck-haskell-setup)
   (setq flycheck-display-errors-delay 0))


### PR DESCRIPTION
I get the following backtrace after starting any mode that includes
flycheck initialization:

Debugger entered--Lisp error: (void-function flycheck-haskell-setup)
  flycheck-haskell-setup()
  run-hooks(flycheck-mode-hook flycheck-mode-on-hook)
  flycheck-mode()
  run-hooks(change-major-mode-after-body-hook prog-mode-hook python-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook prog-mode-hook python-mode-hook))
  run-mode-hooks(python-mode-hook)
  python-mode()
  set-auto-mode-0(python-mode nil)
  set-auto-mode()
  normal-mode(t)
  after-find-file(nil t)
  find-file-noselect-1(#<buffer setup.py> "~/projects/fast-regression-testing/data/packages/libgcrypt-commits-pkg/setup.py" nil nil "~/projects/fast-regression-testing/data/packages/libgcrypt-commits-pkg/setup.py" (11679577 2052))
  find-file-noselect("/home/jcp/projects/fast-regression-testing/data/packages/libgcrypt-commits-pkg/setup.py" nil nil nil)
  find-file("/home/jcp/projects/fast-regression-testing/data/packages/libgcrypt-commits-pkg/setup.py")
  find-file-at-point("/home/jcp/projects/fast-regression-testing/data/packages/libgcrypt-commits-pkg/setup.py")
  helm-find-file-or-marked("/home/jcp/projects/fast-regression-testing/data/packages/libgcrypt-commits-pkg/setup.py")
  ...
  ABBREVIATED HELM BACKTRACE
  ...
  helm-find-files-1("/home/jcp/" nil)
  helm-find-files(nil)
  call-interactively(helm-find-files nil nil)
  command-execute(helm-find-files)

By moving the `flycheck-mode-hook` manipulation to
`haskell/init-flycheck-haskell`, I no longer get this error. Honestly I'm a little puzzled as to why this fixes it.