### PR TITLE
improve document of fcitx.el and disable it in Windows

### DIFF
--- a/layers/chinese/README.org
+++ b/layers/chinese/README.org
@@ -11,6 +11,7 @@
      - [[Configure the Default Input Method(配置默认中文输入法)][Configure the Default Input Method(配置默认中文输入法)]]
      - [[Configure the =Chinese-pyim= Input Method(配置中文拼音输入法)][Configure the =Chinese-pyim= Input Method(配置中文拼音输入法)]]
      - [[Enable fcitx][Enable fcitx]]
+       - [[Requirement][Requirement]]
      - [[Enable YouDao(有道) Dictionary(激活有道字典)][Enable YouDao(有道) Dictionary(激活有道字典)]]
      - [[Set monospaced font size(设置等宽字体）][Set monospaced font size(设置等宽字体）]]
      - [[Enable/Disable ace-pinyin in =avy-goto-char=][Enable/Disable ace-pinyin in =avy-goto-char=]]
@@ -63,7 +64,28 @@ with the following configuration.
 #+BEGIN_SRC emacs-lisp
   (fcitx-aggressive-setup)
 #+END_SRC
+**** Requirement
+***** Linux
+You need use this with =fcitx= and make sure =fcitx-remote= is in your search path.
+***** Mac OS X
+We don't have a =fcitx= in OS X for now.But we already had a simulate =fcitx-remote= to make you happy with other Chinese input-methods.
 
+You can install [[https://github.com/CodeFalling/fcitx-remote-for-osx][fcitx-remote-for-osx]] from homebrew.
+
+#+BEGIN_SRC shell
+  brew install fcitx-remote-for-osx --with-input-method=baidu-pinyin
+#+END_SRC
+
+=--with-input-method=baidu-pinyin= means install for Baidu-pinyin Input Method.
+
+You can use =brew info fcitx-remote-for-osx= to get more options info for input method support.
+
+#+BEGIN_EXAMPLE
+--with-input-method=
+  Select input method: baidu-pinyin(default), baidu-wubi, sogou-pinyin, qq-wubi, squirrel-rime, osx-pinyin
+#+END_EXAMPLE
+***** Windows
+=fcitx.el= dosen't support Windows for now.We just disable it in layer.
 
 *** Enable YouDao(有道) Dictionary(激活有道字典)
 The YouDao Dictionary is disabled by default, if you want enable it.

--- a/layers/chinese/packages.el
+++ b/layers/chinese/packages.el
@@ -26,7 +26,7 @@
     (push 'chinese-wbim chinese-packages)
   (push 'chinese-pyim chinese-packages))
 
-(if chinese-enable-fcitx
+(if (and chinese-enable-fcitx (not (spacemacs/system-is-mswindows))) ;; disable in Windows
     (push 'fcitx chinese-packages))
 
 (defun chinese/init-fcitx ()


### PR DESCRIPTION
fcitx.el works with `fcitx-remote` in Linux or `fcitx-remote-for-osx` in
Mac OS X.But not working in Windows.