### PR TITLE
Define init-keys to enter micro-state from standard function calls

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -176,6 +176,12 @@ Default value is `cache'.")
   "If non nil the paste micro-state is enabled. While enabled pressing `p`
 several times cycle between the kill ring content.'")
 
+(defvar dotspacemacs-micro-init-keys '((buffer . ("n" "N" "p"))
+                                       (window-manipulation . ("[" "]")))
+  "Keys within provided micro-state that should allow entrance into buffer. Form
+is an association list of (`MICRO-STATE' . (`KEY-LIST')). A blank list will
+disable `:init-keys' defined in the micro-state instance.")
+
 (defvar dotspacemacs-which-key-delay 0.4
   "Delay in seconds starting from the last keystroke after which
 the which-key buffer will be shown if you have not completed a

--- a/core/core-micro-state.el
+++ b/core/core-micro-state.el
@@ -105,11 +105,12 @@ used."
                        'message
                      'corelv-message))
          (exec-binding (plist-get props :execute-binding-on-enter))
+         (init-keys (spacemacs/mplist-get props :init-keys))
          (on-enter (spacemacs/mplist-get props :on-enter))
          (on-exit (spacemacs/mplist-get props :on-exit))
          (bindings (spacemacs/mplist-get props :bindings))
          (wrappers (spacemacs//micro-state-create-wrappers
-                    name doc msg-func disable-leader bindings))
+                    name doc msg-func disable-leader init-keys bindings))
          (keymap-body (spacemacs//micro-state-fill-map-sexps wrappers))
          (bindkeys (spacemacs//create-key-binding-form props func)))
     `(progn (defun ,func ()
@@ -144,10 +145,10 @@ used."
        (call-interactively (cadr binding)))))
 
 (defun spacemacs//micro-state-create-wrappers
-    (name doc msg-func disable-leader bindings)
+    (name doc msg-func disable-leader init-keys bindings)
   "Return an alist (key wrapper) for each binding in BINDINGS."
   (mapcar (lambda (x) (spacemacs//micro-state-create-wrapper
-                       name doc msg-func x))
+                       name doc msg-func init-keys x))
           (append bindings
                   ;; force SPC to quit the micro-state to avoid a edge case
                   ;; with evil-leader
@@ -155,13 +156,15 @@ used."
                           ,(unless disable-leader 'spacemacs-default-map)
                           :exit t)))))
 
