### PR TITLE
spacemacs-layer: Fix ahs search

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -235,6 +235,9 @@
         "Info on the last searched highlighted symbol.")
       (make-variable-buffer-local 'spacemacs-last-ahs-highlight-p)
 
+      (defvar spacemacs--ahs-searching-forward nil)
+      (make-variable-buffer-local 'spacemacs--ahs-searching-forward)
+
       (defun spacemacs/goto-last-searched-ahs-symbol ()
         "Go to the last known occurrence of the last symbol searched with
 `auto-highlight-symbol'."


### PR DESCRIPTION
The `setq-local` of `spacemacs--ahs-searching-forward` was not taking effect
for the subsequent call to `spacemacs/quick-ahs-forward` so I was
getting a void variable error. This fixes that problem with a let
bindings instead.