### PR TITLE
Add back and fix evil-matchit for python-mode

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -31,7 +31,7 @@ This layer adds support for the Python language.
 - semantic mode is enabled
 - PEP8 compliant formatting via [[https://github.com/google/yapf][YAPF]]
 - Suppression of unused import with [[https://github.com/myint/autoflake][autoflake]]
-
+- Use the ~%~ key to jump between blocks with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 * Install
 
 ** Layer

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -17,8 +17,8 @@
     company-anaconda
     cython-mode
     eldoc
-    ;; evil-matchit
     evil-jumper
+    evil-matchit
     flycheck
     helm-cscope
     helm-pydoc
@@ -254,15 +254,8 @@
         (setq imenu-create-index-function
               #'spacemacs/python-imenu-create-index-python-or-semantic)))))
 
-;; Has bugs at the moment
-;; (defun python/post-init-evil-matchit ()
-;;   (use-package evil-matchit-python
-;;     :defer t
-;;     :init
-;;     (add-hook `python-mode-hook `turn-on-evil-matchit-mode)
-;;     :config
-;;     (plist-put evilmi-plugins 'python-mode '((evilmi-simple-get-tag evilmi-simple-jump)
-;;                                              (evilmi-python-get-tag evilmi-python-jump)))))
+(defun python/post-init-evil-matchit ()
+    (add-hook `python-mode-hook `turn-on-evil-matchit-mode))
 
 (defun python/post-init-flycheck ()
   (add-hook 'python-mode-hook 'flycheck-mode))


### PR DESCRIPTION
This reverts #3072 and applies some fixes to make it actually work properly. See https://github.com/syl20bnr/spacemacs/issues/3068#issuecomment-141844848

it is in action: 
![gifrecord_2015-09-20_225701](https://cloud.githubusercontent.com/assets/23088/9984744/5b71ae02-5feb-11e5-89c1-1b3fe756426e.gif)


@syl20bnr -- now that I configured it correctly -- you should be able to see the value -- use the following as a test: 

```python
def fib(n):
    if n < 0:
        raise ValueError("n must be positive")
    elif n == 1 or n == 2:
        return 1
    else:
        return fib(n - 1) + fib(n - 2)
```

