### PR TITLE
Python: Fix link in layer Readme.

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -147,7 +147,7 @@ by the [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] package. It provides
 If you need multiple Python versions (e.g. Python 2 and Python 3) then take a
 look at [[https://github.com/yyuu/pyenv][pyenv]]. It enables the installation and managment of multiple
 Python versions.
-[[https://www.brianthicks.com/2015/04/10/pyenv-your-python-environment-automated/][This blogpost]] gives a good overview on how to use the tool. Spacemacs
+[[https://www.brianthicks.com/post/2015/04/15/automate-your-python-environment-with-pyenv/][This blogpost]] gives a good overview on how to use the tool. Spacemacs
 integration is provided by [[https://github.com/proofit404/pyenv-mode][pyenv mode]] which has the following keybindings.
 
 | Key Binding | Description                          |


### PR DESCRIPTION
The blogpost was moved. Maybe it was not a good idea to link to the personal blog of somebody. This fixes it. For now.
