### PR TITLE
add material theme to themes megapack

### DIFF
--- a/contrib/themes-megapack/packages.el
+++ b/contrib/themes-megapack/packages.el
@@ -49,6 +49,7 @@
     leuven-theme
     light-soap-theme
     lush-theme
+    material-theme
     minimal-theme
     moe-theme
     molokai-theme


### PR DESCRIPTION
add the https://github.com/cpaulik/emacs-material-theme to the themes megapack. Should work since it is based on the spacegray theme