### PR TITLE
Don't mark request pacakage as built-in.

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -39,9 +39,7 @@
         (process-menu :location built-in)
         projectile
         (recentf :location built-in)
-        ;; request is not a built-in package
-        ;; this is a hack to be able to configure request cache directory.
-        (request :location built-in)
+        request
         restart-emacs
         (savehist :location built-in)
         (saveplace :location built-in)


### PR DESCRIPTION
@syl20bnr Not sure if you only meant this in #5523. 

helm-gitignore seems to work and the request cache is created in .emacs.d/.cache/request for me . I have no idea what the removed comment means.