### PR TITLE
Add reveal-in-finder in osx contrib layer

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -1,4 +1,4 @@
-(when (equal system-type 'darwin)
+(when (system-is-mac)
   ;; Treat option as meta and command as super
   (setq mac-option-key-is-meta t)
   (setq mac-command-key-is-meta nil)
@@ -19,4 +19,6 @@
 		  (interactive)
 		  (call-interactively (key-binding "\C-x\C-s"))))
   (global-set-key (kbd "s-Z") 'undo-tree-redo)
-  (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen))
+  (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen)
+
+  (evil-leader/set-key "bf" 'reveal-in-finder))

--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,6 +1,7 @@
 (setq osx-packages
   '(
     pbcopy
+    reveal-in-finder
     ))
 
 (if (executable-find "gls")
@@ -15,3 +16,8 @@
   (use-package pbcopy
     :if (not (display-graphic-p))
     :init (turn-on-pbcopy)))
+
+(defun osx/init-reveal-in-finder ()
+  (use-package reveal-in-finder
+    :if (system-is-mac)
+    :commands reveal-in-finder))


### PR DESCRIPTION
Add support for reveal-in-finder on OS X. 

Bound to evil `<leader> b f`, as a buffer related operation. 

Should work regardless of weather visiting a file or not, and also in `dired`.

Should work from GUI and TTY.

PS not using `:defer` because it is implied when using `:commands` AFAIK.