### PR TITLE
Fix py-yapf for yapf>0.2.7

### DIFF
--- a/layers/+lang/python/local/py-yapf/py-yapf.el
+++ b/layers/+lang/python/local/py-yapf/py-yapf.el
@@ -94,19 +94,34 @@ Note that `--in-place' is used by default."
     (with-current-buffer patchbuf
       (erase-buffer))
     (write-region nil nil tmpfile)
-    (if (zerop (apply 'call-process "yapf" nil errbuf nil
-                      (append py-yapf-options `("--in-place" ,tmpfile))))
-        (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile))
-            (progn
-              (kill-buffer errbuf)
-              (message "Buffer is already yapfed"))
-          (py-yapf-apply-rcs-patch patchbuf)
-          (kill-buffer errbuf)
-          (message "Applied yapf"))
-      (error "Could not apply yapf. Check *yapf Errors* for details"))
+    (let ((yapf-ret-code (apply 'call-process "yapf" nil errbuf nil
+                                       (append py-yapf-options `("--in-place" ,tmpfile)))))
+      (cond
+       ((eq yapf-ret-code 1)
+        (py-yapf-apply-rcs-patch-if-needed patchbuf tmpfile errbuf)
+        )
+       ((eq yapf-ret-code 0)
+        (py-yapf-apply-rcs-patch-if-needed patchbuf tmpfile errbuf)
+        )
+       (error "Could not apply yapf. Check *yapf Errors* for details"))
+      )
     (kill-buffer patchbuf)
-    (delete-file tmpfile)))
+    (delete-file tmpfile)
+    ))
 
+(defun py-yapf-apply-rcs-patch-if-needed (patchbuf tmpfile errbuf)
+  "Create and apply patch to current buffer from yapfed tmpfile"
+  (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile))
+      (progn
+        (kill-buffer errbuf)
+        (message "Buffer is already yapfed"))
+    (progn
+      (py-yapf-apply-rcs-patch patchbuf)
+      (kill-buffer errbuf)
+      (message "Applied yapf")
+      )
+    )
+  )
 
 ;;;###autoload
 (defun py-yapf-buffer ()


### PR DESCRIPTION
yapf > 0.2.7 now returns 1 if source code was changed and it breaks current py-yapf.
Fixes #3023.

This change has been introduced by this commit:
      https://github.com/google/yapf/commit/ffb8d734618ba3a073892a72df436c68258f171d