### PR TITLE
[fix #1223] make window inactive face compatible with themes

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2211,6 +2211,10 @@ displayed in the mode-line.")
           (setq-default powerline-default-separator 'wave)
         (setq-default powerline-default-separator 'utf-8))
 
+      ;; change powerline-inactive2 face to make it usable across themes
+      (set-face-attribute 'powerline-inactive2 nil
+                          :inherit 'font-lock-preprocessor-face)
+
       (defun spacemacs/mode-line-prepare-left ()
         (let* ((active (powerline-selected-window-active))
                (line-face (if active 'mode-line 'mode-line-inactive))


### PR DESCRIPTION
The face is not readable in theme like Zenburn and probably other themes
out there. This commit fix it by inheriting from a built-in face.