### PR TITLE
Obey rust-mode indent setting.

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -189,6 +189,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
     (perl-mode . perl-indent-level)
     (puppet-mode . puppet-indent-level)
     (ruby-mode . ruby-indent-level)
+    (rust-mode . rust-indent-offset)
     (scala-mode . scala-indent:step)
     (sgml-mode . sgml-basic-offset)
     (sh-mode . sh-basic-offset)


### PR DESCRIPTION
Also, why aren't these defined in their respective layers?