### PR TITLE
Fix python-enable-yapf-format-on-save

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -432,7 +432,9 @@ fix this issue."
 (defun python/init-yapfify ()
   (use-package yapfify
     :defer t
-    :init (spacemacs/set-leader-keys-for-major-mode 'python-mode
-            "=" 'yapfify-buffer)
-    :config (when python-enable-yapf-format-on-save
-              (add-hook 'python-mode-hook 'yapf-mode))))
+    :init 
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'python-mode
+        "=" 'yapfify-buffer)
+      (when python-enable-yapf-format-on-save
+        (add-hook 'python-mode-hook 'yapf-mode)))))


### PR DESCRIPTION
It seems the original config doesn't work when the variable is true.

