### PR TITLE
Avoid clobbering Go variables

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -11,9 +11,9 @@
   (spacemacs/add-flycheck-hook 'go-mode-hook))
 
 (defun go/init-go-mode()
-  (when (memq window-system '(mac ns x))
-    (exec-path-from-shell-copy-env "GOPATH")
-    (exec-path-from-shell-copy-env "GO15VENDOREXPERIMENT"))
+  (dolist (var '("GOPATH" "GO15VENDOREXPERIMENT"))
+    (unless (getenv var)
+      (exec-path-from-shell-copy-env var)))
 
   (use-package go-mode
     :defer t


### PR DESCRIPTION
Check if the variables have been set, regardless of platform. This avoids clobbering values that may be set elsewhere via elisp.