### PR TITLE
Run kill-emacs-query-functions when exiting

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -588,12 +588,14 @@ dotspacemacs-persistent-server to be t"
 (defun spacemacs/kill-emacs ()
   "Lose all changes and exit Spacemacs"
   (interactive)
+  (run-hook-with-args-until-failure 'kill-emacs-query-functions)
   (setq spacemacs-really-kill-emacs t)
   (kill-emacs))
 
 (defun spacemacs/prompt-kill-emacs ()
   "Prompt to save changed buffers and exit Spacemacs"
   (interactive)
+  (run-hook-with-args-until-failure 'kill-emacs-query-functions)
   (setq spacemacs-really-kill-emacs t)
   (save-some-buffers)
   (kill-emacs))


### PR DESCRIPTION
Fix https://github.com/syl20bnr/spacemacs/issues/7105

I have some better quit functionality in mind but this will be fine for now.