### PR TITLE
Make window inactive face less distracting

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2237,7 +2237,7 @@ displayed in the mode-line.")
       (defun spacemacs//customize-powerline-faces ()
         "Alter powerline face to make them work with more themes."
         (set-face-attribute 'powerline-inactive2 nil
-                            :inherit 'font-lock-preprocessor-face))
+                            :inherit 'font-lock-comment-face))
       (spacemacs//customize-powerline-faces)
 
 


### PR DESCRIPTION
Currently using font-lock-preprocessor-face can make window number too
bright and distract. Use font-lock-comment-face to make it less
distracting while still visible since it's an inherent part of the
theme.