### PR TITLE
[WIP] Function for formatting githubified org files for Spacemacs

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -277,4 +277,77 @@ buffer."
           . (,feature . ,repl-func))
         spacemacs-repl-list))
 
+(defun spacemacs/orgify-orgbuf ()
+  "Transforms current README.org file buffer from the GitHub friendly
+form(see `spacemacs/org-githubify-orgbuf' ) to the canonical."
+  (interactive)
+  (let ((toc-line-rexp "^.*:TOC.*:.*$")
+        (toc-item-rexp  "^[\s]*\-\s\\[\\[.*\\]\\[.*\\]\\].*$")
+        (org-heading-rexp "^[\\*]+\s.*$"))
+    (save-excursion
+      (save-match-data
+
+        ;; Find TOC
+        (let ((last-pos 0)
+              (toc-line-count 0))
+          (progn (beginning-of-buffer)
+                 (while (search-forward-regexp toc-line-rexp nil t)
+                   (incf toc-line-count))
+                 (unless (= toc-line-count 1)
+                   (warn (format (concat "Found %d lines annotated with TOC. "
+                                         "Should be exactly 1.") toc-line-count)))))
+
+        (let ((line-after-toc-head-beg-pos (progn
+                                             (beginning-of-buffer)
+                                             (search-forward-regexp toc-line-rexp)
+                                             (line-beginning-position 2)))
+              headings
+              toc-items-and-levels)
+
+          (progn  (goto-char line-after-toc-head-beg-pos)
+                  ;; Remove TOC items
+                  (while (looking-at-p toc-item-rexp) (kill-whole-line))
+                  ;; Find all headings
+                  (while (search-forward-regexp org-heading-rexp nil t)
+                    (push (buffer-substring-no-properties
+                           (line-beginning-position)
+                           (line-end-position))
+                          headings))
+                  ;; Calculate headings levels
+                  (mapcar (lambda (heading)
+                            (let ((heading-lvl (- (length heading)
+                                                  (length (replace-regexp-in-string
+                                                           "^[\*]+"
+                                                           ""
+                                                           heading))))
+                                  ;; List of filters to be applied to the headings
+                                  (filters `(,(apply-partially 'replace-regexp-in-string "^[\s]*" "")
+                                             ,(apply-partially 'replace-regexp-in-string "[\s]*$" ""))))
+
+                              (progn
+                                ;; Apply filters
+                                (mapcar (lambda (filter) (setq heading (funcall filter heading))) filters)
+
+                                (push (cons heading heading-lvl) toc-items-and-levels))))
+                          (reverse headings))
+
+                  ;; Populate TOC items
+                  (mapcar*  (lambda (item-and-lvl)
+                              (progn (setq item (format " - [[%s][%s]]\n"
+                                                        (replace-regexp-in-string "^[\*]+\s"
+                                                                                  ""
+                                                                                  ;; Link
+                                                                                  (car item-and-lvl))
+                                                        ;; Remove *'s from title
+                                                        (replace-regexp-in-string "^[\*]+\s"
+                                                                                  ""
+                                                                                  ;; Title
+                                                                                  (pop headings))))
+                                     ;; Create indentations
+                                     (dotimes , (1- (cdr item-and-lvl)) (setq item (concat "  " item)))
+                                     ;; Inset the items after the TOC header
+                                     (goto-char line-after-toc-head-beg-pos)
+                                     (insert item)))
+                            toc-items-and-levels)))))))
+
 (provide 'core-funcs)


### PR DESCRIPTION
Add function `spacemacs/orgify-orgbuf` that formats org file(opened in a buffer) to be viewed via Spacemacs. (see #5342)

It seems to works as intended, but I haven't hooked it yet.  Not sure if it should be a separate PR from #5342 or not, but said PR can't destructively affect Spacemacs and can be safely merged and this one should be carefully evaluated.

Part of proposed solution for #4399