### PR TITLE
Add bashate style checker to shell-script layer

### DIFF
--- a/layers/+lang/shell-scripts/README.org
+++ b/layers/+lang/shell-scripts/README.org
@@ -7,6 +7,7 @@
    - [[#features][Features]]
  - [[#install][Install]]
    - [[#linting][Linting]]
+   - [[#style-checking][Style checking]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
@@ -22,6 +23,7 @@ Supported scripting files:
 ** Features
 - Auto-completion using [[https://github.com/Alexander-Miller/company-shell][company-shell]]
 - =Sh= scripts linting using  [[https://www.shellcheck.net/][shellcheck]]
+- =Sh= scripts style checking using [[https://github.com/openstack-dev/bashate][bashate]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -30,6 +32,9 @@ file.
 
 ** Linting
 In order to enable =sh= scripts linting, install [[https://www.shellcheck.net/][shellcheck]].
+
+** Style checking
+In order to enable =sh= scripts style checking, install [[https://github.com/openstack-dev/bashate][bashate]].
 
 * Key Bindings
 

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -15,6 +15,7 @@
         (company-shell :toggle (configuration-layer/package-usedp 'company))
         fish-mode
         flycheck
+        flycheck-bashate
         ggtags
         helm-gtags
         insert-shebang
@@ -35,6 +36,11 @@
 
 (defun shell-scripts/post-init-flycheck ()
   (spacemacs/add-flycheck-hook 'sh-mode))
+
+(defun shell-scripts/init-flycheck-bashate ()
+  (use-package flycheck-bashate
+  :defer t
+  :init (add-hook 'sh-mode-hook 'flycheck-bashate-setup)))
 
 (defun shell-scripts/init-fish-mode ()
   (use-package fish-mode


### PR DESCRIPTION
Hi,

This adds [bashate](https://github.com/openstack-dev/bashate) style checker as a flycheck checker for the shell-script layer.