### PR TITLE
Fix bug in ruby auto-completion

### DIFF
--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -1,6 +1,7 @@
 (defvar ruby-packages
   '(
     bundler
+    company
     enh-ruby-mode
     flycheck
     robe


### PR DESCRIPTION
Fixes ruby auto-completion not activating properly because `company` was missing from the packages list. This should fix the problem @carlosgaldino found in #1045.

This is what happens when you need to have 3 different things in 3 different places for things to work :neutral_face: 