### PR TITLE
Change helm-themes and counsel-load-theme keybinding to SPC T s.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -429,7 +429,7 @@ To install it, just add =themes-megapack= to your =~/.spacemacs= like so:
 (setq-default dotspacemacs-configuration-layers '(themes-megapack))
 #+END_SRC
 
-You have now installed around 100 themes you are free to try with ~SPC T h~
+You have now installed around 100 themes you are free to try with ~SPC T s~
 (helm-themes).
 
 ** Managing private configuration layers
@@ -821,7 +821,7 @@ variable =dotspacemacs-themes=. For instance, to specify =solarized-light=,
 | Key Binding | Description                                           |
 |-------------+-------------------------------------------------------|
 | ~SPC T n~   | switch to next theme listed in =dotspacemacs-themes=. |
-| ~SPC T h~   | select a theme using a =helm= buffer.                 |
+| ~SPC T s~   | select a theme using a =helm= buffer.                 |
 
 You can see samples of all included themes in this [[http://themegallery.robdor.com][theme gallery]] from [[http://www.twitter.com/robmerrell][Rob Merrell]].
 

--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -959,4 +959,4 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
     :defer t
     :init
     (spacemacs/set-leader-keys
-      "Th" 'helm-themes)))
+      "Ts" 'helm-themes)))

--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -285,7 +285,7 @@ Helm hack."
         ;; jumping
         "sj"  'counsel-imenu
         ;; themes
-        "Tc"  'counsel-load-theme
+        "Ts"  'counsel-load-theme
         ;; search
         "/"   'spacemacs/search-project-auto
         "*"   'spacemacs/search-project-auto-region-or-symbol

--- a/layers/themes-megapack/README.org
+++ b/layers/themes-megapack/README.org
@@ -7,7 +7,7 @@
 
 * What is this?
 This simple contribution layer is an example. It installs around 100 themes
-for Emacs. You can try them easily by invoking helm-themes with: ~<SPC> T h~.
+for Emacs. You can try them easily by invoking helm-themes with: ~<SPC> T s~.
 
 You can see samples of all included themes in this [[http://themegallery.robdor.com][theme gallery]] from [[http://www.twitter.com/robmerrell][Rob Merrell]].
 


### PR DESCRIPTION
The current keybinding is SPC T h which is different from the binding for counsel-load-theme. The new mnemonic for both ivy and helm would be`UI themes/color themes` which IMO makes more sense than the helm specific mnemonic of `UI themes/helm`.