### PR TITLE
Fixed dead hyperlink in magit intro

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -37,7 +37,7 @@ This layers adds extensive support for [[http://git-scm.com/][git]].
 - gitignore generator with [[https://github.com/jupl/helm-gitignore][helm-gitignore]]
 - org integration with magit via [[https://github.com/magit/orgit][orgit]]
 
-New to Magit? Checkout the [[http://magit.vc/about.html][official intro]].
+New to Magit? Checkout the [[https://magit.vc/about/][official intro]].
 
 * Install
 ** Layer


### PR DESCRIPTION
The old one appeared to throw a 404 error.
