### PR TITLE
Bind `SPC p T` to projectile-test-project

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2836,7 +2836,7 @@ To search in a project see [[Searching in a project][project searching]].
 | ~SPC p R~   | replace a string                                        |
 | ~SPC p s~   | see [[Searching in a project][search in project]]                                   |
 | ~SPC p t~   | open =NeoTree= in =projectile= root                     |
-| ~SPC p T~   | find test files                                         |
+| ~SPC p T~   | test project                                            |
 | ~SPC p v~   | open project root in =vc-dir= or =magit=                |
 | ~SPC p y~   | find tags                                               |
 | ~SPC /~     | search in project with the best search tool available   |

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -492,7 +492,7 @@
                projectile-find-dir
                projectile-find-file
                projectile-find-tag
-               projectile-find-test-file
+               projectile-test-project
                projectile-grep
                projectile-invalidate-cache
                projectile-kill-buffers
@@ -541,7 +541,7 @@
         "pk" 'projectile-kill-buffers
         "po" 'projectile-multi-occur
         "pR" 'projectile-replace
-        "pT" 'projectile-find-test-file
+        "pT" 'projectile-test-project
         "py" 'projectile-find-tag))
     :config
     (progn


### PR DESCRIPTION
The purpose of `projectile-find-test-file` is not obvious and it is not applicable to all languages.

Actually running the tests seems like a more useful and intuitive binding.