### PR TITLE
Completed instructions for a quick start with boot

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -80,7 +80,7 @@ Or set this variable when loading the configuration layer:
        'refactor-nrepl.middleware/wrap-refactor)
 #+END_SRC
 
-- Run ~SPC m s i~ in any of the clojure source files to connect to the CIDER REPL.
+- Run ~SPC m s i~ in any of the clojure source files to connect to the CIDER REPL.  Note that a build.boot file must be present in your working directory for Cider to recognize that you are using boot.
 
 *** Quick Start with lein
 - Install =lein= via your OS package manager.


### PR DESCRIPTION
As an absolute beginner, this took a while to figure out, and eventually required reading through Cider's source files.  

Currently, there *must* be a build.boot file present - an empty one works - if you want to start a repl through cider with boot.

https://github.com/clojure-emacs/cider/issues/1835