### PR TITLE
[RDY]add annotation when exporting instead of embedding.

### DIFF
--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -13,6 +13,7 @@
 (require 'ox-publish)
 (require 's)
 (require 'dash)
+(require 'f)
 
 (defvar spacemacs--category-names
   '(("config-files" . "Configuration files")
@@ -85,11 +86,41 @@
         (format "%s\n%s%s" beginning-of-content toc-string rest-of-content)
       content)))
 
+(defun spacemacs//add-org-meta-readtheorg-css (origfunc &rest args)
+  (save-current-buffer
+    (let* ((head-css-extra-readtheorg-head (concat
+                                            "#+HTML_HEAD_EXTRA:"
+                                            "<link rel=\"stylesheet\" "
+                                            "type=\"text/css\" "
+                                            "href=\""))
+           (head-css-extra-readtheorg-tail "css/readtheorg.css\" />\n")
+           (filename (car (nthcdr 1 args)))
+           (visitingp (find-buffer-visiting filename)))
+      (with-temp-buffer
+        (when visitingp (with-current-buffer visitingp (setq buffer-file-name nil)))
+        (insert-file-contents filename t)
+        (save-match-data
+          (if (or (re-search-forward "\+HTML_HEAD_EXTRA\:.*\/css\/readtheorg\.css" nil t nil)
+                  (string= filename "LAYERS.org"))
+              (apply origfunc args)
+            (progn (goto-char (point-min))
+                            (if (search-forward "#+TITLE:" nil t nil)
+                                (beginning-of-line 2)
+                              (error "Can't find #+TITLE:"))
+                            (insert (concat head-css-extra-readtheorg-head
+                                            (f-relative user-emacs-directory
+                                                        (file-name-directory filename))
+                                            head-css-extra-readtheorg-tail))
+                            (apply origfunc args)
+                            (not-modified)))))
+        (when visitingp (with-current-buffer visitingp (setq buffer-file-name filename))))))
+
 (defun spacemacs/publish-doc ()
   "Publishe the documentation to doc/export/."
   (interactive)
   (advice-add 'org-html-toc :filter-return #'spacemacs//format-toc)
   (advice-add 'org-html-template :filter-return #'spacemacs//format-content)
+  (advice-add 'org-html-publish-to-html :around #'spacemacs//add-org-meta-readtheorg-css)
   (let* ((header
           "<link rel=\"stylesheet\" type=\"text/css\"
                  href=\"http://www.pirilampo.org/styles/readtheorg/css/htmlize.css\"/>
@@ -137,6 +168,7 @@
              :publishing-function org-publish-attachment))))
     (org-publish-project "spacemacs"))
   (advice-remove 'org-html-toc #'spacemacs//format-toc)
-  (advice-remove 'org-html-template #'spacemacs//format-content))
+  (advice-remove 'org-html-template #'spacemacs//format-content)
+  (advice-remove 'org-html-publish-to-html #'spacemacs//add-org-meta-readtheorg-css))
 
 (provide 'core-documentation)

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -1,5 +1,4 @@
 #+TITLE: Spacemacs Conventions
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Spacemacs conventions                                     :TOC_4_org:noexport:
  - [[Code guidelines][Code guidelines]]

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1,5 +1,4 @@
 #+TITLE: Spacemacs documentation
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Spacemacs documentation                                   :TOC_4_org:noexport:
  - [[Core Pillars][Core Pillars]]

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -1,5 +1,4 @@
 #+TITLE: Frequently Asked Questions
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * FAQ                                                       :TOC_4_org:noexport:
  - [[Common][Common]]

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -1,5 +1,4 @@
 #+TITLE: Configuration layers
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Configuration Layers                                      :TOC_4_org:noexport:
  - [[Introduction][Introduction]]

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -1,5 +1,4 @@
 #+TITLE: Quick start
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Configuration                                             :TOC_4_org:noexport:
  - [[Configuration layers][Configuration layers]]

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -1,5 +1,4 @@
 #+TITLE: Migrating from Vim
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Migrating from vim                                        :TOC_4_org:noexport:
  - [[Purpose of this document][Purpose of this document]]

--- a/layers/+config-files/ansible/README.org
+++ b/layers/+config-files/ansible/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Ansible layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ansible.png]]
 

--- a/layers/+config-files/dockerfile/README.org
+++ b/layers/+config-files/dockerfile/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Dockerfile layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/docker.png]]
 

--- a/layers/+config-files/puppet/README.org
+++ b/layers/+config-files/puppet/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Puppet layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/puppet.png]]
 

--- a/layers/+config-files/salt/README.org
+++ b/layers/+config-files/salt/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Saltstack layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/saltstack.png]]
 

--- a/layers/+config-files/systemd/README.org
+++ b/layers/+config-files/systemd/README.org
@@ -1,5 +1,4 @@
 #+TITLE: systemd layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                        :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+config-files/terraform/README.org
+++ b/layers/+config-files/terraform/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Terraform layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/terraform.png]]
 

