### PR TITLE
Adding window layout toggle (vertical <-> horizontal)

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -167,6 +167,24 @@ windows."
     (window-state-put state1 window2)
     (window-state-put state2 window1)))
 
+;; from @bmag
+(defun spacemacs/window-layout-toggle ()
+  "Toggle between horizontal and vertical layout of two windows."
+  (interactive)
+  (when (= (count-windows) 2)
+    (let* ((window-tree (car (window-tree)))
+           (current-split-vertical-p (car window-tree))
+           (first-window (nth 2 window-tree))
+           (second-window (nth 3 window-tree))
+           (second-window-state (window-state-get second-window))
+           (splitter (if current-split-vertical-p
+                         #'split-window-horizontally
+                       #'split-window-vertically)))
+      (delete-other-windows first-window)
+      ;; `window-state-put' also re-selects the window if needed, so we don't
+      ;; need to call `select-window'
+      (window-state-put second-window-state (funcall splitter)))))
+
 ;; originally from magnars and modified by ffevotte for dedicated windows
 ;; support, it has quite diverged by now
 (defun spacemacs/rotate-windows-forward (count)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -405,6 +405,7 @@
   "ww"  'other-window
   "w/"  'split-window-right
   "w="  'balance-windows
+  "w+"  'spacemacs/window-layout-toggle
   "w_"  'spacemacs/maximize-horizontally)
 ;; text -----------------------------------------------------------------------
 (defalias 'count-region 'count-words-region)


### PR DESCRIPTION
Generally I find toggling window layout when window I open unintentionally opens in other layout. This PR adds a toggle to easily switch between the layouts using `SPC w +`. Used `+` as it's free binding and denotes both layouts in one symbol.