### PR TITLE
Remove sbt-hydra rename wrapper

### DIFF
--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -112,8 +112,3 @@ point to the position of the join."
   "Yank to kill ring and print full type name at point to the minibuffer."
   (interactive)
   (ensime-type-at-point t t))
-
-(defun sbt-hydra ()
-  "Wrapper to rename sbt-hydra:hydra to sbt-hydra"
-  (interactive)
-  (sbt-hydra:hydra))


### PR DESCRIPTION
It has been already renamed as expected upstream.