### PR TITLE
Use magit-log-all in place of magit-log

### DIFF
--- a/contrib/!source-control/git/extensions.el
+++ b/contrib/!source-control/git/extensions.el
@@ -21,6 +21,7 @@
     :commands (magit-status
                magit-blame-mode
                magit-log
+               magit-log-all
                magit-commit)
     :init
     (progn
@@ -41,7 +42,7 @@
 
       (evil-leader/set-key
         "gb" 'magit-blame-mode
-        "gl" 'magit-log
+        "gl" 'magit-log-all
         "gL" 'magit-log-buffer-file
         "gs" 'magit-status
         "gd" 'spacemacs/magit-diff-head


### PR DESCRIPTION
magit-log-all has the same with the old magit-log: show the commit log
immediately without asking for revision. We should use magit-git-log for
smoother transition to magit 2.1.