### PR TITLE
fix git README

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -142,7 +142,7 @@ Here are the often used bindings inside a =status buffer=:
 | ~b b~       | checkout a branch                                   |
 | ~b c~       | create a branch                                     |
 | ~f f~       | fetch changes                                       |
-| ~F~         | Open a =pull buffer=                                |
+| ~F (r) u~   | pull tracked branch and rebase                      |
 | ~gr~        | refresh                                             |
 | ~j~         | goto next magit section                             |
 | ~C-j~       | next visual line                                    |
@@ -152,7 +152,7 @@ Here are the often used bindings inside a =status buffer=:
 | ~n~         | next search occurrence                              |
 | ~N~         | previous search occurrence                          |
 | ~o~         | revert item at point                                |
-| ~P~         | Open a =push buffer=                                |
+| ~P u~       | push to tracked branch                              |
 | ~q~         | quit                                                |
 | ~s~         | on a file or hunk in a diff: stage the file or hunk |
 | ~x~         | discard changes                                     |

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -142,7 +142,7 @@ Here are the often used bindings inside a =status buffer=:
 | ~b b~       | checkout a branch                                   |
 | ~b c~       | create a branch                                     |
 | ~f f~       | fetch changes                                       |
-| ~F -r F~    | pull and rebase                                     |
+| ~F~         | pull and rebase                                     |
 | ~gr~        | refresh                                             |
 | ~j~         | goto next magit section                             |
 | ~C-j~       | next visual line                                    |

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -142,7 +142,7 @@ Here are the often used bindings inside a =status buffer=:
 | ~b b~       | checkout a branch                                   |
 | ~b c~       | create a branch                                     |
 | ~f f~       | fetch changes                                       |
-| ~F~         | pull and rebase                                     |
+| ~F~         | Open a =pull buffer=                                |
 | ~gr~        | refresh                                             |
 | ~j~         | goto next magit section                             |
 | ~C-j~       | next visual line                                    |

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -152,7 +152,7 @@ Here are the often used bindings inside a =status buffer=:
 | ~n~         | next search occurrence                              |
 | ~N~         | previous search occurrence                          |
 | ~o~         | revert item at point                                |
-| ~P P~       | push                                                |
+| ~P~         | Open a =push buffer=                                |
 | ~q~         | quit                                                |
 | ~s~         | on a file or hunk in a diff: stage the file or hunk |
 | ~x~         | discard changes                                     |


### PR DESCRIPTION
I notice that magit have updated and now "P P" can't push directly.
Now "P" only open a push buffer and you need to choose where you want to push.
![1](https://cloud.githubusercontent.com/assets/15358886/11896062/62de7166-a5be-11e5-8a96-90ff680a8a5e.png)
