### PR TITLE
Make entire modeline reflect current mode color

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -571,7 +571,7 @@
                  :group 'spacemacs))
         (set-face-attribute (spacemacs/state-color-face state) nil
                             :background color
-                            :foreground (face-background 'mode-line)
+                            :foreground "gray22"
                             :box (face-attribute 'mode-line :box)
                             :inherit 'mode-line))
 
@@ -2656,7 +2656,7 @@ displayed in the mode-line.")
 
       (defun spacemacs/mode-line-prepare-left ()
         (let* ((active (powerline-selected-window-active))
-               (line-face (if active 'mode-line 'mode-line-inactive))
+               (line-face (if active (spacemacs/current-state-face) 'mode-line-inactive))
                (face1 (if active 'powerline-active1 'powerline-inactive1))
                (face2 (if active 'powerline-active2 'powerline-inactive2))
                (state-face (if active (spacemacs/current-state-face) face2))
@@ -2778,7 +2778,7 @@ It is a string holding:
 
       (defun spacemacs/mode-line-prepare-right ()
         (let* ((active (powerline-selected-window-active))
-               (line-face (if active 'mode-line 'mode-line-inactive))
+               (line-face (if active (spacemacs/current-state-face) 'mode-line-inactive))
                (face1 (if active 'powerline-active1 'powerline-inactive1))
                (face2 (if active 'powerline-active2 'powerline-inactive2))
                (state-face (if active (spacemacs/current-state-face) face2))


### PR DESCRIPTION
Much easier to see which mode you are in. Unsure if this change is the "best" approach. Would also appreciate feedback on how to accomplish this without changing `packages.el`.

Pictured: above, current scheme; below, this PR
![2015-07-04-084850_975x98_scrot](https://cloud.githubusercontent.com/assets/112752/8507977/90732342-2229-11e5-81c6-aed4d8079e14.png)

This also makes it *much clearer* when you're in insert mode (perhaps due to my theme, but still):

Pictured: above, current scheme; below, this PR
![2015-07-04-085103_968x86_scrot](https://cloud.githubusercontent.com/assets/112752/8507984/d558d4c0-2229-11e5-81c7-24122ac1fe89.png)
