### PR TITLE
[RDY] Remove support for jade-mode; add pug-mode

### DIFF
--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -18,8 +18,8 @@ This layer adds support for editing HTML and CSS.
 - Support for Sass/Scss and Less files
 - Generate HTML and CSS coding using [[https://github.com/smihica/emmet-mode][emmet-mode]]
 - Tags navigation on key ~%~ using [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
-- Support for editing Slim and Jade/Pug templates using [[https://github.com/slim-template/emacs-slim][slim-mode]]
-  and [[https://github.com/brianc/jade-mode][jade-mode]]
+- Support for editing Slim and Pug templates using [[https://github.com/slim-template/emacs-slim][slim-mode]]
+  and [[https://github.com/hlissner/emacs-pug-mode][pug-mode]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -19,8 +19,8 @@
     flycheck
     haml-mode
     (helm-css-scss :toggle (configuration-layer/package-usedp 'helm))
-    jade-mode
     less-css-mode
+    pug-mode
     sass-mode
     scss-mode
     slim-mode
@@ -104,8 +104,8 @@
 
 (defun html/post-init-flycheck ()
   (dolist (mode '(haml-mode
-                  jade-mode
                   less-mode
+                  pug-mode
                   sass-mode
                   scss-mode
                   slim-mode
@@ -123,19 +123,15 @@
     (dolist (mode '(css-mode scss-mode))
       (spacemacs/set-leader-keys-for-major-mode mode "gh" 'helm-css-scss))))
 
-(defun html/init-jade-mode ()
-  (use-package jade-mode
-    :defer t
-    :mode ("\\.pug$" . jade-mode)
-    :init
-    ;; Explicitly run prog-mode hooks since jade-mode does not derivate from
-    ;; prog-mode major-mode
-    (add-hook 'jade-mode-hook 'spacemacs/run-prog-mode-hooks)))
-
 (defun html/init-less-css-mode ()
   (use-package less-css-mode
     :defer t
     :mode ("\\.less\\'" . less-css-mode)))
+
+(defun html/init-pug-mode ()
+  (use-package pug-mode
+    :defer t
+    :mode ("\\.pug$" . pug-mode)))
 
 (defun html/init-sass-mode ()
   (use-package sass-mode


### PR DESCRIPTION
This removes jade-mode and add [pug-mode](https://github.com/hlissner/emacs-pug-mode). 

Jade has been deprecated and there is little need to support jade to
support jade anymore. If people need jade-mode, they can install the
package themselves and configure it. Pug is the renamed Jade project.