### PR TITLE
golden-ratio: add to window TS only when used

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -480,15 +480,17 @@
 
 (spacemacs|define-transient-state window-manipulation
   :title "Window Manipulation Transient State"
-  :doc "
+  :doc (concat "
  Select^^^^              Move^^^^              Split^^                Resize^^                     Other^^
  ──────^^^^───────────── ────^^^^───────────── ─────^^─────────────── ──────^^──────────────────── ─────^^──────────────────────────────
  [_j_/_k_] down/up       [_J_/_K_] down/up     [_s_] vertical         [_[_] shrink horizontally    [_q_] quit
  [_h_/_l_] left/right    [_H_/_L_] left/right  [_S_] vert & follow    [_]_] enlarge horizontally   [_u_] restore prev layout
  [_0_-_9_] window N      [_r_]^^   rotate fwd  [_v_] horizontal       [_{_] shrink vertically      [_U_] restore next layout
  [_w_]^^   other window  [_R_]^^   rotate bwd  [_V_] horiz & follow   [_}_] enlarge vertically     [_d_] close current
- [_o_]^^   other frame   ^^^^                  ^^                     ^^                           [_D_] close other
- ^^^^                    ^^^^                  ^^                     ^^                           [_g_] golden-ratio %`golden-ratio-mode"
+ [_o_]^^   other frame   ^^^^                  ^^                     ^^                           [_D_] close other"
+               (if (configuration-layer/package-usedp 'golden-ratio)
+                   "\n ^^^^                    ^^^^                  ^^                     ^^                           [_g_] golden-ratio %`golden-ratio-mode"
+                 ""))
   :bindings
   ("q" nil :exit t)
   ("0" select-window-0)
@@ -509,7 +511,6 @@
   ("}" spacemacs/enlarge-window)
   ("d" delete-window)
   ("D" delete-other-windows)
-  ("g" spacemacs/toggle-golden-ratio)
   ("h" evil-window-left)
   ("<left>" evil-window-left)
   ("j" evil-window-down)

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -61,12 +61,15 @@
   (use-package golden-ratio
     :defer t
     :init
-    (spacemacs|add-toggle golden-ratio
-      :status golden-ratio-mode
-      :on (golden-ratio-mode) (golden-ratio)
-      :off (golden-ratio-mode -1) (balance-windows)
-      :documentation "Resize the focused window using the golden ratio."
-      :evil-leader "tg")
+    (progn
+      (setq spacemacs-window-manipulation-transient-state-add-bindings
+            '(("g" spacemacs/toggle-golden-ratio)))
+      (spacemacs|add-toggle golden-ratio
+        :status golden-ratio-mode
+        :on (golden-ratio-mode) (golden-ratio)
+        :off (golden-ratio-mode -1) (balance-windows)
+        :documentation "Resize the focused window using the golden ratio."
+        :evil-leader "tg"))
     :config
     (progn
       ;; golden-ratio-exclude-modes


### PR DESCRIPTION
Add golden-ratio binding to window manipulation transient state only when `golden-ratio` package is used. Change the TS's documentation accordingly. Fixes #7234.