### PR TITLE
Set projectile-completion-system to helm

### DIFF
--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -46,6 +46,9 @@
             helm-imenu-execute-action-at-once-if-one nil
             helm-org-format-outline-path t)
 
+      (when (configuration-layer/package-usedp 'projectile)
+        (setq projectile-completion-system 'helm))
+
       ;; hide minibuffer in Helm session, since we use the header line already
       (defun helm-hide-minibuffer-maybe ()
         (when (with-helm-buffer helm-echo-input-in-header-line)


### PR DESCRIPTION
It is inconsistent when using helm as default completion and command
such as `SPC m r f c` opens up ido in rails project.