### PR TITLE
Attempt to delete-frame first in frame-killer

### DIFF
--- a/layers/!distribution/spacemacs-core/funcs.el
+++ b/layers/!distribution/spacemacs-core/funcs.el
@@ -514,7 +514,10 @@ dotspacemacs-persistent-server to be t"
   "Kill server buffer and hide the main Emacs window"
   (interactive)
   (server-kill-buffer)
-  (make-frame-invisible nil 1))
+  (condition-case
+      (delete-frame nil 1)
+      (error
+       (make-frame-invisible nil 1))))
 
 (defun spacemacs/toggle-frame-fullscreen ()
   "Respect the `dotspacemacs-fullscreen-use-non-native' variable when

--- a/layers/!distribution/spacemacs-core/funcs.el
+++ b/layers/!distribution/spacemacs-core/funcs.el
@@ -514,7 +514,7 @@ dotspacemacs-persistent-server to be t"
   "Kill server buffer and hide the main Emacs window"
   (interactive)
   (server-kill-buffer)
-  (condition-case
+  (condition-case nil
       (delete-frame nil 1)
       (error
        (make-frame-invisible nil 1))))


### PR DESCRIPTION
This is needed to get the frame to properly close when running a client
from the terminal. server-kill-buffer will close the frame for the
terminal only if the terminal was opened with a file argument and you
haven't changed buffers. make-frame-invisible is still needed as a fall
back if you are still working from the first emacs window since it won't
let you delete the last frame.