### PR TITLE
Fix home buffer keys in terminal

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -515,14 +515,4 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
       (beginning-of-line)
       (widget-forward 1))))
 
-;;this feels like the wrong place to put these
-(add-hook 'spacemacs-mode-hook (lambda ()
-                                 (local-set-key [tab] 'widget-forward)
-                                 (local-set-key [S-tab] 'widget-backward)
-                                 ;; S-tab is backtab in terminal
-                                 (local-set-key [backtab] 'widget-backward)
-                                 (local-set-key [return] 'widget-button-press)
-                                 (local-set-key [down-mouse-1] 'widget-button-click)
-                                 ))
-
 (provide 'core-spacemacs-buffer)

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -18,6 +18,14 @@
 ;; improve delete-other-windows
 (define-key global-map (kbd "C-x 1") 'toggle-maximize-buffer)
 
+;; home buffer key bindings
+(define-key spacemacs-mode-map (kbd "TAB") 'widget-forward)
+(define-key spacemacs-mode-map (kbd "S-TAB") 'widget-backward)
+(define-key spacemacs-mode-map (kbd "RET") 'widget-button-press)
+;; S-tab is backtab in terminal
+(define-key spacemacs-mode-map [backtab] 'widget-backward)
+(define-key spacemacs-mode-map [down-mouse-1] 'widget-button-click)
+
 ;; replace `dired-goto-file' with `helm-find-files', since `helm-find-files'
 ;; can do the same thing and with fuzzy matching and other features.
 (eval-after-load 'dired


### PR DESCRIPTION
Currently, pressing TAB does not move to next widget. Similarly,
pressing RET does not run the button at point. Use `kbd` function to
properly convert to internal key representation in Emacs that is usable
in both GUI and terminal.

Also move the key bindings to spacemacs/keybindings.el since it's a more
suitable place.