### PR TITLE
Improve NeoTree discoverability: new TS, `?` hint, and clarified docs

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2091,17 +2091,17 @@ current state. With default =spacemacs-dark= theme:
 Navigation is centered on the ~hjkl~ keys with the hope of providing a fast
 navigation experience like in [[http://ranger.nongnu.org/][ranger]]:
 
-| Key Binding  | Description                                                            |
-|--------------+------------------------------------------------------------------------|
-| ~h~          | collapse expanded directory or go to parent node                       |
-| ~H~          | previous sibling                                                       |
-| ~j~          | next file or directory                                                 |
-| ~J~          | next expanded directory on level down                                  |
-| ~k~          | previous file or directory                                             |
-| ~K~          | parent directory, when reaching the root change it to parent directory |
-| ~l~ or ~RET~ | expand directory                                                       |
-| ~L~          | next sibling                                                           |
-| ~R~          | make a directory the root directory                                    |
+| Key Binding  | Description                                                                   |
+|--------------+-------------------------------------------------------------------------------|
+| ~h~          | collapse expanded directory or go to parent node                              |
+| ~H~          | select previous sibling                                                       |
+| ~j~          | select next file or directory                                                 |
+| ~J~          | select next expanded directory on level down                                  |
+| ~k~          | select previous file or directory                                             |
+| ~K~          | select parent directory, when reaching the root change it to parent directory |
+| ~l~ or ~RET~ | expand directory                                                              |
+| ~L~          | select next sibling                                                           |
+| ~R~          | make a directory the root directory                                           |
 
 *Note*: Point is automatically set to the first letter of a node for a smoother
 experience.
@@ -2130,6 +2130,7 @@ open the file in a split window with ~|~ and ~-~:
 | ~s~         | toggle showing of hidden files  |
 | ~q~ or ~fd~ | hide =NeoTree= buffer           |
 | ~r~         | rename a node                   |
+| ~?~         | show help                       |
 
 **** NeoTree mode-line
 The mode-line has the following format =[x/y] d (D:a, F:b)= where:

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -175,6 +175,38 @@
             neo-modern-sidebar t
             neo-vc-integration nil)
 
+      (spacemacs|define-transient-state neotree
+        :title "NeoTree Key Hints"
+        :doc "
+Navigation^^^^             Actions^^         Visual actions/config^^^
+───────^^^^─────────────── ───────^^──────── ───────^^^────────────────
+[_J_]   goto child^^       [_c_] create      [_TAB_] shrink/enlarge
+[_K_]   goto parent^^      [_d_] delete      [_|_]   vertical split
+[_L_]   next sibling^^     [_r_] rename      [_-_]   horizonatal split
+[_H_]   previous sibling^^ [_R_] change root [_gr_]  refresh^
+[_l_]   open/expand^^      ^^                [_s_]   hidden:^^^ %s(if neo-buffer--show-hidden-file-p \"on\" \"off\")
+[_h_]   up/collapse^^      ^^                ^^^
+[_RET_] open               ^^^^              [_?_]   close hints
+"
+        :bindings
+        ("RET" 'neotree-enter)
+        ("TAB" 'neotree-stretch-toggle)
+        ("|" 'neotree-enter-vertical-split)
+        ("-" 'neotree-enter-horizontal-split)
+        ("?" nil :exit t)
+        ("c" 'neotree-create-node)
+        ("d" 'neotree-delete-node)
+        ("gr" 'neotree-refresh)
+        ("h" 'spacemacs/neotree-collapse-or-up)
+        ("H" 'neotree-select-previous-sibling-node)
+        ("J" 'neotree-select-down-node)
+        ("K" 'neotree-select-up-node)
+        ("l" 'spacemacs/neotree-expand-or-open)
+        ("L" 'neotree-select-next-sibling-node)
+        ("r" 'neotree-rename-node)
+        ("R" 'neotree-change-root)
+        ("s" 'neotree-hidden-file-toggle))
+
       (defun spacemacs//neotree-key-bindings ()
         "Set the key bindings for a neotree buffer."
         (evilified-state-evilify-map neotree-mode-map
@@ -197,6 +229,7 @@
           (kbd "q") 'neotree-hide
           (kbd "r") 'neotree-rename-node
           (kbd "R") 'neotree-change-root
+          (kbd "?") 'spacemacs/neotree-transient-state/body
           (kbd "s") 'neotree-hidden-file-toggle))
 
       (spacemacs/set-leader-keys

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -164,7 +164,7 @@
     (progn
       (setq neo-window-width 32
             neo-create-file-auto-open t
-            neo-banner-message nil
+            neo-banner-message "Press ? for neotree help"
             neo-show-updir-line nil
             neo-mode-line-type 'neotree
             neo-smart-open t
@@ -220,7 +220,6 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
           (kbd "RET") 'neotree-enter
           (kbd "|") 'neotree-enter-vertical-split
           (kbd "-") 'neotree-enter-horizontal-split
-          (kbd "?") 'evil-search-backward
           (kbd "c") 'neotree-create-node
           (kbd "d") 'neotree-delete-node
           (kbd "gr") 'neotree-refresh

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -180,32 +180,36 @@
         :doc "
 Navigation^^^^             Actions^^         Visual actions/config^^^
 ───────^^^^─────────────── ───────^^──────── ───────^^^────────────────
-[_J_]   goto child^^       [_c_] create      [_TAB_] shrink/enlarge
-[_K_]   goto parent^^      [_d_] delete      [_|_]   vertical split
-[_L_]   next sibling^^     [_r_] rename      [_-_]   horizonatal split
-[_H_]   previous sibling^^ [_R_] change root [_gr_]  refresh^
+[_L_]   next sibling^^     [_c_] create      [_TAB_] shrink/enlarge
+[_H_]   previous sibling^^ [_d_] delete      [_|_]   vertical split
+[_J_]   goto child^^       [_r_] rename      [_-_]   horizonatal split
+[_K_]   goto parent^^      [_R_] change root [_gr_]  refresh^
 [_l_]   open/expand^^      ^^                [_s_]   hidden:^^^ %s(if neo-buffer--show-hidden-file-p \"on\" \"off\")
 [_h_]   up/collapse^^      ^^                ^^^
+[_j_]   line down^^        ^^                ^^^
+[_k_]   line up^^          ^^                ^^
 [_RET_] open               ^^^^              [_?_]   close hints
 "
         :bindings
-        ("RET" 'neotree-enter)
-        ("TAB" 'neotree-stretch-toggle)
-        ("|" 'neotree-enter-vertical-split)
-        ("-" 'neotree-enter-horizontal-split)
+        ("RET" neotree-enter)
+        ("TAB" neotree-stretch-toggle)
+        ("|" neotree-enter-vertical-split)
+        ("-" neotree-enter-horizontal-split)
         ("?" nil :exit t)
-        ("c" 'neotree-create-node)
-        ("d" 'neotree-delete-node)
-        ("gr" 'neotree-refresh)
-        ("h" 'spacemacs/neotree-collapse-or-up)
-        ("H" 'neotree-select-previous-sibling-node)
-        ("J" 'neotree-select-down-node)
-        ("K" 'neotree-select-up-node)
-        ("l" 'spacemacs/neotree-expand-or-open)
-        ("L" 'neotree-select-next-sibling-node)
-        ("r" 'neotree-rename-node)
-        ("R" 'neotree-change-root)
-        ("s" 'neotree-hidden-file-toggle))
+        ("c" neotree-create-node)
+        ("d" neotree-delete-node)
+        ("gr" neotree-refresh)
+        ("h" spacemacs/neotree-collapse-or-up)
+        ("H" neotree-select-previous-sibling-node)
+        ("j" neotree-next-line)
+        ("J" neotree-select-down-node)
+        ("k" neotree-previous-line)
+        ("K" neotree-select-up-node)
+        ("l" spacemacs/neotree-expand-or-open)
+        ("L" neotree-select-next-sibling-node)
+        ("r" neotree-rename-node)
+        ("R" neotree-change-root)
+        ("s" neotree-hidden-file-toggle))
 
       (defun spacemacs//neotree-key-bindings ()
         "Set the key bindings for a neotree buffer."
@@ -222,7 +226,9 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
           (kbd "gr") 'neotree-refresh
           (kbd "h") 'spacemacs/neotree-collapse-or-up
           (kbd "H") 'neotree-select-previous-sibling-node
+          (kbd "j") 'neotree-next-line
           (kbd "J") 'neotree-select-down-node
+          (kbd "k") 'neotree-previous-line
           (kbd "K") 'neotree-select-up-node
           (kbd "l") 'spacemacs/neotree-expand-or-open
           (kbd "L") 'neotree-select-next-sibling-node


### PR DESCRIPTION
Fixes #6867 

Changes `?` binding in NeoTree from `evil-search-backward` to `describe-mode` and adds a mtaching banner at the top of NeoTree buffer. The aim is to increase discoverability of NeoTree, and I think we can give up on `evil-search-backward` for that. Besides, `?` is bound to `describe-mode` also in un-configured NeoTree (because it inherits from `special-mode`).

Also adds some verbs to the docs describing NeoTree movement keys, to make it less laconic.