### PR TITLE
Added quick keybinding for toggle-lisp-state

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -37,10 +37,10 @@ This layer adds support for [[http://clojure.org][Clojure]] language using [[htt
 
 * Features
 - REPL via [[https://github.com/clojure-emacs/cider][CIDER]]
-- Code formatting via [[https://github.com/clojure-emacs/cider][CIDER]] using [[https://github.com/weavejester/cljfmt][Cljfmt]] 
+- Code formatting via [[https://github.com/clojure-emacs/cider][CIDER]] using [[https://github.com/weavejester/cljfmt][Cljfmt]]
 - Refactoring via [[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]]
 - Aligning of code forms via [[https://github.com/clojure-emacs/clojure-mode][clojure-mode]]
-  
+
 * Install
 ** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -85,7 +85,7 @@ Or set this variable when loading the configuration layer:
 *** Quick Start with lein
 - Install =lein= via your OS package manager.
 - Create a file =~/.lein/profiles.clj= with the following content:
-  
+
 #+BEGIN_SRC clojure
   {:repl {:plugins [[cider/cider-nrepl "0.10.0-SNAPSHOT"]
                     [refactor-nrepl "2.0.0-SNAPSHOT"]]
@@ -101,7 +101,7 @@ Or set this variable when loading the configuration layer:
 More info regarding installation of nREPL middleware can be found here:
 - CIDER: [[https://github.com/clojure-emacs/cider#installation][cider_install]]
 - clj-refactor: [[https://github.com/clojure-emacs/refactor-nrepl][refactor-nrepl]]
-  
+
 * Key Bindings
 ** Working with clojure files (barfage, slurpage & more)
 Spacemacs comes with a special ~lisp-state~ for working with lisp code that
@@ -109,9 +109,15 @@ supports slurpage, barfage and more tools you'll likely want when working with
 lisp.
 
 As this state works the same for all files, the documentation is in global
-[[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
+[[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ or ~, ,~ to interact with the lisp-state.
 
 ** Leader
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m ,~     | toggle Lisp state |
+| ~, ,~         | toggle Lisp state |
+
 *** Documentation
 
 | Key Binding | Description    |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -200,6 +200,8 @@ If called with a prefix argument, uses the other-window instead."
 
       (dolist (m '(clojure-mode clojurec-mode clojurescript-mode clojurex-mode))
         (spacemacs/set-leader-keys-for-major-mode m
+          ","  'lisp-state-toggle-lisp-state
+
           "ha" 'cider-apropos
           "hh" 'cider-doc
           "hg" 'cider-grimoire

--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -47,6 +47,12 @@ As this state works the same for all files, the documentation is in global
 [[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
 
 ** Leader
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m ,~     | toggle Lisp state |
+| ~, ,~         | toggle Lisp state |
+
 *** Help
 
 | Key Binding | Description                                             |

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -48,6 +48,7 @@
       ;; TODO: Add bindings for the SLIME debugger?
       (spacemacs/set-leader-keys-for-major-mode 'lisp-mode
         "'" 'slime
+        ","  'lisp-state-toggle-lisp-state
 
         "cc" 'slime-compile-file
         "cC" 'slime-compile-and-load-file

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -42,12 +42,13 @@ supports slurpage, barfage and more tools you'll likely want when working with
 lisp.
 
 As this state works the same for all files, the documentation is in global
-[[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
+[[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ (or ~, ,~ while editing a lisp) to interact with the lisp-state.
 
 ** Leader
 
 | Key Binding                | Description                                                |
 |----------------------------+------------------------------------------------------------|
+| ~SPC m ​,​~                  | toggle =lisp state=                                        |
 | ~SPC m g g~                | go to definition of symbol under point                     |
 | ~SPC m h h~                | describe symbol at point                                   |
 | ~SPC m c c~                | byte compile the current file                              |
@@ -58,7 +59,6 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e e~                | evaluate sexp before point                                 |
 | ~SPC m e r~                | evaluate current region                                    |
 | ~SPC m e f~                | evaluation current function                                |
-| ~SPC m ​,​~                  | toggle =lisp state=                                        |
 | ~SPC m t b~                | run tests of current buffer                                |
 | ~SPC m t q~                | run =ert=                                                  |
 | ~SPC m d m~                | open [[https://github.com/joddie/macrostep][macrostep]] transient-state                        |

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -87,6 +87,7 @@
     (spacemacs/declare-prefix-for-mode mode "me" "eval")
     (spacemacs/declare-prefix-for-mode mode "mt" "tests")
     (spacemacs/set-leader-keys-for-major-mode mode
+      ","  'lisp-state-toggle-lisp-state
       "cc" 'emacs-lisp-byte-compile
       "e$" 'lisp-state-eval-sexp-end-of-line
       "eb" 'eval-buffer
@@ -94,7 +95,6 @@
       "er" 'eval-region
       "ef" 'eval-defun
       "el" 'lisp-state-eval-sexp-end-of-line
-      ","  'lisp-state-toggle-lisp-state
       "tb" 'spacemacs/ert-run-tests-buffer
       "tq" 'ert))
   ;; company support

--- a/layers/+lang/racket/README.org
+++ b/layers/+lang/racket/README.org
@@ -24,6 +24,11 @@ file.
 
 * Key Bindings
 
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m ,~     | toggle Lisp state |
+| ~, ,~         | toggle Lisp state |
+
 ** Navigation
 
 | Key Binding | Description                         |

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -77,6 +77,7 @@
         (spacemacs/declare-prefix-for-mode 'racket-mode (car prefix) (cdr prefix)))
 
       (spacemacs/set-leader-keys-for-major-mode 'racket-mode
+        ","  'lisp-state-toggle-lisp-state
         ;; navigation
         "g`" 'racket-unvisit
         "gg" 'racket-visit-definition

--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -5,7 +5,7 @@
  - [[Description][Description]]
  - [[Install][Install]]
  - [[Key Bindings][Key Bindings]]
-   - [[Compiling ][Compiling ]]
+   - [[Compiling][Compiling]]
    - [[Navigation][Navigation]]
    - [[Documentation][Documentation]]
    - [[Insertion][Insertion]]
@@ -35,7 +35,12 @@ For full Chicken support, the following commands should be run:
 
 * Key Bindings
 
-** Compiling 
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m ,~   | toggle Lisp state |
+| ~, ,~       | toggle Lisp state |
+
+** Compiling
 
 | Key Binding | Description                |
 |-------------+----------------------------|


### PR DESCRIPTION
As already implemented for some lisps, pressing ~, ,~ while editing lisp files switches to lisp-state.
The documentation for each of the layers mentions this capability now.