### PR TITLE
helm-dash use default docsets path on macos

### DIFF
--- a/layers/+tools/dash/packages.el
+++ b/layers/+tools/dash/packages.el
@@ -15,8 +15,9 @@
     :config
     (defun dash//activate-package-docsets (path)
       "Add dash docsets from specified PATH."
-      (setq helm-dash-docsets-path path
-            helm-dash-common-docsets (helm-dash-installed-docsets))
+      (if (not (string-blank-p path))
+          (setq helm-dash-docsets-path path))
+      (setq helm-dash-common-docsets (helm-dash-installed-docsets))
       (message (format "activated %d docsets from: %s"
                        (length helm-dash-common-docsets) path)))
     (dash//activate-package-docsets dash-helm-dash-docset-path)))


### PR DESCRIPTION
If we don't use the default docksets, helm-dash will not work smoothly
unless we set the `dash-helm-dash-docset-path' variable when we import
the dash layer(actually, the default dash docset path is always
"~/Library/Application Support/Dash/DocSets"). Mostly, we don't need to set this variable.