### PR TITLE
correct helm link

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -186,7 +186,7 @@ If you are looking for commands to operate on your buffer, they are right under
 `Spacemacs` comes with a dedicated major mode `spacemacs-mode`. Its goal is to
 give useful feedbacks and easily perform maintenance tasks.
 
-It also comes with dedicated [helm][] sources to quickly find layers, packages
+It also comes with dedicated [helm][helm-link] sources to quickly find layers, packages
 and more.
 
 [guide-key][] is enabled by default, it will display all the available key


### PR DESCRIPTION
The link to helm was defunct, i.e. `[helm][]` with a missing `[helm]` reference. There was a `[helm-link]` instead so I referenced that.