### PR TITLE
Fixes #5629 - Do not delete window when there is only one

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -311,7 +311,8 @@ is achieved by adding the relevant text properties."
                                   (when (string-match "\\(finished\\|exited\\)"
                                                       change)
                                     (kill-buffer (process-buffer proc))
-                                    (delete-window))))))
+                                    (when (> (count-windows) 1)
+                                      (delete-window)))))))
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
       (add-hook 'term-mode-hook (lambda () (linum-mode -1)))
 


### PR DESCRIPTION
If ansi-term is a full-screen window, running `(delete-window)` in this
case would cause an error to appear. This commit guards against this
scenario.

See https://github.com/syl20bnr/spacemacs/issues/5629