### PR TITLE
Enable custom info+ modeline

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1825,6 +1825,8 @@ It will toggle the overlay under point or create an overlay of one character."
 
       (spaceline-spacemacs-theme '(new-version :when active))
       (spaceline-helm-mode t)
+      (when (configuration-layer/package-usedp 'info+)
+        (spaceline-info-mode t))
 
       (defun spacemacs//restore-powerline (buffer)
         "Restore the powerline in buffer"


### PR DESCRIPTION
Leaving no modeline unturned.

Before:

![before](http://i.imgur.com/tyiM98L.png)

After:

![after](http://i.imgur.com/cPNlAS8.png)