### PR TITLE
Fix loading order in some of my layers

### DIFF
--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -14,7 +14,7 @@
     (progn
       (when (member 'company-mode dotspacemacs-configuration-layers)
         (use-package company-auctex
-          :init (company-auctex-init)))
+          :config (company-auctex-init)))
 
       (defun auctex/build-view ()
         (interactive)
@@ -33,6 +33,7 @@
 
       (add-hook 'LaTeX-mode-hook '(lambda () (local-set-key (kbd "H-r") 'auctex/build-view)))
       (add-hook 'LaTeX-mode-hook 'flyspell-mode)
+      (add-hook 'LaTeX-mode-hook 'company-mode)
       (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
       (add-hook 'LaTeX-mode-hook 'spacemacs/load-yasnippet)
 

--- a/contrib/lang/racket/packages.el
+++ b/contrib/lang/racket/packages.el
@@ -4,14 +4,20 @@
 (defun racket/init-racket-mode ()
   (use-package racket-mode
     :defer t
+    ;; Bug exists in Racket company backend that opens docs in new window when
+    ;; company-quickhelp calls it. Note hook is appendended for proper ordering.
+    :init
+    (when (configuration-layer/package-declaredp 'company-quickhelp)
+      (add-hook 'company-mode-hook
+                '(lambda () (when (equal major-mode 'racket-mode) (company-quickhelp-mode -1))) t))
     :config
     (progn
       ;; smartparens configuration
       (eval-after-load 'smartparens
         '(progn (add-to-list 'sp--lisp-modes 'racket-mode)
                 (when (fboundp 'sp-local-pair)
+                  (sp-local-pair 'racket-mode "'" nil :actions nil)
                   (sp-local-pair 'racket-mode "`" nil :actions nil))))
-      (sp-local-pair 'racket-mode "'" nil :actions nil)
 
       (defun spacemacs/racket-test-with-coverage ()
         "Call `racket-test' with universal argument."
@@ -67,9 +73,4 @@
         ;; Tests
         "mtb" 'racket-test
         "mtB" 'spacemacs/racket-test-with-coverage)
-      (define-key racket-mode-map (kbd "H-r") 'racket-run)
-      ;; Bug exists in Racket company backend that opens docs in new window when
-      ;; company-quickhelp calls it. Note hook is appendended for proper ordering.
-      (when (configuration-layer/package-declaredp 'company-quickhelp)
-        (add-hook 'company-mode-hook
-                  '(lambda () (when (equal major-mode 'racket-mode) (company-quickhelp-mode -1))) t)))))
+      (define-key racket-mode-map (kbd "H-r") 'racket-run))))


### PR DESCRIPTION
The new `use-package` and `company-mode` stuff broke some of the load order stuff in some of my layer. Also the racket layer fix I added recently wouldn't work on the first file you opened.

This just makes some minor changes to make that stuff work.