### PR TITLE
bootstrap: spacemacs/set-state-faces function

### DIFF
--- a/layers/+distribution/spacemacs-bootstrap/funcs.el
+++ b/layers/+distribution/spacemacs-bootstrap/funcs.el
@@ -34,6 +34,13 @@
                   evil-state)))
     (spacemacs/state-color-face state)))
 
+(defun spacemacs/set-state-faces ()
+  (cl-loop for (state color cursor) in spacemacs-evil-cursors
+           do
+           (set-face-attribute (intern (format "spacemacs-%s-face" state))
+                               nil
+                               :foreground (face-background 'mode-line))))
+
 (defun evil-insert-state-cursor-hide ()
   (setq evil-insert-state-cursor '((hbar . 0))))
 


### PR DESCRIPTION
This function is called from core-themes-support.el if it exists, but it doesn't exist. This fixes some annoying faces in daemon mode for me.

I'm not sure why it was removed though.