### PR TITLE
Fix problems with multi-account setup in mu4e

### DIFF
--- a/layers/+email/mu4e/funcs.el
+++ b/layers/+email/mu4e/funcs.el
@@ -9,39 +9,38 @@
 ;;
 ;;; License: GPLv3
 
-(defun mu4e//search-account-by-mail-address (mailto)
-  "Return the account given an email address in MAILTO."
-  (car (rassoc-if (lambda (x)
-                    (equal (cadr (assoc 'user-mail-address x)) (car mailto)))
-                  mu4e-account-alist)))
 
 (defun mu4e/set-account ()
   "Set the account for composing a message.
-This function tries to guess the correct account from the email address first
-then fallback to the maildir."
-  (let* ((account
-          (if mu4e-compose-parent-message
-              (let* ((mailtos
-                      (mu4e-message-field mu4e-compose-parent-message :to))
-                     (mailto-account
-                      (car (cl-remove-if-not
-                            'identity
-                            (mapcar 'mu4e//search-account-by-mail-address
-                                    mailtos))))
-                     (maildir
-                      (mu4e-message-field mu4e-compose-parent-message :maildir))
-                     (maildir-account
-                      (progn
-                        (string-match "/\\(.*?\\)/" maildir)
-                        (match-string 1 maildir))))
-                (or mailto-account maildir-account))
-            (funcall mu4e-completing-read-function
-                     "Compose with account:"
-                     (mapcar (lambda (var) (car var)) mu4e-account-alist))))
+This function tries to guess the correct account from the email address from the to and cc fields, or the maildir. If no unambiguous guess can be done, prompts the user."
+  (let* ((emails (when mu4e-compose-parent-message
+                   (mapcar (lambda (x) (downcase (cdr x)))
+                           (append
+                            (mu4e-message-field mu4e-compose-parent-message :to)
+                            (mu4e-message-field mu4e-compose-parent-message :cc)
+                            (mu4e-message-field mu4e-compose-parent-message :from)
+                            ))))
+         (maildir (when mu4e-compose-parent-message
+                    (mu4e-message-field mu4e-compose-parent-message :maildir)))
+         (account-candidates
+          (cond
+           (emails (delq nil (mapcar
+                              (lambda (x) (when (member (downcase (cadr (assoc 'user-mail-address x))) emails)
+                                            (car x)))
+                              mu4e-account-alist)))
+           (maildir (progn
+             (string-match "/\\(.*?\\)/" maildir)
+             (list (match-string 1 maildir))))
+           (t (mapcar 'car mu4e-account-alist))))
+         (account
+          (if (equal (length account-candidates) 1)
+              (car account-candidates)
+            (completing-read "Compose with account:" account-candidates)))
          (account-vars (cdr (assoc account mu4e-account-alist))))
     (if account-vars
         (mu4e//map-set account-vars)
       (error "No email account found"))))
+
 
 (defun mu4e//map-set (vars)
   "Setq an alist VARS of variables and values."
@@ -51,3 +50,4 @@ then fallback to the maildir."
 (defun mu4e/mail-account-reset ()
   "Reset mail account info to first."
   (mu4e//map-set (cdar mu4e-account-alist)))
+


### PR DESCRIPTION
Currently, account guessing for mu4e with multiple accounts has several problems:

- Detection of email in `To` fields is broken.
- It misses `CC` field or `From` field (replying to oneself)
- if we are replying and no guess can be made, it fails.

This commit rewrites the guessing function in a more robust maner, so that all the points above are addressed, and if no guess can be made, it just prompts the user asking for an account.