### PR TITLE
Added glsl layer for OpenGL shader syntax highlighting

### DIFF
--- a/layers/+lang/glsl/README.org
+++ b/layers/+lang/glsl/README.org
@@ -1,0 +1,19 @@
+#+TITLE: GLSL layer
+#+HTML_HEAD_EXTRA: <link rel="stylesheet" type="text/css" href="../../../css/readtheorg.css" />
+
+* Table of Contents
+- [[Desscription][Description]]
+- [[Install][Install]]
+
+* Description
+This layer provides syntax highlighting for GLSL shader files. 
+By default it will provide highlighting for files ending in:
+- .glsl
+- .vert
+- .frag
+- .geom
+
+* Install
+To use this configuration layer, add it to your =~.spacemacs=.
+You will need to add =yaml= to the existing =dotspacemacs-configuration-layers=
+list in this file.

--- a/layers/+lang/glsl/packages.el
+++ b/layers/+lang/glsl/packages.el
@@ -1,0 +1,19 @@
+;;; packages.el --- GLSL Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Alan Love <alan@cattes.us>
+;; URL: https://github.com/ell
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GLPv3
+(setq glsl-packages '(glsl-mode))
+
+(defun glsl/init-glsl-mode ()
+  "Initialize GLSL mode"
+  (use-package glsl-mode
+    :mode (("\\.glsl\\'" . glsl-mode)
+           ("\\.vert\\'" . glsl-mode)
+           ("\\.frag\\'" . glsl-mode)
+           ("\\.geom\\'" . glsl-mode))))


### PR DESCRIPTION
Adds a layer for highlighting the syntax of OpenGL shaders.  

Will add company-mode support when https://github.com/Kaali/company-glsl is added to melpa.