### PR TITLE
csharp: enable evil-matchit for C-like tags

### DIFF
--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -12,6 +12,7 @@
 (setq csharp-packages
   '(
     company
+    evil-matchit
     omnisharp
     ))
 
@@ -82,3 +83,9 @@
 
 (defun csharp/post-init-company ()
   (spacemacs|add-company-hook csharp-mode))
+
+(defun csharp/post-init-evil-matchit ()
+  (with-eval-after-load 'evil-matchit
+    (plist-put evilmi-plugins 'csharp-mode '((evilmi-simple-get-tag evilmi-simple-jump)
+                                             (evilmi-c-get-tag evilmi-c-jump))))
+  (add-hook 'csharp-mode-hook 'turn-on-evil-matchit-mode))


### PR DESCRIPTION
The evil-matchit plugin does not have built-in support for C#, but I followed their instructions (and compared to some other code in Spacemacs) to set it up for C# with simple and C tag support.

Thus, `%` now works as expected on, say `#if ... #else ... #endif`, and `switch` statements as well as their cases.

This is an enhancement.