### PR TITLE
Update doc string for haskell-enable-hindent-style

### DIFF
--- a/layers/!lang/haskell/config.el
+++ b/layers/!lang/haskell/config.el
@@ -21,7 +21,7 @@
   "If non-nil structured-haskell-mode support is enabled")
 
 (defvar haskell-enable-hindent-style nil
-  "Style to use for formatting with hindent; available are: fundamental johan-tibell chris-done andrew-gibiansky. If nil hindent is disabled.")
+  "Style to use for formatting with hindent; available are: fundamental johan-tibell chris-done gibiansky. If nil hindent is disabled.")
 
 (defvar haskell-enable-ghc-mod-support t
   "If non-nil ghc-mod support is enabled")


### PR DESCRIPTION
Info was updated in README file, but not in doc string. Following #1786.