### PR TITLE
Turn on LESS mode for .less files

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -125,6 +125,11 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :mode ("\\.scss\\'" . scss-mode)))
 
+(defun html/init-less-css-mode ()
+  (use-package less-css-mode
+    :defer t
+    :mode ("\\.less\\'" . less-css-mode)))
+
 (defun html/init-flycheck ()
   (add-hook 'web-mode-hook 'flycheck-mode)
   (add-hook 'scss-mode-hook 'flycheck-mode))


### PR DESCRIPTION
LESS syntax highlighting didn't work for me without this.