### PR TITLE
Allow = to be used to increase transparency

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -542,6 +542,7 @@ otherwise it is scaled down."
   :title "Frame Transparency Transient State"
   :bindings
   ("+" spacemacs/increase-transparency "increase")
+  ("=" spacemacs/increase-transparency "increase")
   ("-" spacemacs/decrease-transparency "decrease")
   ("T" spacemacs/toggle-transparency "toggle")
   ("q" nil "quit" :exit t))


### PR DESCRIPTION
-,= is easy to go back and forth, without needing to press shift for +.