### PR TITLE
Add launchctl-el package to the osx layer

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,5 +1,6 @@
 (setq osx-packages
   '(
+    launchctl
     pbcopy
     ))
 
@@ -10,6 +11,40 @@
     (setq insert-directory-program "gls"
           dired-listing-switches "-aBhl --group-directories-first")
   (setq dired-use-ls-dired nil))
+
+(defun osx/init-launchctl ()
+  (use-package launchctl
+    :defer t
+    :init
+    (progn
+      ;; support editing plist files using nxml-mode
+      (add-to-list 'auto-mode-alist '("\\.plist$" . nxml-mode))
+      (evil-leader/set-key "al" 'launchctl))
+    :config
+    (progn
+      ;; evilified mapping
+      (evilify launchctl-mode launchctl-mode-map
+               (kbd "q") 'quit-window
+               (kbd "g") 'launchctl-refresh
+               (kbd "n") 'launchctl-new
+               (kbd "e") 'launchctl-edit
+               (kbd "v") 'launchctl-view
+               (kbd "t") 'tabulated-list-sort
+               (kbd "l") 'launchctl-load)
+               (kbd "u") 'launchctl-unload
+               (kbd "r") 'launchctl-reload
+               (kbd "s") 'launchctl-start
+               (kbd "o") 'launchctl-stop
+               (kbd "a") 'launchctl-restart
+               (kbd "m") 'launchctl-remove
+               (kbd "d") 'launchctl-disable
+               (kbd "p") 'launchctl-enable
+               (kbd "i") 'launchctl-info
+               (kbd "*") 'launchctl-filter
+               (kbd "$") 'launchctl-setenv
+               (kbd "#") 'launchctl-unsetenv
+               (kbd "h") 'launchctl-help
+      )))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy


### PR DESCRIPTION
Adds the `launchctl-el` major-mode to the OS X  layer, with an app launcher shortcut on `al`. 

Bindings are evilified according to the original key bindings suggested for this mode, though couldn't get 'h' (for `launchctl-help`) to override `evil-backward-char`.

Also, `plist` files are associated with `nxml-mode` (not sure if needed to be done here or not...)
