### PR TITLE
[haskell] configure C-c C-l so it doesn't error

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -131,6 +131,9 @@
         "mda"  'haskell-debug/abandon
         "mdr"  'haskell-debug/refresh)
 
+      ;; configure C-c C-l so it doesn't throw any errors
+      (bind-key "C-c C-l" 'haskell-process-load-or-reload haskell-mode-map)
+
       ;; Switch back to editor from REPL
       (evil-leader/set-key-for-mode 'haskell-interactive-mode
         "msS"  'haskell-interactive-switch-back)


### PR DESCRIPTION
By default `C-c C-l` shows following error:

```
haskell-mode-enable-process-minor-mode: Run ‘C-h f haskell-mode‘ for instruction how to setup a Haskell interaction mode.
```

Which might confuse users and they might end up setting
interactive-haskell-mode, which in most cases not what we want.

Also, it gives short key binding for emacs-only editing style users to
bring up REPL.

---

Since it's not Spacemacs key binding, feel free to refuse this PR. But in my opinion, it should be part of haskell layer, because with it we might avoid some confusion. 