### PR TITLE
Bind space-doc-mode to "SPC m v" in Org

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -303,6 +303,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC m C-S-j~                                | org-shiftcontroldown                         |
 | ~SPC m C-S-k~                                | org-shiftcontrolup                           |
 | ~SPC s j~                                    | spacemacs/jump-in-buffer (jump to a heading) |
+| ~SPC v~                                      | space-doc-mode (toggle a read-only view mode)|
 
 *** Tables
 

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -9,6 +9,9 @@
 ;;
 ;;; License: GPLv3
 
+;; Autoload space-doc-mode
+(autoload 'space-doc-mode "space-doc" nil 'interactive)
+
 (defun org-projectile/capture (&optional arg)
   (interactive "P")
   (if arg

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -254,6 +254,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "q" 'org-clock-cancel
         "R" 'org-refile
         "s" 'org-schedule
+        "v" 'space-doc-mode
 
         ;; insertion of common elements
         "ia" 'org-attach


### PR DESCRIPTION
Provide a way to toggle `space-doc-mode` in any org file with a keybinding as requested in #7757. Useful for reading documents in the same mode as Spacemacs documentation is opened in.