### PR TITLE
Make everything support new company auto-completion

### DIFF
--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -62,11 +62,11 @@
   (add-hook 'web-mode-hook 'evil-matchit-mode))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company auctex LaTeX-mode)
+  (spacemacs|init-company auctex LaTeX-mode)
   (defun auctex/init-company-auctex ()
     (use-package company-auctex :defer t
       :init (progn
-              (add-to-list 'company-backends-LaTeX-mode 'company-auctex-labels)
-              (add-to-list 'company-backends-LaTeX-mode 'company-auctex-bibs)
-              (add-to-list 'company-backends-LaTeX-mode
-                           '(company-auctex-macros company-auctex-symbols company-auctex-environments))))))
+              (push 'company-auctex-labels company-backends-LaTeX-mode)
+              (push 'company-auctex-bibs company-backends-LaTeX-mode)
+              (push '(company-auctex-macros company-auctex-symbols company-auctex-environments)
+                    company-backends-LaTeX-mode)))))

--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -2,19 +2,16 @@
   '(
     auctex
     evil-matchit
+    company-auctex
     ))
-
-(when (member 'company-mode dotspacemacs-configuration-layers)
-  (add-to-list 'auctex-packages 'company-auctex))
 
 (defun auctex/init-auctex ()
   (use-package tex
     :defer t
     :config
     (progn
-      (when (member 'company-mode dotspacemacs-configuration-layers)
-        (use-package company-auctex
-          :config (company-auctex-init)))
+      (when (configuration-layer/layer-usedp 'auto-completion)
+        (company-auctex-init))
 
       (defun auctex/build-view ()
         (interactive)
@@ -62,6 +59,10 @@
       (setq-default TeX-auto-save t)
       (setq-default TeX-parse-self t)
       (setq-default TeX-PDF-mode t))))
+
+(defun auctex/init-company-auctex ()
+  (use-package company-auctex :defer t
+    :if (configuration-layer/layer-usedp 'auto-completion)))
 
 (defun auctex/post-init-evil-matchit ()
   (add-hook 'web-mode-hook 'evil-matchit-mode))

--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -10,9 +10,6 @@
     :defer t
     :config
     (progn
-      (when (configuration-layer/layer-usedp 'auto-completion)
-        (company-auctex-init))
-
       (defun auctex/build-view ()
         (interactive)
         (if (buffer-modified-p)
@@ -60,9 +57,16 @@
       (setq-default TeX-parse-self t)
       (setq-default TeX-PDF-mode t))))
 
-(defun auctex/init-company-auctex ()
-  (use-package company-auctex :defer t
-    :if (configuration-layer/layer-usedp 'auto-completion)))
 
 (defun auctex/post-init-evil-matchit ()
   (add-hook 'web-mode-hook 'evil-matchit-mode))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (spacemacs|init-layer-company auctex LaTeX-mode)
+  (defun auctex/init-company-auctex ()
+    (use-package company-auctex :defer t
+      :init (progn
+              (add-to-list 'company-backends-LaTeX-mode 'company-auctex-labels)
+              (add-to-list 'company-backends-LaTeX-mode 'company-auctex-bibs)
+              (add-to-list 'company-backends-LaTeX-mode
+                           '(company-auctex-macros company-auctex-symbols company-auctex-environments))))))

--- a/contrib/auto-completion/funcs.el
+++ b/contrib/auto-completion/funcs.el
@@ -87,7 +87,7 @@ possible to explicitly define a hook with HOOK."
        (add-hook ',mode-hook ',func)
        (add-hook ',mode-hook 'auto-complete-mode))))
 
-(defmacro spacemacs|init-layer-company (layer mode)
+(defmacro spacemacs|init-company (layer mode)
   "Helper to initialize the company-backends-MODE list and enable
 company auto-completion for the mode. If you require more direct control
 use spacemacs|init-company-backends and spacemacs|enable-company."
@@ -96,6 +96,6 @@ use spacemacs|init-company-backends and spacemacs|enable-company."
         (func (intern (format "%S/post-init-company" layer))))
     `(progn
        (spacemacs|init-company-backends ,mode)
-       (add-to-list ',pkg-list 'company)
+       (push 'company ,pkg-list)
        (defun ,func ()
          (spacemacs|enable-company ,mode)))))

--- a/contrib/auto-completion/funcs.el
+++ b/contrib/auto-completion/funcs.el
@@ -86,3 +86,16 @@ possible to explicitly define a hook with HOOK."
               ,(intern (format "company-backends-%S" mode))))
        (add-hook ',mode-hook ',func)
        (add-hook ',mode-hook 'auto-complete-mode))))
+
+(defmacro spacemacs|init-layer-company (layer mode)
+  "Helper to initialize the company-backends-MODE list and enable
+company auto-completion for the mode. If you require more direct control
+use spacemacs|init-company-backends and spacemacs|enable-company."
+  (let ((mode-hook (intern (format "%S-hook" mode)))
+        (pkg-list (intern (format "%S-packages" layer)))
+        (func (intern (format "%S/post-init-company" layer))))
+    `(progn
+       (spacemacs|init-company-backends ,mode)
+       (add-to-list ',pkg-list 'company)
+       (defun ,func ()
+         (spacemacs|enable-company ,mode)))))

--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -67,14 +67,16 @@ conflict.")
   (use-package company
     :defer t
     :init
-    (setq company-idle-delay 0.2
-          company-minimum-prefix-length 2
-          company-require-match nil
-          company-dabbrev-ignore-case nil
-          company-dabbrev-downcase nil
-          company-tooltip-flip-when-above t
-          company-frontends '(company-pseudo-tooltip-frontend)
-          company-clang-prefix-guesser 'company-mode/more-than-prefix-guesser)
+    (progn
+      (setq company-idle-delay 0.2
+            company-minimum-prefix-length 2
+            company-require-match nil
+            company-dabbrev-ignore-case nil
+            company-dabbrev-downcase nil
+            company-tooltip-flip-when-above t
+            company-frontends '(company-pseudo-tooltip-frontend)
+            company-clang-prefix-guesser 'company-mode/more-than-prefix-guesser)
+      (add-hook 'after-init-hook 'global-company-mode))
     :config
     (progn
       (spacemacs|diminish company-mode " ⓐ" " a")

--- a/contrib/finance/packages.el
+++ b/contrib/finance/packages.el
@@ -29,6 +29,7 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :init
     (progn
+      (push '(company-capf :with company-yasnippet) company-backends-ledger-mode)
       (setq ledger-post-amount-alignment-column 62)
       (evil-leader/set-key-for-mode 'ledger-mode
         "mhd"   'ledger-delete-current-transaction
@@ -44,3 +45,6 @@ which require an initialization must be listed explicitly in the list.")
         "mt"    'ledger-insert-effective-date
         "my"    'ledger-set-year
         "m RET" 'ledger-set-month))))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (spacemacs|init-layer-company finance ledger-mode))

--- a/contrib/finance/packages.el
+++ b/contrib/finance/packages.el
@@ -47,4 +47,4 @@ which require an initialization must be listed explicitly in the list.")
         "m RET" 'ledger-set-month))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company finance ledger-mode))
+  (spacemacs|init-company finance ledger-mode))

--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -79,7 +79,7 @@ which require an initialization must be listed explicitly in the list.")
   (defun c-c++/post-init-company ()
     ;; push this backend by default
     (push '(company-clang :with company-yasnippet) company-backends-c-c++)
-    (spacemacs|enable-company c-c++ c-common-mode-hook)
+    (spacemacs|enable-company c-c++ c-mode-common-hook)
 
     ;; .clang_complete file loading
     ;; Sets the arguments for company-clang based on a project-specific text file.

--- a/contrib/lang/csharp/config.el
+++ b/contrib/lang/csharp/config.el
@@ -11,6 +11,3 @@
 ;;; License: GPLv3
 
 ;; variables
-
-(when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-company-backends csharp-mode))

--- a/contrib/lang/csharp/packages.el
+++ b/contrib/lang/csharp/packages.el
@@ -63,4 +63,4 @@
               "m=" 'omnisharp-code-format)))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company csharp csharp-mode))
+  (spacemacs|init-company csharp csharp-mode))

--- a/contrib/lang/csharp/packages.el
+++ b/contrib/lang/csharp/packages.el
@@ -11,8 +11,7 @@
 ;;; License: GPLv3
 
 (defvar csharp-packages
-  '(company
-    omnisharp))
+  '(omnisharp))
 
 (defvar csharp-excluded-packages '()
   "List of packages to exclude.")
@@ -64,5 +63,4 @@
               "m=" 'omnisharp-code-format)))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (defun csharp/post-init-company ()
-    (spacemacs|enable-company csharp-mode)))
+  (spacemacs|init-layer-company csharp csharp-mode))

--- a/contrib/lang/ess/config.el
+++ b/contrib/lang/ess/config.el
@@ -12,8 +12,5 @@
 
 ;; Variables
 
-(when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-company-backends ess-mode))
-
 (defvar ess-enable-smart-equals t
   "If non-nil smart-equal support is enabled")

--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -12,7 +12,6 @@
 
 (defvar ess-packages
   '(
-    company
     company-ess
     ess
     ess-R-data-view
@@ -144,8 +143,7 @@ not play nicely with autoloads"
       (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (defun ess/post-init-company ()
-    (spacemacs|enable-company ess-mode))
+  (spacemacs|init-layer-company ess ess-mode)
 
   (defun ess/init-company-ess ()
     (use-package company-ess

--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -143,7 +143,7 @@ not play nicely with autoloads"
       (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company ess ess-mode)
+  (spacemacs|init-company ess ess-mode)
 
   (defun ess/init-company-ess ()
     (use-package company-ess

--- a/contrib/lang/go/config.el
+++ b/contrib/lang/go/config.el
@@ -11,6 +11,3 @@
 ;;; License: GPLv3
 
 ;; variables
-
-(when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-company-backends go-mode))

--- a/contrib/lang/go/packages.el
+++ b/contrib/lang/go/packages.el
@@ -1,6 +1,5 @@
 (defvar go-packages
   '(
-    company
     company-go
     flycheck
     go-mode
@@ -45,12 +44,9 @@ which require an initialization must be listed explicitly in the list.")
     :init (add-to-list 'ac-sources 'ac-source-go)))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (defun go/post-init-company ()
-    (spacemacs|enable-company go-mode))
-
+  (spacemacs|init-layer-company go go-mode)
   (defun go/init-company-go ()
     (use-package company-go
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init (push '(company-go :with company-yasnippet)
                   company-backends-go-mode))))

--- a/contrib/lang/go/packages.el
+++ b/contrib/lang/go/packages.el
@@ -44,7 +44,7 @@ which require an initialization must be listed explicitly in the list.")
     :init (add-to-list 'ac-sources 'ac-source-go)))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company go go-mode)
+  (spacemacs|init-company go go-mode)
   (defun go/init-company-go ()
     (use-package company-go
       :defer t

--- a/contrib/lang/haskell/config.el
+++ b/contrib/lang/haskell/config.el
@@ -11,9 +11,6 @@
 
 ;; Variables
 
-(when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-company-backends haskell-mode))
-
 (defvar haskell-enable-ghci-ng-support nil
   "If non-nil ghci-ng support is enabled")
 

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -12,7 +12,6 @@
 
 (defvar haskell-packages
   '(
-    company
     company-ghc
     flycheck
     flycheck-haskell
@@ -220,12 +219,10 @@
       (define-key shm-map (kbd "C-k") nil))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (defun haskell/post-init-company ()
-    (spacemacs|enable-company haskell-mode))
+  (spacemacs|init-layer-company haskell haskell-mode)
 
   (defun haskell/init-company-ghc ()
     (use-package company-ghc
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       ;; remove yasnippet for now, it seems to prevent

--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -219,7 +219,7 @@
       (define-key shm-map (kbd "C-k") nil))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company haskell haskell-mode)
+  (spacemacs|init-company haskell haskell-mode)
 
   (defun haskell/init-company-ghc ()
     (use-package company-ghc

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -163,3 +163,7 @@ which require an initialization must be listed explicitly in the list.")
 (defun html/init-slim-mode ()
   (use-package slim-mode
     :defer t))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (spacemacs|init-layer-company html css-mode)
+  (push '(company-css :with company-yasnippet) company-backends-css-mode))

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -165,5 +165,5 @@ which require an initialization must be listed explicitly in the list.")
     :defer t))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company html css-mode)
+  (spacemacs|init-company html css-mode)
   (push '(company-css :with company-yasnippet) company-backends-css-mode))

--- a/contrib/lang/javascript/config.el
+++ b/contrib/lang/javascript/config.el
@@ -11,7 +11,3 @@
 ;;; License: GPLv3
 
 ;; Variables
-
-
-(when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-company-backends js2-mode))

--- a/contrib/lang/javascript/packages.el
+++ b/contrib/lang/javascript/packages.el
@@ -155,7 +155,7 @@ which require an initialization must be listed explicitly in the list.")
       (evil-leader/set-key-for-mode 'js2-mode "mt" 'tern-get-type))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company javascript js2-mode)
+  (spacemacs|init-company javascript js2-mode)
   (defun javascript/init-company-tern ()
     (use-package company-tern
       :if (and (configuration-layer/package-usedp 'company)

--- a/contrib/lang/javascript/packages.el
+++ b/contrib/lang/javascript/packages.el
@@ -13,7 +13,6 @@
 (defvar javascript-packages
   '(
     coffee-mode
-    company
     company-tern
     flycheck
     js2-mode
@@ -156,9 +155,7 @@ which require an initialization must be listed explicitly in the list.")
       (evil-leader/set-key-for-mode 'js2-mode "mt" 'tern-get-type))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (defun javascript/post-init-company ()
-    (spacemacs|enable-company js2-mode))
-
+  (spacemacs|init-layer-company javascript js2-mode)
   (defun javascript/init-company-tern ()
     (use-package company-tern
       :if (and (configuration-layer/package-usedp 'company)

--- a/contrib/lang/python/config.el
+++ b/contrib/lang/python/config.el
@@ -12,9 +12,6 @@
 
 ;; variables
 
-(when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-company-backends python-mode))
-
 ;; Command prefixes
 
 ;; not supported for now

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -264,7 +264,7 @@ which require an initialization must be listed explicitly in the list.")
         (call-interactively 'sp-backward-delete-char)))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company python python-mode)
+  (spacemacs|init-company python python-mode)
 
   (defun python/init-company-anaconda ()
     (use-package company-anaconda

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -14,7 +14,6 @@
   '(
     anaconda-mode
     ac-anaconda
-    company
     company-anaconda
     eldoc
     evil-jumper
@@ -265,12 +264,10 @@ which require an initialization must be listed explicitly in the list.")
         (call-interactively 'sp-backward-delete-char)))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (defun python/post-init-company ()
-    (spacemacs|enable-company python-mode))
+  (spacemacs|init-layer-company python python-mode)
 
   (defun python/init-company-anaconda ()
     (use-package company-anaconda
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       ;; we don't use the yasnippet backend here because it

--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -128,7 +128,11 @@
   "Initialize Robe mode"
   (use-package robe
     :defer t
-    :init (add-hook 'enh-ruby-mode-hook 'robe-mode)
+    :init
+    (progn
+      (add-hook 'enh-ruby-mode-hook 'robe-mode)
+      (when (configuration-layer/layer-usedp 'auto-completion)
+        (push '(company-robe :with company-yasnippet) company-backends-enh-ruby-mode)))
     :config
     (progn
       (spacemacs|hide-lighter robe-mode)
@@ -173,3 +177,6 @@
       (evil-leader/set-key
         "mtb" 'ruby-test-run
         "mtt" 'ruby-test-run-at-point))))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (spacemacs|init-layer-company ruby enh-ruby-mode))

--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -179,4 +179,4 @@
         "mtt" 'ruby-test-run-at-point))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
-  (spacemacs|init-layer-company ruby enh-ruby-mode))
+  (spacemacs|init-company ruby enh-ruby-mode))

--- a/contrib/ycmd/packages.el
+++ b/contrib/ycmd/packages.el
@@ -15,6 +15,7 @@ which require an initialization must be listed explicitly in the list.")
   (use-package company-ycmd
     :if (configuration-layer/layer-usedp 'auto-completion)
     :defer t
+    :commands company-ycmd
     :init (push '(company-ycmd :with company-yasnippet)
                 company-backends-c-c++)))
 

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -834,6 +834,6 @@ If ASCII si not provided then UNICODE is used instead."
   "Initialize a MODE specific company backend variable.
 The variable name format is company-backends-MODE."
   `(defvar ,(intern (format "company-backends-%S" mode))
-     '((company-dabbrev-code company-keywords)
+     '((company-dabbrev-code company-gtags company-etags company-keywords)
        company-files company-dabbrev)
      ,(format "Company backend list for %S" mode)))


### PR DESCRIPTION
Adds a helper macro for handling the simple cases of adding company backends and uses that for many of the existing layers as well as porting over some new layers to the auto-completion infrastructure with it. The macro is designed for replacing copy-paste initialization of auto-completion in the common simple cases. It replaces 5 lines in 3 separate locations with one line in one location.

I used this macro to port the modes listed in #1045 to the new infrastructure as well as fixing some bugs in c-c++ (the hook was wrong and ycmd didn't load). All these new modes have been tested to work except I couldn't test company-omnisharp (I don't have C#) but that is basically the same as many others that work.

This PR also includes #1082 but doesn't actually rely on it AFAIK. It's just in here because the only concern with that PR was that this PR didn't exist yet, but now it does.