### PR TITLE
fix file extension matching for filenames with newlines

### DIFF
--- a/layers/+lang/asciidoc/packages.el
+++ b/layers/+lang/asciidoc/packages.el
@@ -16,7 +16,7 @@
   (use-package adoc-mode
     ;; We will NOT default `.txt' files to AsciiDoc mode,
     ;; and `.asciidoc' extension is just plain stupid.
-    :mode (("\\.adoc?$" . adoc-mode))
+    :mode (("\\.adoc?\\'" . adoc-mode))
 		:defer t
     :config
     (progn

--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -34,7 +34,7 @@
     :init
     (progn
       (add-hook 'nasm-mode-hook #'asm-generic-setup)
-      (add-to-list 'auto-mode-alist '("\\.[n]*\\(asm\\|s\\)$" . nasm-mode))
+      (add-to-list 'auto-mode-alist '("\\.[n]*\\(asm\\|s\\)\\'" . nasm-mode))
       (spacemacs/set-leader-keys-for-major-mode 'nasm-mode "h" 'x86-lookup))
     :config
     (progn

--- a/layers/+lang/autohotkey/packages.el
+++ b/layers/+lang/autohotkey/packages.el
@@ -15,7 +15,7 @@
 
 (defun autohotkey/init-ahk-mode ()
   (use-package ahk-mode
-    :mode "\\.ahk$"
+    :mode "\\.ahk\\'"
     :defer t
     :init
     (spacemacs/set-leader-keys-for-major-mode 'ahk-mode

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -33,7 +33,7 @@
   (use-package cc-mode
     :defer t
     :init
-    (add-to-list 'auto-mode-alist `("\\.h$" . ,c-c++-default-mode-for-headers))
+    (add-to-list 'auto-mode-alist `("\\.h\\'" . ,c-c++-default-mode-for-headers))
     :config
     (progn
       (require 'compile)

--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -16,7 +16,7 @@
 (defun plantuml/init-puml-mode ()
   (use-package puml-mode
     :defer t
-    :mode ("\\.pum$" . puml-mode)
+    :mode ("\\.pum\\'" . puml-mode)
 
     :config (spacemacs/set-leader-keys-for-major-mode 'puml-mode
               "cc" 'puml-preview

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -18,7 +18,7 @@
 (defun windows-scripts/init-dos ()
   (use-package dos
     :commands dos-mode
-    :mode ("\\.bat$" . dos-mode)
+    :mode ("\\.bat\\'" . dos-mode)
     :init
     (progn
       (defun windows-scripts/dos-outline-hook ()
@@ -45,7 +45,7 @@
 
 (defun windows-scripts/init-powershell ()
   (use-package powershell
-    :mode ("\\.ps1$" . powershell-mode)
+    :mode ("\\.ps1\\'" . powershell-mode)
     :defer t
     :init
     (progn

--- a/layers/+tools/pdf-tools/packages.el
+++ b/layers/+tools/pdf-tools/packages.el
@@ -15,7 +15,7 @@
 (defun pdf-tools/init-pdf-tools ()
   (use-package pdf-tools
     :defer t
-    :mode (("\\.pdf$" . pdf-view-mode))
+    :mode (("\\.pdf\\'" . pdf-view-mode))
     :config
     (progn
       (pdf-tools-install)

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -85,7 +85,7 @@
 
 (defun org/init-org ()
   (use-package org
-    :mode ("\\.org$" . org-mode)
+    :mode ("\\.org\\'" . org-mode)
     :commands (org-clock-out org-occur-in-agenda-files org-agenda-files)
     :defer t
     :init

--- a/layers/osx/packages.el
+++ b/layers/osx/packages.el
@@ -43,7 +43,7 @@
     :defer t
     :init
     (progn
-      (add-to-list 'auto-mode-alist '("\\.plist$" . nxml-mode))
+      (add-to-list 'auto-mode-alist '("\\.plist\\'" . nxml-mode))
       (spacemacs/set-leader-keys "al" 'launchctl))
     :config
     (progn


### PR DESCRIPTION
* "\\.ext$" matches both "abc.ext" and "abc.ext\nsomething".
* "\\.ext\\'" matches only "abc.ext".