### PR TITLE
Suppress company-complete call if tooltip is visible in scala-mode

### DIFF
--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -90,7 +90,8 @@ point to the position of the join."
                     (buffer-substring (line-beginning-position) (point)))
     (delete-horizontal-space t))
   (insert ".")
-  (company-complete))
+  (when (not (company-tooltip-visible-p))
+    company-complete))
 
 ;;; Flyspell
 


### PR DESCRIPTION
Currently, the function `scala/completing-dot` causes `company-mode` to be called whenever `.`
is inserted, even if the company tooltip is visible.

This causes the currently displayed candidate to be inserted and doesn't seem to be the required
behavior.

This change suppresses the call to `company-mode` if the tooltip is visible.