### PR TITLE
Adds company-ghci to haskell layer

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -15,6 +15,7 @@
     company
     company-cabal
     company-ghc
+    company-ghci
     flycheck
     flycheck-haskell
     ghc
@@ -325,7 +326,7 @@
       :init
       (push (if haskell-enable-ghc-mod-support
                 '(company-ghc company-dabbrev-code company-yasnippet)
-              '(company-dabbrev-code company-yasnippet))
+              '(company-ghci company-dabbrev-code company-yasnippet))
               company-backends-haskell-mode)))
 
   (defun haskell/init-company-cabal ()


### PR DESCRIPTION
Aloha

I added company-ghci code completion to the haskell layer.

History: it used to be that we needed ghc-mod to do things like code completion.  These days with ghc 7.10 we can just ask ghci for this information (IIRC it works with ghci-ng too for older versions of ghc).

-Tim