### PR TITLE
Add "o" keybinding for opening links with ace-jump

### DIFF
--- a/layers/+tools/elfeed/packages-config.el
+++ b/layers/+tools/elfeed/packages-config.el
@@ -39,7 +39,9 @@
   (use-package elfeed-goodies
     :commands elfeed-goodies/setup
     :init (spacemacs|use-package-add-hook elfeed
-            :post-config (elfeed-goodies/setup))))
+            :post-config (progn
+                           (elfeed-goodies/setup)
+                           (evil-define-key 'evilified elfeed-show-mode-map "o" 'elfeed-goodies/show-ace-link)))))
 
 (defun elfeed/init-elfeed-org ()
   (use-package elfeed-org


### PR DESCRIPTION
There might be better way of using `avy` for doing this but since we're already using `elfeed-goodies` I just added it to evilified bindings. 