### PR TITLE
Remove "symbol" from list of changed charsets

### DIFF
--- a/layers/chinese/config.el
+++ b/layers/chinese/config.el
@@ -22,7 +22,7 @@
 (defun spacemacs//set-monospaced-font (english chinese english-size chinese-size)
   (set-face-attribute 'default nil :font
                       (format   "%s:pixelsize=%d"  english english-size))
-  (dolist (charset '(kana han symbol cjk-misc bopomofo))
+  (dolist (charset '(kana han cjk-misc bopomofo))
     (set-fontset-font (frame-parameter nil 'font) charset
                       (font-spec :family chinese :size chinese-size))))
 


### PR DESCRIPTION
This prevents minor mode lighters from being displayed in the Chinese font. Since the new glyphs are often higher, separators of powerline do not match the new height.