### PR TITLE
Move custom-set-faces out of company config

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -172,6 +172,16 @@ Here is an example to add =company= auto-completion to python buffer:
         :init (push 'company-anaconda company-backends-python-mode))))
 #+END_SRC
 
+** Improved faces
+For nicer-looking faces, try adding the following to `custom-set-faces` in your dotspacemacs file.
+
+#+BEGIN_SRC emacs-lisp
+(custom-set-faces
+ '(company-tooltip-common
+   ((t (:inherit company-tooltip :weight bold :underline nil))))
+ '(company-tooltip-common-selection
+   ((t (:inherit company-tooltip-selection :weight bold :underline nil)))))
+#+END_SRC
 * Key Bindings
 ** Company
 

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -102,12 +102,6 @@
       ;; ensure that the correct bindings are set at startup
       (spacemacs//company-active-navigation dotspacemacs-editing-style)
 
-      ;; Nicer looking faces
-      (custom-set-faces
-       '(company-tooltip-common
-         ((t (:inherit company-tooltip :weight bold :underline nil))))
-       '(company-tooltip-common-selection
-         ((t (:inherit company-tooltip-selection :weight bold :underline nil)))))
       (setq company-transformers '(spacemacs//company-transformer-cancel
                                    company-sort-by-occurrence)))))
 


### PR DESCRIPTION
Keep it in a recommendation in the README for the layer. Eval'ing the
custom-set-faces directly in the config makes it difficult to revert the
customisations.

Addresses #6099

