### PR TITLE
javascript: enhance tern binary detection

### DIFF
--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -15,3 +15,6 @@
 
 (defvar javascript-disable-tern-port-files t
   "Stops tern from creating tern port files.")
+
+(defvar javascript-disable-tern-missing-warning nil
+  "If non-nil then disables tern binary missing wanrings.")

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -1,0 +1,17 @@
+;;; funcs.el --- Javascript Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Muneeb Shaikh <muneeb@reversehack.in>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun javascript//tern-detect ()
+  "Detect tern binary and warn if not found."
+  (if (executable-find "tern")
+      t
+    (unless javascript-disable-tern-missing-warning
+      (warn "tern binary not found"))))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -192,6 +192,7 @@
 (defun javascript/init-tern ()
   (use-package tern
     :defer t
+    :if (javascript//tern-detect)
     :init (add-hook 'js2-mode-hook 'tern-mode)
     :config
     (progn


### PR DESCRIPTION
Fix #4292

If tern binary isn't found, warn the user of missing binary and do not
enable tern package(else it makes emacs unresponsive).
Allow user to disable missing binary warning via configuration layer
variable `javascript-disable-tern-missing-warning`