### PR TITLE
Fix auto-completion README code markup.

### DIFF
--- a/contrib/auto-completion/README.md
+++ b/contrib/auto-completion/README.md
@@ -52,6 +52,7 @@ to `t`
 (setq-default dotspacemacs-configuration-layers
   '(auto-completion :variables
                     auto-completion-enable-company-help-tooltip t))
+```
 
 ## Configure
 


### PR DESCRIPTION
Hello,

I think some backticks were missing in README.