### PR TITLE
Update Scheme docs to curl over https

### DIFF
--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -30,7 +30,7 @@ For full Chicken support, the following commands should be run:
 #+BEGIN_SRC shell
   $ chicken-install -s apropos chicken-doc
   $ cd `csi -p '(chicken-home)'`
-  $ curl http://3e8.org/pub/chicken-doc/chicken-doc-repo.tgz | sudo tar zx
+  $ curl https://3e8.org/pub/chicken-doc/chicken-doc-repo.tgz | sudo tar zx
 #+END_SRC
 
 * Key Bindings


### PR DESCRIPTION
Felt more comfortable running this over https. Not sure what the risks
are of piping files into a root privilege tar process, but the server
supports it so may as well use it.