### PR TITLE
Add clang-format-buffer to c-c++ layer

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -69,20 +69,8 @@ to =t= in the dotfile:
 (=clang-format-region=) or a whole buffer (=clang-format-buffer=) to make it
 conform to a style defined in a =.clang-format= file. This file is either
 located in the same directory as the file being edited, or in any of its parent
-directories (otherwise a default style will be used).
-
-You can add snippets similar to the following to bind clang-format to either a
-particular mode or all modes in your =dotspacemacs/user-config= (within your
-=~/.spacemacs=):
-
-#+BEGIN_SRC emacs-lisp
-  ;; Bind clang-format-region to C-M-tab in all modes:
-  (global-set-key [C-M-tab] 'clang-format-region)
-  ;; Bind clang-format-buffer to tab on the c++-mode only:
-  (add-hook 'c++-mode-hook 'clang-format-bindings)
-    (defun clang-format-bindings ()
-      (define-key c++-mode-map [tab] 'clang-format-buffer))
-#+END_SRC
+directories (otherwise a default style will be used). ~SPC m =~ formats buffer
+or a selected region using =clang-format=.
 
 *** Company-clang and flycheck
 This layer adds some fancy improvements to =company-clang=.
@@ -102,5 +90,6 @@ doesn't complain about missing header files.
 | ~SPC m g A~ | open matching file in another window (e.g. switch between .cpp and .h) |
 | ~SPC m D~   | disaster: disassemble c/c++ code                                       |
 | ~SPC m r~   | srefactor: refactor thing at point.                                    |
+| ~SPC m =~   | format buffer or a selected region                                     |
 
 *Note:*  [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]]  is only available for Emacs 24.4+

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -50,3 +50,16 @@ and the arguments for flyckeck-clang based on a project-specific text file."
       (setq-local company-clang-arguments flags)
       (setq-local company-c-headers-path-system (append '("/usr/include" "/usr/local/include") dirs))
       (setq-local flycheck-clang-args flags))))
+
+(defun c-c++/format-region-or-buffer ()
+  "Indent a region if selected, otherwise the whole buffer."
+  (interactive)
+  (save-excursion
+    (if (region-active-p)
+        (progn
+          (clang-format-region (region-beginning) (region-end))
+          (message "Formatted selected region."))
+      (progn
+        (clang-format-buffer)
+        (message "Formatted buffer.")))
+    (whitespace-cleanup)))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -61,7 +61,13 @@
 
 (defun c-c++/init-clang-format ()
   (use-package clang-format
-    :if c-c++-enable-clang-support))
+    :if c-c++-enable-clang-support
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'c-mode
+        "=" 'c-c++/format-region-or-buffer)
+      (spacemacs/set-leader-keys-for-major-mode 'c++-mode
+        "=" 'c-c++/format-region-or-buffer))))
 
 (defun c-c++/init-cmake-mode ()
   (use-package cmake-mode


### PR DESCRIPTION
Bind `SPC m = in` c-c++ layer to clang-format-buffer (see syl20bnr#7628).

This aligns with the same key binding in other layers, such as `yapfify-buffer` in Python layer or `web-beautify-js` in Javascript layer.