### PR TITLE
[up] and [down] in shell to go to cycle through previous commands

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -418,5 +418,5 @@ Ensure that helm is required before calling FUNC."
 
 (eval-after-load "shell"
   '(progn
-    (define-key comint-mode-map [up] 'comint-previous-input)
-    (define-key comint-mode-map [down] 'comint-next-input)))
+    (evil-define-key 'insert comint-mode-map [up] 'comint-previous-input)
+    (evil-define-key 'insert comint-mode-map [down] 'comint-next-input)))

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -413,3 +413,10 @@ Ensure that helm is required before calling FUNC."
   ("w" other-window                          :doc (spacemacs//window-manipulation-move-doc)))
 
 ;; end of Window Manipulation Micro State
+
+;; shell ----------------------------------------------------------------------
+
+(eval-after-load "shell"
+  '(progn
+    (define-key comint-mode-map [up] 'comint-previous-input)
+    (define-key comint-mode-map [down] 'comint-next-input)))


### PR DESCRIPTION
Allow [up] and [down] to cycle through history in `shell-mode`