### PR TITLE
Add `SPC h SPC` as an alias of `SPC f e h`

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -954,7 +954,8 @@ ARG non nil means that the editing style is `vim'."
     :init
     (progn
       (evil-leader/set-key "feh" 'helm-spacemacs)
-      (evil-leader/set-key "fef" 'helm-spacemacs-faq))))
+      (evil-leader/set-key "fef" 'helm-spacemacs-faq)
+      (evil-leader/set-key "h SPC" 'helm-spacemacs))))
 
 (defun spacemacs-base/init-hs-minor-mode ()
   ;; required for evil folding


### PR DESCRIPTION
Add `SPC h SPC` to access helm-spacemacs. Mnemonic
is **h**elp **SPC**macs. As suggested by syl20bnr on #2145.

Close #2145