### PR TITLE
Add config layer for TypeScript

### DIFF
--- a/contrib/lang/typescript/packages.el
+++ b/contrib/lang/typescript/packages.el
@@ -1,0 +1,35 @@
+;;; packages.el --- typescript Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar typescript-packages '(tss)
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defvar typescript-excluded-packages '()
+  "List of packages to exclude.")
+
+(defun typescript/init-tss ()
+  "Initialize my package"
+  (use-package tss
+    :mode ("\\.ts\\'" . typescript-mode)
+    :defer t
+    :init
+    (progn
+      (require 'typescript)
+      (require 'tss)
+      (evil-leader/set-key-for-mode 'typescript-mode
+        "mh" 'tss-popup-help
+        "md" 'tss-jump-to-definition
+        "mcc" 'tss-run-flymake))
+    :config
+    (progn
+      (tss-config-default))))


### PR DESCRIPTION
This adds support for TypeScript editing via [typescript-tools](https://github.com/clausreinke/typescript-tools) and [emacs-tss](https://github.com/aki2o/emacs-tss).

It is functional but not quite ready to be merged. This is a sort of preemptive PR so I can ask a couple of questions:

* There are external requirements, typescript-tools and the TypeScript compiler tsc. Is it okay to just detail this in the layer's README?
* Generally, is this right? Newcomer to Spacemacs so there's surely something I've got wrong :-)

EDIT: Nevermind, already noticed that I'm on the wrong branch. Closing this to redo.