### PR TITLE
non-restricted-buffer-list-* to SPC b B instead of SPC B b and change which-key names

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -302,7 +302,9 @@
            ("spacemacs/toggle-holy-mode" . "emacs (holy-mode)")
            ("evil-lisp-state-\\(.+\\)" . "\\1")
            ("spacemacs/\\(.+\\)-transient-state/\\(.+\\)" . "\\2")
-           ("spacemacs/\\(.+\\)-transient-state/body" . "\\1-transient-state"))))
+           ("spacemacs/\\(.+\\)-transient-state/body" . "\\1-transient-state")
+           ("helm-mini\\|ivy-switch-buffer" . "list-buffers")
+           ("spacemacs-layouts/non-restricted-buffer-list-\\(helm\\|ivy\\)" . "global-list-buffers"))))
     (dolist (nd new-descriptions)
       ;; ensure the target matches the whole string
       (push (cons (cons nil (concat "\\`" (car nd) "\\'")) (cons nil (cdr nd)))

--- a/layers/+emacs/ibuffer/packages.el
+++ b/layers/+emacs/ibuffer/packages.el
@@ -20,7 +20,7 @@
     :defer t
     :init
     (progn
-      (spacemacs/set-leader-keys "bB" 'ibuffer)
+      (spacemacs/set-leader-keys "bI" 'ibuffer)
       (global-set-key (kbd "C-x C-b") 'ibuffer)
       (defun spacemacs//ibuffer-group-by-modes ()
         "Group buffers by modes."

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -95,14 +95,14 @@
 
 (defun spacemacs-layouts/post-init-helm ()
   (spacemacs/set-leader-keys
-    "Bb" 'spacemacs-layouts/non-restricted-buffer-list-helm
+    "bB" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))
 
 
 
 (defun spacemacs-layouts/post-init-ivy ()
   (spacemacs/set-leader-keys
-    "Bb" 'spacemacs-layouts/non-restricted-buffer-list-ivy))
+    "bB" 'spacemacs-layouts/non-restricted-buffer-list-ivy))
 
  
 
@@ -207,7 +207,6 @@
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
       (spacemacs/declare-prefix "b" "persp-buffers")
-      (spacemacs/declare-prefix "B" "global-buffers")
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
         "TAB"  'spacemacs/alternate-buffer-in-persp


### PR DESCRIPTION
`SPC b B` is more intuitive for listing all buffers and was only previously used in `ibuffer` layer, only when activated (which I suspect is not the case for most user).

Picked `SPC b I` instead, as it is mnemonic for `ibuffer`.

I don't know what was the thought behind this, but `spacemacs-layouts/non-restricted-buffers-list-*` was alone in its `SPC B` prefix.

I also renamed buffers listing functions in `which-key`. 
This way it is clearer for the user: names like `helm-mini` are pretty obscure and kind of defeat the purpose of `which-key`. `spacemacs-layouts-non-restricted-buffer-list-blah` had also such a long name that it couldn't even be displayed.

The user can now choose between `list-buffers` or `global-list-buffers` for listing buffers.

