### PR TITLE
Change default shell to SPC ` to match terminal dropdown applications

### DIFF
--- a/contrib/shell/packages.el
+++ b/contrib/shell/packages.el
@@ -145,7 +145,7 @@
                        shell-default-shell)))
           (call-interactively (intern (format "shell-pop-%S" shell)))))
       (evil-leader/set-key
-        "'"   'spacemacs/default-pop-shell
+        "`"   'spacemacs/default-pop-shell
         "ase" 'shell-pop-eshell
         "asi" 'shell-pop-shell
         "asm" 'shell-pop-multiterm


### PR DESCRIPTION
Suggest using ```SPC `
``` instead of `SPC '` for shellpop to match applications like yakuake and guake.