### PR TITLE
Update installation instructions to use ctags backend

### DIFF
--- a/contrib/gtags/README.org
+++ b/contrib/gtags/README.org
@@ -53,6 +53,13 @@ Download the latest tar.gz archive, then run these commands:
   sudo make install
 #+END_SRC
 
+To be able to use =ctags= and other backends, you need to copy the sample
+=gtags.conf= either to =/etc/gtags.conf= or =$HOME/.globalrc=. For example:
+
+#+begin_src sh
+  cp gtags.conf ~/.globalrc
+#+end_src
+
 To use this contribution add it to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp


### PR DESCRIPTION
Without this gtags.conf copied as .globalrc, generating Global tag
database won't work with other backends.