### PR TITLE
Extract evil-unimpaired as a local package

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
+++ b/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
@@ -1,0 +1,112 @@
+;;; evil-unimpaired.el --- Pairs of handy bracket mappings.
+
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; Keywords: evil, vim-unimpaired, spacemacs
+;; Version: 0.1
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; This is a port of vim-unimpaired https://github.com/tpope/vim-unimpaired
+;; `evil-unimpaired' provides pairs of handy bracket mappings to quickly navigate
+;; to previous/next thing and more.
+
+;;; Code:
+
+(require 'dash)
+(require 'f)
+
+(defun evil-unimpaired//find-relative-filename (offset)
+  (when buffer-file-name
+    (let* ((directory (f-dirname buffer-file-name))
+           (files (f--files directory (not (s-matches? "^\\.?#" it))))
+           (index (+ (-elem-index buffer-file-name files) offset))
+           (file (and (>= index 0) (nth index files))))
+      (when file
+        (f-expand file directory)))))
+
+(defun evil-unimpaired/previous-file ()
+  (interactive)
+  (-if-let (filename (evil-unimpaired//find-relative-filename -1))
+      (find-file filename)
+    (user-error "No previous file")))
+
+(defun evil-unimpaired/next-file ()
+  (interactive)
+  (-if-let (filename (evil-unimpaired//find-relative-filename 1))
+      (find-file filename)
+    (user-error "No next file")))
+
+(defun evil-unimpaired/paste-above ()
+  (interactive)
+  (evil-insert-newline-above)
+  (evil-paste-after 1))
+
+(defun evil-unimpaired/paste-below ()
+  (interactive)
+  (evil-insert-newline-below)
+  (evil-paste-after 1))
+
+(defun evil-unimpaired/insert-space-above ()
+  (interactive)
+  (save-excursion
+    (evil-insert-newline-above)))
+
+(defun evil-unimpaired/insert-space-below ()
+  (interactive)
+  (save-excursion
+    (evil-insert-newline-below)))
+
+(defun evil-unimpaired/next-frame ()
+  (interactive)
+  (raise-frame (next-frame)))
+
+(defun evil-unimpaired/previous-frame ()
+  (interactive)
+  (raise-frame (previous-frame)))
+
+;; from tpope's unimpaired
+(define-key evil-normal-state-map (kbd "[ SPC")
+  'evil-unimpaired/insert-space-above)
+(define-key evil-normal-state-map (kbd "] SPC")
+  'evil-unimpaired/insert-space-below)
+(define-key evil-normal-state-map (kbd "[ e") 'move-text-up)
+(define-key evil-normal-state-map (kbd "] e") 'move-text-down)
+(define-key evil-visual-state-map (kbd "[ e") ":move'<--1")
+(define-key evil-visual-state-map (kbd "] e") ":move'>+1")
+;; (define-key evil-visual-state-map (kbd "[ e") 'move-text-up)
+;; (define-key evil-visual-state-map (kbd "] e") 'move-text-down)
+(define-key evil-normal-state-map (kbd "[ b") 'spacemacs/previous-useful-buffer)
+(define-key evil-normal-state-map (kbd "] b") 'spacemacs/next-useful-buffer)
+(define-key evil-normal-state-map (kbd "[ f") 'evil-unimpaired/previous-file)
+(define-key evil-normal-state-map (kbd "] f") 'evil-unimpaired/next-file)
+(define-key evil-normal-state-map (kbd "] l") 'spacemacs/next-error)
+(define-key evil-normal-state-map (kbd "[ l") 'spacemacs/previous-error)
+(define-key evil-normal-state-map (kbd "] q") 'spacemacs/next-error)
+(define-key evil-normal-state-map (kbd "[ q") 'spacemacs/previous-error)
+(define-key evil-normal-state-map (kbd "[ t") 'evil-unimpaired/previous-frame)
+(define-key evil-normal-state-map (kbd "] t") 'evil-unimpaired/next-frame)
+(define-key evil-normal-state-map (kbd "[ w") 'previous-multiframe-window)
+(define-key evil-normal-state-map (kbd "] w") 'next-multiframe-window)
+;; select pasted text
+(define-key evil-normal-state-map (kbd "g p") (kbd "` [ v ` ]"))
+;; paste above or below with newline
+(define-key evil-normal-state-map (kbd "[ p") 'evil-unimpaired/paste-above)
+(define-key evil-normal-state-map (kbd "] p") 'evil-unimpaired/paste-below)
+
+(provide 'evil-unimpaired)
+;;; evil-unimpaired.el ends here.

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -248,84 +248,8 @@
       (spacemacs/set-leader-keys "hT" 'evil-tutor-start))))
 
 (defun spacemacs-evil/init-evil-unimpaired ()
-
-  (defun evil-unimpaired//find-relative-filename (offset)
-    (when buffer-file-name
-      (let* ((directory (f-dirname buffer-file-name))
-             (files (f--files directory (not (s-matches? "^\\.?#" it))))
-             (index (+ (-elem-index buffer-file-name files) offset))
-             (file (and (>= index 0) (nth index files))))
-        (when file
-          (f-expand file directory)))))
-
-  (defun evil-unimpaired/previous-file ()
-    (interactive)
-    (-if-let (filename (evil-unimpaired//find-relative-filename -1))
-        (find-file filename)
-      (user-error "No previous file")))
-
-  (defun evil-unimpaired/next-file ()
-    (interactive)
-    (-if-let (filename (evil-unimpaired//find-relative-filename 1))
-        (find-file filename)
-      (user-error "No next file")))
-
-  (defun evil-unimpaired/paste-above ()
-    (interactive)
-    (evil-insert-newline-above)
-    (evil-paste-after 1))
-
-  (defun evil-unimpaired/paste-below ()
-    (interactive)
-    (evil-insert-newline-below)
-    (evil-paste-after 1))
-
-  (defun evil-unimpaired/insert-space-above ()
-    (interactive)
-    (save-excursion
-      (evil-insert-newline-above)))
-
-  (defun evil-unimpaired/insert-space-below ()
-    (interactive)
-    (save-excursion
-      (evil-insert-newline-below)))
-
-  (defun evil-unimpaired/next-frame ()
-    (interactive)
-    (raise-frame (next-frame)))
-
-  (defun evil-unimpaired/previous-frame ()
-    (interactive)
-    (raise-frame (previous-frame)))
-
-  ;; from tpope's unimpaired
-  (define-key evil-normal-state-map (kbd "[ SPC")
-    'evil-unimpaired/insert-space-above)
-  (define-key evil-normal-state-map (kbd "] SPC")
-    'evil-unimpaired/insert-space-below)
-  (define-key evil-normal-state-map (kbd "[ e") 'move-text-up)
-  (define-key evil-normal-state-map (kbd "] e") 'move-text-down)
-  (define-key evil-visual-state-map (kbd "[ e") ":move'<--1")
-  (define-key evil-visual-state-map (kbd "] e") ":move'>+1")
-  ;; (define-key evil-visual-state-map (kbd "[ e") 'move-text-up)
-  ;; (define-key evil-visual-state-map (kbd "] e") 'move-text-down)
-  (define-key evil-normal-state-map (kbd "[ b") 'spacemacs/previous-useful-buffer)
-  (define-key evil-normal-state-map (kbd "] b") 'spacemacs/next-useful-buffer)
-  (define-key evil-normal-state-map (kbd "[ f") 'evil-unimpaired/previous-file)
-  (define-key evil-normal-state-map (kbd "] f") 'evil-unimpaired/next-file)
-  (define-key evil-normal-state-map (kbd "] l") 'spacemacs/next-error)
-  (define-key evil-normal-state-map (kbd "[ l") 'spacemacs/previous-error)
-  (define-key evil-normal-state-map (kbd "] q") 'spacemacs/next-error)
-  (define-key evil-normal-state-map (kbd "[ q") 'spacemacs/previous-error)
-  (define-key evil-normal-state-map (kbd "[ t") 'evil-unimpaired/previous-frame)
-  (define-key evil-normal-state-map (kbd "] t") 'evil-unimpaired/next-frame)
-  (define-key evil-normal-state-map (kbd "[ w") 'previous-multiframe-window)
-  (define-key evil-normal-state-map (kbd "] w") 'next-multiframe-window)
-  ;; select pasted text
-  (define-key evil-normal-state-map (kbd "g p") (kbd "` [ v ` ]"))
-  ;; paste above or below with newline
-  (define-key evil-normal-state-map (kbd "[ p") 'evil-unimpaired/paste-above)
-  (define-key evil-normal-state-map (kbd "] p") 'evil-unimpaired/paste-below))
+  ;; No laziness here, unimpaired bindings should be available right away.
+  (use-package evil-unimpaired))
 
 (defun spacemacs-evil/init-evil-visual-mark-mode ()
   (use-package evil-visual-mark-mode


### PR DESCRIPTION
In the `packages.el` of the `spacemacs-evil` layer, `evil-unimpaired` is already defined as local:

``` emacs-lisp
(evil-unimpaired :location local)
```

The PR makes that statement actually true :)

Also fixes #6437 