### PR TITLE
[Fix #661] Add highlight-numbers

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -78,6 +78,7 @@
     helm-swoop
     helm-themes
     highlight
+    highlight-numbers
     hippie-exp
     hl-anything
     hungry-delete
@@ -1549,6 +1550,14 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init
     (evil-leader/set-key "Th" 'helm-themes)))
+
+(defun spacemacs/init-highlight-numbers ()
+  (use-package highlight-numbers
+    :defer t
+    :init
+    (progn
+      (add-hook 'prog-mode-hook 'highlight-numbers-mode)
+      (add-hook 'asm-mode-hook (lambda () (highlight-numbers-mode -1))))))
 
 (defun spacemacs/init-hippie-exp ()
   (global-set-key (kbd "M-/") 'hippie-expand) ;; replace dabbrev-expand


### PR DESCRIPTION
However, disable it in asm-mode since some hex numbers in asm-mode do
not have 0x before them, so the highlighting is random, i.e. a decimal
number like 01 can be highlighted but not ff or e9.