### PR TITLE
enable c++11 mode in company-clang-arguments

### DIFF
--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -14,6 +14,9 @@
 (defvar c-c++-enable-clang-support nil
   "If non nil Clang related packages and configuration are enabled.")
 
+(defvar c-c++-enable-c++11 nil
+  "If non nil then c++11 related features will be enabled")
+
 (spacemacs|defvar-company-backends c-mode-common)
 (spacemacs|defvar-company-backends cmake-mode)
 

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -72,6 +72,9 @@
   (when c-c++-enable-clang-support
     (push 'company-clang company-backends-c-mode-common)
 
+    (when c-c++-enable-c++11
+      (setq company-clang-arguments '("-std=c++11")))
+
     (defun company-mode/more-than-prefix-guesser ()
       (c-c++/load-clang-args)
       (company-clang-guess-prefix))
@@ -90,7 +93,9 @@
   (dolist (mode '(c-mode c++-mode))
     (spacemacs/add-flycheck-hook mode))
   (when c-c++-enable-clang-support
-    (spacemacs/add-to-hooks 'c-c++/load-clang-args '(c-mode-hook c++-mode-hook))))
+    (spacemacs/add-to-hooks 'c-c++/load-clang-args '(c-mode-hook c++-mode-hook))
+    (when c-c++-enable-c++11
+      (setq flycheck-clang-language-standard "c++11"))))
 
 (defun c-c++/init-gdb-mi ()
   (use-package gdb-mi


### PR DESCRIPTION
This adds a new variable, `c-c++-enable-c++11` which follows the existing `c-c++` variable naming conventions.

When the value is not nil (it is nil by default) then `company-clang-arguments` are set up to use `-std=c++11`
