### PR TITLE
Prevent iedit from adding global key binding

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2275,7 +2275,9 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
 
 (defun spacemacs/init-iedit ()
   (use-package iedit
-    :defer t))
+    :defer t
+    :init
+    (setq iedit-toggle-key-default nil)))
 
 (defun spacemacs/init-indent-guide ()
   (use-package indent-guide


### PR DESCRIPTION
I was trying to bind `C-;` but found out that `iedit` binds this key by default. Since `iedit` is deferred it was clobbering my binding even though I had it in `dotspacemacs/config` (making it very difficult to bind this key). This prevents `iedit` from adding the global binding by default.