### PR TITLE
add semantic stickyfunc toggle and activate in python layer

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -27,6 +27,7 @@
     python
     semantic
     smartparens
+    stickyfunc-enhance
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -239,7 +240,20 @@ which require an initialization must be listed explicitly in the list.")
 (defun python/init-semantic ()
   ;; required to correctly load semantic mode
   ;; using the python-mode-hook triggers an error about a deleted buffer.
-  (eval-after-load 'python '(semantic-mode 1)))
+  (eval-after-load 'python '(semantic-mode 1))
+  (add-to-list 'semantic-default-submodes 'global-semantic-stickyfunc-mode))
+
+(defun python/init-stickyfunc-enhance ()
+  (use-package stickyfunc-enhance
+    :defer t
+    :init
+    (progn
+      (defun spacemacs/lazy-load-stickyfunc-enhance ()
+        "Lazy load the package."
+        (interactive)
+        (require 'stickyfunc-enhance))
+      (add-hook 'python-mode-hook 'spacemacs/lazy-load-stickyfunc-enhance)
+                    )))
 
 (defun python/init-smartparens ()
   (defadvice python-indent-dedent-line-backspace

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -224,6 +224,18 @@ Ensure that helm is required before calling FUNC."
                       :off (menu-bar-mode -1)
                       :documentation "Display the menu bar."
                       :evil-leader "Tm")
+(spacemacs|add-toggle semantic-stickyfunc
+                      :status semantic-stickyfunc-mode
+                      :on (semantic-stickyfunc-mode)
+                      :off (semantic-stickyfunc-mode -1)
+                      :documentation "Enable semantic-stickyfunc."
+                      :evil-leader "Ts")
+(spacemacs|add-toggle semantic-stickfunc-globally
+                      :status global-semantic-stickyfunc-mode
+                      :on (global-semantic-stickyfunc-mode)
+                      :off (global-semantic-stickyfunc-mode -1)
+                      :documentation "Enable semantic-stickyfunc globally."
+                      :evil-leader "T C-s")
 ;; quit -----------------------------------------------------------------------
 (evil-leader/set-key
   "qs" 'spacemacs/save-buffers-kill-emacs


### PR DESCRIPTION
As discussed a while ago in #738 this adds a toggle for semantic stickyfunc

It also adds the stickyfunc-enhance function to the python layer

If you want I can separate these two things into 2 PR