### PR TITLE
Revert "Set global pyenv version if no .python-version file exists"

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -133,8 +133,7 @@ has installed. Those will be listed alongside your Python versions.
 
 *** Automatic activation of local pyenv version
 A project-specific pyenv version may be written to a file called
-=.python-version= using the [[https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-local][pyenv local]] command. If this file is not found then
-the global pyenv version is set.
+=.python-version= using the [[https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-local][pyenv local]] command.
 
 Spacemacs can search in parent directories for this file, and automatically set
 the pyenv version. The behavior can be set with the variable

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -44,12 +44,11 @@
     (message "Error: Cannot find autoflake executable.")))
 
 (defun pyenv-mode-set-local-version ()
-  "Set pyenv version from \".python-version\" by looking in parent directories.
-   If no local version is found set the global version."
+  "Set pyenv version from \".python-version\" by looking in parent directories."
   (interactive)
   (let ((root-path (locate-dominating-file default-directory
                                            ".python-version")))
-    (if root-path
+    (when root-path
       (let* ((file-path (expand-file-name ".python-version" root-path))
              (version (with-temp-buffer
                         (insert-file-contents-literally file-path)
@@ -58,10 +57,4 @@
         (if (member version (pyenv-mode-versions))
             (pyenv-mode-set version)
           (message "pyenv: version `%s' is not installed (set by %s)"
-                   version file-path)))
-      (pyenv-mode-set (spacemacs-pyenv-mode-global-version)))))
-
-(defun spacemacs-pyenv-mode-global-version ()
-  "Get global pyenv version directly from pyenv"
-  (replace-regexp-in-string "\n" ""
-                            (shell-command-to-string "pyenv global")))
+                   version file-path))))))


### PR DESCRIPTION
This reverts commit bddf9de8f1c138b60c14f8b261f9b3b591ed8965.

When pyenv-auto-set-local-pyenv-version is set to 'on-visit then this
switched the python version when e.g. using jump to definition which made this whole thing rather unusable.

I'm sorry about that. 