### PR TITLE
Fixing dash layer variable names.

### DIFF
--- a/layers/+tools/dash/config.el
+++ b/layers/+tools/dash/config.el
@@ -9,5 +9,5 @@
 ;;
 ;;; License: GPLv3
 
-(defvar dash-helm-dash-docset-path ""
+(defvar helm-dash-docset-newpath "~/.docsets"
   "Path containing dash docsets.")

--- a/layers/+tools/dash/packages.el
+++ b/layers/+tools/dash/packages.el
@@ -25,7 +25,7 @@
             helm-dash-common-docsets (helm-dash-installed-docsets))
       (message (format "activated %d docsets from: %s"
                        (length helm-dash-common-docsets) path)))
-    (dash//activate-package-docsets dash-helm-dash-docset-path)))
+    (dash//activate-package-docsets helm-dash-docset-newpath)))
 
 (defun dash/init-dash-at-point ()
   (use-package dash-at-point


### PR DESCRIPTION
As reported in #5694 dash layer cannot be configured according to the
documentation. This commit fixes that, and allows you to actually define docset
path with `helm-dash-docset-newpath`. It also defines more sensible default for
docset `~/.docsets`, which is the default path for helm-dash.

Fixes #5694