### PR TITLE
Fix a syntax error in colors package's README.org

### DIFF
--- a/layers/+themes/colors/README.org
+++ b/layers/+themes/colors/README.org
@@ -66,7 +66,7 @@ a quasi-quoted list:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-    =((colors :variables
+    `((colors :variables
               colors-enable-nyan-cat-progress-bar ,(display-graphic-p))))
 #+END_SRC
 


### PR DESCRIPTION
A quasiquoted list starts with `` ` `` and not `=`.