### PR TITLE
spacemacs-editing: disable bracketed-paste for 25+

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -81,6 +81,7 @@
 (defun spacemacs-editing/init-bracketed-paste ()
   (use-package bracketed-paste
     :defer t
+    :if (version< "25.0.92" emacs-version)
     :init
     ;; Enable bracketed-paste for tty
     (add-hook 'tty-setup-hook 'bracketed-paste-enable)))


### PR DESCRIPTION
Bracketed paste is built into emacs 25+

As mentioned in https://github.com/syl20bnr/spacemacs/issues/4700#issuecomment-207326125