### PR TITLE
Wrap PyPI packages with quotation mark

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -70,7 +70,7 @@ opening a python buffer:
 To fix this, install the =anaconda-mode= [[https://github.com/proofit404/anaconda-mode/blob/master/requirements.txt][anaconda-deps]] by hand:
 
 #+begin_src sh
-    pip install  jedi==0.8.1 json-rpc==1.8.1 service_factory==0.1.2
+    pip install 'jedi==0.8.1' 'json-rpc==1.8.1' 'service_factory==0.1.2'
 #+end_src
 
 Source: https://github.com/proofit404/anaconda-mode#issues


### PR DESCRIPTION
Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3
Because Zsh cannot run it.
```
% pip install jedi==0.8.1 json-rpc==1.8.1 service_factory==0.1.2
zsh: 0.8.1 not found
```

Bash can run both.
```
$ pip install jedi==0.8.1 json-rpc==1.8.1 service_factory==0.1.2
Requirement already satisfied (use --upgrade to upgrade): jedi==0.8.1 in /usr/local/lib/python2.7/dist-packages
Requirement already satisfied (use --upgrade to upgrade): json-rpc==1.8.1 in /usr/local/lib/python2.7/dist-packages
Requirement already satisfied (use --upgrade to upgrade): service_factory==0.1.2 in /usr/local/lib/python2.7/dist-packages
Requirement already satisfied (use --upgrade to upgrade): six in /usr/local/lib/python2.7/dist-packages (from service_factory==0.1.2)
```

```
$ pip install 'jedi==0.8.1' 'json-rpc==1.8.1' 'service_factory==0.1.2'
Requirement already satisfied (use --upgrade to upgrade): jedi==0.8.1 in /usr/local/lib/python2.7/dist-packages
Requirement already satisfied (use --upgrade to upgrade): json-rpc==1.8.1 in /usr/local/lib/python2.7/dist-packages
Requirement already satisfied (use --upgrade to upgrade): service_factory==0.1.2 in /usr/local/lib/python2.7/dist-packages
Requirement already satisfied (use --upgrade to upgrade): six in /usr/local/lib/python2.7/dist-packages (from service_factory==0.1.2)
```