### PR TITLE
Python: auto-activate local pyenv version

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -11,6 +11,7 @@
    - [[Test runner][Test runner]]
    - [[Anaconda dependencies][Anaconda dependencies]]
    - [[Automatic buffer formatting on save][Automatic buffer formatting on save]]
+   - [[Automatic activation of local pyenv version][Automatic activation of local pyenv version]]
    - [[autoflake][autoflake]]
    - [[pylookup][pylookup]]
  - [[Key Bindings][Key Bindings]]
@@ -85,6 +86,17 @@ To enable automatic buffer formatting on save with  [[https://github.com/google/
   (setq-default dotspacemacs-configuration-layers '(
     (python :variables python-enable-yapf-format-on-save t)))
 #+END_SRC
+
+** Automatic activation of local pyenv version
+A project-specific pyenv version may be written to a file called
+=.python-version= using the [[https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-local][pyenv local]] command.
+
+Spacemacs can search in parent directories for this file, and automatically set
+the pyenv version. The behavior can be set with the variable
+=python-auto-set-local-pyenv-version= to:
+- =on-visit= (default) set the version when you visit a python buffer,
+- =on-project-switch= set the version when you switch projects,
+- =nil= to disable.
 
 ** autoflake
 To be able to suppress unused imports easily, install [[https://github.com/myint/autoflake][autoflake]]:

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -24,3 +24,8 @@
 
 (defvar python-fill-column 79
   "Fill column value for python buffers")
+
+(defvar python-auto-set-local-pyenv-version 'on-visit
+  "Automatically set pyenv version from \".python-version\".
+
+Possible values are `on-visit', `on-project-switch' or `nil'.")

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -43,3 +43,15 @@
                                (shell-quote-argument (buffer-file-name))))
         (revert-buffer t t t))
     (message "Error: Cannot find autoflake executable.")))
+
+(defun pyenv-mode-set-local-version ()
+  "Set pyenv version from \".python-version\" by looking in parent directories."
+  (interactive)
+  (-when-let (root-path (locate-dominating-file default-directory ".python-version"))
+    (let* ((file-path (expand-file-name ".python-version" root-path))
+           (version (with-temp-buffer
+                      (insert-file-contents-literally file-path)
+                      (current-word))))
+      (if (member version (pyenv-mode-versions))
+          (pyenv-mode-set version)
+        (message "pyenv: version `%s' is not installed (set by %s)" version file-path)))))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -82,10 +82,17 @@
 (defun python/init-pyenv-mode ()
   (use-package pyenv-mode
     :defer t
-    :init (progn
-            (spacemacs/set-leader-keys-for-major-mode 'python-mode
-              "vs" 'pyenv-mode-set
-              "vu" 'pyenv-mode-unset))))
+    :commands (pyenv-mode-versions)
+    :init
+    (progn
+      (pcase python-auto-set-local-pyenv-version
+       (`on-visit
+        (add-hook 'python-mode-hook 'pyenv-mode-set-local-version))
+       (`on-project-switch
+        (add-hook 'projectile-after-switch-project-hook 'pyenv-mode-set-local-version)))
+      (spacemacs/set-leader-keys-for-major-mode 'python-mode
+        "vs" 'pyenv-mode-set
+        "vu" 'pyenv-mode-unset))))
 
 (defun python/init-pyvenv ()
   (use-package pyvenv


### PR DESCRIPTION
Project-specific pyenv versions can be set using [`pyenv local`](https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-local), for example:
```
$ cd path/to/my-project
$ pyenv virtualenv 3.4.3 my-project
$ pyenv local my-project
pyenv-virtualenv: activate my-project
$ cat .python-version
my-project
```
When changing directories inside a shell, if a `.python-version` file is found in any parent directory, pyenv conveniently activates that environment for the user.

This commit adds an interactive function `pyenv-mode-set-local-version` that searches parent directories for a file `.python-version` and activates that version (if found). It also adds a config setting that runs this function when the user visits a python buffer or switches project.