### PR TITLE
Unimpaired contribution layer

### DIFF
--- a/contrib/!vim/unimpaired/README.org
+++ b/contrib/!vim/unimpaired/README.org
@@ -1,0 +1,35 @@
+#+TITLE: Unimpaired port contribution layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#key-bindings][Key bindings]]
+
+* Description
+
+This layer ports some of the functionality of tpope's vim-unimpaired
+[unimpaired][https://github.com/tpope/vim-unimpaired]
+
+This plugin provides several pairs of bracket maps using ~[~ to denote
+previous, and ~]~ as next.
+
+* Key bindings
+
+| KeyBindings | Description                 |
+|-------------+-----------------------------|
+| ~[b~          | Go to previous buffer       |
+| ~]b~          | Go to next buffer           |
+| ~[l~          | Go to the previous error    |
+| ~]l~          | Go to the next error        |
+| ~[h~          | Go to the previous vcs hunk |
+| ~]h~          | Go to the next vcs hunk     |
+| ~[t~          | Go to the previous frame    |
+| ~]t~          | Go to the next frame        |
+| ~[w~          | Go to the previous window   |
+| ~]w~          | Go to the next window       |
+| ~[e~          | Move line up                |
+| ~]e~          | Move line down              |
+| ~[SPACE~      | Insert space above          |
+| ~]SPACE~      | Insert space below          |
+| ~[p~          | Paste above current line    |
+| ~]p~          | Paste below current line    |
+| ~gp~          | Select pasted text          |

--- a/contrib/!vim/unimpaired/funcs.el
+++ b/contrib/!vim/unimpaired/funcs.el
@@ -1,0 +1,11 @@
+;; funcs.el file for unimpaired contribution layer
+
+(defun unimpaired/paste-above ()
+  (interactive) 
+  (evil-insert-newline-above)
+  (evil-paste-after 1))
+
+(defun unimpaired/paste-below ()
+  (interactive) 
+  (evil-insert-newline-below)
+  (evil-paste-after 1))

--- a/contrib/!vim/unimpaired/keybindings.el
+++ b/contrib/!vim/unimpaired/keybindings.el
@@ -1,0 +1,36 @@
+;; from tpope's unimpaired
+
+(define-key evil-normal-state-map (kbd "[ SPC") (lambda() (interactive)(evil-insert-newline-above) (forward-line)))
+(define-key evil-normal-state-map (kbd "] SPC") (lambda() (interactive)(evil-insert-newline-below) (forward-line -1)))
+
+(define-key evil-normal-state-map (kbd "[ e") 'move-text-up)
+(define-key evil-normal-state-map (kbd "] e") 'move-text-down)
+
+(define-key evil-visual-state-map (kbd "[ e") ":move'<--1")
+(define-key evil-visual-state-map (kbd "] e") ":move'>+1")
+
+;; (define-key evil-visual-state-map (kbd "[ e") 'move-text-up)
+;; (define-key evil-visual-state-map (kbd "] e") 'move-text-down)
+
+(define-key evil-normal-state-map (kbd "[ b") 'spacemacs/previous-useful-buffer)
+(define-key evil-normal-state-map (kbd "] b") 'spacemacs/next-useful-buffer)
+
+(define-key evil-normal-state-map (kbd "] l") 'spacemacs/next-error)
+(define-key evil-normal-state-map (kbd "[ l") 'spacemacs/previous-error)
+
+(define-key evil-normal-state-map (kbd "[ h") 'diff-hl-prev-hunk)
+(define-key evil-normal-state-map (kbd "] h") 'diff-hl-next-hunk)
+
+(define-key evil-normal-state-map (kbd "[ t") (lambda () (interactive)(raise-frame (previous-frame))))
+(define-key evil-normal-state-map (kbd "] t") (lambda () (interactive)(raise-frame (next-frame))))
+
+(define-key evil-normal-state-map (kbd "[ w") 'previous-multiframe-window)
+(define-key evil-normal-state-map (kbd "] w") 'next-multiframe-window)
+
+;; select pasted text
+(define-key evil-normal-state-map (kbd "g p") (kbd "` [ v ` ]"))
+
+;; paste above or below with newline
+(define-key evil-normal-state-map (kbd "[ p") 'unimpaired/paste-above)
+(define-key evil-normal-state-map (kbd "] p") 'unimpaired/paste-below)
+

--- a/contrib/!vim/unimpaired/packages.el
+++ b/contrib/!vim/unimpaired/packages.el
@@ -1,0 +1,28 @@
+;;; packages.el --- unimpaired Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq unimpaired-packages
+  '(
+    ;; package unimpaireds go here
+    ))
+
+(setq unimpaired-excluded-packages '())
+
+;; For each package, define a function unimpaired/init-<package-unimpaired>
+;;
+;; (defun unimpaired/init-my-package ()
+;;   "Initialize my package"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package


### PR DESCRIPTION
This creates a port of tpopes unimpaired to add bracket bindings for some common tasks.  I know this is contrary to some of the ideas of Spacemacs, but there are some advantages for having a common convention for previous and next. (`[` and `]`). 