### PR TITLE
rainbow-identifiers improvements

### DIFF
--- a/layers/+themes/colors/config.el
+++ b/layers/+themes/colors/config.el
@@ -14,6 +14,9 @@
 (defvar colors-enable-rainbow-identifiers nil
   "If non nil the `rainbow-identifers' package is enabled.")
 
+(defvar colors-enable-rainbow-identifiers-aggressive-coloring nil
+  "If non nil `rainbow-identifers' package is configured to take over more theme faces.")
+
 (defvar colors-enable-nyan-cat-progress-bar nil
   "If non nil all nyan cat packges are enabled (for now only `nyan-mode').")
 

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -53,10 +53,20 @@
             rainbow-identifiers-cie-l*a*b*-saturation 100
             rainbow-identifiers-cie-l*a*b*-lightness 40
             ;; override theme faces
-            rainbow-identifiers-faces-to-override '(highlight-quoted-symbol
-                                                    font-lock-keyword-face
-                                                    font-lock-function-name-face
-                                                    font-lock-variable-name-face))
+            rainbow-identifiers-faces-to-override (if colors-enable-rainbow-identifiers-aggressive-coloring
+                                                      '(font-lock-builtin-face
+                                                        font-lock-constant-face
+                                                        font-lock-function-name-face
+                                                        font-lock-keyword-face
+                                                        font-lock-type-face
+                                                        font-lock-variable-name-face
+                                                        highlight-quoted-symbol
+                                                        js2-function-call
+                                                        js2-function-param)
+                                                    '(highlight-quoted-symbol
+                                                      font-lock-function-name-face
+                                                      font-lock-keyword-face
+                                                      font-lock-variable-name-face)))
       (spacemacs/declare-prefix "Ci" "colors-identifiers")
 
       (spacemacs|add-toggle rainbow-identifier-globally
@@ -71,13 +81,15 @@
       (defun colors//tweak-theme-colors (theme)
         "Tweak color themes by adjusting rainbow-identifiers."
         (interactive)
-        ;; tweak the saturation and lightness of identifier colors
-        (let ((sat&light (assq theme colors-theme-identifiers-sat&light)))
-          (if sat&light
-              (setq rainbow-identifiers-cie-l*a*b*-saturation (cadr sat&light)
-                    rainbow-identifiers-cie-l*a*b*-lightness (caddr sat&light))
-            (setq rainbow-identifiers-cie-l*a*b*-saturation 80
-                  rainbow-identifiers-cie-l*a*b*-lightness 45)))))
+        ;; tweak the saturation and lightness of identifier colors if the theme is not setting
+        (when (not (assq theme (get 'rainbow-identifiers-cie-l*a*b*-saturation 'theme-value)))
+          (let ((sat&light (assq theme colors-theme-identifiers-sat&light)))
+            (if sat&light
+                (setq rainbow-identifiers-cie-l*a*b*-saturation (cadr sat&light)
+                      rainbow-identifiers-cie-l*a*b*-lightness (caddr sat&light))
+              (setq rainbow-identifiers-cie-l*a*b*-saturation 80
+                    rainbow-identifiers-cie-l*a*b*-lightness 45))))))
+
     (colors//tweak-theme-colors spacemacs--cur-theme)
 
     (defadvice spacemacs/post-theme-init (after colors/post-theme-init activate)


### PR DESCRIPTION
New option to highlight more faces with rainbow-identifiers. Useful for e.g. types were different type names will be highlighted differently now.