### PR TITLE
engine-mode: Fix url to search engine github repository

### DIFF
--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -11,7 +11,7 @@
 
 * Description
 
-This layer adds support for the [[https://github.com/hrs/engine-mode/engine-mode.el][Search Engine]] package.
+This layer adds support for the [[https://github.com/hrs/engine-mode/blob/master/engine-mode.el][Search Engine]] package.
 
 ** Supported search engines
 


### PR DESCRIPTION
Just a little fix of url to search engine github repository