### PR TITLE
prevent auto-highlight-symbol from setting up its own default map

### DIFF
--- a/layers/+distribution/spacemacs/packages-backup.el
+++ b/layers/+distribution/spacemacs/packages-backup.el
@@ -177,6 +177,9 @@
             ahs-idle-interval 0.25
             ahs-inhibit-face-list nil)
 
+      ;; since we are creating our our maps, prevent the default keymap from getting created
+      (setq auto-highlight-symbol-mode-map (make-sparse-keymap))
+
       (spacemacs|add-toggle automatic-symbol-highlight
         :status (timerp ahs-idle-timer)
         :on (progn


### PR DESCRIPTION
when `auto-highlight-symbol` activates, it sets up `M-S-<left>` and `M-S-<right>` as keybindings, which is a big no-no for anyone that uses org-mode.

since spacemacs already sets up the microstate, it's harmless to disable the original.