### PR TITLE
make visual line move configurable

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -171,6 +171,9 @@ size to make separators look not too crappy.")
   "If non-nil, the shift mappings `<' and `>' retain visual state
 if used there.")
 
+(defvar dotspacemacs-visual-line-move t
+  "If non-nil, J and K move lines up and down when in visual mode.")
+
 (defvar dotspacemacs-ex-substitute-global nil
   "If non nil, inverse the meaning of `g' in `:substitute' Evil ex-command.")
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -157,6 +157,9 @@ values."
    ;; If non-nil, the shift mappings `<' and `>' retain visual state if used
    ;; there. (default t)
    dotspacemacs-retain-visual-state-on-shift t
+   ;; If non-nil, J and K move lines up and down when in visual mode.
+   ;; (default t)
+   dotspacemacs-visual-line-move t
    ;; If non nil, inverse the meaning of `g' in `:substitute' Evil ex-command.
    ;; (default nil)
    dotspacemacs-ex-substitute-global nil

--- a/layers/+distribution/spacemacs-bootstrap/packages.el
+++ b/layers/+distribution/spacemacs-bootstrap/packages.el
@@ -118,8 +118,9 @@
     (evil-map visual ">" ">gv"))
 
   ;; move selection up and down
-  (define-key evil-visual-state-map "J" (concat ":m '>+1" (kbd "RET") "gv=gv"))
-  (define-key evil-visual-state-map "K" (concat ":m '<-2" (kbd "RET") "gv=gv"))
+  (when dotspacemacs-visual-line-move
+    (define-key evil-visual-state-map "J" (concat ":m '>+1" (kbd "RET") "gv=gv"))
+    (define-key evil-visual-state-map "K" (concat ":m '<-2" (kbd "RET") "gv=gv")))
 
   (evil-ex-define-cmd "enew" 'spacemacs/new-empty-buffer)
 


### PR DESCRIPTION
This is a non-standard key binding and really should be configurable (really, it
should be in a vim-tweaks layer but that's a different story). For people like
me with muscle memory from vim, deviations from vim can be very frustrating.