### PR TITLE
Added keybinding for cider-format-buffer.

### DIFF
--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -33,8 +33,9 @@ This layer adds support for [[http://clojure.org][Clojure]] language using [[htt
 * Features
 
 - REPL via [[https://github.com/clojure-emacs/cider][CIDER]]
+- Code formatting via [[https://github.com/clojure-emacs/cider][CIDER]] using [[https://github.com/weavejester/cljfmt][Cljfmt]] 
 - Refactoring via [[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]]
-- Automatic formatting via [[https://github.com/gstamp/align-cljlet][align-cljlet]]
+- Aligning of code forms via [[https://github.com/gstamp/align-cljlet][align-cljlet]]
   
 * Install
 
@@ -218,7 +219,8 @@ More info at [[https://github.com/gstamp/align-cljlet][align-cljlet]].
 
 | Key Binding | Description           |
 |-------------+-----------------------|
-| ~SPC m f l~ | reformat current form |
+| ~SPC m f l~ | realign current form |
+| ~SPC m f b~ | reformat current buffer |
 
 ** CIDER Buffers
 

--- a/contrib/!lang/clojure/packages.el
+++ b/contrib/!lang/clojure/packages.el
@@ -207,6 +207,8 @@ the focus."
           "mer" 'cider-eval-region
           "mew" 'cider-eval-last-sexp-and-replace
 
+          "mfb" 'cider-format-buffer
+
           "mgb" 'cider-jump-back
           "mge" 'cider-jump-to-compilation-error
           "mgg" 'cider-jump-to-var


### PR DESCRIPTION
This keybinding automatically formats the contents of the current Clojure buffer using [this](https://github.com/weavejester/cljfmt). 