### PR TITLE
Made build-view always recompile tex

### DIFF
--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -13,13 +13,12 @@
     (progn
       (defun auctex/build-view ()
         (interactive)
-        (if (buffer-modified-p)
-            (progn
-              (let ((TeX-save-query nil))
-                (TeX-save-document (TeX-master-file)))
-              (setq build-proc (TeX-command "LaTeX" 'TeX-master-file -1))
-              (set-process-sentinel  build-proc  'auctex/build-sentinel))
-          (TeX-view)))
+        (progn
+          (let ((TeX-save-query nil))
+            (TeX-save-document (TeX-master-file)))
+          (setq build-proc (TeX-command "LaTeX" 'TeX-master-file -1))
+          (set-process-sentinel  build-proc  'auctex/build-sentinel))
+        (TeX-view))
 
       (defun auctex/build-sentinel (process event)
         (if (string= event "finished\n")


### PR DESCRIPTION
Previously it would only compile upon changes, which would be annoying when making tables of contents update since they only update correctly after two tex compiles.