### PR TITLE
spacemacs-layer: Correct use of setq-local in ahs

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -231,12 +231,10 @@
             ahs-idle-interval 0.25
             ahs-inhibit-face-list nil)
 
-      (defvar spacemacs-last-ahs-highlight-p nil
+      (defvar-local spacemacs-last-ahs-highlight-p nil
         "Info on the last searched highlighted symbol.")
-      (make-variable-buffer-local 'spacemacs-last-ahs-highlight-p)
 
-      (defvar spacemacs--ahs-searching-forward nil)
-      (make-variable-buffer-local 'spacemacs--ahs-searching-forward)
+      (defvar-local spacemacs--ahs-searching-forward t)
 
       (defun spacemacs/goto-last-searched-ahs-symbol ()
         "Go to the last known occurrence of the last symbol searched with
@@ -286,14 +284,14 @@
         "Go to the next occurrence of symbol under point with
 `auto-highlight-symbol'"
         (interactive)
-        (setq-local spacemacs--ahs-searching-forward t)
+        (setq spacemacs--ahs-searching-forward t)
         (spacemacs/quick-ahs-forward))
 
       (defun spacemacs/enter-ahs-backward ()
         "Go to the previous occurrence of symbol under point with
 `auto-highlight-symbol'"
         (interactive)
-        (setq-local spacemacs--ahs-searching-forward nil)
+        (setq spacemacs--ahs-searching-forward nil)
         (spacemacs/quick-ahs-forward))
 
       (defun spacemacs/quick-ahs-forward ()


### PR DESCRIPTION
@syl20bnr I read the manual again on buffer local variables and I believe this is the correct way to accomplish this in ahs. It also happens to correct all the problems I was having with ahs.

`defvar-local` declares the variable and automatically makes it buffer local whenever it is set with `setq`. It's equivalent to `defvar` then `make-variable-buffer-local`. The real difference here is the use of `setq` instead of `setq-local`. I couldn't tell you why the former version was causing me problems in emacs 25, but it was.