### PR TITLE
Adds the evil-remap package to spacemacs layers

### DIFF
--- a/layers/+vim/evil-remap/README.org
+++ b/layers/+vim/evil-remap/README.org
@@ -1,0 +1,47 @@
+#+TITLE: evil-remap layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../css/readtheorg.css" />
+
+* Table of Contents                                        :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Install][Install]]
+ - [[Functions][Functions]]
+ - [[Keybindings][Keybindings]]
+
+* Description
+This layer allows you to use vim-like commands to set new keybindings.
+
+For example, to map semicolon to open the ex modeline:
+
+Without this layer:
+#+begin_src emacs-lisp
+(define-key evil-normal-state-map (kbd ";") 'evil-ex)
+#+end_src
+
+With this layer:
+#+begin_src emacs-lisp
+(evil-nnoremap ";" 'evil-ex)
+#+end_src
+
+* Install
+To use this layer, add it to your =~/.spacemacs=
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(evil-remap))
+#+end_src
+
+* Functions
+
+| Function       | Description                                                                      |
+|----------------+----------------------------------------------------------------------------------|
+| evil-noremap   | Maps a key to a function in the normal, visual, and operator pending states.     |
+| evil-nnoremap  | Maps a key to a function in the normal state.                                    |
+| evil-vnoremap  | Maps a key to a function in the visual state.                                    |
+| evil-xnoremap  | Maps a key to a function in ex-mode                                              |
+| evil-onoremap  | Maps a key to a function when there is an operator (such as `c`) pending         |
+| evil-inoremap  | Maps a key to a function in the insert mode.                                     |
+| evil-enoremap  | Maps a key to a function in the emacs state.                                     |
+| evil-mnoremap  | Maps a key to a function in the motion state.                                    |
+| evil-nnoremap! | Maps a key to a function in normal, visual, motion, and operator pending states. |
+
+* Keybindings
+This layer does not define any keybindings, since it is intended to help you define your own.

--- a/layers/+vim/evil-remap/packages.el
+++ b/layers/+vim/evil-remap/packages.el
@@ -1,0 +1,25 @@
+;;; packages.el --- evil-remap layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Caleb Meyer <kiaulen@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Code:
+
+;; The list of Lisp packages required by the evil-remap layer.
+(defconst evil-remap-packages
+  '(
+    (evil-remap :location (recipe
+                           :fetcher github
+                           :repo "GuiltyDolphin/evil-remap"))
+    ))
+
+(defun evil-remap/init-evil-remap ()
+    (use-package "evil-remap"))
+
+;;; packages.el ends here


### PR DESCRIPTION
# Rationale

Spacemacs is intended (at least in part) for vimmers who have
never used emacs, but may already be very comfortable in vim. Often one
of the first things you learn in vim is to put something like
`imap jj <Esc> " use jj for returning to normal mode`
in your .vimrc

Spacemacs already covers this case pretty well, but there are lots of
other changes you might want to make. Another common one:
`nnoremap ; : " set ; to summon ex-mode`

Unfortunately, today there are many ways to set a keybinding in emacs.
global-set-key, local-set-key, define-key, etc. Worse still, most of the
documentation online doesn't take evil into account. Also, keys aren't
defined simply, via a string. You have to use (kbd "blah") instead.I
personally ran into this problem when starting with spacemacs. I wanted
to map a key in normal mode, but global-set-key was getting overridden
by the already defined behavior of that key in normal mode (a more
specific binding).

Evil-remap allows vim-users to bind keys simply. The functions all
follow the same format as vim:
`<mapping_type> <key to map> <behavior to map it to>`
# Implementation

This layer is very simple, since it's my first foray into emacs lisp.
Based on the documentation for creating a layer, I took the package
definition from my additional-packages and changed the require call to
be a use-package call. I also added documentation based on the
documentation on the package itself. I tested it locally in my private
layers, then moved it to make this PR.
