### PR TITLE
new sr-speedbar layer for !tools

### DIFF
--- a/contrib/!tools/sr-speedbar/README.org
+++ b/contrib/!tools/sr-speedbar/README.org
@@ -6,7 +6,6 @@
      - [[#layer][Layer]]
      - [[#sr-speedbar][sr-speedbar]]
  - [[#usage][Usage]]
- - [[#key-bindings][Key Bindings]]
 
 * Description
 

--- a/contrib/!tools/sr-speedbar/README.org
+++ b/contrib/!tools/sr-speedbar/README.org
@@ -22,4 +22,4 @@ To use this contribution add it to your =~/.spacemacs=
 
 * Usage
 
-M-x sr-speedbar-show-or-hide
+M-x spacemacs/sr-speedbar-show-or-hide

--- a/contrib/!tools/sr-speedbar/README.org
+++ b/contrib/!tools/sr-speedbar/README.org
@@ -1,0 +1,31 @@
+#+TITLE: sr-speedbar contribution layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#install][Install]]
+     - [[#layer][Layer]]
+     - [[#sr-speedbar][sr-speedbar]]
+ - [[#usage][Usage]]
+ - [[#key-bindings][Key Bindings]]
+
+* Description
+
+sr-speedbar is mode make SpeedBar show in Current Frame.
+
+* Install
+
+** Layer
+
+To use this contribution add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(sr-speedbar))
+#+END_SRC
+
+** sr-speedbar
+
+To use the mode please [[http://pandoc.org/installing.html][install]] pandoc first.
+
+* Usage
+
+M-x sr-speedbar-show-or-hide

--- a/contrib/!tools/sr-speedbar/README.org
+++ b/contrib/!tools/sr-speedbar/README.org
@@ -4,7 +4,6 @@
  - [[#description][Description]]
  - [[#install][Install]]
      - [[#layer][Layer]]
-     - [[#sr-speedbar][sr-speedbar]]
  - [[#usage][Usage]]
 
 * Description
@@ -20,10 +19,6 @@ To use this contribution add it to your =~/.spacemacs=
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(sr-speedbar))
 #+END_SRC
-
-** sr-speedbar
-
-To use the mode please [[http://pandoc.org/installing.html][install]] pandoc first.
 
 * Usage
 

--- a/contrib/!tools/sr-speedbar/packages.el
+++ b/contrib/!tools/sr-speedbar/packages.el
@@ -14,7 +14,7 @@
   '(sr-speedbar))
 
 (defun sr-speedbar/post-init-sr-speedbar ()
-  (defun sr-speedbar-show-or-hide ()
+  (defun spacemacs/sr-speedbar-show-or-hide ()
     (interactive)
     (cond ((sr-speedbar-exist-p) (kill-buffer speedbar-buffer))
           (t (sr-speedbar-open) (linum-mode -1) (speedbar-refresh)))))

--- a/contrib/!tools/sr-speedbar/packages.el
+++ b/contrib/!tools/sr-speedbar/packages.el
@@ -1,0 +1,26 @@
+;;; packages.el --- sr-speedbar Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: wsk <tshemeng@live.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq sr-speedbar-packages
+  '(sr-speedbar))
+
+(defun sr-speedbar/post-init-sr-speedbar ()
+  (defun sr-speedbar-show-or-hide ()
+    (interactive)
+    (cond ((sr-speedbar-exist-p) (kill-buffer speedbar-buffer))
+          (t (sr-speedbar-open) (linum-mode -1) (speedbar-refresh)))))
+
+(defun sr-speedbar/init-sr-speedbar ()
+  (use-package sr-speedbar
+    :init
+    (setq sr-speedbar-width 30)
+    (setq sr-speedbar-right-side nil)))


### PR DESCRIPTION
cause `spacemacs` already include `neotree`, so i leave the function `spacemacs/sr-speedbar-show-or-hide` for users' to binding.