### PR TITLE
Defer loading of flyspell-correct-helm, otherwise it just requires helm

### DIFF
--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -78,7 +78,8 @@
   (use-package flyspell-correct-ivy))
 
 (defun spell-checking/init-flyspell-correct-helm ()
-  (use-package flyspell-correct-helm))
+  (use-package flyspell-correct-helm
+    :defer t))
 
 (defun spell-checking/init-flyspell-correct-popup ()
   (use-package flyspell-correct-popup))


### PR DESCRIPTION
Defer loading this package because it explicitly requires `helm`.