### PR TITLE
Python layer: fix the problem of ipython hanging on windows 

### DIFF
--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -164,7 +164,7 @@
         (if (executable-find "ipython")
             (if (system-is-mswindows)
                 (setq python-shell-interpreter "python"
-                      python-shell-interpreter-args "-i c:\\python27\\scripts\\ipython-script.py"
+                      python-shell-interpreter-args (concat "-i " (file-name-directory (executable-find "ipython")) "ipython-script.py")
                       python-shell-prompt-regexp "In \\[[0-9]+\\]: "
                       python-shell-prompt-output-regexp "Out\\[[0-9]+\\]: "
                       python-shell-completion-setup-code "from IPython.core.completerlib import module_completion"

--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -162,16 +162,24 @@
 
       (defun python-setup-shell ()
         (if (executable-find "ipython")
-            (setq python-shell-interpreter "ipython"
-                  ;; python-shell-interpreter-args (if (system-is-mac)
-                  ;;                                   "--gui=osx --matplotlib=osx --colors=Linux"
-                  ;;                                 (if (system-is-linux)
-                  ;;                                     "--gui=wx --matplotlib=wx --colors=Linux"))
-                  python-shell-prompt-regexp "In \\[[0-9]+\\]: "
-                  python-shell-prompt-output-regexp "Out\\[[0-9]+\\]: "
-                  python-shell-completion-setup-code "from IPython.core.completerlib import module_completion"
-                  python-shell-completion-module-string-code "';'.join(module_completion('''%s'''))\n"
-                  python-shell-completion-string-code "';'.join(get_ipython().Completer.all_completions('''%s'''))\n")
+            (if (system-is-mswindows)
+                (setq python-shell-interpreter "python"
+                      python-shell-interpreter-args "-i c:\\python27\\scripts\\ipython-script.py"
+                      python-shell-prompt-regexp "In \\[[0-9]+\\]: "
+                      python-shell-prompt-output-regexp "Out\\[[0-9]+\\]: "
+                      python-shell-completion-setup-code "from IPython.core.completerlib import module_completion"
+                      python-shell-completion-module-string-code "';'.join(module_completion('''%s'''))\n"
+                      python-shell-completion-string-code "';'.join(get_ipython().Completer.all_completions('''%s'''))\n")
+              (setq python-shell-interpreter "ipython"
+                    ;; python-shell-interpreter-args (if (system-is-mac)
+                    ;;                                   "--gui=osx --matplotlib=osx --colors=Linux"
+                    ;;                                 (if (system-is-linux)
+                    ;;                                     "--gui=wx --matplotlib=wx --colors=Linux"))
+                    python-shell-prompt-regexp "In \\[[0-9]+\\]: "
+                    python-shell-prompt-output-regexp "Out\\[[0-9]+\\]: "
+                    python-shell-completion-setup-code "from IPython.core.completerlib import module_completion"
+                    python-shell-completion-module-string-code "';'.join(module_completion('''%s'''))\n"
+                    python-shell-completion-string-code "';'.join(get_ipython().Completer.all_completions('''%s'''))\n"))
           (setq python-shell-interpreter "python")))
 
       (defun inferior-python-setup-hook ()


### PR DESCRIPTION
ipython hangs when called on windows. I reconfigure the python-shell-interpreter and python-shell-interpreter-args to run ipython on windows properly according to the suggestion from http://emacswiki.org/emacs/PythonProgrammingInEmacs, i.e.,

    (setq python-shell-interpreter "python")
    (setq python-shell-interpreter-args "-i c:\\python27\\scripts\\ipython-script.py")