### PR TITLE
Add ability to **add** a layer in helm-spacemacs

### DIFF
--- a/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
+++ b/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
@@ -143,6 +143,7 @@
   `((name . "Layers")
     (candidates . ,(sort (configuration-layer/get-layers-list) 'string<))
     (candidate-number-limit)
+    (keymap . ,helm-spacemacs--layer-map)
     (action . (("Open README.org"
                 . helm-spacemacs//layer-action-open-readme)
                ("Open packages.el"
@@ -150,8 +151,19 @@
                ;; TODO remove extensions in 0.105.0
                ("Open extensions.el"
                 . helm-spacemacs//layer-action-open-extensions)
+               ("Add Layer"
+                . helm-spacemacs//layer-action-add-layer)
                ("Open README.org (for editing)"
                 . helm-spacemacs//layer-action-open-readme-edit)))))
+
+(defvar helm-spacemacs--layer-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map helm-map)
+    (define-key map (kbd "<S-return>") '(lambda () (interactive)
+                                          ;; Add Layer
+                                          (helm-select-nth-action 3)))
+    map)
+  "Keymap for Spacemacs Layers sources")
 
 (defun helm-spacemacs//package-source ()
   "Construct the helm source for the packages."
@@ -234,6 +246,20 @@
 (defun helm-spacemacs//layer-action-open-readme (candidate)
   "Open the `README.org' file of the passed CANDIDATE for reading."
   (helm-spacemacs//layer-action-open-file "README.org" candidate))
+
+(defun helm-spacemacs//layer-action-add-layer (candidate)
+  "Adds layer to dotspacemacs file and reloads configuration"
+  (if (configuration-layer/layer-usedp (intern candidate))
+      (message "Layer already added.")
+    (let ((dotspacemacs   (find-file-noselect (dotspacemacs/location))))
+      (with-current-buffer dotspacemacs
+        (beginning-of-buffer)
+        (let ((insert-point (re-search-forward
+                             "dotspacemacs-configuration-layers *\n?.*\\((\\)")))
+          (insert (format "\n%s\n" candidate))
+          (indent-region insert-point (+ insert-point (length candidate)))
+          (save-current-buffer)))
+      (dotspacemacs/sync-configuration-layers))))
 
 (defun helm-spacemacs//layer-action-open-readme-edit (candidate)
   "Open the `README.org' file of the passed CANDIDATE for editing."


### PR DESCRIPTION
I've been introducing tons of people to Spacemacs, and most of them
always think that having to read documentation in how to add a layer is
too much.

I made this modification to make it easier to install layers.

Using Shift+Return...I'm hopeful there are other ways of doing this that are more pretty....I'm open to suggestions.