### PR TITLE
Add Darkokai theme to themes-megapack

### DIFF
--- a/layers/+themes/themes-megapack/packages.el
+++ b/layers/+themes/themes-megapack/packages.el
@@ -32,6 +32,7 @@
     dakrone-theme
     darkburn-theme
     darkmine-theme
+    darkokai-theme
     darktooth-theme
     django-theme
     dracula-theme


### PR DESCRIPTION
Add the new[ Darkokai theme](https://github.com/sjrmanning/darkokai) to themes-megapack.
The theme was added to MELPA today.

I feel that it's different enough from the proliferation of other Monokai-inspired themes to merit inclusion in the layer.