### PR TITLE
nixos: inhibit spacemacs indation in nix-mode

### DIFF
--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -24,7 +24,8 @@
       "h>" 'helm-nixos-options)))
 
 (defun nixos/init-nix-mode ()
-  (use-package nix-mode))
+  (use-package nix-mode)
+  (add-to-list 'spacemacs-indent-sensitive-modes 'nix-mode))
 
 (defun nixos/init-nixos-options ()
   (use-package nixos-options))


### PR DESCRIPTION
previously [this](https://github.com/NixOS/nix/issues/828#issuecomment-240698002) happened. Turns out it  was because of spacemacs' default indentation.

I looked into resolving the TODO (in the definition of the inhibit function), but I was not entirely sure where to put it in the other layers.