### PR TITLE
mu4e: keymap yank and view mode changes

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -4,6 +4,9 @@
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Install][Install]]
  - [[Commands][Commands]]
+   - [[Global bindings][Global bindings]]
+   - [[Headers mode][Headers mode]]
+   - [[View mode][View mode]]
  - [[Configuration][Configuration]]
    - [[Multiple Accounts][Multiple Accounts]]
    - [[Example configuration][Example configuration]]
@@ -27,9 +30,24 @@ existing =mu4e= list in this file.
 
 * Commands
 
+** Global bindings
+
 | Keybinding | Command    |
 |------------+------------|
 | SPC a M    | Start mu4e |
+
+** Headers mode
+
+| Keybinding | Command                |
+|------------+------------------------|
+| Y          | Select other mu4e view |
+
+** View mode
+
+| Keybinding | Command                 |
+|------------+-------------------------|
+| Y          | Select other mu4e view  |
+| V          | Toggle visual line mode |
 
 * Configuration
 Configuration varies too much to give precise instructions.  What follows is one

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -26,9 +26,20 @@
         :bindings
         (kbd "j") 'mu4e~headers-jump-to-maildir)
       (evilified-state-evilify-map mu4e-headers-mode-map
-        :mode mu4e-headers-mode)
+        :mode mu4e-headers-mode
+        :bindings
+        (kbd "Y") 'mu4e-select-other-view
+        (kbd "y") 'evil-yank)
       (evilified-state-evilify-map mu4e-view-mode-map
-        :mode mu4e-view-mode)
+        :mode mu4e-view-mode
+        :bindings
+        (kbd "Y") 'mu4e-select-other-view
+        (kbd "y") 'evil-yank
+        (kbd "w") 'evil-forward-word-begin
+        (kbd "V") 'visual-line-mode
+        (kbd "e") 'evil-forward-word-end
+        (kbd "{") 'evil-backward-paragraph
+        (kbd "}") 'evil-forward-paragraph)
 
       (setq mu4e-completing-read-function 'helm--completing-read-default)
 


### PR DESCRIPTION
See the mu4e/README.org changes for the changes. This PR is a bit half-baked since I have some open questions:

First, I was going for normal evil nav bindings in mu4e's view mode -- I personally like being able navigate around an email's text, searching and yanking as I like. However, this would alter the default `mu4e-view-mode-map` bindings (see the changes for some examples). Is this preferred? Is there a better way than explicitly setting every binding in `evilified-state-evilify-map`?

If we do change the view mode bindings, the conflicting [mu4e specific view bindings](https://github.com/djcb/mu/blob/master/mu4e/mu4e-view.el#L543) should be rearranged to use the leader keybindings, e.g. <kbd>\<SPC> m e</kbd> for `mu4e-view-save-attachment`.

Keybinding documentation layout is based off of #3922 