### PR TITLE
which-key: Allow evil-operators to popup buffer

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -1428,7 +1428,8 @@ ARG non nil means that the editing style is `vim'."
             which-key-echo-keystrokes 0.02
             which-key-max-description-length 32
             which-key-sort-order 'which-key-key-order-alpha
-            which-key-idle-delay dotspacemacs-which-key-delay)
+            which-key-idle-delay dotspacemacs-which-key-delay
+            which-key-allow-evil-operators t)
       (which-key-mode)
       (spacemacs|diminish which-key-mode " Ⓚ" " K"))))
 


### PR DESCRIPTION
I'm adding some stuff to which-key that is automatically activated if evil is loaded.

I can do this in the which-key config, but this seems simpler and doesn't affect anything in spacemacs.