### PR TITLE
Move vi-tilde auxilliary functions to spacemacs-evil

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -56,3 +56,15 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
                       :inherit 'lazy-highlight
                       :background nil
                       :foreground nil))
+
+
+;; vi-tilde-fringe
+
+(defun spacemacs/disable-vi-tilde-fringe ()
+  "Disable `vi-tilde-fringe' in the current buffer."
+  (vi-tilde-fringe-mode -1))
+
+(defun spacemacs/disable-vi-tilde-fringe-read-only ()
+  "Disable `vi-tilde-fringe' in the current buffer if it is read only."
+  (when buffer-read-only
+    (spacemacs/disable-vi-tilde-fringe)))

--- a/layers/+spacemacs/spacemacs-ui-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/funcs.el
@@ -139,18 +139,6 @@
               (diminish mode dim))))))))
 
 
-;; vi-tilde-fringe
-
-(defun spacemacs/disable-vi-tilde-fringe ()
-  "Disable `vi-tilde-fringe' in the current buffer."
-  (vi-tilde-fringe-mode -1))
-
-(defun spacemacs/disable-vi-tilde-fringe-read-only ()
-  "Disable `vi-tilde-fringe' in the current buffer if it is read only."
-  (when buffer-read-only
-    (spacemacs/disable-vi-tilde-fringe)))
-
-
 ;; zoom
 
 (defun spacemacs//zoom-frm-powerline-reset ()


### PR DESCRIPTION
`spacemacs/disable-vi-tilde-fringe` and `spacemacs/disable-vi-tilde-fringe-read-only` are used by `spacemacs-evil` layer, but are defined in `spacemacs-ui-visual` layer. This PR moves the definitions to the
correct place. The old behavior causes a bug during startup, when using `spacemacs-base` with `spacemacs-evil` and without `spacemacs-ui-visual`.