### PR TITLE
golang: fix regex that searches tests

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -44,7 +44,7 @@
                                    "-check.f"
                                  "-run")))
               (save-excursion
-                  (re-search-backward "^func[ ]+([[:alnum:]]*?[ ]?[*]?\\([[:alnum:]]+\\))[ ]+\\(Test[[:alnum:]]+\\)(.*)")
+                  (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Test[[:alnum:]]+\\)(.*)")
                   (spacemacs/go-run-tests (concat test-method "='" (match-string-no-properties 2) "'"))))
           (message "Must be in a _test.go file to run go-run-test-current-function")))
 
@@ -53,8 +53,8 @@
         (if (string-match "_test\.go" buffer-file-name)
             (if go-use-gocheck-for-testing
                 (save-excursion
-                    (re-search-backward "^func[ ]+([[:alnum:]]*?[ ]?[*]?\\([[:alnum:]]+\\))[ ]+\\(Test[[:alnum:]]+\\)(.*)")
-                    (spacemacs/go-run-tests (concat "-check.f='" (match-string-no-properties 1) "'")))
+                    (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?\\([[:alnum:]]+\\))[ ]+\\)?Test[[:alnum:]]+(.*)")
+                    (spacemacs/go-run-tests (concat "-check.f='" (match-string-no-properties 2) "'")))
               (message "Gocheck is needed to test the current suite"))
           (message "Must be in a _test.go file to run go-test-current-suite")))
 


### PR DESCRIPTION
Related to https://github.com/syl20bnr/spacemacs/issues/4715

Basically what happened here is that I didn't account for tests without suites and thus did not escape parantheses(even though I'm pretty sure I had that in an earlier version of the regex).

So 
```go
func (s *suite) TestRandom(blabla) {
}
```
would work, but
```go
func TestRandom(blabla) {
}
```
wouldn't. The patch makes the whole suite part an optional group.

I did test it once, but I'd love to hear from the guys who responded on the issue.