### PR TITLE
Improve SLIME layer

### DIFF
--- a/contrib/slime/packages.el
+++ b/contrib/slime/packages.el
@@ -23,11 +23,22 @@ which require an initialization must be listed explicitly in the list.")
     :commands slime-mode
     :init
     (progn
-      (setq slime-contribs '(slime-fancy)
+      (setq slime-contribs '(slime-fancy
+                             slime-indentation
+                             slime-sbcl-exts
+                             slime-scratch)
             inferior-lisp-program "sbcl")
-      (add-to-hooks 'slime-mode '(lisp-mode-hook
-                                  emacs-lisp-mode-hook
-                                  scheme-mode-hook)))
+
+      ;; enable fuzzy matching in code buffer and SLIME REPL
+      (setq slime-complete-symbol*-fancy t)
+      (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
+
+      ;; enabel smartparen in code buffer and SLIME REPL
+      (add-hook 'slime-repl-mode-hook #'smartparens-strict-mode)
+
+      (add-to-hooks 'slime-mode '(lisp-mode-hook scheme-mode-hook)))
     :config
     (message "loading slime...")
-    (slime-setup)))
+    (slime-setup)
+    (dolist (m `(,slime-mode-map ,slime-repl-mode-map))
+      (define-key m [(tab)] 'slime-fuzzy-complete-symbol))))


### PR DESCRIPTION
- Use slime for indentation
- Add extension for SBCL
- Allow to create a common lisp scratch buffer with slime-scratch
- Enable fuzzy completion with score.
- Don't enable SLIME in Emacs Lisp. It's not usable. The SLIME of Emacs Lisp is Emacs itself. Currently, when adding SLIME layer, `slime-mode` is enabled in Emacs Lisp mode and all the eval commands of Emacs Lisp are replaced with SLIME ones, which makes Emacs unable to eval Emacs Lisp code until `slime-mode` is turned off.