### PR TITLE
Add the buffers to the persp

### DIFF
--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -182,7 +182,10 @@
   (spacemacs|define-custom-layout "@ERC"
     :binding "E"
     :body
-    (call-interactively 'erc))
+    (progn
+      (add-hook 'erc-mode #'(lambda ()
+                              (persp-add-buffer (current-buffer))))
+      (call-interactively 'erc)))
   ;; do not save erc buffers
   (spacemacs|use-package-add-hook persp-mode
     :post-config

--- a/layers/+irc/rcirc/packages.el
+++ b/layers/+irc/rcirc/packages.el
@@ -28,7 +28,10 @@
   (spacemacs|define-custom-layout "@RCIRC"
     :binding "i"
     :body
-    (call-interactively 'spacemacs/rcirc))
+    (progn
+      (add-hook 'rcirc-mode-hook #'(lambda ()
+                                     (persp-add-buffer (current-buffer))))
+      (call-interactively 'spacemacs/rcirc)))
   ;; do not save rcirc buffers
   (spacemacs|use-package-add-hook persp-mode
     :post-config


### PR DESCRIPTION
When initializing the IRC-related layout (ERC or RCIRC), add the buffers to the persp.

I added it to both layers, RCIRC and ERC. Mainly tested on RCIRC. 

Fix #4347