### PR TITLE
Fix config loading for google-translate

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1237,18 +1237,17 @@ Example: (evil-map visual \"<\" \"<gv\")"
                google-translate-query-translate-reverse
                google-translate-at-point-reverse)
     :init
-    (evil-leader/set-key
-      "xgQ" 'google-translate-query-translate-reverse
-      "xgq" 'google-translate-query-translate
-      "xgT" 'google-translate-at-point-reverse
-      "xgt" 'google-translate-at-point)
-    :config
     (progn
       (require 'google-translate-default-ui)
       (setq google-translate-enable-ido-completion t)
       (setq google-translate-show-phonetic t)
       (setq google-translate-default-source-language "En")
-      (setq google-translate-default-target-language "Fr"))))
+      (setq google-translate-default-target-language "Fr")
+      (evil-leader/set-key
+        "xgQ" 'google-translate-query-translate-reverse
+        "xgq" 'google-translate-query-translate
+        "xgT" 'google-translate-at-point-reverse
+        "xgt" 'google-translate-at-point))))
 
 (defun spacemacs/init-guide-key-tip ()
   (use-package guide-key-tip


### PR DESCRIPTION
Previously, :config was not being loaded.