### PR TITLE
User configurable default company-backends

### DIFF
--- a/core/core-auto-completion.el
+++ b/core/core-auto-completion.el
@@ -11,12 +11,19 @@
 
 ;; Company -------------------------------------------------------------------
 
+(defvar spacemacs-default-company-backends
+  '((company-dabbrev-code company-gtags company-etags company-keywords)
+    company-files company-dabbrev)
+  "The list of default company backends used by spacemacs.
+This variable is used to configure mode-specific company backends in spacemacs.
+Backends in this list will always be active in these modes, as well as any
+backends added by individual spacemacs layers.")
+
 (defmacro spacemacs|defvar-company-backends (mode)
   "Define a MODE specific company backend variable with default backends.
 The variable name format is company-backends-MODE."
   `(defvar ,(intern (format "company-backends-%S" mode))
-     '((company-dabbrev-code company-gtags company-etags company-keywords)
-       company-files company-dabbrev)
+     `,spacemacs-default-company-backends
      ,(format "Company backend list for %S" mode)))
 
 (defmacro spacemacs|add-company-hook (mode)

--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -14,8 +14,9 @@
    - [[#add-auto-completion-in-a-layer][Add auto-completion in a layer]]
      - [[#in-configel][In =config.el=]]
      - [[#in-packagesel][In =packages.el=]]
+   - [[#completion-back-ends][Completion back ends]]
    - [[#improved-faces][Improved faces]]
- - [[#key-bindings][Key Bindings]]
+ - [[#key-bindings-1][Key Bindings]]
    - [[#company][Company]]
    - [[#auto-complete][Auto-complete]]
    - [[#yasnippet][Yasnippet]]
@@ -169,6 +170,19 @@ Here is an example to add =company= auto-completion to python buffer:
       :init (push 'company-anaconda company-backends-python-mode)))
 #+END_SRC
 
+** Completion back ends
+Many spacemacs layers (e.g., python, html, haskell) configure company mode
+backends to provide mode-specific completion. These modes will include
+completion backends specified in the `spacemacs-default-company-backends`
+variable. The defaults should work well, but you can configure this variable in
+your ~.spacemacs~ file with (e.g.)
+#+BEGIN_SRC emacs-lisp
+  (setq-default
+   dotspacemacs-configuration-layers
+   '((auto-completion :variables
+                      spacemacs-default-company-backends '(company-files company-capf))))
+#+END_SRC
+ 
 ** Improved faces
 For nicer-looking faces, try adding the following to `custom-set-faces` in your dotspacemacs file.
 


### PR DESCRIPTION
Currently `spacemacs|defvar-company-backends` hard codes company backends that will be enabled any time `company-mode` is active (at least that appears to be the case, please correct me if that assumption is wrong). Configuring `company-backends` in `.spacemacs` has no effect, because this variable is not used when constructing the mode-specific company backends. This makes it difficult for the user to configure the default set of enabled company backends.

This PR fixes that by using `company-backends` in `spacemacs|defvar-company-backends`. This allows the user to configure a default set of backends that specific modes can then add to. For example, I really only want file completion everywhere, so I have `(auto-completion :variables company-backends '(company-files))` in my `dotspacemacs-configuration-layors`.

Note that I have set `company-backends` to the old hard-coded list, so this PR should not change anything for those who have not set `company-backends` in their `.spacemacs`. For those who have set this variable the PR makes spacemacs respect it when constructing mode specific company backends.
