### PR TITLE
Update documentation for Go-Guru switch

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -13,7 +13,7 @@
    - [[#tests][Tests]]
  - [[#working-with-go][Working with Go]]
    - [[#go-commands-start-with-m][Go commands (start with =m=):]]
-   - [[#go-oracle][Go Oracle]]
+   - [[#go-guru][Go Guru]]
 
 * Description
 This layer adds extensive support for go.
@@ -21,7 +21,7 @@ This layer adds extensive support for go.
 ** Features:
 - gofmt/goimports on file save
 - Auto-completion using [[https://github.com/nsf/gocode/tree/master/emacs][go-autocomplete]] (with the =auto-completion= layer)
-- Source analysis using [[http://golang.org/s/oracle-user-manual][go-oracle]]
+- Source analysis using [[https://godoc.org/golang.org/x/tools/cmd/guru][go-guru]]
 - Linting with flycheck's built-in checkers or flycheck-gometalinter
 - Coverage profile visualization
 
@@ -32,7 +32,7 @@ You will need =gocode= and =godef=:
 #+BEGIN_SRC sh
   go get -u -v github.com/nsf/gocode
   go get -u -v github.com/rogpeppe/godef
-  go get -u -v golang.org/x/tools/cmd/oracle
+  go get -u -v golang.org/x/tools/cmd/guru
   go get -u -v golang.org/x/tools/cmd/gorename
   go get -u -v golang.org/x/tools/cmd/goimports
 #+END_SRC
@@ -119,19 +119,19 @@ The default value is =display-buffer-reuse-window=.
 | ~SPC m t t~ | run "go test" for the function you're currently in (while you're in a _.test.go file) |
 | ~SPC m t s~ | run "go test" for the suite you're currently in (requires gocheck)                    |
 
-** Go Oracle
+** Go Guru
 
-| Key Binding | Description                                                |
-|-------------+------------------------------------------------------------|
-| ~SPC m r o~ | go-oracle set analysis scope                               |
-| ~SPC m r <~ | go-oracle show possible callers                            |
-| ~SPC m r >~ | go-oracle show call targets                                |
-| ~SPC m r c~ | go-oracle show channel sends/receives                      |
-| ~SPC m r d~ | go-oracle show definition                                  |
-| ~SPC m r f~ | go-oracle show free variables                              |
-| ~SPC m r g~ | go-oracle show callgraph                                   |
-| ~SPC m r i~ | go-oracle show implements relation                         |
-| ~SPC m r p~ | go-oracle show what the select expression points to        |
-| ~SPC m r r~ | go-oracle show all references to object                    |
-| ~SPC m r s~ | go-oracle show callstack                                   |
-| ~SPC m r t~ | go-oracle describe selected syntax, kind, type and methods |
+| Key Binding | Description                                          |
+|-------------+------------------------------------------------------|
+| ~SPC m f d~ | go-guru describe symbol at point                     |
+| ~SPC m f f~ | go-guru show free variables                          |
+| ~SPC m f i~ | go-guru show implements relation                     |
+| ~SPC m f c~ | go-guru show channel sends/receives                  |
+| ~SPC m f r~ | go-guru show referrers                               |
+| ~SPC m f j~ | go-guru jump to symbol definition                    |
+| ~SPC m f p~ | go-guru show what the select expression points to    |
+| ~SPC m f s~ | go-guru show callstack                               |
+| ~SPC m f e~ | go-guru show possible contants/types for error value |
+| ~SPC m f <~ | go-guru show possible callers                        |
+| ~SPC m f >~ | go-guru show call targets                            |
+| ~SPC m f o~ | go-guru set analysis scope                           |

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -11,6 +11,7 @@
  - [[#configuration][Configuration]]
    - [[#indentation][Indentation]]
    - [[#tests][Tests]]
+   - [[#guru][Guru]]
  - [[#working-with-go][Working with Go]]
    - [[#go-commands-start-with-m][Go commands (start with =m=):]]
    - [[#go-guru][Go Guru]]
@@ -96,6 +97,18 @@ function testing to work.
 =go-coverage-display-buffer-func= controls how =go-coverage= should display
 the coverage buffer. See [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Choosing-Window.html][=display-buffer=]] for a list of possible functions.
 The default value is =display-buffer-reuse-window=.
+
+** Guru
+
+Go Oracle has been deprecated as of October 1, 2016, it's replacement is =go-guru=.
+
+If you would like to use the =goguru= bindings in your work, you will need to
+install it, and in your project you will need to set the scope with =SPC m f o=.
+The scope is a comma separated set of packages, and =go='s recursive operator is
+supported. In addition, you can prefix with =-= to exclude a package from
+searching.
+
+In addition, =GOPATH= must be set prior to =go-guru= initialization.
 
 * Working with Go
 ** Go commands (start with =m=):

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -103,7 +103,7 @@ The default value is =display-buffer-reuse-window=.
 Go Oracle has been deprecated as of October 1, 2016, it's replacement is =go-guru=.
 
 If you would like to use the =goguru= bindings in your work, you will need to
-install it, and in your project you will need to set the scope with =SPC m f o=.
+install it, and in your project you will need to set the scope with ~SPC m f o~.
 The scope is a comma separated set of packages, and =go='s recursive operator is
 supported. In addition, you can prefix with =-= to exclude a package from
 searching.

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -10,7 +10,7 @@
         helm-gtags
         go-eldoc
         go-mode
-        (go-oracle :location site)
+        (go-guru :location site)
         (go-rename :location local)
         ))
 
@@ -112,31 +112,32 @@
 (defun go/init-go-eldoc()
   (add-hook 'go-mode-hook 'go-eldoc-setup))
 
-(defun go/init-go-oracle()
+(defun go/init-go-guru()
   (let ((go-path (getenv "GOPATH")))
     (if (not go-path)
         (spacemacs-buffer/warning
-         "GOPATH variable not found, go-oracle configuration skipped.")
+         "GOPATH variable not found, go-guru configuration skipped.")
       (when (load-gopath-file
-             go-path "/src/golang.org/x/tools/cmd/oracle/oracle.el")
-        (spacemacs/declare-prefix-for-mode 'go-mode "mr" "rename")
+             go-path "/src/golang.org/x/tools/cmd/guru/go-guru.el")
+        (spacemacs/declare-prefix-for-mode 'go-mode "mf" "guru")
         (spacemacs/set-leader-keys-for-major-mode 'go-mode
-          "ro" 'go-oracle-set-scope
-          "r<" 'go-oracle-callers
-          "r>" 'go-oracle-callees
-          "rc" 'go-oracle-peers
-          "rd" 'go-oracle-definition
-          "rf" 'go-oracle-freevars
-          "rg" 'go-oracle-callgraph
-          "ri" 'go-oracle-implements
-          "rp" 'go-oracle-pointsto
-          "rr" 'go-oracle-referrers
-          "rs" 'go-oracle-callstack
-          "rt" 'go-oracle-describe)))))
+          "fd" 'go-guru-describe
+          "ff" 'go-guru-freevars
+          "fi" 'go-guru-implements
+          "fc" 'go-guru-peers
+          "fr" 'go-guru-referrers
+          "fj" 'go-guru-definition
+          "fp" 'go-guru-pointsto
+          "fs" 'go-guru-callstack
+          "fe" 'go-guru-whicherrs
+          "f<" 'go-guru-callers
+          "f>" 'go-guru-callees
+          "fo" 'go-guru-set-scope)))))
 
 (defun go/init-go-rename()
   (use-package go-rename
     :init
+    (spacemacs/declare-prefix-for-mode 'go-mode "mr" "rename")
     (spacemacs/set-leader-keys-for-major-mode 'go-mode "rn" 'go-rename)))
 
 (defun go/init-flycheck-gometalinter()


### PR DESCRIPTION
This branch is based off of @edrex's work on switching the go layer to use go-guru (#6774). It updates the documentation to warn about Oracle's deprecation and a few usage notes on go-guru.