### PR TITLE
Fix micro-state error.

### DIFF
--- a/core/core-micro-state.el
+++ b/core/core-micro-state.el
@@ -175,7 +175,8 @@ used."
                   (spacemacs//micro-state-set-minibuffer-height defdoc)
                   (apply ',msg-func
                          (list (spacemacs//micro-state-propertize-doc
-                                (format "%S: %s" ',name defdoc)))))))))
+                                (format "%S: %s" ',name defdoc))))
+                  defdoc)))))
          (wrapper-func
           (if (and (boundp wrapped)
                    (eval `(keymapp ,wrapped)))


### PR DESCRIPTION
Seems like `defdoc` was being defined by the return of `spacemacs//micro-state-set-minibuffer-height`. Addresses #3739 