### PR TITLE
Support for Hybrid state in Iedit Insert state

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -9,8 +9,34 @@
 ;;
 ;;; License: GPLv3
 
+(defvar spacemacs--evil-iedit-insert-states-default nil
+  "Default value of the list of additional states enabled in \
+`evil-iedit-insert-state'.")
+
+(defvar spacemacs--evil-iedit-insert-states-hybrid nil
+  "List of additional states enabled in `evil-iedit-insert-state' when
+`hybrid-mode' is active.")
+
 (defun spacemacs//enable-hs-minor-mode ()
   "Enable hs-minor-mode for code folding."
   (ignore-errors
     (hs-minor-mode)
     (spacemacs|hide-lighter hs-minor-mode)))
+
+(defun spacemacs//iedit-insert-state-hybrid (style)
+  "If STYLE is hybrid, update `evil-iedit-insert-state' definition to enable
+`evil-hybrid-state' instead of `evil-insert-state'.
+Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
+  ;; Populate variables on the first invocation.
+  (unless spacemacs--evil-iedit-insert-states-default
+    (setq spacemacs--evil-iedit-insert-states-default
+          (evil-get-property evil-state-properties 'iedit-insert :enable))
+    (setq spacemacs--evil-iedit-insert-states-hybrid
+          (mapcar (lambda (item)
+                    (if (eq item 'insert) 'hybrid item))
+                  spacemacs--evil-iedit-insert-states-default)))
+  (let ((states (if (eq style 'hybrid)
+                    spacemacs--evil-iedit-insert-states-hybrid
+                  spacemacs--evil-iedit-insert-states-default)))
+    (evil-put-property 'evil-state-properties 'iedit-insert
+                       :enable states)))

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -89,7 +89,10 @@
     :config
     ;; activate leader in iedit and iedit-insert states
     (define-key evil-iedit-state-map
-      (kbd dotspacemacs-leader-key) spacemacs-default-map)))
+      (kbd dotspacemacs-leader-key) spacemacs-default-map)
+    (spacemacs//iedit-insert-state-hybrid dotspacemacs-editing-style)
+    (add-hook 'spacemacs-editing-style-hook
+              #'spacemacs//iedit-insert-state-hybrid)))
 
 (defun spacemacs-evil/init-evil-indent-plus ()
   (use-package evil-indent-plus


### PR DESCRIPTION
I use `hybrid` editing style. When I enable `iedit-insert-state`, the `insert-state` is activated instead of the expected `hybrid-state`.

This PR addresses the issue with support for toggling of Hybrid mode.