### PR TITLE
Add hook to ediff org files unfolded

### DIFF
--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -124,6 +124,8 @@
        ;; emacs is evil and decrees that vertical shall henceforth be horizontal
        ediff-split-window-function 'split-window-horizontally
        ediff-merge-split-window-function 'split-window-horizontally)
+      ;; show org ediffs unfolded
+      (add-hook 'ediff-prepare-buffer-hook #'outline-show-all)
       ;; restore window layout when done
       (add-hook 'ediff-quit-hook #'winner-undo))))
 


### PR DESCRIPTION
Add hook to ediff org files unfolded instead of folded as is the current implementation.