### PR TITLE
Match entire path after -I for passing to expand-file-name.

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -26,7 +26,7 @@
       (insert-file-contents cc-file)
       ;; Replace relative paths with absolute paths (by @trishume)
       ;; (goto-char (point-min))
-      (while (re-search-forward "\\(-I\\|-isystem\n\\)\\(\\S-\\)" nil t)
+      (while (re-search-forward "\\(-I\\|-isystem\n\\)\\(\\S-+\\)" nil t)
         (replace-match (format "%s%s" (match-string 1)
                                (expand-file-name (match-string 2) invocation-dir))))
       ;; Turn lines into a list


### PR DESCRIPTION
Fix for .clang_complete expansion of relative paths.

Otherwise I was seeing these transformations:

invocation-dir = C:/Some/Directory

-I../another/directory
-IC:/another/directory

Became

-Ic:/Some/Directory./another/directory
-IC:/SOME/DIRECTORY/C:/another/directory