### PR TITLE
finer configuration of line numbers activation

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -301,8 +301,20 @@ recenters point when it reaches the top or bottom of the
 screen.")
 
 (defvar dotspacemacs-line-numbers nil
-  "If non nil line numbers are turned on in all `prog-mode' and `text-mode'
-derivatives. If set to `relative', also turns on relative line numbers.")
+  "Control line numbers activation.
+If set to `t' or `relative' line numbers are turned on in all `prog-mode' and
+`text-mode' derivatives. If set to `relative', line numbers are relative.
+This variable can also be set to a property list for finer control:
+'(:relative nil
+  :disabled-for-modes dired-mode
+                      doc-view-mode
+                      markdown-mode
+                      org-mode
+                      pdf-view-mode
+                      text-mode
+  :size-limit-kb 1000)
+The property `:enabled-for-modes' takes priority over `:disabled-for-modes' and
+restricts line-number to the specified list of major-mode.")
 
 (defvar dotspacemacs-persistent-server nil
   "If non nil advises quit functions to keep server open when quitting.")

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -252,8 +252,19 @@ values."
    ;; scrolling overrides the default behavior of Emacs which recenters point
    ;; when it reaches the top or bottom of the screen. (default t)
    dotspacemacs-smooth-scrolling t
-   ;; If non-nil line numbers are turned on in all `prog-mode' and `text-mode'
-   ;; derivatives. If set to `relative', also turns on relative line numbers.
+   ;; Control line numbers activation.
+   ;; If set to `t' or `relative' line numbers are turned on in all `prog-mode' and
+   ;; `text-mode' derivatives. If set to `relative', line numbers are relative.
+   ;; This variable can also be set to a property list for finer control:
+   ;; '(:relative nil
+   ;;   :disabled-for-modes dired-mode
+   ;;                       doc-view-mode
+   ;;                       markdown-mode
+   ;;                       org-mode
+   ;;                       pdf-view-mode
+   ;;                       text-mode
+   ;;   :size-limit-kb 1000)
+   ;; See Spacemacs ducumentation (SPC h SPC) for a list of available properties.
    ;; (default nil)
    dotspacemacs-line-numbers nil
    ;; Code folding method. Possible values are `evil' and `origami'.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1122,6 +1122,43 @@ If it is set to =relative=, line numbers are show in a relative way:
 (setq-default dotspacemacs-line-numbers 'relative)
 #+END_SRC
 
+=dotspacemacs-line-numbers= can also be set to a property list for finer control
+over line numbers activation.
+
+Available properties:
+
+| Property              | Description                                                                                  |
+|-----------------------+----------------------------------------------------------------------------------------------|
+| =:disabled-for-modes= | list of major modes where line numbering is inhibited                                        |
+| =:enabled-for-modes=  | disable for all major modes except those listed. Takes precedence over =:disabled-for-modes= |
+| =:relative=           | if non-nil, line numbers are relative to the position of the cursor                          |
+| =:size-limit-kb=      | size limit in kilobytes after which line numbers are not activated                           |
+
+Example:
+
+Disable line numbers in dired-mode, doc-view-mode, markdown-mode, org-mode,
+pdf-view-mode, text-mode as well as buffers over 1Mb:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-lines-numbers '(:relative nil
+                                           :disabled-for-modes dired-mode
+                                                               doc-view-mode
+                                                               markdown-mode
+                                                               org-mode
+                                                               pdf-view-mode
+                                                               text-mode
+                                           :size-limit-kb 1000))
+#+END_SRC
+
+Relative line numbers only in c-mode and c++ mode with a size limit of =dotspacemacs-large-file-size=:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-lines-numbers '(:relative t
+                                           :enabled-for-modes c-mode
+                                                              c++-mode
+                                           :size-limit-kb (* dotspacemacs-large-file-size 1000))
+#+END_SRC
+
 ** Mode-line
 The mode line is a heavily customized [[https://github.com/milkypostman/powerline][powerline]] with the following capabilities:
   - show the window number

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1014,3 +1014,25 @@ a split-side entry, its value must be usable as the SIDE argument for
                                             text-scale-mode-amount) 1)
                                   (if (car (window-margins))
                                       (car (window-margins)) 1)))))
+
+(defun spacemacs/enable-line-numbers-p ()
+  "Return non-nil if line numbers should be enabled for current buffer.
+Decision is based on `dotspacemacs-line-numbers'."
+  (and dotspacemacs-line-numbers
+       (not (string-match-p "\\*.*\\*" (buffer-name)))
+       (not (and (spacemacs/mplist-get dotspacemacs-line-numbers
+                                       :size-limit-kb)
+                 (> (buffer-size)
+                    (* 1000 (car (spacemacs/mplist-get dotspacemacs-line-numbers
+                                                       :size-limit-kb))))))
+       (or (and (spacemacs/mplist-get dotspacemacs-line-numbers
+                                      :enabled-for-modes)
+                (memq major-mode (spacemacs/mplist-get dotspacemacs-line-numbers
+                                                       :enabled-for-modes)))
+           (and (not (spacemacs/mplist-get dotspacemacs-line-numbers
+                                           :enabled-for-modes))
+                (spacemacs/mplist-get dotspacemacs-line-numbers
+                                      :disabled-for-modes)
+                (not (memq major-mode
+                           (spacemacs/mplist-get dotspacemacs-line-numbers
+                                                 :disabled-for-modes)))))))

--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -240,9 +240,20 @@
     :init (spacemacs/set-leader-keys "ji" 'imenu)))
 
 (defun spacemacs-base/init-linum ()
-  (when dotspacemacs-line-numbers
-    (add-hook 'prog-mode-hook 'linum-mode)
-    (add-hook 'text-mode-hook 'linum-mode))
+  (use-package linum
+    :config
+    (progn
+      (if (or (eq dotspacemacs-line-numbers t)
+              (eq dotspacemacs-line-numbers 'relative))
+          (progn
+            (add-hook 'prog-mode-hook 'linum-mode)
+            (add-hook 'text-mode-hook 'linum-mode)))
+      (defun linum-on ()
+        "Overwrite the original `linum-on' function with a more selective one."
+        (when (spacemacs/enable-line-numbers-p)
+          (linum-mode)))
+      (when dotspacemacs-line-numbers
+        (global-linum-mode))))
   (setq linum-format "%4d")
   (spacemacs|add-toggle line-numbers
     :mode linum-mode

--- a/layers/+misc/nlinum/funcs.el
+++ b/layers/+misc/nlinum/funcs.el
@@ -1,0 +1,14 @@
+;;; packages.el --- nlinum Layer packages File
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Thomas de Beauchêne <thomas.de.beauchene@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/nlinum-maybe-on ()
+  (when (spacemacs/enable-line-numbers-p)
+    (nlinum-mode)))

