### PR TITLE
Adapt project-search keybindings

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1935,8 +1935,8 @@ called =pt=.
 **** Searching in a project
 | Key Binding           | Description                                         |
 |-----------------------+-----------------------------------------------------|
-| ~SPC s p~             | search with the first found tool                    |
-| ~SPC /~  or ~SPC s P~ | search with the first found tool with default input |
+| ~SPC /~  or ~SPC s p~ | search with the first found tool                    |
+| ~SPC *~  or ~SPC s P~ | search with the first found tool with default input |
 | ~SPC s a p~           | =ag=                                                |
 | ~SPC s a P~           | =ag= with default text                              |
 | ~SPC s g p~           | =grep= with default text                            |

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1229,7 +1229,8 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "stf" 'spacemacs/helm-files-do-pt
         "stF" 'spacemacs/helm-files-do-pt-region-or-symbol
         ;; current project scope
-        "/"   'spacemacs/helm-project-smart-do-search-region-or-symbol
+        "/"   'spacemacs/helm-project-smart-do-search
+        "*"   'spacemacs/helm-project-smart-do-search-region-or-symbol
         "sp"  'spacemacs/helm-project-smart-do-search
         "sP"  'spacemacs/helm-project-smart-do-search-region-or-symbol
         "sap" 'spacemacs/helm-project-do-ag


### PR DESCRIPTION
For buffers, `*` search for the word under the cursor, and `/` ask to
search for an expression. To keep the same mnemonic at project level,
this commit change `SPC /` to ask for an expression to search, and add
`SPC *` to search for the expression under the cursor (in fact the only
difference being the expression pre-filled inside the input field).