### PR TITLE
Doc typo: "search for files" -> "search in files"

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -121,7 +121,7 @@
        - [[#useful-key-bindings][Useful key bindings]]
        - [[#searching-in-current-file][Searching in current file]]
        - [[#searching-in-all-open-buffers-visiting-files][Searching in all open buffers visiting files]]
-       - [[#searching-for-files-in-an-arbitrary-directory][Searching for files in an arbitrary directory]]
+       - [[#searching-in-files-in-an-arbitrary-directory][Searching in files in an arbitrary directory]]
        - [[#searching-in-a-project][Searching in a project]]
        - [[#searching-the-web][Searching the web]]
      - [[#persistent-highlighting][Persistent highlighting]]
@@ -1902,7 +1902,7 @@ called =pt=.
 | ~SPC s t b~ | =pt=                                                |
 | ~SPC s t B~ | =pt= with default text                              |
 
-**** Searching for files in an arbitrary directory
+**** Searching in files in an arbitrary directory
 | Key Binding | Description                                         |
 |-------------+-----------------------------------------------------|
 | ~SPC s f~   | search with the first found tool                    |


### PR DESCRIPTION
Just noticed a small typo that can misguide new users. "Search for files" means that the command looks for files, while actually `SPC s f` searches in some files for lines that match the given search pattern. Changed it to "search in files" to better reflect what the command does.