### PR TITLE
Add dotspacemacs-ex-substitute-global setting

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -140,6 +140,10 @@ with `:' and Emacs commands are executed with `<leader> :'.")
 (defvaralias 'dotspacemacs-remap-Y-to-y$ 'evil-want-Y-yank-to-eol
   "If non nil `Y' is remapped to `y$'.")
 
+(defvaralias 'dotspacemacs-ex-substitute-global 'evil-ex-substitute-global
+  "If non nil, `:substitute' changes all matches in a line by default.
+The `g' flag toggles one or all matches.")
+
 (defvar dotspacemacs-default-layout-name "Default"
   " Name of the default layout.")
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -135,6 +135,9 @@ values."
    dotspacemacs-command-key ":"
    ;; If non nil `Y' is remapped to `y$'. (default t)
    dotspacemacs-remap-Y-to-y$ t
+   ;; If non nil, `:substitute' changes all matches in a line by default.
+   ;; (default t)
+   dotspacemacs-ex-substitute-global t
    ;; Name of the default layout (default "Default")
    dotspacemacs-default-layout-name "Default"
    ;; If non nil the default layout name is displayed in the mode-line.


### PR DESCRIPTION
If non-nil, this setting inverts the behavior of the `g` flag in `:s/pattern/replacement/g`.

I believe it is a good default since it is more common that a user wants to replace all matches on a line rather than only the first.