### PR TITLE
Add live-python mode to python layer as extension

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -22,6 +22,7 @@
    - [[Running Python Script in shell][Running Python Script in shell]]
    - [[Testing][Testing]]
    - [[Refactoring][Refactoring]]
+   - [[Live coding][Live coding]]
    - [[Other Python commands][Other Python commands]]
  - [[Configuration][Configuration]]
    - [[Fill column][Fill column]]
@@ -203,6 +204,13 @@ Test commands start with ~m t~:
 | Key Binding | Description                          |
 |-------------+--------------------------------------|
 | ~SPC m r i~ | remove unused imports with [[https://github.com/myint/autoflake][autoflake]] |
+
+** Live coding
+Live coding is provided by the [[https://github.com/donkirkby/live-py-plugin][live-py-plugin.]]
+
+| Key Binding | Description         |
+|-------------+---------------------|
+| ~SPC m l~   | Toggle live-py-mode |
 
 ** Other Python commands
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -23,6 +23,7 @@
     helm-pydoc
     hy-mode
     (nose :location local)
+    live-py-mode
     pip-requirements
     pyenv-mode
     (pylookup :location local)
@@ -111,6 +112,15 @@
 (defun python/init-hy-mode ()
   (use-package hy-mode
     :defer t))
+
+(defun python/init-live-py-mode ()
+  (use-package live-py-mode
+    :defer t
+    :commands live-py-mode
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "l" 'live-py-mode))
+  )
 
 (defun python/init-nose ()
   (use-package nose


### PR DESCRIPTION
This adds the [live-py-plugin](https://github.com/donkirkby/live-py-plugin) as an extension.

Think Light Table or the [Inventing on Principle talk by Bret Victor](https://www.youtube.com/watch?v=PUv66718DII).

For a demo see [the video](http://www.youtube.com/watch?v=LV3aFRHlAEQ)