### PR TITLE
Add `SPC c q` to close the compilation window

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2575,6 +2575,7 @@ Spacemacs binds a few commands to support compiling a project.
    | ~SPC c c~   | use =helm-make= via projectile |
    | ~SPC c C~   | compile                        |
    | ~SPC c r~   | recompile                      |
+   | ~SPC c q~   | close compilation window       |
 
 ** Modes
 *** Major Mode leader key

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -905,3 +905,8 @@ is nonempty."
         while (string-match regexp str start)
         do (setq start (match-end 0))
         finally return count))
+
+(defun spacemacs/close-compilation-window ()
+  "Close the window containing the '*compilation*' buffer."
+  (interactive)
+  (delete-windows-on "*compilation*"))

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -159,9 +159,13 @@ Ensure that helm is required before calling FUNC."
 (evil-leader/set-key
   "jh" 'spacemacs/push-mark-and-goto-beginning-of-line
   "jl" 'spacemacs/push-mark-and-goto-end-of-line)
+
 ;; Compilation ----------------------------------------------------------------
-(evil-leader/set-key "cC" 'compile)
-(evil-leader/set-key "cr" 'recompile)
+(evil-leader/set-key
+  "cC" 'compile
+  "cr" 'recompile
+  "cq" 'spacemacs/close-compilation-window)
+
 ;; narrow & widen -------------------------------------------------------------
 (evil-leader/set-key
   "nr" 'narrow-to-region


### PR DESCRIPTION
I found it annoying to have to re-navigate to the `*compilation*` window
and close it after every time I compile with `SPC p c`.

This patch adds a binding to make closing this window fast and easy.

Also a little bit of clean up.