### PR TITLE
[haskell] fallback to interactive mode

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -109,6 +109,8 @@
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)
       (add-hook 'haskell-cabal-mode-hook 'haskell-cabal-hook)
+      (unless haskell-enable-ghc-mod-support
+        (add-hook 'haskell-mode-hook 'interactive-haskell-mode))
 
       ;; prefixes
       (spacemacs/declare-prefix-for-mode 'haskell-mode "mg" "haskell/navigation")


### PR DESCRIPTION
When user disabled ghc-mod, haskell mode should fallback to interactive
mode, so type bindings (and some others) are working properly. It's also
useful for ghci-ng users, but doesn't affect ghci-ng-only bindings.

Fix #3777