### PR TITLE
Make swoop optional and helm-ag follow

### DIFF
--- a/layers/+completion/helm/config.el
+++ b/layers/+completion/helm/config.el
@@ -1,0 +1,15 @@
+;;; config.el --- helm configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Helm ------------------------------------------------------------------------
+
+(defvar helm-use-swoop t
+  "Whether or not helm swoop is used for searching")

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -117,7 +117,17 @@
                 (lambda ()
                   (unless (configuration-layer/package-usedp 'smex)
                     (spacemacs/set-leader-keys
-                      dotspacemacs-emacs-command-key 'helm-M-x)))))
+                      dotspacemacs-emacs-command-key 'helm-M-x))))
+
+      ;; In follow mode, follow on keystrokes as well as up/down
+      (setq helm-follow-follow-on-update t)
+      ;; Run any search with follow mode on
+      (defun spacemacs//helm-do-search-with-follow (helm-source helm-command)
+        (let ((prev-follow-val (helm-attr 'follow (symbol-value helm-source))))
+          (helm-attrset 'follow 1 (symbol-value helm-source))
+          (call-interactively helm-command)
+          (helm-attrset 'follow prev-follow-val (symbol-value helm-source)))))
+
     :config
     (progn
       (helm-mode)
@@ -183,7 +193,7 @@
       (defun spacemacs/helm-file-do-ag (&optional _)
         "Wrapper to execute `helm-ag-this-file.'"
         (interactive)
-        (helm-ag-this-file))
+        (spacemacs//helm-do-search-with-follow 'helm-source-do-ag 'helm-do-ag-this-file))
 
       (defun spacemacs/helm-file-do-ag-region-or-symbol ()
         "Search in current file with `ag' using a default input."
@@ -265,7 +275,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-buffers-do-ag (&optional _)
         "Wrapper to execute `helm-ag-buffers.'"
         (interactive)
-        (helm-do-ag-buffers))
+        (spacemacs//helm-do-search-with-follow 'helm-source-do-ag 'helm-do-ag-buffers))
 
       (defun spacemacs/helm-buffers-do-ag-region-or-symbol ()
         "Search in opened buffers with `ag' with a default input."
@@ -417,7 +427,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         ;; current file scope
         "ss"  'spacemacs/helm-file-smart-do-search
         "sS"  'spacemacs/helm-file-smart-do-search-region-or-symbol
-        "saa" 'helm-ag-this-file
+        "saa" 'spacemacs/helm-file-do-ag
         "saA" 'spacemacs/helm-file-do-ag-region-or-symbol
         ;; files scope
         "sf"  'spacemacs/helm-files-smart-do-search
@@ -548,6 +558,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
 
 (defun helm/init-helm-swoop ()
   (use-package helm-swoop
+    :if helm-use-swoop
     :defer t
     :init
     (progn


### PR DESCRIPTION
- Introduces a layer variable for helm to disable swoop
- helm-ag for single files and open buffers now
  starts in follow mode

Unfortunately there's a minor problem with my code I can't figure out. If I start spacemacs and do `SPC s s` or similar (with swoop disabled so helm-ag is launched with follow mode) then I get: helm-attr: Symbol's value as variable is void: helm-source-do-ag. However, if I run some other helm-ag command (`SPC /`), after that it's fine. So it seems like an issue with when things are being loaded. Not sure exactly how to fix it though.
