### PR TITLE
Silent `next-error-find-buffer` when no error buffer found

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1049,7 +1049,7 @@ is nonempty."
 Delegates to flycheck if it is enabled and the next-error buffer
 is not visible. Otherwise delegates to regular Emacs next-error."
   (if (and (bound-and-true-p flycheck-mode)
-           (let ((buf (next-error-find-buffer)))
+           (let ((buf (ignore-errors (next-error-find-buffer))))
              (not (and buf (get-buffer-window buf)))))
       'flycheck
     'emacs))


### PR DESCRIPTION
Fix #6639. Wrap `next-error-find-buffer` with `ignore-errors` so that when no error buffer is found, it returns `nil`.