### PR TITLE
Update ensime variable name

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -38,7 +38,7 @@
       (add-to-list 'spacemacs-jump-handlers-scala-mode 'ensime-edit-definition))
     :config
     (progn
-      (setq user-emacs-ensime-directory ".cache/ensime")
+      (setq ensime-startup-dirname (expand-file-name "ensime" spacemacs-cache-directory))
 
       (evil-define-key 'insert ensime-mode-map
         (kbd ".") 'scala/completing-dot


### PR DESCRIPTION
This is a follow up to PR #7637. Instead of working around the problem, I just fixed it :)

`user-emacs-ensime-directory` was renamed to `ensime-startup-dirname` on Jun 25th. Without the change, ENSIME would create it's cache into spacemacs/ensime, which is not what we want.

The disadvantage is that people will get the "looks like you run ENSIME for the first time" message again, but it can't be helped.