### PR TITLE
move org essentials to spacemacs distro

### DIFF
--- a/layers/+distribution/spacemacs/config.el
+++ b/layers/+distribution/spacemacs/config.el
@@ -18,7 +18,8 @@
                                       spacemacs-evil
                                       spacemacs-language
                                       spacemacs-ui
-                                      spacemacs-ui-visual))
+                                      spacemacs-ui-visual
+                                      spacemacs-org))
 ;; If the user has not explicitly declared spacemacs-helm or spacemacs-ivy and
 ;; they are using the standard distribution, assume they want helm completion.
 (unless (or (configuration-layer/layer-usedp 'spacemacs-ivy)

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -14,9 +14,8 @@
     company
     company-emoji
     emoji-cheat-sheet-plus
-    (evil-org :location local)
+    evil-org
     evil-surround
-    flyspell
     gnuplot
     htmlize
     mu4e
@@ -25,7 +24,6 @@
     (org :location built-in)
     (org-agenda :location built-in)
     (org-plus-contrib :step pre)
-    org-bullets
     ;; org-mime is installed by `org-plus-contrib'
     (org-mime :location built-in)
     org-pomodoro
@@ -47,18 +45,13 @@
 (defun org/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'org-mode-hook 'spacemacs/delay-emoji-cheat-sheet-hook))
 
-(defun org/init-evil-org ()
+(defun org/post-init-evil-org ()
   (use-package evil-org
-    :commands evil-org-mode
-    :init
-    (add-hook 'org-mode-hook 'evil-org-mode)
+    :defer t
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "C" 'evil-org-recompute-clocks)
-      (evil-define-key 'normal evil-org-mode-map
-        "O" 'evil-open-above)
-      (spacemacs|diminish evil-org-mode " ⓔ" " e"))))
+        "C" 'evil-org-recompute-clocks))))
 
 (defun org/post-init-evil-surround ()
   (defun spacemacs/add-org-surrounds ()
@@ -67,9 +60,6 @@
   (defun spacemacs//surround-drawer ()
     (let ((dname (read-from-minibuffer "" "")))
       (cons (format ":%s:\n" (or dname "")) "\n:END:"))))
-
-(defun org/post-init-flyspell ()
-  (spell-checking/add-flyspell-hook 'org-mode-hook))
 
 (defun org/init-gnuplot ()
   (use-package gnuplot
@@ -83,7 +73,7 @@
     :post-config (require 'org-mu4e nil 'noerror)))
 
 ;; dummy init function to force installation of `org-plus-contrib'
-(defun org/init-org-plus-contrib ())
+(defun org/post-init-org-plus-contrib ())
 
 (defun org/init-ob ()
   (use-package ob
@@ -96,11 +86,8 @@
                                      org-babel-load-languages))
       (add-hook 'org-mode-hook 'spacemacs//org-babel-do-load-languages))))
 
-(defun org/init-org ()
+(defun org/post-init-org ()
   (use-package org
-    :mode ("\\.org$" . org-mode)
-    :commands (org-clock-out org-occur-in-agenda-files org-agenda-files)
-    :defer t
     :init
     (progn
       ;; FIXME: This check has been disabled pending a resolution of
@@ -149,6 +136,13 @@
           "c" 'org-edit-src-exit
           "a" 'org-edit-src-abort
           "k" 'org-edit-src-abort))
+
+      (let ((dir (configuration-layer/get-layer-property 'org :dir)))
+        (setq org-export-async-init-file (concat dir "org-async-init.el")))
+      (defmacro spacemacs|org-emphasize (fname char)
+        "Make function for setting the emphasis in org mode"
+        `(defun ,fname () (interactive)
+                (org-emphasize ,char)))
 
       ;; Insert key for org-mode and markdown a la C-h k
       ;; from SE endless http://emacs.stackexchange.com/questions/2206/i-want-to-have-the-kbd-tags-for-my-blog-written-in-org-mode/2208#2208
@@ -287,14 +281,6 @@ Will work on both org-mode and any mode that accepts plain html."
     :config
     (progn
       (setq org-default-notes-file "notes.org")
-      (font-lock-add-keywords
-       'org-mode '(("\\(@@html:<kbd>@@\\) \\(.*\\) \\(@@html:</kbd>@@\\)"
-                    (1 font-lock-comment-face prepend)
-                    (2 font-lock-function-name-face)
-                    (3 font-lock-comment-face prepend))))
-
-      ;; Open links and files with RET in normal state
-      (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)
 
       ;; We add this key mapping because an Emacs user can change
       ;; `dotspacemacs-major-mode-emacs-leader-key' to `C-c' and the key binding
@@ -444,11 +430,6 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (kbd "M-SPC") 'spacemacs/org-agenda-transient-state/body
       (kbd "s-M-SPC") 'spacemacs/org-agenda-transient-state/body)))
 
-(defun org/init-org-bullets ()
-  (use-package org-bullets
-    :defer t
-    :init (add-hook 'org-mode-hook 'org-bullets-mode)))
-
 (defun org/init-org-mime ()
   (use-package org-mime
     :defer t
@@ -556,14 +537,6 @@ a Markdown buffer and use this command to convert it.
     :binding "o"
     :body
     (find-file (first (org-agenda-files)))))
-
-(defun org/init-toc-org ()
-  (use-package toc-org
-    :defer t
-    :init
-    (progn
-      (setq toc-org-max-depth 10)
-      (add-hook 'org-mode-hook 'toc-org-enable))))
 
 (defun org/init-htmlize ()
  (use-package htmlize

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -1,0 +1,89 @@
+;;; packages.el --- spacemacs-org layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Boris Buliga <d12frosted@d12frosted.local>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;;; Code:
+
+(defconst spacemacs-org-packages
+  '(
+    (evil-org :location local)
+    flyspell
+    ;; org is installed by `org-plus-contrib'
+    (org :location built-in)
+    (org-plus-contrib :step pre)
+    org-bullets
+    toc-org
+    ))
+
+(defun spacemacs-org/init-evil-org ()
+  (use-package evil-org
+    :commands evil-org-mode
+    :init
+    (add-hook 'org-mode-hook 'evil-org-mode)
+    :config
+    (progn
+      (evil-define-key 'normal evil-org-mode-map
+        "O" 'evil-open-above)
+      (spacemacs|diminish evil-org-mode " ⓔ" " e"))))
+
+(defun spacemacs-org/post-init-flyspell ()
+  (spell-checking/add-flyspell-hook 'org-mode-hook))
+
+;; dummy init function to force installation of `org-plus-contrib'
+(defun spacemacs-org/post-init-org-plus-contrib ())
+
+(defun spacemacs-org/init-org ()
+  (use-package org
+    :mode ("\\.org$" . org-mode)
+    :commands (org-clock-out org-occur-in-agenda-files org-agenda-files)
+    :defer t
+    :init
+    (progn
+      ;; FIXME: This check has been disabled pending a resolution of
+      ;; https://github.com/syl20bnr/spacemacs/issues/3933
+      ;; (when (featurep 'org)
+      ;;   (configuration-layer//set-error)
+      ;;   (spacemacs-buffer/append
+      ;;    (concat
+      ;;     "Org features were loaded before the `org' layer initialized.\n"
+      ;;     "Try removing org code from user initialization and private layers.") t))
+
+      (setq org-startup-with-inline-images t
+            org-src-fontify-natively t
+            ;; this is consistent with the value of
+            ;; `helm-org-headings-max-depth'.
+            org-imenu-depth 8)
+    :config
+    (progn
+      (font-lock-add-keywords
+       'org-mode '(("\\(@@html:<kbd>@@\\) \\(.*\\) \\(@@html:</kbd>@@\\)"
+                    (1 font-lock-comment-face prepend)
+                    (2 font-lock-function-name-face)
+                    (3 font-lock-comment-face prepend))))
+
+      ;; Open links and files with RET in normal state
+      (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)))))
+
+(defun spacemacs-org/init-org-bullets ()
+  (use-package org-bullets
+    :defer t
+    :init (add-hook 'org-mode-hook 'org-bullets-mode)))
+
+(defun spacemacs-org/init-toc-org ()
+  (use-package toc-org
+    :defer t
+    :init
+    (progn
+      (setq toc-org-max-depth 10)
+      (add-hook 'org-mode-hook 'toc-org-enable))))
+
+;;; packages.el ends here


### PR DESCRIPTION
Following #4277 

---

I haven't touched readme file, because I think it's good to have all description in one place. Also, I didn't rename `org` layer to anything else. If you think that it's a good idea - just tell me (or it could be done via another PR / commit). 

I tested my changes in different situations and everything seems to be working. But since I don't know all use-cases of org layer, I would like to take some help from org users and those who don't use org at all. 

In case you think that something is not in the right place (some configs should be moved from spacemacs-org to org or vice versa) just let's discuss :)