### PR TITLE
Add support for the osx-trash package

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,5 +1,6 @@
 (setq osx-packages
   '(
+    osx-trash
     pbcopy
     ))
 
@@ -10,6 +11,14 @@
     (setq insert-directory-program "gls"
           dired-listing-switches "-aBhl --group-directories-first")
   (setq dired-use-ls-dired nil))
+
+(defun osx/init-osx-trash ()
+  (use-package osx-trash
+    :defer t
+    :init
+    (progn
+      (osx-trash-setup)
+      (setq delete-by-moving-to-trash t))))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy


### PR DESCRIPTION
Add the `osx-trash` package to the osx layer.

Tweaks `delete-by-moving-to-trash` to force all file deletion within Emacs to be done using the Finder (or System API) using the external command line tool `trash`, available in hombrew via the `osxutils` or `trash` formulas.

WARNING: ALL files deleted within emacs, not just interactively (i.e. using `dired`), will be trashed.