### PR TITLE
Make cljr-keybinding-prefix configurable

### DIFF
--- a/layers/+lang/clojure/config.el
+++ b/layers/+lang/clojure/config.el
@@ -21,6 +21,9 @@
 (defvar clojure-enable-fancify-symbols nil
   "If non nil the `fancify-symbols' function is enabled.")
 
+(defvar clojure-cljr-prefix "C-c C-f"
+  "Prefix keys for cljr bindings.")
+
 (setq clojure/key-binding-prefixes '(("md" . "debug")
                                      ("me" . "evaluation")
                                      ("mg" . "goto")

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -297,7 +297,7 @@ If called with a prefix argument, uses the other-window instead."
     (add-hook 'clojure-mode-hook 'clj-refactor-mode)
     :config
     (progn
-      (cljr-add-keybindings-with-prefix "C-c C-f")
+      (cljr-add-keybindings-with-prefix clojure-cljr-prefix)
 
       (dolist (m '(clojure-mode clojurec-mode clojurescript-mode clojurex-mode))
         (dolist (r cljr--all-helpers)


### PR DESCRIPTION
Previously this was hardcoded as C-c C-f, which is a fine default, but
some users may prefer to change it.
