### PR TITLE
[scala] Improve documentation for scalastyle using flycheck

### DIFF
--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -35,7 +35,7 @@
   (add-hook 'php-mode-hook 'eldoc-mode))
 
 (defun php/post-init-flycheck ()
-  (add-hook 'php-mode-hook 'flycheck-mode))
+  (spacemacs/add-flycheck-hook 'php-mode))
 
 (defun php/post-init-ggtags ()
   (add-hook 'php-mode-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -65,16 +65,21 @@ ensime= once per project. Any Scala files you create or visit within the project
 will automatically use ENSIME for the remainder of your editing session.
 
 * Scalastyle
-[[http://flycheck.readthedocs.org/en/latest/guide/languages.html#el.flycheck-checker.scala-scalastyle][Scalastyle]] provides style-checking and linting. The Emacs functionality is
+[[http://www.scalastyle.org/][Scalastyle]] provides style-checking and linting. The Emacs functionality is
 provided by Flycheck.
 
 To use scalastyle,
 
-1. Download the [[https://oss.sonatype.org/content/repositories/releases/org/scalastyle/scalastyle_2.11/0.6.0/][scalastyle jar]] and put it somewhere sensible
-2. Customise the =flycheck-scalastyle-jar= variable and set it to the path of
-   the jar.
+1. Download the [[http://www.scalastyle.org/#download][scalastyle jar]] and put it somewhere sensible
+   - If you are a brew user in OSX you can do: =brew install scalastyle=
+2. Customise the =flycheck-scalastyle-jar= and =flycheck-scalastylerc= variables in your =dotspacemacs/user-config=
+   i.e.:
+#+BEGIN_SRC
+   (setq flycheck-scalastyle-jar "/usr/local/Cellar/scalastyle/0.8.0/libexec/scalastyle_2.11-0.8.0-batch.jar")
+   (setq flycheck-scalastylerc "/usr/local/etc/scalastyle_config.xml")
+#+END_SRC
 
-See the [[http://flycheck.readthedocs.org/en/latest/guide/languages.html#el.flycheck-checker.scala-scalastyle][flycheck documentation]] for up-to-date configuration instructions.
+See the [[http://www.flycheck.org/en/latest/languages.html?highlight=scala#syntax-checker-scala-scalastyle][flycheck documentation]] and [[http://www.scalastyle.org/configuration.html][scalastyle configuration]] for up-to-date configuration instructions.
 
 ** Use Java doc-style
 To enable =java-doc-style=, set the variable =scala-indent:use-javadoc-style= to =t=

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -12,6 +12,7 @@
 (setq scala-packages
   '(
     ensime
+    flycheck
     ggtags
     helm-gtags
     noflet
@@ -192,6 +193,9 @@
       ;; handle older Ensime versions gracefully.
       (when (configuration-layer/package-usedp 'expand-region)
         (require 'ensime-expand-region nil 'noerror)))))
+
+(defun scala/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'scala-mode))
 
 (defun scala/init-noflet ()
   (use-package noflet))


### PR DESCRIPTION
Now scalastyle warnings are shown up by flycheck
![image](https://cloud.githubusercontent.com/assets/12563308/16893033/19075506-4ade-11e6-8cc9-f43616983c01.png)
