### PR TITLE
Bind "C-c C-e" to spacemacs/helm-find-files-edit for helm-files buffer.

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -107,7 +107,7 @@
       (spacemacs||set-helm-key "swg" helm-google-suggest)
       (with-eval-after-load 'helm-files
         (define-key helm-find-files-map
-          (kbd "C-c C-e") 'helm/find-files-edit))
+          (kbd "C-c C-e") 'spacemacs/helm-find-files-edit))
       ;; Add minibuffer history with `helm-minibuffer-history'
       (define-key minibuffer-local-map (kbd "C-c C-l") 'helm-minibuffer-history)
       ;; define the key binding at the very end in order to allow the user


### PR DESCRIPTION
I thought the key binding of `helm/find-files-edit` may be a typo, cause I can't find a func which is named as it. And the `spacemacs/helm-find-files-edit` func may be the right one.
