### PR TITLE
Latex layer: fix the all in one command (~SPC m a~)

### DIFF
--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -20,6 +20,14 @@
     ;; (when build-proc
     ;;   (set-process-sentinel build-proc 'latex//build-sentinel))))
 
+(defun latex/all ()
+  "Save, build and view in one command."
+  (interactive)
+  (progn
+    (let ((TeX-save-query nil))
+      (TeX-save-document (TeX-master-file)))
+    (TeX-command-run-all ())))
+
 (defun latex//build-sentinel (process event)
   (if (string= event "finished\n")
       (TeX-view)

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -54,8 +54,7 @@
           "-"   'TeX-recenter-output-buffer                  ;; C-c C-l
           "%"   'TeX-comment-or-uncomment-paragraph          ;; C-c %
           ";"   'TeX-comment-or-uncomment-region             ;; C-c ; or C-c :
-          ;; TeX-command-run-all runs compile and open the viewer
-          "a"   'TeX-command-run-all                         ;; C-c C-a
+          "a"   'latex/all
           "b"   'latex/build
           "k"   'TeX-kill-job                                ;; C-c C-k
           "l"   'TeX-recenter-output-buffer                  ;; C-c C-l


### PR DESCRIPTION
~TeX-command-run-all~ always asks to save file or not. Now with ~latex/all~
the .tex files are saved without asking.