### PR TITLE
Scala: fix ensime-typecheck-current-file to ensime-typecheck-current-buffer

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -107,7 +107,7 @@
         "bp"     'ensime-sbt-do-package
         "br"     'ensime-sbt-do-run
 
-        "ct"     'ensime-typecheck-current-file
+        "ct"     'ensime-typecheck-current-buffer
         "cT"     'ensime-typecheck-all
 
         "dA"     'ensime-db-attach


### PR DESCRIPTION
Now, ensime-emacs dose not have `ensime-typecheck-current-file` function. So, keybinding `SPC-m-c-t` should be binded to `ensime-typecheck-current-buffer`