### PR TITLE
Enable auto-complete in Idris repl

### DIFF
--- a/layers/+lang/idris/README.org
+++ b/layers/+lang/idris/README.org
@@ -85,6 +85,7 @@ are reproduced under the local leader.
 | ~SPC m s p~ | Contract the region to be loaded one line at a time                                    |
 | ~SPC m s P~ | Contract the region to be loaded one line at a time and switch to REPL in insert state |
 | ~SPC m s s~ | Switch to REPL buffer                                                                  |
+| ~SPC m s q~ | Quit the Idris process                                                                 |
 
 ** Active term manipulations
 

--- a/layers/+lang/idris/config.el
+++ b/layers/+lang/idris/config.el
@@ -10,3 +10,4 @@
 ;;; License: GPLv3
 
 (spacemacs|defvar-company-backends idris-mode)
+(spacemacs|defvar-company-backends idris-repl-mode)

--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -15,7 +15,9 @@
 
 (defun idris/post-init-company ()
   (spacemacs|add-company-hook idris-mode)
-  (push 'company-capf company-backends-idris-mode))
+  (spacemacs|add-company-hook idris-repl-mode)
+  (push 'company-capf company-backends-idris-mode)
+  (push 'company-capf company-backends-idris-repl-mode))
 
 (defun idris/init-idris-mode ()
   (use-package idris-mode
@@ -91,7 +93,7 @@
         "mc" 'idris-show-core-term
 
         ;; REPL
-        "'" 'idris-repl
+        "'"  'idris-repl
         "sb" 'idris-load-file
         "sB" 'spacemacs/idris-load-file-and-focus
         "si" 'idris-repl
@@ -99,7 +101,8 @@
         "sN" 'spacemacs/idris-load-forward-line-and-focus
         "sp" 'idris-load-backward-line
         "sP" 'spacemacs/idris-load-backward-line-and-focus
-        "ss" 'idris-pop-to-repl)))
+        "ss" 'idris-pop-to-repl
+        "sq" 'idris-quit)))
 
   ;; open special buffers in motion state so they can be closed with ~q~
   (evil-set-initial-state 'idris-compiler-notes-mode 'motion)


### PR DESCRIPTION
1. Enable auto-complete in Idris repl
2. Add keybinding to kill Idris process