### PR TITLE
Add new bindings to ESS layer

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -5,10 +5,15 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Install][Install]]
- - [[Key Bindings][Key Bindings]]
-   - [[Inferior REPL process][Inferior REPL process]]
-   - [[Helpers][Helpers]]
  - [[Options][Options]]
+   - [[Style][Style]]
+   - [[Roxygen][Roxygen]]
+ - [[Key Bindings][Key Bindings]]
+   - [[Inferior ESS Processes][Inferior ESS Processes]]
+   - [[Evaluation Commands][Evaluation Commands]]
+   - [[Developer][Developer]]
+   - [[Debugging][Debugging]]
+   - [[Help][Help]]
 
 * Install
 To use this contribution add it to your =~/.spacemacs=
@@ -16,41 +21,6 @@ To use this contribution add it to your =~/.spacemacs=
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers '(ess))
 #+END_SRC
-
-* Key Bindings
-
-** Inferior REPL process
-Send code to inferior process with these commands:
-
-| Key Binding | Description                                                      |
-|-------------+------------------------------------------------------------------|
-| ~SPC m c c~ | send knitr/sweave chunk and keep buffer focused                  |
-| ~SPC m c C~ | send knitr/sweave chunk and switch to REPL in insert mode        |
-| ~SPC m c d~ | send knitr/sweave chunk and step to next chunk                   |
-| ~SPC m c m~ | mark knitr/sweave chunk around point                             |
-| ~SPC m c n~ | next knitr/sweave chunk                                          |
-| ~SPC m c N~ | previous knitr/sweave chunk                                      |
-| ~SPC m s b~ | send buffer and keep code buffer focused                         |
-| ~SPC m s B~ | send buffer and switch to REPL in insert mode                    |
-| ~SPC m s d~ | send region or line and step (debug)                             |
-| ~SPC m s D~ | send function or paragraph and step (debug)                      |
-| ~SPC m s i~ | start an inferior REPL process                                   |
-| ~SPC m s l~ | send line and keep code buffer focused                           |
-| ~SPC m s L~ | send line and switch to REPL in insert mode                      |
-| ~SPC m s r~ | send region and keep code buffer focused                         |
-| ~SPC m s R~ | send region and switch to REPL in insert mode                    |
-| ~SPC m s t~ | send thing at point (function) and keep code buffer focused      |
-| ~SPC m s T~ | send thing at point (function) and switch to REPL in insert mode |
-| ~CTRL+j~    | next item in REPL history                                        |
-| ~CTRL+k~    | previous item in REPL history                                    |
-
-** Helpers
-Helpers for inspecting objects at point are available in R buffers only.
-| Key Binding | Description                                                         |
-|-------------+---------------------------------------------------------------------|
-| ~SPC m h d~ | view data under point using [ess-R-data-view][ess-R-data-view]      |
-| ~SPC m h i~ | object introspection popup [ess-R-object-popup][ess-R-object-popup] |
-| ~SPC m h t~ | view table using [ess-R-data-view][ess-R-data-view]                 |
 
 * Options
 =ess-smart-equals= is disabled by default. In order to enable it, set in your
@@ -69,3 +39,133 @@ hook:
             (lambda ()
               (ess-toggle-underscore nil)))
 #+end_src
