### PR TITLE
Rubocop [Style/Align(Hash|Array)]

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -79,8 +79,8 @@
     :interpreter "ruby"
     :config
     (progn
-      (setq enh-ruby-deep-indent-paren nil
-            enh-ruby-hanging-paren-deep-indent-level 2))))
+      (setq enh-ruby-deep-indent-paren t
+            enh-ruby-hanging-paren-deep-indent-level 0))))
 
 (defun ruby/post-init-evil-matchit ()
   (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))


### PR DESCRIPTION
# Wrong:
```ruby
h = {some: :value,
  multiline: :hash,
  or: :anything,
  else: :similar}

h.merge(more: :of,
  a: :multiline,
  that: :is,
  wrong: :ident)
```

# Right:
```ruby
h = {some: :value,
     multiline: :hash,
     or: :anything,
     else: :similar}

h.merge(more: :of,
        a: :multiline,
        that: :is,
        right: :ident)
```