### PR TITLE
add go coverage key bindings

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -24,6 +24,7 @@ This layer adds extensive support for go.
 - Auto-completion using [[https://github.com/nsf/gocode/tree/master/emacs][go-autocomplete]] (with the =auto-completion= layer)
 - Source analysis using [[http://golang.org/s/oracle-user-manual][go-oracle]]
 - Linting with flycheck's built-in checkers or flycheck-gometalinter
+- Coverage profile visualization
 
 * Install
 ** Pre-requisites
@@ -60,7 +61,7 @@ add =go= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 * Configuration
-** Formatting
+
 By default, go buffers are run through =gofmt= on save. To use a different
 formatter, set the value of =gofmt-command=, e.g.
 
@@ -87,6 +88,10 @@ If you're using =gocheck= in your project you can use the
 =go-use-gocheck-for-testing= variable to enable suite testing and to get single
 function testing to work.
 
+=go-coverage-display-buffer-func= controls how =go-coverage= should display
+the coverage buffer. See [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Choosing-Window.html][=display-buffer=]] for a list of possible functions.
+The default value is =display-buffer-reuse-window=.
+
 * Working with Go
 ** Go commands (start with =m=):
 
@@ -101,6 +106,7 @@ function testing to work.
 | ~SPC m e d~ | download go-play snippet                                                              |
 | ~SPC m x x~ | run "go run" for the current 'main' package                                           |
 | ~SPC m g a~ | jump to matching test file or back from test to code file                             |
+| ~SPC m g c~ | open a clone of the current buffer with a coverage info (=go tool cover -h= for help) |
 | ~SPC m g g~ | go jump to definition                                                                 |
 | ~SPC m r n~ | go rename                                                                             |
 | ~SPC m t p~ | run "go test" for the current package                                                 |

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -87,6 +87,7 @@
         "ed" 'go-download-play
         "xx" 'spacemacs/go-run-main
         "ga" 'ff-find-other-file
+        "gc" 'go-coverage
         "gg" 'godef-jump
         "tt" 'spacemacs/go-run-test-current-function
         "ts" 'spacemacs/go-run-test-current-suite


### PR DESCRIPTION
Not sure why [`go-coverage`](https://github.com/dominikh/go-mode.el/blob/27b74155dc2896a1809c905a7326b1d6d36014f3/go-mode.el#L1593) wasn't bound, but it is now.  `SPC` `m` `t` `c`  looks like a good place for it. 

I'll test it a bit more and probably add a key binding to make a coverage file. 

Also I removed `*Configuration`'s subheading `** Formatting`. It was wrong.  Now we need at least 3 subheadings - almost one per line. Not sure if it's reasonable.