### PR TITLE
Add server config to the ERC layer

### DIFF
--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -9,6 +9,7 @@
    - [[OS X][OS X]]
    - [[Social graph][Social graph]]
    - [[Default servers][Default servers]]
+     - [[Security Note][Security Note]]
  - [[Key bindings][Key bindings]]
  - [[Spacemacs Layout Support][Spacemacs Layout Support]]
 
@@ -52,20 +53,33 @@ notifications via the OS X Notification Center.
    #+BEGIN_SRC emacs-lisp
      (setq-default dotspacemacs-configuration-layers
                    '((erc :variables
-                          erc-server-list '(
-                                            (erc/server
-                                             :server "irc.freenode.net"
-                                             :port "6697"
-                                             :ssl t
-                                             :nick "some-user"
-                                             :password "secret")
-                                            (erc/server
-                                             :server "irc.myworkirc.net"
-                                             :port "1234"
-                                             :nick "some-suit"
-                                             :password "hunter2")))))
-
+                          erc-server-list
+                          '(("irc.freenode.net"
+                             :port "6697"
+                             :ssl t
+                             :nick "some-user"
+                             :password "secret")
+                            ("irc.myworkirc.net"
+                             :port "1234"
+                             :nick "some-suit"
+                             :password "hunter2")))))
    #+END_SRC
+
+*** Security Note
+    You should not store your passwords in the clear in your =.spacemacs=, and
+    that goes double if you version your config file. ERC allows for a number
+    of ways of protecting this information.
+
+    First, ERC will check your =~/.authinfo.gpg=, looking for lines like
+
+    #+BEGIN_SRC shell
+      machine <irc.server.url> login <yournick> password <yourpassword> port <portnumber>
+    #+END_SRC
+
+    You can leave password blank in this case.
+
+    You could also set an environment variable (or otherwise secret variable) and
+    read that in =:password=.
 
 * Key bindings
 

--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -8,6 +8,7 @@
    - [[Layer][Layer]]
    - [[OS X][OS X]]
    - [[Social graph][Social graph]]
+   - [[Default servers][Default servers]]
  - [[Key bindings][Key bindings]]
  - [[Spacemacs Layout Support][Spacemacs Layout Support]]
 
@@ -43,6 +44,28 @@ notifications via the OS X Notification Center.
 
 ** Social graph
  [[https://github.com/vibhavp/erc-social-graph][erc-social-graph]] needs graphviz to be installed on your system.
+
+** Default servers
+   You can define the default servers in the ERC custom layout by setting the variable =erc-server-list=.
+   Setting =:ssl= non nil will connect with =erc-tls=. You can also use =<leader>aiD=
+   to connect to your default servers outside the custom layout.
+   #+BEGIN_SRC emacs-lisp
+     (setq-default dotspacemacs-configuration-layers
+                   '((erc :variables
+                          erc-server-list '(
+                                            (erc/server
+                                             :server "irc.freenode.net"
+                                             :port "6697"
+                                             :ssl t
+                                             :nick "some-user"
+                                             :password "secret")
+                                            (erc/server
+                                             :server "irc.myworkirc.net"
+                                             :port "1234"
+                                             :nick "some-suit"
+                                             :password "hunter2")))))
+
+   #+END_SRC
 
 * Key bindings
 

--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -76,7 +76,7 @@ notifications via the OS X Notification Center.
       machine <irc.server.url> login <yournick> password <yourpassword> port <portnumber>
     #+END_SRC
 
-    You can leave password blank in this case.
+    You can omit =:password= in this case.
 
     You could also set an environment variable (or otherwise secret variable) and
     read that in =:password=.

--- a/layers/+irc/erc/README.org
+++ b/layers/+irc/erc/README.org
@@ -88,6 +88,7 @@ notifications via the OS X Notification Center.
 | ~SPC a i e~ | Starts ERC                                            |
 | ~SPC a i E~ | Starts ERC via TLS/SSL                                |
 | ~SPC a i i~ | Switch to next active ERC buffer                      |
