### PR TITLE
Revert company-math addition; One of those rare -- I messed up PRs. 

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -91,8 +91,6 @@
   (thanks to robbyoconnor)
 **** Javascript
 - Add =json-snatcher= on ~SPC m h p~ (thanks to CestDiego)
-**** Latex
-- Add =company-math= package (thanks to robbyoconnor)
 **** Ruby-on-rails
 - Activate =projectile-rails= mode for any type of files in a rails
   project (thanks to liuxiang)

--- a/contrib/!lang/latex/README.org
+++ b/contrib/!lang/latex/README.org
@@ -20,7 +20,7 @@
 This layer adds support for LaTeX files with [[https://savannah.gnu.org/projects/auctex/][AucTeX]].
 
 ** Features
-- Auto-completion with [[https://github.com/alexeyr/company-auctex][company-auctex]] and [[https://github.com/vspinu/company-math][company-math]]
+- Auto-completion with [[https://github.com/alexeyr/company-auctex][company-auctex]]
 - Tags navigation on ~%~ with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 - Labels, references, citations and index entries management with [[http://www.gnu.org/software/emacs/manual/html_node/reftex/index.html][RefTeX]]
 

--- a/contrib/!lang/latex/packages.el
+++ b/contrib/!lang/latex/packages.el
@@ -16,7 +16,6 @@
     auctex-latexmk
     company
     company-auctex
-    company-math
     evil-matchit
     flycheck
     flyspell
@@ -97,13 +96,7 @@
         (push 'company-auctex-bibs company-backends-LaTeX-mode)
         (push '(company-auctex-macros
                 company-auctex-symbols
-                company-auctex-environments) company-backends-LaTeX-mode))))
-
-  (defun latex/init-company-math ()
-    (use-package company-math
-      :if (configuration-layer/package-usedp 'company)
-      :defer t
-      :init (push 'company-math company-backends-LaTeX-mode))))
+                company-auctex-environments) company-backends-LaTeX-mode)))))
 
 (defun latex/post-init-evil-matchit ()
   (add-hook 'LaTeX-mode-hook 'evil-matchit-mode))


### PR DESCRIPTION
This is one of those "I messed up" PRs. So as it turns out -- I'm not sure that [company-math](https://github.com/vspinu/company-math) is needed. company-auctex does what it company-math does. -- .company-math isn't really needed...it's just adding functionality we simply don't need. 

I feel that the functionality is duplicated. This was one of those instances where I didn't do my research :crying_cat_face: 

#2425 makes this unnecessary as it can find the unicode symbols. I deeply apologize...I wish I caught this :( 
