### PR TITLE
`aya-persist-snippets-dir` should follow the user customization

### DIFF
--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -269,9 +269,11 @@
     :defer t
     :init
     (progn
-      (setq aya-persist-snippets-dir (concat
-                                      configuration-layer-private-directory
-                                      "snippets/"))
+      (setq aya-persist-snippets-dir (if auto-completion-private-snippets-directory
+                                         auto-completion-private-snippets-directory
+                                         (concat
+                                           configuration-layer-private-directory
+                                           "snippets/")))
       (defun spacemacs/auto-yasnippet-expand ()
         "Call `yas-expand' and switch to `insert state'"
         (interactive)


### PR DESCRIPTION
`aya-persist-snippets-dir` should reference the `configuration-layer-private-directory` if user do customize it.