### PR TITLE
Fix `0` as prefix arg in paste transient state

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -341,6 +341,18 @@ Example: (evil-map visual \"<\" \"<gv\")"
         "n>" 'spacemacs/scroll-transient-state/spacemacs/scroll-half-page-down)
 
       ;; pasting transient-state
+      (evil-define-command spacemacs//transient-state-0 ()
+        :keep-visual t
+        :repeat nil
+        (interactive)
+        (if current-prefix-arg
+            (progn
+              (setq this-command #'digit-argument)
+              (call-interactively #'digit-argument))
+          (setq this-command #'evil-beginning-of-line
+                hydra-deactivate t)
+          (call-interactively #'evil-beginning-of-line)))
+
       (spacemacs|define-transient-state paste
         :title "Pasting Transient State"
         :doc "\n[%s(length kill-ring-yank-pointer)/%s(length kill-ring)] \
@@ -350,7 +362,8 @@ below. Anything else exits."
         ("J" evil-paste-pop)
         ("K" evil-paste-pop-next)
         ("p" evil-paste-after)
-        ("P" evil-paste-before))
+        ("P" evil-paste-before)
+        ("0" spacemacs//transient-state-0))
       (when dotspacemacs-enable-paste-transient-state
         (define-key evil-normal-state-map "p" 'spacemacs/paste-transient-state/evil-paste-after)
         (define-key evil-normal-state-map "P" 'spacemacs/paste-transient-state/evil-paste-before))


### PR DESCRIPTION
When in paste-transient-state, 0 won't exit the transient state and so
it won't take the point to the beginning of line.

I don't know if this is the best idiomatic way to do it @justbur .

Fix #4930 