### PR TITLE
spacemacs-buffer: Add back q binding

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -37,6 +37,7 @@ version the release note it displayed")
     (define-key map [backtab] 'widget-backward)
     (define-key map (kbd "RET") 'widget-button-press)
     (define-key map [down-mouse-1] 'widget-button-click)
+    (define-key map "q" 'quit-window)
     map)
   "Keymap for spacemacs buffer mode.")
 


### PR DESCRIPTION
It seems to have been lost with the switch to fundamental-mode