### PR TITLE
Fix for go-oracle.

### DIFF
--- a/contrib/lang/go/extensions.el
+++ b/contrib/lang/go/extensions.el
@@ -39,9 +39,7 @@
         (spacemacs/message (concat "Warning: GOPATH variable not found, "
                                    "go-oracle configuration skipped."))
       (when (load-gopath-file
-             go-path "/src/code.google.com/p/go.tools/cmd/oracle/oracle.el")
-        (add-hook 'go-mode-hook 'go-oracle-mode)
-        (spacemacs|diminish go-oracle-mode " O")
+             go-path "/src/golang.org/x/tools/cmd/oracle/oracle.el")
         (evil-leader/set-key-for-mode 'go-mode
           "moo" 'go-oracle-set-scope
           "mo<" 'go-oracle-callers


### PR DESCRIPTION
Update import path for oracle.el

Remove references to go-oracle-mode because oracle.el now simply extends go-mode.