### PR TITLE
Correct few defaults of spell-checking's layer

### DIFF
--- a/layers/spell-checking/README.org
+++ b/layers/spell-checking/README.org
@@ -6,6 +6,7 @@
    - [[#layer][Layer]]
    - [[#spell-checker-configuration][Spell Checker Configuration]]
    - [[#disabling-by-default][Disabling by default]]
+   - [[#enabling-auto-dictionary-mode][Enabling auto-dictionary-mode]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
@@ -36,6 +37,17 @@ toggled off with ~SPC t S~. You can default this to off by setting the variable
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
   '((spell-checking :variables spell-checking-enable-by-default nil)))
+#+END_SRC
+
+** Enabling auto-dictionary-mode
+=auto-dictionary-mode= tries to detect the current language from the buffer
+content, and activate the corresponding dictionary. You can enable it by setting
+the variable =spell-checking-enable-auto-dictionary= to something other than
+=nil=:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((spell-checking :variables spell-checking-enable-auto-dictionary t)))
 #+END_SRC
 
 * Key Bindings

--- a/layers/spell-checking/config.el
+++ b/layers/spell-checking/config.el
@@ -18,3 +18,6 @@
 
 (defvar spell-checking-enable-by-default t
   "Enable spell checking by default.")
+
+(defvar spell-checking-enable-auto-dictionary nil
+  "Specify if auto-dictionary should be enabled or not.")


### PR DESCRIPTION
- Disable `auto-dictionary-mode` by default. Add a layer's variable to
  enable it. Its behaviour has some impact on user-defined dictionary
  preferences, it has some bugs in daemon mode, and not all languages
  are supported. It's why it better to have it disabled by default.

- Toggle off `auto-dictionary-mode` when spell-checking is toggled off.

- Call `flyspell-buffer` when toggling **on** spell-checking to reveal
  mistakes (probably the wanted behaviour when activating
  spell-checking)

- When `auto-dictionary-mode` is enabled, if a buffer's dictionary is
  manually changed with `SPC S d`, it is restored after toggling
  spell-checking on/off, otherwise `auto-dictionary` will thy to guess
  it again.