### PR TITLE
spacemacs-base: Always kill buffers with SPC b d

### DIFF
--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -247,7 +247,7 @@ To map ~<Leader>~ keybindings, use the =spacemacs/set-leader-keys= function.
 #+begin_src emacs-lisp
   (spacemacs/set-leader-keys key function) ; Syntax
   ;; Map killing a buffer to <Leader> b c
-  (spacemacs/set-leader-keys "bc" 'kill-this-buffer)
+  (spacemacs/set-leader-keys "bc" 'spacemacs/kill-this-buffer)
   ;; Map opening a link to <Leader> o l only in org-mode (works for any major-mode)
   (spacemacs/set-leader-keys-for-major-mode 'org-mode
     "ol" 'org-open-at-point)

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -176,7 +176,7 @@
            (condition-case-unless-debug nil
                (with-current-buffer (find-file-noselect file)
                  (gh-md-render-buffer)
-                 (kill-this-buffer))
+                 (spacemacs/kill-this-buffer))
              ;; if anything fails, fall back to simply open file
              (find-file file)))
           ((equal (file-name-extension file) "org")

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -98,7 +98,7 @@
            (condition-case-unless-debug nil
                (with-current-buffer (find-file-noselect file)
                  (gh-md-render-buffer)
-                 (kill-this-buffer))
+                 (spacemacs/kill-this-buffer))
              ;; if anything fails, fall back to simply open file
              (find-file file)))
           ((equal (file-name-extension file) "org")

--- a/layers/+distribution/spacemacs-base/funcs.el
+++ b/layers/+distribution/spacemacs-base/funcs.el
@@ -402,6 +402,14 @@ removal."
       (buffer-disable-undo)
       (fundamental-mode))))
 
+;; our own implementation of kill-this-buffer from menu-bar.el
+(defun spacemacs/kill-this-buffer ()
+  "Kill the current buffer."
+  (interactive)
+  (if (window-minibuffer-p)
+      (abort-recursive-edit)
+    (kill-buffer (current-buffer))))
+
 ;; found at http://emacswiki.org/emacs/KillingBuffers
 (defun spacemacs/kill-other-buffers ()
   "Kill all other buffers."

--- a/layers/+distribution/spacemacs-base/keybindings.el
+++ b/layers/+distribution/spacemacs-base/keybindings.el
@@ -117,7 +117,7 @@
   "au"  'undo-tree-visualize)
 ;; buffers --------------------------------------------------------------------
 (spacemacs/set-leader-keys
-  "bd"  'kill-this-buffer
+  "bd"  'spacemacs/kill-this-buffer
   "TAB" 'spacemacs/alternate-buffer
   "bh"  'spacemacs/home
   "be"  'spacemacs/safe-erase-buffer
@@ -418,7 +418,7 @@
   ("n" spacemacs/next-useful-buffer "next")
   ("N" spacemacs/previous-useful-buffer "previous")
   ("p" spacemacs/previous-useful-buffer "previous")
-  ("K" kill-this-buffer "kill")
+  ("K" spacemacs/kill-this-buffer "kill")
   ("q" nil "quit" :exit t))
 (spacemacs/set-leader-keys "b." 'spacemacs/buffer-transient-state/body)
 


### PR DESCRIPTION
The `kill-this-buffer` function is from `menu-bar.el` and has some checks which caused https://github.com/syl20bnr/spacemacs/issues/4929. This replaces it with our own naive implementation.

The menu-bar version also calls `abort-recursive-edit` if the minibuffer is open, not sure if we need that here. Is it possible to trigger the `SPC` leader from the minibuffer?