### PR TITLE
Make directory if it does not exist when renaming the current buffer file

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -380,6 +380,9 @@ argument takes the kindows rotate backwards."
         (cond ((get-buffer new-name)
                (error "A buffer named '%s' already exists!" new-name))
               (t
+               (let ((dir (file-name-directory new-name)))
+                 (when (and (not (file-exists-p dir)) (yes-or-no-p (format "Create directory '%s'?" dir)))
+                   (make-directory dir t)))
                (rename-file filename new-name 1)
                (rename-buffer new-name)
                (set-visited-file-name new-name)


### PR DESCRIPTION
Currently renaming current buffer file fails if directory component of new name does not exist. It's the behaviour of system ```rename``` function which is called by ```rename-file```. This is annoying and I think we should at least ask user if Emacs should create a directory.