### PR TITLE
fix chinese layer doc typo

### DIFF
--- a/layers/+intl/chinese/config.el
+++ b/layers/+intl/chinese/config.el
@@ -12,10 +12,10 @@
 ;; Variables
 
 (defvar chinese-default-input-method 'pinyin
-  "The default chiense input method. Can be `wubi` or `pinyin`.")
+  "The default chinese input method. Can be `wubi` or `pinyin`.")
 
 (defvar chinese-enable-youdao-dict nil
-  "Enble YouDao Dict translation service.")
+  "Enable YouDao Dict translation service.")
 
 (defvar chinese-enable-avy-pinyin t
   "Enable ace-pinyin in avy-goto-char")


### PR DESCRIPTION
Hi, I found there're two typos in config.el of chinese layer.

now I have fixed them.

Thanks.