-(defun spacemacs//micro-state-create-wrapper (name default-doc msg-func binding)
+(defun spacemacs//micro-state-create-wrapper (name default-doc msg-func init-keys binding)
   "Create a wrapper of FUNC and return a tuple (key wrapper BINDING)."
   (let* ((key (car binding))
          (wrapped (cadr binding))
+         (wrapped-name (intern (format "%S" wrapped)))
          (binding-doc (spacemacs/mplist-get binding :doc))
          (binding-pre (spacemacs/mplist-get binding :pre))
          (binding-post (spacemacs/mplist-get binding :post))
+         (micro-name (spacemacs//micro-state-func-name name))
          (wrapper-name (intern (format "spacemacs//%S-%S-%s" name wrapped key)))
          (doc-body
           `((let ((bdoc ,@binding-doc)
@@ -177,6 +180,9 @@ used."
                          (list (spacemacs//micro-state-propertize-doc
                                 (format "%S: %s" ',name defdoc))))
                   defdoc)))))
+         (wrapper-advice
+          `(defadvice ,wrapped-name (after micro-state activate)
+             (,micro-name)))
          (wrapper-func
           (if (and (boundp wrapped)
                    (eval `(keymapp ,wrapped)))
@@ -197,7 +203,20 @@ used."
                (when ,@doc-body
                  (spacemacs//micro-state-set-minibuffer-height ,@doc-body)
                  ,@doc-body)))))
-    (append (list (car binding) (eval wrapper-func)) binding)))
+        (let* ((allowed-keys (cdr-safe (assoc name dotspacemacs-micro-init-keys)))
+               (key-preferred (member key allowed-keys))
+               (key-default (member key init-keys)))
+          (when (and wrapper-advice
+                     (or
+                      key-preferred
+                      (and (not allowed-keys)
+                           key-default)))
+            (progn
+              (message "%s found, advice applied to %s micro-state (def: %s, set: %s)\n%s advised by \n%s" key name key-default key-preferred wrapped-name wrapper-advice)
+              ;; (redisplay)
+              ;; (sleep-for 4)
+              (eval wrapper-advice)))
+        (append (list (car binding) (eval wrapper-func)) binding))))
 
 (defun spacemacs//micro-state-fill-map-sexps (wrappers)
   "Return a list of `define-key' sexp to fill the micro-state temporary map."

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -165,6 +165,11 @@ values."
    ;; If non nil the paste micro-state is enabled. When enabled pressing `p`
    ;; several times cycle between the kill ring content. (default nil)
    dotspacemacs-enable-paste-micro-state nil
+   ;; Keys within provided micro-state that should allow entrance into buffer.
+   ;; Form is an association list of (`MICRO-STATE' . (`KEY-LIST')). A blank
+   ;; list will disable `init-keys' defined in the micro-state instance.
+   dotspacemacs-micro-init-keys '((buffer . ("n" "N" "p"))
+                                  (window-manipulation . ("[" "]")))
    ;; Which-key delay in seconds. The which-key buffer is the popup listing
    ;; the commands bound to the current keystroke sequence. (default 0.4)
    dotspacemacs-which-key-delay 0.4

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -348,7 +348,12 @@ Ensure that helm is required before calling FUNC."
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
   "w/"  'split-window-right
-  "w="  'balance-windows)
+  "w="  'balance-windows
+  "w["  'spacemacs/shrink-window-horizontally
+  "w]"  'spacemacs/enlarge-window-horizontally
+  "w{"  'spacemacs/shrink-window
+  "w}"  'spacemacs/enlarge-window)
+
 ;; text -----------------------------------------------------------------------
 (defalias 'count-region 'count-words-region)
 
@@ -393,6 +398,7 @@ Ensure that helm is required before calling FUNC."
   :doc "[n]ext [p]revious [K]ill [q]uit"
   :disable-evil-leader t
   :evil-leader "b."
+  :init-keys "n" "p" "N"
   :bindings
   ("K" kill-this-buffer)
   ("n" spacemacs/next-useful-buffer)


### PR DESCRIPTION
This PR allows you to enter a micro-state from an external command, as discussed briefly in #3628.  This is accomplished by advising the function in the micro-state call if defined as an `init-key`.  In the current form, `init-keys` can be provided by the micro-state author using within the micro-state initialization, or through a `.spacemacs` variable.  The keys provided through the `:init-keys` property list coincide with the keys defined in the micro-state definition:

```
(spacemacs|define-micro-state buffer
  :doc "[n]ext [p]revious [K]ill [q]uit"
  :disable-evil-leader t
  :evil-leader "b."
  :init-keys "n" "p" "N"
...
```

Additionally, `init-keys` can be defined and overridden in the `dotspacemacs-micro-init-keys` variable by setting up an association list of the form where the defined micro-state is the `car` of the list, and the list of keys are the `cdr`:

```
   ;; Keys within provided micro-state that should allow entrance into buffer.
   ;; Form is an association list of (`MICRO-STATE' . (`KEY-LIST')). A blank
   ;; list will disable `init-keys' defined in the micro-state instance.
   dotspacemacs-micro-init-keys '((buffer . ("n" "N" "p"))
                                  (window-manipulation . ("[" "]")))
```

As stated in the doc string above, setting an association list as an empty list should override any configured `init-keys` in the micro-states definition.  The way that this feature is currently implemented is by looking at the function called with the defined key in the micro-state and then advising this function call to open the micro-state when the function is called.  For this reason, we shouldn't define any init-keys associated to functions that would be called outside of spacemacs bindings, unless we desire the action of always having this micro-state called.  

One way around opening the micro-state when we wouldn't want it open, would be to define a wrapper defun that would be assigned to the basic spacemacs keybindings and the micro-state as well, instead of calling a standard emacs defun.   Currently, this PR defines three bindings for the `buffer` micro-state ( next and previous useful buffer), and enlarge / shrink window from the `window-manipulation` micro-state as examples.  

The following standard spacemacs bindings should now open the associated micro-state:  `SPC bn`, `SPC bp`, `SPC bN`, `SPC w[`, `SPC w]`

I imagine with some discussion we might select one method of defining `init-keys` as opposed to offering both options, but I kept both in for discussion purposes.