### PR TITLE
Fix a `git clone` line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ then cloning the new configuration:
 
 ```sh
 mkdir ~/spacemacs
-git clone git@github.com:syl20bnr/spacemacs.git ~/spacemacs/.emacs.d
+git clone https://github.com/syl20bnr/spacemacs.git ~/spacemacs/.emacs.d
 HOME=~/spacemacs emacs
 ```
 


### PR DESCRIPTION
Fixed the shell code line in "Installation alongside another configuration" paragraph of README.me to use a http address rather than a git@ address. This is more consistent with the rest of file, as well as more compatible with git installations.