### PR TITLE
remove structured-haskell-mode

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -16,7 +16,6 @@
      - [[GHCi-ng support][GHCi-ng support]]
        - [[Stack users][Stack users]]
        - [[ghc-mod users][ghc-mod users]]
-     - [[structured-haskell-mode][structured-haskell-mode]]
      - [[hindent][hindent]]
  - [[Key bindings][Key bindings]]
    - [[Documentation][Documentation]]
@@ -183,37 +182,6 @@ need to add following line in your =dotspacemacs/user-config=:
 
 This might be useful, because =ghc-mod= doesn't require active REPL in order to
 get type of symbol.
-
-*** structured-haskell-mode
-[[https://github.com/chrisdone/structured-haskell-mode][structured-haskell-mode]], or shm, replaces default haskell-mode
-auto-indentation and adds some nice functionalities.
-
-To install =shm= run =cabal install structured-haskell-mode= (or =stack=
-equivalent).
-
-To enable =shm= set the layer variable:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-    '((haskell :variables haskell-enable-shm-support t)))
-#+END_SRC
-
-After shm has been enabled, some of the evil normal state bindings are overridden:
-
-| Key Binding | Description         |
-|-------------+---------------------|
-| ~D~         | =shm/kill-line=     |
-| ~R~         | =shm/raise=         |
-| ~P~         | =shm/yank=          |
-| ~(~         | =shm/forward-node=  |
-| ~)~         | =shm/backward-node= |
-
-For a nice visualization of these functions, please refer to the github page
-for [[https://github.com/chrisdone/structured-haskell-mode#features][structured-haskell-mode]].
-
-*Warning* structured-haskell-mode doesn't play very well with =evil=
-([[https://github.com/chrisdone/structured-haskell-mode/issues/81][structured-haskell-mode/#81]]). So it's better to be used with =emacs= edit
-style.
 
 *** hindent
 [[https://github.com/chrisdone/hindent][hindent]] is an extensible Haskell pretty printer, which let's you

--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -17,9 +17,6 @@
 (defvar haskell-enable-ghci-ng-support nil
   "If non-nil ghci-ng support is enabled")
 
-(defvar haskell-enable-shm-support nil
-  "If non-nil structured-haskell-mode support is enabled")
-
 (defvar haskell-enable-hindent-style nil
   "Style to use for formatting with hindent; available are: fundamental johan-tibell chris-done gibiansky. If nil hindent is disabled.")
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -22,7 +22,6 @@
     haskell-mode
     haskell-snippets
     hindent
-    shm
     ))
 
 (defun haskell/init-cmm-mode ()
@@ -93,10 +92,7 @@
       (defun spacemacs/init-haskell-mode ()
         ;; use only internal indentation system from haskell
         (if (fboundp 'electric-indent-local-mode)
-            (electric-indent-local-mode -1))
-        (when haskell-enable-shm-support
-          ;; in structured-haskell-mode line highlighting creates noise
-          (setq-local global-hl-line-mode nil)))
+            (electric-indent-local-mode -1)))
 
       (defun spacemacs/haskell-interactive-bring ()
         "Bring up the interactive mode for this session without
@@ -258,42 +254,6 @@
       (setq hindent-style haskell-enable-hindent-style)
       (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
         "F" 'hindent-reformat-decl))))
-
-(defun haskell/init-shm ()
-  (use-package shm
-    :defer t
-    :if haskell-enable-shm-support
-    :init
-    (add-hook 'haskell-mode-hook 'structured-haskell-mode)
-    :config
-    (progn
-      (when (require 'shm-case-split nil 'noerror)
-        ;;TODO: Find some better bindings for case-splits
-        (define-key shm-map (kbd "C-c S") 'shm/case-split)
-        (define-key shm-map (kbd "C-c C-s") 'shm/do-case-split))
-
-      (evil-define-key 'normal shm-map
-        (kbd "RET") nil
-        (kbd "C-k") nil
-        (kbd "C-j") nil
-        (kbd "D") 'shm/kill-line
-        (kbd "R") 'shm/raise
-        (kbd "P") 'shm/yank
-        (kbd "RET") 'shm/newline-indent
-        (kbd "RET") 'shm/newline-indent
-        (kbd "M-RET") 'evil-ret
-        )
-
-      (evil-define-key 'operator shm-map
-        (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node)
-
-      (evil-define-key 'motion shm-map
-        (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node)
-
-      (define-key shm-map (kbd "C-j") nil)
-      (define-key shm-map (kbd "C-k") nil))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun haskell/post-init-company ()


### PR DESCRIPTION
Just as the title says - by this commit we remove shm. The main reason is that shm doesn't play well with vim editing style and causing more problems that are not so easily fixed. But still, it's very easy to add it to personal configs if you are using emacs editing style. 

Related issues: #5026, #1048 and #3171(this one has more explanations). 

> officially Chris Done marked `shm` and `evil` as mode-conflict and wont-fix

P. S. Do I need to add anything about how to enable shm to haskell layer readme? With warning 'use it for your own risk and preferably with emacs editing style' :) 

P. P. S. @syl20bnr thanks for the green light :) 

