### PR TITLE
Relocatable spacemacs

### DIFF
--- a/init.el
+++ b/init.el
@@ -11,6 +11,7 @@
 ;;; License: GPLv3
 (defconst spacemacs-version          "0.101.3" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
+(defconst spacemacs-base-path  (file-name-directory (or (buffer-file-name) load-file-name)))
 
 (defun spacemacs/emacs-version-ok ()
   (version<= spacemacs-emacs-min-version emacs-version))

--- a/init.el
+++ b/init.el
@@ -17,6 +17,8 @@
   (version<= spacemacs-emacs-min-version emacs-version))
 
 (when (spacemacs/emacs-version-ok)
+  ;; ensure that packages using `user-emacs-directory' find the right files
+  (setq user-emacs-directory spacemacs-base-path)
   (load-file (concat user-emacs-directory "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (require 'core-configuration-layer)


### PR DESCRIPTION
This contains the minimum viable code to make Spacemacs relocatable (so it no longer absolutely needs to be placed into `~/.emacs.d`).

I've done this so that others like me who are curious but already have a fairly advanced Emacs setup can run Spacemacs in isolation from their main Emacs build.

For reference I run this on the Mac like so:

    $ cd ~/Projects/spacemacs
    $ open -n -a Emacs --args -q -l `pwd`/init.el

I haven't updated the documentation yet because I'm not sure this PR will be accepted - happy to do so if this seems like a worthwhile avenue to take the project.

Using the above commands it seems to load correctly and work as expected.