### PR TITLE
Use file-truename in case user-emacs-directory is symlink

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -239,7 +239,7 @@ found."
 (defun spacemacs/git-has-remote (remote)
   "Return non nil if REMOTE is declared."
   (let((proc-buffer "git-has-remote")
-       (default-directory user-emacs-directory))
+       (default-directory (file-truename user-emacs-directory)))
     (when (eq 0 (process-file "git" nil proc-buffer nil "remote"))
         (with-current-buffer proc-buffer
           (prog2
@@ -250,7 +250,7 @@ found."
 (defun spacemacs/git-declare-remote (remote url)
   "Declare a new REMOTE pointing to URL, return t if no error."
   (let((proc-buffer "git-declare-remote")
-       (default-directory user-emacs-directory))
+       (default-directory (file-truename user-emacs-directory)))
     (prog1
         (eq 0 (process-file "git" nil proc-buffer nil
                             "remote" "add" remote url))
@@ -259,7 +259,7 @@ found."
 (defun spacemacs/git-fetch-tags (remote branch)
   "Fetch the tags for BRANCH in REMOTE repository."
   (let((proc-buffer "git-fetch-tags")
-       (default-directory user-emacs-directory))
+       (default-directory (file-truename user-emacs-directory)))
     (prog2
         (eq 0 (process-file "git" nil proc-buffer nil
                             "fetch" remote branch))
@@ -271,7 +271,7 @@ found."
 (defun spacemacs/git-latest-tag (remote branch)
   "Returns the latest tag on REMOTE/BRANCH."
   (let((proc-buffer "git-latest-tag")
-       (default-directory user-emacs-directory)
+       (default-directory (file-truename user-emacs-directory))
        (where (format "%s/%s" remote branch)))
     (when (eq 0 (process-file "git" nil proc-buffer nil
                               "describe" "--tags" "--abbrev=0"


### PR DESCRIPTION
If not and user-emacs-directory is symlink, all following git commands will fail, resulting in "Unable to check for new version."