### PR TITLE
Updated the Clojure contrib layer README 

### DIFF
--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -72,10 +72,10 @@ Or set this variable when loading the configuration layer:
 - Create a file =~/.lein/profiles.clj= with the following content:
   
 #+BEGIN_SRC clojure
-  {:user {:plugins [[cider/cider-nrepl "0.9.0-SNAPSHOT"]
-                    [refactor-nrepl "0.3.0-SNAPSHOT"]]
+  {:user {:plugins [[cider/cider-nrepl "0.9.1"]
+                    [refactor-nrepl "1.1.0"]]
           :dependencies [[alembic "0.3.2"]
-                         [org.clojure/tools.nrepl "0.2.7"]]}}
+                         [org.clojure/tools.nrepl "0.2.10"]]}}
 #+END_SRC
 
 *** More details

--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -78,6 +78,8 @@ Or set this variable when loading the configuration layer:
                          [org.clojure/tools.nrepl "0.2.10"]]}}
 #+END_SRC
 
+- After creating your project with ~lein new app <projectname>~ or importing an existing project, run ~SPC m s i~ in any of the clojure source files to connect to the Cider REPL.
+
 *** More details
 
 More info regarding installation of nREPL middleware can be found here:


### PR DESCRIPTION
- Updated the dependencies in the leiningen example file to the latest version
- Added instructions on how to connect to the REPL to the leiningen quick start section so that new users won't have to dig through the keybindings list