### PR TITLE
Add missing keybindings to rspec-mode in ruby layer

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -128,17 +128,19 @@ directory local variables.
 *** RSpec-mode
 When =ruby-test-runner= equals =rspec=.
 
-| Key binding | Description                                   |
-|-------------+-----------------------------------------------|
-| ~SPC m t a~ | run all specs                                 |
-| ~SPC m t b~ | run current spec file                         |
-| ~SPC m t c~ | run the current spec file and subsequent ones |
-| ~SPC m t e~ | mark example as pending                       |
-| ~SPC m t f~ | run method                                    |
-| ~SPC m t l~ | run last failed spec                          |
-| ~SPC m t m~ | run specs related to the current buffer       |
-| ~SPC m t r~ | re-run last spec                              |
-| ~SPC m t t~ | run spec at pointer                           |
+| Key binding   | Description                                            |
+|---------------+--------------------------------------------------------|
+| ~SPC m t a~   | run all specs                                          |
+| ~SPC m t b~   | run current spec file                                  |
+| ~SPC m t c~   | run the current spec file and subsequent ones          |
+| ~SPC m t e~   | mark example as pending                                |
+| ~SPC m t f~   | run method                                             |
+| ~SPC m t l~   | run last failed spec                                   |
+| ~SPC m t m~   | run specs related to the current buffer                |
+| ~SPC m t r~   | re-run last spec                                       |
+| ~SPC m t t~   | run spec at pointer                                    |
+| ~SPC m t TAB~ | toggle between spec's and target's buffer              |
+| ~SPC m t ~~   | toggle between spec's and target's buffer find example |
 
 *** Ruby-test-mode
 When =ruby-test-runner= equals =ruby-test=.

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -160,15 +160,17 @@
       (spacemacs|hide-lighter rspec-mode)
       (dolist (mode '(ruby-mode enh-ruby-mode))
         (spacemacs/set-leader-keys-for-major-mode mode
-          "ta" 'rspec-verify-all
-          "tb" 'rspec-verify
-          "tc" 'rspec-verify-continue
-          "te" 'rspec-toggle-example-pendingness
-          "tf" 'rspec-verify-method
-          "tl" 'rspec-run-last-failed
-          "tm" 'rspec-verify-matching
-          "tr" 'rspec-rerun
-          "tt" 'rspec-verify-single)))))
+          "ta"    'rspec-verify-all
+          "tb"    'rspec-verify
+          "tc"    'rspec-verify-continue
+          "te"    'rspec-toggle-example-pendingness
+          "tf"    'rspec-verify-method
+          "tl"    'rspec-run-last-failed
+          "tm"    'rspec-verify-matching
+          "tr"    'rspec-rerun
+          "tt"    'rspec-verify-single
+          "t~"    'rspec-toggle-spec-and-target-find-example
+          "t TAB" 'rspec-toggle-spec-and-target)))))
 
 (defun ruby/init-rubocop ()
   (use-package rubocop


### PR DESCRIPTION
Commands `rspec-toggle-example-pendingness` and
`rspec-toggle-spec-and-target-find-example` were missing.