### PR TITLE
Add duplicate keybinding for toggle fullscreen

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -30,4 +30,6 @@
                       (interactive)
                       (call-interactively (key-binding "\C-x\C-s"))))
     (global-set-key (kbd "s-Z") 'undo-tree-redo)
-    (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen)))
+    (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen)
+    ;; Emacs sometimes registers C-s-f as this weird keycode
+    (global-set-key (kbd "<C-s-268632070>") 'spacemacs/toggle-frame-fullscreen)))


### PR DESCRIPTION
On my mac, using the left command key results in emacs registering the command differently.