### PR TITLE
Add proselint layer

### DIFF
--- a/layers/proselint/README.org
+++ b/layers/proselint/README.org
@@ -1,0 +1,52 @@
+#+TITLE: proselint layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+
+#+CAPTION: logo
+
+# The maximum height of the logo should be 200 pixels.
+[[img/proselint.png]]
+
+* Table of Contents                                        :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Install][Install]]
+ - [[Key bindings][Key bindings]]
+
+* Description
+
+  This layer hooks [[https://github.com/amperser/proselint][proselint]] into flycheck to making typing go good, obviously.
+
+  While flycheck-proselint is enabled (via the toggle or the config var), it
+  will take precedence and be the ONLY functioning flycheck checker. Toggling
+  it off will return the normal flycheck functioning to the buffer.
+
+  It is possible to manually change this behavior using the
+  `flycheck-add-next-checker` function.
+
+* Install
+
+Install the proselint executable. Make sure it is in your $PATH.
+
+#+begin_src sh
+  pip install proselint
+#+end_src
+
+Add the following to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(proselint))
+#+end_src
+
+You may have proselint available but not started immediately by setting the
+`enable-proselint-feedback` variable to `nil`.
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(proselint :variables
+                                                              enable-proselint-feedback nil))
+#+end_src
+
+* Key bindings
+
+| Key Binding  | Description                                        |
+|--------------+--------------------------------------------------- |
+| ~<SPC> t P~  | Toggles the proselint flycheck feedback on and off |
+

--- a/layers/proselint/config.el
+++ b/layers/proselint/config.el
@@ -1,0 +1,15 @@
+;;; packages.el --- proselint layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Chris Ewald <chrisewald@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar enable-proselint-feedback t
+  "Non-nil if proselint feedback should be started automatically.")
+
+;; (length flycheck-checkers)

--- a/layers/proselint/packages.el
+++ b/layers/proselint/packages.el
@@ -1,0 +1,45 @@
+;;; packages.el --- proselint layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Chris Ewald <chrisewald@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst proselint-packages
+  '(flycheck))
+
+(defun proselint/post-init-flycheck ()
+
+  (defun flycheck-proselint-enabled-p ()
+    enable-proselint-feedback)
+
+  (flycheck-define-checker proselint
+    "A linter for prose."
+    :command ("proselint" source-inplace)
+    :error-patterns
+    ((warning line-start (file-name) ":" line ":" column ": "
+              (id (one-or-more (not (any " "))))
+              (message (one-or-more not-newline)
+                       (zero-or-more "\n" (any " ") (one-or-more not-newline)))
+              line-end))
+    :predicate flycheck-proselint-enabled-p)
+    ;; :modes (text-mode markdown-mode gfm-mode))
+
+  (add-to-list 'flycheck-checkers 'proselint)
+
+  (spacemacs|add-toggle flycheck-proselint
+    :status enable-proselint-feedback
+    :on (progn
+          (setq enable-proselint-feedback t)
+          (flycheck-buffer))
+    :off (progn
+           (setq enable-proselint-feedback nil)
+           (flycheck-buffer))
+    :documentation "Better writing with proselint feedback."
+    :evil-leader "tP"))
+
+;;; packages.el ends here


### PR DESCRIPTION
This layer hooks proselint into flycheck. It defines a toggle on `SPC t P` that turns it on and off. Getting this feedback is emacs is fun.

https://github.com/amperser/proselint/

Feedback is appreciated. I do not think that added this as a checker to flycheck is the ideal solution for this, because it can be always enabled like flyspell. When it enabled, it has the bad side effect of canceling the other flycheck checkers until it is toggled off. This works for me as is. Perhaps there is someway use `flycheck-add-next-checker` with a wildcard?
