### PR TITLE
source-control: git-timemachine goto nth revision

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -68,7 +68,7 @@
       (spacemacs|define-transient-state time-machine
         :title "Git Timemachine Transient State"
         :doc "
-[_p_/_N_] previous [_n_] next [_c_] current [_Y_] copy hash [_q_] quit"
+[_p_/_N_] previous [_n_] next [_c_] current [_g_] goto nth rev [_Y_] copy hash [_q_] quit"
         :on-enter (let (golden-ratio-mode)
                     (unless (bound-and-true-p git-timemachine-mode)
                       (call-interactively 'git-timemachine)))
@@ -77,6 +77,7 @@
         :foreign-keys run
         :bindings
         ("c" git-timemachine-show-current-revision)
+        ("g" git-timemachine-show-nth-revision)
         ("p" git-timemachine-show-previous-revision)
         ("n" git-timemachine-show-next-revision)
         ("N" git-timemachine-show-previous-revision)


### PR DESCRIPTION
Allows you to goto arbitrary revision by inputting rev number. 
e.g. To goto 1st revision of the file, enter 1.