### PR TITLE
Add an example for non-standard node bin locations

### DIFF
--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -51,6 +51,11 @@ In order to use automatic code formatting you need to install ~js-beautify~ with
   $ npm install -g js-beautify
 #+END_SRC
 
+If you install these in non-standard locations, then add the following to your =dotspacemacs/user-init= function:
+#+BEGIN_SRC elisp
+  (add-to-list 'exec-path "/path/to/node/bins" t)
+#+END_SRC
+
 Be sure to have the ~e4x~ option set to ~true~ on your ~.jsbeautifyrc~ here it is my configuration as an example:
 #+BEGIN_SRC json
   {

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -57,6 +57,11 @@ such as =ESLint= or =JSHint=:
   $ npm install -g jshint
 #+END_SRC
 
+If you install these in non-standard locations, then add the following to your =dotspacemacs/user-init= function:
+#+BEGIN_SRC elisp
+  (add-to-list 'exec-path "/path/to/node/bins" t)
+#+END_SRC
+
 * Configuration
 ** Tern
 To make tern re-use the server across multiple different editing sessions (thus


### PR DESCRIPTION
If you install your node bins in places outside of the system path, you
need to add those locations to the exec path before packages are loaded
or else spacemacs won't recognize them as existing when it initializes
the layers.
