### PR TITLE
Fix broken links for the git layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,8 +499,8 @@ details.
 [using_package_buf]: doc/DOCUMENTATION.md#using-the-package-list-buffer
 [troubleshoot]: doc/DOCUMENTATION.md#troubleshoot
 [contrib layers]: doc/DOCUMENTATION.md#using-configuration-layers
-[Git support]: contrib/git/README.md
-[git layer]: contrib/git
+[Git support]: contrib/!tools/git/README.md
+[git layer]: contrib/!tools/git
 [ace-jump]: doc/DOCUMENTATION.md#vim-motions-with-ace-jump-mode
 [project management]: doc/DOCUMENTATION.md#project-management
 [Evil Mode]: doc/DOCUMENTATION.md#evil

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -716,7 +716,7 @@ your `~/.spacemacs`):
  - unicode symbols for minor mode lighters which appear in the mode-line
  - [custom fringe bitmaps](#errors-handling) and error feedbacks for
  [Flycheck][flycheck]
- - [custom fringe bitmaps](../contrib/git/README.md#git-gutter-bitmaps) for
+ - [custom fringe bitmaps](../contrib/!tools/git/README.md#git-gutter) for
  git gutter (available in [git layer][])
 
 ### Color themes
@@ -2597,7 +2597,7 @@ developers to elisp hackers!
 [javascript-contrib]: ../contrib/lang/javascript
 [themes-megapack]: ../contrib/themes-megapack
 [python-contrib]: ../contrib/lang/python
-[git layer]: ../contrib/git
+[git layer]: ../contrib/!tools/git
 [html-contrib]: ../contrib/lang/html
 [guide-key]: https://github.com/kai2nenobu/guide-key
 [guide-key-tip]: https://github.com/aki2o/guide-key-tip


### PR DESCRIPTION
This commit fixes broken links that pointed to contrib/git instead of contrib/!tools/git