### PR TITLE
idris: use popwin/motion state for special buffers

### DIFF
--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -10,7 +10,8 @@
 ;;
 ;;; License: GPLv3
 
-(setq idris-packages '(idris-mode))
+(setq idris-packages '(idris-mode
+                       popwin))
 
 (defun idris/init-idris-mode ()
   (use-package idris-mode
@@ -84,4 +85,19 @@
         "sN" 'spacemacs/idris-load-forward-line-and-focus
         "sp" 'idris-load-backward-line
         "sP" 'spacemacs/idris-load-backward-line-and-focus
-        "ss" 'idris-pop-to-repl))))
+        "ss" 'idris-pop-to-repl)))
+
+  ;; open special buffers in motion state so they can be closed with ~q~
+  (evil-set-initial-state 'idris-compiler-notes-mode 'motion)
+  (evil-set-initial-state 'idris-hole-list-mode 'motion)
+  (evil-set-initial-state 'idris-info-mode 'motion))
+
+(defun idris/pre-init-popwin ()
+  (spacemacs|use-package-add-hook popwin
+    :post-config
+    (push '("*idris-notes*" :dedicated t :position bottom :stick t :noselect nil :height 0.4)
+          popwin:special-display-config)
+    (push '("*idris-holes*" :dedicated t :position bottom :stick t :noselect nil :height 0.4)
+          popwin:special-display-config)
+    (push '("*idris-info*" :dedicated t :position bottom :stick t :noselect nil :height 0.4)
+          popwin:special-display-config)))


### PR DESCRIPTION
Idris development results in a lot of transient popup buffers, which
the layer currently doesn't handle particularly well. This commit uses
popwin so that these special buffers appear in a predictable location
and opens them in motion state so that they can be closed immediately by
pressing ~q~.

These changes are largely based on the Clojure layer, which has worked
very well in my experience.