### PR TITLE
Call python-setup-shell only once, not from hook

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -262,9 +262,9 @@
         (setq indent-tabs-mode t))
 
       (add-hook 'inferior-python-mode-hook #'inferior-python-setup-hook)
-      (spacemacs/add-all-to-hook 'python-mode-hook
-                                 'python-default
-                                 'python-setup-shell))
+      (add-hook 'python-mode-hook #'python-default)
+      ;; call `python-setup-shell' once, don't put it in a hook (see issue #5988)
+      (python-setup-shell))
     :config
     (progn
       (add-hook 'inferior-python-mode-hook 'smartparens-mode)


### PR DESCRIPTION
`python-setup-shell` should only be called once. Fixes #5988.