### PR TITLE
open cider-doc without asking for symbol, close with q

### DIFF
--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -129,6 +129,11 @@ the focus."
 
       (evilify cider-stacktrace-mode cider-stacktrace-mode-map)
 
+      ;; open cider-doc directly and close it with q
+      (setq cider-prompt-for-symbol nil)
+      (evilify cider-docview-mode cider-docview-mode-map
+        (kbd "q") 'cider-popup-buffer-quit)
+
       (evil-leader/set-key-for-mode 'clojure-mode
         "mdd" 'cider-doc
         "mdg" 'cider-grimoire


### PR DESCRIPTION
My keybinding skills are somewhat lacking so I used the evilify macro to bind "q"
- fix issue #1028