### PR TITLE
Give a prefix and bindings for org applications

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -11,6 +11,7 @@
    - [[#gnuplot-support][Gnuplot support]]
    - [[#different-bullets][Different bullets]]
  - [[#key-bindings][Key bindings]]
+   - [[#global-keybindings][Global keybindings]]
    - [[#org-with-evil-org-mode][Org with evil-org-mode]]
      - [[#element-insertion][Element insertion]]
      - [[#links][Links]]
@@ -72,6 +73,26 @@ You can tweak the bullets displayed in the org buffer in the function
 #+END_SRC
 
 * Key bindings
+
+** Global keybindings
+
+| Key Binding | Description                    |
+|-------------+--------------------------------|
+| ~SPC a o #~ | org agenda list stuck projects |
+| ~SPC a o /~ | org occur in agenda files      |
+| ~SPC a o a~ | org agenda list                |
+| ~SPC a o e~ | org store agenda views         |
+| ~SPC a o m~ | org tags view                  |
+| ~SPC a o o~ | org agenda                     |
+| ~SPC a o s~ | org search view                |
+| ~SPC a o t~ | org todo list                  |
+| ~SPC a o O~ | org clock out                  |
+| ~SPC a o c~ | org capture                    |
+| ~SPC a o l~ | org store link                 |
+|-------------+--------------------------------|
+| ~SPC C c~   | org-capture                    |
+| ~SPC C t~   | ort/capture-todo               |
+| ~SPC C T~   | ort/capture-checkitem          |
 
 ** Org with evil-org-mode
 
@@ -232,12 +253,9 @@ org-present must be activated explicitly by typing: ~SPC : org-present~
 
 ** Org-repo-todo
 
-| Key Binding | Description           |
-|-------------+-----------------------|
-| ~SPC C c~   | org-capture           |
-| ~SPC C t~   | ort/capture-todo      |
-| ~SPC C T~   | ort/capture-checkitem |
-| ~SPC m g t~ | ort/goto-todos        |
+| Key Binding | Description    |
+|-------------+----------------|
+| ~SPC m g t~ | ort/goto-todos |
 
 ** Org-MIME
 

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -81,15 +81,14 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC a o #~ | org agenda list stuck projects |
 | ~SPC a o /~ | org occur in agenda files      |
 | ~SPC a o a~ | org agenda list                |
+| ~SPC a o c~ | org capture                    |
 | ~SPC a o e~ | org store agenda views         |
+| ~SPC a o l~ | org store link                 |
 | ~SPC a o m~ | org tags view                  |
 | ~SPC a o o~ | org agenda                     |
+| ~SPC a o O~ | org clock out                  |
 | ~SPC a o s~ | org search view                |
 | ~SPC a o t~ | org todo list                  |
-| ~SPC a o O~ | org clock out                  |
-| ~SPC a o c~ | org capture                    |
-| ~SPC a o l~ | org store link                 |
-|-------------+--------------------------------|
 | ~SPC C c~   | org-capture                    |
 | ~SPC C t~   | ort/capture-todo               |
 | ~SPC C T~   | ort/capture-checkitem          |

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -65,6 +65,7 @@
 (defun org/init-org ()
   (use-package org
     :mode ("\\.org$" . org-mode)
+    :commands (org-clock-out org-occur-in-agenda-files)
     :defer t
     :init
     (progn
@@ -196,7 +197,24 @@ Will work on both org-mode and any mode that accepts plain html."
         (define-key org-agenda-mode-map
           (kbd "RET") 'org-agenda-show-and-scroll-up)
         (define-key org-agenda-mode-map
-          (kbd "SPC") evil-leader--default-map)))
+          (kbd "SPC") evil-leader--default-map))
+
+      ;; Add global evil-leader mappings. Used to access org-agenda
+      ;; functionalities – and a few others commands – from any other mode.
+      (evil-leader/set-key
+        ;; org-agenda
+        "ao#" 'org-agenda-list-stuck-projects
+        "ao/" 'org-occur-in-agenda-files
+        "aoa" 'org-agenda-list
+        "aoe" 'org-store-agenda-views
+        "aom" 'org-tags-view
+        "aoo" 'org-agenda
+        "aos" 'org-search-view
+        "aot" 'org-todo-list
+        ;; other
+        "aoO" 'org-clock-out
+        "aoc" 'org-capture
+        "aol" 'org-store-link))
     :config
     (progn
       ;; setup org directory


### PR DESCRIPTION
Related to #1296.

Use `SPC a o` as prefix for org related applications like `org-agenda`
or `org-capture`. The `a` is for "application", and `o` for "org". To
avoid long keystrokes for `agenda`, direct bindings are offered through
`SPC a o <key>`.

Because `org-agenda` is one of the principal application, it has be
mapped to repeating the last letter (`SPC a o o`).