### PR TITLE
change ess-enable-smart-equals default to nil

### DIFF
--- a/contrib/!lang/ess/README.org
+++ b/contrib/!lang/ess/README.org
@@ -61,9 +61,9 @@ Send code to inferior process commands:
 
 * Options
 
-=ess-smart-equals= is enabled by default. In order to disable it, set in your =~/.spacemacs=
+=ess-smart-equals= is disabled by default. In order to enable it, set in your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-enable-smart-equals nil)))
+                                                         ess-enable-smart-equals t)))
 #+END_SRC

--- a/contrib/!lang/ess/config.el
+++ b/contrib/!lang/ess/config.el
@@ -14,5 +14,5 @@
 
 (spacemacs|defvar-company-backends ess-mode)
 
-(defvar ess-enable-smart-equals t
+(defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")


### PR DESCRIPTION
This is a very small change that sets the default value of ess-enable-smart-equals to nil. This change was made after soliciting feedback in https://github.com/syl20bnr/spacemacs/issues/2373; no objections were raised.