### PR TITLE
Add deft layer

### DIFF
--- a/contrib/deft/README.md
+++ b/contrib/deft/README.md
@@ -1,0 +1,27 @@
+# Deft
+
+[Deft](http://jblevins.org/projects/deft/) is an Emacs mode inspired by Notational Velocity for quickly browsing and creating notes.
+
+**Note:** You may have to update the `evil-escape` package for deft to work, otherwise filtering will ignore your escape character.
+
+## Differences from default
+
+This layer sets the default to use filenames for note titles as well as org-mode for editing.
+The default extension is still `txt`.
+
+## Configuration
+
+By default deft tries to put notes in `~/.deft` but you can change this like so:
+```
+(setq deft-directory "~/Dropbox/notes")
+```
+
+## Keybindings
+
+Key Binding         |                 Description
+--------------------|------------------------------------------------------------------
+<kbd>SPC a n  </kbd>| Open Deft (works globally)
+<kbd>SPC m d  </kbd>| Delete selected note
+<kbd>SPC m r  </kbd>| Rename selected note
+<kbd>SPC m i  </kbd>| Toggle to regex search
+<kbd>SPC m n  </kbd>| Create new file with filter text

--- a/contrib/deft/packages.el
+++ b/contrib/deft/packages.el
@@ -1,0 +1,41 @@
+;;; packages.el --- deft Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar deft-packages
+  '(deft))
+
+(defun deft/init-deft ()
+  (use-package deft
+    :defer t
+    :init
+    (progn
+      (defun spacemacs/deft ()
+        "Helper to call deft and then fix things so that it is nice and works"
+        (interactive)
+        (deft)
+        ;; Hungry delete wrecks deft's DEL override
+        (when (fboundp 'hungry-delete-mode)
+          (hungry-delete-mode -1))
+        ;; When opening it you always want to filter right away
+        (evil-insert-state nil))
+      (evil-leader/set-key "an" 'spacemacs/deft)
+      )
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'deft-mode
+        "m d" 'deft-delete-file
+        "m r" 'deft-rename-file
+        "m i" 'deft-toggle-incremental-search
+        "m n" 'deft-new-file)
+      (setq deft-extension "txt"
+            deft-text-mode 'org-mode
+            deft-use-filename-as-title t))))


### PR DESCRIPTION
Adds a layer for the [Deft](http://jblevins.org/projects/deft/) not browsing emacs mode.
Includes some better defaults as well as fixes to make it play well with Spacemacs.

Won't work properly until https://github.com/syl20bnr/evil-escape/pull/22 is merged.