### PR TITLE
Declare `spacemacs/write-file` as not repeatable

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -709,7 +709,7 @@ the right."
   (if (buffer-file-name)
       (call-interactively 'evil-write)
     (call-interactively 'write-file)))
-
+(evil-declare-not-repeat 'spacemacs/write-file)
 
 (defun spacemacs/dos2unix ()
   "Converts the current buffer to UNIX file format."


### PR DESCRIPTION
Close #3433.

`evil-repeat` repeat the last action, but ignore calls to `write-file`
or `evil-write`. `spacemacs/write-file` is a wrapper around those two
function, so it should be ignored to.