### PR TITLE
New layer: +misc/smart-tabs

### DIFF
--- a/layers/+misc/smart-tabs/README.org
+++ b/layers/+misc/smart-tabs/README.org
@@ -1,6 +1,7 @@
 #+TITLE: Smart Tabs layer
 
-# TOC links should be GitHub style anchors.
+The best whitespace is neither spaces nor tabs, it's spaces /and/ tabs!
+
 * Table of Contents                                        :TOC_4_gh:noexport:
  - [[#description][Description]]
  - [[#install][Install]]
@@ -10,18 +11,20 @@
    - [[#respecting-evil-customizations][Respecting evil customizations]]
 
 * Description
-The best whitespace is neither spaces nor tabs, it's spaces *and* tabs!
-
-This layer brings =smart-tabs-mode= integration, a minor mode that intelligently
-indents your code with tabs, while preserving spaces for alignment and ASCII
-art. In this way, multiple team members can choose their preferred tab length
-without breaking alignment. To enable =smart-tabs-mode= for a given language,
-you *insinuate* it (see instructions below, under [[*configuration][Configuration]]).
+This layer installs =smart-tabs-mode=, a minor mode that intelligently indents
+your code with tabs, while preserving spaces for alignment and ASCII art. In
+this way, multiple team members can choose their preferred tab length without
+breaking alignment of other code elements. To enable =smart-tabs-mode= for a
+given language, you /insinuate/ it (see instructions below, under
+[[#configuration][Configuration]]).
 
 If =indent-tabs-mode= is set to nil, you'll always indent with spaces, even if
 =smart-tabs-mode= is on. Nevertheless, it is recommended that =indent-tabs-mode=
 is left =nil= by default; the layer will handle turning it on for the languages
-you insinuate. =smart-tabs-mode= will use =tab-width= as its indent offset.
+you insinuate.
+
+Note that =smart-tabs-mode= will use =tab-width= as its indent offset,
+overriding the normal indent offset for whatever major mode is active.
 
 Please see [[https://www.emacswiki.org/emacs/SmartTabs][Smart Tabs on the Emacs Wiki]] if you would like more information on
 the underlying mode.
@@ -53,19 +56,19 @@ By default, none of these will be insinuated. To use =smart-tabs-mode= with any
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (smart-tabs :variables
-                smart-tabs-default-insinuations '(c c++ cperl javascript java))
-   ))
+                smart-tabs-default-insinuations '(c c++ cperl javascript java))))
 #+END_SRC
 
 ** Adding support for additional languages
-You should use the new =smart-tabs-add-language-and-insinuate= macro to add
-support for additional language. You can call this in your
-=dotspacemacs/user-config= function to enable support for any other languages
-you use. The arguments are:
+You can use the =smart-tabs-add-language-and-insinuate= macro in your
+=dotspacemacs/user-config= to add support for additional languages. The
+arguments are:
 
- - A symbol to represent the language. This value is mostly unimportant; the
-   only rule is that you can't use the same symbol twice.
+ - A symbol to represent the language. It's recommended to use the name of the
+   language's major mode minus the =-mode= suffix, but the actual value is
+   unimportant; the only rule is that you can't use the same symbol twice.
  - The mode hook for the major mode you want to associate with this language.
+   Hooks will be installed to enable =smart-tabs-mode= and =indent-tabs-mode=.
  - An alist of indent rules. Each rule is a cons cell containing an indent
    function followed by the indent offset variable used by that function.
  - Optionally, any number of body parameters to be executed in the language's
@@ -76,21 +79,19 @@ Here's an example that adds support for Groovy via =groovy-mode=.
 #+BEGIN_SRC emacs-lisp
   (defun dotspacemacs/user-config ()
 
-  ;; ...
+    ;; ...
 
-    (smart-tabs-add-language-and-insinuate groovy groovy-mode-hook
-     ;; Note that Groovy mode, like many other C-like languages, simply reuses
-     ;; Emacs' core C indentation commands
+    (smart-tabs-add-language-and-insinuate
+     groovy
+     groovy-mode-hook
      ((c-indent-line . c-basic-offset)
       (c-indent-region . c-basic-offset))))
 #+END_SRC
 
 ** Respecting evil customizations
-Because =evil= uses its own indentation functions, by default =smart-tabs-mode=
-will not work with evil's indentation operator, ~=~. It's possible to work
-around this by making buffer-local changes to =evil-shift-width= and
-=evil-indent-convert-tabs=, two customizations provided by the evil package. By
-default, the layer will handle this for you; however, if you have customized
+Normally, the layer will make buffer-local changes to =evil-shift-width= and
+=evil-indent-convert-tabs=, two customizations provided by the evil package, in
+order to make evil's indentation operators play nice. If you have customized
 those values yourself and want the layer to respect your values, you can disable
 this behavior by setting the layer variable
 =smart-tabs-respect-evil-customizations= to =t=.

--- a/layers/+misc/smart-tabs/README.org
+++ b/layers/+misc/smart-tabs/README.org
@@ -50,8 +50,8 @@ this file.
 | XML        | =nxml-mode=   | =nxml=       |
 
 By default, none of these will be insinuated. To use =smart-tabs-mode= with any
-   of these languages, set the layer variable =smart-tabs-default-insinuations=
-   to a list of any or all of the symbols listed above.
+of these languages, set the layer variable =smart-tabs-default-insinuations=
+to a list of any or all of the symbols listed above.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
@@ -60,7 +60,7 @@ By default, none of these will be insinuated. To use =smart-tabs-mode= with any
 #+END_SRC
 
 ** Adding support for additional languages
-You can use the =smart-tabs-add-language-and-insinuate= macro in your
+You can use the =smart-tabs|add-language-and-insinuate= macro in your
 =dotspacemacs/user-config= to add support for additional languages. The
 arguments are:
 
@@ -81,7 +81,7 @@ Here's an example that adds support for Groovy via =groovy-mode=.
 
     ;; ...
 
-    (smart-tabs-add-language-and-insinuate
+    (smart-tabs|add-language-and-insinuate
      groovy
      groovy-mode-hook
      ((c-indent-line . c-basic-offset)

--- a/layers/+misc/smart-tabs/README.org
+++ b/layers/+misc/smart-tabs/README.org
@@ -1,0 +1,102 @@
+#+TITLE: Smart Tabs layer
+
+# TOC links should be GitHub style anchors.
+* Table of Contents                                        :TOC_4_gh:noexport:
+ - [[#description][Description]]
+ - [[#install][Install]]
+ - [[#configuration][Configuration]]
+   - [[#built-in-languages][Built-in languages]]
+   - [[#adding-support-for-additional-languages][Adding support for additional languages]]
+   - [[#respecting-evil-customizations][Respecting evil customizations]]
+
+* Description
+The best whitespace is neither spaces nor tabs, it's spaces *and* tabs!
+
+This layer brings =smart-tabs-mode= integration, a minor mode that intelligently
+indents your code with tabs, while preserving spaces for alignment and ASCII
+art. In this way, multiple team members can choose their preferred tab length
+without breaking alignment. To enable =smart-tabs-mode= for a given language,
+you *insinuate* it (see instructions below, under [[*configuration][Configuration]]).
+
+If =indent-tabs-mode= is set to nil, you'll always indent with spaces, even if
+=smart-tabs-mode= is on. Nevertheless, it is recommended that =indent-tabs-mode=
+is left =nil= by default; the layer will handle turning it on for the languages
+you insinuate. =smart-tabs-mode= will use =tab-width= as its indent offset.
+
+Please see [[https://www.emacswiki.org/emacs/SmartTabs][Smart Tabs on the Emacs Wiki]] if you would like more information on
+the underlying mode.
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =smart-tabs= to the existing =dotspacemacs-configuration-layers= list in
+this file.
+
+* Configuration
+** Built-in languages
+=smart-tabs-mode= comes with built-in configurations for these languages:
+
+| Language   | Mode          | Symbol       |
+|------------+---------------+--------------|
+| C          | =c-mode=      | =c=          |
+| C++        | =c++-mode=    | =c++=        |
+| Java       | =java-mode=   | =java=       |
+| JavaScript | =js2-mode=    | =javascript= |
+| Perl       | =cperl-mode=  | =cperl=      |
+| Python     | =python-mode= | =python=     |
+| Ruby       | =ruby-mode=   | =ruby=       |
+| XML        | =nxml-mode=   | =nxml=       |
+
+By default, none of these will be insinuated. To use =smart-tabs-mode= with any
+   of these languages, set the layer variable =smart-tabs-default-insinuations=
+   to a list of any or all of the symbols listed above.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (smart-tabs :variables
+                smart-tabs-default-insinuations '(c c++ cperl javascript java))
+   ))
+#+END_SRC
+
+** Adding support for additional languages
+You should use the new =smart-tabs-add-language-and-insinuate= macro to add
+support for additional language. You can call this in your
+=dotspacemacs/user-config= function to enable support for any other languages
+you use. The arguments are:
+
+ - A symbol to represent the language. This value is mostly unimportant; the
+   only rule is that you can't use the same symbol twice.
+ - The mode hook for the major mode you want to associate with this language.
+ - An alist of indent rules. Each rule is a cons cell containing an indent
+   function followed by the indent offset variable used by that function.
+ - Optionally, any number of body parameters to be executed in the language's
+   mode hook after enabling =smart-tabs-mode=.
+
+Here's an example that adds support for Groovy via =groovy-mode=.
+
+#+BEGIN_SRC emacs-lisp
+  (defun dotspacemacs/user-config ()
+
+  ;; ...
+
+    (smart-tabs-add-language-and-insinuate groovy groovy-mode-hook
+     ;; Note that Groovy mode, like many other C-like languages, simply reuses
+     ;; Emacs' core C indentation commands
+     ((c-indent-line . c-basic-offset)
+      (c-indent-region . c-basic-offset))))
+#+END_SRC
+
+** Respecting evil customizations
+Because =evil= uses its own indentation functions, by default =smart-tabs-mode=
+will not work with evil's indentation operator, ~=~. It's possible to work
+around this by making buffer-local changes to =evil-shift-width= and
+=evil-indent-convert-tabs=, two customizations provided by the evil package. By
+default, the layer will handle this for you; however, if you have customized
+those values yourself and want the layer to respect your values, you can disable
+this behavior by setting the layer variable
+=smart-tabs-respect-evil-customizations= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (smart-tabs :variables
+                smart-tabs-respect-evil-customizations t)))
+#+END_SRC

--- a/layers/+misc/smart-tabs/config.el
+++ b/layers/+misc/smart-tabs/config.el
@@ -24,21 +24,23 @@ Set this to t if you want to always respect those values.")
 
 ;;; Code:
 
-;;; Utility function that simply enables indent-tabs-mode
-;;; This is used as an argument to add-hook
-(defun smart-tabs/enable-tabs-mode ()
-  (setq indent-tabs-mode t))
-
 ;;; Macro that combines adding new language support, insinuating it, and hooking
 ;;; indent-tabs-mode in one place
-(defmacro smart-tabs-add-language-and-insinuate (lang mode-hook advice-list &rest body)
+(defmacro smart-tabs|add-language-and-insinuate (lang mode-hook advice-list &rest body)
   `(progn
      (smart-tabs-add-language-support ,lang ,mode-hook ,advice-list ,@body)
      (smart-tabs-insinuate ',lang)
-     (add-hook ',mode-hook 'smart-tabs/enable-tabs-mode)))
+     (add-hook ',mode-hook #'smart-tabs//enable-tabs-mode)))
 
-(defun smart-tabs/no-tabs-mode (orig-fun &rest args)
-  (let ((indent-tabs-mode nil))
-    (apply orig-fun args)))
+;;; Utility function that simply enables indent-tabs-mode
+;;; This is used as an argument to add-hook
+(defun smart-tabs//enable-tabs-mode ()
+  (setq indent-tabs-mode t))
+
+;; Set up evil-mode to play nice with smart-tabs-mode
+(defun smart-tabs//evil-setup ()
+  (unless smart-tabs-respect-evil-customizations
+    (setq-local evil-shift-width tab-width)
+    (setq-local evil-indent-convert-tabs nil)))
 
 ;;; config.el ends here

--- a/layers/+misc/smart-tabs/config.el
+++ b/layers/+misc/smart-tabs/config.el
@@ -1,0 +1,44 @@
+;;; config.el --- smart-tabs layer config file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Curtis Mackie <curtis@mackie.ninja>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Variables:
+
+(defvar smart-tabs-default-insinuations nil
+  "A list of values that will be passed to `smart-tabs-insinuate'
+on package load. Only languages supported by `smart-tabs-mode' by default
+(i.e. c, c++, java, javascript, cperl, python, ruby, or nxml) should be
+included here. Defaults to nil.")
+
+(defvar smart-tabs-respect-evil-customizations nil
+  "If nil, loading `smart-tabs-mode' will locally redefine some evil
+customize values to make `evil-indent' work with smart tabs.
+Set this to t if you want to always respect those values.")
+
+;;; Code:
+
+;;; Utility function that simply enables indent-tabs-mode
+;;; This is used as an argument to add-hook
+(defun smart-tabs/enable-tabs-mode ()
+  (setq indent-tabs-mode t))
+
+;;; Macro that combines adding new language support, insinuating it, and hooking
+;;; indent-tabs-mode in one place
+(defmacro smart-tabs-add-language-and-insinuate (lang mode-hook advice-list &rest body)
+  `(progn
+     (smart-tabs-add-language-support ,lang ,mode-hook ,advice-list ,@body)
+     (smart-tabs-insinuate ',lang)
+     (add-hook ',mode-hook 'smart-tabs/enable-tabs-mode)))
+
+(defun smart-tabs/no-tabs-mode (orig-fun &rest args)
+  (let ((indent-tabs-mode nil))
+    (apply orig-fun args)))
+
+;;; config.el ends here

--- a/layers/+misc/smart-tabs/packages.el
+++ b/layers/+misc/smart-tabs/packages.el
@@ -26,16 +26,11 @@
     :diminish smart-tabs-mode
     :config
     (progn
-      (add-hook 'smart-tabs-mode-hook
-                (lambda ()
-                  ;; Set up evil-mode to play nice with smart-tabs-mode
-                  (unless smart-tabs-respect-evil-customizations
-                    (setq-local evil-shift-width tab-width)
-                    (setq-local evil-indent-convert-tabs nil))))
+      (add-hook 'smart-tabs-mode-hook #'smart-tabs//evil-setup)
       ;; Run default insinuations
       (dolist (lang smart-tabs-default-insinuations)
         (smart-tabs-insinuate lang)
         (add-hook (car (smart-tabs-get-standard-language lang))
-                  'smart-tabs/enable-tabs-mode)))))
+                  #'smart-tabs//enable-tabs-mode)))))
 
 ;;; packages.el ends here

--- a/layers/+misc/smart-tabs/packages.el
+++ b/layers/+misc/smart-tabs/packages.el
@@ -1,0 +1,41 @@
+;;; packages.el --- smart-tabs layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Curtis Mackie <curtis@mackie.ninja>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;; This layer integrates smart-tabs-mode with Spacemacs, allowing users to indent
+;; with tabs and align with spaces. It ensures that it works as expected with
+;; evil's = operator, as well as streamlining the configuration process for new
+;; language support.
+
+;;; Code:
+
+(defconst smart-tabs-packages
+  '(smart-tabs-mode))
+
+(defun smart-tabs/init-smart-tabs-mode ()
+  (use-package smart-tabs-mode
+    :diminish smart-tabs-mode
+    :config
+    (progn
+      (add-hook 'smart-tabs-mode-hook
+                (lambda ()
+                  ;; Set up evil-mode to play nice with smart-tabs-mode
+                  (unless smart-tabs-respect-evil-customizations
+                    (setq-local evil-shift-width tab-width)
+                    (setq-local evil-indent-convert-tabs nil))))
+      ;; Run default insinuations
+      (dolist (lang smart-tabs-default-insinuations)
+        (smart-tabs-insinuate lang)
+        (add-hook (car (smart-tabs-get-standard-language lang))
+                  'smart-tabs/enable-tabs-mode)))))
+
+;;; packages.el ends here


### PR DESCRIPTION
This layer streamlines the process of setting up smart-tabs-mode with Spacemacs; it automates disabling Evil's built-in tab replacement and enabling indent-tabs-mode for supported languages (while leaving those settings alone in other buffers).

This is my first contributed layer, so please let me know if there's any style or naming issues that need to be corrected.

Make what you want of the introductory text, the joke had to be made.
