### PR TITLE
Fix inline code blocks

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -262,11 +262,11 @@ Improve loading robustness:
   in a future version.
 *** New conventions
 - Commit and abort commands conventions:
-  - ~SPC m ,~ and ~SPC m c~ to Valid/Confirm
+  - ~SPC m ​,​~ and ~SPC m c~ to Valid/Confirm
   - ~SPC m a~ and ~SPC m k~ to Abort/Discard
   (thanks to StreakyCobra)
 - Update evilified state rebinding conventions:
-  ~SPC~ to ~'~, ~/~ to ~\~ and ~:~ to ~|~
+  ~SPC~ to ~​'​~, ~/~ to ~\~ and ~:~ to ~|~
 *** New Layers
 - bepo in =keyboard-layouts= (thanks to StreakyCobra)
 - command-log in =tools= (thanks to bmag)
@@ -498,7 +498,7 @@ Improve loading robustness:
 - New key binding scheme using =evil-magit= package (thanks to justbur)
 - New key binding ~SPC g i~ for =magit-init= (thanks to CestDiego)
 - New key binding ~SPC g c~ for =magit-checkout= (thanks to PierreR)
-- New key bindings ~SPC m ,~ and ~SPC m c~ to Valid/Confirm =with-editor=
+- New key bindings ~SPC m ​,​~ and ~SPC m c~ to Valid/Confirm =with-editor=
   buffers (thanks to justbur)
 - New key bindings ~SPC m a~ and ~SPC m k~ to Abort/Discard =with-editor=
   buffers (thanks to justbur)
@@ -576,7 +576,7 @@ Improve loading robustness:
 **** LaTeX
 - New layer variable =latex-enable-folding= to enable text folding, default
   value is =nil= (thanks to justbur)
-- New key bindings ~SPC m ,~ and ~SPC m k~ for ~C-c C-c~ and ~C-c C-k~
+- New key bindings ~SPC m ​,​~ and ~SPC m k~ for ~C-c C-c~ and ~C-c C-k~
   respectively (thanks to justbur)
 - New key bindings:
   - ~SPC m .~ to mark LaTeX environment
@@ -908,7 +908,7 @@ Improve loading robustness:
 *** Core
 - Silence =ad-handle-definition= about advised functions getting redefined  
 - Improve evilification rules, now ~:~ is rebound to ~|~, ~/~ is rebound to ~\~
-  and ~SPC~ is rebound to ~'~
+  and ~SPC~ is rebound to ~​'​~
 *** Other fixes and improvements
 - Add FAQ entry on the difference between available distributions (thanks to
   robbyoconnor)

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -71,7 +71,7 @@ user.
 
 *** Major mode prefix
 ~SPC m~ is reserved for the current major mode. Three keys bindings are not an
-issue (ie. ~SPC m h d~) since ~SPC m~ can be accessed via ~,~.
+issue (ie. ~SPC m h d~) since ~SPC m~ can be accessed via ~​,​~.
 
 *** Transient-state
 Whenever possible a transient-state should be enabled with ~M-SPC~ and ~s-M-SPC~. We
@@ -103,7 +103,7 @@ Setting the =evilified state= to a mode is done by calling the macro
 /Evilification/ rebinds shadowed key bindings according to the following
 rules:
 - alphabetic key bindings: ~x~ -> ~X~ -> ~C-x~ -> ~C-X~
-- ~SPC~ -> ~'~
+- ~SPC~ -> ~​'​~
 - ~/~ -> ~\~
 - ~:~ -> ~|~
 - ~C-g~ cannot be shadowed
@@ -147,7 +147,7 @@ in raw Emacs are mirrored in Spacemacs to:
 
 | Key                     | Description               |
 |-------------------------+---------------------------|
