### PR TITLE
fix anaconda keybindings for latest anaconda mode

### DIFF
--- a/contrib/!lang/python/README.org
+++ b/contrib/!lang/python/README.org
@@ -4,19 +4,19 @@
 
 * Table of Contents                                                   :TOC@4:
  - [[#description][Description]]
-     - [[#features][Features:]]
+   - [[#features][Features:]]
  - [[#install][Install]]
-     - [[#layer][Layer]]
-     - [[#test-runner][Test runner]]
-     - [[#anaconda-dependencies][Anaconda dependencies]]
-     - [[#automatic-buffer-formatting-on-save][Automatic buffer formatting on save]]
-     - [[#autoflake][autoflake]]
+   - [[#layer][Layer]]
+   - [[#test-runner][Test runner]]
+   - [[#anaconda-dependencies][Anaconda dependencies]]
+   - [[#automatic-buffer-formatting-on-save][Automatic buffer formatting on save]]
+   - [[#autoflake][autoflake]]
  - [[#key-bindings][Key Bindings]]
-     - [[#inferior-repl-process][Inferior REPL process]]
-     - [[#running-python-script-in-shell][Running Python Script in shell]]
-     - [[#testing][Testing]]
-     - [[#refactoring][Refactoring]]
-     - [[#other-python-commands][Other Python commands]]
+   - [[#inferior-repl-process][Inferior REPL process]]
+   - [[#running-python-script-in-shell][Running Python Script in shell]]
+   - [[#testing][Testing]]
+   - [[#refactoring][Refactoring]]
+   - [[#other-python-commands][Other Python commands]]
 
 * Description
 
@@ -155,14 +155,15 @@ Test commands (start with ~m t~ or ~m T~):
 
 ** Other Python commands
 
-| Key Binding | Description                                                      |
-|-------------+------------------------------------------------------------------|
-| ~SPC m =~   | Reformat the buffer according to PEP8 using  [[https://github.com/google/yapf][YAPF]]                |
-| ~SPC m d b~ | toggle a breakpoint                                              |
-| ~SPC m g g~ | go to definition using =anaconda-mode-goto= (~C-o~ to jump back) |
-| ~SPC m g u~ | navigate between usages with =anaconda-mode-usages=              |
-| ~SPC m h d~ | look for documentation using =helm-pydoc=                        |
-| ~SPC m h h~ | quick documentation using anaconda                               |
-| ~SPC m h H~ | open documentation in =firefox= using [pylookup][pylookup]       |
-| ~SPC m v~   | activate a virtual environment with [[https://github.com/yyuu/pyenv][pyenv]]                        |
-| ~SPC m V~   | activate a virtual environment with  [[https://github.com/jorgenschaefer/pyvenv][pyvenv]]                      |
+| Key Binding | Description                                                                  |
+|-------------+------------------------------------------------------------------------------|
+| ~SPC m =~   | Reformat the buffer according to PEP8 using  [[https://github.com/google/yapf][YAPF]]                            |
+| ~SPC m d b~ | toggle a breakpoint                                                          |
+| ~SPC m g g~ | go to definition using =anaconda-mode-find-definitions= (~C-o~ to jump back) |
+| ~SPC m g a~ | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back) |
+| ~SPC m g u~ | navigate between usages with =anaconda-mode-find-references=                 |
+| ~SPC m h d~ | look for documentation using =helm-pydoc=                                    |
+| ~SPC m h h~ | quick documentation using anaconda                                           |
+| ~SPC m h H~ | open documentation in =firefox= using [pylookup][pylookup]                   |
+| ~SPC m v~   | activate a virtual environment with [[https://github.com/yyuu/pyenv][pyenv]]                                    |
+| ~SPC m V~   | activate a virtual environment with  [[https://github.com/jorgenschaefer/pyvenv][pyvenv]]                                  |

--- a/contrib/!lang/python/packages.el
+++ b/contrib/!lang/python/packages.el
@@ -40,9 +40,12 @@
     :config
     (progn
       (evil-leader/set-key-for-mode 'python-mode
-        "mhh" 'anaconda-mode-view-doc
-        "mgg" 'anaconda-mode-goto
-        "mgu" 'anaconda-mode-usages)
+        "mhh" 'anaconda-mode-show-doc
+        "mgg" 'anaconda-mode-find-definitions
+        "mga" 'anaconda-mode-find-assignments
+        "mgu" 'anaconda-mode-find-references)
+      (evilify anaconda-mode-view-mode anaconda-mode-view-mode-map
+               (kbd "q") 'kill-buffer-and-window)
       (spacemacs|hide-lighter anaconda-mode))))
 
 (defun python/init-cython-mode ()


### PR DESCRIPTION
anaconda mode changed the public API. This fixes the major keybindings.

I've not yet changed the `anaconda dependencies` section with new error messages since I don't know them yet.

Slightly related to https://github.com/syl20bnr/spacemacs/issues/2917