### PR TITLE
Updated Helm function for `SPC h b` binding

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1478,7 +1478,7 @@ Removes the automatic guessing of the initial value based on thing at point. "
         "ff"   'spacemacs/helm-find-files
         "fF"   'helm-find-files
         "fr"   'helm-recentf
-        "hb"   'helm-pp-bookmarks
+        "hb"   'helm-filtered-bookmarks
         "hi"   'helm-info-at-point
         "hl"   'helm-resume
         "hm"   'helm-man-woman


### PR DESCRIPTION
Helm removed `helm-pp-bookmarks` in the latest update and replaced it with `helm-filtered-bookmarks`.