### PR TITLE
shm: undo awkward normal-map rebindings

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -282,18 +282,6 @@
         (define-key shm-map (kbd "C-c S") 'shm/case-split)
         (define-key shm-map (kbd "C-c C-s") 'shm/do-case-split))
 
-      (evil-define-key 'normal shm-map
-        (kbd "RET") nil
-        (kbd "C-k") nil
-        (kbd "C-j") nil
-        (kbd "D") 'shm/kill-line
-        (kbd "R") 'shm/raise
-        (kbd "P") 'shm/yank
-        (kbd "RET") 'shm/newline-indent
-        (kbd "RET") 'shm/newline-indent
-        (kbd "M-RET") 'evil-ret
-        )
-
       (evil-define-key 'operator shm-map
         (kbd ")") 'shm/forward-node
         (kbd "(") 'shm/backward-node)
@@ -302,8 +290,7 @@
         (kbd ")") 'shm/forward-node
         (kbd "(") 'shm/backward-node)
 
-      (define-key shm-map (kbd "C-j") nil)
-      (define-key shm-map (kbd "C-k") nil))))
+      )))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun haskell/post-init-company ()


### PR DESCRIPTION
I was trying to use structured-haskell-mode in Spacemacs but I found it awkward:

  * The custom shm key bindings remap some important vim key bindings
  * It unmaps `<C-j>` and maps it to normal mode enter, which means you can't use it for `shm/newline-indent`ing lists and strings. You would have to `fdl<enter>` for each list item
  * They are somewhat opinionated and don't match any spacemacs conventions.

We should look into making something similar to evil-lisp-state, which would be really cool.

cc @bjarkevad @d12frosted 