### PR TITLE
Fix a typo in the version switching message

### DIFF
--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -78,7 +78,7 @@ users on `develop' branch must manually pull last commits instead."
              (if (spacemacs//git-hard-reset-to-tag tag)
                  (progn
                    (setq spacemacs-version version)
-                   (message "Succesfully switched to version %s" version))
+                   (message "Successfully switched to version %s" version))
                (message "An error occurred while switching to version %s"
                         version))))
           (t (message "Update aborted.")))))


### PR DESCRIPTION
This change changes the spelling of the word "Succesfully" to "Successfully" in the message that is displayed after updating Spacemacs.