### PR TITLE
Fix cider and cider-repl mode names in company configuration for clojure layer

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -278,8 +278,8 @@
   (spacemacs|add-company-backends
     :backends company-capf
     :modes
-    company-backends-cider-mode
-    company-backends-cider-repl-mode))
+    cider-mode
+    cider-repl-mode))
 
 (defun clojure/post-init-ggtags ()
   (add-hook 'clojure-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
Fix `cider` and `cider-repl` mode names in company configuration.
Right now there is no auto-completion for both of this modes.
Looks like this is just a typo introduced by [this change.](https://github.com/syl20bnr/spacemacs/commit/74fdbb6795018a93a665fa2c417589cd4cbd51fc#diff-43a23dbec19deb02144c5310368c065eR277)