### PR TITLE
Smarter buffer switching.

### DIFF
--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -28,6 +28,7 @@
             cider-repl-pop-to-buffer-on-connect nil
             cider-prompt-save-file-on-load nil
             cider-repl-use-clojure-font-lock t)
+      (push "\\*cider-repl\.\+\\*" spacemacs-useful-buffers-regexp)
       (add-hook 'clojure-mode-hook 'cider-mode)
       (add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
       (if dotspacemacs-smartparens-strict-mode
@@ -118,7 +119,7 @@ the focus."
       ;; open cider-doc directly and close it with q
       (setq cider-prompt-for-symbol nil)
       (evilify cider-docview-mode cider-docview-mode-map
-        (kbd "q") 'cider-popup-buffer-quit)
+               (kbd "q") 'cider-popup-buffer-quit)
 
       (evil-leader/set-key-for-mode 'clojure-mode
         "mhh" 'cider-doc

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -190,11 +190,11 @@
         (if arg
             (call-interactively 'compile)
 
-            (setq compile-command (format "python %s" (file-name-nondirectory
-                                                       buffer-file-name)))
-            (compile compile-command t)
-            (with-current-buffer (get-buffer "*compilation*")
-              (inferior-python-mode))))
+          (setq compile-command (format "python %s" (file-name-nondirectory
+                                                     buffer-file-name)))
+          (compile compile-command t)
+          (with-current-buffer (get-buffer "*compilation*")
+            (inferior-python-mode))))
 
       (defun spacemacs/python-execute-file-focus (arg)
         "Execute a python script in a shell and switch to the shell buffer in

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1,5 +1,3 @@
-# Spacemacs Documentation
-
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
 **Table of Contents**
 
@@ -91,6 +89,7 @@
         - [Buffers and Files](#buffers-and-files)
             - [Buffers manipulation key bindings](#buffers-manipulation-key-bindings)
             - [Buffers manipulation manipulation micro-state](#buffers-manipulation-manipulation-micro-state)
+            - [Special Buffers](#special-buffers)
             - [Files manipulations key bindings](#files-manipulations-key-bindings)
             - [Emacs and Spacemacs files](#emacs-and-spacemacs-files)
         - [Ido](#ido)
@@ -169,6 +168,8 @@
 - [Thank you](#thank-you)
 
 <!-- markdown-toc end -->
+# Spacemacs Documentation
+
 
 # Core Pillars
 
@@ -1437,8 +1438,8 @@ Key Binding            |              Description
 <kbd>SPC b m k</kbd>   | move a buffer to the top
 <kbd>SPC b m l</kbd>   | move a buffer to the right
 <kbd>SPC b M</kbd>     | swap windows using [ace-swap-window][ace-window]
-<kbd>SPC b n</kbd>     | switch to next buffer
-<kbd>SPC b p</kbd>     | switch to previous buffer
+<kbd>SPC b n</kbd>     | switch to next buffer avoiding special buffers
+<kbd>SPC b p</kbd>     | switch to previous buffer avoiding special buffers
 <kbd>SPC b P</kbd>     | copy clipboard and replace buffer (useful when pasting from a browser)
 <kbd>SPC b r</kbd>     | rename the current buffer
 <kbd>SPC b R</kbd>     | revert the current buffer (reload from disk)
@@ -1458,6 +1459,13 @@ Key Binding         | Description
 <kbd>n</kbd>        | go to next buffer (avoid special buffers)
 <kbd>N</kbd>        | go to previous buffer (avoid special buffers)
 Any other key       | leave the micro-state
+
+#### Special Buffers
+
+Unlike vim, emacs creates many buffers that most people do not need to see.
+Some examples are `*Messages*` and `*Compile-Log*`. Spacemacs tries to automatically
+ignore buffers that are not useful. However, you may want to change the way
+Spacemacs marks buffers as useful. For instructions, see the [special buffer howto][].
 
 #### Files manipulations key bindings
 
@@ -2607,6 +2615,7 @@ developers to elisp hackers!
 [guide-key-tip]: https://github.com/aki2o/guide-key-tip
 [gitter]: https://gitter.im/syl20bnr/spacemacs
 [CONTRIBUTE.md]: ./CONTRIBUTE.md
+[special buffer howto]: ./HOWTOs.md#change-special-buffer-rules
 [neotree]: https://github.com/jaypei/emacs-neotree
 [nerdtree]: https://github.com/scrooloose/nerdtree
 [anaconda-mode]: https://github.com/proofit404/anaconda-mode

--- a/doc/HOWTOs.md
+++ b/doc/HOWTOs.md
@@ -7,6 +7,7 @@
     - [Disable a package completely](#disable-a-package-completely)
     - [Disable a package only for a specific major-mode](#disable-a-package-only-for-a-specific-major-mode)
     - [Disable company for a specific major-mode](#disable-company-for-a-specific-major-mode)
+    - [Change special buffer rules](#change-special-buffer-rules)
 
 <!-- markdown-toc end -->
 
@@ -44,4 +45,28 @@ company for `python-mode`:
 
 ```elisp
 (spacemacs|disable-company python-mode)
+```
+
+## Change special buffer rules
+
+To change the way spacemacs marks buffers as useless, you can customize
+`spacemacs-useless-buffers-regexp` which marks buffers matching the regexp
+as useless. The variable `spacemacs-useful-buffers-regexp` marks buffers
+matching the regexp as useful buffers. Both can be customized the same way.
+
+Examples:
+
+```elisp
+;; Only mark helm buffers as useless
+(setq spacemacs-useless-buffers-regexp '("\\*helm\.\+\\*"))
+
+;; Marking the *Messages* buffer as useful
+(push "\\*Messages\\*" spacemacs-useful-buffers-regexp)
+```
+
+Most repl buffers are marked useful by default. This behavior can be disabled
+with the following code:
+
+```elisp
+(remove-hook 'after-change-major-mode-hook 'spacemacs//mark-repl-as-useful)
 ```

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -72,6 +72,18 @@
 ;; Also auto refresh dired, but be quiet about it
 (setq global-auto-revert-non-file-buffers t
       auto-revert-verbose nil)
+;; Regexp for useful and useless buffers for smarter buffer switching
+(defvar spacemacs-useless-buffers-regexp '("*\.\+")
+  "Regexp used to determine if a buffer is not useful.")
+(defvar spacemacs-useful-buffers-regexp '("\\*\\(scratch\\|terminal\.\+\\|ansi-term\\|eshell\\)\\*")
+  "Regexp used to define buffers that are useful despite matching
+`spacemacs-useless-buffers-regexp'.")
+(defvar spacemacs--comint-buffer-regexp '()
+  "Comint buffer regexp that is automatically removed from
+`spacemacs-useful-buffers-regexp'")
+;; Automatically make comint buffers useful-buffers
+(add-hook 'buffer-list-update-hook 'spacemacs//mark-repl-as-useful)
+(add-hook 'kill-buffer-hook 'spacemacs//trim-useful-buffers-list)
 ;; activate winner mode use to undo and redo windows layout
 (winner-mode t)
 ;; no beep pleeeeeease ! (and no visual blinking too please)

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -345,11 +345,19 @@ argument takes the kindows rotate backwards."
   (interactive "p")
   (rotate-windows (* -1 count)))
 
-(defvar spacemacs-useless-buffers-regexp '("*\.\+")
-  "Regexp used to determine if a buffer is not useful.")
-(defvar spacemacs-useful-buffers-regexp '("\\*\\(scratch\\|terminal\.\+\\|ansi-term\\|eshell\\)\\*")
-  "Regexp used to define buffers that are useful despite matching
-`spacemacs-useless-buffers-regexp'.")
+(defun spacemacs//mark-repl-as-useful ()
+  "Marks all buffers derived from `comint-mode' as useful."
+  (when (eq (get (buffer-local-value 'major-mode (current-buffer)) 'derived-mode-parent)
+            'comint-mode)
+    (let ((buffer-regexp (format "*\\%s\\*" (replace-regexp-in-string "*" "" (buffer-name)))))
+      (add-to-list 'spacemacs-useful-buffers-regexp buffer-regexp)
+      (add-to-list 'spacemacs--comint-buffer-regexp buffer-regexp))))
+
+(defun spacemacs//trim-useful-buffers-list ()
+  "Removes old regexp from `spacemacs-useful-buffers-regexp'"
+  (dolist (regexp spacemacs--comint-buffer-regexp)
+    (setq spacemacs-useful-buffers-regexp (delete regexp spacemacs-useful-buffers-regexp)))
+  (setq spacemacs--comint-buffer-regexp '()))
 
 (defun spacemacs/useless-buffer-p (buffer-name)
   "Determines if a buffer is useful."

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -312,56 +312,72 @@ the current state and point position."
 
 ;; from magnars modified by ffevotte for dedicated windows support
 (defun rotate-windows (count)
- "Rotate your windows.
+  "Rotate your windows.
 Dedicated windows are left untouched. Giving a negative prefix
 argument takes the kindows rotate backwards."
- (interactive "p")
- (let* ((non-dedicated-windows (remove-if 'window-dedicated-p (window-list)))
-        (num-windows (length non-dedicated-windows))
-        (i 0)
-        (step (+ num-windows count)))
-   (cond ((not (> num-windows 1))
-          (message "You can't rotate a single window!"))
-         (t
-          (dotimes (counter (- num-windows 1))
-            (let* ((next-i (% (+ step i) num-windows))
+  (interactive "p")
+  (let* ((non-dedicated-windows (remove-if 'window-dedicated-p (window-list)))
+         (num-windows (length non-dedicated-windows))
+         (i 0)
+         (step (+ num-windows count)))
+    (cond ((not (> num-windows 1))
+           (message "You can't rotate a single window!"))
+          (t
+           (dotimes (counter (- num-windows 1))
+             (let* ((next-i (% (+ step i) num-windows))
 
-                   (w1 (elt non-dedicated-windows i))
-                   (w2 (elt non-dedicated-windows next-i))
+                    (w1 (elt non-dedicated-windows i))
+                    (w2 (elt non-dedicated-windows next-i))
 
-                   (b1 (window-buffer w1))
-                   (b2 (window-buffer w2))
+                    (b1 (window-buffer w1))
+                    (b2 (window-buffer w2))
 
-                   (s1 (window-start w1))
-                   (s2 (window-start w2)))
-              (set-window-buffer w1 b2)
-              (set-window-buffer w2 b1)
-              (set-window-start w1 s2)
-              (set-window-start w2 s1)
-              (setq i next-i)))))))
+                    (s1 (window-start w1))
+                    (s2 (window-start w2)))
+               (set-window-buffer w1 b2)
+               (set-window-buffer w2 b1)
+               (set-window-start w1 s2)
+               (set-window-start w2 s1)
+               (setq i next-i)))))))
 
 (defun rotate-windows-backward (count)
- "Rotate your windows backward."
+  "Rotate your windows backward."
   (interactive "p")
   (rotate-windows (* -1 count)))
 
-(defun spacemacs/next-real-buffer ()
-  "Swtich to the next buffer and avoid special buffers."
-  (interactive)
-  (switch-to-next-buffer)
-  (let ((i 0))
-    (while (and (< i 100) (string-equal "*" (substring (buffer-name) 0 1)))
-      (1+ i)
-      (switch-to-next-buffer))))
+(defvar spacemacs-useless-buffers-regexp '("*\.\+")
+  "Regexp used to determine if a buffer is not useful.")
+(defvar spacemacs-useful-buffers-regexp '("\\*\\(scratch\\|terminal\.\+\\|ansi-term\\|eshell\\)\\*")
+  "Regexp used to define buffers that are useful despite matching
+`spacemacs-useless-buffers-regexp'.")
 
-(defun spacemacs/prev-real-buffer ()
-  "Swtich to the previous buffer and avoid special buffers."
+(defun spacemacs/useless-buffer-p (buffer-name)
+  "Determines if a buffer is useful."
+  (cond ((cl-loop for regexp in spacemacs-useful-buffers-regexp do
+                  (if (string-match regexp buffer-name)
+                      (return t))) nil)
+        ((cl-loop for regexp in spacemacs-useless-buffers-regexp do
+                  (if (string-match regexp buffer-name)
+                      (return t))) t)
+        (t nil)))
+
+(defun spacemacs/next-useful-buffer ()
+  "Switch to the next buffer and avoid special buffers."
   (interactive)
-  (switch-to-prev-buffer)
-  (let ((i 0))
-    (while (and (< i 100) (string-equal "*" (substring (buffer-name) 0 1)))
-      (1+ i)
-      (switch-to-prev-buffer))))
+  (let ((start-buffer (current-buffer)))
+    (next-buffer)
+    (while (and (spacemacs/useless-buffer-p (buffer-name (current-buffer)))
+                (not (eq (current-buffer) start-buffer)))
+      (next-buffer))))
+
+(defun spacemacs/previous-useful-buffer ()
+  "Switch to the previous buffer and avoid special buffers."
+  (interactive)
+  (let ((start-buffer (current-buffer)))
+    (previous-buffer)
+    (while (and (spacemacs/useless-buffer-p (buffer-name (current-buffer)))
+                (not (eq (current-buffer) start-buffer)))
+      (previous-buffer))))
 
 ;; from magnars
 (defun rename-current-buffer-file ()

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -62,9 +62,9 @@
   "bK"  'kill-other-buffers
   "bk"  'ido-kill-buffer
   "b C-k" 'kill-matching-buffers-rudely
-  "bn"  'switch-to-next-buffer
-  "bp"  'switch-to-prev-buffer
   "bP"  'copy-clipboard-to-whole-buffer
+  "bn"  'spacemacs/next-useful-buffer
+  "bp"  'spacemacs/previous-useful-buffer
   "bR"  'spacemacs/safe-revert-buffer
   "br"  'rename-current-buffer-file
   "bY"  'copy-whole-buffer-to-clipboard
@@ -322,8 +322,8 @@ Ensure that helm is required before calling FUNC."
   :evil-leader "b."
   :bindings
   ("K" kill-this-buffer)
-  ("n" spacemacs/next-real-buffer)
-  ("N" spacemacs/prev-real-buffer))
+  ("n" spacemacs/next-useful-buffer)
+  ("N" spacemacs/previous-useful-buffer))
 
 ;; end of Buffer micro state
 


### PR DESCRIPTION
See #1127 

The default spacemacs buffer-switching is pretty simple right now. It checks if a buffer starts with `*` and ignores it if it does. This doesn't take into account useful buffers like `*eshell*` and `*scratch*`.

TODO: 

- [x] Make `spacemacs-useful-buffer-regexp` a list so layers like clojure can add buffers to the list (ex. `cider-repl` buffers). I'm no elisp wizard, any tips?

- [x] Add support in layers that create useful buffers.

- [x] Document new behavior
