### PR TITLE
Set `comment-inline-offset` to 2 for python-mode.

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -241,6 +241,7 @@
               fill-column python-fill-column
               ;; auto-indent on colon doesn't work well with if statement
               electric-indent-chars (delq ?: electric-indent-chars))
+        (setq-local comment-inline-offset 2)
         (annotate-pdb)
         ;; make C-j work the same way as RET
         (local-set-key (kbd "C-j") 'newline-and-indent))


### PR DESCRIPTION
Since python's PEP8 recommends two spaces for inline spaces.

Ref:
- https://www.python.org/dev/peps/pep-0008/#inline-comments