### PR TITLE
[Fix #1553 and #1608] Make sure yasnippet is actually loaded

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -194,21 +194,20 @@
       (setq yas-minor-mode-map (make-sparse-keymap))
 
       (defun spacemacs/load-yasnippet ()
-        (if (not (boundp 'yas-minor-mode))
-            (progn
-              (yas-global-mode 1)
-              (let ((private-yas-dir (concat
-                                      configuration-layer-private-directory
-                                      "snippets/")))
-                (setq yas-snippet-dirs
-                      (append (list private-yas-dir)
-                              (when (boundp 'yas-snippet-dirs)
-                                yas-snippet-dirs)))
-                (setq yas-wrap-around-region t)))))
+        (unless yas-global-mode
+          (progn
+            (yas-global-mode 1)
+            (let ((private-yas-dir (concat
+                                    configuration-layer-private-directory
+                                    "snippets/")))
+              (setq yas-snippet-dirs
+                    (append (list private-yas-dir)
+                            (when (boundp 'yas-snippet-dirs)
+                              yas-snippet-dirs)))
+              (setq yas-wrap-around-region t)))))
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook
                                                 org-mode-hook))
-
       (spacemacs|add-toggle yasnippet
                             :status yas-minor-mode
                             :on (yas-minor-mode)
@@ -221,7 +220,8 @@
         (setq yas-dont-activate t))
 
       (add-to-hooks 'spacemacs/force-yasnippet-off '(term-mode-hook
-                                                     shell-mode-hook)))
+                                                     shell-mode-hook
+                                                     eshell-mode-hook)))
     :config
     (progn
       (spacemacs|diminish yas-minor-mode " ⓨ" " y"))))


### PR DESCRIPTION
By checking if the yas-minor-mode is enabled. If so, load yasnippet. We
must do so because some package might load yasnippet and make
yas-minor-mode available, thus prevent Spacemacs to load yasnippet
properly.