### PR TITLE
add .eex extension to web-mode

### DIFF
--- a/contrib/!lang/html/packages.el
+++ b/contrib/!lang/html/packages.el
@@ -128,6 +128,7 @@
      ("\\.htm\\'"        . web-mode)
      ("\\.[gj]sp\\'"     . web-mode)
      ("\\.as[cp]x\\'"    . web-mode)
+     ("\\.eex\\'"        . web-mode)
      ("\\.erb\\'"        . web-mode)
      ("\\.mustache\\'"   . web-mode)
      ("\\.handlebars\\'" . web-mode)


### PR DESCRIPTION
Elixir has a Ruby-like encapsulation syntax which should be used in web-mode.