### PR TITLE
helm-help: pass toggle candidates as list

### DIFF
--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -231,11 +231,12 @@
 
 (defun helm-spacemacs-help//toggle-source ()
   "Construct the helm source for the toggles."
-  (helm-build-sync-source "Toggles"
-    :candidates #'helm-spacemacs-help//toggle-candidates
-    :persistent-action #'helm-spacemacs-help//toggle
-    :keymap helm-map
-    :action (helm-make-actions "Toggle" #'helm-spacemacs-help//toggle)))
+  (let ((candidates (helm-spacemacs-help//toggle-candidates)))
+    (helm-build-sync-source "Toggles"
+      :candidates candidates
+      :persistent-action #'helm-spacemacs-help//toggle
+      :keymap helm-map
+      :action (helm-make-actions "Toggle" #'helm-spacemacs-help//toggle))))
 
 (defun helm-spacemacs-help//toggle-candidates ()
   "Return the sorted candidates for toggle source."


### PR DESCRIPTION
A problem I found with https://github.com/syl20bnr/spacemacs/pull/6178 is that helm evaluates the candidates with the current buffer being the *helm* buffer, thus most local toggles will have bogus statuses. This fixes that.

Can someone check whether the same has to be done with ivy?