### PR TITLE
Properly read version in .python-version

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -53,7 +53,8 @@
       (let* ((file-path (expand-file-name ".python-version" root-path))
              (version (with-temp-buffer
                         (insert-file-contents-literally file-path)
-                        (current-word))))
+                        (buffer-substring-no-properties (line-beginning-position)
+                                                        (line-end-position)))))
         (if (member version (pyenv-mode-versions))
             (pyenv-mode-set version)
           (message "pyenv: version `%s' is not installed (set by %s)"


### PR DESCRIPTION
Fixes #4514 

Update: apparently there can be multiple versions specified in `.python-version`, so just select the first line.