### PR TITLE
restore emacs-style window selection bindings

### DIFF
--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -298,4 +298,14 @@ debug-init and load the given list of packages."
         "7" 'winum-select-window-7
         "8" 'winum-select-window-8
         "9" 'winum-select-window-9)
+      (define-key winum-keymap (kbd "M-0") 'winum-select-window-0-or-10)
+      (define-key winum-keymap (kbd "M-1") 'winum-select-window-1)
+      (define-key winum-keymap (kbd "M-2") 'winum-select-window-2)
+      (define-key winum-keymap (kbd "M-3") 'winum-select-window-3)
+      (define-key winum-keymap (kbd "M-4") 'winum-select-window-4)
+      (define-key winum-keymap (kbd "M-5") 'winum-select-window-5)
+      (define-key winum-keymap (kbd "M-6") 'winum-select-window-6)
+      (define-key winum-keymap (kbd "M-7") 'winum-select-window-7)
+      (define-key winum-keymap (kbd "M-8") 'winum-select-window-8)
+      (define-key winum-keymap (kbd "M-9") 'winum-select-window-9)
       (winum-mode))))


### PR DESCRIPTION
@bmag's [request](https://github.com/syl20bnr/spacemacs/issues/8127#issuecomment-271214642)

I couldn't choose if we should shadow the (crap) original bindings of the package or keep them, so I have opened 2 PRs (see #8140).

This PR keeps the original bindings on top.

Just pick one and close the other :smile_cat: 