### PR TITLE
Fix obsolete method in vagrant layer

### DIFF
--- a/layers/+tools/vagrant/packages.el
+++ b/layers/+tools/vagrant/packages.el
@@ -37,6 +37,6 @@
       (defadvice vagrant-tramp-term (before spacemacs//load-vagrant activate)
         "Lazy load vagrant-tramp."
         (unless spacemacs--vagrant-tramp-loaded
-          (vagrant-tramp-enable)
+          (vagrant-tramp-add-method)
           (setq spacemacs--vagrant-tramp-loaded t)))
       (evil-leader/set-key "Vt" 'vagrant-tramp-term))))


### PR DESCRIPTION
Fixes warning:

    Compiling no file at Tue Nov  3 13:42:42 2015
    ../../init.el:Warning: `vagrant-tramp-enable' is an obsolete function; use
        `vagrant-tramp-add-method' instead.