### PR TITLE
Add toggle to hide/show the mode line

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -884,6 +884,7 @@ Some elements can be dynamically toggled:
 <kbd>SPC t m m</kbd>   | toggle the minor mode lighters
 <kbd>SPC t m n</kbd>   | toggle the cat! (if `colors` layer is declared in your dotfile)
 <kbd>SPC t m p</kbd>   | toggle the point character position
+<kbd>SPC t m t</kbd>   | toggle the mode line itself
 <kbd>SPC t m v</kbd>   | toggle the new version lighter
 
 #### Flycheck integration

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -918,6 +918,31 @@ The body of the advice is in BODY."
   (if (<= (- end beg) spacemacs-yank-indent-threshold)
       (indent-region beg end nil)))
 
+;; hide mode line
+;; from http://bzg.fr/emacs-hide-mode-line.html
+(defvar-local hidden-mode-line-mode nil)
+(define-minor-mode hidden-mode-line-mode
+  "Minor mode to hide the mode-line in the current buffer."
+  :init-value nil
+  :global t
+  :variable hidden-mode-line-mode
+  :group 'editing-basics
+  (if hidden-mode-line-mode
+      (setq hide-mode-line mode-line-format
+            mode-line-format nil)
+    (setq mode-line-format hide-mode-line
+          hide-mode-line nil))
+  (force-mode-line-update)
+  ;; Apparently force-mode-line-update is not always enough to
+  ;; redisplay the mode-line
+  (redraw-display)
+  (when (and (called-interactively-p 'interactive)
+             hidden-mode-line-mode)
+    (run-with-idle-timer
+     0 nil 'message
+     (concat "Hidden Mode Line Mode enabled.  "
+             "Use M-x hidden-mode-line-mode to make the mode-line appear."))))
+
 (spacemacs|advise-commands
  "indent" (yank yank-pop evil-paste-before evil-paste-after) after
  "If current mode is not one of spacemacs-indent-sensitive-modes

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -202,6 +202,12 @@ Ensure that helm is required before calling FUNC."
                       :on (toggle-frame-maximized)
                       :documentation "Maximize the current frame."
                       :evil-leader "TM")
+(spacemacs|add-toggle mode-line
+                      :status hidden-mode-line-mode
+                      :on (hidden-mode-line-mode)
+                      :off (hidden-mode-line-mode -1)
+                      :documentation "Toggle the visibility of modeline."
+                      :evil-leader "tmt")
 (spacemacs|add-toggle transparent-frame
                       :status nil
                       :on (toggle-transparency)


### PR DESCRIPTION
This come in handy in org-present or distraction-free writing.