### PR TITLE
Declare prefix for ruby-mode and enh-ruby-mode in rails layer

### DIFF
--- a/layers/+frameworks/ruby-on-rails/packages.el
+++ b/layers/+frameworks/ruby-on-rails/packages.el
@@ -71,11 +71,10 @@
           "ri" 'projectile-rails-console
           "rxs" 'projectile-rails-server
           ;; Refactoring 'projectile-rails-mode
-          "rRx" 'projectile-rails-extract-region))
-
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mr" "rails/rubocop")
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mrf" "file")
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mrg" "goto")
+          "rRx" 'projectile-rails-extract-region)
+        (spacemacs/declare-prefix-for-mode mode "mr" "rails/rubocop")
+        (spacemacs/declare-prefix-for-mode mode "mrf" "file")
+        (spacemacs/declare-prefix-for-mode mode "mrg" "goto"))
 
       ;; Ex-commands
       (evil-ex-define-cmd "A" 'projectile-toggle-between-implementation-and-test))))


### PR DESCRIPTION
This correctly documents the ruby-on-rails prefixes for both ruby-mode and enh-ruby-mode.

Fixes #7375