### PR TITLE
Move auto-dictionary to spell-checking and activate it

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -17,7 +17,6 @@
         ace-window
         adaptive-wrap
         aggressive-indent
-        auto-dictionary
         auto-highlight-symbol
         avy
         buffer-move
@@ -167,16 +166,6 @@
     (progn
       (add-hook 'diff-auto-refine-mode-hook 'spacemacs/toggle-aggressive-indent-off)
       (spacemacs|diminish aggressive-indent-mode " Ⓘ" " I"))))
-
-(defun spacemacs/init-auto-dictionary ()
-  (use-package auto-dictionary
-    :disabled t
-    :defer t
-    :init
-    (progn
-      (add-hook 'flyspell-mode-hook '(lambda () (auto-dictionary-mode 1)))
-      (evil-leader/set-key
-        "Sd" 'adict-change-dictionary))))
 
 (defun spacemacs/init-auto-highlight-symbol ()
   (use-package auto-highlight-symbol

--- a/layers/spell-checking/README.org
+++ b/layers/spell-checking/README.org
@@ -6,6 +6,7 @@
    - [[#layer][Layer]]
    - [[#spell-checker-configuration][Spell Checker Configuration]]
    - [[#disabling-by-default][Disabling by default]]
+   - [[#disabling-auto-dictionary][Disabling auto-dictionary]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
@@ -29,13 +30,23 @@ dictionary used by =ispell-program-name= (instead of using this variable you can
 also use the key binding ~SPC S d~).
 
 ** Disabling by default
-By default, spell-checking is enabled in all available major modes and may be
+By default, =spell-checking= is enabled in all available major modes and may be
 toggled off with ~SPC t S~. You can default this to off by setting the variable
 =spell-checking-enable-by-default= to =nil=:
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
   '((spell-checking :variables spell-checking-enable-by-default nil)))
+#+END_SRC
+
+** Disabling auto-dictionary
+By default, =spell-checking= tries to detect the current language from the
+buffer content, and activate the corresponding dictionary. You can default this
+to off by setting the variable =spell-checking-auto-dictionary= to =nil=:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((spell-checking :variables spell-checking-auto-dictionary nil)))
 #+END_SRC
 
 * Key Bindings

--- a/layers/spell-checking/README.org
+++ b/layers/spell-checking/README.org
@@ -6,11 +6,10 @@
    - [[#layer][Layer]]
    - [[#spell-checker-configuration][Spell Checker Configuration]]
    - [[#disabling-by-default][Disabling by default]]
-   - [[#disabling-auto-dictionary][Disabling auto-dictionary]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
-This layer provides spell checking using [[http://www-sop.inria.fr/members/Manuel.Serrano/flyspell/flyspell.html][Flyspell]].
+This layer provides spell checking using [[http://www-sop.inria.fr/members/Manuel.Serrano/flyspell/flyspell.html][Flyspell]] and =[[https://github.com/nschum/auto-dictionary-mode][auto-dictionary-mode]]=.
 
 * Install
 ** Layer
@@ -37,16 +36,6 @@ toggled off with ~SPC t S~. You can default this to off by setting the variable
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
   '((spell-checking :variables spell-checking-enable-by-default nil)))
-#+END_SRC
-
-** Disabling auto-dictionary
-By default, =spell-checking= tries to detect the current language from the
-buffer content, and activate the corresponding dictionary. You can default this
-to off by setting the variable =spell-checking-auto-dictionary= to =nil=:
-
-#+BEGIN_SRC emacs-lisp
-(setq-default dotspacemacs-configuration-layers
-  '((spell-checking :variables spell-checking-auto-dictionary nil)))
 #+END_SRC
 
 * Key Bindings

--- a/layers/spell-checking/config.el
+++ b/layers/spell-checking/config.el
@@ -18,6 +18,3 @@
 
 (defvar spell-checking-enable-by-default t
   "Enable spell checking by default.")
-
-(defvar spell-checking-auto-dictionary t
-  "Enable auto-dictionary by default.")

--- a/layers/spell-checking/config.el
+++ b/layers/spell-checking/config.el
@@ -10,11 +10,14 @@
 ;;
 ;;; License: GPLv3
 
-;; Variables
-
 ;; Command Prefixes
 
 (spacemacs/declare-prefix "S" "spelling")
 
+;; Variables
+
 (defvar spell-checking-enable-by-default t
   "Enable spell checking by default.")
+
+(defvar spell-checking-auto-dictionary t
+  "Enable auto-dictionary by default.")

--- a/layers/spell-checking/funcs.el
+++ b/layers/spell-checking/funcs.el
@@ -21,6 +21,6 @@
   "Change the dictionary. Use the ispell version if
 auto-dictionary is not used, use the adict version otherwise."
   (interactive)
-  (if spell-checking-auto-dictionary
+  (if (fboundp 'adict-change-dictionary)
       (adict-change-dictionary)
     (call-interactively 'ispell-change-dictionary)))

--- a/layers/spell-checking/funcs.el
+++ b/layers/spell-checking/funcs.el
@@ -10,9 +10,17 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs/add-flyspell-hook (mode &optional target)
+(defun spell-checking/add-flyspell-hook (mode &optional target)
   "Enable flyspell for the given MODE, if
 `spell-checking-enable-by-default' is true."
   (when spell-checking-enable-by-default
     (let ((mode-hook (intern (format "%S-hook" mode))))
       (add-hook mode-hook 'flyspell-mode))))
+
+(defun spell-checking/change-dictionary ()
+  "Change the dictionary. Use the ispell version if
+auto-dictionary is not used, use the adict version otherwise."
+  (interactive)
+  (if spell-checking-auto-dictionary
+      (adict-change-dictionary)
+    (call-interactively 'ispell-change-dictionary)))

--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -20,7 +20,6 @@
 (defun spell-checking/init-auto-dictionary ()
   (use-package auto-dictionary
     :defer t
-    :if spell-checking-auto-dictionary
     :init
     (add-hook 'flyspell-mode-hook 'auto-dictionary-mode)))
 

--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -12,17 +12,26 @@
 
 (setq spell-checking-packages
   '(
+    auto-dictionary
     flyspell
     helm-flyspell
     ))
 
+(defun spell-checking/init-auto-dictionary ()
+  (use-package auto-dictionary
+    :defer t
+    :if spell-checking-auto-dictionary
+    :init
+    (add-hook 'flyspell-mode-hook 'auto-dictionary-mode)))
+
 (defun spell-checking/init-flyspell ()
   (use-package flyspell
     :defer t
+    :commands (spell-checking/change-dictionary)
     :init
     (progn
-      (spacemacs/add-flyspell-hook 'org-mode)
-      (spacemacs/add-flyspell-hook 'text-mode)
+      (spell-checking/add-flyspell-hook 'org-mode)
+      (spell-checking/add-flyspell-hook 'text-mode)
       (when spell-checking-enable-by-default
         (add-hook 'prog-mode-hook 'flyspell-prog-mode))
 
@@ -35,7 +44,7 @@
         :evil-leader "tS")
 
       (evil-leader/set-key
-        "Sd" 'ispell-change-dictionary
+        "Sd" 'spell-checking/change-dictionary
         "Sn" 'flyspell-goto-next-error))
     :config
     (spacemacs|diminish flyspell-mode " Ⓢ" " S")))


### PR DESCRIPTION
This commit moves the – previously disabled – `auto-dictionary` code to
the `spell-checking` layer and activate it. It is now enabled by
default, but can be disabled by setting `spell-checking-auto-dictionary`
to `nil`.

`auto-dictionary` comes with some interesting improvements:

- Tries to automatically detect what is the language of the buffer and
  activate the corresponding dictionary.

- When a buffer is opened, all spelling mistakes are shown without
  needing first to be under the cursor.

- When the dictionary is changed, the whole buffer is reanalyzed for
  spelling mistakes (close #2088).