### PR TITLE
Add keybinding and evil-ex-cmd string for spacemacs/new-empty-buffer fn

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -384,6 +384,7 @@ argument takes the kindows rotate backwards."
   (interactive)
   (let ((newbuf (generate-new-buffer-name "untitled")))
     (switch-to-buffer newbuf)))
+(evil-ex-define-cmd "enew" 'spacemacs/new-empty-buffer)
 
 ;; from https://gist.github.com/timcharper/493269
 (defun spacemacs/split-window-vertically-and-switch ()

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -67,6 +67,7 @@
   "b C-k" 'spacemacs/kill-matching-buffers-rudely
   "bP"  'spacemacs/copy-clipboard-to-whole-buffer
   "bn"  'spacemacs/next-useful-buffer
+  "bN"  'spacemacs/new-empty-buffer
   "bp"  'spacemacs/previous-useful-buffer
   "bR"  'spacemacs/safe-revert-buffer
   "bs"  'spacemacs/switch-to-scratch-buffer


### PR DESCRIPTION
Closes #4428 

I have added the unused keybinding (`SPC b N`) and the evil command string (right next to the function definition for easy maintenance) as per the discussion in the issue thread.