### PR TITLE
Adds elm-format section and advice for absolute paths with npm

### DIFF
--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -11,6 +11,7 @@
      - [[#universal-installer-using-npm][Universal installer using npm]]
      - [[#source-code][Source code]]
    - [[#elm-oracle][elm-oracle]]
+   - [[#elm-format][elm-format]]
  - [[#basic-usage-tips][Basic usage tips]]
    - [[#compilation][Compilation]]
    - [[#reactor][Reactor]]
@@ -64,6 +65,9 @@ certain operating system and architectures.
 Also, note that you might need to set the ~ELM_HOME~ environment variables to
 the corresponding directory created by the installer.
 
+If you are facing problems with previewing a buffer with ~elm-reactor~ ensure that
+the absolute path of the npm global bin file is on your path within emacs
+
 OS X Users facing problems with ~elm-reactor~ failing to properly install or
 run, see this issue [[https://github.com/kevva/elm-bin/issues/28][https://github.com/kevva/elm-bin/issues/28]].
 
@@ -84,6 +88,20 @@ run this command:
 
 #+BEGIN_SRC sh
   npm install -g elm-oracle
+#+END_SRC
+
+** elm-format
+~elm-format~ can be used to format elm code according to a standard set of rules.
+
+To install ~elm-format~ follow the the instructions for the version of elm installed:
+https://github.com/avh4/elm-format
+
+Also, note that if you use homebrew to install ~elm-format~ the installed exe has a
+version suffix, the installed command name can be set in your =~/spacemacs=:
+
+#+BEGIN_SRC emacs-lisp
+  (elm :variables
+       elm-format-command "elm-format-0.17")
 #+END_SRC
 
 * Basic usage tips


### PR DESCRIPTION
- Use of relative paths for npm global bin directory caused the following error in the browser when trying to preview a buffer with elm-reactor:

`A web handler threw an exception. Details:`
`elm-make: readCreateProcessWithExitCode: runInteractiveProcess: exec: does not exist (No such file or directory)`

- Added a section for elm-format so that hints on how to use homebrew can be given