### PR TITLE
Re-fix 2569

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -88,9 +88,17 @@ Anaconda provides more useful information but can not do it properly
 when this mode is enabled since the minibuffer is cleared all the time."
   (semantic-idle-summary-mode 0))
 
-(defun spacemacs//python-imenu-create-index-use-semantic ()
+(defun spacemacs//python-imenu-create-index-use-semantic-maybe ()
   "Use semantic if the layer is enabled."
-  (setq imenu-create-index-function 'semantic-create-imenu-index))
+  (setq imenu-create-index-function 'spacemacs/python-imenu-create-index))
+
+;; fix for issue #2569 (https://github.com/syl20bnr/spacemacs/issues/2569) and
+;; Emacs 24.5 and older. use `semantic-create-imenu-index' only when
+;; `semantic-mode' is enabled, otherwise use `python-imenu-create-index'
+(defun spacemacs/python-imenu-create-index ()
+  (if (bound-and-true-p semantic-mode)
+      (semantic-create-imenu-index)
+    (python-imenu-create-index)))
 
 (defun spacemacs//python-get-main-testrunner ()
   "Get the main test runner."

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -340,6 +340,11 @@
         (end-of-buffer)
         (evil-insert-state))
 
+      ;; fix for issue #2569 (https://github.com/syl20bnr/spacemacs/issues/2569)
+      (when (version< emacs-version "25")
+        (advice-add 'wisent-python-default-setup :after
+                    #'spacemacs//python-imenu-create-index-use-semantic-maybe))
+
       (spacemacs/declare-prefix-for-mode 'python-mode "mc" "execute")
       (spacemacs/declare-prefix-for-mode 'python-mode "md" "debug")
       (spacemacs/declare-prefix-for-mode 'python-mode "mh" "help")
@@ -392,7 +397,7 @@
                 'spacemacs//disable-semantic-idle-summary-mode t))
   (spacemacs/add-to-hook 'python-mode-hook
                          '(semantic-mode
-                           spacemacs//python-imenu-create-index-use-semantic))
+                           spacemacs//python-imenu-create-index-use-semantic-maybe))
   (defadvice semantic-python-get-system-include-path
       (around semantic-python-skip-error-advice activate)
     "Don't cause error when Semantic cannot retrieve include


### PR DESCRIPTION
Use `spacemacs/python-imenu-create-index` to create imenu's index with semantic, if semantic-mode is enabled, or with python-mode's default method if semantic-mode is disabled.

In Emacs 24.5 and older, requiring `semantic` changes imenu's index function in python-mode to use semantic even if semantic-mode is disabled, which is bad, so we fix that with an advice.

Fixes #2569. This is a modified version of #2583, which was merged already, but the changes were removed at some point for no reason.