### PR TITLE
Add evil keybinding "i a" for org-attach

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -304,6 +304,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC m h s~ | org-insert-subheading            |
 | ~SPC m i f~ | org-insert-footnote              |
 | ~SPC m i l~ | org-insert-link                  |
+| ~SPC m i a~ | org-attach                       |
 
 *** Links
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -257,6 +257,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "s" 'org-schedule
 
         ;; insertion of common elements
+        "ia" 'org-attach
         "il" 'org-insert-link
         "if" 'org-footnote-new
         "ik" 'spacemacs/insert-keybinding-org


### PR DESCRIPTION
Add evil keybinding for org-attach to avoid emacs style `C-c C-a` to add attachments to org files.