### PR TITLE
Improve Leiningen installation instructions in Clojure layer

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -83,7 +83,7 @@ Or set this variable when loading the configuration layer:
 - Run ~SPC m s i~ in any of the clojure source files to connect to the CIDER REPL.
 
 *** Quick Start with lein
-- Install =lein= via your OS package manager.
+- Install =lein= version 2.5.2 or newer (see http://leiningen.org/#install)
 - Create a file =~/.lein/profiles.clj= with the following content:
   
 #+BEGIN_SRC clojure


### PR DESCRIPTION
The previous installation instructions suggested that you install lein via your OS package manager, but since the minimum required version to run the plugins is 2.5.2 and some OS package managers are still packaging versions in 1.x, linking to the official install instructions is better.

Fixes #5612