### PR TITLE
optionally enable ensime

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -13,6 +13,7 @@
  - [[Automatically show the type of the symbol under the cursor][Automatically show the type of the symbol under the cursor]]
  - [[Automatically insert asterisk in multiline comments][Automatically insert asterisk in multiline comments]]
  - [[Automatically replace arrows with unicode ones][Automatically replace arrows with unicode ones]]
+ - [[Disable auto-start][Disable auto-start]]
  - [[Key bindings][Key bindings]]
    - [[Ensime key bindings][Ensime key bindings]]
      - [[Search][Search]]
@@ -116,6 +117,15 @@ the ascii arrows back.
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (scala :variables scala-use-unicode-arrows t)))
+
+* Disable auto-start
+
+If you prefer not to have Ensime start when you load a scala file, you can
+disable it with
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(
+    (scala :variables scala-auto-start-ensime nil)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -17,3 +17,6 @@
 
 (defvar scala-use-unicode-arrows nil
   "If non-nil then `->`, `=>` and `<-` are replaced with unicode arrows.")
+
+(defvar scala-auto-start-ensime t
+  "If non nil then ensime will be started when a scala file is opened.")

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -27,7 +27,8 @@
         (add-hook 'ensime-mode-hook 'scala/enable-eldoc))
       (add-hook 'scala-mode-hook 'scala/configure-flyspell)
       (add-hook 'scala-mode-hook 'scala/configure-ensime)
-      (add-hook 'scala-mode-hook 'scala/maybe-start-ensime))
+      (when scala-auto-start-ensime
+        (add-hook 'scala-mode-hook 'scala/maybe-start-ensime)))
     :config
     (progn
       (setq user-emacs-ensime-directory ".cache/ensime")


### PR DESCRIPTION
I've introduced a new variable, scala-auto-start-ensime, that determines if ensime starts
when a scala file is loaded.

The variable defaults to t to reflect current behaviour.

Its also been documented.