### PR TITLE
Sr speedbar

### DIFF
--- a/layers/+tools/sr-speedbar/README.org
+++ b/layers/+tools/sr-speedbar/README.org
@@ -1,0 +1,25 @@
+#+TITLE: sr-speedbar contribution layer for Spacemacs
+
+* Table of Contents                                                   :TOC@4:
+ - [[#description][Description]]
+ - [[#install][Install]]
+     - [[#layer][Layer]]
+ - [[#usage][Usage]]
+
+* Description
+
+sr-speedbar is mode make SpeedBar show in Current Frame.
+
+* Install
+
+** Layer
+
+To use this contribution add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(sr-speedbar))
+#+END_SRC
+
+* Usage
+
+M-x spacemacs/sr-speedbar-show-or-hide

--- a/layers/+tools/sr-speedbar/README.org
+++ b/layers/+tools/sr-speedbar/README.org
@@ -3,16 +3,14 @@
 * Table of Contents                                                   :TOC@4:
  - [[#description][Description]]
  - [[#install][Install]]
-     - [[#layer][Layer]]
  - [[#usage][Usage]]
+ - [[#key-bindings][Key Bindings]]
 
 * Description
 
 sr-speedbar is mode make SpeedBar show in Current Frame.
 
 * Install
-
-** Layer
 
 To use this contribution add it to your =~/.spacemacs=
 
@@ -21,5 +19,7 @@ To use this contribution add it to your =~/.spacemacs=
 #+END_SRC
 
 * Usage
-
-M-x spacemacs/sr-speedbar-show-or-hide
+* Key Bindings
+| Key Binding | Description                  |
+|-------------+------------------------------|
+| ~SPC f t~   | Toggle sr-speedbar           |

--- a/layers/+tools/sr-speedbar/packages.el
+++ b/layers/+tools/sr-speedbar/packages.el
@@ -1,0 +1,29 @@
+;;; packages.el --- sr-speedbar Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: wsk <tshemeng@live.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq sr-speedbar-packages
+  '(sr-speedbar))
+
+(defun sr-speedbar/post-init-sr-speedbar ()
+  (defun spacemacs/sr-speedbar-show-or-hide ()
+    (interactive)
+    (cond ((sr-speedbar-exist-p) (kill-buffer speedbar-buffer))
+          (t (sr-speedbar-open) (linum-mode -1) (speedbar-refresh)))))
+
+(defun sr-speedbar/init-sr-speedbar ()
+  (use-package sr-speedbar
+    :init
+    (setq sr-speedbar-width 30)
+    (setq sr-speedbar-right-side nil)
+    :config
+    (spacemacs|evilify-map speedbar-mode-map)))
+

--- a/layers/+tools/sr-speedbar/packages.el
+++ b/layers/+tools/sr-speedbar/packages.el
@@ -25,5 +25,7 @@
     (setq sr-speedbar-width 30)
     (setq sr-speedbar-right-side nil)
     :config
+    (evil-leader/set-key
+      "ft" 'spacemacs/sr-speedbar-show-or-hide)
     (spacemacs|evilify-map speedbar-mode-map)))
 


### PR DESCRIPTION
This builds on https://github.com/syl20bnr/spacemacs/pull/2002, adding a key binding `SPC f t` overlaying the `neotree` binding. @CarlQLange also opened https://github.com/syl20bnr/spacemacs/pull/3224, but didn't make any additional commits.

**Caveat:** I'm not 100% happy with [Speedbar](http://www.gnu.org/software/emacs/manual/html_node/emacs/Speedbar.html) being a global singleton buffer rather than allowing an independent buffer per frame. In a multiple frame workflow where the speedbar frame is already visible in another frame, the first `SPC f t` toggles the buffer off in the other frame, and the second reinitializes it in the current frame.
