### PR TITLE
Change elpa to use http.

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -25,7 +25,7 @@
   (setq package-archives '(("melpa" . "http://melpa.org/packages/")
                            ("org" . "http://orgmode.org/elpa/")
                            ("ELPA" . "http://tromey.com/elpa/")
-                           ("gnu" . "https://elpa.gnu.org/packages/")))
+                           ("gnu" . "http://elpa.gnu.org/packages/")))
   ;; optimization, no need to activate all the packages so early
   (setq package-enable-at-startup nil)
   (package-initialize 'noactivate)


### PR DESCRIPTION
GNU is having issues with SSL. Use HTTP for now. 

Fixes #2596 