### PR TITLE
lang/go: Add goimports example to readme

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -18,7 +18,7 @@
 This layer adds extensive support for go.
 
 ** Features:
-- gofmt on file save
+- gofmt/goimports on file save
 - Auto-completion using [[https://github.com/nsf/gocode/tree/master/emacs][go-autocomplete]] (with the =auto-completion= layer)
 - Source analysis using [[http://golang.org/s/oracle-user-manual][go-oracle]]
 
@@ -53,6 +53,8 @@ formatter, set the value of =gofmt-command=, e.g.
 
 #+begin_src emacs-lisp
   (setq gofmt-command "goimports")
+  or
+  (go :variables gofmt-command "goimports")
 #+end_src
 
 * Working with Go


### PR DESCRIPTION
I realised only when writing the readme that the golang layer already had some documentation about goimports. However, I like the variable approach more, it seems to fit the design better.