### PR TITLE
fix call to show-all

### DIFF
--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -126,6 +126,9 @@
        ;; emacs is evil and decrees that vertical shall henceforth be horizontal
        ediff-split-window-function 'split-window-horizontally
        ediff-merge-split-window-function 'split-window-horizontally)
+      ;; show org ediffs unfolded
+      (require 'outline)
+      (add-hook 'ediff-prepare-buffer-hook #'show-all)
       ;; restore window layout when done
       (add-hook 'ediff-quit-hook #'winner-undo))))
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -13,7 +13,6 @@
   '(
     company
     company-emoji
-    ediff
     emoji-cheat-sheet-plus
     (evil-org :location local)
     evil-surround
@@ -43,10 +42,6 @@
 
 (defun org/post-init-company-emoji ()
   (push 'company-emoji company-backends-org-mode))
-
-(defun org/post-init-ediff ()
-  ;; show org ediffs unfolded
-  (add-hook 'ediff-prepare-buffer-hook #'outline-show-all))
 
 (defun org/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'org-mode-hook 'spacemacs/delay-emoji-cheat-sheet-hook))


### PR DESCRIPTION
As @syohex pointed out, `outline-show-all` was introduced in Emacs 25.1. Shouldn't we use `show-all` instead which is aliased to `outline-show-all` in Emacs 25.1 (not by Spacemacs though, but in `outline.el`).

Also, am I missing relation between `org` and `outline`? I mean, why `(with-eval-after-load 'org ...)`? Because of this I moved code back to `spacemacs-base` layer.

Fixes #6500 