### PR TITLE
Fix typo in Agda's packages.el

### DIFF
--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -83,7 +83,7 @@
           "xq"  'agda2-quit
           "xr"  'agda2-restart)))))
 
-(defun idris/pre-init-golden-ratio ()
+(defun agda/pre-init-golden-ratio ()
   (spacemacs|use-package-add-hook golden-ratio
     :post-config
     (add-to-list 'golden-ratio-exclude-buffer-names


### PR DESCRIPTION
`pre-init-golden-ratio` function was copy-pasted from Idris layer without necessary change applied. It causes a warning during startup.