### PR TITLE
Properly initialize the display for daemon mode.

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -1,0 +1,42 @@
+;;; core-display-init.el --- Spacemacs Core File
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar spacemacs--after-display-system-init-list '()
+  "List of functions to be run after the display system is initialized.")
+
+(defadvice server-create-window-system-frame
+    (after spacemacs-init-display activate)
+  "After Emacs server creates a frame, run functions queued in
+`SPACEMACS--AFTER-DISPLAY-SYSTEM-INIT-LIST' to do any setup that needs to have
+the display system initialized."
+  (progn
+    (dolist (fn (reverse spacemacs--after-display-system-init-list))
+      (funcall fn))
+    (ad-disable-advice 'server-create-window-system-frame
+                       'after
+                       'spacemacs-init-display)
+    (ad-activate 'server-create-window-system-frame)))
+
+(defmacro spacemacs|do-after-display-system-init (&rest body)
+  "If the display-system is initialized, run `BODY', otherwise,
+add it to a queue of actions to perform after the first graphical frame is
+created."
+  `(let ((init (cond ((eq system-type 'darwin) 'ns-initialized)
+                     ((eq system-type 'windows-nt) 'w32-initialized)
+                     ((eq system-type 'gnu/linux) 'x-initialized)
+                     (t 't))))           ; fallback to normal loading behavior
+     (if (symbol-value init)
+         (progn
+           ,@body)
+       (push (lambda () ,@body) spacemacs--after-display-system-init-list))))
+
+(provide 'core-display-init)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -16,6 +16,7 @@
 (require 'core-emacs-backports)
 (require 'core-release-management)
 (require 'core-auto-completion)
+(require 'core-display-init)
 (require 'core-themes-support)
 (require 'core-fonts-support)
 (require 'core-spacemacs-buffer)
@@ -117,10 +118,11 @@ initialization."
                                       "able to launch a graphical instance of Emacs"
                                       "with this build.")))
   ;; font
-  (if (find-font (font-spec :name (car dotspacemacs-default-font)))
-      (spacemacs/set-default-font dotspacemacs-default-font)
-    (spacemacs-buffer/warning "Cannot find font \"%s\"!"
-                              (car dotspacemacs-default-font)))
+  (spacemacs|do-after-display-system-init
+   (if (find-font (font-spec :name (car dotspacemacs-default-font)) (selected-frame))
+         (spacemacs/set-default-font dotspacemacs-default-font)
+       (spacemacs-buffer/warning "Cannot find font \"%s\"!"
+                                 (car dotspacemacs-default-font))))
   ;; banner
   (spacemacs-buffer/insert-banner-and-buttons)
   ;; mandatory dependencies


### PR DESCRIPTION
WORK IN PROGRESS.  NEEDS TESTING.  NEEDS TO USE THIS THROUGHOUT THE REST
OF SPACEMACS INITIALIZATION.

Will push a clean commit when everything is working satisfactorily.

Add macro to wrap things that depend on the display being
initialized (and a frame active), such as getting the font.  Advise the
`server-create-window-system-frame` function which is called by
emacsclient when creating a window-system frame.  This is only run the
first time a frame is created, so the advice removes itself.

Fixes: syl20bnr/spacemacs#299 and syl20bnr/spacemacs#1894
(Among others)