### PR TITLE
Check for smartparens package before calling its functions

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,12 @@
 * Release 0.104.x
+** 0.104.3 (2015/11/01)
+*** Layer changes
+**** Evil-snipe
+- Update =evil-snipe= minor mode name to match latest release of
+  the package (thanks to person808)
+**** Haskell
+- Remove indentation guides to comply with latest =haskell-mode=
+  (thanks to PierreR)
 ** 0.104.2 (2015/09/29)
 *** Hotfixes
 - Fix error =void-variable warning-minimum-level= on Emacs 24.3

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,21 @@
 * Release 0.104.x
+** 0.104.2 (2015/09/29)
+*** Hotfixes
+- Fix error =void-variable warning-minimum-level= on Emacs 24.3
+  (thanks to syohex)
+*** Layer changes
+**** Markdown
+- Fix ~SPC m c r~ binding (thanks to tko)
+*** Core
+- Silence =ad-handle-definition= about advised functions getting redefined  
+- Improve evilification rules, now ~:~ is rebound to ~|~, ~/~ is rebound to ~\~
+  and ~SPC~ is rebound to ~'~
+*** Other fixes and improvements
+- Add FAQ entry on the difference between available distributions (thanks to
+  robbyoconnor)
+- Delete obsolete =.gitmodules= file (thanks to robbyoconnor)
+- Improve convention documentation for evilified buffers
+- Typos and documentation improvements (thanks to CarlQLange)
 ** 0.104.1 (2015/09/28)
 *** Dotfile changes
 - New variable =dotspacemacs-remap-Y-to-y$=, when non nil ~Y~ is remapped to

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,7 @@
 * Release 0.104.x
+** 0.104.6 (2015/11/27)
+*** Hotfix
+- Fix void variable error =smartparens-strict-mode= (thanks to TheBB)
 ** 0.104.5 (2015/11/22)
 *** Distribution layer changes
 **** Spacemacs

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,15 @@
 * Release 0.104.x
+** 0.104.4 (2015/11/04)
+*** Layer changes
+**** Scala
+- Fix Ensime test commands to reflect the changes in the recent versions
+  of the package (thanks to lunaryorn)
+**** Vagrant
+- Replace obsolete function =vagrant-tramp-enable= by the function
+  =vagrant-tramp-add-method= (thanks to joehillen)
+*** Core
+- Prevent bootstrap packages from being automatically uninstalled
+  (thanks to TheBB)
 ** 0.104.3 (2015/11/01)
 *** Layer changes
 **** Evil-snipe

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,9 @@
 * Release 0.104.x
+** 0.104.5 (2015/11/22)
+*** Distribution layer changes
+**** Spacemacs
+- Use version 7.1 of =evil-lisp-state=, the version 8 is supported
+  in version 105 of Spacemacs only.
 ** 0.104.4 (2015/11/04)
 *** Layer changes
 **** Scala

