### PR TITLE
python: really start REPL also in emacs 25.1

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -311,8 +311,22 @@
       (defun python-start-or-switch-repl ()
         "Start and/or switch to the REPL."
         (interactive)
-        (python-shell-switch-to-shell)
-        (evil-insert-state))
+        (let ((shell-process
+               (or (python-shell-get-process)
+                   ;; `run-python' has different return values and different
+                   ;; errors in different emacs versions. In 24.4, it throws an
+                   ;; error when the process didn't start, but in 25.1 it
+                   ;; doesn't throw an error, so we demote errors here and
+                   ;; check the process later
+                   (with-demoted-errors "Error: %S"
+                     ;; in Emacs 24.5 and 24.4, `run-python' doesn't return the
+                     ;; shell process
+                     (call-interactively #'run-python)
+                     (python-shell-get-process)))))
+          (unless shell-process
+            (error "Failed to start python shell properly"))
+          (pop-to-buffer (process-buffer shell-process))
+          (evil-insert-state)))
 
       ;; reset compile-command (by default it is `make -k')
       (setq compile-command nil)


### PR DESCRIPTION
Make `python-start-or-switch-repl` start a REPL when necessery also in Emacs 25.1. Fixes #6628.

The new version is supposed to work in Emacs 24.4, 24.5 and 25.1. For any daily python users: please confirm that this change doesn't break `SPC m '` if you're on 24.4 or 24.5, or confirm that it makes `SPC m '` work if you're on 25.1.

Edit: this PR also fixes #2872 