### PR TITLE
Warmly send a lost contributor from the master to the develop branch

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -19,6 +19,19 @@ if [ $USER != "travis" ]; then
     exit 1
 fi
 
+if  [ $TRAVIS_SECURE_ENV_VARS = false ] &&
+    [ $TRAVIS_PULL_REQUEST != false ] &&
+    [ $TRAVIS_BRANCH = "master" ]; then
+
+    	printf '=%.0s' {1..70}
+    	printf "\n       し(*･∀･)／   Thanks for the contribution!  ＼(･∀･*)ノ\n"
+    	printf '=%.0s' {1..70}
+    	printf "\n( ＾◡＾)っ Please submit your pull request against the develop branch.\n"
+    	echo   "You can read the contribution guidelines at:"
+    	echo   "https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org"
+    	exit 1
+fi
+
 echo "Pwd $(pwd)"
 rm -rf ~/.emacs.d
 ln -sf `pwd` ~/.emacs.d


### PR DESCRIPTION
This patch should make Travis builds fail with a nice message if someone pushes to the master branch from a fork. [Example](https://travis-ci.org/JAremko/spacemacs-pr/jobs/114201195).

It relies on the fact that the Travis environment variable `TRAVIS_SECURE_ENV_VARS` should be `false` for a push from a fork, but it should be `true` if both branches are in the same repository.

Might be a good idea or a bad one `¯\_(ツ)_/¯` 