### PR TITLE
Haskell: Add support for `intero-apply-suggestions`

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -283,8 +283,12 @@ Refactor commands are prefixed by ~SPC m r~:
 |-------------+---------------------------------------------------|
 | ~SPC m r b~ | apply all HLint suggestions in the current buffer |
 | ~SPC m r r~ | apply the HLint suggestion under the cursor       |
+| ~SPC m r s~ | list all Intero suggestions                       |
 
 Only some of the HLint suggestions can be applied.
+
+To apply the intero suggestions, press `C-c C-c` when the window is open, which
+is also shown in the window that appears.
 
 ** Ghc-mod
 These commands are only available when ghc-mod is enabled.

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -56,6 +56,7 @@
       "hi" 'intero-info
       "ht" 'intero-type-at
       "hT" 'haskell-intero/insert-type
+      "rs" 'intero-apply-suggestions
       "sb" 'intero-repl-load))
 
   (dolist (mode (cons 'haskell-cabal-mode haskell-modes))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -139,7 +139,8 @@
         (spacemacs/declare-prefix-for-mode mode "ms" "haskell/repl")
         (spacemacs/declare-prefix-for-mode mode "mc" "haskell/cabal")
         (spacemacs/declare-prefix-for-mode mode "mh" "haskell/documentation")
-        (spacemacs/declare-prefix-for-mode mode "md" "haskell/debug"))
+        (spacemacs/declare-prefix-for-mode mode "md" "haskell/debug")
+        (spacemacs/declare-prefix-for-mode mode "mr" "haskell/refactor"))
       (spacemacs/declare-prefix-for-mode 'haskell-interactive-mode "ms" "haskell/repl")
       (spacemacs/declare-prefix-for-mode 'haskell-cabal-mode "ms" "haskell/repl")
 
@@ -284,7 +285,6 @@
     :defer t
     :init
     (progn
-      (spacemacs/declare-prefix-for-mode 'haskell-mode "mr" "haskell/refactor")
       (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
         "rb" 'hlint-refactor-refactor-buffer
         "rr" 'hlint-refactor-refactor-at-point))))


### PR DESCRIPTION
As per #6233 add support for `intero-apply-suggestions` behind `SPC m r s`, 
and move the prefix declaration for "haskell/refactor" to the other prefix declarations, 
since it is no longer only relevant for hlint.