### PR TITLE
Python: Don't remove ':' from electric-indent-chars in emacs >= 24.5

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -123,9 +123,10 @@
       (defun python-default ()
         (setq mode-name "Python"
               tab-width 4
-              fill-column python-fill-column
+              fill-column python-fill-column)
+        (when (version< emacs-version "24.5")
               ;; auto-indent on colon doesn't work well with if statement
-              electric-indent-chars (delq ?: electric-indent-chars))
+              (setq electric-indent-chars (delq ?: electric-indent-chars)))
         (annotate-pdb)
         (spacemacs/highlight-TODO-words)
         ;; make C-j work the same way as RET


### PR DESCRIPTION
According to the conversation in [0] ':' is removed from
electric-indent-chars in python-mode because typing ':' in

```python
for i in range(10):
    print(i)
for i in range(10)_
```

with the point at _ indents the third line. This is not happening in
Emacs 24.5 anymore.

[0] https://github.com/syl20bnr/spacemacs/commit/aed0fc8ef88dc4bd22b4c5b3ce29be17990ef6e9