### PR TITLE
Add support for org-reveal to org layer

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -11,6 +11,7 @@
    - [[#layer][Layer]]
    - [[#github-support][Github support]]
    - [[#gnuplot-support][Gnuplot support]]
+   - [[#reveal.js support][reveal.js support]]
    - [[#different-bullets][Different bullets]]
  - [[#key-bindings][Key bindings]]
    - [[#org][Org]]
@@ -87,6 +88,26 @@ demonstrated [[http://orgmode.org/worg/org-tutorials/org-plot.html][here]]; unfo
 at this stage.  It is possible to disable the configuration of gnuplot support
 as usual by adding the package =gnuplot= to your =dotspacemacs-excluded-packages=
 variable.
+
+** Reveal.js support
+
+To enable the export of your org file as a [[http://lab.hakim.se/reveal-js/][reveal.js]] presentation, set the
+variable =org-enable-reveal-js= to =t=. This will install the [[https://github.com/yjwen/org-reveal/][org-reveal]] extension.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-reveal-js t)))
+#+END_SRC
+
+In order to be able to use org-reveal, download =reveal.js= from its
+[[http://lab.hakim.se/reveal-js/#/][homepage]] and set =org-reveal-js= to the
+download path, as described in the [[https://github.com/yjwen/org-reveal#obtain-revealjs][manual]]. Alternatively, add the following line
+to each =.org= file you want to process:
+
+#+BEGIN_EXAMPLE
+#+REVEAL_ROOT: http://cdn.jsdelivr.net/reveal.js/3.0.0/
+#+END_EXAMPLE
 
 ** Different bullets
 You can tweak the bullets displayed in the org buffer in the function

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -14,4 +14,7 @@
 (defvar org-enable-github-support nil
   "If non-nil Github related packages are configured.")
 
+(defvar org-enable-reveal-js nil
+  "If non-nil, enables ox-reveal export.")
+
 (spacemacs|defvar-company-backends org-mode)

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -31,6 +31,7 @@
     org-repo-todo
     (ox-gfm :location local)
     persp-mode
+    ox-reveal
     ))
 
 (defun org/post-init-company ()
@@ -558,6 +559,24 @@ a Markdown buffer and use this command to convert it.
     :binding "o"
     :body
     (find-file (first (org-agenda-files)))))
+
+(defun org/init-toc-org ()
+  (use-package toc-org
+    :defer t
+    :init
+    (progn
+      (setq toc-org-max-depth 10)
+      (add-hook 'org-mode-hook 'toc-org-enable))))
+
+(defun org/init-ox-reveal ()
+  (use-package ox-reveal
+    :if org-enable-reveal-js
+    :defer t
+    :init
+    (progn
+      ;; seems to be required otherwise the extension is not
+      ;; loaded properly by org
+      (with-eval-after-load 'org (require 'ox-reveal)))))
 
 (defun org/init-htmlize ()
  (use-package htmlize


### PR DESCRIPTION
org-reveal is an extension to org mode that allows exporting of org files
as `reveal.js` presentations. Since not everyone needs this, the loading of
the package is controlled via `org-enable-reveal-js` switch, which, if set
to `t` would load the package.