### PR TITLE
[package/deft] Support for multiple extensions

### DIFF
--- a/contrib/deft/packages.el
+++ b/contrib/deft/packages.el
@@ -18,7 +18,7 @@
     :defer t
     :init
     (progn
-      (setq deft-extension "txt"
+      (setq deft-extensions '("txt")
             deft-text-mode 'org-mode
             deft-use-filename-as-title t)
       (evil-leader/set-key "an" 'spacemacs/deft)


### PR DESCRIPTION
Support for multiple extensions via the `deft-extensions` list. As such, `deft-extension` is now deprecated :)