### PR TITLE
Add files used by eww to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,14 @@ eproject.lst
 \#*
 .places
 .cache
+/eww-bookmarks
 eshell/history
 .emacs.desktop
 .emacs.desktop.lock
 eshell/alias
 eshell/lastdir
 /url/cookies
+/url/cache
 my-org/
 org-files/
 semanticdb/
@@ -33,6 +35,7 @@ tmp/
 /history
 .python-environments/
 server/
+/network-security.data
 *~
 *.elc
 *.pyc


### PR DESCRIPTION
I realize that eww support in spacemacs is still not done, but at least using eww files should be in .gitignore. This is that fix (although it's possible this does not include every kind of eww file).
