### PR TITLE
[Fix #1023] Restore rectangle-mark-mode key binding

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -957,6 +957,7 @@ which require an initialization must be listed explicitly in the list.")
       (global-evil-search-highlight-persist)
       ;; (set-face-attribute )
       (evil-leader/set-key "sc" 'evil-search-highlight-persist-remove-all)
+      (define-key evil-search-highlight-persist-map (kbd "C-x SPC") 'rectangle-mark-mode)
       (evil-ex-define-cmd "nohlsearch"
                           'evil-search-highlight-persist-remove-all))))
 


### PR DESCRIPTION
evil-search-highlight-persist-remove-all is bound to "C-x SPC". However,
it already has "SPC s c". So, we should return it to stock Emacs binding.