### PR TITLE
Fix some cl-lib function with prefix

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -355,7 +355,7 @@ Properties that can be copied are `:location', `:step' and `:excluded'."
 
 (defun configuration-layer/filter-objects (objects ffunc)
   "Return a filtered OBJECTS list where each element satisfies FFUNC."
-  (reverse (reduce (lambda (acc x)
+  (reverse (cl-reduce (lambda (acc x)
                      (if (funcall ffunc x) (push x acc) acc))
                    objects
                    :initial-value nil)))

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -105,7 +105,7 @@ and its values are removed."
 ;; From http://stackoverflow.com/questions/2321904/elisp-how-to-save-data-in-a-file
 (defun spacemacs/dump (varlist buffer)
   "insert into buffer the setq statement to recreate the variables in VARLIST"
-  (loop for var in varlist do
+  (cl-loop for var in varlist do
         (print (list 'setq var (list 'quote (symbol-value var)))
                buffer)))
 

--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -206,7 +206,7 @@ These should have their own segments in the modeline.")
               (null dotspacemacs-auto-save-file-location))
     (make-directory autosave-dir t)))
 ;; Choose auto-save location
-(case dotspacemacs-auto-save-file-location
+(pcase dotspacemacs-auto-save-file-location
   (cache (let ((autosave-dir (concat spacemacs-auto-save-directory "site/")))
            (add-to-list 'auto-save-file-name-transforms
                         `(".*" ,autosave-dir t) 'append)

--- a/layers/+irc/erc/extensions/erc-sasl/erc-sasl.el
+++ b/layers/+irc/erc/extensions/erc-sasl/erc-sasl.el
@@ -51,7 +51,7 @@
 current session"
   (and erc-sasl-use-sasl
        (boundp 'erc-session-server)
-       (loop for re in erc-sasl-server-regexp-list
+       (cl-loop for re in erc-sasl-server-regexp-list
              thereis (integerp (string-match re erc-session-server)))))
 
 (define-erc-response-handler (CAP)


### PR DESCRIPTION
Sine emacs 24.3, function in cl-lib should with cl- prefix.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>