### PR TITLE
rebind 'SPC f b' to 'counsel-bookmark' when using ivy

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -12,6 +12,7 @@
 (setq ivy-packages
       '(
         auto-highlight-symbol
+        bookmark
         counsel
         (counsel-projectile :toggle (configuration-layer/package-usedp 'projectile))
         evil
@@ -202,6 +203,9 @@
   (setq projectile-completion-system 'ivy)
   (spacemacs/set-leader-keys
     "pv"  'projectile-vc))
+
+(defun ivy/post-init-bookmark ()
+  (spacemacs/set-leader-keys "fb" 'counsel-bookmark))
 
 (defun ivy/init-smex ()
   (use-package smex


### PR DESCRIPTION
Currently ```SPC f b``` is bound to ```bookmark-jump```, however a more appropriate choice would be ```counsel-bookmark```.

Currently both functions behave identically, but if abo-abo/swiper#758 is accepted then ```counsel-bookmark``` will be much closer to feature parity with the helm implementation (originally requested here: #7646).