### PR TITLE
Update comment rules for evilified state

### DIFF
--- a/layers/+distributions/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
@@ -30,6 +30,15 @@
 
 ;; The shadowed original mode key bindings are automatically reassigned
 ;; following a set of rules:
+;; Keys such as 
+;; /,:,h,j,k,l,n,N,v,V,gg,G,C-f,C-b,C-d,C-e,C-u,C-y and C-z 
+;; are working as in Evil.
+;; Other keys will be moved according to this pattern:
+;; a -> A -> C-a -> C-A
+;; The first unreserved key will be used. 
+;; There is an exception for g, which will be directly
+;; bound to C-G, since G and C-g (latest being an important escape key in Emacs) 
+;; are already being used.
 
 ;;; Code:
 


### PR DESCRIPTION
Added keybind rules for the evilified state, as requested in issue #5738 

Fixes #5738 
* Pointed out which keys are using as in Evil
* Pointed out the binding order pattern
* Added that the g binding will be directly bound to C-G