### PR TITLE
C/C++ cleanup

### DIFF
--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -15,8 +15,8 @@
 (defvar c-c++-enable-clang-support nil
   "If non nil Clang related packages and configuration are enabled.")
 
-(spacemacs|defvar-company-backends c-mode-common)
-(spacemacs|defvar-company-backends cmake-mode)
-
 (defvar c-c++-default-mode-for-headers 'c-mode
   "Default mode to open header files. Can be `c-mode' or `c++-mode'.")
+
+(spacemacs|defvar-company-backends c-mode-common)
+(spacemacs|defvar-company-backends cmake-mode)

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -41,9 +41,12 @@
     compile-flags))
 
 (defun c-c++/load-clang-args ()
-  "Sets the arguments for company-clang based on a project-specific text file."
+  "Sets the arguments for company-clang, the system paths for company-c-headers
+and the arguments for flyckeck-clang based on a project-specific text file."
   (unless company-clang-arguments
     (let* ((cc-file (company-mode/find-clang-complete-file))
-           (flags (if cc-file (company-mode/load-clang-complete-file cc-file) '())))
+           (flags (if cc-file (company-mode/load-clang-complete-file cc-file) '()))
+           (dirs (mapcar (lambda (d) (substring d 2)) flags)))
       (setq-local company-clang-arguments flags)
+      (setq company-c-headers-path-system (append '("/usr/include" "/usr/local/include") dirs))
       (setq flycheck-clang-args flags))))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -11,27 +11,16 @@
 ;;; License: GPLv3
 
 (setq c-c++-packages
-  '(
-    cc-mode
+  '(cc-mode
     disaster
     clang-format
     cmake-mode
     company
     company-c-headers
-    company-ycmd
     flycheck
     gdb-mi
-    helm-cscope
     helm-gtags
-    semantic
-    srefactor
-    stickyfunc-enhance
-    ycmd
-    xcscope
     ))
-
-(unless (version< emacs-version "24.4")
-  (add-to-list 'c-c++-packages 'srefactor))
 
 (defun c-c++/init-cc-mode ()
   (use-package cc-mode
@@ -108,36 +97,3 @@
 (defun c-c++/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)
   (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode))
-
-(defun c-c++/post-init-semantic ()
-  (semantic/enable-semantic-mode 'c-mode)
-  (semantic/enable-semantic-mode 'c++-mode))
-
-(defun c-c++/post-init-srefactor ()
-  (spacemacs/set-leader-keys-for-major-mode 'c-mode "r" 'srefactor-refactor-at-point)
-  (spacemacs/set-leader-keys-for-major-mode 'c++-mode "r" 'srefactor-refactor-at-point)
-  (spacemacs/add-to-hooks 'spacemacs/lazy-load-srefactor '(c-mode-hook c++-mode-hook)))
-
-(defun c-c++/post-init-stickyfunc-enhance ()
-  (spacemacs/add-to-hooks 'spacemacs/lazy-load-stickyfunc-enhance '(c-mode-hook c++-mode-hook)))
-
-(defun c-c++/post-init-ycmd ()
-  (add-hook 'c++-mode-hook 'ycmd-mode)
-  (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-    "gg" 'ycmd-goto
-    "gG" 'ycmd-goto-imprecise))
-
-(defun c-c++/post-init-company-ycmd ()
-  (push 'company-ycmd company-backends-c-mode-common))
-
-(defun c-c++/pre-init-xcscope ()
-  (spacemacs|use-package-add-hook xcscope
-    :post-init
-    (dolist (mode '(c-mode c++-mode))
-      (spacemacs/set-leader-keys-for-major-mode mode "gi" 'cscope-index-files))))
-
-(defun c-c++/pre-init-helm-cscope ()
-  (spacemacs|use-package-add-hook xcscope
-    :post-init
-    (dolist (mode '(c-mode c++-mode))
-      (spacemacs/setup-helm-cscope mode))))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -25,29 +25,26 @@
 (defun c-c++/init-cc-mode ()
   (use-package cc-mode
     :defer t
-    :init
-    (add-to-list 'auto-mode-alist `("\\.h$" . ,c-c++-default-mode-for-headers))
-    :config
-    (progn
-      (require 'compile)
-      (c-toggle-auto-newline 1)
-      (spacemacs/set-leader-keys-for-major-mode 'c-mode
-        "ga" 'projectile-find-other-file
-        "gA" 'projectile-find-other-file-other-window)
-      (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-        "ga" 'projectile-find-other-file
-        "gA" 'projectile-find-other-file-other-window))))
+    :init (add-to-list 'auto-mode-alist `("\\.h$" . ,c-c++-default-mode-for-headers))
+    :config (progn
+              (require 'compile)
+              (c-toggle-auto-newline 1)
+              (spacemacs/set-leader-keys-for-major-mode 'c-mode
+                "ga" 'projectile-find-other-file
+                "gA" 'projectile-find-other-file-other-window)
+              (spacemacs/set-leader-keys-for-major-mode 'c++-mode
+                "ga" 'projectile-find-other-file
+                "gA" 'projectile-find-other-file-other-window))))
 
 (defun c-c++/init-disaster ()
   (use-package disaster
     :defer t
     :commands (disaster)
-    :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'c-mode
-        "D" 'disaster)
-      (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-        "D" 'disaster))))
+    :init (progn
+            (spacemacs/set-leader-keys-for-major-mode 'c-mode
+              "D" 'disaster)
+            (spacemacs/set-leader-keys-for-major-mode 'c++-mode
+              "D" 'disaster))))
 
 (defun c-c++/init-clang-format ()
   (use-package clang-format
@@ -87,12 +84,11 @@
 (defun c-c++/init-gdb-mi ()
   (use-package gdb-mi
     :defer t
-    :init
-    (setq
-     ;; use gdb-many-windows by default when `M-x gdb'
-     gdb-many-windows t
-     ;; Non-nil means display source file containing the main routine at startup
-     gdb-show-main t)))
+    :init (setq
+           ;; use gdb-many-windows by default when `M-x gdb'
+           gdb-many-windows t
+           ;; Non-nil means display source file containing the main routine at startup
+           gdb-show-main t)))
 
 (defun c-c++/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)


### PR DESCRIPTION
My first ever request for spacemacs, and pretty much my first editing of elisp code (outside of trivial configuration) so I'd love to hear what I can do to improve it.

I get the feeling the C/C++ layer has been somewhat neglected and has collected a bit of cruft, so it could do with a bit of a cleanup in time for the holidays ;)  I basically removed all the packages I couldn't find in my elpa dir after adding and using the layer.  I also found some things that didn't seem to work anyway (*stickyfunc-enhance*), so that and the packages it depended on were removed too.

This also uses the `.clang_complete` file to set up *company-c-headers*.