### PR TITLE
[python] Add py-isort package

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -20,6 +20,7 @@
    - [[Other Python commands][Other Python commands]]
  - [[Configuration][Configuration]]
    - [[Fill column][Fill column]]
+   - [[Sort imports][Sort imports]]
 
 * Description
 This layer adds support for the Python language.
@@ -174,8 +175,23 @@ Test commands start with ~m t~:
 | ~SPC m V~   | activate a virtual environment with  [[https://github.com/jorgenschaefer/pyvenv][pyvenv]]                                  |
 * Configuration
 ** Fill column
-If you want to customize the fill column value, use something like this inside the ~user-init~ function in your ~.spacemacs~:
+If you want to customize the fill column value, set the ~python-fill-column~ variable in the python layer config section:
 
 #+BEGIN_SRC elisp
-(setq python-fill-column 99)
+(setq-default dotspacemacs-configuration-layers '(
+    (python :variables python-fill-column 99)))
 #+END_SRC
+
+** Sort imports
+If you want imports to be automatically sorted when you save a file, set the ~python-sort-imports~ variable in the python layer config section:
+
+#+BEGIN_SRC elisp
+(setq-default dotspacemacs-configuration-layers '(
+    (python :variables python-enable-sort-imports-on-save t)))
+#+END_SRC
+
+You will also need to install the ~isort~ python package:
+
+#+BEGIN_EXAMPLE
+pip install isort
+#+END_EXAMPLE

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -24,3 +24,6 @@
 
 (defvar python-fill-column 79
   "Fill column value for python buffers")
+
+(defvar python-enable-sort-imports-on-save nil
+  "If non-nil, automatically sort imports on save.")

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -25,6 +25,7 @@
     hy-mode
     pip-requirements
     pyenv-mode
+    py-isort
     pytest
     python
     pyvenv
@@ -330,3 +331,9 @@ fix this issue."
   (spacemacs|use-package-add-hook xcscope
     :post-init
     (spacemacs/setup-helm-cscope 'python-mode)))
+
+(defun python/init-py-isort ()
+  (use-package py-isort
+    :if python-enable-sort-imports-on-save
+    :defer t
+    :init (add-hook 'before-save-hook 'py-isort-before-save)))


### PR DESCRIPTION
py-isort sorts the imports to keep it tidy.

Disabled by default.