### PR TITLE
Don't produce on/off toggles if status is nil

### DIFF
--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -76,16 +76,18 @@ used."
                ,@on-body
                (message ,(format "%s enabled." name)))
            (message "This toggle is not supported.")))
-       ;; on-function
-       (defun ,wrapper-func-on ()
-         ,(format "Toggle %s on." (symbol-name name))
-         (interactive)
-         (unless ,status-eval (,wrapper-func)))
-       ;; off-function
-       (defun ,wrapper-func-off ()
-         ,(format "Toggle %s off." (symbol-name name))
-         (interactive)
-         (when ,status-eval (,wrapper-func)))
+       ;; Only define on- or off-functions when status is available
+       ,@(when status
+           ;; on-function
+           `((defun ,wrapper-func-on ()
+               ,(format "Toggle %s on." (symbol-name name))
+               (interactive)
+               (unless ,status-eval (,wrapper-func)))
+             ;; off-function
+             (defun ,wrapper-func-off ()
+               ,(format "Toggle %s off." (symbol-name name))
+               (interactive)
+               (when ,status-eval (,wrapper-func)))))
        ,@bindkeys)))
 
 (provide 'core-toggle)


### PR DESCRIPTION
After #2499, toggles have `on` and `off` functions, but not all toggles have a `status` that makes sense. For those cases the `on` and `off` functions produce unexpected results. It's better not to generate them in these cases.