### PR TITLE
Home buffer: make number of recent files configurable #2335

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -217,6 +217,10 @@ NOT USED FOR NOW :-)")
   "List of items to show in the startup buffer. If nil it is disabled.
 Possible values are: `recents' `bookmarks' `projects'.")
 
+(defvar dotspacemacs-startup-recent-list-size 5
+  "Number of recent files to show in the startup buffer. Ignored if
+`dotspacemacs-startup-lists' doesn't include `recents'.")
+
 (defvar dotspacemacs-excluded-packages '()
   "A list of packages and/or extensions that will not be install and loaded.")
 

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -521,7 +521,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
               (cond
                ((eq el 'recents)
                 (recentf-mode)
-                (when (spacemacs-buffer//insert-file-list "Recent Files:" (recentf-elements 5))
+                (when (spacemacs-buffer//insert-file-list "Recent Files:" (recentf-elements dotspacemacs-startup-recent-list-size))
                   (spacemacs//insert--shortcut "r" "Recent Files:")
                   (insert list-separator)))
                ((eq el 'bookmarks)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -75,6 +75,9 @@ values."
    ;; Possible values are: `recents' `bookmarks' `projects'.
    ;; (default '(recents projects))
    dotspacemacs-startup-lists '(recents projects)
+   ;; Number of recent files to show in the startup buffer. Ignored if
+   ;; `dotspacemacs-startup-lists' doesn't include `recents'. (default 5)
+   dotspacemacs-startup-recent-list-size 5
    ;; List of themes, the first of the list is loaded when spacemacs starts.
    ;; Press <SPC> T n to cycle to the next theme in the list (works great
    ;; with 2 themes variants, one dark and one light)


### PR DESCRIPTION
Fixes issue #2335

Currently the number of recent files in the home buffer is hard-coded to 5, this PR makes the number configurable as a dotspacemacs variable.