### PR TITLE
Fixes #5301 - Define new variable: spacemacs-start-directory.

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -30,7 +30,7 @@
   "Configuration layer templates directory.")
 
 (defconst configuration-layer-directory
-  (expand-file-name (concat user-emacs-directory "layers/"))
+  (expand-file-name (concat spacemacs-start-directory "layers/"))
   "Spacemacs contribution layers base directory.")
 
 (defconst configuration-layer-private-directory

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -34,7 +34,7 @@
   "Spacemacs contribution layers base directory.")
 
 (defconst configuration-layer-private-directory
-  (expand-file-name (concat user-emacs-directory "private/"))
+  (expand-file-name (concat spacemacs-start-directory "private/"))
   "Spacemacs private layers base directory.")
 
 (defconst configuration-layer-private-layer-directory

--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -34,7 +34,7 @@
     (dolist (l layers)
       (let ((layer-name (file-name-nondirectory l))
             (target-path (concat (file-relative-name
-                                  l (concat user-emacs-directory "layers"))
+                                  l (concat spacemacs-start-directory "layers"))
                                  "/README.org")))
         (insert (format "- [[file:%s][%s]]\n" target-path layer-name))))
     (dolist (c categories)
@@ -59,7 +59,7 @@
     (org-set-tags-to '("TOC_4_org" "noexport"))
     (insert "* General layers\n")
     (spacemacs//generate-layers-from-path configuration-layer-directory "*")
-    (write-file (concat user-emacs-directory "layers/LAYERS.org"))))
+    (write-file (concat spacemacs-start-directory "layers/LAYERS.org"))))
 
 (defun spacemacs//format-toc (&rest r)
   (if (not (null (car r)))
@@ -99,7 +99,7 @@
                   src=\"http://www.pirilampo.org/styles/lib/js/jquery.stickytableheaders.js\"></script>
           <script type=\"text/javascript\"
                   src=\"http://www.pirilampo.org/styles/readtheorg/js/readtheorg.js\"></script>")
-         (publish-target (concat user-emacs-directory "export/"))
+         (publish-target (concat spacemacs-start-directory "export/"))
          (org-html-htmlize-output-type 'css)
          (org-publish-project-alist
           `(("spacemacs"
@@ -115,7 +115,7 @@
              :headline-levels 4
              :html-head ,header)
             ("layers-doc"
-             :base-directory ,(concat user-emacs-directory "layers/")
+             :base-directory ,(concat spacemacs-start-directory "layers/")
              :base-extension "org"
              :recursive t
              :publishing-directory ,(concat publish-target "layers/")
@@ -130,7 +130,7 @@
              :publishing-directory ,(concat publish-target "doc/")
              :publishing-function org-publish-attachment)
             ("layers-doc-static"
-             :base-directory ,(concat user-emacs-directory "layers/")
+             :base-directory ,(concat spacemacs-start-directory "layers/")
              :base-extension "jpg\\|png\\|gif"
              :recursive t
              :publishing-directory ,(concat publish-target "layers/")

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -12,7 +12,7 @@
 
 ;; paths
 (defconst spacemacs-core-directory
-  (expand-file-name (concat user-emacs-directory "core/"))
+  (expand-file-name (concat spacemacs-start-directory "core/"))
   "Spacemacs core directory.")
 (defconst spacemacs-info-directory
   (expand-file-name (concat spacemacs-core-directory "info/"))
@@ -33,13 +33,13 @@
   (expand-file-name (concat spacemacs-cache-directory "auto-save/"))
   "Spacemacs auto-save directory")
 (defconst spacemacs-docs-directory
-  (expand-file-name (concat user-emacs-directory "doc/"))
+  (expand-file-name (concat spacemacs-start-directory "doc/"))
   "Spacemacs documentation directory.")
 (defconst spacemacs-assets-directory
-  (expand-file-name (concat user-emacs-directory "assets/"))
+  (expand-file-name (concat spacemacs-start-directory "assets/"))
   "Spacemacs assets directory.")
 (defconst spacemacs-test-directory
-  (expand-file-name (concat user-emacs-directory "tests/"))
+  (expand-file-name (concat spacemacs-start-directory "tests/"))
   "Spacemacs tests directory.")
 
 (defconst user-home-directory
@@ -57,7 +57,7 @@
 ;; load paths
 (mapc 'add-to-load-path
       `(
-        ,(concat user-emacs-directory "core/")
-        ,(concat user-emacs-directory "core/libs/")
+        ,(concat spacemacs-start-directory "core/")
+        ,(concat spacemacs-start-directory "core/libs/")
         ,(concat user-dropbox-directory "emacs/")
         ))

--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -84,8 +84,8 @@ found."
     (message "Start checking for new version...")
     (async-start
      `(lambda ()
-        ,(async-inject-variables "\\`user-emacs-directory\\'")
-        (load-file (concat user-emacs-directory "core/core-load-paths.el"))
+        ,(async-inject-variables "\\`spacemacs-start-directory\\'")
+        (load-file (concat spacemacs-start-directory "core/core-load-paths.el"))
         (require 'core-spacemacs)
         (spacemacs/get-last-version))
      (lambda (result)
@@ -140,7 +140,7 @@ version and the NEW version."
 (defun spacemacs/git-has-remote (remote)
   "Return non nil if REMOTE is declared."
   (let((proc-buffer "git-has-remote")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (when (eq 0 (process-file "git" nil proc-buffer nil "remote"))
         (with-current-buffer proc-buffer
           (prog2
@@ -151,7 +151,7 @@ version and the NEW version."
 (defun spacemacs/git-add-remote (remote url)
   "Add a REMOTE with URL, return t if no error."
   (let((proc-buffer "git-add-remote")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (prog1
         (eq 0 (process-file "git" nil proc-buffer nil
                             "remote" "add" remote url))
@@ -160,7 +160,7 @@ version and the NEW version."
 (defun spacemacs/git-remove-remote (remote)
   "Remove a REMOTE, return t if no error."
   (let((proc-buffer "git-remove-remote")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (prog1
         (eq 0 (process-file "git" nil proc-buffer nil
                             "remote" "remove" remote))
@@ -169,7 +169,7 @@ version and the NEW version."
 (defun spacemacs/git-fetch-remote (remote)
   "Fetch last commits from REMOTE, return t if no error."
   (let((proc-buffer "git-remove-remote")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (prog1
         (eq 0 (process-file "git" nil proc-buffer nil
                             "fetch" remote))
@@ -178,7 +178,7 @@ version and the NEW version."
 (defun spacemacs/git-fetch-tags (remote branch)
   "Fetch the tags for BRANCH in REMOTE repository."
   (let((proc-buffer "git-fetch-tags")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (prog2
         ;; seems necessary to fetch first
         (eq 0 (process-file "git" nil proc-buffer nil
@@ -191,7 +191,7 @@ version and the NEW version."
 (defun spacemacs/git-hard-reset-to-tag (tag)
   "Hard reset the current branch to specifed TAG."
   (let((proc-buffer "git-hard-reset")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (prog1
         (eq 0 (process-file "git" nil proc-buffer nil
                             "reset" "--hard" tag))
@@ -200,7 +200,7 @@ version and the NEW version."
 (defun spacemacs/git-latest-tag (remote branch)
   "Returns the latest tag on REMOTE/BRANCH."
   (let((proc-buffer "git-latest-tag")
-       (default-directory (file-truename user-emacs-directory))
+       (default-directory (file-truename spacemacs-start-directory))
        (where (format "%s/%s" remote branch)))
     (when (eq 0 (process-file "git" nil proc-buffer nil
                               "describe" "--tags" "--abbrev=0"
@@ -219,7 +219,7 @@ version and the NEW version."
 (defun spacemacs/git-checkout (branch)
   "Checkout the given BRANCH. Return t if there is no error."
   (let((proc-buffer "git-checkout")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (prog1
         (eq 0 (process-file "git" nil proc-buffer nil
                             "checkout" branch))
@@ -228,7 +228,7 @@ version and the NEW version."
 (defun spacemacs/git-get-current-branch ()
    "Return the current branch. Return nil if an error occurred."
    (let((proc-buffer "git-get-current-branch")
-        (default-directory (file-truename user-emacs-directory)))
+        (default-directory (file-truename spacemacs-start-directory)))
      (when (eq 0 (process-file "git" nil proc-buffer nil
                                "symbolic-ref" "--short" "-q" "HEAD"))
        (with-current-buffer proc-buffer
@@ -245,7 +245,7 @@ version and the NEW version."
   "Returns the hash of the head commit on the current branch.
 Returns nil if an error occurred."
   (let((proc-buffer "git-get-current-branch-head-hash")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (when (eq 0 (process-file "git" nil proc-buffer nil
                               "rev-parse" "--short" "HEAD"))
       (with-current-buffer proc-buffer
@@ -262,7 +262,7 @@ Returns nil if an error occurred."
   "Non-nil if the user's emacs directory is not clean.
 Returns the output of git status --porcelain."
   (let((proc-buffer "git-working-directory-dirty")
-       (default-directory (file-truename user-emacs-directory)))
+       (default-directory (file-truename spacemacs-start-directory)))
     (when (eq 0 (process-file "git" nil proc-buffer nil
                               "status" "--porcelain"))
       (with-current-buffer proc-buffer

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -265,7 +265,7 @@ If TYPE is nil, just remove widgets."
                                                    :help-echo "Open the full change log."
                                                    :action (lambda (&rest ignore)
                                                              (funcall 'spacemacs/view-org-file
-                                                                      (concat user-emacs-directory "CHANGELOG.org")
+                                                                      (concat spacemacs-start-directory "CHANGELOG.org")
                                                                       "Release 0.105.x"
                                                                       'subtree))
                                                    :mouse-face 'highlight

--- a/init.el
+++ b/init.el
@@ -20,7 +20,10 @@
     (message (concat "Your version of Emacs (%s) is too old. "
                      "Spacemacs requires Emacs version %d or above.")
              emacs-version spacemacs-emacs-min-version)
-  (load-file (concat user-emacs-directory "core/core-load-paths.el"))
+  (setq spacemacs-start-directory
+        (if (boundp 'spacemacs-start-directory)
+            spacemacs-start-directory user-emacs-directory))
+  (load-file (concat spacemacs-start-directory "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (spacemacs/init)
   (spacemacs/maybe-install-dotfile)

--- a/init.el
+++ b/init.el
@@ -20,9 +20,7 @@
     (message (concat "Your version of Emacs (%s) is too old. "
                      "Spacemacs requires Emacs version %d or above.")
              emacs-version spacemacs-emacs-min-version)
-  (setq spacemacs-start-directory
-        (if (boundp 'spacemacs-start-directory)
-            spacemacs-start-directory user-emacs-directory))
+  (defvar spacemacs-start-directory user-emacs-directory)
   (load-file (concat spacemacs-start-directory "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (spacemacs/init)

--- a/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
+++ b/layers/+distribution/spacemacs-base/local/helm-spacemacs/helm-spacemacs.el
@@ -133,7 +133,7 @@
                   ;; CONTRIBUTING.org is a special case as it should be at the
                   ;; root of the repository to be linked as the contributing
                   ;; guide on Github.
-                  (concat user-emacs-directory candidate)
+                  (concat spacemacs-start-directory candidate)
                 (concat spacemacs-docs-directory candidate))))
     (cond ((and (equal (file-name-extension file) "md")
                 (not helm-current-prefix-arg))

--- a/layers/+irc/rcirc/packages.el
+++ b/layers/+irc/rcirc/packages.el
@@ -154,7 +154,7 @@
       (defun spacemacs/rcirc-notify-beep (msg)
         "Beep when notifying."
         (let ((player "mplayer")
-              (sound (concat user-emacs-directory "site-misc/startup.ogg")))
+              (sound (concat spacemacs-start-directory "site-misc/startup.ogg")))
           (when (and (executable-find player)
                      (file-exists-p sound)))
           (start-process "beep-process" nil player sound)))


### PR DESCRIPTION
With this new variable, user can load spacemacs anywhere, e.g. "~/.emacs.d/spacemacs/",
and user can keep there temporary data inside their own "~/.emacs.d/". If user want to
use spacemacs this way, drop one line as the below into "~/.emacs.d/init.el":

  (setq spacemacs-start-directory "~/.emacs.d/spacemacs/")
  (load-file (concat spacemacs-start-directory "init.el"))

This also solve my own problem in this issue: https://github.com/syl20bnr/spacemacs/issues/5301