### PR TITLE
install-package: don't set lazy-install pkg is nil

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -724,7 +724,7 @@ path."
           (cond
            ((or (null pkg) (eq 'elpa location))
             (configuration-layer//install-from-elpa pkg-name)
-            (oset pkg :lazy-install nil))
+            (when pkg (oset pkg :lazy-install nil)))
            ((and (listp location) (eq 'recipe (car location)))
             (configuration-layer//install-from-recipe pkg)
             (oset pkg :lazy-install nil))


### PR DESCRIPTION
When the list of package names returned by `configuration-layer//get-uninstalled-packages` contains a package that isn't contained in `configuration-layer--packages`, then `configuration-layer//install-package` throws a "wrong-argument-type: eieio-object-p nil" error at startup. `configuration-layer//install-packages` catches the error and prints it in the home buffer.

This PR fixes `configuration-layer//install-package` to not set the `lazy-loaded` property of a package, when Spacemacs doesn't have an entry for that package in `configuration-layer--packages`.

Fixes #5020.