### PR TITLE
Fix .gitignore to enable submodule update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ tmp/
 .python-environments/
 server/
 /network-security.data
-*~
 *.elc
 *.pyc
 /*.zip


### PR DESCRIPTION
The `*~` in the .gitignore prevents me from updating the git submodule in [spacemacs-tmux](https://github.com/jgmize/spacemacs-tmux). 