### PR TITLE
[Emergency fix] Don't add separator to the widget list

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -193,7 +193,7 @@ If TYPE is nil, just remove widgets."
                                                    :action (lambda (&rest ignore) (call-interactively #'evil-tutor-start))
                                                    :mouse-face 'highlight
                                                    :follow-link "\C-m"))
-                       (add-to-list 'spacemacs-buffer--note-widgets (widget-insert " "))
+                       (widget-insert " ")
                        (add-to-list 'spacemacs-buffer--note-widgets
                                     (widget-create 'push-button
                                                    :tag (propertize "Emacs Tutorial" 'face 'font-lock-keyword-face)


### PR DESCRIPTION
Otherwise when the widget list is deleted to insert new widgets, the
separator "widget" is essentially text with properties and can cause
error when trying to delete it, which breaks quick help and release note
buttons, making the buttons not function anymore.