### PR TITLE
disable line highlighting when shm is enabled

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -61,7 +61,7 @@
             (electric-indent-local-mode -1))
         (when haskell-enable-shm-support
           ;; in structured-haskell-mode line highlighting creates noise
-          (setq global-hl-line-mode nil))
+          (setq global-hl-line-mode nil)))
 
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)

--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -58,7 +58,10 @@
       (defun spacemacs/init-haskell-mode ()
         ;; use only internal indentation system from haskell
         (if (fboundp 'electric-indent-local-mode)
-            (electric-indent-local-mode -1)))
+            (electric-indent-local-mode -1))
+        (when haskell-enable-shm-support
+          ;; in structured-haskell-mode line highlighting creates noise
+          (setq global-hl-line-mode nil))
 
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)


### PR DESCRIPTION
When `structured-haskell-mode` is enabled users don't want lines to be highlighted, because `structured-haskell-mode` highlights current context (and sometimes it can be whole buffer), so line highlighting doesn't make real sense. 

I hope it doesn't ruin anything. But probably you also want to check if `global-hl-line-mode` is enabled. 