### PR TITLE
Move lorem ipsum bindings to il prefix

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -142,7 +142,7 @@
        - [[Paste Micro-state][Paste Micro-state]]
        - [[Auto-indent pasted text][Auto-indent pasted text]]
      - [[Text manipulation commands][Text manipulation commands]]
-     - [[Searching and inserting Unicode characters][Searching and inserting Unicode characters]]
+     - [[Text insertion commands][Text insertion commands]]
      - [[Smartparens Strict mode][Smartparens Strict mode]]
      - [[Zooming][Zooming]]
        - [[Text][Text]]
@@ -2077,45 +2077,44 @@ adding a major-mode to the variable =spacemacs-indent-sensitive-modes= in your
 *** Text manipulation commands
 Text related commands (start with ~x~):
 
-    | Key Binding   | Description                                                   |
-    |---------------+---------------------------------------------------------------|
-    | ~SPC x o~     | use avy to select a link in the buffer and open it            |
-    | ~SPC x u~     | set the selected text to lower case                           |
-    | ~SPC x U~     | set the selected text to upper case                           |
-    | ~SPC x a a~   | align region (or guessed section) using default rules         |
-    | ~SPC x a r~   | align region using user-specified regexp                      |
-    | ~SPC x a m~   | align region at arithmetic operators (+-*/)                   |
-    | ~SPC x a .~   | align region at . (for numeric tables)                        |
-    | ~SPC x a ,~   | align region at ,                                             |
-    | ~SPC x a ;~   | align region at ;                                             |
-    | ~SPC x a =~   | align region at =                                             |
-    | ~SPC x a &~   | align region at &                                             |
-    | ~SPC x a ¦~   | align region at ¦                                             |
-    | ~SPC x c~     | count the number of chars/words/lines in the selection region |
-    | ~SPC x d w~   | delete trailing whitespaces                                   |
-    | ~SPC x g l~   | set languages used by translate commands                      |
-    | ~SPC x g t~   | translate current word using Google Translate                 |
-    | ~SPC x g T~   | reverse source and target languages                           |
-    | ~SPC x i l l~ | insert lorem-ipsum list                                       |
-    | ~SPC x i l p~ | insert lorem-ipsum paragraph                                  |
-    | ~SPC x i l s~ | insert lorem-ipsum sentence                                   |
-    | ~SPC x J~     | move down a line of text (enter micro-state)                  |
-    | ~SPC x K~     | move up a line of text (enter micro-state)                    |
-    | ~SPC x l s~   | sort lines                                                    |
-    | ~SPC x l u~   | uniquify lines                                                |
-    | ~SPC x t c~   | swap (transpose) the current character with the previous one  |
-    | ~SPC x t w~   | swap (transpose) the current word with the previous one       |
-    | ~SPC x t l~   | swap (transpose) the current line with the previous one       |
-    | ~SPC x w c~   | count the number of occurrences per word in the select region |
-    | ~SPC x w d~   | show dictionary entry of word from wordnik.com                |
+    | Key Binding | Description                                                   |
+    |-------------+---------------------------------------------------------------|
+    | ~SPC x o~   | use avy to select a link in the buffer and open it            |
+    | ~SPC x u~   | set the selected text to lower case                           |
+    | ~SPC x U~   | set the selected text to upper case                           |
+    | ~SPC x a a~ | align region (or guessed section) using default rules         |
+    | ~SPC x a r~ | align region using user-specified regexp                      |
+    | ~SPC x a m~ | align region at arithmetic operators (+-*/)                   |
+    | ~SPC x a .~ | align region at . (for numeric tables)                        |
+    | ~SPC x a ,~ | align region at ,                                             |
+    | ~SPC x a ;~ | align region at ;                                             |
+    | ~SPC x a =~ | align region at =                                             |
+    | ~SPC x a &~ | align region at &                                             |
+    | ~SPC x a ¦~ | align region at ¦                                             |
+    | ~SPC x c~   | count the number of chars/words/lines in the selection region |
+    | ~SPC x d w~ | delete trailing whitespaces                                   |
+    | ~SPC x g l~ | set languages used by translate commands                      |
+    | ~SPC x g t~ | translate current word using Google Translate                 |
+    | ~SPC x g T~ | reverse source and target languages                           |
+    | ~SPC x J~   | move down a line of text (enter micro-state)                  |
+    | ~SPC x K~   | move up a line of text (enter micro-state)                    |
+    | ~SPC x l s~ | sort lines                                                    |
+    | ~SPC x l u~ | uniquify lines                                                |
+    | ~SPC x t c~ | swap (transpose) the current character with the previous one  |
+    | ~SPC x t w~ | swap (transpose) the current word with the previous one       |
+    | ~SPC x t l~ | swap (transpose) the current line with the previous one       |
+    | ~SPC x w c~ | count the number of occurrences per word in the select region |
+    | ~SPC x w d~ | show dictionary entry of word from wordnik.com                |
 
-*** Searching and inserting Unicode characters
-You can very easily search for and insert Unicode characters into the
-current buffer with [[https://github.com/shosti/helm-unicode][helm-unicode]].
+*** Text insertion commands
+Text insertion commands (start with ~i~):
 
-    | Key Binding | Description                                                           |
+    | Key binding | Description                                                           |
     |-------------+-----------------------------------------------------------------------|
     | ~SPC i u~   | Search for Unicode characters and insert them into the active buffer. |
+    | ~SPC i l l~ | insert lorem-ipsum list                                               |
+    | ~SPC i l p~ | insert lorem-ipsum paragraph                                          |
+    | ~SPC i l s~ | insert lorem-ipsum sentence                                           |
 
 *** Smartparens Strict mode
 [[https://github.com/Fuco1/smartparens][Smartparens]] comes with a strict mode which prevents deletion of parenthesis if

--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -58,7 +58,6 @@
                                        ("xa"  "align")
                                        ("xd"  "delete")
                                        ("xg"  "google-translate")
-                                       ("xi"  "insert")
                                        ("xl"  "lines")
                                        ("xm"  "move")
                                        ("xt"  "transpose")

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1486,11 +1486,11 @@ It will toggle the overlay under point or create an overlay of one character."
                lorem-ipsum-insert-sentences)
     :init
     (progn
-      (spacemacs/declare-prefix "xil" "lorem ipsum")
+      (spacemacs/declare-prefix "il" "lorem ipsum")
       (evil-leader/set-key
-        "xill" 'lorem-ipsum-insert-list
-        "xilp" 'lorem-ipsum-insert-paragraphs
-        "xils" 'lorem-ipsum-insert-sentences))))
+        "ill" 'lorem-ipsum-insert-list
+        "ilp" 'lorem-ipsum-insert-paragraphs
+        "ils" 'lorem-ipsum-insert-sentences))))
 
 (defun spacemacs/init-move-text ()
   (use-package move-text


### PR DESCRIPTION
Spacemacs already has the "i" prefix for insertion, why do we also need a separate prefix "xi" for “text insertion”?