### PR TITLE
Add a check for spacemacs-{helm,ivy} exclusivity

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -595,6 +595,19 @@ path."
   (when (eq 'all dotspacemacs-configuration-layers)
     (setq dotspacemacs-configuration-layers
           (ht-keys configuration-layer-paths)))
+  ;; If both `spacemacs-helm' and `spacemacs-ivy' are used, keep only
+  ;; `spacemacs-helm'.
+  ;; TODO: Remove this when they are no longer exclusive, or move this check in
+  ;; the new system to verify `dotspacemacs'-variable values when this will be
+  ;; in place.
+  (when (and (member 'spacemacs-helm dotspacemacs-configuration-layers)
+             (member 'spacemacs-ivy dotspacemacs-configuration-layers))
+    (setq dotspacemacs-configuration-layers
+          (remove 'spacemacs-ivy dotspacemacs-configuration-layers))
+    (warn (concat "You have defined both `spacemacs-helm' and `spacemacs-ivy' "
+                  "in your `dotspacemacs-configuration-layers'. They are "
+                  "mutually exclusive, please select only one. In the meantime "
+                  "`spacemacs-ivy' has been disabled.")))
   (dolist (layer dotspacemacs-configuration-layers)
     (let ((layer-name (if (listp layer) (car layer) layer)))
       (if (ht-contains? configuration-layer-paths layer-name)


### PR DESCRIPTION
Without this check, it's possible to activate both layer at the same
time, what could be a source of problems. This check ensure only one is
loaded. It should be removed when they will no longer be exclusive, or
when a better system to check `dotspacemacs`-variables values will be in
place.