### PR TITLE
tmux: remove global unset of C-h

### DIFF
--- a/layers/+tools/tmux/local/tmux/tmux.el
+++ b/layers/+tools/tmux/local/tmux/tmux.el
@@ -24,9 +24,6 @@
   :prefix "navigate-"
   :group 'evil)
 
-; Without unsetting C-h this is useless
-(global-unset-key (kbd "C-h"))
-
 ; This requires windmove commands
 (when (fboundp 'windmove-default-keybindings)
   (windmove-default-keybindings))


### PR DESCRIPTION
This is unnecessary and prevents hybrid mode from having its normal help bindings.