### PR TITLE
Fix notation inconsistencies

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -33,8 +33,8 @@ values."
    '(
      ;; ----------------------------------------------------------------
      ;; Example of useful layers you may want to use right away.
-     ;; Uncomment some layer names and press <SPC f e R> (Vim style) or
-     ;; <M-m f e R> (Emacs style) to install them.
+     ;; Uncomment some layer names and press `SPC f e R' (Vim style) or
+     ;; `M-m f e R' (Emacs style) to install them.
      ;; ----------------------------------------------------------------
      helm
      ;; auto-completion
@@ -124,7 +124,7 @@ values."
    ;; Default major mode of the scratch buffer (default `text-mode')
    dotspacemacs-scratch-mode 'text-mode
    ;; List of themes, the first of the list is loaded when spacemacs starts.
-   ;; Press <SPC> T n to cycle to the next theme in the list (works great
+   ;; Press `SPC T n' to cycle to the next theme in the list (works great
    ;; with 2 themes variants, one dark and one light)
    dotspacemacs-themes '(spacemacs-dark
                          spacemacs-light)
@@ -139,7 +139,7 @@ values."
                                :powerline-scale 1.1)
    ;; The leader key
    dotspacemacs-leader-key "SPC"
-   ;; The key used for Emacs commands (M-x) (after pressing on the leader key).
+   ;; The key used for Emacs commands `M-x' (after pressing on the leader key).
    ;; (default "SPC")
    dotspacemacs-emacs-command-key "SPC"
    ;; The key used for Vim Ex commands (default ":")
@@ -154,9 +154,9 @@ values."
    ;; (default "C-M-m")
    dotspacemacs-major-mode-emacs-leader-key "C-M-m"
    ;; These variables control whether separate commands are bound in the GUI to
-   ;; the key pairs C-i, TAB and C-m, RET.
-   ;; Setting it to a non-nil value, allows for separate commands under <C-i>
-   ;; and TAB or <C-m> and RET.
+   ;; the key pairs `C-i', `TAB' and `C-m', `RET'.
+   ;; Setting it to a non-nil value, allows for separate commands under `C-i'
+   ;; and TAB or `C-m' and `RET'.
    ;; In the terminal, these pairs are generally indistinguishable, so this only
    ;; works in the GUI. (default nil)
    dotspacemacs-distinguish-gui-tab nil
@@ -165,7 +165,7 @@ values."
    ;; If non-nil, the shift mappings `<' and `>' retain visual state if used
    ;; there. (default t)
    dotspacemacs-retain-visual-state-on-shift t
-   ;; If non-nil, J and K move lines up and down when in visual mode.
+   ;; If non-nil, `J' and `K' move lines up and down when in visual mode.
    ;; (default nil)
    dotspacemacs-visual-line-move-text nil
    ;; If non-nil, inverse the meaning of `g' in `:substitute' Evil ex-command.
@@ -203,7 +203,7 @@ values."
    ;; source settings. Else, disable fuzzy matching in all sources.
    ;; (default 'always)
    dotspacemacs-helm-use-fuzzy 'always
-   ;; If non-nil the paste micro-state is enabled. When enabled pressing `p`
+   ;; If non-nil the paste micro-state is enabled. When enabled pressing `p'
    ;; several times cycle between the kill ring content. (default nil)
    dotspacemacs-enable-paste-transient-state nil
    ;; Which-key delay in seconds. The which-key buffer is the popup listing
@@ -259,7 +259,7 @@ values."
    ;; Code folding method. Possible values are `evil' and `origami'.
    ;; (default 'evil)
    dotspacemacs-folding-method 'evil
-   ;; If non-nil smartparens-strict-mode will be enabled in programming modes.
+   ;; If non-nil `smartparens-strict-mode' will be enabled in programming modes.
    ;; (default nil)
    dotspacemacs-smartparens-strict-mode nil
    ;; If non-nil pressing the closing parenthesis `)' key in insert mode passes

--- a/layers/+chat/slack/README.org
+++ b/layers/+chat/slack/README.org
@@ -61,9 +61,9 @@ client.
 
 | Key Binding | Description              |
 |-------------+--------------------------|
-| ~<SPC> m k~ | Join a channel           |
-| ~<SPC> m @~ | Embed mention of user    |
-| ~<SPC> m #~ | Embed mention of channel |
+| ~SPC m k~ | Join a channel           |
+| ~SPC m @~ | Embed mention of user    |
+| ~SPC m #~ | Embed mention of channel |
 
 In insert state, one can also use ~@~ and ~#~ directly without the leader key
 prefix.

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -46,7 +46,7 @@
     (progn
       (add-hook 'slack-mode #'(lambda ()
                                 (persp-add-buffer (current-buffer))))
-      ;; TODO: We don't want to slack-start every time someone types `<SPC> l o s`
+      ;; TODO: We don't want to slack-start every time someone types `SPC l o s`
       (call-interactively 'slack-start)
       (call-interactively 'slack-channel-select)))
   ;; Do not save slack buffers

--- a/layers/+tools/cfengine/README.org
+++ b/layers/+tools/cfengine/README.org
@@ -56,4 +56,4 @@ from anchor= to =2=. For example:
 
 | Key Binding | Description           |
 |-------------+-----------------------|
-| ~<SPC> m j~ | Reformats JSON string |
+| ~SPC m j~ | Reformats JSON string |


### PR DESCRIPTION
- Replace all instances of <Something x y with `Something x y' and add emphasis to missing occurrences in .spacemacs.template
- Remove the <> around `SPC` in several readmes

This should close #1823.