### PR TITLE
[core]dotspacemacs-excluded-layers

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -338,7 +338,10 @@ the following keys:
 
 (defun configuration-layer/load-layers ()
   "Load all declared layers."
-  (let ((layers (reverse configuration-layer-layers)))
+  (let ((layers (reverse (remove-if
+                          #'(lambda (layer)
+                              (cl-member (car layer) dotspacemacs-excluded-layers))
+                          configuration-layer-layers))))
     (configuration-layer//set-layers-variables layers)
     ;; first load the config files then the package files
     (configuration-layer//load-layers-files layers '("funcs.el" "config.el"))

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -159,6 +159,9 @@ Possible values are: `recents' `bookmarks' `projects'.")
 (defvar dotspacemacs-excluded-packages '()
   "A list of packages and/or extensions that will not be install and loaded.")
 
+(defvar dotspacemacs-excluded-layers '()
+  "A list of layers that will not be loaded.")
+
 ;; only for backward compatibility
 (defalias 'dotspacemacs-mode 'emacs-lisp-mode)
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -36,6 +36,8 @@
    dotspacemacs-additional-packages '()
    ;; A list of packages and/or extensions that will not be install and loaded.
    dotspacemacs-excluded-packages '()
+   ;; A list of layers that will not be loaded.
+   dotspacemacs-excluded-layers '()
    ;; If non-nil spacemacs will delete any orphan packages, i.e. packages that
    ;; are declared in a layer which is not a member of
    ;; the list `dotspacemacs-configuration-layers'


### PR DESCRIPTION
new variable `dotspacemacs-excluded-layers` for spacemacs core, it is useful when user set `dotspacemacs-configuration-layers` to `'all` but want to disable some layers(still installed but not load).
