### PR TITLE
evil-magit: Use horizontal movement option

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -30,6 +30,7 @@
 (defun git/init-evil-magit ()
   (unless (eq dotspacemacs-editing-style 'emacs)
     (with-eval-after-load 'magit
+      (setq evil-magit-want-horizontal-movement t)
       (require 'evil-magit)
       (evil-define-key 'motion magit-mode-map
         (kbd dotspacemacs-leader-key) spacemacs-default-map))))


### PR DESCRIPTION
New option in evil-magit that moves h to H, l to L, and L to C-l to
allow h and l to move horizontally in the buffer.

This is probably a little more natural for vim users.