### PR TITLE
Add Dropbox user dir to load path only if it exists

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -10,6 +10,11 @@
 ;;; License: GPLv3
 (defun add-to-load-path (dir) (add-to-list 'load-path dir))
 
+(defun add-to-load-path-if-exists (dir)
+  "If DIR exists in the file system, add it to `load-path'."
+  (when (file-exists-p dir)
+      (add-to-load-path dir)))
+
 ;; paths
 (defvar spacemacs-start-directory
   user-emacs-directory
@@ -70,5 +75,6 @@
         ,(concat spacemacs-start-directory "core/")
         ,(concat spacemacs-start-directory "core/libs/")
         ,(concat spacemacs-start-directory "core/aprilfool/")
-        ,(concat user-dropbox-directory "emacs/")
         ))
+
+(add-to-load-path-if-exists (concat user-dropbox-directory "emacs/"))


### PR DESCRIPTION
Currently the item `~/Dropbox/emacs` is added to the `load-path`, even if that directory not exists in the filesystem. This may couse troubles. For example, the following code:
```emacs-lisp
(require 'url-about)
(url-probe-protocols)
```
triggers an error:
``` emacs-lisp
Debugger entered--Lisp error: (file-error "Opening directory" "no such file or directory" "/home/madand/Dropbox/emacs/")
  directory-files("/home/madand/Dropbox/emacs/" nil "^url-.*\\.el$")
  #[(d) "\301\302\303\304\305#\"\207" [d mapc #[(f) "\302\303\"\205