### PR TITLE
Spacemacs Layouts Improvements [WIP]

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -302,8 +302,6 @@ format so they are supported by the
       (defadvice persp-activate (before spacemacs//save-toggle-layout activate)
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
-      ;; By default, persp mode wont affect either helm or ido
-      (remove-hook 'ido-make-buffer-list-hook 'persp-restrict-ido-buffers))))
 
 (defun spacemacs-layouts/post-init-spaceline ()
   (setq spaceline-display-default-perspective

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -256,7 +256,7 @@ Available PROPS:
              ;; Check for Clashes
              (if ,already-defined?
                  (unless (equal ,already-defined? ,name)
-                   (warn "Replacing existing binding \"%s\" for %s with %s"
+                   (spacemacs-buffer/warning "Replacing existing binding \"%s\" for %s with %s"
                          ,binding ,already-defined? ,name )
                    (push '(,binding . ,name) spacemacs--custom-layout-alist))
                (push '(,binding . ,name) spacemacs--custom-layout-alist)))))
@@ -279,7 +279,7 @@ Available PROPS:
                          (format "[%s] %s"
                                  (car custom-persp) (cdr custom-persp)))
                        spacemacs--custom-layout-alist " ")
-          (warn (format "`spacemacs--custom-layout-alist' variable is empty" ))))
+          (spacemacs-buffer/warning (format "`spacemacs--custom-layout-alist' variable is empty" ))))
 
       (defun spacemacs//update-custom-layouts ()
         "Ensure the custom-perspectives micro-state is updated.

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -308,11 +308,11 @@ format so they are supported by the
 current perspective."
         (interactive)
         (with-persp-buffer-list ()
-          (other-buffer (current-buffer) t)))
+          (switch-to-buffer (other-buffer (current-buffer) t))))
 
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
-        "TAB" 'spacemacs/alternate-buffer-in-persp
+        "TAB"  'spacemacs/alternate-buffer-in-persp
         "ba"   'persp-add-buffer
         "br"   'persp-remove-buffer))))
 

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -310,11 +310,22 @@ current perspective."
         (with-persp-buffer-list ()
           (switch-to-buffer (other-buffer (current-buffer) t))))
 
+      (defun spacemacs-layouts/non-restricted-buffer-list ()
+        (interactive)
+        (remove-hook 'ido-make-buffer-list-hook  #'persp-restrict-ido-buffers)
+        (helm-mini)
+        (add-hook 'ido-make-buffer-list-hook  #'persp-restrict-ido-buffers))
+
+      (spacemacs/declare-prefix "b" "persp-buffers")
+      (spacemacs/declare-prefix "B" "global-buffers")
+
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
         "TAB"  'spacemacs/alternate-buffer-in-persp
         "ba"   'persp-add-buffer
-        "br"   'persp-remove-buffer))))
+        "br"   'persp-remove-buffer
+        "Bb"   'spacemacs-layouts/non-restricted-buffer-list
+        ))))
 
 (defun spacemacs-layouts/post-init-spaceline ()
   (setq spaceline-display-default-perspective

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -312,7 +312,9 @@ current perspective."
 
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
-        "TAB" 'spacemacs/alternate-buffer-in-persp))))
+        "TAB" 'spacemacs/alternate-buffer-in-persp
+        "ba"   'persp-add-buffer
+        "br"   'persp-remove-buffer))))
 
 (defun spacemacs-layouts/post-init-spaceline ()
   (setq spaceline-display-default-perspective

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -303,6 +303,17 @@ format so they are supported by the
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
 
+      (defun spacemacs/alternate-buffer-in-persp ()
+        "Switch back and forth between current and last buffer in the
+current perspective."
+        (interactive)
+        (with-persp-buffer-list ()
+          (other-buffer (current-buffer) t)))
+
+      ;; Override SPC TAB to only change buffers in perspective
+      (spacemacs/set-leader-keys
+        "TAB" 'spacemacs/alternate-buffer-in-persp))))
+
 (defun spacemacs-layouts/post-init-spaceline ()
   (setq spaceline-display-default-perspective
         dotspacemacs-display-default-layout))


### PR DESCRIPTION
Fix #4579
This fixes:
1. Repeated bindings
2. Leave micro-state when `SPC l <number>` 
3. nope
4. Exit micro-state after opening custom-layout

-----
Fix #4590 
1. SPC b b, SPC TAB, SPC b n and SPC b p are restricted to the current layout
2. New key bindings SPC b a and SPC b r to add/remove buffers to current layout