### PR TITLE
Adding org-jira contrib layer

### DIFF
--- a/contrib/org-jira/README.md
+++ b/contrib/org-jira/README.md
@@ -1,0 +1,39 @@
+# org-jira Spacemacs layer
+
+This Spacemacs layer allows using Jira from within org-mode.
+
+## Installation
+
+1. Clone the git repository somewhere and add it as a private layer
+
+```bash
+git clone git@github.com:jfim/org-jira.git
+ln -s "`pwd`/org-jira" ~/.emacs.d/private/org-jira
+```
+
+2. Add the =org-jira= layer to your .spacemacs file
+3. Add the Jira url to your .spacemacs file. For example, if your Jira is installed at https://example:443/secure/Dashboard.jspa
+
+```lisp
+(setq jiralib-url "https://example:443")
+```
+
+## Usage
+
+When in org-mode:
+
+* <kbd>SPC m j p g</kbd> 'org-jira-get-projects
+* <kbd>SPC m j i b</kbd> 'org-jira-browse-issue
+* <kbd>SPC m j i g</kbd> 'org-jira-get-issues
+* <kbd>SPC m j i h</kbd> 'org-jira-get-issues-headonly
+* <kbd>SPC m j i f</kbd> 'org-jira-get-issues-from-filter-headonly
+* <kbd>SPC m j i F</kbd> 'org-jira-get-issues-from-filter
+* <kbd>SPC m j i u</kbd> 'org-jira-update-issue
+* <kbd>SPC m j i w</kbd> 'org-jira-progress-issue
+* <kbd>SPC m j i r</kbd> 'org-jira-refresh-issue
+* <kbd>SPC m j i c</kbd> 'org-jira-create-issue
+* <kbd>SPC m j i k</kbd> 'org-jira-copy-current-issue-key
+* <kbd>SPC m j s c</kbd> 'org-jira-create-subtask
+* <kbd>SPC m j s g</kbd> 'org-jira-get-subtasks
+* <kbd>SPC m j c u</kbd> 'org-jira-update-comment
+* <kbd>SPC m j t j</kbd> 'org-jira-todo-to-jira

--- a/contrib/org-jira/packages.el
+++ b/contrib/org-jira/packages.el
@@ -1,0 +1,44 @@
+;;; packages.el --- org-jira Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Jean-Francois Im <jeanfrancois.im@gmail.com>
+;; URL: https://github.com/jfim/org-jira
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar org-jira-packages '(org org-jira))
+
+(defvar org-jira-excluded-packages '() "List of packages to exclude.")
+
+(defun org-jira/init-org-jira ()
+  (use-package org-jira
+    :config
+    (progn
+      ;;(spacemacs/declare-prefix-for-mode 'org-mode "mj" "jira")
+      ;;(spacemacs/declare-prefix-for-mode 'org-mode "mjp" "projects")
+      ;;(spacemacs/declare-prefix-for-mode 'org-mode "mji" "issues")
+      ;;(spacemacs/declare-prefix-for-mode 'org-mode "mjs" "subtasks")
+      ;;(spacemacs/declare-prefix-for-mode 'org-mode "mjc" "comments")
+      ;;(spacemacs/declare-prefix-for-mode 'org-mode "mjt" "todos")
+      (evil-leader/set-key-for-mode 'org-mode
+        "mjpg" 'org-jira-get-projects
+        "mjib" 'org-jira-browse-issue
+        "mjig" 'org-jira-get-issues
+        "mjih" 'org-jira-get-issues-headonly
+        "mjif" 'org-jira-get-issues-from-filter-headonly
+        "mjiF" 'org-jira-get-issues-from-filter
+        "mjiu" 'org-jira-update-issue
+        "mjiw" 'org-jira-progress-issue
+        "mjir" 'org-jira-refresh-issue
+        "mjic" 'org-jira-create-issue
+        "mjik" 'org-jira-copy-current-issue-key
+        "mjsc" 'org-jira-create-subtask
+        "mjsg" 'org-jira-get-subtasks
+        "mjcu" 'org-jira-update-comment
+        "mjtj" 'org-jira-todo-to-jira)
+      )
+    ))


### PR DESCRIPTION
This adds a layer around org-jira, which allows using Jira in org-mode.