### PR TITLE
Fix the header for the YAML package.el

### DIFF
--- a/contrib/!lang/yaml/packages.el
+++ b/contrib/!lang/yaml/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- Ruby Layer packages File for Spacemacs
+;;; packages.el --- YAML Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors


### PR DESCRIPTION
Fix a copy/paste error in the header for the YAML layer's `packages.el`. 