### PR TITLE
add ipython keybindings

### DIFF
--- a/contrib/!lang/ipython-notebook/README.org
+++ b/contrib/!lang/ipython-notebook/README.org
@@ -15,6 +15,8 @@
      - [[#open-notebook-list][Open Notebook List]]
      - [[#key-bindings][Key Bindings]]
          - [[#micro-state-ipython-notebook-][Micro-state: =ipython-notebook= ]]
+         - [[#normal-mode][Normal mode]]
+         - [[#insert-mode][Insert mode]]
  - [[#screenshots][Screenshots]]
      - [[#light][Light]]
      - [[#dark][Dark]]
@@ -104,6 +106,27 @@ prefix with ~SPC m~ to use with your evil-leader.
 | ~+~     | ein:notebook-worksheet-insert-next        |
 | ~-~     | ein:notebook-worksheet-delete             |
 | ~x~     | ein:notebook-close                        |
+
+*** Normal mode
+In normal mode the following key bindings are defined:
+
+| Key     | Function                                 |
+|---------+------------------------------------------|
+| ~gj~    | ein:worksheet-goto-next-input            |
+| ~gk~    | ein:worksheet-goto-prev-input            |
+| ~C-RET~ | ein:worksheet-execute-cell               |
+| ~S-RET~ | ein:worksheet-execute-cell-and-goto-next |
+
+Also ~SPC f w~ saves the notebook like you would a regular buffer.
+
+*** Insert mode
+In normal mode the following key bindings are defined:
+
+| Key     | Function                                 |
+|---------+------------------------------------------|
+| ~C-RET~ | ein:worksheet-execute-cell               |
+| ~S-RET~ | ein:worksheet-execute-cell-and-goto-next |
+
 * Screenshots
 ** Light
 [[file:img/light.png]]

--- a/contrib/!lang/ipython-notebook/packages.el
+++ b/contrib/!lang/ipython-notebook/packages.el
@@ -99,9 +99,18 @@
         "m+" 'ein:notebook-worksheet-insert-next
         "m-" 'ein:notebook-worksheet-delete
         "mx" 'ein:notebook-close
-        "mu" 'ein:worksheet-change-cell-type)
+        "mu" 'ein:worksheet-change-cell-type
+        "fw" 'ein:notebook-save-notebook-command)
+
+      ;; keybindings mirror ipython web interface behavior
+      (evil-define-key 'insert ein:notebook-multilang-mode-map
+        (kbd "<C-return>") 'ein:worksheet-execute-cell
+        (kbd "<S-return>") 'ein:worksheet-execute-cell-and-goto-next)
 
       (evil-define-key 'normal ein:notebook-multilang-mode-map
+        ;; keybindings mirror ipython web interface behavior
+        (kbd "<C-return>") 'ein:worksheet-execute-cell
+        (kbd "<S-return>") 'ein:worksheet-execute-cell-and-goto-next
         "gj" 'ein:worksheet-goto-next-input
         "gk" 'ein:worksheet-goto-prev-input)
 


### PR DESCRIPTION
- `C-return` and `S-return` behave like web interface
- bind `SPC f w` to save the notebook to be consistent with
  the rest of spacemacs