### PR TITLE
Fix helm-source-header not updating

### DIFF
--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -303,6 +303,13 @@
       (defvar helm-source-header-default-height
         (face-attribute 'helm-source-header :height) )
 
+      (defadvice spacemacs/post-theme-init (after spacemacs/helm-header-line-adv activate)
+        "Update defaults for `helm' header line whenever a new theme is loaded"
+        (setq helm-source-header-default-foreground (face-attribute 'helm-source-header :foreground)
+              helm-source-header-default-background (face-attribute 'helm-source-header :background)
+              helm-source-header-default-box (face-attribute 'helm-source-header :box)
+              helm-source-header-default-height (face-attribute 'helm-source-header :height)))
+
       (defun helm-toggle-header-line ()
         "Hide the `helm' header is there is only one source."
         (when dotspacemacs-helm-no-header
@@ -317,8 +324,8 @@
             (set-face-attribute
              'helm-source-header
              nil
-             :foreground (face-attribute 'helm-selection :background)
-             :background (face-attribute 'helm-selection :background)
+             :foreground (face-attribute 'default :background)
+             :background (face-attribute 'default :background)
              :box nil
              :height 0.1))))
       (add-hook 'helm-before-initialize-hook 'helm-toggle-header-line)


### PR DESCRIPTION
See issue #4605. When dotspacemacs-helm-header is changed from the
default nil, then the helm-source-header theming does not updated when
a new theme is loaded.

This was due to the helm-source-header-default-xxx variables being set
only once and not updated when a new theme is loaded. The fix adds an
advice to spacemacs/post-theme-init to update these variables.

This allows for all other code including theming to take place and then
set the variables correctly i.e

load-theme -> post-theme-init -> helm-header

This also ensures the code is correctly decoupled now that helm is one
of the optional completion layers.

When a single source helm is viewed the source face-attribute was
changed from helm-selection to default as this gives a more consistent
result for themes that have bright highlight lines and/or no helm face
values.