### PR TITLE
[WIP] Add vim-like alternatives to emacs `C-c …` bindings

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -61,6 +61,25 @@
     'universal-argument-more))
 ;; shell command  -------------------------------------------------------------
 (evil-leader/set-key "!" 'shell-command)
+;; evil-leader aliases for emacs bindings
+(defmacro spacemacs|emacs-binding-aliases (binding &rest evil-aliases)
+  "Define some EVIL-LEADER aliases for an emacs BINDING."
+  (let* ((binding-name (format
+                        "emacs-binding-alias-%s"
+                        (downcase (replace-regexp-in-string " " "-" binding))))
+         (binding-func (intern (format "spacemacs/%s" binding-name)))
+         (binding-regex (format "\\`%s\\'" binding-name)))
+    `(progn
+       (defun ,binding-func ()
+         (interactive)
+         (setq unread-command-events (listify-key-sequence (kbd ,binding))))
+       (dolist (evil-alias ',evil-aliases)
+         (evil-leader/set-key evil-alias ',binding-func))
+       (push '(,binding-regex . ,binding)
+             which-key-description-replacement-alist))))
+(which-key-declare-prefixes "SPC ." "C-c bindings")
+(spacemacs|emacs-binding-aliases "C-c C-c" ".." ".c")
+(spacemacs|emacs-binding-aliases "C-c C-k" ".k")
 ;; applications ---------------------------------------------------------------
 (evil-leader/set-key
   "ac"  'calc-dispatch

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -78,8 +78,11 @@
        (push '(,binding-regex . ,binding)
              which-key-description-replacement-alist))))
 (which-key-declare-prefixes "SPC ." "C-c bindings")
-(spacemacs|emacs-binding-aliases "C-c C-c" ".." ".c")
-(spacemacs|emacs-binding-aliases "C-c C-k" ".k")
+(dolist (letter (mapcar 'string (number-sequence ?a ?z)))
+  (let ((binding (concat "C-c C-" letter))
+        (evil-aliases (concat "." letter)))
+    (spacemacs|emacs-binding-aliases binding evil-aliases)))
+(spacemacs|emacs-binding-aliases "C-c C-c" "..")
 ;; applications ---------------------------------------------------------------
 (evil-leader/set-key
   "ac"  'calc-dispatch

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -79,9 +79,8 @@
              which-key-description-replacement-alist))))
 (which-key-declare-prefixes "SPC ." "C-c bindings")
 (dolist (letter (mapcar 'string (number-sequence ?a ?z)))
-  (let ((binding (concat "C-c C-" letter))
-        (evil-aliases (concat "." letter)))
-    (spacemacs|emacs-binding-aliases binding evil-aliases)))
+  (eval
+   `(spacemacs|emacs-binding-aliases ,(concat "C-c C-" letter) ,(concat "." letter))))
 (spacemacs|emacs-binding-aliases "C-c C-c" "..")
 ;; applications ---------------------------------------------------------------
 (evil-leader/set-key


### PR DESCRIPTION
This commit adds `SPC .` as a prefix for `C-c bindings`, and binds a few
useful ones like `C-c C-c` and `C-c C-k` (for now). It uses a simple
macro and adding new `C-c` bindings is easy.

These bindings (i.e. `C-c C-c`, `C-c C-k`, …) are useful in some modes,
like for instance in magit to valid or cancel a commit. Vim-like
alternative bindings are missing for this, this commit try to correct
this in a general way.