### PR TITLE
Replace `eval-after-load` with `with-eval-after-load`.

### DIFF
--- a/core/core-evilified-state.el
+++ b/core/core-evilified-state.el
@@ -175,7 +175,7 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
                (spacemacs/evilify-configure-default-state ',mode)))))
     (if (null eval-after-load)
         `(,@body)
-      `(eval-after-load ',eval-after-load '(,@body)))))
+      `(with-eval-after-load ',eval-after-load (,@body)))))
 
 (defun spacemacs/evilify-configure-default-state (mode)
   "Configure default state for the passed mode."

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -612,7 +612,7 @@ unnecessary to create the prefix, but it will give your new prefix a name that
 key-discovery tools can use (e.g., which-key).
 
 There is much more to say about bindings keys, but these are the basics. Keys
-can be bound in your =~/.spacemacs= file or in individual layers. 
+can be bound in your =~/.spacemacs= file or in individual layers.
 
 *** Custom variables
 Custom variables configuration from =M-x customize-group= which are

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -193,31 +193,22 @@ some variables or call some functions. This is trivial with =require=, because
 it loads immediately, but it can be tricky with autoloading, because the
 configuration code must also be deferred.
 
-Emacs offers =eval-after-load= for this purpose. It can be used like this:
+Emacs offers =with-eval-after-load= for this purpose. It can be used like this:
 
 #+begin_src emacs-lisp
-  (eval-after-load 'helm
-    '(progn
+  (with-eval-after-load 'helm
        ;; Code
-       ))
+       )
 #+end_src
 
 This arranges for the relevant code to be executed after Helm is loaded (using
 either =require= or an autoload), or if Helm is already loaded, the code is
 executed immediately.
 
-Since =eval-after-load= is a function and not a macro, its argument must be
-quoted. Also, it only accepts one argument, so it's not unusual to have to use
-=progn= as a code block.
+Since =with-eval-after-load= is a macro and not a function, its argument does
+not have to be quoted.
 
-The new macro =with-eval-after-load= in Emacs 24.4 fixes these drawbacks.
-However, note that Spacemacs still supports Emacs 24.3.
-
-#+begin_src emacs-lisp
-  (with-eval-after-load 'helm
-    ;; Code
-    )
-#+end_src
+**Note**: =with-eval-after-load= is backported for those still on Emacs 24.3
 
 ** Use-package
 For /end users/ who are trying to put together an efficient Emacs configuration,
@@ -256,7 +247,7 @@ This form includes code to execute before and after Helm is loaded. The =:init=
 section can be executed immediately, but since Helm is deferred, the =:config=
 section is not executed until after loading, if ever. It is essentially
 equivalent to simply running the =:init= block, and then adding the =:config=
-block in an =eval-after-load=.
+block in an =with-eval-after-load=.
 
 #+begin_src emacs-lisp
   (use-package helm

--- a/layers/+config-files/ansible/packages.el
+++ b/layers/+config-files/ansible/packages.el
@@ -16,8 +16,8 @@
   (use-package ansible
     :defer t
     :init (progn
-            (eval-after-load 'yaml-mode
-              '(add-hook 'yaml-mode-hook 'ansible/ansible-maybe-enable))
+            (with-eval-after-load 'yaml-mode
+              (add-hook 'yaml-mode-hook 'ansible/ansible-maybe-enable))
 
             ;; ansible-mode requires ac-user-dictionary-files. If the
             ;; config is using company-mode this variable will not be
@@ -31,5 +31,5 @@
 (defun ansible/init-ansible-doc ()
   (use-package ansible-doc
     :defer t
-    :init (eval-after-load 'yaml-mode
-            '(add-hook 'yaml-mode-hook 'ansible/ansible-doc-maybe-enable))))
+    :init (with-eval-after-load 'yaml-mode
+            (add-hook 'yaml-mode-hook 'ansible/ansible-doc-maybe-enable))))

--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -143,8 +143,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; The C-d rebinding that most shell-like buffers inherit from
 ;; comint-mode assumes non-evil configuration with its
 ;; `comint-delchar-or-maybe-eof' function, so we disable it
