### PR TITLE
Change 'SPC :' to 'SPC SPC' in quick start

### DIFF
--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -32,7 +32,7 @@ own layer.
 The following command creates a layer in the =private= directory:
 
 #+BEGIN_EXAMPLE
-    SPC : configuration-layer/create-layer RET
+    SPC SPC configuration-layer/create-layer RET
 #+END_EXAMPLE
 
 Any configuration layers you create must be explicitly loaded in =~/.spacemacs=.
@@ -48,7 +48,7 @@ is also a means to customizing Spacemacs.
 The following command will create a =.spacemacs= file in your home directory:
 
 #+BEGIN_EXAMPLE
-    SPC : dotspacemacs/install RET
+    SPC SPC dotspacemacs/install RET
 #+END_EXAMPLE
 
 To open the installed dotfile:


### PR DESCRIPTION
This is a documentation update. The quick start guide should probably not use the deprecated keybinding 😄 