### PR TITLE
[Fix #890] Improve editing functionality for holy-mode

### DIFF
--- a/spacemacs/extensions/holy-mode/holy-mode.el
+++ b/spacemacs/extensions/holy-mode/holy-mode.el
@@ -82,3 +82,28 @@ The `insert state' is replaced by the `emacs state'."
   (setq evil-motion-state-modes holy-mode-motion-state-modes-backup)
   ;; (set-default-evil-emacs-state-cursor)
   (evil-normal-state))
+
+(defun smart-move-beginning-of-line (arg)
+  "Move point back to indentation of beginning of line.
+Move point to the first non-whitespace character on this line.
+If point is already there, move to the beginning of the line.
+Effectively toggle between the first non-whitespace character and
+the beginning of the line.
+If ARG is not nil or 1, move forward ARG - 1 lines first. If
+point reaches the beginning or end of the buffer, stop there."
+  (interactive "^p")
+  (setq arg (or arg 1))
+  ;; Move lines first
+  (when (/= arg 1)
+    (let ((line-move-visual nil))
+      (forward-line (1- arg))))
+  (let ((orig-point (point)))
+    (back-to-indentation)
+    (when (= orig-point (point))
+      (move-beginning-of-line 1))))
+
+;; holy-mode specific key bindings
+(global-set-key (kbd "C-a") 'smart-move-beginning-of-line)
+(evil-leader/set-key
+  "jo" 'evil-open-below
+  "jO" 'evil-open-above)

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -167,6 +167,28 @@ the current state and point position."
       (sp-newline)
       (setq counter (1- counter)))))
 
+
+;; from Prelude
+(defcustom spacemacs-indent-sensitive-modes
+  '(coffee-mode python-mode slim-mode haml-mode yaml-mode
+                makefile-mode makefile-gmake-mode makefile-imake-mode makefile-bsdmake-mode)
+  "Modes for which auto-indenting is suppressed."
+  :type 'list)
+
+(defun spacemacs/indent-region-or-buffer ()
+  "Indent a region if selected, otherwise the whole buffer."
+  (interactive)
+  (unless (member major-mode spacemacs-indent-sensitive-modes)
+    (save-excursion
+      (if (region-active-p)
+          (progn
+            (indent-region (region-beginning) (region-end))
+            (message "Indented selected region."))
+        (progn
+          (evil-indent (point-min) (point-max))
+          (message "Indented buffer.")))
+      (whitespace-cleanup))))
+
 ;; from magnars
 (defun eval-and-replace ()
   "Replace the preceding sexp with its value."

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -106,8 +106,10 @@
 ;; <SPC> J split the current line at point and indent it
 (evil-leader/set-key
   "J"  'sp-split-sexp
+  "jj" 'evil-join
   "jJ" 'spacemacs/split-and-new-line
-  "jj" 'sp-newline
+  "jn" 'sp-newline
+  "ji" 'spacemacs/indent-region-or-buffer
   "jk" 'evil-goto-next-line-and-indent)
 ;; navigation -----------------------------------------------------------------
 (evil-leader/set-key


### PR DESCRIPTION
Add:

- Key binding for evil-join for both evil/holy-mode.
- A command for indenting whole buffer and a key binding in both
evil/holy-mode.
- A smart beginning of line for holy-mode.