### PR TITLE
Fixes #8242 -- Adding additional go test functionality

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -98,6 +98,12 @@ function testing to work.
 the coverage buffer. See [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Choosing-Window.html][=display-buffer=]] for a list of possible functions.
 The default value is =display-buffer-reuse-window=.
 
+
+To provide additional arguments to go test, specify =go-use-test-args=
+#+begin_src emac-lisp
+  (go :variables go-use-test-args "-race -timeout 10s"
+#-end_src
+
 ** Guru
 
 Go Oracle has been deprecated as of October 1, 2016, it's replacement is =go-guru=.

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -21,3 +21,6 @@
 
 (defvar go-use-gometalinter nil
   "Use gometalinter if the variable has non-nil value.")
+
+(defvar go-use-test-args ""
+  "Additional arguments to be supplied to `go test` during runtime.")

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -46,8 +46,9 @@
 
       (defun spacemacs/go-run-tests (args)
         (interactive)
-        (save-selected-window
-          (async-shell-command (concat "go test " args))))
+        (let ((all-args (concat args " " go-use-test-args)))
+          (save-selected-window
+            (async-shell-command (concat "go test " all-args)))))
 
       (defun spacemacs/go-run-package-tests ()
         (interactive)


### PR DESCRIPTION
The gist of this change is the following: `go test` allows different commands to be passed in (like -race, which tests for race conditions). Some of these test arguments are highly desirable in day-to-day testing and development. So, to improve developer experience, the new `go-use-test-args` variable allows go developers to specify whatever they may want or need.

Sorry if this is seen as a drive-by PR!

ADD: 
 - layers/+lang/go/config.el Added new variable `go-use-test-args` to allow specifying
    additional arguments being passed to `go test.

CHANGE:
  - layers/+lang/go/packages.el Updated `go-run-tests` to automatically concat
    the new variable `go-use-test-args` to args passed to `go test`.