### PR TITLE
ivy: Correct sp and sP bindings

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -201,8 +201,8 @@ Helm hack."
         "*"   'spacemacs/search-project-auto-region-or-symbol
         "sf"  'spacemacs/search-auto
         "sF"  'spacemacs/search-auto-region-or-symbol
-        "sp"  'spacemacs/search-project
-        "sP"  'spacemacs/search-project-region-or-symbol
+        "sp"  'spacemacs/search-project-auto
+        "sP"  'spacemacs/search-project-auto-region-or-symbol
         "saf" 'spacemacs/search-ag
         "saF" 'spacemacs/search-ag-region-or-symbol
         "sap" 'spacemacs/search-project-ag


### PR DESCRIPTION
They were bound to a nonexistent function. Fixes one of the issues in #4528 