### PR TITLE
Search for GNU ls after exec-path was setup

### DIFF
--- a/layers/osx/packages.el
+++ b/layers/osx/packages.el
@@ -1,25 +1,28 @@
 (setq osx-packages
-  '(
-    osx-trash
-    pbcopy
-    launchctl
-    reveal-in-osx-finder
-    ))
+      '(
+        exec-path-from-shell
+        osx-trash
+        pbcopy
+        launchctl
+        reveal-in-osx-finder
+        ))
 
 (when (spacemacs/system-is-mac)
   ;; Enable built-in trash support via finder API if available (only on Emacs
   ;; Mac Port)
   (when (boundp 'mac-system-move-file-to-trash-use-finder)
-    (setq mac-system-move-file-to-trash-use-finder t))
-  ;; Use `gls' if `coreutils' was installed prefixed ('g') otherwise, leave
-  ;; alone. Manually add to config `(setq dired-use-ls-dired nil)' to surpesss
-  ;; warnings, when not using `coreutils' version of 'ls' on OS X.
-  ;; See brew info coreutils
-  (when (executable-find "gls")
-    ;; maybe absolute or relative name of the `ls' program used by
-    ;; `insert-directory'.
-    (setq insert-directory-program "gls"
-          dired-listing-switches "-aBhl --group-directories-first")))
+    (setq mac-system-move-file-to-trash-use-finder t)))
+
+(defun osx/post-init-exec-path-from-shell ()
+  ;; Use GNU ls as `gls' from `coreutils' if available.  Add `(setq
+  ;; dired-use-ls-dired nil)' to your config to suppress the Dired warning when
+  ;; not using GNU ls.  We must look for `gls' after `exec-path-from-shell' was
+  ;; initialized to make sure that `gls' is in `exec-path'
+  (when (spacemacs/system-is-mac)
+    (let ((gls (executable-find "gls")))
+      (when gls
+        (setq insert-directory-program gls
+              dired-listing-switches "-aBhl --group-directories-first")))))
 
 (defun osx/init-osx-trash ()
   (use-package osx-trash


### PR DESCRIPTION
We need to look for GNU ls after `exec-path-from-shell` was initialised and has fixed `exec-path`.  Otherwise the directory containing `gls` may not yet be in `exec-path`.