### PR TITLE
add support for omtose-phellack-theme

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -162,6 +162,8 @@
     (junio    . sublime-themes)
     (mccarthy . sublime-themes)
     (odersky  . sublime-themes)
+    (omtose-darker . omtose-phellack-theme)
+    (omtose-softer . omtose-phellack-theme)
     (ritchie  . sublime-themes)
     (spolsky  . sublime-themes)
     (wilson   . sublime-themes)


### PR DESCRIPTION
now can use `omtose-darker` and `omtose-softer` in .spacemacs

https://github.com/syl20bnr/spacemacs/issues/6657