### PR TITLE
Add additional custom file actions for ivy.

### DIFF
--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -30,3 +30,19 @@ with options to run in the shell.")
 than this amount.")
 
 (defvar spacemacs--counsel-initial-number-cand 100)
+
+(defvar spacemacs--ivy-file-actions
+  '(("f" find-file-other-frame "other frame")
+    ("w" find-file-other-window "other window")
+    ("v" spacemacs/find-file-vsplit "in vertical split")
+    ("s" spacemacs/find-file-split "in horizontal split")
+    ("l" find-file-literally "literally"))
+  "Default ivy actions for files.")
+
+(defvar spacemacs--ivy-grep-actions
+  (loop for j in spacemacs--ivy-file-actions
+        for key = (nth 0 j)
+        for func = (nth 1 j)
+        for desc = (nth 2 j)
+        collect `(,key (lambda (x) (spacemacs//counsel-with-git-grep (quote ,func) x)) ,desc))
+  "Default ivy actions to be used with git-grep output.")

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -232,6 +232,20 @@ To prevent this error we just wrap `describe-mode' to defeat the
       (interactive)
       (call-interactively 'describe-mode))))
 
+(defun spacemacs//counsel-with-git-grep (func x)
+  (when (string-match "\\`\\(.*?\\):\\([0-9]+\\):\\(.*\\)\\'" x)
+    (with-ivy-window
+      (let ((file-name (match-string-no-properties 1 x))
+            (line-number (match-string-no-properties 2 x)))
+        (funcall func
+                 (expand-file-name file-name counsel--git-grep-dir))
+        (goto-char (point-min))
+        (forward-line (1- (string-to-number line-number)))
+        (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
+        (unless (eq ivy-exit 'done)
+          (swiper--cleanup)
+          (swiper--add-overlays (ivy--regex ivy-text)))))))
+
 
 ;; Ivy
 
@@ -254,7 +268,8 @@ To prevent this error we just wrap `describe-mode' to defeat the
                         (require (car repl))
                         (call-interactively (cdr repl))))))
 
-;; perspectives
+
+;; Perspectives
 
 (defun spacemacs/ivy-perspectives ()
   "Control Panel for perspectives. Has many actions.

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -18,6 +18,7 @@
         (ivy-spacemacs-help :location local)
         ;; Why do we need this ?
         pcre2el
+        perspectives
         projectile
         smex
         swiper
@@ -71,6 +72,12 @@
         "skF" 'spacemacs/search-ack-region-or-symbol
         "skp" 'spacemacs/search-project-ack
         "skP" 'spacemacs/search-project-ack-region-or-symbol)
+
+      ;; set additional ivy actions
+      (ivy-set-actions
+       'counsel-find-file
+       spacemacs--ivy-file-actions)
+
       ;; remaps built-in commands that have a counsel replacement
       (counsel-mode 1)
       (spacemacs|hide-lighter counsel-mode)
@@ -104,6 +111,12 @@
         "fr" 'ivy-recentf
         "rl" 'ivy-resume
         "bb" 'ivy-switch-buffer)
+
+      ;; custom actions for recentf
+      (ivy-set-actions
+       'ivy-recentf
+       spacemacs--ivy-file-actions)
+
       (ivy-mode 1)
       (global-set-key (kbd "C-c C-r") 'ivy-resume)
       (global-set-key (kbd "<f6>") 'ivy-resume)
@@ -113,24 +126,25 @@
                      'spacemacs//counsel-occur)
       (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
         "w" 'ivy-wgrep-change-to-wgrep-mode)
-      ;; Perspectives support
-      (ivy-set-actions
-       'spacemacs/ivy-perspectives
-       '(("c" persp-kill-without-buffers "Close perspective(s)")
-         ("k" persp-kill  "Kill perspective(s)")))
-      (setq spacemacs-layouts-transient-state-remove-bindings
-            '("b" "l" "C" "X"))
-      (setq spacemacs-layouts-transient-state-add-bindings
-            '(("b" spacemacs/ivy-persp-buffer)
-              ("l" spacemacs/ivy-perspectives)
-              ("C" spacemacs/ivy-persp-close-other :exit t)
-              ("X" spacemacs/ivy-persp-kill-other :exit t)))
       ;; Why do we do this ?
       (ido-mode -1))))
 
 ;; Why do we need this ?
 (defun ivy/init-pcre2el ()
   (use-package pcre2el :defer t))
+
+(defun ivy/post-init-perspectives ()
+  (ivy-set-actions
+   'spacemacs/ivy-perspectives
+   '(("c" persp-kill-without-buffers "Close perspective(s)")
+     ("k" persp-kill  "Kill perspective(s)")))
+  (setq spacemacs-layouts-transient-state-remove-bindings
+        '("b" "l" "C" "X"))
+  (setq spacemacs-layouts-transient-state-add-bindings
+        '(("b" spacemacs/ivy-persp-buffer)
+          ("l" spacemacs/ivy-perspectives)
+          ("C" spacemacs/ivy-persp-close-other :exit t)
+          ("X" spacemacs/ivy-persp-kill-other :exit t))))
 
 (defun ivy/post-init-projectile ()
   (setq projectile-completion-system 'ivy)

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -868,6 +868,28 @@ Compare them on count first,and in case of tie sort them alphabetically."
                                                (region-end))))
  (evil-end-undo-step))
 
+;; find file functions in split
+(defun spacemacs//display-in-split (buffer alist)
+  "Split selected window and display BUFFER in the new window.
+BUFFER and ALIST have the same form as in `display-buffer'. If ALIST contains
+a split-side entry, its value must be usable as the SIDE argument for
+`split-window'."
+  (let ((window (split-window nil nil (cdr (assq 'split-side alist)))))
+    (window--display-buffer buffer window 'window alist)
+    window))
+
+(defun spacemacs/find-file-vsplit (file)
+  "find file in vertical split"
+  (interactive "FFind file (vsplit): ")
+  (let ((buffer (find-file-noselect file)))
+    (pop-to-buffer buffer '(spacemacs//display-in-split (split-side . right)))))
+
+(defun spacemacs/find-file-split (file)
+  "find file in horizonatl split"
+  (interactive "FFind file (split): ")
+  (let ((buffer (find-file-noselect file)))
+    (pop-to-buffer buffer '(spacemacs//display-in-split (split-side . below)))))
+
 (defun spacemacs//intersperse (seq separator)
   "Returns a list with `SEPARATOR' added between each element
 of the list `SEQ'."
@@ -908,4 +930,3 @@ is nonempty."
   (interactive)
   (when compilation-last-buffer
     (delete-windows-on compilation-last-buffer)))
-


### PR DESCRIPTION
This provides a `defvar` with custom actions used with ivy find-file based commands.  At startup, we recreate the list to work within the `spacemacs-ivy/counsel-search` command so that we can use these commands with `grep`-like output as well.
