### PR TITLE
restore spacemacs/new-empty-buffer

### DIFF
--- a/layers/!distribution/spacemacs-core/funcs.el
+++ b/layers/!distribution/spacemacs-core/funcs.el
@@ -424,6 +424,12 @@ argument takes the kindows rotate backwards."
   (ediff-files (dotspacemacs/location)
                (concat dotspacemacs-template-directory ".spacemacs.template")))
 
+(defun spacemacs/new-empty-buffer ()
+  "Create a new buffer called untitled(<n>)"
+  (interactive)
+  (let ((newbuf (generate-new-buffer-name "untitled")))
+    (switch-to-buffer newbuf)))
+
 (defun spacemacs/home ()
   "Go to home Spacemacs buffer"
   (interactive)


### PR DESCRIPTION
I remember that you said that this function was removed accidentally. But it's too damn useful to be out of repository, so I couldn't resist and added it. 