### PR TITLE
Correct the format of recipe. Fix #6610

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1419,18 +1419,18 @@ wether the declared layer is an used one or not."
     (when pkg
       (let ((location (oref pkg :location)))
         (when (and (listp location) (eq 'recipe (car location)))
-          location)))))
+          (cons pkg-name (cdr location)))))))
 
 (defun configuration-layer//new-version-available-p (pkg-name)
   "Return non nil if there is a new version available for PKG-NAME."
   (let ((recipe (configuration-layer//get-package-recipe pkg-name))
         (cur-version (configuration-layer//get-package-version-string pkg-name))
+        (quelpa-upgrade-p t)
         new-version)
     (when cur-version
       (setq new-version
             (if recipe
-                (quelpa-checkout recipe (expand-file-name (symbol-name pkg-name)
-                                                          quelpa-build-dir))
+                (or (quelpa-checkout recipe (expand-file-name (symbol-name pkg-name) quelpa-build-dir)) cur-version)
               (configuration-layer//get-latest-package-version-string
                pkg-name)))
       ;; (message "%s: %s > %s ?" pkg-name cur-version new-version)

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -1746,7 +1746,7 @@
                                           'layer-no-recipe-1)
        ,(configuration-layer/make-package '(pkg2 :location elpa)
                                           'layer-no-recipe-1)) t)
-    (should (eq 'recipe
+    (should (eq 'pkg1
                 (car (configuration-layer//get-package-recipe 'pkg1))))))
 
 (ert-deftest test-get-package-recipe--return-nil-if-package-has-no-recipe ()


### PR DESCRIPTION
After a long dig, I finally found the cause of #6610 .

According to the example in the README of quelpa:

``` elisp
(quelpa '(rainbow-mode :fetcher file :path "/path/to/rainbow-mode/rainbow-mode.el"))
```
The car of the recipe should be the package name instead of "recipe"

P.S.
The upgrade checkout for packages using quelpa wont be done unless we set the `quelpa-upgrade-p` or add `:upgrade` in the recipe:

``` elisp
(defcustom quelpa-upgrade-p nil
  "When non-nil, `quelpa' will try to upgrade packages.
The global value can be overridden for each package by supplying
the `:upgrade' argument."
  :group 'quelpa
  :type 'boolean)
```