### PR TITLE
Replace show-paren-mode with show-smartparens-mode in holy-mode

### DIFF
--- a/spacemacs/extensions/holy-mode/holy-mode.el
+++ b/spacemacs/extensions/holy-mode/holy-mode.el
@@ -72,7 +72,10 @@ The `insert state' is replaced by the `emacs state'."
   (when (fboundp 'spacemacs//helm-hjkl-navigation)
     (spacemacs//helm-hjkl-navigation nil))
   ;; initiate `emacs state' and enter the church
-  (holy-mode//update-states-for-current-buffers))
+  (holy-mode//update-states-for-current-buffers)
+  ;; enable superior pair highlighting
+  (show-paren-mode -1)
+  (show-smartparens-global-mode +1))
 
 (defun amen ()
   "May the force be with you my son (or not)."


### PR DESCRIPTION
Both behave the same in stock Emacs but show-smartparens-mode offers
more features. So, to make up for the "loss" of modal editing, Holy
users should have something of their own.