### PR TITLE
Allow users to disable the overriding of the OS mouse cursor face for themes.

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -151,6 +151,10 @@ Possible values are: `recents' `bookmarks' `projects'.")
     map)
   "Keymap for dostpacemacs-mode.")
 
+(defvar dotspacemacs-theme-override-os-mouse t
+  "If non nil set the mouse cursor in the theme instead of using the OS
+default.")
+
 (define-derived-mode dotspacemacs-mode emacs-lisp-mode "dotspacemacs"
   "dotspacemacs major mode for Spacemacs dotfile.
 

--- a/spacemacs/extensions/solarized-theme/solarized.el
+++ b/spacemacs/extensions/solarized-theme/solarized.el
@@ -290,8 +290,9 @@ customize the resulting theme."
      `(match ((,class (:background ,base02 :foreground ,base1 :weight bold))))
      `(cursor ((,class (:foreground ,base03 :background ,base0
                                     :inverse-video t))))
-     `(mouse ((,class (:foreground ,base03 :background ,base0
-                                   :inverse-video t))))
+     (when dotspacemacs-theme-override-os-mouse
+       `(mouse ((,class (:foreground ,base03 :background ,base0
+                                     :inverse-video t)))))
      `(escape-glyph ((,class (:foreground ,violet))))
      `(fringe ((,class (:foreground ,s-fringe-fg :background ,s-fringe-bg))))
      `(highlight ((,class (:background ,base02))))


### PR DESCRIPTION
As per issue #1181, themes have no way to consult the user's preference before setting the mouse cursor face.

I'm not sure if this is the correct way to do this but in my experimentation I could not find how to reverse the changes of setting the mouse cursor face once they had been set, it can be made close but it's not the same as the default OS cursor.

Unfortunately I'm also not sure how to apply this behaviour to other themes.