--- a/layers/+email/gnus/README.org
+++ b/layers/+email/gnus/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Gnus layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/gnus.gif]]
 

--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Mu4e layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Install][Install]]

--- a/layers/+frameworks/django/README.org
+++ b/layers/+frameworks/django/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Django layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/django.png]]
 

--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -1,5 +1,4 @@
 #+TITLE: React layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/react.png]]
 

--- a/layers/+frameworks/ruby-on-rails/README.org
+++ b/layers/+frameworks/ruby-on-rails/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Ruby on Rails layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ror.png]]
 

--- a/layers/+fun/emoji/README.org
+++ b/layers/+fun/emoji/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Emoji layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/emojis.png]]
 

--- a/layers/+fun/games/README.org
+++ b/layers/+fun/games/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Games layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/games.png]]
 

--- a/layers/+fun/selectric/README.org
+++ b/layers/+fun/selectric/README.org
@@ -1,5 +1,4 @@
 #+TITLE: selectric layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/typewriter.jpg]]
 

--- a/layers/+fun/xkcd/README.org
+++ b/layers/+fun/xkcd/README.org
@@ -1,5 +1,4 @@
 #+TITLE: xkcd layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/xkcd.png]]
 

--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -1,5 +1,4 @@
 #+TITLE: ERC layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+irc/rcirc/README.org
+++ b/layers/+irc/rcirc/README.org
@@ -1,5 +1,4 @@
 #+TITLE: RCIRC layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/irc.png]]
 

--- a/layers/+keyboard-layouts/bepo/README.org
+++ b/layers/+keyboard-layouts/bepo/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Bépo layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 #+CAPTION: logo
 

--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Agda layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/asciidoc/README.org
+++ b/layers/+lang/asciidoc/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Asciidoc layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/asm/README.org
+++ b/layers/+lang/asm/README.org
@@ -1,5 +1,4 @@
 #+TITLE: asm layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 [[file:img/asm.png]]
 

--- a/layers/+lang/autohotkey/README.org
+++ b/layers/+lang/autohotkey/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Autohotkey layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ahk.png]]
 

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -1,5 +1,4 @@
 #+TITLE: C/C++ layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ccpp.jpg]]
 [[file:img/cmake.png]]

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Clojure layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/clojure.png]] [[file:img/cider.png]]
 

--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Common Lisp layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/slime.png]]
 

--- a/layers/+lang/csharp/README.org
+++ b/layers/+lang/csharp/README.org
@@ -1,5 +1,4 @@
 #+TITLE: C# layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/csharp.png]] [[file:img/dotnet.png]]
 

--- a/layers/+lang/csv/README.org
+++ b/layers/+lang/csv/README.org
@@ -1,5 +1,4 @@
 #+TITLE: CSV layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 [[file:img/csv.png]]
 

--- a/layers/+lang/d/README.org
+++ b/layers/+lang/d/README.org
@@ -1,5 +1,4 @@
 #+TITLE: D language layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/dlogo.png]]
 

--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Elixir layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/elixir.png]] with [[file:img/alchemist.png]]
 

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Elm layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/elm.png]]
 

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Emacs Lisp layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/emacs-lisp.png]]
 

--- a/layers/+lang/erlang/README.org
+++ b/layers/+lang/erlang/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Erlang layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/erlang.png]]
 

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -1,5 +1,4 @@
 #+TITLE: ESS (R) layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/r.jpg]]
 

--- a/layers/+lang/extra-langs/README.org
+++ b/layers/+lang/extra-langs/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Extra Languages
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/fsharp/README.org
+++ b/layers/+lang/fsharp/README.org
@@ -1,5 +1,4 @@
 #+TITLE: F# layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/fsharp.png]]
 

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -1,5 +1,4 @@
 #+TITLE: GO layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/go.png]]
 

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Haskell layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/haskell.png]]
 

--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -1,5 +1,4 @@
 #+TITLE: HTML layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/html.png]]
 

--- a/layers/+lang/idris/README.org
+++ b/layers/+lang/idris/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Idris layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/idris.png]]
 

--- a/layers/+lang/ipython-notebook/README.org
+++ b/layers/+lang/ipython-notebook/README.org
@@ -1,5 +1,4 @@
 #+TITLE: IPython Notebook layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Java layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/java.png]]
 

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -1,5 +1,4 @@
 #+TITLE: JavaScript layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/javascript.png]] [[file:img/coffee.png]]
 

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -1,5 +1,4 @@
 #+TITLE: LaTeX layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/latex.png]]
 

