### PR TITLE
Add new alchemist-iex-reload-module functionality

### DIFF
--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -95,6 +95,7 @@ You find and overview of all the key-bindings on the [[file:alchemist-refcard.pd
 | ~SPC m s r~ | Send region to REPL buffer                                      |
 | ~SPC m s R~ | Send region to REPL buffer and focus it in =insert state=       |
 | ~SPC m s c~ | Compiles the current buffer in the IEx process.                 |
+| ~SPC m s m~ | Reloads the module in the current buffer in your IEx process    | 
 
 ** Tests
 

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -63,6 +63,7 @@
       "msr" 'alchemist-iex-send-region
       "msR" 'alchemist-iex-send-region-and-go
       "msc" 'alchemist-iex-compile-this-buffer
+      "msm" 'alchemist-iex-reload-module
 
       "mta" 'alchemist-mix-test
       "mtb" 'alchemist-mix-test-this-buffer


### PR DESCRIPTION
Since https://github.com/tonini/alchemist.el/commit/395e671703252611fb9dc211d693bf5376090e9d calling `alchemist-iex-reload-module` reloads the module in the current buffer via `r(Module)`

(Also my first contribution to spacemacs, hope I'm holding it right)