### PR TITLE
Fix key binding for switching back from REPL

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -124,7 +124,7 @@
 
       ;; Switch back to editor from REPL
       (evil-leader/set-key-for-mode 'haskell-interactive-mode
-        "msS"  'haskell-interactive-switch)
+        "msS"  'haskell-interactive-switch-back)
 
       ;; Compile
       (evil-leader/set-key-for-mode 'haskell-cabal


### PR DESCRIPTION
The problem is that `haskell-interactive-switch` is used to switch from source buffer to REPL (and when you call this function it sets `haskell-interactive-previous-buffer`). But to switch back from REPL to `haskell-interactive-previous-buffer` you have to use `haskell-interactive-switch-back`. 

Lured this thing thanks to @PierreR in #3271.