### PR TITLE
spacemacs-layer: Fix linum-relative-mode

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1462,9 +1462,7 @@ It will toggle the overlay under point or create an overlay of one character."
     (evil-leader/set-key "tr" 'linum-relative-toggle)
     :config
     (progn
-      (setq linum-format 'linum-relative)
-      (setq linum-relative-current-symbol "")
-      (linum-relative-toggle))))
+      (setq linum-relative-current-symbol ""))))
 
 (defun spacemacs/init-move-text ()
   (use-package move-text


### PR DESCRIPTION
The toggle is being called after the package is loaded, but the package
is deferred based on a call to the toggle. This means that the first
time toggle is used it's called at least twice. Furthermore, `(setq
linum-format 'linum-relative)` effectively turns on the mode as it is.

Possible fix for #2161