### PR TITLE
Org download

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,21 @@ HOME=~/spacemacs emacs
 Note: If you're on Fish shell, you will need to modify the last command to: `env
 HOME=$HOME/spacemacs emacs`
 
+## Installation alongside another configuration
+
+To try out Spacemacs (or any other Emacs configuration you desire) without
+having to go through the trouble of backing up you `~/.emacs.d` directory and
+then cloning the new configuration:
+
+```sh
+mkdir ~/spacemacs
+git clone git@github.com:syl20bnr/spacemacs.git ~/spacemacs/.emacs.d
+HOME=~/spacemacs emacs
+```
+
+Note: If you're on Fish shell, you will need to modify the last command to: `env
+HOME=$HOME/spacemacs emacs`
+
 ## Spacemacs logo
 
 If you are using Ubuntu and Unity then you can add the Spacemacs logo by

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/syl20bnr/spacemacs.png?label=ready&title=Ready)](https://waffle.io/syl20bnr/spacemacs)
 <a name="top"></a>
 <a href="http://spacemacs.org"><img src="https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg" alt="Made with Spacemacs"></a><a href="http://www.twitter.com/spacemacs"><img src="http://i.imgur.com/tXSoThF.png" alt="Twitter" align="right"></a><br>
 ***

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -18,10 +18,7 @@
         helm-company
         helm-c-yasnippet
         hippie-exp
-        ;; using stable package waiting for https://github.com/capitaomorte/yasnippet/issues/673
-        (yasnippet :location (recipe :fetcher github
-                                     :repo "capitaomorte/yasnippet"
-                                     :stable t))
+        yasnippet
         auto-yasnippet
         smartparens
         ))

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -18,7 +18,10 @@
         helm-company
         helm-c-yasnippet
         hippie-exp
-        yasnippet
+        ;; using stable package waiting for https://github.com/capitaomorte/yasnippet/issues/673
+        (yasnippet :location (recipe :fetcher github
+                                     :repo "capitaomorte/yasnippet"
+                                     :stable t))
         auto-yasnippet
         smartparens
         ))

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -29,6 +29,7 @@
    - [[#presentation][Presentation]]
    - [[#org-repo-todo][Org-repo-todo]]
    - [[#org-mime][Org-MIME]]
+   - [[#org-download][Org-download]]
 
 * Description
 This layer enables  [[http://orgmode.org/][org mode]] for Spacemacs.
@@ -39,6 +40,7 @@ This layer enables  [[http://orgmode.org/][org mode]] for Spacemacs.
 - A [[http://pomodorotechnique.com/][pomodoro method]] integration via [[https://github.com/lolownia/org-pomodoro][org-pomodoro]]
 - TODO capture via [[https://github.com/waymondo/org-repo-todo][org-repo-todo]]
 - presentation mode via [[https://github.com/rlister/org-present][org-present]]
+- Insertion of images via [[https://github.com/abo-abo/org-download][org-download]]
 
 ** Important Note
 Since version 0.104, spacemacs uses the =org= version from the org ELPA
@@ -411,3 +413,10 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 |-------------+---------------------------------------------------|
 | ~SPC m M~   | in =message-mode= buffers convert into html email |
 | ~SPC m m~   | send current buffer as HTML email message         |
+
+** Org-download
+
+| Key Binding | Description     |
+|-------------+-----------------|
+| ~SPC m i s~ | Take screenshot |
+| ~SPC m i y~ | Yank image url  |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -31,6 +31,7 @@
     (ox-gfm :location local)
     persp-mode
     (space-doc :location local)
+    org-download
     ))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
@@ -441,6 +442,13 @@ Headline^^            Visit entry^^               Filter^^                    Da
         (setq org-pomodoro-audio-player "/usr/bin/afplay"))
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
         "p" 'org-pomodoro))))
+
+(defun org/init-org-download ()
+  (use-package org-download
+    :init
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode
+        "iy" 'org-download-yank
+        "is" 'org-download-screenshot )))
 
 (defun org/init-org-present ()
   (use-package org-present


### PR DESCRIPTION
Added layer for org-download support. It is a package that allows to drag-and-drop images from a web-browser or file-system into org files. Also, it can be used to insert images straight from gnome-screenshot (or the like). The images are automatically saved into a user-defined folder with timestamps.