### PR TITLE
Ensure that `pcache-directory` ends in a slash

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -46,7 +46,7 @@
   (expand-file-name "~/")
   "User home directory (~/).")
 (defconst pcache-directory
-  (concat spacemacs-cache-directory "pcache"))
+  (concat spacemacs-cache-directory "pcache/"))
 (unless (file-exists-p spacemacs-cache-directory)
     (make-directory spacemacs-cache-directory))
 


### PR DESCRIPTION
Otherwise, `pcache` doesn't seem to function, at least in the case of `unicode-fonts`; see https://github.com/rolandwalker/unicode-fonts/issues/20.