### PR TITLE
add C and C++ mode support in gtags layer

### DIFF
--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -40,6 +40,7 @@
         (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'compilation-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode)
+        (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode)
 
         (spacemacs/ggtags-enable-eldoc 'tcl-mode)
         (spacemacs/ggtags-enable-eldoc 'java-mode)

--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -40,6 +40,7 @@
         (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'compilation-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode)
+        (spacemacs/helm-gtags-define-keys-for-mode 'c-mode)
         (spacemacs/helm-gtags-define-keys-for-mode 'c++-mode)
 
         (spacemacs/ggtags-enable-eldoc 'tcl-mode)


### PR DESCRIPTION
GTags works nice for both C and C++ modes.
