### PR TITLE
Add protobuf layer

### DIFF
--- a/layers/+lang/protobuf/packages.el
+++ b/layers/+lang/protobuf/packages.el
@@ -1,0 +1,21 @@
+(setq protobuf-packages
+      '(
+        flycheck
+        (flycheck-protobuf :toggle (configuration-layer/package-usedp 'flycheck))
+
+        protobuf-mode
+        ))
+
+
+(defun protobuf/init-flycheck-protobuf ()
+  (use-package flycheck-protobuf
+    :defer t
+    :init))
+
+(defun protobuf/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'protobuf-mode))
+
+(defun protobuf/init-protobuf-mode()
+  (use-package protobuf-mode
+    :defer t))
+


### PR DESCRIPTION
Includes protobuf-mode and flycheck-protobuf packages

Current issues:
- [ ] When opening a `.proto` file on emacs 25, I see `File mode specification error: (void-variable company-backends-c-mode-common)` (but highlighting works)
- [ ] `flycheck-verify-setup` (`SPC e v`) reports `There are no syntax checkers for this buffer!` (need to add one, see https://github.com/edvorg/flycheck-protobuf)
