### PR TITLE
Reliable loading of custom-file after load

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -377,6 +377,8 @@ If NO-INSTALL is non nil then install steps are skipped."
   (dotspacemacs|call-func dotspacemacs/layers "Calling dotfile layers...")
   (setq dotspacemacs--configuration-layers-saved
         dotspacemacs-configuration-layers)
+  (when (and custom-file (file-exists-p custom-file))
+    (load-file custom-file))
   (when (spacemacs-buffer//choose-banner)
     (spacemacs-buffer//inject-version))
   ;; declare used layers then packages as soon as possible to resolve

--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -153,9 +153,13 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Session
 ;; ---------------------------------------------------------------------------
 
-;; save custom variables in ~/.spacemacs
+;; save custom variables in ~/.emacs.d/private/custom.el or
+;; ~/.spacemacs.d/custom.el by default
 (unless (bound-and-true-p custom-file)
-  (setq custom-file (dotspacemacs/location)))
+  (setq custom-file
+        (concat (or dotspacemacs-directory
+                    configuration-layer-private-directory)
+                "custom.el")))
 ;; scratch buffer empty
 (setq initial-scratch-message nil)
 ;; don't create backup~ files


### PR DESCRIPTION
This lets people use customize to reliably override stuff, even variables that are set in Spacemacs. People who are already modifying the value of `custom-file` should see no change. People who are relying on customize in their dotfile should probably move them, but the existing forms should continue to work as well as they are now.

Fixes: https://github.com/syl20bnr/spacemacs/issues/5170

Obsoletes quite a few other PRs I expect.
