### PR TITLE
osx: allow skipping `option` to `meta` key mapping

### DIFF
--- a/contrib/osx/README.org
+++ b/contrib/osx/README.org
@@ -36,6 +36,17 @@ To use this configuration layer, add it to your =~/.spacemacs=
   (setq-default dotspacemacs-configuration-layers '(osx))
 #+END_SRC
 
+*** Use with non-US keyboard layouts
+
+If you need the ~⌥~ key to type common characters such as `{[]}~` which is usual
+for e.g. Finnish and Swedish keyboard layouts, you'll probably want to leave the
+~⌥~ key unchanged by setting the =osx-use-option-as-meta= variable to =nil=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+     (osx :variables osx-use-option-as-meta nil)))
+#+END_SRC
+
 ** Coreutils
 
 To get =gls= install coreutils homebrew:

--- a/contrib/osx/config.el
+++ b/contrib/osx/config.el
@@ -1,0 +1,3 @@
+(defvar osx-use-option-as-meta t
+  "If non nil the option key is mapped to meta. Set to `nil` if you need the
+  option key to type common characters.")

--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -3,11 +3,14 @@
 
   ;; this is only applicable to GUI mode
   (when (display-graphic-p)
-    ;; Treat option as meta and command as super
-    (setq mac-option-key-is-meta t)
+    ;; Treat command as super
     (setq mac-command-key-is-meta nil)
     (setq mac-command-modifier 'super)
-    (setq mac-option-modifier 'meta)
+
+    (when osx-use-option-as-meta
+      ;; Treat option as meta
+      (setq mac-option-key-is-meta t)
+      (setq mac-option-modifier 'meta))
 
     ;; Keybindings
     (global-set-key (kbd "s-=") 'spacemacs/scale-up-font)


### PR DESCRIPTION
In Finnish/Swedish/other keyboard layouts the `option` key is needed to
type some common characters such as `{[]}~` (#973) so make mapping it to
`meta` conditional.