### PR TITLE
More update tweaks

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -822,7 +822,7 @@ If called with a prefix argument ALWAYS-UPDATE, assume yes to update."
   (interactive "P")
   (spacemacs-buffer/insert-page-break)
   (spacemacs-buffer/append
-   "\nUpdating Spacemacs... (for now only ELPA packages are updated)\n")
+   "\nUpdating Emacs packages from remote repositories (ELPA, MELPA, etc.)... \n")
   (spacemacs-buffer/append
    "--> fetching new package repository indexes...\n")
   (spacemacs//redisplay)


### PR DESCRIPTION
First commit just fixes the message when updating packages.

The second commit mainly adds a check to make sure the working directory is clean before switching versions. The automatic update should not remove changes by the user. They can do that manually if they wish. It also restructures the function to make it a little easier to follow.