### PR TITLE
ocaml: don't auto-close backticks

### DIFF
--- a/contrib/!lang/ocaml/packages.el
+++ b/contrib/!lang/ocaml/packages.el
@@ -95,8 +95,9 @@
         "mcc" 'compile))
     :config
     (when (fboundp 'sp-local-pair)
-      ;; don't auto-close apostrophes (type 'a = foo)
-      (sp-local-pair 'tuareg-mode "'" nil :actions nil))))
+      ;; don't auto-close apostrophes (type 'a = foo) and backticks (`Foo)
+      (sp-local-pair 'tuareg-mode "'" nil :actions nil)
+      (sp-local-pair 'tuareg-mode "`" nil :actions nil))))
 
 (defun ocaml/init-utop ()
   (use-package utop


### PR DESCRIPTION
They are used for polymorphic variants, like `Foo