### PR TITLE
Add requirements list for D

### DIFF
--- a/layers/+lang/d/README.org
+++ b/layers/+lang/d/README.org
@@ -6,6 +6,7 @@
  - [[#description][Description]]
  - [[#install][Install]]
  - [[#key-bindings][Key bindings]]
+ - [[#requirements][Requirements]]
 
 * Description
 This simple layer adds support for the [[http://dlang.org/][D language]].
@@ -30,3 +31,6 @@ instructions]]. After successfully built DCD, you need to copy the binary
 | ~SPC m g r~ | find references to all symbol at point                |
 |-------------+-------------------------------------------------------|
 
+* Requirements
+	- [[https://github.com/Hackerpilot/DCD][DCD]] (completion)
+	- [[https://github.com/dlang/dub][DUB]] (dub projects)


### PR DESCRIPTION
This adds an itemize (:P) with D requirements at the end (#7374).

Probably the installation instructions can be shrinked to the first paragraph, as having binaries on your PATH should be obvious.
