### PR TITLE
elm: fixed misnamed function in repl bindings

### DIFF
--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -81,7 +81,7 @@
         ;; repl
         "si" 'elm-repl-load
         "sf" 'elm-repl-push-decl
-        "sF" 'spacemacs/elm-repl-push-decl
+        "sF" 'spacemacs/elm-repl-push-decl-focus
         "sr" 'elm-repl-push
         "sR" 'spacemacs/elm-repl-push-focus
 


### PR DESCRIPTION
When pull request #3855 was cherry picked in (due to conflicts),
spacemacs/elm-repl-push-decl-focus was incorreclty referenced as
spacemacs/elm-repl-push-decl in the keybindings.