### PR TITLE
core-keys: Map `M-m` to mode-map when available

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -58,28 +58,38 @@ used as the prefix command."
         (define-prefix-command command)
         (evil-leader/set-key-for-mode mode prefix command)))))
 
-(defun spacemacs/activate-major-mode-leader ()
-  "Bind major mode key map to `dotspacemacs-major-mode-leader-key'."
+(define-minor-mode spacemacs-additional-leader-mode ()
+  "This mode follows the design of `evil-leader-mode' and
+complements it by added additional leader keys."
+  :init-value nil
+  :keymap nil
   (let* ((mode-map (cdr (assoc major-mode evil-leader--mode-maps)))
-         (major-mode-map (when mode-map (lookup-key mode-map (kbd "m")))))
-    (when major-mode-map
-      (mapc (lambda (s)
-              (eval `(define-key
-                       ,(intern (format "evil-%S-state-local-map" s))
-                       ,(kbd dotspacemacs-major-mode-leader-key)
-                       major-mode-map)))
-            '(normal motion))
-      (mapc (lambda (s)
-              (eval `(define-key
-                       ,(intern (format "evil-%S-state-local-map" s))
-                       ,(kbd dotspacemacs-major-mode-emacs-leader-key)
-                       major-mode-map)))
-            '(emacs insert normal motion visual))
-      ;; using `bound-and-true-p', because hybrid-mode may not be loaded when
-      ;; using emacs or vim style
-      (when (bound-and-true-p hybrid-mode)
-        (define-key evil-hybrid-state-map
-          (kbd dotspacemacs-major-mode-emacs-leader-key)
-          major-mode-map)))))
+         (root-map (when spacemacs-additional-leader-mode
+                     (or mode-map evil-leader--default-map)))
+         (major-mode-map (when (and spacemacs-additional-leader-mode
+                                    mode-map)
+                           (lookup-key mode-map (kbd "m"))))
+         (state-maps '(evil-normal-state-local-map
+                       evil-motion-state-local-map
+                       evil-visual-state-local-map))
+         (emacs-state-maps '(evil-emacs-state-local-map
+                             evil-insert-state-local-map
+                             evil-normal-state-local-map
+                             evil-motion-state-local-map
+                             evil-visual-state-local-map
+                             evil-hybrid-state-local-map)))
+    (dolist (state-map state-maps)
+      (when state-map
+        (setq state-map (eval state-map))
+        (when dotspacemacs-major-mode-leader-key
+          (define-key state-map
+            (kbd dotspacemacs-major-mode-leader-key) major-mode-map))))
+    (dolist (state-map emacs-state-maps)
+      (when state-map
+        (setq state-map (eval state-map))
+        (when dotspacemacs-major-mode-emacs-leader-key
+          (define-key state-map
+            (kbd dotspacemacs-major-mode-emacs-leader-key) major-mode-map))
+        (define-key state-map (kbd dotspacemacs-emacs-leader-key) root-map)))))
 
 (provide 'core-keybindings)

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -431,7 +431,11 @@ Example: (evil-map visual \"<\" \"<gv\")"
     :init
     (progn
       (setq evil-leader/leader dotspacemacs-leader-key)
-      (global-evil-leader-mode))
+      (global-evil-leader-mode)
+      ;; This is the same hook used by evil-leader. We make sure that this
+      ;; function is called after `evil-leader-mode' using the last argument
+      (add-hook 'evil-local-mode-hook
+                #'spacemacs-additional-leader-mode t))
     :config
     (progn
       ;; Unset shortcuts which shadow evil leader
@@ -439,27 +443,14 @@ Example: (evil-map visual \"<\" \"<gv\")"
         '(progn
            ;; (define-key compilation-mode-map (kbd dotspacemacs-leader-key) nil)
            (define-key compilation-mode-map (kbd "h") nil)))
-      ;; (eval-after-load "dired"
-      ;;   '(define-key dired-mode-map (kbd dotspacemacs-leader-key) nil))
-      ;; make leader available in visual and motion states
-      (mapc (lambda (s)
-              (eval `(define-key
-                       ,(intern (format "evil-%S-state-map" s))
-                       ,(kbd dotspacemacs-leader-key)
-                       evil-leader--default-map)))
-            '(motion visual))
-      ;; emacs and insert states (make it also available in other states
-      ;; for consistency and POLA.)
-      (mapc (lambda (s)
-              (eval `(define-key
-                       ,(intern (format "evil-%S-state-map" s))
-                       ,(kbd dotspacemacs-emacs-leader-key)
-                       evil-leader--default-map)))
-            '(emacs insert normal visual motion))
-      ;; experimental: map SPC m to ,
-      (when dotspacemacs-major-mode-leader-key
-        (add-hook 'evil-local-mode-hook
-                  'spacemacs/activate-major-mode-leader t)))))
+      ;; (eval-after-load "dired" '(define-key dired-mode-map (kbd
+      ;;   dotspacemacs-leader-key) nil))
+      ;; evil-leader does not get activated in existing buffers, so we have to
+      ;; force it here
+      (dolist (buffer (buffer-list))
+        (with-current-buffer buffer
+          (evil-leader-mode 1)
+          (spacemacs-additional-leader-mode 1))))))
 
 (defun spacemacs-base/init-evil-surround ()
   (use-package evil-surround
@@ -964,10 +955,7 @@ ARG non nil means that the editing style is `vim'."
         :on (hybrid-mode)
         :off (hybrid-mode -1)
         :documentation "Globally toggle hybrid mode."
-        :evil-leader "E Y")
-      (eval-after-load 'evil-leader
-        '(define-key evil-hybrid-state-map
-           (kbd dotspacemacs-emacs-leader-key) evil-leader--default-map)))))
+        :evil-leader "E Y"))))
 
 (defun spacemacs-base/init-ido-vertical-mode ()
   (use-package ido-vertical-mode

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -46,8 +46,14 @@
       (evil-leader/set-key-for-mode 'org-mode
         "mC" 'evil-org-recompute-clocks
 
-        ;; evil-org binds these keys, so we unbind them
-        "t" nil "a" nil "b" nil "c" nil "l" nil "o" nil)
+        ;; evil-org binds these keys, so we bind them back to their original
+        ;; value
+        "t" (lookup-key evil-leader--default-map "t")
+        "a" (lookup-key evil-leader--default-map "a")
+        "b" (lookup-key evil-leader--default-map "b")
+        "c" (lookup-key evil-leader--default-map "c")
+        "l" (lookup-key evil-leader--default-map "l")
+        "o" (lookup-key evil-leader--default-map "o"))
       (evil-define-key 'normal evil-org-mode-map
         "O" 'evil-open-above)
       (spacemacs|diminish evil-org-mode " ⓔ" " e"))))


### PR DESCRIPTION
This is how evil-leader gets `SPC m` to work for mode specific bindings,
and we need to mirror this step for `M-m`