### PR TITLE
Fix description: command of generating TOC

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -64,7 +64,7 @@ npm install -g vmd
 * Usage
 ** Generate a TOC
 To generate a table of contents type on top of the buffer:
-~SPC SPC markdown-toc/generate-toc RET~
+~SPC ： markdown-toc-generate-toc RET~
 
 * Key bindings
 ** Element insertion


### PR DESCRIPTION
Just a simple fix, as I figured out that the command for generating table of contents should be `SPC ： markdown-toc-generate-toc`
