### PR TITLE
core: Factor out spacemacs-buffer creation

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -20,7 +20,7 @@ See `spacemacs/load-or-install-package' for more information."
   "Load PKG package. PKG will be installed if it is not already installed.
 Whenever the initial require fails the absolute path to the package
 directory is returned.
-If LOG is non-nil a message is displayed in spacemacs-mode buffer.
+If LOG is non-nil a message is displayed in spacemacs-buffer-mode buffer.
 FILE-TO-LOAD is an explicit file to load after the installation."
   (let ((warning-minimum-level :error))
     (condition-case nil

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -544,4 +544,40 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
     (beginning-of-line)
     (widget-forward 1)))
 
+(defun spacemacs-buffer/goto-buffer ()
+  "Create the special buffer for `spacemacs-mode' if it doesn't
+already exist, and switch to it."
+  (interactive)
+  (unless (buffer-live-p (get-buffer spacemacs-buffer-name))
+    (with-current-buffer (get-buffer-create spacemacs-buffer-name)
+      (save-excursion
+        (spacemacs-buffer/set-mode-line "")
+        ;; needed in case the buffer was deleted and we are recreating it
+        (setq spacemacs-buffer--note-widgets nil)
+        (spacemacs-buffer/insert-banner-and-buttons)
+        ;; non-nil if emacs is loaded
+        (if after-init-time
+            (progn
+              (when dotspacemacs-startup-lists
+                (spacemacs-buffer/insert-startupify-lists))
+              (spacemacs-buffer/set-mode-line spacemacs--default-mode-line)
+              (force-mode-line-update)
+              (spacemacs-buffer-mode))
+          (add-hook 'emacs-startup-hook
+                    (lambda ()
+                      (with-current-buffer (get-buffer-create spacemacs-buffer-name)
+                        (when dotspacemacs-startup-lists
+                          (spacemacs-buffer/insert-startupify-lists))
+                        (if configuration-layer-error-count
+                            (spacemacs-buffer/set-mode-line
+                             (format (concat "%s error(s) at startup! "
+                                             "Spacemacs may not be able to operate properly.")
+                                     configuration-layer-error-count))
+                          (spacemacs-buffer/set-mode-line spacemacs--default-mode-line))
+                        (force-mode-line-update)
+                        (spacemacs-buffer-mode)
+                        (spacemacs-buffer/goto-link-line))))))))
+  (spacemacs-buffer/goto-link-line)
+  (switch-to-buffer spacemacs-buffer-name))
+
 (provide 'core-spacemacs-buffer)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -564,9 +564,8 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
   (interactive)
   (with-current-buffer spacemacs-buffer-name
     (goto-char (point-min))
-    (re-search-forward "Homepage")
-    (beginning-of-line)
-    (widget-forward 1)))
+    (with-demoted-errors "spacemacs buffer error: %s"
+      (widget-forward 1))))
 
 (defun spacemacs-buffer/goto-buffer ()
   "Create the special buffer for `spacemacs-buffer-mode' if it doesn't

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -30,6 +30,30 @@ version the release note it displayed")
 (defvar spacemacs-buffer--previous-insert-type nil
   "Previous type of note inserted.")
 
+(defvar spacemacs-buffer-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [tab] 'widget-forward)
+    (define-key map (kbd "C-i") 'widget-forward)
+    (define-key map [backtab] 'widget-backward)
+    (define-key map (kbd "RET") 'widget-button-press)
+    (define-key map [down-mouse-1] 'widget-button-click)
+    map)
+  "Keymap for spacemacs buffer mode.")
+
+(define-derived-mode spacemacs-buffer-mode special-mode "Spacemacs buffer"
+  "Spacemacs major mode for startup screen.
+
+\\<spacemacs-buffer-mode-map>
+"
+  :group 'spacemacs
+  :syntax-table nil
+  :abbrev-table nil
+  (setq truncate-lines t)
+  ;; needed to make tab work correctly in terminal
+  (evil-define-key 'motion spacemacs-buffer-mode-map (kbd "C-i") 'widget-forward)
+  ;; motion state since this is a special mode
+  (add-to-list 'evil-motion-state-modes 'spacemacs-buffer-mode))
+
 (defun spacemacs-buffer/insert-banner-and-buttons ()
   "Choose a banner according to `dotspacemacs-startup-banner'and insert it
 in spacemacs buffer along with quick buttons underneath.
@@ -393,13 +417,13 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
       (spacemacs//redisplay))))
 
 (defmacro spacemacs//insert--shortcut (shortcut-char search-label &optional no-next-line)
-  `(define-key spacemacs-mode-map ,shortcut-char (lambda ()
-                                                   (interactive)
-                                                   (unless (search-forward ,search-label (point-max) t)
-                                                     (search-backward ,search-label (point-min) t))
-                                                   ,@(unless no-next-line
-                                                       '((forward-line 1)))
-                                                   (back-to-indentation))))
+  `(define-key spacemacs-buffer-mode-map ,shortcut-char (lambda ()
+                                                          (interactive)
+                                                          (unless (search-forward ,search-label (point-max) t)
+                                                            (search-backward ,search-label (point-min) t))
+                                                          ,@(unless no-next-line
+                                                              '((forward-line 1)))
+                                                          (back-to-indentation))))
 
 (defun spacemacs-buffer//insert-buttons ()
   (goto-char (point-max))
@@ -545,7 +569,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
     (widget-forward 1)))
 
 (defun spacemacs-buffer/goto-buffer ()
-  "Create the special buffer for `spacemacs-mode' if it doesn't
+  "Create the special buffer for `spacemacs-buffer-mode' if it doesn't
 already exist, and switch to it."
   (interactive)
   (unless (buffer-live-p (get-buffer spacemacs-buffer-name))

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -44,29 +44,8 @@
   (/ spacemacs-loading-dots-count spacemacs-loading-dots-chunk-count))
 (defvar spacemacs-loading-dots-chunk-threshold 0)
 
-(defvar spacemacs-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "<tab>") 'widget-forward)
-    (define-key map (kbd "<return>") 'widget-button-press)
-    (define-key map [backtab] 'widget-backward)
-    (define-key map [down-mouse-1] 'widget-button-click)
-    map)
-  "Keymap for spacemacs mode.")
-
 (defvar spacemacs--default-mode-line mode-line-format
   "Backup of default mode line format.")
-
-(define-derived-mode spacemacs-mode special-mode "Spacemacs"
-  "Spacemacs major mode for startup screen.
-
-\\<spacemacs-mode-map>
-"
-  :group 'spacemacs
-  :syntax-table nil
-  :abbrev-table nil
-  (setq truncate-lines t)
-  ;; motion state since this is a special mode
-  (add-to-list 'evil-motion-state-modes 'spacemacs-mode))
 
 (defun spacemacs/init ()
   "Perform startup initialization."

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -69,8 +69,7 @@
   (add-to-list 'evil-motion-state-modes 'spacemacs-mode))
 
 (defun spacemacs/init ()
-  "Create the special buffer for `spacemacs-mode' and perform startup
-initialization."
+  "Perform startup initialization."
   ;; explicitly set the prefered coding systems to avoid annoying prompt
   ;; from emacs (especially on Microsoft Windows)
   (prefer-coding-system 'utf-8)
@@ -82,11 +81,9 @@ initialization."
   (dotspacemacs|call-func dotspacemacs/user-init "Calling dotfile user init...")
   ;; spacemacs init
   (require 'core-configuration-layer)
-  (switch-to-buffer (get-buffer-create spacemacs-buffer-name))
+  ;; spacemacs buffer
+  (spacemacs-buffer/goto-buffer)
   (setq initial-buffer-choice (lambda () (get-buffer spacemacs-buffer-name)))
-  (spacemacs-buffer/set-mode-line "")
-  ;; no welcome buffer
-  (setq inhibit-startup-screen t)
   ;; silence ad-handle-definition about advised functions getting redefined
   (setq ad-redefinition-action 'accept)
   ;; default theme
@@ -121,8 +118,6 @@ initialization."
       (spacemacs/set-default-font dotspacemacs-default-font)
     (spacemacs-buffer/warning "Cannot find font \"%s\"!"
                               (car dotspacemacs-default-font)))
-  ;; banner
-  (spacemacs-buffer/insert-banner-and-buttons)
   ;; mandatory dependencies
   ;; dash is required to prevent a package.el bug with f on 24.3.1
   (spacemacs/load-or-install-protected-package 'dash t)
@@ -153,9 +148,7 @@ initialization."
   ;; check for new version
   (if dotspacemacs-mode-line-unicode-symbols
       (setq-default spacemacs-version-check-lighter "[⇪]"))
-  (spacemacs/set-new-version-lighter-mode-line-faces)
-  (add-hook 'emacs-startup-hook 'spacemacs-buffer/goto-link-line)
-  (spacemacs-mode))
+  (spacemacs/set-new-version-lighter-mode-line-faces))
 
 (defun spacemacs/maybe-install-dotfile ()
   "Install the dotfile if it does not exist."
@@ -199,18 +192,8 @@ initialization."
         (format "\n[%s packages loaded in %.3fs]\n"
                 (configuration-layer/configured-packages-count)
                 elapsed)))
-     ;; Display useful lists of items
-     (when dotspacemacs-startup-lists
-       (spacemacs-buffer/insert-startupify-lists))
-     (if configuration-layer-error-count
-         (spacemacs-buffer/set-mode-line
-          (format (concat "%s error(s) at startup! "
-                          "Spacemacs may not be able to operate properly.")
-                  configuration-layer-error-count))
-       (spacemacs-buffer/set-mode-line spacemacs--default-mode-line))
-     (force-mode-line-update)
-     (spacemacs/check-for-new-version spacemacs-version-check-interval)
-     (add-hook 'pre-command-hook 'spacemacs//handle-terminal-keys))))
+     (add-hook 'pre-command-hook 'spacemacs//handle-terminal-keys)
+     (spacemacs/check-for-new-version spacemacs-version-check-interval))))
 
 (defun spacemacs/describe-system-info ()
   "Gathers info about your Spacemacs setup and copies to clipboard."

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -196,8 +196,8 @@ If you are looking for commands to operate on your buffer, they are right under
 ~SPC b~, if you want to operate on your project, then it is ~SPC p~, etc...
 
 ** Discoverable
-Spacemacs comes with a dedicated major mode =spacemacs-mode=. Its goal is to
-give useful feedbacks and easily perform maintenance tasks.
+Spacemacs comes with a dedicated major mode =spacemacs-buffer-mode=. Its goal is
+to give useful feedbacks and easily perform maintenance tasks.
 
 It also comes with dedicated [[https://github.com/emacs-helm/helm][helm]] sources to quickly find layers, packages and
 more.

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -394,10 +394,8 @@ argument takes the kindows rotate backwards."
   (delete-other-windows)
   (split-window-right))
 
-(defun spacemacs/home ()
-  "Go to home Spacemacs buffer"
-  (interactive)
-  (switch-to-buffer "*spacemacs*"))
+(defalias 'spacemacs/home 'spacemacs-buffer/goto-buffer
+  "Go to home Spacemacs buffer")
 
 (defun spacemacs/insert-line-above-no-indent (count)
   (interactive "p")

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -104,7 +104,7 @@
     :commands spacemacs/ace-buffer-links
     :init
     (progn
-      (define-key spacemacs-mode-map "o" 'spacemacs/ace-buffer-links)
+      (define-key spacemacs-buffer-mode-map "o" 'spacemacs/ace-buffer-links)
       (with-eval-after-load 'info
         (define-key Info-mode-map "o" 'ace-link-info))
       (with-eval-after-load 'help-mode


### PR DESCRIPTION
Factor out the code related to creating the spacemacs buffer, so that it
can be recreated easily if it gets deleted.

Completes @person808's work on #3357 