### PR TITLE
Make Semantic fast

### DIFF
--- a/layers/+emacs/semantic/README.org
+++ b/layers/+emacs/semantic/README.org
@@ -38,6 +38,10 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =semantic= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+By default, Spacemacs sets Semantic to parse only file, local and project scope.
+For a different parsing scope, you can customize the variable
+=semanticdb-find-default-throttle=.
+
 * Key Bindings
 
 | Key Binding | Description                         |

--- a/layers/+emacs/semantic/config.el
+++ b/layers/+emacs/semantic/config.el
@@ -13,5 +13,6 @@
                                     "srecode-map.el"))
 (setq semanticdb-default-save-directory (concat spacemacs-cache-directory
                                                 "semanticdb/"))
+(setq semanticdb-find-default-throttle '(file local project))
 (unless (file-exists-p semanticdb-default-save-directory)
   (make-directory semanticdb-default-save-directory))


### PR DESCRIPTION
Limit the parsing scope to file, local and project. The choices are listed in semanticdb-find-default-throttle variable.