### PR TITLE
Properly override purpose-mode-map

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -97,10 +97,6 @@
   (use-package window-purpose
     :init
     (progn
-      ;; overriding `purpose-mode-map' with empty keymap, so it doesn't conflict
-      ;; with original `C-x C-f', `C-x b', etc. and `semantic' key bindings.
-      ;; must be done before `window-purpose' is loaded
-      (setq purpose-mode-map (make-sparse-keymap))
       ;; 'r' is for "puRpose" ('w', 'p' are crowded, 'W', 'P' aren't
       ;; comfortable)
       (spacemacs/set-leader-keys
@@ -113,6 +109,9 @@
       (purpose-mode))
     :config
     (progn
+      ;; overriding `purpose-mode-map' with empty keymap, so it doesn't conflict
+      ;; with original `C-x C-f', `C-x b', etc. and `semantic' key bindings.
+      (setcdr purpose-mode-map nil)
       (spacemacs|diminish purpose-mode)
       (purpose-x-golden-ratio-setup)
       ;; when killing a purpose-dedicated buffer that is displayed in a window,


### PR DESCRIPTION
Setting `purpose-mode-map` to nil before loading `window-purpose` didn't work, because several packages require `window-purpose` before we get to it. Setting to nil with `setcdr` is more reliable and doesn't depend as much on loading order (just need to run it after `window-purpose` was loaded).
cc @ksjogo 