### PR TITLE
elm: define key binding prefixes for major mode

### DIFF
--- a/layers/+lang/elm/config.el
+++ b/layers/+lang/elm/config.el
@@ -11,3 +11,13 @@
 ;;; License: GPLv3
 
 (spacemacs|defvar-company-backends elm-mode)
+
+(setq elm/key-binding-prefixes '(("mR" . "reactor")
+                                 ("mc" . "compile")
+                                 ("mh" . "help")
+                                 ("mp" . "package")
+                                 ("ms" . "repl")))
+
+(mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                   'elm-mode (car x) (cdr x)))
+      elm/key-binding-prefixes)


### PR DESCRIPTION
The hints for the elm-mode bindings weren't labelled. I've added the labels that I think fit.

Looking at other language layers, there doesn't seem to be a standard on whether this should be done in the `config.el` or the `package.el`, but config seems most common.