### PR TITLE
Last `spacemacs/activate-evil-leader-for-map` call to remove.

### DIFF
--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -127,7 +127,7 @@ the focus."
         (cider-switch-to-repl-buffer)
         (evil-insert-state))
 
-      (spacemacs/activate-evil-leader-for-map 'cider-stacktrace-mode-map)
+      (evilify cider-stacktrace-mode cider-stacktrace-mode-map)
       (evil-leader/set-key-for-mode 'clojure-mode
         "mdd" 'cider-doc
         "mdg" 'cider-grimoire


### PR DESCRIPTION
Everything should use the `evilify` macro now.