### PR TITLE
fix Source Code Pro not found issue

### DIFF
--- a/contrib/chinese/README.org
+++ b/contrib/chinese/README.org
@@ -9,6 +9,7 @@
      - [[#configuration][Configuration]]
          - [[#configure-the-default-input-method配置默认中文输入法][Configure the Default Input Method(配置默认中文输入法)]]
          - [[#configure-the-chinese-pyim-input-method配置中文拼音输入法][Configure the =Chinese-pyim= Input Method(配置中文拼音输入法)]]
+         - [[#enable-youdao有道-dictionary激活有道字典][Enable YouDao(有道) Dictionary(激活有道字典)]]
          - [[#set-monospaced-font-size设置等宽字体）][Set monospaced font size(设置等宽字体）]]
  - [[#key-bindings][Key Bindings]]
      - [[#youdao-dictionary][Youdao Dictionary]]
@@ -46,6 +47,16 @@ file. You could call =pyim-dicts-manager= to open up the settings buffer and
 press =i e= to install the default lexicon. The lexicon is about 20M, so you
 should be patient when downloading starts. After the lexicon file is downloaded,
 just press =s= to save and =R= to restart configuration.
+*** Enable YouDao(有道) Dictionary(激活有道字典)
+The YouDao Dictionary is disabled by default, if you want enable it.
+You should set `chinese-enable-youdao-dict` to `t`.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((chinese :variables
+                                                             chinese-enable-youdao-dict t)))
+
+#+END_SRC
+
 
 *** Set monospaced font size(设置等宽字体）
 If you are mixing Chinese words with English words, the text is not perfectly

--- a/contrib/chinese/config.el
+++ b/contrib/chinese/config.el
@@ -25,5 +25,6 @@
 
 ;; If the Hiragino Sans GB font is not found in your system, you could call this
 ;; method in dotspacemacs/config function with a different Chinese font name.
-(when (system-is-mac)
-  (spacemacs//set-monospaced-font "Source Code Pro" "Hiragino Sans GB" 14 16))
+;; If you are using mac, you could put the following code in your dotspacemacs/config function.
+;; (when (system-is-mac)
+;;   (spacemacs//set-monospaced-font "Source Code Pro" "Hiragino Sans GB" 14 16))

--- a/contrib/chinese/config.el
+++ b/contrib/chinese/config.el
@@ -15,6 +15,9 @@
 (defvar chinese-default-input-method 'pinyin
   "The default chiense input method. Can be `wubi` or `pinyin`.")
 
+(defvar chinese-enable-youdao-dict nil
+  "Enble YouDao Dict translation service.")
+
 ;; Set the monospaced font size when mixed Chinese and English words
 (defun spacemacs//set-monospaced-font (english chinese english-size chinese-size)
   (set-face-attribute 'default nil :font

--- a/contrib/chinese/packages.el
+++ b/contrib/chinese/packages.el
@@ -19,11 +19,11 @@
       ))
 
 (if chinese-enable-youdao-dict
-  (add-to-list 'chinese-packages 'youdao-dictionary))
+  (push 'youdao-dictionary chinese-packages))
 
 (if (eq chinese-default-input-method 'wubi)
-    (add-to-list 'chinese-packages 'chinese-wbim)
-  (add-to-list 'chinese-packages 'chinese-pyim))
+    (push 'chinese-wbim chinese-packages)
+  (push 'chinese-pyim chinese-packages))
 
 (defun chinese/init-chinese-wbim ()
   "Initialize chinese-wubi"

--- a/contrib/chinese/packages.el
+++ b/contrib/chinese/packages.el
@@ -14,12 +14,16 @@
 ;; which require an initialization must be listed explicitly in the list.
 (setq chinese-packages
     '(
-      youdao-dictionary
-      chinese-pyim
       find-by-pinyin-dired
       ace-pinyin
-      chinese-wbim
       ))
+
+(if chinese-enable-youdao-dict
+  (add-to-list 'chinese-packages 'youdao-dictionary))
+
+(if (eq chinese-default-input-method 'wubi)
+    (add-to-list 'chinese-packages 'chinese-wbim)
+  (add-to-list 'chinese-packages 'chinese-pyim))
 
 (defun chinese/init-chinese-wbim ()
   "Initialize chinese-wubi"
@@ -40,6 +44,8 @@
 
 (defun chinese/init-youdao-dictionary ()
   (use-package youdao-dictionary
+    :if chinese-enable-youdao-dict
+    :defer
     :config
     (progn
       ;; Enable Cache


### PR DESCRIPTION
1. fix loading error when "Source Code Pro" font is not installed.
2. only install one of Chinese-pyim and Chinese-wbim package.
3. Make youdao dictionary package an optional package.


