### PR TITLE
[Fix] Disable company-tooltip-flip

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -72,7 +72,6 @@
             company-require-match nil
             company-dabbrev-ignore-case nil
             company-dabbrev-downcase nil
-            company-tooltip-flip-when-above t
             company-frontends '(company-pseudo-tooltip-frontend)
             company-clang-prefix-guesser 'company-mode/more-than-prefix-guesser))
     :config


### PR DESCRIPTION
Currently by default company knows when to flip the popup. However, when
the above option is set to t, it causes a strange behaviour: when the
tooltip is flipped, press down (i.e. M-n or arrow key) go up and press
up (i.e. M-p or arrow key) go down.