### PR TITLE
Add modes that should be ignored by golden-ratio

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1136,6 +1136,26 @@ which require an initialization must be listed explicitly in the list.")
                           :evil-leader "tg")
     :config
     (progn
+      (setq golden-ratio-exclude-modes '("bs-mode"
+                                         "calc-mode"
+                                         "ediff-mode"
+                                         "dired-mode"
+                                         "gud-mode"
+                                         "gdb-locals-mode"
+                                         "gdb-registers-mode"
+                                         "gdb-breakpoints-mode"
+                                         "gdb-threads-mode"
+                                         "gdb-frames-mode"
+                                         "gdb-inferior-io-mode"
+                                         "gud-mode"
+                                         "gdb-inferior-io-mode"
+                                         "gdb-disassembly-mode"
+                                         "gdb-memory-mode"
+                                         "restclient-mode"
+                                         "speedbar-mode"
+                                         "restclient-mode"
+                                         ))
+
       (setq golden-ratio-extra-commands
             (append golden-ratio-extra-commands
                     '(windmove-left


### PR DESCRIPTION
- ediff-mode: this is the small one-line panel at the bottom when using
  ediff. Should not be messed up.

- gdb buffers: this should not be messed up in a gdb-many-windows
  debugging session.

- Dired buffers don't need extra empty space, so is speedbar and bs-show buffer.