### PR TITLE
haskell: Don't enable haskell-tags-on-save

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -113,8 +113,6 @@
      ;; Use notify.el (if you have it installed) at the end of running
      ;; Cabal commands or generally things worth notifying.
      haskell-notify-p t
-     ;; To enable tags generation on save.
-     haskell-tags-on-save t
      ;; Remove annoying error popups
      haskell-interactive-popup-errors nil
      ;; Better import handling


### PR DESCRIPTION
This is a very opinionated option and works very poorly on even
moderately large projects as it invokes `hasktags` synchronously,
freezing the editor for several seconds on every save. Users who want
this behavior should enable it manually.

Fixes #6292.