### PR TITLE
Toggles: print message only in interactive usage

### DIFF
--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -86,9 +86,11 @@ used."
                       ,condition))
              (if (,wrapper-func-status)
                  (progn ,@off-body
-                        (message ,(format "%s disabled." name)))
+                        (when (called-interactively-p 'any)
+                          (message ,(format "%s disabled." name))))
                ,@on-body
-               (message ,(or on-message (format "%s enabled." name))))
+               (when (called-interactively-p 'any)
+                 (message ,(or on-message (format "%s enabled." name)))))
            (message "This toggle is not supported.")))
        ;; predicate function
        (defun ,wrapper-func-status ()


### PR DESCRIPTION
Prevent `spacemacs/toggle-*` functions from echoing "enabled"/"disabled" messages when called non-interactively. In other words, we don't need to print the result of the toggle if it wasn't explicitly toggles by the user. The same condition is used for regular Emacs minor mode toggles.