### PR TITLE
haskell: update broken hoogle-lookup-from-local

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -151,7 +151,7 @@
 
         "hd"  'inferior-haskell-find-haddock
         "hh"  'hoogle
-        "hH"  'hoogle-lookup-from-local
+        "hH"  'haskell-hoogle-lookup-from-local
         "hi"  (lookup-key haskell-mode-map (kbd "C-c TAB"))
         "ht"  (lookup-key haskell-mode-map (kbd "C-c C-t"))
         "hT"  'spacemacs/haskell-process-do-type-on-prev-line


### PR DESCRIPTION
It was renamed to `haskell-hoogle-lookup-from-local` in:

https://github.com/haskell/haskell-mode/commit/44b542082951c298b2a075d101cc9de6cd9f72d2#diff-7d97c622509a7bc5ed311b9ef7719095R110