### PR TITLE
Fix jumping to nil perspectives

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -46,9 +46,11 @@
         "Timer for layouts auto-save.")
 
       (defun spacemacs/jump-to-last-layout ()
-        "Open the previously selected layout."
+        "Open the previously selected layout, if it exists."
         (interactive)
-        (when (persp-get-by-name spacemacs--last-selected-layout)
+        (unless (eq 'non-existent
+                    (gethash spacemacs--last-selected-layout
+                             *persp-hash* 'non-existent))
           (persp-switch spacemacs--last-selected-layout)))
 
       ;; Perspectives micro-state -------------------------------------------


### PR DESCRIPTION
It turns out that `nil` is a valid value for a perspective, so we can't check if a perspective exists just by looking it up like this. We have to supply a different default for non-existent perspectives.

Fixes #4436.