### PR TITLE
Add support for org-links to the magit buffers

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -390,5 +390,4 @@ Will work on both org-mode and any mode that accepts plain html."
  (use-package htmlize
     :defer t))
 
-(defun org/init-orgit ()
-  (use-package orgit))
+(defun org/init-orgit ())

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -31,6 +31,7 @@
     org-repo-todo
     persp-mode
     toc-org
+    orgit
     ))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
@@ -387,4 +388,8 @@ Will work on both org-mode and any mode that accepts plain html."
 
 (defun org/init-htmlize ()
  (use-package htmlize
+    :defer t))
+
+(defun org/init-orgit ()
+  (use-package orgit
     :defer t))

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -391,5 +391,4 @@ Will work on both org-mode and any mode that accepts plain html."
     :defer t))
 
 (defun org/init-orgit ()
-  (use-package orgit
-    :defer t))
+  (use-package orgit))


### PR DESCRIPTION
Here link to the orgit package: https://github.com/magit/orgit

Still not confident about where this lines should be: in git layer or in org layer. But I think this package should be in default installation for users who use both org and git layers.