### PR TITLE
Evilify ledger report mode

### DIFF
--- a/contrib/finance/packages.el
+++ b/contrib/finance/packages.el
@@ -44,7 +44,8 @@
         "mR"    'ledger-report
         "mt"    'ledger-insert-effective-date
         "my"    'ledger-set-year
-        "m RET" 'ledger-set-month))))
+        "m RET" 'ledger-set-month)
+      (evilify ledger-report-mode ledger-report-mode-map))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun finance/post-init-company ()


### PR DESCRIPTION
Evilify ledger report mode.

Enables some useful bindings like `q`uit, `e`dit, `s`ave.