### PR TITLE
[WIP] Cleanse the org file headlines

### DIFF
--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -38,7 +38,7 @@ add =react= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 You will also need to install =tern= to use the auto-completion and
-documentation features:
+documentation features
 #+BEGIN_SRC sh
   $ npm install -g tern
 #+END_SRC

--- a/layers/+fun/xkcd/README.org
+++ b/layers/+fun/xkcd/README.org
@@ -13,7 +13,7 @@
 * Description
 This layer adds a [[http://xkcd.com/][xkcd]] navigation mode using [[https://github.com/vibhavp/emacs-xkcd][emacs-xkcd]].
 
-Features:
+Features
 - Load a random xkcd
 - Show the text in the modeline
 - Open explanation and current comic in browser

--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -3,7 +3,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Some features:][Some features:]]
+   - [[Some features][Some features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
    - [[Agda][Agda]]
@@ -12,7 +12,7 @@
 * Description
 This layer adds support for the [[http://wiki.portal.chalmers.se/agda/pmwiki.php][Agda]] programming language.
 
-** Some features:
+** Some features
 - Faces redefined to correctly play with themes.
 - Spacemacs bindings to Agda's interactive tools.
 

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -26,7 +26,7 @@
 * Description
 This layer adds support for [[http://elm-lang.org][Elm]].
 
-It relies on [[https://github.com/jcollard/elm-mode][elm-mode]] and [[https://github.com/bsermons/flycheck-elm][flycheck-elm]] to provide the following features:
+It relies on [[https://github.com/jcollard/elm-mode][elm-mode]] and [[https://github.com/bsermons/flycheck-elm][flycheck-elm]] to provide the following features
 - Syntax highlighting.
 - Intelligent indentation
 - Auto-completion integration for company (default) or auto-complete modes,

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Pre-requisites][Pre-requisites]]
    - [[Layer][Layer]]
@@ -18,7 +18,7 @@
 * Description
 This layer adds extensive support for go.
 
-** Features:
+** Features
 - gofmt/goimports on file save
 - Auto-completion using [[https://github.com/nsf/gocode/tree/master/emacs][go-autocomplete]] (with the =auto-completion= layer)
 - Source analysis using [[http://golang.org/s/oracle-user-manual][go-oracle]]

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
    - [[Dependencies][Dependencies]]
@@ -35,7 +35,7 @@
 * Description
 This layer adds support for the [[https://www.haskell.org/][Haskell]] language.
 
-** Features:
+** Features
 - syntax highlighting for [[https://github.com/haskell/haskell-mode][haskell source]], [[https://github.com/haskell/haskell-mode][cabal files]], [[https://github.com/bgamari/cmm-mode][C-- source]],
 - auto-completion with [[https://github.com/iquiw/company-ghc][company-ghc]].
 

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
  - [[Configuration][Configuration]]
    - [[Tern][Tern]]
@@ -25,7 +25,7 @@
 
 This layer adds support for the JavaScript language using [[https://github.com/mooz/js2-mode][js2-mode]].
 
-** Features:
+** Features
 - Smart code folding
 - Refactoring: done using [[https://github.com/magnars/js2-refactor.el][js2-refactor]].
 - Auto-completion and documentation: provided by [[http://ternjs.net/][tern]]
@@ -40,7 +40,7 @@ add =javascript= to the existing =dotspacemacs-configuration-layers= list in thi
 file.
 
 You will also need to install =tern= to use the auto-completion and
-documentation features:
+documentation features
 #+BEGIN_SRC sh
   $ npm install -g tern
 #+END_SRC

--- a/layers/+lang/lua/README.org
+++ b/layers/+lang/lua/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
  - [[Key Bindings][Key Bindings]]
    - [[Commands][Commands]]
@@ -13,7 +13,7 @@
 * Description
 This layer adds support for editing Lua.
 
-** Features:
+** Features
 - Editing lua files using [[https://github.com/immerrr/lua-mode][lua-mode]]
 - Sending code to a lua REPL
 - Code linting using [[https://github.com/mpeterv/luacheck][Luacheck]]

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
  - [[Usage][Usage]]
  - [[Key bindings][Key bindings]]
@@ -24,7 +24,7 @@
 
 This layer adds markdown support to Spacemacs.
 
-** Features:
+** Features
 - markdown files support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
 - TOC generation via [[https://github.com/ardumont/markdown-toc][markdown-toc]]
 - Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either

--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -5,7 +5,7 @@
 
 * Table of Content                                          :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
    - [[OPAM packages][OPAM packages]]
@@ -19,7 +19,7 @@
 * Description
 This is a very basic layer for editing ocaml files.
 
-** Features:
+** Features
 - Syntax highlighting (major-mode) via [[https://github.com/ocaml/tuareg][tuareg-mode]]
 - Error reporting, completion and type display via [[https://github.com/the-lambda-church/merlin][merlin]]
 - auto-completion with company mode via [[https://github.com/the-lambda-church/merlin][merlin]]

--- a/layers/+lang/php/README.org
+++ b/layers/+lang/php/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
  - [[Key bindings][Key bindings]]
 
@@ -13,7 +13,7 @@
 
 This layer adds PHP language support to Spacemacs.
 
-** Features:
+** Features
 - Edit PHP files using [[https://github.com/ejmr/php-mode][php-mode]]
 - Edit Drupal files
 - Run tests with PHPUnit

--- a/layers/+lang/swift/README.org
+++ b/layers/+lang/swift/README.org
@@ -16,7 +16,7 @@ This layer adds support for Apple's Swift programming language, used as a
 general purpose scripting language.
 
 It relies on the [[https://github.com/chrisbarrett/swift-mode][swift-mode]] major-mode* for Emacs 24.4 or later, to provide the
-following features:
+following features
 
 - Syntax highlighting
 - Indentation

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -6,7 +6,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
    - [[Magit status fullscreen][Magit status fullscreen]]
@@ -28,7 +28,7 @@
 * Description
 This layers adds extensive support for [[http://git-scm.com/][git]].
 
-** Features:
+** Features
 - git repository management the indispensable [[http://magit.vc/][magit]] package
 - [[https://github.com/jtatarik/magit-gitflow][git-flow]] add-on for magit.
 - quick in buffer history browsing with [[https://github.com/pidu/git-timemachine][git-timemachine]].

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
  - [[Key Bindings][Key Bindings]]
@@ -18,7 +18,7 @@
 
 This layers adds support for [[http://github.com][Github]].
 
-** Features:
+** Features
 - [[https://github.com/sigma/magit-gh-pulls][magit-gh-pulls]]: handy =magit= add-on to manage Github pull requests.
 - [[https://github.com/defunkt/gist.el][gist.el]]: full-featured mode to browse and post Github gists.
 - [[https://github.com/osener/github-browse-file][github-browse-file]] and [[https://github.com/sshaw/git-link][git-link]]: quickly browse github URL in your

--- a/layers/+tools/vagrant/README.org
+++ b/layers/+tools/vagrant/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
    - [[Vagrant][Vagrant]]
@@ -17,7 +17,7 @@
 This layer adds support for working with Vagrant using [[https://github.com/ottbot/vagrant.el][vagrant.el]] and
 [[https://github.com/dougm/vagrant-tramp][vagrant-tramp]].
 
-** Features:
+** Features
  - Manage boxes (under the ~SPC V~ prefix)
  - Remote editing on Vagrant boxes via Tramp
 

--- a/layers/nixos/README.org
+++ b/layers/nixos/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
  - [[Key Bindings][Key Bindings]]
@@ -15,7 +15,7 @@
 
 This layer adds tools for better integration of emacs in NixOS.
 
-** Features:
+** Features
 - Nix-mode using  [[https://github.com/NixOS/nix/blob/master/misc/emacs/nix-mode.el][nix-mode]]
 - Auto-completion of NixOS Options using [[https://github.com/travisbhartwell/nix-emacs/blob/master/company-nixos-options.el][company-nixos-options]]
 - Helm Lookup for NixOS Options  [[https://github.com/travisbhartwell/nix-emacs/blob/master/helm-nixos-options.el][helm-nixos-options]]

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -5,7 +5,7 @@
 
 * Table of Contents                                         :TOC_4_org:noexport:
  - [[Description][Description]]
-   - [[Features:][Features:]]
+   - [[Features][Features]]
    - [[Important Note][Important Note]]
  - [[Install][Install]]
    - [[Layer][Layer]]
@@ -34,7 +34,7 @@
 * Description
 This layer enables  [[http://orgmode.org/][org mode]] for Spacemacs.
 
-** Features:
+** Features
 - Vim inspired key bindings are provided by [[https://github.com/edwtjo/evil-org-mode][evil-org-mode]]
 - Nicer bullet via [[https://github.com/sabof/org-bullets][org-bullets]]
 - A [[http://pomodorotechnique.com/][pomodoro method]] integration via [[https://github.com/lolownia/org-pomodoro][org-pomodoro]]


### PR DESCRIPTION
This way the doc headers are more consistent. Also it will help with making org files work both in Emacs and GitHub.