### PR TITLE
Disable company-quickhelp-mode only when it is already enabled

### DIFF
--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -16,7 +16,8 @@
   ;; company-quickhelp calls it. Note hook is appendended for proper ordering.
   (add-hook 'company-mode-hook
             '(lambda ()
-               (when (equal major-mode 'racket-mode)
+               (when (and (equal major-mode 'racket-mode)
+                          (bound-and-true-p company-quickhelp-mode))
                  (company-quickhelp-mode -1))) t))
 
 (defun racket/init-racket-mode ()


### PR DESCRIPTION
This is related to #4945.
CC: @hujianxin @greghendershott

`(company-quickhelp-mode -1)` restores `company-tooltip-minimum-width` value, but when `company-quickhelp-mode` is never enabled,  `company-tooltip-minimum-width` is set `nil`. Its type must be integer, so #4945 error is raised. I think this issue is reproduced only on `emacs -nw`,  `company-quickhelp-mode` is not enabled on `emacs -nw`