### PR TITLE
Add mu4e support to the bepo layer

### DIFF
--- a/layers/+keyboard-layouts/bepo/packages.el
+++ b/layers/+keyboard-layouts/bepo/packages.el
@@ -26,6 +26,7 @@
     helm
     ivy
     magit
+    mu4e
     neotree
     org
     org-agenda
@@ -323,6 +324,26 @@
       (magit-change-popup-key 'magit-dispatch-popup :actions ?t ?j)
       (magit-change-popup-key 'magit-dispatch-popup :actions ?s ?k)
       (magit-change-popup-key 'magit-dispatch-popup :actions ?S ?K))))
+
+(defun bepo/pre-init-mu4e ()
+  (bepo|config mu4e
+    :description
+    "Remap navigation keys in `mu4e' headers and view mode"
+    :loader
+    (spacemacs|use-package-add-hook mu4e :post-config BODY)
+    :config
+    (dolist (map (list mu4e-headers-mode-map
+                       mu4e-view-mode-map))
+      (bepo/evil-correct-keys 'evilified map
+        "h"
+        "j"
+        "k"
+        "l"
+        )
+      (evil-define-key 'evilified map
+        "è" 'mu4e-headers-mark-subthread
+        "/" 'mu4e-headers-search
+        ))))
 
 (defun bepo/pre-init-neotree ()
   (bepo|config neotree


### PR DESCRIPTION
In mu4e headers and view mode `hjkl` are movements keys.
This commit replace these with `csrt`.
`t` and `s` are in both mode bind to important mu4e functions for tagging mail and searching.
I propose to remap them respectively to `è` which is the original `t` place on Azerty keyboard and `/` which is the robust search binding everywhere in spacemacs. 
