### PR TITLE
Remove php-extras for now

### DIFF
--- a/contrib/!lang/php/packages.el
+++ b/contrib/!lang/php/packages.el
@@ -17,7 +17,6 @@
                      ggtags
                      helm-gtags
                      php-auto-yasnippets
-                     php-extras
                      php-mode
                      phpcbf
                      phpunit
@@ -41,10 +40,6 @@
 
 (defun php/init-php-auto-yasnippets ()
   (use-package php-auto-yasnippets
-    :defer t))
-
-(defun php/init-php-extras ()
-  (use-package php-extras
     :defer t))
 
 (defun php/init-php-mode ()


### PR DESCRIPTION
The php-extras package is not available on ELPA. I suggest we remove it
for now, and add it when/if its available on ELPA. I dont see php-mode getting merged to master when its not fully working. It also slows down Spacemacs startup. Closes  #1986 #2503 #1314