### PR TITLE
Add magit-init to keybindings

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -106,6 +106,7 @@
 
       (evil-leader/set-key
         "gb" 'spacemacs/git-blame-micro-state
+        "gi" 'magit-init
         "gl" 'magit-log-all
         "gL" 'magit-log-buffer-file
         "gs" 'magit-status


### PR DESCRIPTION
I noticed that magit-init is a faster way of initializing vcs maintained
projects.