### PR TITLE
Fix jumping backwards after calling spacemacs/evil-smart-goto-definition

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -66,6 +66,14 @@
         (call-interactively binding)
       (evil-goto-definition))))
 
+;; Set the `:jump' property manually instead of just using `evil-define-motion'
+;; in an `eval-after-load' macro invocation because doing that prevents
+;; `describe-function' from correctly finding the source.
+;;
+;; See discussion on https://github.com/syl20bnr/spacemacs/pull/6771
+(with-eval-after-load 'evil
+  (evil-set-command-property 'spacemacs/evil-smart-goto-definition :jump t))
+
 (defun spacemacs//set-evil-shift-width ()
   "Set the value of `evil-shift-width' based on the indentation settings of the
 current major mode."


### PR DESCRIPTION
Ensure that the "previous position" mark is set correctly. Credit goes to @eltechnic0 to figuring this out.

Fixes #4942