### PR TITLE
Restclient: don't hijack "ji" global keybinding

### DIFF
--- a/layers/+tools/restclient/packages.el
+++ b/layers/+tools/restclient/packages.el
@@ -63,4 +63,4 @@
 
 (defun restclient/init-restclient-helm ()
   (use-package restclient-helm
-    :init (spacemacs/set-leader-keys "ji" 'helm-restclient)))
+    :init (spacemacs/set-leader-keys-for-major-mode 'restclient-mode "ji" 'helm-restclient)))


### PR DESCRIPTION
Restclient layer was overriding "SPC j i" (spacemacs/helm-jump-in-buffer) in all modes.