### PR TITLE
[python] Allow user to customize fill column

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -17,6 +17,8 @@
    - [[#testing][Testing]]
    - [[#refactoring][Refactoring]]
    - [[#other-python-commands][Other Python commands]]
+ - [[#configuration][Configuration]]
+   - [[#fill-column][Fill column]]
 
 * Description
 
@@ -167,3 +169,10 @@ Test commands (start with ~m t~ or ~m T~):
 | ~SPC m h H~ | open documentation in =firefox= using [pylookup][pylookup]                   |
 | ~SPC m v~   | activate a virtual environment with [[https://github.com/yyuu/pyenv][pyenv]]                                    |
 | ~SPC m V~   | activate a virtual environment with  [[https://github.com/jorgenschaefer/pyvenv][pyvenv]]                                  |
+* Configuration
+** Fill column
+If you want to customize the fill column value, use something like this inside the ~user-init~ function in your ~.spacemacs~:
+
+#+BEGIN_SRC elisp
+(setq python-fill-column 99)
+#+END_SRC

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -21,3 +21,6 @@
 
 (defvar python-test-runner 'nose
   "Test runner to use. Possible values are `nose' or `pytest'.")
+
+(defvar python-fill-column 79
+  "Fill column value for python buffers")

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -119,7 +119,7 @@
       (defun python-default ()
         (setq mode-name "Python"
               tab-width 4
-              fill-column 79
+              fill-column python-fill-column
               ;; auto-indent on colon doesn't work well with if statement
               electric-indent-chars (delq ?: electric-indent-chars))
         (annotate-pdb)


### PR DESCRIPTION
This does not work because the value is overridden in the python layer:

```
  (add-hook 'python-mode-hook (lambda ()
                                (interactive)
                                ;; FIXME: This is not working
                                ;; `SPC h d v' on `fill-column' says:
                                ;; Its value is 79
                                ;; Original value was 70
                                ;; Local in buffer foo.py; global value is 80
                                (set-fill-column 99)))
```

So, it would be great if we had a way to customize the fill column value for python mode.