### PR TITLE
fix for git-blame transient state

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -146,7 +146,7 @@
         "gS" 'magit-stage-file
         "gU" 'magit-unstage-file)
 
-      (spacemacs|define-micro-state git-blame
+      (spacemacs|define-transient-state git-blame
         :title "Git Blame Transient State"
         :doc "
 Press [_b_] again to blame further in the history, [_q_] to go up or quit."


### PR DESCRIPTION
looks like a typo, use transient state vs micro-state for magit-blame