### PR TITLE
Add cider-refresh binding

### DIFF
--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -226,6 +226,7 @@ the focus."
           "msr" 'spacemacs/cider-send-region-to-repl
           "msR" 'spacemacs/cider-send-region-to-repl-focus
           "mss" 'cider-switch-to-repl-buffer
+          "msx" 'cider-refresh
 
           "mTf" 'spacemacs/cider-toggle-repl-font-locking
           "mTp" 'spacemacs/cider-toggle-repl-pretty-printing
@@ -256,6 +257,7 @@ the focus."
         "msn" 'cider-repl-set-ns
         "msq" 'cider-quit
         "mss" 'cider-switch-to-last-clojure-buffer
+        "msx" 'cider-refresh
 
         "mTf" 'spacemacs/cider-toggle-repl-font-locking
         "mTp" 'spacemacs/cider-toggle-repl-pretty-printing


### PR DESCRIPTION
This is needed for clearing out polluted namespaces for tests and such.
"msR" and "msr" were taken, and the cider default is C-c C-x, so I opted
for "msx". It is also close to "mss", switch to repl.