### PR TITLE
counsel: Use counsel-mode

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -309,7 +309,9 @@ Helm hack."
         "skF" 'spacemacs/search-ack-region-or-symbol
         "skp" 'spacemacs/search-project-ack
         "skP" 'spacemacs/search-project-ack-region-or-symbol)
-      (global-set-key (kbd "M-x") 'counsel-M-x)
+
+      ;; remaps built-in commands that have a counsel replacement
+      (counsel-mode 1)
 
       ;; Note: Must be set before which-key is loaded.
       (setq prefix-help-command 'counsel-descbinds)


### PR DESCRIPTION
Minor mode that remaps all built-in Emacs commands that have a counsel
replacement.