### PR TITLE
elixir: flycheck on idle

### DIFF
--- a/layers/+lang/elixir/funcs.el
+++ b/layers/+lang/elixir/funcs.el
@@ -15,10 +15,6 @@
     (forward-line -1)
     (indent-according-to-mode)))
 
-(defun spacemacs//elixir-flycheck-check-on-save-only ()
-  "Configure flycheck to check on save only since mix is slow."
-  (setq-local flycheck-check-syntax-automatically '(mode-enabled save)))
-
 (defun spacemacs//elixir-enable-compilation-checking ()
   "Enable compile checking if `elixir-enable-compilation-checking' is non nil."
   (when (or elixir-enable-compilation-checking)

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -137,9 +137,7 @@
     (spacemacs|define-jump-handlers elixir-mode)))
 
 (defun elixir/post-init-flycheck ()
-  (spacemacs/add-flycheck-hook 'elixir-mode)
-  (add-hook 'elixir-mode-hook
-            'spacemacs//elixir-flycheck-check-on-save-only t))
+  (spacemacs/add-flycheck-hook 'elixir-mode))
 
 (defun elixir/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin


### PR DESCRIPTION
`flycheck-mix` now uses `flycheck-buffer-saved-p` so it is safe to
flycheck on idle: https://github.com/tomekowal/flycheck-mix/pull/2