### PR TITLE
Fix for new line insertions with 'SPC i'

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -648,6 +648,24 @@ For instance pass En as source for english."
   (switch-to-buffer "*spacemacs*")
   )
 
+(defun spacemacs/insert-line-above-no-indent (count)
+  (interactive "p")
+  (save-excursion
+    (evil-previous-line)
+    (evil-move-end-of-line)
+    (while (> count 0)
+      (insert "\n")
+      (setq count (1- count)))))
+
+(defun spacemacs/insert-line-below-no-indent (count)
+  "Insert a new line below with no identation."
+  (interactive "p")
+  (save-excursion
+    (evil-move-end-of-line)
+    (while (> count 0)
+      (insert "\n")
+      (setq count (1- count)))))
+
 ;; from https://github.com/gempesaw/dotemacs/blob/emacs/dg-defun.el
 (defun kill-matching-buffers-rudely (regexp &optional internal-too)
   "Kill buffers whose name matches the specified REGEXP. This

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -117,15 +117,10 @@ Ensure that helm is required before calling FUNC."
   "fy" 'show-and-copy-buffer-filename)
 ;; insert stuff ---------------------------------------------------------------
 (evil-leader/set-key
-  "ij"  (lambda (count)
-          "Insert a new line below with no identation."
-          (interactive "p")
-          (save-excursion
-            (evil-move-end-of-line)
-            (while (> count 0)
-              (insert "\n")
-              (setq count (1- count)))))
-  "ik" 'evil-insert-line-above)
+  "iJ" 'spacemacs/insert-line-below-no-indent 
+  "iK" 'spacemacs/insert-line-above-no-indent 
+  "ik" 'evil-insert-line-above
+  "ij" 'evil-insert-line-below)
 ;; format ---------------------------------------------------------------------
 ;; <SPC> j k key binding for a frequent action: go and indent line below the point
 ;; <SPC> J split the current line at point and indent it


### PR DESCRIPTION
Previous behaviour was inconsistent. When pressing `SPC i` the `j` entry shows '??' and it inserts new lines below with **no** indentations. On the other hand `SPC i k` inserts new lines above while keeping the indentations.

Now `SPC i j` & `SPC i k` keep the indentations levels and `SPC i J` & `SPC i K` inserts new lines with no indentations.