### PR TITLE
Layouts: graphical/terminal frames should have different workspaces

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -492,16 +492,52 @@ STATE is a window-state object as returned by `window-state-get'."
 
 ;; Eyebrowse and Persp integration
 
+(defun spacemacs//get-persp-workspace (&optional persp frame)
+  "Get the correct workspace parameters for perspective.
+PERSP is the perspective, and defaults to the current perspective.
+FRAME is the frame where the parameters are expected to be used, and
+defaults to the current frame."
+  (let ((param-names (if (display-graphic-p frame)
+                         '(gui-eyebrowse-window-configs
+                           gui-eyebrowse-current-slot
+                           gui-eyebrowse-last-slot)
+                       '(term-eyebrowse-window-configs
+                         term-eyebrowse-current-slot
+                         term-eyebrowse-last-slot))))
+    (--map (persp-parameter it persp) param-names)))
+
+(defun spacemacs//set-persp-workspace (workspace-params &optional persp frame)
+  "Set workspace parameters for perspective.
+WORKSPACE-PARAMS should be a list containg 3 elements in this order:
+- window-configs, as returned by (eyebrowse--get 'window-configs)
+- current-slot, as returned by (eyebrowse--get 'current-slot)
+- last-slot, as returned by (eyebrowse--get 'last-slot)
+PERSP is the perspective, and defaults to the current perspective.
+FRAME is the frame where the parameters came from, and defaults to the
+current frame.
+
+Each perspective has two sets of workspace parameters: one set for
+graphical frames, and one set for terminal frames."
+  (let ((param-names (if (display-graphic-p frame)
+                         '(gui-eyebrowse-window-configs
+                           gui-eyebrowse-current-slot
+                           gui-eyebrowse-last-slot)
+                       '(term-eyebrowse-window-configs
+                         term-eyebrowse-current-slot
+                         term-eyebrowse-last-slot))))
+    (--zip-with (set-persp-parameter it other persp)
+                param-names workspace-params)))
+
 (defun spacemacs/load-eyebrowse-for-perspective (type &optional frame)
   "Load an eyebrowse workspace according to a perspective's parameters.
  FRAME's perspective is the perspective that is considered, defaulting to
  the current frame's perspective.
  If the perspective doesn't have a workspace, create one."
   (when (eq type 'frame)
-    (let* ((persp (get-frame-persp frame))
-           (window-configs (persp-parameter 'eyebrowse-window-configs persp))
-           (current-slot (persp-parameter 'eyebrowse-current-slot persp))
-           (last-slot (persp-parameter 'eyebrowse-last-slot persp)))
+    (let* ((workspace-params (spacemacs//get-persp-workspace (get-frame-persp frame) frame))
+           (window-configs (nth 0 workspace-params))
+           (current-slot (nth 1 workspace-params))
+           (last-slot (nth 2 workspace-params)))
       (if window-configs
           (progn
             (eyebrowse--set 'window-configs window-configs frame)
@@ -525,10 +561,8 @@ Parameters _NEW-PERSP-NAME and _FRAME are ignored, and exists only for
 (defun spacemacs/save-eyebrowse-for-perspective (&optional frame)
   "Save FRAME's eyebrowse workspace to FRAME's perspective.
 FRAME defaults to the current frame."
-  (let ((persp (get-frame-persp frame)))
-    (set-persp-parameter
-     'eyebrowse-window-configs (eyebrowse--get 'window-configs frame) persp)
-    (set-persp-parameter
-     'eyebrowse-current-slot (eyebrowse--get 'current-slot frame) persp)
-    (set-persp-parameter
-     'eyebrowse-last-slot (eyebrowse--get 'last-slot frame) persp)))
+  (spacemacs//set-persp-workspace (list (eyebrowse--get 'window-configs frame)
+                                        (eyebrowse--get 'current-slot frame)
+                                        (eyebrowse--get 'last-slot frame))
+                                  (get-frame-persp frame)
+                                  frame))


### PR DESCRIPTION
Use two different sets of workspaces for each perspective - one set for graphical frames, and one set for terminal frames. This is required because workspaces from graphical frames are not compatible for use in terminal frames.

Should fix #5978, but I didn't have time for extensive testing.