### PR TITLE
replaced "uninstall" with "delete" in comments on dotspacemacs-install-packages

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -75,10 +75,10 @@ Paths must have a trailing slash (ie. `~/.mycontribs/')")
 (defvar dotspacemacs-install-packages 'used-only
   "Defines the behaviour of Spacemacs when installing packages.
 Possible values are `used-only', `used-but-keep-unused' and `all'. `used-only'
-installs only explicitly used packages and uninstall any unused packages as well
+installs only explicitly used packages and deletes any unused packages as well
 as their unused dependencies. `used-but-keep-unused' installs only the used
-packages but won't uninstall them if they become unused. `all' installs *all*
-packages supported by Spacemacs and never uninstall them.")
+packages but won't delete unused ones. `all' installs *all*
+packages supported by Spacemacs and never uninstalls them.")
 
 (defvar dotspacemacs-enable-lazy-installation 'unused
   "Lazy installation of layers (i.e. layers are installed only when a file


### PR DESCRIPTION
to avoid conflation of loading/ignoring with downloading/deleting.

Rationale:

The original confuses "uninstall" with "delete". The correct meaning is "delete".

Usage case study:

My goal was to avoid needless download time when switching between vanilla and modded configs. I like to switch back and forth rapidly to implement new features and track down problems. This works great with magit branch switching and lazy-load fast Spacemacs restart times. However, the bottleneck was that Spacemacs kept deleting and redownloading all the packages.

I read the original instructions above. They were unclear. I wasn't sure whether "keep-unused" would merely avoid deleting orphans, or actually load them. I had to test to verify that orphan layers were not loaded.

The description of 'all is confusing as well. I think it means that all Spacemacs layers are downloaded and activated regardless of whether they have been explicitly enabled, and that orphans are not deleted.
