### PR TITLE
add highlight-indentation-mode support for python and ruby (can disable but is enabled by default)

### DIFF
--- a/contrib/!lang/python/README.org
+++ b/contrib/!lang/python/README.org
@@ -41,6 +41,22 @@ To use this contribution add it to your =~/.spacemacs=
   (setq-default dotspacemacs-configuration-layers '(python))
 #+END_SRC
 
+There is a configuration setting to add [[https://github.com/antonj/Highlight-Indentation-for-Emacs][highlight-indentation-mode]], which is handy.
+It shows you where your code is indented since indentation level determines scope.
+
+It is *enabled* by default, unless explicitly set to =nil= in your =~/.spacemacs=.
+
+- To *disable* it, set the =enable-highlight-indentation-mode= variable to =nil=
+
+- To *enable* it, set the =enable-highlight-identation-mode= to =t=
+
+To *disable* when add the layer in your =~/.spacemacs= do:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(python :variables enable-highlight-indentation-mode nil))
+#+END_SRC
+
+
 ** Test runner
 
 Both =nose= and =pytest= are supported. By default =nose= is used.

--- a/contrib/!lang/python/config.el
+++ b/contrib/!lang/python/config.el
@@ -19,5 +19,8 @@
 (defvar python-enable-yapf-format-on-save nil
   "If non-nil, automatically format code with YAPF on save.")
 
+(defvar enable-highlight-indentation-mode t
+  "If non-nil will enable highlight-indentation-mode")
+
 (defvar python-test-runner 'nose
   "Test runner to use. Possible values are `nose' or `pytest'.")

--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -142,6 +142,9 @@
                        'python-setup-shell))
     :config
     (progn
+      (when enable-highlight-indentation-mode
+        (spacemacs|diminish highlight-indentation-mode " ⓗ" "h")
+        (add-hook 'python-mode-hook 'highlight-indentation-mode))
       (add-hook 'inferior-python-mode-hook 'smartparens-mode)
       ;; add support for `ahs-range-beginning-of-defun' for python-mode
       (eval-after-load 'auto-highlight-symbol

--- a/contrib/!lang/ruby/README.org
+++ b/contrib/!lang/ruby/README.org
@@ -24,6 +24,20 @@ To use this contribution add it to your =~/.spacemacs=
   (setq-default dotspacemacs-configuration-layers '(ruby))
 #+END_SRC
 
+There is a configuration setting to add [[https://github.com/antonj/Highlight-Indentation-for-Emacs][highlight-indentation-mode]], which is handy.
+
+It is *enabled* by default, unless explicitly set to =nil= in your =~/.spacemacs=.
+
+- To *disable* it, set the =enable-highlight-indentation-mode= variable to =nil=
+
+- To *enable* it, set the =enable-highlight-identation-mode= to =t=
+
+To *disable* when add the layer in your =~/.spacemacs= do:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(ruby :variables enable-highlight-indentation-mode nil))
+#+END_SRC
+
 ** Prerequisites
 
 Some of the advanced features supported by this layer depend on external gems

--- a/contrib/!lang/ruby/config.el
+++ b/contrib/!lang/ruby/config.el
@@ -16,3 +16,6 @@
 
 (defvar ruby-version-manager nil
   "If non nil defines the Ruby version manager (i.e. rbenv, rvm)")
+
+(defvar enable-highlight-indentation-mode t
+  "If non-nil will enable highlight-indentation-mode")

--- a/contrib/!lang/ruby/packages.el
+++ b/contrib/!lang/ruby/packages.el
@@ -47,6 +47,9 @@
            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))
     :config
     (progn
+      (when enable-highlight-indentation-mode
+        (spacemacs|diminish highlight-indentation-mode " ⓗ" "h")
+        (add-hook 'enh-ruby-mode-hook 'highlight-indentation-mode))
       (setq enh-ruby-deep-indent-paren nil
             enh-ruby-hanging-paren-deep-indent-level 2)
       (sp-with-modes '(ruby-mode enh-ruby-mode)


### PR DESCRIPTION
Add highlight-indentation-mode and document it. 