### PR TITLE
Changed hotkeys for processes and packages. Fixes #3507.

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -65,7 +65,8 @@
 (evil-leader/set-key
   "ac"  'calc-dispatch
   "ad"  'dired
-  "ap"  'proced
+  "ap"  'list-processes
+  "aP"  'proced
   "au"  'undo-tree-visualize)
 ;; buffers --------------------------------------------------------------------
 (evil-leader/set-key

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1660,7 +1660,7 @@ It will toggle the overlay under point or create an overlay of one character."
                                  "L" 'paradox-menu-view-commit-list
                                  "o" 'paradox-menu-visit-homepage))
       (evil-leader/set-key
-        "aP" 'spacemacs/paradox-list-packages))))
+        "a\\" 'spacemacs/paradox-list-packages))))
 
 (defun spacemacs/init-rainbow-delimiters ()
   (use-package rainbow-delimiters


### PR DESCRIPTION
This commit changes:
<leader> a p from proced to list-processes
<leader> a P from paradox-list-packages to proced
and <leader> a \ to paradox-list-packages.