### PR TITLE
Refactor spacemacs/python-execute-file

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -314,22 +314,19 @@
         (python-shell-switch-to-shell)
         (evil-insert-state))
 
-      ;; reset compile-command (by default it is `make -k')
-      (setq compile-command nil)
       (defun spacemacs/python-execute-file (arg)
         "Execute a python script in a shell."
         (interactive "P")
         ;; set compile command to buffer-file-name
         ;; universal argument put compile buffer in comint mode
-        (setq universal-argument t)
-        (if arg
-            (call-interactively 'compile)
-
-          (setq compile-command (format "python %s" (file-name-nondirectory
-                                                     buffer-file-name)))
-          (compile compile-command t)
-          (with-current-buffer (get-buffer "*compilation*")
-            (inferior-python-mode))))
+        (let ((universal-argument t)
+              (compile-command (format "python %s" (file-name-nondirectory
+                                                    buffer-file-name))))
+          (if arg
+              (call-interactively 'compile)
+            (compile compile-command t)
+            (with-current-buffer (get-buffer "*compilation*")
+              (inferior-python-mode)))))
 
       (defun spacemacs/python-execute-file-focus (arg)
         "Execute a python script in a shell and switch to the shell buffer in


### PR DESCRIPTION
- `compile-command` changes after every compilation, we don't need to reset it to `nil`.
- Let-bind `universal-argument` to minimize side effects (probably didn't hurt anything anyway).
- When running `SPC u SPC m c c` in python file, pre-fill `"python <filename>"` as the compile command, instead of whatever was in history. Old entries are still reachable via `M-p` and `M-n`.