### PR TITLE
Change shortcut of bookmarks in *spacemacs* buffer

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -557,7 +557,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                ((eq el 'bookmarks)
                 (helm-mode)
                 (when (spacemacs-buffer//insert-bookmark-list "Bookmarks:" (bookmark-all-names))
-                  (spacemacs//insert--shortcut "m" "Bookmarks:")
+                  (spacemacs//insert--shortcut "a" "Bookmarks:")
                   (insert list-separator)))
                ((eq el 'projects)
                 (projectile-mode)

--- a/core/info/quickhelp.txt
+++ b/core/info/quickhelp.txt
@@ -8,6 +8,8 @@ Press p to jump to project list.
 
 Press m to jump to the top menu.
 
+Press a to jump to the bookmarks if bookmark is enabled in the startup list.
+
 Press o to jump to any link or button.
 
 Press SPC (in Vim mode) or Alt-m (in Emacs mode) to access Spacemacs commands.


### PR DESCRIPTION
In *spacemacs* buffer, the quick help in `[?]` shows that `m` jumps to
the menu. However, if one customizes the startup lists by setting
`dotspacemacs-startup-lists '(recents bookmarks projects)`, the
shortcut `m` of jumping to the menu would be shadowed and `m` jumps to
Bookmarks.

With the help of @travisbhartwell and @TheBB, I changed the shortcut of
jumping to the Bookmarks to `a` to avoid this shortcut conflict.