### PR TITLE
ESS company sources should be grouped

### DIFF
--- a/contrib/!lang/ess/packages.el
+++ b/contrib/!lang/ess/packages.el
@@ -82,8 +82,7 @@ not play nicely with autoloads"
 
       (mapc (lambda (sym) (ess/auto-load-hack sym)) ess/r-modes-list)
 
-      (push 'company-R-objects company-backends-ess-mode)
-      (push 'company-R-args company-backends-ess-mode)))
+      (push '(company-R-args company-R-objects) company-backends-ess-mode)))
 
   ;; R --------------------------------------------------------------------------
   (eval-after-load "ess-site"


### PR DESCRIPTION
The ess company sources should be grouped, when they are not grouped
they are pretty buggy (like not showing completions under certain
circumstances).

To see the problem, try opening an R file and start the interpreter.

When you type the following ([] is the cursor):

    setN[]

You will see completions offering up `setNames`. Press `<enter>`.

Now, try doing the following:

    setNames(setN[])

You will see no completions. Company is trying the `company-R-args`
source, failing it, then skipping the execution of the
`company-R-objects` source.

Grouping them together fixes this, and is what's done within ess itself.