### PR TITLE
Add magit-repolist support

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -284,4 +284,4 @@ stanza insert the following with the directories of your choice:
 |-------------+------------------------------------------------------------------------|
 | ~gL~        | start git repo list                                                    |
 | ~RETURN~    | show the git status window for the selected project                    |
-| ~g~         | refresh the project list                                               |
+| ~gr~        | refresh the project list                                               |

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -23,6 +23,7 @@
    - [[#git-flow-1][Git-Flow]]
    - [[#git-time-machine][Git time machine]]
    - [[#git-links-to-web-services][Git links to web services]]
+   - [[#git-magit-repolist][Repo List]]
 
 * Description
 This layers adds extensive support for [[http://git-scm.com/][git]].
@@ -111,6 +112,7 @@ Git commands (start with ~g~):
 | ~SPC g H h~ | highlight regions by age of commits                 |
 | ~SPC g H t~ | highlight regions by last updated time              |
 | ~SPC g I~   | open =helm-gitignore=                               |
+| ~SPC g L~   | open magit-repolist                                 |
 | ~SPC g s~   | open a =magit= status window                        |
 | ~SPC g S~   | stage current file                                  |
 | ~SPC g m~   | magit dispatch popup                                |
@@ -266,3 +268,20 @@ or lines in a file hosted on Git web services like GitHub, GitLab, Bitbucket...
 - When the link is opened, the URL is also copied in the kill ring, you can
   override this behavior by setting the variable =git-link-open-in-browser= to
   =nil=.
+
+** Repo List
+
+This feature will show a list of git directories. The feature needs slight
+configuration within your `.spacemacs` config. In the `dotspacemacs/user-config()` 
+stanza insert the following with the directories of your choice:
+
+```
+ (setq magit-repository-directories 
+      '( "~/Development" ))
+```
+
+| Key Binding | Description                                                            |
+|-------------+------------------------------------------------------------------------|
+| ~gL~        | start git repo list                                                    |
+| ~RETURN~    | show the git status window for the selected project                    |
+| ~g~         | refresh the project list                                               |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -158,7 +158,7 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
       (evilified-state-evilify-map magit-repolist-mode-map
           :mode magit-repolist-mode
           :bindings
-          (kbd "g") 'magit-list-repositories
+          (kbd "gr") 'magit-list-repositories
           (kbd "RET") 'magit-repolist-status)
       (unless (configuration-layer/package-usedp 'evil-magit)
         ;; use auto evilification if `evil-magit' is not used

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -124,6 +124,7 @@
       (spacemacs/set-leader-keys
         "gb"  'spacemacs/git-blame-micro-state
         "gfh" 'magit-log-buffer-file
+        "gL"  'magit-list-repositories
         "gm"  'magit-dispatch-popup
         "gs"  'magit-status
         "gS"  'magit-stage-file
@@ -154,6 +155,11 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
       (require 'git-rebase)
       ;; bind function keys
       ;; (define-key magit-mode-map (kbd "<tab>") 'magit-section-toggle)
+      (evilified-state-evilify-map magit-repolist-mode-map
+          :mode magit-repolist-mode
+          :bindings
+          (kbd "g") 'magit-list-repositories
+          (kbd "RET") 'magit-repolist-status)
       (unless (configuration-layer/package-usedp 'evil-magit)
         ;; use auto evilification if `evil-magit' is not used
         (evilified-state-evilify-map magit-mode-map


### PR DESCRIPTION
Adds Magit Repolist support.

Bindings:

`SPC gL`
`RET`
`g`

Fixes #7083 