### PR TITLE
Don't delete bootstrap packages as orphans

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -129,6 +129,9 @@
 (defvar configuration-layer--skipped-packages nil
   "A list of all packages that were skipped during last update attempt.")
 
+(defvar configuration-layer--protected-packages nil
+  "A list of packages that will be protected from removal as orphans.")
+
 (defvar configuration-layer-error-count nil
   "Non nil indicates the number of errors occurred during the
 installation of initialization.")
@@ -1033,7 +1036,8 @@ to select one."
 
 (defun configuration-layer//is-package-orphan (pkg-name dist-pkgs dependencies)
   "Returns not nil if PKG-NAME is the name of an orphan package."
-  (unless (object-assoc pkg-name :name dist-pkgs)
+  (unless (or (object-assoc pkg-name :name dist-pkgs)
+              (memq pkg-name configuration-layer--protected-packages))
     (if (ht-contains? dependencies pkg-name)
         (let ((parents (ht-get dependencies pkg-name)))
           (reduce (lambda (x y) (and x y))
@@ -1123,24 +1127,16 @@ to select one."
    (t (let ((p (cadr (assq pkg-name package-alist))))
         (when p (package-delete p))))))
 
-(defun configuration-layer//filter-used-themes (orphans)
-  "Filter out used theme packages from ORPHANS candidates.
-Returns the filtered list."
-  (delq nil (mapcar (lambda (x)
-                      (and (not (memq x spacemacs-used-theme-packages))
-                           x)) orphans)))
-
 (defun configuration-layer/delete-orphan-packages (packages)
   "Delete PACKAGES if they are orphan."
   (interactive)
   (let* ((dependencies (configuration-layer//get-packages-dependencies))
          (implicit-packages (configuration-layer//get-implicit-packages
                              configuration-layer--used-distant-packages))
-         (orphans (configuration-layer//filter-used-themes
-                   (configuration-layer//get-orphan-packages
-                    configuration-layer--used-distant-packages
-                    implicit-packages
-                    dependencies)))
+         (orphans (configuration-layer//get-orphan-packages
+                   configuration-layer--used-distant-packages
+                   implicit-packages
+                   dependencies))
          (orphans-count (length orphans)))
     ;; (message "dependencies: %s" dependencies)
     ;; (message "implicit: %s" implicit-packages)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -10,6 +10,12 @@
 ;;
 ;;; License: GPLv3
 
+(defun spacemacs/load-or-install-protected-package (pkg &optional log file-to-load)
+  "Load PKG package, and protect it against being deleted as an orphan.
+See `spacemacs/load-or-install-package' for more information."
+  (push pkg configuration-layer--protected-packages)
+  (spacemacs/load-or-install-package pkg log file-to-load))
+
 (defun spacemacs/load-or-install-package (pkg &optional log file-to-load)
   "Load PKG package. PKG will be installed if it is not already installed.
 Whenever the initial require fails the absolute path to the package

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -92,10 +92,12 @@ initialization."
   ;; default theme
   (let ((default-theme (car dotspacemacs-themes)))
     (spacemacs/load-theme default-theme)
-    ;; used to prevent automatic deletion of used packages
-    (setq spacemacs-used-theme-packages
-          (delq nil (mapcar 'spacemacs//get-theme-package
-                            dotspacemacs-themes)))
+    ;; protect used themes from deletion as orphans
+    (setq configuration-layer--protected-packages
+          (append
+           (delq nil (mapcar 'spacemacs//get-theme-package
+                             dotspacemacs-themes))
+           configuration-layer--protected-packages))
     (setq-default spacemacs--cur-theme default-theme)
     (setq-default spacemacs--cycle-themes (cdr dotspacemacs-themes)))
   ;; removes the GUI elements
@@ -123,30 +125,30 @@ initialization."
   (spacemacs-buffer/insert-banner-and-buttons)
   ;; mandatory dependencies
   ;; dash is required to prevent a package.el bug with f on 24.3.1
-  (spacemacs/load-or-install-package 'dash t)
-  (spacemacs/load-or-install-package 's t)
+  (spacemacs/load-or-install-protected-package 'dash t)
+  (spacemacs/load-or-install-protected-package 's t)
   ;; bind-key is required by use-package
-  (spacemacs/load-or-install-package 'bind-key t)
-  (spacemacs/load-or-install-package 'use-package t)
+  (spacemacs/load-or-install-protected-package 'bind-key t)
+  (spacemacs/load-or-install-protected-package 'use-package t)
   (setq use-package-verbose init-file-debug)
   ;; package-build is required by quelpa
-  (spacemacs/load-or-install-package 'package-build t)
+  (spacemacs/load-or-install-protected-package 'package-build t)
   (setq quelpa-verbose init-file-debug
         quelpa-dir (concat spacemacs-cache-directory "quelpa/")
         quelpa-build-dir (expand-file-name "build" quelpa-dir)
         quelpa-persistent-cache-file (expand-file-name "cache" quelpa-dir)
         quelpa-update-melpa-p nil)
-  (spacemacs/load-or-install-package 'quelpa t)
+  (spacemacs/load-or-install-protected-package 'quelpa t)
   ;; inject use-package hooks for easy customization of
   ;; stock package configuration
   (setq use-package-inject-hooks t)
   ;; which-key
-  (spacemacs/load-or-install-package 'which-key t)
+  (spacemacs/load-or-install-protected-package 'which-key t)
   ;; evil and evil-leader must be installed at the beginning of the
   ;; boot sequence.
   ;; Use C-u as scroll-up (must be set before actually loading evil)
-  (spacemacs/load-or-install-package 'evil t)
-  (spacemacs/load-or-install-package 'evil-leader t)
+  (spacemacs/load-or-install-protected-package 'evil t)
+  (spacemacs/load-or-install-protected-package 'evil-leader t)
   (require 'core-evilified-state)
   ;; check for new version
   (if dotspacemacs-mode-line-unicode-symbols

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -146,9 +146,6 @@
   "alist matching a theme name with its package name, required when
 package name does not match theme name + `-theme' suffix.")
 
-(defvar spacemacs-used-theme-packages nil
-  "List of packages of used themes.")
-
 (defun spacemacs//get-theme-package (theme)
   "Returns the package theme for the given THEME name."
   (cond


### PR DESCRIPTION
We had a go at gitter and finally solved ths. When a package (typically `s`) is installed and deleted on startup each time, it's because it's installed as part of the bootstrap process, but those packages aren't protected from being deleted as orphans. Some of them (`dash`, `package-build` and `s`) are not listed explicitly in any layer, but `dash` and `package-build` are kept alive as dependencies. `s` is not. On develop, spaceline (at least) depends on `s` so this problem is less prevalent there, but people who exclude it or who use spacemacs-base might still see this error.