### PR TITLE
keyboard-layout: fix twittering-mode defun name

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -466,7 +466,7 @@
       "k"
       "l")))
 
-(defun kl/pre-init-twittering-mode ()
+(defun keyboard-layout/pre-init-twittering-mode ()
   (kl|config twittering-mode
     :description
     "Remap navigation keys in `twittering-mode'."


### PR DESCRIPTION
Twittering-mode defun in the keyboard-layout layer appears to have the old layer name of "kl". Changed to match layer name.