--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ For efficient searches we recommend to install `pt` ([the platinum searcher][]).
    git clone --recursive https://github.com/syl20bnr/spacemacs ~/.emacs.d
    ```
 
-`master` is the stable branch and it is _immutable_, **DO NOT** make any
-modification to it or you will break the update mechanism. If you want to
-fork Spacemacs safely use the `develop` branch where you handle the update
-manually.
+   `master` is the stable branch and it is _immutable_, **DO NOT** make any
+   modification to it or you will break the update mechanism. If you want to
+   fork Spacemacs safely use the `develop` branch where you handle the update
+   manually.
 
 3. Launch Emacs. Spacemacs will automatically install the packages it requires.
 

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -17,6 +17,7 @@
 (require 'cl-lib)
 (require 'eieio)
 (require 'package)
+(require 'warnings)
 (require 'ht)
 (require 'core-dotspacemacs)
 (require 'core-funcs)

--- a/core/core-evilified-state.el
+++ b/core/core-evilified-state.el
@@ -219,10 +219,10 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
     (cond
      ;; space
      ((equal event 32) nil)
-     ((equal event ?/) nil)
      ((equal event ?:) nil)
      ;; C-g (cannot remap C-g)
      ((equal event ?\a) nil)
+     ((equal event ?/) ?\\)
      ((and (<= ?a event) (<= event ?z)) (- event 32))
      ;; don't shadow C-g, G is mapped directly to C-S-g
      ((equal event ?G) (+ (expt 2 25) ?\a))

--- a/core/core-evilified-state.el
+++ b/core/core-evilified-state.el
@@ -219,10 +219,10 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
     (cond
      ;; space
      ((equal event 32) nil)
-     ((equal event ?:) nil)
      ;; C-g (cannot remap C-g)
      ((equal event ?\a) nil)
      ((equal event ?/) ?\\)
+     ((equal event ?:) ?|)
      ((and (<= ?a event) (<= event ?z)) (- event 32))
      ;; don't shadow C-g, G is mapped directly to C-S-g
      ((equal event ?G) (+ (expt 2 25) ?\a))

--- a/core/core-evilified-state.el
+++ b/core/core-evilified-state.el
@@ -217,15 +217,12 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
   "Return a new event for the evilified EVENT."
   (when event
     (cond
-     ;; space
-     ((equal event 32) nil)
-     ;; C-g (cannot remap C-g)
-     ((equal event ?\a) nil)
+     ((equal event ?\a) nil) ; C-g (cannot remap C-g)
+     ((equal event 32) ?')   ; space
      ((equal event ?/) ?\\)
      ((equal event ?:) ?|)
      ((and (<= ?a event) (<= event ?z)) (- event 32))
-     ;; don't shadow C-g, G is mapped directly to C-S-g
-     ((equal event ?G) (+ (expt 2 25) ?\a))
+     ((equal event ?G) (+ (expt 2 25) ?\a)) ; G is mapped directly to C-S-g
      ((and (<= ?A event) (<= event ?Z)) (- event 64))
      ((and (<= 1 event) (<= event 26)) (+ (expt 2 25) event)))))
 

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -10,6 +10,12 @@
 ;;
 ;;; License: GPLv3
 
+(defun spacemacs/load-or-install-protected-package (pkg &optional log file-to-load)
+  "Load PKG package, and protect it against being deleted as an orphan.
+See `spacemacs/load-or-install-package' for more information."
+  (push pkg configuration-layer--protected-packages)
+  (spacemacs/load-or-install-package pkg log file-to-load))
+
 (defun spacemacs/load-or-install-package (pkg &optional log file-to-load)
   "Load PKG package. PKG will be installed if it is not already installed.
 Whenever the initial require fails the absolute path to the package

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -86,6 +86,8 @@ initialization."
   (spacemacs-buffer/set-mode-line "")
   ;; no welcome buffer
   (setq inhibit-startup-screen t)
+  ;; silence ad-handle-definition about advised functions getting redefined
+  (setq ad-redefinition-action 'accept)
   ;; default theme
   (let ((default-theme (car dotspacemacs-themes)))
     (spacemacs/load-theme default-theme)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -91,10 +91,12 @@ initialization."
   ;; default theme
   (let ((default-theme (car dotspacemacs-themes)))
     (spacemacs/load-theme default-theme)
-    ;; used to prevent automatic deletion of used packages
-    (setq spacemacs-used-theme-packages
-          (delq nil (mapcar 'spacemacs//get-theme-package
-                            dotspacemacs-themes)))
+    ;; protect used themes from deletion as orphans
+    (setq configuration-layer--protected-packages
+          (append
+           (delq nil (mapcar 'spacemacs//get-theme-package
+                             dotspacemacs-themes))
+           configuration-layer--protected-packages))
     (setq-default spacemacs--cur-theme default-theme)
     (setq-default spacemacs--cycle-themes (cdr dotspacemacs-themes)))
   ;; removes the GUI elements
@@ -122,30 +124,30 @@ initialization."
   (spacemacs-buffer/insert-banner-and-buttons)
   ;; mandatory dependencies
   ;; dash is required to prevent a package.el bug with f on 24.3.1
-  (spacemacs/load-or-install-package 'dash t)
-  (spacemacs/load-or-install-package 's t)
+  (spacemacs/load-or-install-protected-package 'dash t)
+  (spacemacs/load-or-install-protected-package 's t)
   ;; bind-key is required by use-package
-  (spacemacs/load-or-install-package 'bind-key t)
-  (spacemacs/load-or-install-package 'use-package t)
+  (spacemacs/load-or-install-protected-package 'bind-key t)
+  (spacemacs/load-or-install-protected-package 'use-package t)
   (setq use-package-verbose dotspacemacs-verbose-loading)
   ;; package-build is required by quelpa
-  (spacemacs/load-or-install-package 'package-build t)
+  (spacemacs/load-or-install-protected-package 'package-build t)
   (setq quelpa-verbose dotspacemacs-verbose-loading
         quelpa-dir (concat spacemacs-cache-directory "quelpa/")
         quelpa-build-dir (expand-file-name "build" quelpa-dir)
         quelpa-persistent-cache-file (expand-file-name "cache" quelpa-dir)
         quelpa-update-melpa-p nil)
-  (spacemacs/load-or-install-package 'quelpa t)
+  (spacemacs/load-or-install-protected-package 'quelpa t)
   ;; inject use-package hooks for easy customization of
   ;; stock package configuration
   (setq use-package-inject-hooks t)
   ;; which-key
-  (spacemacs/load-or-install-package 'which-key t)
+  (spacemacs/load-or-install-protected-package 'which-key t)
   ;; evil and evil-leader must be installed at the beginning of the
   ;; boot sequence.
   ;; Use C-u as scroll-up (must be set before actually loading evil)
-  (spacemacs/load-or-install-package 'evil t)
-  (spacemacs/load-or-install-package 'evil-leader t)
+  (spacemacs/load-or-install-protected-package 'evil t)
+  (spacemacs/load-or-install-protected-package 'evil-leader t)
   (require 'core-evilified-state)
   ;; check for new version
   (if dotspacemacs-mode-line-unicode-symbols

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -146,9 +146,6 @@
   "alist matching a theme name with its package name, required when
 package name does not match theme name + `-theme' suffix.")
 
-(defvar spacemacs-used-theme-packages nil
-  "List of packages of used themes.")
-
 (defun spacemacs//get-theme-package (theme)
   "Returns the package theme for the given THEME name."
   (cond

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -1,40 +1,40 @@
 * Spacemacs conventions
 ** Table of Contents                                                 :TOC@4:
  - [[#spacemacs-conventions][Spacemacs conventions]]
-     - [[#code-guidelines][Code guidelines]]
-         - [[#spacemacs-core-and-layer][Spacemacs core and layer]]
-         - [[#all-layers][All layers]]
-     - [[#key-bindings-conventions][Key bindings conventions]]
-         - [[#reserved-prefix][Reserved prefix]]
-             - [[#user-prefix][User prefix]]
-             - [[#major-mode-prefix][Major mode prefix]]
-             - [[#micro-state][Micro-state]]
-         - [[#evilify-buffers][Evilify buffers]]
-         - [[#navigation][Navigation]]
-             - [[#n-and-n][n and N]]
-             - [[#code-navigation][Code Navigation]]
-             - [[#insert-state-buffers][=insert state= buffers]]
-         - [[#evaluation][Evaluation]]
-         - [[#repls][REPLs]]
-             - [[#send-code][Send code]]
-             - [[#in-terminal][In terminal]]
-         - [[#building-and-compilation][Building and Compilation]]
-         - [[#debugging][Debugging]]
-         - [[#plain-text-markup-languages][Plain Text Markup Languages]]
-             - [[#headers][Headers]]
-             - [[#insertion-of-common-elements][Insertion of common elements]]
-             - [[#text-manipulation][Text manipulation]]
-             - [[#movement-in-normal-mode][Movement in normal mode]]
-             - [[#promotion-demotion-and-element-movement][Promotion, Demotion and element movement]]
-             - [[#table-editing][Table editing]]
-         - [[#tests][Tests]]
-             - [[#all-languages][All languages]]
-             - [[#language-specific][Language specific]]
-         - [[#toggles][Toggles]]
-         - [[#refactoring][Refactoring]]
-         - [[#help-or-documentation][Help or Documentation]]
-     - [[#writing-documentation][Writing documentation]]
-         - [[#spacing-in-documentation][Spacing in documentation]]
+   - [[#code-guidelines][Code guidelines]]
+     - [[#spacemacs-core-and-layer][Spacemacs core and layer]]
+     - [[#all-layers][All layers]]
+   - [[#key-bindings-conventions][Key bindings conventions]]
+     - [[#reserved-prefix][Reserved prefix]]
+       - [[#user-prefix][User prefix]]
+       - [[#major-mode-prefix][Major mode prefix]]
+       - [[#micro-state][Micro-state]]
+     - [[#evilified-buffers][Evilified buffers]]
+     - [[#navigation][Navigation]]
+       - [[#n-and-n][n and N]]
+       - [[#code-navigation][Code Navigation]]
+       - [[#insert-state-buffers][=insert state= buffers]]
+     - [[#evaluation][Evaluation]]
+     - [[#repls][REPLs]]
+       - [[#send-code][Send code]]
+       - [[#in-terminal][In terminal]]
+     - [[#building-and-compilation][Building and Compilation]]
+     - [[#debugging][Debugging]]
+     - [[#plain-text-markup-languages][Plain Text Markup Languages]]
+       - [[#headers][Headers]]
+       - [[#insertion-of-common-elements][Insertion of common elements]]
+       - [[#text-manipulation][Text manipulation]]
+       - [[#movement-in-normal-mode][Movement in normal mode]]
+       - [[#promotion-demotion-and-element-movement][Promotion, Demotion and element movement]]
+       - [[#table-editing][Table editing]]
+     - [[#tests][Tests]]
+       - [[#all-languages][All languages]]
+       - [[#language-specific][Language specific]]
+     - [[#toggles][Toggles]]
+     - [[#refactoring][Refactoring]]
+     - [[#help-or-documentation][Help or Documentation]]
+   - [[#writing-documentation][Writing documentation]]
+     - [[#spacing-in-documentation][Spacing in documentation]]
 
 ** Code guidelines
 *** Spacemacs core and layer
@@ -71,25 +71,34 @@ buffers are good candidates to be put on ~M-SPC~ and ~s-M-SPC~.
 
 It is recommended to add ~q~ to leave the micro-state.
 
-*** Evilify buffers
-=Spacemacs= offers convenient functions to /evilify/ a buffer.
+*** Evilified buffers
 /Evilifying/ a buffer is to set the =evilified state= as the default
 state for the major mode of the buffer.
 
 The =evilified state= is derived from the =emacs state= and modify the
-map to: - add ~hjkl~ navigation - add incremental search with ~/~, ~n~
-and ~N~ - add =visual state= and =visual line state= - add yank (copy)
-with ~y~ - activate evil-leader key
+map to:
+- add ~hjkl~ navigation
+- add scrolling feature on ~C-f~, ~C-b~, ~C-d~ and ~C-u~ 
+- ~G~ and ~gg~ to go to the end and beginning of the buffer
+- add incremental search with ~/~, ~n~ and ~N~
+- enabling =evil-ex= on ~:~
+- add =visual state= and =visual line state= on ~v~ and ~V~
+- add yank on ~y~ _in visual state only_
+- activate evil-leader key on ~SPC~
 
 Setting the =evilified state= to a mode is done by calling the macro
-=evilify= which takes optional parameters to fix the key bindings
-shadowed by the above modifications.
+=spacemacs|evilify-map=.
 
-To fix the shadowed bindings we capitalize them, for instance: shadowed
-~h~ is transposed to ~H~, if ~H~ is taken then it is transposed to ~C-h~
-and so on...
+/Evilification/ rebinds shadowed key bindings according to the following
+rules:
+- alphabetic key bindings: ~x~ -> ~X~ -> ~C-x~ -> ~C-X~
+- ~SPC~ -> ~'~
+- ~/~ -> ~\~
+- ~:~ -> ~|~
+- ~C-g~ cannot be shadowed
 
-Example of /evilified/ buffers are =magit status=, =paradox buffer=.
+If a key binding cannot be remapped then it is ignored and a warning message
+is displayed in =*Messages*=.
 
 *** Navigation
 **** n and N

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -7,6 +7,7 @@
      - [[#the-powerline-separators-are-ugly-how-can-i-fix-them-][The powerline separators are ugly, how can I fix them ?]]
      - [[#the-powerline-separators-have-no-anti-aliasing-what-can-i-do-][The powerline separators have no anti-aliasing, what can I do ?]]
      - [[#why-is-after-init-hook-not-executed-][Why is after-init-hook not executed ?]]
+     - [[#what-is-the-difference-between-spacemacs-base-and-spacemacs-distributions-][What is the difference between =spacemacs-base= and =spacemacs= distributions ?]]
    - [[#windows][Windows]]
      - [[#why-do-the-fonts-look-crappy-on-windows-][Why do the fonts look crappy on Windows ?]]
      - [[#why-is-there-no-spacemacs-logo-in-the-startup-buffer-][Why is there no Spacemacs logo in the startup buffer ?]]
@@ -43,6 +44,16 @@ See the powerline section in the font section of the [[file:DOCUMENTATION.org][d
 Don't launch Spacemacs with =emacs -q -l init.el= command. This command will
 run the hooked function in =after-init-hook= before the evaluation of the
 passed =-l init.el= file.
+
+*** What is the difference between =spacemacs-base= and =spacemacs= distributions ?
+ The =distribution= concept was introduced in 0.104.x. You can now choose
+ between two distributions =spacemacs= or =spacemacs-base=.
+ =spacemacs-base= contains only a minimal set of packages; whereas =spacemacs=
+ is the full Spacemacs experience.
+ Set the distribution with =dotspacemacs-distribution= variable. The default is
+ =spacemacs=. For more information as to what is included,
+ check out the =packages.el= file in the respective folders in the
+ =+distribution= folder of the =layers/= directory.
 
 ** Windows
 *** Why do the fonts look crappy on Windows ?

--- a/init.el
+++ b/init.el
@@ -14,7 +14,7 @@
 ;; (package-initialize)
 
 (setq gc-cons-threshold 100000000)
-(defconst spacemacs-version          "0.104.2" "Spacemacs version.")
+(defconst spacemacs-version          "0.104.3" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/init.el
+++ b/init.el
@@ -14,7 +14,7 @@
 ;; (package-initialize)
 
 (setq gc-cons-threshold 100000000)
-(defconst spacemacs-version          "0.104.1" "Spacemacs version.")
+(defconst spacemacs-version          "0.104.2" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/init.el
+++ b/init.el
@@ -14,7 +14,7 @@
 ;; (package-initialize)
 
 (setq gc-cons-threshold 100000000)
-(defconst spacemacs-version          "0.104.4" "Spacemacs version.")
+(defconst spacemacs-version          "0.104.5" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/init.el
+++ b/init.el
@@ -14,7 +14,7 @@
 ;; (package-initialize)
 
 (setq gc-cons-threshold 100000000)
-(defconst spacemacs-version          "0.104.3" "Spacemacs version.")
+(defconst spacemacs-version          "0.104.4" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/init.el
+++ b/init.el
@@ -14,7 +14,7 @@
 ;; (package-initialize)
 
 (setq gc-cons-threshold 100000000)
-(defconst spacemacs-version          "0.104.5" "Spacemacs version.")
+(defconst spacemacs-version          "0.104.6" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (defun spacemacs/emacs-version-ok ()

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -381,10 +381,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
       (when (configuration-layer/package-usedp 'smartparens)
         (defadvice evil-delete-backward-char-and-join
             (around spacemacs/evil-delete-backward-char-and-join activate)
-          (defvar smartparens-strict-mode)
-          ;; defadvice compiles this sexp generating a compiler warning for a
-          ;; free variable reference. The line above fixes this
-          (if smartparens-strict-mode
+          (if (bound-and-true-p smartparens-strict-mode)
               (call-interactively 'sp-backward-delete-char)
             ad-do-it))))))
 

--- a/layers/+distribution/spacemacs/local/evil-lisp-state/evil-lisp-state.el
+++ b/layers/+distribution/spacemacs/local/evil-lisp-state/evil-lisp-state.el
@@ -1,0 +1,329 @@
+;;; evil-lisp-state.el --- An evil state to edit Lisp code
+
+;; Copyright (C) 2014, 2015 syl20bnr
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; Keywords: convenience editing evil smartparens lisp mnemonic
+;; Created: 9 Oct 2014
+;; Version: 7.1
+;; Package-Requires: ((evil "1.0.9") (evil-leader "0.4.3") (smartparens "1.6.1"))
+;; URL: https://github.com/syl20bnr/evil-lisp-state
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Adds a new Evil state called --LISP-- (<L>) with mnemonics key bindings
+;; to navigate Lisp code and edit the sexp tree.
+
+;; Principle:
+;; ----------
+
+;; To execute a command while in normal state, the evil-leader is used.
+;; By default, the prefix for each command is `<leader> m`.
+;; Commands when executed set the current state to `lisp state`.
+
+;; By example, to slurp three times while in normal state:
+;;     <leader> m 3 s
+;; Or to wrap a symbol in parenthesis then slurping two times:
+;;     <leader> m w 2 s
+
+;; Key Binding    | Function
+;; ---------------|------------------------------------------------------------
+;; `leader'       | evil leader
+;; `leader m %'   | evil jump item
+;; `leader m :'   | ex command
+;; `leader m ('   | insert expression before (same level as current one)
+;; `leader m )'   | insert expression after (same level as current one)
+;; `leader m $'   | go to the end of current sexp
+;; `leader m ` k' | hybrid version of kill sexp (can be used in non lisp dialects)
+;; `leader m ` p' | hybrid version of push sexp (can be used in non lisp dialects)
+;; `leader m ` s' | hybrid version of slurp sexp (can be used in non lisp dialects)
+;; `leader m ` t' | hybrid version of transpose sexp (can be used in non lisp dialects)
+;; `leader m 0'   | go to the beginning of current sexp
+;; `leader m a'   | absorb expression
+;; `leader m b'   | forward barf expression
+;; `leader m B'   | backward barf expression
+;; `leader m c'   | convolute expression
+;; `leader m ds'  | delete symbol
+;; `leader m dw'  | delete word
+;; `leader m dx'  | delete expression
+;; `leader m e'   | (splice) unwrap current expression and kill all symbols after point
+;; `leader m E'   | (splice) unwrap current expression and kill all symbols before point
+;; `leader m h'   | previous symbol
+;; `leader m H'   | go to previous sexp
+;; `leader m i'   | switch to `insert state`
+;; `leader m I'   | go to beginning of current expression and switch to `insert state`
+;; `leader m j'   | next closing parenthesis
+;; `leader m J'   | join expression
+;; `leader m k'   | previous opening parenthesis
+;; `leader m l'   | next symbol
+;; `leader m L'   | go to next sexp
+;; `leader m p'   | paste after
+;; `leader m P'   | paste before
+;; `leader m r'   | raise expression (replace parent expression by current one)
+;; `leader m s'   | forwared slurp expression
+;; `leader m S'   | backward slurp expression
+;; `leader m t'   | transpose expression
+;; `leader m u'   | undo
+;; `leader m U'   | got to parent sexp backward
+;; `leader m C-r' | redo
+;; `leader m v'   | switch to `visual state`
+;; `leader m V'   | switch to `visual line state`
+;; `leader m C-v' | switch to `visual block state`
+;; `leader m w'   | wrap expression with parenthesis
+;; `leader m W'   | unwrap expression
+;; `leader m y'   | copy expression
+
+;; Configuration:
+;; --------------
+
+;; Key bindings are set only for `emacs-lisp-mode' by default.
+;; It is possible to add major modes with the variable
+;; `evil-lisp-state-major-modes'.
+
+;; It is also possible to define the key bindings globally by
+;; setting `evil-lisp-state-global' to t. In this case
+;; `evil-lisp-state-major-modes' has no effect.
+
+;; The prefix key is `<leader> m' by default, it is possible to
+;; change the `m' key to anything else with the variable
+;; `evil-lisp-state-leader-prefix'. Set it to an empty string
+;; if you want all the commands to be directly available
+;; under the `<leader>' key.
+
+;;; Code:
+
+(require 'evil)
+(require 'evil-leader)
+(require 'smartparens)
+
+(evil-define-state lisp
+  "Lisp state.
+ Used to navigate lisp code and manipulate the sexp tree."
+  :tag " <L> "
+  :suppress-keymap t
+  :cursor (bar . 2)
+  ;; force smartparens mode
+  (if (evil-lisp-state-p) (smartparens-mode)))
+
+(defgroup evil-lisp-state nil
+  "Evil lisp state."
+  :group 'emulations
+  :prefix 'evil-lisp-state-)
+
+(eval-and-compile
+  (defcustom evil-lisp-state-leader-prefix "m"
+    "Prefix key added to evil-lader."
+    :type 'string
+    :group 'evil-lisp-state)
+
+  (defcustom evil-lisp-state-global nil
+    "If non nil evil-lisp-state is available everywhere."
+    :type 'boolean
+    :group 'evil-lisp-state)
+
+  (defcustom evil-lisp-state-major-modes '(emacs-lisp-mode)
+    "Major modes where evil leader key bindings are defined.
+If `evil-lisp-state-global' is non nil then this variable has no effect."
+    :type 'sexp
+    :group 'evil-lisp-state))
+
+(defmacro evil-lisp-state-enter-command (command)
+  "Wrap COMMAND to call evil-lisp-state before executing COMMAND."
+  (let ((funcname (if (string-match "lisp-state-"
+                                    (symbol-name command))
+                      (intern (format "evil-%s" command))
+                    (intern (format "evil-lisp-state-%s" command)))))
+    `(progn
+       (defun ,funcname ()
+        (interactive)
+        (evil-lisp-state)
+        (call-interactively ',command))
+       ',funcname)))
+
+(defun evil-lisp-state-escape-command (command)
+  "Wrap COMMAND to escape to normal state before executing COMMAND."
+  `(lambda ()
+     (interactive)
+     (evil-normal-state)
+     (call-interactively ',command)))
+
+;; escape
+(define-key evil-lisp-state-map [escape] 'evil-normal-state)
+;; toggle lisp state
+(define-key evil-lisp-state-map ",," 'lisp-state-toggle-lisp-state)
+;; hjkl
+(define-key evil-lisp-state-map "h" 'evil-backward-char)
+(define-key evil-lisp-state-map "j" 'evil-next-visual-line)
+(define-key evil-lisp-state-map "k" 'evil-previous-visual-line)
+(define-key evil-lisp-state-map "l" 'evil-forward-char)
+;; leader
+(define-key evil-lisp-state-map (kbd evil-leader/leader) evil-leader--default-map)
+
+;; auto-switch to lisp state commands
+(defconst evil-lisp-state-commands
+  `(("%"   . evil-jump-item)
+    (":"   . evil-ex)
+    ("("   . lisp-state-insert-sexp-before)
+    (")"   . lisp-state-insert-sexp-after)
+    ("$"   . sp-end-of-sexp)
+    ("`k"  . sp-kill-hybrid-sexp)
+    ("`p"  . sp-push-hybrid-sexp)
+    ("`s"  . sp-slurp-hybrid-sexp)
+    ("`t"  . sp-transpose-hybrid-sexp)
+    ("0"   . lisp-state-beginning-of-sexp)
+    ("1"   . digit-argument)
+    ("2"   . digit-argument)
+    ("3"   . digit-argument)
+    ("4"   . digit-argument)
+    ("5"   . digit-argument)
+    ("6"   . digit-argument)
+    ("7"   . digit-argument)
+    ("8"   . digit-argument)
+    ("9"   . digit-argument)
+    ("a"   . sp-absorb-sexp)
+    ("b"   . sp-forward-barf-sexp)
+    ("B"   . sp-backward-barf-sexp)
+    ("c"   . sp-convolute-sexp)
+    ("ds"  . sp-kill-symbol)
+    ("Ds"  . sp-backward-kill-symbol)
+    ("dw"  . sp-kill-word)
+    ("Dw"  . sp-backward-kill-word)
+    ("dx"  . sp-kill-sexp)
+    ("Dx"  . sp-backward-kill-sexp)
+    ("e"   . sp-splice-sexp-killing-forward)
+    ("E"   . sp-splice-sexp-killing-backward)
+    ("h"   . sp-backward-symbol)
+    ("H"   . sp-backward-sexp)
+    ("i"   . evil-insert-state)
+    ("I"   . evil-insert-line)
+    ("j"   . lisp-state-next-closing-paren)
+    ("J"   . sp-join-sexp)
+    ("k"   . lisp-state-prev-opening-paren)
+    ("l"   . lisp-state-forward-symbol)
+    ("L"   . sp-forward-sexp)
+    ("p"   . evil-paste-after)
+    ("P"   . evil-paste-before)
+    ("r"   . sp-raise-sexp)
+    ("s"   . sp-forward-slurp-sexp)
+    ("S"   . sp-backward-slurp-sexp)
+    ("t"   . sp-transpose-sexp)
+    ("u"   . undo-tree-undo)
+    ("U"   . sp-backward-up-sexp)
+    ("C-r" . undo-tree-redo)
+    ("v"   . evil-visual-char)
+    ("V"   . evil-visual-line)
+    ("C-v" . evil-visual-block)
+    ("w"   . lisp-state-wrap)
+    ("W"   . sp-unwrap-sexp)
+    ("y"   . sp-copy-sexp))
+  "alist of keys and commands in lisp state.")
+(dolist (x evil-lisp-state-commands)
+  (let ((key (car x))
+        (cmd (cdr x)))
+    (eval
+     `(progn
+        (define-key evil-lisp-state-map ,(kbd key) ',cmd)
+        (if evil-lisp-state-global
+            (evil-leader/set-key
+              ,(kbd (concat evil-lisp-state-leader-prefix " " key))
+              (evil-lisp-state-enter-command ,cmd))
+          (dolist (mm evil-lisp-state-major-modes)
+            (evil-leader/set-key-for-mode mm
+              ,(kbd (concat evil-lisp-state-leader-prefix " " key))
+              (evil-lisp-state-enter-command ,cmd))))))))
+
+(defun lisp-state-toggle-lisp-state ()
+  "Toggle the lisp state."
+  (interactive)
+  (message "state: %s" evil-state)
+  (if (eq 'lisp evil-state)
+      (evil-normal-state)
+    (evil-lisp-state)))
+
+(defun lisp-state-wrap (&optional arg)
+  "Wrap a symbol with parenthesis."
+  (interactive "P")
+  (sp-wrap-with-pair "("))
+
+(defun evil-lisp-state-next-paren (&optional closing)
+  "Go to the next/previous closing/opening parenthesis."
+  (if closing
+      (let ((curr (point)))
+        (forward-char)
+        (unless (eq curr (search-forward ")"))
+          (backward-char)))
+    (search-backward "(")))
+
+(defun lisp-state-prev-opening-paren ()
+  "Go to the next closing parenthesis."
+  (interactive)
+  (evil-lisp-state-next-paren))
+
+(defun lisp-state-next-closing-paren ()
+  "Go to the next closing parenthesis."
+  (interactive)
+  (evil-lisp-state-next-paren 'closing))
+
+(defun lisp-state-forward-symbol (&optional arg)
+  "Go to the beginning of the next symbol."
+  (interactive "P")
+  (let ((n (if (char-equal (char-after) ?\() 1 2)))
+    (sp-forward-symbol (+ (if arg arg 0) n))
+    (sp-backward-symbol)))
+
+(defun lisp-state-insert-sexp-after ()
+  "Insert sexp after the current one."
+  (interactive)
+  (let ((sp-navigate-consider-symbols nil))
+    (if (char-equal (char-after) ?\() (forward-char))
+    (sp-up-sexp)
+    (evil-insert-state)
+    (sp-newline)
+    (sp-insert-pair "(")))
+
+(defun lisp-state-insert-sexp-before ()
+  "Insert sexp before the current one."
+  (interactive)
+  (let ((sp-navigate-consider-symbols nil))
+    (if (char-equal (char-after) ?\() (forward-char))
+    (sp-backward-sexp)
+    (evil-insert-state)
+    (sp-newline)
+    (evil-previous-visual-line)
+    (evil-end-of-line)
+    (insert " ")
+    (sp-insert-pair "(")
+    (indent-for-tab-command)))
+
+(defun lisp-state-eval-sexp-end-of-line ()
+  "Evaluate the last sexp at the end of the current line."
+  (interactive)
+  (save-excursion
+    (end-of-line)
+    (eval-last-sexp nil)))
+
+(defun lisp-state-beginning-of-sexp (&optional arg)
+  "Go to the beginning of current s-exp"
+  (interactive "P")
+  (sp-beginning-of-sexp)
+  (evil-backward-char))
+
+
+(provide 'evil-lisp-state)
+
+;;; evil-lisp-state.el ends here

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -33,7 +33,7 @@
         evil-iedit-state
         (evil-indent-textobject :location (recipe :fetcher github :repo "TheBB/evil-indent-textobject"))
         evil-jumper
-        evil-lisp-state
+        (evil-lisp-state :location local)
         evil-nerd-commenter
         evil-matchit
         evil-numbers
@@ -573,11 +573,12 @@
       (evil-jumper-mode t))))
 
 (defun spacemacs/init-evil-lisp-state ()
-  (use-package evil-lisp-state
-    :init
-    (progn
-      (setq evil-lisp-state-global t)
-      (setq evil-lisp-state-leader-prefix "k"))))
+  (with-eval-after-load 'smartparens
+    (use-package evil-lisp-state
+      :init
+      (progn
+        (setq evil-lisp-state-global t)
+        (setq evil-lisp-state-leader-prefix "k")))))
 
 ;; other commenting functions in funcs.el with keybinds in keybindings.el
 (defun spacemacs/init-evil-nerd-commenter ()

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -31,7 +31,9 @@
       (defun slime/disable-smartparens ()
         (smartparens-strict-mode -1)
         (turn-off-smartparens-mode))
-      (add-hook 'slime-repl-mode-hook #'slime/disable-smartparens)
+      ;; only add hook if smartparens is present
+      (when (require 'smartparens nil 'noerror)
+        (add-hook 'slime-repl-mode-hook #'slime/disable-smartparens))
       (spacemacs/add-to-hooks 'slime-mode '(lisp-mode-hook)))
     :config
     (progn

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -167,29 +167,7 @@
       ;; Useful to have these keybindings for .cabal files, too.
       (eval-after-load 'haskell-cabal-mode-map
         '(define-key haskell-cabal-mode-map
-           [?\C-c ?\C-z] 'haskell-interactive-switch))))
-
-
-  (eval-after-load 'haskell-indentation
-    '(progn
-       ;; Show indentation guides in insert or emacs state only.
-       (defun spacemacs//haskell-indentation-show-guides ()
-         "Show visual indentation guides."
-         (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
-           (haskell-indentation-enable-show-indentations)))
-
-       (defun spacemacs//haskell-indentation-hide-guides ()
-         "Hide visual indentation guides."
-         (when (and (boundp 'haskell-indentation-mode) haskell-indentation-mode)
-           (haskell-indentation-disable-show-indentations)))
-
-       ;; first entry in normal state
-       (add-hook 'evil-normal-state-entry-hook 'spacemacs//haskell-indentation-hide-guides)
-
-       (add-hook 'evil-insert-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-       (add-hook 'evil-emacs-state-entry-hook 'spacemacs//haskell-indentation-show-guides)
-       (add-hook 'evil-insert-state-exit-hook 'spacemacs//haskell-indentation-hide-guides)
-       (add-hook 'evil-emacs-state-exit-hook 'spacemacs//haskell-indentation-hide-guides))))
+           [?\C-c ?\C-z] 'haskell-interactive-switch)))))
 
 (defun haskell/init-haskell-snippets ()
   ;; manually load the package since the current implementation is not lazy

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -13,6 +13,7 @@
 (setq markdown-packages
   '(
     emoji-cheat-sheet-plus
+    gh-md
     markdown-mode
     markdown-toc
     mmm-mode
@@ -23,6 +24,10 @@
 
 (defun markdown/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'markdown-mode-hook 'emoji-cheat-sheet-plus-display-mode))
+
+(defun markdown/init-gh-md ()
+  (use-package gh-md
+    :defer t))
 
 (defun markdown/post-init-smartparens ()
   (add-hook 'markdown-mode-hook 'smartparens-mode))

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -27,7 +27,10 @@
 
 (defun markdown/init-gh-md ()
   (use-package gh-md
-    :defer t))
+    :defer t
+    :init
+    (evil-leader/set-key-for-mode 'markdown-mode
+      "mcr"  'gh-md-render-buffer)))
 
 (defun markdown/post-init-smartparens ()
   (add-hook 'markdown-mode-hook 'smartparens-mode))
@@ -69,7 +72,6 @@ Will work on both org-mode and any mode that accepts plain html."
         "mcw"  'markdown-kill-ring-save
         "mcc"  'markdown-check-refs
         "mcn"  'markdown-cleanup-list-numbers
-        "mcr"  'gh-md-render-buffer
         ;; headings
         "mhi"  'markdown-insert-header-dwim
         "mhI"  'markdown-insert-header-setext-dwim

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -139,9 +139,9 @@
         "mrt"     'ensime-import-type-at-point
         "mrv"     'ensime-refactor-extract-local
 
-        "mta"     'ensime-sbt-do-test
-        "mtr"     'ensime-sbt-do-test-quick
-        "mtt"     'ensime-sbt-do-test-only
+        "mta"     'ensime-sbt-do-test-dwim
+        "mtr"     'ensime-sbt-do-test-quick-dwim
+        "mtt"     'ensime-sbt-do-test-only-dwim
 
         "msa"     'ensime-inf-load-file
         "msb"     'ensime-inf-eval-buffer

--- a/layers/+source-control/github/config.el
+++ b/layers/+source-control/github/config.el
@@ -13,6 +13,6 @@
 ;; Command prefixes
 
 (setq github/key-binding-prefixes '(("gf" . "github/file")
-                                    ("gg" . "githib/gist")))
+                                    ("gg" . "github/gist")))
 (mapc (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))
       github/key-binding-prefixes)

--- a/layers/+tools/vagrant/packages.el
+++ b/layers/+tools/vagrant/packages.el
@@ -37,6 +37,6 @@
       (defadvice vagrant-tramp-term (before spacemacs//load-vagrant activate)
         "Lazy load vagrant-tramp."
         (unless spacemacs--vagrant-tramp-loaded
-          (vagrant-tramp-enable)
+          (vagrant-tramp-add-method)
           (setq spacemacs--vagrant-tramp-loaded t)))
       (evil-leader/set-key "Vt" 'vagrant-tramp-term))))

--- a/layers/+vim/evil-snipe/packages.el
+++ b/layers/+vim/evil-snipe/packages.el
@@ -2,7 +2,7 @@
 
 (defun evil-snipe/init-evil-snipe ()
   (use-package evil-snipe
-    :diminish evil-snipe-mode
+    :diminish evil-snipe-local-mode
     :init
     (setq evil-snipe-scope 'whole-buffer
           evil-snipe-enable-highlight t

--- a/tests/core/core-evilified-state-utest.el
+++ b/tests/core/core-evilified-state-utest.el
@@ -37,17 +37,17 @@
   (let ((input (+ (expt 2 25) ?\C-s)))
     (should (equal nil (spacemacs//evilify-find-new-event input)))))
 
-(ert-deftest test-evilify-find-new-event--Space-error-return-nil ()
+(ert-deftest test-evilify-find-new-event--Space-remap ()
   (let ((input 32))
-    (should (equal nil (spacemacs//evilify-find-new-event input)))))
+    (should (equal ?' (spacemacs//evilify-find-new-event input)))))
 
-(ert-deftest test-evilify-find-new-event--/-error-not-covered-for-now ()
+(ert-deftest test-evilify-find-new-event--/-remap ()
   (let ((input ?/))
-    (should (equal nil (spacemacs//evilify-find-new-event input)))))
+    (should (equal ?\\ (spacemacs//evilify-find-new-event input)))))
 
-(ert-deftest test-evilify-find-new-event--/-error-return-nil ()
+(ert-deftest test-evilify-find-new-event--:-remap ()
   (let ((input ?:))
-    (should (equal nil (spacemacs//evilify-find-new-event input)))))
+    (should (equal ?| (spacemacs//evilify-find-new-event input)))))
 
 ;; ---------------------------------------------------------------------------
 ;; spacemacs//evilify-sort-keymap


### PR DESCRIPTION
smartparens does not seem to be included in the common-lisp layer.  I am using spacemacs-base with common-lisp and emacs-lisp layers, and exwm as an additional package. smartparens is not installed.

Calling its functions when it isn't installed causes slime to crash before getting to a repl, every time.  One of the hooks for the common-lisp layer calls two of them.

Installing the smartparens package from within emacs, using package-install, allowed me to get to a repl.  

Commenting out its functions, without installing smartparens, also allowed me to get to a repl.

This is a better solution than either.  This change allows you to use slime without having smartparens installed.  If it isn't found, its hook isn't invoked.