### PR TITLE
Enhance Org viewing experienced with SPC f e h

### DIFF
--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -94,15 +94,18 @@
 (defun helm-spacemacs//documentation-action-open-file (candidate)
   "Open documentation FILE."
   (let ((file (concat spacemacs-docs-directory candidate)))
-    (if (and (equal (file-name-extension file) "md")
-             (not helm-current-prefix-arg))
-        (condition-case nil
-            (with-current-buffer (find-file-noselect file)
-              (gh-md-render-buffer)
-              (kill-this-buffer))
-          ;; if anything fails, fall back to simply open file
-          (find-file file))
-      (find-file file))))
+    (cond ((and (equal (file-name-extension file) "md")
+                (not helm-current-prefix-arg))
+           (condition-case nil
+               (with-current-buffer (find-file-noselect file)
+                 (gh-md-render-buffer)
+                 (kill-this-buffer))
+             ;; if anything fails, fall back to simply open file
+             (find-file file)))
+          ((equal (file-name-extension file) "org")
+           (spacemacs/open-file file "^"))
+          (t
+           (find-file file)))))
 
 (defun helm-spacemacs//layer-source ()
   "Construct the helm source for the layer section."


### PR DESCRIPTION
Reuse spacemacs/open-file that is used for viewing the Change Log when
the opened file is an Org file. It means the following things:

- The document is in `view-mode` just for reading, as it should be, so
user won't mess things up while reading their doc.

- After PR #1902 is merged, it enhances reading experience.