### PR TITLE
keys: Fix #3981

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -70,7 +70,8 @@
     (bind-map spacemacs-default-map
       :prefix-cmd spacemacs-cmds
       :keys (dotspacemacs-emacs-leader-key)
-      :evil-keys (dotspacemacs-leader-key))))
+      :evil-keys (dotspacemacs-leader-key)
+      :evil-use-local t)))
 
 (defun spacemacs-base/init-bookmark ()
   (use-package bookmark


### PR DESCRIPTION
Make bind-map use default behavior of evil-leader, which used local
state maps for global bindings.

This is a hack, because we are using local maps for global bindings, but it replicates the behavior of evil-leader and makes it unnecessary to manually rebind SPC where it is being shadowed.

For this to take effect people will have to update bind-map. The new argument is ignored in older versions though, so there should be no change for those who don't update.