### PR TITLE
add a function to remove unused imports

### DIFF
--- a/contrib/lang/python/README.md
+++ b/contrib/lang/python/README.md
@@ -152,6 +152,7 @@ Test commands (start with <kbd>m t</kbd> or <kbd>m T</kbd>):
 <kbd>SPC m h H</kbd>  | open documentation in `firefox` using [pylookup][pylookup]
 <kbd>SPC m v</kbd>    | activate a virtual environment with [pyenv][pyenv]
 <kbd>SPC m V</kbd>    | activate a virtual environment with [pyvenv][pyvenv]
+<kbd>SPC c i</kbd>    | remove unused imports with [autoflake][autoflake]
 
 ### Django
 
@@ -226,3 +227,4 @@ Manage Django with <kbd>SPC m j m</kbd>.
 [pony-mode]: https://github.com/davidmiller/pony-mode
 [anaconda-deps]: https://github.com/proofit404/anaconda-mode/blob/master/requirements.txt
 [YAPF]: https://github.com/google/yapf
+[autoflake]: https://github.com/myint/autoflake

--- a/contrib/lang/python/funcs.el
+++ b/contrib/lang/python/funcs.el
@@ -31,3 +31,13 @@
         (insert-string trace)
         (insert-string "\n")
         (python-indent-line)))))
+
+;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
+(defun python-remove-unused-imports()
+  "Use Autoflake to remove unused function"
+  "autoflake --remove-all-unused-imports -i unused_imports.py"
+  (interactive)
+  (shell-command
+   (format "autoflake --remove-all-unused-imports -i %s"
+           (shell-quote-argument (buffer-file-name))))
+  (revert-buffer t t t))

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -208,6 +208,7 @@
       (evil-leader/set-key-for-mode 'python-mode
         "mcc" 'spacemacs/python-execute-file
         "mcC" 'spacemacs/python-execute-file-focus
+        "mci" 'python-remove-unused-imports
         "mdb" 'python-toggle-breakpoint
         "msB" 'python-shell-send-buffer-switch
         "msb" 'python-shell-send-buffer


### PR DESCRIPTION
I found a code snippet to remove unused imports in python code. I think it might be a nice thing to have in spacemacs.