### PR TITLE
Fix `web-mode` and `erc-log` micro-states bindings

### DIFF
--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -166,7 +166,7 @@
       (spacemacs|define-micro-state erc-log
         :doc (spacemacs//erc-log-ms-documentation)
         :use-minibuffer t
-        :evil-leader "m."
+        :evil-leader-for-mode (erc-mode . ".")
         :bindings
         ("r" erc-view-log-reload-file)
         (">" erc-view-log-next-mention)

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -225,7 +225,7 @@
       (spacemacs|define-micro-state web-mode
         :doc (spacemacs//web-mode-ms-doc)
         :persistent t
-        :evil-leader-for-mode (web-mode . "m.")
+        :evil-leader-for-mode (web-mode . ".")
         :bindings
         ("<escape>" nil :exit t)
         ("?" spacemacs//web-mode-ms-toggle-doc)


### PR DESCRIPTION
Without this change, `erc-log-micro-state` is overriding all `SPC m .`
bindings, and `web-mode` micro state is under `SPC m m .`.