### PR TITLE
Fix Clojure layer cider-repl-mode keybindings

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -28,6 +28,7 @@
      - [[#stacktrace-mode][stacktrace-mode]]
      - [[#inspector-mode][inspector-mode]]
      - [[#test-report-mode][test-report-mode]]
+     - [[#cider-repl-mode][cider-repl-mode]]
  - [[#development-notes][Development Notes]]
    - [[#indentation][Indentation]]
 
@@ -306,6 +307,13 @@ In general, ~q~ should always quit the popped up buffer.
 | ~r~         | rerun tests       |
 | ~t~         | run test          |
 | ~T~         | run tests         |
+
+*** cider-repl-mode
+
+| Key Binding | Description    |
+|-------------+----------------|
+| ~C-j~       | next input     |
+| ~C-k~       | previous input |
 
 * Development Notes
 ** Indentation

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -180,8 +180,8 @@
         "ep" 'cider-eval-print-last-sexp)
 
       (evil-define-key 'normal cider-repl-mode-map
-        "C-j" 'cider-repl-next-input
-        "C-k" 'cider-repl-previous-input)
+        (kbd "C-j") 'cider-repl-next-input
+        (kbd "C-k") 'cider-repl-previous-input)
 
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)


### PR DESCRIPTION
Clojure layer attempted to provide `C-j` and `C-k` keybindings to the cider-repl-mode but there was a bug.

This fixes the bug and adds those keybindings to the documentation.

fixes #7785 