### PR TITLE
Fix ejs detection in html layer

### DIFF
--- a/contrib/!lang/html/packages.el
+++ b/contrib/!lang/html/packages.el
@@ -134,6 +134,7 @@
      ("\\.hbs\\'"        . web-mode)
      ("\\.eco\\'"        . web-mode)
      ("\\.jsx\\'"        . web-mode)
+     ("\\.ejs\\'"        . web-mode)
      ("\\.djhtml\\'"     . web-mode))))
 
 (defun html/init-emmet-mode ()


### PR DESCRIPTION
EJS files were not being opened in web-mode -- now they are.