### PR TITLE
Better default behaviour in enh-ruby-mode

### DIFF
--- a/contrib/!lang/ruby/packages.el
+++ b/contrib/!lang/ruby/packages.el
@@ -37,7 +37,16 @@
   "Initialize Ruby Mode"
   (use-package enh-ruby-mode
     :mode (("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . enh-ruby-mode)
-           ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))))
+           ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))
+    :config
+    (progn
+      (setq enh-ruby-deep-indent-paren nil
+            enh-ruby-hanging-paren-deep-indent-level 2)
+      (sp-with-modes '(ruby-mode enh-ruby-mode)
+        (sp-local-pair "{" "}"
+                       :pre-handlers '(sp-ruby-pre-handler)
+                       :post-handlers '(sp-ruby-post-handler (spacemacs/smartparens-pair-newline-and-indent "RET"))
+                       :suffix "")))))
 
 (defun ruby/post-init-flycheck ()
   (add-hook 'enh-ruby-mode-hook 'flycheck-mode))
@@ -174,4 +183,5 @@
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun ruby/post-init-company ()
-    (spacemacs|add-company-hook enh-ruby-mode)))
+    (spacemacs|add-company-hook enh-ruby-mode)
+    (push 'enh-ruby-mode company-dabbrev-code-modes)))


### PR DESCRIPTION
This fixes the very annoying and unconventional behaviour of parentheses in Ruby.
The default behaviour is deep indentation, which is incredibly annoying when trying to write hash literals like thin (very common in ruby):
```ruby
some_verbose_name = {
  lol: 5,
  wow: 6,
}
```

The default behaviour not only does not do the fancy line opening on brace (it is overriden in smartparens-ruby) but it tries to line up the keys with the opening brace (way too far out).

This PR fixes that and also a problem that company didn't recogize `enh-ruby-mode` as a programming mode so `dabbrev` completion didn't properly complete things with underscores.

You can tell I'm working in Ruby again full time since I haven't contributed anything for a while and when I finally do it is just PRing major annoyances that I fixed in my dotfile long ago. :stuck_out_tongue: 