### PR TITLE
added ace-link in spacemacs package

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1192,6 +1192,15 @@ Key Binding          |                 Description
 
 Hint: you may change to char mode by `C-c C-c` in word mode.
 
+#### ace-link mode
+
+Similar to `ace-jump-mode`, [ace-link][ace-link] allows one to jump to any link in
+`help-mode` and `info-mode` with two key strokes.
+
+Key Binding          |                 Description
+---------------------|------------------------------------------------------------------
+<kbd>o</kbd>         | initiate ace link mode in `help-mode` and `info-mode`
+
 ### Window manipulation
 
 #### Window manipulation key bindings
@@ -2432,6 +2441,7 @@ developers to elisp hackers!
 [keychords]: http://www.emacswiki.org/emacs/KeyChord
 [centered-cursor]: http://www.emacswiki.org/emacs/centered-cursor-mode.el
 [ace-jump]: https://github.com/winterTTr/ace-jump-mode
+[ace-link]: https://github.com/abo-abo/ace-link
 [ace-window]: https://github.com/abo-abo/ace-window
 [helm-link]: https://github.com/emacs-helm/helm
 [helm-doc]: https://github.com/emacs-helm/helm/wiki

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -13,6 +13,7 @@
 (defvar spacemacs-packages
   '(
     ace-jump-mode
+    ace-link
     ace-window
     adaptive-wrap
     aggressive-indent
@@ -135,6 +136,11 @@ which require an initialization must be listed explicitly in the list.")
     (progn
       (setq ace-jump-mode-scope 'global)
       (evil-leader/set-key "`" 'ace-jump-mode-pop-mark))))
+
+(defun spacemacs/init-ace-link ()
+  (use-package ace-link
+    :defer t
+    :init (ace-link-setup-default)))
 
 (defun spacemacs/init-ace-window ()
   (use-package ace-window


### PR DESCRIPTION
`ace-link` allows fast navigation in `info-mode`, i.e. reading documentation in emacs, and quickly jump to source code in `help-mode`. I found it's quite handy and therefore think it could be a good fit in spacemacs.

there is a a live demo in its [homepage](https://github.com/abo-abo/ace-link)