### PR TITLE
Remove `gnus-fetch-old-headers` customization

### DIFF
--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -48,7 +48,6 @@
        gnus-sum-thread-tree-single-leaf "╰► "
        gnus-sum-thread-tree-vertical "│"
        gnus-article-browse-delete-temp t
-       gnus-fetch-old-headers t
        gnus-treat-strip-trailing-blank-lines 'last
        gnus-keep-backlog 'nil
        gnus-summary-display-arrow nil ; Don't show that annoying arrow:


### PR DESCRIPTION
Fix #1331

@andreas-h @amardeep (and maybe @cpaulik) You are the only users of `gnus` that I know. Do you agree on this consensus, discussed in the cited issue?