### PR TITLE
fix mht and mhi bindings for haskell-mode

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -64,6 +64,19 @@
           ;; in structured-haskell-mode line highlighting creates noise
           (setq-local global-hl-line-mode nil)))
 
+      (defun spacemacs/haskell-mode-call-key (KEY)
+        "Call function that is bound to `KEY' in haskell-mode-map."
+        (interactive)
+        (call-interactively (lookup-key haskell-mode-map (kbd KEY))))
+
+      (defun spacemacs/haskell-mode-get-type ()
+        (interactive)
+        (spacemacs/haskell-mode-call-key "C-c C-t"))
+
+      (defun spacemacs/haskell-mode-get-info ()
+        (interactive)
+        (spacemacs/haskell-mode-call-key "C-c C-i"))
+
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)
       (add-hook 'haskell-cabal-mode-hook 'haskell-cabal-hook)
@@ -109,8 +122,8 @@
         "mhd"  'inferior-haskell-find-haddock
         "mhh"  'hoogle
         "mhH"  'hoogle-lookup-from-local
-        "mhi"  'haskell-process-do-info
-        "mht"  'haskell-process-do-type
+        "mhi"  'spacemacs/haskell-mode-get-info
+        "mht"  'spacemacs/haskell-mode-get-info
         "mhT"  'spacemacs/haskell-process-do-type-on-prev-line
         "mhy"  'hayoo
 
@@ -161,6 +174,8 @@
         (setq haskell-process-path-ghci "ghci-ng")
 
         (evil-leader/set-key-for-mode 'haskell-mode
+          ;; function suggested in
+          ;; https://github.com/chrisdone/ghci-ng#using-with-haskell-mode
           "mu"   'haskell-mode-find-uses
           "mht"  'haskell-mode-show-type-at
           "mgg"  'haskell-mode-goto-loc))


### PR DESCRIPTION
As discussed in #3197.

I've created separate PR for two reasons.

1. Original PR doesn't really solve the problem.
2. Author of that PR doesn't respond to any messages and suggestions. 

---

Tested with `ghc-mod`, `interactive-mode` (in different combinations), but haven't tested with `ghci-ng` (should be a problem, though, since we override binding). 

When `ghc-mod` and `interactive-mode` are both enabled it uses the binding from `interactive-mode`. Some people might not like it, but this is how it works in `haskell-mode` out of Spacemacs. Anyway, it's easy to set preferred bindings. 