### PR TITLE
Fix helm-spacemacs logic for open layer doc

### DIFF
--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -112,8 +112,8 @@
                  (concat (ht-get configuration-layer-paths
                                  (intern candidate))
                          candidate)))))
-    (if (or (equal (file-name-extension file) "md")
-            helm-current-prefix-arg)
+    (if (and (equal (file-name-extension file) "md")
+             (not helm-current-prefix-arg))
         (condition-case nil
             (with-current-buffer (find-file-noselect (concat path file))
               (gh-md-render-buffer)


### PR DESCRIPTION
It is supposed to open plain markdown file inside Emacs when a prefix
argument is supplied and render the markdown file otherwise. Currently,
both actions open the markdown file in a rendered buffer. This commit
fixed the issue.