### PR TITLE
Replace toggle-read-only with read-only-mode

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -68,7 +68,7 @@
   "bR"  'spacemacs/safe-revert-buffer
   "br"  'rename-current-buffer-file
   "bY"  'copy-whole-buffer-to-clipboard
-  "bw"  'toggle-read-only)
+  "bw"  'read-only-mode)
 ;; Cycling settings -----------------------------------------------------------
 (evil-leader/set-key "Tn" 'spacemacs/cycle-spacemacs-theme)
 ;; describe functions ---------------------------------------------------------


### PR DESCRIPTION
Because `C-h f toggle-read-only` says:

    toggle-read-only is an interactive compiled Lisp function in `files.el'.

    It is bound to SPC b w, M-m b w.

    (toggle-read-only &optional ARG INTERACTIVE)

    This function is obsolete since 24.3;
    use `read-only-mode' instead.

    Change whether this buffer is read-only.