### PR TITLE
Scala: Update Readme with latest ensime-sbt version

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -48,26 +48,27 @@ provides an SBT plugin to generate these files.
 
 ** Installation
 
-1. Configure the ENSIME sbt plugin by adding the following to
-   =~/.sbt/0.13/plugins/plugins.sbt=:
-   
-   #+BEGIN_SRC scala
-   resolvers += Resolver.sonatypeRepo("snapshots")
+Configure the ENSIME sbt plugin by adding the following to
+=~/.sbt/0.13/plugins/plugins.sbt=:
 
-   addSbtPlugin("org.ensime" % "ensime-sbt" % "0.1.7-SNAPSHOT")
-   #+END_SRC
-   
-2. Run =sbt= at the shell to download and install the plugin.
-   
-See the [[https://github.com/ensime/ensime-server/wiki/Quick-Start-Guide#installing-the-ensime-sbt-plugin][ENSIME quickstart]] guide for further information.
+#+BEGIN_SRC scala
+  addSbtPlugin("org.ensime" % "ensime-sbt" % "0.2.3")
+#+END_SRC
+
+Please go to [[https://github.com/ensime/ensime-sbt][ensime-sbt Github Page]] to check the latest version of =ensime-sbt= plugin.
+
+Please note your projects' =project/build.properties= need to use a version newer that =0.13.5= of sbt.
+#+BEGIN_SRC scala
+  sbt.version=0.13.9
+#+END_SRC
 
 ** Usage
 
 1. Create a =.ensime= file at the root of your Scala project using =sbt
    gen-ensime= at the shell.
-   
+
 2. Run =M-x ensime= within Emacs to start an ENSIME session.
-   
+
 Each Scala project uses a dedicated ENSIME session, so you only need to run =M-x
 ensime= once per project. Any Scala files you create or visit within the project
 will automatically use ENSIME for the remainder of your editing session.
@@ -82,7 +83,7 @@ To use scalastyle,
 1. Download the [[https://oss.sonatype.org/content/repositories/releases/org/scalastyle/scalastyle_2.11/0.6.0/][scalastyle jar]] and put it somewhere sensible
 2. Customise the =flycheck-scalastyle-jar= variable and set it to the path of
    the jar.
-   
+
 See the [[http://flycheck.readthedocs.org/en/latest/guide/languages.html#el.flycheck-checker.scala-scalastyle][flycheck documentation]] for up-to-date configuration instructions.
 
 * Automatically show the type of the symbol under the cursor


### PR DESCRIPTION
Added a note to use sbt 0.13.9 and remove unnecessary sonata repository
from the instructions.

Finally removed a link to a non existent page and added a link to
ensime-sbt GitHub page for further instructions.