### PR TITLE
Display 'done' after a theme is loaded

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -209,8 +209,11 @@ package name does not match theme name + `-theme' suffix.")
           (or (cdr (memq spacemacs--cur-theme dotspacemacs-themes))
               dotspacemacs-themes)))
   (setq spacemacs--cur-theme (pop spacemacs--cycle-themes))
-  (message "Loading theme %s..." spacemacs--cur-theme)
-  (spacemacs/load-theme spacemacs--cur-theme))
+  (let ((progress-reporter
+         (make-progress-reporter
+          (format "Loading theme %s..." spacemacs--cur-theme))))
+    (spacemacs/load-theme spacemacs--cur-theme)
+    (progress-reporter-done progress-reporter)))
 
 (defadvice load-theme (after spacemacs/load-theme-adv activate)
   "Perform post load processing."


### PR DESCRIPTION
Theme (down)loading may take a minute so it is good to see some confirmation when it's over.