### PR TITLE
Fixed #5524 - Colorize spacemacs/counsel-search results

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -318,7 +318,10 @@ Helm hack."
       ;; Note: Must be set before which-key is loaded.
       (setq prefix-help-command 'counsel-descbinds)
       ;; TODO: Commands to port
-      (spacemacs//ivy-command-not-implemented-yet "jI"))))
+      (spacemacs//ivy-command-not-implemented-yet "jI")
+
+      ;; Set syntax highlighting for counsel search results
+      (ivy-set-display-transformer 'spacemacs/counsel-search 'counsel-git-grep-transformer))))
 
 (defun spacemacs-ivy/post-init-auto-highlight-symbol ()
   (setq spacemacs-symbol-highlight-transient-state-remove-bindings


### PR DESCRIPTION
Fixes #5524.
Use counsel-git-grep-transformer for search results.