### PR TITLE
Use exec-path-from-shell-copy-env to set GOPATH.

### DIFF
--- a/contrib/!lang/go/packages.el
+++ b/contrib/!lang/go/packages.el
@@ -11,6 +11,9 @@
     (add-hook 'go-mode-hook 'flycheck-mode))
 
 (defun go/init-go-mode()
+  (when (memq window-system '(mac ns x))
+    (exec-path-from-shell-copy-env "GOPATH"))
+
   (use-package go-mode
     :defer t
     :config


### PR DESCRIPTION
The `go` layer expects the `GOPATH` environment variable to be set, but GUI Emacsen don't pickup `GOPATH` from the shell by default.