### PR TITLE
[haskell] make switch key bindings more consistent

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -259,8 +259,8 @@ REPL commands are prefixed by ~SPC m s~:
 |-------------+-------------------------------------------------|
 | ~SPC m s b~ | load or reload the current buffer into the REPL |
 | ~SPC m s c~ | clear the REPL                                  |
-| ~SPC m s s~ | show the REPL                                   |
-| ~SPC m s S~ | show and switch to the REPL                     |
+| ~SPC m s s~ | show and switch to the REPL or back from REPL   |
+| ~SPC m s S~ | show the REPL                                   |
 
 ** Cabal commands
 Cabal commands are prefixed by ~SPC m c~:
@@ -275,19 +275,20 @@ Cabal commands are prefixed by ~SPC m c~:
 ** Cabal files
 This commands are available in a cabal file.
 
-| Key Binding | Description                                 |
-|-------------+---------------------------------------------|
-| ~SPC m d~   | add a dependency to the project             |
-| ~SPC m b~   | go to benchmark section                     |
-| ~SPC m e~   | go to executable section                    |
-| ~SPC m t~   | go to test-suite section                    |
-| ~SPC m m~   | go to exposed modules                       |
-| ~SPC m l~   | go to libary section                        |
-| ~SPC m n~   | go to next subsection                       |
-| ~SPC m p~   | go to previous subsection                   |
-| ~SPC m N~   | go to next section                          |
-| ~SPC m P~   | go to previous section                      |
-| ~SPC m f~   | find or create source-file under the cursor |
+| Key Binding | Description                                   |
+|-------------+-----------------------------------------------|
+| ~SPC m d~   | add a dependency to the project               |
+| ~SPC m b~   | go to benchmark section                       |
+| ~SPC m e~   | go to executable section                      |
+| ~SPC m t~   | go to test-suite section                      |
+| ~SPC m m~   | go to exposed modules                         |
+| ~SPC m l~   | go to libary section                          |
+| ~SPC m n~   | go to next subsection                         |
+| ~SPC m p~   | go to previous subsection                     |
+| ~SPC m N~   | go to next section                            |
+| ~SPC m P~   | go to previous section                        |
+| ~SPC m f~   | find or create source-file under the cursor   |
+| ~SPC m s s~ | show and switch to the REPL or back from REPL |
 
 * FAQ
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -91,6 +91,8 @@
       (spacemacs/declare-prefix-for-mode 'haskell-mode "mc" "haskell/cabal")
       (spacemacs/declare-prefix-for-mode 'haskell-mode "mh" "haskell/documentation")
       (spacemacs/declare-prefix-for-mode 'haskell-mode "md" "haskell/debug")
+      (spacemacs/declare-prefix-for-mode 'haskell-interactive-mode "ms" "haskell/repl")
+      (spacemacs/declare-prefix-for-mode 'haskell-cabal-mode "ms" "haskell/repl")
 
       ;; key bindings
       (defun spacemacs/haskell-process-do-type-on-prev-line ()
@@ -106,8 +108,8 @@
 
         "msb"  'haskell-process-load-or-reload
         "msc"  'haskell-interactive-mode-clear
-        "mss"  'haskell-interactive-bring
-        "msS"  'haskell-interactive-switch
+        "mss"  'haskell-interactive-switch
+        "msS"  'haskell-interactive-bring
 
         "mca"  'haskell-process-cabal
         "mcb"  'haskell-process-cabal-build
@@ -133,26 +135,24 @@
 
       ;; Switch back to editor from REPL
       (evil-leader/set-key-for-mode 'haskell-interactive-mode
-        "msS"  'haskell-interactive-switch-back)
-
-      ;; Compile
-      (evil-leader/set-key-for-mode 'haskell-cabal
-        "mC"  'haskell-compile)
+        "mss"  'haskell-interactive-switch-back)
 
       ;; Cabal-file bindings
       (evil-leader/set-key-for-mode 'haskell-cabal-mode
         ;; "m="  'haskell-cabal-subsection-arrange-lines ;; Does a bad job, 'gg=G' works better
-        "md" 'haskell-cabal-add-dependency
-        "mb" 'haskell-cabal-goto-benchmark-section
-        "me" 'haskell-cabal-goto-executable-section
-        "mt" 'haskell-cabal-goto-test-suite-section
-        "mm" 'haskell-cabal-goto-exposed-modules
-        "ml" 'haskell-cabal-goto-library-section
-        "mn" 'haskell-cabal-next-subsection
-        "mp" 'haskell-cabal-previous-subsection
-        "mN" 'haskell-cabal-next-section
-        "mP" 'haskell-cabal-previous-section
-        "mf" 'haskell-cabal-find-or-create-source-file)
+        "md"  'haskell-cabal-add-dependency
+        "mb"  'haskell-cabal-goto-benchmark-section
+        "mC"  'haskell-compile
+        "me"  'haskell-cabal-goto-executable-section
+        "mt"  'haskell-cabal-goto-test-suite-section
+        "mm"  'haskell-cabal-goto-exposed-modules
+        "ml"  'haskell-cabal-goto-library-section
+        "mn"  'haskell-cabal-next-subsection
+        "mp"  'haskell-cabal-previous-subsection
+        "mN"  'haskell-cabal-next-section
+        "mP"  'haskell-cabal-previous-section
+        "mf"  'haskell-cabal-find-or-create-source-file
+        "mss" 'haskell-interactive-switch)
 
       ;; Make "RET" behaviour in REPL saner
       (evil-define-key 'insert haskell-interactive-mode-map


### PR DESCRIPTION
Function `haskell-interactive-switch` is more useful than `haskell-interactive-bring`, because it allows you to use `haskell-interactive-switch-back` function to return to the file you were before switching to REPL. Switch functions were bound to `, s S` which is harder to type (not that hard, but ... you know :smile: ). That's why I am proposing to use `, s s` key bindings for `switch` functions, and `, s S` for `bring` function. Also, added `switch` function to cabal-mode, so now you can jump from cabal file right to REPL and back. And then I added two new prefixes. If you want me to split this commit into different commits - just say it.