### PR TITLE
emoji layer company-emoji font support

### DIFF
--- a/layers/+fun/emoji/README.org
+++ b/layers/+fun/emoji/README.org
@@ -26,6 +26,11 @@ To use this contribution add it to your =~/.spacemacs=
   (setq-default dotspacemacs-configuration-layers '(emoji))
 #+END_SRC
 
+Linux user could install [[https://zhm.github.io/symbola/][Symbola]] font to get company-emoji support with =apt-get=
+
+#+BEGIN_SRC shell
+  apt-get install ttf-ancient-fonts
+#+END_SRC
 * Key bindings
 
 | Key Binding | Description                             |

--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -44,14 +44,16 @@
         (setq company-emoji-insert-unicode nil)
         ;; From https://github.com/dunn/company-emoji/README.md for Linux, or on Mac OS X and using the Cocoa version of Emacs
         (defun --set-emoji-font (frame)
-          "Adjust the font settings of FRAME so Emacs can display emoji properly."
-          (if (eq system-type 'darwin)
-              ;; For NS/Cocoa
-              (set-fontset-font t 'symbol (font-spec :family "Apple Color Emoji") frame 'prepend)
-            ;; For Linux
-            (set-fontset-font t 'symbol (font-spec :family "Symbola") frame 'prepend)))
+          "Adjust the font settings of FRAME so Emacs can display emoji properly.Only works in GUI mode"
+          (when (display-graphic-p)
+            (cond
+             ;; For NS/Cocoa
+             ((spacemacs/system-is-mac)
+              (set-fontset-font t 'symbol (font-spec :family "Apple Color Emoji") frame 'prepend))
+             ;; For Linux
+             ((spacemacs/system-is-linux)
+              (set-fontset-font t 'symbol (font-spec :family "Symbola") frame 'prepend)))))
 
-        ;; For when Emacs is started in GUI mode:
         (--set-emoji-font nil)
         ;; Hook for when a frame is created with emacsclient
         ;; see https://www.gnu.org/software/emacs/manual/html_node/elisp/Creating-Frames.html

--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -39,4 +39,21 @@
     (use-package company-emoji
       :if (configuration-layer/package-usedp 'company)
       :defer t
-      :init (setq company-emoji-insert-unicode nil))))
+      :init
+      (progn
+        (setq company-emoji-insert-unicode nil)
+        ;; From https://github.com/dunn/company-emoji/README.md for Linux, or on Mac OS X and using the Cocoa version of Emacs
+        (defun --set-emoji-font (frame)
+          "Adjust the font settings of FRAME so Emacs can display emoji properly."
+          (if (eq system-type 'darwin)
+              ;; For NS/Cocoa
+              (set-fontset-font t 'symbol (font-spec :family "Apple Color Emoji") frame 'prepend)
+            ;; For Linux
+            (set-fontset-font t 'symbol (font-spec :family "Symbola") frame 'prepend)))
+
+        ;; For when Emacs is started in GUI mode:
+        (--set-emoji-font nil)
+        ;; Hook for when a frame is created with emacsclient
+        ;; see https://www.gnu.org/software/emacs/manual/html_node/elisp/Creating-Frames.html
+        (add-hook 'after-make-frame-functions '--set-emoji-font)
+        ))))


### PR DESCRIPTION
Font support for company-emoji on Linux or on Mac OS X and using the Cocoa version of Emacs.
See https://github.com/dunn/company-emoji/blob/master/README.md
