### PR TITLE
shell: fix bad casing in README

### DIFF
--- a/layers/shell/README.org
+++ b/layers/shell/README.org
@@ -149,7 +149,7 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~SPC a s m~ | Open, close or go to a =multi-term=                        |
 | ~SPC a s t~ | Open, close or go to a =ansi-term=                         |
 | ~SPC a s T~ | Open, close or go to a =term=                              |
-| ~SPC m h~   | browse history with =helm= (works in =eshell= and =shell=) |
+| ~SPC m H~   | browse history with =helm= (works in =eshell= and =shell=) |
 | ~C-j~       | next item in history                                       |
 | ~C-k~       | previous item in history                                   |
 


### PR DESCRIPTION
The history browse command is bound under <kbd>SPC m H</kbd>, not <kbd>SPC m h</kbd>. I'm assuming the docs are just off, but if it needs to be fixed in the keybinding instead let me know and I'll submit a modified PR. :)