### PR TITLE
Add keybinding for magit-reset-popup

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -124,6 +124,7 @@ Git commands (start with ~g~):
 | ~SPC g I~   | open =helm-gitignore=                               |
 | ~SPC g l~   | open a =magit= log                                  |
 | ~SPC g L~   | display the log for a file                          |
+| ~SPC g O~   | show reset prompt                                   |
 | ~SPC g r~   | show rebase prompt                                  |
 | ~SPC g P~   | show push prompt                                    |
 | ~SPC g s~   | open a =magit= status window                        |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -141,6 +141,7 @@
         "gi" 'magit-init
         "gl" 'magit-log-popup
         "gL" 'magit-log-buffer-file
+        "gO" 'magit-reset-popup
         "gr" 'magit-rebase-popup
         "gP" 'magit-push-popup
         "gs" 'magit-status


### PR DESCRIPTION
I felt like this was missing. It matches `magit`'s keybinding. 