### PR TITLE
Update package name to reveal-in-osx-finder

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -1,5 +1,17 @@
+;;; keybindings.el --- OS X Layer key bindings File
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
 (when (system-is-mac)
-  (evil-leader/set-key "bf" 'reveal-in-finder)
+  (evil-leader/set-key "bf" 'reveal-in-osx-finder)
 
   ;; this is only applicable to GUI mode
   (when (display-graphic-p)

--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -2,7 +2,7 @@
   '(
     pbcopy
     launchctl
-    reveal-in-finder
+    reveal-in-osx-finder
     ))
 
 (when (system-is-mac)
@@ -17,7 +17,7 @@
   (if (executable-find "trash")
       (defun system-move-file-to-trash (file)
         "Use `trash' to move FILE to the system/volume trash can.
-Can be installed with `brew install trash'." 
+Can be installed with `brew install trash'."
         (call-process (executable-find "trash") nil 0 nil file))
     (setq mac-system-move-file-to-trash-use-finder t))
 
@@ -34,7 +34,7 @@ Can be installed with `brew install trash'."
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy
-    :if (and (system-is-mac)(not (display-graphic-p))) 
+    :if (and (system-is-mac)(not (display-graphic-p)))
     :init (turn-on-pbcopy)))
 
 (defun osx/init-launchctl ()
@@ -69,7 +69,7 @@ Can be installed with `brew install trash'."
                (kbd "#") 'launchctl-unsetenv
                (kbd "h") 'launchctl-help))))
 
-(defun osx/init-reveal-in-finder ()
-  (use-package reveal-in-finder
+(defun osx/init-reveal-in-osx-finder ()
+  (use-package reveal-in-osx-finder
     :if (system-is-mac)
-    :commands reveal-in-finder))
+    :commands reveal-in-osx-finder))


### PR DESCRIPTION
see #1829 (referring to #2532)

PS  it there a point keeping a separate keybindings.el or should it be merged into package.el (I don't see many layer using a separate keybindings.el file)