### PR TITLE
Add spacemacs/smart-goto-definition

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -691,6 +691,17 @@ Example: (evil-map visual \"<\" \"<gv\")"
           (error (evil-lookup))))
       (define-key evil-normal-state-map (kbd "K") 'spacemacs/smart-doc-lookup)
 
+      (defun spacemacs/smart-goto-definition ()
+        "Version of `evil-goto-definition' that attempts to use
+        the mode the mode specific goto-definition binding,
+        i.e. `SPC m g g`, to lookup the source of the definition,
+        while falling back to `evil-goto-definition'."
+        (interactive)
+        (condition-case nil
+            (execute-kbd-macro (kbd "SPC m g g"))
+          (error (evil-goto-definition))))
+      (define-key evil-normal-state-map (kbd "gd") 'spacemacs/smart-goto-definition)
+
       ;; scrolling micro state
       (defun spacemacs/scroll-half-page-up ()
         "Scroll half a page up while keeping cursor in middle of page."


### PR DESCRIPTION
It attempts to call `SPC m g g` and falls back to `evil-goto-definition`
if that fails.