### PR TITLE
Fix auto-completion toggle without default

### DIFF
--- a/layers/auto-completion/config.el
+++ b/layers/auto-completion/config.el
@@ -11,6 +11,9 @@
 
 ;; Company -------------------------------------------------------------------
 
+(defvar-local auto-completion-front-end 'company
+  "Which auto-completion front end to use.")
+
 (defvar auto-completion-return-key-behavior 'complete
   "What the RET key should do when auto-completion menu is active.
 Possible values are `complete' or `nil'.")

--- a/layers/auto-completion/funcs.el
+++ b/layers/auto-completion/funcs.el
@@ -11,13 +11,9 @@
 
 (spacemacs|add-toggle auto-completion
   :status
-  (if (boundp 'auto-completion-front-end)
-      (if (eq 'company auto-completion-front-end)
-          company-mode
-        auto-complete-mode)
-    ;; default completion hardcoded to be company for now
-    (setq auto-completion-front-end 'company)
-    nil)
+  (if (eq 'company auto-completion-front-end)
+      (bound-and-true-p company-mode)
+    (bound-and-true-p auto-complete-mode))
   :on
   (progn
     (if (eq 'company auto-completion-front-end)


### PR DESCRIPTION
There were some problems toggling auto-completion on if a default was not configured. (You'd get unbound variable error on `auto-complete-mode` for starters.) This commit also ensures that the frontend variable is always defined and that it always defaults to company.