### PR TITLE
Turn flycheck on by default for php files

### DIFF
--- a/layers/!lang/php/packages.el
+++ b/layers/!lang/php/packages.el
@@ -61,6 +61,9 @@
   (use-package phpunit
     :defer t))
 
+(defun php/post-init-flycheck ()
+  (add-hook 'php-mode-hook 'flycheck-mode))
+
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun php/post-init-company ()
     (spacemacs|add-company-hook php-mode)))


### PR DESCRIPTION
No idea why it wasn't.