### PR TITLE
Improve Helm Spacemac Documentation further

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -109,16 +109,25 @@ Supported properties:
         (dolist (val ',def-key)
           (define-key (eval (car val)) (kbd (cdr val)) ',func))))))
 
-(defun spacemacs/open-file (file anchor-text)
+(defun spacemacs/view-org-file (file &optional anchor-text expand-scope)
   "Open the change log for the current version."
   (interactive)
   (find-file file)
   (org-indent-mode)
   (view-mode)
   (goto-char (point-min))
-  (re-search-forward anchor-text)
+
+  (when anchor-text
+    (re-search-forward anchor-text))
   (beginning-of-line)
-  (show-subtree)
+
+  (cond
+   ((eq expand-scope 'subtree)
+    (show-subtree))
+   ((eq expand-scope 'all)
+    (show-all))
+   (t nil))
+
   (setq-local org-emphasis-alist '(("*" bold)
                                    ("/" italic)
                                    ("_" underline)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -221,9 +221,10 @@ If TYPE is nil, just remove widgets."
                                                    :tag (propertize "Click here for full change log" 'face 'font-lock-warning-face)
                                                    :help-echo "Open the full change log."
                                                    :action (lambda (&rest ignore)
-                                                             (funcall 'spacemacs/open-file
+                                                             (funcall 'spacemacs/view-org-file
                                                                       (concat user-emacs-directory "CHANGELOG.org")
-                                                                      "Release 0.103.x"))
+                                                                      "Release 0.103.x"
+                                                                      'subtree))
                                                    :mouse-face 'highlight
                                                    :follow-link "\C-m")))))
     (spacemacs-buffer//insert-note file

--- a/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
+++ b/spacemacs/extensions/helm-spacemacs/helm-spacemacs.el
@@ -88,9 +88,12 @@
              "Open Documentation" #'helm-spacemacs//documentation-action-open-file)))
 
 (defun helm-spacemacs//documentation-candidates ()
-  (let (result)
+  (let (result file-extension)
     (dolist (file-path (f-files spacemacs-docs-directory))
-      (push (f-relative file-path spacemacs-docs-directory) result))
+      (setq file-extension (file-name-extension file-path))
+      (when (or (equal file-extension "md")
+                (equal file-extension "org"))
+        (push (f-relative file-path spacemacs-docs-directory) result)))
     ;; delete DOCUMENTATION.md to make it the first guide
     (delete "DOCUMENTATION.md" result)
     (push "DOCUMENTATION.md" result)
@@ -124,7 +127,7 @@
              ;; if anything fails, fall back to simply open file
              (find-file file)))
           ((equal (file-name-extension file) "org")
-           (spacemacs/open-file file "^"))
+           (spacemacs/view-org-file file "^" 'all))
           (t
            (find-file file)))))
 


### PR DESCRIPTION
Refactor spacemacs/open-file to spacemacs/view-org-file to correctly
reflect its functionality. In Emacs, view means read-only. Make the
anchor-text optional so we can omit when not needed. Also add
expand-scope that can be either 'subtree or 'all to open a tree at point
or expand everything. 'subtree is used for the Change Log while 'all is
used for all Spacemacs documents.

Currently helm-spacemacs//documentation-candidates grabs everything it
can in the doc directory. In the future we might put some images there
so better just choose the correct file type to include.