### PR TITLE
Add command-log layer: logs key strokes, commands

### DIFF
--- a/layers/+tools/command-log/README.org
+++ b/layers/+tools/command-log/README.org
@@ -1,0 +1,25 @@
+#+TITLE: command-log layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+
+* Table of Contents                                        :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Install][Install]]
+ - [[Key bindings][Key bindings]]
+
+* Description
+command-log can be used to demo Emacs to an audience. When activated,
+keystrokes get logged into a designated buffer, along with the command
+bound to them. For more info check [[https://github.com/lewang/command-log-mode][command-log-mode]].
+
+* Install
+To use this contribution add it to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(command-log))
+#+end_src
+
+* Key bindings
+
+| Key Binding | Description            |
+|-------------+------------------------|
+| ~SPC a L~   | Toggle the command log |

--- a/layers/+tools/command-log/packages.el
+++ b/layers/+tools/command-log/packages.el
@@ -1,0 +1,36 @@
+;;; packages.el --- command-log Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq command-log-packages
+      ;; bmag/command-log-mode is a fork of lewang/command-log-mode, and there
+      ;; is an open PR to merge the fork into the original repo.
+      ;; TODO when the PR is merged upstream, change to use the original package
+      ;; from MELPA (IOW remove :location argument)
+      '((command-log-mode :location (recipe :fetcher github
+                                            :repo "bmag/command-log-mode"
+                                            :branch "color"))))
+
+(setq command-log-excluded-packages '())
+
+(defun command-log/init-command-log-mode ()
+  (use-package command-log-mode
+    :commands global-command-log-mode
+    ;; :commands (clm/open-command-log-buffer global-command-log-mode spacemacs/toggle-command-log-mode)
+    :init
+    (spacemacs/set-leader-keys "aL" #'global-command-log-mode)
+    :config
+    (setq clm/log-command-exceptions* (append clm/log-command-exceptions*
+                                              '(evil-next-line
+                                                evil-previous-line
+                                                evil-forward-char
+                                                evil-backward-char))
+          command-log-mode-auto-show t)))


### PR DESCRIPTION
Uses command-log-mode package, useful for creating demos.

[command-log-mode](https://github.com/lewang/command-log-mode) is a newer fork of mwe-log-commands with a cleaner code IMHO, so I think this PR can replace #2006.

@BlinkD I based the description in README.org on the one you wrote in your PR, I hope you don't mind.

Currently the PR installs via Quelpa a fork (by me) that adds colors to command-log-mode, but if/when the fork is merged upstream I'll change the `:location` to install command-log-mode from Melpa.

The command-log is toggled by `SPC a L`.

Here's a picture:
![2015-12-08-100511_1366x742_scrot](https://cloud.githubusercontent.com/assets/4334375/11650857/211904ca-9d95-11e5-8b51-21ba2a81260b.png)