### PR TITLE
eww web browsing layer

### DIFF
--- a/layers/eww/README.org
+++ b/layers/eww/README.org
@@ -17,12 +17,12 @@ browse websites or html files in text mode.
 It also provides some helm awesomeness such as fast bookmarks retrieval and
 editing.
 
-`eww-lnum` allows to quickly navigate to a link highlighting them with numbers,
-just press `f` and select the correct number; if you start typing you will
+~eww-lnum~ allows to quickly navigate to a link highlighting them with numbers,
+just press ~f~ and select the correct number; if you start typing you will
 filter the available links.
 
-`helm-eww-bookmarks` will search on all your saved pages and provides a primary
-action (enter or `F1`) to open the url and a secondary action (`F2`) to delete
+~helm-eww-bookmarks~ will search on all your saved pages and provides a primary
+action (enter or ~F1~) to open the url and a secondary action (~F2~) to delete
 the bookmark.
 
 * Install
@@ -31,6 +31,24 @@ To use this contribution add it to your =~/.spacemacs=
 #+begin_src emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(eww))
 #+end_src
+
+When you open a new eww buffer you will be prompted for an url or a search term.
+By default google will be used as a search engine.
+
+you can use the ~default-search-engine~ variable to use another service.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    eww :variables default-search-engine 'duckduckgo
+  ))
+#+END_SRC
+
+currently provided engines are:
+- 'google
+- 'stackoverflow
+- 'bing
+- 'answers (yahoo answers)
+- 'duckduckgo
 
 * Key bindings
 

--- a/layers/eww/README.org
+++ b/layers/eww/README.org
@@ -11,8 +11,19 @@
  - [[Key bindings][Key bindings]]
 
 * Description
-This layer does wonderful things:
-  - thing01
+This layer brings you vimperator style navigation on eww buffers to quickly
+browse websites or html files in text mode.
+
+It also provides some helm awesomeness such as fast bookmarks retrieval and
+editing.
+
+`eww-lnum` allows to quickly navigate to a link highlighting them with numbers,
+just press `f` and select the correct number; if you start typing you will
+filter the available links.
+
+`helm-eww-bookmarks` will search on all your saved pages and provides a primary
+action (enter or `F1`) to open the url and a secondary action (`F2`) to delete
+the bookmark.
 
 * Install
 To use this contribution add it to your =~/.spacemacs=
@@ -23,6 +34,15 @@ To use this contribution add it to your =~/.spacemacs=
 
 * Key bindings
 
-| Key Binding     | Description    |
-|-----------------+----------------|
-| ~<SPC> x x x~   | Does thing01   |
+| Key Binding | Description                   |
+|-------------+-------------------------------|
+| ~<SPC> a w~ | open a new eww buffer         |
+| ~H~         | go to previous page           |
+| ~L~         | go to next page               |
+| ~f~         | follow link with lnum         |
+| ~F~         | do action with link           |
+| ~o~         | open url                      |
+| ~Y~         | copy current page url         |
+| ~r~         | reload page                   |
+| ~b~         | helm bookmarks                |
+| ~a~         | add current page to bookmarks |

--- a/layers/eww/README.org
+++ b/layers/eww/README.org
@@ -1,0 +1,28 @@
+#+TITLE: eww layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+
+#+CAPTION: logo
+
+[[img/eww.png]]
+
+* Table of Contents                                        :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Install][Install]]
+ - [[Key bindings][Key bindings]]
+
+* Description
+This layer does wonderful things:
+  - thing01
+
+* Install
+To use this contribution add it to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(eww))
+#+end_src
+
+* Key bindings
+
+| Key Binding     | Description    |
+|-----------------+----------------|
+| ~<SPC> x x x~   | Does thing01   |

