### PR TITLE
Disable projectile-caching by default.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2495,6 +2495,9 @@ To search in a project see [[Searching in a project][project searching]].
     | ~SPC s k p~ | run =ack=                                             |
     | ~SPC s p p~ | run =pt=                                              |
 
+*Note for Windows Users*: To enable fast indexing the GNU ~find~ or
+Cygwin ~find~ must be in your ~PATH~.
+
 ** Registers
 Access commands to the various registers start with =r=:
 

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -1230,14 +1230,12 @@ ARG non nil means that the editing style is `vim'."
                projectile-vc)
     :init
     (progn
-      ;; note for Windows: GNU find or Cygwin find must be in path
-      ;; default parameters are not supported on Windows, we default
-      ;; to simplest call to find.
-      (when (spacemacs/system-is-mswindows)
-        (setq projectile-generic-command "find . -type f"))
-      (setq projectile-enable-caching t
-            projectile-indexing-method 'alien
-            projectile-sort-order 'recentf
+      ;; note for Windows: GNU find or Cygwin find must be in path to enable
+      ;; fast indexing
+      (when (and (spacemacs/system-is-mswindows) (executable-find "find"))
+          (setq  projectile-indexing-method 'alien)
+                 projectile-generic-command "find . -type f")
+      (setq projectile-sort-order 'recentf
             projectile-cache-file (concat spacemacs-cache-directory
                                           "projectile.cache")
             projectile-known-projects-file (concat spacemacs-cache-directory


### PR DESCRIPTION
After reading [this exchange on reddit](https://www.reddit.com/r/emacs/comments/3snefv/findfileinproject_40/cwysonp) I was checking out the spacemacs projectile settings. The following changes should be made.

- Default projectile settings are to disable caching when indexing
  method is `alien. So setting the indexing method should be enough.
- On windows we keep the 'native method unless find is found

I have not removed the [hooks](https://github.com/bbatsov/projectile/blob/master/projectile.el#L2721-L2724) since all but one are there to cache projects and not project files. 