### PR TITLE
Convenience function to 'go run' a .go file with main()

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -24,6 +24,12 @@
         (interactive)
         (shell-command "go test"))
 
+      (defun spacemacs/go-run-main ()
+        (interactive)
+        (shell-command
+          (format "go run %s"
+                  (shell-quote-argument (buffer-file-name)))))
+
       (evil-leader/set-key-for-mode 'go-mode
         "mhh" 'godoc-at-point
         "mig" 'go-goto-imports
@@ -32,6 +38,7 @@
         "meb" 'go-play-buffer
         "mer" 'go-play-region
         "med" 'go-download-play
+        "mee" 'spacemacs/go-run-main
         "mga" 'ff-find-other-file
         "mgg" 'godef-jump
         "mtp" 'spacemacs/go-run-package-tests))))


### PR DESCRIPTION
Similar to calling 'go test' on packages to run tests, it would be nice to have a convenience function to call the 'go run' on files which have a main() function. Please accept this change if you think this is useful.