### PR TITLE
emacs-restart: make debugging commands accessible.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3159,6 +3159,8 @@ server is to use the following bindings:
 | ~SPC q Q~  | Quit Emacs and kill the server, lose all unsaved changes.                |
 | ~SPC q r~  | Restart both Emacs and the server, prompting to save any changed buffers |
 | ~SPC q s~  | Save the buffers, quit Emacs and kill the server                         |
+| ~SPC q t~  | Restart Emacs and debug with --with-timed-requires                       |
+| ~SPC q T~  | Restart Emacs and debug with --adv-timers                                |
 | ~SPC q z~  | Kill the current frame                                                   |
 
 ** Troubleshoot

--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -240,6 +240,14 @@ When ARG is non-nil search in junk files."
       "Restart emacs and enable debug-init."
       (interactive)
       (spacemacs/restart-emacs (cons "--debug-init" args)))
+    (defun spacemacs/restart-emacs-timed-requires (&optional args)
+      "Restart emacs and time loads / requires."
+      (interactive)
+      (spacemacs/restart-emacs (cons "--timed-requires" args)))
+    (defun spacemacs/restart-emacs-adv-timers (&optional args)
+      "Restart emacs and time loads / requires and spacemacs configuration."
+      (interactive)
+      (spacemacs/restart-emacs (cons "--adv-timers" args)))
     (defun spacemacs/restart-stock-emacs-with-packages (packages &optional args)
       "Restart emacs without the spacemacs configuration, enable
 debug-init and load the given list of packages."
@@ -266,7 +274,10 @@ debug-init and load the given list of packages."
       "qd" 'spacemacs/restart-emacs-debug-init
       "qD" 'spacemacs/restart-stock-emacs-with-packages
       "qr" 'spacemacs/restart-emacs-resume-layouts
-      "qR" 'spacemacs/restart-emacs)))
+      "qR" 'spacemacs/restart-emacs
+      "qt" 'spacemacs/restart-emacs-timed-requires
+      "qT" 'spacemacs/restart-emacs-adv-timers
+      )))
 
 (defun spacemacs-ui/init-window-numbering ()
   (use-package window-numbering


### PR DESCRIPTION
Add debugging commands to `emacs-restart`, using `SPC q t` and `SPC q T`. 