### PR TITLE
mwe-log-commands

### DIFF
--- a/contrib/!tools/mwe-log-commands/README.org
+++ b/contrib/!tools/mwe-log-commands/README.org
@@ -1,0 +1,26 @@
+#+TITLE: mwe-log-commands contribution layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#install][Install]]
+     - [[#layer][Layer]]
+     - [[#mwe-log-commands][mwe-log-commands]]
+ - [[#usage][Usage]]
+
+* Description
+
+mwe-log-commands can be used to demo Emacs to an audience. When activated, keystrokes get logged into a designated buffer, along with the command bound to them.
+
+* Install
+
+** Layer
+
+To use this contribution add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(mwe-log-commands))
+#+END_SRC
+
+* Usage
+
+M-x spacemacs/mwe-log-commands

--- a/contrib/!tools/mwe-log-commands/packages.el
+++ b/contrib/!tools/mwe-log-commands/packages.el
@@ -1,0 +1,44 @@
+;;; packages.el --- mwe-log-commands Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: blinkd <tshemeng@live.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq mwe-log-commands-packages
+    '(mwe-log-commands))
+
+(defun mwe-log-commands/post-init-mwe-log-commands ()
+  (defun spacemacs/mwe-log-commands ()
+    (interactive)
+    (let ((current-buffer (current-buffer)))
+      (mwe:log-keyboard-commands t)
+      (mwe:open-command-log-buffer)
+      (erase-buffer)
+      (linum-mode -1)
+      (delete-other-windows)
+      (split-window-horizontally -30)
+      (other-window 0)
+      (switch-to-buffer current-buffer)))
+
+  (define-minor-mode mwe-log-commands-mode
+    "log commands")
+
+  (defun mwe-log-commands-on ()
+    (unless (minibufferp)
+      (mwe:log-keyboard-commands t)))
+
+  (define-globalized-minor-mode global-mwe-log-commands-mode mwe-log-commands-mode mwe-log-commands-on)
+  (global-mwe-log-commands-mode))
+
+(defun mwe-log-commands/init-mwe-log-commands ()
+  "Initialize my package"
+  (use-package mwe-log-commands)
+  :defer t
+  :init
+  (add-hook 'spacemacs-mode-hook (function mwe:log-keyboard-commands)))


### PR DESCRIPTION
mwe-log-commands by MichaelWeber can be used to demo Emacs to an audience. When activated, keystrokes get logged into a designated buffer, along with the command bound to them.

i define a global minor mode for `mwe-log-commands` package, so that function `spacemacs/mwe-log-commands` can track all actions in emacs.
