### PR TITLE
Don't refer to ~/.emacs.d/ directly.

### DIFF
--- a/contrib/perspectives/packages.el
+++ b/contrib/perspectives/packages.el
@@ -28,7 +28,7 @@ which require an initialization must be listed explicitly in the list.")
       (defun custom-persp/emacs ()
         (interactive)
         (custom-persp ".emacs.d"
-                      (find-file "~/.emacs.d/init.el")))
+                      (find-file (locate-user-emacs-file "init.el"))))
 
       (defun custom-persp/org ()
         (interactive)

--- a/contrib/rcirc/packages.el
+++ b/contrib/rcirc/packages.el
@@ -118,7 +118,7 @@ which require an initialization must be listed explicitly in the list.")
       (defun spacemacs/rcirc-notify-beep (msg)
         "Beep when notifying."
         (let ((player "mplayer")
-              (sound "~/.emacs.d/site-misc/startup.ogg"))
+              (sound (concat user-emacs-directory "/site-misc/startup.ogg")))
           (when (and (executable-find player)
                      (file-exists-p sound)))
           (start-process "beep-process" nil player sound)))

--- a/contrib/ycmd/packages.el
+++ b/contrib/ycmd/packages.el
@@ -21,7 +21,7 @@ which require an initialization must be listed explicitly in the list.")
       ;; define excplicitly the hooks here
       (add-hook 'c++-mode-hook 'ycmd-mode)
       (setq-default ycmd-global-config
-                    (expand-file-name "~/.emacs.d/contrib/ycmd/global_conf.py"))
+                    (expand-file-name (concat user-emacs-directory "/contrib/ycmd/global_conf.py")))
       (evil-leader/set-key-for-mode 'c++-mode
         "mgg" 'ycmd-goto
         "mgG" 'ycmd-goto-imprecise))))

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -427,7 +427,7 @@ which require an initialization must be listed explicitly in the list.")
   (use-package bookmark
     :defer t
     :init
-    (setq bookmark-default-file "~/.emacs.d/bookmarks" ; keep my ~/ clean
+    (setq bookmark-default-file (concat user-emacs-directory "/bookmarks") ; keep my ~/ clean
           bookmark-save-flag 1)))                      ; autosave each change
 
 (defun spacemacs/init-buffer-move ()
@@ -2369,7 +2369,7 @@ displayed in the mode-line.")
                                            (recentf-track-opened-file))))
     :config
     (progn
-      (setq recentf-exclude '("~/.emacs.d/.cache"))
+      (setq recentf-exclude `(,(concat user-emacs-directory ".cache")))
       (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
       (setq recentf-save-file (concat spacemacs-cache-directory "/recentf"))
       (setq recentf-max-saved-items 100)


### PR DESCRIPTION
This is mostly a style thing, since I think it would probably be a lot
of effort getting spacemacs working on windows smoothly. But it is also
a first step towards a "try out spacemacs" script that doesn't require
someone to move their `~/.emacs.d` around.