### PR TITLE
Center the startup banner

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -161,14 +161,14 @@ If ALL is non-nil then truly all banners can be selected."
            (spec (create-image banner))
            (size (image-size spec))
            (width (car size))
-           (left-margin (floor (- spacemacs-buffer--banner-length width) 2)))
+           (left-margin (max 0 (floor (- spacemacs-buffer--banner-length width) 2))))
       (goto-char (point-min))
       (insert "\n")
       (insert (make-string left-margin ?\ ))
       (insert-image spec)
       (insert "\n\n")
-      (insert (make-string (floor (/ (- spacemacs-buffer--banner-length
-                                        (+ (length title) 1)) 2)) ?\ ))
+      (insert (make-string (max 0 (floor (/ (- spacemacs-buffer--banner-length
+                                        (+ (length title) 1)) 2))) ?\ ))
       (insert (format "%s\n\n" title)))))
 
 (defun spacemacs-buffer//inject-version (&optional insert-distro)
@@ -188,7 +188,7 @@ buffer, right justified."
         (goto-char (point-min))
         (delete-region (point) (progn (end-of-line) (point)))
         (insert (format
-                 (format "%%s %%%ds" len)
+                 (format "%%s%%%ds" len)
                  lhs rhs))))))
 
 (defun spacemacs-buffer//insert-note (file caption &optional additional-widgets)
@@ -473,103 +473,109 @@ border."
                           '((forward-line 1)))
                       (back-to-indentation))))
 
