### PR TITLE
Use counsel-projectile for projects with ivy.

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -12,6 +12,7 @@
 (setq ivy-packages
       '(auto-highlight-symbol
         counsel
+        counsel-projectile
         evil
         flx
         ivy
@@ -78,6 +79,19 @@
       (spacemacs//ivy-command-not-implemented-yet "jI")
       ;; Set syntax highlighting for counsel search results
       (ivy-set-display-transformer 'spacemacs/counsel-search 'counsel-git-grep-transformer))))
+
+(defun ivy/init-counsel-projectile ()
+  (when (configuration-layer/package-usedp 'projectile)
+    (use-package counsel-projectile
+      :defer t
+      :init
+      (spacemacs/set-leader-keys
+        "pb" 'counsel-projectile-switch-to-buffer
+        "pd" 'counsel-projectile-find-dir
+        "pp" 'counsel-projectile
+        "pf" 'counsel-projectile-find-file
+        "pr" 'projectile-recentf
+        "ps" 'counsel-projectile))))
 
 (defun ivy/post-init-auto-highlight-symbol ()
   (setq spacemacs-symbol-highlight-transient-state-remove-bindings

--- a/layers/+spacemacs/spacemacs-projects/packages.el
+++ b/layers/+spacemacs/spacemacs-projects/packages.el
@@ -153,7 +153,8 @@
                                           "projectile.cache")
             projectile-known-projects-file (concat spacemacs-cache-directory
                                                    "projectile-bookmarks.eld"))
-      (unless (configuration-layer/package-usedp 'helm-projectile)
+      (unless (or (configuration-layer/package-usedp 'helm-projectile)
+                  (configuration-layer/package-usedp 'counsel-projectile))
         (spacemacs/set-leader-keys
           "pb" 'projectile-switch-to-buffer
           "pd" 'projectile-find-dir


### PR DESCRIPTION
Use `counsel-projectile` for project based commands in ivy, providing for additional custom actions.  