### PR TITLE
Diminish purpose-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -115,6 +115,7 @@
       (purpose-mode))
     :config
     (progn
+      (spacemacs|diminish purpose-mode)
       (purpose-x-golden-ratio-setup)
       ;; when killing a purpose-dedicated buffer that is displayed in a window,
       ;; ensure that the buffer is replaced by a buffer with the same purpose


### PR DESCRIPTION
I made a dedicated segment in Spaceline for this, so let's diminish the minor mode lighter. Will merge when MELPA updates.

cc @bmag 