### PR TITLE
Remove non-directories from rollback slot list

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -996,7 +996,8 @@ If called with a prefix argument ALWAYS-UPDATE, assume yes to update."
       (reverse
        (delq nil (mapcar
                   (lambda (x)
-                    (when (not (or (string= "." x) (string= ".." x)))
+                    (when (and (file-directory-p (concat rolldir x))
+                               (not (or (string= "." x) (string= ".." x))))
                       (let ((p (length (directory-files (file-name-as-directory
                                                          (concat rolldir x))))))
                         ;; -3 for . .. and rollback-info


### PR DESCRIPTION
The PR is to fix #4586.

Currently, it stops Spacemacs from listing rollback slots if there is a non-directory (i.e. file) found under the rollback directory. For instance, `.emacs.d/.cache/.rollback/.DS_Store`, which happens frequently on OS X.

Thanks for reviewing in advance.