### PR TITLE
Added the go/run-package-tests command along with the 'mtp' key combo to invoke it

### DIFF
--- a/contrib/lang/go/packages.el
+++ b/contrib/lang/go/packages.el
@@ -16,20 +16,25 @@ which require an initialization must be listed explicitly in the list.")
 (defun go/init-flycheck ()
     (add-hook 'go-mode-hook 'flycheck-mode))
 
+(defun go/run-package-tests ()
+  (interactive)
+  (shell-command "go test"))
+
 (defun go/init-go-mode()
   (use-package go-mode
     :defer t
     :config
       (add-hook 'before-save-hook 'gofmt-before-save)
       (evil-leader/set-key-for-mode 'go-mode
-        "mdp"  'godoc-at-point
-        "mig"  'go-goto-imports
-        "mia"  'go-import-add
-        "mir"  'go-remove-unused-imports
-        "mpb"  'go-play-buffer
-        "mpr"  'go-play-region
-        "mpd"  'go-download-play
-        "mgg"   'godef-jump)))
+        "mdp" 'godoc-at-point
+        "mig" 'go-goto-imports
+        "mia" 'go-import-add
+        "mir" 'go-remove-unused-imports
+        "mpb" 'go-play-buffer
+        "mpr" 'go-play-region
+        "mpd" 'go-download-play
+        "mgg" 'godef-jump
+        "mtp" 'go/run-package-tests)))
 
 (defun go/init-go-eldoc()
     (add-hook 'go-mode-hook 'go-eldoc-setup))


### PR DESCRIPTION
Not sure if this is the correct way to approach this feature from the standpoint of supporting all operating systems or not. I have only tested it on a mac.

This invokes a shell command "go test" which defaults to the current directory of the file of the buffer you run it from. This gives the effect of running the tests for just the go package the file in the buffer belongs to.