### PR TITLE
dumb-jump: Specify selector from completion framework used

### DIFF
--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -25,6 +25,14 @@
       ;; https://github.com/syl20bnr/spacemacs/issues/7107)
 
       (spacemacs/set-leader-keys "jq" #'dumb-jump-quick-look)
+
+      ;; Use Helm or Ivy as the selector for dumb-jump.
+      (cond
+       ((configuration-layer/layer-usedp 'ivy)
+        (setq dumb-jump-selector 'ivy))
+       ((configuration-layer/layer-usedp 'helm)
+        (setq dumb-jump-selector 'helm)))
+
       ;; Since it's dumb, we add it to the end of the default jump handlers. At
       ;; the time of writing it is the only default jump handler. (gtags remains
       ;; mode-local)


### PR DESCRIPTION
This commit adds a conditional which allows `dumb-jump` to use a selector matching the current completion framework used (`ivy` or `helm`), instead of the default popup.

This relates to work done for adding Helm support to `dumb-jump` here: https://github.com/jacktasia/dumb-jump/pull/96

The motivation behind this is two-fold: the fact that popups are known to be broken when used with conflicting packages, such as `fci-mode` for showing a column marker, and the need for better completions with the possiblity for fuzzy-matching.

This should hopefully lead to a more consistent experience as well.
