### PR TITLE
Add pangu space and remove extra space between Chinese words

### DIFF
--- a/contrib/chinese/README.org
+++ b/contrib/chinese/README.org
@@ -22,7 +22,8 @@ This Layer adds Chinese related packages:
 - [[https://github.com/xuchunyang/youdao-dictionary.el][youdao-dictionary]]: The Youdao(有道) Dictionary interface for Emacs.
 - [[https://github.com/redguardtoo/find-by-pinyin-dired][find-by-pinyin-dired]]: Find file by first Pinyin characters of Chinese Hanzi.
 - [[https://github.com/cute-jumper/ace-pinyin][ace-pinyin]]: Jump to Chinese character by pinyin with `ace-jump-mode'.
-  
+- [[https://github.com/coldnew/pangu-spacing][coldnew/pangu-spacing]] : emacs minor-mode to add space between Chinese and English characters.
+- Join consecutive Chinese lines into a single long line without unwanted space when exporting org-mode to html.
 
 * Install
 ** Layer

--- a/contrib/chinese/packages.el
+++ b/contrib/chinese/packages.el
@@ -16,6 +16,8 @@
     '(
       find-by-pinyin-dired
       ace-pinyin
+      pangu-spacing
+      org
       ))
 
 (if chinese-enable-youdao-dict
@@ -79,3 +81,26 @@
     (progn
       (ace-pinyin-global-mode t)
       (spacemacs|hide-lighter ace-pinyin-mode))))
+
+(defun chinese/init-pangu-spacing ()
+  (use-package pangu-spacing
+    :defer t
+    :init (progn (global-pangu-spacing-mode 1)
+                 (spacemacs|hide-lighter pangu-spacing-mode)
+                 ;; Always insert `real' space in org-mode.
+                 (add-hook 'org-mode-hook
+                           '(lambda ()
+                              (set (make-local-variable 'pangu-spacing-real-insert-separtor) t))))))
+
+(defun chinese/post-init-org ()
+  (defadvice org-html-paragraph (before org-html-paragraph-advice
+                                        (paragraph contents info) activate)
+    "Join consecutive Chinese lines into a single long line without
+unwanted space when exporting org-mode to html."
+    (let* ((origin-contents (ad-get-arg 1))
+           (fix-regexp "[[:multibyte:]]")
+           (fixed-contents
+            (replace-regexp-in-string
+             (concat
+              "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)") "\\1\\2" origin-contents)))
+      (ad-set-arg 1 fixed-contents))))


### PR DESCRIPTION
1. Add pangu space minor mode.

2. remove extra whitespace when export Chinese org file as HTML