### PR TITLE
Temporarily comment-out toxi-theme

### DIFF
--- a/contrib/themes-megapack/packages.el
+++ b/contrib/themes-megapack/packages.el
@@ -89,7 +89,8 @@
     tao-theme
     ;; contains error
     ; tommyh-theme
-    toxi-theme
+    ;; currently not available from melpa
+    ;; toxi-theme
     tronesque-theme
     twilight-anti-bright-theme
     twilight-bright-theme


### PR DESCRIPTION
Right now toxi-theme is unavailable from melpa, which causes an update error for some users.
This is a temporary fix until toxi-theme is available again.

Refs:
https://github.com/milkypostman/melpa/issues/3056
https://github.com/syl20bnr/spacemacs/issues/2795
https://github.com/syl20bnr/spacemacs/issues/839#issuecomment-135028793