### PR TITLE
Add typography layer

### DIFF
--- a/layers/typography/README.org
+++ b/layers/typography/README.org
@@ -1,0 +1,55 @@
+#+TITLE typography contribution layer for Spacemacs
+
+* Table of Contents
+* Description
+
+This layer provides support for typographic text editing in Spacemacs.  It
+provides modes to automatically insert and cycle among typographic characters:
+
+- [[https://github.com/jorgenschaefer/typoel][Typo Mode]] automatically inserts and cycles among typographic Unicode
+  characters on some keys.
+- Tildify Mode automatically inserts non-breaking spaces where required.
+
+* Install
+
+To use this contribution add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(typography))
+#+END_SRC
+
+Typographic editing however is disabled by default.  To enable it by default set
+=typography-enable-typographic-editing= to =t=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '(typography :variables typography-enable-typographic-editing t))
+#+END_SRC
+
+This setting enables automatic insertion of non-breaking spaces where required
+and automatic insertion and cycling among of typographic quotes and dashes.
+
+* Key bindings
+
+| Key Bindings | Description                                                      |
+|--------------+------------------------------------------------------------------|
+| ~SPC t T y~  | Toggle Typo Mode (automatic insertion of typographic characters) |
+| ~SPC t T d~  | Toggle Tildify Mode (automatic insertion of non-breaking spaces) |
+| ~SPC x T t~  | Insert non-breaking spaces in the current region                 |
+
+** Typo Mode
+
+| Key Bindings (insert mode) | Description                              |
+|----------------------------+------------------------------------------|
+| ~"~                        | Cycle among quotation marks              |
+| ~`~                        | Cycle among left single quotation marks  |
+| ~'~                        | Cycle among right single quotation marks |
+| ~-~                        | Cycle among dashes                       |
+| ~.~                        | Cycle among ellipsis                     |
+| ~<~                        | Cycle among left angle brackets          |
+| ~>~                        | Cycle among right angle brackets         |
+
+** Tildify Mode
+
+| Key bindings (insert mode) | Description                             |
+| ~SPC~                      | Insert non-breaking space when required |

--- a/layers/typography/config.el
+++ b/layers/typography/config.el
@@ -1,0 +1,13 @@
+;;; config.el --- typography Layer configuration
+;;
+;; Copyright (c) 2015 Sylvain Benner & Contributors
+;;
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar typography-enable-typographic-editing nil
+  "If non-nil automatically enable typographic editing.")

--- a/layers/typography/packages.el
+++ b/layers/typography/packages.el
@@ -1,0 +1,63 @@
+;;; packages.el --- typography Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2015 Sylvain Benner & Contributors
+;;
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq typography-packages
+      '(
+        typo
+        ))
+
+(when (version<= "25" emacs-version)
+  (push 'tildify typography-packages))
+
+(setq typography-excluded-packages '())
+
+(defun typography/init-typo ()
+  (use-package typo
+    :defer t
+    :init
+    (progn
+      (when typography-enable-typographic-editing
+        (dolist (hook '(text-mode-hook org-mode-hook))
+          (add-hook hook 'typo-mode)))
+
+      (spacemacs|add-toggle typographic-substitutions
+        :status typo-mode
+        :on (typo-mode)
+        :off (typo-mode -1)
+        :documentation "Enable typographic substitutions"
+        :evil-leader "tTy")
+      (spacemacs|diminish typo-mode " 𝔗" " ty"))
+    :config (setq typo-language "English")))
+
+(defun typography/init-tildify ()
+  (use-package tildify
+    :defer t
+    :init
+    (progn
+      (when typography-enable-typographic-editing
+        (add-hook 'text-mode-hook 'tildify-mode))
+
+      (evil-leader/set-key
+        "xTt" 'tildify-region)
+
+      ;; Use the symbolic non-breaking space for LaTeX
+      (defun typography/tildify-latex-space ()
+        "Set tildify space for LaTeX"
+        (setq-local tildify-space-string "~"))
+      (add-hook 'LaTeX-mode-hook 'typography/tildify-latex-space)
+
+      (spacemacs|add-toggle tildify-space
+        :status tildify-mode
+        :on (tildify-mode)
+        :off (tildify-mode -1)
+        :documentation "Enable electric non-breaking space"
+        :evil-leader "tTd")
+      (spacemacs|diminish tildify-mode " 𝔇" " td"))))


### PR DESCRIPTION
Adds:

- `typo-mode` (3rd party) for automatic insertion and cycling of typographic quotation marks, dashes and dots
- `tildify-mode` (built-in) for automatic insertion of non-breaking spaces when required (after single-character words, etc.), plus a binding to ‘tildify” the current region

Both modes are diminished—though the choice of characters is debatable—and have toggles.  Both are also disabled by default, with an option to turn them on.

Future features for this layer could include explicit bindings for insertion of typographic characters, corresponding micro states, etc., but I think the current feature set is sufficient for an initial version of this layer.