### PR TITLE
make spacemacs/ert-run-tests-buffer run only the current buffer's tests

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -665,12 +665,18 @@ The body of the advice is in BODY."
   (if (y-or-n-p (format "Erase content of buffer %s ? " (current-buffer)))
       (erase-buffer)))
 
+(defun spacemacs//find-ert-test-buffer (ert-test)
+  "Return the buffer where ERT-TEST is defined."
+  (car (find-definition-noselect (ert-test-name ert-test) 'ert-deftest)))
+
 (defun spacemacs/ert-run-tests-buffer ()
   "Run all the tests in the current buffer."
   (interactive)
   (save-buffer)
   (load-file (buffer-file-name))
-  (ert t))
+  (let ((cbuf (current-buffer)))
+    (ert '(satisfies (lambda (test)
+                       (eq cbuf (spacemacs//find-ert-test-buffer test)))))))
 
 (defun spacemacs/alternate-buffer (&optional window)
   "Switch back and forth between current and last buffer in the


### PR DESCRIPTION
Previously, `spacemacs/ert-run-tests-buffer` would run the entire ERT "universe", meaning all the tests that were defined in the current Emacs session. Change it so it only tuns the tests that are defined in the current buffer.
Fixes #7266 