### PR TITLE
Fix the change log of release 0.105.11

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,10 +1,9 @@
 * Release 0.105.x
 ** 0.105.11 (2016/02/18)
 Improve loading robustness:
-- when an ELPA repository is down Spacemacs will now be able to finish
-loading,
-- Spacemacs will use the default theme (i.e. no theme) if there is any
-error during the download of the starting theme.
+- When an ELPA repository is down Spacemacs will now be able to finish loading
+- Spacemacs will use the default theme (i.e. no theme) if there is any error
+  during the download of the starting theme.
 ** 0.105.10 (2016/02/18)
 *** Fixes
 - Fix re-toggle of fullscreen when pressing ~SPC f e R~ (thanks to MadAnd)


### PR DESCRIPTION
<img width="702" alt="screen shot 2016-02-20 at 1 49 49 pm" src="https://cloud.githubusercontent.com/assets/2863444/13194777/e5e69060-d7d8-11e5-88b4-bc487904611f.png">

It looks weird.