### PR TITLE
add key binding for projectile-replace-regexp

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2823,6 +2823,7 @@ To search in a project see [[Searching in a project][project searching]].
 | ~SPC p p~   | switch project                                          |
 | ~SPC p r~   | open a recent file                                      |
 | ~SPC p R~   | replace a string                                        |
+| ~SPC p %~   | replace a regexp                                        |
 | ~SPC p s~   | see [[Searching in a project][search in project]]                                   |
 | ~SPC p t~   | open =NeoTree= in =projectile= root                     |
 | ~SPC p T~   | find test files                                         |

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -496,6 +496,7 @@
                projectile-recentf
                projectile-regenerate-tags
                projectile-replace
+               projectile-replace-regexp
                projectile-run-async-shell-command-in-root
                projectile-run-shell-command-in-root
                projectile-switch-project
@@ -534,7 +535,8 @@
         "po" 'projectile-multi-occur
         "pR" 'projectile-replace
         "pT" 'projectile-find-test-file
-        "py" 'projectile-find-tag))
+        "py" 'projectile-find-tag
+        "p%" 'projectile-replace-regexp))
     :config
     (progn
       (projectile-global-mode)


### PR DESCRIPTION
Following https://github.com/bbatsov/projectile/pull/977

Probably not the best key binding, but at least it's consistent with `query-replace[-regexp]` which uses `%`. Ideally I would like to have `SPC p r` bound to `projectile-replace` and `SPC p R` bound to `projectile-replace-regexp`. But I am not sure what binding to use for `projectile-recentf` then.

If you come up with better key bindings - just let me know.

N. B. This functionality is not released yet.