### PR TITLE
Add jade mode to the html layer; hooks to company for slim & jade; flycheck for slim & haml

### DIFF
--- a/contrib/!lang/html/config.el
+++ b/contrib/!lang/html/config.el
@@ -14,4 +14,8 @@
 
 (spacemacs|defvar-company-backends css-mode)
 (spacemacs|defvar-company-backends web-mode)
+(spacemacs|defvar-company-backends jade-mode)
+(spacemacs|defvar-company-backends slim-mode)
+;;TODO: when this becomes available -- uncomment. -@robbyoconnor
+;; (spacemacs|defvar-company-backends haml-mode)
 

--- a/contrib/!lang/html/packages.el
+++ b/contrib/!lang/html/packages.el
@@ -28,6 +28,7 @@
     yasnippet
     haml-mode
     slim-mode
+    jade-mode
     ))
 
 (defun html/init-css-mode ()
@@ -171,8 +172,13 @@
 
 (defun html/post-init-flycheck ()
   (add-hook 'web-mode-hook 'flycheck-mode)
+  (add-hook `less-mode 'flycheck-mode)
   (add-hook 'scss-mode-hook 'flycheck-mode)
-  (add-hook 'sass-mode-hook 'flycheck-mode))
+  (add-hook 'sass-mode-hook 'flycheck-mode)
+  (add-hook 'slim-mode 'flycheck-mode)
+  (add-hook 'haml-mode 'flycheck-mode)
+  (add-hook 'jade-mode 'flycheck-mode))
+
 
 (defun html/init-tagedit ()
   (use-package tagedit
@@ -187,7 +193,9 @@
   (use-package yasnippet
     :defer t
     :init
-    (add-hook 'css-mode-hook 'spacemacs/load-yasnippet)))
+    (add-hook 'css-mode-hook 'spacemacs/load-yasnippet)
+    (add-hook 'jade-mode 'spacemacs/load-yasnippet)
+    (add-hook 'slim-mode 'spacemacs/load-yasnippet)))
 
 (defun html/init-haml-mode ()
   (use-package haml-mode
@@ -197,10 +205,19 @@
   (use-package slim-mode
     :defer t))
 
+
+(defun html/init-jade-mode ()
+  (use-package jade-mode
+    :defer t))
+
+
 (when (configuration-layer/layer-usedp 'auto-completion)
+  ;;TODO: whenever company-web makes a backend for haml-mode it should be added here. -- @robbyoconnor
   (defun html/post-init-company ()
     (spacemacs|add-company-hook css-mode)
-    (spacemacs|add-company-hook web-mode))
+    (spacemacs|add-company-hook web-mode)
+    (spacemacs|add-company-hook jade)
+    (spacemacs|add-company-hook slim))
 
   (defun html/init-company-web ()
     (use-package company-web)))
@@ -209,4 +226,10 @@
   (when (configuration-layer/package-usedp 'less-css-mode)
     (add-hook 'less-css-mode-hook 'rainbow-delimiters-mode))
   (when (configuration-layer/package-usedp 'scss-mode)
-    (add-hook 'scss-mode-hook 'rainbow-delimiters-mode)))
+    (add-hook 'scss-mode-hook 'rainbow-delimiters-mode))
+  (when (configuration-layer/package-usedp 'jade-mode)
+    (add-hook 'jade-mode-hook 'rainbow-delimiters-mode))
+  (when (configuration-layer/package-usedp 'haml-mode)
+    (add-hook 'haml-mode 'rainbow-delimiters-mode))
+  (when (configuration-layer/package-usedp 'slim-mode)
+    (add-hook 'slim-mode 'rainbow-delimiters-mode)))


### PR DESCRIPTION
This is a lot of changes that **COULD** be multiple PRs but they are all isolated in the `html` layer so I figured I was fine.

**What's done vs. Not done:**

- [x] [Company web][6] for [slim][1] -- yay autocomplete
- [x] [Company web][6] for [Jade][2] -- yay autocomplete
- [x] Support for [Jade][2] using [jade-mode][3]
- [x] [Rainbow-delimiters][5] for [Jade][2] files using [jade-mode][3] -- because, why not!
- [x] Add [Rainbow-delimiters][5] for [Slim][1] and [haml][] files.
- [x] Snippet support for both [slim][1] and [jade][2]
- [x] Flycheck support for [slim][1] and [haml][]
- [x] [Flycheck][4] for [Jade][2] using [jade-mode][3] via flycheck/flycheck#686, which was merged.

**One issue** -- which I have zero control over -- is that it bails on the first error and only reports errors, not warnings.

[haml]: http://haml.info
[1]: http://slim-lang.com
[2]: http://jade-lang.com
[3]: https://github.com/brianc/jade-mode
[4]: http://github.com/flycheck/flycheck
[5]: https://github.com/Fanael/rainbow-delimiters
[6]: https://github.com/osv/company-web