### PR TITLE
Add <C-i> for jumping forward

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -588,8 +588,10 @@
                   (if evil-jumper-mode
                       (progn
                         (define-key evil-motion-state-map (kbd "TAB") 'evil-jumper/forward)
+                        (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jumper/forward)
                         (define-key evil-motion-state-map (kbd "C-o") 'evil-jumper/backward))
                     (define-key evil-motion-state-map (kbd "TAB") 'evil-jump-forward)
+                    (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jump-forward)
                     (define-key evil-motion-state-map (kbd "C-o") 'evil-jump-backward))))
       (evil-jumper-mode t)
       (setcdr evil-jumper-mode-map nil))))


### PR DESCRIPTION
I had to do this to get `C-i` to work as forward jump in org-mode. Right? @justbur @syl20bnr 

Replaces #3999.