### PR TITLE
Maximize frame earlier in the startup process

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -80,6 +80,9 @@ the final step of executing code in `emacs-startup-hook'.")
   (dotspacemacs/load-file)
   (require 'core-configuration-layer)
   (dotspacemacs|call-func dotspacemacs/init "Calling dotfile init...")
+  (when dotspacemacs-maximized-at-startup
+    (toggle-frame-maximized)
+    (add-to-list 'default-frame-alist '(fullscreen . maximized)))
   (dotspacemacs|call-func dotspacemacs/user-init "Calling dotfile user init...")
   (setq dotspacemacs-editing-style (dotspacemacs//read-editing-style-config
                                     dotspacemacs-editing-style))

--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -134,9 +134,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
     ;; but IS available during the subsequent config reloads
     (if (fboundp 'spacemacs/toggle-fullscreen-frame-on)
         (spacemacs/toggle-fullscreen-frame-on)
-      (spacemacs/toggle-frame-fullscreen))
-  (if dotspacemacs-maximized-at-startup
-      (add-hook 'window-setup-hook 'toggle-frame-maximized)))
+      (spacemacs/toggle-frame-fullscreen)))
 
 (setq ns-use-native-fullscreen (not dotspacemacs-fullscreen-use-non-native))
 


### PR DESCRIPTION
Maximize frame as early as possible when `dotspacemacs-maximized-at-startup` is `t`.

This avoid this annoying effect that during all the loading and the displaying of the startup/update messages the frame is ridiculously small.

This code should work on windows as well.