### PR TITLE
clojure: add clojure-snippets to clojure layer

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -4,11 +4,12 @@
     cider-eval-sexp-fu
     clj-refactor
     clojure-mode
+    (clojure-snippets :toggle (configuration-layer/layer-usedp 'auto-completion))
     company
     popwin
     rainbow-delimiters
     subword
-   ))
+    ))
 
 
 (defun clojure/init-cider ()
@@ -379,3 +380,7 @@ If called with a prefix argument, uses the other-window instead."
 
     (push 'company-capf company-backends-cider-repl-mode)
     (spacemacs|add-company-hook cider-repl-mode)))
+
+(defun clojure/init-clojure-snippets ()
+  (use-package clojure-snippets
+    :defer t))


### PR DESCRIPTION
The purpose of this is to have available right out of the box some nice snippets on clojure mode.

It would be pretty easy to install the package alone without putting it into the layer, but I think this is easier for the user, who might not even know the existence of this package.

I had doubts about putting this on auto-completion layer or clojure layer, I finally put this here as it's directly related to the mode and so.