### PR TITLE
add sort-lines-by-column, -reverse funcs and keys

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -835,6 +835,20 @@ With negative N, comment out original line and use the absolute value."
         (end (if (region-active-p) (region-end) (point-max))))
     (sort-lines nil beg end)))
 
+(defun spacemacs/sort-lines-by-column (&optional reverse)
+  "Sort lines by the selected column.
+A non-nil argument sorts in reverse order."
+  (interactive "P")
+  (let* ((region-active (or (region-active-p) (evil-visual-state-p)))
+         (beg (if region-active (region-beginning) (point-min)))
+         (end (if region-active (region-end) (point-max))))
+    (sort-columns reverse beg end)))
+
+(defun spacemacs/sort-lines-by-column-reverse ()
+  "Sort lines by the selected column in reverse order."
+  (interactive)
+  (spacemacs/sort-columns -1))
+
 ;; BEGIN linum mouse helpers
 
 (defvar spacemacs-linum-mdown-line nil

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -434,6 +434,8 @@
   "xjl" 'set-justification-left
   "xjn" 'set-justification-none
   "xjr" 'set-justification-right
+  "xlc" 'spacemacs/sort-lines-by-column
+  "xlC" 'spacemacs/sort-lines-by-column-reverse
   "xld" 'spacemacs/duplicate-line-or-region
   "xls" 'spacemacs/sort-lines
   "xlu" 'spacemacs/uniquify-lines


### PR DESCRIPTION
Add two functions and key bindings:
<kbd>SPC x l c</kbd> `spacemacs/sort-lines-by-column` with an optional reverse argument,
<kbd>SPC x l C</kbd> `spacemacs/sort-lines-by-column-reverse`