### PR TITLE
Make org-edit-src keybindings more similar to keybindings in similar situations (for example in magit git-comit)

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -136,6 +136,7 @@
         (spacemacs/set-leader-keys-for-minor-mode 'org-src-mode
           "'" 'org-edit-src-exit
           "c" 'org-edit-src-exit
+          "," 'org-edit-src-exit
           "a" 'org-edit-src-abort
           "k" 'org-edit-src-abort))
 


### PR DESCRIPTION
This adds a keybinding for pressing `, ,` to exit the src edit buffer in org-mode.
This makes them more line with: https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org#confirm-and-abort , even though they don't apply