### PR TITLE
Evilify Neotree

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1513,7 +1513,6 @@ It will toggle the overlay under point or create an overlay of one character."
     :commands neo-global--window-exists-p
     :init
     (progn
-      (add-to-list 'evil-motion-state-modes 'neotree-mode)
       (setq neo-window-width 32
             neo-create-file-auto-open t
             neo-banner-message nil
@@ -1573,31 +1572,32 @@ It will toggle the overlay under point or create an overlay of one character."
 
       (defun spacemacs//neotree-key-bindings ()
         "Set the key bindings for a neotree buffer."
-        (define-key evil-motion-state-local-map (kbd "TAB")  'neotree-stretch-toggle)
-        (define-key evil-motion-state-local-map (kbd "RET")  'neotree-enter)
-        (define-key evil-motion-state-local-map (kbd "|")    'neotree-enter-vertical-split)
-        (define-key evil-motion-state-local-map (kbd "-")    'neotree-enter-horizontal-split)
-        (define-key evil-motion-state-local-map (kbd "?")    'evil-search-backward)
-        (define-key evil-motion-state-local-map (kbd "c")    'neotree-create-node)
-        (define-key evil-motion-state-local-map (kbd "d")    'neotree-delete-node)
-        (define-key evil-motion-state-local-map (kbd "gr")   'neotree-refresh)
-        (define-key evil-motion-state-local-map (kbd "h")    'spacemacs/neotree-collapse-or-up)
-        (define-key evil-motion-state-local-map (kbd "H")    'neotree-select-previous-sibling-node)
-        (define-key evil-motion-state-local-map (kbd "J")    'neotree-select-down-node)
-        (define-key evil-motion-state-local-map (kbd "K")    'neotree-select-up-node)
-        (define-key evil-motion-state-local-map (kbd "l")    'spacemacs/neotree-expand-or-open)
-        (define-key evil-motion-state-local-map (kbd "L")    'neotree-select-next-sibling-node)
-        (define-key evil-motion-state-local-map (kbd "q")    'neotree-hide)
-        (define-key evil-motion-state-local-map (kbd "r")    'neotree-rename-node)
-        (define-key evil-motion-state-local-map (kbd "R")    'neotree-change-root)
-        (define-key evil-motion-state-local-map (kbd "s")    'neotree-hidden-file-toggle))
+        (evilified-state-evilify neotree-mode neotree-mode-map
+          (kbd "TAB")  'neotree-stretch-toggle
+          (kbd "RET") 'neotree-enter
+          (kbd "|") 'neotree-enter-vertical-split
+          (kbd "-") 'neotree-enter-horizontal-split
+          (kbd "?") 'evil-search-backward
+          (kbd "c") 'neotree-create-node
+          (kbd "d") 'neotree-delete-node
+          (kbd "gr") 'neotree-refresh
+          (kbd "h") 'spacemacs/neotree-collapse-or-up
+          (kbd "H") 'neotree-select-previous-sibling-node
+          (kbd "J") 'neotree-select-down-node
+          (kbd "K") 'neotree-select-up-node
+          (kbd "l") 'spacemacs/neotree-expand-or-open
+          (kbd "L") 'neotree-select-next-sibling-node
+          (kbd "q") 'neotree-hide
+          (kbd "r") 'neotree-rename-node
+          (kbd "R") 'neotree-change-root
+          (kbd "s") 'neotree-hidden-file-toggle))
 
       (spacemacs/set-leader-keys
         "ft" 'neotree-toggle
         "pt" 'neotree-find-project-root))
 
     :config
-    (spacemacs/add-to-hook 'neotree-mode-hook '(spacemacs//neotree-key-bindings))))
+    (spacemacs//neotree-key-bindings)))
 
 (defun spacemacs/init-pcre2el ()
   (use-package pcre2el


### PR DESCRIPTION
This PR evilifies Neotree, instead of binding to `evil-motion-state-local-map` in a hook as we currently do. `gg`, `gr` (refresh) and `G` still work, the other `g` prefixed bindings are gone because of the evilification. If anyone misses them, they can be added back.

@StreakyCobra I assume this requires some changes to the `bepo` layer as well?

Fixes #3752 and affects #4042 