### PR TITLE
better-defaults: Add backward-kill-word-or-region

### DIFF
--- a/layers/better-defaults/README.org
+++ b/layers/better-defaults/README.org
@@ -6,7 +6,8 @@
  - [[#description][Description]]
  - [[#install][Install]]
  - [[#functions][Functions]]
-     - [[#smart-move-beginning-of-line][smart-move-beginning-of-line]]
+   - [[#spacemacssmart-move-beginning-of-line][spacemacs/smart-move-beginning-of-line]]
+   - [[#spacemacsbackward-kill-word-or-region][spacemacs/backward-kill-word-or-region]]
  - [[#key-bindings][Key bindings]]
 
 * Description
@@ -31,15 +32,22 @@ To use this contribution add it to your =~/.spacemacs=
 
 * Functions
 
-** smart-move-beginning-of-line
+** spacemacs/smart-move-beginning-of-line
 
 Pressed one time, go to the first non-whitespace character of the line, pressed
 again, go to the beginning of the line.
+
+** spacemacs/backward-kill-word-or-region
+
+A combination of =kill-region= and =backward-kill-word=, depending on whether
+there is an active region. If there's an active region kill that. If not kill
+the preceding word.
 
 * Key bindings
 
 | Key Binding | Description                                                                      |
 |-------------+----------------------------------------------------------------------------------|
 | ~C-a~       | smart beginning of line                                                          |
+| ~C-w~       | backward kill word or region                                                     |
 | ~C-y~       | Automatically indenting after pasting. With prefix argument, paste text as it is |
 

--- a/layers/better-defaults/funcs.el
+++ b/layers/better-defaults/funcs.el
@@ -28,3 +28,12 @@ point reaches the beginning or end of the buffer, stop there."
     (back-to-indentation)
     (when (= orig-point (point))
       (move-beginning-of-line 1))))
+
+(defun spacemacs/backward-kill-word-or-region (&optional arg)
+  "Calls `kill-region' when a region is active and
+`backward-kill-word' otherwise. ARG is passed to
+`backward-kill-word' if no region is active."
+  (interactive "p")
+  (if (region-active-p)
+      (kill-region (region-beginning) (region-end))
+    (backward-kill-word arg)))

--- a/layers/better-defaults/keybindings.el
+++ b/layers/better-defaults/keybindings.el
@@ -11,3 +11,4 @@
 ;;; License: GPLv3
 
 (global-set-key (kbd "C-a") 'spacemacs/smart-move-beginning-of-line)
+(global-set-key (kbd "C-w") 'spacemacs/backward-kill-word-or-region)


### PR DESCRIPTION
This function merges the functionality of `evil-delete-backward-word` and
`kill-region`. Which is called depends on whether a region is active or
not. This is the perfect `C-w` binding (for me :))