### PR TITLE
Rust: add key binding for `cargo fmt`

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -45,12 +45,13 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 
 * Key bindings
 
-| Key Binding | Description                       |
-|-------------+-----------------------------------|
-| ~SPC m c c~ | compile project with Cargo        |
-| ~SPC m c t~ | run tests with Cargo              |
-| ~SPC m c d~ | generate documentation with Cargo |
-| ~SPC m c x~ | execute the project with Cargo    |
-| ~SPC m c C~ | remove build artifacts with Cargo |
-| ~SPC m g g~ | jump to definition                |
-| ~SPC m =~   | reformat the buffer               |
+| Key Binding | Description                           |
+|-------------+---------------------------------------|
+| ~SPC m c c~ | compile project with Cargo            |
+| ~SPC m c t~ | run tests with Cargo                  |
+| ~SPC m c d~ | generate documentation with Cargo     |
+| ~SPC m c x~ | execute the project with Cargo        |
+| ~SPC m c C~ | remove build artifacts with Cargo     |
+| ~SPC m c f~ | format all project files with rustfmt |
+| ~SPC m g g~ | jump to definition                    |
+| ~SPC m =~   | reformat the buffer                   |

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -29,3 +29,7 @@
 (defun spacemacs/rust-cargo-clean ()
   (interactive)
   (compile "cargo clean"))
+
+(defun spacemacs/rust-cargo-fmt ()
+  (interactive)
+  (compile "cargo fmt"))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -41,7 +41,8 @@
         "ct" 'spacemacs/rust-cargo-test
         "cd" 'spacemacs/rust-cargo-doc
         "cx" 'spacemacs/rust-cargo-run
-        "cC" 'spacemacs/rust-cargo-clean))))
+        "cC" 'spacemacs/rust-cargo-clean
+        "cf" 'spacemacs/rust-cargo-fmt))))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode


### PR DESCRIPTION
Rustfmt is an optional component, but it's a popular one and will likely be officially supported once it leaves the nursery. It is used by rust-mode and is already mentioned in the Install section of the README for the Rust layer.