### PR TITLE
evil-magit: Allow yanking with y

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -31,6 +31,7 @@
 (defun git/init-evil-magit ()
   (unless (eq dotspacemacs-editing-style 'emacs)
     (with-eval-after-load 'magit
+      (setq evil-magit-use-y-for-yank t)
       (require 'evil-magit)
       (evil-define-key 'motion magit-mode-map
         (kbd dotspacemacs-leader-key) spacemacs-default-map))))


### PR DESCRIPTION
Use the option evil-magit-use-y-for-yank. See the docstring for this
variable or the readme to learn more about the effects of this option.
I've been using it for a while without difficulty.

Note: If possible this should be merged before the next master release to avoid two changes in magit key bindings. 