### PR TITLE
remove old custom layout on override

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -197,7 +197,10 @@ Available PROPS:
        (if ,already-defined?
            (unless (equal ,already-defined? ,name)
              (spacemacs-buffer/warning "Replacing existing binding \"%s\" for %s with %s"
-                                ,binding ,already-defined? ,name)
+                                       ,binding ,already-defined? ,name)
+             (setq spacemacs--custom-layout-alist
+                   (delete (assoc ,binding spacemacs--custom-layout-alist)
+                     spacemacs--custom-layout-alist))
              (push '(,binding . ,name) spacemacs--custom-layout-alist))
          (push '(,binding . ,name) spacemacs--custom-layout-alist)))))
 


### PR DESCRIPTION
For example, creating new custom layout `["e" . "Name"]` clashes with
`["e" . "Spacemacs"]`. After override `SPC l o` should not show both of
them, but only the override.