### PR TITLE
Use helm ag file with interactive input

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -183,7 +183,7 @@
       (defun spacemacs/helm-file-do-ag (&optional _)
         "Wrapper to execute `helm-ag-this-file.'"
         (interactive)
-        (helm-ag-this-file))
+        (helm-do-ag-this-file))
 
       (defun spacemacs/helm-file-do-ag-region-or-symbol ()
         "Search in current file with `ag' using a default input."


### PR DESCRIPTION
Currently, when using helm-ag on an individual file through spacemacs, instead of going directly into the helm prompt, it asks for the pattern upfront in the minibuffer and only shows helm after enter is hit. This isn't as nice and is not consistent with anything else.

Most likely this has not been noticed because most people use swoop, which I don't.