### PR TITLE
Fix Typo on Prodigy Readme

### DIFF
--- a/layers/+tools/prodigy/README.org
+++ b/layers/+tools/prodigy/README.org
@@ -14,7 +14,7 @@
 This layer adds support for the [[https://github.com/rejeep/prodigy.el][prodigy]] package to manage external services from
 within Emacs, check the package's documentation for more details
 
-It is recommended to put to put your prodigy services in the
+It is recommended to put your prodigy services in the
 =dotspacemacs/user-config= part of your =~/.spacemacs= file.
 
 * Install


### PR DESCRIPTION
Just a simple typo fix for the Prodigy readme file.