### PR TITLE
Further improve gtags layer

### DIFF
--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -65,7 +65,7 @@
   (spacemacs|add-company-hook nasm-mode))
 
 (defun asm/post-init-ggtags ()
-  (add-hook 'asm-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'asm-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun asm/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -92,8 +92,8 @@
     (spacemacs/add-to-hooks 'c-c++/load-clang-args '(c-mode-hook c++-mode-hook))))
 
 (defun c-c++/post-init-ggtags ()
-  (add-hook 'c-mode-hook #'spacemacs/ggtags-mode-enable)
-  (add-hook 'c++-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'c-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
+  (add-hook 'c++-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun c-c++/init-gdb-mi ()
   (use-package gdb-mi

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -248,7 +248,7 @@
   (spacemacs|add-company-hook cider-repl-mode))
 
 (defun clojure/post-init-ggtags ()
-  (add-hook 'clojure-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'clojure-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun clojure/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'clojure-mode))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -28,7 +28,7 @@
     "sI" 'spacemacs/helm-slime))
 
 (defun common-lisp/post-init-ggtags ()
-  (add-hook 'common-lisp-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'common-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun common-lisp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'common-lisp-mode))

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -93,7 +93,7 @@
   (add-hook 'csharp-mode-hook 'turn-on-evil-matchit-mode))
 
 (defun csharp/post-init-ggtags ()
-  (add-hook 'csharp-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'csharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun csharp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'csharp-mode))

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -37,7 +37,7 @@
     :init (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path)))
 
 (defun d/post-init-ggtags ()
-  (add-hook 'd-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'd-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun d/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'd-mode))

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -161,7 +161,7 @@
          :actions '(insert))))))
 
 (defun elixir/post-init-ggtags ()
-  (add-hook 'elixir-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'elixir-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun elixir/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'elixir-mode))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -142,7 +142,7 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'emacs-lisp-mode))
 
 (defun emacs-lisp/post-init-ggtags ()
-  (add-hook 'emacs-lisp-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'emacs-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun emacs-lisp/post-init-semantic ()
   (add-hook 'emacs-lisp-mode-hook 'semantic-mode)

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -46,7 +46,7 @@
   (spacemacs/add-flycheck-hook 'erlang-mode))
 
 (defun erlang/post-init-ggtags ()
-  (add-hook 'erlang-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'erlang-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun erlang/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'erlang-mode))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -73,7 +73,7 @@
         "xf" 'fsharp-run-executable-file))))
 
 (defun fsharp/post-init-ggtags ()
-  (add-hook 'fsharp-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'fsharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun fsharp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'fsharp-mode))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -147,7 +147,7 @@
     (add-hook 'go-mode-hook 'spacemacs//go-enable-gometalinter t)))
 
 (defun go/post-init-ggtags ()
-  (add-hook 'go-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun go/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'go-mode))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -56,7 +56,7 @@
     :defer t))
 
 (defun haskell/post-init-ggtags ()
-  (add-hook 'haskell-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'haskell-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun haskell/init-ghc ()
   (use-package ghc

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -140,7 +140,7 @@
     (push 'company-emacs-eclim company-backends-java-mode)))
 
 (defun java/post-init-ggtags ()
-  (add-hook 'java-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'java-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun java/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'java-mode))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -62,7 +62,7 @@
     (spacemacs/add-flycheck-hook mode)))
 
 (defun javascript/post-init-ggtags ()
-  (add-hook 'js2-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun javascript/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'js2-mode))

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -177,7 +177,7 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'latex-mode))
 
 (defun latex/post-init-ggtags ()
-  (add-hook 'latex-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'latex-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun latex/post-init-smartparens ()
   (add-hook 'LaTeX-mode-hook 'smartparens-mode))

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -30,7 +30,7 @@
   (add-hook 'lua-mode-hook 'company-mode))
 
 (defun lua/post-init-ggtags ()
-  (add-hook 'lua-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'lua-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun lua/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'lua-mode))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -41,7 +41,7 @@
           (flycheck-ocaml-setup))))))
 
 (defun ocaml/post-init-ggtags ()
-  (add-hook 'ocaml-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'ocaml-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun ocaml/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'ocaml-mode))

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -34,7 +34,7 @@
               "sr" 'octave-send-region)))
 
 (defun octave/post-init-ggtags ()
-  (add-hook 'octave-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'octave-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun octave/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'octave-mode))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -38,7 +38,7 @@
   (spacemacs/add-flycheck-hook 'php-mode))
 
 (defun php/post-init-ggtags ()
-  (add-hook 'php-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'php-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun php/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'php-mode))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -108,7 +108,7 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'python-mode))
 
 (defun python/post-init-ggtags ()
-  (add-hook 'python-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'python-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun python/init-helm-pydoc ()
   (use-package helm-pydoc

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -23,7 +23,7 @@
                  (company-quickhelp-mode -1))) t))
 
 (defun racket/post-init-ggtags ()
-  (add-hook 'racket-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'racket-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun racket/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'racket-mode))

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -78,7 +78,7 @@
   (spacemacs/add-flycheck-hook 'enh-ruby-mode))
 
 (defun ruby/post-init-ggtags ()
-  (add-hook 'ruby-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'ruby-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun ruby/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'ruby-mode))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -30,7 +30,7 @@
     :init (add-hook 'flycheck-mode-hook #'flycheck-rust-setup)))
 
 (defun rust/post-init-ggtags ()
-  (add-hook 'rust-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'rust-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun rust/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'rust-mode))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -275,7 +275,7 @@ replace it with the unicode arrow."
             scala-indent:default-run-on-strategy scala-indent:operator-strategy))))
 
 (defun scala/post-init-ggtags ()
-  (add-hook 'scala-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'scala-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun scala/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'scala-mode))

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -76,7 +76,7 @@
         "ss" 'geiser-set-scheme))))
 
 (defun scheme/post-init-ggtags ()
-  (add-hook 'scheme-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'scheme-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun scheme/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'scheme-mode))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -64,7 +64,7 @@
       (add-hook 'sh-mode-hook 'spacemacs//setup-shell))))
 
 (defun shell-scripts/post-init-ggtags ()
-  (add-hook 'sh-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'sh-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun shell-scripts/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'sh-mode))

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -42,7 +42,7 @@
     :defer t))
 
 (defun vimscript/post-init-ggtags ()
-  (add-hook 'vimrc-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'vimrc-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun vimscript/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'vimrc-mode))

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -47,7 +47,7 @@
       "z"  'windows-scripts/dos-outline)))
 
 (defun windows-scripts/post-init-ggtags ()
-  (add-hook 'dos-mode-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'dos-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun windows-scripts/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'dos-mode))

--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -11,6 +11,7 @@
        - [[Install with recommended features][Install with recommended features]]
        - [[Configure your environment to use pygments and ctags][Configure your environment to use pygments and ctags]]
    - [[Emacs Configuration][Emacs Configuration]]
+     - [[Disabling by default][Disabling by default]]
  - [[Usage][Usage]]
      - [[Language Support][Language Support]]
        - [[Built-in languages][Built-in languages]]
@@ -117,6 +118,18 @@ will need to add =gtags= to the existing =dotspacemacs-configuration-layers=.
            ;; ...
           ))
 #+end_src
+
+*** Disabling by default
+If =ggtags-mode= is too intrusive you can disable it by default, by setting the
+layer variable =gtags-enable-by-default= to =nil=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((gtags :variables gtags-enable-by-default t)))
+#+END_SRC
+
+This variable can also be set as a file-local or directory-local variable for
+additional control per project.
 
 * Usage
 

--- a/layers/+tags/gtags/config.el
+++ b/layers/+tags/gtags/config.el
@@ -1,0 +1,13 @@
+;;; config.el --- gtags configuration File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar gtags-enable-by-default t
+  "Whether or not to enable ggtags-mode.")

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -9,7 +9,6 @@
 ;;
 ;;; License: GPLv3
 
-
 (defun helm-gtags-dwim-other-window ()
   "helm-gtags-dwim in the other window"
   (interactive)
@@ -18,11 +17,28 @@
         (split-width-threshold 140))
     (helm-gtags-dwim)))
 
+(defun spacemacs/helm-gtags-maybe-dwim ()
+  "Runs `helm-gtags-dwim' if `gtags-enable-by-default' is on.
+Otherwise does nothing."
+  (interactive)
+  (when gtags-enable-by-default
+    (call-interactively 'helm-gtags-dwim)))
+
 (defun spacemacs/helm-gtags-define-keys-for-mode (mode)
   "Define key bindings for the specific MODE."
   (when (fboundp mode)
-    (let ((hook (intern (concat (symbol-name mode) "-hook"))))
-      (add-hook hook 'helm-gtags-mode))
+    ;; The functionality of `helm-gtags-mode' is pretty much entirely superseded
+    ;; by `ggtags-mode', so we don't add this hook
+    ;; (let ((hook (intern (concat (symbol-name mode) "-hook"))))
+    ;;   (add-hook hook 'helm-gtags-mode))
+
+    ;; `helm-gtags-dwim' is added to the end of the mode-specific jump handlers
+    ;; Some modes have more sophisticated jump handlers that go to the beginning
+    ;; It might be possible to add `helm-gtags-dwim' instead to the default
+    ;; handlers, if it does a reasonable job in ALL modes.
+    (let ((hook (intern (format "spacemacs-jump-handlers-%S" mode))))
+      (add-hook hook 'spacemacs/helm-gtags-maybe-dwim 'append))
+
     (spacemacs/set-leader-keys-for-major-mode mode
       "gc" 'helm-gtags-create-tags
       "gd" 'helm-gtags-find-tag
@@ -45,5 +61,6 @@
 
 For eldoc, ggtags advises the eldoc function at the lowest priority
 so that if the major mode has better support it will use it first."
-  (ggtags-mode 1)
-  (eldoc-mode 1))
+  (when gtags-enable-by-default
+    (ggtags-mode 1)
+    (eldoc-mode 1)))

--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -23,10 +23,21 @@
     :init
     (progn
       ;; modes that do not have a layer, add here.
-      (add-hook 'awk-mode-hook #'spacemacs/ggtags-mode-enable)
-      (add-hook 'shell-mode-hook #'spacemacs/ggtags-mode-enable)
-      (add-hook 'tcl-mode-hook #'spacemacs/ggtags-mode-enable)
-      (add-hook 'vhdl-mode-hook #'spacemacs/ggtags-mode-enable))))
+      (add-hook 'awk-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
+      (add-hook 'shell-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
+      (add-hook 'tcl-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
+      (add-hook 'vhdl-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+    :config
+    (when (configuration-layer/package-usedp 'helm-gtags)
+      ;; If anyone uses helm-gtags, they would want to use these key bindings.
+      ;; These are bound in `ggtags-mode-map', since the functionality of
+      ;; `helm-gtags-mode' is basically entirely contained within
+      ;; `ggtags-mode-map' --- this way we don't have to enable both.
+      ;; Note: all of these functions are autoloadable.
+      (define-key ggtags-mode-map (kbd "M-.") 'helm-gtags-dwim)
+      (define-key ggtags-mode-map (kbd "C-x 4 .") 'helm-gtags-find-tag-other-window)
+      (define-key ggtags-mode-map (kbd "M-,") 'helm-gtags-pop-stack)
+      (define-key ggtags-mode-map (kbd "M-*") 'helm-gtags-pop-stack))))
 
 (defun gtags/init-helm-gtags ()
   (use-package helm-gtags
@@ -43,11 +54,4 @@
       (spacemacs/helm-gtags-define-keys-for-mode 'awk-mode)
       (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
       (spacemacs/helm-gtags-define-keys-for-mode 'compilation-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode))
-    :config
-    (progn
-      ;; if anyone uses helm-gtags, they would want to use these key bindings
-      (define-key helm-gtags-mode-map (kbd "M-.") 'helm-gtags-dwim)
-      (define-key helm-gtags-mode-map (kbd "C-x 4 .") 'helm-gtags-find-tag-other-window)
-      (define-key helm-gtags-mode-map (kbd "M-,") 'helm-gtags-pop-stack)
-      (define-key helm-gtags-mode-map (kbd "M-*") 'helm-gtags-pop-stack))))
+      (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode))))


### PR DESCRIPTION
- Add option to disable by default
- Use local-vars hook to allow per-project enable/disable
- Don’t enable helm-gtags-mode (no need)
- Move emacs bindings from helm-gtags-mode-map to ggtags-mode-map

Fixes https://github.com/syl20bnr/spacemacs/issues/6819