### PR TITLE
Unbind TAB in org-mode

### DIFF
--- a/layers/org/extensions/evil-org/evil-org.el
+++ b/layers/org/extensions/evil-org/evil-org.el
@@ -141,8 +141,7 @@ FUN function callback"
   "^" 'org-beginning-of-line
   "<" 'org-metaleft
   ">" 'org-metaright
-  "-" 'org-cycle-list-bullet
-  (kbd "TAB") 'org-cycle)
+  "-" 'org-cycle-list-bullet)
 
 ;; normal & insert state shortcuts.
 (mapc (lambda (state)

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -262,6 +262,10 @@ Will work on both org-mode and any mode that accepts plain html."
       ;; Open links and files with RET in normal state
       (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)
 
+      ;; Disable the TAB binding so that C-i will invoke the correct action
+      ;; in the GUI.
+      (define-key org-mode-map (kbd "TAB") nil)
+
       ;; We add this key mapping because an Emacs user can change
       ;; `dotspacemacs-major-mode-emacs-leader-key' to `C-c' and the key binding
       ;; C-c ' is shadowed by `spacemacs/default-pop-shell', effectively making


### PR DESCRIPTION
Follow up on https://github.com/syl20bnr/spacemacs/commit/a19c0f3d2457912e80a7934e8060096a90a733c8. After this, `C-i` will correctly invoke evil-jumper in org-mode, while the tab key still cycles visibility. In the terminal, `C-i` will still cycle visibility.