### PR TITLE
Enable company in Python REPL for code completion

### DIFF
--- a/contrib/lang/python/config.el
+++ b/contrib/lang/python/config.el
@@ -13,6 +13,7 @@
 ;; variables
 
 (spacemacs|defvar-company-backends python-mode)
+(spacemacs|defvar-company-backends inferior-python-mode)
 (spacemacs|defvar-company-backends pip-requirements-mode)
 
 (defvar python-enable-yapf-format-on-save nil

--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -257,7 +257,12 @@
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun python/post-init-company ()
-    (spacemacs|add-company-hook python-mode))
+    (spacemacs|add-company-hook python-mode)
+    (spacemacs|add-company-hook inferior-python-mode)
+    (push 'company-capf company-backends-inferior-python-mode)
+    (add-hook 'inferior-python-mode-hook (lambda ()
+                                           (setq-local company-minimum-prefix-length 0)
+                                           (setq-local company-idle-delay 0.5))))
 
   (defun python/init-company-anaconda ()
     (use-package company-anaconda


### PR DESCRIPTION
- Anconda should be enabled in Python REPL for retrieving proper
completion candidates. This can be tested in Python REPL: when
anaconda-mode is enabled and without any prefix string before point, run
the command completion-at-point (bound to C-M-i by default), completion
candidates from Anaconda are displayed; when anaconda-mode is disabled,
nothing is displayed.

- Company should be enabled in Python REPL for displaying completion
candidates. Note that in Python REPL, we must use company-capf to
display the candidates from Anaconda, since in the REPL it uses
completion-at-point to display Anaconda candidates. company-anaconda
backend cannot be used in Python REPL since it is buggy: it cannot
retrieve any prefix before point and narrow properly.