### PR TITLE
A few improvements to AucTeX

### DIFF
--- a/contrib/auctex/README.md
+++ b/contrib/auctex/README.md
@@ -11,6 +11,7 @@
         - [Layer](#layer)
         - [Auto-completion](#auto-completion)
         - [Previewing](#previewing)
+    - [Configuration](#configuration)
     - [Keybindings](#keybindings)
         - [RefTeX](#reftex)
     - [Maintainer](#maintainer)
@@ -54,17 +55,37 @@ under `dotspacemacs/config`:
 Then when you open up a compiled PDF, the preview will update automatically
 when you recompile.
 
+## Configuration
+
+The AucTeX layer can be customized by setting some variables in your `.spacemacs` as follows:
+```elisp
+dotspacemacs-configuration-layers '(
+    ;; ...
+    (auctex :variables
+            auctex-build-command "LatexMk"
+            auctex-electric-escape t))
+```
+        
+The variables and associated default values are:
+- `auctex-build-command` -- `"LaTeX"`:  The default command to build when using <kbd>SPC m b</kbd>.  If `"LatexMk"` is specified, the appropriate `LatexMk` configuration will be applied.
+- `auctex-auto-fill` -- `t`:  Toggles the use of a smart auto-fill.
+- `auctex-nofill-env` -- `'(<see source>)`:  List of environment in which auto-fill-mode is disabled (default includes math environments, tabular and tikzpicture).
+- `auctex-electric-sub-and-supercript` -- `t`:  Toggle the AucTeX electric <kbd>_</kbd> and <kbd>^</kbd> in math mode
+- `auctex-electric-escape` -- `nil`:  Toggle the AucTeX electric <kbd>\\</kbd>
+- `auctex-reftex-plugin` -- `'(nil nil t t t)`:  Sets the `reftex-plug-into-AUCTeX` variable; by default it is set to provide existing labels but not create new ones.
+
 ## Keybindings
 
 Key Binding         |                 Description
 --------------------|------------------------------------------------------------------
-<kbd>SPC m b  </kbd>| build and view
+<kbd>SPC m b  </kbd>| build
+<kbd>SPC m v  </kbd>| view
 <kbd>SPC m e  </kbd>| insert LaTeX environment
 <kbd>SPC m c  </kbd>| close LaTeX environment
 <kbd>SPC m i  </kbd>| insert `\item`
 <kbd>SPC m f  </kbd>| insert LaTeX font - full bindings here: [AUCTeX documentation][AUCTeX Font]
 <kbd>SPC m C  </kbd>| TeX command on master file
-<kbd>SPC m p r <kbd>| preview region
+<kbd>SPC m p r<kbd> | preview region
 <kbd>SPC m p b</kbd>| preview buffer
 <kbd>SPC m p d</kbd>| preview document
 <kbd>SPC m p e</kbd>| preview environment
@@ -73,6 +94,7 @@ Key Binding         |                 Description
 <kbd>SPC m p f</kbd>| cache preamble for preview
 <kbd>SPC m p c</kbd>| clear previews
 <kbd>SPC m *</kbd>  | TeX documentation, can be very slow
+
 
 ### RefTeX
 

--- a/contrib/auctex/config.el
+++ b/contrib/auctex/config.el
@@ -12,4 +12,42 @@
 
 ;; variables
 
+;; Company-mode LaTeX-backend
 (spacemacs|defvar-company-backends LaTeX-mode)
+
+(defvar auctex-build-command
+  "LaTeX"
+  "The defualt command to use with `SPC m b'")
+
+(defvar auctex-auto-fill
+  t
+  "Whether to use auto-fill-mode or not in tex files.")
+
+(defvar auctex-nofill-env
+  '("equation" "equation*"
+    "align" "align*"
+    "tabular"
+    "tikzpicture")
+  "List of environment names inw hich `auto-fill-mode' will be inhibited.")
+
+
+(defvar auctex-electric-sub-and-superscript
+  t
+  "Whether electric sub- and superscripts should be used.")
+
+(defvar auctex-electric-escape
+  nil
+  "Whether `\' is electric.")
+
+(defvar auctex-reftex-plugin
+  '(nil nil t t t)
+  "The value for `reftex-plug-into-AUCTeX'.")
+
+;; Command prefixes
+(setq auctex/key-binding-prefixes '())
+(push (cons "mp" "LaTeX Preview") auctex/key-binding-prefixes)
+(push (cons "mr" "RefTeX") auctex/key-binding-prefixes)
+
+(mapc (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))
+      auctex/key-binding-prefixes)
+

--- a/contrib/auctex/extensions.el
+++ b/contrib/auctex/extensions.el
@@ -16,12 +16,9 @@
   "Initialize reftex"
 
   (add-hook 'LaTeX-mode-hook 'turn-on-reftex)
-  (setq reftex-plug-into-AUCTeX t)
+  (setq reftex-plug-into-AUCTeX auctex-reftex-plugin)
 
-  ;; not supported for now
-  ;; (setq spacemacs/key-binding-prefixes '(("mr" . "RefTeX")))
-
-  (evil-leader/set-key-for-mode 'LaTeX-mode
+  (evil-leader/set-key-for-mode 'latex-mode
     "mrc"    'reftex-citation
     "mrg"    'reftex-grep-document
     "mri"    'reftex-index-selection-or-word

--- a/contrib/auctex/funcs.el
+++ b/contrib/auctex/funcs.el
@@ -1,0 +1,49 @@
+;;; funcs.el --- Auctex Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+;; functions
+(defun auctex/build ()
+  (interactive)
+  (progn
+    (let ((TeX-save-query nil))
+      (TeX-save-document (TeX-master-file)))
+    (TeX-command auctex-build-command 'TeX-master-file -1)))
+    ;; (setq build-proc (TeX-command auctex-build-command 'TeX-master-file -1))
+    ;; ;; Sometimes, TeX-command returns nil causing an error in set-process-sentinel
+    ;; (when build-proc
+    ;;   (set-process-sentinel build-proc 'auctex//build-sentinel))))
+
+(defun auctex//build-sentinel (process event)
+  (if (string= event "finished\n")
+      (TeX-view)
+    (message "Errors! Check with C-`")))
+
+(defun auctex//autofill ()
+  "Check whether the pointer is ucrrently inside on the
+environments described in `auctex-nofill-env' and if so, inhibits
+the automatic filling of the current paragraph."
+  (let ((do-auto-fill t)
+        (current-environment "")
+        (level 0))
+    (while (and do-auto-fill (not (string= current-environment "document")))
+      (setq level (1+ level)
+            current-environment (LaTeX-current-environment level)
+            do-auto-fill (not (member current-environment auctex-nofill-env))))
+    (when do-auto-fill
+      (do-auto-fill))))
+
+(defun auctex/auto-fill-mode ()
+  "Toggle uato-fill-mode using the custom auto-fill function."
+  (interactive)
+  (auto-fill-mode)
+  (setq auto-fill-function 'auctex//autofill))

--- a/contrib/auctex/packages.el
+++ b/contrib/auctex/packages.el
@@ -1,6 +1,7 @@
 (setq auctex-packages
   '(
     auctex
+    auctex-latexmk
     company
     company-auctex
     evil-matchit
@@ -12,36 +13,36 @@
     :defer t
     :config
     (progn
-      (defun auctex/build-view ()
-        (interactive)
-        (progn
-          (let ((TeX-save-query nil))
-            (TeX-save-document (TeX-master-file)))
-          (setq build-proc (TeX-command "LaTeX" 'TeX-master-file -1))
-          (set-process-sentinel  build-proc  'auctex/build-sentinel))
-        (TeX-view))
+      (add-hook 'TeX-mode-hook 'flyspell-mode)
+      (add-hook 'TeX-mode-hook 'company-mode)
+      (add-hook 'TeX-mode-hook 'spacemacs/load-yasnippet)
+      (when auctex-auto-fill (add-hook 'TeX-mode-hook 'auctex/auto-fill-mode))
+      (add-hook 'TeX-mode-hook 'smartparens-mode)
+      (add-hook 'LaTeX-mode-hook 'latex-math-mode)
 
-      (defun auctex/build-sentinel (process event)
-        (if (string= event "finished\n")
-            (TeX-view)
-          (message "Errors! Check with C-`")))
+      ;; (setq spacemacs/key-binding-prefixes '(("mp" . "LaTeX Preview")))
 
-      (add-hook 'LaTeX-mode-hook '(lambda () (local-set-key (kbd "H-r") 'auctex/build-view)))
-      (add-hook 'LaTeX-mode-hook 'flyspell-mode)
-      (add-hook 'LaTeX-mode-hook 'company-mode)
-      (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
-      (add-hook 'LaTeX-mode-hook 'spacemacs/load-yasnippet)
+      ;; Key bindings for plain TeX
+      (evil-leader/set-key-for-mode 'tex-mode
+        "mC" 'TeX-command-master
+        "mb" 'auctex/build
+        "mv" 'TeX-view
+        "m\\" 'TeX-insert-macro
+        "mf" 'TeX-font) ;; Find a way to rebind tex-fonts
 
-      (setq spacemacs/key-binding-prefixes '(("mp" . "LaTeX Preview")))
+      ;; Key bindings for LaTeX
       (evil-leader/set-key-for-mode 'latex-mode
-        "mb" 'auctex/build-view
+        "mC" 'TeX-command-master
+        "mb" 'auctex/build
+        "mv" 'TeX-view
+        "m\\" 'TeX-insert-macro
+        "mf" 'TeX-font ;; Find a way to rebind tex-fonts
         "me" 'LaTeX-environment
         "mc" 'LaTeX-close-environment
-        "mi" 'LaTeX-insert-item
-        "mf" 'TeX-font ;; Find a way to rebind tex-fonts
+        "mi" 'LaTeX-insert-item)
 
-        "mC" 'TeX-command-master
-
+      ;; Preview key bindings
+      (evil-leader/set-key-for-mode 'latex-mode
         "mpr" 'preview-region
         "mpb" 'preview-buffer
         "mpd" 'preview-document
@@ -54,10 +55,36 @@
         "mhd" 'TeX-doc ;; TeX-doc is a very slow function
         )
 
+      (setq-default TeX-command-default auctex-build-command)
+
       (setq-default TeX-auto-save t)
       (setq-default TeX-parse-self t)
-      (setq-default TeX-PDF-mode t))))
+      (setq-default TeX-syntactic-comment t)
+      (setq-default TeX-PDF-mode t)
 
+      (when auctex-electric-sub-and-superscript
+        (setq-default TeX-electric-sub-and-superscript t))
+      (when auctex-electric-escape
+        (setq-default TeX-electric-escape t))
+      (setq-default TeX-electric-macro)
+
+      ;; Synctex support
+      (setq-default TeX-source-correlate-mode t)
+      (setq-default TeX-source-correlate-start-server nil)
+
+      ;; Setup reftex style (RefTeX is supported through extension)
+      (setq-default reftex-use-fonts t)
+
+      ;; Don't insert line-break at inline math
+      (setq-default LaTeX-fill-break-at-separators '()))))
+
+(when (string= auctex-build-command "LatexMk")
+  (defun auctex/init-auctex-latexmk ()
+    (use-package auctex-latexmk
+      :defer t
+      :init
+      (progn
+        (auctex-latexmk-setup)))))
 
 (defun auctex/post-init-evil-matchit ()
   (add-hook 'LaTeX-mode-hook 'evil-matchit-mode))


### PR DESCRIPTION
This commit contains a few, individually small, changes.  If you wish me to create several pull request for each change, I can do so but I thought in this case it would be alright in this case as they individually are fairly small changes.


The changes are:
- Move function definitions from inside package.el to funcs.el;
- Add a few variables to allow some configuration with .spacemacs;
- Enable RefTeX support;
- Move key-binding-prefixes to config.el (similar to git layer);
- Use auto-fill-mode, with a environment-aware auto-fill function;
- Provide a few additional sane defaults (some of the more "annoying"
  ones are configurable from .spacemacs)
- Remove `build-view` in favour of just `build` as it seemed to be
  broken and introduce `SPC m v` to view;
- Add support to LatexMk.

Signed-off-by: JP-Ellis <coujellis@gmail.com>