### PR TITLE
Fixes #5106

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -122,14 +122,14 @@ the current state and point position."
 ;; TODO: dispatch these in the layers
 (defvar spacemacs-indent-sensitive-modes
   '(coffee-mode
-    python-mode
-    slim-mode
     haml-mode
-    yaml-mode
+    haskell-mode
+    slim-mode
     makefile-mode
+    makefile-bsdmake-mode
     makefile-gmake-mode
     makefile-imake-mode
-    makefile-bsdmake-mode)
+    python-mode)
   "Modes for which auto-indenting is suppressed.")
 
 (defcustom spacemacs-yank-indent-threshold 1000


### PR DESCRIPTION
Fix #5106 -- Add haskell-mode to the spacemacs-indent-sensitive-modes list; also
makes the lost alphabetical. I went ahead and reordered the list alphabetically.