### PR TITLE
git: add `SPC g L` keybinding for magit-file-log

### DIFF
--- a/contrib/!source-control/git/README.org
+++ b/contrib/!source-control/git/README.org
@@ -96,6 +96,7 @@ Git commands (start with ~g~):
 | ~SPC g h t~ | highlight regions by last updated time              |
 | ~SPC g I~   | open =helm-gitignore=                               |
 | ~SPC g l~   | open a =magit= log                                  |
+| ~SPC g L~   | display the log for a file                          |
 | ~SPC g s~   | open a =magit= status window                        |
 | ~SPC g m~   | display the last commit message of the current line |
 | ~SPC g t~   | launch the git time machine                         |

--- a/contrib/!source-control/git/packages.el
+++ b/contrib/!source-control/git/packages.el
@@ -126,6 +126,7 @@
       (evil-leader/set-key
         "gb" 'magit-blame-mode
         "gl" 'magit-log
+        "gL" 'magit-file-log
         "gs" 'magit-status
         "gd" 'spacemacs/magit-diff-head
         "gC" 'magit-commit)


### PR DESCRIPTION
Display the log for the currently visited file or another one.