### PR TITLE
Change behaviour of [=] [0] in zooms

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2122,11 +2122,13 @@ The font size of the current buffer can be adjusted with the commands:
 | Key Binding   | Description                                                                |
 |---------------+----------------------------------------------------------------------------|
 | ~SPC z x +~   | scale up the font and initiate the font scaling micro-state                |
+| ~SPC z x =~   | scale up the font and initiate the font scaling micro-state                |
 | ~SPC z x -~   | scale down the font and initiate the font scaling micro-state              |
-| ~SPC z x =~   | reset the font size (no scaling) and initiate the font scaling micro-state |
+| ~SPC z x 0~   | reset the font size (no scaling) and initiate the font scaling micro-state |
 | ~+~           | increase the font size                                                     |
+| ~=~           | increase the font size                                                     |
 | ~-~           | decrease the font size                                                     |
-| ~=~           | reset the font size                                                        |
+| ~0~           | reset the font size                                                        |
 | Any other key | leave the font scaling micro-state                                         |
 
 Note that /only/ the text of the current buffer is scaled, the other buffers,
@@ -2136,15 +2138,17 @@ a frame use the =zoom frame= bindings (see next section).
 **** Frame
 You can zoom in and out the whole content of the frame with the commands:
 
-| Key Binding   | Description                      |
-|---------------+----------------------------------|
-| ~SPC z f +~   | zoom in the frame content        |
-| ~SPC z f -~   | zoom out the frame content       |
-| ~SPC z f =~   | reset the frame content size     |
-| ~+~           | zoom in                          |
-| ~-~           | zoom out                         |
-| ~=~           | reset zoom                       |
-| Any other key | leave the zoom frame micro-state |
+| Key Binding   | Description                                                             |
+|---------------+-------------------------------------------------------------------------|
+| ~SPC z f +~   | zoom in the frame content and initiate the frame scaling micro-state    |
+| ~SPC z f =~   | zoom in the frame content and initiate the frame scaling micro-state    |
+| ~SPC z f -~   | zoom out the frame content and initiate the frame scaling micro-state   |
+| ~SPC z f 0~   | reset the frame content size and initiate the frame scaling micro-state |
+| ~+~           | zoom in                                                                 |
+| ~=~           | zoom in                                                                 |
+| ~-~           | zoom out                                                                |
+| ~0~           | reset zoom                                                              |
+| Any other key | leave the zoom frame micro-state                                        |
 
 *** Increase/Decrease numbers
 Spacemacs uses [[https://github.com/cofi/evil-numbers][evil-numbers]] to easily increase or increase numbers.

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -547,12 +547,13 @@ otherwise it is scaled down."
   (spacemacs/scale-up-or-down-font-size 0))
 
 (spacemacs|define-micro-state scale-font
-  :doc "[+] scale up [-] scale down [=] reset font [q]uit"
+  :doc "[+/=] scale up [-] scale down [0] reset font [q]uit"
   :evil-leader "zx"
   :bindings
   ("+" spacemacs/scale-up-font)
+  ("=" spacemacs/scale-up-font)
   ("-" spacemacs/scale-down-font)
-  ("=" spacemacs/reset-font-size)
+  ("0" spacemacs/reset-font-size)
   ("q" nil :exit t))
 
 ;; end of Text Manipulation Micro State

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1957,13 +1957,15 @@ It will toggle the overlay under point or create an overlay of one character."
     :init
     (progn
       (spacemacs|define-micro-state zoom-frm
-        :doc "[+] zoom frame in [-] zoom frame out [=] reset zoom"
+        :doc "[+/=] zoom frame in [-] zoom frame out [0] reset zoom [q]uit"
         :evil-leader "zf"
         :use-minibuffer t
         :bindings
         ("+" spacemacs/zoom-frm-in :post (spacemacs//zoom-frm-powerline-reset))
+        ("=" spacemacs/zoom-frm-in :post (spacemacs//zoom-frm-powerline-reset))
         ("-" spacemacs/zoom-frm-out :post (spacemacs//zoom-frm-powerline-reset))
-        ("=" spacemacs/zoom-frm-unzoom :post (spacemacs//zoom-frm-powerline-reset)))
+        ("0" spacemacs/zoom-frm-unzoom :post (spacemacs//zoom-frm-powerline-reset))
+        ("q" nil :exit t))
 
       (defun spacemacs//zoom-frm-powerline-reset ()
         (when (fboundp 'powerline-reset)


### PR DESCRIPTION
As proposed in #2144, Use [=] as an alias of [+], and use [0] instead
for resetting the zoom.

Add a missing `q` binding/documentation.

Close #2144