### PR TITLE
Fix inline code block

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -263,7 +263,7 @@ error during the download of the starting theme.
   in a future version.
 *** New conventions
 - Commit and abort commands conventions:
-  - ~SPC m ,~ and ~SPC m c~ to Valid/Confirm
+  - ~SPC m ,​~ and ~SPC m c~ to Valid/Confirm
   - ~SPC m a~ and ~SPC m k~ to Abort/Discard
   (thanks to StreakyCobra)
 - Update evilified state rebinding conventions:
@@ -499,7 +499,7 @@ error during the download of the starting theme.
 - New key binding scheme using =evil-magit= package (thanks to justbur)
 - New key binding ~SPC g i~ for =magit-init= (thanks to CestDiego)
 - New key binding ~SPC g c~ for =magit-checkout= (thanks to PierreR)
-- New key bindings ~SPC m ,~ and ~SPC m c~ to Valid/Confirm =with-editor=
+- New key bindings ~SPC m ,​~ and ~SPC m c~ to Valid/Confirm =with-editor=
   buffers (thanks to justbur)
 - New key bindings ~SPC m a~ and ~SPC m k~ to Abort/Discard =with-editor=
   buffers (thanks to justbur)
@@ -577,7 +577,7 @@ error during the download of the starting theme.
 **** LaTeX
 - New layer variable =latex-enable-folding= to enable text folding, default
   value is =nil= (thanks to justbur)
-- New key bindings ~SPC m ,~ and ~SPC m k~ for ~C-c C-c~ and ~C-c C-k~
+- New key bindings ~SPC m ,​~ and ~SPC m k~ for ~C-c C-c~ and ~C-c C-k~
   respectively (thanks to justbur)
 - New key bindings:
   - ~SPC m .~ to mark LaTeX environment

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -71,7 +71,7 @@ user.
 
 *** Major mode prefix
 ~SPC m~ is reserved for the current major mode. Three keys bindings are not an
-issue (ie. ~SPC m h d~) since ~SPC m~ can be accessed via ~,~.
+issue (ie. ~SPC m h d~) since ~SPC m~ can be accessed via ~​,​~.
 
 *** Micro-state
 Whenever possible a micro-state should be enabled with ~M-SPC~ and ~s-M-SPC~. We
@@ -103,7 +103,7 @@ Setting the =evilified state= to a mode is done by calling the macro
 /Evilification/ rebinds shadowed key bindings according to the following
 rules:
 - alphabetic key bindings: ~x~ -> ~X~ -> ~C-x~ -> ~C-X~
-- ~SPC~ -> ~'~
+- ~SPC~ -> ~​'​~
 - ~/~ -> ~\~
 - ~:~ -> ~|~
 - ~C-g~ cannot be shadowed
@@ -147,7 +147,7 @@ in raw Emacs are mirrored in Spacemacs to:
 
 | Key                     | Description               |
 |-------------------------+---------------------------|
