### PR TITLE
Ignore newsticker data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ server/
 /*.zip
 *.db
 python-*-docs-html
+newsticker
 
 # Private directory
 private/*


### PR DESCRIPTION
[Newsticker](https://www.gnu.org/software/emacs/manual/html_node/newsticker/Overview.html#Overview), which is included by default with Spacemacs, stores its data under ~/.emacs.d.