### PR TITLE
Added JS repl via skewer-mode and livid-mode to javascript layer

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -16,6 +16,7 @@
      - [[Documentation (js-doc)][Documentation (js-doc)]]
    - [[Auto-complete and documentation (tern)][Auto-complete and documentation (tern)]]
    - [[JSON][JSON]]
+   - [[REPL (skewer-mode)][REPL (skewer-mode)]]
 
 * Description
 
@@ -28,6 +29,7 @@ This layer adds support for the JavaScript language using [[https://github.com/m
 - CoffeeScript support
 - Formatting with [[https://github.com/yasuyk/web-beautify][web-beautify]]
 - Get the path to a JSON value with [[https://github.com/Sterlingg/json-snatcher][json-snatcher]]
+- REPL available via [[https://github.com/skeeto/skewer-mode][skewer-mode]] and [[https://github.com/pandeiro/livid-mode][livid-mode]]
   
 * Install
 
@@ -65,6 +67,14 @@ Similarly, to change how js-mode indents JSON files, set the variable =js-indent
 #+BEGIN_SRC emacs-lisp
   (setq-default js-indent-level 2)
 #+END_SRC
+
+To use the available JS repl, you need a running httpd server and a page
+loaded with skewer. If a blank page serves your needs, just use the
+run-skewer command in your javascript buffer. If you want to inject it
+in your own page, follow the instructions in
+https://github.com/skeeto/skewer-mode#skewering-with-cors (install the
+Greasemonkey script and then click the triangle in the top-right
+corner - if it turns green, you're good to go). 
 
 * Key Bindings
 
@@ -156,3 +166,14 @@ You can check more [[https://github.com/mooz/js-doc/][here]]
 | Key Binding | Description                        |
 |-------------+------------------------------------|
 | ~SPC m h p~ | Get the path of the value at point |
+
+** REPL (skewer-mode)
+
+| Key Binding | Description                                                             |
+|-------------+-------------------------------------------------------------------------|
+| ~SPC m s s~ | prepares the skewer environment - run this before running REPL commands |
+| ~SPC m s i~ | starts/goes to the skewer REPL                                          |
+| ~SPC m s b~ | loads the current file in the skewer REPL                               |
+| ~SPC m e e~ | evaluates the last expression                                           |
+| ~SPC m e p~ | evaluates and inserts the result of the last expression at point        |
+| ~SPC m s f~ | evaluates the current function at point                                 |

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -24,6 +24,8 @@
     json-snatcher
     tern
     web-beautify
+    skewer-mode
+    livid-mode
     ))
 
 (defun javascript/init-coffee-mode ()
@@ -207,3 +209,28 @@
       (spacemacs/set-leader-keys-for-major-mode 'json-mode "=" 'web-beautify-js)
       (spacemacs/set-leader-keys-for-major-mode 'web-mode  "=" 'web-beautify-html)
       (spacemacs/set-leader-keys-for-major-mode 'css-mode  "=" 'web-beautify-css))))
+
+(defun javascript/init-skewer-mode ()
+  (use-package skewer-mode
+    :defer t
+    :init
+    (progn
+      (add-hook 'js2-mode-hook 'skewer-mode)
+      (httpd-start)) ;; this starts the server process - otherwise we need to call httpd-start or run-skewer manually
+    :config
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "ss" 'run-skewer)
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "si" 'skewer-repl)
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "sb" 'skewer-load-buffer)
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "ee" 'skewer-eval-last-expression)
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "ep" 'skewer-eval-print-last-expression)
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "sf" 'skewer-eval-defun)
+      )))
+
+(defun javascript/init-livid-mode ()
+  (use-package livid-mode
+    :defer t
+    :init
+    (progn
+      (defalias 'js-live-eval 'livid-mode "Minor mode for automatic evaluation of a JavaScript buffer on every change")
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode "st" 'js-live-eval))))


### PR DESCRIPTION
skewer-mode is a very good REPL for Javascript, and its setup is very easy (just install a Grease/TamperMonkey script) compared to other options (swank-js, jss). This PR adds it to the javascript layer, and includes livid-mode for hot reloading of a JS buffer.

This is the corrected version of #2975.