### PR TITLE
fix broken macOS paths for homebrew service

### DIFF
--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -177,7 +177,9 @@
 
 (defun spacemacs-base/init-exec-path-from-shell ()
   (use-package exec-path-from-shell
-    :init (when (memq window-system '(mac ns x))
+    :init (when (or (spacemacs/system-is-mac)
+                    (spacemacs/system-is-linux)
+                    (memq window-system '(x)))
             (exec-path-from-shell-initialize))))
 
 (defun spacemacs-base/init-help-fns+ ()


### PR DESCRIPTION
When Spacemacs is run as a macOS homebrew service, the window-system at startup time is not set as it is running essentially headless.  This causes the very-early call to exec-path-from-shell, which was checking for macOS via window-system, to fail the check.  This is pretty much game over for macOS and user-customized paths, as the exec paths are not updated and any extra user-path utilities (e.g. aspell, gls) won't be found.

This change switches over to using spacemacs/system-is-mac and spacemacs/system-is-linux as the primary checks, and keeps the window-system check for 'x in case other Unix variants are getting exec-path set via that check.