### PR TITLE
Improve Semantic layer

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -18,6 +18,8 @@
     company-c-headers
     flycheck
     helm-gtags
+    semantic
+    srefactor
     stickyfunc-enhance
     ))
 
@@ -53,11 +55,14 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)
   (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode))
 
-(defun c-c++/post-init-srefactor ()
+(defun c-c++/post-init-semantic ()
   (semantic/enable-semantic-mode 'c-mode)
-  (semantic/enable-semantic-mode 'c++-mode)
+  (semantic/enable-semantic-mode 'c++-mode))
+
+(defun c-c++/post-init-srefactor ()
   (evil-leader/set-key-for-mode 'c-mode "mr" 'srefactor-refactor-at-point)
-  (evil-leader/set-key-for-mode 'c++-mode "mr" 'srefactor-refactor-at-point))
+  (evil-leader/set-key-for-mode 'c++-mode "mr" 'srefactor-refactor-at-point)
+  (add-to-hooks 'spacemacs/lazy-load-srefactor '(c-mode-hook c++-mode-hook)))
 
 (defun c-c++/post-init-stickyfunc-enhance ()
   (add-to-hooks 'spacemacs/lazy-load-stickyfunc-enhance '(c-mode-hook c++-mode-hook)))

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -256,6 +256,8 @@
       (push '(company-anaconda :with company-yasnippet)
             company-backends-python-mode))))
 
+(defun python/post-init-semantic ()
+  (semantic/enable-semantic-mode 'python-mode))
+
 (defun python/post-init-stickyfunc-enhance ()
-  (semantic/enable-semantic-mode 'python-mode)
   (add-hook 'python-mode-hook 'spacemacs/lazy-load-stickyfunc-enhance))

--- a/contrib/semantic/packages.el
+++ b/contrib/semantic/packages.el
@@ -13,6 +13,8 @@
 (defvar semantic-packages
   '(
     ;; package semantic go here
+    semantic
+    srefactor
     stickyfunc-enhance
     )
   "List of all packages to install and/or initialize. Built-in packages
@@ -39,24 +41,41 @@ which require an initialization must be listed explicitly in the list.")
                      (require 'semantic)
                      (add-to-list 'semantic-default-submodes 'global-semantic-stickyfunc-mode)
                      (add-to-list 'semantic-default-submodes 'global-semantic-idle-summary-mode)
-                     ;; enable specific major mode setup before it can be used
-                     ;; properly. For now, only Emacs Lisp.
                      (when (eq major-mode 'emacs-lisp-mode)
-                       (semantic-default-elisp-setup)
-                       (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfb" 'srefactor-lisp-format-buffer)
-                       (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfd" 'srefactor-lisp-format-defun)
-                       (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfr" 'srefactor-lisp-format-sexp)
-                       (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfo" 'srefactor-lisp-one-line))
+                       (semantic-default-elisp-setup))
                      (semantic-mode 1)))))
 
-(defun semantic/init-srefactor ()
-  (use-package srefactor
+(defun semantic/init-semantic ()
+  (use-package semantic
     :defer t
     :init
     (progn
       (setq srecode-map-save-file (concat spacemacs-cache-directory "srecode-map.el"))
       (setq semanticdb-default-save-directory (concat spacemacs-cache-directory "semanticdb/"))
       (semantic/enable-semantic-mode 'emacs-lisp-mode))))
+
+(defun semantic/init-srefactor ()
+  (use-package srefactor
+    :defer t
+    :init
+    (progn
+      (defun spacemacs/lazy-load-srefactor ()
+        "Lazy load the package."
+        (require 'srefactor)
+        ;; currently, evil-mode overrides key mapping of srefactor menu
+        ;; must expplicity enable evil-emacs-state. This is ok since
+        ;; srefactor supports j,k,/ and ? commands when Evil is
+        ;; available
+        (add-hook 'srefactor-ui-menu-mode-hook 'evil-emacs-state)
+        ;; enable specific major mode setup before it can be used
+        ;; properly. For now, only Emacs Lisp.
+        (when (eq major-mode 'emacs-lisp-mode)
+          (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfb" 'srefactor-lisp-format-buffer)
+          (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfd" 'srefactor-lisp-format-defun)
+          (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfr" 'srefactor-lisp-format-sexp)
+          (evil-leader/set-key-for-mode 'emacs-lisp-mode "mfo" 'srefactor-lisp-one-line)))
+      ;; load srefactor for emac-lisp-mode
+      (add-hook 'emacs-lisp-mode-hook 'spacemacs/lazy-load-srefactor))))
 
 (defun semantic/init-stickyfunc-enhance ()
   (use-package stickyfunc-enhance


### PR DESCRIPTION
- Explicitly load Semantic. Currently is loaded only when Srefactor is
  loaded, which is not good for other packages that depends on
  Semantic but outside of C/C++, i.e. Python.

- Enable evil-emacs-state in Srefactor UI menu, since currently Evil key
  mapping override the key mapping of the menu. Vim key bindings are
  already supported upstream, with j,k,/ and ? which is good enough to
  navigate the menu.