### PR TITLE
create align-repeat-backslash command

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -689,6 +689,7 @@ the right."
 (spacemacs|create-align-repeat-x "bar" "|")
 (spacemacs|create-align-repeat-x "left-paren" "(")
 (spacemacs|create-align-repeat-x "right-paren" ")" t)
+(spacemacs|create-align-repeat-x "backslash" "\\\\")
 
 ;; END align functions
 

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -341,6 +341,7 @@
   "xa:" 'spacemacs/align-repeat-colon
   "xa;" 'spacemacs/align-repeat-semicolon
   "xa=" 'spacemacs/align-repeat-equal
+  "xa\\" 'spacemacs/align-repeat-backslash
   "xaa" 'align
   "xac" 'align-current
   "xam" 'spacemacs/align-repeat-math-oper


### PR DESCRIPTION
I frequently like to align the backslash character in my code when breaking string and such across multiple lines. This PR adds a menu option for backslash to the align menu.

```bash
 for f in \
   foo    \
   barbaz \
   qux    \
; do
```