### PR TITLE
haskell layer: do not reset haskell-process-type

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -67,8 +67,7 @@
         (add-hook 'haskell-mode-hook 'haskell-indentation-mode))
 
       ;; settings
-      (setq haskell-process-type 'auto
-            ;; Use notify.el (if you have it installed) at the end of running
+      (setq ;; Use notify.el (if you have it installed) at the end of running
             ;; Cabal commands or generally things worth notifying.
             haskell-notify-p t
             ;; To enable tags generation on save.


### PR DESCRIPTION
`haskell-process-type` is already auto by default, there is no need to
set it again. Not setting it again makes customization for users easier,
since they can just setq `haskell-process-type` in their config
function, without having to take special steps to order the setq after
the one in the haskell configuration layer (which may, if the user is not
careful, override the user's setq).