### PR TITLE
Unwrap flyspell hooks

### DIFF
--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -21,8 +21,8 @@
     :defer t
     :init
     (progn
-      (add-hook 'markdown-mode-hook '(lambda () (flyspell-mode 1)))
-      (add-hook 'text-mode-hook '(lambda () (flyspell-mode 1)))
+      (add-hook 'markdown-mode-hook 'flyspell-mode)
+      (add-hook 'text-mode-hook 'flyspell-mode)
       (spacemacs|add-toggle spelling-checking
         :status flyspell-mode
         :on (flyspell-mode)


### PR DESCRIPTION
The lambda makes it difficult to remove the hooks in user config.