### PR TITLE
support package archive on local disk

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -243,7 +243,8 @@ refreshed during the current session."
                                     "\nError while contacting %s repository!"
                                     (car archive)))
                                   'error))
-                             (url-retrieve-synchronously (cdr archive))))
+                             (or (file-directory-p (cdr archive))
+                                 (url-retrieve-synchronously (cdr archive)))))
           (let ((package-archives (list archive)))
             (package-refresh-contents))))
       (package-read-all-archive-contents)

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -243,7 +243,8 @@ refreshed during the current session."
                                     "\nError while contacting %s repository!"
                                     (car archive)))
                                   'error))
-                             (or (file-directory-p (cdr archive))
+                             ;; Check for local file system path
+                             (or (null (url-host (url-generic-parse-url (cdr archive))))
                                  (url-retrieve-synchronously (cdr archive)))))
           (let ((package-archives (list archive)))
             (package-refresh-contents))))


### PR DESCRIPTION
This change avoids error that would result if package archives are located on local disk, i.e., if package-archives specifies local directories rather than URLs.

Without this change I'm forced to URL such as http://localhost/.
Yes this avoids internet access if URL points to a host on local intranet.
However using local disk rather than URL is much much faster.
