### PR TITLE
spacemacs-ivy: escape special chars in counsel input

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -140,7 +140,7 @@ that directory."
                                               spacemacs--counsel-search-max-path-length)
                                            (length counsel--git-grep-dir))))))
        (spacemacs//make-counsel-search-function tool)
-       :initial-input initial-input
+       :initial-input (rxt-quote-pcre initial-input)
        :dynamic-collection t
        :history 'counsel-git-grep-history
        :action #'counsel-git-grep-action


### PR DESCRIPTION
fix #5378 

I tried with latest swiper(`swiper-20160307.1239` which has `shell-quote-argument` fix) but it still doesn't show the expected result. Hence I used the fix present in helm-ag  [here](https://github.com/syl20bnr/spacemacs/blob/895455d44cc935a4f1099886ac154522a5a18b26/layers/+completion/spacemacs-helm/packages.el#L538) which works fine. 