### PR TITLE
github: Add bindings for the addition of remotes

### DIFF
--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -72,7 +72,10 @@
     :defer t
     :init
     (spacemacs/set-leader-keys
-      "gh C-c" 'github-clone)))
+      "gh C-c" 'github-clone
+      "ghr" 'github-clone-add-existing-remote
+      "ghf" 'github-clone-fork-remote
+      "ghu" 'github-clone-add-source-remote))
 
 (defun github/init-git-link ()
   (use-package git-link


### PR DESCRIPTION
`github-clone-fork-remote` forks an existing remote
`github-clone-add-existing-remote` Adds an existing remote using completion on any existing forks of the source remote.
`github-clone-add-source-remote` Adds the original parent of a remote that is a fork.

These functions only exist in the newest version of github-clone.el (they were merged here https://github.com/dgtized/github-clone.el/commit/467b40ca60a6c26257466ebc43c74414df7f19cc), but they are definitely already in melpa. Can we do anything to ensure that people are using a properly up to date github-clone.el when these bindings are present?