### PR TITLE
remove structured-haskell-mode

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -166,9 +166,9 @@ versions from ghci-ng, and a new keybinding available:
 
 | Key Binding | Description                                                               |
 |-------------+---------------------------------------------------------------------------|
-| ~SPC m h t~ | gets the type of the identifier under the cursor or for the active region |
-| ~SPC m g g~ | go to definition                                                          |
-| ~SPC m u~   | finds uses of identifier                                                  |
+| ~SPC m h t~   | gets the type of the identifier under the cursor or for the active region |
+| ~SPC m g g~   | go to definition                                                          |
+| ~SPC m u~     | finds uses of identifier                                                  |
 
 **** Stack users
 =Stack= and =ghci-ng= doesn't play well with each other, so the general advice
@@ -238,10 +238,10 @@ Top-level commands are prefixed by ~SPC m~:
 
 | Key Binding | Description                                                         |
 |-------------+---------------------------------------------------------------------|
-| ~SPC m g g~ | go to definition or tag                                             |
-| ~SPC m g i~ | cycle the Haskell import lines or return to point (with prefix arg) |
-| ~SPC m f~   | format buffer using haskell-stylish                                 |
-| ~SPC m F~   | format declaration using hindent (if enabled)                       |
+| ~SPC m g g~   | go to definition or tag                                             |
+| ~SPC m g i~   | cycle the Haskell import lines or return to point (with prefix arg) |
+| ~SPC m f~     | format buffer using haskell-stylish                                 |
+| ~SPC m F~     | format declaration using hindent (if enabled)                       |
 
 ** Documentation
 Documentation commands are prefixed by ~SPC m h~
@@ -261,80 +261,80 @@ Debug commands are prefixed by ~SPC m d~:
 
 | Key Binding | Description                                |
 |-------------+--------------------------------------------|
-| ~SPC m d a~ | abandon current process                    |
-| ~SPC m d b~ | insert breakpoint at function              |
-| ~SPC m d B~ | delete breakpoint                          |
-| ~SPC m d c~ | continue current process                   |
-| ~SPC m d d~ | start debug process, needs to be run first |
-| ~SPC m d n~ | next breakpoint                            |
-| ~SPC m d N~ | previous breakpoint                        |
-| ~SPC m d p~ | previous breakpoint                        |
-| ~SPC m d r~ | refresh process buffer                     |
-| ~SPC m d s~ | step into the next function                |
-| ~SPC m d t~ | trace the expression                       |
+| ~SPC m d a~   | abandon current process                    |
+| ~SPC m d b~   | insert breakpoint at function              |
+| ~SPC m d B~   | delete breakpoint                          |
+| ~SPC m d c~   | continue current process                   |
+| ~SPC m d d~   | start debug process, needs to be run first |
+| ~SPC m d n~   | next breakpoint                            |
+| ~SPC m d N~   | previous breakpoint                        |
+| ~SPC m d p~   | previous breakpoint                        |
+| ~SPC m d r~   | refresh process buffer                     |
+| ~SPC m d s~   | step into the next function                |
+| ~SPC m d t~   | trace the expression                       |
 
 ** Debug Buffer
 | Key Binding | Description                                 |
 |-------------+---------------------------------------------|
-| ~RET~       | select object at the point                  |
-| ~a~         | abandon current computation                 |
-| ~b~         | break on function                           |
-| ~c~         | continue the current computation            |
-| ~d~         | delete object at the point                  |
-| ~n~         | go to next step to inspect bindings         |
-| ~N~ or ~p~  | go to previous step to inspect the bindings |
-| ~r~         | refresh the debugger buffer                 |
-| ~s~         | step into the next function                 |
-| ~t~         | trace the expression                        |
+| ~RET~         | select object at the point                  |
+| ~a~           | abandon current computation                 |
+| ~b~           | break on function                           |
+| ~c~           | continue the current computation            |
+| ~d~           | delete object at the point                  |
+| ~n~           | go to next step to inspect bindings         |
+| ~N~ or ~p~      | go to previous step to inspect the bindings |
+| ~r~           | refresh the debugger buffer                 |
+| ~s~           | step into the next function                 |
+| ~t~           | trace the expression                        |
 
 ** REPL
 REPL commands are prefixed by ~SPC m s~:
 
 | Key Binding | Description                                     |
 |-------------+-------------------------------------------------|
