### PR TITLE
Automatically toggle emacs-state when artist-mode is toggled

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing/funcs.el
@@ -10,6 +10,17 @@
 ;;; License: GPLv3
 
 
+;; artist-mode
+
+(defun spacemacs/artist-mode-toggle-emacs-state ()
+  "Toggle emacs-state when `artist-mode' is toggled."
+  (unless (eq dotspacemacs-editing-style 'emacs)
+    (if artist-mode
+        (unless (evil-emacs-state-p)
+          (evil-emacs-state))
+      (evil-exit-emacs-state))))
+
+
 ;; smartparens
 
 (defun spacemacs/smartparens-pair-newline (id action context)

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -11,6 +11,7 @@
 
 (setq spacemacs-editing-packages
       '(aggressive-indent
+        (artist :location built-in)
         avy
         (bracketed-paste :toggle (version<= emacs-version "25.0.92"))
         clean-aindent-mode
@@ -47,6 +48,12 @@
     (progn
       (add-hook 'diff-auto-refine-mode-hook 'spacemacs/toggle-aggressive-indent-off)
       (spacemacs|diminish aggressive-indent-mode " Ⓘ" " I"))))
+
+(defun spacemacs-editing/init-artist ()
+  ;; `artist-mode' utilizes the mouse, and works better in emacs state, so we
+  ;; automatically toggle emacs state on/off together with artist-mode (unless
+  ;; the editing style is emacs)
+  (add-hook 'artist-mode-hook #'spacemacs/artist-mode-toggle-emacs-state))
 
 (defun spacemacs-editing/init-avy ()
   (use-package avy


### PR DESCRIPTION
I found that when using `artist-mode`, I always switch to emacs-state. I think others will also want that, so here's a PR :)

Unless the user uses emacs editing style, then emacs-state will be enabled when `artist-mode` is enabled, and disabled when `artist-mode` is disabled.

I think we should document this behavior, because it would be surprising at first, but I don't know where. If somebody points out where to add the documentation, I will write it. On the other hand, who'se going to read and remember such an anecdotal piece of documentation?
