### PR TITLE
re-fix window numbering bug

### DIFF
--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -301,4 +301,8 @@ debug-init and load the given list of packages."
                  ;; assigning 0 only to the top-left window
                  (eq (selected-window) (window-at 0 0)))
         0))
-    (setq window-numbering-assign-func #'spacemacs//window-numbering-assign)))
+
+    ;; using lambda to work-around a bug in window-numbering, see
+    ;; https://github.com/nschum/window-numbering.el/issues/10
+    (setq window-numbering-assign-func
+          (lambda () (spacemacs//window-numbering-assign)))))


### PR DESCRIPTION
4b2f123 recently removed a workaround which according to the comment was fixing some window-numbering bug. I just reapplied the workaround as it broke my emacs.

While it was working nice on my computer at work, it broke everything on my personal laptop: when trying to quit emacs, it wouldn't, but instead all commands would only split windows.

After manually sigterming the frame, I still had to use sigkill to get rid of the emacs process taking 100% CPU.