### PR TITLE
Ocaml tweaks

### DIFF
--- a/contrib/lang/ocaml/README.md
+++ b/contrib/lang/ocaml/README.md
@@ -55,6 +55,7 @@ opam install merlin utop ocp-indent
 ----------------------|--------------------------------------------------------
 <kbd>SPC m c c</kbd>  | Compile
 <kbd>SPC m e t</kbd>  | Highlight identifier under cursor and print its type
+<kbd>SPC m h h</kbd>  | Document the identifier under point
 
 ### REPL (utop)
 

--- a/contrib/lang/ocaml/README.md
+++ b/contrib/lang/ocaml/README.md
@@ -54,10 +54,22 @@ opam install merlin utop ocp-indent
     Key Binding       |                 Description
 ----------------------|--------------------------------------------------------
 <kbd>SPC m c c</kbd>  | Compile
-<kbd>SPC m e t</kbd>  | Highlight identifier under cursor and print its type
+<kbd>SPC m c p</kbd>  | Check .merlin for errors
+<kbd>SPC m c r</kbd>  | Refresh changed .cmis in merlin
+<kbd>SPC m e C</kbd>  | Check for errors in current buffer
+<kbd>SPC m e n</kbd>  | Jump to next error
+<kbd>SPC m e N</kbd>  | Jump back to previous error
 <kbd>SPC m g a</kbd>  | Switch ML <-> MLI
-<kbd>SPC m g g</kbd>  | Locate the identifier under point
+<kbd>SPC m g b</kbd>  | Go back to the last position where the user did a locate
+<kbd>SPC m g g</kbd>  | Locate the identifier under point (same window)
+<kbd>SPC m g G</kbd>  | Locate the identifier under point (different window)
+<kbd>SPC m g l</kbd>  | Prompt for identifier and locate
+<kbd>SPC m g i</kbd>  | Prompt for module name and switch to ML file
+<kbd>SPC m g I</kbd>  | Prompt for module name and switch to MLI file
 <kbd>SPC m h h</kbd>  | Document the identifier under point
+<kbd>SPC m h t</kbd>  | Highlight identifier under cursor and print its type
+<kbd>SPC m h T</kbd>  | Prompt for expression and show its type
+<kbd>SPC m r d</kbd>  | Case analyze the current enclosing
 
 ### REPL (utop)
 

--- a/contrib/lang/ocaml/README.md
+++ b/contrib/lang/ocaml/README.md
@@ -55,6 +55,8 @@ opam install merlin utop ocp-indent
 ----------------------|--------------------------------------------------------
 <kbd>SPC m c c</kbd>  | Compile
 <kbd>SPC m e t</kbd>  | Highlight identifier under cursor and print its type
+<kbd>SPC m g a</kbd>  | Switch ML <-> MLI
+<kbd>SPC m g g</kbd>  | Locate the identifier under point
 <kbd>SPC m h h</kbd>  | Document the identifier under point
 
 ### REPL (utop)

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -14,8 +14,8 @@
   '(
    ;; auto-complete
     company
-    flycheck
-    flycheck-ocaml
+   ;; flycheck
+   ;; flycheck-ocaml
     merlin
     ocp-indent
     tuareg
