### PR TITLE
Make sure new workspaces and layouts only show the home buffer

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -413,6 +413,13 @@ argument takes the kindows rotate backwards."
 (defalias 'spacemacs/home 'spacemacs-buffer/goto-buffer
   "Go to home Spacemacs buffer")
 
+(defun spacemacs/home-delete-other-windows ()
+  "Open home Spacemacs buffer and delete other windows.
+Useful for making the home buffer the only visible buffer in the frame."
+  (interactive)
+  (spacemacs/home)
+  (delete-other-windows))
+
 (defun spacemacs/insert-line-above-no-indent (count)
   (interactive "p")
   (let ((p (+ (point) count)))

--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -15,7 +15,7 @@
   (use-package eyebrowse
     :init
     (progn
-      (setq eyebrowse-new-workspace #'spacemacs/home
+      (setq eyebrowse-new-workspace #'spacemacs/home-delete-other-windows
             eyebrowse-wrap-around t)
       (eyebrowse-mode)
 

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -167,7 +167,7 @@
                            "Do you want to create one? "))
               (let ((persp-reset-windows-on-nil-window-conf t))
                 (persp-switch nil)
-                (spacemacs/home))))))
+                (spacemacs/home-delete-other-windows))))))
 
       ;; Define all `spacemacs/persp-switch-to-X' functions
       (dolist (i (number-sequence 9 0 -1))


### PR DESCRIPTION
Previous code would show two windows when invoked from a window that is dedicated to its buffer: the home buffer and the dedicated buffer.

Fixes #4838 