### PR TITLE
add default layers

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -10,7 +10,9 @@
    dotspacemacs-configuration-layer-path '()
    ;; List of configuration layers to load. If it is the symbol `all' instead
    ;; of a list then all discovered layers will be installed.
-   dotspacemacs-configuration-layers '()
+   dotspacemacs-configuration-layers '(auto-completion
+                                       git
+                                       lang/markdown)
    ;; A list of packages and/or extensions that will not be install and loaded.
    dotspacemacs-excluded-packages '()
    ;; If non-nil spacemacs will delete any orphan packages, i.e. packages that


### PR DESCRIPTION
Closes #1047

Adds `auto-completion`, `git`, and `lang/markdown` to the default .spacemacs template.