### PR TITLE
[command-log] fix readme css path

### DIFF
--- a/layers/+tools/command-log/README.org
+++ b/layers/+tools/command-log/README.org
@@ -1,5 +1,5 @@
 #+TITLE: command-log layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                        :TOC_4_org:noexport:
  - [[Description][Description]]


### PR DESCRIPTION
Current command-log layer isn't showing custom css.
LHS (without) - RHS (with css)
![image](https://cloud.githubusercontent.com/assets/12563308/12865057/40d08b4a-cc56-11e5-8383-5ead7411a273.png)