### PR TITLE
Refactor `system-move-to-file-trash` declaration to the osx layer

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -11,6 +11,15 @@
           dired-listing-switches "-aBhl --group-directories-first")
   (setq dired-use-ls-dired nil))
 
+;; use trash if installed
+(if (executable-find "trash")
+    (defun system-move-file-to-trash (file)
+      "Use `trash' to move FILE to the system trash.
+Can be installed with `brew install trash', or `brew install osxutils`''."
+      (call-process (executable-find "trash") nil 0 nil file))
+  ;; regular move to trash directory
+  (setq trash-directory "~/.Trash/emacs"))
+
 (defun osx/init-pbcopy ()
   (use-package pbcopy
     :if (not (display-graphic-p))

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -145,15 +145,6 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; should work on Windows and Linux distros
 ;; on OS X, install `trash' from `homebrew'
 (setq delete-by-moving-to-trash t)
-(when (system-is-mac)
-  ;; use trash if installed
-  (if (executable-find "trash")
-      (defun system-move-file-to-trash (file)
-        "Use `trash' to move FILE to the system trash.
-Can be installed with `brew install trash'."
-        (call-process (executable-find "trash") nil 0 nil file))
-    ;; regular move to trash directory
-    (setq trash-directory "~/.Trash/emacs")))
 
 ;; auto fill breaks line beyond current-fill-column
 (setq-default default-fill-column 80)


### PR DESCRIPTION
Move `system-move-file-to-trash` decleration to `contrib/osx`. No need to test if `system-is-mac` (?).