### PR TITLE
Add table related shortcuts to org-mode.

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -87,6 +87,38 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC m T~                                    | org-show-todo-tree                           |
 | ~SPC s l~                                    | spacemacs/jump-in-buffer (jump to a heading) |
 
+Table-related shortcuts:
+
+| Key Binding     | Description                          |
+|-----------------+--------------------------------------|
+| ~SPC m t n~     | org-table-create                     |
+| ~SPC m t N~     | org-table-create-with-table.el       |
+| ~SPC m t a~     | org-table-align                      |
+| ~SPC m t i r~   | org-table-insert-row                 |
+| ~SPC m t i c~   | org-table-insert-column              |
+| ~SPC m t i h~   | org-table-insert-hline               |
+| ~SPC m t i H~   | org-table-hline-and-move             |
+| ~SPC m t d c~   | org-table-delete-column              |
+| ~SPC m t b~     | org-table-blank-field                |
+| ~SPC m t r~     | org-table-recalculate                |
+| ~SPC m t e~     | org-table-eval-formula               |
+| ~SPC m t s~     | org-table-sort-lines                 |
+| ~SPC m t I~     | org-table-import                     |
+| ~SPC m t E~     | org-table-export                     |
+| ~SPC m t c~     | org-table-convert                    |
+| ~SPC m t g n r~ | org-table-next-row                   |
+| ~SPC m t g n f~ | org-table-next-field                 |
+| ~SPC m t g p f~ | org-table-previous-field             |
+| ~SPC m t m r~   | org-table-move-row-down              |
+| ~SPC m t m R~   | org-table-move-row-up                |
+| ~SPC m t m c~   | org-table-move-column-right          |
+| ~SPC m t m C~   | org-table-move-column-left           |
+| ~SPC m t k r~   | org-table-kill-row                   |
+| ~SPC m t w~     | org-table-wrap-region                |
+| ~SPC m t t o~   | org-table-toggle-coordinate-overlays |
+| ~SPC m t t f~   | org-table-toggle-formula-debugger    |
+| ~SPC m t p~     | org-plot/gnuplot                     | 
+
 | Key Binding | Description                     |
 |-------------+---------------------------------|
 | ~TAB~       | org-cycle                       |

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -103,6 +103,34 @@ Will work on both org-mode and any mode that accepts plain html."
         "mhi" 'org-insert-heading-after-current
         "mhI" 'org-insert-heading
 
+        ;; tables
+        "mtn" 'org-table-create
+        "mtN" 'org-table-create-with-table.el
+        "mta" 'org-table-align
+        "mtir" 'org-table-insert-row
+        "mtic" 'org-table-insert-column
+        "mtih" 'org-table-insert-hline
+        "mtiH" 'org-table-hline-and-move
+        "mtdc" 'org-table-delete-column
+        "mtb" 'org-table-blank-field
+        "mtr" 'org-table-recalculate
+        "mte" 'org-table-eval-formula
+        "mts" 'org-table-sort-lines
+        "mtI" 'org-table-import
+        "mtE" 'org-table-export
+        "mtc" 'org-table-convert
+        "mtgnr" 'org-table-next-row
+        "mtgnf" 'org-table-next-field
+        "mtgpf" 'org-table-previous-field
+        "mtmr" 'org-table-move-row-down
+        "mtmR" 'org-table-move-row-up
+        "mtmc" 'org-table-move-column-right
+        "mtmC" 'org-table-move-column-left
+        "mtkr" 'org-table-kill-row
+        "mtw" 'org-table-wrap-region
+        "mtto" 'org-table-toggle-coordinate-overlays
+        "mttf" 'org-table-toggle-formula-debugger
+
         "mI" 'org-clock-in
         (if dotspacemacs-major-mode-leader-key
             (concat "m" dotspacemacs-major-mode-leader-key)


### PR DESCRIPTION
Add various table-related shortcuts under `SPC m t` prefix for Org-mode.

It contains one shortcut which is introduced by #2904 (if that pull request is not accepted, I will amend this pull request).