### PR TITLE
Re-PR Add support for launchctld on OS X

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -1,6 +1,7 @@
 (setq osx-packages
   '(
     pbcopy
+    launchctl
     reveal-in-finder
     ))
 
@@ -15,6 +16,38 @@
   (use-package pbcopy
     :if (and (system-is-mac)(not (display-graphic-p))) 
     :init (turn-on-pbcopy)))
+
+(defun osx/init-launchctl ()
+  (use-package launchctl
+    :if (system-is-mac)
+    :defer t
+    :init
+    (progn
+      (add-to-list 'auto-mode-alist '("\\.plist$" . nxml-mode))
+      (evil-leader/set-key "al" 'launchctl))
+    :config
+    (progn
+      (evilify launchctl-mode launchctl-mode-map
+               (kbd "q") 'quit-window
+               (kbd "s") 'tabulated-list-sort
+               (kbd "g") 'launchctl-refresh
+               (kbd "n") 'launchctl-new
+               (kbd "e") 'launchctl-edit
+               (kbd "v") 'launchctl-view
+               (kbd "l") 'launchctl-load
+               (kbd "u") 'launchctl-unload
+               (kbd "r") 'launchctl-reload
+               (kbd "S") 'launchctl-start
+               (kbd "K") 'launchctl-stop
+               (kbd "R") 'launchctl-restart
+               (kbd "D") 'launchctl-remove
+               (kbd "d") 'launchctl-disable
+               (kbd "E") 'launchctl-enable
+               (kbd "i") 'launchctl-info
+               (kbd "f") 'launchctl-filter
+               (kbd "=") 'launchctl-setenv
+               (kbd "#") 'launchctl-unsetenv
+               (kbd "h") 'launchctl-help))))
 
 (defun osx/init-reveal-in-finder ()
   (use-package reveal-in-finder


### PR DESCRIPTION
Re-PR (see #1661) with keybindings following suggestions made by @tko 

PS not sure when use-package was updated for `spacemacs`, but I'm using to current styling, where there's no need to enclose commands between keywords in a `progn` form.