### PR TITLE
colorize compilation buffers by processing ansi color sequences

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -10,7 +10,8 @@
 ;;; License: GPLv3
 
 (setq spacemacs-ui-visual-packages
-      '(fancy-battery
+      '((ansi-colors :location built-in)
+	fancy-battery
         fill-column-indicator
         golden-ratio
         hl-todo
@@ -20,6 +21,14 @@
         (smooth-scrolling :location built-in)
         spaceline
         (zoom-frm :location local)))
+
+(defun spacemacs-ui-visual/init-ansi-colors ()
+  :init
+  (progn
+    (defun spacemacs-ui-visual/compilation-buffer-apply-ansi-colors ()
+      (let ((inhibit-read-only t))
+	(ansi-color-apply-on-region compilation-filter-start (point-max))))
+    (add-hook 'compilation-filter-hook 'spacemacs-ui-visual/compilation-buffer-apply-ansi-colors)))
 
 (defun spacemacs-ui-visual/init-fancy-battery ()
   (use-package fancy-battery


### PR DESCRIPTION
By default, compilation buffers do not handle ansi color SGRs and print them instead, making the output messy and not readable.

This commit brings some color and readability to compilation buffers by treating ansi color SGRs.

The approach taken here uses [the function](https://github.com/emacs-mirror/emacs/blob/master/lisp/ansi-color.el#L233) used in [the function used in comint-mode](https://github.com/emacs-mirror/emacs/blob/master/lisp/comint.el#L389).
