### PR TITLE
Mark css-indent-offset as safe local variable

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -50,6 +50,9 @@
     (progn
       (push 'company-css company-backends-css-mode)
 
+      ;; Mark `css-indent-offset' as safe-local variable
+      (put 'css-indent-offset 'safe-local-variable #'integerp)
+
       (defun css-expand-statement ()
         "Expand CSS block"
         (interactive)


### PR DESCRIPTION
Allows to set `css-indent-offset` via local variables without annoying prompts.  Don't know why Emacs doesn't do that itself, probably oversight.  I haven't found a debbugs entry for it, but also haven't bother to report one either :sunglasses: 