### PR TITLE
Switch the default distribution to spacemacs

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -322,7 +322,7 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
                     vim)
                    ("On the planet Emacs in the Holy control tower (emacs)"
                     emacs)))))
-             ("dotspacemacs-distribution 'spacemacs-base"
+             ("dotspacemacs-distribution 'spacemacs"
               ,(format
                 "dotspacemacs-distribution '%S"
                 (dotspacemacs//ido-completing-read

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -9,8 +9,8 @@ values."
   (setq-default
    ;; Base distribution to use. This is a layer contained in the directory
    ;; `+distribution'. For now available distributions are `spacemacs-base'
-   ;; or `spacemacs'. (default 'spacemacs-base)
-   dotspacemacs-distribution 'spacemacs-base
+   ;; or `spacemacs'. (default 'spacemacs)
+   dotspacemacs-distribution 'spacemacs
    ;; List of additional paths where to look for configuration layers.
    ;; Paths must have a trailing slash (i.e. `~/.mycontribs/')
    dotspacemacs-configuration-layer-path '()


### PR DESCRIPTION
This will cause a lot of confusion for newcomers. It is documented that it's an option.