### PR TITLE
Fixes broken link to the magit "introduction" page

### DIFF
--- a/contrib/!source-control/git/README.org
+++ b/contrib/!source-control/git/README.org
@@ -30,7 +30,7 @@ This layers adds extensive support for [[http://git-scm.com/][git]].
 - colorize buffer line by age of commit with [[https://github.com/syohex/emacs-smeargle][smeargle]]
 - gitignore generator with [[https://github.com/jupl/helm-gitignore][helm-gitignore]]
 
-New to Magit? Checkout the [[https://magit.github.io/master/magit.html#Introduction][official intro]].
+New to Magit? Checkout the [[http://magit.vc/about.html][official intro]].
 
 * Install
 


### PR DESCRIPTION
The old link was 404-ing.  I'm not sure what it used to link to but the "about" page seems to be correct.