### PR TITLE
disable global-hl-line mode only locally

### DIFF
--- a/contrib/!lang/haskell/packages.el
+++ b/contrib/!lang/haskell/packages.el
@@ -62,7 +62,7 @@
             (electric-indent-local-mode -1))
         (when haskell-enable-shm-support
           ;; in structured-haskell-mode line highlighting creates noise
-          (setq global-hl-line-mode nil)))
+          (setq-local global-hl-line-mode nil)))
 
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)


### PR DESCRIPTION
After we talked a bit with @TheBB he pointed out that it's not good to use `setq` in this case. 

So now `global-hl-line-mode` is disabled only for `haskell-mode` when `shm` is enabled. 