### PR TITLE
Allow user to opt in to flycheck/flyspell

### DIFF
--- a/contrib/!config/puppet/packages.el
+++ b/contrib/!config/puppet/packages.el
@@ -39,7 +39,7 @@
   (spacemacs|add-company-hook puppet-mode))
 
 (defun puppet/post-init-flycheck ()
-  (add-hook 'puppet-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'puppet-mode))
 
 (defun puppet/init-puppetfile-mode ()
   (use-package puppetfile-mode

--- a/contrib/!frameworks/react/packages.el
+++ b/contrib/!frameworks/react/packages.el
@@ -44,7 +44,7 @@
                                           '(json-jsonlist))))))
 
 (defun react/post-init-flycheck ()
-  (add-hook 'react-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'react-mode))
 
 (defun react/post-init-js-doc ()
   (add-hook 'react-mode-hook 'spacemacs/js-doc-require)

--- a/contrib/!irc/rcirc/packages.el
+++ b/contrib/!irc/rcirc/packages.el
@@ -24,8 +24,8 @@
     :defer t
     :init
     (progn
-      (spacemacs/add-to-hook 'rcirc-mode-hook '(flyspell-mode
-                                                rcirc-omit-mode
+      (spacemacs/add-flyspell-hook 'rcirc-mode)
+      (spacemacs/add-to-hook 'rcirc-mode-hook '(rcirc-omit-mode
                                                 rcirc-track-minor-mode))
 
       (defun spacemacs//rcirc-with-authinfo (arg)

--- a/contrib/!lang/c-c++/packages.el
+++ b/contrib/!lang/c-c++/packages.el
@@ -126,7 +126,8 @@
       :init (push 'company-c-headers company-backends-c-mode-common))))
 
 (defun c-c++/post-init-flycheck ()
-  (spacemacs/add-to-hooks 'flycheck-mode '(c-mode-hook c++-mode-hook)))
+  (dolist (mode '(c-mode-hook c++-mode-hook))
+    (spacemacs/add-flycheck-hook mode)))
 
 (defun c-c++/init-gdb-mi ()
   (use-package gdb-mi

--- a/contrib/!lang/d/packages.el
+++ b/contrib/!lang/d/packages.el
@@ -26,7 +26,7 @@
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun d/post-init-flycheck ()
-    (add-hook 'd-mode-hook 'flycheck-mode))
+    (spacemacs/add-flycheck-hook 'd-mode))
   (defun d/init-flycheck-dmd-dub ()
     (use-package flycheck-dmd-dub :defer t
       :init (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path))))

--- a/contrib/!lang/emacs-lisp/packages.el
+++ b/contrib/!lang/emacs-lisp/packages.el
@@ -81,6 +81,7 @@
                                                           ""))))
 
 (defun emacs-lisp/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'emacs-lisp-mode)
   ;; Make flycheck recognize packages in loadpath
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))

--- a/contrib/!lang/erlang/packages.el
+++ b/contrib/!lang/erlang/packages.el
@@ -42,4 +42,4 @@
     (require 'erlang-start)))
 
 (defun erlang/post-init-flycheck ()
-  (add-hook 'erlang-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'erlang-mode))

--- a/contrib/!lang/go/packages.el
+++ b/contrib/!lang/go/packages.el
@@ -8,7 +8,7 @@
     ))
 
 (defun go/post-init-flycheck ()
-    (add-hook 'go-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'go-mode))
 
 (defun go/init-go-mode()
   (when (memq window-system '(mac ns x))

--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -30,7 +30,7 @@
     :defer t))
 
 (defun haskell/post-init-flycheck ()
-  (add-hook 'haskell-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'haskell-mode))
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun haskell/init-flycheck-haskell ()

--- a/contrib/!lang/html/packages.el
+++ b/contrib/!lang/html/packages.el
@@ -66,13 +66,8 @@
   (add-hook 'web-mode-hook 'evil-matchit-mode))
 
 (defun html/post-init-flycheck ()
-  (spacemacs/add-to-hooks 'flycheck-mode '(haml-mode-hook
-                                           jade-mode-hook
-                                           less-mode-hook
-                                           sass-mode-hook
-                                           scss-mode-hook
-                                           slim-mode-hook
-                                           web-mode-hook)))
+  (dolist (mode '(haml-mode jade-mode less-mode sass-mode scss-mode slim-mode web-mode))
+    (spacemacs/add-flycheck-hook mode)))
 
 (defun html/init-haml-mode ()
   (use-package haml-mode

--- a/contrib/!lang/javascript/packages.el
+++ b/contrib/!lang/javascript/packages.el
@@ -55,9 +55,8 @@
       (push 'company-tern company-backends-js2-mode))))
 
 (defun javascript/post-init-flycheck ()
-  (add-hook 'coffee-mode-hook 'flycheck-mode)
-  (add-hook 'js2-mode-hook    'flycheck-mode)
-  (add-hook 'json-mode-hook   'flycheck-mode))
+  (dolist (mode '(coffee-mode js2-mode json-mode))
+    (spacemacs/add-flycheck-hook mode)))
 
 (defun javascript/init-js-doc ()
   (use-package js-doc

--- a/contrib/!lang/latex/packages.el
+++ b/contrib/!lang/latex/packages.el
@@ -102,7 +102,7 @@
   (add-hook 'LaTeX-mode-hook 'evil-matchit-mode))
 
 (defun latex/post-init-flycheck ()
-  (add-hook 'LaTeX-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'LaTeX-mode))
 
 (defun latex/post-init-flyspell ()
   (add-hook 'LaTeX-mode-hook 'flyspell-mode))

--- a/contrib/!lang/lua/packages.el
+++ b/contrib/!lang/lua/packages.el
@@ -6,7 +6,7 @@
     ))
 
 (defun lua/post-init-flycheck ()
-  (add-hook 'lua-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'lua-mode))
 
 (defun lua/init-lua-mode ()
   (use-package lua-mode

--- a/contrib/!lang/nim/extensions.el
+++ b/contrib/!lang/nim/extensions.el
@@ -6,6 +6,6 @@
       '(flycheck-nim))
 
 (defun nim/init-flycheck-nim ()
-  (add-hook 'nim-mode-hook 'flycheck-mode)
+  (spacemacs/add-flycheck-hook 'nim-mode)
   (use-package flycheck-nim
     :if (configuration-layer/layer-usedp 'syntax-checking)))

--- a/contrib/!lang/ocaml/packages.el
+++ b/contrib/!lang/ocaml/packages.el
@@ -30,7 +30,7 @@
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun ocaml/post-init-flycheck ()
-    (add-hook 'merlin-mode-hook 'flycheck-mode))
+    (spacemacs/add-flycheck-hook 'merlin-mode))
   (defun ocaml/init-flycheck-ocaml ()
     (use-package flycheck-ocaml
       :if (configuration-layer/package-usedp 'flycheck)

--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -251,7 +251,7 @@
               #'spacemacs/python-imenu-create-index-python-or-semantic)))))
 
 (defun python/post-init-flycheck ()
-  (add-hook 'python-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'python-mode))
 
 (defun python/init-hy-mode ()
   (use-package hy-mode

--- a/contrib/!lang/ruby/packages.el
+++ b/contrib/!lang/ruby/packages.el
@@ -56,7 +56,7 @@
                        :suffix "")))))
 
 (defun ruby/post-init-flycheck ()
-  (add-hook 'enh-ruby-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'enh-ruby-mode))
 
 (defun ruby/init-ruby-tools ()
   (use-package ruby-tools

--- a/contrib/!lang/rust/packages.el
+++ b/contrib/!lang/rust/packages.el
@@ -22,7 +22,7 @@
     ))
 
 (defun rust/post-init-flycheck ()
-  (add-hook 'rust-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'rust-mode))
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun rust/init-flycheck-rust ()

--- a/contrib/spell-checking/README.org
+++ b/contrib/spell-checking/README.org
@@ -3,18 +3,16 @@
 * Table of Contents                                                   :TOC@4:
  - [[#description][Description]]
  - [[#install][Install]]
-     - [[#layer][Layer]]
-     - [[#spell-checker-configuration][Spell Checker Configuration]]
+   - [[#layer][Layer]]
+   - [[#spell-checker-configuration][Spell Checker Configuration]]
+   - [[#disabling-by-default][Disabling by default]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
-
 This layer provides spell checking using [[http://www-sop.inria.fr/members/Manuel.Serrano/flyspell/flyspell.html][Flyspell]].
 
 * Install
-
 ** Layer
-
 To use this configuration layer add it to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp
@@ -22,7 +20,6 @@ To use this configuration layer add it to your =~/.spacemacs=
 #+END_SRC
 
 ** Spell Checker Configuration
-
 The built-in Emacs variable that controls which external spell-checking program
 is used is =ispell-program-name=, which can be set in your =dotspacemacs/init=
 function if you do not like the default. It will give priority to =aspell= if it
@@ -31,6 +28,15 @@ is installed on your system. Another important variable to be aware of is
 =ispell-program-name= (instead of using this variable you can also use the key
 binding ~SPC S d~).
 
+** Disabling by default
+By default, spell-checking is enabled in all available major modes and may be
+toggled off with ~SPC t S~. You can default this to off by setting the variable
+=spell-checking-enable-by-default= to =nil=:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((spell-checking :variables spell-checking-enable-by-default nil)))
+#+END_SRC
 
 * Key Bindings
 

--- a/contrib/spell-checking/config.el
+++ b/contrib/spell-checking/config.el
@@ -15,3 +15,6 @@
 ;; Command Prefixes
 
 (spacemacs/declare-prefix "S" "spelling")
+
+(defvar spell-checking-enable-by-default t
+  "Enable spell checking by default.")

--- a/contrib/spell-checking/funcs.el
+++ b/contrib/spell-checking/funcs.el
@@ -1,0 +1,18 @@
+;;; funcs.el --- Spell Checking Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/add-flyspell-hook (mode &optional target)
+  "Enable flyspell for the given MODE, if
+`spell-checking-enable-by-default' is true."
+  (when spell-checking-enable-by-default
+    (let ((mode-hook (intern (format "%S-hook" mode))))
+      (add-hook mode-hook 'flyspell-mode))))

--- a/contrib/spell-checking/packages.el
+++ b/contrib/spell-checking/packages.el
@@ -21,8 +21,8 @@
     :defer t
     :init
     (progn
-      (add-hook 'markdown-mode-hook '(lambda () (flyspell-mode 1)))
-      (add-hook 'text-mode-hook '(lambda () (flyspell-mode 1)))
+      (spacemacs/add-flyspell-hook 'markdown-mode)
+      (spacemacs/add-flyspell-hook 'text-mode)
       (spacemacs|add-toggle spelling-checking
         :status flyspell-mode
         :on (flyspell-mode)
@@ -32,7 +32,8 @@
         :evil-leader "tS"))
     :config
     (progn
-      (flyspell-prog-mode)
+      (when spell-checking-enable-by-default
+        (flyspell-prog-mode))
       (spacemacs|diminish flyspell-mode " Ⓢ" " S"))))
 
 (defun spell-checking/init-helm-flyspell ()

--- a/contrib/syntax-checking/README.org
+++ b/contrib/syntax-checking/README.org
@@ -5,18 +5,16 @@
 * Table of Contents                                                   :TOC@4:
  - [[#description][Description]]
  - [[#install][Install]]
-     - [[#layer][Layer]]
-     - [[#enablingdisabling-tooltips][Enabling/Disabling tooltips]]
+   - [[#layer][Layer]]
+   - [[#enablingdisabling-tooltips][Enabling/Disabling tooltips]]
+   - [[#disabling-by-default][Disabling by default]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
-
 This layer provides on the fly syntax checking using [[http://www.flycheck.org/][Flycheck]].
 
 * Install
-
 ** Layer
-
 To use this configuration layer add it to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp
@@ -24,7 +22,6 @@ To use this configuration layer add it to your =~/.spacemacs=
 #+END_SRC
 
 ** Enabling/Disabling tooltips
-
 By default tooltips are enabled and used whenever it is possible.
 You can disable them by setting the variable =syntax-checking-enable-tooltips=
 to =nil=:
@@ -34,6 +31,15 @@ to =nil=:
   '((syntax-checking :variables syntax-checking-enable-tooltips nil)))
 #+END_SRC
 
+** Disabling by default
+By default, syntax-checking is enabled in all available major modes and may be
+toggled off with ~SPC t s~. You can default this to off by setting the variable
+=syntax-checking-enable-by-default= to =nil=:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((syntax-checking :variables syntax-checking-enable-by-default nil)))
+#+END_SRC
 
 * Key Bindings
 

--- a/contrib/syntax-checking/config.el
+++ b/contrib/syntax-checking/config.el
@@ -15,5 +15,8 @@
 (defvar syntax-checking-enable-tooltips t
   "If non nil some feedback are displayed in tooltips.")
 
+(defvar syntax-checking-enable-by-default t
+  "Enable syntax-checking by default.")
+
 ;; Command Prefixes
 

--- a/contrib/syntax-checking/funcs.el
+++ b/contrib/syntax-checking/funcs.el
@@ -1,0 +1,18 @@
+;;; funcs.el --- Syntax Checking Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/add-flycheck-hook (mode &optional target)
+  "Enable flycheck for the given MODE, if
+`syntax-checking-enable-by-default' is true."
+  (when syntax-checking-enable-by-default
+    (let ((mode-hook (intern (format "%S-hook" mode))))
+      (add-hook mode-hook 'flycheck-mode))))


### PR DESCRIPTION
At the moment it's impossible to enable the `syntax-checking` or `spell-checking` layers without having these rather intrusive and potentially resource intensive modes enabled everywhere by default. This PR adds two configuration variables that makes this configurable by the user.