### PR TITLE
Better spacemacs/dump-vars-to-file and shorter startup time

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -86,17 +86,12 @@ and its values are removed."
       (push (pop tail) result))
     (nreverse result)))
 
-;; From http://stackoverflow.com/questions/2321904/elisp-how-to-save-data-in-a-file
+;; Originally based on http://stackoverflow.com/questions/2321904/elisp-how-to-save-data-in-a-file
 (defun spacemacs/dump-vars-to-file (varlist filename)
   "simplistic dumping of variables in VARLIST to a file FILENAME"
-  (save-excursion
-    (let ((buf (find-file-noselect filename)))
-      (set-buffer buf)
-      (erase-buffer)
-      (spacemacs/dump varlist buf)
-      (make-directory (file-name-directory filename) t)
-      (save-buffer)
-      (kill-buffer))))
+  (with-temp-file filename
+    (spacemacs/dump varlist (current-buffer))
+    (make-directory (file-name-directory filename) t)))
 
 ;; From http://stackoverflow.com/questions/2321904/elisp-how-to-save-data-in-a-file
 (defun spacemacs/dump (varlist buffer)


### PR DESCRIPTION
Visiting the dump file before writing to it is slow, because it triggers all the regular actions that happen when a user opens a file, e.g. enable major mode and minor modes. We don't need all that, `with-temp-file` is what we really want.

This rewrite of `spacemacs/dump-vars-to-file` removes the startup lag reported by @zilongshanren in #5958.