### PR TITLE
[Fix #915] Change position of guide-key popup window

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1275,7 +1275,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
                                            "z"
                                            "C-h")
             guide-key/recursive-key-sequence-flag t
-            guide-key/popup-window-position 'right
+            guide-key/popup-window-position 'bottom
             guide-key/idle-delay dotspacemacs-guide-key-delay
             guide-key/text-scale-amount 0
             ;; use this in your ~/.spacemacs file to enable tool tip in a


### PR DESCRIPTION
A fix for https://github.com/syl20bnr/spacemacs/issues/915.

Previously situations like this would occur:

![screenshot 2015-04-26 13 38 19](https://cloud.githubusercontent.com/assets/2999209/7336159/bdfa6792-ec20-11e4-86f3-21a4406e4631.png)

which makes it hard for new users to grasp what the commands are, if they vertically split windows.

Now at least they can all be displayed fully.

![screenshot 2015-04-26 14 16 48](https://cloud.githubusercontent.com/assets/2999209/7336162/d97f5c2a-ec20-11e4-83b1-eb2c68d9311e.png)

https://github.com/syl20bnr/spacemacs/pull/1072 works fine for me. However if `window-purpose` is not to be incorporated soon, this could be a temporary fix?