### PR TITLE
Clean state when switching to a new workspace

### DIFF
--- a/contrib/window-management/eyebrowse/packages.el
+++ b/contrib/window-management/eyebrowse/packages.el
@@ -17,11 +17,12 @@
     :diminish eyebrowse-mode
     :init
     (progn
+      (setq eyebrowse-new-workspace #'spacemacs/home)
       (eyebrowse-mode)
 
       (defun spacemacs/workspace-number ()
         "Return the number of the current workspace."
-        (let* ((num (eyebrowse-get 'current-slot))
+        (let* ((num (eyebrowse--get 'current-slot))
                (str (if num (int-to-string num))))
           (cond
            ((not dotspacemacs-mode-line-unicode-symbols) (concat " " str " "))
@@ -38,8 +39,8 @@
 
       (defun spacemacs//workspaces-ms-documentation ()
         "Return the docstring for the workspaces micro-state."
-        (let* ((current-slot (number-to-string (eyebrowse-get 'current-slot)))
-               (window-configs (eyebrowse-get 'window-configs))
+        (let* ((current-slot (number-to-string (eyebrowse--get 'current-slot)))
+               (window-configs (eyebrowse--get 'window-configs))
                (window-config-slots (mapcar (lambda (x)
                                               (number-to-string (car x)))
                                             window-configs)))


### PR DESCRIPTION
In i3, whenever you switch to a new workspace, it starts with a blank
frame with default wallpaper. It would be useful when we switch
workspace, the window is reset to a default buffer so it's more obvious
for first time users and is closer to i3 or Vim's tabs. Since eyebrowse
supports this feature already, we simply set it to switch to
spacemacs/home function.

Also, eyebrowse-get becomes eyebrowse--get to express that it is now
private function. So this commit fixes it appropriately.