### PR TITLE
Rust layer - Fix error message about no eldoc support 

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -92,6 +92,6 @@
     :defer t
     :init
     (progn
-      (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode eldoc-mode))
+      (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
       (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
       (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition))))


### PR DESCRIPTION
There is an error when opening rust files that says there is "no ELDoc support in this buffer", however eldoc always worked anyway. This gets rid of that error message.
