### PR TITLE
Switch project layout: rename buffer

### DIFF
--- a/layers/+window-management/spacemacs-layouts/funcs.el
+++ b/layers/+window-management/spacemacs-layouts/funcs.el
@@ -115,7 +115,7 @@ perspectives does."
                     (persp-switch project)
                     (let ((projectile-completion-system 'helm))
                       (projectile-switch-project-by-name project)))))))
-   :buffer "*Projectile Layouts*"))
+   :buffer "*Helm Projectile Layouts*"))
 
 (defun spacemacs/ivy-persp-switch-project (arg)
   (interactive "P")


### PR DESCRIPTION
Rename "\*Projectile Layouts\*" (helm buffer for `SPC p l`) to start with "\*Helm" like the other helm buffers.
Helm buffers normally have names that start with "\*helm" or "\*Helm", that's how they can be (progrematicaly) identified as helm buffers. One real impact is that [`window-purpose`](https://github.com/syl20bnr/spacemacs/pull/1958) won't identify it as a helm buffer and will display it in a wrong window.

cc @nixmaniack