### PR TITLE
layouts: remove "toggle help" text string

### DIFF
--- a/layers/+window-management/spacemacs-layouts/packages.el
+++ b/layers/+window-management/spacemacs-layouts/packages.el
@@ -89,11 +89,7 @@
                      persp (position persp persp-list))) persp-list " | "))))
           (concat formatted-persp-list
                   (if (equal 1 spacemacs--layouts-ms-doc-toggle)
-                      spacemacs--layouts-ms-documentation
-                    (concat
-                     "\n ["
-                     (propertize "?" 'face 'hydra-face-red)
-                     "]   toggle help")))))
+                      spacemacs--layouts-ms-documentation))))
 
       (spacemacs|define-transient-state layouts
         :title "Layouts Transient State"


### PR DESCRIPTION
Transient state's toggleable docstring should conventionally be on `?`
so it can be removed to save space.

before:
<img width="480" alt="screenshot 2016-03-03 13 37 40" src="https://cloud.githubusercontent.com/assets/542810/13488436/2e1eb58e-e147-11e5-9b3a-42a1ff91ffd5.png">

after:
<img width="433" alt="screenshot 2016-03-03 13 52 59" src="https://cloud.githubusercontent.com/assets/542810/13488450/490f2450-e147-11e5-8dcb-ab26afdb94d6.png">
