### PR TITLE
corrected brew tap url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Both Emacs and XEmacs have graphical support.
 We recommend the homebrew [emacs-mac-port][] formula:
 
 ```sh
-$ brew tap railwaycat/emacsmacport
+$ brew tap railwaycat/homebrew-emacsmacport
 $ brew install emacs-mac --with-spacemacs-icon  # OR, brew cask install emacs-mac
 ```
 


### PR DESCRIPTION
README correction: corrects url of formula for `brew tap` on OS X