### PR TITLE
Set flycheck error severity

### DIFF
--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -58,16 +58,19 @@
                   #b00000000)))
 
       (flycheck-define-error-level 'error
+ 	:severity 2
         :overlay-category 'flycheck-error-overlay
         :fringe-bitmap 'my-flycheck-fringe-indicator
         :fringe-face 'flycheck-fringe-error)
 
       (flycheck-define-error-level 'warning
+	:severity 1
         :overlay-category 'flycheck-warning-overlay
         :fringe-bitmap 'my-flycheck-fringe-indicator
         :fringe-face 'flycheck-fringe-warning)
 
       (flycheck-define-error-level 'info
+	:severity 0
         :overlay-category 'flycheck-info-overlay
         :fringe-bitmap 'my-flycheck-fringe-indicator
         :fringe-face 'flycheck-fringe-info)


### PR DESCRIPTION

This fixes the bug when errors are not being filtered in error list or
`flycheck-navigation-minimum-level` is not taken into account.