### PR TITLE
Remove references to Solarized themes

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -98,8 +98,6 @@ of a list then all discovered layers will be installed.")
 
 (defvar dotspacemacs-themes '(spacemacs-dark
                               spacemacs-light
-                              solarized-dark
-                              solarized-light
                               leuven)
   "List of themes, the first of the list is loaded when spacemacs starts.
 Press <SPC> T n to cycle to the next theme in the list (works great

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -101,8 +101,6 @@ values."
    ;; with 2 themes variants, one dark and one light)
    dotspacemacs-themes '(spacemacs-dark
                          spacemacs-light
-                         solarized-light
-                         solarized-dark
                          leuven
                          monokai
                          zenburn)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -811,11 +811,11 @@ in the function =dotspacemacs/user-init= of your =~/.spacemacs=:
   - the height of org section titles with =spacemacs-theme-org-height=
 
 It is possible to define your default themes in your =~/.spacemacs= with the
-variable =dotspacemacs-themes=. For instance, to specify =solarized-light=,
+variable =dotspacemacs-themes=. For instance, to specify =spacemacs-light=,
 =leuven= and =zenburn=:
 
 #+BEGIN_SRC emacs-lisp
-(setq-default dotspacemacs-themes '(solarized-light leuven zenburn))
+(setq-default dotspacemacs-themes '(spacemacs-light leuven zenburn))
 #+END_SRC
 
 | Key Binding | Description                                           |


### PR DESCRIPTION
The documentation and configuration files shouldn't assume that the user have installed themes that isn't part of the default distribution in their general documentation.