### PR TITLE
Enable goto-address-prog-mode

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -99,6 +99,10 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Mouse cursor in terminal mode
 (xterm-mouse-mode 1)
 
+;; Highlight and allow to open http link at point in programming buffers
+;; goto-address-prog-mode only highlights links in strings and comments
+(add-hook 'prog-mode-hook 'goto-address-prog-mode)
+
 ;; ---------------------------------------------------------------------------
 ;; Edit
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
So we can see web links easily and jump to the links with a mouse click
or a key binding.