### PR TITLE
Enable helm-descbinds globally

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1548,6 +1548,9 @@ ARG non nil means that the editing style is `vim'."
   (use-package helm-descbinds
     :defer t
     :init
+    (add-hook 'helm-mode-hook (lambda ()
+                                (helm-descbinds-mode 1)
+                                (setq helm-descbinds-window-style 'split)))
     (evil-leader/set-key "?" 'helm-descbinds)))
 
 (defun spacemacs/init-helm-flyspell ()


### PR DESCRIPTION
It offers superior key binding and command exploration interface compare
with stock Help buffer:

- It can search for key bindings or associated with Helm.
- Since using Helm, it can narrow to relevant matches.

Stock help-mode buffer has nothing on this. One useful example is using
`C-h b` to explore major mode key bindings.