### PR TITLE
Fix scroll transient state

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -312,33 +312,19 @@ Example: (evil-map visual \"<\" \"<gv\")"
         (kbd "gd") 'spacemacs/evil-smart-goto-definition)
 
       ;; scrolling transient state
-      (defun spacemacs/scroll-half-page-up ()
-        "Scroll half a page up while keeping cursor in middle of page."
-        (interactive)
-        (evil-window-top)
-        (let ((recenter-redisplay nil))
-          (recenter nil)))
-      (defun spacemacs/scroll-half-page-down ()
-        "Scroll half a page down while keeping cursor in middle of page."
-        (interactive)
-        (evil-window-bottom)
-        ;; required to make repeated presses idempotent
-        (evil-next-visual-line)
-        (let ((recenter-redisplay nil))
-          (recenter nil)))
       (spacemacs|define-transient-state scroll
         :title "Scrolling Transient State"
         :bindings
         ("," evil-scroll-page-up "page up")
         ("." evil-scroll-page-down "page down")
         ;; half page
-        ("<" spacemacs/scroll-half-page-up "half page up")
-        (">" spacemacs/scroll-half-page-down "half page down"))
+        ("<" evil-scroll-up "half page up")
+        (">" evil-scroll-down "half page down"))
       (spacemacs/set-leader-keys
         "n," 'spacemacs/scroll-transient-state/evil-scroll-page-up
         "n." 'spacemacs/scroll-transient-state/evil-scroll-page-down
-        "n<" 'spacemacs/scroll-transient-state/spacemacs/scroll-half-page-up
-        "n>" 'spacemacs/scroll-transient-state/spacemacs/scroll-half-page-down)
+        "n<" 'spacemacs/scroll-transient-state/scroll-half-page-up
+        "n>" 'spacemacs/scroll-transient-state/scroll-half-page-down)
 
       ;; pasting transient-state
       (spacemacs|define-transient-state paste


### PR DESCRIPTION
Fixes #3450

For some reason, the scroll transient state was trying to reinvent
scrolling halfway up and down a page when these are well supported
operations in evil.