### PR TITLE
Only disable semantic-idle-summary in python if anaconda-mode is used.

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -378,8 +378,9 @@
               (add-hook 'python-mode-hook 'py-yapf-enable-on-save))))
 
 (defun python/post-init-semantic ()
-  (add-hook 'python-mode-hook
-            'spacemacs//disable-semantic-idle-summary-mode t)
+  (when (configuration-layer/package-usedp 'anaconda-mode)
+      (add-hook 'python-mode-hook
+                'spacemacs//disable-semantic-idle-summary-mode t))
   (add-hook 'python-mode-hook 'semantic-mode)
   (add-hook 'python-mode-hook 'spacemacs//python-imenu-create-index-use-semantic)
 


### PR DESCRIPTION
Some people have problems with anaconda mode and exclude it. This
enables them to at least have the semantic summary in their modeline.