### PR TITLE
layouts: add funct to switch between open projects

### DIFF
--- a/layers/+window-management/spacemacs-layouts/README.org
+++ b/layers/+window-management/spacemacs-layouts/README.org
@@ -64,7 +64,7 @@ The layouts transient-state is initiated with ~SPC l~.
 
 *** Project Layouts
 To create a layout for a specific project use ~SPC p l~.
-
+To switch between already open projects layouts use ~SPC p L~.
 *** Custom Layouts Transient State
 The layouts transient-state is initiated with ~SPC l o~.
 

--- a/layers/+window-management/spacemacs-layouts/config.el
+++ b/layers/+window-management/spacemacs-layouts/config.el
@@ -20,3 +20,6 @@
 
 (defvar layouts-autosave-delay 900
   "Delay in seconds between each layouts auto-save.")
+
+(defvar layouts-projectile nil
+  "List of projectile open layouts")

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -205,7 +205,10 @@
       (defun spacemacs/layouts-ms-close ()
         "Kill current perspective"
         (interactive)
-        (persp-kill-without-buffers (spacemacs//current-layout-name)))
+        (let ((persp (spacemacs//current-layout-name)))
+          (persp-kill-without-buffers persp)
+          (and (member persp layouts-projectile)
+               (setq layouts-projectile (remove persp layouts-projectile)))))
 
       (defun spacemacs/layouts-ms-close-other ()
         (interactive)
@@ -351,7 +354,8 @@ current perspective."
 
 (defun spacemacs-layouts/post-init-helm ()
   (spacemacs/set-leader-keys
-    "pl" 'spacemacs/helm-persp-switch-project))
+    "pl" 'spacemacs/helm-persp-switch-project
+    "pL" 'spacemacs/helm-persp-switch-open-project))
 
 (defun spacemacs-layouts/post-init-swiper ()
   (defun spacemacs/ivy-persp-switch-project (arg)
@@ -368,4 +372,5 @@ current perspective."
                             (projectile-switch-project-by-name project))))))
 
   (spacemacs/set-leader-keys
-    "pl" 'spacemacs/ivy-persp-switch-project))
+    "pl" 'spacemacs/ivy-persp-switch-project
+    "pL" 'spacemacs/ivy-persp-switch-open-projects))


### PR DESCRIPTION
This will allow a user to switch between already open projects' layouts more easily than looking for the desired project in `SPC p l`. I find this really helpful since I'm working on several projects at a time and it's a pretty common operation for me.

It still has no keybinding because I didn't know where to put, something like `SPC p L` might me nice. When a keybinding is chosen i'll add the proper documentation. It's also missing a helm function that i'll add as soon as i can.

Hope it helps! Any suggestions and corrections welcome.