### PR TITLE
Make linum toggle local and add a variable for global mode

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -188,6 +188,9 @@ can be toggled through `toggle-transparency'.")
 overrides the default behavior of Emacs which recenters the point when
 it reaches the top or bottom of the screen.")
 
+(defvar dotspacemacs-global-line-numbers nil
+  "If non nil line numbers are turned on in all `prog-mode' and `text-mode'.")
+
 (defvar dotspacemacs-persistent-server nil
   "If non nil advises quit functions to keep server open when quitting.")
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -168,6 +168,9 @@ values."
    ;; scrolling overrides the default behavior of Emacs which recenters the
    ;; point when it reaches the top or bottom of the screen. (default t)
    dotspacemacs-smooth-scrolling t
+   ;; If non nil line numbers are turned on in all `prog-mode' and `text-mode'.
+   ;; (default nil)
+   dotspacemacs-global-line-numbers nil
    ;; If non-nil smartparens-strict-mode will be enabled in programming modes.
    ;; (default nil)
    dotspacemacs-smartparens-strict-mode nil

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -61,6 +61,7 @@
      - [[#color-themes][Color themes]]
      - [[#font][Font]]
      - [[#graphical-ui-toggles][Graphical UI Toggles]]
+       - [[#global-line-numbers][Global line numbers]]
      - [[#mouse-usage][Mouse usage]]
      - [[#mode-line][Mode-line]]
        - [[#powerline-font-installation-for-terminal-mode-users][Powerline font installation for terminal-mode users]]
@@ -922,7 +923,7 @@ and ~T~):
 | ~SPC t i~   | toggle indentation guide at point                                 |
 | ~SPC t l~   | toggle truncate lines                                             |
 | ~SPC t L~   | toggle visual lines                                               |
-| ~SPC t n~   | show the absolute line numbers                                    |
+| ~SPC t n~   | toggle line numbers                                               |
 
 | Key Binding | Description                                                  |
 |-------------+--------------------------------------------------------------|
@@ -935,6 +936,15 @@ and ~T~):
 
 *Note*: These toggles are all available via the =helm-spacemacs= interface (press
 ~SPC f e h~ to display the =helm-spacemacs= buffer).
+
+**** Global line numbers
+Line numbers can be toggled on in all =prog-mode= and =text-mode= buffers by
+setting the =dotspacemacs-global-line-numbers= variable in your =~/.spacemacs=
+to something different than =nil=:
+
+#+begin_src emacs-lisp
+    (setq-default dotspacemacs-global-line-numbers t)
+#+end_src
 
 *** Mouse usage
 There are some added mouse features set for the line number margin (if shown):

--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -165,6 +165,11 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
               '((truncation . nil) (continuation . nil)))
 ;; Show column number in mode line
 (setq column-number-mode t)
+;; Activate linum-mode in all prog-mode and text-mode buffers if the setting is
+;; enabled.
+(when dotspacemacs-global-line-numbers
+  (add-hook 'prog-mode-hook 'linum-mode)
+  (add-hook 'text-mode-hook 'linum-mode))
 ;; line number
 (setq linum-format "%4d")
 ;; highlight current line

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -206,8 +206,8 @@ Ensure that helm is required before calling FUNC."
   :evil-leader "tL")
 (spacemacs|add-toggle line-numbers
   :status linum-mode
-  :on (global-linum-mode)
-  :off (global-linum-mode -1)
+  :on (linum-mode)
+  :off (linum-mode -1)
   :documentation "Show the line numbers."
   :evil-leader "tn")
 (spacemacs|add-toggle auto-fill-mode


### PR DESCRIPTION
`global-linum-mode` is making line numbers appearing in `*spacemacs*`
and `helm` buffers, what is annoying.

This change make the linum `SPC t n` toggle buffer-local, and add a
customization variable in `.spacemacs` to enable line numbers globally.
«Globally» here as to be understood as «in `prog-mode` and `text-mode`».