### PR TITLE
New org-mode leader keys for narrowing

### DIFF
--- a/contrib/org/README.md
+++ b/contrib/org/README.md
@@ -64,6 +64,8 @@ You can tweak the bullets displayed in the org buffer in the function
 <kbd>SPC m j</kbd>    | helm-org-in-buffer-headings
 <kbd>SPC m l</kbd>    | evil-org-open-links
 <kbd>SPC m m</kbd>    | org-ctrl-c-ctrl-c
+<kbd>SPC m n</kbd>    | org-narrow-to-subtree
+<kbd>SPC m N</kbd>    | widen
 <kbd>SPC m o</kbd>    | org-clock-out
 <kbd>SPC m q</kbd>    | org-clock-cancel
 <kbd>SPC m r</kbd>    | org-refile

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -62,6 +62,8 @@
         "mj" 'helm-org-in-buffer-headings
         "mo" 'org-clock-out
         "mm" 'org-ctrl-c-ctrl-c
+        "mn" 'org-narrow-to-subtree
+        "mN" 'widen
         "mq" 'org-clock-cancel
         "mr" 'org-refile
         "ms" 'org-schedule)


### PR DESCRIPTION
Really though, I'm finding that I don't use any of the built-in major-mode leader keys in org, but lots of other org functions. Perhaps some of the functionality (clocking, scheduling, todo management, etc) should be put under subleaders?