### PR TITLE
Add "system-info" fn for IRC / issues support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,14 @@ are extensively documented.
 If you need help, ask your question in the [Gitter Chat][] and a member of the
 community will help you out.
 
+Tip: Run `SPC : spacemacs/system-info` (it gathers info about your
+Spacemacs setup and copies to your clipboard) and then paste into the
+Gitter chat so that others know the basic info about your setup
+necessary to help diagnose any issues you may be facing.
+
 If you prefer IRC, connect to the [Gitter Chat IRC server][] and join the
 `#syl20bnr/spacemacs` channel.
+
 
 # Prerequisites
 

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -227,4 +227,20 @@ FILE-TO-LOAD is an explicit file to load after the installation."
        (force-mode-line-update))
      (spacemacs/check-for-new-version spacemacs-version-check-interval))))
 
+(defun spacemacs/system-info ()
+  "Gathers info about your Spacemacs setup and copies to clipboard."
+  (interactive)
+  (kill-new
+   (format
+    (concat "OS: %s"
+            " Emacs: %s"
+            " Spacemacs: %s"
+            " Spacemacs branch: %s"
+            " Layers: %s")
+    system-type
+    emacs-version
+    spacemacs-version
+    (spacemacs/git-get-current-branch)
+    dotspacemacs-configuration-layers)))
+
 (provide 'core-spacemacs)


### PR DESCRIPTION
I have seen many "I have a problem" discussions in the Gitter chat which
starts with a barrage of questions "Which OS? Which Emacs version?",
etc., so I thought it may be useful to have one function that will
generate the info to be copy-pasted into the Gitter chat and hence both
the user and others helping in the Gitter chat can jump directly to
solving the problem instead of the support volley to figure out the
setup.

Example output:

    ELISP> (spacemacs/system-info)
    "OS: darwin Emacs: 24.5.1 Spacemacs: 0.103.0 Spacemacs branch: develop
    Layers: ((auto-completion :variables auto-completion-enable-help-tooltip
    t) better-defaults emacs-lisp git markdown org (shell :variables
    shell-default-height 30 shell-default-position (quote bottom))
    syntax-checking version-control c-c++ clojure dash github html osx
    python semantic sql)"

References:

From https://github.com/syl20bnr/spacemacs/issues/2033#issuecomment-113861451 :

> Also what is your emacs version and OS ?

From https://github.com/syl20bnr/spacemacs/issues/2042#issuecomment-113861501 :

> What's your Emacs version ? I presume it comes from the semantic
layer, can you test without the semantic layer ?