### PR TITLE
update scala layer readme javadoc variables

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -107,7 +107,7 @@ variable =scala-enable-eldoc= to =t=.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (scala :variables scala-use-java-doc-style t)))
+    (scala :variables scala-enable-eldoc t)))
 #+END_SRC
 
 Enabling this option can cause slow editor performance.


### PR DESCRIPTION
changed `scala-use-java-doc-style` to `scala-enable-eldoc` to reflect what it said above in the doc

deleted the `scala-indent:use-javadoc-style` section cause i didn't see any references to it in the repo
