### PR TITLE
add common-lisp layer prefix-names for which-key

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -89,7 +89,17 @@
         "si" 'slime
         "sq" 'slime-quit-lisp
 
-        "tf" 'slime-toggle-fancy-trace))))
+        "tf" 'slime-toggle-fancy-trace)
+      ;; prefix names for which-key
+      (mapc (lambda (x)
+              (spacemacs/declare-prefix-for-mode 'lisp-mode (car x) (cdr x)))
+            '(("mh" . "help")
+              ("me" . "eval")
+              ("ms" . "repl")
+              ("mc" . "compile")
+              ("mg" . "nav")
+              ("mm" . "macro")
+              ("mt" . "toggle"))))))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
   (defun common-lisp/init-common-lisp-snippets ()))


### PR DESCRIPTION
Add the `SPC m` prefix key names to `common-lisp` layer for `which-key`.