### PR TITLE
Enhance shell-pop and term integration

### DIFF
--- a/contrib/shell/config.el
+++ b/contrib/shell/config.el
@@ -12,7 +12,9 @@
 
 ;; Variables
 
-(defvar shell-default-shell 'eshell
+(defvar shell-default-shell (if (eq window-system 'w32)
+                                'eshell
+                              'ansi-term)
   "Default shell to use in Spacemacs. Possible values are `eshell', `shell',
 `term' and `ansi-term'.")
 

--- a/contrib/shell/packages.el
+++ b/contrib/shell/packages.el
@@ -100,6 +100,19 @@
       (make-shell-pop-command term shell-pop-term-shell)
       (make-shell-pop-command ansi-term shell-pop-term-shell)
 
+      (defun ansi-term-handle-close ()
+        "Close current term buffer when `exit' from term buffer."
+        (when (ignore-errors (get-buffer-process (current-buffer)))
+          (set-process-sentinel (get-buffer-process (current-buffer))
+                                (lambda (proc change)
+                                  (when (string-match "\\(finished\\|exited\\)" change)
+                                    (kill-buffer (process-buffer proc))
+                                    (delete-window))))))
+      (add-hook 'term-mode-hook 'ansi-term-handle-close)
+      (defun term-switch-dir-hook ()
+        (term-send-raw-string (concat "cd " default-directory "\n")))
+      (add-hook 'shell-pop-in-hook #'term-switch-dir-hook)
+
       (defun spacemacs/default-pop-shell ()
         "Open the default shell in a popup."
         (interactive)
@@ -108,8 +121,8 @@
         ";"   'spacemacs/default-pop-shell
         "ase" 'shell-pop-eshell
         "asi" 'shell-pop-shell
-        "ast" 'shell-pop-term
-        "asT" 'shell-pop-ansi-term))))
+        "ast" 'shell-pop-ansi-term
+        "asT" 'shell-pop-term))))
 
 (defun shell/init-term ()
   (defun term-send-tab ()


### PR DESCRIPTION
- Only set Eshell by default on Windows; in other OSes we use `ansi-term`,
NOT `term`. The reason is that `ansi-term` can use Emacs key bindings
such as C-x b, C-x 1... even editing commands such as M-u/M-l. `term`
cannot and we have to use the default `C-c b` variants i.e. C-c b to
switch buffer instead of "C-x b". `ansi-term` is currently the best
terminal emulator in Emacs.

- Allow ansi-term/term to close its shell-pop window when a user type
"exit".

- With shell-pop, we can allow ansi-term/term to track current directory
of current buffer. It is a useful feature and it also makes ansi-term
consistent with eshell/shell.

- Swap "term" and "ansi-term" key bindings, since the old "ast" was used 
for multi-term, which is a wrapper around ansi-term.