### PR TITLE
auto-completion: manual help tooltip and minor fix

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -102,12 +102,22 @@ the popup, set the variable =auto-completion-enable-snippets-in-popup= to =t=.
 #+END_SRC
 
 ** Tooltips
-To enable docstring tooltips set =auto-completion-enable-help-tooltip= to =t=
+To enable automatic docstring tooltips set =auto-completion-enable-help-tooltip=
+to =t=.
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
   '((auto-completion :variables
                     auto-completion-enable-help-tooltip t)))
+#+END_SRC
+
+To enable manual non-automatic invocation of docstring tooltips, set it to
+=manual=. The tooltip can be invoked manually by pressing ~M-h~.
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((auto-completion :variables
+                    auto-completion-enable-help-tooltip 'manual)))
 #+END_SRC
 
 ** Sort results by usage
@@ -197,11 +207,12 @@ For nicer-looking faces, try adding the following to `custom-set-faces` in your 
 * Key Bindings
 ** Company
 
-| Key Binding | Description                                                              |
-|-------------+--------------------------------------------------------------------------|
-| ~C-d~       | open minibuffer with documentation of thing at point in company dropdown |
-| ~C-/~       | show candidates in Helm (for fuzzy searching)                            |
-| ~C-M-/~     | filter the company dropdown menu                                         |
+| Key Binding | Description                                                                                          |
+|-------------+------------------------------------------------------------------------------------------------------|
+| ~C-d~       | open minibuffer with documentation of thing at point in company dropdown                             |
+| ~C-/~       | show candidates in Helm (for fuzzy searching)                                                        |
+| ~C-M-/~     | filter the company dropdown menu                                                                     |
+| ~M-h~       | show current candidate's documentation in a tooltip (requires =auto-completion-enable-help-tooltip=) |
 
 Vim Style:
 

--- a/layers/+completion/auto-completion/config.el
+++ b/layers/+completion/auto-completion/config.el
@@ -37,7 +37,9 @@ selection.")
   "If non nil suggestions are sorted by how often they are used.")
 
 (defvar auto-completion-enable-help-tooltip nil
-  "If non nil the docstring appears in a tooltip.")
+  "If non nil the docstring appears in a tooltip.
+If set to `manual', help tooltip appears only when invoked
+manually.")
 
 (defvar company-mode-completion-cancel-keywords
   '("do"

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -115,12 +115,14 @@
 (defun auto-completion/init-company-quickhelp ()
   (use-package company-quickhelp
     :if (and auto-completion-enable-help-tooltip (display-graphic-p))
+    :commands company-quickhelp-manual-begin
     :defer t
     :init
-    (progn
-      (add-hook 'company-mode-hook 'company-quickhelp-mode)
-      (with-eval-after-load 'company
-        (setq company-frontends (delq 'company-echo-metadata-frontend company-frontends))))))
+    (with-eval-after-load 'company
+      (setq company-frontends (delq 'company-echo-metadata-frontend company-frontends))
+      (define-key company-active-map (kbd "M-h") #'company-quickhelp-manual-begin)
+      (unless (eq auto-completion-enable-help-tooltip 'manual)
+        (company-quickhelp-mode)))))
 
 (defun auto-completion/init-helm-c-yasnippet ()
   (use-package helm-c-yasnippet


### PR DESCRIPTION
New value `manual` for `auto-completion-enable-help-tooltip` enables the user to display help tooltip on-demand, by pressing <kbd>M-h</kbd> while Company completion is active. Follows the suggestion in [company-quickhelp's readme](https://github.com/expez/company-quickhelp#customizing).

Other values remain the same: `nil` for no tooltip at all, `t` (or any non-nil non-manual value) for automatic tooltip.

Minor fix: call `company-quickhelp-mode` just once, because it's a global minor-mode.