### PR TITLE
setq compilation-scroll-output first-error

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -820,6 +820,8 @@ first element is the symbol `image')."
             ;; no errors
             (message "compilation ok.")))))
 
+(setq compilation-scroll-output 'first-error)
+
 ;; from http://www.emacswiki.org/emacs/WordCount
 (defun spacemacs/count-words-analysis (start end)
   "Count how many times each word is used in the region.


### PR DESCRIPTION
https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation.html

Without this set, the compilation buffer just stays at the top. first-error is a nice default.