### PR TITLE
Fix markup in README.md

### DIFF
--- a/contrib/auto-completion/README.md
+++ b/contrib/auto-completion/README.md
@@ -52,6 +52,7 @@ to `t`
 (setq-default dotspacemacs-configuration-layers
   '(auto-completion :variables
                     auto-completion-enable-company-help-tooltip t))
+```
 
 ## Configure
 


### PR DESCRIPTION
Just a quick fix, the README is not interpreted as regular Markdown from that line down due to these missing backquotes.