### PR TITLE
Added hide-others shortcut to osx layer

### DIFF
--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -42,5 +42,7 @@
                       (call-interactively (key-binding "\C-x\C-s"))))
     (global-set-key (kbd "s-Z") 'undo-tree-redo)
     (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen)
-    ;; Emacs sometimes registers C-s-f as this weird keycode
-    (global-set-key (kbd "<C-s-268632070>") 'spacemacs/toggle-frame-fullscreen)))
+    (global-set-key (kbd "M-s-h") 'ns-do-hide-others)
+    ;; Emacs sometimes registers C-s-f or M-s-h as this weird keycode
+    (global-set-key (kbd "<C-s-268632070>") 'spacemacs/toggle-frame-fullscreen)
+    (global-set-key [142607065] 'ns-do-hide-others)))


### PR DESCRIPTION
In emacs 25.1, the osx system default shortcut cmd+alt+h to hide other windows is broken. This commit fixes this (see #7464).
