### PR TITLE
Fix `SPC i K` for the first line of buffer.

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -661,12 +661,17 @@ For instance pass En as source for english."
 
 (defun spacemacs/insert-line-above-no-indent (count)
   (interactive "p")
-  (save-excursion
-    (evil-previous-line)
-    (evil-move-end-of-line)
-    (while (> count 0)
-      (insert "\n")
-      (setq count (1- count)))))
+  (let ((p (+ (point) count)))
+    (save-excursion
+       (if (eq (line-number-at-pos) 1)
+          (evil-move-beginning-of-line)
+        (progn
+          (evil-previous-line)
+          (evil-move-end-of-line)))
+      (while (> count 0)
+        (insert "\n")
+        (setq count (1- count))))
+    (goto-char p)))
 
 (defun spacemacs/insert-line-below-no-indent (count)
   "Insert a new line below with no identation."


### PR DESCRIPTION
WIP Fix for #1873.  Attached as PR to make easier to test and update.

Works as desired if you are not on the first character of the buffer.

If you are, the point stays on the new blank line, instead of the
current line.  Need to fix this for this issue to be completely
resolved.