### PR TITLE
Hasell readme – note about exec-path-from-shell

### DIFF
--- a/contrib/!lang/haskell/README.org
+++ b/contrib/!lang/haskell/README.org
@@ -57,14 +57,15 @@ To install them, use the following command:
 Then you have to add this path to your system =$PATH= (preferred):
 Note that on *Linux* distributions the installed binaries should be in
 =~/.cabal/bin= and on *OS X* the binaries are installed in
-=/Users/<username>/Library/Haskell/bin=.
+=/Users/<username>/Library/Haskell/bin=. Spacemacs will automatically 
+pick up shell PATH.
 
 #+BEGIN_SRC sh
   export PATH=~/.cabal/bin/:$PATH
 #+END_SRC
 
-_or_ to the Emacs =exec-path= variable in the =dotspacemacs/init= function of
-your =.spacemacs= file:
+_Alternatively_, you can add to the Emacs =exec-path= variable in the 
+=dotspacemacs/init= function of your =.spacemacs= file:
 
 #+BEGIN_SRC emacs-lisp
   (add-to-list 'exec-path "~/.cabal/bin/")


### PR DESCRIPTION
cf. https://github.com/syl20bnr/spacemacs/issues/2331#issuecomment-121686918

(i was trying to do both, but it is not necessary given spacemacs defaults)