### PR TITLE
Allow `tsfmt` to use the local project's config.

### DIFF
--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -89,7 +89,7 @@
                           (progn
                             (with-current-buffer outputbuf (erase-buffer))
                             (write-region nil nil tmpfile)
-                            (if (zerop (apply 'call-process "tsfmt" nil outputbuf nil (list tmpfile)))
+                            (if (zerop (apply 'call-process "tsfmt" nil outputbuf nil (list "--baseDir=." tmpfile)))
                                 (let ((p (point)))
                                   (save-excursion
                                     (with-current-buffer (current-buffer)


### PR DESCRIPTION
By adding `--baseDir=.` to the command line arguments. This option is documented [here](https://github.com/vvakame/typescript-formatter).