### PR TITLE
auto-complete: Better binding for hippie-expand

### DIFF
--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -168,8 +168,7 @@
 (defun auto-completion/init-hippie-exp ()
   ;; replace dabbrev-expand
   (global-set-key (kbd "M-/") 'hippie-expand)
-  (when (eq dotspacemacs-editing-style 'vim)
-    (define-key evil-insert-state-map (kbd "C-p") 'hippie-expand))
+  (define-key evil-insert-state-map [remap evil-complete-previous] 'hippie-expand)
   (setq hippie-expand-try-functions-list
         '(
           ;; Try to expand word "dynamically", searching the current buffer.


### PR DESCRIPTION
Using a remap is better, because it will "automatically toggle" the key
binding if hybrid-mode is toggled.

The previous version just disabled the key binding completely if someone
used hybrid style.

@TheBB  this is a small improvement on @nixmaniack's last commit. 