### PR TITLE
Disable paste transient state by default

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -232,7 +232,7 @@ auto-save the file in-place, `cache' to auto-save the file to another
 file stored in the cache directory and `nil' to disable auto-saving.
 Default value is `cache'.")
 
-(defvar dotspacemacs-enable-paste-transient-state t
+(defvar dotspacemacs-enable-paste-transient-state nil
   "If non nil the paste transient-state is enabled. While enabled pressing `p`
 several times cycle between the kill ring content.'")
 (defvaralias


### PR DESCRIPTION
To match the default configuration template which [also disables it](https://github.com/syl20bnr/spacemacs/blob/a1516a600399715e86926f5ce3c07d62fd3730ec/core/templates/.spacemacs.template#L208).

See https://github.com/syl20bnr/spacemacs/issues/6251#issuecomment-262289770