### PR TITLE
Use popwin for rspec-compilations

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -746,6 +746,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
       ;; buffers that we manage
       (push '("*Help*"                 :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)
       (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
+      (push '("*rspec-compilation*"    :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Shell Command Output*" :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*Async Shell Command*"  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '(" *undo-tree*"           :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)


### PR DESCRIPTION
With the introduction of `rspec` support in version 0.105.0
tests run with rspec launch in their own `rspec-compilation`
which is not managed in `spacemacs-base/init-popwin` causing
those compilations to open a new buffer and take over an exisiting
window.

It is preferable to have the test compilation open in a popwin
that does not disrupt the current state of a workspace layout and
takes advantage of the full width of the current editor view
so it's easier to read. Popwin is also nice because it is easier
to dismiss with a simple `C-g` or `SPC w p p`.