### PR TITLE
Fixed layout transient state not closing on layer select in ivy layer

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -183,7 +183,7 @@
         '("b" "l" "C" "X"))
   (setq spacemacs-layouts-transient-state-add-bindings
         '(("b" spacemacs/ivy-spacemacs-layout-buffer)
-          ("l" spacemacs/ivy-spacemacs-layouts)
+          ("l" spacemacs/ivy-spacemacs-layouts :exit t)
           ("C" spacemacs/ivy-spacemacs-layout-close-other :exit t)
           ("X" spacemacs/ivy-spacemacs-layout-kill-other :exit t))))
 


### PR DESCRIPTION
Close layouts transient state after pressing 'l' to list layouts in ivy. This makes more sense than leaving the transient state open and matches the helm functionality. I use ```SPC l l``` frequently to jump between my layouts and the extra step of having to explicitly exit the transient state constantly throws me off.

This fixes:  #7427
