### PR TITLE
Add centering to space-doc

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -499,7 +499,8 @@ arguments of the =ag= program.
 You can modify the list of visual enhancements applied by the =space-doc-mode=:
 #+BEGIN_SRC emacs-lisp
 (setq spacemacs-space-doc-modificators
-      '(spacemacs//space-doc-org-indent-mode
+      '(spacemacs//space-doc-center-buffer-mode
+        spacemacs//space-doc-org-indent-mode
         spacemacs//space-doc-view-mode
         spacemacs//space-doc-hide-line-numbers
         spacemacs//space-doc-emphasis-overlays
@@ -512,6 +513,7 @@ You can modify the list of visual enhancements applied by the =space-doc-mode=:
 #+END_SRC
 It's the default value of the variable with all enhancements.
 Each function in the list represents some modification.
+Some of them might be order dependant so don't shuffle the list!
 You can make a modification deferred by moving it to =spacemacs-space-doc-modificators-deferred= list.
 
 ** Remap paste key to be able to paste copied text multiple times

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -508,7 +508,7 @@ You can modify the list of visual enhancements applied by the =space-doc-mode=:
         spacemacs//space-doc-org-block-line-face-remap
         spacemacs//space-doc-org-kbd-face-remap
         spacemacs//space-doc-resize-inline-images
-        spacemacs//space-doc-advice-org-do-emphasis-faces)
+        spacemacs//space-doc-advice-org-do-emphasis-faces))
 #+END_SRC
 It's the default value of the variable with all enhancements.
 Each function in the list represents some modification.

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -191,34 +191,30 @@ automatically applied to."
       (window-configuration-to-register ?_)
       (delete-other-windows))))
 
