### PR TITLE
Swap haskell layer specific keys f and F

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -173,8 +173,8 @@ Top-level commands are prefixed by ~SPC m~:
 |-------------+---------------------------------------------------------------------|
 | ~SPC m g g~ | go to definition or tag                                             |
 | ~SPC m g i~ | cycle the Haskell import lines or return to point (with prefix arg) |
-| ~SPC m f~   | format buffer using haskell-stylish                                 |
-| ~SPC m F~   | format declaration using hindent (if enabled)                       |
+| ~SPC m F~   | format buffer using haskell-stylish                                 |
+| ~SPC m f~   | format declaration using hindent (if enabled)                       |
 
 ** Documentation
 Documentation commands are prefixed by ~SPC m h~

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -150,7 +150,7 @@
         (spacemacs/set-leader-keys-for-major-mode mode
           "gg"  'haskell-mode-jump-to-def-or-tag
           "gi"  'haskell-navigate-imports
-          "f"   'haskell-mode-stylish-buffer
+          "F"   'haskell-mode-stylish-buffer
 
           "sb"  'haskell-process-load-file
           "sc"  'haskell-interactive-mode-clear
@@ -276,7 +276,7 @@
     (progn
       (setq hindent-style haskell-enable-hindent-style)
       (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
-        "F" 'hindent-reformat-decl))))
+        "f" 'hindent-reformat-decl))))
 
 (defun haskell/init-hlint-refactor ()
   (use-package hlint-refactor


### PR DESCRIPTION
Brought up in #6591. hindent is potentially much more used than stylish-haskell, therefore it now has the fewer keystrokes.