### PR TITLE
Add missing "m key" to debugging and help base prefix

### DIFF
--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -215,7 +215,7 @@ Note: we don't distinguish between the file and the buffer. We can
 implement an auto-save of the buffer before compiling the buffer.
 
 ** Debugging
-The base prefix for debugging commands is ~SPC d~.
+The base prefix for debugging commands is ~SPC m d~.
 
 | Key Binding | Description             |
 |-------------+-------------------------|
@@ -350,7 +350,7 @@ Major-mode code formatting is under prefix ~SPC m =~.
 | ~m = f~     | format current function  |
 
 ** Help or Documentation
-The base prefix for help commands is ~SPC h~. Documentation is considered
+The base prefix for help commands is ~SPC m h~. Documentation is considered
 as an help command.
 
 | Key     | Description                        |


### PR DESCRIPTION
Noticed that for the debugging and help base prefix the "m key" was missing in CONVENTIONS.org and added it.