### PR TITLE
[Emergency fix] spacemacs//mark-repl-as-useful

### DIFF
--- a/doc/HOWTOs.md
+++ b/doc/HOWTOs.md
@@ -64,9 +64,3 @@ Examples:
 (push "\\*Messages\\*" spacemacs-useful-buffers-regexp)
 ```
 
-Most repl buffers are marked useful by default. This behavior can be disabled
-with the following code:
-
-```elisp
-(remove-hook 'after-change-major-mode-hook 'spacemacs//mark-repl-as-useful)
-```

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -78,8 +78,7 @@
 (defvar spacemacs-useful-buffers-regexp '("\\*\\(scratch\\|terminal\.\+\\|ansi-term\\|eshell\\)\\*")
   "Regexp used to define buffers that are useful despite matching
 `spacemacs-useless-buffers-regexp'.")
-;; Automatically make comint buffers useful-buffers
-(add-hook 'buffer-list-update-hook 'spacemacs//mark-repl-as-useful)
+
 ;; activate winner mode use to undo and redo windows layout
 (winner-mode t)
 ;; no beep pleeeeeease ! (and no visual blinking too please)


### PR DESCRIPTION

This function is making asynchronous commands fail because it tries to
add string literal to spacemacs-useful-buffers-regexp while add-to-list
only works when first argument is a symbol and the second is an
element. Otherwise, it throws this error:

if: Wrong type argument: symbolp

This commit fixes the following issues:

- Don't add spacemacs//mark-repl-as-useful to
  buffer-list-update-hook. We only need this function to switch to next
  or previous buffer. So, better check when and only when those commands
  are actually used.

- As a result, we remove the function since it's unneeded anymore.

- Do the checking in of comint-mode in spacemacs-useful-buffer-p
  function. Better do it in one place than scatter the logic in a hook
  and this function.

- Change useless-buffer-p to accept an actual buffer object and check
  for buffer name inside.
