### PR TITLE
jabber: don't overwrite mini-buffer and other annoyances

### DIFF
--- a/layers/+chat/jabber/packages.el
+++ b/layers/+chat/jabber/packages.el
@@ -33,3 +33,17 @@
       (evilified-state-evilify jabber-roster-mode jabber-roster-mode-map
         "j" 'jabber-go-to-next-roster-item
         "k" 'jabber-go-to-previous-roster-item))))
+
+(defun jabber/jabber-connect-hook (jc)
+  (jabber-send-presence "" "Online" 10)
+  (jabber-whitespace-ping-start)
+
+  ;; Disable the minibuffer getting jabber messages when active
+  ;; See http://www.emacswiki.org/JabberEl
+  (define-jabber-alert echo "Show a message in the echo area"
+    (lambda (msg)
+      (unless (minibuffer-prompt)
+        (message "%s" msg)))))
+
+(defun jabber/post-init-jabber ()
+  (add-hook 'jabber-post-connect-hooks 'jabber/jabber-connect-hook))


### PR DESCRIPTION
jabber.el has the annoying habit of overwriting the mini-buffer with status messages, even when the mini-buffer is active (you are entering a command or whatever), this stops that.

sets status to online when connecting

jabber-whitespace-ping-start to help keep from getting disconnected