### PR TITLE
add 'cider-apropos functionalty to clojure layer

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -116,6 +116,7 @@ As this state works the same for all files, the documentation is in global
 
 | Key Binding | Description    |
 |-------------+----------------|
+| ~SPC m h a~ | cider apropos  |
 | ~SPC m h g~ | cider grimoire |
 | ~SPC m h h~ | cider doc      |
 | ~SPC m h j~ | cider javadoc  |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -200,6 +200,7 @@ If called with a prefix argument, uses the other-window instead."
 
       (dolist (m '(clojure-mode clojurec-mode clojurescript-mode clojurex-mode))
         (spacemacs/set-leader-keys-for-major-mode m
+          "ha" 'cider-apropos
           "hh" 'cider-doc
           "hg" 'cider-grimoire
           "hj" 'cider-javadoc


### PR DESCRIPTION
I'm unsure if this is important enough for inclusion or falls under "user key-bindings".