### PR TITLE
declare-prefix-for-mode for all derived `clojure-mode`s.

### DIFF
--- a/layers/+lang/clojure/config.el
+++ b/layers/+lang/clojure/config.el
@@ -44,6 +44,12 @@
                                      ("mt" . "test")
                                      ("mT" . "toggle")
                                      ("mf" . "format")))
-(mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                   'clojure-mode (car x) (cdr x)))
-            clojure/key-binding-prefixes)
+
+(dolist (mode '(clojure-mode
+                clojurec-mode
+                clojurescript-mode
+                clojurex-mode
+                cider-repl-mode))
+  (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                     mode (car x) (cdr x)))
+        clojure/key-binding-prefixes))


### PR DESCRIPTION
Previously, prefixes only worked for `.clj` files, not `.cljs`, `.cljx`,
or `.cljc`. `clojure-mode.el` defines derived major modes for each of
those other filetypes.

In other parts of the clojure layer, `(dolist (m '(...` is used to apply
effects to all of the derived modes, but it was missing from the usage
of `spacemacs/declare-prefix-for-mode`.

`cider-repl-mode` was also added to this list.