### PR TITLE
Move .org-id-locations to .cache directory

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -70,6 +70,8 @@
     (progn
       (setq org-clock-persist-file
             (concat spacemacs-cache-directory "org-clock-save.el")
+            org-id-locations-file
+            (concat spacemacs-cache-directory ".org-id-locations")
             org-log-done t
             org-startup-with-inline-images t
             org-src-fontify-natively t)


### PR DESCRIPTION
My .org-id-locations turned up in the .emacs.d folder, but it probably should go into the .cache folder? Setting org-id-locations-file to point to the cache folder achieves that.