### PR TITLE
Add manual completion function to ycmd layer

### DIFF
--- a/layers/+tools/ycmd/README.org
+++ b/layers/+tools/ycmd/README.org
@@ -9,6 +9,7 @@
  - [[#configuration][Configuration]]
    - [[#activating-ycmd-in-a-major-mode][Activating ycmd in a major mode]]
    - [[#getting-the-compilation-flags][Getting the compilation flags]]
+ - [[#functions][Functions]]
  - [[#key-bindings][Key Bindings]]
 
 * Description
@@ -87,6 +88,23 @@ Example .ycm_extra_flags:
 If your build system doesn't handle the creation of a compile_commands.json,
 you can use tools such as [[https://github.com/rizsotto/Bear][Bear]] or [[https://pypi.python.org/pypi/scan-build][scan-build]] to generate it, which both work
 with almost any build system.
+
+* Functions
+
+If ~company-ycmd~ is used, then a function
+~spacemacs/company-ycmd-manual-semantic-complete~ is defined. This function is
+useful if you want to get semantic completions only when you press a
+keybinding; in larger projects ycmd may not be performant for as-you-type
+auto-completion to work well. You can bind it like so:
+
+#+BEGIN_SRC emacs-lisp
+(global-set-key (kbd "<C-tab>") 'spacemacs/company-ycmd-manual-semantic-complete)
+#+END_SRC
+
+This function will automatically cancel out of any active completers, and offer
+semantic completions. It will automatically make an exception when you are
+completing includes; these do not count as semantic completion so the exception
+is necessary for the keybinding to work when completing includes.
 
 * Key Bindings
 

--- a/layers/+tools/ycmd/funcs.el
+++ b/layers/+tools/ycmd/funcs.el
@@ -1,0 +1,7 @@
+(when (configuration-layer/package-usedp 'company-ycmd)
+  (defun spacemacs/company-ycmd-manual-semantic-complete ()
+    (interactive)
+    (company-cancel)
+    (let ((ycmd-force-semantic-completion (not (company-ycmd--in-include))))
+      (setq company-backend 'company-ycmd)
+      (company-manual-begin))))


### PR DESCRIPTION
Adds a function that is useful for those who prefer for ycmd completion to be triggered manually, as well as some explanation in the docs.