### PR TITLE
Added ensime folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ python-*-docs-html
 /session.*
 /srecode-map.el
 /recentf
+ensime/
 
 # Private directory
 private/


### PR DESCRIPTION
Ensime creates the folder "ensime" in .emacs.d on start to store local classpath info. Added it to .gitignore so that it doesn't dirty the repo state.
