### PR TITLE
Adds tide keybindings to tsx web mode

### DIFF
--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -54,13 +54,20 @@
         (interactive)
         (tide-jump-to-definition t))
 
-      (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
-        "gb" 'tide-jump-back
-        "gt" 'typescript/jump-to-type-def
-        "gu" 'tide-references
-        "hh" 'tide-documentation-at-point
-        "rr" 'tide-rename-symbol
-        "Sr" 'tide-restart-server))))
+      (setq keybindingList '(
+                             "gb" tide-jump-back
+                             "gt" typescript/jump-to-type-def
+                             "gu" tide-references
+                             "hh" tide-documentation-at-point
+                             "rr" tide-rename-symbol
+                             "sr" tide-restart-server
+                             )
+            typescriptList (cons 'typescript-mode keybindingList)
+            webList (cons 'web-mode (cons "gg" (cons 'tide-jump-to-definition keybindingList )))
+            )
+
+      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptList)
+      (apply 'spacemacs/set-leader-keys-for-major-mode webList))))
 
 (defun typescript/post-init-web-mode ()
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . web-mode))


### PR DESCRIPTION
Currently, when a tsx file is edited, the typescript layer puts it into web
mode so we can properly edit/format the html that's inside. However, with this
you lose the awesome ", g g" keybinding which takes you to a definition of
the current function/variable. You also lose the ", g u" keybinding which
gives you all references of current function/variable. This PR adds
all the tide bindings that are in typescript mode into web mode while using the typescript layer.

NOTE:
I must add ("gg" tide-jump-to-definition) to the webList because spacemacs-jump-handlers-web-mode does not exist.