### PR TITLE
mu4e: Set account by "to" field

### DIFF
--- a/layers/+email/mu4e/funcs.el
+++ b/layers/+email/mu4e/funcs.el
@@ -9,14 +9,29 @@
 ;;
 ;;; License: GPLv3
 
+(defun mu4e/search-account-by-mail-address (mail-address)
+  (car (rassoc-if (lambda (x)
+                    (equal (cadr (assoc 'user-mail-address x)) mail-address))
+                  mu4e-account-alist)))
+
 (defun mu4e/set-account ()
   "Set the account for composing a message."
   (let* ((account
           (if mu4e-compose-parent-message
-              (let ((maildir
-                     (mu4e-message-field mu4e-compose-parent-message :maildir)))
-                (string-match "/\\(.*?\\)/" maildir)
-                (match-string 1 maildir))
+              (let* ((mailtos
+                      (mu4e-message-field mu4e-compose-parent-message :to))
+                     (mailto-account
+                      (car (cl-remove-if-not 'identity
+                                             (mapcar (lambda (x)
+                                                       (mu4e/search-account-by-mail-address (cdr x)))
+                                                     mailtos))))
+                     (maildir
+                      (mu4e-message-field mu4e-compose-parent-message :maildir))
+                     (maildir-account
+                      (progn
+                        (string-match "/\\(.*?\\)/" maildir)
+                        (match-string 1 maildir))))
+                (or mailto-account maildir-account))
             (helm-comp-read
              "Compose with account:"
              (mapcar (lambda (var) (car var)) mu4e-account-alist))))


### PR DESCRIPTION
Currently, in multi-account mode, the mu4e layer guesses which account
to use to reply a message by its "maildir". However, some messages may
be forwarded and may need to use the original email address to reply.
This commit detects whether such an email address is defined in
"mu4e-account-alist", and uses that to do the replying if possible.
