### PR TITLE
Rename: ensime-refactor-inline-local -> ensime-refactor-diff-inline-l…

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -143,7 +143,7 @@
         "ns"     'ensime
         "nS"     'ensime-gen-and-restart
 
-        "rd"     'ensime-refactor-inline-local
+        "rd"     'ensime-refactor-diff-inline-local
         "rD"     'ensime-undo-peek
         "rf"     'ensime-format-source
         "ri"     'ensime-refactor-organize-imports


### PR DESCRIPTION
Function has different name in ensime-emacs (see ensime-refactor.el). Inlining works now.