### PR TITLE
Hotfix: Remove ox-gfm, it's causing many issues at the moment

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -17,7 +17,7 @@
     org-bullets
     org-pomodoro
     org-repo-todo
-    ox-gfm
+    ;; ox-gfm
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")


### PR DESCRIPTION
ox-gfm appears to break org-mode. Removing it fixes org-mode.

I'm thinking ox-gfm doesn't like to be deferred, but I couldn't find anything in their source to validate that claim.

Bug reports follow:

https://gitter.im/syl20bnr/spacemacs?at=552b6ede0e3138bb6be7f231
#1130
https://gitter.im/syl20bnr/spacemacs?at=552b8751789279384a038ed8
https://gitter.im/syl20bnr/spacemacs?at=552b861f08c7a53a4a1d2cb5