### PR TITLE
emacs-lisp: Use auto-compile package

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -856,16 +856,6 @@ Compare them on count first,and in case of tie sort them alphabetically."
         (message "No words.")))
     words))
 
-;; byte compile elisp files
-(defun byte-compile-current-buffer ()
-  "`byte-compile' current buffer if it's emacs-lisp-mode and compiled file exists."
-  (interactive)
-  (when (and (eq major-mode 'emacs-lisp-mode)
-             (file-exists-p (byte-compile-dest-file buffer-file-name)))
-    (byte-compile-file buffer-file-name)))
-
-(add-hook 'after-save-hook 'byte-compile-current-buffer)
-
 ;; indent on paste
 ;; from Prelude: https://github.com/bbatsov/prelude
 (defun spacemacs/yank-advised-indent-function (beg end)

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -5,6 +5,7 @@
 * Table of Contents                                                   :TOC@4:
  - [[#description][Description]]
  - [[#install][Install]]
+ - [[#auto-compile][Auto-compile]]
  - [[#key-bindings][Key bindings]]
    - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
    - [[#leader][Leader]]
@@ -21,6 +22,20 @@ To use this contribution add it to your =~/.spacemacs=
   (setq-default dotspacemacs-configuration-layers '(emacs-lisp))
 #+END_SRC
 
+* Auto-compile
+This layer adds the [[https://github.com/tarsius/auto-compile][auto-compile]] package to automatically keep the byte-compiled
+version of your Emacs lisp files synced with the uncompiled version on every
+save. If there are any compiler errors in the file, you will see a counter show
+up in the mode line. You can hover over these numbers to get a description or
+view the compiler output with the ~SPC m c l~ key binding. To disable the
+feature use this line in your =dotspacemacs/user-config= function.
+
+#+BEGIN_SRC emacs-lisp
+  (remove-hook 'emacs-lisp-mode-hook 'auto-compile-mode)
+#+END_SRC
+
+You can also exclude the =auto-compile= package.
+
 * Key bindings
 ** Working with lisp files (barfage, slurpage & more)
 Spacemacs comes with a special ~lisp-state~ for working with lisp code that
@@ -36,6 +51,8 @@ As this state works the same for all files, the documentation is in global
 |----------------------------+------------------------------------------------------------|
 | ~SPC m g g~                | go to definition of symbol under point                     |
 | ~SPC m h h~                | describe symbol at point                                   |
+| ~SPC m c c~                | byte compile the current file                              |
+| ~SPC m c l~                | popup compile-log buffer                                   |
 | ~SPC m e $~ or ~SPC m e l~ | go to end of current line and evaluate                     |
 | ~SPC m e b~                | evaluate current buffer                                    |
 | ~SPC m e c~                | evaluate current form (start with =defun=, =setq=, etc...) |

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -12,6 +12,7 @@
 
 (setq emacs-lisp-packages
       '(
+        auto-compile
         company
         eldoc
         elisp-slime-nav
@@ -46,6 +47,22 @@
 (defun emacs-lisp/post-init-eldoc ()
   (add-hook 'emacs-lisp-mode-hook 'eldoc-mode))
 
+(defun emacs-lisp/init-auto-compile ()
+  (use-package auto-compile
+    :defer t
+    :diminish (auto-compile-mode . "")
+    :init
+    (progn
+      (setq auto-compile-display-buffer nil
+            ;; lets spaceline manage the mode-line
+            auto-compile-use-mode-line nil
+            auto-compile-mode-line-counter t)
+      (add-hook 'emacs-lisp-mode-hook 'auto-compile-mode))
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'emacs-lisp-mode
+        "mcl" 'auto-compile-display-log))))
+
 (defun emacs-lisp/init-elisp-slime-nav ()
   ;; Elisp go-to-definition with M-. and back again with M-,
   (use-package elisp-slime-nav
@@ -62,9 +79,11 @@
 
 (defun emacs-lisp/init-emacs-lisp ()
   (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
+    (spacemacs/declare-prefix-for-mode mode "mc" "compile")
     (spacemacs/declare-prefix-for-mode mode "me" "eval")
     (spacemacs/declare-prefix-for-mode mode "mt" "tests")
     (evil-leader/set-key-for-mode mode
+      "mcc" 'emacs-lisp-byte-compile
       "me$" 'lisp-state-eval-sexp-end-of-line
       "meb" 'eval-buffer
       "mee" 'eval-last-sexp


### PR DESCRIPTION
Also add key bindings for compiling and showing the compile log.

@lunaryorn This seems like it may be a nicer solution to #3398 than #3404 