### PR TITLE
Don't use company-racer with racer

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -12,7 +12,6 @@
 (setq rust-packages
   '(
     company
-    company-racer
     racer
     flycheck
     flycheck-rust


### PR DESCRIPTION
Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3
racer.el offers a superset of the functionality of company-racer.

We don't support using racer.el with company-racer, and it causes user confusion.

If you'd prefer instead to use company-racer exclusively, that's fine of course, but please don't use both.