### PR TITLE
configure latexmk as the defualt build command

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -20,6 +20,7 @@
 This layer adds support for LaTeX files with [[https://savannah.gnu.org/projects/auctex/][AucTeX]].
 
 ** Features
+- Auto-build with [[https://github.com/tom-tan/auctex-latexmk/][auctex-latexmk]]
 - Auto-completion with [[https://github.com/alexeyr/company-auctex][company-auctex]]
 - Tags navigation on ~%~ with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 - Labels, references, citations and index entries management with [[http://www.gnu.org/software/emacs/manual/html_node/reftex/index.html][RefTeX]]
@@ -54,14 +55,18 @@ when you recompile.
 
 ** Build command
 
-A build command can be specific via the layer variable =latex-build-command=.
+A build command can be specified via the layer variable =latex-build-command=.
 
-The default value is =LaTeX=. If =LatexMk= is specified, the appropriate
-=LatexMk= configuration will be applied.
+If =LatexMk= is specified, the appropriate =LatexMk= configuration
+will be applied. (the default on systems with =latexmk= in the path)
+This variable can be set to any of the entities in =TeX-command-list=,
+including any custom entries you may have added there. To use the
+regular =AucTeX= command set =latex-build-command= to =LaTeX= as shown
+below.
 
 #+BEGIN_SRC emacs-lisp
   dotspacemacs-configuration-layers '(
-    (latex :variables latex-build-command "LatexMk"))
+    (latex :variables latex-build-command "LaTeX"))
 #+END_SRC
 
 ** Auto-fill

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -15,7 +15,7 @@
 ;; Company-mode LaTeX-backend
 (spacemacs|defvar-company-backends LaTeX-mode)
 
-(defvar latex-build-command "LaTeX"
+(defvar latex-build-command (if (executable-find "latexmk") "LatexMk" "LaTeX")
   "The default command to use with `SPC m b'")
 
 (defvar latex-enable-auto-fill t

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -77,10 +77,16 @@
         "mv" 'TeX-view))))
 
 (when (string= latex-build-command "LatexMk")
-(defun latex/init-auctex-latexmk ()
-  (use-package auctex-latexmk
-    :defer t
-    :init (add-hook 'LaTeX-mode-hook 'auctex-latexmk-setup))))
+  (defun latex/init-auctex-latexmk ()
+    (use-package auctex-latexmk
+      :defer t
+      :init
+      (progn
+        (eval-after-load "tex-mode"
+          '(progn
+             (auctex-latexmk-setup)
+             (setq auctex-latexmk-inherit-TeX-PDF-mode t)))
+        (add-hook 'LaTeX-mode-hook (lambda() (setq TeX-command-default "LatexMk")))))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun latex/post-init-company ()


### PR DESCRIPTION
This PR configures automatic compilation of LaTeX documents via `latexmk` by default if `latexmk` is available on the system. It also clarifies the use of the `latex-build-command` variable in response to https://github.com/syl20bnr/spacemacs/issues/2462#issuecomment-126143492. With these changes emacs will be configured to compile latex documents in a single step unless the user opts out, or the `latexmk` executable is unavailable.

The changes proposed here require a recent version of https://github.com/tom-tan/auctex-latexmk -- I'm not sure what the expectation is here. Since the changes I propose here will break without the latest version of `auctex-latexmk` should add an `if` expression to handle older versions, or do we expect users to keep packages up to date? 