### PR TITLE
Override C-s in SPC p p to use other search tools

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1199,6 +1199,19 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         (interactive)
         (spacemacs/helm-project-smart-do-search t))
 
+      ;; This overrides the default C-s action in helm-projectile-switch-project
+      ;; to search using ag/pt/whatever instead of just grep
+      (with-eval-after-load 'helm-projectile
+        (defun spacemacs/helm-project-smart-do-search-in-dir (dir)
+          (interactive)
+          (let ((default-directory dir))
+            (spacemacs/helm-project-smart-do-search)))
+        (define-key helm-projectile-projects-map
+          (kbd "C-s")
+          (lambda ()
+            (interactive)
+            (helm-exit-and-execute-action 'spacemacs/helm-project-smart-do-search-in-dir))))
+
       ;; evilify the helm-grep buffer
       (evilify helm-grep-mode helm-grep-mode-map
                (kbd "RET") 'helm-grep-mode-jump-other-window


### PR DESCRIPTION
`SPC p p` has a `C-s` binding and action that runs grep on the given project without having to open a file and to `SPC /`. This PR makes it run the appropriate search tool instead of only using grep.

I wanted to use use-package hooks, but couldn't get them to work. I even added a nonempty `:config` to `helm-projectile` but no dice.