### PR TITLE
Don’t change custom-file if already set

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -188,7 +188,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; ---------------------------------------------------------------------------
 
 ;; save custom variables in ~/.spacemacs
-(setq custom-file (dotspacemacs/location))
+(unless (bound-and-true-p custom-file)
+  (setq custom-file (dotspacemacs/location)))
 ;; scratch buffer empty
 (setq initial-scratch-message nil)
 ;; don't create backup~ files


### PR DESCRIPTION
Allows users to change the location of custom-file safely.

That's a pretty important thing to me, as I keep my Spacemacs configuration in a public dotfile repository and use custom variables for system specific and private settings that must not end up in version control.

In my `~/.spacemacs.d/init.el` that changes `custom-file` when `init.el` is loaded, but obviously Spacemacs overrides it.  Changing `custom-file` after Spacemacs initialisation is not enough because some code (particularly package installation) in Spacemacs initialisation writes custom variables, so they could sometimes still end up in `init.el`. 