### PR TITLE
purpose: disable kill extension

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -113,8 +113,4 @@
       ;; with original `C-x C-f', `C-x b', etc. and `semantic' key bindings.
       (setcdr purpose-mode-map nil)
       (spacemacs|diminish purpose-mode)
-      (purpose-x-golden-ratio-setup)
-      ;; when killing a purpose-dedicated buffer that is displayed in a window,
-      ;; ensure that the buffer is replaced by a buffer with the same purpose
-      ;; (or the window deleted, if no such buffer)
-      (purpose-x-kill-setup))))
+      (purpose-x-golden-ratio-setup))))


### PR DESCRIPTION
`purpose-x-kill-setup` enables purpose's "kill" extension, which makes `kill-buffer` aware of purpose when looking for a new buffer to display in a window instead of the killed buffer. This is done by overriding `replace-buffer-in-windows`, and recently I have noticed that it can slow down some operations, so we should not enable it by default.

<s>Probably</s> fixes #7460