### PR TITLE
Change VIMUSERS first headline to use toc-org package

### DIFF
--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -1,4 +1,4 @@
-* Migrating from vim
+* Migrating from vim                                                    :TOC@4:
  - [[#purpose-of-this-document][Purpose of this document]]
  - [[#philosophy][Philosophy]]
  - [[#basic-orientation][Basic orientation]]


### PR DESCRIPTION
As this includes 4 levels of headings, the tag that needs to be used is
:TOC@4:. Now every time one saves this file, the TOC is automatically
generated. There is an interesting feature from toc-org that enables
users to use org links or GitHub enabled
[links](https://github.com/snosov1/toc-org#use)
 we should discuss how to use it because on one hand, having org links
 makes it easier to read in emacs, while having GitHub links makes it
 easier to read online.