### PR TITLE
update evil-snipe readme about symbol groups

### DIFF
--- a/layers/+vim/evil-snipe/README.org
+++ b/layers/+vim/evil-snipe/README.org
@@ -72,24 +72,27 @@ remove this line from =evil-snipe/packages.el=:
 
 ** Symbol groups
 With symbol groups you can let a character stand for a regex, for example a
-group of characters. By adding a pair of ='(CHAR REGEX)= to the list
-='evil-snipe-symbol-groups= you can search for a regex very simply:
+group of characters. By adding a pair of =(CHAR REGEX)= to the list
+=evil-snipe-aliases= you can search for a regex very simply:
 
-- Here we set the ~[~ character to mean =all characters "[({"= so a search
+- Here we set the ~[~ character to mean =all characters [({= *in all modes* so a search
 with ~sa[~ would find ~a[~, ~a{~ or ~a(~.
 
 #+BEGIN_SRC emacs-lisp
   ;; Alias [ and ] to all types of brackets
-  (add-to-list 'evil-snipe-symbol-groups '(?\\[ \"[[{(]\"))
+  (push '(?\[ "[[{(]") evil-snipe-aliases)
+  (push '(?\] "[]})]") evil-snipe-aliases)
 #+END_SRC
 
-- Here we set the char ~:~ to mean =a regex matching python function
-definitions= so by searching with ~f:fff~ you can quickly cycle through
+- Here we set the char ~:~ to mean =a regex matching python function definitions= (but only in python-mode), so by searching with ~f:fff~ you can quickly cycle through
 all function definitions in a buffer!
 
 #+BEGIN_SRC emacs-lisp
   ;; For python style functions
-  (add-to-list 'evil-snipe-symbol-groups '(?\\: \"def .+:\"\))
+  (add-hook 'python-mode-hook
+            (lambda ()
+              (make-variable-buffer-local 'evil-snipe-aliases)
+              (push '(?: "def .+:") evil-snipe-aliases)))
 #+END_SRC
 
 * TODO Key bindings


### PR DESCRIPTION
There were some changes in the upstream documentation related to symbol groups.
The details may be found in https://github.com/hlissner/evil-snipe/issues/32
Also I deleted some unnecessary quotation marks in verbatim blocks, so they are properly rendered now.