### PR TITLE
Allow fsharp-mode to determine build path.

### DIFF
--- a/contrib/!lang/fsharp/packages.el
+++ b/contrib/!lang/fsharp/packages.el
@@ -16,8 +16,7 @@
   (use-package fsharp-mode
     :defer t
     :init
-    (setq fsharp-doc-idle-delay .2
-          fsharp-build-command "/usr/local/bin/xbuild")
+    (setq fsharp-doc-idle-delay .2)
     :config
     (progn
 


### PR DESCRIPTION
This removes the linux specific path in the configuration.  Currently, fsharp-mode will search for the correct path for the fsharp-build-command variable.  Removing this line will allow windows users to benefit from this functionality.

see: https://github.com/fsharp/fsharpbinding/blob/master/emacs/fsharp-mode.el
and: https://github.com/fsharp/fsharpbinding/blob/master/emacs/fsharp-mode-util.el