### PR TITLE
fix spacemacs/swiper-region-or-symbol

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -546,7 +546,7 @@ around point as the initial input."
                          (buffer-substring-no-properties
                           (region-beginning) (region-end))
                        (thing-at-point 'symbol t))))
-          (swiper--ivy input)))
+          (swiper input)))
 
       (defun spacemacs/swiper-all-region-or-symbol ()
         "Run `swiper-all' with the selected region or the symbol


### PR DESCRIPTION
`swiper--ivy` takes candidates list and initial input. That's why in current implementation `spacemacs/swiper-region-or-symbol` is not working as expected. Looks like `swiper` is what it should be.