### PR TITLE
Improve .org file formatting tool

### DIFF
--- a/core/tools/doc-fmt/fmt.el
+++ b/core/tools/doc-fmt/fmt.el
@@ -1,0 +1,150 @@
+;;; fmt.el --- .org file formatter.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+(load-file  "./core/tools/doc-fmt/toc-org.el")
+
+(require 'cl)
+(require 'files)
+(require 'org)
+
+(defconst empty-line-regexp "^[ \t]*$")
+
+(defconst toc-heading-head "* Table of Contents")
+(defconst toc-heading-tail ":TOC_4_gh:noexport:")
+(defconst toc-headline (format "%-41s%s"
+                               toc-heading-head
+                               toc-heading-tail))
+
+(defun apply-all ()
+  "Apply all filters."
+  (remove-empty-lines-at-the-beginning)
+  (insert-title)
+  (insert-toc)
+  (apply-toc)
+  (remove-empty-lines-after-headlines)
+  ;; Multiply empty lines are handled by
+  ;; the bash script.
+  (insert-empty-line-before-tables)
+  (insert-empty-line-after-tables)
+  (insert-empty-line-after-sections)
+  (insert-empty-line-at-the-end)
+  (align-tables)
+  (save-buffer 0))
+
+(defun remove-empty-lines-at-the-beginning ()
+  "Remove empty lines at the begging of the buffer."
+  (goto-char (point-min))
+  (while (looking-at-p empty-line-regexp)
+    (delete-blank-lines)))
+
+(defun insert-empty-line-at-the-end ()
+  "Insert an empty line at the end of the buffer."
+  (goto-char (point-max))
+  (unless (looking-at-p empty-line-regexp)
+    (open-line 1)))
+
+(defun insert-title()
+  "Insert #TITLE:{DIR_NAME} if the buffer doesn't have one."
+  (goto-char (point-min))
+  (unless (looking-at-p "^#\\+TITLE:.*$")
+    (insert (format "#+TITLE:%s\n"
+                    (clj/->> (buffer-file-name)
+                             file-name-directory
+                             directory-file-name
+                             file-name-base)))))
+
+(defun insert-toc ()
+  "Insert toc if the buffer doesn't have one."
+  (goto-char (point-min))
+  (unless (re-search-forward toc-org-toc-org-regexp nil t)
+    (goto-char (point-max))
+    ;; Skip from the end of the buffer to the first headling.
+    (while (re-search-backward org-heading-regexp nil t))
+    (open-line 3)
+    (forward-line 1)
+    (insert-string toc-headline)))
+
+(defun remove-empty-lines-after-headlines()
+  "Remove empty liners after each headline."
+  (goto-char (point-min))
+  (while (re-search-forward org-heading-regexp nil t)
+    (unless (= (forward-line) 0)
+      (while (looking-at-p empty-line-regexp)
+        (delete-blank-lines)))))
+
+(defun insert-empty-line-before-tables ()
+  "Insert an empty line before each org table."
+  (goto-char (point-min))
+  (while (goto-next-table)
+    (forward-line -1)
+    (unless (looking-at-p empty-line-regexp)
+      (end-of-line)
+      (open-line 1))
+    (forward-line 1)))
+
+(defun insert-empty-line-after-sections ()
+  "Insert an empty line after each section."
+  (goto-char (point-min))
+  (while (re-search-forward org-heading-regexp nil t)
+    (forward-line -1)
+    (unless (or (looking-at-p empty-line-regexp)
+                (looking-at-p org-heading-regexp))
+      (end-of-line)
+      (open-line 1))
+    (forward-line 2)))
+
+(defun insert-empty-line-after-tables ()
+  "Insert an empty line after each table."
+  (goto-char (point-min))
+  (while (goto-next-table)
+    ;; Skip current table.
+    (while (looking-at-p org-table-any-line-regexp)
+      (forward-line))
+    (unless (looking-at-p empty-line-regexp)
+      (beginning-of-line)
+      (open-line 1)
+      (forward-line))))
+
+(defun align-tables ()
+  "Align all tables"
+  (goto-char (point-min))
+  (while (goto-next-table)
+    (org-table-align)))
+
+(defun apply-toc ()
+  "Apply current toc-org TAG to TOC."
+  (goto-char (point-min))
+  (toc-org-insert-toc))
+
+(defun goto-next-table ()
+  "Goto next org table.
+Returns nil if no more tables left."
+  ;; Skip current table.
+  (while (looking-at-p org-table-any-line-regexp)
+    (forward-line))
+  ;; Skip to the next table.
+  (when (re-search-forward org-table-hline-regexp nil t)
+    (forward-line -1 )))
+
+(defmacro clj/->> (o &rest forms)
+  "Threads the expr through the forms.
+ Inserts o as the  last item in the first form,
+ making a list of it if it is not a  list already.
+If there are more forms, inserts the first form
+ as the  last item in second form, etc."
+  (cond ((not forms) o)
+        ((= 1 (length forms))
+         (let ((f (first forms)))
+           (append (if (symbolp f)
+                       (list f) f)
+                   (list o))))
+        (:else `(clj/->> (clj/->> ,o ,(first forms)) ,@(rest forms)))))

--- a/core/tools/doc-fmt/run.bash
+++ b/core/tools/doc-fmt/run.bash
@@ -6,24 +6,31 @@ if ! [ -d "./.git" ]
 		exit 1
 fi
 
-#rm #+HTML_HEAD_EXTRA: ... readtheorg.css" /> in the doc.
-find ./doc    -name "*.org" -type f -exec gsed -i '/#+HTML_HEAD_EXTRA.*readtheorg.css.*/d' {} \;
+#Use "sed" or "gsed" if avaliable.
+seder="sed"
+if hash gsed 2>/dev/null; then
+    $seder="gsed"
+fi
 
-#rm #+HTML_HEAD_EXTRA: ... readtheorg.css" /> in the layers.
-find ./layers -name "*.org" -type f -exec gsed -i '/#+HTML_HEAD_EXTRA.*readtheorg.css.*/d' {} \;
+if [ $1 = "test" ]
+  then
+    places=("./core/tools/doc-fmt")
+  else
+    places=("./doc" "./layers")
+fi
 
-
-
-#replace :TOC_4_org: with :TOC_4_gh: in the doc.
-find ./doc    -name "*.org" -type f -exec gsed -i 's/:TOC_4_org:/:TOC_4_gh:/' {} \;
-
-#replace :TOC_4_org: with :TOC_4_gh: in the layers.
-find ./layers -name "*.org" -type f -exec gsed -i 's/:TOC_4_org:/:TOC_4_gh:/' {} \;
-
-
-
-#apply toc-org to doc.
-find ./doc    -name "*.org" -type f -exec emacs -batch -l ./core/tools/doc-fmt/toc-org-apply.el '{}' -f toc-apply \;
-
-#apply toc-org to layers.
-find ./layers -name "*.org" -type f -exec emacs -batch -l ./core/tools/doc-fmt/toc-org-apply.el '{}' -f toc-apply \;
+for place in "${places[@]}"
+do :
+   #Remove trailing delimiters in headlines
+   find $place -name "*.org" -type f -exec $seder -i 's/^\(*\+\s\+.*\)[;,.]$/\1/g' {} \;
+   #Remove trailing spaces
+   find $place -name "*.org" -type f -exec $seder -i 's/[ \t]*$//' {} \;
+   #Remove #+HTML_HEAD_EXTRA: ... readtheorg.css" />
+   find $place -name "*.org" -type f -exec $seder -i '/#+HTML_HEAD_EXTRA.*readtheorg.css.*/d' {} \;
+   #Replace multiply empty lines with a single empty line
+   find $place -name "*.org" -type f -exec $seder -i '/^$/N;/^\n$/D' {} \;
+   #Replace :TOC_4_org: with :TOC_4_gh:
+   find $place -name "*.org" -type f -exec $seder -i 's/:TOC_4_org:/:TOC_4_gh:/' {} \;
+   #apply toc-org
+   find $place -name "*.org" -type f -exec emacs -batch -l ./core/tools/doc-fmt/fmt.el '{}' -f apply-all \;
+done

--- a/core/tools/doc-fmt/test.org
+++ b/core/tools/doc-fmt/test.org
@@ -1,29 +1,28 @@
-#+TITLE: FOO
 
-* Table of Contents                                         :TOC_4_gh:noexport:
- - [[#links][Links]]
- - [[#foo][FOO]]
- - [[#bar][BAR]]
- - [[#baz][BAZ]]
 
-* Links
 
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
+
+
+* Links,
 [[https://github.com/syl20bnr/spacemacs/blob/master/doc/FAQ.org#os-x][Link to FAQ "OS X" heading]]
-
 [[https://www.google.com][Link to www.google.com]]
-
 [[https://github.com/syl20bnr/spacemacs/blob/master/doc/VIMUSERS.org#sessions]]
-
 [[https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bfun/emoji/README.org][Link to Emoji layer README.org]]
-
-* FOO
-
+* FOO;
+| Key Binding | Description                                |
+|-------------+--------------------------------------------|
+                | ~SPC m d~   | lookup thing at point in lua documentation |
+| ~SPC m s b~ | send buffer contents to REPL               |
+| ~SPC m s f~ | send current function to REPL              |
+| ~SPC m s l~ | send current line to REPL                  |
+| ~SPC m s r~ | send current region to REPL                |
+===========================================================================
+** Org:
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed conseq
-
 * BAR
-
+** SUBBAR 
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed conseq
-
 * BAZ
-
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed conseq
+* FOOBAZ

--- a/core/tools/doc-fmt/toc-org-apply.el
+++ b/core/tools/doc-fmt/toc-org-apply.el
@@ -1,4 +1,0 @@
-(load-file  "./core/tools/doc-fmt/toc-org.el")
-(defun toc-apply ()
-  (toc-org-insert-toc)
-  (save-buffer 0))

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -21,7 +21,7 @@
    - [[#typing-quickly-fd-takes-me-out-of-insert-state-what-is-going-on][Typing quickly =fd= takes me out of =insert state=. What is going on?]]
    - [[#why-do-i-get-files-starting-with-][Why do I get files starting with .#?]]
    - [[#why-do-i-get-4m-characters-inside-ansi-term][Why do I get '4m' characters inside ansi-term?]]
- - [[#how-do-i][How do I...]]
+ - [[#how-do-i][How do I:]]
    - [[#install-a-package-not-provided-by-a-layer][Install a package not provided by a layer?]]
    - [[#disable-a-package-completely][Disable a package completely?]]
    - [[#disable-a-package-only-for-a-specific-major-mode][Disable a package only for a specific major-mode?]]
@@ -207,7 +207,7 @@ the =~/.terminfo= yourself.
 tic -o ~/.terminfo $TERMINFO/e/eterm-color.ti
 #+END_SRC
 
-* How do I...
+* How do I:
 ** Install a package not provided by a layer?
 Spacemacs provides a variable in the =dotspacemacs/layers= function in
 =.spacemacs= called =dotspacemacs-additional-packages=. Just add a package name


### PR DESCRIPTION
### This PR greatly improves [.org file formatting tool](https://github.com/syl20bnr/spacemacs/tree/develop/core/tools/doc-fmt)
 
  - **Upgrade doc-fmt d36487a3accdb976f5e700a512223c1bad91c130**  - This is the real thing now! :muscle: 

    - Add test mode: `{repo-root}/core/tools/doc-fmt/run.bash test`
      applies formatting only to `{repo-root}/core/tools/doc-fmt/test.org`
    - Use `gsed` if present.
    - Add new filters, refactor code.
    - `test.org` now represents most of the .org file formatting errors. 

**It should be able to fix literally anything!**  :smile: 
 Also, when applied, will fix #5626 

---


  - **Change headline "How do I..." -> "How do I: 457adc5a0da4537ab725b672b5a665cca0a717eb**  - It's a more common form. Also it simplifies removal of trailing ",", ";", "." from org headlines.