### PR TITLE
Enabled comment inversion without toggling switch

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2081,15 +2081,17 @@ well.
 *** Commenting
 Comments are handled by [[https://github.com/redguardtoo/evil-nerd-commenter][evil-nerd-commenter]], it's bound to the following keys.
 
-    | Key Binding | Description        |
-    |-------------+--------------------|
-    | ~SPC ;~     | comment operator   |
-    | ~SPC c i~   | comment invert     |
-    | ~SPC c l~   | comment lines      |
-    | ~SPC c p~   | comment paragraphs |
-    | ~SPC c r~   | comment region     |
-    | ~SPC c t~   | comment to line    |
-    | ~SPC c y~   | comment and yank   |
+    | Key Binding | Description               |
+    |-------------+---------------------------|
+    | ~SPC ;~     | comment operator          |
+    | ~SPC c l~   | comment lines             |
+    | ~SPC c L~   | invert comment lines      |
+    | ~SPC c p~   | comment paragraphs        |
+    | ~SPC c P~   | invert comment paragraphs |
+    | ~SPC c t~   | comment to line           |
+    | ~SPC c T~   | invert comment to line    |
+    | ~SPC c y~   | comment and yank          |
+    | ~SPC c Y~   | invert comment and yank   |
 
 *Tips:* To comment efficiently a block of line use the combo ~SPC ; SPC l~
 

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -539,6 +539,49 @@ argument takes the kindows rotate backwards."
   "Edit the `file' in the spacemacs base directory, in the current window."
   (ido-find-file-in-dir configuration-layer-contrib-directory))
 
+;; doubled all the commenting functions so that the inverse operations
+;; can be called without setting a flag
+(defun comment-or-uncomment-lines-inverse (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line t))
+    (evilnc-comment-or-uncomment-lines NUM)))
+
+(defun comment-or-uncomment-lines (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line nil))
+    (evilnc-comment-or-uncomment-lines NUM)))
+
+(defun copy-and-comment-lines-inverse (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line t))
+    (evilnc-copy-and-comment-lines NUM)))
+
+(defun copy-and-comment-lines (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line nil))
+    (evilnc-copy-and-comment-lines NUM)))
+
+(defun quick-comment-or-uncomment-to-the-line-inverse (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line t))
+    (evilnc-comment-or-uncomment-to-the-line NUM)))
+
+(defun quick-comment-or-uncomment-to-the-line (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line nil))
+    (evilnc-comment-or-uncomment-to-the-line NUM)))
+
+(defun comment-or-uncomment-paragraphs-inverse (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line t))
+    (evilnc-comment-or-uncomment-paragraphs NUM)))
+
+(defun comment-or-uncomment-paragraphs (&optional NUM)
+  (interactive "p")
+  (let ((evilnc-invert-comment-line-by-line nil))
+    (evilnc-comment-or-uncomment-paragraphs NUM)))
+
+
 ;; From http://xugx2007.blogspot.ca/2007/06/benjamin-rutts-emacs-c-development-tips.html
 (setq compilation-finish-function
       (lambda (buf str)

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -150,6 +150,15 @@ Ensure that helm is required before calling FUNC."
 (evil-leader/set-key "cc" 'helm-make-projectile)
 (evil-leader/set-key "cC" 'compile)
 (evil-leader/set-key "cr" 'recompile)
+;; Commenting -----------------------------------------------------------------
+(evil-leader/set-key "cl" 'comment-or-uncomment-lines)
+(evil-leader/set-key "cL" 'comment-or-uncomment-lines-inverse)
+(evil-leader/set-key "cp" 'comment-or-uncomment-paragraphs)
+(evil-leader/set-key "cP" 'comment-or-uncomment-paragraphs-inverse)
+(evil-leader/set-key "ct" 'quick-comment-or-uncomment-to-the-line)
+(evil-leader/set-key "cT" 'quick-comment-or-uncomment-to-the-line-inverse)
+(evil-leader/set-key "cy" 'copy-and-comment-lines)
+(evil-leader/set-key "cY" 'copy-and-comment-lines-inverse)
 ;; narrow & widen -------------------------------------------------------------
 (evil-leader/set-key
   "nr" 'narrow-to-region

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -920,23 +920,15 @@ Example: (evil-map visual \"<\" \"<gv\")"
       (setq evil-lisp-state-global t)
       (setq evil-lisp-state-leader-prefix "k"))))
 
+;; other commenting functions in funcs.el with keybinds in keybindings.el
 (defun spacemacs/init-evil-nerd-commenter ()
   (use-package evil-nerd-commenter
-    :commands (evilnc-comment-operator
-               evilnc-comment-or-uncomment-lines
-               evilnc-toggle-invert-comment-line-by-line
-               evilnc-comment-or-uncomment-paragraphs
-               evilnc-quick-comment-or-uncomment-to-the-line
-               evilnc-copy-and-comment-lines)
+    :commands (evilnc-comment-operator)
     :init
     (progn
       (evil-leader/set-key
-        ";"  'evilnc-comment-operator
-        "cl" 'evilnc-comment-or-uncomment-lines
-        "ci" 'evilnc-toggle-invert-comment-line-by-line
-        "cp" 'evilnc-comment-or-uncomment-paragraphs
-        "ct" 'evilnc-quick-comment-or-uncomment-to-the-line
-        "cy" 'evilnc-copy-and-comment-lines))))
+        ";"  'evilnc-comment-operator))))
+
 
 (defun spacemacs/init-evil-matchit ()
   (use-package evil-matchit


### PR DESCRIPTION
Previously, you had to set the evilnc-invert-comment-line-by-line
to be enable inverted comments. Since whether you want to invert
comments or not varies on a case to case basis, depending on the region
you wish to comment, this is bad UI.

Made two functions per original commenting function, one for inverse
the other for regular.

Added keybindings for the new inverted operations on capital letter,
so that comment lines is SPC c l and invert comment lines is SPC c L.

I removed the comment invert toggle as it is no longer needed.

(Also removed old docs which said that SPC c r is comment region;
it is actually recompile)