### PR TITLE
yas-new-snippet tries to create a Snippet in ~/.emacs.d/snippets

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -198,9 +198,9 @@
               (yas-global-mode 1)
               (let ((private-yas-dir (concat configuration-layer-private-directory "snippets")))
                 (setq yas-snippet-dirs
-                      (append (when (boundp 'yas-snippet-dirs)
-                                yas-snippet-dirs)
-                              (list private-yas-dir)))
+                      (append (list private-yas-dir)
+                              (when (boundp 'yas-snippet-dirs)
+                                yas-snippet-dirs)))
                 (setq yas-wrap-around-region t)))))
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook


### PR DESCRIPTION
This is because the list of snippet dirs had our
~/.emacs.d/private/snippets at the end so it doesn't guess that.
Something must have changed upstream. Also it's better to have our own
custom snippets to be first so as to override the default ones if we
pleased.

Doc for yas-new-snippet:
```
Documentation:
List of top-level snippet directories.

Each element, a string or a symbol whose value is a string,
designates a top-level directory where per-mode snippet
directories can be found.

Elements appearing earlier in the list override later elements'
snippets.

The first directory is taken as the default for storing snippet's
created with `yas-new-snippet'. 
```

With this now saving a snippet works, but there is this `~/.emacs.d/snippets` directory in the yas directory variables. So when doing yas-reload-all it fails because that dir doesn't exist.

Does this have something to do with this?
https://github.com/syl20bnr/spacemacs/blob/develop/core/core-configuration-layer.el#L184-L188