### PR TITLE
fix start up error if perforce layer is enabled

### DIFF
--- a/layers/+source-control/perforce/config.el
+++ b/layers/+source-control/perforce/config.el
@@ -8,7 +8,3 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
-
-(setq perforce/key-binding-prefixes '(("p4" . "perforce")))
-(mapc (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))
-      perforce/key-binding-prefixes)

--- a/layers/+source-control/perforce/packages.el
+++ b/layers/+source-control/perforce/packages.el
@@ -13,6 +13,9 @@
 
 (defun perforce/init-p4 ()
   (use-package p4
+    :init
+    (progn
+      (spacemacs/declare-prefix "p4" "perforce"))
     :commands (p4-add
                p4-branch
                p4-branches

--- a/layers/+source-control/perforce/packages.el
+++ b/layers/+source-control/perforce/packages.el
@@ -14,8 +14,7 @@
 (defun perforce/init-p4 ()
   (use-package p4
     :init
-    (progn
-      (spacemacs/declare-prefix "p4" "perforce"))
+    (spacemacs/declare-prefix "p4" "perforce")
     :commands (p4-add
                p4-branch
                p4-branches


### PR DESCRIPTION
fix start up error if perforc layer is enabled

This fixes startup error with the following stack trace in perforce layer:

```
Debugger entered--Lisp error: (void-function which-key-declare-prefixes)
  (which-key-declare-prefixes full-prefix-emacs (cons name long-name) full-prefix (cons name long-name))
  (let* ((command name) (full-prefix (concat dotspacemacs-leader-key " " prefix)) (full-prefix-emacs (concat dotspacemacs-emacs-leader-key " " prefix)) (full-prefix-lst (listify-key-sequence (kbd full-prefix))) (full-prefix-emacs-lst (listify-key-sequence (kbd full-prefix-emacs)))) (if long-name nil (setq long-name name)) (which-key-declare-prefixes full-prefix-emacs (cons name long-name) full-prefix (cons name long-name)))
  spacemacs/declare-prefix("p4" "perforce")
  (lambda (x) (spacemacs/declare-prefix (car x) (cdr x)))(("p4" . "perforce"))
  mapc((lambda (x) (spacemacs/declare-prefix (car x) (cdr x))) (("p4" . "perforce")))
  eval-buffer(#<buffer  *load*-942658> nil "/home/kimr/opt/spacemacs25/layers/+source-control/perforce/config.el" nil t)  ; Reading at buffer position 452
...

```