### PR TITLE
update shm key bindings

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -234,12 +234,12 @@
         )
 
       (evil-define-key 'operator shm-map
-        (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node)
+        (kbd ")") 'shm/close-paren
+        (kbd "(") 'shm/open-paren)
 
       (evil-define-key 'motion shm-map
-        (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node))))
+        (kbd ")") 'shm/close-paren
+        (kbd "(") 'shm/open-paren))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun haskell/post-init-company ()

--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -227,14 +227,9 @@
         (define-key shm-map (kbd "C-c C-s") 'shm/do-case-split))
 
       (evil-define-key 'normal shm-map
-        (kbd "RET") nil
-        (kbd "C-k") nil
-        (kbd "C-j") nil
         (kbd "D") 'shm/kill-line
         (kbd "R") 'shm/raise
         (kbd "P") 'shm/yank
-        (kbd "RET") 'shm/newline-indent
-        (kbd "RET") 'shm/newline-indent
         (kbd "M-RET") 'evil-ret
         )
 
@@ -244,10 +239,7 @@
 
       (evil-define-key 'motion shm-map
         (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node)
-
-      (define-key shm-map (kbd "C-j") nil)
-      (define-key shm-map (kbd "C-k") nil))))
+        (kbd "(") 'shm/backward-node))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun haskell/post-init-company ()


### PR DESCRIPTION
By default `structured-haskell-mode` binds `C-j` to `shm/newline-indent-proxy`. And this is very important functionality of `structured-haskell-mode` as it inserts code that you would insert manually and also allows better indentation insertion in certain contexts. So I think it shouldn't be thrown away when `haskell-enable-shm-support` is `t`.

Also, when `C-j` is set to `nil`, `haskell-mode` argues that indentation isn't configured. So it doesn't looks nice.

The only thing I am not sure about is how `C-j` should behave in `normal` state. I don't use it all, so not sure if it's a good practice for `C-j` to insert code in certain situations, but anyway, this is how Chris Done intended it to behave, so I removed this rebind for `normal` state as well. 

For normal state there is also a mess for `RET` key. And by default, when `electric-mode` is on, the default bind from `structured-haskell-mode` will do `shm/newline-indent`. So I've removed them as well.

And about `C-k`. The idea of `structured-haskell-mode` is that you operate on context rather than on line. So I don't understand the point of making `C-k` to remove line.

What do you think? :smile: 