### PR TITLE
fix the docs to reflect submodules are no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **Quick Install:**
 
-    git clone --recursive https://github.com/syl20bnr/spacemacs ~/.emacs.d
+    git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -272,10 +272,10 @@ For now it is still needed to update the =Spacemacs= repository manually.
 Close Emacs and update the git repository:
 
 #+begin_src sh
-  $ git pull --rebase; git submodule sync; git submodule update
+  $ git pull --rebase
 #+end_src
 
-*Note* It is recommended to update the packages first, see next session.
+*Note* It is recommended to update the packages first, see next section.
 
 ** Update packages
 To update =Spacemacs= press RET (enter) or click on the link =[Update]= in the


### PR DESCRIPTION
Two things are included here: 

- We no longer need to update submodules
- the `--recursive` switch deals with submodules so it's no longer needed. 