### PR TITLE
Remove smooth scroll margin for shells

### DIFF
--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -249,6 +249,3 @@
       (if erc-server-list
           (erc/default-servers)
         (call-interactively 'erc)))))
-
-(defun erc/post-init-smooth-scrolling ()
-  (add-hook 'erc-mode-hook 'spacemacs//unset-scroll-margin))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -308,12 +308,6 @@ is achieved by adding the relevant text properties."
         "ast" 'spacemacs/shell-pop-ansi-term
         "asT" 'spacemacs/shell-pop-term))))
 
-(defun shell/post-init-smooth-scrolling ()
-  (spacemacs/add-to-hooks 'spacemacs//unset-scroll-margin
-                          '(eshell-mode-hook
-                            comint-mode-hook
-                            term-mode-hook)))
-
 (defun shell/init-term ()
   (spacemacs/register-repl 'term 'term)
   (spacemacs/register-repl 'term 'ansi-term)


### PR DESCRIPTION
Remove scroll margin hack for shells, since we are no longer using smooth-scrolling package.