### PR TITLE
Add missing prefices for js2-mode

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -260,6 +260,8 @@
         (skewer-repl)
         (evil-insert-state))
 
+      (spacemacs/declare-prefix-for-mode 'js2-mode "ms" "skewer")
+      (spacemacs/declare-prefix-for-mode 'js2-mode "me" "eval")
       (spacemacs/set-leader-keys-for-major-mode 'js2-mode
         "'" 'spacemacs/skewer-start-repl
         "ee" 'skewer-eval-last-expression


### PR DESCRIPTION
`skewer-eval-last-expression` and `skewer-eval-print-last-expression` are on `SPC e`.
Move them under `SPC s` and add `skewer` prefix