### PR TITLE
Use outline mode for folding in LaTeX

### DIFF
--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -42,7 +42,8 @@
             LaTeX-fill-break-at-separators nil)
       (when latex-enable-auto-fill
         (add-hook 'LaTeX-mode-hook 'latex/auto-fill-mode))
-      (add-hook 'LaTeX-mode-hook 'latex-math-mode))
+      (add-hook 'LaTeX-mode-hook 'latex-math-mode)
+      (add-hook 'LaTeX-mode-hook 'outline-minor-mode))
     :config
     (progn
       ;; Key bindings for plain TeX
@@ -77,10 +78,10 @@
         "mv" 'TeX-view))))
 
 (when (string= latex-build-command "LatexMk")
-(defun latex/init-auctex-latexmk ()
-  (use-package auctex-latexmk
-    :defer t
-    :init (add-hook 'LaTeX-mode-hook 'auctex-latexmk-setup))))
+  (defun latex/init-auctex-latexmk ()
+    (use-package auctex-latexmk
+      :defer t
+      :init (add-hook 'LaTeX-mode-hook 'auctex-latexmk-setup))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun latex/post-init-company ()


### PR DESCRIPTION
Also fix some indentation while I'm at it.

It doesn't do environments, though. AUCTeX comes with a more sophisticated folding mode, but it doesn't really behave like one would expect from vim. (It's more like a conceal kind of feature.) I think it would work better with major mode leader bindings.

Edit: Come to think of it, this might work better as a doc tip?