### PR TITLE
Add default keybinding for org-capture

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -272,6 +272,7 @@ Will work on both org-mode and any mode that accepts plain html."
       (require 'org-indent)
       (define-key global-map "\C-cl" 'org-store-link)
       (define-key global-map "\C-ca" 'org-agenda)
+      (define-key global-map "\C-cc" 'org-capture)
 
       ;; Open links and files with RET in normal state
       (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)


### PR DESCRIPTION
It adds the default keybinding for the `org-capture` function, as stated
in its documentation it should be `C-c c`.

Fix #4467 