### PR TITLE
layouts: persp-mode changed variable to enable ido-hooks

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -108,7 +108,7 @@
             persp-reset-windows-on-nil-window-conf nil
             persp-set-last-persp-for-new-frames nil
             persp-save-dir spacemacs-layouts-directory
-            persp-hook-up-emacs-buffer-completion t)
+            persp-set-ido-hooks t)
 
       (defun spacemacs//activate-persp-mode ()
         "Always activate persp-mode, unless it is already active.


### PR DESCRIPTION
Since persp-mode 2.5 the way to enable ido hooks changed again. Without this, SPC b b lists all buffers instead of persp-local ones.