### PR TITLE
Fix Magit manual link

### DIFF
--- a/contrib/!source-control/git/README.org
+++ b/contrib/!source-control/git/README.org
@@ -64,7 +64,7 @@ function, this is the folder where you keep all your git-controlled projects
   (setq magit-repository-directories '("~/repos/"))
 #+END_SRC
 
-For more information, see [[https://magit.github.io/master/magit.html#Status][Magit-User-Manual#Status]]
+For more information, see [[http://magit.vc/manual/magit/Status-buffer.html#Status-buffer][Magit-User-Manual#Status]]
 
 ** Magit SVN plugin
 


### PR DESCRIPTION
Hi there - the current link to the magit manual is broken.   I think it should be http://magit.vc/manual/magit/Status-buffer.html#Status-buffer ?