### PR TITLE
Fixes #4229 - allow emacs to be launched with -q option

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -776,8 +776,8 @@ already exist, and switch to it."
         ;; needed in case the buffer was deleted and we are recreating it
         (setq spacemacs-buffer--note-widgets nil)
         (spacemacs-buffer/insert-banner-and-buttons)
-        ;; non-nil if emacs is loaded
-        (if after-init-time
+        ;; non-nil if emacs-startup-hook was run
+        (if (bound-and-true-p spacemacs-initialized)
             (progn
               (when dotspacemacs-startup-lists
                 (spacemacs-buffer/insert-startupify-lists))

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -53,6 +53,9 @@
 
 (defvar spacemacs--default-mode-line mode-line-format
   "Backup of default mode line format.")
+(defvar spacemacs-initialized nil
+  "Whether or not spacemacs has finished initializing by completing
+the final step of executing code in `emacs-startup-hook'.")
 
 (defun spacemacs/init ()
   "Perform startup initialization."
@@ -206,7 +209,8 @@ defer call using `spacemacs-post-user-config-hook'."
         (format "\n[%s packages loaded in %.3fs]\n"
                 (configuration-layer/configured-packages-count)
                 elapsed)))
-     (spacemacs/check-for-new-version spacemacs-version-check-interval))))
+     (spacemacs/check-for-new-version spacemacs-version-check-interval)
+     (setq spacemacs-initialized t))))
 
 (defun spacemacs//describe-system-info-string ()
   "Gathers info about your Spacemacs setup and returns it as a string."


### PR DESCRIPTION
If emacs is launched with -q option and spacemacs files are loaded via
--eval option, then spacemacs fails due to depending 'after-init-time'
variable being set properly which is done only when emacs is launched
without -q. This patch is to remove this dependence so that spacemacs
launched with -q can still work. This is done by introducing
'spacemacs-initialized' variable which is set properly regardless of
which command line options are present or absent.