### PR TITLE
doc: Don't make a link to quelpa verbatim

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -355,7 +355,7 @@ Where:
 
 =Packages= are =ELPA= packages which can be installed from an =ELPA= compliant
 repository, local packages in a layer's =local= folder, or packages that can be
-installed from an online source using =[[https://github.com/quelpa/quelpa][quelpa]]=.
+installed from an online source using [[https://github.com/quelpa/quelpa][quelpa]].
 
 ** Packages
 *** Within a layer


### PR DESCRIPTION
At least GitHubs org renderer only showed the raw markup when rendering
this link.