### PR TITLE
Fix evil-shift-width indent level in Ruby

### DIFF
--- a/contrib/!lang/ruby/packages.el
+++ b/contrib/!lang/ruby/packages.el
@@ -46,7 +46,8 @@
         (sp-local-pair "{" "}"
                        :pre-handlers '(sp-ruby-pre-handler)
                        :post-handlers '(sp-ruby-post-handler (spacemacs/smartparens-pair-newline-and-indent "RET"))
-                       :suffix "")))))
+                       :suffix ""))
+      (add-hook 'enh-ruby-mode-hook '(lambda () (setq evil-shift-width enh-ruby-indent-level))))))
 
 (defun ruby/post-init-flycheck ()
   (add-hook 'enh-ruby-mode-hook 'flycheck-mode))


### PR DESCRIPTION
Even when `enh-ruby-indent-level` was set to 2, `evil-shift-left` and `-right`
functions (triggered by `>>` and `<<`) were changing indentation in steps
of 4. This commit fixes such behaviour by setting the `evil-shift-width`
to the same value as `enh-ruby-indent-level`.