### PR TITLE
Emoji Fun! :)

### DIFF
--- a/contrib/!fun/emoji/README.org
+++ b/contrib/!fun/emoji/README.org
@@ -17,6 +17,7 @@ This layer adds support for Emoji emoticons from [[http://www.emoji-cheat-sheet.
 - Browse Emoji in a dedicated buffer
 - Display Emoji images in buffer
 - Insert one or several Emoji with an helm front-end
+- Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]]
   
 * Install
 

--- a/contrib/!fun/emoji/packages.el
+++ b/contrib/!fun/emoji/packages.el
@@ -10,7 +10,9 @@
 ;;
 ;;; License: GPLv3
 
-(setq emoji-packages '(emoji-cheat-sheet-plus))
+(setq emoji-packages
+      '(emoji-cheat-sheet-plus
+        company-emoji))
 
 (defun emoji/init-emoji-cheat-sheet-plus ()
   (use-package emoji-cheat-sheet-plus
@@ -32,4 +34,13 @@
         ;; text properties are not applied correctly.
         (run-at-time 0.1 nil 'emoji-cheat-sheet-plus-display-mode))
       (add-hook 'org-mode-hook 'spacemacs//delay-emoji-cheat-sheet-hook)
-      (add-to-hooks 'emoji-cheat-sheet-plus-display-mode '(markdown-mode)))))
+      (add-to-hooks 'emoji-cheat-sheet-plus-display-mode '(markdown-mode-hook
+                                                           rcirc-mode-hook
+                                                           erc-mode-hook)))))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun emoji/init-company-emoji ()
+    (use-package company-emoji
+      :if (configuration-layer/package-usedp 'company)
+      :init
+      (setq company-emoji-insert-unicode nil))))

--- a/contrib/!irc/erc/README.org
+++ b/contrib/!irc/erc/README.org
@@ -25,6 +25,8 @@ Layer for [[http://www.emacswiki.org/emacs/ERC][ERC IRC chat]].
   =github= layer enabled, or using =gist= package)
 - Optional SASL authentication via the variable =erc-enable-sasl-auth=
   (using [[http://emacswiki.org/emacs/ErcSASL][erc-sasl]])
+- Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
+  using the =emoji= layer or having a proper font) :clap:
 
 * Install
 

--- a/contrib/!irc/erc/config.el
+++ b/contrib/!irc/erc/config.el
@@ -12,3 +12,5 @@
 
 (defvar erc-enable-sasl-auth nil
   "If non nil then use SASL authenthication with ERC.")
+
+(spacemacs|defvar-company-backends erc-mode)

--- a/contrib/!irc/erc/packages.el
+++ b/contrib/!irc/erc/packages.el
@@ -18,6 +18,8 @@
         erc-social-graph
         erc-view-log
         erc-yt
+        company
+        company-emoji
         ))
 
 (when (system-is-mac)
@@ -149,3 +151,11 @@
     :init (eval-after-load 'erc '(add-to-list 'erc-modules 'image))))
 
 (defun erc/init-erc-terminal-notifier ())
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun erc/post-init-company ()
+    (spacemacs|add-company-hook erc-mode)
+    (push 'company-capf company-backends-erc-mode))
+
+  (defun erc/post-init-company-emoji ()
+    (push 'company-emoji company-backends-erc-mode)))

--- a/contrib/!irc/rcirc/README.org
+++ b/contrib/!irc/rcirc/README.org
@@ -31,6 +31,8 @@ and ZNC.
 - Support ZNC support (with optional =~/.authinfo.gpg=)
 - Colored nicknames
 - WIP: Real time change when people use =/s/foo/bar= in the chats
+- Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
+  using the =emoji= layer or having a proper font) :clap:
   
 * Install
 

--- a/contrib/!irc/rcirc/config.el
+++ b/contrib/!irc/rcirc/config.el
@@ -17,3 +17,5 @@
 
 (defvar rcirc-enable-znc-support nil
   "if non nil then znc is enabled.")
+
+(spacemacs|defvar-company-backends rcirc-mode)

--- a/contrib/!irc/rcirc/packages.el
+++ b/contrib/!irc/rcirc/packages.el
@@ -3,6 +3,8 @@
     rcirc
     rcirc-notify
     rcirc-color
+    company
+    company-emoji
     ))
 
 (defun rcirc/init-rcirc ()
@@ -127,3 +129,11 @@
 
 (defun rcirc/init-rcirc-color ()
   (use-package rcirc-color :defer t))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun rcirc/post-init-company ()
+    (spacemacs|add-company-hook rcirc-mode)
+    (push 'company-capf company-backends-rcirc-mode))
+
+  (defun rcirc/post-init-company-emoji ()
+    (push 'company-emoji company-backends-rcirc-mode)))

--- a/contrib/!lang/markdown/README.org
+++ b/contrib/!lang/markdown/README.org
@@ -26,6 +26,8 @@ This layer adds markdown support to Spacemacs.
 ** Features:
 - markdown files support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
 - TOC generation via [[https://github.com/ardumont/markdown-toc][markdown-toc]]
+- Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
+  using the =emoji= layer or having a proper font) :clap:
 
 * Install
 

--- a/contrib/!lang/markdown/packages.el
+++ b/contrib/!lang/markdown/packages.el
@@ -15,6 +15,8 @@
     markdown-mode
     markdown-toc
     mmm-mode
+    company
+    company-emoji
     ))
 
 (defun markdown/init-markdown-mode ()
@@ -165,3 +167,10 @@ Will work on both org-mode and any mode that accepts plain html."
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-c++)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-elisp)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-html))))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun markdown/post-init-company ()
+    (spacemacs|add-company-hook markdown-mode)
+    (push 'company-capf company-backends-markdown-mode))
+  (defun markdown/post-init-company-emoji ()
+    (push 'company-emoji company-backends-markdown-mode)))

--- a/contrib/org/config.el
+++ b/contrib/org/config.el
@@ -14,3 +14,5 @@
 
 (defvar org-enable-github-support nil
   "If non-nil Github related packages are configured.")
+
+(spacemacs|defvar-company-backends org-mode)

--- a/contrib/org/packages.el
+++ b/contrib/org/packages.el
@@ -20,6 +20,8 @@
     org-present
     org-repo-todo
     toc-org
+    company
+    company-emoji
     ))
 
 (defun org/init-evil-org ()
@@ -209,3 +211,11 @@ Will work on both org-mode and any mode that accepts plain html."
 (defun org/init-htmlize ()
  (use-package htmlize
     :defer t))
+
+(when (configuration-layer/layer-usedp 'auto-completion)
+  (defun org/post-init-company ()
+    (spacemacs|add-company-hook org-mode)
+    (push 'company-capf company-backends-org-mode))
+  (defun org/post-init-company-emoji ()
+    (push 'company-emoji company-backends-org-mode)))
+


### PR DESCRIPTION
Also Now org,markdown and ERC have company enabled (why wasn't this done
before)
Although there are some caveats in org mode, sometimes the emoji-display thing doesn't fully replace the `:`s
[![alt](http://imgur.com/7XGxr60.png)](http://imgur.com/7XGxr60.png)
Also there is this bug in the company popup for candidates but that might be from company-emoji. They have a fix for it which is having the right font..but somehow I didn't get it working in spacemacs, so I just disabled inserting an unicode and just leaving the renderring to emoji-display package we have. But the company popup would be nice to have working as well. 

I don't know much about fonts so maybe @syl20bnr can expand on this :)