### PR TITLE
Add 'git diff' leader key alias

### DIFF
--- a/contrib/!tools/git/packages.el
+++ b/contrib/!tools/git/packages.el
@@ -239,6 +239,7 @@
         "gb" 'magit-blame-mode
         "gl" 'magit-log
         "gs" 'magit-status
+        "gd" #'(lambda () (interactive) (magit-diff "HEAD"))
         "gC" 'magit-commit)
       (evilify magit-commit-mode magit-commit-mode-map
                (kbd "C-j") 'magit-goto-next-section


### PR DESCRIPTION
This allows `<leader>gd` to perform the equivalent of a `git diff` (ie, compare currently un-staged changes with HEAD).