### PR TITLE
Fix package loading in lang/ess

### DIFF
--- a/contrib/lang/ess/packages.el
+++ b/contrib/lang/ess/packages.el
@@ -28,9 +28,9 @@
   (defun load-ess-on-demand ()
     (interactive)
     (-all? '---truthy? (list
-                        (use-package ess-site)
-                        (use-package ess-R-object-popup)
-                        (use-package ess-R-data-view))))
+                        (require 'ess-site)
+                        (require 'ess-R-object-popup)
+                        (require 'ess-R-data-view))))
 
   (evil-leader/set-key "ess" 'load-ess-on-demand)
 


### PR DESCRIPTION
Originally `load-ess-on-demand` used `use-package` for the purposes of
actually loading `ess-site` and related elisp for dealing with R. But
since `use-package` doesn't return true or false when a package is
actually successfully loaded anymore, and the semantics of how it will
work aren't precisely clear, it makes sense to use `require` here
instead.

    (defun load-ess-on-demand ()
      (interactive)
      (-all? '---truthy? (list
                          (require 'ess-site)
                          (require 'ess-R-object-popup)
                          (require 'ess-R-data-view))))

All the normal hooks setup by `use-package` will work as normal. I
actually don't see a reason we should use `use-package` instead of
`require` in this specific instance. Since `use-package` often defers
loading packages, it's arguably clearer to use `require` in this
particular instance.