### PR TITLE
Ignore eww created url directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ eshell/history
 .emacs.desktop.lock
 eshell/alias
 eshell/lastdir
-/url/cookies
+url/*
 my-org/
 org-files/
 semanticdb/


### PR DESCRIPTION
Eww creates a url directory inside of .emacs.d.  This prevents updates because the git status is not clean.
