### PR TITLE
Add shortcuts for full left and right scroll

### DIFF
--- a/layers/+tools/pdf-tools/README.org
+++ b/layers/+tools/pdf-tools/README.org
@@ -102,6 +102,7 @@ If you use Emacs editing style, check the key bindings at the [[https://github.c
 | *Navigation*         |                                           |
 |----------------------+-------------------------------------------|
 | ~M-SPC~ or ~s-M-SPC~ | pdf-tools transient state                 |
+| ~0/$~                | Left/right full scroll                    |
 | ~J~                  | Move to next page                         |
 | ~K~                  | Move to previous page                     |
 | ~u~                  | Scroll page up                            |
@@ -127,6 +128,11 @@ If you use Emacs editing style, check the key bindings at the [[https://github.c
 | ~o~                  | Follow link                               |
 | ~O~                  | Show outline                              |
 | ~r~                  | Refresh file                              |
+|----------------------+-------------------------------------------|
+| *Zoom*               |                                           |
+|----------------------+-------------------------------------------|
+| ~+/-~                | Zoom in/out                               |
+| ~zr~                 | Reset zoom                                |
 |----------------------+-------------------------------------------|
 
 /For evil users/: Note that the search keys activate =isearch=, which works

--- a/layers/+tools/pdf-tools/packages.el
+++ b/layers/+tools/pdf-tools/packages.el
@@ -33,9 +33,9 @@
  [_h_/_l_] scroll left/right   [_H_] fit to height            [_at_] text         [_O_] outline
  [_d_/_u_] pg down/up          [_P_] fit to page              [_aD_] delete       [_p_] print
  [_J_/_K_] next/prev pg        [_m_] slice using mouse        [_am_] markup       [_o_] open link
- ^^^^                          [_b_] slice from bounding box  ^^                  [_r_] revert
+ [_0_/_$_] full scroll l/r     [_b_] slice from bounding box  ^^                  [_r_] revert
  ^^^^                          [_R_] reset slice              ^^                  [_t_] attachments
- ^^^^                          ^^                             ^^                  [_n_] night mode
+ ^^^^                          [_zr_] reset zoom              ^^                  [_n_] night mode
  "
         :bindings
         ;; Navigation
@@ -47,13 +47,16 @@
         ("K"  pdf-view-previous-page)
         ("u"  pdf-view-scroll-down-or-previous-page)
         ("d"  pdf-view-scroll-up-or-next-page)
+        ("0"  scroll-right)
+        ("$"  scroll-left)
         ;; Scale/Fit
-        ("W" pdf-view-fit-width-to-window)
-        ("H" pdf-view-fit-height-to-window)
-        ("P" pdf-view-fit-page-to-window)
-        ("m" pdf-view-set-slice-using-mouse)
-        ("b" pdf-view-set-slice-from-bounding-box)
-        ("R" pdf-view-reset-slice)
+        ("W"  pdf-view-fit-width-to-window)
+        ("H"  pdf-view-fit-height-to-window)
+        ("P"  pdf-view-fit-page-to-window)
+        ("m"  pdf-view-set-slice-using-mouse)
+        ("b"  pdf-view-set-slice-from-bounding-box)
+        ("R"  pdf-view-reset-slice)
+        ("zr" pdf-view-scale-reset)
         ;; Annotations
         ("aD" pdf-annot-delete)
         ("at" pdf-annot-attachment-dired :exit t)
@@ -103,6 +106,8 @@
       ;; TODO: Make `/', `?' and `n' work like in Evil
       (evilified-state-evilify pdf-view-mode pdf-view-mode-map
         ;; Navigation
+        "0"  'scroll-right
+        "$"  'scroll-left
         "j"  'pdf-view-next-line-or-next-page
         "k"  'pdf-view-previous-line-or-previous-page
         "l"  'image-forward-hscroll
@@ -124,7 +129,8 @@
         ;; Actions
         "r"   'pdf-view-revert-buffer
         "o"   'pdf-links-action-perform
-        "O"   'pdf-outline)
+        "O"   'pdf-outline
+        "zr"  'pdf-view-scale-reset)
       (evilified-state-evilify pdf-outline-buffer-mode pdf-outline-buffer-mode-map
         "-"                'negative-argument
         "j"                'next-line


### PR DESCRIPTION
Add `0` and `$` commands for left/right scrolling. Very handy for reading 2 column articles.
Change reset zoom shortcut from `0` to `zr`.