### PR TITLE
Bind hn to view-emacs-news

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -107,6 +107,7 @@ Ensure that helm is required before calling FUNC."
 (evil-leader/set-key "hds" 'spacemacs/describe-system-info)
 (spacemacs||set-helm-key "hdt" describe-theme)
 (spacemacs||set-helm-key "hdv" describe-variable)
+(spacemacs||set-helm-key "hn"  view-emacs-news)
 (spacemacs||set-helm-key "hL"  helm-locate-library)
 ;; search functions -----------------------------------------------------------
 (spacemacs||set-helm-key "sww" helm-wikipedia-suggest)


### PR DESCRIPTION
Bind `SPC h n` to `view-emacs-news` which shows the changelog of the current Emacs release (with prefix arg it let's you select the version whose changelog to view).

Note that `SPC h n` and `SPC h N` are taken by `hl-anything`, but `hl-anything` is apparently disabled pending a bug in the package, so I'm not sure whether it's ok to take its bindings.  I went ahead and just took then :sunglasses: because `SPC h n` seems like the best binding for this.

If it's not ok, please suggest a better binding, I couldn't come up with any other obvious one.

I'll add it to the docs when we've settled on a binding.