### PR TITLE
Use raw prefix argument instead numeric prefix argument

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -358,7 +358,7 @@ removal."
 
 ;; from magnars
 (defun spacemacs/sudo-edit (&optional arg)
-  (interactive "p")
+  (interactive "P")
   (let ((fname (if (or arg (not buffer-file-name))
                    (read-file-name "File: ")
                  buffer-file-name)))


### PR DESCRIPTION
With numeric prefix argument, the `arg` will always be true, and `spacemacs/sudo-edit` will always prompt to select a file 