### PR TITLE
Add more features for D language

### DIFF
--- a/layers/+lang/d/README.org
+++ b/layers/+lang/d/README.org
@@ -5,6 +5,7 @@
 * Table of Contents                                         :TOC_4_gh:noexport:
  - [[#description][Description]]
  - [[#install][Install]]
+ - [[#key-bindings][Key bindings]]
 
 * Description
 This simple layer adds support for the [[http://dlang.org/][D language]].
@@ -14,3 +15,18 @@ It adds =d-mode= as well as integrating it with =auto-completion= and =syntax-ch
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =d= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+To enable smart D completion, you need to install [[https://github.com/Hackerpilot/DCD][DCD]]. Here are [[https://github.com/Hackerpilot/DCD#setup][installation
+instructions]]. After successfully built DCD, you need to copy the binary
+=dcd-server= and  =dcd-client= in =bin/= directory to somewhere in your $PATH e.g.
+=/usr/local/bin= on Linux.
+
+* Key bindings
+
+| Key Binding | Description                                           |
+|-------------+-------------------------------------------------------|
+| ~SPC m g g~ | Go to definition                                      |
+| ~SPC m g b~ | Jump back (after go to definition with above command) |
+| ~SPC m g r~ | find references to all symbol at point                |
+|-------------+-------------------------------------------------------|
+

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -14,6 +14,7 @@
 (setq d-packages
       '(
         company
+        (company-dcd :toggle (configuration-layer/package-usedp 'company))
         d-mode
         flycheck
         (flycheck-dmd-dub :toggle (configuration-layer/package-usedp 'flycheck))
@@ -25,6 +26,19 @@
   ;; Need to convince company that this C-derived mode is a code mode.
   (with-eval-after-load 'company-dabbrev-code (push 'd-mode company-dabbrev-code-modes))
   (spacemacs|add-company-hook d-mode))
+
+(defun d/init-company-dcd ()
+  (use-package company-dcd
+    :defer t
+    :init
+    (progn
+      (add-hook 'd-mode-hook 'company-dcd-mode)
+      (push 'company-dcd company-backends-d-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'd-mode
+        "gg" 'company-dcd-goto-definition
+        "gb" 'company-dcd-goto-def-pop-marker
+        "hh" 'company-dcd-show-ddoc-with-buffer
+        "gr" 'company-dcd-ivy-search-symbol))))
 
 (defun d/init-d-mode ()
   (use-package d-mode :defer t))


### PR DESCRIPTION
Add `company-dcd` package that uses DCD (a completion daemon for D) to
provide better IDE features:

- Better code completion.
- Jump to definition.
- Search symbol references.