### PR TITLE
deft-extension is now deprecated

### DIFF
--- a/contrib/deft/packages.el
+++ b/contrib/deft/packages.el
@@ -18,7 +18,7 @@
     :defer t
     :init
     (progn
-      (setq deft-extension "txt"
+      (setq deft-extensions '("txt")
             deft-text-mode 'org-mode
             deft-use-filename-as-title t)
       (evil-leader/set-key "an" 'spacemacs/deft)


### PR DESCRIPTION
We can use a couple more extensions like "org", "md". But I will leave it to you to decide.
And deft-recursive is pretty useful too.