### PR TITLE
[puppet] Fix typos in README keybindings

### DIFF
--- a/contrib/lang/puppet/README.md
+++ b/contrib/lang/puppet/README.md
@@ -30,16 +30,16 @@ The following key bindings are available in Puppet Mode:
 
 Key Binding         | Description
 --------------------|--------------------------------------------------
-<kbd>SPC> m {</kbd> | Move to the beginning of the current block
-<kbd>SPC> m }</kbd> | Move to the end of the current block
-<kbd>SPC> m a</kbd> | Align parameters in the current block
-<kbd>SPC> m '</kbd> | Toggle string quoting between single and double
-<kbd>SPC> m ;</kbd> | Blank the string at point
-<kbd>SPC> m j</kbd> | Jump to a `class`, `define`, variable or resource
-<kbd>SPC> m c</kbd> | Apply the current manifest in dry-run mode
-<kbd>SPC> m v</kbd> | Validate the syntax of the current manifest
-<kbd>SPC> m l</kbd> | Check the current manifest for semantic issues
-<kbd>SPC> m $</kbd> | Interpolate with ${} in double quoted strings
+<kbd>SPC m {</kbd> | Move to the beginning of the current block
+<kbd>SPC m }</kbd> | Move to the end of the current block
+<kbd>SPC m a</kbd> | Align parameters in the current block
+<kbd>SPC m '</kbd> | Toggle string quoting between single and double
+<kbd>SPC m ;</kbd> | Blank the string at point
+<kbd>SPC m j</kbd> | Jump to a `class`, `define`, variable or resource
+<kbd>SPC m c</kbd> | Apply the current manifest in dry-run mode
+<kbd>SPC m v</kbd> | Validate the syntax of the current manifest
+<kbd>SPC m l</kbd> | Check the current manifest for semantic issues
+<kbd>SPC m $</kbd> | Interpolate with ${} in double quoted strings
 
 Use `M-x customize-group RET puppet` to customize Puppet Mode.
 


### PR DESCRIPTION
This commit removes the errant '>' character from the key bindings
section of the Puppet README.