### PR TITLE
use winum.el for window numbers

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -212,16 +212,6 @@ Dedicated (locked) windows are left untouched."
   (interactive "p")
   (spacemacs/rotate-windows-forward (* -1 count)))
 
-;; Note that this duplicates code from select-window-by-number, ideally should
-;; upstream this function into windows.el
-(defun spacemacs/get-window-by-number (i)
-  (let ((windows (car (gethash (selected-frame) window-numbering-table)))
-        window)
-    (if (and (>= i 0) (< i 10)
-             (setq window (aref windows i)))
-        window
-      (error "No window numbered %s" i))))
-
 (defun spacemacs/move-buffer-to-window (windownum follow-focus-p)
   "Moves a buffer to a window, using the spacemacs numbering. follow-focus-p
    controls whether focus moves to new window (with buffer), or stays on
@@ -229,12 +219,12 @@ Dedicated (locked) windows are left untouched."
   (interactive)
   (let ((b (current-buffer))
         (w1 (selected-window))
-        (w2 (spacemacs/get-window-by-number windownum)))
+        (w2 (winum-get-window-by-number windownum)))
     (unless (eq w1 w2)
       (set-window-buffer w2 b)
       (switch-to-prev-buffer)
       (unrecord-window-buffer w1 b)))
-  (when follow-focus-p (select-window (spacemacs/get-window-by-number windownum))))
+  (when follow-focus-p (select-window (winum-get-window-by-number windownum))))
 
 (defun spacemacs/swap-buffers-to-window (windownum follow-focus-p)
   "Swaps visible buffers between active window and selected window.
@@ -243,7 +233,7 @@ Dedicated (locked) windows are left untouched."
   (interactive)
   (let* ((b1 (current-buffer))
          (w1 (selected-window))
-         (w2 (spacemacs/get-window-by-number windownum))
+         (w2 (winum-get-window-by-number windownum))
          (b2 (window-buffer w2)))
     (unless (eq w1 w2)
       (set-window-buffer w1 b2)

--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -19,9 +19,7 @@
         open-junk-file
         paradox
         restart-emacs
-        window-numbering))
-
-;; Initialization of packages
+        winum))
 
 (defun spacemacs-ui/init-ace-link ()
   (use-package ace-link
@@ -268,41 +266,36 @@ debug-init and load the given list of packages."
       "qr" 'spacemacs/restart-emacs-resume-layouts
       "qR" 'spacemacs/restart-emacs)))
 
-(defun spacemacs-ui/init-window-numbering ()
-  (use-package window-numbering
+(defun spacemacs-ui/init-winum ()
+  (use-package winum
     :config
     (progn
-      (when (configuration-layer/package-usedp 'spaceline)
-        (defun window-numbering-install-mode-line (&optional position)
-          "Do nothing, the display is handled by the powerline."))
-      (setq window-numbering-auto-assign-0-to-minibuffer nil)
+      (defun spacemacs//winum-assign-func ()
+        "Custom number assignment for neotree."
+        (when (and (boundp 'neo-buffer-name)
+                   (string= (buffer-name) neo-buffer-name)
+                   ;; in case there are two neotree windows. Example: when
+                   ;; invoking a transient state from neotree window, the new
+                   ;; window will show neotree briefly before displaying the TS,
+                   ;; causing an error message. the error is eliminated by
+                   ;; assigning 0 only to the top-left window
+                   (eq (selected-window) (frame-first-window)))
+          0))
+      (setq winum-auto-assign-0-to-minibuffer nil
+            winum-assign-func 'spacemacs//winum-assign-func
+            winum-auto-setup-mode-line nil
+            winum-ignored-buffers '(" *which-key*"))
       (spacemacs/set-leader-keys
-        "0" 'select-window-0
-        "1" 'select-window-1
-        "2" 'select-window-2
-        "3" 'select-window-3
-        "4" 'select-window-4
-        "5" 'select-window-5
-        "6" 'select-window-6
-        "7" 'select-window-7
-        "8" 'select-window-8
-        "9" 'select-window-9)
-      (window-numbering-mode 1))
-
-    ;; make sure neotree is always 0
-    (defun spacemacs//window-numbering-assign ()
-      "Custom number assignment for neotree."
-      (when (and (boundp 'neo-buffer-name)
-                 (string= (buffer-name) neo-buffer-name)
-                 ;; in case there are two neotree windows. Example: when
-                 ;; invoking a transient state from neotree window, the new
-                 ;; window will show neotree briefly before displaying the TS,
-                 ;; causing an error message. the error is eliminated by
-                 ;; assigning 0 only to the top-left window
-                 (eq (selected-window) (window-at 0 0)))
-        0))
-
-    ;; using lambda to work-around a bug in window-numbering, see
-    ;; https://github.com/nschum/window-numbering.el/issues/10
-    (setq window-numbering-assign-func
-          (lambda () (spacemacs//window-numbering-assign)))))
+        "`" 'winum-select-window-by-number
+        "²" 'winum-select-window-by-number
+        "0" 'winum-select-window-0-or-10
+        "1" 'winum-select-window-1
+        "2" 'winum-select-window-2
+        "3" 'winum-select-window-3
+        "4" 'winum-select-window-4
+        "5" 'winum-select-window-5
+        "6" 'winum-select-window-6
+        "7" 'winum-select-window-7
+        "8" 'winum-select-window-8
+        "9" 'winum-select-window-9)
+      (winum-mode))))


### PR DESCRIPTION
[winum.el](https://github.com/deb0ch/winum.el) is a rewrite of [window-numbering.el](https://github.com/nschum/window-numbering.el) that heavily extends it.

Among other things, it allows for sharing numbers across multiple frames, allowing to switch windows more smoothly when multi-screen.

It also brings a lot of new features and adapts the package to how we use it in Spacemacs.

See https://github.com/nschum/window-numbering.el/issues/16.

This should be merged only after https://github.com/TheBB/spaceline/pull/124 to make it display nicely in the mode-line.

It is also [on its way to Melpa](https://github.com/melpa/melpa/pull/4451).

**EDIT:**
- [X] winum [merged in Melpa](https://github.com/melpa/melpa/pull/4451)
- [X] https://github.com/TheBB/spaceline/pull/124 merged in Spaceline

PR ready for merge :100: 
