### PR TITLE
don't set haskell-process-type

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -68,8 +68,7 @@
         (add-hook 'haskell-mode-hook 'haskell-indentation-mode))
 
       ;; settings
-      (setq haskell-process-type 'auto
-            ;; Use notify.el (if you have it installed) at the end of running
+      (setq ;; Use notify.el (if you have it installed) at the end of running
             ;; Cabal commands or generally things worth notifying.
             haskell-notify-p t
             ;; To enable tags generation on save.


### PR DESCRIPTION
By default (from `haskell-mode`) `haskell-process-type` is set to `'auto`, so no need to set it here. Also when you explicitly set the value of `haskell-process-type` it gets much harder to configure it.