### PR TITLE
Fix #2148: Update failure in Emacs 25

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -998,6 +998,10 @@ to select one."
    ((version< emacs-version "24.3.50")
     (let ((v (configuration-layer//get-package-version-string pkg-name)))
       (when v (package-delete (symbol-name pkg-name) v))))
+   ((version<= "25.0.50" emacs-version)
+    (let ((p (cadr (assq pkg-name package-alist))))
+      ;; add force flag to ignore dependency checks in Emacs25
+      (when p (package-delete p t))))
    (t (let ((p (cadr (assq pkg-name package-alist))))
         (when p (package-delete p))))))
 


### PR DESCRIPTION
The `package-delete` function refuses to delete a package that is a
depency by default, which prevents the spacemacs update function from
working most of the time.

This commit sets the flag to force deletion for Emacs 25.