### PR TITLE
yas: master: configure yas-snippet-dirs before enabling yas-global-mode

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -208,7 +208,6 @@
       (defun spacemacs/load-yasnippet ()
         (unless yas-global-mode
           (progn
-            (yas-global-mode 1)
             (let ((private-yas-dir (concat
                                     configuration-layer-private-directory
                                     "snippets/"))
@@ -222,7 +221,8 @@
                             spacemacs-snippets-dir))
               (yas-load-directory spacemacs-snippets-dir t)
               (yas-load-directory private-yas-dir t)
-              (setq yas-wrap-around-region t))))
+              (setq yas-wrap-around-region t))
+            (yas-global-mode 1)))
         (yas-minor-mode 1))
 
       (add-to-hooks 'spacemacs/load-yasnippet '(prog-mode-hook


### PR DESCRIPTION
fixes https://github.com/syl20bnr/spacemacs/issues/1867
supersedes https://github.com/syl20bnr/spacemacs/pull/2143