### PR TITLE
Exit layout transient state on select custom layout

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -304,7 +304,7 @@ format so they are supported by the
             (let* ((binding (car custom-persp))
                    (name (cdr custom-persp))
                    (func-name (spacemacs//custom-layout-func-name name)))
-              (push (list binding func-name) bindings)))
+              (push (list binding func-name :exit t) bindings)))
           (eval `(spacemacs|define-transient-state custom-layouts
                    :doc (concat (spacemacs//custom-layouts-ms-documentation))
                    :bindings


### PR DESCRIPTION
This was asked for in the gitter chat. I thought at first it would be
great for when people wanted to open many perspectives at the same time,
but now I don't think the same. It'd be very hard to modify the macro
for adding custom layouts to make this argument optional, so I leave it
at @syl20bnr discretion.