### PR TITLE
Add ox-pandoc to Org layer

### DIFF
--- a/contrib/org/config.el
+++ b/contrib/org/config.el
@@ -14,3 +14,6 @@
 
 (defvar org-enable-github-support nil
   "If non-nil Github related packages are configured.")
+
+(defvar org-enable-pandoc-support nil
+  "If non-nil Pandoc related packages are configured.")

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -16,6 +16,7 @@
     htmlize
     org
     org-bullets
+    ox-pandoc
     org-pomodoro
     org-present
     org-repo-todo
@@ -206,3 +207,10 @@ Will work on both org-mode and any mode that accepts plain html."
 (defun org/init-htmlize ()
  (use-package htmlize
     :defer t))
+
+(defun org/init-ox-pandoc ()
+  (use-package ox-pandoc
+    :if org-enable-pandoc-support
+    :defer t
+    :init
+    (eval-after-load 'org '(require 'ox-pandoc))))


### PR DESCRIPTION
[`ox-pandoc`][] adds support for exporting Org mode files via Pandoc.

I wanted to make the dependency optional in the same way `ox-gfm` is, so copied the general approach. I've verified `ox-pandoc` is only enabled with `org-enable-pandoc-support` is non-nil, but would appreciate feedback if this could be better implemented.

With Pandoc we can export Org mode files to the following formats:

| Format            | Extension | Buffer | File |
|-------------------|-----------|--------|------|
| asciidoc          | txt       | t      | t    |
| beamer            | tex       | t      | t    |
| beamer-pdf        | pdf       | nil    | t    |
| commonmark        | md        | t      | t    |
| context           | tex       | t      | t    |
| docbook           | xml       | t      | t    |
| docx              |           | nil    | t    |
| dzslides          | html      | t      | t    |
| epub              |           | nil    | t    |
| epub3             | epub      | nil    | t    |
| fb2               | fb2       | t      | t    |
| html              |           | t      | t    |
| html5             | html      | t      | t    |
| icml              |           | t      | t    |
| json              |           | t      | t    |
| latex             | tex       | t      | t    |
| latex-pdf         | pdf       | nil    | t    |
| man               |           | t      | t    |
| markdown          | md        | t      | t    |
| markdown_github   | md        | t      | t    |
| markdown_mmd      | md        | t      | t    |
| markdown_phpextra | md        | t      | t    |
| markdown_strict   | md        | t      | t    |
| mediawiki         |           | t      | t    |
| native            | hs        | t      | t    |
| odt               |           | nil    | t    |
| opendocument      | xml       | t      | t    |
| opml              |           | t      | t    |
| org               |           | t      | t    |
| plain             | txt       | t      | t    |
| revealjs          | html      | t      | t    |
| rst               |           | t      | t    |
| rtf               |           | t      | t    |
| s5                | html      | t      | t    |
| slideous          | html      | t      | t    |
| slidy             | html      | t      | t    |
| texinfo           | texi      | t      | t    |
| textile           |           | t      | t    |

[`ox-pandoc`]: https://github.com/kawabata/ox-pandoc