### PR TITLE
Removed deprecated insert-string and replace by insert

### DIFF
--- a/core/tools/spacefmt/spacefmt.el
+++ b/core/tools/spacefmt/spacefmt.el
@@ -72,7 +72,7 @@
     (while (re-search-backward org-heading-regexp nil t))
     (open-line 3)
     (forward-line 1)
-    (insert-string toc-headline)))
+    (insert toc-headline)))
 
 (defun remove-empty-lines-after-headlines()
   "Remove empty liners after each headline."

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -49,8 +49,8 @@
         (kill-whole-line)
       (progn
         (back-to-indentation)
-        (insert-string trace)
-        (insert-string "\n")
+        (insert trace)
+        (insert "\n")
         (python-indent-line)))))
 
 ;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen


### PR DESCRIPTION
The `insert-string` functions is deprecated and to be replaced by `insert`.