### PR TITLE
[feature] Add highlight-parentheses [#1173]

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -123,6 +123,10 @@ it reaches the top or bottom of the screen.")
 (defvar dotspacemacs-smartparens-strict-mode nil
   "If non-nil smartparens-strict-mode will be enabled in programming modes.")
 
+(defvar dotspacemacs-highlight-delimiters 'scope
+  "Select a scope to highlight delimiters. Possible value is `scope', `all' or `none'.
+Default is `scope'")
+
 (defvar dotspacemacs-delete-orphan-packages t
   "If non-nil spacemacs will delete any orphan packages, i.e. packages that are
 declared in a layer which is not a member of

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -72,6 +72,7 @@
     helm-themes
     highlight-indentation
     highlight-numbers
+    highlight-parentheses
     hippie-exp
     hl-anything
     hungry-delete
@@ -1700,6 +1701,17 @@ If ARG is non nil then `ag' and `pt' and ignored."
       (add-hook 'prog-mode-hook 'highlight-numbers-mode)
       (add-hook 'asm-mode-hook (lambda () (highlight-numbers-mode -1))))))
 
+(defun spacemacs/init-highlight-parentheses ()
+  (use-package highlight-parentheses
+    :defer t
+    :init
+    (progn
+      (when (eq dotspacemacs-highlight-delimiters 'scope)
+        (add-hook 'prog-mode-hook #'highlight-parentheses-mode))
+      (evil-leader/set-key "tCp" 'highlight-parentheses-mode)
+      ;; use green to clearly distinguish the sexp we are in
+      (setq hl-paren-colors '("Springgreen3" "IndianRed1" "IndianRed3" "IndianRed4")))))
+
 (defun spacemacs/init-hippie-exp ()
   (global-set-key (kbd "M-/") 'hippie-expand) ;; replace dabbrev-expand
   (setq hippie-expand-try-functions-list
@@ -2487,7 +2499,8 @@ It is a string holding:
     :init
     (progn
       (evil-leader/set-key "tCd" 'rainbow-delimiters-mode)
-      (add-to-hooks 'rainbow-delimiters-mode '(prog-mode-hook)))))
+      (when (eq dotspacemacs-highlight-delimiters 'all)
+        (add-to-hooks 'rainbow-delimiters-mode '(prog-mode-hook))))))
 
 (defun spacemacs/init-recentf ()
   (use-package recentf


### PR DESCRIPTION
highlight-parentheses highlights the sexp scope the cursor is in and
3 upper sexp levels. We don't have to actually place the cursor on a
parenthesis just to see where it ends or begins. This package takes of this
issue regardless where we are in the sexp.

It's more useful than `rainbow-delimiters`, which I think only make our buffer look prettier.