### PR TITLE
Remove redundant flyspell-mode hook

### DIFF
--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -21,7 +21,6 @@
     :defer t
     :init
     (progn
-      (spacemacs/add-flyspell-hook 'markdown-mode)
       (spacemacs/add-flyspell-hook 'org-mode)
       (spacemacs/add-flyspell-hook 'text-mode)
       (spacemacs|add-toggle spelling-checking


### PR DESCRIPTION
Markdown Mode derives from Text Mode, and thus runs text-mode-hook anyway.  Hence, there's no use in adding Flyspell Mode to Markdown Mode Hook.