### PR TITLE
Add tests for correctness of .spacemacs

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -267,4 +267,82 @@ If MSG is not nil then display a message in `*Messages'."
      (when ,msg (spacemacs-buffer/message ,msg))
      (if (fboundp ',func) (,func))))
 
+(defun dotspacemacs//test-dotspacemacs/layers ()
+  "Tests for `dotspacemacs/layers'"
+  (princ "\nTesting settings in dotspacemacs/layers\n")
+  ;; protect global values of these variables
+  (let (dotspacemacs-configuration-layer-path dotspacemacs-configuration-layers
+        dotspacemacs-additional-packages dotspacemacs-excluded-packages
+        dotspacemacs-delete-orphan-packages
+        (passed-tests 0) (total-tests 0))
+    (load dotspacemacs-filepath)
+    (dotspacemacs/layers)
+    (spacemacs//test-list
+     'stringp 'dotspacemacs-configuration-layer-path "is a string" "path")
+    (spacemacs//test-list
+     'file-directory-p 'dotspacemacs-configuration-layer-path "exists in filesystem" "path")
+    (setq dotspacemacs-configuration-layers
+          (mapcar (lambda (l) (if (listp l) (car l) l)) dotspacemacs-configuration-layers))
+    (spacemacs//test-list
+     'configuration-layer/get-layer-path 'dotspacemacs-configuration-layers  "can be found" "layer")
+    (princ (format
+            "RESULTS: dotspacemacs/layers passed %s out of %s tests\n" passed-tests total-tests))))
+
+(defun dotspacemacs//test-dotspacemacs/init ()
+  "Tests for `dotspacemacs/init'"
+  (princ "\nTesting settings in dotspacemacs/init\n")
+  ;; protect global values of these variables
+  (let (dotspacemacs-editing-style dotspacemacs-verbose-loading
+        dotspacemacs-startup-banner dotspacemacs-startup-lists
+        dotspacemacs-themes dotspacemacs-colorize-cursor-according-to-state
+        dotspacemacs-default-font dotspacemacs-leader-key
+        dotspacemacs-emacs-leader-key dotspacemacs-major-mode-leader-key
+        dotspacemacs-major-mode-emacs-leader-key dotspacemacs-command-key
+        dotspacemacs-auto-save-file-location dotspacemacs-use-ido
+        dotspacemacs-enable-paste-micro-state dotspacemacs-guide-key-delay
+        dotspacemacs-loading-progress-bar dotspacemacs-fullscreen-at-startup
+        dotspacemacs-fullscreen-use-non-native dotspacemacs-maximized-at-startup
+        dotspacemacs-active-transparency dotspacemacs-inactive-transparency
+        dotspacemacs-mode-line-unicode-symbols dotspacemacs-smooth-scrolling
+        dotspacemacs-smartparens-strict-mode dotspacemacs-highlight-delimiters
+        dotspacemacs-persistent-server dotspacemacs-search-tools
+        dotspacemacs-default-package-repository
+        (passed-tests 0) (total-tests 0))
+    (load dotspacemacs-filepath)
+    (dotspacemacs/init)
+    (spacemacs//test-var
+     (lambda (x) (member x '(vim emacs))) 'dotspacemacs-editing-style "is \'vim or \'emacs")
+    (spacemacs//test-var
+     (lambda (x) (member x '(original cache nil))) 'dotspacemacs-auto-save-file-location
+     "is one of \'original, \'cache or nil")
+    (spacemacs//test-var
+     (lambda (x) (member x '(all current nil))) 'dotspacemacs-highlight-delimiters
+     "is one of \'all, \'current or nil")
+    (spacemacs//test-list
+     (lambda (x) (member x '(recents bookmarks projects))) 'dotspacemacs-startup-lists
+     "includes only \'recents, \'bookmarks or \'projects")
+    (spacemacs//test-var 'stringp 'dotspacemacs-leader-key "is a string")
+    (spacemacs//test-var 'stringp 'dotspacemacs-emacs-leader-key "is a string")
+    (spacemacs//test-var 'stringp 'dotspacemacs-major-mode-leader-key "is a string")
+    (spacemacs//test-var 'stringp 'dotspacemacs-command-key "is a string")
+    (princ (format
+            "RESULTS: dotspacemacs/init passed %s out of %s tests\n" passed-tests total-tests))))
+
+(defun dotspacemacs/test-dotfile ()
+  "Test settings in dotfile for correctness."
+  (interactive)
+  (let ((min-version "0.0"))
+    ;; dotspacemacs-version not implemented yet
+    ;; (if (version< dotspacemacs-version min-version)
+    (if nil
+        (error (format "error: dotspacemacs/test-dotfile requires dotspacemacs-version %s" min-version))
+      (save-excursion
+        (let ((buf (get-buffer-create "*dotfile-test-results*")))
+          (with-output-to-temp-buffer buf
+            (princ (format "Running tests on %s (v%s)\n" dotspacemacs-filepath "0.0"))
+            ;; dotspacemacs-version not implemented yet
+            ;; (princ (format "Running tests on %s (v%s)\n" dotspacemacs-filepath dotspacemacs-version))
+            (dotspacemacs//test-dotspacemacs/layers)
+            (dotspacemacs//test-dotspacemacs/init)))))))
+
 (provide 'core-dotspacemacs)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -269,7 +269,9 @@ If MSG is not nil then display a message in `*Messages'."
 
 (defun dotspacemacs//test-dotspacemacs/layers ()
   "Tests for `dotspacemacs/layers'"
-  (princ "\nTesting settings in dotspacemacs/layers\n")
+  (insert
+   (format "\n* Testing settings in dotspacemacs/layers [[file:%s::dotspacemacs/layers][Show in File]]\n"
+           dotspacemacs-filepath))
   ;; protect global values of these variables
   (let (dotspacemacs-configuration-layer-path dotspacemacs-configuration-layers
         dotspacemacs-additional-packages dotspacemacs-excluded-packages
@@ -284,13 +286,17 @@ If MSG is not nil then display a message in `*Messages'."
     (setq dotspacemacs-configuration-layers
           (mapcar (lambda (l) (if (listp l) (car l) l)) dotspacemacs-configuration-layers))
     (spacemacs//test-list
-     'configuration-layer/get-layer-path 'dotspacemacs-configuration-layers  "can be found" "layer")
-    (princ (format
-            "RESULTS: dotspacemacs/layers passed %s out of %s tests\n" passed-tests total-tests))))
+     'configuration-layer/get-layer-path
+     'dotspacemacs-configuration-layers  "can be found" "layer")
+    (insert (format
+             "** RESULTS: [[file:%s::dotspacemacs/layers][dotspacemacs/layers]] passed %s out of %s tests\n"
+             dotspacemacs-filepath passed-tests total-tests))))
 
 (defun dotspacemacs//test-dotspacemacs/init ()
   "Tests for `dotspacemacs/init'"
-  (princ "\nTesting settings in dotspacemacs/init\n")
+  (insert
+   (format "\n* Testing settings in dotspacemacs/init [[file:%s::dotspacemacs/init][Show in File]]\n"
+           dotspacemacs-filepath))
   ;; protect global values of these variables
   (let (dotspacemacs-editing-style dotspacemacs-verbose-loading
         dotspacemacs-startup-banner dotspacemacs-startup-lists
@@ -325,8 +331,9 @@ If MSG is not nil then display a message in `*Messages'."
     (spacemacs//test-var 'stringp 'dotspacemacs-emacs-leader-key "is a string")
     (spacemacs//test-var 'stringp 'dotspacemacs-major-mode-leader-key "is a string")
     (spacemacs//test-var 'stringp 'dotspacemacs-command-key "is a string")
-    (princ (format
-            "RESULTS: dotspacemacs/init passed %s out of %s tests\n" passed-tests total-tests))))
+    (insert (format
+             "** RESULTS: [[file:%s::dotspacemacs/init][dotspacemacs/init]] passed %s out of %s tests\n"
+             dotspacemacs-filepath passed-tests total-tests))))
 
 (defun dotspacemacs/test-dotfile ()
   "Test settings in dotfile for correctness."
@@ -337,12 +344,15 @@ If MSG is not nil then display a message in `*Messages'."
     (if nil
         (error (format "error: dotspacemacs/test-dotfile requires dotspacemacs-version %s" min-version))
       (save-excursion
-        (let ((buf (get-buffer-create "*dotfile-test-results*")))
-          (with-output-to-temp-buffer buf
-            (princ (format "Running tests on %s (v%s)\n" dotspacemacs-filepath "0.0"))
-            ;; dotspacemacs-version not implemented yet
-            ;; (princ (format "Running tests on %s (v%s)\n" dotspacemacs-filepath dotspacemacs-version))
-            (dotspacemacs//test-dotspacemacs/layers)
-            (dotspacemacs//test-dotspacemacs/init)))))))
+        (switch-to-buffer-other-window "*dotfile-test-results*")
+        (erase-buffer)
+        (org-mode)
+        (insert (format "* Running tests on [[file:%s][%s]] (v%s)\n"
+                        dotspacemacs-filepath dotspacemacs-filepath "0.0"))
+        ;; dotspacemacs-version not implemented yet
+        ;; (insert (format "* Running tests on %s (v%s)\n" dotspacemacs-filepath dotspacemacs-version))
+        (dotspacemacs//test-dotspacemacs/layers)
+        (dotspacemacs//test-dotspacemacs/init)
+        (goto-char (point-min))))))
 
 (provide 'core-dotspacemacs)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -149,11 +149,14 @@ passed-tests and total-tests."
   (let ((var-name (symbol-name var))
         (var-val (symbol-value var)))
     (when (boundp 'total-tests) (setq total-tests (1+ total-tests)))
+    (insert (format "** TEST: [[file:%s::%s][%s]] %s\n"
+                    dotspacemacs-filepath var-name var-name test-desc))
     (if (funcall pred var-val)
         (progn
           (when (boundp 'passed-tests) (setq passed-tests (1+ passed-tests)))
-          (princ (format "  TEST: %s %s\n    PASS: %s\n" var-name test-desc var-val)))
-      (princ (format "  TEST: %s %s\n    FAIL: %s\n" var-name test-desc var-val)))))
+          (insert (format "*** PASS: %s\n" var-val)))
+      (insert (propertize (format "*** FAIL: %s\n" var-val)
+                                  'font-lock-face 'font-lock-warning-face)))))
 
 (defun spacemacs//test-list (pred varlist test-desc &optional element-desc)
   "Test PRED against each element of VARLIST and print test
@@ -161,14 +164,19 @@ result, incrementing passed-tests and total-tests."
   (let ((varlist-name (symbol-name varlist))
         (varlist-val (symbol-value varlist)))
     (if element-desc
-        (princ (format "  TEST: Each %s in %s %s\n" element-desc varlist-name test-desc))
-      (princ (format "  TEST: Each element of %s %s\n" varlist-name test-desc)))
+        (insert (format "** TEST: Each %s in [[file:%s::%s][%s]] %s\n"
+                        element-desc dotspacemacs-filepath varlist-name
+                        varlist-name test-desc))
+      (insert (format "** TEST: Each element of [[file:%s::%s][%s]] %s\n"
+                      dotspacemacs-filepath varlist-name varlist-name
+                      test-desc)))
     (dolist (var varlist-val)
       (when (boundp 'total-tests) (setq total-tests (1+ total-tests)))
       (if (funcall pred var)
           (progn
             (when (boundp 'passed-tests) (setq passed-tests (1+ passed-tests)))
-            (princ (format "    PASS: %s\n" var)))
-        (princ (format "    FAIL: %s\n" var))))))
+            (insert (format "*** PASS: %s\n" var)))
+        (insert (propertize (format "*** FAIL: %s\n" var) 'font-lock-face 'font-lock-warning-face))))))
 
 (provide 'core-funcs)
+

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -143,4 +143,32 @@ Supported properties:
 
   (setq-local org-hide-emphasis-markers t))
 
+(defun spacemacs//test-var (pred var test-desc)
+  "Test PRED against VAR and print test result, incrementing
+passed-tests and total-tests."
+  (let ((var-name (symbol-name var))
+        (var-val (symbol-value var)))
+    (when (boundp 'total-tests) (setq total-tests (1+ total-tests)))
+    (if (funcall pred var-val)
+        (progn
+          (when (boundp 'passed-tests) (setq passed-tests (1+ passed-tests)))
+          (princ (format "  TEST: %s %s\n    PASS: %s\n" var-name test-desc var-val)))
+      (princ (format "  TEST: %s %s\n    FAIL: %s\n" var-name test-desc var-val)))))
+
+(defun spacemacs//test-list (pred varlist test-desc &optional element-desc)
+  "Test PRED against each element of VARLIST and print test
+result, incrementing passed-tests and total-tests."
+  (let ((varlist-name (symbol-name varlist))
+        (varlist-val (symbol-value varlist)))
+    (if element-desc
+        (princ (format "  TEST: Each %s in %s %s\n" element-desc varlist-name test-desc))
+      (princ (format "  TEST: Each element of %s %s\n" varlist-name test-desc)))
+    (dolist (var varlist-val)
+      (when (boundp 'total-tests) (setq total-tests (1+ total-tests)))
+      (if (funcall pred var)
+          (progn
+            (when (boundp 'passed-tests) (setq passed-tests (1+ passed-tests)))
+            (princ (format "    PASS: %s\n" var)))
+        (princ (format "    FAIL: %s\n" var))))))
+
 (provide 'core-funcs)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -74,6 +74,7 @@ initialization."
   ;; dotfile init
   (dotspacemacs/load-file)
   (dotspacemacs|call-func dotspacemacs/init "Calling dotfile init...")
+  (dotspacemacs|call-func dotspacemacs/user-init "Calling dotfile user init...")
   ;; spacemacs init
   (switch-to-buffer (get-buffer-create spacemacs-buffer-name))
   (spacemacs-buffer/set-mode-line "")

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -152,8 +152,10 @@ before layers configuration."
    ;; specified with an installed package.
    ;; Not used for now.
    dotspacemacs-default-package-repository nil
-   )
-  ;; User initialization goes here
+   ))
+
+(defun dotspacemacs/user-init ()
+  "Initialization function for user. Called immediately following `dotspacemacs/init'."
   )
 
 (defun dotspacemacs/config ()


### PR DESCRIPTION
I wrote a function, `dotspacemacs/test-dotfile`, to test each of the official configuration variables in .spacemacs. It's basically designed along the lines of `ert-deftest` and `should`, but I found the output of those potentially confusing to new users (the idea is that a user would run these themselves when they are having trouble), so I wrote my own testing functions. I know it's a lot of code, but a lot of this is code to protect the global definitions of the configuration variables while the test is run to make it safe to run whenever you like (after changing .spacemacs for example). It's really easy to add and change tests, which I thought was important. 

This will catch errors like #2044 among others. Here's a sample output (note the failed test for latexs)

![dotspacemacs-tests](https://cloud.githubusercontent.com/assets/2208382/8382622/e4f6eca6-1c01-11e5-938d-3d22710cd537.PNG)

This is much easier to do cleanly if `dotspacemacs/init` is broken into `dotspacemacs/init` and `dotspacemacs/user-init` (we can't test user configuration reliably anyway), so I did that in .spacemacs.template and now call `dotspacemacs/user-init` right after `dotspacemacs/init`.

If anyone knows how to clean this up more or wants to make the results fancier looking let me know
