### PR TITLE
Edebug Contribution Layer

### DIFF
--- a/contrib/edebug/extensions.el
+++ b/contrib/edebug/extensions.el
@@ -1,0 +1,31 @@
+;;; extensions.el --- edebug Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq edebug-pre-extensions
+      '(
+        ;; pre extension names go here
+        ))
+
+(setq edebug-post-extensions
+      '(
+        ;; post extension names go here
+        ))
+
+;; For each extension, define a function edebug/init-<extension-name>
+;;
+;; (defun edebug/init-my-extension ()
+;;   "Initialize my extension"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package

--- a/contrib/edebug/packages.el
+++ b/contrib/edebug/packages.el
@@ -1,0 +1,65 @@
+;;;; packages.el --- edebug Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Christopher McCloud <mccloud.christopher@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; List of all packages to install and/or initialize. Built-in packages
+;; which require an initialization must be listed explicitly in the list.
+(setq edebug-packages
+      '(
+        edebug
+        edebug-x
+        ))
+
+(defun edebug/init-edebug ()
+  (use-package edebug
+   :config
+   (progn
+
+     (defun spacemacs//toggle-edebug-micro-state ()
+       "Activates evilified mode and triggers edebug micro state.
+Attaches to edebug-mode-hook"
+       (if (evil-evilified-state-p)
+           (normal-mode)
+         (evil-evilified-state))
+       (spacemacs/edebug-mode-micro-state))
+
+     (defun spacemacs//edebug-doc ()
+       "docstring for edebug-mode micro state"
+       (concat
+        "[q] quit [s] step [n] next [f] forward-sexp [i] step-in [o] step-out "
+        "[t] trace [e] eval-expression [f] forward-sexp [b] set-breakpoint "
+        "[c] goto-point [I] instrument-callee [S] stop [?] edebug-mode help"))
+
+     (spacemacs|define-micro-state edebug-mode
+       :doc (spacemacs//edebug-doc)
+       :persistent t
+       :bindings
+       ("q" edebug-top-level-nonstop :exit t)
+       ("s" edebug-step-mode)
+       ("n" edebug-next-mode)
+       ("i" edebug-step-in)
+       ("o" edebug-step-out)
+       ("b" edebug-set-breakpoint)
+       ("t" edebug-trace-mode)
+       ("e" edebug-eval-last-sexp)
+       ("f" edebug-forward-sexp)
+       ("c" edebug-goto-here)
+       ("I" edebug-instrument-callee)
+       ("S" edebug-stop)
+       ("?" edebug-help))
+
+     (spacemacs|evilify-map edebug-mode-map)
+
+     (add-hook 'edebug-mode-hook 'spacemacs//toggle-edebug-micro-state))))
+
+(defun edebug/init-edebug-x ()
+  (use-package edebug-x))
+


### PR DESCRIPTION
I've started working on integrating edebug more closely into Spacemacs. 
I've encountered a couple of issues - any suggestions would be useful.
1 - I've had to create an explicit toggle function to trigger both the evilified state and the edebug microstate. Initially I thought to use the spacemacs|define-micro-state :on-enter and :on-exit properties, however only the former worked correctly. Setting :on-enter to (evil-evilified-state) worked correctly, but :on-exit failed to trigger with either (evil-normal-state) and (normal-mode).
2 - I find that the micro-state works well with edebug - by default it puts you into read-only mode and having persistent documentation for the available actions seems helpful - alternatively I could write remove the microstate and put the commands directly on the evilified-map. Any preferences?

If it looks good I'll continue making some tweaks and add documentation - I may attempt to bring the debugger into a similar place, too.