### PR TITLE
C-C++ should only enable gtags if the layer is enabled

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -57,9 +57,10 @@ which require an initialization must be listed explicitly in the list.")
   (add-to-hooks 'flycheck-mode '(c-mode-hook c++-mode-hook)))
 
 (defun c-c++/post-init-helm-gtags ()
-  (add-hook 'c-mode-common-hook 'helm-gtags-mode)
-  (spacemacs/gtags-define-keys-for-mode 'c-mode)
-  (spacemacs/gtags-define-keys-for-mode 'c++-mode))
+  (when (configuration-layer/layer-usedp 'gtags)
+    (add-hook 'c-mode-common-hook 'helm-gtags-mode)
+    (spacemacs/gtags-define-keys-for-mode 'c-mode)
+    (spacemacs/gtags-define-keys-for-mode 'c++-mode)))
 
 (defun c-c++/init-srefactor ()
   (use-package srefactor


### PR DESCRIPTION
I ran across this since I'm using c-c++ but not the gtags layer. I get
an error since `spacemacs/gtags-define-keys-for-mode` doesn't exist
except for in the gtags layer.