### PR TITLE
emacs-lisp: add missing keys to lisp-interaction

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -82,7 +82,7 @@
     (spacemacs/declare-prefix-for-mode mode "mc" "compile")
     (spacemacs/declare-prefix-for-mode mode "me" "eval")
     (spacemacs/declare-prefix-for-mode mode "mt" "tests")
-    (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
+    (spacemacs/set-leader-keys-for-major-mode mode
       "cc" 'emacs-lisp-byte-compile
       "e$" 'lisp-state-eval-sexp-end-of-line
       "eb" 'eval-buffer


### PR DESCRIPTION
The `spacemacs/set-leader-keys` wasn't using the `mode` from the enclosing `dolist`, so leader-keys were not getting set for `lisp-interaction-mode`.