### PR TITLE
pcre2el is not loaded in `spacemacs-base`

### DIFF
--- a/layers/+completion/spacemacs-ivy/packages.el
+++ b/layers/+completion/spacemacs-ivy/packages.el
@@ -17,6 +17,7 @@
         ;; treat it as a stand-alone package
         (ivy :location built-in)
         (ivy-spacemacs-help :location local)
+        pcre2el
         smex
         swiper
         wgrep))
@@ -513,6 +514,9 @@ perspectives does."
               ("l" spacemacs/ivy-perspectives)
               ("C" spacemacs/ivy-persp-close-other :exit t)
               ("X" spacemacs/ivy-persp-kill-other :exit t))))))
+
+(defun spacemacs-ivy/init-pcre2el ()
+  (use-package pcre2el :defer t))
 
 (defun spacemacs-ivy/init-smex ()
   (use-package smex


### PR DESCRIPTION
pcre2el is not loaded by `spacemacs-base`, but is needed for ivy support.  Should address #5812