### PR TITLE
Add prev/next file navigation to unimpaired layer

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -102,6 +102,7 @@
   ;; bootstrap packages
   (spacemacs/load-or-install-protected-package 'dash t)
   (spacemacs/load-or-install-protected-package 's t)
+  (spacemacs/load-or-install-protected-package 'f t)
   (setq evil-want-Y-yank-to-eol dotspacemacs-remap-Y-to-y$
         evil-ex-substitute-global dotspacemacs-ex-substitute-global)
   (spacemacs/load-or-install-protected-package 'evil t)

--- a/layers/+vim/unimpaired/README.org
+++ b/layers/+vim/unimpaired/README.org
@@ -13,22 +13,24 @@ previous, and ~]~ as next.
 
 * Key bindings
 
-| KeyBindings | Description                 |
-|-------------+-----------------------------|
-| ~[b~        | Go to previous buffer       |
-| ~]b~        | Go to next buffer           |
-| ~[l~        | Go to the previous error    |
-| ~]l~        | Go to the next error        |
-| ~[h~        | Go to the previous vcs hunk |
-| ~]h~        | Go to the next vcs hunk     |
-| ~[t~        | Go to the previous frame    |
-| ~]t~        | Go to the next frame        |
-| ~[w~        | Go to the previous window   |
-| ~]w~        | Go to the next window       |
-| ~[e~        | Move line up                |
-| ~]e~        | Move line down              |
-| ~[SPACE~    | Insert space above          |
-| ~]SPACE~    | Insert space below          |
-| ~[p~        | Paste above current line    |
-| ~]p~        | Paste below current line    |
-| ~gp~        | Select pasted text          |
+| KeyBindings | Description                      |
+|-------------+----------------------------------|
+| ~[b~        | Go to previous buffer            |
+| ~]b~        | Go to next buffer                |
+| ~[f~        | Go to previous file in directory |
+| ~]f~        | Go to next file in directory     |
+| ~[l~        | Go to the previous error         |
+| ~]l~        | Go to the next error             |
+| ~[h~        | Go to the previous vcs hunk      |
+| ~]h~        | Go to the next vcs hunk          |
+| ~[t~        | Go to the previous frame         |
+| ~]t~        | Go to the next frame             |
+| ~[w~        | Go to the previous window        |
+| ~]w~        | Go to the next window            |
+| ~[e~        | Move line up                     |
+| ~]e~        | Move line down                   |
+| ~[SPACE~    | Insert space above               |
+| ~]SPACE~    | Insert space below               |
+| ~[p~        | Paste above current line         |
+| ~]p~        | Paste below current line         |
+| ~gp~        | Select pasted text               |

--- a/layers/+vim/unimpaired/funcs.el
+++ b/layers/+vim/unimpaired/funcs.el
@@ -1,5 +1,26 @@
 ;; funcs.el file for unimpaired contribution layer
 
+(defun unimpaired//find-relative-filename (offset)
+  (when buffer-file-name
+    (let* ((directory (f-dirname buffer-file-name))
+           (files (f--files directory (not (s-matches? "^\\.?#" it))))
+           (index (+ (-elem-index buffer-file-name files) offset))
+           (file (and (>= index 0) (nth index files))))
+      (when file
+        (f-expand file directory)))))
+
+(defun unimpaired/previous-file ()
+  (interactive)
+  (-if-let (filename (unimpaired//find-relative-filename -1))
+      (find-file filename)
+    (user-error "No previous file")))
+
+(defun unimpaired/next-file ()
+  (interactive)
+  (-if-let (filename (unimpaired//find-relative-filename 1))
+      (find-file filename)
+    (user-error "No next file")))
+
 (defun unimpaired/paste-above ()
   (interactive)
   (evil-insert-newline-above)

--- a/layers/+vim/unimpaired/keybindings.el
+++ b/layers/+vim/unimpaired/keybindings.el
@@ -15,6 +15,9 @@
 (define-key evil-normal-state-map (kbd "[ b") 'spacemacs/previous-useful-buffer)
 (define-key evil-normal-state-map (kbd "] b") 'spacemacs/next-useful-buffer)
 
+(define-key evil-normal-state-map (kbd "[ f") 'unimpaired/previous-file)
+(define-key evil-normal-state-map (kbd "] f") 'unimpaired/next-file)
+
 (define-key evil-normal-state-map (kbd "] l") 'spacemacs/next-error)
 (define-key evil-normal-state-map (kbd "[ l") 'spacemacs/previous-error)
 
@@ -33,4 +36,3 @@
 ;; paste above or below with newline
 (define-key evil-normal-state-map (kbd "[ p") 'unimpaired/paste-above)
 (define-key evil-normal-state-map (kbd "] p") 'unimpaired/paste-below)
-


### PR DESCRIPTION
Useful for stepping through a bunch of a files in a directory. Files are sorted lexicographically, so order may not be the same as in dired.

Note that this adds `f.el` as a protected package. I think it's a reasonable addition since it pairs nicely with `dash.el` and `s.el`, and will probably end up being installed by another package either way.