### PR TITLE
move the eshell-z history file into the eshell cache directory

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -186,7 +186,8 @@ is achieved by adding the relevant text properties."
     :defer t
     :init
     (with-eval-after-load 'eshell
-      (require 'eshell-z))))
+      (require 'eshell-z)
+      (setq eshell-z-freq-dir-hash-table-file-name (concat eshell-directory-name "/z")))))
 
 (defun shell/pre-init-helm ()
   (spacemacs|use-package-add-hook helm


### PR DESCRIPTION
Previously, it was saved directly to the user's home directory (`~/.z`) :scream:.