### PR TITLE
Replace ace-jump with avy

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -12,13 +12,13 @@
 
 (setq spacemacs-packages
       '(
-        ace-jump-mode
         ace-link
         ace-window
         adaptive-wrap
         aggressive-indent
         auto-dictionary
         auto-highlight-symbol
+        avy
         bind-key
         bookmark
         buffer-move
@@ -119,19 +119,6 @@
   (push 'paradox spacemacs-packages))
 
 ;; Initialization of packages
-
-(defun spacemacs/init-ace-jump-mode ()
-  (use-package ace-jump-mode
-    :defer t
-    :init
-    (progn
-      (add-hook 'ace-jump-mode-end-hook 'golden-ratio)
-      (evil-leader/set-key "SPC" 'evil-ace-jump-word-mode)
-      (evil-leader/set-key "l" 'evil-ace-jump-line-mode))
-    :config
-    (progn
-      (setq ace-jump-mode-scope 'global)
-      (evil-leader/set-key "`" 'ace-jump-mode-pop-mark))))
 
 (defun spacemacs/init-ace-link ()
   (use-package ace-link
@@ -410,6 +397,20 @@
                  (prophidden (propertize hidden 'face '(:weight bold))))
             (echo "%s %s%s (n/N) move, (e) edit, (r) range, (R) reset, (d/D) definition, (/) find in project, (f) find in files, (b) find in opened buffers"
                   propplugin propx/y prophidden)))))))
+
+(defun spacemacs/init-avy ()
+  (use-package avy
+    :defer t
+    :init
+    (progn
+      (setq avy-keys (number-sequence ?a ?z))
+      (setq avy-all-windows 'all-frames)
+      (setq avy-background t)
+      (evil-leader/set-key
+        "SPC" 'avy-goto-word-or-subword-1
+        "l" 'avy-goto-line))
+    :config
+    (evil-leader/set-key "`" 'avy-pop-mark)))
 
 (defun spacemacs/init-bind-key ())
 
@@ -1254,7 +1255,6 @@ Example: (evil-map visual \"<\" \"<gv\")"
                       select-window-7
                       select-window-8
                       select-window-9
-                      ace-jump-mode-pop-mark
                       buf-move-left
                       buf-move-right
                       buf-move-up
@@ -3486,13 +3486,13 @@ one of `l' or `r'."
                ("spacemacs/toggle-\\(.+\\)" . "\\1")
                ("select-window-\\([0-9]\\)" . "window \\1")
                ("spacemacs/alternate-buffer" . "last buffer")
-               ("evil-ace-jump-word-mode" . "ace word")
+               ("avy-goto-word-or-subword-1" . "avy word")
                ("shell-command" . "shell cmd")
                ("spacemacs/default-pop-shell" . "open shell")
                ("spacemacs/helm-project-smart-do-search-region-or-symbol" . "smart search")
                ("helm-descbinds" . "show keybindings")
                ("sp-split-sexp" . "split sexp")
-               ("evil-ace-jump-line-mode" . "ace line")
+               ("avy-goto-line" . "avy line")
                ("universal-argument" . "universal arg")
                ("er/expand-region" . "expand region")
                ("helm-apropos" . "apropos"))))


### PR DESCRIPTION
Related issue: #1354 @TheBB suggested to do a PR to get things in motion.
I've made the necessary changes to replace [ace-jump](https://github.com/winterTTr/ace-jump-mode) with [avy](https://github.com/abo-abo/avy). Below is a summary.

<kbd>SPC SPC</kbd> is bound to `avy-goto-word-or-subword-1` (was `evil-ace-jump-word-mode`)
<kbd>SPC l</kbd> is bound to `avy-goto-line` (was `evil-ace-jump-line-mode`)
<kbd>SPC \`</kbd> is bound to `avy-pop-mark` (was `ace-jump-mode-pop-mark`)

I set `avy-keys` to use the same keys as `ace-jump` (`a-z`) when selecting candidates. It might be
better UI to use `avy`'s default keys (`asdfghjkl`).

I set `avy` to allow jumping to other windows and frames, as mentioned in https://github.com/syl20bnr/spacemacs/issues/1534#issuecomment-124239142

I didn't add `avy` faces to any themes, despite it being suggested in https://github.com/syl20bnr/spacemacs/issues/1534#issuecomment-120402345.

`avy-pop-mark` is actually `pop-to-mark-command` in disguise, and it doesn't work as well as
`ace-jump-mode-pop-mark` - it doesn't jump back across windows. I'll report an issue upstream and hopefully it will be improved. (EDIT: issue opened at https://github.com/abo-abo/avy/issues/88)

I decided not to trigger `golden-ratio` after jumping, because I found it annoying. If there is
interest in it, the relevant commands can be added to `golden-ratio-extra-commands`.

I haven't touched the docs yet.