### PR TITLE
Adding rubocop to ruby layer

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -10,6 +10,7 @@
  - [[#key-bindings][Key bindings]]
      - [[#ruby-enh-ruby-mode-robe-inf-ruby-ruby-tools][Ruby (enh-ruby-mode, robe, inf-ruby, ruby-tools)]]
      - [[#ruby-test-mode][ruby-test-mode]]
+     - [[#rubocop][rubocop]]
 
 * Description
 
@@ -32,6 +33,7 @@ based on your version manager):
 
 - =pry= and =pry-doc= are required for *jump to definition* and *code documentation* (=robe-mode=)
 - =ruby_parser= is required for *goto-step_definition* in =feature-mode=
+- =rubocop= is required for rubocop integration
 
 You can install the gems in the context of your current project by
 adding them to the =Gemfile=, e.g.:
@@ -64,6 +66,7 @@ Possible values are =rbenv= and =rvm=.
 
 ** Ruby (enh-ruby-mode, robe, inf-ruby, ruby-tools)
 
+
 | Key binding | Description                                 |
 |-------------+---------------------------------------------|
 | ~SPC m g g~ | go to definition (robe-jump)                |
@@ -88,3 +91,11 @@ a couple of useful keybindings:
 |-------------+---------------------|
 | ~SPC m t b~ | run test file       |
 | ~SPC m t t~ | run test at pointer |
+
+** rubocop
+
+| Key binding   | Description                   |
+|---------------+-------------------------------|
+| ~SPC m r a F~ | autocorrect current file      |
+| ~SPC m r a D~ | autocorrect current directory |
+| ~SPC m r a P~ | autocorrect current project   |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -19,7 +19,8 @@
     flycheck
     robe
     ruby-test-mode
-    ruby-tools))
+    ruby-tools
+    rubocop))
 
 (when ruby-version-manager
   (add-to-list 'ruby-packages ruby-version-manager))
@@ -126,6 +127,17 @@
       (spacemacs|hide-lighter ruby-test-mode)
       (evil-leader/set-key-for-mode 'enh-ruby-mode "mtb" 'ruby-test-run)
       (evil-leader/set-key-for-mode 'enh-ruby-mode "mtt" 'ruby-test-run-at-point))))
+
+(defun ruby/init-rubocop ()
+  (use-package rubocop
+    :defer t
+    :init (add-hook 'enh-ruby-mode-hook 'rubocop-mode)
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'enh-ruby-mode "mraD" 'rubocop-autocorrect-directory)
+      (evil-leader/set-key-for-mode 'enh-ruby-mode "mraP" 'rubocop-autocorrect-project)
+      (evil-leader/set-key-for-mode 'enh-ruby-mode "mraF" 'rubocop-autocorrect-current-file)
+      )))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun ruby/post-init-company ()


### PR DESCRIPTION
[rubocop](https://github.com/bbatsov/rubocop) is a useful lint tool and should have its place in Spacemacs.