### PR TITLE
Make --nocapture optional for nosetests

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -72,6 +72,22 @@ directory local variable in your project root. ~SPC f v d~ in Spacemacs. See
 
 The root of the project is detected with a =.git= directory or a =setup.cfg= file.
 
+By default, =nose= is run with =--nocapture= flag enabled. This can be changed
+by setting the layer variable =nose-capture= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((python :variables nose-capture t)))
+#+END_SRC
+
+The verbosity of =nose= can be changed with =nose-use-verbose=, which is true by
+default. To make =nose= less verbose, it can be set to =nil=.
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((python :variables nose-use-verbose nil)))
+#+END_SRC
+
 ** Anaconda dependencies
 =anaconda-mode= tries to install the dependencies itself but sometimes
 it does not work and you may encounter the following message when

--- a/layers/+lang/python/local/nose/nose.el
+++ b/layers/+lang/python/local/nose/nose.el
@@ -61,6 +61,7 @@
                                   ".git"))
 (defvar nose-project-root-test 'nose-project-root)
 (defvar nose-use-verbose t)
+(defvar nose-capture nil)
 
 (defun run-nose (&optional tests suite debug failed)
   "run nosetests by calling python instead of nosetests script.
@@ -88,7 +89,9 @@ For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-fro
              (format
               (concat "%s "
                       (if nose-use-verbose "-v " "")
-                      "%s -s -w \"%s\" -c \"%ssetup.cfg\" \"%s\"")
+                      "%s "
+                      (if nose-capture "" "-s ")
+                      "-w \"%s\" -c \"%ssetup.cfg\" \"%s\"")
               nose args where where tnames)))
   )
 


### PR DESCRIPTION
There was a hard-coded switch `-s` for nosetests. This commit makes the
switch optional. One can toggle it with `nose-nocapture` variable. The
default behaviour is to use `nocapture` as before.

To disable `--nocapture`, one can use Python layer as:

```
(python :variables
        nose-nocapture nil)
```
