### PR TITLE
Added Asciidoc contrib layer.

### DIFF
--- a/contrib/lang/asciidoc/README.md
+++ b/contrib/lang/asciidoc/README.md
@@ -1,0 +1,28 @@
+# Asciidoc contribution layer for Spacemacs
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+- [Asciidoc contribution layer for Spacemacs](#asciidoc-contribution-layer-for-spacemacs)
+    - [Description](#description)
+    - [Install](#install)
+    - [Key bindings](#key-bindings)
+
+<!-- markdown-toc end -->
+
+
+## Description
+
+This is simplest possible layer to enable [Asciidoc](https://asciidoctor.org) markup language support in Spacemacs.
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(asciidoc))
+```
+
+## Key bindings
+
+`adoc-mode` doesn't export any key bindings as far as I know.

--- a/contrib/lang/asciidoc/packages.el
+++ b/contrib/lang/asciidoc/packages.el
@@ -1,0 +1,21 @@
+;;; packages.el --- Asciidoc Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2015 Mark Safronov & Contributors
+;;
+;; Author: Mark Safronov <hijarian@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar asciidoc-packages
+  '(adoc-mode)
+  "List of all packages to install and/or initialize. Built-in packages
+which require an initialization must be listed explicitly in the list.")
+
+(defun asciidoc/init-adoc-mode ()
+  (use-package adoc-mode
+    :mode (("\\.adoc?$" . adoc-mode))
+    :defer t))


### PR DESCRIPTION
Hello! I have found no support for [Asciidoctor](http://asciidoctor.org) in Spacemacs, so I have composed a simplest possible contrib layer for `adoc-mode`. There's not much in this mode, just highlighting, some documentation examples and customize variables. 

As far as I understand I did everything by-the-book, as described in wiki. On my local workstation this layer is working (opening `.adoc` files correctly switch Spacemacs to `adoc-mode`).