### PR TITLE
expand gtags use to many more languages

### DIFF
--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -13,6 +13,8 @@
       '(
         ;; package names go here
         asm-mode
+        ggtags
+        helm-gtags
         nasm-mode
         x86-lookup
         ))
@@ -56,3 +58,9 @@
 (defun asm/post-init-company ()
   (spacemacs|add-company-hook asm-mode)
   (spacemacs|add-company-hook nasm-mode))
+
+(defun asm/post-init-ggtags ()
+  (add-hook 'asm-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun asm/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -20,6 +20,7 @@
     company-ycmd
     flycheck
     gdb-mi
+    ggtags
     helm-cscope
     helm-gtags
     semantic
@@ -92,6 +93,10 @@
   (when c-c++-enable-clang-support
     (spacemacs/add-to-hooks 'c-c++/load-clang-args '(c-mode-hook c++-mode-hook))))
 
+(defun c-c++/post-init-ggtags ()
+  (add-hook 'c-mode-hook #'spacemacs/ggtags-mode-enable)
+  (add-hook 'c++-mode-hook #'spacemacs/ggtags-mode-enable))
+
 (defun c-c++/init-gdb-mi ()
   (use-package gdb-mi
     :defer t
@@ -102,10 +107,9 @@
      ;; Non-nil means display source file containing the main routine at startup
      gdb-show-main t)))
 
-(when (configuration-layer/layer-usedp 'spacemacs-helm)
-  (defun c-c++/post-init-helm-gtags ()
-    (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)
-    (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode)))
+(defun c-c++/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)
+  (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode))
 
 (defun c-c++/post-init-semantic ()
   (spacemacs/add-to-hooks 'semantic-mode '(c-mode-hook c++-mode-hook)))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -6,6 +6,8 @@
     clojure-mode
     (clojure-snippets :toggle (configuration-layer/layer-usedp 'auto-completion))
     company
+    ggtags
+    helm-gtags
     popwin
     subword
     ))
@@ -362,6 +364,12 @@ If called with a prefix argument, uses the other-window instead."
 
     (push 'company-capf company-backends-cider-repl-mode)
     (spacemacs|add-company-hook cider-repl-mode)))
+
+(defun clojure/post-init-ggtags ()
+  (add-hook 'clojure-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun clojure/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'clojure-mode))
 
 (defun clojure/init-clojure-snippets ()
   (use-package clojure-snippets

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -12,11 +12,19 @@
 (setq common-lisp-packages
       '(auto-highlight-symbol
         common-lisp-snippets
+        ggtags
+        helm-gtags
         slime))
 
 (defun common-lisp/post-init-auto-highlight-symbol ()
   (with-eval-after-load 'auto-highlight-symbol
     (add-to-list 'ahs-plugin-bod-modes 'lisp-mode)))
+
+(defun common-lisp/post-init-ggtags ()
+  (add-hook 'common-lisp-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun common-lisp/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'common-lisp-mode))
 
 (defun common-lisp/init-slime ()
   (use-package slime

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -12,6 +12,8 @@
 (setq csharp-packages
   '(
     company
+    ggtags
+    helm-gtags
     omnisharp
     ))
 
@@ -83,3 +85,9 @@
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun csharp/post-init-company ()
     (spacemacs|add-company-hook csharp-mode)))
+
+(defun csharp/post-init-ggtags ()
+  (add-hook 'csharp-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun csharp/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'csharp-mode))

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -17,6 +17,8 @@
         flycheck-dmd-dub
         flycheck
         company
+        ggtags
+        helm-gtags
         ))
 
 (defun d/init-d-mode ()
@@ -34,3 +36,9 @@
     ;; Need to convince company that this C-derived mode is a code mode.
     (with-eval-after-load 'company-dabbrev-code (push 'd-mode company-dabbrev-code-modes))
     (spacemacs|add-company-hook d-mode)))
+
+(defun d/post-init-ggtags ()
+  (add-hook 'd-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun d/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'd-mode))

--- a/layers/+lang/elixir/packages-config.el
+++ b/layers/+lang/elixir/packages-config.el
@@ -119,6 +119,12 @@
   (use-package elixir-mode
     :defer t))
 
