### PR TITLE
Fixes #621 - mimic haskell-indentation on region in evil

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -160,6 +160,17 @@
       (evil-define-key 'normal haskell-interactive-mode-map
         (kbd "RET") 'haskell-interactive-mode-return)
 
+      ;; mimic haskell-indentation on region in visual state
+      (unless haskell-enable-shm-support
+        (spacemacs|define-micro-state haskell-indentation
+          :doc "Press = to indent further or - to indent backwards"
+          :use-minibuffer t
+          :bindings
+          ("=" indent-for-tab-command)
+          ("-" haskell-indentation-indent-backwards))
+
+        (evil-define-key 'visual haskell-mode-map (kbd "=") 'spacemacs/haskell-indentation-micro-state))
+
       ;;GHCi-ng
       (when haskell-enable-ghci-ng-support
         ;; haskell-process-type is set to auto, so setup ghci-ng for either case


### PR DESCRIPTION
Fix #621 

---

`haskell-indentation` has something similar to `micro-state` in Spacemacs when you indent region. It allows you to indent it further by one space by hitting `TAB` and indent backwards by one space by hitting `S-TAB`. 

![haskell-indentation-region-1](https://cloud.githubusercontent.com/assets/6507913/10811743/fce60914-7e17-11e5-8eb1-7881dc300d58.gif)

As you can see, when I hit `TAB` it visually disables region and indents region by one space further. So I implemented `micro-state` that mimics this behaviour when you press `=` in visual state. It's just doesn't indent on the first usage. I tried to do it but due to how `haskell-indentation-indent-region` works with region - there is unnecessary flickering when I try to select region again programatically after I call `haskell-indentation-indent-region`. So this can be improved a bit. Just not sure how at this point.

Also, I hope that evil users will like `-` and `=` bindings more that `S-TAB` and `TAB` respectively.