### PR TITLE
Add mwim (move where i mean) to layer better-defaults

### DIFF
--- a/layers/+emacs/better-defaults/README.org
+++ b/layers/+emacs/better-defaults/README.org
@@ -4,10 +4,11 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
  - [[#description][Description]]
- - [[#install][Install]]
- - [[#functions][Functions]]
-   - [[#spacemacssmart-move-beginning-of-line][=spacemacs/smart-move-beginning-of-line=]]
+ - [[#features][Features]]
+   - [[#smart-line-navigation][Smart line navigation]]
    - [[#spacemacsbackward-kill-word-or-region][=spacemacs/backward-kill-word-or-region=]]
+ - [[#install][Install]]
+ - [[#configuration][Configuration]]
  - [[#key-bindings][Key bindings]]
 
 * Description
@@ -21,26 +22,40 @@ style.
 
 The commands defined in this layer are taken from various sources like [[https://github.com/bbatsov/prelude][Prelude]].
 
-* Install
-To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add =better-defaults= to the existing =dotspacemacs-configuration-layers= list in this
-file.
-
-* Functions
-** =spacemacs/smart-move-beginning-of-line=
-Pressed one time, go to the first non-whitespace character of the line, pressed
-again, go to the beginning of the line.
+* Features
+** Smart line navigation
+Subsequent presses of ~C-a~ toggles between the beginning of the line and the first non-whitespace character.
+Similarly, subsequent presses of ~C-e~ will toggle between the end of the code and the end of the comments.
 
 ** =spacemacs/backward-kill-word-or-region=
 A combination of =kill-region= and =backward-kill-word=, depending on whether
 there is an active region. If there's an active region kill that. If not kill
 the preceding word.
 
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =better-defaults= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Configuration
+Choose if ~C-a~ first brings you to the beginning of the line or the beginning of the code (first non-whitespace character)
+#+BEGIN_SRC emacs-lisp
+     (better-defaults :variables
+		      better-defaults-move-to-beginning-of-code-first t)
+#+END_SRC
+
+Choose if ~C-e~ first brings you to the end of the line or the end of the code (before or after comments)
+#+BEGIN_SRC emacs-lisp
+     (better-defaults :variables
+		      better-defaults-move-to-end-of-code-first t)
+#+END_SRC
+
+
 * Key bindings
 
-| Key Binding | Description                                                                      |
-|-------------+----------------------------------------------------------------------------------|
-| ~C-a~       | smart beginning of line                                                          |
-| ~C-w~       | backward kill word or region                                                     |
-| ~C-y~       | Automatically indenting after pasting. With prefix argument, paste text as it is |
-
+| Key Binding | Description                                                                        |
+|-------------+------------------------------------------------------------------------------------|
+| ~C-a~       | move to beginning of line or code                                                  |
+| ~C-e~       | move to end of line or code                                                        |
+| ~C-w~       | backward kill word or region                                                       |
+| ~C-y~       | Automatically indenting after pasting. With prefix argument, paste text as it is   |

--- a/layers/+emacs/better-defaults/config.el
+++ b/layers/+emacs/better-defaults/config.el
@@ -1,0 +1,20 @@
+;;; config.el --- Better Emacs Defaults Layer configuration variables File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Thomas de Beauchêne <thomas.de.beauchene@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar better-defaults-move-to-beginning-of-code-first t
+  "when t, first stroke of C-a will move the cursor to the beginning of code.
+When nil, first stroke will go to the beginning of line.
+Subsequent strokes will toggle between beginning of line and beginning of code.")
+
+(defvar better-defaults-move-to-end-of-code-first t
+  "when t, first stroke of C-e will move the cursor to the end of code (before comments).
+When nil, first stroke will go to the end of line (after comments).
+Subsequent strokes will toggle between end of line and end of code.")

--- a/layers/+emacs/better-defaults/funcs.el
+++ b/layers/+emacs/better-defaults/funcs.el
@@ -9,25 +9,6 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs/smart-move-beginning-of-line (arg)
-  "Move point back to indentation of beginning of line.
-Move point to the first non-whitespace character on this line.
-If point is already there, move to the beginning of the line.
-Effectively toggle between the first non-whitespace character and
-the beginning of the line.
-If ARG is not nil or 1, move forward ARG - 1 lines first. If
-point reaches the beginning or end of the buffer, stop there."
-  (interactive "^p")
-  (setq arg (or arg 1))
-  ;; Move lines first
-  (when (/= arg 1)
-    (let ((line-move-visual nil))
-      (forward-line (1- arg))))
-  (let ((orig-point (point)))
-    (back-to-indentation)
-    (when (= orig-point (point))
-      (move-beginning-of-line 1))))
-
 (defun spacemacs/backward-kill-word-or-region (&optional arg)
   "Calls `kill-region' when a region is active and
 `backward-kill-word' otherwise. ARG is passed to

--- a/layers/+emacs/better-defaults/keybindings.el
+++ b/layers/+emacs/better-defaults/keybindings.el
@@ -9,5 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(global-set-key (kbd "C-a") 'spacemacs/smart-move-beginning-of-line)
 (global-set-key (kbd "C-w") 'spacemacs/backward-kill-word-or-region)

--- a/layers/+emacs/better-defaults/packages.el
+++ b/layers/+emacs/better-defaults/packages.el
@@ -1,0 +1,27 @@
+;;; packages.el --- Better Emacs Defaults Layer functions File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Thomas de Beauchêne <thomas.de.beauchene@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst better-defaults-packages
+  '(mwim)
+  "The list of Lisp packages required by the mwim layer.")
+
+(defun better-defaults/init-mwim ()
+  (use-package mwim
+    :defer t
+    :init
+    (progn
+      (if better-defaults-move-to-beginning-of-code-first
+	  (global-set-key (kbd "C-a") 'mwim-beginning-of-code-or-line)
+	(global-set-key (kbd "C-a") 'mwim-beginning-of-line-or-code))
+
+      (if better-defaults-move-to-end-of-code-first
+	  (global-set-key (kbd "C-e") 'mwim-end-of-code-or-line)
+	(global-set-key (kbd "C-e") 'mwim-end-of-line-or-code)))))


### PR DESCRIPTION
mwim (move where i mean) is an elpa package for enhancing C-a and C-e behaviours: subsequent strokes will toggle between beginning of line and beginning of code, or between end of line and end of code (before/after comments) respectively.

Before this PR only one behaviour was offered for C-a: going to beginning of line first.

This PR allows for choosing whether you prefer to move to beginning of line or code first (defaults tot the same as before) and adds the equivalent for end of code (before or after comments).

Two layer variables allow for tweaking C-a and C-e behaviours:

- better-defaults-move-to-beginning-of-code-first
- better-defaults-move-to-end-of-code-first