### PR TITLE
ivy: don't override prefix-help-command

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -315,8 +315,6 @@ Helm hack."
       (counsel-mode 1)
       (spacemacs|hide-lighter counsel-mode)
 
-      ;; Note: Must be set before which-key is loaded.
-      (setq prefix-help-command 'counsel-descbinds)
       ;; TODO: Commands to port
       (spacemacs//ivy-command-not-implemented-yet "jI")
 


### PR DESCRIPTION
Fixes: #5839 

counsel-descbinds is accessible through SPC-?, and shadowing the C-h key
for which key makes pagination impossible. As this deviates from
which-key defaults, this should be up to user to config, not a base in
spacemacs-ivy.