### PR TITLE
shell layer: Add option to protect the Eshell prompt

### DIFF
--- a/contrib/shell/README.org
+++ b/contrib/shell/README.org
@@ -10,6 +10,7 @@
      - [[#default-shell-position-and-height][Default shell position and height]]
      - [[#set-shell-for-term-and-ansi-term][Set shell for term and ansi-term]]
      - [[#enable-em-smart-in-eshell][Enable em-smart in Eshell]]
+     - [[#protect-your-eshell-prompt][Protect your Eshell prompt]]
  - [[#eshell][Eshell]]
  - [[#key-bindings][Key bindings]]
      - [[#multi-term][Multi-term]]
@@ -102,6 +103,22 @@ To enable =em-smart= put the following layer variable to non-nil:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
     '(shell :variables shell-enable-smart-eshell t))
+#+END_SRC
+
+** Protect your Eshell prompt
+
+Comint mode (Shell mode) has good support for Evil mode as it inhibits movement
+commands over the prompt. This has the added benefit that Evil mode functions
+work sensibly. E.g. you can press ~cc~ in normal state i.e.
+=evil-change-whole-line= to kill the current input and start typing a new
+command. In Eshell you also kill the prompt, which is often unintended.
+
+To enable a the same behavior as in Comint mode you can enable the following
+variable:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '(shell :variables shell-protect-eshell-prompt t))
 #+END_SRC
 
 * Eshell

--- a/contrib/shell/config.el
+++ b/contrib/shell/config.el
@@ -32,3 +32,8 @@
 (defvar shell-enable-smart-eshell nil
   "If non-nil then `em-smart' is enabled. `em-smart' allows to quickly review
 commands, modify old commands or enter a new one.")
+
+(defvar shell-protect-eshell-prompt nil
+  "If non-nil then eshell's prompt is protected. This means that
+  that movement to the prompt is inhibited like for `comint-mode'
+  prompts and the prompt is made read-only")

--- a/contrib/shell/packages.el
+++ b/contrib/shell/packages.el
@@ -60,6 +60,23 @@
                    (not (eq (line-end-position) (point-max))))
           (end-of-buffer)))
 
+      (when shell-protect-eshell-prompt
+        (defun protect-eshell-prompt ()
+          "Protect Eshell's prompt like Comint's prompts.
+
+E.g. `evil-change-whole-line' won't wipe the prompt. This
+is achieved by adding the relevant text properties."
+          (let ((inhibit-field-text-motion t))
+            (add-text-properties
+             (point-at-bol)
+             (point)
+             '(rear-nonsticky t
+               inhibit-line-move-field-capture t
+               field output
+               read-only t
+               front-sticky (field inhibit-line-move-field-capture)))))
+        (add-hook 'eshell-after-prompt-hook 'protect-eshell-prompt))
+
       (defun spacemacs//init-eshell ()
         "Stuff to do when enabling eshell."
         (setq pcomplete-cycle-completions nil)


### PR DESCRIPTION
Comint mode (Shell mode) has good support for Evil mode as the prompt inhibits movement commands. This has the added benefit that Evil mode functions work sensibly. E.g. you can press ~cc~ in normal state i.e. =evil-change-whole-line= to kill the current input and start typing a new command. In Eshell you also kill the prompt, which is often unintended.

The pop-shell functionality is currently broken and pending the merge of one PR: https://github.com/kyagi/shell-pop-el/pull/33

Relevant StackExchange question: http://emacs.stackexchange.com/questions/13592/how-does-comint-mode-override-beginning-of-line-behavior-i-want-same-functional