### PR TITLE
Allow customization of spaceline additional segments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ my-org/
 org-files/
 semanticdb/
 edts/
+/recentf
 .recentf
 .recentf~
 projectile.cache

--- a/layers/+spacemacs/spacemacs-ui-visual/config.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/config.el
@@ -1,0 +1,22 @@
+;;; config.el --- Spacemacs UI Visual Layer configuration File
+;;
+;; Copyright (c) 2016 Sylvain Benner & Contributors
+;;
+;; Author: Riccardo Murri <riccardo.murri@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defcustom spacemacs-spaceline-additional-segments
+  '((new-version :when active))
+  "Additional segments for the Spacemacs modeline.
+
+They are inserted in the modeline between `global' and
+`buffer-position'.
+
+Must be a list of valid segments; see `spaceline-install' for
+more information on what constitutes a valid segment."
+  :type '(repeat sexp)
+  :group 'spacemacs)

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -310,7 +310,8 @@
           (spacemacs-powerline-new-version
            (spacemacs/get-new-version-lighter-face
             spacemacs-version spacemacs-new-version))))
-      (spaceline-spacemacs-theme '(new-version :when active))
+      (apply #'spaceline-spacemacs-theme
+             spacemacs-spaceline-additional-segments)
       ;; Additional spacelines
       (when (package-installed-p 'helm)
         (spaceline-helm-mode t))


### PR DESCRIPTION
Introduce a new customization variable
`spacemacs-spaceline-additional-segments', which is a list of the
additional segments that should be inserted in the modeline when it is
initialized.

(This is basically the same patch as PR #6846 but applied to the "develop"
branch instead of "master".)