### PR TITLE
Add jbeans theme

### DIFF
--- a/layers/themes-megapack/packages.el
+++ b/layers/themes-megapack/packages.el
@@ -49,6 +49,7 @@
     inkpot-theme
     ir-black-theme
     jazz-theme
+    jbeans-theme
     light-soap-theme
     lush-theme
     material-theme


### PR DESCRIPTION
https://github.com/synic/jbeans-emacs is a theme I started by forking ujelly and just changing the colors I didn't agree with, and adding other colors for things that weren't supported.  It's different enough from the original that I think it warrants it's own theme.

1.  The default foreground white color isn't so bright and blinding.
2.  It's got better support for spacemacs - things that are completely missing (like ediff and flycheck) in ujelly are not missing in jbeans.
3.  Better magit colors.  At least to me, they stand out much better.  In the original, the added/removed lines don't stand out very well - they don't have a background color set.  In this one, they look more like what you see in `zenburn`.