### PR TITLE
Correct :diminish arg for evil-snipe

### DIFF
--- a/layers/+vim/evil-snipe/packages.el
+++ b/layers/+vim/evil-snipe/packages.el
@@ -2,7 +2,7 @@
 
 (defun evil-snipe/init-evil-snipe ()
   (use-package evil-snipe
-    :diminish evil-snipe-mode
+    :diminish evil-snipe-local-mode
     :init
     (setq evil-snipe-scope 'whole-buffer
           evil-snipe-enable-highlight t


### PR DESCRIPTION
Super minor change, but without out it, spacemacs fails to load if `evil-snipe` is in the users's `dotspacemacs-configuration-layers`

Commit message:
Recent updates to evil snipe changed the symbol of the minor mode.  Only
the name of that symbol in :diminsh needs to change in order for the
layer to load correctly and hide evil-snipe's indicator.