### PR TITLE
Only add smartparens-mode to markdown-mode-hook if installed

### DIFF
--- a/layers/!lang/markdown/packages.el
+++ b/layers/!lang/markdown/packages.el
@@ -27,7 +27,9 @@
   (use-package markdown-mode
     :mode ("\\.m[k]d" . markdown-mode)
     :defer t
-    :init (add-hook 'markdown-mode-hook 'smartparens-mode)
+    :init
+    (when (configuration-layer/package-usedp 'smartparens)
+      (add-hook 'markdown-mode-hook 'smartparens-mode))
     :config
     (progn
       ;; Insert key for org-mode and markdown a la C-h k

--- a/layers/!lang/markdown/packages.el
+++ b/layers/!lang/markdown/packages.el
@@ -18,18 +18,19 @@
     mmm-mode
     company
     company-emoji
+    smartparens
     ))
 
 (defun markdown/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'markdown-mode-hook 'emoji-cheat-sheet-plus-display-mode))
 
+(defun markdown/post-init-smartparens ()
+  (add-hook 'markdown-mode-hook 'smartparens-mode))
+
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
     :mode ("\\.m[k]d" . markdown-mode)
     :defer t
-    :init
-    (when (configuration-layer/package-usedp 'smartparens)
-      (add-hook 'markdown-mode-hook 'smartparens-mode))
     :config
     (progn
       ;; Insert key for org-mode and markdown a la C-h k


### PR DESCRIPTION
If smartparens package is not installed (perhaps, because spacemacs-core option is chosen), smartparens-mode should not be added to the markdown-mode-hook.

When using the spacemacs-core distribution, opening a markdown file produced this message: "File mode specification error: (void-function smartparens-mode)". This PR fixes this issue.

(I have switched to using the spacemacs-core distribution, at least for now. It's much snappier. I suspect there's more such issues lurking where layers need to be adjusted to not assume that the full spacemacs distribution is present.)