### PR TITLE
core: don’t warn about equal owners

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -270,8 +270,9 @@ Properties that can be copied are `:location', `:step' and `:excluded'."
                 (push obj result))
               (when (fboundp init-func)
                 ;; last owner wins over the previous one,
-                ;; still warn about mutliple owners
-                (when (oref obj :owner)
+                ;; still warn about multiple owners
+                (when (and (oref obj :owner)
+                           (not (eq name (oref obj :owner))))
                   (spacemacs-buffer/warning
                    (format (concat "More than one init function found for "
                                    "package %S. Previous owner was %S, "


### PR DESCRIPTION
`helm-spacemacs` started generating these warnings. In any case I don't think it makes sense to warn when the owners aren't different.