### PR TITLE
Buffer vim microstate

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -460,8 +460,10 @@
   :title "Buffer Selection Transient State"
   :bindings
   ("n" next-buffer "next")
+  ("j" next-buffer "next")
   ("N" previous-buffer "previous")
   ("p" previous-buffer "previous")
+  ("k" previous-buffer "previous")
   ("K" spacemacs/kill-this-buffer "kill")
   ("q" nil "quit" :exit t))
 (spacemacs/set-leader-keys "b." 'spacemacs/buffer-transient-state/body)


### PR DESCRIPTION
#4778
Adds j/k bindings to move around buffers on the buffer-transient-state. Old bindings remain.
This adds some consistency for vim users that prefer j/k instead of n/p or n/N.