### PR TITLE
ocaml: REPL (utop), flycheck, auto-completion (company-mode) support

### DIFF
--- a/contrib/lang/ocaml/README.md
+++ b/contrib/lang/ocaml/README.md
@@ -30,6 +30,10 @@ To use this contribution add it to your `~/.spacemacs`
 (setq-default dotspacemacs-configuration-layers '(ocaml))
 ```
 
+Optional configuration layers supported:
+ * auto-completion (company mode via merlin)
+ * syntax-checking (flycheck-ocaml)
+
 ### OPAM packages
 
 This layer requires some [opam](http://opam.ocaml.org) packages:

--- a/contrib/lang/ocaml/README.md
+++ b/contrib/lang/ocaml/README.md
@@ -9,6 +9,8 @@
     - [Description](#description)
     - [Install](#install)
         - [OPAM packages](#opam-packages)
+    - [Key Bindings](#key-bindings)
+        - [REPL (utop)](#repl-utop)
     - [TODO](#todo)
 
 <!-- markdown-toc end -->
@@ -40,8 +42,29 @@ To install them, use the following command:
 opam install merlin 
 ```
 
+## Key Bindings
+
+    Key Binding       |                 Description
+----------------------|--------------------------------------------------------
+<kbd>SPC m c c</kbd>  | Compile
+<kbd>SPC m e t</kbd>  | Highlight identifier under cursor and print its type
+
+### REPL (utop)
+
+    Key Binding       |                 Description
+----------------------|--------------------------------------------------------
+<kbd>SPC m s b</kbd>  | Send buffer to the REPL
+<kbd>SPC m s B</kbd>  | Send buffer to the REPL and switch to the REPL in `insert state`
+<kbd>SPC m s i</kbd>  | Start a REPL
+<kbd>SPC m s p</kbd>  | Send phrase to the REPL
+<kbd>SPC m s P</kbd>  | Send phrase to the REPL and switch to the REPL in `insert state`
+<kbd>SPC m s r</kbd>  | Send region to the REPL
+<kbd>SPC m s R</kbd>  | Send region to the REPL and switch to the REPL in `insert state`
+<kbd>C-j</kbd>        | next item in history
+<kbd>C-k</kbd>        | previous item in history
+
 ## TODO
 
-- Add support for `flycheck` (using `flycheck-ocaml`)
-- Add proper spacemacs key-bindings for basic merlin tasks
-
+- Add more proper spacemacs key-bindings for basic merlin tasks
+- Add proper keybindings for ocamldebug
+- Add more keybindings for tuareg-mode

--- a/contrib/lang/ocaml/README.md
+++ b/contrib/lang/ocaml/README.md
@@ -39,11 +39,13 @@ Optional configuration layers supported:
 This layer requires some [opam](http://opam.ocaml.org) packages:
 
 - `merlin`
+- `utop`
+- `ocp-indent`
 
 To install them, use the following command: 
 
 ```sh
-opam install merlin 
+opam install merlin utop ocp-indent
 ```
 
 ## Key Bindings

--- a/contrib/lang/ocaml/config.el
+++ b/contrib/lang/ocaml/config.el
@@ -1,0 +1,1 @@
+(spacemacs|defvar-company-backends merlin-mode)

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -17,8 +17,8 @@
     utop
     ocp-indent
     company
-;;    flycheck
-;;    flycheck-ocaml
+    flycheck
+    flycheck-ocaml
     ;; package ocamls go here
     )
   "List of all packages to install and/or initialize. Built-in packages
@@ -74,14 +74,22 @@ which require an initialization must be listed explicitly in the list.")
 (when (configuration-layer/layer-usedp 'auto-completion)
   ;; Hook company to merlin-mode
   (defun ocaml/post-init-company ()
-    (spacemacs|add-company-hook merlin-mode)))
+    (spacemacs|add-company-hook merlin-mode)
+    ))
 
