### PR TITLE
Restart Spacemacs restoring the layouts

### DIFF
--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -9,6 +9,10 @@
 ;;
 ;;; License: GPLv3
 
+(defvar spacemacs-force-resume-layout nil
+  "If non-nil force the current emacs instance to resume layouts
+  at start time despite the value of `dotspacemacs-auto-resume-layouts'.")
+
 (defun spacemacs//parse-command-line (args)
   "Handle Spacemacs specific command line arguments.
 The reason why we don't use the Emacs hooks for processing user defined
@@ -39,6 +43,8 @@ arguments is that we want to process these arguments as soon as possible."
            (setq spacemacs-debugp t))
           ("--insecure"
            (setq dotspacemacs-elpa-https nil))
+          ("--resume-layouts"
+           (setq spacemacs-force-resume-layouts t))
           (_ (push arg new-args))))
       (setq i (1+ i)))
     (nreverse new-args)))

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -852,11 +852,16 @@ below. Anything else exits."
   (use-package restart-emacs
     :defer t
     :init
-    (spacemacs/set-leader-keys "qr" 'spacemacs/restart-emacs)
-    (defun spacemacs/restart-emacs ()
+    (defun spacemacs/restart-emacs (&optional args)
       (interactive)
       (setq spacemacs-really-kill-emacs t)
-      (restart-emacs))))
+      (restart-emacs args))
+    (defun spacemacs/restart-emacs-resume-layouts (&optional args)
+      (interactive)
+      (spacemacs/restart-emacs (cons "--resume-layouts" args)))
+    (spacemacs/set-leader-keys
+      "qr" 'spacemacs/restart-emacs-resume-layouts
+      "qR" 'spacemacs/restart-emacs)))
 
 (defun spacemacs-base/init-savehist ()
   (use-package savehist

--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -24,7 +24,9 @@
     :diminish persp-mode
     :init
     (progn
-      (setq persp-auto-resume-time (if dotspacemacs-auto-resume-layouts 1 -1)
+      (setq persp-auto-resume-time (if (or dotspacemacs-auto-resume-layouts
+                                           spacemacs-force-resume-layouts)
+                                       1 -1)
             persp-nil-name dotspacemacs-default-layout-name
             persp-reset-windows-on-nil-window-conf nil
             persp-set-last-persp-for-new-frames nil


### PR DESCRIPTION
With this change:

- `SPC q r` will restart emacs restoring the layouts.
- `SPC q R` will restart emacs without restoring the layouts.

I put restart resuming the layouts on `SPC q r` as it's probably the intended users' behavior, and used `SPC q R` for restart without resuming the layouts as it's a more destructive operation.

Also it's possible now to use `emacs --resume-layouts` to temporary start an emacs instance resuming the previous layouts.

Note: Setting directly `dotspacemacs-auto-resume-layouts` in the command line parsing is not possible because it get overridden when parsing the `.spacemacs`. I created a new variable instead.

Fix #5058