### PR TITLE
Improve toggle-maximize-centered-buffer

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -182,32 +182,24 @@ the current state and point position."
       (window-configuration-to-register ?_)
       (delete-other-windows))))
 
-;; A small minor mode to use a big fringe
-;; from http://bzg.fr/emacs-strip-tease.html
-(defvar bzg-big-fringe-mode nil)
-(define-minor-mode bzg-big-fringe-mode
+;; A small minor mode to use a big fringe adapted from
+;; http://bzg.fr/emacs-strip-tease.html
+(define-minor-mode spacemacs-centered-buffer-mode
   "Minor mode to use big fringe in the current buffer."
-  :init-value nil
   :global t
-  :variable bzg-big-fringe-mode
+  :init-value nil
   :group 'editing-basics
-  (if (not bzg-big-fringe-mode)
-      (set-fringe-style nil)
-    (set-fringe-mode
-     (/ (- (frame-pixel-width)
-           (* 100 (frame-char-width)))
-        2))))
-
-(defun spacemacs/toggle-maximize-centered-buffer ()
-  "Maximize buffer and center it on the screen"
-  (interactive)
-  (if (= 1 (length (window-list)))
-      (progn  (bzg-big-fringe-mode 0)
-              (jump-to-register '_))
-    (progn
-      (set-register '_ (list (current-window-configuration)))
-      (delete-other-windows)
-      (bzg-big-fringe-mode 1))))
+  (if spacemacs-centered-buffer-mode
+      (progn
+        (window-configuration-to-register ?_)
+        (delete-other-windows)
+        (set-fringe-mode
+         (/ (- (frame-pixel-width)
+               (* 100 (frame-char-width)))
+            2)))
+    (set-fringe-style nil)
+    (when (assoc ?_ register-alist)
+      (jump-to-register ?_))))
 
 (defun spacemacs/useless-buffer-p (buffer)
   "Determines if a buffer is useful."

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -316,7 +316,7 @@
   "wl"  'evil-window-right
   "w <right>"  'evil-window-right
   "wm"  'spacemacs/toggle-maximize-buffer
-  "wM"  'spacemacs/toggle-maximize-centered-buffer
+  "wM"  'spacemacs-centered-buffer-mode
   "wo"  'other-frame
   "wR"  'spacemacs/rotate-windows
   "ws"  'split-window-below


### PR DESCRIPTION
1. The register name should be a character not a symbol.

2. Combine toggle-maximize-centered-buffer and bzg-big-fringe-mode to
   make new minor mode that combines the two effects.

3. Fix problem where the mode could only be enabled if there was more
   than one window, which makes no sense.

4. Use window-configuration-to-register function