### PR TITLE
Some fixes for google-translate

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -357,9 +357,6 @@
   "xU"  'upcase-region
   "xu"  'downcase-region
   "xwc" 'spacemacs/count-words-analysis)
-;; google translate -----------------------------------------------------------
-(spacemacs/set-leader-keys
-  "xgl" 'spacemacs/set-google-translate-languages)
 ;; shell ----------------------------------------------------------------------
 (with-eval-after-load 'shell
   (evil-define-key 'insert comint-mode-map [up] 'comint-previous-input)

--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -951,10 +951,6 @@
 
 (defun spacemacs/init-google-translate ()
   (use-package google-translate
-    :commands (google-translate-query-translate
-               google-translate-at-point
-               google-translate-query-translate-reverse
-               google-translate-at-point-reverse)
     :init
     (progn
       (defun spacemacs/set-google-translate-languages (source target)
@@ -969,17 +965,15 @@ For instance pass En as source for English."
         (setq google-translate-default-source-language (downcase source))
         (setq google-translate-default-target-language (downcase target)))
       (spacemacs/set-leader-keys
+        "xgl" 'spacemacs/set-google-translate-languages
         "xgQ" 'google-translate-query-translate-reverse
         "xgq" 'google-translate-query-translate
         "xgT" 'google-translate-at-point-reverse
         "xgt" 'google-translate-at-point))
-    :config
-    (progn
-      (require 'google-translate-default-ui)
       (setq google-translate-enable-ido-completion t)
       (setq google-translate-show-phonetic t)
       (setq google-translate-default-source-language "en")
-      (setq google-translate-default-target-language "fr"))))
+      (setq google-translate-default-target-language "fr")))
 
 
 (defun spacemacs/init-highlight-indentation ()


### PR DESCRIPTION
- Don't explicitly list commands (they are autoloaded)
- Move `SPC xgl` binding from keybindings.el
- Don't explicitly require the default-ui feature (not necessary)
- Set variables in init instead of config (easier to change for users)

Fixes #4827.