### PR TITLE
Note in README: customize dotfile *after* install

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please note: these homebrew commands will install Emacs, and link it to your
 the start of this file. That will populate your `~/.emacs.d` directory, which
 is what transforms a regular Emacs into Spacemacs.
 
-It is also recommended to add the [osx layer][] to your [dotfile][]:
+*After* you have completed the [install process below](#install), it is also recommended to add the [osx layer][] to your [dotfile][]:
 
 ```elisp
 (setq-default dotspacemacs-configuration-layers '(osx))


### PR DESCRIPTION
Prefix the "It is also recommended…" part of the Mac installation prerequisites with a note that this should be done *after* the basic install process.

This tripped me up and prevented initial installation. (The more detailed instructions and warnings added to Install since the current master will also help.)