### PR TITLE
add optional argument to configuration-layer/update-packages so it can be called non-interactively

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -589,9 +589,9 @@ This function also processed recursively the package dependencies."
            (version<= (configuration-layer//get-latest-package-version-string x)
                       installed-ver))))))
 
-(defun configuration-layer/update-packages ()
-  "Upgrade elpa packages"
-  (interactive)
+(defun configuration-layer/update-packages (&optional always-update)
+  "Upgrade elpa packages.  If called with a prefix argument ALWAYS-UPDATE, assume yes to update."
+  (interactive "P")
   (spacemacs-buffer/insert-page-break)
   (spacemacs-buffer/append
    "\nUpdating Spacemacs... (for now only ELPA packages are updated)\n")
@@ -609,9 +609,10 @@ This function also processed recursively the package dependencies."
          (upgraded-count 0)
          (update-packages-alist))
     (if (> upgrade-count 0)
-        (if (not (yes-or-no-p (format (concat "%s package(s) to update, "
-                                              "do you want to continue ? ")
-                                      upgrade-count)))
+        (if (and (not always-update)
+                 (not (yes-or-no-p (format (concat "%s package(s) to update, "
+                                                   "do you want to continue ? ")
+                                           upgrade-count))))
             (spacemacs-buffer/append
              "Packages update has been cancelled.\n")
           ;; backup the package directory and construct an alist


### PR DESCRIPTION
I wanted to write a script to keep Spacemacs up-to-date, especially on machines I don't use often.

But `configuration-layer/update-packages` required interaction.  So I added an optional argument so that if called with the universal argument or with an argument, it would assume yes to the question of whether or not to update packages.  This enables me to do something like this:

```bash
emacs --eval '(progn (configuration-layer/update-packages t) (kill-emacs))'
emacs --eval '(progn (message "Running once again to finish update, if needed") (kill-emacs))'
```
I would probably want to capture the output of this (Emacs in batch mode should output *Messages* to stderr) and then see if there were any errors.