### PR TITLE
Add functionality for squashing whitespace

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -114,6 +114,16 @@ the current state and point position."
       (newline-and-indent)
       (setq counter (1- counter)))))
 
+(defun spacemacs/kill-whitespace ()
+  "Remove all whitespace (including newlines) surrounding `point'."
+  (interactive "*")
+  (save-excursion
+    (save-restriction
+      (save-match-data
+        (re-search-backward "[^ \t\r\n]" nil t)
+        (re-search-forward "[ \t\r\n]+" nil t)
+        (replace-match "" nil nil)))))
+
 ;; from Prelude
 ;; TODO: dispatch these in the layers
 (defvar spacemacs-indent-sensitive-modes

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -153,7 +153,9 @@ Ensure that helm is required before calling FUNC."
   "jo" 'open-line
   "j=" 'spacemacs/indent-region-or-buffer
   "jJ" 'spacemacs/split-and-new-line
-  "jk" 'spacemacs/evil-goto-next-line-and-indent)
+  "jk" 'spacemacs/evil-goto-next-line-and-indent
+  "j SPC" 'just-one-space
+  "j |" 'spacemacs/kill-whitespace)
 
 ;; navigation -----------------------------------------------------------------
 (evil-leader/set-key


### PR DESCRIPTION
Emacs provides a standard command for _squashing_ multiple spaces into one, however, spacemacs does not bind this command. This pull-request introduces a binding -- `<kbd>LEADER</kbd> <kbd>j</kbd> <kbd>SPACE</kbd>' -- that is grouped logically among the **join/split** commands.

Furthermore a command to kill all whitespace is introduced (`spacemacs/kill-whitespace`) and bound to `<kbd>LEADER</kbd> <kbd>j</kbd> <kbd>|</kbd>'
