### PR TITLE
Fix helm eshell history switch to evil mode

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -196,12 +196,14 @@ is achieved by adding the relevant text properties."
           "Correctly revert to insert state after selection."
           (interactive)
           (helm-eshell-history)
-          (evil-insert-state))
+          (when (not(eq dotspacemacs-editing-style 'emacs))
+            (evil-insert-state)))
         (defun spacemacs/helm-shell-history ()
           "Correctly revert to insert state after selection."
           (interactive)
           (helm-comint-input-ring)
-          (evil-insert-state))
+          (when (not(eq dotspacemacs-editing-style 'emacs))
+            (evil-insert-state)))
         (defun spacemacs/init-helm-eshell ()
           "Initialize helm-eshell."
           ;; this is buggy for now


### PR DESCRIPTION
Patch #5729 

Check if we are not in the emacs edit mode then enter evil-insert-state.