### PR TITLE
Cleanup warning about duplicate layers

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1091,7 +1091,7 @@ Returns nil if the directory is not a category."
                   (if indexed-layer
                       ;; the same layer may have been discovered twice,
                       ;; in which case we don't need a warning
-                      (unless (string-equal (replace-regexp-in-string "\/$" "" (oref indexed-layer :dir)) (replace-regexp-in-string "\/$" "" sub))
+                      (unless (string-equal (directory-file-name (oref indexed-layer :dir)) (directory-file-name sub))
                         (configuration-layer//warning
                          (concat
                           "Duplicated layer %s detected in directory \"%s\", "

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1091,7 +1091,7 @@ Returns nil if the directory is not a category."
                   (if indexed-layer
                       ;; the same layer may have been discovered twice,
                       ;; in which case we don't need a warning
-                      (unless (string-equal (oref indexed-layer :dir) sub)
+                      (unless (string-equal (replace-regexp-in-string "\/$" "" (oref indexed-layer :dir)) (replace-regexp-in-string "\/$" "" sub))
                         (configuration-layer//warning
                          (concat
                           "Duplicated layer %s detected in directory \"%s\", "


### PR DESCRIPTION
Changed my previous PR to use 'directory-file-name' instead of regex replacing the trailing /.

This PR will cleanup the warnings produced for any private layers under ~/.spacemacs.d/layers

