### PR TITLE
Add key binding for going back in anaconda mode

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -167,6 +167,7 @@ Test commands start with ~m t~:
 | ~SPC m d b~ | toggle a breakpoint                                                          |
 | ~SPC m g g~ | go to definition using =anaconda-mode-find-definitions= (~C-o~ to jump back) |
 | ~SPC m g a~ | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back) |
+| ~SPC m g b~ | jump back                                                                    |
 | ~SPC m g u~ | navigate between usages with =anaconda-mode-find-references=                 |
 | ~SPC m h d~ | look for documentation using =helm-pydoc=                                    |
 | ~SPC m h h~ | quick documentation using anaconda                                           |

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -48,6 +48,7 @@
         "hh" 'anaconda-mode-show-doc
         "gg" 'anaconda-mode-find-definitions
         "ga" 'anaconda-mode-find-assignments
+        "gb" 'anaconda-mode-go-back
         "gu" 'anaconda-mode-find-references)
       (evilified-state-evilify anaconda-mode-view-mode anaconda-mode-view-mode-map
         (kbd "q") 'quit-window)


### PR DESCRIPTION
There are keybindings `C-o` and `M-*` to go back already, but it could
be a good idea to add an entry to `SPC m g` (or `, g`) menu where the
other movement commands are.

I'm open to other key binding suggestions if `b` under `SPC m g` is not good.