### PR TITLE
Only disable scala syntax checker in Ensime

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -156,8 +156,10 @@
       ;; Don't use scala checker if ensime mode is active, since it provides
       ;; better error checking.
       (with-eval-after-load 'flycheck
-        (defun scala/disable-flycheck () (flycheck-mode -1))
-        (add-hook 'ensime-mode-hook 'scala/disable-flycheck)))))
+        (defun scala/disable-flycheck-scala ()
+          (push 'scala flycheck-disabled-checkers))
+
+        (add-hook 'ensime-mode-hook 'scala/disable-flycheck-scala)))))
 
 (defun scala/init-noflet ())
 


### PR DESCRIPTION
Flycheck also includes a scalastyle syntax checker which is still useful because Ensime doesn't have scalastyle support.

This PR keeps Flycheck Mode enabled in Ensime, and only adds `scala` to `flycheck-disabled-checkers` to disable the `scala` checker locally.