### PR TITLE
bind avy-goto-line to `SPC y` 

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -96,7 +96,7 @@
    - [[Navigating][Navigating]]
      - [[Point/Cursor][Point/Cursor]]
        - [[Smooth scrolling][Smooth scrolling]]
-     - [[Vim motions with ace-jump mode][Vim motions with ace-jump mode]]
+     - [[Vim motions with avy][Vim motions with avy]]
        - [[ace-link mode][ace-link mode]]
      - [[Window manipulation][Window manipulation]]
        - [[Window manipulation key bindings][Window manipulation key bindings]]
@@ -1432,23 +1432,23 @@ On Windows, you may want to disable it. To disable the smooth scrolling set the
 (setq-default dotspacemacs-smooth-scrolling t)
 #+END_SRC
 
-*** Vim motions with ace-jump mode
-Spacemacs uses the =evil= integration of [[https://github.com/winterTTr/ace-jump-mode][ace-jump mode]] which enables the
-invocation of =ace-jump-mode= during motions.
+*** Vim motions with avy
+Spacemacs uses the =evil= integration of [[https://github.com/abo-abo/avy][avy]] which enables the
+invocation of =avy= during motions.
 
 It is useful for deleting visually a set of lines, try the following sequence in
-a buffer containing some text: ~d SPC L~
+a buffer containing some text: ~d SPC y~
 
 | Key Binding | Description                                        |
 |-------------+----------------------------------------------------|
-| ~SPC SPC~   | initiate ace jump word mode                        |
-| ~SPC L~     | initiate ace jump line mode                        |
+| ~SPC SPC~   | initiate avy jump word                             |
+| ~SPC y~     | initiate avy jump line                             |
 | ~SPC `~     | go back to the previous location (before the jump) |
 
 *Hint*: you may change to char mode by ~C-c C-c~ in word mode.
 
 **** ace-link mode
-Similar to =ace-jump-mode=, [[https://github.com/abo-abo/ace-link][ace-link]] allows one to jump to any link in
+Similar to =avy=, [[https://github.com/abo-abo/ace-link][ace-link]] allows one to jump to any link in
 =help-mode= and =info-mode= with two key strokes.
 
 | Key Binding | Description                                           |
@@ -2389,7 +2389,7 @@ Comments are handled by [[https://github.com/redguardtoo/evil-nerd-commenter][ev
     | ~SPC c y~   | comment and yank          |
     | ~SPC c Y~   | invert comment and yank   |
 
-*Tips:* To comment efficiently a block of line use the combo ~SPC ; SPC L~
+*Tips:* To comment efficiently a block of line use the combo ~SPC ; SPC y~
 
 *** Deleting files
 Deletion is configured to send deleted files to system trash.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1437,12 +1437,12 @@ Spacemacs uses the =evil= integration of [[https://github.com/winterTTr/ace-jump
 invocation of =ace-jump-mode= during motions.
 
 It is useful for deleting visually a set of lines, try the following sequence in
-a buffer containing some text: ~d SPC l~
+a buffer containing some text: ~d SPC L~
 
 | Key Binding | Description                                        |
 |-------------+----------------------------------------------------|
 | ~SPC SPC~   | initiate ace jump word mode                        |
-| ~SPC l~     | initiate ace jump line mode                        |
+| ~SPC L~     | initiate ace jump line mode                        |
 | ~SPC `~     | go back to the previous location (before the jump) |
 
 *Hint*: you may change to char mode by ~C-c C-c~ in word mode.
@@ -2389,7 +2389,7 @@ Comments are handled by [[https://github.com/redguardtoo/evil-nerd-commenter][ev
     | ~SPC c y~   | comment and yank          |
     | ~SPC c Y~   | invert comment and yank   |
 
-*Tips:* To comment efficiently a block of line use the combo ~SPC ; SPC l~
+*Tips:* To comment efficiently a block of line use the combo ~SPC ; SPC L~
 
 *** Deleting files
 Deletion is configured to send deleted files to system trash.

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -72,14 +72,14 @@ check out the =packages.el= file in the respective folders in the
 
 ** How can I change or define an alias for an =evil-leader= prefix?
 It is possible to change an =evil-leader= prefix by binding its keymap to
-another sequence. For instance, if you want to switch ~SPC l~
-(=evil-avy-goto-line=) with ~SPC L~ (=perspectives= layer) to make the later
+another sequence. For instance, if you want to switch ~SPC L~
+(=evil-avy-goto-line=) with ~SPC l~ (=perspectives= layer) to make the later
 easier to reach, you can use:
 
 #+begin_src emacs-lisp
 (evil-leader/set-key
-  "l" (lookup-key evil-leader--default-map "L")
-  "L" 'evil-avy-goto-line)
+  "L" (lookup-key evil-leader--default-map "l")
+  "l" 'evil-avy-goto-line)
 #+end_src
 
 ** Should I place my settings in =user-init= or =user-config=?

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -72,13 +72,13 @@ check out the =packages.el= file in the respective folders in the
 
 ** How can I change or define an alias for an =evil-leader= prefix?
 It is possible to change an =evil-leader= prefix by binding its keymap to
-another sequence. For instance, if you want to switch ~SPC L~
+another sequence. For instance, if you want to switch ~SPC y~
 (=evil-avy-goto-line=) with ~SPC l~ (=perspectives= layer) to make the later
 easier to reach, you can use:
 
 #+begin_src emacs-lisp
 (evil-leader/set-key
-  "L" (lookup-key evil-leader--default-map "l")
+  "y" (lookup-key evil-leader--default-map "l")
   "l" 'evil-avy-goto-line)
 #+end_src
 

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -399,7 +399,7 @@
       (setq avy-background t)
       (evil-leader/set-key
         "SPC" 'avy-goto-word-or-subword-1
-        "L" 'avy-goto-line
+        "y" 'avy-goto-line
         "xo" 'spacemacs/avy-open-url))
     :config
     (progn

--- a/layers/+irc/rcirc/README.org
+++ b/layers/+irc/rcirc/README.org
@@ -175,7 +175,7 @@ For now authinfo is mandatory to use the ZNC configuration.
 | Key Binding | Description                                                                   |
 |-------------+-------------------------------------------------------------------------------|
 | ~SPC a i r~ | Open rcirc                                                                    |
-| ~SPC L o i~ | Open rcirc in a custom perspective "@RICRC" (need perspectives layer enabled) |
+| ~SPC l o i~ | Open rcirc in a custom perspective "@RICRC" (need perspectives layer enabled) |
 
 In normal state:
 

--- a/layers/+vim/evil-commentary/README.org
+++ b/layers/+vim/evil-commentary/README.org
@@ -29,5 +29,5 @@ To use this contribution add it to your =~/.spacemacs=.
 | ~SPC ;~     | comment operator              |
 | ~gcc~       | comment current line          |
 | ~gcap~      | comment paragraphs            |
-| ~gc SPC l~  | comment up to a line with avy |
+| ~gc SPC L~  | comment up to a line with avy |
 | ~gy~        | comment and yank              |

--- a/layers/+vim/evil-commentary/README.org
+++ b/layers/+vim/evil-commentary/README.org
@@ -29,5 +29,5 @@ To use this contribution add it to your =~/.spacemacs=.
 | ~SPC ;~     | comment operator              |
 | ~gcc~       | comment current line          |
 | ~gcap~      | comment paragraphs            |
-| ~gc SPC L~  | comment up to a line with avy |
+| ~gc SPC y~  | comment up to a line with avy |
 | ~gy~        | comment and yank              |

--- a/layers/+window-management/perspectives/README.org
+++ b/layers/+window-management/perspectives/README.org
@@ -40,7 +40,7 @@ To use this contribution add it to your =~/.spacemacs=
 ** Micro-states
 *** Perspective Management Micro State
 
-Prefix command for perspective management commands is ~SPC L~ (for Layout).
+Prefix command for perspective management commands is ~SPC l~ (for Layout).
 
 | Key Binding            | Description                                     |
 |------------------------+-------------------------------------------------|

--- a/layers/+window-management/perspectives/README.org
+++ b/layers/+window-management/perspectives/README.org
@@ -20,11 +20,11 @@
 
 * Description
 This contribution layer adds Perspectives to Spacemacs. Perspectives are window
-configurations that have buffer isolation between each other (under the keybinding ~SPC L b~).
+configurations that have buffer isolation between each other (under the keybinding ~SPC l b~).
 At the beginning there is a ~@Home~ perspective which will contain all buffers by default.
 Basically, staying in this perspective will feel as if you didn't have the perspectives layer enabled.
-After creating the first perspective via the method you choose (~SPC L s~ or ~SPC L o custom-poersp~
-or ~SPC L P~ for projectile perspectives). If you kill the ~@Home~ perspective ~SPC L k~,
+After creating the first perspective via the method you choose (~SPC l s~ or ~SPC l o custom-poersp~
+or ~SPC l P~ for projectile perspectives). If you kill the ~@Home~ perspective ~SPC l k~,
 you will also kill every buffer.
 
 * Install
@@ -44,28 +44,28 @@ Prefix command for perspective management commands is ~SPC L~ (for Layout).
 
 | Key Binding            | Description                                     |
 |------------------------+-------------------------------------------------|
-| ~SPC L ?~              | Toggle Documentation of micro-state             |
-| ~SPC L b~              | List buffers in current perspective             |
-| ~SPC L f~              | List buffers in current perspective             |
-| ~SPC L K~              | Remove buffer from perspective                  |
-| ~SPC L i~              | import all buffers from other perspective       |
-| ~SPC L t~              | display buffer without adding it to perspective |
-| ~SPC L a~              | add buffer to current perspective               |
-| ~SPC L x~              | kill current perspective with its buffers       |
-| ~SPC L X~              | kill other perspective with its buffers         |
-| ~SPC L c~              | close current perspective and keep buffers      |
-| ~SPC L c~              | close current perspective and keep buffers      |
-| ~SPC L C~              | close other perspective and keep buffers        |
-| ~SPC L i~              | Import buffers from other perspective           |
-| ~SPC L o~              | open a custom perspective                       |
-| ~SPC L n~              | switch to next perspective                      |
-| ~SPC L N~ or ~SPC W p~ | switch to previous perspective                  |
-| ~SPC L <tab>~          | switch to latest perspective                    |
-| ~SPC L [1..n..9]~      | switch to nth perspective                       |
-| ~SPC L r~              | rename perspective                              |
-| ~SPC L w~              | Save perspectives to file                       |
-| ~SPC L l~              | Load perspectives from file                     |
-| ~SPC L s~              | switch perspective                              |
+| ~SPC l ?~              | Toggle Documentation of micro-state             |
+| ~SPC l b~              | List buffers in current perspective             |
+| ~SPC l f~              | List buffers in current perspective             |
+| ~SPC l K~              | Remove buffer from perspective                  |
+| ~SPC l i~              | import all buffers from other perspective       |
+| ~SPC l t~              | display buffer without adding it to perspective |
+| ~SPC l a~              | add buffer to current perspective               |
+| ~SPC l x~              | kill current perspective with its buffers       |
+| ~SPC l X~              | kill other perspective with its buffers         |
+| ~SPC l c~              | close current perspective and keep buffers      |
+| ~SPC l c~              | close current perspective and keep buffers      |
+| ~SPC l C~              | close other perspective and keep buffers        |
+| ~SPC l i~              | Import buffers from other perspective           |
+| ~SPC l o~              | open a custom perspective                       |
+| ~SPC l n~              | switch to next perspective                      |
+| ~SPC l N~ or ~SPC W p~ | switch to previous perspective                  |
+| ~SPC l <tab>~          | switch to latest perspective                    |
+| ~SPC l [1..n..9]~      | switch to nth perspective                       |
+| ~SPC l r~              | rename perspective                              |
+| ~SPC l w~              | Save perspectives to file                       |
+| ~SPC l l~              | Load perspectives from file                     |
+| ~SPC l s~              | switch perspective                              |
 
 *** Custom Perspectives Micro State
 
@@ -73,10 +73,10 @@ The default bindings are the following:
 
 | Key Binding | Description                                              |
 |-------------+----------------------------------------------------------|
-| ~SPC L o e~ | Emacs custom perspective                                 |
-| ~SPC L o E~ | ERC custom perspective (needs the erc layer enabled)     |
-| ~SPC L o i~ | RCIRC custom perspective (needs the rcirc layer enabled) |
-| ~SPC L o o~ | Org custom perspective                                   |
+| ~SPC l o e~ | Emacs custom perspective                                 |
+| ~SPC l o E~ | ERC custom perspective (needs the erc layer enabled)     |
+| ~SPC l o i~ | RCIRC custom perspective (needs the rcirc layer enabled) |
+| ~SPC l o o~ | Org custom perspective                                   |
 
 You can of course add more custom perspectives by using the
 ~spacemacs|define-custom-perspective~ macro explained further below.
@@ -85,11 +85,11 @@ You can of course add more custom perspectives by using the
 
 Projectile will work normally in any perspectives by adding buffers to the current
 perspective, but if you want to create a perspective specific to some project you
-can use the ~SPC L P~. 
+can use the ~SPC l P~.
 
 ** Save/Load perspectives into a file
 
-With ~SPC L w~ and ~SPC L l~ you can save and load perspectives to a file this
+With ~SPC l w~ and ~SPC l l~ you can save and load perspectives to a file this
 is done without configuration, support is great for emacs 24.4, but depends on
 =workgroups.el= for Emacs <= 24.3.
 
@@ -122,7 +122,7 @@ to define a perspective with a layout.
     (... do more stuff but be careful not to destroy the universe ...))
 #+END_SRC
 
-Then you can access this persp with =SPC L o +=, where =+= is the binding.
+Then you can access this persp with =SPC l o +=, where =+= is the binding.
 
 
 ** Predefined custom perspectives


### PR DESCRIPTION
This PR depends on #3673 in order to avoid a merge conflict.

After the change in 1d340dc, there was some grumbling in gitter that `SPC L` is not as convenient as `SPC l`. Apparently avy-goto-line is a popular function.

`SPC y` is chosen because it is:

- currently unused (as far as I can tell).
- sort of mnemonic because "avy" has a "y" in it.
- doesn't require SHIFT to type
- is accessible even on non-US keyboards
  (there were suggestions such ";" and "\" that are not as accessible
   on non-US keyboards)

This change also updates the documentation regarding the change from
ace-jump-mode to avy.