### PR TITLE
Re-enable lockfiles

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -247,9 +247,7 @@ or lists of these.")
 ;; scratch buffer empty
 (setq initial-scratch-message nil)
 ;; don't create backup~ files
-(setq backup-by-copying t
-      make-backup-files nil
-      create-lockfiles nil)
+(setq make-backup-files nil)
 
 ;; Auto-save file
 (setq auto-save-default (not (null dotspacemacs-auto-save-file-location)))


### PR DESCRIPTION
Created from issue #2271.

I understand the rationale for setting `make-backup-files` to `nil` (although the default value of `vc-make-backup-files` is already `nil`), but I think it isn't necessary to change the value of `backup-by-copying` and `create-lockfiles`. Here are my reasons:

* The value of `make-backup-files` is already `nil`, so changing the value of `backup-by-copying` won't have any effect.
* IMHO lockfiles are more important than backup files since they can prevent concurrent changes.