### PR TITLE
Disable typo-mode in LaTeX

### DIFF
--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -20,6 +20,7 @@
     flycheck
     flyspell
     smartparens
+    typo
     yasnippet
     ))
 
@@ -114,6 +115,12 @@
 
 (defun latex/post-init-smartparens ()
   (add-hook 'LaTeX-mode-hook 'smartparens-mode))
+
+(defun latex/post-init-typo ()
+  ;; Typo mode isn't useful for LaTeX.
+  (defun spacemacs//disable-typo-mode ()
+    (typo-mode -1))
+  (add-hook 'LaTeX-mode-hook 'spacemacs//disable-typo-mode))
 
 (defun latex/post-init-yasnippet ()
   (add-hook 'LaTeX-mode-hook 'spacemacs/load-yasnippet))

--- a/layers/typography/packages.el
+++ b/layers/typography/packages.el
@@ -25,8 +25,7 @@
     :init
     (progn
       (when typography-enable-typographic-editing
-        (dolist (hook '(text-mode-hook org-mode-hook))
-          (add-hook hook 'typo-mode)))
+        (add-hook 'text-mode-hook 'typo-mode))
 
       (spacemacs|add-toggle typographic-substitutions
         :status typo-mode


### PR DESCRIPTION
LaTeX has its own quirky ways of inputting these characters which typo-mode interferes with.

Also, org-mode derives from text-mode so no need to mention it explicitly.

cc @lunaryorn