### PR TITLE
layers: Fix missing owner for some layers

### DIFF
--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -8,6 +8,8 @@
 (defun nim/post-init-company ()
   (spacemacs|add-company-hook nim-mode))
 
+(defun nim/init-company-nim ())
+
 (defun nim/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'nim-mode))
 

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -1,7 +1,7 @@
 (setq racket-packages
   '(
     company
-    company-quickhelp-mode
+    company-quickhelp
     racket-mode
     ))
 

--- a/layers/semantic/packages.el
+++ b/layers/semantic/packages.el
@@ -10,15 +10,13 @@
 ;;
 ;;; License: GPLv3
 
-(defvar semantic-packages
-  '(
-    ;; package semantic go here
-    semantic
-    srefactor
-    stickyfunc-enhance
-    )
-  "List of all packages to install and/or initialize. Built-in packages
-which require an initialization must be listed explicitly in the list.")
+(setq semantic-packages
+      '(
+        ;; package semantic go here
+        semantic
+        ;; srefactor
+        stickyfunc-enhance
+        ))
 
 (unless (version< emacs-version "24.4")
   (add-to-list 'semantic-packages 'srefactor))


### PR DESCRIPTION
This is a partial fix for #3493. I didn't touch layers where I can't
tell what the intention was for how it should work.

I'm not sure what's going on with javascript, react, html, etc. This brings the list of nil layer packages for me down to
 - company-tern
 - ielm
 - js-doc
 - js2-doc
 - js2-refactor
 - tern
 - web-beautify
 - web-mode