### PR TITLE
Add javascript support on markdown

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -183,6 +183,11 @@ Will work on both org-mode and any mode that accepts plain html."
                           :face mmm-declaration-submode-face
                           :front "^```elisp[\n\r]+"
                           :back "^```$")))
+      (mmm-add-classes '((markdown-javascript
+                          :submode javascript-mode
+                          :face mmm-declaration-submode-face
+                          :front "^```javascript[\n\r]+"
+                          :back "^```$")))
       (setq mmm-global-mode t)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-python)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-java)
@@ -190,7 +195,8 @@ Will work on both org-mode and any mode that accepts plain html."
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-c)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-c++)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-elisp)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-html))))
+      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-html)
+      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-javascript))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun markdown/post-init-company ()


### PR DESCRIPTION
Enable syntax highlighting.

Fix #4527