### PR TITLE
Set cscope key bindings to 'SPC m c'

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -131,7 +131,7 @@
   (spacemacs|use-package-add-hook xcscope
     :post-init
     (dolist (mode '(c-mode c++-mode))
-      (spacemacs/set-leader-keys-for-major-mode mode "gi" 'cscope-index-files))))
+      (spacemacs/set-leader-keys-for-major-mode mode "ci" 'cscope-index-files))))
 
 (when (configuration-layer/layer-usedp 'spacemacs-helm)
   (defun c-c++/pre-init-helm-cscope ()

--- a/layers/+tags/cscope/README.org
+++ b/layers/+tags/cscope/README.org
@@ -54,18 +54,18 @@ pip install pycscope
 * Usage
 Before using any helm-cscope commands, remember to create a Cscope index file.
 Do it by running the command =cscope-index-files= for C and C++ projects, or the
-command =cscope/run-pycscope= for Python projects, bound to ~SPC m g i~.
+command =cscope/run-pycscope= for Python projects, bound to ~SPC m c i~.
 
 * Key bindings
 
 | Key Binding | Description                                   |
 |-------------+-----------------------------------------------|
-| ~SPC m g c~ | find which functions are called by a function |
-| ~SPC m g C~ | find where a function is called               |
-| ~SPC m g d~ | find global definition of a symbol            |
-| ~SPC m g e~ | search regular expression                     |
-| ~SPC m g f~ | find a file                                   |
-| ~SPC m g F~ | find which files include a file               |
-| ~SPC m g i~ | create Cscope index                           |
-| ~SPC m g r~ | find references of a symbol                   |
-| ~SPC m g x~ | search text                                   |
+| ~SPC m c c~ | find which functions are called by a function |
+| ~SPC m c C~ | find where a function is called               |
+| ~SPC m c d~ | find global definition of a symbol            |
+| ~SPC m c e~ | search regular expression                     |
+| ~SPC m c f~ | find a file                                   |
+| ~SPC m c F~ | find which files include a file               |
+| ~SPC m c i~ | create Cscope index                           |
+| ~SPC m c r~ | find references of a symbol                   |
+| ~SPC m c x~ | search text                                   |

--- a/layers/+tags/cscope/packages.el
+++ b/layers/+tags/cscope/packages.el
@@ -45,14 +45,14 @@
       (defun spacemacs/setup-helm-cscope (mode)
         "Setup `helm-cscope' for MODE"
         (spacemacs/set-leader-keys-for-major-mode mode
-          "gc" 'helm-cscope-find-called-function
-          "gC" 'helm-cscope-find-calling-this-funtcion
-          "gd" 'helm-cscope-find-global-definition
-          "ge" 'helm-cscope-find-egrep-pattern
-          "gf" 'helm-cscope-find-this-file
-          "gF" 'helm-cscope-find-files-including-file
-          "gr" 'helm-cscope-find-this-symbol
-          "gx" 'helm-cscope-find-this-text-string))
+          "cc" 'helm-cscope-find-called-function
+          "cC" 'helm-cscope-find-calling-this-funtcion
+          "cd" 'helm-cscope-find-global-definition
+          "ce" 'helm-cscope-find-egrep-pattern
+          "cf" 'helm-cscope-find-this-file
+          "cF" 'helm-cscope-find-files-including-file
+          "cr" 'helm-cscope-find-this-symbol
+          "cx" 'helm-cscope-find-this-text-string))
       :config
       (defadvice helm-cscope-find-this-symbol (before cscope/goto activate)
         (evil--jumps-push)))))


### PR DESCRIPTION
As per issue [5891](https://github.com/syl20bnr/spacemacs/issues/5891), this PR maps `cscope` keybindings for major mode to `SPC m c` from `SPC m g` to avoid the keybindings for the two layers,  `cscope` and `gtags`, tramping on each other when both are enabled
