### PR TITLE
version control: let the user pick on which side to display the diff

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -35,6 +35,13 @@ by setting =version-control-diff-tool=
                   version-control-diff-tool 'diff-hl)
 #+END_SRC
 
+You can choose the side on which the diff appears (by default it's the right side)
+
+#+BEGIN_SRC emacs-lisp
+'(version-control :variables
+                  version-control-side 'left)
+#+END_SRC
+
 To automatically enable diff margins in all buffers, set
 =version-control-global-margin=
 

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -40,7 +40,8 @@
           (global-diff-hl-mode))
         (diff-hl-margin-mode)
         (spacemacs|do-after-display-system-init
-         (setq diff-hl-side 'right)
+         (setq diff-hl-side (if (eq version-control-side 'left)
+                                'left 'right))
          (diff-hl-margin-mode -1))))))
 
 (defun version-control/post-init-evil-unimpaired ()
@@ -80,7 +81,8 @@
       (spacemacs|do-after-display-system-init
        (with-eval-after-load 'git-gutter
          (require 'git-gutter-fringe)))
-      (setq git-gutter-fr:side 'right-fringe))
+      (setq git-gutter-fr:side (if (eq version-control-side 'left)
+                                   'left-fringe 'right-fringe)))
     :config
     (progn
       ;; custom graphics that works nice with half-width fringes
@@ -141,7 +143,8 @@
       (spacemacs|do-after-display-system-init
        (with-eval-after-load 'git-gutter+
          (require 'git-gutter-fringe+)))
-      (setq git-gutter-fr+-side 'right-fringe))
+      (setq git-gutter-fr+-side (if (eq version-control-side 'left)
+                                    'left-fringe 'right-fringe)))
     :config
     (progn
       ;; custom graphics that works nice with half-width fringes


### PR DESCRIPTION
I prefer displaying the version control diff info on the left. I always overrode the spacemacs right default in my config file but it's breaking almost everytime I upgrade.

I think a PR to make also the side for the flycheck info to be configurable will follow now (I prefer that one on the right). (EDIT: for that second one, it's probably not needed. for that one you need only ` (custom-set-variables '(flycheck-indication-mode (quote right-fringe))`, and I think spacemacs doesn't overwrite it at startup, unlike the source-control setting)