### PR TITLE
Fix major mode bindings for finance layer.

### DIFF
--- a/layers/finance/packages.el
+++ b/layers/finance/packages.el
@@ -32,19 +32,19 @@
       (setq ledger-post-amount-alignment-column 62)
       (push 'company-capf company-backends-ledger-mode)
       (spacemacs/set-leader-keys-for-major-mode 'ledger-mode
-         "mhd" 'ledger-delete-current-transaction
-         "ma" 'ledger-add-transaction
-         "mb" 'ledger-post-edit-amount
-         "mc" 'ledger-toggle-current
-         "mC" 'ledger-mode-clean-buffer
-         "ml" 'ledger-display-ledger-stats
-         "mp" 'ledger-display-balance-at-point
-         "mq" 'ledger-post-align-xact
-         "mr" 'ledger-reconcile
-         "mR" 'ledger-report
-         "mt" 'ledger-insert-effective-date
-         "my" 'ledger-set-year
-         "m RET" 'ledger-set-month)
+         "hd" 'ledger-delete-current-transaction
+         "a" 'ledger-add-transaction
+         "b" 'ledger-post-edit-amount
+         "c" 'ledger-toggle-current
+         "C" 'ledger-mode-clean-buffer
+         "l" 'ledger-display-ledger-stats
+         "p" 'ledger-display-balance-at-point
+         "q" 'ledger-post-align-xact
+         "r" 'ledger-reconcile
+         "R" 'ledger-report
+         "t" 'ledger-insert-effective-date
+         "y" 'ledger-set-year
+         "RET" 'ledger-set-month)
       (evilified-state-evilify ledger-report-mode ledger-report-mode-map))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)


### PR DESCRIPTION
Key definitions no longer need to be prefixed with "m".