### PR TITLE
Updated the plantuml plugin to use `plantuml-mode` instead of the now deprecated `puml-mode`

### DIFF
--- a/layers/+lang/plantuml/README.org
+++ b/layers/+lang/plantuml/README.org
@@ -8,7 +8,7 @@
  - [[#key-bindings][Key bindings]]
 
 * Description
-This layer enables support for [[https://github.com/skuro/puml-mode][puml-mode]], which provides
+This layer enables support for [[https://github.com/skuro/plantuml-mode][plantuml-mode]], which provides
 a major-mode for [[http://plantuml.com][plantuml]]. PlantUML is a tool to generate [[https://en.wikipedia.org/wiki/Unified_Modeling_Language][UML diagrams]] from plain-text.
 
 For help with how to use plantuml, see the [[http://plantuml.com][plantuml website]] and the [[http://plantuml.com/PlantUML_Language_Reference_Guide.pdf][reference guide]].

--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -3,25 +3,30 @@
 ;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
 ;;
 ;; Author: Robert O'Connor <robby.oconnor@gmail.com>
+;; Contributor: Carlo Sciolla <carlo.sciolla@gmail.com>
 ;; URL: https://github.com/robbyoconnor
 ;;
+;;; Commentary:
+;;
+;; Adds PlantUML support to Spacemacs using plantuml-mode.
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
 
+
+;;; Code:
 (defconst plantuml-packages
   '(org
-    puml-mode))
+    plantuml-mode))
 
 (defun plantuml/post-init-org ()
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(plantuml . t))))
 
-(defun plantuml/init-puml-mode ()
-  (use-package puml-mode
+(defun plantuml/init-plantuml-mode ()
+  (use-package plantuml-mode
     :defer t
-    :mode ("\\.pum\\'" . puml-mode)
-    :config (spacemacs/set-leader-keys-for-major-mode 'puml-mode
-              "cc" 'puml-preview
-              "co" 'puml-set-output-type)))
-
+    :mode ("\\.pum\\'" . plantuml-mode)
+    :config (spacemacs/set-leader-keys-for-major-mode 'plantuml-mode
+              "cc" 'plantuml-preview
+              "co" 'plantuml-set-output-type)))


### PR DESCRIPTION
As soon as [this PR](https://github.com/melpa/melpa/pull/4324) gets merged, the [agreed merge](https://github.com/zwz/plantuml-mode/issues/8) between [skuro/puml-mode](https://github.com/skuro/puml-mode) and [zwz/plantuml-mode](https://github.com/zwz/plantuml-mode) will be finalized.

The code provided here updates the relevant pointers to move to [the new home](https://github.com/skuro/plantuml-mode) of the one and only maintained PlantUML emacs mode.

With <3,
c.