### PR TITLE
restclient: add helm support to jump to variable or request

### DIFF
--- a/layers/+tools/restclient/README.org
+++ b/layers/+tools/restclient/README.org
@@ -30,6 +30,7 @@ Also there is an [[http://emacsrocks.com/e15.html][Emacs Rocks!]] episode of it.
 
 | Key Binding | Description                                                 |
 |-------------+-------------------------------------------------------------|
+| ~SPC m j~   | Jump to a variable or request in current buffer             |
 | ~SPC m s~   | Send and stay in window (pretty-print response if possible) |
 | ~SPC m S~   | Send and switch window (pretty-print response if possible)  |
 | ~SPC m r~   | Send and stay in window (do not attempt to pretty-print)    |

--- a/layers/+tools/restclient/packages.el
+++ b/layers/+tools/restclient/packages.el
@@ -13,6 +13,7 @@
         golden-ratio
         ob-http
         restclient
+        (restclient-helm :toggle (configuration-layer/package-usedp 'helm))
         ))
 
 (defun restclient/pre-init-golden-ratio ()
@@ -40,3 +41,10 @@
         "r" 'restclient-http-send-current-raw-stay-in-window
         "R" 'restclient-http-send-current-raw
         "y" 'restclient-copy-curl-command))))
+
+(defun restclient/init-restclient-helm ()
+  (use-package restclient-helm
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'restclient-mode
+        "j" 'helm-restclient))))


### PR DESCRIPTION
Enable restclient-helm that is included in restclient package and add
`SPC m j` key binding.
