### PR TITLE
Initial attempt at a layer for ProofGeneral

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,5 @@
 * Release 0.105.x
-** 0.105.0 (2015/01/04)
+** 0.105.0 (2016/01/04)
 *** IMPORTANT - Breaking changes
 - ~SPC l~ for =avy-goto-line= is now under ~SPC y~. ~SPC l~ is for
   spacemacs layouts.

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,4 +1,30 @@
 * Release 0.105.x
+** 0.105.1 (2016/01/05)
+*** Hot fixes
+- Fix and improve support for GUI clients using a server started with
+  =emacs --daemon=:
+  - Fix font
+  - Fix graphical Spaceline separator
+  - Fix theme colors (most of them)
+  - Fix Spacemacs logo in home buffer
+  - Add support for graphical Nyan Cat
+**** Spacemacs layer
+- Fix broken =evil-escape-mode= when toggling =holy-mode= (emacs style)
+**** Bépo layer
+- Fix support for Magit (thanks to StreakyCobra)
+**** Magit layer
+- Fix ~TAB~ key bindings to expand/collapse sections (thanks to justbur)
+**** Scala layer
+- Fix a typo in function name =scala-auto-insert-asterisk-in-comments=
+  (thanks to lunaryorn)
+*** Layer changes
+**** Spacemacs
+- New key binding ~SPC h n~ to browse the Emacs news (thanks to lunaryorn)
+**** Themes megapack
+- Add =monokai= theme (thanks to jonboiser)
+*** Other improvements
+- Typos and documentation improvements (thanks to mjs2600, person808,
+  robbyoconnor, StreakyCobra, TheBB and xfq)
 ** 0.105.0 (2016/01/04)
 *** IMPORTANT - Breaking changes
 - ~SPC l~ for =avy-goto-line= is now under ~SPC y~. ~SPC l~ is for

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ branch, for instance to revert to the last `0.103`:
    git checkout origin/release-0.103
    ```
 
+**After you update, either manually, or automatically, you are advised to update
+  your packages by clicking the `[Update Packages]` button on the Spacemacs Home
+  Buffer.**
+
 # Contributions
 
 Spacemacs is a community-driven project, it needs _you_ to keep it up to

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ git reset --hard <tag version which you are updating to>
 
 ## On develop branch
 
-1. Update Emacs packages by clicking (press `RET`) on the `[Update]` link of
+1. Update Emacs packages by clicking (press `RET`) on the `[Update Packages]` link of
 the starting page.
 
 2. Close Emacs and update the git repository:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ For efficient searches we recommend to install `pt` ([the platinum searcher][]).
    manually.
 
 3. Launch Emacs. Spacemacs will automatically install the packages it requires.
+   If you get an error regarding package downloads then you may try to disable
+   HTTPS protocol by starting Emacs with
+
+   ```sh
+   emacs --insecure
+   ```
 
 4. Restart Emacs to complete the installation.
 

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -30,9 +30,9 @@ the display system initialized."
   "If the display-system is initialized, run `BODY', otherwise,
 add it to a queue of actions to perform after the first graphical frame is
 created."
