### PR TITLE
Use helm or ibuffer to provide :ls

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -546,6 +546,10 @@ Removes the automatic guessing of the initial value based on thing at point. "
       ;; helm-locate uses es (from everything on windows, which doesnt like fuzzy)
       (setq helm-locate-fuzzy-match (executable-find "locate"))
 
+      ;; Use helm to provide :ls, unless ibuffer is used
+      (unless (configuration-layer/package-usedp 'ibuffer)
+        (evil-ex-define-cmd "buffers" 'helm-buffers-list))
+
       (defun spacemacs//helm-do-grep-region-or-symbol (&optional targs use-region-or-symbol-p)
         "Version of `helm-do-grep' with a default input."
         (interactive)

--- a/layers/ibuffer/packages.el
+++ b/layers/ibuffer/packages.el
@@ -27,7 +27,10 @@
         "Group buffers by modes."
         (when (eq 'modes ibuffer-group-buffers-by)
           (spacemacs//ibuffer-create-buffs-group)))
-      (add-hook 'ibuffer-hook 'spacemacs//ibuffer-group-by-modes))
+      (add-hook 'ibuffer-hook 'spacemacs//ibuffer-group-by-modes)
+
+      ;; Use ibuffer to provide :ls
+      (evil-ex-define-cmd "buffers" 'ibuffer))
     :config
     (spacemacs|evilify-map ibuffer-mode-map
       :mode ibuffer-mode)))


### PR DESCRIPTION
Use helm-buffers-list by default, or ibuffer if that layer is enabled.

Fixes #3111.