### PR TITLE
Layer common-lisp - set jump handler to SLIME-EDIT-DEFINITION

### DIFF
--- a/layers/+lang/common-lisp/config.el
+++ b/layers/+lang/common-lisp/config.el
@@ -9,5 +9,5 @@
 ;;
 ;;; License: GPLv3
 
-(spacemacs|define-jump-handlers lisp-mode slime-inspect-definition)
+(spacemacs|define-jump-handlers lisp-mode slime-edit-definition)
 (spacemacs|define-jump-handlers common-lisp-mode)


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/issues/8043

"Go to definition" should go to the definition - meaning, where the function is defined in the source code.

I am for changing the default keybinding to `slime-edit-definition` because it fulfills this - allows the user to see the source code for a given function.

`slime-inspect-definition` does not open the source code - it opens the SLIME inspector with the function **object** open in the inspector. While the function **object** contains some valuable data, it does not contain the *definition* itself - which is what the user wants in this case.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3