### PR TITLE
Speedup: defer loading of helm-purpose.  Requires all of purpose.

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -29,6 +29,7 @@
 
 (defun spacemacs-purpose/init-helm-purpose ()
   (use-package helm-purpose
+    :defer t
     :init
     (progn
       (setq purpose-preferred-prompt 'helm)


### PR DESCRIPTION
`helm-purpose` requires `windows-purpose` directly, so defer loading of it.