### PR TITLE
electric-indent-local-mode is not always defined

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -57,7 +57,8 @@
       ;; Haskell main editing mode key bindings.
       (defun spacemacs/init-haskell-mode ()
         ;; use only internal indentation system from haskell
-        (electric-indent-local-mode -1))
+        (if (fboundp 'electric-indent-local-mode)
+            (electric-indent-local-mode -1)))
 
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)


### PR DESCRIPTION
I don't know why this only breaks me, but everywhere else in the tree where I see electric-local-indent-mode called it is first tested for like this.