### PR TITLE
Added REPL (skewer-mode and livid-mode) to javascript layer

### DIFF
--- a/contrib/!lang/javascript/README.org
+++ b/contrib/!lang/javascript/README.org
@@ -13,6 +13,7 @@
      - [[#formatting-web-beautify][Formatting (web-beautify)]]
          - [[#documentation-js-doc][Documentation (js-doc)]]
      - [[#auto-complete-and-documentation-tern][Auto-complete and documentation (tern)]]
+     - [[#repl-skewer-mode][REPL (skewer-mode)]]
 
 * Description
 
@@ -24,6 +25,7 @@ This layer adds support for the JavaScript language using [[https://github.com/m
 - Auto-completion and documentation: provided by [[http://ternjs.net/][tern]]
 - CoffeeScript support
 - Formatting with [[https://github.com/yasuyk/web-beautify][web-beautify]]
+- REPL available via [[https://github.com/skeeto/skewer-mode][skewer-mode]] and [[https://github.com/pandeiro/livid-mode][livid-mode]]
   
 * Install
 
@@ -42,6 +44,14 @@ To use the formatting features, install =js-beautify=:
 #+BEGIN_SRC sh
   $ npm install -g js-beautify
 #+END_SRC
+
+To use the available JS repl, need a running httpd server and a page
+loaded with skewer. If a blank page serves your needs, just use the
+run-skewer command in your javascript buffer. If you want to inject it
+in your own page, follow the instructions in
+https://github.com/skeeto/skewer-mode#skewering-with-cors (install the
+Greasemonkey script and then click the triangle in the top-right
+corner - if it turns green, you're good to go). 
 
 * Key Bindings
 
@@ -126,3 +136,14 @@ You can check more [[https://github.com/mooz/js-doc/][here]]
 | ~SPC m h d~   | find docs of the thing under the cursor. Press again to open the associated URL (if any) |
 | ~SPC m h t~   | find the type of the thing under the cursor                                              |
 | ~SPC m r r V~ | rename variable under the cursor using tern                                              |
+
+** REPL (skewer-mode)
+
+| Key Binding | Description                                                             |
+|-------------+-------------------------------------------------------------------------|
+| ~SPC m s i~ | prepares the skewer environment - run this before running REPL commands |
+| ~SPC m s r~ | starts/goes to the skewer REPL                                          |
+| ~SPC m s b~ | loads the current file in the skewer REPL                               |
+| ~SPC m s e~ | evaluates the last expression                                           |
+| ~SPC m s p~ | prints the result of the last expression                                |
+| ~SPC m s d~ | evaluates the current function at point                                |

--- a/contrib/!lang/javascript/packages.el
+++ b/contrib/!lang/javascript/packages.el
@@ -22,6 +22,8 @@
     tern
     js-doc
     web-beautify
+    skewer-mode
+    livid-mode
     ))
 
 (defun javascript/init-coffee-mode ()
@@ -193,3 +195,28 @@
       :defer t
       :init
       (push 'company-tern company-backends-js2-mode))))
+
+(defun javascript/init-skewer-mode ()
+  (use-package skewer-mode
+    :defer t
+    :init
+    (progn
+      (add-hook 'js2-mode-hook 'skewer-mode)
+      (httpd-start)) ;; this starts the server process - otherwise we need to call httpd-start or run-skewer manually
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'js2-mode "msi" 'run-skewer)
+      (evil-leader/set-key-for-mode 'js2-mode "msr" 'skewer-repl)
+      (evil-leader/set-key-for-mode 'js2-mode "msb" 'skewer-load-buffer)
+      (evil-leader/set-key-for-mode 'js2-mode "mse" 'skewer-eval-last-expression)
+      (evil-leader/set-key-for-mode 'js2-mode "msp" 'skewer-eval-print-last-expression)
+      (evil-leader/set-key-for-mode 'js2-mode "msd" 'skewer-eval-defun)
+      )))
+
+(defun javascript/init-livid-mode ()
+  (use-package livid-mode
+    :defer t
+    :init
+    (progn
+      (defalias 'js-live-eval 'livid-mode "Minor mode for automatic evaluation of a JavaScript buffer on every change")
+      (evil-leader/set-key-for-mode 'js2-mode "mst" 'js-live-eval))))


### PR DESCRIPTION
[skewer-mode](https://github.com/skeeto/skewer-mode) is a very good REPL for Javascript, and its setup is very easy (just install a Grease/TamperMonkey script) compared to other options ([swank-js](https://github.com/swank-js/swank-js), [jss](https://github.com/segv/jss)). This PR adds it to the javascript layer, and includes [livid-mode](https://github.com/pandeiro/livid-mode) for hot reloading of a JS buffer.