### PR TITLE
Don't un-exclude an excluded package

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -490,7 +490,7 @@ If TOGGLEP is non nil then `:toggle' parameter is ignored."
          (obj (if obj obj (cfgl-package name-str :name name-sym))))
     (when location (oset obj :location location))
     (when step (oset obj :step step))
-    (oset obj :excluded excluded)
+    (oset obj :excluded (or excluded (oref obj :excluded)))
     (when toggle (oset obj :toggle toggle))
     ;; cannot override protected packages
     (unless copyp


### PR DESCRIPTION
If a layer using a package is loaded after a layer excluding it, the
exclude flag should not be overwritten.