### PR TITLE
Add switch-to-scratch-buffer function and bind it

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1558,6 +1558,7 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC b p~   | switch to previous buffer avoiding special buffers                       |
 | ~SPC b P~   | copy clipboard and replace buffer (useful when pasting from a browser)   |
 | ~SPC b R~   | revert the current buffer (reload from disk)                             |
+| ~SPC b s~   | switch to the =*scratch*= buffer (create it if needed)                   |
 | ~SPC b w~   | toggle read-only (writable state)                                        |
 | ~SPC b Y~   | copy whole buffer to clipboard (useful when copying to a browser)        |
 | ~z f~       | Make current function or comments visible in buffer as much as possible  |

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -905,3 +905,9 @@ is nonempty."
     (cond ((listp val) val)
           ((stringp val) (< 0 (length val)))
           (t))))
+
+(defun spacemacs/switch-to-scratch-buffer ()
+  "Switch to the `*scratch*' buffer. Create it first if needed."
+  (interactive)
+  (switch-to-buffer (get-buffer-create "*scratch*"))
+  )

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -76,6 +76,7 @@
   "bn"  'spacemacs/next-useful-buffer
   "bp"  'spacemacs/previous-useful-buffer
   "bR"  'spacemacs/safe-revert-buffer
+  "bs"  'spacemacs/switch-to-scratch-buffer
   "bY"  'spacemacs/copy-whole-buffer-to-clipboard
   "bw"  'read-only-mode)
 ;; Cycling settings -----------------------------------------------------------


### PR DESCRIPTION
This change add a `switch-to-scratch-buffer` function allowing to – you
guessed it – switch to the `*scratch*` buffer, taking care of creating
it if necessary. The function is bind to `SPC b s`, `b` as it concerns
buffers, and `s` for `scratch`.