### PR TITLE
Add text alignment keybindings

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1893,6 +1893,15 @@ Text related commands (start with `x`):
 -----------------------|------------------------------------------------------------
 <kbd>SPC x u</kbd>     | set the selected text to lower case
 <kbd>SPC x U</kbd>     | set the selected text to upper case
+<kbd>SPC x a a</kbd>   | align region (or guessed section) using default rules
+<kbd>SPC x a r</kbd>   | align region using user-specified regexp 
+<kbd>SPC x a m</kbd>   | align region at arithmetic operators (+-*/) 
+<kbd>SPC x a .</kbd>   | align region at . (for numeric tables)
+<kbd>SPC x a ,</kbd>   | align region at ,
+<kbd>SPC x a ;</kbd>   | align region at ;
+<kbd>SPC x a =</kbd>   | align region at =
+<kbd>SPC x a &</kbd>   | align region at &
+<kbd>SPC x a |</kbd>   | align region at |
 <kbd>SPC x d w</kbd>   | delete trailing whitespaces
 <kbd>SPC x g l</kbd>   | set languages used by translate commands
 <kbd>SPC x g t</kbd>   | translate current word using Google Translate

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -50,6 +50,7 @@
                                        ("wp" . "windows-popup")
                                        ("wS" . "windows-size")
                                        ("x" .  "text")
+                                       ("xa" . "text-align")
                                        ("xd" . "text-delete")
                                        ("xg" . "text-google-translate")
                                        ("xm" . "text-move")

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -956,3 +956,47 @@ The body of the advice is in BODY."
               (member major-mode spacemacs-indent-sensitive-modes)))
      (let ((transient-mark-mode nil))
        (yank-advised-indent-function (region-beginning) (region-end)))))
+
+;; modified function from http://emacswiki.org/emacs/AlignCommands
+(defun align-repeat (start end regexp &optional justify-right after)
+  "Repeat alignment with respect to the given regular expression.
+If JUSTIFY-RIGHT is non nil justify to the right instead of the
+left. If AFTER is non-nil, add whitespace to the left instead of
+the right."
+  (interactive "r\nsAlign regexp: ")
+  (let ((complete-regexp (if after
+                             (concat regexp "\\([ \t]*\\)")
+                           (concat "\\([ \t]*\\)" regexp)))
+        (group (if justify-right -1 1)))
+    (align-regexp start end complete-regexp group 1 t)))
+
+;; Modified answer from http://emacs.stackexchange.com/questions/47/align-vertical-columns-of-numbers-on-the-decimal-point
+(defun align-repeat-decimal (start end)
+  "Align a table of numbers on decimal points and dollar signs (both optional)"
+  (interactive "r")
+  (require 'align)
+  (align-region start end nil
+                '((nil (regexp . "\\([\t ]*\\)\\$?\\([\t ]+[0-9]+\\)\\.?")
+                       (repeat . t)
+                       (group 1 2)
+                       (spacing 1 1)
+                       (justify nil t)))
+                nil))
+
+(defmacro create-align-repeat-x (name regexp &optional justify-right default-after)
+  (let ((new-func (intern (concat "align-repeat-" name))))
+    `(defun ,new-func (start end switch)
+       (interactive "r\nP")
+       (let ((after (not (eq (if switch t nil) (if ,default-after t nil)))))
+         (align-repeat start end ,regexp ,justify-right after)))))
+
+(create-align-repeat-x "comma" "," nil t)
+(create-align-repeat-x "semicolon" ";" nil t)
+(create-align-repeat-x "colon" ":" nil t)
+(create-align-repeat-x "equal" "=")
+(create-align-repeat-x "math-oper" "[+\\-*/]")
+(create-align-repeat-x "ampersand" "&")
+(create-align-repeat-x "bar" "|")
+(create-align-repeat-x "left-paren" "(")
+(create-align-repeat-x "right-paren" ")" t)
+

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -295,6 +295,18 @@ Ensure that helm is required before calling FUNC."
   "w="  'balance-windows)
 ;; text -----------------------------------------------------------------------
 (evil-leader/set-key
+  "xaa" 'align
+  "xar" 'align-repeat
+  "xam" 'align-repeat-math-oper
+  "xa." 'align-repeat-decimal
+  "xa," 'align-repeat-comma
+  "xa;" 'align-repeat-semicolon
+  "xa:" 'align-repeat-colon
+  "xa=" 'align-repeat-equal
+  "xa&" 'align-repeat-ampersand
+  "xa|" 'align-repeat-bar
+  "xa(" 'align-repeat-left-paren
+  "xa)" 'align-repeat-right-paren
   "xdw" 'delete-trailing-whitespace
   "xtc" 'transpose-chars
   "xtl" 'transpose-lines


### PR DESCRIPTION
I added some keybindings for the `xa` prefix in the spacemacs layer related to aligning text. I tried to guess the most common delimiters and create functions for those directly. Let me know if you want me to add or subtract from these. All of the functions repeat until the end of the line (unlike the default behavior of `align-regexp`).

Also, I couldn't figure out any logical organization to the spacemacs/funcs.el file so I added the new functions to the end. 