### PR TITLE
turn on color in helm-swoop

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1602,6 +1602,7 @@ ignored)."
     :init
     (setq helm-swoop-split-with-multiple-windows t
           helm-swoop-split-direction 'split-window-vertically
+          helm-swoop-speed-or-color t
           helm-swoop-split-window-function 'helm-default-display-buffer)
     (evil-leader/set-key
       "sS"    'helm-multi-swoop


### PR DESCRIPTION
Turn on `helm-swoop-speed-or-color` for better user experience.