### PR TITLE
Add binding for jump to def'n other window

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -135,6 +135,7 @@
 
   (define-key evil-normal-state-map (kbd "K") 'spacemacs/evil-smart-doc-lookup)
   (define-key evil-normal-state-map (kbd "gd") 'spacemacs/jump-to-definition)
+  (define-key evil-normal-state-map (kbd "gD") 'spacemacs/jump-to-definition-other-window)
 
   ;; scrolling transient state
   (spacemacs|define-transient-state scroll


### PR DESCRIPTION
Adds a binding for goto-defn-other-window at gD, normal binding is gd. gD is not taken and is a natural choice, layers often use ,gg and ,gG similarly. 