### PR TITLE
html: Don't enable web-mode for jsx files

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -249,7 +249,6 @@
      ("\\.handlebars\\'" . web-mode)
      ("\\.hbs\\'"        . web-mode)
      ("\\.eco\\'"        . web-mode)
-     ("\\.jsx\\'"        . web-mode)
      ("\\.ejs\\'"        . web-mode)
      ("\\.djhtml\\'"     . web-mode))))
 


### PR DESCRIPTION
- Conceptually it just doesn't feel right: JSX is no HTML, this would be the wrong layer.
- It seems redundant as well: There's a `react` layer that provides dedicated JSX support.
- Finally, there are other modes for JSX (`js2-jsx-mode` for instance) that user might want to use,
  without affecting Web Mode for template files.