### PR TITLE
Discussion: Move customized settings to custom.el

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -45,10 +45,17 @@
 (defconst user-home-directory
   (expand-file-name "~/")
   "User home directory (~/).")
+
 (defconst pcache-directory
   (concat spacemacs-cache-directory "pcache/"))
 (unless (file-exists-p spacemacs-cache-directory)
-    (make-directory spacemacs-cache-directory))
+  (make-directory spacemacs-cache-directory))
+
+(setq custom-file
+      (concat spacemacs-cache-directory "custom.el"))
+(unless (file-exists-p custom-file)
+  (with-temp-buffer (write-file custom-file))
+  (custom-save-all))
 
 (defconst user-dropbox-directory
   (expand-file-name (concat user-home-directory "Dropbox/"))

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -186,7 +186,9 @@ defer call using `spacemacs-post-user-config-hook'."
          (funcall dotspacemacs-scratch-mode)))
      (configuration-layer/display-summary emacs-start-time)
      (spacemacs/check-for-new-version spacemacs-version-check-interval)
-     (setq spacemacs-initialized t))))
+     (setq spacemacs-initialized t)
+     (load-file custom-file)
+     )))
 
 (defun spacemacs//describe-system-info-string ()
   "Gathers info about your Spacemacs setup and returns it as a string."


### PR DESCRIPTION
As discussed in #5751, proposes to move customized settings in a file within the /.cache directory.  One thing missing in this PR is some indication that the current mess at the bottom of the dotspacemacs file can be deleted by the user.  
