### PR TITLE
remove duplicated configs of eldoc

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -99,17 +99,6 @@
   (autoload 'dired-jump-other-window "dired-x"
     "Like \\[dired-jump] (dired-jump) but in other window." t))
 
-(defun spacemacs-base/init-eldoc ()
-  (use-package eldoc
-    :defer t
-    :config
-    (progn
-      ;; enable eldoc in `eval-expression'
-      (add-hook 'eval-expression-minibuffer-setup-hook #'eldoc-mode)
-      ;; enable eldoc in IELM
-      (add-hook 'ielm-mode-hook #'eldoc-mode)
-      ;; don't display eldoc on modeline
-      (spacemacs|hide-lighter eldoc-mode))))
 
 (defun spacemacs-base/init-electric-indent-mode ()
   (electric-indent-mode))


### PR DESCRIPTION
There are two exactly the same copy of eldoc config in spacemacs-base/packages.el