### PR TITLE
maps <escape> instead of ESC to quit help-mode

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -254,7 +254,7 @@ evil-normal state."
       (spacemacs/set-leader-keys "re" 'evil-show-registers)
       (define-key evil-visual-state-map (kbd "<escape>") 'keyboard-quit)
       ;; motions keys for help buffers
-      (evil-define-key 'motion help-mode-map (kbd "ESC") 'quit-window)
+      (evil-define-key 'motion help-mode-map (kbd "<escape>") 'quit-window)
       (evil-define-key 'motion help-mode-map (kbd "<tab>") 'forward-button)
       (evil-define-key 'motion help-mode-map (kbd "S-<tab>") 'backward-button)
       (evil-define-key 'motion help-mode-map (kbd "]") 'help-go-forward)


### PR DESCRIPTION
prevents masking M- keys in GUI.