### PR TITLE
fix: mu4e reply

### DIFF
--- a/layers/+email/mu4e/funcs.el
+++ b/layers/+email/mu4e/funcs.el
@@ -26,7 +26,7 @@ then fallback to the maildir."
                      (mailto-account
                       (car (cl-remove-if-not
                             'identity
-                            (mapcar ´mu4e//search-account-by-mail-address
+                            (mapcar 'mu4e//search-account-by-mail-address
                                     mailtos))))
                      (maildir
                       (mu4e-message-field mu4e-compose-parent-message :maildir))


### PR DESCRIPTION
This typo produced a silly symbol's variable is void.

Okay, fixes #5076 