+
+** Style
+ESS offers good support for various indentation styles.  This layer offers two
+variables to control the style =ess-user-style= and =ess-user-style-def=.  Set
+the former to the symbol of the style you want to use e.g.
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '((ess :variables
+                                                         ess-user-style 'GNU)))
+#+END_SRC
+
+ESS defines styles for (at time of writing) RStudio, GNU, RRR, BSD, C++, CLB,
+RRR+, and K&R
+
+If you want to define your own style, set the =ess-user-style-def= variable to
+the style specification; the layer will put it on =ess-style-alist=.  For
+example:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+ '((ess :variables
+         ess-user-style-def '(my-RStudio
+                              (ess-indent-offset . 4) ;; this is the only change.
+                              (ess-offset-arguments . open-delim)
+                              (ess-offset-arguments-newline . prev-line)
+                              (ess-offset-block . prev-line)
+                              (ess-offset-continued . straight)
+                              (ess-align-declaration-args . t)
+                              (ess-align-nested-calls . nil)
+                              (ess-align-continuations-in-calls . nil)
+                              (ess-align-blocks . nil)
+                              (ess-indent-prev-call-lhs . t)
+                              (ess-indent-prev-call-chains . t)
+                              (ess-indent-with-fancy-comments . nil)))))
+#+END_SRC
+
+** Roxygen
+ESS' fills in Roxygen templates from an internal variable.  Some users may wish
+to overwrite this variable with an alternative value e.g. so that the author
+field is specified.  For example:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+ '((ess :variables
+        ess-user-roxy-template '(("description" . " headline ")
+                                 ("details" . " details ")
+                                 ("param" . "")
+                                 ("author" . "Your Name")))))
+#+END_SRC
+
+* Key Bindings
+
+** Inferior ESS Processes
+Manage inferior ESS processes.
+
+| Key Binding | Description                                                                |
+|-------------+----------------------------------------------------------------------------|
+| ~SPC m s i~ | start an inferior REPL process                                             |
+| ~SPC m s a~ | pick an inferior process to attach the current buffer to                   |
+| ~SPC m s w~ | set the working directory for the REPL                                     |
+| ~SPC m s p~ | load the specified library into the REPL                                   |
+| ~SPC m s P~ | install the specified library                                              |
+
+** Evaluation Commands
+Send code to inferior process with these commands:
+
+| Key Binding | Description                                                                      |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m c c~ | send knitr/sweave chunk and keep buffer focused                                  |
+| ~SPC m c C~ | send knitr/sweave chunk and switch to REPL in insert mode                        |
+| ~SPC m c d~ | send knitr/sweave chunk and step to next chunk                                   |
+| ~SPC m c m~ | mark knitr/sweave chunk around point                                             |
+| ~SPC m c n~ | next knitr/sweave chunk                                                          |
+| ~SPC m c N~ | previous knitr/sweave chunk                                                      |
+| ~SPC m s b~ | send buffer and keep code buffer focused                                         |
+| ~SPC m s B~ | send buffer and switch to REPL in insert mode                                    |
+| ~SPC m s d~ | send region or line and step (debug)                                             |
+| ~SPC m s D~ | send function or paragraph and step (debug)                                      |
+| ~SPC m s l~ | send line and keep code buffer focused                                           |
+| ~SPC m s L~ | send line and switch to REPL in insert mode                                      |
+| ~SPC m s r~ | send region and keep code buffer focused                                         |
+| ~SPC m s R~ | send region and switch to REPL in insert mode                                    |
+| ~SPC m s t~ | send thing at point (function) and keep code buffer focused                      |
+| ~SPC m s T~ | send thing at point (function) and switch to REPL in insert mode                 |
+| ~SPC m s :~ | execute a command in the REPL, displaying the results in a separate buffer       |
+| ~SPC m v d~ | display a dired-like buffer browsing the objects in the inferior session buffer. |
+| ~CTRL+j~    | next item in REPL history                                                        |
+| ~CTRL+k~    | previous item in REPL history                                                    |
+
+** Developer
+Useful, IDE like functions.
+| Key Binding | Description                                                                                |
+|-------------+--------------------------------------------------------------------------------------------|
+| ~SPC m d l~ | ~(ess-developer-load-package)~ load a specified directory with ~devtools::load_all~        |
+| ~SPC m d s~ | ~(ess-set-style)~ set the indenting style from the available specifications.               |
+| ~SPC m d t~ | ~(ess-build-tags-for-directory)~ build a RTAGS file for the specified directory            |
+| ~SPC m r r~ | ~(ess-roxy-update-entry)~ insert or update the roxygen string for the function under point |
+| ~SPC m r h~ | ~(ess-roxy-hide-all)~ hide all roxygen strings in the buffer                               |
+| ~SPC m r t~ | ~(ess-roxy-toggle-hiding)~ toggle hiding of the roxygen strings                            |
+| ~SPC m r n~ | ~(ess-roxy-next-entry)~ go to the next roxygen entry                                       |
+| ~SPC m r p~ | ~(ess-roxy-previous-entry)~ go to the previous roxygen entry                               |
+| ~SPC m r P~ | ~(ess-roxy-preview-text)~ preview the rendered help text                                   |
+
+** Debugging
+Bindings for interacting with the debugger.
+| Key Binding | Description                                                                                                      |
+|-------------+------------------------------------------------------------------------------------------------------------------|
+| ~SPC m d e~ | ~(ess-debug-toggle-error-action)~ cycle the error action for the buffer's inferior process                       |
+| ~SPC m d w~ | ~(ess-watch)~ set an ess-watch                                                                                   |
+| ~SPC m b s~ | ~(ess-bp-set)~ set a breakpoint at the point                                                                     |
+| ~SPC m b c~ | ~(ess-bp-set-condition)~ set a conditional breakpoint at the point                                               |
+| ~SPC m b l~ | ~(ess-bp-set-logger)~ set a logger at the point                                                                  |
+| ~SPC m b t~ | ~(ess-bp-toggle-state)~ toggle the state of the breakpoint under point                                           |
+| ~SPC m b k~ | ~(ess-bp-kill)~ kill the breakpoint under the point                                                              |
+| ~SPC m b K~ | ~(ess-bp-kill-all)~ kill all of the breakpoints                                                                  |
+| ~SPC m b n~ | ~(ess-bp-next)~ go to the next breakpoint                                                                        |
+| ~SPC m b p~ | ~(ess-bp-next)~ go to the previous breakpoint                                                                    |
+| ~SPC m b m~ | ~(ess-debug-flag-for-debugging)~ flag the specified function for debugging, as though you called debug(function) |
+| ~SPC m b M~ | ~(ess-debug-unflag-for-debugging)~ unset the debug flag for the specified function.                              |
+
+** Help
+Helpers for inspecting objects at point are available in R buffers only.
+| Key Binding | Description                                                         |
+|-------------+---------------------------------------------------------------------|
+| ~SPC m h d~ | view data under point using [ess-R-data-view][ess-R-data-view]      |
+| ~SPC m h i~ | object introspection popup [ess-R-object-popup][ess-R-object-popup] |
+| ~SPC m h t~ | view table using [ess-R-data-view][ess-R-data-view]                 |
+| ~SPC m h h~ | display help on the object under point (or as specified)            |
+| ~SPC m h a~ | display help apropos the search string                              |
+| ~SPC m h p~ | display the package index for the attached process                  |
+| ~SPC m h v~ | display vignettes for the selected package                          |

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -12,5 +12,13 @@
 
 ;; Variables
 
