### PR TITLE
Fix #6274 : making buffer-move bepo bindings when needed

### DIFF
--- a/layers/+keyboard-layouts/bepo/packages.el
+++ b/layers/+keyboard-layouts/bepo/packages.el
@@ -59,12 +59,10 @@
     :config
     (setq-default avy-keys '(?t ?e ?s ?i ?r ?u ?n ?a ?c ?,))))
 
-(defun bepo/pre-init-buffer-move ()
+(defun bepo/post-init-buffer-move ()
   (bepo|config buffer-move
     :description
     "Remap `buffer-move' bindings."
-    :loader
-    (with-eval-after-load 'buffer-move BODY)
     :config
     (bepo/leader-correct-keys
       "bmh"


### PR DESCRIPTION
As stated in #6274 buffer-move bepo bindings are set only after one use of a buffer-move command.
The behavior is caused by the mapping being set in a `(with-eval-after-load 'buffer-move BODY)`, but `buffer-move.el` isn't loaded until you call one of its function.

The idea here it to make bindings instantly and not eval them after a file-loading. For that I used a `bepo/post-init-buffer-move` instead of a `bepo/pre-init-buffer-move`. I do not know if this is the correct fix or if that change implies undesirable consequences (there is no post-init anywhere in the `packages.el`).
