### PR TITLE
Switch to Spacemacs Home on creating *new* layout

### DIFF
--- a/layers/+window-management/spacemacs-layouts/funcs.el
+++ b/layers/+window-management/spacemacs-layouts/funcs.el
@@ -58,7 +58,10 @@ perspectives does."
                  '(("Create new perspective" .
                     (lambda (name)
                       (let ((persp-reset-windows-on-nil-window-conf t))
-                        (persp-switch name)))))))))
+                        (if (member name (persp-names-current-frame-fast-ordered))
+                            (persp-switch name)
+                          (persp-switch name)
+                          (spacemacs/home))))))))))
 
 ;; ability to use helm find files but also adds to current perspective
 (defun spacemacs/helm-persp-close ()

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -150,7 +150,8 @@
                    (concat "Perspective in this position doesn't exist.\n"
                            "Do you want to create one? "))
               (let ((persp-reset-windows-on-nil-window-conf t))
-                (persp-switch nil))))))
+                (persp-switch nil)
+                (spacemacs/home))))))
 
       ;; Define all `spacemacs/persp-switch-to-X' functions
       (dolist (i (number-sequence 9 0 -1))


### PR DESCRIPTION
It seems better to switch to `*spacemacs*` buffer instead of `*scratch*` on creating new layout where we have handful of useful functions. 