### PR TITLE
Enable make completion with ivy

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -15,6 +15,7 @@
         (counsel-projectile :toggle (configuration-layer/package-usedp 'projectile))
         evil
         flx
+        helm-make
         ivy
         ivy-hydra
         (ivy-spacemacs-help :location local)
@@ -114,6 +115,15 @@
           ("f" spacemacs/search-auto-region-or-symbol :exit t))))
 
 (defun ivy/init-flx ())
+
+(defun ivy/init-helm-make ()
+  (use-package helm-make
+    :defer t
+    :init
+    (setq helm-make-completion-method 'ivy)
+    (spacemacs/set-leader-keys
+      "cc" 'helm-make-projectile
+      "cm" 'helm-make)))
 
 (defun ivy/init-ivy ()
   (use-package ivy


### PR DESCRIPTION
Invoking "make" or "project compilation" (<kbd>SPC c m</kbd>, <kbd>SPC c c</kbd>) is currently not supported in ivy mode. The PR re-enables them by adding helm-make to the ivy packages with ivy completion method.