### PR TITLE
Update emacs-eclim package name

### DIFF
--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -12,7 +12,7 @@
 (setq java-packages
       '(
         company
-        emacs-eclim
+        eclim
         ggtags
         helm-gtags
         (java-mode :location built-in)
@@ -21,7 +21,7 @@
 (defun java/post-init-company ()
   (spacemacs|add-company-hook java-mode))
 
-(defun java/init-emacs-eclim ()
+(defun java/init-eclim ()
   (use-package eclim
     :defer t
     :diminish eclim-mode


### PR DESCRIPTION
I think MELPA has an `old-names` back
[compatibility](https://github.com/melpa/melpa/issues/4159) measure for
cases like this, but for now it isn't working. And it's breaking all new
installs that use the java layer.