### PR TITLE
allow to set dotspacemacs-filepath

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -33,7 +33,7 @@
 SPACEMACSDIR environment variable. If neither of these
 directories exist, this variable will be nil.")
 
-(defconst dotspacemacs-filepath
+(defvar dotspacemacs-filepath
   (let* ((default (concat user-home-directory ".spacemacs"))
          (spacemacs-dir-init (when dotspacemacs-directory
                                  (concat dotspacemacs-directory


### PR DESCRIPTION
Following the trend. This is useful in addition to allowing to set `spacemacs-start-directory` and `package-user-dir`. But not sure if it should be documented.