### PR TITLE
Enable emmet-mode in sass and scss modes.

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -84,6 +84,8 @@
     :defer t
     :init (spacemacs/add-to-hooks 'emmet-mode '(css-mode-hook
                                                 html-mode-hook
+                                                sass-mode-hook
+                                                scss-mode-hook
                                                 web-mode-hook))
     :config
     (progn


### PR DESCRIPTION
emmet-mode handles detecting the major-mode and inserting the correct expansion for the major-mode automatically.