### PR TITLE
Let smart-search-project fall back to searching files when not in project. 

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1898,10 +1898,11 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'
 If DEFAULT-INPUTP is non nil then the current region or symbol at point
 are used as default input."
         (interactive)
-        (call-interactively
-         (spacemacs//helm-do-search-find-tool "helm-project-do"
-                                              dotspacemacs-search-tools
-                                              default-inputp)))
+        (let ((projectile-require-project-root nil))
+         (call-interactively
+          (spacemacs//helm-do-search-find-tool "helm-project-do"
+                                               dotspacemacs-search-tools
+                                               default-inputp))))
 
       (defun spacemacs/helm-project-smart-do-search-region-or-symbol ()
         "Search in current project using `dotspacemacs-search-tools' with


### PR DESCRIPTION
For me, this makes `SPC /` more convenient. It temporarily sets `projectile-require-project-root` to `nil` when using `SPC /`, which means that if you are not in a project projectile will assume that the current directory is the root of a project for the search. So if I am in a project the command behaves as it does now, but if I'm not instead of saying "error: not in project" it gives me search results starting from the current directory. It even works in buffers not related to files. 

This was just an idea but makes sense to me for a "smart" command.