### PR TITLE
Fix typo in layers/+tools/shell/README.org

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -112,7 +112,7 @@ work sensibly. E.g. you can press ~cc~ in normal state i.e.
 =evil-change-whole-line= to kill the current input and start typing a new
 command. In Eshell you also kill the prompt, which is often unintended.
 
-By default this layer also protects the =ehsell= prompt. If you want to
+By default this layer also protects the =eshell= prompt. If you want to
 disable this protection you can set the variable =shell-protect-eshell-prompt=
 to nil.
 


### PR DESCRIPTION
fix typo in README.org