### PR TITLE
Move the dictionary selection code into adict hook

### DIFF
--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -22,7 +22,18 @@
     :defer t
     :if spell-checking-enable-auto-dictionary
     :init
-    (add-hook 'flyspell-mode-hook 'auto-dictionary-mode)))
+    (progn
+      (add-hook 'flyspell-mode-hook 'auto-dictionary-mode)
+      ;; Select the buffer local dictionary if it was set, otherwise
+      ;; auto-dictionary will replace it with a guessed one at each activation.
+      ;; https://github.com/nschum/auto-dictionary-mode/issues/5
+      (add-hook 'auto-dictionary-mode-hook
+                (lambda ()
+                  (when (and
+                         (fboundp 'adict-change-dictionary)
+                         ispell-local-dictionary)
+                    (adict-change-dictionary ispell-local-dictionary))) 'append)
+      )))
 
 (defun spell-checking/init-flyspell ()
   (use-package flyspell
@@ -40,14 +51,9 @@
       (spacemacs|add-toggle spelling-checking
         :status flyspell-mode
         :on
-        (progn
-          (if (derived-mode-p 'prog-mode)
-              (flyspell-prog-mode)
-            (flyspell-mode))
-          ;; Redefine the buffer local dictionary if it was set, otherwise
-          ;; auto-dictionary will replace it with guessed one.
-          (when (and (fboundp 'adict-change-dictionary) ispell-local-dictionary)
-            (adict-change-dictionary ispell-local-dictionary)))
+        (if (derived-mode-p 'prog-mode)
+            (flyspell-prog-mode)
+          (flyspell-mode))
         :off
         (progn
           (flyspell-mode-off)


### PR DESCRIPTION
When `auto-dictionary-mode` is activated, it tries to guess the
dictionary no matter if a dictionary was manually selected before, what
is annoying when toggling spell-checking off/on. To avoid this, a piece
of code was added to the spell-checking toggle to select the
buffer-local dictionary if it was set.

As mentioned by lunaryorn, this part of code should also be called when
flyspell is enabled/disabled by an other mean than the spacemacs toggle.
This commit move the code to the `auto-dictionary-mode-hook` for this
purpose.