### PR TITLE
Add toml-mode to extra-langs layer

### DIFF
--- a/contrib/lang/extra-langs/packages.el
+++ b/contrib/lang/extra-langs/packages.el
@@ -7,6 +7,7 @@
     nix-mode
     qml-mode
     rust-mode
+    toml-mode
     scad-mode
     wolfram-mode
     yaml-mode
@@ -42,6 +43,9 @@
     :config
     (when (fboundp 'sp-local-pair) ; Don't pair lifetime specifiers
       (sp-local-pair 'rust-mode "'" nil :actions nil))))
+
+(defun extra-langs/init-toml-mode ()
+  (use-package toml-mode :defer t))
 
 ;; no associated extension because conflicts with more common Objective-C, manually invoke for .m files.
 (defun extra-langs/init-wolfram-mode ()


### PR DESCRIPTION
Toml is used for Rust's cargo configuration files.