### PR TITLE
Add toggle for mouse click events

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,10 @@
 * Release 0.102.x
+** 0.102.2 (2015/06/03)
+*** Layer changes
+**** Org
+- Fix bug with =ox-gfm= by moving it to extensions
+*** Core
+- Fix detection of new versions by correctly fetch latest changes
 ** 0.102.1 (2015/06/01)
 *** Layer changes
 **** Org

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,10 @@
 * Release 0.102.x
+** 0.102.1 (2015/06/01)
+*** Layer changes
+**** Org
+- Fix lazy-loading of =ox-gfm= package.
+*** Core
+- Catch layer variables syntax errors
 ** 0.102.0 (2015/05/31)
 *** IMPORTANT: Breaking changes
 - All Emacs Lisp related configuration has been moved to its own layer

--- a/contrib/org/README.md
+++ b/contrib/org/README.md
@@ -9,6 +9,7 @@
     - [Description](#description)
     - [Install](#install)
         - [Layer](#layer)
+        - [Github support](#github-support)
         - [Different bullets](#different-bullets)
     - [Key bindings](#key-bindings)
         - [Org with evil-org-mode](#org-with-evil-org-mode)
@@ -39,6 +40,17 @@ To use this contribution add it to your `~/.spacemacs`
 
 ```elisp
 (setq-default dotspacemacs-configuration-layers '(org))
+```
+
+### Github support
+
+To install Github related extensions like [ox-gfm][] to export to Github
+flavored markdown set the variable `org-enable-github-support` to `t`.
+
+```elisp
+(setq-default dotspacemacs-configuration-layers '(
+  (org :variables
+       org-enable-github-support t)))
 ```
 
 ### Different bullets

--- a/contrib/org/config.el
+++ b/contrib/org/config.el
@@ -1,0 +1,16 @@
+;;; config.el --- Org configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar org-enable-github-support nil
+  "If non-nil Github related packages are configured.")

--- a/contrib/org/extensions.el
+++ b/contrib/org/extensions.el
@@ -1,0 +1,57 @@
+;;; extensions.el --- Org Extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq org-post-extensions '(ox-gfm))
+
+(defun org/init-ox-gfm ()
+  ;; installing this package from melpa is buggy,
+  ;; so we install it as an extension for now.
+  (use-package ox-gfm
+    :if org-enable-github-support
+    :defer t
+    :init
+    (progn
+      ;; seems to be required otherwise the extension is not
+      ;; loaded properly by org
+      (eval-after-load 'org '(require 'ox-gfm))
+      (autoload 'org-gfm-export-as-markdown "ox-gfm" "\
+ Export current buffer to a Github Flavored Markdown buffer.
+
+If narrowing is active in the current buffer, only export its
+narrowed part.
+
+If a region is active, export that region.
+
+A non-nil optional argument ASYNC means the process should happen
+asynchronously.  The resulting buffer should be accessible
+through the `org-export-stack' interface.
+
+When optional argument SUBTREEP is non-nil, export the sub-tree
+at point, extracting information from the headline properties
+first.
+
+When optional argument VISIBLE-ONLY is non-nil, don't export
+contents of hidden elements.
+
+Export is done in a buffer named \"*Org GFM Export*\", which will
+be displayed when `org-export-show-temporary-export-buffer' is
+non-nil.
+
+\(fn &optional ASYNC SUBTREEP VISIBLE-ONLY)" t nil)
+
+      (autoload 'org-gfm-convert-region-to-md "ox-gfm" "\
+Assume the current region has org-mode syntax, and convert it
+to Github Flavored Markdown.  This can be used in any buffer.
+For example, you can write an itemized list in org-mode syntax in
+a Markdown buffer and use this command to convert it.
+
+\(fn)" t nil))))

--- a/contrib/org/extensions/ox-gfm/ox-gfm.el
+++ b/contrib/org/extensions/ox-gfm/ox-gfm.el
@@ -1,0 +1,191 @@
+;;; ox-gfm.el --- Github Flavored Markdown Back-End for Org Export Engine
+
+;; Copyright (C) 2014 Lars Tveito
+
+;; Author: Lars Tveito
+;; Keywords: org, wp, markdown, github
+;; Package-Version: 20141211.240
+
+;; This file is not part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This library implements a Markdown back-end (github flavor) for Org
+;; exporter, based on the `md' back-end.
+
+;;; Code:
+
+(require 'ox-md)
+
+
+
+;;; User-Configurable Variables
+
+(defgroup org-export-gfm nil
+  "Options specific to Markdown export back-end."
+  :tag "Org Github Flavored Markdown"
+  :group 'org-export
+  :version "24.4"
+  :package-version '(Org . "8.0"))
+
+
+;;; Define Back-End
+
+(org-export-define-derived-backend 'gfm 'md
+  :export-block '("GFM" "GITHUB FLAVORED MARKDOWN")
+  :filters-alist '((:filter-parse-tree . org-md-separate-elements))
+  :menu-entry
+  '(?g "Export to Github Flavored Markdown"
+       ((?G "To temporary buffer"
+            (lambda (a s v b) (org-gfm-export-as-markdown a s v)))
+        (?g "To file" (lambda (a s v b) (org-gfm-export-to-markdown a s v)))
+        (?o "To file and open"
+            (lambda (a s v b)
+              (if a (org-gfm-export-to-markdown t s v)
+                (org-open-file (org-gfm-export-to-markdown nil s v)))))))
+  :translate-alist '((inner-template . org-gfm-inner-template)
+                     (strike-through . org-gfm-strike-through)
+                     (src-block . org-gfm-src-block)))
+
+
+
+;;; Transcode Functions
+
+;;;; Src Block
+
+(defun org-gfm-src-block (src-block contents info)
+  "Transcode SRC-BLOCK element into Github Flavored Markdown
+format. CONTENTS is nil.  INFO is a plist used as a communication
+channel."
+  (let* ((lang (org-element-property :language src-block))
+         (code (org-export-format-code-default src-block info))
+         (prefix (concat "```" lang "\n"))
+         (suffix "```"))
+    (concat prefix code suffix)))
+
+
+;;;; Strike-Through
+
+(defun org-gfm-strike-through (strike-through contents info)
+  "Transcode STRIKE-THROUGH from Org to Markdown (GFM).
+CONTENTS is the text with strike-through markup.  INFO is a plist
+holding contextual information."
+  (format "~~%s~~" contents))
+
+;;;; Table of contents
+
+(defun org-gfm-format-toc (headline)
+  "Return an appropriate table of contents entry for HEADLINE. INFO is a
+plist used as a communication channel."
+  (let* ((title (org-export-data
+                 (org-export-get-alt-title headline info) info))
+         (level (1- (org-element-property :level headline)))
+         (indent (concat (make-string (* level 2) ? )))
+         (anchor (or (org-element-property :custom_id headline)
+                     (concat "sec-" (mapconcat 'number-to-string
+                                               (org-export-get-headline-number
+                                                headline info) "-")))))
+    (concat indent "- [" title "]" "(#" anchor ")")))
+
+
+
+
+;;;; Template
+
+(defun org-gfm-inner-template (contents info)
+  "Return body of document after converting it to Markdown syntax.
+CONTENTS is the transcoded contents string.  INFO is a plist
+holding export options."
+  (let* ((depth (plist-get info :with-toc))
+         (headlines (and depth (org-export-collect-headlines info depth)))
+         (toc-string (or (mapconcat 'org-gfm-format-toc headlines "\n") ""))
+         (toc-tail (if headlines "\n\n" "")))
+    (concat toc-string toc-tail contents)))
+
+
+
+;;; Interactive function
+
+;;;###autoload
+(defun org-gfm-export-as-markdown (&optional async subtreep visible-only)
+  "Export current buffer to a Github Flavored Markdown buffer.
+
+If narrowing is active in the current buffer, only export its
+narrowed part.
+
+If a region is active, export that region.
+
+A non-nil optional argument ASYNC means the process should happen
+asynchronously.  The resulting buffer should be accessible
+through the `org-export-stack' interface.
+
+When optional argument SUBTREEP is non-nil, export the sub-tree
+at point, extracting information from the headline properties
+first.
+
+When optional argument VISIBLE-ONLY is non-nil, don't export
+contents of hidden elements.
+
+Export is done in a buffer named \"*Org GFM Export*\", which will
+be displayed when `org-export-show-temporary-export-buffer' is
+non-nil."
+  (interactive)
+  (org-export-to-buffer 'gfm "*Org GFM Export*"
+    async subtreep visible-only nil nil (lambda () (text-mode))))
+
+
+;;;###autoload
+(defun org-gfm-convert-region-to-md ()
+  "Assume the current region has org-mode syntax, and convert it
+to Github Flavored Markdown.  This can be used in any buffer.
+For example, you can write an itemized list in org-mode syntax in
+a Markdown buffer and use this command to convert it."
+  (interactive)
+  (org-export-replace-region-by 'gfm))
+
+
+;;;###autoload
+(defun org-gfm-export-to-markdown (&optional async subtreep visible-only)
+  "Export current buffer to a Github Flavored Markdown file.
+
+If narrowing is active in the current buffer, only export its
+narrowed part.
+
+If a region is active, export that region.
+
+A non-nil optional argument ASYNC means the process should happen
+asynchronously.  The resulting file should be accessible through
+the `org-export-stack' interface.
+
+When optional argument SUBTREEP is non-nil, export the sub-tree
+at point, extracting information from the headline properties
+first.
+
+When optional argument VISIBLE-ONLY is non-nil, don't export
+contents of hidden elements.
+
+Return output file's name."
+  (interactive)
+  (let ((outfile (org-export-output-file-name ".md" subtreep)))
+    (org-export-to-file 'gfm outfile async subtreep visible-only)))
+
+(provide 'ox-gfm)
+
+;; Local variables:
+;; generated-autoload-file: "org-loaddefs.el"
+;; End:
+
+;;; ox-gfm.el ends here

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -19,7 +19,6 @@
     org-pomodoro
     org-present
     org-repo-todo
-    ox-gfm
     ))
 
 (defun org/init-evil-org ()
@@ -186,9 +185,6 @@ Will work on both org-mode and any mode that accepts plain html."
         "CT"  'ort/capture-todo-check)
       (evil-leader/set-key-for-mode 'org-mode
         "mgt" 'ort/goto-todos))))
-
-(defun org/init-ox-gfm ()
-  (eval-after-load 'org '(require 'ox-gfm)))
 
 (defun org/init-htmlize ()
  (use-package htmlize

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -13,18 +13,12 @@
 (setq org-packages
   '(
     evil-org
+    htmlize
     org
     org-bullets
     org-pomodoro
     org-present
     org-repo-todo
-    ox-gfm
-    htmlize
-    ))
-
-(setq org-excluded-packages
-  '(
-    ;; seems to be problematic, to investigate
     ox-gfm
     ))
 
@@ -194,8 +188,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "mgt" 'ort/goto-todos))))
 
 (defun org/init-ox-gfm ()
-  (use-package ox-gfm
-    :defer t))
+  (eval-after-load 'org '(require 'ox-gfm)))
 
 (defun org/init-htmlize ()
  (use-package htmlize

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -280,14 +280,21 @@ the following keys:
   "Set the configuration variables for the passed LAYERS."
   (dolist (layer layers)
     (let ((variables (spacemacs/mplist-get layer :variables)))
-      (while variables
-        (let ((var (pop variables)))
-          (if (consp variables)
-              (progn
-                ;; (message "%s" `(set-default ,var ,(pop variables)))
-                (set-default var (eval (pop variables))))
-            (spacemacs-buffer/warning "Missing value for variable %s !"
-                                      var)))))))
+          (while variables
+            (let ((var (pop variables)))
+              (if (consp variables)
+                  (condition-case err
+                      (set-default var (eval (pop variables)))
+                    ('error
+                     (configuration-layer//set-error)
+                     (spacemacs-buffer/append
+                      (format (concat "An error occurred while setting layer "
+                                      "variable %s "
+                                      "(error: %s). Be sure to quote the value "
+                                      "if needed.\n") var err))))
+                (spacemacs-buffer/warning "Missing value for variable %s !"
+                                          var)))))))
+
 
 (defun configuration-layer/package-usedp (pkg)
   "Return non-nil if PKG symbol corresponds to a used package."

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -203,8 +203,7 @@ FILE-TO-LOAD is an explicit file to load after the installation."
   "Return the last tagged version of BRANCH on REMOTE repository from
 OWNER REPO."
   (let ((url (format "https://github.com/%s/%s" owner repo)))
-    (unless (spacemacs/git-has-remote remote)
-      (spacemacs/git-declare-remote remote url)))
+    (spacemacs/git-declare-remote remote url))
   (spacemacs/git-fetch-tags remote branch)
   (let ((version (spacemacs/git-latest-tag remote branch)))
     (when version
@@ -255,9 +254,14 @@ found."
   "Declare a new REMOTE pointing to URL, return t if no error."
   (let((proc-buffer "git-declare-remote")
        (default-directory (file-truename user-emacs-directory)))
-    (prog1
+    (prog2
+        (progn
+          (eq 0 (process-file "git" nil proc-buffer nil
+                              "remote" "remove" remote))
+          (eq 0 (process-file "git" nil proc-buffer nil
+                              "remote" "add" remote url)))
         (eq 0 (process-file "git" nil proc-buffer nil
-                            "remote" "add" remote url))
+                            "fetch" remote))
       (kill-buffer proc-buffer))))
 
 (defun spacemacs/git-fetch-tags (remote branch)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -330,6 +330,21 @@ Example: (1 42 3) = 1 042 003"
     (reduce '+ (mapcar (lambda (n) (setq i (1+ i)) (* n (expt 10 (* i 3))))
                        (reverse version)))))
 
+(defun spacemacs/silence ()
+  "Does nothing, just used to silence '<key> is unbound' messages"
+  (interactive))
+
+(defun spacemacs/mouse-binding (enable)
+  "Switches mouse clicking in window on or off"
+  (interactive)
+  (if enable
+      (progn
+        (define-key evil-motion-state-map [down-mouse-1] 'evil-mouse-drag-region)
+        (define-key evil-motion-state-map [mouse-1] 'nil))
+    (progn
+      (define-key evil-motion-state-map [down-mouse-1] 'spacemacs/silence)
+      (define-key evil-motion-state-map [mouse-1] 'spacemacs/silence))))
+
 (defun spacemacs/get-new-version-lighter-face (current new)
   "Return the new version lighter face given the difference between the CURRENT
 version and the NEW version."

--- a/core/tests/core-configuration-layer-utest.el
+++ b/core/tests/core-configuration-layer-utest.el
@@ -75,7 +75,7 @@
   (let ((input '((testlayer :dir "/a/path/"
                             :ext-dir "/a/path/extensions/"
                             :variables
-                            var1 bar))))
+                            var1 'bar))))
     (setq var1 'foo)
     (configuration-layer//set-layers-variables input)
     (should (eq var1 'bar))))
@@ -84,9 +84,9 @@
   (let ((input '((testlayer :dir "/a/path/"
                             :ext-dir "/a/path/extensions/"
                             :variables
-                            var1 bar1
-                            var2 bar2
-                            var3 bar3))))
+                            var1 'bar1
+                            var2 'bar2
+                            var3 'bar3))))
     (setq var1 'foo)
     (setq var2 'foo)
     (setq var3 'foo)
@@ -99,7 +99,7 @@
   (let ((input '((testlayer :dir "/a/path/"
                             :ext-dir "/a/path/extensions/"
                             :variables
-                            var1 bar
+                            var1 'bar
                             var2))))
     (mocker-let
      ((spacemacs-buffer/warning

--- a/init.el
+++ b/init.el
@@ -9,7 +9,7 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
-(defconst spacemacs-version          "0.102.1" "Spacemacs version.")
+(defconst spacemacs-version          "0.102.2" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/init.el
+++ b/init.el
@@ -9,7 +9,7 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
-(defconst spacemacs-version          "0.102.0" "Spacemacs version.")
+(defconst spacemacs-version          "0.102.1" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -240,6 +240,12 @@ Ensure that helm is required before calling FUNC."
                       :off (global-semantic-stickyfunc-mode -1)
                       :documentation "Enable semantic-stickyfunc globally."
                       :evil-leader "T C-s")
+(spacemacs|add-toggle mouse-clicking
+                      :status spacemacs/mouse-binding
+                      :on (spacemacs/mouse-binding t)
+                      :off (spacemacs/mouse-binding nil)
+                      :documentation "Enable mouse click events in buffers"
+                      :evil-leader "tc")
 ;; quit -----------------------------------------------------------------------
 (evil-leader/set-key
   "qs" 'spacemacs/save-buffers-kill-emacs


### PR DESCRIPTION
I got the suggestion to [make a toggle for mouse click events](https://twitter.com/spacemacs/status/613335292666195968) so I got this pull request. Let's start a discussion whether we want this feature in Spacemacs.

Rationale: I often click on the Emacs window to focus it and, coming from console vim, it was never a problem. Unfortunately, Spacemacs relocates the cursor to the random area I clicked, so the focus jumps to some random place. Personally, I only move the cursor using the keyboard, so I wanted to disable it altogether.

This pull request adds a new function to enable and disable the default evil mouse bindings (`spacemacs/mouse-binding`, this part works) and a toggle (this part does not work, for some reason).

I don't know any Emacs Lisp, so I am completely open to suggestions on how to improve it and hope to get it merged eventually.

Looking forward to your suggestions!