### PR TITLE
Use tide instead of emacs-tss for typescript layer

### DIFF
--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -1,4 +1,4 @@
-#+TITLE: TypeScript contribution layer for Spacemacs
+#+TITLE: TypeScript Interactive Development Environment for Emacs
 
 [[file:img/TypeScript.png]]
 
@@ -6,41 +6,44 @@
  - [[#description][Description]]
  - [[#install][Install]]
      - [[#layer][Layer]]
-     - [[#prerequisites][Prerequisites]]
+     - [[#notes][Notes]]
  - [[#key-bindings][Key bindings]]
 
 * Description
 
-This layer adds support for TypeScript editing via [[https://github.com/clausreinke/typescript-tools][typescript-tools]] and
-[[https://github.com/aki2o/emacs-tss][emacs-tss]].
+This layer adds support for TypeScript editing via [[https://github.com/ananthakumaran/tide][tide]].
 
 This layer provides:
-- syntax coloring
-- error highlighting
-- auto-completion via Flymake
-- jump-to-definition
+- ElDoc
+- Auto complete
+- Flycheck
+- Jump to definition, Jump to type definition
+- Find occurrences
+- Rename symbol
+- Imenu
 
 * Install
 
 ** Layer
 
-To use this contribution add it to your =~/.spacemacs=
+You'll need typescript
+
+#+BEGIN_SRC sh
+  $ npm install -g typescript
+#+END_SRC
+
+then add this layer to your =~/.spacemacs=
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers '(typescript))
 #+END_SRC
 
-** Prerequisites
+** Notes
 
-You'll need [[https://github.com/clausreinke/typescript-tools][typescript-tools]] and fairly obviously also the TypeScript
-compiler:
+Make sure to add [[https://github.com/Microsoft/TypeScript/wiki/tsconfig.json][tsconfig.json]] in the project root folder.
 
-#+BEGIN_SRC sh
-  $ npm install typescript
-  $ git clone git://github.com/clausreinke/typescript-tools.git
-  $ cd typescript-tools/
-  $ npm install -g
-#+END_SRC
+tsserver mangles output sometimes [[https://github.com/Microsoft/TypeScript/issues/2758][issue - #2758]], which will result in json parse error. Try node version 0.12.x if you get this error
+
 
 * Key bindings
 
@@ -48,3 +51,4 @@ compiler:
 |-------------+----------------------------------|
 | ~SPC m g g~ | Jump to definition               |
 | ~SPC m h h~ | Show popup help (with type info) |
+| ~SPC m r r~ | Rename Symbol                    |

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -1,23 +1,32 @@
 ;;; packages.el --- typescript Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
-;; Copyright (c) 2014-2015 Chris Bowdon & Contributors
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
 ;;
-;; Author: Chris Bowdon <c.bowdon@bath.edu>
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
 
-(setq typescript-packages '(tss))
+(setq typetide-packages '(tide))
 
-(defun typescript/init-tss ()
-  "Initialize my package"
-  (use-package tss
+(defun typetide/init-tide ()
+  "Initialize tide package"
+  (use-package tide
     :defer t
-    :mode ("\\.ts\\'" . typescript-mode)
-    :init (evil-leader/set-key-for-mode 'typescript-mode
-            "mgg" 'tss-jump-to-definition
-            "mhh" 'tss-popup-help)
-    :config (tss-config-default)))
+    :init
+    (progn
+      (add-hook 'typescript-mode-hook
+                (lambda ()
+                  (evil-leader/set-key-for-mode 'typescript-mode
+                    "mgg" 'tide-jump-to-definition
+                    "mhh" 'tide-documentation-at-point
+                    "mrr" 'tide-rename-symbol)
+                  (tide-setup)
+                  (flycheck-mode t)
+                  (setq flycheck-check-syntax-automatically '(save mode-enabled))
+                  (eldoc-mode t)
+                  (company-mode-on))))
+    :config (message "Tide mode loaded")))


### PR DESCRIPTION
It seems like [typescript-tools](https://github.com/clausreinke/typescript-tools/) which is used by [emacs-tss](https://github.com/aki2o/emacs-tss) isn't maintained anymore. 

I've been using this [tide.el](https://github.com/ananthakumaran/tide) (which is written by the author of [typescript-mode.el](https://github.com/ananthakumaran/typescript.el)) for quite some time. It performs better than emacs-tss. 

thanks..