### PR TITLE
Added visual-marks layer

### DIFF
--- a/layers/+vim/visual-marks/README.org
+++ b/layers/+vim/visual-marks/README.org
@@ -1,0 +1,25 @@
+#+TITLE: visual-marks layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#install][Install]]
+   - [[#layer][Layer]]
+ - [[#keybindings][Keybindings]]
+
+* Description
+The package [[https://github.com/roman/evil-visual-mark-mode][evil-visual-mark-mode]] allows you to see your marks visually in your file.
+
+* Install
+** Layer
+
+To use this contribution add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(visual-marks))
+#+END_SRC
+
+* Keybindings
+
+| Key Binding | Description             |
+|-------------+-------------------------|
+| ~SPC t M~   | Toggle visual mark mode |

--- a/layers/+vim/visual-marks/extensions.el
+++ b/layers/+vim/visual-marks/extensions.el
@@ -1,0 +1,21 @@
+;;; extensions.el --- visual-marks Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq visual-marks-pre-extensions
+      '(
+        ;; pre extension names go here
+        ))
+
+(setq visual-marks-post-extensions
+      '(
+        ;; post extension names go here
+        ))

--- a/layers/+vim/visual-marks/keybindings.el
+++ b/layers/+vim/visual-marks/keybindings.el
@@ -1,0 +1,1 @@
+(evil-leader/set-key "tM" 'evil-visual-mark-mode)

--- a/layers/+vim/visual-marks/packages.el
+++ b/layers/+vim/visual-marks/packages.el
@@ -1,0 +1,20 @@
+;;; packages.el --- visual-marks Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq visual-marks-packages
+    '(
+      evil-visual-mark-mode
+      ))
+
+(setq visual-marks-excluded-packages '())
+
+(defun visual-marks/init-evil-visual-mark-mode ())


### PR DESCRIPTION
Allows you to see your marks (created by `ma`, `mb`, `m[char]`) where you set them in your file.

Future
=====

* It would be nice to have a micro-state where you can jump forward and backwards through your marks
* Perhaps have a helm source, similar to `swoop`, that just shows all the lines with your marks, and allows you to search through them.