### PR TITLE
Add a rev number to SPC hds.

### DIFF
--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -208,11 +208,27 @@ version and the NEW version."
       (kill-buffer proc-buffer))))
 
 (defun spacemacs/git-get-current-branch ()
-  "Return the current branch. Return nil if an error occurred."
-  (let((proc-buffer "git-get-current-branch")
+   "Return the current branch. Return nil if an error occurred."
+   (let((proc-buffer "git-get-current-branch")
+        (default-directory (file-truename user-emacs-directory)))
+     (when (eq 0 (process-file "git" nil proc-buffer nil
+                               "symbolic-ref" "--short" "-q" "HEAD"))
+       (with-current-buffer proc-buffer
+         (prog1
+             (when (buffer-string)
+               (goto-char (point-min))
+               (replace-regexp-in-string
+                "\n$" ""
+                (buffer-substring (line-beginning-position)
+                                  (line-end-position))))
+           (kill-buffer proc-buffer))))))
+
+(defun spacemacs/git-get-current-branch-rev ()
+  "Returns the hash of the head commit on the current branch. Returns nil if an error occurred."
+  (let((proc-buffer "git-get-current-branch-head-hash")
        (default-directory (file-truename user-emacs-directory)))
     (when (eq 0 (process-file "git" nil proc-buffer nil
-                              "symbolic-ref" "--short" "-q" "HEAD"))
+                              "rev-parse" "--short" "HEAD"))
       (with-current-buffer proc-buffer
         (prog1
             (when (buffer-string)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -249,12 +249,13 @@ FILE-TO-LOAD is an explicit file to load after the installation."
                           "- OS: %s\n"
                           "- Emacs: %s\n"
                           "- Spacemacs: %s\n"
-                          "- Spacemacs branch: %s\n"
+                          "- Spacemacs branch: %s (rev. %s)\n"
                           "- Layers:\n```elisp\n%s```\n")
                   system-type
                   emacs-version
                   spacemacs-version
                   (spacemacs/git-get-current-branch)
+                  (spacemacs/git-get-current-branch-rev)
                   (pp dotspacemacs-configuration-layers))))
     (kill-new sysinfo)
     (message sysinfo)


### PR DESCRIPTION
Fix the system-information to show revision number. 

Here is what <kbd>SPC hds</kbd> shows: 

#### System Info
- OS: gnu/linux
- Emacs: 24.4.1
- Spacemacs: 0.104.0
- Spacemacs branch: add-revision-to-system-info (rev. 57b6f17)
- Layers:
```elisp
((auto-completion :variables auto-completion-return-key-behavior 'complete auto-completion-tab-key-behavior 'cycle auto-completion-complete-with-key-sequence nil auto-completion-enable-help-tooltip t auto-completion-enable-sort-by-usage t auto-completion-show-snippets-in-popup t)
 better-defaults emacs-lisp
 (git :variables git-magit-status-fullscreen t)
 github version-control markdown syntax-checking
 (latex :variables latex-enable-auto-fill t)
 (colors :variables colors-enable-rainbow-identifiers t colors-enable-nyan-cat-progress-bar t)
 dockerfile ansible puppet evil-commentary
 (evil-snipe :variables evil-snipe-enable-alternate-f-and-t-behaviors t)
 fasd finance floobits xkcd autohotkey
 (c-c++ :variables c-c++-enable-clang-support t)
 (clojure :variables clojure-enable-fancify-symbols t)
 extra-langs go
 (haskell :variables haskell-enable-ghci-ng-support t haskell-enable-shm-support t haskell-enable-hindent-style "andrew-gibiansky")
 html javascript
 (python :variables python-enable-yapf-format-on-save t)
 racket
 (ruby :variables ruby-version-manager `rvm)
 ruby-on-rails rust scala shell-scripts restclient themes-megapack tmux vim-empty-lines spotify pandoc vagrant
 (ibuffer :variables ibuffer-group-buffers-by 'projects)
 semantic deft
 (shell :variables shell-default-shell 'eshell shell-default-position 'bottom shell-default-height 30 shell-default-term-shell "/bin/zsh")
 typescript
 (eyebrowse :variables eyebrowse-display-help t)
 (perspectives :variables perspective-enable-persp-projectile t)
 erc chrome d extra-langs smex emoji gtags prodigy evernote
 (org :variables org-enable-github-support t)
 search-engine encoding evil-little-word evil-shift-width no-dots yaml sql nim ipython-notebook lua scheme purescript sml common-lisp ranger dash spell-checking jabber deft cscope vineger unimpaired rcirc games)
```
