### PR TITLE
Add support for system trash on OS X

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,7 +1,9 @@
 (setq osx-packages
   '(
+    osx-trash
     pbcopy
     ))
+
 
 (if (executable-find "gls")
     ;; maybe absolute or relative name of the `ls' program used by
@@ -10,6 +12,13 @@
     (setq insert-directory-program "gls"
           dired-listing-switches "-aBhl --group-directories-first")
   (setq dired-use-ls-dired nil))
+
+(defun osx/init-osx-trash ()
+  (use-package osx-trash
+    :init
+    (progn
+      (osx-trash-setup)
+      (setq delete-by-moving-to-trash t))))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy


### PR DESCRIPTION
Use Finder to move files to the system trash, using the command line utility `trash` (which is available from Homebrew's `osxutils`, or `trash` formula's). If neither is installed, it'll use the bundled AppleScript (which is slower).
