### PR TITLE
Show symlink paths in vinegar.

### DIFF
--- a/contrib/!vim/vinegar/funcs.el
+++ b/contrib/!vim/vinegar/funcs.el
@@ -86,6 +86,8 @@
 (defun vinegar/dired-setup ()
   "Setup custom dired settings for vinegar"
   (setq dired-omit-verbose nil)
+  (make-local-variable 'dired-hide-symlink-targets)
+  (setq dired-hide-details-hide-symlink-targets nil)
 
   ;; hide details by default
   (dired-hide-details-mode t)


### PR DESCRIPTION
This keeps symlink paths visible when `dired-hide-details` is active.