### PR TITLE
persp-mode: switch back to melpa

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -9,11 +9,7 @@
 ;;
 ;;; License: GPLv3
 (setq spacemacs-layouts-packages
-      '(;; temporary switch on a fork to fix
-        ;; https://github.com/syl20bnr/spacemacs/issues/4120
-        (persp-mode :location (recipe :fetcher github
-                                      :repo "syl20bnr/persp-mode.el"
-                                      :branch "fix-emacsclient-crash"))
+      '(persp-mode
         spaceline
         eyebrowse
         helm


### PR DESCRIPTION
I don't understand the problem that caused us to switch to a fork, but the switch was supposed to be temporary and the problem is claimed to be fixed upstream. In the meantime there were a few more commits upstream, so let's switch back.
I didn't experience any errors switching back to upstream, but I haven't tested thoroughly either.

Refs:
https://github.com/Bad-ptr/persp-mode.el/pull/25
https://github.com/syl20bnr/spacemacs/issues/4120