### PR TITLE
Provide additional jump options.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1702,15 +1702,18 @@ The ~SPC j~ prefix is for jumping, joining and splitting.
 | ~SPC j b~   | undo a jump (go back to previous location)                                        |
 | ~SPC j d~   | jump to a listing of the current directory                                        |
 | ~SPC j D~   | jump to a listing of the current directory (other window)                         |
-| ~SPC j f~   | jump to the definition of the function around point                               |
+| ~SPC j f~   | jump to the definition of a function                                              |
+| ~SPC j F~   | jump to the definition of the function around point                               |
 | ~SPC j i~   | jump to a definition in buffer (imenu)                                            |
 | ~SPC j I~   | jump to a definition in any buffer (imenu)                                        |
 | ~SPC j j~   | jump to a character in the buffer (works as an evil motion)                       |
 | ~SPC j J~   | jump to a suite of two characters in the buffer (works as an evil motion)         |
 | ~SPC j k~   | jump to next line and indent it using auto-indent rules                           |
 | ~SPC j l~   | jump to a line with avy (works as an evil motion)                                 |
+| ~SPC j L~   | jump to an emacs library                                                          |
 | ~SPC j u~   | jump to a URL in the current buffer                                               |
-| ~SPC j v~   | jump to the definition/declaration of the variable around point                   |
+| ~SPC j v~   | jump to the definition/declaration of a variable                                  |
+| ~SPC j V~   | jump to the definition/declaration of the variable around point                   |
 | ~SPC j w~   | jump to a word in the current buffer (works as an evil motion)                    |
 
 **** Joining and splitting

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -193,9 +193,12 @@
 (spacemacs/set-leader-keys
   "j0" 'spacemacs/push-mark-and-goto-beginning-of-line
   "j$" 'spacemacs/push-mark-and-goto-end-of-line
-  "jf" 'find-function-at-point
+  "jL" 'find-library
+  "jF" 'find-function-at-point
+  "jf" 'find-function
   "ji" 'spacemacs/jump-in-buffer
-  "jv" 'find-variable-at-point)
+  "jv" 'find-variable
+  "jV" 'find-variable-at-point)
 
 ;; Compilation ----------------------------------------------------------------
 (spacemacs/set-leader-keys


### PR DESCRIPTION
Moved `jf` and `jv` to their uppercase versions to be consistent with the rest of Spacemacs.  The lowercase will prompt to find any function or variable.  Also added a library lookup as another option. 