### PR TITLE
Add org-insert-subheading keybinding

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -233,10 +233,11 @@ You can tweak the bullets displayed in the org buffer in the function
 
 | Key Binding | Description                      |
 |-------------+----------------------------------|
-| ~SPC m h i~ | org-insert-heading-after-current |
-| ~SPC m h I~ | org-insert-heading               |
-| ~SPC m i f~ | org-insert-footnote              |
-| ~SPC m i l~ | org-insert-link                  |
+| ~SPC m h i~   | org-insert-heading-after-current |
+| ~SPC m h I~   | org-insert-heading               |
+| ~SPC m h s~   | org-insert-subheading            |
+| ~SPC m i f~   | org-insert-footnote              |
+| ~SPC m i l~   | org-insert-link                  |
 
 *** Links
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -169,6 +169,7 @@ Will work on both org-mode and any mode that accepts plain html."
         ;; headings
         "hi" 'org-insert-heading-after-current
         "hI" 'org-insert-heading
+        "hs" 'org-insert-subheading
 
         ;; More cycling options (timestamps, headlines, items, properties)
         "L" 'org-shiftright


### PR DESCRIPTION
This commit allows for easy creation of subheadings in orgmode buffers, similar to how headings can be inserted with `SPC m h i`