### PR TITLE
core-keys: Make TAB more useful in help buffers

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -45,6 +45,10 @@
 (global-set-key (kbd "<left-margin> <double-mouse-1>") 'spacemacs/select-current-block)
 (global-set-key (kbd "<left-margin> <drag-mouse-1>") 'spacemacs/mu-select-linum)
 
+;; let TAB jump between links in help buffers
+(evil-define-key 'motion help-mode-map (kbd "TAB") 'forward-button)
+(evil-define-key 'motion help-mode-map (kbd "S-TAB") 'backward-button)
+
 ;; ---------------------------------------------------------------------------
 ;; evil-leader key bindings
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
In help buffers, TAB in emacs state allows you to jump through the
links. This allows for the same behavior in motion state. This is very
useful for jumping to function definitions.