### PR TITLE
Support wdb for debugging Python

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -265,7 +265,7 @@ Send code to hy REPL commands:
 | Key Binding | Description                                                                  |
 |-------------+------------------------------------------------------------------------------|
 | ~SPC m =~   | Reformat the buffer according to PEP8 using  [[https://github.com/google/yapf][YAPF]]                            |
-| ~SPC m d b~ | toggle a breakpoint                                                          |
+| ~SPC m d b~ | toggle a breakpoint using =wdb=, =ipdb=, =pudb= or =pdb=                     |
 | ~SPC m g g~ | go to definition using =anaconda-mode-find-definitions= (~C-o~ to jump back) |
 | ~SPC m g a~ | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back) |
 | ~SPC m g b~ | jump back                                                                    |

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -38,7 +38,8 @@
 (defun spacemacs/python-toggle-breakpoint ()
   "Add a break point, highlight it."
   (interactive)
-  (let ((trace (cond ((spacemacs/pyenv-executable-find "ipdb") "import ipdb; ipdb.set_trace()")
+  (let ((trace (cond ((spacemacs/pyenv-executable-find "wdb") "import wdb; wdb.set_trace()")
+                     ((spacemacs/pyenv-executable-find "ipdb") "import ipdb; ipdb.set_trace()")
                      ((spacemacs/pyenv-executable-find "pudb") "import pudb; pudb.set_trace()")
                      (t "import pdb; pdb.set_trace()")))
         (line (thing-at-point 'line)))


### PR DESCRIPTION
wdb (https://github.com/Kozea/wdb) is a Web-based debugger
for Python. Use it if installed for python-toggle-breakpoint.