### PR TITLE
simplify the evil-matchit code in the ruby layer to make it simpler 

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -57,13 +57,7 @@
                        :suffix "")))))
 
 (defun ruby/post-init-evil-matchit ()
-  (use-package evil-matchit-ruby
-    :defer t
-    :init (add-hook `enh-ruby-mode-hook `turn-on-evil-matchit-mode)
-    :config
-    (progn
-      (plist-put evilmi-plugins 'enh-ruby-mode '((evilmi-simple-get-tag evilmi-simple-jump)
-                                                 (evilmi-ruby-get-tag evilmi-ruby-jump))))))
+  (add-hook `enh-ruby-mode-hook `turn-on-evil-matchit-mode))
 
 
 (defun ruby/post-init-flycheck ()


### PR DESCRIPTION
This simplifies the code to turn on evil-matchit for ruby. I used the following code to test it. 
Here is a screencast demo: 

![gifrecord_2015-09-21_002246](https://cloud.githubusercontent.com/assets/23088/9985278/1342ded8-5ff7-11e5-8390-9a621fb06d78.gif)

Here is my test code if you so choose to use it:

```ruby
def fib(n)
  if n < 0
    fail 'n must be positive'
  elsif n == 1 || n == 2
    return 1
  else
    fib(n - 1) + fib(n - 2)
  end
end
```