### PR TITLE
layers: add replace-text layer

### DIFF
--- a/layers/replace-text/replace-text/README.org
+++ b/layers/replace-text/replace-text/README.org
@@ -1,0 +1,29 @@
+#+TITLE: replace-text layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+
+* Table of Contents                                        :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Install][Install]]
+ - [[Key bindings][Key bindings]]
+
+* Description
+This simple layer provides functions to interactively replace text in a buffer
+using more commonly known versions of regex (default is Python's). It uses the
+=visual-regexp-steroids= package to provide the functionality.
+
+* Install
+To use this contribution add it to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(replace-text))
+#+end_src
+
+If you use the default settings you should have a python interpreter installed
+in your system PATH variable.
+
+* Key bindings
+
+| Key Binding   | Description                         |
+|---------------+-------------------------------------|
+| ~<SPC> x r r~ | Regexp replace with visual feedback |
+| ~<SPC> x r q~ | Version of =query-replace-regexp=   |

--- a/layers/replace-text/replace-text/packages.el
+++ b/layers/replace-text/replace-text/packages.el
@@ -1,0 +1,23 @@
+;;; packages.el --- replace-text Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;;
+;; Author: Justin Burkett <justin@burkett.cc>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq replace-text-packages
+    '(visual-regexp-steroids))
+
+(defun replace-text/init-visual-regexp-steroids ()
+  (use-package visual-regexp-steroids
+    :defer t
+    :init
+    (spacemacs/declare-prefix "xr" "replace")
+    (spacemacs/set-leader-keys
+      "xrr" 'vr/replace
+      "xrq" 'vr/query-replace)))


### PR DESCRIPTION
This layer provides functions to interactively replace text in a buffer using more commonly known versions of regex (default is Python's). It uses the `visual-regexp-steroids` package to provide the functionality.