### PR TITLE
rustfmt: Remove obsolete package

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -35,19 +35,13 @@ To enable auto-completion, ensure that the =auto-completion= layer is enabled.
 instructions can be found on the main page of [[http://doc.crates.io/index.html][Cargo]].
 
 ** Rustfmt
-
 Format Rust code according to style guidelines using [[https://github.com/rust-lang-nursery/rustfmt][rustfmt]].
 
 #+BEGIN_SRC sh
 cargo install rustfmt
 #+END_SRC
 
-To enable automatic buffer formatting on save, set the variable =rust-enable-rustfmt-on-save= to =t=.
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(
-    (rust :variables rust-enable-rustfmt-on-save t)))
-#+END_SRC
+To enable automatic buffer formatting on save, set the variable =rust-format-on-save= to =t=.
 
 * Key bindings
 

--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -14,6 +14,3 @@
 
 ;; Define the buffer local company backend variable
 (spacemacs|defvar-company-backends rust-mode)
-
-(defvar rust-enable-rustfmt-on-save nil
-  "If non-nil, automatically format code with rustfmt on save.")

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -17,7 +17,6 @@
     flycheck-rust
     rust-mode
     toml-mode
-    rustfmt
     ))
 
 (when (configuration-layer/layer-usedp 'syntax-checking)
@@ -37,6 +36,7 @@
     (progn
       (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+        "="  'rust-format-buffer
         "cc" 'spacemacs/rust-cargo-build
         "ct" 'spacemacs/rust-cargo-test
         "cd" 'spacemacs/rust-cargo-doc
@@ -72,15 +72,3 @@
       (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
         "gg" 'racer-find-definition))))
-
-(defun rust/init-rustfmt ()
-  (use-package rustfmt
-    :defer t
-    :init
-    (progn
-      (when rust-enable-rustfmt-on-save
-          (spacemacs/add-to-hook 'rust-mode-hook
-                                 '(rustfmt-enable-on-save)))
-
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "=" 'rustfmt-format-buffer))))


### PR DESCRIPTION
This package was merged into rust-mode.

Edit: instead of marking `rust-enable-rustfmt-on-save` as an obsolete variable, I simply deleted it since it never reached the master branch.