### PR TITLE
Add ipython-notebook insert mode bindings also to hybrid mode

### DIFF
--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -114,6 +114,11 @@
         (kbd "<C-return>") 'ein:worksheet-execute-cell
         (kbd "<S-return>") 'ein:worksheet-execute-cell-and-goto-next)
 
+      ;; keybindings mirror ipython web interface behavior
+      (evil-define-key 'hybrid ein:notebook-multilang-mode-map
+        (kbd "<C-return>") 'ein:worksheet-execute-cell
+        (kbd "<S-return>") 'ein:worksheet-execute-cell-and-goto-next)
+
       (evil-define-key 'normal ein:notebook-multilang-mode-map
         ;; keybindings mirror ipython web interface behavior
         (kbd "<C-return>") 'ein:worksheet-execute-cell


### PR DESCRIPTION
In insert mode the following key bindings are defined:

| Key | Function |
| --- | --- |
| C-RET | ein:worksheet-execute-cell |
| S-RET | ein:worksheet-execute-cell-and-goto-next |

This pull request adds support for those also in hybrid mode.
