### PR TITLE
Magit next

### DIFF
--- a/contrib/!source-control/git/extensions.el
+++ b/contrib/!source-control/git/extensions.el
@@ -27,8 +27,7 @@
       (add-to-list 'load-path (format "%smagit-next/lisp/"
                                       (configuration-layer/get-layer-property
                                        'git :ext-dir)))
-      (setq magit-last-seen-setup-instructions "1.4.0"
-            magit-completing-read-function 'magit-ido-completing-read)
+      (setq magit-completing-read-function 'magit-ido-completing-read)
       (add-hook 'git-commit-mode-hook 'fci-mode)
       ;; must enable auto-fill-mode again because somehow fci-mode disable it
       (add-hook 'git-commit-mode-hook 'auto-fill-mode)

--- a/contrib/!source-control/git/extensions.el
+++ b/contrib/!source-control/git/extensions.el
@@ -91,17 +91,27 @@
 
       (defun magit-toggle-whitespace ()
         (interactive)
-        (if (member "-w" magit-diff-options)
+        (if (member "-w" (if (derived-mode-p 'magit-diff-mode)
+			     magit-refresh-args
+			   magit-diff-section-arguments))
             (magit-dont-ignore-whitespace)
           (magit-ignore-whitespace)))
 
       (defun magit-ignore-whitespace ()
         (interactive)
-        (add-to-list 'magit-diff-options "-w")
+        (add-to-list (if (derived-mode-p 'magit-diff-mode)
+			 'magit-refresh-args
+		       'magit-diff-section-arguments)
+		     "-w")
         (magit-refresh))
 
       (defun magit-dont-ignore-whitespace ()
         (interactive)
-        (setq magit-diff-options (remove "-w" magit-diff-options))
-        (magit-refresh)))
-    (define-key magit-status-mode-map (kbd "W") 'magit-toggle-whitespace)))
+        (setq magit-diff-options
+	      (remove "-w"
+		      (if (derived-mode-p 'magit-diff-mode)
+			  magit-refresh-args
+			magit-diff-section-arguments)))
+        (magit-refresh))
+
+      (define-key magit-status-mode-map (kbd "W") 'magit-toggle-whitespace))))

--- a/contrib/!source-control/git/extensions.el
+++ b/contrib/!source-control/git/extensions.el
@@ -83,17 +83,11 @@
 
       ;; full screen magit-status
       (when git-magit-status-fullscreen
-        (defadvice magit-status (around magit-fullscreen activate)
-          (window-configuration-to-register :magit-fullscreen)
-          ad-do-it
-          (delete-other-windows))
-
-        (defun magit-quit-session ()
-          "Restores the previous window configuration and kills the magit buffer"
-          (interactive)
-          (kill-buffer)
-          (jump-to-register :magit-fullscreen))
-        (define-key magit-status-mode-map (kbd "q") 'magit-quit-session))
+	(setq magit-restore-window-configuration t)
+	(setq magit-status-buffer-switch-function
+	      (lambda (buffer)
+		(pop-to-buffer buffer)
+		(delete-other-windows))))
 
       (defun magit-toggle-whitespace ()
         (interactive)


### PR DESCRIPTION
So here are some changes that don't require that I understand how vim works :-) I haven't actually tested these changes.

Also note that you'll have to find a new key for `magit-toggle-whitespace`, `W` is now used for the `magit-patch-popup`.