### PR TITLE
fix inaccuracy in omnisharp readme file

### DIFF
--- a/layers/+lang/csharp/README.org
+++ b/layers/+lang/csharp/README.org
@@ -28,7 +28,6 @@ This layer adds experimental support for C# language using [[https://github.com/
 * Packages Included
 
 - [[https://github.com/OmniSharp/omnisharp-emacs][OmniSharp-emacs]]
-- [[https://github.com/OmniSharp/omnisharp-server][OmniSharp-server]]
   
 * Install
 


### PR DESCRIPTION
Omnisharp-server is not included in this layer - only omnisharp-emacs.
Server is installed (as described) manually.