### PR TITLE
ivy: Add C-c C-e to edit counsel-ag search results

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -96,6 +96,12 @@
        (spacemacs//gne-init-counsel))
      (pop-to-buffer buf))))
 
+(defun spacemacs//counsel-edit ()
+  "Edit the current search results in a buffer using wgrep."
+  (interactive)
+  (run-with-idle-timer 0 nil 'ivy-wgrep-change-to-wgrep-mode)
+  (ivy-occur))
+
 (defun spacemacs//gne-init-counsel ()
   (with-current-buffer "*ivy results*"
     (setq spacemacs--gne-min-line 1
@@ -113,6 +119,7 @@
 (defvar spacemacs--counsel-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<f3>") 'spacemacs//counsel-save-in-buffer)
+    (define-key map (kbd "C-c C-e") 'spacemacs//counsel-edit)
     map))
 
 ;; see `counsel-ag'


### PR DESCRIPTION
Adds `C-c C-e` like helm-ag to edit search results in ivy.