### PR TITLE
layouts: fix B b b not restricting to layout-local buffers

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -51,9 +51,8 @@ current perspective."
 
 (defun spacemacs-layouts/non-restricted-buffer-list ()
   (interactive)
-  (remove-hook 'ido-make-buffer-list-hook  #'persp-restrict-ido-buffers)
-  (helm-mini)
-  (add-hook 'ido-make-buffer-list-hook  #'persp-restrict-ido-buffers))
+  (let ((ido-make-buffer-list-hook (remove #'persp-restrict-ido-buffers ido-make-buffer-list-hook)))
+    (helm-mini)))
 
 
 ;; Persp transient-state

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -107,7 +107,8 @@
             persp-nil-name dotspacemacs-default-layout-name
             persp-reset-windows-on-nil-window-conf nil
             persp-set-last-persp-for-new-frames nil
-            persp-save-dir spacemacs-layouts-directory)
+            persp-save-dir spacemacs-layouts-directory
+            persp-hook-up-emacs-buffer-completion t)
 
       (defun spacemacs//activate-persp-mode ()
         "Always activate persp-mode, unless it is already active.


### PR DESCRIPTION
This fixes two issues regarding layouts:

1. Since Bad-ptr/persp-mode.el@e950bf15, persp-mode requires setting
persp-hook-up-emacs-buffer-completion in order to install the hooks for
ido & friends. This variable is nil by default, making SPB b b not
restrict to layout-local buffers.

2. The function spacemacs-layouts/non-restricted-buffer-list removes a
hook and re-adds it later. This makes the assumption that the hook was
already present. If it was not (due to 1) then SPC B b changes global
state by adding that hook. Instead, just let-bind the hook variable
for the scope we need it changed.

This explains and partially fixes #5788 and #6266. It does not fix the
dependency on ido-mode. If ido-mode is excluded, persp-mode will not
install the hook for ido, and SPB b b will still be unrestricted.