### PR TITLE
Hint at cask for fast binary install

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ via [homebrew][] with the following commands:
 
 ```sh
 $ brew tap railwaycat/emacsmacport
-$ brew install emacs-mac --with-spacemacs-icon
+$ brew install emacs-mac --with-spacemacs-icon  # OR, brew cask install emacs-mac
 ```
 (The `with-spacemacs-icon` option uses the official spacemacs logo for the app bundle.)
 


### PR DESCRIPTION
Instaling via cask takes a few seconds as it fetches pre-built binary, also managed by the [same railwaycat repo](https://github.com/railwaycat/homebrew-emacsmacport/blob/master/Casks/emacs-mac.rb).

Here is how Emacs looks when started with spacemacs:
![screen shot 2015-08-01 at 9 35 40 am](https://cloud.githubusercontent.com/assets/3998/9022611/c98654ac-3830-11e5-9ef0-bfaa2f93340a.png)
