### PR TITLE
Gitignore emojis folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ python-*-docs-html
 /session.*
 /srecode-map.el
 /recentf
+/emojis
 
 # Private directory
 private/


### PR DESCRIPTION
The Emoji layer downloads image files in a root directory called `emojis`. This
folder doesn't need to be tracked in version control.