### PR TITLE
Shows error when loading .spacemacs in *Messages* buffer 

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -361,7 +361,7 @@ value."
   "Load ~/.spacemacs if it exists."
   (let ((dotspacemacs (dotspacemacs/location)))
     (if (file-exists-p dotspacemacs)
-        (unless (ignore-errors (load dotspacemacs))
+        (unless (with-demoted-errors "Error loading .spacemacs: %S" (load dotspacemacs))
           (dotspacemacs/safe-load)))))
 
 (defun dotspacemacs/safe-load ()


### PR DESCRIPTION
If there is an error while loading .spacemacs, it currently ignores it silently and loads the template file. This PR uses the ```with-demoted-errors``` macro to show the error in the *Messages* buffer.