### PR TITLE
Fixes #5546 - Set popwin config for Help buffer :noselect t

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -734,7 +734,7 @@ below. Anything else exits."
       (setq popwin:special-display-config nil)
 
       ;; buffers that we manage
-      (push '("*Help*"                 :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)
+      (push '("*Help*"                 :dedicated t :position bottom :stick t :noselect t :height 0.4) popwin:special-display-config)
       (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Shell Command Output*" :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*Async Shell Command*"  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)


### PR DESCRIPTION
Fixes issue #5546. Does not change behavior when calling help directly,
as with describe-function or describe-variable.