### PR TITLE
Make sure we use-package git-commit

### DIFF
--- a/contrib/!source-control/git/packages.el
+++ b/contrib/!source-control/git/packages.el
@@ -15,6 +15,7 @@
         gitattributes-mode
         gitconfig-mode
         gitignore-mode
+        git-commit
         git-messenger
         git-timemachine
         helm-gitignore
@@ -30,6 +31,9 @@
   (use-package helm-gitignore
     :defer t
     :init (evil-leader/set-key "gI" 'helm-gitignore)))
+
+(defun git/init-git-commit ()
+  (use-package git-commit))
 
 (defun git/init-git-messenger ()
   (use-package git-messenger


### PR DESCRIPTION
With the move to Magit 2.1.0, `git-commit-mode` is deprecated and no
longer shipped in favor of the `git-commit` package, which is shipped
separately from Magit. This ensures that the `git-commit` package is
loaded so that using Spacemacs as your $GITEDITOR outside of Magit works
as expected.