### PR TITLE
Fix image of update indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Its color depends on the number of versions available since your last update.
 Green means that your current version is recent, orange and red that your
 current version is older.
 
-[[file:doc/img/powerline-update.png]]
+![Image of update indicator](doc/img/powerline-update.png)
 
 Click on the arrow to update Spacemacs to the last version.
 


### PR DESCRIPTION
Looks like it was added in org format in https://github.com/syl20bnr/spacemacs/commit/2ab7a2a60fc40f94d6e2efcb058ca15cdb88de5f