### PR TITLE
Update ensime buffer name

### DIFF
--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -39,7 +39,7 @@
   (let ((default-directory (file-name-directory file)))
     (-when-let (project-name (projectile-project-p))
       (--first (-when-let (bufname (buffer-name it))
-                 (and (s-contains? "inferior-ensime-server" bufname)
+                 (and (s-contains? "ENSIME-backend" bufname)
                       (s-contains? (file-name-nondirectory project-name) bufname)))
                (buffer-list)))))
 


### PR DESCRIPTION
The name of the buffer for Ensime changed in the latest releases so the spacemacs integration layer is trying to open a new instance for every file you open. This should fix it.
