### PR TITLE
osx layer: Set sensible Emoji font

### DIFF
--- a/layers/osx/config.el
+++ b/layers/osx/config.el
@@ -1,3 +1,8 @@
 (defvar osx-use-option-as-meta t
   "If non nil the option key is mapped to meta. Set to `nil` if you need the
   option key to type common characters.")
+
+;; Use the OS X Emoji font for Emoticons
+(set-fontset-font "fontset-default"
+                  '(#x1F600 . #x1F64F)
+                  (font-spec :name "Apple Color Emoji") nil 'prepend)


### PR DESCRIPTION
On default settings the Emoji unicode characters won't show up when using the Cocoa version. This PR fixes this.