### PR TITLE
[FIX #1300] Remove kill-ring from save-hist to avoid freezing Emacs on OS X

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -238,7 +238,7 @@ Can be installed with `brew install trash'."
 (setq savehist-file (concat spacemacs-cache-directory "savehist")
       enable-recursive-minibuffers t ; Allow commands in minibuffers
       history-length 1000
-      savehist-additional-variables '(kill-ring mark-ring global-mark-ring search-ring regexp-search-ring extended-command-history)
+      savehist-additional-variables '(mark-ring global-mark-ring search-ring regexp-search-ring extended-command-history)
       savehist-autosave-interval 60)
 (savehist-mode +1)
 


### PR DESCRIPTION
Since it is reported to have abnormal size on OS X and can freeze Emacs
without a way to recover: https://github.com/syl20bnr/spacemacs/issues/1300