### PR TITLE
hint about where to put web-mode setq

### DIFF
--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -82,7 +82,7 @@ Be sure to have the ~e4x~ option set to ~true~ on your ~.jsbeautifyrc~ here it i
 
 You may refer to the =web-mode= configuration for fine tuning the indenting behaviour.
 
-For example to have a consistent 2 spaces indenting both on =js= and =jsx= you may use these settings:
+For example to have a consistent 2 spaces indenting both on =js= and =jsx= you may use these settings in `dotspacemacs/user-init`:
 
 #+begin_src emacs-lisp
   (setq-default


### PR DESCRIPTION
Web-mode ignores settings set in `dotspacemacs/user-config` on the file opened at launch (though it picks them up for subsequent files), so it took me a while to figure out that I needed to put them in `dotspacemacs/user-init`. This might be nice to save some other people the anguish.