### PR TITLE
Helm-mu integration.

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -19,7 +19,7 @@
     :commands (mu4e mu4e-compose-new)
     :init
     (progn
-      (spacemacs/set-leader-keys "a M m" 'mu4e)
+      (spacemacs/set-leader-keys "a m m" 'mu4e)
       (global-set-key (kbd "C-x m") 'mu4e-compose-new))
     :config
     (progn
@@ -44,8 +44,8 @@
 
 (defun mu4e/init-helm-mu ()
   (spacemacs/set-leader-keys
-    "a M s" 'helm-mu
-    "a M c" 'helm-mu-contacts))
+    "a m s" 'helm-mu
+    "a m c" 'helm-mu-contacts))
 
 
 (defun mu4e/post-init-helm ()

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -11,14 +11,15 @@
 ;;; License: GPLv3
 
 (setq mu4e-packages
-      '((mu4e :location built-in)))
+      '((mu4e :location built-in)
+        helm-mu))
 
 (defun mu4e/init-mu4e ()
   (use-package mu4e
     :commands (mu4e mu4e-compose-new)
     :init
     (progn
-      (spacemacs/set-leader-keys "a M" 'mu4e)
+      (spacemacs/set-leader-keys "a M m" 'mu4e)
       (global-set-key (kbd "C-x m") 'mu4e-compose-new))
     :config
     (progn
@@ -39,3 +40,16 @@
       (when mu4e-account-alist
         (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
         (add-hook 'message-sent-hook 'mu4e/mail-account-reset)))))
+
+
+(defun mu4e/init-helm-mu ()
+  (spacemacs/set-leader-keys
+    "a M s" 'helm-mu
+    "a M c" 'helm-mu-contacts))
+
+
+(defun mu4e/post-init-helm ()
+  (require 'helm-config)
+  (autoload 'helm-mu "helm-mu" "" t)
+  (autoload 'helm-mu-contacts "helm-mu" "" t))
+

--- a/layers/spotify/config.el
+++ b/layers/spotify/config.el
@@ -10,5 +10,5 @@
 ;;
 ;;; License: GPLv3
 
-(spacemacs/declare-prefix "am" "music")
-(spacemacs/declare-prefix "ams" "Spotify")
+(spacemacs/declare-prefix "aM" "music")
+(spacemacs/declare-prefix "aMs" "Spotify")

--- a/layers/spotify/packages.el
+++ b/layers/spotify/packages.el
@@ -15,12 +15,12 @@
 (defun spotify/init-spotify ()
   (use-package spotify
     :config (spacemacs/set-leader-keys
-              "amsp" 'spotify-playpause
-              "amsn" 'spotify-next
-              "amsN" 'spotify-previous
-              "amsQ" 'spotify-quit)))
+              "aMsp" 'spotify-playpause
+              "aMsn" 'spotify-next
+              "aMsN" 'spotify-previous
+              "aMsQ" 'spotify-quit)))
 
 (defun spotify/init-helm-spotify ()
   (use-package helm-spotify
     :config (spacemacs/set-leader-keys
-              "amsg" 'helm-spotify)))
+              "aMsg" 'helm-spotify)))


### PR DESCRIPTION
Also contains leader key changes for fitting with [helm-mu](https://github.com/emacs-helm/helm-mu) integration.

* `a M m` launches `mu4e`
* `a M c` launches `helm-mu-contacts` (searching for contacts to compose email to)
* `a M s` launches `helm-mu` (searching with helm)