### PR TITLE
[git] Bind `magit-blame` rather than `magit-blame-mode` to "gb".

### DIFF
--- a/contrib/!source-control/git/packages.el
+++ b/contrib/!source-control/git/packages.el
@@ -106,7 +106,7 @@
         (magit-diff "HEAD"))
 
       (evil-leader/set-key
-        "gb" 'magit-blame-mode
+        "gb" 'magit-blame
         "gl" 'magit-log
         "gL" 'magit-log-buffer-file
         "gs" 'magit-status


### PR DESCRIPTION
Calling `magit-blame-mode` directly is not advised as of Magit 2.1.0,
and will leave a buffer in read-only mode upon exit. `magit-blame` also
allows recursive blame upon repeated usage.

See magit/magit#1948.