### PR TITLE
Correct s-v keybinding with `yank`

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -14,7 +14,7 @@
     (global-set-key (kbd "s--") 'spacemacs/scale-down-font)
     (global-set-key (kbd "s-0") 'spacemacs/reset-font-size)
     (global-set-key (kbd "s-q") 'save-buffers-kill-terminal)
-    (global-set-key (kbd "s-v") 'evil-paste-before)
+    (global-set-key (kbd "s-v") 'yank)
     (global-set-key (kbd "s-c") 'evil-yank)
     (global-set-key (kbd "s-a") 'mark-whole-buffer)
     (global-set-key (kbd "s-x") 'kill-region)


### PR DESCRIPTION
Correction to https://github.com/syl20bnr/spacemacs/pull/1972#issuecomment-111796588. Sorry for the mistake!