### PR TITLE
Re-factor and expand support for trash can on OS X

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -4,12 +4,32 @@
     reveal-in-finder
     ))
 
-(if (and (system-is-mac) (executable-find "gls")) 
+(when (system-is-mac)
+  ;; Note: `delete-by-moving-to-trash' is set to true globaly in
+  ;; `spacemacs/config.el'
+  ;; (setq trash-directory "~/.Trash/emacs") ; bare minimum
+
+  ;; Use `trash' cli tool, if installed.
+  ;; See brew info trash (or osx-tools)
+  ;; otherwise, enable built-in support for trashing using Finder API
+
+  (if (executable-find "trash")
+      (defun system-move-file-to-trash (file)
+        "Use `trash' to move FILE to the system/volume trash can.
+Can be installed with `brew install trash'." 
+        (call-process (executable-find "trash") nil 0 nil file))
+    (setq mac-system-move-file-to-trash-use-finder t))
+
+  ;; Use `gls' if `coreutils' was installed prefixed ('g') otherwise, leave
+  ;; alone. Manually add to config `(setq dired-use-ls-dired nil)' to surpesss
+  ;; warnings, when not using `coreutils' version of 'ls' on OS X.
+  ;; See brew info coreutils
+  (when (executable-find "gls")
     ;; maybe absolute or relative name of the `ls' program used by
     ;; `insert-directory'.
-    ;; brew info coreutils
     (setq insert-directory-program "gls"
-          dired-listing-switches "-aBhl --group-directories-first"))
+          dired-listing-switches "-aBhl --group-directories-first")
+    ))
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy

--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -143,17 +143,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 
 ;; Use system trash for file deletion
 ;; should work on Windows and Linux distros
-;; on OS X, install `trash' from `homebrew'
+;; on OS X, see contrib/osx layer
 (setq delete-by-moving-to-trash t)
-(when (system-is-mac)
-  ;; use trash if installed
-  (if (executable-find "trash")
-      (defun system-move-file-to-trash (file)
-        "Use `trash' to move FILE to the system trash.
-Can be installed with `brew install trash'."
-        (call-process (executable-find "trash") nil 0 nil file))
-    ;; regular move to trash directory
-    (setq trash-directory "~/.Trash/emacs")))
 
 ;; auto fill breaks line beyond current-fill-column
 (setq-default default-fill-column 80)


### PR DESCRIPTION
Uses the built-in support for moving files to System/Volume trash resulting from operations carried in Emacs, or uses the external cli tool `trash`, if the user has installed it.

Also, removed the OS X specific handling in spacemacs/config.el

I'm not sure what is the minimum version of emacs supporting `mac-system-move-file-to-trash-use-finder`.