### PR TITLE
Modularize and add quickhelp button

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -113,7 +113,9 @@ Supported properties:
   "Open the change log for the current version."
   (interactive)
   ;; For now hardcode it
-  (find-file  file)
+  (find-file file)
+  (org-indent-mode)
+  (view-mode)
   (goto-char (point-min))
   (re-search-forward anchor-text)
   (beginning-of-line)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -109,13 +109,13 @@ Supported properties:
         (dolist (val ',def-key)
           (define-key (eval (car val)) (kbd (cdr val)) ',func))))))
 
-(defun spacemacs/open-change-log ()
+(defun spacemacs/open-file (file anchor-text)
   "Open the change log for the current version."
   (interactive)
   ;; For now hardcode it
-  (find-file (concat user-emacs-directory "CHANGELOG.org"))
+  (find-file  file)
   (goto-char (point-min))
-  (re-search-forward "Releases 0.101.x")
+  (re-search-forward anchor-text)
   (beginning-of-line)
   (show-subtree))
 

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -378,6 +378,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
 (defun spacemacs-buffer//insert-buttons ()
   (goto-char (point-max))
   (insert "      ")
+  (spacemacs//insert--shorcut "m" "[?]" t)
   (widget-create 'url-link
                  :tag (propertize "?" 'face 'font-lock-doc-face)
                  :help-echo "Open the quickhelp."
@@ -443,18 +444,19 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                  :follow-link "\C-m")
   (insert "\n\n"))
 
-(defmacro spacemacs//insert-widget-with-shorcut (shortcut-char search-label)
+(defmacro spacemacs//insert--shorcut (shortcut-char search-label &optional no-next-line)
   `(define-key spacemacs-mode-map ,shortcut-char (lambda ()
                                                    (interactive)
                                                    (unless (search-forward ,search-label (point-max) t)
                                                      (search-backward ,search-label (point-min) t))
-                                                   (forward-line 1)
+                                                   (unless ,no-next-line
+                                                     (forward-line 1))
                                                    (back-to-indentation))))
 
 (defun spacemacs-buffer//insert-file-list (list-display-name list shortcut-char)
   (when (car list)
-    (spacemacs//insert-widget-with-shorcut "r" "Recent Files:")
-    (spacemacs//insert-widget-with-shorcut "p" "Projects:")
+    (spacemacs//insert--shorcut "r" "Recent Files:")
+    (spacemacs//insert--shorcut "p" "Projects:")
     (insert list-display-name)
     (mapc (lambda (el)
             (insert "\n    ")

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -149,8 +149,7 @@ HELP-STRING is the help message of the button for additional action."
                                                              spacemacs-buffer--banner-length
                                                              caption))))
       (add-to-list 'spacemacs-buffer--note-widgets (widget-create 'text note))
-      (dolist (w additional-widgets)
-        (add-to-list 'spacemacs-buffer--note-widgets (funcall w))))))
+      (funcall additional-widgets))))
 
 (defun spacemacs-buffer//insert-note-p (type)
   "Decicde if whether to insert note widget or not based on current note TYPE.
@@ -187,38 +186,41 @@ If TYPE is nil, just remove widgets."
 (defun spacemacs-buffer//insert-quickhelp-widget (file)
   "Insert quickhelp with content from FILE."
   (spacemacs-buffer//remove-existing-widget-if-exist)
-  (let ((w1 (lambda ()
-              (widget-create 'push-button
-                             :tag (propertize "Evil Tutorial" 'face 'font-lock-warning-face)
-                             :help-echo "Teach you how to use Vim basics."
-                             :action (lambda (&rest ignore) (call-interactively #'evil-tutor-start))
-                             :mouse-face 'highlight
-                             :follow-link "\C-m")))
-        (w2 (lambda ()
-              (widget-create 'push-button
-                             :tag (propertize "Emacs Tutorial" 'face 'font-lock-warning-face)
-                             :help-echo "Teach you how to use Emacs basics."
-                             :action (lambda (&rest ignore) (call-interactively #'help-with-tutorial))
-                             :mouse-face 'highlight
-                             :follow-link "\C-m"))))
-    (spacemacs-buffer//insert-note file "Quick Help" (list w1 w2)))
+  (let ((widget-func (lambda ()
+                       (add-to-list 'spacemacs-buffer--note-widgets
+                                    (widget-create 'push-button
+                                                   :tag (propertize "Evil Tutorial" 'face 'font-lock-keyword-face)
+                                                   :help-echo "Teach you how to use Vim basics."
+                                                   :action (lambda (&rest ignore) (call-interactively #'evil-tutor-start))
+                                                   :mouse-face 'highlight
+                                                   :follow-link "\C-m"))
+                       (add-to-list 'spacemacs-buffer--note-widgets
+                                    (widget-create 'push-button
+                                                   :tag (propertize "Emacs Tutorial" 'face 'font-lock-keyword-face)
+                                                   :help-echo "Teach you how to use Emacs basics."
+                                                   :action (lambda (&rest ignore) (call-interactively #'help-with-tutorial))
+                                                   :mouse-face 'highlight
+                                                   :follow-link "\C-m")))))
+    (spacemacs-buffer//insert-note file "Quick Help" widget-func))
   (setq spacemacs-buffer--previous-insert-type 'quickhelp))
 
 (defun spacemacs-buffer//insert-release-note-widget (file)
   "Insert release note with content from FILE."
   (spacemacs-buffer//remove-existing-widget-if-exist)
-  (let ((w1 (lambda () (widget-create 'push-button
-                                      :tag (propertize "Click here for full change log" 'face 'font-lock-warning-face)
-                                      :help-echo "Open the full change log."
-                                      :action (lambda (&rest ignore)
-                                                (funcall 'spacemacs/open-file
-                                                         (concat user-emacs-directory "CHANGELOG.org")
-                                                         "Release 0.102.x"))
-                                      :mouse-face 'highlight
-                                      :follow-link "\C-m"))))
+  (let ((widget-func (lambda ()
+                       (add-to-list 'spacemacs-buffer--note-widgets
+                                    (widget-create 'push-button
+                                                   :tag (propertize "Click here for full change log" 'face 'font-lock-warning-face)
+                                                   :help-echo "Open the full change log."
+                                                   :action (lambda (&rest ignore)
+                                                             (funcall 'spacemacs/open-file
+                                                                      (concat user-emacs-directory "CHANGELOG.org")
+                                                                      "Release 0.102.x"))
+                                                   :mouse-face 'highlight
+                                                   :follow-link "\C-m")))))
     (spacemacs-buffer//insert-note file
                                    " Important Notes (Release 0.102.x) "
-                                   (list w1)))
+                                   widget-func))
 
   (setq spacemacs-buffer--release-note-version nil)
   (spacemacs/dump-vars-to-file
@@ -497,7 +499,8 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
     (with-current-buffer spacemacs-buffer-name
       (goto-char (point-min))
       (re-search-forward "Homepage")
-      (beginning-of-line))))
+      (beginning-of-line)
+      (widget-forward 1))))
 
 ;;this feels like the wrong place to put these
 (add-hook 'spacemacs-mode-hook (lambda ()

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -202,13 +202,13 @@ If TYPE is nil, just remove widgets."
   "Insert release note with content from FILE."
   (spacemacs-buffer//remove-existing-widget-if-exist)
   (spacemacs-buffer//insert-release-note file
-                                         " Important Notes (Release 0.101.x) "
+                                         " Important Notes (Release 0.102.x) "
                                          "Click here for full change log"
                                          "Open the full change log."
                                          (lambda (&rest ignore)
                                            (funcall 'spacemacs/open-file
                                                     (concat user-emacs-directory "CHANGELOG.org")
-                                                    "Releases 0.101.x")))
+                                                    "Release 0.102.x")))
   (setq spacemacs-buffer--release-note-version nil)
   (spacemacs/dump-vars-to-file
    '(spacemacs-buffer--release-note-version) spacemacs-buffer--cache-file)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -495,7 +495,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                                  ;; S-tab is backtab in terminal
                                  (local-set-key [backtab] 'widget-backward)
                                  (local-set-key [return] 'widget-button-press)
-                                 (local-set-key [down-mouse-1] 'widget-button-press)
+                                 (local-set-key [down-mouse-1] 'widget-button-click)
                                  ))
 
 (provide 'core-spacemacs-buffer)

--- a/core/templates/quickhelp.txt
+++ b/core/templates/quickhelp.txt
@@ -6,6 +6,8 @@ Press r to jump to recent file list.
 
 Press p to jump to project list.
 
-Press SPC (in Vim mode) or `Alt-m` (in Emacs mode) to access Spacemacs commands.
+Press m to jump to the top menu.
+
+Press SPC (in Vim mode) or Alt-m (in Emacs mode) to access Spacemacs commands.
 
 Please consult Spacemacs documentation for more details.

--- a/core/templates/quickhelp.txt
+++ b/core/templates/quickhelp.txt
@@ -1,0 +1,11 @@
+Press TAB to move to next button.
+
+Press SHIFT-TAB to move to previous button.
+
+Press r to jump to recent file list.
+
+Press p to jump to project list.
+
+Press SPC (in Vim mode) or `Alt-m` (in Emacs mode) to access Spacemacs commands.
+
+Please consult Spacemacs documentation for more details.


### PR DESCRIPTION
Split the current hardcoded release note display functions into smaller
reusable functions. Then reuse it for creating quickhelp button.