### PR TITLE
Add unicode to core with SPC i u which stands for insert unicode

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -123,6 +123,7 @@
              - [[#paste-micro-state][Paste Micro-state]]
              - [[#auto-indent-pasted-text][Auto-indent pasted text]]
          - [[#text-manipulation-commands][Text manipulation commands]]
+         - [[#searching-and-inserting-unicode-characters][Searching and inserting unicode characters]]
          - [[#smartparens-strict-mode][Smartparens Strict mode]]
          - [[#zooming][Zooming]]
              - [[#text][Text]]
@@ -1856,6 +1857,12 @@ Text related commands (start with ~x~):
     | ~SPC x w c~ | count the number of words in the selection region             |
     | ~SPC x w C~ | count the number of occurrences per word in the select region |
     | ~SPC x w d~ | show dictionary entry of word from wordnik.com                |
+
+*** Searching and inserting unicode characters
+     You can very easily search for and insert unicode characters into the current buffer.
+     | Key Binding | Description                                                                              |
+     |-------------+------------------------------------------------------------------------------------------|
+     | ~SPC i u~   | Search for unicode characters using [[https://github.com/shosti/helm-unicode][helm-unicode]] and insert them into the active buffer. |
 
 *** Smartparens Strict mode
 [[https://github.com/Fuco1/smartparens][Smartparens]] comes with a strict mode which prevents deletion of parenthesis if

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -68,6 +68,7 @@
         helm-projectile
         helm-swoop
         helm-themes
+        helm-unicode
         highlight-indentation
         highlight-numbers
         highlight-parentheses
@@ -2076,6 +2077,12 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
     :init
     (evil-leader/set-key
       "Th" 'helm-themes)))
+
+(defun spacemacs/init-helm-unicode ()
+  (use-package helm-unicode
+    :defer t
+    :init
+      (evil-leader/set-key "iu" 'helm-unicode)))
 
 (defun spacemacs/init-highlight-indentation ()
   (use-package highlight-indentation


### PR DESCRIPTION
Use  [helm-unicode](https://github.com/shosti/helm-unicode/) to help users select unicode characters by name and insert them into the active buffer. I chose to add this to core as I didn't feel it belonged in a layer.

I don't know why but it looks pretty in emacs but shitty in markdown and on when opened elsewhere :( 