### PR TITLE
Fixes #5273 - core: make retaining visual mode on shift optional

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -159,6 +159,9 @@ size to make separators look not too crappy.")
 (defvar dotspacemacs-remap-Y-to-y$ nil
   "If non nil `Y' is remapped to `y$' in Evil states.")
 
+(defvar dotspacemacs-retain-visual-mode-on-shift nil
+  "If non nil `>' is remapped to `>gv' and `<' is remapped to `<gv' in visual mode.")
+
 (defvar dotspacemacs-ex-substitute-global nil
   "If non nil, inverse the meaning of `g' in `:substitute' Evil ex-command.")
 

--- a/layers/+distribution/spacemacs-bootstrap/packages.el
+++ b/layers/+distribution/spacemacs-bootstrap/packages.el
@@ -108,8 +108,9 @@
   (add-hook 'after-change-major-mode-hook 'spacemacs//set-evil-shift-width 'append)
 
   ;; Keep the region active when shifting
-  (evil-map visual "<" "<gv")
-  (evil-map visual ">" ">gv")
+  (when dotspacemacs-retain-visual-mode-on-shift
+    ((evil-map visual "<" "<gv")
+     (evil-map visual ">" ">gv")))
 
   ;; move selection up and down
   (define-key evil-visual-state-map "J" (concat ":m '>+1" (kbd "RET") "gv=gv"))


### PR DESCRIPTION
This breaks repeated indentations (>.) in visual mode and deviates from vim.

Fixes #5273