### PR TITLE
fix python-start-or-switch-repl bug

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -311,8 +311,18 @@
       (defun python-start-or-switch-repl ()
         "Start and/or switch to the REPL."
         (interactive)
-        (python-shell-switch-to-shell)
-        (evil-insert-state))
+        (if (python-shell-get-process)
+            (progn
+              (python-shell-switch-to-shell)
+              (evil-insert-state)
+              )
+            (progn
+              (run-python)
+              (python-shell-switch-to-shell)
+              (evil-insert-state)
+            )
+          )
+        )
 
       ;; reset compile-command (by default it is `make -k')
       (setq compile-command nil)


### PR DESCRIPTION
Fixes #2872
`python-shell-switch-to-shell` doesn't create a new python process if one doesn't already exist. Thus when `python-start-or-switch-repl` was called with `SPC m s i` without an existing python process running somewhere, you would get the error `No inferior Python process running.`