### PR TITLE
Change `SPC f e h` to `SPC h SPC` for helm-spacemacs default binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Spacemacs is currently in beta, and contributions are very welcome.
 # Features
 
 - **Great documentation:** access documentation in Emacs with
-<kbd>SPC f e h</kbd>.
+<kbd>SPC h SPC</kbd>.
 - **Beautiful GUI:** you'll love the distraction free UI and its functional
 mode-line.
 - **Excellent ergonomics:** all the key bindings are accessible by pressing
@@ -85,7 +85,7 @@ organised in configuration layers following a set of
 # Documentation
 
 Comprehensive documentation is available for each layer by pressing
-<kbd>SPC f e h</kbd>.
+<kbd>SPC h SPC</kbd>.
 
 To go to the general documentation [click here][DOCUMENTATION.org].
 

--- a/core/info/quickhelp.txt
+++ b/core/info/quickhelp.txt
@@ -16,7 +16,7 @@ Press SPC (in Vim mode) or Alt-m (in Emacs mode) to access Spacemacs commands.
 
 Press SPC f e d (Vim) or Alt-m f e d (Emacs) to access .spacemacs file.
 
-Press SPC f e h (Vim) or Alt-m f e h (Emacs) to access a list of documentation
+Press SPC h SPC (Vim) or Alt-m h SPC (Emacs) to access a list of documentation
 and supported layers. You can type anything to narrow to a specific feature i.e.
 "python" for Python layer. There are five lists and you can press Ctrl-o to switch
 between them:
@@ -28,4 +28,4 @@ When reading a document, you can use SPC s l (Vim) or M-m s l (Emacs) to jump to
 a heading. The table of content is just for overview and for using with Github
 when you read the doc with a web browser.
 
-Please consult Spacemacs documentation from SPC f e h for more details.
+Please consult Spacemacs documentation from SPC h SPC for more details.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -954,7 +954,7 @@ and ~T~):
 | ~SPC T T~   | toggle frame transparency and enter transparency micro-state |
 
 *Note*: These toggles are all available via the =helm-spacemacs= interface (press
-~SPC f e h~ to display the =helm-spacemacs= buffer).
+~SPC h SPC~ to display the =helm-spacemacs= buffer).
 
 **** Global line numbers
 Line numbers can be toggled on in all =prog-mode= and =text-mode= buffers by
@@ -1638,13 +1638,10 @@ navigate between =Emacs= and Spacemacs specific files.
 | ~SPC f e c~ | open =ido= in the =contrib= folder                                 |
 | ~SPC f e d~ | open the spacemacs dotfile (=~/.spacemacs=)                        |
 | ~SPC f e D~ | open =ediff= buffer of =~/.spacemacs= and =.spacemacs.template=    |
-| ~SPC f e h~ | discover Spacemacs documentation, layers and packages using =helm= |
 | ~SPC f e f~ | discover the =FAQ= using =helm=                                    |
 | ~SPC f e i~ | open the all mighty =init.el=                                      |
 | ~SPC f e R~ | resync the dotfile with spacemacs                                  |
 | ~SPC f e v~ | display and copy the spacemacs version                             |
-
-Additionally, ~SPC h SPC~ is a alias for ~SPC f e h~.
 
 **** Browsing files with Helm
 In =vim= and  =hybrid= styles, Spacemacs remap the navigation in Helm find-files

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -122,7 +122,7 @@ In =vim= editing style the universal argument defaults to ~SPC u~
 instead of ~C-u~ because the latter is used to scroll up as in Vim.
 
 ** Configuration layers and Package discovery
-By using =helm-spacemacs= with ~SPC f e h~ you can quickly search
+By using =helm-spacemacs= with ~SPC h SPC~ you can quickly search
 for a package and get the name of the layers using it.
 
 You can also easily go to the =README.org= of a layer or go to the initialization

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -184,7 +184,7 @@ explore:
 
 | Keybinding  | Function                                                      |
 |-------------+---------------------------------------------------------------|
-| ~SPC f e h~ | Lists all layers and allows you to view files from the layer. |
+| ~SPC h SPC~ | Lists all layers and allows you to view files from the layer. |
 | ~SPC ?~     | Lists all keybindings.                                        |
 
 * Customization
