### PR TITLE
lang/go: Added more features for testing in golang layer

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -54,24 +54,29 @@ formatter, set the value of =gofmt-command=, e.g.
 #+begin_src emacs-lisp
   (setq gofmt-command "goimports")
 #+end_src
+#
+If you're using =gocheck= in your project you can use the =go-use-gocheck-for-testing= variable to enable suite testing and to get single function testing to work.
 
 * Working with Go
 
 ** Go commands (start with =m=):
-| Key Binding | Description                                               |
-|-------------+-----------------------------------------------------------|
-| ~SPC m h h~ | godoc at point                                            |
-| ~SPC m i g~ | goto imports                                              |
-| ~SPC m i a~ | add import                                                |
-| ~SPC m i r~ | remove unused import                                      |
-| ~SPC m e b~ | go-play buffer                                            |
-| ~SPC m e r~ | go-play region                                            |
-| ~SPC m e d~ | download go-play snippet                                  |
-| ~SPC m x x~ | run "go run" for the current 'main' package               |
-| ~SPC m t p~ | run "go test" for the current package                     |
-| ~SPC m g a~ | jump to matching test file or back from test to code file |
-| ~SPC m g g~ | go jump to definition                                     |
-| ~SPC m r n~ | go rename                                                 |
+| Key Binding | Description                                                                           |
+|-------------+---------------------------------------------------------------------------------------|
+| ~SPC m h h~ | godoc at point                                                                        |
+| ~SPC m i g~ | goto imports                                                                          |
+| ~SPC m i a~ | add import                                                                            |
+| ~SPC m i r~ | remove unused import                                                                  |
+| ~SPC m e b~ | go-play buffer                                                                        |
+| ~SPC m e r~ | go-play region                                                                        |
+| ~SPC m e d~ | download go-play snippet                                                              |
+| ~SPC m x x~ | run "go run" for the current 'main' package                                           |
+| ~SPC m g a~ | jump to matching test file or back from test to code file                             |
+| ~SPC m g g~ | go jump to definition                                                                 |
+| ~SPC m r n~ | go rename                                                                             |
+| ~SPC m t p~ | run "go test" for the current package                                                 |
+| ~SPC m t P~ | run "go test" for the current package and all packages under it                       |
+| ~SPC m t t~ | run "go test" for the function you're currently in (while you're in a _.test.go file) |
+| ~SPC m t s~ | run "go test" for the suite you're currently in (requires gocheck)                    |
 
 
 ** Go Oracle

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -13,3 +13,6 @@
 ;; variables
 
 (spacemacs|defvar-company-backends go-mode)
+
+(defvar go-use-gocheck-for-testing nil
+  "If using gocheck for testing when running the tests -check.f will be used instead of -run to specify the test that will be ran. Gocheck is mandatory for testing suites.")


### PR DESCRIPTION
Adds 3 more functions for golang testing.

During testing the PR I noticed that since I use gocheck it *needs* -check.f not -run, but regular go uses -run, so I included both options.