### PR TITLE
added/corrected, rotate key documentation

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1856,7 +1856,8 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w o~              | cycle and focus between frames                                              |
 | ~SPC w p m~            | open messages buffer in a popup window                                      |
 | ~SPC w p p~            | close the current sticky popup window                                       |
-| ~SPC w R~              | rotate windows clockwise                                                    |
+| ~SPC w r~              | rotate windows forward                                                      |
+| ~SPC w R~              | rotate windows backward                                                     |
 | ~SPC w s~ or ~SPC w -~ | horizontal split                                                            |
 | ~SPC w S~              | horizontal split and focus new window                                       |
 | ~SPC w u~              | undo window layout (used to effectively undo a closed window)               |
@@ -1903,7 +1904,8 @@ window resizing.
 | ~K~           | move bottom to the top                                        |
 | ~L~           | move window to the right                                      |
 | ~o~           | focus other frame                                             |
-| ~R~           | rotate windows                                                |
+| ~r~           | rotate windows forward                                        |
+| ~R~           | rotate windows backward                                       |
 | ~s~           | horizontal split                                              |
 | ~S~           | horizontal split and focus new window                         |
 | ~u~           | undo window layout (used to effectively undo a closed window) |


### PR DESCRIPTION
In the "Windows manipulation commands (start with ~w~):" section:
Added the `SPC w r` keybinding:
| ~SPC w r~              | rotate windows forward                                                      |

In the `SPC w R` keybinding description, replaced "clockwise" with "backward".
| ~SPC w R~              | rotate windows backward                                                     |

In the "Window manipulation transient state" section:
Added the`r` keybinding.
| ~r~           | rotate windows forward                                        |

In the `R` keybinding description, added "backward"
| ~R~           | rotate windows backward                                       |