### PR TITLE
[Python Layer] Autoload feature for local virtualenv

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -179,6 +179,12 @@ the pyenv version. The behavior can be set with the variable
 - =on-project-switch= set the version when you switch projects,
 - =nil= to disable.
 
+The same is also possible on pyvenv with a file called =.venv=. The behavior
+can be set with the variable =python-auto-set-local-pyvenv-virtualenv== to:
+- =on-visit= (default) set the virtualenv when you visit a python buffer,
+- =on-project-switch= set the virtualenv when you switch projects,
+- =nil= to disable.
+
 * Key Bindings
 
 ** Inferior REPL process

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -35,5 +35,10 @@
 
 Possible values are `on-visit', `on-project-switch' or `nil'.")
 
+(defvar python-auto-set-local-pyvenv-virtualenv 'on-visit
+  "Automatically set pyvenv virtualenv from \".venv\".
+
+Possible values are `on-visit', `on-project-switch' or `nil'.")
+
 (defvar python-sort-imports-on-save nil
   "If non-nil, automatically sort imports on save.")

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -82,6 +82,20 @@
           (message "pyenv: version `%s' is not installed (set by %s)"
                    version file-path))))))
 
+(defun spacemacs//pyvenv-mode-set-local-virtualenv ()
+  "Set pyvenv virtualenv from \".venv\" by looking in parent directories."
+  (interactive)
+  (let ((root-path (locate-dominating-file default-directory
+                                           ".venv")))
+    (when root-path
+      (let* ((file-path (expand-file-name ".venv" root-path))
+             (virtualenv
+              (with-temp-buffer
+                (insert-file-contents-literally file-path)
+                (buffer-substring-no-properties (line-beginning-position)
+                                                (line-end-position)))))
+            (pyvenv-workon virtualenv)))))
+
 
 ;; Tests
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -207,6 +207,14 @@
     :defer t
     :init
     (progn
+      (pcase python-auto-set-local-pyvenv-virtualenv
+        (`on-visit
+         (spacemacs/add-to-hooks 'spacemacs//pyvenv-mode-set-local-virtualenv
+                                 '(python-mode-hook
+                                   hy-mode-hook)))
+        (`on-project-switch
+         (add-hook 'projectile-after-switch-project-hook
+                   'spacemacs//pyvenv-mode-set-local-virtualenv)))
       (dolist (mode '(python-mode hy-mode))
         (spacemacs/set-leader-keys-for-major-mode mode
           "Va" 'pyvenv-activate


### PR DESCRIPTION
Several prompts has autoload support for pyvenv which is possiple via [adding a `.venv` file to the root of the project directory](https://virtualenvwrapper.readthedocs.io/en/latest/tips.html)

This is basically a duplicated implementation of the pyenv's autoload feature. Since pyvenv-mode doesn't directly provide a list of virtual environments, I stripped the part that checks validity of an entry. (there is a function called `pyvenv-virtualenv-list` but I think that is not useful here)