--- a/layers/+lang/lua/README.org
+++ b/layers/+lang/lua/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Lua contribution layer for Spacemacs
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/lua.gif]]
 

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Markdown layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/markdown.png]]
 

--- a/layers/+lang/nim/README.org
+++ b/layers/+lang/nim/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Nim layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/logo.png]]
 

--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Ocaml layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ocaml.png]]
 

--- a/layers/+lang/octave/README.org
+++ b/layers/+lang/octave/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Octave layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/octave.png]]
 

--- a/layers/+lang/php/README.org
+++ b/layers/+lang/php/README.org
@@ -1,5 +1,4 @@
 #+TITLE: PHP layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
  
 [[file:img/php.png]]
 

--- a/layers/+lang/plantuml/README.org
+++ b/layers/+lang/plantuml/README.org
@@ -1,5 +1,4 @@
 #+TITLE: plantuml layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 [[file:img/logo.png]]
 * Table of Contents                                        :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/purescript/README.org
+++ b/layers/+lang/purescript/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Purescript layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/purescript-logo.png]]
 

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Python layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/python.png]]
 

--- a/layers/+lang/racket/README.org
+++ b/layers/+lang/racket/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Racket layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/racket.png]]
 

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Ruby layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ruby.png]]
 

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Rust contribution layer for Spacemacs
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/rust.png]]
 

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Scala layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/scala.png]] with [[file:img/ensime.png]]
 

--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Scheme layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/shell-scripts/README.org
+++ b/layers/+lang/shell-scripts/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Shell Scripts layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/fish.png]]
 

--- a/layers/+lang/sml/README.org
+++ b/layers/+lang/sml/README.org
@@ -1,5 +1,4 @@
 #+TITLE: SML layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/sml.png]]
 

--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -1,5 +1,4 @@
 #+TITLE: SQL layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/sql.png]]
 

--- a/layers/+lang/swift/README.org
+++ b/layers/+lang/swift/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Swift layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/swift.png]]
 

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -1,5 +1,4 @@
 #+TITLE: TypeScript layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/TypeScript.png]]
 

--- a/layers/+lang/vimscript/README.org
+++ b/layers/+lang/vimscript/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Vimscript language layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+lang/windows-scripts/README.org
+++ b/layers/+lang/windows-scripts/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Windows Scripting layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/ps.png]]
 

--- a/layers/+lang/yaml/README.org
+++ b/layers/+lang/yaml/README.org
@@ -1,5 +1,4 @@
 #+TITLE: YAML layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Git contribution layer for Spacemacs
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 
 [[file:img/git.png]]

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Github layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/github.png]]
 

--- a/layers/+source-control/perforce/README.org
+++ b/layers/+source-control/perforce/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Perforce layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/p4.png]]
 

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Version-Control layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/command-log/README.org
+++ b/layers/+tools/command-log/README.org
@@ -1,5 +1,4 @@
 #+TITLE: command-log layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                        :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/dash/README.org
+++ b/layers/+tools/dash/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Dash layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/dash.png]]
 

--- a/layers/+tools/elfeed/README.org
+++ b/layers/+tools/elfeed/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Elfeed layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/elfeed.png]]
 

--- a/layers/+tools/evernote/README.org
+++ b/layers/+tools/evernote/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Evernote layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/evernote.png]] with [[file:img/geeknote.png]]
 

--- a/layers/+tools/fasd/README.org
+++ b/layers/+tools/fasd/README.org
@@ -1,5 +1,4 @@
 #+TITLE: fasd layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/pandoc/README.org
+++ b/layers/+tools/pandoc/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Pandoc layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Ranger layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+tools/tmux/README.org
+++ b/layers/+tools/tmux/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Tmux layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[What is this][What is this]]

--- a/layers/+tools/vagrant/README.org
+++ b/layers/+tools/vagrant/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Vagrant layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/vagrant.png]]
 

--- a/layers/+tools/wakatime/README.org
+++ b/layers/+tools/wakatime/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Wakatime layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/wakatime.png]]
 

--- a/layers/+tools/ycmd/README.org
+++ b/layers/+tools/ycmd/README.org
@@ -1,5 +1,4 @@
 #+TITLE: YCMD layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/evil-cleverparens/README.org
+++ b/layers/+vim/evil-cleverparens/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Evil-Cleverparens layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                                   :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/evil-commentary/README.org
+++ b/layers/+vim/evil-commentary/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Evil-commentary layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/evil-snipe/README.org
+++ b/layers/+vim/evil-snipe/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Evil-snipe layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/Cat_With_Rifle.jpg]]
 

