### PR TITLE
Disable evil-snipe in magit-status-mode.

### DIFF
--- a/contrib/vim/evil-snipe/packages.el
+++ b/contrib/vim/evil-snipe/packages.el
@@ -5,6 +5,8 @@
     :diminish evil-snipe-mode
     :init
     (progn
+      (if (configuration-layer/package-usedp 'magit)
+          (add-hook 'magit-status-mode-hook (lambda () (evil-snipe-mode -1))))
       (setq evil-snipe-scope 'whole-buffer
             evil-snipe-enable-highlight t
             evil-snipe-enable-incremental-highlight t


### PR DESCRIPTION
Evil-snipe takes over the keybinding for s, making it impossible to
stage part of a hunk.