### PR TITLE
fix void variable when not using osx layer

### DIFF
--- a/layers/+spacemacs/spacemacs-language/packages.el
+++ b/layers/+spacemacs/spacemacs-language/packages.el
@@ -10,7 +10,7 @@
 ;;; License: GPLv3
 
 (setq spacemacs-language-packages
-      '((define-word :toggle (not osx-use-dictionary-app))
+      '((define-word :toggle (not (bound-and-true-p osx-use-dictionary-app)))
         google-translate))
 
 (defun spacemacs-language/init-define-word ()


### PR DESCRIPTION
Fix `Symbol's value as variable is void: osx-use-dictionary-app` when
not using osx layer.

Check: https://github.com/syl20bnr/spacemacs/commit/047b57223a8913699bc9ce52aa3046d934f40c9f#commitcomment-18905104

Fix: #7042 