### PR TITLE
Fix documentation on Workspace mini state

### DIFF
--- a/layers/+window-management/eyebrowse/packages.el
+++ b/layers/+window-management/eyebrowse/packages.el
@@ -52,12 +52,14 @@
            "<" (if window-configs
                    (concat
                     (mapconcat 'spacemacs//workspaces-ms-get-slot-name
-                               window-configs "> <") ">")
-                 (when eyebrowse-display-help
-                   (concat
-                    "\n[0-9] to create/switch to a workspace, "
-                    "[n] next, [p/N] previous, [TAB] back and forth, [c] close, "
-                    "[r] rename"))))))
+                               window-configs "> <"))
+                 current-slot)
+           ">"
+           (when eyebrowse-display-help
+             (concat
+              "\n[0-9] to create/switch to a workspace, "
+              "[n] next, [p/N] previous, [TAB] back and forth, [c] close, "
+              "[r] rename")))))
 
       (spacemacs|define-micro-state workspaces
         :doc (spacemacs//workspaces-ms-documentation)


### PR DESCRIPTION
The Workspace documentation on the mini state was not being properly
displayed because the branching was only returning the documentation
when there was no workspaces definitions being returned.

This commit changes the branch to point to always include the
information if it has been configured with the variable.

This is a fix on top of **master**, instead of *develop*, as the configuration layer for `eyebrowser` has been removed in favour of `spacemacs-layouts`, and does not happen there anymore.

### Before:
<img width="1390" alt="screen shot 2016-09-06 at 3 07 45 pm" src="https://cloud.githubusercontent.com/assets/109474/18285361/695650d6-7444-11e6-8188-5b6b66c2b814.png">

### With fix:
<img width="1390" alt="screen shot 2016-09-06 at 3 07 21 pm" src="https://cloud.githubusercontent.com/assets/109474/18285362/695812fe-7444-11e6-9f07-b4ef19d31bf5.png">
