### PR TITLE
Add javascript-standard as a flycheck checker to react-mode

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -36,7 +36,8 @@
 
 (defun react/post-init-flycheck ()
   (with-eval-after-load 'flycheck
-    (flycheck-add-mode 'javascript-eslint 'react-mode))
+    (dolist (checker '(javascript-eslint javascript-standard))
+      (flycheck-add-mode checker 'react-mode)))
   (defun react/use-eslint-from-node-modules ()
     (let* ((root (locate-dominating-file
                   (or (buffer-file-name) default-directory)


### PR DESCRIPTION
By default the only available checker in `react-mode` is
javascript-eslint. `javascript-standard` is based on `javascript-eslint`
and has some modification on rules. Since it's not defined as a checker
for this mode, it's also impossible to select it in a buffer.