### PR TITLE
[Fix #1813] Insert tab in Python REPL

### DIFF
--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -152,6 +152,10 @@
                   python-shell-completion-string-code "';'.join(get_ipython().Completer.all_completions('''%s'''))\n")
           (setq python-shell-interpreter "python")))
 
+      (defun inferior-python-setup-hook ()
+        (setq indent-tabs-mode t))
+
+      (add-hook 'inferior-python-mode-hook #'inferior-python-setup-hook)
       (add-all-to-hook 'python-mode-hook
                        'python-default
                        'python-setup-shell))


### PR DESCRIPTION
Currently, when tab is pressed, spaces are inserted. It makes Python
REPL unable to recognize code indentation. We must use tab to indent.
Setting indent-tabs-mode is buffer local, so it does not affect its
value in other buffers.