### PR TITLE
Fix a typo introduced when setting up org-babel support

### DIFF
--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -142,7 +142,7 @@
 
 (defun elixir/pre-init-org ()
   (spacemacs|use-package-add-hook org
-    :post-config (add-to-list 'org-babel-load-languages '(python . t))))
+    :post-config (add-to-list 'org-babel-load-languages '(elixir . t))))
 
 (defun elixir/init-ob-elixir ()
   (spacemacs|use-package-add-hook org


### PR DESCRIPTION
Fix a typo introduced in 42a33f3ae8c58b8f416207e6d553dbcbd78e5385