### PR TITLE
Fix fetch in magit status

### DIFF
--- a/contrib/git/packages.el
+++ b/contrib/git/packages.el
@@ -243,6 +243,7 @@ which require an initialization must be listed explicitly in the list.")
                (kbd "C-v") 'magit-revert-item)
       (evilify magit-status-mode magit-status-mode-map
                "K" 'magit-discard-item
+               "f" 'magit-key-mode-popup-fetching
                "L" 'magit-key-mode-popup-logging
                "H" 'magit-key-mode-popup-diff-options
                (kbd "C-j") 'magit-goto-next-section


### PR DESCRIPTION
"f" was no longer bound to "f" 'magit-key-mode-popup-fetching after the switch to evilified mode in magit-status. This adds it back.