### PR TITLE
spacemacs-base: Don't use obsolete variable

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -143,8 +143,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; on OS X, see contrib/osx layer
 (setq delete-by-moving-to-trash t)
 
-;; auto fill breaks line beyond current-fill-column
-(setq-default default-fill-column 80)
+;; auto fill breaks line beyond buffer's fill-column
+(setq-default fill-column 80)
 (spacemacs|diminish auto-fill-function " Ⓕ" " F")
 
 ;; persistent abbreviation file


### PR DESCRIPTION
default-fill-column is marked obsolete since 23.2. Use setq-default on
fill-column.