### PR TITLE
Forcing jsx content type in react mode

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -72,6 +72,8 @@
   (defun spacemacs//setup-react-mode ()
     "Adjust web-mode to accommodate react-mode"
     (emmet-mode 0)
+    ;; Force jsx content type
+    (web-mode-set-content-type "jsx")
     ;; Why do we do this ?
     (defadvice web-mode-highlight-part (around tweak-jsx activate)
       (let ((web-mode-enable-part-face nil))


### PR DESCRIPTION
PR for https://github.com/syl20bnr/spacemacs/issues/3163

web-mode needs jsx as content type declared for indentation to work. The only ways to do this is with having `.jsx` as file ending or the deprecated pragma park. 

Since react mode always assumes that the user works on react, we can force the jsx content type without problems. 