### PR TITLE
Reverted extra-search-engines-alist

### DIFF
--- a/contrib/search-engine/README.org
+++ b/contrib/search-engine/README.org
@@ -61,7 +61,7 @@ Also if you want more search engines, just push them (do this in =dotspacemacs/c
 (push '(custom1
          :name "Custom Search Engine 1"
          :url "http://www.domain.com/s/stuff_sutff_remember_to_replace_search_candidate_with_%s")
-        extra-search-engines-alist)
+        search-engine-alist)
 #+END_SRC
 
 If you'd rather not use helm but would want a specific search engine, remember


### PR DESCRIPTION
I searched commits and found @CestDiego mentioned that `extra-search-engines-alist` has been reverted. See https://github.com/syl20bnr/spacemacs/pull/1685/commits

But I checked out `develop` branch, `extra-search-engine-alist` still exists in [`README.org`](https://github.com/syl20bnr/spacemacs/blob/develop/contrib/search-engine/README.org). 

If this PR is duplicate, please close it. 