### PR TITLE
Use Magit 2.8's built-in fullscreen status display function

### DIFF
--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -34,29 +34,3 @@
                 (if (derived-mode-p 'magit-diff-mode)
                     magit-refresh-args
                   magit-diff-section-arguments))) (magit-refresh))
-
-(defun spacemacs//fullscreen-magit (buffer)
-  "Display Magit status buffer in fullscreen."
-  (if (or
-       ;; the original should stay alive, so we can't go fullscreen
-       magit-display-buffer-noselect
-       ;; don't go fullscreen for certain magit buffers if current
-       ;; buffer is a magit buffer (we're conforming to
-       ;; `magit-display-buffer-traditional')
-       (and (derived-mode-p 'magit-mode)
-            (not (memq (with-current-buffer buffer major-mode)
-                       '(magit-process-mode
-                         magit-revision-mode
-                         magit-diff-mode
-                         magit-stash-mode
-                         magit-status-mode)))))
-      ;; open buffer according to original magit rules
-      (magit-display-buffer-traditional buffer)
-    ;; open buffer in fullscreen
-    (delete-other-windows)
-    ;; make sure the window isn't dedicated, otherwise
-    ;; `set-window-buffer' throws an error
-    (set-window-dedicated-p nil nil)
-    (set-window-buffer nil buffer)
-    ;; return buffer's window
-    (get-buffer-window buffer)))

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -358,7 +358,7 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
         'spacemacs/magit-toggle-whitespace)
       ;; full screen magit-status
       (when git-magit-status-fullscreen
-        (setq magit-display-buffer-function 'spacemacs//fullscreen-magit)))))
+        (setq magit-display-buffer-function 'magit-display-buffer-fullframe-status-v1)))))
 
 (defun git/init-magit-gitflow ()
   (use-package magit-gitflow


### PR DESCRIPTION
Magit 2.8(changelog here https://emacsair.me/2016/08/21/magit-2.8/) added it's own set of display functions one of which is a fullscreen display function that acts the same way as Spacemacs' version. These are documented here https://magit.vc/manual/magit/Switching-Buffers.html. This removes the need for Spacemacs to maintain its own version of a fullscreen status function.
