### PR TITLE
Setup indentation rules for common Clojure vars

### DIFF
--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -238,7 +238,33 @@ the focus."
     :config
     (progn
       (when clojure-enable-fancify-symbols
-        (clojure/fancify-symbols 'clojure-mode)))))
+        (clojure/fancify-symbols 'clojure-mode))
+
+      (define-clojure-indent
+        ;; Compojure
+        (ANY 2)
+        (DELETE 2)
+        (GET 2)
+        (HEAD 2)
+        (POST 2)
+        (PUT 2)
+        (context 2)
+        (defroutes 'defun)
+
+        ;; Cucumber
+        (After 1)
+        (Before 1)
+        (Given 2)
+        (Then 2)
+        (When 2)
+
+        ;; Schema
+        (s/defrecord 2)
+
+        ;; test.check
+        (for-all 'defun)
+        ))))
+
 (defun clojure/init-rainbow-delimiters ()
   (if (configuration-layer/package-usedp 'cider)
       (add-hook 'cider-mode-hook 'rainbow-delimiters-mode)))


### PR DESCRIPTION
Most Clojure users will share a certain amount of indentation settings, and although the list of libraries used is personal the indentation settings are not.

I'd like to start a conversation about whether this is something that belongs in Spacemacs… what are your thoughts @syl20bnr?