### PR TITLE
setup emojify cache directory

### DIFF
--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -19,6 +19,7 @@
   '(
     alert
     emoji-cheat-sheet-plus
+    emojify
     flyspell
     linum
     persp-mode
@@ -32,6 +33,13 @@
 
 (defun slack/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'slack-mode-hook 'emoji-cheat-sheet-plus-display-mode))
+
+;; pulled as dependency of slack package
+(defun slack/init-emojify ()
+  (use-package emojify
+    :defer t
+    :init
+    (setq emojify-emojis-dir (concat spacemacs-cache-directory "emojis/"))))
 
 (defun slack/post-init-flyspell ()
   (add-hook 'lui-mode-hook 'flyspell-mode))


### PR DESCRIPTION
Following #8037. 

It turns out that `slack` package pulls `emojify` as it's dependency. I am not sure that it's a proper place to configure `emojify`. That's why I am opening PR 😸 

Any thoughts? 