### PR TITLE
[RIP] hide org meta when using `SPC` `h` `SPC`

### DIFF
--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -290,6 +290,51 @@ Will work on both org-mode and any mode that accepts plain html."
       (spacemacs/set-leader-keys
         "Cc" 'org-capture)
 
+      (defvar spacemacs--org-hide-docs-meta-tags-p nil)
+
+      (defun spacemacs//org-hide-docs-meta-tags ()
+        "Hide org export tags and annotations."
+        (unless spacemacs--org-hide-docs-meta-tags-p
+          (progn
+            (setq spacemacs--org-hide-docs-meta-tags-p t)
+
+            (defvar spacemacs--org-tag-f-o
+              (face-attribute 'org-tag :foreground))
+            (defvar spacemacs--org-meta-line-f-o
+              (face-attribute 'org-meta-line :foreground))
+            (defvar spacemacs--org-block-begin-line-f-o
+              (face-attribute 'org-block-begin-line :foreground))
+            (defvar spacemacs--org-document-info-keyword-f-o
+              (face-attribute 'org-document-info-keyword :foreground))
+
+            (let ((bg (face-attribute 'default :background)))
+              (set-face-attribute 'org-tag                   nil :foreground bg)
+              (set-face-attribute 'org-meta-line             nil :foreground bg)
+              (set-face-attribute 'org-block-begin-line      nil :foreground bg)
+              (set-face-attribute 'org-document-info-keyword nil :foreground bg)))))
+
+      (defun spacemacs//org-unhide-docs-meta-tags ()
+        "Unhide org export tags and annotations."
+        (when spacemacs--org-hide-docs-meta-tags-p
+          (progn
+            (setq spacemacs--org-hide-docs-meta-tags-p nil)
+
+            (set-face-attribute 'org-tag                   nil :foreground spacemacs--org-tag-f-o)
+            (set-face-attribute 'org-meta-line             nil :foreground spacemacs--org-meta-line-f-o)
+            (set-face-attribute 'org-block-begin-line      nil :foreground spacemacs--org-block-begin-line-f-o) 
+            (set-face-attribute 'org-document-info-keyword nil :foreground spacemacs--org-document-info-keyword-f-o))))
+
+      (defun spacemacs//org-toggle-docs-meta-tags-hook ()
+        "Make `org-mode' meta tags transparent when viewing README.org
+        files for layers with `view-mode' enabled."
+        (if (and
+             (string-match (concat (expand-file-name "~") "/.emacs.d/layers/.*README\.org")  buffer-file-name)
+             (boundp 'view-mode))
+            (spacemacs//org-hide-docs-meta-tags)
+          (spacemacs//org-unhide-docs-meta-tags)))
+
+      (add-hook 'org-mode-hook 'spacemacs//org-toggle-docs-meta-tags-hook)
+
       ;; Evilify the calendar tool on C-c .
       (unless (eq 'emacs dotspacemacs-editing-style)
         (define-key org-read-date-minibuffer-local-map (kbd "M-h")

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -327,11 +327,9 @@ Will work on both org-mode and any mode that accepts plain html."
       (defun spacemacs//org-toggle-docs-meta-tags-hook ()
         "Make `org-mode' meta tags transparent when viewing README.org
         files for layers with `view-mode' enabled."
-        (if (and
-             (string-match (concat (expand-file-name "~") "/.emacs.d/layers/.*README\.org")  buffer-file-name)
-             (boundp 'view-mode))
+        (if (bound-and-true-p view-mode)
             (spacemacs//org-hide-docs-meta-tags)
-          (spacemacs//org-unhide-docs-meta-tags)))
+            (spacemacs//org-unhide-docs-meta-tags)))
 
       (add-hook 'org-mode-hook 'spacemacs//org-toggle-docs-meta-tags-hook)
 


### PR DESCRIPTION
I reworked #4981 from scratch.

PROS compered to the old PR:
  - Doesn't requires Emacs version "24.4".
  - Intelligently hides lines instead of exact match.
  - You still can select hidden lines if you want.
  - Less code smell = happy :nose:  (it's a nose).
  - Can be disabled.
  - Doesn't do stuff if there is nothing to do.  

CONS:
  - A bit more complicated.
  - Proper global state management might require extra hookery.  (So far looks good)

*I found it rather neat to have. So I removed all the :hankey: added some more and created this brand new PR.*