### PR TITLE
Add jsdoc prefix

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -176,6 +176,10 @@
     (push '(company-web-html company-css) company-backends-web-mode)
     :config
     (progn
+      (spacemacs/declare-prefix-for-mode 'web-mode "me" "errors")
+      (spacemacs/declare-prefix-for-mode 'web-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'web-mode "mh" "dom")
+      (spacemacs/declare-prefix-for-mode 'web-mode "mr" "refractor")
       (spacemacs/set-leader-keys-for-major-mode 'web-mode
         "eh" 'web-mode-dom-errors-show
         "gb" 'web-mode-element-beginning

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -79,6 +79,7 @@
 
       (defun spacemacs/js-doc-set-key-bindings (mode)
         "Setup the key bindings for `js2-doc' for the given MODE."
+        (spacemacs/declare-prefix-for-mode mode "mrd" "documentation")
         (spacemacs/set-leader-keys-for-major-mode mode "rdb" 'js-doc-insert-file-doc)
         (spacemacs/set-leader-keys-for-major-mode mode "rdf" 'js-doc-insert-function-doc)
         (spacemacs/set-leader-keys-for-major-mode mode "rdt" 'js-doc-insert-tag)


### PR DESCRIPTION
In javascript layer `SPC m r` is missing prefix keyword for `d` (js-doc). Add `documentation` prefix it.