### PR TITLE
ivy: remove extra projectile-switch-project binding

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -185,7 +185,6 @@
 (defun ivy/post-init-projectile ()
   (setq projectile-completion-system 'ivy)
   (spacemacs/set-leader-keys
-    "pp"  'projectile-switch-project
     "pv"  'projectile-vc))
 
 (defun ivy/init-smex ()


### PR DESCRIPTION
We're already defining `SPC p p` to `counsel-projectile` [here](https://github.com/syl20bnr/spacemacs/blob/5c371f0843ccdbeee3d7d1b7405f201dd43463bc/layers/+completion/ivy/packages.el#L116). This change removes the extra binding since `counsel-projectile` has much more options. 

Fix #6577 