### PR TITLE
Allow storing of .spacemacs in the private config layer.

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -188,8 +188,15 @@ If ARG is non nil then `dotspacemacs/config' is skipped."
           (spacemacs//restore-powerline (current-buffer)))))))
 
 (defun dotspacemacs/location ()
-  "Return the absolute path to the spacemacs dotfile."
-  (concat user-home-directory ".spacemacs"))
+  "Return the absolute path to the spacemacs dotfile.
+
+If there exists a file called init.el in the private configuration directory
+that will be used, otherwise we look for dotspacemacs-filepath."
+  (let ((init.el (expand-file-name "~/.emacs.d/private/init.el"))
+        (.spacemacs dotspacemacs-filepath))
+    (if (file-exists-p init.el)
+        init.el
+      .spacemacs)))
 
 (defun dotspacemacs/copy-template ()
   "Copy `.spacemacs.template' in home directory. Ask for confirmation


### PR DESCRIPTION
this allows all the spacemacs config settings to be kept in a single repo (otherwise private is one repo and then we need to play games with symlinks to put .spacemacs in its own place). the name init.el was choose only because of the ~/.emacs == ~/.emacs.d/init.el convention.

if there's another, better or more spacemacs-y way to do this, let me know and ignore this commit.

(note: the dotspacmecs wizard and installation helpers have intentionally not been changed, once you get to the point of wanting this it's not hard to figure out and you probably aren't using the wizards anymore anyway)