### PR TITLE
osx: Set `$PATH` and `$MANPATH` from login shell

### DIFF
--- a/contrib/osx/README.md
+++ b/contrib/osx/README.md
@@ -1,11 +1,11 @@
-# OSX contribution layer for Spacemacs
+# OS X contribution layer for Spacemacs
 
 ![applogo](img/apple.png)![osxlogo](img/osx.png)
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
 **Table of Contents**
 
-- [OSX contribution layer for Spacemacs](#osx-contribution-layer-for-spacemacs)
+- [OS X contribution layer for Spacemacs](#os-x-contribution-layer-for-spacemacs)
     - [Description](#description)
     - [Philosophy](#philosophy)
     - [Install](#install)
@@ -16,15 +16,20 @@
 
 ## Description
 
-Spacemacs is not just emacs+vim. It can have OSX keybindings too! 
-This layer globally defines common OSX keybindings. ⌘ is set to
-`super` and ⌥ is set to `meta`. Aside from that, there's nothing
-much, really.
+Spacemacs is not just emacs+vim. It can have OS X keybindings too!
+This layer globally defines common OS X keybindings. ⌘ is set to
+`super` and ⌥ is set to `meta`.
+
+On OS X GUI applications do not inherit shell variables from a
+user's login shell session but this layer makes sure it does. This
+makes Emacs correctly discover packages installed by Homebrew.
+
+Aside from that, there's nothing much, really.
 
 ## Philosophy
 
-While this layer enables common OSX bindings, it does not implement
-OSX navigation keybindings. Spacemacs is meant to be used with evil,
+While this layer enables common OS X bindings, it does not implement
+OS X navigation keybindings. Spacemacs is meant to be used with evil,
 and we encourage you to do so :)
 
 ## Install
@@ -34,6 +39,21 @@ To use this configuration layer, add it to your `~/.spacemacs`
 ```elisp
 (setq-default dotspacemacs-configuration-layers '(osx)
   ;; List of contribution to load.
+)
+```
+
+By default only `$PATH` and `$MANPATH` are taken from your shell
+session. Any additional environment variables that you would like to
+also keep can be copied through calls to `exec-path-from-shell-copy-env`
+or by passing a list to `exec-path-from-shell-copy-envs`.
+
+```elisp
+(defun dotspacemacs/config ()
+  "Configuration function.
+ This function is called at the very end of Spacemacs initialization after
+layers configuration."
+  (exec-path-from-shell-copy-env "PYENV_ROOT")
+  (exec-path-from-shell-copy-envs '("RBENV_ROOT" "ANDROID_HOME"))
 )
 ```
 
@@ -53,4 +73,4 @@ To use this configuration layer, add it to your `~/.spacemacs`
 ## Future Work
 
 - Allow user to choose from either `hyper` or `super` as ⌘. This is an option that is supported cross-platform.
-- Configurable option to keep the OSX and spacemacs clipboards separate
+- Configurable option to keep the OS X and spacemacs clipboards separate

--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,5 +1,6 @@
 (defvar osx-packages
   '(
+    exec-path-from-shell
     pbcopy
     )
   "List of all packages to install and/or initialize. Built-in packages
@@ -9,3 +10,8 @@ which require an initialization must be listed explicitly in the list.")
   (use-package pbcopy
     :if (not (display-graphic-p))
     :init (turn-on-pbcopy)))
+
+(defun osx/init-exec-path-from-shell ()
+  (use-package exec-path-from-shell
+    :if (display-graphic-p)
+    :init (exec-path-from-shell-initialize)))


### PR DESCRIPTION
* Add spaces between `OS` and `X`
* Add `exec-path-from-shell` support

On OS X the Emacs GUI does not inherit the environment variables set by a user's login shell.

This can lead to unexpected behaviour if the user is using brew for example to manage additional packages.

Exec-path-from-shell resolves this issue. It executes the login shell and by default copies `$PATH` and `$MANPATH`.