### PR TITLE
Use weirder-looking templating variables

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -175,7 +175,7 @@ LAYER_DIR is nil, the private directory is used."
     (find-file dest)
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "NAME" nil t)
+      (while (re-search-forward "%LAYERNAME%" nil t)
         (replace-match name t)))
     (save-buffer)))
 

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -175,8 +175,9 @@ LAYER_DIR is nil, the private directory is used."
     (find-file dest)
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "%LAYERNAME%" nil t)
-        (replace-match name t)))
+      (let ((case-fold-search nil))
+        (while (re-search-forward "%LAYERNAME%" nil t)
+          (replace-match name t))))
     (save-buffer)))
 
 (defun configuration-layer//get-contrib-category-dirs ()

--- a/core/templates/extensions.template
+++ b/core/templates/extensions.template
@@ -1,4 +1,4 @@
-;;; extensions.el --- NAME Layer extensions File for Spacemacs
+;;; extensions.el --- %LAYERNAME% Layer extensions File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
@@ -10,19 +10,19 @@
 ;;
 ;;; License: GPLv3
 
-(setq NAME-pre-extensions
+(setq %LAYERNAME%-pre-extensions
       '(
         ;; pre extension names go here
         ))
 
-(setq NAME-post-extensions
+(setq %LAYERNAME%-post-extensions
       '(
         ;; post extension names go here
         ))
 
-;; For each extension, define a function NAME/init-<extension-name>
+;; For each extension, define a function %LAYERNAME%/init-<extension-name>
 ;;
-;; (defun NAME/init-my-extension ()
+;; (defun %LAYERNAME%/init-my-extension ()
 ;;   "Initialize my extension"
 ;;   )
 ;;

--- a/core/templates/layer-README.template
+++ b/core/templates/layer-README.template
@@ -1,6 +1,6 @@
-# LAYER contribution layer for Spacemacs
+# %LAYERNAME% contribution layer for Spacemacs
 
-![logo](img/LAYER.png)
+![logo](img/%LAYERNAME%.png)
 
 ;; Generate TOC here, use the commande `markdown-toc/generate-toc`
 
@@ -14,7 +14,7 @@ This layer does wondeful things:
 To use this contribution add it to your `~/.spacemacs`
 
 ```elisp
-(setq-default dotspacemacs-configuration-layers '(LAYER))
+(setq-default dotspacemacs-configuration-layers '(%LAYERNAME%))
 ```
 
 ## Key bindings

--- a/core/templates/packages.template
+++ b/core/templates/packages.template
@@ -1,4 +1,4 @@
-;;; packages.el --- NAME Layer packages File for Spacemacs
+;;; packages.el --- %LAYERNAME% Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
@@ -12,17 +12,17 @@
 
 ;; List of all packages to install and/or initialize. Built-in packages
 ;; which require an initialization must be listed explicitly in the list.
-(setq NAME-packages
+(setq %LAYERNAME%-packages
     '(
       ;; package names go here
       ))
 
 ;; List of packages to exclude.
-(setq NAME-excluded-packages '())
+(setq %LAYERNAME%-excluded-packages '())
 
-;; For each package, define a function NAME/init-<package-name>
+;; For each package, define a function %LAYERNAME%/init-<package-name>
 ;;
-;; (defun NAME/init-my-package ()
+;; (defun %LAYERNAME%/init-my-package ()
 ;;   "Initialize my package"
 ;;   )
 ;;


### PR DESCRIPTION
It's important to make templating variables something unique-looking so
that you don't accidentally write template variables where you don't
mean to.  For example, in extensions.template, "package names go here"
was being replaced with "package [name of package]s go here", etc.