### PR TITLE
Allow user more control over space-doc mode

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -149,23 +149,22 @@ Supported properties:
   "Apply visual enchantments to the current buffer.
 The buffer's major mode should be `org-mode'."
   (interactive)
-  (if (not (derived-mode-p 'org-mode))
-      (user-error "org-mode should be enabled in the current buffer.")
-    (org-indent-mode)
-    (view-mode))
-    ;; Make ~SPC ,~ work, reference:
-    ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
-    (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
-    (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
-    (setq-local org-emphasis-alist '(("*" bold)
-                                     ("/" italic)
-                                     ("_" underline)
-                                     ("=" org-verbatim verbatim)
-                                     ("~" org-kbd)
-                                     ("+"
-                                      (:strike-through t))))
-    (when (require 'space-doc nil t)
-      (space-doc-mode)))
+  (unless (derived-mode-p 'org-mode)
+    (user-error "org-mode should be enabled in the current buffer."))
+
+  ;; Make ~SPC ,~ work, reference:
+  ;; http://stackoverflow.com/questions/24169333/how-can-i-emphasize-or-verbatim-quote-a-comma-in-org-mode
+  (setcar (nthcdr 2 org-emphasis-regexp-components) " \t\n")
+  (org-set-emph-re 'org-emphasis-regexp-components org-emphasis-regexp-components)
+  (setq-local org-emphasis-alist '(("*" bold)
+                                   ("/" italic)
+                                   ("_" underline)
+                                   ("=" org-verbatim verbatim)
+                                   ("~" org-kbd)
+                                   ("+"
+                                    (:strike-through t))))
+  (when (require 'space-doc nil t)
+    (space-doc-mode)))
 
 (defun spacemacs/view-org-file (file &optional anchor-text expand-scope)
   "Open org file and apply visual enchantments.

--- a/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
+++ b/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
@@ -44,8 +44,10 @@ keeping their content visible.
                      (buffer-name)))
     (setq space-doc-mode nil)))
 
-(defconst spacemacs--space-doc-modificators
-  '(spacemacs//space-doc-set-space-doc-cache
+(defvar spacemacs--space-doc-modificators
+  '(spacemacs//space-doc-org-indent-mode
+    spacemacs//space-doc-view-mode
+    spacemacs//space-doc-set-space-doc-cache
     spacemacs//space-doc-hide-line-numbers
     spacemacs//space-doc-modf-emphasis-overlays
     spacemacs//space-doc-modf-meta-tags-overlays
@@ -61,6 +63,12 @@ keeping their content visible.
 The functions work with a current buffer and accept ENABLE(flag) argument.
 If the argument has non-nil value - enable the modifications introduced
 by the function. Otherwise - disable.")
+
+(defun spacemacs//space-doc-org-indent-mode (&optional flag)
+  (org-indent-mode (if flag 1 -1)))
+
+(defun spacemacs//space-doc-view-mode (&optional flag)
+  (view-mode (if flag 1 -1)))
 
 (cl-defstruct spacemacs//space-doc-cache
   marker-face


### PR DESCRIPTION
* Move org-indent-mode and view-mode from spacemacs/prettify-buffer to space-doc.el.
* Make spacemacs--space-doc-modificators a variable instead of a constant, so users can change it.
