### PR TITLE
[haskell] fix REPL bring function

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -259,7 +259,7 @@ REPL commands are prefixed by ~SPC m s~:
 |-------------+-------------------------------------------------|
 | ~SPC m s b~ | load or reload the current buffer into the REPL |
 | ~SPC m s c~ | clear the REPL                                  |
-| ~SPC m s s~ | show the REPL                                   |
+| ~SPC m s s~ | show the REPL without switching to it           |
 | ~SPC m s S~ | show and switch to the REPL                     |
 
 ** Cabal commands

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -285,6 +285,9 @@ This commands are available in a cabal file.
 | ~SPC m l~   | go to libary section                        |
 | ~SPC m n~   | go to next subsection                       |
 | ~SPC m p~   | go to previous subsection                   |
+| ~SPC m s c~ | clear the REPL                              |
+| ~SPC m s s~ | show the REPL without switching to it       |
+| ~SPC m s S~ | show and switch to the REPL                 |
 | ~SPC m N~   | go to next section                          |
 | ~SPC m P~   | go to previous section                      |
 | ~SPC m f~   | find or create source-file under the cursor |

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -99,6 +99,8 @@
       (spacemacs/declare-prefix-for-mode 'haskell-mode "mc" "haskell/cabal")
       (spacemacs/declare-prefix-for-mode 'haskell-mode "mh" "haskell/documentation")
       (spacemacs/declare-prefix-for-mode 'haskell-mode "md" "haskell/debug")
+      (spacemacs/declare-prefix-for-mode 'haskell-interactive-mode "ms" "haskell/repl")
+      (spacemacs/declare-prefix-for-mode 'haskell-cabal-mode "ms" "haskell/repl")
 
       ;; key bindings
       (defun spacemacs/haskell-process-do-type-on-prev-line ()
@@ -149,18 +151,21 @@
 
       ;; Cabal-file bindings
       (evil-leader/set-key-for-mode 'haskell-cabal-mode
-        ;; "m="  'haskell-cabal-subsection-arrange-lines ;; Does a bad job, 'gg=G' works better
-        "md" 'haskell-cabal-add-dependency
-        "mb" 'haskell-cabal-goto-benchmark-section
-        "me" 'haskell-cabal-goto-executable-section
-        "mt" 'haskell-cabal-goto-test-suite-section
-        "mm" 'haskell-cabal-goto-exposed-modules
-        "ml" 'haskell-cabal-goto-library-section
-        "mn" 'haskell-cabal-next-subsection
-        "mp" 'haskell-cabal-previous-subsection
-        "mN" 'haskell-cabal-next-section
-        "mP" 'haskell-cabal-previous-section
-        "mf" 'haskell-cabal-find-or-create-source-file)
+        ;; "m="   'haskell-cabal-subsection-arrange-lines ;; Does a bad job, 'gg=G' works better
+        "md"   'haskell-cabal-add-dependency
+        "mb"   'haskell-cabal-goto-benchmark-section
+        "me"   'haskell-cabal-goto-executable-section
+        "mt"   'haskell-cabal-goto-test-suite-section
+        "mm"   'haskell-cabal-goto-exposed-modules
+        "ml"   'haskell-cabal-goto-library-section
+        "mn"   'haskell-cabal-next-subsection
+        "mp"   'haskell-cabal-previous-subsection
+        "msc"  'haskell-interactive-mode-clear
+        "mss"  'spacemacs/haskell-interactive-bring
+        "msS"  'haskell-interactive-switch
+        "mN"   'haskell-cabal-next-section
+        "mP"   'haskell-cabal-previous-section
+        "mf"   'haskell-cabal-find-or-create-source-file)
 
       ;; Make "RET" behaviour in REPL saner
       (evil-define-key 'insert haskell-interactive-mode-map

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -64,6 +64,14 @@
           ;; in structured-haskell-mode line highlighting creates noise
           (setq-local global-hl-line-mode nil)))
 
+      (defun spacemacs/haskell-interactive-bring ()
+        "Bring up the interactive mode for this session without
+         switching to it."
+        (interactive)
+        (let* ((session (haskell-session))
+               (buffer (haskell-session-interactive-buffer session)))
+          (display-buffer buffer)))
+
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)
       (add-hook 'haskell-cabal-mode-hook 'haskell-cabal-hook)
@@ -106,7 +114,7 @@
 
         "msb"  'haskell-process-load-or-reload
         "msc"  'haskell-interactive-mode-clear
-        "mss"  'haskell-interactive-bring
+        "mss"  'spacemacs/haskell-interactive-bring
         "msS"  'haskell-interactive-switch
 
         "mca"  'haskell-process-cabal


### PR DESCRIPTION
So now, instead of switching to it - `SPC m s s` shows REPL buffer without switching to it.