### PR TITLE
Make ivy restrict buffers to layout

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -175,6 +175,17 @@
   (use-package ivy-hydra))
 
 (defun ivy/post-init-persp-mode ()
+  ;; based on https://gist.github.com/Bad-ptr/1aca1ec54c3bdb2ee80996eb2b68ad2d#file-persp-ivy-el
+  (add-hook 'ivy-ignore-buffers #'spacemacs//layout-not-contains-buffer-p)
+  (setq ivy-sort-functions-alist
+        (append ivy-sort-functions-alist
+                '((persp-kill-buffer . nil)
+                  (persp-remove-buffer . nil)
+                  (persp-add-buffer . nil)
+                  (persp-switch . nil)
+                  (persp-window-switch . nil)
+                  (persp-frame-switch . nil))))
+
   (ivy-set-actions
    'spacemacs/ivy-spacemacs-layouts
    '(("c" persp-kill-without-buffers "Close layout(s)")

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -34,6 +34,10 @@ Cancels autosave on exiting perspectives mode."
       (cancel-timer spacemacs--layouts-autosave-timer)
       (setq spacemacs--layouts-autosave-timer nil))))
 
+(defun spacemacs//layout-not-contains-buffer-p (buffer)
+  "Return non-nil if current layout doesn't contain BUFFER."
+  (not (persp-contain-buffer-p buffer)))
+
 (defun spacemacs/jump-to-last-layout ()
   "Open the previously selected layout, if it exists."
   (interactive)
@@ -49,10 +53,15 @@ current perspective."
   (with-persp-buffer-list ()
                           (switch-to-buffer (other-buffer (current-buffer) t))))
 
-(defun spacemacs-layouts/non-restricted-buffer-list ()
+(defun spacemacs-layouts/non-restricted-buffer-list-helm ()
   (interactive)
   (let ((ido-make-buffer-list-hook (remove #'persp-restrict-ido-buffers ido-make-buffer-list-hook)))
     (helm-mini)))
+
+(defun spacemacs-layouts/non-restricted-buffer-list-ivy ()
+  (interactive)
+  (let ((ivy-ignore-buffers (remove #'spacemacs//layout-not-contains-buffer-p ivy-ignore-buffers)))
+    (ivy-switch-buffer)))
 
 
 ;; Persp transient-state

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -12,6 +12,7 @@
 (setq spacemacs-layouts-packages
       '(eyebrowse
         helm
+        ivy
         persp-mode
         spaceline
         swiper))
@@ -94,7 +95,14 @@
 
 (defun spacemacs-layouts/post-init-helm ()
   (spacemacs/set-leader-keys
+    "Bb" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))
+
+
+
+(defun spacemacs-layouts/post-init-ivy ()
+  (spacemacs/set-leader-keys
+    "Bb" 'spacemacs-layouts/non-restricted-buffer-list-ivy))
 
  
 
@@ -208,8 +216,7 @@
       (spacemacs/set-leader-keys
         "TAB"  'spacemacs/alternate-buffer-in-persp
         "ba"   'persp-add-buffer
-        "br"   'persp-remove-buffer
-        "Bb"   'spacemacs-layouts/non-restricted-buffer-list))))
+        "br"   'persp-remove-buffer))))
 
 
 


### PR DESCRIPTION
Make `SPC b b` and `SPC l b` restrict buffer selection to current layout's buffers. Fixes #6300.

Also create separate non-restricted-buffer-list (`SPC B b`) for helm and ivy (formerly, `SPC B b` will use a Helm prompt even when Ivy layer is used).