### PR TITLE
Update command to change powerline separator

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1171,7 +1171,8 @@ file:
 (defun dotspacemacs/user-config ()
   "This is were you can ultimately override default Spacemacs configuration.
 This function is called at the very end of Spacemacs initialization."
-  (setq powerline-default-separator 'arrow))
+  (setq powerline-default-separator 'arrow)
+  (spaceline-compile))
 #+END_SRC
 
 To save you the time to try all the possible separators provided by the


### PR DESCRIPTION
I was having issues changing the default powerline separator -- `(setq powerline-default-separator ‘arrow)` was setting the value as expected, but I could not see any change in the powerline separators displayed. It turns out that invoking `(spaceline-compile)` is now required for the change to take visible effect.

ref: #6052,
https://github.com/TheBB/spaceline#compiling-a-mode-line