### PR TITLE
Integrate pdf-tools with latex layer.

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -10,11 +10,12 @@
    - [[#layer][Layer]]
    - [[#auto-completion][Auto-completion]]
    - [[#previewing][Previewing]]
+     - [[#combination-with-pdf-tools][Combination with pdf-tools]]
    - [[#build-command][Build command]]
    - [[#auto-fill][Auto-fill]]
    - [[#folding][Folding]]
  - [[#keybindings][Keybindings]]
-   - [[#folding][Folding]]
+   - [[#folding-1][Folding]]
    - [[#reftex][RefTeX]]
 
 * Description
@@ -51,6 +52,18 @@ under =dotspacemacs/user-config=:
 
 Then when you open up a compiled PDF, the preview will update automatically
 when you recompile.
+
+*** Combination with pdf-tools
+
+When the pdf-tools layer is installed you can use =pdf-tools= as the view
+program by setting the layer variable =latex-view-with-pdf-tools= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  dotspacemacs-configuration-layers '(
+    (latex :variables latex-view-with-pdf-tools t))
+#+END_SRC
+
+This also enables jumping to the part of the PDF under your cursor using ~SPC m v~.
 
 ** Build command
 A build command can be specified via the layer variable =latex-build-command=.

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -30,3 +30,6 @@
                            "tabular"
                            "tikzpicture")
   "List of environment names in which `auto-fill-mode' will be inhibited.")
+
+(defvar latex-view-with-pdf-tools nil
+  "Whether to use pdf-tools for viewing pdf output.")

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -40,6 +40,9 @@
             LaTeX-fill-break-at-separators nil)
       (when latex-enable-auto-fill
         (add-hook 'LaTeX-mode-hook 'latex/auto-fill-mode))
+      (when (and (configuration-layer/layer-usedp 'pdf-tools)
+                 latex-view-with-pdf-tools)
+        (setq TeX-view-program-selection '((output-pdf "PDF Tools"))))
       (when latex-enable-folding
         (add-hook 'LaTeX-mode-hook 'TeX-fold-mode))
       (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)


### PR DESCRIPTION
This enables viewing of tex output using pdf-tools. Includes jumping to
the part of the pdf under the cursor in the .tex file.

The only problem it has is that `auctex` seems to not play nice with lazy loading. It uses `(unless (featurep 'pdf-tools))` [here](https://github.com/giordano/auctex/blob/master/tex.el#L1265).
The code works fine if the `unless` is removed. Is there a way around this or could this be considered a bug in `auctex`?
