### PR TITLE
Add support for osx-trash in osx layer

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,5 +1,6 @@
 (setq osx-packages
   '(
+    osx-trash
     pbcopy
     ))
 
@@ -10,6 +11,14 @@
     (setq insert-directory-program "gls"
           dired-listing-switches "-aBhl --group-directories-first")
   (setq dired-use-ls-dired nil))
+
+(defun osx/init-osx-trash ()
+  (use-package osx-trash
+    :defer t
+    :init
+    (progn
+      (osx-trash-setup)
+      (setq delete-by-moving-to-trash t))))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy


### PR DESCRIPTION
Adds support for trashing files (using Finder or System API) under OS X. 

Needs the `trash` command line tool, which can be installed using Homebrew's `osxutils` or `trash` formulas.

If the `trash` command is not found, it'll use the bundled AppleScript, which is slower but works the same way.

IMPORTANT enabling `delete-by-moving-to-trash` will make every thing deleted within emacs go to the trash, not just files deleted interactively in `dired` etc.