### PR TITLE
activate ycmd-mode in c files as well

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -124,6 +124,10 @@
   (add-hook 'c++-mode-hook 'ycmd-mode)
   (spacemacs/set-leader-keys-for-major-mode 'c++-mode
     "gg" 'ycmd-goto
+    "gG" 'ycmd-goto-imprecise)
+  (add-hook 'c-mode-hook 'ycmd-mode)
+  (spacemacs/set-leader-keys-for-major-mode 'c-mode
+    "gg" 'ycmd-goto
     "gG" 'ycmd-goto-imprecise))
 
 (defun c-c++/post-init-company-ycmd ()


### PR DESCRIPTION
ycmd-mode was only activated when entering c++-mode, making syntax
checking unavailable in c-mode as flycheck-ycmd-mode is hooked to
ycmd-mode.