### PR TITLE
org: Set org-imenu-depth to 8

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -99,7 +99,10 @@
             (concat spacemacs-cache-directory ".org-id-locations")
             org-log-done t
             org-startup-with-inline-images t
-            org-src-fontify-natively t)
+            org-src-fontify-natively t
+            ;; this is consistent with the value of
+            ;; `helm-org-headings-max-depth'.
+            org-imenu-depth 8)
 
       (with-eval-after-load 'org-indent
         (spacemacs|hide-lighter org-indent-mode))


### PR DESCRIPTION
This makes the depth of imenu consistent with
helm-org-headings-max-depth when ivy is used instead of helm.