### PR TITLE
Remove server-kill-buffer from frame-killer

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -475,7 +475,6 @@ dotspacemacs-persistent-server to be t"
 (defun spacemacs/frame-killer ()
   "Kill server buffer and hide the main Emacs window"
   (interactive)
-  (server-kill-buffer)
   (condition-case nil
       (delete-frame nil 1)
       (error


### PR DESCRIPTION
Not entirely sure why, but server-kill-buffer will close other open frames if emacs is started as a terminal client with ```emacsclient -nw ./filename```. There does not appear to be a downside to removing the command. 