### PR TITLE
Disable exec path from shell under X

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -466,7 +466,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
 
 (defun spacemacs-base/init-exec-path-from-shell ()
   (use-package exec-path-from-shell
-    :init (when (memq window-system '(mac ns x))
+    :init (when (memq window-system '(mac ns))
             (exec-path-from-shell-initialize))))
 
 (defun spacemacs-base/init-fill-column-indicator ()


### PR DESCRIPTION
I'm running into a bug where my path is set incorrectly in Emacs. Specifically, it is not picking up exports I make in my ~/.zshenv file. I'm not sure if this is the correct solution, but this is the best way for me to get Emacs to properly get my environment variables. I think I am setting the env correctly, as it is in my ~/.zshenv and works with this change.

I would disable exec-path-from-shell, but the Go and rust layers need it.

Is anybody more familiar with the Emacs environment able to confirm that this will not break user's setups?