### PR TITLE
Ipython-notebook improvements/switch to major-mode leader

### DIFF
--- a/contrib/!lang/ipython-notebook/README.org
+++ b/contrib/!lang/ipython-notebook/README.org
@@ -6,7 +6,7 @@ Do not hesitate to check the original package README [[https://github.com/millej
 lots of informative stuff.
 
 ** Features
-- Micro-State with "evilified" keybindings
+- Keybindings available through micro-State or leader key
 - Lazy-loading
 
 ** TODO List
@@ -31,13 +31,19 @@ Have an iPython notebook running
   ipython notebook
 #+end_src
 
-** Key Bindings
+** Using the IPython notebook
 *** Open Notebook List
 This layer is lazy loaded so the micro-state will only work after you summon the
 command =ein:notebooklist-open= which is bound to =SPC a i n=
-*** Micro-state: =ipython-notebook= 
+*** Key Bindings
+The key bindings can be used through a micro state or the usual evil-leader.
+
+**** Micro-state: =ipython-notebook= 
 Once you are in the ipython notebook you can activate the micro-state with
-=SPC a i n=
+=SPC e i n=
+
+The following table lists the keys. Use them as listed in the micro-state or
+prefix with =SPC m= to use with your evil-leader.
 
 | Key     | Function                                  |
 |---------+-------------------------------------------|
@@ -56,6 +62,7 @@ Once you are in the ipython notebook you can activate the micro-state with
 | =p=     | ein:worksheet-yank-cell                   |
 | =o=     | ein:worksheet-insert-cell-below           |
 | =O=     | ein:worksheet-insert-cell-above           |
+| =u=     | ein:worksheet-change-cell-type            |
 | =RET=   | ein:worksheet-execute-cell-and-goto-next  |
 | =C-l=   | ein:worksheet-clear-output                |
 | =C-S-l= | ein:worksheet-clear-all-output            |
@@ -76,7 +83,6 @@ Once you are in the ipython notebook you can activate the micro-state with
 | =+=     | ein:notebook-worksheet-insert-next        |
 | =-=     | ein:notebook-worksheet-delete             |
 | =x=     | ein:notebook-close                        |
-
 ** Screenshots
 *** Light
 [[img/light.png]]

--- a/contrib/!lang/ipython-notebook/packages.el
+++ b/contrib/!lang/ipython-notebook/packages.el
@@ -14,6 +14,7 @@
 
 (defun ipython-notebook/init-ein ()
   (use-package ein
+    :defer t
     :commands ein:notebooklist-open
     :init
     (evil-leader/set-key "ain" 'ein:notebooklist-open)
@@ -36,7 +37,7 @@
         [h,l] prev/next worksheet          [H,L] move worksheet left/right
         [C-k,C-j] merge cell above/bellow  [O,o] insert cell above/bellow
         [d] kill cell                      [y,p] copy or past cell
-        [RET] execute cell
+        [RET] execute cell                 [u] change cell type
 
         [C-o]: open console                [t] toggle output
         [C-l,C-S-L] clear/clear all output
@@ -51,6 +52,63 @@
         (interactive)
         (setq spacemacs--ipython-notebook-ms-doc-toggle
               (logxor spacemacs--ipython-notebook-ms-doc-toggle 1)))
+
+      (defun spacemacs//concat-leader (key)
+        (if dotspacemacs-major-mode-leader-key
+            (concat dotspacemacs-major-mode-leader-key key)
+            (concat "," key)
+        ))
+
+      (evil-leader/set-key-for-mode 'ein:notebook-multilang-mode
+        "my" 'ein:worksheet-copy-cell
+        "mp" 'ein:worksheet-yank-cell
+        "md" 'ein:worksheet-kill-cell
+        "mh" 'ein:notebook-worksheet-open-prev-or-last
+        "mj" 'ein:worksheet-goto-next-input
+        "mk" 'ein:worksheet-goto-prev-input
+        "ml" 'ein:notebook-worksheet-open-next-or-first
+        "mH" 'ein:notebook-worksheet-move-prev
+        "mJ" 'ein:worksheet-move-cell-down
+        "mK" 'ein:worksheet-move-cell-up
+        "mL" 'ein:notebook-worksheet-move-next
+        "mt" 'ein:worksheet-toggle-output
+        "mR" 'ein:worksheet-rename-sheet
+        "mo" 'ein:worksheet-insert-cell-below
+        "mO" 'ein:worksheet-insert-cell-above
+        "m RET" 'ein:worksheet-execute-cell-and-goto-next
+        ;; Output
+        "m C-l" 'ein:worksheet-clear-output
+        "m C-S-l" 'ein:worksheet-clear-all-output
+        ;;Console
+        "m C-o" 'ein:console-open
+        ;; Merge cells
+        "m C-k" 'ein:worksheet-merge-cell
+        "m C-j" 'spacemacs/ein:worksheet-merge-cell-next
+        ;; Notebook
+        "m C-s" 'ein:notebook-save-notebook-command
+        "m C-r" 'ein:notebook-rename-command
+        "m1" 'ein:notebook-worksheet-open-1th
+        "m2" 'ein:notebook-worksheet-open-2th
+        "m3" 'ein:notebook-worksheet-open-3th
+        "m4" 'ein:notebook-worksheet-open-4th
+        "m5" 'ein:notebook-worksheet-open-5th
+        "m6" 'ein:notebook-worksheet-open-6th
+        "m7" 'ein:notebook-worksheet-open-7th
+        "m8" 'ein:notebook-worksheet-open-8th
+        "m9" 'ein:notebook-worksheet-open-last
+        "m+" 'ein:notebook-worksheet-insert-next
+        "m-" 'ein:notebook-worksheet-delete
+        "mx" 'ein:notebook-close
+        "mu" 'ein:worksheet-change-cell-type)
+
+      (evil-define-key 'normal ein:notebook-multilang-mode-map
+        "gj" 'ein:worksheet-goto-next-input
+        "gk" 'ein:worksheet-goto-prev-input)
+
+      ;; if this is not required then the following keygindings fail
+      (require 'ein-multilang)
+      (define-key ein:notebook-multilang-mode-map (kbd "M-j") 'ein:worksheet-move-cell-down)
+      (define-key ein:notebook-multilang-mode-map (kbd "M-k") 'ein:worksheet-move-cell-up)
 
       (spacemacs|define-micro-state ipython-notebook
         :doc (spacemacs//ipython-notebook-ms-doc)
@@ -74,6 +132,7 @@
         ("p" ein:worksheet-yank-cell)
         ("o" ein:worksheet-insert-cell-below)
         ("O" ein:worksheet-insert-cell-above)
+        ("u" ein:worksheet-change-cell-type)
         ("RET" ein:worksheet-execute-cell-and-goto-next)
         ;; Output
         ("C-l" ein:worksheet-clear-output)


### PR DESCRIPTION
@CestDiego I've moved the keybindings to the major mode leader and did not have any problems. Could you please test?

I think working with the leader is way faster than the micro-state.

If this works for you and you agree then I'll update the Readme and we can remove the micro state?

This also adds movement between cells with `gj` and `gk` in normal mode and movement of cells with `M-j` and `M-k`