### PR TITLE
Move helm-popwin display config to helm layer

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -11,10 +11,32 @@
 
 
 
+(defvar helm--popwin-mode nil
+  "Temp variable to store `popwin-mode''s value.")
+
 (defun spacemacs//helm-cleanup ()
   "Cleanup some helm related states when quitting."
   ;; deactivate any running transient map (transient-state)
   (setq overriding-terminal-local-map nil))
+
+(defun spacemacs//helm-prepare-display ()
+  "Prepare necessary settings to make Helm display properly."
+  (setq spacemacs-display-buffer-alist display-buffer-alist)
+  ;; the only buffer to display is Helm, nothing else we must set this
+  ;; otherwise Helm cannot reuse its own windows for copyinng/deleting
+  ;; etc... because of existing popwin buffers in the alist
+  (setq display-buffer-alist nil)
+  (setq helm--popwin-mode popwin-mode)
+  (when popwin-mode
+    (popwin-mode -1)))
+
+(defun spacemacs//helm-restore-display ()
+  ;; we must enable popwin-mode first then restore `display-buffer-alist'
+  ;; Otherwise, popwin keeps adding up its own buffers to
+  ;; `display-buffer-alist' and could slow down Emacs as the list grows
+  (when helm--popwin-mode
+    (popwin-mode))
+  (setq display-buffer-alist spacemacs-display-buffer-alist))
 
 
 ;; REPLs integration

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -24,6 +24,7 @@
         helm-swoop
         helm-themes
         (helm-spacemacs-help :location local)
+        popwin
         projectile
         ))
 
@@ -579,6 +580,12 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
     :init
     (spacemacs/set-leader-keys
       "Ts" 'helm-themes)))
+
+(defun helm/post-init-popwin ()
+  ;; disable popwin-mode while Helm session is running
+  (add-hook 'helm-after-initialize-hook #'spacemacs//helm-prepare-display)
+  ;;  Restore popwin-mode after a Helm session finishes.
+  (add-hook 'helm-cleanup-hook #'spacemacs//helm-restore-display))
 
 (defun helm/post-init-projectile ()
   (setq projectile-completion-system 'helm))

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -111,23 +111,6 @@
     (window-height . 0.4)))
 (defvar spacemacs-display-buffer-alist nil)
 
-(defun spacemacs//helm-prepare-display ()
-  "Prepare necessary settings to make Helm display properly."
-  ;; avoid Helm buffer being diplaye twice when user
-  ;; sets this variable to some function that pop buffer to
-  ;; a window. See https://github.com/syl20bnr/spacemacs/issues/1396
-  (let ((display-buffer-base-action '(nil)))
-    (setq spacemacs-display-buffer-alist display-buffer-alist)
-    ;; the only buffer to display is Helm, nothing else we must set this
-    ;; otherwise Helm cannot reuse its own windows for copyinng/deleting
-    ;; etc... because of existing popwin buffers in the alist
-    (setq display-buffer-alist nil)
-    (popwin-mode -1)
-    ;; workaround for a helm-evil incompatibility
-    ;; see https://github.com/syl20bnr/spacemacs/issues/3700
-    (when helm-prevent-escaping-from-minibuffer
-      (define-key evil-motion-state-map [down-mouse-1] nil))))
-
 (defun spacemacs//display-helm-window (buffer)
   "Display the Helm window respecting `dotspacemacs-helm-position'."
   (let ((display-buffer-alist
@@ -143,17 +126,18 @@
                spacemacs-helm-display-buffer-regexp)))
     (helm-default-display-buffer buffer)))
 
-(defun spacemacs//restore-previous-display-config ()
-  "Workaround for a helm-evil incompatibility
- see https://github.com/syl20bnr/spacemacs/issues/3700"
+(defun spacemacs//unprevent-minibuffer-escape ()
+  "Workaround for a helm-evil incompatibility.
+See https://github.com/syl20bnr/spacemacs/issues/3700"
   (when helm-prevent-escaping-from-minibuffer
     (define-key evil-motion-state-map
-      [down-mouse-1] 'evil-mouse-drag-region))
-  (popwin-mode 1)
-  ;; we must enable popwin-mode first then restore `display-buffer-alist'
-  ;; Otherwise, popwin keeps adding up its own buffers to
-  ;; `display-buffer-alist' and could slow down Emacs as the list grows
-  (setq display-buffer-alist spacemacs-display-buffer-alist))
+      [down-mouse-1] 'evil-mouse-drag-region)))
+
+(defun spacemacs//prevent-minibuffer-escape ()
+  "Workaround for a helm-evil incompatibility.
+See https://github.com/syl20bnr/spacemacs/issues/3700"
+  (when helm-prevent-escaping-from-minibuffer
+    (define-key evil-motion-state-map [down-mouse-1] nil)))
 
 ;; Helm Transient state
 

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -39,10 +39,9 @@
               'spacemacs//helm-hide-minibuffer-maybe)
     (add-hook 'helm-before-initialize-hook 'helm-toggle-header-line)
     (spacemacs/add-to-hook 'helm-after-initialize-hook
-                           '(spacemacs//helm-prepare-display
+                           '(spacemacs//prevent-minibuffer-escape
                              spacemacs//hide-cursor-in-helm-buffer))
-    ;;  Restore popwin-mode after a Helm session finishes.
-    (add-hook 'helm-cleanup-hook #'spacemacs//restore-previous-display-config)
+    (add-hook 'helm-cleanup-hook #'spacemacs//unprevent-minibuffer-escape)
     (add-hook 'helm-find-files-before-init-hook
               'spacemacs//set-dotted-directory)
     (add-hook 'spacemacs-editing-style-hook 'spacemacs//helm-hjkl-navigation)


### PR DESCRIPTION
Rename and move `spacemacs//helm-prepare-display` and `spacemacs//restore-previous-display-config` to Helm layer. Use them only when `popwin` is used. Fixes #6634 

Misc:
- Move the code that prevents escaping the minibuffer with the mouse to separate functions, leave it in spacemacs-completion layer.
- Delete let-binding of `display-buffer-base-action`. It was introduced in #1397 to fix #1396, but didn't do anything since we stopped using `(popwin:display-buffer helm-buffer t)` in #1428.