### PR TITLE
replace apostrophes with backticks inside pcases

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -17,7 +17,7 @@
 (spacemacs|defvar-company-backends haskell-cabal-mode)
 (spacemacs|defvar-company-backends intero-repl-mode)
 
-(defvar haskell-completion-backend 'ghci
+(defvar haskell-completion-backend `ghci
   "Completion backend used by company.
 Available options are `ghci', `intero' and `ghc-mod'. Default is
 `ghci'.")

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -15,9 +15,9 @@
     (add-hook 'haskell-mode-hook 'interactive-haskell-mode))
   (when (configuration-layer/package-usedp 'company)
     (pcase haskell-completion-backend
-      ('ghci (spacemacs-haskell//setup-ghci))
-      ('ghc-mod (spacemacs-haskell//setup-ghc-mod))
-      ('intero (spacemacs-haskell//setup-intero)))))
+      (`ghci (spacemacs-haskell//setup-ghci))
+      (`ghc-mod (spacemacs-haskell//setup-ghc-mod))
+      (`intero (spacemacs-haskell//setup-intero)))))
 
 (defun spacemacs-haskell//setup-ghci ()
   (add-to-list 'company-backends-haskell-mode


### PR DESCRIPTION
It looks like when pcase is being used, backticks is the right way to go as mentioned in https://github.com/syl20bnr/spacemacs/issues/5333

On my setup, when I try to open a project in haskell-mode, I get the error below in Messages:

```
File local-variables error: (error "Unknown upattern `(quote ghci)'")
```
