### PR TITLE
Add C-j and C-k history commands in shells

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -146,7 +146,6 @@
       ;; don't display eldoc on modeline
       (spacemacs|hide-lighter eldoc-mode))))
 
-
 (defun spacemacs-base/init-evil ()
   (use-package evil
     :init
@@ -382,7 +381,15 @@ Example: (evil-map visual \"<\" \"<gv\")"
           ;; free variable reference. The line above fixes this
           (if smartparens-strict-mode
               (call-interactively 'sp-backward-delete-char)
-            ad-do-it))))))
+            ad-do-it)))
+
+      ;; Define history commands for comint
+      (evil-define-key 'insert comint-mode-map
+        (kbd "C-k") 'comint-next-input
+        (kbd "C-j") 'comint-previous-input)
+      (evil-define-key 'normal comint-mode-map
+        (kbd "C-k") 'comint-next-input
+        (kbd "C-j") 'comint-previous-input))))
 
 (defun spacemacs-base/init-evil-escape ()
   (use-package evil-escape

--- a/layers/shell/packages.el
+++ b/layers/shell/packages.el
@@ -129,7 +129,13 @@ is achieved by adding the relevant text properties."
 
       ;; automatically truncate buffer after output
       (when (boundp 'eshell-output-filter-functions)
-        (push 'eshell-truncate-buffer eshell-output-filter-functions)))))
+        (push 'eshell-truncate-buffer eshell-output-filter-functions))
+
+      ;; These don't work well in normal state
+      ;; due to evil/emacs cursor incompatibility
+      (evil-define-key 'insert eshell-mode-map
+        (kbd "C-k") 'eshell-previous-matching-input-from-input
+        (kbd "C-j") 'eshell-next-matching-input-from-input))))
 
 (defun shell/init-esh-help ()
   (use-package esh-help
@@ -283,7 +289,14 @@ is achieved by adding the relevant text properties."
   ;; work in term
   (evil-define-key 'normal term-raw-map "p" 'term-paste)
   (evil-define-key 'insert term-raw-map (kbd "C-c C-d") 'term-send-eof)
-  (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab))
+  (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab)
+
+  (evil-define-key 'insert term-raw-map
+    (kbd "C-k") 'term-send-up
+    (kbd "C-j") 'term-send-down)
+  (evil-define-key 'normal term-raw-map
+    (kbd "C-k") 'term-send-up
+    (kbd "C-j") 'term-send-down))
 
 (defun shell/pre-init-magit ()
   (spacemacs|use-package-add-hook magit


### PR DESCRIPTION
This PR is based on work by @mijoharas in #1759. It covers all comint-derived modes, as well as term and eshell. I left out normal-state bindings in eshell because it suffers from the evil/emacs cursor incompatibility issue.

It's not necessary to guard with editing style because it only applies in the given evil states.

Fixes #586 and supersedes #1759.