### PR TITLE
vim/hybrid: rebind C-k, C-h to M-k, M-h in helm

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1704,13 +1704,15 @@ navigate between =Emacs= and Spacemacs specific files.
 In =vim= and  =hybrid= styles, Spacemacs remap the navigation in Helm find-files
 to keep finger on the home row.
 
-| Key Binding | Description                       |
-|-------------+-----------------------------------|
-| ~C-h~       | go up one level (parent directory |
-| ~C-H~       | describe key (replace ~C-h~)      |
-| ~C-j~       | go to previous candidate          |
-| ~C-k~       | go to next candidate              |
-| ~C-l~       | enter current directory           |
+| Key Binding | Description                        |
+|-------------+------------------------------------|
+| ~C-h~       | go up one level (parent directory) |
+| ~C-H~       | describe key (replace ~C-h k~)     |
+| ~C-j~       | go to previous candidate           |
+| ~C-k~       | go to next candidate               |
+| ~C-l~       | enter current directory            |
+| ~M-h~       | help prefix (replace ~C-h~)        |
+| ~M-k~       | kill input (replace ~C-k~)         |
 
 *** Ido
 Spacemacs displays the =ido= minibuffer vertically thanks to the

--- a/layers/+completion/spacemacs-helm/packages.el
+++ b/layers/+completion/spacemacs-helm/packages.el
@@ -399,6 +399,9 @@ ARG non nil means Vim like movements."
           (define-key helm-map (kbd "C-h") 'helm-next-source)
           (define-key helm-map (kbd "C-S-h") 'describe-key)
           (define-key helm-map (kbd "C-l") (kbd "RET"))
+          ;; rebind missing `C-k' and `C-h' commands to `M-k' and `M-h'
+          (define-key helm-map (kbd "M-k") 'helm-delete-minibuffer-contents)
+          (define-key helm-map (kbd "M-h") 'help-command)
           (with-eval-after-load 'helm-files
             (dolist (keymap (list helm-find-files-map helm-read-file-map))
               (define-key keymap (kbd "C-l") 'helm-execute-persistent-action)


### PR DESCRIPTION
In Helm, when Vim or Hybrid editing style is used, we shadow the useful original bindings of `C-k` and `C-h`. This PR rebinds the missing commands to `M-k` and `M-h`.