### PR TITLE
mdfind for helm-locate on osx layer

### DIFF
--- a/layers/osx/packages.el
+++ b/layers/osx/packages.el
@@ -5,6 +5,7 @@
         pbcopy
         launchctl
         reveal-in-osx-finder
+        helm
         ))
 
 (when (spacemacs/system-is-mac)
@@ -71,3 +72,21 @@
   (use-package reveal-in-osx-finder
     :if (spacemacs/system-is-mac)
     :commands reveal-in-osx-finder))
+
+(defun osx/helm-post-init ()
+  ;; Use `mdfind' instead of `locate'.
+  (when (spacemacs/system-is-mac)
+    ;; Disable fuzzy matchting to make mdfind work with helm-locate
+    ;; https://github.com/emacs-helm/helm/issues/799
+    (setq helm-locate-fuzzy-match nil)
+    (setq helm-locate-command "mdfind -name %s %s")))
+
+(defun osx/pre-init-helm ()
+  ;; Use `mdfind' instead of `locate'.
+  (when (spacemacs/system-is-mac)
+    (spacemacs|use-package-add-hook helm
+      :post-config
+      ;; Disable fuzzy matchting to make mdfind work with helm-locate
+      ;; https://github.com/emacs-helm/helm/issues/799
+      (setq helm-locate-fuzzy-match nil)
+      (setq helm-locate-command "mdfind -name %s %s"))))

--- a/layers/osx/packages.el
+++ b/layers/osx/packages.el
@@ -73,14 +73,6 @@
     :if (spacemacs/system-is-mac)
     :commands reveal-in-osx-finder))
 
-(defun osx/helm-post-init ()
-  ;; Use `mdfind' instead of `locate'.
-  (when (spacemacs/system-is-mac)
-    ;; Disable fuzzy matchting to make mdfind work with helm-locate
-    ;; https://github.com/emacs-helm/helm/issues/799
-    (setq helm-locate-fuzzy-match nil)
-    (setq helm-locate-command "mdfind -name %s %s")))
-
 (defun osx/pre-init-helm ()
   ;; Use `mdfind' instead of `locate'.
   (when (spacemacs/system-is-mac)


### PR DESCRIPTION
Make `mdfind` the default backend for `helm-locate` on `osx` layer.

Discussion on [this issue](https://github.com/syl20bnr/spacemacs/issues/3280).