### PR TITLE
Eshell: Quit/bury shell only if there is no char left to delete

### DIFF
--- a/layers/shell/packages.el
+++ b/layers/shell/packages.el
@@ -118,10 +118,11 @@ is achieved by adding the relevant text properties."
         (eshell-send-input))
 
       ;; Caution! this will erase buffer's content at C-l
+      (require 'em-rebind)
       (add-hook 'eshell-mode-hook
          #'(lambda ()
              (define-key eshell-mode-map (kbd "C-l") 'eshell/clear)
-             (define-key eshell-mode-map (kbd "C-d") 'eshell-life-is-too-much)))
+             (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof)))
       (add-hook 'eshell-mode-hook 'spacemacs//init-eshell))
     :config
     (progn


### PR DESCRIPTION
This PR is to address #4630. Currently, `C-d` is bound to `eshell-life-is-too-much` which buries the shell buffer. This behaviour is not ideal as it stops you from being able do the normal `delete-char` operation within shell.

With the change, `C-d` is bound to `eshell-delchar-or-maybe-eof` which checks if there is a char after the point/cursor. If so, it runs `delete-char` otherwise `eshell-life-is-too-much`. This behaviour is consistent with other terminal emulators I've used in the past.

Thanks for reviewing in advance. 