### PR TITLE
ask to install emacs on os x using emacs-plus tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ distributions as well.
 The recommended way of installing Emacs on OS X is using [homebrew][]:
 
 ```sh
-$ brew install emacs --with-cocoa --with-gnutls --with-rsvg --with-imagemagick
+$ brew tap d12frosted/emacs-plus
+$ brew install emacs-plus --with-cocoa --with-gnutls --with-librsvg --with-imagemagick --with-spacemacs-icon
 $ brew linkapps
 ```
 


### PR DESCRIPTION
So as discussed in #5161 and https://github.com/syl20bnr/spacemacs/commit/fa5e66c799e74325fbd513cdfa9348b53e023491#commitcomment-16933870, I've created `emacs-plus` [tap](https://github.com/d12frosted/homebrew-emacs-plus) which adds an option to install Emacs with Spacemacs icon.

The name of new formula is `emacs-plus` and not `emacs`. If we keep original name people have to refer to `emacs` from `emacs-plus` using `d12frosted/emacs-plus/emacs` instead of plain `emacs`. And also they would have to `reinstall` instead of `install` when they switch from `emacs` to `emacs-plus`. This has advantage of showing that there is nothing special about this version of `emacs`, but it adds complexity for end user, so I thought it's better to have distinct name :) If you don't agree - just let me know.

Another thing to consider. Currently the formula is just upstream version of `emacs.rb` with minor modification. It means that I have to check for any changes in original formula and reflect them in my formula. I couldn't find a good way to reuse original formula (like using `Emacs` class as parent), so this is how things are right now. Will keep looking for better solution.

I am going to add travis support to that tap a little bit later. If someone wants to do it faster - feel free to open PR. :) 

P. S. also fixed wrong option `--with-rsvg` -> `--with-librsvg`