### PR TITLE
Introduce 'relative for global-line-numbers

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -189,7 +189,8 @@ overrides the default behavior of Emacs which recenters the point when
 it reaches the top or bottom of the screen.")
 
 (defvar dotspacemacs-global-line-numbers nil
-  "If non nil line numbers are turned on in all `prog-mode' and `text-mode'.")
+  "If non nil line numbers are turned on in all `prog-mode' and `text-mode'
+derivatives. If set to `'relative', also turns on relative line numbers.")
 
 (defvar dotspacemacs-persistent-server nil
   "If non nil advises quit functions to keep server open when quitting.")

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -168,7 +168,8 @@ values."
    ;; scrolling overrides the default behavior of Emacs which recenters the
    ;; point when it reaches the top or bottom of the screen. (default t)
    dotspacemacs-smooth-scrolling t
-   ;; If non nil line numbers are turned on in all `prog-mode' and `text-mode'.
+   ;; If non nil line numbers are turned on in all `prog-mode' and `text-mode'
+   ;; derivatives. If set to `'relative', also turns on relative line numbers.
    ;; (default nil)
    dotspacemacs-global-line-numbers nil
    ;; If non-nil smartparens-strict-mode will be enabled in programming modes.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -942,10 +942,16 @@ and ~T~):
 **** Global line numbers
 Line numbers can be toggled on in all =prog-mode= and =text-mode= buffers by
 setting the =dotspacemacs-global-line-numbers= variable in your =~/.spacemacs=
-to something different than =nil=:
+to something different than =nil=.
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-global-line-numbers t)
+#+END_SRC
+
+If it is set to =relative=, line numbers are show in a relative way:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-global-line-numbers 'relative)
 #+END_SRC
 
 *** Mouse usage

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1458,9 +1458,12 @@ It will toggle the overlay under point or create an overlay of one character."
 
 (defun spacemacs/init-linum-relative ()
   (use-package linum-relative
-    :commands linum-relative-toggle
+    :commands (linum-relative-toggle linum-relative-on)
     :init
-    (evil-leader/set-key "tr" 'linum-relative-toggle)
+    (progn
+      (when (eq dotspacemacs-global-line-numbers 'relative)
+        (linum-relative-on))
+      (evil-leader/set-key "tr" 'linum-relative-toggle))
     :config
     (progn
       (setq linum-relative-current-symbol ""))))


### PR DESCRIPTION
Allow to use 'relative as value for the dotspacemacs-global-line-numbers
setting. This enable relative global line numbers as it is a common
usage.