### PR TITLE
FAQ: Fix git clone command for trying Spacemacs

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -490,7 +490,7 @@ the new configuration. This can be achieved easily using the following steps:
 
 #+BEGIN_SRC sh
 mkdir ~/spacemacs
-git clone git@github.com:syl20bnr/spacemacs.git ~/spacemacs/.emacs.d
+git clone https://github.com/syl20bnr/spacemacs.git ~/spacemacs/.emacs.d
 HOME=~/spacemacs emacs
 #+END_SRC
 


### PR DESCRIPTION
End users shouldn't clone via SSH :)

This fixes the FAQ to have the same `git clone` command for trying Spacemacs as the README.
