### PR TITLE
Slime configuration layer readme. Recomend uninstall of any other slime.

### DIFF
--- a/contrib/slime/README.org
+++ b/contrib/slime/README.org
@@ -18,6 +18,8 @@ A Spacemacs contribution layer for [[https://github.com/slime/slime][SLIME]].
 
 * Install
 
+If you have previously installed slime in any other way, it is recomended that you uninstall it before proceeding. You should clean up any config files tied to slime that are left behind as well. Linux users can just purge the slime package if it was a distribution install.
+
 To use this contribution, add it to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp


### PR DESCRIPTION
If you have installed previously a linux distribution slime package, most probably emacs will use it instead of the one configured in spacemacs.