### PR TITLE
Make yasnippet loading more robust

### DIFF
--- a/contrib/auto-completion/packages.el
+++ b/contrib/auto-completion/packages.el
@@ -188,9 +188,12 @@
 
 (defun auto-completion/init-yasnippet ()
   (use-package yasnippet
-    :commands yas-global-mode
+    :commands (yas-global-mode yas-minor-mode)
     :init
     (progn
+      ;; We don't want undefined variable errors
+      (defvar yas-global-mode nil)
+
       ;; disable yas minor mode map
       ;; use hippie-expand instead
       (setq yas-minor-mode-map (make-sparse-keymap))


### PR DESCRIPTION
I have recently started getting strange yasnippet related errors. Most of them can be explained by the fact that yas-global-mode isn't defined as a variable before loading yasnippet. Even executing `spacemacs/load-yasnippet` fails with that error, so I thought it more robust to define the variable in the init-section of the use-package call.

This PR also fixes the `spacemacs/toggle-yasnippet` by adding yas-minor-mode to the commands-section in the use-package call. 