### PR TITLE
Add info+ to improve Info reading experience

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -85,6 +85,7 @@
     hl-anything
     hungry-delete
     ido-vertical-mode
+    info+
     iedit
     let-alist
     leuven-theme
@@ -1773,6 +1774,14 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
 (defun spacemacs/init-iedit ()
   (use-package iedit
     :defer t))
+
+(defun spacemacs/init-info+ ()
+  (use-package info
+    :commands (info Info-mode)
+    :config
+    (use-package info+
+      :config
+      (setq Info-fontify-angle-bracketed-flag nil))))
 
 (defun spacemacs/init-leuven-theme ()
   (use-package leuven-theme


### PR DESCRIPTION
Important keywords are highlighted, so when we open an Info page we immediately have an overview of important concepts. With Info+ it looks like this:

![image](https://cloud.githubusercontent.com/assets/4818719/6765707/83390e06-d01e-11e4-9015-c20ef4442691.png)
