### PR TITLE
Add command line option to track use-package usage for debugging.

### DIFF
--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -44,6 +44,9 @@ arguments is that we want to process these arguments as soon as possible."
              (setq spacemacs-debug-timer-threshold next-arg-digit
                    i (1+ 1)))
            (setq spacemacs-debugp t))
+          ("--use-package-loads"
+           (setq spacemacs-debug-use-package t)
+           (setq spacemacs-debugp t))
           ("--insecure"
            (setq spacemacs-insecure t))
           ("--no-layer"


### PR DESCRIPTION
Debugging option to track `use-package` loads, and which packages are deferred.  