### PR TITLE
Disable smartparens in SLIME REPL

### DIFF
--- a/contrib/slime/packages.el
+++ b/contrib/slime/packages.el
@@ -29,7 +29,12 @@
       (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
 
       ;; enabel smartparen in code buffer and SLIME REPL
-      (add-hook 'slime-repl-mode-hook #'smartparens-strict-mode)
+      ;; (add-hook 'slime-repl-mode-hook #'smartparens-strict-mode)
+      (defun slime/disable-smartparens ()
+        (smartparens-strict-mode -1)
+        (turn-off-smartparens-mode))
+
+      (add-hook 'slime-repl-mode-hook #'slime/disable-smartparens)
 
       (add-to-hooks 'slime-mode '(lisp-mode-hook scheme-mode-hook)))
     :config


### PR DESCRIPTION
Some people prefer typing code in the SLIME REPL, and autoclosing parenthesis makes `RET` evaluate code instead of inserting newline. Disable this in SLIME REPL to remove the annoyance, though it's better to create a temp buffer, write code there then evaluate code written there.