### PR TITLE
dumb-jump: bind key instead of enable mode

### DIFF
--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -20,11 +20,15 @@
     :defer t
     :init
     (progn
+      ;; not activating `dumb-jump-mode' because it only adds key bindings, and
+      ;; they conflict with existing bindings (see
+      ;; https://github.com/syl20bnr/spacemacs/issues/7107)
+
+      (spacemacs/set-leader-keys "jq" #'dumb-jump-quick-look)
       ;; Since it's dumb, we add it to the end of the default jump handlers. At
       ;; the time of writing it is the only default jump handler. (gtags remains
       ;; mode-local)
-      (add-to-list 'spacemacs-default-jump-handlers 'dumb-jump-go 'append)
-      (add-hook 'prog-mode-hook 'dumb-jump-mode))))
+      (add-to-list 'spacemacs-default-jump-handlers 'dumb-jump-go 'append))))
 
 (defun spacemacs-misc/init-request ()
   (setq request-storage-directory


### PR DESCRIPTION
Fixes #7107. We don't need to enable `dumb-jump-mode` because all it does is add key bindings that we don't need (resulting in #7107). I decided to bind `dumb-jump-quick-look` because it appears useful, and chose `SPC d q` (for **d**efinition/**d**umb **q**uick-look).