+(defun elixir/post-init-ggtags ()
+  (add-hook 'elixir-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun elixir/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'elixir-mode))
+
 (defun elixir/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin
     :post-config

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -14,6 +14,8 @@
     alchemist
     company
     elixir-mode
+    ggtags
+    helm-gtags
     popwin
     smartparens
     ))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -18,6 +18,8 @@
         (emacs-lisp :location built-in)
         evil
         flycheck
+        ggtags
+        helm-gtags
         (ielm :location built-in)
         macrostep
         semantic
@@ -134,6 +136,12 @@
   ;; Make flycheck recognize packages in loadpath
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))
+
+(defun emacs-lisp/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'emacs-lisp-mode))
+
+(defun emacs-lisp/post-init-ggtags ()
+  (add-hook 'emacs-lisp-mode-hook #'spacemacs/ggtags-mode-enable))
 
 (defun emacs-lisp/post-init-semantic ()
   (add-hook 'emacs-lisp-mode-hook 'semantic-mode)

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -13,6 +13,8 @@
   '(
     company
     erlang
+    ggtags
+    helm-gtags
     flycheck
     ))
 
@@ -42,3 +44,9 @@
 
 (defun erlang/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'erlang-mode))
+
+(defun erlang/post-init-ggtags ()
+  (add-hook 'erlang-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun erlang/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'erlang-mode))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -9,7 +9,12 @@
 ;;
 ;;; License: GPLv3
 
-(setq fsharp-packages '(fsharp-mode))
+(setq fsharp-packages
+      '(
+        fsharp-mode
+        ggtags
+        helm-gtags
+        ))
 
 (defun fsharp/init-fsharp-mode ()
   (use-package fsharp-mode
@@ -66,3 +71,9 @@
         "ss" 'fsharp-show-subshell
 
         "xf" 'fsharp-run-executable-file))))
+
+(defun fsharp/post-init-ggtags ()
+  (add-hook 'fsharp-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun fsharp/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'fsharp-mode))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -3,6 +3,8 @@
         company
         company-go
         flycheck
+        ggtags
+        helm-gtags
         go-eldoc
         go-mode
         (go-oracle :location site)
@@ -134,3 +136,9 @@
   (use-package go-rename
     :init
     (spacemacs/set-leader-keys-for-major-mode 'go-mode "rn" 'go-rename)))
+
+(defun go/post-init-ggtags ()
+  (add-hook 'go-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun go/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'go-mode))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -17,9 +17,11 @@
     company-ghc
     flycheck
     flycheck-haskell
+    ggtags
     ghc
     haskell-mode
     haskell-snippets
+    helm-gtags
     helm-hoogle
     hindent
     shm
@@ -48,6 +50,9 @@
       :if (configuration-layer/package-usedp 'flycheck)
       :commands flycheck-haskell-configure
       :init (add-hook 'flycheck-mode-hook 'flycheck-haskell-configure))))
