### PR TITLE
core-conf-layer: Use NOSAVE for pack. update (v25)

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1077,7 +1077,7 @@ to select one."
    ((version<= "25.0.50" emacs-version)
     (let ((p (cadr (assq pkg-name package-alist))))
       ;; add force flag to ignore dependency checks in Emacs25
-      (when p (package-delete p t))))
+      (when p (package-delete p t t))))
    (t (let ((p (cadr (assq pkg-name package-alist))))
         (when p (package-delete p))))))
 


### PR DESCRIPTION
Should fix #2849. The new package-delete tries to save changes to the
selected package variable during the update process and this can cause
conflicts with how spacemacs wants to update packages (and even lead to
the .spacemacs file being deleted. This is also unnecessary, because we
are only deleting the packages temporarily to be installed at the next
boot, so there should be no need to update this variable.

This change only affects Emacs 25 users.