### PR TITLE
lang/go: change keybindings

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -48,16 +48,17 @@ To use this contribution add it to your =~/.spacemacs=
 ** Go commands (start with =m=):
 | Key Binding | Description                                               |
 |-------------+-----------------------------------------------------------|
-| ~SPC m d p~ | godoc at point                                            |
+| ~SPC m h p~ | godoc at point                                            |
 | ~SPC m i g~ | goto imports                                              |
 | ~SPC m i a~ | add import                                                |
 | ~SPC m i r~ | remove unused import                                      |
-| ~SPC m p b~ | go-play buffer                                            |
-| ~SPC m p r~ | go-play region                                            |
-| ~SPC m p d~ | download go-play snippet                                  |
+| ~SPC m e b~ | go-play buffer                                            |
+| ~SPC m e r~ | go-play region                                            |
+| ~SPC m e d~ | download go-play snippet                                  |
 | ~SPC m t p~ | run "go test" for the current package                     |
 | ~SPC m g a~ | jump to matching test file or back from test to code file |
 | ~SPC m g g~ | go jump to definition                                     |
+| ~SPC m r n~ | go rename                                                 |
 
 
 ** Go Oracle

--- a/layers/+lang/go/extensions.el
+++ b/layers/+lang/go/extensions.el
@@ -56,4 +56,4 @@
 (defun go/init-go-rename()
   (use-package go-rename
     :init
-    (evil-leader/set-key-for-mode 'go-mode "mr" 'go-rename)))
+    (evil-leader/set-key-for-mode 'go-mode "mrn" 'go-rename)))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -25,13 +25,13 @@
         (shell-command "go test"))
 
       (evil-leader/set-key-for-mode 'go-mode
-        "mdp" 'godoc-at-point
+        "mhp" 'godoc-at-point
         "mig" 'go-goto-imports
         "mia" 'go-import-add
         "mir" 'go-remove-unused-imports
-        "mpb" 'go-play-buffer
-        "mpr" 'go-play-region
-        "mpd" 'go-download-play
+        "meb" 'go-play-buffer
+        "mer" 'go-play-region
+        "med" 'go-download-play
         "mga" 'ff-find-other-file
         "mgg" 'godef-jump
         "mtp" 'spacemacs/go-run-package-tests))))


### PR DESCRIPTION
So I've tried using go oracle only to find everything has been shadowed by go rename. So go rename has been changed to mrn, which makes for a decent mnemonic.

As for the rest, the conventions specify to use h for any kind of documentation, not d, as well as e for evaluation(which is kind of what go-play does).

Hopefully more improvements coming.