### PR TITLE
Fix various naming errors in package file descriptions

### DIFF
--- a/contrib/!irc/erc/config.el
+++ b/contrib/!irc/erc/config.el
@@ -1,4 +1,4 @@
-;;; config.el --- rcirc Layer configuration File for Spacemacs
+;;; config.el --- erc Layer configuration File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/!lang/html/packages.el
+++ b/contrib/!lang/html/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- HTTP Layer packages File for Spacemacs
+;;; packages.el --- HTML Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/!lang/markdown/packages.el
+++ b/contrib/!lang/markdown/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- Finance Layer packages File for Spacemacs
+;;; packages.el --- Markdown Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/!window-management/eyebrowse/packages.el
+++ b/contrib/!window-management/eyebrowse/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- Colors Layer packages File for Spacemacs
+;;; packages.el --- Eyebrowse Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/chinese/config.el
+++ b/contrib/chinese/config.el
@@ -1,4 +1,4 @@
-;;; config.el --- Colors Layer configuration File for Spacemacs
+;;; config.el --- Chinese Layer configuration File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/chinese/packages.el
+++ b/contrib/chinese/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- chinese Layer packages File for Spacemacs
+;;; packages.el --- Chinese Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/chrome/packages.el
+++ b/contrib/chrome/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- edit-server Layer packages File for Spacemacs
+;;; packages.el --- Chrome Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors

--- a/contrib/ibuffer/funcs.el
+++ b/contrib/ibuffer/funcs.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Ansible Layer extensions File for Spacemacs
+;;; funcs.el --- ibuffer Layer extensions File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2015 Aleksandr Guljajev & Contributors
@@ -45,4 +45,3 @@
                         ignore-modes) '())))))
     (setq ibuffer-saved-filter-groups cur-bufs)
     (ibuffer-switch-to-saved-filter-groups "Home")))
-

--- a/contrib/prodigy/packages.el
+++ b/contrib/prodigy/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- org2blog Layer packages File for Spacemacs
+;;; packages.el --- Prodigy Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors


### PR DESCRIPTION
Well, probably mostly aesthetic, but still they just look a bit jarring out there.