### PR TITLE
remove redundant yasnippt submodule. use yasnippet-install-dir instead.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "spacemacs/extensions/spray"]
 	path = spacemacs/extensions/spray
 	url = https://github.com/syl20bnr/spray
-[submodule "spacemacs/extensions/yasnippet-snippets"]
-	path = spacemacs/extensions/yasnippet-snippets
-	url = https://github.com/AndreaCrotti/yasnippet-snippets.git

--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -195,15 +195,13 @@
       (defun spacemacs/load-yasnippet ()
         (if (not (boundp 'yas-minor-mode))
             (progn
-              (let* ((dir (configuration-layer/get-layer-property 'spacemacs :ext-dir))
-                     (private-yas-dir (concat configuration-layer-private-directory "snippets"))
-                     (yas-dir (concat dir "yasnippet-snippets")))
+              (yas-global-mode 1)
+              (let ((private-yas-dir (concat configuration-layer-private-directory "snippets")))
                 (setq yas-snippet-dirs
                       (append (when (boundp 'yas-snippet-dirs)
                                 yas-snippet-dirs)
-                              (list  private-yas-dir yas-dir)))
-                (setq yas-wrap-around-region t)
-                (yas-global-mode 1)))))
+                              (list private-yas-dir)))
+                (setq yas-wrap-around-region t)))))
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook
                                                 org-mode-hook))


### PR DESCRIPTION
Cleanups yas-snippet-dirs to what they should be. The melpa yasnippet package includes https://github.com/AndreaCrotti/yasnippet-snippets as a submodule and sets it to ` yas-installed-snippets-dir` so we do not need to handle this in spacemacs.

`yas-snippet-dirs` before PR: 
```
("/Users/chris/.emacs.d/private/snippets" "/Users/chris/.emacs.d/spacemacs/extensions/yasnippet-snippets")
```

`yas-snippet-dirs` after PR: 
```
 ("~/.emacs.d/snippets" yas-installed-snippets-dir "/Users/chris/.emacs.d/private/snippets")
```