### PR TITLE
tmux: replace deprecated post-extensions with packages

### DIFF
--- a/layers/+tools/tmux/packages.el
+++ b/layers/+tools/tmux/packages.el
@@ -1,4 +1,4 @@
-(setq tmux-post-extensions '((tmux :location local)))
+(setq tmux-packages '((tmux :location local)))
 
 (defun tmux/init-tmux ()
   "Initialize tmux"


### PR DESCRIPTION
I don't know what `tmux-post-extensions` is, but it never appears to init the package listed in it. Changing this to `tmux-packages` fixes the layer.