### PR TITLE
Fix erc-tex warning when starting spacemacs

### DIFF
--- a/layers/+irc/erc/extensions/erc-tex/erc-tex.el
+++ b/layers/+irc/erc/extensions/erc-tex/erc-tex.el
@@ -72,7 +72,7 @@
 ;; expression MATH-STRING. Return the image descriptor if it was sucessful,
 ;; NIL otherwise.
 (defun erc-tex-make-image (math-expression fg bg)
-  (condition-case nil 
+  (condition-case nil
       (let* ((prefix   (concat temporary-file-directory (make-temp-name "erc-tex-")))
              (tex-file (concat prefix ".tex"))
              (dvi-file (concat prefix ".dvi"))
@@ -88,10 +88,10 @@
                   "\\end{document}\n"))
 
         (erc-tex-run-latex (concat "-output-directory=" temporary-file-directory) tex-file)
-    
-        (flet ((colorize (color)
+
+        (cl-flet ((colorize (color)
                  ;; Return a string which stand for COLOR in the format that
-                 ;; dvipng understands.               
+                 ;; dvipng understands.
                  (let ((max (car (color-values "#ffffff"))))
                    (destructuring-bind (r g b)
                        (color-values color)


### PR DESCRIPTION
```
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or
`cl-letf'.
```
I was not sure which to use. So opted for `cl-flet`