### PR TITLE
Adds docs to ruby-refactor work

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -16,6 +16,7 @@
      - [[#rspec-mode][RSpec-mode]]
      - [[#ruby-test-mode][Ruby-test-mode]]
    - [[#rake][Rake]]
+   - [[#refactor][Refactor]]
 
 * Description
 This layer provides support for the Ruby language with the following feature:
@@ -173,3 +174,11 @@ When =ruby-test-runner= equals =ruby-test=.
 | ~SPC m k r~ | Re-runs the last rake task      |
 | ~SPC m k R~ | Regenerates the rake cache      |
 | ~SPC m k f~ | Finds definition of a rake task |
+** Refactor
+
+| Key binding   | Description            |
+|---------------+------------------------|
+| ~SPC m r R m~ | Extract to method      |
+| ~SPC m r R v~ | Extract local variable |
+| ~SPC m r R c~ | Extract constant       |
+| ~SPC m r R l~ | Extract to let (rspec) |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -23,6 +23,7 @@
         rspec-mode
         rubocop
         (ruby-mode :location built-in :toggle (not ruby-enable-enh-ruby-mode))
+        ruby-refactor
         ruby-test-mode
         ruby-tools
         rvm
@@ -176,6 +177,21 @@
     :config (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
               "'" 'ruby-toggle-string-quotes
               "{" 'ruby-toggle-block)))
+
+(defun ruby/init-ruby-refactor ()
+  (use-package ruby-refactor
+    :defer t
+    :init (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+            (add-hook hook 'ruby-refactor-mode-launch))
+    :config
+    (progn
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (spacemacs/declare-prefix-for-mode mode "mrR" "ruby/refactor")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "rRm" 'ruby-refactor-extract-to-method
+          "rRv" 'ruby-refactor-extract-local-variable
+          "rRc" 'ruby-refactor-extract-constant
+          "rRl" 'ruby-refactor-extract-to-let)))))
 
 (defun ruby/init-ruby-tools ()
   (use-package ruby-tools


### PR DESCRIPTION
Builds on @dcluna's work in https://github.com/syl20bnr/spacemacs/pull/6307 to add documentation to the ruby-refactor bindings.
