### PR TITLE
fixed space-j-k unwanted comment when cursor on comments a line operate to next uncompate form line

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -111,7 +111,7 @@ the current state and point position."
   (let ((counter (or count 1)))
     (while (> counter 0)
       (join-line 1)
-      (sp-newline)
+      (newline-and-indent)
       (setq counter (1- counter)))))
 
 ;; from Prelude


### PR DESCRIPTION
when cursor on comment line then indent with unwanted comment
     ;; replace a global binding with own function
     (define-key lispy-mode-map
       (kbd "C-e") 'my-custom-eol)
 
will to :
     ;; replace a global binding with own function
     ;; (define-key lispy-mode-map
       (kbd "C-e") 'my-custom-eol)