### PR TITLE
fix return binding in terminal for spacemacs-mode

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -46,7 +46,7 @@
     (define-key map [tab] 'widget-forward)
     (define-key map (kbd "C-i") 'widget-forward)
     (define-key map [backtab] 'widget-backward)
-    (define-key map [return] 'widget-button-press)
+    (define-key map (kbd "RET") 'widget-button-press)
     (define-key map [down-mouse-1] 'widget-button-click)
     map)
   "Keymap for spacemacs mode.")


### PR DESCRIPTION
Just tried spacemacs in terminal and found that in `spacemacs-mode` return button doesn't function. It turned out that `widget-button-press` is bound to `<return>`. But when I `C-h k return` in terminal, emacs says that this is `RET` button and it is bound to `new-line-and-indent`. 

This PR fixes the problem in terminal and doesn't cause any new in GUI version.