### PR TITLE
S-Tab is interpreted as <backtab> in linux

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -339,6 +339,8 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
 ;;this feels like the wrong place to put these
 (add-hook 'spacemacs-mode-hook (lambda ()
                                  (local-set-key [tab] 'widget-forward)
-                                 (local-set-key [S-tab] 'widget-backward)))
+                                 (local-set-key [S-tab] 'widget-backward)
+                                 (local-set-key [backtab] 'widget-backward)
+                                 ))
 
 (provide 'core-spacemacs-buffer)


### PR DESCRIPTION
I have this problem everytime when someone wants to do sth like "Shift + Tab" :(