### PR TITLE
Feature: Add alternate window with keybinding at SPC w TAB

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -326,7 +326,7 @@ current frame."
   (let (;; switch to first window previously shown in this frame
         (prev-window (get-mru-window nil t t)))
     ;; Check window was not found successfully
-    (unless prev-window (error "Last window not found."))
+    (unless prev-window (user-error "Last window not found."))
     (select-window prev-window)))
 
 (defun spacemacs/comint-clear-buffer ()

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -319,6 +319,16 @@ current window."
          ;; `other-buffer' honors `buffer-predicate' so no need to filter
          (other-buffer current-buffer t)))))
 
+(defun spacemacs/alternate-window ()
+  "Switch back and forth between current and last window in the
+current frame."
+  (interactive)
+  (let (;; switch to first window previously shown in this frame
+        (prev-window (get-mru-window nil t t)))
+    ;; Check window was not found successfully
+    (unless prev-window (error "Last window not found."))
+    (select-window prev-window)))
+
 (defun spacemacs/comint-clear-buffer ()
   (interactive)
   (let ((comint-buffer-maximum-size 0))

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1876,6 +1876,7 @@ Windows manipulation commands (start with ~w~):
 
 | Key Binding            | Description                                                                 |
 |------------------------+-----------------------------------------------------------------------------|
+| ~SPC w TAB~            | switch to alternate window in the current frame (switch back and forth)     |
 | ~SPC w =~              | balance split windows                                                       |
 | ~SPC w b~              | force the focus back to the minibuffer (useful with =helm= popups)         |
 | ~SPC w c~              | maximize/minimize a window and center it                                    |

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -368,6 +368,7 @@
     (golden-ratio)))
 
 (spacemacs/set-leader-keys
+  "w TAB"  'spacemacs/alternate-window
   "w2"  'spacemacs/layout-double-columns
   "w3"  'spacemacs/layout-triple-columns
   "wb"  'spacemacs/switch-to-minibuffer-window


### PR DESCRIPTION
`spacemacs/alternate-window` was suggested to switch between the last selected window, or the window-analog of `SPC TAB` (`spacemacs/alternate-buffer`). This is part of a larger family of functions, such as `spacemacs/jump-to-last-layout` on `SPC l TAB` and `eyebrowse-last-window-config` on `SPC l w TAB`.

Resolves #7845