### PR TITLE
Revert #6576; TL;DR: We no longer need to do this.

### DIFF
--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -47,7 +47,7 @@ In a =magit status= buffer (~SPC g s~):
 | Key Binding | Description                                                 |
 |-------------+-------------------------------------------------------------|
 | ~# c~       | create a pull request                                       |
-| ~# r~       | get a list of (or reload) all PRs in the current repository |
+| ~# g~      | get a list of (or reload) all PRs in the current repository |
 | ~# f~       | fetch the commits associated with the current PR at point   |
 | ~# b~       | create a branch for the current PR at point                 |
 | ~# m~       | merge the PR with current branch at point                   |


### PR DESCRIPTION
This change reverts #6576  -- @justbur no longer changes the keybindings for magit-gh-pulls. 

See https://github.com/justbur/evil-magit/issues/24 and https://github.com/justbur/evil-magit/commit/4a375ea3045671a0bdef7cdaed28efc84c9681a5