### PR TITLE
python: use semantic for imenu only when semantic-mode is on

### DIFF
--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -234,7 +234,20 @@
         (define-key inferior-python-mode-map (kbd "C-l") 'comint-clear-buffer))
 
       ;; add this optional key binding for Emacs user, since it is unbound
-      (define-key inferior-python-mode-map (kbd "C-c M-l") 'comint-clear-buffer))))
+      (define-key inferior-python-mode-map (kbd "C-c M-l") 'comint-clear-buffer)
+
+      ;; fix for issue #2569 (https://github.com/syl20bnr/spacemacs/issues/2569)
+      ;; use `semantic-create-imenu-index' only when `semantic-mode' is enabled,
+      ;; otherwise use `python-imenu-create-index'
+      (defun python/imenu-create-index-python-or-semantic ()
+        (if (bound-and-true-p semantic-mode)
+            (semantic-create-imenu-index)
+          (python-imenu-create-index)))
+
+      (defadvice wisent-python-default-setup
+          (after python/set-imenu-create-index-function activate)
+        (setq imenu-create-index-function
+              #'python/imenu-create-index-python-or-semantic)))))
 
 (defun python/post-init-flycheck ()
   (add-hook 'python-mode-hook 'flycheck-mode))


### PR DESCRIPTION
Fixes #2569 
Sets `imenu-create-index-function` to `python/imenu-create-index-python-or-semantic` (new function) instead of `semantic-create-imenu-index` in python buffers. The new function knows when to use `python-imenu-create-index` and when to use `semantic-create-imenu-index`, so imenu always finds the correct entries.