### PR TITLE
Update `brew linkapps` to be more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The recommended way of installing Emacs on OS X is using [homebrew][]:
 ```sh
 $ brew tap d12frosted/emacs-plus
 $ brew install emacs-plus --with-cocoa --with-gnutls --with-librsvg --with-imagemagick --with-spacemacs-icon
-$ brew linkapps
+$ brew linkapps emacs-plus
 ```
 
 *Note:* these homebrew commands will install Emacs, and link it to your


### PR DESCRIPTION
Users may not want to link all possible apps and doing so isn't required to link Spacemacs individually. (I accidentally linked all my apps because I always forget that Homebrew linkapps can accept a list of formulae 😬)
