### PR TITLE
Fix name of google-translate's init function

### DIFF
--- a/layers/+spacemacs/spacemacs-language/packages.el
+++ b/layers/+spacemacs/spacemacs-language/packages.el
@@ -20,7 +20,7 @@
     (spacemacs/set-leader-keys
       "xwd" 'define-word-at-point)))
 
-(defun spacemacs/init-google-translate ()
+(defun spacemacs-language/init-google-translate ()
   (use-package google-translate
     :init
     (progn


### PR DESCRIPTION
`spacemacs/init-google-translate` should be `spacemacs-language/init-google-translate`, `google-translate` is not loaded because of this.