### PR TITLE
C-j/C-k bindings in shell only with vim style

### DIFF
--- a/layers/shell/packages.el
+++ b/layers/shell/packages.el
@@ -165,9 +165,10 @@ is achieved by adding the relevant text properties."
 
       ;; These don't work well in normal state
       ;; due to evil/emacs cursor incompatibility
-      (evil-define-key 'insert eshell-mode-map
-        (kbd "C-k") 'eshell-previous-matching-input-from-input
-        (kbd "C-j") 'eshell-next-matching-input-from-input))))
+      (when (eq dotspacemacs-editing-style 'vim)
+        (evil-define-key 'insert eshell-mode-map
+          (kbd "C-k") 'eshell-previous-matching-input-from-input
+          (kbd "C-j") 'eshell-next-matching-input-from-input)))))
 
 (defun shell/init-eshell-prompt-extras ()
   (use-package eshell-prompt-extras
@@ -347,12 +348,14 @@ is achieved by adding the relevant text properties."
   (evil-define-key 'insert term-raw-map (kbd "C-c C-z") 'term-stop-subjob)
   (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab)
 
-  (evil-define-key 'insert term-raw-map
-    (kbd "C-k") 'term-send-up
-    (kbd "C-j") 'term-send-down)
-  (evil-define-key 'normal term-raw-map
-    (kbd "C-k") 'term-send-up
-    (kbd "C-j") 'term-send-down))
+  (when (eq dotspacemacs-editing-style 'vim)
+    (progn
+      (evil-define-key 'insert term-raw-map
+        (kbd "C-k") 'term-send-up
+        (kbd "C-j") 'term-send-down)
+      (evil-define-key 'normal term-raw-map
+        (kbd "C-k") 'term-send-up
+        (kbd "C-j") 'term-send-down))))
 
 (defun shell/init-xterm-color ()
   (use-package xterm-color


### PR DESCRIPTION
This wraps C-k/C-j binding customization in a check for the
dotspacemacs-editing-style variable, and only applies them if vim style
is selected. For hybrid or emacs style users, C-k not killing line and
C-j not sending a form of return will be confusing, and they will be
more used to C-n/p or M-n/p bindings, which exist in the shells already.