### PR TITLE
Let counsel-search respect ivy-count-format

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -129,7 +129,7 @@ that directory."
             (or initial-directory
                 (read-directory-name "Start from directory: ")))
       (ivy-read
-       (concat "%-5d "
+       (concat ivy-count-format
                (format "%s from [%s]: "
                        tool
                        (if (< (length counsel--git-grep-dir)


### PR DESCRIPTION
There is no reason to hardcode the formatting string for this search function in particular. Let it be set by a variable, so user can change the ivy-format as they wish.