### PR TITLE
Don't switch to error-list window if already on it

### DIFF
--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -85,8 +85,8 @@ If the error list is visible, hide it.  Otherwise, show it."
         "Open and go to the error list buffer."
         (interactive)
         (unless (get-buffer-window (get-buffer flycheck-error-list-buffer))
-          (flycheck-list-errors))
-        (switch-to-buffer-other-window flycheck-error-list-buffer))
+          (flycheck-list-errors)
+          (switch-to-buffer-other-window flycheck-error-list-buffer)))
 
       (evilified-state-evilify-map flycheck-error-list-mode-map
         :mode flycheck-error-list-mode


### PR DESCRIPTION
It seems unnecessary to open the buffer if it's already displayed in the current window, especially because using `switch-to-buffer-other-window` in that case causes `flycheck-error-list-buffer` to be opened in *two* windows.