### PR TITLE
Fix connecting to default servers with TLS more than once with ERC

### DIFF
--- a/layers/+chat/erc/funcs.el
+++ b/layers/+chat/erc/funcs.el
@@ -11,6 +11,7 @@
 
 (defun erc//servers (server-list)
   (dolist (s server-list)
+    (setq s (copy-list s))
     (apply (if
                (plist-get (cdr s) :ssl)
                (progn


### PR DESCRIPTION
The erc//servers function removes the :ssl variable from the list so it can be passed directly to erc-tls, but this means that subsequent connections will not use TLS. Thus, we should operate on a copy of the list instead.