### PR TITLE
Revert "(5719) Fix multi-term shell popup"

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -226,7 +226,7 @@ is achieved by adding the relevant text properties."
     :init
     (progn
       (spacemacs/register-repl 'multi-term 'multi-term)
-      (defun multiterm ()
+      (defun multiterm (_)
         "Wrapper to be able to call multi-term from shell-pop"
         (interactive)
         (multi-term)))


### PR DESCRIPTION
This reverts commit 8526ee7145e3b4cf6c0a96f6e21480d4df5ee2e9.

---

The cause of https://github.com/syl20bnr/spacemacs/issues/5719 was reverted, and therefore the change needs to be reverted since the multiterm popup is now broken again.