### PR TITLE
Use hl-todo for TODOs/FIXMEs highlighting

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -236,9 +236,6 @@ or lists of these.")
     (if dotspacemacs-maximized-at-startup
         (add-hook 'window-setup-hook 'toggle-frame-maximized))))
 
-;; Highlight keywords like TODO, FIXME, etc.
-(add-hook 'prog-mode-hook 'spacemacs/highlight-TODO-words)
-
 ;; ---------------------------------------------------------------------------
 ;; Session
 ;; ---------------------------------------------------------------------------

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -562,13 +562,6 @@ current window."
       (switch-to-buffer (car (evil-alternate-buffer)))
     (switch-to-buffer (other-buffer (current-buffer) t))))
 
-(defun spacemacs/highlight-TODO-words ()
-  "Highlight keywords in comments."
-  (interactive)
-  (font-lock-add-keywords
-   nil '(("\\<\\(\\(FIX\\(ME\\)?\\|TODO\\|OPTIMIZE\\|HACK\\|REFACTOR\\)\\>:?\\)"
-          1 font-lock-warning-face t))))
-
 (defun current-line ()
   "Return the line at point as a string."
   (buffer-substring (line-beginning-position) (line-end-position)))

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -33,6 +33,7 @@
         helm-projectile
         (helm-spacemacs :location local)
         help-fns+
+        hl-todo
         (hs-minor-mode :location built-in)
         (holy-mode :location local :step pre)
         (hybrid-mode :location local :step pre)
@@ -958,6 +959,14 @@ ARG non nil means that the editing style is `vim'."
   (use-package help-fns+
     :commands (describe-keymap)
     :init (spacemacs/set-leader-keys "hdK" 'describe-keymap)))
+
+(defun spacemacs-base/init-hl-todo ()
+  (use-package hl-todo
+    :commands (hl-todo-mode)
+    :init
+    (progn
+      (setq hl-todo-activate-in-modes '(prog-mode))
+      (global-hl-todo-mode))))
 
 (defun spacemacs-base/init-hs-minor-mode ()
   ;; required for evil folding


### PR DESCRIPTION
The current way to highlight TODOs is `spacemacs/highlight-TODO-words`
which is a spacemacs' hard-coded function.

This commit changes it for the `hl-todo` package. This imply:

- More keywords are supported out of the box.

- Keywords are associated to faces, so they are shown in different
  colors.

- Keywords are stored with their faces in a list, so it's easier for
  users to add their own keywords and faces (as contrary to a regexp).

- It is possible to disable highlighting by simply excluding the
  package.