### PR TITLE
Fixed osx/init function for reveal-in-osx-finder

### DIFF
--- a/contrib/osx/packages.el
+++ b/contrib/osx/packages.el
@@ -69,7 +69,7 @@ Can be installed with `brew install trash'."
                (kbd "#") 'launchctl-unsetenv
                (kbd "h") 'launchctl-help))))
 
-(defun osx/init-reveal-in-finder ()
+(defun osx/init-reveal-in-osx-finder ()
   (use-package reveal-in-osx-finder
     :if (system-is-mac)
     :commands reveal-in-osx-finder))


### PR DESCRIPTION
When the name of the "reveal-in-osx-finder" package in the osx layer was changed, the (defun osx/init-reveal-in-finder ...) call was not changed. This leads to the package not being installed. This change fixes the issue (mentioned at https://github.com/syl20bnr/spacemacs/pull/2532).