### PR TITLE
Show buffer file encoding on powerline modeline

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2434,6 +2434,13 @@ It is a string holding:
            (list
             ;; row:column
             (powerline-raw " " face1)
+            ;; buffer encoding
+            (powerline-raw (format "%s |" (let ((buf-coding (format "%s" buffer-file-coding-system)))
+                                              (if (string-match "\\(dos\\|unix\\|mac\\)" buf-coding)
+                                                  (match-string 1 buf-coding)
+                                                buf-coding
+                                              )))
+                           face1 'r)
             (powerline-raw (if spacemacs-mode-line-display-point-p
                                (concat (format "%d | " (point)) "%l:%2c" )
                              "%l:%2c")


### PR DESCRIPTION
This should help catch some incorrect file encodings in the future.