### PR TITLE
Allow to pin packages to specific archive

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -328,6 +328,9 @@ as follows:
                              :fetcher github
                              :repo "some/repo"))
 
+    ;; A pinned package
+    (some-package :archive melpa-stable)
+
     ;; An excluded package
     (some-package :excluded t)
     ))
@@ -337,6 +340,8 @@ The =:location= attribute specifies where the package may be found. Spacemacs
 currently supports packages on ELPA compliant repositories, local packages and
 MELPA recipes (through the Quelpa package). See the [[https://github.com/milkypostman/melpa#recipe-format][MELPA documentation]] for more
 information about recipes.
+
+By using =:archive= attribute one can pin specific package to specific archive.
 
 Packages may be /excluded/ by setting the =:excluded= property to true. This
 will prevent the package from being installed even if it is used by another


### PR DESCRIPTION
Somewhat fixes or moves towards fixing #6531, #2057 and #3542.

Also #4165 is somewhat related.

Basically thanks to @tonylotts I realised that pinning packages to stable MELPA can be easily automated.

This leverages described problem. But doesn't solve it fully.
# Hot it works

This PR does following.
1. Adds MELPA stable to list of package archives. This has minor drawback - longer update. But this is very minor.
2. Exposes function `configuration-layer/pin-package` which can be used to pin specific package to one of available archives. One can use it manually, but there is a better choice.
3. Adds custom handling for packages with `:archive archive-name`. To be accurate - it just pins that package.
# Usage

``` elisp
(defun dotspacemacs/layers ()
  "Configuration Layers declaration."
  (setq-default
   ;; ...
   dotspacemacs-additional-packages '(;; ...
                                      (ensime :archive melpa-stable))
   ;; ...
   )
```

This will force Spacemacs to download `ensime` from MELPA stable. 
