### PR TITLE
compilation-mode: maps `gf` to `find-file-at-point`

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -234,6 +234,7 @@
   "cr" 'recompile
   "cd" 'spacemacs/close-compilation-window)
 (with-eval-after-load 'compile
+  (evil-define-key 'motion compilation-mode-map (kbd "gf") 'find-file-at-point)
   (define-key compilation-mode-map "r" 'recompile)
   (define-key compilation-mode-map "g" nil))
 ;; narrow & widen -------------------------------------------------------------


### PR DESCRIPTION
Hi,

This PR maybe solves https://github.com/syl20bnr/spacemacs/issues/7702

I found two ways of adding the keybinding, but not sure if this is the right thing and the right place.

```
;; option 1
  (define-key evil-motion-state-map "gf" 'find-file-at-point)
;; option 2
  (evil-define-key 'motion compilation-mode-map (kbd "gf") 'find-file-at-point)
```

Guidance would be highly appreciated.

All best