### PR TITLE
Don't inject version in home buffer if no banner

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -139,7 +139,8 @@ directory with a name starting with `+'.")
 (defun configuration-layer/sync ()
   "Synchronize declared layers in dotfile with spacemacs."
   (dotspacemacs|call-func dotspacemacs/layers "Calling dotfile layers...")
-  (spacemacs-buffer//inject-version t)
+  (when (spacemacs-buffer//choose-banner)
+    (spacemacs-buffer//inject-version t))
   ;; layers
   (setq configuration-layer--layers (configuration-layer//declare-layers))
   (configuration-layer//configure-layers configuration-layer--layers)


### PR DESCRIPTION
Fixes #3004.

This behaviour is consistent with `spacemacs-buffer/insert-banner-and-buttons`.