### PR TITLE
Typo in window-manipulation-full-doc

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -348,7 +348,7 @@ Ensure that helm is required before calling FUNC."
   "
   [?]                       display this help
   [0,9]                     go to numbered window
-  [-] [/] [s] [v] [S] [V]   split windows bellow|right and focus
+  [-] [/] [s] [v] [S] [V]   split windows below|right and focus
   [c] [C]                   close current|other windows
   [g]                       toggle golden-ratio
   [h] [j] [k] [l]           go to left|bottom|top|right


### PR DESCRIPTION
Quite a minor typo, but I figured I'd send it in.