### PR TITLE
Fix get-package-directory regex

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -39,7 +39,7 @@
   "Return the directory of PKG. Return nil if not found."
   (let ((elpa-dir (file-name-as-directory package-user-dir)))
     (when (file-exists-p elpa-dir)
-      (let* ((pkg-match (concat (symbol-name pkg) "-[0-9]+"))
+      (let* ((pkg-match (concat "^" (symbol-name pkg) "-[0-9]+"))
              (dir (car (directory-files elpa-dir 'full pkg-match))))
         (when dir (file-name-as-directory dir))))))
 


### PR DESCRIPTION
Previous change in 5d6e9ab7892501079bba41afe0dcfb043d62be10 dropped the "/" marker to match at beginning of string. Since directory-files matches a regex, use "^" to indicate match at beginning of string.

Resolves #7002.