### PR TITLE
Explain helm-descbind prompt more detailed

### DIFF
--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -145,7 +145,7 @@ type a pattern like this regular expression:
     SPC\ b
 #+END_EXAMPLE
 
-which would list all =buffer= related bindings.
+which would list all =buffer= related bindings. *Note:* You are at the /HELM-Descbind/ prompt, the pattern consists of 6 letters: uppercase ~SPC~, a backslash and a lowercase ~b~.
 
 ** Describe functions
 =Describe functions= are powerful Emacs introspection commands to get information


### PR DESCRIPTION
To prevent missunderstandings, times before "SPC" meant the spacebar. This time not.
"a blank" is still missing in the enumeration of the letters to type. Please correct me.