### PR TITLE
[RDY] Don't set insert-state for emacs users

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -226,6 +226,12 @@
       (defun evil-insert-state-cursor-hide ()
         (setq evil-insert-state-cursor '((hbar . 0))))
 
+      (defun spacemacs/normal-to-insert-state ()
+        "Switches to evil-insert-state if the current state is
+evil-normal state."
+        (when (evil-normal-state-p)
+          (evil-insert-state)))
+
       (unless (eq dotspacemacs-editing-style 'emacs)
         (evil-mode 1)))
     :config

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -57,7 +57,7 @@ the focus."
 `insert state'."
         (interactive)
         (cider-insert-last-sexp-in-repl t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/cider-send-region-to-repl (start end)
         "Send region to REPL and evaluate it without changing
@@ -72,7 +72,7 @@ the focus."
         (interactive "r")
         (cider-insert-in-repl
          (buffer-substring-no-properties start end) t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/cider-send-function-to-repl ()
         "Send current function to REPL and evaluate it without changing
@@ -85,7 +85,7 @@ the focus."
 `insert state'."
         (interactive)
         (cider-insert-defun-in-repl t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/cider-send-ns-form-to-repl ()
         "Send buffer's ns form to REPL and evaluate it without changing
@@ -98,7 +98,7 @@ the focus."
 `insert state'."
         (interactive)
         (cider-insert-ns-form-in-repl t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/cider-send-buffer-in-repl-and-focus ()
         "Send the current buffer in the REPL and switch to the REPL in
@@ -106,7 +106,7 @@ the focus."
         (interactive)
         (cider-load-buffer)
         (cider-switch-to-repl-buffer)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/cider-test-run-focused-test ()
         (interactive)

--- a/layers/+lang/elm/packages-funcs.el
+++ b/layers/+lang/elm/packages-funcs.el
@@ -25,10 +25,10 @@
   (interactive)
   (elm-repl-push-decl)
   (run-elm-interactive)
-  (evil-insert-state))
+  (spacemacs/normal-to-insert-state))
 
 (defun spacemacs/elm-repl-push-focus ()
   "Send current region to the REPL and focus it in insert state."
   (elm-repl-push)
   (run-elm-interactive)
-  (evil-insert-state))
+  (spacemacs/normal-to-insert-state))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -27,7 +27,7 @@
         (interactive)
         (fsharp-load-buffer-file)
         (switch-to-buffer-other-window inferior-fsharp-buffer-name)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/fsharp-eval-phrase-focus ()
         "Send the current phrase to REPL and switch to the REPL in
@@ -35,7 +35,7 @@
         (interactive)
         (fsharp-eval-phrase)
         (switch-to-buffer-other-window inferior-fsharp-buffer-name)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/fsharp-eval-region-focus (start end)
         "Send the current phrase to REPL and switch to the REPL in
@@ -43,7 +43,7 @@
         (interactive "r")
         (fsharp-eval-region start end)
         (switch-to-buffer-other-window inferior-fsharp-buffer-name)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
         ;; Compile

--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -24,21 +24,21 @@
         (interactive "p")
         (idris-load-file set-line)
         (idris-pop-to-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/idris-load-forward-line-and-focus ()
         "Pass the next line to REPL and switch to it in `insert state'."
         (interactive)
         (idris-load-forward-line)
         (idris-pop-to-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/idris-load-backward-line-and-focus ()
         "Pass the previous line to REPL and switch to it in `insert state'."
         (interactive)
         (idris-load-backward-line)
         (idris-pop-to-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/set-leader-keys-for-major-mode 'idris-mode
         ;; Shorthands: rebind the standard evil-mode combinations to the local

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -231,14 +231,14 @@
         (interactive)
         (skewer-load-buffer)
         (skewer-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/skewer-eval-defun-and-focus ()
        "Execute function at point in browser and switch to REPL in insert state."
        (interactive)
        (skewer-eval-defun)
        (skewer-repl)
-       (evil-insert-state))
+       (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/skewer-eval-region (beg end)
         "Execute the region as JavaScript code in the attached browser."
@@ -250,7 +250,7 @@
         (interactive "r")
         (spacemacs/skewer-eval-region beg end)
         (skewer-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/set-leader-keys-for-major-mode 'js2-mode
         "'" 'spacemacs/skewer-start-repl

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -123,7 +123,7 @@
         (interactive)
         (utop-eval-phrase)
         (utop)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/utop-eval-buffer-and-go ()
         "Send buffer to REPL and evaluate it and switch to the REPL in
@@ -131,7 +131,7 @@
         (interactive)
         (utop-eval-buffer)
         (utop)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/utop-eval-region-and-go (start end)
         "Send region to REPL and evaluate it and switch to the REPL in
@@ -139,7 +139,7 @@
         (interactive "r")
         (utop-eval-region start end)
         (utop)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
         "'"  'utop

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -271,27 +271,27 @@
         (interactive)
         (python-shell-send-buffer)
         (python-shell-switch-to-shell)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun python-shell-send-defun-switch ()
         "Send function content to shell and switch to it in insert mode."
         (interactive)
         (python-shell-send-defun nil)
         (python-shell-switch-to-shell)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun python-shell-send-region-switch (start end)
         "Send region content to shell and switch to it in insert mode."
         (interactive "r")
         (python-shell-send-region start end)
         (python-shell-switch-to-shell)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun python-start-or-switch-repl ()
         "Start and/or switch to the REPL."
         (interactive)
         (python-shell-switch-to-shell)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       ;; reset compile-command (by default it is `make -k')
       (setq compile-command nil)
@@ -317,7 +317,7 @@
         (spacemacs/python-execute-file arg)
         (switch-to-buffer-other-window "*compilation*")
         (end-of-buffer)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/declare-prefix-for-mode 'python-mode "mc" "execute")
       (spacemacs/declare-prefix-for-mode 'python-mode "md" "debug")

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -43,7 +43,7 @@
 `insert state'."
         (interactive)
         (racket-run-and-switch-to-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/racket-send-last-sexp-focus ()
         "Call `racket-send-last-sexp' and switch to REPL buffer in
@@ -51,7 +51,7 @@
         (interactive)
         (racket-send-last-sexp)
         (racket-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/racket-send-definition-focus ()
         "Call `racket-send-definition' and switch to REPL buffer in
@@ -59,7 +59,7 @@
         (interactive)
         (racket-send-definition)
         (racket-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/racket-send-region-focus (start end)
         "Call `racket-send-region' and switch to REPL buffer in
@@ -67,7 +67,7 @@
         (interactive "r")
         (racket-send-region start end)
         (racket-repl)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/set-leader-keys-for-major-mode 'racket-mode
         ;; navigation

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -74,14 +74,14 @@
         (interactive)
         (ensime-inf-eval-buffer)
         (ensime-inf-switch)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun ensime-inf-eval-region-switch (start end)
         "Send region content to shell and switch to it in insert mode."
         (interactive "r")
         (ensime-inf-switch)
         (ensime-inf-eval-region start end)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (dolist (prefix '(("mb" . "scala/build")
                         ("mc" . "scala/check")

--- a/layers/+lang/sml/packages.el
+++ b/layers/+lang/sml/packages.el
@@ -27,19 +27,19 @@
         "Send buffer to REPL and switch to it in `insert state'."
         (interactive)
         (sml-prog-proc-send-buffer t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/sml-prog-proc-send-region-and-focus (start end)
         "Send region to REPL and switch to it in `insert state'."
         (interactive "r")
         (sml-prog-proc-send-region start end t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (defun spacemacs/sml-send-function-and-focus ()
         "Send function at point to REPL and switch to it in `insert state'."
         (interactive)
         (sml-send-function t)
-        (evil-insert-state))
+        (spacemacs/normal-to-insert-state))
 
       (spacemacs/set-leader-keys-for-major-mode 'sml-mode
         ;; REPL

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -55,28 +55,28 @@
         (interactive)
         (let ((sql-pop-to-buffer-after-send-region t))
           (call-interactively 'sql-send-string)
-          (evil-insert-state)))
+          (spacemacs/normal-to-insert-state)))
 
       (defun spacemacs/sql-send-buffer-and-focus ()
         "Send the buffer to SQLi and switch to SQLi in `insert state'."
         (interactive)
         (let ((sql-pop-to-buffer-after-send-region t))
           (sql-send-buffer)
-          (evil-insert-state)))
+          (spacemacs/normal-to-insert-state)))
 
       (defun spacemacs/sql-send-paragraph-and-focus ()
         "Send the paragraph to SQLi and switch to SQLi in `insert state'."
         (interactive)
         (let ((sql-pop-to-buffer-after-send-region t))
           (sql-send-paragraph)
-          (evil-insert-state)))
+          (spacemacs/normal-to-insert-state)))
 
       (defun spacemacs/sql-send-region-and-focus (start end)
         "Send region to SQLi and switch to SQLi in `insert state'."
         (interactive "r")
         (let ((sql-pop-to-buffer-after-send-region t))
           (sql-send-region start end)
-          (evil-insert-state)))
+          (spacemacs/normal-to-insert-state)))
 
       (spacemacs/set-leader-keys-for-major-mode 'sql-mode
         "'" 'spacemacs/sql-start

--- a/layers/shell/packages.el
+++ b/layers/shell/packages.el
@@ -193,12 +193,12 @@ is achieved by adding the relevant text properties."
           "Correctly revert to insert state after selection."
           (interactive)
           (helm-eshell-history)
-          (evil-insert-state))
+          (spacemacs/normal-to-insert-state))
         (defun spacemacs/helm-shell-history ()
           "Correctly revert to insert state after selection."
           (interactive)
           (helm-comint-input-ring)
-          (evil-insert-state))
+          (spacemacs/normal-to-insert-state))
         (defun spacemacs/init-helm-eshell ()
           "Initialize helm-eshell."
           ;; this is buggy for now


### PR DESCRIPTION
When switching to repl in python-mode don't set evil-insert-state if the
user is using emacs editing style.

I don't know if this happens in other repls, i'll look for them :P.