### PR TITLE
Use gometalinter if present.

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -23,6 +23,7 @@ This layer adds extensive support for go.
 - gofmt/goimports on file save
 - Auto-completion using [[https://github.com/nsf/gocode/tree/master/emacs][go-autocomplete]] (with the =auto-completion= layer)
 - Source analysis using [[http://golang.org/s/oracle-user-manual][go-oracle]]
+- Linting with flycheck's built-in checkers or flycheck-gometalinter
 
 * Install
 ** Pre-requisites
@@ -34,6 +35,16 @@ You will need =gocode= and =godef=:
   go get -u -v golang.org/x/tools/cmd/oracle
   go get -u -v golang.org/x/tools/cmd/gorename
 #+END_SRC
+
+If you wish to use =gometalinter=:
+
+#+BEGIN_SRC sh
+  go get -u -v github.com/alecthomas/gometalinter
+  gometalinter --install --update
+#+END_SRC
+
+For more information read [[https://github.com/alecthomas/gometalinter/blob/master/README.md][gometalinter README.md]]
+and [[https://github.com/favadi/flycheck-gometalinter/blob/master/README.md][flycheck-gometalinter README.md]]
 
 Make sure that =gocode= executable is in your PATH. For information about
 setting up =$PATH=, check out the corresponding section in the FAQ (~SPC h SPC

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -3,6 +3,7 @@
         company
         company-go
         flycheck
+        flycheck-gometalinter
         go-eldoc
         go-mode
         (go-oracle :location site)
@@ -10,7 +11,22 @@
         ))
 
 (defun go/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'go-mode))
+
+  (spacemacs/add-flycheck-hook 'go-mode)
+
+  (defun spacemacs//go-gometalinter-maybe-enable ()
+    "Enable `flycheck-gometalinter' and disable overlapping `flycheck' linters
+if gometalinter executable is found."
+    (when (executable-find "gometalinter")
+      (setq flycheck-disabled-checkers '(go-gofmt
+                                         go-golint
+                                         go-vet
+                                         go-build
+                                         go-test
+                                         go-errcheck)))
+    (flycheck-gometalinter-setup))
+
+  (add-hook 'go-mode-hook 'spacemacs//go-gometalinter-maybe-enable) t)
 
 (defun go/init-go-mode()
   (when (memq window-system '(mac ns x))
@@ -134,3 +150,7 @@
   (use-package go-rename
     :init
     (spacemacs/set-leader-keys-for-major-mode 'go-mode "rn" 'go-rename)))
+
+(defun go/init-flycheck-gometalinter()
+  (use-package flycheck-gometalinter
+  :defer t))


### PR DESCRIPTION
Use [flycheck-gometalinter](https://github.com/favadi/flycheck-gometalinter) if [gometalinter](https://github.com/alecthomas/gometalinter) is installed.

Solves #5644 Closes #4108

| default*    | gometalinter**  |
|-------------|-----------------|
| go-gofmt    |                 |
| go-golint   | golint          |
| go-vet      | go vet          |
| go-build    |                 |
| go-test     |                 |
| go-errcheck | errcheck        |
|             | go vet --shadow |
|             | gotype          |
|             | deadcode        |
|             | gocyclo         |
|             | varcheck        |
|             | structcheck     |
|             | aligncheck      |
|             | dupl            |
|             | ineffassign     |
|             | interfacer      |
|             | unconvert       |
|             | goconst         |
|             | gosimple        |

*Looks like I managed to disable the overlapping linters. But sometimes different tools (in the gometalinter package) have similar warning/error message.*