### PR TITLE
Disable vim-empty-lines for which-key buffer

### DIFF
--- a/layers/+vim/vim-empty-lines/packages.el
+++ b/layers/+vim/vim-empty-lines/packages.el
@@ -8,11 +8,12 @@
   (use-package vim-empty-lines-mode
     :diminish vim-empty-lines-mode
     :init
-    (spacemacs/add-to-hooks (lambda () (vim-empty-lines-mode -1)) '(comint-mode-hook
-                                                                    eshell-mode-hook
-                                                                    eww-mode-hook
-                                                                    shell-mode-hook
-                                                                    term-mode-hook))
+    (spacemacs/add-to-hooks (lambda () (vim-empty-lines-mode -1))
+                            '(comint-mode-hook
+                              eshell-mode-hook
+                              eww-mode-hook
+                              shell-mode-hook
+                              term-mode-hook))
     :config
     (progn
       (global-vim-empty-lines-mode)
@@ -23,9 +24,10 @@
         :documentation
         "Display an overlay of ~ on empty lines."
         :evil-leader "t~")
-      ;; don't enable it on spacemacs home buffer
-      (with-current-buffer  "*spacemacs*"
-        (vim-empty-lines-mode -1))
+      ;; Don't enable it where it is detrimental.
+      (with-current-buffer "*spacemacs*" (vim-empty-lines-mode -1))
+      (with-current-buffer "*Messages*" (vim-empty-lines-mode -1))
+      (with-current-buffer which-key--buffer (vim-empty-lines-mode -1))
       ;; after a major mode is loaded, check if the buffer is read only
       ;; if so, disable vim-empty-lines-mode
       (add-hook 'after-change-major-mode-hook (lambda ()


### PR DESCRIPTION
Applies the fix for [this](https://github.com/justbur/emacs-which-key/issues/121) issue to spacemacs. Disables vim-empty-lines in which-key buffers.