### PR TITLE
Add option for helm fuzzy matching

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -202,6 +202,12 @@ start.")
 (defvar dotspacemacs-helm-position 'bottom
   "Position in which to show the `helm' mini-buffer.")
 
+(defvar dotspacemacs-helm-use-fuzzy 'always
+  "Controls fuzzy matching in helm. If set to `always', force fuzzy matching
+  in all non-asynchronous sources. If set to `source', preserve individual
+  source settings. Else, disable fuzzy matching in all sources.
+  Default `always'.")
+
 (defvar dotspacemacs-large-file-size 1
   "Size (in MB) above which spacemacs will prompt to open the large file
 literally to avoid performance issues. Opening a file literally means that

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -186,6 +186,11 @@ values."
    ;; define the position to display `helm', options are `bottom', `top',
    ;; `left', or `right'. (default 'bottom)
    dotspacemacs-helm-position 'bottom
+   ;; Controls fuzzy matching in helm. If set to `always', force fuzzy matching
+   ;; in all non-asynchronous sources. If set to `source', preserve individual
+   ;; source settings. Else, disable fuzzy matching in all sources.
+   ;; Default 'always.
+   dotspacemacs-helm-use-fuzzy 'always
    ;; If non nil the paste micro-state is enabled. When enabled pressing `p`
    ;; several times cycle between the kill ring content. (default nil)
    dotspacemacs-enable-paste-transient-state nil

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -40,7 +40,7 @@
   (let ((source-type (cadr args))
         (props (cddr args)))
     (unless (eq source-type 'helm-source-async)
-      (plist-put props :fuzzy-match t)))
+      (plist-put props :fuzzy-match (eq 'always dotspacemacs-helm-use-fuzzy))))
   (apply f args))
 
 ;; Helm Header line

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -46,7 +46,9 @@
     (add-hook 'spacemacs-editing-style-hook 'spacemacs//helm-hjkl-navigation)
     ;; setup advices
     ;; fuzzy matching for all the sourcess
-    (advice-add 'helm-make-source :around #'spacemacs//helm-make-source)
+    (unless (eq dotspacemacs-helm-use-fuzzy 'source)
+      (advice-add 'helm-make-source :around #'spacemacs//helm-make-source))
+
     (defadvice spacemacs/post-theme-init
         (after spacemacs/helm-header-line-adv activate)
       "Update defaults for `helm' header line whenever a new theme is loaded"


### PR DESCRIPTION
Adds an option in dotspacemacs which controls whether or not most helm sources have fuzzy matching enabled.
