### PR TITLE
Temporary fix for #2995

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -52,7 +52,7 @@ exists. Otherwise, fallback to ~/.spacemacs")
 (defvar dotspacemacs-verbose-loading nil
   "If non nil output loading progess in `*Messages*' buffer.")
 
-(defvar dotspacemacs-distribution 'spacemacs-core
+(defvar dotspacemacs-distribution 'spacemacs
   "Base distribution to use. This is a layer contained in the directory
 `+distribution'. For now available distributions are `spacemacs-core'
 or `spacemacs'.")


### PR DESCRIPTION
This sets the default distribution back to spacemacs. This is for people
who for whatever reason don't set `dotspacemacs-distribution` in their
dotfile.

Note it's only temporary because it doesn't touch the template or the install procedure