### PR TITLE
improve font documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,15 @@ For efficient searches we recommend to install `pt` ([the platinum searcher][]).
    fork Spacemacs safely use the `develop` branch where you handle the update
    manually.
 
-3. Launch Emacs. Spacemacs will automatically install the packages it requires.
+3. (Optionally) Install
+   [Source Code Pro](https://github.com/adobe-fonts/source-code-pro):
+
+   If you wish to use default Spacemacs font you'll need to install
+   [Source Code Pro](https://github.com/adobe-fonts/source-code-pro). If you are
+   running in terminal you'll also need to change font settings of your
+   terminal.
+
+4. Launch Emacs. Spacemacs will automatically install the packages it requires.
    If you get an error regarding package downloads then you may try to disable
    the HTTPS protocol by starting Emacs with
 
@@ -224,7 +232,7 @@ For efficient searches we recommend to install `pt` ([the platinum searcher][]).
    clear out your `.emacs.d/elpa` directory before doing this, so that any
    corrupted packages you may have downloaded will be re-installed.
 
-4. Restart Emacs to complete the installation.
+5. Restart Emacs to complete the installation.
 
 If the mode-line turns red then be sure to consult the [FAQ][FAQ.org].
 

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -160,7 +160,9 @@ emacs.")
                                     :powerline-scale 1.1)
   "Default font, or prioritized list of fonts. `powerline-scale'
 allows to quickly tweak the mode-line size to make separators
-look not too crappy.")
+look not too crappy.
+
+Has no effect when running Emacs in terminal.")
 
 (defvar dotspacemacs-remap-Y-to-y$ nil
   "If non nil `Y' is remapped to `y$' in Evil states.")

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -984,12 +984,10 @@ You can see samples of all included themes in this [[http://themegallery.robdor.
 
 ** Font
 The default font used by Spacemacs is [[https://github.com/adobe-fonts/source-code-pro][Source Code Pro]] by Adobe. It is
-recommended to install it on your system.
+recommended to install it on your system if you wish to use it.
 
 To change the default font set the variable =dotspacemacs-default-font= in your
-=.spacemacs= file.
-
-By default its value is:
+=.spacemacs= file. By default its value is:
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-default-font '("Source Code Pro"
@@ -998,6 +996,10 @@ By default its value is:
                                           :width normal
                                           :powerline-scale 1.1))
 #+END_SRC
+
+If specified font can't found, the fallback one will be used (depends on your
+system). Also note that changing this value has no effect if you are running
+Emacs in terminal.
 
 The properties should be pretty straightforward, it is possible to set any valid
 property of a [[http://www.gnu.org/software/emacs/manual/html_node/elisp/Low_002dLevel-Font.html][font-spec]]:


### PR DESCRIPTION
- make it clear that setting dotspacemacs-default-font has no effect in
  terminal
- make it clear that it's user responsibility to install Source Code Pro
  font

Related issues: #2864, #5863