### PR TITLE
Eyebrowse layer keybinding refactoring

### DIFF
--- a/layers/+window-management/eyebrowse/README.org
+++ b/layers/+window-management/eyebrowse/README.org
@@ -12,12 +12,12 @@
 * Description
 This layer adds [[https://i3wm.org/][i3wm]] like workspaces thanks to the [[https://github.com/wasamasa/eyebrowse][eyebrowse]] package.
 
-Once the layer is activated a new number is added to the right side of the
+Once the layer is activated a new number is added to the left side of the
 mode-line. This number corresponds to the currently active workspace number.
 
 At startup, the workspace number 1 is active. Switching to a workspace will
 create it if it does not exist. For instance at startup you can press
-~SPC W 2~ to create the workspace 2.
+~SPC l w 2~ to create the workspace 2.
 
 The key bindings are registered in a micro-state displayed in the minibuffer.
 The docstring of the micro-state displays the existing workspaces and the
@@ -49,23 +49,23 @@ Set the variable =eyebrowse-display-help= to =nil=
 
 * Key bindings
 
-| Key Binding                         | Description                        |
-|-------------------------------------+------------------------------------|
-| ~gt~                                | go to next workspace               |
-| ~gT~                                | got to previous workspace          |
-| ~SPC W 1~                           | create or switch to workspace 1    |
-| ~SPC W 2~                           | create or switch to workspace 2    |
-| ~SPC W 3~                           | create or switch to workspace 3    |
-| ~SPC W 4~                           | create or switch to workspace 4    |
-| ~SPC W 5~                           | create or switch to workspace 5    |
-| ~SPC W 6~                           | create or switch to workspace 6    |
-| ~SPC W 7~                           | create or switch to workspace 7    |
-| ~SPC W 8~                           | create or switch to workspace 8    |
-| ~SPC W 9~                           | create or switch to workspace 9    |
-| ~SPC W 0~                           | create or switch to workspace 0    |
-| ~SPC W TAB~                         | switch to last active workspace    |
-| ~SPC W c~                           | close current workspace            |
-| ~SPC W n~ or ~SPC W l~              | switch to next workspace           |
-| ~SPC W N~ or ~SPC W p~ or ~SPC W h~ | switch to previous workspace       |
-| ~SPC W r~                           | set a tag to the current workspace |
-| ~SPC W s~                           | switched to tagged workspace       |
+| Key Binding                               | Description                        |
+|-------------------------------------------+------------------------------------|
+| ~gt~                                      | go to next workspace               |
+| ~gT~                                      | got to previous workspace          |
+| ~SPC l w 1~                               | create or switch to workspace 1    |
+| ~SPC l w 2~                               | create or switch to workspace 2    |
+| ~SPC l w 3~                               | create or switch to workspace 3    |
+| ~SPC l w 4~                               | create or switch to workspace 4    |
+| ~SPC l w 5~                               | create or switch to workspace 5    |
+| ~SPC l w 6~                               | create or switch to workspace 6    |
+| ~SPC l w 7~                               | create or switch to workspace 7    |
+| ~SPC l w 8~                               | create or switch to workspace 8    |
+| ~SPC l w 9~                               | create or switch to workspace 9    |
+| ~SPC l w 0~                               | create or switch to workspace 0    |
+| ~SPC l w TAB~                             | switch to last active workspace    |
+| ~SPC l w c~                               | close current workspace            |
+| ~SPC l w n~ or ~SPC l w l~                | switch to next workspace           |
+| ~SPC l w N~ or ~SPC l w p~ or ~SPC l w h~ | switch to previous workspace       |
+| ~SPC l w r~                               | set a tag to the current workspace |
+| ~SPC l w w~                               | switched to tagged workspace       |

--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -65,7 +65,9 @@
       (spacemacs|define-micro-state workspaces
         :doc (spacemacs//workspaces-ms-documentation)
         :use-minibuffer t
-        :evil-leader "W"
+        ;; This binding is effectively overridden by init-persp-mode, which runs
+        ;; after this function. This should be transparent to the user.
+        :evil-leader "lw"
         :bindings
         ("0" eyebrowse-switch-to-window-config-0)
         ("1" eyebrowse-switch-to-window-config-1)
@@ -86,4 +88,4 @@
         ("N" eyebrowse-prev-window-config)
         ("p" eyebrowse-prev-window-config)
         ("r" spacemacs/workspaces-ms-rename :exit t)
-        ("s" eyebrowse-switch-to-window-config :exit t)))))
+        ("w" eyebrowse-switch-to-window-config :exit t)))))

--- a/layers/+window-management/spacemacs-layouts/funcs.el
+++ b/layers/+window-management/spacemacs-layouts/funcs.el
@@ -128,3 +128,12 @@ Cancels autosave on exiting perspectives mode."
     (when spacemacs--layouts-autosave-timer
       (cancel-timer spacemacs--layouts-autosave-timer)
       (setq spacemacs--layouts-autosave-timer nil))))
+
+;; Eyebrowse micro-state wrapper -------------------------------------------
+
+(defun spacemacs/layout-workspaces-micro-state ()
+  "Launches the workspaces micro state, if defined."
+  (interactive)
+  (if (fboundp 'spacemacs/workspaces-micro-state)
+      (call-interactively 'spacemacs/workspaces-micro-state)
+    (message "You need the eyebrowse layer to use this feature.")))

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -87,6 +87,7 @@
   [R]                  rename or create layout
   [s]                  save layouts
   [t]                  show a buffer without adding it to current layout
+  [w]                  workspaces micro-state
   [x]                  kill layout and its buffers
   [X]                  kill other layout(s) and their buffers")
 
@@ -143,6 +144,7 @@
         ("R" spacemacs/layouts-ms-rename :exit t)
         ("s" persp-save-state-to-file :exit t)
         ("t" persp-temporarily-display-buffer :exit t)
+        ("w" spacemacs/layout-workspaces-micro-state :exit t)
         ("x" spacemacs/layouts-ms-kill)
         ("X" spacemacs/layouts-ms-kill-other :exit t))
 


### PR DESCRIPTION
This PR moves the eyebrowse micro-state to `SPC l w`, since it is also a layout feature. It is accessible both through the perspectives micro-state and a regular old keybinding. The former overrides the latter, so this should work as intended in all relevant cases.

I also switched the eyebrowse helm key to `SPC l w w` since the perspectives helm key is `SPC l l`.

This frees up a capital letter leader key, too.