+
+(defun haskell/post-init-ggtags ()
+  (add-hook 'haskell-mode-hook #'spacemacs/ggtags-mode-enable))
 
 (defun haskell/init-ghc ()
   (use-package ghc
@@ -263,6 +268,9 @@
       (yas-load-directory snip-dir)))
 
   (with-eval-after-load 'yasnippet (haskell-snippets-initialize)))
+
+(defun haskell/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'haskell-mode))
 
 ;; doesn't support literate-haskell-mode :(
 (defun haskell/init-hindent ()

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -13,6 +13,8 @@
       '(
         company
         emacs-eclim
+        ggtags
+        helm-gtags
         (java-mode :location built-in)
         ))
 
@@ -132,6 +134,12 @@
     :defer t
     :init
     (push 'company-emacs-eclim company-backends-java-mode)))
+
+(defun java/post-init-ggtags ()
+  (add-hook 'java-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun java/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'java-mode))
 
 (defun java/init-java-mode ()
   (setq java/key-binding-prefixes '(("me" . "errors")

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -16,6 +16,8 @@
     company-tern
     evil-matchit
     flycheck
+    ggtags
+    helm-gtags
     js-doc
     js2-mode
     js2-refactor
@@ -59,6 +61,12 @@
 (defun javascript/post-init-flycheck ()
   (dolist (mode '(coffee-mode js2-mode json-mode))
     (spacemacs/add-flycheck-hook mode)))
+
+(defun javascript/post-init-ggtags ()
+  (add-hook 'js2-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun javascript/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'js2-mode))
 
 (defun javascript/init-js-doc ()
   (use-package js-doc

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -19,6 +19,8 @@
     (reftex :location built-in)
     flycheck
     flyspell
+    ggtags
+    helm-gtags
     smartparens
     typo
     yasnippet
@@ -171,6 +173,12 @@
 
 (defun latex/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'LaTeX-mode-hook))
+
+(defun latex/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'latex-mode))
+
+(defun latex/post-init-ggtags ()
+  (add-hook 'latex-mode-hook #'spacemacs/ggtags-mode-enable))
 
 (defun latex/post-init-smartparens ()
   (add-hook 'LaTeX-mode-hook 'smartparens-mode))

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -2,6 +2,8 @@
   '(
     company
     flycheck
+    ggtags
+    helm-gtags
     lua-mode
     ))
 
@@ -25,3 +27,9 @@
 
 (defun lua/post-init-company ()
   (add-hook 'lua-mode-hook 'company-mode))
+
+(defun lua/post-init-ggtags ()
+  (add-hook 'lua-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun lua/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'lua-mode))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -15,6 +15,8 @@
     company
    ;; flycheck
    ;; flycheck-ocaml
+    ggtags
+    helm-gtags
     merlin
     ocp-indent
     smartparens
@@ -37,6 +39,12 @@
         (with-eval-after-load 'merlin
           (setq merlin-error-after-save nil)
           (flycheck-ocaml-setup))))))
+
+(defun ocaml/post-init-ggtags ()
+  (add-hook 'ocaml-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun ocaml/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'ocaml-mode))
 
 (defun ocaml/init-merlin ()
   (use-package merlin

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -11,6 +11,8 @@
 
 (setq octave-packages
   '(
+    ggtags
+    helm-gtags
     (octave :location built-in)
     ))
 
@@ -30,3 +32,9 @@
               "si" 'run-octave
               "sl" 'octave-send-line
               "sr" 'octave-send-region)))
+
+(defun octave/post-init-ggtags ()
+  (add-hook 'octave-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun octave/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'octave-mode))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -33,19 +33,16 @@
     :defer t))
 
 (defun php/post-init-eldoc ()
-  (add-hook 'php-mode-hook 'eldoc-mode)
-  (when (configuration-layer/package-usedp 'ggtags)
-    (spacemacs/ggtags-enable-eldoc 'php-mode)))
+  (add-hook 'php-mode-hook 'eldoc-mode))
 
 (defun php/post-init-flycheck ()
   (add-hook 'php-mode-hook 'flycheck-mode))
 
 (defun php/post-init-ggtags ()
-  (add-hook 'php-mode-hook 'ggtags-mode))
+  (add-hook 'php-mode-hook #'spacemacs/ggtags-mode-enable))
 
-(when (configuration-layer/layer-usedp 'spacemacs-helm)
-  (defun php/post-init-helm-gtags ()
-    (spacemacs/helm-gtags-define-keys-for-mode 'php-mode)))
+(defun php/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'php-mode))
 
 (defun php/init-php-auto-yasnippets ()
   (use-package php-auto-yasnippets

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -18,7 +18,9 @@
     eldoc
     evil-matchit
     flycheck
+    ggtags
     helm-cscope
+    helm-gtags
     helm-pydoc
     hy-mode
     (nose :location local)
@@ -104,6 +106,12 @@
     (spacemacs|use-package-add-hook xcscope
       :post-init
       (spacemacs/setup-helm-cscope 'python-mode))))
+
+(defun python/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'python-mode))
+
+(defun python/post-init-ggtags ()
+  (add-hook 'python-mode-hook #'spacemacs/ggtags-mode-enable))
 
 (when (configuration-layer/layer-usedp 'spacemacs-helm)
   (defun python/init-helm-pydoc ()
@@ -416,3 +424,4 @@ fix this issue."
   (spacemacs|use-package-add-hook xcscope
     :post-init
     (spacemacs/set-leader-keys-for-major-mode 'python-mode "gi" 'cscope/run-pycscope)))
+

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -2,6 +2,8 @@
   '(
     company
     company-quickhelp
+    ggtags
+    helm-gtags
     racket-mode
     ))
 
@@ -19,6 +21,12 @@
                (when (and (equal major-mode 'racket-mode)
                           (bound-and-true-p company-quickhelp-mode))
                  (company-quickhelp-mode -1))) t))
+
+(defun racket/post-init-ggtags ()
+  (add-hook 'racket-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun racket/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'racket-mode))
 
 (defun racket/init-racket-mode ()
   (use-package racket-mode

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -17,6 +17,8 @@
         (enh-ruby-mode :toggle ruby-enable-enh-ruby-mode)
         evil-matchit
         flycheck
+        ggtags
+        helm-gtags
         popwin
         rbenv
         robe
@@ -80,6 +82,12 @@
 (defun ruby/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'ruby-mode)
   (spacemacs/add-flycheck-hook 'enh-ruby-mode))
+
+(defun ruby/post-init-ggtags ()
+  (add-hook 'ruby-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun ruby/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'ruby-mode))
 
 (defun ruby/post-init-popwin ()
   (push '("*rspec-compilation*" :dedicated t :position bottom :stick t :noselect t :height 0.4)

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -15,6 +15,8 @@
     racer
     flycheck
     flycheck-rust
+    ggtags
+    helm-gtags
     rust-mode
     toml-mode
     ))
@@ -28,6 +30,12 @@
       :if (configuration-layer/package-usedp 'flycheck)
       :defer t
       :init (add-hook 'flycheck-mode-hook #'flycheck-rust-setup))))
+
+(defun rust/post-init-ggtags ()
+  (add-hook 'rust-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun rust/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'rust-mode))
 
 (defun rust/init-rust-mode ()
   (use-package rust-mode

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -12,6 +12,8 @@
 (setq scala-packages
   '(
     ensime
+    ggtags
+    helm-gtags
     noflet
     sbt-mode
     scala-mode2
@@ -256,3 +258,9 @@ replace it with the unicode arrow."
       (setq scala-indent:align-forms t
             scala-indent:align-parameters t
             scala-indent:default-run-on-strategy scala-indent:operator-strategy))))
+
+(defun scala/post-init-ggtags ()
+  (add-hook 'scala-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun scala/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'scala-mode))

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -10,7 +10,11 @@
 ;;; License: GPLv3
 
 (setq scheme-packages
-      '(geiser))
+      '(
+        geiser
+        ggtags
+        helm-gtags
+        ))
 
 (defun scheme/init-geiser ()
   (use-package geiser
@@ -70,3 +74,9 @@
   (defun scheme/post-init-company ()
     ;; Geiser provides completion as long as company mode is loaded.
     (spacemacs|add-company-hook scheme-mode)))
+
+(defun scheme/post-init-ggtags ()
+  (add-hook 'scheme-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun scheme/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'scheme-mode))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -14,6 +14,8 @@
         company-shell
         fish-mode
         flycheck
+        ggtags
+        helm-gtags
         (sh-script :location built-in)))
 
 (defun shell-scripts/post-init-flycheck ()
@@ -61,3 +63,9 @@
       (progn
         (push 'company-shell                      company-backends-sh-mode)
         (push '(company-shell company-fish-shell) company-backends-fish-mode)))))
+
+(defun shell-scripts/post-init-ggtags ()
+  (add-hook 'sh-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun shell-scripts/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'sh-mode))

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -12,6 +12,8 @@
 (setq vimscript-packages
     '(
       vimrc-mode
+      ggtags
+      helm-gtags
       dactyl-mode
       ))
 
@@ -38,3 +40,9 @@
     :mode "\\.penta\\'"
     :mode "\\.vimp\\'"
     :defer t))
+
+(defun vimscript/post-init-ggtags ()
+  (add-hook 'vimrc-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun vimscript/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'vimrc-mode))

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -12,6 +12,8 @@
 (setq windows-scripts-packages
   '(
     (dos :location local)
+    ggtags
+    helm-gtags
     powershell
     ))
 
@@ -42,6 +44,12 @@
       "t"  'dos-template-mini
       "T"  'dos-template
       "z"  'windows-scripts/dos-outline)))
+
+(defun windows-scripts/post-init-ggtags ()
+  (add-hook 'dos-mode-hook #'spacemacs/ggtags-mode-enable))
+
+(defun windows-scripts/post-init-helm-gtags ()
+  (spacemacs/helm-gtags-define-keys-for-mode 'dos-mode))
 
 (defun windows-scripts/init-powershell ()
   (use-package powershell

--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -1,124 +1,252 @@
 #+TITLE: Helm Gtags layer
 
-* Table of Contents                                         :TOC_4_gh:noexport:
- - [[#description][Description]]
- - [[#features][Features]]
- - [[#install][Install]]
-   - [[#gnu-global][GNU Global]]
- - [[#usage][Usage]]
-   - [[#eldoc-integration][Eldoc integration]]
- - [[#key-bindings][Key bindings]]
+* Table of Contents                                         :TOC_4_org:noexport:
+ - [[Description][Description]]
+ - [[Features][Features]]
+ - [[Install][Install]]
+   - [[GNU Global (gtags)][GNU Global (gtags)]]
+     - [[Install on OSX using Homebrew][Install on OSX using Homebrew]]
+     - [[Install on *nix from source][Install on *nix from source]]
+       - [[Install recommended dependencies][Install recommended dependencies]]
+       - [[Install with recommended features][Install with recommended features]]
+       - [[Configure your environment to use pygments and ctags][Configure your environment to use pygments and ctags]]
+   - [[Emacs Configuration][Emacs Configuration]]
+ - [[Usage][Usage]]
+     - [[Language Support][Language Support]]
+       - [[Built-in languages][Built-in languages]]
+       - [[Exuberant ctags languages][Exuberant ctags languages]]
+       - [[Universal ctags languages][Universal ctags languages]]
+       - [[Pygments languages (plus symbol and reference tags)][Pygments languages (plus symbol and reference tags)]]
+   - [[Eldoc integration][Eldoc integration]]
+ - [[Key bindings][Key bindings]]
 
 * Description
-=helm-gtags= and =ggtags= are clients for GNU Global. GNU Global is a source
-code tagging system that allows querying symbol locations in source code, such
-as definitions or references.
+
+  =helm-gtags= and =ggtags= are clients for GNU Global. GNU Global is a source
+  code tagging system that allows querying symbol locations in source code, such
+  as definitions or references. Adding the =gtags= layer enables both of these modes.
 
 * Features
 
-- Select any tag in a project retrieves by gtags
-- Resume previous helm-gtags session
-- Jump to a location based on context
-- Find definitions
-- Find references
-- Present tags in current function only
-- Create a tag database
-- Jump to definitions in file
-- Show stack of visited locations
-- Manually update tag database
-- Jump to next location in context stack
-- Jump to previous location in context stack
-- Jump to a file in tag database
+  - Select any tag in a project retrieves by gtags
+  - Resume previous helm-gtags session
+  - Jump to a location based on context
+  - Find definitions
+  - Find references
+  - Present tags in current function only
+  - Create a tag database
+  - Jump to definitions in file
+  - Show stack of visited locations
+  - Manually update tag database
+  - Jump to next location in context stack
+  - Jump to previous location in context stack
+  - Jump to a file in tag database
+  - Enables =eldoc= in modes that otherwise might not support it.
+  - Enables =company complete= in modes that otherwise might not support it.
 
 * Install
-** GNU Global
 
-You can install =helm-gtags= from the software repository of your OS. For example, in Ubuntu:
+** GNU Global (gtags)
 
-#+BEGIN_SRC sh
-  sudo apt-get install global
-#+END_SRC
+   To use =gtags=, you first have to install [[https://www.gnu.org/software/global/download.html][GNU Global]].
 
-To use =helm-gtags=, you first have to install [[https://www.gnu.org/software/global/download.html][GNU Global]].
+   You can install =global= from the software repository of your OS; however,
+   many OS distributions are out of date, and you will probably be missing
+   support for =pygments= and =exuberant ctags=, and thus support for many
+   languages. We recommend installing from source. If not for example to install
+   on Ubuntu:
 
-Download the latest tar.gz archive, then run these commands:
+   #+begin_src sh
+     sudo apt-get install global
+   #+end_src
 
-#+BEGIN_SRC sh
-  tar xvf global-6.4.tar.gz
-  cd global-6.4
-  ./configure
-  make
-  sudo make install
-#+END_SRC
+*** Install on OSX using Homebrew
 
-To be able to use =ctags= and other backends, you need to copy the sample
-=gtags.conf= either to =/etc/gtags.conf= or =$HOME/.globalrc=. For example:
+    #+begin_src sh options
+      brew install global --with-pygments --with-ctags
+    #+end_src
 
-#+begin_src sh
-  cp gtags.conf ~/.globalrc
-#+end_src
+*** Install on *nix from source
 
-To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add =gtags= to the existing =dotspacemacs-configuration-layers= list in this
-file.
+**** Install recommended dependencies
+
+    To take full advantage of global you should install 2 extra packages in
+    addition to global: pygments and ctags (exuberant). You can do this using
+    your normal OS package manager, e.g., on Ubuntu
+
+    #+BEGIN_SRC sh
+      sudo apt-get install exuberant-ctags python-pygments
+    #+END_SRC
+
+    or e.g., Archlinux:
+
+    #+BEGIN_SRC sh
+      sudo pacman -S ctags python-pygments
+    #+END_SRC
+
+**** Install with recommended features
+
+    Download the latest tar.gz archive, then run these commands:
+
+    #+BEGIN_SRC sh
+      tar xvf global-6.5.3.tar.gz
+      cd global-6.5.3
+      ./configure --with-exuberant-ctags=/usr/bin/ctags
+      make
+      sudo make install
+    #+END_SRC
+
+**** Configure your environment to use pygments and ctags
+
+    To be able to use =pygments= and =ctags=, you need to copy the sample
+    =gtags.conf= either to =/etc/gtags.conf= or =$HOME/.globalrc=. For example:
+
+    #+begin_src sh
+      cp gtags.conf ~/.globalrc
+    #+end_src
+
+    Additionally you should define GTAGSLABEL in your shell startup file e.g.
+    with sh/ksh:
+
+    #+begin_src sh
+      echo export GTAGSLABEL=pygments >> .profile
+    #+end_src
+
+** Emacs Configuration
+
+    To use this configuration layer, add it to your =~/.spacemacs=. You
+    will need to add =gtags= to the existing =dotspacemacs-configuration-layers=.
+
+    #+begin_src emacs-lisp
+      (setq dotspacemacs-configuration-layers
+            '( ;; ...
+              gtags
+               ;; ...
+              ))
+    #+end_src
 
 * Usage
 
-Before using the helm-gtags, remember to create a GTAGS database by the following methods:
+  Before using the =gtags=, remember to create a GTAGS database by the following
+  methods:
 
-- From within Emacs, runs the command =helm-gtags-create-tags=, which is bound
-  to ~SPC m g c~. If the language is not directly supported by GNU Global, you
-  can choose =ctags= or =pygment= as a backend to generate tag database.
+  - From within Emacs, runs the command =helm-gtags-create-tags=, which is bound
+    to ~SPC m g c~. If the language is not directly supported by GNU Global, you
+    can choose =ctags= or =pygments= as a backend to generate tag database.
 
-- From inside terminal, runs gtags at your project root in terminal:
+  - From inside terminal, runs gtags at your project root in terminal:
 
-#+BEGIN_SRC sh
-  cd /path/to/project/root
-  gtags
-#+END_SRC
+  #+BEGIN_SRC sh
+    cd /path/to/project/root
+    gtags
+  #+END_SRC
 
-If the language is not directly supported by =gtags= but =ctags=, use this command instead:
+  If the language is not directly supported by =gtags=, and you have not set the
+  GTAGSLABEL environment variable, use this command instead:
 
-#+BEGIN_SRC sh
-  gtags --gtagslabel=ctags
-#+END_SRC
+  #+BEGIN_SRC sh
+    gtags --gtagslabel=pygments
+  #+END_SRC
+
+*** Language Support
+
+**** Built-in languages
+
+     If you do not have =ctags= or =pygments= enabled gtags will only produce
+     tags for the following languages:
+
+     - asm
+     - c/c++
+     - java
+     - php
+     - yacc
+     -
+**** Exuberant ctags languages
+
+     If you have enabled =exuberant ctags= and use that as the backend (i.e.,
+     GTAGSLABEL=ctags or --gtagslabel=ctags) the following additional languages
+     will have tags created for them:
+
+     - c#
+     - erlang
+     - javascript
+     - common-lisp
+     - emacs-lisp
+     - lua
+     - ocaml
+     - python
+     - ruby
+     - scheme
+     - vimscript
+     - windows-scripts (.bat .cmd files)
+
+**** Universal ctags languages
+
+     If instead you installed you the newer/beta =universal ctags= and use that
+     as the backend (i.e., GTAGSLABEL=ctags or --gtagslabel=ctags) the following
+     additional languages will have tags created for them:
+
+     - clojure
+     - d
+     - go
+     - rust
+
+**** Pygments languages (plus symbol and reference tags)
+
+     In order to look up symbol references for any language not in the built in
+     parser you must use the pygments backend. When this backend is used global
+     actually uses both ctags and pygments to find the definitions and uses of
+     functions and variables as well as "other symbols".
+
+     If you enabled pygments (the best choice) and use that as the backend (i.e.,
+     GTAGSLABEL=pygments or --gtagslabel=pygments) the following additional
+     languages will have tags created for them:
+
+     - exlixir
+     - fsharp
+     - haskell
+     - octave
+     - racket
+     - scala
+     - shell-scripts
+     - tex
 
 ** Eldoc integration
 
-This layer also integrates =ggtags= for its Eldoc feature. That means, when
-writing code, you can look at the minibuffer (at the bottom) and see variable
-and function definition of the symbol the cursor is on. However, this feature is
-only activated for programming modes that are not one of these languages:
+   This layer also integrates =ggtags= for its Eldoc feature. That means, when
+   writing code, you can look at the minibuffer (at the bottom) and see variable
+   and function definition of the symbol the cursor is on. However, this feature is
+   only activated for programming modes that are not one of these languages:
 
-- C mode
-- C++ mode
-- Common Lisp
-- Emacs Lisp
-- Python
-- Ruby-mode
+   - C mode
+   - C++ mode
+   - Common Lisp
+   - Emacs Lisp
+   - Python
+   - Ruby-mode
 
-In addition, if output from =compile= (bound to ~SPC c C~), =shell-command=
-(bound to ~SPC !~ and ~M-!~) or =async-shell-command= (bound to ~M-&~) commands
-contains symbol in your project, you move cursor on such symbol and use any of
-the gtags commands.
+   Since these modes have better Eldoc integration already.
 
-Since these modes have better Eldoc integration already.
+   In addition, if output from =compile= (bound to ~SPC c C~), =shell-command=
+   (bound to ~SPC !~ and ~M-!~) or =async-shell-command= (bound to ~M-&~) commands
+   contains symbol in your project, you move cursor on such symbol and use any of
+   the gtags commands.
 
 * Key bindings
 
-| Key Binding | Description                                               |
-|-------------+-----------------------------------------------------------|
-| ~SPC m g c~ | create a tag database                                     |
-| ~SPC m g f~ | jump to a file in tag database                            |
-| ~SPC m g g~ | jump to a location based on context                       |
-| ~SPC m g G~ | jump to a location based on context (open another window) |
-| ~SPC m g d~ | find definitions                                          |
-| ~SPC m g i~ | present tags in current function only                     |
-| ~SPC m g l~ | jump to definitions in file                               |
-| ~SPC m g n~ | jump to next location in context stack                    |
-| ~SPC m g p~ | jump to previous location in context stack                |
-| ~SPC m g r~ | find references                                           |
-| ~SPC m g R~ | resume previous helm-gtags session                        |
-| ~SPC m g s~ | select any tag in a project retrieved by gtags            |
-| ~SPC m g S~ | show stack of visited locations                           |
-| ~SPC m g u~ | manually update tag database                              |
+  | Key Binding | Description                                               |
+  |-------------+-----------------------------------------------------------|
+  | ~SPC m g c~ | create a tag database                                     |
+  | ~SPC m g f~ | jump to a file in tag database                            |
+  | ~SPC m g g~ | jump to a location based on context                       |
+  | ~SPC m g G~ | jump to a location based on context (open another window) |
+  | ~SPC m g d~ | find definitions                                          |
+  | ~SPC m g i~ | present tags in current function only                     |
+  | ~SPC m g l~ | jump to definitions in file                               |
+  | ~SPC m g n~ | jump to next location in context stack                    |
+  | ~SPC m g p~ | jump to previous location in context stack                |
+  | ~SPC m g r~ | find references                                           |
+  | ~SPC m g R~ | resume previous helm-gtags session                        |
+  | ~SPC m g s~ | select any tag in a project retrieved by gtags            |
+  | ~SPC m g S~ | show stack of visited locations                           |
+  | ~SPC m g u~ | manually update tag database                              |

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -39,10 +39,10 @@
       "gS" 'helm-gtags-show-stack
       "gu" 'helm-gtags-update-tags)))
 
-(defun spacemacs/ggtags-enable-eldoc (mode)
-  (add-hook (intern (concat (symbol-name mode) "-hook"))
-            (lambda ()
-              (ggtags-mode 1)
-              (eldoc-mode 1)
-              (setq-local eldoc-documentation-function
-                          #'ggtags-eldoc-function))))
+(defun spacemacs/ggtags-mode-enable ()
+  "Enable ggtags and eldoc mode.
+
+For eldoc, ggtags advises the eldoc function at the lowest priority
+so that if the major mode has better support it will use it first."
+  (ggtags-mode 1)
+  (eldoc-mode 1))

--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -3,6 +3,7 @@
 ;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;;    and: Christian E. Hopps <chopps@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -11,13 +12,21 @@
 
 (setq gtags-packages
   '(
+    eldoc
     helm-gtags
     ggtags
     ))
 
 (defun gtags/init-ggtags ()
   (use-package ggtags
-    :defer t))
+    :defer t
+    :init
+    (progn
+      ;; modes that do not have a layer, add here.
+      (add-hook 'awk-mode-hook #'spacemacs/ggtags-mode-enable)
+      (add-hook 'shell-mode-hook #'spacemacs/ggtags-mode-enable)
+      (add-hook 'tcl-mode-hook #'spacemacs/ggtags-mode-enable)
+      (add-hook 'vhdl-mode-hook #'spacemacs/ggtags-mode-enable))))
 
 (when (configuration-layer/layer-usedp 'spacemacs-helm)
   (defun gtags/init-helm-gtags ()
@@ -31,18 +40,11 @@
               helm-gtags-pulse-at-cursor t)
         ;; modes that do not have a layer, define here
         (spacemacs/helm-gtags-define-keys-for-mode 'tcl-mode)
-        (spacemacs/helm-gtags-define-keys-for-mode 'java-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'vhdl-mode)
-        (spacemacs/helm-gtags-define-keys-for-mode 'shell-script-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'awk-mode)
-        (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'compilation-mode)
-        (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode)
-
-        (spacemacs/ggtags-enable-eldoc 'tcl-mode)
-        (spacemacs/ggtags-enable-eldoc 'java-mode)
-        (spacemacs/ggtags-enable-eldoc 'vhdl-mode))
+        (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode))
       :config
       (progn
         ;; if anyone uses helm-gtags, they would want to use these key bindings


### PR DESCRIPTION
- Add gtags support to many languages.
- Add documentation on using exuberant ctags and python pygments to enable this support in global.
- Cleanup and standardize how ggtags and helm-gtags is enabled. There is no need to check for the layer enabled as `post-init-*` won't be run unless that package has been enabled.

This is a first round of changes. It's also worth looking into enabling eldoc and company in as many modes as possible who might otherwise not support those features.