### PR TITLE
shell-layer: deactivate eshell autocomplete for remote paths

### DIFF
--- a/contrib/shell/packages.el
+++ b/contrib/shell/packages.el
@@ -24,12 +24,22 @@
         magit
         ))
 
+(defun shell/toggle-automatic-completion-based-on-path ()
+  "Deactivates automatic completion on remote paths
+
+Retrieving completions for Eshell blocks Emacs. Over remote
+connections the delay is often annoying, so it's better to let
+the user activate the completion manually."
+  (if (file-remote-p default-directory)
+      (setq-local company-idle-delay nil)
+    (setq-local company-idle-delay 0.2)))
+
 (defun shell/post-init-company ()
   ;; support in eshell
   (spacemacs|use-package-add-hook eshell
     :post-config
     (progn
-      (setq-local company-idle-delay 0.2)
+      (add-hook 'eshell-directory-change-hook 'shell/toggle-automatic-completion-based-on-path)
       ;; The default frontend screws everything up in short windows like
       ;; terminal often are
       (setq-local company-frontends '(company-preview-frontend))


### PR DESCRIPTION
Retrieving completions for Eshell blocks Emacs. Over remote connections the delay is often annoying, so it's better to let the user activate the completion manually when needed.