### PR TITLE
fix neotree window number when using menu-bar-mode in terminal

### DIFF
--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -299,7 +299,7 @@ debug-init and load the given list of packages."
                  ;; window will show neotree briefly before displaying the TS,
                  ;; causing an error message. the error is eliminated by
                  ;; assigning 0 only to the top-left window
-                 (eq (selected-window) (window-at 0 0)))
+                 (eq (selected-window) (frame-first-window)))
         0))
 
     ;; using lambda to work-around a bug in window-numbering, see


### PR DESCRIPTION
when using `menu-bar-mode` in terminal, `(window-at 0 0)` does not return the NeoTree window, where `frame-first-window` does.