### PR TITLE
Add support for fancy frame title (cont'd)

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -119,6 +119,10 @@ of a list then all discovered layers will be installed.")
 Press `SPC T n' to cycle to the next theme in the list (works great
 with 2 themes variants, one dark and one light")
 
+(defvar dotspacemacs-frame-title-format nil
+  "Default format string for a frame title bar, using the
+  original format spec, and additional customizations.")
+
 (defvar dotspacemacs-colorize-cursor-according-to-state t
   "If non nil the cursor color matches the state color in GUI Emacs.")
 
@@ -507,6 +511,51 @@ value."
     (if (file-exists-p dotspacemacs)
         (unless (with-demoted-errors "Error loading .spacemacs: %S" (load dotspacemacs))
           (dotspacemacs/safe-load)))))
+
+(defun spacemacs/frame-title-prepare ()
+  "A string is printed verbatim except for %-constructs.
+  %a -- prints the `abbreviated-file-name', or `buffer-name'
+  %t -- prints `projectile-project-name'
+  %I -- prints `invocation-name'
+  %S -- prints `system-name'
+  %U -- prints contents of $USER
+  %b -- prints buffer name
+  %f -- prints visited file name
+  %F -- prints frame name
+  %s -- prints process status
+  %p -- prints percent of buffer above top of window, or Top, Bot or All
+  %P -- prints percent of buffer above bottom of window, perhaps plus Top, or
+  print Bottom or All
+  %m -- prints mode name
+  %n -- prints Narrow if appropriate
+  %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
+  %Z -- like %z, but including the end-of-line format"
+  (let* ((fs (format-spec-make
+              ?a (abbreviate-file-name (or (buffer-file-name) (buffer-name))) 
+              ?t (if (boundp 'projectile-mode) (projectile-project-name) "-")
+              ?S system-name
+              ?I invocation-name
+              ?U (or (getenv "USER") "")
+              ?b "%b"
+              ?f "%f"
+              ?F "%F"
+              ?* "%*"
+              ?+ "%+"
+              ?s "%s"
+              ?l "%l"
+              ?c "%c"
+              ?p "%p"
+              ?P "%P"
+              ?m "%m"
+              ?n "%n"
+              ?z "%z"
+              ?Z "%Z"
+              ?[ "%["
+              ?] "%]"
+              ?% "%%"
+              ?- "%-"
+              )))
+    (format-spec dotspacemacs-frame-title-format fs)))
 
 (defun dotspacemacs/safe-load ()
   "Error recovery from malformed .spacemacs.

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -82,6 +82,9 @@ the final step of executing code in `emacs-startup-hook'.")
   (setq dotspacemacs-editing-style (dotspacemacs//read-editing-style-config
                                     dotspacemacs-editing-style))
   (configuration-layer/initialize)
+  ;; frame title init
+  (when (and (display-graphic-p) dotspacemacs-frame-title-format)
+    (setq frame-title-format '((:eval (spacemacs/frame-title-prepare)))))
   ;; default theme
   (let ((default-theme (car dotspacemacs-themes)))
     (spacemacs/load-theme default-theme)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -250,6 +250,8 @@ values."
    ;; specified with an installed package.
    ;; Not used for now. (default nil)
    dotspacemacs-default-package-repository nil
+   ;; Format specification for setting the frame title.
+   dotspacemacs-frame-title-format "%I@%S"
    ;; Delete whitespace while saving buffer. Possible values are `all'
    ;; to aggressively delete empty line and long sequences of whitespace,
    ;; `trailing' to delete only the whitespace at end of lines, `changed'to


### PR DESCRIPTION
Dear contributors,

I would like to re-submit the change by @usharf from pull request #2299 (originating in #2139) for merging into current `develop`. I've rebased the change and resolved the merge conflicts. Unfortunately `develop` is non functional for me at the moment so I could only test the change on `master` where it works like a charm.

The change introduces the possibility to configure the formatting and contents of frame titles. By doing this users can now customize frame titles to contain for example the names of the currently active buffer or project. The default behauvior remains unchanged. Therefore the frame title will be formatted as `user@hostname` if the user does not customize this setting.

Thank you very much in advance

Best regards
Christoph
