### PR TITLE
python: explicitly autoload py-yapf-buffer

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -383,6 +383,7 @@
 (defun python/init-py-yapf ()
   (use-package py-yapf
     :defer t
+    :commands py-yapf-buffer
     :init (spacemacs/set-leader-keys-for-major-mode 'python-mode
             "=" 'py-yapf-buffer)
     :config (when python-enable-yapf-format-on-save


### PR DESCRIPTION
e511a1211cac48f03513669b35005c19e52f5713 added lazy-load for py-yapf which caused `py-yapf-buffer` to be undefined. 

Since it's a local package, there's no autoloads file. Adding it to `:commands` to let use-package add autoload for it.