### PR TITLE
+lang/python: use  instead of  for leader commands.

### DIFF
--- a/layers/+lang/python/extensions.el
+++ b/layers/+lang/python/extensions.el
@@ -37,16 +37,16 @@
                nosetests-pdb-suite)
     :init
     (evil-leader/set-key-for-mode 'python-mode
-      "mtA" 'nosetests-pdb-all
-      "mta" 'nosetests-all
-      "mtB" 'nosetests-pdb-module
-      "mtb" 'nosetests-module
-      "mtT" 'nosetests-pdb-one
-      "mtt" 'nosetests-one
-      "mtM" 'nosetests-pdb-module
-      "mtm" 'nosetests-module
-      "mtS" 'nosetests-pdb-suite
-      "mts" 'nosetests-suite)
+      "ctA" 'nosetests-pdb-all
+      "cta" 'nosetests-all
+      "ctB" 'nosetests-pdb-module
+      "ctb" 'nosetests-module
+      "ctT" 'nosetests-pdb-one
+      "ctt" 'nosetests-one
+      "ctM" 'nosetests-pdb-module
+      "ctm" 'nosetests-module
+      "ctS" 'nosetests-pdb-suite
+      "cts" 'nosetests-suite)
     :config
     (progn
       (add-to-list 'nose-project-root-files "setup.cfg")
@@ -59,7 +59,7 @@
     (progn
       (evilify pylookup-mode pylookup-mode-map)
       (evil-leader/set-key-for-mode 'python-mode
-        "mhH"  'pylookup-lookup))
+        "chH"  'pylookup-lookup))
     :config
     (progn
       (let ((dir (configuration-layer/get-layer-property 'python)))
@@ -70,7 +70,7 @@
 (defun python/init-py-yapf ()
   (use-package py-yapf
     :init
-    (evil-leader/set-key-for-mode 'python-mode "m=" 'py-yapf-buffer)
+    (evil-leader/set-key-for-mode 'python-mode "c=" 'py-yapf-buffer)
     :config
     (if python-enable-yapf-format-on-save
         (add-hook 'python-mode-hook 'py-yapf-enable-on-save))))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -45,10 +45,10 @@
     :config
     (progn
       (evil-leader/set-key-for-mode 'python-mode
-        "mhh" 'anaconda-mode-show-doc
-        "mgg" 'anaconda-mode-find-definitions
-        "mga" 'anaconda-mode-find-assignments
-        "mgu" 'anaconda-mode-find-references)
+        "chh" 'anaconda-mode-show-doc
+        "cgg" 'anaconda-mode-find-definitions
+        "cga" 'anaconda-mode-find-assignments
+        "cgu" 'anaconda-mode-find-references)
       (evilify anaconda-mode-view-mode anaconda-mode-view-mode-map
                (kbd "q") 'quit-window)
       (spacemacs|hide-lighter anaconda-mode))))
@@ -59,9 +59,9 @@
     :init
     (progn
       (evil-leader/set-key-for-mode 'cython-mode
-        "mhh" 'anaconda-mode-view-doc
-        "mgg" 'anaconda-mode-goto
-        "mgu" 'anaconda-mode-usages))))
+        "chh" 'anaconda-mode-view-doc
+        "cgg" 'anaconda-mode-goto
+        "cgu" 'anaconda-mode-usages))))
 
 (defun python/post-init-eldoc ()
   (add-hook 'python-mode-hook 'eldoc-mode))
@@ -84,15 +84,15 @@
     :defer t
     :init (progn
             (evil-leader/set-key-for-mode 'python-mode
-              "mvs" 'pyenv-mode-set
-              "mvu" 'pyenv-mode-unset))))
+              "cvs" 'pyenv-mode-set
+              "cvu" 'pyenv-mode-unset))))
 
 (defun python/init-pyvenv ()
   (use-package pyvenv
     :defer t
     :init
     (evil-leader/set-key-for-mode 'python-mode
-      "mV" 'pyvenv-workon)))
+      "cV" 'pyvenv-workon)))
 
 (defun python/init-pytest ()
   (use-package pytest
@@ -105,14 +105,14 @@
                pytest-module
                pytest-pdb-module)
     :init (evil-leader/set-key-for-mode 'python-mode
-            "mtA" 'pytest-pdb-all
-            "mta" 'pytest-all
-            "mtB" 'pytest-pdb-module
-            "mtb" 'pytest-module
-            "mtT" 'pytest-pdb-one
-            "mtt" 'pytest-one
-            "mtM" 'pytest-pdb-module
-            "mtm" 'pytest-module)
+            "ctA" 'pytest-pdb-all
+            "cta" 'pytest-all
+            "ctB" 'pytest-pdb-module
+            "ctb" 'pytest-module
+            "ctT" 'pytest-pdb-one
+            "ctt" 'pytest-one
+            "ctM" 'pytest-pdb-module
+            "ctm" 'pytest-module)
     :config (add-to-list 'pytest-project-root-files "setup.cfg")))
 
 (defun python/init-python ()
@@ -212,17 +212,17 @@
         (evil-insert-state))
 
       (evil-leader/set-key-for-mode 'python-mode
-        "mcc" 'spacemacs/python-execute-file
-        "mcC" 'spacemacs/python-execute-file-focus
-        "mdb" 'python-toggle-breakpoint
-        "mri" 'python-remove-unused-imports
-        "msB" 'python-shell-send-buffer-switch
-        "msb" 'python-shell-send-buffer
-        "msF" 'python-shell-send-defun-switch
-        "msf" 'python-shell-send-defun
-        "msi" 'python-start-or-switch-repl
-        "msR" 'python-shell-send-region-switch
-        "msr" 'python-shell-send-region)
+        "cc" 'spacemacs/python-execute-file
+        "cC" 'spacemacs/python-execute-file-focus
+        "cdb" 'python-toggle-breakpoint
+        "cri" 'python-remove-unused-imports
+        "csB" 'python-shell-send-buffer-switch
+        "csb" 'python-shell-send-buffer
+        "csF" 'python-shell-send-defun-switch
+        "csf" 'python-shell-send-defun
+        "csi" 'python-start-or-switch-repl
+        "csR" 'python-shell-send-region-switch
+        "csr" 'python-shell-send-region)
 
       ;; Emacs users won't need these key bindings
       ;; TODO: make these key bindings dynamic given the current style
@@ -272,7 +272,7 @@
   (use-package helm-pydoc
     :defer t
     :init
-    (evil-leader/set-key-for-mode 'python-mode "mhd" 'helm-pydoc)))
+    (evil-leader/set-key-for-mode 'python-mode "chd" 'helm-pydoc)))
 
 (defun python/post-init-smartparens ()
   (defadvice python-indent-dedent-line-backspace
@@ -316,7 +316,7 @@ fix this issue."
 (defun python/pre-init-xcscope ()
   (spacemacs|use-package-add-hook xcscope
     :post-init
-    (evil-leader/set-key-for-mode 'python-mode "mgi" 'cscope/run-pycscope)))
+    (evil-leader/set-key-for-mode 'python-mode "cgi" 'cscope/run-pycscope)))
 
 (defun python/pre-init-helm-cscope ()
   (spacemacs|use-package-add-hook xcscope


### PR DESCRIPTION
I am very, very new to spacemacs -- so feel free to close this if there is something I am mising, but going through the documentation it ensures that `<leader>m` commands will be reserved to the user.

The `python` layer however uses the `m` key by default.

Going through the different "memonics" I think that the `c` key is a far better choice for "code layer" commands -- in fact, it could be made `comments and code` instead of `comments and compile`.

I believe this doesn't over-ride any of the standard `c` commands except for:

- `c c`: run the python file, the equivalent of "compile" for python (each language would develop their own version)
- `c t`: replaces "comment to line" with the "code test" memonic.

There are a few changes I would like to make as well:
- change `c r i` to `c d i` -- as in `d` would be mapped to "delete and debug" instead of "remove"
- add `c r` memonic, as in "code run". Many lanagauges have a "compile and run" command line, which would be used for that specific lanaguage. (i.e. `cargo run` (rust), `go run` (golang), etc). For dynamic languages (like python) `c r` would be equivalent to `c c`

it would be great if this memonic were preserved across all layers. I will be learning rust, and it would be awesome to have community support for standard memonics so that `c r` would always run my project code.

Thanks!