### PR TITLE
Prepend number to perspectives microstate

### DIFF
--- a/layers/+window-management/perspectives/packages.el
+++ b/layers/+window-management/perspectives/packages.el
@@ -85,10 +85,11 @@ Cancels autosave on exiting perspectives mode."
 
     (defun persp-format-name (name)
       "Format the perspective name given by NAME for display in `persp-modestring'."
-      (let ((string-name (format "%s" name)))
+      (let* ((string-name (format "%s" name))
+             (persp-name-with-pos (format "<%s:%s>" (1+ (cl-position name (persp-names-current-frame-fast-ordered) :test 'equal)) string-name)))
         (if (equal name (spacemacs/persp-curr-name))
-            (propertize string-name 'face 'persp-selected-face)
-          string-name)))
+            (propertize persp-name-with-pos 'face 'persp-selected-face)
+          persp-name-with-pos)))
 
     (defun spacemacs/persp-switch-by-pos (pos)
       "Switch to perspective of position (1-index)."


### PR DESCRIPTION
Feature I was missing from eyebrowse to jump to a persp using `SPC l <number>` even though the switching part was there but no visual indication. With this patch, it would look like following. 

<img width="350" alt="screen shot 2015-11-08 at 4 33 19 pm" src="https://cloud.githubusercontent.com/assets/542810/11019995/ce010424-8636-11e5-8f92-c24dadb8ae4b.png">