@@ -310,7 +310,7 @@ this:
 You can uncomment these suggested layers by deleting the semi-colons for a nice
 out-of-the-box experience. To add a layer, add its name to the list and restart
 Emacs or press ~SPC f e R~ . To view all layers and their documentation use ~SPC
-f e h~.
+h SPC~.
 
 ** Creating a Layer
 To group configuration or when configuration doesn't fit well in your

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -973,7 +973,12 @@ ARG non nil means that the editing style is `vim'."
     :commands (helm-spacemacs helm-spacemacs-faq)
     :init
     (progn
-      (spacemacs/set-leader-keys "feh" 'helm-spacemacs)
+      (defun spacemacs-base/helm-spacemacs-deprecated (arg)
+        "Provide helm-spacemacs with a binding's depreciation message."
+        (interactive "P")
+        (warn "The 'SPC f e h' (or 'M-m f e h') binding is now deprecated and will be remove in the next release. Please use 'SPC h SPC' (or 'M-m h SPC') instead.")
+        (helm-spacemacs arg))
+      (spacemacs/set-leader-keys "feh" 'spacemacs-base/helm-spacemacs-deprecated)
       (spacemacs/set-leader-keys "fef" 'helm-spacemacs-faq)
       (spacemacs/set-leader-keys "h SPC" 'helm-spacemacs))))
 

--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -35,7 +35,7 @@ Quick instructions to install Agda assuming you have cabal installed:
 
 Then check that =agda= is available on your =$PATH= and seen by Emacs. For
 information about setting up =$PATH=, check out the corresponding section in the
-FAQ (~SPC f e h $PATH RET~).
+FAQ (~SPC h SPC $PATH RET~).
 
 * Key bindings
 The key bindings of this layer don't follow the Spacemacs conventions,

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -35,7 +35,7 @@ You will need =gocode= and =godef=:
 #+END_SRC
 
 Make sure that =gocode= executable is in your PATH. For information about
-setting up =$PATH=, check out the corresponding section in the FAQ (~SPC f e h
+setting up =$PATH=, check out the corresponding section in the FAQ (~SPC h SPC
 $PATH RET~).
 
 For best results, make sure that the =auto-completion= and =syntax-checking=

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -75,7 +75,7 @@ packages. If you are using =cabal= it should be =~/.cabal/bin= or
 are using =stack= then it should be =~/.local/bin=.
 
 For information about setting up =$PATH=, check out the corresponding section in
-the FAQ (~SPC f e h $PATH RET~).
+the FAQ (~SPC h SPC $PATH RET~).
 
 ** ghc-mod support
 [[http://www.mew.org/~kazu/proj/ghc-mod/][ghc-mod]] enhances =haskell-mode= with for example code completion, templates,

--- a/layers/+lang/octave/README.org
+++ b/layers/+lang/octave/README.org
@@ -17,7 +17,7 @@ extensions and configures spacemacs-style [[#Key-bindings][Key Bindings]]
 * Install
 Make sure that [[https://gnu.org/software/octave/][GNU Octave]] is installed and
 in your PATH. For information about setting up $PATH, check out the
-corresponding section in the FAQ (=SPC f e h $PATH RET=).
+corresponding section in the FAQ (=SPC h SPC $PATH RET=).
 
 To use this contribution add it to your =~/.spacemacs=
 

--- a/layers/+tools/evernote/README.org
+++ b/layers/+tools/evernote/README.org
@@ -46,7 +46,7 @@ installing =geeknote=:
 If you would prefer to customize the geeknote command to be used such as
 specifying the path to the geeknote python script, please refer to the
 =geeknote.el= [[https://github.com/avendael/emacs-geeknote][documentation]]. For more information about setting up =$PATH=,
-check out the corresponding section in the FAQ (~SPC f e h $PATH RET~).
+check out the corresponding section in the FAQ (~SPC h SPC $PATH RET~).
 
 * Key Bindings
 


### PR DESCRIPTION
This make `SPC h SPC` as default binding for accessing `helm-spacemacs`,
by either A) changing all the documentation; and B) adding a deprecation
message for `SPC f e h`.

The deprecation use a warning, because if a message is used it's hidden
directly when the helm buffer is shown, making it nearly unnoticeable
for the user.