### PR TITLE
ghci-ng should now override mht rather than mt

### DIFF
--- a/contrib/lang/haskell/README.md
+++ b/contrib/lang/haskell/README.md
@@ -102,7 +102,7 @@ versions from ghci-ng, and a new keybinding available:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m t</kbd>    | gets the type of the identifier under the cursor or for the active region
+<kbd>SPC m h t</kbd>  | gets the type of the identifier under the cursor or for the active region
 <kbd>SPC m g g</kbd>  | go to definition
 <kbd>SPC m u</kbd>    | finds uses of identifier
 

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -218,7 +218,7 @@
 
           (evil-leader/set-key-for-mode 'haskell-mode
             "mu"   'haskell-mode-find-uses
-            "mt"   'haskell-mode-show-type-at
+            "mht"   'haskell-mode-show-type-at
             "mgg"  'haskell-mode-goto-loc
             ))
         )


### PR DESCRIPTION
As the standard show type is now bound to mht, we should override this binding in ghci-ng mode as well.