### PR TITLE
markdown: Add binding for live preview mode

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -112,18 +112,19 @@ To generate a table of contents type on top of the buffer:
 
 ** Buffer-wide commands
 
-| Key Binding | Description          |
-|-------------+----------------------|
-| ~SPC m c ]~ | complete buffer      |
-| ~SPC m c m~ | other window         |
-| ~SPC m c p~ | preview              |
-| ~SPC m c e~ | export               |
-| ~SPC m c v~ | export and preview   |
-| ~SPC m c o~ | open                 |
-| ~SPC m c w~ | kill ring save       |
-| ~SPC m c c~ | check refs           |
-| ~SPC m c n~ | cleanup list numbers |
-| ~SPC m c r~ | render buffer        |
+| Key Binding | Description                             |
+|-------------+-----------------------------------------|
+| ~SPC m c ]~ | complete buffer                         |
+| ~SPC m c m~ | other window                            |
+| ~SPC m c p~ | preview                                 |
+| ~SPC m c P~ | live preview in Emacs' built-in browser |
+| ~SPC m c e~ | export                                  |
+| ~SPC m c v~ | export and preview                      |
+| ~SPC m c o~ | open                                    |
+| ~SPC m c w~ | kill ring save                          |
+| ~SPC m c c~ | check refs                              |
+| ~SPC m c n~ | cleanup list numbers                    |
+| ~SPC m c r~ | render buffer                           |
 
 ** List editing
 

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -78,6 +78,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "cn"  'markdown-cleanup-list-numbers
         "co"  'markdown-open
         "cp"  'markdown-preview
+        "cP"  'markdown-live-preview-mode
         "cv"  'markdown-export-and-preview
         "cw"  'markdown-kill-ring-save
         ;; headings


### PR DESCRIPTION
Recent versions of markdown provide markdown-live-preview-mode which shows a live preview in another window using Emacs' built-in EWW browser.  This pull request adds a binding to toggle this mode.  I'm not sure whether I should have implemented a proper spacemacs toggle for this so I went with the simpler route and bound the mode directly.  If you'd like to have a toggle please tell me.

Note that as it builds upon EWW this mode may not be available for older versions of Emacs.  As I'm using Emacs head I don't know however when EWW was introduced to Emacs, but I can find out if you'd like to add that to the documentation.