### PR TITLE
Fix call to popwin-mode before it's loaded

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2517,7 +2517,7 @@ Put (global-hungry-delete-mode) in dotspacemacs/config to enable by default."
 
 (defun spacemacs/init-popwin ()
   (use-package popwin
-    :init
+    :config
     (progn
       (popwin-mode 1)
       (evil-leader/set-key "wpm" 'popwin:messages)


### PR DESCRIPTION
I removed guide-key and suddenly got this error about popwin-mode not being defined. I guess because guide-key was loading popwin this never showed up, but `(popwin-mode 1)` should be in the config section, not the init section, otherwise there's no guarantee it's loaded in time. 