### PR TITLE
FIX: spacemacs|evilify-map wrecks the magit-delete-thing magic

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -121,7 +121,10 @@
       ;; seems to be necessary at the time of release
       (require 'git-rebase)
       ;; mode maps
-      (spacemacs|evilify-map magit-mode-map)
+      (spacemacs|evilify-map magit-mode-map
+        :bindings
+        ;; `spacemacs|evilify-map' wrecks the `magit-delete-thing' magic.
+        (kbd "K") 'magit-delete-thing)
       (spacemacs|evilify-map magit-status-mode-map
         :mode magit-status-mode
         :bindings


### PR DESCRIPTION
Magit depends on remapping `magit-delete-thing' to various other functions. spacemacs|evilify-map breaks the magic. This patch brings the magic back.

:)