### PR TITLE
Enable c++ mode in proper files

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -30,6 +30,9 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :config
     (progn
+      (add-to-list 'auto-mode-alist '("\\.cxx$" . c++-mode))
+      (add-to-list 'auto-mode-alist '("\\.hpp$" . c++-mode))
+      (add-to-list 'auto-mode-alist '("\\.h$" . c++-mode))
       (require 'compile)
       (add-to-list 'semantic-default-submodes 'global-semantic-stickyfunc-mode)
       (add-to-list 'semantic-default-submodes 'global-semantic-idle-summary-mode)


### PR DESCRIPTION
Aside from cpp, better enable c++-mode in .h file since C is a subset of
C++ anyway. Without it, when entering .h file of C++, syntax
highlighting is wrong.