### PR TITLE
mu4e layer: Convenient navigation bindings

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -4,6 +4,9 @@
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Install][Install]]
  - [[Commands][Commands]]
+   - [[Global bindings][Global bindings]]
+   - [[Headers mode][Headers mode]]
+   - [[View mode][View mode]]
  - [[Configuration][Configuration]]
    - [[Maildirs extension][Maildirs extension]]
    - [[Multiple Accounts][Multiple Accounts]]
@@ -28,9 +31,27 @@ existing =dotspacemacs-configuration-layers= list in this file.
 
 * Commands
 
+** Global bindings
+
 | Keybinding | Command    |
 |------------+------------|
 | SPC a M    | Start mu4e |
+
+** Headers mode
+
+| Keybinding | Command                                                     |
+|------------+-------------------------------------------------------------|
+| J          | Go to next unread thread marking other mail read on the way |
+| C-j        | Next header                                                 |
+| C-k        | Previous header                                             |
+
+** View mode
+
+| Keybinding | Command                                                     |
+|------------+-------------------------------------------------------------|
+| J          | Go to next unread thread marking other mail read on the way |
+| C-j        | Next header                                                 |
+| C-k        | Previous header                                             |
 
 * Configuration
 Configuration varies too much to give precise instructions.  What follows is one

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -29,10 +29,26 @@
         :mode mu4e-main-mode
         :bindings
         (kbd "j") 'mu4e~headers-jump-to-maildir)
-      (evilified-state-evilify-map mu4e-headers-mode-map
-        :mode mu4e-headers-mode)
-      (evilified-state-evilify-map mu4e-view-mode-map
-        :mode mu4e-view-mode)
+
+      (evilified-state-evilify-map
+       mu4e-headers-mode-map
+       :mode mu4e-headers-mode
+       :bindings
+       (kbd "C-j") 'mu4e-headers-next
+       (kbd "C-k") 'mu4e-headers-prev
+       (kbd "J") (lambda ()
+                   (interactive)
+                   (mu4e-headers-mark-thread nil '(read))))
+
+      (evilified-state-evilify-map
+       mu4e-view-mode-map
+       :mode mu4e-view-mode
+       :bindings
+       (kbd "C-j") 'mu4e-view-headers-next
+       (kbd "C-k") 'mu4e-view-headers-prev
+       (kbd "J") (lambda ()
+                   (interactive)
+                    (mu4e-view-mark-thread '(read))))
 
       (setq mu4e-completing-read-function
             (if (configuration-layer/layer-usedp 'spacemacs-ivy)


### PR DESCRIPTION
I think the evilification of mu4e maps makes the common navigation bindings cumbersome. This PR introduces `C-j` and `C-k` for next/prev navigation in the view-mode. View-mode is read-only, so the overridden bindings aren't needed.

I also added a binding in both headers and view mode for jumping to the next unread thread marking all other mails on the way read. This is my primary means of processing high volume mailing lists.