### PR TITLE
spacemacs-helm: Add `C-c C-e` to switch to wdired

### DIFF
--- a/layers/+completion/spacemacs-helm/keybindings.el
+++ b/layers/+completion/spacemacs-helm/keybindings.el
@@ -27,3 +27,14 @@ Ensure that helm is required before calling FUNC."
 ;; search functions -----------------------------------------------------------
 (spacemacs||set-helm-key "sww" helm-wikipedia-suggest)
 (spacemacs||set-helm-key "swg" helm-google-suggest)
+
+(defun spacemacs-helm//find-files-edit (candidate)
+  (dired (file-name-directory candidate))
+  (dired-goto-file candidate)
+  (dired-toggle-read-only))
+(defun spacemacs-helm/find-files-edit ()
+  "Exits helm, opens a dired buffer and immediately switches to editable mode."
+  (interactive)
+  (helm-exit-and-execute-action 'spacemacs-helm//find-files-edit))
+(with-eval-after-load 'helm
+  (define-key helm-find-files-map (kbd "C-c C-e") 'spacemacs-helm/find-files-edit))


### PR DESCRIPTION
Fixes #3724

This is my first pull request to spacemacs, so please let me know what I can improve. Thanks!

Right now, `helm-ag` has `C-c C-e` built in, a handy way to edit ag results. To do the same from `helm-find-files` requires hitting <kbd>F2 C-x C-q</kbd>. This adds a command to `helm-find-files` at `C-c C-e` to do this for consistency's sake.