### PR TITLE
Add Ctrl-P like feature

### DIFF
--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -21,6 +21,9 @@
 ;; Escape from isearch-mode("/" and "?" in evil-mode) like vim
 (define-key isearch-mode-map (kbd "<escape>") 'isearch-cancel)
 
+;; add Ctrl-P functionality to normal mode
+(define-key evil-normal-state-map (kbd "C-/") 'helm-projectile)
+
 ;; Make <escape> quit as much as possible
 (define-key minibuffer-local-map (kbd "<escape>") 'keyboard-escape-quit)
 (define-key evil-visual-state-map (kbd "<escape>") 'keyboard-quit)

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1677,14 +1677,19 @@ If ARG is non nil then `ag' and `pt' and ignored."
           (call-interactively (spacemacs//helm-projectile-do-search-find-tool
                                tools))))
 
+      (setq helm-projectile-sources-list '(helm-source-projectile-projects
+                                           helm-source-projectile-files-list
+                                           helm-source-recentf
+                                           helm-source-pp-bookmarks
+                                           helm-source-file-cache))
+
       (evil-leader/set-key
         "/"   'spacemacs/helm-projectile-smart-do-search
         "pb"  'helm-projectile-switch-to-buffer
         "pd"  'helm-projectile-find-dir
         "pe"  'helm-projectile-recentf
         "pf"  'helm-projectile-find-file
-        "ph"  'helm-projectile
-        "pp"  'helm-projectile-switch-project
+        "pp"  'helm-projectile
         "psa" 'helm-projectile-ag
         "psg" 'helm-projectile-grep
         "psk" 'helm-projectile-ack


### PR DESCRIPTION
- Bind it to M-p in normal mode so we have no key binding conflict. M-p
  is easier to press than C-S-p.

- Bind `SPC p p` to helm-projectile, since if we use it outside a
  project, we only get project list effectively become
  helm-projectile-switch-projects. The advantage of using
  helm-projectile to switch projects is that we can switch back and
  forth between multiple projects within the same Helm session.