### PR TITLE
Process user-config before command line arguments

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -174,8 +174,27 @@ defer call using `spacemacs-post-user-config-hook'."
       (funcall func)
     (add-hook 'spacemacs-post-user-config-hook func)))
 
+(defun spacemacs/setup-after-init-hook ()
+   "Add post init processing (before command line arguments are being processed)."
+  (add-hook
+   'after-init-hook
+   (lambda ()
+     ;; Ultimate configuration decisions are given to the user who can defined
+     ;; them in his/her ~/.spacemacs file
+     ;;
+     ;; This needs to be called in `after-init-hook' to make sure that command
+     ;; line arguments are not yet processed (as with `emacs-startup-hook').
+     ;; Otherwise if Emacs is run with file arguments, the respective major mode
+     ;; will already be initialized when the function is executed. Variables set
+     ;; and code defined in user-config will not have the desired effect in that
+     ;; particular scenario.
+     (dotspacemacs|call-func dotspacemacs/user-config
+                             "Calling dotfile user config...")
+     (run-hooks 'spacemacs-post-user-config-hook)
+     (setq spacemacs-post-user-config-hook-run t))))
+
 (defun spacemacs/setup-startup-hook ()
-  "Add post init processing."
+  "Add post init processing (after command line arguments are being processed)."
   (add-hook
    'emacs-startup-hook
    (lambda ()
@@ -184,12 +203,6 @@ defer call using `spacemacs-post-user-config-hook'."
      ;; nil earlier in the startup process to properly handle command line
      ;; arguments.
      (setq initial-buffer-choice (lambda () (get-buffer spacemacs-buffer-name)))
-     ;; Ultimate configuration decisions are given to the user who can defined
-     ;; them in his/her ~/.spacemacs file
-     (dotspacemacs|call-func dotspacemacs/user-config
-                             "Calling dotfile user config...")
-     (run-hooks 'spacemacs-post-user-config-hook)
-     (setq spacemacs-post-user-config-hook-run t)
      (when (fboundp dotspacemacs-scratch-mode)
        (with-current-buffer "*scratch*"
          (funcall dotspacemacs-scratch-mode)))

--- a/init.el
+++ b/init.el
@@ -29,6 +29,7 @@
   (spacemacs/maybe-install-dotfile)
   (configuration-layer/sync)
   (spacemacs-buffer/display-info-box)
+  (spacemacs/setup-after-init-hook)
   (spacemacs/setup-startup-hook)
   (require 'server)
   (unless (server-running-p) (server-start)))


### PR DESCRIPTION
emacs-startup-hook is run after the command line arguments are being processed (and not at all if in batch mode). This has several undesired side-effects. If Emacs is started with file arguments, user-config is being run after the respective major mode has been initialized. Thus, variables set and code defined in user-config will not have the desired effect in that particular scenario. Also, in batch mode, user-config will not be evaluated at all which in some cases is not what the user might want and/or expect.

This refactors the handling of user-config to the after-init-hook and introduces another needed setup function for init.el.