-;; (defun ocaml/init-flycheck-ocaml ()
-;;   (progn
-;;     (setq merlin-error-after-save nil)
-;;     (flycheck-ocaml-setup)
-;;     )
-;; )
+(when (configuration-layer/layer-usedp 'syntax-checking)
+  (defun ocaml/init-flycheck-ocaml ()
+    (use-package flycheck-ocaml
+      :if (configuration-layer/package-usedp 'flycheck)
+      :defer t
+      :init
+      (add-hook 'merlin-mode-hook 'flycheck-mode)
+      (with-eval-after-load 'merlin
+        ;; Disable Merlin's own error checking
+        (setq merlin-error-after-save nil)
+        ;; Enable Flycheck checker
+        (flycheck-ocaml-setup))
+      )))
 
 ;; For each package, define a function ocaml/init-<package-ocaml>
 ;;

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -29,6 +29,9 @@ which require an initialization must be listed explicitly in the list.")
 
 (defun ocaml/init-tuareg ()
   (add-hook 'tuareg-mode-hook #'merlin-mode)
+  (evil-leader/set-key-for-mode 'tuareg-mode
+   "mcc" 'compile
+  )
   )
 
 (defun ocaml/opam ()
@@ -49,7 +52,30 @@ which require an initialization must be listed explicitly in the list.")
     ;; Update the emacs path
     (setq exec-path (append (parse-colon-path (getenv "PATH"))
                             (list exec-directory)))
+    (defun utop-eval-phrase-and-go ()
+      (interactive)
+      (utop-eval-phrase)
+      (utop))
+    (defun utop-eval-buffer-and-go ()
+      (interactive)
+      (utop-eval-buffer)
+      (utop))
+    (defun utop-eval-region-and-go (start end)
+      (interactive "r")
+      (utop-eval-region start end)
+      (utop))
+    (evil-leader/set-key-for-mode 'tuareg-mode
+      "msb" 'utop-eval-buffer
+      "msB" 'utop-eval-buffer-and-go
+      "msi" 'utop
+      "msp" 'utop-eval-phrase
+      "msP" 'utop-eval-phrase-and-go
+      "msr" 'utop-eval-region
+      "msR" 'utop-eval-region-and-go
+      )
     )
+    (define-key utop-mode-map (kbd "C-j") 'utop-history-goto-next)
+    (define-key utop-mode-map (kbd "C-k") 'utop-history-goto-prev)
   )
 
 (defun ocaml/init-ocp-indent ()
@@ -69,6 +95,11 @@ which require an initialization must be listed explicitly in the list.")
     (when (configuration-layer/package-usedp 'company)
       (push 'merlin-company-backend company-backends-merlin-mode))
     )
+    (evil-leader/set-key-for-mode 'tuareg-mode
+      "mgg" 'merlin-locate
+      "met" 'merlin-type-enclosing
+     ;;      "mhh" 'merlin-document
+      )
   )
 
 (when (configuration-layer/layer-usedp 'auto-completion)

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -80,7 +80,6 @@ which require an initialization must be listed explicitly in the list.")
 
 (defun ocaml/init-ocp-indent ()
   (use-package ocp-indent
-    :defer t
     :init
     (ocaml/opam)
     )

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -14,6 +14,8 @@
   '(
     tuareg
     merlin
+    utop
+    ocp-indent
 ;;    flycheck
 ;;    flycheck-ocaml
     ;; package ocamls go here
@@ -28,8 +30,36 @@ which require an initialization must be listed explicitly in the list.")
   (add-hook 'tuareg-mode-hook #'merlin-mode)
   )
 
-(defun ocaml/init-merlin ())
+(defun ocaml/opam ()
+  (setq opam-share (substring (shell-command-to-string "opam config var share 2> /dev/null") 0 -1))
+  (setq opam-load-path (concat opam-share "/emacs/site-lisp"))
+  (add-to-list 'load-path opam-load-path))
 
+(defun ocaml/init-utop ()
+  (use-package utop
+    :init
+    (autoload 'utop "utop" "Toplevel for OCaml" t)
+    (autoload 'utop-minor-mode "utop" "Minor mode for utop" t)
+    (add-hook 'tuareg-mode-hook 'utop-minor-mode)
+    :config
+    ;; Setup environment variables using opam
+    (dolist (var (car (read-from-string (shell-command-to-string "opam config env --sexp"))))
+      (setenv (car var) (cadr var)))
+    ;; Update the emacs path
+    (setq exec-path (append (parse-colon-path (getenv "PATH"))
+                            (list exec-directory)))
+    )
+  )
+
+(defun ocaml/init-ocp-indent ()
+  (use-package ocp-indent
+    :defer t
+    :init
+    (ocaml/opam)
+    )
+  )
+
+(defun ocaml/init-merlin ())
 ;; (defun ocaml/init-flycheck-ocaml ()
 ;;   (progn
 ;;     (setq merlin-error-after-save nil)

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -16,6 +16,7 @@
     merlin
     utop
     ocp-indent
+    company
 ;;    flycheck
 ;;    flycheck-ocaml
     ;; package ocamls go here
@@ -59,7 +60,22 @@ which require an initialization must be listed explicitly in the list.")
     )
   )
 
-(defun ocaml/init-merlin ())
+(defun ocaml/init-merlin ()
+  (use-package merlin
+    :defer t
+    :init
+    (ocaml/opam)
+    (set-default 'merlin-use-auto-complete-mode 'easy)
+    (when (configuration-layer/package-usedp 'company)
+      (push 'merlin-company-backend company-backends-merlin-mode))
+    )
+  )
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  ;; Hook company to merlin-mode
+  (defun ocaml/post-init-company ()
+    (spacemacs|add-company-hook merlin-mode)))
+
 ;; (defun ocaml/init-flycheck-ocaml ()
 ;;   (progn
 ;;     (setq merlin-error-after-save nil)

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -32,6 +32,10 @@ which require an initialization must be listed explicitly in the list.")
   (evil-leader/set-key-for-mode 'tuareg-mode
    "mcc" 'compile
   )
+  ;; don't auto-close apostrophes (type 'a = foo)
+  (when (fboundp 'sp-local-pair)
+    (sp-local-pair 'tuareg-mode "'" nil :actions nil)
+  )
   )
 
 (defun ocaml/opam ()


### PR DESCRIPTION
This improves upon the initial ocaml support from @ranjitjhala:
 * adds a REPL and some basic keybindings (requires `utop`)
 * adds indentation plugin `ocp-indent`
 * adds optional flycheck support (can be enabled with `syntax-checking` config layer), otherwise merlin only shows warnings/errors when you save the file
 * adds optional auto-completion (can be enabled with `auto-completion` config layer) using company mode.
 * adds some basic keybindings that follow CONVENTIONS.md

I am coming from Vim and consider myself a beginner in elisp and (spac)emacs, please review
my changes.
Some inspiration was taken from https://github.com/OCamlPro/opam-user-setup/blob/master/emacs/emacs.ml.

Questions:
  * merlin also supports auto-complete by using `auto-complete.el` instead of `company mode`. Should this be configurable, and if so how?
  * there is a lot more functionality supported by merlin and tuareg-mode, which already has its own keybindings but no real equivalent in CONVENTIONS.md. What should be done about these? Would seem rather inconsistent that some functionality is available via SPC, and some via the plugin's default bindings ...
   * some of these plugins require packages installed by opam, which means that it needs to set the load-path. I have a function `ocaml/opam` for that now that I call in each plugin-specific init function, but  is there some global place I could call it from?
   * opam-user-setup has a bunch  more tweaks in the form of custom-set-variables, keybindings, etc. how should these be mapped to Spacemacs?