### PR TITLE
iedit-mode: bind iedit-mode for emacs users

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -69,7 +69,9 @@
 (defun spacemacs-evil/init-evil-iedit-state ()
   (use-package evil-iedit-state
     :commands (evil-iedit-state evil-iedit-state/iedit-mode)
-    :init (spacemacs/set-leader-keys "se" 'evil-iedit-state/iedit-mode)
+    :init (spacemacs/set-leader-keys "se" (if (eq dotspacemacs-editing-style 'emacs)
+                                              'iedit-mode
+                                            'evil-iedit-state/iedit-mode))
     :config
     ;; activate leader in iedit and iedit-insert states
     (define-key evil-iedit-state-map


### PR DESCRIPTION
If the user has emacs editing style, bind iedit-mode instead.

I don't know if this is the right place to put this, i thought so as here is where the binding is being set. Anyway, any discussion is warmly welcome.

Address #5060