### PR TITLE
[Fix] Enable evil-snipe conditionally

### DIFF
--- a/contrib/vim/evil-snipe/packages.el
+++ b/contrib/vim/evil-snipe/packages.el
@@ -5,8 +5,6 @@
     :diminish evil-snipe-mode
     :init
     (progn
-      (if (configuration-layer/package-usedp 'magit)
-          (add-hook 'magit-status-mode-hook (lambda () (evil-snipe-mode -1))))
       (setq evil-snipe-scope 'whole-buffer
             evil-snipe-enable-highlight t
             evil-snipe-enable-incremental-highlight t
@@ -16,4 +14,5 @@
       (when evil-snipe-enable-alternate-f-and-t-behaviors
         (setq evil-snipe-repeat-scope 'whole-buffer
               evil-snipe-override-evil t))
-      (global-evil-snipe-mode))))
+      (add-hook 'prog-mode-hook 'evil-snipe-mode)
+      (add-hook 'text-mode-hook 'evil-snipe-mode))))


### PR DESCRIPTION
This fixes a bug that caused magit-status to launch in a blank split. #1530 