### PR TITLE
Add theming layer

### DIFF
--- a/layers/theming/README.org
+++ b/layers/theming/README.org
@@ -1,0 +1,90 @@
+* Theming contribution layer for Spacemacs
+
+** Table of Contents                                                  :TOC@4:
+ - [[#theming-contribution-layer-for-spacemacs][Theming contribution layer for Spacemacs]]
+   - [[#description][Description]]
+   - [[#install][Install]]
+   - [[#usage][Usage]]
+   - [[#attributes][Attributes]]
+   - [[#faces][Faces]]
+   - [[#headers][Headers]]
+
+** Description
+This layer allows for a simple way of modifying themes.
+
+** Install
+To use this contribution add it to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(theming))
+#+end_src
+
+** Usage
+To use this layer, set the value of =theming-modifications=. It should be a list
+of the following form:
+
+#+begin_src emacs-lisp
+  ((theme1 (face1 attributes...)
+           (face2 attributes...)
+           ...)
+   (theme2 (face1 attributes...)
+           (face2 attributes...)
+           ...)
+   ...)
+#+end_src
+
+This will apply the given attributes to the relevant faces whenever the
+appropriate theme is loaded. To update without changing the theme, use ~SPC :
+spacemacs/update-theme~.
+
+** Attributes
+See [[http://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html#Face-Attributes][face attributes]] in the Emacs manual for more information. Some of the more
+common attributes you might want to tweak are the following:
+
+- =:inherit= :: the name of a face to inherit attributes from
+- =:foreground= and =:background= :: Hexadecimal color strings
+- =:height= :: typically a floating point number (1.0 gives the same height as
+     the underlying face)
+- =:weight= :: typically =bold= or =normal=
+- =:underline= :: typically =nil= or =t=
+- =:slant= :: typically =oblique=, =italic= or =normal=
+- =:box= :: set to =t= to draw a box around characters in the foreground
+
+** Faces
+To see a list over all loaded faces and what they look like, use ~SPC :
+list-faces-display~. You can also use ~SPC h d c~ (describe character) on a
+character to see its face.
+
+Some of the most common faces to modify are the syntactical elements:
+- =font-lock-builtin-face=
+- =font-lock-comment-delimiter-face=
+- =font-lock-comment-face=
+- =font-lock-constant-face=
+- =font-lock-doc-face=
+- =font-lock-function-name-face=
+- =font-lock-keyword-face=
+- =font-lock-preprocessor-face=
+- =font-lock-string-face=
+- =font-lock-type-face=
+- =font-lock-variable-name-face=
+- =font-lock-warning-face=
+
+As well as the mode-line faces for the active and inactive windows:
+- =powerline-active1=
+- =powerline-active2=
+- =powerline-inactive1=
+- =powerline-inactive2=
+- =mode-line=
+- =mode-line-inactive=
+
+** Headers
+This layer includes three additional layer variables for tweaking headings.
+Allowed values are a list of themes in which the given effect should happen, or
+the symbol =all= to apply it on all themes.
+
+- =theming-headings-inherit-from-default= :: inherits all headings from the
+     default face to avoid non-monospaced fonts
+- =theming-headings-same-size= :: sets the =:height= attribute to one on all
+     headings to give them the same size as the rest of the text
+- =theming-headings-bold= :: sets the =:weight= attribute to bold on all
+     headings

--- a/layers/theming/config.el
+++ b/layers/theming/config.el
@@ -1,0 +1,67 @@
+;;; config.el --- Theming Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar theming-modifications '()
+  "An alist of theme modifications. Each element should
+be on the form (THEME . SPEC), where THEME is a symbol
+representing a theme, and SPEC is an alist mapping faces
+to face specs (see `defface').")
+
+(defvar theming-headings-inherit-from-default '()
+  "A list of themes where all headings should inherit
+from the default face, or the symbol `all'.")
+
+(defvar theming-headings-same-size '()
+  "A list of themes where all headings should have the
+same size, or the symbol `all'.")
+
+(defvar theming-headings-bold '()
+  "A list of themes where all headings should be bold,
+or the symbol `all'.")
+
+(defvar spacemacs--theming-modified-faces '())
+
+(defvar spacemacs--theming-header-faces
+  '(font-latex-sectioning-0-face
+    font-latex-sectioning-1-face
+    font-latex-sectioning-2-face
+    font-latex-sectioning-3-face
+    font-latex-sectioning-4-face
+    font-latex-sectioning-5-face
+    font-latex-slide-title-face
+    info-title-1
+    info-title-2
+    info-title-3
+    info-title-4
+    markdown-header-face
+    markdown-header-face-1
+    markdown-header-face-2
+    markdown-header-face-3
+    markdown-header-face-4
+    markdown-header-face-5
+    markdown-header-face-6
+    org-document-title
+    org-level-1
+    org-level-2
+    org-level-3
+    org-level-4
+    org-level-5
+    org-level-6
+    org-level-7
+    org-level-8)
+  "List of header faces.")
+
+;; Apply theme customizations after any call to load-theme
+(advice-add 'load-theme :after 'spacemacs//theming)
+
+;; Apply the initial customizations now, because load-theme has already been called
+(spacemacs//theming spacemacs--cur-theme)

--- a/layers/theming/funcs.el
+++ b/layers/theming/funcs.el
@@ -1,0 +1,47 @@
+;;; config.el --- Theming Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//in-or-all (key seq)
+  (or (eq 'all seq) (memq key seq)))
+
+(defun spacemacs//theming (theme &optional no-confirm no-enable)
+  "Removes existing user theming and applies customizations for the given
+theme."
+  (unless no-enable
+
+    ;; Remove existing modifications
+    (dolist (face spacemacs--theming-modified-faces)
+      (custom-set-faces `(,face ((t ())))))
+    (setq spacemacs--theming-modified-faces nil)
+
+    ;; Headings
+    (let ((mods nil))
+      (when (spacemacs//in-or-all theme theming-headings-inherit-from-default)
+        (setq mods (plist-put mods :inherit 'default)))
+      (when (spacemacs//in-or-all theme theming-headings-same-size)
+        (setq mods (plist-put mods :height 1.0)))
+      (when (spacemacs//in-or-all theme theming-headings-bold)
+        (setq mods (plist-put mods :weight 'bold)))
+      (when mods
+        (dolist (face spacemacs--theming-header-faces)
+          (custom-set-faces `(,face ((t ,mods))))
+          (push face spacemacs--theming-modified-faces))))
+
+    ;; Add new modifications
+    (dolist (spec (append (cdr (assq theme theming-modifications))
+                          (cdr (assq t theming-modifications))))
+      (custom-set-faces `(,(car spec) ((t ,(cdr spec)))))
+      (push (car spec) spacemacs--theming-modified-faces))))
+
+(defun spacemacs/update-theme ()
+  (interactive)
+  (spacemacs//theming spacemacs--cur-theme))


### PR DESCRIPTION
This adds a new layer called theming. It uses no packages, but provides a couple of layer variables that make it relatively easy to modify themes instead of having to use `custom-set-faces` or `set-face-attribute`.

It's essentially a carbon copy of my private [modify-theme layer](https://github.com/TheBB/spacemacs-layers/tree/master/modify-theme). [Here](https://github.com/TheBB/dotfiles/blob/master/emacs/spacemacs.el#L229-L265) is an example of how I use it.