### PR TITLE
Add gnuplot as a dependency to the org layer.

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -8,6 +8,7 @@
  - [[#install][Install]]
    - [[#layer][Layer]]
    - [[#github-support][Github support]]
+   - [[#gnuplot-support][Gnuplot support]]
    - [[#different-bullets][Different bullets]]
  - [[#key-bindings][Key bindings]]
    - [[#org-with-evil-org-mode][Org with evil-org-mode]]
@@ -48,6 +49,19 @@ flavored markdown set the variable =org-enable-github-support= to =t=.
   (setq-default dotspacemacs-configuration-layers '(
     (org :variables
          org-enable-github-support t)))
+#+END_SRC
+
+** Gnuplot support
+
+Org-mode support the plotting of data within tables through [[http://www.gnuplot.info/][Gnuplot]] as
+demonstrated [[http://orgmode.org/worg/org-tutorials/org-plot.html][here]]; unfortunately, this is [[https://github.com/bruceravel/gnuplot-mode/issues/15][not terribly well supported]] on Windows
+at this stage.  It is possible to disable the configuration of gnuplot support
+through the variable =org-disable-gnuplot-support=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-disable-github-support t)))
 #+END_SRC
 
 ** Different bullets

--- a/layers/org/config.el
+++ b/layers/org/config.el
@@ -15,4 +15,7 @@
 (defvar org-enable-github-support nil
   "If non-nil Github related packages are configured.")
 
+(defvar org-disable-gnuplot-support nil
+  "If non-nil Gnuplot related packages are not configured.")
+
 (spacemacs|defvar-company-backends org-mode)

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -16,6 +16,7 @@
     company-emoji
     emoji-cheat-sheet-plus
     evil-org
+    gnuplot
     htmlize
     org
     org-bullets
@@ -50,6 +51,14 @@
       (evil-define-key 'normal evil-org-mode-map
         "O" 'evil-open-above)
       (spacemacs|diminish evil-org-mode " ⓔ" " e"))))
+
+(defun org/init-gnuplot ()
+  (use-package gnuplot
+    :if (not org-disable-gnuplot-support)
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'org-mode
+        "mtp" 'org-plot/gnuplot))))
 
 (defun org/init-org ()
   (use-package org


### PR DESCRIPTION
It is possible to plot data from tables in org-mode; however, this
requires `gnuplot.el`.

http://orgmode.org/worg/org-tutorials/org-plot.html