### PR TITLE
Fix to allow ~SPC ,~ and others as such to be rendered

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -54,7 +54,6 @@
       (setq org-startup-indented t)
       (let ((dir (configuration-layer/get-layer-property 'org :dir)))
         (setq org-export-async-init-file (concat dir "org-async-init.el")))
-
       (defmacro spacemacs|org-emphasize (fname char)
         "Make function for setting the emphasis in org mode"
         `(defun ,fname () (interactive)
@@ -127,6 +126,12 @@ Will work on both org-mode and any mode that accepts plain html."
                     (1 font-lock-comment-face prepend)
                     (2 font-lock-function-name-face)
                     (3 font-lock-comment-face prepend))))
+
+      ;; Make ~SPC ,~ work, reference:
+      ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
+      (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
+      (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
+
       (require 'org-indent)
       (define-key global-map "\C-cl" 'org-store-link)
       (define-key global-map "\C-ca" 'org-agenda)


### PR DESCRIPTION
Fix found by @tuhdo 