### PR TITLE
Make python-execute-file use python-shell-interpreter

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -332,8 +332,10 @@
         ;; set compile command to buffer-file-name
         ;; universal argument put compile buffer in comint mode
         (let ((universal-argument t)
-              (compile-command (format "python %s" (file-name-nondirectory
-                                                    buffer-file-name))))
+              (compile-command (format "%s %s"
+                                       python-shell-interpreter
+                                       (file-name-nondirectory
+                                        buffer-file-name))))
           (if arg
               (call-interactively 'compile)
             (compile compile-command t)


### PR DESCRIPTION
So that we can customize to use `python3` instead of `python`