### PR TITLE
Keep current random ascii banner and startup summary when auto-centering emacs buffer on window resize

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1913,15 +1913,21 @@ to select one."
         (configuration-layer//insert-lazy-install-form
          layer-name (car x) (cdr x))))))
 
+(defvar configuration-layer//spacemacs-startup-time nil
+  "Spacemacs full startup duration.")
+
 (defun configuration-layer/display-summary (start-time)
   "Display a summary of loading time."
-  (let ((elapsed (float-time (time-subtract (current-time) emacs-start-time)))
-        (stats (configuration-layer/configured-packages-stats
+  (if (not configuration-layer//spacemacs-startup-time)
+      (setq configuration-layer//spacemacs-startup-time
+	    (float-time (time-subtract (current-time) emacs-start-time))))
+  (let ((stats (configuration-layer/configured-packages-stats
                 configuration-layer--used-packages)))
+    (spacemacs-buffer/insert-page-break)
     (spacemacs-buffer/append
      (format "\n%s packages loaded in %.3fs (e:%s r:%s l:%s b:%s)\n"
              (cadr (assq 'total stats))
-             elapsed
+             configuration-layer//spacemacs-startup-time
              (cadr (assq 'elpa stats))
              (cadr (assq 'recipe stats))
              (cadr (assq 'local stats))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -140,10 +140,8 @@ Cate special text banner can de reachable via `998', `cat' or `random*'.
            (if (and (display-graphic-p) (image-type-available-p 'png))
                spacemacs-banner-official-png
              (spacemacs-buffer//get-banner-path 1)))
-          ((eq 'random dotspacemacs-startup-banner)
-           (spacemacs-buffer//choose-random-text-banner))
-          ((eq 'random* dotspacemacs-startup-banner)
-           (spacemacs-buffer//choose-random-text-banner t))
+          ((or (eq 'random dotspacemacs-startup-banner) (eq 'random* dotspacemacs-startup-banner))
+           spacemacs-buffer//current-random-text-banner-path)
           ((eq 'doge dotspacemacs-startup-banner)
            (spacemacs-buffer//get-banner-path 999))
           ((eq 'cat dotspacemacs-startup-banner)
@@ -170,6 +168,11 @@ If ALL is non-nil then truly all banners can be selected."
          ;; -2 to remove the two last ones (easter eggs)
          (choice (random (- count (if all 0 2)))))
     (nth choice files)))
+
+(defvar spacemacs-buffer//current-random-text-banner-path (if (eq 'random* dotspacemacs-startup-banner)
+                                                              (spacemacs-buffer//choose-random-text-banner t)
+                                                            (spacemacs-buffer//choose-random-text-banner nil))
+  "The currently chosen random ascii banner.")
 
 (defun spacemacs-buffer//get-banner-path (index)
   "Return the full path to banner with index INDEX."
@@ -912,6 +915,9 @@ already exist, and switch to it."
   "Force recreation of the spacemacs buffer."
   (interactive)
   (setq spacemacs-buffer--last-width nil)
+  (setq spacemacs-buffer//current-random-text-banner-path (if (eq 'random* dotspacemacs-startup-banner)
+                                                              (spacemacs-buffer//choose-random-text-banner t)
+                                                            (spacemacs-buffer//choose-random-text-banner nil)))
   (spacemacs-buffer/goto-buffer t))
 
 (provide 'core-spacemacs-buffer)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -106,8 +106,6 @@ Cate special text banner can de reachable via `998', `cat' or `random*'.
           (spacemacs-buffer/insert-ascii-banner-centered banner))
         (spacemacs-buffer//inject-version))
       (spacemacs-buffer//insert-buttons)
-      (unless (bound-and-true-p spacemacs-initialized)
-        (spacemacs-buffer/insert-page-break))
       (spacemacs//redisplay))))
 
 (defun spacemacs-buffer/display-info-box ()
@@ -885,6 +883,7 @@ already exist, and switch to it."
             ;; non-nil if emacs-startup-hook was run
             (if (bound-and-true-p spacemacs-initialized)
                 (progn
+                  (configuration-layer/display-summary emacs-start-time)
                   (when dotspacemacs-startup-lists
                     (spacemacs-buffer/insert-startupify-lists))
                   (spacemacs-buffer//insert-footer)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -851,42 +851,67 @@ list. Return entire list if `END' is omitted."
     (force-mode-line-update)
     (spacemacs-buffer/goto-link-line)))
 
-(defun spacemacs-buffer/goto-buffer ()
+(defvar spacemacs-buffer--last-width nil
+  "Previous width of spacemacs-buffer")
+
+(defun spacemacs-buffer/goto-buffer (&optional refresh)
   "Create the special buffer for `spacemacs-buffer-mode' if it doesn't
 already exist, and switch to it."
   (interactive)
-  (unless (buffer-live-p (get-buffer spacemacs-buffer-name))
-    ;; revise banner length in GUI
-    (when (display-graphic-p)
-      (setq spacemacs-buffer--banner-length
-            (- (window-total-width) 2)))
-    (with-current-buffer (get-buffer-create spacemacs-buffer-name)
-      (page-break-lines-mode)
-      (save-excursion
-        (spacemacs-buffer/set-mode-line "")
-        ;; needed in case the buffer was deleted and we are recreating it
-        (setq spacemacs-buffer--note-widgets nil)
-        (spacemacs-buffer/insert-banner-and-buttons)
-        ;; non-nil if emacs-startup-hook was run
-        (if (bound-and-true-p spacemacs-initialized)
-            (progn
-              (when dotspacemacs-startup-lists
-                (spacemacs-buffer/insert-startupify-lists))
-              (spacemacs-buffer//insert-footer)
-              (spacemacs-buffer/set-mode-line spacemacs--default-mode-line)
-              (force-mode-line-update)
-              (spacemacs-buffer-mode))
-          (add-hook 'emacs-startup-hook 'spacemacs-buffer//startup-hook t)))))
-  (spacemacs-buffer/goto-link-line)
-  (switch-to-buffer spacemacs-buffer-name)
-  (spacemacs//redisplay))
+  (let ((buffer-exists (buffer-live-p (get-buffer spacemacs-buffer-name)))
+        ln)
+    (when (or refresh
+              (not buffer-exists))
+      ;; revise banner length in GUI
+      (when (display-graphic-p)
+        (setq spacemacs-buffer--banner-length
+              (window-width)))
+      (unless (eq spacemacs-buffer--last-width spacemacs-buffer--banner-length)
+        (setq spacemacs-buffer--last-width spacemacs-buffer--banner-length)
+        (with-current-buffer (get-buffer-create spacemacs-buffer-name)
+          (page-break-lines-mode)
+          (save-excursion
+            (when (> (buffer-size) 0)
+              (setq ln (line-number-at-pos))
+              (let ((inhibit-read-only t))
+                (erase-buffer)))
+            (spacemacs-buffer/set-mode-line "")
+            ;; needed in case the buffer was deleted and we are recreating it
+            (setq spacemacs-buffer--note-widgets nil)
+            (spacemacs-buffer/insert-banner-and-buttons)
+            ;; non-nil if emacs-startup-hook was run
+            (if (bound-and-true-p spacemacs-initialized)
+                (progn
+                  (when dotspacemacs-startup-lists
+                    (spacemacs-buffer/insert-startupify-lists))
+                  (spacemacs-buffer//insert-footer)
+                  (spacemacs-buffer/set-mode-line spacemacs--default-mode-line)
+                  (force-mode-line-update)
+                  (spacemacs-buffer-mode))
+              (add-hook 'emacs-startup-hook 'spacemacs-buffer//startup-hook t))))
+        (if ln
+            ;; return to previous line before refresh
+            (progn (goto-char (point-min))
+                   (forward-line (1- ln))
+                   (forward-to-indentation 0))
+          (spacemacs-buffer/goto-link-line))
+        (switch-to-buffer spacemacs-buffer-name)
+        (spacemacs//redisplay)))))
+
+(add-hook 'window-configuration-change-hook 'spacemacs-buffer//resize-on-hook)
+
+(defun spacemacs-buffer//resize-on-hook ()
+  (let ((space-win (get-buffer-window spacemacs-buffer-name))
+        (frame-win (frame-selected-window)))
+    (when (and space-win
+               (not (window-minibuffer-p frame-win)))
+      (with-selected-window space-win
+        (spacemacs-buffer/goto-buffer t)))))
 
 (defun spacemacs-buffer/refresh ()
-  "Recreate the spacemacs buffer."
+  "Force recreation of the spacemacs buffer."
   (interactive)
-  (let ((inhibit-redisplay t))
-    (when (buffer-live-p (get-buffer spacemacs-buffer-name))
-      (kill-buffer spacemacs-buffer-name))
-    (spacemacs-buffer/goto-buffer)))
+  (setq spacemacs-buffer--last-width nil)
+  (spacemacs-buffer/goto-buffer t))
 
 (provide 'core-spacemacs-buffer)

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -519,7 +519,7 @@ If the universal prefix argument is used then will the windows too."
   (delete-other-windows)
   (split-window-right))
 
-(defalias 'spacemacs/home 'spacemacs-buffer/goto-buffer
+(defalias 'spacemacs/home 'spacemacs-buffer/refresh
   "Go to home Spacemacs buffer")
 
 (defun spacemacs/home-delete-other-windows ()


### PR DESCRIPTION
Written on top of #6259 by @ralesi.

Now, for having tested it, these two PRs combined offer a smooth home buffer experience :smile: 

This PR has several commits because they are tightly related and depend on each other.
