### PR TITLE
Change s-v binding from evil-paste-after to evil-paste-before

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -14,7 +14,7 @@
     (global-set-key (kbd "s--") 'spacemacs/scale-down-font)
     (global-set-key (kbd "s-0") 'spacemacs/reset-font-size)
     (global-set-key (kbd "s-q") 'save-buffers-kill-terminal)
-    (global-set-key (kbd "s-v") 'evil-paste-after)
+    (global-set-key (kbd "s-v") 'evil-paste-before)
     (global-set-key (kbd "s-c") 'evil-yank)
     (global-set-key (kbd "s-a") 'mark-whole-buffer)
     (global-set-key (kbd "s-x") 'kill-region)


### PR DESCRIPTION
Hi, this is a simple change, but I think it makes sense. When in normal mode, <kbd>p</kbd> is simpler than <kbd>s-v</kbd> to press. The only time you would <kbd>s-v</kbd> is while typing, in insert mode. In insert mode, `evil-paste-after` gives completely unexpected behaviour. This is especially noticeable when making edits and pasting together.