### PR TITLE
Fixes #6051, checks for existence of git-gutter.

### DIFF
--- a/layers/+source-control/version-control/funcs.el
+++ b/layers/+source-control/version-control/funcs.el
@@ -100,8 +100,10 @@
   (interactive)
   (cl-case version-control-diff-tool
     (diff-hl     diff-hl-mode)
-    (git-gutter  git-gutter-mode)
-    (git-gutter+ git-gutter+-mode)))
+    (git-gutter  (bound-and-true-p
+                  git-gutter-mode))
+    (git-gutter+ (bound-and-true-p
+                  git-gutter+-mode))))
 
 (defun version-control/margin-global-p ()
   (interactive)

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -46,7 +46,8 @@
 
 (defun version-control/init-git-gutter ()
   (use-package git-gutter
-    :commands global-git-gutter-mode
+    :commands (global-git-gutter-mode
+               git-gutter-mode)
     :init
     (progn
       ;; If you enable global minor mode
@@ -105,7 +106,8 @@
 
 (defun version-control/init-git-gutter+ ()
   (use-package git-gutter+
-    :commands global-git-gutter+-mode
+    :commands (global-git-gutter+-mode
+               git-gutter+-mode)
     :init
     (progn
       ;; If you enable global minor mode


### PR DESCRIPTION
Non-global vcs margin's are not autoloaded in git-gutter and git-gutter+.  This checks for it's existence when `version-control-global-margin` is nil.