### PR TITLE
emacs-lisp: Add separate cmds for save and compile

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -856,16 +856,6 @@ Compare them on count first,and in case of tie sort them alphabetically."
         (message "No words.")))
     words))
 
-;; byte compile elisp files
-(defun byte-compile-current-buffer ()
-  "`byte-compile' current buffer if it's emacs-lisp-mode and compiled file exists."
-  (interactive)
-  (when (and (eq major-mode 'emacs-lisp-mode)
-             (file-exists-p (byte-compile-dest-file buffer-file-name)))
-    (byte-compile-file buffer-file-name)))
-
-(add-hook 'after-save-hook 'byte-compile-current-buffer)
-
 ;; indent on paste
 ;; from Prelude: https://github.com/bbatsov/prelude
 (defun spacemacs/yank-advised-indent-function (beg end)

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -1145,6 +1145,7 @@ ARG non nil means that the editing style is `vim'."
       ;; buffers that we manage
       (push '("*Help*"                 :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)
       (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
+      (push '("*Compile-Log*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Shell Command Output*" :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*Async Shell Command*"  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '(" *undo-tree*"           :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -61,6 +61,27 @@
           "mhh" 'elisp-slime-nav-describe-elisp-thing-at-point)))))
 
 (defun emacs-lisp/init-emacs-lisp ()
+
+  (defun spacemacs//warn-on-old-byte-compiled-file ()
+    "Warn if it's emacs-lisp-mode and compiled file exists and is
+older than the current file."
+    (when (and (file-exists-p (byte-compile-dest-file buffer-file-name))
+               (file-newer-than-file-p
+                (buffer-file-name)
+                (byte-compile-dest-file buffer-file-name)))
+      (message "warning: There is an older byte-compiled version of this file")))
+  (add-hook 'emacs-lisp-mode-hook
+            (lambda ()
+              (add-hook 'after-save-hook 'spacemacs//warn-on-old-byte-compiled-file nil t)))
+
+  (defun spacemacs/save-and-maybe-compile-elisp ()
+    "Save the file and byte-compile it if a byte-compiled version exists."
+    (interactive)
+    (call-interactively 'spacemacs/write-file)
+    (when (and (eq major-mode 'emacs-lisp-mode)
+               (file-exists-p (byte-compile-dest-file buffer-file-name)))
+      (byte-compile-file buffer-file-name)))
+
   (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
     (spacemacs/declare-prefix-for-mode mode "me" "eval")
     (spacemacs/declare-prefix-for-mode mode "mt" "tests")
@@ -71,6 +92,7 @@
       "mer" 'eval-region
       "mef" 'eval-defun
       "mel" 'lisp-state-eval-sexp-end-of-line
+      "mfs" 'spacemacs/save-and-maybe-compile-elisp
       "m,"  'lisp-state-toggle-lisp-state
       "mtb" 'spacemacs/ert-run-tests-buffer
       "mtq" 'ert))


### PR DESCRIPTION
1. Only issue a warning for old byte-compiled files on save
2. New command "SPC mfs" to save and byte-compile in emacs-lisp mode
3. Manage compile buffer with popwin

Ref #3398