### PR TITLE
scala: Fix bindings for Ensime test commands

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -152,9 +152,9 @@
         "mrt"     'ensime-import-type-at-point
         "mrv"     'ensime-refactor-extract-local
 
-        "mta"     'ensime-sbt-do-test
-        "mtr"     'ensime-sbt-do-test-quick
-        "mtt"     'ensime-sbt-do-test-only
+        "mta"     'ensime-sbt-do-test-dwim
+        "mtr"     'ensime-sbt-do-test-quick-dwim
+        "mtt"     'ensime-sbt-do-test-only-dwim
 
         "msa"     'ensime-inf-load-file
         "msb"     'ensime-inf-eval-buffer


### PR DESCRIPTION
Ensime changed the names of the test commands, see https://github.com/ensime/ensime-emacs/commit/6d83487f1d4187a5b4f82f8f12b35cb2b11fbc80