### PR TITLE
Add key bindings for useful Helm commands

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -89,6 +89,7 @@ Ensure that helm is required before calling FUNC."
 (spacemacs||describe-set-key "hdp" describe-package)
 (spacemacs||describe-set-key "hdt" describe-theme)
 (spacemacs||describe-set-key "hdv" describe-variable)
+(spacemacs||describe-set-key "hL" helm-locate-library)
 ;; errors ---------------------------------------------------------------------
 (evil-leader/set-key
   "en" 'spacemacs/next-error

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1393,6 +1393,8 @@ ignored)."
         "sl"  'helm-semantic-or-imenu
         "hb"  'helm-bookmarks
         "hl"  'helm-resume
+        "hi"  'helm-info-at-point
+        "hm"  'helm-man-woman
         "ry"  'helm-show-kill-ring
         "rr"  'helm-register
         "rm"  'helm-all-mark-rings
@@ -1414,6 +1416,9 @@ ignored)."
 
       ;;  Restore popwin-mode after a Helm session finishes.
       (add-hook 'helm-cleanup-hook (lambda () (popwin-mode 1)))
+
+      ;; Add minibuffer history with `helm-minibuffer-history'
+      (define-key minibuffer-local-map (kbd "C-c C-l") 'helm-minibuffer-history)
 
       (defun spacemacs//helm-before-initialize ()
         "Stuff to do before helm initializes."


### PR DESCRIPTION
- helm-info-at-point: find an info entry for symbol at point, if
  available. It can also be used to search for available info pages.

- helm-man-woman: find man pages with Helm.

- helm-locate-library: find a loaded Emacs Lisp library using Helm.

- helm-minibuffer-history: search minibuffer history using Helm.