### PR TITLE
add tab size to modeline

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2717,6 +2717,7 @@ must be a valid segment specification, see documentation for
         '((battery :when active)
           selection-info
           ((buffer-encoding-abbrev
+            tab-size
             point-position
             line-column)
            :separator " | ")
@@ -2863,6 +2864,7 @@ It is a string holding:
         :when spacemacs-mode-line-display-point-p)
       (spacemacs|define-mode-line-segment line-column "%l:%2c")
       (spacemacs|define-mode-line-segment buffer-position "%p")
+      (spacemacs|define-mode-line-segment tab-size (format "Spaces: %d" tab-width))
 
       (spacemacs|define-mode-line-segment hud
         (powerline-hud state-face default-face)


### PR DESCRIPTION
<img width="313" alt="qq20150806-1 2x" src="https://cloud.githubusercontent.com/assets/785541/9108554/9b420430-3c61-11e5-8f6f-9b0217cfd233.png">

Here is the screenshot of Sublime Text3, I think it could be the better defaults.
