### PR TITLE
haskell: haskell-process-load-or-reload is obsolete

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -133,7 +133,7 @@
         "gi"  'haskell-navigate-imports
         "f"   'haskell-mode-stylish-buffer
 
-        "sb"  'haskell-process-load-or-reload
+        "sb"  'haskell-process-load-file
         "sc"  'haskell-interactive-mode-clear
         "ss"  'spacemacs/haskell-interactive-bring
         "sS"  'haskell-interactive-switch
@@ -161,7 +161,7 @@
         "dr"  'haskell-debug/refresh)
 
       ;; configure C-c C-l so it doesn't throw any errors
-      (bind-key "C-c C-l" 'haskell-process-load-or-reload haskell-mode-map)
+      (bind-key "C-c C-l" 'haskell-process-load-file haskell-mode-map)
 
       ;; Switch back to editor from REPL
       (spacemacs/set-leader-keys-for-major-mode 'haskell-interactive-mode


### PR DESCRIPTION
Fixes:

    `haskell-process-load-or-reload' is an obsolete command (as of 2015-11-14);
    use `haskell-process-load-file' instead.