### PR TITLE
Bind <leader>msQ to restart Cider

### DIFF
--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -165,6 +165,7 @@ the focus."
         "msn" 'spacemacs/cider-send-ns-form-to-repl
         "msN" 'spacemacs/cider-send-ns-form-to-repl-focus
         "msq" 'cider-quit
+        "msQ" 'cider-restart
         "msr" 'spacemacs/cider-send-region-to-repl
         "msR" 'spacemacs/cider-send-region-to-repl-focus
         "mss" 'cider-switch-to-repl-buffer


### PR DESCRIPTION
Sometimes restarting Cider is necessary, for example when you remove files that have already been used. As this seems like an extension of quitting Cider I've opted for <kbd>SPC m s Q</kbd>.
