### PR TITLE
Add twittering-mode support to bepo layer

### DIFF
--- a/layers/+keyboard-layouts/bepo/packages.el
+++ b/layers/+keyboard-layouts/bepo/packages.el
@@ -31,6 +31,7 @@
     org
     org-agenda
     ranger
+    twittering-mode
     ))
 
 (defun bepo/pre-init-ace-window ()
@@ -450,3 +451,20 @@
       "K"
       "J"
       "L")))
+
+(defun bepo/pre-init-twittering-mode ()
+  (bepo|config twittering-mode
+    :description
+    "Remap navigation keys in `twittering-mode'."
+    :loader
+    (spacemacs|use-package-add-hook twittering-mode BODY)
+    :config
+      (bepo/correct-keys twittering-mode-map
+        "h"
+        "j"
+        "k"
+        "l"
+        ;;
+        "H"
+        "J"
+        "K")))


### PR DESCRIPTION
Add bepo `ctsr` movement key in place of `hjkl` in twittering-mode.
Based on twitter layer bindings only `r`, `R` (stands for retweet functions) and `t` functions are shadowed by remapping. 
These function got mapped by symmetry to `h`, `H` and `j` respectively. 