### PR TITLE
Revamp org-repo-todo

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -37,8 +37,8 @@ This layer enables  [[http://orgmode.org/][org mode]] for Spacemacs.
 - Vim inspired key bindings are provided by [[https://github.com/edwtjo/evil-org-mode][evil-org-mode]]
 - Nicer bullet via [[https://github.com/sabof/org-bullets][org-bullets]]
 - A [[http://pomodorotechnique.com/][pomodoro method]] integration via [[https://github.com/lolownia/org-pomodoro][org-pomodoro]]
-- TODO capture via [[https://github.com/waymondo/org-repo-todo][org-repo-todo]]
-- presentation mode via [[https://github.com/rlister/org-present][org-present]]
+- Project TODO capture via [[https://github.com/waymondo/org-repo-todo][org-repo-todo]]
+- Presentation mode via [[https://github.com/rlister/org-present][org-present]]
 
 ** Important Note
 Since version 0.104, spacemacs uses the =org= version from the org ELPA
@@ -107,8 +107,6 @@ You can tweak the bullets displayed in the org buffer in the function
 | ~SPC a o s~ | org search view                |
 | ~SPC a o t~ | org todo list                  |
 | ~SPC C c~   | org-capture                    |
-| ~SPC C t~   | ort/capture-todo               |
-| ~SPC C T~   | ort/capture-checkitem          |
 
 ** Org with evil-org-mode
 
@@ -401,9 +399,13 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 
 ** Org-repo-todo
 
-| Key Binding | Description    |
-|-------------+----------------|
-| ~SPC m g t~ | ort/goto-todos |
+| Key Binding | Description                                                |
+|-------------+------------------------------------------------------------|
+| ~SPC C t~   | capture a TODO item for the current project                |
+| ~SPC C T~   | capture a checklist item for the current project           |
+| ~SPC a o p~ | show the TODO list for the current project                 |
+| ~SPC a o P~ | show the TODO list for all known projects                  |
+| ~SPC a o T~ | show the TODO list including those from all known projects |
 
 ** Org-MIME
 

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -1,0 +1,41 @@
+;;; funcs.el --- Org Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun ort/find-todo-file (&optional directory)
+  (let* ((ort/todo-root (or directory (ort/find-root default-directory)))
+         (file (ort/todo-file)))
+    (when (and (not (file-remote-p file))
+               (file-readable-p file))
+      file)))
+
+(defun ort/find-all-todo-files ()
+  (require 'projectile)
+  (delq nil (mapcar 'ort/find-todo-file projectile-known-projects)))
+
+(defun ort/list-project-todos ()
+  "List all the TODOs of the current project."
+  (interactive)
+  (let ((org-agenda-files (list (ort/find-todo-file))))
+    (org-todo-list)))
+
+(defun ort/list-all-project-todos ()
+  "List all the TODOs of all known projects (excluding remote
+projects)."
+  (interactive)
+  (let ((org-agenda-files (ort/find-all-todo-files)))
+    (org-todo-list)))
+
+(defun ort/list-all-todos ()
+  "List all the TODOs of all known projects (excluding remote
+projects) as well as those from `org-agenda-files'."
+  (interactive)
+  (let ((org-agenda-files (append (org-agenda-files) (ort/find-all-todo-files))))
+    (org-todo-list)))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -498,14 +498,21 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
 (defun org/init-org-repo-todo ()
   (use-package org-repo-todo
-    :defer t
+    :commands (ort/todo-root ort/find-root ort/todo-file)
     :init
     (progn
       (spacemacs/set-leader-keys
-        "Ct"  'ort/capture-todo
-        "CT"  'ort/capture-checkitem)
-      (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "gt" 'ort/goto-todos))))
+        "Ct" 'ort/capture-todo
+        "CT" 'ort/capture-checkitem
+        "aop" 'ort/list-project-todos)
+      (when (configuration-layer/package-usedp 'projectile)
+        (spacemacs/set-leader-keys
+          "aoT" 'ort/list-all-todos
+          "aoP" 'ort/list-all-project-todos)))
+    :config
+    ;; Better default capture template
+    (setcdr (cdddr (assoc "ort/todo" org-capture-templates))
+            '("* TODO %?\n%U\n\n%i" :empty-lines 1))
 
 (defun org/init-ox-gfm ()
   ;; installing this package from melpa is buggy,


### PR DESCRIPTION
* Remove `SPC m g t` binding (it's not specific to emacs lisp mode)
* Add bindings for showing the todo lists of (a) the project, (b) all projects, and (c) all projects + the regular TODOs from `org-agenda-files`. Use `projectile-known-projects` for this.

Note: `org-repo-todo` does *not* use projectile to decide where to put the todo file.

I didn't put much thought into the actual bindings, so feel free to criticise.

I also changed the capture template because I didn't like it, but that's subjective of course, so feel free to criticise that too.

CC @CHedgren