### PR TITLE
Fixes #4229 - support emacs started with -q

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -585,7 +585,7 @@ already exist, and switch to it."
         (setq spacemacs-buffer--note-widgets nil)
         (spacemacs-buffer/insert-banner-and-buttons)
         ;; non-nil if emacs-startup-hook was run
-        (if (bound-and-true-p spacemacs-version-check-timer)
+        (if (bound-and-true-p spacemacs-initialized)
             (progn
               (when dotspacemacs-startup-lists
                 (spacemacs-buffer/insert-startupify-lists))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -585,7 +585,7 @@ already exist, and switch to it."
         (setq spacemacs-buffer--note-widgets nil)
         (spacemacs-buffer/insert-banner-and-buttons)
         ;; non-nil if emacs is loaded
-        (if after-init-time
+        (if (and init-file-user after-init-time)
             (progn
               (when dotspacemacs-startup-lists
                 (spacemacs-buffer/insert-startupify-lists))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -584,8 +584,8 @@ already exist, and switch to it."
         ;; needed in case the buffer was deleted and we are recreating it
         (setq spacemacs-buffer--note-widgets nil)
         (spacemacs-buffer/insert-banner-and-buttons)
-        ;; non-nil if emacs is loaded
-        (if (and init-file-user after-init-time)
+        ;; non-nil if emacs-startup-hook was run
+        (if (bound-and-true-p spacemacs-version-check-timer)
             (progn
               (when dotspacemacs-startup-lists
                 (spacemacs-buffer/insert-startupify-lists))

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -45,6 +45,9 @@
 
 (defvar spacemacs--default-mode-line mode-line-format
   "Backup of default mode line format.")
+(defvar spacemacs-initialized nil
+  "Whether or not spacemacs has finished initializing by completing
+the final step of executing code in `emacs-startup-hook'.")
 
 (defun spacemacs/init ()
   "Perform startup initialization."
@@ -175,7 +178,8 @@
         (format "\n[%s packages loaded in %.3fs]\n"
                 (configuration-layer/configured-packages-count)
                 elapsed)))
-     (spacemacs/check-for-new-version spacemacs-version-check-interval))))
+     (spacemacs/check-for-new-version spacemacs-version-check-interval)
+     (setq spacemacs-initialized t))))
 
 (defun spacemacs/describe-system-info ()
   "Gathers info about your Spacemacs setup and copies to clipboard."


### PR DESCRIPTION
This change is to allow starting emacs via the following method:

```sh
emacs -q --eval '(setq user-emacs-directory "/u/me/Public/spacemacs24/")' --eval '(load "/home/me/Public/spacemacs24/init.el")'
```

This is a fix for https://github.com/syl20bnr/spacemacs/issues/4229
This is in lieu of relying on ~/.emacs or ~/.emacs.d.

This should have no impact for users who follow the official instruction on how to use spacemacs, i.e., those who over-ride ~/.emacs.d with the spacemacs directory.  This is because init-file-user should always be non-nil for those users.  init-file-user should be nil only if emacs was launched with -q option.

On second thought, perhaps there is a better solution.  You are trying to test whether spacemacs has been loaded or not here, right?  If so, shouldn't the test be something like (featurep 'a-spacemacs-feature)
or even (fboundp 'some-spacemacs-function)?