### PR TITLE
Add documentation for '# g c' to the github layer

### DIFF
--- a/contrib/!source-control/github/README.org
+++ b/contrib/!source-control/github/README.org
@@ -40,6 +40,7 @@ In a =magit status= buffer (~SPC g s~):
 
 | Key Binding | Description                                     |
 |-------------+-------------------------------------------------|
+| ~# g c~     | create a pull request                           |
 | ~# g g~     | get a list of all PRs in the current repository |
 | ~# g f~     | fetch the commits associated to the current PR  |
 | ~# g b~     | create a branch for the current PR              |


### PR DESCRIPTION
Update the README to include documentation for '# g c'
which  allows people to create PRs from emacs and then opens
it in the browser.

Works for a test repo I made...for spacemacs it...doesn't seem to work :/