### PR TITLE
Defer gmail-message, requires a lot of files.

### DIFF
--- a/layers/+tools/chrome/packages.el
+++ b/layers/+tools/chrome/packages.el
@@ -25,4 +25,5 @@
     ))
 
 (defun chrome/init-gmail-message-mode ( )
-  (use-package gmail-message-mode))
+  (use-package gmail-message-mode
+    :defer t))


### PR DESCRIPTION
Defer `gmail-message` to speedup startup.  