### PR TITLE
Make flycheck/flyspell hooks more explicit

### DIFF
--- a/layers/+config-files/puppet/packages.el
+++ b/layers/+config-files/puppet/packages.el
@@ -39,7 +39,7 @@
   (spacemacs|add-company-hook puppet-mode))
 
 (defun puppet/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'puppet-mode))
+  (spacemacs/add-flycheck-hook 'puppet-mode-hook))
 
 (defun puppet/init-puppetfile-mode ()
   (use-package puppetfile-mode

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -42,7 +42,7 @@
       (add-hook 'react-mode-hook #'react/disable-jshint))))
 
 (defun react/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'react-mode))
+  (spacemacs/add-flycheck-hook 'react-mode-hook))
 
 (defun react/post-init-js-doc ()
   (add-hook 'react-mode-hook 'spacemacs/js-doc-require)

--- a/layers/+irc/rcirc/packages.el
+++ b/layers/+irc/rcirc/packages.el
@@ -22,7 +22,7 @@
   (add-hook 'rcirc-mode-hook 'emoji-cheat-sheet-plus-display-mode))
 
 (defun rcirc/post-init-flyspell ()
-  (spell-checking/add-flyspell-hook 'rcirc-mode))
+  (spell-checking/add-flyspell-hook 'rcirc-mode-hook))
 
 (defun rcirc/post-init-persp-mode ()
   (spacemacs|define-custom-layout "@RCIRC"

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -90,8 +90,8 @@
       :init (push 'company-c-headers company-backends-c-mode-common))))
 
 (defun c-c++/post-init-flycheck ()
-  (dolist (mode '(c-mode c++-mode))
-    (spacemacs/add-flycheck-hook mode))
+  (dolist (hook '(c-mode-hook c++-mode-hook))
+    (spacemacs/add-flycheck-hook hook))
   (when c-c++-enable-clang-support
     (spacemacs/add-to-hooks 'c-c++/load-clang-args '(c-mode-hook c++-mode-hook))))
 

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -26,7 +26,7 @@
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun d/post-init-flycheck ()
-    (spacemacs/add-flycheck-hook 'd-mode))
+    (spacemacs/add-flycheck-hook 'd-mode-hook))
   (defun d/init-flycheck-dmd-dub ()
     (use-package flycheck-dmd-dub :defer t
       :init (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path))))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -127,7 +127,8 @@
 (defun emacs-lisp/post-init-flycheck ()
   ;; Don't activate flycheck by default in elisp
   ;; because of too much false warnings
-  ;; (spacemacs/add-flycheck-hook 'emacs-lisp-mode)
+  ;; (spacemacs/add-flycheck-hook 'emacs-lisp-mode-hook)
+
   ;; Make flycheck recognize packages in loadpath
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -42,4 +42,4 @@
     (require 'erlang-start)))
 
 (defun erlang/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'erlang-mode))
+  (spacemacs/add-flycheck-hook 'erlang-mode-hook))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -8,7 +8,7 @@
         ))
 
 (defun go/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'go-mode))
+  (spacemacs/add-flycheck-hook 'go-mode-hook))
 
 (defun go/init-go-mode()
   (when (memq window-system '(mac ns x))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -30,7 +30,7 @@
     :defer t))
 
 (defun haskell/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'haskell-mode))
+  (spacemacs/add-flycheck-hook 'haskell-mode-hook))
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun haskell/init-flycheck-haskell ()

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -100,8 +100,14 @@
   (add-hook 'web-mode-hook 'turn-on-evil-matchit-mode))
 
 (defun html/post-init-flycheck ()
-  (dolist (mode '(haml-mode jade-mode less-mode sass-mode scss-mode slim-mode web-mode))
-    (spacemacs/add-flycheck-hook mode)))
+  (dolist (hook '(haml-mode-hook
+                  jade-mode-hook
+                  less-mode-hook
+                  sass-mode-hook
+                  scss-mode-hook
+                  slim-mode-hook
+                  web-mode-hook))
+    (spacemacs/add-flycheck-hook hook)))
 
 (defun html/init-haml-mode ()
   (use-package haml-mode

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -56,8 +56,8 @@
       (push 'company-tern company-backends-js2-mode))))
 
 (defun javascript/post-init-flycheck ()
-  (dolist (mode '(coffee-mode js2-mode json-mode))
-    (spacemacs/add-flycheck-hook mode)))
+  (dolist (hook '(coffee-mode-hook js2-mode-hook json-mode-hook))
+    (spacemacs/add-flycheck-hook hook)))
 
 (defun javascript/init-js-doc ()
   (use-package js-doc

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -134,10 +134,10 @@
   (add-hook 'LaTeX-mode-hook 'evil-matchit-mode))
 
 (defun latex/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'LaTeX-mode))
+  (spacemacs/add-flycheck-hook 'LaTeX-mode-hook))
 
 (defun latex/post-init-flyspell ()
-  (spell-checking/add-flyspell-hook 'LaTeX-mode))
+  (spell-checking/add-flyspell-hook 'LaTeX-mode-hook))
 
 (defun latex/post-init-smartparens ()
   (add-hook 'LaTeX-mode-hook 'smartparens-mode))

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -6,7 +6,7 @@
     ))
 
 (defun lua/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'lua-mode))
+  (spacemacs/add-flycheck-hook 'lua-mode-hook))
 
 (defun lua/init-lua-mode ()
   (use-package lua-mode

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -7,9 +7,8 @@
 (defun nim/post-init-company ()
   (spacemacs|add-company-hook nim-mode))
 
-
 (defun nim/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'nim-mode))
+  (spacemacs/add-flycheck-hook 'nim-mode-hook))
 
 (defun nim/init-flycheck-nim ()
   (use-package flycheck-nim

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -30,7 +30,7 @@
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun ocaml/post-init-flycheck ()
-    (spacemacs/add-flycheck-hook 'merlin-mode))
+    (spacemacs/add-flycheck-hook 'merlin-mode-hook))
   (defun ocaml/init-flycheck-ocaml ()
     (use-package flycheck-ocaml
       :if (configuration-layer/package-usedp 'flycheck)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -269,7 +269,7 @@
     (add-hook `python-mode-hook `turn-on-evil-matchit-mode))
 
 (defun python/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'python-mode))
+  (spacemacs/add-flycheck-hook 'python-mode-hook))
 
 (defun python/init-hy-mode ()
   (use-package hy-mode

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -94,8 +94,8 @@
     (add-hook hook `turn-on-evil-matchit-mode)))
 
 (defun ruby/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'ruby-mode)
-  (spacemacs/add-flycheck-hook 'enh-ruby-mode))
+  (spacemacs/add-flycheck-hook 'ruby-mode-hook)
+  (spacemacs/add-flycheck-hook 'enh-ruby-mode-hook))
 
 (defun ruby/init-rbenv ()
   (use-package rbenv

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -22,7 +22,7 @@
     ))
 
 (defun rust/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'rust-mode))
+  (spacemacs/add-flycheck-hook 'rust-mode-hook))
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
   (defun rust/init-flycheck-rust ()

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -17,6 +17,7 @@
     emoji-cheat-sheet-plus
     (evil-org :location local)
     evil-surround
+    flyspell
     gnuplot
     htmlize
     ;; org and org-agenda are installed by `org-plus-contrib'
@@ -63,6 +64,9 @@
   (defun spacemacs//surround-drawer ()
     (let ((dname (read-from-minibuffer "" "")))
       (cons (format ":%s:" (or dname "")) ":END:"))))
+
+(defun org/post-init-flyspell ()
+  (spell-checking/add-flyspell-hook 'org-mode-hook))
 
 (defun org/init-gnuplot ()
   (use-package gnuplot

--- a/layers/spell-checking/funcs.el
+++ b/layers/spell-checking/funcs.el
@@ -10,12 +10,11 @@
 ;;
 ;;; License: GPLv3
 
-(defun spell-checking/add-flyspell-hook (mode &optional target)
-  "Enable flyspell for the given MODE, if
+(defun spell-checking/add-flyspell-hook (hook)
+  "Add `flyspell-mode' to the given HOOK, if
 `spell-checking-enable-by-default' is true."
   (when spell-checking-enable-by-default
-    (let ((mode-hook (intern (format "%S-hook" mode))))
-      (add-hook mode-hook 'flyspell-mode))))
+    (add-hook hook 'flyspell-mode)))
 
 (defun spell-checking/change-dictionary ()
   "Change the dictionary. Use the ispell version if

--- a/layers/spell-checking/packages.el
+++ b/layers/spell-checking/packages.el
@@ -41,10 +41,8 @@
     :commands (spell-checking/change-dictionary)
     :init
     (progn
-      (spell-checking/add-flyspell-hook 'org-mode)
-      (spell-checking/add-flyspell-hook 'text-mode)
-      (when spell-checking-enable-by-default
-        (add-hook 'prog-mode-hook 'flyspell-prog-mode))
+      (spell-checking/add-flyspell-hook 'text-mode-hook)
+      (spell-checking/add-flyspell-hook 'prog-mode-hook)
 
       (spacemacs|add-toggle spelling-checking
         :status flyspell-mode

--- a/layers/syntax-checking/funcs.el
+++ b/layers/syntax-checking/funcs.el
@@ -10,9 +10,8 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs/add-flycheck-hook (mode &optional target)
-  "Enable flycheck for the given MODE, if
+(defun spacemacs/add-flycheck-hook (hook)
+  "Add flycheck to the given HOOK, if
 `syntax-checking-enable-by-default' is true."
   (when syntax-checking-enable-by-default
-    (let ((mode-hook (intern (format "%S-hook" mode))))
-      (add-hook mode-hook 'flycheck-mode))))
+    (add-hook hook 'flycheck-mode)))


### PR DESCRIPTION
The way I wrote `add-flyspell-hook` and `add-flycheck-hook` inadvertently caused the bug fixed by https://github.com/syl20bnr/spacemacs/commit/549219e58324373027c1466872da4a7dbe94977a. I'm more of a fan of this more explicity style.

There is precedent for doing a macro instead (see `add-company-hook`) but that one does a lot more.

This PR also moves the flyspell hook for org-mode into the org layer.