### PR TITLE
Enable Helm Gtags on compilation-mode and shell-mode

### DIFF
--- a/contrib/gtags/README.org
+++ b/contrib/gtags/README.org
@@ -94,6 +94,11 @@ only activated for programming modes that are not one of these languages:
 - Python
 - Ruby-mode
 
+In addition, if output from =compile= (bound to ~SPC c C~), =shell-command=
+(bound to ~SPC !~ and ~M-!~) or =async-shell-command= (bound to ~M-&~) commands
+contains symbol in your project, you move cursor on such symbol and use any of
+the gtags commands.
+
 Since these modes have better Eldoc integration already.
 
 * Key bindings

--- a/contrib/gtags/packages.el
+++ b/contrib/gtags/packages.el
@@ -37,6 +37,8 @@
       (spacemacs/helm-gtags-define-keys-for-mode 'awk-mode)
       (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode)
       (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
+      (spacemacs/helm-gtags-define-keys-for-mode 'compilation-mode)
+      (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode)
 
       (spacemacs/ggtags-enable-eldoc 'tcl-mode)
       (spacemacs/ggtags-enable-eldoc 'java-mode)


### PR DESCRIPTION
Since we can use helm-gtags to jump to any valid symbol on
shell/compilation buffer. For example, if a test case fails and it
outputs a function where the failure occurs, we can move point on that
failed function and jump directly to it.