### PR TITLE
python-mode: fill-column should be 79 instead of 80

### DIFF
--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -115,6 +115,7 @@
       (defun python-default ()
         (setq mode-name "Python"
               tab-width 4
+              fill-column 79
               ;; auto-indent on colon doesn't work well with if statement
               electric-indent-chars (delq ?: electric-indent-chars))
         (annotate-pdb)


### PR DESCRIPTION
PEP8 wants the fill-column to be 79 instead of 80.  This will make other
packages, like flake8 and electric-indent happy.

Fixes #2754 