### PR TITLE
keys: Fix an issue with C-i/tab distinction

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -19,13 +19,28 @@
   "Base keymap for all spacemacs leader key commands.")
 
 (defun spacemacs/translate-C-i (_)
+  "If `dotspacemacs-distinguish-gui-tab' is non nil, the raw key
+sequence does not include <tab> or <kp-tab>, and we are in the
+gui, translate to [C-i]. Otherwise, [9] (TAB)."
   (interactive)
-  (if (and dotspacemacs-distinguish-gui-tab (display-graphic-p)) [C-i] [?\C-i]))
+  (if (and (not (cl-position 'tab (this-single-command-raw-keys)))
+           (not (cl-position 'kp-tab (this-single-command-raw-keys)))
+           dotspacemacs-distinguish-gui-tab
+           (display-graphic-p))
+      [C-i] [?\C-i]))
 (define-key key-translation-map [?\C-i] 'spacemacs/translate-C-i)
 
 ;; (defun spacemacs/translate-C-m (_)
+;;   "If `dotspacemacs-distinguish-gui-ret' is non nil, the raw key
+;; sequence does not include <ret>, and we are in the gui, translate
+;; to [C-m]. Otherwise, [9] (TAB)."
 ;;   (interactive)
-;;   (if (and dotspacemacs-distinguish-gui-ret (display-graphic-p)) [C-m] [?\C-m]))
+;;   (if (and
+;;        (not (cl-position 'return (this-single-command-raw-keys)))
+;;        (not (cl-position 'kp-enter (this-single-command-raw-keys)))
+;;        dotspacemacs-distinguish-gui-ret
+;;        (display-graphic-p))
+;;     [C-m] [?\C-m]))
 ;; (define-key key-translation-map [?\C-m] 'spacemacs/translate-C-m)
 
 (defun spacemacs/declare-prefix (prefix name &optional long-name)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -120,7 +120,7 @@ values."
    ;; In the terminal, these pairs are generally indistinguishable, so this only
    ;; works in the GUI. (default nil)
    dotspacemacs-distinguish-gui-tab nil
-   dotspacemacs-distinguish-gui-ret nil
+   ;; (Not implemented) dotspacemacs-distinguish-gui-ret nil
    ;; The command key used for Evil commands (ex-commands) and
    ;; Emacs commands (M-x).
    ;; By default the command key is `:' so ex-commands are executed like in Vim

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -866,7 +866,7 @@ ARG non nil means that the editing style is `vim'."
         ("9" spacemacs/helm-action-9 :exit t)
         ("0" spacemacs/helm-action-10 :exit t)
         ("<tab>" helm-select-action :exit t)
-        ("C-i" helm-select-action :exit t)
+        ("TAB" helm-select-action :exit t)
         ("<RET>" helm-maybe-exit-minibuffer :exit t)
         ("?" nil :doc (spacemacs//helm-navigation-ms-full-doc))
         ("a" helm-select-action :post (spacemacs//helm-navigation-ms-set-face))

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1443,7 +1443,7 @@ It will toggle the overlay under point or create an overlay of one character."
         :off (indent-guide-global-mode -1)
         :documentation
         "Highlight indentation level at point globally. (alternative to highlight-indentation)."
-        :evil-leader "t C-i"))
+        :evil-leader "t TAB"))
     :config
     (spacemacs|diminish indent-guide-mode " ⓘ" " i")))
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -146,7 +146,7 @@
         "hd"  'inferior-haskell-find-haddock
         "hh"  'hoogle
         "hH"  'hoogle-lookup-from-local
-        "mhi"  (lookup-key haskell-mode-map (kbd "C-c C-i"))
+        "mhi"  (lookup-key haskell-mode-map (kbd "C-c TAB"))
         "mht"  (lookup-key haskell-mode-map (kbd "C-c C-t"))
         "hT"  'spacemacs/haskell-process-do-type-on-prev-line
         "hy"  'hayoo

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -116,7 +116,7 @@ The variable =latex-nofill-env= provide the list of environment names where
 | ~SPC m r g~   | reftex-grep-document                  |
 | ~SPC m r i~   | reftex-index-selection-or-word        |
 | ~SPC m r I~   | reftex-display-index                  |
-| ~SPC m r C-i~ | reftex-index                          |
+| ~SPC m r TAB~ | reftex-index                          |
 | ~SPC m r l~   | reftex-label                          |
 | ~SPC m r p~   | reftex-index-phrase-selection-or-word |
 | ~SPC m r P~   | reftex-index-visit-phrases-buffer     |
@@ -125,3 +125,4 @@ The variable =latex-nofill-env= provide the list of environment names where
 | ~SPC m r t~   | reftex-toc                            |
 | ~SPC m r T~   | reftex-toc-recenter                   |
 | ~SPC m r v~   | reftex-view-crossref                  |
+|               |                                       |

--- a/layers/+lang/latex/extensions.el
+++ b/layers/+lang/latex/extensions.el
@@ -23,7 +23,7 @@
     "rg"    'reftex-grep-document
     "ri"    'reftex-index-selection-or-word
     "rI"    'reftex-display-index
-    "r C-i" 'reftex-index
+    "r TAB" 'reftex-index
     "rl"    'reftex-label
     "rp"    'reftex-index-phrase-selection-or-word
     "rP"    'reftex-index-visit-phrases-buffer


### PR DESCRIPTION
Before this `<tab> => TAB` if there is no binding for `<tab>`, but then
`spacemacs/translate-C-i` turned this into `<C-i>`, which we don't want
because that would mean having to always bind `<tab>` when this option is
enabled. This commit adds a check to make sure we can't possibly be
translating from `<tab>` originally (we only want to capture the `C-i`
events in the GUI).