### PR TITLE
scala: support inserting unicode arrows

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -12,6 +12,7 @@
  - [[Scalastyle][Scalastyle]]
  - [[Automatically show the type of the symbol under the cursor][Automatically show the type of the symbol under the cursor]]
  - [[Automatically insert asterisk in multiline comments][Automatically insert asterisk in multiline comments]]
+ - [[Automatically replace arrows with unicode ones][Automatically replace arrows with unicode ones]]
  - [[Key bindings][Key bindings]]
    - [[Ensime key bindings][Ensime key bindings]]
      - [[Search][Search]]
@@ -101,6 +102,20 @@ To insert a leading asterisk in multiline comments automatically, set the variab
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (scala :variables scala-auto-insert-asterisk-in-comments t)))
+#+END_SRC
+
+* Automatically replace arrows with unicode ones
+
+To replace ~=>~, =->= and =<-= with unicode arrows =⇒=, =→= and =←=, set the
+variable =scala-use-unicode-arrows= to =t=.
+
+If in some occasions you don't want the arrows replaced (for example when
+defining compound operators like ~=>>~), you can always undo the change and get
+the ascii arrows back.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (scala :variables scala-use-unicode-arrows t)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -14,3 +14,6 @@
 
 (defvar scala-auto-insert-asterisk-in-comments nil
   "If non-nil automatically insert leading asterisk in multi-line comments.")
+
+(defvar scala-use-unicode-arrows nil
+  "If non-nil then `->`, `=>` and `<-` are replaced with unicode arrows.")

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -207,6 +207,45 @@
       (evil-define-key 'insert scala-mode-map
         (kbd "RET") 'scala/newline-and-indent-with-asterisk)
 
+      ;; Automatically replace arrows with unicode ones when enabled
+      (defconst scala-unicode-arrows-alist
+        '(("=>" . "⇒")
+          ("->" . "→")
+          ("<-" . "←")))
+
+      (defun scala/replace-arrow-at-point ()
+        "Replace the arrow before the point (if any) with unicode ones.
+An undo boundary is inserted before doing the replacement so that
+it can be undone."
+        (let* ((end (point))
+               (start (max (- end 2) (point-min)))
+               (x (buffer-substring start end))
+               (arrow (assoc x scala-unicode-arrows-alist)))
+          (when arrow
+            (undo-boundary)
+            (backward-delete-char 2)
+            (insert (cdr arrow)))))
+
+      (defun scala/gt ()
+        "Insert a `>' to the buffer. If it's part of a right arrow (`->' or `=>'),
+replace it with the corresponding unicode arrow."
+        (interactive)
+        (insert ">")
+        (scala/replace-arrow-at-point))
+
+      (defun scala/hyphen ()
+        "Insert a `-' to the buffer. If it's part of a left arrow (`<-'),
+replace it with the unicode arrow."
+        (interactive)
+        (insert "-")
+        (scala/replace-arrow-at-point))
+
+      (when scala-use-unicode-arrows
+        (define-key scala-mode-map
+          (kbd ">") 'scala/gt)
+        (define-key scala-mode-map
+          (kbd "-") 'scala/hyphen))
+
       (evil-define-key 'normal scala-mode-map "J" 'spacemacs/scala-join-line)
 
       ;; Compatibility with `aggressive-indent'


### PR DESCRIPTION
Add a configuration option `scala-use-unicode-arrows` to
the scala layer, which when enabled replaces `->`, `=>`
and `<-` with corresponding unicode characters (Scala
supports unicode arrows natively).