-(eval-after-load 'comint
-  '(define-key comint-mode-map (kbd "C-d") nil))
+(with-eval-after-load 'comint
+  (define-key comint-mode-map (kbd "C-d") nil))
 
 ;; ---------------------------------------------------------------------------
 ;; UI

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -20,10 +20,9 @@
 
 ;; replace `dired-goto-file' with `helm-find-files', since `helm-find-files'
 ;; can do the same thing and with fuzzy matching and other features.
-(eval-after-load 'dired
-  '(progn
-     (evil-define-key 'normal dired-mode-map "J" 'spacemacs/helm-find-files)
-     (define-key dired-mode-map "j" 'spacemacs/helm-find-files)))
+(with-eval-after-load 'dired
+  (evil-define-key 'normal dired-mode-map "J" 'spacemacs/helm-find-files)
+  (define-key dired-mode-map "j" 'spacemacs/helm-find-files))
 
 ;; alternate binding to search next occurrence with isearch without
 ;; exiting isearch
@@ -357,10 +356,9 @@ Ensure that helm is required before calling FUNC."
 (evil-leader/set-key
   "xgl" 'spacemacs/set-google-translate-languages)
 ;; shell ----------------------------------------------------------------------
-(eval-after-load "shell"
-  '(progn
-    (evil-define-key 'insert comint-mode-map [up] 'comint-previous-input)
-    (evil-define-key 'insert comint-mode-map [down] 'comint-next-input)))
+(with-eval-after-load 'shell
+  (evil-define-key 'insert comint-mode-map [up] 'comint-previous-input)
+  (evil-define-key 'insert comint-mode-map [down] 'comint-next-input))
 
 ;; ---------------------------------------------------------------------------
 ;; Micro-states

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -70,20 +70,20 @@
     (progn
       ;; Minor modes abbrev --------------------------------------------------------
       (when (display-graphic-p)
-        (eval-after-load "eproject"
-          '(diminish 'eproject-mode " eⓅ"))
-        (eval-after-load "flymake"
-          '(diminish 'flymake-mode " Ⓕ2")))
+        (with-eval-after-load 'eproject
+          (diminish 'eproject-mode " eⓅ"))
+        (with-eval-after-load 'flymake
+          (diminish 'flymake-mode " Ⓕ2")))
       ;; Minor Mode (hidden) ------------------------------------------------------
-      (eval-after-load 'elisp-slime-nav
-        '(diminish 'elisp-slime-nav-mode))
-      (eval-after-load "hi-lock"
-        '(diminish 'hi-lock-mode))
-      (eval-after-load "abbrev"
-        '(diminish 'abbrev-mode))
-      (eval-after-load "subword"
-        '(when (eval-when-compile (version< "24.3.1" emacs-version))
-           (diminish 'subword-mode))))))
+      (with-eval-after-load 'elisp-slime-nav
+        (diminish 'elisp-slime-nav-mode))
+      (with-eval-after-load 'hi-lock
+        (diminish 'hi-lock-mode))
+      (with-eval-after-load 'abbrev
+        (diminish 'abbrev-mode))
+      (with-eval-after-load 'subword
+        (when (eval-when-compile (version< "24.3.1" emacs-version))
+          (diminish 'subword-mode))))))
 
 (defun spacemacs-base/init-eldoc ()
   (use-package eldoc
@@ -412,7 +412,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
         '(progn
            ;; (define-key compilation-mode-map (kbd dotspacemacs-leader-key) nil)
            (define-key compilation-mode-map (kbd "h") nil)))
-      ;; (eval-after-load "dired" '(define-key dired-mode-map (kbd
+      ;; (with-eval-after-load "dired" (define-key dired-mode-map (kbd
       ;;   dotspacemacs-leader-key) nil))
       ;; evil-leader does not get activated in existing buffers, so we have to
       ;; force it here
@@ -473,8 +473,8 @@ Example: (evil-map visual \"<\" \"<gv\")"
     :config
     (progn
       (when (and dotspacemacs-helm-resize
-                  (or (eq dotspacemacs-helm-position 'bottom)
-                      (eq dotspacemacs-helm-position 'top)))
+                 (or (eq dotspacemacs-helm-position 'bottom)
+                     (eq dotspacemacs-helm-position 'top)))
         (setq helm-autoresize-min-height 10)
         (helm-autoresize-mode 1))
 
@@ -508,14 +508,14 @@ Example: (evil-map visual \"<\" \"<gv\")"
 Removes the automatic guessing of the initial value based on thing at point. "
         (interactive "P")
         (let* ((hist          (and arg helm-ff-history (helm-find-files-history)))
-                (default-input hist )
-                (input         (cond ((and (eq major-mode 'dired-mode) default-input)
-                                    (file-name-directory default-input))
+               (default-input hist )
+               (input         (cond ((and (eq major-mode 'dired-mode) default-input)
+                                     (file-name-directory default-input))
                                     ((and (not (string= default-input ""))
-                                            default-input))
+                                          default-input))
                                     (t (expand-file-name (helm-current-directory))))))
-            (set-text-properties 0 (length input) nil input)
-            (helm-find-files-1 input ))))
+          (set-text-properties 0 (length input) nil input)
+          (helm-find-files-1 input ))))
     :init
     (progn
       (setq helm-prevent-escaping-from-minibuffer t
@@ -558,23 +558,23 @@ Removes the automatic guessing of the initial value based on thing at point. "
              ((symbol-function 'helm-do-grep-1)
               (lambda (targets &optional recurse zgrep exts default-input region-or-symbol-p)
                 (let* ((new-input (when region-or-symbol-p
-                                   (if (region-active-p)
-                                       (buffer-substring-no-properties
-                                        (region-beginning) (region-end))
-                                     (thing-at-point 'symbol t))))
-                      (quoted-input (when new-input (rxt-quote-pcre new-input))))
+                                    (if (region-active-p)
+                                        (buffer-substring-no-properties
+                                         (region-beginning) (region-end))
+                                      (thing-at-point 'symbol t))))
+                       (quoted-input (when new-input (rxt-quote-pcre new-input))))
                   (this-fn targets recurse zgrep exts default-input quoted-input))))
              (preselection (or (dired-get-filename nil t)
                                (buffer-file-name (current-buffer))))
              (targets   (if targs
                             targs
                           (helm-read-file-name
-                          "Search in file(s): "
-                          :marked-candidates t
-                          :preselect (and helm-do-grep-preselect-candidate
-                                          (if helm-ff-transformer-show-only-basename
-                                              (helm-basename preselection)
-                                            preselection))))))
+                           "Search in file(s): "
+                           :marked-candidates t
+                           :preselect (and helm-do-grep-preselect-candidate
+                                           (if helm-ff-transformer-show-only-basename
+                                               (helm-basename preselection)
+                                             preselection))))))
           (helm-do-grep-1 targets nil nil nil nil use-region-or-symbol-p)))
 
       (defun spacemacs/helm-file-do-grep ()
@@ -620,9 +620,9 @@ Removes the automatic guessing of the initial value based on thing at point. "
         (interactive)
         (if (get-buffer "*helm ag results*")
             (switch-to-buffer-other-window "*helm ag results*")
-            (if (get-buffer "*hgrep*")
-                (switch-to-buffer-other-window "*hgrep*")
-                (message "No previous search buffer found"))))
+          (if (get-buffer "*hgrep*")
+              (switch-to-buffer-other-window "*hgrep*")
+            (message "No previous search buffer found"))))
 
       ;; use helm by default for M-x
       (unless (configuration-layer/package-usedp 'smex)
@@ -849,8 +849,8 @@ ARG non nil means that the editing style is `vim'."
       (define-key helm-map (kbd "TAB") 'helm-execute-persistent-action)
       (define-key helm-map (kbd "C-z") 'helm-select-action)
 
-      (eval-after-load "helm-mode" ; required
-        '(spacemacs|hide-lighter helm-mode)))))
+      (with-eval-after-load 'helm-mode ; required
+        (spacemacs|hide-lighter helm-mode)))))
 
 (defun spacemacs-base/init-helm-descbinds ()
   (use-package helm-descbinds

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -95,14 +95,13 @@
     :init
     (progn
       (define-key spacemacs-mode-map "o" 'spacemacs/ace-buffer-links)
-      (eval-after-load "info"
-        '(define-key Info-mode-map "o" 'ace-link-info))
-      (eval-after-load "help-mode"
-        '(define-key help-mode-map "o" 'ace-link-help))
-      (eval-after-load "eww"
-        '(progn
-           (define-key eww-link-keymap "o" 'ace-link-eww)
-           (define-key eww-mode-map "o" 'ace-link-eww))))
+      (with-eval-after-load 'info
+        (define-key Info-mode-map "o" 'ace-link-info))
+      (with-eval-after-load 'help-mode
+        (define-key help-mode-map "o" 'ace-link-help))
+      (with-eval-after-load 'eww
+        (define-key eww-link-keymap "o" 'ace-link-eww)
+        (define-key eww-mode-map "o" 'ace-link-eww)))
     :config
     (progn
       (defvar spacemacs--link-pattern "~?/.+\\|\s\\[")
@@ -118,10 +117,10 @@
         "Ace jump to links in `spacemacs' buffer."
         (interactive)
         (let ((res (avy--with-avy-keys spacemacs/ace-buffer-links
-                    (avy--process
-                        (spacemacs//collect-spacemacs-buffer-links)
-                        #'avy--overlay-pre))))
-            (when res
+                                       (avy--process
+                                        (spacemacs//collect-spacemacs-buffer-links)
+                                        #'avy--overlay-pre))))
+          (when res
             (goto-char (1+ res))
             (widget-button-press (point))))))))
 
@@ -306,12 +305,11 @@
             (ahs-backward)
             )))
 
-      (eval-after-load 'evil
-        '(progn
-           (define-key evil-motion-state-map (kbd "*")
-             'spacemacs/enter-ahs-forward)
-           (define-key evil-motion-state-map (kbd "#")
-             'spacemacs/enter-ahs-backward)))
+      (with-eval-after-load 'evil
+        (define-key evil-motion-state-map (kbd "*")
+          'spacemacs/enter-ahs-forward)
+        (define-key evil-motion-state-map (kbd "#")
+          'spacemacs/enter-ahs-backward))
 
       (defun spacemacs/symbol-highlight ()
         "Highlight the symbol under point with `auto-highlight-symbol'."
@@ -954,9 +952,9 @@ For instance pass En as source for english."
                    ((symbol-function 'thing-at-point)
                     (lambda (thing)
                       (let ((res (if (region-active-p)
-                          (buffer-substring-no-properties
-                           (region-beginning) (region-end))
-                          (this-fn thing))))
+                                     (buffer-substring-no-properties
+                                      (region-beginning) (region-end))
+                                   (this-fn thing))))
                         (when res (rxt-quote-pcre res))))))
           (funcall func dir)))
 
@@ -976,7 +974,7 @@ For instance pass En as source for english."
                       (if (fboundp func)
                           func
                         (intern (format "%s-%s"  base x))))))
-                     tools)
+              tools)
            (t 'helm-do-grep))))
 
       ;; Search in current file ----------------------------------------------
@@ -1170,10 +1168,10 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
 are used as default input."
         (interactive)
         (let ((projectile-require-project-root nil))
-         (call-interactively
-          (spacemacs//helm-do-search-find-tool "helm-project-do"
-                                               dotspacemacs-search-tools
-                                               default-inputp))))
+          (call-interactively
+           (spacemacs//helm-do-search-find-tool "helm-project-do"
+                                                dotspacemacs-search-tools
+                                                default-inputp))))
 
       (defun spacemacs/helm-project-smart-do-search-region-or-symbol ()
         "Search in current project using `dotspacemacs-search-tools' with
@@ -1429,8 +1427,8 @@ It will toggle the overlay under point or create an overlay of one character."
     :defer t
     :init
     (progn
-      (eval-after-load 'info
-        '(require 'info+))
+      (with-eval-after-load 'info
+        (require 'info+))
       (setq Info-fontify-angle-bracketed-flag nil))))
 
 (defun spacemacs/init-leuven-theme ()

--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -6,18 +6,18 @@
 
 ** Table of Contents                                                  :TOC@4:
  - [[#react-contribution-layer-for-spacemacs][React contribution layer for Spacemacs]]
-     - [[#description][Description]]
-         - [[#features][Features]]
-     - [[#todo-install][TODO Install]]
-     - [[#optional-configuration][Optional Configuration]]
+   - [[#description][Description]]
+     - [[#features][Features]]
+   - [[#install][Install]]
+   - [[#optional-configuration][Optional Configuration]]
  - [[#key-bindings][Key Bindings]]
-     - [[#js2-mode][js2-mode]]
-     - [[#folding-js2-mode][Folding (js2-mode)]]
-     - [[#refactoring-js2-refactor][Refactoring (js2-refactor)]]
-     - [[#formatting-web-beautify][Formatting (web-beautify)]]
-         - [[#documentation-js-doc][Documentation (js-doc)]]
-     - [[#auto-complete-and-documentation-tern][Auto-complete and documentation (tern)]]
-     - [[#json][JSON]]
+   - [[#js2-mode][js2-mode]]
+   - [[#folding-js2-mode][Folding (js2-mode)]]
+   - [[#refactoring-js2-refactor][Refactoring (js2-refactor)]]
+   - [[#formatting-web-beautify][Formatting (web-beautify)]]
+     - [[#documentation-js-doc][Documentation (js-doc)]]
+   - [[#auto-complete-and-documentation-tern][Auto-complete and documentation (tern)]]
+   - [[#json][JSON]]
 
 ** Description
 

--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -128,13 +128,13 @@
 
 (defun erc/init-erc-yt ()
   (use-package erc-yt
-    :init (eval-after-load 'erc '(add-to-list 'erc-modules 'youtube))))
+    :init (with-eval-after-load 'erc (add-to-list 'erc-modules 'youtube))))
 
 (defun erc/init-erc-view-log ()
   (use-package erc-view-log
     :init
     (progn
-      (eval-after-load 'erc '(add-to-list 'erc-modules 'log))
+      (with-eval-after-load 'erc (add-to-list 'erc-modules 'log))
       (setq erc-log-channels-directory
             (expand-file-name
              (concat spacemacs-cache-directory
@@ -172,6 +172,6 @@
 
 (defun erc/init-erc-image ()
   (use-package erc-image
-    :init (eval-after-load 'erc '(add-to-list 'erc-modules 'image))))
+    :init (with-eval-after-load 'erc (add-to-list 'erc-modules 'image))))
 
 (defun erc/init-erc-terminal-notifier ())

--- a/layers/+lang/agda/extensions.el
+++ b/layers/+lang/agda/extensions.el
@@ -74,6 +74,6 @@
         "mxq" 'agda2-quit
         "mxr" 'agda2-restart)
 
-      (eval-after-load 'golden-ratio
-        '(add-to-list 'golden-ratio-exclude-buffer-names
-                      "*Agda information*")))))
+      (with-eval-after-load 'golden-ratio
+        (add-to-list 'golden-ratio-exclude-buffer-names
+                     "*Agda information*")))))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -37,8 +37,8 @@
     :config
     (progn
       ;; add support for golden-ratio
-      (eval-after-load 'golden-ratio
-        '(push 'cider-popup-buffer-quit-function golden-ratio-extra-commands))
+      (with-eval-after-load 'golden-ratio
+        (push 'cider-popup-buffer-quit-function golden-ratio-extra-commands))
       ;; add support for evil
       (push 'cider-stacktrace-mode evil-motion-state-modes)
       (push 'cider-popup-buffer-mode evil-motion-state-modes)
@@ -289,8 +289,8 @@ If called with a prefix argument, uses the other-window instead."
         (evil-set-jump)))))
 
 (defun clojure/init-cider-eval-sexp-fu ()
-  (eval-after-load 'eval-sexp-fu
-    '(require 'cider-eval-sexp-fu)))
+  (with-eval-after-load 'eval-sexp-fu
+    (require 'cider-eval-sexp-fu)))
 
 (defun clojure/init-clj-refactor ()
   (use-package clj-refactor

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -34,5 +34,5 @@
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun d/post-init-company ()
     ;; Need to convince company that this C-derived mode is a code mode.
-    (eval-after-load 'company-dabbrev-code '(push 'd-mode company-dabbrev-code-modes))
+    (with-eval-after-load 'company-dabbrev-code (push 'd-mode company-dabbrev-code-modes))
     (spacemacs|add-company-hook d-mode)))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -111,8 +111,8 @@
 
 (defun emacs-lisp/post-init-semantic ()
   (semantic/enable-semantic-mode 'emacs-lisp-mode)
-  (eval-after-load 'semantic
-    '(semantic-default-elisp-setup)))
+  (with-eval-after-load 'semantic
+    (semantic-default-elisp-setup)))
 
 (defun emacs-lisp/post-init-srefactor ()
   (add-hook 'emacs-lisp-mode-hook 'spacemacs/lazy-load-srefactor)

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -85,43 +85,42 @@ not play nicely with autoloads"
       (push '(company-R-args company-R-objects) company-backends-ess-mode)))
 
   ;; R --------------------------------------------------------------------------
-  (eval-after-load "ess-site"
-    '(progn
-       (add-to-list 'auto-mode-alist '("\\.R$" . R-mode))
-       ;; Follow Hadley Wickham's R style guide
-       (setq ess-first-continued-statement-offset 2
-             ess-continued-statement-offset 0
-             ess-expression-offset 2
-             ess-nuke-trailing-whitespace-p t
-             ess-default-style 'DEFAULT)
-       (evil-leader/set-key-for-mode 'ess-mode
-         "msi" 'R
-         ;; noweb
-         "mcC" 'ess-eval-chunk-and-go
-         "mcc" 'ess-eval-chunk
-         "mcd" 'ess-eval-chunk-and-step
-         "mcm" 'ess-noweb-mark-chunk
-         "mcN" 'ess-noweb-previous-chunk
-         "mcn" 'ess-noweb-next-chunk
-         ;; helpers
-         "mhd" 'ess-R-dv-pprint
-         "mhi" 'ess-R-object-popup
-         "mht" 'ess-R-dv-ctable
-         ;; REPL
-         "msB" 'ess-eval-buffer-and-go
-         "msb" 'ess-eval-buffer
-         "msD" 'ess-eval-function-or-paragraph-and-step
-         "msd" 'ess-eval-region-or-line-and-step
-         "msL" 'ess-eval-line-and-go
-         "msl" 'ess-eval-line
-         "msR" 'ess-eval-region-and-go
-         "msr" 'ess-eval-region
-         "msT" 'ess-eval-function-and-go
-         "mst" 'ess-eval-function
-         )
-       (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
-       (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
-       (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input))))
+  (with-eval-after-load 'ess-site
+    (add-to-list 'auto-mode-alist '("\\.R$" . R-mode))
+    ;; Follow Hadley Wickham's R style guide
+    (setq ess-first-continued-statement-offset 2
+          ess-continued-statement-offset 0
+          ess-expression-offset 2
+          ess-nuke-trailing-whitespace-p t
+          ess-default-style 'DEFAULT)
+    (evil-leader/set-key-for-mode 'ess-mode
+      "msi" 'R
+      ;; noweb
+      "mcC" 'ess-eval-chunk-and-go
+      "mcc" 'ess-eval-chunk
+      "mcd" 'ess-eval-chunk-and-step
+      "mcm" 'ess-noweb-mark-chunk
+      "mcN" 'ess-noweb-previous-chunk
+      "mcn" 'ess-noweb-next-chunk
+      ;; helpers
+      "mhd" 'ess-R-dv-pprint
+      "mhi" 'ess-R-object-popup
+      "mht" 'ess-R-dv-ctable
+      ;; REPL
+      "msB" 'ess-eval-buffer-and-go
+      "msb" 'ess-eval-buffer
+      "msD" 'ess-eval-function-or-paragraph-and-step
+      "msd" 'ess-eval-region-or-line-and-step
+      "msL" 'ess-eval-line-and-go
+      "msl" 'ess-eval-line
+      "msR" 'ess-eval-region-and-go
+      "msr" 'ess-eval-region
+      "msT" 'ess-eval-function-and-go
+      "mst" 'ess-eval-function
+      )
+    (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
+    (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
+    (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)))
 
 (defun ess/init-ess-R-data-view ())
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -165,31 +165,30 @@
           "mgg"  'haskell-mode-goto-loc))
 
       ;; Useful to have these keybindings for .cabal files, too.
-      (eval-after-load 'haskell-cabal-mode-map
-        '(define-key haskell-cabal-mode-map
-           [?\C-c ?\C-z] 'haskell-interactive-switch))))
+      (with-eval-after-load 'haskell-cabal-mode-map
+        (define-key haskell-cabal-mode-map
+          [?\C-c ?\C-z] 'haskell-interactive-switch))))
 
 
-  (eval-after-load 'haskell-indentation
-    '(progn
-       ;; Show indentation guides in insert or emacs state only.
-       (defun spacemacs//haskell-indentation-show-guides ()
-         "Show visual indentation guides."
-         (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
-           (haskell-indentation-enable-show-indentations)))
+  (with-eval-after-load 'haskell-indentation
+    ;; Show indentation guides in insert or emacs state only.
+    (defun spacemacs//haskell-indentation-show-guides ()
+      "Show visual indentation guides."
+      (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
+        (haskell-indentation-enable-show-indentations)))
 
-       (defun spacemacs//haskell-indentation-hide-guides ()
-         "Hide visual indentation guides."
-         (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
-           (haskell-indentation-disable-show-indentations)))
+    (defun spacemacs//haskell-indentation-hide-guides ()
+      "Hide visual indentation guides."
+      (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
+        (haskell-indentation-disable-show-indentations)))
 
-       ;; first entry in normal state
-       (add-hook 'evil-normal-state-entry-hook 'spacemacs//haskell-indentation-hide-guides)
+    ;; first entry in normal state
+    (add-hook 'evil-normal-state-entry-hook 'spacemacs//haskell-indentation-hide-guides)
 
-       (add-hook 'evil-insert-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-       (add-hook 'evil-emacs-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-       (add-hook 'evil-insert-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)
-       (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides))))
+    (add-hook 'evil-insert-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
+    (add-hook 'evil-emacs-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
+    (add-hook 'evil-insert-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)
+    (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)))
 
 (defun haskell/init-haskell-snippets ()
   ;; manually load the package since the current implementation is not lazy
@@ -202,7 +201,7 @@
       (add-to-list 'yas-snippet-dirs snip-dir t)
       (yas-load-directory snip-dir)))
 
-  (eval-after-load 'yasnippet '(haskell-snippets-initialize)))
+  (with-eval-after-load 'yasnippet (haskell-snippets-initialize)))
 
 (defun haskell/init-hindent ()
   (use-package hindent

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -38,10 +38,9 @@
       :init
       (progn
         (with-eval-after-load 'merlin
-          (progn
-            (setq merlin-error-after-save nil)
-            (flycheck-ocaml-setup))
-          )))))
+          (setq merlin-error-after-save nil)
+          (flycheck-ocaml-setup))
+        ))))
 
 (defun ocaml/init-merlin ()
   (use-package merlin

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -155,8 +155,8 @@
     (progn
       (add-hook 'inferior-python-mode-hook 'smartparens-mode)
       ;; add support for `ahs-range-beginning-of-defun' for python-mode
-      (eval-after-load 'auto-highlight-symbol
-        '(add-to-list 'ahs-plugin-bod-modes 'python-mode))
+      (with-eval-after-load 'auto-highlight-symbol
+        (add-to-list 'ahs-plugin-bod-modes 'python-mode))
 
       (defun python-shell-send-buffer-switch ()
         "Send buffer content to shell and switch to it in insert mode."

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -25,11 +25,11 @@
     :config
     (progn
       ;; smartparens configuration
-      (eval-after-load 'smartparens
-        '(progn (add-to-list 'sp--lisp-modes 'racket-mode)
-                (when (fboundp 'sp-local-pair)
-                  (sp-local-pair 'racket-mode "'" nil :actions nil)
-                  (sp-local-pair 'racket-mode "`" nil :actions nil))))
+      (with-eval-after-load 'smartparens
+        (add-to-list 'sp--lisp-modes 'racket-mode)
+        (when (fboundp 'sp-local-pair)
+          (sp-local-pair 'racket-mode "'" nil :actions nil)
+          (sp-local-pair 'racket-mode "`" nil :actions nil)))
 
       (defun spacemacs/racket-test-with-coverage ()
         "Call `racket-test' with universal argument."

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -124,5 +124,5 @@
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun ruby/post-init-company ()
     (spacemacs|add-company-hook enh-ruby-mode)
-    (eval-after-load 'company-dabbrev-code
-      '(push 'enh-ruby-mode company-dabbrev-code-modes))))
+    (with-eval-after-load 'company-dabbrev-code
+      (push 'enh-ruby-mode company-dabbrev-code-modes))))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -155,10 +155,9 @@
 
       ;; Don't use scala checker if ensime mode is active, since it provides
       ;; better error checking.
-      (eval-after-load 'flycheck
-        '(progn
-           (defun scala/disable-flycheck () (flycheck-mode -1))
-           (add-hook 'ensime-mode-hook 'scala/disable-flycheck))))))
+      (with-eval-after-load 'flycheck
+        (defun scala/disable-flycheck () (flycheck-mode -1))
+        (add-hook 'ensime-mode-hook 'scala/disable-flycheck)))))
 
 (defun scala/init-noflet ())
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -283,9 +283,8 @@
     :commands turn-on-magit-gitflow
     :init (progn
             (add-hook 'magit-mode-hook 'turn-on-magit-gitflow)
-            (eval-after-load 'magit
-              '(progn
-                 (define-key magit-mode-map "#f" 'magit-gitflow-popup))))
+            (with-eval-after-load 'magit
+              (define-key magit-mode-map "#f" 'magit-gitflow-popup)))
     :config (spacemacs|diminish magit-gitflow-mode "Flow")))
 
 (defun git/init-magit-svn ()

--- a/layers/+tools/pandoc/packages.el
+++ b/layers/+tools/pandoc/packages.el
@@ -36,4 +36,4 @@
   (use-package ox-pandoc
     :defer t
     :init
-    (eval-after-load 'org '(require 'ox-pandoc))))
+    (with-eval-after-load 'org (require 'ox-pandoc))))

--- a/layers/+vim/vinegar/keybindings.el
+++ b/layers/+vim/vinegar/keybindings.el
@@ -3,7 +3,7 @@
 
 (add-hook 'dired-mode-hook 'vinegar/dired-setup)
 
-(eval-after-load "dired-mode"
+(with-eval-after-load 'dired-mode
   (evilify dired-mode dired-mode-map
            "j"         'vinegar/move-down
            "k"         'vinegar/move-up

--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -34,8 +34,8 @@
     :init
     (progn
       (setq ac-ispell-requires 4)
-      (eval-after-load 'auto-complete
-        '(ac-ispell-setup))
+      (with-eval-after-load 'auto-complete
+        (ac-ispell-setup))
       ;; (add-hook 'markdown-mode-hook 'ac-ispell-ac-setup)
       )))
 

--- a/layers/finance/packages.el
+++ b/layers/finance/packages.el
@@ -20,8 +20,8 @@
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun finance/init-flycheck-ledger ()
-    (eval-after-load 'flycheck
-      '(require 'flycheck-ledger))))
+    (with-eval-after-load 'flycheck
+      (require 'flycheck-ledger))))
 
 (defun finance/init-ledger-mode ()
   (use-package ledger-mode

--- a/layers/org/extensions.el
+++ b/layers/org/extensions.el
@@ -22,7 +22,7 @@
     (progn
       ;; seems to be required otherwise the extension is not
       ;; loaded properly by org
-      (eval-after-load 'org '(require 'ox-gfm))
+      (with-eval-after-load 'org (require 'ox-gfm))
       (autoload 'org-gfm-export-as-markdown "ox-gfm" "\
  Export current buffer to a Github Flavored Markdown buffer.
 

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -83,8 +83,8 @@
             org-startup-with-inline-images t
             org-src-fontify-natively t)
 
-      (eval-after-load 'org-indent
-        '(spacemacs|hide-lighter org-indent-mode))
+      (with-eval-after-load 'org-indent
+        (spacemacs|hide-lighter org-indent-mode))
       (setq org-startup-indented t)
       (let ((dir (configuration-layer/get-layer-property 'org :dir)))
         (setq org-export-async-init-file (concat dir "org-async-init.el")))
@@ -198,15 +198,14 @@ Will work on both org-mode and any mode that accepts plain html."
           "mxu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
           "mxv" (spacemacs|org-emphasize spacemacs/org-verbose ?=))
 
-      (eval-after-load "org-agenda"
-        '(progn
-           (define-key org-agenda-mode-map "j" 'org-agenda-next-line)
-           (define-key org-agenda-mode-map "k" 'org-agenda-previous-line)
-           ;; Since we override SPC, let's make RET do that functionality
-           (define-key org-agenda-mode-map
-             (kbd "RET") 'org-agenda-show-and-scroll-up)
-           (define-key org-agenda-mode-map
-             (kbd "SPC") evil-leader--default-map))))
+      (with-eval-after-load 'org-agenda
+        (define-key org-agenda-mode-map "j" 'org-agenda-next-line)
+        (define-key org-agenda-mode-map "k" 'org-agenda-previous-line)
+        ;; Since we override SPC, let's make RET do that functionality
+        (define-key org-agenda-mode-map
+          (kbd "RET") 'org-agenda-show-and-scroll-up)
+        (define-key org-agenda-mode-map
+          (kbd "SPC") evil-leader--default-map)))
     :config
     (progn
       ;; setup org directory


### PR DESCRIPTION
We now backport the macro for 24.3 so we can use it everywhere. If anyone on 24.3 could test to make sure nothing breaks that would be awesome, but it shouldn't break.