### PR TITLE
remove empty line after heading in readme template

### DIFF
--- a/core/templates/layer-README.template
+++ b/core/templates/layer-README.template
@@ -22,7 +22,6 @@ To use this contribution add it to your =~/.spacemacs=
 #+end_src
 
 * Key bindings
-
 | Key Binding     | Description    |
 |-----------------+----------------|
 | ~<SPC> x x x~   | Does thing01   |


### PR DESCRIPTION
As far as I understand, we don't want empty line here. 