### PR TITLE
Add ,tb binding for rspec-verify

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -130,16 +130,17 @@ directory local variables.
 *** RSpec-mode
 When =ruby-test-runner= equals =rspec=.
 
-| Key binding | Description                        |
-|-------------+------------------------------------|
-| ~SPC m t a~ | run all specs                      |
-| ~SPC m t c~ | =rspec-verify-continue=            |
-| ~SPC m t e~ | =rspec-toggle-example-pendingness= |
-| ~SPC m t f~ | run method                         |
-| ~SPC m t l~ | run last failed spec               |
-| ~SPC m t m~ | =rspec-verify-matching=            |
-| ~SPC m t r~ | re-run last spec                   |
-| ~SPC m t t~ | run spec at pointer                |
+| Key binding | Description                                   |
+|-------------+-----------------------------------------------|
+| ~SPC m t a~ | run all specs                                 |
+| ~SPC m t b~ | run current spec file                         |
+| ~SPC m t c~ | run the current spec file and subsequent ones |
+| ~SPC m t e~ | mark example as pending                       |
+| ~SPC m t f~ | run method                                    |
+| ~SPC m t l~ | run last failed spec                          |
+| ~SPC m t m~ | run specs related to the current buffer       |
+| ~SPC m t r~ | re-run last spec                              |
+| ~SPC m t t~ | run spec at pointer                           |
 
 *** Ruby-test-mode
 When =ruby-test-runner= equals =ruby-test=.

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -167,6 +167,7 @@
       (dolist (mode '(ruby-mode enh-ruby-mode))
         (spacemacs/set-leader-keys-for-major-mode mode
           "ta" 'rspec-verify-all
+          "tb" 'rspec-verify
           "tc" 'rspec-verify-continue
           "te" 'rspec-toggle-example-pendingness
           "tf" 'rspec-verify-method


### PR DESCRIPTION
The regular ruby-test-mode has a `,tb` binding for testing the current buffer.   How about adding the same binding for `rspec-verify`?