### PR TITLE
Add binding to open cargo docs in Rust layer.

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -34,6 +34,7 @@
         "cX" 'cargo-process-run-example
         "cc" 'cargo-process-build
         "cd" 'cargo-process-doc
+        "cD" 'cargo-process-doc-open                                               
         "ce" 'cargo-process-bench
         "cf" 'cargo-process-current-test
         "cf" 'cargo-process-fmt


### PR DESCRIPTION
My pull request for a command to open cargo documentation in rust projects with a keybinding in the Cargo.el package was recently merged. This pull request adds a keybinding to the Rust layer to use the added command. 

See [this commit](https://github.com/kwrooijen/cargo.el/commit/4fdf141e33044c81f1ba776f0146fe25797561e4) on the Cargo.el repo for more information.