### PR TITLE
Show images by default in org-mode

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -47,6 +47,7 @@
     :init
     (progn
       (setq org-log-done t
+            org-startup-with-inline-images t
             org-src-fontify-natively t)
 
       (eval-after-load 'org-indent


### PR DESCRIPTION
To have org-document show as

[![alt](http://i.imgur.com/5eMPROR.png)](http://i.imgur.com/5eMPROR.png)