--- a/layers/+vim/vim-empty-lines/README.org
+++ b/layers/+vim/vim-empty-lines/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Vim-empty-lines layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/vim-powerline/README.org
+++ b/layers/+vim/vim-powerline/README.org
@@ -1,5 +1,4 @@
 #+TITLE: vim-powerline layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+vim/vinegar/README.org
+++ b/layers/+vim/vinegar/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Vinegar layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/+window-management/eyebrowse/README.org
+++ b/layers/+window-management/eyebrowse/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Eyebrowse layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 [[file:img/eyebrowse.gif]] [[file:img/i3wm.png]]
 

--- a/layers/+window-management/spacemacs-layouts/README.org
+++ b/layers/+window-management/spacemacs-layouts/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Spacemacs Layouts layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1,5 +1,4 @@
 #+TITLE: Configuration layers
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                      :TOC_4_org:noexport:
  - [[General layers][General layers]]

--- a/layers/auto-completion/README.org
+++ b/layers/auto-completion/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Auto-completion layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/better-defaults/README.org
+++ b/layers/better-defaults/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Better Defaults layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/emacs.png]]
 

--- a/layers/chinese/README.org
+++ b/layers/chinese/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Chinese layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/China.png]]  [[file:img/Chinese.png]]
 

--- a/layers/chrome/README.org
+++ b/layers/chrome/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Chrome layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/chrome.png]]
 

--- a/layers/colors/README.org
+++ b/layers/colors/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Colors layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/rainbow_dash.png]]
 

--- a/layers/cscope/README.org
+++ b/layers/cscope/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Cscope layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/cscope.jpg]]
 

--- a/layers/deft/README.org
+++ b/layers/deft/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Deft layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Content                                          :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/finance/README.org
+++ b/layers/finance/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Finance layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/floobits/README.org
+++ b/layers/floobits/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Floobits layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/floobits.png]]
 

--- a/layers/geolocation/README.org
+++ b/layers/geolocation/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Geolocation layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/gtags/README.org
+++ b/layers/gtags/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Helm Gtags layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/ibuffer/README.org
+++ b/layers/ibuffer/README.org
@@ -1,5 +1,4 @@
 #+TITLE: IBuffer layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/jabber/README.org
+++ b/layers/jabber/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Jabber contribution layer for Spacemacs
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/jabber-logo.gif]]
 

--- a/layers/nixos/README.org
+++ b/layers/nixos/README.org
@@ -1,5 +1,4 @@
 #+TITLE: NixOS layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/nixos.jpg]]
 

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Org layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/org.png]]
 

--- a/layers/osx/README.org
+++ b/layers/osx/README.org
@@ -1,5 +1,4 @@
 #+TITLE: OSX layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/apple.png]]
 

--- a/layers/prodigy/README.org
+++ b/layers/prodigy/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Prodigy layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/prodigy.png]]
 

--- a/layers/restclient/README.org
+++ b/layers/restclient/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Restclient layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[What is this?][What is this?]]

--- a/layers/search-engine/README.org
+++ b/layers/search-engine/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Search Engine layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/searchengine.jpg]]
 

--- a/layers/semantic/README.org
+++ b/layers/semantic/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Semantic layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Description
 

--- a/layers/shell/README.org
+++ b/layers/shell/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Shell layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/shell.png]]
 

--- a/layers/smex/README.org
+++ b/layers/smex/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Smex layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/smex.png]]
 

--- a/layers/speed-reading/README.org
+++ b/layers/speed-reading/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Speed Reading layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
 
 * Table of Contents                                        :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/spell-checking/README.org
+++ b/layers/spell-checking/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Spell Checking layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/spotify/README.org
+++ b/layers/spotify/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Spotify layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/spotify.png]]
 

--- a/layers/syntax-checking/README.org
+++ b/layers/syntax-checking/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Syntax Checking layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 [[file:img/flycheck.png]]
 

--- a/layers/themes-megapack/README.org
+++ b/layers/themes-megapack/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Themes Megapack layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[What is this?][What is this?]]

--- a/layers/theming/README.org
+++ b/layers/theming/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Theming layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]

--- a/layers/typography/README.org
+++ b/layers/typography/README.org
@@ -1,5 +1,4 @@
 #+TITLE: Typography layer
-#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../css/readtheorg.css" />
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]


### PR DESCRIPTION
Add function `spacemacs//add-org-meta-readtheorg-css` that wraps around `org-html-publish-to-html`. The function inserts `readtheorg.css` link with a proper path if the document to be published doesn't have it.

It removes the need to clutter Spacemacs documentation with `#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />` in each org file.  Also it reduces amount of bugs, because it's hard to get the path right.

Also I removed those links from the org files.