### PR TITLE
Fixed default value of `open-junk-file-directory'.

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1451,7 +1451,7 @@ It will toggle the overlay under point or create an overlay of one character."
     :commands (open-junk-file)
     :init
     (evil-leader/set-key "fJ" 'open-junk-file)
-    (setq open-junk-file-directory (concat spacemacs-cache-directory "junk/"))))
+    (setq open-junk-file-directory (concat spacemacs-cache-directory "junk/%Y/%m/%d-%H%M%S."))))
 
 (defun spacemacs/init-info+ ()
   (use-package info+


### PR DESCRIPTION
This variable does NOT specify the directory portion for the junk file
creation; it is an alias for `open-junk-file-format'. Hence, it should
contain format markers for the randomisation of the junk file name.

The previous value would not auto-generate a junk name for the junk
file: the prompt would ask for a file extension without having an
auto-generated junk file name.