### PR TITLE
core: Add spacemacs/set-key funcs

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -92,4 +92,73 @@ complements it by added additional leader keys."
             (kbd dotspacemacs-major-mode-emacs-leader-key) major-mode-map))
         (define-key state-map (kbd dotspacemacs-emacs-leader-key) root-map)))))
 
+(defun spacemacs/set-key (key binding &rest bindings)
+  (while (and key binding)
+    (let ((full-key (kbd (concat dotspacemacs-leader-key " " key)))
+          (full-emacs-key (kbd (concat dotspacemacs-emacs-leader-key " " key))))
+      (dolist (state '(normal visual motion))
+        (evil-global-set-key state full-key binding))
+      (dolist (state '(insert emacs normal visual motion hybrid))
+        (evil-global-set-key state full-emacs-key binding)))
+    (setq key (pop bindings) binding (pop bindings))))
+
+(defun spacemacs/set-default-key (key binding &rest bindings)
+  (while (and key binding)
+    (let ((full-key (kbd (concat dotspacemacs-leader-key " " key)))
+          (full-emacs-key (kbd (concat dotspacemacs-emacs-leader-key " " key))))
+      (dolist (state '(normal visual motion))
+        (unless (lookup-key (evil-state-property state :keymap t) full-key)
+          (evil-global-set-key state full-key binding)))
+      (dolist (state '(insert emacs normal visual motion hybrid))
+        (unless (lookup-key (evil-state-property state :keymap t) full-emacs-key)
+          (evil-global-set-key state full-emacs-key binding))))
+    (setq key (pop bindings) binding (pop bindings))))
+
+(defun spacemacs/set-key-for-mode (major-mode-map key binding &rest bindings)
+  (while (and key binding)
+    (let ((full-key (kbd (concat dotspacemacs-leader-key " m " key)))
+          (full-emacs-key (kbd (concat dotspacemacs-emacs-leader-key " m " key)))
+          (full-mm-key
+           (when dotspacemacs-major-mode-leader-key
+             (kbd (concat dotspacemacs-major-mode-leader-key " " key))))
+          (full-mm-emacs-key
+           (when dotspacemacs-major-mode-emacs-leader-key
+             (kbd (concat dotspacemacs-major-mode-emacs-leader-key " " key)))))
+      (dolist (state '(normal visual motion))
+        (evil-define-key state major-mode-map full-key binding)
+        (when full-mm-key
+          (evil-define-key state major-mode-map full-mm-key binding)))
+      (dolist (state '(insert emacs normal visual motion hybrid))
+        (evil-define-key state major-mode-map full-emacs-key binding)
+        (when full-mm-emacs-key
+          (evil-define-key state major-mode-map full-mm-emacs-key binding)))
+      (setq key (pop bindings) binding (pop bindings)))))
+
+(defun spacemacs//lookup-key-for-mode (major-mode-map state key)
+  (let ((aux-map (evil-get-auxiliary-keymap major-mode-map state)))
+    (when aux-map
+      (lookup-key aux-map key))))
+
+(defun spacemacs/set-default-key-for-mode (major-mode-map key binding &rest bindings)
+  (while (and key binding)
+    (let ((full-key (kbd (concat dotspacemacs-leader-key " m " key)))
+          (full-emacs-key (kbd (concat dotspacemacs-emacs-leader-key " m " key)))
+          (full-mm-key
+           (when dotspacemacs-major-mode-leader-key
+             (kbd (concat dotspacemacs-major-mode-leader-key " " key))))
+          (full-mm-emacs-key
+           (when dotspacemacs-major-mode-emacs-leader-key
+             (kbd (concat dotspacemacs-major-mode-emacs-leader-key " " key)))))
+      (dolist (state '(normal visual motion))
+        (unless (spacemacs//lookup-key-for-mode major-mode-map state full-key)
+          (evil-define-key state major-mode-map full-key binding)
+          (when full-mm-key
+            (evil-define-key state major-mode-map full-mm-key binding))))
+      (dolist (state '(insert emacs normal visual motion hybrid))
+        (unless (spacemacs//lookup-key-for-mode major-mode-map state full-emacs-key)
+          (evil-define-key state major-mode-map full-emacs-key binding)
+          (when full-mm-emacs-key
+            (evil-define-key state major-mode-map full-mm-emacs-key binding)))))
+    (setq key (pop bindings) binding (pop bindings))))
+
 (provide 'core-keybindings)


### PR DESCRIPTION
@syl20bnr I know you've said no to an idea like this before, but I think this is the way to go with key bindings. I think we are trying to hack around evil-leader's shortcomings, when evil itself provides all that is needed to set keys. Furthermore, moving this functionality "in house" brings control. I think the idea of using `spacemacs/set-default-key` in all layers is the right way to solve the issue of user's key bindings getting overridden by layers that are deferred. This is just an initial commit, but it's almost complete, showing how simple this can be. With this approach we can do away with evil-leader and all of the nonsense with the major-mode leader key and such (it's just another key binding after all and shouldn't be complicated). 

The commit message: 

Initial commit to implement spacemacs replacements for evil-leader
functions using built-in evil functions. The two main advantages are the
removal of the need to play around with major mode hooks and the like,
as evil-leader does, and the ability to extend the functionality of
evil-leader for spacemacs without having to hack our way around the
evil-leader implementation.

As an example of one of these advantages, I implemented
spacemacs/set-default-key which will only set the key binding if one
does not already exist. Think of this like a defvar for key bindings,
which will not clobber the user's personal choices of bindings. Using
this function in layers, will make it not matter if the user declares
the key before or after the layer has loaded.