### PR TITLE
Fix toggle-maximize-buffer

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -176,10 +176,10 @@ the current state and point position."
   "Maximize buffer"
   (interactive)
   (if (and (= 1 (length (window-list)))
-           (assoc'_ register-alist))
-      (jump-to-register '_)
+           (assoc ?_ register-alist))
+      (jump-to-register ?_)
     (progn
-      (window-configuration-to-register '_)
+      (window-configuration-to-register ?_)
       (delete-other-windows))))
 
 ;; A small minor mode to use a big fringe


### PR DESCRIPTION
Was using the symbol _ as the name of a register when the docs for
register-alist state that the name of a register should be a character.