### PR TITLE
Load and initialize racer package

### DIFF
--- a/contrib/!lang/rust/packages.el
+++ b/contrib/!lang/rust/packages.el
@@ -14,6 +14,7 @@
   '(
     company
     company-racer
+    racer
     flycheck
     flycheck-rust
     rust-mode
@@ -58,3 +59,12 @@
       :if (configuration-layer/package-usedp 'company)
       :defer t
       :init (push 'company-racer company-backends-rust-mode))))
+
+(defun rust/init-racer ()
+  (use-package racer
+    :if rust-enable-racer
+    :defer t
+    :init (add-hook 'rust-mode-hook
+                    '(lambda ()
+                       (racer-mode)
+                       (eldoc-mode)))))


### PR DESCRIPTION
There is now a racer package available, that seems to complete `company-racer` introduced in #2025.
Some bindings should probably be setup, but I'm really not an expert with using `company` and `eldoc`, so I don't know what defaults are sensible.