### PR TITLE
Don't suggest `SPC q r` if restart-emacs is missing

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1668,8 +1668,10 @@ If called with a prefix argument ALWAYS-UPDATE, assume yes to update."
         (spacemacs-buffer/append
          (format "\n--> %s package(s) to be updated.\n" upgraded-count))
         (spacemacs-buffer/append
-         (concat "\nEmacs has to be restarted to actually install the "
-                 "new version of the packages (SPC q r).\n"))
+         (format
+          (concat "\nEmacs has to be restarted to actually install the "
+                  "new version of the packages%s.\n")
+          (if (member "restart-emacs" update-packages) "" " (SPC q r)")))
         (configuration-layer//cleanup-rollback-directory)
         (spacemacs//redisplay)))
     (when (eq upgrade-count 0)


### PR DESCRIPTION
When upgrading packages, Spacemacs backs up the old versions of the
packages and then tells the user to restart Emacs using `SPC q r` so
that the new version will be auto-installed.  But `SPC q r` doesn't
work if restart-emacs is one of the packages which is being upgraded,
and hence isn't currently installed.