### PR TITLE
add option to use pytest instead of nose for python testing

### DIFF
--- a/contrib/!lang/python/README.md
+++ b/contrib/!lang/python/README.md
@@ -151,6 +151,34 @@ Test commands (start with <kbd>m t</kbd> or <kbd>m T</kbd>):
 <kbd>SPC m T s</kbd> | launch all tests of the current suite in debug mode
 <kbd>SPC m T t</kbd> | launch the current test (function) in debug mode
 
+#### Using pytest
+
+If you would rather use pytest then set `python-use-pytest` to `t` in your
+`dotspacemacs/init` function.
+
+
+```elisp
+(defun dotspacemacs/init ()
+  (setq-default python-use-pytest t)
+)
+```
+
+Test commands (start with <kbd>m t</kbd> or <kbd>m T</kbd>):
+
+    No Debug         |                 Description
+---------------------|------------------------------------------------------------
+<kbd>SPC m t a</kbd> | launch all tests of the project
+<kbd>SPC m t b</kbd> | launch all tests of the current buffer (same as module)
+<kbd>SPC m t m</kbd> | launch all tests of the current module
+<kbd>SPC m t t</kbd> | launch the current test (function)
+
+     Debug           |                 Description
+---------------------|------------------------------------------------------------
+<kbd>SPC m T a</kbd> | launch all tests of the project in debug mode
+<kbd>SPC m T b</kbd> | launch all tests of the current buffer (module) in debug mode
+<kbd>SPC m T m</kbd> | launch all tests of the current module in debug mode
+<kbd>SPC m T t</kbd> | launch the current test (function) in debug mode
+
 ### Refactoring
 
     Key Binding       |                 Description

--- a/contrib/!lang/python/extensions.el
+++ b/contrib/!lang/python/extensions.el
@@ -16,12 +16,13 @@
 ;; Post extensions are loaded *after* the packages
 (setq python-post-extensions
   '(
-    nose
     pylookup
     python-compile
     py-yapf
     ))
 
+(unless python-use-pytest
+    (push 'nose python-post-extensions))
 ;; Initialize the extensions
 
 (defun python/init-nose ()

--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -31,6 +31,9 @@
     stickyfunc-enhance
     ))
 
+(if python-use-pytest
+    (push 'pytest python-packages))
+
 (defun python/init-anaconda-mode ()
   (use-package anaconda-mode
     :defer t
@@ -122,6 +125,30 @@
     :init
     (evil-leader/set-key-for-mode 'python-mode
       "mV" 'pyvenv-workon)))
+
+(defun python/init-pytest ()
+  (use-package pytest
+    :defer t
+    :commands (pytest-one
+               pytest-pdb-one
+               pytest-all
+               pytest-pdb-all
+               pytest-module
+               pytest-pdb-module)
+    :init
+    (evil-leader/set-key-for-mode 'python-mode
+      "mTa" 'pytest-pdb-all
+      "mta" 'pytest-all
+      "mTb" 'pytest-pdb-module
+      "mtb" 'pytest-module
+      "mTt" 'pytest-pdb-one
+      "mtt" 'pytest-one
+      "mTm" 'pytest-pdb-module
+      "mtm" 'pytest-module)
+    :config
+    (progn
+      (add-to-list 'pytest-project-root-files "setup.cfg")
+      )))
 
 (defun python/init-python ()
   (use-package python


### PR DESCRIPTION
pytest became available in MELPA a few hours ago. 

I personally prefer it over nose and have some projects that only work with it so I thought it is time to make this an option in spacemacs.

Regarding the implementation:

I've seen this in a few layers now that the configuration variables should be added in `dotspacemacs/init` instead at the `:variables` keyword. Is there a preferred way?