### PR TITLE
Compare system-type as symbol

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -57,11 +57,11 @@
     (apply 'message msg args)))
 
 (defun spacemacs/system-is-mac ()
-  (string-equal system-type "darwin"))
+  (eq system-type 'darwin))
 (defun spacemacs/system-is-linux ()
-  (string-equal system-type "gnu/linux"))
+  (eq system-type 'gnu/linux))
 (defun spacemacs/system-is-mswindows ()
-  (string-equal system-type "windows-nt"))
+  (eq system-type 'windows-nt))
 
 (defun spacemacs/jump-in-buffer ()
   (interactive)


### PR DESCRIPTION
I just stumbled over this.  I'm not sure why it was done this way, but I think it's wrong.  As per documentation, `system-type` holds a symbol denoting the OS type, and I see no reason to treat it as string for comparison.