### PR TITLE
common-lisp: make `SPC m e` keys behave like in elisp

### DIFF
--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -67,13 +67,14 @@ As this state works the same for all files, the documentation is in global
 
 *** Evaluation
 
-| Key Binding | Description                     |
-|-------------+---------------------------------|
-| ~SPC m e b~ | Evaluate buffer                 |
-| ~SPC m e e~ | Evaluate last expression        |
-| ~SPC m e f~ | Evaluate top level s-expression |
-| ~SPC m e F~ | Undefine the function at point  |
-| ~SPC m e r~ | Evaluate region                 |
+| Key Binding | Description                              |
+|-------------+------------------------------------------|
+| ~SPC m e b~ | Evaluate buffer                          |
+| ~SPC m e e~ | Evaluate last sexp                       |
+| ~SPC m e l~ | Go to end of line and evaluate last sexp |
+| ~SPC m e f~ | Evaluate top level sexp                  |
+| ~SPC m e F~ | Undefine the function at point           |
+| ~SPC m e r~ | Evaluate region                          |
 
 *** REPL
 

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -38,6 +38,18 @@
       (slime-setup)
       (dolist (m `(,slime-mode-map ,slime-repl-mode-map))
         (define-key m [(tab)] 'slime-fuzzy-complete-symbol))
+      (defun slime-eval-sexp-end-of-line ()
+        (interactive)
+        (move-end-of-line 1)
+        (slime-eval-last-expression))
+      (defadvice slime-last-expression (around evil activate)
+        "In normal-state or motion-state, last sexp ends at point."
+        (if (and (not evil-move-beyond-eol)
+                 (or (evil-normal-state-p) (evil-motion-state-p)))
+            (save-excursion
+              (unless (or (eobp) (eolp)) (forward-char))
+              ad-do-it)
+          ad-do-it))
       ;; TODO: Add bindings for the SLIME debugger?
       (evil-leader/set-key-for-mode 'lisp-mode
         "mcc" 'slime-compile-file
@@ -50,7 +62,8 @@
         "meb" 'slime-eval-buffer
         "mef" 'slime-eval-defun
         "meF" 'slime-undefine-function
-        "mee" 'slime-eval-last-sexp
+        "mee" 'slime-eval-last-expression
+        "mel" 'slime-eval-sexp-end-of-line
         "mer" 'slime-eval-region
 
         "mgg" 'slime-inspect-definition


### PR DESCRIPTION
- Make `SPC m e e` (eval-last-sexp) respect evil mode, e.g. you can eval statement while cursor is on closing parenthesis. 
- Add `SPC m e l` for going to end of line and eval last sexp.

I am new to elisp and borrowed a code from [evil-integration.el-318](https://bitbucket.org/lyro/evil/src/09e823db8a4e7a12b713f30039aa6336ae95cf1b/evil-integration.el?fileviewer=file-view-default#evil-integration.el-318) But I don't understand why there is a cond `(version< emacs-version "25")` . Is `defadvice` will be deprecated in that version? Should I add this to my code too?
