### PR TITLE
Switch commands for Tab and C-z in Helm

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1528,6 +1528,13 @@ ARG non nil means that the editing style is `vim'."
         ("T" helm-toggle-all-marks)
         ("v" helm-execute-persistent-action))
 
+      ;; Swap default TAB and C-z commands.
+      ;; For GUI.
+      (define-key helm-map (kbd "<tab>") 'helm-execute-persistent-action)
+      ;; For terminal.
+      (define-key helm-map (kbd "TAB") 'helm-execute-persistent-action)
+      (define-key helm-map (kbd "C-z") 'helm-select-action)
+
       (eval-after-load "helm-mode" ; required
         '(spacemacs|hide-lighter helm-mode)))))
 


### PR DESCRIPTION
The command bound to C-z is much more useful than the one bound to Tab,
so it makes sense to swap them.  It's also recommended here: https://tuhdo.github.io/helm-intro.html