### PR TITLE
Add ability to disable `flycheck-pos-tip`

### DIFF
--- a/contrib/syntax-checking/README.md
+++ b/contrib/syntax-checking/README.md
@@ -8,6 +8,7 @@
 - [Syntax Checking configuration layer for Spacemacs](#syntax-checking-configuration-layer-for-spacemacs)
     - [Description](#description)
     - [Install](#install)
+        - [Variables](#variables)
     - [Key Bindings](#key-bindings)
 
 <!-- markdown-toc end -->
@@ -23,6 +24,22 @@ To use this configuration layer add it to your `~/.spacemacs`
 ```elisp
 (setq-default dotspacemacs-configuration-layers '(syntax-checking))
 ```
+
+### Variables
+
+To set any variables for this layer, add the following to your `~/.spacemacs`
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(
+  (syntax-checking :variables
+                   syntax-checking-flycheck-pos-tip nil)
+)
+```
+
+    Variable                       |                 Description
+-----------------------------------|------------------------------------------------------------------------------------------------------------------
+syntax-checking-flycheck-pos-tip   | If nil (default t), the [flycheck-pos-tip](https://github.com/flycheck/flycheck-pos-tip) package will be disabled 
+
 
 ## Key Bindings
 

--- a/contrib/syntax-checking/config.el
+++ b/contrib/syntax-checking/config.el
@@ -1,0 +1,16 @@
+;;; config.el --- Syntax Checking Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar syntax-checking-flycheck-pos-tip t
+  "If non nil the `flycheck-pos-tip` package is is enabled.")

--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -13,9 +13,11 @@
 (defvar syntax-checking-packages
   '(
     flycheck
-    flycheck-pos-tip
     popwin
     ))
+
+(if syntax-checking-flycheck-pos-tip
+    (push 'flycheck-pos-tip syntax-checking-packages))
 
 (defvar syntax-checking-excluded-packages '()
   "Packages that use syntax-checking that are no longer necessary and might
@@ -119,6 +121,7 @@ conflict.")
 
 (defun syntax-checking/init-flycheck-pos-tip ()
   (use-package flycheck-pos-tip
+    :if syntax-checking-flycheck-pos-tip
     :defer t
     :init
     (setq flycheck-display-errors-function 'flycheck-pos-tip-error-messages)))


### PR DESCRIPTION
Some people don't like pop-up messages in their editing window (me :wink:) and prefer to keep it located in the echo area.

Let me know if you'd rather I target the `develop` branch instead of `master`. Thanks!