### PR TITLE
evil-escape documentation link update

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -206,7 +206,7 @@ change your terminal color palette. More explanations can be found on
 This is a feature of Spacemacs, enabling you to easily escape from a lot of
 situations, like escaping from =insert state= to =normal state=.
 
-The sequence of characters used can be customized. See the [[http://spacemacs.org/doc/DOCUMENTATION.html#orgheadline78][documentation]] for
+The sequence of characters used can be customized. See the [[http://spacemacs.org/doc/DOCUMENTATION.html#escaping][documentation]] for
 more information.
 
 If you don't like this feature, you can deactivate it by adding =evil-escape= to


### PR DESCRIPTION
Updated the FAQ evil-escape documentation link to point to the "14.1.1 Escaping" section of the documentation, where the evil-escape function is described.

Currently the FAQ evil-escape documentation link points to http://spacemacs.org/doc/DOCUMENTATION.html#orgheadline78, which takes you to the "13.1 Layouts" section of the documentation.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3