### PR TITLE
Remove custom write-file function, use save-buffer

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -676,16 +676,6 @@ the right."
 
 ;; END align functions
 
-(defun spacemacs/write-file ()
-  "Write the file if visiting a file.
-   Otherwise ask for new filename."
-  (interactive)
-  (if (buffer-file-name)
-      (call-interactively 'evil-write)
-    (call-interactively 'write-file)))
-(with-eval-after-load 'evil
-  (evil-declare-not-repeat 'spacemacs/write-file))
-
 (defun spacemacs/dos2unix ()
   "Converts the current buffer to UNIX file format."
   (interactive)

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -124,7 +124,7 @@ Ensure that helm is required before calling FUNC."
   "fo" 'spacemacs/open-in-external-app
   "fR" 'spacemacs/rename-current-buffer-file
   "fS" 'evil-write-all
-  "fs" 'spacemacs/write-file
+  "fs" 'save-buffer
   "fvd" 'add-dir-local-variable
   "fvf" 'add-file-local-variable
   "fvp" 'add-file-local-variable-prop-line


### PR DESCRIPTION
Could not find a use case where the custom function performs differently
it is just missing functionality for indirect buffers.

Should fix https://github.com/syl20bnr/spacemacs/issues/4353