### PR TITLE
Improve ivy keybindings for hybrid editing style

### DIFF
--- a/layers/+completion/spacemacs-ivy/config.el
+++ b/layers/+completion/spacemacs-ivy/config.el
@@ -13,3 +13,8 @@
 ;; to use the ownership mechanism of layers because it is dependent
 ;; on the order of layer declaration
 (configuration-layer/remove-layer 'smex)
+
+(defvar ivy-want-escape-quit (member dotspacemacs-editing-style '(vim hybrid))
+  "If non-nil, <escape> quits the ivy minibuffer with one
+  keypress, rather than requiring three. Vim and hybrid editing
+  styles set this variable to non-nil by default.")

--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -376,27 +376,30 @@ Helm hack."
                               (call-interactively (cdr repl))))))
 
       (defun spacemacs//ivy-hjkl-navigation (&optional arg)
-        "Set navigation on \"hjkl\" for ivy. ARG non nil means
-vim like movements."
-        (if arg
+        "Set navigation on \"hjkl\" for ivy when ARG is non-nil.
+ARG non-nil means vim movements."
+        (let ((map ivy-minibuffer-map))
+          (if arg
+              (progn
+                ;; better navigation on homerow
+                (define-key map (kbd "C-j") 'ivy-next-line)
+                (define-key map (kbd "C-k") 'ivy-previous-line)
+                (define-key map (kbd "C-h") (kbd "DEL"))
+                ;; Move C-h to C-S-h
+                (define-key map (kbd "C-S-h") help-map)
+                (define-key map (kbd "C-l") 'ivy-alt-done))
             (progn
-              ;; better navigation on homerow
-              (define-key ivy-minibuffer-map (kbd "C-j") 'ivy-next-line)
-              (define-key ivy-minibuffer-map (kbd "C-k") 'ivy-previous-line)
-              (define-key ivy-minibuffer-map (kbd "C-h") (kbd "DEL"))
-              ;; Move C-h to C-S-h
-              (define-key ivy-minibuffer-map (kbd "C-S-h") help-map)
-              (define-key ivy-minibuffer-map (kbd "C-l") 'ivy-alt-done)
-              (define-key ivy-minibuffer-map (kbd "<escape>")
-                'minibuffer-keyboard-quit))
-          (define-key ivy-minibuffer-map (kbd "C-j") 'ivy-alt-done)
-          (define-key ivy-minibuffer-map (kbd "C-k") 'ivy-kill-line)
-          (define-key ivy-minibuffer-map (kbd "C-h") nil)
-          (define-key ivy-minibuffer-map (kbd "C-l") nil)))
+              (define-key map (kbd "C-j") 'ivy-alt-done)
+              (define-key map (kbd "C-k") 'ivy-kill-line)
+              (define-key map (kbd "C-h") nil)
+              (define-key map (kbd "C-S-h") nil)
+              (define-key map (kbd "C-l") nil)))
+          (when ivy-want-escape-quit
+            (define-key map (kbd "<escape>") 'minibuffer-keyboard-quit))))
       (add-hook 'spacemacs--hjkl-completion-navigation-functions
                 'spacemacs//ivy-hjkl-navigation)
       (run-hook-with-args 'spacemacs--hjkl-completion-navigation-functions
-                          (member dotspacemacs-editing-style '(vim hybrid)))
+                          (member dotspacemacs-editing-style '(vim)))
 
       (defun spacemacs/counsel-up-directory-no-error ()
         "`counsel-up-directory' ignoring errors."


### PR DESCRIPTION
Previously, there was no distinction between hybrid and vim styles,
which caused hybrid style to inherit some "vim-isms" like C-hjkl
navigation, which led to conflicts. This commit lets hybrid keybindings
adhere more closely to emacs defaults.

The addition of a ivy-want-escape-quit variable allows user selection of
escape key behavior, defaulting to 'minibuffer-keyboard-quit for vim and
hybrid styles.