### PR TITLE
Adds OSX command +/- keybindings for font scaling

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -6,6 +6,8 @@
   (setq mac-option-modifier 'meta)
 
   ;; Keybindings
+  (global-set-key (kbd "s-=") 'text-scale-increase)
+  (global-set-key (kbd "s--") 'text-scale-decrease)
   (global-set-key (kbd "s-q") 'save-buffers-kill-terminal)
   (global-set-key (kbd "s-v") 'yank)
   (global-set-key (kbd "s-c") 'kill-ring-save)


### PR DESCRIPTION
This PR adds ⌘-= and ⌘-- for font scaling up and down, respectively.  I'm new to Spacemacs so I'm not 100% sure these keybindings will not conflict with anything but on evil-mode they work perfectly for me.