### PR TITLE
Change default fringe color for centered-buffer-mode.

### DIFF
--- a/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
+++ b/layers/+distributions/spacemacs-base/local/centered-buffer-mode/centered-buffer-mode.el
@@ -41,7 +41,7 @@ that differed modifications won't cause an overflow."
   :type 'integer
   :group 'spacemacs-centered-buffer-mode)
 
-(defcustom spacemacs-centered-buffer-mode-fringe-color "black"
+(defcustom spacemacs-centered-buffer-mode-fringe-color (face-background 'default)
   "Color of the fringes."
   :type 'color
   :group 'spacemacs-centered-buffer-mode)


### PR DESCRIPTION
The current default color is "black", which creates ugly bars for many
themes on both sides of the centered buffer. This change sets the fringe
color to the buffer's background color, which blends in nicely.

An example:
### Before

![screenshot from 2016-10-22 20-06-22](https://cloud.githubusercontent.com/assets/1031518/19618337/24eb4276-9893-11e6-9e41-e5154d2eab31.png)
### After

![screenshot from 2016-10-22 20-05-11](https://cloud.githubusercontent.com/assets/1031518/19618336/1946abfe-9893-11e6-935f-984d57119b6e.png)
