### PR TITLE
Add alist of replacement strings to guide-key

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -1009,3 +1009,12 @@ the right."
 (create-align-repeat-x "bar" "|")
 (create-align-repeat-x "left-paren" "(")
 (create-align-repeat-x "right-paren" ")" t)
+
+(defun replace-strings-from-alist (replacements)
+  "Find and replace text in buffer according to REPLACEMENTS,
+which is an alist where the car of each element is the text to
+replace and the cdr is the replacement text. "
+  (dolist (rep replacements)
+    (save-excursion
+      (while (search-forward (car rep) nil t)
+        (replace-match (cdr rep) nil t)))))

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1330,6 +1330,30 @@ Example: (evil-map visual \"<\" \"<gv\")"
             guide-key-tip/enabled nil)
       (setq guide-key/highlight-command-regexp
                    (cons spacemacs/prefix-command-string font-lock-warning-face))
+
+      (defvar spacemacs-guide-key-replacement-alist
+            '(("spacemacs/helm-project-smart-do-search-region-or-symbol" . "\"Smart Search Project\"")
+              ("select-window-0" . "\"Window 0\"")
+              ("spacemacs/" . "")
+              ("evil-" . ""))
+            "List of text replacements for commands in guide-key popup")
+
+      (defadvice guide-key/popup-function (around filter-bindings 0 nil activate)
+        "Advice the guide-key/popup-function to use the text
+replacements in `spacemacs-guide-key-replacement-alist'."
+        (cl-letf* (((symbol-function 'orig-describe-buffer-bindings)
+                    (symbol-function 'describe-buffer-bindings))
+                   ((symbol-function 'describe-buffer-bindings)
+                    (lambda (buffer &optional prefix menus)
+                      (let (res)
+                        (with-temp-buffer
+                          (orig-describe-buffer-bindings buffer prefix menus)
+                          (goto-char (point-min))
+                          (replace-strings-from-alist spacemacs-guide-key-replacement-alist)
+                          (setq res (buffer-string)))
+                        (insert res)))))
+          ad-do-it))
+
       (guide-key-mode 1)
       (spacemacs|diminish guide-key-mode " Ⓖ" " G"))))
 


### PR DESCRIPTION
This is one solution I came up with to #2071. What it does is adds `spacemacs-guide-key-replacement-alist`, which as an example looks like

```
(("spacemacs/helm-project-smart-do-search-region-or-symbol" . "\"Smart Search Project\"")
  ("select-window-0" . "\"Window 0\"")
  ("spacemacs/" . ""))
```

With this addition guide-key will go through this list and replace the strings in the car with the string in the cdr of each cons cell. The example above gives the result

![guide-key](https://cloud.githubusercontent.com/assets/2208382/8340512/fe1e0636-1a8c-11e5-8ddc-67dfa890f0c7.PNG)

Obviously this list is not adequate, but I use it as an example to show the possibility of replacing unneeded text (for the purpose of guide-key) like perhaps "spacemacs/". At the very least we could use this to replace super long function names without worrying about changing the names or creating aliases. I think of guide-key as just needing to provide a hint for what the command does. You can always dig deeper with other help tools like `helm-descbinds`.
