### PR TITLE
Fix broken keybindings in the Rust layer

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -40,9 +40,9 @@
         "cC" 'spacemacs/rust-cargo-clean
         "cc" 'spacemacs/rust-cargo-build
         "cd" 'spacemacs/rust-cargo-doc
-        "cf" 'spacemacs/rust-cargo-fmt))))
+        "cf" 'spacemacs/rust-cargo-fmt
         "ct" 'spacemacs/rust-cargo-test
-        "cx" 'spacemacs/rust-cargo-run
+        "cx" 'spacemacs/rust-cargo-run))))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode


### PR DESCRIPTION
Due to some misplaced parenthesis, the keybindings for `spacemacs/rust-cargo-run` and `spacemacs/rust-cargo-test` were not being evaluated. I've gone ahead and fixed it, so the keybindings should work now.