### PR TITLE
fix #5951

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -38,6 +38,13 @@ You will need =gocode= and =godef=:
 #+END_SRC
 
 If you wish to use =gometalinter=:
+set the value of =go-use-gometalinter=
+
+#+begin_src emacs-lisp
+  (go :variables go-use-gometalinter t)
+#+end_src
+
+ and install the tool:
 
 #+BEGIN_SRC sh
   go get -u -v github.com/alecthomas/gometalinter

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -18,3 +18,6 @@
 
 (defvar go-tab-width 8
   "Set the `tab-width' in Go mode. Default is 8.")
+
+(defvar go-use-gometalinter nil
+  "Use gometalinter if the variable has non-nil value.")

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -3,7 +3,7 @@
         company
         company-go
         flycheck
-        (flycheck-gometalinter :toggle (executable-find "gometalinter"))
+        (flycheck-gometalinter :toggle go-use-gometalinter)
         go-eldoc
         go-mode
         (go-oracle :location site)


### PR DESCRIPTION
[Add var go-use-gometalinter](https://github.com/syl20bnr/spacemacs/compare/develop...JAremko:issues-5951-1#diff-259d6d865b8b60e83481365b00d8064eR22)

I think it's better way to handle gometalinter all around. It's a command-line tool first of all. Really powerful one, but also heavy. I'm pretty sure that there is someone who would prefer running it from the command-line since it might make old machines unresponsive. But it's @syl20bnr call for sure.