### PR TITLE
[Fix yasnippet] Explicitly enable yas-minor-mode

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -204,7 +204,8 @@
                     (append (list private-yas-dir)
                             (when (boundp 'yas-snippet-dirs)
                               yas-snippet-dirs)))
-              (setq yas-wrap-around-region t)))))
+              (setq yas-wrap-around-region t))))
+        (yas-minor-mode 1))
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook
                                                 markdown-mode-hook
                                                 org-mode-hook))


### PR DESCRIPTION
yas-global-mode is always enabled to ensure snippets are loaded
properly, but to use the snippets, a major mode must have yas-minor-mode
enabled. This commit ensure such condition happen.

Since we already have a function hook for loading yas in `prog-mode-hook`, reuse that hook.