### PR TITLE
Add hoogle to list of packages for haskell layer

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -44,11 +44,12 @@ This layer requires some [[https://www.haskell.org/cabal/][cabal]] packages:
 - =hlint=
 - =stylish-haskell=
 - =hasktags=
+- =hoogle=
 
 To install them, use the following command: 
 
 #+BEGIN_SRC sh
-  cabal install stylish-haskell hlint hasktags
+  cabal install stylish-haskell hlint hasktags hoogle
 #+END_SRC
 
 Then you have to add this path to your system =$PATH= (preferred):


### PR DESCRIPTION
Closes #4320 

Adds hoogle to the list of packages for the haskell layer.