### PR TITLE
Replace org-set-tags when ivy layer is used

### DIFF
--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -35,3 +35,37 @@
 (defun spacemacs//surround-code ()
   (let ((dname (read-from-minibuffer "" "")))
     (cons (format "#+BEGIN_SRC %s" (or dname "")) "#+END_SRC")))
+
+(defun spacemacs//org-ctrl-c-ctrl-c-counsel-org-tag ()
+  "Hook for `org-ctrl-c-ctrl-c-hook' to use `counsel-org-tag'."
+  (if (save-excursion (beginning-of-line) (looking-at "[ \t]*$"))
+      (or (run-hook-with-args-until-success 'org-ctrl-c-ctrl-c-final-hook)
+          (user-error "C-c C-c can do nothing useful at this location"))
+    (let* ((context (org-element-context))
+           (type (org-element-type context)))
+      (case type
+        ;; When at a link, act according to the parent instead.
+        (link (setq context (org-element-property :parent context))
+              (setq type (org-element-type context)))
+        ;; Unsupported object types: refer to the first supported
+        ;; element or object containing it.
+        ((bold code entity export-snippet inline-babel-call inline-src-block
+               italic latex-fragment line-break macro strike-through subscript
+               superscript underline verbatim)
+         (setq context
+               (org-element-lineage
+                context '(radio-target paragraph verse-block table-cell)))))
+      ;; For convenience: at the first line of a paragraph on the
+      ;; same line as an item, apply function on that item instead.
+      (when (eq type 'paragraph)
+        (let ((parent (org-element-property :parent context)))
+          (when (and (eq (org-element-type parent) 'item)
+                     (= (line-beginning-position)
+                        (org-element-property :begin parent)))
+            (setq context parent type 'item))))
+
+      ;; Act according to type of element or object at point.
+      (case type
+        ((headline inlinetask)
+         (save-excursion (goto-char (org-element-property :begin context))
+                         (call-interactively 'counsel-org-tag)) t)))))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -328,7 +328,12 @@ Will work on both org-mode and any mode that accepts plain html."
             (org-eval-in-calendar '(calendar-backward-year 1))))
         (define-key org-read-date-minibuffer-local-map (kbd "M-J")
           (lambda () (interactive)
-            (org-eval-in-calendar '(calendar-forward-year 1))))))))
+            (org-eval-in-calendar '(calendar-forward-year 1)))))
+
+      ;; Default `org-set-tags' does not work well with ivy.
+      (when (configuration-layer/layer-usedp 'ivy)
+        (add-hook 'org-ctrl-c-ctrl-c-hook
+                  'spacemacs//org-ctrl-c-ctrl-c-counsel-org-tag)))))
 
 (defun org/init-org-agenda ()
   (use-package org-agenda


### PR DESCRIPTION
When ivy is used, the default org-set-tags will only complete for the
first tag, and any additional tags must be typed manually.  counsel
provides a replacement function to fix this.

See https://github.com/syl20bnr/spacemacs/issues/6918
