### PR TITLE
Added git ignore for Semantic Layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ server/
 /*.zip
 *.db
 python-*-docs-html
-
+srecode-map.el
 # Private directory
 private/*
 !private/README.md


### PR DESCRIPTION
The semantic layer creates a `~/.emacs.d/srecode-map.el`.  Add it to git ignore so it is not accidentally committed.