### PR TITLE
Add keybinding for rotating windows backwards

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -366,7 +366,8 @@
   "wm"  'spacemacs/toggle-maximize-buffer
   "wM"  'spacemacs-centered-buffer-mode
   "wo"  'other-frame
-  "wR"  'spacemacs/rotate-windows
+  "wr"  'spacemacs/rotate-windows
+  "wR"  'spacemacs/rotate-windows-backward
   "ws"  'split-window-below
   "wS"  'split-window-below-and-focus
   "w-"  'split-window-below


### PR DESCRIPTION
I figured since the `<leader>wr` keybinding wasn't used anyways, we could have it execute `rotate-windows` and `<leader>wR` execute `rotate-windows-backward`