### PR TITLE
puppet: remove puppetfile-mode

### DIFF
--- a/layers/+config-files/puppet/README.org
+++ b/layers/+config-files/puppet/README.org
@@ -5,15 +5,11 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
- - [[Features][Features]]
  - [[Install][Install]]
  - [[Key bindings][Key bindings]]
 
 * Description
 This layer aims at providing support for the Puppet DSL using [[https://github.com/lunaryorn/puppet-mode][puppet-mode]].
-
-* Features
-Puppetfile support via [[http://melpa.org/#/puppetfile-mode][puppetfile-mode]]
 
 * Install
 To use this contribution add it to your =~/.spacemacs=

--- a/layers/+config-files/puppet/packages.el
+++ b/layers/+config-files/puppet/packages.el
@@ -1,7 +1,6 @@
 (setq puppet-packages
   '(
     puppet-mode
-    puppetfile-mode
     company
     flycheck
     ))
@@ -40,7 +39,3 @@
 
 (defun puppet/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'puppet-mode-hook))
-
-(defun puppet/init-puppetfile-mode ()
-  (use-package puppetfile-mode
-    :defer t))


### PR DESCRIPTION
puppetfile-mode package no longer exists.

https://github.com/tarsius/melpa/commit/69d3c7a24afba8e889efc0d848621c220f58a6ad
http://melpa.org/#/puppetfile-mode

This change should also be cherry-picked into master as there is a melpa error on every startup without it when using the puppet layer.