### PR TITLE
add Stan modeling language to extra-langs

### DIFF
--- a/contrib/!lang/extra-langs/README.md
+++ b/contrib/!lang/extra-langs/README.md
@@ -8,6 +8,7 @@ These include:
 - Nix Expressions
 - Nim
 - QML
+- Stan
 - YAML
 - Rust
 - The Wolfram Language / Mathematica

--- a/contrib/!lang/extra-langs/packages.el
+++ b/contrib/!lang/extra-langs/packages.el
@@ -8,6 +8,7 @@
     nix-mode
     qml-mode
     scad-mode
+    stan-mode
     wolfram-mode
     yaml-mode
     ))
@@ -35,6 +36,9 @@
 
 (defun extra-langs/init-matlab-mode ()
   (use-package matlab-mode :defer t))
+
+(defun extra-langs/init-stan-mode ()
+  (use-package stan-mode :defer t))
 
 (defun extra-langs/init-yaml-mode ()
   (use-package yaml-mode :defer t))


### PR DESCRIPTION
Stan is a probabilistic programming language for Bayesian statistical
inference which interfaces with R, python, Julia and Matlab.