### PR TITLE
Fix Layout Transient Menu's docstring

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -138,13 +138,14 @@
  [_C-0_,_C-9_]^^ nth/new layout               [_A_]^^   add all from layout
  [_<tab>_]^^^^   last layout                  [_d_]^^   close current layout
  [_b_]^^^^       buffer in layout             [_D_]^^   close other layout
- [_h_]^^^^       default layout               [_r_]^^   remove current buffer
- [_l_]^^^^       layout w/helm/ivy            [_R_]^^   rename current layout
- [_L_]^^^^       layouts in file              [_s_/_S_] save all layouts/save by names
- [_n_/_C-l_]^^   next layout                  [_t_]^^   show a buffer without adding it to current layout
- [_N_/_p_/_C-h_] prev layout                  [_x_]^^   kill current w/buffers
- [_o_]^^^^       custom layout                [_X_]^^   kill other w/buffers
- [_w_]^^^^       workspaces transient state   [_?_]^^   toggle help\n")
+ [_h_]^^^^       default layout               [_L_]^^   load layouts from file
+ [_l_]^^^^       layout w/helm/ivy            [_r_]^^   remove current buffer
+ [_n_/_C-l_]^^   next layout                  [_R_]^^   rename current layout
+ [_N_/_p_/_C-h_] prev layout                  [_s_/_S_] save all layouts/save by names
+ [_o_]^^^^       custom layout                [_t_]^^   show a buffer without adding it to current layout
+ [_w_]^^^^       workspaces transient state   [_x_]^^   kill current w/buffers
+ ^^^^^^                                       [_X_]^^   kill other w/buffers
+ ^^^^^^                                       [_?_]^^   toggle help\n")
 
       (spacemacs|define-transient-state layouts
         :title "Layouts Transient State"


### PR DESCRIPTION
Fixes #7597

Moved the `L` option to `Actions` and changed the doc string for it.

@theBB This works but the output is a bit wonky. Like below. I perhaps do not understand the formatting completely.

![Wonk](http://i.imgur.com/Ik3lLtu.png)
