### PR TITLE
Java layer: fix keyboard shortcut documentation.

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -64,7 +64,7 @@ option in =emacs-eclim= itself.
 | ~SPC m p j~ | Information about project      |
 | ~SPC m p k~ | Close project                  |
 | ~SPC m p o~ | Open project                   |
-| ~SPC m p s~ | Open project management buffer |
+| ~SPC m p p~ | Open project management buffer |
 | ~SPC m p u~ | Update project                 |
 
 *** Maven


### PR DESCRIPTION
Java layer: fix keyboard shortcut documentation.

The "Open project management buffer" shortcut is actually SC m p p, as per https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Blang/java/packages.el#L121, not SPC m p s which does nothing.