### PR TITLE
scala: Fix typo in variable name

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -202,7 +202,7 @@
       (defun scala/newline-and-indent-with-asterisk ()
         (interactive)
         (newline-and-indent)
-        (when scala-auto-insert-asterisk-in-comment
+        (when scala-auto-insert-asterisk-in-comments
           (scala-indent:insert-asterisk-on-multiline-comment)))
 
       (evil-define-key 'insert scala-mode-map


### PR DESCRIPTION
Sorry :(