### PR TITLE
Fontify code in org-block

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -52,7 +52,8 @@
     :defer t
     :init
     (progn
-      (setq org-log-done t)
+      (setq org-log-done t
+            org-src-fontify-natively t)
 
       (eval-after-load 'org-indent
         '(spacemacs|hide-lighter org-indent-mode))


### PR DESCRIPTION
Org look prettier when source code block is fontified by its major mode,
instead of a plain gray of `org-block` face.