### PR TITLE
Fix typo in nyan cat var docstring

### DIFF
--- a/layers/+themes/colors/config.el
+++ b/layers/+themes/colors/config.el
@@ -16,7 +16,7 @@
 programming language buffers.")
 
 (defvar colors-enable-nyan-cat-progress-bar nil
-  "If non nil all nyan cat packges are enabled (for now only `nyan-mode').")
+  "If non nil all nyan cat packages are enabled (for now only `nyan-mode').")
 
 (defvar colors-theme-identifiers-sat&light
   '((jazz . (50 55))


### PR DESCRIPTION
Simple typo: packges -> packages.
