### PR TITLE
Don't auto-close apostrophes in SML

### DIFF
--- a/layers/+lang/sml/packages.el
+++ b/layers/+lang/sml/packages.el
@@ -13,6 +13,7 @@
   '(
     sml-mode
     ob-sml
+    smartparens
     ))
 
 (defun sml/init-sml-mode ()
@@ -54,6 +55,12 @@
         "ss" 'run-sml)
       (define-key sml-mode-map (kbd "M-SPC") 'sml-electric-space)
       (define-key sml-mode-map (kbd "|") 'sml-electric-pipe))))
+
+(defun sml/post-init-smartparens ()
+  (with-eval-after-load 'smartparens
+    ;; don't auto-close apostrophes (type 'a = foo) and backticks (`Foo)
+    (sp-local-pair 'sml-mode "'" nil :actions nil)
+    (sp-local-pair 'sml-mode "`" nil :actions nil)))
 
 (defun sml/init-ob-sml ()
   (use-package ob-sml


### PR DESCRIPTION
Don't auto-close apostrophes (`type 'a = foo`) and backticks (`Foo) as in OCaml layer
