### PR TITLE
Optionally use C-g like escape in evil

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -112,6 +112,10 @@ size to make separators look not too crappy.")
 By default the command key is `:' so ex-commands are executed like in Vim
 with `:' and Emacs commands are executed with `<leader> :'.")
 
+(defvar dotspacemacs-use-C-g-to-escape nil
+  "If non nil, then C-g will be bound to `evil-normal-state' in
+insert mode and lisp mode. It works in visual mode by default.")
+
 (defvar dotspacemacs-use-ido nil
   "If non nil then `ido' replaces `helm' for some commands. For now only
 `find-files' (SPC f f) is replaced.")

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -96,6 +96,9 @@ before layers configuration."
    ;; By default the command key is `:' so ex-commands are executed like in Vim
    ;; with `:' and Emacs commands are executed with `<leader> :'.
    dotspacemacs-command-key ":"
+   ;; If non nil, then C-g will be bound to `evil-normal-state' in insert mode
+   ;; and lisp mode. It works in visual mode by default.
+   dotspacemacs-use-C-g-to-escape nil
    ;; Location where to auto-save files. Possible values are `original' to
    ;; auto-save the file in-place, `cache' to auto-save the file to another
    ;; file stored in the cache directory and `nil' to disable auto-saving.

--- a/spacemacs/keybindings.el
+++ b/spacemacs/keybindings.el
@@ -40,6 +40,11 @@
 (define-key minibuffer-local-must-match-map (kbd "<escape>") 'keyboard-escape-quit)
 (define-key minibuffer-local-isearch-map (kbd "<escape>") 'keyboard-escape-quit)
 
+;; Use C-g like escape in evil
+(when dotspacemacs-use-C-g-to-escape
+  (define-key evil-insert-state-map (kbd "C-g") 'evil-normal-state)
+  (define-key evil-lisp-state-map (kbd "C-g") 'evil-normal-state))
+
 ;; linum margin bindings-------------------------------------------------------
 (global-set-key (kbd "<left-margin> <down-mouse-1>") 'spacemacs/md-select-linum)
 (global-set-key (kbd "<left-margin> <mouse-1>") 'spacemacs/mu-select-linum)


### PR DESCRIPTION
I use this myself, so I thought other people might be interested. I'm not sure if there are any inherent downsides, but it's an easy key sequence to use for escaping insert mode and it's kind of second nature for emacs. Hitting it twice gets you to a `keyboard-quit` from insert mode, so it's not that far from the current behavior. 

For whatever reason `keyboard-quit` escapes the visual state but not insert state.

Of course, this could be made into an option.