### PR TITLE
Add global access to all available REPLs

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -11,6 +11,8 @@
 
 (defvar configuration-layer--protected-packages)
 (defvar dotspacemacs-filepath)
+(defvar spacemacs-repl-list '()
+  "List of all registered REPLs.")
 
 (defun spacemacs/load-or-install-protected-package (pkg &optional log file-to-load)
   "Load PKG package, and protect it against being deleted as an orphan.
@@ -261,6 +263,17 @@ result, incrementing passed-tests and total-tests."
 Emacs versions."
   (interactive)
   (byte-recompile-directory package-user-dir nil t))
+
+(defun spacemacs/register-repl (major-mode repl-func &optional tag)
+  "Register REPL-FUNC to the global list of REPLs SPACEMACS-REPL-LIST.
+Major-mode will be loaded before running the REPL,  in case it is
+not already loaded. If TAG is non-nil, it will be used as the string
+to show in the helm buffer."
+  (setq spacemacs-repl-list (cons (cons (or tag
+                                            (symbol-name major-mode))
+                                        (cons major-mode repl-func))
+                                  spacemacs-repl-list))
+  spacemacs-repl-list)
 
 (provide 'core-funcs)
 

--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -161,12 +161,32 @@
                           (format "%s" (or default "default")))
                 :buffer "*helm faces*")))
 
+      (defun helm-available-repls ()
+        "Show all the repls available."
+        (interactive)
+        (let ((helm-available-repls
+               `((name . "HELM available REPLs")
+                 (candidates . ,(mapcar #'car spacemacs-repl-list))
+                 (action . (lambda (candidate)
+                             (let* ((repl (cdr (assoc candidate spacemacs-repl-list)))
+                                    (mode (car repl))
+                                    (f    (cdr repl)))
+                               (if (featurep mode)
+                                   (funcall f)
+                                 (let ((old-mode major-mode))
+                                   (funcall mode)
+                                   (funcall old-mode)
+                                   (funcall f)))))))))
+          (helm :sources '(helm-available-repls)
+                :buffer "*helm repls*")))
+
       ;; use helm by default for M-x
       (unless (configuration-layer/package-usedp 'smex)
         (global-set-key (kbd "M-x") 'helm-M-x))
 
       (spacemacs/set-leader-keys
         "<f1>" 'helm-apropos
+        "aR"   'helm-available-repls
         "bb"   'helm-mini
         "Cl"   'helm-colors
         "ff"   'spacemacs/helm-find-files


### PR DESCRIPTION
Enable a global binding to access a list of available REPLs to run everywhere. If the requested REPL depends on a major-mode that hasn't been loaded, it will be loaded along its dependencies. The global binding is under `SPC a R`.

To make this work, a new `spacemacs/register-repl` function is included. This function adds a major-mode and its repl function to a global variable.

Further work, such as add every layer REPL to this list is due to be completed after this PR is eviewed, to avoid silly work.

Address #3395