### PR TITLE
Fix yaml layer autocompletion

### DIFF
--- a/layers/+lang/yaml/config.el
+++ b/layers/+lang/yaml/config.el
@@ -1,0 +1,14 @@
+;;; config.el --- YAML Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; variables
+
+(spacemacs|defvar-company-backends yaml-mode)

--- a/layers/+lang/yaml/packages.el
+++ b/layers/+lang/yaml/packages.el
@@ -12,7 +12,7 @@
                       yaml-mode))
 
 (defun yaml/post-init-company ()
-  (add-hook 'yaml-mode-hook 'company-mode))
+  (spacemacs|add-company-hook yaml-mode))
 
 (defun yaml/init-yaml-mode ()
   "Initialize YAML mode"


### PR DESCRIPTION
Autocompletion was not working with yasnippets for yaml layer. This also fixes autocompletion for ansible layer.