### PR TITLE
evil-commentary and evil-nerd-commenter don't conflict

### DIFF
--- a/contrib/evil-commentary/packages.el
+++ b/contrib/evil-commentary/packages.el
@@ -14,7 +14,7 @@
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
 
-(defvar evil-commentary-excluded-packages '(evil-nerd-commenter)
+(defvar evil-commentary-excluded-packages '()
   "List of packages to exclude.")
 
 (defun evil-commentary/init-evil-commentary ()


### PR DESCRIPTION
As @syl20bnr said in gitter im chat:

> do you use all the layers ? evil-commentary layer replaces evil-nerd-commenter (but I don't see why, the 2 packages can live together)