### PR TITLE
Fixes #3379 - core: different elpa dir per emacs version

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -46,8 +46,13 @@
       configuration-layer-private-directory))
   "Spacemacs default directory for private layers.")
 
-(defconst configuration-layer-rollback-directory
-  (expand-file-name (concat spacemacs-cache-directory ".rollback/"))
+(defun configuration-layer/emacs-version-dirname ()
+  "Directory name for current emacs version.
+Example output: \"24.5\"."
+  (format "%d%s%d" emacs-major-version version-separator emacs-minor-version))
+
+(defvar configuration-layer-rollback-directory
+  (concat spacemacs-cache-directory ".rollback/")
   "Spacemacs rollback directory.")
 
 (defconst configuration-layer-rollback-info "rollback-info"
@@ -242,6 +247,15 @@ cache folder.")
   "Initialize `package.el'."
   (setq configuration-layer--refresh-package-timeout dotspacemacs-elpa-timeout)
   (unless package--initialized
+    (when dotspacemacs-enable-multiple-emacs-version
+      (setq configuration-layer-rollback-directory
+            (file-name-as-directory
+             (expand-file-name (configuration-layer/emacs-version-dirname)
+                               configuration-layer-rollback-directory)))
+      (setq package-user-dir
+            (file-name-as-directory
+             (expand-file-name (configuration-layer/emacs-version-dirname)
+                               package-user-dir))))
     (setq package-archives (configuration-layer//resolve-package-archives
                             configuration-layer--elpa-archives))
     ;; optimization, no need to activate all the packages so early

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -61,6 +61,11 @@ environment, otherwise it is strongly recommended to let it set to t.")
 (defvar dotspacemacs-elpa-timeout 5
   "Maximum allowed time in seconds to contact an ELPA repository.")
 
+(defvar dotspacemacs-enable-multiple-emacs-version nil
+  "If non nil, different emacs versions have different package directories.
+e.g. for Emacs 24.5, packages are stored in elpa/24.5/. Rollback
+directories are also separated.")
+
 (defvar dotspacemacs-configuration-layer-path '()
   "List of additional paths where to look for configuration layers.
 Paths must have a trailing slash (ie. `~/.mycontribs/')")

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -89,6 +89,10 @@ values."
    ;; If non nil then spacemacs will check for updates at startup
    ;; when the current branch is not `develop'. (default t)
    dotspacemacs-check-for-update t
+   ;; If non nil, different emacs versions have different package directories.
+   ;; e.g. for Emacs 24.5, packages are stored in elpa/24.5/. Rollback
+   ;; directories are also separated.
+   dotspacemacs-enable-multiple-emacs-version nil
    ;; One of `vim', `emacs' or `hybrid'.
    ;; `hybrid' is like `vim' except that `insert state' is replaced by the
    ;; `hybrid state' with `emacs' key bindings. The value can also be a list


### PR DESCRIPTION
For emacs 24.5.1 packages will be installed in .emacs.d/elpa/24.5.1, for emacs 24.4.1 packages will be installed in .emacs.d/elpa/24.4.1, etc.
For a user that uses several emacs versions with the same config, the packages for version X will be in .emacs.d/elpa/X and the packages for version Y will be in .emacs.d/elpa/Y.  This is instead of using the same .emacs.d/elpa and possibly having copmiled elisp packages the are incompatible with one of the emacs versions in use.

I've also changed the rollback directory to be version-dependent (`.cache/.rollback/VERSION/`), so rollback mechanism should work. If I've missed something, please point it out.

ref https://github.com/syl20bnr/spacemacs/issues/3379 
