### PR TITLE
motion-state for flycheck and anaconda-nav-mode

### DIFF
--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -43,6 +43,13 @@
         "mhh" 'anaconda-mode-view-doc
         "mgg" 'anaconda-mode-goto
         "mgu" 'anaconda-mode-usages)
+      (evilify anaconda-nav-mode anaconda-nav-mode-map
+               "RET" #'anaconda-nav-goto-item
+               "j" #'next-error
+               "k" #'previous-error
+               "J" #'anaconda-nav-next-module
+               "K" #'anaconda-nav-previous-module
+               "q" #'anaconda-nav-quit)
       (spacemacs|hide-lighter anaconda-mode))))
 
 (defun python/init-cython-mode ()

--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -102,7 +102,11 @@
       ;; key bindings
       (evil-leader/set-key
         "ec" 'flycheck-clear
-        "el" 'flycheck-list-errors))))
+        "el" 'flycheck-list-errors)
+      (evilify flycheck-error-list-mode flycheck-error-list-mode-map
+               "RET" #'flycheck-error-list-goto-error
+               "j" #'flycheck-error-list-next-error
+               "k" #'flycheck-error-list-previous-error))))
 
 (defun syntax-checking/init-flycheck-pos-tip ()
   (use-package flycheck-pos-tip


### PR DESCRIPTION
Add `flycheck-error-list-mode` and `anaconda-nav-mode` (python usages buffer) to evil-motion-state-modes, and define some useful key bindings for each. Previously they were opened in normal mode.

Makes the relevant code buffer "follow" the selected line when hitting <kbd>j</kbd> or <kbd>k</kbd> in either mode. Also <kbd>q</kbd> now closes the flycheck/anaconda window. I find the flycheck and anaconda buffers much easier to use like this.

Not sure about the <kbd>J</kbd> and <kbd>K</kbd> bindings for next/previous module in `anaconda-nav-mode`, maybe <kbd>l</kbd> and <kbd>h</kbd> would be better.