### PR TITLE
change insert map only for vim editing style

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -412,9 +412,10 @@ below. Anything else exits."
             ad-do-it)))
 
       ;; Define history commands for comint
-      (evil-define-key 'insert comint-mode-map
-        (kbd "C-k") 'comint-previous-input
-        (kbd "C-j") 'comint-next-input)
+      (when (eq dotspacemacs-editing-style 'vim)
+        (evil-define-key 'insert comint-mode-map
+          (kbd "C-k") 'comint-previous-input
+          (kbd "C-j") 'comint-next-input))
       (evil-define-key 'normal comint-mode-map
         (kbd "C-k") 'comint-previous-input
         (kbd "C-j") 'comint-next-input))))

--- a/layers/shell/packages.el
+++ b/layers/shell/packages.el
@@ -350,9 +350,10 @@ is achieved by adding the relevant text properties."
   (evil-define-key 'insert term-raw-map (kbd "C-c C-z") 'term-stop-subjob)
   (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab)
 
-  (evil-define-key 'insert term-raw-map
-    (kbd "C-k") 'term-send-up
-    (kbd "C-j") 'term-send-down)
+  (when (eq dotspacemacs-editing-style 'vim)
+    (evil-define-key 'insert term-raw-map
+      (kbd "C-k") 'term-send-up
+      (kbd "C-j") 'term-send-down))
   (evil-define-key 'normal term-raw-map
     (kbd "C-k") 'term-send-up
     (kbd "C-j") 'term-send-down)


### PR DESCRIPTION
For now, prevent cluttering hybrid insert state map until there's cleaner solution.