### PR TITLE
Added Asciidoc contrib layer.

### DIFF
--- a/contrib/!lang/asciidoc/README.md
+++ b/contrib/!lang/asciidoc/README.md
@@ -1,0 +1,56 @@
+# Asciidoc contribution layer for Spacemacs
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+- [Asciidoc contribution layer for Spacemacs](#asciidoc-contribution-layer-for-spacemacs)
+    - [Description](#description)
+    - [Install](#install)
+    - [Key bindings](#key-bindings)
+        - [Element insertion](#element-insertion)
+        - [Promotion, Demotion](#promotion-demotion)
+
+<!-- markdown-toc end -->
+
+## Description
+
+This layer adds [AsciiDoc][] markup language support to Spacemacs.
+
+Feature
+- asciidoc format support via [adoc-mode][]
+- `.adoc` files are associated with `adoc-mode` by default
+
+## Install
+
+To use this contribution add it to your `~/.spacemacs`
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(asciidoc))
+```
+
+## Key bindings
+
+### Element insertion
+
+    Key Binding       |                 Description
+----------------------|------------------------------------------------------------
+<kbd>SPC m h 1<kbd>   | Insert title level 1
+<kbd>SPC m h I<kbd>   | Insert title level 1 (the most important one)
+<kbd>SPC m h 2<kbd>   | Insert title level 2
+<kbd>SPC m h i<kbd>   | Insert title level 2 (the most usual one)
+<kbd>SPC m h 3<kbd>   | Insert title level 3
+<kbd>SPC m h 4<kbd>   | Insert title level 4
+<kbd>SPC m h 5<kbd>   | Insert title level 5
+<kbd>SPC m h 5<kbd>   | Insert title level 5
+<kbd>SPC m x b<kbd>   | Boldface selected
+<kbd>SPC m x i<kbd>   | Italicize selected
+
+
+### Promotion, Demotion
+    Key Binding       |                 Description
+----------------------|------------------------------------------------------------
+<kbd>M-h<kbd>   | Promote title level
+<kbd>M-l<kbd>   | Denote title level
+
+[AsciiDoc]: https://asciidoctor.org
+[adoc-mode]: https://github.com/sensorflo/adoc-mode

--- a/contrib/!lang/asciidoc/packages.el
+++ b/contrib/!lang/asciidoc/packages.el
@@ -1,0 +1,41 @@
+;;; packages.el --- Asciidoc Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2015 Mark Safronov, Torben Hoffmann & Contributors
+;;
+;; Author: Mark Safronov <hijarian@gmail.com>
+;; Author: Torben Hoffmann <torben.lehoff@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq asciidoc-packages
+  '(cl adoc-mode))
+
+(defun asciidoc/init-adoc-mode ()
+  (use-package adoc-mode
+    :mode (("\\.adoc?$" . adoc-mode)) ; We will NOT default `.txt' files to AsciiDoc mode, and `.asciidoc' extension is just plain stupid.
+		:defer t
+    :config
+    (progn
+      ;; We have quite a lot of possible keybindings. See `adoc-mode.el', its bottom part where the huge easy-menu is defined and after that, where the various `tempo-template-*' functions are defined.
+
+      ;; See /doc/CONVENTIONS.md#plain-text-markup-languages
+      (evil-leader/set-key-for-mode 'adoc-mode
+        "mh1" 'tempo-template-adoc-title-1
+        "mhI" 'tempo-template-adoc-title-1 ; Alternative method of inserting top-level heading - capital "I"
+        "mh2" 'tempo-template-adoc-title-2
+        "mhi" 'tempo-template-adoc-title-2 ; Alternative method of inserting the most usual heading - lowercase "i"
+        "mh3" 'tempo-template-adoc-title-3
+        "mh4" 'tempo-template-adoc-title-4
+        "mh5" 'tempo-template-adoc-title-5
+        "mxb" 'tempo-template-adoc-strong
+        "mxi" 'tempo-template-adoc-emphasis)
+      (define-key adoc-mode-map (kbd "M-h") 'adoc-denote) ; yes, exactly like that. To "promote" title is to INCREASE its size. `adoc-denote' does the opposite: increases its LEVEL, which DECREASES its size.
+      (define-key adoc-mode-map (kbd "M-l") 'adoc-promote)))) ; see the comment about  adoc-denote above
+
+(defun asciidoc/init-cl ()
+  (use-package cl))
+


### PR DESCRIPTION
Here it is, a successful merge of #1650 and #1692. Those PRs can be closed now.

It seems there are a lot of possibilities for keybindings. Currently only the rudimentary ones are included. If it's an issue, I'll add keybindings later to this PR.

Asciidoctor doesn't have any icon (yet), see asciidoctor/asciidoctor#48

Thank you, @lehoff for reminding me about `cl` package and keybindings. Included you as an author in title.