### PR TITLE
Use org-startup-indented instead of a hook

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -54,7 +54,7 @@ which require an initialization must be listed explicitly in the list.")
 
       (eval-after-load 'org-indent
         '(spacemacs|hide-lighter org-indent-mode))
-      (add-hook 'org-mode-hook 'org-indent-mode)
+      (setq org-startup-indented t)
 
       (evil-leader/set-key-for-mode 'org-mode
         "mc" 'org-capture


### PR DESCRIPTION
Use the variable provided by org-mode to start in indented mode instead
of adding a hook.  This way, a user can override the setting of
org-startup-indented and not wonder why the heck org buffers are still
starting in org-indent-mode.