### PR TITLE
Fix some features in daemon mode

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -14,7 +14,7 @@
         auto-complete
         ac-ispell
         company
-        company-quickhelp
+        (company-quickhelp :toggle auto-completion-enable-help-tooltip)
         company-statistics
         (helm-company :toggle (configuration-layer/package-usedp 'helm))
         (helm-c-yasnippet :toggle (configuration-layer/package-usedp 'helm))
@@ -114,13 +114,12 @@
 
 (defun auto-completion/init-company-quickhelp ()
   (use-package company-quickhelp
-    :if (and auto-completion-enable-help-tooltip (display-graphic-p))
     :defer t
     :init
-    (progn
-      (add-hook 'company-mode-hook 'company-quickhelp-mode)
-      (with-eval-after-load 'company
-        (setq company-frontends (delq 'company-echo-metadata-frontend company-frontends))))))
+    (spacemacs|do-after-display-system-init
+     (add-hook 'company-mode-hook 'company-quickhelp-mode)
+     (with-eval-after-load 'company
+       (setq company-frontends (delq 'company-echo-metadata-frontend company-frontends))))))
 
 (defun auto-completion/init-helm-c-yasnippet ()
   (use-package helm-c-yasnippet

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -32,15 +32,16 @@
   (use-package diff-hl
     :init
     (progn
-      (setq diff-hl-side 'right)
+      (setq diff-hl-side 'left)
       (when (eq version-control-diff-tool 'diff-hl)
         (when (configuration-layer/package-usedp 'magit)
           (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh))
         (when version-control-global-margin
           (global-diff-hl-mode))
-        (unless (display-graphic-p)
-          (setq diff-hl-side 'left)
-          (diff-hl-margin-mode))))))
+        (diff-hl-margin-mode)
+        (spacemacs|do-after-display-system-init
+         (setq diff-hl-side 'right)
+         (diff-hl-margin-mode -1))))))
 
 (defun version-control/post-init-evil-unimpaired ()
   (define-key evil-normal-state-map (kbd "[ h") 'spacemacs/vcs-previous-hunk)
@@ -76,9 +77,9 @@
     :commands git-gutter-mode
     :init
     (progn
-      (when (display-graphic-p)
-        (with-eval-after-load 'git-gutter
-          (require 'git-gutter-fringe)))
+      (spacemacs|do-after-display-system-init
+       (with-eval-after-load 'git-gutter
+         (require 'git-gutter-fringe)))
       (setq git-gutter-fr:side 'right-fringe))
     :config
     (progn
@@ -137,9 +138,9 @@
     :commands git-gutter+-mode
     :init
     (progn
-      (when (display-graphic-p)
-        (with-eval-after-load 'git-gutter+
-          (require 'git-gutter-fringe+)))
+      (spacemacs|do-after-display-system-init
+       (with-eval-after-load 'git-gutter+
+         (require 'git-gutter-fringe+)))
       (setq git-gutter-fr+-side 'right-fringe))
     :config
     (progn


### PR DESCRIPTION
We can't reliably use `(display-graphic-p)` during startup. Therefore assume no graphic display and use `spacemacs|do-after-display-system-init` otherwise.

Probably fixes: https://github.com/syl20bnr/spacemacs/issues/5821, https://github.com/syl20bnr/spacemacs/issues/2180 and https://github.com/syl20bnr/spacemacs/issues/1894

Tested in daemon mode with all combinations of margin tool and frame type.