### PR TITLE
Support plain-text gmail via chrome layer variable

### DIFF
--- a/layers/chrome/README.org
+++ b/layers/chrome/README.org
@@ -23,6 +23,10 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =chrome= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+The layer variable ~chrome-gmail-rich-text-format~ chooses between plain text
+and rich text composition. It should match the setting in the Gmail web
+interface.  The default is ~t~, which selects rich text composition.
+
 ** Chrome extension
 [[http://melpa.org/#/edit-server][edit-server]] is a server that responds to edit requests sent Chrome via the
 Google Chrome extension [[https://chrome.google.com/webstore/detail/edit-with-emacs/ljobjlafonikaiipfkggjbhkghgicgoh][Edit with Emacs]]. You have to install this extension.
@@ -31,9 +35,11 @@ More information can be found on [[http://www.emacswiki.org/emacs/Edit_with_Emac
 The edit server is configured to start automatically when Spacemacs starts.
 
 * Configuration
-Use =edit-server-url-major-mode-alist= to choose a major mode initialization
-function based on =edit-server-url=, or fall back to
-=edit-server-default-major-mode= that has a current value of =markdown-mode=.
+
+When using rich text composition, use =edit-server-url-major-mode-alist= to
+choose a major mode initialization function based on =edit-server-url=, or fall
+back to =edit-server-default-major-mode= that has a current value of
+=markdown-mode=.
 
 #+BEGIN_SRC emacs-lisp
   (defun dotspacemacs/user-config ()

--- a/layers/chrome/config.el
+++ b/layers/chrome/config.el
@@ -1,0 +1,13 @@
+;;; packages.el --- Chrome Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Ben Hayden <hayden767@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar chrome-gmail-rich-text-format t
+  "Default message format in Gmail web interface.")

--- a/layers/chrome/packages.el
+++ b/layers/chrome/packages.el
@@ -11,18 +11,41 @@
 
 (setq chrome-packages '(
                         edit-server
-                        gmail-message-mode
                         ))
 
 (defun chrome/init-edit-server ()
+  (message "init-edit-server" chrome-gmail-rich-text-format)
   (use-package edit-server
-    :init
-    (progn
-      (edit-server-start))
-    :config
-    (progn
-      (setq edit-server-default-major-mode 'markdown-mode))
-    ))
+    :init (edit-server-start)))
 
-(defun chrome/init-gmail-message-mode ( )
-  (use-package gmail-message-mode))
+;; gmail-message-mode autoloads code that drags the rest of the package in. So
+;; use-package's :if is actually useless, and if we don't want it to steal the
+;; composition buffer we need this outer cond to avoid ever reading in the file.
+(cond
+ (chrome-gmail-rich-text-format
+  (progn
+    (add-to-list 'chrome-packages 'gmail-message-mode)
+    (defun chrome/init-gmail-message-mode ()
+      (use-package gmail-message-mode
+        :if chrome-gmail-rich-text-format
+        :after edit-server
+        :init (setq edit-server-default-major-mode 'markdown-mode)))))
+ (t
+  (progn
+    (add-to-list 'chrome-packages 'edit-server-htmlize)
+    (defun chrome/init-edit-server-htmlize ()
+      (use-package edit-server-htmlize
+        :if (not chrome-gmail-rich-text-format)
+        :after edit-server
+        :init
+        (progn
+          (defun chrome/gmail-compose-buffer-p ()
+            (string-match-p "^mail\\.google\\.com/mail/u/" (buffer-name)))
+          (defun chrome/gmail-compose-dehtmlize ()
+            (when (chrome/gmail-compose-buffer-p)
+              (edit-server-dehtmlize-buffer)))
+          (defun chrome/gmail-compose-htmlize ()
+            (when (chrome/gmail-compose-buffer-p)
+              (edit-server-htmlize-buffer)))
+          (add-hook 'edit-server-start-hook 'chrome/gmail-compose-dehtmlize)
+          (add-hook 'edit-server-done-hook 'chrome/gmail-compose-htmlize)))))))


### PR DESCRIPTION
Those who use the chrome layer for gmail can now choose between rich-text
composition (default) or plain-text composition. In plain-text mode, the buffer
is de-htmlized before editing and re-htmlized afterward in a way compatible with
the Plain-text editing mode of gmail's web interface.

This implements #5266 .

As this is my first PR, it's very likely I've overlooked or misunderstood some part of your contribution guidelines. Corrections and advice will be received gratefully. Thanks!