### PR TITLE
[scala] Disable Ensime autostart

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -13,7 +13,7 @@
  - [[#automatically-show-the-type-of-the-symbol-under-the-cursor][Automatically show the type of the symbol under the cursor]]
  - [[#automatically-insert-asterisk-in-multiline-comments][Automatically insert asterisk in multiline comments]]
  - [[#automatically-replace-arrows-with-unicode-ones][Automatically replace arrows with unicode ones]]
- - [[#disable-auto-start][Disable auto-start]]
+ - [[#auto-start][Auto-start]]
  - [[#key-bindings][Key bindings]]
    - [[#ensime-key-bindings][Ensime key bindings]]
      - [[#search][Search]]
@@ -124,13 +124,13 @@ the ascii arrows back.
     (scala :variables scala-use-unicode-arrows t)))
 #+END_SRC
 
-* Disable auto-start
-If you prefer not to have Ensime start when you load a scala file, you can
-disable it with
+* Auto-start
+If you prefer to have Ensime start when you load a scala file, you can
+enable it with
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers '(
-    (scala :variables scala-auto-start-ensime nil)))
+    (scala :variables scala-auto-start-ensime t)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -18,5 +18,5 @@
 (defvar scala-use-unicode-arrows nil
   "If non-nil then `->`, `=>` and `<-` are replaced with unicode arrows.")
 
-(defvar scala-auto-start-ensime t
+(defvar scala-auto-start-ensime nil
   "If non nil then ensime will be started when a scala file is opened.")


### PR DESCRIPTION
Disables Ensime autostart, default should be `false`.

When you work with multiple projects this will start an ensime instance every time a scala file is opened. It will be a huge memory consumer.

Also there is a bug with current spacemacs implementation of autostart: https://github.com/syl20bnr/spacemacs/pull/6530