### PR TITLE
Use built-in web-mode pairing instead of smartparens

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -150,20 +150,7 @@
      'smartparens-mode)
    '(css-mode-hook scss-mode-hook sass-mode-hook less-css-mode-hook))
 
-  ;; Only use smartparens in web-mode
-  (with-eval-after-load 'smartparens
-    (setq web-mode-enable-auto-pairing nil)
-    (sp-local-pair 'web-mode "<% " " %>")
-    (sp-local-pair 'web-mode "{ " " }")
-    (sp-local-pair 'web-mode "<%= "  " %>")
-    (sp-local-pair 'web-mode "<%# "  " %>")
-    (sp-local-pair 'web-mode "<%$ "  " %>")
-    (sp-local-pair 'web-mode "<%@ "  " %>")
-    (sp-local-pair 'web-mode "<%: "  " %>")
-    (sp-local-pair 'web-mode "{{ "  " }}")
-    (sp-local-pair 'web-mode "{% "  " %}")
-    (sp-local-pair 'web-mode "{%- "  " %}")
-    (sp-local-pair 'web-mode "{# "  " #}")))
+  (add-hook 'web-mode-hook 'spacemacs/toggle-smartparens-off))
 
 (defun html/init-tagedit ()
   (use-package tagedit


### PR DESCRIPTION
Fixes https://github.com/syl20bnr/spacemacs/issues/4499 and a host of questions on gitter.

The current solution is quite buggy. This will prevent stuff autoclosing of stuff like `(` in regular text in HTML, but I think it's a net win.

Maybe other regular web-mode users can give some feedback?

Ping @synic