### PR TITLE
[FIX] Change org-kbd face to prevent breaking table

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -14,8 +14,8 @@
   "List of emacs built-in themes")
 
 (defface org-kbd
-  '((t (:background "LemonChiffon1" :foreground "black" :box
-                    (:line-width 2 :color nil :style released-button))))
+  '((t
+     (:overline "black" :foreground "black" :background "LemonChiffon1")))
   "Face for displaying key bindings in Spacemacs documents."
   :group 'org-faces)
 


### PR DESCRIPTION
We don't use a box anymore. Instead, we add a black overline to separate
between key bindings.

@syl20bnr @CestDiego @cpaulik I suggest that we wrap each key binding inside a bracket pair like this: `[ SPC f e h ]`. That way, we can add spaces and make key binding look nicer.

Demo:

![org-kbd-new-face-demo](https://cloud.githubusercontent.com/assets/4818719/8203598/2dc9b75c-150d-11e5-8a9d-71c72a847189.jpg)

Here is the above Org snippet to test:

```text
| Key Binding | Description                     |
|-------------+---------------------------------|
| ~[ TAB ]~     | org-cycle                       |
| ~[ $ ]~       | org-end-of-line                 |
| ~[ ^ ]~       | org-beginning-of-line           |
| ~[ < ]~       | org-metaleft                    |
| ~[ > ]~       | org-metaright                   |
| ~[ gh ]~      | outline-up-heading              |
| ~[ gj ]~      | org-forward-heading-same-level  |
| ~[ gk ]~      | org-backward-heading-same-level |
| ~[ gl ]~      | outline-next-visible-heading    |
| ~[ t ]~       | org-todo                        |
| ~[ T ]~       | org-insert-todo-heading nil     |
| ~[ H ]~       | org-beginning-of-line           |
| ~[ L ]~       | org-end-of-line                 |
| ~[ o ]~       | always-insert-item              |
| ~[ O ]~       | org-open-above                  |
```
