### PR TITLE
Tweak ediff to optionally ignore regions with magic comment.

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -154,13 +154,16 @@ before layers configuration."
    dotspacemacs-default-package-repository nil
    )
   ;; User initialization goes here
+  ;; EDIFF-IGNORE
   )
 
 (defun dotspacemacs/config ()
   "Configuration function.
  This function is called at the very end of Spacemacs initialization after
 layers configuration."
+  ;; EDIFF-IGNORE
 )
 
 ;; Do not write anything past this comment. This is where Emacs will
 ;; auto-generate custom variable definitions.
+;; EDIFF-IGNORE

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -524,7 +524,18 @@
        ediff-window-setup-function 'ediff-setup-windows-plain
        ;; emacs is evil and decrees that vertical shall henceforth be horizontal
        ediff-split-window-function 'split-window-horizontally
-       ediff-merge-split-window-function 'split-window-horizontally))))
+       ediff-merge-split-window-function 'split-window-horizontally)
+      (defvar ediff-start-with-ignores nil
+	"If non-nil start ediff using ediff-hide-regex-and-ignores to select diff
+	regions to compare.")
+      (add-hook 'ediff-startup-hook
+                (lambda ()
+                  (when ediff-start-with-ignores
+                    (setq-local
+                     ediff-hide-regexp-matches-function 'ediff-hide-regex-and-ignores)
+                    (setq-local
+                     ediff-skip-diff-region-function 'ediff-hide-regex-and-ignores)
+                    (ediff-update-diffs)))))))
 
 (defun spacemacs/init-eldoc ()
   (use-package eldoc


### PR DESCRIPTION
Controlled through new variable `ediff-start-with-ignores`. For use in diffing .spacemacs with template for now.

Reference #2065. This is not exactly how I wanted this to work but it will give you something to play with @syl20bnr.

