### PR TITLE
added ace-link mode

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1192,6 +1192,15 @@ Key Binding          |                 Description
 
 Hint: you may change to char mode by `C-c C-c` in word mode.
 
+#### ace-link mode
+
+Similar to `ace-jump-mode`, [ace-link][ace-link] allows one to jump to any link in
+`help-mode` and `info-mode` with two key strokes.
+
+Key Binding          |                 Description
+---------------------|------------------------------------------------------------------
+<kbd>o</kbd>         | initiate ace link mode in `help-mode` and `info-mode`
+
 ### Window manipulation
 
 #### Window manipulation key bindings
@@ -2432,6 +2441,7 @@ developers to elisp hackers!
 [keychords]: http://www.emacswiki.org/emacs/KeyChord
 [centered-cursor]: http://www.emacswiki.org/emacs/centered-cursor-mode.el
 [ace-jump]: https://github.com/winterTTr/ace-jump-mode
+[ace-link]: https://github.com/abo-abo/ace-link
 [ace-window]: https://github.com/abo-abo/ace-window
 [helm-link]: https://github.com/emacs-helm/helm
 [helm-doc]: https://github.com/emacs-helm/helm/wiki

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -13,6 +13,7 @@
 (defvar spacemacs-packages
   '(
     ace-jump-mode
+    ace-link
     ace-window
     adaptive-wrap
     aggressive-indent
@@ -135,6 +136,35 @@ which require an initialization must be listed explicitly in the list.")
     (progn
       (setq ace-jump-mode-scope 'global)
       (evil-leader/set-key "`" 'ace-jump-mode-pop-mark))))
+
+(defun spacemacs/init-ace-link ()
+  (use-package ace-link
+    :defer t
+    :init (ace-link-setup-default)
+    :config
+    (progn
+      (defvar spacemacs--link-pattern "~?/.+\\|\s\\[")
+
+      (defun spacemacs//collect-spacemacs-buffer-links ()
+        (let ((end (window-end))
+              points)
+          (save-excursion
+            (goto-char (window-start))
+            (while (re-search-forward spacemacs--link-pattern end t)
+              (push (+ (match-beginning 0) 1) points))
+            (nreverse points))))
+
+      (defun spacemacs//ace-buffer-links ()
+        "Ace jump to links in `spacemacs' buffer."
+        (interactive)
+        (ali-generic
+            (spacemacs//collect-spacemacs-buffer-links)
+          (forward-char 1)
+          (push-button)
+          ))
+
+      (define-key spacemacs-mode-map "o" 'spacemacs//ace-buffer-links)
+      )))
 
 (defun spacemacs/init-ace-window ()
   (use-package ace-window


### PR DESCRIPTION
- integrated `ace-link` mode
- jump to any link in spacemacs buffer using `ace-link` with single `o`

See a live demo of `ace-link` on its website https://github.com/abo-abo/ace-link.