### PR TITLE
scala: Automatically insert asterisk in multiline comments

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -11,6 +11,7 @@
    - [[Usage][Usage]]
  - [[Scalastyle][Scalastyle]]
  - [[Automatically show the type of the symbol under the cursor][Automatically show the type of the symbol under the cursor]]
+ - [[Automatically insert asterisk in multiline comments][Automatically insert asterisk in multiline comments]]
  - [[Key bindings][Key bindings]]
    - [[Ensime key bindings][Ensime key bindings]]
      - [[Search][Search]]
@@ -85,7 +86,6 @@ To use scalastyle,
    the jar.
 
 See the [[http://flycheck.readthedocs.org/en/latest/guide/languages.html#el.flycheck-checker.scala-scalastyle][flycheck documentation]] for up-to-date configuration instructions.
-
 * Automatically show the type of the symbol under the cursor
 
 To enable the feature =ensime-print-type-at-point= when cursor moves, set the variable =scala-enable-eldoc-mode= to =t=.
@@ -96,6 +96,15 @@ To enable the feature =ensime-print-type-at-point= when cursor moves, set the va
 #+END_SRC
 
 Enabling this option can cause slow editor performance.
+
+* Automatically insert asterisk in multiline comments
+
+To insert a leading asterisk in multiline comments automatically, set the variable =scala-auto-insert-asterisk-in-comments= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (scala :variables scala-auto-insert-asterisk-in-comments t)))
+#+END_SRC
 
 * Key bindings
 

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -12,3 +12,6 @@
 
 (defvar scala-enable-eldoc nil
   "If non nil then eldoc-mode is enabled in the scala layer.")
+
+(defvar scala-auto-insert-asterisk-in-comments nil
+  "If non-nil automatically insert leading asterisk in multi-line comments.")

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -197,6 +197,16 @@
       (add-to-list 'completion-ignored-extensions ext))
     :config
     (progn
+      ;; Automatically insert asterisk in a comment when enabled
+      (defun scala/newline-and-indent-with-asterisk ()
+        (interactive)
+        (newline-and-indent)
+        (when scala-auto-insert-asterisk-in-comment
+          (scala-indent:insert-asterisk-on-multiline-comment)))
+
+      (evil-define-key 'insert scala-mode-map
+        (kbd "RET") 'scala/newline-and-indent-with-asterisk)
+
       (evil-define-key 'normal scala-mode-map "J" 'spacemacs/scala-join-line)
 
       ;; Compatibility with `aggressive-indent'


### PR DESCRIPTION
Add a new option `scala-auto-insert-asterisk-in-comments` which when enabled makes Scala Mode automatically insert a leading asterisk when typing RET in a multiline comment.