### PR TITLE
finance: Add keybindings for ledger-reconcile-mode

### DIFF
--- a/layers/+tools/finance/README.org
+++ b/layers/+tools/finance/README.org
@@ -7,7 +7,8 @@
  - [[#configuration][Configuration]]
    - [[#ledger][Ledger]]
  - [[#key-bindings][Key bindings]]
-   - [[#ledger][Ledger]]
+   - [[#ledger-1][Ledger]]
+   - [[#ledger-reconcile][Ledger-Reconcile]]
 
 * Description
 
@@ -53,3 +54,12 @@ your =dotspacemacs/user-config=.  The default value, set in the layer, is =62=.
 | ~SPC m t~   | append an effective date to a post            |
 | ~SPC m y~   | set the year for quicker entry                |
 | ~SPC m RET~ | set the month for quicker entry               |
+
+** Ledger-Reconcile
+
+| Key Binding | Description                                                               |
+|-------------+---------------------------------------------------------------------------|
+| ~SPC m ,~   | toggle the current transaction pending                                    |
+| ~SPC m a~   | quickly add a transaction, without exiting the reconciliation buffer      |
+| ~SPC m t~   | change the target amount for the selected account                         |
+| ~SPC m RET~ | finalize the reconciliation, changing all pending transactions to cleared |

--- a/layers/+tools/finance/README.org
+++ b/layers/+tools/finance/README.org
@@ -62,4 +62,5 @@ your =dotspacemacs/user-config=.  The default value, set in the layer, is =62=.
 | ~SPC m ,~   | toggle the current transaction pending                                    |
 | ~SPC m a~   | quickly add a transaction, without exiting the reconciliation buffer      |
 | ~SPC m t~   | change the target amount for the selected account                         |
+| ~SPC m q~   | quit reconciliation                                                       |
 | ~SPC m RET~ | finalize the reconciliation, changing all pending transactions to cleared |

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -46,6 +46,7 @@
       (spacemacs/set-leader-keys-for-major-mode 'ledger-reconcile-mode
         "," 'ledger-reconcile-toggle
         "a" 'ledger-reconcile-add
+        "q" 'ledger-reconcile-quit
         "t" 'ledger-reconcile-change-target
         "RET" 'ledger-reconcile-finish)
       ;; temporary hack to work-around an issue with evil-define-key

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -43,6 +43,11 @@
          "t" 'ledger-insert-effective-date
          "y" 'ledger-set-year
          "RET" 'ledger-set-month)
+      (spacemacs/set-leader-keys-for-major-mode 'ledger-reconcile-mode
+        "," 'ledger-reconcile-toggle
+        "a" 'ledger-reconcile-add
+        "t" 'ledger-reconcile-change-target
+        "RET" 'ledger-reconcile-finish)
       ;; temporary hack to work-around an issue with evil-define-key
       ;; more info: https://bitbucket.org/lyro/evil/issues/301/evil-define-key-for-minor-mode-does-not
       ;; TODO remove this hack if the limitation is removed upstream


### PR DESCRIPTION
This commit introduces some keybindings which should prove useful during account reconciliation.