### PR TITLE
Disabled automatic eldoc-mode in scala layer

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -10,6 +10,7 @@
    - [[Installation][Installation]]
    - [[Usage][Usage]]
  - [[Scalastyle][Scalastyle]]
+ - [[Automatically show the type of the symbol under the cursor][Automatically show the type of the symbol under the cursor]]
  - [[Key bindings][Key bindings]]
    - [[Ensime key bindings][Ensime key bindings]]
      - [[Search][Search]]
@@ -83,6 +84,17 @@ To use scalastyle,
    the jar.
    
 See the [[http://flycheck.readthedocs.org/en/latest/guide/languages.html#el.flycheck-checker.scala-scalastyle][flycheck documentation]] for up-to-date configuration instructions.
+
+* Automatically show the type of the symbol under the cursor
+
+To enable the feature =ensime-print-type-at-point= when cursor moves, set the variable =scala-enable-eldoc-mode= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (scala :variables scala-enable-eldoc-mode t)))
+#+END_SRC
+
+Enabling this option can cause slow editor performance.
 
 * Key bindings
 

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -1,0 +1,2 @@
+(defvar scala-enable-eldoc-mode nil
+  "If non nil then eldoc-mode is enabled in the scala layer")

--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -49,7 +49,8 @@
               (lambda ()
                 (when (ensime-connected-p)
                   (ensime-print-type-at-point))))
-  (eldoc-mode +1))
+  (when scala-enable-eldoc-mode
+    (eldoc-mode +1)))
 
 (defun spacemacs/ensime-refactor-accept ()
   (interactive)


### PR DESCRIPTION
A conf var is provided to enable it automatically.
Default is null.

## Problem:
In the following commit https://github.com/lululau/spacemacs/commit/c12590877646d8b20b2d80b6aeea7048312878d3 a change was introduced to automatically enabled ```eldoc`` which is causing a weird behavior when moving between lines.

Every time cursor moves (hjkl) the ensime function *Show the type of the symbol under the cursor* ```ensime-print-type-at-point``` is called, which cause slow performance.
![image](http://i.imgur.com/2bhFrgl.gif)


There is already a shortcut to manually call the function ```ensime-print-type-at-point```, so there is not need to do it every time you move the cursor.
```
It is bound to M-RET h t, , h t, M-m m h t, SPC m h t, C-c C-v t.
```

In my PR a var is created to enabled the previous behavior.
```
  (setq scala-enable-eldoc-mode t)
```