### PR TITLE
layouts: fix update-eyebrowse-for-perspective missing argument

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -511,10 +511,10 @@ STATE is a window-state object as returned by `window-state-get'."
       (eyebrowse-init frame)
       (spacemacs/save-eyebrowse-for-perspective frame))))
 
-(defun spacemacs/update-eyebrowse-for-perspective (_new-persp-name)
+(defun spacemacs/update-eyebrowse-for-perspective (_new-persp-name _window)
   "Update and save current frame's eyebrowse workspace to its perspective.
-Parameter _NEW-PERSP-NAME is ignored, and exists only for compatibility with
-`persp-before-switch-functions'."
+Parameters _NEW-PERSP-NAME and _WINDOW are ignored, and exist
+only for compatibility with `persp-before-switch-functions'."
   (let* ((current-slot (eyebrowse--get 'current-slot))
          (current-tag (nth 2 (assoc current-slot (eyebrowse--get 'window-configs)))))
     (eyebrowse--update-window-config-element


### PR DESCRIPTION
Functions in `persp-before-switch-functions` must take two arguments -- a name of a perspective to switch and a frame or a window for which the switching takes place.