### PR TITLE
Don't insert extra quote in dotspacemacs-mode

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2513,6 +2513,9 @@ displayed in the mode-line.")
       ;; don't create a pair with single quote in minibuffer
       (sp-local-pair 'minibuffer-inactive-mode "'" nil :actions nil)
 
+      ;; don't create a pair with single quote in dotspacemacs-mode
+      (sp-local-pair 'dotspacemacs-mode "'" nil :actions nil)
+
       (setq sp-cancel-autoskip-on-backward-movement nil))
     :config
     (progn


### PR DESCRIPTION
Since dotspacemacs-mode is essentially a Lisp mode, insert a single
quote should not automatically insert another single quote to close
it. This is the same as smartparens in Emacs Lisp mode out of the box.