### PR TITLE
org: Use RET in normal-state for links

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -222,6 +222,9 @@ Will work on both org-mode and any mode that accepts plain html."
       (define-key global-map "\C-cl" 'org-store-link)
       (define-key global-map "\C-ca" 'org-agenda)
 
+      ;; Open links and files with RET in normal state
+      (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)
+
       ;; We add this key mapping because an Emacs user can change
       ;; `dotspacemacs-major-mode-emacs-leader-key' to `C-c' and the key binding
       ;; C-c ' is shadowed by `spacemacs/default-pop-shell', effectively making


### PR DESCRIPTION
Return is not useful in normal state, so let it open/follow links like `C-c C-o`