### PR TITLE
Diminish setting for visual-line-mode.

### DIFF
--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -48,6 +48,7 @@
         undo-tree
         (uniquify :location built-in)
         (url :location built-in)
+        (visual-line-mode :location built-in)
         (whitespace :location built-in)
         (winner :location built-in)
         ws-butler))
@@ -98,9 +99,11 @@
                dired-jump-other-window
                dired-omit-mode)))
 
-
 (defun spacemacs-base/init-electric-indent-mode ()
   (electric-indent-mode))
+
+(defun spacemacs-base/init-visual-line-mode ()
+  (spacemacs|diminish visual-line-mode " Ⓥ" " V"))
 
 ;; notes from mijoharas
 ;; We currently just set a few variables to make it look nicer.


### PR DESCRIPTION
I'm a heavy user of `visual-line-mode`, and I guess there're lots of users as me who will turn on `visual-line-mode` globally. So I think it's better to set diminish for `visual-line-mode`.

