### PR TITLE
[haskell] fix type and info hey bindings

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -91,8 +91,10 @@
           "me" 'ghc-expand-th
           "mn" 'ghc-goto-next-hole
           "mp" 'ghc-goto-prev-hole
-          "m>"  'ghc-make-indent-deeper
-          "m<"  'ghc-make-indent-shallower))
+          "m>" 'ghc-make-indent-deeper
+          "m<" 'ghc-make-indent-shallower
+          "hi" 'ghc-show-info
+          "ht" 'ghc-show-type))
       (when (configuration-layer/package-usedp 'flycheck)
         ;; remove overlays from ghc-check.el if flycheck is enabled
         (set-face-attribute 'ghc-face-error nil :underline nil)
@@ -232,7 +234,15 @@
       (evil-define-key 'normal haskell-interactive-mode-map
         (kbd "RET") 'haskell-interactive-mode-return)
 
-      ;;GHCi-ng
+      ;; interactive haskell mode
+      (unless (or haskell-enable-ghc-mod-support
+                  haskell-enable-ghci-ng-support)
+        (dolist (mode haskell-modes)
+          (spacemacs/set-leader-keys-for-major-mode mode
+            "hi" 'haskell-process-do-info
+            "ht" 'haskell-process-do-type)))
+
+      ;; GHCi-ng
       (when haskell-enable-ghci-ng-support
         ;; haskell-process-type is set to auto, so setup ghci-ng for either case
         ;; if haskell-process-type == cabal-repl
@@ -336,4 +346,3 @@
 
       (define-key shm-map (kbd "C-j") nil)
       (define-key shm-map (kbd "C-k") nil))))
-


### PR DESCRIPTION
At some point it became broken again. I noticed it by accident as I use `C-c C-t` and `C-c C-i` whenever I need to get type / info. By 'broken' I mean that those bindings call function that shows error about misconfiguration, while `C-c C-t` and `C-c C-i` are properly set. 

---

I left the part where it sets `, h t` and `, h i` to whatever is set to `C-c C-t` and `C-c C-i` respectively just to make sure that it shows error when something goes wring (but if someone thinks that it just leads to more confusion - feel free to remove them). 