### PR TITLE
helm-mu4e integration + keybinding changes

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -13,6 +13,7 @@
       '(
         (mu4e :skip-install t)
         mu4e-maildirs-extension
+        helm-mu
         org
         ))
 
@@ -21,7 +22,7 @@
     :commands (mu4e mu4e-compose-new)
     :init
     (progn
-      (spacemacs/set-leader-keys "a M" 'mu4e)
+      (spacemacs/set-leader-keys "a m m" 'mu4e)
       (global-set-key (kbd "C-x m") 'mu4e-compose-new))
     :config
     (progn
@@ -42,6 +43,16 @@
       (when mu4e-account-alist
         (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
         (add-hook 'message-sent-hook 'mu4e/mail-account-reset)))))
+
+(defun mu4e/init-helm-mu ()
+  (spacemacs/set-leader-keys
+    "a m s" 'helm-mu
+    "a m c" 'helm-mu-contacts))
+
+(defun mu4e/post-init-helm ()
+  (require 'helm-config)
+  (autoload 'helm-mu "helm-mu" "" t)
+  (autoload 'helm-mu-contacts "helm-mu" "" t))
 
 (defun mu4e/init-mu4e-maildirs-extension ()
   (use-package mu4e-maildirs-extension

--- a/layers/spotify/packages.el
+++ b/layers/spotify/packages.el
@@ -14,13 +14,13 @@
 (defun spotify/init-spotify ()
   (use-package spotify
     :config (spacemacs/set-leader-keys
-              "amsp" 'spotify-playpause
-              "amsn" 'spotify-next
-              "amsN" 'spotify-previous
-              "amsQ" 'spotify-quit)))
+              "aMsp" 'spotify-playpause
+              "aMsn" 'spotify-next
+              "aMsN" 'spotify-previous
+              "aMsQ" 'spotify-quit)))
 
 (when (configuration-layer/layer-usedp 'spacemacs-helm)
   (defun spotify/init-helm-spotify ()
     (use-package helm-spotify
       :config (spacemacs/set-leader-keys
-                "amsg" 'helm-spotify))))
+                "aMsg" 'helm-spotify))))


### PR DESCRIPTION
This pull request contains 2 things:
- helm-mu integration
- Change keybinding `SPC M` to `SPC m` for `mu4e` layer
- Change keybinding `SPC m` to `SPC M` for `spotify` layer
  - Adds `SPC m s` for `helm-mu`
  - Adds `SPC m c` for `helm-mu-contacts`
