### PR TITLE
add #f magit binding for magit-gitflow-popup

### DIFF
--- a/contrib/!source-control/git/packages.el
+++ b/contrib/!source-control/git/packages.el
@@ -267,7 +267,11 @@
 (defun git/init-magit-gitflow ()
   (use-package magit-gitflow
     :commands turn-on-magit-gitflow
-    :init (add-hook 'magit-mode-hook 'turn-on-magit-gitflow)
+    :init (progn
+            (add-hook 'magit-mode-hook 'turn-on-magit-gitflow)
+            (eval-after-load 'magit
+              '(progn
+                 (define-key magit-mode-map "#f" 'magit-gitflow-popup))))
     :config (spacemacs|diminish magit-gitflow-mode "Flow")))
 
 (defun git/init-magit-svn ()


### PR DESCRIPTION
fixes #2496 as suggested by syl20bnr

Implements in way similar to the magit-gh-pull-request extension by binding after magit loads instead of inserting into the main magit key-binds in the same file, but foregoes JIT activation of magit-gitflow.