### PR TITLE
Revert C-o binding in holy-mode

### DIFF
--- a/contrib/better-defaults/README.md
+++ b/contrib/better-defaults/README.md
@@ -47,8 +47,6 @@ pressed again, go to the beginning of the line.
 Key Binding   | Description
 --------------|------------------------------------------------------------
 `C-a`         | smart beginning of line
-`C-o`         | get into Vim normal mode to execute one command, then go back Emacs editing mode
-`M-o` (Dired) | Open file in other window without moving point. It is the replacement for `C-o` in Dired.
 `C-y`         | Automatically indenting after pasting. With prefix argument, paste text as it is
 
 [Prelude]: https://github.com/bbatsov/prelude

--- a/contrib/better-defaults/keybindings.el
+++ b/contrib/better-defaults/keybindings.el
@@ -11,8 +11,3 @@
 ;;; License: GPLv3
 
 (global-set-key (kbd "C-a") 'spacemacs/smart-move-beginning-of-line)
-
-;; emacs state bindings
-(define-key evil-emacs-state-map (kbd "C-o") 'evil-execute-in-normal-state)
-(add-hook 'dired-mode-hook (lambda ()
-                             (local-set-key (kbd "M-o") 'dired-display-file)))


### PR DESCRIPTION
The current key binding shadows many other built-in modes and packages,
not just Dired. It is far too intrusive. We better go back to default.