### PR TITLE
Put the bookmark file in the cache directory.

### DIFF
--- a/spacemacs/config.el
+++ b/spacemacs/config.el
@@ -265,11 +265,7 @@ These should have their own segments in the modeline.")
 (savehist-mode +1)
 
 ;; cache files
-;; bookmarks
-(setq bookmark-default-file (concat spacemacs-cache-directory "bookmarks")
-      ;; save after every change
-      bookmark-save-flag 1
-      url-configuration-directory (concat spacemacs-cache-directory "url")
+(setq url-configuration-directory (concat spacemacs-cache-directory "url")
       eshell-directory-name (concat spacemacs-cache-directory "eshell" )
       tramp-persistency-file-name (concat spacemacs-cache-directory "tramp"))
 

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -428,7 +428,7 @@
   (use-package bookmark
     :defer t
     :init
-    (setq bookmark-default-file (concat user-emacs-directory "bookmarks")
+    (setq bookmark-default-file (concat spacemacs-cache-directory "bookmarks")
           ;; autosave each change
           bookmark-save-flag 1)))
 


### PR DESCRIPTION
Only set `bookmark-default-file` in the package configuration.  Put the
file in the Spacemacs cache directory instead of the Emacs user
directory.

Also only set `bookmark-save-flag` in the package configuration.

This is a breaking change.  Those with existing bookmarks file will have
to do something equivalent to this:

`mv ~/.emacs.d/bookmarks ~/.emacs.d/.cache`

and restart Emacs.

Fixes syl20bnr/spacemacs#2594