### PR TITLE
add autoload for the magit-rebase-popup command

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -102,6 +102,7 @@
                magit-log-popup
                magit-pull-popup
                magit-push-popup
+               magit-rebase-popup
                magit-status)
     :init
     (progn


### PR DESCRIPTION
Whoever did this forgot to add it to the autoload list in the init function 