+| ~SPC a i D~ | Start ERC with default servers                        |
 | ~SPC m b~   | Switch between ERC buffers                            |
 | ~SPC m d~   | Interactively input a user action and send it to IRC. |
 | ~SPC m D~   | Draw Social Graph using  [[https://github.com/vibhavp/erc-social-graph][erc-social-graph]]             |

--- a/layers/+irc/erc/config.el
+++ b/layers/+irc/erc/config.el
@@ -18,4 +18,7 @@
 (defvar erc-spacemacs-layout-binding "E"
   "Binding used in the setup for `spacemacs-layouts' micro-state")
 
+(defvar erc-server-list nil
+  "If non nil, connect automatically to the specified servers with the given credentials.")
+
 (spacemacs|defvar-company-backends erc-mode)

--- a/layers/+irc/erc/funcs.el
+++ b/layers/+irc/erc/funcs.el
@@ -1,19 +1,12 @@
-(defun erc//server (erc-func &rest args)
-  (funcall erc-func :server (plist-get args :server)
-           :nick (plist-get args :nick)
-           :port (plist-get args :port)
-           :password (plist-get args :password)))
-
-(defun erc/server (&rest args)
-  (apply #'erc//server
-         (if (plist-get args :ssl)
-             'erc-tls
-           'erc)
-         args))
-
 (defun erc//servers (server-list)
-  (dolist (a-server server-list)
-    (eval a-server)))
+  (dolist (s server-list)
+    (apply (if
+               (plist-get (cdr s) :ssl)
+               (progn
+                 (remf (cdr s) :ssl)
+                 'erc-tls)
+             'erc)
+           :server s)))
 
 (defun erc/default-servers ()
   (interactive)

--- a/layers/+irc/erc/funcs.el
+++ b/layers/+irc/erc/funcs.el
@@ -1,0 +1,22 @@
+(defun erc//server (erc-func &rest args)
+  (funcall erc-func :server (plist-get args :server)
+           :nick (plist-get args :nick)
+           :port (plist-get args :port)
+           :password (plist-get args :password)))
+
+(defun erc/server (&rest args)
+  (apply #'erc//server
+         (if (plist-get args :ssl)
+             'erc-tls
+           'erc)
+         args))
+
+(defun erc//servers (server-list)
+  (dolist (a-server server-list)
+    (eval a-server)))
+
+(defun erc/default-servers ()
+  (interactive)
+  (if erc-server-list
+      (erc//servers erc-server-list)
+    (message "You must define erc-server-list")))

--- a/layers/+irc/erc/packages.el
+++ b/layers/+irc/erc/packages.el
@@ -53,7 +53,8 @@
     (spacemacs/set-leader-keys
       "aie" 'erc
       "aiE" 'erc-tls
-      "aii" 'erc-track-switch-buffer)
+      "aii" 'erc-track-switch-buffer
+      "aiD" 'erc/default-servers)
     ;; utf-8 always and forever
     (setq erc-server-coding-system '(utf-8 . utf-8))
     ;; disable linum mode in erc
@@ -233,7 +234,9 @@
                           (persp-get-by-name
                            erc-spacemacs-layout-name)))
       (add-hook 'erc-mode-hook #'spacemacs-layouts/add-erc-buffer-to-persp)
-      (call-interactively 'erc))))
+      (if erc-server-list
+          (erc/default-servers)
+        (call-interactively 'erc)))))
 
 (defun erc/post-init-smooth-scrolling ()
   (add-hook 'erc-mode-hook 'spacemacs//unset-scroll-margin))


### PR DESCRIPTION
All right, so @TheBB has been talking about this for a bit (see #5272, for instance), so I took a crack at adding some support for default servers in the ERC layer. It's a tiny bit uglier than I might like, but it's markedly *less* ugly than manually typing in servers every time you connect.

This likely subsumes my last PR (#5503), though I could rework this to take it into account.