### PR TITLE
Improve keybinding for beginning/end of line in pdf-tools

### DIFF
--- a/layers/+tools/pdf-tools/packages.el
+++ b/layers/+tools/pdf-tools/packages.el
@@ -47,8 +47,8 @@
         ("K"  pdf-view-previous-page)
         ("u"  pdf-view-scroll-down-or-previous-page)
         ("d"  pdf-view-scroll-up-or-next-page)
-        ("0"  scroll-right)
-        ("$"  scroll-left)
+        ("0"  image-bol)
+        ("$"  image-eol)
         ;; Scale/Fit
         ("W"  pdf-view-fit-width-to-window)
         ("H"  pdf-view-fit-height-to-window)
@@ -106,8 +106,8 @@
       ;; TODO: Make `/', `?' and `n' work like in Evil
       (evilified-state-evilify pdf-view-mode pdf-view-mode-map
         ;; Navigation
-        "0"  'scroll-right
-        "$"  'scroll-left
+        "0"  'image-bol
+        "$"  'image-eol
         "j"  'pdf-view-next-line-or-next-page
         "k"  'pdf-view-previous-line-or-previous-page
         "l"  'image-forward-hscroll


### PR DESCRIPTION
`image-bol` and `image-eol` are more appropriate than`scroll-left` and `scroll-right`.