### PR TITLE
Fix dot completion bug in scala mode

### DIFF
--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -89,6 +89,7 @@ point to the position of the join."
   (when (s-matches? (rx (+ (not space)))
                     (buffer-substring (line-beginning-position) (point)))
     (delete-horizontal-space t))
+  (company-abort)
   (insert ".")
   (company-complete))
 


### PR DESCRIPTION
This is a fix to resolve an issue in scala-mode that manifests itself when trying to insert a period while a completion is active. 

If a company completion is active then attempting to insert a dot will result in inserting the current completion (with a duplicated first letter), and does not actually insert a period.

The way it should behave is that the period should actually be inserted and if any completions are available then they should be listed. The easiest way to visualize this is through the following before and after screencasts:

Before (notice each completion with the duplicated first char, this is the result of pressing '.'):

![Before](http://drop.bryangilbert.com/YoKY.gif)

After:

![After](http://drop.bryangilbert.com/JnVa.gif)

Notice the second GIF shows the period being inserted and completions actually being shown. This was being caused by some weirdness as a result of ```scala/completing-dot``` being called while a company completion is active. Simply calling ```company-abort``` before attempting to either insert the dot or perform the completion solved the problem.
