### PR TITLE
evil-jumper: Move bindings to global motion map

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -582,7 +582,17 @@
     :init
     (progn
       (setq evil-jumper-auto-save-interval 600)
-      (evil-jumper-mode t))))
+      ;; Move keybindings into global motion state map
+      (add-hook 'evil-jumper-mode-hook
+                (lambda ()
+                  (if evil-jumper-mode
+                      (progn
+                        (define-key evil-motion-state-map (kbd "TAB") 'evil-jumper/forward)
+                        (define-key evil-motion-state-map (kbd "C-o") 'evil-jumper/backward))
+                    (define-key evil-motion-state-map (kbd "TAB") 'evil-jump-forward)
+                    (define-key evil-motion-state-map (kbd "C-o") 'evil-jump-backward))))
+      (evil-jumper-mode t)
+      (setcdr evil-jumper-mode-map nil))))
 
 (defun spacemacs/init-evil-lisp-state ()
   (use-package evil-lisp-state


### PR DESCRIPTION
Having them in a minor mode map gives them precedence over other minor
modes. It's better to put the bindings in the same place as the original
evil jump commands which is the global motion map.

Will fix #4387