### PR TITLE
Fix tests

### DIFF
--- a/tests/spacemacs/dotspacemacs.el
+++ b/tests/spacemacs/dotspacemacs.el
@@ -1,3 +1,7 @@
-(defun dotspacemacs/layers ())
+(defun dotspacemacs/layers ()
+  (setq-default
+   dotspacemacs-distribution 'spacemacs))
 (defun dotspacemacs/init ())
+(defun dotspacemacs/user-init ())
 (defun dotspacemacs/config ())
+(defun dotspacemacs/user-config ())


### PR DESCRIPTION
Now that the default distribution is `spacemacs-core`, the tests fail.