### PR TITLE
Dired with coreutils gls

### DIFF
--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -183,8 +183,17 @@
       (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides))))
 
 (defun haskell/init-haskell-snippets ()
-  (use-package haskell-snippets
-    :defer t))
+  ;; manually load the package since the current implementation is not lazy
+  ;; loading friendly (funny coming from the haskell mode :-))
+  (setq haskell-snippets-dir (spacemacs//get-package-directory
+                              'haskell-snippets))
+
+  (defun haskell-snippets-initialize ()
+    (let ((snip-dir (expand-file-name "snippets" haskell-snippets-dir)))
+      (add-to-list 'yas-snippet-dirs snip-dir t)
+      (yas-load-directory snip-dir)))
+
+  (eval-after-load 'yasnippet '(haskell-snippets-initialize)))
 
 (defun haskell/init-hindent ()
   (use-package hindent

--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -3,6 +3,13 @@
     pbcopy
     ))
 
+(if (executable-find "gls")
+    ; maybe absolute or relative name of the `ls' program used by `insert-directory'.
+    ; brew info coreutils
+    (setq insert-directory-program "gls"
+          dired-listing-switches "-aBhl --group-directories-first")
+  (setq dired-use-ls-dired nil))
+
 (defun osx/init-pbcopy ()
   (use-package pbcopy
     :if (not (display-graphic-p))


### PR DESCRIPTION
Make `dired` use `gls` on OS X, if found (maybe installed with `brew`). 

If not available, make sure `ls` is called with legal options only, so to avoid this error:

```emacs-lisp
ls does not support --dired; see `dired-use-ls-dired' for more details.
```