### PR TITLE
holy-mode: Version of holy-mode that disables evil entirely

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -204,6 +204,15 @@ or lists of these.")
 ;; UI
 ;; ---------------------------------------------------------------------------
 
+(defface face-of-god
+  `((t (:background "SkyBlue2"
+                    :foreground ,(face-background 'mode-line)
+                    :box ,(face-attribute 'mode-line :box)
+                    :inherit 'mode-line)))
+  "Face to use when `evil-mode' is disabled or `evil-state' is
+nil."
+  :group 'spacemacs)
+
 ;; important for golden-ratio to better work
 (setq window-combination-resize t)
 ;; fringes

--- a/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
+++ b/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
@@ -29,7 +29,8 @@
 ;;; Code:
 
 (defvar holy-mode-modes-to-disable-alist
-  `((evil-escape-mode . ,(when (boundp 'evil-escape-mode) evil-escape-mode)))
+  `((evil-escape-mode . ,(when (boundp 'evil-escape-mode) evil-escape-mode))
+    (hybrid-mode . ,(when (boundp 'hybrid-mode) hybrid-mode)))
   "Alist of modes that should be disabled when activating
 `holy-mode'. The cdr in each cell stores the state of the mode
 before it was disabled.")
@@ -55,6 +56,9 @@ The `insert state' is replaced by the `emacs state'."
           (spacemacs//helm-hjkl-navigation nil)))
     (when (fboundp 'spacemacs//helm-hjkl-navigation)
       (spacemacs//helm-hjkl-navigation t))
-    (evil-mode 1)))
+    (evil-mode 1)
+    (dolist (mode holy-mode-modes-to-disable-alist)
+      (when (boundp (car mode))
+        (funcall (car mode) (cdr mode))))))
 
 (provide 'holy-mode)

--- a/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
+++ b/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
@@ -39,7 +39,8 @@ before it was disabled.")
 (define-minor-mode holy-mode
   "Global minor mode to repulse the evil from spacemacs.
 
-The `insert state' is replaced by the `emacs state'."
+`evil-mode' is disabled and conflicting minor modes in
+`holy-mode-modes-to-disable-alist' are turned off."
   :global t
   :lighter " holy"
   :group 'spacemacs

--- a/layers/+distribution/spacemacs-base/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distribution/spacemacs-base/local/hybrid-mode/hybrid-mode.el
@@ -30,6 +30,15 @@
 
 (require 'evil)
 
+(defvar hybrid-mode-default-state-backup evil-default-state
+  "Backup of `evil-default-state'.")
+
+(defcustom hybrid-mode-default-state 'normal
+  "Value of `evil-default-state' for hybrid-mode. Set to hybrid
+to start in hybrid state (emacs bindings) by default."
+  :group 'spacemacs
+  :type 'symbol)
+
 (evil-define-state hybrid
   "Emacs/insert state for hybrid mode."
   :tag " <H> "
@@ -74,8 +83,12 @@ with `evil-hybrid-state-map'."
   :lighter " hybrid"
   :group 'spacemacs
   (if hybrid-mode
-      (setf (symbol-function 'evil-insert-state)
-            (symbol-function 'evil-hybrid-state))
+      (progn
+        (setq hybrid-mode-default-state-backup evil-default-state
+              evil-default-state hybrid-mode-default-state)
+        (setf (symbol-function 'evil-insert-state)
+              (symbol-function 'evil-hybrid-state)))
+    (setq evil-default-state hybrid-mode-default-state-backup)
     (setf (symbol-function 'evil-insert-state)
           (symbol-function 'hybrid-mode--evil-insert-state-backup))))
 

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -220,7 +220,8 @@
       (defun evil-insert-state-cursor-hide ()
         (setq evil-insert-state-cursor '((hbar . 0))))
 
-      (evil-mode 1))
+      (unless (eq dotspacemacs-editing-style 'emacs)
+        (evil-mode 1)))
     :config
     (progn
       ;; bind function keys

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -414,7 +414,8 @@ Example: (evil-map visual \"<\" \"<gv\")"
 (defun spacemacs-base/init-evil-escape ()
   (use-package evil-escape
     :init
-    (evil-escape-mode)
+    (unless (eq dotspacemacs-editing-style 'emacs)
+      (evil-escape-mode))
     :config
     (spacemacs|hide-lighter evil-escape-mode)))
 

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1820,8 +1820,10 @@ Open junk file using helm, with `prefix-arg' search in junk files"
       (setq spaceline-org-clock-p nil)
 
       (defun spacemacs//evil-state-face ()
-        (let ((state (if (eq 'operator evil-state) evil-previous-state evil-state)))
-          (intern (format "spacemacs-%S-face" state))))
+        (if (bound-and-true-p evil-state)
+            (let ((state (if (eq 'operator evil-state) evil-previous-state evil-state)))
+              (intern (format "spacemacs-%S-face" state)))
+          'face-of-god))
       (setq spaceline-highlight-face-func 'spacemacs//evil-state-face)
 
       (let ((unicodep (dotspacemacs|symbol-value


### PR DESCRIPTION
This version of holy-mode works by disabling evil-mode entirely. To do
this, we need to fix some aspects of spacemacs that depend on evil-mode
being enabled (cursor, mode-line, etc.), but otherwise this is really a
very simple implementation of holy-mode.

This is mostly a proof of concept to show that spacemacs can be made to work without evil-mode. @TheBB I'm having trouble with the mode-line in some buffers (\*Messages\* for example). Maybe you could figure out why I'm getting errors.