### PR TITLE
Try to fix #2167

### DIFF
--- a/core/core-evilify-keymap.el
+++ b/core/core-evilify-keymap.el
@@ -139,7 +139,7 @@
              map-value event evil-value evil-event)
            (interactive)
            (if (and (eq 'evilified evil-state)
-                    (null evil-escape-inhibit))
+                    (not (boundp 'evil-escape-inhibit)))
                ;; evilified state
                ,(if evil-value
                    (spacemacs//evilify-call evil-value event)


### PR DESCRIPTION
Actually I don't know what's this function suppose to do.

I changed it into ```not boundp``` since ```boundp``` will return ```t``` if symbol's value is not void.

Hopefully this will fix issue #2167.