### PR TITLE
core: update report-issue docs and docstring

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -242,7 +242,9 @@ defer call using `spacemacs-post-user-config-hook'."
 
 (defun spacemacs/report-issue (arg)
   "Browse the page for creating a new Spacemacs issue on GitHub,
-with the message pre-filled with template and information."
+with the message pre-filled with template and information.
+
+With prefix arg also inlcude last pressed keys."
   (interactive "P")
   (let* ((url "http://github.com/syl20bnr/spacemacs/issues/new?body=")
          (template (with-temp-buffer

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1528,10 +1528,11 @@ Navigation key bindings in =help-mode=:
 
 Reporting an issue:
 
-| Key Binding     | Description                                                                          |
-|-----------------+--------------------------------------------------------------------------------------|
-| ~SPC h I~       | Open a page for creating a new Spacemacs issue on GitHub with information pre-filled |
-| ~SPC u SPC h I~ | Open a page for creating a new Spacemacs issue on GitHub with information pre-filled |
+| Key Binding     | Description                                                                              |
+|-----------------+------------------------------------------------------------------------------------------|
+| ~SPC h I~       | Open Spacemacs GitHub issue page with pre-filled information                             |
+| ~SPC u SPC h I~ | Open Spacemacs GitHub issue page with pre-filled information - include last pressed keys |
+
 
 /Note:/ If these two bindings are used with the =*Backtrace*= buffer open, the
 backtrace is automatically included


### PR DESCRIPTION
* core/core-spacemacs.el (spacemacs/report-issue): update docstring
* doc/DOCUMENTATION.org (Reporting Issue table): reword key description
  to keep table width small

Fix #5155