### PR TITLE
Implement :enabled-for layer keyword

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -627,9 +627,32 @@ you can do it with the following layer declaration.
 (defun dotspacemacs/layers ()
   ;; List of configuration layers to load.
   (setq-default dotspacemacs-configuration-layers
-    '(org
+    '(org git
       (auto-completion :disabled-for org git))))
 #+END_SRC
+
+You can also use the =:enabled-for= construct to disable it for /all/ layers
+/except/ those explicitly identified.
+
+#+BEGIN_SRC emacs-lisp
+(defun dotspacemacs/layers ()
+  ;; List of configuration layers to load.
+  (setq-default dotspacemacs-configuration-layers
+    '(java python c-c++
+      (auto-completion :enabled-for java python))))
+#+END_SRC
+
+Note that =:enabled-for= may be an empty list.
+
+#+BEGIN_SRC emacs-lisp
+(defun dotspacemacs/layers ()
+  ;; List of configuration layers to load.
+  (setq-default dotspacemacs-configuration-layers
+    '(java python c-c++
+      (auto-completion :enabled-for))))
+#+END_SRC
+
+=:enabled-for= takes precedence over =:disabled-for= if both are present.
 
 *** Selecting/Ignoring packages of a layer
 By default a declared layer installs/configures all its associated packages. You


### PR DESCRIPTION
This implements an `:enabled-for` feature that does the opposite of what `:disabled-for` already does.

Rationale: except for the sake of completeness, this might be useful for layers like ycmd and gtags. Ycmd shines in C/C++ but it also supports auto-completion in a number of different major modes where we already have other options (python, rust, C#). Gtags often competes with other jump-to-definition handlers (although, that has been largely resolved already with another method). In both cases it could be useful to restrict ycmd/gtags to work only in the modes where the user feels they are needed. This way we don't have to introduce superfluous layer variables to turn on or off support, and the user doesn't have to keep up with a potentially changing list of additional layers that they might have to disable.

Layers where this could be useful should probably explicitly note this possibility in their documentation.