### PR TITLE
ahs-to-iedit: restrict iedit region to ahs range

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -234,10 +234,14 @@
         (cond
          ((and (not (eq dotspacemacs-editing-style 'emacs))
                (configuration-layer/package-usedp 'evil-iedit-state))
-          (evil-iedit-state/iedit-mode))
+          (evil-iedit-state/iedit-mode)
+          (iedit-restrict-region (ahs-current-plugin-prop 'start)
+                                 (ahs-current-plugin-prop 'end)))
          ((and (eq dotspacemacs-editing-style 'emacs)
                (configuration-layer/package-usedp 'iedit))
-          (iedit-mode))
+          (iedit-mode)
+          (iedit-restrict-region (ahs-current-plugin-prop 'start)
+                                 (ahs-current-plugin-prop 'end)))
          (t (ahs-edit-mode t))))
 
       (spacemacs|define-transient-state symbol-highlight


### PR DESCRIPTION
Fixes #6223. AHS (auto-highlight-search) can restrict the search to "ranges" (whole buffer, function, display area). Now when `ahs-to-iedit` calls Iedit it also restricts Iedit to AHS's active range.
Each range is called in AHS a "plugin", and this fix should work also for user-defined AHS plugins.

@darkfeline can you confirm that the issue is fixed?