### PR TITLE
Fix package definition for evil-unimpaired

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -30,7 +30,7 @@
         ;; https://github.com/7696122/evil-terminal-cursor-changer/issues/8
         ;; evil-terminal-cursor-changer
         evil-tutor
-        (evil-unimpaired :location (recipe :fetcher local))
+        (evil-unimpaired :location local)
         evil-visual-mark-mode
         (hs-minor-mode :location built-in)
         linum-relative


### PR DESCRIPTION
After upgrading to latest develop I got this error on the startup screen:

```
An error occurred while installing evil-unimpaired (error: (wrong-type-argument arrayp nil))
```

And these in the message buffer:

```
(Spacemacs) --> installing package: evil-unimpaired@spacemacs-evil... [1/1]
Fetcher: file
Source: nil

Saving file /home/toupeira/.emacs.d/.cache/quelpa/packages/evil-unimpaired-0.1pre0.20160804.05201.el...
Wrote /home/toupeira/.emacs.d/.cache/quelpa/packages/evil-unimpaired-0.1pre0.20160804.05201.el
Wrote /home/toupeira/.emacs.d/.cache/quelpa/packages/evil-unimpaired-readme.txt
Error getting PACKAGE-DESC: (file-error Opening input file no such file or directory /home/toupeira/.emacs.d/.cache/quelpa/packages/evil-unimpaired-0.1pre0.20160804.5201.el)
Cannot load evil-unimpaired
```

Changing the package definition to `:location local` seems to fix it and the unimpaired shortcuts are still working as well.