### PR TITLE
Add FAQ as a source in helm-spacemacs

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1613,6 +1613,7 @@ navigate between =Emacs= and =Spacemacs= specific files.
 | ~SPC f e d~ | open the spacemacs dotfile (=~/.spacemacs=)                          |
 | ~SPC f e D~ | open =ediff= buffer of =~/.spacemacs= and =.spacemacs.template=      |
 | ~SPC f e h~ | discover =Spacemacs= documentation, layers and packages using =helm= |
+| ~SPC f e f~ | discover the =FAQ= using =helm=                                      |
 | ~SPC f e i~ | open the all mighty =init.el=                                        |
 | ~SPC f e R~ | resync the dotfile with spacemacs                                    |
 | ~SPC f e v~ | display and copy the spacemacs version                               |

--- a/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
+++ b/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
@@ -29,6 +29,7 @@
 (require 'cl)
 (require 'ht)
 (require 'helm)
+(require 'helm-org)
 (require 'core-configuration-layer)
 
 (defvar helm-spacemacs-all-layers nil
@@ -66,7 +67,16 @@
                    ,(helm-spacemacs//layer-source)
                    ,(helm-spacemacs//package-source)
                    ,(helm-spacemacs//dotspacemacs-source)
-                   ,(helm-spacemacs//toggle-source))))
+                   ,(helm-spacemacs//toggle-source)
+                   ,(helm-spacemacs//faq-source))))
+
+;;;###autoload
+(defun helm-spacemacs-faq (arg)
+  "Looking in the FAQ with helm."
+  (interactive "P")
+  (helm-spacemacs-mode)
+  (helm :buffer "*helm: spacemacs*"
+        :sources `(,(helm-spacemacs//faq-source))))
 
 (defun helm-spacemacs//documentation-source ()
   "Construct the helm source for the documentation section."
@@ -255,6 +265,22 @@
   (re-search-forward (format "^[a-z\s\\(\\-]*%s" candidate))
   (beginning-of-line))
 
+(defun helm-spacemacs//faq-source ()
+  "Construct the helm source for the FAQ."
+  `((name . "FAQ")
+    (candidates . ,(helm-spacemacs//faq-candidates))
+    (candidate-number-limit)
+    (action . (("Go to question" . helm-org-goto-marker)))))
+
+(defun helm-spacemacs//faq-candidates ()
+  (delq nil (mapcar (lambda (c)
+                      (let ((str (substring-no-properties (car c))))
+                        (when (string-match "\\`\\([^/]*\\)/\\(.*\\)\\'" str)
+                          (cons (concat (match-string 1 str) ": "
+                                        (match-string 2 str))
+                                (cdr c)))))
+                    (helm-get-org-candidates-in-file
+                     (concat spacemacs-docs-directory "FAQ.org") 2 8 nil t))))
 
 (provide 'helm-spacemacs)
 

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -886,9 +886,11 @@ ARG non nil means that the editing style is `vim'."
 
 (defun spacemacs-base/init-helm-spacemacs ()
   (use-package helm-spacemacs
-    :commands helm-spacemacs
+    :commands (helm-spacemacs helm-spacemacs-faq)
     :init
-    (evil-leader/set-key "feh" 'helm-spacemacs)))
+    (progn
+      (evil-leader/set-key "feh" 'helm-spacemacs)
+      (evil-leader/set-key "fef" 'helm-spacemacs-faq))))
 
 (defun spacemacs-base/init-hs-minor-mode ()
   ;; required for evil folding


### PR DESCRIPTION
Add the `FAQ.org` file as a source in helm-spacemacs (`SPC f e h`).
Define a new keybinding for looking directly inside the FAQ with helm:
`SPC f e f`.

With help from TheBB, thanks!