### PR TITLE
core: Add v24.3 backport funcs

### DIFF
--- a/core/core-emacs-backports.el
+++ b/core/core-emacs-backports.el
@@ -36,4 +36,12 @@
       "Check whether STRING is empty."
       (string= string "")))
 
+(unless (fboundp 'with-eval-after-load)
+  (defmacro with-eval-after-load (file &rest body)
+    "Execute BODY after FILE is loaded.
+FILE is normally a feature name, but it can also be a file name,
+in case that file does not provide any feature."
+    (declare (indent 1) (debug t))
+    `(eval-after-load ,file (lambda () ,@body))))
+
 (provide 'core-emacs-backports)


### PR DESCRIPTION
Just adds `with-eval-after-load` for now

Ref #3116