### PR TITLE
helm-dash use default docsets path on macos

### DIFF
--- a/layers/+tools/dash/README.org
+++ b/layers/+tools/dash/README.org
@@ -83,4 +83,4 @@ Or you can use [[https://github.com/areina/helm-dash][helm-dash]] instead, it re
 CLOSED: [2015-06-12 Fri 16:30]
 [[http://zealdocs.org/][zeal]] is an open source alternative to dash with Emacs integration available.
 
-** TODO Make helm-dash use zeal or dash docsets by default.
+** DONE Make helm-dash use zeal or dash docsets by default.

--- a/layers/+tools/dash/packages.el
+++ b/layers/+tools/dash/packages.el
@@ -15,8 +15,9 @@
     :config
     (defun dash//activate-package-docsets (path)
       "Add dash docsets from specified PATH."
-      (setq helm-dash-docsets-path path
-            helm-dash-common-docsets (helm-dash-installed-docsets))
+      (if (not (string-blank-p path))
+          (setq helm-dash-docsets-path path))
+      (setq helm-dash-common-docsets (helm-dash-installed-docsets))
       (message (format "activated %d docsets from: %s"
                        (length helm-dash-common-docsets) path)))
     (dash//activate-package-docsets dash-helm-dash-docset-path)))


### PR DESCRIPTION
If we don't use the default docsets, helm-dash will not work smoothly
unless we set the `dash-helm-dash-docset-path' variable when we import
the dash layer. Actually, the default dash docset path is always
"~/Library/Application Support/Dash/DocSets", if we must set it manually, that 
would be boring).
This is no docset-path like variable in zeal-at-point, so everything is just OK.
