### PR TITLE
Add custom evil-register listing with ivy.

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -245,8 +245,29 @@ To prevent this error we just wrap `describe-mode' to defeat the
         (unless (eq ivy-exit 'done)
           (swiper--cleanup)
           (swiper--add-overlays (ivy--regex ivy-text)))))))
-
 
+
+;; Evil
+
+(defun spacemacs/ivy-evil-registers ()
+  "Show evil registers"
+  (interactive)
+  (let ((ivy-height 24))
+    (ivy-read "Evil Registers:"
+              (cl-loop for (key . val) in (evil-register-list)
+                       collect (eval `(format "%s : %s" (propertize ,(char-to-string key) 'face 'font-lock-builtin-face)
+                                              ,(or (and val
+                                                        (stringp val)
+                                                        (replace-regexp-in-string "\n" "^J" val))
+                                                   ""))))
+              :action #'spacemacs/ivy-insert-evil-register)))
+
+(defun spacemacs/ivy-insert-evil-register (candidate)
+  (insert (replace-regexp-in-string "\\^J" "\n"
+                                    (substring-no-properties candidate 4))))
+
+
+
 ;; Ivy
 
 (defun spacemacs//ivy-command-not-implemented-yet (key)
@@ -268,7 +289,8 @@ To prevent this error we just wrap `describe-mode' to defeat the
                         (require (car repl))
                         (call-interactively (cdr repl))))))
 
-
+
+
 ;; Layouts
 
 (defun spacemacs/ivy-spacemacs-layouts ()

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -25,8 +25,13 @@
         swiper
         wgrep))
 
-(defun ivy/init-ivy-hydra ()
-  (use-package ivy-hydra))
+(defun ivy/post-init-auto-highlight-symbol ()
+  (setq spacemacs-symbol-highlight-transient-state-remove-bindings
+        '("/" "b" "f"))
+  (setq spacemacs-symbol-highlight-transient-state-add-bindings
+        '(("/" spacemacs/search-project-auto-region-or-symbol :exit t)
+          ("b" spacemacs/swiper-all-region-or-symbol :exit t)
+          ("f" spacemacs/search-auto-region-or-symbol :exit t))))
 
 (defun ivy/init-counsel ()
   (use-package counsel
@@ -106,13 +111,9 @@
           "pf" 'counsel-projectile-find-file
           "pr" 'projectile-recentf)))))
 
-(defun ivy/post-init-auto-highlight-symbol ()
-  (setq spacemacs-symbol-highlight-transient-state-remove-bindings
-        '("/" "b" "f"))
-  (setq spacemacs-symbol-highlight-transient-state-add-bindings
-        '(("/" spacemacs/search-project-auto-region-or-symbol :exit t)
-          ("b" spacemacs/swiper-all-region-or-symbol :exit t)
-          ("f" spacemacs/search-auto-region-or-symbol :exit t))))
+(defun ivy/post-init-evil ()
+  (spacemacs/set-leader-keys
+    "re" 'spacemacs/ivy-evil-registers))
 
 (defun ivy/init-flx ())
 
@@ -158,6 +159,9 @@
         "w" 'ivy-wgrep-change-to-wgrep-mode)
       ;; Why do we do this ?
       (ido-mode -1))))
+
+(defun ivy/init-ivy-hydra ()
+  (use-package ivy-hydra))
 
 (defun ivy/post-init-persp-mode ()
   (ivy-set-actions


### PR DESCRIPTION
Add function to display list of `evil-registers` in `ivy`, overwriting basic evil-register binding.  