### PR TITLE
Add verbatim markup to paths

### DIFF
--- a/layers/+chat/erc/README.org
+++ b/layers/+chat/erc/README.org
@@ -18,7 +18,7 @@ Layer for [[http://www.emacswiki.org/emacs/ERC][ERC IRC chat]].
 * Features
 - Highlight nicks (using [[https://github.com/leathekd/erc-hl-nicks][erc-hl-nicks]])
 - Image inline support (using [[https://github.com/kidd/erc-image.el][erc-image]])
-- Logging to ~/.emacs.d/.cache/erc-logs and ViewLogMode for viewing logs
+- Logging to =~/.emacs.d/.cache/erc-logs= and =ViewLogMode= for viewing logs
   (using [[https://github.com/Niluge-KiWi/erc-view-log][erc-view-log]])
 - YouTube videos Thumbnails inline (using [[https://github.com/yhvh/erc-yt][erc-yt]])
 - Social Graph for ERC messages (using [[https://github.com/vibhavp/erc-social-graph][erc-social-graph]])

--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -81,10 +81,10 @@ you don't use it already.
 
 ** Snippets directories
 The following directories are added by default:
-- ~/.emacs.d/elpa/yasnippet-xxxxx/snippets
-- ~/.emacs.d/layers/auto-completion/snippets
-- ~/.emacs.d/private/snippets (conditional to the value of =auto-completion-private-snippets-directory=)
-- ~/.spacemacs.d/snippets (conditional to the existence of =~/.spacemacs.d= directory)
+- =~/.emacs.d/elpa/yasnippet-xxxxx/snippets=
+- =~/.emacs.d/layers/auto-completion/snippets=
+- =~/.emacs.d/private/snippets= (conditional to the value of =auto-completion-private-snippets-directory=)
+- =~/.spacemacs.d/snippets= (conditional to the existence of =~/.spacemacs.d= directory)
 
 You can provide additional directories by setting the variable
 =auto-completion-private-snippets-directory= which can take a string in case of


### PR DESCRIPTION
By convention, filepaths are marked up with `=`.  Also add this markup to the
string `ViewLogMode`.