### PR TITLE
Remove git layer documentation to show submodule prompt

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -105,7 +105,6 @@ Git commands (start with ~g~):
 
 | Key Binding | Description                                         |
 |-------------+-----------------------------------------------------|
-| ~SPC g >~   | show submodule prompt                               |
 | ~SPC g b~   | open a =magit= blame                                |
 | ~SPC g f h~ | show file commits history                           |
 | ~SPC g H c~ | clear highlights                                    |


### PR DESCRIPTION
There is no such keybinding `SPC g >` in the source code.