### PR TITLE
Propose new ace-window key and key sequence

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -169,10 +169,13 @@ which require an initialization must be listed explicitly in the list.")
   (use-package ace-window
     :defer t
     :init
-    (evil-leader/set-key
-      "bM"  'ace-swap-window
-      "wC"  'ace-delete-window
-      "wW"  'ace-window)
+    (progn
+      (evil-leader/set-key
+        "bM"  'ace-swap-window
+        "wC"  'ace-delete-window
+        "w <SPC>"  'ace-window)
+      ;; set ace-window keys to home-row
+      (setq aw-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l)))
     :config
     (progn
       ;; add support for golden-ratio


### PR DESCRIPTION
`w SPC` is easier than `w W` and more consistent with using SPC like on other `ace` commands.

Set ace-window keys to home row to prevent needing to go to number row.