### PR TITLE
don't push company-ghc when ghc-mod is disabled

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -291,8 +291,10 @@
       :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
-      (push '(company-ghc company-dabbrev-code company-yasnippet)
-            company-backends-haskell-mode)))
+      (push (if company-enable-ghc-mod-support
+                '(company-ghc company-dabbrev-code company-yasnippet)
+              '(company-dabbrev-code company-yasnippet)
+              company-backends-haskell-mode)))
 
   (defun haskell/init-company-cabal ()
     (use-package company-cabal


### PR DESCRIPTION
Because it forces `ghc-mod`, so haskell layer doesn't respects the value of `haskell-enable-ghc-mod-support`.

Also, the question - `company-dabbrev-code` is already in `company-backends-haskell-mode` - so is it necessary to add it here? And is it safe? 