### PR TITLE
delay sp-local-pair conditional initialization until after smartparens is loaded

### DIFF
--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -96,7 +96,7 @@
       (dolist (ext '(".cmo" ".cmx" ".cma" ".cmxa" ".cmi" ".cmxs" ".cmt" ".annot"))
         (add-to-list 'completion-ignored-extensions ext)))
     :config
-    (when (fboundp 'sp-local-pair)
+    (with-eval-after-load 'smartparens
       ;; don't auto-close apostrophes (type 'a = foo) and backticks (`Foo)
       (sp-local-pair 'tuareg-mode "'" nil :actions nil)
       (sp-local-pair 'tuareg-mode "`" nil :actions nil))))


### PR DESCRIPTION
Not sure if this is the best way to fix it, but I noticed that `sp-local-pair` changes didn't have an effect
unless I've run `SPC f e R`: on startup it always reverted back to auto-closing apostrophes and backticks.
