### PR TITLE
Some yasnippet loading tweaks

### DIFF
--- a/layers/auto-completion/README.org
+++ b/layers/auto-completion/README.org
@@ -57,8 +57,9 @@ layer variables:
    as been entered quickly enough. If its value is =nil= then the feature is
    disabled.
 
-4. =auto-completion-private-snippets-directory= is a path to your private
-   snippets directory. If its value is =nil= then the spacemacs default is used.
+4. =auto-completion-private-snippets-directory= is a path or list of paths to
+   your private snippets directory. If its value is =nil= then the spacemacs
+   default (=~/.emacs.d/private/snippets=) is used.
 
 The default configuration of the layer is:
 

--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -226,7 +226,7 @@
       (defun spacemacs/load-yasnippet ()
         (unless yas-global-mode
           (progn
-            (yas-global-mode 1)
+            (require 'yasnippet)
             (let ((private-yas-dir (if auto-completion-private-snippets-directory
                                        auto-completion-private-snippets-directory
                                      (concat
@@ -236,12 +236,13 @@
                                            "snippets"
                                            spacemacs--auto-completion-dir)))
               (setq yas-snippet-dirs
-                    (append (list private-yas-dir)
+                    (append (if (listp private-yas-dir)
+                                private-yas-dir
+                              (list private-yas-dir))
                             (when (boundp 'yas-snippet-dirs)
-                              yas-snippet-dirs)
+                              (remove yas--default-user-snippets-dir yas-snippet-dirs))
                             (list spacemacs-snippets-dir)))
-              (yas-load-directory spacemacs-snippets-dir t)
-              (yas-load-directory private-yas-dir t)
+              (yas-global-mode 1)
               (setq yas-wrap-around-region t))))
         (yas-minor-mode 1))
 


### PR DESCRIPTION
- Don't enable yasnippet before setting folders (avoid explicitly loading them)
- Require yasnippet manually to get the `yas-snippet-dirs` value
- Don't include `yas--default-user-snippet-dir` (this is ~/.emacs.d/snippets)
- Allow `auto-completion-private-snippets-directory` to also be a list of directories

The third point might be a bit contentious? It avoids a warning at least, and we have another path for this purpose.

Fixes https://github.com/syl20bnr/spacemacs/issues/4457 and https://github.com/syl20bnr/spacemacs/issues/1830.