### PR TITLE
Fix #4151

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -586,11 +586,8 @@
 
 (defun spacemacs/init-evil-lisp-state ()
   (use-package evil-lisp-state
-    :init (setq evil-lisp-state-global t
-                ;; TODO work-around to be removed when the fix is available in
-                ;; MELPA
-                evil-lisp-state-leader (concat dotspacemacs-leader-key " k"))
-    :config (evil-lisp-state-leader (concat dotspacemacs-leader-key " k"))))
+    :init (setq evil-lisp-state-global t)
+    :config (spacemacs/set-leader-keys "k" evil-lisp-state-map)))
 
 (defun spacemacs/init-evil-mc ()
   (use-package evil-mc


### PR DESCRIPTION
Given the intended behavior of having evil-lisp-state-map available
under SPC k, it is simplest to bind it directly to
spacemacs-default-map.

This requires no changes to evil-lisp-state itself.

Fixes #4151