-| ~SPC m s b~ | load or reload the current buffer into the REPL |
-| ~SPC m s c~ | clear the REPL                                  |
-| ~SPC m s s~ | show the REPL without switching to it           |
-| ~SPC m s S~ | show and switch to the REPL                     |
+| ~SPC m s b~   | load or reload the current buffer into the REPL |
+| ~SPC m s c~   | clear the REPL                                  |
+| ~SPC m s s~   | show the REPL without switching to it           |
+| ~SPC m s S~   | show and switch to the REPL                     |
 
 ** Cabal commands
 
 Cabal commands are prefixed by ~SPC m c~:
 
-| Key Binding | Description                                                |
-|-------------+------------------------------------------------------------|
-| ~SPC m c a~ | cabal actions                                              |
-| ~SPC m c b~ | build the current cabal project, i.e. invoke =cabal build= |
-| ~SPC m c c~ | compile the current project, i.e. invoke =ghc=             |
-| ~SPC m c v~ | visit the cabal file                                       |
+| Key Binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC m c a~   | cabal actions                                            |
+| ~SPC m c b~   | build the current cabal project, i.e. invoke =cabal build= |
+| ~SPC m c c~   | compile the current project, i.e. invoke =ghc=             |
+| ~SPC m c v~   | visit the cabal file                                     |
 
 ** Cabal files
 This commands are available in a cabal file.
 
 | Key Binding | Description                                 |
 |-------------+---------------------------------------------|
-| ~SPC m d~   | add a dependency to the project             |
-| ~SPC m b~   | go to benchmark section                     |
-| ~SPC m e~   | go to executable section                    |
-| ~SPC m t~   | go to test-suite section                    |
-| ~SPC m m~   | go to exposed modules                       |
-| ~SPC m l~   | go to libary section                        |
-| ~SPC m n~   | go to next subsection                       |
-| ~SPC m p~   | go to previous subsection                   |
-| ~SPC m s c~ | clear the REPL                              |
-| ~SPC m s s~ | show the REPL without switching to it       |
-| ~SPC m s S~ | show and switch to the REPL                 |
-| ~SPC m N~   | go to next section                          |
-| ~SPC m P~   | go to previous section                      |
-| ~SPC m f~   | find or create source-file under the cursor |
+| ~SPC m d~     | add a dependency to the project             |
+| ~SPC m b~     | go to benchmark section                     |
+| ~SPC m e~     | go to executable section                    |
+| ~SPC m t~     | go to test-suite section                    |
+| ~SPC m m~     | go to exposed modules                       |
+| ~SPC m l~     | go to libary section                        |
+| ~SPC m n~     | go to next subsection                       |
+| ~SPC m p~     | go to previous subsection                   |
+| ~SPC m s c~   | clear the REPL                              |
+| ~SPC m s s~   | show the REPL without switching to it       |
+| ~SPC m s S~   | show and switch to the REPL                 |
+| ~SPC m N~     | go to next section                          |
+| ~SPC m P~     | go to previous section                      |
+| ~SPC m f~     | find or create source-file under the cursor |
 
 ** Refactor
 Refactor commands are prefixed by ~SPC m r~:
 
 | Key Binding | Description                                       |
 |-------------+---------------------------------------------------|
-| ~SPC m r b~ | apply all HLint suggestions in the current buffer |
-| ~SPC m r r~ | apply the HLint suggestion under the cursor       |
+| ~SPC m r b~   | apply all HLint suggestions in the current buffer |
+| ~SPC m r r~   | apply the HLint suggestion under the cursor       |
 
 Only some of the HLint suggestions can be applied.
 
@@ -346,17 +346,17 @@ http://www.mew.org/~kazu/proj/ghc-mod/en/emacs.html
 
 ghc-mod commands are prefixed by ~SPC m m~:
 
