### PR TITLE
Allow erc-track-mode to be disabled

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2351,7 +2351,7 @@ displayed in the mode-line.")
                    (powerline-raw " " line-face)))
            ;; erc
            (when (and active
-                      (boundp 'erc-track-mode))
+                      (bound-and-true-p erc-track-mode))
              ;; Copied from erc-track.el -> erc-modified-channels-display
              (let* ((buffers (mapcar 'car erc-modified-channels-alist))
                     (long-names (mapcar #'(lambda (buf) (or (buffer-name buf) "")) buffers)))


### PR DESCRIPTION
The minor mode `erc-track-mode` dumps a lot of text in the modeline. It's enabled by default, but the modeline code doesn't actually check whether the user has disabled it, only whether the variable is bound.