### PR TITLE
Common-lisp layer slime-company integration.

### DIFF
--- a/layers/+lang/common-lisp/config.el
+++ b/layers/+lang/common-lisp/config.el
@@ -10,3 +10,8 @@
 ;;; License: GPLv3
 
 (spacemacs|define-jump-handlers lisp-mode slime-inspect-definition)
+
+;; Company integration
+(spacemacs|defvar-company-backends lisp-mode)
+(defcustom enable-slime-company t
+  "If non nil enables the slime-company package. DEFAULT: t")

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -15,7 +15,16 @@
         ggtags
         helm
         helm-gtags
-        slime))
+        slime
+        auto-completion
+        (company :toogle lisp-mode-enable-slime-company)
+        (slime-company :toogle (configuration-layer/package-usedp 'company))))
+
+;; Hook company to common-lisp-mode
+(defun common-lisp/post-init-company ())
+
+;; Add the backend to the major mode specific backend list
+(defun common-lisp/init-slime-company ())
 
 (defun common-lisp/post-init-auto-highlight-symbol ()
   (with-eval-after-load 'auto-highlight-symbol
@@ -44,6 +53,8 @@
                              slime-sbcl-exts
                              slime-scratch)
             inferior-lisp-program "sbcl")
+      (when enable-slime-company
+        (push 'slime-company slime-contribs))
       ;; enable fuzzy matching in code buffer and SLIME REPL
       (setq slime-complete-symbol*-fancy t)
       (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)


### PR DESCRIPTION
Integration of slime-company contrib by default when using the common-lisp layer. Company auto complete will now work as well as all options from the slime-company (ie fuzzy matching). Also added a variable to disable/enable (enabled by default as no auto complete is working atm).

First contribution so tell me if I have done some conventions wrong and I will fix.

commit:

Add packages/init-functions. Add company conditional.

Initialize and define toggle variable.