### PR TITLE
Remove spacemacs/init-dired+ function

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -463,10 +463,6 @@
     (spacemacs/set-leader-keys
       "xwd" 'define-word-at-point)))
 
-(defun spacemacs/init-dired+ ()
-  (use-package dired+
-    :defer t))
-
 (defun spacemacs/init-doc-view ()
   (use-package doc-view
     :defer t


### PR DESCRIPTION
The package dired+ is initialized but it's not in the spacemacs-packages
list, so it is not finally loaded.

Fix #4141 