### PR TITLE
Use unless-debug version of condition-case

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -256,7 +256,7 @@ refreshed during the current session."
                              "\nError connection time out for %s repository!"
                              (car archive)) :warning)
                            'error))
-                      (condition-case err
+                      (condition-case-unless-debug err
                           (url-retrieve-synchronously (cdr archive))
                         ('error
                          (display-warning 'spacemacs
@@ -921,7 +921,7 @@ path."
              pkg-name (if layer (format "@%S" layer) "")
              installed-count noinst-count) t)
     (unless (package-installed-p pkg-name)
-      (condition-case err
+      (condition-case-unless-debug err
           (cond
            ((or (null pkg) (eq 'elpa location))
             (configuration-layer//install-from-elpa pkg-name)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -27,7 +27,7 @@ directory is returned.
 If LOG is non-nil a message is displayed in spacemacs-buffer-mode buffer.
 FILE-TO-LOAD is an explicit file to load after the installation."
   (let ((warning-minimum-level :error))
-    (condition-case nil
+    (condition-case-unless-debug nil
         (require pkg)
       (error
        ;; not installed, we try to initialize package.el only if required to

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -189,7 +189,7 @@ package name does not match theme name + `-theme' suffix.")
 (defun spacemacs/load-theme (theme)
   "Load THEME."
   ;; Required dependencies for some themes
-  (condition-case err
+  (condition-case-unless-debug err
       (progn
         (when (or (eq 'zonokai-blue theme)
                   (eq 'zonokai-red theme)

--- a/layers/+completion/spacemacs-helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/spacemacs-helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -176,7 +176,7 @@
                 (concat spacemacs-docs-directory candidate))))
     (cond ((and (equal (file-name-extension file) "md")
                 (not helm-current-prefix-arg))
-           (condition-case nil
+           (condition-case-unless-debug nil
                (with-current-buffer (find-file-noselect file)
                  (gh-md-render-buffer)
                  (kill-this-buffer))

--- a/layers/+completion/spacemacs-ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/spacemacs-ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -98,7 +98,7 @@
                   (concat user-emacs-directory candidate)
                 (concat spacemacs-docs-directory candidate))))
     (cond ((equal (file-name-extension file) "md")
-           (condition-case nil
+           (condition-case-unless-debug nil
                (with-current-buffer (find-file-noselect file)
                  (gh-md-render-buffer)
                  (kill-this-buffer))

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -166,7 +166,7 @@ the current state and point position."
   "Replace the preceding sexp with its value."
   (interactive)
   (backward-kill-sexp)
-  (condition-case nil
+  (condition-case-unless-debug nil
       (prin1 (eval (read (current-kill 0)))
              (current-buffer))
     (error (message "Invalid expression")
@@ -500,7 +500,7 @@ dotspacemacs-persistent-server to be t"
 (defun spacemacs/frame-killer ()
   "Kill server buffer and hide the main Emacs window"
   (interactive)
-  (condition-case nil
+  (condition-case-unless-debug nil
       (delete-frame nil 1)
       (error
        (make-frame-invisible nil 1))))

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -300,7 +300,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
         i.e. `SPC m h h`, to lookup the source of the definition,
         while falling back to `evil-lookup'"
         (interactive)
-        (condition-case nil
+        (condition-case-unless-debug nil
             (execute-kbd-macro (kbd (concat dotspacemacs-leader-key " mhh")))
           (error (evil-lookup))))
       (define-key evil-normal-state-map (kbd "K") 'spacemacs/evil-smart-doc-lookup)
@@ -311,7 +311,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
         i.e. `SPC m g g`, to lookup the source of the definition,
         while falling back to `evil-goto-definition'"
         (interactive)
-        (condition-case nil
+        (condition-case-unless-debug nil
             (execute-kbd-macro (kbd (concat dotspacemacs-leader-key " mgg")))
           (error (evil-goto-definition))))
       (define-key evil-normal-state-map

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -300,9 +300,10 @@ Example: (evil-map visual \"<\" \"<gv\")"
         i.e. `SPC m h h`, to lookup the source of the definition,
         while falling back to `evil-lookup'"
         (interactive)
-        (condition-case-unless-debug nil
-            (execute-kbd-macro (kbd (concat dotspacemacs-leader-key " mhh")))
-          (error (evil-lookup))))
+        (let (binding (key-binding " mhh"))
+          (if (commandp binding)
+              (call-interactively binding)
+            (evil-lookup))))
       (define-key evil-normal-state-map (kbd "K") 'spacemacs/evil-smart-doc-lookup)
 
       (defun spacemacs/evil-smart-goto-definition ()
@@ -311,9 +312,10 @@ Example: (evil-map visual \"<\" \"<gv\")"
         i.e. `SPC m g g`, to lookup the source of the definition,
         while falling back to `evil-goto-definition'"
         (interactive)
-        (condition-case-unless-debug nil
-            (execute-kbd-macro (kbd (concat dotspacemacs-leader-key " mgg")))
-          (error (evil-goto-definition))))
+        (let (binding (key-binding " mgg"))
+          (if (commandp binding)
+              (call-interactively binding)
+            (evil-goto-definition))))
       (define-key evil-normal-state-map
         (kbd "gd") 'spacemacs/evil-smart-goto-definition)
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -391,7 +391,7 @@
 paths for Python then prevent the buffer to be switched. This
 issue might be fixed in Emacs 25. Until then, we need it here to
 fix this issue."
-    (condition-case nil
+    (condition-case-unless-debug nil
         ad-do-it
       (error nil))))
 

--- a/layers/+vim/vinegar/funcs.el
+++ b/layers/+vim/vinegar/funcs.el
@@ -128,7 +128,7 @@
           (error "No file chosen"))
       (set-buffer (window-buffer window))
       (goto-char pos)
-      (condition-case ex
+      (condition-case-unless-debug ex
           (progn
             (setq file (dired-get-file-for-visit))
             (dired-find-file-other-window))


### PR DESCRIPTION
It's not possible to get full backtraces in these instances when an
error is signaled, and I think we should generate full backtraces when
debug-on-error is enabled as a general rule.

I had to make this change at one place to track down the root of problem
2 in #5200.