### PR TITLE
Fix magit-gh-pulls and magit-gitflow keys

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -295,7 +295,7 @@
     :init (progn
             (add-hook 'magit-mode-hook 'turn-on-magit-gitflow)
             (with-eval-after-load 'magit
-              (define-key magit-mode-map "#f" 'magit-gitflow-popup)))
+              (define-key magit-mode-map "%" 'magit-gitflow-popup)))
     :config (spacemacs|diminish magit-gitflow-mode "Flow")))
 
 (defun git/init-magit-svn ()

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -107,6 +107,6 @@
             (magit-gh-pulls-mode)
             (magit-gh-pulls-popup))
 
-          (define-key magit-mode-map "#g" 'spacemacs/load-gh-pulls-mode))
+          (define-key magit-mode-map "#" 'spacemacs/load-gh-pulls-mode))
         :config
         (spacemacs|diminish magit-gh-pulls-mode "Github-PR")))))

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -105,15 +105,8 @@
             "Start `magit-gh-pulls-mode' only after a manual request."
             (interactive)
             (magit-gh-pulls-mode)
-            (magit-gh-pulls-reload))
+            (magit-gh-pulls-popup))
 
-          (defun spacemacs/fetch-gh-pulls-mode ()
-            "Start `magit-gh-pulls-mode' only after a manual request."
-            (interactive)
-            (magit-gh-pulls-mode)
-            (magit-gh-pulls-fetch-commits))
-
-          (define-key magit-mode-map "#f" 'spacemacs/fetch-gh-pulls-mode)
           (define-key magit-mode-map "#g" 'spacemacs/load-gh-pulls-mode))
         :config
         (spacemacs|diminish magit-gh-pulls-mode "Github-PR")))))


### PR DESCRIPTION
Keeping consistent with previous keys, this commit allows you to use
`#g` for `magit-gh-pulls` and `#f` for `magit-gitflow`

It removes old key `#gf` since it's provided by `magit-gh-pulls-popup`

It also advices `magit-mode-burry-buffer` for the reasons explained in
the comment.

NOTE: We don't want to hook `magit-gh-pulls` in `magit-status` as it
would slow the normal invocation of `magit-status`. Hence we only load
`magit-gh-pulls` when asked for and remove it when leaving `magit-status`

Resolves #3481 (probably in better way!) 