### PR TITLE
[Fix #992] Use gh-md for superior reading experience

### DIFF
--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -112,7 +112,14 @@
                  (concat (ht-get configuration-layer-paths
                                  (intern candidate))
                          candidate)))))
-    (find-file (concat path file))))
+    (if helm-current-prefix-arg
+        (find-file (concat path file))
+      (condition-case nil
+          (with-current-buffer (find-file-noselect (concat path file))
+            (gh-md-render-buffer)
+            (kill-this-buffer))
+        ;; if anything fails, fall back to simply open file
+        (find-file (concat path file))))))
 
 (defun helm-spacemacs//layer-action-open-readme (candidate)
   "Open the `README.md' file of the passed CANDIDATE."

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -54,6 +54,7 @@
     flx-ido
     flyspell
     fringe-helper
+    gh-md
     golden-ratio
     google-translate
     guide-key-tip
@@ -1104,6 +1105,8 @@ which require an initialization must be listed explicitly in the list.")
       (spacemacs|diminish flyspell-mode " ⓢ" " s"))))
 
 (defun spacemacs/init-fringe-helper ())
+
+(defun spacemacs/init-gh-md ())
 
 (defun spacemacs/init-golden-ratio ()
   (use-package golden-ratio


### PR DESCRIPTION
With gh-md, it can use Github API to render HTML to be viewed right
inside Emacs using eww web browser. It is especially useful since it
does not required markdown-mode to be installed. One benefit is that it
automatically open the rendered buffer in other window, so for example
user is learning Clojure mode and want to read documentation of Clojure
layer, he will just simply fired up helm-spacemacs, narrow to `clojure`
and press RET. Then a nicely formatted documentation buffer appears on
the right side with all the key bindings of that layer, which greatly
enhances the explorability of Spacemacs.