### PR TITLE
Don’t explicitly set box attribute

### DIFF
--- a/layers/+distribution/spacemacs-bootstrap/packages.el
+++ b/layers/+distribution/spacemacs-bootstrap/packages.el
@@ -67,7 +67,6 @@
            (eval `(defface ,(intern (format "spacemacs-%s-face" state))
                     `((t (:background ,color
                                       :foreground ,(face-background 'mode-line)
-                                      :box ,(face-attribute 'mode-line :box)
                                       :inherit 'mode-line)))
                     (format "%s state face." state)
                     :group 'spacemacs))


### PR DESCRIPTION
Since the face inherits from mode-line this is unnecessary, and makes it difficult to change the mode-line box property.