### PR TITLE
Add magit-checkout binding

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -112,6 +112,7 @@
 
       (evil-leader/set-key
         "gb" 'spacemacs/git-blame-micro-state
+        "gc" 'magit-checkout
         "gi" 'magit-init
         "gl" 'magit-log-all
         "gL" 'magit-log-buffer-file


### PR DESCRIPTION
This is particularly useful to switch from one branch to another without
going through the status buffer for instance.