### PR TITLE
add copy key to neotree

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2173,6 +2173,7 @@ open the file in a split window with ~|~ and ~-~:
 |-------------+---------------------------------|
 | ~TAB~       | toggle stretching of the buffer |
 | ~c~         | create a node                   |
+| ~C~         | copy a node                     |
 | ~d~         | delete a node                   |
 | ~gr~        | refresh                         |
 | ~s~         | toggle showing of hidden files  |

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -184,10 +184,10 @@
 Navigation^^^^             Actions^^         Visual actions/config^^^
 ───────^^^^─────────────── ───────^^──────── ───────^^^────────────────
 [_L_]   next sibling^^     [_c_] create      [_TAB_] shrink/enlarge
-[_H_]   previous sibling^^ [_d_] delete      [_|_]   vertical split
-[_J_]   goto child^^       [_r_] rename      [_-_]   horizonatal split
-[_K_]   goto parent^^      [_R_] change root [_gr_]  refresh^
-[_l_]   open/expand^^      ^^                [_s_]   hidden:^^^ %s(if neo-buffer--show-hidden-file-p \"on\" \"off\")
+[_H_]   previous sibling^^ [_C_] copy        [_|_]   vertical split
+[_J_]   goto child^^       [_d_] delete      [_-_]   horizonatal split
+[_K_]   goto parent^^      [_r_] rename      [_gr_]  refresh^
+[_l_]   open/expand^^      [_R_] change root [_s_]   hidden:^^^ %s(if neo-buffer--show-hidden-file-p \"on\" \"off\")
 [_h_]   up/collapse^^      ^^                ^^^
 [_j_]   line down^^        ^^                ^^^
 [_k_]   line up^^          ^^                ^^
@@ -200,6 +200,7 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
         ("-" neotree-enter-horizontal-split)
         ("?" nil :exit t)
         ("c" neotree-create-node)
+        ("C" neotree-copy-node)
         ("d" neotree-delete-node)
         ("gr" neotree-refresh)
         ("h" spacemacs/neotree-collapse-or-up)
@@ -224,6 +225,7 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
           (kbd "|") 'neotree-enter-vertical-split
           (kbd "-") 'neotree-enter-horizontal-split
           (kbd "c") 'neotree-create-node
+          (kbd "C") 'neotree-copy-node
           (kbd "d") 'neotree-delete-node
           (kbd "gr") 'neotree-refresh
           (kbd "h") 'spacemacs/neotree-collapse-or-up


### PR DESCRIPTION
CHANGES
-------
Add new keybinding to neotree to allow the copying of nodes from the neotree
buffer.

WHY
-------
There appear to be all other common file operations bound to the neotree buffer,
however copying of a node is not.