### PR TITLE
Rainbow-delimiters for LESS and SCSS in HTML layer

### DIFF
--- a/contrib/lang/html/packages.el
+++ b/contrib/lang/html/packages.el
@@ -20,6 +20,7 @@
     flycheck
     helm-css-scss
     less-css-mode
+    rainbow-delimiters
     scss-mode
     sass-mode
     tagedit
@@ -203,3 +204,9 @@
 
   (defun html/init-company-web ()
     (use-package company-web)))
+
+(defun html/init-rainbow-delimiters ()
+  (when (configuration-layer/package-usedp 'less-css-mode)
+    (add-hook 'less-css-mode-hook 'rainbow-delimiters-mode))
+  (when (configuration-layer/package-usedp 'scss-mode)
+    (add-hook 'scss-mode-hook 'rainbow-delimiters-mode)))


### PR DESCRIPTION
Nested brackets is possible in LESS and SCSS, which is why it's only enabled for them and not for CSS (no nesting) nor Sass. (nesting by indentation)