### PR TITLE
Optimize macro and fix typo in its name

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -374,6 +374,15 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
       (spacemacs-buffer/set-mode-line spacemacs-loading-string)
       (spacemacs//redisplay))))
 
+(defmacro spacemacs//insert--shortcut (shortcut-char search-label &optional no-next-line)
+  `(define-key spacemacs-mode-map ,shortcut-char (lambda ()
+                                                   (interactive)
+                                                   (unless (search-forward ,search-label (point-max) t)
+                                                     (search-backward ,search-label (point-min) t))
+                                                   ,@(unless no-next-line
+                                                       '((forward-line 1)))
+                                                   (back-to-indentation))))
+
 (defun spacemacs-buffer//insert-buttons ()
   (goto-char (point-max))
   (insert "    ")
@@ -443,15 +452,6 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                  :mouse-face 'highlight
                  :follow-link "\C-m")
   (insert "\n\n"))
-
-(defmacro spacemacs//insert--shortcut (shortcut-char search-label &optional no-next-line)
-  `(define-key spacemacs-mode-map ,shortcut-char (lambda ()
-                                                   (interactive)
-                                                   (unless (search-forward ,search-label (point-max) t)
-                                                     (search-backward ,search-label (point-min) t))
-                                                   ,@(unless no-next-line
-                                                       '((forward-line 1)))
-                                                   (back-to-indentation))))
 
 (defun spacemacs-buffer//insert-file-list (list-display-name list shortcut-char)
   (when (car list)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -377,7 +377,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
 (defun spacemacs-buffer//insert-buttons ()
   (goto-char (point-max))
   (insert "    ")
-  (spacemacs//insert--shorcut "m" "[?]" t)
+  (spacemacs//insert--shortcut "m" "[?]" t)
   (widget-create 'url-link
                  :tag (propertize "?" 'face 'font-lock-doc-face)
                  :help-echo "Open the quickhelp."
@@ -444,19 +444,19 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                  :follow-link "\C-m")
   (insert "\n\n"))
 
-(defmacro spacemacs//insert--shorcut (shortcut-char search-label &optional no-next-line)
+(defmacro spacemacs//insert--shortcut (shortcut-char search-label &optional no-next-line)
   `(define-key spacemacs-mode-map ,shortcut-char (lambda ()
                                                    (interactive)
                                                    (unless (search-forward ,search-label (point-max) t)
                                                      (search-backward ,search-label (point-min) t))
-                                                   (unless ,no-next-line
-                                                     (forward-line 1))
+                                                   ,@(unless no-next-line
+                                                       '((forward-line 1)))
                                                    (back-to-indentation))))
 
 (defun spacemacs-buffer//insert-file-list (list-display-name list shortcut-char)
   (when (car list)
-    (spacemacs//insert--shorcut "r" "Recent Files:")
-    (spacemacs//insert--shorcut "p" "Projects:")
+    (spacemacs//insert--shortcut "r" "Recent Files:")
+    (spacemacs//insert--shortcut "p" "Projects:")
     (insert list-display-name)
     (mapc (lambda (el)
             (insert "\n    ")


### PR DESCRIPTION
I assume the optional argument is only ever supposed to be `t` or `nil`.