### PR TITLE
Move usage of spacemacs//restore-previous-display-config to spacemacs-completion (fixes 6598)

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -57,10 +57,7 @@
     :commands (spacemacs/helm-find-files)
     :init
     (progn
-      ;;  Restore popwin-mode after a Helm session finishes.
-      (spacemacs/add-to-hook 'helm-cleanup-hook
-                             '(spacemacs//restore-previous-display-config
-                               spacemacs//helm-cleanup))
+      (add-hook 'helm-cleanup-hook #'spacemacs//helm-cleanup)
       ;; key bindings
       ;; Use helm to provide :ls, unless ibuffer is used
       (unless (configuration-layer/package-usedp 'ibuffer)

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -41,6 +41,8 @@
     (spacemacs/add-to-hook 'helm-after-initialize-hook
                            '(spacemacs//helm-prepare-display
                              spacemacs//hide-cursor-in-helm-buffer))
+    ;;  Restore popwin-mode after a Helm session finishes.
+    (add-hook 'helm-cleanup-hook #'spacemacs//restore-previous-display-config)
     (add-hook 'helm-find-files-before-init-hook
               'spacemacs//set-dotted-directory)
     (add-hook 'spacemacs-editing-style-hook 'spacemacs//helm-hjkl-navigation)


### PR DESCRIPTION
Move usage of `spacemacs//restore-previous-display-config` from `helm` layer to `spacemacs-completion` layer. Fixes #6598.