### PR TITLE
Add a function and keybinding for `cargo clean`

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -36,3 +36,4 @@ instructions can be found on the main page of [[http://doc.crates.io/index.html]
 | ~SPC m c t~ | run tests with Cargo              |
 | ~SPC m c d~ | generate documentation with Cargo |
 | ~SPC m c x~ | execute the project with Cargo    |
+| ~SPC m c C~ | remove build artifacts with Cargo |

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -26,3 +26,7 @@
 (defun spacemacs/rust-cargo-doc ()
   (interactive)
   (compile "cargo doc"))
+
+(defun spacemacs/rust-cargo-clean ()
+  (interactive)
+  (compile "cargo clean"))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -44,7 +44,8 @@
         "mcc" 'spacemacs/rust-cargo-build
         "mct" 'spacemacs/rust-cargo-test
         "mcd" 'spacemacs/rust-cargo-doc
-        "mcx" 'spacemacs/rust-cargo-run))))
+        "mcx" 'spacemacs/rust-cargo-run
+        "mcC" 'spacemacs/rust-cargo-clean))))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode


### PR DESCRIPTION
I've added the `SPC c C` keybinding to the `lang/rust` layer which will run `cargo clean` on the current Cargo project.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/syl20bnr/spacemacs/3038)
<!-- Reviewable:end -->
