### PR TITLE
Bump plugin versions for clojure quickstart

### DIFF
--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -72,8 +72,8 @@ Or set this variable when loading the configuration layer:
 - Create a file =~/.lein/profiles.clj= with the following content:
   
 #+BEGIN_SRC clojure
-  {:user {:plugins [[cider/cider-nrepl "0.9.0-SNAPSHOT"]
-                    [refactor-nrepl "0.3.0-SNAPSHOT"]]
+  {:user {:plugins [[cider/cider-nrepl "0.10.0-SNAPSHOT"]
+                    [refactor-nrepl "1.2.0-SNAPSHOT"]]
           :dependencies [[alembic "0.3.2"]
                          [org.clojure/tools.nrepl "0.2.7"]]}}
 #+END_SRC


### PR DESCRIPTION
Bumped cider-nrepl and refactor-nrepl up to their current versions as the previous were throwing exceptions. I was getting this error with the old versions:

```
Error loading refactor-nrepl.ns.clean-ns: clojure.lang.ArityException: Wrong number of args (2) passed to: StringReader, compiling:(abnf.clj:189:28)```