### PR TITLE
Add bindings for magit-(un)stage-file

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -120,7 +120,9 @@
         "gi" 'magit-init
         "gl" 'magit-log-all
         "gL" 'magit-log-buffer-file
-        "gs" 'magit-status)
+        "gs" 'magit-status
+        "gf" 'magit-stage-file
+        "gF" 'magit-unstage-file)
 
       (spacemacs|define-micro-state git-blame
         :doc (concat "Press [b] again to blame further in the history, "


### PR DESCRIPTION
Add bindings for magit-(un)stage-file:

gf = magit-stage-file
gF = magit-unstage-file

These also complement the binding gc for magit-commit, which would commit all changes if nothing is staged.