### PR TITLE
CSS-ify documentation publishing

### DIFF
--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -54,7 +54,8 @@
   (interactive)
   (with-temp-buffer
     (org-mode)
-    (insert "#+TITLE: Configuration layers\n\n")
+    (insert "#+TITLE: Configuration layers\n")
+    (insert "#+HTML_HEAD_EXTRA: <link rel=\"stylesheet\" type=\"text/css\" href=\"../css/readtheorg.css\" />\n\n")
     (insert "* Table of Contents\n")
     (org-set-tags-to '("TOC_4_org" "noexport"))
     (insert "* General layers\n")
@@ -66,9 +67,7 @@
   (interactive)
   (let* ((header
           "<link rel=\"stylesheet\" type=\"text/css\"
-                href=\"http://www.pirilampo.org/styles/readtheorg/css/htmlize.css\"/>
-          <link rel=\"stylesheet\" type=\"text/css\"
-                href=\"http://www.pirilampo.org/styles/readtheorg/css/readtheorg.css\"/>
+                 href=\"http://www.pirilampo.org/styles/readtheorg/css/htmlize.css\"/>
           <script src=\"https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js\"></script>
           <script src=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js\"></script>
           <script type=\"text/javascript\"
@@ -76,6 +75,7 @@
           <script type=\"text/javascript\"
                   src=\"http://www.pirilampo.org/styles/readtheorg/js/readtheorg.js\"></script>")
          (publish-target (concat user-emacs-directory "export/"))
+         (org-html-htmlize-output-type 'css)
          (org-publish-project-alist
           `(("spacemacs"
              :components ("spacemacs-doc"

--- a/doc/CONTRIBUTE.org
+++ b/doc/CONTRIBUTE.org
@@ -1,4 +1,5 @@
 #+TITLE: Contribute to Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Contribute to Spacemacs                                   :TOC_4_org:noexport:
  - [[Pull Request Guidelines][Pull Request Guidelines]]

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -1,4 +1,5 @@
 #+TITLE: Spacemacs Conventions
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Spacemacs conventions                                     :TOC_4_org:noexport:
  - [[Code guidelines][Code guidelines]]

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1,4 +1,5 @@
 #+TITLE: Spacemacs documentation
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Spacemacs documentation                                   :TOC_4_org:noexport:
  - [[Core Pillars][Core Pillars]]

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -1,4 +1,5 @@
 #+TITLE: Frequently Asked Questions
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * FAQ                                                       :TOC_4_org:noexport:
  - [[Common][Common]]

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -1,4 +1,5 @@
 #+TITLE: Configuration layers
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Configuration Layers                                      :TOC_4_org:noexport:
  - [[Introduction][Introduction]]

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -1,4 +1,5 @@
 #+TITLE: Quick start
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Configuration                                             :TOC_4_org:noexport:
  - [[Configuration layers][Configuration layers]]

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -1,4 +1,5 @@
 #+TITLE: Migrating from Vim
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Migrating from vim                                        :TOC_4_org:noexport:
  - [[Purpose of this document][Purpose of this document]]

--- a/doc/theme-readtheorg.setup
+++ b/doc/theme-readtheorg.setup
@@ -1,9 +1,0 @@
-# -*- mode: org; -*-
-
-#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="http://www.pirilampo.org/styles/readtheorg/css/htmlize.css"/>
-#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="http://www.pirilampo.org/styles/readtheorg/css/readtheorg.css"/>
-
-#+HTML_HEAD: <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-#+HTML_HEAD: <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-#+HTML_HEAD: <script type="text/javascript" src="http://www.pirilampo.org/styles/lib/js/jquery.stickytableheaders.js"></script>
-#+HTML_HEAD: <script type="text/javascript" src="http://www.pirilampo.org/styles/readtheorg/js/readtheorg.js"></script>

--- a/layers/+config-files/ansible/README.org
+++ b/layers/+config-files/ansible/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Ansible contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ansible.png]]
 

--- a/layers/+config-files/dockerfile/README.org
+++ b/layers/+config-files/dockerfile/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Dockerfile contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/docker.png]]
 

--- a/layers/+config-files/puppet/README.org
+++ b/layers/+config-files/puppet/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Puppet contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/puppet.png]]
 

--- a/layers/+config-files/salt/README.org
+++ b/layers/+config-files/salt/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Saltstack contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/saltstack.png]]
 

--- a/layers/+config-files/terraform/README.org
+++ b/layers/+config-files/terraform/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Terraform contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/terraform.png]]
 

--- a/layers/+email/gnus/README.org
+++ b/layers/+email/gnus/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Gnus contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/gnus.gif]]
 

--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -1,4 +1,5 @@
 #+TITLE: mu4e layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Installation][Installation]]

--- a/layers/+frameworks/django/README.org
+++ b/layers/+frameworks/django/README.org
@@ -1,4 +1,6 @@
 #+TITLE: Python contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
+
 [[file:img/django.png]]
 
 * Table of Contents                                         :TOC_4_org:noexport:

--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -1,4 +1,5 @@
 #+TITLE: React contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/react.png]]
 

--- a/layers/+frameworks/ruby-on-rails/README.org
+++ b/layers/+frameworks/ruby-on-rails/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Ruby on Rails contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ror.png]]
 

--- a/layers/+fun/emoji/README.org
+++ b/layers/+fun/emoji/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Emoji contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 #+HTML: :blue_heart::green_heart::heart::gift_heart::heartbeat::heartpulse::purple_heart::sparkling_heart::yellow_heart:
 

--- a/layers/+fun/games/README.org
+++ b/layers/+fun/games/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Games contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/games.png]]
 

--- a/layers/+fun/xkcd/README.org
+++ b/layers/+fun/xkcd/README.org
@@ -1,4 +1,5 @@
 #+TITLE: xkcd contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/xkcd.png]]
 

--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -1,4 +1,5 @@
 #+TITLE: ERC contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+irc/rcirc/README.org
+++ b/layers/+irc/rcirc/README.org
@@ -1,4 +1,5 @@
 #+TITLE: RCIRC contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/irc.png]]
 

--- a/layers/+keyboard-layouts/bepo/README.org
+++ b/layers/+keyboard-layouts/bepo/README.org
@@ -1,4 +1,5 @@
 #+TITLE: bepo contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 #+CAPTION: logo
 

--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Agda contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/asciidoc/README.org
+++ b/layers/+lang/asciidoc/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Asciidoc contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/autohotkey/README.org
+++ b/layers/+lang/autohotkey/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Autohotkey contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ahk.png]]
 

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -1,4 +1,5 @@
 #+TITLE: C/C++ contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ccpp.jpg]]
 [[file:img/cmake.png]]

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Clojure contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/clojure.png]] [[file:img/cider.png]]
 

--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Common Lisp contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/slime.png]]
 

--- a/layers/+lang/csharp/README.org
+++ b/layers/+lang/csharp/README.org
@@ -1,4 +1,5 @@
 #+TITLE: C# contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/csharp.png]] [[file:img/dotnet.png]]
 

--- a/layers/+lang/d/README.org
+++ b/layers/+lang/d/README.org
@@ -1,4 +1,5 @@
 #+TITLE: D language contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/dlogo.png]]
 

--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Elixir contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/elixir.png]] with [[file:img/alchemist.png]]
 

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Elm contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/elm.png]]
 

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Emacs Lisp contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/emacs-lisp.png]]
 

--- a/layers/+lang/erlang/README.org
+++ b/layers/+lang/erlang/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Erlang contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/erlang.png]]
 

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -1,4 +1,5 @@
 #+TITLE: R (ESS) contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/r.jpg]]
 

--- a/layers/+lang/extra-langs/README.org
+++ b/layers/+lang/extra-langs/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Extra Languages
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 Adds many more language modes for less common languages, some more niche than others.
 

--- a/layers/+lang/fsharp/README.org
+++ b/layers/+lang/fsharp/README.org
@@ -1,4 +1,5 @@
 #+TITLE: F# contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/fsharp.png]]
 

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -1,4 +1,5 @@
 #+TITLE: GO contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/go.png]]
 

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Haskell contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/haskell.png]]
 
@@ -24,6 +25,7 @@
    - [[Cabal commands][Cabal commands]]
    - [[Cabal files][Cabal files]]
    - [[Ghc-mod][Ghc-mod]]
+     - [[insert template][insert template]]
  - [[FAQ][FAQ]]
    - [[REPL doesn't work][REPL doesn't work]]
    - [[REPL is stuck][REPL is stuck]]
@@ -319,17 +321,17 @@ http://www.mew.org/~kazu/proj/ghc-mod/en/emacs.html
 
 ghc-mod commands are prefixed by ~SPC m m~:
 
-| Key Binding | Description                                 |
-|-------------+---------------------------------------------|
-| ~SPC m m t~ | insert template                             |
-| ~SPC m m u~ | insert template with holes                  |
-| ~SPC m m a~ | select one of possible cases (~ghc-auto~)   |
-| ~SPC m m f~ | replace a hole (~ghc-refine~)               |
-| ~SPC m m e~ | expand template haskell                     |
-| ~SPC m m n~ | go to next type hole                        |
-| ~SPC m m p~ | go to previous type hole                    |
-| ~SPC m m >~ | make indent deeper                          |
-| ~SPC m m <~ | make indent shallower                       |
+| Key Binding | Description                               |
+|-------------+-------------------------------------------|
+| ~SPC m m t~ | insert template                           |
+| ~SPC m m u~ | insert template with holes                |
+| ~SPC m m a~ | select one of possible cases (~ghc-auto~) |
+| ~SPC m m f~ | replace a hole (~ghc-refine~)             |
+| ~SPC m m e~ | expand template haskell                   |
+| ~SPC m m n~ | go to next type hole                      |
+| ~SPC m m p~ | go to previous type hole                  |
+| ~SPC m m >~ | make indent deeper                        |
+| ~SPC m m <~ | make indent shallower                     |
 
 *** insert template
 ~SPC m m t~ inserts a template. What this means is that

--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -1,4 +1,5 @@
 #+TITLE: HTML contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/html.png]]
 

--- a/layers/+lang/idris/README.org
+++ b/layers/+lang/idris/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Idris contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/idris.png]]
 

--- a/layers/+lang/ipython-notebook/README.org
+++ b/layers/+lang/ipython-notebook/README.org
@@ -1,4 +1,5 @@
 #+TITLE: IPython Notebook contribution layer for Spacemacs (WIP)
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Java contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/java.png]]
 

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -1,4 +1,5 @@
 #+TITLE: JavaScript contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/javascript.png]] [[file:img/coffee.png]]
 

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -1,4 +1,5 @@
 #+TITLE: LaTeX Layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/latex.png]]
 

--- a/layers/+lang/lua/README.org
+++ b/layers/+lang/lua/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Lua contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/lua.gif]]
 

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Markdown contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/markdown.png]]
 

--- a/layers/+lang/nim/README.org
+++ b/layers/+lang/nim/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Nim contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/logo.png]]
 

--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Ocaml contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ocaml.png]]
 

--- a/layers/+lang/php/README.org
+++ b/layers/+lang/php/README.org
@@ -1,4 +1,5 @@
 #+TITLE: PHP contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
  
 [[file:img/php.png]]
 

--- a/layers/+lang/purescript/README.org
+++ b/layers/+lang/purescript/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Purescript contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/purescript-logo.png]]
 

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Python contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/python.png]]
 

--- a/layers/+lang/racket/README.org
+++ b/layers/+lang/racket/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Racket contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/racket.png]]
 

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Ruby contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ruby.png]]
 

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Rust contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/rust.png]]
 

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Scala contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/scala.png]] with [[file:img/ensime.png]]
 

--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Scheme contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/shell-scripts/README.org
+++ b/layers/+lang/shell-scripts/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Shell Scripting contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/fish.png]]
 

--- a/layers/+lang/sml/README.org
+++ b/layers/+lang/sml/README.org
@@ -1,4 +1,5 @@
 #+TITLE: SML contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/sml.png]]
 

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -1,4 +1,5 @@
 #+TITLE: TypeScript contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/TypeScript.png]]
 

--- a/layers/+lang/vimscript/README.org
+++ b/layers/+lang/vimscript/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Vimscript language contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/windows-scripts/README.org
+++ b/layers/+lang/windows-scripts/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Windows Scripting contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ps.png]]
 

--- a/layers/+lang/yaml/README.org
+++ b/layers/+lang/yaml/README.org
@@ -1,4 +1,5 @@
 #+TITLE: YAML contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Git contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/git.png]]
 

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Github contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/github.png]]
 

--- a/layers/+source-control/perforce/README.org
+++ b/layers/+source-control/perforce/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Perforce contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/p4.png]]
 

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Version-Control contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/dash/README.org
+++ b/layers/+tools/dash/README.org
@@ -1,4 +1,6 @@
 #+TITLE: Dash contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
+
 [[file:img/dash.png]]
 
 [[file:img/zeal.png]]

--- a/layers/+tools/evernote/README.org
+++ b/layers/+tools/evernote/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Evernote contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/evernote.png]] with [[file:img/geeknote.png]]
 

--- a/layers/+tools/fasd/README.org
+++ b/layers/+tools/fasd/README.org
@@ -1,4 +1,5 @@
 #+TITLE: fasd contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/pandoc/README.org
+++ b/layers/+tools/pandoc/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Pandoc contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Ranger contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/tmux/README.org
+++ b/layers/+tools/tmux/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Tmux contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[What is this][What is this]]

--- a/layers/+tools/vagrant/README.org
+++ b/layers/+tools/vagrant/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Vagrant contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/vagrant.png]]
 

--- a/layers/+tools/wakatime/README.org
+++ b/layers/+tools/wakatime/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Wakatime contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/wakatime.png]]
 

--- a/layers/+tools/ycmd/README.org
+++ b/layers/+tools/ycmd/README.org
@@ -1,4 +1,5 @@
 #+TITLE: YCMD contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/evil-commentary/README.org
+++ b/layers/+vim/evil-commentary/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Evil-commentary contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/evil-snipe/README.org
+++ b/layers/+vim/evil-snipe/README.org
@@ -1,4 +1,5 @@
 #+TITLE: evil-snipe contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/Cat_With_Rifle.jpg]]
 

--- a/layers/+vim/unimpaired/README.org
+++ b/layers/+vim/unimpaired/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Unimpaired port contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/vim-empty-lines/README.org
+++ b/layers/+vim/vim-empty-lines/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Vim-empty-lines contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/vim-powerline/README.org
+++ b/layers/+vim/vim-powerline/README.org
@@ -1,4 +1,5 @@
 #+TITLE: vim-powerline contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/vinegar/README.org
+++ b/layers/+vim/vinegar/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Vinegar contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+window-management/eyebrowse/README.org
+++ b/layers/+window-management/eyebrowse/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Eyebrowse contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/eyebrowse.gif]] [[file:img/i3wm.png]]
 

--- a/layers/+window-management/spacemacs-layouts/README.org
+++ b/layers/+window-management/spacemacs-layouts/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Spacemacs Layouts configuration layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1,4 +1,5 @@
 #+TITLE: Configuration layers
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[General layers][General layers]]
@@ -42,6 +43,7 @@
 - [[file:syntax-checking/README.org][syntax-checking]]
 - [[file:themes-megapack/README.org][themes-megapack]]
 - [[file:theming/README.org][theming]]
+- [[file:typography/README.org][typography]]
 
 * Configuration files
 - [[file:+config-files/ansible/README.org][ansible]]

--- a/layers/auto-completion/README.org
+++ b/layers/auto-completion/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Auto-completion layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/better-defaults/README.org
+++ b/layers/better-defaults/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Better Defaults layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/emacs.png]]
 

--- a/layers/chinese/README.org
+++ b/layers/chinese/README.org
@@ -1,6 +1,7 @@
 #+TITLE: Chinese contribution layer for Spacemacs
-[[file:img/China.png]]  [[file:img/Chinese.png]]
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
+[[file:img/China.png]]  [[file:img/Chinese.png]]
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
@@ -48,6 +49,7 @@ file. You could call =pyim-dicts-manager= to open up the settings buffer and
 press =i e= to install the default lexicon. The lexicon is about 20M, so you
 should be patient when downloading starts. After the lexicon file is downloaded,
 just press =s= to save and =R= to restart configuration.
+
 *** Enable YouDao(有道) Dictionary(激活有道字典)
 The YouDao Dictionary is disabled by default, if you want enable it.
 You should set `chinese-enable-youdao-dict` to `t`.
@@ -57,7 +59,6 @@ You should set `chinese-enable-youdao-dict` to `t`.
                                                              chinese-enable-youdao-dict t)))
 
 #+END_SRC
-
 
 *** Set monospaced font size(设置等宽字体）
 If you are mixing Chinese words with English words, the text is not perfectly
@@ -71,7 +72,6 @@ Example configuration:
 ;; If you are not using MacOS X, you should change it to another Chinese font name.
 (spacemacs//set-monospaced-font   "Source Code Pro" "Hiragino Sans GB" 14 16)
 #+END_SRC
-
 
 * Key Bindings
 Currently, there are no built-in key bindings for this layer. You could define

--- a/layers/chrome/README.org
+++ b/layers/chrome/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Chrome contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/chrome.png]]
 

--- a/layers/colors/README.org
+++ b/layers/colors/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Colors contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/rainbow_dash.png]]
 

--- a/layers/cscope/README.org
+++ b/layers/cscope/README.org
@@ -1,6 +1,7 @@
 #+TITLE: Cscope contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
-[[file:img/cscope.png]]
+[[file:img/cscope.jpg]]
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/deft/README.org
+++ b/layers/deft/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Deft configuration layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Content                                          :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/finance/README.org
+++ b/layers/finance/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Finance contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/floobits/README.org
+++ b/layers/floobits/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Floobits integration layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/floobits.png]]
 

--- a/layers/geolocation/README.org
+++ b/layers/geolocation/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Geolocation contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/gtags/README.org
+++ b/layers/gtags/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Helm Gtags contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/ibuffer/README.org
+++ b/layers/ibuffer/README.org
@@ -1,4 +1,5 @@
 #+TITLE: ibuffer contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/jabber/README.org
+++ b/layers/jabber/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Jabber contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/jabber-logo.gif]]
 

--- a/layers/nixos/README.org
+++ b/layers/nixos/README.org
@@ -1,4 +1,5 @@
 #+TITLE: NixOS contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/nixos.jpg]]
 

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Org contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/org.png]]
 

--- a/layers/osx/README.org
+++ b/layers/osx/README.org
@@ -1,4 +1,5 @@
 #+TITLE: OSX contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/apple.png]]
 

--- a/layers/prodigy/README.org
+++ b/layers/prodigy/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Prodigy contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/prodigy.png]]
 

--- a/layers/restclient/README.org
+++ b/layers/restclient/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Restclient contribution layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[What is this?][What is this?]]

--- a/layers/search-engine/README.org
+++ b/layers/search-engine/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Search Engine contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/searchengine.jpg]]
 

--- a/layers/semantic/README.org
+++ b/layers/semantic/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Semantic contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Description
 

--- a/layers/shell/README.org
+++ b/layers/shell/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Shell contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/shell.png]]
 

--- a/layers/syntax-checking/README.org
+++ b/layers/syntax-checking/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Syntax Checking layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 [[file:img/flycheck.png]]
 

--- a/layers/themes-megapack/README.org
+++ b/layers/themes-megapack/README.org
@@ -1,4 +1,5 @@
 #+TITLE: Themes Megapack layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[What is this?][What is this?]]

--- a/layers/typography/README.org
+++ b/layers/typography/README.org
@@ -1,4 +1,5 @@
-#+TITLE typography contribution layer for Spacemacs
+#+TITLE: typography contribution layer for Spacemacs
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]


### PR DESCRIPTION
This generates documentation with real CSS classes for code instead of hardcoded colors. In order to refer to the correct CSS file I had to code the path in each org file. There is apparently no good way to do absolute paths on a github pages site, since `/css/readtheorg.css` will point to `spacemacs.org/css/readtheorg.css` when on `spacemacs.org` (correct) but to `thebb.github.io/css/readtheorg.css` when on `thebb.github.io/spacemacs/` (incorrect—it should be `thebb.github.io/spacemacs/css/readtheorg.css`). This seems to me a little arcane but I couldn't find a better way to do it. That's why I'm submitting this as a PR instead of pushing directly.

Is there a way to hide these `#+HTML_HEAD_EXTRA` in view mode, maybe?