### PR TITLE
Restore easy ex-command remap

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -140,6 +140,9 @@ pressing `<leader> m`. Set it to `nil` to disable it.")
 (defvar dotspacemacs-major-mode-emacs-leader-key "C-M-m"
   "Major mode leader key accessible in `emacs state' and `insert state'")
 
+(defvar dotspacemacs-ex-key ":"
+  "The key used for Ex commands on normal and visual states.")
+
 (defvar dotspacemacs-command-key "SPC"
   "The key used for Emacs commands (M-x) (after pressing on the leader key).")
 (defvaralias 'dotspacemacs-emacs-command-key 'dotspacemacs-command-key

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -138,6 +138,9 @@ values."
    ;; Major mode leader key accessible in `emacs state' and `insert state'.
    ;; (default "C-M-m)
    dotspacemacs-major-mode-emacs-leader-key "C-M-m"
+   ;; The key used for Ex commands on normal and visual states.
+   ;; (default ":")
+   dotspacemacs-ex-key ":"
    ;; The key used for Emacs commands (M-x) (after pressing on the leader key).
    ;; (default "SPC")
    dotspacemacs-emacs-command-key "SPC"

--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -153,6 +153,9 @@
 
 (defun spacemacs-base/init-evil-evilified-state ()
   (use-package evil-evilified-state)
+  (define-key evil-normal-state-map (kbd dotspacemacs-ex-key) 'evil-ex)
+  (define-key evil-visual-state-map (kbd dotspacemacs-ex-key) 'evil-ex)
+  (define-key evil-motion-state-map (kbd dotspacemacs-ex-key) 'evil-ex)
   (define-key evil-evilified-state-map (kbd dotspacemacs-leader-key)
     spacemacs-default-map))
 


### PR DESCRIPTION
A [recent change (58e5241)](https://github.com/syl20bnr/spacemacs/commit/58e5241c8d96da0a2cf04d4897a74c9d1250875e#diff-7029ffb75eb55c012543d9cc2099a688R286) diminished command key into emacs command key. This provides the complementary remap variable for the ex command key `dotspacemacs-ex-key`.