### PR TITLE
which-key: remove spacemacs/ prefix from which-key description

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -303,7 +303,7 @@
            ("spacemacs/toggle-holy-mode" . "emacs (holy-mode)")
            ("evil-lisp-state-\\(.+\\)" . "\\1")
            ("\\(.+\\)-transient-state/\\(.+\\)" . "\\2")
-           ("\\(.+\\)-transient-state/body" . "\\1-transient-state"))))
+           ("spacemacs/\\(.+\\)-transient-state/body" . "\\1-transient-state"))))
     (dolist (nd new-descriptions)
       ;; ensure the target matches the whole string
       (push (cons (cons nil (concat "\\`" (car nd) "\\'")) (cons nil (cdr nd)))


### PR DESCRIPTION
Transient states are prefixed with `spacemacs/`, since it's a common prefix - remove it to save some precious screen space.