### PR TITLE
Add Spacemacs Snippets

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -193,8 +193,18 @@
       ;; use hippie-expand instead
       (setq yas-minor-mode-map (make-sparse-keymap))
 
+      ;; allow nested expansions
+      (setq yas-triggers-in-field t)
+
+      ;; this makes it easy to get out of a nested expansion
+      (define-key yas-minor-mode-map
+        (kbd "M-s-/") 'yas-next-field)
+
       ;; add key into candidate list
       (setq helm-yas-display-key-on-candidate t)
+      (setq spacemacs--snippets-dir
+            (concat (ht-get configuration-layer-paths 'auto-completion)
+                    "auto-completion"))
 
       (defun spacemacs/load-yasnippet ()
         (unless yas-global-mode
@@ -202,13 +212,21 @@
             (yas-global-mode 1)
             (let ((private-yas-dir (concat
                                     configuration-layer-private-directory
-                                    "snippets/")))
+                                    "snippets/"))
+                  (spacemacs-snippets-dir (expand-file-name
+                                           "snippets"
+                                           spacemacs--snippets-dir)))
               (setq yas-snippet-dirs
                     (append (list private-yas-dir)
                             (when (boundp 'yas-snippet-dirs)
-                              yas-snippet-dirs)))
-              (setq yas-wrap-around-region t))))
+                              yas-snippet-dirs)
+                            spacemacs-snippets-dir))
+              (yas-load-directory spacemacs-snippets-dir t)
+              (setq yas-wrap-around-region t)
+              )
+            ))
         (yas-minor-mode 1))
+
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook
                                                 org-mode-hook))

--- a/contrib/auto-completion/snippets/emacs-lisp-mode/.yas-parents
+++ b/contrib/auto-completion/snippets/emacs-lisp-mode/.yas-parents
@@ -1,0 +1,1 @@
+prog-mode

--- a/contrib/auto-completion/snippets/emacs-lisp-mode/.yas-setup.el
+++ b/contrib/auto-completion/snippets/emacs-lisp-mode/.yas-setup.el
@@ -1,0 +1,6 @@
+(defun spacemacs/get-parent-dir ()
+  (car (cdr ; Last item
+        (reverse
+         (split-string
+          (file-name-sans-extension (buffer-file-name))
+          "/")))))

--- a/contrib/auto-completion/snippets/emacs-lisp-mode/micro-state
+++ b/contrib/auto-completion/snippets/emacs-lisp-mode/micro-state
@@ -1,0 +1,12 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: micro-state
+# key: micro
+# binding: direct-keybinding
+# --
+(spacemacs|define-micro-state ${1:micro-state-name}
+    ${2::doc (spacemacs//$1-ms-documentation)}
+    ${3::use-minibuffer t}
+    ${4::evil-leader "${5:Leader-key}"}
+    :bindings
+    ${}
+    )

--- a/contrib/auto-completion/snippets/emacs-lisp-mode/new-package
+++ b/contrib/auto-completion/snippets/emacs-lisp-mode/new-package
@@ -1,0 +1,15 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# contributor: Diego Berrocal (cestdiego 4t gm4il d0t com)
+# name: new-package
+# key: newp
+# binding: direct-keybinding
+# --
+(defun `(spacemacs/get-parent-dir)`/init-${2:package-name} ()
+  ${3:(use-package $2
+  ${4::defer t
+  }${5::init
+  ${;; This block executes before the package has been loaded}
+  }${:config
+  ${;; This block executes after the package has been loaded}
+  })})
+$0


### PR DESCRIPTION
There are many stuff that we have in spacemacs which are creating new
layers and also creating micro-states. This Snippets try to help with
the process (the micro-state is a work in progress).

I also set the binding `C-M-/` to `(yas-next-field-or-maybe-expand)`
because `tab` doesn't have the behaviour I quite want (to be able to
expand a snippet like (defun) inside the new-package snippet and still
be able to continue in the outer snippet afterwards. With `tab` this
is *not* possible, but with `C-M-/` it *is*.