### PR TITLE
ruby: Enable built-in Ruby Mode

### DIFF
--- a/layers/+frameworks/ruby-on-rails/packages.el
+++ b/layers/+frameworks/ruby-on-rails/packages.el
@@ -27,50 +27,51 @@
       (spacemacs|diminish projectile-rails-mode " ⇋" " RoR")
 
       ;; Find files
-      (evil-leader/set-key-for-mode 'enh-ruby-mode
-        "mrfa" 'projectile-rails-find-locale
-        "mrfc" 'projectile-rails-find-controller
-        "mrfe" 'projectile-rails-find-environment
-        "mrff" 'projectile-rails-find-feature
-        "mrfh" 'projectile-rails-find-helper
-        "mrfi" 'projectile-rails-find-initializer
-        "mrfj" 'projectile-rails-find-javascript
-        "mrfl" 'projectile-rails-find-lib
-        "mrfm" 'projectile-rails-find-model
-        "mrfn" 'projectile-rails-find-migration
-        "mrfo" 'projectile-rails-find-log
-        "mrfp" 'projectile-rails-find-spec
-        "mrfr" 'projectile-rails-find-rake-task
-        "mrfs" 'projectile-rails-find-stylesheet
-        "mrft" 'projectile-rails-find-test
-        "mrfu" 'projectile-rails-find-fixture
-        "mrfv" 'projectile-rails-find-view
-        "mrfy" 'projectile-rails-find-layout
-        "mrf@" 'projectile-rails-find-mailer
-        ;; Goto file
-        "mrgc" 'projectile-rails-find-current-controller
-        "mrgd" 'projectile-rails-goto-schema
-        "mrge" 'projectile-rails-goto-seeds
-        "mrgh" 'projectile-rails-find-current-helper
-        "mrgj" 'projectile-rails-find-current-javascript
-        "mrgg" 'projectile-rails-goto-gemfile
-        "mrgm" 'projectile-rails-find-current-model
-        "mrgn" 'projectile-rails-find-current-migration
-        "mrgp" 'projectile-rails-find-current-spec
-        "mrgr" 'projectile-rails-goto-routes
-        "mrgs" 'projectile-rails-find-current-stylesheet
-        "mrgt" 'projectile-rails-find-current-test
-        "mrgu" 'projectile-rails-find-current-fixture
-        "mrgv" 'projectile-rails-find-current-view
-        "mrgz" 'projectile-rails-goto-spec-helper
-        "mrg." 'projectile-rails-goto-file-at-point
-        ;; Rails external commands
-        "mrcc" 'projectile-rails-generate
-        "mri" 'projectile-rails-console
-        "mrr:" 'projectile-rails-rake
-        "mrxs" 'projectile-rails-server
-        ;; Refactoring 'projectile-rails-mode
-        "mrRx" 'projectile-rails-extract-region)
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (evil-leader/set-key-for-mode mode
+          "mrfa" 'projectile-rails-find-locale
+          "mrfc" 'projectile-rails-find-controller
+          "mrfe" 'projectile-rails-find-environment
+          "mrff" 'projectile-rails-find-feature
+          "mrfh" 'projectile-rails-find-helper
+          "mrfi" 'projectile-rails-find-initializer
+          "mrfj" 'projectile-rails-find-javascript
+          "mrfl" 'projectile-rails-find-lib
+          "mrfm" 'projectile-rails-find-model
+          "mrfn" 'projectile-rails-find-migration
+          "mrfo" 'projectile-rails-find-log
+          "mrfp" 'projectile-rails-find-spec
+          "mrfr" 'projectile-rails-find-rake-task
+          "mrfs" 'projectile-rails-find-stylesheet
+          "mrft" 'projectile-rails-find-test
+          "mrfu" 'projectile-rails-find-fixture
+          "mrfv" 'projectile-rails-find-view
+          "mrfy" 'projectile-rails-find-layout
+          "mrf@" 'projectile-rails-find-mailer
+          ;; Goto file
+          "mrgc" 'projectile-rails-find-current-controller
+          "mrgd" 'projectile-rails-goto-schema
+          "mrge" 'projectile-rails-goto-seeds
+          "mrgh" 'projectile-rails-find-current-helper
+          "mrgj" 'projectile-rails-find-current-javascript
+          "mrgg" 'projectile-rails-goto-gemfile
+          "mrgm" 'projectile-rails-find-current-model
+          "mrgn" 'projectile-rails-find-current-migration
+          "mrgp" 'projectile-rails-find-current-spec
+          "mrgr" 'projectile-rails-goto-routes
+          "mrgs" 'projectile-rails-find-current-stylesheet
+          "mrgt" 'projectile-rails-find-current-test
+          "mrgu" 'projectile-rails-find-current-fixture
+          "mrgv" 'projectile-rails-find-current-view
+          "mrgz" 'projectile-rails-goto-spec-helper
+          "mrg." 'projectile-rails-goto-file-at-point
+          ;; Rails external commands
+          "mrcc" 'projectile-rails-generate
+          "mri" 'projectile-rails-console
+          "mrr:" 'projectile-rails-rake
+          "mrxs" 'projectile-rails-server
+          ;; Refactoring 'projectile-rails-mode
+          "mrRx" 'projectile-rails-extract-region))
       ;; Ex-commands
       (evil-ex-define-cmd "A" 'projectile-toggle-between-implementation-and-test))))
 

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -13,8 +13,8 @@
 
 * Description
 
-This layer aims at providing support for the Ruby language using
-[[https://github.com/zenspider/enhanced-ruby-mode][enh-ruby-mode]] and [[https://github.com/dgutov/robe][robe-mode]].
+This layer provides support for the Ruby language with [[https://github.com/zenspider/enhanced-ruby-mode][enh-ruby-mode]] and [[https://github.com/dgutov/robe][robe-mode]].
+Optionally Enh Ruby Mode can be replaced with the built-in Emacs Ruby Mode.
 
 * Install
 
@@ -22,6 +22,16 @@ To use this contribution add it to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(ruby))
+#+END_SRC
+
+This layer supports two different Ruby modes: Emacs' built-in Ruby Mode and
+[[https://github.com/zenspider/enhanced-ruby-mode][enh-ruby-mode]].  By default this layer enables the latter.  To switch to the
+built-in Ruby Mode set =ruby-use-built-in-ruby-mode=:
+
+#+BEGIN_SRC emacs-lisp
+  (defun dotspacemacs/user-init ()
+    (setq-default ruby-use-built-in-ruby-mode t)
+  )
 #+END_SRC
 
 ** Prerequisites
@@ -64,20 +74,22 @@ Possible values are =rbenv= and =rvm=.
 
 ** Ruby (enh-ruby-mode, robe, inf-ruby, ruby-tools)
 
-| Key binding | Description                                 |
-|-------------+---------------------------------------------|
-| ~SPC m g g~ | go to definition (robe-jump)                |
-| ~SPC m h d~ | go to Documentation                         |
-| ~SPC m s f~ | send function definition                    |
-| ~SPC m s F~ | send function definition and switch to REPL |
-| ~SPC m s i~ | start REPL                                  |
-| ~SPC m s r~ | send region                                 |
-| ~SPC m s R~ | send region and switch to REPL              |
-| ~SPC m s s~ | switch to REPL                              |
-| ~SPC m x '~ | Change symbol or " string to '              |
-| ~SPC m x "~ | Change symbol or ' string to "              |
-| ~SPC m x :~ | Change string to symbol                     |
-| ~%~         | [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] jumps between blocks           |
+| Key binding | Description                                          |
+|-------------+------------------------------------------------------|
+| ~SPC m '~   | toggle quotes of current string (only built-in mode) |
+| ~SPC m {~   | toggle style of current block (only built-in mode)   |
+| ~SPC m g g~ | go to definition (robe-jump)                         |
+| ~SPC m h d~ | go to Documentation                                  |
+| ~SPC m s f~ | send function definition                             |
+| ~SPC m s F~ | send function definition and switch to REPL          |
+| ~SPC m s i~ | start REPL                                           |
+| ~SPC m s r~ | send region                                          |
+| ~SPC m s R~ | send region and switch to REPL                       |
+| ~SPC m s s~ | switch to REPL                                       |
+| ~SPC m x '~ | Change symbol or " string to '                       |
+| ~SPC m x "~ | Change symbol or ' string to "                       |
+| ~SPC m x :~ | Change string to symbol                              |
+| ~%~         | [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] jumps between blocks                    |
 
 ** ruby-test-mode
 

--- a/layers/+lang/ruby/config.el
+++ b/layers/+lang/ruby/config.el
@@ -13,6 +13,12 @@
 ;; Variables
 
 (spacemacs|defvar-company-backends enh-ruby-mode)
+(spacemacs|defvar-company-backends ruby-mode)
+
+(defvar ruby-use-built-in-ruby-mode nil
+  "If non-nil, use built-in Ruby Mode.
+
+Otherwise use Enh Ruby Mode, which is the default.")
 
 (defvar ruby-version-manager nil
   "If non nil defines the Ruby version manager (i.e. rbenv, rvm)")

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -11,34 +11,52 @@
 ;;; License: GPLv3
 
 (setq ruby-packages
-  '(
-    bundler
-    company
-    enh-ruby-mode
-    evil-matchit
-    flycheck
-    robe
-    ruby-test-mode
-    ruby-tools))
+      '(
+        bundler
+        company
+        evil-matchit
+        flycheck
+        robe
+        ruby-test-mode
+        ruby-tools))
 
 (when ruby-version-manager
   (add-to-list 'ruby-packages ruby-version-manager))
+
+(if ruby-use-built-in-ruby-mode
+    (add-to-list 'ruby-packages 'ruby-mode)
+  (add-to-list 'ruby-packages 'enh-ruby-mode))
 
 (defun ruby/init-rbenv ()
   "Initialize RBENV mode"
   (use-package rbenv
     :defer t
     :init (global-rbenv-mode)
-    :config (add-hook 'enh-ruby-mode-hook
-                      (lambda () (rbenv-use-corresponding)))))
+    :config (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+              (add-hook hook (lambda () (rbenv-use-corresponding))))))
 
 (defun ruby/init-rvm ()
   "Initialize RVM mode"
   (use-package rvm
     :defer t
     :init (rvm-use-default)
-    :config (add-hook 'enh-ruby-mode-hook
-                      (lambda () (rvm-activate-corresponding-ruby)))))
+    :config (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+              (add-hook hook
+                        (lambda () (rvm-activate-corresponding-ruby))))))
+
+(defun ruby/init-ruby-mode ()
+  (use-package ruby-mode
+    :defer t
+    :config
+    (progn
+      (evil-leader/set-key-for-mode 'ruby-mode
+        "m'" 'ruby-toggle-string-quotes
+        "m{" 'ruby-toggle-block)
+      (sp-with-modes 'ruby-mode
+        (sp-local-pair "{" "}"
+                       :pre-handlers '(sp-ruby-pre-handler)
+                       :post-handlers '(sp-ruby-post-handler (spacemacs/smartparens-pair-newline-and-indent "RET"))
+                       :suffix "")))))
 
 (defun ruby/init-enh-ruby-mode ()
   "Initialize Ruby Mode"
@@ -50,41 +68,46 @@
     (progn
       (setq enh-ruby-deep-indent-paren nil
             enh-ruby-hanging-paren-deep-indent-level 2)
-      (sp-with-modes '(ruby-mode enh-ruby-mode)
+      (sp-with-modes 'enh-ruby-mode
         (sp-local-pair "{" "}"
                        :pre-handlers '(sp-ruby-pre-handler)
                        :post-handlers '(sp-ruby-post-handler (spacemacs/smartparens-pair-newline-and-indent "RET"))
                        :suffix "")))))
 
 (defun ruby/post-init-evil-matchit ()
-  (add-hook `enh-ruby-mode-hook `turn-on-evil-matchit-mode))
-
+  (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+    (add-hook hook `turn-on-evil-matchit-mode)))
 
 (defun ruby/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'ruby-mode)
   (spacemacs/add-flycheck-hook 'enh-ruby-mode))
 
 (defun ruby/init-ruby-tools ()
   (use-package ruby-tools
     :defer t
     :init
-    (add-hook 'enh-ruby-mode-hook 'ruby-tools-mode)
+    (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+      (add-hook hook 'ruby-tools-mode))
     :config
     (progn
       (spacemacs|hide-lighter ruby-tools-mode)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mx\'" 'ruby-tools-to-single-quote-string)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mx\"" 'ruby-tools-to-double-quote-string)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mx:" 'ruby-tools-to-symbol))))
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (evil-leader/set-key-for-mode mode
+          "mx\'" 'ruby-tools-to-single-quote-string
+          "mx\"" 'ruby-tools-to-double-quote-string
+          "mx:" 'ruby-tools-to-symbol)))))
 
 (defun ruby/init-bundler ()
   (use-package bundler
     :defer t
     :init
-    (progn
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mbc" 'bundle-check)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mbi" 'bundle-install)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mbs" 'bundle-console)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mbu" 'bundle-update)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mbx" 'bundle-exec))))
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (evil-leader/set-key-for-mode mode
+        "mbc" 'bundle-check
+        "mbi" 'bundle-install
+        "mbs" 'bundle-console
+        "mbu" 'bundle-update
+        "mbx" 'bundle-exec))))
 
 (defun ruby/init-robe ()
   "Initialize Robe mode"
@@ -92,37 +115,47 @@
     :defer t
     :init
     (progn
-      (add-hook 'enh-ruby-mode-hook 'robe-mode)
+      (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+        (add-hook hook 'robe-mode))
       (when (configuration-layer/layer-usedp 'auto-completion)
-        (push 'company-robe company-backends-enh-ruby-mode)))
+        (push 'company-robe company-backends-enh-ruby-mode)
+        (push 'company-robe company-backends-ruby-mode)))
     :config
     (progn
       (spacemacs|hide-lighter robe-mode)
-      ;; robe mode specific
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mgg" 'robe-jump)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mhd" 'robe-doc)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mrsr" 'robe-rails-refresh)
-      ;; inf-enh-ruby-mode
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "msf" 'ruby-send-definition)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "msF" 'ruby-send-definition-and-go)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "msi" 'robe-start)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "msr" 'ruby-send-region)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "msR" 'ruby-send-region-and-go)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mss" 'ruby-switch-to-inf))))
+
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (evil-leader/set-key-for-mode mode
+          ;; robe mode specific
+          "mgg" 'robe-jump
+          "mhd" 'robe-doc
+          "mrsr" 'robe-rails-refresh
+          ;; inf-enh-ruby-mode
+          "msf" 'ruby-send-definition
+          "msF" 'ruby-send-definition-and-go
+          "msi" 'robe-start
+          "msr" 'ruby-send-region
+          "msR" 'ruby-send-region-and-go
+          "mss" 'ruby-switch-to-inf)))))
 
 (defun ruby/init-ruby-test-mode ()
   "Define keybindings for ruby test mode"
   (use-package ruby-test-mode
     :defer t
-    :init (add-hook 'enh-ruby-mode-hook 'ruby-test-mode)
+    :init (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+            (add-hook hook 'ruby-test-mode))
     :config
     (progn
       (spacemacs|hide-lighter ruby-test-mode)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mtb" 'ruby-test-run)
-      (evil-leader/set-key-for-mode 'enh-ruby-mode "mtt" 'ruby-test-run-at-point))))
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (evil-leader/set-key-for-mode mode "mtb" 'ruby-test-run)
+        (evil-leader/set-key-for-mode mode "mtt" 'ruby-test-run-at-point)))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun ruby/post-init-company ()
+    (spacemacs|add-company-hook ruby-mode)
     (spacemacs|add-company-hook enh-ruby-mode)
+
     (with-eval-after-load 'company-dabbrev-code
-      (push 'enh-ruby-mode company-dabbrev-code-modes))))
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (push mode company-dabbrev-code-modes)))))


### PR DESCRIPTION
Add built-in Ruby Mode.  Keybindings are added for both modes, and there are two extra bindings for the built-in mode which have no equivalent in Enh Ruby Mode to my knowledge.

This change enables Ruby Mode by default on Emacs 24.4 and newer where it was significantly improved, and otherwise keeps using Enh Ruby Mode.  That's a breaking change, obviously, and I'm fine with keeping enh ruby mode as default, too, so if you'd like to have that changed, just tell me :relaxed:  I think, though, that as of 24.4 the built-in Ruby Mode is much better than Enh Ruby Mode, but YMMV obviously.

In any case, there's a variable to explicitly enable/disable the built-in mode, of course.

That's my first major change to a layer, and I'm not sure whether it's all correct.  Please review carefully :blush: