### PR TITLE
Make google translate language code case-insensitive

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -934,15 +934,15 @@
     (progn
       (defun spacemacs/set-google-translate-languages (source target)
         "Set source language for google translate.
-For instance pass En as source for english."
+For instance pass En as source for English."
         (interactive
-         "sEnter source language (ie. En): \nsEnter target language (ie. En): "
+         "sEnter source language (ie. en): \nsEnter target language (ie. en): "
          source target)
         (message
          (format "Set google translate source language to %s and target to %s"
                  source target))
-        (setq google-translate-default-source-language source)
-        (setq google-translate-default-target-language target))
+        (setq google-translate-default-source-language (downcase source))
+        (setq google-translate-default-target-language (downcase target)))
       (evil-leader/set-key
         "xgQ" 'google-translate-query-translate-reverse
         "xgq" 'google-translate-query-translate
@@ -953,8 +953,8 @@ For instance pass En as source for english."
       (require 'google-translate-default-ui)
       (setq google-translate-enable-ido-completion t)
       (setq google-translate-show-phonetic t)
-      (setq google-translate-default-source-language "En")
-      (setq google-translate-default-target-language "Fr"))))
+      (setq google-translate-default-source-language "en")
+      (setq google-translate-default-target-language "fr"))))
 
 (defun spacemacs/init-helm-ag ()
   (use-package helm-ag


### PR DESCRIPTION
In google translate package, when you change language (`SPC x g l`) and enter language code starting with capital letter, eg `En`, you see `nil` values in results window instead of actual language: `Translate from nil to nil`.