### PR TITLE
Reinstate avy jump commands

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -224,6 +224,9 @@
   "j0" 'spacemacs/push-mark-and-goto-beginning-of-line
   "j$" 'spacemacs/push-mark-and-goto-end-of-line
   "jf" 'find-function
+  "jj" 'avy-goto-char
+  "jl" 'avy-goto-line
+  "jw" 'avy-goto-word-1
   "jv" 'find-variable)
 
 ;; Compilation ----------------------------------------------------------------


### PR DESCRIPTION
Avy jump command are in the news01.org and the documentation
but the actual keybindings are not defined. This change defines them.