### PR TITLE
Enable c++-mode when opening a .h file the first time

### DIFF
--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -31,11 +31,12 @@
 (defun c-c++/init-cc-mode ()
   (use-package cc-mode
     :defer t
+    :init
+    (add-to-list 'auto-mode-alist '("\\.h$" . c++-mode))
     :config
     (progn
       (add-to-list 'auto-mode-alist '("\\.cxx$" . c++-mode))
       (add-to-list 'auto-mode-alist '("\\.hpp$" . c++-mode))
-      (add-to-list 'auto-mode-alist '("\\.h$" . c++-mode))
       (require 'compile)
       (c-toggle-auto-newline 1)
       (evil-leader/set-key-for-mode 'c-mode


### PR DESCRIPTION
With current configuration, .h file is only associated with c++-mode
only when cc-mode is loaded. So, when a .h file is opened the first
time, it is opened and is applied with c-mode. Only the 2nd time then
c++-mode is properly used.