### PR TITLE
Close codeblock in autocomplete README

### DIFF
--- a/contrib/auto-completion/README.md
+++ b/contrib/auto-completion/README.md
@@ -52,6 +52,7 @@ to `t`
 (setq-default dotspacemacs-configuration-layers
   '(auto-completion :variables
                     auto-completion-enable-company-help-tooltip t))
+```
 
 ## Configure
 


### PR DESCRIPTION
This unclosed codeblock ate a reasonable chunk of the README. Closing it causes it to render correctly.