### PR TITLE
[fix] make <f2> open the layer source instead of gh-md

### DIFF
--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -112,14 +112,15 @@
                  (concat (ht-get configuration-layer-paths
                                  (intern candidate))
                          candidate)))))
-    (if helm-current-prefix-arg
-        (find-file (concat path file))
-      (condition-case nil
-          (with-current-buffer (find-file-noselect (concat path file))
-            (gh-md-render-buffer)
-            (kill-this-buffer))
-        ;; if anything fails, fall back to simply open file
-        (find-file (concat path file))))))
+    (if (or (equal (file-name-extension file) "md")
+            helm-current-prefix-arg)
+        (condition-case nil
+            (with-current-buffer (find-file-noselect (concat path file))
+              (gh-md-render-buffer)
+              (kill-this-buffer))
+          ;; if anything fails, fall back to simply open file
+          (find-file (concat path file)))
+      (find-file (concat path file)))))
 
 (defun helm-spacemacs//layer-action-open-readme (candidate)
   "Open the `README.md' file of the passed CANDIDATE."


### PR DESCRIPTION
Since helm-spacemacs//layer-action-open-file shares between first and
second actions, we always want second action to open file. For that
reason, we set helm-prefix-arg before calling the function.