### PR TITLE
integerated helm-pydoc

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -18,6 +18,7 @@
     eldoc
     evil-jumper
     flycheck
+    helm-pydoc
     hy-mode
     pony-mode
     pyenv-mode
@@ -254,6 +255,12 @@ which require an initialization must be listed explicitly in the list.")
 (defun spacemacs/init-hy-mode ()
   (use-package hy-mode
     :defer t))
+
+(defun python/init-helm-pydoc ()
+  (use-package helm-pydoc
+    :defer t
+    :init
+    (evil-leader/set-key-for-mode 'python-mode "mhd" 'helm-pydoc)))
 
 (defun python/init-semantic ()
   ;; required to correctly load semantic mode


### PR DESCRIPTION
In this PR, I'd like to use a more useful command `helm-pydoc` as `evil-lookup-func` in python mode.

Basically key `K` is bound to `evil-lookup` command in normal state for documentation lookup, which calls `evil-lookup-func` with default value "woman". I consider this is as less useful because in python buffer, what a programmer really needs is quick way for looking at python doc rather than linux man page. After some investigation, I think `helm-pydoc` is a pretty good fit.

Now I have two options in order to integrate python doc lookup.
1. directly bind `K` in normal state to `helm-pydoc`.
2. make `evil-lookup-func` as a local variable and set its value to `helm-pydoc`. This is what I did in this PR. I feel this is more "evil" way but less intuitive, and I'm not so sure. Can you review my changes and let me know your thoughts.
