### PR TITLE
Enable helm-pydoc to automatically narrow to symbol at point

### DIFF
--- a/contrib/lang/python/packages.el
+++ b/contrib/lang/python/packages.el
@@ -244,7 +244,9 @@
   (use-package helm-pydoc
     :defer t
     :init
-    (evil-leader/set-key-for-mode 'python-mode "mhd" 'helm-pydoc)))
+    (evil-leader/set-key-for-mode 'python-mode "mhd" 'helm-pydoc)
+    (add-to-list 'helm-sources-using-default-as-input 'helm-pydoc--imported-source)
+    (add-to-list 'helm-sources-using-default-as-input 'helm-pydoc--installed-source)))
 
 (defun python/init-smartparens ()
   (defadvice python-indent-dedent-line-backspace


### PR DESCRIPTION
So, whenever a user want to see a symbol doc, `SPC m h d` on a symbol
and it automatically narrows to the symbol at point. The next step is
either pressing TAB or RET.