### PR TITLE
Update geolocation (re-write)

### DIFF
--- a/layers/geolocation/README.org
+++ b/layers/geolocation/README.org
@@ -19,7 +19,6 @@ forecast and on OS X, also automatic tracking of location, using OS X's
 CoreLocation services.
 
 ** Supported packages in this layer
-- [[https://github.com/hadronzoo/theme-changer][theme-changer]]
 - [[https://github.com/aaronbieber/sunshine.el/blob/master/sunshine.el][sunshine]]
 - [[https://github.com/purcell/osx-location][osx-location]]
 
@@ -27,7 +26,7 @@ CoreLocation services.
 To enable this contribution layer, add it to your =~/.spacemacs=~ like this:
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(location))
+  (setq-default dotspacemacs-configuration-layers '(geolocation))
 #+END_SRC
 
 All services are disable by default. To enable all, or some of them, add instead
@@ -35,9 +34,9 @@ something like this:
 
 #+BEGIN_SRC emacs-lisp
   (geolocation :variables
-               geolocation-enable-osx-location-service-support t
-               geolocation-enable-weather-forecast t
-               geolocation-enable-automatic-theme-changer t)
+               geolocation-enable-automatic-theme-changer t
+               geolocation-enable-location-service t
+               geolocation-enable-weather-forecast t)
 #+END_SRC
 
 * Configuration
@@ -51,24 +50,33 @@ defun~.
         calendar-longitude 1.80)
 #+END_SRC
 
-On OS X, all of these variables get setup automatically by the ~osx-location~
-service, when enabled. If ~calendar-location-name~ was omitted, it'll be
-stringed-up like so: "41.23, 1.80".
+On OS X, all of these variables get setup automatically if the ~osx-location~
+service was enabled. In this case, if ~calendar-location-name~ was omitted,
+it'll be stringed-up ~calendar-latitude~ and ~calendar-longitude~ i.e. "41.23,
+1.80".
 
 ** theme-changer
-Theme changer will switch between the first two themes the user has setup in
-~dotspacemacs-themes~, depending on time at geographical location.
+This layer implement a simple "theme changer" which, when enabled, will switch
+between first two themes the user has setup in ~dotspacemacs-themes~. First
+theme listed will be used as light variant, while the second as the the dark.
+Other themes will be ignored by this layer, though they are still available for
+cycling, etc.
 
 ** sunshine (weather forecast)
-Sunshine uses the imperial unit system by default. To switch to metric, do this:
+Sunshine display local weather forecast.
+
+It will use the imperial unit system by default. To switch to metric, add
+~sunshine-units 'metric~ to the variables list for this layer, or add this.
 
 #+BEGIN_SRC emacs-lisp
   (setq sunshine-units 'metric)
 #+END_SRC
 
-Weather forecast icons are disabled by default, but can be toggled by pressing
-`i' within this mode's main buffer. To display weather forecast icons by default
-("pretty mode"), change the settings to this:
+Weather forecast icons are disabled by default, and can be toggled by pressing
+`i' within this mode's main buffer. 
+
+To display weather forecast icons by default ("pretty mode"), add
+~sunshine-show-icons t~ to the variables list for this layer, or add this:
 
 #+BEGIN_SRC emacs-lisp
   (setq sunshine-show-icons t)

--- a/layers/geolocation/config.el
+++ b/layers/geolocation/config.el
@@ -10,11 +10,12 @@
 ;;
 ;;; License: GPLv3
 
-(defvar geolocation-enable-osx-location-service-support nil
+(defvar geolocation-enable-automatic-theme-changer nil
+  "If non nil enable the automatic change of theme based on the current time.")
+
+(defvar geolocation-enable-location-service nil
   "If non nil enable the OS X location service support.")
 
 (defvar geolocation-enable-weather-forecast nil
   "If non nil enable the weather forecast service.")
 
-(defvar geolocation-enable-automatic-theme-changer nil
-  "If non nil enable the automatic change of theme based on the current time.")

--- a/layers/geolocation/extensions.el
+++ b/layers/geolocation/extensions.el
@@ -1,0 +1,19 @@
+;;; extensions.el --- geolocation configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Uri Sharf & Contributors
+;;
+;; Author: Uri Sharf <uri.sharf@me.com>
+;; URL: https://github.com/usharf/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq geolocation-post-extensions '(theme-changer))
+
+(defun geolocation/init-theme-changer ()
+  "Initialize theme-changer"
+  (use-package theme-changer
+    :if (and geolocation-enable-automatic-theme-changer
+             (> (length dotspacemacs-themes) 1))))

--- a/layers/geolocation/extensions/theme-changer/theme-changer.el
+++ b/layers/geolocation/extensions/theme-changer/theme-changer.el
@@ -1,0 +1,33 @@
+;;; theme-changer.el --- geolocation configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Uri Sharf & Contributors
+;;
+;; Author: Uri Sharf <uri.sharf@me.com>
+;; URL: https://github.com/usharf/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(require 'rase)
+
+(defun theme-changer/switch-themes (sun-event &optional first-run)
+  "Switch first two themes in dotspacemacs-themes on sunrise and sunset."
+  (if first-run				                ; set theme on initialization
+      (cond ((memq sun-event '(sunrise midday))
+             (load-theme (nth 0 dotspacemacs-themes) t))
+            ((memq sun-event '(sunset midnight))
+             (load-theme (nth 1 dotspacemacs-themes) t)))
+    (cond ((eq sun-event 'sunrise)    ; after initialization deal only with
+                                        ; sunrise and sunset
+           (load-theme (nth 0 dotspacemacs-themes) t))
+          ((eq sun-event 'sunset)
+           (load-theme (nth 1 dotspacemacs-themes) t))))
+  )
+
+(with-eval-after-load 'rase ; probably redaundant because it's a post extension
+  (add-hook 'rase-functions 'theme-changer/switch-themes)
+  (rase-start t))
+
+(provide 'theme-changer)

--- a/layers/geolocation/packages.el
+++ b/layers/geolocation/packages.el
@@ -1,10 +1,10 @@
-;;; packages.el --- Geolocation Layer packages File for Spacemacs
+;;; packages.el --- geolocation configuration File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
-;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;; Copyright (c) 2014-2015 Uri Sharf & Contributors
 ;;
-;; Author: Sylvain Benner <sylvain.benner@gmail.com>
-;; URL: https://github.com/syl20bnr/spacemacs
+;; Author: Uri Sharf <uri.sharf@me.com>
+;; URL: https://github.com/usharf/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -13,32 +13,62 @@
 (setq geolocation-packages
     '(
       osx-location
+      popwin
+      rase
       sunshine
-      theme-changer
       ))
 
 (defun geolocation/init-osx-location ()
   "Initialize osx-location"
   (use-package osx-location
-    :if geolocation-enable-osx-location-service-support
+    :if geolocation-enable-location-service
+    :defer t
     :init
     (progn
-      (add-hook 'osx-location-changed-hook
-                (lambda ()
-                  (setq calendar-latitude osx-location-latitude
-                        calendar-longitude osx-location-longitude)
-                  (unless calendar-location-name
-                    (setq calendar-location-name
-                          (format "%s, %s"
-                                  osx-location-latitude
-                                  osx-location-longitude)))))
-      (osx-location-watch))))
+      (when (spacemacs/system-is-mac)
+          (add-hook 'osx-location-changed-hook
+                    (lambda ()
+                      (let ((location-changed-p nil)
+                            (_longitude (/ (truncate (* osx-location-longitude 10)) 10.0)) ; one decimal point, no rounding
+                            (_latitdue (/ (truncate (* osx-location-latitude 10)) 10.0)))
+                        (unless (equal (bound-and-true-p calendar-longitude) _longitude)
+                          (setq calendar-longitude _longitude
+                                location-changed-p t))
+                        (unless (equal (bound-and-true-p  calendar-latitude) _latitdue)
+                          (setq calendar-latitude _latitdue
+                                location-changed-p t))
+                        (when (and (configuration-layer/layer-usedp 'geolocation) location-changed-p)
+                          (message "Location changed %s %s (restarting rase-timer)" calendar-latitude calendar-longitude)
+                          (rase-start t)
+                          ))))
+          (osx-location-watch)))))
+
+(defun geolocation/init-rase ()
+  (use-package rase
+    :defer t
+    :init
+    (progn
+      (defadvice rase-start (around test-calendar activate)
+        "Don't call `raise-start' if `calendar-latitude' or
+`calendar-longitude' are not bound yet, or still nil.
+
+This is setup this way because `rase.el' does not test these
+values, and will fail under such conditions, when calling
+`solar.el' functions.
+
+Also, it allows users who enabled service such as `osx-location'
+to not have to set these variables manually when enabling this layer."
+        (if (and (bound-and-true-p calendar-longitude)
+                 (bound-and-true-p calendar-latitude))
+            ad-do-it))
+      (rase-start t)
+      )))
 
 (defun geolocation/init-sunshine ()
   "Initialize sunshine"
   (use-package sunshine
     :if geolocation-enable-weather-forecast
-    :defer t
+    :commands (sunshine-forecast sunshine-quick-forecast)
     :init
     (progn
       (evil-leader/set-key
@@ -48,21 +78,9 @@
       (evilify sunshine-mode sunshine-mode-map
                (kbd "q") 'quit-window
                (kbd "i") 'sunshine-toggle-icons))
-    :config
-    ;; just in case location was not set by user, or on OS X,
-    ;; if wasn't set up automatically, will not work with Emac's
-    ;; default for ;; `calendar-location-name'
-    (when (not (boundp 'sunshine-location))
-      (setq sunshine-location (format "%s, %s"
-                                      calendar-latitude
-                                      calendar-longitude)))))
+    ))
 
-(defun geolocation/init-theme-changer ()
-  "Initialize theme-changer"
-  (use-package theme-changer
-    :if geolocation-enable-automatic-theme-changer
-    :config
-    (progn
-      (when (> (length dotspacemacs-themes) 1)
-        (change-theme (nth 0 dotspacemacs-themes)
-                      (nth 1 dotspacemacs-themes))))))
+(defun geolocation/post-init-popwin ()
+  ;; Pin the weather forecast to the bottom window
+  (push '("*Sunshine*" :dedicated t :position bottom)
+        popwin:special-display-config))


### PR DESCRIPTION
Incorporated upstream suggested changes and brought `osx-location` back to the `geolocation` layer as a new PR. Couldn't amend #3409, so please ignore that one. 