### PR TITLE
Correct Idris layer's name in its README

### DIFF
--- a/layers/+lang/idris-lang/README.org
+++ b/layers/+lang/idris-lang/README.org
@@ -24,7 +24,7 @@ This layer adds support for the [[http://www.idris-lang.org/][Idris]] language.
 To use this layer, add it to your =~/.spacemacs=
 
 #+BEGIN_SRC elisp
-(setq-default dotspacemacs-configuration-layers '(idris))
+(setq-default dotspacemacs-configuration-layers '(idris-lang))
 #+END_SRC
 
 ** Idris


### PR DESCRIPTION
Updated the Idris layer's README to reflect the layer name change in https://github.com/syl20bnr/spacemacs/commit/2ccea679da94ac1292d8ef8be6fd633e07224e42.