### PR TITLE
Additional home buffer fixes

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -870,7 +870,7 @@ already exist, and switch to it."
   (interactive)
   (let ((buffer-exists (buffer-live-p (get-buffer spacemacs-buffer-name)))
         (save-line nil))
-    (when (or (not (eq spacemacs-buffer--last-width spacemacs-buffer--banner-length))
+    (when (or (not (eq spacemacs-buffer--last-width (window-width)))
               (not buffer-exists)
               refresh)
       (setq spacemacs-buffer--banner-length (window-width)
@@ -901,9 +901,9 @@ already exist, and switch to it."
           (progn (goto-char (point-min))
                  (forward-line (1- save-line))
                  (forward-to-indentation 0))
-        (spacemacs-buffer/goto-link-line))))
-  (switch-to-buffer spacemacs-buffer-name)
-  (spacemacs//redisplay))
+        (spacemacs-buffer/goto-link-line))
+      (switch-to-buffer spacemacs-buffer-name)
+      (spacemacs//redisplay))))
 
 (add-hook 'window-setup-hook
           (lambda ()
@@ -917,7 +917,7 @@ already exist, and switch to it."
                space-win
                (not (window-minibuffer-p frame-win)))
       (with-selected-window space-win
-        (spacemacs-buffer/goto-buffer t)))))
+        (spacemacs-buffer/goto-buffer)))))
 
 (defun spacemacs-buffer/refresh ()
   "Force recreation of the spacemacs buffer."


### PR DESCRIPTION
CC @deb0ch. Does this make sense? Fixes https://github.com/syl20bnr/spacemacs/issues/7116

Rationale: Doesn't make sense to force redisplay every time the window configuration changes. Only when the width changes. I assume the condition should have checked `(window-width)` since the value of `--last-width` and `--banner-length` is the same (as per the `setq`), so the current condition will never fire. When I make these changes the redrawing correctly happens only when the width changes and not on every window configuration change.

Also don't redisplay every time even if nothing changes. That really shouldn't have to happen.