### PR TITLE
Add keybinding and evilify CIDER Inspect

### DIFF
--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -14,10 +14,10 @@
  - [[#key-bindings][Key Bindings]]
      - [[#documentation][Documentation]]
      - [[#evaluation][Evaluation]]
-     - [[#inspection][Inspection]]
      - [[#goto][Goto]]
      - [[#repl][REPL]]
      - [[#tests][Tests]]
+     - [[#debugging][Debugging]]
      - [[#refactoring][Refactoring]]
      - [[#reformatting][Reformatting]]
 
@@ -100,12 +100,6 @@ More info regarding installation of nREPL middleware can be found here:
 | ~SPC m e r~ | eval region                            |
 | ~SPC m e w~ | eval last sexp and replace with result |
 
-** Inspection
-
-| Key Binding | Description                        |
-|-------------+------------------------------------|
-| ~SPC m i~   | inspect the result of a expression |
-
 ** Goto
 
 | Key Binding | Description   |
@@ -141,6 +135,12 @@ More info regarding installation of nREPL middleware can be found here:
 | ~SPC m t a~ | run all tests in namespace         |
 | ~SPC m t r~ | re-run test failures for namespace |
 | ~SPC m t t~ | run test at point                  |
+
+** Debugging
+
+| Key Binding | Description                    |
+|-------------+--------------------------------|
+| ~SPC m d i~ | inspect expression at point    |
 
 ** Refactoring
 

--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -140,6 +140,7 @@ More info regarding installation of nREPL middleware can be found here:
 
 | Key Binding | Description                    |
 |-------------+--------------------------------|
+| ~SPC m d b~ | instrument expression at point |
 | ~SPC m d i~ | inspect expression at point    |
 
 ** Refactoring

--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -14,6 +14,7 @@
  - [[#key-bindings][Key Bindings]]
      - [[#documentation][Documentation]]
      - [[#evaluation][Evaluation]]
+     - [[#inspection][Inspection]]
      - [[#goto][Goto]]
      - [[#repl][REPL]]
      - [[#tests][Tests]]
@@ -98,6 +99,12 @@ More info regarding installation of nREPL middleware can be found here:
 | ~SPC m e f~ | eval function at point                 |
 | ~SPC m e r~ | eval region                            |
 | ~SPC m e w~ | eval last sexp and replace with result |
+
+** Inspection
+
+| Key Binding | Description                        |
+|-------------+------------------------------------|
+| ~SPC m i~   | inspect the result of a expression |
 
 ** Goto
 

--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -173,7 +173,7 @@ the focus."
         "mtr" 'spacemacs/cider-test-rerun-tests
         "mtt" 'spacemacs/cider-test-run-focused-test
 
-        "mi" 'cider-inspect)
+        "mdi" 'cider-inspect)
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)))
 

--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -135,6 +135,8 @@ the focus."
       (setq cider-prompt-for-symbol nil)
       (evilify cider-docview-mode cider-docview-mode-map
                (kbd "q") 'cider-popup-buffer-quit)
+      (evilify cider-inspector-mode cider-inspector-mode-map
+               (kbd "L") 'cider-inspector-pop)
 
       (evil-leader/set-key-for-mode 'clojure-mode
         "mhh" 'cider-doc

--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -171,7 +171,9 @@ the focus."
 
         "mta" 'spacemacs/cider-test-run-all-tests
         "mtr" 'spacemacs/cider-test-rerun-tests
-        "mtt" 'spacemacs/cider-test-run-focused-test)
+        "mtt" 'spacemacs/cider-test-run-focused-test
+
+        "mi" 'cider-inspect)
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)))
 

--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -173,7 +173,8 @@ the focus."
         "mtr" 'spacemacs/cider-test-rerun-tests
         "mtt" 'spacemacs/cider-test-run-focused-test
 
-        "mdi" 'cider-inspect)
+        "mdi" 'cider-inspect
+        "mdb" 'cider-debug-defun-at-point)
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)))
 


### PR DESCRIPTION
I evilified `cider-inspector` and replaced `l` to `L` for `cider-inspector-pop`.

I would like to hear some opinions of keeping `L` (`cider-inspector-pop`) and `g` (`cider-inspector-refresh`) or if there are better keybindings for those commands.

Also, is "<leader> mi" a good keybinding for `cider-inspect`?