### PR TITLE
[core] long-lines' toggle now accepts prefix arguments.

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -274,12 +274,11 @@
     :commands (column-enforce-mode global-column-enforce-mode)
     :init
     (progn
-      ;; TODO Ideally find a way to define the minimum length for long lines
-      ;; We may add support for the universal prefix argument in toggles to
-      ;; be able to do this.
       (spacemacs|add-toggle highlight-long-lines
         :status column-enforce-mode
-        :on (column-enforce-mode)
+        :prefix columns
+        :on (column-enforce-n (or columns column-enforce-column))
+        :on-message (format "long-lines enabled for %s columns." (or columns column-enforce-column))
         :off (column-enforce-mode -1)
         :documentation "Highlight the characters past the 80th column."
         :evil-leader "t8")


### PR DESCRIPTION
This commit introduces two new options to add-toggle:

:prefix, a symbol that is bound to the raw prefix argument (as
in `(interactive "P") forms).

:on-message, an expression overriding the default 'on' toggle
message (useful to document a toggle's argument).

These new options are applied to long-lines' toggle, so we can choose
how many lines to toggle it on via a raw prefix argument.

This is a follow-up to [#5260](https://github.com/syl20bnr/spacemacs/pull/5260)