### PR TITLE
Tab width in Go mode

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -11,6 +11,7 @@
    - [[Layer][Layer]]
  - [[Configuration][Configuration]]
    - [[Formatting][Formatting]]
+   - [[Indentation][Indentation]]
  - [[Working with Go][Working with Go]]
    - [[Go commands (start with =m=):][Go commands (start with =m=):]]
    - [[Go Oracle][Go Oracle]]
@@ -59,6 +60,19 @@ or
 
 #+begin_src emacs-lisp
   (go :variables gofmt-command "goimports")
+#+end_src
+
+** Indentation
+By default, the width of tab in Go mode is 8 spaces. To use a different value for tab width, set the value of =go-tab-width=, e.g.
+
+#+begin_src emacs-lisp
+  (setq go-tab-width 4)
+#+end_src
+
+or
+
+#+begin_src emacs-lisp
+  (go :variables go-tab-width 4)
 #+end_src
 
 If you're using =gocheck= in your project you can use the

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -9,6 +9,11 @@
         (go-rename :location local)
         ))
 
+(defcustom go-tab-width 8
+  "`tab-width' in Go mode. Default is 8."
+  :type 'integer
+  :group 'go)
+
 (defun go/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'go-mode))
 
@@ -18,7 +23,9 @@
       (unless (getenv var)
         (exec-path-from-shell-copy-env var))))
 
-  (add-hook 'go-mode-hook (lambda () (setq-local tab-width 8)))
+  (add-hook 'go-mode-hook
+            (lambda ()
+              (setq-local tab-width go-tab-width)))
 
   (use-package go-mode
     :defer t


### PR DESCRIPTION
`tab-width` in Go mode is now configurable (default: 8). I posted my concerns regarding the existing code [here](https://github.com/syl20bnr/spacemacs/pull/3415#issuecomment-199704438). Let me know if there is a better way of doing this. Thanks!