### PR TITLE
Disable automatic call to flyspell-buffer

### DIFF
--- a/layers/spell-checking/README.org
+++ b/layers/spell-checking/README.org
@@ -54,6 +54,7 @@ the variable =spell-checking-enable-auto-dictionary= to something other than
 
 | Key Binding | Description              |
 |-------------+--------------------------|
+| ~SPC S b~   | flyspell whole buffer    |
 | ~SPC S c~   | flyspell correct         |
 | ~SPC S d~   | change dictionary        |
 | ~SPC S n~   | flyspell goto next error |

--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -35,8 +35,6 @@
       (when spell-checking-enable-by-default
         (add-hook 'prog-mode-hook 'flyspell-prog-mode))
 
-      (add-hook 'flyspell-mode-hook 'flyspell-buffer)
-
       (spacemacs|add-toggle spelling-checking
         :status flyspell-mode
         :on
@@ -58,6 +56,7 @@
         :evil-leader "tS")
 
       (evil-leader/set-key
+        "Sb" 'flyspell-buffer
         "Sd" 'spell-checking/change-dictionary
         "Sn" 'flyspell-goto-next-error))
     :config


### PR DESCRIPTION
Some users complained about slowness when opening files due to
spell-checking being activated. This commit revert to old behaviour
checking only the words under the cursor and not the whole buffer.