### PR TITLE
Add keybindings to move buffers by window number

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -184,6 +184,55 @@ Dedicated (locked) windows are left untouched."
   (interactive "p")
   (spacemacs/rotate-windows (* -1 count)))
 
+;; Note that this duplicates code from select-window-by-number, ideally should
+;; upstream this function into windows.el
+(defun spacemacs/get-window-by-number (i)
+  (let ((windows (car (gethash (selected-frame) window-numbering-table)))
+        window)
+    (if (and (>= i 0) (< i 10)
+             (setq window (aref windows i)))
+        window
+      (error "No window numbered %s" i))))
+
+(defun spacemacs/move-buffer-to-window (windownum follow-focus-p)
+  "Moves a buffer to a window, using the spacemacs numbering. follow-focus-p
+   controls whether focus moves to new window (with buffer), or stays on
+   current"
+  (interactive)
+  (let ((b (current-buffer))
+        (w1 (selected-window))
+        (w2 (spacemacs/get-window-by-number windownum)))
+    (unless (eq w1 w2)
+      (set-window-buffer w2 b)
+      (switch-to-prev-buffer)
+      (unrecord-window-buffer w1 b)))
+  (when follow-focus-p (select-window (spacemacs/get-window-by-number windownum))))
+
+(defun spacemacs/swap-buffers-to-window (windownum follow-focus-p)
+  "Swaps visible buffers between active window and selected window.
+   follow-focus-p controls whether focus moves to new window (with buffer), or
+   stays on current"
+  (interactive)
+  (let* ((b1 (current-buffer))
+         (w1 (selected-window))
+         (w2 (spacemacs/get-window-by-number windownum))
+         (b2 (window-buffer w2)))
+    (unless (eq w1 w2)
+      (set-window-buffer w1 b2)
+      (set-window-buffer w2 b1)
+      (unrecord-window-buffer w1 b1)
+      (unrecord-window-buffer w2 b2)))
+  (when follow-focus-p (select-window-by-number windownum)))
+
+(dotimes (i 9)
+  (let ((n (+ i 1)))
+    (eval `(defun ,(intern (format "buffer-to-window-%s" n)) (&optional arg)
+              ,(format "Move buffer to the window with number %i." n)
+              (interactive "P")
+              (if arg
+                  (spacemacs/swap-buffers-to-window ,n t)
+                (spacemacs/move-buffer-to-window ,n t))))))
+
 (defun spacemacs/rename-file (filename &optional new-filename)
   "Rename FILENAME to NEW-FILENAME.
 
@@ -907,4 +956,3 @@ a split-side entry, its value must be usable as the SIDE argument for
                                             text-scale-mode-amount) 1)
                                   (if (car (window-margins))
                                       (car (window-margins)) 1)))))
-

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -130,6 +130,10 @@
   "bs"    'spacemacs/switch-to-scratch-buffer
   "bY"    'spacemacs/copy-whole-buffer-to-clipboard
   "bw"    'read-only-mode)
+(dotimes (i 9)
+  (let ((n (+ i 1)))
+    (spacemacs/set-leader-keys (format "b%i" n)
+      (intern (format "buffer-to-window-%s" n)))))
 ;; Cycling settings -----------------------------------------------------------
 (spacemacs/set-leader-keys "Tn" 'spacemacs/cycle-spacemacs-theme)
 ;; errors ---------------------------------------------------------------------


### PR DESCRIPTION
Adds functions and keybindings that allow moving the current buffer to the nth window via SPC b n. Adding the prefix key causes a swap instead. Window focus follows the buffer, though we could later change this to a setting. Note that the associated buffers of the window are handled correctly; that is when the buffer is moved away from the window, that buffer is deleted from the window's history, so for instance SPC TAB does not switch back to the buffer you just moved away.