### PR TITLE
Added check to catch when org has already been loaded.

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -216,8 +216,8 @@ values."
 
 (defun dotspacemacs/user-init ()
   "Initialization function for user code.
-It is called immediately after `dotspacemacs/init'.  You are free to put any
-user code."
+It is called immediately after `dotspacemacs/init'.  You are free to put almost any
+user code here. The exception is org related code, which should be placed in dotspacemacs/user-config."
   )
 
 (defun dotspacemacs/user-config ()

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -41,6 +41,8 @@ Since version 0.104, spacemacs uses the `org` version from the org ELPA
 repository instead of the one shipped with emacs. Then, any `org` related code
 should not be loaded before `dotspacemacs/user-config`, otherwise both versions
 will be loaded and will conflict.
+Org layer checks if this has occurred and signals an error if org features have
+been instantiated prior to org layer loading.
 
 * Install
 ** Layer

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -79,6 +79,11 @@
     :defer t
     :init
     (progn
+      (when (member 'org features)
+        (configuration-layer//set-error)
+        (spacemacs-buffer/append
+         "Org features have been loaded before the spacemacs org layer has initialised. \nTry removing org code from user initialisation and private layers." t
+         ))
       (setq org-clock-persist-file
             (concat spacemacs-cache-directory "org-clock-save.el")
             org-id-locations-file


### PR DESCRIPTION
fixes #3742 
Adding a check and error signal to the org layer seemed the easiest method, given that it's ok to use the builtin org if you haven't enabled the org layer, however rare that might be.
I wasn't sure about using a spacemacs error signal but it's a cool feature.