### PR TITLE
Fix docs link to themes-megapack README.org

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -456,7 +456,7 @@ guidelines first in [[file:../CONTRIBUTING.org][CONTRIBUTING]].
 
 ** Example: Themes Megapack example
 This is a simple configuration layer listing a bunch of themes which you can
-find [[../layers/themes-megapack][here]].
+find [[../layers/themes-megapack/README.org][here]].
 
 To install it, just add =themes-megapack= to your =~/.spacemacs= like so:
 


### PR DESCRIPTION
This should fix a broken link on the website

http://spacemacs.org/doc/DOCUMENTATION.html#orgheadline26

And in the in-editor documentation (in OSX, clicking this link opens up the folder in Finder)