### PR TITLE
Fix :owner reference in ivy-spacemacs-help

### DIFF
--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -207,18 +207,20 @@
            (lambda (a x) (max (length (symbol-name (oref x :name))) a))
            ivy-spacemacs-help-all-layers :initial-value 0)))
         (owners (cl-remove-duplicates
-                 (mapcar (lambda (pkg) (oref pkg :owner))
+                 (mapcar (lambda (pkg)
+                           (car (oref pkg :owners)))
                          ivy-spacemacs-help-all-packages))))
     (dolist (pkg ivy-spacemacs-help-all-packages)
       (push (list (format (concat "%-" left-column-width "S %s %s")
-                          (oref pkg :owner)
+                          (car (oref pkg :owners ))
                           (propertize (symbol-name (oref pkg :name))
                                       'face 'font-lock-type-face)
                           (propertize
                            (if (package-installed-p (oref pkg :name))
                                "[installed]" "")
                            'face 'font-lock-comment-face))
-                  (symbol-name (oref pkg :owner))
+                  (symbol-name
+                   (car (oref pkg :owners )))
                   (symbol-name (oref pkg :name)))
             result))
     (dolist (layer (delq nil


### PR DESCRIPTION
Recent changes to `:owner` property to include list as `:owners` property broke ivy-spacemacs-help.  This commit updates ivy-spacemacs-help to address these changes.  