### PR TITLE
[extra-langs] Remove mention of YAML from README

### DIFF
--- a/contrib/!lang/extra-langs/README.org
+++ b/contrib/!lang/extra-langs/README.org
@@ -8,5 +8,4 @@ These include:
 - Nim
 - QML
 - Stan
-- YAML
 - The Wolfram Language / Mathematica


### PR DESCRIPTION
This commit updates the extra-langs README to no longer list YAML as one
of the packages it provides (since YAML is now in its own layer).