### PR TITLE
org-agenda: Add missed key binding for pomodoro

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -322,6 +322,7 @@ The evilified org agenda supports the following bindings:
 | ~SPC m f~            | org-agenda-set-effort         |
 | ~SPC m I~            | org-agenda-clock-in           |
 | ~SPC m O~            | org-agenda-clock-out          |
+| ~SPC m p~            | org-pomodoro                  |
 | ~SPC m P~            | org-agenda-set-property       |
 | ~SPC m q~            | org-agenda-refile             |
 | ~SPC m Q~            | org-agenda-clock-cancel       |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -343,6 +343,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "f" 'org-agenda-set-effort
         "I" 'org-agenda-clock-in
         "O" 'org-agenda-clock-out
+        "p" 'org-pomodoro
         "P" 'org-agenda-set-property
         "q" 'org-agenda-refile
         "Q" 'org-agenda-clock-cancel


### PR DESCRIPTION
Just realized that keybinding for pomodoro is missed in agenda buffer.