### PR TITLE
Web mode fixes

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -127,7 +127,8 @@ which require an initialization must be listed explicitly in the list.")
       (add-hook 'css-mode-hook 'emmet-mode))
     :config
     (progn
-      (local-set-key (kbd "<tab>") 'emmet-expand-yas)
+      (evil-define-key 'insert emmet-mode-keymap "TAB" 'emmet-expand-yas)
+      (evil-define-key 'insert emmet-mode-keymap (kbd "<tab>") 'emmet-expand-yas)
       (spacemacs|hide-lighter emmet-mode))))
 
 (defun html/post-init-evil-matchit ()

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -115,6 +115,7 @@ which require an initialization must be listed explicitly in the list.")
      ("\\.mustache\\'"   . web-mode)
      ("\\.handlebars\\'" . web-mode)
      ("\\.hbs\\'"        . web-mode)
+     ("\\.eco\\'"        . web-mode)
      ("\\.djhtml\\'"     . web-mode))))
 
 (defun html/init-emmet-mode ()

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -130,6 +130,8 @@ which require an initialization must be listed explicitly in the list.")
     (progn
       (evil-define-key 'insert emmet-mode-keymap "TAB" 'emmet-expand-yas)
       (evil-define-key 'insert emmet-mode-keymap (kbd "<tab>") 'emmet-expand-yas)
+      (evil-define-key 'emacs emmet-mode-keymap "TAB" 'emmet-expand-yas)
+      (evil-define-key 'emacs emmet-mode-keymap (kbd "<tab>") 'emmet-expand-yas)
       (spacemacs|hide-lighter emmet-mode))))
 
 (defun html/post-init-evil-matchit ()

--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -48,6 +48,9 @@ which require an initialization must be listed explicitly in the list.")
     :defer t
     :config
     (progn
+      ;; Only use smartparens in web-mode
+      (sp-local-pair 'web-mode "<%" "%>")
+      (setq web-mode-enable-auto-pairing nil)
 
       (evil-leader/set-key-for-mode 'web-mode
         "meh" 'web-mode-dom-errors-show


### PR DESCRIPTION
Fixes for a few issues that were bothering me about web-mode.

 * Disables web-modes' auto-pairing in favor of smartparens (they we're conflicting in a few cases)
 * add .eco to mode-alist
 * expands on louy2 emmet fix to include emacs mode. (is there a better way to do this?)

Includes #1232 and f436eeb7a998ac60 from louy2. Thanks for fixing emmet @louy2!

Fixes #1161

Web-mode still has #823 and #965 (duplicates).