### PR TITLE
Replace after-init-hook with emacs-startup-hook

### DIFF
--- a/contrib/!vim/vim-powerline/extensions.el
+++ b/contrib/!vim/vim-powerline/extensions.el
@@ -28,5 +28,5 @@
             (setq-local mode-line-format (default-value 'mode-line-format))
             (powerline-set-selected-window)
             (powerline-reset))))))
-  (add-hook 'after-init-hook
+  (add-hook 'emacs-startup-hook
             'spacemacs//set-vimish-powerline-for-startup-buffers))

--- a/contrib/!window-management/perspectives/packages.el
+++ b/contrib/!window-management/perspectives/packages.el
@@ -60,7 +60,7 @@
            (when initialize ,@body)
            (setq persp-last current-perspective)))
 
-      (add-hook 'after-init-hook '(lambda ()
+      (add-hook 'emacs-startup-hook '(lambda ()
                                     (persp-rename "@spacemacs")))
       ;; Jump to last perspective
       ;; taken from Magnar Sveen

--- a/contrib/smex/packages.el
+++ b/contrib/smex/packages.el
@@ -35,7 +35,7 @@
 
       ;; define the key binding at the very end in order to allow the user
       ;; to overwrite any key binding
-      (add-hook 'after-init-hook
+      (add-hook 'emacs-startup-hook
                 (lambda () (evil-leader/set-key dotspacemacs-command-key
                              'spacemacs/smex)))
       (evil-leader/set-key "m:" 'spacemacs/smex-major-mode-commands)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -137,7 +137,7 @@ initialization."
   (if dotspacemacs-mode-line-unicode-symbols
       (setq-default spacemacs-version-check-lighter "[⇪]"))
   (spacemacs/set-new-version-lighter-mode-line-faces)
-  (add-hook 'after-init-hook 'spacemacs-buffer/goto-link-line)
+  (add-hook 'emacs-startup-hook 'spacemacs-buffer/goto-link-line)
   (spacemacs-mode))
 
 (defun spacemacs//get-package-directory (pkg)
@@ -202,10 +202,10 @@ FILE-TO-LOAD is an explicit file to load after the installation."
   "Change the default welcome message of minibuffer to another one."
   (message "Spacemacs is ready."))
 
-(defun spacemacs/setup-after-init-hook ()
+(defun spacemacs/setup-startup-hook ()
   "Add post init processing."
   (add-hook
-   'after-init-hook
+   'emacs-startup-hook
    (lambda ()
      ;; Ultimate configuration decisions are given to the user who can defined
      ;; them in his/her ~/.spacemacs file

--- a/init.el
+++ b/init.el
@@ -19,13 +19,26 @@
 (defun spacemacs/emacs-version-ok ()
   (version<= spacemacs-emacs-min-version emacs-version))
 
+(defun spacemacs/this-file ()
+  "Return true path to this file."
+  (cond
+   (load-in-progress load-file-name)
+   ((and (boundp 'byte-compile-current-file) byte-compile-current-file)
+    byte-compile-current-file)
+   (:else (buffer-file-name))))
+
+;; Always use emacs.d/ of the init.el supplied
+(setq user-emacs-directory (file-name-directory
+                            (file-truename
+                             (spacemacs/this-file))))
+
 (when (spacemacs/emacs-version-ok)
   (load-file (concat user-emacs-directory "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (require 'core-configuration-layer)
   (spacemacs/init)
   (configuration-layer/sync)
-  (spacemacs/setup-after-init-hook)
+  (spacemacs/setup-startup-hook)
   (spacemacs/maybe-install-dotfile)
   (require 'server)
   (unless (server-running-p) (server-start)))

--- a/spacemacs/extensions.el
+++ b/spacemacs/extensions.el
@@ -104,7 +104,7 @@
     (progn
       ;; save and restore layout
       (add-hook 'kill-emacs-hook 'emacs-save-layout)
-      (add-hook 'after-init-hook 'emacs-load-layout t))))
+      (add-hook 'emacs-startup-hook 'emacs-load-layout t))))
 
 (defun spacemacs/init-spray ()
   (use-package spray

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1510,7 +1510,7 @@ Removes the automatic guessing of the initial value based on thing at point. "
 
       ;; define the key binding at the very end in order to allow the user
       ;; to overwrite any key binding
-      (add-hook 'after-init-hook
+      (add-hook 'emacs-startup-hook
                 (lambda ()
                   (unless (configuration-layer/package-usedp 'smex)
                     (evil-leader/set-key dotspacemacs-command-key 'helm-M-x))))
@@ -2893,7 +2893,7 @@ It is a string holding:
           (dolist (buffer '("*Messages*" "*spacemacs*" "*Compile-Log*"))
             (when (get-buffer buffer)
               (spacemacs//restore-powerline buffer)))))
-      (add-hook 'after-init-hook
+      (add-hook 'emacs-startup-hook
                 'spacemacs//set-powerline-for-startup-buffers))))
 
 (defun spacemacs/init-projectile ()


### PR DESCRIPTION
This has a benefit of not assuming that the user .emacs.d/ is in the
user home directory. Should continue to work as expected when this is
the case, but you could also start a fresh Emacs session like
so (assumes OSX):
`open -a Emacs.app -n --args -q -l /path/to/emacs.d/init.el`
So you don't have to muddle with symlinking your `~/.emacs.d` or replacing
it with another just to try Spacemacs (or any other config). Note, that
this won't work with `after-init-hook` which doesn't appear to run when
Emacs is run with `-q` flag. As a result the `dotspacemacs/config` in your
`.spacemacs` won't run.