### PR TITLE
Use login shell as default term shell

### DIFF
--- a/layers/shell/config.el
+++ b/layers/shell/config.el
@@ -31,7 +31,7 @@
 (defvar shell-default-height 30
   "Height in percents for the shell window.")
 
-(defvar shell-default-term-shell "/bin/bash"
+(defvar shell-default-term-shell shell-file-name
   "Default shell to use in `term' and `ansi-term' shells.")
 
 (defvar shell-enable-smart-eshell nil


### PR DESCRIPTION
Use `shell-file-name` as default term shell, as it's the better default for users of shells other than bash.

Emacs initialises `shell-file-name` from `$SHELL`, i.e. the user’s current login shell, and falls back to a system-dependent default, which is just about as arbitrary as the current `/bin/bash` default.