### PR TITLE
Add support for ripgrep, fixes #7370

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -326,9 +326,9 @@ to aggressively delete empty lines and long sequences of whitespace, `trailing'
 to delete only the whitespace at end of lines, `changed' to delete only
 whitespace for changed lines or `nil' to disable cleanup.")
 
-(defvar dotspacemacs-search-tools '("ag" "pt" "ack" "grep")
+(defvar dotspacemacs-search-tools '("rg" "ag" "pt" "ack" "grep")
   "List of search tool executable names. Spacemacs uses the first installed
-tool of the list. Supported tools are `ag', `pt', `ack' and `grep'.")
+tool of the list. Supported tools are `rg', `ag', `pt', `ack' and `grep'.")
 
 (defvar dotspacemacs-default-package-repository 'melpa-stable
   "The default package repository used if no explicit repository has been

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2289,10 +2289,11 @@ You can toggle auto-save in a buffer by calling the command =auto-save-mode=.
 ** Searching
 *** With an external tool
 Spacemacs can be interfaced with different search utilities like:
-  - ack
-  - grep
+  - [[https://github.com/BurntSushi/ripgrep][rg]]
   - [[https://github.com/ggreer/the_silver_searcher][ag]]
   - [[https://github.com/monochromegane/the_platinum_searcher][pt]]
+  - [[http://beyondgrep.com/][ack]]
+  - grep
 
 The search commands in Spacemacs are organized under the ~SPC s~ prefix with the
 next key is the tool to use and the last key is the scope. For instance ~SPC s a
@@ -2304,9 +2305,9 @@ a B~ will search with symbol under point (if there is no active region).
 
 If the tool key is omitted then a default tool will be automatically selected
 for the search. This tool corresponds to the first tool found on the system of
-the list =dotspacemacs-search-tools=, the default order is =ag=, =pt=, =ack=
-then =grep=. For instance ~SPC s b~ will search in the opened buffers using =pt=
-if =ag= has not been found on the system.
+the list =dotspacemacs-search-tools=, the default order is =rg=, =ag=, =pt=,
+=ack= then =grep=. For instance ~SPC s b~ will search in the opened buffers
+using =pt= if =rg= and =ag= have not been found on the system.
 
 The tool keys are:
 
@@ -2315,6 +2316,7 @@ The tool keys are:
 | ag   | a   |
 | grep | g   |
 | ack  | k   |
+| rg   | r   |
 | pt   | t   |
 
 The available scopes and corresponding keys are:
@@ -2330,7 +2332,7 @@ of the sequence, for instance ~SPC s a a~ will search in the current
 file with =ag=.
 
 *Notes*:
-- =ag= and =pt= are optimized to be used in a source control repository but
+- =rg=, =ag= and =pt= are optimized to be used in a source control repository but
   they can be used in an arbitrary directory as well.
 - It is also possible to search in several directories at once by marking
   them in the helm buffer.
@@ -2362,6 +2364,8 @@ bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~
 | ~SPC s a A~ | =ag= with default input                             |
 | ~SPC s g g~ | =grep=                                              |
 | ~SPC s g G~ | =grep= with default input                           |
+| ~SPC s r r~ | =rg=                                                |
+| ~SPC s r R~ | =rg= with default input                             |
 
 **** Searching in all open buffers visiting files
 
@@ -2375,6 +2379,8 @@ bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~
 | ~SPC s g B~ | =grep= with default text                            |
 | ~SPC s k b~ | =ack=                                               |
 | ~SPC s k B~ | =ack= with default text                             |
+| ~SPC s r b~ | =rg=                                                |
+| ~SPC s r B~ | =rg= with default text                              |
 | ~SPC s t b~ | =pt=                                                |
 | ~SPC s t B~ | =pt= with default text                              |
 
@@ -2390,6 +2396,8 @@ bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~
 | ~SPC s g F~ | =grep= with default text                            |
 | ~SPC s k f~ | =ack=                                               |
 | ~SPC s k F~ | =ack= with default text                             |
+| ~SPC s r f~ | =rg=                                                |
+| ~SPC s r F~ | =rg= with default text                              |
 | ~SPC s t f~ | =pt=                                                |
 | ~SPC s t F~ | =pt= with default text                              |
 
@@ -2406,6 +2414,8 @@ bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~
 | ~SPC s k P~           | =ack= with default text                             |
 | ~SPC s t p~           | =pt=                                                |
 | ~SPC s t P~           | =pt= with default text                              |
+| ~SPC s r p~           | =rg=                                                |
+| ~SPC s r P~           | =rg= with default text                              |
 
 *Hint*: It is also possible to search in a project without needing to open a
 file beforehand. To do so use ~SPC p p~ and then ~C-s~ on a given project to
@@ -2788,8 +2798,8 @@ an ~occurrence~.
    e p ESC ESC~
 
 *** Replacing text in several files
-If you have =ag=, =pt= or =ack= installed, replacing an occurrence of text in
-several files can be performed via [[https://github.com/syohex/emacs-helm-ag][helm-ag]].
+If you have =rg=, =ag=, =pt= or =ack= installed, replacing an occurrence of text
+in several files can be performed via [[https://github.com/syohex/emacs-helm-ag][helm-ag]].
 
 Say you want to replace all =foo= occurrences by =bar= in your current
 project:
@@ -2799,8 +2809,8 @@ project:
   - edit the occurrences then leave the =iedit state=
   - press ~C-c C-c~
 
-*Note*: In Spacemacs, =helm-ag= despite its name works with =ack= and =pt= as
-well (but not with =grep=).
+*Note*: In Spacemacs, =helm-ag= despite its name works with =rg=, =pt= and =ack=
+as well (but not with =grep=).
 
 *** Renaming files in a directory
 It is possible to batch rename files in a directory using =wdired= from an
@@ -3005,6 +3015,7 @@ To search in a project see [[Searching in a project][project searching]].
 | ~SPC s g p~ | run =grep=                                              |
 | ~SPC s k p~ | run =ack=                                               |
 | ~SPC s t p~ | run =pt=                                                |
+| ~SPC s r p~ | run =rg=                                                |
 
 *Note for Windows Users*: To enable fast indexing the GNU ~find~ or
 Cygwin ~find~ must be in your ~PATH~.

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -242,6 +242,17 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         (interactive)
         (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-pt))
 
+      (defun spacemacs/helm-files-do-rg (&optional dir)
+        "Search in files with `rg'."
+        (interactive)
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --vimgrep"))
+          (helm-do-ag dir)))
+
+      (defun spacemacs/helm-files-do-rg-region-or-symbol ()
+        "Search in files with `rg' using a default input."
+        (interactive)
+        (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-rg))
+
       (defun spacemacs/helm-files-smart-do-search (&optional default-inputp)
         "Search in opened buffers using `dotspacemacs-search-tools'.
 Search for a search tool in the order provided by `dotspacemacs-search-tools'
@@ -293,6 +304,17 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "Search in opened buffers with `pt' using a default input."
         (interactive)
         (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-buffers-do-pt))
+
+      (defun spacemacs/helm-buffers-do-rg (&optional _)
+        "Search in opened buffers with `rg'."
+        (interactive)
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --vimgrep"))
+          (helm-do-ag-buffers)))
+
+      (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()
+        "Search in opened buffers with `rg' using a default input."
+        (interactive)
+        (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-buffers-do-rg))
 
       (defun spacemacs/helm-buffers-smart-do-search (&optional default-inputp)
         "Search in opened buffers using `dotspacemacs-search-tools'.
@@ -364,6 +386,23 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
                'spacemacs/helm-files-do-pt dir)
             (message "error: Not in a project."))))
 
+      (defun spacemacs/helm-project-do-rg ()
+        "Search in current project with `rg'."
+        (interactive)
+        (let ((dir (projectile-project-root)))
+          (if dir
+              (spacemacs/helm-files-do-rg dir)
+            (message "error: Not in a project."))))
+
+      (defun spacemacs/helm-project-do-rg-region-or-symbol ()
+        "Search in current project with `rg' using a default input."
+        (interactive)
+        (let ((dir (projectile-project-root)))
+          (if dir
+              (spacemacs//helm-do-ag-region-or-symbol
+               'spacemacs/helm-files-do-rg dir)
+            (message "error: Not in a project."))))
+
       (defun spacemacs/helm-project-smart-do-search (&optional default-inputp)
         "Search in current project using `dotspacemacs-search-tools'.
 Search for a search tool in the order provided by `dotspacemacs-search-tools'
@@ -384,7 +423,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         (spacemacs/helm-project-smart-do-search t))
 
       ;; This overrides the default C-s action in helm-projectile-switch-project
-      ;; to search using ag/pt/whatever instead of just grep
+      ;; to search using rg/ag/pt/whatever instead of just grep
       (with-eval-after-load 'helm-projectile
         (defun spacemacs/helm-project-smart-do-search-in-dir (dir)
           (interactive)
@@ -412,6 +451,8 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "saB" 'spacemacs/helm-buffers-do-ag-region-or-symbol
         "skb" 'spacemacs/helm-buffers-do-ack
         "skB" 'spacemacs/helm-buffers-do-ack-region-or-symbol
+        "srb" 'spacemacs/helm-buffers-do-rg
+        "srB" 'spacemacs/helm-buffers-do-rg-region-or-symbol
         "stb" 'spacemacs/helm-buffers-do-pt
         "stB" 'spacemacs/helm-buffers-do-pt-region-or-symbol
         ;; current file scope
@@ -426,6 +467,8 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "saF" 'spacemacs/helm-files-do-ag-region-or-symbol
         "skf" 'spacemacs/helm-files-do-ack
         "skF" 'spacemacs/helm-files-do-ack-region-or-symbol
+        "srf" 'spacemacs/helm-files-do-rg
+        "srF" 'spacemacs/helm-files-do-rg-region-or-symbol
         "stf" 'spacemacs/helm-files-do-pt
         "stF" 'spacemacs/helm-files-do-pt-region-or-symbol
         ;; current project scope
@@ -437,6 +480,8 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         "saP" 'spacemacs/helm-project-do-ag-region-or-symbol
         "skp" 'spacemacs/helm-project-do-ack
         "skP" 'spacemacs/helm-project-do-ack-region-or-symbol
+        "srp" 'spacemacs/helm-project-do-rg
+        "srP" 'spacemacs/helm-project-do-rg-region-or-symbol
         "stp" 'spacemacs/helm-project-do-pt
         "stP" 'spacemacs/helm-project-do-pt-region-or-symbol))
     :config

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -13,7 +13,8 @@
 ;; Variables
 
 (defvar spacemacs--counsel-commands
-  '(("ag" . "ag --nocolor --nogroup %s %S .")
+  '(("rg" . "rg --smart-case --no-heading --vimgrep %s %S .")
+    ("ag" . "ag --nocolor --nogroup %s %S .")
     ("pt" . "pt -e --nocolor --nogroup %s %S .")
     ("ack" . "ack --nocolor --nogroup %s %S .")
     ("grep" . "grep -nrP %s %S ."))

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -165,6 +165,7 @@ that directory."
 ;; Define search functions for each tool
 (cl-loop
    for (tools tool-name) in '((dotspacemacs-search-tools "auto")
+                              ((list "rg") "rg")
                               ((list "ag") "ag")
                               ((list "pt") "pt")
                               ((list "ack") "ack")

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -76,10 +76,6 @@
         "saF" 'spacemacs/search-ag-region-or-symbol
         "sap" 'spacemacs/search-project-ag
         "saP" 'spacemacs/search-project-ag-region-or-symbol
-        "stf" 'spacemacs/search-pt
-        "stF" 'spacemacs/search-pt-region-or-symbol
-        "stp" 'spacemacs/search-project-pt
-        "stP" 'spacemacs/search-project-pt-region-or-symbol
         "sgf" 'spacemacs/search-grep
         "sgF" 'spacemacs/search-grep-region-or-symbol
         "sgp" 'counsel-git-grep
@@ -87,7 +83,15 @@
         "skf" 'spacemacs/search-ack
         "skF" 'spacemacs/search-ack-region-or-symbol
         "skp" 'spacemacs/search-project-ack
-        "skP" 'spacemacs/search-project-ack-region-or-symbol)
+        "skP" 'spacemacs/search-project-ack-region-or-symbol
+        "srf" 'spacemacs/search-rg
+        "srF" 'spacemacs/search-rg-region-or-symbol
+        "srp" 'spacemacs/search-project-rg
+        "srP" 'spacemacs/search-project-rg-region-or-symbol
+        "stf" 'spacemacs/search-pt
+        "stF" 'spacemacs/search-pt-region-or-symbol
+        "stp" 'spacemacs/search-project-pt
+        "stP" 'spacemacs/search-project-pt-region-or-symbol)
 
       ;; set additional ivy actions
       (ivy-set-actions


### PR DESCRIPTION
Working on a first contribution to spacemacs, be gentle. :-)

Note this puts ripgrep _first_ in the list, ahead of the silver searcher. This
is based on my own experience of ag being buggy with long lines and large
files, and it's the reason I'm pursuing ripgrep support in spacemacs. I think
when this PR is done, it's appropriate for ripgrep to take the first priority
slot.

Naturally up for discussion. ;-)
- [x] add to dotspacemacs-search-tools
- [x] add to documentation
- [x] add functions and bindings to helm layer
- [x] add functions and bindings to ivy layer
- [x] fix the regex joining problem for multiple words https://github.com/syohex/emacs-helm-ag/pull/278 https://github.com/syohex/emacs-helm-ag/pull/280
- [x] ~~figure out if this needs to depend on helm v2.3.0 which [added ripgrep support](https://github.com/emacs-helm/helm/pull/1625) as @koterpillar [mentioned](https://github.com/syl20bnr/spacemacs/issues/7370#issuecomment-254371441)~~ (I don't think this has any dependency on helm v2.3.0 since that code is distinct from the ag/rg support in helm-ag.)
