### PR TITLE
Use non-visual lines for j/k navigation

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -654,12 +654,6 @@
       (define-key evil-normal-state-map (kbd dotspacemacs-command-key) 'evil-ex)
       (define-key evil-visual-state-map (kbd dotspacemacs-command-key) 'evil-ex)
       (define-key evil-motion-state-map (kbd dotspacemacs-command-key) 'evil-ex)
-      ;; Make evil-mode up/down operate in screen lines instead of logical lines
-      (define-key evil-normal-state-map "j" 'evil-next-visual-line)
-      (define-key evil-normal-state-map "k" 'evil-previous-visual-line)
-      ;; Also in visual mode
-      (define-key evil-visual-state-map "j" 'evil-next-visual-line)
-      (define-key evil-visual-state-map "k" 'evil-previous-visual-line)
       ;; Make the current definition and/or comment visible.
       (define-key evil-normal-state-map "zf" 'reposition-window)
 


### PR DESCRIPTION
This PR changes the behavior of j/k back to vim does it, how evil does it by default, how up/down keys work, and it makes relative line jumps line up with the shown numbers.