### PR TITLE
Enable GDB many windows

### DIFF
--- a/contrib/!lang/c-c++/packages.el
+++ b/contrib/!lang/c-c++/packages.el
@@ -19,6 +19,7 @@
     company-c-headers
     company-ycmd
     flycheck
+    gdb-mi
     helm-gtags
     semantic
     srefactor
@@ -112,6 +113,16 @@
 
 (defun c-c++/post-init-flycheck ()
   (add-to-hooks 'flycheck-mode '(c-mode-hook c++-mode-hook)))
+
+(defun c-c++/init-gdb-mi ()
+  (use-package gdb-mi
+    :defer t
+    :init
+    (setq
+     ;; use gdb-many-windows by default when `M-x gdb'
+     gdb-many-windows t
+     ;; Non-nil means display source file containing the main routine at startup
+     gdb-show-main t)))
 
 (defun c-c++/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)


### PR DESCRIPTION
gdb-many-windows enables an IDE like debugger frontend for Emacs. Here is [my old demo](http://tuhdo.github.io/static/c-ide/gdb-many-windows.gif).