### PR TITLE
Do not compile elisp on save

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -856,16 +856,6 @@ Compare them on count first,and in case of tie sort them alphabetically."
         (message "No words.")))
     words))
 
-;; byte compile elisp files
-(defun byte-compile-current-buffer ()
-  "`byte-compile' current buffer if it's emacs-lisp-mode and compiled file exists."
-  (interactive)
-  (when (and (eq major-mode 'emacs-lisp-mode)
-             (file-exists-p (byte-compile-dest-file buffer-file-name)))
-    (byte-compile-file buffer-file-name)))
-
-(add-hook 'after-save-hook 'byte-compile-current-buffer)
-
 ;; indent on paste
 ;; from Prelude: https://github.com/bbatsov/prelude
 (defun spacemacs/yank-advised-indent-function (beg end)


### PR DESCRIPTION
Remove the entire feature, mostly to make you aware that it's not really working well.  It's very intrusive—poping up a compilation buffer after _every_ save—and a constant nuisance.

I'm not sure what purpose this feature originally served, but I've chosen to remove rather than to improve it because it seems entirely redundant to me.  I see no use case at all:  

- It's unlikely that normal users ever need it for their configuration, since Spacemacs neither compiles files on its own, nor encourages users to compile their configuration.
- Emacs Lisp developers might need it for error checking of their sources, but then there's Flycheck, which is much less intrusive und much more powerful.

I'm aware that entirely removing it may not be the best option regardless, and I won't object to this PR being closed.  Nonetheless, I'd like to see this feature being improved.  Specifically, I think it belongs to the `emacs-lisp` layer and needs a clean way to disable it, i.e. an option, and probably also a proper popwin configuration.