### PR TITLE
Make adding company backends easier

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -50,12 +50,7 @@ which require an initialization must be listed explicitly in the list.")
     :mode (("CMakeLists\\.txt\\'" . cmake-mode) ("\\.cmake\\'" . cmake-mode))
     :init
     (progn
-      (spacemacs|reset-local-company-backends cmake-mode)
-      (defun spacemacs//cmake-company-backend ()
-        "Add cmake company backend."
-        (push (spacemacs/company-backend-with-yas 'company-cmake)
-              company-backends))
-      (add-hook 'cmake-mode-hook 'spacemacs//cmake-company-backend t))))
+      (spacemacs|add-mode-company-backend cmake-mode company-cmake))))
 
 (defun c-c++/init-company ()
   ;; .clang_complete file loading
@@ -107,14 +102,8 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init
     (progn
-      (spacemacs|reset-local-company-backends c-mode)
-      (spacemacs|reset-local-company-backends c++-mode)
-      (defun spacemacs//c-headers-company-backend ()
-        "Add c-headers company backend."
-        (push (spacemacs/company-backend-with-yas 'company-c-headers)
-              company-backends))
-      (add-hook 'c-mode-hook 'spacemacs//c-headers-company-backend t)
-      (add-hook 'c++-mode-hook 'spacemacs//c-headers-company-backend t))))
+      (spacemacs|add-mode-company-backend c-mode company-c-headers)
+      (spacemacs|add-mode-company-backend c++-mode company-c-headers))))
 
 (defun c-c++/init-flycheck ()
   (add-to-hooks 'flycheck-mode '(c-mode-hook c++-mode-hook)))
@@ -139,4 +128,3 @@ which require an initialization must be listed explicitly in the list.")
         (require 'stickyfunc-enhance))
       (add-to-hooks 'spacemacs/lazy-load-stickyfunc-enhance
                     '(c-mode-hook c++-mode-hook)))))
-

--- a/contrib/lang/csharp/packages.el
+++ b/contrib/lang/csharp/packages.el
@@ -60,7 +60,4 @@
               "mi" 'omnisharp-fix-usings
               "m=" 'omnisharp-code-format
 
-    ;; Init omnisharp company backend
-    (eval-after-load 'company
-      '(add-to-list 'company-backends 'company-omnisharp))
-    ))
+    (spacemacs|add-mode-company-backend csharp-mode company-omnisharp)))

--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -147,9 +147,4 @@ not play nicely with autoloads"
     :defer t
     :init
     (progn
-      (spacemacs|reset-local-company-backends ess-mode)
-      (defun spacemacs//ess-company-backend ()
-        "Add ESS company backend."
-        (push (spacemacs/company-backend-with-yas 'company-ess-backend)
-              company-backends))
-      (add-hook 'ess-mode-hook 'spacemacs//ess-company-backend t))))
+      (spacemacs|add-mode-company-backend ess-mode company-ess-backend))))

--- a/contrib/lang/go/packages.el
+++ b/contrib/lang/go/packages.el
@@ -45,8 +45,4 @@ which require an initialization must be listed explicitly in the list.")
    :defer t
    :init
    (progn
-     (spacemacs|reset-local-company-backends go-mode)
-     (defun spacemacs//go-company-backend ()
-       (push (spacemacs/company-backend-with-yas 'company-go)
-             company-backends))
-   (add-hook 'go-mode-hook 'spacemacs//go-company-backend t))))
+     (spacemacs|add-mode-company-backend go-mode company-go))))

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -226,12 +226,7 @@
     :defer t
     :init
     (progn
-      (spacemacs|reset-local-company-backends haskell-mode)
-      (defun spacemacs//ghc-company-backend ()
-        "Add GHC company backend."
-        (push (spacemacs/company-backend-with-yas 'company-ghc)
-              company-backends))
-      (add-hook 'haskell-mode-hook 'spacemacs//ghc-company-backend t))))
+      (spacemacs|add-mode-company-backend haskell-mode company-ghc))))
 
 (defun haskell/init-hi2 ()
   (use-package hi2

--- a/contrib/lang/javascript/packages.el
+++ b/contrib/lang/javascript/packages.el
@@ -169,10 +169,4 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init
     (progn
-      (spacemacs|reset-local-company-backends tern-mode)
-      (defun spacemacs//tern-company-backend ()
-        "Add tern company backend."
-        (push (spacemacs/company-backend-with-yas 'company-tern)
-              company-backends))
-      (add-hook 'tern-mode-hook 'spacemacs//tern-company-backend t))))
-
+      (spacemacs|add-mode-company-backend tern-mode company-tern))))

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -60,12 +60,7 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init
     (progn
-      (spacemacs|reset-local-company-backends python-mode)
-      (defun spacemacs//anaconda-company-backend ()
-        "Add anaconda company backend."
-        (push (spacemacs/company-backend-with-yas 'company-anaconda)
-              company-backends))
-      (add-hook 'python-mode-hook 'spacemacs//anaconda-company-backend t))))
+      (spacemacs|add-mode-company-backend python-mode company-anaconda))))
 
 (defun python/init-cython-mode ()
   (use-package cython-mode

--- a/contrib/ycmd/packages.el
+++ b/contrib/ycmd/packages.el
@@ -30,7 +30,10 @@ which require an initialization must be listed explicitly in the list.")
 (defun ycmd/init-company-ycmd ()
   (use-package company-ycmd
     :defer t
-    :init (add-hook 'ycmd-mode-hook 'company-ycmd-setup)))
+    :init
+    (progn
+      (spacemacs|add-mode-company-backend c-mode company-ycmd)
+      (spacemacs|add-mode-company-backend c++-mode company-ycmd))))
 
 (defun ycmd/init-flycheck-ycmd ()
   (use-package flycheck-ycmd

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -790,7 +790,24 @@ If ASCII si not provided then UNICODE is used instead."
     (comint-truncate-buffer)))
 
 (defmacro spacemacs|reset-local-company-backends (mode)
-  "Helper to make `company-backends' buffer local and reset it."
+  "Helper to make `company-backends' buffer local and reset it.
+Use *only* if a default backend interferes with completion in a specific mode."
   `(add-hook ',(intern (format "%S-hook" mode))
              (lambda ()
                (set (make-variable-buffer-local 'company-backends) nil))))
+
+(defun spacemacs//make-company-backends-local ()
+  "Helper to make `company-backends' buffer local and reset it."
+  (make-variable-buffer-local 'company-backends))
+
+(defmacro spacemacs|add-mode-company-backend (mode backend)
+  "Add a new `company-mode' backend for a specific mode."
+  (let ((back-hook-sym (intern (format "spacemacs//add-%S-%S" mode backend)))
+        (mode-hook-sym (intern (format "%S-hook" mode))))
+    ; Need the company *layer* for the backend-with-yas function, not just the package. See #961
+    `(when (configuration-layer/layer-declaredp 'company-mode)
+       ;; this hook will be added once even if this macro is used multiple times on the same mode.
+       (add-hook ',mode-hook-sym 'spacemacs//make-company-backends-local)
+       (defun ,back-hook-sym ()
+         (add-to-list 'company-backends (spacemacs/company-backend-with-yas ',backend)))
+       (add-hook ',mode-hook-sym ',back-hook-sym t))))


### PR DESCRIPTION
This PR adds a fancy macro for adding a new company-backend using the new technique discussed in #924. This leads to less copy-pasting and a central way to make tweaks if necessary. It also replaces all places company backends are added with this method.

The only change in the actual behaviour is that `company-backends` is no longer erased on making it buffer local allowing some global default backends, like you suggested in #924. This is important because it makes it so that backends like `company-c-headers`  can be added without breaking the rest of autocompletion. Currently in `develop` there is basically no auto-complete in c/c++ because only the header backend is present.

The `spacemacs|reset-local-company-backends` is kept around although currently unused in case some default company backend is annoying in some mode. For example in `org-mode` it might be annoying to have `company-dabbrev` completing english words but you still want some other type of completion.

Depending on how smart git is this may conflict with #961 but rest assured these don't actually interfere, just make very close but non-overlapping changes. Actually this PR does solve the error that prompted #961 in the new macro but that PR should still be merged anyways because it does the right thing™.