### PR TITLE
org: bind org-refile from 'R' to 'r'

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -131,7 +131,7 @@
           "a" 'org-capture-kill
           "c" 'org-capture-finalize
           "k" 'org-capture-kill
-          "R" 'org-capture-refile))
+          "r" 'org-capture-refile))
 
       (with-eval-after-load 'org-src
         (spacemacs/set-leader-keys-for-minor-mode 'org-src-mode
@@ -253,7 +253,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "N" 'widen
         "O" 'org-clock-out
         "q" 'org-clock-cancel
-        "R" 'org-refile
+        "r" 'org-refile
         "s" 'org-schedule
 
         ;; insertion of common elements
@@ -352,7 +352,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "O" 'org-agenda-clock-out
         "P" 'org-agenda-set-property
         "q" 'org-agenda-clock-cancel
-        "R" 'org-agenda-refile
+        "r" 'org-agenda-refile
         "s" 'org-agenda-schedule)
       (spacemacs|define-transient-state org-agenda
       :title "Org-agenda transient state"
@@ -365,7 +365,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
 --------^^---------   -----------^^------------   ------^^-----------------   ----^^-------------  -----------^^------  ----^^---------    -----^^------  -----^^-----------
 [_ht_] set status     [_SPC_] in other window     [_ft_] by tag               [_ds_] schedule      [_tf_] follow        [_vd_] day         [_cI_] in      [_gr_] reload
 [_hk_] kill           [_TAB_] & go to location    [_fr_] refine by tag        [_dd_] set deadline  [_tl_] log           [_vw_] week        [_cO_] out     [_._]  go to today
-[_hR_] refile         [_RET_] & del other windows [_fc_] by category          [_dt_] timestamp     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
+[_hr_] refile         [_RET_] & del other windows [_fc_] by category          [_dt_] timestamp     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
 [_hA_] archive        [_o_]   link                [_fh_] by top headline      [_+_]  do later      [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
 [_h:_] set tags       ^^                          [_fx_] by regexp            [_-_]  do earlier    [_td_] diaries       [_vy_] year        ^^             ^^
 [_hp_] set priority   ^^                          [_fd_] delete all filters   ^^                   ^^                   [_vn_] next span   ^^             ^^
@@ -379,7 +379,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
       ("hA" org-agenda-archive-default)
       ("hk" org-agenda-kill)
       ("hp" org-agenda-priority)
-      ("hR" org-agenda-refile)
+      ("hr" org-agenda-refile)
       ("ht" org-agenda-todo)
 
       ;; Visit entry


### PR DESCRIPTION
Why?
 - 'r' is free binding - not used anywhere for org related modes
 - refiling is quite common activity if you use org heavily, so moving it for
 easy access makes sense