### PR TITLE
Option to choose intepreter for python-execute-file

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -327,9 +327,9 @@
         (setq universal-argument t)
         (if arg
             (call-interactively 'compile)
-
-          (setq compile-command (format "python %s" (file-name-nondirectory
-                                                     buffer-file-name)))
+          (setq compile-command (format "%s %s" python-shell-interpreter
+                                        (file-name-nondirectory
+                                         buffer-file-name)))
           (compile compile-command t)
           (with-current-buffer (get-buffer "*compilation*")
             (inferior-python-mode))))


### PR DESCRIPTION
In the function python-execute-file, the name of the python interpreter
has been hard-coded to "python". If one uses Python 3, there is no way
to invoke "python3" interpreter. Invoke python interpreter by the name
set in python-shell-interpreter variable, i.e.:

(setq python-shell-interpreter "python3")
