### PR TITLE
Remove depreciated cider-turn-on-eldoc-mode

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -10,7 +10,6 @@
     subword
     ))
 
-
 (defun clojure/init-cider ()
   (use-package cider
     :defer t
@@ -23,7 +22,8 @@
             cider-repl-use-clojure-font-lock t)
       (push "\\*cider-repl\.\+\\*" spacemacs-useful-buffers-regexp)
       (add-hook 'clojure-mode-hook 'cider-mode)
-      (add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
+      (add-hook 'cider-mode-hook 'eldoc-mode)
+      (add-hook 'cider-repl-mode-hook 'eldoc-mode)
       (if dotspacemacs-smartparens-strict-mode
           (add-hook 'cider-repl-mode-hook #'smartparens-strict-mode)))
     :config


### PR DESCRIPTION
Use more general 'eldoc-mode instead. Also enable eldoc-mode in the repl as well.