### PR TITLE
Replace C-o with M-o in Dired buffer

### DIFF
--- a/contrib/better-defaults/README.md
+++ b/contrib/better-defaults/README.md
@@ -47,6 +47,7 @@ pressed again, go to the beginning of the line.
 Key Binding   | Description
 --------------|------------------------------------------------------------
 `C-a`         | smart beginning of line
-`C-o`         | get into Vim normal mode to execute one command, then go back Emacs edit              | ing mode
+`C-o`         | get into Vim normal mode to execute one command, then go back Emacs editing mode
+`M-o` (Dired) | Open file in other window without moving point. It is the replacement for `C-o` in Dired.
 
 [Prelude]: https://github.com/bbatsov/prelude

--- a/contrib/better-defaults/keybindings.el
+++ b/contrib/better-defaults/keybindings.el
@@ -14,3 +14,5 @@
 
 ;; emacs state bindings
 (define-key evil-emacs-state-map (kbd "C-o") 'evil-execute-in-normal-state)
+(add-hook 'dired-mode-hook (lambda ()
+                             (local-set-key (kbd "M-o") 'dired-display-file)))


### PR DESCRIPTION
Since `C-o` is replaced with evil-execute-in-normal-state.