### PR TITLE
add open config action to layer spacemacs help

### DIFF
--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -195,6 +195,8 @@
                 . helm-spacemacs-help//layer-action-open-readme)
                ("Open packages.el"
                 . helm-spacemacs-help//layer-action-open-packages)
+               ("Open config.el"
+                . helm-spacemacs-help//layer-action-open-config)
                ("Install Layer"
                 . helm-spacemacs-help//layer-action-install-layer)
                ("Open README.org (for editing)"
@@ -307,7 +309,10 @@
         (if edit
             (find-file (concat path file))
           (spacemacs/view-org-file (concat path file) "^" 'all))
-      (find-file (concat path file)))))
+      (let ((filepath (concat path file)))
+        (if (file-exists-p filepath)
+            (find-file filepath)
+          (message "%s does not have %s" candidate file))))))
 
 (defun helm-spacemacs-help//layer-action-open-readme (candidate)
   "Open the `README.org' file of the passed CANDIDATE for reading."
@@ -325,6 +330,10 @@
 (defun helm-spacemacs-help//layer-action-open-packages (candidate)
   "Open the `packages.el' file of the passed CANDIDATE."
   (helm-spacemacs-help//layer-action-open-file "packages.el" candidate))
+
+(defun helm-spacemacs-help//layer-action-open-config (candidate)
+  "Open the `config.el' file of the passed CANDIDATE."
+  (helm-spacemacs-help//layer-action-open-file "config.el" candidate))
 
 (defun helm-spacemacs-help//package-action-decribe (candidate)
   "Describe the passed package using Spacemacs describe function."

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -146,7 +146,10 @@
         (if edit
             (find-file (concat path file))
           (spacemacs/view-org-file (concat path file) "^" 'all))
-      (find-file (concat path file)))))
+      (let ((filepath (concat path file)))
+        (if (file-exists-p filepath)
+            (find-file filepath)
+          (message "%s does not have %s" candidate file))))))
 
 (defun ivy-spacemacs-help//layer-action-open-readme (candidate)
   "Open the `README.org' file of the passed CANDIDATE for reading."
@@ -175,6 +178,10 @@
   "Open the `README.org' file of the passed CANDIDATE for editing."
   (ivy-spacemacs-help//layer-action-open-file "README.org" candidate t))
 
+(defun ivy-spacemacs-help//layer-action-open-config (candidate)
+  "Open the `config.el' file of the passed CANDIDATE."
+  (ivy-spacemacs-help//layer-action-open-file "config.el" candidate))
+
 (defun ivy-spacemacs-help//layer-action-open-packages (candidate)
   "Open the `packages.el' file of the passed CANDIDATE."
   (ivy-spacemacs-help//layer-action-open-file "packages.el" candidate))
@@ -193,6 +200,7 @@
  '(("a" ivy-spacemacs-help//layer-action-add-layer "add layer")
    ("d" ivy-spacemacs-help//layer-action-open-dired "open dired at layer location")
    ("e" ivy-spacemacs-help//layer-action-open-readme-edit "open readme for editing")
+   ("c" ivy-spacemacs-help//layer-action-open-config "open config.el")
    ("p" ivy-spacemacs-help//layer-action-open-packages "open packages.el")
    ("r" ivy-spacemacs-help//layer-action-open-readme "open readme")))
 
@@ -266,6 +274,10 @@
   (dired
    (ivy-spacemacs-help//layer-action-get-directory (cadr args))))
 
+(defun ivy-spacemacs-help//help-action-open-config (args)
+  "Open the `packages.el' file of the passed CANDIDATE."
+  (ivy-spacemacs-help//layer-action-open-file "config.el" (cadr args)))
+
 (defun ivy-spacemacs-help//help-action-open-packages (args)
   "Open the `packages.el' file of the passed CANDIDATE."
   (ivy-spacemacs-help//layer-action-open-file "packages.el" (cadr args)))
@@ -307,6 +319,7 @@
    ("d" ivy-spacemacs-help//help-action-open-dired "open dired at layer location")
    ("D" ivy-spacemacs-help//help-action-describe-package "describe package")
    ("e" ivy-spacemacs-help//help-action-open-readme-edit "open readme for editing")
+   ("c" ivy-spacemacs-help//help-action-open-config "open config.el")
    ("p" ivy-spacemacs-help//help-action-open-packages "open packages.el")
    ("r" ivy-spacemacs-help//help-action-open-readme "open readme")))
 


### PR DESCRIPTION
This PR adds `c` action to open `config.el` file when using `SPC h l` or `SPC h SPC` with `ivy` completion<a href="#sup_1"><sup>1</sup></a>. The only controversial thing is that message is shown when `config.el` is missing instead of opening new file. I feel like it's for better. 

<sup id="sup_1">1</sup>: Gonna implement the same thing for `helm` if you like the idea of having quick access to `config.el`. 