### PR TITLE
Fixes #3902 - Remove rainbow-delimiters-mode from mode-specific hooks

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -7,7 +7,6 @@
     clojure-mode
     company
     popwin
-    rainbow-delimiters
     subword
    ))
 
@@ -389,10 +388,6 @@ If called with a prefix argument, uses the other-window instead."
           popwin:special-display-config)
     (push '("*cider-doc*" :dedicated t :position bottom :stick t :noselect nil :height 0.4)
           popwin:special-display-config)))
-
-(defun clojure/post-init-rainbow-delimiters ()
-  (if (configuration-layer/package-usedp 'cider)
-      (add-hook 'cider-mode-hook 'rainbow-delimiters-mode)))
 
 (defun clojure/post-init-subword ()
   (unless (version< emacs-version "24.4")

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -17,7 +17,6 @@
     ess-R-data-view
     ess-R-object-popup
     ess-smart-equals
-    rainbow-delimiters
     ))
 
 (defun ess/init-ess ()
@@ -53,6 +52,9 @@
     :commands (R stata julia SAS)
     :init
     (progn
+      ;; Explicitly run prog-mode hooks since ess-mode does not derive from
+      ;; prog-mode major-mode
+      (add-hook 'ess-mode-hook (lambda () (run-hooks 'prog-mode-hook)))
       (when (configuration-layer/package-usedp 'company)
           (add-hook 'ess-mode-hook 'company-mode))))
 
@@ -107,9 +109,6 @@
 (defun ess/init-ess-R-data-view ())
 
 (defun ess/init-ess-R-object-popup ())
-
-(defun ess/post-init-rainbow-delimiters ()
-  (add-hook 'ess-mode-hook #'rainbow-delimiters-mode))
 
 (defun ess/init-ess-smart-equals ()
   (use-package ess-smart-equals

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -22,7 +22,6 @@
     helm-css-scss
     jade-mode
     less-css-mode
-    rainbow-delimiters
     sass-mode
     scss-mode
     slim-mode
@@ -52,6 +51,10 @@
 
       ;; Mark `css-indent-offset' as safe-local variable
       (put 'css-indent-offset 'safe-local-variable #'integerp)
+
+      ;; Explicitly run prog-mode hooks since css-mode does not derive from
+      ;; prog-mode major-mode
+      (add-hook 'css-mode-hook (lambda () (run-hooks 'prog-mode-hook)))
 
       (defun css-expand-statement ()
         "Expand CSS block"
@@ -123,7 +126,11 @@
 
 (defun html/init-jade-mode ()
   (use-package jade-mode
-    :defer t))
+    :defer t
+    :init
+    ;; Explicitly run prog-mode hooks since jade-mode does not derivate from
+    ;; prog-mode major-mode
+    (add-hook 'jade-mode-hook (lambda () (run-hooks 'prog-mode-hook)))))
 
 (defun html/init-less-css-mode ()
   (use-package less-css-mode
@@ -174,13 +181,6 @@
       (tagedit-add-experimental-features)
       (add-hook 'html-mode-hook (lambda () (tagedit-mode 1)))
       (spacemacs|diminish tagedit-mode " Ⓣ" " T"))))
-
-(defun html/post-init-rainbow-delimiters ()
-  (spacemacs/add-to-hooks 'rainbow-delimiters-mode '(haml-mode-hook
-                                                     jade-mode-hook
-                                                     less-css-mode-hook
-                                                     scss-mode-hook
-                                                     slim-mode-hook)))
 
 (defun html/init-web-mode ()
   (use-package web-mode


### PR DESCRIPTION
`spacemacs` now handles `rainbow-delimiters-mode` by adding it to the
`prog-mode-hook`, if wanted by the user. Some layers are adding it on
their own mode-hook, having for effect that `rainbow-delimiters-mode` is
called twice, which disable it.

This commit remove these layer-specific definitions of
`rainbow-delimiters` as it is now handled by the `spacemacs`
distribution.

Fixes #3902