### PR TITLE
add custom calling function for helm-find-files

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1291,23 +1291,13 @@ Removes the automatic guessing of the initial value based on thing at point. "
         (interactive "P")
         (let* ((hist          (and arg helm-ff-history (helm-find-files-history)))
                 (default-input hist )
-                (input         (cond ((and (eq major-mode 'org-agenda-mode)
-                                            org-directory
-                                            (not default-input))
-                                    (expand-file-name org-directory))
-                                    ((and (eq major-mode 'dired-mode) default-input)
+                (input         (cond ((and (eq major-mode 'dired-mode) default-input)
                                     (file-name-directory default-input))
                                     ((and (not (string= default-input ""))
                                             default-input))
-                                    (t (expand-file-name (helm-current-directory)))))
-                (presel        (helm-aif (or hist
-                                            (buffer-file-name (current-buffer))
-                                            (and (eq major-mode 'dired-mode)
-                                                default-input))
-                                    (if helm-ff-transformer-show-only-basename
-                                        (helm-basename it) it))))
+                                    (t (expand-file-name (helm-current-directory))))))
             (set-text-properties 0 (length input) nil input)
-            (helm-find-files-1 input (and presel (concat "^" (regexp-quote presel))))))
+            (helm-find-files-1 input )))
       )
     :init
     (progn
@@ -1389,6 +1379,7 @@ If ARG is non nil then `ag' and `pt' and ignored."
         "bb"  'helm-mini
         "Cl"  'helm-colors
         "ff"  'spacemacs/helm-find-files
+        "fF"  'helm-find-files
         "fr"  'helm-recentf
         "hb"  'helm-pp-bookmarks
         "hi"  'helm-info-at-point


### PR DESCRIPTION
The function is pretty much a copy of the `helm-find-files` in helm. But I removed the part in which they guess what the initial input should be. This means that all guessing based on the thing at point is removed. 

The functions that are no longer called can be found [here](https://github.com/emacs-helm/helm/blob/master/helm-files.el#L2319-L2357)

This should be tested well to make sure it does not have any unintended side effects.