### PR TITLE
move org-clock-save.el to .cache

### DIFF
--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -31,7 +31,7 @@
     (progn
       (evil-leader/set-key-for-mode 'org-mode
            "a" nil "ma" 'org-agenda
-           "b" nil "mb" 'org-tree-to-indirect-buffer 
+           "b" nil "mb" 'org-tree-to-indirect-buffer
            "c" nil "mA" 'org-archive-subtree
            "o" nil "mC" 'evil-org-recompute-clocks
            "l" nil "mo" 'evil-org-open-links
@@ -46,6 +46,7 @@
     :defer t
     :init
     (progn
+      (setq org-clock-persist-file (concat spacemacs-cache-directory "org-clock-save.el"))
       (setq org-log-done t
             org-startup-with-inline-images t
             org-src-fontify-natively t)


### PR DESCRIPTION
when clocking an action in org-mode,it will create file `org-clock-save.el` in `.emacs.d/`by default, this PR move it to ` spacemacs-cache-directory`.