### PR TITLE
Allow default theme in dotspacemacs-themes

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -73,7 +73,8 @@
   (configuration-layer/initialize)
   ;; default theme
   (let ((default-theme (car dotspacemacs-themes)))
-    (spacemacs/load-theme default-theme)
+    (unless (string= "default" (car dotspacemacs-themes))
+      (spacemacs/load-theme default-theme))
     ;; protect used themes from deletion as orphans
     (setq configuration-layer--protected-packages
           (append


### PR DESCRIPTION
This PR allows for not setting a custom theme by checking if "default" is the first element of `dotspacemacs-themes`. I made this change to address https://github.com/syl20bnr/spacemacs/issues/4723. I don't feel strongly about it, but it is arguably better to have some way to use spacemacs without setting a custom theme.