### PR TITLE
Add leader binding for `flycheck-explain-error`

### DIFF
--- a/layers/+checkers/syntax-checking/README.org
+++ b/layers/+checkers/syntax-checking/README.org
@@ -61,6 +61,7 @@ variable =syntax-checking-use-original-bitmaps= to =t=:
 | ~SPC e h~   | describe flycheck checker                                    |
 | ~SPC e l~   | display a list of all the errors                             |
 | ~SPC e L~   | display a list of all the errors and focus the errors buffer |
+| ~SPC e e~   | explain the error at point                                   |
 | ~SPC e s~   | set flycheck checker                                         |
 | ~SPC e S~   | set flycheck checker executable                              |
 | ~SPC e v~   | verify flycheck setup                                        |

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -104,6 +104,7 @@ If the error list is visible, hide it.  Otherwise, show it."
         "eh" 'flycheck-describe-checker
         "el" 'spacemacs/toggle-flycheck-error-list
         "eL" 'spacemacs/goto-flycheck-error-list
+        "ee" 'flycheck-explain-error-at-point
         "es" 'flycheck-select-checker
         "eS" 'flycheck-set-checker-executable
         "ev" 'flycheck-verify-setup))))


### PR DESCRIPTION
Flycheck recently gained a feature to explain the error at point (bound
under `C-c ! e` by default).  This commit adds a corresponding leader
binding to the flycheck layer.