### PR TITLE
transient-state: Improve handling of additional bindings

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -45,11 +45,11 @@
     ;; add some functions to ahs transient states
     (setq spacemacs--symbol-highlight-transient-state-doc
           (concat spacemacs--symbol-highlight-transient-state-doc
-                  "  [_b_] search buffers [_/_] search proj [_f_] search files")
-     spacemacs-symbol-highlight-transient-state-add-bindings
-     '(("/" spacemacs/helm-project-smart-do-search-region-or-symbol :exit t)
-       ("b" spacemacs/helm-buffers-smart-do-search-region-or-symbol :exit t)
-       ("f" spacemacs/helm-files-smart-do-search-region-or-symbol :exit t)))))
+                  "  [_b_] search buffers [_/_] search proj [_f_] search files"))
+    (spacemacs/transient-state-register-add-bindings "symbol-highlight"
+      '(("/" spacemacs/helm-project-smart-do-search-region-or-symbol :exit t)
+        ("b" spacemacs/helm-buffers-smart-do-search-region-or-symbol :exit t)
+        ("f" spacemacs/helm-files-smart-do-search-region-or-symbol :exit t)))))
 
 (defun helm/post-init-bookmark ()
   (spacemacs/set-leader-keys "fb" 'helm-filtered-bookmarks))
@@ -641,6 +641,6 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
   (setq projectile-completion-system 'helm))
 
 (defun helm/post-init-persp-mode ()
-   (setq spacemacs-layouts-transient-state-add-bindings
-           '(("b" spacemacs/persp-helm-mini :exit t)
-             ("l" spacemacs/helm-perspectives :exit t))))
+  (spacemacs/transient-state-register-add-bindings "layouts"
+    '(("b" spacemacs/persp-helm-mini :exit t)
+      ("l" spacemacs/helm-perspectives :exit t))))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -195,13 +195,13 @@
    'spacemacs/ivy-spacemacs-layouts
    '(("c" persp-kill-without-buffers "Close layout(s)")
      ("k" persp-kill  "Kill layout(s)")))
-  (setq spacemacs-layouts-transient-state-remove-bindings
-        '("C" "X"))
-  (setq spacemacs-layouts-transient-state-add-bindings
-        '(("b" spacemacs/ivy-spacemacs-layout-buffer :exit t)
-          ("l" spacemacs/ivy-spacemacs-layouts :exit t)
-          ("C" spacemacs/ivy-spacemacs-layout-close-other :exit t)
-          ("X" spacemacs/ivy-spacemacs-layout-kill-other :exit t))))
+  (spacemacs/transient-state-register-remove-bindings "layouts"
+    '("C" "X"))
+  (spacemacs/transient-state-register-add-bindings "layouts"
+    '(("b" spacemacs/ivy-spacemacs-layout-buffer :exit t)
+      ("l" spacemacs/ivy-spacemacs-layouts :exit t)
+      ("C" spacemacs/ivy-spacemacs-layout-close-other :exit t)
+      ("X" spacemacs/ivy-spacemacs-layout-kill-other :exit t))))
 
 (defun ivy/post-init-projectile ()
   (setq projectile-completion-system 'ivy)

--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -62,8 +62,8 @@
     :defer t
     :init
     (progn
-      (setq spacemacs-window-manipulation-transient-state-add-bindings
-            '(("g" spacemacs/toggle-golden-ratio)))
+      (spacemacs/transient-state-register-add-bindings "window-manipulation"
+        '(("g" spacemacs/toggle-golden-ratio)))
       (spacemacs|add-toggle golden-ratio
         :status golden-ratio-mode
         :on (golden-ratio-mode) (golden-ratio)


### PR DESCRIPTION
Add two new functions: `spacemacs/transient-state-register-add-bindings`
and `spacemacs/transient-state-register-remove-bindings` to prevent layer authors and end users from dealing with the underlying variables' subtleties.

Background

`spacemacs-%s-transient-state-add-bindings` and
`spacemacs-%s-transient-state-remove-bindings` are special variables that allow
to hook into transient state creation process to add or remove some bindings
before a Hydra is created. The problem is that these variables are not
existing by default and expected to be created on demand by the external code.

Currently layers that use this feature, set the variables directly with `setq`.
This works OK until some other layer wants to register its own additional bindings
for the same transient state. Obviously, depending on the load order, the last
layer's `setq` will win, while other layer's changes will be lost. In fact,
it has [happend](https://xkcd.com/1172/) to me with b515253026998ebbea83df6cb825108e3c788623, since one of my private layers also modified `spacemacs-layouts-transient-state-add-bindings`.

For a while I used the following ugly hack in `helm/packages.el`:
```emacs-lisp
 (defun helm/post-init-persp-mode ()
   (or (boundp 'spacemacs-layouts-transient-state-add-bindings)
       (setq spacemacs-layouts-transient-state-add-bindings '()))
   (dolist (binding '(("b" spacemacs/persp-helm-mini :exit t)
                      ("l" spacemacs/helm-perspectives :exit t)))
     (push binding spacemacs-layouts-transient-state-add-bindings)))
```
Finally, found some time to properly address the issue. So here is the PR.