### PR TITLE
Update layer docs for packages.el to note where should local packages reside

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -335,8 +335,7 @@ as follows:
 
 The =:location= attribute specifies where the package may be found. Spacemacs
 currently supports packages on ELPA compliant repositories, local packages and
-MELPA recipes (through the Quelpa package). See the [[https://github.com/milkypostman/melpa#recipe-format][MELPA documentation]] for more
-information about recipes.
+MELPA recipes (through the Quelpa package). Local packages should reside at =<layer>/local/<package>/=. For information about recipes see the [[https://github.com/milkypostman/melpa#recipe-format][MELPA documentation]].
 
 Packages may be /excluded/ by setting the =:excluded= property to true. This
 will prevent the package from being installed even if it is used by another


### PR DESCRIPTION
The information about location of local packages is noted in the parent section. While this can be considered enough I kept re-reading `packages.el` and couldn't find the information. Adding the information here as well makes the section more self-contained.