### PR TITLE
(mu4e) Don't require multiple account list

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -4,7 +4,7 @@
  - [[Installation][Installation]]
  - [[Commands][Commands]]
  - [[Configuration][Configuration]]
-   - [[Important note][Important note]]
+   - [[Multiple Accounts][Multiple Accounts]]
    - [[Example configuration][Example configuration]]
  - [[See also][See also]]
 
@@ -32,9 +32,10 @@ Configuration varies too much to give precise instructions.  What follows is one
 example configuration.  Refer to mu4e's manual for more detailed configuration
 instructions.
 
-** Important note
-This layer includes support for multiple sending accounts.  Configure the
-`mu4e-account-alist` variable:
+** Multiple Accounts
+This layer includes support for multiple sending accounts.
+If you have only one account you do not need to define this variable.
+If you have multiple accounts, configure the `mu4e-account-alist` variable:
 
 #+BEGIN_SRC emacs-lisp
   (setq mu4e-account-alist

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -33,5 +33,7 @@
 
       (add-to-list 'mu4e-view-actions
                    '("View in browser" . mu4e-action-view-in-browser) t)
-      (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
-      (add-hook 'message-sent-hook 'mu4e/mail-account-reset))))
+
+      (when mu4e-account-alist
+        (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
+        (add-hook 'message-sent-hook 'mu4e/mail-account-reset)))))


### PR DESCRIPTION
This commit deactivates account selection and switching support if the
account list isn't defined. We also don't need the follow-up action of
undoing the account selection changes, so we can just skip both of the
hooks.

This is useful for users who only have 1 account - they don't need the
helm popup to select which account to use. They can just define the
variables outside of the `mu4e-account-list`.