### PR TITLE
Change page break line on *spacemacs* buffer

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -538,7 +538,7 @@ ARGS: format string arguments."
 
 (defun spacemacs-buffer/insert-page-break ()
   "Insert a page break line in spacemacs buffer."
-  (spacemacs-buffer/append "\n\n"))
+  (spacemacs-buffer/append (concat "\n" (make-string (window-body-width) ?\u2500) "\n")))
 
 (defun spacemacs-buffer/append (msg &optional messagebuf)
   "Append MSG to spacemacs buffer.


### PR DESCRIPTION
Fix the issue #6924 .
Instead of inserting one ^L page break symbol it creates a page break line with
using \u2500 (box drawings light horizontal) symbol. It improves rendering
when an user navigates through a page break line.