### PR TITLE
Use spacemacs-core-directory const when building load-path

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -68,7 +68,7 @@
 ;; load paths
 (mapc 'add-to-load-path
       `(
-        ,(concat spacemacs-start-directory "core/")
-        ,(concat spacemacs-start-directory "core/libs/")
-        ,(concat spacemacs-start-directory "core/aprilfool/")
+        ,spacemacs-core-directory
+        ,(concat spacemacs-core-directory "libs/")
+        ,(concat spacemacs-core-directory "aprilfool/")
         ))


### PR DESCRIPTION
As long as we've defined a spacemacs-core-directory, it seems odd not to use it when building the load-path. Is there any reason not to do so? Some small performance hit, maybe? The only thing I could think of was the fact the the characters don't line up as nicely. Then again, there's also fewer of them, so that's nice.