### PR TITLE
Add duplicate-line-or-region under SPC x l d

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2562,6 +2562,7 @@ Text related commands (start with ~x~):
 | ~SPC x j r~ | set the justification to right                                |
 | ~SPC x J~   | move down a line of text (enter transient state)              |
 | ~SPC x K~   | move up a line of text (enter transient state)                |
+| ~SPC x l d~ | duplicate line or region                                      |
 | ~SPC x l s~ | sort lines                                                    |
 | ~SPC x l u~ | uniquify lines                                                |
 | ~SPC x o~   | use avy to select a link in the frame and open it             |

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -710,6 +710,29 @@ the right."
   (interactive)
   (call-interactively 'write-file))
 
+;; from https://www.emacswiki.org/emacs/CopyingWholeLines
+(defun spacemacs/duplicate-line-or-region (&optional n)
+  "Duplicate current line, or region if active.
+With argument N, make N copies.
+With negative N, comment out original line and use the absolute value."
+  (interactive "*p")
+  (let ((use-region (use-region-p)))
+    (save-excursion
+      (let ((text (if use-region        ; Get region if active, otherwise line
+                      (buffer-substring (region-beginning) (region-end))
+                    (prog1 (thing-at-point 'line)
+                      (end-of-line)
+                      (if (< 0 (forward-line 1)) ; Go to beginning of next line, or make a new one
+                          (newline))))))
+        (dotimes (i (abs (or n 1)))     ; Insert N times, or once if not specified
+          (insert text))))
+    (if use-region nil                  ; Only if we're working with a line (not a region)
+      (let ((pos (- (point) (line-beginning-position)))) ; Save column
+        (if (> 0 n)                             ; Comment out original with negative arg
+            (comment-region (line-beginning-position) (line-end-position)))
+        (forward-line 1)
+        (forward-char pos)))))
+
 (defun spacemacs/uniquify-lines ()
   "Remove duplicate adjacent lines in region or current buffer"
   (interactive)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -418,6 +418,7 @@
   "xjl" 'set-justification-left
   "xjn" 'set-justification-none
   "xjr" 'set-justification-right
+  "xld" 'spacemacs/duplicate-line-or-region
   "xls" 'spacemacs/sort-lines
   "xlu" 'spacemacs/uniquify-lines
   "xtc" 'transpose-chars


### PR DESCRIPTION
from https://www.emacswiki.org/emacs/CopyingWholeLines

Duplicate current line, or currently selected region if active.
With argument N, make N copies.
With negative N, comment out original line and use the absolute value.

Default keybinding is C-d to allow fast access in emacs editing style, configurable with a layer variable.
Also accessible under `SPC x l d` for "text - line - duplicate".

**Ongoing reflection:**
- `SPC x l d` seems like the most logical but it is quite long, if you have an idea of something shorter your advice is very welcomed.
- `C-d` seems like a fine shortcut to me: fast access and mnemonic, but as it might (?) break someone's workflow I put it in a configuration variable.
  Still not sure if that configuration variable is really needed or if we should hard-code it. Input needed.
