### PR TITLE
Fix chineselayer and add ivy-hydra package to ivy layer

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -16,12 +16,16 @@
         evil
         flx
         ivy
+        ivy-hydra
         (ivy-spacemacs-help :location local)
         persp-mode
         projectile
         smex
         swiper
         wgrep))
+
+(defun ivy/init-ivy-hydra ()
+  (use-package ivy-hydra))
 
 (defun ivy/init-counsel ()
   (use-package counsel

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -22,7 +22,7 @@
         ace-pinyin
         pangu-spacing
         org
-        (youdao-dictionary :toggle (configuration-layer/package-usedp 'chinese-enable-youdao-dict))
+        (youdao-dictionary :toggle (eq chinese-enable-youdao-dict t))
         ))
 
 (defun chinese/init-fcitx ()


### PR DESCRIPTION
Fix Chinese layer youdao-dictionary installation.

Add `ivy-hdyra` to ivy layer, since the ivy-hydra package has been removed from the ivy package and now it's a separate package.

http://melpa.org/#/ivy-hydra

@syl20bnr @TheBB 