### PR TITLE
Be obvious about which fork of Emacs to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ favorite package manager.
 
 Install Emacs from the package manager of your favorite Linux distribution.
 
+If your distro has both `emacs` and `xemacs`, you want `emacs`. The X has 
+nothing to do with graphical support, the reason is historical and both 
+versions have graphical support. Spacemacs only works with Emacs and not 
+XEmacs.
+
 ### OS X
 
 The recommended version for OS X is [emacs-mac-port][]. It can be installed


### PR DESCRIPTION
I am a vim user. When told to search my distro's repository for emacs, I just did `pacman -Ss emacs`, saw...

```
extra/emacs 24.5-2 [installed]
    The extensible, customizable, self-documenting real-time display editor
...
community/xemacs 21.5.33-6
    An highly customizable open source text editor and application development system forked from GNU Emacs
```

And figured this was like the `gvim` and `vim` situation. (`gvim` is `vim` + GTK, `vim` by itself is just a tty program)

I installed xemacs and nothing worked, so then I tried to move `.emacs.d` to `.xemacs` and still nothing worked, and then I discovered I was wrong and I actually needed `emacs` all along and yes `emacs` is a graphical application as well and not TTY...