### PR TITLE
fix neotree duplicate function comment

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/funcs.el
@@ -25,7 +25,7 @@
 ;; neotree
 
 (defun spacemacs/neotree-expand-or-open ()
-  "Collapse a neotree node."
+  "Expand or open a neotree node."
   (interactive)
   (let ((node (neo-buffer--get-filename-current-line)))
     (when node


### PR DESCRIPTION
Both the `spacemacs/neotree-expand-or-open` and `spacemacs/neotree-collapse`
functions had the same comment: 

> "Collapse a neotree node."

This renames the spacemacs/neotree-expand-or-open function to:

> "Expand or open a neotree node."