### PR TITLE
Fix inconsistent notation of SPC key in docs

### DIFF
--- a/core/templates/README.org.template
+++ b/core/templates/README.org.template
@@ -24,6 +24,6 @@ To use this contribution add it to your =~/.spacemacs=
 
 * Key bindings
 
-| Key Binding     | Description    |
-|-----------------+----------------|
-| ~<SPC> x x x~   | Does thing01   |
+| Key Binding | Description    |
+|-------------+----------------|
+| ~SPC x x x~ | Does thing01   |

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -33,7 +33,7 @@ own layer.
 The following command creates a layer in the =private= directory:
 
 #+BEGIN_EXAMPLE
-    <SPC> : configuration-layer/create-layer RET
+    SPC : configuration-layer/create-layer RET
 #+END_EXAMPLE
 
 Any configuration layers you create must be explicitly loaded in =~/.spacemacs=.
@@ -49,13 +49,13 @@ is also a means to customizing Spacemacs.
 The following command will create a =.spacemacs= file in your home directory:
 
 #+BEGIN_EXAMPLE
-    <SPC> : dotspacemacs/install RET
+    SPC : dotspacemacs/install RET
 #+END_EXAMPLE
 
 To open the installed dotfile:
 
 #+BEGIN_EXAMPLE
-    <SPC> f e d
+    SPC f e d
 #+END_EXAMPLE
 
 To load some configuration layers using the variable

--- a/layers/+config-files/systemd/README.org
+++ b/layers/+config-files/systemd/README.org
@@ -19,7 +19,7 @@ To use this contribution add it to your =~/.spacemacs=
 
 * Key bindings
 
-| Key Binding   | Description                                                              |
-|---------------+--------------------------------------------------------------------------|
-| ~<SPC> m h d~ | Systemd open the directives documentation                                |
-| ~<SPC> m h o~ | Systemd open documentation (if a =\=Documentation= directive is provided |
+| Key Binding | Description                                                              |
+|-------------+--------------------------------------------------------------------------|
+| ~SPC m h d~ | Systemd open the directives documentation                                |
+| ~SPC m h o~ | Systemd open documentation (if a =\=Documentation= directive is provided |

--- a/layers/colors/README.org
+++ b/layers/colors/README.org
@@ -76,7 +76,7 @@ The prefix associated with colors is ~C~.
 
 =rainbow-identifiers= mode can be toggled on and off with:
 
-    ~<SPC> t C i~
+    ~SPC t C i~
 
 Note that the toggle is local to the current buffer.
 
@@ -85,8 +85,8 @@ with the transient-state:
 
 | Key Binding     | Description                              |
 |-----------------+------------------------------------------|
-| ~<SPC> C i s~   | initiate change =saturation= mini-mode   |
-| ~<SPC> C i l~   | initiate change =lightness= mini-mode    |
+| ~SPC C i s~     | initiate change =saturation= mini-mode   |
+| ~SPC C i l~     | initiate change =lightness= mini-mode    |
 | ~+~             | increase the =saturation= or =lightness= |
 | ~-~             | decrease the =saturation= or =lightness= |
 | ~=~             | reset the =saturation= or =lightness=    |
@@ -98,11 +98,11 @@ with the transient-state:
 
 =rainbow-mode= mode can be toggled on and off with:
 
-    ~<SPC> t C c~
+    ~SPC t C c~
 
 ** Nyan Mode
 =nyan-mode= mode can be toggled on and off with:
 
-    ~<SPC> t m n~
+    ~SPC t m n~
 
 Note that the toggle is local to the current buffer.

--- a/layers/themes-megapack/README.org
+++ b/layers/themes-megapack/README.org
@@ -7,7 +7,7 @@
 
 * What is this?
 This simple contribution layer is an example. It installs around 100 themes
-for Emacs. You can try them easily by invoking helm-themes with: ~<SPC> T h~.
+for Emacs. You can try them easily by invoking helm-themes with: ~SPC T h~.
 
 You can see samples of all included themes in this [[http://themegallery.robdor.com][theme gallery]] from [[http://www.twitter.com/robmerrell][Rob Merrell]].
 


### PR DESCRIPTION
Replace all occurrences of `<SPC>` in org files with `SPC`.

Fixes syl20bnr/spacemacs#1823