### PR TITLE
Excluding from global-mode-string

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -212,6 +212,10 @@ Can be installed with `brew install trash'."
     (if dotspacemacs-maximized-at-startup
         (add-hook 'window-setup-hook 'toggle-frame-maximized))))
 
+(defvar spacemacs--global-mode-line-excludes nil
+  "List of elements to exclude from the global modeline string.
+These should have their own segments in the modeline.")
+
 ;; ---------------------------------------------------------------------------
 ;; Session
 ;; ---------------------------------------------------------------------------

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -1085,20 +1085,14 @@ Example: (evil-map visual \"<\" \"<gv\")"
     :defer t
     :init
     (progn
-
       (spacemacs|add-toggle mode-line-battery
-                            :status fancy-battery-mode
-                            :on
-                            (fancy-battery-mode)
-                            (spacemacs/mode-line-battery-remove-from-global)
-                            :off (fancy-battery-mode -1)
-                            :documentation "Display battery info in mode-line."
-                            :evil-leader "tmb")
+        :status fancy-battery-mode
+        :on (fancy-battery-mode)
+        :off (fancy-battery-mode -1)
+        :documentation "Display battery info in mode-line."
+        :evil-leader "tmb")
 
-      (defun spacemacs/mode-line-battery-remove-from-global ()
-        "Remove the battery info from the `global-mode-string'."
-        (setq global-mode-string (delq 'fancy-battery-mode-line
-                                       global-mode-string)))
+      (push 'fancy-battery spacemacs--global-mode-excludes)
 
       (defun spacemacs/mode-line-battery-percentage ()
         "Return the load percentage or an empty string."
@@ -1122,9 +1116,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
       ;; basically remove all faces and properties.
       (defun fancy-battery-default-mode-line ()
         "Assemble a mode line string for Fancy Battery Mode."
-        (spacemacs/mode-line-battery-remove-from-global)
         (when fancy-battery-last-status
-
           (let* ((type (cdr (assq ?L fancy-battery-last-status)))
                  (percentage (spacemacs/mode-line-battery-percentage))
                  (time (spacemacs/mode-line-battery-time)))
@@ -2855,7 +2847,8 @@ It is a string holding:
         :when (bound-and-true-p nyan-mode))
 
       (spacemacs|define-mode-line-segment global-mode
-        (powerline-raw global-mode-string)
+        (powerline-raw (-difference global-mode-string
+                                    spacemacs--global-mode-line-excludes))
         :when (spacemacs//mode-line-nonempty global-mode-string))
 
       (spacemacs|define-mode-line-segment battery
@@ -2883,15 +2876,17 @@ It is a string holding:
                          (spacemacs|custom-flycheck-lighter ,type))))))
 
       (spacemacs|define-mode-line-segment org-clock
-        (funcall spacemacs-mode-line-org-clock-format-function)
+        (substring-no-properties (funcall spacemacs-mode-line-org-clock-format-function))
         :when (and spacemacs-mode-line-org-clock-current-taskp
                    (fboundp 'org-clocking-p)
                    (org-clocking-p)))
+      (push 'org-mode-line-string spacemacs--global-mode-line-excludes)
 
       (spacemacs|define-mode-line-segment org-pomodoro
-        (concat "[" (nth 1 org-pomodoro-mode-line) "]")
+        (nth 1 org-pomodoro-mode-line)
         :when (and (fboundp 'org-pomodoro-active-p)
                    (org-pomodoro-active-p)))
+      (push 'org-pomodoro-mode-line spacemacs--global-mode-line-excludes)
 
       ;; END define modeline segments
 


### PR DESCRIPTION
I thougt this was a cute way to solve a few problems related to #2500.

This introduces a new list `spacemacs--global-mode-line-excludes`, which is a list of elements that should be excluded from `global-mode-string` upon rendering. This is useful for packages that insert themselves in there, but for which we want more control, such as (at the moment):

* pomodoro
* org clocks
* fancy battery

Fixes #2500.