-  `(let ((init (cond ((bound-and-true-p ns-initialized) 'ns-initialized)
-                     ((bound-and-true-p w32-initialized) 'w32-initialized)
-                     ((bound-and-true-p x-initialized) 'x-initialized)
+  `(let ((init (cond ((boundp 'ns-initialized) 'ns-initialized)
+                     ((boundp 'w32-initialized) 'w32-initialized)
+                     ((boundp 'x-initialized) 'x-initialized)
                      (t 't))))           ; fallback to normal loading behavior
      (if (symbol-value init)
          (progn

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -233,20 +233,19 @@ derivatives. If set to `relative', also turns on relative line numbers.")
 
 (defvar dotspacemacs-highlight-delimiters 'all
   "Select a scope to highlight delimiters. Possible values are `any',
-  `current', `all' or `nil'. Default is `all' (highlight any scope and
-  emphasis the current one.")
+`current', `all' or `nil'. Default is `all' (highlight any scope and
+ emphasis the current one.")
 
-
-(defvar dotspacemacs-whitespace-cleanup 'changed
-  "Delete whitespace while saving buffer.
-
-Possible values are `all', `trailing', `changed' or `nil'.
-Default is `changed' (cleanup whitespace on changed lines)")
+(defvar dotspacemacs-whitespace-cleanup nil
+  "delete whitespace while saving buffer. possible values are `all'
+to aggressively delete empty lines and long sequences of whitespace, `trailing'
+to delete only the whitespace at end of lines, `changed' to delete only
+whitespace for changed lines or `nil' to disable cleanup.")
 
 (defvar dotspacemacs-delete-orphan-packages t
   "If non-nil spacemacs will delete any orphan packages, i.e. packages that are
 declared in a layer which is not a member of
- `dotspacemacs-configuration-layers'")
+`dotspacemacs-configuration-layers'")
 
 (defvar dotspacemacs-search-tools '("ag" "pt" "ack" "grep")
   "List of search tool executable names. Spacemacs uses the first installed

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -84,6 +84,11 @@
                                (car dotspacemacs-default-font))))
   ;; spacemacs init
   (spacemacs-buffer/goto-buffer)
+  ;; explicitly recreate the home buffer for the first GUI client
+  (spacemacs|do-after-display-system-init
+   (kill-buffer (get-buffer spacemacs-buffer-name))
+   (spacemacs-buffer/goto-buffer))
+
   (setq initial-buffer-choice (lambda () (get-buffer spacemacs-buffer-name)))
   ;; mandatory dependencies
   ;; dash is required to prevent a package.el bug with f on 24.3.1

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -88,7 +88,6 @@
   (spacemacs|do-after-display-system-init
    (kill-buffer (get-buffer spacemacs-buffer-name))
    (spacemacs-buffer/goto-buffer))
-
   (setq initial-buffer-choice (lambda () (get-buffer spacemacs-buffer-name)))
   ;; mandatory dependencies
   ;; dash is required to prevent a package.el bug with f on 24.3.1

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -185,7 +185,10 @@ package name does not match theme name + `-theme' suffix.")
       ;; if not we will handle the special themes as we get issues in the tracker.
       (let ((pkg (spacemacs//get-theme-package theme)))
         (spacemacs/load-or-install-package pkg)))))
-  (load-theme theme t))
+  (load-theme theme t)
+  ;; explicitly reload the theme for the first GUI client
+  (eval `(spacemacs|do-after-display-system-init
+          (load-theme ',theme t))))
 
 (defun spacemacs/cycle-spacemacs-theme ()
   "Cycle through themes defined in `dotspacemacs-themes.'"

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -38,7 +38,7 @@ values."
      )
    ;; List of additional packages that will be installed without being
    ;; wrapped in a layer. If you need some configuration for these
-   ;; packages then consider to create a layer, you can also put the
+   ;; packages, then consider creating a layer. You can also put the
    ;; configuration in `dotspacemacs/user-config'.
    dotspacemacs-additional-packages '()
    ;; A list of packages and/or extensions that will not be install and loaded.

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -223,17 +223,19 @@ values."
    ;; specified with an installed package.
    ;; Not used for now. (default nil)
    dotspacemacs-default-package-repository nil
-   ;; Delete whitespace while saving buffer. Possible values are `all',
-   ;; `trailing', `changed' or `nil'. Default is `changed' (cleanup whitespace
-   ;; on changed lines) (default 'changed)
-   dotspacemacs-whitespace-cleanup 'changed
+   ;; Delete whitespace while saving buffer. Possible values are `all'
+   ;; to aggressively delete empty line and long sequences of whitespace,
+   ;; `trailing' to delete only the whitespace at end of lines, `changed'to
+   ;; delete only whitespace for changed lines or `nil' to disable cleanup.
+   ;; (default nil)
+   dotspacemacs-whitespace-cleanup nil
    ))
 
 (defun dotspacemacs/user-init ()
   "Initialization function for user code.
-It is called immediately after `dotspacemacs/init'.  You are free to put almost any
-user code here.  The exception is org related code, which should be placed in
-`dotspacemacs/user-config'."
+It is called immediately after `dotspacemacs/init'.  You are free to put almost
+any user code here.  The exception is org related code, which should be placed
+in `dotspacemacs/user-config'."
   )
 
 (defun dotspacemacs/user-config ()

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1289,6 +1289,7 @@ Other help key bindings:
 | ~SPC h k~   | show top-level bindings with =which-key=                           |
 | ~SPC h L~   | go to library a implementation                                     |
 | ~SPC h m~   | search available man pages                                         |
+| ~SPC h n~   | browse emacs news                                                  |
 
 Navigation key bindings in =help-mode=:
 

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -16,6 +16,7 @@
    - [[Why is Spacemacs hanging on startup?][Why is Spacemacs hanging on startup?]]
    - [[Why does =helm-M-x= (~SPC :~) not accept the prefix argument?][Why does =helm-M-x= (~SPC :~) not accept the prefix argument?]]
    - [[Why does my color theme not render correctly in terminal mode?][Why does my color theme not render correctly in terminal mode?]]
+   - [[Why do I get =(wrong-type-argument arrayp nil)= errors on startup?][Why do I get =(wrong-type-argument arrayp nil)= errors on startup?]]
  - [[How do I...][How do I...]]
    - [[Install a package not provided by a layer?][Install a package not provided by a layer?]]
    - [[Disable a package completely?][Disable a package completely?]]
@@ -145,6 +146,10 @@ In the terminal version of Emacs, color themes will not render correctly as
 colors are rendered by the terminal and not by emacs. You will probably have to
 change your terminal color palette. More explanations can be found on
 [[https://github.com/sellout/emacs-color-theme-solarized#important-note-for-terminal-users][emacs-color-theme-solarized webpage]].
+
+** Why do I get =(wrong-type-argument arrayp nil)= errors on startup?
+This is most likely caused by a corrupted package archive. Try deleting your
+=~/.emacs.d/elpa/archives/= folder and restart Emacs.
 
 * How do I...
 ** Install a package not provided by a layer?

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -27,7 +27,7 @@
    - [[Disable evilification of a mode?][Disable evilification of a mode?]]
    - [[Include underscores in word motions?][Include underscores in word motions?]]
    - [[Setup =$PATH=?][Setup =$PATH=?]]
-   - [[Change or define an alias for an =evil-leader= prefix?][Change or define an alias for an =evil-leader= prefix?]]
+   - [[Change or define an alias for a leader key?][Change or define an alias for a leader key?]]
    - [[Restore the sentence delimiter to two spaces?][Restore the sentence delimiter to two spaces?]]
    - [[Prevent the visual selection overriding my system clipboard?][Prevent the visual selection overriding my system clipboard?]]
    - [[Make spell-checking support curly quotes (or any other character)?][Make spell-checking support curly quotes (or any other character)?]]
@@ -240,7 +240,7 @@ binding in the mode's map, e.g. for =magit-status-mode=,
 #+begin_src emacs-lisp
   (with-eval-after-load 'magit
     (define-key magit-status-mode-map
-      (kbd dotspacemacs-leader-key) evil-leader--default-map))
+      (kbd dotspacemacs-leader-key) spacemacs-default-map))
 #+end_src
 
 ** Include underscores in word motions?
@@ -300,26 +300,26 @@ In that case you have the option of updating the value of =exec-path= in the
 (add-to-list 'exec-path "~/.local/bin/")
 #+END_SRC
 
-** Change or define an alias for an =evil-leader= prefix?
-It is possible to change an =evil-leader= prefix by binding its keymap to
-another sequence. For instance, if you want to switch ~SPC S~ (spelling) with
-~SPC d~ (used by dash) to make the former easier to reach, you can use:
+** Change or define an alias for a leader key?
+It is possible to change a leader key by binding its keymap to another sequence.
+For instance, if you want to switch ~SPC S~ (spelling) with ~SPC d~ (used by
+dash) to make the former easier to reach, you can use:
 
 #+begin_src emacs-lisp
 (defun dear-leader/swap-keys (key1 key2)
-  (let ((map1 (lookup-key evil-leader--default-map key1))
-        (map2 (lookup-key evil-leader--default-map key2)))
+  (let ((map1 (lookup-key spacemacs-default-map key1))
+        (map2 (lookup-key spacemacs-default-map key2)))
     (spacemacs/set-leader-keys key1 map2 key2 map1)))
 (dear-leader/swap-keys "S" "d")
 #+end_src
 
-If you want to define your own alias, like using ~SPC é~ (because it's an
-unmapped key on your keyboard-layout for instance) for accessing ~SPC w~
-(windows management), you can use this:
+If you want to define your own alias, like using ~SPC é~ (because it's a not
+used key on your keyboard-layout for instance) for accessing ~SPC w~ (windows
+management), you can use this:
 
 #+begin_src emacs-lisp
 (defun dear-leader/alias-of (key1 key2)
-  (let ((map (lookup-key evil-leader--default-map key2)))
+  (let ((map (lookup-key spacemacs-default-map key2)))
     (spacemacs/set-leader-keys key1 map)))
 (dear-leader/alias-of "é" "w")
 #+end_src

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -6,6 +6,7 @@
    - [[Which version of Spacemacs am I running?][Which version of Spacemacs am I running?]]
    - [[What is the official pronunciation of Spacemacs?][What is the official pronunciation of Spacemacs?]]
    - [[Why are packages installed with =package-install= automatically deleted by Spacemacs when it boots?][Why are packages installed with =package-install= automatically deleted by Spacemacs when it boots?]]
+   - [[How to fix package download errors when installing Spacemacs ?][How to fix package download errors when installing Spacemacs ?]]
    - [[The Spacemacs banner is ugly, what should I do?][The Spacemacs banner is ugly, what should I do?]]
    - [[The powerline separators are ugly, how can I fix them?][The powerline separators are ugly, how can I fix them?]]
    - [[The powerline separators have no anti-aliasing, what can I do?][The powerline separators have no anti-aliasing, what can I do?]]
@@ -52,6 +53,14 @@ As it is written, that is _space_ then _macs_.
 To declare new packages you have to create a new configuration layer or
 add the package name to the variable =dotspacemacs-additonal-packages=
 of your dotfile, see the [[file:QUICK_START.org][quick start guide]] for more info.
+
+** How to fix package download errors when installing Spacemacs ?
+Since 0.105.0 HTTPS protocol is used by default to download packages. If your
+environment does not allow HTTPS to reach ELPA repositories then you can start
+Emacs with the =--insecure= argument for force the usage of HTTP non secured
+protocol.
+Then you can set the variable =dotspacemacs-elpa-https= to =nil= in your
+dotfile to remove the need to start Emacs with =--insecure== argument.
 
 ** The Spacemacs banner is ugly, what should I do?
 Install the default font supported by Spacemacs or choose a fixed width font.

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -463,12 +463,8 @@ you can [[Uninstalling a package][uninstall]] the =evil-search-highlight-persist
 
 *** Sessions
 Spacemacs does not automatically restore your windows and buffers when you
-reopen it. If you use vim sessions regularly you may want to add
-=(desktop-save-mode t)= to your =dotspacemacs/user-config= in your =.spacemacs=
-to get this functionality. You will then be able to load the saved session
-using ~SPC : desktop-read~. The location of the desktop file can be set with
-the variable =desktop-dirname=. To automatically load a session,
-add =(desktop-read)= to your =.spacemacs=.
+reopen it. If you use vim sessions regularly you may want to set
+=dotspacemacs-auto-resume-layouts= to =t= in your =.spacemacs=.
 
 *** Navigating using visual lines
 Spacemacs uses the vim default of navigating by actual lines, even if they are

--- a/init.el
+++ b/init.el
@@ -14,7 +14,7 @@
 ;; (package-initialize)
 
 (setq gc-cons-threshold 100000000)
-(defconst spacemacs-version          "0.105.0" "Spacemacs version.")
+(defconst spacemacs-version          "0.105.1" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 
 (if (not (version<= spacemacs-emacs-min-version emacs-version))

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -97,6 +97,7 @@ Ensure that helm is required before calling FUNC."
 (spacemacs/set-leader-keys "hds" 'spacemacs/describe-system-info)
 (spacemacs||set-helm-key "hdt" describe-theme)
 (spacemacs||set-helm-key "hdv" describe-variable)
+(spacemacs||set-helm-key "hn"  view-emacs-news)
 (spacemacs||set-helm-key "hL"  helm-locate-library)
 ;; search functions -----------------------------------------------------------
 (spacemacs||set-helm-key "sww" helm-wikipedia-suggest)

--- a/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
+++ b/layers/+distribution/spacemacs-base/local/holy-mode/holy-mode.el
@@ -31,7 +31,7 @@
 (defvar holy-mode-modes-to-disable-alist
   `((evil-mode . 1)
     (hybrid-mode . -1)
-    (evil-escape-mode . ,(when (boundp 'evil-escape-mode) 1 -1)))
+    (evil-escape-mode . ,(if (boundp 'evil-escape-mode) evil-escape-mode -1)))
   "Alist of modes that should be disabled when activating
 `holy-mode'. The cdr in each cell stores the state of the mode
 before it was disabled.")

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -582,7 +582,17 @@
     :init
     (progn
       (setq evil-jumper-auto-save-interval 600)
-      (evil-jumper-mode t))))
+      ;; Move keybindings into global motion state map
+      (add-hook 'evil-jumper-mode-hook
+                (lambda ()
+                  (if evil-jumper-mode
+                      (progn
+                        (define-key evil-motion-state-map (kbd "TAB") 'evil-jumper/forward)
+                        (define-key evil-motion-state-map (kbd "C-o") 'evil-jumper/backward))
+                    (define-key evil-motion-state-map (kbd "TAB") 'evil-jump-forward)
+                    (define-key evil-motion-state-map (kbd "C-o") 'evil-jump-backward))))
+      (evil-jumper-mode t)
+      (setcdr evil-jumper-mode-map nil))))
 
 (defun spacemacs/init-evil-lisp-state ()
   (use-package evil-lisp-state

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -1735,8 +1735,9 @@ Open junk file using helm, with `prefix-arg' search in junk files"
   (use-package spaceline-config
     :init
     (progn
-      (setq-default powerline-default-separator (if (display-graphic-p) 'wave 'utf-8))
-
+      (spacemacs|do-after-display-system-init
+       (setq-default powerline-default-separator
+                     (if (display-graphic-p) 'wave 'utf-8)))
       (defun spacemacs//set-powerline-for-startup-buffers ()
         "Set the powerline for buffers created when Emacs starts."
         (unless configuration-layer-error-count
@@ -1746,7 +1747,6 @@ Open junk file using helm, with `prefix-arg' search in junk files"
               (spacemacs//restore-powerline buffer)))))
       (add-hook 'emacs-startup-hook
                 'spacemacs//set-powerline-for-startup-buffers))
-
     :config
     (progn
       (defun spacemacs/customize-powerline-faces ()

--- a/layers/+keyboard-layouts/bepo/keybindings.el
+++ b/layers/+keyboard-layouts/bepo/keybindings.el
@@ -234,8 +234,6 @@
     (bepo/set-in-state helm-generic-files-map "C-s" 'helm-previous-line)
     (bepo/set-in-state helm-generic-files-map "C-k" 'helm-ff-run-grep)))
 
-;; HACK: Waiting to find the bug…
-(setq evil-magit-use-y-for-yank nil)
 (bepo|config magit
   :description
   "Remap `magit' bindings."
@@ -243,7 +241,7 @@
   (spacemacs|use-package-add-hook magit :post-config BODY)
   :config
   (progn
-    (bepo/evil-correct-keys 'motion magit-mode-map
+    (bepo/evil-correct-keys evil-magit-state magit-mode-map
       "j"
       "k"
       "C-j"

--- a/layers/+keyboard-layouts/bepo/keybindings.el
+++ b/layers/+keyboard-layouts/bepo/keybindings.el
@@ -234,6 +234,8 @@
     (bepo/set-in-state helm-generic-files-map "C-s" 'helm-previous-line)
     (bepo/set-in-state helm-generic-files-map "C-k" 'helm-ff-run-grep)))
 
+;; HACK: Waiting to find the bug…
+(setq evil-magit-use-y-for-yank nil)
 (bepo|config magit
   :description
   "Remap `magit' bindings."

--- a/layers/+lang/proof-general/README.org
+++ b/layers/+lang/proof-general/README.org
@@ -1,0 +1,41 @@
+#+TITLE: ProofGeneral contribution layer for Spacemacs
+
+* Description
+
+This layer adds support for the [[http://http://proofgeneral.inf.ed.ac.uk/][Proof General]] proof assistant front-end
+
+** Some features:
+- Spacemacs bindings to some of Proof General's interactive tools
+  
+*This layer is in construction, it needs your contributions and bug reports.*
+
+* Install
+** Layer
+To use this contribution add it to your =~/.spacemacs=
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(proof-general))
+#+END_SRC
+
+** Proof General
+
+Quick instructions to install Proof General:
+
+#+BEGIN_SRC sh
+  curl http://proofgeneral.inf.ed.ac.uk/ProofGeneral-stable.tgz -o /usr/local/pgs.tgz
+  cd /usr/local
+  tar -xpzf pgs.tgz
+#+END_SRC
+
+*this layer assumes you have extracted Proof General to =/usr/local=*
+
+* Key bindings
+
+The key bindings of this layer don't follow the Spacemacs conventions, opting instead to
+follow Proof General's bindings prefixed by major-mode leader
+~SPC m~
+
+| Key binding | Description                |
+|-------------+----------------------------|
+| ~SPC m s~   | toggle active scripting    |
+| ~SPC m .~   | toggle electric terminator |

--- a/layers/+lang/proof-general/extensions.el
+++ b/layers/+lang/proof-general/extensions.el
@@ -1,0 +1,20 @@
+(defvar proof-general-post-extensions '(proof-general))
+
+(defun proof-general/init-proof-general ()
+  "Initialize Proof General"
+
+  (unless (executable-find "proofgeneral")
+    (spacemacs/buffer/warning
+     (concat "ProofGeneral not detected, be sure that ProofGeneral binaries are "
+             "available in your PATH or check the installation instructions in "
+             "the README file.")))
+
+  (use-package proof-site
+    :if (executable-find "proofgeneral")
+    :defer t
+    :mode ("\\.v\\'" . coq-mode)
+    :load-path "/usr/local/ProofGeneral/generic"
+    :config (progn
+              (evil-leader/set-key-for-mode 'coq-mode
+                "ms" 'proof-toggle-active-scripting
+                "m." 'proof-electric-terminator-toggle))))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -202,7 +202,7 @@
       (defun scala/newline-and-indent-with-asterisk ()
         (interactive)
         (newline-and-indent)
-        (when scala-auto-insert-asterisk-in-comment
+        (when scala-auto-insert-asterisk-in-comments
           (scala-indent:insert-asterisk-on-multiline-comment)))
 
       (evil-define-key 'insert scala-mode-map

--- a/layers/colors/extensions.el
+++ b/layers/colors/extensions.el
@@ -20,31 +20,14 @@
       (setq nyan-wavy-trail t)
       (setq nyan-animate-nyancat t)
       (nyan-mode)
+      ;; explicitly re-enable the cat for the first GUI client
+      (spacemacs|do-after-display-system-init
+       (nyan-mode -1)
+       (nyan-mode))
 
       (spacemacs|add-toggle nyan-cat-progress-bar
         :status nyan-mode
         :on (nyan-mode)
         :off (nyan-mode -1)
         :documentation "Show a nyan cat progress bar in the mode-line."
-        :evil-leader "tmn")
-
-      (defun spacemacs/powerline-nyan-cat ()
-        "Construct a powerline segment for nyan cat."
-        (let* ((active (powerline-selected-window-active))
-               (l (1+ (truncate (powerline-width lhs))))
-               (r (1+ (truncate (powerline-width rhs))))
-               (face1 (if active 'powerline-active1 'powerline-inactive1))
-               (face2 (if active 'powerline-active2 'powerline-inactive2))
-               (separator-left
-                (intern (format "powerline-%s-%s"
-                                powerline-default-separator
-                                (car powerline-default-separator-dir))))
-               (separator-right
-                (intern (format "powerline-%s-%s"
-                                powerline-default-separator
-                                (cdr powerline-default-separator-dir)))))
-          (setq nyan-bar-length (min 32 (/ (- (window-total-width) l r) 2)))
-          (list
-           (funcall separator-right face2 face1)
-           (powerline-raw (nyan-create) face1)
-           (funcall separator-left face1 face2)))))))
+        :evil-leader "tmn"))))

--- a/layers/themes-megapack/packages.el
+++ b/layers/themes-megapack/packages.el
@@ -58,6 +58,7 @@
     minimal-theme
     moe-theme
     molokai-theme
+    monokai-theme
     monochrome-theme
     mustang-theme
     naquadah-theme


### PR DESCRIPTION
This isn't complete, in terms of key bindings or file types that proof general can deal with, but wanted to get something for `ProofGeneral` into spacemacs.

- looks for `proofgeneral` executable, before attempting to use the `proof-site` package
- loads `coq-mode` for *.v files
- adds 2 key bindings:
  - toggle active script
  - toggle electric terminator