### PR TITLE
Fix wrong filename in a layer file’s header comment

### DIFF
--- a/layers/+emacs/better-defaults/keybindings.el
+++ b/layers/+emacs/better-defaults/keybindings.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Better Emacs Defaults Layer key bindings File
+;;; keybindings.el --- Better Emacs Defaults Layer key bindings File
 ;;
 ;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
 ;;


### PR DESCRIPTION
the header of `keybindings.el` in the `better-defaults` layer