### PR TITLE
vim-unimpaired: don't re-position point

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -751,13 +751,13 @@
 
   (defun evil-unimpaired/insert-space-above ()
     (interactive)
-    (evil-insert-newline-above)
-    (forward-line))
+    (save-excursion
+      (evil-insert-newline-above)))
 
   (defun evil-unimpaired/insert-space-below ()
     (interactive)
-    (evil-insert-newline-below)
-    (forward-line -1))
+    (save-excursion
+      (evil-insert-newline-below)))
 
   (defun evil-unimpaired/next-frame ()
     (interactive)


### PR DESCRIPTION
Keep the point the same for evil-unimpaired/insert-space-above and
evil-unimpaired/insert-space-below.

Old Behavior

    A newline<POINT>
    \n

    ===== (evil-unimpaired/insert-space-below)

    <POINT>A newline
    \n
    \n

New behavior

    A newline<POINT>
    \n

    ===== (evil-unimpaired/insert-space-below)

    A newline<POINT>
    \n
    \n