### PR TITLE
Fixes #5593 - Add ansi-term information to FAQ

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -20,6 +20,7 @@
    - [[Why do I get =(wrong-type-argument arrayp nil)= errors on startup?][Why do I get =(wrong-type-argument arrayp nil)= errors on startup?]]
    - [[Typing quickly =fd= takes me out of =insert state=. What is going on?][Typing quickly =fd= takes me out of =insert state=. What is going on?]]
    - [[Why do I get files starting with .#?][Why do I get files starting with .#?]]
+   - [[Why do I get '4m' characters inside ansi-term?][Why do I get '4m' characters inside ansi-term?]]
  - [[How do I...][How do I...]]
    - [[Install a package not provided by a layer?][Install a package not provided by a layer?]]
    - [[Disable a package completely?][Disable a package completely?]]
@@ -182,6 +183,12 @@ disable this behaviour:
 
 #+BEGIN_SRC emacs-lisp
 (setq create-lockfiles nil)
+#+END_SRC
+
+** Why do I get '4m' characters inside ansi-term?
+Ansi-term only has a subset of capabilities supported by xterm256. Your shell (e.g. fish shell) might ignore =$TERMINFO= information and require you to set the =~/.terminfo= yourself.
+#+BEGIN_SRC fish
+tic -o ~/.terminfo $TERMINFO/e/eterm-color.ti
 #+END_SRC
 
 * How do I...


### PR DESCRIPTION
As discussed in #5593 shells (e.g. fish shell) can have some difficulties to find out the ansi-term configuration. This PR adds an entry in the FAQ that give a pointer on how to solve this situation.