### PR TITLE
add in variable to skip version check for spacemacs

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -80,6 +80,9 @@ banner, `random' chooses a random text banner in `core/banners'
 directory. A string value must be a path to a .PNG file.
 If the value is nil then no banner is displayed.")
 
+(defvar dotspacemacs-version-check-enable t
+  "If non-nil then enable checking for new versions of spacemacs")
+
 (defvar dotspacemacs-configuration-layers '(emacs-lisp)
   "List of configuration layers to load. If it is the symbol `all' instead
 of a list then all discovered layers will be installed.")

--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -74,29 +74,31 @@ users on `develop' branch must manually pull last commits instead."
   "Periodicly check for new for new Spacemacs version.
 Update `spacemacs-new-version' variable if any new version has been
 found."
-  (if (string-equal "develop" (spacemacs/git-get-current-branch))
-      (message "Skipping check for new version because you are on develop.")
-    (message "Start checking for new version...")
-    (async-start
-     `(lambda ()
-        ,(async-inject-variables "\\`user-emacs-directory\\'")
-        (load-file (concat user-emacs-directory "core/core-load-paths.el"))
-        (require 'core-spacemacs)
-        (spacemacs/get-last-version))
-     (lambda (result)
-       (if result
-           (if (or (version< result spacemacs-version)
-                   (string= result spacemacs-version)
-                   (if spacemacs-new-version
-                       (string= result spacemacs-new-version)))
-               (message "Spacemacs is up to date.")
-             (message "New version of Spacemacs available: %s" result)
-             (setq spacemacs-new-version result))
-         (message "Unable to check for new version."))))
-    (when interval
-      (setq spacemacs-version-check-timer
-            (run-at-time t (timer-duration interval)
-                         'spacemacs/check-for-new-version)))))
+  (if (not dotspacemacs-version-check-enable)
+      (message "Skipping check for new version because dotspacemacs-version-check-enable nil")
+    (if (string-equal "develop" (spacemacs/git-get-current-branch))
+        (message "Skipping check for new version because you are on develop.")
+      (message "Start checking for new version...")
+      (async-start
+       `(lambda ()
+          ,(async-inject-variables "\\`user-emacs-directory\\'")
+          (load-file (concat user-emacs-directory "core/core-load-paths.el"))
+          (require 'core-spacemacs)
+          (spacemacs/get-last-version))
+       (lambda (result)
+         (if result
+             (if (or (version< result spacemacs-version)
+                     (string= result spacemacs-version)
+                     (if spacemacs-new-version
+                         (string= result spacemacs-new-version)))
+                 (message "Spacemacs is up to date.")
+               (message "New version of Spacemacs available: %s" result)
+               (setq spacemacs-new-version result))
+           (message "Unable to check for new version."))))
+      (when interval
+        (setq spacemacs-version-check-timer
+              (run-at-time t (timer-duration interval)
+                           'spacemacs/check-for-new-version))))))
 
 (defun spacemacs/get-last-version ()
   "Return the last tagged version."

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -62,6 +62,8 @@ values."
    ;; environment, otherwise it is strongly recommended to let it set to t.
    ;; (default t)
    dotspacemacs-elpa-https t
+   ;; If non nil then checking for updates is enabled (default t)
+   dotspacemacs-version-check-enable t
    ;; One of `vim', `emacs' or `hybrid'. Evil is always enabled but if the
    ;; variable is `emacs' then the `holy-mode' is enabled at startup. `hybrid'
    ;; uses emacs key bindings for vim's insert mode, but otherwise leaves evil
@@ -80,6 +82,8 @@ values."
    ;; Possible values are: `recents' `bookmarks' `projects'.
    ;; (default '(recents projects))
    dotspacemacs-startup-lists '(recents projects)
+   ;; If non nil then checking for updates is enabled
+   dotspacemacs-version-check-enable t
    ;; Number of recent files to show in the startup buffer. Ignored if
    ;; `dotspacemacs-startup-lists' doesn't include `recents'. (default 5)
    dotspacemacs-startup-recent-list-size 5


### PR DESCRIPTION
Referring to Spacemacs issues:

How to disable fetching new package repository indexes (internet update packages) #3438
disable automatic update check #3526

My first proposed patch to spacemacs which allows a user can set an override in their .spacemacs file to disable spacemacs from checking for new versions of itself. Works similarly to how the "develop" branch check works but supersedes that one.

dotspacemacs-version-check-enable t
;; If non nil then checking for updates is enabled
