### PR TITLE
Add Colemak layout to keyboard-layout layer

### DIFF
--- a/layers/+intl/keyboard-layout/README.org
+++ b/layers/+intl/keyboard-layout/README.org
@@ -156,6 +156,23 @@ found at the [[https://colemak.com/][Colemak website]].
 
 [[file:img/colemak-layout.png]]
 
+The configuration `colemak-jkhl` reuses HJKL as movement keys, but permuted as
+JKHL:
+- ~j~ is now left
+- ~k~ is now down
+- ~h~ is now up
+- ~l~ is right, unchanged
+
+While not on the home row, the keys are still easily accessible and do not
+conflict with any other ~evil~ binding.
+
+Additionally, in normal and motion states, ~L~ is bound to ~evil-lookup~ while
+~H~ and ~K~ are respectively bound to ~evil-window-top~ and
+~evil-window-bottom~.
+
+*Note*: for technical reasons (see [[https://github.com/syl20bnr/spacemacs/pull/7178#issuecomment-249360301][GH-7178]]), the ~kl/pre-config-evil~ and
+~kl/post-config-evil~ hooks will be run /twice/.
+
 * Package Configurations
 The available configurations are:
 

--- a/layers/+intl/keyboard-layout/README.org
+++ b/layers/+intl/keyboard-layout/README.org
@@ -156,22 +156,17 @@ found at the [[https://colemak.com/][Colemak website]].
 
 [[file:img/colemak-layout.png]]
 
-The configuration `colemak-jkhl` reuses HJKL as movement keys, but permuted as
-JKHL:
-- ~j~ is now left
-- ~k~ is now down
-- ~h~ is now up
-- ~l~ is right, unchanged
+This layer offers three flavors of Colemak bindings:
 
-While not on the home row, the keys are still easily accessible and do not
-conflict with any other ~evil~ binding.
+- =colemak-hnei= remaps ~HJKL~ to ~HNEI~, keeping the same key location; useful
+  for people used to the ~HJKL~ scheme on a Qwerty keyboard.
+- =colemak-neio= remaps ~HJKL~ to ~NEIO~, shifted one key to the right for
+  easier access.
+- =colemak-jkhl= remaps ~HJKL~ to ~JKHL~, permuting the direction of the keys
+  without disturbing any other binding.
 
-Additionally, in normal and motion states, ~L~ is bound to ~evil-lookup~ while
-~H~ and ~K~ are respectively bound to ~evil-window-top~ and
-~evil-window-bottom~.
-
-*Note*: for technical reasons (see [[https://github.com/syl20bnr/spacemacs/pull/7178#issuecomment-249360301][GH-7178]]), the ~kl/pre-config-evil~ and
-~kl/post-config-evil~ hooks will be run /twice/.
+*Note*: for technical reasons (see [[https://github.com/syl20bnr/spacemacs/pull/7178#issuecomment-249360301][GH-7178]]), when using =colemak-jkhl=, the
+~kl/pre-config-evil~ and ~kl/post-config-evil~ hooks will be run /twice/.
 
 * Package Configurations
 The available configurations are:

--- a/layers/+intl/keyboard-layout/config.el
+++ b/layers/+intl/keyboard-layout/config.el
@@ -15,7 +15,8 @@
 
 (defvar kl-layout 'dvorak
   "The keyboard-layout to use. Possible values are
-`dvorak',`bepo', `colemak' and `colemak-jkhl'.")
+`dvorak',`bepo', `colemak-hnei', `colemak-hnei` and
+`colemak-jkhl'.")
 
 (defvar kl-enabled-configurations nil
   "If non nil, `keyboard-layout' will enable configurations only
@@ -42,15 +43,6 @@ case.")
              ("j" . "t")
              ("k" . "s")
              ("l" . "c")))
-    (colemak . (("n" . "h")
-                ("e" . "j")
-                ("i" . "k")
-                ("o" . "l")
-                ;;
-                ("h" . "n")
-                ("j" . "e")
-                ("k" . "i")
-                ("l" . "o")))
     (dvorak . (("h" . "h")
                ("t" . "j")
                ("n" . "k")
@@ -60,15 +52,24 @@ case.")
                ("j" . "t")
                ("k" . "n")
                ("l" . "s")))
-    (colemak . (("h" . "h")
-                ("n" . "j")
-                ("e" . "k")
-                ("i" . "l")
-                ;;
-                ("h" . "h")
-                ("j" . "n")
-                ("k" . "e")
-                ("l" . "i")))
+    (colemak-neio . (("n" . "h")
+                     ("e" . "j")
+                     ("i" . "k")
+                     ("o" . "l")
+                     ;;
+                     ("h" . "n")
+                     ("j" . "e")
+                     ("k" . "i")
+                     ("l" . "o")))
+    (colemak-hnei . (("h" . "h")
+                     ("n" . "j")
+                     ("e" . "k")
+                     ("i" . "l")
+                     ;;
+                     ("h" . "h")
+                     ("j" . "n")
+                     ("k" . "e")
+                     ("l" . "i")))
     (colemak-jkhl . (("j" . "h")
                      ("k" . "j")
                      ("h" . "k")

--- a/layers/+intl/keyboard-layout/config.el
+++ b/layers/+intl/keyboard-layout/config.el
@@ -14,7 +14,8 @@
 ;;------------------------------------------------------------------------------
 
 (defvar kl-layout 'dvorak
-  "The keyboard-layout to use. Possible values are `colemak', `dvorak' and `bepo'.")
+  "The keyboard-layout to use. Possible values are
+`dvorak',`bepo', `colemak' and `colemak-jkhl'.")
 
 (defvar kl-enabled-configurations nil
   "If non nil, `keyboard-layout' will enable configurations only
@@ -24,8 +25,8 @@ for the passed list of symbols. Configurations that are also in
 (defvar kl-disabled-configurations nil
   "If non nil, `keyboard-layout' will disable configurations for
 the passed list of symbols. This list takes priority over
-`kl-enabled-configurations', so they will not be loaded in
-any case.")
+`kl-enabled-configurations', so they will not be loaded in any
+case.")
 
 ;;------------------------------------------------------------------------------
 ;; PRIVATE VARIABLES
@@ -67,10 +68,19 @@ any case.")
                 ("h" . "h")
                 ("j" . "n")
                 ("k" . "e")
-                ("l" . "i"))))
+                ("l" . "i")))
+    (colemak-jkhl . (("j" . "h")
+                     ("k" . "j")
+                     ("h" . "k")
+                     ("l" . "l")
+                     ;;
+                     ("h" . "j")
+                     ("j" . "k")
+                     ("k" . "h")
+                     ("l" . "l"))))
   "The base rebinding map. Dots should be read as `will behave
-  as'. It should be a bidirectional mapping, i.e. all present
-  keys should be once in each column.")
+as'. It should be a bidirectional mapping, i.e. all present keys
+should be once in each column.")
 
 (defvar kl--rebinding-maps
   (mapcar (lambda (map) `(,(car map) . ,(kl//generate-full-rebinding-map (cdr map))))

--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -42,10 +42,12 @@
     (spacemacs|use-package-add-hook ace-window :post-init BODY)
     :bepo
     (setq aw-keys '(?a ?u ?i ?e ?t ?s ?r ?n))
-    :colemak
-    (setq aw-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
     :dvorak
     (setq aw-keys '(?a ?o ?e ?u ?h ?t ?n ?s))
+    :colemak-neio
+    (setq aw-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
+    :colemak-hnei
+    (setq aw-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
     :colemak-jkhl
     (setq aw-keys '(?a ?r ?s ?t ?n ?e ?i ?o))))
 
@@ -57,10 +59,12 @@
     (spacemacs|use-package-add-hook avy :post-init BODY)
     :bepo
     (setq-default avy-keys '(?a ?u ?i ?e ?t ?s ?r ?n))
-    :colemak
-    (setq-default avy-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
     :dvorak
     (setq-default avy-keys '(?a ?o ?e ?u ?h ?t ?n ?s))
+    :colemak-neio
+    (setq-default avy-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
+    :colemak-hnei
+    (setq-default avy-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
     :colemak-jkhl
     (setq-default avy-keys '(?a ?r ?s ?t ?n ?e ?i ?o))))
 
@@ -199,7 +203,7 @@
     (spacemacs|use-package-add-hook evil-escape :post-init BODY)
     :bepo
     (setq-default evil-escape-key-sequence "gq")
-    :colemak
+    :colemak-neio
     (setq-default evil-escape-key-sequence "tn")))
 
 (defun keyboard-layout/pre-init-evil-evilified-state ()
@@ -480,7 +484,7 @@
         ;; additional
         (kbd "«") 'org-metaleft
         (kbd "»") 'org-metaright))
-    :colemak
+    :colemak-neio
     (progn
       (spacemacs|use-package-add-hook evil-org
         :post-config

--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -45,7 +45,9 @@
     :colemak
     (setq aw-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
     :dvorak
-    (setq aw-keys '(?a ?o ?e ?u ?h ?t ?n ?s))))
+    (setq aw-keys '(?a ?o ?e ?u ?h ?t ?n ?s))
+    :colemak-jkhl
+    (setq aw-keys '(?a ?r ?s ?t ?n ?e ?i ?o))))
 
 (defun keyboard-layout/pre-init-avy ()
   (kl|config avy
@@ -58,7 +60,9 @@
     :colemak
     (setq-default avy-keys '(?a ?r ?s ?t ?n ?e ?i ?o))
     :dvorak
-    (setq-default avy-keys '(?a ?o ?e ?u ?h ?t ?n ?s))))
+    (setq-default avy-keys '(?a ?o ?e ?u ?h ?t ?n ?s))
+    :colemak-jkhl
+    (setq-default avy-keys '(?a ?r ?s ?t ?n ?e ?i ?o))))
 
 (defun keyboard-layout/pre-init-comint ()
   (kl|config comint-mode
@@ -142,7 +146,13 @@
     ;; Invert it twice to reset `k' and `K' for searching
     (dolist (map kl--all-evil-states-but-insert)
       (kl/correct-keys map
-        "K")))
+        "K"))
+    :colemak-jkhl
+    (progn
+      (define-key evil-motion-state-map "J" 'evil-join)
+      (define-key evil-motion-state-map "K" 'evil-window-bottom)
+      (define-key evil-motion-state-map "H" 'evil-window-top)
+      (define-key evil-motion-state-map "L" 'evil-lookup)))
 
   (kl|config evil-window
     :description
@@ -167,6 +177,19 @@
         "wé" 'other-window
         "wq" 'delete-window)
       (kl/leader-alias-of "é" "w"))))
+
+;; HACK: These are defined by the spacemacs-bootstrap layer, and this is the
+;; only I've found to make them stick.  An unfortunate consequence of using
+;; `kl|config evil' twice is that user hooks for this configuration will be run
+;; twice as well.
+(defun keyboard-layout/post-init-evil ()
+  (kl|config evil
+    :description
+    "Remap `evil' bindings."
+    :colemak-jkhl
+    (progn
+      (define-key evil-normal-state-map "K" nil)
+      (define-key evil-normal-state-map "L" 'spacemacs/evil-smart-doc-lookup))))
 
 (defun keyboard-layout/pre-init-evil-escape ()
   (kl|config evil-escape
@@ -263,7 +286,13 @@
       (kl/set-in-state helm-find-files-map "C-k" 'helm-ff-run-grep)
       (kl/set-in-state helm-find-files-map "C-r" 'helm-maybe-exit-minibuffer)
       (kl/set-in-state helm-read-file-map "C-s" 'helm-previous-line)
-      (kl/set-in-state helm-read-file-map "C-K" 'helm-previous-line)))
+      (kl/set-in-state helm-read-file-map "C-K" 'helm-previous-line))
+
+    :colemak-jkhl
+    (progn
+      ;; HACK: Forced to correct wrong behaviour
+      (kl/set-in-state helm-find-files-map "C-h" 'helm-previous-line)
+      (kl/set-in-state helm-find-files-map "C-j" 'helm-find-files-up-one-level)))
 
   (kl|config helm-locate
     :description
@@ -347,7 +376,12 @@
     (progn
       (magit-change-popup-key 'magit-dispatch-popup :actions ?t ?j)
       (magit-change-popup-key 'magit-dispatch-popup :actions ?s ?k)
-      (magit-change-popup-key 'magit-dispatch-popup :actions ?S ?K))))
+      (magit-change-popup-key 'magit-dispatch-popup :actions ?S ?K))
+    :colemak-jkhl
+    (progn
+      (kl/evil-correct-keys 'visual magit-mode-map
+        "j"
+        "k"))))
 
 (defun keyboard-layout/pre-init-mu4e ()
   (kl|config mu4e


### PR DESCRIPTION
This commit remaps the HJKL movement keys to JKHL.

See https://colemak.com/ for a description of the Colemak layout.

See #6631 for a background discussion.
### Remaining issues

I would consider this layour useable as is, but far from complete. 
At the very least, this coulp help Colemak users of Spacemacs to get something going without diving into too much Elisp.

Here are a couple of annoying issues that I did not manage to fix yet:
- Lost the binding to `evil-join` which was `J` by default.  Now `J` maps to `evil-window-top` and `evil-join` is unbound.
- In magit, `H` and `K` are correctly rebound to `evil-previous-visual-line` and `evil-next-visual-line`, but not when entering visual mode, where `H` becomes `evil-lookup` and `K` becomes `evil-previous-visual-line`.  This is puzzling to me,  as they are correctly bound in visual mode outside of magit.

cc @StreakyCobra.
