### PR TITLE
Use exec-path-from-shell-copy-env to set RUST_SRC_PATH for racer

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -61,6 +61,9 @@
       :init (push 'company-racer company-backends-rust-mode))))
 
 (defun rust/init-racer ()
+  (when (memq window-system '(mac ns x))
+    (exec-path-from-shell-copy-env "RUST_SRC_PATH"))
+
   (use-package racer
     :if rust-enable-racer
     :defer t


### PR DESCRIPTION
`racer` expects `RUST_SRC_PATH` to be defined, but on osx the environment variable is not being picked up by emacs.  This is analogous to #1878.