### PR TITLE
org: change keybindings for org-agenda-mode

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -269,17 +269,29 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~M-K~       | One year backward  |
 
 ** Org agenda
-The evilified org agenda supports, among others, the following bindings:
+The evilified org agenda supports, the following bindings:
 
-| Key Binding | Description   |
-|-------------+---------------|
-| ~M-j~       | next item     |
-| ~M-k~       | previous item |
-| ~M-h~       | earlier view  |
-| ~M-l~       | later view    |
-| ~gr~        | refresh       |
-| ~gd~        | toggle grid   |
-| ~C-v~       | change view   |
+| Key Binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC m a~   | org-agenda                    |
+| ~SPC m d~   | org-agenda-deadline           |
+| ~SPC m s~   | org-agenda-schedule           |
+| ~SPC m f~   | org-agenda-set-effort         |
+| ~SPC m P~   | org-agenda-set-property       |
+| ~SPC m :~   | org-agenda-set-tags           |
+| ~SPC m I~   | org-agenda-clock-in           |
+| ~SPC m O~   | org-agenda-clock-out          |
+| ~SPC m q~   | org-agenda-clock-cancel       |
+| ~SPC m q~   | org-agenda-refile             |
+| ~M-j~       | next item                     |
+| ~M-k~       | previous item                 |
+| ~M-h~       | earlier view                  |
+| ~M-l~       | later view                    |
+| ~gr~        | refresh                       |
+| ~gd~        | toggle grid                   |
+| ~C-v~       | change view                   |
+| ~RET~       | org-agenda-goto               |
+| ~M-RET~     | org-agenda-show-and-scroll-up |
 
 ** Pomodoro
 

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -21,6 +21,7 @@
      - [[Links][Links]]
      - [[Emphasis][Emphasis]]
      - [[Tagging][Tagging]]
+     - [[Navigating in calendar][Navigating in calendar]]
    - [[Org agenda][Org agenda]]
    - [[Pomodoro][Pomodoro]]
    - [[Presentation][Presentation]]
@@ -253,6 +254,19 @@ You can tweak the bullets displayed in the org buffer in the function
 | Key Binding | Description  |
 |-------------+--------------|
 | ~SPC m :~   | org-set-tags |
+
+*** Navigating in calendar
+
+| Key Binding | Description        |
+|-------------+--------------------|
+| ~L~         | One day forward    |
+| ~H~         | One day backward   |
+| ~J~         | One week forward   |
+| ~K~         | One week backward  |
+| ~M-L~       | One month forward  |
+| ~M-H~       | One month backward |
+| ~M-J~       | One year forward   |
+| ~M-K~       | One year backward  |
 
 ** Org agenda
 The evilified org agenda supports, among others, the following bindings:

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -224,15 +224,6 @@ Will work on both org-mode and any mode that accepts plain html."
         "xu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
         "xv" (spacemacs|org-emphasize spacemacs/org-verbose ?=))
 
-      (with-eval-after-load 'org-agenda
-        (define-key org-agenda-mode-map "j" 'org-agenda-next-line)
-        (define-key org-agenda-mode-map "k" 'org-agenda-previous-line)
-        ;; Since we override SPC, let's make RET do that functionality
-        (define-key org-agenda-mode-map
-          (kbd "RET") 'org-agenda-show-and-scroll-up)
-        (define-key org-agenda-mode-map
-          (kbd "SPC") spacemacs-default-map))
-
       ;; Add global evil-leader mappings. Used to access org-agenda
       ;; functionalities – and a few others commands – from any other mode.
       (spacemacs/declare-prefix "ao" "org")

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -270,13 +270,13 @@ Will work on both org-mode and any mode that accepts plain html."
 
       ;; Evilify the calendar tool on C-c .
       (unless (eq 'emacs dotspacemacs-editing-style)
-        (define-key org-read-date-minibuffer-local-map (kbd "M-h")
+        (define-key org-read-date-minibuffer-local-map (kbd "H")
           (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-day 1))))
-        (define-key org-read-date-minibuffer-local-map (kbd "M-l")
+        (define-key org-read-date-minibuffer-local-map (kbd "L")
           (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-day 1))))
-        (define-key org-read-date-minibuffer-local-map (kbd "M-k")
+        (define-key org-read-date-minibuffer-local-map (kbd "K")
           (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-week 1))))
-        (define-key org-read-date-minibuffer-local-map (kbd "M-j")
+        (define-key org-read-date-minibuffer-local-map (kbd "J")
           (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-week 1))))
         (define-key org-read-date-minibuffer-local-map (kbd "M-H")
           (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-month 1))))

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -291,7 +291,19 @@ Will work on both org-mode and any mode that accepts plain html."
   (use-package org-agenda
     :defer t
     :init
-    (setq org-agenda-restore-windows-after-quit t)
+    (progn
+      (setq org-agenda-restore-windows-after-quit t)
+      (spacemacs/set-leader-keys-for-major-mode 'org-agenda-mode
+	"d" 'org-agenda-deadline
+	"s" 'org-agenda-schedule
+	"f" 'org-agenda-set-effort
+	"P" 'org-agenda-set-property
+	":" 'org-agenda-set-tags
+	"a" 'org-agenda
+	"I" 'org-agenda-clock-in
+	"O" 'org-agenda-clock-out
+	"q" 'org-agenda-clock-cancel
+	"q" 'org-agenda-refile))
     :config
     (evilified-state-evilify-map org-agenda-mode-map
       :mode org-agenda-mode
@@ -303,7 +315,9 @@ Will work on both org-mode and any mode that accepts plain html."
       (kbd "M-h") 'org-agenda-earlier
       (kbd "M-l") 'org-agenda-later
       (kbd "gd") 'org-agenda-toggle-time-grid
-      (kbd "gr") 'org-agenda-redo)))
+      (kbd "gr") 'org-agenda-redo
+      (kbd "M-RET") 'org-agenda-show-and-scroll-up
+      (kbd "RET") 'org-agenda-goto)))
 
 (defun org/init-org-bullets ()
   (use-package org-bullets


### PR DESCRIPTION
I'm actively using org-agenda-mode and facing with some troubles with current evilification of org-agenda-mode. So I want to change some of keybindings and place new one.

Key bindings for calendar
----------------------------------
There are two particular reasons why I've changed this bindings:

1. Emacs in-calendar navigation bindings are "Shift + arrows". So Shift + hjkl is more similar to the old emacs bindings and so they may be less confusing. (IMHO)
2. Binding "M-h" doesn't work for some reason.

Major-mode bindings for agenda-mode
------------------------------------------------------
I confused that evilified agenda mode lacks support of major mode keybindings like "SPC m s" and in evilified agenda buffer you should use "C-c C-s" instead. For my opinion, as far as agenda and org mode is very similar modes, they should have similar keybindings too. So I've tried to add missed major-mode bindings to the agenda mode.