### PR TITLE
Update README.org

### DIFF
--- a/contrib/!lang/clojure/README.org
+++ b/contrib/!lang/clojure/README.org
@@ -68,8 +68,8 @@ Or set this variable when loading the configuration layer:
 - Create a file =~/.lein/profiles.clj= with the following content:
   
 #+BEGIN_SRC clojure
-  {:user {:plugins [[cider/cider-nrepl "0.9.0-SNAPSHOT"]
-                    [refactor-nrepl "0.3.0-SNAPSHOT"]]
+  {:user {:plugins [[cider/cider-nrepl "0.10.0-SNAPSHOT"]
+                    [refactor-nrepl "1.2.0-SNAPSHOT"]]
           :dependencies [[alembic "0.3.2"]
                          [org.clojure/tools.nrepl "0.2.7"]]}}
 #+END_SRC


### PR DESCRIPTION
The cider-nrepl and refactor-nrepl plugin versions are [out of date](https://github.com/clojure-emacs/cider-nrepl/issues/254#issuecomment-140896514).