### PR TITLE
Don't use ido for sudo-edit of new files

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1605,6 +1605,7 @@ Files manipulation commands (start with ~f~):
 | ~SPC f C d~ | convert file from unix to dos encoding                         |
 | ~SPC f C u~ | convert file from dos to unix encoding                         |
 | ~SPC f D~   | delete a file and the associated buffer (ask for confirmation) |
+| ~SPC f E~   | open a file with elevated privileges (sudo edit)               |
 | ~SPC f f~   | open file with =helm= (or =ido=)                               |
 | ~SPC f F~   | try to open the file under point =helm=                        |
 | ~SPC f j~   | jump to the current buffer file in dired                       |

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -313,7 +313,7 @@ argument takes the kindows rotate backwards."
 (defun spacemacs/sudo-edit (&optional arg)
   (interactive "p")
   (if (or arg (not buffer-file-name))
-      (find-file (concat "/sudo:root@localhost:" (ido-read-file-name "File: ")))
+      (find-file (concat "/sudo:root@localhost:" (read-file-name "File: ")))
     (find-alternate-file (concat "/sudo:root@localhost:" buffer-file-name))))
 
 ;; found at http://emacswiki.org/emacs/KillingBuffers

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -130,6 +130,7 @@ Ensure that helm is required before calling FUNC."
   "fg" 'rgrep
   "fj" 'dired-jump
   "fl" 'find-file-literally
+  "fE" 'spacemacs/sudo-edit
   "fo" 'spacemacs/open-in-external-app
   "fR" 'spacemacs/rename-current-buffer-file
   "fS" 'evil-write-all


### PR DESCRIPTION
We should use the default here since this is then adviced by either helm or ido AFAIK.