### PR TITLE
startup: Fix for #4057

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -85,10 +85,12 @@
   ;; spacemacs init
   (spacemacs-buffer/goto-buffer)
   ;; explicitly recreate the home buffer for the first GUI client
-  (spacemacs|do-after-display-system-init
-   (kill-buffer (get-buffer spacemacs-buffer-name))
-   (spacemacs-buffer/goto-buffer))
-  (setq initial-buffer-choice (lambda () (get-buffer spacemacs-buffer-name)))
+  ;; (spacemacs|do-after-display-system-init
+  ;;  (kill-buffer (get-buffer spacemacs-buffer-name))
+  ;;  (spacemacs-buffer/goto-buffer))
+  ;; (setq initial-buffer-choice (lambda () (get-buffer spacemacs-buffer-name)))
+  (setq initial-buffer-choice nil)
+  (setq inhibit-startup-screen t)
   ;; mandatory dependencies
   ;; dash is required to prevent a package.el bug with f on 24.3.1
   ;; (spacemacs/load-or-install-protected-package 'dash t)


### PR DESCRIPTION
Please check this, but this does the trick for me to fix #4057. The
reason I'm not sure about it is I don't know what the purpose of the
do-after-display-system-init code is. It doesn't seem necessary for me,
and I'm testing this on the GUI version.