### PR TITLE
Update document for tern configuration for windows.

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -68,6 +68,13 @@ layer, as detailed in [[file:../../../doc/DOCUMENTATION.org::Setting%20configura
   (javascript :variables javascript-disable-tern-port-files nil)
 #+END_SRC
 
+Windows users may need to set the variable =tern-command= in order for emacs to locate
+and launch tern server successfully. See [[https://github.com/ternjs/tern/issues/256#issuecomment-141531735][this open issue for more details]]:
+
+#+BEGIN_SRC emacs-lisp
+  (setq tern-command '("node" "/path/to/tern/bin/tern"))
+#+END_SRC
+
 ** Indentation
 To change how js2-mode indents code, set the variable =js2-basic-offset=, as such:
 


### PR DESCRIPTION
Currently, it looks like emacs won't be able to find `tern` and launch it in windows without additional configuration. So `tern` doesn't work by default and the error is: `windows Could not start Tern server`

I updated the document to include the necessary configuration for windows users.

This is my first PR. Please let me know if there is any issues or questions. Thanks. :)

Please see links below for more details:
- https://github.com/ternjs/tern/issues/256#issuecomment-141531735
- https://www.reddit.com/r/emacs/comments/3ld4pa/how_can_i_make_tern_find_my_terncmd_on_windows/