### PR TITLE
Fix +lang/markdown documentation on promotion and movement keybindings

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -79,12 +79,10 @@ To generate a table of contents type on top of the buffer:
 |-------------+---------------------|
 | ~SPC m k~   | kill thing at point |
 
-** Completion, and Cycling
+** Completion
 
 | Key Binding | Description |
 |-------------+-------------|
-| ~SPC m =~   | promote     |
-| ~SPC m -~   | demote      |
 | ~SPC m ]~   | complete    |
 
 ** Following and Jumping
@@ -129,11 +127,7 @@ To generate a table of contents type on top of the buffer:
 
 | Key Binding | Description      |
 |-------------+------------------|
-| ~SPC m l h~ | promote          |
 | ~SPC m l i~ | insert list item |
-| ~SPC m l j~ | move down        |
-| ~SPC m l k~ | move up          |
-| ~SPC m l l~ | demote           |
 
 ** Movement
 


### PR DESCRIPTION
Update documentation by removing obsolete keybindings that
were deleted from +lang/markdown layer in 7b6678e.

In particular the ~SPC m =~, ~SPC m -~ and ~SPC m l [h/j/k/l]~
have been superseded by the **Movement** bindings.