### PR TITLE
Add option to open .h files with c++-mode

### DIFF
--- a/contrib/lang/c-c++/README.md
+++ b/contrib/lang/c-c++/README.md
@@ -8,6 +8,9 @@
 
 - [C/C++ contribution layer for Spacemacs](#cc-contribution-layer-for-spacemacs)
     - [Description](#description)
+    - [Features](#features)
+        - [Clang Fanciness](#clang-fanciness)
+    - [Key Bindings](#key-bindings)
     - [Install](#install)
 
 <!-- markdown-toc end -->
@@ -48,10 +51,14 @@ doesn't complain about missing header files.
 
 ## Install
 
-To use this contribution add it to your `~/.spacemacs`
+To use this contribution add it to your `~/.spacemacs`.
+This layer has a single configuration variable: c-c++-use-c++-mode-for-dot-h,
+when this value is non-nil then *.h files will open with c++-mode, otherwise
+they will open in C mode. The default is nil.
 
 ```elisp
-(setq-default dotspacemacs-configuration-layers '(c-c++))
+(setq-default dotspacemacs-configuration-layers
+    '((c-c++ variables: c-c++-use-c++-mode-for-dot-h t)))
 ```
 
 ** Note: ** [semantic-refactor][] is only available for Emacs 24.4+

--- a/contrib/lang/c-c++/config.el
+++ b/contrib/lang/c-c++/config.el
@@ -14,3 +14,6 @@
 
 (spacemacs|defvar-company-backends c-mode-common)
 (spacemacs|defvar-company-backends cmake-mode)
+
+(defvar c-c++-use-c++-mode-for-dot-h nil
+  "If non nil then use c++-mode when opening .h files.")

--- a/contrib/lang/c-c++/packages.el
+++ b/contrib/lang/c-c++/packages.el
@@ -32,7 +32,8 @@
   (use-package cc-mode
     :defer t
     :init
-    (add-to-list 'auto-mode-alist '("\\.h$" . c++-mode))
+    (when c-c++-use-c++-mode-for-dot-h
+      (add-to-list 'auto-mode-alist '("\\.h$" . c++-mode)))
     :config
     (progn
       (require 'compile)


### PR DESCRIPTION
Remove default auto-mode-alist mapping from *.h to c++-mode.
Introduce a variable and use that in the init: section of cc-mode to
conditionally update the auto-mode-alist.
Updated the documentation.