### PR TITLE
Restore smart closing paren behavior in racket-mode

### DIFF
--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -111,9 +111,4 @@
         ;; Tests
         "tb" 'racket-test
         "tB" 'spacemacs/racket-test-with-coverage)
-      (define-key racket-mode-map (kbd "H-r") 'racket-run)
-      ;; remove racket auto-insert of closing delimiter
-      ;; see https://github.com/greghendershott/racket-mode/issues/140
-      (define-key racket-mode-map ")" 'self-insert-command)
-      (define-key racket-mode-map "]" 'self-insert-command)
-      (define-key racket-mode-map "}" 'self-insert-command))))
+      (define-key racket-mode-map (kbd "H-r") 'racket-run))))


### PR DESCRIPTION
Remove the shadowing keybindings for `)`, `]`, and `}` so the default
`racket-insert-closing` command is used again.