### PR TITLE
Remove `gc` prefix as unused from guide-key

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -26,7 +26,6 @@
                                        ("f" .  "files")
                                        ("fe" . "files-emacs/spacemacs")
                                        ("g" .  "git/versions-control")
-                                       ("gc" . "smeargle")
                                        ("h" .  "helm/help/highlight")
                                        ("hd" . "help-describe")
                                        ("i" .  "insertion")


### PR DESCRIPTION
smeargle commands are no longer there, they're in `gh`