### PR TITLE
Only restore powerline when it is used

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -3192,7 +3192,8 @@ one of `l' or `r'."
         "Set the powerline for buffers created when Emacs starts."
         (unless configuration-layer-error-count
           (dolist (buffer '("*Messages*" "*spacemacs*" "*Compile-Log*"))
-            (when (get-buffer buffer)
+            (when (and (get-buffer buffer)
+                       (configuration-layer/package-usedp 'powerline))
               (spacemacs//restore-powerline buffer)))))
       (add-hook 'emacs-startup-hook
                 'spacemacs//set-powerline-for-startup-buffers))))


### PR DESCRIPTION
Recently, spacemacs started giving a warning here. Although powerline is
nearly a default, we still have this package-usedp check in other
places, it's appropriate here as well for those who don't use it.