### PR TITLE
Fix rcirc logging where the channel name has '/' in it

### DIFF
--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -128,8 +128,6 @@
       (setq rcirc-log-flag t)
       (defun rcirc-write-log (process sender response target text)
         (when rcirc-log-directory
-          (when (not (file-directory-p rcirc-log-directory))
-            (make-directory rcirc-log-directory))
           (with-temp-buffer
             ;; Sometimes TARGET is a buffer :-(
             (when (bufferp target)
@@ -143,9 +141,12 @@
                 (insert "/" (downcase response) " "))
               (insert text "\n")
               ;; Append the line to the appropriate logfile.
-              (let ((coding-system-for-write 'no-conversion))
+              (let ((coding-system-for-write 'no-conversion)
+                    (logfile (concat rcirc-log-directory  (downcase target))))
+                (when (not (file-directory-p (file-name-directory logfile)))
+                  (make-directory (file-name-directory logfile)))
                 (write-region (point-min) (point-max)
-                              (concat rcirc-log-directory  (downcase target))
+                              logfile
                               t 'quietly))))))
       (add-hook 'rcirc-print-hooks 'rcirc-write-log)
 


### PR DESCRIPTION
This happens when connecting to gitter via irc.gitter.im, for instance.
It turns out that channels are named like #syl20bnr/spacemacs. For the
logging to work, we need to create the directory #syl20bnr first.
