### PR TITLE
Add ace-jump-helm-line for quick helm navigation.

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -13,6 +13,7 @@
 (setq spacemacs-packages
       '(
         ;; default
+        ace-jump-helm-line
         ace-link
         ace-window
         adaptive-wrap
@@ -91,6 +92,12 @@
   (push 'paradox spacemacs-packages))
 
 ;; Initialization of packages
+
+(defun spacemacs/init-ace-jump-helm-line ()
+  (use-package ace-jump-helm-line
+    :init
+    (with-eval-after-load "helm"
+      (define-key helm-map (kbd "C-'") 'ace-jump-helm-line))))
 
 (defun spacemacs/init-ace-link ()
   (use-package ace-link


### PR DESCRIPTION
Useful when you don't desire filtering helm buffer but still want to
navigate the helm buffer when selecting multiple items.