### PR TITLE
common-lisp: Remove <tab> key binding

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -36,8 +36,6 @@
     :config
     (progn
       (slime-setup)
-      (dolist (m `(,slime-mode-map ,slime-repl-mode-map))
-        (define-key m [(tab)] 'slime-fuzzy-complete-symbol))
       ;; TODO: Add bindings for the SLIME debugger?
       (evil-leader/set-key-for-mode 'lisp-mode
         "mcc" 'slime-compile-file


### PR DESCRIPTION
'indent-command-for-tab' that already bound to tab globally is more useful.