### PR TITLE
*Optional* spacemacs directory

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -208,12 +208,13 @@ Returns nil if the directory is not a category."
 (defun configuration-layer//discover-layers ()
   "Return a hash table where the key is the layer symbol and the value is its
 path."
-  ;; load private layers at the end on purpose
-  ;; we asume that the user layers must have the final word
-  ;; on configuration choices.
+  ;; load private layers at the end on purpose we asume that the user layers
+  ;; must have the final word on configuration choices. Let
+  ;; `dotspacemacs-directory' override the private directory if it exists.
   (let ((search-paths (append (list configuration-layer-contrib-directory)
                               dotspacemacs-configuration-layer-path
-                              (list configuration-layer-private-directory)))
+                              (list configuration-layer-private-directory)
+                              (list dotspacemacs-directory)))
         (discovered '())
         (result (make-hash-table :size 256)))
     ;; depth-first search of subdirectories

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -43,6 +43,17 @@
   (expand-file-name (concat user-emacs-directory "private/"))
   "Spacemacs private layers base directory.")
 
+(defconst configuration-layer-private-layer-directory
+  (let ((dotspacemacs-layer-dir
+         (if dotspacemacs-directory
+             (expand-file-name
+              (concat dotspacemacs-directory "layers/")))))
+    (if (and dotspacemacs-directory
+             (file-exists-p dotspacemacs-layer-dir))
+        dotspacemacs-layer-dir
+      configuration-layer-private-directory))
+  "Spacemacs default directory for private layers.")
+
 (defconst configuration-layer-rollback-directory
   (expand-file-name (concat spacemacs-cache-directory ".rollback/"))
   "Spacemacs rollback directory.")
@@ -118,7 +129,7 @@ layer directory."
   (interactive)
   (let* ((current-layer-paths (mapcar (lambda (dir) (expand-file-name dir))
                                       (cl-pushnew
-                               configuration-layer-private-directory
+                               configuration-layer-private-layer-directory
                                dotspacemacs-configuration-layer-path)))
          (other-choice "Another directory...")
          (helm-lp-source
@@ -152,7 +163,7 @@ layer directory."
 (defun configuration-layer//get-private-layer-dir (name)
   "Return an absolute path the the private configuration layer with name
 NAME."
-  (concat configuration-layer-private-directory name "/"))
+  (concat configuration-layer-private-layer-directory name "/"))
 
 (defun configuration-layer//copy-template (template &optional layer-dir)
   "Copy and replace special values of TEMPLATE to LAYER_DIR. If
@@ -213,7 +224,7 @@ path."
   ;; `dotspacemacs-directory' override the private directory if it exists.
   (let ((search-paths (append (list configuration-layer-contrib-directory)
                               dotspacemacs-configuration-layer-path
-                              (list configuration-layer-private-directory)
+                              (list configuration-layer-private-layer-directory)
                               (list dotspacemacs-directory)))
         (discovered '())
         (result (make-hash-table :size 256)))

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -45,9 +45,9 @@
 
 (defconst configuration-layer-private-layer-directory
   (let ((dotspacemacs-layer-dir
-         (if dotspacemacs-directory
-             (expand-file-name
-              (concat dotspacemacs-directory "layers/")))))
+         (when dotspacemacs-directory
+           (expand-file-name
+            (concat dotspacemacs-directory "layers/")))))
     (if (and dotspacemacs-directory
              (file-exists-p dotspacemacs-layer-dir))
         dotspacemacs-layer-dir

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -15,7 +15,7 @@
 
 (defconst dotspacemacs-directory
   (let* ((env (getenv "SPACEMACSDIR"))
-         (env-dir (if env (expand-file-name (concat env "/"))))
+         (env-dir (when env (expand-file-name (concat env "/"))))
          (no-env-dir-default (expand-file-name
                               (concat user-home-directory
                                       ".spacemacs.d/"))))
@@ -33,7 +33,7 @@ directories exist, this variable will be nil.")
 
 (defconst dotspacemacs-filepath
   (let* ((default (concat user-home-directory ".spacemacs"))
-         (spacemacs-dir-init (if dotspacemacs-directory
+         (spacemacs-dir-init (when dotspacemacs-directory
                                  (concat dotspacemacs-directory
                                          "init.el"))))
     (if (and (not (file-exists-p default))

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -13,9 +13,38 @@
   (expand-file-name (concat spacemacs-core-directory "templates/"))
   "Templates directory.")
 
+(defconst dotspacemacs-directory
+  (let* ((env (getenv "SPACEMACSDIR"))
+         (env-dir (if env (expand-file-name (concat env "/"))))
+         (no-env-dir-default (expand-file-name
+                              (concat user-home-directory
+                                      ".spacemacs.d/"))))
+    (cond
+     ((and env (file-exists-p env-dir))
+      env-dir)
+     ((file-exists-p no-env-dir-default)
+      no-env-dir-default)
+     (t
+      nil)))
+  "Optional spacemacs directory, which defaults to
+~/.spacemacs.d. This setting can be overridden using the
+SPACEMACSDIR environment variable. If neither of these
+directories exist, this variable will be nil.")
+
 (defconst dotspacemacs-filepath
-  (concat user-home-directory ".spacemacs")
-  "Filepath to the installed dotfile.")
+  (let* ((default (concat user-home-directory ".spacemacs"))
+         (spacemacs-dir-init (if dotspacemacs-directory
+                                 (concat dotspacemacs-directory
+                                         "init.el"))))
+    (if (and (not (file-exists-p default))
+             dotspacemacs-directory
+             (file-exists-p spacemacs-dir-init))
+        spacemacs-dir-init
+      default))
+  "Filepath to the installed dotfile. If ~/.spacemacs exists,
+then this is used. If ~/.spacemacs does not exist, then check
+for init.el in dotspacemacs-directory and use this if it
+exists. Otherwise, fallback to ~/.spacemacs")
 
 (defvar dotspacemacs-verbose-loading nil
   "If non nil output loading progess in `*Messages*' buffer.")


### PR DESCRIPTION
I know that this PR will probably be unwelcome from prior discussion, but please hear me out before you close it. This is one way to approach #1607, #1619, and #1620. 

This PR adds support for a completely optional spacemacs directory. The existence of ~/.spacemacs essentially overrides the use of the directory, so this will not affect existing configurations. 

To use the directory:

1. Move ~/.spacemacs to ~/.spacemacs.d/init.el (~/.spacemacs must be missing)
  * treated as the .spacemacs file when ~/.spacemacs is missing
2. Create ~/.spacemacs.d/layers/ 
  * new default directory for private layers when the spacemacs directory is being used
  * you can add this directory explicitly in `dotspacemacs-configuration-layer-path`, but it will also be used in case that variable is empty (only when the `dotspacemacs-directory` is non-nil though).
3. Create ~/.spacemacs.d/snippets/ 
  * new default directory for snippets

The location of the directory can also be changed using the SPACEMACSDIR environment variable. Setting this variable overrides the use of ~/.spacemacs.d

If ~/.spacemacs does not exist and ~/.spacemacs.d/init.el does not either, then `dotspacemacs-filepath` falls back to ~/.spacemacs which triggers the existing behavior when there is no init file. The only way for ~/.spacemacs.d/init.el to be read is if this file exists and ~/.spacemacs doesn't. So you have to explicitly setup the directory to make it work. 

I can but have not rewritten any documentation. I am just throwing this idea out there because I really like it and I think others will too. I tried to implement it in a way that is completely optional and safely ignored by those who are not interested. 

I see clear advantages and will continue to use it for myself, since I can now have an independent spacemacs configuration that is very easily put into vc or backed up in a dropbox folder for example. I can now blow away .emacs.d and clone spacemacs again if things get really out of whack (I screw up the repo for example). The disadvantage would be for someone to "accidentally" set this up and not realize it, but that seems difficult to do. 

Finally, I did this in several commits to allow for only part of the functionality to be implemented.