### PR TITLE
Fix wrong variable name in README for rcirc layer.

### DIFF
--- a/layers/+irc/rcirc/README.org
+++ b/layers/+irc/rcirc/README.org
@@ -148,7 +148,7 @@ For now authinfo is mandatory to use the ZNC configuration.
 
    #+BEGIN_SRC emacs-lisp
      (setq-default dotspacemacs-configuration-layers '(
-       (rcirc :variables rcirc-enable-authinfo-support t)))
+       (rcirc :variables rcirc-enable-znc-support t)))
    #+END_SRC
 
 2) In your =~/.authinfo.gpg= file store your credentials like this:


### PR DESCRIPTION
Very minor, but can really trip you up if you're into copy-pasting :)