### PR TITLE
add mu4e-maildirs-extension to mu4e layer

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -5,6 +5,7 @@
  - [[Installation][Installation]]
  - [[Commands][Commands]]
  - [[Configuration][Configuration]]
+   - [[Maildirs extension][Maildirs extension]]
    - [[Multiple Accounts][Multiple Accounts]]
    - [[Example configuration][Example configuration]]
  - [[See also][See also]]
@@ -32,6 +33,20 @@ the layer variable =mu4e-installation-path=, for example:
 Configuration varies too much to give precise instructions.  What follows is one
 example configuration.  Refer to mu4e's manual for more detailed configuration
 instructions.
+
+** Maildirs extension
+The maildirs extension adds a list of all your maildirs to the main mu4e view
+that by default shows the unread and total mail counts for all your mail under
+your base mail directory.
+
+If you wish enable the maildirs extension you can set =mu4e-use-maildirs= to non
+nil value.
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((mu4e :variables
+                        mu4e-use-maildirs t)))
+#+end_src
 
 ** Multiple Accounts
 This layer includes support for multiple sending accounts.

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -16,5 +16,8 @@
 (defvar mu4e-account-alist nil
   "Account alist for custom multi-account compose.")
 
+(defvar mu4e-use-maildirs nil
+  "Set to non-nil to use the maildirs extension.")
+
 (when mu4e-installation-path
   (push mu4e-installation-path load-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -11,7 +11,8 @@
 ;;; License: GPLv3
 
 (setq mu4e-packages
-      '((mu4e :location built-in)))
+      '((mu4e :location built-in)
+        (mu4e-maildirs-extension)))
 
 (defun mu4e/init-mu4e ()
   (use-package mu4e
@@ -39,3 +40,8 @@
       (when mu4e-account-alist
         (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
         (add-hook 'message-sent-hook 'mu4e/mail-account-reset)))))
+
+(defun mu4e/init-mu4e-maildirs-extension ()
+  (use-package mu4e-maildirs-extension
+    :if mu4e-use-maildirs
+    :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension))))


### PR DESCRIPTION
Add optional mu4e-maildirs extension to mu4e layer.

This is a redo of https://github.com/syl20bnr/spacemacs/pull/4384, which I mistakenly created from my forked develop branch, and then messed up by doing a rebase..