### PR TITLE
Move org-emphasis-regexp-components to spacemacs/view-org-file

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -127,11 +127,6 @@ Will work on both org-mode and any mode that accepts plain html."
                     (2 font-lock-function-name-face)
                     (3 font-lock-comment-face prepend))))
 
-      ;; Make ~SPC ,~ work, reference:
-      ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
-      (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
-      (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
-
       (require 'org-indent)
       (define-key global-map "\C-cl" 'org-store-link)
       (define-key global-map "\C-ca" 'org-agenda)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -128,6 +128,11 @@ Supported properties:
     (show-all))
    (t nil))
 
+  ;; Make ~SPC ,~ work, reference:
+  ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
+  (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
+  (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
+
   (setq-local org-emphasis-alist '(("*" bold)
                                    ("/" italic)
                                    ("_" underline)


### PR DESCRIPTION
If we put this in Org layer, new users won't have that layer and thus
this fix will not be applied.