### PR TITLE
Close layout transient state on 'buffer select' in ivy

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -193,7 +193,7 @@
   (setq spacemacs-layouts-transient-state-remove-bindings
         '("b" "l" "C" "X"))
   (setq spacemacs-layouts-transient-state-add-bindings
-        '(("b" spacemacs/ivy-spacemacs-layout-buffer)
+        '(("b" spacemacs/ivy-spacemacs-layout-buffer :exit t)
           ("l" spacemacs/ivy-spacemacs-layouts :exit t)
           ("C" spacemacs/ivy-spacemacs-layout-close-other :exit t)
           ("X" spacemacs/ivy-spacemacs-layout-kill-other :exit t))))


### PR DESCRIPTION
Shortly after completing #7430, I noticed that the exact same problem existed when selecting the "buffer in layout" option in the layouts transient state when using ivy. That is the transient state did not close when entering 'buffer select' as it does when using helm.