### PR TITLE
Reserve SPC m o for user

### DIFF
--- a/contrib/!email/gnus/README.org
+++ b/contrib/!email/gnus/README.org
@@ -120,5 +120,5 @@ Basic and Spacemacs specific keybindings can be found in the following table.
 | ~J~         | Article Buffer - Next article                            |
 | ~RET~       | Summary Buffer(RSS) - Open article Link in browser       |
 | ~TAB~       | Summary Buffer(RSS) - Open article and switch to it      |
-| ~SPC m o~   | Message Buffer - Use org mode to convert into html email |
+| ~SPC m h~   | Message Buffer - Use org mode to convert into html email |
 | ~SPC m H~   | Org Mode - Send current buffer as HTML email message     |

--- a/contrib/!email/gnus/packages.el
+++ b/contrib/!email/gnus/packages.el
@@ -94,6 +94,6 @@
     (progn
       ;; setup org-mime
       (evil-leader/set-key-for-mode 'message-mode
-        "mo" 'org-mime-htmlize)
+        "mh" 'org-mime-htmlize)
       (evil-leader/set-key-for-mode 'org-mode
         "mH" 'org-mime-org-buffer-htmlize))))

--- a/contrib/!lang/agda/README.org
+++ b/contrib/!lang/agda/README.org
@@ -62,7 +62,7 @@ All Agda specific bindings are prefixed with the major-mode leader
 | ~SPC m h~   | Compute the type of a hypothetical helper function.                                                                                       |
 | ~SPC m l~   | Load current buffer.                                                                                                                      |
 | ~SPC m n~   | Computes the normal form of the given expression, using the scope of the current goal or, if point is not in a goal, the top-level scope. |
-| ~SPC m o~   | Shows all the top-level names in the given module.                                                                                        |
+| ~SPC m p~   | Shows all the top-level names in the given module.                                                                                        |
 | ~SPC m r~   | Refine the goal at point.                                                                                                                 |
 | ~SPC m s~   | Solves all goals that are already instantiated internally.                                                                                |
 | ~SPC m t~   | Show the type of the goal at point.                                                                                                       |

--- a/contrib/!lang/agda/extensions.el
+++ b/contrib/!lang/agda/extensions.el
@@ -63,7 +63,7 @@
         "mh" 'agda2-helper-function-type
         "ml" 'agda2-load
         "mn" 'agda2-compute-normalised-maybe-toplevel
-        "mo" 'agda2-module-contents-maybe-toplevel
+        "mp" 'agda2-module-contents-maybe-toplevel
         "mr" 'agda2-refine
         "ms" 'agda2-solveAll
         "mt" 'agda2-goal-type

--- a/contrib/!lang/go/README.org
+++ b/contrib/!lang/go/README.org
@@ -63,15 +63,15 @@ To use this contribution add it to your =~/.spacemacs=
 
 | Key Binding | Description                                                |
 |-------------+------------------------------------------------------------|
-| ~SPC m o o~ | go-oracle set analysis scope                               |
-| ~SPC m o <~ | go-oracle show possible callers                            |
-| ~SPC m o >~ | go-oracle show call targets                                |
-| ~SPC m o c~ | go-oracle show channel sends/receives                      |
-| ~SPC m o d~ | go-oracle show definition                                  |
-| ~SPC m o f~ | go-oracle show free variables                              |
-| ~SPC m o g~ | go-oracle show callgraph                                   |
-| ~SPC m o i~ | go-oracle show implements relation                         |
-| ~SPC m o p~ | go-oracle show what the select expression points to        |
-| ~SPC m o r~ | go-oracle show all references to object                    |
-| ~SPC m o s~ | go-oracle show callstack                                   |
-| ~SPC m o t~ | go-oracle describe selected syntax, kind, type and methods |
+| ~SPC m r o~ | go-oracle set analysis scope                               |
+| ~SPC m r <~ | go-oracle show possible callers                            |
+| ~SPC m r >~ | go-oracle show call targets                                |
+| ~SPC m r c~ | go-oracle show channel sends/receives                      |
+| ~SPC m r d~ | go-oracle show definition                                  |
+| ~SPC m r f~ | go-oracle show free variables                              |
+| ~SPC m r g~ | go-oracle show callgraph                                   |
+| ~SPC m r i~ | go-oracle show implements relation                         |
+| ~SPC m r p~ | go-oracle show what the select expression points to        |
+| ~SPC m r r~ | go-oracle show all references to object                    |
+| ~SPC m r s~ | go-oracle show callstack                                   |
+| ~SPC m r t~ | go-oracle describe selected syntax, kind, type and methods |

--- a/contrib/!lang/go/extensions.el
+++ b/contrib/!lang/go/extensions.el
@@ -40,18 +40,18 @@
       (when (load-gopath-file
              go-path "/src/golang.org/x/tools/cmd/oracle/oracle.el")
         (evil-leader/set-key-for-mode 'go-mode
-          "moo" 'go-oracle-set-scope
-          "mo<" 'go-oracle-callers
-          "mo>" 'go-oracle-callees
-          "moc" 'go-oracle-peers
-          "mod" 'go-oracle-definition
-          "mof" 'go-oracle-freevars
-          "mog" 'go-oracle-callgraph
-          "moi" 'go-oracle-implements
-          "mop" 'go-oracle-pointsto
-          "mor" 'go-oracle-referrers
-          "mos" 'go-oracle-callstack
-          "mot" 'go-oracle-describe)))))
+          "mro" 'go-oracle-set-scope
+          "mr<" 'go-oracle-callers
+          "mr>" 'go-oracle-callees
+          "mrc" 'go-oracle-peers
+          "mrd" 'go-oracle-definition
+          "mrf" 'go-oracle-freevars
+          "mrg" 'go-oracle-callgraph
+          "mri" 'go-oracle-implements
+          "mrp" 'go-oracle-pointsto
+          "mrr" 'go-oracle-referrers
+          "mrs" 'go-oracle-callstack
+          "mrt" 'go-oracle-describe)))))
 
 (defun go/init-go-rename()
   (use-package go-rename

--- a/contrib/!lang/ipython-notebook/README.org
+++ b/contrib/!lang/ipython-notebook/README.org
@@ -4,9 +4,9 @@
  - [[#description][Description]]
  - [[#features][Features]]
  - [[#list-of-todos][List of TODOS]]
-     - [[#todo-maybe-itd-be-better-if-there-was-a-state-for-this][TODO Maybe it'd be better if there was a state for this]]
-     - [[#todo-make-more-keybinding-to-connect-to-a-python-buffer][TODO Make more keybinding to =connect= to a python buffer.]]
-     - [[#todo-deleting-visual-regions-dont-work-find-out-why][TODO Deleting visual regions don't work, find out why.]]
+     - [[#maybe-itd-be-better-if-there-was-a-state-for-this][Maybe it'd be better if there was a state for this]]
+     - [[#make-more-keybinding-to-connect-to-a-python-buffer][Make more keybinding to =connect= to a python buffer.]]
+     - [[#deleting-visual-regions-dont-work-find-out-why][Deleting visual regions don't work, find out why.]]
  - [[#install][Install]]
      - [[#layer][Layer]]
      - [[#dependencies][Dependencies]]
@@ -84,8 +84,8 @@ prefix with ~SPC m~ to use with your evil-leader.
 | ~R~     | ein:worksheet-rename-sheet                |
 | ~y~     | ein:worksheet-copy-cell                   |
 | ~p~     | ein:worksheet-yank-cell                   |
-| ~o~     | ein:worksheet-insert-cell-below           |
-| ~O~     | ein:worksheet-insert-cell-above           |
+| ~i~     | ein:worksheet-insert-cell-below           |
+| ~I~     | ein:worksheet-insert-cell-above           |
 | ~u~     | ein:worksheet-change-cell-type            |
 | ~RET~   | ein:worksheet-execute-cell-and-goto-next  |
 | ~C-l~   | ein:worksheet-clear-output                |

--- a/contrib/!lang/ipython-notebook/packages.el
+++ b/contrib/!lang/ipython-notebook/packages.el
@@ -64,6 +64,8 @@
         "mp" 'ein:worksheet-yank-cell
         "md" 'ein:worksheet-kill-cell
         "mh" 'ein:notebook-worksheet-open-prev-or-last
+        "mi" 'ein:worksheet-insert-cell-below
+        "mI" 'ein:worksheet-insert-cell-above
         "mj" 'ein:worksheet-goto-next-input
         "mk" 'ein:worksheet-goto-prev-input
         "ml" 'ein:notebook-worksheet-open-next-or-first
@@ -73,8 +75,6 @@
         "mL" 'ein:notebook-worksheet-move-next
         "mt" 'ein:worksheet-toggle-output
         "mR" 'ein:worksheet-rename-sheet
-        "mo" 'ein:worksheet-insert-cell-below
-        "mO" 'ein:worksheet-insert-cell-above
         "m RET" 'ein:worksheet-execute-cell-and-goto-next
         ;; Output
         "m C-l" 'ein:worksheet-clear-output

--- a/contrib/!lang/markdown/packages.el
+++ b/contrib/!lang/markdown/packages.el
@@ -91,7 +91,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "mxP"  'markdown-pre-region
         ;; Following and Jumping
         "mN"   'markdown-next-link
-        "mo"   'markdown-follow-thing-at-point
+        "mf"   'markdown-follow-thing-at-point
         "mP"   'markdown-previous-link
         "m <RET>" 'markdown-jump)
 

--- a/contrib/jabber/README.org
+++ b/contrib/jabber/README.org
@@ -9,36 +9,34 @@
      - [[#jabber-roster][Jabber Roster]]
 
 * Description
-
 This layer adds keybindings for jabber.el. jabber.el is a Jabber (XMPP) client for Emacs
 
 * Install
-
 To use this contribution layer add it to your `~/.spacemacs`
 
-```elisp
+#+begin_src emacs-lisp
 (set-default dotspacemacs-configuration-layers '(jabber))
-```
+#+end_src
 
 * Key bindings
 
-Key Binding         | Description
---------------------|-------------------------------
-<kbd>SPC a j </kbd> | Connect all accounts
+| Key Binding | Description          |
+|-------------+----------------------|
+| ~SPC a j~   | Connect all accounts |
 
 ** Jabber Roster
 
-Key Binding             | Description
-------------------------|--------------------------------
-<kbd>SPC m a</kbd>      | Jabber send presence
-<kbd>SPC m b</kbd>      | Jabber get browse
-<kbd>SPC m d</kbd>      | Jabber disconnect
-<kbd>SPC m e</kbd>      | Jabber roster edit action at point
-<kbd>SPC m g</kbd>      | Jabber display roster
-<kbd>SPC m i</kbd>      | Jabber get disco items
-<kbd>SPC m j</kbd>      | Jabber muc join
-<kbd>SPC m q</kbd>      | bury buffer
-<kbd>SPC m r</kbd>      | Jabber roster toggle offline display
-<kbd>SPC m s</kbd>      | Jabber send subscription request
-<kbd>SPC m v</kbd>      | Jabber get version
-<kbd>SPC m RET</kbd>    | Jabber roster ret action at point
+| Key Binding | Description                          |
+|-------------+--------------------------------------|
+| ~SPC m a~   | Jabber send presence                 |
+| ~SPC m b~   | Jabber get browse                    |
+| ~SPC m d~   | Jabber disconnect                    |
+| ~SPC m e~   | Jabber roster edit action at point   |
+| ~SPC m g~   | Jabber display roster                |
+| ~SPC m i~   | Jabber get disco items               |
+| ~SPC m j~   | Jabber muc join                      |
+| ~SPC m q~   | bury buffer                          |
+| ~SPC m r~   | Jabber roster toggle offline display |
+| ~SPC m s~   | Jabber send subscription request     |
+| ~SPC m v~   | Jabber get version                   |
+| ~SPC m RET~ | Jabber roster ret action at point    |

--- a/contrib/jabber/README.org
+++ b/contrib/jabber/README.org
@@ -37,8 +37,8 @@ Key Binding             | Description
 <kbd>SPC m g</kbd>      | Jabber display roster
 <kbd>SPC m i</kbd>      | Jabber get disco items
 <kbd>SPC m j</kbd>      | Jabber muc join
-<kbd>SPC m o</kbd>      | Jabber roster toggle offline display
 <kbd>SPC m q</kbd>      | bury buffer
+<kbd>SPC m r</kbd>      | Jabber roster toggle offline display
 <kbd>SPC m s</kbd>      | Jabber send subscription request
 <kbd>SPC m v</kbd>      | Jabber get version
 <kbd>SPC m RET</kbd>    | Jabber roster ret action at point

--- a/contrib/jabber/packages.el
+++ b/contrib/jabber/packages.el
@@ -24,8 +24,8 @@
               "mg" 'jabber-display-roster
               "mi" 'jabber-get-disco-items
               "mj" 'jabber-muc-join
-              "mo" 'jabber-roster-toggle-offline-display
               "mq" 'bury-buffer
+              "mr" 'jabber-roster-toggle-offline-display
               "ms" 'jabber-send-subscription-request
               "mv" 'jabber-get-version
               "m RET" 'jabber-roster-ret-action-at-point)))

--- a/contrib/org/README.org
+++ b/contrib/org/README.org
@@ -76,10 +76,10 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC m e~                                    | org-export-dispatch                          |
 | ~SPC m f~                                    | org-set-effort                               |
 | ~SPC m I~                                    | org-clock-in                                 |
+| ~SPC m l~                                    | evil-org-open-links                          |
 | ~SPC m n~                                    | org-narrow-to-subtree                        |
 | ~SPC m N~                                    | widen                                        |
 | ~SPC m <dotspacemacs-major-mode-leader-key>~ | org-ctrl-c-ctrl-c                            |
-| ~SPC m o~                                    | evil-org-open-links                          |
 | ~SPC m O~                                    | org-clock-out                                |
 | ~SPC m q~                                    | org-clock-cancel                             |
 | ~SPC m R~                                    | org-refile                                   |

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -34,7 +34,7 @@
            "b" nil "mb" 'org-tree-to-indirect-buffer
            "c" nil "mA" 'org-archive-subtree
            "o" nil "mC" 'evil-org-recompute-clocks
-           "l" nil "mo" 'evil-org-open-links
+           "l" nil "ml" 'evil-org-open-links
            "t" nil "mT" 'org-show-todo-tree)
       (evil-define-key 'normal evil-org-mode-map
         "O" 'evil-open-above)

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -56,7 +56,8 @@ A package is initialized in a function with name =<layer>/init-xxx= where:
 
 *** Reserved prefix
 **** User prefix
-~SPC o~ must not be used by any layer. It is reserved for the user.
+~SPC o~ and ~SPC m o~ must not be used by any layer. They are reserved for the
+user.
 
 **** Major mode prefix
 ~SPC m~ is reserved for the current major mode. Three keys bindings are not an

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -996,8 +996,8 @@ layer. The leader key is by default ~SPC~ (space). It is possible to change this
 key with the variable =dotspacemacs-leader-key=.
 
 ** Reserved prefix command for user
-~SPC o~ is reserved for the user. Setting key bindings behind ~SPC o~ is
-*guaranteed* to never conflict with =Spacemacs= defaults key bindings.
+~SPC o~ and ~SPC m o~ are reserved for the user. Setting key bindings behind
+these is *guaranteed* to never conflict with =Spacemacs= default key bindings.
 
 *Example:* Put =(evil-leader/set-key "oc" 'org-capture)= inside
 =dotspacemacs/config= in your =~/.spacemacs= file, to be able to use ~SPC o c~


### PR DESCRIPTION
There's only a handful of keybindings to change. Most glaring was perhaps the loss of `,o` and `,O` in the IPython notebook.

Also Jabber was lacking orgification so I did it.

Fixes #2112.