### PR TITLE
Fix makefile for python version 2.7.10

### DIFF
--- a/layers/+lang/python/local/pylookup/makefile
+++ b/layers/+lang/python/local/pylookup/makefile
@@ -1,4 +1,4 @@
-VER := $(shell python --version 2>&1 | grep -o "[0-9].[0-9].[0-9]")
+VER := $(shell python --version 2>&1 | grep -o "[0-9].[0-9].[0-9]*")
 MAJOR_VERSION = $(shell python -version 2>&1 | grep -o "Python [0-9]")
 ZIP := python-${VER}-docs-html.zip
 URL := http://docs.python.org/py3k/archives/${ZIP}


### PR DESCRIPTION
Old version of makefile in `layers/+lang/python/local/pylookup` may not work well since Python 2.7.10 can not be matched properly. This version fixes this problem.