### PR TITLE
Fix Python jumping with async anaconda mode function.

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -49,7 +49,7 @@
             (concat spacemacs-cache-directory "anaconda-mode"))
       (add-hook 'python-mode-hook 'anaconda-mode)
       (add-hook 'spacemacs-jump-handlers-python-mode
-                'anaconda-mode-find-definitions))
+                '(anaconda-mode-find-definitions :async t)))
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'python-mode


### PR DESCRIPTION

Without this dumb-jump-go is often used if anaconda-mode-find-defintions
takes a little to return a result.

fix #6985