### PR TITLE
Make ispell more easily configurable

### DIFF
--- a/contrib/syntax-checking/README.org
+++ b/contrib/syntax-checking/README.org
@@ -6,7 +6,7 @@
  - [[#description][Description]]
  - [[#install][Install]]
      - [[#layer][Layer]]
-     - [[#enablingdisabling-tooltips][Enabling/Disabling tooltips]]
+     - [[#configuration-options][Configuration options]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
@@ -24,15 +24,20 @@ To use this configuration layer add it to your =~/.spacemacs=
 (setq-default dotspacemacs-configuration-layers '(syntax-checking))
 #+END_SRC
 
-** Enabling/Disabling tooltips
+** Configuration options
 
-By default tooltips are enabled and used whenever it is possible.
-You can disable them by setting the variable =syntax-checking-enable-tooltips=
-to =nil=:
+By default tooltips are enabled and used whenever it is possible. You can
+disable them by setting the variable =syntax-checking-enable-tooltips= to =nil=.
+The variables =syntax-checking-ispell-program= and
+=syntax-checking-ispell-dictionary= get passed to =ispell-program-name= and
+=ispell-dictionary= respectively. The defaults are shown below.
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
-  '((syntax-checking :variables syntax-checking-enable-tooltips nil)))
+  '((syntax-checking 
+     :variables syntax-checking-enable-tooltips nil
+                syntax-checking-ispell-program "aspell"
+                syntax-checking-ispell-dictionary "english")))
 #+END_SRC
 
 

--- a/contrib/syntax-checking/config.el
+++ b/contrib/syntax-checking/config.el
@@ -15,6 +15,12 @@
 (defvar syntax-checking-enable-tooltips t
   "If non nil some feedback are displayed in tooltips.")
 
+(defvar syntax-checking-ispell-program "aspell"
+  "External program to use for ispell. Defaults to \"aspell\".")
+
+(defvar syntax-checking-ispell-dictionary "english"
+  "Dictionary to use for ispell. Defaults to \"english\".")
+
 ;; Command Prefixes
 
 (spacemacs/declare-prefix "S" "spelling")

--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -118,8 +118,8 @@
     :defer t
     :init
     (progn
-      (setq-default ispell-program-name "aspell")
-      (setq-default ispell-dictionary "english")
+      (setq-default ispell-program-name syntax-checking-ispell-program)
+      (setq-default ispell-dictionary syntax-checking-ispell-dictionary)
       (add-hook 'markdown-mode-hook '(lambda () (flyspell-mode 1)))
       (add-hook 'text-mode-hook '(lambda () (flyspell-mode 1)))
       (spacemacs|add-toggle spelling-checking


### PR DESCRIPTION
Adds variables `syntax-checking-ispell-program` and `syntax-checking-ispell-dictionary` to the syntax-checking layer. It was annoying me that I was trying to use hunspell and aspell was hard coded in. 

I think the dictionary should be left unspecified, so that it falls back to the default on the system, but I didn't make that change here. 