### PR TITLE
Don't use golden ratio mode in Idris holes buffer

### DIFF
--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -102,7 +102,11 @@
         "sp" 'idris-load-backward-line
         "sP" 'spacemacs/idris-load-backward-line-and-focus
         "ss" 'idris-pop-to-repl
-        "sq" 'idris-quit)))
+        "sq" 'idris-quit)
+
+      (with-eval-after-load 'golden-ratio
+        (add-to-list 'golden-ratio-exclude-buffer-names
+                      "*idris-notes*"))))
 
   ;; open special buffers in motion state so they can be closed with ~q~
   (evil-set-initial-state 'idris-compiler-notes-mode 'motion)


### PR DESCRIPTION
Drawing inspiration from the Agda layer https://github.com/syl20bnr/spacemacs/blob/b2d108877c290d6965f45e34df437346a47a90ea/layers/%2Blang/agda/packages.el#L80-L82
This change makes it so that the Idris type holes buffer does not open in golden ratio mode.