### PR TITLE
Change shortcut of Bookmarks in *spacemacs* buffer

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -516,7 +516,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                ((eq el 'bookmarks)
                 (helm-mode)
                 (when (spacemacs-buffer//insert-bookmark-list "Bookmarks:" (bookmark-all-names))
-                  (spacemacs//insert--shortcut "m" "Bookmarks:")
+                  (spacemacs//insert--shortcut "M" "Bookmarks:")
                   (insert list-separator)))
                ((eq el 'projects)
                 (projectile-mode)


### PR DESCRIPTION
The default shortcut `m` is to jump to the menu in *spacemacs* buffer. If one change the startup lists by setting `dotspacemacs-startup-lists '(recents bookmarks projects)`, then the shortcut `m` is shadowed and jumps to `Bookmarks`. I changed the shortcut of jumping to Bookmarks to `M`.