### PR TITLE
Fix eldoc not enabled properly in gtags layer

### DIFF
--- a/contrib/gtags/funcs.el
+++ b/contrib/gtags/funcs.el
@@ -44,5 +44,6 @@
   (add-hook (intern (concat (symbol-name mode) "-hook"))
             (lambda ()
               (ggtags-mode 1)
+              (eldoc-mode 1)
               (setq-local eldoc-documentation-function
                           #'ggtags-eldoc-function))))


### PR DESCRIPTION
spacemacs/ggtags-enable-eldoc is supposed to enable eldoc-mode, but
currently it's not. This commit fixed it.