### PR TITLE
core: misc. goodies for describe-package

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1505,7 +1505,8 @@ thusly:
 | ~SPC h d K~ | describe a keymap                                         |
 | ~SPC h d l~ | copy last pressed keys that you can paste in gitter chat  |
 | ~SPC h d m~ | describe current modes                                    |
-| ~SPC h d p~ | describe a package                                        |
+| ~SPC h d p~ | describe a package (Emacs built-in function)              |
+| ~SPC h d P~ | describe a package (Spacemacs layer information)          |
 | ~SPC h d s~ | copy system information that you can paste in gitter chat |
 | ~SPC h d t~ | describe a theme                                          |
 | ~SPC h d v~ | describe a variable                                       |

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -169,6 +169,7 @@
   "hdk" 'describe-key
   "hdl" 'spacemacs/describe-last-keys
   "hdp" 'describe-package
+  "hdP" 'configuration-layer/describe-package
   "hds" 'spacemacs/describe-system-info
   "hdt" 'describe-theme
   "hdv" 'describe-variable


### PR DESCRIPTION
- Use completing-read when called interactively
- Check for string locations in addition to built-in etc.
- Don’t double-print on/off for toggles
- Bind to SPC hdP