### PR TITLE
Fix typo in docstring

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/funcs.el
@@ -91,7 +91,7 @@
   (setq scroll-conservatively 101))
 
 (defun spacemacs/disable-smooth-scrolling ()
-  "Enable smooth scrolling."
+  "Disable smooth scrolling."
   (interactive)
   (setq scroll-conservatively 0))
 


### PR DESCRIPTION
Small typo in the docstring for `spacemacs/disable-smooth-scrolling`.