### PR TITLE
Fix number of arguments in calling cider-test- funcs

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -124,19 +124,19 @@ the focus."
   "Run loaded tests."
   (interactive)
   (cider-load-buffer)
-  (cider-test-run-loaded-tests nil))
+  (cider-test-run-loaded-tests))
 
 (defun spacemacs/cider-test-run-project-tests ()
   "Run project tests."
   (interactive)
   (cider-load-buffer)
-  (cider-test-run-project-tests nil))
+  (cider-test-run-project-tests))
 
-(defun spacemacs/cider-test-rerun-tests ()
-  "Run previous tests again."
+(defun spacemacs/cider-test-rerun-failed-tests ()
+  "Rerun failed tests."
   (interactive)
   (cider-load-buffer)
-  (cider-test-rerun-tests))
+  (cider-test-rerun-failed-tests))
 
 (defun spacemacs/cider-display-error-buffer (&optional arg)
   "Displays the *cider-error* buffer in the current window.

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -165,7 +165,7 @@
           "tl" 'spacemacs/cider-test-run-loaded-tests
           "tp" 'spacemacs/cider-test-run-project-tests
           "tn" 'spacemacs/cider-test-run-ns-tests
-          "tr" 'spacemacs/cider-test-rerun-tests
+          "tr" 'spacemacs/cider-test-rerun-failed-tests
           "tt" 'spacemacs/cider-test-run-focused-test
 
           "db" 'cider-debug-defun-at-point


### PR DESCRIPTION
Fix wrong number of arguments while calling some `cider-test-` functions in **clojure** layer.
Change missing function `cider-test-rerun-tests` to `cider-test-rerun-failed-tests`.