### PR TITLE
Add org layer keybindings for subtree & TODOs

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -76,6 +76,7 @@ You can tweak the bullets displayed in the org buffer in the function
 | Key Binding                                  | Description                                  |
 |----------------------------------------------+----------------------------------------------|
 | ~SPC m '~                                    | org-edit-special                             |
+| ~SPC m .~                                    | org-time-stamp                               |
 | ~SPC m a~                                    | org-agenda                                   |
 | ~SPC m b~                                    | org-tree-to-indirect-buffer                  |
 | ~SPC m A~                                    | org-archive-subtree                          |
@@ -94,7 +95,16 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC m R~                                    | org-refile                                   |
 | ~SPC m s~                                    | org-schedule                                 |
 | ~SPC m T~                                    | org-show-todo-tree                           |
+| ~SPC m L~                                    | org-shiftright                               |
+| ~SPC m H~                                    | org-shiftleft                                |
+| ~SPV m K~                                    | org-shiftup                                  |
+| ~SPC m J~                                    | org-shiftdown                                |
+| ~SPC m C-S-l~                                | org-shiftcontrolright                        |
+| ~SPC m C-S-h~                                | org-shiftcontrolleft                         |
+| ~SPC m C-S-j~                                | org-shiftcontroldown                         |
+| ~SPC m C-S-k~                                | org-shiftcontrolup                           |
 | ~SPC s l~                                    | spacemacs/jump-in-buffer (jump to a heading) |
+
 
 Table-related shortcuts:
 
@@ -127,7 +137,16 @@ Table-related shortcuts:
 | ~SPC m t t f~ | Toggle the formula debugger in tables                                      |
 | ~SPC m t t o~ | Toggle the display of Row/Column numbers in tables                         |
 | ~SPC m t w~   | Wrap several fields in a column like a paragraph                           |
-|               |                                                                            |
+
+Tree related shorcuts: 
+
+| Key Binding | Description           |
+|-------------+-----------------------|
+| ~SPC m S l~ | org-demote-subtree    |
+| ~SPC m S h~ | org-promote-subtree   |
+| ~SPC m S k~ | org-move-subtree-up   |
+| ~SPC m S j~ | org-move-subtree-down |
+
 
 | Key Binding | Description                     |
 |-------------+---------------------------------|

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -106,9 +106,29 @@ Will work on both org-mode and any mode that accepts plain html."
         "ml" 'org-open-at-point
         "mT" 'org-show-todo-tree
 
+        "m." 'org-time-stamp
+
         ;; headings
         "mhi" 'org-insert-heading-after-current
         "mhI" 'org-insert-heading
+
+        ;; More cycling options (timestamps, headlines, items, properties)
+        "mL" 'org-shiftright
+        "mH" 'org-shiftleft
+        "mJ" 'org-shiftdown
+        "mK" 'org-shiftup
+
+        ;; Change between TODO sets
+        "m C-S-l" 'org-shiftcontrolright
+        "m C-S-h" 'org-shiftcontrolleft
+        "m C-S-j" 'org-shiftcontroldown
+        "m C-S-k" 'org-shiftcontrolup
+
+        ;; Subtree editing
+        "mSl" 'org-demote-subtree
+        "mSh" 'org-promote-subtree
+        "mSj" 'org-move-subtree-down
+        "mSk" 'org-move-subtree-up
 
         ;; tables
         "mta" 'org-table-align


### PR DESCRIPTION
* Move whole subtrees up/down/right/left with SPC mS commands
* When using more complex TODO sets, move between them with SPC m C-S
commands
* Add more cycling options with SPC mL SPC mK, etc.
(for timestamps, headlines, items, properties)
* Insert timestamps with SPC m.