### PR TITLE
Rust:  Use compile instead of shell for cargo.

### DIFF
--- a/contrib/!lang/rust/README.org
+++ b/contrib/!lang/rust/README.org
@@ -11,9 +11,9 @@
 
 * Description
 
-This layer aims to support [[http://www.rust-lang.org/][Rust]] development in Spacemacs.
-
-For now only basic support for [[http://doc.crates.io/index.html][Cargo]] is provided.
+This layer aims to support [[http://www.rust-lang.org/][Rust]] development in Spacemacs.  It supports [[http://doc.crates.io/index.html][Cargo]],
+and has some basic auto-completion support through [[https://github.com/phildawes/racer][Racer]], though Racer needs
+some additional configurations as described on their page.
 
 * Install
 
@@ -32,8 +32,9 @@ instructions can be found on the main page of [[http://doc.crates.io/index.html]
 
 * Key bindings
 
-| Key Binding | Description                            |
-|-------------+----------------------------------------|
-| ~SPC m c c~ | compile project with Cargo             |
-| ~SPC m c x~ | compile and execute project with Cargo |
-| ~SPC m t a~ | execute all tests with Cargo           |
+| Key Binding | Description                       |
+|-------------+-----------------------------------|
+| ~SPC m c c~ | compile project with Cargo        |
+| ~SPC m c C~ | execute the project with Cargo    |
+| ~SPC m c t~ | run tests with Cargo              |
+| ~SPC m c d~ | generate documentation with Cargo |

--- a/contrib/!lang/rust/config.el
+++ b/contrib/!lang/rust/config.el
@@ -1,0 +1,20 @@
+;;; config.el --- Rust Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+
+;; Author: Chris Hoeppner <me@mkaito.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+;; Define the buffer local company backend variable
+(spacemacs|defvar-company-backends rust-mode)
+
+(defvar rust-enable-racer nil
+  "If non-nil, load the racer package (this has an external dependency).")

--- a/contrib/!lang/rust/funcs.el
+++ b/contrib/!lang/rust/funcs.el
@@ -1,0 +1,28 @@
+;;; funcs.el --- Rust Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2015 Chris Hoeppner & Contributors
+;;
+;; Author: Chris Hoeppner <me@mkaito.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; http://doc.crates.io/guide.html
+(defun spacemacs/rust-cargo-build ()
+  (interactive)
+  (compile "cargo build"))
+
+(defun spacemacs/rust-cargo-run ()
+  (interactive)
+  (compile "cargo run"))
+
+(defun spacemacs/rust-cargo-test ()
+  (interactive)
+  (compile "cargo test"))
+
+(defun spacemacs/rust-cargo-doc ()
+  (interactive)
+  (compile "cargo doc"))

--- a/contrib/!lang/rust/packages.el
+++ b/contrib/!lang/rust/packages.el
@@ -16,6 +16,8 @@
     flycheck-rust
     rust-mode
     toml-mode
+    company
+    company-racer
     )
   "List of all packages to install and/or initialize. Built-in packages
 which require an initialization must be listed explicitly in the list.")
@@ -39,24 +41,12 @@ which require an initialization must be listed explicitly in the list.")
       (when (fboundp 'sp-local-pair) ;Don't pair lifetime specifiers
         (sp-local-pair 'rust-mode "'" nil :actions nil))
 
-      ;; http://doc.crates.io/guide.html
-      (defun spacemacs/rust-cargo-build ()
-        (interactive)
-        (shell-command "cargo build"))
-
-      (defun spacemacs/rust-cargo-run ()
-        (interactive)
-        (shell-command "cargo run"))
-
-      (defun spacemacs/rust-cargo-test ()
-        (interactive)
-        (shell-command "cargo test"))
-
       ;; (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
       (evil-leader/set-key-for-mode 'rust-mode
         "mcc" 'spacemacs/rust-cargo-build
         "mcC" 'spacemacs/rust-cargo-run
-        "mta" 'spacemacs/rust-cargo-test)))
+        "mct" 'spacemacs/rust-cargo-test
+        "mcd" 'spacemacs/rust-cargo-doc)))
   "Initialize rust-mode"
   )
 
@@ -64,3 +54,13 @@ which require an initialization must be listed explicitly in the list.")
   (use-package toml-mode
     :defer t)
   "Initialize toml-mode")
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun rust/post-init-company ()
+    (spacemacs|add-company-hook rust-mode))
+
+  (defun rust/init-company-racer ()
+    (use-package company-racer
+      :if (configuration-layer/package-usedp 'company)
+      :defer t
+      :init (push 'company-racer company-backends-rust-mode))))


### PR DESCRIPTION
This allow Emacs to parse the output, including all the errors :)