### PR TITLE
Allow to install local package using quelpa

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -477,7 +477,7 @@ layer directory."
   "Make `cfgl-layer' objects from the passed layer SYMBOLS."
   (delq nil (mapcar 'configuration-layer/make-layer symbols)))
 
-(defun configuration-layer/make-package (pkg &optional obj togglep)
+(defun configuration-layer/make-package (pkg &optional obj togglep layer)
   "Return a `cfgl-package' object based on PKG.
 If OBJ is non nil then copy PKG properties into OBJ, otherwise create
 a new object.
@@ -493,6 +493,16 @@ If TOGGLEP is nil then `:toggle' parameter is ignored."
          (protected (when (listp pkg) (plist-get (cdr pkg) :protected)))
          (copyp (not (null obj)))
          (obj (if obj obj (cfgl-package name-str :name name-sym))))
+    (when (and (listp location)
+               (eq (car location) 'recipe)
+               (eq (plist-get (cdr location) :fetcher) 'local))
+      (setq location
+            `(recipe
+              :fetcher url
+              :url ,(format
+                     "file://%s%s/%s.el"
+                     (configuration-layer/get-layer-local-dir (oref layer :name))
+                     name-str name-str))))
     (when location (oset obj :location location))
     (when min-version (oset obj :min-version (version-to-list min-version)))
     (when step (oset obj :step step))
@@ -716,8 +726,8 @@ no-op."
                (obj (object-assoc pkg-name
                                   :name configuration-layer--packages)))
           (if obj
-              (setq obj (configuration-layer/make-package pkg obj ownerp))
-            (setq obj (configuration-layer/make-package pkg nil ownerp))
+              (setq obj (configuration-layer/make-package pkg obj ownerp layer))
+            (setq obj (configuration-layer/make-package pkg nil ownerp layer))
             (push obj configuration-layer--packages))
           (when ownerp
             ;; last owner wins over the previous one,
@@ -1869,4 +1879,3 @@ FILE-TO-LOAD is an explicit file to load after the installation."
 (provide 'core-configuration-layer)
 
 ;;; core-configuration-layer.el ends here
-

--- a/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
+++ b/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
@@ -3,6 +3,7 @@
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; Keywords: evil, vim-unimpaired, spacemacs
 ;; Version: 0.1
+;; Package-Requires: ((dash "2.12.0") (f "0.18.0"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -30,7 +30,7 @@
         ;; https://github.com/7696122/evil-terminal-cursor-changer/issues/8
         ;; evil-terminal-cursor-changer
         evil-tutor
-        (evil-unimpaired :location local)
+        (evil-unimpaired :location (recipe :fetcher local))
         evil-visual-mark-mode
         (hs-minor-mode :location built-in)
         linum-relative


### PR DESCRIPTION
This PR adds ability to mark local package to be installed using `quelpa`.

Following #6523 (initial issue), #6559 (proposed self-claimed ugly workaround) and discussion around https://github.com/d12frosted/spacemacs/commit/664946f1e6403f7fc7e77397707339c9bae7bfa3#commitcomment-18211735. 

This might be not the cleanest way to achieve the goal, but still lets us to install local packages differently.

```
;; this will be installed by `load-path' modification
(package-name :location local)

;; this will be installed using quelpa
(package-name :location (recipe :fetcher local))
```

Any tips and ideas are welcome! 

