### PR TITLE
Diminish relative line numbers

### DIFF
--- a/layers/+distribution/spacemacs/packages-backup.el
+++ b/layers/+distribution/spacemacs/packages-backup.el
@@ -1176,6 +1176,7 @@ on whether the spacemacs-ivy layer is used or not, with
 (defun spacemacs/init-linum-relative ()
   (use-package linum-relative
     :commands (linum-relative-toggle linum-relative-on)
+    :diminish ""
     :init
     (progn
       (when (eq dotspacemacs-line-numbers 'relative)


### PR DESCRIPTION
It's a little pointless taking up space in the modeline to indicate that the LR minor mode is active when line numbers are themselves visible and it is this clear to everyone that the mode is active.