### PR TITLE
keys: Fix #3927

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -70,6 +70,7 @@
     (bind-map spacemacs-default-map
       :prefix-cmd spacemacs-cmds
       :keys (dotspacemacs-emacs-leader-key)
+      :override-minor-modes t ; only applies to :keys
       :evil-keys (dotspacemacs-leader-key)
       :evil-use-local t)))
 


### PR DESCRIPTION
Use new bind-map option to override minor-mode maps with the emacs
leader key.

Note this relies on a new bind-map option, so an update is needed for it to take effect.