### PR TITLE
Add binding for projectile-toggle-between-implementation-and-test

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2224,6 +2224,7 @@ To search in a project see [[#searching-in-a-project][project searching]].
     |-------------+-------------------------------------------------------|
     | ~SPC p !~   | run shell command in root                             |
     | ~SPC p &~   | run async shell command in root                       |
+    | ~SPC p a~   | toggle between implementation and test                |
     | ~SPC p b~   | switch to project buffer                              |
     | ~SPC p c~   | compile project using =projectile=                    |
     | ~SPC p d~   | find directory                                        |
@@ -2237,7 +2238,7 @@ To search in a project see [[#searching-in-a-project][project searching]].
     | ~SPC p p~   | switch project                                        |
     | ~SPC p r~   | open a recent file                                    |
     | ~SPC p R~   | replace a string                                      |
-    | ~SPC p s~   | see [[#searching-in-a-project][search in project]]                                 |
+    | ~SPC p s~   | see [[#searching-in-a-project][search in project]]    |
     | ~SPC p t~   | open =NeoTree= in =projectile= root                   |
     | ~SPC p T~   | find test files                                       |
     | ~SPC p v~   | open project root in =vc-dir= or =magit=              |

--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -3235,6 +3235,7 @@ one of `l' or `r'."
       (evil-leader/set-key
         "p!" 'projectile-run-shell-command-in-root
         "p&" 'projectile-run-async-shell-command-in-root
+        "pa" 'projectile-toggle-between-implementation-and-test
         "pc" 'projectile-compile-project
         "pD" 'projectile-dired
         "pG" 'projectile-regenerate-tags


### PR DESCRIPTION
The logic for binding this to `SPC p a` is that it's analogous with
vim-projectionist's notion of "alternate" files (where alternates could
be tests, headers or what-have-you). It would be more in keeping with
Spacemacs to have it on `SPC p t`, however this is already taken by
projectile neotree. If that were to be moved to `SPC p n`, then there
would be space for it, but I have no idea whether there is desire to
make a potentially significant change such as that.