### PR TITLE
optimize helm-gtags keybindings

### DIFF
--- a/contrib/gtags/README.org
+++ b/contrib/gtags/README.org
@@ -113,10 +113,10 @@ Since these modes have better Eldoc integration already.
 | Key Binding | Description                                               |
 |-------------+-----------------------------------------------------------|
 | ~SPC m g c~ | create a tag database                                     |
-| ~SPC m g f~ | jump to a file in tag database                            |
-| ~SPC m g g~ | jump to a location based on context                       |
-| ~SPC m g G~ | jump to a location based on context (open another window) |
-| ~SPC m g d~ | find definitions                                          |
+| ~SPC m g P~ | jump to a file in tag database                            |
+| ~SPC m g d~ | jump to a location based on context                       |
+| ~SPC m g D~ | jump to a location based on context (open another window) |
+| ~SPC m g f~ | find definitions                                          |
 | ~SPC m g i~ | present tags in current function only                     |
 | ~SPC m g l~ | jump to definitions in file                               |
 | ~SPC m g n~ | jump to next location in context stack                    |

--- a/contrib/gtags/funcs.el
+++ b/contrib/gtags/funcs.el
@@ -26,10 +26,10 @@
       (add-hook hook 'helm-gtags-mode))
     (evil-leader/set-key-for-mode mode
       "mgc" 'helm-gtags-create-tags
-      "mgd" 'helm-gtags-find-tag
-      "mgf" 'helm-gtags-select-path
-      "mgg" 'helm-gtags-dwim
-      "mgG" 'helm-gtags-dwim-other-window
+      "mgf" 'helm-gtags-find-tag
+      "mgP" 'helm-gtags-select-path
+      "mgd" 'helm-gtags-dwim
+      "mgD" 'helm-gtags-dwim-other-window
       "mgi" 'helm-gtags-tags-in-this-function
       "mgl" 'helm-gtags-parse-file
       "mgn" 'helm-gtags-next-history


### PR DESCRIPTION
When using `ycmd` layer together with `gtags` layer, the keybindings are conflict.

`ycmd` use `SPC m gg` and `SPC m gG` to goto definition.

So I change `helm-gtags-dwim` to `SPC m gd`  and `helm-gtags-dwim-other-window` to `SPC m gD`. 
I think use `dD` for dwim is Mnemonic.


