### PR TITLE
Add TLS flag for ERC layer

### DIFF
--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -6,6 +6,7 @@
  - [[Features][Features]]
  - [[Install][Install]]
    - [[Layer][Layer]]
+   - [[Use =erc-tls= in ERC layout][Use =erc-tls= in ERC layout]]
    - [[OS X][OS X]]
    - [[Social graph][Social graph]]
  - [[Key bindings][Key bindings]]
@@ -36,6 +37,16 @@ Layer for [[http://www.emacswiki.org/emacs/ERC][ERC IRC chat]].
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =erc= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** Use =erc-tls= in ERC layout
+   To use =erc-tls= in the predefined custom layout rather than the default =erc=
+   set the variable =erc-enable-tls= to =t=:
+
+   #+BEGIN_SRC emacs-lisp
+     (setq-default dotspacemacs-configuration-layers
+                   '((erc :variables
+                          erc-enable-tls)))
+   #+END_SRC
 
 ** OS X
 It's recommended to install the [[https://github.com/alloy/terminal-notifier][terminal-notifier gem]] so that you get

--- a/layers/+irc/erc/config.el
+++ b/layers/+irc/erc/config.el
@@ -12,6 +12,9 @@
 (defvar erc-enable-sasl-auth nil
   "If non nil then use SASL authenthication with ERC.")
 
+(defvar erc-enable-tls nil
+  "If non nil then use ERC over TLS.")
+
 (defvar erc-spacemacs-layout-name "@ERC"
   "Name used in the setup for `spacemacs-layouts' micro-state")
 

--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -233,7 +233,9 @@
                           (persp-get-by-name
                            erc-spacemacs-layout-name)))
       (add-hook 'erc-mode-hook #'spacemacs-layouts/add-erc-buffer-to-persp)
-      (call-interactively 'erc))))
+      (if erc-enable-tls
+          (call-interactively 'erc-tls)
+        (call-interactively 'erc)))))
 
 (defun erc/post-init-smooth-scrolling ()
   (add-hook 'erc-mode-hook 'spacemacs//unset-scroll-margin))

--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -233,9 +233,10 @@
                           (persp-get-by-name
                            erc-spacemacs-layout-name)))
       (add-hook 'erc-mode-hook #'spacemacs-layouts/add-erc-buffer-to-persp)
-      (if erc-enable-tls
-          (call-interactively 'erc-tls)
-        (call-interactively 'erc)))))
+      (call-interactively
+       (if erc-enable-tls
+           'erc-tls
+         'erc)))))
 
 (defun erc/post-init-smooth-scrolling ()
   (add-hook 'erc-mode-hook 'spacemacs//unset-scroll-margin))


### PR DESCRIPTION
Just adding a layer variable to allow users to use `erc-tls` rather than `erc` in the custom layout. Happy to make any changes if there's a nicer way to do this.