### PR TITLE
Teach shell-scripts about common ZSH files

### DIFF
--- a/contrib/!lang/shell-scripts/config.el
+++ b/contrib/!lang/shell-scripts/config.el
@@ -1,0 +1,27 @@
+;;; packages.el --- Shell Scripts Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: James Conroy-Finn <james@logi.cl>
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Use sh-mode when opening `.zsh' files, and when opening Prezto runcoms.
+(dolist (pattern '("\\.zsh\\'"
+                   "zlogin\\'"
+                   "zlogout\\'"
+                   "zpreztorc\\'"
+                   "zprofile\\'"
+                   "zshenv\\'"
+                   "zshrc\\'"))
+  (add-to-list 'auto-mode-alist (cons pattern 'sh-mode)))
+
+;; When we open a `.zsh' file set the shell to ZSH.
+(add-hook
+ 'sh-mode-hook
+ (lambda ()
+   (if (string-match "\\.zsh$" buffer-file-name)
+       (sh-set-shell "zsh"))))


### PR DESCRIPTION
I wasn't sure of the best place to put these settings. As it's related to shell scripting I thought the shell-scripts layer might be the right place.

I was looking for something like [`add-auto-mode`][] to simplify adding a list of file patterns to the `auto-mode-alist` but nothing jumped out at me. If there's an existing way of doing this I'll happily make use of it, or failing that can repeat the calls to `add-to-list` (maybe that should be a `push`…)

``` elisp
(defun add-auto-mode (mode &rest patterns)
  "Add entries to `auto-mode-alist' to use `MODE' for all given file
`PATTERNS'."
  (dolist (pattern patterns)
    (add-to-list 'auto-mode-alist (cons pattern mode))))
```

[`add-auto-mode`]: https://github.com/jcf/emacs.d/blob/5861b347e66fb17f6df6fbbb8a9d1cbcaa6d0309/init-defuns.org#add-auto-mode