### PR TITLE
syntax-checking: Enable Flycheck Pos Tip Mode

### DIFF
--- a/layers/syntax-checking/packages.el
+++ b/layers/syntax-checking/packages.el
@@ -99,10 +99,9 @@ If the error list is visible, hide it.  Otherwise, show it."
     :if syntax-checking-enable-tooltips
     :defer t
     :init
-    (setq flycheck-display-errors-function 'flycheck-pos-tip-error-messages)
-    :config
-    (when (fboundp 'flycheck-pos-tip-mode)
-      (flycheck-pos-tip-mode))))
+    (with-eval-after-load 'flycheck
+      (when (fboundp 'flycheck-pos-tip-mode)
+        (flycheck-pos-tip-mode)))))
 
 (defun syntax-checking/post-init-popwin ()
   (push '("^\\*Flycheck.+\\*$" :regexp t :dedicated t :position bottom :stick t :noselect t) popwin:special-display-config))


### PR DESCRIPTION
flycheck-pos-tip now provides a global minor mode which is the proper entry point to enable the package now.