### PR TITLE
Warn Linux users away from the "xemacs" package

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ favorite package manager.
 
 Install Emacs from the package manager of your favorite Linux distribution.
 
+You should install the "emacs" package, not the "xemacs" package.
+XEmacs is an old fork of Emacs. The X in its name is unrelated to X11.
+Both Emacs and XEmacs have graphical support.
+
 ### OS X
 
 The recommended version for OS X is [emacs-mac-port][]. It can be installed


### PR DESCRIPTION
XEmacs is packaged in many Linux distributions as "xemacs". Some may assume that "xemacs" and "emacs" have the same relationship as "gvim" and "vim", when in reality both packages have graphical support. Since I just had to correct this misunderstanding in someone, let's put it in the README to avoid it in the future.