### PR TITLE
Javascript mode: Add prefix names for "text" bindings

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -165,6 +165,9 @@
         (spacemacs/set-leader-keys-for-major-mode mode "rwl" 'js2r-wrap-in-for-loop)
 
         (spacemacs/set-leader-keys-for-major-mode mode "k" 'js2r-kill)
+
+        (spacemacs/declare-prefix-for-mode mode "mx" "text")
+        (spacemacs/declare-prefix-for-mode mode "mxm" "move")
         (spacemacs/set-leader-keys-for-major-mode mode "xmj" 'js2r-move-line-down)
         (spacemacs/set-leader-keys-for-major-mode mode "xmk" 'js2r-move-line-up))
 


### PR DESCRIPTION
The names for the "mx" ("text") and "mxm" ("move") prefixes are not defined.
I've defined them in the same style as the other prefixes in the `packages.el`.

Is there a reason some(?) of the top level prefixes are defined differently in the `config.el`? Should these be moved into `packages.el`, or should I have defined "mx" in `config.el` instead?