### PR TITLE
C/C++: Set up company-c-headers based on clang config

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -23,11 +23,16 @@ scripts.
 - Support syntax checking via flycheck with Clang.
 - Support for disassembly of code with [[https://github.com/jart/disaster][disaster]].
 - Support code reformatting with [[http://clang.llvm.org/docs/ClangFormat.html][clang-format]].
-- Display function or variable definition at the bottom. (when =semantic= layer is included)
+- Display function or variable definition at the bottom. (when =semantic= layer
+  is included)
 - Display current function cursor is in at the top. See [[https://github.com/tuhdo/semantic-stickyfunc-enhance][stickyfunc-demos]] for
   demos in some programming languages. (when =semantic= layer is included)
 - Support common refactoring with [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]] . See [[https://github.com/tuhdo/semantic-refactor/blob/master/srefactor-demos/demos.org][srefactor-demos]] for
   demonstration of refactoring features. (when =semantic= layer is included)
+- Support code navigation via cscope (when =cscope= layer is included) and gtags.
+- Support auto-completion (when =auto-completion= layer is included) via
+  company-clang (when =c-c++-enable-clang-support= is turned on), or
+  company-ycmd (when =ycmd= layer is included).
 
 * Install
 ** Layer

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -40,9 +40,13 @@
     compile-flags))
 
 (defun c-c++/load-clang-args ()
-  "Sets the arguments for company-clang based on a project-specific text file."
+  "Sets the arguments for company-clang, the system paths for company-c-headers
+and the arguments for flyckeck-clang based on a project-specific text file."
   (unless company-clang-arguments
     (let* ((cc-file (company-mode/find-clang-complete-file))
-           (flags (if cc-file (company-mode/load-clang-complete-file cc-file) '())))
+           (flags (if cc-file (company-mode/load-clang-complete-file cc-file) '()))
+           (dirs (mapcar (lambda (f) (substring f 2))
+                         (remove-if-not (lambda (f) (string-prefix-p "-I" f)) flags))))
       (setq-local company-clang-arguments flags)
-      (setq flycheck-clang-args flags))))
+      (setq-local company-c-headers-path-system (append '("/usr/include" "/usr/local/include") dirs))
+      (setq-local flycheck-clang-args flags))))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -23,7 +23,6 @@
     helm-cscope
     helm-gtags
     semantic
-    srefactor
     stickyfunc-enhance
     ycmd
     xcscope


### PR DESCRIPTION
Set up *company-c-headers* 's `company-c-headers-path-system` to match arguments for *company-clang* and *flycheck-clang*.

The other two changes clean up the inclusion of `srefactor` and (hopefully) improves the layer's documentation.