### PR TITLE
New option: auto-generate layout names

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -198,6 +198,10 @@ if used there.")
   "If non nil then the last auto saved layouts are resume automatically upon
 start.")
 
+(defvar dotspacemacs-auto-generate-layout-names nil
+  "If non-nil, auto-generate layout name when creating new layouts.
+Only has effect when using the \"jump to layout by number\" commands.")
+
 (defvar dotspacemacs-max-rollback-slots 5
   "Maximum number of rollback slots to keep in the cache.")
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -177,6 +177,9 @@ values."
    ;; If non nil then the last auto saved layouts are resume automatically upon
    ;; start. (default nil)
    dotspacemacs-auto-resume-layouts nil
+   ;; If non-nil, auto-generate layout name when creating new layouts. Only has
+   ;; effect when using the "jump to layout by number" commands.
+   dotspacemacs-auto-generate-layout-names nil
    ;; Size (in MB) above which spacemacs will prompt to open the large file
    ;; literally to avoid performance issues. Opening a file literally means that
    ;; no major mode or minor modes are active. (default is 1)

--- a/layers/+spacemacs/spacemacs-layouts/config.el
+++ b/layers/+spacemacs/spacemacs-layouts/config.el
@@ -33,3 +33,25 @@
 
 (defvar spacemacs--layouts-autosave-timer nil
   "Timer for layouts auto-save.")
+
+(defvar spacemacs-generic-layout-names
+  '(("zebra" "zucchini" "zen" "yellow" "yeti" "yard") ; grab-bag
+    ("baboon" "banana" "blue")                        ; 2nd layout
+    ("crab" "cabbage" "crayon")                       ; 3rd
+    ("deer" "doughnut" "door")                        ; 4th
+    ("elephant" "eggplant" "extreme")                 ; 5th
+    ("falcon" "fig" "fjord")                          ; 6th
+    ("gnu" "garlic" "guardian")                       ; 7th
+    ("horse" "honey" "hallelujah")                    ; 8th
+    ("iguana" "ice-cream" "internet")                 ; 9th
+    ("jellyfish" "jalapeno" "jolt"))                  ; 10th (aka 0th)
+  "Names for auto-generated layout names.
+Used by `spacemacs//generate-layout-name'.
+
+Must be a list with 10 entries, where each entry is a list of
+names. The 2nd list contains possible names for the 2nd
+layout (or 10th) layout, the 3rd list contains names for the 3rd
+layout, the 4th for the 4th, and so on until the 10th (aka layout
+number 0). The first list is sepcial - it is a grab-bag for names
+in case none of the regular names can be used for a new layout.")
+

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -94,23 +94,49 @@ current perspective."
                (propertize "?" 'face 'hydra-face-red)
                "] help)")))))
 
+(defun spacemacs//generate-layout-name (pos)
+  "Generate name for layout of position POS.
+POS should be a number between 1 and 9, where 1 represents the
+2nd layout, 2 represents the 3rd and so on. 9 represents the 10th
+layout, which is also knows as the 0th layout.
+
+ If no name can be generated, return nil."
+  (catch 'found
+    ;; return 1st available name
+    (dolist (name (nth pos spacemacs-generic-layout-names))
+      (unless (persp-get-by-name name)
+        (throw 'found name)))
+
+    ;; return 1st available name from grab-bag
+    (dolist (name (car spacemacs-generic-layout-names))
+      (unless (persp-get-by-name name)
+        (throw 'found name)))))
+
 (defun spacemacs/layout-switch-by-pos (pos)
-  "Switch to perspective of position POS."
+  "Switch to perspective of position POS.
+If POS has no layout, and `dotspacemacs-auto-generate-layout-names'
+is non-nil, create layout with auto-generated name. Otherwise,
+ask the user if a new layout should be created."
   (let ((persp-to-switch
          (nth pos (persp-names-current-frame-fast-ordered))))
     (if persp-to-switch
         (persp-switch persp-to-switch)
-      (when (y-or-n-p
-             (concat "Perspective in this position doesn't exist.\n"
-                     "Do you want to create one? "))
-        (let ((persp-reset-windows-on-nil-window-conf t))
+      (let ((persp-reset-windows-on-nil-window-conf t)
+            (generated-name (and dotspacemacs-auto-generate-layout-names
+                                 (spacemacs//generate-layout-name pos))))
+        (cond
+         (generated-name
+          (persp-switch generated-name))
+         ((y-or-n-p (concat "Layout in this position doesn't exist. "
+                            "Do you want to create one? "))
           (persp-switch nil)
-          (spacemacs/home-delete-other-windows))))))
+          (spacemacs/home-delete-other-windows)))))))
 
 ;; Define all `spacemacs/persp-switch-to-X' functions
 (dolist (i (number-sequence 9 0 -1))
   (eval `(defun ,(intern (format "spacemacs/persp-switch-to-%s" i)) nil
-           ,(format "Switch to layout %s." i)
+           ,(format "Switch to layout %s.\n%s"
+                    i "See `spacemacs/layout-switch-by-pos' for details.")
            (interactive)
            (spacemacs/layout-switch-by-pos ,(if (eq 0 i) 9 (1- i))))))
 


### PR DESCRIPTION
If `spacemacs-auto-generate-layout-names` is non-nil, and the user tries to open a layout in a position that doesn't yet have a layout (e.g. with `SPC l 2`), then create a new layout with an automatically generated name. I tried to choose names that are familiar and easy to remember. To enable the feature, add the following to `user-config`:

``` elisp
(setq spacemacs-auto-generate-layout-names t)
```

Known issues:
- persp-mode doesn't really have a notion of a numbered layout. Because of this, creating a layout with `SPC l 7` (7 is only an example) will give it a name suitable for a 7th layout, but the actual position of the layout may be smaller. For example, if the user only had 4 layouts, then the "7th" layout is created in position 5.
- the new layout is created with a single window, but it doesn't show the home buffer. Instead, it will show the buffer of the previous layout's selected window. This is a difference I do not understand (or researched) between `(persp-switch "some-new-name")` and `(persp-switch nil)`.
