### PR TITLE
Add info about SSH key to github layer README

### DIFF
--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -35,6 +35,8 @@ You will need to generate a [[https://github.com/settings/tokens][personal acces
 have the =gist= and =repo= permissions. Once this token is created, it needs to
 be added to your =~/.gitconfig=
 
+You will also need to [[https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/][generate an SSH key]] and [[https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/][add it to your GitHub account]].
+
 #+BEGIN_SRC sh
   git config --global github.oauth-token <token>
 #+END_SRC


### PR DESCRIPTION
Github clone repo failed (with an unhelpful error) because I didn't have an SSH key associated. (This is because magit calls `git clone` using the `git://` protocol, rather than http or https.) Creating an SSH key and adding it to my GitHub account fixed the problem.