### PR TITLE
Fix early call to smartparens in ruby

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -81,13 +81,14 @@
     (progn
       (setq enh-ruby-deep-indent-paren nil
             enh-ruby-hanging-paren-deep-indent-level 2)
-      (sp-with-modes 'enh-ruby-mode
-        (sp-local-pair
-         "{" "}"
-         :pre-handlers '(sp-ruby-pre-handler)
-         :post-handlers '(sp-ruby-post-handler
-                          (spacemacs/smartparens-pair-newline-and-indent "RET"))
-         :suffix "")))))
+      (with-eval-after-load 'smartparens
+        (sp-with-modes 'enh-ruby-mode
+          (sp-local-pair
+           "{" "}"
+           :pre-handlers '(sp-ruby-pre-handler)
+           :post-handlers '(sp-ruby-post-handler
+                            (spacemacs/smartparens-pair-newline-and-indent "RET"))
+           :suffix ""))))))
 
 (defun ruby/post-init-evil-matchit ()
   (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
@@ -200,11 +201,12 @@
       (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
         "'" 'ruby-toggle-string-quotes
         "{" 'ruby-toggle-block)
-      (sp-with-modes 'ruby-mode
-        (sp-local-pair "{" "}"
-                       :pre-handlers '(sp-ruby-pre-handler)
-                       :post-handlers '(sp-ruby-post-handler (spacemacs/smartparens-pair-newline-and-indent "RET"))
-                       :suffix "")))))
+      (with-eval-after-load 'smartparens
+        (sp-with-modes 'ruby-mode
+          (sp-local-pair "{" "}"
+                         :pre-handlers '(sp-ruby-pre-handler)
+                         :post-handlers '(sp-ruby-post-handler (spacemacs/smartparens-pair-newline-and-indent "RET"))
+                         :suffix ""))))))
 
 (defun ruby/init-ruby-tools ()
   (use-package ruby-tools


### PR DESCRIPTION
`sp-with-modes` was called before `smartparens` was loaded, so I wrapped it in a `with-eval-after-load`. I wasn't sure if this needs to go in a `ruby/post-init-smartparens` instead, or if `smartparens` should be replaced with `smartparens-config` as the argument to `with-eval-after-load`.

I don't use Ruby, so I couldn't test it. Can some Ruby user give it a try please? Should also check that the pre and post handlers definition in a Ruby file match the configuration here and are not overridden by `smartparens-config`.

This should fix one of the two issues encountered in #4098 - the `Symbol's function definition is void: sp-with-modes` error.