### PR TITLE
enable flycheck in puppet-mode

### DIFF
--- a/contrib/!config/puppet/packages.el
+++ b/contrib/!config/puppet/packages.el
@@ -3,6 +3,7 @@
     puppet-mode
     puppetfile-mode
     company
+    flycheck
     ))
 
 ;; For each package, define a function puppet-mode/init-<package-puppet-mode>
@@ -36,6 +37,9 @@
 
 (defun puppet/post-init-company ()
   (spacemacs|add-company-hook puppet-mode))
+
+(defun puppet/post-init-flycheck ()
+  (add-hook 'puppet-mode-hook 'flycheck-mode))
 
 (defun puppet/init-puppetfile-mode ()
   (use-package puppetfile-mode


### PR DESCRIPTION
Flycheck already knows what to do, we just need to turn it on.

I wonder, wouldn't it be more convenient to turn flycheck on by default for all prog-modes?