### PR TITLE
core-keys: Enable distinction between C-i and TAB

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -109,6 +109,14 @@ pressing `<leader> m`. Set it to `nil` to disable it.")
 (defvar dotspacemacs-major-mode-emacs-leader-key "C-M-m"
   "Major mode leader key accessible in `emacs state' and `insert state'")
 
+(defvar dotspacemacs-distinguish-gui-tab nil
+  "If non nil, distinguish C-i and tab in the GUI version of
+emacs.")
+
+;; (defvar dotspacemacs-distinguish-gui-ret nil
+;;   "If non nil, distinguish C-m and return in the GUI version of
+;; emacs.")
+
 (defvar dotspacemacs-default-font '("Source Code Pro"
                                     :size 13
                                     :weight normal

--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -18,6 +18,16 @@
 (defvar spacemacs-default-map (make-sparse-keymap)
   "Base keymap for all spacemacs leader key commands.")
 
+(defun spacemacs/translate-C-i (_)
+  (interactive)
+  (if (and dotspacemacs-distinguish-gui-tab (display-graphic-p)) [C-i] [?\C-i]))
+(define-key key-translation-map [?\C-i] 'spacemacs/translate-C-i)
+
+;; (defun spacemacs/translate-C-m (_)
+;;   (interactive)
+;;   (if (and dotspacemacs-distinguish-gui-ret (display-graphic-p)) [C-m] [?\C-m]))
+;; (define-key key-translation-map [?\C-m] 'spacemacs/translate-C-m)
+
 (defun spacemacs/declare-prefix (prefix name &optional long-name)
   "Declare a prefix PREFIX. PREFIX is a string describing a key
 sequence. NAME is a string used as the prefix command.
@@ -57,19 +67,6 @@ used as the prefix command."
       (when (and is-major-mode-prefix dotspacemacs-major-mode-emacs-leader-key)
         (which-key-declare-prefixes-for-mode
           mode major-mode-prefix-emacs prefix-name)))))
-
-(defun spacemacs//handle-terminal-keys ()
-  "Translate on the fly terminal special keys to access the emacs function key.
-Translation occurs only the function key is effectively bound to a function."
-  (let ((kcode (and (not (display-graphic-p))
-                    (aref (this-command-keys-vector) 0))))
-    (cond
-     ((eq 9 kcode)
-      (let ((command (key-binding (kbd "<tab>"))))
-        (when command (setq this-command command))))
-     ((eq 13 kcode)
-      (let ((command (key-binding (kbd "<return>"))))
-        (when command (setq this-command command)))))))
 
 (defun spacemacs/set-leader-keys (key def &rest bindings)
   "Add KEY and DEF as key bindings under

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -210,8 +210,7 @@ initialization."
                   configuration-layer-error-count))
        (spacemacs-buffer/set-mode-line spacemacs--default-mode-line))
      (force-mode-line-update)
-     (spacemacs/check-for-new-version spacemacs-version-check-interval)
-     (add-hook 'pre-command-hook 'spacemacs//handle-terminal-keys))))
+     (spacemacs/check-for-new-version spacemacs-version-check-interval))))
 
 (defun spacemacs/describe-system-info ()
   "Gathers info about your Spacemacs setup and copies to clipboard."

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -113,6 +113,11 @@ values."
    ;; Major mode leader key accessible in `emacs state' and `insert state'.
    ;; (default "C-M-m)
    dotspacemacs-major-mode-emacs-leader-key "C-M-m"
+   ;; This variable controls whether separate commands are bound in the GUI to
+   ;; C-i and TAB. Setting it to a non-nil value, allows for separate commands.
+   ;; In the terminal, these keys are generally indistinguishable, so this only
+   ;; works in the GUI. (default nil)
+   dotspacemacs-distinguish-gui-tab nil
    ;; The command key used for Evil commands (ex-commands) and
    ;; Emacs commands (M-x).
    ;; By default the command key is `:' so ex-commands are executed like in Vim


### PR DESCRIPTION
Also C-m and RET. Added dotfile variable to template and
core-dotspacemacs.el

After enabling the C-i/TAB version for example, C-i is translated to the
"key" <C-i> which allows you to bind a separate command in the GUI like
this

(define-key map [C-i] 'c-i-command)

or this

(define-key map (kbd "\<C-i\>") 'c-i-command)

This has the side effect of no longer making C-i default to TAB in the
GUI, but will not affect the TAB or <tab> bindings.