### PR TITLE
org: substitue org-projectile for org-repo-todo

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -13,6 +13,7 @@
    - [[#gnuplot-support][Gnuplot support]]
    - [[#revealjs-support][Reveal.js support]]
    - [[#different-bullets][Different bullets]]
+   - [[#project-support][Project support]]
  - [[#key-bindings][Key bindings]]
    - [[#org][Org]]
    - [[#org-with-evil-org-mode][Org with evil-org-mode]]
@@ -29,9 +30,9 @@
      - [[#org-agenda-transient-state][Org agenda transient state]]
    - [[#pomodoro][Pomodoro]]
    - [[#presentation][Presentation]]
-   - [[#org-repo-todo][Org-repo-todo]]
    - [[#org-mime][Org-MIME]]
    - [[#org-download][Org-download]]
+   - [[#org-projectile][Org-projectile]]
 
 * Description
 This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
@@ -40,9 +41,9 @@ This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
 - Vim inspired key bindings are provided by [[https://github.com/edwtjo/evil-org-mode][evil-org-mode]]
 - Nicer bullet via [[https://github.com/sabof/org-bullets][org-bullets]]
 - A [[http://pomodorotechnique.com/][pomodoro method]] integration via [[https://github.com/lolownia/org-pomodoro][org-pomodoro]]
-- Project TODO capture via [[https://github.com/waymondo/org-repo-todo][org-repo-todo]]
-- presentation mode via [[https://github.com/rlister/org-present][org-present]]
+- Presentation mode via [[https://github.com/rlister/org-present][org-present]]
 - Insertion of images via [[https://github.com/abo-abo/org-download][org-download]]
+- Project-specific TODOs via [[https://github.com/IvanMalison/org-projectile][org-projectile]]
 
 ** BibTeX
 For more extensive support of references through BibTeX files, have a look at
@@ -94,8 +95,8 @@ variable =org-enable-reveal-js-support= to =t=. This will install the [[https://
 extension.
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(
-    (org :variables org-enable-reveal-js-support t)))
+  (setq-default dotspacemacs-configuration-layers
+   '((org :variables org-enable-reveal-js-support t)))
 #+END_SRC
 
 In order to be able to use org-reveal, download =reveal.js= from its
@@ -114,6 +115,27 @@ You can tweak the bullets displayed in the org buffer in the function
 
 #+BEGIN_SRC emacs-lisp
   (setq org-bullets-bullet-list '("■" "◆" "▲" "▶"))
+#+END_SRC
+
+** Project support
+Set the layer variable =org-projectile-file= to the filename where you want to
+store project-specific TODOs. If this is an absolute path, all todos will be
+stored in the same file (organized by project), whereas if it is just a single
+filename, todos will be stored in each project root.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((org :variables org-projectile-file "TODOs.org")))
+#+END_SRC
+
+The TODO files are not added to the agenda automatically. You can do this with
+the following snippet. Note that this may have unintended consequences until
+[[https://github.com/IvanMalison/org-projectile/issues/10][this bug]] is fixed.
+
+#+BEGIN_SRC emacs-lisp
+  (with-eval-after-load 'org-agenda
+    (require 'org-projectile)
+    (push (org-projectile:todo-files) org-agenda-files))
 #+END_SRC
 
 * Key bindings
@@ -424,16 +446,6 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 | ~l~         | next slide     |
 | ~q~         | quit           |
 
-** Org-repo-todo
-
-| Key Binding | Description                                                |
-|-------------+------------------------------------------------------------|
-| ~SPC C t~   | capture a TODO item for the current project                |
-| ~SPC C T~   | capture a checklist item for the current project           |
-| ~SPC a o p~ | show the TODO list for the current project                 |
-| ~SPC a o P~ | show the TODO list for all known projects                  |
-| ~SPC a o T~ | show the TODO list including those from all known projects |
-
 ** Org-MIME
 
 | Key Binding | Description                                       |
@@ -447,3 +459,11 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 |-------------+-----------------|
 | ~SPC m i s~ | Take screenshot |
 | ~SPC m i y~ | Yank image url  |
+
+** Org-projectile
+
+| Key Binding       | Description                                             |
+|-------------------+---------------------------------------------------------|
+| ~SPC a o p~       | Capture a TODO for the current project                  |
+| ~SPC u SPC a o p~ | Capture a TODO for any given project (choose from list) |
+| ~SPC a o P~       | Go to the TODOs for the current project                 |

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -17,4 +17,10 @@
 (defvar org-enable-reveal-js-support nil
   "If non-nil, enable export to reveal.js.")
 
+(defvar org-projectile-file "TODOs.org"
+  "The file to store project TODOs in. If this is a relative
+path, one file per project is used (and the path is relative to
+the project root). If it an absolute path, one global file is
+used.")
+
 (spacemacs|defvar-company-backends org-mode)

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -9,36 +9,15 @@
 ;;
 ;;; License: GPLv3
 
-(defun ort/find-todo-file (&optional directory)
-  (let* ((ort/todo-root (or directory (ort/find-root default-directory)))
-         (file (ort/todo-file)))
-    (when (and (not (file-remote-p file))
-               (file-readable-p file))
-      file)))
+(defun org-projectile/capture (&optional arg)
+  (interactive "P")
+  (if arg
+      (org-projectile:project-todo-completing-read nil :empty-lines 1)
+    (org-projectile:capture-for-current-project nil :empty-lines 1)))
 
-(defun ort/find-all-todo-files ()
-  (require 'projectile)
-  (delq nil (mapcar 'ort/find-todo-file projectile-known-projects)))
-
-(defun ort/list-project-todos ()
-  "List all the TODOs of the current project."
+(defun org-projectile/goto-todos ()
   (interactive)
-  (let ((org-agenda-files (list (ort/find-todo-file))))
-    (org-todo-list)))
-
-(defun ort/list-all-project-todos ()
-  "List all the TODOs of all known projects (excluding remote
-projects)."
-  (interactive)
-  (let ((org-agenda-files (ort/find-all-todo-files)))
-    (org-todo-list)))
-
-(defun ort/list-all-todos ()
-  "List all the TODOs of all known projects (excluding remote
-projects) as well as those from `org-agenda-files'."
-  (interactive)
-  (let ((org-agenda-files (append (org-agenda-files) (ort/find-all-todo-files))))
-    (org-todo-list)))
+  (org-projectile:location-for-project (projectile-project-name)))
 
 
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -28,7 +28,7 @@
     (org-mime :location built-in)
     org-pomodoro
     org-present
-    org-repo-todo
+    (org-projectile :toggle (configuration-layer/package-usedp 'projectile))
     ;; use a for of ox-gfm to fix index generation
     (ox-gfm :location (recipe :fetcher github :repo "syl20bnr/ox-gfm")
             :toggle org-enable-github-support)
@@ -500,23 +500,25 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (add-hook 'org-present-mode-hook 'spacemacs//org-present-start)
       (add-hook 'org-present-mode-quit-hook 'spacemacs//org-present-end))))
 
-(defun org/init-org-repo-todo ()
-  (use-package org-repo-todo
-    :commands (ort/todo-root ort/find-root ort/todo-file)
+(defun org/init-org-projectile ()
+  (use-package org-projectile
+    :commands (org-projectile:location-for-project)
     :init
     (progn
       (spacemacs/set-leader-keys
-        "Ct" 'ort/capture-todo
-        "CT" 'ort/capture-checkitem
-        "aop" 'ort/list-project-todos)
-      (when (configuration-layer/package-usedp 'projectile)
-        (spacemacs/set-leader-keys
-          "aoT" 'ort/list-all-todos
-          "aoP" 'ort/list-all-project-todos)))
+        "aop" 'org-projectile/capture
+        "aoP" 'org-projectile/goto-todos)
+      (with-eval-after-load 'org-capture
+        (require 'org-projectile)))
     :config
-    ;; Better default capture template
-    (setcdr (cdddr (assoc "ort/todo" org-capture-templates))
-            '("* TODO %?\n%U\n\n%i" :empty-lines 1))))
+    (if (file-name-absolute-p org-projectile-file)
+        (progn
+          (setq org-projectile:projects-file org-projectile-file)
+          (push (org-projectile:project-todo-entry
+                 nil nil nil :empty-lines 1)
+                org-capture-templates))
+      (org-projectile:per-repo)
+      (setq org-projectile:per-repo-filename org-projectile-file))))
 
 (defun org/init-ox-gfm ()
   (spacemacs|use-package-add-hook org :post-config (require 'ox-gfm)))


### PR DESCRIPTION
Fixes #6086, #3066 and #3405.