### PR TITLE
Fix and enhance spacemacs|diminish

### DIFF
--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -87,11 +87,15 @@ PLIST has the form (\"fontname\" :prop1 val1 :prop2 val2 ...)"
                              "~/.emacs.d/doc/DOCUMENTATION.org for more "
                              "info).")))
 
-(defmacro spacemacs|diminish (mode unicode &optional ascii)
+(defmacro spacemacs|diminish (mode &optional unicode ascii)
   "Diminish MODE name in mode line to UNICODE or ASCII depending on the value
 `dotspacemacs-mode-line-unicode-symbols'.
-If ASCII si not provided then UNICODE is used instead."
-  `(add-to-list 'spacemacs--diminished-minor-modes '(,mode ,unicode ,ascii)))
+If ASCII si not provided then UNICODE is used instead. If neither are provided,
+the mode will not show in the mode line."
+  `(let ((cell (assq ',mode spacemacs--diminished-minor-modes)))
+     (if cell
+         (setcdr cell '(,unicode ,ascii))
+       (push '(,mode ,unicode ,ascii) spacemacs--diminished-minor-modes))))
 
 (defmacro spacemacs|hide-lighter (mode)
   "Diminish MODE name in mode line to LIGHTER."


### PR DESCRIPTION
Since this macro always pushes to the front of the list, and the function in the modeline hook reads the whole list, it becomes impossible to override minor mode lighters set with `spacemacs|diminish`.  This PR fixes #4679. It also makes the unicode argument optional.