### PR TITLE
Add support for fancy frame title

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -56,6 +56,10 @@ of a list then all discovered layers will be installed.")
 Press <SPC> T n to cycle to the next theme in the list (works great
 with 2 themes variants, one dark and one light")
 
+(defvar dotspacemacs-frame-title-format nil
+  "Default format string for a frame title bar, using the
+  original format spec, and additional customizations.")
+
 (defvar dotspacemacs-colorize-cursor-according-to-state t
   "If non nil the cursor color matches the state color.")
 
@@ -261,6 +265,51 @@ value."
   "Load ~/.spacemacs if it exists."
   (let ((dotspacemacs (dotspacemacs/location)))
     (if (file-exists-p dotspacemacs) (load dotspacemacs))))
+
+(defun spacemacs/frame-title-prepare ()
+  "A string is printed verbatim except for %-constructs.
+  %a -- prints the `abbreviated-file-name', or `buffer-name'
+  %t -- prints `projectile-project-name'
+  %I -- prints `invocation-name'
+  %S -- prints `system-name'
+  %U -- prints contents of $USER
+  %b -- prints buffer name
+  %f -- prints visited file name
+  %F -- prints frame name
+  %s -- prints process status
+  %p -- prints percent of buffer above top of window, or Top, Bot or All
+  %P -- prints percent of buffer above bottom of window, perhaps plus Top, or
+  print Bottom or All
+  %m -- prints mode name
+  %n -- prints Narrow if appropriate
+  %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
+  %Z -- like %z, but including the end-of-line format"
+  (let* ((fs (format-spec-make
+              ?a (abbreviate-file-name (or (buffer-file-name) (buffer-name))) 
+              ?t (if (boundp 'projectile-mode) (projectile-project-name) "-")
+              ?S system-name
+              ?I invocation-name
+              ?U (or (getenv "USER") "")
+              ?b "%b"
+              ?f "%f"
+              ?F "%F"
+              ?* "%*"
+              ?+ "%+"
+              ?s "%s"
+              ?l "%l"
+              ?c "%c"
+              ?p "%p"
+              ?P "%P"
+              ?m "%m"
+              ?n "%n"
+              ?z "%z"
+              ?Z "%Z"
+              ?[ "%["
+              ?] "%]"
+              ?% "%%"
+              ?- "%-"
+              )))
+    (format-spec dotspacemacs-frame-title-format fs)))
 
 (defmacro dotspacemacs|call-func (func &optional msg)
   "Call the function from the dotfile only if it is bound.

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -77,6 +77,9 @@ initialization."
   ;; spacemacs init
   (switch-to-buffer (get-buffer-create spacemacs-buffer-name))
   (spacemacs-buffer/set-mode-line "")
+  ;; frame title init
+  (when (and (display-graphic-p) dotspacemacs-frame-title-format)
+    (setq frame-title-format '((:eval (spacemacs/frame-title-prepare)))))
   ;; no welcome buffer
   (setq inhibit-startup-screen t)
   ;; default theme

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -152,6 +152,8 @@ before layers configuration."
    ;; specified with an installed package.
    ;; Not used for now.
    dotspacemacs-default-package-repository nil
+   ;; Format specification for setting the frame title.
+   dotspacemacs-frame-title-format "%I@%S"
    )
   ;; User initialization goes here
   )


### PR DESCRIPTION
@syl20bnr  Follow-up to #2139, this is a somewhat naive, I believe, attempt allow users to format the frame title dynamically.

The default behavior is that only when there is more than one frame, the frame-title is updated to show buffer/file name in the title. At least for me this is the default behavior.

This solution uses the built-in format specs (which are passed verbatim) and adds couple of new ones, like:

%a abbreviated-file-name (if buffer visiting a file, or buffer name)
%t name of projectile project (or "-")
%S system-name
%I invocation-name (name of the program, which is "Emacs")
%U user name (taken for $USER, if defined)

I wasn't sure where in `core-spacemacs.el` put the initialization code, if it even belongs there. 

Right now, as is, frame-title will blank before becoming visible again, so I guess it's not the right place.

Also, default for configuration template is "%I@%S", which gives me "Emacs@imac.local" (my hostname), which is what you get by default with spacemacs or without any startup init at all.

Example user customization  (in .spacemacs)

```emacs-lisp
   dotspacemacs-frame-title-format "%a [%t] (%U@%S)"
```

I should also add that not all original specs work as expected, and I'm not even sure if they should work when used for  frame-title (notably the %+, %- etc.)