### PR TITLE
[Complete] Add xwidget layer

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -15,7 +15,8 @@
         ggtags
         helm
         helm-gtags
-        slime))
+        slime
+        slime-company))
 
 (defun common-lisp/post-init-auto-highlight-symbol ()
   (with-eval-after-load 'auto-highlight-symbol
@@ -33,6 +34,10 @@
 (defun common-lisp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'common-lisp-mode))
 
+(defun common-lisp/init-slime-company ()
+  :config
+  (setq slime-company-completion 'fuzzy))
+
 (defun common-lisp/init-slime ()
   (use-package slime
     :commands slime-mode
@@ -43,7 +48,8 @@
       (setq slime-contribs '(slime-fancy
                              slime-indentation
                              slime-sbcl-exts
-                             slime-scratch)
+                             slime-scratch
+			     slime-company)
             inferior-lisp-program "sbcl")
       ;; enable fuzzy matching in code buffer and SLIME REPL
       (setq slime-complete-symbol*-fancy t)


### PR DESCRIPTION
Add xwdiget layer that configures xwidget-browser to behave more like a
normal browser. In the future, anything related to xwidget - aside from
the browser - should be put here. Hence the name "xwidget".
here