### PR TITLE
hybrid-mode: Cleaner implementation

### DIFF
--- a/layers/+distribution/spacemacs-core/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distribution/spacemacs-core/local/hybrid-mode/hybrid-mode.el
@@ -55,11 +55,8 @@
         (evil-move-cursor-back))))))
 
 (define-key evil-hybrid-state-map [escape] 'evil-normal-state)
-
-(defadvice evil-insert-state (around hybrid-state-advice disable)
-  "In Hybrid style this advice is run to switch to hybrid
-state instead of insert state."
-  (evil-hybrid-state))
+(setf (symbol-function 'hybrid-mode--evil-insert-state-backup)
+      (symbol-function 'evil-insert-state))
 
 ;;;###autoload
 (define-minor-mode hybrid-mode
@@ -69,10 +66,9 @@ with `evil-hybrid-state-map'."
   :lighter " Hy"
   :group 'spacemacs
   (if hybrid-mode
-      (progn
-        (ad-enable-advice 'evil-insert-state 'around 'hybrid-state-advice)
-        (ad-activate 'evil-insert-state))
-    (ad-disable-advice 'evil-insert-state 'around 'hybrid-state-advice)
-    (ad-activate 'evil-insert-state)))
+      (setf (symbol-function 'evil-insert-state)
+            (symbol-function 'evil-hybrid-state))
+    (setf (symbol-function 'evil-insert-state)
+          (symbol-function 'hybrid-mode--evil-insert-state-backup))))
 
 (provide 'hybrid-mode)

--- a/layers/+distribution/spacemacs-core/packages.el
+++ b/layers/+distribution/spacemacs-core/packages.el
@@ -954,8 +954,7 @@ ARG non nil means that the editing style is `vim'."
 
 (defun spacemacs-core/init-hybrid-mode ()
   (use-package hybrid-mode
-    :commands hybrid-mode
-    :init
+    :config
     (progn
       (when (eq 'hybrid dotspacemacs-editing-style) (hybrid-mode))
       (spacemacs|add-toggle hybrid-mode
@@ -963,9 +962,7 @@ ARG non nil means that the editing style is `vim'."
         :on (hybrid-mode)
         :off (hybrid-mode -1)
         :documentation "Globally toggle hybrid mode."
-        :evil-leader "E Y"))
-    :config
-    (progn
+        :evil-leader "E Y")
       (eval-after-load 'evil-leader
         '(define-key evil-hybrid-state-map
            (kbd dotspacemacs-emacs-leader-key) evil-leader--default-map)))))


### PR DESCRIPTION
Using setf is better than using the previous advice, because it was
ignoring the arguments passed to evil-insert-state and the arguments
control whether the state message displays in the minibuffer. In this
version we just switch out the function definition for
evil-insert-state, and all arguments are handled perfectly.

@syl20bnr I think you'll like this