### PR TITLE
Disable popwin-mode when a Helm session is active

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1353,6 +1353,14 @@ which require an initialization must be listed explicitly in the list.")
                   (unless (configuration-layer/package-declaredp 'smex)
                     (evil-leader/set-key dotspacemacs-command-key 'helm-M-x))))
 
+      ;; disable popwin-mode in an active Helm session It should be disabled
+      ;; otherwise it will conflict with other window opened by Helm persistent
+      ;; action, such as *Help* window.
+      (add-hook 'helm-after-initialize-hook (lambda () (popwin-mode -1)))
+
+      ;;  Restore popwin-mode after a Helm session finishes.
+      (add-hook 'helm-cleanup-hook (lambda () (popwin-mode 1)))
+
       (defun spacemacs//helm-before-initialize ()
         "Stuff to do before helm initializes."
         ;; be sure that any previous micro-state face override are


### PR DESCRIPTION
In many Helm commands, persistent action may open another window to
temporary view its content. For example, execute persistent action in
helm-M-x open a *Help* window for that command. Unfortunately, if
popwin-mode is active, the temporary *Help* buffer is opened below and
Helm's *Help* buffer is opened above by Helm, both show the same
content. Another command is helm-apropos. Since all Helm windows are
effectively temporary already, we do not need popwin in action anymore.