### PR TITLE
Add open packages.el shortcut in spacemacs-help

### DIFF
--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -205,6 +205,9 @@
     (define-key map (kbd "<S-return>") '(lambda () (interactive)
                                           ;; Add Layer
                                           (helm-select-nth-action 3)))
+    (define-key map (kbd "<M-return>") '(lambda () (interactive)
+                                          ;; Open packages.el
+                                          (helm-select-nth-action 1)))
     map)
   "Keymap for Spacemacs Layers sources")
 


### PR DESCRIPTION
I find myself wanting to open the package.el and f3 is just too far away
in my keyboard. And I thought maybe this would be something people might
want. Also maybe we could have special binding for actions? like `C-1`
`C-2`, etc