### PR TITLE
Switch to an alist for startup lists.

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -302,13 +302,12 @@ tool of the list. Supported tools are `ag', `pt', `ack' and `grep'.")
 specified with an installed package.
 NOT USED FOR NOW :-)")
 
-(defvar dotspacemacs-startup-lists '(recents projects)
-  "List of items to show in the startup buffer. If nil it is disabled.
-Possible values are: `recents' `bookmarks' `projects' `agenda' `todos'.")
-
-(defvar dotspacemacs-startup-recent-list-size 5
-  "Number of recent files to show in the startup buffer. Ignored if
-`dotspacemacs-startup-lists' doesn't include `recents'.")
+(defvar dotspacemacs-startup-lists '((recents  . 5)
+                                    (projects . 7))
+  "Association list of items to show in the startup buffer of the form
+`(list-type . list-size)`. If nil it is disabled.
+Possible values for list-type are:
+`recents' `bookmarks' `projects' `agenda' `todos'.")
 
 (defvar dotspacemacs-excluded-packages '()
   "A list of packages that will not be install and loaded.")

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -744,6 +744,13 @@ border."
                                    (cdr (assoc "text" el)))))
           list)))
 
+(defun spacemacs//subseq (seq start end)
+  "Use `cl-subseq`, but accounting for end points greater than the size of the
+list. Return entire list if `END' is omitted."
+  (let ((len (length seq)))
+    (cl-subseq seq start (and (number-or-marker-p end)
+                              (min len end)))))
+
 (defun spacemacs-buffer/insert-startupify-lists ()
   (interactive)
   (with-current-buffer (get-buffer spacemacs-buffer-name)
@@ -751,44 +758,50 @@ border."
           (list-separator "\n\n"))
       (goto-char (point-max))
       (spacemacs-buffer/insert-page-break)
-      (mapc (lambda (el)
-              (cond
-               ((eq el 'recents)
-                (recentf-mode)
-                (when (spacemacs-buffer//insert-file-list
-                       "Recent Files:"
-                       (recentf-elements dotspacemacs-startup-recent-list-size))
-                  (spacemacs//insert--shortcut "r" "Recent Files:")
-                  (insert list-separator)))
-               ((eq el 'todos)
-                (when (spacemacs-buffer//insert-todo-list
-                       "ToDo:"
-                       (spacemacs-buffer//todo-list))
-                  (spacemacs//insert--shortcut "d" "ToDo:")
-                  (insert list-separator)))
-               ((eq el 'agenda)
-                (when (spacemacs-buffer//insert-todo-list
-                       "Agenda:"
-                       (spacemacs-buffer//agenda-list))
-                  (spacemacs//insert--shortcut "c" "Agenda:")
-                  (insert list-separator)))
-               ((eq el 'bookmarks)
-                (when (configuration-layer/package-usedp 'helm)
-                  (helm-mode))
-                (require 'bookmark)
-                (when (spacemacs-buffer//insert-bookmark-list
-                       "Bookmarks:"
-                       (bookmark-all-names))
-                  (spacemacs//insert--shortcut "b" "Bookmarks:")
-                  (insert list-separator)))
-               ((and (eq el 'projects)
-                     (fboundp 'projectile-mode))
-                (projectile-mode)
-                (when (spacemacs-buffer//insert-file-list
-                       "Projects:"
-                       (projectile-relevant-known-projects))
-                  (spacemacs//insert--shortcut "p" "Projects:")
-                  (insert list-separator))))) dotspacemacs-startup-lists))))
+      (mapc (lambda (els)
+              (let ((el (or (car-safe els) els))
+                    (list-size (cdr-safe els)))
+                (cond
+                 ((eq el 'recents)
+                  (recentf-mode)
+                  (when (spacemacs-buffer//insert-file-list
+                         "Recent Files:"
+                         (spacemacs//subseq recentf-list 0 list-size))
+                    (spacemacs//insert--shortcut "r" "Recent Files:")
+                    (insert list-separator)))
+                 ((eq el 'todos)
+                  (when (spacemacs-buffer//insert-todo-list
+                         "ToDo:"
+                         (spacemacs//subseq (spacemacs-buffer//todo-list)
+                                     0 list-size))
+                    (spacemacs//insert--shortcut "d" "ToDo:")
+                    (insert list-separator)))
+                 ((eq el 'agenda)
+                  (when (spacemacs-buffer//insert-todo-list
+                         "Agenda:"
+                         (spacemacs//subseq (spacemacs-buffer//agenda-list)
+                                     0 list-size))
+                    (spacemacs//insert--shortcut "c" "Agenda:")
+                    (insert list-separator)))
+                 ((eq el 'bookmarks)
+                  (when (configuration-layer/layer-usedp 'spacemacs-helm)
+                    (helm-mode))
+                  (require 'bookmark)
+                  (when (spacemacs-buffer//insert-bookmark-list
+                         "Bookmarks:"
+                         (spacemacs//subseq (bookmark-all-names)
+                                     0 list-size))
+                    (spacemacs//insert--shortcut "b" "Bookmarks:")
+                    (insert list-separator)))
+                 ((and (eq el 'projects)
+                       (fboundp 'projectile-mode))
+                  (projectile-mode)
+                  (when (spacemacs-buffer//insert-file-list
+                         "Projects:"
+                         (spacemacs//subseq (projectile-relevant-known-projects)
+                                     0 list-size))
+                    (spacemacs//insert--shortcut "p" "Projects:")
+                    (insert list-separator)))))) dotspacemacs-startup-lists))))
 
 (defun spacemacs-buffer/goto-link-line ()
   "Set point to the beginning of the link line."

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -103,13 +103,12 @@ values."
    ;; by your Emacs build.
    ;; If the value is nil then no banner is displayed. (default 'official)
    dotspacemacs-startup-banner 'official
-   ;; List of items to show in the startup buffer. If nil it is disabled.
-   ;; Possible values are: `recents' `bookmarks' `projects' `agenda' `todos'.
-   ;; (default '(recents projects))
-   dotspacemacs-startup-lists '(recents projects)
-   ;; Number of recent files to show in the startup buffer. Ignored if
-   ;; `dotspacemacs-startup-lists' doesn't include `recents'. (default 5)
-   dotspacemacs-startup-recent-list-size 5
+   ;; List of items to show in startup buffer or an association list of of
+   ;; the form `(list-type . list-size)`. If nil it is disabled.
+   ;; Possible values for list-type are:
+   ;; `recents' `bookmarks' `projects' `agenda' `todos'."
+   dotspacemacs-startup-lists '((recents . 5)
+                                (projects . 7))
    ;; Default major mode of the scratch buffer (default `text-mode')
    dotspacemacs-scratch-mode 'text-mode
    ;; List of themes, the first of the list is loaded when spacemacs starts.


### PR DESCRIPTION
Defines an `alist` that is used to define the lists to show in the spacemacs-buffer and specifying maximum list size for each list.  This allows each user to limit the output of long lists (like todo, or projects).