### PR TITLE
elm: fix incorrect binding for elm-repl-load

### DIFF
--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -79,7 +79,7 @@
         "mht" 'elm-oracle-type-at-point
 
         ;; repl
-        "msi" 'load-elm-repl
+        "msi" 'elm-repl-load
         "msf" 'push-decl-elm-repl
         "msF" 'spacemacs/push-decl-elm-repl-focus
         "msr" 'push-elm-repl


### PR DESCRIPTION
The function that loads a new Elm REPL is `elm-repl-load`, but it was incorrectly referenced in the elm layer as `load-elm-repl`.

Cf: `elm-repo-load` in [elm-mode](https://github.com/jcollard/elm-mode/blob/master/elm-interactive.el#L240).