### PR TITLE
Remove flycheck-fringe's bullet underlining

### DIFF
--- a/layers/syntax-checking/packages.el
+++ b/layers/syntax-checking/packages.el
@@ -52,7 +52,7 @@
                   #b00000000
                   #b00000000
                   #b00000000
-                  #b01111111)))
+                  #b00000000)))
 
       (flycheck-define-error-level 'error
         :overlay-category 'flycheck-error-overlay


### PR DESCRIPTION
Currently flycheck's bullets in the fringe are underlined. The
underlining is hardcoded in the bitmap. This commit remove this
underlining.