### PR TITLE
Automatically detect changes in .spacemacs.template

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -2,6 +2,11 @@
 ;; This file is loaded by Spacemacs at startup.
 ;; It must be stored in your home directory.
 
+;; Version of the .spacemacs file format. When the .spacemacs template is
+;; updated this version number will increase. If you comment out this line,
+;; the version check will be disabled.
+(setq dotspacemacs-version "0.0")
+
 (defun dotspacemacs/layers ()
   "Configuration Layers declaration.
 You should not put any user code in this function besides modifying the variable


### PR DESCRIPTION
This stores a hash of the current .spacemacs.template in the cache folder. When spacemacs loads, it uses this to check for changes in the template file. If a change is detected report it in the spacemacs buffer with a link to do a diff of your .spacemacs and the new one.

I have no opinion on how this information should appear in the buffer. This is how I added it, but please change it to your liking. 

![diff](https://cloud.githubusercontent.com/assets/2208382/8268225/94340930-174b-11e5-9985-b18bfd05ad62.png)

