### PR TITLE
Fix changelog saying systemd is in +config-files

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -109,7 +109,7 @@
 - rebox in =+tools= (thanks to choppsv1)
 - shaders in =+lang= (thanks to Ell)
 - slack in =+chat= (thanks to kostajh)
-- systemd in =+config-files= (thanks to StreakyCobra)
+- systemd in =+tools= (thanks to StreakyCobra)
 *** Dotfile changes
 **** Changes for variable values and keywords
 - Add new keyword =:packages= for the list of layers in variable


### PR DESCRIPTION
The changelog says that systemd is under `+config-files`, when it is really under `+tools`. This fixes that mistake.