### PR TITLE
Change a link from the GitHub file to spacemacs.org in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 |
 <b><a href="doc/DOCUMENTATION.org#screenshots">screenshots</a></b>
 |
-<b><a href="doc/DOCUMENTATION.org">documentation</a></b>
+<b><a href="http://spacemacs.org/doc/DOCUMENTATION.html">documentation</a></b>
 |
 <b><a href="CONTRIBUTING.org">contribute</a></b>
 |


### PR DESCRIPTION
I only changed the link to `doc/DOCUMENTATION.org`.  Other ones, like `doc/DOCUMENTATION.org#screenshots`, remain unchanged, because their anchors on spacemacs.org is unstable.  For example, `doc/DOCUMENTATION.org#screenshots` is http://spacemacs.org/doc/DOCUMENTATION.html#orgheadline7 on spacemacs.org (currently).