### PR TITLE
neotree: add ts for easy discoverabilty of keys

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -175,6 +175,38 @@
             neo-modern-sidebar t
             neo-vc-integration nil)
 
+      (spacemacs|define-transient-state neotree
+        :title "NeoTree Key Hints"
+        :doc "
+Navigation^^^^             Actions^^         Visual actions/config^^^
+───────^^^^─────────────── ───────^^──────── ───────^^^────────────────
+[_J_]   goto child^^       [_c_] create      [_TAB_] shrink/enlarge
+[_K_]   goto parent^^      [_d_] delete      [_|_]   vertical split
+[_L_]   next sibling^^     [_r_] rename      [_-_]   horizonatal split
+[_H_]   previous sibling^^ [_R_] change root [_gr_]  refresh^
+[_l_]   open/expand^^      ^^                [_s_]   hidden:^^^ %s(if neo-buffer--show-hidden-file-p \"on\" \"off\")
+[_h_]   up/collapse^^      ^^                ^^^
+[_RET_] open               ^^^^              [_?_]   close hints
+"
+        :bindings
+        ("RET" 'neotree-enter)
+        ("TAB" 'neotree-stretch-toggle)
+        ("|" 'neotree-enter-vertical-split)
+        ("-" 'neotree-enter-horizontal-split)
+        ("?" nil :exit t)
+        ("c" 'neotree-create-node)
+        ("d" 'neotree-delete-node)
+        ("gr" 'neotree-refresh)
+        ("h" 'spacemacs/neotree-collapse-or-up)
+        ("H" 'neotree-select-previous-sibling-node)
+        ("J" 'neotree-select-down-node)
+        ("K" 'neotree-select-up-node)
+        ("l" 'spacemacs/neotree-expand-or-open)
+        ("L" 'neotree-select-next-sibling-node)
+        ("r" 'neotree-rename-node)
+        ("R" 'neotree-change-root)
+        ("s" 'neotree-hidden-file-toggle))
+
       (defun spacemacs//neotree-key-bindings ()
         "Set the key bindings for a neotree buffer."
         (evilified-state-evilify-map neotree-mode-map
@@ -197,6 +229,7 @@
           (kbd "q") 'neotree-hide
           (kbd "r") 'neotree-rename-node
           (kbd "R") 'neotree-change-root
+          (kbd "?") 'spacemacs/neotree-transient-state/body
           (kbd "s") 'neotree-hidden-file-toggle))
 
       (spacemacs/set-leader-keys


### PR DESCRIPTION
Attempted to fix #6867

It looks like this. Any suggestions/modifications are welcome. 

<img width="649" alt="screen shot 2016-08-29 at 7 11 58 pm" src="https://cloud.githubusercontent.com/assets/542810/18053356/9036f3d2-6e1c-11e6-9de7-85e2ed939e54.png">

Not sure about the warning in the echo area. @bmag any idea about it? 