### PR TITLE
Add binding for EOF (^D) in term

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1947,7 +1947,7 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
         (term-send-raw-string "\t"))
 
       (add-to-list 'term-bind-key-alist '("<tab>" . term-send-tab))
-      (add-to-list 'term-bind-key-alist `(,(kbd "C-c C-d") . term-send-eof)))))
+      (evil-define-key 'insert term-raw-map (kbd "C-c C-d") 'term-send-eof))))
 
 (defun spacemacs/init-neotree ()
   (use-package neotree

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1946,7 +1946,8 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
         (interactive)
         (term-send-raw-string "\t"))
 
-      (add-to-list 'term-bind-key-alist '("<tab>" . term-send-tab)))))
+      (add-to-list 'term-bind-key-alist '("<tab>" . term-send-tab))
+      (add-to-list 'term-bind-key-alist `(,(kbd "C-c C-d") . term-send-eof)))))
 
 (defun spacemacs/init-neotree ()
   (use-package neotree


### PR DESCRIPTION
This is a useful binding to have, and is bound similarly to
term-send-esc (`C-c C-e`) and term-interrupt-subjob (`C-c C-c`).