### PR TITLE
Disable tilde fringe in shell/comint modes

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -387,7 +387,13 @@
        ;; if so, disable vi-tilde-fringe-mode
        (add-hook 'after-change-major-mode-hook (lambda ()
                                                  (when buffer-read-only
-                                                   (vi-tilde-fringe-mode -1)))))
+                                                   (vi-tilde-fringe-mode -1))))
+       (spacemacs/add-to-hooks (lambda () (vi-tilde-fringe-mode -1))
+                               '(comint-mode-hook
+                                 eshell-mode-hook
+                                 eww-mode-hook
+                                 shell-mode-hook
+                                 term-mode-hook)))
      :config
      (spacemacs|hide-lighter vi-tilde-fringe-mode))))
 


### PR DESCRIPTION
Disable the tilde fringe mode in shells, this seems to be the same behaviour that would be expected in VIM.