### PR TITLE
select neotree window with backtick key

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -531,18 +531,19 @@
 (spacemacs|define-transient-state window-manipulation
   :title "Window Manipulation Transient State"
   :doc (concat "
- Select^^^^              Move^^^^              Split^^                Resize^^                     Other^^
- ──────^^^^───────────── ────^^^^───────────── ─────^^─────────────── ──────^^──────────────────── ─────^^──────────────────────────────
- [_j_/_k_] down/up       [_J_/_K_] down/up     [_s_] vertical         [_[_] shrink horizontally    [_q_] quit
- [_h_/_l_] left/right    [_H_/_L_] left/right  [_S_] vert & follow    [_]_] enlarge horizontally   [_u_] restore prev layout
- [_0_-_9_] window N      [_r_]^^   rotate fwd  [_v_] horizontal       [_{_] shrink vertically      [_U_] restore next layout
- [_w_]^^   other window  [_R_]^^   rotate bwd  [_V_] horiz & follow   [_}_] enlarge vertically     [_d_] close current
- [_o_]^^   other frame   ^^^^                  ^^                     ^^                           [_D_] close other"
+ Select^^^^^^                 Move^^^^              Split^^                Resize^^                     Other^^
+ ──────^^^^^^──────────────── ────^^^^───────────── ─────^^─────────────── ──────^^──────────────────── ─────^^──────────────────────────────
+ [_j_/_k_]^^    down/up       [_J_/_K_] down/up     [_s_] vertical         [_[_] shrink horizontally    [_q_] quit
+ [_h_/_l_]^^    left/right    [_H_/_L_] left/right  [_S_] vert & follow    [_]_] enlarge horizontally   [_u_] restore prev layout
+ [_`_,_0_.._9_] window 0..9   [_r_]^^   rotate fwd  [_v_] horizontal       [_{_] shrink vertically      [_U_] restore next layout
+ [_w_]^^^^      other window  [_R_]^^   rotate bwd  [_V_] horiz & follow   [_}_] enlarge vertically     [_d_] close current
+ [_o_]^^^^      other frame   ^^^^                  ^^                     ^^                           [_D_] close other"
                (if (configuration-layer/package-usedp 'golden-ratio)
-                   "\n ^^^^                    ^^^^                  ^^                     ^^                           [_g_] golden-ratio %`golden-ratio-mode"
+                   "\n ^^^^^^                       ^^^^                  ^^                     ^^                           [_g_] golden-ratio %`golden-ratio-mode"
                  ""))
   :bindings
   ("q" nil :exit t)
+  ("`" select-window-0)
   ("0" select-window-0)
   ("1" select-window-1)
   ("2" select-window-2)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -308,7 +308,10 @@
       (push (cons (cons nil (concat "\\`" (car nd) "\\'")) (cons nil (cdr nd)))
             which-key-replacement-alist)))
 
-  (push '(("\\(.*\\) 0" . "select-window-0") . ("\\1 0..9" . "window 0..9"))
+  ;; hide the "` -> select-window-0" entry in the spacemacs root which-key panel
+  (push '((nil . "select-window-0") . t) which-key-replacement-alist)
+
+  (push '(("\\(.*\\) 0" . "select-window-0") . ("\\1 `,0..9" . "window 0..9"))
         which-key-replacement-alist)
   (push '((nil . "select-window-[1-9]") . t) which-key-replacement-alist)
 

--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -277,6 +277,7 @@ debug-init and load the given list of packages."
           "Do nothing, the display is handled by the powerline."))
       (setq window-numbering-auto-assign-0-to-minibuffer nil)
       (spacemacs/set-leader-keys
+        "`" 'select-window-0
         "0" 'select-window-0
         "1" 'select-window-1
         "2" 'select-window-2


### PR DESCRIPTION
Resolves #7826

Bind \` (backtick) to the select-window-0 command, it selects
an open neotree window.

Hide the \` -> select-window-0 entry in the SPC panel.

Add \` to the SPC window entry: `,0..9 -> window 0..9.

Update the SPC w .  window manipulation transient state panel:
Select column
Add \` to  [`,0..9] window 0..9.

#### The following window TS formatting were removed from this PR, and will be made in a separate PR.
> Formatting
> Split column
> Add "i" to the end of "vert", then it'll have the same number
> of characters as "horiz", and the text will be aligned.
> 
> Resize column
> Shorten "horizontally" and "vertically" to "horiz" and "verti",
> it reduces the panels width slightly.
> 
> Other column
> Shorten the horizontal line below the title, so that it matches
> the longest key description.
> 
> Move [q] quit to the bottom of the column.
> 
> Equalize the horizontal spacing between the columns,
> from: 2, 2, 3, 3, to 2 between all columns.