### PR TITLE
Add `:A` ex-command to the Ruby layer

### DIFF
--- a/contrib/lang/ruby/packages.el
+++ b/contrib/lang/ruby/packages.el
@@ -122,7 +122,9 @@
       (evil-leader/set-key "mrr:" 'projectile-rails-rake)
       (evil-leader/set-key "mrxs" 'projectile-rails-server)
       ;; Refactoring
-      (evil-leader/set-key "mrRx" 'projectile-rails-extract-region))))
+      (evil-leader/set-key "mrRx" 'projectile-rails-extract-region)
+      ;; Ex-commands
+      (evil-ex-define-cmd "A" 'projectile-toggle-between-implementation-and-test))))
 
 (defun ruby/init-robe ()
   "Initialize Robe mode"


### PR DESCRIPTION
This is related to the issue #1308 but implements only the `:A` command.

I thought about other ex-commands from the [evil-rails](https://github.com/antono/evil-rails) package but they are very well covered by projectile keybindings already. Plus, I didn't really use them back in my days of Vim usage anyway.

But `:A` command is so-widely used in the vim-rails world, I'm voting to add it :cat: