### PR TITLE
haskell: fix haskell-indentation eval-after-load

### DIFF
--- a/contrib/lang/haskell/packages.el
+++ b/contrib/lang/haskell/packages.el
@@ -162,25 +162,25 @@
            [?\C-c ?\C-z] 'haskell-interactive-switch))))
 
   (eval-after-load 'haskell-indentation
-    (progn
-      ;; Show indentation guides in insert or emacs state only.
-      (defun spacemacs//haskell-indentation-show-guides ()
-        "Show visual indentation guides."
-        (when (derived-mode-p 'haskell-mode)
-          (haskell-indentation-enable-show-indentations)))
+    '(progn
+       ;; Show indentation guides in insert or emacs state only.
+       (defun spacemacs//haskell-indentation-show-guides ()
+         "Show visual indentation guides."
+         (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
+           (haskell-indentation-enable-show-indentations)))
 
-      (defun spacemacs//haskell-indentation-hide-guides ()
-        "Hide visual indentation guides."
-        (when (derived-mode-p 'haskell-mode)
-          (haskell-indentation-disable-show-indentations)))
+       (defun spacemacs//haskell-indentation-hide-guides ()
+         "Hide visual indentation guides."
+         (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
+           (haskell-indentation-disable-show-indentations)))
 
-      ;; first entry in normal state
-      (add-hook 'evil-normal-state-entry-hook 'spacemacs//haskell-indentation-hide-guides)
+       ;; first entry in normal state
+       (add-hook 'evil-normal-state-entry-hook 'spacemacs//haskell-indentation-hide-guides)
 
-      (add-hook 'evil-insert-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-      (add-hook 'evil-emacs-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-      (add-hook 'evil-insert-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)
-      (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides))))
+       (add-hook 'evil-insert-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
+       (add-hook 'evil-emacs-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
+       (add-hook 'evil-insert-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)
+       (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides))))
 
 (defun haskell/init-haskell-snippets ()
   ;; manually load the package since the current implementation is not lazy


### PR DESCRIPTION
The `progn` in the eval-after-load was not quoted, so it was being evaluated unconditionally. This led to the haskell-indentation guides being unconditionally enabled.

Additionally, only enable the indentation guides when haskell-indentation-mode is on.

Resolves #1136.