### PR TITLE
Don't enter evil-insert-state for holy-mode after aya-expand

### DIFF
--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -269,7 +269,7 @@
         "Call `yas-expand' and switch to `insert state'"
         (interactive)
         (call-interactively 'aya-expand)
-        (evil-insert-state))
+        (unless holy-mode (evil-insert-state)))
       (spacemacs/declare-prefix "iS" "auto-yasnippet")
       (spacemacs/set-leader-keys
         "iSc" 'aya-create


### PR DESCRIPTION
I started using auto-yasnippet today and found that it's annoying to be put in the evil-insert-state every time after doing a aya-expand. The key binding "SPC i S e" should only put the user into evil-insert-state if he is not using the emacs editing style.