### PR TITLE
Refactor jump to definition

### DIFF
--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -1,0 +1,61 @@
+;;; core-jump.el --- Spacemacs Core File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar spacemacs-default-jump-handlers '()
+  "List of jump handlers available in every mode.")
+
+(defvar-local spacemacs-jump-handlers '()
+  "List of jump handlers local to this buffer.")
+
+(defmacro spacemacs|define-jump-handlers (mode &rest handlers)
+  "Defines jump handlers for the given MODE.
+This defines a variable `spacemacs-jump-handlers-MODE' to which
+handlers can be added, and a function added to MODE-hook which
+sets `spacemacs-jump-handlers' in buffers of that mode."
+  (let ((mode-hook (intern (format "%S-hook" mode)))
+        (func (intern (format "spacemacs//init-jump-handlers-%S" mode)))
+        (handlers-list (intern (format "spacemacs-jump-handlers-%S" mode))))
+    `(progn
+       (defvar ,handlers-list ',handlers
+         ,(format (concat "List of mode-specific jump handlers for %S. "
+                          "These take priority over those in "
+                          "`spacemacs-default-jump-handlers'.")
+                  mode))
+       (defun ,func ()
+         (setq spacemacs-jump-handlers
+               (append ,handlers-list
+                       spacemacs-default-jump-handlers)))
+       (add-hook ',mode-hook ',func)
+       (spacemacs/set-leader-keys-for-major-mode ',mode
+         "gg" 'spacemacs/jump-to-definition))))
+
+(defun spacemacs/jump-to-definition ()
+  (interactive)
+  (catch 'done
+    (let ((old-buffer (current-buffer))
+          (old-point (point)))
+      (dolist (handler spacemacs-jump-handlers)
+        (ignore-errors
+          (call-interactively handler))
+        (unless (and (eq old-point (point))
+                     (equal old-buffer (current-buffer)))
+          (throw 'done t))))
+    (message "No jump handler was able to find this symbol.")))
+
+;; Set the `:jump' property manually instead of just using `evil-define-motion'
+;; in an `eval-after-load' macro invocation because doing that prevents
+;; `describe-function' from correctly finding the source.
+;;
+;; See discussion on https://github.com/syl20bnr/spacemacs/pull/6771
+(with-eval-after-load 'evil
+  (evil-set-command-property 'spacemacs/jump-to-definition :jump t))
+
+(provide 'core-jump)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -18,6 +18,7 @@
 (require 'core-dotspacemacs)
 (require 'core-release-management)
 (require 'core-auto-completion)
+(require 'core-jump)
 (require 'core-display-init)
 (require 'core-themes-support)
 (require 'core-fonts-support)

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -61,18 +61,9 @@
         i.e. `SPC m g g`, to lookup the source of the definition,
         while falling back to `evil-goto-definition'"
   (interactive)
-  (let ((binding (key-binding (kbd (concat dotspacemacs-leader-key " mgg")))))
-    (if (commandp binding)
-        (call-interactively binding)
-      (evil-goto-definition))))
-
-;; Set the `:jump' property manually instead of just using `evil-define-motion'
-;; in an `eval-after-load' macro invocation because doing that prevents
-;; `describe-function' from correctly finding the source.
-;;
-;; See discussion on https://github.com/syl20bnr/spacemacs/pull/6771
-(with-eval-after-load 'evil
-  (evil-set-command-property 'spacemacs/evil-smart-goto-definition :jump t))
+  (if spacemacs-jump-handlers
+      (call-interactively 'spacemacs/jump-to-definition)
+    (call-interactively 'evil-goto-definition)))
 
 (defun spacemacs//set-evil-shift-width ()
   "Set the value of `evil-shift-width' based on the indentation settings of the

--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -28,17 +28,19 @@
     (use-package agda2-mode
       :defer t
       :init (when agda-mode-path (load-file agda-mode-path))
-      (mapc
-        (lambda (x) (add-to-list 'face-remapping-alist x))
-          '((agda2-highlight-datatype-face              . font-lock-type-face)
-            (agda2-highlight-function-face              . font-lock-type-face)
-            (agda2-highlight-inductive-constructor-face . font-lock-function-name-face)
-            (agda2-highlight-keyword-face               . font-lock-keyword-face)
-            (agda2-highlight-module-face                . font-lock-constant-face)
-            (agda2-highlight-number-face                . nil)
-            (agda2-highlight-postulate-face             . font-lock-type-face)
-            (agda2-highlight-primitive-type-face        . font-lock-type-face)
-            (agda2-highlight-record-face                . font-lock-type-face)))
+      (progn
+        (spacemacs|define-jump-handlers agda2-mode agda2-goto-definition-keyboard)
+        (mapc
+         (lambda (x) (add-to-list 'face-remapping-alist x))
+         '((agda2-highlight-datatype-face              . font-lock-type-face)
+           (agda2-highlight-function-face              . font-lock-type-face)
+           (agda2-highlight-inductive-constructor-face . font-lock-function-name-face)
+           (agda2-highlight-keyword-face               . font-lock-keyword-face)
+           (agda2-highlight-module-face                . font-lock-constant-face)
+           (agda2-highlight-number-face                . nil)
+           (agda2-highlight-postulate-face             . font-lock-type-face)
+           (agda2-highlight-primitive-type-face        . font-lock-type-face)
+           (agda2-highlight-record-face                . font-lock-type-face))))
       :config
       (progn
         (spacemacs|define-transient-state goal-navigation
@@ -62,7 +64,6 @@
           "c"   'agda2-make-case
           "d"   'agda2-infer-type-maybe-toplevel
           "e"   'agda2-show-context
-          "gg"  'agda2-goto-definition-keyboard
           "gG"  'agda2-go-back
           "h"   'agda2-helper-function-type
           "l"   'agda2-load

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -34,7 +34,10 @@
   (use-package cc-mode
     :defer t
     :init
-    (add-to-list 'auto-mode-alist `("\\.h\\'" . ,c-c++-default-mode-for-headers))
+    (progn
+      (add-to-list 'auto-mode-alist `("\\.h\\'" . ,c-c++-default-mode-for-headers))
+      (spacemacs|define-jump-handlers c++-mode)
+      (spacemacs|define-jump-handlers c-mode))
     :config
     (progn
       (require 'compile)
@@ -122,13 +125,11 @@
 
 (defun c-c++/post-init-ycmd ()
   (add-hook 'c++-mode-hook 'ycmd-mode)
-  (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-    "gg" 'ycmd-goto
-    "gG" 'ycmd-goto-imprecise)
-  (add-hook 'c-mode-hook 'ycmd-mode)
-  (spacemacs/set-leader-keys-for-major-mode 'c-mode
-    "gg" 'ycmd-goto
-    "gG" 'ycmd-goto-imprecise))
+  (add-hook 'spacemacs-jump-handlers-c++-mode 'ycmd-goto)
+  (add-hook 'spacemacs-jump-handlers-c-mode 'ycmd-goto)
+  (dolist (mode '(c++-mode c-mode))
+    (spacemacs/set-leader-keys-for-major-mode mode
+      "gG" 'ycmd-goto-imprecise)))
 
 (defun c-c++/post-init-company-ycmd ()
   (push 'company-ycmd company-backends-c-mode-common))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -25,7 +25,13 @@
             cider-prompt-save-file-on-load nil
             cider-repl-use-clojure-font-lock t)
       (push "\\*cider-repl\.\+\\*" spacemacs-useful-buffers-regexp)
-      (add-hook 'clojure-mode-hook 'cider-mode))
+      (add-hook 'clojure-mode-hook 'cider-mode)
+      (dolist (hook '(spacemacs-jump-handlers-clojure-mode
+                      spacemacs-jump-handlers-clojurec-mode
+                      spacemacs-jump-handlers-clojurescript-mode
+                      spacemacs-jump-handlers-clojurex-mode
+                      spacemacs-jump-handlers-cider-repl-mode))
+        (add-hook hook 'cider-find-var)))
     :config
     (progn
       ;; add support for golden-ratio
@@ -112,7 +118,6 @@
 
           "gb" 'cider-pop-back
           "ge" 'cider-jump-to-compilation-error
-          "gg" 'cider-find-var
           "gr" 'cider-jump-to-resource
 
           "'"  'cider-jack-in
@@ -209,7 +214,12 @@
     (progn
       (add-to-list 'auto-mode-alist '("\\.boot\\'" . clojure-mode))
       ;; This regexp matches shebang expressions like `#!/usr/bin/env boot'
-      (add-to-list 'magic-mode-alist '("#!.*boot\\s-*$" . clojure-mode)))
+      (add-to-list 'magic-mode-alist '("#!.*boot\\s-*$" . clojure-mode))
+      (spacemacs|define-jump-handlers clojure-mode)
+      (spacemacs|define-jump-handlers clojurec-mode)
+      (spacemacs|define-jump-handlers clojurescript-mode)
+      (spacemacs|define-jump-handlers clojurex-mode)
+      (spacemacs|define-jump-handlers cider-repl-mode))
     :config
     (progn
       (dolist (m '(clojure-mode clojurec-mode clojurescript-mode clojurex-mode))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -38,6 +38,7 @@
     :commands slime-mode
     :init
     (progn
+      (spacemacs|define-jump-handlers lisp-mode slime-inspect-definition)
       (spacemacs/register-repl 'slime 'slime)
       (setq slime-contribs '(slime-fancy
                              slime-indentation
@@ -74,7 +75,6 @@
         "ee" 'slime-eval-last-expression
         "er" 'slime-eval-region
 
-        "gg" 'slime-inspect-definition
         "gb" 'slime-pop-find-definition-stack
         "gn" 'slime-next-note
         "gN" 'slime-previous-note

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -12,6 +12,7 @@
 (setq csharp-packages
   '(
     company
+    csharp-mode
     evil-matchit
     ggtags
     helm-gtags
@@ -30,7 +31,9 @@
         ;; Note: if you are using a roslyn based omnisharp server you can
         ;; set back this variable to t.
         (setq omnisharp-auto-complete-want-documentation nil))
-      (push 'company-omnisharp company-backends-csharp-mode))
+      (push 'company-omnisharp company-backends-csharp-mode)
+      (add-hook 'spacemacs-jump-handlers-csharp-mode
+                'omnisharp-go-to-definition))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'csharp-mode "mc" "csharp/compile")
@@ -50,7 +53,6 @@
         "fR" 'omnisharp-remove-from-project-dired-selected-files
         "pl" 'omnisharp-add-reference
         ;; Navigation
-        "gg"   'omnisharp-go-to-definition
         "gG"   'omnisharp-go-to-definition-other-window
         "gu"   'omnisharp-helm-find-usages
         "gU"   'omnisharp-find-usages-with-ido
@@ -85,6 +87,12 @@
 
 (defun csharp/post-init-company ()
   (spacemacs|add-company-hook csharp-mode))
+
+(defun csharp/init-csharp-mode ()
+  (use-package csharp-mode
+    :defer t
+    :init
+    (spacemacs|define-jump-handlers csharp-mode)))
 
 (defun csharp/post-init-evil-matchit ()
   (with-eval-after-load 'evil-matchit

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -37,7 +37,9 @@
             alchemist-test-status-modeline nil)
       ;; setup company backends
       (push 'alchemist-company company-backends-elixir-mode)
-      (push 'alchemist-company company-backends-alchemist-iex-mode))
+      (push 'alchemist-company company-backends-alchemist-iex-mode)
+      (add-hook 'spacemacs-jump-handlers-elixir-mode
+                'alchemist-goto-definition-at-point))
     :config
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mc" "compile")
     (spacemacs/declare-prefix-for-mode 'elixir-mode "me" "eval")
@@ -102,7 +104,6 @@
       "cf" 'alchemist-compile-file
       "c:" 'alchemist-compile
 
-      "gg" 'alchemist-goto-definition-at-point
       "," 'alchemist-goto-jump-back)
 
     (dolist (mode (list alchemist-compile-mode-map
@@ -131,7 +132,9 @@
 
 (defun elixir/init-elixir-mode ()
   (use-package elixir-mode
-    :defer t))
+    :defer t
+    :init
+    (spacemacs|define-jump-handlers elixir-mode)))
 
 (defun elixir/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'elixir-mode)

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -24,8 +24,7 @@
         macrostep
         semantic
         smartparens
-        srefactor
-        ))
+        srefactor))
 
 (defun emacs-lisp/init-ielm ()
   (use-package ielm
@@ -76,15 +75,19 @@
     :diminish elisp-slime-nav-mode
     :init
     (progn
+      (spacemacs/add-to-hooks
+       'elisp-slime-nav-find-elisp-thing-at-point
+       '(spacemacs-jump-handlers-emacs-lisp-mode
+         spacemacs-jump-handlers-lisp-interaction-mode))
       (add-hook 'emacs-lisp-mode-hook 'elisp-slime-nav-mode)
       (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
         (spacemacs/declare-prefix-for-mode mode "mg" "find-symbol")
         (spacemacs/declare-prefix-for-mode mode "mh" "help")
         (spacemacs/set-leader-keys-for-major-mode mode
-          "gg" 'elisp-slime-nav-find-elisp-thing-at-point
           "hh" 'elisp-slime-nav-describe-elisp-thing-at-point)))))
 
 (defun emacs-lisp/init-emacs-lisp ()
+  (spacemacs|define-jump-handlers emacs-lisp-mode)
   (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
     (spacemacs/declare-prefix-for-mode mode "mc" "compile")
     (spacemacs/declare-prefix-for-mode mode "me" "eval")

--- a/layers/+lang/faust/packages.el
+++ b/layers/+lang/faust/packages.el
@@ -13,32 +13,23 @@
 
 (defconst faust-packages
   '(company
-    dumb-jump
     faust-mode
     yasnippet))
 
 (defun faust/post-init-company ()
   (spacemacs|add-company-hook faust-mode))
 
-;; Consider to move this package somewhere else if we use it for other languages.
-(defun faust/init-dumb-jump ()
-  (use-package dumb-jump
-    :defer t
-    :init
-    (progn
-      (add-hook 'faust-mode-hook 'dumb-jump-mode)
-      (spacemacs/set-leader-keys-for-major-mode 'faust-mode
-        "gb" 'dumb-jump-back
-        "gg" 'dumb-jump-go))))
-
 (defun faust/init-faust-mode ()
   (use-package faust-mode
     :defer t
     :mode "\\.\\(dsp\\|lib\\)\\'"
-    :init (spacemacs/set-leader-keys-for-major-mode 'faust-mode
-            "cf" 'spacemacs/faust-to-firefox
-            "cg" 'spacemacs/faust-to-jack-gtk
-            "cq" 'spacemacs/faust-to-jack-qt)))
+    :init
+    (progn
+      (spacemacs|define-jump-handlers faust-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'faust-mode
+        "cf" 'spacemacs/faust-to-firefox
+        "cg" 'spacemacs/faust-to-jack-gtk
+        "cq" 'spacemacs/faust-to-jack-qt))))
 
 (defun faust/post-init-yasnippet ()
   (add-hook 'faust-mode-hook 'spacemacs/load-yasnippet))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -22,7 +22,8 @@
     :init
     (progn
       (setq fsharp-doc-idle-delay .2)
-      (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#"))
+      (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#")
+      (spacemacs|define-jump-handlers fsharp-mode fsharp-ac/gotodefn-at-point))
     :config
     (progn
 
@@ -55,8 +56,6 @@
         "cc" 'compile
 
         "fa" 'fsharp-find-alternate-file
-
-        "gg" 'fsharp-ac/gotodefn-at-point
 
         "ht" 'fsharp-ac/show-tooltip-at-point
 

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -42,7 +42,8 @@
       (defun spacemacs//go-set-tab-width ()
         "Set the tab width."
         (setq-local tab-width go-tab-width))
-      (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width))
+      (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width)
+      (spacemacs|define-jump-handlers go-mode godef-jump))
     :config
     (progn
       (add-hook 'before-save-hook 'gofmt-before-save)
@@ -104,7 +105,6 @@
         "xx" 'spacemacs/go-run-main
         "ga" 'ff-find-other-file
         "gc" 'go-coverage
-        "gg" 'godef-jump
         "tt" 'spacemacs/go-run-test-current-function
         "ts" 'spacemacs/go-run-test-current-suite
         "tp" 'spacemacs/go-run-package-tests

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -49,10 +49,10 @@
 (defun spacemacs-haskell//setup-intero ()
   (add-to-list 'company-backends-haskell-mode
                '(company-intero company-dabbrev-code company-yasnippet))
+  (push 'intero-goto-definition spacemacs-jump-handlers)
   (intero-mode)
   (dolist (mode haskell-modes)
     (spacemacs/set-leader-keys-for-major-mode mode
-      "gg" 'intero-goto-definition
       "hi" 'intero-info
       "ht" 'intero-type-at
       "hT" 'haskell-intero/insert-type

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -111,7 +111,9 @@
        haskell-process-auto-import-loaded-modules t
        ;; Disable haskell-stylish-on-save, as it breaks flycheck highlighting.
        ;; NOTE: May not be true anymore - taksuyu 2015-10-06
-       haskell-stylish-on-save nil))
+       haskell-stylish-on-save nil)
+      (spacemacs|define-jump-handlers haskell-mode
+                               haskell-mode-jump-to-def-or-tag))
     :config
     (progn
       ;; Haskell main editing mode key bindings.
@@ -148,7 +150,6 @@
 
       (dolist (mode haskell-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
-          "gg"  'haskell-mode-jump-to-def-or-tag
           "gi"  'haskell-navigate-imports
           "F"   'haskell-mode-stylish-buffer
 

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -25,7 +25,10 @@
   (use-package eclim
     :defer t
     :diminish eclim-mode
-    :init (add-hook 'java-mode-hook 'eclim-mode)
+    :init
+    (progn
+      (add-hook 'java-mode-hook 'eclim-mode)
+      (add-hook 'spacemacs-jump-handlers-java-mode 'eclim-java-find-declaration))
     :config
     (progn
       (require 'eclimd)
@@ -93,7 +96,6 @@
 
         "ff" 'eclim-java-find-generic
 
-        "gg" 'eclim-java-find-declaration
         "gt" 'eclim-java-find-type
 
         "rc" 'eclim-java-constructor
@@ -146,6 +148,7 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'java-mode))
 
 (defun java/init-java-mode ()
+  (spacemacs|define-jump-handlers java-mode)
   (setq java/key-binding-prefixes '(("me" . "errors")
                                     ("md" . "eclimd")
                                     ("mf" . "find")

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -14,10 +14,11 @@
 
 (defun spacemacs//set-tern-key-bindings (mode)
   "Set the key bindings for tern and the given MODE."
+  (add-hook (intern ("spacemacs-jump-handlers-%S" mode))
+            'tern-find-definitions)
   (spacemacs/set-leader-keys-for-major-mode mode
     "rrV" 'tern-rename-variable
     "hd" 'tern-get-docs
-    "gg" 'tern-find-definition
     "gG" 'tern-find-definition-by-name
     (kbd "C-g") 'tern-pop-find-definition
     "ht" 'tern-get-type))

--- a/layers/+lang/ocaml/funcs.el
+++ b/layers/+lang/ocaml/funcs.el
@@ -22,3 +22,13 @@
     (spacemacs-buffer/warning
      (concat "Cannot find \"opam\" executable. "
              "The ocaml layer won't work properly."))))
+
+(defun spacemacs/merlin-locate ()
+  (interactive)
+  (let ((merlin-locate-in-new-window 'never))
+    (merlin-locate)))
+
+(defun spacemacs/merlin-locate-other-window ()
+  (interactive)
+  (let ((merlin-locate-in-new-window 'always))
+    (merlin-locate)))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -51,6 +51,8 @@
     :defer t
     :init
     (progn
+      (add-hook 'spacemacs-jump-handlers-tuareg-mode
+                'spacemacs/merlin-locate)
       (add-hook 'tuareg-mode-hook 'merlin-mode)
       (setq merlin-completion-with-doc t)
       (push 'merlin-company-backend company-backends-merlin-mode)
@@ -61,14 +63,7 @@
         "en" 'merlin-error-next
         "eN" 'merlin-error-prev
         "gb" 'merlin-pop-stack
-        "gg" #'(lambda ()
-                (interactive)
-                (let ((merlin-locate-in-new-window 'never))
-                  (merlin-locate)))
-        "gG" #'(lambda ()
-                (interactive)
-                (let ((merlin-locate-in-new-window 'always))
-                  (merlin-locate)))
+        "gG" 'spacemacs/merlin-locate-other-window
         "gl" 'merlin-locate-ident
         "gi" 'merlin-switch-to-ml
         "gI" 'merlin-switch-to-mli
@@ -103,6 +98,7 @@
     :defer t
     :init
     (progn
+      (spacemacs|define-jump-handlers tuareg-mode)
       (spacemacs//init-ocaml-opam)
       (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
         "ga" 'tuareg-find-alternate-file

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -29,6 +29,7 @@
     :defer t
     :init
     (progn
+      (spacemacs|define-jump-handlers purescript-mode)
       (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "i="  'purescript-mode-format-imports
@@ -62,6 +63,7 @@
       (customize-set-variable 'psc-ide-add-import-on-completion purescript-add-import-on-completion)
       (customize-set-variable 'psc-ide-rebuild-on-save purescript-enable-rebuild-on-save)
 
+      (add-hook 'spacemacs-jump-handlers-purescript-mode 'psc-ide-goto-definition)
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "mt"  'psc-ide-add-clause
         "mcs" 'psc-ide-case-split
@@ -72,8 +74,7 @@
         "mL"  'psc-ide-load-module
         "mia" 'psc-ide-add-import
         "mis" 'psc-ide-flycheck-insert-suggestion
-        "ht"  'psc-ide-show-type
-        "gg"  'psc-ide-goto-definition))))
+        "ht"  'psc-ide-show-type))))
 
 (defun purescript/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -47,12 +47,13 @@
     (progn
       (setq anaconda-mode-installation-directory
             (concat spacemacs-cache-directory "anaconda-mode"))
-      (add-hook 'python-mode-hook 'anaconda-mode))
+      (add-hook 'python-mode-hook 'anaconda-mode)
+      (add-hook 'spacemacs-jump-handlers-python-mode
+                'anaconda-mode-find-definitions))
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "hh" 'anaconda-mode-show-doc
-        "gg" 'anaconda-mode-find-definitions
         "ga" 'anaconda-mode-find-assignments
         "gb" 'anaconda-mode-go-back
         "gu" 'anaconda-mode-find-references)
@@ -82,9 +83,9 @@
     :defer t
     :init
     (progn
+      (spacemacs|define-jump-handlers cython-mode anaconda-mode-goto)
       (spacemacs/set-leader-keys-for-major-mode 'cython-mode
         "hh" 'anaconda-mode-view-doc
-        "gg" 'anaconda-mode-goto
         "gu" 'anaconda-mode-usages))))
 
 (defun python/post-init-eldoc ()
@@ -259,6 +260,8 @@
     :init
     (progn
       (spacemacs/register-repl 'python 'python-start-or-switch-repl "python")
+
+      (spacemacs|define-jump-handlers python-mode)
 
       (defun python-default ()
         (setq mode-name "Python"

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -31,7 +31,10 @@
 (defun racket/init-racket-mode ()
   (use-package racket-mode
     :defer t
-    :init (spacemacs/register-repl 'racket-mode 'racket-repl "racket")
+    :init
+    (progn
+      (spacemacs/register-repl 'racket-mode 'racket-repl "racket")
+      (spacemacs|define-jump-handlers racket-mode racket-visit-definition))
     :config
     (progn
       ;; smartparens configuration
@@ -87,7 +90,6 @@
       (spacemacs/set-leader-keys-for-major-mode 'racket-mode
         ;; navigation
         "g`" 'racket-unvisit
-        "gg" 'racket-visit-definition
         "gm" 'racket-visit-module
         "gr" 'racket-open-require-path
         ;; doc

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -66,8 +66,11 @@
            ("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . enh-ruby-mode)
            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))
     :interpreter "ruby"
-    :init (setq enh-ruby-deep-indent-paren nil
-                enh-ruby-hanging-paren-deep-indent-level 2)))
+    :init
+    (progn
+      (spacemacs|define-jump-handlers enh-ruby-mode)
+      (setq enh-ruby-deep-indent-paren nil
+            enh-ruby-hanging-paren-deep-indent-level 2))))
 
 (defun ruby/post-init-evil-matchit ()
   (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
@@ -106,7 +109,10 @@
         (add-hook hook 'robe-mode))
       (when (configuration-layer/package-usedp 'company)
         (push 'company-robe company-backends-enh-ruby-mode)
-        (push 'company-robe company-backends-ruby-mode)))
+        (push 'company-robe company-backends-ruby-mode))
+      (spacemacs/add-to-hooks 'robe-jump
+                       '(spacemacs-jump-handlers-ruby-mode
+                         spacemacs-jump-handlers-enh-ruby-mode)))
     :config
     (progn
       (spacemacs|hide-lighter robe-mode)
@@ -117,7 +123,6 @@
         (spacemacs/set-leader-keys-for-major-mode mode
           "'" 'robe-start
           ;; robe mode specific
-          "gg" 'robe-jump
           "hd" 'robe-doc
           "rsr" 'robe-rails-refresh
           ;; inf-enh-ruby-mode
@@ -180,7 +185,10 @@
     :defer t
     :mode (("Appraisals\\'" . ruby-mode)
            ("Puppetfile" . ruby-mode))
-    :init (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "ruby/test")
+    :init
+    (progn
+      (spacemacs|define-jump-handlers ruby-mode)
+      (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "ruby/test"))
     :config (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
               "'" 'ruby-toggle-string-quotes
               "{" 'ruby-toggle-block)))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -63,8 +63,10 @@
   (use-package rust-mode
     :defer t
     :init
-    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-      "=" 'rust-format-buffer)))
+    (progn
+      (spacemacs|define-jump-handlers rust-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+        "=" 'rust-format-buffer))))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode
@@ -93,5 +95,4 @@
     (progn
       (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode eldoc-mode))
       (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "gg" 'racer-find-definition))))
+      (add-hook 'spacemacs-jump-handlers-rust-mode 'racer-find-definition))))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -34,7 +34,8 @@
       (add-hook 'scala-mode-hook 'scala/configure-flyspell)
       (add-hook 'scala-mode-hook 'scala/configure-ensime)
       (when scala-auto-start-ensime
-        (add-hook 'scala-mode-hook 'scala/maybe-start-ensime)))
+        (add-hook 'scala-mode-hook 'scala/maybe-start-ensime))
+      (add-hook 'spacemacs-jump-handlers-scala-mode 'ensime-edit-definition))
     :config
     (progn
       (setq user-emacs-ensime-directory ".cache/ensime")
@@ -136,7 +137,6 @@
         "el"     'ensime-show-all-errors-and-warnings
         "es"     'ensime-stacktrace-switch
 
-        "gg"     'ensime-edit-definition
         "gp"     'ensime-pop-find-definition-stack
         "gi"     'ensime-goto-impl
         "gt"     'ensime-goto-test
@@ -214,8 +214,10 @@
   (use-package scala-mode
     :defer t
     :init
-    (dolist (ext '(".cfe" ".cfs" ".si" ".gen" ".lock"))
-      (add-to-list 'completion-ignored-extensions ext))
+    (progn
+      (dolist (ext '(".cfe" ".cfs" ".si" ".gen" ".lock"))
+        (add-to-list 'completion-ignored-extensions ext))
+      (spacemacs|define-jump-handlers scala-mode))
     :config
     (progn
       ;; Automatically insert asterisk in a comment when enabled

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -24,7 +24,10 @@
 (defun scheme/init-geiser ()
   (use-package geiser
     :commands run-geiser
-    :init (spacemacs/register-repl 'geiser 'geiser-mode-switch-to-repl "geiser")
+    :init
+    (progn
+      (spacemacs|define-jump-handlers scheme-mode geiser-edit-symbol-at-point)
+      (spacemacs/register-repl 'geiser 'geiser-mode-switch-to-repl "geiser"))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'scheme-mode "mc" "compiling")
@@ -47,7 +50,6 @@
         "el" 'lisp-state-eval-sexp-end-of-line
         "er" 'geiser-eval-region
 
-        "gg" 'geiser-edit-symbol-at-point
         "gb" 'geiser-pop-symbol-stack
         "gm" 'geiser-edit-module
         "gn" 'next-error

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -20,43 +20,48 @@
   (use-package tide
     :defer t
     :commands (typescript/jump-to-type-def)
-    :init (progn
-            (evilified-state-evilify tide-references-mode tide-references-mode-map
-              (kbd "C-k") 'tide-find-previous-reference
-              (kbd "C-j") 'tide-find-next-reference
-              (kbd "C-l") 'tide-goto-reference)
+    :init
+    (progn
+      (evilified-state-evilify tide-references-mode tide-references-mode-map
+        (kbd "C-k") 'tide-find-previous-reference
+        (kbd "C-j") 'tide-find-next-reference
+        (kbd "C-l") 'tide-goto-reference)
 
-            (add-hook 'typescript-mode-hook
-                      (lambda ()
-                        (tide-setup)
-                        (flycheck-mode t)
-                        (setq flycheck-check-syntax-automatically '(save mode-enabled))
-                        (eldoc-mode t)
-                        (when (configuration-layer/package-usedp 'company)
-                          (company-mode-on)))))
-    :config (progn
-              (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")
-              (spacemacs/declare-prefix-for-mode 'typescript-mode "mh" "help")
-              (spacemacs/declare-prefix-for-mode 'typescript-mode "mn" "name")
-              (spacemacs/declare-prefix-for-mode 'typescript-mode "mr" "rename")
-              (spacemacs/declare-prefix-for-mode 'typescript-mode "mS" "server")
-              (spacemacs/declare-prefix-for-mode 'typescript-mode "ms" "send")
+      ;; FIXME -- this is not good!
+      (add-hook 'typescript-mode-hook
+                (lambda ()
+                  (tide-setup)
+                  (flycheck-mode t)
+                  (setq flycheck-check-syntax-automatically '(save mode-enabled))
+                  (eldoc-mode t)
+                  (when (configuration-layer/package-usedp 'company)
+                    (company-mode-on))))
 
-              (defun typescript/jump-to-type-def()
-                (interactive)
-                (tide-jump-to-definition t))
+      (add-hook 'spacemacs-jump-handlers-typescript-mode 'tide-jump-to-definition))
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mn" "name")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mr" "rename")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mS" "server")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "ms" "send")
 
-              (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
-                "gb" 'tide-jump-back
-                "gg" 'tide-jump-to-definition
-                "gt" 'typescript/jump-to-type-def
-                "gu" 'tide-references
-                "hh" 'tide-documentation-at-point
-                "rr" 'tide-rename-symbol
-                "Sr" 'tide-restart-server))))
+      (defun typescript/jump-to-type-def()
+        (interactive)
+        (tide-jump-to-definition t))
+
+      (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
+        "gb" 'tide-jump-back
+        "gt" 'typescript/jump-to-type-def
+        "gu" 'tide-references
+        "hh" 'tide-documentation-at-point
+        "rr" 'tide-rename-symbol
+        "Sr" 'tide-restart-server))))
 
 (defun typescript/post-init-web-mode ()
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . web-mode))
+  ;; FIXME -- this is not good!
   (add-hook 'web-mode-hook
             (lambda ()
               (when (string-equal "tsx" (file-name-extension buffer-file-name))
@@ -70,9 +75,12 @@
 (defun typescript/init-typescript-mode ()
   (use-package typescript-mode
     :defer t
-    :config (progn
-              (when typescript-fmt-on-save
-                (add-hook 'typescript-mode-hook 'typescript/fmt-before-save-hook))
-              (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
-                "="  'typescript/format
-                "sp" 'typescript/open-region-in-playground))))
+    :init
+    (spacemacs|define-jump-handlers typescript-mode)
+    :config
+    (progn
+      (when typescript-fmt-on-save
+        (add-hook 'typescript-mode-hook 'typescript/fmt-before-save-hook))
+      (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
+        "="  'typescript/format
+        "sp" 'typescript/open-region-in-playground))))

--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -11,8 +11,20 @@
 
 (setq spacemacs-misc-packages
       '(
+        dumb-jump
         request
         ))
+
+(defun spacemacs-misc/init-dumb-jump ()
+  (use-package dumb-jump
+    :defer t
+    :init
+    (progn
+      ;; Since it's dumb, we add it to the end of the default jump handlers. At
+      ;; the time of writing it is the only default jump handler. (gtags remains
+      ;; mode-local)
+      (add-to-list 'spacemacs-default-jump-handlers 'dumb-jump-go 'append)
+      (add-hook 'prog-mode-hook 'dumb-jump-mode))))
 
 (defun spacemacs-misc/init-request ()
   (setq request-storage-directory

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -21,14 +21,19 @@
 (defun spacemacs/helm-gtags-define-keys-for-mode (mode)
   "Define key bindings for the specific MODE."
   (when (fboundp mode)
-    (let ((hook (intern (concat (symbol-name mode) "-hook"))))
+    (let ((hook (intern (format "%S-hook" mode))))
       (add-hook hook 'helm-gtags-mode))
+    ;; `helm-gtags-dwim' is added to the end of the mode-specific jump handlers
+    ;; Some modes have more sophisticated jump handlers that go to the beginning
+    ;; It might be possible to add `helm-gtags-dwim' instead to the default
+    ;; handlers, if it does a reasonable job in ALL modes.
+    (let ((hook (intern (format "spacemacs-jump-handlers-%S" mode))))
+      (add-hook hook 'helm-gtags-dwim 'append))
     (spacemacs/set-leader-keys-for-major-mode mode
       "gc" 'helm-gtags-create-tags
       "gd" 'helm-gtags-find-tag
       "gD" 'helm-gtags-find-tag-other-window
       "gf" 'helm-gtags-select-path
-      "gg" 'helm-gtags-dwim
       "gG" 'helm-gtags-dwim-other-window
       "gi" 'helm-gtags-tags-in-this-function
       "gl" 'helm-gtags-parse-file


### PR DESCRIPTION
According to discussion with @syl20bnr.

This commit defines:

- spacemacs-default-jump-handlers: a list of functions that can jump to
  definition in ALL modes.

- spacemacs-jump-handlers-MODE: a list of functions that can jump to
  definition in MODE.

- spacemacs-jump-handlers: a buffer-local list of functions that can
  jump to definition. This is made up of the values of the two previous
  variables whenever a given major mode is activated.

- spacemacs/jump-to-definition: a function that tries each function in
  spacemacs-jump-handlers in order, and stops when one of them takes us
  somewhere new.

- spacemacs|define-jump-handlers: a macro that
  * defines spacemacs-jump-handlers-MODE, possibly filled with initial
    functions
  * defines a function that is added to the hook of the given MODE
  * binds “SPC m g g” of that MODE to spacemacs/jump-to-definition

This is an attempt to harmonize all the different approaches to jumping.
Specifically,

- Existing intelligent jump packages that work for only a single mode
  should go to the beginning of spacemacs-jump-handlers-MODE. E.g.
  anaconda for python, ensime for scala, etc.

- Packages like gtags that work for several modes (but potentially not
  all) and which is dumber than the intelligent jumpers should go the
  the END of spacemacs-jump-handlers-MODE.

- Packages like dumb-jump that work for all modes should go to
  spacemacs-default-jump-handlers.

In all cases the order of the jump handlers in each list should be from
most to least intelligent.

Fixes #6619, and to some degree supersedes #6164 (CC @axyz re: dumb-jump)