### PR TITLE
Add Clojure to org-babel-load-languages

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -12,6 +12,7 @@
     popwin
     smartparens
     subword
+    org
     ))
 
 (defun clojure/init-cider ()
@@ -288,3 +289,8 @@
 (defun clojure/init-clojure-snippets ()
   (use-package clojure-snippets
     :defer t))
+
+(defun clojure/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(clojure . t))
+    (setq org-babel-clojure-backend 'cider)))


### PR DESCRIPTION
Add Clojure to list of org-babel languages. Add `org` as a dependency. Set `cider` as backend for clojure evaluation by org-babel.

#7282 
