### PR TITLE
Make helm-find-files backspace behave like Ido

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1300,6 +1300,12 @@ Example: (evil-map visual \"<\" \"<gv\")"
             helm-recentf-fuzzy-match t
             helm-semantic-fuzzy-match t)
 
+      (defun spacemacs/helm-find-files-navigate-back (orig-fun &rest args)
+        (if (= (length helm-pattern) (length (helm-find-files-initial-input)))
+            (helm-find-files-up-one-level 1)
+          (apply orig-fun args)))
+      (advice-add 'helm-ff-delete-char-backward :around #'spacemacs/helm-find-files-navigate-back)
+
       (defun spacemacs/helm-do-ack ()
         "Perform a search with ack using `helm-ag.'"
         (interactive)


### PR DESCRIPTION
To make it easier for people to switch to helm-find-files from Ido.

Code taken from [here](http://emacs.stackexchange.com/questions/3798/how-do-i-make-pressing-ret-in-helm-find-files-open-the-directory). However, the `RET` command is buggy since it only expands once and the next time you press `RET` on the same directory, it goes into Dired. The proper solution for `RET` (as [written by Helm maintainer](https://github.com/emacs-helm/helm/issues/776)) is this:

```elisp
(defun helm-find-file-or-expand ()
  (interactive)
  (with-helm-window (if (and (file-directory-p (helm-get-selection))
                             (< (length (helm-marked-candidates)) 2))
                        (helm-execute-persistent-action)
                      (helm-exit-minibuffer))))
(define-key helm-find-files-map (kbd "RET") 'helm-find-file-or-expand)
```

However, I don't include this since we already have `TAB` and making `RET` to go into next directory level is confusing if a user really wants to open a Dired buffer on that directory. Of course, it's possible by simply pressing `f2` or switch to action menu but it's not obvious.