### PR TITLE
bind-map: Define minor-mode name

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -70,9 +70,9 @@
     (bind-map spacemacs-default-map
       :prefix-cmd spacemacs-cmds
       :keys (dotspacemacs-emacs-leader-key)
-      :override-minor-modes t ; only applies to :keys
       :evil-keys (dotspacemacs-leader-key)
-      :evil-use-local t)))
+      :override-minor-modes t
+      :override-mode-name spacemacs-leader-override-mode)))
 
 (defun spacemacs-base/init-bookmark ()
   (use-package bookmark


### PR DESCRIPTION
New bind-map option allows defining the name for the overriding-mode.
This does that and removes the now redundant :evil-use-local option.

Feel free to change the name. I just picked something I thought made sense. 