### PR TITLE
Add JIT load for spacemacs snippets at startup

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -222,6 +222,7 @@
                               yas-snippet-dirs)
                             spacemacs-snippets-dir))
               (yas-load-directory spacemacs-snippets-dir t)
+              (yas-load-directory private-yas-dir t)
               (setq yas-wrap-around-region t))))
         (yas-minor-mode 1))
 

--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -202,7 +202,7 @@
 
       ;; add key into candidate list
       (setq helm-yas-display-key-on-candidate t)
-      (setq spacemacs--snippets-dir
+      (setq spacemacs--auto-completion-dir
             (concat (ht-get configuration-layer-paths 'auto-completion)
                     "auto-completion"))
 
@@ -215,13 +215,13 @@
                                     "snippets/"))
                   (spacemacs-snippets-dir (expand-file-name
                                            "snippets"
-                                           spacemacs--snippets-dir)))
+                                           spacemacs--auto-completion-dir)))
               (setq yas-snippet-dirs
                     (append (list private-yas-dir)
                             (when (boundp 'yas-snippet-dirs)
                               yas-snippet-dirs)
-                            spacemacs-snippets-dir
-                            ))
+                            spacemacs-snippets-dir))
+              (yas-load-directory spacemacs-snippets-dir t)
               (setq yas-wrap-around-region t))))
         (yas-minor-mode 1))
 

--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -203,8 +203,7 @@
       ;; add key into candidate list
       (setq helm-yas-display-key-on-candidate t)
       (setq spacemacs--auto-completion-dir
-            (concat (ht-get configuration-layer-paths 'auto-completion)
-                    "auto-completion"))
+            (configuration-layer/get-layer-property 'auto-completion :dir))
 
       (defun spacemacs/load-yasnippet ()
         (unless yas-global-mode


### PR DESCRIPTION
It seems that there is a weird issue with the loading of snippets, the
same goes to snippets in the private directory.