### PR TITLE
Persistent scratch contribution layer.

### DIFF
--- a/layers/persistent-scratch/README.org
+++ b/layers/persistent-scratch/README.org
@@ -1,0 +1,32 @@
+#+TITLE: Persistent scratch contribution layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#install][Install]]
+ - [[#key-bindings][Key bindings]]
+
+* Description
+
+This layer adds functionality to preserve the state of scratch buffers across
+Emacs sessions. The package recognizes buffers named like =*scratch*= as
+persistent buffers reloaded on startup.  Buffers titled as =untitled=, as
+created by default with Spacemacs =spacemacs/new-empty-buffer=, ~SPC b t~, will
+not persist across sessions.   
+
+Use binding ~SPC h s~ to show all open scratch buffers. 
+
+* Install
+
+To use this contribution layer add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+(set-default dotspacemacs-configuration-layers '(persistent-scratch))
+#+END_SRC
+
+* Key bindings
+
+| Key Binding | Description                      |
+|-------------+----------------------------------|
+| ~SPC h s~   | Show recognized scratch bufffers |
+| ~SPC b s~   | Create persistent scratch buffer |
+| ~SPC b t~   | Create temporary scratch buffer  |

--- a/layers/persistent-scratch/funcs.el
+++ b/layers/persistent-scratch/funcs.el
@@ -1,0 +1,18 @@
+
+(defun persistent-scratch-file-match-regexp-p ()
+  "Return non-nil if the current buffer's name is *scratch* or untitled."
+  (string-match "*scratch.*\\|untitled.*" (buffer-name)))
+
+(defun persistent-scratch-persistent-file-match-regexp-p ()
+  "Return non-nil if the current buffer's name is *scratch*."
+  (string-match "*scratch.*" (buffer-name)))
+
+(defun filter-scratch-buffers (buffer-list)
+  "Filter all buffers that are not recognized as scratch buffers."
+  (delq nil (mapcar
+             (lambda (buffer)
+               (if (with-current-buffer
+                       buffer
+                     (persistent-scratch-file-match-regexp-p))
+                   buffer nil))
+             buffer-list)))

--- a/layers/persistent-scratch/packages.el
+++ b/layers/persistent-scratch/packages.el
@@ -1,0 +1,52 @@
+;;; packages.el --- persistent-scratch Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; List of all packages to install and/or initialize. Built-in packages
+;; which require an initialization must be listed explicitly in the list.
+(setq persistent-scratch-packages
+      '(persistent-scratch
+        helm))
+
+;; List of packages to exclude.
+(setq persistent-scratch-excluded-packages '())
+
+(defun persistent-scratch/init-persistent-scratch ()
+  (use-package persistent-scratch
+    :defer t
+    :init
+    (progn
+      ;; add binding for temp scratch buffer
+      (evil-leader/set-key
+        "b t" 'spacemacs/new-empty-buffer)
+      ;; clean up which-key
+      (add-to-list 'which-key-description-replacement-alist '("persistent-scratch\/" . ""))
+      (setq persistent-scratch-backup-directory
+            (concat spacemacs-cache-directory ".scratch/")
+            persistent-scratch-save-file
+            (concat spacemacs-cache-directory ".persistent-scratch")
+            persistent-scratch-scratch-buffer-p-function
+            'persistent-scratch-persistent-file-match-regexp-p)
+      (add-hook 'after-init-hook 'persistent-scratch-setup-default))))
+
+(defun persistent-scratch/post-init-helm ()
+
+  (defun persistent-scratch/scratch-buffers-list ()
+    "Show list of buffers recognized as scratch buffers."
+    (interactive)
+    (advice-add 'helm-skip-boring-buffers :filter-return 'filter-scratch-buffers)
+    (call-interactively 'helm-buffers-list)
+    (advice-remove 'helm-skip-boring-buffers 'filter-scratch-buffers))
+
+  (evil-leader/set-key
+    "h s" 'persistent-scratch/scratch-buffers-list)
+  )
+


### PR DESCRIPTION
Saves and all temporary buffers matching "*scratch*" and loads them on restart.  Also adds new bindings to create persistent scratch `SPC b S`, temporary scratch `SPC b t`, and show buffer list of persistent and temporary buffers `SPC b s`.