### PR TITLE
Reduce gc-cons-threshold after init

### DIFF
--- a/init.el
+++ b/init.el
@@ -12,7 +12,10 @@
 ;; Without this comment emacs25 adds (package-initialize) here
 ;; (package-initialize)
 
+;; increase gc-cons-threshold during init
 (setq gc-cons-threshold 100000000)
+(add-hook 'after-init-hook (lambda () (setq gc-cons-threshold 800000)))
+
 (defconst spacemacs-version         "0.105.19" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.3" "Minimal version of Emacs.")
 


### PR DESCRIPTION
Reset the value of `gc-cons-threshold` after init to improve overall responsiveness.
See https://github.com/syl20bnr/spacemacs/issues/4687