### PR TITLE
Fix next-error behavior when flycheck is active

### DIFF
--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -602,7 +602,8 @@ current window."
   "Dispatch to flycheck or standard emacs error."
   (interactive "P")
   (if (and (boundp 'flycheck-mode)
-           (symbol-value flycheck-mode))
+           (symbol-value flycheck-mode)
+           (not (get-buffer-window "*compilation*")))
       (call-interactively 'flycheck-next-error)
     (call-interactively 'next-error)))
 
@@ -610,7 +611,8 @@ current window."
   "Dispatch to flycheck or standard emacs error."
   (interactive "P")
   (if (and (boundp 'flycheck-mode)
-           (symbol-value flycheck-mode))
+           (symbol-value flycheck-mode)
+           (not (get-buffer-window "*compilation*")))
       (call-interactively 'flycheck-previous-error)
     (call-interactively 'previous-error)))
 


### PR DESCRIPTION
@spott suggested in #776, that `spacemacs/next-error` should go to the next compilation error if the compilation window is open, regardless of whether flycheck is enabled or not. IMO, that makes the available keybindings much more usable for people who compile from inside emacs (like me :wink:)