### PR TITLE
elm: update documentation and key bindings

### DIFF
--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -152,8 +152,6 @@ can be controlled by passing in these variables in your =~/.spacemacs=:
 | Key Binding | Description          |
 |-------------+----------------------|
 | ~g~         | elm-package-refresh  |
-| ~n~         | elm-package-next     |
-| ~p~         | elm-package-previous |
 | ~v~         | elm-package-view     |
 | ~m~         | elm-package-mark     |
 | ~u~         | elm-package-unmark   |

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -20,7 +20,8 @@
    - [[#elm-reactor][elm-reactor]]
    - [[#elm-package][elm-package]]
      - [[#package-list-buffer][package list buffer]]
-   - [[#elm-oracle][elm-oracle]]
+   - [[#elm-oracle-1][elm-oracle]]
+   - [[#refactoring][Refactoring]]
 
 * Description
 This layer adds support for [[http://elm-lang.org][Elm]].
@@ -164,3 +165,8 @@ can be controlled by passing in these variables in your =~/.spacemacs=:
 |-------------+--------------------------|
 | ~SPC m h t~ | elm-oracle-type-at-point |
 
+** Refactoring
+
+| Key Binding | Description      |
+|-------------+------------------|
+| ~SPC m r i~ | elm-sort-imports |

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -14,6 +14,7 @@
  - [[#basic-usage-tips][Basic usage tips]]
    - [[#compilation][Compilation]]
    - [[#reactor][Reactor]]
+   - [[#sort-imports-on-save][Sort imports on save]]
  - [[#key-bindings][Key bindings]]
    - [[#elm-make][elm-make]]
    - [[#elm-repl][elm-repl]]
@@ -112,6 +113,14 @@ can be controlled by passing in these variables in your =~/.spacemacs=:
   (elm :variables
        elm-reactor-port "3000"          ; default 8000
        elm-reactor-address "0.0.0.0") ; default 127.0.0.1
+#+END_SRC
+
+** Sort imports on save
+Set ~elm-sort-imports-on-save~ to ~t~ to sort the imports in the current file on
+every save.
+
+#+BEGIN_SRC emacs-lisp
+  (elm :variables elm-sort-imports-on-save t)
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -60,6 +60,9 @@
         ;; oracle
         "ht" 'elm-oracle-type-at-point
 
+        ;; refactoring
+        "ri" 'elm-sort-imports
+
         ;; repl
         "'"  'elm-repl-load
         "si" 'elm-repl-load
@@ -81,6 +84,7 @@
                    ("mc" . "compile")
                    ("mh" . "help")
                    ("mp" . "package")
+                   ("mr" . "refactor")
                    ("ms" . "repl")))
         (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x)))
 

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -86,8 +86,6 @@
 
       (evilified-state-evilify elm-package-mode elm-package-mode-map
         "g" 'elm-package-refresh
-        "n" 'elm-package-next
-        "p" 'elm-package-prev
         "v" 'elm-package-view
         "m" 'elm-package-mark
         "u" 'elm-package-unmark


### PR DESCRIPTION
* allow `n` to work as ~~deity~~vim intended
* make `elm-sort-imports` more easily accessible