### PR TITLE
fix osx-use-options-as-meta on emacs 25

### DIFF
--- a/layers/osx/keybindings.el
+++ b/layers/osx/keybindings.el
@@ -9,8 +9,8 @@
 
     (when osx-use-option-as-meta
       ;; Treat option as meta
-      (setq mac-option-key-is-meta t)
-      (setq mac-option-modifier 'meta))
+      (setq mac-option-key-is-meta t))
+    (setq mac-option-modifier (if osx-use-option-as-meta 'meta nil))
 
     ;; Keybindings
     (global-set-key (kbd "s-=") 'spacemacs/scale-up-font)


### PR DESCRIPTION
By default it's already `meta`, so when you set `osx-use-options-as-meta` to `nil` - option is still `meta`. This fixes the issue on Emacs 25, and should still work on previous versions of Emacs (though I haven't tested).

CC @brenogil