### PR TITLE
Add function and keybinding to ediff current dotfile with template

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -491,6 +491,12 @@ argument takes the kindows rotate backwards."
   (interactive)
   (find-file-existing (dotspacemacs/location)))
 
+(defun ediff-dotfile-and-template ()
+  "ediff the current `dotfile' with the template"
+  (interactive)
+  (ediff-files (dotspacemacs/location)
+               (concat dotspacemacs-template-directory ".spacemacs.template")))
+
 (defun find-spacemacs-file ()
   (interactive)
   "Edit the `file' in the spacemacs base directory, in the current window."

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -106,6 +106,7 @@ Ensure that helm is required before calling FUNC."
   "fes" 'find-spacemacs-file
   "fec" 'find-contrib-file
   "fed" 'find-dotfile
+  "feD" 'ediff-dotfile-and-template
   "feR" 'dotspacemacs/sync-configuration-layers
   "fev" 'spacemacs/display-and-copy-version
   "ff" 'ido-find-file


### PR DESCRIPTION
Just adds a simple function to ediff the current .spacemacs with its template. 