### PR TITLE
Refine typography layer

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -921,7 +921,6 @@ and ~T~):
 
 | Key Binding | Description                                                       |
 |-------------+-------------------------------------------------------------------|
-| ~SPC t ~~   | display =~= in the fringe on empty lines                          |
 | ~SPC t f~   | display the fill column (by default the fill column is set to 80) |
 | ~SPC t h h~ | toggle highlight of the current line                              |
 | ~SPC t h i~ | toggle highlight indentation levels                               |
@@ -933,6 +932,7 @@ and ~T~):
 
 | Key Binding | Description                                                  |
 |-------------+--------------------------------------------------------------|
+| ~SPC T ~~   | display =~= in the fringe on empty lines                          |
 | ~SPC T F~   | toggle frame fullscreen                                      |
 | ~SPC T f~   | toggle display of the fringe                                 |
 | ~SPC T m~   | toggle menu bar                                              |

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1899,7 +1899,7 @@ It will toggle the overlay under point or create an overlay of one character."
         :off (global-vi-tilde-fringe-mode -1)
         :documentation
         "Globally display a ~ on empty lines in the fringe."
-        :evil-leader "t~")
+        :evil-leader "T~")
       ;; don't enable it on spacemacs home buffer
       (with-current-buffer  "*spacemacs*"
         (vi-tilde-fringe-mode -1))

--- a/layers/typography/packages.el
+++ b/layers/typography/packages.el
@@ -33,8 +33,8 @@
         :on (typo-mode)
         :off (typo-mode -1)
         :documentation "Enable typographic substitutions"
-        :evil-leader "tTy")
-      (spacemacs|diminish typo-mode " 𝔗" " ty"))
+        :evil-leader "tY")
+      (spacemacs|diminish typo-mode " Ⓨ" " ty"))
     :config (setq-default typo-language "English")))
 
 (defun typography/init-tildify ()
@@ -46,7 +46,7 @@
         (add-hook 'text-mode-hook 'tildify-mode))
 
       (evil-leader/set-key
-        "xTt" 'tildify-region)
+        "x~" 'tildify-region)
 
       ;; Use the symbolic non-breaking space for LaTeX
       (defun typography/tildify-latex-space ()
@@ -59,5 +59,5 @@
         :on (tildify-mode)
         :off (tildify-mode -1)
         :documentation "Enable electric non-breaking space"
-        :evil-leader "tTd")
-      (spacemacs|diminish tildify-mode " 𝔇" " td"))))
+        :evil-leader "t~")
+      (spacemacs|diminish tildify-mode " ~" " ~"))))


### PR DESCRIPTION
- Move vi tilde fringe from `SPC t ~` to `SPC T ~` to free the former.
- Move tildify toggle from `SPC t T d` to `SPC t ~`.  
- Move tildify region from `SPC x T T` to `SPC x ~`
- Use `~` as mode line indicator for tildify mode
- Move typography toggle from `SPC t T y` to `SPC t Y`
- Use circled capital Y `Ⓨ` as mode line indicator for typo mode

See https://github.com/syl20bnr/spacemacs/pull/3554#issuecomment-156491394