### PR TITLE
deft: Fix create new file with filter text

### DIFF
--- a/layers/+tools/deft/packages.el
+++ b/layers/+tools/deft/packages.el
@@ -33,6 +33,7 @@
         (evil-insert-state nil)))
     :config
     (progn
+      (setq deft-use-filter-string-for-filename t)
       (spacemacs/set-leader-keys-for-major-mode 'deft-mode
         "d" 'deft-delete-file
         "i" 'deft-toggle-incremental-search


### PR DESCRIPTION
The binding of `SPC m n` calls `deft-new-file`, which only uses the filter text `(when deft-use-filter-string-for-filename)`, which is set to nil originally. So we need to make it true.