### PR TITLE
Go layer requires gocode

### DIFF
--- a/contrib/lang/go/README.md
+++ b/contrib/lang/go/README.md
@@ -24,6 +24,16 @@ Features:
 
 ## Install
 
+### Pre-requisites 
+
+You will need gocode:
+
+```
+go get -u github.com/nsf/gocode
+```
+
+Make sure that `gocode` executable is in your PATH.
+
 ### Layer
 
 To use this contribution add it to your `~/.spacemacs`


### PR DESCRIPTION
Make this clear in the documentation. Otherwise, the user will see the following periodically in the Emacs status line:

```
 (file-error Searching for program no such file or directory gocode)
```