### PR TITLE
Generate mmm-modes automatically based on a list

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -63,13 +63,14 @@ npm install -g vmd
 #+END_SRC
 
 ** Automatic MMM-Mode Generation
-To generate MMM-Modes for languages where the language name directly relates to
-the Emacs mode name, set the value of the variable =markdown-mmm-auto-modes= to
-a list of the languages:
+To generate MMM-Modes for languages set the value of the variable
+=markdown-mmm-auto-modes= to a list of the languages. For languages where the
+mode name directly relates to the language name, use a string. Otherwise, use a
+list of `("language" "mode")`:
 
 #+BEGIN_SRC emacs-lisp
   dotspacemacs-configuration-layers '(
-    (markdown :variables markdown-mmm-auto-modes '("c" "c++" "python" "scala"))
+    (markdown :variables markdown-mmm-auto-modes '("c" "c++" "python" "scala" ("elisp" "emacs-lisp"))
 #+END_SRC
 
 * Usage

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -9,6 +9,7 @@
  - [[#install][Install]]
  - [[#configuration][Configuration]]
    - [[#live-preview][Live preview]]
+   - [[#automatic-mmm-mode-generation][Automatic MMM-Mode Generation]]
  - [[#usage][Usage]]
    - [[#generate-a-toc][Generate a TOC]]
  - [[#key-bindings][Key bindings]]
@@ -59,6 +60,16 @@ And install the executable with:
 
 #+BEGIN_SRC shell
 npm install -g vmd
+#+END_SRC
+
+** Automatic MMM-Mode Generation
+To generate MMM-Modes for languages where the language name directly relates to
+the Emacs mode name, set the value of the variable =markdown-mmm-auto-modes= to
+a list of the languages:
+
+#+BEGIN_SRC emacs-lisp
+  dotspacemacs-configuration-layers '(
+    (markdown :variables markdown-mmm-auto-modes '("c" "c++" "python" "scala"))
 #+END_SRC
 
 * Usage

--- a/layers/+lang/markdown/config.el
+++ b/layers/+lang/markdown/config.el
@@ -15,3 +15,8 @@
 
 (defvar markdown-live-preview-engine 'eww
   "Possibe values are `eww' (built-in browser) or `vmd' (installed with `npm').")
+
+(defvar markdown-mmm-auto-modes
+  '("c" "c++" "css" "java" "javascript" "python" "ruby" "rust" "scala")
+  "Automatically add mmm class for languages where its name and mode name are
+directly related")

--- a/layers/+lang/markdown/config.el
+++ b/layers/+lang/markdown/config.el
@@ -17,6 +17,5 @@
   "Possibe values are `eww' (built-in browser) or `vmd' (installed with `npm').")
 
 (defvar markdown-mmm-auto-modes
-  '("c" "c++" "css" "java" "javascript" "python" "ruby" "rust" "scala")
-  "Automatically add mmm class for languages where its name and mode name are
-directly related")
+  '("c" "c++" "css" "java" "javascript" "python" "ruby" "rust" "scala" ("html" "web") ("elisp" "emacs-lisp") ("ess" "R"))
+  "List of language names or lists of language and mode names for which to generate mmm classes.")

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -206,6 +206,11 @@ Will work on both org-mode and any mode that accepts plain html."
                           :face mmm-declaration-submode-face
                           :front "^```rust[\n\r]+"
                           :back "^```$")))
+      (mmm-add-classes '((markdown-scala
+                          :submode scala-mode
+                          :face mmm-declaration-submode-face
+                          :front "^```scala[\n\r]+"
+                          :back "^```$")))
       (setq mmm-global-mode t)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-python)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-java)
@@ -216,7 +221,8 @@ Will work on both org-mode and any mode that accepts plain html."
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-html)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-javascript)
       (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-ess)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-rust))))
+      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-rust)
+      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-scala))))
 
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -42,6 +42,17 @@
 (defun markdown/post-init-smartparens ()
   (add-hook 'markdown-mode-hook 'smartparens-mode))
 
