### PR TITLE
Buffer TS, :doc section, missing slash, 2 spaces

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -446,12 +446,13 @@
 
 (spacemacs|define-transient-state buffer
   :title "Buffer Selection Transient State"
+  :doc "\n[_n_] next  [_N_/_p_] previous  [_K_] kill  [_q_] quit"
   :bindings
-  ("n" next-buffer "next")
-  ("N" previous-buffer "previous")
-  ("p" previous-buffer "previous")
-  ("K" spacemacs/kill-this-buffer "kill")
-  ("q" nil "quit" :exit t))
+  ("n" next-buffer)
+  ("N" previous-buffer)
+  ("p" previous-buffer)
+  ("K" spacemacs/kill-this-buffer)
+  ("q" nil :exit t))
 (spacemacs/set-leader-keys "b." 'spacemacs/buffer-transient-state/body)
 
 ;; end of Buffer transient state


### PR DESCRIPTION
"[N p] previous" was missing a slash between the "N" and "p" keys, and the listed keys were written with "," (commas) between the keys and a "." (period) at the end, that's different from most of the other transient states. By adding a ":doc" section then the slash can be added, the commas and period won't appear and the keys can be separated with 2 spaces instead of 1.
