### PR TITLE
python: register python language for org-babel

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -21,8 +21,9 @@
     helm-cscope
     helm-pydoc
     hy-mode
-    (nose :location local)
     live-py-mode
+    (nose :location local)
+    org
     pip-requirements
     pyenv-mode
     (pylookup :location local)
@@ -151,6 +152,10 @@
     (progn
       (add-to-list 'nose-project-root-files "setup.cfg")
       (setq nose-use-verbose nil))))
+
+(defun python/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(python . t))))
 
 (defun python/init-pip-requirements ()
   (use-package pip-requirements


### PR DESCRIPTION
Based on https://github.com/syl20bnr/spacemacs/commit/931652bf8da3902b1bda62e32e6bffe5a08f3016 , I assume the plan is to add all the language layers to babel. 

Since I already had this one in my `.spacemacs`, I figured add it to the layer.