### PR TITLE
shell-layer: fix magit-status alias

### DIFF
--- a/contrib/shell/packages.el
+++ b/contrib/shell/packages.el
@@ -257,10 +257,4 @@
 (defun shell/pre-init-magit ()
   (spacemacs|use-package-add-hook magit
     :post-init
-    (progn
-      ;; add a quick alias to open magit-status in current directory
-      (defun spacemacs/eshell-magit-status ()
-        "Function to open magit-status for the current directory"
-        (interactive)
-        (magit-status default-directory))
-      (defalias 's 'spacemacs/eshell-magit-status))))
+    (defalias 's 'magit-status)))


### PR DESCRIPTION
Now (i guess after the 2.1 release) magit-status can be executed
directly in eshell. If magit-status is called with the path as parameter
the path must be the git repo root. If not from the git repo root magit
will ask if a new repo should be created like this:

```
~/system-management/ is a repository.  Create another in ~/system-management/ansible/? (y or n)
```