### PR TITLE
Store mc-lists.el in .cache

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -90,7 +90,9 @@
 
 (defun spacemacs-evil/init-evil-mc ()
   (use-package evil-mc
-    :defer t))
+    :defer t
+    :init
+    (setq mc/list-file (concat spacemacs-cache-directory "mc-lists.el"))))
 
 ;; other commenting functions in funcs.el with keybinds in keybindings.el
 (defun spacemacs-evil/init-evil-nerd-commenter ()


### PR DESCRIPTION
This file is created by multiple-cursors and saves user preferences.

Not moving this file prevents updating spacemacs due to a dirty work
tree.

This change moves the file to .cache so updates to spacemacs work
without having to do anything.

See https://github.com/magnars/multiple-cursors.el#unknown-commands for
more information