### PR TITLE
core: Simple fix for #839

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -699,7 +699,7 @@ path."
               (configuration-layer//get-latest-package-version-string
                pkg-name)))
       ;; (message "%s: %s > %s ?" pkg-name cur-version new-version)
-      (version< cur-version new-version))))
+      (and new-version cur-version (version< cur-version new-version)))))
 
 (defun configuration-layer//get-packages-to-update (pkg-names)
   "Return a filtered list of PKG-NAMES to update."


### PR DESCRIPTION
Just checks to make sure that the new-version string exists before
making the comparison to the cur-version in
`configuration-layer//new-version-available-p`.