### PR TITLE
Add an example hook to evil-cleverparens layer doc

### DIFF
--- a/layers/+vim/evil-cleverparens/README.org
+++ b/layers/+vim/evil-cleverparens/README.org
@@ -9,16 +9,16 @@
 
 This simple layer adds the [[https://github.com/luxbock/evil-cleverparens][evil-cleverparens]] package, which overrides common
 normal-mode vim commands like D, dd, c, etc. to keep parentheses balanced. See
-the repository for more details. All the layer does right now is to add a hook
-to load evil-cleverparens with emacs-lisp-mode.
+the repository for more details.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =evil-cleverparens= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-Then enable it in your =user-config= function:
+Then enable it in your =user-config= function and add your desired hooks, for example:
 
 #+BEGIN_SRC emacs-lisp
   (spacemacs/toggle-evil-cleverparens-on)
+  (add-hook 'clojure-mode-hook #'evil-cleverparens-mode)
 #+END_SRC


### PR DESCRIPTION
Add an example `clojure-mode-hook` and remove misstatement

The layer doesn't add a hook to load with `emacs-lisp-mode`. A hook is required in the dotfile.