### PR TITLE
Enable flyspell-popup

### DIFF
--- a/layers/spell-checking/config.el
+++ b/layers/spell-checking/config.el
@@ -15,3 +15,6 @@
 ;; Command Prefixes
 
 (spacemacs/declare-prefix "S" "spelling")
+
+(defvar enable-flyspell-auto-popup nil
+  "If not nil, show speeling suggestions in popups.")

--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -13,6 +13,7 @@
 (setq spell-checking-packages
   '(
     flyspell
+    flyspell-popup
     helm-flyspell
     ))
 
@@ -38,7 +39,17 @@
       (flyspell-prog-mode)
       (spacemacs|diminish flyspell-mode " Ⓢ" " S"))))
 
+(defun spell-checking/init-flyspell-popup ()
+  (use-package flyspell-popup
+    :commands (flyspell-popup-correct)
+    :init
+    (progn
+      (add-hook 'flyspell-mode-hook #'flyspell-popup-auto-correct-mode)
+      (evil-leader/set-key
+        "SC" 'flyspell-popup-correct))))
+
 (defun spell-checking/init-helm-flyspell ()
   (use-package helm-flyspell
     :commands helm-flyspell-correct
     :init (evil-leader/set-key "Sc" 'helm-flyspell-correct)))
+


### PR DESCRIPTION
Wondering is this might be useful to add to the spell checking layer. 

It does not effect the current setup and adds support for auto suggestion for word at point, or `SPC SC` (to complement `SPC Sc` with helm) for misspelled word before point. 

I guess the auto spell suggestions feature is really more useful, as the second one duplicates what can be done with helm. 

Feature disabled by default in config.el.