### PR TITLE
cider-turn-on-eldoc-mode is deprecated

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -23,7 +23,7 @@
             cider-repl-use-clojure-font-lock t)
       (push "\\*cider-repl\.\+\\*" spacemacs-useful-buffers-regexp)
       (add-hook 'clojure-mode-hook 'cider-mode)
-      (add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
+      (add-hook 'cider-mode-hook 'eldoc-mode)
       (if dotspacemacs-smartparens-strict-mode
           (add-hook 'cider-repl-mode-hook #'smartparens-strict-mode)))
     :config


### PR DESCRIPTION
It's reported in minibuffer (presumably by cider-mode) that cider-turn-on-eldoc-mode is deprecated and we should use eldoc-mode instead. So a simple update to do so.