### PR TITLE
replace fill-or-unfill with unfill package

### DIFF
--- a/layers/+emacs/better-defaults/funcs.el
+++ b/layers/+emacs/better-defaults/funcs.el
@@ -19,14 +19,3 @@
       ;; correctly (see https://github.com/syl20bnr/spacemacs/issues/3278)
       (call-interactively #'kill-region)
     (backward-kill-word arg)))
-
-;; http://endlessparentheses.com/fill-and-unfill-paragraphs-with-a-single-key.html
-(defun spacemacs/fill-or-unfill ()
-  "Like `fill-paragraph', but unfill if used twice."
-  (interactive)
-  (let ((fill-column
-         (if (eq last-command 'spacemacs/fill-or-unfill)
-             (progn (setq this-command nil)
-                    (point-max))
-           fill-column)))
-    (call-interactively #'fill-paragraph)))

--- a/layers/+emacs/better-defaults/keybindings.el
+++ b/layers/+emacs/better-defaults/keybindings.el
@@ -10,4 +10,3 @@
 ;;; License: GPLv3
 
 (global-set-key (kbd "C-w") 'spacemacs/backward-kill-word-or-region)
-(global-set-key [remap fill-paragraph] #'spacemacs/fill-or-unfill)

--- a/layers/+emacs/better-defaults/packages.el
+++ b/layers/+emacs/better-defaults/packages.el
@@ -10,7 +10,8 @@
 ;;; License: GPLv3
 
 (defconst better-defaults-packages
-  '(mwim)
+  '(mwim
+    unfill)
   "The list of Lisp packages required by the mwim layer.")
 
 (defun better-defaults/init-mwim ()
@@ -25,3 +26,10 @@
       (if better-defaults-move-to-end-of-code-first
 	  (global-set-key (kbd "C-e") 'mwim-end-of-code-or-line)
 	(global-set-key (kbd "C-e") 'mwim-end-of-line-or-code)))))
+
+(defun better-defaults/init-unfill ()
+  (use-package unfill
+    :defer t
+    :commands (unfill-region unfill-paragraph unfill-toggle)
+    :init
+    (global-set-key [remap fill-paragraph] #'unfill-toggle)))


### PR DESCRIPTION
Following #7960. It's better than previous version for the following reasons.

- It works well with regions (thanks to `deactivate-mark` set to `nil`).
- Exposes functions to unfill region and paragraph.
- Better second usage check by using `this-command`.
