### PR TITLE
Fix python path with virtualenv on Windows in Python nose package

### DIFF
--- a/layers/+lang/python/local/nose/nose.el
+++ b/layers/+lang/python/local/nose/nose.el
@@ -95,7 +95,9 @@ For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-fro
 (defun nosetests-nose-command ()
   (let ((nose "python -u -c \"import nose; nose.run()\""))
     (if python-shell-virtualenv-path
-        (format "%s/bin/%s" python-shell-virtualenv-path nose)
+        (if (spacemacs/system-is-mswindows)
+            (format "%s/Scripts/%s" python-shell-virtualenv-path nose)
+         (format "%s/bin/%s" python-shell-virtualenv-path nose))
       nose)))
 
 (defun nosetests-all (&optional debug failed)


### PR DESCRIPTION
Virtualenv uses a different directory structure on Windows than it does on *nix.  The nose package in the Python language layer was using the same path for both Windows and *nix and was failing when trying to run unit tests via nose as a result.

This just checks to see if the system type is windows and uses an alternate path if that's the case.
