### PR TITLE
Fix access to possibly void variable

### DIFF
--- a/layers/geolocation/packages.el
+++ b/layers/geolocation/packages.el
@@ -27,7 +27,7 @@
                 (lambda ()
                   (setq calendar-latitude osx-location-latitude
                         calendar-longitude osx-location-longitude)
-                  (unless calendar-location-name
+                  (unless (bound-and-true-p calendar-location-name)
                     (setq calendar-location-name
                           (format "%s, %s"
                                   osx-location-latitude


### PR DESCRIPTION
`calendar-location-name` comes from solar.el which is neither loaded by default nor by this layer.  Hence it can potentially be void and must not be accessed directly.

Wrap it in `bound-and-true-p` to guard against it being void.  Not sure though whether that's the right thing to do here, as I'm not sure what the intention of the original code was.