### PR TITLE
Preserve default Helm bindings for Emacs users

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1052,8 +1052,8 @@ to read the [Helm documentation wiki][helm-doc].
 `Spacemacs` defines a [micro-state](#micro-states) for `Helm` to make it
 work like [Vim's Unite][] plugin.
 
-Initiate the micro-state with <kbd>C-SPC</kbd> while in a `Helm` buffer.
-Use <kbd>C-SPC</kbd> again to exit from the micro-state.
+Initiate the micro-state with <kbd>M-SPC</kbd> while in a `Helm` buffer.
+Use <kbd>M-SPC</kbd> again to exit from the micro-state.
 
 Key Binding           | Description
 ----------------------|------------------------------------------------------------

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1507,11 +1507,11 @@ ARG non nil means that the editing style is `vim'."
       (spacemacs|define-micro-state helm-navigation
         :persistent t
         :disable-evil-leader t
-        :define-key (helm-map . "C-SPC") (helm-map . "C-@")
+        :define-key (helm-map . "M-SPC")
         :on-enter (spacemacs//helm-navigation-ms-on-enter)
         :on-exit  (spacemacs//helm-navigation-ms-on-exit)
         :bindings
-        ("C-SPC" nil :exit t)
+        ("M-SPC" nil :exit t)
         ("C-@" nil :exit t)
         ("<tab>" helm-select-action :exit t)
         ("C-i" helm-select-action :exit t)
@@ -1815,9 +1815,7 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
         (define-key ido-completion-map (kbd "<left>") 'ido-delete-backward-updir)
         (define-key ido-completion-map (kbd "<right>") 'ido-exit-minibuffer)
         ;; initiate micro-state
-        (define-key ido-completion-map (kbd "C-SPC") 'spacemacs/ido-navigation-micro-state)
-        (define-key ido-completion-map (kbd "C-@") 'spacemacs/ido-navigation-micro-state)
-        )
+        (define-key ido-completion-map (kbd "M-SPC") 'spacemacs/ido-navigation-micro-state))
       (add-hook 'ido-setup-hook 'spacemacs//ido-setup)
 
       (defvar spacemacs--ido-navigation-ms-enabled nil


### PR DESCRIPTION
Emacs users rely on C-n/C-p/C-v/M-v for navigating the list up and
down. Major opreations are centered around the control key for
convenient, i.e. C-n to next caniddate and C-SPC to mark it without then
C-n to next candidate releasing the control key. Switching to M-SPC
degrades this efficiency, i.e. C-n M-SPC C-n is 6 key pressings compared
with 4 key pressings C-n C-SPC C-n. It gets worse if a user wants to
mark more candidates with current binding.

Another problem is, getting in Helm microstate causes a strange bug that
an action is executed based on the digit pressed. Without entering the
microstate, this problem won't happen.

Also, simply key binding logic depends on editing style.