### PR TITLE
Add ibuffer bindings for updating and filter-group motion

### DIFF
--- a/layers/+emacs/ibuffer/README.org
+++ b/layers/+emacs/ibuffer/README.org
@@ -6,10 +6,12 @@
    - [[#layer][Layer]]
    - [[#grouping-buffers][Grouping buffers]]
  - [[#key-bindings][Key bindings]]
+   - [[#global][Global]]
+   - [[#ibuffer][IBuffer]]
 
 * Description
 
-This layer configures Emacs ibuffer for Spacemacs.
+This layer configures Emacs IBuffer for Spacemacs.
 
 * Install
 ** Layer
@@ -36,9 +38,18 @@ Example:
 #+END_SRC
 
 * Key bindings
+** Global
 
-| Key Binding | Description       |
-|-------------+-------------------|
-| ~SPC b B~   | open ibuffer menu |
+| Key Binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC b B~   | open IBuffer menu (global)    |
 
-*Note:* The layer will also replace regular ~C-x C-b~ by ibuffer.
+*Note:* The layer will also replace regular ~C-x C-b~ with =ibuffer=.
+
+** IBuffer
+
+| Key Binding | Description                   |
+|-------------+-------------------------------|
+| ~g r~       | update IBuffer ("refresh")    |
+| ~g j~       | move to next filter group     |
+| ~g k~       | move to previous filter group |

--- a/layers/+emacs/ibuffer/packages.el
+++ b/layers/+emacs/ibuffer/packages.el
@@ -32,7 +32,11 @@
       (evil-ex-define-cmd "buffers" 'ibuffer))
     :config
     (evilified-state-evilify-map ibuffer-mode-map
-      :mode ibuffer-mode)))
+      :mode ibuffer-mode
+      :bindings
+      "gr" 'ibuffer-update
+      "gj" 'ibuffer-forward-filter-group
+      "gk" 'ibuffer-backward-filter-group)))
 
 (defun ibuffer/init-ibuffer-projectile()
     (use-package ibuffer-projectile


### PR DESCRIPTION
The `ibuffer-update` command is originally on `g` but is evilified to
the inconvenient `C-S-g`, so bind it to `r` (for "refresh").