### PR TITLE
(5719) Fix multi-term shell popup

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -226,7 +226,7 @@ is achieved by adding the relevant text properties."
     :init
     (progn
       (spacemacs/register-repl 'multi-term 'multi-term)
-      (defun multiterm (_)
+      (defun multiterm ()
         "Wrapper to be able to call multi-term from shell-pop"
         (interactive)
         (multi-term)))


### PR DESCRIPTION
This commit removes the unused argument from the wrapper lambda, which
appears to be no longer provided when the function is called.