### PR TITLE
Use evil-define-minor-mode-key over define-key

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -172,24 +172,15 @@
   :status visual-line-mode
   :on (progn
         (visual-line-mode)
-        (define-key evil-motion-state-map "j" 'evil-next-visual-line)
-        (define-key evil-motion-state-map "k" 'evil-previous-visual-line)
+        (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
+        (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
         (when (bound-and-true-p evil-escape-mode)
           (evil-escape-mode -1)
           (setq evil-escape-motion-state-shadowed-func nil)
-          (define-key evil-motion-state-map "j" 'evil-next-visual-line)
-          (define-key evil-motion-state-map "k" 'evil-previous-visual-line)
+          (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
+          (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
           (evil-escape-mode)))
-  :off (progn
-         (visual-line-mode -1)
-         (define-key evil-motion-state-map "j" 'evil-next-line)
-         (define-key evil-motion-state-map "k" 'evil-previous-line)
-         (when (bound-and-true-p evil-escape-mode)
-           (evil-escape-mode -1)
-           (setq evil-escape-motion-state-shadowed-func nil)
-           (define-key evil-motion-state-map "j" 'evil-next-line)
-           (define-key evil-motion-state-map "k" 'evil-previous-line)
-           (evil-escape-mode)))
+  :off (visual-line-mode -1)
   :documentation "Move point according to visual lines."
   :evil-leader "tL")
 (spacemacs|add-toggle line-numbers


### PR DESCRIPTION
Use evil-define-minor-mode-key over define-key

This keeps the keybinding specific to the visual-line minor mode, and
fixes #5418. Reverting the bindings on the :off toggle is no longer
necessary as well, turning off visual-line-mode will handle it.