### PR TITLE
core: add another code folding method using origami to spacemacs-editing

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -166,6 +166,9 @@ if used there.")
 (defvar dotspacemacs-ex-substitute-global nil
   "If non nil, inverse the meaning of `g' in `:substitute' Evil ex-command.")
 
+(defvar dotspacemacs-folding-method 'evil
+  "Code folding method. Possible values are `evil' and `origami'.")
+
 (defvar dotspacemacs-default-layout-name "Default"
   " Name of the default layout.")
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -21,6 +21,7 @@
         link-hint
         lorem-ipsum
         move-text
+        origami
         pcre2el
         smartparens
         uuidgen))
@@ -203,6 +204,77 @@
     (spacemacs/set-leader-keys
       "xJ" 'spacemacs/move-text-transient-state/move-text-down
       "xK" 'spacemacs/move-text-transient-state/move-text-up)))
+
+(defun spacemacs-editing/init-origami ()
+  (use-package origami
+    :defer t
+    :init
+    (progn
+      (pcase dotspacemacs-folding-method
+        (`origami
+         (progn
+           (global-origami-mode)
+           (define-key evil-normal-state-map "za" 'origami-forward-toggle-node)
+           (define-key evil-normal-state-map "zc" 'origami-close-node)
+           (define-key evil-normal-state-map "zC" 'origami-close-node-recursively)
+           (define-key evil-normal-state-map "zO" 'origami-open-node-recursively)
+           (define-key evil-normal-state-map "zo" 'origami-open-node)
+           (define-key evil-normal-state-map "zr" 'origami-open-all-nodes)
+           (define-key evil-normal-state-map "zm" 'origami-close-all-nodes)
+           (define-key evil-normal-state-map "zs" 'origami-show-only-node)
+           (define-key evil-normal-state-map "zn" 'origami-next-fold)
+           (define-key evil-normal-state-map "zp" 'origami-previous-fold)
+           (define-key evil-normal-state-map "zR" 'origami-reset)
+           (define-key evil-normal-state-map (kbd "z <tab>") 'origami-recursively-toggle-node)
+           (define-key evil-normal-state-map (kbd "z TAB") 'origami-recursively-toggle-node))
+
+         (spacemacs|define-transient-state fold
+           :title "Code Fold Transient State"
+           :doc "
+Close^^                Open^^                 Toggle^^                 Goto^^                   Other^^
+───────^^────────────  ─────^^──────────────  ─────^^───────────────── ──────^^──────────────── ─────^^──────────────────────────
+[_c_] at point         [_o_] at point         [_a_] first after point  [_n_] next               [_s_] show at point, close others
+[_C_] recursively      [_O_] recursively      [_A_] all                [_p_] previous           [_R_] reset
+[_m_] all              [_r_] all              [_TAB_] all (like org)   ^^                       [_q_] quit"
+           :foreign-keys run
+           :on-enter (unless (bound-and-true-p origami-mode) (origami-mode 1))
+           :bindings
+           ("a" origami-forward-toggle-node)
+           ("A" origami-toggle-all-nodes)
+           ("c" origami-close-node)
+           ("C" origami-close-node-recursively)
+           ("o" origami-open-node)
+           ("O" origami-open-node-recursively)
+           ("r" origami-open-all-nodes)
+           ("m" origami-close-all-nodes)
+           ("n" origami-next-fold)
+           ("p" origami-previous-fold)
+           ("s" origami-show-only-node)
+           ("R" origami-reset)
+           ("TAB" origami-recursively-toggle-node)
+           ("<tab>" origami-recursively-toggle-node)
+           ("q" nil :exit t)))
+
+        (`evil
+          (spacemacs|define-transient-state fold
+           :title "Code Fold Transient State"
+           :doc "
+Close^^                Open^^                 Toggle^^                  Other^^
+───────^^────────────  ─────^^──────────────  ─────^^─────────────────  ─────^^───
+[_c_] at point         [_o_] at point         [_a_] around point        [_q_] quit
+^^                     [_O_] recursively      ^^
+[_m_] all              [_r_] all"
+           :foreign-keys run
+           :bindings
+           ("a" evil-toggle-fold)
+           ("c" evil-close-fold)
+           ("o" evil-open-fold)
+           ("O" evil-open-fold-rec)
+           ("r" evil-open-folds)
+           ("m" evil-close-folds)
+           ("q" nil :exit t))))
+
+      (spacemacs/set-leader-keys "z." 'spacemacs/fold-transient-state/body))))
 
 (defun spacemacs-editing/init-pcre2el ()
   (use-package pcre2el

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -231,11 +231,11 @@
          (spacemacs|define-transient-state fold
            :title "Code Fold Transient State"
            :doc "
-Close^^                Open^^                 Toggle^^                 Goto^^                   Other^^
-───────^^────────────  ─────^^──────────────  ─────^^───────────────── ──────^^──────────────── ─────^^──────────────────────────
-[_c_] at point         [_o_] at point         [_a_] first after point  [_n_] next               [_s_] show at point, close others
-[_C_] recursively      [_O_] recursively      [_A_] all                [_p_] previous           [_R_] reset
-[_m_] all              [_r_] all              [_TAB_] all (like org)   ^^                       [_q_] quit"
+Close^^            Open^^             Toggle^^         Goto^^         Other^^
+───────^^───────── ─────^^─────────── ─────^^───────── ──────^^────── ─────^^─────────
+[_c_] at point     [_o_] at point     [_a_] at point   [_n_] next     [_s_] single out
+[_C_] recursively  [_O_] recursively  [_A_] all        [_p_] previous [_R_] reset
+[_m_] all          [_r_] all          [_TAB_] like org ^^             [_q_] quit"
            :foreign-keys run
            :on-enter (unless (bound-and-true-p origami-mode) (origami-mode 1))
            :bindings
@@ -253,17 +253,19 @@ Close^^                Open^^                 Toggle^^                 Goto^^   
            ("R" origami-reset)
            ("TAB" origami-recursively-toggle-node)
            ("<tab>" origami-recursively-toggle-node)
-           ("q" nil :exit t)))
+           ("q" nil :exit t)
+           ("C-g" nil :exit t)
+           ("<SPC>" nil :exit t)))
 
         (`evil
           (spacemacs|define-transient-state fold
            :title "Code Fold Transient State"
            :doc "
-Close^^                Open^^                 Toggle^^                  Other^^
-───────^^────────────  ─────^^──────────────  ─────^^─────────────────  ─────^^───
-[_c_] at point         [_o_] at point         [_a_] around point        [_q_] quit
-^^                     [_O_] recursively      ^^
-[_m_] all              [_r_] all"
+Close^^          Open^^              Toggle^^             Other^^
+───────^^──────  ─────^^───────────  ─────^^────────────  ─────^^───
+[_c_] at point   [_o_] at point      [_a_] around point   [_q_] quit
+^^               [_O_] recursively   ^^
+[_m_] all        [_r_] all"
            :foreign-keys run
            :bindings
            ("a" evil-toggle-fold)
@@ -272,7 +274,9 @@ Close^^                Open^^                 Toggle^^                  Other^^
            ("O" evil-open-fold-rec)
            ("r" evil-open-folds)
            ("m" evil-close-folds)
-           ("q" nil :exit t))))
+           ("q" nil :exit t)
+           ("C-g" nil :exit t)
+           ("<SPC>" nil :exit t))))
 
       (spacemacs/set-leader-keys "z." 'spacemacs/fold-transient-state/body))))
 


### PR DESCRIPTION
While working on some heavily nested JSON data(works with other major modes as well), I was finding evil fold capabilities quite limiting. Hence I looked at other folding packages and found [origami](https://github.com/gregsexton/origami.el) to be much nicer. I've configured it since then and thought of sharing it here.  I'm mostly using `TAB` a lot to show/hide like org does for nested structure. Let me know the feedback if it's useful or needs improvement or trash it if it's not helpful! 

Functionality is [documented](https://github.com/gregsexton/origami.el#what-can-it-do) on origami repo nicely. Do check it out. 

To keep it consistent with evil-fold commands, I remap them to substituting origami commands when new dotspacemacs variable `dotspacemacs-folding-method` is set to `origami`. Code folding transient state is available on `SPC z .`

Demos:
![origami-demo](https://cloud.githubusercontent.com/assets/542810/14930524/1bee30ca-0e82-11e6-97bb-244b618b173b.gif)


![origami-demo-2](https://cloud.githubusercontent.com/assets/542810/14930532/3478a04e-0e82-11e6-8959-7d262a5d5df5.gif)

* layers/+spacemacs/spacemacs-editing/packages.el (spacemacs-editing/init-origami):
  add origami package and initialize it
* core/core-dotspacemacs.el (dotspacemacs-override-evil-folding): new variable to allow choosing between different code folding methods. Currently supported `evil` and `origami`