### PR TITLE
Ignore "emms" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ eproject.lst
 eshell/history
 .emacs.desktop
 .emacs.desktop.lock
+emms/
 eshell/alias
 eshell/lastdir
 /url/cookies


### PR DESCRIPTION
The ``~/.emacs.d/emms`` directory may contain files ``emms-cache``, ``emms-history``, and ``scores``.

Ignore the ``emms`` directory to keep the working area clean.