### PR TITLE
Properly enable saveplace

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -198,8 +198,8 @@ Can be installed with `brew install trash'."
       eval-expression-print-level nil)
 ;; Save point position between sessions
 (require 'saveplace)
-(setq save-place t
-      save-place-file (concat spacemacs-cache-directory "places"))
+(setq-default save-place t
+              save-place-file (concat spacemacs-cache-directory "places"))
 
 ;; minibuffer history
 (require 'savehist)


### PR DESCRIPTION
Curretnly saveplace is not activated because setq only set the value
save-place is buffer local when set. We must set it to default to make
saveplace affects all buffers.