### PR TITLE
Emacs25 requires `(package-initialize)` to be in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -9,6 +9,10 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
+
+;; Without this comment emacs25 adds (package-initialize) here
+;; (package-initialize)
+
 (defconst spacemacs-version          "0.103.0" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 


### PR DESCRIPTION
even if it's commented out. 

It's an emacs25 thing, but it's harmless in earlier versions.

See https://github.com/emacs-mirror/emacs/blob/master/lisp/emacs-lisp/package.el#L1366-L1373