### PR TITLE
sql: support for keywords auto capitalization

### DIFF
--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -5,14 +5,17 @@
 * Table of Contents                                         :TOC_4_gh:noexport:
  - [[#description][Description]]
  - [[#install][Install]]
+   - [[#sql-keywords-capitalization][SQL Keywords Capitalization]]
+     - [[#sql-interactive-mode][SQL Interactive Mode]]
+     - [[#blacklisting-keywords][Blacklisting keywords]]
  - [[#key-bindings][Key bindings]]
    - [[#highlighting][Highlighting]]
    - [[#inferior-process-interactions-sqli][Inferior Process Interactions (SQLi)]]
      - [[#send-sql-queries-to-sqli][Send SQL queries to SQLi:]]
    - [[#sqli-buffer][SQLi buffer]]
+   - [[#code-formating][Code Formating]]
 
 * Description
-
 This layer adds key bindings and configuration for =sql-mode=, which manages
 interactive SQL buffers and highlights a wide range of SQL dialects.
 
@@ -20,6 +23,33 @@ interactive SQL buffers and highlights a wide range of SQL dialects.
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =sql= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** SQL Keywords Capitalization
+SQL, by convention, uses upper-case keywords, although lower-case works just as
+well. As humans, the separation between upper-case and lower-case helps scan and
+parse the code much more quickly.
+
+To install [[https://github.com/Trevoke/sqlup-mode.el][sqlup-mode]] which enables auto capitalization in =sql mode= set the
+variable =sql-capitalize-keywords= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (sql :variables sql-capitalize-keywords t)))
+#+END_SRC
+
+*** SQL Interactive Mode
+If you want capitalization only in =sql-mode= and not in =sql-interactive-mode=
+you can set the variable =sql-capitalize-keywords-disable-interactive= to =t=.
+
+*** Blacklisting keywords
+[[https://github.com/Trevoke/sqlup-mode.el][sqlup-mode]] can be configured to ignore certain keywords. For example if you use
+=name= as column name it would be annoying to have it upcased. You can prevent
+this behaviour by setting the variable =sql-capitalize-keywords-blacklist= to
+string with one keyword (like ="name"=) or to list with multiple keywords (like
+='("name" "varchar")=) to ignore.
+
+This layer is blacklisting =name= by default as it is very common name for
+column and NAME is non-reserved SQL keyword.
 
 * Key bindings
 
@@ -58,3 +88,7 @@ file.
 |-------------+--------------------------------------------------------------|
 | ~SPC m b r~ | rename buffer (follow up in the SQL buffer with ~SPC m b s~) |
 | ~SPC m b S~ | save the current connection                                  |
+
+** Code Formating
+
+| ~SPC m = c~ | capitalize SQL keywords in region (if capitalize is enabled) |

--- a/layers/+lang/sql/config.el
+++ b/layers/+lang/sql/config.el
@@ -1,0 +1,19 @@
+;;; config.el --- sql Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2016 Sylvain Benner & Contributors
+;;
+;; Author: Kepi <kepi@igloonet.cz>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar sql-capitalize-keywords nil
+  "Capitalize keywords in SQL mode.")
+
+(defvar sql-capitalize-keywords-disable-interactive nil
+  "Do not capitalize keywords in interactive session (e.g. psql).")
+
+(defvar sql-capitalize-keywords-blacklist "name"
+  "Keyword or list of keywords to ignore during capitalization.")

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -9,7 +9,12 @@
 ;;
 ;;; License: GPLv3
 
-(setq sql-packages '(sql sql-indent))
+(setq sql-packages
+      '(
+        sql
+        sql-indent
+        (sqlup-mode :toggle sql-capitalize-keywords)
+        ))
 
 (defun sql/init-sql ()
   (use-package sql
@@ -117,3 +122,21 @@
 (defun sql/init-sql-indent ()
   (use-package sql-indent
     :defer t))
+
+(defun sql/init-sqlup-mode ()
+  (use-package sqlup-mode
+    :defer t
+    :init
+    (progn
+      (add-hook 'sql-mode-hook 'sqlup-mode)
+      (unless sql-capitalize-keywords-disable-interactive
+        (add-hook 'sql-interactive-mode-hook 'sqlup-mode))
+      (spacemacs/set-leader-keys-for-major-mode 'sql-mode
+        "=c" 'sqlup-capitalize-keywords-in-region))
+    :config
+    (progn
+      (spacemacs|diminish sqlup-mode)
+      (when sql-capitalize-keywords-blacklist
+        (if (listp sql-capitalize-keywords-blacklist)
+            (setq sqlup-blacklist (append sqlup-blacklist sql-capitalize-keywords-blacklist))
+          (add-to-list 'sqlup-blacklist sql-capitalize-keywords-blacklist))))))


### PR DESCRIPTION
SQL, by convention, uses upper-case keywords, although lower-case works just as
well. As humans, the separation between upper-case and lower-case helps scan and
parse the code much more quickly.

This PR add configurable support for minor mode `sqlup-mode` to SQL layer.

I would be glad to receive comments how to improve PR if there are any troubles with it.
I tried to follow conventions and check other layers about common ways. But this is
not only my first contribution to Spacemacs but I'm also really not the best in elisp :)

Design decisions:
----------------------
- sqlup is disabled by default. IMHO it would be best to enable it by default but I was afraid it isn't good idea to change default behavior for current users. **If you want it on by default** please [upvote this comment](https://github.com/syl20bnr/spacemacs/pull/7789#issuecomment-262094062).
- If you enable sqlup it will enable for both sql-mode and sql-interactive mode which is little different from default sqlup behavior. IMHO it is more comfortable and expected way from spacemacs layer.
- sqlup has empty blacklist by default. IMHO `name` is so common column name (it is also mentioned in sqlup documentation) that it deserves default blacklisting.
- I wasn't sure if it is ok to create another layer config variable for blacklist as it can be configured through customizable variable `sqlup-blacklist`. But it made more sense to me to define it when enabling capitalization. I guess that people who want sql layer fast will appreciate this.
- I added keybinding to code formatting section but let me know if it is better to move it to different part (I thought about higlighting before).
