### PR TITLE
remove tern port files

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -54,6 +54,13 @@ To activate error checking using flycheck install =JSHint=:
 
 * Configuration
 
+To make tern re-use the server across multiple different editing sessions (thus creating multiple 
+`.tern-port` files for each document you have open [[http://ternjs.net/doc/manual.html][see here for more details]]):
+
+#+BEGIN_SRC emacs-lisp
+  (javascript :variables javascript-disable-tern-port-files nil)
+#+END_SRC
+
 To change how js2-mode indents code, set the variable =js2-basic-offset=, as such:
 
 #+BEGIN_SRC emacs-lisp

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -21,3 +21,6 @@
 (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
                    'js2-mode (car x) (cdr x)))
       javascript/key-binding-prefixes)
+
+(defvar javascript-disable-tern-port-files t
+  "stops tern from creating tern port files")

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -191,6 +191,8 @@
     :init (add-hook 'js2-mode-hook 'tern-mode)
     :config
     (progn
+      (when javascript-disable-tern-port-files
+        (add-to-list 'tern-command "--no-port-file" 'append))
       (spacemacs/set-leader-keys-for-major-mode 'js2-mode "rrV" 'tern-rename-variable)
       (spacemacs/set-leader-keys-for-major-mode 'js2-mode "hd" 'tern-get-docs)
       (spacemacs/set-leader-keys-for-major-mode 'js2-mode "gg" 'tern-find-definition)


### PR DESCRIPTION
Javascript mode leaves a bunch of `.tern-port` files lying around everywhere you edit a javascript file. To avoid having to add these to any projects `.gitignore` don't create them in the first place.