### PR TITLE
Add ghc-show-type/info key mappings (haskell).

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -96,6 +96,9 @@
         "mgg"  'haskell-mode-jump-to-def-or-tag
         "mf"   'haskell-mode-stylish-buffer
 
+        "mt"   'ghc-show-type
+        "mi"   'ghc-show-info
+
         "msb"  'haskell-process-load-or-reload
         "msc"  'haskell-interactive-mode-clear
         "mss"  'haskell-interactive-bring


### PR DESCRIPTION
Two short key mappings for two very useful functions.