### PR TITLE
Add Minitest support to Ruby Layer

### DIFF
--- a/layers/+lang/ruby/config.el
+++ b/layers/+lang/ruby/config.el
@@ -25,4 +25,4 @@
 Possible values are `rbenv', `rvm' or `chruby'.)")
 
 (defvar ruby-test-runner 'ruby-test
-  "Test runner to use. Possible values are `ruby-test' or `rspec'.")
+  "Test runner to use. Possible values are `ruby-test', `minitest' or `rspec'.")

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -51,3 +51,11 @@ Called interactively it prompts for a directory."
   "Conditionally enable `ruby-test-mode'"
   (when (eq 'ruby-test ruby-test-runner)
     (ruby-test-mode)))
+
+
+;; minitest
+
+(defun spacemacs//ruby-enable-minitest-mode ()
+  "Conditionally enable `minitest-mode'"
+  (when (eq 'minitest ruby-test-runner)
+    (minitest-enable-appropriate-mode)))

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -19,6 +19,7 @@
         flycheck
         ggtags
         helm-gtags
+        minitest
         popwin
         rbenv
         robe
@@ -84,6 +85,27 @@
 
 (defun ruby/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'ruby-mode))
+
+(defun ruby/init-minitest ()
+  (use-package minitest
+    :defer t
+    :init
+    (progn
+      (spacemacs/add-to-hooks 'spacemacs//ruby-enable-minitest-mode
+                              '(ruby-mode-local-vars-hook
+                                enh-ruby-mode-local-vars-hook))
+      ;; remove hooks added by minitest mode
+      (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+        (remove-hook hook 'minitest-enable-appropriate-mode)))
+    :config
+    (progn
+      (spacemacs|hide-lighter minitest-mode)
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "ta" 'minitest-verify-all
+          "tb" 'minitest-verify
+          "tr" 'minitest-rerun
+          "ts" 'minitest-verify-single)))))
 
 (defun ruby/post-init-popwin ()
   (push '("*rspec-compilation*" :dedicated t :position bottom :stick t :noselect t :height 0.4)


### PR DESCRIPTION
This is a fix for #6969 

I added support for Minitest via the [minitest-mode](https://github.com/arthurnn/minitest-emacs) package. 

This is my first time contributing to Spacemacs, and also the first time writing Emacs Lisp. I have tried to follow the guidelines and also learnt stuff by looking at the rspec mode support. I have tested it on rails projects and it works well. 