### PR TITLE
yasnippet: default helm-yas-display-key-on-candidate to t

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -193,6 +193,9 @@
       ;; use hippie-expand instead
       (setq yas-minor-mode-map (make-sparse-keymap))
 
+      ;; add key into candidate list
+      (setq helm-yas-display-key-on-candidate t)
+
       (defun spacemacs/load-yasnippet ()
         (unless yas-global-mode
           (progn


### PR DESCRIPTION
When I was trying to figure out yasnippet today, I ran into a problem: they name of the snippet and the key used to access it are sometimes different. I understand why this is, but my workflow for figuring out the out-of-the-box snippets is this:

 1. check out what snippets I have available with `SPC i s`
 2. insert temporarily through Helm
 3. the next time, insert by typing the *name* and hitting `M-/`.

Of course, once I figured out that the name and key were sometimes different, it added another step (tab) in my process of inserting. This removes that step and makes the snippets more discoverable. The format of the snippets goes from: `word_regexp` (as an example) to `[<] word_regexp`.