### PR TITLE
fixed syntax highlight in README

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -178,8 +178,8 @@ intended. To work around this, you can use =v= instead (since Magit only stages
 whole lines, in any case).
 
 ** Commit message editing buffer
-In a commit message buffer press ~,c~ (if =dotspacemacs-major-mode-leader-key= is ~​,​~)
-or ~C-c C-c~ to commit the changes with the entered message. Pressing ~,a~ or ~C-c C-k~
+In a commit message buffer press ~​,​c~ (if =dotspacemacs-major-mode-leader-key= is ~​,​~)
+or ~C-c C-c~ to commit the changes with the entered message. Pressing ~​,​a~ or ~C-c C-k~
 will discard the commit message.
 
 | Key Binding | Description |
@@ -211,14 +211,14 @@ will discard the commit message.
 - Amend a commit:
   - ~l l~ to open =log buffer=
   - ~c a~ on the commit you want to amend
-  - ~,c~ or ~C-c C-c~ to submit the changes
+  - ~​,​c~ or ~C-c C-c~ to submit the changes
 - Squash last commit:
   - ~l l~ to open =log buffer=
   - ~r e~ on the second to last commit, it opens the =rebase buffer=
   - ~j~ to put point on last commit
   - ~s~ to squash it
-  - ~,c~ or ~C-c C-c~ to continue to the =commit message buffer=
-  - ~,c~ or ~C-c C-c~ again when you have finished to edit the commit message
+  - ~​,​c~ or ~C-c C-c~ to continue to the =commit message buffer=
+  - ~​,​c~ or ~C-c C-c~ again when you have finished to edit the commit message
 - Force push a squashed commit:
   - in the =status buffer= you should see the new commit unpushed and the old
     commit unpulled


### PR DESCRIPTION
Currently, `git`'s README is kinda confusing for submitting commits. In original README, it is `~,c~`. I realized this must be some kinda syntax highlight mistake in `org`. I fixed them in this PR. 