### PR TITLE
Fixed ghci-ng keybindings being overriden

### DIFF
--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -58,19 +58,6 @@
         ;; use only internal indentation system from haskell
         (electric-indent-local-mode -1))
 
-      ;;GHCi-ng
-      (when haskell-enable-ghci-ng-support
-        ;; haskell-process-type is set to auto, so setup ghci-ng for either case
-        ;; if haskell-process-type == cabal-repl
-        (setq haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans" "--with-ghc=ghci-ng"))
-        ;; if haskell-process-type == GHCi
-        (setq haskell-process-path-ghci "ghci-ng")
-
-        (evil-leader/set-key-for-mode 'haskell-mode
-          "mu"   'haskell-mode-find-uses
-          "mht"   'haskell-mode-show-type-at
-          "mgg"  'haskell-mode-goto-loc))
-
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)
       (add-hook 'haskell-cabal-mode-hook 'haskell-cabal-hook)
@@ -160,6 +147,19 @@
       (eval-after-load 'haskell-cabal-mode-map
         '(define-key haskell-cabal-mode-map
            [?\C-c ?\C-z] 'haskell-interactive-switch))))
+
+      ;;GHCi-ng
+      (when haskell-enable-ghci-ng-support
+        ;; haskell-process-type is set to auto, so setup ghci-ng for either case
+        ;; if haskell-process-type == cabal-repl
+        (setq haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans" "--with-ghc=ghci-ng"))
+        ;; if haskell-process-type == GHCi
+        (setq haskell-process-path-ghci "ghci-ng")
+
+        (evil-leader/set-key-for-mode 'haskell-mode
+          "mu"   'haskell-mode-find-uses
+          "mht"   'haskell-mode-show-type-at
+          "mgg"  'haskell-mode-goto-loc))
 
   (eval-after-load 'haskell-indentation
     (progn


### PR DESCRIPTION
`ghci-ng` specific keybindings were being overriden by the default bindings when the layer variable `haskell-enable-ghci-ng-support` was enabled.