### PR TITLE
Fix usage of gorename on symlinked projects

### DIFF
--- a/layers/+lang/go/local/go-rename/go-rename.el
+++ b/layers/+lang/go/local/go-rename/go-rename.el
@@ -36,7 +36,7 @@ the `gorename' tool."
                              (and (buffer-file-name)
                                   (string= (file-name-extension (buffer-file-name)) ".go"))))
   (let* ((posflag (format "-offset=%s:#%d"
-                          buffer-file-name
+                          (expand-file-name buffer-file-truename)
                           (1- (go--position-bytes (point)))))
          (env-vars (go-root-and-paths))
          (goroot-env (concat "GOROOT=" (car env-vars)))


### PR DESCRIPTION
I often work on Go projects under a symlink, e.g. ~/Code/project points to
$GOPATH/src/github.com/grncdr/...

This works fine 99% of the time, but gorename doesn't follow symlinks in order
to get the "truename" of a file, so it will complain about
~/Code/project/somefile.go not belonging to any package. This fixes that
situation by ensuring that gorename is only passed the true filename.