### PR TITLE
Refactored `spacemacs/init-evil-lisp-state` to use `use-package`

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -902,9 +902,11 @@ Example: (evil-map visual \"<\" \"<gv\")"
                   'spacemacs/activate-major-mode-leader)))))
 
 (defun spacemacs/init-evil-lisp-state ()
-  (setq evil-lisp-state-global t)
-  (setq evil-lisp-state-leader-prefix "k")
-  (require 'evil-lisp-state))
+  (use-package evil-lisp-state
+    :init
+    (progn
+      (setq evil-lisp-state-global t)
+      (setq evil-lisp-state-leader-prefix "k"))))
 
 (defun spacemacs/init-evil-nerd-commenter ()
   (use-package evil-nerd-commenter


### PR DESCRIPTION
Caveat: I'm new to elisp development and haven't seen use-package before, so I may have no idea what I'm doing.

Would this be the correct way to load evil-lisp-state in accordance with the rest of spacemacs, or is there a reason use-package was avoided for this package?

Thanks!