### PR TITLE
Use shell-pop to toggle shell/eshell/term

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -48,8 +48,8 @@
   "ac"  'calc-dispatch
   "ad"  'dired
   "ap"  'proced
-  "ase" 'eshell
-  "asi" 'shell
+  "ase" 'shell-pop-eshell
+  "asi" 'shell-pop-shell
   "au"  'undo-tree-visualize)
 ;; buffers --------------------------------------------------------------------
 (evil-leader/set-key

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -95,6 +95,7 @@
     recentf
     rfringe
     shell
+    shell-pop
     smartparens
     smooth-scrolling
     subword
@@ -2554,6 +2555,23 @@ It is a string holding:
   (add-hook 'shell-mode-hook 'shell-comint-input-sender-hook)
   (add-hook 'eshell-mode-hook (lambda ()
                                 (setq pcomplete-cycle-completions nil))))
+
+(defun spacemacs/init-shell-pop ()
+  (use-package shell-pop
+    :defer t
+    :init
+    (defmacro make-shell-pop-command (type &optional shell)
+      (let* ((name (symbol-name type)))
+        `(defun ,(intern (concat "shell-pop-" name)) (index)
+           (interactive "P")
+           (require 'shell-pop)
+           (shell-pop--set-shell-type 'shell-pop-shell-type (backquote (,name
+                                                                        ,(concat "*" name "*")
+                                                                        (lambda nil (funcall ',type ,shell)))))
+           (shell-pop index))))
+    (make-shell-pop-command eshell)
+    (make-shell-pop-command shell)
+    (make-shell-pop-command term shell-pop-term-shell)))
 
 (defun spacemacs/init-smartparens ()
   (use-package smartparens


### PR DESCRIPTION
The advantages:

- Always pop at the bottom, never taking whole window. It's convenient
when we need a shell to run some commands, then put it out.

- Can track the directory of current buffer, so we won't have to change
directory to current directory if we want to have a shell to do
something. For example, we can navigate using Dired to a directory, then
open a shell with shell-pop to run some commands.

- You can pop up multiple shells with different indexes and later select one
pop up based on the index specified by prefix argument.

- With shell-pop, Vim users who are used to tmux will find the built-in shells of Emacs more useful.