### PR TITLE
Fix layouts TAB behavior

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -48,7 +48,8 @@
       (defun spacemacs/jump-to-last-layout ()
         "Open the previously selected layout."
         (interactive)
-        (persp-switch spacemacs--last-selected-layout))
+        (when (persp-get-by-name spacemacs--last-selected-layout)
+          (persp-switch spacemacs--last-selected-layout)))
 
       ;; Perspectives micro-state -------------------------------------------
 


### PR DESCRIPTION
Because of renaming or deleting, the previous layout may not exist.