### PR TITLE
remove dotspacemacs-use-ido from template

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -160,8 +160,6 @@ values."
    dotspacemacs-auto-save-file-location 'cache
    ;; Maximum number of rollback slots to keep in the cache. (default 5)
    dotspacemacs-max-rollback-slots 5
-   ;; If non nil then `ido' replaces `helm' for some commands.
-   dotspacemacs-use-ido nil
    ;; If non nil, `helm' will try to minimize the space it uses. (default nil)
    dotspacemacs-helm-resize nil
    ;; if non nil, the helm header is hidden when there is only one source.


### PR DESCRIPTION
This looks like it was forgotten in https://github.com/syl20bnr/spacemacs/commit/d52eb414bb5f25321fd136f4ae0d38af328a9863#diff-f81ff68d78d5c3218a2448dbbe9b57f0R180