### PR TITLE
add glsl-company to shaders layer

### DIFF
--- a/layers/+lang/shaders/README.org
+++ b/layers/+lang/shaders/README.org
@@ -14,6 +14,11 @@ provide highlighting for files ending in:
 - =.frag=
 - =.geom=
 
+Also this layer provides completion for =.vert=, =.tesc=, =.tese=, =.geom=,
+=.frag= and =.comp= shaders via =company-glsl= when [[https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/][=glslangValidator=]] can be
+found on your system and =auto-completion= layer is enabled. Note that
+completion is [[https://github.com/Kaali/company-glsl][rather simple]].
+
 * Install
 To use this configuration layer, add it to your =~.spacemacs=. You will need to
 add =shaders= to the existing =dotspacemacs-configuration-layers= list in this

--- a/layers/+lang/shaders/config.el
+++ b/layers/+lang/shaders/config.el
@@ -1,0 +1,14 @@
+;;; config.el --- Shaders Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(spacemacs|defvar-company-backends glsl-mode)

--- a/layers/+lang/shaders/packages.el
+++ b/layers/+lang/shaders/packages.el
@@ -8,7 +8,25 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GLPv3
-(setq shaders-packages '(glsl-mode))
+(setq shaders-packages
+      '(glsl-mode
+        company
+        (company-glsl
+         :location (recipe
+                    :fetcher github
+                    :repo "Kaali/company-glsl")
+         :toggle (and (configuration-layer/package-usedp 'company)
+                      (executable-find "glslangValidator")))))
+
+(defun shaders/post-init-company ()
+  (spacemacs|add-company-hook glsl-mode))
+
+(defun shaders/init-company-glsl ()
+  (use-package company-glsl
+    :defer t
+    :init
+    (push 'company-glsl
+          company-backends-glsl-mode)))
 
 (defun shaders/init-glsl-mode ()
   "Initialize GLSL mode"


### PR DESCRIPTION
Following #6359. Not pushing it directly mainly because `company-glsl` provides very simple completion. So simple that word expansion is much more powerful. 

So I am going to see if anyone is interested in this change. 

cc @Ell 
