### PR TITLE
clojure: Add more SPC m bindings

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -132,12 +132,15 @@ As this state works the same for all files, the documentation is in global
 
 *** Goto
 
-| Key Binding | Description   |
-|-------------+---------------|
-| ~SPC m g b~ | go back       |
-| ~SPC m g g~ | goto var      |
-| ~SPC m g e~ | goto error    |
-| ~SPC m g r~ | goto resource |
+| Key Binding | Description           |
+|-------------+-----------------------|
+| ~SPC m g b~ | go back               |
+| ~SPC m g C~ | browse classpath      |
+| ~SPC m g g~ | goto var              |
+| ~SPC m g e~ | goto error            |
+| ~SPC m g r~ | goto resource         |
+| ~SPC m g n~ | browse namespaces     |
+| ~SPC m g N~ | browse all namespaces |
 
 *** REPL
 
@@ -175,6 +178,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m T f~ | toggle REPL font-locking    |
 | ~SPC m T p~ | toggle REPL pretty-printing |
 | ~SPC m T i~ | toggle indentation style    |
+| ~SPC m T t~ | toggle auto test mode       |
 
 *** Debugging
 
@@ -183,6 +187,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m d r~ | reload namepspaces             |
 | ~SPC m d b~ | instrument expression at point |
 | ~SPC m d e~ | display last stacktrace        |
+| ~SPC m d E~ | toggle englighten mode         |
 | ~SPC m d i~ | inspect expression at point    |
 
 *** Refactoring

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -175,6 +175,7 @@ As this state works the same for all files, the documentation is in global
 
 | Key Binding | Description                 |
 |-------------+-----------------------------|
+| ~SPC m T e~ | toggle englighten mode      |
 | ~SPC m T f~ | toggle REPL font-locking    |
 | ~SPC m T p~ | toggle REPL pretty-printing |
 | ~SPC m T i~ | toggle indentation style    |
@@ -187,7 +188,6 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m d r~ | reload namepspaces             |
 | ~SPC m d b~ | instrument expression at point |
 | ~SPC m d e~ | display last stacktrace        |
-| ~SPC m d E~ | toggle englighten mode         |
 | ~SPC m d i~ | inspect expression at point    |
 
 *** Refactoring

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -136,6 +136,7 @@
 
           "Tf" 'spacemacs/cider-toggle-repl-font-locking
           "Tp" 'spacemacs/cider-toggle-repl-pretty-printing
+          "Tt" 'cider-auto-test-mode
 
           "ta" 'spacemacs/cider-test-run-all-tests
           "tb" 'cider-test-show-report

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -111,9 +111,12 @@
           "fb" 'cider-format-buffer
 
           "gb" 'cider-pop-back
+          "gC" 'cider-classpath
           "ge" 'cider-jump-to-compilation-error
           "gg" 'cider-find-var
           "gr" 'cider-jump-to-resource
+          "gn" 'cider-browse-ns
+          "gN" 'cider-browse-ns-all
 
           "'"  'cider-jack-in
           "sb" 'cider-load-buffer
@@ -148,6 +151,7 @@
 
           "db" 'cider-debug-defun-at-point
           "de" 'spacemacs/cider-display-error-buffer
+          "dE" 'cider-enlighten-mode
           "di" 'cider-inspect))
 
       (evil-define-key 'normal cider-repl-mode-map

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -137,6 +137,7 @@
           "ss" 'cider-switch-to-repl-buffer
           "sx" 'cider-refresh
 
+          "Te" 'cider-enlighten-mode
           "Tf" 'spacemacs/cider-toggle-repl-font-locking
           "Tp" 'spacemacs/cider-toggle-repl-pretty-printing
           "Tt" 'cider-auto-test-mode
@@ -151,7 +152,6 @@
 
           "db" 'cider-debug-defun-at-point
           "de" 'spacemacs/cider-display-error-buffer
-          "dE" 'cider-enlighten-mode
           "di" 'cider-inspect))
 
       (evil-define-key 'normal cider-repl-mode-map


### PR DESCRIPTION
Possible fix for issue #5667.

I've added all extra cider commands that my version supports (`0.14.0snapshot`). These include:
* cider-classpath
* cider-browse-ns
* cider-browse-ns-all
* cider-auto-test-mode
* cider-enlighten-mode