### PR TITLE
Eyebrowse doesn't have a lighter anymore

### DIFF
--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -14,7 +14,6 @@
 
 (defun eyebrowse/init-eyebrowse ()
   (use-package eyebrowse
-    :diminish eyebrowse-mode
     :init
     (progn
       (setq eyebrowse-new-workspace #'spacemacs/home


### PR DESCRIPTION
As of https://github.com/wasamasa/eyebrowse/commit/adb02b17374638d570db96d9edbbab4cfaecf3ef eyebrowse has removed its lighter, so we don't need to diminish it anymore.

Fixes #4172 