### PR TITLE
Use j/k in spacemacs buffer for forward/backward widget motions. Curr…

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -53,9 +53,9 @@ version the release note it displayed")
 
 (defvar spacemacs-buffer-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [tab] 'widget-forward)
+    (define-key map (kbd "j") 'widget-forward)
     (define-key map (kbd "C-i") 'widget-forward)
-    (define-key map [backtab] 'widget-backward)
+    (define-key map (kbd "k") 'widget-backward)
     (define-key map (kbd "RET") 'widget-button-press)
     (define-key map [down-mouse-1] 'widget-button-click)
     (define-key map "q" 'quit-window)


### PR DESCRIPTION
…ently j/k were only navigating between lines,
but hitting RET wouldn't work on a recent file and the like,
when the cursor wasn't directly over the filename.

Changing j/k to widget navigation, ensures that the cursor is always on something activatable. This change should make the home buffer feel more at home for evil mode users.

Not sure this is the best solution and it doesn't take into account non-evil users. So take it as a suggestion.

I found myself again and again using j/k, ending up on the beginning of a line containing a filename, pressing RET, and being slightly annoyed that it didn't just work.