### PR TITLE
core-keys: Allow major-mode-leader to be nil

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -473,7 +473,11 @@ If MSG is not nil then display a message in `*Messages'."
    (spacemacs//test-var 'stringp 'dotspacemacs-leader-key "is a string")
    (spacemacs//test-var 'stringp 'dotspacemacs-emacs-leader-key "is a string")
    (spacemacs//test-var
-    'stringp 'dotspacemacs-major-mode-leader-key "is a string")
+    (lambda (x) (or (null x) (stringp x)))
+    'dotspacemacs-major-mode-leader-key "is a string or nil")
+   (spacemacs//test-var
+    (lambda (x) (or (null x) (stringp x)))
+    'dotspacemacs-major-mode-emacs-leader-key "is a string or nil")
    (spacemacs//test-var 'stringp 'dotspacemacs-command-key "is a string")
    (insert (format
             (concat "** RESULTS: "

--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -51,10 +51,10 @@ used as the prefix command."
             (which-key-declare-prefixes-for-mode mode
               full-prefix-emacs prefix-name
               full-prefix prefix-name)
-            (when is-major-mode-prefix
-              (which-key-declare-prefixes-for-mode mode
-                major-mode-prefix prefix-name
-                major-mode-prefix-emacs prefix-name)))
+            (when (and is-major-mode-prefix dotspacemacs-major-mode-leader-key)
+              (which-key-declare-prefixes-for-mode mode major-mode-prefix prefix-name))
+            (when (and is-major-mode-prefix dotspacemacs-major-mode-emacs-leader-key)
+              (which-key-declare-prefixes-for-mode mode major-mode-prefix-emacs prefix-name)))
         (define-prefix-command command)
         (evil-leader/set-key-for-mode mode prefix command)))))
 


### PR DESCRIPTION
The dotfile says that setting the major-mode leaders to nil will disable
the functionality, but there were a couple of places where that option
was not being respected.

Might be worth merging this to master too