### PR TITLE
Fix key binding for Elisp format sexp

### DIFF
--- a/contrib/lang/emacs-lisp/packages.el
+++ b/contrib/lang/emacs-lisp/packages.el
@@ -58,6 +58,6 @@
     (evil-leader/set-key-for-mode 'emacs-lisp-mode
       "mfb" 'srefactor-lisp-format-buffer
       "mfd" 'srefactor-lisp-format-defun
-      "mfr" 'srefactor-lisp-format-sexp
+      "mfs" 'srefactor-lisp-format-sexp
       "mfo" 'srefactor-lisp-one-line
       )))


### PR DESCRIPTION
It should be "mfs" to better synergize with srefactor-lisp-format-sexp.