### PR TITLE
Remove invalid keybindings of ensime

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -173,9 +173,7 @@ with
 | ~SPC m d B~ | clear breakpoint            |
 | ~SPC m d C~ | clear all breakpoints       |
 | ~SPC m d c~ | continue                    |
-| ~SPC m d d~ | start a debug session       |
 | ~SPC m d i~ | inspect value at point      |
-| ~SPC m d l~ | list local variables        |
 | ~SPC m d n~ | next                        |
 | ~SPC m d o~ | step out                    |
 | ~SPC m d q~ | quit                        |

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -123,9 +123,7 @@
         "dB"     'ensime-db-clear-break
         "dC"     'ensime-db-clear-all-breaks
         "dc"     'ensime-db-continue
-        "dd"     'ensime-db-start
         "di"     'ensime-db-inspect-value-at-point
-        "dl"     'ensime-db-list-locals
         "dn"     'ensime-db-next
         "do"     'ensime-db-step-out
         "dq"     'ensime-db-quit

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -38,7 +38,9 @@
       (add-hook 'typescript-mode-hook 'tide-setup)
       (add-hook 'typescript-mode-hook 'eldoc-mode)
 
-      (add-to-list 'spacemacs-jump-handlers-typescript-mode 'tide-jump-to-definition))
+      (add-to-list 'spacemacs-jump-handlers-typescript-mode 'tide-jump-to-definition)
+
+      (push 'company-tide company-backends-typescript-mode))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")


### PR DESCRIPTION
The function **ensime-db-start** is obsoleted and removed in the newest ensime. 
In the fact, we can not find the function ensime-db-start in the spacemacs.
According to the document (http://ensime.github.io/editors/emacs/userguide/#debugging), now ensime need you use ensimeRunDebug command to start a debug session.

ensime-db-list-locals is unavailable as well.

So remove the invalid keybinding accordingly. 