### PR TITLE
don't try and install mu4e

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -19,7 +19,7 @@
     flyspell
     gnuplot
     htmlize
-    mu4e
+    (mu4e :skip-install t)
     ;; org and org-agenda are installed by `org-plus-contrib'
     (org :location built-in)
     (org-agenda :location built-in)


### PR DESCRIPTION
recent change added mu4e to packages in org layer, but didn't include `:skip-install t` from the mu4e layer causing spacemacs to incorrectly try (and fail) to install mu4e.