-;; A small minor mode to use a big fringe adapted from
-;; http://bzg.fr/emacs-strip-tease.html
-(define-minor-mode spacemacs-centered-buffer-mode
-  "Minor mode to use big fringe in the current buffer."
-  :global t
-  :init-value nil
-  :group 'editing-basics
-  (if spacemacs-centered-buffer-mode
-      (progn
-        (window-configuration-to-register ?_)
-        (delete-other-windows)
-        (set-fringe-mode
-         (/ (- (frame-pixel-width)
-               (* 100 (frame-char-width)))
-            2)))
-    (set-fringe-style nil)
-    (when (assoc ?_ register-alist)
-      (jump-to-register ?_))))
-
-(defun spacemacs/ace-center-window ()
-  "Ace center window."
+;; https://tsdh.wordpress.com/2007/03/28/deleting-windows-vertically-or-horizontally/
+(defun  spacemacs/maximize-horizontally ()
+  "Delete all windows left or right of the current window."
   (interactive)
-  (require 'ace-window)
-  (aw-select
-   " Ace - Center Window"
-   (lambda (window)
-     (aw-switch-to-window window)
-     (spacemacs-centered-buffer-mode))))
+  (require 'windmove)
+  (save-excursion
+    (while (condition-case nil (windmove-left) (error nil))
+      (delete-window))
+    (while (condition-case nil (windmove-right) (error nil))
+      (delete-window))))
+
+(defun spacemacs/toggle-centered-buffer-mode ()
+  "Toggle `spacemacs-centered-buffer-mode'."
+  (interactive)
+  (when (require 'centered-buffer-mode nil t)
+    (call-interactively 'spacemacs-centered-buffer-mode)))
+
+(defun spacemacs/centered-buffer-mode-full-width ()
+  "Toggle `spacemacs-centered-buffer-mode'."
+  (interactive)
+  (when (require 'centered-buffer-mode nil t)
+    (spacemacs/maximize-horizontally)
+    (call-interactively 'spacemacs-centered-buffer-mode)))
+
 
 (defun spacemacs/useless-buffer-p (buffer)
   "Determines if a buffer is useful."

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -209,7 +209,7 @@ automatically applied to."
     (call-interactively 'spacemacs-centered-buffer-mode)))
 
 (defun spacemacs/centered-buffer-mode-full-width ()
-  "Toggle `spacemacs-centered-buffer-mode'."
+  "Center buffer in the frame."
   (interactive)
   (when (require 'centered-buffer-mode nil t)
     (spacemacs/maximize-horizontally)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -380,7 +380,8 @@
   "wl"  'evil-window-right
   "w <right>"  'evil-window-right
   "wm"  'spacemacs/toggle-maximize-buffer
-  "wc"  'spacemacs-centered-buffer-mode
+  "wc"  'spacemacs/toggle-centered-buffer-mode
+  "wC"  'spacemacs/centered-buffer-mode-full-width
   "wo"  'other-frame
   "wr"  'spacemacs/rotate-windows
   "wR"  'spacemacs/rotate-windows-backward
@@ -393,7 +394,8 @@
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
   "w/"  'split-window-right
-  "w="  'balance-windows)
+  "w="  'balance-windows
+  "w_"  'spacemacs/maximize-horizontally)
 ;; text -----------------------------------------------------------------------
 (defalias 'count-region 'count-words-region)
 

--- a/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
+++ b/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
@@ -38,7 +38,7 @@ that differed modifications won't cause an overflow."
   :type 'integer
   :group 'editing-basics)
 
-(defcustom spacemacs-centered-buffer-mode-min-fringe-color "black"
+(defcustom spacemacs-centered-buffer-mode-fringe-color "black"
   "Color of the fringes."
   :type 'string
   :group 'editing-basics)
@@ -75,49 +75,50 @@ that differed modifications won't cause an overflow."
           (outline-show-all))
         (switch-to-buffer indirect-buffer nil t)
         (with-mode-disabled page-break-lines-mode
-                            (let* ((fringe-w (spacemacs//centered-buffer-calc-fringe
-                                              window)))
-                              (if (> fringe-w spacemacs-centered-buffer-mode-min-fringe-width)
-                                  (progn
-                                    ;; Fix visual glitch.
-                                    (spacemacs/toggle-line-numbers)
-                                    (spacemacs/toggle-line-numbers)
-                                    ;;
-                                    (setq spacemacs--centered-buffer-mode-indirect-buffers
-                                          (append (list indirect-buffer)
-                                                  spacemacs--centered-buffer-mode-indirect-buffers)
-                                          spacemacs--centered-buffer-mode-origin-buffer origin-buffer
-                                          spacemacs-centered-buffer-mode t
-                                          indicate-empty-lines nil
-                                          fringes-outside-margins t
-                                          left-fringe-width fringe-w
-                                          right-fringe-width fringe-w
-                                          ;; looks better with some margin.
-                                          left-margin-width (if (or (not left-margin-width)
-                                                                    (= left-margin-width 0))
-                                                                1
-                                                              left-margin-width)
-                                          spacemacs--centered-buffer-mode-text-pixel-size
-                                          (car (window-text-pixel-size window)))
-                                    (face-remap-add-relative 'fringe :background
-                                                             spacemacs-centered-buffer-mode-min-fringe-color)
-                                    (set-window-buffer window indirect-buffer)
-                                    (add-hook 'buffer-list-update-hook
-                                              'spacemacs//centered-buffer-buffer-list-update-fringes)
-                                    (add-hook 'window-configuration-change-hook
-                                              'spacemacs//centered-buffer-buffer-list-update-fringes))
-                                (setq spacemacs--centered-buffer-mode-origin-buffer nil)
-                                (set-buffer origin-buffer)
-                                (kill-buffer indirect-buffer)
-                                (setq spacemacs--centered-buffer-mode-indirect-buffer nil)
-                                (when (called-interactively-p 'any)
-                                  (message "Not enough space to center the buffer!"))))))
+          (let* ((fringe-w (spacemacs//centered-buffer-calc-fringe
+                            window)))
+            (if (> fringe-w spacemacs-centered-buffer-mode-min-fringe-width)
+                (progn
+                  ;; Fix visual glitch.
+                  (spacemacs/toggle-line-numbers)
+                  (spacemacs/toggle-line-numbers)
+                  ;;
+                  (setq spacemacs--centered-buffer-mode-indirect-buffers
+                        (append (list indirect-buffer)
+                                spacemacs--centered-buffer-mode-indirect-buffers)
+                        spacemacs--centered-buffer-mode-origin-buffer origin-buffer
+                        spacemacs-centered-buffer-mode t
+                        indicate-empty-lines nil
+                        fringes-outside-margins t
+                        left-fringe-width fringe-w
+                        right-fringe-width fringe-w
+                        ;; looks better with some margin.
+                        left-margin-width (if (or (not left-margin-width)
+                                                  (= left-margin-width 0))
+                                              1
+                                            left-margin-width)
+                        spacemacs--centered-buffer-mode-text-pixel-size
+                        (car (window-text-pixel-size window)))
+                  (face-remap-add-relative 'fringe :background
+                                           spacemacs-centered-buffer-mode-fringe-color)
+                  (set-window-buffer window indirect-buffer)
+                  (add-hook 'buffer-list-update-hook
+                            'spacemacs//centered-buffer-buffer-list-update-fringes)
+                  (add-hook 'window-configuration-change-hook
+                            'spacemacs//centered-buffer-buffer-list-update-fringes))
+              (setq spacemacs--centered-buffer-mode-origin-buffer nil)
+              (set-buffer origin-buffer)
+              (kill-buffer indirect-buffer)
+              (setq spacemacs--centered-buffer-mode-indirect-buffer nil)
+              (when (called-interactively-p 'any)
+                (message "Not enough space to center the buffer!"))))))
     (let* ((window (selected-window))
            (origin-buffer spacemacs--centered-buffer-mode-origin-buffer)
            (indirect-buffer (window-buffer window)))
       (setq spacemacs--centered-buffer-mode-origin-buffer nil)
-      (switch-to-buffer origin-buffer nil t)
-      (setq spacemacs--centered-buffer-mode-indirect-buffer nil)
+      (when (buffer-live-p origin-buffer)
+        (switch-to-buffer origin-buffer nil t)
+        (setq spacemacs--centered-buffer-mode-indirect-buffer nil))
       (when (buffer-live-p indirect-buffer)
         (dolist (window (get-buffer-window-list indirect-buffer 2))
           (set-window-buffer window origin-buffer))

--- a/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
+++ b/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
@@ -40,7 +40,7 @@ that differed modifications won't cause an overflow."
 
 (defcustom spacemacs-centered-buffer-mode-fringe-color "black"
   "Color of the fringes."
-  :type 'string
+  :type 'color
   :group 'editing-basics)
 
 (defvar-local spacemacs--centered-buffer-mode-origin-buffer nil)
@@ -52,7 +52,6 @@ that differed modifications won't cause an overflow."
   "Minor mode to center buffer in its window."
   :init-value nil
   :group 'editing-basics
-  :lighter " -B-"
   (if spacemacs-centered-buffer-mode
       (let* ((window (selected-window))
              (origin-buffer (window-buffer window))

--- a/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
+++ b/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
@@ -1,0 +1,128 @@
+;;; centered-buffer-mode.el --- Minor mode for centering buffers.
+
+;; Copyright (C) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; Keywords: centering
+;; Created: 1 July 2016
+;; Version: 1.00
+;; Package-Requires: ((emacs "24.4"))
+;; URL: https://github.com/syl20bnr/spacemacs
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+(require 'face-remap)
+
+(defvar-local spacemacs--centered-buffer-mode-origin-buffer nil)
+(defvar-local spacemacs--centered-buffer-mode-indirect-buffer nil)
+(defvar-local spacemacs--centered-buffer-mode-text-pixel-size nil)
+(defvar spacemacs--centered-buffer-mode-min-fringe-width 50)
+
+(define-minor-mode spacemacs-centered-buffer-mode
+  "Minor mode to center the current buffer.
+
+Hide line number and empty lines indicator(~) if
+called interactively."
+  :init-value nil
+  :group 'editing-basics
+  :lighter "-||-"
+  (if spacemacs-centered-buffer-mode
+      (let* ((window (selected-window))
+             (origin-buffer (window-buffer window))
+             (indirect-buffer
+              (if (buffer-live-p
+                   spacemacs--centered-buffer-mode-indirect-buffer)
+                  spacemacs--centered-buffer-mode-indirect-buffer
+                (setq spacemacs--centered-buffer-mode-indirect-buffer
+                      (make-indirect-buffer origin-buffer
+                                            (format "%s(centered)"
+                                                    origin-buffer)
+                                            t)))))
+        ;; Mode will be applied to the indirect buffer.
+        (setq spacemacs-centered-buffer-mode
+              nil
+              spacemacs--centered-buffer-mode-indirect-buffer
+              indirect-buffer)
+        (when (derived-mode-p 'org-mode)
+          (setq-local org-startup-folded nil)
+          (outline-show-all))
+        (switch-to-buffer indirect-buffer nil t)
+        (spacemacs/toggle-line-numbers-off)
+        (let* ((fringe-w (spacemacs//centered-buffer-calc-fringe
+                          window)))
+          (if (> fringe-w spacemacs--centered-buffer-mode-min-fringe-width)
+              (progn
+                (setq spacemacs--centered-buffer-mode-origin-buffer origin-buffer
+                      spacemacs-centered-buffer-mode t
+                      fringes-outside-margins t
+                      left-fringe-width fringe-w
+                      right-fringe-width fringe-w
+                      indicate-empty-lines nil
+                      spacemacs--centered-buffer-mode-text-pixel-size
+                      (car (window-text-pixel-size window)))
+                (face-remap-add-relative 'fringe :background "black")
+                (set-window-buffer window indirect-buffer)
+                (read-only-mode t)
+                (add-hook 'buffer-list-update-hook
+                          'spacemacs//centered-buffer-buffer-list-update-fringes)
+                (add-hook 'window-configuration-change-hook
+                          'spacemacs//centered-buffer-buffer-list-update-fringes))
+            (setq spacemacs--centered-buffer-mode-origin-buffer nil)
+            (set-buffer origin-buffer)
+            (kill-buffer indirect-buffer)
+            (setq spacemacs--centered-buffer-mode-indirect-buffer nil)
+            (when (called-interactively-p 'any)
+              (message "Not enough space to center the buffer!")))))
+    (let* ((window (selected-window))
+           (origin-buffer spacemacs--centered-buffer-mode-origin-buffer)
+           (indirect-buffer (window-buffer window)))
+      (setq spacemacs--centered-buffer-mode-origin-buffer nil)
+      (switch-to-buffer origin-buffer nil t)
+      (setq spacemacs--centered-buffer-mode-indirect-buffer nil)
+      (dolist (window (get-buffer-window-list indirect-buffer 2))
+        (set-window-buffer window origin-buffer))
+      (kill-buffer indirect-buffer))))
+
+(defun spacemacs//centered-buffer-calc-fringe (&optional window text-pixel-size)
+  "Calculate fringe width for `spacemacs-centered-buffer-mode'.
+Uses text-pixel-size if provided, otherwise calculates it with `window-pixel-width'."
+  (-(/ (- (window-pixel-width window)
+          (or text-pixel-size
+              (car (window-text-pixel-size window))))
+       2)
+    ;; 20 * 2 extra pixels for the `org-indent' shenanigans
+    ;; and 20 as a safe base.
+    (if (bound-and-true-p org-indent-mode) 40 20)))
+
+(defun spacemacs//centered-buffer-buffer-list-update-fringes ()
+  "Used in `spacemacs//centered-buffer-buffer-list-update-hook' and
+`spacemacs//centered-buffer-buffer-window-configuration-change-hook'."
+  (dolist (window (window-list))
+    (when (and (buffer-local-value 'spacemacs--centered-buffer-mode-origin-buffer
+                                   (window-buffer window))
+               (buffer-live-p (window-buffer window)))
+      (with-selected-window window
+        (let ((fringe-w (spacemacs//centered-buffer-calc-fringe
+                         window
+                         spacemacs--centered-buffer-mode-text-pixel-size)))
+          (if (> fringe-w spacemacs--centered-buffer-mode-min-fringe-width)
+              (set-window-fringes window fringe-w fringe-w t)
+            (spacemacs-centered-buffer-mode -1)))))))
+
+(provide 'centered-buffer-mode)
+
+;;; centered-buffer-mode.el ends here

--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -14,6 +14,7 @@
         (abbrev :location built-in)
         ace-window
         (bookmark :location built-in)
+        (centered-buffer-mode :location local)
         (dired :location built-in)
         (dired-x :location built-in)
         (electric-indent-mode :location built-in)
@@ -60,7 +61,8 @@
     (progn
       (spacemacs/set-leader-keys
         "bD" 'spacemacs/ace-kill-this-buffer
-        "wC" 'spacemacs/ace-center-window
+        ;; NOTE: Needs new binding.
+        ;; "wC" 'spacemacs/ace-center-window
         "wD" 'spacemacs/ace-delete-window
         "wM" 'ace-swap-window
         "wW" 'ace-window)
@@ -496,3 +498,5 @@
       (setq winner-boring-buffers
             (append winner-boring-buffers spacemacs/winner-boring-buffers))
       (winner-mode t))))
+
+(defun spacemacs-base/init-centered-buffer-mode ())

--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -61,7 +61,7 @@
     (progn
       (spacemacs/set-leader-keys
         "bD" 'spacemacs/ace-kill-this-buffer
-        ;; NOTE: Needs new binding.
+        ;; FIXME: Needs new binding.
         ;; "wC" 'spacemacs/ace-center-window
         "wD" 'spacemacs/ace-delete-window
         "wM" 'ace-swap-window

--- a/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
+++ b/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
@@ -48,7 +48,8 @@ keeping their content visible.
 
 ;; NOTE: Dont forget to update Spacemacs FAQ if you modify this list!
 (defvar spacemacs-space-doc-modificators
-  '(spacemacs//space-doc-org-indent-mode
+  '(spacemacs//space-doc-center-buffer-mode
+    spacemacs//space-doc-org-indent-mode
     spacemacs//space-doc-view-mode
     spacemacs//space-doc-hide-line-numbers
     spacemacs//space-doc-emphasis-overlays
@@ -68,6 +69,34 @@ by the function. Otherwise - disable.")
   '()
   "Same as `spacemacs-space-doc-modificators' but the modificators will
 be run deferred.")
+
+(defun spacemacs//space-doc-center-buffer-mode (&optional flag)
+  "Enable `spacemacs-centered-buffer-mode' if flag is non nil, disable it otherwise.
+This functions is aimed to be used with `spacemacs-space-doc-modificators'."
+  ;;FIXME: Need to redesign this.. One day.
+  (if flag
+      (progn
+        ;; HACK: Hide the original buffer from `spacemacs/previous-useful-buffer'.
+        (rename-buffer (format "*%s*" (buffer-name)))
+        (set (make-local-variable 'spacemacs--space-doc-origin-fringe-color)
+             (face-background 'fringe))
+        ;; HACK: Fix glitchy fringe color.
+        (face-remap-add-relative 'fringe :background
+                                 spacemacs-centered-buffer-mode-fringe-color)
+        ;; HACK: Needed to get proper content width.
+        (run-with-idle-timer 0 nil 'spacemacs-centered-buffer-mode +1))
+    (when spacemacs-centered-buffer-mode
+      (set-window-buffer
+       (selected-window)
+       spacemacs--centered-buffer-mode-origin-buffer)
+      (rename-buffer (substring (buffer-name) 1 (1- (length (buffer-name)))))
+      (kill-buffer spacemacs--centered-buffer-mode-indirect-buffer)
+      ;; HACK: Now we call it for the original buffer.
+      (space-doc-mode -1))
+    (when (bound-and-true-p spacemacs--space-doc-origin-fringe-color)
+      ;; HACK: Removing or reseting doesn't work.
+      (face-remap-add-relative 'fringe :background
+                               spacemacs--space-doc-origin-fringe-color))))
 
 (defun spacemacs//space-doc-org-indent-mode (&optional flag)
   "Enable `org-indent-mode' if flag is non nil, disable it otherwise.
@@ -228,8 +257,9 @@ This functions is aimed to be used with `spacemacs-space-doc-modificators'."
             'spacemacs--space-doc-org-kbd-face-remap-cookie)
            (face-remap-add-relative 'org-kbd
                                     `(:box nil)))
-    (face-remap-remove-relative
-     spacemacs--space-doc-org-kbd-face-remap-cookie)))
+    (when (bound-and-true-p spacemacs--space-doc-org-kbd-face-remap-cookie)
+      (face-remap-remove-relative
+       spacemacs--space-doc-org-kbd-face-remap-cookie))))
 
 (defun spacemacs//space-doc-resize-inline-images (&optional enable)
   "Resize inline images.

--- a/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
+++ b/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
@@ -27,6 +27,7 @@
 ;;; Code:
 (require 'face-remap)
 (require 'org)
+(require 'centered-buffer-mode)
 
 (define-minor-mode space-doc-mode
   "Buffer local minor mode for Spacemacs documentation files.
@@ -77,7 +78,9 @@ This functions is aimed to be used with `spacemacs-space-doc-modificators'."
   (if flag
       (progn
         ;; HACK: Hide the original buffer from `spacemacs/previous-useful-buffer'.
-        (rename-buffer (format "*%s*" (buffer-name)))
+        (unless (and (string-prefix-p "*" (buffer-name))
+                     (string-suffix-p "*" (buffer-name)))
+          (rename-buffer (format "*%s*" (buffer-name))))
         (set (make-local-variable 'spacemacs--space-doc-origin-fringe-color)
              (face-background 'fringe))
         ;; HACK: Fix glitchy fringe color.


### PR DESCRIPTION
Integrate `centered-buffer-mode` and `space-doc-mode` + minor fixes and improvements. 
Looks like it works, but `spacemacs//space-doc-center-buffer-mode` is kinda funny..  For now.
