### PR TITLE
Mark tern command as async. Fixes #7591.

### DIFF
--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -15,7 +15,7 @@
 (defun spacemacs//set-tern-key-bindings (mode)
   "Set the key bindings for tern and the given MODE."
   (add-to-list (intern (format "spacemacs-jump-handlers-%S" mode))
-            'tern-find-definition)
+            '(tern-find-definition :async t))
   (spacemacs/set-leader-keys-for-major-mode mode
     "rrV" 'tern-rename-variable
     "hd" 'tern-get-docs


### PR DESCRIPTION
Mark `tern-find-definition` as async so it functions properly as a `jump-to-definition` handler.
