### PR TITLE
Temporarily exclude evil-terminal-cursor-changer

### DIFF
--- a/layers/!distribution/spacemacs/packages.el
+++ b/layers/!distribution/spacemacs/packages.el
@@ -38,7 +38,9 @@
         evil-matchit
         evil-numbers
         evil-search-highlight-persist
-        evil-terminal-cursor-changer
+        ;; Temporarily disabled, pending the resolution of
+        ;; https://github.com/7696122/evil-terminal-cursor-changer/issues/8
+        (evil-terminal-cursor-changer :excluded t)
         evil-tutor
         expand-region
         fancy-battery


### PR DESCRIPTION
Fixes #2707, #2940 and #2964.