### PR TITLE
Fix type error in package-archives

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -24,9 +24,9 @@
 (require 'core-spacemacs-buffer)
 
 (unless package--initialized
-  (let ((archives '((melpa . "melpa.org/packages/")
-                    ("org" . "orgmode.org/elpa/")
-                    ("gnu" . "elpa.gnu.org/packages/"))))
+  (let ((archives '(("melpa" . "melpa.org/packages/")
+                    ("org"   . "orgmode.org/elpa/")
+                    ("gnu"   . "elpa.gnu.org/packages/"))))
     (setq package-archives
           (mapcar (lambda (x)
                     (cons (car x) (concat


### PR DESCRIPTION
The archive name must be a name.

Fixes `SPC a P`.