### PR TITLE
Fix "the point" problems

### DIFF
--- a/CHANGELOG.next
+++ b/CHANGELOG.next
@@ -60,7 +60,7 @@ This file containes the change log for the next major version of Spacemacs.
   - ~SPC j b~ to jump to a bookmark
   - ~SPC j d~ to jump to a listing of the current directory
   - ~SPC j D~ to jump to a listing of the current directory (other window)
-  - ~SPC j f~ to jump to the definition of the function under the point
+  - ~SPC j f~ to jump to the definition of the function around point
   - ~SPC j i~ to jump to a definition in buffer (imenu)
   - ~SPC j j~ to jump to a character in the buffer (works as an evil motion)
   - ~SPC j J~ to jump to a suite of two characters in the buffer (works as an evil motion)

--- a/CHANGELOG.next
+++ b/CHANGELOG.next
@@ -72,8 +72,7 @@ This file containes the change log for the next major version of Spacemacs.
   - ~SPC j S~ to split a quoted string or s-expression, insert a new line and auto-indent
   - ~SPC j u~ to undo a jump (go back to previous location)
   - ~SPC j U~ to jump to a URL in the current buffer
-  - ~SPC j v~ to jump to the definition/declaration of the variable under the
-    point
+  - ~SPC j v~ to jump to the definition/declaration of the variable around point
   - ~SPC j w~ to jump to a word in the current buffer (works as an evil motion)
   (thanks to justbur)
 - New key bindings under ~SPC h~:

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -222,9 +222,10 @@ can be toggled through `toggle-transparency'.")
   "If non nil unicode symbols are displayed in the mode-line (eg. for lighters)")
 
 (defvar dotspacemacs-smooth-scrolling t
-  "If non nil smooth scrolling (native-scrolling) is enabled. Smooth scrolling
-overrides the default behavior of Emacs which recenters the point when
-it reaches the top or bottom of the screen.")
+  "If non nil smooth scrolling (native-scrolling) is enabled.
+Smooth scrolling overrides the default behavior of Emacs which
+recenters point when it reaches the top or bottom of the
+screen.")
 
 (defvar dotspacemacs-line-numbers nil
   "If non nil line numbers are turned on in all `prog-mode' and `text-mode'

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -578,7 +578,7 @@ HPADDING is the horizontal spacing betwee the content line and the frame border.
                   (insert list-separator))))) dotspacemacs-startup-lists))))
 
 (defun spacemacs-buffer/goto-link-line ()
-  "Move the point to the beginning of the link line."
+  "Set point to the beginning of the link line."
   (interactive)
   (with-current-buffer spacemacs-buffer-name
     (goto-char (point-min))

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -201,8 +201,8 @@ values."
    ;; If non nil unicode symbols are displayed in the mode line. (default t)
    dotspacemacs-mode-line-unicode-symbols t
    ;; If non nil smooth scrolling (native-scrolling) is enabled. Smooth
-   ;; scrolling overrides the default behavior of Emacs which recenters the
-   ;; point when it reaches the top or bottom of the screen. (default t)
+   ;; scrolling overrides the default behavior of Emacs which recenters point
+   ;; when it reaches the top or bottom of the screen. (default t)
    dotspacemacs-smooth-scrolling t
    ;; If non nil line numbers are turned on in all `prog-mode' and `text-mode'
    ;; derivatives. If set to `relative', also turns on relative line numbers.

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -156,14 +156,14 @@ mails or =org-mode= notes.
 ** Evaluation
 Live evaluation of code is under the prefix ~SPC m e~.
 
-| Key     | Description                                       |
-|---------+---------------------------------------------------|
+| Key     | Description                                   |
+|---------+-----------------------------------------------|
 | ~m e $~ | put point at the end of the line and evaluate |
-| ~m e b~ | evaluate buffer                                   |
-| ~m e e~ | evaluate last expression                          |
-| ~m e f~ | evaluate function                                 |
-| ~m e l~ | evaluate line                                     |
-| ~m e r~ | evaluate region                                   |
+| ~m e b~ | evaluate buffer                               |
+| ~m e e~ | evaluate last expression                      |
+| ~m e f~ | evaluate function                             |
+| ~m e l~ | evaluate line                                 |
+| ~m e r~ | evaluate region                               |
 
 ** REPLs
 *** Send code

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -158,7 +158,7 @@ Live evaluation of code is under the prefix ~SPC m e~.
 
 | Key     | Description                                       |
 |---------+---------------------------------------------------|
-| ~m e $~ | put the point at the end of the line and evaluate |
+| ~m e $~ | put point at the end of the line and evaluate |
 | ~m e b~ | evaluate buffer                                   |
 | ~m e e~ | evaluate last expression                          |
 | ~m e f~ | evaluate function                                 |

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1472,7 +1472,7 @@ The ~SPC j~ prefix is for jumping, joining and splitting.
 | ~SPC j b~   | jump to a bookmark                                                                |
 | ~SPC j d~   | jump to a listing of the current directory                                        |
 | ~SPC j D~   | jump to a listing of the current directory (other window)                         |
-| ~SPC j f~   | jump to the definition of the function under the point                            |
+| ~SPC j f~   | jump to the definition of the function around point                               |
 | ~SPC j i~   | jump to a definition in buffer (imenu)                                            |
 | ~SPC j I~   | jump to a definition in any buffer (imenu)                                        |
 | ~SPC j j~   | jump to a character in the buffer (works as an evil motion)                       |
@@ -1481,7 +1481,7 @@ The ~SPC j~ prefix is for jumping, joining and splitting.
 | ~SPC j l~   | jump to a line with avy (works as an evil motion)                                 |
 | ~SPC j u~   | undo a jump (go back to previous location)                                        |
 | ~SPC j U~   | jump to a URL in the current buffer                                               |
-| ~SPC j v~   | jump to the definition/declaration of the variable under the point                |
+| ~SPC j v~   | jump to the definition/declaration of the variable around point                   |
 | ~SPC j w~   | jump to a word in the current buffer (works as an evil motion)                    |
 
 
@@ -1792,8 +1792,8 @@ experience like in [[http://ranger.nongnu.org/][ranger]]:
 | ~L~          | next sibling                                                           |
 | ~R~          | make a directory the root directory                                    |
 
-*Note*: The point is automatically set to the first letter of a node for a
-smoother experience.
+*Note*: Point is automatically set to the first letter of a node for a smoother
+experience.
 
 **** Opening files with NeoTree
 By default a file is opened in the last active window. It is possible to choose
@@ -2321,7 +2321,7 @@ state=:
   - ~ai~ - Above and Indentation: ~ii~ + the line above with a different indentation
   - ~aI~ - Above and Indentation+: ~ai~ + the line below with a different indentation
 
-Example (=|= is the point):
+Example (=|= indicates point):
 
 #+BEGIN_SRC emacs-lisp
 (while (not done)

--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -104,7 +104,7 @@ than this amount.")
       (&optional tools use-initial-input initial-directory)
     "Search using the first available tool in TOOLS. Default tool
 to try is grep. If INPUT is non nil, use the region or the symbol
-at the point as the initial input. If DIR is non nil start in
+around point as the initial input. If DIR is non nil start in
 that directory."
     (interactive)
     (require 'counsel)
@@ -164,7 +164,7 @@ that directory."
                                tool-name)) ()
          ,(format
            "Use `spacemacs/counsel-search' to search for
- the selected region or the symbol under the point in the current
+ the selected region or the symbol around point in the current
  directory with %s." (if (string= tool-name "auto")
                          "a tool selected from `dotspacemacs-search-tools'."
                        tool-name))
