### PR TITLE
Rust: Add binding for describing symbol at point

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -61,4 +61,5 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | ~SPC m c u~ | update dependencies with Cargo              |
 | ~SPC m c x~ | execute a project with Cargo                |
 | ~SPC m g g~ | jump to definition                          |
+| ~SPC m h h~ | describe symbol at point                    |
 | ~SPC m t~   | run tests with Cargo                        |

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -1,0 +1,16 @@
+;;; funcs.el --- rust Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: NJBS <DoNotTrackMeUsingThis@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/racer-describe ()
+  "Show a *Racer Help* buffer for the function or type at point and switch to
+it."
+  (interactive)
+  (select-window (racer-describe)))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -94,4 +94,10 @@
     (progn
       (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode eldoc-mode))
       (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
-      (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition))))
+      (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
+
+      (evilified-state-evilify racer-help-mode racer-help-mode-map)
+      (spacemacs/declare-prefix-for-mode 'rust-mode "mh" "help")
+      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+        "hh" 'spacemacs/racer-describe)
+      (add-hook 'spacemacs-jump-handlers-rust-mode 'racer-find-definition))))


### PR DESCRIPTION
Adds a binding for the new [racer-describe](http://www.wilfred.me.uk/blog/2016/08/27/rustdoc-meets-the-self-documenting-editor/) function.

Seems to work fairly well out of the box.
