### PR TITLE
Fix small typo in CHANGELOG

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,7 +21,7 @@
 **** Git
 - Fix =magit-repository-directories= variable name (thanks to travisbhartwell)
 - Fix =magit-blame= key binding (thanks to jenanwise)
-- Use -magit-log-all= instead of =magit-log= on ~SPC g l~ (thanks to tuhdo)
+- Use =magit-log-all= instead of =magit-log= on ~SPC g l~ (thanks to tuhdo)
 *** Other fixes and improvements
 - Typos and documentation improvements (thanks to cscorley, dstcruz, h3dkandi,
   kccai, MadAnd, person808, Profpatsch, stnly, stormpat, xfq, zachlatta)


### PR DESCRIPTION
Ordinarily I wouldn't make a PR against `master` but this is a fix to the CHANGELOG there -- small typo.