### PR TITLE
[Fix #878] Add flycheck-pos-tip

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -59,6 +59,7 @@
     fish-mode
     flx-ido
     flycheck
+    flycheck-pos-tip
     flyspell
     ;; required for update
     gh
@@ -1168,7 +1169,13 @@ which require an initialization must be listed explicitly in the list.")
       (evil-leader/set-key
         "ec" 'flycheck-clear
         "ef" 'flycheck-mode
-        "el" 'flycheck-list-errors))))
+        "el" 'flycheck-list-errors)
+
+      ;; flycheck-pos-tip
+      (use-package flycheck-pos-tip
+        :defer t
+        :init
+        (setq flycheck-display-errors-function #'flycheck-pos-tip-error-messages)))))
 
 (defun spacemacs/init-flyspell ()
   (use-package flyspell


### PR DESCRIPTION
So flycheck won't have to rely on the minibuffer to display its error
messages anymore, and won't conflict with modes like el-doc or
semantic-idle-summary-mode that displays useful information in the
minibuffer.