### PR TITLE
Fixed `electric-pair-skip` not working in racket mode

### DIFF
--- a/contrib/!lang/racket/packages.el
+++ b/contrib/!lang/racket/packages.el
@@ -85,4 +85,7 @@
         ;; Tests
         "mtb" 'racket-test
         "mtB" 'spacemacs/racket-test-with-coverage)
-      (define-key racket-mode-map (kbd "H-r") 'racket-run))))
+      (define-key racket-mode-map (kbd "H-r") 'racket-run)
+      (define-key racket-mode-map ")" 'self-insert-command)
+      (define-key racket-mode-map "]" 'self-insert-command)
+      (define-key racket-mode-map "}" 'self-insert-command))))


### PR DESCRIPTION
See https://github.com/greghendershott/racket-mode/issues/140 I feel this is the more natural behavior as a closing paren is already automatically inserted by default in Spacemacs. Therefore it makes more sense to make `electric-pair-skip` the default behavior instead of `racket-insert-closing-paren`