### PR TITLE
Use `RET` instead of `return` for return key

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2078,8 +2078,8 @@ Basic =ido= operations can be done with ~Ctrl~ key:
 
 | Key Binding        | Description                                       |
 |--------------------+---------------------------------------------------|
-| ~C-<return>~       | open a =dired buffer=                             |
-| ~M-<return>~       | open a =dired buffer= in terminal                 |
+| ~C-RET~            | open a =dired buffer=                             |
+| ~M-RET~            | select the buffer or file named by the prompt     |
 | ~C-d~              | delete selected file (ask for confirmation)       |
 | ~C-h~              | go to parent directory                            |
 | ~C-j~              | select next file or directory                     |
@@ -3111,7 +3111,7 @@ Spacemacs add =hjkl= navigation to =helm= buffers:
     | ~C-H~       | describe key (replace ~C-h~) |
     | ~C-j~       | go to previous candidate     |
     | ~C-k~       | go to next candidate         |
-    | ~C-l~       | same as ~return~             |
+    | ~C-l~       | same as ~RET~                |
 
 ** Emacs Server
 Spacemacs starts a server at launch. This server is killed whenever you close

--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -238,7 +238,7 @@ Emacs style:
 | ~C-k~       | select previous candidate                                            |
 | ~TAB~       | expand selection or select next candidate                            |
 | ~S-TAB~     | select previous candidate                                            |
-| ~return~    | complete word, if word is already completed insert a carriage return |
+| ~RET~       | complete word, if word is already completed insert a carriage return |
 
 ** Yasnippet
 

--- a/layers/+tools/rebox/README.org
+++ b/layers/+tools/rebox/README.org
@@ -26,7 +26,7 @@ A nice video demonstration by the package author can be found [[https://www.yout
 - Auto-wrap correctly in comments,
 - Auto-fill correctly in comments,
 - Boxes auto-adapt as text is inserted or deleted,
-- ~S-return~ to continue a comment on the next line,
+- ~S-RET~ to continue a comment on the next line,
 - Kill/yank within the box,
 - Apparently works well with ancient ~filladpt-mode~ (see authors video).
 
@@ -339,4 +339,4 @@ These templates are added by the Spacemacs layer.
 | ~SPC x b b~ | Draw next box defined in =rebox-style-loop=                       |
 | ~SPC x b B~ | Draw previous box defined in =rebox-style-loop=                   |
 | ~SPC x b c~ | Center box (point must be around left side of the box)            |
-| ~S-return~  | rebox-indent-new-line                                             |
+| ~S-RET~     | rebox-indent-new-line                                             |


### PR DESCRIPTION
It is an Emacs-wide convention to use `RET` when referring to the act of
pressing the return key.  Spacemacs seems to follow that convention as well.  So
fix some Org files that were deviating from this convention.

In particular, replace usages of `<return>` and `return` with `RET`.