### PR TITLE
changed binding `SPC j =` to `SPC x i` for indenting buffer

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2200,6 +2200,7 @@ Text related commands (start with ~x~):
     | ~SPC x g l~ | set languages used by translate commands                      |
     | ~SPC x g t~ | translate current word using Google Translate                 |
     | ~SPC x g T~ | reverse source and target languages                           |
+    | ~SPC x i~   | corrent indentation of region or buffer                       |
     | ~SPC x j c~ | set the justification to center                               |
     | ~SPC x j f~ | set the justification to full                                 |
     | ~SPC x j l~ | set the justification to left                                 |

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -128,7 +128,6 @@
 ;; <SPC> J split the current line at point and indent it
 (spacemacs/set-leader-keys
   "jo" 'open-line
-  "j=" 'spacemacs/indent-region-or-buffer
   "jS" 'spacemacs/split-and-new-line
   "jk" 'spacemacs/evil-goto-next-line-and-indent)
 
@@ -347,6 +346,7 @@
   "xa)" 'spacemacs/align-repeat-right-paren
   "xc"  'count-region
   "xdw" 'delete-trailing-whitespace
+  "xi"  'spacemacs/indent-region-or-buffer
   "xjc" 'set-justification-center
   "xjf" 'set-justification-full
   "xjl" 'set-justification-left


### PR DESCRIPTION
imho it belongs better together with align-\* commands 
rather than with jumps and joins
`x i` for teXt Indent seems also an easier mnemonic
at least for the 'holy' guys
