### PR TITLE
core-debug: Add --adv-timers

### DIFF
--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -1,4 +1,4 @@
-;;; core-debug.el --- Spacemacs Core File
+;;; core-debug.el --- Spacemacs Core File  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
 ;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
@@ -15,8 +15,88 @@
 ;; Keep debug-on-error on for stuff that is lazily loaded
 (add-hook 'after-init-hook (lambda () (setq debug-on-error t)))
 
-(when (member "--profile" command-line-args)
-  (setq command-line-args (delete "--profile" command-line-args))
+(defvar spacemacs-debug-timer-threshold 0.15
+  "Generate message if file takes longer than this number of
+seconds to load")
+
+(defvar spacemacs-debug-with-profile nil)
+(defvar spacemacs-debug-with-timed-requires nil)
+(defvar spacemacs-debug-with-adv-timers nil)
+
+;; process args
+(defun spacemacs-debug-process-args (args)
+  "Process ARGS relevant to core-debug.el"
+  (let ((i 0) new-args)
+    (while (< i (length args))
+      (let ((arg (nth i args))
+	    (next-arg-digit
+	     (when (< (1+ i) (length args))
+	       (string-to-number (nth (1+ i ) args)))))
+	(when (or (null next-arg-digit) (= 0 next-arg-digit))
+	  (setq next-arg-digit nil))
+	(pcase arg
+	  ("--profile"
+	   (setq spacemacs-debug-with-profile t))
+	  ("--timed-requires"
+	   (setq spacemacs-debug-with-timed-requires t)
+	   (when next-arg-digit
+	     (setq spacemacs-debug-timer-threshold next-arg-digit
+		   i (1+ i))))
+	  ("--adv-timers"
+	   (setq spacemacs-debug-with-adv-timers t)
+	   (when next-arg-digit
+	     (setq spacemacs-debug-timer-threshold next-arg-digit
+		   i (1+ 1))))
+	  (_ (push arg new-args))))
+      (setq i (1+ i)))
+    (nreverse new-args)))
+
+(setq command-line-args (spacemacs-debug-process-args command-line-args))
+
+(defun spacemacs//load-timer (origfunc &rest args)
+  "Used to time invocation of `require' or `load'."
+  (let ((start (current-time))
+        (required (car args))
+        delta)
+    (prog1
+        (apply origfunc args)
+      (setq delta (float-time (time-since start)))
+      (when (> delta spacemacs-debug-timer-threshold)
+        (with-current-buffer "*load-times*"
+          (goto-char (point-max))
+          (insert (format "[%.3f] (%.3f) Load or require\n    Feature: %s\n    In file: %s\n\n"
+                          (float-time (time-since emacs-start-time))
+                          delta required load-file-name)))))))
+
+(defmacro spacemacs||make-function-timer (func)
+  "Used to time call to FUNC."
+  `(lambda (origfunc &rest args)
+     (let ((start (current-time))
+           delta)
+       (prog1
+           (apply origfunc args)
+         (setq delta (float-time (time-since start)))
+         (when (> delta spacemacs-debug-timer-threshold)
+           (with-current-buffer "*load-times*"
+             (goto-char (point-max))
+             (insert (format "[%.3f] (%.3f) Function call\n    Function: %s\n    Args: %s\n\n"
+                             (float-time (time-since emacs-start-time))
+                             delta ',func args))))))))
+
+(defmacro spacemacs||make-function-profiler (func)
+  `(lambda (origfunc &rest args)
+     (if (profiler-running-p)
+         (profiler-report)
+       (profiler-start 'cpu))
+     (prog1
+         (apply origfunc args)
+       (with-current-buffer "*load-times*"
+         (goto-char (point-max))
+         (insert (format "[%.3f] Done profiling function: %s\n\n"
+                         (float-time (time-since emacs-start-time)) ',func)))
+       (profiler-report))))
+
+(when spacemacs-debug-with-profile
   (profiler-start 'cpu+mem)
   (add-hook 'after-init-hook
             (lambda ()
@@ -24,22 +104,26 @@
                                            (profiler-report)
                                            (profiler-stop))))))
 
-(when (member "--timed-requires" command-line-args)
-  (setq command-line-args (delete "--timed-requires" command-line-args))
-
-  (defvar spacemacs-load-time-threshold 0.15
-    "Generate message if file takes longer than this number of
-seconds to load")
-
+(when spacemacs-debug-with-timed-requires
   (with-current-buffer (get-buffer-create "*load-times*")
-    (insert (format "All files that took longer than %.3f seconds to load\n\n"
-                    spacemacs-load-time-threshold)))
+    (insert (format "Threshold set at %.3f seconds\n\n"
+                    spacemacs-debug-timer-threshold)))
+
+  (defadvice package-initialize (around spacemacs//timed-initialize activate)
+    (let ((start (current-time)) res delta)
+      (setq res ad-do-it
+            delta (float-time (time-since start)))
+      (when (> delta spacemacs-debug-timer-threshold)
+        (with-current-buffer "*load-times*"
+          (goto-char (point-max))
+          (insert (format "package-initialize took %.3f sec\n" delta))))
+      res))
 
   (defadvice require (around spacemacs//timed-require activate)
     (let ((start (current-time)) res delta)
       (setq res ad-do-it
             delta (float-time (time-since start)))
-      (when (> delta spacemacs-load-time-threshold)
+      (when (> delta spacemacs-debug-timer-threshold)
         (with-current-buffer "*load-times*"
           (goto-char (point-max))
           (insert (format "File %s: Required %s: %.3f sec\n"
@@ -50,11 +134,38 @@ seconds to load")
     (let ((start (current-time)) res delta)
       (setq res ad-do-it
             delta (float-time (time-since start)))
-      (when (> delta spacemacs-load-time-threshold)
+      (when (> delta spacemacs-debug-timer-threshold)
         (with-current-buffer "*load-times*"
           (goto-char (point-max))
           (insert (format "File %s: Loaded %s: %.3f sec\n"
                           load-file-name (ad-get-arg 0) delta))))
       res)))
+
+(when spacemacs-debug-with-adv-timers
+  (with-current-buffer (get-buffer-create "*load-times*")
+    (insert (format "Measured times greater than %.3f sec:\n\n"
+                    spacemacs-debug-timer-threshold)))
+
+  (add-hook 'after-init-hook
+            (lambda ()
+              (with-current-buffer "*load-times*"
+                (goto-char (point-max))
+                (insert (format "[%.3f] Spacemacs finished initializing\n\n"
+                                (float-time (time-since emacs-start-time)) )))))
+
+  (advice-add 'load :around #'spacemacs//load-timer)
+  (advice-add 'require :around #'spacemacs//load-timer)
+  (advice-add 'package-initialize
+	      :around
+        (spacemacs||make-function-timer package-intialize))
+  (advice-add 'configuration-layer/sync
+              :around
+              (spacemacs||make-function-timer configuration-layer/sync))
+  ;; (advice-add 'configuration-layer/sync
+  ;;             :around
+  ;;             (spacemacs||make-function-profiler configuration-layer/sync))
+  (advice-add 'configuration-layer//configure-package
+	      :around
+	      (spacemacs||make-function-timer configuration-layer//configure-package)))
 
 (provide 'core-debug)


### PR DESCRIPTION
More advanced timing of functions and loading with
--debug-init --adv-timers [N]. The last arg is optional and specifies
the threshold time for placing entries in the *load-timers* buffer.

Here's a sample of the new output
```
Measured times greater than 0.050 sec:

[0.077] (0.079) Load or require
    Feature: core-spacemacs
    In file: ~/.emacs.d/init.el

[0.153] (0.054) Load or require
    Feature: eieio
    In file: ~/.emacs.d/core/core-configuration-layer.el

[0.205] (0.108) Load or require
    Feature: core-configuration-layer
    In file: ~/.emacs.d/init.el

[0.373] (0.155) Function call
    Function: package-intialize
    Args: (noactivate)

[0.612] (0.121) Load or require
    Feature: evil
    In file: ~/.emacs.d/init.el

[0.838] (0.051) Load or require
    Feature: mail-parse
    In file: /emacs/share/emacs/25.0.50/lisp/gnus/mm-decode.elc

[0.854] (0.072) Load or require
    Feature: mm-decode
    In file: ~/.emacs.d/elpa/package-build-20151211.1444/package-build.elc

[0.857] (0.200) Load or require
    Feature: package-build
    In file: ~/.emacs.d/init.el

[1.106] (0.090) Load or require
    Feature: ~/.emacs.d/layers/+distribution/spacemacs/config.el
    In file: ~/.emacs.d/init.el

[1.758] (0.078) Load or require
    Feature: diff-hl
    In file: ~/.emacs.d/init.el

[1.758] (0.079) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package diff-hl version-control nil nil elpa nil nil nil])

[1.887] (0.058) Load or require
    Feature: eval-sexp-fu
    In file: ~/.emacs.d/init.el

[1.887] (0.058) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package eval-sexp-fu spacemacs nil nil elpa nil nil nil])

[2.257] (0.088) Load or require
    Feature: tramp-compat
    In file: /emacs/share/emacs/25.0.50/lisp/net/tramp.elc

[2.299] (0.144) Load or require
    Feature: tramp
    In file: ~/.emacs.d/elpa/git-gutter+-20151204.923/git-gutter+.elc

[2.546] (0.198) Load or require
    Feature: message
    In file: /emacs/share/emacs/25.0.50/lisp/vc/log-edit.elc

[2.550] (0.251) Load or require
    Feature: log-edit
    In file: ~/.emacs.d/elpa/git-gutter+-20151204.923/git-gutter+.elc

[2.632] (0.058) Load or require
    Feature: tramp-sh
    In file: ~/.emacs.d/elpa/with-editor-20151214.505/with-editor.elc

[2.693] (0.123) Load or require
    Feature: with-editor
    In file: ~/.emacs.d/elpa/git-commit-20151111.418/git-commit.elc

[2.703] (0.153) Load or require
    Feature: git-commit
    In file: ~/.emacs.d/elpa/git-gutter+-20151204.923/git-gutter+.elc

[2.709] (0.556) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package git-gutter+ version-control nil nil elpa nil nil nil])

[2.988] (0.061) Load or require
    Feature: info+
    In file: ~/.emacs.d/init.el

[2.988] (0.061) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package info+ spacemacs nil nil elpa nil nil nil])

[3.362] (0.073) Load or require
    Feature: spaceline-segments
    In file: ~/.emacs.d/elpa/spaceline-20151215.25/spaceline-config.elc

[3.363] (0.075) Load or require
    Feature: spaceline-config
    In file: ~/.emacs.d/init.el

[3.366] (0.079) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package spaceline spacemacs nil (spacemacs-layouts) elpa nil nil nil])

[3.448] (0.050) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package undo-tree spacemacs-base nil nil elpa nil nil nil])

[3.558] (0.053) Load or require
    Feature: xref
    In file: /emacs/share/emacs/25.0.50/lisp/progmodes/etags.elc

[3.563] (0.079) Load or require
    Feature: etags
    In file: ~/.emacs.d/init.el

[3.572] (0.098) Function call
    Function: configuration-layer//configure-package
    Args: ([eieio-class-tag--cfgl-package volatile-highlights spacemacs nil nil elpa nil nil nil])

[3.683] (2.788) Function call
    Function: configuration-layer/sync
    Args: nil

[3.733] Spacemacs finished initializing

[3.819] (0.063) Load or require
    Feature: ispell
    In file: /emacs/share/emacs/25.0.50/lisp/textmodes/flyspell.elc

[6.114] (0.063) Load or require
    Feature: helm-source
    In file: ~/.emacs.d/elpa/helm-core-20151213.17/helm.elc

[6.282] (0.084) Load or require
    Feature: helm-types
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[6.345] (0.063) Load or require
    Feature: helm-utils
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[6.530] (0.072) Load or require
    Feature: url-cookie
    In file: /emacs/share/emacs/25.0.50/lisp/url/url.elc

[6.652] (0.254) Load or require
    Feature: url
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-net.elc

[6.757] (0.078) Load or require
    Feature: browse-url
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-net.elc

[6.760] (0.388) Load or require
    Feature: helm-net
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-external.elc

[6.761] (0.415) Load or require
    Feature: helm-external
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[6.851] (0.063) Load or require
    Feature: helm-regexp
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-grep.elc

[6.894] (0.133) Load or require
    Feature: helm-grep
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[7.109] (0.186) Load or require
    Feature: helm-bookmark
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[7.182] (0.050) Load or require
    Feature: helm-buffers
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[7.257] (0.075) Load or require
    Feature: ffap
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[7.375] (0.093) Load or require
    Feature: dired-x
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[7.429] (0.054) Load or require
    Feature: image-dired
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-files.elc

[7.484] (1.308) Load or require
    Feature: helm-files
    In file: ~/.emacs.d/elpa/helm-20151220.2233/helm-mode.elc

[7.498] (1.529) Load or require
    Feature: helm
    In file: nil
```