### PR TITLE
Add keybindings for debugging using emacs-eclim

### DIFF
--- a/contrib/!lang/java/README.org
+++ b/contrib/!lang/java/README.org
@@ -117,6 +117,21 @@ option in =emacs-eclim= itself.
 |-------------+---------------------------------------------------------------|
 | ~SPC m t t~ | run JUnit tests for current method or current file or project |
 
+*** Debug
+Please note that most of the keybindings will work after starting the debugger.
+| Key Binding | Description                 |
+|-------------+-----------------------------|
+| ~SPC m d d~ | Debug current test file     |
+| ~SPC m d b~ | Create breakpoint           |
+| ~SPC m d r~ | Run debuged program         |
+| ~SPC m d c~ | Continue after break        |
+| ~SPC m d s~ | Step into the method        |
+| ~SPC m d f~ | Finish current method       |
+| ~SPC m d n~ | Next line (step over)       |
+| ~SPC m d l~ | Print local variables state |
+| ~SPC m d i~ | Inspect current variable    |
+| ~SPC m d .~ | Enter debug micro-state     |
+
 
 ** Problems buffer
 | Key Binding | Description                         |

--- a/contrib/!lang/java/funcs.el
+++ b/contrib/!lang/java/funcs.el
@@ -40,3 +40,7 @@
 (defun spacemacs/java-maven-install ()
   (interactive)
   (eclim-maven-run "install"))
+
+(defun spacemacs/gud-locals ()
+  (interactive)
+  (gud-basic-call "locals"))

--- a/contrib/!lang/java/packages.el
+++ b/contrib/!lang/java/packages.el
@@ -118,6 +118,16 @@
         "mpo" 'eclim-project-open
         "mpp" 'eclim-project-mode
         "mpu" 'eclim-project-update
+        "mpr" 'eclim-project-refresh
+
+        "mdb" 'gud-break
+        "mdc" 'gud-cont
+        "mdn" 'gud-next
+        "mdr" 'gud-run
+        "mds" 'gud-step
+        "mdi" 'gud-print
+        "mdl" 'spacemacs/gud-locals
+        "mdd" 'eclim-debug-test
 
         "mtt" 'eclim-run-junit)))
 

--- a/contrib/!lang/java/packages.el
+++ b/contrib/!lang/java/packages.el
@@ -27,6 +27,20 @@
       (add-to-list 'minor-mode-alist
                    '(eclim-mode (:eval (eclim-modeline-string))))
 
+      (spacemacs|define-micro-state eclim
+        :doc "[b] break [r] run [n] next [s] step [c] cont [i] inspect [q] quit"
+        :disable-evil-leader t
+        :persistent t
+        :evil-leader-for-mode (java-mode . "md.")
+        :bindings
+        ("b" gud-break)
+        ("r" gud-run)
+        ("n" gud-next)
+        ("s" gud-step)
+        ("i" gud-print)
+        ("c" gud-cont)
+        ("q" nil :exit t))
+
       (evil-define-key 'insert java-mode-map
         (kbd ".") 'spacemacs/java-completing-dot
         (kbd ":") 'spacemacs/java-completing-double-colon
@@ -125,6 +139,7 @@
         "mdn" 'gud-next
         "mdr" 'gud-run
         "mds" 'gud-step
+        "mdf" 'gud-finish
         "mdi" 'gud-print
         "mdl" 'spacemacs/gud-locals
         "mdd" 'eclim-debug-test


### PR DESCRIPTION
This is very basic and not 100% compliant with https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org#debugging. What is missing:
- no toggle on `mdb`
- no remove all breakpoints

I had little problem with defining micro state but with little help I think I could manage it. 
