### PR TITLE
Add better integration with edit-server package

### DIFF
--- a/contrib/chrome/README.md
+++ b/contrib/chrome/README.md
@@ -28,7 +28,7 @@ Feature:
 To use this contribution add it to your `~/.spacemacs`
 
 ```elisp
-(setq-default dotspacemacs-configuration-layers '(edit-server))
+(setq-default dotspacemacs-configuration-layers '(chrome))
 ```
 
 ### Chrome extension
@@ -42,18 +42,20 @@ The edit server is configured to start automatically when Spacemacs starts.
 
 ## Configuration
 
-You can hook into `edit-server`'s provided hooks in `dotspacemacs/config` in
-your `.spacemacs` file.
+Use `edit-server-url-major-mode-alist` to choose a major mode initialization
+function based on `edit-server-url`, or fall back to
+`edit-server-default-major-mode` that has a current value of `markdown-mode`.
 
 ```elisp
 (defun dotspacemacs/config ()
-  ;; Open github text areas as markdown
-  (add-hook 'edit-server-start-hook
-            (lambda ()
-              (when (string-match "github.com" (buffer-name))
-                (markdown-mode))))
+;; Open github text areas as org buffers
+;; currently they are opened as markdown
+  (setq edit-server-url-major-mode-alist
+      '(("github\\.com" . org-mode)))
 )
 ```
+
+Or 
 
 [edit-server]: http://melpa.org/#/edit-server
 [Edit with Emacs]: https://chrome.google.com/webstore/detail/edit-with-emacs/ljobjlafonikaiipfkggjbhkghgicgoh

--- a/contrib/chrome/packages.el
+++ b/contrib/chrome/packages.el
@@ -16,4 +16,8 @@
   (use-package edit-server
     :init
     (progn
-      (edit-server-start))))
+      (edit-server-start))
+    :config
+    (progn
+      (setq edit-server-default-major-mode 'markdown-mode))
+    ))

--- a/contrib/chrome/packages.el
+++ b/contrib/chrome/packages.el
@@ -10,7 +10,10 @@
 ;;
 ;;; License: GPLv3
 
-(setq chrome-packages '(edit-server))
+(setq chrome-packages '(
+                        edit-server
+                        gmail-message-mode
+                        ))
 
 (defun chrome/init-edit-server ()
   (use-package edit-server
@@ -21,3 +24,6 @@
     (progn
       (setq edit-server-default-major-mode 'markdown-mode))
     ))
+
+(defun chrome/init-gmail-message-mode ( )
+  (use-package gmail-message-mode))


### PR DESCRIPTION
Fix typo in doc: should be `chrome` not `edit-server`
@syl20bnr I believe you may want to check this change in the doc too.

Btw, there is also a firefox package.... kinda
http://stackoverflow.com/questions/10383986/emacs-mode-for-stack-overflows-markdown

