### PR TITLE
spacemacs/open-in-external-app should only work for buffers with files associated with them and dired buffers. 

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -875,11 +875,12 @@ The body of the advice is in BODY."
   (let ((file-path (if (eq major-mode 'dired-mode)
                        (dired-get-file-for-visit)
                      (buffer-file-name))))
-    (cond
-     ((system-is-mswindows) (w32-shell-execute "open" (replace-regexp-in-string "/" "\\\\" file-path)))
-     ((system-is-mac) (shell-command (format "open \"%s\"" file-path)))
-     ((system-is-linux) (let ((process-connection-type nil))
-                          (start-process "" nil "xdg-open" file-path))))))
+    (when file-path
+      (cond
+       ((system-is-mswindows) (w32-shell-execute "open" (replace-regexp-in-string "/" "\\\\" file-path)))
+       ((system-is-mac) (shell-command (format "open \"%s\"" file-path)))
+       ((system-is-linux) (let ((process-connection-type nil))
+                            (start-process "" nil "xdg-open" file-path)))))))
 
 (defun spacemacs/next-error (&optional n reset)
   "Dispatch to flycheck or standard emacs error."


### PR DESCRIPTION
Other buffers, such as the *spacemacs* buffer should not be supported.

i.e., don't try to open 'nil'.

I'm not sure if this should output a message to *Messages* if you try to run this on a non-file or dired buffer or just silently do nothing as this does.