### PR TITLE
Add mu installation note for OSX/Homebrew users

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -19,6 +19,14 @@
 In order to use this layer you must install mu and mu4e separately. Typically
 mu4e will be bundled with mu (this is the case on many Linux distributions).
 
+If you're on OS X and install mu using Homebrew, you must specify the
+location of your Emacs binary at install time using the EMACS environment
+variable, as well as passing the --with-emacs option:
+
+#+begin_src shell
+EMACS=$(which emacs) brew install homebrew --with-emacs
+#+end_src
+
 If the installation directory of mu4e is not in Emacs’ load path, you can set
 the layer variable =mu4e-installation-path=, for example:
 


### PR DESCRIPTION
I discovered this after a good deal of messing about trying to get mu to work, and figured it may be useful to include in the official docs.