### PR TITLE
Add mu4-alert Package to emails mu4e Layer

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -8,6 +8,7 @@
    - [[Maildirs extension][Maildirs extension]]
    - [[Multiple Accounts][Multiple Accounts]]
    - [[Example configuration][Example configuration]]
+   - [[Notifications][Notifications]]
  - [[See also][See also]]
 
 * Install
@@ -115,6 +116,44 @@ the given account variables.
                         mu4e-maildir-shortcuts) " OR ")
            "All inboxes" ?i)))
 #+END_SRC
+
+** Notifications
+~mu4e-alert~ is an extension that provides desktop notifications and adds the
+count of unread messages to the modeline.
+
+[[https://raw.githubusercontent.com/iqbalansari/mu4e-alert/master/screenshots/mu4e-alert-in-action.png]]
+
+To enable notifications about new messages, add the following line to your
+~dotspacemacs/user-config~:
+
+#+BEGIN_SRC emacs-lisp
+  (setq mu4e-enable-notifications t)
+#+END_SRC
+
+By default, notifications will be shown in the ~*Messages*~ buffer. To enable
+desktop notifications about new messages, add the following lines to
+your ~dotspacemacs/user-config~, according to your operating system and the
+installed libraries:
+
+#+BEGIN_SRC emacs-lisp
+  (with-eval-after-load 'mu4e-alert
+    ;; Enable Desktop notifications
+    (mu4e-alert-set-default-style 'notifications)) ; For linux
+    ;; (mu4e-alert-set-default-style 'libnotify))  ; Alternative for linux
+    ;; (mu4e-alert-set-default-style 'notifier))   ; For Mac OSX (through the
+                                                   ; terminal notifier app)
+    ;; (mu4e-alert-set-default-style 'growl))      ; Alternative for Mac OSX
+#+END_SRC
+
+To enable modeline display about new messages, add the following line to
+your ~dotspacemacs/user-config~:
+
+#+BEGIN_SRC emacs-lisp
+  (setq mu4e-enable-mode-line t)
+#+END_SRC
+
+For an extended documentation of the available customizations please refer to
+[[https://github.com/iqbalansari/mu4e-alert#customizations][mu4e-alert's documentation]]
 
 * See also
 Refer to the official mu and mu4e documentation for additional info.

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -15,5 +15,11 @@
 (defvar mu4e-account-alist nil
   "Account alist for custom multi-account compose.")
 
+(defvar mu4e-enable-notifications nil
+  "If non-nil, enable desktop notifications for unread emails.")
+
+(defvar mu4e-enable-mode-line nil
+  "If non-nil, enable display of unread emails in mode-line.")
+
 (when mu4e-installation-path
   (push mu4e-installation-path load-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -12,6 +12,7 @@
 (setq mu4e-packages
       '(
         (mu4e :skip-install t)
+        mu4e-alert
         mu4e-maildirs-extension
         org
         ))
@@ -45,6 +46,17 @@
       (when mu4e-account-alist
         (add-hook 'mu4e-compose-pre-hook 'mu4e/set-account)
         (add-hook 'message-sent-hook 'mu4e/mail-account-reset)))))
+
+(defun mu4e/init-mu4e-alert ()
+  (use-package mu4e-alert
+    :defer t
+    :init
+    (progn
+      (with-eval-after-load 'mu4e
+        (when mu4e-enable-notifications
+          (mu4e-alert-enable-notifications))
+        (when mu4e-enable-mode-line
+          (mu4e-alert-enable-mode-line-display))))))
 
 (defun mu4e/init-mu4e-maildirs-extension ()
   (use-package mu4e-maildirs-extension


### PR DESCRIPTION
mu4e-alert is an extension that provides desktop notifications and adds
the count of unread messages to the modeline.