### PR TITLE
Cleaned up directory warning about duplicate layers.

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1091,7 +1091,7 @@ Returns nil if the directory is not a category."
                   (if indexed-layer
                       ;; the same layer may have been discovered twice,
                       ;; in which case we don't need a warning
-                      (unless (string-equal (replace-regexp-in-string "\/$" "" (oref indexed-layer :dir)) (replace-regexp-in-string "\/$" "" sub))
+                      (unless (string-equal (directory-file-name (oref indexed-layer :dir)) (directory-file-name sub))
                         (configuration-layer//warning
                          (concat
                           "Duplicated layer %s detected in directory \"%s\", "

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1091,7 +1091,7 @@ Returns nil if the directory is not a category."
                   (if indexed-layer
                       ;; the same layer may have been discovered twice,
                       ;; in which case we don't need a warning
-                      (unless (string-equal (oref indexed-layer :dir) sub)
+                      (unless (string-equal (replace-regexp-in-string "\/$" "" (oref indexed-layer :dir)) (replace-regexp-in-string "\/$" "" sub))
                         (configuration-layer//warning
                          (concat
                           "Duplicated layer %s detected in directory \"%s\", "


### PR DESCRIPTION
Cleaned up a warning that occurs when loading private layers
The layer discovery loop scans the private layer directory (
~/.spacemacs.d/layers) AND also ~/.spacemacs.d
The code then checks if a layer directory already exists
but the comparison fails due to trailing / in some paths.

The fix is to strip any trailing slash from both directories being
compared.

[Edit TheBB: removed text that specifically says to remove]