### PR TITLE
Fix eshell setup for xterm-color

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -19,3 +19,12 @@
   "Locally disable global-hl-line-mode"
   (interactive)
   (setq-local global-hl-line-mode nil))
+
+(defun spacemacs/init-eshell-xterm-color ()
+  "Initialize xterm coloring for eshell"
+  (setq-local xterm-color-preserve-properties t)
+  (make-local-variable 'eshell-preoutput-filter-functions)
+  (add-hook 'eshell-preoutput-filter-functions 'xterm-color-filter)
+  (setq-local eshell-output-filter-functions
+              (remove 'eshell-handle-ansi-color
+                      eshell-output-filter-functions)))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -375,10 +375,4 @@ is achieved by adding the relevant text properties."
       (setq comint-output-filter-functions
             (remove 'ansi-color-process-output comint-output-filter-functions))
       (setq font-lock-unfontify-region-function 'xterm-color-unfontify-region)
-      (with-eval-after-load 'esh-mode
-        (add-hook 'eshell-mode-hook
-                  (lambda () (setq xterm-color-preserve-properties t)))
-        (add-hook 'eshell-preoutput-filter-functions 'xterm-color-filter)
-        (setq eshell-output-filter-functions
-              (remove 'eshell-handle-ansi-color
-                      eshell-output-filter-functions))))))
+      (add-hook 'eshell-mode-hook 'spacemacs/init-eshell-xterm-color))))


### PR DESCRIPTION
This makes sure that all the setup happens at the same time. Previously some setup happened at loading time of esh-mode while some happened in eshell-mode-hook. Everything output between this (the first prompt) looks different.

Fixes #5542.