### PR TITLE
Switch evil-indent-textobject to a fork

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -42,7 +42,7 @@
         evil-escape
         evil-exchange
         evil-iedit-state
-        evil-indent-textobject
+        (evil-indent-textobject :location recipe)
         evil-jumper
         evil-leader
         evil-lisp-state
@@ -124,6 +124,9 @@
 (if  (version< emacs-version "24.4")
     (push '(paradox :location local) spacemacs-packages)
   (push 'paradox spacemacs-packages))
+
+(setq spacemacs-package-recipes
+      '((evil-indent-textobject :fetcher github :repo "TheBB/evil-indent-textobject")))
 
 ;; Initialization of packages
 


### PR DESCRIPTION
With the shiny new quelpa, I figured I might suggest this.

`evil-indent-textobject` is broken, see #2326 and https://github.com/cofi/evil-indent-textobject/issues/1. This switches to a fork (full disclosure, it's my fork) that fixes it. It also adds a couple of indentation-related text objects that the previous package doesn't have.