### PR TITLE
Switch mode-line toggle meanings

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -245,9 +245,9 @@ Ensure that helm is required before calling FUNC."
   :documentation "Maximize the current frame."
   :evil-leader "TM")
 (spacemacs|add-toggle mode-line
-  :status hidden-mode-line-mode
-  :on (hidden-mode-line-mode)
-  :off (hidden-mode-line-mode -1)
+  :status (equal hidden-mode-line-mode nil)
+  :on (hidden-mode-line-mode -1)
+  :off (hidden-mode-line-mode)
   :documentation "Toggle the visibility of modeline."
   :evil-leader "tmt")
 (spacemacs|add-toggle transparent-frame

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -245,7 +245,7 @@ Ensure that helm is required before calling FUNC."
   :documentation "Maximize the current frame."
   :evil-leader "TM")
 (spacemacs|add-toggle mode-line
-  :status (equal hidden-mode-line-mode nil)
+  :status (not hidden-mode-line-mode)
   :on (hidden-mode-line-mode -1)
   :off (hidden-mode-line-mode)
   :documentation "Toggle the visibility of modeline."


### PR DESCRIPTION
Before this change, typing "SPC t m t" would disable the mode-line and print "mode-line enabled", or enable the mode-line and print "mode-line disabled".

This might break existing configurations, since the on and off toggles would now have the opposite meanings.