### PR TITLE
Update package version in Quick Start with lein

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -92,9 +92,9 @@ Or set this variable when loading the configuration layer:
   
 #+BEGIN_SRC clojure
   {:repl {:plugins [[cider/cider-nrepl "0.10.0-SNAPSHOT"]
-                    [refactor-nrepl "1.2.0-SNAPSHOT"]]
+                    [refactor-nrepl "2.0.0-SNAPSHOT"]]
           :dependencies [[alembic "0.3.2"]
-                         [org.clojure/tools.nrepl "0.2.10"]]}}
+                         [org.clojure/tools.nrepl "0.2.12"]]}}
 #+END_SRC
 
 - After creating your project with ~lein new app <projectname>~ or


### PR DESCRIPTION
To prevent the warning message when start REPL.
```
WARNING: CIDER requires nREPL 0.2.12 (or newer) to work properly
WARNING: The following nREPL ops are not supported:
find-used-locals
Please, install (or update) refactor-nrepl and restart the REPL.
You can mute this warning by changing cljr-suppress-middleware-warnings.
WARNING: clj-refactor and refactor-nrepl are out of sync.
Their versions are 2.0.0-SNAPSHOT (package: 20151129.519) and 1.2.0-SNAPSHOT, respectively.
You can mute this warning by changing cljr-suppress-middleware-warnings.
```
