### PR TITLE
Fix erc notification icon

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -36,6 +36,9 @@
 (defconst spacemacs-docs-directory
   (expand-file-name (concat user-emacs-directory "doc/"))
   "Spacemacs documentation directory.")
+(defconst spacemacs-assets-directory
+  (expand-file-name (concat user-emacs-directory "assets/"))
+  "Spacemacs assets directory.")
 (defconst spacemacs-test-directory
   (expand-file-name (concat user-emacs-directory "tests/"))
   "Spacemacs tests directory.")

--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -88,7 +88,7 @@
         (notifications-notify
          :title nick
          :body message
-         :app-icon "/home/io/.emacs.d/assets/spacemacs.svg"
+         :app-icon (concat spacemacs-assets-directory "spacemacs.svg")
          :urgency 'low))
 
       ;; osx doesn't have dbus support


### PR DESCRIPTION
Introduce and use spacemacs-assets-directory for specifying the
spacemacs assets used in defining the app icon path, instead of a
hardcoded string.