### PR TITLE
fix latexmk not using xetex

### DIFF
--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -126,6 +126,7 @@
     :init
     (progn
       (setq auctex-latexmk-inherit-TeX-PDF-mode t)
+      (require 'auctex-latexmk)
       (spacemacs|use-package-add-hook tex
         :post-config
         (auctex-latexmk-setup)))))


### PR DESCRIPTION
Fix latexmk working with xetex

Hi, i dont know if my problem is universal but I fixed it and this was my solution.  Feel free to edit or anything.  I previously used this emacs configuration: https://github.com/basille/.emacs.d/ where latexmk works with xetex. By comparing the configurations I came up with this solution. Why it works with this change is black magic to me. 

Problem Description:
When editing an xetex document in auctex LatexMk chooses pdflatex and fails. 
How to reproduce:
1) create xelatex document with the following content:

```
\documentclass{article}
\usepackage{fontspec}
\begin{document}
This is a unicode Test: Ä
\end{document}
%%% Local Variables:
%%% coding: utf-8
%%% mode: latex
%%% TeX-engine: xetex
%%% TeX-master: t
%%% End:
```

2) Press C-c C-c and choose Latexmk as command

Observed behaviour: :eyes: :broken_heart:

```
ERROR: Fatal fontspec error: "cannot-use-pdftex"

--- TeX said ---
! 
! The fontspec package requires either XeTeX or LuaTeX to function.
! 
Observed behaviour: :eyes: :broken_heart:
ERROR: Fatal fontspec error: "cannot-use-pdftex"

--- TeX said ---
! 
! The fontspec package requires either XeTeX or LuaTeX to function.
! 
! You must change your typesetting engine to, e.g., "xelatex" or "lualatex"
! instead of plain "latex" or "pdflatex".
! 
! See the fontspec documentation for further information.
! 
! For immediate help type H <return>.
!...............................................  

l.41  }

--- HELP ---
No help available

```

Expected behavior:
`LaTeX: successfully formatted {1} page`
