### PR TITLE
Markup fixes

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -252,9 +252,9 @@ It is even possible to exclude /any/ unwanted packages.
 
 /Terminal (urxvt)/ [[file:img/spacemacs-urxvt.png]]
 
-/Note: Even though screenshots are updated frequently, =Spacemacs= is evolving
+*Note*: Even though screenshots are updated frequently, =Spacemacs= is evolving
 quickly and the screenshots may not reflect exactly the current state of the
-project./
+project.
 
 * Who can benefit from this?
 =Spacemacs= is first intended to be used by *Vim users* who want to go to the
@@ -2019,7 +2019,7 @@ selection.
 
 It is pretty useful combined with the [[#region-selection][expand-region]] bindings.
 
-/Note:/ If the current state is not the =visual state= then pressing ~*~ uses
+*Note*: If the current state is not the =visual state= then pressing ~*~ uses
 [[#auto-highlight-symbols][auto-highlight-symbol]] and its micro-state.
 
 *** Listing symbols by semantic

--- a/layers/jabber/README.org
+++ b/layers/jabber/README.org
@@ -15,7 +15,7 @@
 This layer adds keybindings for jabber.el. jabber.el is a Jabber (XMPP) client for Emacs
 
 * Install
-To use this contribution layer add it to your `~/.spacemacs`
+To use this contribution layer add it to your =~/.spacemacs=
  #+begin_src emacs-lisp
     (set-default dotspacemacs-configuration-layers '(jabber))
  #+end_src


### PR DESCRIPTION
This makes all Notes in DOCUMENTATION.org be *Note*: and changes the
markup around the spacemacs init file path in jabbers README.org to
proper org markup.