### PR TITLE
Fix escaping in open-in-external-app on windows

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -810,7 +810,7 @@ If ASCII si not provided then UNICODE is used instead."
                        (dired-get-file-for-visit)
                      (buffer-file-name))))
     (cond
-     ((system-is-mswindows) (w32-shell-execute "open" (replace-regexp-in-string "/" "\\" file-path)))
+     ((system-is-mswindows) (w32-shell-execute "open" (replace-regexp-in-string "/" "\\\\" file-path)))
      ((system-is-mac) (shell-command (format "open \"%s\"" file-path)))
      ((system-is-linux) (let ((process-connection-type nil))
                           (start-process "" nil "xdg-open" file-path))))))


### PR DESCRIPTION
Replace-regexp needs extra backslahes. See discussion in:
http://lists.gnu.org/archive/html/help-gnu-emacs/2009-08/msg00713.html