### PR TITLE
Add toggle for syntax highlighting (via font-lock)

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1086,6 +1086,7 @@ and ~T~):
 | ~SPC t h h~ | toggle highlight of the current line                              |
 | ~SPC t h i~ | toggle highlight indentation levels                               |
 | ~SPC t h c~ | toggle highlight indentation current column                       |
+| ~SPC t H~   | toggle syntax highlighting                                        |
 | ~SPC t i~   | toggle indentation guide at point                                 |
 | ~SPC t l~   | toggle truncate lines                                             |
 | ~SPC t L~   | toggle visual lines                                               |

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -304,6 +304,10 @@
   :off (hidden-mode-line-mode)
   :documentation "Toggle the visibility of modeline."
   :evil-leader "tmt")
+(spacemacs|add-toggle syntax-highlighting
+  :mode font-lock-mode
+  :documentation "Toggle syntax highlighting."
+  :evil-leader "tH")
 (spacemacs|add-toggle transparent-frame
   :status nil
   :on (spacemacs/toggle-transparency)


### PR DESCRIPTION
I titled it Syntax Highlighting as the description would make more sense to a newbie compared to font lock. Also, [it's referenced as syntax highlighting in the documentation](https://www.gnu.org/software/emacs/manual/html_node/efaq/Turning-on-syntax-highlighting.html).