### PR TITLE
Improve yasnippet

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1634,6 +1634,8 @@ ARG non nil means that the editing style is `vim'."
   (global-set-key (kbd "M-/") 'hippie-expand) ;; replace dabbrev-expand
   (setq hippie-expand-try-functions-list
         '(
+          ;; Try to expand yasnippet snippets based on prefix
+          yas-hippie-try-expand
           ;; Try to expand word "dynamically", searching the current buffer.
           try-expand-dabbrev
           ;; Try to expand word "dynamically", searching all other buffers.
@@ -2665,16 +2667,17 @@ displayed in the mode-line.")
     :init
     (progn
       (defun spacemacs/load-yasnippet ()
-          (if (not (boundp 'yas-minor-mode))
-              (progn
-                (let* ((dir (configuration-layer/get-layer-property 'spacemacs :ext-dir))
-                       (private-yas-dir (concat configuration-layer-private-directory "snippets"))
-                       (yas-dir (concat dir "yasnippet-snippets")))
-                  (setq yas-snippet-dirs
-                        (append (when (boundp 'yas-snippet-dirs)
-                                  yas-snippet-dirs)
-                                (list  private-yas-dir yas-dir)))
-                  (yas-global-mode 1)))))
+        (if (not (boundp 'yas-minor-mode))
+            (progn
+              (let* ((dir (configuration-layer/get-layer-property 'spacemacs :ext-dir))
+                     (private-yas-dir (concat configuration-layer-private-directory "snippets"))
+                     (yas-dir (concat dir "yasnippet-snippets")))
+                (setq yas-snippet-dirs
+                      (append (when (boundp 'yas-snippet-dirs)
+                                yas-snippet-dirs)
+                              (list  private-yas-dir yas-dir)))
+                (setq yas-wrap-around-region t)
+                (yas-global-mode 1)))))
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook
                                                 org-mode-hook))


### PR DESCRIPTION
- Allow a snippet to wrap around a selected region when expanded: A user
  can select a region, press 'C-x C-x' to go to the original mark and
  run `yas-expand` to wrap the selected region in expanded snippet.

- Reindent spacemacs/load-yasnipppet.

- Allow `hippie-expand` to expand snippets as well. May replace TAB in
  the future.