### PR TITLE
shell-scripts: Enable flycheck in sh-mode

### DIFF
--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -10,11 +10,14 @@
 ;;; License: GPLv3
 
 (setq shell-scripts-packages
-  '(fish-mode
-    (sh-script :location built-in)
-    company
-    company-shell
-    ))
+      '(company
+        company-shell
+        fish-mode
+        flycheck
+        (sh-script :location built-in)))
+
+(defun shell-scripts/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'sh-mode))
 
 (defun shell-scripts/init-fish-mode ()
   (use-package fish-mode


### PR DESCRIPTION
`fish-mode` has no checkers, but maybe it should be enabled there as well, in case of a future checker?