### PR TITLE
Add request/curl-cookie-jar to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ server/
 *.db
 python-*-docs-html
 /.cask/
+/request/curl-cookie-jar
 
 # Private directory
 private/*


### PR DESCRIPTION
This file gets generated when using the `request` library (ex. `helm-gitignore`) and prevents the "Update Spacemacs" feature working properly.