### PR TITLE
Use tab-width instead of default-tab-width

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -120,7 +120,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 
 ;; use only spaces and no tabs
 (setq-default indent-tabs-mode nil
-              default-tab-width 2)
+              tab-width 2)
 
 ;; Text
 (setq longlines-show-hard-newlines t)


### PR DESCRIPTION
default-tab-width is obsolete since Emacs 23