### PR TITLE
Remove obsolete evil-jumper-file

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -582,8 +582,7 @@
   (use-package evil-jumper
     :init
     (progn
-      (setq evil-jumper-file (concat spacemacs-cache-directory "evil-jumps")
-            evil-jumper-auto-save-interval 600)
+      (setq evil-jumper-auto-save-interval 600)
       (evil-jumper-mode t))))
 
 (defun spacemacs/init-evil-lisp-state ()


### PR DESCRIPTION
I just updated my packages and got this.

    The variable 'evil-jumper-file' is obsolete.  Persistence is done with 'savehist' now.

Since we are already using and setting up savehist, I think we can just remove this `setq`.