### PR TITLE
Fix broken links in the docs

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3212,7 +3212,7 @@ with ~SPC SPC spacemacs/recompile-elpa~.
 | The Librarian (doc-fmt tool and space-doc mode) | [[https://github.com/JAremko][JAremko]]      |
 
 * Thank you
-[[Using configuration layers][Jokes aside]], thank you Richard for this great piece of software.
+Thank you Richard for this great piece of software.
 
 Thank you to all the contributors and the whole Emacs community from core
 developers to elisp hackers!

--- a/layers/+intl/keyboard-layout/README.org
+++ b/layers/+intl/keyboard-layout/README.org
@@ -57,7 +57,7 @@ It is possible to override or add bindings by defining functions named
 They are respectively called just before and after the actual configuration of
 keybindings in this layer, so *you don't have to think about when to apply the
 configuration by yourself*. =<NAME>= is the name of the configuration you want
-to customize, they are listed under the [[#configurations][Configurations]] section.
+to customize, they are listed under the [[#configuration][Configuration]] section.
 
 Example:
 #+begin_src emacs-lisp


### PR DESCRIPTION
This PR fix some broken links in the docs that prevent the creation of the docs when running `spacemacs/publish-doc` from `core/core-documentation.el`