### PR TITLE
Don't automatically select *compilation* buffer

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -2707,7 +2707,7 @@ It will toggle the overlay under point or create an overlay of one character."
 
       ;; buffers that we manage
       (push '("*Help*"                 :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)
-      (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)
+      (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Shell Command Output*" :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*Async Shell Command*"  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '(" *undo-tree*"           :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)


### PR DESCRIPTION
This matches the default behavior of emacs, wherein the *compilation*
buffer is not automatically selected when created by the compile
command. See:

http://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation.html

In particular:

    "Starting a compilation displays the *compilation* buffer in another
    window but does not select it."