+(defvar ess-user-style-def nil
+  "If non-nil, add the style to ess-style-alist")
+(defvar ess-user-style 'RStudio
+  "Use the named style for ess-set-style.  Defaults to 'RStudio")
 (defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")
+(defvar ess-user-R-fontlock nil
+  "If non-nil, set ess-R-font-lock-keywords to its value.")
+(defvar ess-user-roxy-template nil
+  "If non-null, set ess-roxy-template-alist to its value")

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -11,14 +11,14 @@
 ;;; License: GPLv3
 
 (setq ess-packages
-  '(
-    company
-    ess
-    ess-R-data-view
-    ess-R-object-popup
-    ess-smart-equals
-    rainbow-delimiters
-    ))
+      '(
+        company
+        ess
+        ess-R-data-view
+        ess-R-object-popup
+        ess-smart-equals
+        rainbow-delimiters
+        ))
 
 (defun ess/init-ess ()
   (use-package ess-site
@@ -54,55 +54,94 @@
     :init
     (progn
       (when (configuration-layer/package-usedp 'company)
-          (add-hook 'ess-mode-hook 'company-mode-on))))
+        (add-hook 'ess-mode-hook 'company-mode-on))
+      (with-eval-after-load 'ess-site
+        (if ess-user-style-def
+            (add-to-list 'ess-style-alist ess-user-style-def))
+        (if ess-user-roxy-template
+            (setq ess-roxy-template-alist ess-user-roxy-template))
 
-  ;; R --------------------------------------------------------------------------
-  (with-eval-after-load 'ess-site
-    ;; Follow Hadley Wickham's R style guide
-    (setq ess-first-continued-statement-offset 2
-          ess-continued-statement-offset 0
-          ess-expression-offset 2
-          ess-nuke-trailing-whitespace-p t
-          ess-default-style 'DEFAULT)
+        ;; instead of setting style vars directly, set style with ess-set-style
+        (add-hook 'ess-mode-hook (lambda () (ess-set-style ess-user-style)))
 
-    (defun spacemacs/ess-start-repl ()
-      "Start a REPL corresponding to the ess-language of the current buffer."
-      (interactive)
-      (cond
-       ((string= "S" ess-language) (call-interactively 'R))
-       ((string= "STA" ess-language) (call-interactively 'stata))
-       ((string= "SAS" ess-language) (call-interactively 'SAS))))
+        ;; Follow Hadley Wickham's R style guide
+        ;; (setq ess-first-continued-statement-offset 2
+        ;;       ess-continued-statement-offset 0
+        ;;       ess-expression-offset 2
+        ;;       ess-nuke-trailing-whitespace-p t
+        ;;       ess-default-style 'DEFAULT)
 
-    (spacemacs/set-leader-keys-for-major-mode 'ess-julia-mode
-      "si" 'julia)
-    (spacemacs/set-leader-keys-for-major-mode 'ess-mode
-      "si" 'spacemacs/ess-start-repl
-      ;; noweb
-      "cC" 'ess-eval-chunk-and-go
-      "cc" 'ess-eval-chunk
-      "cd" 'ess-eval-chunk-and-step
-      "cm" 'ess-noweb-mark-chunk
-      "cN" 'ess-noweb-previous-chunk
-      "cn" 'ess-noweb-next-chunk
-      ;; REPL
-      "sB" 'ess-eval-buffer-and-go
-      "sb" 'ess-eval-buffer
-      "sD" 'ess-eval-function-or-paragraph-and-step
-      "sd" 'ess-eval-region-or-line-and-step
-      "sL" 'ess-eval-line-and-go
-      "sl" 'ess-eval-line
-      "sR" 'ess-eval-region-and-go
-      "sr" 'ess-eval-region
-      "sT" 'ess-eval-function-and-go
-      "st" 'ess-eval-function
-      ;; R helpers
-      "hd" 'ess-R-dv-pprint
-      "hi" 'ess-R-object-popup
-      "ht" 'ess-R-dv-ctable
-      )
-    (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
-    (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
-    (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)))
+        (defun spacemacs/ess-start-repl ()
+          "Start a REPL corresponding to the ess-language of the current buffer."
+          (interactive)
+          (cond
+           ((string= "S" ess-language) (call-interactively 'R))
+           ((string= "STA" ess-language) (call-interactively 'stata))
+           ((string= "SAS" ess-language) (call-interactively 'SAS))))
+
+        (spacemacs/set-leader-keys-for-major-mode 'ess-julia-mode
+          "si" 'julia)
+        (spacemacs/set-leader-keys-for-major-mode 'ess-mode
+          "si" 'spacemacs/ess-start-repl
+          ;; noweb
+          "cC" 'ess-eval-chunk-and-go
+          "cc" 'ess-eval-chunk
+          "cd" 'ess-eval-chunk-and-step
+          "cm" 'ess-noweb-mark-chunk
+          "cN" 'ess-noweb-previous-chunk
+          "cn" 'ess-noweb-next-chunk
+          ;; REPL
+          "sa" 'ess-switch-process
+          "sB" 'ess-eval-buffer-and-go
+          "sb" 'ess-eval-buffer
+          "sD" 'ess-eval-function-or-paragraph-and-step
+          "sd" 'ess-eval-region-or-line-and-step
+          "sL" 'ess-eval-line-and-go
+          "sl" 'ess-eval-line
+          "sR" 'ess-eval-region-and-go
+          "sr" 'ess-eval-region
+          "sT" 'ess-eval-function-and-go
+          "st" 'ess-eval-function
+          "sP" 'ess-install-library
+          "sp" 'ess-load-library
+          "s:" 'ess-execute
+          "sw" 'ess-set-working-directory
+          ;; R helpers
+          "hd" 'ess-R-dv-pprint
+          "hi" 'ess-R-object-popup
+          "ht" 'ess-R-dv-ctable
+          "hh" 'ess-display-help-on-object
+          "ha" 'ess-display-help-apropos
+          "hp" 'ess-display-package-index
+          "hv" 'ess-display-vignettes
+          ;; Developer bindings
+          "dl" 'ess-developer-load-package
+          "de" 'ess-debug-toggle-error-action
+          "dt" 'ess-build-tags-for-directory
+          "dw" 'ess-watch
+          "ds" 'ess-set-style
+          "bs" 'ess-bp-set
+          "bc" 'ess-bp-set-conditional
+          "bl" 'ess-bp-set-logger
+          "bt" 'ess-bp-toggle-state
+          "bk" 'ess-bp-kill
+          "bK" 'ess-bp-kill-all
+          "bn" 'ess-bp-next
+          "bp" 'ess-bp-previous
+          "bm" 'ess-debug-flag-for-debugging
+          "bM" 'ess-debug-unflag-for-debugging
+          ;; roxygen
+          "rh" 'ess-roxy-hide-all
+          "rr" 'ess-roxy-update-entry
+          "rn" 'ess-roxy-next-entry
+          "rp" 'ess-roxy-previous-entry
+          "rP" 'ess-roxy-preview-text
+          "rt" 'ess-roxy-toggle-hiding
+          ;; other views
+          "vd"  'ess-rdired)
+        (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
+        (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
+        (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)))))
 
 (defun ess/init-ess-R-data-view ())
 


### PR DESCRIPTION
Add new evil-leader bindings for lots of the functions behind
ess-dev-map and ess-doc-map. Major additions are SPC m d for IDE-like
commands (roxygen, style), SPC m b for debugger interaction, and a few
extras in SPC m s and SPC m h.

Also add a few new layer variables controlling the indenting style, and
update README for all.