### PR TITLE
extra-langs: enable qml-mode for qml files

### DIFF
--- a/contrib/!lang/extra-langs/packages.el
+++ b/contrib/!lang/extra-langs/packages.el
@@ -28,7 +28,7 @@
   (use-package nim-mode :defer t))
 
 (defun extra-langs/init-qml-mode ()
-  (use-package qml-mode :defer t))
+  (use-package qml-mode :defer t :mode "\\.qml\\'"))
 
 (defun extra-langs/init-julia-mode ()
   (use-package julia-mode :defer t))


### PR DESCRIPTION
This should be safe as there are no other file types having the qml extension.