### PR TITLE
New dotvariable to control switch-to-buffer behavior

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -248,6 +248,14 @@ key sequence. Setting this variable is equivalent to setting
 right, and right-then-bottom. The last one will display on the
 right if possible and fallback to bottom if not.")
 
+(defvar dotspacemacs-switch-to-buffer-prefers-purpose nil
+  "Control where `switch-to-buffer' displays the buffer.
+If nil, `switch-to-buffer' displays the buffer in the current
+window even if another same-purpose window is available. If non
+nil, `switch-to-buffer' displays the buffer in a same-purpose
+window even if the buffer can be displayed in the current
+window.")
+
 (defvar dotspacemacs-loading-progress-bar t
   "If non nil a progress bar is displayed when spacemacs is loading. This
 may increase the boot time on some systems and emacs builds, set it to nil

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -214,6 +214,12 @@ values."
    ;; right; if there is insufficient space it displays it at the bottom.
    ;; (default 'bottom)
    dotspacemacs-which-key-position 'bottom
+   ;; Control where `switch-to-buffer' displays the buffer. If nil,
+   ;; `switch-to-buffer' displays the buffer in the current window even if
+   ;; another same-purpose window is available. If non nil, `switch-to-buffer'
+   ;; displays the buffer in a same-purpose window even if the buffer can be
+   ;; displayed in the current window. (default nil)
+   dotspacemacs-switch-to-buffer-prefers-purpose nil
    ;; If non nil a progress bar is displayed when spacemacs is loading. This
    ;; may increase the boot time on some systems and emacs builds, set it to
    ;; nil to boost the loading time. (default t)

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -109,6 +109,25 @@
       (purpose-mode))
     :config
     (progn
+      ;; change `switch-to-buffer' display preferences according to
+      ;; `dotspacemacs-switch-to-buffer-prefers-purpose'. This affects actions
+      ;; like `spacemacs/alternate-buffer', and opening buffers from Dired
+      (setcdr (assq 'switch-to-buffer purpose-action-sequences)
+              (if dotspacemacs-switch-to-buffer-prefers-purpose
+                  '(purpose-display-reuse-window-buffer
+                    purpose-display-reuse-window-purpose
+                    purpose-display-maybe-same-window
+                    purpose-display-maybe-other-window
+                    purpose-display-maybe-other-frame
+                    purpose-display-maybe-pop-up-window
+                    purpose-display-maybe-pop-up-frame)
+                '(purpose-display-maybe-same-window
+                  purpose-display-reuse-window-buffer
+                  purpose-display-reuse-window-purpose
+                  purpose-display-maybe-other-window
+                  purpose-display-maybe-other-frame
+                  purpose-display-maybe-pop-up-window
+                  purpose-display-maybe-pop-up-frame)))
       ;; overriding `purpose-mode-map' with empty keymap, so it doesn't conflict
       ;; with original `C-x C-f', `C-x b', etc. and `semantic' key bindings.
       (setcdr purpose-mode-map nil)


### PR DESCRIPTION
With a nil value for `dotspacemacs-switch-to-buffer-prefers-purpose`, switch-to-buffer prefers using the current window, same as vanilla Emacs. With a non-nil value, switch-to-buffer prefers another window with the same purpose as the buffer. This affects actions like `spacemacs/alternate-buffer`, and opening buffers from Dired.

I chose `nil` as the default value so that `switch-to-buffer` stays roughly the same as vanila Emacs, and users who are familiar with Emacs don't get surprised (as in #7453). Personally I think setting to `dotspacemacs-switch-to-buffer-prefers-purpose` to `t` is better, I'm just not sure if it's good as the default behavior for unsuspecting users.