### PR TITLE
add an option to use google-c-style in c-c++ mode

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -12,6 +12,7 @@
    - [[#enable-clang-support][Enable Clang support]]
      - [[#clang-format][clang-format]]
      - [[#company-clang-and-flycheck][Company-clang and flycheck]]
+   - [[#enable-google-set-c-style][Enable google-set-c-style]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
@@ -93,6 +94,36 @@ other text editor clang plugins.
 Not only does this allow proper autocomplete on projects with extra
 includes and flags, but there is also support for flycheck so that it
 doesn't complain about missing header files.
+
+** Enable google-set-c-style
+If you have clang enabled with =clang-format= as described earlier in this page
+you may not have a lot of neeed for =google-set-c-style= if you are already
+using a mode based on Google mode for most of your projects.
+
+However, if you don't have (or want) =clang-format=, or if you have to do a lot
+[[https://www.emacswiki.org/emacs/TrampMode][Tramp]] remote editing on systems that don't have =clang-format= installed, you
+may want =google-c-style= enabled and added to your common hooks.
+
+To get =google-c-style= actually install itself into your C/C++ common hooks,
+you need to have =c-c++-enable-google-style= defined to true when you load the
+C-C++ lang in Spacemacs. In your =~/.spacemacs= file, a possible way that this
+would look is that in your list of =dostpacemacs-configuration-layers= you have
+an entry like
+
+#+BEGIN_SRC emacs-lisp
+     (c-c++ :variables
+            c-c++-enable-google-style t)
+#+END_SRC emacs-lisp
+
+Additionally, if you have =c-c++-enable-google-newline= variable set then
+=`google-make-newline-indent= will be set as a =c-mode-common-hook=. You would
+set that up like this:
+
+#+BEGIN_SRC emacs-lisp
+     (c-c++ :variables
+            c-c++-enable-google-style t
+            c-c++-enable-google-newline t)
+#+END_SRC emacs-lisp
 
 * Key Bindings
 

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -14,6 +14,14 @@
 (defvar c-c++-enable-clang-support nil
   "If non nil Clang related packages and configuration are enabled.")
 
+(defvar c-c++-enable-google-style nil
+  "If non-nil `google-set-c-style' will be added as as
+  `c-mode-common-hook'.")
+
+(defvar c-c++-enable-google-newline nil
+  "If non-nil `google-make-newline-indent' will be added as as
+  `c-mode-common-hook'.")
+
 (spacemacs|defvar-company-backends c-mode-common)
 (spacemacs|defvar-company-backends cmake-mode)
 

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -20,6 +20,7 @@
     company-ycmd
     flycheck
     gdb-mi
+    google-c-style
     helm-cscope
     helm-gtags
     semantic
@@ -102,10 +103,18 @@
      ;; Non-nil means display source file containing the main routine at startup
      gdb-show-main t)))
 
+
 (when (configuration-layer/layer-usedp 'spacemacs-helm)
   (defun c-c++/post-init-helm-gtags ()
     (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)
     (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode)))
+
+(defun c-c++/init-google-c-style ()
+  (use-package google-c-style
+    :if (or 'c-c++-enable-google-style 'c-c++-enable-google-newline)
+    :config (progn
+    (when 'c-c++-enable-google-style (add-hook 'c-mode-common-hook 'google-set-c-style))
+    (when 'c-c++-enable-google-newline (add-hook 'c-mode-common-hook 'google-set-c-style)))))
 
 (defun c-c++/post-init-semantic ()
   (spacemacs/add-to-hooks 'semantic-mode '(c-mode-hook c++-mode-hook)))


### PR DESCRIPTION
This adds an option (which is disabled by default) to add `google-set-c-style` to the `c-common-mode-hooks`.

Again, this is disabled by default: it's only turned on when a user sets `'use-google` to true when enabling `c-c++` mode.

I've also updated the documentation to describe the new feature and how to enable it.
