### PR TITLE
Use `counsel-find-file` when spacemacs-ivy is used

### DIFF
--- a/layers/+vim/vinegar/packages.el
+++ b/layers/+vim/vinegar/packages.el
@@ -54,7 +54,9 @@
       (kbd "RET") (if vinegar-reuse-dired-buffer
                       'dired-find-alternate-file
                     'dired-find-file)
-      "f"         'helm-find-files
+      "f"         (if (configuration-layer/layer-usedp 'spacemacs-ivy)
+                      'counsel-find-file
+                    'helm-find-files)
       "J"         'dired-goto-file
       (kbd "C-f") 'find-name-dired
       "H"         'diredp-dired-recent-dirs


### PR DESCRIPTION
Simple keybinding change. Keep `helm-find-files` otherwise.