### PR TITLE
Update smooth-scroll to use recommended variables

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2685,10 +2685,10 @@ It is a string holding:
   ;; no require are needed for this package everything is auto-loaded
   (if dotspacemacs-smooth-scrolling
       ;; enable smooth scrolling
-      (setq scroll-step 1
-            scroll-conservatively 10000
-            auto-window-vscroll nil
-            smooth-scroll-margin 5)
+      (setq scroll-margin 5
+            smooth-scroll-margin 5
+            scroll-conservatively 101
+            scroll-preserve-screen-position)
 
     ;; deactivate the defadvice's
     (ad-disable-advice 'previous-line 'after 'smooth-scroll-down)


### PR DESCRIPTION
The emacs documentation not using scroll-margin. I have used these settings personally for a few months and have had much fewer problems (when moving in larger increments, or of cases where the scroll-margin is not respected).