### PR TITLE
Update DOCUMENTATION.org - missing doc for #6027

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1028,7 +1028,7 @@ Note the these colors may vary depending on your theme.
 
 **** Powerline separators
 It is possible to easily customize the =powerline separator= by setting the
-=powerline-default-separator= variable in your =~./spacemacs=. For instance if
+=powerline-default-separator= variable in your =~./spacemacs= and call =spaceline-compile= after that. For instance if
 you want to set back the separator to the well-known =arrow= separator add the
 following snippet to your configuration file:
 
@@ -1036,7 +1036,8 @@ following snippet to your configuration file:
 (defun dotspacemacs/user-config ()
   "This is were you can ultimately override default Spacemacs configuration.
 This function is called at the very end of Spacemacs initialization."
-  (setq powerline-default-separator 'arrow))
+  (setq powerline-default-separator 'arrow)
+  (spaceline-compile))
 #+END_SRC
 
 To save you the time to try all the possible separators provided by the


### PR DESCRIPTION
Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3
Hi, let's add a missing documentation for:
"You'll have to call spaceline-compile in your user-config after setting powerline-default-separator."
described at issue #6027

Thanks!