### PR TITLE
Add helm-company

### DIFF
--- a/layers/auto-completion/README.org
+++ b/layers/auto-completion/README.org
@@ -180,6 +180,7 @@ Here is an example to add =company= auto-completion to python buffer:
 | ~C-j~       | go down in company dropdown menu                                         |
 | ~C-k~       | go up in company dropdown menu                                           |
 | ~C-/~       | search in company dropdown                                               |
+| ~C-/~       | show candidates in Helm (for fuzzy searching)                            |
 | ~C-M-/~     | filter the company dropdown menu                                         |
 | ~C-d~       | open minibuffer with documentation of thing at point in company dropdown |
 

--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -16,6 +16,7 @@
         ac-ispell
         company
         company-statistics
+        helm-company
         helm-c-yasnippet
         hippie-exp
         yasnippet
@@ -153,6 +154,15 @@
         (call-interactively 'helm-yas-complete))
       (evil-leader/set-key "is" 'spacemacs/helm-yas)
       (setq helm-c-yas-space-match-any-greedy t))))
+
+(defun auto-completion/init-helm-company ()
+  (use-package helm-company
+    :if (configuration-layer/package-usedp 'company)
+    :defer t
+    :init
+    (with-eval-after-load 'company
+      (define-key company-active-map (kbd "C-/") 'helm-company)
+      (define-key company-mode-map (kbd "C-/") 'helm-company))))
 
 (defun auto-completion/init-hippie-exp ()
   ;; replace dabbrev-expand


### PR DESCRIPTION
I just tried this out for kicks and fell in love with it. Company is nice but sometimes you want fuzzy matching, and it's hard to get because AFAIK it has to be configured on a backend-to-backend basis, if it's even possible in the first place. `C-M-/` is nice too but it's still not fuzzy.

This PR adds a `C-/` binding that drops you into a helm session with all company candidates, which *has* fuzzy matching.