### PR TITLE
[Fix #1553] Make sure yasnippet is actually loaded

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -193,7 +193,9 @@
       (setq yas-minor-mode-map (make-sparse-keymap))
 
       (defun spacemacs/load-yasnippet ()
-        (if (not (boundp 'yas-minor-mode))
+        (if (or (not (boundp 'yas-minor-mode))
+                (and (boundp 'yas-minor-mode)
+                     (not yas-minor-mode)))
             (progn
               (let* ((dir (configuration-layer/get-layer-property 'spacemacs :ext-dir))
                      (private-yas-dir (concat configuration-layer-private-directory "snippets"))


### PR DESCRIPTION
By checking if the yas-minor-mode is enabled. If so, load yasnippet. We
must do so because some package might load yasnippet and make
yas-minor-mode available, thus prevent Spacemacs to load yasnippet
properly.