### PR TITLE
reenabled magit-gitflow for magit 2.1

### DIFF
--- a/contrib/!source-control/git/packages.el
+++ b/contrib/!source-control/git/packages.el
@@ -19,8 +19,7 @@
         git-timemachine
         helm-gitignore
         magit
-        ;; not compatible with magit 2.1 at the time of release
-        ;; magit-gitflow
+        magit-gitflow
         ;; not compatible with magit 2.1 at the time of release
         ;; magit-svn
         smeargle


### PR DESCRIPTION
magit-gitflow was updated to work with magit 2.1