### PR TITLE
Fixes #5389 - helm-imenu doesn't work in react-mode

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -55,6 +55,8 @@
   (spacemacs/js-doc-set-key-bindings 'react-mode))
 
 (defun react/post-init-js2-mode ()
+  (add-hook 'react-mode-hook (lambda ()
+                               (setq imenu-create-index-function #'js2-mode-create-imenu-index)))
   (add-hook 'react-mode-hook 'js2-imenu-extras-mode)
   (add-hook 'react-mode-hook 'js2-minor-mode))
 


### PR DESCRIPTION
#5389 

In react-mode, when invoke helm-imenu, the list is empty. Because this
feature is only enabled in js2-mode, not js2-minor-mode.

So we should enable it by ourself.

link: https://github.com/mooz/js2-mode/blob/master/js2-mode.el#L11557