### PR TITLE
Fix plantuml org-babel loading

### DIFF
--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -13,9 +13,10 @@
   '(org
     puml-mode))
 
-(defun plantuml/post-init-org ()
+(defun plantuml/pre-init-org ()
   (spacemacs|use-package-add-hook org
-    :post-config (add-to-list 'org-babel-load-languages '(plantuml . t))))
+    :post-config (add-to-list 'org-babel-load-languages '(plantuml . t))
+    (add-to-list 'org-src-lang-modes '("plantuml" . puml))))
 
 (defun plantuml/init-puml-mode ()
   (use-package puml-mode


### PR DESCRIPTION
- Replace plantuml/post-init-org with a pre-init-org hook to properly
load the configuration.
- Associate plantuml with its major mode for org src buffers/blocks

Fixes: #7298

Sorry @NJBS as I didn't notice the Autumnal Cleanup 2016 beforehand and this was assigned to you it seems. Hopefully this saves you a trivial fix at least :smile: 