### PR TITLE
Automatically set evil-shift-width based on mode settings

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -166,6 +166,39 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
   (`all (add-hook 'before-save-hook 'whitespace-cleanup))
   (`trailing (add-hook 'before-save-hook 'delete-trailing-whitespace)))
 
+;; Thanks to `editorconfig-emacs' for many of these
+(defvar spacemacs--indent-variable-alist
+  '(((awk-mode c-mode c++-mode java-mode groovy-mode
+      idl-mode java-mode objc-mode pike-mode) . c-basic-offset)
+    (python-mode . python-indent-offset)
+    (cmake-mode . cmake-tab-width)
+    (coffee-mode . coffee-tab-width)
+    (cperl-mode . cperl-indent-level)
+    (css-mode . css-indent-offset)
+    (elixir-mode . elixir-smie-indent-basic)
+    ((emacs-lisp-mode lisp-mode) . lisp-indent-offset)
+    (enh-ruby-mode . enh-ruby-indent-level)
+    (erlang-mode . erlang-indent-level)
+    ((js-mode json-mode) . js-indent-level)
+    (js2-mode . js2-basic-offset)
+    (js3-mode . js3-indent-level)
+    (latex-mode . (LaTeX-indent-level tex-indent-basic))
+    (livescript-mode . livescript-tab-width)
+    (mustache-mode . mustache-basic-offset)
+    (nxml-mode . nxml-child-indent)
+    (perl-mode . perl-indent-level)
+    (puppet-mode . puppet-indent-level)
+    (ruby-mode . ruby-indent-level)
+    (scala-mode . scala-indent:step)
+    (sgml-mode . sgml-basic-offset)
+    (sh-mode . sh-basic-offset)
+    (web-mode . web-mode-markup-indent-offset)
+    (yaml-mode . yaml-indent-offset))
+  "An alist where each key is either a symbol corresponding
+to a major mode, a list of such symbols, or the symbol t,
+acting as default. The values are either integers, symbols
+or lists of these.")
+
 ;; ---------------------------------------------------------------------------
 ;; UI
 ;; ---------------------------------------------------------------------------

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -910,3 +910,26 @@ is nonempty."
   "Close the window containing the '*compilation*' buffer."
   (interactive)
   (delete-windows-on "*compilation*"))
+
+(defun spacemacs//set-evil-shift-width ()
+  "Set the value of `evil-shift-width' based on the indentation settings of the
+current major mode."
+  (let ((shift-width
+         (catch 'break
+           (dolist (test spacemacs--indent-variable-alist)
+             (let ((mode (car test))
+                   (val (cdr test)))
+               (when (or (and (symbolp mode) (derived-mode-p mode))
+                         (and (listp mode) (apply 'derived-mode-p mode))
+                         (eq 't mode))
+                 (when (not (listp val))
+                   (setq val (list val)))
+                 (dolist (v val)
+                   (cond
+                    ((integerp v) (throw 'break v))
+                    ((and (symbolp v) (boundp v))
+                     (throw 'break (symbol-value v))))))))
+           (throw 'break (default-value 'evil-shift-width)))))
+    (when (and (integerp shift-width)
+               (< 0 shift-width))
+      (setq-local evil-shift-width shift-width))))

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -240,6 +240,12 @@
 
       (spacemacs/set-leader-keys "re" 'evil-show-registers)
 
+      ;; After major mode has changed, reset evil-shift-width
+      (add-hook 'after-change-major-mode-hook 'spacemacs//set-evil-shift-width 'append)
+
+      ;; It's better that the default value is too small than too big
+      (setq-default evil-shift-width 2)
+
       (defmacro evil-map (state key seq)
         "Map for a given STATE a KEY to a sequence SEQ of keys.
 


### PR DESCRIPTION
This is from my [`evil-shift-width`](https://github.com/TheBB/spacemacs-layers/blob/master/evil-shift-width/config.el) layer. I was planning on PRing this for a while but @mijoharas' [elixir PR](https://github.com/syl20bnr/spacemacs/pull/3846) got me off my ass.

The alist of indentation variables is mostly stolen from editorconfig, with a few additions of my own, as well as elixir (thanks to @mijoharas). There is a function in `after-change-major-mode-hook` which looks up the variable to use depending on the major mode. It falls back to the default value in case nothing can be found, which I have set in this PR to **2**, on the assumption that it's better to have it be too small than too big (the default value is **4**).

I've been using this layer for a good while and I've had no issues.

This partly addresses #3203.