### PR TITLE
Use built-in evil functions to set default states

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -54,7 +54,7 @@ version the release note it displayed")
   (evil-define-key 'motion spacemacs-buffer-mode-map (kbd "C-i") 'widget-forward)
   ;; motion state since this is a special mode
   (unless (eq dotspacemacs-editing-style 'emacs)
-    (add-to-list 'evil-motion-state-modes 'spacemacs-buffer-mode)))
+    (evil-set-initial-state 'spacemacs-buffer-mode 'motion)))
 
 (defun spacemacs-buffer/insert-banner-and-buttons ()
   "Choose a banner according to `dotspacemacs-startup-banner'and insert it

--- a/layers/+distribution/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distribution/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
@@ -175,9 +175,8 @@ BODY is a list of additional key bindings to apply for the given MAP in
               (unless (memq ',mode evilified-state--modes)
                 (push ',mode evilified-state--modes))
               (unless (or (bound-and-true-p holy-mode)
-                          (memq ',mode evil-evilified-state-modes))
-                (delq ',mode evil-emacs-state-modes)
-                (push ',mode evil-evilified-state-modes)))
+                          (eq 'evilified (evil-initial-state ',mode)))
+                (evil-set-initial-state ',mode 'evilified)))
             (unless ,(null defkey) (,@defkey)))))
 (put 'evilified-state-evilify 'lisp-indent-function 'defun)
 
@@ -257,8 +256,7 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
   "Configure default state for the passed mode."
   (add-to-list 'evilified-state--modes mode)
   (unless (bound-and-true-p holy-mode)
-    (delq mode evil-emacs-state-modes)
-    (add-to-list 'evil-evilified-state-modes mode)))
+    (evil-set-initial-state mode 'evilified)))
 
 (defun evilified-state--evilify-event (map map-symbol evil-map event evil-value
                                            &optional processed pending-funcs)

--- a/layers/+irc/rcirc/packages.el
+++ b/layers/+irc/rcirc/packages.el
@@ -72,7 +72,7 @@
          (rcirc-enable-authinfo-support (spacemacs//rcirc-with-authinfo arg))
          (rcirc-enable-znc-support (spacemacs//rcirc-with-znc arg))
          (t (rcirc arg))))
-      (push 'rcirc-mode evil-insert-state-modes))
+      (evil-set-initial-state 'rcirc-mode 'insert))
     :config
     (progn
       ;; (set-input-method "latin-1-prefix")

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -40,8 +40,8 @@
       (with-eval-after-load 'golden-ratio
         (push 'cider-popup-buffer-quit-function golden-ratio-extra-commands))
       ;; add support for evil
-      (push 'cider-stacktrace-mode evil-motion-state-modes)
-      (push 'cider-popup-buffer-mode evil-motion-state-modes)
+      (evil-set-initial-state 'cider-stacktrace-mode 'motion)
+      (evil-set-initial-state 'cider-popup-buffer-mode 'motion)
 
       (defun spacemacs//cider-eval-in-repl-no-focus (form)
         "Insert FORM in the REPL buffer and eval it."

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -261,7 +261,7 @@
         ;; default state for additional modes
         (dolist (mode '(magit-popup-mode
                         magit-popup-sequence-mode))
-          (add-to-list 'evil-emacs-state-modes mode))
+          (evil-set-initial-state mode 'emacs))
         (let ((refresh-key "gr")
               (refresh-all-key "gR")
               (delete-key (nth 0 (where-is-internal 'magit-delete-thing


### PR DESCRIPTION
evil-set-initial-state is safer than manually adding and deleting from
the lists, because it knows about all available states and ensures that
the mode only shows up in one list. If it is in multiple lists the
initial state depends on which is checked first, which we don't want.

There are several examples of this in holy-mode.el, but I'm not changing those
because of #3514 