### PR TITLE
Add Align-cljlet function to Clojurescript mode

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -17,8 +17,9 @@
     :init
     (add-hook 'clojure-mode-hook (lambda () (require 'align-cljlet)))
     :config
-    (spacemacs/set-leader-keys-for-major-mode 'clojure-mode
-      "fl" 'align-cljlet)))
+    (dolist (mode '(clojure-mode clojurescript-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "fl" 'align-cljlet))))
 
 (defun clojure/init-cider ()
   (use-package cider


### PR DESCRIPTION
Derived modes don't inherit evil keybindings from their parents, this is
interesting to note, also it would be so great if we could have a
`set-leader-keys` macro that could take a list of modes as well.