### PR TITLE
osx: Add term-mode hook to make s-v paste in terminals

### DIFF
--- a/layers/osx/keybindings.el
+++ b/layers/osx/keybindings.el
@@ -18,6 +18,10 @@
     (global-set-key (kbd "s-0") 'spacemacs/reset-font-size)
     (global-set-key (kbd "s-q") 'save-buffers-kill-terminal)
     (global-set-key (kbd "s-v") 'yank)
+    ;; Allow s-v to paste in term-mode
+    (add-hook 'term-mode-hook
+              (lambda ()
+                (define-key term-raw-map (kbd "s-v") 'term-paste)))
     (global-set-key (kbd "s-c") 'evil-yank)
     (global-set-key (kbd "s-a") 'mark-whole-buffer)
     (global-set-key (kbd "s-x") 'kill-region)


### PR DESCRIPTION
Currently, even with the OS X layer, `s-v` (`Cmd+v`) doesn't paste when in term-mode due to the way term mode interprets input. `s-v` pastes the text into the buffer, but is not interpreted by the terminal despite appearing to have pasted correctly.

This commit fixes this by adding a simple binding for `s-v` to `term-paste` in term-mode. IMHO, this is much less confusing default behavior and one that most people who use the OS X layer would want.

Apologies if I've gone about anything in the wrong way. I'm still pretty new to emacs/elisp and this is my first attempted contribution to an OSS project.