### PR TITLE
Prevent warnings when toggles are turned on

### DIFF
--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -82,7 +82,7 @@ used."
                  (progn ,@off-body
                         (message ,(format "%s disabled." name)))
                ,@on-body
-               (message ,(or on-message `(format "%s enabled." name))))
+               (message ,(or on-message (format "%s enabled." name))))
            (message "This toggle is not supported.")))
        ;; Only define on- or off-functions when status is available
        ,@(when status


### PR DESCRIPTION
A recent commit introduced a warning when toggles are turned on. This is due to improper quoting in the `spacemacs|add-toggle` macro, which I've corrected here.