### PR TITLE
Make trailing whitespace less distracting

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -121,7 +121,18 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; because it avoids autoloads of elisp modes)
 (setq initial-major-mode 'text-mode)
 ;; whitespace-mode
-(add-hook 'prog-mode-hook (lambda () (setq show-trailing-whitespace 1)))
+(defcustom spacemacs-show-trailing-whitespace t
+  "If t, show trailing whitespace."
+  :type 'boolean
+  :group 'spacemacs)
+
+(add-hook 'prog-mode-hook (lambda ()
+                            (when spacemacs-show-trailing-whitespace
+                              (set-face-attribute 'trailing-whitespace nil
+                                                  :background (face-attribute 'font-lock-comment-face
+                                                                              :foreground))
+                              (setq show-trailing-whitespace 1))))
+
 
 ;; use only spaces and no tabs
 (setq-default indent-tabs-mode nil


### PR DESCRIPTION
By using font-lock-comment-face, it's less distracting than the default
bright red, since comment face is designed to be subtle.