### PR TITLE
php-mode: Adjust initialization of ggtags to avoid errors on startup

### DIFF
--- a/contrib/lang/php/packages.el
+++ b/contrib/lang/php/packages.el
@@ -36,7 +36,8 @@
                                      #'ggtags-eldoc-function)))))
 
 (defun php/post-init-ggtags ()
-  (add-hook php-mode-hook 'ggtags-mode))
+  (when (configuration-layer/package-usedp 'ggtags)
+    (add-hook 'php-mode-hook 'ggtags-mode)))
 
 (defun php/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'php-mode))


### PR DESCRIPTION
This fixes the start up error noted in #1140