### PR TITLE
Make pug files use jade-mode since jade is now called pug

### DIFF
--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -18,7 +18,7 @@ This layer adds support for editing HTML and CSS.
 - Support for Sass/Scss and Less files
 - Generate HTML and CSS coding using [[https://github.com/smihica/emmet-mode][emmet-mode]]
 - Tags navigation on key ~%~ using [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
-- Support for editing Slim and Jade templates using [[https://github.com/slim-template/emacs-slim][slim-mode]]
+- Support for editing Slim and Jade/Pug templates using [[https://github.com/slim-template/emacs-slim][slim-mode]]
   and [[https://github.com/brianc/jade-mode][jade-mode]]
 
 * Install

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -128,6 +128,8 @@
 (defun html/init-jade-mode ()
   (use-package jade-mode
     :defer t
+    :mode
+    ("\\.pug$" . jade-mode)
     :init
     ;; Explicitly run prog-mode hooks since jade-mode does not derivate from
     ;; prog-mode major-mode


### PR DESCRIPTION
Jade was renamed to pug -- we can't just yank jade support yet -- but the language itself hasn't changed -- so add .pug to the mode list 