### PR TITLE
evil-lisp-state loading bug

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -591,7 +591,7 @@
                 ;; TODO work-around to be removed when the fix is available in
                 ;; MELPA
                 evil-lisp-state-leader (concat dotspacemacs-leader-key " k"))
-    :config (evil-lisp-state-leader (concat dotspacemacs-leader-key " k"))))
+    :config (setq evil-lisp-state-leader (concat dotspacemacs-leader-key " k"))))
 
 (defun spacemacs/init-evil-mc ()
   (use-package evil-mc


### PR DESCRIPTION
I get this on startup, recent develop:

Error (use-package): evil-lisp-state :config: Symbol's function definition is void: evil-lisp-state-leader

Looks like a typo.