### PR TITLE
check for dbus before add erc-notify hook.

### DIFF
--- a/contrib/!irc/erc/packages.el
+++ b/contrib/!irc/erc/packages.el
@@ -73,7 +73,10 @@
          :app-icon "/home/io/.emacs.d/assets/spacemacs.svg"
          :urgency 'low))
 
-      (add-hook 'erc-text-matched-hook 'erc-global-notify)
+      ;; osx doesn't have dbus support
+      (when (boundp 'dbus-compiled-version)
+        (add-hook 'erc-text-matched-hook 'erc-global-notify))
+
       ;; keybindings
       (evil-leader/set-key-for-mode 'erc-mode
         "md" 'erc-input-action


### PR DESCRIPTION
Emcs for OSX doesn't have dbus support by default. 'erc-global-notify makes a call to
notifications which seems to rely on dbus. Check to see if
dbus-compiled-version exists before adding hook.

Note: This variable is added in emacs 24.3. There may be a better way to
check for dbus support.

See #2324 