### PR TITLE
Update buffer transient state formatting

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -465,10 +465,10 @@
 (spacemacs|define-transient-state buffer
   :title "Buffer Selection Transient State"
   :doc (concat "
- [_C-1_,_C-9_]^^  goto nth window              [_n_]^^     next buffer
- [_1_,_9_]^^      move buffer to nth window    [_N_/_p_]   previous buffer
- [_M-1_,_M-9_]^^  swap buffer w/ nth window    [_d_]^^     kill buffer
-              ^^^^^^                           [_q_]^^     quit")
+ [_C-1_,_C-9_] goto nth window            [_n_]^^   next buffer
+ [_1_,_9_]     move buffer to nth window  [_N_/_p_] previous buffer
+ [_M-1_,_M-9_] swap buffer w/ nth window  [_d_]^^   kill buffer
+ ^^^^                                     [_q_]^^   quit")
   :bindings
   ("n" next-buffer)
   ("N" previous-buffer)


### PR DESCRIPTION
Changed the buffer transient states formatting so that it matches
most of the other transient states.

Frontend
Reduced spacing:
- Between the keys and descriptions, from 2 to 1.
- Between both columns, from 4 to 2.

Backend
The first column didn't need the last two "^" (caret) characters.
Changed the last line so that "^^^^" starts below the first column.