### PR TITLE
ERC terminal notifier

### DIFF
--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -214,7 +214,9 @@
   (use-package erc-image
     :init (with-eval-after-load 'erc (add-to-list 'erc-modules 'image))))
 
-(defun erc/init-erc-terminal-notifier ())
+(defun erc/init-erc-terminal-notifier ()
+  (use-package erc-terminal-notifier
+    :if (executable-find "terminal-notifier")))
 
 (defun erc/post-init-persp-mode ()
   (spacemacs|define-custom-layout "@ERC"


### PR DESCRIPTION
`use-package` wasn't being used in `erc/init-erc-terminal-notifier`. Now I get notifications.

Two things:

a) Should this be really part of the `erc` layer instead of `osx`? In the end the result would be the same  in both ways, of course, but `osx` makes more sense to me. (edit: never mind, `erc` makes more sense indeed)
b) I don't understand why this doesn't trigger any error  when `terminal-notifier` isn't installed, but it really doesn't. Why? (edit: as nixmaniack suggested, I added an `if` on the `use-package` line checking for the executable).