### PR TITLE
spacemacs-ui-visual: enable vi-tilde-fringe only when graphic

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -16,7 +16,7 @@
         neotree
         smooth-scrolling
         spaceline
-        vi-tilde-fringe
+        (vi-tilde-fringe :toggle (display-graphic-p))
         (zoom-frm :location local)))
 
 (defun spacemacs-ui-visual/init-fancy-battery ()


### PR DESCRIPTION
Using emacs-nox, enabling `vi-tilde-fringe` produces following error on startup, hence exclude it on non-graphic display system.

```
vi-tilde-fringe-mode: Symbol's function definition is void: define-fringe-bitmap
Error in post-command-hook (global-vi-tilde-fringe-mode-check-buffers): (void-function define-fringe-bitmap)
```