### PR TITLE
Fix wakatime-dashboard url

### DIFF
--- a/layers/+tools/wakatime/packages.el
+++ b/layers/+tools/wakatime/packages.el
@@ -8,6 +8,6 @@
     :config
     (defun spacemacs/wakatime-dashboard ()
       (interactive)
-      (browse-url "wakatime.com/dashboard"))
+      (browse-url "https://wakatime.com/dashboard"))
     (spacemacs/set-leader-keys
       "aW" 'spacemacs/wakatime-dashboard)))


### PR DESCRIPTION
Fixing an odd navigation problem with wakatime-dashboard not opening a browser window due to a lack of "https://" qualifying the url