### PR TITLE
Added java mode prefixes (FIXED)

### DIFF
--- a/contrib/!lang/java/config.el
+++ b/contrib/!lang/java/config.el
@@ -10,3 +10,17 @@
 
 ;; Define the buffer local company backend variable
 (spacemacs|defvar-company-backends java-mode)
+
+;; Command prefixes
+(setq java/key-binding-prefixes '(("me" . "errors")
+                                  ("mf" . "find")
+                                  ("mg" . "goto")
+                                  ("mr" . "refactor")
+                                  ("mh" . "documentation")
+                                  ("mm" . "maven")
+                                  ("ma" . "ant")
+                                  ("mp" . "project")
+                                  ("mt" . "test")))
+
+(mapc (lambda(x) (spacemacs/declare-prefix-for-mode 'java-mode (car x) (cdr x)))
+      java/key-binding-prefixes)


### PR DESCRIPTION
Added prefixes for java mode.  Needs to merge PR https://github.com/syl20bnr/spacemacs/pull/2266 first in order to work. Otherwise the declare-prefix-for-mode method won't be found and Emacs won't boot up correctly,

I am resubmitting this PR becaused I messed my fork and it was easier to delete it and start fresh.
