### PR TITLE
Add emmet-mode to react-mode

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -88,6 +88,7 @@
                                                 html-mode-hook
                                                 sass-mode-hook
                                                 scss-mode-hook
+                                                react-mode-hook
                                                 web-mode-hook))
     :config
     (progn


### PR DESCRIPTION
This enables `emmet-mode` in `react-mode` (`*.jsx` files).
It automatically uses `className` instead of `class`, so no other configuration needed.

Put it there because thats how other modes are hooked, could also add it as a hook in the react layer if that would be preferred?

Closes syl20bnr/spacemacs#5130