### PR TITLE
Fix overriding `exec-path` by the OCaml layer

### DIFF
--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -97,16 +97,9 @@
       (spacemacs/register-repl 'utop 'utop "ocaml"))
     :config
     (progn
-      ;; Setup environment variables using opam
       (if (executable-find "opam")
-          (let ((vars (car (read-from-string
-                            (shell-command-to-string "opam config env --sexp")))))
-            (dolist (var vars)
-              (setenv (car var) (cadr var))))
+          (setq utop-command "opam config exec -- utop -emacs")
         (spacemacs-buffer/warning "Cannot find \"opam\" executable."))
-      ;; Update the emacs path
-      (setq exec-path (append (parse-colon-path (getenv "PATH"))
-                              (list exec-directory)))
 
       (defun spacemacs/utop-eval-phrase-and-go ()
         "Send phrase to REPL and evaluate it and switch to the REPL in


### PR DESCRIPTION
The old config has the following:
```
(let ((vars (car (read-from-string
                  (shell-command-to-string "opam config env --sexp")))))
  (dolist (var vars)
    (setenv (car var) (cadr var))))
```
On my machine, `opam config env --sexp` returns
>(
  ("CAML_LD_LIBRARY_PATH" "/Users/jeremybi/.opam/system/lib/stublibs:/usr/local/lib/ocaml/stublibs")
  ("OPAMUTF8MSGS" "1")
  ("MANPATH" "/Users/jeremybi/.opam/system/man:/usr/local/man:/usr/man:/usr/local/share/man:/usr/share/man:/usr/local/opt/coreutils/libexec/gnuman")
  ("PERL5LIB" "/Users/jeremybi/.opam/system/lib/perl5")
  ("OCAML_TOPLEVEL_PATH" "/Users/jeremybi/.opam/system/lib/toplevel")
  ("PATH" "/Users/jeremybi/.opam/system/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/TeX/texbin")
)

This piece of code is dangerous as it overrides users' `PATH` variable blindly. I don't know why we put this code here in the first place. Anyway, I updated the config of `utop`  as per instructions on the official site of `utop`.

(I spent several hours figuring out why `exec-path` returned is so different from `PATH` in the terminal  :broken_heart:)