### PR TITLE
rotate-windows and -backwards, comment correction

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -229,9 +229,9 @@ automatically applied to."
 
 ;; from magnars modified by ffevotte for dedicated windows support
 (defun spacemacs/rotate-windows (count)
-  "Rotate your windows.
-Dedicated windows are left untouched. Giving a negative prefix
-argument takes the kindows rotate backwards."
+  "Rotate each window forwards.
+A negative prefix argument rotates each window backwards.
+Dedicated (locked) windows are left untouched."
   (interactive "p")
   (let* ((non-dedicated-windows (remove-if 'window-dedicated-p (window-list)))
          (num-windows (length non-dedicated-windows))
@@ -258,7 +258,8 @@ argument takes the kindows rotate backwards."
                (setq i next-i)))))))
 
 (defun spacemacs/rotate-windows-backward (count)
-  "Rotate your windows backward."
+  "Rotate each window backwards.
+Dedicated (locked) windows are left untouched."
   (interactive "p")
   (spacemacs/rotate-windows (* -1 count)))
 


### PR DESCRIPTION
Changes to the comment in the `spacemacs/rotate-windows` function
Sentences reordered:
From:
Default behavior.
Additional behavior. Prefix argument behavior.

To:
Default behavior,
Prefix argument behavior,
Additional behavior.

Spelling:
First sentence:
"your" replaced with "each",
"forwards" added to the end.

Second sentence (after reordering the last two sentences):
"Giving" removed,
"takes" replaced with "rotates",
"kindows" corrected to "windows",
"rotate" (next to last word) removed

(Optional) Third sentence (after reordering):
"(locked)" added after "Dedicated", it might clarify that a dedicated window means that it is locked.

After these changes:
Before:
  "Rotate your windows.
Dedicated windows are left untouched. Giving a negative prefix
argument takes the kindows rotate backwards."

After:
  "Rotate each window forwards.
A negative prefix argument rotates each window backwards.
Dedicated (locked) windows are left untouched."


The comment in the function: `spacemacs/rotate-windows-backward`
"your" replaced with "each",
"s" added to "backward",
added the same additional behavior comment as in the "main" rotation function,
"Dedicated (locked) windows are left untouched."

Before:
  "Rotate your windows backward."

After:
  "Rotate each window backwards.
Dedicated (locked) windows are left untouched."