### PR TITLE
Corrected key bindings for Swift major mode

### DIFF
--- a/layers/+lang/swift/packages.el
+++ b/layers/+lang/swift/packages.el
@@ -48,14 +48,14 @@ before activiting or switching to REPL."
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'swift-mode
-        "msS" 'swift-mode-run-repl      ; run or switch to an existing swift repl
-        "mss" 'swift-mode-run-repl
-        "msb" 'swift-mode-send-buffer
-        "msr" 'swift-mode-send-region)
+        "sS" 'swift-mode-run-repl      ; run or switch to an existing swift repl
+        "ss" 'swift-mode-run-repl
+        "sb" 'swift-mode-send-buffer
+        "sr" 'swift-mode-send-region)
 
       (with-eval-after-load 'swift-repl-mode-map
         ;; Switch back to editor from REPL
         (spacemacs/set-leader-keys-for-major-mode 'swift-repl-mode
-          "mss"  'spacemacs/swift-repl-mode-switch-back)
+          "ss"  'spacemacs/swift-repl-mode-switch-back)
         (define-key swift-repl-mode-map
           (kbd "C-c C-z") 'spacemacs/swift-repl-mode-switch-back)))))


### PR DESCRIPTION
Key bindings are not consistent with the documentation. Since the bindings are under major mode, they should not have the prefix 'm'.