### PR TITLE
Add reveal-in-finder support (OS X layer)

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,6 +1,7 @@
 (setq osx-packages
   '(
     pbcopy
+    reveal-in-finder
     ))
 
 (if (executable-find "gls")
@@ -15,3 +16,11 @@
   (use-package pbcopy
     :if (not (display-graphic-p))
     :init (turn-on-pbcopy)))
+
+(defun osx/init-reveal-in-finder ()
+  (use-package reveal-in-finder
+    :defer t
+    :init
+    (progn
+      (evil-leader/set-key
+        "bf" 'reveal-in-finder))))


### PR DESCRIPTION
If `M-x reveal-in-finder` (or `SPC b f` is invoked in a file-associated buffer, it will open the folder enclosing the file in the OS X Finder. It will also select the file the buffer is associated with within the folder.

If `M-x reveal-in-finder` is invoked in a buffer not associated with a file, it will open the folder defined in the default-directory variable. 

In a `dired` buffer, this should open the current folder in the OS X Finder.

Evil default bind is `bf` (as it is buffer centric)