### PR TITLE
Set desktop-dirname during init

### DIFF
--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -87,10 +87,10 @@
 (defun spacemacs-ui/init-desktop ()
   (use-package desktop
     :defer t
+    :init
+    (setq desktop-dirname spacemacs-cache-directory)
     :config
-    (progn
-      (setq desktop-dirname spacemacs-cache-directory)
-      (push spacemacs-cache-directory desktop-path))))
+    (push spacemacs-cache-directory desktop-path)))
 
 (defun spacemacs-ui/init-doc-view ()
   (use-package doc-view


### PR DESCRIPTION
Makes it easier to override, see #6741