### PR TITLE
mute exec-path-from-shell at startup

### DIFF
--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -168,6 +168,7 @@
 (defun spacemacs-base/init-exec-path-from-shell ()
   (use-package exec-path-from-shell
     :init (when (memq window-system '(mac ns x))
+	    (setq exec-path-from-shell-check-startup-files nil)
             (exec-path-from-shell-initialize))))
 
 (defun spacemacs-base/init-help-fns+ ()


### PR DESCRIPTION
exec-path-from-shell pollutes the \*Messages\* buffer during startup saying that you are not setting your shell environment variables in the right files.

Mute it and make it leave your shell configuration alone.

Incriminated message:

`"You appear to be setting environment variables %S in your .bashrc or .zshrc: those files are only read by interactive shells, so you should instead set environment variables in startup files like .profile, .bash_profile or .zshenv.  Refer to your shell's man page for more info.  Customize `exec-path-from-shell-arguments' to remove \"-i\" when done, or disable `exec-path-from-shell-check-startup-files' to disable this message."`