### PR TITLE
core: fix: 'ahs-edit-mode' func requires argument

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -377,7 +377,7 @@
         ("e" nil
          :post (if (configuration-layer/package-usedp 'evil-iedit-state)
                    (evil-iedit-state/iedit-mode)
-                 (ahs-edit-mode))
+                 (ahs-edit-mode t))
          :exit t)
         ("n" spacemacs/quick-ahs-forward)
         ("N" spacemacs/quick-ahs-backward)


### PR DESCRIPTION
- func signature is (defun ahs-edit-mode (arg &optional temporary))
- This happens if I exclude evil-iedit package