### PR TITLE
diminish ycmd lighter in mode line

### DIFF
--- a/contrib/!tools/ycmd/packages.el
+++ b/contrib/!tools/ycmd/packages.el
@@ -29,4 +29,6 @@
     :init
     (unless (boundp 'ycmd-global-config)
       (let ((dir (configuration-layer/get-layer-property 'ycmd :dir)))
-        (setq-default ycmd-global-config (concat dir "global_conf.py"))))))
+        (setq-default ycmd-global-config (concat dir "global_conf.py"))))
+    :config
+    (spacemacs|hide-lighter ycmd-mode)))


### PR DESCRIPTION
I like the beautiful UI in spacemacs, but the `ycmd` lighter seems strange compared to the existing unicode lighter. 