### PR TITLE
Add pivot-window-split function

### DIFF
--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -344,6 +344,31 @@
              (symbol-value golden-ratio-mode))
     (golden-ratio)))
 
+(defun pivot-window-split ()
+  (interactive)
+  (if (= (count-windows) 2)
+      (let* ((this-win-buffer (window-buffer))
+             (next-win-buffer (window-buffer (next-window)))
+             (this-win-edges (window-edges (selected-window)))
+             (next-win-edges (window-edges (next-window)))
+             (this-win-2nd (not (and (<= (car this-win-edges)
+                                         (car next-win-edges))
+                                     (<= (cadr this-win-edges)
+                                         (cadr next-win-edges)))))
+             (splitter
+              (if (= (car this-win-edges)
+                     (car (window-edges (next-window))))
+                  'split-window-horizontally
+                'split-window-vertically)))
+        (delete-other-windows)
+        (let ((first-win (selected-window)))
+          (funcall splitter)
+          (if this-win-2nd (other-window 1))
+          (set-window-buffer (selected-window) this-win-buffer)
+          (set-window-buffer (next-window) next-win-buffer)
+          (select-window first-win)
+          (if this-win-2nd (other-window 1))))))
+
 (spacemacs/set-leader-keys
   "w2"  'spacemacs/layout-double-columns
   "w3"  'spacemacs/layout-triple-columns
@@ -381,7 +406,8 @@
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
   "w/"  'split-window-right
-  "w="  'balance-windows)
+  "w="  'balance-windows
+  "wi"  'pivot-window-split)
 ;; text -----------------------------------------------------------------------
 (defalias 'count-region 'count-words-region)
 


### PR DESCRIPTION
This function will toggle the orientation of window split between
vertical and horizontal. I have bound to SPC-wi, for "window (i)nvert" or
"window p(i)vot".

Only works when there are two windows, but is still useful much of the time.