### PR TITLE
Add org-agenda transient state

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -24,6 +24,8 @@
      - [[Navigating in calendar][Navigating in calendar]]
    - [[Capture buffers and src blocks][Capture buffers and src blocks]]
    - [[Org agenda][Org agenda]]
+     - [[Keybindings][Keybindings]]
+     - [[Org agenda transient state][Org agenda transient state]]
    - [[Pomodoro][Pomodoro]]
    - [[Presentation][Presentation]]
    - [[Org-repo-todo][Org-repo-todo]]
@@ -283,29 +285,105 @@ conventions.
 | ~SPC m r~                                    | org-capture-refile in org-capture-mode |
 
 ** Org agenda
-The evilified org agenda supports, the following bindings:
 
-| Key Binding | Description                   |
-|-------------+-------------------------------|
-| ~SPC m :~   | org-agenda-set-tags           |
-| ~SPC m a~   | org-agenda                    |
-| ~SPC m d~   | org-agenda-deadline           |
-| ~SPC m f~   | org-agenda-set-effort         |
-| ~SPC m I~   | org-agenda-clock-in           |
-| ~SPC m O~   | org-agenda-clock-out          |
-| ~SPC m P~   | org-agenda-set-property       |
-| ~SPC m q~   | org-agenda-refile             |
-| ~SPC m Q~   | org-agenda-clock-cancel       |
-| ~SPC m s~   | org-agenda-schedule           |
-| ~M-j~       | next item                     |
-| ~M-k~       | previous item                 |
-| ~M-h~       | earlier view                  |
-| ~M-l~       | later view                    |
-| ~gr~        | refresh                       |
-| ~gd~        | toggle grid                   |
-| ~C-v~       | change view                   |
-| ~RET~       | org-agenda-goto               |
-| ~M-RET~     | org-agenda-show-and-scroll-up |
+*** Keybindings
+The evilified org agenda supports the following bindings:
+
+| Key Binding          | Description                   |
+|----------------------+-------------------------------|
+| ~M-SPC~ or ~s-M-SPC~ | org-agenda transient state    |
+| ~SPC m :~            | org-agenda-set-tags           |
+| ~SPC m a~            | org-agenda                    |
+| ~SPC m d~            | org-agenda-deadline           |
+| ~SPC m f~            | org-agenda-set-effort         |
+| ~SPC m I~            | org-agenda-clock-in           |
+| ~SPC m O~            | org-agenda-clock-out          |
+| ~SPC m P~            | org-agenda-set-property       |
+| ~SPC m q~            | org-agenda-refile             |
+| ~SPC m Q~            | org-agenda-clock-cancel       |
+| ~SPC m s~            | org-agenda-schedule           |
+| ~M-j~                | next item                     |
+| ~M-k~                | previous item                 |
+| ~M-h~                | earlier view                  |
+| ~M-l~                | later view                    |
+| ~gr~                 | refresh                       |
+| ~gd~                 | toggle grid                   |
+| ~C-v~                | change view                   |
+| ~RET~                | org-agenda-goto               |
+| ~M-RET~              | org-agenda-show-and-scroll-up |
+
+*** Org agenda transient state
+Use ~M-SPC~ or ~s-M-SPC~ in an org agenda buffer to activate its transient state.
+The transient state aims to list the most useful org agenda commands and
+visually organize them by category. The commands associated with each binding
+are listed bellow.
+
+| Keybinding  | Description         | Command                           |
+|-------------+---------------------+-----------------------------------|
+| Entry       |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~ht~        | set status          | org-agenda-todo                   |
+| ~hk~        | kill                | org-agenda-kill                   |
+| ~hr~        | refile              | org-agenda-refile                 |
+| ~hA~        | archive             | org-agenda-archive-default        |
+| ~hT~        | set tags            | org-agenda-set-tags               |
+| ~hp~        | set priority        | org-agenda-priority               |
+|-------------+---------------------+-----------------------------------|
+| Visit entry |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~SPC~       | in other window     | org-agenda-show-and-scroll-up     |
+| ~TAB~       | & go to location    | org-agenda-goto                   |
+| ~RET~       | & del other windows | org-agenda-switch-to              |
+| ~o~         | link                | link-hint-open-link               |
+|-------------+---------------------+-----------------------------------|
+| Filter      |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~ft~        | by tag              | org-agenda-filter-by-tag          |
+| ~fr~        | refine by tag       | org-agenda-filter-by-tag-refine   |
+| ~fc~        | by category         | org-agenda-filter-by-category     |
+| ~fh~        | by top headline     | org-agenda-filter-by-top-headline |
+| ~fx~        | by regexp           | org-agenda-filter-by-regexp       |
+| ~fd~        | delete all filters  | org-agenda-filter-remove-all      |
+|-------------+---------------------+-----------------------------------|
+| Date        |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~ds~        | schedule            | org-agenda-schedule               |
+| ~dd~        | set deadline        | org-agenda-deadline               |
+| ~dt~        | timestamp           | org-agenda-date-prompt            |
+| ~+~         | do later            | org-agenda-do-date-later          |
+| ~-~         | do earlier          | org-agenda-do-date-earlier        |
+|-------------+---------------------+-----------------------------------|
+| Toggle      |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~tf~        | follow              | org-agenda-follow-mode            |
+| ~tl~        | log                 | org-agenda-log-mode               |
+| ~ta~        | archive             | org-agenda-archives-mode          |
+| ~tr~        | clock report        | org-agenda-clockreport-mode       |
+| ~td~        | diaries             | org-agenda-toggle-diary           |
+|-------------+---------------------+-----------------------------------|
+| View        |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~vd~        | day                 | org-agenda-day-view               |
+| ~vw~        | week                | org-agenda-week-view              |
+| ~vt~        | fortnight           | org-agenda-fortnight-view         |
+| ~vm~        | month               | org-agenda-month-view             |
+| ~vy~        | year                | org-agenda-year-view              |
+| ~vn~        | next span           | org-agenda-later                  |
+| ~vp~        | prev span           | org-agenda-earlier                |
+| ~vr~        | reset               | org-agenda-reset-view             |
+|-------------+---------------------+-----------------------------------|
+| Clock       |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~ci~        | in                  | org-agenda-clock-in               |
+| ~co~        | out                 | org-agenda-clock-out              |
+| ~ck~        | cancel              | org-agenda-clock-cancel           |
+| ~cj~        | jump                | org-agenda-clock-goto             |
+|-------------+---------------------+-----------------------------------|
+| Other       |                     |                                   |
+|-------------+---------------------+-----------------------------------|
+| ~gr~        | reload              | org-agenda-redo                   |
+| ~.~         | go to today         | org-agenda-goto-today             |
+| ~gd~        | go to date          | org-agenda-goto-date              |
 
 ** Pomodoro
 

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -318,14 +318,92 @@ Will work on both org-mode and any mode that accepts plain html."
       (spacemacs/set-leader-keys-for-major-mode 'org-agenda-mode
         ":" 'org-agenda-set-tags
         "a" 'org-agenda
-	"d" 'org-agenda-deadline
+        "d" 'org-agenda-deadline
         "f" 'org-agenda-set-effort
         "I" 'org-agenda-clock-in
         "O" 'org-agenda-clock-out
         "P" 'org-agenda-set-property
         "q" 'org-agenda-refile
         "Q" 'org-agenda-clock-cancel
-        "s" 'org-agenda-schedule))
+        "s" 'org-agenda-schedule)
+      (spacemacs|define-transient-state org-agenda
+      :title "Org-agenda transient state"
+      :on-enter (setq which-key-inhibit t)
+      :on-exit (setq which-key-inhibit nil)
+      :foreign-keys run
+      :doc
+      "
+Headline^^            Visit entry^^               Filter^^                    Date^^               Toggle mode^^        View^^             Clock^^        Other^^
+--------^^---------   -----------^^------------   ------^^-----------------   ----^^-------------  -----------^^------  ----^^---------    -----^^------  -----^^-----------
+[_ht_] set status     [_SPC_] in other window     [_ft_] by tag               [_ds_] schedule      [_tf_] follow        [_vd_] day         [_ci_] in      [_gr_] reload
+[_hk_] kill           [_TAB_] & go to location    [_fr_] refine by tag        [_dd_] set deadline  [_tl_] log           [_vw_] week        [_co_] out     [_._]  go to today
+[_hr_] refile         [_RET_] & del other windows [_fc_] by category          [_dt_] timestamp     [_ta_] archive       [_vt_] fortnight   [_ck_] cancel  [_gd_] go to date
+[_hA_] archive        [_o_]   link                [_fh_] by top headline      [_+_]  do later      [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
+[_hT_] set tags       ^^                          [_fx_] by regexp            [_-_]  do earlier    [_td_] diaries       [_vy_] year        ^^             ^^
+[_hp_] set priority   ^^                          [_fd_] delete all filters   ^^                   ^^                   [_vn_] next span   ^^             ^^
+^^                    ^^                          ^^                          ^^                   ^^                   [_vp_] prev span   ^^             ^^
+^^                    ^^                          ^^                          ^^                   ^^                   [_vr_] reset       ^^             ^^
+[_q_] quit
+"
+      :bindings
+      ;; Entry
+      ("ht" org-agenda-todo)
+      ("hk" org-agenda-kill)
+      ("hr" org-agenda-refile)
+      ("hA" org-agenda-archive-default)
+      ("hT" org-agenda-set-tags)
+      ("hp" org-agenda-priority)
+
+      ;; Visit entry
+      ("SPC" org-agenda-show-and-scroll-up)
+      ("<tab>" org-agenda-goto :exit t)
+      ("TAB" org-agenda-goto :exit t)
+      ("RET" org-agenda-switch-to :exit t)
+      ("o"   link-hint-open-link :exit t)
+
+      ;; Date
+      ("ds" org-agenda-schedule)
+      ("dd" org-agenda-deadline)
+      ("dt" org-agenda-date-prompt)
+      ("+" org-agenda-do-date-later)
+      ("-" org-agenda-do-date-earlier)
+
+      ;; View
+      ("vd" org-agenda-day-view)
+      ("vw" org-agenda-week-view)
+      ("vt" org-agenda-fortnight-view)
+      ("vm" org-agenda-month-view)
+      ("vy" org-agenda-year-view)
+      ("vn" org-agenda-later)
+      ("vp" org-agenda-earlier)
+      ("vr" org-agenda-reset-view)
+
+      ;; Toggle mode
+      ("tf" org-agenda-follow-mode)
+      ("tl" org-agenda-log-mode)
+      ("ta" org-agenda-archives-mode)
+      ("tr" org-agenda-clockreport-mode)
+      ("td" org-agenda-toggle-diary)
+
+      ;; Filter
+      ("ft" org-agenda-filter-by-tag)
+      ("fr" org-agenda-filter-by-tag-refine)
+      ("fc" org-agenda-filter-by-category)
+      ("fh" org-agenda-filter-by-top-headline)
+      ("fx" org-agenda-filter-by-regexp)
+      ("fd" org-agenda-filter-remove-all)
+
+      ;; Clock
+      ("ci" org-agenda-clock-in :exit t)
+      ("co" org-agenda-clock-out)
+      ("ck" org-agenda-clock-cancel)
+      ("cj" org-agenda-clock-goto :exit t)
+
+      ;; Other
+      ("q" nil :exit t)
+      ("gr" org-agenda-redo)
+      ("." org-agenda-goto-today)
+      ("gd" org-agenda-goto-date)))
     :config
     (evilified-state-evilify-map org-agenda-mode-map
       :mode org-agenda-mode
@@ -339,7 +417,9 @@ Will work on both org-mode and any mode that accepts plain html."
       (kbd "gd") 'org-agenda-toggle-time-grid
       (kbd "gr") 'org-agenda-redo
       (kbd "M-RET") 'org-agenda-show-and-scroll-up
-      (kbd "RET") 'org-agenda-goto)))
+      (kbd "RET") 'org-agenda-goto
+      (kbd "M-SPC") 'spacemacs/org-agenda-transient-state/body
+      (kbd "s-M-SPC") 'spacemacs/org-agenda-transient-state/body)))
 
 (defun org/init-org-bullets ()
   (use-package org-bullets


### PR DESCRIPTION
It's hard to remember `org-agenda`'s keybindings. Also, some of them are shadowed by using `evilify`.

So I created this transient state:

![screenshot 2016-02-09 18 21 37](https://cloud.githubusercontent.com/assets/7083061/12929503/2d6478da-cf5a-11e5-9615-91f523f263b4.png)

It's big, so I tried to put the most useful keybindings first and  `q` is on the bottom, so it's always visible.

It's activated with `M-SPC` in a `org-agenda` buffer , as Spacemacs conventions recommend.

Also I haven't documented it yet, what should I do? Just insert its keybinding in the agenda part of the `README`?