### PR TITLE
Fix git layer documentation

### DIFF
--- a/contrib/!source-control/git/README.org
+++ b/contrib/!source-control/git/README.org
@@ -61,7 +61,7 @@ function, this is the folder where you keep all your git-controlled projects
 (the path should end up with a ~=/~= to respect Emacs conventions):
 
 #+BEGIN_SRC emacs-lisp
-  (setq magit-repo-dirs '("~/repos/"))
+  (setq magit-repository-directories '("~/repos/"))
 #+END_SRC
 
 For more information, see [[https://magit.github.io/master/magit.html#Status][Magit-User-Manual#Status]]


### PR DESCRIPTION
The variable `magit-repo-dirs` was changed to `magit-repository-directories` in magit 2.1.0