### PR TITLE
GNE (Generalized next-error)

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2216,13 +2216,17 @@ called =pt=.
 
 **** Useful key bindings
 
-| Key Binding            | Description                                                              |
-|------------------------+--------------------------------------------------------------------------|
-| ~F3~                   | in a =helm= buffer, convert a =helm= search buffer into a regular buffer |
-| ~SPC r l~              | resume the last =completion= buffer                                      |
-| ~SPC r s~ or ~SPC s l~ | resume search buffer (completion or converted search buffer)             |
-| ~SPC s `~              | go back to the previous place reached with =helm-ag=                     |
-| Prefix argument        | will ask for file extensions                                             |
+| Key Binding            | Description                                                   |
+|------------------------+---------------------------------------------------------------|
+| ~F3~                   | in a =helm= or =ivy= buffer, save results to a regular buffer |
+| ~SPC r l~              | resume the last =completion= buffer                           |
+| ~SPC r s~ or ~SPC s l~ | resume search buffer (completion or converted search buffer)  |
+| ~SPC s `~              | go back to the previous place reached with =helm-ag=          |
+| Prefix argument        | will ask for file extensions                                  |
+
+When results have been saved in a regular buffer with ~F3~, that buffer supports
+browsing through the matches with Spacemacs’ =next-error= and =previous-error=
+bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~).
 
 **** Searching in current file
 
@@ -2904,6 +2908,12 @@ Errors management commands (start with ~e~):
 | ~SPC e n~   | go to the next error                                                  |
 | ~SPC e p~   | go to the previous error                                              |
 | ~SPC e v~   | verify flycheck setup (useful to debug 3rd party tools configuration) |
+| ~SPC e .~   | error transient state                                                 |
+
+The next/previous error bindings and the error transient state can be used to
+browse errors from flycheck as well as errors from compilation buffers, and
+indeed anything that supports Emacs’ =next-error= API. This includes for example
+search results that have been saved to a separate buffer.
 
 Custom fringe bitmaps:
 

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -156,3 +156,30 @@ Ensure that helm is required before calling FUNC."
   "Exits helm, opens a dired buffer and immediately switches to editable mode."
   (interactive)
   (helm-exit-and-execute-action 'spacemacs//helm-find-files-edit))
+
+
+;; Generalized next-error interface
+
+(defun spacemacs//gne-init-helm-ag (&rest args)
+  (with-current-buffer "*helm ag results*"
+    (setq spacemacs--gne-min-line 5
+          spacemacs--gne-max-line (save-excursion
+            (goto-char (point-max))
+            (previous-line)
+            (line-number-at-pos))
+          spacemacs--gne-line-func
+          (lambda (c)
+            (helm-ag--find-file-action
+             c 'find-file helm-ag--search-this-file-p))
+          next-error-function 'spacemacs//gne-next)))
+
+(defun spacemacs//gne-init-helm-grep (&rest args)
+  (with-current-buffer "*hgrep*"
+    (setq spacemacs--gne-min-line 5
+          spacemacs--gne-max-line
+          (save-excursion
+            (goto-char (point-max))
+            (previous-line)
+            (line-number-at-pos))
+          spacemacs--gne-line-func 'helm-grep-action
+          next-error-function 'spacemacs//gne-next)))

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -120,6 +120,7 @@
     :config
     (progn
       (helm-mode)
+      (advice-add 'helm-grep-save-results-1 :after 'spacemacs//gne-init-helm-grep)
       ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
       (helm-locate-set-command)
       (setq helm-locate-fuzzy-match (string-match "locate" helm-locate-command))
@@ -439,6 +440,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "stP" 'spacemacs/helm-project-do-pt-region-or-symbol))
     :config
     (progn
+      (advice-add 'helm-ag--save-results :after 'spacemacs//gne-init-helm-ag)
       (evil-define-key 'normal helm-ag-map "SPC" spacemacs-default-map)
       (evilified-state-evilify helm-ag-mode helm-ag-mode-map
         (kbd "RET") 'helm-ag-mode-jump-other-window

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -139,6 +139,33 @@
   "en" 'spacemacs/next-error
   "eN" 'spacemacs/previous-error
   "ep" 'spacemacs/previous-error)
+(spacemacs|define-transient-state error
+  :title "Error transient state"
+  :hint-is-doc t
+  :dynamic-hint
+  (let ((sys (spacemacs//error-delegate)))
+    (cond
+     ((eq 'flycheck sys)
+      "\nBrowsing flycheck errors from this buffer.")
+     ((eq 'emacs sys)
+      (let ((buf (next-error-find-buffer)))
+        (if buf
+            (concat "\nBrowsing entries from \""
+                    (buffer-name buf)
+                    "\""
+                    (with-current-buffer buf
+                      (when spacemacs--gne-line-func
+                        (format " (%d of %d)"
+                                (max 1 (1+ (- spacemacs--gne-cur-line
+                                              spacemacs--gne-min-line)))
+                                (1+ (- spacemacs--gne-max-line
+                                       spacemacs--gne-min-line))))))
+          "\nNo next-error capable buffer found.")))))
+  :bindings
+  ("n" spacemacs/next-error "next")
+  ("p" spacemacs/previous-error "prev")
+  ("q" nil "quit" :exit t)
+  :evil-leader "e.")
 ;; file -----------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "fc" 'spacemacs/copy-file


### PR DESCRIPTION
This PR does a few different things.

- Refactor the `spacemacs/next-error` and `spacemacs/previous-error` to use a common function to choose which system to use (flycheck or emacs). Also make sure that this function looks for *any* `next-error` capable buffer, and not just one named `*compilation*`.
- Implement a small "generalized" next-error interface that can run in any buffer that stores the results from searches. It plugs in the Emacs next-error system.
- Implement an "error" transient state on `SPC e .` that works with all these systems: it shows which system is in use, and displays additional information from GNE if the next-error buffer in use supports it.
- Advice the functions from helm-grep and helm-ag that saves the results in a buffer (bound to F3 in both cases) to set up the GNE in those buffers.
- Add a keymap to the Spacemacs counsel search with an action on F3 that does the same as the helm variants: writes the results to a buffer. Also set up the GNE in this buffer.

This should fix at least https://github.com/syl20bnr/spacemacs/issues/2452.

This PR is WIP only because I am at a conference right now with limited Emacs capabilities so I can't check if I did everything correctly, but I had it working yesterday in my own config so I'll double check tonight if I got it all right.