### PR TITLE
Fix neotree 0 window bug.

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -3233,7 +3233,8 @@ It is a string holding:
                          (eq w neo-global--window))
                 (window-numbering-assign w 0)))
             windows))
-    (add-hook 'window-numbering-before-hook 'spacemacs//window-numbering-assign)))
+    (add-hook 'window-numbering-before-hook 'spacemacs//window-numbering-assign)
+    (add-hook 'neo-after-create-hook '(lambda (w) (window-numbering-update)))))
 
 (defun spacemacs/init-winner ()
   (use-package winner


### PR DESCRIPTION
Fixes #2527
Needs new NeoTree version `20150904.226`.