### PR TITLE
Consider adding vmd support in markdown mode

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -25,6 +25,7 @@ This layer adds markdown support to Spacemacs.
 
 ** Features:
 - markdown files support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
+- Fast Github-flavored live preview via [[https://github.com/blak3mill3r/vmd-mode][vmd-mode]]
 - TOC generation via [[https://github.com/ardumont/markdown-toc][markdown-toc]]
 - Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
   using the =emoji= layer or having a proper font) :clap:
@@ -37,6 +38,9 @@ For more extensive support of references with BibTeX files, have a look at the
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =markdown= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+To enable Github-flavored live preview, you will need to install the executable
+with =npm install -g vmd=.
 
 * Usage
 To generate a table of contents type on top of the buffer:
@@ -117,6 +121,7 @@ To generate a table of contents type on top of the buffer:
 | ~SPC m c m~ | other window                            |
 | ~SPC m c p~ | preview                                 |
 | ~SPC m c P~ | live preview in Emacs' built-in browser |
+| ~SPC m c d~ | Github-flavored live preview            |
 | ~SPC m c e~ | export                                  |
 | ~SPC m c v~ | export and preview                      |
 | ~SPC m c o~ | open                                    |

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -19,6 +19,7 @@
     markdown-toc
     mmm-mode
     smartparens
+    vmd-mode
     ))
 
 (defun markdown/post-init-company ()
@@ -216,3 +217,13 @@ Will work on both org-mode and any mode that accepts plain html."
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-javascript)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-ess)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-rust))))
+
+(defun markdown/init-vmd-mode ()
+  (use-package vmd-mode
+    :if (executable-find "vmd")
+    :defer t
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
+        ;; Github-flavored live preview in a separate window
+        "cd" 'vmd-mode))))


### PR DESCRIPTION
From its [project](https://github.com/blak3mill3r/vmd-mode) README:
> Fast Github-flavored Markdown previews synchronized with changes to an emacs buffer (no need to save).

In my opinion this is much better than the current live preview support in markdown mode. The only problem might be users need to explicitly install `vmd` binary (this is just as simple as  `npm install -g vmd`).

If you guys are interested, I can then document this functionality in later commits.