### PR TITLE
Scala readme: code block for scala-enable-eldoc

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -107,7 +107,7 @@ variable =scala-enable-eldoc= to =t=.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (scala :variables scala-use-java-doc-style t)))
+    (scala :variables scala-enable-eldoc t)))
 #+END_SRC
 
 Enabling this option can cause slow editor performance.


### PR DESCRIPTION
The readme (which I hope gets generated to the HTML for the docs) has an incorrect code block for the scala-enable-eldoc variable, showing the wrong variable. This fixes it.