### PR TITLE
Make flycheck recognize `loadpath`

### DIFF
--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -33,6 +33,10 @@
         :evil-leader "ts"))
     :config
     (progn
+      ;; Make flycheck recognize packages in loadpath
+      ;; i.e (require 'company) will not give an error now
+      (setq flycheck-emacs-lisp-load-path 'inherit)
+
       (spacemacs|diminish flycheck-mode " ⓢ" " s")
 
       ;; color mode line faces


### PR DESCRIPTION
So that lines like

```elisp
  (require 'company)
```

Are not listed as errors.