### PR TITLE
Add :layers property to keep track of all layers with package init

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -141,7 +141,11 @@ LAYER has to be installed for this method to work properly."
    (owners :initarg :owners
            :initform nil
            :type list
-           :documentation "The layer defining the init function.")
+           :documentation "The loaded layers defining the init function.")
+   (layers :initarg :layers
+           :initform nil
+           :type list
+           :documentation "All layers defining the init function.")
    (pre-layers :initarg :pre-layers
                :initform '()
                :type list
@@ -611,7 +615,12 @@ If TOGGLEP is nil then `:toggle' parameter is ignored."
        obj :protected (or protected (eq 'bootstrap step)))
       (when protected
         (push pkg-name configuration-layer--protected-packages)))
-    (when ownerp
+    ;; include all layers in :layers
+    (object-add-to-list obj :layers layer-name)
+    ;; only include used layers in :owners
+    (when (and ownerp
+               (or (eq 'dotfile layer-name)
+                (configuration-layer/layer-usedp layer-name)))
       ;; warn about mutliple owners
       (when (and (oref obj :owners)
                  (not (memq layer-name (oref obj :owners))))
@@ -627,7 +636,7 @@ If TOGGLEP is nil then `:toggle' parameter is ignored."
                 (eq 'dotfile layer-name)
                 (fboundp pre-init-func)
                 (fboundp post-init-func)
-                (oref obj :excluded))
+                (or excluded (oref obj :excluded)))
       (configuration-layer//warning
        (format (concat "package %s not initialized in layer %s, "
                        "you may consider removing this package from "

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -226,28 +226,26 @@
   (let (result)
     (dolist (pkg-name (configuration-layer/get-packages-list))
       (let* ((pkg (configuration-layer/get-package pkg-name))
-             (owner (cfgl-package-get-safe-owner pkg))
+             (owner (car (oref pkg :owners)))
              ;; the notion of owner does not make sense if the layer is not used
-             (init-type (if (configuration-layer/layer-usedp owner)
+             (init-type (if (configuration-layer/layer-usedp pkg-name)
                             "owner" "init")))
-        (when owner
-          (push (format "%s (%s: %S layer)"
-                        (propertize (symbol-name (oref pkg :name))
-                                    'face 'font-lock-type-face)
-                        init-type
-                        owner)
-                result))
+        (push (format "%s (%s: %S layer)"
+                      (propertize (symbol-name (oref pkg :name))
+                                  'face 'font-lock-type-face)
+                      init-type
+                      (or owner (car (oref pkg :layers))))
+              result)
         (dolist (initfuncs `((,(oref pkg :owners) "init")
                              (,(oref pkg :pre-layers) "pre-init")
                              (,(oref pkg :post-layers) "post-init")))
           (dolist (layer (car initfuncs))
-            (unless (and owner (eq owner layer))
-              (push (format "%s (%s: %S layer)"
-                            (propertize (symbol-name (oref pkg :name))
-                                        'face 'font-lock-type-face)
-                            (cadr initfuncs)
-                            layer)
-                    result))))))
+            (push (format "%s (%s: %S layer)"
+                          (propertize (symbol-name (oref pkg :name))
+                                      'face 'font-lock-type-face)
+                          (cadr initfuncs)
+                          layer)
+                  result)))))
     (sort result 'string<)))
 
 (defun helm-spacemacs-help//toggle-source ()

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -214,15 +214,23 @@
     (dolist (pkg-name (configuration-layer/get-packages-list))
       (let ((pkg (configuration-layer/get-package pkg-name)))
         (push (list (format (concat "%-" left-column-width "S %s %s")
-                            (car (oref pkg :owners ))
+                            (or (car (oref pkg :owners ))
+                                (car (oref pkg :layers )))
                             (propertize (symbol-name (oref pkg :name))
                                         'face 'font-lock-type-face)
                             (propertize
-                             (if (package-installed-p (oref pkg :name))
-                                 "[installed]" "")
+                             (cond
+                              ((configuration-layer/layer-usedp
+                                (car (oref pkg :layers)))
+                               "[loaded]")
+                              ((package-installed-p (oref pkg :name))
+                               "[installed]")
+                              (t 
+                               ""))
                              'face 'font-lock-comment-face))
                     (symbol-name
-                     (car (oref pkg :owners )))
+                     (or (car (oref pkg :owners ))
+                         (car (oref pkg :layers ))))
                     (symbol-name (oref pkg :name)))
               result)))
     (dolist (layer (delq nil
@@ -231,7 +239,7 @@
                           (configuration-layer/get-layers-list))))
       (push (list (format (concat "%-" left-column-width "S %s")
                           layer
-                          (propertize "no packages"
+                          (propertize "[layer]"
                                       'face 'warning))
                   layer
                   nil)


### PR DESCRIPTION
Grants visibility to owners of layers that are currently not loaded.  Added benefit is that `-help` functions can now find `package.el` files for unused layers.