### PR TITLE
Prevent find-file-at-point from pinging what looks like domains

### DIFF
--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -62,6 +62,9 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Scroll compilation to first error or end
 (setq compilation-scroll-output 'first-error)
 
+;; Don't try to ping things that look like domain names
+(setq ffap-machine-p-known 'reject)
+
 ;; ---------------------------------------------------------------------------
 ;; Edit
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Previously,

* typing `gf` in domain names (for example google.com) in normal buffers
* typing `<tab>` in domain names in the minibuffer

would start pinging that domain name. This is not really useful, so
disable it.

Fixes #2654.

I'm not sure if that's the correct place to put this line, but I couldn't find a better one.