### PR TITLE
Remove reference to undefined function haskell-cabal-hook

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -108,7 +108,6 @@
 
       ;; hooks
       (add-hook 'haskell-mode-hook 'spacemacs/init-haskell-mode)
-      (add-hook 'haskell-cabal-mode-hook 'haskell-cabal-hook)
       (unless haskell-enable-ghc-mod-support
         (add-hook 'haskell-mode-hook 'interactive-haskell-mode))
 


### PR DESCRIPTION
Resolves #4512