### PR TITLE
evil-snipe: Use separate hooks for override mode

### DIFF
--- a/layers/+vim/evil-snipe/packages.el
+++ b/layers/+vim/evil-snipe/packages.el
@@ -12,11 +12,14 @@
           evil-snipe-smart-case t)
     :config
     (progn
-      (evil-snipe-mode 1)
-      (if (configuration-layer/layer-usedp 'git)
+      (if evil-snipe-enable-alternate-f-and-t-behaviors
           (progn
-            (add-hook 'magit-mode-hook 'turn-off-evil-snipe-override-mode)
-            (add-hook 'git-rebase-mode-hook 'turn-off-evil-snipe-override-mode)))
-      (when evil-snipe-enable-alternate-f-and-t-behaviors
-        (setq evil-snipe-repeat-scope 'whole-buffer)
-        (evil-snipe-override-mode 1)))))
+            (setq evil-snipe-repeat-scope 'whole-buffer)
+            (evil-snipe-override-mode 1)
+            (when (configuration-layer/layer-usedp 'git)
+              (add-hook 'magit-mode-hook 'turn-off-evil-snipe-override-mode)
+              (add-hook 'git-rebase-mode-hook 'turn-off-evil-snipe-override-mode)))
+        (evil-snipe-mode 1)
+        (when (configuration-layer/layer-usedp 'git)
+          (add-hook 'magit-mode-hook 'turn-off-evil-snipe-mode)
+          (add-hook 'git-rebase-mode-hook 'turn-off-evil-snipe-mode))))))


### PR DESCRIPTION
This just adjusts 4e302bc0c039b7f25e0768abd78d52c5e5cdd653 to use the appropriate turn-off functions for evil snipe