### PR TITLE
throw a real error if emacs version is too old

### DIFF
--- a/init.el
+++ b/init.el
@@ -20,9 +20,9 @@
 (defconst spacemacs-emacs-min-version   "24.4" "Minimal version of Emacs.")
 
 (if (not (version<= spacemacs-emacs-min-version emacs-version))
-    (message (concat "Your version of Emacs (%s) is too old. "
-                     "Spacemacs requires Emacs version %s or above.")
-             emacs-version spacemacs-emacs-min-version)
+    (error (concat "Your version of Emacs (%s) is too old. "
+                   "Spacemacs requires Emacs version %s or above.")
+           emacs-version spacemacs-emacs-min-version)
   (load-file (concat (file-name-directory load-file-name)
                      "core/core-load-paths.el"))
   (require 'core-spacemacs)


### PR DESCRIPTION
Many people (including me) were confused when trying to install Spacemacs on an outdated Emacs. A message was issued, but honestly nobody thinks of going to see the `*Messages*` buffer when a perfeclty normal vanilla Emacs starts up, especially not beginners.

This way, an error is visible and users can take corrective actions.

One more thing: I changed the concatenated string to a normal full string even if it makes it > 80 cols, as cutting it prevents it from being searched in the code base. This is a recommendation of the Linux Kernel coding style (line 86) to never break user-visible strings, which makes a lot of sense to me.