### PR TITLE
[ABANDONED] add autocompletion for bootstrap & font-awesome CSS classes 

### DIFF
--- a/contrib/!lang/html/packages.el
+++ b/contrib/!lang/html/packages.el
@@ -12,6 +12,7 @@
 
 (setq html-packages
   '(
+    ac-html-bootstrap
     company
     company-web
     css-mode
@@ -40,7 +41,11 @@
     (spacemacs|add-company-hook web-mode))
 
   (defun html/init-company-web ()
-    (use-package company-web)))
+    (use-package company-web))
+
+  (defun html/init-ac-html-bootstrap ()
+    (use-package company-web-bootstrap+)
+    (use-package company-web-fa+)))
 
 (defun html/init-css-mode ()
   (use-package css-mode


### PR DESCRIPTION
This adds support for autocompletion via company-web using [ac-html-bootstrap](https://github.com/osv/ac-html-bootstrap) which is on [melpa](http://melpa.org/#/ac-html-bootstrap). I was going to include it in #2249 but it has already been merged.  