### PR TITLE
Correcting scala-enable-eldoc-mode to scala-enable-eldoc

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -86,11 +86,11 @@ To use scalastyle,
 See the [[http://flycheck.readthedocs.org/en/latest/guide/languages.html#el.flycheck-checker.scala-scalastyle][flycheck documentation]] for up-to-date configuration instructions.
 * Automatically show the type of the symbol under the cursor
 
-To enable the feature =ensime-print-type-at-point= when cursor moves, set the variable =scala-enable-eldoc-mode= to =t=.
+To enable the feature =ensime-print-type-at-point= when cursor moves, set the variable =scala-enable-eldoc= to =t=.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (scala :variables scala-enable-eldoc-mode t)))
+    (scala :variables scala-enable-eldoc t)))
 #+END_SRC
 
 Enabling this option can cause slow editor performance.


### PR DESCRIPTION
The documentation refers to scala-enable-eldoc-mode whereas the variable is scala-enable-eldoc.
This PR corrects that.