### PR TITLE
Add spacemacs/set-keys

### DIFF
--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -98,6 +98,38 @@ used as the prefix command."
     (define-prefix-command command)
     (evil-leader/set-key-for-mode mode prefix command)))
 
+(defun spacemacs/set-keys (key binding &rest bindings)
+  "Bind KEY to command BINDING in `evil-leader/default-map'.
+
+Key has to be readable by `read-kbd-macro'. BINDING is either a
+command, in which case this is equvalent to \(evil-leader/set-key
+key binding\), or a list. If it's a list, then the KEY is treated
+as a prefix key and the first element of the list is the name of
+the prefix. The remaining elements of the list are further KEY
+BINDING pairs. Accepts further KEY BINDING pairs."
+  (while key
+    (cond ((listp binding)
+           (spacemacs/declare-prefix key (pop binding))
+           (apply #'spacemacs/set-keys binding))
+          (t (evil-leader/set-key key binding)))
+    (setq key (pop bindings)
+          binding (pop bindings))))
+(put 'spacemacs/set-keys 'lisp-indent-function 'defun)
+
+(defun spacemacs/set-keys-for-mode (mode key binding &rest bindings)
+  "Create key binding for major-mode MODE with KEY bound to BINDING.
+
+Except for targeting a major-mode, this macro functions the same
+as `spacemacs/set-keys'."
+  (while key
+    (cond ((listp binding)
+           (spacemacs/declare-prefix-for-mode mode key (pop binding))
+           (apply (apply-partially #'spacemacs/set-keys-for-mode mode) binding))
+          (t (evil-leader/set-key-for-mode mode key binding)))
+    (setq key (pop bindings)
+          binding (pop bindings))))
+(put 'spacemacs/set-keys-for-mode 'lisp-indent-function 'defun)
+
 (defun spacemacs/activate-major-mode-leader ()
   "Bind major mode key map to `dotspacemacs-major-mode-leader-key'."
   (setq mode-map (cdr (assoc major-mode evil-leader--mode-maps)))

--- a/spacemacs/funcs.el
+++ b/spacemacs/funcs.el
@@ -100,46 +100,63 @@ used as the prefix command."
 
 (defun spacemacs//add-prefix-keys (prefix bindings)
   "PREFIX is a string added to the front of each key in BINDINGS."
-  (let ((i 0))
-    (mapcar (lambda (bndg)
-              (setq bndg (if (= (mod i 2) 0) (concat prefix bndg) bndg))
-              (incf i)
-              bndg)
-            bindings)))
+  (let (res)
+    (while bindings
+      (push (concat prefix (pop bindings)) res)
+      (push (pop bindings) res))
+    (reverse res)))
 
-(cl-defun spacemacs/set-keys (&rest bindings &key major-mode prefix-keys prefix-name
-                                    prefix-long-name &allow-other-keys)
+(defun spacemacs/set-keys (&rest args)
   "Bind keys using `evil-leader'.
 
-The key bindings are stored in BINDINGS which is a list of key
-sequence strings, readable by `read-kbd-macro', each followed by
-commands. Without using keyword arguments this function is
-equivalent to `evil-leader/set-key'.
+ARGS is a list of keyword-value or key-command pairs. Key-command
+pairs are a key sequence string, readable by `read-kbd-macro',
+followed by a command. Without using keyword-value arguments this
+function is equivalent to `evil-leader/set-key'.
 
-Keyword arguments, which must precede the list of bindings, can
-be used with the following effects. Using :major-mode will bind
-the keys only when the corresponding major-mode is
-active. :prefix-keys allows you to specify one or more keys that
-will precede all of the keys in BINDINGS. :prefix-name will
-declare the name of the prefix specified in :prefix-keys for use
-in reporting keys. :prefix-long-name will specify a long-name for
-the prefix. See `spacemacs/declare-prefix' for more information
-on this last option."
-  (let* ((clean-bindings
-          (-take-while (lambda (arg) (not (keywordp arg))) bindings))
-         (prefixed-bindings
-          (if (stringp prefix-keys)
-              (spacemacs//add-prefix-keys prefix-keys clean-bindings)
-            clean-bindings))
-         (declare-prefix (and (stringp prefix-name) (stringp prefix-keys))))
-    (if (and major-mode (symbolp major-mode))
-        (progn (when declare-prefix
-                 (spacemacs/declare-prefix-for-mode major-mode prefix-keys prefix-name))
-               (apply (apply-partially #'evil-leader/set-key-for-mode major-mode)
-                      prefixed-bindings))
-      (when declare-prefix
-        (spacemacs/declare-prefix prefix-keys prefix-name prefix-long-name))
-      (apply #'evil-leader/set-key prefixed-bindings))))
+Keyword-value pairs can be used with the following effects.
+Using :major-mode will bind the keys only when the corresponding
+major-mode is active. :prefix-keys allows you to specify one or
+more keys that will precede all of the keys in the key-command
+pairs. :prefix-name will declare the name of the prefix specified
+in :prefix-keys for use in reporting keys. :prefix-long-name will
+specify a long-name for the prefix. See
+`spacemacs/declare-prefix' for more information on this last
+option. An example is the following which binds (in text-mode
+only) command-1 to the key sequence \"aa\" and command-2 to the
+sequence \"ab\". The \"a\" prefix is declared to have the name
+\"a-commands\".
+
+\(spacemacs/set-keys
+  :major-mode text-mode
+  :prefix-keys \"a\"
+  :prefix-name \"a-comands\"
+  \"a\" 'command-1
+  \"b\" 'command-2\)
+
+The keyword-value pairs can come before or after the list of bindings."
+  (let (major-mode prefix-keys prefix-name prefix-long-name bindings)
+    (while args
+      (pcase (pop args)
+        (:major-mode  (setq major-mode (pop args)))
+        (:prefix-keys (setq prefix-keys (pop args)))
+        (:prefix-name (setq prefix-name (pop args)))
+        (:prefix-long-name (setq prefix-name (pop args)))
+        (binding (push binding bindings))))
+    (let* ((bindings (reverse bindings))
+           (prefixed-bindings
+            (if (stringp prefix-keys)
+                (spacemacs//add-prefix-keys prefix-keys bindings)
+              bindings))
+           (declare-prefix (and (stringp prefix-name) (stringp prefix-keys))))
+      (if (and major-mode (symbolp major-mode))
+          (progn (when declare-prefix
+                   (spacemacs/declare-prefix-for-mode major-mode prefix-keys prefix-name))
+                 (apply (apply-partially #'evil-leader/set-key-for-mode major-mode)
+                        prefixed-bindings))
+        (when declare-prefix
+          (spacemacs/declare-prefix prefix-keys prefix-name prefix-long-name))
+        (apply #'evil-leader/set-key prefixed-bindings)))))
 
 (defun spacemacs/activate-major-mode-leader ()
   "Bind major mode key map to `dotspacemacs-major-mode-leader-key'."


### PR DESCRIPTION
These functions are better versions of `evil-leader/set-key` and
`evil-leader/set-key-for-mode`. The difference is the ability to specify
a prefix with a name that will automatically be declared.

Here's an illustration of how it is meant to be used, which will simultaneously declare "p" and "pp" as prefixes with names "prefix-name" and "sub-prefix-name" as well as the corresponding bindings. More string-command or string-list pairs can be used, and they can also be nested. I think this makes for a nicely structured and cleaner way to define bindings, avoiding the need to declare prefixes. 

```elisp
(spacemacs/set-keys
    "r" 'root-binding
    "p" '("prefix-name"
          "pb" awesome-command
          "pp" ("sub-prefix-name"
                "ppr" awesome-command-2))
    "f" 'second-root-binding)
```

EDIT: This post only applies to the implementation in the first commit