### PR TITLE
Give titles for documents in SPC f e h

### DIFF
--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -80,16 +80,37 @@
 
 (defun helm-spacemacs//documentation-source ()
   "Construct the helm source for the documentation section."
-  `((name . "Documentation")
-    (candidates . ,(helm-spacemacs//documentation-candidates))
-    (candidate-number-limit)
-    (action . (("Open documentation" . helm-spacemacs//documentation-action-open-file)))))
+  (helm-build-sync-source "Helm Spacemacs Documentation"
+    :candidates #'helm-spacemacs//documentation-candidates
+    :persistent-action #'helm-spacemacs//documentation-action-open-file
+    :keymap helm-map
+    :action (helm-make-actions
+             "Open Documentation" #'helm-spacemacs//documentation-action-open-file)))
 
 (defun helm-spacemacs//documentation-candidates ()
   (let (result)
     (dolist (file-path (f-files spacemacs-docs-directory))
       (push (f-relative file-path spacemacs-docs-directory) result))
-    (sort result 'string<)))
+    ;; delete DOCUMENTATION.md to make it the first guide
+    (delete "DOCUMENTATION.md" result)
+    (push "DOCUMENTATION.md" result)
+
+    ;; give each document an appropriate title
+    (mapcar (lambda (r)
+              (cond
+               ((string-equal r "CONTRIBUTE.md")
+                `("How to contribute to Spacemacs" . ,r))
+               ((string-equal r "CONVENTIONS.md")
+                `("Spacemacs conventions" . ,r))
+               ((string-equal r "DOCUMENTATION.md")
+                `("Spacemacs starter guide" . ,r))
+               ((string-equal r "HOWTOs.md")
+                `("Quick HOW-TOs for Spacemacs" . ,r))
+               ((string-equal r "VIMUSERS.org")
+                `("Vim users migration guide" . ,r))
+               (t
+                `(r . ,r))))
+            result)))
 
 (defun helm-spacemacs//documentation-action-open-file (candidate)
   "Open documentation FILE."


### PR DESCRIPTION
Since Helm can candidates can also be a alist of '(DISPLAY . REAL),
where DISPLAY is the text to be displayed for a candidate when it is
listed and REAL is the actual object DISPLAY is presenting, we can use
this feature to give appropriate document titles instead of using raw
file names.

Also, we do not need to sort the file list getting from the doc/
directory just reverse the list.