### PR TITLE
Add helm-gitignore to git layer

### DIFF
--- a/contrib/tools/git/README.md
+++ b/contrib/tools/git/README.md
@@ -40,6 +40,7 @@ Features:
 - quick in buffer last commit message per line with [git-messenger][]
 - colorize buffer line by age of commit with [smeargle][]
 - git gutter in fringe with [git-gutter][]
+- gitignore generator with [helm-gitignore][]
 
 This layer also provides support for Github with:
 - [magit-gh-pulls][]: handy `magit` add-on to manage Github pull requests.
@@ -135,6 +136,7 @@ Git commands (start with `g`):
 <kbd>SPC g h c</kbd>       | clear highlights
 <kbd>SPC g h h</kbd>       | highlight regions by age of commits
 <kbd>SPC g h t</kbd>       | highlight regions by last updated time
+<kbd>SPC g i</kbd>         | open `helm-gitignore`
 <kbd>SPC g l</kbd>         | open a `magit` log
 <kbd>SPC g s</kbd>         | open a `magit` status window
 <kbd>SPC g m</kbd>         | display the last commit message of the current line
@@ -374,3 +376,4 @@ override this behavior by setting the variable `git-link-open-in-browser` to
 [gist.el]: https://github.com/defunkt/gist.el
 [git-link]: https://github.com/sshaw/git-link
 [github-browse-file]: https://github.com/osener/github-browse-file
+[helm-gitignore]: https://github.com/jupl/helm-gitignore

--- a/contrib/tools/git/packages.el
+++ b/contrib/tools/git/packages.el
@@ -24,6 +24,7 @@
     git-link
     ;; not up to date
     ;; helm-gist
+    helm-gitignore
     magit
     magit-gh-pulls
     magit-gitflow
@@ -52,6 +53,13 @@
         "ggl" 'gist-list
         "ggr" 'gist-region
         "ggR" 'gist-region-private))))
+
+(defun git/init-helm-gitignore ()
+  (use-package helm-gitignore
+    :defer t
+    :config
+    (evil-leader/set-key
+      "gi" 'helm-gitignore)))
 
 (defun git/init-git-commit-mode ()
   (use-package git-commit-mode

--- a/contrib/tools/git/packages.el
+++ b/contrib/tools/git/packages.el
@@ -56,7 +56,6 @@
 
 (defun git/init-helm-gitignore ()
   (use-package helm-gitignore
-    :defer t
     :config
     (evil-leader/set-key
       "gi" 'helm-gitignore)))


### PR DESCRIPTION
[helm-gitignore](https://github.com/jupl/helm-gitignore) helps generate gitignore files with ease using [gitignore.io](https://www.gitignore.io/). A leader key is also set up for it.