### PR TITLE
space-doc/centered-buffer improvements.

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -501,13 +501,12 @@ You can modify the list of visual enhancements applied by the =space-doc-mode=:
         org-indent-mode
         view-mode
         hide-line-numbers
-        emphasis-overlays
-        meta-tags-overlays
+        alternative-emphasis
+        alternative-tags-look
         link-protocol
         org-block-line-face-remap
         org-kbd-face-remap
-        resize-inline-images
-        advice-org-do-emphasis-faces))
+        resize-inline-images))
 #+END_SRC
 It's the default value of the variable with all enhancements.
 

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -497,21 +497,19 @@ arguments of the =ag= program.
 You can modify the list of visual enhancements applied by the =space-doc-mode=:
 #+BEGIN_SRC emacs-lisp
 (setq spacemacs-space-doc-modificators
-      '(spacemacs//space-doc-center-buffer-mode
-        spacemacs//space-doc-org-indent-mode
-        spacemacs//space-doc-view-mode
-        spacemacs//space-doc-hide-line-numbers
-        spacemacs//space-doc-emphasis-overlays
-        spacemacs//space-doc-meta-tags-overlays
-        spacemacs//space-doc-link-protocol
-        spacemacs//space-doc-org-block-line-face-remap
-        spacemacs//space-doc-org-kbd-face-remap
-        spacemacs//space-doc-resize-inline-images
-        spacemacs//space-doc-advice-org-do-emphasis-faces))
+      '(center-buffer-mode
+        org-indent-mode
+        view-mode
+        hide-line-numbers
+        emphasis-overlays
+        meta-tags-overlays
+        link-protocol
+        org-block-line-face-remap
+        org-kbd-face-remap
+        resize-inline-images
+        advice-org-do-emphasis-faces))
 #+END_SRC
 It's the default value of the variable with all enhancements.
-Each function in the list represents some modification.
-Some of them might be order dependant so don't shuffle the list!
 
 ** Remap paste key to be able to paste copied text multiple times
 In vim and evil, pasting over a text would cause it to be copied, hence making it impossible to paste

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -512,7 +512,6 @@ You can modify the list of visual enhancements applied by the =space-doc-mode=:
 It's the default value of the variable with all enhancements.
 Each function in the list represents some modification.
 Some of them might be order dependant so don't shuffle the list!
-You can make a modification deferred by moving it to =spacemacs-space-doc-modificators-deferred= list.
 
 ** Remap paste key to be able to paste copied text multiple times
 In vim and evil, pasting over a text would cause it to be copied, hence making it impossible to paste

--- a/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
+++ b/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
@@ -120,12 +120,12 @@ Assume to be called interactively when INTERACT has non nil value."
                 (face-remap-add-relative 'fringe :background
                                          spacemacs-centered-buffer-mode-fringe-color)
                 (set-window-buffer window indirect-buffer)
-                (advice-add 'spacemacs/previous-useful-buffer
+                (advice-add 'previous-buffer
                             :before
-                            #'spacemacs//centered-buffer-mode-prev-next-useful-buffer-advice)
-                (advice-add 'spacemacs/next-useful-buffer
+                            #'spacemacs//centered-buffer-mode-prev-next-buffer-advice)
+                (advice-add 'next-buffer
                             :before
-                            #'spacemacs//centered-buffer-mode-prev-next-useful-buffer-advice)
+                            #'spacemacs//centered-buffer-mode-prev-next-buffer-advice)
                 (add-hook 'buffer-list-update-hook
                           'spacemacs//centered-buffer-buffer-list-update-fringes)
                 (add-hook 'window-configuration-change-hook
@@ -138,16 +138,15 @@ Assume to be called interactively when INTERACT has non nil value."
             (when interact
               (message "Not enough space to center the buffer!"))))))))
 
-(defun spacemacs//centered-buffer-mode-prev-next-useful-buffer-advice ()
-  "Disables `spacemacs-centered-buffer-mode' when `spacemacs/previous-useful-buffer'
-or `spacemacs/next-useful-buffer' is called. It's better than flagging the original
-buffer as 'unuseful'."
+(defun spacemacs//centered-buffer-mode-prev-next-buffer-advice ()
+  "Disables `spacemacs-centered-buffer-mode' when `spacemacs/previous-buffer'
+or `spacemacs/next-buffer' is called."
   (when (bound-and-true-p spacemacs-centered-buffer-mode)
     (spacemacs-centered-buffer-mode -1)))
 
 (defun spacemacs//centered-buffer-mode-disable-branch ()
   "Used in `spacemacs-centered-buffer-mode'."
-  ;; Don't run if the mode is disabled.
+  ;; Don't run if the mode is disabled(we are not in the indirect buffer).
   (when spacemacs--centered-buffer-mode-origin-buffer
     (let* ((window (selected-window))
            (origin-buffer spacemacs--centered-buffer-mode-origin-buffer)
@@ -223,10 +222,10 @@ minimize the performance hit when the mode isn't used."
               (setq spacemacs--centered-buffer-mode-indirect-buffers nil)))))))
   ;; Remove hooks and advices when they are not needed anymore.
   (unless spacemacs--centered-buffer-mode-indirect-buffers
-    (advice-remove 'spacemacs/previous-useful-buffer
-                   #'spacemacs//centered-buffer-mode-prev-next-useful-buffer-advice)
-    (advice-remove 'spacemacs/next-useful-buffer
-                   #'spacemacs//centered-buffer-mode-prev-next-useful-buffer-advice)
+    (advice-remove 'previous-buffer
+                   #'spacemacs//centered-buffer-mode-prev-next-buffer-advice)
+    (advice-remove 'next-buffer
+                   #'spacemacs//centered-buffer-mode-prev-next-buffer-advice)
     (remove-hook 'buffer-list-update-hook
                  'spacemacs//centered-buffer-buffer-list-update-fringes)
     (remove-hook 'window-configuration-change-hook


### PR DESCRIPTION
Slightly reduced amount of hacks and moved them in the place where there is less chance that someone notice them. Also made dedicated window noop for `centered-buffer-mode` as @syl20bnr  hinted.