### PR TITLE
Fix ivy wgrep when used with rg

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -245,7 +245,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-files-do-rg (&optional dir)
         "Search in files with `rg'."
         (interactive)
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --vimgrep"))
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never"))
           (helm-do-ag dir)))
 
       (defun spacemacs/helm-files-do-rg-region-or-symbol ()
@@ -308,7 +308,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-buffers-do-rg (&optional _)
         "Search in opened buffers with `rg'."
         (interactive)
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --vimgrep"))
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never"))
           (helm-do-ag-buffers)))
 
       (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -13,7 +13,7 @@
 ;; Variables
 
 (defvar spacemacs--counsel-commands
-  '(("rg" . "rg --smart-case --no-heading --vimgrep %s %S .")
+  '(("rg" . "rg --smart-case --no-heading --color never %s %S .")
     ("ag" . "ag --nocolor --nogroup %s %S .")
     ("pt" . "pt -e --nocolor --nogroup %s %S .")
     ("ack" . "ack --nocolor --nogroup %s %S .")


### PR DESCRIPTION
wgrep does not know how to handle column numbers, which the `--vimgrep` flag
adds.

To reproduce the original issue:

* `SPC /`
* Search for something that has results
* `C-c C-o`
* `C-x C-q`
* Make a change
* `C-c C-e`

Note that the changes fail to apply. wgrep does not understand the results because of the column numbers.