### PR TITLE
Fix #5953, pcre2el should be a post-init in spacemacs-editing.

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -17,7 +17,6 @@
         ivy
         (ivy-spacemacs-help :location local)
         ;; Why do we need this ?
-        pcre2el
         projectile
         smex
         swiper
@@ -127,10 +126,6 @@
               ("X" spacemacs/ivy-persp-kill-other :exit t)))
       ;; Why do we do this ?
       (ido-mode -1))))
-
-;; Why do we need this ?
-(defun ivy/init-pcre2el ()
-  (use-package pcre2el :defer t))
 
 (defun ivy/post-init-projectile ()
   (setq projectile-completion-system 'ivy)

--- a/layers/+distribution/spacemacs-base/packages.el
+++ b/layers/+distribution/spacemacs-base/packages.el
@@ -28,6 +28,7 @@
         (hybrid-mode :location local :step pre)
         nlinum
         (package-menu :location built-in)
+        pcre2el
         (process-menu :location built-in)
         (recentf :location built-in)
         (savehist :location built-in)
@@ -199,6 +200,10 @@
 (defun spacemacs-base/init-package-menu ()
   (evilified-state-evilify-map package-menu-mode-map
     :mode package-menu-mode))
+
+(defun spacemacs-base/init-pcre2el ()
+  (use-package pcre2el
+    :defer t))
 
 (defun spacemacs-base/init-process-menu ()
   (evilified-state-evilify process-menu-mode process-menu-mode-map))

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -206,30 +206,26 @@
       "xJ" 'spacemacs/move-text-transient-state/move-text-down
       "xK" 'spacemacs/move-text-transient-state/move-text-up)))
 
-(defun spacemacs-editing/init-pcre2el ()
-  (use-package pcre2el
-    :defer t
-    :init
-    (progn
-      (spacemacs/declare-prefix "R" "pcre2el")
-      (spacemacs/set-leader-keys
-        "R/"  'rxt-explain
-        "Rc"  'rxt-convert-syntax
-        "Rx"  'rxt-convert-to-rx
-        "R'"  'rxt-convert-to-strings
-        "Rpe" 'rxt-pcre-to-elisp
-        "R%"  'pcre-query-replace-regexp
-        "Rpx" 'rxt-pcre-to-rx
-        "Rps" 'rxt-pcre-to-sre
-        "Rp'" 'rxt-pcre-to-strings
-        "Rp/" 'rxt-explain-pcre
-        "Re/" 'rxt-explain-elisp
-        "Rep" 'rxt-elisp-to-pcre
-        "Rex" 'rxt-elisp-to-rx
-        "Res" 'rxt-elisp-to-sre
-        "Re'" 'rxt-elisp-to-strings
-        "Ret" 'rxt-toggle-elisp-rx
-        "Rt"  'rxt-toggle-elisp-rx))))
+(defun spacemacs-editing/post-init-pcre2el ()
+  (spacemacs/declare-prefix "R" "pcre2el")
+  (spacemacs/set-leader-keys
+    "R/"  'rxt-explain
+    "Rc"  'rxt-convert-syntax
+    "Rx"  'rxt-convert-to-rx
+    "R'"  'rxt-convert-to-strings
+    "Rpe" 'rxt-pcre-to-elisp
+    "R%"  'pcre-query-replace-regexp
+    "Rpx" 'rxt-pcre-to-rx
+    "Rps" 'rxt-pcre-to-sre
+    "Rp'" 'rxt-pcre-to-strings
+    "Rp/" 'rxt-explain-pcre
+    "Re/" 'rxt-explain-elisp
+    "Rep" 'rxt-elisp-to-pcre
+    "Rex" 'rxt-elisp-to-rx
+    "Res" 'rxt-elisp-to-sre
+    "Re'" 'rxt-elisp-to-strings
+    "Ret" 'rxt-toggle-elisp-rx
+    "Rt"  'rxt-toggle-elisp-rx))
 
 (defun spacemacs-editing/init-smartparens ()
   (use-package smartparens


### PR DESCRIPTION
This gets rid of the warning on load.  spacemacs-base will always be loaded, regardless of the distribution used.  Call in spacemacs-editing will add keybindings.