### PR TITLE
Suggestion for common keybinding in markup languagues

### DIFF
--- a/contrib/email/gnus/README.md
+++ b/contrib/email/gnus/README.md
@@ -117,7 +117,7 @@ Key Binding  | Gnus mode - Description
 `<RET>`      | Summary Buffer(RSS) - Open article Link in browser 
 `<TAB>`      | Summary Buffer(RSS) - Open article and switch to it
 `<SPC> m o`  | Message Buffer - Use org mode to convert into html email
-`<SPC> m h`  | Org Mode - Send current buffer as email message
+`<SPC> m H`  | Org Mode - Send current buffer as HTML email message
 
 
 [application specific password]: https://support.google.com/accounts/answer/185833?hl=en

--- a/contrib/email/gnus/packages.el
+++ b/contrib/email/gnus/packages.el
@@ -96,4 +96,4 @@
       (evil-leader/set-key-for-mode 'message-mode
         "mo" 'org-mime-htmlize)
       (evil-leader/set-key-for-mode 'org-mode
-        "mh" 'org-mime-org-buffer-htmlize))))
+        "mH" 'org-mime-org-buffer-htmlize))))

--- a/contrib/lang/markdown/README.md
+++ b/contrib/lang/markdown/README.md
@@ -12,13 +12,14 @@
     - [Key bindings](#key-bindings)
         - [Element insertion](#element-insertion)
         - [Element removal](#element-removal)
-        - [Promotion, Demotion, Completion, and Cycling](#promotion-demotion-completion-and-cycling)
+        - [Completion, and Cycling](#completion-and-cycling)
         - [Following and Jumping](#following-and-jumping)
         - [Indentation](#indentation)
         - [Header navigation](#header-navigation)
         - [Buffer-wide commands](#buffer-wide-commands)
         - [List editing](#list-editing)
         - [Movement](#movement)
+        - [Promotion, Demotion](#promotion-demotion)
 
 <!-- markdown-toc end -->
 
@@ -49,31 +50,31 @@ To generate a table of contents type on top of the buffer:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m -</kbd>    | insert hr
-<kbd>SPC m a l</kbd>  | insert link
-<kbd>SPC m a L</kbd>  | insert reference link dwim
-<kbd>SPC m a u</kbd>  | insert uri
-<kbd>SPC m a f</kbd>  | insert footnote
-<kbd>SPC m a w</kbd>  | insert wiki link
+<kbd>SPC m -</kbd>    | insert horizontal line
+<kbd>SPC m i l</kbd>  | insert link
+<kbd>SPC m i L</kbd>  | insert reference link dwim
+<kbd>SPC m i u</kbd>  | insert uri
+<kbd>SPC m i f</kbd>  | insert footnote
+<kbd>SPC m i w</kbd>  | insert wiki link
 <kbd>SPC m i i</kbd>  | insert image
 <kbd>SPC m i I</kbd>  | insert reference image
-<kbd>SPC m t h</kbd>  | insert header dwim
-<kbd>SPC m t H</kbd>  | insert header setext dwim
-<kbd>SPC m t 1</kbd>  | insert header atx 1
-<kbd>SPC m t 2</kbd>  | insert header atx 2
-<kbd>SPC m t 3</kbd>  | insert header atx 3
-<kbd>SPC m t 4</kbd>  | insert header atx 4
-<kbd>SPC m t 5</kbd>  | insert header atx 5
-<kbd>SPC m t 6</kbd>  | insert header atx 6
-<kbd>SPC m t !</kbd>  | insert header setext 1
-<kbd>SPC m t @</kbd>  | insert header setext 2
-<kbd>SPC m s s</kbd>  | insert bold
-<kbd>SPC m s e</kbd>  | insert italic
-<kbd>SPC m s c</kbd>  | insert code
-<kbd>SPC m s b</kbd>  | insert blockquote
-<kbd>SPC m s B</kbd>  | blockquote region
-<kbd>SPC m s p</kbd>  | insert pre
-<kbd>SPC m s P</kbd>  | pre region
+<kbd>SPC m h h</kbd>  | insert header dwim
+<kbd>SPC m h H</kbd>  | insert header setext dwim
+<kbd>SPC m h 1</kbd>  | insert header atx 1
+<kbd>SPC m h 2</kbd>  | insert header atx 2
+<kbd>SPC m h 3</kbd>  | insert header atx 3
+<kbd>SPC m h 4</kbd>  | insert header atx 4
+<kbd>SPC m h 5</kbd>  | insert header atx 5
+<kbd>SPC m h 6</kbd>  | insert header atx 6
+<kbd>SPC m h !</kbd>  | insert header setext 1
+<kbd>SPC m h @</kbd>  | insert header setext 2
+<kbd>SPC m r b</kbd>  | make region bold or insert bold
+<kbd>SPC m r i</kbd>  | make region italic or insert italic
+<kbd>SPC m r c</kbd>  | make region code or insert code
+<kbd>SPC m r q</kbd>  | make region blockquote or insert blockquote
+<kbd>SPC m r Q</kbd>  | blockquote region
+<kbd>SPC m r p</kbd>  | make region or insert pre
+<kbd>SPC m r P</kbd>  | pre region
 
 ### Element removal
 
@@ -81,7 +82,7 @@ To generate a table of contents type on top of the buffer:
 ----------------------|------------------------------------------------------------
 <kbd>SPC m k</kbd>    | kill thing at point
 
-### Promotion, Demotion, Completion, and Cycling
+### Completion, and Cycling
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
@@ -107,11 +108,10 @@ To generate a table of contents type on top of the buffer:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m n</kbd>    | outline next visible heading
-<kbd>SPC m p</kbd>    | outline previous visible heading
-<kbd>SPC m f</kbd>    | outline forward same level
-<kbd>SPC m b</kbd>    | outline backward same level
-<kbd>SPC m u</kbd>    | outline up heading
+<kbd>gj</kbd>         | outline forward same level
+<kbd>gk</kbd>         | outline backward same level
+<kbd>gh</kbd>         | outline up one level
+<kbd>gl</kbd>         | outline next visible heading
 
 ### Buffer-wide commands
 
@@ -145,6 +145,15 @@ To generate a table of contents type on top of the buffer:
 <kbd>SPC m }</kbd>    | forward paragraph
 <kbd>SPC m N</kbd>    | next link
 <kbd>SPC m P</kbd>    | previous link
+
+### Promotion, Demotion
+
+    Key Binding       |                 Description
+----------------------|------------------------------------------------------------
+<kbd>M-k</kbd>        | markdown-move-up
+<kbd>M-j</kbd>        | markdown-move-down
+<kbd>M-h</kbd>        | markdown-promote
+<kbd>M-l</kbd>        | markdown-demote
 
 [markdown-mode]: http://jblevins.org/git/markdown-mode.git/
 [markdown-toc]: https://github.com/ardumont/markdown-toc

--- a/contrib/lang/markdown/README.md
+++ b/contrib/lang/markdown/README.md
@@ -49,7 +49,7 @@ To generate a table of contents type on top of the buffer:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m "</kbd>    | insert hr
+<kbd>SPC m -</kbd>    | insert hr
 <kbd>SPC m a l</kbd>  | insert link
 <kbd>SPC m a L</kbd>  | insert reference link dwim
 <kbd>SPC m a u</kbd>  | insert uri

--- a/contrib/lang/markdown/packages.el
+++ b/contrib/lang/markdown/packages.el
@@ -28,8 +28,8 @@
       (sp-local-pair 'markdown-mode "'" nil :actions nil))
     (progn
       (evil-leader/set-key-for-mode 'markdown-mode
-        ;; Element insertion
-        "m\""   'markdown-insert-hr
+        ;; Insertion of common elements
+        "m-"   'markdown-insert-hr
         "mil"   'markdown-insert-link
         "miL"   'markdown-insert-reference-link-dwim
         "miu"   'markdown-insert-uri
@@ -37,6 +37,7 @@
         "miw"   'markdown-insert-wiki-link
         "mii"   'markdown-insert-image
         "miI"   'markdown-insert-reference-image
+        ;; headings
         "mhh"   'markdown-insert-header-dwim
         "mhH"   'markdown-insert-header-setext-dwim
         "mh1"   'markdown-insert-header-atx-1
@@ -47,29 +48,26 @@
         "mh6"   'markdown-insert-header-atx-6
         "mh!"   'markdown-insert-header-setext-1
         "mh@"   'markdown-insert-header-setext-2
-        "msb"   'markdown-insert-bold
-        "msi"   'markdown-insert-italic
-        "msc"   'markdown-insert-code
-        "msq"   'markdown-insert-blockquote
-        "msQ"   'markdown-blockquote-region
-        "msp"   'markdown-insert-pre
-        "msP"   'markdown-pre-region
+        ;; text manipulation
+        "mtb"   'markdown-insert-bold
+        "mti"   'markdown-insert-italic
+        "mtc"   'markdown-insert-code
+        "mtq"   'markdown-insert-blockquote
+        "mtQ"   'markdown-blockquote-region
+        "mtp"   'markdown-insert-pre
+        "mtP"   'markdown-pre-region
         ;; Element removal
         "mk"    'markdown-kill-thing-at-point
         ;; Promotion, Demotion, Completion, and Cycling
         "m]"    'markdown-complete
         ;; Following and Jumping
         "mo"   'markdown-follow-thing-at-point
-        "mj"   'markdown-jump
+        "m <RET>"   'markdown-jump
         ;; Indentation
         "m>"   'markdown-indent-region
         "m<"   'markdown-exdent-region
         ;; Header navigation
-        "mn"   'outline-next-visible-heading
         "mp"   'outline-previous-visible-heading
-        "mf"   'outline-forward-same-level
-        "mb"   'outline-backward-same-level
-        "mu"   'outline-up-heading
         ;; Buffer-wide commands
         "mc]"  'markdown-complete-buffer
         "mcm"  'markdown-other-window
@@ -81,10 +79,6 @@
         "mcc"  'markdown-check-refs
         "mcn"  'markdown-cleanup-list-numbers
         ;; List editing
-        "mlk"  'markdown-move-up
-        "mlj"  'markdown-move-down
-        "mlh"  'markdown-promote
-        "mll"  'markdown-demote
         "mli"  'markdown-insert-list-item
         ;; Movement
         "m{"   'markdown-backward-paragraph
@@ -92,7 +86,16 @@
         "mN"   'markdown-next-link
         "mP"   'markdown-previous-link)
 
-
+      ;; normal state movements
+      (evil-define-key 'normal markdown-mode-map
+        "gj" 'outline-forward-same-level
+        "gk" 'outline-backward-same-level
+        "gh" 'outline-up-heading
+        ;; next visible heading is not exactly what we want but close enough
+        "gl" 'outline-next-visible-heading
+        )
+      (define-key markdown-mode-map (kbd "M-k") 'markdown-move-up)
+      (define-key markdown-mode-map (kbd "M-j") 'markdown-move-down)
       (define-key markdown-mode-map (kbd "M-h") 'markdown-promote)
       (define-key markdown-mode-map (kbd "M-l") 'markdown-demote))))
 

--- a/contrib/lang/markdown/packages.el
+++ b/contrib/lang/markdown/packages.el
@@ -48,17 +48,17 @@
         "mh6"   'markdown-insert-header-atx-6
         "mh!"   'markdown-insert-header-setext-1
         "mh@"   'markdown-insert-header-setext-2
-        ;; text manipulation
-        "mtb"   'markdown-insert-bold
-        "mti"   'markdown-insert-italic
-        "mtc"   'markdown-insert-code
-        "mtq"   'markdown-insert-blockquote
-        "mtQ"   'markdown-blockquote-region
-        "mtp"   'markdown-insert-pre
-        "mtP"   'markdown-pre-region
+        ;; region manipulation
+        "mrb"   'markdown-insert-bold
+        "mri"   'markdown-insert-italic
+        "mrc"   'markdown-insert-code
+        "mrq"   'markdown-insert-blockquote
+        "mrQ"   'markdown-blockquote-region
+        "mrp"   'markdown-insert-pre
+        "mrP"   'markdown-pre-region
         ;; Element removal
         "mk"    'markdown-kill-thing-at-point
-        ;; Promotion, Demotion, Completion, and Cycling
+        ;; Completion, and Cycling
         "m]"    'markdown-complete
         ;; Following and Jumping
         "mo"   'markdown-follow-thing-at-point
@@ -66,8 +66,6 @@
         ;; Indentation
         "m>"   'markdown-indent-region
         "m<"   'markdown-exdent-region
-        ;; Header navigation
-        "mp"   'outline-previous-visible-heading
         ;; Buffer-wide commands
         "mc]"  'markdown-complete-buffer
         "mcm"  'markdown-other-window
@@ -86,7 +84,7 @@
         "mN"   'markdown-next-link
         "mP"   'markdown-previous-link)
 
-      ;; normal state movements
+      ;; Header navigation in normal state movements
       (evil-define-key 'normal markdown-mode-map
         "gj" 'outline-forward-same-level
         "gk" 'outline-backward-same-level
@@ -94,6 +92,8 @@
         ;; next visible heading is not exactly what we want but close enough
         "gl" 'outline-next-visible-heading
         )
+
+      ;; Promotion, Demotion
       (define-key markdown-mode-map (kbd "M-k") 'markdown-move-up)
       (define-key markdown-mode-map (kbd "M-j") 'markdown-move-down)
       (define-key markdown-mode-map (kbd "M-h") 'markdown-promote)

--- a/contrib/lang/markdown/packages.el
+++ b/contrib/lang/markdown/packages.el
@@ -30,35 +30,33 @@
       (evil-leader/set-key-for-mode 'markdown-mode
         ;; Element insertion
         "m\""   'markdown-insert-hr
-        "mal"   'markdown-insert-link
-        "maL"   'markdown-insert-reference-link-dwim
-        "mau"   'markdown-insert-uri
-        "maf"   'markdown-insert-footnote
-        "maw"   'markdown-insert-wiki-link
+        "mil"   'markdown-insert-link
+        "miL"   'markdown-insert-reference-link-dwim
+        "miu"   'markdown-insert-uri
+        "mif"   'markdown-insert-footnote
+        "miw"   'markdown-insert-wiki-link
         "mii"   'markdown-insert-image
         "miI"   'markdown-insert-reference-image
-        "mth"   'markdown-insert-header-dwim
-        "mtH"   'markdown-insert-header-setext-dwim
-        "mt1"   'markdown-insert-header-atx-1
-        "mt2"   'markdown-insert-header-atx-2
-        "mt3"   'markdown-insert-header-atx-3
-        "mt4"   'markdown-insert-header-atx-4
-        "mt5"   'markdown-insert-header-atx-5
-        "mt6"   'markdown-insert-header-atx-6
-        "mt!"   'markdown-insert-header-setext-1
-        "mt@"   'markdown-insert-header-setext-2
-        "mss"   'markdown-insert-bold
-        "mse"   'markdown-insert-italic
+        "mhh"   'markdown-insert-header-dwim
+        "mhH"   'markdown-insert-header-setext-dwim
+        "mh1"   'markdown-insert-header-atx-1
+        "mh2"   'markdown-insert-header-atx-2
+        "mh3"   'markdown-insert-header-atx-3
+        "mh4"   'markdown-insert-header-atx-4
+        "mh5"   'markdown-insert-header-atx-5
+        "mh6"   'markdown-insert-header-atx-6
+        "mh!"   'markdown-insert-header-setext-1
+        "mh@"   'markdown-insert-header-setext-2
+        "msb"   'markdown-insert-bold
+        "msi"   'markdown-insert-italic
         "msc"   'markdown-insert-code
-        "msb"   'markdown-insert-blockquote
-        "msB"   'markdown-blockquote-region
+        "msq"   'markdown-insert-blockquote
+        "msQ"   'markdown-blockquote-region
         "msp"   'markdown-insert-pre
         "msP"   'markdown-pre-region
         ;; Element removal
         "mk"    'markdown-kill-thing-at-point
         ;; Promotion, Demotion, Completion, and Cycling
-        "m="    'markdown-promote
-        "m-"    'markdown-demote
         "m]"    'markdown-complete
         ;; Following and Jumping
         "mo"   'markdown-follow-thing-at-point
@@ -92,7 +90,11 @@
         "m{"   'markdown-backward-paragraph
         "m}"   'markdown-forward-paragraph
         "mN"   'markdown-next-link
-        "mP"   'markdown-previous-link))))
+        "mP"   'markdown-previous-link)
+
+
+      (define-key markdown-mode-map (kbd "M-h") 'markdown-promote)
+      (define-key markdown-mode-map (kbd "M-l") 'markdown-demote))))
 
 (defun markdown/init-markdown-toc ()
   (use-package markdown-toc

--- a/contrib/org/README.md
+++ b/contrib/org/README.md
@@ -12,6 +12,8 @@
         - [Different bullets](#different-bullets)
     - [Key bindings](#key-bindings)
         - [Org with evil-org-mode](#org-with-evil-org-mode)
+            - [Element insertion](#element-insertion)
+            - [Org emphasize](#org-emphasize)
         - [Pomodoro](#pomodoro)
         - [Org-repo-todo](#org-repo-todo)
 
@@ -51,24 +53,27 @@ You can tweak the bullets displayed in the org buffer in the function
 
 ### Org with evil-org-mode
 
-    Key Binding       |                 Description
-----------------------|------------------------------------------------------------
-<kbd>SPC m a</kbd>    | org-agenda
-<kbd>SPC m A</kbd>    | org-archive-subtree
-<kbd>SPC m c</kbd>    | org-capture
-<kbd>SPC m C</kbd>    | evil-org-recompute-clocks
-<kbd>SPC m d</kbd>    | org-deadline
-<kbd>SPC m e</kbd>    | org-export-dispatch
-<kbd>SPC m f</kbd>    | org-set-effort
-<kbd>SPC m i</kbd>    | org-clock-in
-<kbd>SPC m j</kbd>    | helm-org-in-buffer-headings
-<kbd>SPC m l</kbd>    | evil-org-open-links
-<kbd>SPC m m</kbd>    | org-ctrl-c-ctrl-c
-<kbd>SPC m o</kbd>    | org-clock-out
-<kbd>SPC m q</kbd>    | org-clock-cancel
-<kbd>SPC m r</kbd>    | org-refile
-<kbd>SPC m s</kbd>    | org-schedule
-<kbd>SPC m t</kbd>    | org-show-todo-tree
+    Key Binding                                          |          Description
+---------------------------------------------------------|------------------------------
+<kbd>SPC m a</kbd>                                       | org-agenda
+<kbd>SPC m A</kbd>                                       | org-archive-subtree
+<kbd>SPC m c</kbd>                                       | org-capture
+<kbd>SPC m C</kbd>                                       | evil-org-recompute-clocks
+<kbd>SPC m d</kbd>                                       | org-deadline
+<kbd>SPC m e</kbd>                                       | org-export-dispatch
+<kbd>SPC m f</kbd>                                       | org-set-effort
+<kbd>SPC m I</kbd>                                       | org-clock-in
+<kbd>SPC m j</kbd>                                       | helm-org-in-buffer-headings
+<kbd>SPC m RET</kbd>                                     | evil-org-open-links
+<kbd>SPC m m</kbd>                                       | org-ctrl-c-ctrl-c
+<kbd>SPC m <dotspacemacs-major-mode-leader-key></kbd>    | org-ctrl-c-ctrl-c
+<kbd>SPC m O</kbd>                                       | org-clock-out
+<kbd>SPC m q</kbd>                                       | org-clock-cancel
+<kbd>SPC m R</kbd>                                       | org-refile
+<kbd>SPC m s</kbd>                                       | org-schedule
+<kbd>SPC m T</kbd>                                       | org-show-todo-tree
+<kbd>SPC m '</kbd>                                       | org-edit-special
+
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
@@ -86,7 +91,7 @@ You can tweak the bullets displayed in the org buffer in the function
 <kbd>H</kbd>          | org-beginning-of-line
 <kbd>L</kbd>          | org-end-of-line
 <kbd>o</kbd>          | always-insert-item
-<kbd>O</kbd>          | org-insert-heading
+<kbd>O</kbd>          | org-open-above
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
@@ -101,6 +106,27 @@ You can tweak the bullets displayed in the org buffer in the function
 <kbd>M-o</kbd>        | org-insert-heading+org-metaright
 <kbd>M-t</kbd>        | org-insert-todo-heading nil+ org-metaright
 
+#### Element insertion
+
+    Key Binding             |                 Description
+----------------------------|------------------------------------------------------------
+<kbd>SPC m h h</kbd>        | org-insert-heading-after-current
+<kbd>SPC m h H</kbd>        | org-insert-heading
+<kbd>SPC m i l</kbd>        | org-insert-link
+<kbd>SPC m i f</kbd>        | org-insert-footnote
+
+#### Org emphasize
+
+    Key Binding             |                 Description
+----------------------------|------------------------------------------------------------
+<kbd>SPC m r b</kbd>        | make region bold
+<kbd>SPC m r i</kbd>        | make region italic
+<kbd>SPC m r c</kbd>        | make region code
+<kbd>SPC m r u</kbd>        | make region underline
+<kbd>SPC m r v</kbd>        | make region verbose
+<kbd>SPC m r s</kbd>        | make region strike-through
+<kbd>SPC m r SPC</kbd>      | clear region emphasis
+
 ### Pomodoro
 
     Key Binding       |                 Description
@@ -111,6 +137,7 @@ You can tweak the bullets displayed in the org buffer in the function
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
+<kbd>SPC C c</kbd>    | org-capture
 <kbd>SPC C t</kbd>    | ort/capture-todo
 <kbd>SPC C T</kbd>    | ort/capture-todo-check
 <kbd>SPC m g t</kbd>  | ort/goto-todos

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -37,8 +37,11 @@
            "a" nil "ma" 'org-agenda
            "c" nil "mA" 'org-archive-subtree
            "o" nil "mC" 'evil-org-recompute-clocks
-           "l" nil "ml" 'evil-org-open-links
+           "l" nil "m <RET>" 'evil-org-open-links
            "t" nil "mt" 'org-show-todo-tree)
+      (evil-define-key 'normal evil-org-mode-map
+        "O" 'evil-open-above
+        )
       (spacemacs|diminish evil-org-mode " ⓔ" " e"))))
 
 (defun org/init-org ()
@@ -62,9 +65,21 @@
         "mj" 'helm-org-in-buffer-headings
         "mo" 'org-clock-out
         "mm" 'org-ctrl-c-ctrl-c
+        (concat "m" dotspacemacs-major-mode-leader-key) 'org-ctrl-c-ctrl-c
         "mq" 'org-clock-cancel
         "mr" 'org-refile
-        "ms" 'org-schedule)
+        "mS" 'org-schedule
+        ;; headings
+        "mhh" 'org-insert-heading
+        "mhH" 'org-insert-heading-after-current
+        ;; changeing emphasis
+        "msb" '(lambda () (interactive) (org-emphasize ?*))
+        "msi" '(lambda () (interactive) (org-emphasize ?/))
+        "msc" '(lambda () (interactive) (org-emphasize ?~))
+        "msu" '(lambda () (interactive) (org-emphasize ?_))
+        "msv" '(lambda () (interactive) (org-emphasize ?=))
+        "mss" '(lambda () (interactive) (org-emphasize ?+))
+        )
 
       (eval-after-load "org-agenda"
         '(progn
@@ -79,7 +94,13 @@
     (progn
       (require 'org-indent)
       (define-key global-map "\C-cl" 'org-store-link)
-      (define-key global-map "\C-ca" 'org-agenda))))
+      (define-key global-map "\C-ca" 'org-agenda)
+      (evil-leader/set-key
+        "Cc" 'org-capture
+        )
+      ))
+
+  )
 
 (defun org/init-org-bullets ()
   (use-package org-bullets

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -38,7 +38,7 @@
            "c" nil "mA" 'org-archive-subtree
            "o" nil "mC" 'evil-org-recompute-clocks
            "l" nil "m <RET>" 'evil-org-open-links
-           "t" nil "mt" 'org-show-todo-tree)
+           "t" nil "mT" 'org-show-todo-tree)
       (evil-define-key 'normal evil-org-mode-map
         "O" 'evil-open-above
         )
@@ -56,6 +56,11 @@
         '(spacemacs|hide-lighter org-indent-mode))
       (setq org-startup-indented t)
 
+      (defmacro spacemacs|org-emphasize (fname char)
+        "Make function for setting the emphasize in org mode"
+        `(defun ,fname () (interactive)
+                (org-emphasize ,char))
+        )
       (evil-leader/set-key-for-mode 'org-mode
         "mc" 'org-capture
         "md" 'org-deadline
@@ -73,12 +78,13 @@
         "mhh" 'org-insert-heading
         "mhH" 'org-insert-heading-after-current
         ;; changeing emphasis
-        "msb" '(lambda () (interactive) (org-emphasize ?*))
-        "msi" '(lambda () (interactive) (org-emphasize ?/))
-        "msc" '(lambda () (interactive) (org-emphasize ?~))
-        "msu" '(lambda () (interactive) (org-emphasize ?_))
-        "msv" '(lambda () (interactive) (org-emphasize ?=))
-        "mss" '(lambda () (interactive) (org-emphasize ?+))
+        "mtb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
+        "mti" (spacemacs|org-emphasize spacemacs/org-italic ?/)
+        "mtc" (spacemacs|org-emphasize spacemacs/org-code ?~)
+        "mtu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
+        "mtv" (spacemacs|org-emphasize spacemacs/org-verbose ?=)
+        "mts" (spacemacs|org-emphasize spacemacs/org-strike-through ?+)
+        "mt <SPC>" (spacemacs|org-emphasize spacemacs/org-clear ? )
         )
 
       (eval-after-load "org-agenda"

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -66,18 +66,23 @@
         "md" 'org-deadline
         "me" 'org-export-dispatch
         "mf" 'org-set-effort
-        "mi" 'org-clock-in
+        "mI" 'org-clock-in
         "mj" 'helm-org-in-buffer-headings
-        "mo" 'org-clock-out
+        "mO" 'org-clock-out
         "mm" 'org-ctrl-c-ctrl-c
         (concat "m" dotspacemacs-major-mode-leader-key) 'org-ctrl-c-ctrl-c
         "mq" 'org-clock-cancel
         "mr" 'org-refile
         "mS" 'org-schedule
         ;; headings
-        "mhh" 'org-insert-heading
-        "mhH" 'org-insert-heading-after-current
-        ;; changeing emphasis
+        "mhh" 'org-insert-heading-after-current
+        "mhH" 'org-insert-heading
+        ;; insertion of common elements
+        "mil" 'org-insert-link
+        "mif" 'org-footnote-new
+        ;; images and other link types have no commands in org mode-line
+        ;; could be inserted using yasnippet?
+        ;; text manipulation
         "mtb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
         "mti" (spacemacs|org-emphasize spacemacs/org-italic ?/)
         "mtc" (spacemacs|org-emphasize spacemacs/org-code ?~)

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -57,7 +57,7 @@
       (setq org-startup-indented t)
 
       (defmacro spacemacs|org-emphasize (fname char)
-        "Make function for setting the emphasize in org mode"
+        "Make function for setting the emphasis in org mode"
         `(defun ,fname () (interactive)
                 (org-emphasize ,char))
         )
@@ -72,8 +72,9 @@
         "mm" 'org-ctrl-c-ctrl-c
         (concat "m" dotspacemacs-major-mode-leader-key) 'org-ctrl-c-ctrl-c
         "mq" 'org-clock-cancel
-        "mr" 'org-refile
-        "mS" 'org-schedule
+        "mR" 'org-refile
+        "ms" 'org-schedule
+        "m'" 'org-edit-special
         ;; headings
         "mhh" 'org-insert-heading-after-current
         "mhH" 'org-insert-heading
@@ -82,14 +83,14 @@
         "mif" 'org-footnote-new
         ;; images and other link types have no commands in org mode-line
         ;; could be inserted using yasnippet?
-        ;; text manipulation
-        "mtb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
-        "mti" (spacemacs|org-emphasize spacemacs/org-italic ?/)
-        "mtc" (spacemacs|org-emphasize spacemacs/org-code ?~)
-        "mtu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
-        "mtv" (spacemacs|org-emphasize spacemacs/org-verbose ?=)
-        "mts" (spacemacs|org-emphasize spacemacs/org-strike-through ?+)
-        "mt <SPC>" (spacemacs|org-emphasize spacemacs/org-clear ? )
+        ;; region manipulation
+        "mrb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
+        "mri" (spacemacs|org-emphasize spacemacs/org-italic ?/)
+        "mrc" (spacemacs|org-emphasize spacemacs/org-code ?~)
+        "mru" (spacemacs|org-emphasize spacemacs/org-underline ?_)
+        "mrv" (spacemacs|org-emphasize spacemacs/org-verbose ?=)
+        "mrs" (spacemacs|org-emphasize spacemacs/org-strike-through ?+)
+        "mr <SPC>" (spacemacs|org-emphasize spacemacs/org-clear ? )
         )
 
       (eval-after-load "org-agenda"

--- a/doc/CONVENTIONS.md
+++ b/doc/CONVENTIONS.md
@@ -222,6 +222,72 @@ Notes:
 the spacemacs level and ideally the function should be proposed as a patch
 upstream (major mode repository).
 
+### Plain Text Markup Languages
+
+For layers supporting markup languages please follow the following keybindings
+whenever applicable.
+
+#### Headers ####
+
+All header functionality should be grouped under <kbd>SPC m h</kbd>
+
+    Key Binding      |                 Description
+---------------------|------------------------------------------------------------
+<kbd>m h h</kbd>     | Insert a header 
+<kbd>m h H</kbd>     | Insert a header alternative method (if existing) 
+<kbd>m h 1</kbd>     | Insert a header of level 1 (if possible)
+<kbd>m h 2</kbd>     | Insert a header of level 2 (if possible)
+
+#### Text manipulation ####
+
+Text manipulation commands should be grouped under <kbd>SPC m t</kbd>
+
+    Key Binding      |                 Description
+---------------------|------------------------------------------------------------
+<kbd>m t b</kbd>     | Make text bold
+<kbd>m t i</kbd>     | Make text italic
+<kbd>m t c</kbd>     | Make text code
+<kbd>m t u</kbd>     | Make text underlined
+<kbd>m t v</kbd>     | Make text verbose
+<kbd>m t s</kbd>     | Make text strike-through
+<kbd>m t q</kbd>     | Quote a text
+<kbd>m t <SPC></kbd> | Remove formatting from text
+
+#### Insertion of common elements ####
+
+Insertion of common elements like links or footnotes should be grouped under <kbd>SPC m i</kbd>
+
+    Key Binding      |                 Description
+---------------------|------------------------------------------------------------
+<kbd>m i l</kbd>     | Insert link
+<kbd>m i u</kbd>     | Insert url
+<kbd>m i f</kbd>     | Insert footnote
+<kbd>m i w</kbd>     | Insert wiki-link
+<kbd>m i i</kbd>     | Insert image
+
+#### Movement in normal mode ####
+
+In normal mode Vim style movement should be enabled
+
+    Key Binding      |                 Description
+---------------------|------------------------------------------------------------
+<kbd>gh</kbd>        | Move up one level in headings
+<kbd>gl</kbd>        | Move down one level in headings
+<kbd>gj</kbd>        | Move to next heading on same level
+<kbd>gk</kbd>        | Move to previous heading on same level
+
+#### Promotion, Demotion and element movement ####
+
+Promotion and demotion and movement of headings or list elements (whatever is possible)
+should be enabled with the following keys in any mode
+
+    Key Binding      |                 Description
+---------------------|------------------------------------------------------------
+<kbd>M-j</kbd>       | Move element down
+<kbd>M-k</kbd>       | Move element up
+<kbd>M-h</kbd>       | Promote heading by one level
+<kbd>M-l</kbd>       | Demote heading by one level
+
 ### Tests
 
 A lot of languages have their own test frameworks. These frameworks share

--- a/doc/CONVENTIONS.md
+++ b/doc/CONVENTIONS.md
@@ -240,18 +240,18 @@ All header functionality should be grouped under <kbd>SPC m h</kbd>
 
 #### Text manipulation ####
 
-Text manipulation commands should be grouped under <kbd>SPC m t</kbd>
+Manipulation of text regions should be grouped under <kbd>SPC m r</kbd>
 
     Key Binding      |                 Description
 ---------------------|------------------------------------------------------------
-<kbd>m t b</kbd>     | Make text bold
-<kbd>m t i</kbd>     | Make text italic
-<kbd>m t c</kbd>     | Make text code
-<kbd>m t u</kbd>     | Make text underlined
-<kbd>m t v</kbd>     | Make text verbose
-<kbd>m t s</kbd>     | Make text strike-through
-<kbd>m t q</kbd>     | Quote a text
-<kbd>m t <SPC></kbd> | Remove formatting from text
+<kbd>m r b</kbd>     | Make region bold
+<kbd>m r i</kbd>     | Make region italic
+<kbd>m r c</kbd>     | Make region code
+<kbd>m r u</kbd>     | Make region underlined
+<kbd>m r v</kbd>     | Make region verbose
+<kbd>m r s</kbd>     | Make region strike-through
+<kbd>m r q</kbd>     | Quote a region
+<kbd>m r <SPC></kbd> | Remove formatting from region
 
 #### Insertion of common elements ####
 
@@ -267,7 +267,7 @@ Insertion of common elements like links or footnotes should be grouped under <kb
 
 #### Movement in normal mode ####
 
-In normal mode Vim style movement should be enabled
+In normal mode Vim style movement should be enabled with these keybindings:
 
     Key Binding      |                 Description
 ---------------------|------------------------------------------------------------
@@ -287,6 +287,10 @@ should be enabled with the following keys in any mode
 <kbd>M-k</kbd>       | Move element up
 <kbd>M-h</kbd>       | Promote heading by one level
 <kbd>M-l</kbd>       | Demote heading by one level
+
+#### Table editing ####
+
+If table specific commands are available the they are grouped under the <kbd>SPC m t</kbd> group.
 
 ### Tests
 


### PR DESCRIPTION
This is an attempt to solve issue #1110 .

Please see the updated CONVENTIONS.md for the suggested keybindings.

I have also updated the org and markdown layers to follow the bindings as far as possible so you can test them. 

In org mode I had to capitalize some existing keybindings to make room for the suggested keybindings.

I will update the markdown and org README files and squash my commits when the discussion about this is over.

Since org mode and other markup languages might not have commands for all insertions we could also think about using snippets for these modes to provide consistent behaviour across languages.