### PR TITLE
When using vim editing style use single space sentence delimiter.

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -92,6 +92,11 @@
     (spacemacs|hide-lighter hs-minor-mode)))
 (add-hook 'prog-mode-hook 'spacemacs//enable-hs-minor-mode)
 
+;; single-space sentence navigation to match vim if vim is selected as the
+;; editing style
+(when (eq 'vim dotspacemacs-editing-style)
+  (setq-default sentence-end-double-space nil))
+
 ;; Hack to fix a bug with tabulated-list.el
 ;; see: http://redd.it/2dgy52
 (defun tabulated-list-revert (&rest ignored)


### PR DESCRIPTION
Hey ya'll,

This makes it more vim-like. Vim by default uses a single space delimiter for sentences so when in vim editing mode it makes sense to do that. I wasn't sure where to stick it in the config, let me know if I messed up.

This makes it so **das** when the cursor is on foo here:

```
Foo. Bar.
```

Leaves just Bar. instead of deleting the whole thing because there is no double space delimiter.