### PR TITLE
Allow ranger to replace usage of dired.

### DIFF
--- a/layers/+tools/ranger/config.el
+++ b/layers/+tools/ranger/config.el
@@ -1,0 +1,16 @@
+;;; config.el --- shell configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar ranger-replace-dired nil
+  "Replace instances of dired loading with `deer'")

--- a/layers/+tools/ranger/packages.el
+++ b/layers/+tools/ranger/packages.el
@@ -16,6 +16,7 @@
 (defun ranger/init-ranger ()
   (use-package ranger
     :defer t
+    :commands (ranger deer)
     :init
     (progn
       (evil-leader/set-key
@@ -26,6 +27,8 @@
       ;; set up image-dired to allow picture resize
       (setq image-dired-dir (concat spacemacs-cache-directory "image-dir"))
       (unless (file-directory-p image-dired-dir)
-        (make-directory image-dired-dir)))
+        (make-directory image-dired-dir))
+      (when ranger-replace-dired
+        (add-hook 'dired-mode-hook 'deer)))
     :config
     (define-key ranger-mode-map (kbd "-") 'ranger-up-directory)))


### PR DESCRIPTION
Setting config option to override dired loading with `deer`.  