### PR TITLE
Fix duplicated layer string format error

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -923,9 +923,11 @@ path."
                 ;; in which case we don't need a warning
                 (unless (string-equal (ht-get result (car l)) (cdr l))
                   (configuration-layer//warning
-                   (concat "Duplicated layer %s detected in directory \"%s\", "
-                           "keeping only the layer in directory \"%s\"")
-                   (car l) (cdr l) (ht-get result (car l))))
+                   (format
+                    (concat "Duplicated layer %s detected in directory \"%s\""
+                            ", keeping only the layer in directory \"%s\"")
+                    (car l) (cdr l) (ht-get result (car l)))))
+
               (puthash (car l) (cdr l) result)))
           discovered)
     result))


### PR DESCRIPTION
I had a duplicated layer, but the message that's printed broke spacemacs starting up because it was a format string but wasn't in a `format` form. Simple fix. Spacemacs works again! Yay!

This issue was introduced in https://github.com/syl20bnr/spacemacs/commit/c0851ddcb3cd0f18e41c37f7bfe6b195117f3e27, according to a quick `git bisect`. :)