### PR TITLE
Fix startup error when dotspacemacs-smooth-scrolling is nil

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -253,12 +253,10 @@
 
   (unless dotspacemacs-smooth-scrolling
     ;; deactivate smooth-scrolling advices
-    (ad-disable-advice 'previous-line 'after 'smooth-scroll-down)
-    (ad-activate 'previous-line)
-    (ad-disable-advice 'next-line 'after 'smooth-scroll-up)
-    (ad-activate 'next-line)
-    (ad-disable-advice 'isearch-repeat 'after 'isearch-smooth-scroll)
-    (ad-activate 'isearch-repeat)))
+    (when (featurep 'smooth-scrolling)
+      (disable-smooth-scroll-for-function previous-line)
+      (disable-smooth-scroll-for-function next-line)
+      (disable-smooth-scroll-for-function isearch-repeat))))
 
 (defun spacemacs-ui-visual/init-spaceline ()
   (use-package spaceline-config


### PR DESCRIPTION
```
error: ad-disable-advice: `previous-line' is not advised
```