### PR TITLE
Fix bugs when version-control-diff-tool = diff-hl

### DIFF
--- a/layers/+source-control/version-control/funcs.el
+++ b/layers/+source-control/version-control/funcs.el
@@ -60,7 +60,7 @@
   (let ((current-prefix-arg t))
     (call-interactively
      (cl-case version-control-diff-tool
-       (diff-hl     'diff-hl-margin-minor-mode)
+       (diff-hl     'diff-hl-mode)
        (git-gutter  'git-gutter-mode)
        (git-gutter+ 'git-gutter+-mode)))))
 
@@ -69,7 +69,7 @@
   (let ((current-prefix-arg nil))
     (call-interactively
      (cl-case version-control-diff-tool
-       (diff-hl     'diff-hl-margin-minor-mode)
+       (diff-hl     'diff-hl-mode)
        (git-gutter  'git-gutter-mode)
        (git-gutter+ 'git-gutter+-mode)))))
 
@@ -78,7 +78,7 @@
   (let ((current-prefix-arg t))
     (call-interactively
      (cl-case version-control-diff-tool
-       (diff-hl     'diff-hl-margin-mode)
+       (diff-hl     'global-diff-hl-mode)
        (git-gutter  'global-git-gutter-mode)
        (git-gutter+ 'global-git-gutter+-mode)))))
 
@@ -87,7 +87,7 @@
   (let ((current-prefix-arg nil))
     (call-interactively
      (cl-case version-control-diff-tool
-       (diff-hl     'diff-hl-margin-mode)
+       (diff-hl     'global-diff-hl-mode)
        (git-gutter  'global-git-gutter-mode)
        (git-gutter+ 'global-git-gutter+-mode)))))
 
@@ -99,14 +99,14 @@
 (defun version-control/margin-p ()
   (interactive)
   (cl-case version-control-diff-tool
-    (diff-hl     diff-hl-margin-minor-mode)
+    (diff-hl     diff-hl-mode)
     (git-gutter  git-gutter-mode)
     (git-gutter+ git-gutter+-mode)))
 
 (defun version-control/margin-global-p ()
   (interactive)
   (cl-case version-control-diff-tool
-    (diff-hl     diff-hl-margin-mode)
+    (diff-hl     global-diff-hl-mode)
     (git-gutter  global-git-gutter-mode)
     (git-gutter+ global-git-gutter+-mode)))
 


### PR DESCRIPTION
I configured version-control-diff-tool to diff-hl today and found the behaviour was buggy. It turns out that the original code is confused by diff-hl-mode and diff-hl-margin-mode and used wrong variables/functions in several places.

This commit should fix the issue according to my testing, please help to review it. Thanks very much.