+(defun markdown/mmm-auto-class (lang &optional submode)
+  (let ((class (intern (concat "markdown-" lang)))
+        (submode (or submode (intern (concat lang "-mode"))))
+        (front (concat "^```" lang "[\n\r]+"))
+        (back "^```$"))
+    (mmm-add-classes (list (list class
+                               :submode submode
+                               :front front
+                               :back back)))
+    (mmm-add-mode-ext-class 'markdown-mode nil class)))
+
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
     :mode ("\\.m[k]d" . markdown-mode)
@@ -156,73 +167,16 @@ Will work on both org-mode and any mode that accepts plain html."
       "cs"   'mmm-parse-buffer)
     :config
     (progn
-      (mmm-add-classes '((markdown-python
-                          :submode python-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```python[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-html
-                          :submode web-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```html[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-java
-                          :submode java-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```java[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-ruby
-                          :submode ruby-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```ruby[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-c
-                          :submode c-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```c[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-c++
-                          :submode c++-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```c\+\+[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-elisp
-                          :submode emacs-lisp-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```elisp[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-javascript
-                          :submode javascript-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```javascript[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-ess
-                          :submode R-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```{?r.*}?[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-rust
-                          :submode rust-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```rust[\n\r]+"
-                          :back "^```$")))
-      (mmm-add-classes '((markdown-scala
-                          :submode scala-mode
-                          :face mmm-declaration-submode-face
-                          :front "^```scala[\n\r]+"
-                          :back "^```$")))
-      (setq mmm-global-mode t)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-python)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-java)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-ruby)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-c)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-c++)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-elisp)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-html)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-javascript)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-ess)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-rust)
-      (mmm-add-mode-ext-class 'markdown-mode nil 'markdown-scala))))
+      ;; Automatically add mmm class for languages where its name and mode
+      ;; name are directly related
+      (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)
+
+      ;; Otherwise define these manually
+      (markdown/mmm-auto-class "html" 'web-mode)
+      (markdown/mmm-auto-class "elisp" 'emacs-lisp-mode)
+      (markdown/mmm-auto-class "ess" 'R-mode)
+
+      (setq mmm-global-mode t))))
 
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -42,6 +42,7 @@
 (defun markdown/post-init-smartparens ()
   (add-hook 'markdown-mode-hook 'smartparens-mode))
 
+;; from Jason Blevins http://jblevins.org/log/mmm
 (defun markdown/mmm-auto-class (lang &optional submode)
   (let ((class (intern (concat "markdown-" lang)))
         (submode (or submode (intern (concat lang "-mode"))))

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -43,11 +43,13 @@
   (add-hook 'markdown-mode-hook 'smartparens-mode))
 
 ;; from Jason Blevins http://jblevins.org/log/mmm
-(defun markdown/mmm-auto-class (lang &optional submode)
-  (let ((class (intern (concat "markdown-" lang)))
-        (submode (or submode (intern (concat lang "-mode"))))
-        (front (concat "^```" lang "[\n\r]+"))
-        (back "^```$"))
+(defun markdown/mmm-auto-class (lang)
+  (let* ((l (if (listp lang) (car lang) lang))
+         (s (if (listp lang) (cadr lang) lang))
+         (class (intern (concat "markdown-" l)))
+         (submode (intern (concat s "-mode")))
+         (front (concat "^```" l "[\n\r]+"))
+         (back "^```$"))
     (mmm-add-classes (list (list class
                                :submode submode
                                :front front
@@ -168,14 +170,8 @@ Will work on both org-mode and any mode that accepts plain html."
       "cs"   'mmm-parse-buffer)
     :config
     (progn
-      ;; Automatically add mmm class for languages where its name and mode
-      ;; name are directly related
+      ;; Automatically add mmm class for languages
       (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)
-
-      ;; Otherwise define these manually
-      (markdown/mmm-auto-class "html" 'web-mode)
-      (markdown/mmm-auto-class "elisp" 'emacs-lisp-mode)
-      (markdown/mmm-auto-class "ess" 'R-mode)
 
       (setq mmm-global-mode t))))
 


### PR DESCRIPTION
This "fixes"  #6571 

**Question:**
Should we really add all possible combinations of languages, or let the user (Spacemacsian) take care of that themselves?

If we keep adding definitions to the core, we'll end up with a terribly long list...
