### PR TITLE
evilify: Only modify map in evilified state

### DIFF
--- a/core/core-evilify-keymap.el
+++ b/core/core-evilify-keymap.el
@@ -104,7 +104,7 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
                    (wrapper (spacemacs//evilify-wrapper map map-symbol
                                                         map-value event
                                                         evil-value evil-event)))
-              (define-key map kbd-event wrapper)))
+              (evil-define-key 'evilified map kbd-event wrapper)))
           (when map-value
             (add-to-list 'pending-funcs (cons map-value event) 'append))
           (push event processed)


### PR DESCRIPTION
@syl20bnr I don't completely understand all that's happening in the evilify stuff yet, but I think you want to always use `evil-define-key` so that the binding only applies in the evilified state. Otherwise, the magit-status-map for example in emacs state is only partially evilified. 

See #3078