### PR TITLE
Fix documentation for emacsclient

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2508,12 +2508,19 @@ You can open a file in Emacs from the terminal using =emacsclient=. Use
 =emacsclient -c= to open the file in Emacs GUI. Use =emacsclient -t= to open the
 file in Emacs within the terminal.
 
-If you want your Linux/OS X system to use Emacs by default for any prompt, use
-=export EDITOR="emacsclient -c"= in your shell configuration.
+If you want your Linux/OS X system to use Emacs by default for any prompt, you
+need to set it in your shell configuration, e.g. =~/.bashrc= or =~/.zshrc=:
+
+#+begin_src sh-mode
+export EDITOR="emacsclient -c"
+#+end_src
 
 Note that if you're on OS X, you may have to refer to the emacsclient that comes
-with your GUI Emacs, e.g. =export
-EDITOR="/Applications/Emacs.app/Contents/MacOS/bin/emacsclient -c"=.
+with your GUI Emacs, e.g.:
+
+#+begin_src sh-mode
+export EDITOR="/Applications/Emacs.app/Contents/MacOS/bin/emacsclient -c"
+#+end_src
 
 Tip: Remember to use ~:wq~ or ~C-x #~ after you are done editing the file in
 Emacs.


### PR DESCRIPTION
Verbatim text with equal sign was't displaying correctly. Another
solution would be to escape `=` with Org mode entity, but GitHub won't
display it correctly.