### PR TITLE
Add the "evil-smartparens" package to editing layer

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -25,6 +25,7 @@
         evil-matchit
         evil-numbers
         evil-search-highlight-persist
+        evil-smartparens
         evil-surround
         ;; Temporarily disabled, pending the resolution of
         ;; https://github.com/7696122/evil-terminal-cursor-changer/issues/8
@@ -210,6 +211,11 @@
                           'evil-search-highlight-persist-remove-all)
       (spacemacs//adaptive-evil-highlight-persist-face)
       (add-hook 'spacemacs-post-theme-change-hook 'spacemacs//adaptive-evil-highlight-persist-face))))
+
+(defun spacemacs-evil/init-evil-smartparens ()
+  (use-package evil-smartparens
+    :defer t
+    :init (add-hook 'smartparens-enabled-hook #'evil-smartparens-mode)))
 
 (defun spacemacs-evil/init-evil-surround ()
   (use-package evil-surround


### PR DESCRIPTION
The default implementation of smartparens is not aware of all the various "extra" editing functions in evil mode. For example, if the caret is at `|` in the following code:
```
(defun foo (do-thing |bar) (other-thing baz))
```
and a user hits "C" in normal mode, the result is:
```
(defun foo (do-thing |
```
leaving two unbalanced parens. It is much more likely that the user would want the result be:
```
(defun foo (do-thing |))
```
which is the result following this commit.