### PR TITLE
Google translate refactor

### DIFF
--- a/layers/+spacemacs/spacemacs-language/packages-config.el
+++ b/layers/+spacemacs/spacemacs-language/packages-config.el
@@ -1,0 +1,29 @@
+;;; packages-config.el --- Spacemacs Language Layer packages File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs-language/init-define-word ()
+  (use-package define-word
+    :defer t
+    :init
+    (spacemacs/set-leader-keys
+      "xwd" 'define-word-at-point)))
+
+(defun spacemacs-language/init-google-translate ()
+  (use-package google-translate
+    :init
+    (progn
+      (spacemacs/set-leader-keys
+        "xgl" 'spacemacs/set-google-translate-languages
+        "xgQ" 'google-translate-query-translate-reverse
+        "xgq" 'google-translate-query-translate
+        "xgT" 'google-translate-at-point-reverse
+        "xgt" 'google-translate-at-point))
+    ))

--- a/layers/+spacemacs/spacemacs-language/packages-funcs.el
+++ b/layers/+spacemacs/spacemacs-language/packages-funcs.el
@@ -1,0 +1,22 @@
+;;; packages.el --- Spacemacs Language Layer packages File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs-language/set-google-translate-languages (source target)
+  "Set source language for google translate.
+For instance pass En as source for English."
+  (interactive
+   "sEnter source language (ie. en): \nsEnter target language (ie. fr): "
+   source target)
+  (message
+   (format "Set google translate source language to %s and target to %s"
+           source target))
+  (setq google-translate-default-source-language (downcase source))
+  (setq google-translate-default-target-language (downcase target)))

--- a/layers/+spacemacs/spacemacs-language/packages.el
+++ b/layers/+spacemacs/spacemacs-language/packages.el
@@ -12,36 +12,3 @@
 (setq spacemacs-language-packages
       '(define-word
         google-translate))
-
-(defun spacemacs-language/init-define-word ()
-  (use-package define-word
-    :defer t
-    :init
-    (spacemacs/set-leader-keys
-      "xwd" 'define-word-at-point)))
-
-(defun spacemacs/init-google-translate ()
-  (use-package google-translate
-    :init
-    (progn
-      (defun spacemacs/set-google-translate-languages (source target)
-        "Set source language for google translate.
-For instance pass En as source for English."
-        (interactive
-         "sEnter source language (ie. en): \nsEnter target language (ie. en): "
-         source target)
-        (message
-         (format "Set google translate source language to %s and target to %s"
-                 source target))
-        (setq google-translate-default-source-language (downcase source))
-        (setq google-translate-default-target-language (downcase target)))
-      (spacemacs/set-leader-keys
-        "xgl" 'spacemacs/set-google-translate-languages
-        "xgQ" 'google-translate-query-translate-reverse
-        "xgq" 'google-translate-query-translate
-        "xgT" 'google-translate-at-point-reverse
-        "xgt" 'google-translate-at-point))
-      (setq google-translate-enable-ido-completion t)
-      (setq google-translate-show-phonetic t)
-      (setq google-translate-default-source-language "en")
-      (setq google-translate-default-target-language "fr")))


### PR DESCRIPTION
google-translate refactoring
- Suit spacemacs-language layer to new layout
- Don't explicitly list commands (they are autoloaded)
- Move xgl binding from keybindings.el
- Don't explicitly require the default-ui feature (not necessary)
- Set variables in init instead of config (easier to change for users)

Credits to @TheBB for initial PR #4829 
Fixes #4827.
