### PR TITLE
Add smart closing parenthesis

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -246,6 +246,11 @@ derivatives. If set to `relative', also turns on relative line numbers.")
 (defvar dotspacemacs-smartparens-strict-mode nil
   "If non-nil smartparens-strict-mode will be enabled in programming modes.")
 
+(defvar dotspacemacs-smart-closing-parenthesis nil
+  "If non-nil pressing the closing parenthesis `)' key in insert mode passes
+  over any automatically added closing parenthesis, bracket, quote, etc…
+  This can be temporary disabled by pressing `C-q' before `)'. (default nil)")
+
 (defvar dotspacemacs-highlight-delimiters 'all
   "Select a scope to highlight delimiters. Possible values are `any',
 `current', `all' or `nil'. Default is `all' (highlight any scope and

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -218,6 +218,10 @@ values."
    ;; If non-nil smartparens-strict-mode will be enabled in programming modes.
    ;; (default nil)
    dotspacemacs-smartparens-strict-mode nil
+   ;; If non-nil pressing the closing parenthesis `)' key in insert mode passes
+   ;; over any automatically added closing parenthesis, bracket, quote, etc…
+   ;; This can be temporary disabled by pressing `C-q' before `)'. (default nil)
+   dotspacemacs-smart-closing-parenthesis nil
    ;; Select a scope to highlight delimiters. Possible values are `any',
    ;; `current', `all' or `nil'. Default is `all' (highlight any scope and
    ;; emphasis the current one). (default 'all)

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -261,7 +261,7 @@ It will toggle the overlay under point or create an overlay of one character."
 (defun spacemacs-editing/init-smartparens ()
   (use-package smartparens
     :defer t
-    :commands (sp-split-sexp sp-newline)
+    :commands (sp-split-sexp sp-newline sp-up-sexp)
     :init
     (progn
       (spacemacs/add-to-hooks (if dotspacemacs-smartparens-strict-mode
@@ -321,6 +321,22 @@ It will toggle the overlay under point or create an overlay of one character."
       (sp-pair "{" nil :post-handlers
                '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
       (sp-pair "[" nil :post-handlers
-               '(:add (spacemacs/smartparens-pair-newline-and-indent "RET"))))))
+               '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
 
-
+      (defun spacemacs/smart-closing-parenthesis ()
+        (interactive)
+        (let* ((sp-navigate-close-if-unbalanced t)
+               (current-pos (point))
+               (current-line (line-number-at-pos current-pos))
+               (next-pos (save-excursion
+                           (sp-up-sexp)
+                           (point)))
+               (next-line (line-number-at-pos next-pos)))
+          (cond
+           ((and (= current-line next-line)
+                 (not (= current-pos next-pos)))
+            (sp-up-sexp))
+           (t
+            (insert-char ?\))))))
+      (when dotspacemacs-smart-closing-parenthesis
+          (define-key evil-insert-state-map ")" 'spacemacs/smart-closing-parenthesis)))))


### PR DESCRIPTION
When pressing `)` in insert mode, the point will go over the next closing parenthesis/bracket/quote/etc… For instance (the `|` character being the cursor position):

    [("{|}")]

pressing 6 times `)` will do:

    [("{}|")]
    [("{}"|)]
    [("{}")|]
    [("{}")]|
    [("{}")])|
    [("{}")]))|

It also takes care of creating closing surrounding as in:

    [({|
    [({}|
    [({})|
    [({})]|
    [({})])|

Let split the behavior in two cases:

**The surroundings are balanced**

- If there is a closing surrounding *on the same line*, pass over it
- Otherwise, insert the `)` character

**The surroundings are unbalanced**

- Insert the char closing the next surrounding, even if it is not open on the same line.
- I noticed one border case problem though:
  - `{"` fails if there is no newline at the end of the line, or becomes `{"}}}` otherwise.

Despite this small quirk, I think it could be added as it's an opt-in feature anyway.

BTW pressing `C-q` before a surrounding will enter it textually, this can be use when people want to write `")"` (try it :wink:) with this enabled. `" C-q ) )` works.