### PR TITLE
Remove guides to comply with latest haskell-mode

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -180,27 +180,6 @@
         (define-key haskell-cabal-mode-map
           [?\C-c ?\C-z] 'haskell-interactive-switch))))
 
-
-  (with-eval-after-load 'haskell-indentation
-    ;; Show indentation guides in insert or emacs state only.
-    (defun spacemacs//haskell-indentation-show-guides ()
-      "Show visual indentation guides."
-      (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
-        (haskell-indentation-enable-show-indentations)))
-
-    (defun spacemacs//haskell-indentation-hide-guides ()
-      "Hide visual indentation guides."
-      (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
-        (haskell-indentation-disable-show-indentations)))
-
-    ;; first entry in normal state
-    (add-hook 'evil-normal-state-entry-hook 'spacemacs//haskell-indentation-hide-guides)
-
-    (add-hook 'evil-insert-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-    (add-hook 'evil-emacs-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-    (add-hook 'evil-insert-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)
-    (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides))
-
   ;; align rules for Haskell
   (with-eval-after-load 'align
     (add-to-list 'align-rules-list


### PR DESCRIPTION
The visual guides have been removed from haskell-mode as of ee55de1 (#947)