### PR TITLE
disable line highlighting when shm is enabled

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -59,7 +59,10 @@
       (defun spacemacs/init-haskell-mode ()
         ;; use only internal indentation system from haskell
         (if (fboundp 'electric-indent-local-mode)
-            (electric-indent-local-mode -1)))
+            (electric-indent-local-mode -1))
+        (when haskell-enable-shm-support
+          ;; in structured-haskell-mode line highlighting creates noise
+          (setq global-hl-line-mode nil)))
 
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)


### PR DESCRIPTION
Clean version of #2614 (aa1b556). Copying description so you don't need to follow the link.

When `structured-haskell-mode` is enabled users don't want lines to be highlighted, because `structured-haskell-mode` highlights current context (and sometimes it can be whole buffer), so line highlighting doesn't make real sense. 

P. S. Sorry for the mess with commits. In future I'll always use separate branch vs your develop.