### PR TITLE
(PUPPET) Add Puppetfile support

### DIFF
--- a/contrib/!config/puppet/README.org
+++ b/contrib/!config/puppet/README.org
@@ -11,6 +11,10 @@
 
 This layer aims at providing support for the Puppet DSL using [[https://github.com/lunaryorn/puppet-mode][puppet-mode]].
 
+* Features
+
+Puppetfile support via [[http://melpa.org/#/puppetfile-mode][puppetfile-mode]]
+
 * Install
 
 To use this contribution add it to your =~/.spacemacs=

--- a/contrib/!config/puppet/packages.el
+++ b/contrib/!config/puppet/packages.el
@@ -1,7 +1,7 @@
 (setq puppet-packages
   '(
-    ;; package puppets go here
     puppet-mode
+    puppetfile-mode
     company
     ))
 
@@ -36,3 +36,7 @@
 
 (defun puppet/post-init-company ()
   (spacemacs|add-company-hook puppet-mode))
+
+(defun puppet/init-puppetfile-mode ()
+  (use-package puppetfile-mode
+    :defer t))


### PR DESCRIPTION
This commit enables syntax highlighting for Puppetfiles via the
puppetfile-mode package.

A Puppetfile is the configuration file used by librarian-puppet and
r10k for Puppet module management a la Ruby's Bundler.