### PR TITLE
Clean up vinegar layer

### DIFF
--- a/contrib/!vim/vinegar/README.org
+++ b/contrib/!vim/vinegar/README.org
@@ -1,12 +1,12 @@
 #+TITLE: Vinegar contribution layer for Spacemacs
 
 * Table of Contents                                                   :TOC@4:
- - [[#desciption][Desciption]]
-     - [[#features][Features]]
-     - [[#mouse-bindings][Mouse bindings]]
-     - [[#key-bindings][Key bindings]]
+ - [[#description][Description]]
+   - [[#features][Features]]
+   - [[#mouse-bindings][Mouse bindings]]
+   - [[#key-bindings][Key bindings]]
 
-* Desciption
+* Description
 
 This layer is a port contribution layer for vim-vinegar for emacs.
 
@@ -45,10 +45,10 @@ buffers to enter dired.
 | ~I~         | (Dired) Toggle showing dotfiles                    |
 | ~~~         | (Dired) Navigate to home directory                 |
 | ~f~         | (Dired) Helm find file                             |
+| ~J~         | (Dired) Goto file                                  |
 | ~C-f~       | (Dired) dired-find                                 |
 | ~H~         | (Dired) Show dired history                         |
 | ~T~         | (Dired) Move down in dired tree                    |
 | ~K~         | (Dired) Kill marked lines (hide, do not delete)    |
 | ~r~         | (Dired) Redisplay buffer                           |
-| ~C-r~       | (Dired) Revert buffer                              |
 

--- a/contrib/!vim/vinegar/config.el
+++ b/contrib/!vim/vinegar/config.el
@@ -1,0 +1,16 @@
+;;; config.el --- Vinegar Layer Configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar vinegar-reuse-dired-buffer nil
+  "If non-nil, reuses one dired buffer for navigation.")

--- a/contrib/!vim/vinegar/keybindings.el
+++ b/contrib/!vim/vinegar/keybindings.el
@@ -14,14 +14,16 @@
            (kbd "C-k") 'dired-prev-subdir
            "I"         'vinegar/dotfiles-toggle
            (kbd "~")   '(lambda ()(interactive) (find-alternate-file "~/"))
-           (kbd "RET") 'dired-find-alternate-file
+           (kbd "RET") (if vinegar-reuse-dired-buffer
+                           'dired-find-alternate-file
+                         'dired-find-file)
            "f"         'helm-find-files
+           "J"         'dired-goto-file
            (kbd "C-f") 'find-name-dired
            "H"         'diredp-dired-recent-dirs
            "T"         'dired-tree-down
            "K"         'dired-do-kill-lines
-           "r"         'dired-do-redisplay
-           (kbd "C-r") 'revert-buffer
+           "r"         'revert-buffer
+           "C-r"       'dired-do-redisplay
            "gg"        'vinegar/back-to-top
-           "G"         'vinegar/jump-to-bottom
-           ))
+           "G"         'vinegar/jump-to-bottom))


### PR DESCRIPTION
Add keybinding for dired-goto-file at `J`, previously shadowed by `j`.
This command take you *to* a file or folder but does not enter it. Add
dotspacemacs variable to determine dired buffer reuse behavior (rather
than forcing only reuse). Swap `C-r` and `r` bindings, as revert-buffer
is far more generally useful.