### PR TITLE
Link format fix terraform layer README

### DIFF
--- a/layers/+tools/terraform/README.org
+++ b/layers/+tools/terraform/README.org
@@ -8,7 +8,7 @@
 
 * Description
 This layer provides syntax support for Terraform =.tf= files using
-[terraform-mode](https://github.com/syohex/emacs-terraform-mode).
+[[https://github.com/syohex/emacs-terraform-mode][terraform-mode]].
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
* Change .md formatted link to .org formatted link to address display
  issue on [terraform layer page](http://spacemacs.org/layers/+config-files/terraform/README.html)