### PR TITLE
Fix Python and Semantic integration

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -267,7 +267,15 @@
       (push 'company-anaconda company-backends-python-mode))))
 
 (defun python/post-init-semantic ()
-  (semantic/enable-semantic-mode 'python-mode))
+  (semantic/enable-semantic-mode 'python-mode)
+  (defadvice semantic-python-get-system-include-path (around semantic-python-skip-error-advice activate)
+    "Don't cause error when Semantic cannot retrieve include
+paths for Python then prevent the buffer to be switched. This
+issue might be fixed in Emacs 25. Until then, we need it here to
+fix this issue."
+    (condition-case nil
+        ad-do-it
+      (error nil))))
 
 (defun python/post-init-stickyfunc-enhance ()
   (add-hook 'python-mode-hook 'spacemacs/lazy-load-stickyfunc-enhance))


### PR DESCRIPTION
When no Python executable is detected, Semantic causes an error that it cannot
retrieve include paths from the executable, causing an error that prevents
Python buffer to be switched and error is repeatedly reported whenever a Python
buffer is opened. This commit ignores the error from
semantic-python-get-system-include-path that is called when Semantic setup
itself for a Python buffer.