### PR TITLE
Fixes #5321 - Keep escape binding in evil-visual-state default

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -252,7 +252,6 @@ evil-normal state."
       (define-key evil-window-map (kbd "<up>") 'evil-window-up)
       (define-key evil-window-map (kbd "<down>") 'evil-window-down)
       (spacemacs/set-leader-keys "re" 'evil-show-registers)
-      (define-key evil-visual-state-map (kbd "<escape>") 'keyboard-quit)
       ;; motions keys for help buffers
       (evil-define-key 'motion help-mode-map (kbd "<escape>") 'quit-window)
       (evil-define-key 'motion help-mode-map (kbd "<tab>") 'forward-button)


### PR DESCRIPTION
While seemingly equivalent, this binding change can cause brittle
behavior in at least one case (used in conjunction with
multiple-cursors). Such a highly niche customization would probably be
better in a personal config, unless a case can be made that all
spacemacs users would benefit.

Addressed in #5321