-| ~SPC m ,~ and ~SPC m c~ | Valid/Confirm the message |
+| ~SPC m ​,​~ and ~SPC m c~ | Valid/Confirm the message |
 | ~SPC m a~ and ~SPC m k~ | Abort/Discard the message |
 
 Some example of these modes are =magit= commit messages, =message-mode= for

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -699,7 +699,7 @@ Note: Technically speaking there is also the =operator= evil state.
 Spacemacs heavily uses the [[https://github.com/cofi/evil-leader][evil-leader]] mode which brings the Vim leader key to
 the Emacs world.
 
-This leader key is commonly set to ~,~ by Vim users, in Spacemacs the leader
+This leader key is commonly set to ~​,​~ by Vim users, in Spacemacs the leader
 key is set on ~SPC~ (space bar, hence the name =spacemacs=). This key is the
 most accessible key on a keyboard and it is pressed with the thumb which is a
 good choice to lower the risk of [[http://en.wikipedia.org/wiki/Repetitive_strain_injury][RSI]].
@@ -738,7 +738,7 @@ Auto-highlight-symbol transient-state:
 [[file:img/spacemacs-scale-transient-state.png]]
 
 * Differences between Vim, Evil and Spacemacs
-- The ~,~ key does "repeat last ~f~, ~t~, ~F~, or ~T~ command in
+- The ~​,​~ key does "repeat last ~f~, ~t~, ~F~, or ~T~ command in
   opposite direction in =Vim=, but in Spacemacs it is the major mode specific
   leader key by default (which can be set on another key binding in the
   dotfile).
@@ -2188,7 +2188,7 @@ Text related commands (start with ~x~):
     | ~SPC x a &~ | align region at &                                             |
     | ~SPC x a (~ | align region at (                                             |
     | ~SPC x a )~ | align region at )                                             |
-    | ~SPC x a ,~ | align region at ,                                             |
+    | ~SPC x a ​,​~ | align region at ,                                             |
     | ~SPC x a .~ | align region at . (for numeric tables)                        |
     | ~SPC x a :~ | align region at :                                             |
     | ~SPC x a ;~ | align region at ;                                             |
@@ -2573,7 +2573,7 @@ To search in a project see [[Searching in a project][project searching]].
 
     | Key Binding | Description                                             |
     |-------------+---------------------------------------------------------|
-    | ~SPC p '~   | open a shell in project's root (with the =shell= layer) |
+    | ~SPC p '​~   | open a shell in project's root (with the =shell= layer) |
     | ~SPC p !~   | run shell command in project's root                     |
     | ~SPC p &~   | run async shell command in project's root               |
     | ~SPC p a~   | toggle between implementation and test                  |
@@ -2655,7 +2655,7 @@ Spacemacs binds a few commands to support compiling a project.
 *** Major Mode leader key
 Key bindings specific to the current =major mode= start with ~SPC m~. For
 convenience a shortcut key called the major mode leader key is set by default on
-~,~ which saves one precious keystroke.
+~​,​~ which saves one precious keystroke.
 
 It is possible to change the major mode leader key by defining the variable
 =dotspacemacs-major-mode-leader-key= in your =~/.spacemacs=. For example to

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -109,7 +109,7 @@ For simplicity the documentation always refers to the leader key as
 ~SPC~.
 
 There is secondary leader key called the major-mode leader key which is
-set to ~,~ by default. This key is a shortcut for ~SPC m~
+set to ~​,​~ by default. This key is a shortcut for ~SPC m~
 where all the major-mode specific commands are bound.
 
 ** Evil-tutor

--- a/layers/+config-files/puppet/README.org
+++ b/layers/+config-files/puppet/README.org
@@ -24,7 +24,7 @@ The following key bindings are available in Puppet Mode:
 | ~SPC m {~   | Move to the beginning of the current block        |
 | ~SPC m }~   | Move to the end of the current block              |
 | ~SPC m a~   | Align parameters in the current block             |
-| ~SPC m '~   | Toggle string quoting between single and double   |
+| ~SPC m '​~   | Toggle string quoting between single and double   |
 | ~SPC m ;~   | Blank the string at point                         |
 | ~SPC m j~   | Jump to a =class=, =define=, variable or resource |
 | ~SPC m c~   | Apply the current manifest in dry-run mode        |

--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -47,7 +47,7 @@ All Agda specific bindings are prefixed with the major-mode leader
 |-------------+-------------------------------------------------------------------------------------------------------------------------------------------|
 | ~SPC m =~   | Show constraints.                                                                                                                         |
 | ~SPC m ?~   | Show all goals.                                                                                                                           |
-| ~SPC m ,~   | Shows the type of the goal at point and the currect context.                                                                              |
+| ~SPC m ​,​~   | Shows the type of the goal at point and the currect context.                                                                              |
 | ~SPC m .~   | Shows the context, the goal and the given expression's inferred type.                                                                     |
 | ~SPC m a~   | Simple proof search.                                                                                                                      |
 | ~SPC m b~   | Go to the previous goal, if any and activate goal-navigation transient-state.                                                             |

--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -127,4 +127,4 @@ You find and overview of all the key-bindings on the [[file:alchemist-refcard.pd
 | Key Binding | Description                                        |
 |-------------+----------------------------------------------------|
 | ~SPC m g g~ | Jump to the elixir expression definition at point. |
-| ~SPC m ,~   | Pop back to where ~SPC m g g~ was last invoked.    |
+| ~SPC m ​,​~   | Pop back to where ~SPC m g g~ was last invoked.    |

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -58,7 +58,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e e~                | evaluate sexp before point                                 |
 | ~SPC m e r~                | evaluate current region                                    |
 | ~SPC m e f~                | evaluation current function                                |
-| ~SPC m ,~                  | toggle =lisp state=                                        |
+| ~SPC m ​,​~                  | toggle =lisp state=                                        |
 | ~SPC m t b~                | run tests of current buffer                                |
 | ~SPC m t q~                | run =ert=                                                  |
 | ~SPC m d m~                | open [[https://github.com/joddie/macrostep][macrostep]] transient-state                        |

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -80,7 +80,7 @@ option in =emacs-eclim= itself.
 *** Goto
 | Key Binding | Description                                 |
 |-------------+---------------------------------------------|
-| ~M-,~       | jump back from go to declaration/definition |
+| ~M-​,​~       | jump back from go to declaration/definition |
 | ~SPC m g g~ | go to declaration                           |
 | ~SPC m g t~ | go to type definition                       |
 

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -88,7 +88,7 @@ is nil.
 | Key Binding   | Description                                |
 |---------------+--------------------------------------------|
 | ~SPC m -~     | recenter output buffer                     |
-| ~SPC m ,~     | TeX command on master file                 |
+| ~SPC m ​,​~     | TeX command on master file                 |
 | ~SPC m .~     | mark LaTeX environment                     |
 | ~SPC m *~     | mark LaTeX section                         |
 | ~SPC m %~     | comment or uncomment a paragraph           |

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -100,7 +100,7 @@ directory local variables.
 
 | Key binding | Description                                          |
 |-------------+------------------------------------------------------|
-| ~SPC m '~   | toggle quotes of current string (only built-in mode) |
+| ~SPC m '​~   | toggle quotes of current string (only built-in mode) |
 | ~SPC m {~   | toggle style of current block (only built-in mode)   |
 | ~SPC m g g~ | go to definition (robe-jump)                         |
 | ~SPC m h d~ | go to Documentation                                  |
@@ -110,8 +110,8 @@ directory local variables.
 | ~SPC m s r~ | send region                                          |
 | ~SPC m s R~ | send region and switch to REPL                       |
 | ~SPC m s s~ | switch to REPL                                       |
-| ~SPC m x '~ | Change symbol or " string to '                       |
-| ~SPC m x "~ | Change symbol or ' string to "                       |
+| ~SPC m x '​~ | Change symbol or " string to '                       |
+| ~SPC m x "​~| Change symbol or ' string to "                       |
 | ~SPC m x :~ | Change string to symbol                              |
 | ~%~         | [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] jumps between blocks                    |
 

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -190,7 +190,7 @@ intended. To work around this, you can use =v= instead (since Magit only stages
 whole lines, in any case).
 
 ** Commit message editing buffer
-In a commit message buffer press ~,c~ (if =dotspacemacs-major-mode-leader-key= is ~,~)
+In a commit message buffer press ~,c~ (if =dotspacemacs-major-mode-leader-key= is ~​,​~)
 or ~C-c C-c~ to commit the changes with the entered message. Pressing ~,a~ or ~C-c C-k~
 will discard the commit message.
 

--- a/layers/+vim/evil-snipe/README.org
+++ b/layers/+vim/evil-snipe/README.org
@@ -35,7 +35,7 @@ file.
 With evil-snipe you can define your own search scope for ~f~ and ~t~ searches
 which means that you won't have to jump to the correct line before searching
 with ~f~ / ~t~ / ~F~ / ~T~. And after you have found a match, you can just press
-~f~ or ~t~ again afterwards to continue the search. No need to use ~;~ / ~,~.
+~f~ or ~t~ again afterwards to continue the search. No need to use ~;~ / ~​,​~.
 
 This alternate behavior is disabled by default, to enable it set the
 layer variable =evil-snipe-enable-alternate-f-and-t-behaviors= to =t=:

--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -119,7 +119,7 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC m *~                                    | org-ctrl-c-star                              |
 | ~SPC m RET~                                  | org-ctrl-c-ret                               |
 | ~SPC m -~                                    | org-ctrl-c-minus                             |
-| ~SPC m '~                                    | org-edit-special                             |
+| ~SPC m '​~                                    | org-edit-special                             |
 | ~SPC m ^~                                    | org-sort                                     |
 | ~SPC m /~                                    | org-sparse-tree                              |
 | ~SPC m .~                                    | org-time-stamp                               |
@@ -278,7 +278,7 @@ conventions.
 | Key Binding                                  | Description                            |
 |----------------------------------------------+----------------------------------------|
 | ~SPC m <dotspacemacs-major-mode-leader-key>~ | confirm in =org-capture-mode=          |
-| ~SPC m '~                                    | confirm in =org-src-mode=              |
+| ~SPC m '​~                                    | confirm in =org-src-mode=              |
 | ~SPC m c~                                    | confirm                                |
 | ~SPC m a~                                    | abort                                  |
 | ~SPC m k~                                    | abort                                  |

--- a/layers/shell/README.org
+++ b/layers/shell/README.org
@@ -48,7 +48,7 @@ to the following variables:
   '(shell :variables shell-default-shell 'eshell))
 #+END_SRC
 
-The default shell is quickly accessible via a the default shortcut key ~SPC '~.
+The default shell is quickly accessible via a the default shortcut key ~SPC '​~.
 
 ** Default shell position and height
 It is possible to choose where the shell should pop up by setting the variable
@@ -132,8 +132,8 @@ Some advanced configuration is setup for =eshell= in this layer:
 
 | Key Binding | Description                                                |
 |-------------+------------------------------------------------------------|
-| ~SPC '~     | Open, close or go to the default shell                     |
-| ~SPC p '~   | Open a shell in the project's root                         |
+| ~SPC '​~     | Open, close or go to the default shell                     |
+| ~SPC p '​~   | Open a shell in the project's root                         |
 | ~SPC a s e~ | Open, close or go to an =eshell=                           |
 | ~SPC a s i~ | Open, close or go to a =shell=                             |
 | ~SPC a s m~ | Open, close or go to a =multi-term=                        |
@@ -144,7 +144,7 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~C-k~       | previous item in history                                   |
 
 *Note:* You can open multiple shells using a numerical prefix argument,
-for instance pressing ~2 SPC '~ will a second default shell, the
+for instance pressing ~2 SPC '​~ will a second default shell, the
 number of shell is indicated on the mode-line.
 
 ** Multi-term

--- a/layers/typography/README.org
+++ b/layers/typography/README.org
@@ -47,9 +47,9 @@ The following keybindings are available in insert state.
 
 | Key Bindings | Description                              |
 |--------------+------------------------------------------|
-| ~"~          | Cycle among quotation marks              |
+| ~​"​~          | Cycle among quotation marks              |
 | ~`~          | Cycle among left single quotation marks  |
-| ~'~          | Cycle among right single quotation marks |
+| ~​'​~          | Cycle among right single quotation marks |
 | ~-~          | Cycle among dashes                       |
 | ~.~          | Cycle among ellipsis                     |
 | ~<~          | Cycle among left angle brackets          |


### PR DESCRIPTION
Add zero-width space because emphasis blocks can't start/end with
a comma, an apostrophe or a quote.