### PR TITLE
Add key binding to run current Rust file

### DIFF
--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -16,3 +16,18 @@ If `help-window-select' is non-nil, also select the help window."
   (let ((window (racer-describe)))
     (when help-window-select
       (select-window window))))
+
+(defun spacemacs/rust-quick-run ()
+  "Quickly run a Rust file using rustc.
+Meant for a quick-prototype flow only - use `spacemacs/open-junk-file' to
+open a junk Rust file, type in some code and quickly run it.
+If you want to use third-party crates, create a a new project using `cargo-process-new' and run
+using `cargo-process-run'."
+  (interactive)
+  (let ((input-file-name (buffer-file-name))
+        (output-file-name (concat temporary-file-directory (make-temp-name "rustbin"))))
+    (compile
+     (format "rustc -o %s %s && %s"
+             (shell-quote-argument output-file-name)
+             (shell-quote-argument input-file-name)
+             (shell-quote-argument output-file-name)))))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -65,7 +65,8 @@
     :init
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "=" 'rust-format-buffer))))
+        "=" 'rust-format-buffer
+        "q" 'spacemacs/rust-quick-run))))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode


### PR DESCRIPTION
Meant for a quick-prototype flow only - use `spacemacs/open-junk-file' to
open a junk Rust file, type in some code and quickly run it.