### PR TITLE
evil-jumper: Remove obsolete package

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -70,7 +70,7 @@
   (setq-default evil-want-C-u-scroll t
                 ;; `evil-want-C-i-jump' is set to nil to avoid `TAB' being
                 ;; overlapped in terminal mode. The GUI specific `<C-i>' is used
-                ;; instead (defined in the init of `evil-jumper' package).
+                ;; instead.
                 evil-want-C-i-jump nil)
   (dotspacemacs/load-file)
   (require 'core-configuration-layer)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -786,7 +786,6 @@ Spacemacs ships with the following evil plugins:
 | [[https://github.com/juanjux/evil-search-highlight-persist][evil-search-highlight-persist]] | emulation of hlsearch behavior                           |
 | [[https://github.com/cofi/evil-numbers][evil-numbers]]                  | like ~C-a~ and ~C-x~ in vim                              |
 | [[https://github.com/wcsmith/evil-args][evil-args]]                     | motions and text objects for arguments                   |
-| [[https://github.com/bling/evil-jumper][evil-jumper]]                   | jump list emulation                                      |
 | [[https://github.com/jaypei/emacs-neotree][NeoTree]]                       | mimic [[https://github.com/scrooloose/nerdtree][NERD Tree]]                                          |
 
 * Spacemacs UI

--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -948,8 +948,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "sS"    'spacemacs/helm-swoop-region-or-symbol
         "s C-s" 'helm-multi-swoop-all)
       (defadvice helm-swoop (before add-evil-jump activate)
-        (when (configuration-layer/package-usedp 'evil-jumper)
-          (evil-set-jump))))))
+        (evil-set-jump)))))
 
 (defun spacemacs-helm/init-helm-themes ()
   (use-package helm-themes

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -280,9 +280,8 @@ If called with a prefix argument, uses the other-window instead."
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)))
 
-    (when (configuration-layer/package-usedp 'evil-jumper)
-      (defadvice cider-jump-to-var (before add-evil-jump activate)
-        (evil-set-jump)))))
+    (defadvice cider-jump-to-var (before add-evil-jump activate)
+      (evil-set-jump))))
 
 (defun clojure/init-cider-eval-sexp-fu ()
   (with-eval-after-load 'eval-sexp-fu

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -16,7 +16,6 @@
     company-anaconda
     cython-mode
     eldoc
-    evil-jumper
     evil-matchit
     flycheck
     helm-cscope
@@ -55,7 +54,10 @@
         "gu" 'anaconda-mode-find-references)
       (evilified-state-evilify anaconda-mode-view-mode anaconda-mode-view-mode-map
         (kbd "q") 'quit-window)
-      (spacemacs|hide-lighter anaconda-mode))))
+      (spacemacs|hide-lighter anaconda-mode)
+
+      (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
+        (evil-jumper--push)))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun python/post-init-company ()
@@ -86,10 +88,6 @@
 
 (defun python/post-init-eldoc ()
   (add-hook 'python-mode-hook 'eldoc-mode))
-
-(defun python/post-init-evil-jumper ()
-  (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
-    (evil-jumper--push)))
 
 (defun python/post-init-evil-matchit ()
   (add-hook `python-mode-hook `turn-on-evil-matchit-mode))

--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -150,15 +150,13 @@
             (progn
               (spacemacs/integrate-evil-search t)
               (spacemacs/ahs-highlight-now-wrapper)
-              (when (configuration-layer/package-usedp 'evil-jumper)
-                (evil-set-jump))
+              (evil-set-jump)
               (spacemacs/symbol-highlight-transient-state/body)
               (ahs-forward))
           (progn
             (spacemacs/integrate-evil-search nil)
             (spacemacs/ahs-highlight-now-wrapper)
-            (when (configuration-layer/package-usedp 'evil-jumper)
-              (evil-set-jump))
+            (evil-set-jump)
             (spacemacs/symbol-highlight-transient-state/body)
             (ahs-backward))))
 

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -15,7 +15,6 @@
         evil-exchange
         evil-iedit-state
         evil-indent-plus
-        evil-jumper
         evil-lisp-state
         ;; for testing purpose, contribute by reporting bugs and sending PRs
         ;; to https://github.com/gabesoft/evil-mc
@@ -78,10 +77,6 @@
 (defun spacemacs-evil/init-evil-indent-plus ()
   (use-package evil-indent-plus
     :init (evil-indent-plus-default-bindings)))
-
-(defun spacemacs-evil/init-evil-jumper ()
-  (use-package evil-jumper
-    :init (evil-jumper-mode t)))
 
 (defun spacemacs-evil/init-evil-lisp-state ()
   (use-package evil-lisp-state

--- a/layers/cscope/packages.el
+++ b/layers/cscope/packages.el
@@ -9,13 +9,8 @@
 ;;
 ;;; License: GPLv3
 
-(setq cscope-packages '(evil-jumper
-                        helm-cscope
+(setq cscope-packages '(helm-cscope
                         xcscope))
-
-(defun cscope/post-init-evil-jump ()
-  (defadvice helm-cscope-find-this-symbol (before cscope/goto activate)
-    (evil-jumper--push)))
 
 (defun cscope/init-xcscope ()
   (use-package xcscope
@@ -57,4 +52,7 @@
           "gf" 'helm-cscope-find-this-file
           "gF" 'helm-cscope-find-files-including-file
           "gr" 'helm-cscope-find-this-symbol
-          "gx" 'helm-cscope-find-this-text-string)))))
+          "gx" 'helm-cscope-find-this-text-string))
+      :config
+      (defadvice helm-cscope-find-this-symbol (before cscope/goto activate)
+        (evil-jumper--push)))))


### PR DESCRIPTION
The functionality is now incorporated into the evil core and this
package has been marked as obsolete.