### PR TITLE
layout: make layout name shorter in microstate line

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -59,8 +59,11 @@
               (logxor spacemacs--layouts-ms-doc-toggle 1)))
 
       (defun spacemacs//layout-format-name (name pos)
-        "Format the layout name given by NAME for display in  mode-line."
-        (let* ((string-name (format "%s" name))
+        "Format the layout name given by NAME for display in mode-line."
+        (let* ((layout-name (if (file-directory-p name)
+                                (file-name-nondirectory (directory-file-name name))
+                              name))
+               (string-name (format "%s" layout-name))
                (current (equal name (spacemacs//current-layout-name)))
                (caption (concat (number-to-string (if (eq 9 pos) 0 (1+ pos)))
                                 ":" string-name)))


### PR DESCRIPTION
If layout name is long path, it takes up too much space.

Visual diff of the change. 
Before:
<img width="1070" alt="screen shot 2015-12-19 at 11 06 04 pm" src="https://cloud.githubusercontent.com/assets/542810/11914392/2cd3ba3e-a6a6-11e5-8ef4-8beca1c73954.png">
After:
<img width="696" alt="screen shot 2015-12-19 at 11 04 16 pm" src="https://cloud.githubusercontent.com/assets/542810/11914394/33633a28-a6a6-11e5-8c08-bbfe60847197.png">

