### PR TITLE
put helm buffer at the bottom

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1296,6 +1296,13 @@ Example: (evil-map visual \"<\" \"<gv\")"
             helm-bookmark-show-location t
             helm-split-window-in-side-p t
             helm-always-two-windows t)
+
+      (setq helm-display-function
+            (lambda (buf)
+              (split-window-vertically-and-switch)
+              (evil-window-move-very-bottom)
+              (spacemacs/shrink-window (/ (window-height) 3))
+              (switch-to-buffer buf)))
       ;; fuzzy matching setting
       (setq helm-M-x-fuzzy-match t
             helm-apropos-fuzzy-match t


### PR DESCRIPTION
Hi, unfortunately this PR isn't fully ready, but I rushed it in as I need to leave (and don't want to forget it). There are two things:

1) I think this should probably be put behind a config option, but when I tried to do it I started getting errors and didn't have the time to debug it.

2) it was suggested by @mkcode in the chat that maybe the height (currently set to 1 third of the screen, (or 2/3 of the bottom 1/2 of the screen as that's how it's calculated)) should be the same as `popwin:popup-window-height` which seems like a reasonable suggestion.