### PR TITLE
Allow user to enable rainbow-identifiers-mode without making it default

### DIFF
--- a/layers/+themes/colors/README.org
+++ b/layers/+themes/colors/README.org
@@ -28,22 +28,12 @@ file.
 
 ** Enable rainbow-identifiers
 
-To enable the package =rainbow-identifiers= set the variable
-=colors-enable-rainbow-identifiers= to =t=:
+To enable =rainbow-identifiers-mode= by default, set the variable
+=colors-enable-rainbow-identifiers-by-default= to =t=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (colors :variables colors-enable-rainbow-identifiers t)))
-#+END_SRC
-
-You may also choose not to enable =rainbow-identifiers= by default
-by setting the =colors-rainbow-identifiers-add-hook= variable to =nil=:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(
-    (colors :variables
-            colors-enable-rainbow-identifiers   t
-            colors-rainbow-identifiers-add-hook nil)))
+    (colors :variables colors-enable-rainbow-identifiers-by-default t)))
 #+END_SRC
 
 Saturation and lightness of identifiers can be set per theme by adding

--- a/layers/+themes/colors/README.org
+++ b/layers/+themes/colors/README.org
@@ -36,6 +36,16 @@ To enable the package =rainbow-identifiers= set the variable
     (colors :variables colors-enable-rainbow-identifiers t)))
 #+END_SRC
 
+You may also choose not to enable =rainbow-identifiers= by default
+by setting the =colors-rainbow-identifiers-add-hook= variable to =nil=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (colors :variables
+            colors-enable-rainbow-identifiers   t
+            colors-rainbow-identifiers-add-hook nil)))
+#+END_SRC
+
 Saturation and lightness of identifiers can be set per theme by adding
 an entry in the variable =colors-theme-identifiers-sat&light=. This
 is an alist where the key is a theme symbol and the value is a pair

--- a/layers/+themes/colors/config.el
+++ b/layers/+themes/colors/config.el
@@ -11,11 +11,8 @@
 
 ;; Variables
 
-(defvar colors-enable-rainbow-identifiers nil
+(defvar colors-enable-rainbow-identifiers-by-default nil
   "If non nil the `rainbow-identifers' package is enabled.")
-
-(defvar colors-rainbow-identifiers-add-hook t
-  "If non nil then `rainbow-identifers-mode' is added to `prog-mode-hook'.")
 
 (defvar colors-enable-nyan-cat-progress-bar nil
   "If non nil all nyan cat packges are enabled (for now only `nyan-mode').")

--- a/layers/+themes/colors/config.el
+++ b/layers/+themes/colors/config.el
@@ -14,6 +14,9 @@
 (defvar colors-enable-rainbow-identifiers nil
   "If non nil the `rainbow-identifers' package is enabled.")
 
+(defvar colors-rainbow-identifiers-add-hook t
+  "If non nil then `rainbow-identifers-mode' is added to `prog-mode-hook'.")
+
 (defvar colors-enable-nyan-cat-progress-bar nil
   "If non nil all nyan cat packges are enabled (for now only `nyan-mode').")
 

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -62,7 +62,8 @@
         :documentation "Colorize identifiers globally."
         :evil-leader "tCi")
 
-      (add-hook 'prog-mode-hook 'rainbow-identifiers-mode)
+      (when colors-rainbow-identifiers-add-hook
+        (add-hook 'prog-mode-hook 'rainbow-identifiers-mode))
 
       (defun colors//tweak-theme-colors (theme)
         "Tweak color themes by adjusting rainbow-identifiers."

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -43,7 +43,6 @@
 
 (defun colors/init-rainbow-identifiers ()
   (use-package rainbow-identifiers
-    :if colors-enable-rainbow-identifiers
     :commands rainbow-identifiers-mode
     :init
     (progn
@@ -62,7 +61,7 @@
         :documentation "Colorize identifiers globally."
         :evil-leader "tCi")
 
-      (when colors-rainbow-identifiers-add-hook
+      (when colors-enable-rainbow-identifiers-by-default
         (add-hook 'prog-mode-hook 'rainbow-identifiers-mode))
 
       (defun colors//tweak-theme-colors (theme)


### PR DESCRIPTION
When you add the colors layer with the `rainbow-identifiers` package enabled (`colors-enable-rainbow-identifiers` variable set to `t`), currently the layer always adds `'rainbow-identifiers-mode` to the `prog-mode-hook`, essentially making it the default. This PR adds a new variable, `colors-rainbow-identifiers-add-hook`, which controls this behavior. Defaults to `t` (previous behavior); if set to `nil`, this hook is not created. This allows a user to install `rainbow-identifiers` through the preexisting layer, still getting the `SPC t C i` toggle binding, without turning it on by default.

Example usage has also been added to the README.org for the colors layer.

I've been running with this for a few months now, but just now got around to prettying it up for release; let me know if there's any style/naming issues.