-| Key Binding | Description                               |
-|-------------+-------------------------------------------|
-| ~SPC m m t~ | insert template                           |
-| ~SPC m m u~ | insert template with holes                |
-| ~SPC m m a~ | select one of possible cases (~ghc-auto~) |
-| ~SPC m m f~ | replace a hole (~ghc-refine~)             |
-| ~SPC m m e~ | expand template haskell                   |
-| ~SPC m m n~ | go to next type hole                      |
-| ~SPC m m p~ | go to previous type hole                  |
-| ~SPC m m >~ | make indent deeper                        |
-| ~SPC m m <~ | make indent shallower                     |
+| Key Binding | Description                             |
+|-------------+-----------------------------------------|
+| ~SPC m m t~   | insert template                         |
+| ~SPC m m u~   | insert template with holes              |
+| ~SPC m m a~   | select one of possible cases (~ghc-auto~) |
+| ~SPC m m f~   | replace a hole (~ghc-refine~)             |
+| ~SPC m m e~   | expand template haskell                 |
+| ~SPC m m n~   | go to next type hole                    |
+| ~SPC m m p~   | go to previous type hole                |
+| ~SPC m m >~   | make indent deeper                      |
+| ~SPC m m <~   | make indent shallower                   |
 
 *** Insert template
 ~SPC m m t~ inserts a template. What this means is that in the beginning of a

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -188,8 +188,8 @@ if you have =stack.yaml= file in the root of your project, =stack-ghci= will be
 used as process type.
 
 **** ghc-mod users
