### PR TITLE
activate tern-mode to make it work with company

### DIFF
--- a/contrib/!frameworks/react/packages.el
+++ b/contrib/!frameworks/react/packages.el
@@ -27,6 +27,7 @@
     (spacemacs|add-company-hook react-mode))
 
   (defun react/post-init-company-tern ()
+    (add-hook 'react-mode-hook 'tern-mode)
     (push 'company-tern company-backends-react-mode)))
 
 (defun react/pre-init-flycheck ()


### PR DESCRIPTION
If we do not manually call  `tern-mode` on the react layer hook it seems not to start and company does not complete as it does on `js2-mode`