### PR TITLE
Add OCaml binding to indent buffer with ocp-indent

### DIFF
--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -76,7 +76,9 @@
   (use-package ocp-indent
     :defer t
     :init
-    (add-hook 'tuareg-mode-hook 'ocp-indent-caml-mode-setup)))
+    (add-hook 'tuareg-mode-hook 'ocp-indent-caml-mode-setup)
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "=" 'ocp-indent-buffer)))
 
 (defun ocaml/post-init-smartparens ()
   (with-eval-after-load 'smartparens


### PR DESCRIPTION
Adds a binding to the OCaml layer under `m =` which allows you to indent the buffer using `ocp-indent`.
