### PR TITLE
Mention support for Slim and Jade templates in the HTML Layer docs

### DIFF
--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -19,6 +19,8 @@ This layer adds support for editing HTML and CSS.
 - Support for Sass/Scss and Less files
 - Generate HTML and CSS coding using [[https://github.com/smihica/emmet-mode][emmet-mode]]
 - Tags navigation on key ~%~ using [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
+- Support for editing Slim and Jade templates using [[https://github.com/slim-template/emacs-slim][slim-mode]]
+  and [[https://github.com/brianc/jade-mode][jade-mode]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
Updates the docs to mention that editing Slim and Jade templates are supported.

Fixes #5206.