### PR TITLE
FAQ: add "where to learn elisp" entry

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -24,6 +24,7 @@
    - [[#why-do-i-get-4m-characters-inside-ansi-term][Why do I get '4m' characters inside ansi-term?]]
    - [[#why-are-my-font-settings-not-being-respected][Why are my font settings not being respected?]]
    - [[#why-am-i-getting-a-message-about-environment-variables-on-startup][Why am I getting a message about environment variables on startup?]]
+   - [[#i-want-to-learn-elisp-where-do-i-start-][I want to learn elisp, where do I start ?]]
  - [[#how-do-i][How do I:]]
    - [[#install-a-package-not-provided-by-a-layer][Install a package not provided by a layer?]]
    - [[#disable-a-package-completely][Disable a package completely?]]
@@ -261,6 +262,13 @@ warning, e.g. from =dotspacemacs/user-init=:
 You can also disable this feature entirely by adding =exec-path-from-shell= to
 the list =dotspacemacs-excluded-packages= if you prefer setting =exec-path=
 yourself.
+
+** I want to learn elisp, where do I start ?
+Very quick start: [[http://learnxinyminutes.com/docs/elisp/][learn X in Y minutes (where X is elisp)]]
+
+Practical reference with code examples for various situations that you will
+encounter: [[http://caiorss.github.io/Emacs-Elisp-Programming/][http://caiorss.github.io/Emacs-Elisp-Programming/]], more particularly
+sections [[http://caiorss.github.io/Emacs-Elisp-Programming/Elisp_Programming.html][Elisp Programming]] and [[http://caiorss.github.io/Emacs-Elisp-Programming/Elisp_Snippets.html][Elisp code snippets]].
 
 * How do I:
 ** Install a package not provided by a layer?


### PR DESCRIPTION
As this question is frequently asked in the gitter chat, I thought that it might be nice to have an entry for it in the FAQ.

For the very quick tutorial I linked to https://learnxinyminutes.com/docs/elisp/, whereas the original post for that article was in http://emacs-doctor.com/learn-emacs-lisp-in-15-minutes.html. Not sure which one should be in the FAQ, but I like LearnXInYMinutes because it opens to many more languages :smiley: 

Although emacs-doctor also has good arguments in its favor.

I'm really undecided, so just tell me which one you would prefer to be in the FAQ.
