### PR TITLE
flexible linum-format

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -226,7 +226,20 @@ nil."
   (add-hook 'prog-mode-hook 'linum-mode)
   (add-hook 'text-mode-hook 'linum-mode))
 ;; line number
-(setq linum-format "%4d")
+;; add a space before/after the line number
+;; and make number width more flexible to suit with the max lines
+(defun linum-format-func (line)
+  (concat
+    (propertize " " 'face 'linum)
+    (propertize (format linum-format-fmt line) 'face 'linum)
+    (propertize " " 'face 'linum)))
+(add-hook 'linum-before-numbering-hook
+  (lambda ()
+    (setq-local linum-format-fmt
+    (let ((w (length (number-to-string
+          (line-number-at-pos (point-max))))))
+      (concat "%" (number-to-string w) "d")))))
+(setq linum-format 'linum-format-func)
 ;; highlight current line
 (global-hl-line-mode t)
 ;; no blink


### PR DESCRIPTION
- add a space before/after the line number, because linum and emacs border or linum and content are so crowded.
- make number width more flexible to suit with the max lines

**Edit**: I'm not very familiar with lisp, so feel free to modify my commit. Thanks