### PR TITLE
Use --simple-prompt for IPython 5.

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -16,6 +16,25 @@
   (highlight-lines-matching-regexp "import i?pu?db")
   (highlight-lines-matching-regexp "i?pu?db.set_trace()"))
 
+(defun spacemacs/pyenv-executable-find (command)
+  "Find executable taking pyenv shims into account."
+  (if (executable-find "pyenv")
+      (progn
+        (let ((pyenv-string (shell-command-to-string (concat "pyenv which " command))))
+          (unless (string-match "not found" pyenv-string)
+            pyenv-string)))
+    (executable-find command)))
+
+(defun spacemacs/python-setup-shell (&rest args)
+  (if (spacemacs/pyenv-executable-find "ipython")
+      (progn (setq python-shell-interpreter "ipython")
+             (if (version< (replace-regexp-in-string "\n$" "" (shell-command-to-string "ipython --version")) "5")
+                 (setq python-shell-interpreter-args "-i")
+               (setq python-shell-interpreter-args "--simple-prompt -i")))
+    (progn
+      (setq python-shell-interpreter-args "-i")
+      (setq python-shell-interpreter "python"))))
+
 (defun spacemacs/python-toggle-breakpoint ()
   "Add a break point, highlight it."
   (interactive)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -191,6 +191,9 @@
        (`on-project-switch
         (add-hook 'projectile-after-switch-project-hook
                   'spacemacs//pyenv-mode-set-local-version)))
+      ;; setup shell correctly on environment switch
+      (dolist (func '(pyenv-mode-set pyenv-mode-unset))
+        (advice-add func :after 'spacemacs/python-setup-shell))
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "vu" 'pyenv-mode-unset
         "vs" 'pyenv-mode-set))))
@@ -204,7 +207,10 @@
         (spacemacs/set-leader-keys-for-major-mode mode
           "Va" 'pyvenv-activate
           "Vd" 'pyvenv-deactivate
-          "Vw" 'pyvenv-workon)))))
+          "Vw" 'pyvenv-workon))
+      ;; setup shell correctly on environment switch
+      (dolist (func '(pyvenv-activate pyvenv-deactivate pyvenv-workon))
+        (advice-add func :after 'spacemacs/python-setup-shell)))))
 
 (defun python/init-pylookup ()
   (use-package pylookup
@@ -255,18 +261,14 @@
         ;; make C-j work the same way as RET
         (local-set-key (kbd "C-j") 'newline-and-indent))
 
-      (defun python-setup-shell ()
-        (if (executable-find "ipython")
-            (setq python-shell-interpreter "ipython")
-          (setq python-shell-interpreter "python")))
 
       (defun inferior-python-setup-hook ()
         (setq indent-tabs-mode t))
 
       (add-hook 'inferior-python-mode-hook #'inferior-python-setup-hook)
       (add-hook 'python-mode-hook #'python-default)
-      ;; call `python-setup-shell' once, don't put it in a hook (see issue #5988)
-      (python-setup-shell))
+      ;; call `spacemacs/python-setup-shell' once, don't put it in a hook (see issue #5988)
+      (spacemacs/python-setup-shell))
     :config
     (progn
       ;; add support for `ahs-range-beginning-of-defun' for python-mode


### PR DESCRIPTION
IPython 5 does no longer use readline and so the emacs integration is
broken. See also
http://ipython.readthedocs.io/en/stable/whatsnew/version5.html#id1

Fix #6622 and related to #6580