### PR TITLE
Remove unused variable p2 and two progn

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -867,16 +867,12 @@ With negative N, comment out original line and use the absolute value."
 (defun spacemacs/select-current-block ()
   "Select the current block of text between blank lines."
   (interactive)
-  (let (p1 p2)
-    (progn
-      (if (re-search-backward "\n[ \t]*\n" nil "move")
-          (progn (re-search-forward "\n[ \t]*\n")
-                 (setq p1 (point)))
-        (setq p1 (point)))
-      (if (re-search-forward "\n[ \t]*\n" nil "move")
-          (progn (re-search-backward "\n[ \t]*\n")
-                 (setq p2 (point)))
-        (setq p2 (point))))
+  (let (p1)
+    (when (re-search-backward "\n[ \t]*\n" nil "move")
+      (re-search-forward "\n[ \t]*\n"))
+    (setq p1 (point))
+    (if (re-search-forward "\n[ \t]*\n" nil "move")
+        (re-search-backward "\n[ \t]*\n"))
     (set-mark p1)))
 
 ;; END linum mouse helpers


### PR DESCRIPTION
Resolves #8031
The variable p2 was defined and assigned, but never used, and two instances of progn could be removed as well.