### PR TITLE
Hide PROPERTIES drawers in space-doc-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
+++ b/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
@@ -304,6 +304,10 @@ This functions is aimed to be used with `spacemacs-space-doc-modificators'."
            "\\([ \t]*\\#\\+TITLE\\:\[ \t]*\\)"
            ;; Hide CAPTION logo meta line.
            "\\(\n.*\\#\\+CAPTION\\:.*\\)"
+           ;; Hide PROPERTIES lines.
+           "\\(\n.*\\:PROPERTIES\\:.*\\)"
+           "\\(\n.*\\:CUSTOM_ID\\:.*\\)"
+           "\\(\n.*\\:END\\:.*\\)"
            ;; Hide TOC-ORG tag and spaces before it.
            ;; Use modified `toc-org-toc-org-regexp' because
            ;; the original one matches whole string.


### PR DESCRIPTION
Hide `PROPERTIES` drawers in space-doc-mode to allow the use of `CUSTOM_ID` tags in documentation for correct link exporting, as discussed in #8054, #8136 and #8138. Complementary the latter two PR:s.