### PR TITLE
Associate .mkd with markdown-mode

### DIFF
--- a/contrib/lang/markdown/packages.el
+++ b/contrib/lang/markdown/packages.el
@@ -20,7 +20,7 @@ which require an initialization must be listed explicitly in the list.")
 
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
-    :mode ("\\.md" . markdown-mode)
+    :mode ("\\.m[k]d" . markdown-mode)
     :defer t
     :init
     (eval-after-load 'smartparens


### PR DESCRIPTION
This is a common enough extension that it seems reasonable to do this by
default.