### PR TITLE
Add eshell layer

### DIFF
--- a/contrib/eshell/README.md
+++ b/contrib/eshell/README.md
@@ -1,0 +1,23 @@
+# Eshell
+
+This layer adds some fancy features and better defaults to the built in Emacs Eshell:
+- Commands for popping out shells
+- Better integration with evil mode
+- Company mode completion integration
+- Some handy aliases and config options
+
+## Aliases
+
+#### cdp
+Changes to the root directory of the project.
+
+#### x
+Exits the shell and closes the window
+
+## Keybindings
+
+Key Binding         |                 Description
+--------------------|------------------------------------------------------------------
+<kbd>SPC E s  </kbd>| Start eshell in current window
+<kbd>SPC E p  </kbd>| Pop open an eshell window below the current buffer in its dir
+<kbd>SPC E d  </kbd>| Switch an existing eshell to the directory of the current buffer

--- a/contrib/eshell/config.el
+++ b/contrib/eshell/config.el
@@ -1,0 +1,54 @@
+;;; config.el --- Eshell configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; START: Code based on https://github.com/technomancy/emacs-starter-kit
+(setq eshell-cmpl-cycle-completions nil
+      eshell-save-history-on-exit t
+      eshell-hist-ignoredups t
+      eshell-buffer-shorthand t
+      eshell-cmpl-dir-ignore "\\`\\(\\.\\.?\\|CVS\\|\\.svn\\|\\.git\\)/\\'")
+
+(eval-after-load 'esh-opt
+  '(progn
+     (require 'em-prompt)
+     (require 'em-term)
+     (require 'em-cmpl)
+     (setenv "PAGER" "cat")
+     (add-hook 'eshell-mode-hook ;; for some reason this needs to be a hook
+               '(lambda () (define-key eshell-mode-map "\C-a" 'eshell-bol)))
+     (setq eshell-cmpl-cycle-completions nil)
+
+     ;; TODO: submit these via M-x report-emacs-bug
+     (add-to-list 'eshell-visual-commands "ssh")
+     (add-to-list 'eshell-visual-commands "tail")
+     (add-to-list 'eshell-command-completions-alist
+                  '("gunzip" "gz\\'"))
+     (add-to-list 'eshell-command-completions-alist
+                  '("tar" "\\(\\.tar|\\.tgz\\|\\.tar\\.gz\\)\\'"))))
+;; END
+
+;; Move point to end of current prompt line if we were scrolling around in normal mode but now want to type.
+(defun spacemacs//eshell-auto-end ()
+  (when (and (eq major-mode 'eshell-mode)
+             ;; Not on last line, we might want to edit within it.
+             (not (eq (line-end-position) (point-max))))
+    (end-of-buffer)))
+(add-hook 'evil-insert-state-entry-hook 'spacemacs//eshell-auto-end)
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun spacemacs//eshell-setup-company ()
+    ;; This completion backend is a bit laggy, I think it searches the PATH constantly.
+    (setq-local company-idle-delay 0.2)
+    ;; The default frontend screws everything up in short windows like terminal often are
+    (setq-local company-frontends '(company-preview-frontend)))
+  (add-hook 'eshell-mode-hook 'spacemacs//eshell-setup-company)
+  (spacemacs|defvar-company-backends eshell-mode))

--- a/contrib/eshell/extensions.el
+++ b/contrib/eshell/extensions.el
@@ -1,0 +1,26 @@
+;;; extensions.el --- Eshell Layer extensions File
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Extensions are in emacs_paths/extensions
+;; Pre extensions are loaded *before* the packages
+(defvar eshell-pre-extensions
+  '())
+
+;; Post extensions are loaded *after* the packages
+(defvar eshell-post-extensions
+  '(emacs-builtin-eshell))
+
+(defun eshell/init-emacs-builtin-eshell ()
+  (when (configuration-layer/layer-usedp 'auto-completion)
+    (push '(company-capf :with company-yasnippet)
+          company-backends-eshell-mode)
+    (spacemacs|add-company-hook eshell-mode)))

--- a/contrib/eshell/funcs.el
+++ b/contrib/eshell/funcs.el
@@ -1,0 +1,133 @@
+;;; funcs.el --- Eshell configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; ==================================================
+;; Commands
+;; ==================================================
+(defun eshell/cdp ()
+  "Change directory to the project's root."
+  (eshell/cd (projectile-project-root)))
+
+(defun eshell/x ()
+  (insert "exit")
+  (eshell-send-input)
+  (delete-window))
+
+;; ==================================================
+;; Completion
+;; ==================================================
+
+;; START: Code based on https://github.com/technomancy/emacs-starter-kit
+(defun pcomplete/rake ()
+    "Completion rules for the `ssh' command."
+    (pcomplete-here (pcmpl-rake-tasks)))
+
+(defun pcmpl-rake-tasks ()
+  "Return a list of all the rake tasks defined in the current
+projects.  I know this is a hack to put all the logic in the
+exec-to-string command, but it works and seems fast"
+  (delq nil (mapcar '(lambda(line)
+                       (if (string-match "rake \\([^ ]+\\)" line) (match-string 1 line)))
+                    (split-string (shell-command-to-string "rake -T") "[\n]"))))
+;; END
+
+;; START: Code based on http://www.masteringemacs.org/article/pcomplete-context-sensitive-completion-emacs
+(defconst pcmpl-git-commands
+  '("add" "bisect" "branch" "checkout" "clone"
+    "commit" "diff" "fetch" "grep"
+    "init" "log" "merge" "mv" "pull" "push" "rebase"
+    "reset" "rm" "show" "status" "tag" )
+  "List of `git' commands")
+
+(defvar pcmpl-git-ref-list-cmd "git for-each-ref refs/ --format='%(refname)'"
+  "The `git' command to run to get a list of refs")
+
+(defun pcmpl-git-get-refs (type)
+  "Return a list of `git' refs filtered by TYPE"
+  (with-temp-buffer
+    (insert (shell-command-to-string pcmpl-git-ref-list-cmd))
+    (goto-char (point-min))
+    (let ((ref-list))
+      (while (re-search-forward (concat "^refs/" type "/\\(.+\\)$") nil t)
+        (add-to-list 'ref-list (match-string 1)))
+      ref-list)))
+
+(defun pcomplete/git ()
+  "Completion for `git'"
+  ;; Completion for the command argument.
+  (pcomplete-here* pcmpl-git-commands)
+  ;; complete files/dirs forever if the command is `add' or `rm'
+  (cond
+   ((pcomplete-match (regexp-opt '("add" "rm")) 1)
+    (while (pcomplete-here (pcomplete-entries))))
+   ;; provide branch completion for the command `checkout'.
+   ((pcomplete-match "checkout" 1)
+    (pcomplete-here* (pcmpl-git-get-refs "heads")))))
+;; END
+
+;; ==================================================
+;; Eshell manipulation functions
+;; ==================================================
+
+(defun spacemacs/eshell ()
+  (interactive)
+  (eshell)
+  (evil-insert-state nil))
+
+;; START: Code based on https://github.com/technomancy/emacs-starter-kit
+(defun spacemacs/eshell-for-dir (&optional prompt)
+  "Change the directory of an existing eshell to the directory of the file in
+  the current buffer or launch a new eshell if one isn't running.  If the
+  current buffer does not have a file (e.g., a *scratch* buffer) launch or raise
+  eshell, as appropriate.  Given a prefix arg, prompt for the destination
+  directory."
+  (interactive "P")
+  (let* ((name (buffer-file-name))
+         (dir (cond (prompt (read-directory-name "Directory: " nil nil t))
+                    (name (file-name-directory name))
+                    (t nil)))
+         (buffers (delq nil (mapcar (lambda (buf)
+                                      (with-current-buffer buf
+                                        (when (eq 'eshell-mode major-mode)
+                                          (buffer-name))))
+                                    (buffer-list))))
+         (buffer (cond ((eq 1 (length buffers)) (first buffers))
+                       ((< 1 (length buffers)) (ido-completing-read
+                                                "Eshell buffer: " buffers nil t
+                                                nil nil (first buffers)))
+                       (t (eshell)))))
+    (with-current-buffer buffer
+      (when dir
+        (eshell/cd (list dir))
+        (eshell-send-input))
+      (end-of-buffer)
+      (pop-to-buffer buffer)
+      (evil-insert-state nil))))
+;; END
+
+;; START: Code based on http://www.howardism.org/Technical/Emacs/eshell-fun.html
+(defun spacemacs/eshell-pop ()
+  "Opens up a new shell in the directory associated with the
+current buffer's file. The eshell is renamed to match that
+directory to make multiple eshell windows easier."
+  (interactive)
+  (let* ((parent (if (buffer-file-name)
+                     (file-name-directory (buffer-file-name))
+                   default-directory))
+         (height (/ (window-total-height) 3))
+         (name   (car (last (split-string parent "/" t)))))
+    (split-window-vertically (- height))
+    (other-window 1)
+    (eshell "new")
+    (evil-insert-state nil)
+    (rename-buffer (concat "*eshell: " name "*"))))
+;; END

--- a/contrib/eshell/keybindings.el
+++ b/contrib/eshell/keybindings.el
@@ -1,0 +1,16 @@
+;;; keybindings.el --- Eshell configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(evil-leader/set-key
+  "Ep" 'spacemacs/eshell-pop
+  "Es" 'spacemacs/eshell
+  "Ed" 'spacemacs/eshell-for-dir)


### PR DESCRIPTION
This layer adds some fancy features and better defaults to the built in Emacs Eshell:
- Commands for popping out shells
- Better integration with evil mode
- Company mode completion integration
- Some handy aliases and config options

It also fixes some annoyances so that it works better with spacemacs.