### PR TITLE
Add contribution guidelines for github to show when opening issues/PRs 

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,16 @@
+The following is based off of the [Rails Contribution guidelines][].
+
+Spacemacs is a volunteer effort. We encourage you to pitch in. The community makes Spacemacs what it is. We have a few guidelines, which we ask all contributors to follow.
+
+- If you want to ask a usage question, be sure to read [our documentation][], as it may hold the answer. You should also reference the `README.org` of the relevant layer(s). If your question is not answered there, then feel free to ask on our [gitter chat][].
+- If you want to submit a Pull Request (PR), please read [our contribution guidelines][] before submitting. Also, make sure that your PR is against the `develop` branch, not `master`.
+- If you are opening an issue, consider seeing if the bug has been fixed on `develop`, and that you are up to date by doing `git pull --rebase`. If it is not fixed, please include the output of `SPC h d s` in your bug report. This will include the following: OS, Emacs version, Spacemacs version, Spacemacs branch(`master` or `develop`), as well as current HEAD revision, distribution (`spacemacs` or `spacemacs-base`), and what layers you are using. This will help us to help you better.
+
+Thanks! :heart: :heart: :heart:
+
+Spacemacs Team
+
+[Rails Contribution guidelines]: https://github.com/rails/rails/blob/master/CONTRIBUTING.md
+[our documentation]: doc/DOCUMENTATION.org
+[gitter chat]: https://gitter.im/syl20bnr/spacemacs
+[our contribution guidelines]: doc/CONTRIBUTE.org

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 |
 <b><a href="doc/DOCUMENTATION.org">documentation</a></b>
 |
-<b><a href="doc/CONTRIBUTE.org">contribute</a></b>
+<b><a href="doc/CONTRIBUTE.org">cont                                                       (spacemacs-0.104.0)ribute</a></b>
 |
 <b><a href="doc/DOCUMENTATION.org#achievements">achievements</a></b>
 |


### PR DESCRIPTION
We are adopting and properly attributing a modified version of the [Rails contribution guidelines](https://github.com/rails/rails/blob/master/CONTRIBUTING.md). Thanks to @bmag for his awesome words and I added more encouragement by pointing them to the gitter chat :) 

Fixes #3135 