### PR TITLE
Add evil-numbers binding for =

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -916,13 +916,14 @@
     (progn
       (defun spacemacs/evil-numbers-micro-state-doc ()
         "Display a short documentation in the mini buffer."
-        (echo "+ to increase the value or - to decrease it"))
+        (echo "+/= to increase the value or - to decrease it"))
 
       (defun spacemacs/evil-numbers-micro-state-overlay-map ()
         "Set a temporary overlay map to easily increase or decrease a number"
         (set-temporary-overlay-map
          (let ((map (make-sparse-keymap)))
            (define-key map (kbd "+") 'spacemacs/evil-numbers-increase)
+           (define-key map (kbd "=") 'spacemacs/evil-numbers-increase)
            (define-key map (kbd "-") 'spacemacs/evil-numbers-decrease)
            map) t)
         (spacemacs/evil-numbers-micro-state-doc))
@@ -938,6 +939,7 @@
         (evil-numbers/dec-at-pt amount)
         (spacemacs/evil-numbers-micro-state-overlay-map))
       (evil-leader/set-key "n+" 'spacemacs/evil-numbers-increase)
+      (evil-leader/set-key "n=" 'spacemacs/evil-numbers-increase)
       (evil-leader/set-key "n-" 'spacemacs/evil-numbers-decrease))))
 
 (defun spacemacs/init-evil-search-highlight-persist ()


### PR DESCRIPTION
Add a binding to evil-numbers so that `SPC n =` is synonymous with `SPC n +`.
Also add the binding to the evil-numbers micro-state so that `+` or `=` can be used to increment.

It's nice not to have to press shift when tweaking numbers as it makes the motion easier to do on a whim, this also makes - and + more symmetric feeling. Examples of other programs that don't require shift for +/- distinctions include Chrome and Firefox when zooming. Having two synonymous bindings is unfortunate, but I think it is the least surprising behavior if both work.