### PR TITLE
Remove `tooltip-use-echo-area' usage.

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -96,7 +96,6 @@ initialization."
   ;; tooltips in echo-aera
   (when (and (fboundp 'tooltip-mode) (not (eq tooltip-mode -1)))
     (tooltip-mode -1))
-  (setq tooltip-use-echo-area t)
   (unless (eq window-system 'mac)
     (when (and (fboundp 'menu-bar-mode) (not (eq menu-bar-mode -1)))
       (menu-bar-mode -1)))


### PR DESCRIPTION
`tooltip-use-echo-area` is obsolete since 24.1; disabling `tooltip-mode` achieves similar effect, and Tooltip mode has already been disabled in the current code. Since Spacemacs supports Emacs 24.3 and 24.4, `tooltip-use-echo-area` usage can be removed safely.