### PR TITLE
Allow multiple python test runners and per project test runner.

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -51,12 +51,26 @@ Both =nose= and =pytest= are supported. By default =nose= is used.
 To choose your test runner set the layer variable =python-test-runner= to
 either =nose= or =pytest=.
 
-The root of the project is detected with a =.git= directory or a =setup.cfg= file.
-
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
   '((python :variables python-test-runner 'pytest)))
 #+END_SRC
+
+If you need both then you can set =python-test-runner= to a list like this:
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((python :variables python-test-runner '(pytest nose))))
+#+END_SRC
+
+This means that =pytest= is your primary test runner. To use the secondary test
+runner you can call the test functions with a prefix argument e.g. ~SPC u SPC m
+t t~ to run one test with =nose=.
+
+To set project specific test runners you can set =python-test-runner= in a
+directory local variable in your project root. ~SPC f v d~ in Spacemacs. See
+[[https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html][the official documentation]] for more information.
+
+The root of the project is detected with a =.git= directory or a =setup.cfg= file.
 
 ** Anaconda dependencies
 =anaconda-mode= tries to install the dependencies itself but sometimes
@@ -180,7 +194,8 @@ modules.
 compilation command.
 
 ** Testing
-Test commands start with ~m t~:
+Test commands start with ~m t~. To use the secondary test runner call the
+function with a prefix argument, for example ~SPC u SPC m t a~.
 
 | No Debug    | Description                                              |
 |-------------+----------------------------------------------------------|

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -68,3 +68,71 @@ when this mode is enabled since the minibuffer is cleared all the time."
 (defun spacemacs//python-imenu-create-index-use-semantic ()
   "Use semantic if the layer is enabled."
   (setq imenu-create-index-function 'semantic-create-imenu-index))
+
+(defun python-get-main-testrunner ()
+  "Get the main test runner."
+  (if (listp python-test-runner) (car python-test-runner) python-test-runner))
+
+(defun python-get-secondary-testrunner ()
+  "Get the secondary test runner"
+  (cdr (assoc (python-get-main-testrunner) '((pytest . nose)
+                                             (nose . pytest)))))
+
+(defun python-call-correct-test-function (arg funcalist)
+  "Call a test function based on the chosen test framework.
+ARG is the universal-argument which chooses between the main and
+the secondary test runner. FUNCALIST is an alist of the function
+to be called for each testrunner. "
+  (let ((test-runner (if arg
+                         (python-get-secondary-testrunner)
+                       (python-get-main-testrunner))))
+    (funcall (cdr (assoc test-runner funcalist)))))
+
+(defun python-test-all (arg)
+  "Run all tests."
+  (interactive "P")
+  (python-call-correct-test-function arg '((pytest . pytest-all)
+                                           (nose . nosetests-all))))
+
+(defun python-test-pdb-all (arg)
+  "Run all tests in debug mode."
+  (interactive "P")
+  (python-call-correct-test-function arg '((pytest . pytest-pdb-all)
+                                           (nose . nosetests-pdb-all))))
+
+(defun python-test-module (arg)
+  "Run all tests in the current module."
+  (interactive "P")
+  (python-call-correct-test-function arg '((pytest . pytest-module)
+                                           (nose . nosetests-module))))
+
+(defun python-test-pdb-module (arg)
+  "Run all tests in the current module in debug mode."
+  (interactive "P")
+  (python-call-correct-test-function arg '((pytest . pytest-pdb-module)
+                                           (nose . nosetests-pdb-module))))
+
+(defun python-test-one (arg)
+  "Run current test."
+  (interactive "P")
+  (python-call-correct-test-function arg '((pytest . pytest-one)
+                                           (nose . nosetests-one))))
+
+(defun python-test-pdb-one (arg)
+  "Run current test in debug mode."
+  (interactive "P")
+  (python-call-correct-test-function arg '((pytest . pytest-pdb-one)
+                                           (nose . nosetests-pdb-one))))
+
+(defun spacemacs//bind-python-testing-keys ()
+  "Bind the keys for testing in Python."
+  (spacemacs/set-leader-keys-for-major-mode 'python-mode
+    "tA" 'python-test-pdb-all
+    "ta" 'python-test-all
+    "tB" 'python-test-pdb-module
+    "tb" 'python-test-module
+    "tT" 'python-test-pdb-one
+    "tt" 'python-test-one
+    "tM" 'python-test-pdb-module
+    "tm" 'python-test-module)
+  (spacemacs/declare-prefix-for-mode 'python-mode "mt" "test"))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -126,7 +126,7 @@
 
 (defun python/init-nose ()
   (use-package nose
-    :if (eq 'nose python-test-runner)
+    :if (or (eq 'nose python-test-runner) (member 'nose python-test-runner))
     :commands (nosetests-one
                nosetests-pdb-one
                nosetests-all
@@ -136,17 +136,11 @@
                nosetests-suite
                nosetests-pdb-suite)
     :init
-    (spacemacs/set-leader-keys-for-major-mode 'python-mode
-      "tA" 'nosetests-pdb-all
-      "ta" 'nosetests-all
-      "tB" 'nosetests-pdb-module
-      "tb" 'nosetests-module
-      "tT" 'nosetests-pdb-one
-      "tt" 'nosetests-one
-      "tM" 'nosetests-pdb-module
-      "tm" 'nosetests-module
-      "tS" 'nosetests-pdb-suite
-      "ts" 'nosetests-suite)
+    (progn
+      (spacemacs//bind-python-testing-keys)
+      (spacemacs/set-leader-keys-for-major-mode 'python-mode
+        "tS" 'nosetests-pdb-suite
+        "ts" 'nosetests-suite))
     :config
     (progn
       (add-to-list 'nose-project-root-files "setup.cfg")
@@ -207,7 +201,7 @@
 
 (defun python/init-pytest ()
   (use-package pytest
-    :if (eq 'pytest python-test-runner)
+    :if (or (eq 'pytest python-test-runner) (member 'pytest python-test-runner))
     :defer t
     :commands (pytest-one
                pytest-pdb-one
@@ -215,15 +209,9 @@
                pytest-pdb-all
                pytest-module
                pytest-pdb-module)
-    :init (spacemacs/set-leader-keys-for-major-mode 'python-mode
-            "tA" 'pytest-pdb-all
-            "ta" 'pytest-all
-            "tB" 'pytest-pdb-module
-            "tb" 'pytest-module
-            "tT" 'pytest-pdb-one
-            "tt" 'pytest-one
-            "tM" 'pytest-pdb-module
-            "tm" 'pytest-module)
+    :init
+    (progn
+      (spacemacs//bind-python-testing-keys))
     :config (add-to-list 'pytest-project-root-files "setup.cfg")))
 
 (defun python/init-python ()
@@ -327,7 +315,6 @@
       (spacemacs/declare-prefix-for-mode 'python-mode "md" "debug")
       (spacemacs/declare-prefix-for-mode 'python-mode "mh" "help")
       (spacemacs/declare-prefix-for-mode 'python-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mt" "test")
       (spacemacs/declare-prefix-for-mode 'python-mode "ms" "send to REPL")
       (spacemacs/declare-prefix-for-mode 'python-mode "mr" "refactor")
       (spacemacs/declare-prefix-for-mode 'python-mode "mv" "pyenv")


### PR DESCRIPTION
This allows python-test-runner to also be a list of either `'(nose
pytest)` or `'(pytest nose)` . Dispatch functions call the primary test runner by default unless the prefix argument is set in which case the other test runner is called. 

This also adds documentation about using directory local variables to set this per project.