### PR TITLE
Org enhancements

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -99,7 +99,13 @@ You can tweak the bullets displayed in the org buffer in the function
 
 | Key Binding                                  | Description                                  |
 |----------------------------------------------+----------------------------------------------|
+| ~SPC m <dotspacemacs-major-mode-leader-key>~ | org-ctrl-c-ctrl-c                            |
+| ~SPC m *~                                    | org-ctrl-c-star                              |
+| ~SPC m RET~                                  | org-ctrl-c-ret                               |
+| ~SPC m -~                                    | org-ctrl-c-minus                             |
 | ~SPC m '~                                    | org-edit-special                             |
+| ~SPC m ^~                                    | org-sort                                     |
+| ~SPC m /~                                    | org-sparse-tree                              |
 | ~SPC m .~                                    | org-time-stamp                               |
 | ~SPC m a~                                    | org-agenda                                   |
 | ~SPC m b~                                    | org-tree-to-indirect-buffer                  |
@@ -113,7 +119,6 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC m l~                                    | org-open-at-point                            |
 | ~SPC m n~                                    | org-narrow-to-subtree                        |
 | ~SPC m N~                                    | widen                                        |
-| ~SPC m <dotspacemacs-major-mode-leader-key>~ | org-ctrl-c-ctrl-c                            |
 | ~SPC m O~                                    | org-clock-out                                |
 | ~SPC m q~                                    | org-clock-cancel                             |
 | ~SPC m R~                                    | org-refile                                   |

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -16,6 +16,7 @@
     company-emoji
     emoji-cheat-sheet-plus
     (evil-org :location local)
+    evil-surround
     gnuplot
     htmlize
     ;; org is installed by `org-plus-contrib'
@@ -52,6 +53,14 @@
       (evil-define-key 'normal evil-org-mode-map
         "O" 'evil-open-above)
       (spacemacs|diminish evil-org-mode " ⓔ" " e"))))
+
+(defun org/post-init-evil-surround ()
+  (defun spacemacs/add-org-surrounds ()
+    (push '(?: . spacemacs//surround-drawer) evil-surround-pairs-alist))
+  (add-hook 'org-mode-hook 'spacemacs/add-org-surrounds)
+  (defun spacemacs//surround-drawer ()
+    (let ((dname (read-from-minibuffer "" "")))
+      (cons (format ":%s:" (or dname "")) ":END:"))))
 
 (defun org/init-gnuplot ()
   (use-package gnuplot

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -165,32 +165,39 @@ Will work on both org-mode and any mode that accepts plain html."
         "mtto" 'org-table-toggle-coordinate-overlays
         "mtw" 'org-table-wrap-region
 
-        "mI" 'org-clock-in
+        ;; Multi-purpose keys
         (if dotspacemacs-major-mode-leader-key
             (concat "m" dotspacemacs-major-mode-leader-key)
           "m,") 'org-ctrl-c-ctrl-c
-          "mn" 'org-narrow-to-subtree
-          "mN" 'widen
-          "mO" 'org-clock-out
-          "mq" 'org-clock-cancel
-          "mR" 'org-refile
-          "ms" 'org-schedule
+        "m*" 'org-ctrl-c-star
+        "m RET" 'org-ctrl-c-ret
+        "m-" 'org-ctrl-c-minus
+        "m^" 'org-sort
+        "m/" 'org-sparse-tree
 
-          ;; insertion of common elements
-          "mil" 'org-insert-link
-          "mif" 'org-footnote-new
-          "mik" 'spacemacs/insert-keybinding-org
+        "mI" 'org-clock-in
+        "mn" 'org-narrow-to-subtree
+        "mN" 'widen
+        "mO" 'org-clock-out
+        "mq" 'org-clock-cancel
+        "mR" 'org-refile
+        "ms" 'org-schedule
 
-          ;; images and other link types have no commands in org mode-line
-          ;; could be inserted using yasnippet?
-          ;; region manipulation
-          "mxb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
-          "mxc" (spacemacs|org-emphasize spacemacs/org-code ?~)
-          "mxi" (spacemacs|org-emphasize spacemacs/org-italic ?/)
-          "mxr" (spacemacs|org-emphasize spacemacs/org-clear ? )
-          "mxs" (spacemacs|org-emphasize spacemacs/org-strike-through ?+)
-          "mxu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
-          "mxv" (spacemacs|org-emphasize spacemacs/org-verbose ?=))
+        ;; insertion of common elements
+        "mil" 'org-insert-link
+        "mif" 'org-footnote-new
+        "mik" 'spacemacs/insert-keybinding-org
+
+        ;; images and other link types have no commands in org mode-line
+        ;; could be inserted using yasnippet?
+        ;; region manipulation
+        "mxb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
+        "mxc" (spacemacs|org-emphasize spacemacs/org-code ?~)
+        "mxi" (spacemacs|org-emphasize spacemacs/org-italic ?/)
+        "mxr" (spacemacs|org-emphasize spacemacs/org-clear ? )
+        "mxs" (spacemacs|org-emphasize spacemacs/org-strike-through ?+)
+        "mxu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
+        "mxv" (spacemacs|org-emphasize spacemacs/org-verbose ?=))
 
       (with-eval-after-load 'org-agenda
         (define-key org-agenda-mode-map "j" 'org-agenda-next-line)


### PR DESCRIPTION
This PR adds a few keybindings for those Org `C-c` bindings that do many different things. I mapped `C-c <x>` to `SPC m <x>` in each case.

Also added evil-surround support for drawers. I'm not sure how to make `ds:` work, but at least creating them works.