### PR TITLE
cider: yet another missed occurrence of cider-test-run-tests

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -116,7 +116,7 @@ the focus."
       (defun spacemacs/cider-test-run-all-tests ()
         (interactive)
         (cider-load-buffer)
-        (spacemacs//cider-eval-in-repl-no-focus (cider-test-run-tests nil)))
+        (spacemacs//cider-eval-in-repl-no-focus (cider-test-run-ns-tests nil)))
 
       (defun spacemacs/cider-test-rerun-tests ()
         (interactive)


### PR DESCRIPTION
Okay this was my bad as i didn't see this occurrence when I fixed the binding. This was not directly called but would result in another bug, so here's the fix.

If there is any other occurrence, please let me know. Should be hotfix?