### PR TITLE
Fix visual-state evil-yank-binding in evilified modes

### DIFF
--- a/spacemacs/extensions/evil-evilified-state/evil-evilified-state.el
+++ b/spacemacs/extensions/evil-evilified-state/evil-evilified-state.el
@@ -50,7 +50,7 @@
     (setq-local evil-visual-state-map (cons 'keymap nil))
     (add-hook 'evil-visual-state-entry-hook
               (lambda () (interactive)
-                (local-set-key evil-visual-state-map "y" 'evil-yank))
+                (local-set-key "y" 'evil-yank))
               nil 'local)))
 
 ;; default key bindings for all evilified buffers


### PR DESCRIPTION
In my emacs version `GNU Emacs 24.5.1 (x86_64-apple-darwin14.3.0, Carbon Version 157 AppKit 1347.57) of 2015-04-13` the `local-set-key`-function only takes two arguments.

```
(defun local-set-key (key command)
  "Give KEY a local binding as COMMAND.
COMMAND is the command definition to use; usually it is
a symbol naming an interactively-callable function.
KEY is a key sequence; noninteractively, it is a string or vector
of characters or event types, and non-ASCII characters with codes
above 127 (such as ISO Latin-1) can be included if you use a vector.

The binding goes in the current buffer's local map, which in most
cases is shared with all other buffers in the same major mode."
```

Without this fix I got the following error when pressing entering visual-state in for example a magit-status buffer.

```
Debugger entered--Lisp error: (wrong-number-of-arguments (2 . 2) 3)
  local-set-key((keymap) "y" evil-yank)
  (lambda nil (interactive) (local-set-key evil-visual-state-map "y" (quote evil-yank)))()
  run-hooks(evil-visual-state-entry-hook)
  evil-visual-state()
  evil-visual-make-region(nil nil inclusive t)
  evil-visual-char(nil nil inclusive t)
  call-interactively(evil-visual-char)
  (if nil nil (call-interactively (quote evil-visual-char)))
  (unless nil (call-interactively (quote evil-visual-char)))
  (if nil (progn (message "%s-" "v") (set-transient-map (quote evil-visual-char))) (unless nil (call-interactively (quote evil-visual-char))))
  (if (eq (quote evilified) evil-state) (if nil (progn (message "%s-" "v") (set-transient-map (quote evil-visual-char))) (unless nil (call-interactively (quote evil-visual-char)))) (if nil (progn (message "%s-" "v") (set-transient-map (quote magit-reverse))) (unless nil (call-interactively (quote magit-reverse)))))
  magit-reverse-or-evil-visual-char--evilified-magit-file-section-map-v()
  call-interactively(magit-reverse-or-evil-visual-char--evilified-magit-file-section-map-v nil nil)
  command-execute(magit-reverse-or-evil-visual-char--evilified-magit-file-section-map-v)
```