### PR TITLE
Add key binding for ranger-search-files

### DIFF
--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -116,7 +116,7 @@ To set the max files size (in MB), set the following parameter:
 | ~k~         | (ranger) navigate up                                 |
 | ~C-j~       | (ranger) scroll preview window down                  |
 | ~C-k~       | (ranger) scroll preview window up                    |
-| ~f~         | (ranger) search for file names                       |
+| ~e~         | (ranger) search for file names                       |
 | ~i~         | (ranger) show preview of current file                |
 | ~zi~        | (ranger) toggle showing literal / full-text previews |
 | ~zh~        | (ranger) toggle showing dotfiles                     |

--- a/layers/+tools/ranger/packages.el
+++ b/layers/+tools/ranger/packages.el
@@ -26,4 +26,6 @@
       (unless (file-directory-p image-dired-dir)
         (make-directory image-dired-dir)))
     :config
-    (define-key ranger-mode-map (kbd "-") 'ranger-up-directory)))
+    (progn
+      (define-key ranger-mode-map (kbd "e") 'ranger-search-files)
+      (define-key ranger-mode-map (kbd "-") 'ranger-up-directory))))


### PR DESCRIPTION
The default binding `f` is shadowed by `evil-mode`.
Regarding https://github.com/syl20bnr/spacemacs/issues/5029