### PR TITLE
Fix the loading of `vmd` for daemon mode

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -19,8 +19,7 @@
     markdown-toc
     mmm-mode
     smartparens
-    (vmd-mode :toggle (and (eq 'vmd markdown-live-preview-engine)
-                           (executable-find "vmd")))
+    (vmd-mode :toggle (eq 'vmd markdown-live-preview-engine))
     ))
 
 (defun markdown/post-init-company ()


### PR DESCRIPTION
When Spacemacs is used in daemon mode, the `PATH` is not always filled
up with user-defined run paths when Spacemacs load the packages. The
`toggle` of the `vmd` package is checking for the `vmd` executable which
may be in one of the user path, what prevent the package to be loaded,
even if the executable is available at execution time.

If people want to use `vmd`, setting `markdown-live-preview-engine`
should be enough, there is no need for checking for the executable to be
present, this is the responsability of the user to ensure this.