### PR TITLE
elfeed: Add an unjam keybinding

### DIFF
--- a/layers/+tools/elfeed/packages.el
+++ b/layers/+tools/elfeed/packages.el
@@ -29,6 +29,7 @@
         :bindings
         "c"  'elfeed-db-compact
         "gr" 'elfeed-update
+        "J"  'elfeed-unjam
         "o"  'elfeed-load-opml
         "q"  'quit-window
         "r"  'elfeed-search-update--force


### PR DESCRIPTION
Major reason is that when the connection is flaky, elfeed has trouble timing feed fetches out. Leaving it alone overnight with an hourly auto-update, I usually end up with 3000+ items in the queue and growing. Quick access to `elfeed-unjam` comes in very handy here.