### PR TITLE
[puppet] Use ruby-mode for Puppetfile support

### DIFF
--- a/layers/+config-files/puppet/config.el
+++ b/layers/+config-files/puppet/config.el
@@ -7,3 +7,6 @@
 ;; Variables
 
 (spacemacs|defvar-company-backends puppet-mode)
+
+;; Enable ruby-mode for Puppetfile support
+(configuration-layer/declare-layer 'ruby)

--- a/layers/+config-files/puppet/packages.el
+++ b/layers/+config-files/puppet/packages.el
@@ -1,22 +1,11 @@
 (setq puppet-packages
   '(
-    puppet-mode
     company
     flycheck
+    puppet-mode
     ))
 
-;; For each package, define a function puppet-mode/init-<package-puppet-mode>
-;;
-;; (defun puppet-mode/init-my-package ()
-;;   "Initialize my package"
-;;   )
-;;
-;; Often the body of an initialize function uses `use-package'
-;; For more info on `use-package', see readme:
-;; https://github.com/jwiegley/use-package
-
 (defun puppet/init-puppet-mode ()
-  "Initialize Puppet mode"
   (use-package puppet-mode
     :defer t
     :init

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -190,6 +190,7 @@
 (defun ruby/init-ruby-mode ()
   (use-package ruby-mode
     :defer t
+    :mode "Puppetfile"
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'ruby-mode


### PR DESCRIPTION
The package 'puppetfile-mode' is no longer available as it's considered
redundant with ruby-mode, which should now be the mode to use for
"Puppetfile" files.