### PR TITLE
Higher visibility warnings + check if layers changed outside dotspacemacs/layers

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -375,6 +375,8 @@ refreshed during the current session."
   "Synchronize declared layers in dotfile with spacemacs.
 If NO-INSTALL is non nil then install steps are skipped."
   (dotspacemacs|call-func dotspacemacs/layers "Calling dotfile layers...")
+  (setq dotspacemacs--configuration-layers-saved
+        dotspacemacs-configuration-layers)
   (when (spacemacs-buffer//choose-banner)
     (spacemacs-buffer//inject-version))
   ;; declare used layers then packages as soon as possible to resolve

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -126,6 +126,9 @@ whenever you start Emacs.")
 (defvar dotspacemacs-configuration-layers '(emacs-lisp)
   "List of configuration layers to load.")
 
+(defvar dotspacemacs--configuration-layers-saved nil
+  "Saved value of `dotspacemacs-configuration-layers' after sync.")
+
 (defvar dotspacemacs-themes '(spacemacs-dark
                               spacemacs-light)
   "List of themes, the first of the list is loaded when spacemacs starts.
@@ -361,6 +364,16 @@ are caught and signalled to user in spacemacs buffer."
                                            ',(symbol-name func)
                                            (error-message-string err))
                                    t))))))
+
+(defun dotspacemacs//check-layers-changed ()
+  "Check if the value of `dotspacemacs-configuration-layers'
+changed, and issue a warning if it did."
+  (unless (eq dotspacemacs-configuration-layers
+              dotspacemacs--configuration-layers-saved)
+    (spacemacs-buffer/warning
+     "`dotspacemacs-configuration-layers' was changed outside of `dotspacemacs/layers'.")))
+(add-hook 'spacemacs-post-user-config-hook
+          'dotspacemacs//check-layers-changed)
 
 (defun dotspacemacs//read-editing-style-config (config)
   "Read editing style CONFIG: apply variables and return the editing style.

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -410,10 +410,15 @@ The message is displayed only if `init-file-debug' is non nil."
   (when init-file-debug
     (message "(Spacemacs) %s" (apply 'format msg args))))
 
+(defvar spacemacs-buffer--warnings nil
+  "List of warnings during startup.")
+
 (defun spacemacs-buffer/warning (msg &rest args)
   "Display MSG as a warning message but in buffer `*Messages*'.
 The message is always displayed. "
-  (message "(Spacemacs) Warning: %s" (apply 'format msg args)))
+  (let ((msg (apply 'format msg args)))
+    (message "(Spacemacs) Warning: %s" msg)
+    (add-to-list 'spacemacs-buffer--warnings msg 'append)))
 
 (defun spacemacs-buffer/insert-page-break ()
   "Insert a page break line in spacemacs buffer."
@@ -670,6 +675,22 @@ border."
     (spacemacs-buffer//center-line)
     (insert "\n\n"))
 
+(defun spacemacs-buffer//insert-string-list (list-display-name list)
+  (when (car list)
+    (insert list-display-name)
+    (mapc (lambda (el)
+            (insert
+             "\n"
+             (with-temp-buffer
+               (insert el)
+               (fill-paragraph)
+               (goto-char (point-min))
+               (insert "    - ")
+               (while (= 0 (forward-line))
+                 (insert "      "))
+               (buffer-string))))
+          list)))
+
 (defun spacemacs-buffer//insert-file-list (list-display-name list)
   (when (car list)
     (insert list-display-name)
@@ -811,6 +832,12 @@ list. Return entire list if `END' is omitted."
                      (or (cdr-safe els)
                          spacemacs-buffer-startup-lists-length)))
                 (cond
+                 ((eq el 'warnings)
+                  (when (spacemacs-buffer//insert-string-list
+                         "Warnings:"
+                         spacemacs-buffer--warnings)
+                    (spacemacs//insert--shortcut "w" "Warnings:")
+                    (insert list-separator)))
                  ((eq el 'recents)
                   (recentf-mode)
                   (when (spacemacs-buffer//insert-file-list
@@ -850,7 +877,10 @@ list. Return entire list if `END' is omitted."
                          (spacemacs//subseq (projectile-relevant-known-projects)
                                             0 list-size))
                     (spacemacs//insert--shortcut "p" "Projects:")
-                    (insert list-separator)))))) dotspacemacs-startup-lists)))
+                    (insert list-separator))))))
+            (append
+             '(warnings)
+             dotspacemacs-startup-lists))))
 
 (defun spacemacs-buffer//get-buffer-width ()
   (save-excursion

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -225,7 +225,7 @@ defer call using `spacemacs-post-user-config-hook'."
          ((configuration-layer/layer-usedp 'ivy)
           'ivy)
          (t 'helm))
-   (pp-to-string dotspacemacs-configuration-layers)
+   (pp-to-string dotspacemacs--configuration-layers-saved)
    (bound-and-true-p system-configuration-features)))
 
 (defun spacemacs/describe-system-info ()


### PR DESCRIPTION
The first commit stores the value of `dotspacemacs/layers` immediately after calling the function, and adds a check in `spacemacs-post-user-config-hook` to check if the value was changed. If it was, it issues a warning. (Note, the comparison is done with `eq`, not `equal`.) It also uses the saved value when reporting an issue.

The second commit shows warnings as a non-removable startup list.

Example:

![](http://i.imgur.com/NMaqC4b.png)
