### PR TITLE
feature: add gtags layer

### DIFF
--- a/contrib/gtags/README.md
+++ b/contrib/gtags/README.md
@@ -1,0 +1,121 @@
+# Helm Gtags contribution layer for Spacemacs
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+- [Helm Gtags contribution layer for Spacemacs](#helm-gtags-contribution-layer-for-spacemacs)
+    - [Description](#description)
+    - [Features](#features)
+    - [Install](#install)
+        - [GNU Global](#gnu-global)
+    - [Usage](#usage)
+    - [Key bindings](#key-bindings)
+
+<!-- markdown-toc end -->
+
+## Description
+
+`helm-gtags` and `ggtags` are clients for GNU Global. GNU Global is a source
+code tagging system that allows querying symbol locations in source code, such
+as definitions or references.
+
+## Features
+
+- Select any tag in a project retreived by gtags
+- Resume previous helm-gtags sesssion
+- Jump to a location based on context
+- Find definitions
+- Find references
+- Present tags in current function only
+- Create a tag databas
+- Jump to definitions in file
+- Show stack of visited locations
+- Manually update tag database
+- Jump to next location in context stack
+- Jump to previous location in context stack
+- Jump to a file in tag database
+
+## Install
+
+### GNU Global
+
+You can install `helm-gtags` from the software repository of your OS. For example, in Ubuntu:
+
+```shell-script
+sudo apt-get install global
+```
+
+To use `helm-gtags`, you first have to install GNU Global: [Download link][gnu-global-download].
+
+Download the latest tar.gz archive, then run these commands:
+
+```shell-script
+tar xvf global-6.4.tar.gz
+cd global-6.4
+./configure
+make
+sudo make install
+```
+
+[gnu-global-download]: https://www.gnu.org/software/global/download.html
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(gtags))
+```
+
+## Usage
+
+Before using the helm-gtags, remember to create a GTAGS database by the following methods:
+
+- From within Emacs, runs the command `helm-gtags-create-tags`, which is bound
+  to `SPC m g c`. If the language is not directly supported by GNU Global, you
+  can choose `ctags` or `pygment` as a backend to generate tag database.
+
+- From inside terminal, runs gtags at your project root in terminal:
+
+```shell-script
+cd /path/to/project/root
+gtags
+```
+
+If the language is not directly supported by `gtags` but `ctags`, use this command instead:
+
+```shell-script
+gtags --gtagslabel=ctags
+```
+
+### Eldoc integration
+
+This layer also integrates `ggtags` for its Eldoc feature. That means, when
+writing code, you can look at the minibuffer (at the bottom) and see variable
+and function definition of the symbol the cursor is on. However, this feature is
+only activated for programming modes that are not one of these languages:
+
+- C mode
+- C++ mode
+- Common Lisp
+- Emacs Lisp
+- Python
+- Ruby-mode
+
+Since these modes have better Eldoc integration already.
+
+## Key bindings
+
+    Key Binding       |                 Description
+----------------------|------------------------------------------------------------
+<kbd>SPC m g s</kbd>  | select any tag in a project retreived by gtags
+<kbd>SPC m g R</kbd>  | resume previous helm-gtags sesssion
+<kbd>SPC m g g</kbd>  | jump to a location based on context
+<kbd>SPC m g d</kbd>  | find definitions
+<kbd>SPC m g r</kbd>  | find references
+<kbd>SPC m g i</kbd>  | present tags in current function only
+<kbd>SPC m g c</kbd>  | create a tag databas
+<kbd>SPC m g l</kbd>  | jump to definitions in file
+<kbd>SPC m g S</kbd>  | show stack of visited locations
+<kbd>SPC m g u</kbd>  | manually update tag database
+<kbd>SPC m g n</kbd>  | jump to next location in context stack
+<kbd>SPC m g p</kbd>  | jump to previous location in context stack
+<kbd>SPC m g f</kbd>  | jump to a file in tag database

--- a/contrib/gtags/extensions.el
+++ b/contrib/gtags/extensions.el
@@ -1,0 +1,33 @@
+;;; extensions.el --- gtags Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar gtags-pre-extensions
+  '(
+    ;; pre extension gtagss go here
+    )
+  "List of all extensions to load before the packages.")
+
+(defvar gtags-post-extensions
+  '(
+    ;; post extension gtagss go here
+    )
+  "List of all extensions to load after the packages.")
+
+;; For each extension, define a function gtags/init-<extension-gtags>
+;;
+;; (defun gtags/init-my-extension ()
+;;   "Initialize my extension"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package

--- a/contrib/gtags/packages.el
+++ b/contrib/gtags/packages.el
@@ -1,0 +1,86 @@
+;;; packages.el --- gtags Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar gtags-packages
+  '(
+    ;; package gtagss go here
+    helm-gtags
+    ggtags
+    )
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defvar gtags-excluded-packages '()
+  "List of packages to exclude.")
+
+;; For each package, define a function gtags/init-<package-gtags>
+;;
+(defun gtags/init-ggtags ()
+  "Initialize my package"
+  (use-package ggtags
+    :defer t
+    :init
+    (progn
+      (add-hook 'prog-mode-hook
+                (lambda ()
+                  ;; these modes have better eldoc integration
+                  (unless (derived-mode-p 'c-mode
+                                          'c++-mode
+                                          'lisp-mode
+                                          'emacs-lisp-mode
+                                          'python-mode
+                                          'ruby-mode)
+                    (ggtags-mode 1)
+                    (eldoc-mode 1)
+                    (setq-local eldoc-documentation-function #'ggtags-eldoc-function)))))))
+
+(defun gtags/init-helm-gtags ()
+  (use-package helm-gtags
+    :defer t
+    :init
+    (progn
+      ;; add to Dired so we can select tag in Dired buffer
+      ;; with helm-gtags-select
+      ;; so is eshell
+      (add-hook 'prog-mode-hook 'helm-gtags-mode)
+      (setq helm-gtags-ignore-case t
+            helm-gtags-auto-update t
+            helm-gtags-use-input-at-cursor t
+            helm-gtags-pulse-at-cursor t))
+    :config
+    (progn
+      ;; if anyone uses helm-gtags, they would want to use these key bindings
+      (define-key helm-gtags-mode-map (kbd "M-.") 'helm-gtags-dwim)
+      (define-key helm-gtags-mode-map (kbd "C-x 4 .") 'helm-gtags-find-tag-other-window)
+      (define-key helm-gtags-mode-map (kbd "M-,") 'helm-gtags-pop-stack)
+      (define-key helm-gtags-mode-map (kbd "M-*") 'pop-tag-mark)
+
+      (let (l (if (eq dotspacemacs-editing-style 'emacs)
+                  dotspacemacs-major-mode-emacs-leader-key
+                dotspacemacs-major-mode-leader-key))
+        (define-key helm-gtags-mode-map (kbd (concat l " gs")) 'helm-gtags-select)
+        (define-key helm-gtags-mode-map (kbd (concat l " gs")) 'helm-gtags-resume)
+        (define-key helm-gtags-mode-map (kbd (concat l " gR")) 'helm-gtags-dwim)
+        (define-key helm-gtags-mode-map (kbd (concat l " gg")) 'helm-gtags-find-tag)
+        (define-key helm-gtags-mode-map (kbd (concat l " gd")) 'helm-gtags-find-rtag)
+        (define-key helm-gtags-mode-map (kbd (concat l " gr")) 'helm-gtags-tags-in-this-function)
+        (define-key helm-gtags-mode-map (kbd (concat l " gi")) 'helm-gtags-create-tags)
+        (define-key helm-gtags-mode-map (kbd (concat l " gc")) 'helm-gtags-parse-file)
+        (define-key helm-gtags-mode-map (kbd (concat l " gl")) 'helm-gtags-show-stack)
+        (define-key helm-gtags-mode-map (kbd (concat l " gS")) 'helm-gtags-update-tags)
+        (define-key helm-gtags-mode-map (kbd (concat l " gu")) 'helm-gtags-next-history)
+        (define-key helm-gtags-mode-map (kbd (concat l " gn")) 'helm-gtags-previous-history)
+        (define-key helm-gtags-mode-map (kbd (concat l " gp")) 'helm-gtags-select-path)))
+    ;; Often the body of an initialize function uses `use-package'
+    ;; For more info on `use-package', see readme:
+    ;; https://github.com/jwiegley/use-package
+    ))


### PR DESCRIPTION
helm-gtags is a helm client for GNU Global. GNU GLOBAL is a source code
tagging system that allows querying symbol locations in source code,
such as definitions or references. Currently, helm-gtags with GNU Global
is faster than anything else in Emacs for retrieving a large amount of
candidates (even more than 10000 candidates, the list appears in an
instant) and offers more features for language that GNU Global directly:
C, C++, Yacc, Java, PHP4 and assembly.