### PR TITLE
Work around the fact that w32-initialized is t too early for us

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -29,11 +29,15 @@ the display system initialized."
   "If the display-system is initialized, run `BODY', otherwise,
 add it to a queue of actions to perform after the first graphical frame is
 created."
-  `(let ((init (cond ((boundp 'ns-initialized) 'ns-initialized)
-                     ((boundp 'w32-initialized) 'w32-initialized)
-                     ((boundp 'x-initialized) 'x-initialized)
+  `(let ((init (cond ((boundp 'ns-initialized) ns-initialized)
+                     ;; w32-initialized gets set too early, so
+                     ;; if we're on Windows, check the list of fonts
+                     ;; instead (this is nil until the graphics system
+                     ;; is initialized)
+                     ((boundp 'w32-initialized) (font-family-list))
+                     ((boundp 'x-initialized) x-initialized)
                      (t 't))))           ; fallback to normal loading behavior
-     (if (symbol-value init)
+     (if init
          (progn
            ,@body)
        (push (lambda () ,@body) spacemacs--after-display-system-init-list))))


### PR DESCRIPTION
Unlike the symbols ```x-initialized``` and ```ns-initialized```, the symbol ```w32-initialized``` is true in daemon mode before GUI functions like ```(find-font)``` work. As a result, ```spacemacs|do-after-display-system-init ``` does not work as expected on Windows in daemon mode.

This patch changes the behaviour on Windows to queue the action if ```(font-family-list)``` is still nil, on the basis that once ```(font-family-list)``` is available, we know that the GUI must be set up.

It's possible that the same check would be just as good on Unix/OSX, but I don't have these systems to check on, and I didn't want to modify working code for no good reason.