### PR TITLE
New commands for flycheck

### DIFF
--- a/contrib/syntax-checking/packages.el
+++ b/contrib/syntax-checking/packages.el
@@ -99,10 +99,21 @@
         :fringe-bitmap 'my-flycheck-fringe-indicator
         :fringe-face 'flycheck-fringe-info)
 
+      ;; toggle flycheck window
+      (defun spacemacs/toggle-flycheck-error-list ()
+        "Toggle flycheck's error list window.
+If the error list is visible, hide it.  Otherwise, show it."
+        (interactive)
+        (-if-let (window (flycheck-get-error-list-window))
+            (quit-window nil window)
+          (flycheck-list-errors)))
+
       ;; key bindings
       (evil-leader/set-key
         "ec" 'flycheck-clear
-        "el" 'flycheck-list-errors))))
+        "el" 'spacemacs/toggle-flycheck-error-list
+        "ev" 'flycheck-verify-setup
+        "e?" 'flycheck-describe-checker))))
 
 (defun syntax-checking/init-flycheck-pos-tip ()
   (use-package flycheck-pos-tip


### PR DESCRIPTION
- SPC e l: toggle display of flycheck's error window
- SPC e v : flycheck-verify-setup
- SPC e ? : flycheck-describe-checker

Old `SPC e l` is a no-op when error list is displayed. New `SPC e l` should be more convenient and is consistent with `SPC f t` (neotree). Not 100% necessary, since the window can also be closed with `C-g` (thanks to popwin).
`SPC e v` and `SPC e ?` should be helpful for debugging issues with flycheck. Especially `SPC e v` which should reveal any errors in current buffer's flycheck settings.