### PR TITLE
Replace show-paren-mode with show-smartparens-mode

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -108,8 +108,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 (setq initial-major-mode 'text-mode)
 ;; whitespace-mode
 (add-hook 'prog-mode-hook (lambda () (setq show-trailing-whitespace 1)))
-;; When point is on paranthesis, highlight the matching one
-(show-paren-mode t)
+
 ;; use only spaces and no tabs
 (setq-default indent-tabs-mode nil
               default-tab-width 2)

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2493,6 +2493,9 @@ displayed in the mode-line.")
       (require 'smartparens-config)
       (spacemacs|diminish smartparens-mode " (Ⓢ)" " (S)")
 
+      ;; When point is on a pair, highlight the matching one
+      (show-smartparens-global-mode +1)
+
       (defun spacemacs/smartparens-pair-newline (id action context)
         (save-excursion
           (newline)


### PR DESCRIPTION
show-smartparens-mode offers better highlighting: it can highlights pair
recognized by Smartparens, including pairs such as \\(\\) and XML tags.