### PR TITLE
Run `diff-hl-magit-post-refresh` after Magit commit

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -34,6 +34,8 @@
     (progn
       (setq diff-hl-side 'right)
       (when (eq version-control-diff-tool 'diff-hl)
+        (when (configuration-layer/package-usedp 'magit)
+          (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh))
         (when version-control-global-margin
           (global-diff-hl-mode))
         (unless (display-graphic-p)


### PR DESCRIPTION
Otherwise `diff-hl-mode` still highlights uncommitted changes. See https://github.com/dgutov/diff-hl#magit