### PR TITLE
substitute align-cljlet with clojure-align

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -39,7 +39,7 @@ This layer adds support for [[http://clojure.org][Clojure]] language using [[htt
 - REPL via [[https://github.com/clojure-emacs/cider][CIDER]]
 - Code formatting via [[https://github.com/clojure-emacs/cider][CIDER]] using [[https://github.com/weavejester/cljfmt][Cljfmt]] 
 - Refactoring via [[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]]
-- Aligning of code forms via [[https://github.com/gstamp/align-cljlet][align-cljlet]]
+- Aligning of code forms via [[https://github.com/clojure-emacs/clojure-mode][clojure-mode]]
   
 * Install
 ** Layer
@@ -231,20 +231,6 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m r u w~ | unwind                      |
 
 *** Reformatting
-Forms currently handled:
-  - let
-  - when-let
-  - if-let
-  - binding
-  - loop
-  - with-open
-  - literal hashes {}
-  - defroute
-  - cond
-  - condp (except :>> subforms)
-  
-More info at [[https://github.com/gstamp/align-cljlet][align-cljlet]].
-
 | Key Binding | Description             |
 |-------------+-------------------------|
 | ~SPC m f l~ | realign current form    |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -1,6 +1,5 @@
 (setq clojure-packages
   '(
-    align-cljlet
     cider
     cider-eval-sexp-fu
     clj-refactor
@@ -11,15 +10,6 @@
     subword
    ))
 
-(defun clojure/init-align-cljlet ()
-  (use-package align-cljlet
-    :defer t
-    :init
-    (add-hook 'clojure-mode-hook (lambda () (require 'align-cljlet)))
-    :config
-    (dolist (mode '(clojure-mode clojurescript-mode))
-      (spacemacs/set-leader-keys-for-major-mode mode
-        "fl" 'align-cljlet))))
 
 (defun clojure/init-cider ()
   (use-package cider
@@ -355,7 +345,8 @@ If called with a prefix argument, uses the other-window instead."
 
       (dolist (m '(clojure-mode clojurec-mode clojurescript-mode clojurex-mode))
         (spacemacs/set-leader-keys-for-major-mode m
-          "Ti" 'spacemacs/clojure-mode-toggle-default-indent-style))
+          "Ti" 'spacemacs/clojure-mode-toggle-default-indent-style
+          "fl" 'clojure-align))
 
       (when clojure-enable-fancify-symbols
         (dolist (m '(clojure-mode clojurescript-mode clojurec-mode clojurex-mode))


### PR DESCRIPTION
`align-cljlet` was deprecated in favour of the vertical alignment in the
`clojure-mode` package.

This is documented on the [`ailgn-cljlet` homepage](https://github.com/gstamp/align-cljlet)