### PR TITLE
[ruby layer] Automatically switch from common Ruby compilation modes to interact with a debugger

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -149,6 +149,10 @@
     ;; setup the hook via an autoload
     :config
     (progn
+      (defun spacemacs//inf-ruby-auto-enter ()
+        "Automatically enters inf-ruby-mode in ruby modes' debugger breakpoints."
+        (add-hook 'compilation-filter-hook 'inf-ruby-auto-enter nil t))
+      (add-hook 'rspec-compilation-mode-hook 'spacemacs//inf-ruby-auto-enter)
       (spacemacs|hide-lighter rspec-mode)
       (dolist (mode '(ruby-mode enh-ruby-mode))
         (spacemacs/set-leader-keys-for-major-mode mode


### PR DESCRIPTION
This commit adds the 'inf-ruby-auto-enter function to 'compilation-filter-hook, automatically entering inf-ruby-mode when it hits a breakpoint (see the [inf-ruby-manual](https://github.com/nonsequitur/inf-ruby/#manual) for more details).

This might have the side-effect of slightly slowing down compilation modes for other languages, as the hook is run whenever a line is inserted in a comint buffer. We might want to conditionally enable it
via an optional variable.