### PR TITLE
Adjusted state coloring for more consitency with editor logos

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -697,19 +697,19 @@ So anything bound to =g= originally will be found on =C-G=, since =g=, =G= and
 ** States
 Spacemacs has 10 states:
 
-| State        | Color       | Description                                                                                                |
-|--------------+-------------+------------------------------------------------------------------------------------------------------------|
-| normal       | orange      | like the =normal mode of Vim=, used to execute and combine commands                                        |
-| insert       | green       | like the =insert mode of Vim=, used to actually insert text                                                |
-| visual       | gray        | like the =visual mode of Vim=, used to make text selection                                                 |
-| motion       | purple      | exclusive to =Evil=, used to navigate read only buffers                                                    |
-| emacs        | blue        | exclusive to =Evil=, using this state is like using a regular Emacs without Vim                            |
-| replace      | chocolate   | exclusive to =Evil=, overwrites the character under point instead of inserting a new one                   |
-| hybrid       | blue        | exclusive to Spacemacs, this is like the insert state except that all the emacs key bindings are available |
-| evilified    | light brown | exclusive to Spacemacs, this is an =emacs state= modified to bring Vim navigation, selection and search.   |
-| lisp         | pink        | exclusive to Spacemacs, used to navigate Lisp code and modify it (more [[Editing Lisp code][info]])                               |
-| iedit        | red         | exclusive to Spacemacs, used to navigate between multiple regions of text using =iedit= (more [[Replacing text with iedit][info]])        |
-| iedit-insert | red         | exclusive to Spacemacs, used to replace multiple regions of text using =iedit= (more [[Replacing text with iedit][info]])                 |
+| State        | Color       | Description                                                                                                  |
+|--------------+-------------+--------------------------------------------------------------------------------------------------------------|
+| normal       | green       | like the =normal mode of Vim=, used to execute and combine commands                                          |
+| insert       | gray        | like the =insert mode of Vim=, used to actually insert text                                                  |
+| visual       | white       | like the =visual mode of Vim=, used to make text selection                                                   |
+| motion       | violet      | exclusive to =Evil=, used to navigate read only buffers                                                      |
+| emacs        | purple      | exclusive to =Evil=, using this state is like using a regular Emacs without Vim                              |
+| replace      | chocolate   | exclusive to =Evil=, overwrites the character under point instead of inserting a new one                     |
+| hybrid       | sea green   | exclusive to =Spacemacs=, this is like the insert state except that all the emacs key bindings are available |
+| evilified    | light brown | exclusive to =Spacemacs=, this is an =emacs state= modified to bring Vim navigation, selection and search.   |
+| lisp         | pink        | exclusive to =Spacemacs=, used to navigate Lisp code and modify it (more [[#editing-lisp-code][info]])                               |
+| iedit        | red         | exclusive to =Spacemacs=, used to navigate between multiple regions of text using =iedit= (more [[#replacing-text-with-iedit][info]])        |
+| iedit-insert | red         | exclusive to =Spacemacs=, used to replace multiple regions of text using =iedit= (more [[#replacing-text-with-iedit][info]])                 |
 
 Note: Technically speaking there is also the =operator= evil state.
 
@@ -987,11 +987,12 @@ Reminder of the color codes for the states:
 
 | Evil State         | Color     |
 |--------------------+-----------|
-| Normal             | Orange    |
-| Insert             | Green     |
-| Visual             | Grey      |
-| Emacs              | Blue      |
-| Motion             | Purple    |
+| Normal             | Green     |
+| Insert             | Gray      |
+| Visual             | White     |
+| Emacs              | Purple    |
+| Hybrid             | Sea green |
+| Motion             | Violet    |
 | Replace            | Chocolate |
 | Lisp               | Pink      |
 | Iedit/Iedit-Insert | Red       |

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -162,13 +162,13 @@
   (use-package evil
     :init
     (progn
-      (defvar spacemacs-evil-cursors '(("normal" "DarkGoldenrod2" box)
-                                       ("insert" "chartreuse3" (bar . 2))
-                                       ("emacs" "SkyBlue2" box)
-                                       ("hybrid" "SkyBlue2" (bar . 2))
+      (defvar spacemacs-evil-cursors '(("normal" "#007F00" box)
+                                       ("insert" "#7F7F7F" (bar . 2))
+                                       ("emacs" "#5955A9" box)
+                                       ("hybrid" "#2B6B52" (bar . 2))
                                        ("replace" "chocolate" (hbar . 2))
                                        ("evilified" "LightGoldenrod3" box)
-                                       ("visual" "gray" (hbar . 2))
+                                       ("visual" "gray" (hollow . 2))
                                        ("motion" "plum3" box)
                                        ("lisp" "HotPink1" box)
                                        ("iedit" "firebrick1" box)


### PR DESCRIPTION
Hello,

Firstly, it's my first (shy) pull request on github and in public in general.
I really like spacemacs and it's consistency principle,
and I would like to start contributing.

Therefore, I would like to propose to change the colors so they correspond to editor logos,
and hybrid is in the middle of the two,
I changed Insert state color changed to resolve the conflict into gray,
(I thought it's simple and afaik it's included in hybrid mode so why use it at all?),
and proposed hollow for visual mode (it suits nicely selecting text in every theme).
And I tried to keep the documentation consistent too.

See my reasoning form this graphic:
![editorstatecolorfromlogos](https://cloud.githubusercontent.com/assets/15216366/11487362/e8aa5f20-97be-11e5-820f-117b634d18bb.png)