-| ~SPC m ,~ and ~SPC m c~ | Valid/Confirm the message |
+| ~SPC m ,​~ and ~SPC m c~ | Valid/Confirm the message |
 | ~SPC m a~ and ~SPC m k~ | Abort/Discard the message |
 
 Some example of these modes are =magit= commit messages, =message-mode= for

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -697,7 +697,7 @@ Note: Technically speaking there is also the =operator= evil state.
 Spacemacs heavily uses the [[https://github.com/cofi/evil-leader][evil-leader]] mode which brings the Vim leader key to
 the Emacs world.
 
-This leader key is commonly set to ~,~ by Vim users, in Spacemacs the leader
+This leader key is commonly set to ~​,​~ by Vim users, in Spacemacs the leader
 key is set on ~SPC~ (space bar, hence the name =spacemacs=). This key is the
 most accessible key on a keyboard and it is pressed with the thumb which is a
 good choice to lower the risk of [[http://en.wikipedia.org/wiki/Repetitive_strain_injury][RSI]].
@@ -736,7 +736,7 @@ Auto-highlight-symbol micro-state:
 [[file:img/spacemacs-scale-micro-state.png]]
 
 * Differences between Vim, Evil and Spacemacs
-- The ~,~ key does "repeat last ~f~, ~t~, ~F~, or ~T~ command in
+- The ~​,​~ key does "repeat last ~f~, ~t~, ~F~, or ~T~ command in
   opposite direction in =Vim=, but in Spacemacs it is the major mode specific
   leader key by default (which can be set on another key binding in the
   dotfile).
@@ -1166,7 +1166,7 @@ state= to press quickly ~jj~ and inadvertently escape to =normal state=.
 The command key ~:~ can be easily changed with the variable
 =dotspacemacs-command-key= of your =~/.spacemacs=. Note that is will change both
 ~:~ and ~SPC :~ bindings to keep the symmetry between Vim and Emacs. A good key
-can be ~,~ for example.
+can be ~​,​~ for example.
 
 *** Leader key
 On top of =Vim= modes (modes are called states in Spacemacs) there is a
@@ -2123,7 +2123,7 @@ Text related commands (start with ~x~):
     | ~SPC x a r~ | align region using user-specified regexp                      |
     | ~SPC x a m~ | align region at arithmetic operators (+-*/)                   |
     | ~SPC x a .~ | align region at . (for numeric tables)                        |
-    | ~SPC x a ,~ | align region at ,                                             |
+    | ~SPC x a ,​~ | align region at ,                                             |
     | ~SPC x a ;~ | align region at ;                                             |
     | ~SPC x a =~ | align region at =                                             |
     | ~SPC x a &~ | align region at &                                             |
@@ -2588,7 +2588,7 @@ Spacemacs binds a few commands to support compiling a project.
 *** Major Mode leader key
 Key bindings specific to the current =major mode= start with ~SPC m~. For
 convenience a shortcut key called the major mode leader key is set by default on
-~,~ which saves one precious keystroke.
+~​,​~ which saves one precious keystroke.
 
 It is possible to change the major mode leader key by defining the variable
 =dotspacemacs-major-mode-leader-key= in your =~/.spacemacs=. For example to

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -109,7 +109,7 @@ For simplicity the documentation always refers to the leader key as
 ~SPC~.
 
 There is secondary leader key called the major-mode leader key which is
-set to ~,~ by default. This key is a shortcut for ~SPC m~
+set to ~​,​~ by default. This key is a shortcut for ~SPC m~
 where all the major-mode specific commands are bound.
 
 ** Evil-tutor

--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -47,7 +47,7 @@ All Agda specific bindings are prefixed with the major-mode leader
 |-------------+-------------------------------------------------------------------------------------------------------------------------------------------|
 | ~SPC m =~   | Show constraints.                                                                                                                         |
 | ~SPC m ?~   | Show all goals.                                                                                                                           |
-| ~SPC m ,~   | Shows the type of the goal at point and the currect context.                                                                              |
+| ~SPC m ,​~   | Shows the type of the goal at point and the currect context.                                                                              |
 | ~SPC m .~   | Shows the context, the goal and the given expression's inferred type.                                                                     |
 | ~SPC m a~   | Simple proof search.                                                                                                                      |
 | ~SPC m b~   | Go to the previous goal, if any and activate goal-navigation micro-state.                                                                 |

--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -127,4 +127,4 @@ You find and overview of all the key-bindings on the [[file:alchemist-refcard.pd
 | Key Binding | Description                                        |
 |-------------+----------------------------------------------------|
 | ~SPC m g g~ | Jump to the elixir expression definition at point. |
-| ~SPC m ,~   | Pop back to where ~SPC m g g~ was last invoked.    |
+| ~SPC m ,​~   | Pop back to where ~SPC m g g~ was last invoked.    |

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -58,7 +58,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e e~                | evaluate sexp before point                                 |
 | ~SPC m e r~                | evaluate current region                                    |
 | ~SPC m e f~                | evaluation current function                                |
-| ~SPC m ,~                  | toggle =lisp state=                                        |
+| ~SPC m ,​~                  | toggle =lisp state=                                        |
 | ~SPC m t b~                | run tests of current buffer                                |
 | ~SPC m t q~                | run =ert=                                                  |
 | ~SPC m d m~                | open [[https://github.com/joddie/macrostep][macrostep]] micro-state                                 |

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -80,7 +80,7 @@ option in =emacs-eclim= itself.
 *** Goto
 | Key Binding | Description                                 |
 |-------------+---------------------------------------------|
-| ~M-,~       | jump back from go to declaration/definition |
+| ~M-,​~       | jump back from go to declaration/definition |
 | ~SPC m g g~ | go to declaration                           |
 | ~SPC m g t~ | go to type definition                       |
 

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -88,7 +88,7 @@ is nil.
 | Key Binding   | Description                         |
 |---------------+-------------------------------------|
 | ~SPC m -~     | recenter output buffer              |
-| ~SPC m ,~     | TeX command on master file          |
+| ~SPC m ,​~     | TeX command on master file          |
 | ~SPC m .~     | mark LaTeX environment              |
 | ~SPC m *~     | mark LaTeX section                  |
 | ~SPC m b~     | build                               |

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -109,7 +109,7 @@ directory local variables.
 | ~SPC m s R~ | send region and switch to REPL                       |
 | ~SPC m s s~ | switch to REPL                                       |
 | ~SPC m x '~ | Change symbol or " string to '                       |
-| ~SPC m x "~ | Change symbol or ' string to "                       |
+| ~SPC m x "​~ | Change symbol or ' string to "                       |
 | ~SPC m x :~ | Change string to symbol                              |
 | ~%~         | [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] jumps between blocks                    |
 

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -188,7 +188,7 @@ intended. To work around this, you can use =v= instead (since Magit only stages
 whole lines, in any case).
 
 ** Commit message editing buffer
-In a commit message buffer press ~,c~ (if =dotspacemacs-major-mode-leader-key= is ~,~)
+In a commit message buffer press ~,c~ (if =dotspacemacs-major-mode-leader-key= is ~​,​~)
 or ~C-c C-c~ to commit the changes with the entered message. Pressing ~,a~ or ~C-c C-k~
 will discard the commit message.
 

--- a/layers/+vim/evil-snipe/README.org
+++ b/layers/+vim/evil-snipe/README.org
@@ -35,7 +35,7 @@ file.
 With evil-snipe you can define your own search scope for ~f~ and ~t~ searches
 which means that you won't have to jump to the correct line before searching
 with ~f~ / ~t~ / ~F~ / ~T~. And after you have found a match, you can just press
-~f~ or ~t~ again afterwards to continue the search. No need to use ~;~ / ~,~.
+~f~ or ~t~ again afterwards to continue the search. No need to use ~;~ / ~​,​~.
 
 This alternate behavior is disabled by default, to enable it set the
 layer variable =evil-snipe-enable-alternate-f-and-t-behaviors= to =t=:

--- a/layers/typography/README.org
+++ b/layers/typography/README.org
@@ -47,9 +47,9 @@ The following keybindings are available in insert state.
 
 | Key Bindings | Description                              |
 |--------------+------------------------------------------|
-| ~"~          | Cycle among quotation marks              |
+| ~​"​~          | Cycle among quotation marks              |
 | ~`~          | Cycle among left single quotation marks  |
-| ~'~          | Cycle among right single quotation marks |
+| ~​'​~          | Cycle among right single quotation marks |
 | ~-~          | Cycle among dashes                       |
 | ~.~          | Cycle among ellipsis                     |
 | ~<~          | Cycle among left angle brackets          |


### PR DESCRIPTION
Added a zero-width space between `,` and `~` because emphasis blocks won't get parsed if they end with a comma.

This makes the inline code block show up correctly on GitHub and hopefully [the website](http://spacemacs.org/doc/DOCUMENTATION.html#orgheadline145) as well.
It's not a pretty hack, but it works.