### PR TITLE
Add diminish for highlight-indentation-mode and highlight-indentation-current-column-mode

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -915,6 +915,8 @@ can be reached using the =control= key.
 | ~SPC t F~   | =Ⓕ=     | F     | auto-fill mode                      |
 | ~SPC t g~   | =ⓖ=     | g     | [[https://github.com/roman/golden-ratio.el][golden-ratio]] mode                   |
 | ~SPC t G~   | =Ⓖ=     | G     | guide-key mode                      |
+| ~SPC t h i~ | =ⓗ=     | h     | toggle highlight indentation levels         |
+| ~SPC t h c~ | =ⓗⒸ=    | hC    | toggle highlight indentation current column |
 | ~SPC t i~   | =ⓘ=     | i     | indentation guide                   |
 | ~SPC t C-i~ | =ⓘ=     | i     | global indentation guide            |
 | ~SPC t I~   | =Ⓘ=     | I     | aggressive indent mode              |

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2093,7 +2093,10 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         :on (highlight-indentation-current-column-mode)
         :off (highlight-indentation-current-column-mode -1)
         :documentation "Highlight indentation level at point."
-        :evil-leader "thc"))))
+        :evil-leader "thc"))
+    :config
+    (spacemacs|diminish highlight-indentation-mode " ⓗ" " h")
+    (spacemacs|diminish highlight-indentation-current-column-mode " ⓗⒸ" " hC")))
 
 (defun spacemacs/init-highlight-numbers ()
   (use-package highlight-numbers


### PR DESCRIPTION
The || and | were *HORRIBLE* -- and I hated them (for highlight-indentation-mode and highlight-indentation-current-column-mode respectively)  

Here is an illustration of the problem that lead to this change: 
![image](https://cloud.githubusercontent.com/assets/23088/8773815/6a778c18-2ea5-11e5-922f-b42cdac95d15.png)

I chose:
-  ⓗ (h for non-unicode) for highlight-indentation-mode
- ⓗⒸ (hC for non-unicode) for  highlight-indentation-current-column-mode

I couldn't think of a better one for highlight-indentation-current-column-mode and am open to suggestions. 

Here is the change with both highlight-indentation-mode and highlight-indentation-current-column-mode enabled -- you can see it's much cleaner: 

With unicode: 

![image](https://cloud.githubusercontent.com/assets/23088/8923528/dcd7e86e-34bf-11e5-8059-b237459274c8.png)

Without unicode: 

![image](https://cloud.githubusercontent.com/assets/23088/8923544/13f36e90-34c0-11e5-8652-918b18d903a0.png)


