### PR TITLE
avoid conflict with hydra's lv.el

### DIFF
--- a/core/core-micro-state.el
+++ b/core/core-micro-state.el
@@ -10,7 +10,7 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
-(require 'lv)
+(require 'corelv)
 
 (defun spacemacs/defface-micro-state-faces ()
   "Define faces for micro-states."
@@ -91,7 +91,7 @@ used."
          (doc (spacemacs/mplist-get props :doc))
          (persistent (plist-get props :persistent))
          (disable-leader (plist-get props :disable-evil-leader))
-         (msg-func (if (plist-get props :use-minibuffer) 'message 'lv-message))
+         (msg-func (if (plist-get props :use-minibuffer) 'message 'corelv-message))
          (exec-binding (plist-get props :execute-binding-on-enter))
          (on-enter (spacemacs/mplist-get props :on-enter))
          (on-exit (spacemacs/mplist-get props :on-exit))
@@ -241,9 +241,9 @@ pressed)."
 
 (defun spacemacs//micro-state-close-window ()
   "Close micro-state help window."
-  (when (window-live-p lv-wnd)
-    (let ((buf (window-buffer lv-wnd)))
-      (delete-window lv-wnd)
+  (when (window-live-p corelv-wnd)
+    (let ((buf (window-buffer corelv-wnd)))
+      (delete-window corelv-wnd)
       (kill-buffer buf))))
 
 (provide 'core-micro-state)

--- a/core/libs/corelv.el
+++ b/core/libs/corelv.el
@@ -1,4 +1,4 @@
-;;; lv.el --- Other echo area
+;;; corelv.el --- Other echo area
 
 ;; Copyright (C) 2015  Free Software Foundation, Inc.
 
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 ;;
-;; This package provides `lv-message' intended to be used in place of
+;; This package provides `corelv-message' intended to be used in place of
 ;; `message' when semi-permanent hints are needed, in order to not
 ;; interfere with Echo Area.
 ;;
@@ -33,16 +33,16 @@
 
 ;;; Code:
 
-(defvar lv-wnd nil
+(defvar corelv-wnd nil
   "Holds the current LV window.")
 
-(defun lv-window ()
+(defun corelv-window ()
   "Ensure that LV window is live and return it."
-  (if (window-live-p lv-wnd)
-      lv-wnd
+  (if (window-live-p corelv-wnd)
+      corelv-wnd
     (let ((ori (selected-window))
           buf)
-      (prog1 (setq lv-wnd
+      (prog1 (setq corelv-wnd
                    (select-window
                     (split-window
                      (frame-root-window) -1 'below)))
@@ -52,17 +52,17 @@
           (setq truncate-lines nil)
           (setq mode-line-format nil)
           (setq cursor-type nil)
-          (set-window-dedicated-p lv-wnd t))
+          (set-window-dedicated-p corelv-wnd t))
         (select-window ori)))))
 
-(defun lv-message (format-string &rest args)
+(defun corelv-message (format-string &rest args)
   "Set LV window contents to (`format' FORMAT-STRING ARGS)."
   (let ((ori (selected-window))
         (str (apply #'format format-string args))
         (golden-ratio (when (boundp 'golden-ratio-mode) golden-ratio-mode))
         deactivate-mark)
     (when (bound-and-true-p golden-ratio-mode) (golden-ratio-mode -1))
-    (select-window (lv-window))
+    (select-window (corelv-window))
     (when golden-ratio (golden-ratio-mode))
     (unless (string= (buffer-string) str)
       (delete-region (point-min) (point-max))
@@ -71,6 +71,6 @@
     (goto-char (point-min)) (end-of-line)
     (select-window ori)))
 
-(provide 'lv)
+(provide 'corelv)
 
-;;; lv.el ends here
+;;; corelv.el ends here


### PR DESCRIPTION
This renames `lv.el` in spacemacs to `corelv.el` to avoid breaking Hydra as hydra has added more functions.
Perhaps a better way would be to sync with latest version of `lv.el` from hydra, but I see there are some local spacemacs-specific patches to `lv.el`, so for now I just did the safer fix.