### PR TITLE
Fixes #5696 #4710 - Synchronize Neotree window when changing context

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -201,6 +201,10 @@
             (neotree-find (projectile-project-root))
             (neotree-find origin-buffer-file-name))))
 
+      (defun spacemacs//neotree-maybe-attach-window ()
+        (when (get-buffer-window (neo-global--get-buffer))
+          (neo-global--attach)))
+
       (defun spacemacs//neotree-key-bindings ()
         "Set the key bindings for a neotree buffer."
         (evilified-state-evilify-map neotree-mode-map
@@ -230,7 +234,10 @@
         "pt" 'neotree-find-project-root))
 
     :config
-    (spacemacs//neotree-key-bindings)))
+    (progn
+      (spacemacs//neotree-key-bindings)
+      (add-hook 'persp-activated-hook #'spacemacs//neotree-maybe-attach-window)
+      (add-hook 'eyebrowse-post-window-switch-hook #'spacemacs//neotree-maybe-attach-window))))
 
 (defun spacemacs-ui-visual/init-smooth-scrolling ()
   (use-package smooth-scrolling


### PR DESCRIPTION
Fix Neotree losing track of its window when changing workspaces or layouts.

Combined with [this change](https://github.com/syl20bnr/persp-mode.el/pull/1) to our fork of persp-mode, it should fix most cases of Neotree messing the window configuration when switching workspaces or layouts.

I'm not sure if it fixes all the cases, but it should be better than what we have now. I think we can test run this PR in develop branch to get feedback from users.

Related issues: #5696 #4710