### PR TITLE
google translate config tweaks

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1237,18 +1237,17 @@ Example: (evil-map visual \"<\" \"<gv\")"
                google-translate-query-translate-reverse
                google-translate-at-point-reverse)
     :init
-    (evil-leader/set-key
-      "xgQ" 'google-translate-query-translate-reverse
-      "xgq" 'google-translate-query-translate
-      "xgT" 'google-translate-at-point-reverse
-      "xgt" 'google-translate-at-point)
-    :config
     (progn
       (require 'google-translate-default-ui)
       (setq google-translate-enable-ido-completion t)
       (setq google-translate-show-phonetic t)
       (setq google-translate-default-source-language "En")
-      (setq google-translate-default-target-language "Fr"))))
+      (setq google-translate-default-target-language "Fr")
+      (evil-leader/set-key
+        "xgQ" 'google-translate-query-translate-reverse
+        "xgq" 'google-translate-query-translate
+        "xgT" 'google-translate-at-point-reverse
+        "xgt" 'google-translate-at-point))))
 
 (defun spacemacs/init-guide-key-tip ()
   (use-package guide-key-tip


### PR DESCRIPTION
1. some `(setq ...)` settings were not being loaded, moved them under `:init` to ensure loading
2. Mange `google-translate` window with popwin, to keep consistent behaviour and appearance
3. Change default languages from "En" and "Fr" to "Auto" and "En" (more useful for most people)