### PR TITLE
Fix Python layer loading on emacs master branch.

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -144,7 +144,8 @@
 
 (defun python/init-nose ()
   (use-package nose
-    :if (or (eq 'nose python-test-runner) (member 'nose python-test-runner))
+    :if (or (eq 'nose python-test-runner)
+            (if (listp python-test-runner) (member 'nose python-test-runner)))
     :commands (nosetests-one
                nosetests-pdb-one
                nosetests-all
@@ -230,7 +231,8 @@
 
 (defun python/init-pytest ()
   (use-package pytest
-    :if (or (eq 'pytest python-test-runner) (member 'pytest python-test-runner))
+    :if (or (eq 'pytest python-test-runner)
+            (if (listp python-test-runner) (member 'pytest python-test-runner)))
     :defer t
     :commands (pytest-one
                pytest-pdb-one


### PR DESCRIPTION

The member function works slightly different on the master branch of
emacs than in emacs 24.5 or emacs 25 release candidates. This might be a
bug in emacs but for now we can add a check if python-test-runner is a
list to work around that.

Fix #6246.