### PR TITLE
add function comment, evil goto next line indent

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -47,6 +47,8 @@ the current state and point position."
   (dotimes (_ count) (save-excursion (evil-insert-newline-below))))
 
 (defun spacemacs/evil-goto-next-line-and-indent (&optional count)
+  "Match the current lines indentation to the next line.
+A COUNT argument matches the indentation to the next COUNT lines."
   (interactive "p")
   (let ((counter (or count 1)))
     (while (> counter 0)


### PR DESCRIPTION
`spacemacs/evil-goto-next-line-and-indent` doesn't have a function comment, this corrects that by adding:

>   "Match the current lines indentation to the next line.
> A COUNT argument matches the indentation to the next COUNT lines."