### PR TITLE
include quickfix bindings from unimpaired

### DIFF
--- a/layers/+distribution/spacemacs/packages.el
+++ b/layers/+distribution/spacemacs/packages.el
@@ -783,6 +783,8 @@
   (define-key evil-normal-state-map (kbd "] f") 'evil-unimpaired/next-file)
   (define-key evil-normal-state-map (kbd "] l") 'spacemacs/next-error)
   (define-key evil-normal-state-map (kbd "[ l") 'spacemacs/previous-error)
+  (define-key evil-normal-state-map (kbd "] q") 'spacemacs/next-error)
+  (define-key evil-normal-state-map (kbd "[ q") 'spacemacs/previous-error)
   (define-key evil-normal-state-map (kbd "[ h") 'diff-hl-previous-hunk)
   (define-key evil-normal-state-map (kbd "] h") 'diff-hl-next-hunk)
   (define-key evil-normal-state-map (kbd "[ t") 'evil-unimpaired/previous-frame)


### PR DESCRIPTION
vim has a quickfix and location list, while emacs only has compilation-mode to serve both usages.  plugins like ag.vim and ack.vim will populate the quickfix list, so the corresponding quickfix bindings should be included by default.