### PR TITLE
[purescript] Pass mode rather than hooks to add-flycheck-hook

### DIFF
--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -24,7 +24,7 @@
   (spacemacs|add-company-hook purescript-mode))
 
 (defun purescript/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'purescript-mode-hook))
+  (spacemacs/add-flycheck-hook 'purescript-mode))
 
 (when (configuration-layer/package-usedp 'flycheck)
   (defun purescript/init-flycheck-purescript ()


### PR DESCRIPTION
The signature of `add-flycheck-hook` changed (compared to master) and it looks like the purescript layer still uses the old signature.