### PR TITLE
Fix #2363

### DIFF
--- a/contrib/!lang/markdown/packages.el
+++ b/contrib/!lang/markdown/packages.el
@@ -23,10 +23,6 @@
     :defer t
     :init (add-hook 'markdown-mode-hook 'smartparens-mode)
     :config
-    ;; Don't do terrible things with Github code blocks (```)
-    (when (fboundp 'sp-local-pair)
-      (sp-local-pair 'markdown-mode "`" nil :actions '(:rem autoskip))
-      (sp-local-pair 'markdown-mode "'" nil :actions nil))
     (progn
       ;; Insert key for org-mode and markdown a la C-h k
       ;; from SE endless http://emacs.stackexchange.com/questions/2206/i-want-to-have-the-kbd-tags-for-my-blog-written-in-org-mode/2208#2208


### PR DESCRIPTION
Fix for  https://github.com/syl20bnr/spacemacs/issues/2363 

Disabled additional `sp-local-pair` actions on backtick and single quote.

Not sure why that part of code was introduced in the first place but it seems to no longer work with the newest packages. Both backtick and quote behaviors were a kind of broken. For backtick there was no auto skip, and there's no automatic pairing for single quote. Removing the code makes them normal again(Automatic pairing for single quote will only occur if it's not typed in the middle of a sentence, which seems fine). And there seems to be nothing wrong with Github code block behaviors.