### PR TITLE
Improve ranger contrib.

### DIFF
--- a/contrib/!tools/ranger/packages.el
+++ b/contrib/!tools/ranger/packages.el
@@ -13,13 +13,20 @@
 
 (setq ranger-packages '(ranger))
 
-(setq ranger-excluded-packages '())
+(setq ranger-excluded-packages '(vinegar))
 
 (defun ranger/init-ranger ()
   (use-package ranger
     :defer t
     :init
     (progn
-      (setq ranger-parent-depth 1
-            ranger-preview-file t)
-      (evil-leader/set-key "ar" 'ranger))))
+      (evil-leader/set-key
+        "ar" 'ranger
+        "ad" 'deer)
+      (evil-define-key 'normal 'dired-mode-map "-" 'ranger-up-directory)
+      (define-key evil-normal-state-map (kbd "-") 'deer)
+
+      ;; set up image-dired to allow picture resize
+      (setq image-dired-dir (concat spacemacs-cache-directory "image-dir"))
+      (unless (file-directory-p image-dired-dir)
+        (make-directory image-dired-dir)))))


### PR DESCRIPTION
New ranger options:
* `-` binding drops to `deer-mode`
* setup `image-dired-dir` to allow picture resizing
* disable vinegar to fix #2687 
* revert defined settings, as they are default for package now