### PR TITLE
Better avy-keys default value

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -397,7 +397,6 @@
     :commands (spacemacs/avy-open-url)
     :init
     (progn
-      (setq avy-keys (number-sequence ?a ?z))
       (setq avy-all-windows 'all-frames)
       (setq avy-background t)
       (evil-leader/set-key


### PR DESCRIPTION
Staying on the home to reduce RSI.