### PR TITLE
evil-jumper: Remove hack for evil-jumper bindings

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -573,17 +573,7 @@
     :init
     (progn
       (setq evil-jumper-auto-save-interval 600)
-      ;; Move keybindings into global motion state map
-      (add-hook 'evil-jumper-mode-hook
-                (lambda ()
-                  (if evil-jumper-mode
-                      (progn
-                        (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jumper/forward)
-                        (define-key evil-motion-state-map (kbd "C-o") 'evil-jumper/backward))
-                    (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jump-forward)
-                    (define-key evil-motion-state-map (kbd "C-o") 'evil-jump-backward))))
-      (evil-jumper-mode t)
-      (setcdr evil-jumper-mode-map nil))))
+      (evil-jumper-mode t))))
 
 (defun spacemacs/init-evil-lisp-state ()
   (use-package evil-lisp-state


### PR DESCRIPTION
A recent change in evil-jumper makes this unnecessary. The keys are now
bound as remaps, which means they have the same priority as the location
of the evil-jump-forward and evil-jump-backward commands. This is
exactly what this hack was trying to accomplish, so it's no longer
necessary.

See https://github.com/bling/evil-jumper/pull/24