### PR TITLE
[eyebrowse] add support of keyboard-like num sort

### DIFF
--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -39,13 +39,18 @@
               (format "[%s]" caption)
             caption)))
 
+      (defun spacemacs//workspaces-ms-get-window-configs ()
+        "Return the list of window configs. Depends on value of
+`eyebrowse-place-zero-at-the-end'."
+        (--sort (if (eq (car other) 0)
+                    t
+                  (< (car it) (car other)))
+                (eyebrowse--get 'window-configs)))
+
       (defun spacemacs//workspaces-ms-documentation ()
         "Return the docstring for the workspaces micro-state."
         (let* ((current-slot (eyebrowse--get 'current-slot))
-               (window-configs (eyebrowse--get 'window-configs))
-               (window-config-slots (mapcar (lambda (x)
-                                              (number-to-string (car x)))
-                                            window-configs)))
+               (window-configs (spacemacs//workspaces-ms-get-window-configs)))
           (concat
            "<" (if window-configs
                    (concat


### PR DESCRIPTION
So instead of `0 1 2 ... 9` user will see `1 2 ... 9 0`. Which reflects
how numbers appear on keyboard. It's optional, and disabled by default.

---

I can't believe I am the only one who doesn't like the current position of `0` :smile: .

If you don't like the idea of this predefined sorting rule - I can add support for custom sorting function. So anyone can sort configurations as they want (and not only by numbers).