### PR TITLE
Completed instructions for a quick start with boot

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -85,7 +85,7 @@ REPL and skip the rest of this section.
        'refactor-nrepl.middleware/wrap-refactor)
 #+END_SRC
 
-- Run ~SPC m s i~ in any of the clojure source files to connect to the CIDER REPL.
+- Run ~SPC m s i~ in any of the clojure source files to connect to the CIDER REPL.  Note that a build.boot file must be present in your working directory for Cider to recognize the presence of boot.
 
 *** Quick Start with lein
 - Install =lein= version 2.5.2 or newer (see http://leiningen.org/#install)


### PR DESCRIPTION
Moved to develop branch, original pull request -

https://github.com/syl20bnr/spacemacs/pull/7003

As an absolute beginner, this took a while to figure out, and eventually required reading through Cider's source files.

Currently, there _must_ be a build.boot file present - an empty one works - if you want to start a repl through cider with boot.  This is a vital step in getting to a REPL.

Please feel free to edit the wording, if you have any suggestions!  

https://github.com/clojure-emacs/cider/issues/1835