### PR TITLE
python: fixes for anaconda-mode-view-mode

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -195,3 +195,11 @@ to be called for each testrunner. "
   (when (and python-sort-imports-on-save
              (derived-mode-p 'python-mode))
     (py-isort-before-save)))
+
+
+;;* Anaconda
+(defun spacemacs/anaconda-view-forward-and-push ()
+  "Find next button and hit RET"
+  (interactive)
+  (forward-button 1)
+  (call-interactively #'push-button))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -57,8 +57,15 @@
         "ga" 'anaconda-mode-find-assignments
         "gb" 'anaconda-mode-go-back
         "gu" 'anaconda-mode-find-references)
-      (evilified-state-evilify anaconda-mode-view-mode anaconda-mode-view-mode-map
-        (kbd "q") 'quit-window)
+
+      (evilified-state-evilify-map anaconda-mode-view-mode-map
+        :mode anaconda-mode-view-mode
+        :bindings
+        (kbd "q") 'quit-window
+        (kbd "C-j") 'next-error-no-select
+        (kbd "C-k") 'previous-error-no-select
+        (kbd "RET") 'spacemacs/anaconda-view-forward-and-push)
+
       (spacemacs|hide-lighter anaconda-mode)
 
       (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)


### PR DESCRIPTION
* layers/+lang/python/funcs.el (spacemacs/anaconda-view-forward-and-push):
  Added helper function to go forward and hit RET
* layers/+lang/python/packages.el (python/init-anaconda-mode):
   - use new evilification macro
   - use helper function to go ahead and push button when hitting `RET`
   - Add `C-j`, `C-k` for easy navigation in anaconda-view-mode when multiple
   references are displayed. Doesn't conflict with normal `hjkl` navigation in
   other views of `anaconda-view-mode`

Fix #7538
Fix #5737