### PR TITLE
Register ESS repl bindings in spacemacs-repl-list.

### DIFF
--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -53,7 +53,11 @@
     :init
     (progn
       (when (configuration-layer/package-usedp 'company)
-          (add-hook 'ess-mode-hook 'company-mode))))
+        (add-hook 'ess-mode-hook 'company-mode))
+      (spacemacs/register-repl 'ess-site 'R)
+      (spacemacs/register-repl 'ess-site 'stata)
+      (spacemacs/register-repl 'ess-site 'SAS)
+      (spacemacs/register-repl 'ess-site 'julia)))
 
   ;; R --------------------------------------------------------------------------
   (with-eval-after-load 'ess-site


### PR DESCRIPTION
Following up on https://github.com/syl20bnr/spacemacs/pull/4600 by registering ESS REPL's in `spacemacs-repl-list`. This allows for starting inferior R, Stata, Julia, and SAS processes via `SPC a '` (`helm-available-repls`).