### PR TITLE
don't show warning on layout key clashes

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -204,7 +204,7 @@ Available PROPS:
        ;; Check for Clashes
        (if ,already-defined?
            (unless (equal ,already-defined? ,name)
-             (spacemacs-buffer/warning "Replacing existing binding \"%s\" for %s with %s"
+             (spacemacs-buffer/message "Replacing existing binding \"%s\" for %s with %s"
                                        ,binding ,already-defined? ,name)
              (setq spacemacs--custom-layout-alist
                    (delete (assoc ,binding spacemacs--custom-layout-alist)


### PR DESCRIPTION
Now that we show warning in the startup buffer I think it should not be considered warning when user defines his/her own layout and binds on the key with existing layout. Because, for example, not all people need Spacemacs layout bound on `e` (I use it for `environment`). And seeing warning in the startup buffer makes me think that for some reason it's not advices to rebind these layouts. 
