### PR TITLE
Turn projectile-rails on for all rails file in a rail project

### DIFF
--- a/contrib/!frameworks/ruby-on-rails/packages.el
+++ b/contrib/!frameworks/ruby-on-rails/packages.el
@@ -23,7 +23,7 @@
     :defer t
     :init
     (progn
-      (add-hook 'enh-ruby-mode-hook 'projectile-rails-on))
+      (add-hook 'projectile-mode-hook 'projectile-rails-on))
     :config
     (progn
       (spacemacs|diminish projectile-rails-mode " ⇋" " RoR")


### PR DESCRIPTION
Turn projectile-rails on for all rails file in a rail project, not only for enh-ruby-mode files(`.rb` files), but also for `.erb` files.

The `projectile-rails-on` function checks whether it's in a rails project. 