### PR TITLE
eyebrowse: add s for switch-to-window-config

### DIFF
--- a/contrib/!window-management/eyebrowse/README.org
+++ b/contrib/!window-management/eyebrowse/README.org
@@ -70,3 +70,4 @@ Set the variable =eyebrowse-display-help= to =nil=
 | ~SPC W n~              | switch to next workspace             |
 | ~SPC W N~ or ~SPC W p~ | create or switch to workspace 0      |
 | ~SPC W r~              | set a label to the current workspace |
+| ~SPC W s~              | switched to tagged workspace         | 

--- a/contrib/!window-management/eyebrowse/packages.el
+++ b/contrib/!window-management/eyebrowse/packages.el
@@ -85,6 +85,7 @@
         ("7" eyebrowse-switch-to-window-config-7)
         ("8" eyebrowse-switch-to-window-config-8)
         ("9" eyebrowse-switch-to-window-config-9)
+        ("s" eyebrowse-switch-to-window-config)
         ("<tab>" eyebrowse-last-window-config)
         ("C-i" eyebrowse-last-window-config)
         ("n" eyebrowse-next-window-config)


### PR DESCRIPTION
This has been sitting in my tree for some time. As far as I can tell, this is the only way to switch to a tagged workspace.