### PR TITLE
Add theme mappings for omtose-phellack-theme

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -151,6 +151,8 @@
     (minimal-light . minimal-theme)
     (moe-dark  . moe-theme)
     (moe-light . moe-theme)
+    (omtose-darker . omtose-phellack-theme)
+    (omtose-softer . omtose-phellack-theme)
     (stekene-dark  . stekene-theme)
     (stekene-light . stekene-theme)
     (brin     . sublime-themes)


### PR DESCRIPTION
Add a mapping in `core-themes-support.el` for the themes in the omtose-phellack-theme package so we don't barf during load if one of those themes is the user's default theme.
