### PR TITLE
Remove key based on obsolete package

### DIFF
--- a/contrib/irc/erc/packages.el
+++ b/contrib/irc/erc/packages.el
@@ -42,7 +42,6 @@
             erc-server-coding-system '(utf-8 . utf-8))
       ;; keybindings
       (evil-leader/set-key-for-mode 'erc-mode
-        "mb" 'erc-iswitchb
         "md" 'erc-input-action
         "mj" 'erc-join-channel
         "mn" 'erc-channel-names


### PR DESCRIPTION
As per http://www.emacswiki.org/emacs/IswitchBuffers :

> Note: IswitchB was part of GnuEmacs, but it has been removed starting
> with Emacs 24.4. The Emacs ‘NEWS’ (‘C-h N’) says to use IcompleteMode
> instead, but for those wanting more familiar functionality,
> InteractivelyDoThings is a closer fit.

/cc @cpaulik 