@@ -182,7 +182,7 @@ that directory."
                                tool-name)) ()
          ,(format
            "Use `spacemacs/counsel-search' to search for
- the selected region or the symbol under the point in the current
+ the selected region or the symbol around point in the current
  project with %s." (if (string= tool-name "auto")
                        "a tool selected from `dotspacemacs-search-tools'."
                      tool-name))
@@ -197,7 +197,7 @@ that directory."
 
   (defun spacemacs/counsel-git-grep-region-or-symbol ()
     "Use `counsel-git-grep' to search for the selected region or
- the symbol under the point in the current project with git grep."
+ the symbol around point in the current project with git grep."
     (let ((input (if (region-active-p)
                      (buffer-substring-no-properties
                       (region-beginning) (region-end))
@@ -376,8 +376,8 @@ Helm hack."
     :config
     (progn
       (defun spacemacs/swiper-region-or-symbol ()
-        "Run `swiper' with the selected region or the symbol under
-the point as the initial input."
+        "Run `swiper' with the selected region or the symbol
+around point as the initial input."
         (interactive)
         (let ((input (if (region-active-p)
                          (buffer-substring-no-properties
@@ -387,7 +387,7 @@ the point as the initial input."
 
       (defun spacemacs/swiper-all-region-or-symbol ()
         "Run `swiper-all' with the selected region or the symbol
-under the point as the initial input."
+around point as the initial input."
         (interactive)
         (ivy-read "Swiper: " (swiper--multi-candidates
                               (cl-remove-if-not

--- a/layers/+distribution/spacemacs/local/centered-cursor/centered-cursor-mode.el
+++ b/layers/+distribution/spacemacs/local/centered-cursor/centered-cursor-mode.el
@@ -332,7 +332,7 @@ the center. Just the variable ccm-vpos is set."
                    (bottom-lines (+ (count-lines (point) (point-max))
                                     correction)))
 
-              ;; only animate if the point was moved rather far away
+              ;; only animate if point was moved rather far away
               ;; before by a mouseclick (see ccm-ignored-commands)
               ;; or if minor mode is just entered interactively
               (if (not (and (> (abs diff) 4)

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -178,8 +178,8 @@ Requires smartparens because all movement is done using
       (call-interactively 'eval-last-sexp)))
 
   (defun spacemacs/eval-current-symbol-sp ()
-    "Call `eval-last-sexp' on the symbol underneath the
-point. Requires smartparens because all movement is done using
+    "Call `eval-last-sexp' on the symbol around point. Requires
+smartparens because all movement is done using
 `sp-forward-symbol'."
     (interactive)
     (require 'smartparens)

--- a/layers/+lang/go/local/go-rename/go-rename.el
+++ b/layers/+lang/go/local/go-rename/go-rename.el
@@ -69,7 +69,7 @@ the `gorename' tool."
             (set-window-point w (point-min)))))))
 
   ;; Reload the modified files, saving line/col.
-  ;; (Don't restore the point since the text has changed.)
+  ;; (Don't restore point since the text has changed.)
   ;;
   ;; TODO(adonovan): should we also do this for all other files
   ;; that were updated (the tool can print them)?

--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -46,8 +46,8 @@ file.
 | ~SPC m s b~ | Send the whole buffer to the SQLi buffer                                                 |
 | ~SPC m s B~ | Send the whole buffer to the SQLi buffer and switch to it in =insert state=              |
 | ~SPC m s i~ | Start the SQLi process                                                                   |
-| ~SPC m s f~ | Send the paragraph under the point to the SQLi buffer                                    |
-| ~SPC m s F~ | Send the paragraph under the point to the SQLi buffer and switch to it in =insert state= |
+| ~SPC m s f~ | Send the paragraph around point to the SQLi buffer                              |
+| ~SPC m s F~ | Send the paragraph around point to the SQLi buffer and switch to it in =insert state= |
 | ~SPC m s q~ | Prompt for a string to send to the SQLi buffer                                           |
 | ~SPC m s Q~ | Prompt for a string to send to the SQLi buffer and switch to it in =insert state=        |
 | ~SPC m s r~ | Send the selected region to the SQLi buffer                                              |

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -91,7 +91,7 @@
         "si" 'spacemacs/sql-start
         ;; paragraph gets "f" here because they can be assimilated to functions.
         ;; If you separate your commands in a SQL file, this key will send the
-        ;; command under the point, which is what you probably want.
+        ;; command around point, which is what you probably want.
         "sf" 'sql-send-paragraph
         "sF" 'spacemacs/sql-send-paragraph-and-focus
         "sq" 'sql-send-string

--- a/layers/shell/README.org
+++ b/layers/shell/README.org
@@ -83,12 +83,11 @@ ease of use of modern day shells, and the review-before-you-proceed
 mentality of Plan 9's 9term.
 #+END_QUOTE
 
-In a nutshell, when =em-smart= is enabled the point won't jump at the
-end of the buffer when a command is executed, it will stay at the
-same command prompt used to execute the command. This allows to quickly
-edit the last command in the case of a mistake. If there is no mistake
-and you directly type a new command then the prompt will jump to the
-next prompt at the end of the buffer.
+In a nutshell, when =em-smart= is enabled point won't jump at the end of the
+buffer when a command is executed, it will stay at the same command prompt used
+to execute the command. This allows to quickly edit the last command in the case
+of a mistake. If there is no mistake and you directly type a new command then
+the prompt will jump to the next prompt at the end of the buffer.
 
 To enable =em-smart= put the following layer variable to non-nil:
 

--- a/layers/shell/packages.el
+++ b/layers/shell/packages.el
@@ -113,7 +113,7 @@ is achieved by adding the relevant text properties."
         (if (bound-and-true-p linum-mode) (linum-mode -1))
         (unless shell-enable-smart-eshell
           ;; we don't want auto-jump to prompt when smart eshell is enabled.
-          ;; Idea: maybe we could make auto-jump smarter and jump only if the
+          ;; Idea: maybe we could make auto-jump smarter and jump only if
           ;; point is not on a prompt line
           (add-hook 'evil-insert-state-entry-hook
                     'spacemacs//eshell-auto-end nil t))


### PR DESCRIPTION
Point is a proper name when it refers to the current editing location.
Moreover, point designates a place *between* two characters (or before the first
character, or after the last character), rather than a particular character.

References:

* http://lists.gnu.org/archive/html/emacs-devel/2008-10/msg00414.html
* https://www.gnu.org/software/emacs/manual/html_node/elisp/Point.html#index-point