### PR TITLE
Fixes #5925 - layouts: don't double activate persp-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -108,8 +108,11 @@
             persp-reset-windows-on-nil-window-conf nil
             persp-set-last-persp-for-new-frames nil
             persp-save-dir spacemacs-layouts-directory)
-      ;; always activate persp-mode
-      (persp-mode)
+      ;; always activate persp-mode, unless it is already active (e.g. don't
+      ;; re-activate during `dotspacemacs/sync-configuration-layers' - see
+      ;; issues #5925 and #3875)
+      (unless (bound-and-true-p persp-mode)
+        (persp-mode))
       ;; layouts transient state
       (spacemacs|transient-state-format-hint layouts
         spacemacs--layouts-ts-full-hint


### PR DESCRIPTION
If `persp-mode` is already activated, don't re-activate it. Should fix bug where running `dotspacemacs/sync-configuration-layers` (<kbd>SPC f e R</kbd>) resets all the layouts.
I didn't test it thoroughly, but it seems ok.

Ref: #5925 #3875 
CC participants of those discussions: @hedning @dsdshcym @d12frosted @AlejandroCatalina 