### PR TITLE
Fix #5966, slime-eval-last-sexp is not defined

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -59,7 +59,7 @@
         "eb" 'slime-eval-buffer
         "ef" 'slime-eval-defun
         "eF" 'slime-undefine-function
-        "ee" 'slime-eval-last-sexp
+        "ee" 'slime-eval-last-expression
         "er" 'slime-eval-region
 
         "gg" 'slime-inspect-definition


### PR DESCRIPTION
I don't know if i am right to change it to slime-eval-last-expression, there is also an eval-last-sexp.