### PR TITLE
do not force rspec-mode on ruby files

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -151,15 +151,6 @@
 (defun ruby/init-rspec-mode ()
   (use-package rspec-mode
     :defer t
-    :init
-    (progn
-      (defun spacemacs//ruby-enable-rspec-mode ()
-        "Conditionally enable `rspec-mode'"
-        (when (eq 'rspec ruby-test-runner)
-          (rspec-mode)))
-      (spacemacs/add-to-hooks
-       'spacemacs//ruby-enable-rspec-mode '(ruby-mode-hook
-                                            enh-ruby-mode-hook)))
     :config
     (progn
       (spacemacs|hide-lighter rspec-mode)


### PR DESCRIPTION
fixes #4775 - forcing rspec-mode on plain ruby files breaks jump-in-file, and is not necessary as `rspec-mode` installs its own initialisation hooks