### PR TITLE
Disable org-indent by default

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -103,7 +103,6 @@
 
       (with-eval-after-load 'org-indent
         (spacemacs|hide-lighter org-indent-mode))
-      (setq org-startup-indented t)
       (let ((dir (configuration-layer/get-layer-property 'org :dir)))
         (setq org-export-async-init-file (concat dir "org-async-init.el")))
       (defmacro spacemacs|org-emphasize (fname char)
@@ -261,7 +260,6 @@ Will work on both org-mode and any mode that accepts plain html."
                     (2 font-lock-function-name-face)
                     (3 font-lock-comment-face prepend))))
 
-      (require 'org-indent)
       (define-key global-map "\C-cl" 'org-store-link)
       (define-key global-map "\C-ca" 'org-agenda)
 


### PR DESCRIPTION
This is not a *fix*, but probably the easiest way to deal with a number of annoying bugs. I left it enabled for viewing docs and for the dotfile tests.

"Fixes": https://github.com/syl20bnr/spacemacs/issues/4692, https://github.com/syl20bnr/spacemacs/issues/2732