### PR TITLE
OCaml: Better opam handling

### DIFF
--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -4,19 +4,18 @@
 
 * Table of Content                                                    :TOC@4:
  - [[#description][Description]]
-     - [[#features][Features:]]
+   - [[#features][Features:]]
  - [[#install][Install]]
-     - [[#layer][Layer]]
-     - [[#opam-packages][OPAM packages]]
+   - [[#layer][Layer]]
+   - [[#opam-packages][OPAM packages]]
  - [[#key-bindings][Key Bindings]]
-     - [[#repl-utop][REPL (utop)]]
+   - [[#repl-utop][REPL (utop)]]
  - [[#todos][TODOS]]
-     - [[#todo-add-more-proper-spacemacs-key-bindings-for-basic-merlin-tasks][TODO Add more proper spacemacs key-bindings for basic merlin tasks]]
-     - [[#todo-add-proper-keybindings-for-ocamldebug][TODO Add proper keybindings for ocamldebug]]
-     - [[#todo-add-more-keybindings-for-tuareg-mode][TODO Add more keybindings for tuareg-mode]]
+   - [[#add-more-proper-spacemacs-key-bindings-for-basic-merlin-tasks][Add more proper spacemacs key-bindings for basic merlin tasks]]
+   - [[#add-proper-keybindings-for-ocamldebug][Add proper keybindings for ocamldebug]]
+   - [[#add-more-keybindings-for-tuareg-mode][Add more keybindings for tuareg-mode]]
 
 * Description
-
 This is a very basic layer for editing ocaml files.
 
 ** Features:
@@ -26,9 +25,7 @@ This is a very basic layer for editing ocaml files.
 - syntax-checking via [[https://github.com/diml/utop][flycheck-ocaml]]
 
 * Install
-
 ** Layer
-
 To use this contribution add it to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp
@@ -36,7 +33,6 @@ To use this contribution add it to your =~/.spacemacs=
 #+END_SRC
 
 ** OPAM packages
-
 This layer requires some [[http://opam.ocaml.org][opam]] packages:
 
 - =merlin= for auto-completion
@@ -48,6 +44,13 @@ To install them, use the following command:
 #+BEGIN_SRC sh
   opam install merlin utop ocp-indent
 #+END_SRC
+
+Make sure opam is initialized and configured.
+
+#+begin_src sh
+  opam init
+  opam config setup -a
+#+end_src
 
 * Key Bindings
 

--- a/layers/+lang/ocaml/funcs.el
+++ b/layers/+lang/ocaml/funcs.el
@@ -12,12 +12,14 @@
 
 (defun spacemacs//init-ocaml-opam ()
   (if (executable-find "opam")
-      (let ((share (substring (shell-command-to-string
-                               "opam config var share 2> /dev/null") 0 -1)))
-        (when share
-          (setq opam-share share
-                opam-load-path (concat share "/emacs/site-lisp")))
-        (add-to-list 'load-path opam-load-path))
+      (let* ((output (shell-command-to-string
+                      "opam config var share 2> /dev/null"))
+             (share (when (< 0 (length output))
+                      (substring output 0 -1))))
+          (when share
+            (setq opam-share share
+                  opam-load-path (concat share "/emacs/site-lisp")))
+          (add-to-list 'load-path opam-load-path))
     (spacemacs-buffer/warning
      (concat "Cannot find \"opam\" executable. "
              "The ocaml layer won't work properly."))))


### PR DESCRIPTION
As experienced by @feniix in #3219, the call to opam may return an empty string, in which case don't error out.

Also document how to set it up so that it *doesn't* return an empty string.