### PR TITLE
Update the documentation for spacemacs-layouts

### DIFF
--- a/layers/+window-management/spacemacs-layouts/README.org
+++ b/layers/+window-management/spacemacs-layouts/README.org
@@ -32,7 +32,7 @@ existing =dotspacemacs-configuration-layers= list in this file.
 * Features 
 
 ** Micro-states
-*** TODO Layouts Micro State
+*** Layouts Micro State
 The layouts micro-state is initiated with ~SPC l~.
 
 | Key Binding | Description                                                |
@@ -47,7 +47,7 @@ The layouts micro-state is initiated with ~SPC l~.
 | ~C~         | close the other layouts and keep their buffers             |
 | ~h~         | go to default layout                                       |
 | ~C-h~       | previous layout in list                                    |
-| ~l~         | select a layout with helm                                  |
+| ~l~         | select/create a layout with helm                           |
 | ~L~         | load layouts from file                                     |
 | ~C-l~       | next layout in list                                        |
 | ~n~         | next layout in list                                        |
@@ -55,9 +55,10 @@ The layouts micro-state is initiated with ~SPC l~.
 | ~o~         | open a custom layout                                       |
 | ~p~         | previous layout in list                                    |
 | ~r~         | remove current buffer from layout                          |
-| ~R~         | rename layout                                              |
+| ~R~         | rename current layout                                      |
 | ~s~         | save layouts                                               |
 | ~t~         | display a buffer without adding it to the current layout   |
+| ~w~         | workspaces micro-state (needs eyebrowse layer enabled)     |
 | ~x~         | kill current layout with its buffers                       |
 | ~X~         | kill other layouts with their buffers                      |
 

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -78,27 +78,27 @@
       (defvar spacemacs--layouts-ms-documentation
         "
   [?]                  toggle this help
-  [0,9]                go to nth layout
-  [tab]                last layout
-  [a]                  add a buffer from another layout
+  [0,9]                switch to nth layout
+  [tab]                switch to the last
   [A]                  add all buffers from another layout
-  [b]                  select a buffer of the current layout
-  [c]                  close layout (buffers are not closed)
-  [C]                  close other layout(s) (buffers are not closed)
+  [a]                  add all the buffers from another layout in the current one
+  [b]                  select a buffer in the current layout
+  [c]                  close the current layout and keep its buffers
+  [C]                  close the other layouts and keep their buffers
   [h]                  go to default layout
-  [l]                  jump to a layout
-  [L]                  load saved layouts
-  [n] or [C-l]         next layout
-  [N] or [p] or [C-h]  previous layout
-  [o]                  custom layouts
+  [l]                  select/create a layout with helm
+  [L]                  load layouts from file
+  [n] or [C-l]         next layout in list
+  [N] or [p] or [C-h]  previous layout in list
+  [o]                  open a custom layout
   [r]                  remove current buffer from layout
-  [R]                  rename or create layout
+  [R]                  rename current layout
   [s]                  save all layouts
   [S]                  save layouts by names
   [t]                  show a buffer without adding it to current layout
-  [w]                  workspaces micro-state
-  [x]                  kill layout and its buffers
-  [X]                  kill other layout(s) and their buffers")
+  [w]                  workspaces micro-state (needs eyebrowse layer enabled)
+  [x]                  kill current layout with its buffers
+  [X]                  kill other layouts with their buffers")
 
       (defun spacemacs//layouts-ms-doc ()
         "Return the docstring for the layouts micro-state."


### PR DESCRIPTION
Two specific issues have been addressed. In README.org there was no
mention of the workspaces micro-state.
The micro-state documentation erroneously stated that 'R' could be used
to create a new layout. 'l' was mentioned nowhere as the way to create a
new layout.

The rest of this commit only updates both docs to contain the same info.