### PR TITLE
Add auto-yasnippet

### DIFF
--- a/contrib/auto-completion/README.md
+++ b/contrib/auto-completion/README.md
@@ -27,7 +27,7 @@ The following completion engines are supported:
 - [company][]
 - [auto-complete][]
 
-Snippets are supported via [yasnippet][].
+Snippets are supported via [yasnippet][] and [auto-yasnippet][].
 
 This layer also configures `hippie-expand`.
 
@@ -178,7 +178,18 @@ In `packages.el`:
 <kbd>S-TAB</kbd>   | select previous candidate
 <kbd>return</kbd>  | complete word, if word is already completed insert a carriage return
 
+### Yasnippet
+
+    Key Binding    |                 Description
+-------------------|------------------------------------------------------------
+<kbd>M-/<kbd>      | Expand a snippet if text before point is a prefix of a snippet
+<kbd>SPC i s</kbd> | List all current yasnippets for inserting
+<kbd>SPC i y</kbd> | Yank and create a snippet from an active region
+<kbd>SPC i e</kbd> | Expand the snippet just created with <kbd>SPC i y</kbd>
+<kbd>SPC i w</kbd> | Write the snippet inside `private/snippets` directory for future sessions
+
 [company]: http://company-mode.github.io/
 [auto-complete]: http://auto-complete.org/
 [yasnippet]: https://github.com/capitaomorte/yasnippet
+[auto-yasnippet]: https://github.com/abo-abo/auto-yasnippet
 [company-statistics]: https://github.com/company-mode/company-statistics

--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -19,6 +19,7 @@
         helm-c-yasnippet
         hippie-exp
         yasnippet
+        auto-yasnippet
         ))
 
 ;; company-quickhelp from MELPA is not compatible with 24.3 anymore
@@ -224,3 +225,16 @@
     :config
     (progn
       (spacemacs|diminish yas-minor-mode " ⓨ" " y"))))
+
+(defun spacemacs/init-auto-yasnippet ()
+  (use-package auto-yasnippet
+    :defer t
+    :init
+    (setq aya-persist-snippets-dir (concat user-emacs-directory "private/snippets/"))
+    (evil-leader/set-key
+      ;; aya *y*ank
+      "iy" 'aya-create
+      ;; aya *e*xpand
+      "ie" 'aya-expand
+      ;; aya *w*rite
+      "iw" 'aya-persist-snippet)))


### PR DESCRIPTION
Make it easy to create snippets. For example:

- Sample code:

```C++
const Point<3> curl(grad[~2][~1] - grad[~1][~2],
```

- Run `aya-create` on the selected region above.
- See the `~` removed.
- Run `aya-expand` to insert the snippet again, except this time we will be able to move through the positions masked with `~` earlier using `TAB` or `S-TAB`. It is useful when combined with a macro to increase the counter. The nice thing is, the one marked with the same index automatically change accordingly as you type.
- To save the snippet, run `aya-persist-snippet`. A prompt asks for snippet name, and the positions with `~` earlier is replaced with appropriate variables.