### PR TITLE
Use jump-forward `C-i` binding only in GUI mode

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -60,9 +60,13 @@
   ;; explicitly set the prefered coding systems to avoid annoying prompt
   ;; from emacs (especially on Microsoft Windows)
   (prefer-coding-system 'utf-8)
-  ;; TODO move evil-want-C-u-scroll when evil is removed from the bootstrapped
+  ;; TODO move these variables when evil is removed from the bootstrapped
   ;; packages.
-  (setq-default evil-want-C-u-scroll t)
+  (setq-default evil-want-C-u-scroll t
+                ;; `evil-want-C-i-jump' is set to nil to avoid `TAB' being
+                ;; overlapped in terminal mode. The GUI specific `<C-i>' is used
+                ;; instead (defined in the init of `evil-jumper' package).
+                evil-want-C-i-jump nil)
   (dotspacemacs/load-file)
   (require 'core-configuration-layer)
   (dotspacemacs|call-func dotspacemacs/init "Calling dotfile init...")

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -587,10 +587,8 @@
                 (lambda ()
                   (if evil-jumper-mode
                       (progn
-                        (define-key evil-motion-state-map (kbd "TAB") 'evil-jumper/forward)
                         (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jumper/forward)
                         (define-key evil-motion-state-map (kbd "C-o") 'evil-jumper/backward))
-                    (define-key evil-motion-state-map (kbd "TAB") 'evil-jump-forward)
                     (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jump-forward)
                     (define-key evil-motion-state-map (kbd "C-o") 'evil-jump-backward))))
       (evil-jumper-mode t)


### PR DESCRIPTION
Background: `C-i` and `TAB` are the same keycode for historic reasons.

With the current settings, evil [1] and evil-jumper [2] associate
`jump-forward` to `C-i` (==`TAB`), what overrides bindings set to
`TAB` (==`C-i`) in terminal mode, like `orc-cycle`. To fix this,
this commit:

- Set `evil-want-C-i-jump` to `nil`, to prevent `evil` and `evil-jumper`
  to use the `C-i` (==`TAB`) keycode.

- Remove the spacemacs' code that bind `jump-forward` to `TAB`(==`C-i`)

The current spacemacs code already rebind `jump-forward` to the GUI-only
`<C-i>` keycode.

[1] https://bitbucket.org/lyro/evil/src/082bd65cccee9f5aa4d342c3b2921865175914af/evil-maps.el?fileviewer=file-view-default#evil-maps.el-323
[2] https://github.com/bling/evil-jumper/blob/efaa841ca4489aa7fd8edaa50d8a63b059530366/evil-jumper.el#L241

Fix #4505
Fix #4487