### PR TITLE
Enable volatile highlights for evil and undo-tree

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -377,5 +377,12 @@
     :config
     (progn
       (volatile-highlights-mode t)
-      (spacemacs|hide-lighter volatile-highlights-mode))))
-
+      (spacemacs|hide-lighter volatile-highlights-mode)
+      (vhl/define-extension 'evil 'evil-paste-after 'evil-paste-before 'evil-paste-pop 'evil-move)
+      (vhl/define-extension 'undo-tree 'undo-tree-yank 'undo-tree-move)
+      (with-eval-after-load 'evil
+        (vhl/install-extension 'evil)
+        (vhl/load-extension 'evil))
+      (with-eval-after-load 'undo-tree
+        (vhl/install-extension 'undo-tree)
+        (vhl/load-extension 'undo-tree)))))


### PR DESCRIPTION
These are not enabled by default.  This patch uses a modified version of the examples [here](https://github.com/k-talo/volatile-highlights.el).