### PR TITLE
also provide align functions for {, }, [ and ] under SPC x a

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -772,6 +772,10 @@ the right."
 (spacemacs|create-align-repeat-x "bar" "|")
 (spacemacs|create-align-repeat-x "left-paren" "(")
 (spacemacs|create-align-repeat-x "right-paren" ")" t)
+(spacemacs|create-align-repeat-x "left-curly-brace" "{")
+(spacemacs|create-align-repeat-x "right-curly-brace" "}" t)
+(spacemacs|create-align-repeat-x "left-square-brace" "\\[")
+(spacemacs|create-align-repeat-x "right-square-brace" "\\]" t)
 (spacemacs|create-align-repeat-x "backslash" "\\\\")
 
 ;; END align functions

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -417,6 +417,10 @@
   "xa&" 'spacemacs/align-repeat-ampersand
   "xa(" 'spacemacs/align-repeat-left-paren
   "xa)" 'spacemacs/align-repeat-right-paren
+  "xa{" 'spacemacs/align-repeat-left-curly-brace
+  "xa}" 'spacemacs/align-repeat-right-curly-brace
+  "xa[" 'spacemacs/align-repeat-left-square-brace
+  "xa]" 'spacemacs/align-repeat-right-square-brace
   "xa," 'spacemacs/align-repeat-comma
   "xa." 'spacemacs/align-repeat-decimal
   "xa:" 'spacemacs/align-repeat-colon


### PR DESCRIPTION
This feature was requested by a user in the gitter channel ([January 6, 2017 6:32 PM](https://gitter.im/syl20bnr/spacemacs?at=586fd4b15ffdeea72314b947)), and it makes sense to have it.

Also, as @jredville suggested ([January 6, 2017 6:55 PM](https://gitter.im/syl20bnr/spacemacs?at=586fda0961e516c157902664)), it could be nice to have an align function reading a character to align by from the minibuffer.

I haven't had time to implement it today, just let me know if it could be useful and I'll implement it.

Cheers :smile_cat: 
