### PR TITLE
Don't call exec-path-from-shell function on Windows

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -11,9 +11,10 @@
   (spacemacs/add-flycheck-hook 'go-mode-hook))
 
 (defun go/init-go-mode()
-  (dolist (var '("GOPATH" "GO15VENDOREXPERIMENT"))
-    (unless (getenv var)
-      (exec-path-from-shell-copy-env var)))
+  (when (memq window-system '(mac ns x))
+    (dolist (var '("GOPATH" "GO15VENDOREXPERIMENT"))
+      (unless (getenv var)
+        (exec-path-from-shell-copy-env var))))
 
   (use-package go-mode
     :defer t


### PR DESCRIPTION
This is related to #4584.