### PR TITLE
Space-doc package improvements

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -140,6 +140,18 @@ Supported properties:
        `((dolist (val ',def-key)
           (define-key (eval (car val)) (kbd (cdr val)) ',func)))))))
 
+(defun spacemacs/prettify-org-buffer ()
+  "Apply visual enchantments to the current buffer.
+The buffer's major mode should be `org-mode'."
+  (interactive)
+  (if (not (derived-mode-p 'org-mode))
+      (user-error "org-mode should be enabled in the current buffer.")
+
+    (require 'space-doc)
+    (org-indent-mode)
+    (view-mode)
+    (space-doc-mode)))
+
 (defun spacemacs/view-org-file (file &optional anchor-text expand-scope)
   "Open org file and apply visual enchantments.
 `file' - org file to be opened.
@@ -149,48 +161,43 @@ If `anchor-text' isn't a GitHub style anchor - run `re-search-forward' with `anc
 If `expand-scope' is `subtree' run `outline-show-subtree' at the matched line.
 If `expand-scope' is `all' `outline-show-all' at the matched line."
   (interactive)
-  (require 'space-doc)
   (find-file file)
-  (if (not (string-suffix-p ".org" file))
-      (user-error (format "%s not a .org file", file))
-    (org-indent-mode)
-    (view-mode)
-    (space-doc-mode)
-    (goto-char (point-min))
-    (when anchor-text
-      ;; If `anchor-text' is GitHub style link.
-      (if (string-prefix-p "#" anchor-text)
-          ;; If the toc-org package is loaded.
-          (if (configuration-layer/package-usedp 'toc-org)
-              ;; For each heading. Search the heading that corresponds
-              ;; to `anchor-text'.
-              (while (and (re-search-forward "^[\\*]+\s\\(.*\\).*$" nil t)
-                          (not (string= (toc-org-hrefify-gh (match-string 1))
-                                        anchor-text))))
-            ;; This is not a problem because without the space-doc package
-            ;; those links will be opened in the browser.
-            (message (format (concat "Can't follow the GitHub style anchor: '%s' "
-                                     "without the org layer.") anchor-text)))
-        (re-search-forward anchor-text)))
-    (beginning-of-line)
-    (cond
-     ((eq expand-scope 'subtree)
-      (outline-show-subtree))
-     ((eq expand-scope 'all)
-      (outline-show-all))
-     (t nil))
-    ;; Make ~SPC ,~ work, reference:
-    ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
-    (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
-    (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
-    (setq-local org-emphasis-alist '(("*" bold)
-                                     ("/" italic)
-                                     ("_" underline)
-                                     ("=" org-verbatim verbatim)
-                                     ("~" org-kbd)
-                                     ("+"
-                                      (:strike-through t))))
-    (setq-local org-hide-emphasis-markers t)))
+  (spacemacs/prettify-org-buffer)
+  (goto-char (point-min))
+  (when anchor-text
+    ;; If `anchor-text' is GitHub style link.
+    (if (string-prefix-p "#" anchor-text)
+        ;; If the toc-org package is loaded.
+        (if (configuration-layer/package-usedp 'toc-org)
+            ;; For each heading. Search the heading that corresponds
+            ;; to `anchor-text'.
+            (while (and (re-search-forward "^[\\*]+\s\\(.*\\).*$" nil t)
+                        (not (string= (toc-org-hrefify-gh (match-string 1))
+                                      anchor-text))))
+          ;; This is not a problem because without the space-doc package
+          ;; those links will be opened in the browser.
+          (message (format (concat "Can't follow the GitHub style anchor: '%s' "
+                                   "without the org layer.") anchor-text)))
+      (re-search-forward anchor-text)))
+  (beginning-of-line)
+  (cond
+   ((eq expand-scope 'subtree)
+    (outline-show-subtree))
+   ((eq expand-scope 'all)
+    (outline-show-all))
+   (t nil))
+  ;; Make ~SPC ,~ work, reference:
+  ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
+  (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
+  (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
+  (setq-local org-emphasis-alist '(("*" bold)
+                                   ("/" italic)
+                                   ("_" underline)
+                                   ("=" org-verbatim verbatim)
+                                   ("~" org-kbd)
+                                   ("+"
+                                    (:strike-through t))))
+  (setq-local org-hide-emphasis-markers t))
 
 (defun spacemacs//test-var (pred var test-desc)
   "Test PRED against VAR and print test result, incrementing

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -141,7 +141,13 @@ Supported properties:
           (define-key (eval (car val)) (kbd (cdr val)) ',func)))))))
 
 (defun spacemacs/view-org-file (file &optional anchor-text expand-scope)
-  "Open the change log for the current version."
+  "Open org file and apply visual enchantments.
+`file' - org file to be opened.
+If `anchor-text'  is `nil' - run `re-search-forward' with  ^ (beginning-of-line).
+If `anchor-text' is a GitHub style anchor - find a corresponding header.
+If `anchor-text' isn't a GitHub style anchor - run `re-search-forward' with `anchor-text'.
+If `expand-scope' is `subtree' run `outline-show-subtree' at the matched line.
+If `expand-scope' is `all' `outline-show-all' at the matched line."
   (interactive)
   (require 'space-doc)
   (find-file file)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -145,44 +145,46 @@ Supported properties:
   (interactive)
   (require 'space-doc)
   (find-file file)
-  (org-indent-mode)
-  (view-mode)
-  (space-doc-mode)
-  (goto-char (point-min))
-  (when anchor-text
-    ;; If `anchor-text' is GitHub style link.
-    (if (string-prefix-p "#" anchor-text)
-        ;; If the toc-org package is loaded.
-        (if (configuration-layer/package-usedp 'toc-org)
-            ;; For each heading. Search the heading that corresponds
-            ;; to `anchor-text'.
-            (while (and (re-search-forward "^[\\*]+\s\\(.*\\).*$" nil t)
-                        (not (string= (toc-org-hrefify-gh (match-string 1))
-                                      anchor-text))))
-          ;; This is not a problem because without the space-doc package
-          ;; those links will be opened in the browser.
-          (message (format (concat "Can't follow the GitHub style anchor: '%s' "
-                                   "without the org layer.") anchor-text)))
-      (re-search-forward anchor-text)))
-  (beginning-of-line)
-  (cond
-   ((eq expand-scope 'subtree)
-    (outline-show-subtree))
-   ((eq expand-scope 'all)
-    (outline-show-all))
-   (t nil))
-  ;; Make ~SPC ,~ work, reference:
-  ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
-  (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
-  (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
-  (setq-local org-emphasis-alist '(("*" bold)
-                                   ("/" italic)
-                                   ("_" underline)
-                                   ("=" org-verbatim verbatim)
-                                   ("~" org-kbd)
-                                   ("+"
-                                    (:strike-through t))))
-  (setq-local org-hide-emphasis-markers t))
+  (if (not (string-suffix-p ".org" file))
+      (user-error (format "%s not a .org file", file))
+    (org-indent-mode)
+    (view-mode)
+    (space-doc-mode)
+    (goto-char (point-min))
+    (when anchor-text
+      ;; If `anchor-text' is GitHub style link.
+      (if (string-prefix-p "#" anchor-text)
+          ;; If the toc-org package is loaded.
+          (if (configuration-layer/package-usedp 'toc-org)
+              ;; For each heading. Search the heading that corresponds
+              ;; to `anchor-text'.
+              (while (and (re-search-forward "^[\\*]+\s\\(.*\\).*$" nil t)
+                          (not (string= (toc-org-hrefify-gh (match-string 1))
+                                        anchor-text))))
+            ;; This is not a problem because without the space-doc package
+            ;; those links will be opened in the browser.
+            (message (format (concat "Can't follow the GitHub style anchor: '%s' "
+                                     "without the org layer.") anchor-text)))
+        (re-search-forward anchor-text)))
+    (beginning-of-line)
+    (cond
+     ((eq expand-scope 'subtree)
+      (outline-show-subtree))
+     ((eq expand-scope 'all)
+      (outline-show-all))
+     (t nil))
+    ;; Make ~SPC ,~ work, reference:
+    ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
+    (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
+    (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
+    (setq-local org-emphasis-alist '(("*" bold)
+                                     ("/" italic)
+                                     ("_" underline)
+                                     ("=" org-verbatim verbatim)
+                                     ("~" org-kbd)
+                                     ("+"
+                                      (:strike-through t))))
+    (setq-local org-hide-emphasis-markers t)))
 
 (defun spacemacs//test-var (pred var test-desc)
   "Test PRED against VAR and print test result, incrementing

--- a/core/templates/README.org.template
+++ b/core/templates/README.org.template
@@ -3,6 +3,7 @@
 # The maximum height of the logo should be 200 pixels.
 [[img/%LAYER_NAME%.png]]
 
+# TOC links should be GitHub style anchors.
 * Table of Contents                                        :TOC_4_gh:noexport:
  - [[#decsription][Description]]
  - [[#install][Install]]
@@ -22,3 +23,8 @@ file.
 | Key Binding | Description    |
 |-------------+----------------|
 | ~SPC x x x~ | Does thing01   |
+# Use GitHub URLs if you wish to link a Spacemacs documentation file or its heading.
+# Examples:
+# [[https://github.com/syl20bnr/spacemacs/blob/master/doc/VIMUSERS.org#sessions]]
+# [[https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bfun/emoji/README.org][Link to Emoji layer README.org]]
+# If space-doc-mode is enabled, Spacemacs will open a local copy of the linked file.

--- a/layers/+emacs/org/local/space-doc/space-doc.el
+++ b/layers/+emacs/org/local/space-doc/space-doc.el
@@ -34,7 +34,7 @@
 The mode hides `org-mode' meta tags like #+TITLE: while
 keeping their content visible."
   :init-value nil
-  :lighter " ❤"
+  :lighter " SD"
   (if (eq major-mode 'org-mode)
       (if space-doc-mode
           (let ((bg (face-attribute 'default :background)))

--- a/layers/+emacs/org/local/space-doc/space-doc.el
+++ b/layers/+emacs/org/local/space-doc/space-doc.el
@@ -39,51 +39,50 @@ keeping their content visible.
   :lighter " SD"
   (if (derived-mode-p 'org-mode)
       (if space-doc-mode
-          (progn
+          (let ((bg (face-attribute 'default :background)))
             ;; Make `space-doc' https link opener buffer local
             ;; and enable it only when `space-doc' mode is enabled.
             (make-local-variable 'org-link-types)
             (make-local-variable 'org-link-protocols)
             (org-add-link-type "https" 'spacemacs//space-doc-open)
 
-            (let ((bg (face-attribute 'default :background)))
-              (progn
-                ;; Make `org-mode' meta tags invisible.
-                (set (make-local-variable
-                      'spacemacs--org-face-remap-cookie-org-tag)
-                     (face-remap-add-relative 'org-tag
-                                              `(:foreground ,bg)))
-                (set (make-local-variable
-                      'spacemacs--org-face-remap-cookie-org-meta-line)
-                     (face-remap-add-relative 'org-meta-line
-                                              `(:foreground ,bg)))
-                (set (make-local-variable
-                      'spacemacs--org-face-remap-cookie-org-block-begin-line)
-                     (face-remap-add-relative 'org-block-begin-line
-                                              `(:foreground ,bg)))
-                (set (make-local-variable
-                      'spacemacs--org-face-remap-cookie-org-document-info-keyword)
-                     (face-remap-add-relative 'org-document-info-keyword
-                                              `(:foreground ,bg))))))
-        (progn
-          (kill-local-variable 'org-link-types)
-          (kill-local-variable 'org-link-protocols)
-          ;; Trigger `org-mode' internal updates.
-          (org-add-link-type nil)
+            ;; Make `org-mode' meta tags invisible.
+            (set (make-local-variable
+                  'spacemacs--org-face-remap-cookie-org-tag)
+                 (face-remap-add-relative 'org-tag
+                                          `(:foreground ,bg)))
+            (set (make-local-variable
+                  'spacemacs--org-face-remap-cookie-org-meta-line)
+                 (face-remap-add-relative 'org-meta-line
+                                          `(:foreground ,bg)))
+            (set (make-local-variable
+                  'spacemacs--org-face-remap-cookie-org-block-begin-line)
+                 (face-remap-add-relative 'org-block-begin-line
+                                          `(:foreground ,bg)))
+            (set (make-local-variable
+                  'spacemacs--org-face-remap-cookie-org-document-info-keyword)
+                 (face-remap-add-relative 'org-document-info-keyword
+                                          `(:foreground ,bg))))
 
-          ;; Make `org-mode' meta tags visible.
-          (face-remap-remove-relative
-           spacemacs--org-face-remap-cookie-org-tag)
-          (face-remap-remove-relative
-           spacemacs--org-face-remap-cookie-org-meta-line)
-          (face-remap-remove-relative
-           spacemacs--org-face-remap-cookie-org-block-begin-line)
-          (face-remap-remove-relative
-           spacemacs--org-face-remap-cookie-org-document-info-keyword)
-          (setq spacemacs--org-face-remap-p nil)))
-    (progn (message (format "space-doc-mode error:%s isn't an org-mode buffer"
-                            (buffer-name)))
-           (setq org-mode nil))))
+        (kill-local-variable 'org-link-types)
+        (kill-local-variable 'org-link-protocols)
+        ;; Trigger `org-mode' internal updates.
+        (org-add-link-type nil)
+
+        ;; Make `org-mode' meta tags visible.
+        (face-remap-remove-relative
+         spacemacs--org-face-remap-cookie-org-tag)
+        (face-remap-remove-relative
+         spacemacs--org-face-remap-cookie-org-meta-line)
+        (face-remap-remove-relative
+         spacemacs--org-face-remap-cookie-org-block-begin-line)
+        (face-remap-remove-relative
+         spacemacs--org-face-remap-cookie-org-document-info-keyword)
+        (setq spacemacs--org-face-remap-p nil))
+
+    (message (format "space-doc-mode error:%s isn't an org-mode buffer"
+                     (buffer-name)))
+    (setq org-mode nil)))
 
 (defun spacemacs//space-doc-open (path)
   "If the `path' argument is a link to an .org file that is located

--- a/layers/+emacs/org/local/space-doc/space-doc.el
+++ b/layers/+emacs/org/local/space-doc/space-doc.el
@@ -31,32 +31,46 @@
 ;;;###autoload
 (define-minor-mode space-doc-mode
   "Buffer local minor mode for Spacemacs documentation files.
-The mode hides `org-mode' meta tags like #+TITLE: while
-keeping their content visible."
+This mode:
+ - hides `org-mode' meta tags like #+TITLE: while
+keeping their content visible.
+ - enables buffer local link  opening with `spacemacs//space-doc-open'."
   :init-value nil
   :lighter " SD"
-  (if (eq major-mode 'org-mode)
+  (if (derived-mode-p 'org-mode)
       (if space-doc-mode
-          (let ((bg (face-attribute 'default :background)))
-            (progn
-              ;; Make `org-mode' meta tags invisible.
-              (set (make-local-variable
-                    'spacemacs--org-face-remap-cookie-org-tag)
-                   (face-remap-add-relative 'org-tag
-                                            `(:foreground ,bg)))
-              (set (make-local-variable
-                    'spacemacs--org-face-remap-cookie-org-meta-line)
-                   (face-remap-add-relative 'org-meta-line
-                                            `(:foreground ,bg)))
-              (set (make-local-variable
-                    'spacemacs--org-face-remap-cookie-org-block-begin-line)
-                   (face-remap-add-relative 'org-block-begin-line
-                                            `(:foreground ,bg)))
-              (set (make-local-variable
-                    'spacemacs--org-face-remap-cookie-org-document-info-keyword)
-                   (face-remap-add-relative 'org-document-info-keyword
-                                            `(:foreground ,bg)))))
+          (progn
+            ;; Make `space-doc' https link opener buffer local
+            ;; and enable it only when `space-doc' mode is enabled.
+            (make-local-variable 'org-link-types)
+            (make-local-variable 'org-link-protocols)
+            (org-add-link-type "https" 'spacemacs//space-doc-open)
+
+            (let ((bg (face-attribute 'default :background)))
+              (progn
+                ;; Make `org-mode' meta tags invisible.
+                (set (make-local-variable
+                      'spacemacs--org-face-remap-cookie-org-tag)
+                     (face-remap-add-relative 'org-tag
+                                              `(:foreground ,bg)))
+                (set (make-local-variable
+                      'spacemacs--org-face-remap-cookie-org-meta-line)
+                     (face-remap-add-relative 'org-meta-line
+                                              `(:foreground ,bg)))
+                (set (make-local-variable
+                      'spacemacs--org-face-remap-cookie-org-block-begin-line)
+                     (face-remap-add-relative 'org-block-begin-line
+                                              `(:foreground ,bg)))
+                (set (make-local-variable
+                      'spacemacs--org-face-remap-cookie-org-document-info-keyword)
+                     (face-remap-add-relative 'org-document-info-keyword
+                                              `(:foreground ,bg))))))
         (progn
+          (kill-local-variable 'org-link-types)
+          (kill-local-variable 'org-link-protocols)
+          ;; Trigger `org-mode' internal updates.
+          (org-add-link-type nil)
+
           ;; Make `org-mode' meta tags visible.
           (face-remap-remove-relative
            spacemacs--org-face-remap-cookie-org-tag)
@@ -86,8 +100,6 @@ Open all other links with `browse-url'."
                                      "^")
                                  'subtree)
       (browse-url (concat "https://" path)))))
-
-(org-add-link-type "https" 'spacemacs//space-doc-open)
 
 (provide 'space-doc)
 ;;; space-doc.el ends here


### PR DESCRIPTION
### This PR adds improvements to [`space-doc`](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bemacs/org/local/space-doc/space-doc.el)
---

  - **view-org-file emits error for non .org files 1bf47f07164d535c2bb59236fc0fa9bd507d74c0**  - Now spacemacs/view-org-file emits user-error if used on non *.org file. 

---

  - **Change space-doc lighter 7bfad17b713e0341a5122eb35f0834592aa797c2**  - fixes #5642 

---


  - **Tie `space-doc-mode' and Spacemacs link opener fb1445ae2996bb00fd747795a20f94b84879e1f4**  - use [space-doc link opener](https://github.com/JAremko/spacemacs-pr/blob/space-doc2/layers/%2Bemacs/org/local/space-doc/space-doc.el#L87) only if [space-doc-mode](https://github.com/JAremko/spacemacs-pr/blob/space-doc2/layers/%2Bemacs/org/local/space-doc/space-doc.el#L32) is enabled. Since it's a really specific mechanism to the Spacemacs documentation, I think it should be more granular. It will help in avoiding conflicts and this way it can be disabled.

---


  - **Add space-doc link examples to README.org.template 11f414d94f2665fff7b687444f9e4d92e7ac1702**

---


  - **Update spacemacs/view-org-file doc string ccdb314**  - it was misleading.

---


  - **Refactor space-doc.el 8c84184**  - Friendly lisper explained how to lisp without a ton of `progn`s.  And I think I might converted him to Spacemacs :smile:

---


  - **Add function spacemacs/prettify-org-buffer 6392682**  - fulfilling @nwolfe request.