### PR TITLE
Configures the classpath directory for the ensime server

### DIFF
--- a/contrib/!lang/scala/packages.el
+++ b/contrib/!lang/scala/packages.el
@@ -34,6 +34,8 @@
       (add-hook 'scala-mode-hook 'scala/maybe-start-ensime))
     :config
     (progn
+      (setq user-emacs-ensime-directory ".cache/ensime")
+
       (evil-define-key 'insert ensime-mode-map
         (kbd ".") 'scala/completing-dot
         (kbd "M-.") 'ensime-edit-definition


### PR DESCRIPTION
Configures the directory to store the calculated classpaths for the ensime server. By default it creates `ensime` folder in `.emacs.d/`.

https://github.com/ensime/ensime-emacs/pull/135