### PR TITLE
Update package name

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -1,5 +1,5 @@
 (when (system-is-mac)
-  (evil-leader/set-key "bf" 'reveal-in-finder)
+  (evil-leader/set-key "bf" 'reveal-in-osx-finder)
 
   ;; this is only applicable to GUI mode
   (when (display-graphic-p)

--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -2,7 +2,7 @@
   '(
     pbcopy
     launchctl
-    reveal-in-finder
+    reveal-in-osx-finder
     ))
 
 (when (system-is-mac)
@@ -70,6 +70,6 @@ Can be installed with `brew install trash'."
                (kbd "h") 'launchctl-help))))
 
 (defun osx/init-reveal-in-finder ()
-  (use-package reveal-in-finder
+  (use-package reveal-in-osx-finder
     :if (system-is-mac)
-    :commands reveal-in-finder))
+    :commands reveal-in-osx-finder))


### PR DESCRIPTION
reveal-in-finder was renamed to reveal-in-osx-finder.

See also
- https://github.com/milkypostman/melpa/commit/2bf40285279b761b0efd6bc8542ae9aad4b329e1
- https://github.com/kaz-yos/reveal-in-osx-finder/commit/5710e5936e47139a610ec9a06899f72e77ddc7bc