### PR TITLE
Global company temporary stopgap

### DIFF
--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -2,19 +2,16 @@
   '(
     auctex
     evil-matchit
+    company-auctex
     ))
-
-(when (member 'company-mode dotspacemacs-configuration-layers)
-  (add-to-list 'auctex-packages 'company-auctex))
 
 (defun auctex/init-auctex ()
   (use-package tex
     :defer t
     :config
     (progn
-      (when (member 'company-mode dotspacemacs-configuration-layers)
-        (use-package company-auctex
-          :config (company-auctex-init)))
+      (when (configuration-layer/layer-usedp 'auto-completion)
+        (company-auctex-init))
 
       (defun auctex/build-view ()
         (interactive)
@@ -62,6 +59,10 @@
       (setq-default TeX-auto-save t)
       (setq-default TeX-parse-self t)
       (setq-default TeX-PDF-mode t))))
+
+(defun auctex/init-company-auctex ()
+  (use-package company-auctex :defer t
+    :if (configuration-layer/layer-usedp 'auto-completion)))
 
 (defun auctex/post-init-evil-matchit ()
   (add-hook 'web-mode-hook 'evil-matchit-mode))

--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -67,14 +67,16 @@ conflict.")
   (use-package company
     :defer t
     :init
-    (setq company-idle-delay 0.2
-          company-minimum-prefix-length 2
-          company-require-match nil
-          company-dabbrev-ignore-case nil
-          company-dabbrev-downcase nil
-          company-tooltip-flip-when-above t
-          company-frontends '(company-pseudo-tooltip-frontend)
-          company-clang-prefix-guesser 'company-mode/more-than-prefix-guesser)
+    (progn
+      (setq company-idle-delay 0.2
+            company-minimum-prefix-length 2
+            company-require-match nil
+            company-dabbrev-ignore-case nil
+            company-dabbrev-downcase nil
+            company-tooltip-flip-when-above t
+            company-frontends '(company-pseudo-tooltip-frontend)
+            company-clang-prefix-guesser 'company-mode/more-than-prefix-guesser)
+      (add-hook 'after-init-hook 'global-company-mode))
     :config
     (progn
       (spacemacs|diminish company-mode " ⓐ" " a")


### PR DESCRIPTION
Institutes a temporary measure @syl20bnr and I discussed to allow company autocomplete to work in modes that have not yet been ported to the new architecture. Basically just enables company globally and patches up auctex. This might enable an earlier release (see #1046).

I have tested and this fixes all the problems I listed in #1045, except Racket (see #1081 :rage:).
Also solves #1043.
