### PR TITLE
Fix shells asking for "Run program"

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -62,10 +62,10 @@ SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
        (require 'shell-pop)
        (if (equal '(4) index)
            ;; no popup
-           (call-interactively ',func)
+           (,func ,shell)
          (shell-pop--set-shell-type
           'shell-pop-shell-type
           (backquote (,name
                       ,(concat "*" name "*")
-                      (lambda nil (call-interactively ',func ,shell)))))
+                      (lambda nil (,func ,shell)))))
          (shell-pop index)))))


### PR DESCRIPTION
After 63dc8f7ea0b262e3bd1e164bda87d7e1265adfcf `SPC '` started to ask
for "Run program" instead of opening the terminal with the defined shell.

This commit remove the `call-interactively` that are causing this
problem. `SPC u SPC '` is still working as far as I tested.