### PR TITLE
Correct ignore pattern for private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ python-*-docs-html
 /.cask/
 
 # Private directory
-private/*
+private/
 !private/README.md
 !private/snippets/README.md
 !private/local/README.md


### PR DESCRIPTION
The pattern `private/*` only ignores items one level deep in the private directory. More deeply nested files (e.g. `private/snippets/mysnip`) will *not* be ignored. Changing this to just `private/` ignores the entire directory structure (minus the files explicitly included).