### PR TITLE
Doc fix for spacemacs/show-and-copy-buffer-filename

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1671,7 +1671,7 @@ Files manipulation commands (start with ~f~):
 | ~SPC f v d~ | add a directory variable                                                                                                        |
 | ~SPC f v f~ | add a local variable to the current file                                                                                        |
 | ~SPC f v p~ | add a local variable to the first line of the current file                                                                      |
-| ~SPC f y~   | show current file absolute path in the minibuffer                                                                               |
+| ~SPC f y~   | show and copy current file absolute path in the minibuffer                                                                      |
 
 **** Emacs and Spacemacs files
 Convenient key bindings are located under the prefix ~SPC f e~ to quickly

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -352,7 +352,7 @@ argument takes the kindows rotate backwards."
 
 ;; http://camdez.com/blog/2013/11/14/emacs-show-buffer-file-name/
 (defun spacemacs/show-and-copy-buffer-filename ()
-  "Show the full path to the current file in the minibuffer."
+  "Show and copy the full path to the current file in the minibuffer."
   (interactive)
   (let ((file-name (buffer-file-name)))
     (if file-name


### PR DESCRIPTION
BTW, just FYI - Emacs (as a GNU project) usually doesn't use the term "path" in its documentation.  Search the word "path" in [GCS](https://www.gnu.org/prep/standards/html_node/GNU-Manuals.html#GNU-Manuals) for more information.