### PR TITLE
gtags: don’t check if mode function is bound

### DIFF
--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -26,34 +26,34 @@ Otherwise does nothing."
 
 (defun spacemacs/helm-gtags-define-keys-for-mode (mode)
   "Define key bindings for the specific MODE."
-  (when (fboundp mode)
-    ;; The functionality of `helm-gtags-mode' is pretty much entirely superseded
-    ;; by `ggtags-mode', so we don't add this hook
-    ;; (let ((hook (intern (format "%S-hook" mode))))
-    ;;   (add-hook hook 'helm-gtags-mode))
+  ;; The functionality of `helm-gtags-mode' is pretty much entirely superseded
+  ;; by `ggtags-mode', so we don't add this hook
+  ;; (let ((hook (intern (format "%S-hook" mode))))
+  ;;   (add-hook hook 'helm-gtags-mode))
 
-    ;; `helm-gtags-dwim' is added to the end of the mode-specific jump handlers
-    ;; Some modes have more sophisticated jump handlers that go to the beginning
-    ;; It might be possible to add `helm-gtags-dwim' instead to the default
-    ;; handlers, if it does a reasonable job in ALL modes.
-    (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode))))
-      (add-to-list jumpl 'spacemacs/helm-gtags-maybe-dwim 'append))
+  ;; `helm-gtags-dwim' is added to the end of the mode-specific jump handlers
+  ;; Some modes have more sophisticated jump handlers that go to the beginning
+  ;; It might be possible to add `helm-gtags-dwim' instead to the default
+  ;; handlers, if it does a reasonable job in ALL modes.
+  (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode))))
+    (when (boundp jumpl)
+      (add-to-list jumpl 'spacemacs/helm-gtags-maybe-dwim 'append)))
 
-    (spacemacs/set-leader-keys-for-major-mode mode
-      "gc" 'helm-gtags-create-tags
-      "gd" 'helm-gtags-find-tag
-      "gD" 'helm-gtags-find-tag-other-window
-      "gf" 'helm-gtags-select-path
-      "gG" 'helm-gtags-dwim-other-window
-      "gi" 'helm-gtags-tags-in-this-function
-      "gl" 'helm-gtags-parse-file
-      "gn" 'helm-gtags-next-history
-      "gp" 'helm-gtags-previous-history
-      "gr" 'helm-gtags-find-rtag
-      "gR" 'helm-gtags-resume
-      "gs" 'helm-gtags-select
-      "gS" 'helm-gtags-show-stack
-      "gu" 'helm-gtags-update-tags)))
+  (spacemacs/set-leader-keys-for-major-mode mode
+    "gc" 'helm-gtags-create-tags
+    "gd" 'helm-gtags-find-tag
+    "gD" 'helm-gtags-find-tag-other-window
+    "gf" 'helm-gtags-select-path
+    "gG" 'helm-gtags-dwim-other-window
+    "gi" 'helm-gtags-tags-in-this-function
+    "gl" 'helm-gtags-parse-file
+    "gn" 'helm-gtags-next-history
+    "gp" 'helm-gtags-previous-history
+    "gr" 'helm-gtags-find-rtag
+    "gR" 'helm-gtags-resume
+    "gs" 'helm-gtags-select
+    "gS" 'helm-gtags-show-stack
+    "gu" 'helm-gtags-update-tags))
 
 (defun spacemacs/ggtags-mode-enable ()
   "Enable ggtags and eldoc mode.


### PR DESCRIPTION
I'm not sure why this was there in the first place, but there's no guarantee that the mode function is bound when this function runs.

Fixes https://github.com/syl20bnr/spacemacs/issues/7585
