### PR TITLE
prodigy-view-mode: go to file at point

### DIFF
--- a/layers/+tools/prodigy/packages.el
+++ b/layers/+tools/prodigy/packages.el
@@ -27,4 +27,6 @@
       "L" 'prodigy-start
       "d" 'prodigy-jump-dired
       "g" 'prodigy-jump-magit
-      "Y" 'prodigy-copy-cmd)))
+      "Y" 'prodigy-copy-cmd)
+    (evil-define-key 'motion prodigy-view-mode-map (kbd "gf") 'find-file-at-point)
+))


### PR DESCRIPTION
This is a small feature request.
When running a process and having a look at it's output in prodigy (`prodigy-view`), I would love to be able to open the file at point with <gf> as in other modes.

What do you think?
Thanks for your time