### PR TITLE
Move helm specific layout transient state keybindings to helm layer

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -25,6 +25,7 @@
         helm-themes
         (helm-spacemacs-help :location local)
         imenu
+        persp-mode
         popwin
         projectile
         ))
@@ -593,3 +594,8 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
 
 (defun helm/post-init-projectile ()
   (setq projectile-completion-system 'helm))
+
+(defun helm/post-init-persp-mode ()
+   (setq spacemacs-layouts-transient-state-add-bindings
+           '(("b" spacemacs/persp-helm-mini :exit t)
+             ("l" spacemacs/helm-perspectives :exit t))))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -191,7 +191,7 @@
    '(("c" persp-kill-without-buffers "Close layout(s)")
      ("k" persp-kill  "Kill layout(s)")))
   (setq spacemacs-layouts-transient-state-remove-bindings
-        '("b" "l" "C" "X"))
+        '("C" "X"))
   (setq spacemacs-layouts-transient-state-add-bindings
         '(("b" spacemacs/ivy-spacemacs-layout-buffer)
           ("l" spacemacs/ivy-spacemacs-layouts :exit t)

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -129,8 +129,6 @@
       (spacemacs/defer-until-after-user-config #'spacemacs//activate-persp-mode)
 
       ;; layouts transient state
-      ;; TODO move helm specific key bindings to helm layer
-      ;;      (see ivy for how to do it)
       (spacemacs|transient-state-format-hint layouts
         spacemacs--layouts-ts-full-hint
         "\n\n
@@ -181,11 +179,9 @@
         ("C-l" persp-next)
         ("a" persp-add-buffer :exit t)
         ("A" persp-import-buffers :exit t)
-        ("b" spacemacs/persp-helm-mini :exit t)
         ("d" spacemacs/layouts-ts-close)
         ("D" spacemacs/layouts-ts-close-other :exit t)
         ("h" spacemacs/layout-goto-default :exit t)
-        ("l" spacemacs/helm-perspectives :exit t)
         ("L" persp-load-state-from-file :exit t)
         ("n" persp-next)
         ("N" persp-prev)


### PR DESCRIPTION
While implementing #7527 I noticed a minor TODO to move the helm specific keybindings out of the layouts layer to the helm layer. This pull request implements that refactor.
