### PR TITLE
osx: add osx-dictionary and make it default for OS X

### DIFF
--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -8,6 +8,7 @@
  - [[#install][Install]]
    - [[#layer][Layer]]
      - [[#use-with-non-us-keyboard-layouts][Use with non-US keyboard layouts]]
+     - [[#define-words-using-os-x-dictionary][Define words using OS X Dictionary]]
    - [[#coreutils][Coreutils]]
  - [[#key-bindings][Key Bindings]]
  - [[#future-work][Future Work]]
@@ -48,6 +49,16 @@ key.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default mac-right-option-modifier nil)
+#+END_SRC
+
+*** Define words using OS X Dictionary
+
+This layer by default enables defining words under point ~SPC x w d~ using OS X Dictionary.
+You can disable it by setting =osx-use-dictionary-app= variable to =nil=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+     (osx :variables osx-use-dictionary-app nil)))
 #+END_SRC
 
 ** Coreutils

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -2,6 +2,9 @@
   "If non nil the option key is mapped to meta. Set to `nil` if you need the
   option key to type common characters.")
 
+(defvar osx-use-dictionary-app t
+  "If non nil use osx dictionary app instead of wordnet")
+
 ;; Use the OS X Emoji font for Emoticons
 (when (fboundp 'set-fontset-font)
   (set-fontset-font "fontset-default"

--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -3,6 +3,7 @@
         exec-path-from-shell
         helm
         launchctl
+        (osx-dictionary :toggle osx-use-dictionary-app)
         osx-trash
         pbcopy
         reveal-in-osx-finder
@@ -67,6 +68,20 @@
         (kbd "=") 'launchctl-setenv
         (kbd "#") 'launchctl-unsetenv
         (kbd "h") 'launchctl-help))))
+
+(defun osx/init-osx-dictionary ()
+  (use-package osx-dictionary
+    :if osx-use-dictionary-app
+    :init (spacemacs/set-leader-keys "xwd" 'osx-dictionary-search-pointer)
+    :config
+    (progn
+      (evilified-state-evilify-map osx-dictionary-mode-map
+        :mode osx-dictionary-mode
+        :bindings
+        "q" 'osx-dictionary-quit
+        "r" 'osx-dictionary-read-word
+        "s" 'osx-dictionary-search-input
+        "o" 'osx-dictionary-open-dictionary.app))))
 
 (defun osx/init-osx-trash ()
   (use-package osx-trash

--- a/layers/+spacemacs/spacemacs-language/packages.el
+++ b/layers/+spacemacs/spacemacs-language/packages.el
@@ -10,7 +10,7 @@
 ;;; License: GPLv3
 
 (setq spacemacs-language-packages
-      '(define-word
+      '(define-word :toggle (not osx-use-dictionary-app)
         google-translate))
 
 (defun spacemacs-language/init-define-word ()


### PR DESCRIPTION
Why?
 - Offline hence fast
 - Definitions are better than default(wordnet?)
 - Pronunciation

How does it look?
<img width="638" alt="screen shot 2016-01-06 at 7 17 12 pm" src="https://cloud.githubusercontent.com/assets/542810/12144203/3120ff16-b4ac-11e5-9ae3-ee2377a3d38d.png">
