### PR TITLE
Add cmake-ide to lang/c-c++ layer

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -32,6 +32,9 @@ scripts.
 - Support auto-completion (when =auto-completion= layer is included) via
   company-clang (when =c-c++-enable-clang-support= is turned on), or
   company-ycmd (when =ycmd= layer is included).
+- Support for CMake configure/build (with limited support for other build systems),
+  automatic generation of =compile_commands.json= (compile flags), on-the-fly configuration
+  of flycheck, company-clang and RTags (if installed) with [[https://github.com/atilaneves/cmake-ide][cmake-ide]] .
 
 * Install
 ** Layer
@@ -102,5 +105,7 @@ doesn't complain about missing header files.
 | ~SPC m g A~ | open matching file in another window (e.g. switch between .cpp and .h) |
 | ~SPC m D~   | disaster: disassemble c/c++ code                                       |
 | ~SPC m r~   | srefactor: refactor thing at point.                                    |
+| ~SPC m p~   | Project / Build system management                                      |
+| ~SPC m c c~ | Compile project                                                        |
 
 *Note:*  [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]]  is only available for Emacs 24.4+

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -14,6 +14,7 @@
     cc-mode
     disaster
     clang-format
+    cmake-ide
     cmake-mode
     company
     (company-c-headers :toggle (configuration-layer/package-usedp 'company))
@@ -41,12 +42,13 @@
     (progn
       (require 'compile)
       (c-toggle-auto-newline 1)
-      (spacemacs/set-leader-keys-for-major-mode 'c-mode
-        "ga" 'projectile-find-other-file
-        "gA" 'projectile-find-other-file-other-window)
-      (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-        "ga" 'projectile-find-other-file
-        "gA" 'projectile-find-other-file-other-window))))
+      (dolist (mode '(c++-mode c-mode))
+        (spacemacs/declare-prefix-for-mode mode "mc" "compile")
+        (spacemacs/declare-prefix-for-mode mode "mg" "goto")
+        (spacemacs/declare-prefix-for-mode mode "mp" "project/build system")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "ga" 'projectile-find-other-file
+          "gA" 'projectile-find-other-file-other-window)))))
 
 (defun c-c++/init-disaster ()
   (use-package disaster
@@ -62,6 +64,18 @@
 (defun c-c++/init-clang-format ()
   (use-package clang-format
     :if c-c++-enable-clang-support))
+
+(defun c-c++/init-cmake-ide ()
+  (use-package cmake-ide)
+    :config
+    (progn
+      (cmake-ide-setup)
+      (dolist (mode '(c++-mode c-mode))
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "cc" 'cmake-ide-compile
+          "pc" 'cmake-ide-run-cmake
+          "pC" 'cmake-ide-maybe-run-cmake
+          "pd" 'cmake-ide-delete-file))))
 
 (defun c-c++/init-cmake-mode ()
   (use-package cmake-mode


### PR DESCRIPTION
cmake-ide nicely orchestrates between cmake, flycheck, company-clang and RTags by using cmake to generate a compile_commands.json that it uses to set the appropriate compile flags for flycheck and company-clang. This nicely centralizes all build related settings where they belong: in the build system itself.

It comes with a zero need for configuration and usually works just out of the box. Nevertheless, and recommended as well, build directory and additional compile flags (...) can also be set through directory local variables. In the future, we could improve here on the user experience by providing an automatic and predicable naming scheme for build dirs that the user can partially influence through a base directory variable. With that in place, those build directories would be fully automatic and
still reusable by cmake-ide.

Since cmake-ide makes it a breeze to use RTags by automating much of the necessary setup, I see this as a precursor to proper RTags support which also requires the rtags lisp package to be installed and required along with the RTags client/server counterpart (see pull request #2834).
