### PR TITLE
Change obsolete 'new-frame to 'make-frame in osx-layer/keybindings.el

### DIFF
--- a/contrib/osx/keybindings.el
+++ b/contrib/osx/keybindings.el
@@ -23,7 +23,7 @@
     (global-set-key (kbd "s-x") 'kill-region)
     (global-set-key (kbd "s-w") 'delete-window)
     (global-set-key (kbd "s-W") 'delete-frame)
-    (global-set-key (kbd "s-n") 'new-frame)
+    (global-set-key (kbd "s-n") 'make-frame)
     (global-set-key (kbd "s-z") 'undo-tree-undo)
     (global-set-key (kbd "s-s")
                     (lambda ()


### PR DESCRIPTION
Every time the osx-layer "s-n" key is used to make a new frame, there's a warning "'new-frame' is an obsolete command (as of 22.1); use 'make-frame' instead." While 'new-frame' is aliased to 'make-frame', so there's no issue with functionality, the warning is annoying. The fix is to have "s-n" call 'make-frame'.