@@ -29,16 +29,19 @@
   (spacemacs|add-company-hook merlin-mode))
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
+  (defun ocaml/post-init-flycheck ()
+    (add-hook 'merlin-mode-hook 'flycheck-mode))
   (defun ocaml/init-flycheck-ocaml ()
     (use-package flycheck-ocaml
       :if (configuration-layer/package-usedp 'flycheck)
       :defer t
       :init
       (progn
-        (add-to-hook 'merlin-mode-hook '(flycheck-mode
-                                         flycheck-ocaml-setup))
-        (eval-after-load 'merlin
-          (setq merlin-use-auto-complete-mode nil))))))
+        (with-eval-after-load 'merlin
+          (progn
+            (setq merlin-error-after-save nil)
+            (flycheck-ocaml-setup))
+          )))))
 
 (defun ocaml/init-merlin ()
   (use-package merlin

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -12,6 +12,7 @@
 
 (setq ocaml-packages
   '(
+   ;; auto-complete
     company
     flycheck
     flycheck-ocaml
@@ -20,6 +21,9 @@
     tuareg
     utop
     ))
+
+(defun ocaml/post-init-auto-complete ()
+  (spacemacs|enable-auto-complete merlin-mode))
 
 (defun ocaml/post-init-company ()
   (spacemacs|add-company-hook merlin-mode))
@@ -42,8 +46,7 @@
     :init
     (progn
       (add-hook 'tuareg-mode-hook 'merlin-mode)
-      ;; disable integration with auto-complete, we use flycheck
-      (set-default 'merlin-use-auto-complete-mode nil)
+      (set-default 'merlin-use-auto-complete-mode t)
       (push 'merlin-company-backend company-backends-merlin-mode)
       (evil-leader/set-key-for-mode 'tuareg-mode
         "met" 'merlin-type-enclosing

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -22,8 +22,8 @@
     utop
     ))
 
-(defun ocaml/post-init-auto-complete ()
-  (spacemacs|enable-auto-complete merlin-mode))
+;;(defun ocaml/post-init-auto-complete ()
+;;  (spacemacs|enable-auto-complete merlin-mode))
 
 (defun ocaml/post-init-company ()
   (spacemacs|add-company-hook merlin-mode))
@@ -49,7 +49,8 @@
     :init
     (progn
       (add-hook 'tuareg-mode-hook 'merlin-mode)
-      (set-default 'merlin-use-auto-complete-mode t)
+;;      (set-default 'merlin-use-auto-complete-mode t)
+      (set-default 'merlin-use-auto-complete-mode nil)
       (setq merlin-completion-with-doc t)
       (push 'merlin-company-backend company-backends-merlin-mode)
       (evil-leader/set-key-for-mode 'tuareg-mode

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -53,9 +53,28 @@
       (setq merlin-completion-with-doc t)
       (push 'merlin-company-backend company-backends-merlin-mode)
       (evil-leader/set-key-for-mode 'tuareg-mode
-        "met" 'merlin-type-enclosing
-        "mgg" 'merlin-locate
+        "mcp" 'merlin-project-check
+        "mcr" 'merlin-refresh
+        "mcv" 'merlin-goto-project-file
+        "meC" 'merlin-error-check
+        "men" 'merlin-error-next
+        "meN" 'merlin-error-prev
+        "mgb" 'merlin-pop-stack
+        "mgg" #'(lambda ()
+                (interactive)
+                (let ((merlin-locate-in-new-window 'never))
+                  (merlin-locate)))
+        "mgG" #'(lambda ()
+                (interactive)
+                (let ((merlin-locate-in-new-window 'always))
+                  (merlin-locate)))
+        "mgl" 'merlin-locate-ident
+        "mgi" 'merlin-switch-to-ml
+        "mgI" 'merlin-switch-to-mli
         "mhh" 'merlin-document
+        "mht" 'merlin-type-enclosing
+        "mhT" 'merlin-type-expr
+        "mrd" 'merlin-destruct
         ))))
 
 (defun ocaml/init-ocp-indent ()

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -71,6 +71,7 @@
     (progn
       (spacemacs//init-ocaml-opam)
       (evil-leader/set-key-for-mode 'tuareg-mode
+        "mga" 'tuareg-find-alternate-file
         "mcc" 'compile))
     :config
     (when (fboundp 'sp-local-pair)

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -50,6 +50,7 @@
     (progn
       (add-hook 'tuareg-mode-hook 'merlin-mode)
       (set-default 'merlin-use-auto-complete-mode t)
+      (setq merlin-completion-with-doc t)
       (push 'merlin-company-backend company-backends-merlin-mode)
       (evil-leader/set-key-for-mode 'tuareg-mode
         "met" 'merlin-type-enclosing

--- a/contrib/lang/ocaml/packages.el
+++ b/contrib/lang/ocaml/packages.el
@@ -55,7 +55,7 @@
       (evil-leader/set-key-for-mode 'tuareg-mode
         "met" 'merlin-type-enclosing
         "mgg" 'merlin-locate
-        ;;"mhh" 'merlin-document
+        "mhh" 'merlin-document
         ))))
 
 (defun ocaml/init-ocp-indent ()


### PR DESCRIPTION
Flycheck initialization fixed, although not sure about its interaction with auto-complete and company, maybe it'd be better to just keep it disabled by default for now?

Add bindings for most merlin commands.
Merlin now supports showing ocamldoc (with `company` completion press F1)
