### PR TITLE
Fix the recentf-exclude variable

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2455,13 +2455,13 @@ It is a string holding:
                                            (recentf-mode)
                                            (recentf-track-opened-file))))
     :config
-    (progn
-      (setq recentf-exclude '(spacemacs-cache-directory))
-      (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
-      (setq recentf-save-file (concat spacemacs-cache-directory "recentf"))
-      (setq recentf-max-saved-items 100)
-      (setq recentf-auto-cleanup 'never)
-      (setq recentf-auto-save-timer (run-with-idle-timer 600 t 'recentf-save-list)))))
+    (add-to-list 'recentf-exclude (expand-file-name spacemacs-cache-directory))
+    (add-to-list 'recentf-exclude (expand-file-name package-user-dir))
+    (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
+    (setq recentf-save-file (concat spacemacs-cache-directory "recentf"))
+    (setq recentf-max-saved-items 100)
+    (setq recentf-auto-cleanup 'never)
+    (setq recentf-auto-save-timer (run-with-idle-timer 600 t 'recentf-save-list))))
 
 (defun spacemacs/init-rfringe ()
   (use-package rfringe


### PR DESCRIPTION
`recentf-exclude` variable takes regexps or functions for filenames excluded. `spacemacs-cache-directory` should not be quoted since it's not a function. 

My osx configuration requires an absolute path, thus the expression uses `expand-file-name`. I also added elpa directory, since there is a lot of noise after a spacemacs update.

You should run `M-x recentf-cleanup` to update the `recentf-list` with the new rules.