### PR TITLE
+tools/elfeed: elfeed-goodies is on MELPA now

### DIFF
--- a/layers/+tools/elfeed/packages.el
+++ b/layers/+tools/elfeed/packages.el
@@ -12,8 +12,7 @@
 
 (setq elfeed-packages
       '(elfeed
-        (elfeed-goodies :location (recipe :fetcher github
-                                          :repo "algernon/elfeed-goodies"))
+        elfeed-goodies
         elfeed-org
         elfeed-web
         ))


### PR DESCRIPTION
No need for a :location anymore, elfeed-goodies is on MELPA now.
