### PR TITLE
Prevent attempt to find mu4e on ELPA/MELPA.

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -11,7 +11,8 @@
 
 (setq mu4e-packages
       '(
-        (mu4e :skip-install t)
+        (mu4e :skip-install t
+              :location built-in)
         mu4e-maildirs-extension
         org
         ))


### PR DESCRIPTION
This removes the message about mu4e not being found, and possibly being mispelled.