### PR TITLE
add a layer for pandoc-mode

### DIFF
--- a/contrib/pandoc/Readme.md
+++ b/contrib/pandoc/Readme.md
@@ -1,0 +1,35 @@
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+- [Pandoc mode](#pandoc-mode)
+    - [Keybindings](#keybindings)
+
+<!-- markdown-toc end -->
+
+# Pandoc mode #
+
+[Pandoc](http://johnmacfarlane.net/pandoc/) is a universal
+document converter. It makes it easy to e.g. convert a Markdown file to org mode
+or vice versa. It can also export your text to PDF or DOCX.
+
+To use the mode please install pandoc first.
+
+For a full list of possible conversions see the [Pandoc website](http://johnmacfarlane.net/pandoc/).
+
+An explanation of all the options offered by pandoc-mode can be found at the
+[Pandoc-mode website](http://joostkremers.github.io/pandoc-mode/). The command
+`C-c /` is mapped to <kbd>SPC P /</kbd> in Spacemacs.
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(pandoc))
+```
+## Keybindings
+
+    Key Binding     |                 Description
+--------------------|------------------------------------------------------------
+<kbd>SPC P /</kbd>  | Start pandoc-mode and open menu
+

--- a/contrib/pandoc/extensions.el
+++ b/contrib/pandoc/extensions.el
@@ -1,0 +1,33 @@
+;;; extensions.el --- pandoc Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar pandoc-pre-extensions
+  '(
+    ;; pre extension pandocs go here
+    )
+  "List of all extensions to load before the packages.")
+
+(defvar pandoc-post-extensions
+  '(
+    ;; post extension pandocs go here
+    )
+  "List of all extensions to load after the packages.")
+
+;; For each extension, define a function pandoc/init-<extension-pandoc>
+;;
+;; (defun pandoc/init-my-extension ()
+;;   "Initialize my extension"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package

--- a/contrib/pandoc/packages.el
+++ b/contrib/pandoc/packages.el
@@ -1,0 +1,50 @@
+;;; packages.el --- pandoc Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2015 Christoph Paulik & Contributors
+;;
+;; Author: Christoph Paulik <cpaulik@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar pandoc-packages
+  '(
+    ;; package pandocs go here
+    pandoc-mode
+    )
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defvar pandoc-excluded-packages '()
+  "List of packages to exclude.")
+
+;; For each package, define a function pandoc/init-<package-pandoc>
+;;
+(defun pandoc/init-pandoc-mode ()
+  "Initialize my package"
+  (use-package pandoc-mode
+    :defer t
+    :commands spacemacs/run-pandoc
+    :config
+    (progn
+      (defun spacemacs/run-pandoc ()
+        "Start pandoc for the buffer and open the menu"
+        (interactive)
+        (pandoc-mode)
+        (pandoc-main-hydra/body)
+        )
+      (add-hook 'pandoc-mode-hook 'pandoc-load-default-settings)
+      )
+    :init
+    (progn
+      (evil-leader/set-key "P/" 'spacemacs/run-pandoc)
+      )
+    )
+  )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package


### PR DESCRIPTION
This layer enables conversion of documents directly from emacs
e.g. .md to .docx or .md to .org etc using [pandoc](http://johnmacfarlane.net/pandoc/)

Feel free to change the keybinding if <kbd>SPC P</kbd> is reserved for other things or if export/conversion commands would fit better elsewhere.