### PR TITLE
Fix for powerline not displaying in active window (#1426)

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2410,7 +2410,8 @@ It is a string holding:
                 ;; percentage in the file
                 (powerline-raw "%p" line-face 'r)
                 ;; display hud
-                (powerline-chamfer-left line-face face1)
+                ;; Not sure why but commenting out next line fixes #1426
+                ;; (powerline-chamfer-left line-face face1)
                 (if (string-match "\%" progress)
                     (powerline-hud state-face face1))))))))
 


### PR DESCRIPTION
Wasn't able to determine the exact cause, but this fixes a "Bad bounding idices" error that prevents the mode line from displaying (see #1426). I don't think it has much impact on the look of the mode line. 