### PR TITLE
Fix issue with jump handler in omnisharp-mode where the handler is async

### DIFF
--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -33,7 +33,7 @@
         (setq omnisharp-auto-complete-want-documentation nil))
       (push 'company-omnisharp company-backends-csharp-mode)
       (add-to-list 'spacemacs-jump-handlers-csharp-mode
-                'omnisharp-go-to-definition))
+                   '(omnisharp-go-to-definition :async t)))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'csharp-mode "mc" "csharp/compile")


### PR DESCRIPTION
This fixes an issue where default jump handler, like dump-jump-go runs
in sync and omnisharp-go-to-definition is not able to actually go to
definition until it completes thus slowing down the completion process.

A similar issue (for C++) was fixed in syl20bnr/spacemacs#6904