### PR TITLE
Eyebrowse: goto buffer in workspace

### DIFF
--- a/layers/+window-management/eyebrowse/funcs.el
+++ b/layers/+window-management/eyebrowse/funcs.el
@@ -1,0 +1,77 @@
+;;; funcs.el --- Eyebrowse Layer functions File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(require 'dash)
+
+;; Eyebrowse uses window-state objects (as returned by `window-state-get') to
+;; store window configurations, so here are some utility functions to help us
+;; analyse window-states.
+;; it might make more sense to move these functions to a more general place
+
+(defun spacemacs/window-state-window-p (object)
+  "Return t if OBJECT is a window, as represented in window-state objects.
+Note: this function doesn't test for real window objects, but for
+representations of a window in a window-state object as returned by
+`window-state-get'."
+  (and (listp object)
+       (memq (car object) '(leaf vc hc))))
+
+(defun spacemacs/window-state-get-buffer (window)
+  "Get WINDOW's buffer.
+WINDOW is the representation of a window in a window-state object.
+The returned value is the representation of a buffer in a window-state
+object."
+  (cdr (assq 'buffer window)))
+
+(defun spacemacs/window-state-get-buffer-name (window)
+  "Get WINDOW's buffer's name.
+WINDOW is the representation of a window in a window-state object."
+  (car (spacemacs/window-state-get-buffer window)))
+
+(defun spacemacs/window-state-walk-windows-1 (window fn)
+  "Helper function for `spacemacs/window-state-walk-windows'."
+  ;; WINDOW is a misleading name. WINDOW is a list that can represent a window,
+  ;; or a concatenation of several windows. window-state objects are weird.
+  (let ((child-windows
+         (-filter #'spacemacs/window-state-window-p window))
+        (bare-window
+         ;; if WINDOW contains more than one window, take only the first window
+         (--take-while (not (spacemacs/window-state-window-p it))
+                       window)))
+    (--each child-windows
+      (spacemacs/window-state-walk-windows-1 it fn))
+    (push (funcall fn bare-window) result)))
+
+(defun spacemacs/window-state-walk-windows (state fn)
+  "Execute FN once for each window in STATE and make a list of the results.
+FN is a function to execute.
+STATE is a window-state object."
+  (let (result)
+    (spacemacs/window-state-walk-windows-1 (cdr state) fn)
+    result))
+
+(defun spacemacs/window-state-all-windows (state)
+  "Get all windows contained in STATE.
+STATE is a window-state object.
+The returned windows are not actual window objects. They are windows as
+represented in window-state objects."
+  (spacemacs/window-state-walk-windows state #'identity))
+
+(defun spacemacs/window-state-get-buffer-names (state)
+  "Get names of all buffers saved in STATE.
+STATE is a window-state object as returned by `window-state-get'."
+  (delq nil (spacemacs/window-state-walk-windows state #'spacemacs/window-state-get-buffer-name)))
+
+(defun spacemacs/window-state-get-buffers (state)
+  "Get all buffers saved in STATE.
+STATE is a window-state object as returned by `window-state-get'."
+  ;; delq nil - removes buffers stored in STATE that don't exist anymore
+  (delq nil (mapcar #'get-buffer (spacemacs/window-state-get-buffer-names state))))

--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -23,6 +23,37 @@
       (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
       (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config)
 
+      (defun spacemacs/find-workspace (buffer)
+        "Find Eyebrowse workspace containing BUFFER.
+If several workspaces contain BUFFER, return the first one. Workspaces are
+ordered by slot number.
+If no workspace contains
+BUFFER, return nil."
+        ;; the second element of a workspace is its window-state object
+        (--find (memq buffer (spacemacs/window-state-get-buffers (cadr it)))
+               (eyebrowse--get 'window-configs)))
+
+      (defun spacemacs/display-in-workspace (buffer alist)
+        "Display BUFFER's workspace.
+Return BUFFER's window, if exists, otherwise nil.
+If BUFFER is already visible in current workspace, just return its window
+without switching workspaces."
+        (or (get-buffer-window buffer)
+            (-when-let (workspace (spacemacs/find-workspace buffer))
+              (eyebrowse-switch-to-window-config (car workspace))
+              (get-buffer-window buffer))))
+
+      (defun spacemacs/goto-buffer-workspace (buffer)
+        "Switch to BUFFER's window in BUFFER's workspace.
+If BUFFER isn't displayed in any workspace, display it in the current
+workspace, preferably in the current window."
+        (interactive "B")
+        (pop-to-buffer buffer '((;; reuse buffer window from some workspace
+                                 spacemacs/display-in-workspace
+                                 ;; fallback to display in current window
+                                 display-buffer-same-window)
+                                (inhibit-same-window . nil))))
+
       (defun spacemacs/workspaces-ms-rename ()
         "Rename a workspace and get back to transient-state."
         (interactive)


### PR DESCRIPTION
`spacemacs/find-workspace`, `spacemacs/display-in-workspace` and `spacemacs/goto-buffer-workspace` allow us to find and display a buffer's workspace.
This goes part of the way towards implementing #4075.

The functions in `funcs.el` are all related to window-state objects, and not strictly to Eyebrowse, so I don't know if they should remain part of Eyebrowse layer or moved elsewhere. Also I'm not sure what's the policy about having `(require 'dash)` in `funcs.el`.