### PR TITLE
evil: Bind evil-jump-forward for GUI

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -229,6 +229,9 @@
     (progn
       ;; bind function keys
 
+      ;; bind evil-jump-forward for GUI only.
+      (define-key evil-motion-state-map [C-i] 'evil-jump-forward)
+
       ;; Make the current definition and/or comment visible.
       (define-key evil-normal-state-map "zf" 'reposition-window)
       ;; toggle maximize buffer


### PR DESCRIPTION
Bind to <C-i> so that evil-jump-forward works in the GUI and we don't
rebind TAB in the terminal.

Bind <C-i> for the evil-jumper package too

@TheBB sorry for the trouble. You can blame me for this one. 