### PR TITLE
Revert 'Make Y equivalent to y$.'

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -696,9 +696,6 @@ Additional information may as well be displayed in the minibuffer.
   opposite direction in =Vim=, but in =Spacemacs= it is the major mode specific
   leader key by default (which can be set on another key binding in the
   dotfile).
-- The ~Y~ key does not yank the whole line. It yanks from the current point to
-  the end of the line. This is more consistent with the behavior of ~C~ and ~D~
-  and is also recommended by the vim documentation.
 
 Send a PR to add the differences you found in this section.
 

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -252,13 +252,6 @@
       (define-key evil-window-map (kbd "<right>") 'evil-window-right)
       (define-key evil-window-map (kbd "<up>") 'evil-window-up)
       (define-key evil-window-map (kbd "<down>") 'evil-window-down)
-      ;; Make Y equivalent to y$
-      (defun spacemacs/evil-yank-to-end-of-line ()
-        "Yank from point to end of line."
-        (interactive)
-        (evil-yank (point) (point-at-eol)))
-      (define-key evil-normal-state-map (kbd "Y") 'spacemacs/evil-yank-to-end-of-line)
-      (define-key evil-motion-state-map (kbd "Y") 'spacemacs/evil-yank-to-end-of-line)
 
       (evil-leader/set-key "re" 'evil-show-registers)
 


### PR DESCRIPTION
from commit 5fc80917be117039b620ed5e4e79aa1f62b9b4bf #2818

We should strive to be as vim-like as possible, non-default bindings
on core keys such as Y should be discouraged imo.

Let me know what you guys think.