### PR TITLE
go layer : function to 'go run' on current 'main' package

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -67,6 +67,7 @@ formatter, set the value of =gofmt-command=, e.g.
 | ~SPC m e b~ | go-play buffer                                            |
 | ~SPC m e r~ | go-play region                                            |
 | ~SPC m e d~ | download go-play snippet                                  |
+| ~SPC m e e~ | run "go run" for the current 'main' package               |
 | ~SPC m t p~ | run "go test" for the current package                     |
 | ~SPC m g a~ | jump to matching test file or back from test to code file |
 | ~SPC m g g~ | go jump to definition                                     |

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -67,7 +67,7 @@ formatter, set the value of =gofmt-command=, e.g.
 | ~SPC m e b~ | go-play buffer                                            |
 | ~SPC m e r~ | go-play region                                            |
 | ~SPC m e d~ | download go-play snippet                                  |
-| ~SPC m e e~ | run "go run" for the current 'main' package               |
+| ~SPC m x x~ | run "go run" for the current 'main' package               |
 | ~SPC m t p~ | run "go test" for the current package                     |
 | ~SPC m g a~ | jump to matching test file or back from test to code file |
 | ~SPC m g g~ | go jump to definition                                     |

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -24,6 +24,12 @@
         (interactive)
         (shell-command "go test"))
 
+      (defun spacemacs/go-run-main ()
+        (interactive)
+        (shell-command
+          (format "go run %s"
+                  (shell-quote-argument (buffer-file-name)))))
+
       (evil-leader/set-key-for-mode 'go-mode
         "mhh" 'godoc-at-point
         "mig" 'go-goto-imports
@@ -32,6 +38,7 @@
         "meb" 'go-play-buffer
         "mer" 'go-play-region
         "med" 'go-download-play
+        "mee" 'spacemacs/go-run-main
         "mga" 'ff-find-other-file
         "mgg" 'godef-jump
         "mtp" 'spacemacs/go-run-package-tests))))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -38,7 +38,7 @@
         "meb" 'go-play-buffer
         "mer" 'go-play-region
         "med" 'go-download-play
-        "mee" 'spacemacs/go-run-main
+        "mxx" 'spacemacs/go-run-main
         "mga" 'ff-find-other-file
         "mgg" 'godef-jump
         "mtp" 'spacemacs/go-run-package-tests))))


### PR DESCRIPTION
Similar to a convenience function to execute 'go test' on a package, this adds a function to execute 'go run' if the current file is marked as a 'main' package. 

Please accept this change if this you think this is beneficial.

PS. This is the first emacs function I have ever written, so please suggest any things I need to consider.