### PR TITLE
Fix d-mode flycheck imports on dub projects

### DIFF
--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -34,7 +34,10 @@
 
 (defun d/init-flycheck-dmd-dub ()
   (use-package flycheck-dmd-dub :defer t
-    :init (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path)))
+    :init (progn
+            (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path)
+            (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-variables)
+            )))
 
 (defun d/post-init-ggtags ()
   (add-hook 'd-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
The d layer was missing a hook that caused dub projects to have wrong dependencies for flycheck.
