### PR TITLE
Add omtose-phellack theme

### DIFF
--- a/layers/themes-megapack/packages.el
+++ b/layers/themes-megapack/packages.el
@@ -66,6 +66,7 @@
     noctilux-theme
     obsidian-theme
     occidental-theme
+    omtose-phellack-theme
     oldlace-theme
     organic-green-theme
     pastels-on-dark-theme


### PR DESCRIPTION
Adds the dark purple/teal [omtose-phellack-theme](https://github.com/franksn/omtose-phellack-theme) to the megapack