### PR TITLE
Fixes #5742 - Add binding for opening tag in another window

### DIFF
--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -114,6 +114,7 @@ Since these modes have better Eldoc integration already.
 | ~SPC m g g~ | jump to a location based on context                       |
 | ~SPC m g G~ | jump to a location based on context (open another window) |
 | ~SPC m g d~ | find definitions                                          |
+| ~SPC m g D~ | find definitions (open another window)                    |
 | ~SPC m g i~ | present tags in current function only                     |
 | ~SPC m g l~ | jump to definitions in file                               |
 | ~SPC m g n~ | jump to next location in context stack                    |

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -26,6 +26,7 @@
     (spacemacs/set-leader-keys-for-major-mode mode
       "gc" 'helm-gtags-create-tags
       "gd" 'helm-gtags-find-tag
+      "gD" 'helm-gtags-find-tag-other-window
       "gf" 'helm-gtags-select-path
       "gg" 'helm-gtags-dwim
       "gG" 'helm-gtags-dwim-other-window


### PR DESCRIPTION
Adds a binding to the gtags layer which opens the found tag in another window similar to the already present gg and gG bindings.