### PR TITLE
Defer space-doc

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -535,4 +535,5 @@ a Markdown buffer and use this command to convert it.
 
 (defun org/init-space-doc ()
   (use-package space-doc
+    :commands space-doc-mode
     :config (spacemacs|diminish space-doc-mode " ❤" " d")))


### PR DESCRIPTION
`space-doc` currently adds a large chunk of time to initial load time since it has to require `org`.