### PR TITLE
Add magit-checkout binding

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -107,6 +107,7 @@ Git commands (start with ~g~):
 |-------------+-----------------------------------------------------|
 | ~SPC g b~   | open a =magit= blame                                |
 | ~SPC g B~   | quit =magit= blame                                  |
+| ~SPC g c~   | checkout branches                                   |
 | ~SPC g C~   | commit changes                                      |
 | ~SPC g d~   | show diff against current head                      |
 | ~SPC g h c~ | clear highlights                                    |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -112,6 +112,7 @@
 
       (evil-leader/set-key
         "gb" 'spacemacs/git-blame-micro-state
+        "gc" 'magit-checkout
         "gi" 'magit-init
         "gl" 'magit-log-all
         "gL" 'magit-log-buffer-file


### PR DESCRIPTION
This is particularly useful to switch from one branch to another without
going through the status buffer for instance.