### PR TITLE
Add Lean Mode

### DIFF
--- a/layers/+lang/lean/README.org
+++ b/layers/+lang/lean/README.org
@@ -1,0 +1,52 @@
+#+TITLE: Lean Layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
+
+
+* Description
+This layer adds support for the [[https://leanprover.github.io][Lean]] theorem prover.
+* Install
+** Layer
+To use this layer, first add it to your =.spacemacs=.
+
+#+BEGIN_SRC elisp
+(setq-default dotspacemacs-configuration-layers '(lean))
+#+END_SRC
+
+Then configure Lean's root directory as follows:
+*** Case 1: You built Lean from source:
+Suppose that the full path to the root directory of Lean's source is =~/projects/lean=, then put this in your =.spacemacs=:
+
+#+BEGIN_SRC elisp
+(setq-default lean-rootdir "~/projects/lean")
+#+END_SRC
+
+*** Case 2: You installed Lean via dpkg, or apt-get:
+Put this in your =.spacemacs.=
+
+#+BEGIN_SRC elisp
+(setq-default lean-rootdir "/usr")
+#+END_SRC
+
+*** Case 3: You installed Lean via homebrew:
+If you installed Lean in the default directory, put this in your =.spacemacs.=:
+
+#+BEGIN_SRC elisp
+(setq-default lean-rootdir "/usr/local")
+#+END_SRC
+
+
+* Key Bindings
+| Key Binding | Description                                  |
+|-------------+----------------------------------------------|
+| ~SPC m L~   | Compile the current file/project.            |
+| ~SPC m R~   | Restart the Lean Server.                     |
+| ~SPC m d~   | Show Eldoc Documentation for value at point. |
+| ~SPC m f~   | Fill a placeholder.                          |
+| ~SPC m g g~ | Find tag at point.                           |
+| ~SPC m g u~ | Update Lean tags.                            |
+| ~SPC m o~   | Set options for current Lean process.        |
+| ~SPC m c~   | Execute a Lean commmand.                     |
+| ~SPC m ,~   | Show goal at point.                          |
+| ~SPC m t~   | Show type of value at point.                 |
+| ~SPC m i~   | Show ID/Keyword info t point.                |
+| ~SPC m k~   | Show how to type the key at point.           |

--- a/layers/+lang/lean/README.org
+++ b/layers/+lang/lean/README.org
@@ -38,15 +38,15 @@ If you installed Lean in the default directory, put this in your =.spacemacs.=:
 * Key Bindings
 | Key Binding | Description                                  |
 |-------------+----------------------------------------------|
-| ~SPC m L~   | Compile the current file/project.            |
+| ~SPC m c c~ | Compile the current file/project.            |
 | ~SPC m R~   | Restart the Lean Server.                     |
-| ~SPC m d~   | Show Eldoc Documentation for value at point. |
+| ~SPC m h h~ | Show Eldoc Documentation for value at point. |
+| ~SPC m h t~ | Show type of value at point.                 |
+| ~SPC m h i~ | Show ID/Keyword info t point.                |
 | ~SPC m f~   | Fill a placeholder.                          |
 | ~SPC m g g~ | Find tag at point.                           |
 | ~SPC m g u~ | Update Lean tags.                            |
-| ~SPC m o~   | Set options for current Lean process.        |
-| ~SPC m c~   | Execute a Lean commmand.                     |
+| ~SPC e f~   | Set flags for current Lean process.          |
+| ~SPC e c~   | Execute a Lean commmand.                     |
 | ~SPC m ,~   | Show goal at point.                          |
-| ~SPC m t~   | Show type of value at point.                 |
-| ~SPC m i~   | Show ID/Keyword info t point.                |
-| ~SPC m k~   | Show how to type the key at point.           |
+| ~SPC m h k~ | Show how to type the key at point.           |

--- a/layers/+lang/lean/config.el
+++ b/layers/+lang/lean/config.el
@@ -1,0 +1,16 @@
+;;; config.el --- Lean Layer config File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(configuration-layer/declare-layers '(auto-completion lua syntax-checking))
+
+(spacemacs|defvar-company-backends lean-mode)
+(push 'lean-company company-backends-lean-mode)

--- a/layers/+lang/lean/packages.el
+++ b/layers/+lang/lean/packages.el
@@ -14,17 +14,11 @@
                                             :fetcher github
                                             :repo leanprover/lean
                                             :files ("src/emacs/*.el")))))
-(defun lean/init-f ()
-  (use-package f
-    :defer t))
+(defun lean/init-f ())
 
-(defun lean/init-dash-functional ()
-  (use-package dash-functional
-    :defer t))
+(defun lean/init-dash-functional ())
 
-(defun lean/init-mmm-mode ()
-  (use-package mmm-mode
-    :defer t))
+(defun lean/init-mmm-mode ())
 
 (defun lean/init-lean-mode ()
   (use-package lean-mode

--- a/layers/+lang/lean/packages.el
+++ b/layers/+lang/lean/packages.el
@@ -1,0 +1,45 @@
+;;; packages.el --- Lean Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+(setq lean-packages '(mmm-mode f dash-functional
+                      (lean-mode :location (recipe
+                                            :fetcher github
+                                            :repo leanprover/lean
+                                            :files ("src/emacs/*.el")))))
+(defun lean/init-f ()
+  (use-package f
+    :defer t))
+
+(defun lean/init-dash-functional ()
+  (use-package dash-functional
+    :defer t))
+
+(defun lean/init-mmm-mode ()
+  (use-package mmm-mode
+    :defer t))
+
+(defun lean/init-lean-mode ()
+  (use-package lean-mode
+    :defer t
+    :config
+    (evil-leader/set-key-for-mode 'lean-mode
+      "L" 'lean-std-exe
+      "R" 'lean-server-restart-process
+      "d" 'lean-eldoc-documentation-function
+      "f" 'lean-fill-placeholder
+      "gu" 'lean-generate-tags
+      "gg" 'lean-find-tag
+      "o" 'lean-set-option
+      "c" 'lean-eval-cmd
+      "," 'lean-show-goal-at-pos
+      "k" 'quail-show-key
+      "i" 'lean-show-id-keyword-info
+      "t" 'lean-show-type)))

--- a/layers/+lang/lean/packages.el
+++ b/layers/+lang/lean/packages.el
@@ -26,16 +26,17 @@
   (use-package lean-mode
     :defer t
     :config
+    (progn
     (spacemacs/set-leader-keys-for-major-mode 'lean-mode
-      "L" 'lean-std-exe
+      "cc" 'lean-std-exe
       "R" 'lean-server-restart-process
-      "d" 'lean-eldoc-documentation-function
+      "hh" 'lean-eldoc-documentation-function
       "f" 'lean-fill-placeholder
       "gu" 'lean-generate-tags
       "gg" 'lean-find-tag
-      "o" 'lean-set-option
-      "c" 'lean-eval-cmd
+      "ef" 'lean-set-option
+      "ec" 'lean-eval-cmd
       "," 'lean-show-goal-at-pos
-      "k" 'quail-show-key
-      "i" 'lean-show-id-keyword-info
-      "t" 'lean-show-type)))
+      "hk" 'quail-show-key
+      "hi" 'lean-show-id-keyword-info
+      "ht" 'lean-show-type))))

--- a/layers/+lang/lean/packages.el
+++ b/layers/+lang/lean/packages.el
@@ -9,7 +9,9 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
-(setq lean-packages '(mmm-mode f dash-functional
+(setq lean-packages '(mmm-mode 
+                      f 
+                      dash-functional
                       (lean-mode :location (recipe
                                             :fetcher github
                                             :repo leanprover/lean
@@ -24,7 +26,7 @@
   (use-package lean-mode
     :defer t
     :config
-    (evil-leader/set-key-for-mode 'lean-mode
+    (spacemacs/set-leader-keys-for-major-mode 'lean-mode
       "L" 'lean-std-exe
       "R" 'lean-server-restart-process
       "d" 'lean-eldoc-documentation-function


### PR DESCRIPTION
This pull request adds a layer for the Lean proof assistant: https://leanprover.github.io/. The layer owns `dash-functional` and `f` as to my own knowledge these packages aren't installed by Spacemacs itself. The layer requires additional layers since those layers own packages that lean-mode imports using `require`. 