### PR TITLE
Use `enh-ruby-mode` on interpreter-detected ruby files.

### DIFF
--- a/contrib/!lang/ruby/packages.el
+++ b/contrib/!lang/ruby/packages.el
@@ -38,6 +38,7 @@
   (use-package enh-ruby-mode
     :mode (("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . enh-ruby-mode)
            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))
+    :interpreter "ruby"
     :config
     (progn
       (setq enh-ruby-deep-indent-paren nil


### PR DESCRIPTION
This makes ruby files that start with shebang ruby directives use
`enh-ruby-mode` for consistency with `.rb` files that already use that
mode.