### PR TITLE
mu4e: Don't use maildirs-extension by default.

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -29,6 +29,7 @@ the layer variable =mu4e-installation-path=, for example:
                         mu4e-installation-path "/usr/share/emacs/site-lisp")))
 #+end_src
 
+
 Then add this layer to your =~/.spacemacs=. You will need to add =mu4e= to the
 existing =dotspacemacs-configuration-layers= list in this file.
 
@@ -62,12 +63,18 @@ example configuration.  Refer to mu4e's manual for more detailed configuration
 instructions.
 
 ** Maildirs extension
-The maildirs extension adds a list of all your maildirs to the main mu4e view
+The [[https://github.com/agpchil/mu4e-maildirs-extension][maildirs extension]] adds a list of all your maildirs to the main mu4e view
 that by default shows the unread and total mail counts for all your mail under
 your base mail directory.
 
-This extension is enabled by default, you can deactivate (and uninstall) it by
-adding the package == to your dotfile variable =dotspacemacs-excluded-packages=.
+The maildirs extension is not enabled by default. To activate it, change the
+variable =mu4e-use-maildirs-extension= to a non-nil value:
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((mu4e :variables
+                        mu4e-use-maildirs-extension t)))
+#+end_src
 
 ** Multiple Accounts
 This layer includes support for multiple sending accounts.

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -21,5 +21,8 @@
 (defvar mu4e-enable-mode-line nil
   "If non-nil, enable display of unread emails in mode-line.")
 
+(defvar mu4e-use-maildirs-extension nil
+  "Use mu4e-maildirs-extension package if value is non-nil.")
+
 (when mu4e-installation-path
   (push mu4e-installation-path load-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -70,12 +70,12 @@
               (mu4e-alert-enable-mode-line-display)))))
 
 (defun mu4e/init-mu4e-maildirs-extension ()
+  "If mu4e-use-maildirs-extension is non-nil, set
+mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
   (use-package mu4e-maildirs-extension
-    :defer t
+    :if mu4e-use-maildirs-extension
     :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load))))
 
 (defun mu4e/post-init-org ()
   ;; load org-mu4e when org is actually loaded
   (with-eval-after-load 'org (require 'org-mu4e nil 'noerror)))
-
-


### PR DESCRIPTION
The maildirs extension is no longer turned on by default. It is now
installed only if the variable mu4e-use-maildirs-extension is non-nil.

Related issue: #4892
