### PR TITLE
Add avy-open-url and its keybinding to open urls

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2040,6 +2040,7 @@ Text related commands (start with ~x~):
 
     | Key Binding | Description                                                   |
     |-------------+---------------------------------------------------------------|
+    | ~SPC x o~   | use avy to select a link in the buffer and open it            |
     | ~SPC x u~   | set the selected text to lower case                           |
     | ~SPC x U~   | set the selected text to upper case                           |
     | ~SPC x a a~ | align region (or guessed section) using default rules         |

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -393,6 +393,7 @@
 (defun spacemacs/init-avy ()
   (use-package avy
     :defer t
+    :commands (spacemacs/avy-open-url)
     :init
     (progn
       (setq avy-keys (number-sequence ?a ?z))
@@ -400,9 +401,22 @@
       (setq avy-background t)
       (evil-leader/set-key
         "SPC" 'avy-goto-word-or-subword-1
-        "l" 'avy-goto-line))
+        "l" 'avy-goto-line
+        "xo" 'spacemacs/avy-open-url))
     :config
-    (evil-leader/set-key "`" 'avy-pop-mark)))
+    (progn
+      (defun spacemacs/avy-goto-url()
+        "Use avy to go to an URL in the buffer."
+        (interactive)
+        (avy--generic-jump "https?://" nil 'pre))
+      (defun spacemacs/avy-open-url ()
+        "Use avy to select an URL in the buffer and open it."
+        (interactive)
+        (save-excursion
+          (spacemacs/avy-goto-url)
+          (browse-url-at-point)))
+      (evil-leader/set-key "`" 'avy-pop-mark))
+      ))
 
 (defun spacemacs/init-buffer-move ()
   (use-package buffer-move


### PR DESCRIPTION
The function `spacemacs/avy-open-url` allows to easily select an URL on
the screen with `avy` and open it. The function is bind to `SPC x o`,
`x` as it is text-related and `o` for open.