### PR TITLE
evilify helm-ag and helm-grep buffers

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1722,12 +1722,16 @@ Key Binding               |                 Description
 <kbd>SPC s g</kbd>        | `grep`
 <kbd>SPC s k</kbd>        | `ack`
 <kbd>SPC s p</kbd>        | `pt`
+<kbd>SPC s L</kbd>        | open stored search buffer (stored with <kbd>F3<kbd> in helm search buffer)
 
 **Note** Use the universal argument to change the search list of
 <kbd>SPC s /</kbd> to `ack` and `grep` (does not look for `ag` or `pt`).
 
 **Note** It is also possible to search in several directories at once by
 marking them in the helm buffer.
+
+**Pro Tip** Use <kbd>F3</kbd> in the helm search buffer to save the list of
+  results to a buffer.
 
 #### Searching in a project
 
@@ -1742,6 +1746,7 @@ Key Binding               |                 Description
 <kbd>SPC p s p</kbd>      | `pt`
 
 **Pro Tip** Use <kbd>SPC h l</kbd> to bring back the last helm session.
+
 
 #### Searching the web
 

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1391,6 +1391,20 @@ If ARG is non nil then `ag' and `pt' and ignored."
                  dotspacemacs-search-tools)))
           (call-interactively (spacemacs//helm-do-search-find-tool tools))))
 
+      ;; evilify the helm-grep buffer
+      (evilify helm-grep-mode helm-grep-mode-map
+               (kbd "RET") 'helm-grep-mode-jump-other-window
+               (kbd "q") 'quit-window)
+
+      (defun spacemacs/last-search-buffer ()
+        "open last helm-ag or hgrep buffer."
+        (interactive)
+        (if (get-buffer "*helm ag results*")
+            (switch-to-buffer-other-window "*helm ag results*")
+            (if (get-buffer "*hgrep*")
+                (switch-to-buffer-other-window "*hgrep*")
+                (message "No previous search buffer found"))))
+
       ;; use helm by default for M-x
       (unless (configuration-layer/package-usedp 'smex)
         (global-set-key (kbd "M-x") 'helm-M-x))
@@ -1414,6 +1428,7 @@ If ARG is non nil then `ag' and `pt' and ignored."
         "sg"  'helm-do-grep
         "sk"  'spacemacs/helm-do-ack
         "sp"  'spacemacs/helm-do-pt
+        "sL"  'spacemacs/last-search-buffer
         "sl"  'helm-semantic-or-imenu)
 
       ;; define the key binding at the very end in order to allow the user
@@ -1603,7 +1618,10 @@ ARG non nil means that the editing style is `vim'."
   (use-package helm-ag
     :defer t
     :config
-    (evil-define-key 'normal helm-ag-map "SPC" evil-leader--default-map)))
+    (evil-define-key 'normal helm-ag-map "SPC" evil-leader--default-map)
+    (evilify helm-ag-mode helm-ag-mode-map
+             (kbd "RET") 'helm-ag-mode-jump-other-window
+             (kbd "q") 'quit-window)))
 
 (defun spacemacs/init-helm-descbinds ()
   (use-package helm-descbinds


### PR DESCRIPTION
This adds the `C-z F3` binding to the documentation and enables navigation in the saved helm-grep and helm-ag buffers. 

I've not tested this with `ack` but since it is based on the `helm-ag` command like `pt` it should work also.

The buffers stick around after being closed but helm does not list the `helm-ag` buffers. So right now it is not easy to get the last search back.

@geo7