### PR TITLE
Fix README to say auto-fill on by default.

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -68,14 +68,15 @@ below.
 #+END_SRC
 
 ** Auto-fill
-To enable auto-fill set the variable =latex-enable-auto-fill= to =t=.
+To disable auto-fill (which is on by default) set the variable
+=latex-enable-auto-fill= to =nil=.
 
 The variable =latex-nofill-env= provide the list of environment names where
 =auto-fill-mode= will be inhibited.
 
 #+BEGIN_SRC emacs-lisp
   dotspacemacs-configuration-layers '(
-    (latex :variables latex-enable-auto-fill t))
+    (latex :variables latex-enable-auto-fill nil))
 #+END_SRC
 
 ** Folding


### PR DESCRIPTION
The LaTeX layer docs described how to _enable_ auto-fill as if it wasn't on by default (it is). Now they will describe how to _disable_ auto-fill.

This was perhaps a point of confusion in #7851.