### PR TITLE
Use a temp buffer to read the FAQ in helm-spacemacs

### DIFF
--- a/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
+++ b/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
@@ -265,12 +265,16 @@
   (re-search-forward (format "^[a-z\s\\(\\-]*%s" candidate))
   (beginning-of-line))
 
+(defvar helm-spacemacs--faq-filename
+  (concat spacemacs-docs-directory "FAQ.org")
+  "Location of the FAQ file.")
+
 (defun helm-spacemacs//faq-source ()
   "Construct the helm source for the FAQ."
   `((name . "FAQ")
     (candidates . ,(helm-spacemacs//faq-candidates))
     (candidate-number-limit)
-    (action . (("Go to question" . helm-org-goto-marker)))))
+    (action . (("Go to question" . helm-spacemacs//faq-goto-marker)))))
 
 (defun helm-spacemacs//faq-candidates ()
   (delq nil (mapcar (lambda (c)
@@ -280,9 +284,18 @@
                                         (match-string 2 str))
                                 (cdr c)))))
                     (with-temp-buffer
-                      (insert-file-contents (concat spacemacs-docs-directory "FAQ.org"))
+                      (insert-file-contents helm-spacemacs--faq-filename)
                       (org-mode)
-                      (helm-get-org-candidates-in-file (current-buffer) 2 8 nil t)))))
+                      (mapcar '(lambda (candidate)
+                                 `(,(car candidate) . ,(marker-position (cdr candidate))))
+                              (helm-get-org-candidates-in-file (current-buffer) 2 8 nil t))
+                      ))))
+
+(defun helm-spacemacs//faq-goto-marker (marker)
+  (find-file helm-spacemacs--faq-filename)
+  (goto-char marker)
+  (org-show-context)
+  (org-show-entry))
 
 (provide 'helm-spacemacs)
 

--- a/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
+++ b/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
@@ -279,8 +279,10 @@
                           (cons (concat (match-string 1 str) ": "
                                         (match-string 2 str))
                                 (cdr c)))))
-                    (helm-get-org-candidates-in-file
-                     (concat spacemacs-docs-directory "FAQ.org") 2 8 nil t))))
+                    (with-temp-buffer
+                      (insert-file-contents (concat spacemacs-docs-directory "FAQ.org"))
+                      (org-mode)
+                      (helm-get-org-candidates-in-file (current-buffer) 2 8 nil t)))))
 
 (provide 'helm-spacemacs)
 


### PR DESCRIPTION
Correct a bug in helm-spacemacs: Whenever a function was needing the
FAQ's candidates in helm-spacemancs (`SPC f e h` and `SPC f e f`), the
`FAQ.org` file was open in a buffer and not closed. This commit corrects
this by loading the content of `FAQ.org` in a temp buffer and switch it
to `org-mode` in order to get the candidates.