### PR TITLE
Python: Highlight wdb breakpoints as well as pdb/ipdb/pudb

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -13,8 +13,8 @@
 (defun spacemacs/python-annotate-pdb ()
   "Highlight break point lines."
   (interactive)
-  (highlight-lines-matching-regexp "import i?pu?db")
-  (highlight-lines-matching-regexp "i?pu?db.set_trace()"))
+  (highlight-lines-matching-regexp "import \\(pdb\\|ipdb\\|pudb\\|wdb\\)")
+  (highlight-lines-matching-regexp "\\(pdb\\|ipdb\\|pudb\\|wdb\\).set_trace()"))
 
 (defun spacemacs/pyenv-executable-find (command)
   "Find executable taking pyenv shims into account."


### PR DESCRIPTION
`wdb` is another Python debugger, its breakpoints should be highlighted as well as `pdb`, etc.

Listed debugger names in full instead of a clever `i?pu?db` because this helps greppability (i.e. you won't miss this occurrence when searching the repository for `pdb`).