### PR TITLE
Feature startup lists

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -127,6 +127,10 @@ declared in a layer which is not a member of
 specified with an installed package.
 NOT USED FOR NOW :-)")
 
+(defvar dotspacemacs-startup-lists '()
+  "Which file lists to show in the startup buffer. '() for none.
+Options are: 'recent 'bookmarks 'projects.")
+
 (defvar dotspacemacs-excluded-packages '()
   "A list of packages and/or extensions that will not be install and loaded.")
 

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -31,6 +31,7 @@ Doge special text banner can be reachable via `999', `doge' or `random*'.
         (insert-file-contents banner))
       (spacemacs//inject-version)
       (spacemacs/insert-buttons)
+      ;; (spacemacs/insert-startupify-lists)
       (spacemacs//redisplay))))
 
 (defun spacemacs//choose-banner ()
@@ -177,6 +178,35 @@ buffer, right justified."
                    'help-echo "Find Spacemacs package and layer configs using helm-spacemacs."))
   (insert "\n\n")
   )
+
+(defun spacemacs//insert-file-list (list-display-name list)
+  (when (car list)
+    (insert list-display-name)
+    (mapc (lambda (el)
+            (insert "\n    ")
+            (insert-button el
+                           'action `(lambda (b) (find-file-existing ,el))
+                           'follow-link t))
+          list)))
+
+(defun spacemacs/insert-startupify-lists ()
+  (interactive)
+  (with-current-buffer (get-buffer-create "*spacemacs*")
+    (let ((buffer-read-only nil)
+          (list-separator "\n\n"))
+      (goto-char (point-max))
+
+      (recentf-mode)
+      (when (spacemacs//insert-file-list "  Recent Files:" (recentf-elements 5))
+        (insert list-separator))
+
+      (helm-mode)
+      (when (spacemacs//insert-file-list "  Bookmarks:" (bookmark-all-names))
+        (insert list-separator))
+
+      (projectile-mode)
+      (when (spacemacs//insert-file-list "  Projects:" (projectile-relevant-known-projects))
+        (insert list-separator)))))
 
 (defun spacemacs/goto-link-line ()
   "Move the point to the beginning of the link line."

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -31,7 +31,6 @@ Doge special text banner can be reachable via `999', `doge' or `random*'.
         (insert-file-contents banner))
       (spacemacs//inject-version)
       (spacemacs/insert-buttons)
-      ;; (spacemacs/insert-startupify-lists)
       (spacemacs//redisplay))))
 
 (defun spacemacs//choose-banner ()
@@ -196,17 +195,20 @@ buffer, right justified."
           (list-separator "\n\n"))
       (goto-char (point-max))
 
-      (recentf-mode)
-      (when (spacemacs//insert-file-list "  Recent Files:" (recentf-elements 5))
-        (insert list-separator))
-
-      (helm-mode)
-      (when (spacemacs//insert-file-list "  Bookmarks:" (bookmark-all-names))
-        (insert list-separator))
-
-      (projectile-mode)
-      (when (spacemacs//insert-file-list "  Projects:" (projectile-relevant-known-projects))
-        (insert list-separator)))))
+      (mapc (lambda (el)
+              (cond
+               ((equal el 'recents)
+                (recentf-mode)
+                (when (spacemacs//insert-file-list "  Recent Files:" (recentf-elements 5))
+                  (insert list-separator)))
+               ((equal el 'bookmarks)
+                (helm-mode)
+                (when (spacemacs//insert-file-list "  Bookmarks:" (bookmark-all-names))
+                  (insert list-separator)))
+               ((equal el 'projects)
+                (projectile-mode)
+                (when (spacemacs//insert-file-list "  Projects:" (projectile-relevant-known-projects))
+                  (insert list-separator))))) dotspacemacs-startup-lists))))
 
 (defun spacemacs/goto-link-line ()
   "Move the point to the beginning of the link line."

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -197,15 +197,15 @@ buffer, right justified."
 
       (mapc (lambda (el)
               (cond
-               ((equal el 'recents)
+               ((eq el 'recents)
                 (recentf-mode)
                 (when (spacemacs//insert-file-list "  Recent Files:" (recentf-elements 5))
                   (insert list-separator)))
-               ((equal el 'bookmarks)
+               ((eq el 'bookmarks)
                 (helm-mode)
                 (when (spacemacs//insert-file-list "  Bookmarks:" (bookmark-all-names))
                   (insert list-separator)))
-               ((equal el 'projects)
+               ((eq el 'projects)
                 (projectile-mode)
                 (when (spacemacs//insert-file-list "  Projects:" (projectile-relevant-known-projects))
                   (insert list-separator))))) dotspacemacs-startup-lists))))

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -322,6 +322,7 @@ version and the NEW version."
      ;; Ultimate configuration decisions are given to the user who can defined
      ;; them in his/her ~/.spacemacs file
      (dotspacemacs|call-func dotspacemacs/config "Calling dotfile config...")
+     (spacemacs/insert-startupify-lists)
      ;; from jwiegley
      ;; https://github.com/jwiegley/dot-emacs/blob/master/init.el
      (let ((elapsed (float-time

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -322,7 +322,7 @@ version and the NEW version."
      ;; Ultimate configuration decisions are given to the user who can defined
      ;; them in his/her ~/.spacemacs file
      (dotspacemacs|call-func dotspacemacs/config "Calling dotfile config...")
-     (unless (equal 'dotspacemacs-startup-lists 'nil)
+     (when (boundp 'dotspacemacs-startup-lists)
        (spacemacs/insert-startupify-lists))
      ;; from jwiegley
      ;; https://github.com/jwiegley/dot-emacs/blob/master/init.el

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -322,7 +322,8 @@ version and the NEW version."
      ;; Ultimate configuration decisions are given to the user who can defined
      ;; them in his/her ~/.spacemacs file
      (dotspacemacs|call-func dotspacemacs/config "Calling dotfile config...")
-     (spacemacs/insert-startupify-lists)
+     (unless (equal 'dotspacemacs-startup-lists 'nil)
+       (spacemacs/insert-startupify-lists))
      ;; from jwiegley
      ;; https://github.com/jwiegley/dot-emacs/blob/master/init.el
      (let ((elapsed (float-time

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -322,7 +322,7 @@ version and the NEW version."
      ;; Ultimate configuration decisions are given to the user who can defined
      ;; them in his/her ~/.spacemacs file
      (dotspacemacs|call-func dotspacemacs/config "Calling dotfile config...")
-     (when (boundp 'dotspacemacs-startup-lists)
+     (when 'dotspacemacs-startup-lists
        (spacemacs/insert-startupify-lists))
      ;; from jwiegley
      ;; https://github.com/jwiegley/dot-emacs/blob/master/init.el

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -107,7 +107,11 @@ before layers configuration."
    ;; The default package repository used if no explicit repository has been
    ;; specified with an installed package.
    ;; Not used for now.
-   dotspacemacs-default-package-repository nil)
+   dotspacemacs-default-package-repository nil
+   ;; If one or more of ('recents 'projects 'bookmarks), shows lists of those
+   ;; files at startup in that order.
+   dotspacemacs-startup-lists '(recents projects)
+   )
   ;; User initialization goes here
   )
 


### PR DESCRIPTION
Closes #807: Displays lists of recent files, projects, and bookmarks at startup in the *spacemacs* buffer. Each item is a button, so you can go straight to it. If you don't have recent files, projects, or bookmarks, they won't show up.

![](https://cloud.githubusercontent.com/assets/859820/6881413/1ecefe96-d567-11e4-979f-b89753ad8744.png)