### PR TITLE
fix call to correctly go to transient-state

### DIFF
--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -27,7 +27,7 @@
         "Rename a workspace and get back to transient-state."
         (interactive)
         (eyebrowse-rename-window-config (eyebrowse--get 'current-slot) nil)
-        (spacemacs/workspaces-micro-state))
+        (spacemacs/workspaces-transient-state/body))
 
       (defun spacemacs//workspaces-ms-get-slot-name (window-config)
         "Return the name for the given window-config"


### PR DESCRIPTION
we want to call workspaces-transient-state vs workspaces-micro-state.
this was probably just an oversight, but nonetheless keeps the fn from
working properly and needs to be updated.