### PR TITLE
Add C-S-(JK) to helm-follow-action

### DIFF
--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -397,6 +397,8 @@ Removes the automatic guessing of the initial value based on thing at point. "
                    hybrid-mode-enable-hjkl-bindings))
           (define-key helm-map (kbd "C-j") 'helm-next-line)
           (define-key helm-map (kbd "C-k") 'helm-previous-line)
+          (define-key helm-map (kbd "C-S-j") 'helm-follow-action-forward)
+          (define-key helm-map (kbd "C-S-k") 'helm-follow-action-backward)
           (define-key helm-map (kbd "C-h") 'helm-next-source)
           (define-key helm-map (kbd "C-S-h") 'describe-key)
           (define-key helm-map (kbd "C-l") (kbd "RET"))


### PR DESCRIPTION
I noticed that one can go down and up with `C-j` and `C-k` but
helm-follow-action bindings are M-down or M-up, which is not EVIL at all
:P just putting it out there @syl20bnr this should not break anything
