### PR TITLE
elixir: add support for credo

### DIFF
--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -50,22 +50,16 @@ file.
 time.
 
 *** Credo
-A flycheck checker for [[https://github.com/rrrene/credo][credo]] is installed. The check needs both =bunt= and
-=credo= to be available, you can install them like this:
-
+You need to install [[https://github.com/rrrene/credo][credo]] into your project. Fort this,
+add ={:credo, "~> 0.5", only: [:dev, :test]}= to dependencies of your project (in file mix.exs) and
+run:
 #+BEGIN_SRC shell
-git clone https://github.com/rrrene/bunt
-cd bunt
-mix archive.build
-mix archive.install
-#+END_SRC
-
-#+BEGIN_SRC shell
-git clone https://github.com/rrrene/credo
-cd credo
 mix deps.get
-mix archive.build
-mix archive.install
+#+END_SRC
+For more info about mix [[http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html][see]].
+You can tell flycheck-credo to call credo with the '--strict' argument.
+#+BEGIN_SRC elisp
+(setq flycheck-elixir-credo-strict t)
 #+END_SRC
 
 *** mix compile

--- a/layers/+lang/elixir/funcs.el
+++ b/layers/+lang/elixir/funcs.el
@@ -34,4 +34,6 @@
 (defun spacemacs//elixir-enable-compilation-checking ()
   "Enable compile checking if `elixir-enable-compilation-checking' is non nil."
   (when (or elixir-enable-compilation-checking)
-    (flycheck-mix-setup)))
+    (flycheck-mix-setup)
+    ;; enable credo only if there are no compilation errors
+    (flycheck-add-next-checker 'elixir-mix '(warning . elixir-credo))))

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -16,6 +16,7 @@
     elixir-mode
     flycheck
     flycheck-mix
+    flycheck-credo
     ggtags
     helm-gtags
     ob-elixir
@@ -130,6 +131,11 @@
                    (cons 'elixir-enable-compilation-checking t))
       (add-hook 'elixir-mode-local-vars-hook
                 'spacemacs//elixir-enable-compilation-checking))))
+
+(defun elixir/init-flycheck-credo ()
+  (use-package flycheck-credo
+    :defer t
+    :init (add-hook 'flycheck-mode-hook #'flycheck-credo-setup)))
 
 (defun elixir/init-elixir-mode ()
   (use-package elixir-mode


### PR DESCRIPTION
There was no flycheck-credo package in the layer.
Although it was described in documentation, how to install credo (It [made](https://github.com/tonini/alchemist.el/issues/273) some confusion for users).
This commit fixes documentation and adds flycheck-credo package.

Note that there is PR for integrating this package to flycheck (https://github.com/flycheck/flycheck/issues/1062). But it is unknown when it will be merged, since flycheck lacks the main maintainer now.