### PR TITLE
spacemacs/layers/+lang/latex/README.org typo

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -136,7 +136,7 @@ is nil.
 | ~SPC m x f u~ | use upright font                           |
 
 ** Folding
-Available only when =latex-enable-auto-fill= is non nil.
+Available only when =latex-enable-folding= is non nil.
 
 | Key Binding | Description          |
 |-------------+----------------------|


### PR DESCRIPTION
Docs: Folding keybindings are enabled by `latex-enable-folding`
I just noticed this (i think) typo.
If it isn't a typo, then why are folding keybindings controlled by `latex-enable-auto-fill`?