### PR TITLE
Add missing keybinding for starting REPL from ess-julia-mode buffers

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -19,15 +19,7 @@ To use this contribution add it to your =~/.spacemacs=
 * Key Bindings
 
 ** Inferior REPL process
-Start an inferior REPL process with these commands:
-| Keybinding | Description         |
-|------------+---------------------|
-| ~SCP msir~ | start R process     |
-| ~SPC msis~ | start Stata process |
-| ~SPC msiS~ | start SAS process   |
-| ~SPC msij~ | start Julia process |
-
-Send code to inferior process commands:
+Send code to inferior process with these commands:
 
 | Key Binding | Description                                                      |
 |-------------+------------------------------------------------------------------|
@@ -52,7 +44,7 @@ Send code to inferior process commands:
 | ~CTRL+k~    | previous item in REPL history                                    |
 
 ** Helpers
-
+Helpers for inspecting objects at point are available in R buffers only.
 | Key Binding | Description                                                         |
 |-------------+---------------------------------------------------------------------|
 | ~SPC m h d~ | view data under point using [ess-R-data-view][ess-R-data-view]      |

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -64,11 +64,19 @@
           ess-expression-offset 2
           ess-nuke-trailing-whitespace-p t
           ess-default-style 'DEFAULT)
+
+    (defun spacemacs/ess-start-repl ()
+      "Start a REPL corresponding to the ess-language of the current buffer."
+      (interactive)
+      (cond
+       ((string= "S" ess-language) (call-interactively 'R))
+       ((string= "STA" ess-language) (call-interactively 'stata))
+       ((string= "SAS" ess-language) (call-interactively 'SAS))))
+
+    (evil-leader/set-key-for-mode 'ess-julia-mode
+      "msi" 'julia)
     (evil-leader/set-key-for-mode 'ess-mode
-      "msir" 'R
-      "msis" 'stata
-      "msiS" 'SAS
-      "msij" 'julia
+      "msi" 'spacemacs/ess-start-repl
       ;; noweb
       "mcC" 'ess-eval-chunk-and-go
       "mcc" 'ess-eval-chunk
@@ -76,10 +84,6 @@
       "mcm" 'ess-noweb-mark-chunk
       "mcN" 'ess-noweb-previous-chunk
       "mcn" 'ess-noweb-next-chunk
-      ;; helpers
-      "mhd" 'ess-R-dv-pprint
-      "mhi" 'ess-R-object-popup
-      "mht" 'ess-R-dv-ctable
       ;; REPL
       "msB" 'ess-eval-buffer-and-go
       "msb" 'ess-eval-buffer
@@ -91,6 +95,10 @@
       "msr" 'ess-eval-region
       "msT" 'ess-eval-function-and-go
       "mst" 'ess-eval-function
+      ;; R helpers
+      "mhd" 'ess-R-dv-pprint
+      "mhi" 'ess-R-object-popup
+      "mht" 'ess-R-dv-ctable
       )
     (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
     (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)


### PR DESCRIPTION
Since `ess-jula-mode` doesn't inherit from `ess-mode` the keybindings for starting REPLs from `ess-mode` buffers are not active in `ess-julia-mode`.  This PR fixes that by adding keybindings to `ess-julia-mode` so that a julia REPL can easily be started from julia scripts.