### PR TITLE
Improve count-words-analysis output

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -815,7 +815,7 @@ first element is the symbol `image')."
   "Count how many times each word is used in the region.
  Punctuation is ignored."
   (interactive "r")
-  (let (words)
+  (let (words alist_words_compare (formated ""))
     (save-excursion
       (goto-char start)
       (while (re-search-forward "\\w+" end t)
@@ -824,8 +824,26 @@ first element is the symbol `image')."
           (if cell
               (setcdr cell (1+ (cdr cell)))
             (setq words (cons (cons word 1) words))))))
+    (defun alist_words_compare (a b)
+      "Compare elements from an associative list of words count.
+Compare them on count first,and in case of tie sort them alphabetically."
+      (let ((a_key (car a))
+            (a_val (cdr a))
+            (b_key (car b))
+            (b_val (cdr b)))
+        (if (eq a_val b_val)
+            (string-lessp a_key b_key)
+          (> a_val b_val))))
+    (setq words (cl-sort words 'alist_words_compare))
+    (while words
+      (let* ((word (pop words))
+             (name (car word))
+             (count (cdr word)))
+        (setq formated (concat formated (format "[%s: %d], " name count)))))
     (when (interactive-p)
-      (message "%S" words))
+      (if (> (length formated) 2)
+          (message (substring formated 0 -2))
+        (message "No words.")))
     words))
 
 ;; byte compile elisp files


### PR DESCRIPTION
The `spacemacs/count-words-analysis' function displays results with the
default elisp formatting of associative list. This change improves it by
changing the format to a more human-readable form, and also by ordering
results by frequencies first, and then alphabetically in case of tie.