### PR TITLE
sql: use Helm to select dialect/client

### DIFF
--- a/contrib/lang/sql/README.md
+++ b/contrib/lang/sql/README.md
@@ -9,8 +9,8 @@
     - [Description](#description)
     - [Install](#install)
     - [Key bindings](#key-bindings)
-        - [Dialects and Clients](#dialects-and-clients)
-        - [Inferior Process interactions (SQLi)](#inferior-process-interactions-sqli)
+        - [Highlighting](#highlighting)
+        - [Inferior Process Interactions (SQLi)](#inferior-process-interactions-sqli)
         - [SQLi buffer](#sqli-buffer)
 
 <!-- markdown-toc end -->
@@ -30,26 +30,13 @@ To use this contribution layer add it to your `~/.spacemacs`
 
 ## Key bindings
 
-### Dialects and Clients
+### Highlighting
 
-Database  | Client + Dialect     | Dialect (highlighting) only
-----------|----------------------|----------------------------
-ANSI SQL  | n/a                  | <kbd>SPC m h k a</kbd>
-DB2       | <kbd>SPC m c d</kbd> | <kbd>SPC m h k d</kbd>
-Informix  | <kbd>SPC m c i</kbd> | <kbd>SPC m h k i</kbd>
-Ingrex    | <kbd>SPC m c n</kbd> | <kbd>SPC m h k n</kbd>
-Interbase | <kbd>SPC m c t</kbd> | <kbd>SPC m h k t</kbd>
-Linter    | <kbd>SPC m c l</kbd> | <kbd>SPC m h k l</kbd>
-Microsoft | <kbd>SPC m c s</kbd> | <kbd>SPC m h k s</kbd>
-MySQL     | <kbd>SPC m c m</kbd> | <kbd>SPC m h k m</kbd>
-Oracle    | <kbd>SPC m c o</kbd> | <kbd>SPC m h k o</kbd>
-Postgres  | <kbd>SPC m c p</kbd> | <kbd>SPC m h k p</kbd>
-Solid     | <kbd>SPC m c S</kbd> | <kbd>SPC m h k S</kbd>
-SQLite    | <kbd>SPC m c q</kbd> | <kbd>SPC m h k q</kbd>
-Sybase    | <kbd>SPC m c b</kbd> | <kbd>SPC m h k b</kbd>
-Vertica   | <kbd>SPC m c v</kbd> | <kbd>SPC m h k v</kbd>
+Key Binding          | Description
+---------------------|--------------------------------------------------------------------
+<kbd>SPC m h k</kbd> | select a SQL dialect to highlight
 
-### Inferior Process interactions (SQLi)
+### Inferior Process Interactions (SQLi)
 
 Key Binding          | Description
 ---------------------|--------------------------------------------------------------------
@@ -64,6 +51,7 @@ Key Binding          | Description
 ---------------------|--------------------------------------------------------------------
 <kbd>SPC m s b</kbd> | Send the whole buffer to the SQLi buffer
 <kbd>SPC m s B</kbd> | Send the whole buffer to the SQLi buffer and switch to it in `insert state`
+<kbd>SPC m s i</kbd> | Start the SQLi process
 <kbd>SPC m s f</kbd> | Send the paragraph under the point to the SQLi buffer
 <kbd>SPC m s F</kbd> | Send the paragraph under the point to the SQLi buffer and switch to it in `insert state`
 <kbd>SPC m s q</kbd> | Prompt for a string to send to the SQLi buffer

--- a/contrib/lang/sql/packages.el
+++ b/contrib/lang/sql/packages.el
@@ -17,35 +17,40 @@
 (defun sql/init-sql ()
   (use-package sql
     :defer t
-    :init
+    :config
     (progn
-      ;; should not set this to anything else than nil
-      ;; the focus of SQLi is handled by spacemacs conventions
-      (setq sql-pop-to-buffer-after-send-region nil)
+      (setq spacemacs-sql-highlightable sql-product-alist
+            spacemacs-sql-startable (remove-if-not
+                                (lambda (product) (sql-get-product-feature (car product) :sqli-program))
+                                sql-product-alist)
 
-      (defmacro sql-client (name)
-        "Define a function to set syntax highlighting and start a SQLi buffer."
-        (let
-            ((funcname (intern (concat "sql/" name "-client")))
-             (highlight (intern (concat "sql-highlight-" name "-keywords")))
-             (client (intern (concat "sql-" name))))
-          `(defun ,funcname ()
-             (interactive)
-             (,highlight)
-             (,client))))
-      (sql-client "db2")
-      (sql-client "mysql")
-      (sql-client "postgres")
-      (sql-client "sqlite")
-      (sql-client "ms")
-      (sql-client "informix")
-      (sql-client "ingrex")
-      (sql-client "interbase")
-      (sql-client "linter")
-      (sql-client "oracle")
-      (sql-client "solid")
-      (sql-client "sybase")
-      (sql-client "vertica")
+            ;; should not set this to anything else than nil
+            ;; the focus of SQLi is handled by spacemacs conventions
+            sql-pop-to-buffer-after-send-region nil)
+
+      (defun spacemacs//sql-source (products)
+        "return a source for helm selection"
+        `((name . "SQL Products")
+          (candidates . ,(mapcar (lambda (product)
+                                   (cons (sql-get-product-feature (car product) :name)
+                                         (car product)))
+                                 products))
+          (action . (lambda (candidate) (helm-marked-candidates)))))
+
+      (defun spacemacs/sql-highlight ()
+        "set SQL dialect-specific highlighting"
+        (interactive)
+        (let ((product (car (helm
+                             :sources (list (spacemacs//sql-source spacemacs-sql-highlightable))))))
+          (sql-set-product product)))
+
+      (defun spacemacs/sql-start ()
+        "set SQL dialect-specific highlighting and start inferior SQLi process"
+        (interactive)
+        (let ((product (car (helm
+                             :sources (list (spacemacs//sql-source spacemacs-sql-startable))))))
+          (sql-set-product product)
+          (sql-product-interactive product)))
 
       (defun spacemacs/sql-send-string-and-focus ()
         "Send a string to SQLi and switch to SQLi in `insert state'."
@@ -80,46 +85,16 @@
         "mbb" 'sql-show-sqli-buffer
         "mbs" 'sql-set-sqli-buffer
 
-        ;; clients
-        ;; TODO: change the key binding to `msi' and use a helm buffer
-        ;; to choose the client type
-        "mcb" 'sql/sybase-client
-        "mcd" 'sql/db2-client
-        "mci" 'sql/informix-client
-        "mcl" 'sql/linter-client
-        "mcm" 'sql/mysql-client
-        "mcn" 'sql/ingrex-client
-        "mco" 'sql/oracle-client
-        "mcp" 'sql/postgres-client
-        "mcq" 'sql/sqlite-client
-        "mcs" 'sql/ms-client
-        "mcS" 'sql/solid-client
-        "mct" 'sql/interbase-client
-        "mcv" 'sql/vertica-client
-
         ;; dialects
-        ;; TODO: use `mhk' and use a helm buffer to choose the dialect
-        "mhka" 'sql-highlight-ansi-keywords
-        "mhkb" 'sql-highlight-sybase-keywords
-        "mhkd" 'sql-highlight-db2-keywords
-        "mhki" 'sql-highlight-informix-keywords
-        "mhkl" 'sql-highlight-linter-keywords
-        "mhkm" 'sql-highlight-mysql-keywords
-        "mhkn" 'sql-highlight-ingrex-keywords
-        "mhko" 'sql-highlight-oracle-keywords
-        "mhkp" 'sql-highlight-postgres-keywords
-        "mhkq" 'sql-highlight-sqlite-keywords
-        "mhks" 'sql-highlight-ms-keywords
-        "mhkS" 'sql-highlight-solid-keywords
-        "mhkt" 'sql-highlight-interbase-keywords
-        "mhkv" 'sql-highlight-vertica-keywords
+        "mhk" 'spacemacs/sql-highlight
 
         ;; interactivity
         "msb" 'sql-send-buffer
         "msB" 'spacemacs/sql-send-buffer-and-focus
+        "msi" 'spacemacs/sql-start
         ;; paragraph gets "f" here because they can be assimilated to functions.
-        ;; If you separate your commands in a SQL file, double-tapping the key
-        ;; will send the command under the point, which is what you probably want.
+        ;; If you separate your commands in a SQL file, this key will send the
+        ;; command under the point, which is what you probably want.
         "msf" 'sql-send-paragraph
         "msF" 'spacemacs/sql-send-paragraph-and-focus
         "msq" 'sql-send-string


### PR DESCRIPTION
Now with 100% fewer macros! :sparkles:

So, questions:

 - are the keybindings correct?
 - `spacemacs//sql-source ` is private - should it be? (and thanks for linking to the conventions doc. I hadn't seen it before, somehow!)
 - `(car (helm ...))` (lines 43 and 50) feels a little clumsy to me. Is there a more elegant way of getting a single value back from helm?
 - as best I can tell, `sql-set-product` and `sql-product-interactive` are public functions, but I pulled them directly out of the [source](http://repo.or.cz/w/emacs.git/blob/HEAD:/lisp/progmodes/sql.el) so... are they private? I don't know.

Pinging @tuhdo and @trishume, if you want to tell me how my elisp sucks please do!

Original PR/discussion: #1141.