### PR TITLE
Fix elm to not switch to root directory

### DIFF
--- a/layers/+lang/elm/funcs.el
+++ b/layers/+lang/elm/funcs.el
@@ -12,9 +12,6 @@
 
 ;; elm-mode
 
-(defun spacemacs//elm-find-root ()
-  (setq default-directory (elm--find-dependency-file-path)))
-
 (defun spacemacs/elm-compile-buffer-output ()
   (interactive)
   (let* ((fname (format "%s.js" (downcase (file-name-base (buffer-file-name))))))

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -25,8 +25,7 @@
   (push 'company-elm company-backends-elm-mode))
 
 (defun elm/post-init-flycheck ()
-  (add-hook 'elm-mode-hook 'flycheck-mode)
-  (add-hook 'elm-mode-hook 'spacemacs//elm-find-root))
+  (add-hook 'elm-mode-hook 'flycheck-mode))
 
 (defun elm/init-flycheck-elm ()
   "Initialize flycheck-elm"


### PR DESCRIPTION
Issue: `default-directory` gets changed to the project's root when you open an Elm file. This is annoying because whenever you try perform an action in the current directory it will instead change to the project's root  (e.g. `M-x find-file`).

I don't know why this was implemented like this, there are probably some function that need to be executed from the project's root. However changing `default-directory` globally is a bad solution and should be scoped within the function instead.

EDIT: Just found this this PR https://github.com/syl20bnr/spacemacs/pull/5004/files

However flycheck still works for me so I'm not sure what the issue is.