### PR TITLE
Improve keybindings for text-region counting.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2051,6 +2051,7 @@ Text related commands (start with ~x~):
     | ~SPC x a =~ | align region at =                                             |
     | ~SPC x a &~ | align region at &                                             |
     | ~SPC x a ¦~ | align region at ¦                                             |
+    | ~SPC x c~   | count the number of chars/words/lines in the selection region |
     | ~SPC x d w~ | delete trailing whitespaces                                   |
     | ~SPC x g l~ | set languages used by translate commands                      |
     | ~SPC x g t~ | translate current word using Google Translate                 |
@@ -2062,8 +2063,7 @@ Text related commands (start with ~x~):
     | ~SPC x t c~ | swap (transpose) the current character with the previous one  |
     | ~SPC x t w~ | swap (transpose) the current word with the previous one       |
     | ~SPC x t l~ | swap (transpose) the current line with the previous one       |
-    | ~SPC x w c~ | count the number of words in the selection region             |
-    | ~SPC x w C~ | count the number of occurrences per word in the select region |
+    | ~SPC x w c~ | count the number of occurrences per word in the select region |
     | ~SPC x w d~ | show dictionary entry of word from wordnik.com                |
 
 *** Searching and inserting Unicode characters

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -330,6 +330,8 @@ Ensure that helm is required before calling FUNC."
   "w/"  'split-window-right
   "w="  'balance-windows)
 ;; text -----------------------------------------------------------------------
+(defalias 'count-region 'count-words-region)
+
 (evil-leader/set-key
   "xaa" 'align
   "xar" 'spacemacs/align-repeat
@@ -343,6 +345,7 @@ Ensure that helm is required before calling FUNC."
   "xa|" 'spacemacs/align-repeat-bar
   "xa(" 'spacemacs/align-repeat-left-paren
   "xa)" 'spacemacs/align-repeat-right-paren
+  "xc"  'count-region
   "xdw" 'delete-trailing-whitespace
   "xls" 'spacemacs/sort-lines
   "xlu" 'spacemacs/uniquify-lines
@@ -351,8 +354,7 @@ Ensure that helm is required before calling FUNC."
   "xtw" 'transpose-words
   "xU"  'upcase-region
   "xu"  'downcase-region
-  "xwC" 'spacemacs/count-words-analysis
-  "xwc" 'count-words-region)
+  "xwc" 'spacemacs/count-words-analysis)
 ;; google translate -----------------------------------------------------------
 (evil-leader/set-key
   "xgl" 'spacemacs/set-google-translate-languages)


### PR DESCRIPTION
Emacs provides a `count-words-region' which is badly named as it counts
not only words, but also characters and lines. The current keybinding
for this function `SPC x w c' implies it's referring to words only. The
new mapping `SPC x c` is more coherent since it means counting text,
whether it is characters, words or lines. An alias `count-region` is
created to be less confusing in which-key description.

`SPC x w c` being free, `spacemacs/count-words-analysis` is remapped to
it instead of `SPC x w C` to save one keystroke.