### PR TITLE
Layouts and Workspaces: Synchronise Persistence

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -550,10 +550,22 @@ graphical frames, and one set for terminal frames."
         (eyebrowse-init frame)
         (spacemacs/save-eyebrowse-for-perspective frame)))))
 
-(defun spacemacs/update-eyebrowse-for-perspective (_new-persp-name _frame)
-  "Update and save current frame's eyebrowse workspace to its perspective.
-Parameters _NEW-PERSP-NAME and _FRAME are ignored, and exists only for
- compatibility with `persp-before-switch-functions'."
+(defun spacemacs/load-eyebrowse-after-loading-layout (_state-file _phash persp-names)
+  "Bridge between `persp-after-load-state-functions' and
+`spacemacs/load-eyebrowse-for-perspective'.
+
+_PHASH is the hash were the loaded perspectives were placed, and
+PERSP-NAMES are the names of these perspectives."
+  (let ((cur-persp (get-current-persp)))
+    ;; load eyebrowse for current perspective only if it was one of the loaded
+    ;; perspectives
+    (when (member (or (and cur-persp (persp-name cur-persp))
+                      persp-nil-name)
+                  persp-names)
+      (spacemacs/load-eyebrowse-for-perspective 'frame))))
+
+(defun spacemacs/update-eyebrowse-for-perspective (&rest _args)
+  "Update and save current frame's eyebrowse workspace to its perspective."
   (let* ((current-slot (eyebrowse--get 'current-slot))
          (current-tag (nth 2 (assoc current-slot (eyebrowse--get 'window-configs)))))
     (eyebrowse--update-window-config-element

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -84,6 +84,8 @@
                 #'spacemacs/save-eyebrowse-for-perspective)
       (add-hook 'persp-activated-functions
                 #'spacemacs/load-eyebrowse-for-perspective)
+      (add-hook 'persp-before-save-state-to-file-functions #'spacemacs/update-eyebrowse-for-perspective)
+      (add-hook 'persp-after-load-state-functions #'spacemacs/load-eyebrowse-after-loading-layout)
       ;; vim-style tab switching
       (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
       (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config))))


### PR DESCRIPTION
Update current layout's workspaces before saving layouts to file. (fixes #7214)
Load current layout's workspaces after loading layouts from file, if it's one of the loaded layouts. (fixes #6979)

<s>I would rather use a hook than an advice for `persp-save-state-to-file`, but there is no suitable hook.
Edit: opened a feature request for a suitable hook (https://github.com/Bad-ptr/persp-mode.el/issues/48), but please don't let that request delay this PR.</s>
Edit 2: the code now uses a hook