### PR TITLE
core: remove support for all layers

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -885,9 +885,6 @@ path."
   (setq configuration-layer--layers nil)
   (setq configuration-layer-paths (configuration-layer//discover-layers))
   (unless configuration-layer-no-layer
-    (when (eq 'all dotspacemacs-configuration-layers)
-      (setq dotspacemacs-configuration-layers
-            (ht-keys configuration-layer-paths)))
     (dolist (layer dotspacemacs-configuration-layers)
       (let ((layer-name (if (listp layer) (car layer) layer)))
         (unless (string-match-p "+distribution"

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -107,8 +107,7 @@ If the value is nil then no banner is displayed.")
 when the current branch is not `develop'")
 
 (defvar dotspacemacs-configuration-layers '(emacs-lisp)
-  "List of configuration layers to load. If it is the symbol `all' instead
-of a list then all discovered layers will be installed.")
+  "List of configuration layers to load.")
 
 (defvar dotspacemacs-themes '(spacemacs-dark
                               spacemacs-light

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -28,8 +28,7 @@ values."
    ;; List of additional paths where to look for configuration layers.
    ;; Paths must have a trailing slash (i.e. `~/.mycontribs/')
    dotspacemacs-configuration-layer-path '()
-   ;; List of configuration layers to load. If it is the symbol `all' instead
-   ;; of a list then all discovered layers will be installed.
+   ;; List of configuration layers to load.
    dotspacemacs-configuration-layers
    '(
      ;; ----------------------------------------------------------------

--- a/tests/core/core-configuration-layer-ftest.el
+++ b/tests/core/core-configuration-layer-ftest.el
@@ -26,17 +26,6 @@
        (should (eq 'spacemacs-bootstrap
                    (oref (first configuration-layer--layers) :name)))))))
 
-(ert-deftest test-declare-layers--bootstrap-layer-always-first-all ()
-  (let ((dotspacemacs-distribution 'spacemacs)
-        (dotspacemacs-configuration-layers 'all)
-        (mocker-mock-default-record-cls 'mocker-stub-record))
-    (mocker-let
-     ((load (f) ((:output nil))))
-     (let (configuration-layer--layers)
-       (configuration-layer//declare-layers)
-       (should (eq 'spacemacs-bootstrap
-                   (oref (first configuration-layer--layers) :name)))))))
-
 (ert-deftest test-declare-layers--distribution-layer-is-second ()
   (let ((dotspacemacs-distribution 'spacemacs-base)
         (dotspacemacs-configuration-layers '(emacs-lisp
@@ -45,14 +34,3 @@
       (configuration-layer//declare-layers)
       (should (eq 'spacemacs-base
                   (oref (second configuration-layer--layers) :name))))))
-
-(ert-deftest test-declare-layers--distribution-layer-position-with-all-layers ()
-  (let ((dotspacemacs-distribution 'spacemacs-base)
-        (dotspacemacs-configuration-layers 'all)
-        (mocker-mock-default-record-cls 'mocker-stub-record))
-    (mocker-let
-     ((load (f) ((:output nil))))
-     (let (configuration-layer--layers)
-       (configuration-layer//declare-layers)
-       (should (eq 'spacemacs-base
-                   (oref (second configuration-layer--layers) :name)))))))


### PR DESCRIPTION
We have lazy installation now, and some layers are conflicting, while others are not really intended to be part of all (bepo).