### PR TITLE
ranger: add jump other window bindings, minus to enter

### DIFF
--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -33,6 +33,11 @@ session. Any settings that are desired on startup should be set below.
 
 ** Customizing
 
+You toggle the use of =-= to enter ranger with `ranger-enter-with-minus`.
+#+BEGIN_SRC elisp
+(setq ranger-enter-with-minus t)
+#+END_SRC
+
 When disabling the mode you can choose to kill the buffers that were opened
 while browsing the directories.
 #+BEGIN_SRC elisp

--- a/layers/+tools/ranger/config.el
+++ b/layers/+tools/ranger/config.el
@@ -1,0 +1,17 @@
+;;; config.el --- ranger Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2014 Sylvain Benner
+;; Copyright (c) 2014-2016 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar ranger-override-dired nil
+  "Override usage of dired with deer.")
+
+(defvar ranger-enter-with-minus t
+  "Option to enter `deer' when `-' is pressed.  Idea from `vim-vinegar'.")

--- a/layers/+tools/ranger/packages.el
+++ b/layers/+tools/ranger/packages.el
@@ -19,15 +19,22 @@
 (defun ranger//set-leader-keys ()
   (spacemacs/set-leader-keys
     "ar" 'ranger
-    "ad" 'deer))
+    "ad" 'deer
+    "jD" 'deer-jump-other-window
+    "jd" 'deer))
 
 (defun ranger/init-ranger ()
   (use-package ranger
     :defer t
-    :commands (ranger deer ranger-override-dired-fn)
+    :commands (ranger deer deer-jump-other-window ranger-override-dired-mode)
     :init
     (progn
       (ranger//set-leader-keys)
+
+      ;; allow '-' to enter ranger
+      (when ranger-enter-with-minus
+        (define-key evil-normal-state-map (kbd "-") 'deer))
+
       ;; set up image-dired to allow picture resize
       (setq image-dired-dir (concat spacemacs-cache-directory "image-dir"))
       (unless (file-directory-p image-dired-dir)
@@ -41,4 +48,4 @@
   ;; need to apply this to compensate for defer
   (spacemacs|use-package-add-hook ranger
     :post-init (when ranger-override-dired
-                 (add-hook 'dired-mode-hook #'ranger-override-dired-fn))))
+                 (ranger-override-dired-mode t))))


### PR DESCRIPTION
Add `ranger-enter-with-minus` option to bind `-` key to enter `deer` from opened buffer. 