### PR TITLE
Add clean-aindent-mode package

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -22,6 +22,7 @@
     bind-key
     bookmark
     buffer-move
+    clean-aindent-mode
     diminish
     doc-view
     ediff
@@ -414,6 +415,11 @@
       "bmj" 'buf-move-down
       "bmk" 'buf-move-up
       "bml" 'buf-move-right)))
+
+(defun spacemacs/init-clean-aindent-mode ()
+  (use-package clean-aindent-mode
+    :init
+    (add-hook 'prog-mode-hook 'clean-aindent-mode)))
 
 (defun spacemacs/init-diminish ()
   (require 'diminish)


### PR DESCRIPTION
When we press RET to move to next line without inserting anything, the
trailing whitespace (used for indentation) is left there
forever. clean-aindent-mode is used for cleaning up such whitespace
automatically. See Emacswiki page for demo:
http://www.emacswiki.org/emacs/CleanAutoIndent.