### PR TITLE
Issue template: direct link to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,3 +1,4 @@
 If you are posting about a *bug* please close this issue and open a new one
-using [SPC h I] or [M-m h I] (I = capital i) from within Spacemacs.
+using [SPC h I] or [M-m h I] (I = capital i) from within Spacemacs. If the
+bug makes Spacemacs unusable, you can find the bug report template [here](https://github.com/syl20bnr/spacemacs/blob/develop/core/templates/REPORTING.template)
 You can delete this message to start typing.


### PR DESCRIPTION
Bugs that make Spacemacs unusable can't be reported from inside Spacemacs, so I added a direct link to the template used by `SPC h I`. The link is to the file in develop branch, and not master, because I assume it will be more up-to-date than master.

I made the PR against master (and not develop) because I think the change needs to be in master for users to see it when clicking the "New Issue" button.