### PR TITLE
mu4e: Make use of maildirs extension configurable.

### DIFF
--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -16,5 +16,8 @@
 (defvar mu4e-account-alist nil
   "Account alist for custom multi-account compose.")
 
+(defvar mu4e-enable-maildirs-extension nil
+  "Enable the maildirs extension.")
+
 (when mu4e-installation-path
   (push mu4e-installation-path load-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -41,7 +41,8 @@
         (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
         (add-hook 'message-sent-hook 'mu4e/mail-account-reset)))))
 
-(defun mu4e/init-mu4e-maildirs-extension ()
-  (use-package mu4e-maildirs-extension
-    :defer t
-    :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load))))
+(when mu4e-enable-maildirs-extension
+  (defun mu4e/init-mu4e-maildirs-extension ()
+    (use-package mu4e-maildirs-extension
+      :defer t
+      :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load)))))


### PR DESCRIPTION
The maildirs extension doesn't seem to offer any easy way of turning it off, and having it for dirs with *many* folders is rather painful.  This adds a variable, `mu4e-enable-maildirs-extension` (off by default) to control it.