### PR TITLE
Remove obsolete variable.

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -574,7 +574,6 @@
   (use-package evil-jumper
     :init
     (progn
-      (setq evil-jumper-auto-save-interval 600)
       (evil-jumper-mode t))))
 
 (defun spacemacs/init-evil-lisp-state ()


### PR DESCRIPTION
evil-jumper-auto-save-interval has been removed in favor of relying on
savehist to perform persistence.