### PR TITLE
Use proper markup to preserve meaning of code

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -21,7 +21,7 @@ mu4e will be bundled with mu (this is the case on many Linux distributions).
 
 If you're on OS X and install mu using Homebrew, you must specify the
 location of your Emacs binary at install time using the EMACS environment
-variable, as well as passing the --with-emacs option:
+variable, as well as passing the =--with-emacs= option:
 
 #+begin_src shell
 brew install mu --with-emacs

--- a/layers/+lang/nim/README.org
+++ b/layers/+lang/nim/README.org
@@ -29,9 +29,9 @@ and =nimsuggest= binary must be in $PATH.
 
 ** Nim commands (start with =m=):
 
-| Key Binding          | Description                |
-|----------------------+----------------------------|
-| ~SPC m c r~          | nim compile --run main.nim |
-| ~SPC m g g~ or ~M-.~ | Jump to definition         |
-| ~SPC m g b~ or ~M-,~ | Jump back                  |
-|----------------------+----------------------------|
+| Key Binding          | Description                  |
+|----------------------+------------------------------|
+| ~SPC m c r~          | =nim compile --run main.nim= |
+| ~SPC m g g~ or ~M-.~ | Jump to definition           |
+| ~SPC m g b~ or ~M-,~ | Jump back                    |
+|----------------------+------------------------------|

--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -167,7 +167,7 @@ tags for the following languages:
 
 **** Exuberant ctags languages
 If you have enabled =exuberant ctags= and use that as the backend (i.e.,
-GTAGSLABEL=ctags or --gtagslabel=ctags) the following additional languages
+=GTAGSLABEL=ctags= or =--gtagslabel=ctags=) the following additional languages
 will have tags created for them:
 
 - c#
@@ -200,7 +200,7 @@ actually uses both ctags and pygments to find the definitions and uses of
 functions and variables as well as "other symbols".
 
 If you enabled pygments (the best choice) and use that as the backend (i.e.,
-GTAGSLABEL=pygments or --gtagslabel=pygments) the following additional
+=GTAGSLABEL=pygments= or =--gtagslabel=pygments=) the following additional
 languages will have tags created for them:
 
 - elixir


### PR DESCRIPTION
Mark up code that is mentioned in the documentation of some readmes.

In the case of “long options”, like for example `--with-emacs`, this is not just
cosmetic.  On GitHub, Org files are apparently rendered in such a way that
strings like `--` in non-verbatim text (i.e. not verbatim-quoted nor
code-quoted) is transformed to `–` (EN DASH U+2013).  So the string:

    … --with-emacs option:

Will show up like this:

    … –with-emacs option:

Also mark up nearby not-marked-up code mentions.  But this pattern was what was
searched for, so this mostly changes the abovementioned kind of thing.