### PR TITLE
Focus current file when opening project's neotree

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1506,7 +1506,9 @@ It will toggle the overlay under point or create an overlay of one character."
         (interactive)
         (if (neo-global--window-exists-p)
             (neotree-hide)
-          (neotree-find (projectile-project-root))))
+          (let ((origin-buffer-file-name (buffer-file-name)))
+            (neotree-find (projectile-project-root))
+            (neotree-find origin-buffer-file-name))))
 
       (defun spacemacs//neotree-key-bindings ()
         "Set the key bindings for a neotree buffer."


### PR DESCRIPTION
The `SPC p t` keybinding opens the neotree at the project root.
Currently the neotree only shows the root of the project, nothing is
expanded and no file is focused/selected. With this modification, the
neotree is still showing the project root, but with the current file
being focused/selected in the hierarchy (its path being expanded).

Signed-off-by: Fabien Dubosson <fabien.dubosson@gmail.com>