### PR TITLE
keybindings: Add SPC j for jumping

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -99,6 +99,7 @@
        - [[Smooth scrolling][Smooth scrolling]]
      - [[Vim motions with avy][Vim motions with avy]]
        - [[ace-link mode][ace-link mode]]
+     - [[Jumping][Jumping]]
      - [[Window manipulation][Window manipulation]]
        - [[Window manipulation key bindings][Window manipulation key bindings]]
        - [[Window manipulation micro-state][Window manipulation micro-state]]
@@ -1406,8 +1407,8 @@ Navigation is performed using the Vi key bindings ~hjkl~.
 | ~l~         | move cursor right                                                                 |
 | ~H~         | move cursor to the top of the screen                                              |
 | ~L~         | move cursor to the bottom of the screen                                           |
-| ~SPC j h~   | go to the beginning of line (and set a mark at the previous location in the line) |
-| ~SPC j l~   | go to the end of line (and set a mark at the previous location in the line)       |
+| ~SPC j 0~   | go to the beginning of line (and set a mark at the previous location in the line) |
+| ~SPC j $~   | go to the end of line (and set a mark at the previous location in the line)       |
 | ~SPC t -~   | lock the cursor at the center of the screen                                       |
 
 **** Smooth scrolling
@@ -1443,6 +1444,28 @@ Similar to =avy=, [[https://github.com/abo-abo/ace-link][ace-link]] allows one t
 | Key Binding | Description                                           |
 |-------------+-------------------------------------------------------|
 | ~o~         | initiate ace link mode in =help-mode= and =info-mode= |
+
+*** Jumping
+The ~SPC j~ prefix includes several commands related to "jumping" or quickly
+moving to a relevant location based on context. You'll recognize some of the
+bindings from the previous sections, which are duplicated here.
+
+| Key Binding | Description                                                                       |
+|-------------+-----------------------------------------------------------------------------------|
+| ~SPC j 0~   | go to the beginning of line (and set a mark at the previous location in the line) |
+| ~SPC j $~   | go to the end of line (and set a mark at the previous location in the line)       |
+| ~SPC j b~   | jump to a bookmark                                                                |
+| ~SPC j c~   | jump to a character in the buffer                                                 |
+| ~SPC j d~   | jump to a listing of the current directory                                        |
+| ~SPC j D~   | jump to a listing of the current directory (other window)                         |
+| ~SPC j f~   | jump to the definition of the function under the point                            |
+| ~SPC j i~   | jump to a definition in buffer (imenu)                                            |
+| ~SPC j I~   | jump to a definition in any buffer (imenu)                                        |
+| ~SPC j l~   | initiate avy jump line                                                            |
+| ~SPC j u~   | undo a jump (go back to previous location)                                        |
+| ~SPC j U~   | jump to a URL in the current buffer                                               |
+| ~SPC j v~   | jump to the definition/declaration of the variable under the point                |
+| ~SPC j w~   | jump to a word in the current buffer                                              |
 
 *** Window manipulation
 **** Window manipulation key bindings

--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -31,7 +31,7 @@
                                        ("h"   "helm/help/highlight")
                                        ("hd"  "help-describe")
                                        ("i"   "insertion")
-                                       ("j"   "join/split")
+                                       ("j"   "jump/join/split")
                                        ("k"   "lisp")
                                        ("kd"  "delete")
                                        ("kD"  "delete-backward")

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -144,10 +144,22 @@ Ensure that helm is required before calling FUNC."
   "jJ" 'spacemacs/split-and-new-line
   "jk" 'spacemacs/evil-goto-next-line-and-indent)
 
-;; navigation -----------------------------------------------------------------
+;; navigation/jumping ---------------------------------------------------------
 (spacemacs/set-leader-keys
-  "jh" 'spacemacs/push-mark-and-goto-beginning-of-line
-  "jl" 'spacemacs/push-mark-and-goto-end-of-line)
+  "j0" 'spacemacs/push-mark-and-goto-beginning-of-line
+  "j$" 'spacemacs/push-mark-and-goto-end-of-line
+  "jb" 'bookmark-jump
+  "jc" 'evil-avy-goto-char-2
+  "jd" 'dired-jump
+  "jD" 'dired-jump-other-window
+  "jf" 'find-function-at-point
+  "ji" 'spacemacs/jump-in-buffer
+  "jI" 'helm-imenu-in-all-buffers
+  "jl" 'evil-avy-goto-line
+  "ju" 'avy-pop-mark
+  "jU" 'spacemacs/avy-goto-url
+  "jv" 'find-variable-at-point
+  "jw" 'evil-avy-goto-word-or-subword-1)
 
 ;; Compilation ----------------------------------------------------------------
 (spacemacs/set-leader-keys

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -677,6 +677,7 @@ Removes the automatic guessing of the initial value based on thing at point. "
         "rr"   'helm-register
         "rm"   'helm-all-mark-rings
         "sl"   'spacemacs/last-search-buffer
+        "jm"   'spacemacs/jump-in-buffer
         "sj"   'spacemacs/jump-in-buffer)
 
       ;; search with grep

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -391,7 +391,7 @@
 (defun spacemacs/init-avy ()
   (use-package avy
     :defer t
-    :commands (spacemacs/avy-open-url)
+    :commands (spacemacs/avy-open-url avy-pop-mark)
     :init
     (progn
       (setq avy-all-windows 'all-frames)


### PR DESCRIPTION
I'd like to make `SPC j` more useful by adding a bunch of "jumping" commands under it. Please feel free to add or subtract as you see fit. I just tried to think of some useful operations here. I know some of the functionality is duplicated, but that doesn't bother me.

Commit message:

Use mnemonic j for jumping commands. Although some of these commands
exist in other places, they are duplicated here when they don't
conflict.

Add:

  1. jb for bookmark-jump
  2. jc for avy char jump
  3. jd for dired-jump
  4. jD for dired-jump-other-window
  5. jf for find-function-at-point
  6. ji for spacemacs/jump-in-buffer
  7. jI for helm imenu in all buffers
  8. jl for avy go to line
  9. ju for avy-pop-mark (u for "undo")
  10. jU for spacmacs/avy-goto-url
  11. jv for find-variable-at-point
  12. jw for avy go to word or subword

Move:
  1. jh to j0 (push mark and go to beginning of line)
  1. jl to j$ (push mark and go to end of line)