### PR TITLE
Enable OSX non-native fullscreen on regular builds

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -244,6 +244,8 @@ or lists of these.")
     (if dotspacemacs-maximized-at-startup
         (add-hook 'window-setup-hook 'toggle-frame-maximized))))
 
+(setq ns-use-native-fullscreen (not dotspacemacs-fullscreen-use-non-native))
+
 ;; ---------------------------------------------------------------------------
 ;; Session
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
The mac port build supports this out of the box, but the version
installed with `brew install emacs --with-cocoa` requires this variable to be
cleared.