### PR TITLE
Let ESS configure company backends

### DIFF
--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -12,7 +12,5 @@
 
 ;; Variables
 
-(spacemacs|defvar-company-backends ess-mode)
-
 (defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -53,7 +53,8 @@
     :commands (R stata julia SAS)
     :init
     (progn
-      (push '(company-R-args company-R-objects) company-backends-ess-mode)))
+      (when (configuration-layer/package-usedp 'company)
+          (add-hook 'ess-mode-hook 'company-mode-on))))
 
   ;; R --------------------------------------------------------------------------
   (with-eval-after-load 'ess-site
@@ -110,6 +111,3 @@
     (progn
       (add-hook 'ess-mode-hook 'ess-smart-equals-mode)
       (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode))))
-
-(defun ess/post-init-company ()
-  (spacemacs|add-company-hook ess-mode))


### PR DESCRIPTION
ESS does a good job of configuring company (and auto-complete) back ends. Currently the spacemacs ess layer tries to do this configuration as well, with the result being that completions only work for R. This PR removes the completion configuration from the ess layer, allowing the ESS package to configure completions correctly. The main benefit is that completions now work in `ess-julia-mode` as well as in `ess-R-mode`.