### PR TITLE
Make golden-ratio work after avy-goto-word-or-subword-1

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -412,6 +412,11 @@
       (setq avy-keys (number-sequence ?a ?z))
       (setq avy-all-windows 'all-frames)
       (setq avy-background t)
+      ; make golden ratio work after switching windows with avy-goto-word-or-subword-1
+      (eval-after-load 'golden-ratio
+        '(setq golden-ratio-extra-commands
+               (append golden-ratio-extra-commands
+                       '(evil-avy-goto-word-or-subword-1))))
       (evil-leader/set-key
         "SPC" 'avy-goto-word-or-subword-1
         "l" 'avy-goto-line))


### PR DESCRIPTION
Fixes issue #2730 

* When moving around windows via ace, the golden ratio plugin works fine.
  This PR makes it so jumping windows with `SPC SPC [character]` works as
  well.