### PR TITLE
fix ranger with golden-ratio activated

### DIFF
--- a/layers/+tools/ranger/packages.el
+++ b/layers/+tools/ranger/packages.el
@@ -13,6 +13,7 @@
 (setq ranger-packages
       '(
         (dired :location built-in)
+        golden-ratio
         ranger
         ))
 
@@ -42,3 +43,7 @@
   (spacemacs|use-package-add-hook ranger
     :post-init (when ranger-override-dired
                  (add-hook 'dired-mode-hook #'ranger-override-dired-fn))))
+
+(defun ranger/post-init-golden-ratio ()
+  (with-eval-after-load 'golden-ratio
+    (add-to-list 'golden-ratio-exclude-modes "ranger-mode")))


### PR DESCRIPTION
A user in the gitter chat pointed out that `ranger` was not working correctly along with `golden-ratio`.

After some investigations, we came up with that fix :smile_cat: 