### PR TITLE
Enable evil-execute-in-normal-state in holy-mode

### DIFF
--- a/contrib/better-defaults/README.md
+++ b/contrib/better-defaults/README.md
@@ -47,5 +47,6 @@ pressed again, go to the beginning of the line.
 Key Binding   | Description
 --------------|------------------------------------------------------------
 `C-a`         | smart beginning of line
+`C-o`         | get into Vim normal mode to execute one command, then go back Emacs edit              | ing mode
 
 [Prelude]: https://github.com/bbatsov/prelude

--- a/contrib/better-defaults/keybindings.el
+++ b/contrib/better-defaults/keybindings.el
@@ -11,3 +11,6 @@
 ;;; License: GPLv3
 
 (global-set-key (kbd "C-a") 'spacemacs/smart-move-beginning-of-line)
+
+;; emacs state bindings
+(define-key evil-emacs-state-map (kbd "C-o") 'evil-execute-in-normal-state)

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -132,6 +132,7 @@ Ensure that helm is required before calling FUNC."
 (evil-leader/set-key
   "J"  'sp-split-sexp
   "jj" 'sp-newline
+  "jo" 'open-line
   "j=" 'spacemacs/indent-region-or-buffer
   "jJ" 'spacemacs/split-and-new-line
   "jk" 'evil-goto-next-line-and-indent)


### PR DESCRIPTION
Add open-line command to "SPC j" group: open-line breaks the current
line into two lines without moving the cursor down. It's different from
`o` in Vim.
    
Use C-o to enter evil-execute-in-normal-state.