### PR TITLE
Add example of evil-leader/set-key for new users

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -993,6 +993,8 @@ It is possible to change this key with the variable `dotspacemacs-leader-key`.
 `<SPC> o` is **guaranteed** to never conflict with `Spacemacs` defaults key
 bindings.
 
+Example: Put `(evil-leader/set-key "oc" 'org-capture)` inside `dotspacemacs/config` in your `~/.spacemacs` file, to be able to use `SPC o c` to run org mode capture.
+
 ## Helm
 
 `Spacemacs` is powered by [Helm][helm-link] which is an incremental completion


### PR DESCRIPTION
Since using `global-set-key` results in a `Key sequence SPC o c starts with non-prefix key SPC` error.