### PR TITLE
restore emacs-style window selection bindings

### DIFF
--- a/layers/+spacemacs/spacemacs-ui/packages.el
+++ b/layers/+spacemacs/spacemacs-ui/packages.el
@@ -268,6 +268,21 @@ debug-init and load the given list of packages."
 
 (defun spacemacs-ui/init-winum ()
   (use-package winum
+    :init
+    (setq winum-keymap
+          (let ((map (make-sparse-keymap)))
+            (define-key map (kbd "C-`") 'winum-select-window-by-number)
+            (define-key map (kbd "C-²") 'winum-select-window-by-number)
+            (define-key map (kbd "M-0") 'winum-select-window-0-or-10)
+            (define-key map (kbd "M-1") 'winum-select-window-1)
+            (define-key map (kbd "M-2") 'winum-select-window-2)
+            (define-key map (kbd "M-3") 'winum-select-window-3)
+            (define-key map (kbd "M-4") 'winum-select-window-4)
+            (define-key map (kbd "M-5") 'winum-select-window-5)
+            (define-key map (kbd "M-6") 'winum-select-window-6)
+            (define-key map (kbd "M-7") 'winum-select-window-7)
+            (define-key map (kbd "M-8") 'winum-select-window-8)
+            map))
     :config
     (progn
       (defun spacemacs//winum-assign-func ()


### PR DESCRIPTION
@bmag's [request](https://github.com/syl20bnr/spacemacs/issues/8127#issuecomment-271214642)

I couldn't choose if we should shadow the (crap) original bindings of the package or keep them, so I have opened 2 PRs (see #8139).

Just pick one and close the other :smile_cat: 