### PR TITLE
Don't use background but foreground colors

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1705,8 +1705,7 @@ If ARG is non nil then `ag' and `pt' and ignored."
     (progn
       (add-hook 'prog-mode-hook #'highlight-parentheses-mode)
       (evil-leader/set-key "tCp" 'highlight-parentheses-mode)
-      (setq hl-paren-colors nil)
-      (setq hl-paren-background-colors '("white" "white" "white" "white")))
+      (setq hl-paren-colors '("Springgreen3" "IndianRed1" "IndianRed3" "IndianRed4")))
     :config
     (set-face-attribute 'hl-paren-face nil :weight 'bold :inverse-video t)))
 


### PR DESCRIPTION
Using background colors and setting inverse-video, the parentheses are
barely visible. This looks annoying.

Using foreground colors and setting inverse-video, the background colors
are there (but not inverted) and parentheses are very visible.