### PR TITLE
Org download layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,21 @@ HOME=~/spacemacs emacs
 Note: If you're on Fish shell, you will need to modify the last command to: `env
 HOME=$HOME/spacemacs emacs`
 
+## Installation alongside another configuration
+
+To try out Spacemacs (or any other Emacs configuration you desire) without
+having to go through the trouble of backing up you `~/.emacs.d` directory and
+then cloning the new configuration:
+
+```sh
+mkdir ~/spacemacs
+git clone git@github.com:syl20bnr/spacemacs.git ~/spacemacs/.emacs.d
+HOME=~/spacemacs emacs
+```
+
+Note: If you're on Fish shell, you will need to modify the last command to: `env
+HOME=$HOME/spacemacs emacs`
+
 ## Spacemacs logo
 
 If you are using Ubuntu and Unity then you can add the Spacemacs logo by

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/syl20bnr/spacemacs.png?label=ready&title=Ready)](https://waffle.io/syl20bnr/spacemacs)
 <a name="top"></a>
 <a href="http://spacemacs.org"><img src="https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg" alt="Made with Spacemacs"></a><a href="http://www.twitter.com/spacemacs"><img src="http://i.imgur.com/tXSoThF.png" alt="Twitter" align="right"></a><br>
 ***

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -18,10 +18,7 @@
         helm-company
         helm-c-yasnippet
         hippie-exp
-        ;; using stable package waiting for https://github.com/capitaomorte/yasnippet/issues/673
-        (yasnippet :location (recipe :fetcher github
-                                     :repo "capitaomorte/yasnippet"
-                                     :stable t))
+        yasnippet
         auto-yasnippet
         smartparens
         ))

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -18,7 +18,10 @@
         helm-company
         helm-c-yasnippet
         hippie-exp
-        yasnippet
+        ;; using stable package waiting for https://github.com/capitaomorte/yasnippet/issues/673
+        (yasnippet :location (recipe :fetcher github
+                                     :repo "capitaomorte/yasnippet"
+                                     :stable t))
         auto-yasnippet
         smartparens
         ))

--- a/layers/+tools/org-download/README.org
+++ b/layers/+tools/org-download/README.org
@@ -1,0 +1,24 @@
+#+TITLE: org-download layer
+
+# The maximum height of the logo should be 200 pixels.
+
+* Table of Contents                                        :TOC_4_gh:noexport:
+ - [[#description][Description]]
+ - [[#install][Install]]
+ - [[#key-bindings][Key bindings]]
+
+* Description
+This layer adds org-download support to spacemacs. It allows to drag-and-drop images from your browser or file-system into an org file.
+For further details about the org-download package, have a look at the [[https://github.com/abo-abo/org-download][readme]].
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =org-download= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key bindings
+
+| Key Binding | Description             |
+|-------------+-------------------------|
+| ~SPC m i s~ | org-download-screenshot |
+| ~SPC m i y~ | org-download-yank       |

--- a/layers/+tools/org-download/packages-config.el
+++ b/layers/+tools/org-download/packages-config.el
@@ -1,0 +1,26 @@
+;;; packages-config.el --- org-download layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Laurent Lejeune <olol85@gmail.com>
+;; URL: https://github.com/krakapwa
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;;; Code:
+(defun org-download/init-org-download()
+  (use-package org-download 
+    :config
+    ))
+
+(defun org-download/post-init-org ()
+  (spacemacs/set-leader-keys-for-major-mode 'org-mode
+    "iy" 'org-download-yank
+    "is" 'org-download-screenshot
+    ))
+
+;;; packages-config.el ends here

--- a/layers/+tools/org-download/packages.el
+++ b/layers/+tools/org-download/packages.el
@@ -1,0 +1,22 @@
+;;; packages.el --- org-download layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Laurent Lejeune <olol85@gmail.com>
+;; URL: https://github.com/krakapwa
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;;; Code:
+
+(defconst org-download-packages
+  '(
+    org
+    org-download
+    )
+)
+;;; packages.el ends here


### PR DESCRIPTION
This layer adds org-download support to spacemacs. It allows to drag-and-drop images from your browser or file-system into an org file. You can also insert images straight from gnome-screenshot (or the like).

For further details about the org-download package, have a look at the original package homepage: https://github.com/abo-abo/org-download

I use this for my research: I can quickly copy figures/images/graphs that I find on website or pdf files (with gnome-screenshot) straight into my org document.