### PR TITLE
Ocaml layer init without opam.

### DIFF
--- a/layers/+lang/ocaml/funcs.el
+++ b/layers/+lang/ocaml/funcs.el
@@ -19,9 +19,10 @@
             (setq opam-share share
                   opam-load-path (concat share "/emacs/site-lisp")))
           (add-to-list 'load-path opam-load-path))
-    (spacemacs-buffer/warning
-     (concat "Cannot find \"opam\" executable. "
-             "The ocaml layer won't work properly."))))
+    (unless (executable-find "ocamlmerlin")
+      (spacemacs-buffer/warning
+       (concat "Cannot find \"opam\" or \"merlin\" executable. "
+               "The ocaml layer won't work properly.")))))
 
 (defun spacemacs/merlin-locate ()
   (interactive)


### PR DESCRIPTION
Currently the ocaml layer requires opam in order to work. However
opam is only really required for an easy installation of the
required ocaml binaries. The only place where opam is used
instead is to add the merlin files of the merlin installed
via opam instead of the merlin files from melp.

This commit introduces a fallback if opam is not installed but
ocamlmerlin is installed, since the melpa package of merlin
is already installed through packages.

This should fix issue #7312.