### PR TITLE
[ruby-layer] Adding ruby-refactor package and associated keybindings

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -23,6 +23,7 @@
         rspec-mode
         rubocop
         (ruby-mode :location built-in :toggle (not ruby-enable-enh-ruby-mode))
+        ruby-refactor
         ruby-test-mode
         ruby-tools
         rvm
@@ -176,6 +177,21 @@
     :config (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
               "'" 'ruby-toggle-string-quotes
               "{" 'ruby-toggle-block)))
+
+(defun ruby/init-ruby-refactor ()
+  (use-package ruby-refactor
+    :defer t
+    :init (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+            (add-hook hook 'ruby-refactor-mode-launch))
+    :config
+    (progn
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (spacemacs/declare-prefix-for-mode mode "mrR" "ruby/refactor")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "rRm" 'ruby-refactor-extract-to-method
+          "rRv" 'ruby-refactor-extract-local-variable
+          "rRc" 'ruby-refactor-extract-constant
+          "rRl" 'ruby-refactor-extract-to-let)))))
 
 (defun ruby/init-ruby-tools ()
   (use-package ruby-tools


### PR DESCRIPTION
This commit adds a series of refactoring commands for Ruby under "ruby/refactor", by use of the `ruby-refactor` package.
