### PR TITLE
fix c-c++/post-init-ycmd: activate ycmd-mode in c files as well.

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -125,6 +125,7 @@
 
 (defun c-c++/post-init-ycmd ()
   (add-hook 'c++-mode-hook 'ycmd-mode)
+  (add-hook 'c-mode-hook 'ycmd-mode)
   (add-hook 'spacemacs-jump-handlers-c++-mode '(ycmd-goto :async t))
   (add-hook 'spacemacs-jump-handlers-c-mode '(ycmd-goto :async t))
   (dolist (mode '(c++-mode c-mode))


### PR DESCRIPTION

Fix regression brought by 928983d Refactor jump to definition. See also #6770