### PR TITLE
Fix Spacemacs Home Buffer to jump to bookmarks.

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -478,6 +478,22 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                            (abbreviate-file-name el)))
           list)))
 
+(defun spacemacs-buffer//insert-bookmark-list (list-display-name list)
+  (when (car list)
+    (insert list-display-name)
+    (mapc (lambda (el)
+            (insert "\n    ")
+            (widget-create 'push-button
+                           :action `(lambda (&rest ignore) (bookmark-jump ,el))
+                           :mouse-face 'highlight
+                           :follow-link "\C-m"
+                           :button-prefix ""
+                           :button-suffix ""
+                           :format "%[%t%]"
+                           (format "%s - %s" el (abbreviate-file-name
+                                                 (bookmark-get-filename el)))))
+          list)))
+
 (defun spacemacs-buffer/insert-startupify-lists ()
   (interactive)
   (with-current-buffer (get-buffer-create "*spacemacs*")
@@ -495,7 +511,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                   (insert list-separator)))
                ((eq el 'bookmarks)
                 (helm-mode)
-                (when (spacemacs-buffer//insert-file-list "Bookmarks:" (mapcar 'bookmark-get-filename (bookmark-all-names)))
+                (when (spacemacs-buffer//insert-bookmark-list "Bookmarks:" (bookmark-all-names))
                   (spacemacs//insert--shortcut "m" "Bookmarks:")
                   (insert list-separator)))
                ((eq el 'projects)


### PR DESCRIPTION
Instead of opening the file for the bookmark, use the bookmark-jump
function to properly jump to the file and location in the file.  Also
show the bookmark name and the filename in the list.

Fixes syl20bnr/spacemacs#2431