### PR TITLE
Fix Latin function name

### DIFF
--- a/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
+++ b/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
@@ -47,10 +47,10 @@ The `insert state' is replaced by the `emacs state'."
   :lighter " holy"
   :group 'spacemacs
   (if holy-mode
-      (in-nominus-patris-et-filii-et-sipritus-sancti)
+      (in-nomine-patris-et-filii-et-sipritus-sancti)
     (amen)))
 
-(defun in-nominus-patris-et-filii-et-sipritus-sancti ()
+(defun in-nomine-patris-et-filii-et-sipritus-sancti ()
   "Enter the church of Emacs (wash your hands)."
   ;; transfert all modes defaulting to `evilified state' to
   ;; `emacs state'

--- a/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
+++ b/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
@@ -47,10 +47,10 @@ The `insert state' is replaced by the `emacs state'."
   :lighter " holy"
   :group 'spacemacs
   (if holy-mode
-      (in-nomine-patris-et-filii-et-sipritus-sancti)
+      (in-nomine-patris-et-filii-et-spiritus-sancti)
     (amen)))
 
-(defun in-nomine-patris-et-filii-et-sipritus-sancti ()
+(defun in-nomine-patris-et-filii-et-spiritus-sancti ()
   "Enter the church of Emacs (wash your hands)."
   ;; transfert all modes defaulting to `evilified state' to
   ;; `emacs state'


### PR DESCRIPTION
Apparently ` in-nominus-patris-et-filii-et-sipritus-sancti` should be
`in-nomine-patris-et-filii-et-filii-et-sipritus-sancti`

See: https://en.wikipedia.org/wiki/Trinitarian_formula
Via: https://twitter.com/PeterHilton/status/672133909795196928