### PR TITLE
Fix single missing character in documentation

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -56,7 +56,7 @@ should not be loaded before =dotspacemacs/user-config=, otherwise both versions
 will be loaded and will conflict.
 
 Because of autoloading, calling to =org= functions will trigger the loading up
-of the =org= shipped with emacs wich will induce conflicts.
+of the =org= shipped with emacs which will induce conflicts.
 One way to avoid conflict is to wrap your =org= config code in a
 =with-eval-after-load= block like this:
 


### PR DESCRIPTION
Within the "Important Note" there is a single character (which written as wich) typo that this change corrects.