### PR TITLE
Remove visual noise in Helm window

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1307,6 +1307,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
     (progn
       (setq helm-prevent-escaping-from-minibuffer t
             helm-bookmark-show-location t
+            helm-display-header-line nil
             helm-split-window-in-side-p t
             helm-always-two-windows t)
 


### PR DESCRIPTION
In a Helm window, the top header line displays a key binding to execute
persistent action. The key binding is C-j. The problem, not all sources
are applicable with C-j, i.e. helm-projectile-switch-project.

Removing the header line also makes Helm look cleaner.