### PR TITLE
Fixes #3379 - use emacs version specific elpa directories

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1069,7 +1069,7 @@ to select one."
                  (pkg-dir-name (cdr apkg))
                  (installed-ver
                   (configuration-layer//get-package-version-string pkg))
-                 (elpa-dir (concat user-emacs-directory "elpa/"))
+                 (elpa-dir package-user-dir)
                  (src-dir (expand-file-name
                            (concat rollback-dir (file-name-as-directory
                                                  pkg-dir-name))))
@@ -1169,7 +1169,7 @@ to select one."
     (cond
      ((version< emacs-version "24.3.50")
       (let* ((version (aref (cdr pkg-desc) 0))
-             (elpa-dir (concat user-emacs-directory "elpa/"))
+             (elpa-dir package-user-dir)
              (pkg-dir-name (format "%s-%s.%s"
                                    (symbol-name pkg-name)
                                    (car version)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -50,7 +50,7 @@ FILE-TO-LOAD is an explicit file to load after the installation."
 
 (defun spacemacs//get-package-directory (pkg)
   "Return the directory of PKG. Return nil if not found."
-  (let ((elpa-dir (concat user-emacs-directory "elpa/")))
+  (let ((elpa-dir package-user-dir))
     (when (file-exists-p elpa-dir)
       (let ((dir (cl-reduce (lambda (x y) (if x x y))
                          (mapcar (lambda (x)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -46,6 +46,13 @@
 (defvar spacemacs--default-mode-line mode-line-format
   "Backup of default mode line format.")
 
+;; Use emacs version number in the directory where packages are installed in
+;; order to support multiple emacs versions (with potentially incompatible
+;; bytecode formats) from the same spacemacs directory.
+(let ((ver (format "%s.%s" emacs-major-version emacs-minor-version)))
+  (custom-set-variables
+   `(package-user-dir (locate-user-emacs-file (format "elpa-%s/" ,ver)))))
+
 (defun spacemacs/init ()
   "Perform startup initialization."
   ;; silence ad-handle-definition about advised functions getting redefined


### PR DESCRIPTION
Let ROOT represent the spacemacs root directory. Spacemacs installs
packages into ROOT/elpa directory. This is problematic for those who use
multiple versions of emacs, e.g., emacs 24 and 25 or even emacs 24.3 and
24.5. This is because the byte compiled files may not be compatible from
one version of emacs to another. Hence it is important to use separate
directories to house byte compiled files for different versions of
emacs. That is why directories such as ROOT/elpa-24.5 and ROOT/elpa-25.0
are proposed instead of ROOT/elpa.