### PR TITLE
Add <leader>msa to "send all" in clojure-mode

### DIFF
--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -154,6 +154,7 @@ the focus."
         "mgg" 'cider-jump-to-var
         "mgr" 'cider-jump-to-resource
 
+        "msa" 'cider-refresh
         "msb" 'cider-load-buffer
         "msB" 'spacemacs/cider-send-buffer-in-repl-and-focus
         "msc" 'cider-connect


### PR DESCRIPTION
Not sure if there's a better mnemonic for this, but if I'm guessing right and `s` stands for `send` then send all makes some sense.

I've missed being able to refresh my namespaces via a single key binding more than anything else since I started using Spacemacs, and hope others will find this useful.