### PR TITLE
Don't reset dired-use-ls-dired when gls not found

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -3,13 +3,12 @@
     pbcopy
     ))
 
-(if (executable-find "gls")
+(if (and (system-is-mac) (executable-find "gls")) 
     ;; maybe absolute or relative name of the `ls' program used by
     ;; `insert-directory'.
     ;; brew info coreutils
     (setq insert-directory-program "gls"
-          dired-listing-switches "-aBhl --group-directories-first")
-  (setq dired-use-ls-dired nil))
+          dired-listing-switches "-aBhl --group-directories-first"))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy


### PR DESCRIPTION
When `coreutils` is installed from `nixpkgs`, `ls` (and other commands) are not prefixed, and there's no way to tell (also in case `ls` was aliased) if the command supports the specialized arguments used by `dired`.

So maybe it would be better to only update `insert-directory-program` when `gls` is on the path (and `system-is-mac`), and otherwise, alert the user to a possible error issued by `dired`, and advise to `(setq dired-use-ls-dired nil)` manually in `dotspacemacs`, if they do not wish to install `coreutils'.