### PR TITLE
Add keys for whole buffer copy & paste (useful when editing text to be used in a browser or app)

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1844,6 +1844,8 @@ Text related commands (start with `x`):
 <kbd>SPC x t l</kbd>   | swap (transpose) the current line with the previous one
 <kbd>SPC x w c</kbd>   | count the number of words in the selection region
 <kbd>SPC x w C</kbd>   | count the number of occurrences per word in the select region
+<kbd>SPC x y</kbd>     | copy whole buffer to clipboard (useful when copying to a browser)
+<kbd>SPC x p</kbd>     | copy clipboard and replace buffer (useful when pasting from a browser)
 
 ### Smartparens Strict mode
 

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -841,3 +841,17 @@ If ASCII si not provided then UNICODE is used instead."
   (interactive)
   (let ((comint-buffer-maximum-size 0))
     (comint-truncate-buffer)))
+
+;; http://stackoverflow.com/a/10216338/4869
+(defun copy-whole-buffer-to-clipboard ()
+  "Copy entire buffer to clipboard"
+  (interactive)
+  (clipboard-kill-ring-save (point-min) (point-max)))
+
+
+(defun copy-clipboard-to-whole-buffer ()
+  "Copy clipboard and replace buffer"
+  (interactive)
+  (delete-region (point-min) (point-max))
+  (clipboard-yank)
+  (deactivate-mark))

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -280,11 +280,13 @@ Ensure that helm is required before calling FUNC."
 ;; text -----------------------------------------------------------------------
 (evil-leader/set-key
   "xdw" 'delete-trailing-whitespace
+  "xp"  'copy-clipboard-to-whole-buffer
   "xtc" 'transpose-chars
   "xtl" 'transpose-lines
   "xtw" 'transpose-words
   "xU"  'upcase-region
   "xu"  'downcase-region
+  "xy"  'copy-whole-buffer-to-clipboard
   "xwC" 'count-words-analysis
   "xwc" 'count-words-region)
 ;; google translate -----------------------------------------------------------


### PR DESCRIPTION
When you're composing text in a browser and then you suddenly want to switch to Emacs for editing.