### PR TITLE
org-layer: follow the confirm and abort conventions

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -22,6 +22,7 @@
      - [[Emphasis][Emphasis]]
      - [[Tagging][Tagging]]
      - [[Navigating in calendar][Navigating in calendar]]
+   - [[Capture buffers and src blocks][Capture buffers and src blocks]]
    - [[Org agenda][Org agenda]]
    - [[Pomodoro][Pomodoro]]
    - [[Presentation][Presentation]]
@@ -267,6 +268,19 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~M-H~       | One month backward |
 | ~M-J~       | One year forward   |
 | ~M-K~       | One year backward  |
+
+** Capture buffers and src blocks
+=org-capture-mode= and =org-src-mode= both support the confirm and abort
+conventions.
+
+| Key Binding                                  | Description                            |
+|----------------------------------------------+----------------------------------------|
+| ~SPC m <dotspacemacs-major-mode-leader-key>~ | confirm in =org-capture-mode=          |
+| ~SPC m '~                                    | confirm in =org-src-mode=              |
+| ~SPC m c~                                    | confirm                                |
+| ~SPC m a~                                    | abort                                  |
+| ~SPC m k~                                    | abort                                  |
+| ~SPC m r~                                    | org-capture-refile in org-capture-mode |
 
 ** Org agenda
 The evilified org agenda supports, the following bindings:

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -120,6 +120,22 @@
         `(defun ,fname () (interactive)
                 (org-emphasize ,char)))
 
+      ;; Follow the confirm and abort conventions
+      (with-eval-after-load 'org-capture
+        (spacemacs/set-leader-keys-for-minor-mode 'org-capture-mode
+          dotspacemacs-major-mode-leader-key 'org-capture-finalize
+          "c" 'org-capture-finalize
+          "k" 'org-capture-kill
+          "a" 'org-capture-kill
+          "r" 'org-capture-refile))
+
+      (with-eval-after-load 'org-src
+        (spacemacs/set-leader-keys-for-minor-mode 'org-src-mode
+          "'" 'org-edit-src-exit
+          "c" 'org-edit-src-exit
+          "a" 'org-edit-src-abort
+          "k" 'org-edit-src-abort))
+
       ;; Insert key for org-mode and markdown a la C-h k
       ;; from SE endless http://emacs.stackexchange.com/questions/2206/i-want-to-have-the-kbd-tags-for-my-blog-written-in-org-mode/2208#2208
       (defun spacemacs/insert-keybinding-org (key)


### PR DESCRIPTION
The [conventions](https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org#confirm-and-abort) even mentions org-mode notes as one an example, but I didn't find any support for it. I have now added keybindings for the `org-capture-mode` used when capturing notes and `org-src-mode` used when editing source code blocks.

I tested that these keybindings work for both vim and emacs keys. It is peculiar that I am the only user of `spacemacs/set-leader-keys-for-minor-mode`. Is it the right way to implement these kinds of bindings? In the git layer a similar feature is implemented using `evil-define-key` https://github.com/syl20bnr/spacemacs/blob/develop/layers/+source-control/git/packages.el#L382-L390, but doesn't that drop support for holy-mode bindings?

