### PR TITLE
Add `helm-apropos` on `SPC h d d`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1271,6 +1271,7 @@ thusly:
 |-------------+-----------------------------------------------------------|
 | ~SPC h d b~ | describe bindings in a =helm= buffer                      |
 | ~SPC h d c~ | describe current character under point                    |
+| ~SPC h d d~ | describe current expression under point                   |
 | ~SPC h d f~ | describe a function                                       |
 | ~SPC h d F~ | describe a face                                           |
 | ~SPC h d k~ | describe a key                                            |

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -106,6 +106,7 @@
 (spacemacs/set-leader-keys
   "hdb" 'describe-bindings
   "hdc" 'describe-char
+  "hdd" 'helm-apropos
   "hdf" 'describe-function
   "hdk" 'describe-key
   "hdl" 'spacemacs/describe-last-keys


### PR DESCRIPTION
Bind it to `SPC h d d` as it's a way to describe a lot of elements:
- commands
- functions
- classes
- generic functions
- variables
- faces
- helm-attributes

Is also bound on `SPC F1` and will also stay there.