--- a/layers/+misc/nlinum/funcs.el
+++ b/layers/+misc/nlinum/funcs.el
@@ -12,3 +12,9 @@
 (defun spacemacs/nlinum-maybe-on ()
   (when (spacemacs/enable-line-numbers-p)
     (nlinum-mode)))
+
+(defun spacemacs/nlinum-relative-toggle ()
+  (interactive)
+  (if (not (bound-and-true-p nlinum-relative-mode))
+      (nlinum-mode))
+  (nlinum-relative-toggle))

--- a/layers/+misc/nlinum/packages.el
+++ b/layers/+misc/nlinum/packages.el
@@ -46,4 +46,4 @@
                 (eq dotspacemacs-line-numbers 'relative))
         (nlinum-relative-setup-evil)
         (add-hook 'nlinum-mode-hook 'nlinum-relative-on))
-      (spacemacs/set-leader-keys "tr" 'nlinum-relative-toggle))))
+      (spacemacs/set-leader-keys "tr" 'spacemacs/nlinum-relative-toggle))))

--- a/layers/+misc/nlinum/packages.el
+++ b/layers/+misc/nlinum/packages.el
@@ -20,15 +20,19 @@
 (defun nlinum/init-nlinum ()
   (use-package nlinum
     :init
+    (spacemacs|add-toggle line-numbers
+      :mode nlinum-mode
+      :documentation "Show the line numbers."
+      :evil-leader "tn")
+    :config
     (progn
-      (when dotspacemacs-line-numbers
-        (add-hook 'prog-mode-hook 'nlinum-mode)
-        (add-hook 'text-mode-hook 'nlinum-mode))
-      (setq nlinum-format "%4d")
-      (spacemacs|add-toggle line-numbers
-        :mode nlinum-mode
-        :documentation "Show the line numbers."
-        :evil-leader "tn"))))
+      (if (or (eq dotspacemacs-line-numbers t)
+              (eq dotspacemacs-line-numbers 'relative))
+          (progn
+            (add-hook 'prog-mode-hook 'nlinum-mode)
+            (add-hook 'text-mode-hook 'nlinum-mode))
+        (add-hook 'after-change-major-mode-hook 'spacemacs/nlinum-maybe-on))
+      (setq nlinum-format "%4d"))))
 
 (defun nlinum/init-nlinum-relative ()
   (use-package nlinum-relative
@@ -37,7 +41,9 @@
     (progn
       (setq nlinum-relative-current-symbol ""
             nlinum-relative-redisplay-delay 0)
-      (when (eq dotspacemacs-line-numbers 'relative)
+      (when (or (car (spacemacs/mplist-get dotspacemacs-line-numbers
+                                           :relative))
+                (eq dotspacemacs-line-numbers 'relative))
         (nlinum-relative-setup-evil)
         (add-hook 'nlinum-mode-hook 'nlinum-relative-on))
       (spacemacs/set-leader-keys "tr" 'nlinum-relative-toggle))))

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -259,12 +259,13 @@
     :commands (linum-relative-toggle linum-relative-on)
     :init
     (progn
-      (when (eq dotspacemacs-line-numbers 'relative)
-        (linum-relative-on))
+      (when (or (eq dotspacemacs-line-numbers 'relative)
+                (car (spacemacs/mplist-get dotspacemacs-line-numbers
+                                           :relative)))
+        (add-hook 'spacemacs-post-user-config-hook 'linum-relative-on))
       (spacemacs/set-leader-keys "tr" 'spacemacs/linum-relative-toggle))
     :config
-    (progn
-      (setq linum-relative-current-symbol ""))))
+    (setq linum-relative-current-symbol "")))
 
 (defun spacemacs-evil/init-vi-tilde-fringe ()
   (spacemacs|do-after-display-system-init


### PR DESCRIPTION
Allow for controlling more precisely when line numbers are activated.

This change is 100% backward compatible: the old `nil`, `t` and `'relative` values work just like usual.

As an alternative to these values, the user can now choose to set `dotspacemacs-line-numbers` to a property list like:

``` elisp
(setq-default dotspacemacs-lines-numbers '(:relative nil
                                           :disabled-for dired-mode
                                                         doc-view-mode
                                                         markdown-mode
                                                         org-mode
                                                         pdf-view-mode
                                                         text-mode
                                           :size-limit-kb 1000))
```
This allows for precisely filtering based on major and file size.

Possible improvements would be:

- choose between `linum` and `nlinum` from there (remove `nlinum` layer, merge it into `spacemacs-base`)
- disable/enable in all derived modes
- add a default list of major modes where you never want line numbers **(?)**

**PS:** also made nlinum consistent with linum by reflecting ddbee36: now activating nlinum-relative also activates nlinum.