### PR TITLE
Fix tramp history file path

### DIFF
--- a/layers/+distribution/spacemacs-base/config.el
+++ b/layers/+distribution/spacemacs-base/config.el
@@ -191,7 +191,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
       eval-expression-print-level nil)
 
 ;; cache files
-(setq tramp-persistency-file-name (concat spacemacs-cache-directory "tramp/"))
+(setq tramp-persistency-file-name (concat spacemacs-cache-directory "tramp"))
 
 ;; seems pointless to warn. There's always undo.
 (put 'narrow-to-region 'disabled nil)


### PR DESCRIPTION
The variable 'tramp-persistency-file-name' is supposed to be a filename,
currently it is pointing to a directory which means tramp will not be
able to save and reuse connection information.