### PR TITLE
Defer loading of persp mode until after user-config

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -108,11 +108,15 @@
             persp-reset-windows-on-nil-window-conf nil
             persp-set-last-persp-for-new-frames nil
             persp-save-dir spacemacs-layouts-directory)
-      ;; always activate persp-mode, unless it is already active (e.g. don't
-      ;; re-activate during `dotspacemacs/sync-configuration-layers' - see
-      ;; issues #5925 and #3875)
-      (unless (bound-and-true-p persp-mode)
-        (persp-mode))
+
+      (defun spacemacs//activate-persp-mode ()
+        "Always activate persp-mode, unless it is already active.
+ (e.g. don't re-activate during `dotspacemacs/sync-configuration-layers' -
+ see issues #5925 and #3875)"
+        (unless (bound-and-true-p persp-mode)
+          (persp-mode)))
+      (spacemacs/defer-until-after-user-config #'spacemacs//activate-persp-mode)
+
       ;; layouts transient state
       (spacemacs|transient-state-format-hint layouts
         spacemacs--layouts-ts-full-hint


### PR DESCRIPTION
This should fix #3881

Tested it with `(add-hook 'python-mode-hook 'highlight-indentation-mode)` in my `user-config`