### PR TITLE
add magnars/multiple-cursors.el's mc-lists.el to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ python-*-docs-html
 /session.*
 /srecode-map.el
 /recentf
+.mc-lists.el
 
 # Private directory
 private/


### PR DESCRIPTION
Even if Spacemacs doesn't support this package, it still puts that file in your `.emacs.d` if you use it as an additional package.

(and prevents users from updating too)