### PR TITLE
Improve indentation in golang

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -15,6 +15,8 @@
     (exec-path-from-shell-copy-env "GOPATH")
     (exec-path-from-shell-copy-env "GO15VENDOREXPERIMENT"))
 
+  (add-hook 'go-mode-hook (lambda () (setq-local tab-width 8)))
+
   (use-package go-mode
     :defer t
     :config


### PR DESCRIPTION
This makes emacs show on screen the format that gofmt uses.