### PR TITLE
[READY] Deactivate loading of evil-snipe in magit-mode if git layer is used

### DIFF
--- a/layers/+vim/evil-snipe/packages.el
+++ b/layers/+vim/evil-snipe/packages.el
@@ -13,6 +13,10 @@
     :config
     (progn
       (evil-snipe-mode 1)
+      (if (configuration-layer/layer-usedp 'git)
+          (progn
+            (add-hook 'magit-mode-hook 'turn-off-evil-snipe-override-mode)
+            (add-hook 'git-rebase-mode-hook 'turn-off-evil-snipe-override-mode)))
       (when evil-snipe-enable-alternate-f-and-t-behaviors
         (setq evil-snipe-repeat-scope 'whole-buffer)
         (evil-snipe-override-mode 1)))))


### PR DESCRIPTION
Otherwise `f` `F` `t` and `T` do not work in magit.

See also comment in https://github.com/syl20bnr/spacemacs/issues/3592