### PR TITLE
recentf: add let bound variable to stop org from contaminating the re…

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -873,7 +873,8 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
 
 (defun spacemacs-buffer//do-insert-startupify-lists ()
   "Insert the startup lists in the current buffer."
-  (let ((list-separator "\n\n"))
+  (let ((list-separator "\n\n")
+        (spacemacs-recentf-ignore t))
     (mapc (lambda (els)
             (let ((el (or (car-safe els) els))
                   (list-size

--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -360,6 +360,16 @@
     :defer t
     :init
     (progn
+      ;; Define variable to ignore loading files in recentf
+      (defvar spacemacs-recentf-ignore nil
+        "Have recentf ignore the opening of files when non-nil.")
+
+      ;; advise recentf to ignore when spacemacs-recentf-ignore is non-nil.
+      (defadvice recentf-track-opened-file (around spacemacs-recentf-ignore activate)
+        "Ignore files to be saved if `spacemacs-recentf-ignore'"
+        (unless spacemacs-recentf-ignore
+            ad-do-it))
+
       ;; lazy load recentf
       (add-hook 'find-file-hook (lambda () (unless recentf-mode
                                              (recentf-mode)


### PR DESCRIPTION
When spacemacs-recentf-ignore is `t`, will not update recentf-list.