### PR TITLE
Python: search for Pylint and Flake8 in the virtualenvs

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -35,6 +35,15 @@
       (setq python-shell-interpreter-args "-i")
       (setq python-shell-interpreter "python"))))
 
+(defun spacemacs/python-setup-checkers (&rest args)
+  (let ((pylint (spacemacs/pyenv-executable-find "pylint"))
+        (flake8 (spacemacs/pyenv-executable-find "flake8")))
+    (when pylint
+      (flycheck-set-checker-executable "python-pylint" pylint))
+    (when flake8
+      (flycheck-set-checker-executable "python-flake8" flake8))
+    ))
+
 (defun spacemacs/python-toggle-breakpoint ()
   "Add a break point, highlight it."
   (interactive)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -214,7 +214,8 @@
           "Vw" 'pyvenv-workon))
       ;; setup shell correctly on environment switch
       (dolist (func '(pyvenv-activate pyvenv-deactivate pyvenv-workon))
-        (advice-add func :after 'spacemacs/python-setup-shell)))))
+        (advice-add func :after 'spacemacs/python-setup-shell)
+        (advice-add func :after 'spacemacs/python-setup-checkers)))))
 
 (defun python/init-pylookup ()
   (use-package pylookup


### PR DESCRIPTION
When a Python virtual environment is activated, search for the Flycheck checkers - Pylint and Flake8 - in that virtual environment.