### PR TITLE
Assign 0 to NeoTree's window only when it is the top-left window

### DIFF
--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -293,9 +293,12 @@ debug-init and load the given list of packages."
     (defun spacemacs//window-numbering-assign ()
       "Custom number assignment for neotree."
       (when (and (boundp 'neo-buffer-name)
-                 (string= (buffer-name) neo-buffer-name))
+                 (string= (buffer-name) neo-buffer-name)
+                 ;; in case there are two neotree windows. Example: when
+                 ;; invoking a transient state from neotree window, the new
+                 ;; window will show neotree briefly before displaying the TS,
+                 ;; causing an error message. the error is eliminated by
+                 ;; assigning 0 only to the top-left window
+                 (eq (selected-window) (window-at 0 0)))
         0))
-    ;; using lambda to work-around a bug in window-numbering, see
-    ;; https://github.com/nschum/window-numbering.el/issues/10
-    (setq window-numbering-assign-func
-          (lambda () (spacemacs//window-numbering-assign)))))
+    (setq window-numbering-assign-func #'spacemacs//window-numbering-assign)))


### PR DESCRIPTION
When a transient state is invoked from NeoTree's window, an error message is shown:

<img width="649" alt="window-number-double" src="https://cloud.githubusercontent.com/assets/4334375/18057488/e56f58a2-6e18-11e6-9b98-8a01a99de01b.png">

The error happens because, for a very brief moment, two windows display NeoTree: the original, and the new window that is created for the TS. This PR solves the issue by assigning the number 0 only to the top-left NeoTree window.

(image copied from #6951)