### PR TITLE
Fix eclim documentation in Java layer

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -42,7 +42,7 @@ Then set the =Eclipse= and =Eclim= paths in =dotspacemacs/user-config=,
 for instance:
 
 #+BEGIN_SRC elisp
-  (setq eclim-eclipse-dirs "~/opt/eclipse"
+  (setq eclim-eclipse-dirs '("~/opt/eclipse")
         eclim-executable "~/opt/eclipse/eclim")
 #+END_SRC
 


### PR DESCRIPTION
`eclim-eclipse-dirs` is a list, not a string.