### PR TITLE
scala: add SPC m x for sbt-hydra

### DIFF
--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -111,3 +111,8 @@ point to the position of the join."
   "Yank to kill ring and print full type name at point to the minibuffer."
   (interactive)
   (ensime-type-at-point t t))
+
+(defun sbt-hydra ()
+  "Wrapper to rename sbt-hydra:hydra to sbt-hydra"
+  (interactive)
+  (sbt-hydra:hydra))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -175,6 +175,8 @@
         "sr"     'ensime-inf-eval-region
         "sR"     'ensime-inf-eval-region-switch
 
+        "x"      'sbt-hydra
+
         "yT"     'scala/yank-type-at-point-full-name
         "yt"     'scala/yank-type-at-point
 


### PR DESCRIPTION
This PR introduces the main key binding to interact with hydra in `sbt-mode`. See section on *Hydra* in [ensime sbt-mode documentation[(https://ensime.github.io/editors/emacs/sbt-mode/).

I'm not sure `x` is the right key binding so please let me know any other key that makes more sense than `x`, or if you believe this belongs under an existing scala prefix. Notice also that `sbt-hydra` provides several functions so this binding may become a prefixed key under its own prefix section in the future.