### PR TITLE
hybrid-mode: Simplify implementation

### DIFF
--- a/layers/+distribution/spacemacs-base/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distribution/spacemacs-base/local/hybrid-mode/hybrid-mode.el
@@ -42,6 +42,16 @@ to start in hybrid state (emacs bindings) by default."
 
 (defvar hybrid-mode-insert-cursor evil-hybrid-state-cursor)
 (defvar hybrid-mode-insert-cursor-backup evil-insert-state-cursor)
+(defvar hybrid-mode-insert-state-entry-hook)
+(defvar hybrid-mode-insert-state-exit-hook)
+
+(defun hybrid-mode-insert-state-entry-hook ()
+  "Run hooks in `hybrid-mode-insert-state-entry-hook'."
+  (run-hooks 'hybrid-mode-insert-state-entry-hook))
+
+(defun hybrid-mode-insert-state-exit-hook ()
+  "Run hooks in `hybrid-mode-insert-state-exit-hook'."
+  (run-hooks 'hybrid-mode-insert-state-exit-hook))
 
 ;;;###autoload
 (define-minor-mode hybrid-mode
@@ -57,10 +67,14 @@ to start in hybrid state (emacs bindings) by default."
         (put 'spacemacs-insert-face 'face-alias 'spacemacs-hybrid-face)
         ;; using this function to set the variable triggers the defcustom :set
         ;; property which actually does the work of removing the bindings.
-        (customize-set-variable 'evil-disable-insert-state-bindings t))
+        (customize-set-variable 'evil-disable-insert-state-bindings t)
+        (add-hook 'evil-insert-state-entry-hook 'hybrid-mode-insert-state-entry-hook)
+        (add-hook 'evil-insert-state-exit-hook 'hybrid-mode-insert-state-exit-hook))
     (setq evil-default-state hybrid-mode-default-state-backup
           evil-insert-state-cursor hybrid-mode-insert-cursor-backup)
     (put 'spacemacs-insert-face 'face-alias nil)
-    (customize-set-variable 'evil-disable-insert-state-bindings nil)))
+    (customize-set-variable 'evil-disable-insert-state-bindings nil)
+    (remove-hook 'evil-insert-state-entry-hook 'hybrid-mode-insert-state-entry-hook)
+    (remove-hook 'evil-insert-state-exit-hook 'hybrid-mode-insert-state-exit-hook)))
 
 (provide 'hybrid-mode)

--- a/layers/+distribution/spacemacs-base/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distribution/spacemacs-base/local/hybrid-mode/hybrid-mode.el
@@ -77,4 +77,28 @@ to start in hybrid state (emacs bindings) by default."
     (remove-hook 'evil-insert-state-entry-hook 'hybrid-mode-insert-state-entry-hook)
     (remove-hook 'evil-insert-state-exit-hook 'hybrid-mode-insert-state-exit-hook)))
 
+;;; Temporary to support old method of defining bindings. Should be removed
+;;; eventually.
+(when (fboundp 'advice-add)
+  (defun hybrid-mode-evil-define-key (old-func &rest args)
+    (if (equal (car args) ''hybrid)
+        (let ((map (nth 1 args))
+              (key (nth 2 args))
+              (def (nth 3 args))
+              (bindings (nthcdr 4 args)))
+          (message "warning: evil-define-key no longer supports \
+hybrid as a state please convert to (define-key map key def)")
+          (while key
+            (when (keymapp (symbol-value map))
+              (define-key (symbol-value map) key def)
+              (setq key (pop bindings)
+                    def (pop bindings)))))
+      (apply old-func args)))
+  (advice-add 'evil-define-key :around #'hybrid-mode-evil-define-key))
+
+(defvar evil-hybrid-state-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent evil-insert-state-map map)
+    map))
+
 (provide 'hybrid-mode)

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -521,19 +521,20 @@ Example: (evil-map visual \"<\" \"<gv\")"
       (spacemacs|diminish holy-mode " Ⓔe" " Ee"))))
 
 (defun spacemacs-base/init-hybrid-mode ()
-  (use-package hybrid-mode
-    :config
-    (progn
-      (when (eq 'hybrid dotspacemacs-editing-style) (hybrid-mode))
-      (spacemacs|add-toggle hybrid-mode
-        :status hybrid-mode
-        :on (progn (when (bound-and-true-p holy-mode)
-                     (holy-mode -1))
-                   (hybrid-mode))
-        :off (hybrid-mode -1)
-        :documentation "Globally toggle hybrid mode."
-        :evil-leader "tEh")
-      (spacemacs|diminish hybrid-mode " Ⓔh" " Eh"))))
+  (with-eval-after-load 'evil
+    (use-package hybrid-mode
+      :config
+      (progn
+        (when (eq 'hybrid dotspacemacs-editing-style) (hybrid-mode))
+        (spacemacs|add-toggle hybrid-mode
+          :status hybrid-mode
+          :on (progn (when (bound-and-true-p holy-mode)
+                       (holy-mode -1))
+                     (hybrid-mode))
+          :off (hybrid-mode -1)
+          :documentation "Globally toggle hybrid mode."
+          :evil-leader "tEh")
+        (spacemacs|diminish hybrid-mode " Ⓔh" " Eh")))))
 
 (defun spacemacs-base/init-ido ()
   (ido-mode t)

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -520,21 +520,21 @@ Example: (evil-map visual \"<\" \"<gv\")"
         :evil-leader "tEe")
       (spacemacs|diminish holy-mode " Ⓔe" " Ee"))))
 
-(defun spacemacs-base/init-hybrid-mode ()
-  (with-eval-after-load 'evil
-    (use-package hybrid-mode
-      :config
-      (progn
-        (when (eq 'hybrid dotspacemacs-editing-style) (hybrid-mode))
-        (spacemacs|add-toggle hybrid-mode
-          :status hybrid-mode
-          :on (progn (when (bound-and-true-p holy-mode)
-                       (holy-mode -1))
-                     (hybrid-mode))
-          :off (hybrid-mode -1)
-          :documentation "Globally toggle hybrid mode."
-          :evil-leader "tEh")
-        (spacemacs|diminish hybrid-mode " Ⓔh" " Eh")))))
+(defun spacemacs-base/init-hybrid-mode ())
+(defun spacemacs-base/post-init-evil ()
+  (use-package hybrid-mode
+    :config
+    (progn
+      (when (eq 'hybrid dotspacemacs-editing-style) (hybrid-mode))
+      (spacemacs|add-toggle hybrid-mode
+        :status hybrid-mode
+        :on (progn (when (bound-and-true-p holy-mode)
+                     (holy-mode -1))
+                   (hybrid-mode))
+        :off (hybrid-mode -1)
+        :documentation "Globally toggle hybrid mode."
+        :evil-leader "tEh")
+      (spacemacs|diminish hybrid-mode " Ⓔh" " Eh"))))
 
 (defun spacemacs-base/init-ido ()
   (ido-mode t)


### PR DESCRIPTION
Make use of new evil variable evil-disable-insert-state-bindings. This
is better because we are not copying evil code to get hybrid state to
work. We should not need to worry about tracking upstream evil changes
with this version of hybrid mode.

The only effect I can think of with this change is that there is no
longer a distinct hybrid-map, since there is no longer a distinct hybrid
state. This means that, for example, (evil-define-key 'hybrid ...)
will throw an error. You can either use (evil-define-key 'insert ...) or
the preferred (global-set-key ...). The latter is preferred because the
purpose of hybrid mode is to not interfere with Emacs bindings in insert
state.