### PR TITLE
load org mu4e functionality when org or mu4e loads

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -19,7 +19,9 @@
     :init
     (progn
       (spacemacs/set-leader-keys "a M" 'mu4e)
-      (global-set-key (kbd "C-x m") 'mu4e-compose-new))
+      (global-set-key (kbd "C-x m") 'mu4e-compose-new)
+      (with-eval-after-load 'org
+        (require 'org-mu4e)))
     :config
     (progn
       (evilified-state-evilify-map mu4e-main-mode-map
@@ -35,6 +37,9 @@
 
       (add-to-list 'mu4e-view-actions
                    '("View in browser" . mu4e-action-view-in-browser) t)
+
+      (when (configuration-layer/layer-usedp 'org)
+        (require 'org-mu4e))
 
       (when mu4e-account-alist
         (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)


### PR DESCRIPTION
Load org-mu4e.el (in mu4e package) if org layer is configured when mu4e is loaded. This adds ability to store links to email in mu4e in org files. Additionally load this library when org mode loads (with-eval-after-load) as it adds the "open link" functionality which is required to open said links to email. The org-mu4e library ```(requires``` both org and mu4e.