### PR TITLE
Added link to lisp keybindings to lispy languages

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -12,6 +12,7 @@
      - [[#quick-start-with-lein][Quick Start with lein]]
      - [[#more-details][More details]]
  - [[#key-bindings][Key Bindings]]
+   - [[#working-with-clojure-files-barfage-slurpage--more][Working with clojure files (barfage, slurpage & more)]]
    - [[#leader][Leader]]
      - [[#documentation][Documentation]]
      - [[#evaluation][Evaluation]]
@@ -90,10 +91,16 @@ More info regarding installation of nREPL middleware can be found here:
 - clj-refactor: [[https://github.com/clojure-emacs/refactor-nrepl][refactor-nrepl]]
   
 * Key Bindings
+** Working with clojure files (barfage, slurpage & more)
+
+spacemacs comes with a special ~lisp-state~ for working with lisp code that supports slurpage, barfage and more tools you'll likely want when working with lisp. 
+
+As this state works for all files the same, the documentation for it has been added into the global [[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
 
 ** Leader
 
 *** Documentation
+
 
 | Key Binding | Description    |
 |-------------+----------------|

--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -6,12 +6,14 @@
  - [[#description][Description]]
  - [[#install][Install]]
  - [[#key-bindings][Key Bindings]]
-   - [[#help][Help]]
-   - [[#evaluation][Evaluation]]
-   - [[#repl][REPL]]
-   - [[#compile][Compile]]
-   - [[#navigation][Navigation]]
-   - [[#macroexpansion][Macroexpansion]]
+   - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
+   - [[#leader][Leader]]
+     - [[#help][Help]]
+     - [[#evaluation][Evaluation]]
+     - [[#repl][REPL]]
+     - [[#compile][Compile]]
+     - [[#navigation][Navigation]]
+     - [[#macroexpansion][Macroexpansion]]
 
 * Description
 
@@ -40,7 +42,14 @@ of Common Lisp, you can specify it in your =~/.spacemacs=
 
 * Key Bindings
 
-** Help
+** Working with lisp files (barfage, slurpage & more)
+
+spacemacs comes with a special ~lisp-state~ for working with lisp code that supports slurpage, barfage and more tools you'll likely want when working with lisp. 
+
+As this state works for all files the same, the documentation for it has been added into the global [[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
+
+** Leader
+*** Help
 
 | Key Binding | Description                                             |
 |-------------+---------------------------------------------------------|
@@ -57,7 +66,7 @@ of Common Lisp, you can specify it in your =~/.spacemacs=
 | ~SPC m h r~ | Show references to global variable                      |
 | ~SPC m h s~ | Show all methods specialized on a class                 |
 
-** Evaluation
+*** Evaluation
 
 | Key Binding | Description                     |
 |-------------+---------------------------------|
@@ -67,7 +76,7 @@ of Common Lisp, you can specify it in your =~/.spacemacs=
 | ~SPC m e F~ | Undefine the function at point  |
 | ~SPC m e r~ | Evaluate region                 |
 
-** REPL
+*** REPL
 
 | Key Binding | Description                      |
 |-------------+----------------------------------|
@@ -75,7 +84,7 @@ of Common Lisp, you can specify it in your =~/.spacemacs=
 | ~SPC m s e~ | Evaluate last expression in REPL |
 | ~SPC m s q~ | Quit                             |
 
-** Compile
+*** Compile
 
 | Key Binding | Description              |
 |-------------+--------------------------|
@@ -86,7 +95,7 @@ of Common Lisp, you can specify it in your =~/.spacemacs=
 | ~SPC m c f~ | Compile function         |
 | ~SPC m c r~ | Compile region           |
 
-** Navigation
+*** Navigation
 
 
 | Key Binding               | Description        |
@@ -95,7 +104,7 @@ of Common Lisp, you can specify it in your =~/.spacemacs=
 | ~SPC m g b~               | Go back            |
 | ~SPC m g n~               | Next note          |
 | ~SPC m g N~ or ~SPC m g p | Previous note      |
-** Macroexpansion
+*** Macroexpansion
 
 | Key Binding | Description                                   |
 |-------------+-----------------------------------------------|

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -6,7 +6,9 @@
  - [[#description][Description]]
  - [[#install][Install]]
  - [[#key-bindings][Key bindings]]
-     - [[#srefactor][srefactor]]
+   - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
+   - [[#leader][Leader]]
+   - [[#srefactor][srefactor]]
 
 * Description
 
@@ -22,6 +24,13 @@ To use this contribution add it to your =~/.spacemacs=
 #+END_SRC
 
 * Key bindings
+** Working with lisp files (barfage, slurpage & more)
+
+spacemacs comes with a special ~lisp-state~ for working with lisp code that supports slurpage, barfage and more tools you'll likely want when working with lisp. 
+
+As this state works for all files the same, the documentation for it has been added into the global [[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
+
+** Leader
 
 | Key Binding                | Description                                                |
 |----------------------------+------------------------------------------------------------|


### PR DESCRIPTION
I worked with clojure today and was surprised to not see support for barfage, slurpage and other lispy goodies. Only after asking in gitter, TheBB told me that there is a lisp-state that adds this kind of stuff. 

I read `THE documentation` a lot but that wasn't the place where I expected to find keybindings for lisp languages. 

With this PR I added a link to the `lisp-common` `emacs-lisp` and `clojure` (where this stuff is really crucial for a good workflow) READMEs pointing to the spot inside `DOCUMENTATION.org` where the keybindings are. 