### PR TITLE
Fix way of binding "TAB" for emmet-expand-yas

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -129,9 +129,9 @@
       (add-hook 'css-mode-hook 'emmet-mode))
     :config
     (progn
-      (evil-define-key 'insert emmet-mode-keymap "TAB" 'emmet-expand-yas)
+      (evil-define-key 'insert emmet-mode-keymap (kbd "TAB") 'emmet-expand-yas)
       (evil-define-key 'insert emmet-mode-keymap (kbd "<tab>") 'emmet-expand-yas)
-      (evil-define-key 'emacs emmet-mode-keymap "TAB" 'emmet-expand-yas)
+      (evil-define-key 'emacs emmet-mode-keymap (kbd "TAB") 'emmet-expand-yas)
       (evil-define-key 'emacs emmet-mode-keymap (kbd "<tab>") 'emmet-expand-yas)
       (spacemacs|hide-lighter emmet-mode))))
 


### PR DESCRIPTION
This fixes not being able to type 'T' in insert state in a html file.