### PR TITLE
Share installed packages among multiple users

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -124,6 +124,12 @@ when the current branch is not `develop'. Note that checking for
 new versions works via git commands, thus it calls GitHub services
 whenever you start Emacs.")
 
+(defvar dotspacemacs-use-shared-packages nil
+  "If non-`nil', then look in all directories of `package-directory-list' when
+looking for the installed directory of a package which was not found under
+`package-user-dir'. Site administrators can install packages in one of
+these system-wide directories so that all users at the site can benefit.")
+
 (defvar dotspacemacs-configuration-layers '(emacs-lisp)
   "List of configuration layers to load.")
 

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -36,12 +36,18 @@
   (run-hooks 'text-mode-hook))
 
 (defun spacemacs//get-package-directory (pkg)
-  "Return the directory of PKG. Return nil if not found."
-  (let ((elpa-dir (file-name-as-directory package-user-dir)))
-    (when (file-exists-p elpa-dir)
-      (let* ((pkg-match (concat (symbol-name pkg) "-[0-9]+"))
-             (dir (car (directory-files elpa-dir 'full pkg-match))))
-        (when dir (file-name-as-directory dir))))))
+  "Return the installed directory of PKG. Return `nil' if not found."
+  (let ((directories (cons package-user-dir
+                           (and dotspacemacs-use-shared-packages
+                                package-directory-list)))
+        elpa-dir dir)
+    (while (and (not dir) directories)
+      (setq elpa-dir (pop directories))
+      (when (file-exists-p elpa-dir)
+        (let* ((pkg-match (concat (symbol-name pkg) "-[0-9]+"))
+               (dir (car (directory-files elpa-dir 'full pkg-match))))
+          (when dir (setq dir (file-name-as-directory dir))))))
+    dir))
 
 (defun spacemacs/mplist-get (plist prop)
   "Get the values associated to PROP in PLIST, a modified plist.


### PR DESCRIPTION
This PR allows me to install packages once which then can be used by all my colleagues without each
of them having to install the same pacakges.  There are potentially hundreds of my colleagues
who can be using the same shared file system so that the ability to share files is important not
only to save disk space, but also to reduce startup time.

Created dotspacemacs-use-shared-packages user option, so that if it is
set to non-nil, then directories listed in package-directory-list are
also searched for installed packages in addition to package-user-dir.
Site administrator can then install packages in one or more of the
directories in package-directory-list so that all users at the site can
share the same installed packages without each user having to install
them.

This change has no impact unless dotspacemacs-use-shared-packages is
explicitly changed to non-nil from the default value of nil.
