### PR TITLE
[scala] Add function to insert types and add yank type at point

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -193,6 +193,7 @@ the ascii arrows back.
 | ~SPC m i i~ | inspect type at point                  |
 | ~SPC m i I~ | inspect type in other frame            |
 | ~SPC m i p~ | inspect project package                |
+| ~SPC m i y~ | yank type at point                     |
 
 *** Server
 
@@ -206,6 +207,7 @@ the ascii arrows back.
 
 | Key Binding | Description                                                          |
 |-------------+----------------------------------------------------------------------|
+| ~SPC m r a~ | add type annotation                                                  |
 | ~SPC m r f~ | format source                                                        |
 | ~SPC m r d~ | get rid of an intermediate variable (=ensime-refactor-inline-local=) |
 | ~SPC m r D~ | get rid of an intermediate variable (=ensime-undo-peek=)             |

--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -101,3 +101,11 @@ point to the position of the join."
 
 (defun scala/configure-flyspell ()
   (setq-local flyspell-generic-check-word-predicate 'scala/flyspell-verify))
+
+(defun scala/yank-type-at-point ()
+  "Yank to kill ring and print type at point to the minibuffer without package name."
+  (interactive)
+  (let* ((type (ensime-rpc-get-type-at-point))
+         (shortname (ensime-type-short-name-with-args type)))
+    (kill-new shortname)
+    (message shortname)))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -140,11 +140,13 @@
         "ii"     'ensime-inspect-type-at-point
         "iI"     'ensime-inspect-type-at-point-other-frame
         "ip"     'ensime-inspect-project-package
+        "iy"     'scala/yank-type-at-point
 
         "nF"     'ensime-reload-open-files
         "ns"     'ensime
         "nS"     'ensime-gen-and-restart
 
+        "ra"     'ensime-refactor-add-type-annotation
         "rd"     'ensime-refactor-diff-inline-local
         "rD"     'ensime-undo-peek
         "rf"     'ensime-format-source


### PR DESCRIPTION
Add function to insert types and add yank type at point

- `, i y` Add function to yank type at point but just yank type name without full
package

- `, r a` Add function to insert type annotation i.e.:

![Demo](https://cldup.com/5_KiKW66BU.gif)

Tested with the following examples:
```scala
  private val startTime = startDate.toDateTimeAtStartOfDay.getMillis
  private val endTime = endDate.toDateTimeAtStartOfDay.getMillis

  for {
    a <- List(1, 2)
    b <- Map(1 -> 1)
    (c, d) <- Map("" -> true)
  } yield 1

  def test = 1
  def test2() = 1
  def test3(x: Int) = 1
  def test4(x: Int = 3) = 1
  def test5(x: Int = 3, b: (Int, String) = (1, "")) = 1
  def test6(x: Int = 3, b: (Int, String) = (1, ""))(implicit z: (Int, Boolean)) = 1
  def sum[A](xs: List[A])(implicit m: List[A] ) = m
  def default1(dateStr: String = "a", b: (Int, Int))(implicit x: Int) = { List("") }

  def default(
    dateStr: String = "a", b: (Int, Int)
  )(implicit x: Int) = AuthenticatedAction { request =>
```

This function is being added to upstream package as well, https://github.com/ensime/ensime-emacs/pull/390 when it's got merged I'll update spacemacs reference to new function
