### PR TITLE
Fixes display of per-binding docs in micro-state

### DIFF
--- a/core/core-micro-state.el
+++ b/core/core-micro-state.el
@@ -164,17 +164,20 @@ used."
          (doc-body
           `((let ((bdoc ,@binding-doc)
                   (defdoc ,@default-doc))
-              (if bdoc
-                  (apply ',msg-func
-                         (list (spacemacs//micro-state-propertize-doc
-                                (format "%S: %s" ',name bdoc))))
-                (when (and defdoc
-                           ',wrapped (not (plist-get ',binding :exit)))
-                  (spacemacs//micro-state-set-minibuffer-height defdoc)
-                  (apply ',msg-func
-                         (list (spacemacs//micro-state-propertize-doc
-                                (format "%S: %s" ',name defdoc))))
-                  defdoc)))))
+              (cond
+               (bdoc
+                (apply ',msg-func
+                       (list (spacemacs//micro-state-propertize-doc
+                              (format "%S: %s" ',name bdoc))))
+                bdoc)
+               ((and defdoc
+                     ',wrapped
+                     (not (plist-get ',binding :exit)))
+                (spacemacs//micro-state-set-minibuffer-height defdoc)
+                (apply ',msg-func
+                       (list (spacemacs//micro-state-propertize-doc
+                              (format "%S: %s" ',name defdoc))))
+                defdoc)))))
          (wrapper-func
           (if (and (boundp wrapped)
                    (eval `(keymapp ,wrapped)))


### PR DESCRIPTION
Previous behavior, if a micro-state binding had :doc not nil, was an error
  Wrong type argument: stringp, 1

Detailed reproduction:
cat > /tmp/test.el <<EOF
(spacemacs|define-micro-state test
  :doc "[a] a [b] b [q] quit"
  :bindings
  ("a" nil :doc "a")
  ("b" nil :doc "b")
  ("q" nil :doc "quit" :exit t))

(spacemacs/test-micro-state)
EOF
emacs --load /tmp/test.el

Type a, b, or q and see the error in the echo buffer.