### PR TITLE
adds keybindings for searching the web using helm-suggest

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1682,6 +1682,13 @@ Key Binding               |                 Description
 
 **Pro Tip** Use <kbd>SPC h l</kbd> to bring back the last helm session.
 
+#### Searching the web
+
+Key Binding               |                 Description
+--------------------------|---------------------------------------------
+<kbd>SPC s w g</kbd>      | Get Google suggestions in emacs. Opens Google results in Browser.
+<kbd>SPC s w w</kbd>      | Get Wikipedia suggestions in emacs. Opens Wikipedia page in Browser.
+
 ### Persistent highlighting
 
 `Spacemacs` uses `evil-search-highlight-persist` to keep the searched expression

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -90,6 +90,9 @@ Ensure that helm is required before calling FUNC."
 (spacemacs||set-helm-key "hdt" describe-theme)
 (spacemacs||set-helm-key "hdv" describe-variable)
 (spacemacs||set-helm-key "hL" helm-locate-library)
+;; search functions -----------------------------------------------------------
+(spacemacs||set-helm-key "sww" helm-wikipedia-suggest)
+(spacemacs||set-helm-key "swg" helm-google-suggest)
 ;; errors ---------------------------------------------------------------------
 (evil-leader/set-key
   "en" 'spacemacs/next-error


### PR DESCRIPTION
I find this useful when looking something up I can directly open the Browser at the correct Google or Wikipedia search from emacs.