### PR TITLE
bindings: move highlight-parentheses-mode from `SPC t C p` to `SPC t h p`

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -330,7 +330,7 @@
       (when (member dotspacemacs-highlight-delimiters '(all current))
         (add-hook 'prog-mode-hook #'highlight-parentheses-mode))
       (setq hl-paren-delay 0.2)
-      (spacemacs/set-leader-keys "tCp" 'highlight-parentheses-mode)
+      (spacemacs/set-leader-keys "thp" 'highlight-parentheses-mode)
       (setq hl-paren-colors '("Springgreen3"
                               "IndianRed1"
                               "IndianRed3"


### PR DESCRIPTION
It seems to be more logical / mnemonic / instinctive to have highlight parentheses toggle with other highlighting toggles rather than color toggles.

This is the very first place where I searched for it.
