### PR TITLE
Fix toggle-maximize-buffer

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -258,10 +258,11 @@ the current state and point position."
 (defun toggle-maximize-buffer ()
   "Maximize buffer"
   (interactive)
-  (if (= 1 (length (window-list)))
+  (if (and (= 1 (length (window-list)))
+           (assoc'_ register-alist))
       (jump-to-register '_)
     (progn
-      (set-register '_ (list (current-window-configuration)))
+      (window-configuration-to-register '_)
       (delete-other-windows))))
 
 (defun toggle-maximize-centered-buffer ()

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -14,6 +14,12 @@
 (setq echo-keystrokes 0.02)
 ;; auto-indent on RET
 (define-key global-map (kbd "RET") 'newline-and-indent)
+
+;; improve delete-other-windows
+(define-key global-map (kbd "C-x 1") 'toggle-maximize-buffer)
+(define-key evil-window-map (kbd "o") 'toggle-maximize-buffer)
+(define-key evil-window-map (kbd "C-o") 'toggle-maximize-buffer)
+
 ;; alternate binding to search next occurrence with isearch without
 ;; exiting isearch
 (define-key isearch-mode-map (kbd "S-<return>") 'isearch-repeat-forward)


### PR DESCRIPTION
- Use high level function window-configuration-to-register. Using
set-register causes the error wrong-type-argument integer-or-marker-p
when we later want to jump to the register.

- Check if the register actually has a window configuration before
jumping to it. Otherwise error happens because we try jump to non-existent
window configuration.

- Add key bindings.