### PR TITLE
Allow syntax checking to happen on buffer change

### DIFF
--- a/contrib/syntax-checking/config.el
+++ b/contrib/syntax-checking/config.el
@@ -15,6 +15,9 @@
 (defvar syntax-checking-enable-tooltips t
   "If non nil some feedback are displayed in tooltips.")
 
+(defvar syntax-checking-check-on-buffer-change nil
+  "If non nil check syntax on idle and upon entering a newline, in addition to upon enabling flycheck-mode and upon saving the buffer.")
+
 ;; Command Prefixes
 
 (spacemacs/declare-prefix "S" "spelling")

--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -24,8 +24,12 @@
     :defer t
     :init
     (progn
-      (setq flycheck-check-syntax-automatically '(save mode-enabled)
-            flycheck-standard-error-navigation nil)
+      (if syntax-checking-check-on-buffer-change
+          (setq flycheck-check-syntax-automatically
+              '(save idle-change new-line mode-enabled))
+        (setq flycheck-check-syntax-automatically
+                '(save mode-enabled)))
+      (setq flycheck-standard-error-navigation nil)
       (spacemacs|add-toggle syntax-checking
                             :status flycheck-mode
                             :on (flycheck-mode)


### PR DESCRIPTION
Add a variable `syntax-checking-check-on-buffer-change` to the
`syntax-checking` layer which conditionally sets the variable
`flycheck-check-syntax-automatically` to:

 - `'(save mode-enabled)` when nil
 - `'(save idle-change new-line mode-enabled)` (the package default)
   when non-nil

The various settings determine when Flycheck evaluates the buffer:

 - `save` triggers a buffer check after buffer save.
 - `mode-enabled` triggers a buffer check when `flycheck-mode` is
   enabled.
 - `idle-change` triggers a buffer check after the editor has been idle
   for `flycheck-idle-change-delay`
 - `new-line` triggers a buffer check whenever a new line is inserted
   into the buffer