### PR TITLE
Remove unnecessary auto-mode-alist additions

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -33,8 +33,6 @@
     :defer t
     :config
     (progn
-      (add-to-list 'auto-mode-alist '("\\.cxx$" . c++-mode))
-      (add-to-list 'auto-mode-alist '("\\.hpp$" . c++-mode))
       (add-to-list 'auto-mode-alist '("\\.h$" . c++-mode))
       (require 'compile)
       (c-toggle-auto-newline 1)


### PR DESCRIPTION
Hi,

I'm just looking at the auto-mode-list stuff for c++,  in particular the mapping for .h files to c++-mode. I will send another patch addressing that, but as I was passing I discovered that the two entries for .cxx and .hpp files are not needed

This is my first patch, is it OK - commit message etc?

Thanks

CE