### PR TITLE
ensure that less gets loaded

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -131,6 +131,11 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :mode ("\\.sass\\'" . sass-mode)))
 
+(defun html/init-less-css-mode ()
+  (use-package less-css-mode
+    :defer t
+    :mode ("\\.less\\'" . less-css-mode)))
+
 (defun html/init-flycheck ()
   (add-hook 'web-mode-hook 'flycheck-mode)
   (add-hook 'scss-mode-hook 'flycheck-mode)


### PR DESCRIPTION
less mode appears to work when html mode is first loaded, but does not work thereafter. this fixes it (I think either the layer gets deleted or not initialised properly).