### PR TITLE
core: Add recompile-elpa function

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -253,5 +253,11 @@ result, incrementing passed-tests and total-tests."
      (concat "Hidden Mode Line Mode enabled.  "
              "Use M-x hidden-mode-line-mode to make the mode-line appear."))))
 
+(defun spacemacs/recompile-elpa ()
+  "Recompile packages in elpa directory. Useful if you switch
+Emacs versions."
+  (interactive)
+  (byte-recompile-directory package-user-dir nil t))
+
 (provide 'core-funcs)
 


### PR DESCRIPTION
This is easier than "nuking elpa" when changing versions of Emacs since
we don't need to fetch the packages again, only recompile them.