### PR TITLE
Fix a bug with being unable to paste via p

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -168,11 +168,6 @@
     ("P" evil-paste-before)
     ("0" spacemacs//transient-state-0))
 
-  (when dotspacemacs-enable-paste-transient-state
-    (define-key evil-normal-state-map
-      "p" 'spacemacs/paste-transient-state/evil-paste-after)
-    (define-key evil-normal-state-map
-      "P" 'spacemacs/paste-transient-state/evil-paste-before))
   ;; fold transient state
   (when (eq 'evil dotspacemacs-folding-method)
     (spacemacs|define-transient-state fold


### PR DESCRIPTION
Previous to this change, any time I tried yanking with `yy` and pasting via `p`, I received the following error:

`Symbol's function definition is void: spacemacs/paste-transient-state/evil-paste-after`

I tried putting `(setq dotspacemacs-enable-paste-transient-state nil)` in user-config, but the error still occurs.

With this change, that error disappears and pasting works normally.