### PR TITLE
Enable OS X trash support using osx-trash

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,5 +1,6 @@
 (setq osx-packages
   '(
+    osx-trash
     pbcopy
     ))
 
@@ -10,6 +11,14 @@
     (setq insert-directory-program "gls"
           dired-listing-switches "-aBhl --group-directories-first")
   (setq dired-use-ls-dired nil))
+
+(defun osx/init-osx-trash
+    (use-package osx-trash
+      :defer t
+      :init
+      (progn
+        (osx-trash-setup)
+        (setq delete-by-moving-to-trash t))))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy


### PR DESCRIPTION
Enable deleting files using an external command line utility `trash`, which is available via Hombrew (either `osxutils` or `trash`). If neither was installed, it'll use the bundled (but slower) AppleScript instead.

PS this will make EVERYTHING deleted within Emacs go to the Trash first, including packages upgraded when Spacemacs is started... not sure this is desirable, but don't see how to force it to be selective.