### PR TITLE
restore evil-binding of 'g' key in a compilation buffer

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -148,6 +148,8 @@
   "ck" 'kill-compilation
   "cr" 'recompile
   "cq" 'spacemacs/close-compilation-window)
+(define-key compilation-mode-map "r" 'recompile)
+(define-key compilation-mode-map "g" nil)
 
 ;; narrow & widen -------------------------------------------------------------
 (spacemacs/set-leader-keys


### PR DESCRIPTION
By default, recompile is bound to 'g' in compilation buffer.
It was rebound to 'r' key.