### PR TITLE
Fix Markdown to Org for README in Jabber Layer

### DIFF
--- a/contrib/jabber/README.org
+++ b/contrib/jabber/README.org
@@ -15,30 +15,28 @@ This layer adds keybindings for jabber.el. jabber.el is a Jabber (XMPP) client f
 * Install
 
 To use this contribution layer add it to your `~/.spacemacs`
-
-```elisp
-(set-default dotspacemacs-configuration-layers '(jabber))
-```
+ #+begin_src emacs-lisp
+    (set-default dotspacemacs-configuration-layers '(jabber))
+ #+end_src
 
 * Key bindings
 
-Key Binding         | Description
---------------------|-------------------------------
-<kbd>SPC a j </kbd> | Connect all accounts
+| Key Binding | Description          |
+| =SPC a j=   | Connect all accounts |
+
 
 ** Jabber Roster
 
-Key Binding             | Description
-------------------------|--------------------------------
-<kbd>SPC m a</kbd>      | Jabber send presence
-<kbd>SPC m b</kbd>      | Jabber get browse
-<kbd>SPC m d</kbd>      | Jabber disconnect
-<kbd>SPC m e</kbd>      | Jabber roster edit action at point
-<kbd>SPC m g</kbd>      | Jabber display roster
-<kbd>SPC m i</kbd>      | Jabber get disco items
-<kbd>SPC m j</kbd>      | Jabber muc join
-<kbd>SPC m o</kbd>      | Jabber roster toggle offline display
-<kbd>SPC m q</kbd>      | bury buffer
-<kbd>SPC m s</kbd>      | Jabber send subscription request
-<kbd>SPC m v</kbd>      | Jabber get version
-<kbd>SPC m RET</kbd>    | Jabber roster ret action at point
+| Key Binding | Description                          |
+| =SPC m a=   | Jabber send presence                 |
+| =SPC m b=   | Jabber get browse                    |
+| =SPC m d=   | Jabber disconnect                    |
+| =SPC m e=   | Jabber roster edit action at point   |
+| =SPC m g=   | Jabber display roster                |
+| =SPC m i=   | Jabber get disco items               |
+| =SPC m j=   | Jabber muc join                      |
+| =SPC m o=   | Jabber roster toggle offline display |
+| =SPC m q=   | bury buffer                          |
+| =SPC m s=   | Jabber send subscription request     |
+| =SPC m v=   | Jabber get version                   |
+| =SPC m RET= | Jabber roster ret action at point    |


### PR DESCRIPTION
Fix tables in the README for the Jabber Layer which had markdown artifacts.