+(defun spacemacs-buffer//center-line ()
+  (let* ((width (current-column))
+         (margin (max 0 (floor (/ (- spacemacs-buffer--banner-length width) 2)))))
+    (beginning-of-line)
+    (insert (make-string margin ?\ ))
+    (end-of-line)))
+
 (defun spacemacs-buffer//insert-buttons ()
-  (goto-char (point-max))
-  (insert "     ")
-  (spacemacs//insert--shortcut "m" "[?]" t)
-  (widget-create 'url-link
-                 :tag (propertize "?" 'face 'font-lock-doc-face)
-                 :help-echo "Open the quickhelp."
-                 :action (lambda (&rest ignore)
-                           (spacemacs-buffer/toggle-note
-                            (concat spacemacs-info-directory "quickhelp.txt")
-                            ;; if nil is returned,
-                            ;; just delete the current note widgets
-                            (spacemacs-buffer//insert-note-p 'quickhelp)))
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 )
-  (insert " ")
-  (widget-create 'url-link
-                 :tag (propertize "Homepage" 'face 'font-lock-keyword-face)
-                 :help-echo "Open the Spacemacs Github page in your browser."
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 "http://spacemacs.org")
-  (insert " ")
-  (widget-create 'url-link
-                 :tag (propertize "Documentation" 'face 'font-lock-keyword-face)
-                 :help-echo "Open the Spacemacs documentation in your browser."
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 "http://spacemacs.org/doc/DOCUMENTATION.html")
-  (insert " ")
-  (widget-create 'url-link
-                 :tag (propertize "Gitter Chat" 'face 'font-lock-keyword-face)
-                 :help-echo
-                 "Ask questions and chat with fellow users in our chat room."
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 "https://gitter.im/syl20bnr/spacemacs")
-  (insert " ")
-  (widget-create 'push-button
-                 :help-echo "Update Spacemacs core and layers."
-                 :action (lambda (&rest ignore) (spacemacs/switch-to-version))
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 (propertize "Update Spacemacs" 'face 'font-lock-keyword-face))
-  (insert "\n               ")
-  (widget-create 'push-button
-                 :help-echo "Update all ELPA packages to the latest versions."
-                 :action (lambda (&rest ignore)
-                           (configuration-layer/update-packages))
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 (propertize "Update Packages" 'face 'font-lock-keyword-face))
-  (insert " ")
-  (widget-create 'push-button
-                 :help-echo
-                 "Rollback ELPA package updates if something got borked."
-                 :action (lambda (&rest ignore)
-                           (call-interactively 'configuration-layer/rollback))
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 (propertize "Rollback Package Update"
-                             'face 'font-lock-keyword-face))
-  (insert "\n")
-  (insert "                  ")
-  (widget-create 'push-button
-                 :tag (propertize "Release Notes"
-                                  'face 'font-lock-preprocessor-face)
-                 :help-echo "Hide or show the Changelog"
-                 :action (lambda (&rest ignore)
-                           (spacemacs-buffer/toggle-note
-                            (concat spacemacs-release-notes-directory
-                                    spacemacs-buffer-version-info
-                                    ".txt")
-                            ;; if nil is returned,
-                            ;; just delete the current note widgets
-                            (spacemacs-buffer//insert-note-p 'release-note)))
-                 :mouse-face 'highlight
-                 :follow-link "\C-m"
-                 )
-  (insert " ")
-  (widget-create 'url-link
-                 :tag (propertize "Search in Spacemacs"
-                                  'face 'font-lock-function-name-face)
-                 :help-echo "Search Spacemacs contents."
-                 :action
-                 (lambda (&rest ignore)
-                   (let ((comp-frontend
-                          (cond
-                           ((configuration-layer/layer-usedp 'spacemacs-helm)
-                            'helm-spacemacs-help)
-                           ((configuration-layer/layer-usedp 'spacemacs-ivy)
-                            'ivy-spacemacs-help))))
-                     (call-interactively comp-frontend)))
-                 :mouse-face 'highlight
-                 :follow-link "\C-m")
-  (insert "\n\n"))
+    (goto-char (point-max))
+    (spacemacs//insert--shortcut "m" "[?]" t)
+    (widget-create 'url-link
+                   :tag (propertize "?" 'face 'font-lock-doc-face)
+                   :help-echo "Open the quickhelp."
+                   :action (lambda (&rest ignore)
+                             (spacemacs-buffer/toggle-note
+                              (concat spacemacs-info-directory "quickhelp.txt")
+                              ;; if nil is returned,
+                              ;; just delete the current note widgets
+                              (spacemacs-buffer//insert-note-p 'quickhelp)))
+                   :mouse-face 'highlight
+                   :follow-link "\C-m")
+    (insert " ")
+    (widget-create 'url-link
+                   :tag (propertize "Homepage" 'face 'font-lock-keyword-face)
+                   :help-echo "Open the Spacemacs Github page in your browser."
+                   :mouse-face 'highlight
+                   :follow-link "\C-m"
+                   "http://spacemacs.org")
+    (insert " ")
+    (widget-create 'url-link
+                   :tag (propertize "Documentation" 'face 'font-lock-keyword-face)
+                   :help-echo "Open the Spacemacs documentation in your browser."
+                   :mouse-face 'highlight
+                   :follow-link "\C-m"
+                   "http://spacemacs.org/doc/DOCUMENTATION.html")
+    (insert " ")
+    (widget-create 'url-link
+                   :tag (propertize "Gitter Chat" 'face 'font-lock-keyword-face)
+                   :help-echo
+                   "Ask questions and chat with fellow users in our chat room."
+                   :mouse-face 'highlight
+                   :follow-link "\C-m"
+                   "https://gitter.im/syl20bnr/spacemacs")
+    (insert " ")
+    (widget-create 'push-button
+                   :help-echo "Update Spacemacs core and layers."
+                   :action (lambda (&rest ignore) (spacemacs/switch-to-version))
+                   :mouse-face 'highlight
+                   :follow-link "\C-m"
+                   (propertize "Update Spacemacs" 'face 'font-lock-keyword-face))
+    (spacemacs-buffer//center-line)
+    (insert "\n")
+    (widget-create 'push-button
+                   :help-echo "Update all ELPA packages to the latest versions."
+                   :action (lambda (&rest ignore)
+                             (configuration-layer/update-packages))
+                   :mouse-face 'highlight
+                   :follow-link "\C-m"
+                   (propertize "Update Packages" 'face 'font-lock-keyword-face))
+    (insert " ")
+    (widget-create 'push-button
+                   :help-echo
+                   "Rollback ELPA package updates if something got borked."
+                   :action (lambda (&rest ignore)
+                             (call-interactively 'configuration-layer/rollback))
+                   :mouse-face 'highlight
+                   :follow-link "\C-m"
+                   (propertize "Rollback Package Update"
+                               'face 'font-lock-keyword-face))
+    (spacemacs-buffer//center-line)
+    (insert "\n")
+    (widget-create 'push-button
+                   :tag (propertize "Release Notes"
+                                    'face 'font-lock-preprocessor-face)
+                   :help-echo "Hide or show the Changelog"
+                   :action (lambda (&rest ignore)
+                             (spacemacs-buffer/toggle-note
+                              (concat spacemacs-release-notes-directory
+                                      spacemacs-buffer-version-info
+                                      ".txt")
+                              ;; if nil is returned,
+                              ;; just delete the current note widgets
+                              (spacemacs-buffer//insert-note-p 'release-note)))
+                   :mouse-face 'highlight
+                   :follow-link "\C-m")
+    (insert " ")
+    (widget-create 'url-link
+                   :tag (propertize "Search in Spacemacs"
+                                    'face 'font-lock-function-name-face)
+                   :help-echo "Search Spacemacs contents."
+                   :action
+                   (lambda (&rest ignore)
+                     (let ((comp-frontend
+                            (cond
+                             ((configuration-layer/layer-usedp 'spacemacs-helm)
+                              'helm-spacemacs-help)
+                             ((configuration-layer/layer-usedp 'spacemacs-ivy)
+                              'ivy-spacemacs-help))))
+                       (call-interactively comp-frontend)))
+                   :mouse-face 'highlight
+                   :follow-link "\C-m")
+    (spacemacs-buffer//center-line)
+    (insert "\n\n"))
 
 (defun spacemacs-buffer//insert-file-list (list-display-name list)
   (when (car list)
@@ -776,6 +782,10 @@ border."
 already exist, and switch to it."
   (interactive)
   (unless (buffer-live-p (get-buffer spacemacs-buffer-name))
+    ;; revise banner length in GUI
+    (when (display-graphic-p)
+      (setq spacemacs-buffer--banner-length
+            (- (window-total-width) 2)))
     (with-current-buffer (get-buffer-create spacemacs-buffer-name)
       (save-excursion
         (spacemacs-buffer/set-mode-line "")

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -47,6 +47,7 @@ version the release note it displayed")
     (define-key map (kbd "RET") 'widget-button-press)
     (define-key map [down-mouse-1] 'widget-button-click)
     (define-key map "q" 'quit-window)
+    (define-key map (kbd "C-r") 'spacemacs-buffer/refresh)
     map)
   "Keymap for spacemacs buffer mode.")
 
@@ -86,7 +87,7 @@ Doge special text banner can be reachable via `999', `doge' or `random*'.
         (if (image-type-available-p (intern (file-name-extension banner)))
             (spacemacs-buffer//insert-image-banner banner)
           (insert-file-contents banner))
-        (spacemacs-buffer//inject-version))
+        (spacemacs-buffer//inject-version t))
       (spacemacs-buffer//insert-buttons)
       (spacemacs//redisplay))))
 
@@ -793,5 +794,13 @@ already exist, and switch to it."
   (spacemacs-buffer/goto-link-line)
   (switch-to-buffer spacemacs-buffer-name)
   (spacemacs//redisplay))
+
+(defun spacemacs-buffer/refresh ()
+  "Recreate the spacemacs buffer."
+  (interactive)
+  (let ((inhibit-redisplay t))
+    (when (buffer-live-p (get-buffer spacemacs-buffer-name))
+      (kill-buffer spacemacs-buffer-name))
+    (spacemacs-buffer/goto-buffer)))
 
 (provide 'core-spacemacs-buffer)


### PR DESCRIPTION
This centers the banner and button widgets in the spacemacs-buffer based on the initial window size on startup.  Terminal windows should use the pre-defined 75 columns.  In addition, provides a refresh button `C-r` to allow refresh of the buffer if window size changes.  