### PR TITLE
Fix Java layer command documentation.

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -64,7 +64,7 @@ option in =emacs-eclim= itself.
 | ~SPC m p j~ | Information about project      |
 | ~SPC m p k~ | Close project                  |
 | ~SPC m p o~ | Open project                   |
-| ~SPC m p s~ | Open project management buffer |
+| ~SPC m p p~ | Open project management buffer |
 | ~SPC m p u~ | Update project                 |
 
 *** Maven


### PR DESCRIPTION
The "Open project management buffer" shortcut is actually SPC m p p, as per 
https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/java/packages.el#L121
not SPC m p s which does nothing.