### PR TITLE
(4604) Restore avy-open-url and fix avy-goto-url

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -378,7 +378,7 @@
 (defun spacemacs/init-avy ()
   (use-package avy
     :defer t
-    :commands (spacemacs/avy-open-url avy-pop-mark)
+    :commands (spacemacs/avy-open-url spacemacs/avy-goto-url avy-pop-mark)
     :init
     (progn
       (setq avy-all-windows 'all-frames)
@@ -389,7 +389,8 @@
         "jl" 'evil-avy-goto-line
         "ju" 'avy-pop-mark
         "jU" 'spacemacs/avy-goto-url
-        "jw" 'evil-avy-goto-word-or-subword-1))
+        "jw" 'evil-avy-goto-word-or-subword-1
+        "xo" 'spacemacs/avy-open-url))
     :config
     (progn
       (defun spacemacs/avy-goto-url()


### PR DESCRIPTION
This commit restores the spacemacs/avy-open-url SPC x o keybinding,
and also adds spacemacs/avy-goto-url to the package :commands to fix the
missing function definition on the SPC j U keybinding.