### PR TITLE
Add more bindings to scroll-transient-state

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -35,6 +35,7 @@
                                        ("kD"  "delete-backward")
                                        ("k`"  "hybrid")
                                        ("n"   "narrow/numbers")
+                                       ("N"   "navigation")
                                        ("p"   "projects")
                                        ("p$"  "projects/shell")
                                        ("q"   "quit")

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -139,17 +139,50 @@
   ;; scrolling transient state
   (spacemacs|define-transient-state scroll
     :title "Scrolling Transient State"
+    :doc "
+ Buffer^^^^              Full page^^^^     Half page^^^^        Line/column^^^^
+ ──────^^^^───────────── ─────────^^^^──── ─────────^^^^─────── ───────────^^^^─────
+ [_<_/_>_] beginning/end [_f_/_b_] down/up [_J_/_K_] down/up    [_j_/_k_] down/up
+  ^ ^ ^ ^                 ^ ^ ^ ^          [_H_/_L_] left/right [_h_/_l_] left/right
+  ^ ^ ^ ^                 ^ ^ ^ ^          [_d_/_u_] down/up     ^ ^ ^ ^"
     :bindings
-    ("," evil-scroll-page-up "page up")
-    ("." evil-scroll-page-down "page down")
+    ;; buffer
+    ("<" evil-goto-first-line)
+    (">" evil-goto-line)
+    ;; full page
+    ("f" evil-scroll-page-down)
+    ("b" evil-scroll-page-up)
     ;; half page
-    ("<" evil-scroll-up "half page up")
-    (">" evil-scroll-down "half page down"))
+    ("d" evil-scroll-down)
+    ("u" evil-scroll-up)
+    ("J" evil-scroll-down)
+    ("K" evil-scroll-up)
+    ("H" evil-scroll-left)
+    ("L" evil-scroll-right)
+    ;; lines and columns
+    ("j" evil-scroll-line-down)
+    ("k" evil-scroll-line-up)
+    ("h" evil-scroll-column-left)
+    ("l" evil-scroll-column-right))
   (spacemacs/set-leader-keys
-    "n," 'spacemacs/scroll-transient-state/evil-scroll-page-up
-    "n." 'spacemacs/scroll-transient-state/evil-scroll-page-down
-    "n<" 'spacemacs/scroll-transient-state/evil-scroll-up
-    "n>" 'spacemacs/scroll-transient-state/evil-scroll-down)
+    ;; buffer
+    "N<" 'spacemacs/scroll-transient-state/evil-goto-first-line
+    "N>" 'spacemacs/scroll-transient-state/evil-goto-line
+    ;; full page
+    "Nf" 'spacemacs/scroll-transient-state/evil-scroll-page-down
+    "Nb" 'spacemacs/scroll-transient-state/evil-scroll-page-up
+    ;; half page
+    "Nd" 'spacemacs/scroll-transient-state/evil-scroll-down
+    "Nu" 'spacemacs/scroll-transient-state/evil-scroll-up
+    "NJ" 'spacemacs/scroll-transient-state/evil-scroll-down
+    "NK" 'spacemacs/scroll-transient-state/evil-scroll-up
+    "NH" 'spacemacs/scroll-transient-state/evil-scroll-left
+    "NL" 'spacemacs/scroll-transient-state/evil-scroll-right
+    ;; lines and columns
+    "Nj" 'spacemacs/scroll-transient-state/evil-scroll-line-down
+    "Nk" 'spacemacs/scroll-transient-state/evil-scroll-line-up
+    "Nh" 'spacemacs/scroll-transient-state/evil-scroll-column-left
+    "Nl" 'spacemacs/scroll-transient-state/evil-scroll-column-right)
 
   ;; pasting transient-state
   (evil-define-command spacemacs//transient-state-0 ()


### PR DESCRIPTION
Add more bindings to scroll-transient-state

As described in #7995. Once in scroll-transient-state more bindings are available. I haven't added new SPC n mappings for scrolling yet. Let me know if I should add these too or if perhaps there should be a generic binding that switches to scroll-transient-state/body.

Edit: Originally, I had 0 and $ bound to evil-scroll-left and evil-scroll-right (just like H and L). I have removed them, because these keys are probably expected to scroll to the very first and last column of the buffer.