### PR TITLE
Fix ggtags eldoc integration

### DIFF
--- a/contrib/gtags/funcs.el
+++ b/contrib/gtags/funcs.el
@@ -29,3 +29,10 @@
       "mgs" 'helm-gtags-select
       "mgS" 'helm-gtags-show-stack
       "mgu" 'helm-gtags-update-tags)))
+
+(defun spacemacs/ggtags-enable-eldoc (mode)
+  (add-hook (intern (concat (symbol-name mode) "-hook"))
+            (lambda ()
+              (ggtags-mode 1)
+              (setq-local eldoc-documentation-function
+                          #'ggtags-eldoc-function))))

--- a/contrib/gtags/packages.el
+++ b/contrib/gtags/packages.el
@@ -36,7 +36,11 @@
       (spacemacs/helm-gtags-define-keys-for-mode 'shell-script-mode)
       (spacemacs/helm-gtags-define-keys-for-mode 'awk-mode)
       (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode))
+      (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
+
+      (spacemacs/ggtags-enable-eldoc 'tcl-mode)
+      (spacemacs/ggtags-enable-eldoc 'java-mode)
+      (spacemacs/ggtags-enable-eldoc 'vhdl-mode))
     :config
     (progn
       ;; if anyone uses helm-gtags, they would want to use these key bindings

--- a/contrib/lang/php/packages.el
+++ b/contrib/lang/php/packages.el
@@ -31,9 +31,7 @@
 (defun php/post-init-eldoc ()
   (add-hook 'php-mode-hook 'eldoc-mode)
   (when (configuration-layer/package-usedp 'ggtags)
-    (add-hook 'php-mode-hook
-              (lambda () (setq-local eldoc-documentation-function
-                                     #'ggtags-eldoc-function)))))
+    (spacemacs/ggtags-enable-eldoc 'php-mode)))
 
 (defun php/post-init-ggtags ()
   (add-hook php-mode-hook 'ggtags-mode))


### PR DESCRIPTION
- ggtags eldoc works only if we enable ggtags-mode.
- For that reason, move the code that enable eldoc into its own
function.
- Also enable gtags for some other modes that have no layer.