### PR TITLE
emacs-lisp: Fix mode hook

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -117,12 +117,9 @@
         ("q" macrostep-collapse-all :exit t)))))
 
 (defun emacs-lisp/post-init-evil ()
-  (spacemacs/add-to-hook 'emacs-lisp-mode
-                         '(lambda ()
-                            (spacemacs|define-text-object ";"
-                                                          "elisp-comment"
-                                                          ";; "
-                                                          ""))))
+  (add-hook 'emacs-lisp-mode-hook
+            (lambda ()
+              (spacemacs|define-text-object ";" "elisp-comment" ";; " ""))))
 
 (defun emacs-lisp/post-init-flycheck ()
   ;; Don't activate flycheck by default in elisp


### PR DESCRIPTION
Fix incorrect use of spacemacs/add-to-hook which used emacs-lisp-mode
for the hook variable. Since we are only adding a single function to the
hook, just use add-hook.