### PR TITLE
docs: correct keybinding for `helm-resume`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1721,7 +1721,7 @@ press just ~l~).
 The following helm actions are available on packages:
   - default: toggle on/off
 
-*Tips* Use ~SPC h l~ to resume the last helm session. It is handy to quickly
+*Tips* Use ~SPC r l~ to resume the last helm session. It is handy to quickly
 toggle on and off a toggle.
 
 ** Navigating


### PR DESCRIPTION
The keybinding has changed from `SPC h l` to `SPC r l`; see the changelog, entry
0.200.0 (2016/10/02). So correct the documentation to reflect that.

`SPC h l` is currently bound to `helm-spacemacs-help-layers` (on branch
`develop`).