### PR TITLE
Remove projectile from scala layer.

### DIFF
--- a/contrib/!lang/scala/packages.el
+++ b/contrib/!lang/scala/packages.el
@@ -12,16 +12,11 @@
 
 (setq scala-packages
   '(
-    projectile
     ensime
     noflet
     sbt-mode
     scala-mode2
     ))
-
-(defun scala/init-projectile ()
-  (use-package projectile
-    :defer t))
 
 (defun scala/init-ensime ()
   (use-package ensime


### PR DESCRIPTION
The `projectile` package is already in the `spacemacs` core layer, I think there is no need keep `projectile` in the `scala` layer. And this config of projectile in scala layer overrides the owner of `projectile` pkg with scala mistakenly. This finally causes the issue about `projectile-known-projects` hooks.