### PR TITLE
Add ability to disable `flycheck-pos-tip`

### DIFF
--- a/contrib/syntax-checking/config.el
+++ b/contrib/syntax-checking/config.el
@@ -1,0 +1,16 @@
+;;; config.el --- Syntax Checking Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar syntax-checking-flycheck-pos-tip t
+  "If non nil the `flycheck-pos-tip` package is is enabled.")

--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -13,10 +13,11 @@
 (setq syntax-checking-packages
   '(
     flycheck
-    flycheck-pos-tip
     popwin
     ))
 
+(if syntax-checking-flycheck-pos-tip
+    (push 'flycheck-pos-tip syntax-checking-packages))
 
 (defun syntax-checking/init-flycheck ()
   (use-package flycheck
@@ -116,6 +117,7 @@
 
 (defun syntax-checking/init-flycheck-pos-tip ()
   (use-package flycheck-pos-tip
+    :if syntax-checking-flycheck-pos-tip
     :defer t
     :init
     (setq flycheck-display-errors-function 'flycheck-pos-tip-error-messages)))


### PR DESCRIPTION
Some people don't like pop-up messages in their editing window (me :wink:) and
prefer to keep it located in the echo area.

(Originally #1386 - reopened on `develop` branch)