### PR TITLE
Add package archive fallback mechanism

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -333,11 +333,12 @@ The returned list has a `package-archives' compliant format."
 Available return values are available and unavailable."
   (let ((url (format "%sarchive-contents"
                      (cdr (assoc archive package-archives))))
-        state)
+        (state 'unavailable))
     (condition-case nil
-        (if (url-http-file-exists-p url)
-            (setq state 'available)
-          (setq state 'unavailable))
+        (when (or (and (string-prefix-p "/" url)
+                       (file-readable-p url))
+                  (url-http-file-exists-p url))
+          (setq state 'available))
       ((error) (setq state 'unavailable)))
     state))
 

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -60,9 +60,6 @@ or `spacemacs'.")
 possible. Set it to nil if you have no way to use HTTPS in your
 environment, otherwise it is strongly recommended to let it set to t.")
 
-(defvar dotspacemacs-elpa-timeout 5
-  "Maximum allowed time in seconds to contact an ELPA repository.")
-
 (defvar dotspacemacs-elpa-subdirectory nil
   "If non-nil, a form that evaluates to a package directory. For
 example, to use different package directories for different Emacs

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -197,15 +197,6 @@
 ;; configuration-layer/retrieve-package-archives
 ;; ---------------------------------------------------------------------------
 
-(ert-deftest test-retrieve-package-archives--catch-time-out-error ()
-  (let ((package-archives '(("gnu" . "https://elpa.gnu.org/packages/")))
-        (configuration-layer--package-archives-refreshed nil)
-        (dotspacemacs-elpa-timeout -1))
-    (mocker-let
-        ((message (format-string &rest args)
-                  ((:record-cls 'mocker-stub-record :output nil))))
-      (configuration-layer/retrieve-package-archives))))
-
 (ert-deftest test-retrieve-package-archives--catch-connection-errors ()
   (let ((package-archives '(("gnu" . "https://elpa.gnu.org/packages/")))
         (configuration-layer--package-archives-refreshed nil))
@@ -219,7 +210,9 @@
                                        :service 443
                                        :nowait nil))))
               ((symbol-function 'message) 'ignore))
-      (configuration-layer/retrieve-package-archives))))
+      (should-error
+       (configuration-layer/retrieve-package-archives)
+       :type 'error))))
 
 ;; ---------------------------------------------------------------------------
 ;; configuration-layer//select-packages

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -199,7 +199,8 @@
 
 (ert-deftest test-retrieve-package-archives--catch-connection-errors ()
   (let ((package-archives '(("gnu" . "https://elpa.gnu.org/packages/")))
-        (configuration-layer--package-archives-refreshed nil))
+        (configuration-layer--package-archives-refreshed nil)
+        (configuration-layer-fallback-package-archives nil))
     (cl-letf (((symbol-function 'url-retrieve-synchronously)
                (lambda (x)
                  (signal 'file-error '("make client process failed"


### PR DESCRIPTION
Seeing all these issues with package installation due to MELPA availability problems I decided to improve status check for all elpa archives and error about archive being unavailable instead of showing errors like 'package xxx is not available' in the future.

Also I removed timeout heuristic as it's not 100% accurate. I don't see any reason for it to be here once `configuration-layer-check-archive-status` is used. 

Note that `configuration-layer-check-archive-status` is a little bit beefed (more than we need at this point), but it might become handy in future. 

Oh, and I am not sure about the error message though. @syl20bnr, you might want to improve it. 😸 

P. S. Hope I didn't miss anything. 

P. P. S. Somewhat fixes #6836. Another related issue is #4453.
