### PR TITLE
Add zygospore package

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -98,6 +98,7 @@
     whitespace
     window-numbering
     winner
+    zygospore
     ))
 
 (setq spacemacs-excluded-packages '())
@@ -2826,3 +2827,13 @@ It is a string holding:
       (setq winner-boring-buffers
             (append winner-boring-buffers spacemacs/winner-boring-buffers))
       (winner-mode t))))
+
+(defun spacemacs/init-zygospore (args)
+  (use-package zygospore
+    :defer t
+    :init
+    (progn
+      ;; reservable delete-other-windows
+      (define-key global-map (kbd "C-x 1") 'zygospore-toggle-delete-other-windows)
+      (define-key evil-window-map (kbd "o") 'zygospore-toggle-delete-other-windows)
+      (define-key evil-window-map (kbd "C-o") 'zygospore-toggle-delete-other-windows))))


### PR DESCRIPTION
This package allows deleting other windows and later restore back the
old window configuration with the same key binding. For example, after
binding `C-x 1` to zygospore-toggle-delete-other-windows, we can press
`C-x 1` to temporary "zoom in" the current window by deleting other
windows and "C-x 1" again to restore it. This is especially handy when
we want to pop a shell with "C-c ;", but the shell window is small and
we want to maximize it. However, maximizing destroys current window
layout. With this package, we are free to maximize the shell window and
later restore back the old window configuration.