### PR TITLE
Fix spacemacs-start-directory variable definition

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -11,6 +11,9 @@
 (defun add-to-load-path (dir) (add-to-list 'load-path dir))
 
 ;; paths
+(defvar spacemacs-start-directory
+  user-emacs-directory
+  "Spacemacs start directory.")
 (defconst spacemacs-core-directory
   (expand-file-name (concat spacemacs-start-directory "core/"))
   "Spacemacs core directory.")

--- a/init.el
+++ b/init.el
@@ -17,13 +17,13 @@
 
 (defconst spacemacs-version         "0.105.21" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "24.4" "Minimal version of Emacs.")
-(defconst spacemacs-start-directory user-emacs-directory)
 
 (if (not (version<= spacemacs-emacs-min-version emacs-version))
     (message (concat "Your version of Emacs (%s) is too old. "
                      "Spacemacs requires Emacs version %s or above.")
              emacs-version spacemacs-emacs-min-version)
-  (load-file (concat spacemacs-start-directory "core/core-load-paths.el"))
+  (load-file (concat (file-name-directory load-file-name)
+                     "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (spacemacs/init)
   (spacemacs/maybe-install-dotfile)


### PR DESCRIPTION
Should use defvar to define the spacemacs-start-directory so that user can override the default value.