### PR TITLE
Remove backtick from smartparens pairs for Clojure

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -269,7 +269,8 @@
   (add-hook 'cider-repl-mode-hook
             (if dotspacemacs-smartparens-strict-mode
                 #'smartparens-strict-mode
-              #'smartparens-mode)))
+              #'smartparens-mode))
+  (sp-local-pair 'clojure-mode "`" nil :actions nil))
 
 (defun clojure/post-init-subword ()
   (add-hook 'cider-mode-hook 'subword-mode))


### PR DESCRIPTION
Single backticks are used for namespaced quotes, there is no purpose for
automatically inserting double backticks.