### PR TITLE
Improve cider-test integration

### DIFF
--- a/contrib/lang/clojure/README.md
+++ b/contrib/lang/clojure/README.md
@@ -133,7 +133,9 @@ More info regarding installation of nREPL middleware can be found here:
 
     Key Binding       |                 Description
 ----------------------|------------------------------------------------------------
-<kbd>SPC m t t</kbd>  | run tests
+<kbd>SPC m t t</kbd>  | run all tests in namespace
+<kbd>SPC m t T</kbd>  | run test at point
+<kbd>SPC m t r</kbd>  | re-run test failures for namespace
 
 ### Refactoring
 

--- a/contrib/lang/clojure/packages.el
+++ b/contrib/lang/clojure/packages.el
@@ -114,6 +114,21 @@ the focus."
         (cider-switch-to-repl-buffer)
         (evil-insert-state))
 
+      (defun spacemacs/cider-test-run-focused-test ()
+        (interactive)
+        (cider-load-buffer)
+        (spacemacs//cider-eval-in-repl-no-focus (cider-test-run-test)))
+
+      (defun spacemacs/cider-test-run-all-tests ()
+        (interactive)
+        (cider-load-buffer)
+        (spacemacs//cider-eval-in-repl-no-focus (cider-test-run-tests nil)))
+
+      (defun spacemacs/cider-test-rerun-tests ()
+        (interactive)
+        (cider-load-buffer)
+        (spacemacs//cider-eval-in-repl-no-focus (cider-test-rerun-tests)))
+
       (evilify cider-stacktrace-mode cider-stacktrace-mode-map)
 
       ;; open cider-doc directly and close it with q
@@ -150,7 +165,9 @@ the focus."
         "msR" 'spacemacs/cider-send-region-to-repl-focus
         "mss" 'cider-switch-to-repl-buffer
 
-        "mtt" 'cider-test-run-tests)
+        "mtt" 'spacemacs/cider-test-run-all-tests
+        "mtT" 'spacemacs/cider-test-run-focused-test
+        "mtr" 'spacemacs/cider-test-rerun-tests)
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)))))
 


### PR DESCRIPTION
* `mtt` now reloads test ns before running all tests
* added `mtT` to reload test ns and run focused test
* added `mtr` to reload test ns and re-run failed tests for namespace

The test namespace reloading is a workflow optimization. The alternative
is a minimum of two commands (`SPC m e b` or `SPC m e f` and `SPC m t
t`) in order to re-run a single test. When driving development from
tests, this is onerous at best (and I couldn't think of a good reason
_not_ to reload the test ns).