### PR TITLE
Clarify README regarding the installation of the os x layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,7 @@ the start of this file. That will populate your `~/.emacs.d` directory, which
 is what transforms a regular Emacs into Spacemacs.
 
 *After* you have completed the [install process below](#install), it is also
- recommended to add the [osx layer][] to your [dotfile][]:
-
-```elisp
-(setq-default dotspacemacs-configuration-layers '(osx))
-```
+ recommended to add the [osx layer][] to your [dotfile][]. Install instructions are available in the [osx layer][] documentation.
 
 Note that the `emacs-mac-port` server behaves differently than the regular Emacs
 server which in particular **DOES NOT** allow multi-tty if you start GUI i.e.

--- a/layers/osx/README.org
+++ b/layers/osx/README.org
@@ -32,11 +32,7 @@ and we encourage you to do so :)
 
 ** Layer
 
-To use this configuration layer, add it to your =~/.spacemacs=
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(osx))
-#+END_SRC
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to add `osx` to the existing list of `dotspacemacs-configuration-layers` in this file.
 
 *** Use with non-US keyboard layouts
 


### PR DESCRIPTION
This clarifies how to add the `osx` layer to the `.spacemacs` file. The existing instructions, despite my best efforts, didn't work, and this seemed confirmed by folks in the chat channel.