### PR TITLE
Fixes #1522 - Default to using helm for files and buffers.

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -162,8 +162,7 @@ start.")
   "Maximum number of rollback slots to keep in the cache.")
 
 (defvar dotspacemacs-use-ido nil
-  "If non nil then `ido' replaces `helm' for some commands. For now only
-`find-files' (SPC f f) is replaced.")
+  "If non nil then `ido' replaces `helm' for some commands.")
 
 (defvar dotspacemacs-helm-resize nil
   "If non nil, `helm' will try to minimize the space it uses.")

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -156,9 +156,7 @@ values."
    dotspacemacs-auto-save-file-location 'cache
    ;; Maximum number of rollback slots to keep in the cache. (default 5)
    dotspacemacs-max-rollback-slots 5
-   ;; If non nil then `ido' replaces `helm' for some commands. For now only
-   ;; `find-files' (SPC f f), `find-spacemacs-file' (SPC f e s), and
-   ;; `find-contrib-file' (SPC f e c) are replaced. (default nil)
+   ;; If non nil then `ido' replaces `helm' for some commands.
    dotspacemacs-use-ido nil
    ;; If non nil, `helm' will try to minimize the space it uses. (default nil)
    dotspacemacs-helm-resize nil

--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -174,9 +174,12 @@
           (helm :sources '(helm-available-repls)
                 :buffer "*helm repls*")))
 
-      ;; use helm by default for M-x
+      ;; use helm by default for M-x, C-x C-f, and C-x b
       (unless (configuration-layer/package-usedp 'smex)
         (global-set-key (kbd "M-x") 'helm-M-x))
+      (unless dotspacemacs-use-ido
+        (global-set-key (kbd "C-x C-f") 'spacemacs/helm-find-files)
+        (global-set-key (kbd "C-x b") 'helm-buffers-list))
 
       (spacemacs/set-leader-keys
         "<f1>" 'helm-apropos


### PR DESCRIPTION
This PR sets the following keybindings in `global-map`:

Key | Function
------------ | -------------
C-x C-f | spacemacs/helm-find-files
C-x b | helm-mini

as suggested in https://github.com/syl20bnr/spacemacs/issues/1522. I'm not sure I've put this in the right place, or even if binding these in `global-map` is the right thing, but if nothing else I hope this gets things moving on this issue, since I find it jarring that helm is used by `SPC b b` but ido is used by `C-x C-f`.