--- a/layers/eww/config.el
+++ b/layers/eww/config.el
@@ -1,0 +1,23 @@
+;;; config.el --- eww Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Andrea Moretti <axyzxp@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar eww--search-engines
+  '((google . "https://www.google.com/search?q=")
+    (stackoverflow . "http://stackoverflow.com/search?q=")
+    (bing . "https://www.bing.com/search?q=")
+    (answers . "https://answers.yahoo.com/search/search_result?p=")
+    (yahoo . "https://search.yahoo.com/search?p=")
+    (duckduckgo . "https://duckduckgo.com/html/?q=")))
+
+(defvar default-search-engine 'google)

--- a/layers/eww/extensions.el
+++ b/layers/eww/extensions.el
@@ -1,0 +1,31 @@
+;;; extensions.el --- eww Layer extensions File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Andrea Moretti <axyzxp@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq eww-pre-extensions
+      '(
+        ;; pre extension names go here
+        ))
+
+(setq eww-post-extensions
+      '(
+        ;; post extension names go here
+        ))
+
+;; For each extension, define a function eww/init-<extension-name>
+;;
+;; (defun eww/init-my-extension ()
+;;   "Initialize my extension"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package

--- a/layers/eww/packages.el
+++ b/layers/eww/packages.el
@@ -35,6 +35,8 @@
   (use-package eww
     :defer t
     :init
+    (custom-set-variables
+     `(eww-search-prefix ,(cdr (assoc default-search-engine eww--search-engines))))
     (evil-leader/set-key "aw" 'eww)
     :config
     ;; needed to populate eww-bookmarks

--- a/layers/eww/packages.el
+++ b/layers/eww/packages.el
@@ -38,9 +38,9 @@
     :init
     (evil-leader/set-key "aw" 'eww)
     :config
-    (evilified-state-evilify-map eww-mode-map
-      :mode eww-mode
-      :bindings
+    (evil-make-overriding-map eww-mode-map 'normal)
+    (evil-define-key 'normal eww-mode-map
+      "l" 'evil-forward-char
       "i" 'evil-insert
       "H" 'eww-back-url
       "L" 'eww-forward-url
@@ -50,7 +50,8 @@
       "Y" 'eww-copy-page-url
       ;; "p" TODO: open url on clipboard
       "r" 'eww-reload
-      "b" 'eww-add-bookmark)))
+      ;; "b" TODO: helm buffer with bookmarks
+      "a" 'eww-add-bookmark)))
 
 (defun eww/init-eww-lnum ()
   (use-package eww-lnum

--- a/layers/eww/packages.el
+++ b/layers/eww/packages.el
@@ -74,8 +74,9 @@
       (helm :sources (helm-source-eww-bookmarks)
             :buffer "*helm-eww-bookmarks*"))
 
-    (evil-make-overriding-map eww-mode-map 'normal)
-    (evil-define-key 'normal eww-mode-map
+    (evilified-state-evilify-map eww-mode-map
+      :mode eww-mode
+      :bindings
       "l" 'evil-forward-char
       "i" 'evil-insert
       "H" 'eww-back-url

--- a/layers/eww/packages.el
+++ b/layers/eww/packages.el
@@ -15,6 +15,7 @@
 (setq eww-packages
     '(
       eww
+      eww-lnum
       ;; package names go here
       ))
 
@@ -40,11 +41,17 @@
     (evilified-state-evilify-map eww-mode-map
       :mode eww-mode
       :bindings
+      "i" 'evil-insert
       "H" 'eww-back-url
       "L" 'eww-forward-url
-      "f" 'ace-link-eww
+      "f" 'eww-lnum-follow ;;ace-link-eww
+      "F" 'eww-lnum-universal
       "o" 'eww
       "Y" 'eww-copy-page-url
       ;; "p" TODO: open url on clipboard
       "r" 'eww-reload
       "b" 'eww-add-bookmark)))
+
+(defun eww/init-eww-lnum ()
+  (use-package eww-lnum
+    :defer t))

--- a/layers/eww/packages.el
+++ b/layers/eww/packages.el
@@ -1,0 +1,50 @@
+;;; packages.el --- eww Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Andrea Moretti <axyzxp@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; List of all packages to install and/or initialize. Built-in packages
+;; which require an initialization must be listed explicitly in the list.
+(setq eww-packages
+    '(
+      eww
+      ;; package names go here
+      ))
+
+;; List of packages to exclude.
+(setq eww-excluded-packages '())
+
+;; For each package, define a function eww/init-<package-name>
+;;
+;; (defun eww/init-my-package ()
+;;   "Initialize my package"
+;;   )
+;;
+;; Often the body of an initialize function uses `use-package'
+;; For more info on `use-package', see readme:
+;; https://github.com/jwiegley/use-package
+
+(defun eww/init-eww ()
+  (use-package eww
+    :defer t
+    :init
+    (evil-leader/set-key "aw" 'eww)
+    :config
+    (evilified-state-evilify-map eww-mode-map
+      :mode eww-mode
+      :bindings
+      "H" 'eww-back-url
+      "L" 'eww-forward-url
+      "f" 'ace-link-eww
+      "o" 'eww
+      "Y" 'eww-copy-page-url
+      ;; "p" TODO: open url on clipboard
+      "r" 'eww-reload
+      "b" 'eww-add-bookmark)))


### PR DESCRIPTION
As proposed on #4107 here it is an initial implementation of vimperator style keybindings for the eww browser.

the layer provides also a helm-eww-bookmarks function to quickly work with saved urls.

The layer seems to work, but it need to be reviewed:
- I'm not sure about function naming: I've seen a lot of variants around so I've prototyped everything with short names to be able to add prefixes as requested.
- I'd like to add a `<SPC> h w` key to open `helm-eww-bookmarks` from everywhere, but the functions needed to populate and generate it are enclosed in the eww use-package and I was not able to have them defined on spacemacs start, but only on the first eww launch (I'd like to avoid to force code outside of a deferred use-package)

new ideas and new keybindings are also welcomed.

also with just those few keys and the magic of lnum is now a pleasure to me to quickly google or stackoverflow something right inside emacs :smile: 
