### PR TITLE
Add `Appraisals` to Ruby modes

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -75,7 +75,8 @@
 
 (defun ruby/init-enh-ruby-mode ()
   (use-package enh-ruby-mode
-    :mode (("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . enh-ruby-mode)
+    :mode (("Appraisals\\'" . enh-ruby-mode)
+           ("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . enh-ruby-mode)
            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))
     :interpreter "ruby"
     :config
@@ -192,7 +193,8 @@
 (defun ruby/init-ruby-mode ()
   (use-package ruby-mode
     :defer t
-    :mode "Puppetfile"
+    :mode (("Appraisals\\'" . ruby-mode)
+           ("Puppetfile" . ruby-mode))
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'ruby-mode


### PR DESCRIPTION
This is a small change that adds `Appraisals` files to all Ruby modes.

https://github.com/thoughtbot/appraisal

> Appraisal integrates with bundler and rake to test your library against different versions of dependencies in repeatable scenarios called "appraisals." Appraisal is designed to make it easy to check for regressions in your library without interfering with day-to-day development using Bundler.