### PR TITLE
Fixes #247 - New layer: writeroom

### DIFF
--- a/layers/+tools/writeroom/README.org
+++ b/layers/+tools/writeroom/README.org
@@ -1,0 +1,24 @@
+#+TITLE: writeroom layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+
+* Table of Contents                                        :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Install][Install]]
+ - [[Key bindings][Key bindings]]
+
+* Description
+When activated, the writeroom mode offers a distraction-free environment for
+writing text.
+
+* Install
+To use this contribution add it to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(writeroom))
+#+end_src
+
+* Key bindings
+
+| Key Binding | Description           |
+|-------------+-----------------------|
+| ~SPC a W~   | Toggle writeroom mode |

--- a/layers/+tools/writeroom/packages.el
+++ b/layers/+tools/writeroom/packages.el
@@ -1,0 +1,21 @@
+;;; packages.el --- writeroom Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2015 Gergely Nagy
+;;
+;; Author: Gergely Nagy <algernon@madhouse-project.org>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq writeroom-packages
+      '(
+        writeroom-mode
+        ))
+
+(defun writeroom/init-writeroom-mode ()
+  "Initialize writeroom-mode"
+
+  (use-package writeroom-mode
+    :init (spacemacs/set-leader-keys "aW" #'writeroom-mode)))


### PR DESCRIPTION
When activated, `SPC a W` will toggle writeroom-mode for distraction-free editing, a great way to edit large amounts of text.
