### PR TITLE
Fix bad Markdown markup in private/README

### DIFF
--- a/private/README.md
+++ b/private/README.md
@@ -5,7 +5,7 @@ where to store your private configuration layers.
 
 To create a new configuration layer:
 
-    `<SPC> : configuration-layer/create-layer RET`
+    <SPC> : configuration-layer/create-layer RET
 
 Then enter the name of your configuration in the prompt.
 


### PR DESCRIPTION
A four-space indent is enough to mark the contents as code. Adding <code>\`</code><code>\`</code> just makes the code itself contain <code>\`</code><code>\`</code>.