### PR TITLE
Break new spell-checking layer out of syntax-checking

### DIFF
--- a/contrib/spell-checking/README.org
+++ b/contrib/spell-checking/README.org
@@ -1,0 +1,42 @@
+#+TITLE: Spell Checking configuration layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#install][Install]]
+     - [[#layer][Layer]]
+     - [[#spell-checker-configuration][Spell Checker Configuration]]
+ - [[#key-bindings][Key Bindings]]
+
+* Description
+
+This layer provides spell checking using [[http://www-sop.inria.fr/members/Manuel.Serrano/flyspell/flyspell.html][Flyspell]].
+
+* Install
+
+** Layer
+
+To use this configuration layer add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(spell-checking))
+#+END_SRC
+
+** Spell Checker Configuration
+
+The built-in Emacs variable that controls which external spell-checking program
+is used is =ispell-program-name=, which can be set in your =dotspacemacs/init=
+function if you do not like the default. It will give priority to =aspell= if it
+is installed on your system. Another important variable to be aware of is
+=ispell-dictionary= which will control the default dictionary used by
+=ispell-program-name= (instead of using this variable you can also use the key
+binding ~SPC S d~).
+
+
+* Key Bindings
+
+| Key Binding | Description              |
+|-------------+--------------------------|
+| ~SPC S c~   | flyspell correct         |
+| ~SPC S d~   | change dictionary        |
+| ~SPC S n~   | flyspell goto next error |
+| ~SPC t S~   | toggle flyspell          |

--- a/contrib/spell-checking/config.el
+++ b/contrib/spell-checking/config.el
@@ -1,4 +1,4 @@
-;;; config.el --- Syntax Checking Layer configuration File for Spacemacs
+;;; config.el --- Spell Checking Layer configuration File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
@@ -12,8 +12,6 @@
 
 ;; Variables
 
-(defvar syntax-checking-enable-tooltips t
-  "If non nil some feedback are displayed in tooltips.")
-
 ;; Command Prefixes
 
+(spacemacs/declare-prefix "S" "spelling")

--- a/contrib/spell-checking/packages.el
+++ b/contrib/spell-checking/packages.el
@@ -1,0 +1,42 @@
+;;; packages.el --- Spell Checking Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq spell-checking-packages
+  '(
+    flyspell
+    helm-flyspell
+    ))
+
+(defun spell-checking/init-flyspell ()
+  (use-package flyspell
+    :defer t
+    :init
+    (progn
+      (add-hook 'markdown-mode-hook '(lambda () (flyspell-mode 1)))
+      (add-hook 'text-mode-hook '(lambda () (flyspell-mode 1)))
+      (spacemacs|add-toggle spelling-checking
+        :status flyspell-mode
+        :on (flyspell-mode)
+        :off (flyspell-mode -1)
+        :documentation
+        "Enable flyspell for automatic spelling checking."
+        :evil-leader "tS"))
+    :config
+    (progn
+      (flyspell-prog-mode)
+      (spacemacs|diminish flyspell-mode " Ⓢ" " S"))))
+
+(defun spell-checking/init-helm-flyspell ()
+  (use-package helm-flyspell
+    :commands helm-flyspell-correct
+    :init (evil-leader/set-key "Sc" 'helm-flyspell-correct)))
+

--- a/contrib/syntax-checking/README.org
+++ b/contrib/syntax-checking/README.org
@@ -11,8 +11,7 @@
 
 * Description
 
-This layer provides on the fly syntax and spelling checking using
-[[http://www.flycheck.org/][Flycheck]] and [[http://www-sop.inria.fr/members/Manuel.Serrano/flyspell/flyspell.html][Flyspell]].
+This layer provides on the fly syntax checking using [[http://www.flycheck.org/][Flycheck]].
 
 * Install
 
@@ -42,6 +41,4 @@ to =nil=:
 |-------------+----------------------------------|
 | ~SPC e c~   | clear errors                     |
 | ~SPC e l~   | display a list of all the errors |
-| ~SPC S c~   |                                  |
 | ~SPC t s~   | toggle flycheck                  |
-| ~SPC t S~   | toggle flyspell                  |

--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -14,8 +14,6 @@
   '(
     flycheck
     flycheck-pos-tip
-    flyspell
-    helm-flyspell
     popwin
     ))
 
@@ -112,32 +110,6 @@
     :defer t
     :init
     (setq flycheck-display-errors-function 'flycheck-pos-tip-error-messages)))
-
-(defun syntax-checking/init-flyspell ()
-  (use-package flyspell
-    :defer t
-    :init
-    (progn
-      (setq-default ispell-program-name "aspell")
-      (setq-default ispell-dictionary "english")
-      (add-hook 'markdown-mode-hook '(lambda () (flyspell-mode 1)))
-      (add-hook 'text-mode-hook '(lambda () (flyspell-mode 1)))
-      (spacemacs|add-toggle spelling-checking
-        :status flyspell-mode
-        :on (flyspell-mode)
-        :off (flyspell-mode -1)
-        :documentation
-        "Enable flyspell for automatic spelling checking."
-        :evil-leader "tS"))
-    :config
-    (progn
-      (flyspell-prog-mode)
-      (spacemacs|diminish flyspell-mode " Ⓢ" " S"))))
-
-(defun syntax-checking/init-helm-flyspell ()
-  (use-package helm-flyspell
-    :commands helm-flyspell-correct
-    :init (evil-leader/set-key "Sc" 'helm-flyspell-correct)))
 
 (defun syntax-checking/post-init-popwin ()
   (push '("^\*Flycheck.+\*$" :regexp t :dedicated t :position bottom :stick t :noselect t) popwin:special-display-config))


### PR DESCRIPTION
This supersedes #2553. 

I checked and there doesn't seem to be a good reason to set `ispell-program-name` to "aspell", because the default behavior at least in my emacs is to use "aspell" if it exists on the machine. I left this out along with the setting of the dictionary, and opted for a short explanation in the documentation. 