-If you want to use ~SPC m h t~ from =ghc-mod= instead of =ghci-ng=, then you
-need to add following line in your =dotspacemacs/user-config=:
+If you want to use ~SPC m h t~ from =ghc-mod= instead of =ghci-ng=, then you need to
+add following line in your =dotspacemacs/user-config=:
 
 #+BEGIN_SRC emacs-lisp
 (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
@@ -200,35 +200,16 @@ This might be useful, because =ghc-mod= doesn't require active REPL in order to
 get type of symbol.
 
 *** structured-haskell-mode
-[[https://github.com/chrisdone/structured-haskell-mode][structured-haskell-mode]], or shm, replaces default haskell-mode auto-indentation
-and adds some nice functionalities.
+Currently there is no support for [[https://github.com/chrisdone/structured-haskell-mode][structured-haskell-mode]], since it doesn't play
+very well with non-emacs editing style ([[https://github.com/chrisdone/structured-haskell-mode/issues/81][structured-haskell-mode/#81]]). Emacs
+editing style users might easily enable it by adding =structured-haskell-mode= to
+list of =dotspacemacs-additional-packages= in your =.spacemacs= file. For more
+installation instructions, please refer to the official documentation at
+[[https://github.com/chrisdone/structured-haskell-mode#features][structured-haskell-mode]] page. In case you are non-emacs editing style user and
+still want to use =structured-haskell-mode= - use it at your own risk.
 
-To install =shm= run =cabal install structured-haskell-mode= (or =stack=
-equivalent).
-
-To enable =shm= set the layer variable:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-    '((haskell :variables haskell-enable-shm-support t)))
-#+END_SRC
-
-After shm has been enabled, some of the evil normal state bindings are overridden:
-
-| Key Binding | Description         |
-|-------------+---------------------|
-| ~D~         | =shm/kill-line=     |
-| ~R~         | =shm/raise=         |
-| ~P~         | =shm/yank=          |
-| ~(~         | =shm/forward-node=  |
-| ~)~         | =shm/backward-node= |
-
-For a nice visualization of these functions, please refer to the github page
-for [[https://github.com/chrisdone/structured-haskell-mode#features][structured-haskell-mode]].
-
-*Warning* structured-haskell-mode doesn't play very well with =evil=
-([[https://github.com/chrisdone/structured-haskell-mode/issues/81][structured-haskell-mode/#81]]). So it's recommended only to be used with the
-=emacs= editing style.
+Any contributions that will help to solve issues with =structured-haskell-mode=
+are warmly welcome!
 
 *** hindent
 [[https://github.com/chrisdone/hindent][hindent]] is an extensible Haskell pretty printer, which let's you
@@ -267,13 +248,13 @@ Documentation commands are prefixed by ~SPC m h~
 
 | Key Binding | Description                                                                |
 |-------------+----------------------------------------------------------------------------|
-| ~SPC m h d~ | find or generate Haddock documentation for the identifier under the cursor |
-| ~SPC m h f~ | do a helm-hoogle lookup                                                    |
-| ~SPC m h h~ | do a Hoogle lookup                                                         |
-| ~SPC m h H~ | do a local Hoogle lookup                                                   |
-| ~SPC m h i~ | gets information for the identifier under the cursor                       |
-| ~SPC m h t~ | gets the type of the identifier under the cursor                           |
-| ~SPC m h y~ | do a Hayoo lookup                                                          |
+| ~SPC m h d~   | find or generate Haddock documentation for the identifier under the cursor |
+| ~SPC m h f~   | do a helm-hoogle lookup                                                    |
+| ~SPC m h h~   | do a Hoogle lookup                                                         |
+| ~SPC m h H~   | do a local Hoogle lookup                                                   |
+| ~SPC m h i~   | gets information for the identifier under the cursor                       |
+| ~SPC m h t~   | gets the type of the identifier under the cursor                           |
+| ~SPC m h y~   | do a Hayoo lookup                                                          |
 
 ** Debug
 Debug commands are prefixed by ~SPC m d~:

--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -19,9 +19,6 @@
 (defvar haskell-enable-ghci-ng-support nil
   "If non-nil ghci-ng support is enabled")
 
-(defvar haskell-enable-shm-support nil
-  "If non-nil structured-haskell-mode support is enabled")
-
 (defvar haskell-enable-hindent-style nil
   "Style to use for formatting with hindent; available are: fundamental johan-tibell chris-done gibiansky. If nil hindent is disabled.")
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -26,7 +26,6 @@
     (helm-hoogle :toggle (configuration-layer/package-usedp 'helm))
     hindent
     hlint-refactor
-    shm
     ))
 
 (defun haskell/init-cmm-mode ()
@@ -129,10 +128,7 @@
       (defun spacemacs/init-haskell-mode ()
         ;; use only internal indentation system from haskell
         (if (fboundp 'electric-indent-local-mode)
-            (electric-indent-local-mode -1))
-        (when haskell-enable-shm-support
-          ;; in structured-haskell-mode line highlighting creates noise
-          (setq-local global-hl-line-mode nil)))
+            (electric-indent-local-mode -1)))
 
       (defun spacemacs/haskell-interactive-bring ()
         "Bring up the interactive mode for this session without
@@ -335,38 +331,3 @@
       (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
         "rb" 'hlint-refactor-refactor-buffer
         "rr" 'hlint-refactor-refactor-at-point))))
-
-(defun haskell/init-shm ()
-  (use-package shm
-    :defer t
-    :if haskell-enable-shm-support
-    :init
-    (add-hook 'haskell-mode-hook 'structured-haskell-mode)
-    :config
-    (progn
-      (when (require 'shm-case-split nil 'noerror)
-        ;;TODO: Find some better bindings for case-splits
-        (define-key shm-map (kbd "C-c S") 'shm/case-split)
-        (define-key shm-map (kbd "C-c C-s") 'shm/do-case-split))
-
-      (evil-define-key 'normal shm-map
-        (kbd "RET") nil
-        (kbd "C-k") nil
-        (kbd "C-j") nil
-        (kbd "D") 'shm/kill-line
-        (kbd "R") 'shm/raise
-        (kbd "P") 'shm/yank
-        (kbd "RET") 'shm/newline-indent
-        (kbd "RET") 'shm/newline-indent
-        (kbd "M-RET") 'evil-ret)
-
-      (evil-define-key 'operator shm-map
-        (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node)
-
-      (evil-define-key 'motion shm-map
-        (kbd ")") 'shm/forward-node
-        (kbd "(") 'shm/backward-node)
-
-      (define-key shm-map (kbd "C-j") nil)
-      (define-key shm-map (kbd "C-k") nil))))


### PR DESCRIPTION
Ok, so now it's agains develop (see #5078).

---

Just as the title says - by this commit we remove shm. The main reason is that shm doesn't play well with vim editing style and causing more problems that are not so easily fixed. But still, it's very easy to add it to personal configs if you are using emacs editing style. 

Related issues: #5026, #1048 and #3171(this one has more explanations). 

> officially Chris Done marked `shm` and `evil` as mode-conflict and wont-fix

---

Also added some notes about removal.

As @robbyoconnor mentioned in my previous PR we could also support shm only for emacs editing style. So Spacemacs would have a good starting point for shm users. But it's really only two configs - add hook and disable line highlight in haskell sources. So I'll let @syl20bnr to decide what to do with this PR. I am ok with both solutions. 

And as README file says - if someone comes with a good solution for evil + shm - please be so kind and send us PR :) 