### PR TITLE
react: Fix Flycheck setup

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -35,13 +35,11 @@
     :post-config
     (progn
       (flycheck-add-mode 'javascript-eslint 'react-mode)
-      (setq-default
-       ;; disable jshint since we prefer eslint checking
-       flycheck-disabled-checkers (append flycheck-disabled-checkers
-                                          '(javascript-jshint))
-       ;; disable json-jsonlist checking for json files
-       flycheck-disabled-checkers (append flycheck-disabled-checkers
-                                          '(json-jsonlist))))))
+
+      (defun react/disable-jshint ()
+        (push 'javascript-jshint flycheck-disabled-checkers))
+
+      (add-hook 'react-mode-hook #'react/disable-jshint))))
 
 (defun react/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'react-mode))


### PR DESCRIPTION
Do not disable jshint globally, but only for React Mode.  It’s perfectly fine to use jshint for a Javascript project and eslint for a React project.  A layer should not enforce its language specific preferences upon everything else, and above all, you should **never** disable syntax globally without a very good reason.

Also remove the redundant expression disabling `json-jsonlist`, which simply does not exist.  We have `json-jsonlint`, but why would you want to disable that?

No offense meant, but did you actually ever _review_ this?