### PR TITLE
Remove unnecessary parameter to cider-test-run-project-tests

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -130,7 +130,7 @@ the focus."
   "Run project tests."
   (interactive)
   (cider-load-buffer)
-  (cider-test-run-project-tests nil))
+  (cider-test-run-project-tests))
 
 (defun spacemacs/cider-test-rerun-tests ()
   "Run previous tests again."


### PR DESCRIPTION
The nil parameter was causing [`cider-test-run-project-tests`](https://github.com/clojure-emacs/cider/blob/master/cider-test.el#L634) to fail (not run).  Furthermore, the function us a 0-arity function.
