### PR TITLE
Fixes #5897 - Fix init error for emacs in terminal mode

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -32,7 +32,7 @@ created."
   `(let ((init (cond ((boundp 'ns-initialized) 'ns-initialized)
                      ((boundp 'w32-initialized) 'w32-initialized)
                      ((boundp 'x-initialized) 'x-initialized)
-                     (t 't))))           ; fallback to normal loading behavior
+                     (t (display-graphic-p))))) ; fallback to normal loading behavior only for GUI client
      (if (symbol-value init)
          (progn
            ,@body)


### PR DESCRIPTION
The behavior of loading `vi-tilde-fringe` only for graphical emacs
was removed in d95f9df, and changed to load it after display init.
But the `spacemacs|do-after-display-system-init` macro is no help
to terminal mode emacs.