### PR TITLE
Refactor cases of layer-usedp for layer composability

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -19,7 +19,7 @@
  - [[#case-study-auto-completion][Case study: auto-completion]]
  - [[#layer-tips-and-tricks][Layer tips and tricks]]
    - [[#cross-dependencies][Cross-dependencies]]
-   - [[#use-package][Use-package]]
+   - [[#use-package-1][Use-package]]
    - [[#use-package-hooks][Use-package hooks]]
    - [[#best-practices][Best practices]]
      - [[#package-ownership][Package ownership]]
@@ -559,11 +559,9 @@ if the =auto-completion= layer is enabled.
                         ;; ...
                         )
 
-  (when (configuration-layer/layer-usedp 'auto-completion)
+  (when (configuration-layer/package-usedp 'company)
     (defun yoyo/init-some-weird-package ()
       (use-package some-weird-package
-        ;; Only if company is installed
-        :if (configuration-layer/package-usedp 'company)
         :defer t
         ;; This has to be in init because it's a package entry point
         :init

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -33,7 +33,7 @@
 (when (spacemacs/system-is-mac)
   (push 'erc-terminal-notifier erc-packages))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun erc/post-init-company ()
     (spacemacs|add-company-hook erc-mode)
     (push 'company-capf company-backends-erc-mode))

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -11,7 +11,7 @@
     rcirc-notify
     ))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun rcirc/post-init-company ()
     (spacemacs|add-company-hook rcirc-mode)
     (push 'company-capf company-backends-rcirc-mode))

--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -14,7 +14,7 @@
    - [[#add-auto-completion-in-a-layer][Add auto-completion in a layer]]
      - [[#in-configel][In =config.el=]]
      - [[#in-packagesel][In =packages.el=]]
- - [[#key-bindings][Key Bindings]]
+ - [[#key-bindings-1][Key Bindings]]
    - [[#company][Company]]
    - [[#auto-complete][Auto-complete]]
    - [[#yasnippet][Yasnippet]]
@@ -158,7 +158,7 @@ Here is an example to add =company= auto-completion to python buffer:
       ...))
 
   ;; Configure the packages
-  (when (configuration-layer/layer-usedp 'auto-completion)
+  (when (configuration-layer/package-usedp 'company)
 
     ;; Hook company to python-mode
     (defun python/post-init-company ()
@@ -167,7 +167,6 @@ Here is an example to add =company= auto-completion to python buffer:
     ;; Add the backend to the major-mode specific backend list
     (defun python/init-company-anaconda ()
       (use-package company-anaconda
-        :if (configuration-layer/package-usedp 'company)
         :defer t
         :init (push 'company-anaconda company-backends-python-mode))))
 #+END_SRC

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -33,7 +33,7 @@
     persp-mode
     ))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun org/post-init-company ()
     (spacemacs|add-company-hook org-mode)
     (push 'company-capf company-backends-org-mode))

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -22,7 +22,7 @@
         web-mode
         ))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun react/post-init-company ()
     (spacemacs|add-company-hook react-mode))
 

--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -34,9 +34,8 @@
         ;; text properties are not applied correctly.
         (run-at-time 0.1 nil 'emoji-cheat-sheet-plus-display-mode)))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun emoji/init-company-emoji ()
     (use-package company-emoji
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init (setq company-emoji-insert-unicode nil))))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -79,10 +79,9 @@
     (setq company-clang-prefix-guesser 'company-mode/more-than-prefix-guesser)
     (spacemacs/add-to-hooks 'c-c++/load-clang-args '(c-mode-hook c++-mode-hook))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun c-c++/init-company-c-headers ()
     (use-package company-c-headers
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init (push 'company-c-headers company-backends-c-mode-common))))
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -235,7 +235,7 @@
   (unless (version< emacs-version "24.4")
     (add-hook 'cider-mode-hook 'subword-mode)))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun clojure/post-init-company ()
     (push 'company-capf company-backends-cider-mode)
     (spacemacs|add-company-hook cider-mode)

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -80,6 +80,6 @@
         "i" 'omnisharp-fix-usings
         "=" 'omnisharp-code-format))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun csharp/post-init-company ()
     (spacemacs|add-company-hook csharp-mode)))

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -22,7 +22,7 @@
 (defun d/init-d-mode ()
   (use-package d-mode :defer t))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun d/post-init-flycheck ()
     (spacemacs/add-flycheck-hook 'd-mode))
   (defun d/init-flycheck-dmd-dub ()

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -29,7 +29,7 @@
     (use-package flycheck-dmd-dub :defer t
       :init (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun d/post-init-company ()
     ;; Need to convince company that this C-derived mode is a code mode.
     (with-eval-after-load 'company-dabbrev-code (push 'd-mode company-dabbrev-code-modes))

--- a/layers/+lang/elm/packages-config.el
+++ b/layers/+lang/elm/packages-config.el
@@ -17,11 +17,10 @@
   (add-hook 'elm-mode-hook 'flycheck-mode)
   (add-hook 'elm-mode-hook 'spacemacs//elm-find-root))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun elm/init-flycheck-elm ()
     "Initialize flycheck-elm"
     (use-package flycheck-elm
-      :if (configuration-layer/package-usedp 'flycheck)
       :defer t
       :init (add-hook 'flycheck-mode-hook 'flycheck-elm-setup t))))
 

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -97,13 +97,12 @@
 (defun go/init-go-eldoc()
   (add-hook 'go-mode-hook 'go-eldoc-setup))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun go/post-init-company ()
     (spacemacs|add-company-hook go-mode))
 
   (defun go/init-company-go ()
     (use-package company-go
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       (progn

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -67,10 +67,9 @@
 (defun haskell/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'haskell-mode))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun haskell/init-flycheck-haskell ()
     (use-package flycheck-haskell
-      :if (configuration-layer/package-usedp 'flycheck)
       :commands flycheck-haskell-configure
       :init (add-hook 'flycheck-mode-hook 'flycheck-haskell-configure))))
 

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -30,7 +30,7 @@
     yasnippet
     ))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   ;;TODO: whenever company-web makes a backend for haml-mode it should be added here. -- @robbyoconnor
   (defun html/post-init-company ()
     (spacemacs|add-company-hook css-mode)

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -44,7 +44,7 @@
                                      (setq indent-line-function 'javascript/coffee-indent
                                            evil-shift-width coffee-tab-width))))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun javascript/post-init-company ()
     (spacemacs|add-company-hook js2-mode))
 

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -147,13 +147,12 @@
     "rT"    'reftex-toc-recenter
     "rv"    'reftex-view-crossref))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun latex/post-init-company ()
     (spacemacs|add-company-hook LaTeX-mode))
 
   (defun latex/init-company-auctex ()
     (use-package company-auctex
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       (progn

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -210,7 +210,7 @@ Will work on both org-mode and any mode that accepts plain html."
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-ess)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-rust))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun markdown/post-init-company ()
     (spacemacs|add-company-hook markdown-mode)
     (push 'company-capf company-backends-markdown-mode))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -25,12 +25,11 @@
 (defun ocaml/post-init-company ()
   (spacemacs|add-company-hook merlin-mode))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun ocaml/post-init-flycheck ()
     (spacemacs/add-flycheck-hook 'merlin-mode))
   (defun ocaml/init-flycheck-ocaml ()
     (use-package flycheck-ocaml
-      :if (configuration-layer/package-usedp 'flycheck)
       :defer t
       :init
       (progn

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -24,7 +24,7 @@
         phpunit
         ))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun php/post-init-company ()
     (spacemacs|add-company-hook php-mode)))
 

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -26,10 +26,9 @@
 (defun purescript/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'purescript-mode-hook))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun purescript/init-flycheck-purescript ()
     (use-package flycheck-purescript
-      :if (configuration-layer/package-usedp 'flycheck)
       :commands flycheck-purescript-configure
       :init (add-hook 'flycheck-mode-hook 'flycheck-purescript-configure))))
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -60,7 +60,7 @@
       (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
         (evil--jumps-push)))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun python/post-init-company ()
     (spacemacs|add-company-hook python-mode)
     (spacemacs|add-company-hook inferior-python-mode)
@@ -71,7 +71,6 @@
 
   (defun python/init-company-anaconda ()
     (use-package company-anaconda
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       (push 'company-anaconda company-backends-python-mode))))

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -44,7 +44,7 @@
         "bx" 'bundle-exec
         "bo" 'bundle-open))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun ruby/post-init-company ()
     (spacemacs|add-company-hook ruby-mode)
     (spacemacs|add-company-hook enh-ruby-mode)
@@ -117,7 +117,7 @@
       (spacemacs/register-repl 'robe 'robe-start "robe")
       (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
         (add-hook hook 'robe-mode))
-      (when (configuration-layer/layer-usedp 'auto-completion)
+      (when (configuration-layer/package-usedp 'company)
         (push 'company-robe company-backends-enh-ruby-mode)
         (push 'company-robe company-backends-ruby-mode)))
     :config

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -19,13 +19,12 @@
     toml-mode
     ))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun rust/post-init-flycheck ()
     (spacemacs/add-flycheck-hook 'rust-mode))
 
   (defun rust/init-flycheck-rust ()
     (use-package flycheck-rust
-      :if (configuration-layer/package-usedp 'flycheck)
       :defer t
       :init (add-hook 'flycheck-mode-hook #'flycheck-rust-setup))))
 

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -47,7 +47,7 @@
   (use-package toml-mode
     :mode "/\\(Cargo.lock\\|\\.cargo/config\\)\\'"))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun rust/post-init-company ()
     (push 'company-capf company-backends-rust-mode)
     (spacemacs|add-company-hook rust-mode)

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -66,7 +66,7 @@
         "sR" 'geiser-eval-region-and-go
         "ss" 'geiser-set-scheme))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun scheme/post-init-company ()
     ;; Geiser provides completion as long as company mode is loaded.
     (spacemacs|add-company-hook scheme-mode)))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -48,14 +48,13 @@
       (add-hook 'sh-mode-hook 'spacemacs//setup-shell))))
 
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun shell-scripts/post-init-company ()
     (spacemacs|add-company-hook sh-mode)
     (spacemacs|add-company-hook fish-mode))
 
   (defun shell-scripts/init-company-shell ()
     (use-package company-shell
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       (progn

--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -17,14 +17,13 @@
       (spacemacs/set-leader-keys
         "h>" 'helm-nixos-options))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun nixos/post-init-company ()
     (spacemacs|add-company-hook nix-mode)
     (push 'company-capf company-backends-nix-mode))
 
   (defun nixos/init-company-nixos-options ()
     (use-package company-nixos-options
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :init
       (push 'company-nixos-options company-backends-nix-mode))))

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -50,6 +50,6 @@
       (add-hook 'ledger-mode-hook 'evil-normalize-keymaps)
       (evilified-state-evilify ledger-report-mode ledger-report-mode-map))))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun finance/post-init-company ()
     (spacemacs|add-company-hook ledger-mode)))

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -17,7 +17,7 @@
     ))
 
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun finance/init-flycheck-ledger ()
     (with-eval-after-load 'flycheck
       (require 'flycheck-ledger))))

--- a/layers/+tools/ycmd/packages.el
+++ b/layers/+tools/ycmd/packages.el
@@ -9,10 +9,9 @@
   (message (concat "YCMD won't work unless you set the ycmd-server-command "
                    "variable to the path to a ycmd install.")))
 
-(when (configuration-layer/layer-usedp 'auto-completion)
+(when (configuration-layer/package-usedp 'company)
   (defun ycmd/init-company-ycmd ()
     (use-package company-ycmd
-      :if (configuration-layer/package-usedp 'company)
       :defer t
       :commands company-ycmd)))
 

--- a/layers/+tools/ycmd/packages.el
+++ b/layers/+tools/ycmd/packages.el
@@ -16,10 +16,9 @@
       :defer t
       :commands company-ycmd)))
 
-(when (configuration-layer/layer-usedp 'syntax-checking)
+(when (configuration-layer/package-usedp 'flycheck)
   (defun ycmd/init-flycheck-ycmd ()
     (use-package flycheck-ycmd
-      :if (configuration-layer/package-usedp 'flycheck)
       :defer t
       :init (add-hook 'ycmd-mode-hook 'flycheck-ycmd-setup))))
 


### PR DESCRIPTION
The rationale is that users may not have included `auto-completion` layer, but manage `company` themselves. They would want all these other layers to setup company related config, but in each layer, we are currently only checking `layer-usedp 'auto-completion`, etc.