### PR TITLE
Count of killed matching buffers

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -539,19 +539,22 @@ If the universal prefix argument is used then will the windows too."
       (insert "\n")
       (setq count (1- count)))))
 
-;; from https://github.com/gempesaw/dotemacs/blob/emacs/dg-defun.el
+;; from https://github.com/gempesaw/dotemacs/blob/emacs/dg-elisp/dg-defun.el
 (defun spacemacs/kill-matching-buffers-rudely (regexp &optional internal-too)
   "Kill buffers whose name matches the specified REGEXP. This
 function, unlike the built-in `kill-matching-buffers` does so
 WITHOUT ASKING. The optional second argument indicates whether to
-kill internal buffers too."
+kill internal buffers too. Returns count of killed buffers"
   (interactive "sKill buffers matching this regular expression: \nP")
-  (dolist (buffer (buffer-list))
-    (let ((name (buffer-name buffer)))
-      (when (and name (not (string-equal name ""))
-                 (or internal-too (/= (aref name 0) ?\s))
-                 (string-match regexp name))
-        (kill-buffer buffer)))))
+  (let* ((buffers (remove-if-not
+                   (lambda (buffer)
+                     (let ((name (buffer-name buffer)))
+                       (and name (not (string-equal name ""))
+                            (or internal-too (/= (aref name 0) ?\s))
+                            (string-match regexp name))))
+                   (buffer-list))))
+    (mapc 'kill-buffer buffers)
+    (length buffers)))
 
 ;; advise to prevent server from closing
 

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -540,12 +540,12 @@ If the universal prefix argument is used then will the windows too."
       (setq count (1- count)))))
 
 ;; from https://github.com/gempesaw/dotemacs/blob/emacs/dg-elisp/dg-defun.el
-(defun spacemacs/kill-matching-buffers-rudely (regexp &optional internal-too)
-  "Kill buffers whose name matches the specified REGEXP. This
-function, unlike the built-in `kill-matching-buffers` does so
-WITHOUT ASKING. The optional second argument indicates whether to
-kill internal buffers too. Returns count of killed buffers"
-  (interactive "sKill buffers matching this regular expression: \nP")
+(defun spacemacs/rudekill-matching-buffers (regexp &optional internal-too)
+  "Kill buffers whose name matches the specified REGEXP. This function, unlike
+the built-in `kill-matching-buffers` does so WITHOUT ASKING. The optional second
+argument indicates whether to kill internal buffers too.
+
+Returns the count of killed buffers."
   (let* ((buffers (remove-if-not
                    (lambda (buffer)
                      (let ((name (buffer-name buffer)))
@@ -555,6 +555,17 @@ kill internal buffers too. Returns count of killed buffers"
                    (buffer-list))))
     (mapc 'kill-buffer buffers)
     (length buffers)))
+
+(defun spacemacs/kill-matching-buffers-rudely (regexp &optional internal-too)
+  "Kill buffers whose name matches the specified REGEXP. This function, unlike
+the built-in `kill-matching-buffers` does so WITHOUT ASKING. The optional second
+argument indicates whether to kill internal buffers too.
+
+Returns a message with the count of killed buffers."
+  (interactive "sKill buffers matching this regular expression: \nP")
+  (message
+   (format "%d buffer(s) killed."
+           (spacemacs/rudekill-matching-buffers regexp internal-too))))
 
 ;; advise to prevent server from closing
 

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -539,11 +539,11 @@ If the universal prefix argument is used then will the windows too."
       (insert "\n")
       (setq count (1- count)))))
 
-;; from https://github.com/gempesaw/dotemacs/blob/emacs/dg-elisp/dg-defun.el
+;; see https://github.com/gempesaw/dotemacs/blob/emacs/dg-elisp/dg-defun.el
 (defun spacemacs/rudekill-matching-buffers (regexp &optional internal-too)
-  "Kill buffers whose name matches the specified REGEXP. This function, unlike
-the built-in `kill-matching-buffers` does so WITHOUT ASKING. The optional second
-argument indicates whether to kill internal buffers too.
+  "Kill - WITHOUT ASKING - buffers whose name matches the specified REGEXP. See
+the `kill-matching-buffers` for grateful killing. The optional 2nd argument
+indicates whether to kill internal buffers too.
 
 Returns the count of killed buffers."
   (let* ((buffers (remove-if-not
@@ -557,9 +557,9 @@ Returns the count of killed buffers."
     (length buffers)))
 
 (defun spacemacs/kill-matching-buffers-rudely (regexp &optional internal-too)
-  "Kill buffers whose name matches the specified REGEXP. This function, unlike
-the built-in `kill-matching-buffers` does so WITHOUT ASKING. The optional second
-argument indicates whether to kill internal buffers too.
+  "Kill - WITHOUT ASKING - buffers whose name matches the specified REGEXP. See
+the `kill-matching-buffers` for grateful killing. The optional 2nd argument
+indicates whether to kill internal buffers too.
 
 Returns a message with the count of killed buffers."
   (interactive "sKill buffers matching this regular expression: \nP")


### PR DESCRIPTION
Enables feedback messsages indication like e.g.:
    "5 buffer(s) killed"

Please consider involving the original author @gempesaw to the discussion.