### PR TITLE
Add kill-buffer-and-window keybinding

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1840,6 +1840,7 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC TAB~   | switch to alternate buffer in the current window (switch back and forth) |
 | ~SPC b b~   | switch to a buffer using =helm=                                          |
 | ~SPC b d~   | kill the current buffer (does not delete the visited file)               |
+| ~SPC b D~   | kill the current buffer and its window                                   |
 | ~SPC b e~   | erase the content of the buffer (ask for confirmation)                   |
 | ~SPC b h~   | open =*spacemacs*= home buffer                                           |
 | ~SPC b k~   | kill a buffer                                                            |

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -118,6 +118,7 @@
 ;; buffers --------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "bd"  'spacemacs/kill-this-buffer
+  "bD"  'kill-buffer-and-window
   "TAB" 'spacemacs/alternate-buffer
   "bh"  'spacemacs/home
   "be"  'spacemacs/safe-erase-buffer


### PR DESCRIPTION
`SPC b D` would be bound to `kill-buffer-and-window`, which kills the buffer and windows.

This concerns #6334.

I simply added this keybinding and it seems to work fine. 
If you use it on the only existing window, `spacemacs` prevents you from killing it completely, which is the behaviour I'd expect.  

btw: Kudos to everyone who worked on the **Contribution guidelines**. :smiley: 

