### PR TITLE
Fix links in documentation which breaks org html export

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -25,18 +25,24 @@ Thanks! :heart: :heart: :heart:
  - [[#credits][Credits]]
 
 * Asking for help
+  :PROPERTIES:
+:CUSTOM_ID: asking-for-help
+:END:
 If you want to ask an usage question, be sure to look first into some places as
 it may hold the answer:
 
-- [[doc/FAQ.org][The FAQ]]. Some of the most frequently asked questions are answered there.
-- [[doc/DOCUMENTATION.org][The documentation]]. It's the general documentation of Spacemacs.
-- You may also read the =README.org= of the [[layers/][relevant layer(s)]].
+- [[file:doc/FAQ.org][The FAQ]]. Some of the most frequently asked questions are answered there.
+- [[file:doc/DOCUMENTATION.org][The documentation]]. It's the general documentation of Spacemacs.
+- You may also read the =README.org= of the [[file:layers/][relevant layer(s)]].
 
 If your question is not answered there, then please come into our [[https://gitter.im/syl20bnr/spacemacs][gitter chat]] to
 discuss it with us :relaxed:. We will direct you to a solution, or ask you to
 open an issue if it is needed.
 
 * Reporting issues
+:PROPERTIES:
+:CUSTOM_ID: reporting-issues
+:END:
 Issues have to be reported on our [[https://github.com/syl20bnr/spacemacs/issues][issues tracker]]. Please:
 
 - Check that the issue has not already been reported.
@@ -56,6 +62,9 @@ Issues have to be reported on our [[https://github.com/syl20bnr/spacemacs/issues
     step guide.
 
 * Contributing code
+:PROPERTIES:
+:CUSTOM_ID: contributing-code
+:END:
 Code contributions are welcome. Please read the following sections carefully. In
 any case, feel free to join us on the [[https://gitter.im/syl20bnr/spacemacs][gitter chat]] to ask questions about
 contributing!
@@ -198,7 +207,7 @@ can be done from the =dotspacemacs/user-config= function of your =.spacemacs=
 file and don't require any contribution to Spacemacs.
 
 If you think it worth contributing a new key bindings then be sure to read
-the [[doc/CONVENTIONS.org][CONVENTIONS.org]] file to find the best key bindings, then create a
+the [[file:doc/CONVENTIONS.org][CONVENTIONS.org]] file to find the best key bindings, then create a
 Pull-Request with your changes.
 
 *ALWAYS* document your new keybindings or keybindings changes inside the

--- a/doc/BEGINNERS_TUTORIAL.org
+++ b/doc/BEGINNERS_TUTORIAL.org
@@ -228,6 +228,9 @@ a very common task and is done with ~SPC f r~. An edited file is saved with
 ~SPC f s~.
 
 * Configuring Spacemacs
+:PROPERTIES:
+:CUSTOM_ID: configuring-spacemacs
+:END:
 ** Adding language support and other features: using layers
 Spacemacs divides its configuration into self-contained units called
 configuration layers. These layers are stacked on top of each other to achieve a


### PR DESCRIPTION
It seems that some of the documentation files cannot longer be exported to html via org. I had a look into this and found some wrongly declared internal and external links which I have corrected so that it is again possible to export each spacemacs documentation file.

However in #8054 @deb0ch has noticed that this is happening even in the automatically generated table of content so the root cause may still be a bug in org mode.

Anyway this merge request may at least kill the symptoms of the issue by adding "Custom_ID properties" as well as correcting links to relative paths where necessary in the documentation files.