### PR TITLE
company: Fix :init and use default company-frontends

### DIFF
--- a/layers/auto-completion/packages.el
+++ b/layers/auto-completion/packages.el
@@ -76,21 +76,21 @@
             company-minimum-prefix-length 2
             company-require-match nil
             company-dabbrev-ignore-case nil
-            company-dabbrev-downcase nil
-            company-frontends '(company-pseudo-tooltip-frontend)))
-            (defvar-local company-fci-mode-on-p nil)
+            company-dabbrev-downcase nil)
 
-        (defun company-turn-off-fci (&rest ignore)
-          (when (boundp 'fci-mode)
-            (setq company-fci-mode-on-p fci-mode)
-            (when fci-mode (fci-mode -1))))
+      (defvar-local company-fci-mode-on-p nil)
 
-        (defun company-maybe-turn-on-fci (&rest ignore)
-          (when company-fci-mode-on-p (fci-mode 1)))
+      (defun company-turn-off-fci (&rest ignore)
+        (when (boundp 'fci-mode)
+          (setq company-fci-mode-on-p fci-mode)
+          (when fci-mode (fci-mode -1))))
 
-        (add-hook 'company-completion-started-hook 'company-turn-off-fci)
-        (add-hook 'company-completion-finished-hook 'company-maybe-turn-on-fci)
-        (add-hook 'company-completion-cancelled-hook 'company-maybe-turn-on-fci)
+      (defun company-maybe-turn-on-fci (&rest ignore)
+        (when company-fci-mode-on-p (fci-mode 1)))
+
+      (add-hook 'company-completion-started-hook 'company-turn-off-fci)
+      (add-hook 'company-completion-finished-hook 'company-maybe-turn-on-fci)
+      (add-hook 'company-completion-cancelled-hook 'company-maybe-turn-on-fci))
     :config
     (progn
       (spacemacs|diminish company-mode " ⓐ" " a")
@@ -139,7 +139,11 @@
   (use-package company-quickhelp
     :if (and auto-completion-enable-help-tooltip (display-graphic-p))
     :defer t
-    :init (add-hook 'company-mode-hook 'company-quickhelp-mode)))
+    :init
+    (progn
+      (add-hook 'company-mode-hook 'company-quickhelp-mode)
+      (with-eval-after-load 'company
+        (setq company-frontends (delq 'company-echo-metadata-frontend company-frontends))))))
 
 (when (configuration-layer/layer-usedp 'spacemacs-helm)
   (defun auto-completion/init-helm-c-yasnippet ()


### PR DESCRIPTION
The default value of `company-frontends` includes the following frontends:

- `company-pseudo-tooltip-unless-just-one-frontend`
  ![2016-02-11-112558_219x61_scrot](https://cloud.githubusercontent.com/assets/1211003/12974188/450bd07e-d0b2-11e5-8e71-b84e7963d319.png)
  Display the "popup" with candidates if there are more than 1 candidate.

- `company-preview-if-just-one-frontend`
  ![2016-02-11-113101_185x23_scrot](https://cloud.githubusercontent.com/assets/1211003/12974269/f7edf848-d0b2-11e5-8df8-d6d7d6ae49c1.png)
  If there is only one candidate, display it inline ("preview").

- `company-echo-metadata-frontend`
  ![rsz_screenshot_2016-02-11_11-28-28](https://cloud.githubusercontent.com/assets/1211003/12974258/d4b2c048-d0b2-11e5-8e29-409199f64f4c.png)
  Show metadata in echoarea.

The previous setting only enabled the "popup" frontend. I'm not sure why it was set, maybe because `company-echo-metadata-frontend` interferes a bit with the `company-quickhelp-frontend`. I'd argue that the default is better, and we can disable the echo frontend if quickhelp is enabled.

This also fixes the messed up `:init` form.