### PR TITLE
Clojure: fix spacemacs|add-company-backends in cider-mode.

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -278,8 +278,8 @@
   (spacemacs|add-company-backends
     :backends company-capf
     :modes
-    company-backends-cider-mode
-    company-backends-cider-repl-mode))
+    cider-mode
+    cider-repl-mode))
 
 (defun clojure/post-init-ggtags ()
   (add-hook 'clojure-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
New spacemacs|add-company-backeds broke company in cider-mode because of a typo.