### PR TITLE
Add yasnippet to default company backends

### DIFF
--- a/core/core-auto-completion.el
+++ b/core/core-auto-completion.el
@@ -16,7 +16,7 @@
   "Define a MODE specific company backend variable with default backends.
 The variable name format is company-backends-MODE."
   `(defvar ,(intern (format "company-backends-%S" mode))
-     '((company-dabbrev-code company-gtags company-etags company-keywords)
+     '((company-dabbrev-code company-gtags company-etags company-keywords :with company-yasnippet)
        company-files company-dabbrev)
      ,(format "Company backend list for %S" mode)))
 


### PR DESCRIPTION
This makes it so that yasnippet menus work in modes like ruby that fall back on the default backend. Yasnippet completion for people using tab for their auto-completion key also won't work without this IIRC.

Ruby is a bad example though since it won't actually work until #1225 is merged.