### PR TITLE
Adding pudb as a python breakpoint

### DIFF
--- a/contrib/lang/python/funcs.el
+++ b/contrib/lang/python/funcs.el
@@ -14,15 +14,15 @@
 (defun annotate-pdb ()
   "Highlight break point lines."
   (interactive)
-  (highlight-lines-matching-regexp "import i?pdb")
-  (highlight-lines-matching-regexp "i?pdb.set_trace()"))
+  (highlight-lines-matching-regexp "import i?pu?db")
+  (highlight-lines-matching-regexp "i?pu?db.set_trace()"))
 
 (defun python-toggle-breakpoint ()
   "Add a break point, highlight it."
   (interactive)
-  (let ((trace (if (executable-find "ipdb")
-                   "import ipdb; ipdb.set_trace()"
-                 "import pdb; pdb.set_trace()"))
+  (let ((trace (cond ((executable-find "ipdb") "import ipdb; ipdb.set_trace()")
+                     ((executable-find "pudb") "import pudb; pudb.set_trace()")
+                     ((t "import pdb; pdb.set_trace()"))))
         (line (thing-at-point 'line)))
     (if (and line (string-match trace line))
         (kill-whole-line)


### PR DESCRIPTION
I use & love [pudb](https://pypi.python.org/pypi/pudb), so I updated the breakpoint function to insert pudb if it was installed. Let me know if I should document this somewhere!