### PR TITLE
Fix cider-pop-back function name

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -214,7 +214,7 @@ If called with a prefix argument, uses the other-window instead."
 
           "fb" 'cider-format-buffer
 
-          "gb" 'cider-jump-back
+          "gb" 'cider-pop-back
           "ge" 'cider-jump-to-compilation-error
           "gg" 'cider-find-var
           "gr" 'cider-jump-to-resource


### PR DESCRIPTION
Alias `cider-jump-back` was deprecated and then removed from CIDER here: https://github.com/clojure-emacs/cider/commit/705133f2bdca33cb5bc6e0a5b4861965e0883ee4