### PR TITLE
Don't hard-code location of elpa directory, use package-user-dir where appropriate

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1335,7 +1335,7 @@ to select one."
                  (pkg-dir-name (cdr apkg))
                  (installed-ver
                   (configuration-layer//get-package-version-string pkg))
-                 (elpa-dir (concat user-emacs-directory "elpa/"))
+                 (elpa-dir (file-name-as-directory package-user-dir))
                  (src-dir (expand-file-name
                            (concat rollback-dir (file-name-as-directory
                                                  pkg-dir-name))))
@@ -1436,7 +1436,7 @@ to select one."
     (cond
      ((version< emacs-version "24.3.50")
       (let* ((version (aref (cdr pkg-desc) 0))
-             (elpa-dir (concat user-emacs-directory "elpa/"))
+             (elpa-dir (file-name-as-directory package-user-dir))
              (pkg-dir-name (format "%s-%s.%s"
                                    (symbol-name pkg-name)
                                    (car version)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -49,7 +49,7 @@ FILE-TO-LOAD is an explicit file to load after the installation."
 
 (defun spacemacs//get-package-directory (pkg)
   "Return the directory of PKG. Return nil if not found."
-  (let ((elpa-dir (concat user-emacs-directory "elpa/")))
+  (let ((elpa-dir (file-name-as-directory package-user-dir)))
     (when (file-exists-p elpa-dir)
       (let ((dir (cl-reduce (lambda (x y) (if x x y))
                          (mapcar (lambda (x)


### PR DESCRIPTION
Currently the elpa directory is hard-coded to `<user-emacs-directory>/elpa` (usually `~/.emacs.d/elpa`).
With this PR, users can change the location of the elpa directory by changing the value of `package-user-dir`.
Users interested in changing the location of the elpa directory should set `package-user-dir` in `dotspacemacs/user-init`.