### PR TITLE
Fix typo in var name for suppressing error popups in interactive Haskell buffers 

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -78,7 +78,7 @@
        ;; To enable tags generation on save.
        haskell-tags-on-save t
        ;; Remove annoying error popups
-       haskell-interactive-popup-error nil
+       haskell-interactive-popup-errors nil
        ;; Better import handling
        haskell-process-suggest-remove-import-lines t
        haskell-process-auto-import-loaded-modules t


### PR DESCRIPTION
Looks like `haskell-interactive-popup-error` (error in singular) is a name of a function, while `haskell-interactive-popup-errors` is the defcustom we need to set. As is, though set in this layer to nil by default, it does not apply and windows popup on errors. With it, the errors are inlined inside the interactive buffer.

```sh
Hours of hacking await!
If I break, you can:
  1. Restart:           M-x haskell-process-restart
  2. Configure logging: C-h v haskell-process-log (useful for debugging)
  3. General config:    M-x customize-mode
  4. Hide these tips:   C-h v haskell-process-show-debug-tips
Changed directory: /Users/uri/Projects/haskell/redo/
λ> ls

<interactive>:6:1-2: Not in scope: ‘ls’
λ>  
```