### PR TITLE
Improve Spacemacs describe functions

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -226,4 +226,21 @@
                      "You can paste it in the gitter chat.\n"
                      "Check the *Messages* buffer if you need to review it"))))
 
+(defun spacemacs/describe-last-keys ()
+  "Gathers info about your Emacs last keys and copies to clipboard."
+  (interactive)
+  (view-lossage)
+  (let* ((lossage-buffer "*Help*")
+         (lossage (format "#### Emacs last keys\n```text\n%s```\n"
+                          (with-current-buffer lossage-buffer
+                            (buffer-string)))))
+    (kill-buffer lossage-buffer)
+    (kill-new lossage)
+    (message lossage)
+    (message (concat "Information has been copied to clipboard.\n"
+                     (propertize
+                      "PLEASE REVIEW THE DATA BEFORE GOING FURTHER AS IT CAN CONTAIN SENSITIVE DATA (PASSWORD, ...)\n"
+                      'face 'font-lock-warning-face)
+                     "You can paste it in the gitter chat.\n"
+                     "Check the *Messages* buffer if you need to review it"))))
 (provide 'core-spacemacs)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -204,6 +204,8 @@
                           "- Spacemacs: %s\n"
                           "- Spacemacs branch: %s (rev. %s)\n"
                           "- Distribution: %s\n"
+                          "- Editing style: %s\n"
+                          "- Completion: %s\n"
                           "- Layers:\n```elisp\n%s```\n")
                   system-type
                   emacs-version
@@ -211,6 +213,12 @@
                   (spacemacs/git-get-current-branch)
                   (spacemacs/git-get-current-branch-rev)
                   dotspacemacs-distribution
+                  dotspacemacs-editing-style
+                  (cond ((configuration-layer/layer-usedp 'spacemacs-helm)
+                         'helm)
+                        ((configuration-layer/layer-usedp 'spacemacs-ivy)
+                         'ivy)
+                        (t 'helm))
                   (pp dotspacemacs-configuration-layers))))
     (kill-new sysinfo)
     (message sysinfo)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1274,6 +1274,7 @@ thusly:
 | ~SPC h d F~ | describe a face                                           |
 | ~SPC h d k~ | describe a key                                            |
 | ~SPC h d K~ | describe a keymap                                         |
+| ~SPC h d l~ | copy last pressed keys that you can paste in gitter chat  |
 | ~SPC h d m~ | describe current modes                                    |
 | ~SPC h d p~ | describe a package                                        |
 | ~SPC h d s~ | copy system information that you can paste in gitter chat |

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -75,8 +75,6 @@
   "bw"  'read-only-mode)
 ;; Cycling settings -----------------------------------------------------------
 (spacemacs/set-leader-keys "Tn" 'spacemacs/cycle-spacemacs-theme)
-;; describe functions ---------------------------------------------------------
-(spacemacs/set-leader-keys "hds" 'spacemacs/describe-system-info)
 ;; errors ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "en" 'spacemacs/next-error

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -109,6 +109,7 @@
   "hdc" 'describe-char
   "hdf" 'describe-function
   "hdk" 'describe-key
+  "hdl" 'spacemacs/describe-last-keys
   "hdp" 'describe-package
   "hds" 'spacemacs/describe-system-info
   "hdt" 'describe-theme


### PR DESCRIPTION
This PR:

- Improve the output of `SPC h d s` to include the editing style and completion tool used.
- Add `spacemacs/describe-last-keys` to get an easy way to get last pressed keys (will be pointed when user find a weird behaviour without knowing what they did)
- Bugfix a duplicate key definition