### PR TITLE
themes: Silence free variable warning

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -203,7 +203,8 @@ package name does not match theme name + `-theme' suffix.")
 (defadvice load-theme (after spacemacs/load-theme-adv activate)
   "Perform post load processing."
   (let ((theme (ad-get-arg 0)))
-    (setq spacemacs--cur-theme theme)
+    (with-no-warnings
+      (setq spacemacs--cur-theme theme))
     (spacemacs/post-theme-init theme)))
 
 (defun spacemacs/post-theme-init (theme)


### PR DESCRIPTION
Without this a popup is raised every time emacs25 starts up for
assignment to a free variable