### PR TITLE
Never use negative widths when formatting the spacemacs buffer caption.

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -477,8 +477,8 @@ The vertical spacing is always one line."
        "╭─"
        (if caption
            (concat caption
-                   (make-string (+ (- fill-column caption-len 1)
-                                   hpadding) ?─))
+                   (make-string (max 0 (+ (- fill-column caption-len 1)
+                                   hpadding)) ?─))
          (make-string fill-column ?─))
        (make-string hpadding ?─) "╮\n"
        ;; content


### PR DESCRIPTION
Fixes: #7114