### PR TITLE
[bepo] Fix loading of the ranger correction

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -458,7 +458,7 @@
     :description
     "Remap navigation keys in `ranger'."
     :loader
-    (with-eval-after-load 'ranger BODY)
+    (spacemacs|use-package-add-hook ranger :post-config BODY)
     :common
     (kl/correct-keys ranger-mode-map
       "h"


### PR DESCRIPTION
For whatever-reason-unknown-to-me, this change is needed in order to
make key correction working now :-)