### PR TITLE
[Core] <SPC> f y working in dired buffers

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -357,11 +357,10 @@ argument takes the kindows rotate backwards."
 (defun spacemacs/show-and-copy-buffer-filename ()
   "Show and copy the full path to the current file in the minibuffer."
   (interactive)
-  (let ((file-name (buffer-file-name)))
+  ;; list-buffers-directory is the variable set in dired buffers
+  (let ((file-name (or (buffer-file-name) list-buffers-directory)))
     (if file-name
-        (progn
-          (message file-name)
-          (kill-new file-name))
+        (message (kill-new file-name))
       (error "Buffer not visiting a file"))))
 
 ;; adapted from bozhidar


### PR DESCRIPTION
Currently, the `spacemacs/show-and-copy-buffer-filename` does not work in dired buffers, this PR fixes that.