### PR TITLE
fix split multiple directories GOPATH problem (windows)

### DIFF
--- a/contrib/!lang/go/extensions.el
+++ b/contrib/!lang/go/extensions.el
@@ -22,7 +22,10 @@
 
 (defun load-gopath-file(gopath name)
   "Search for NAME file in all paths referenced in GOPATH."
-  (let ((paths (split-string gopath ":"))
+  (if (eq system-type 'windows-nt)
+    (setq sep '";")
+  (setq sep '":"))
+  (let ((paths (split-string gopath sep))
         found)
     (loop for p in paths
           for file = (concat p name) when (file-exists-p file)


### PR DESCRIPTION
e.g. %GOPATH%=d:\go-project