### PR TITLE
Fix escaping in buffer name regexp

### DIFF
--- a/layers/syntax-checking/packages.el
+++ b/layers/syntax-checking/packages.el
@@ -102,4 +102,4 @@ If the error list is visible, hide it.  Otherwise, show it."
     (setq flycheck-display-errors-function 'flycheck-pos-tip-error-messages)))
 
 (defun syntax-checking/post-init-popwin ()
-  (push '("^\*Flycheck.+\*$" :regexp t :dedicated t :position bottom :stick t :noselect t) popwin:special-display-config))
+  (push '("^\\*Flycheck.+\\*$" :regexp t :dedicated t :position bottom :stick t :noselect t) popwin:special-display-config))


### PR DESCRIPTION
Emacs has no raw strings, and needs two backslashes for a backslash in regular expressions.