### PR TITLE
Turn on auto parens in web mode

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -164,9 +164,7 @@
    (if dotspacemacs-smartparens-strict-mode
        'smartparens-strict-mode
      'smartparens-mode)
-   '(css-mode-hook scss-mode-hook sass-mode-hook less-css-mode-hook))
-
-  (add-hook 'web-mode-hook 'spacemacs/toggle-smartparens-off))
+   '(css-mode-hook scss-mode-hook sass-mode-hook less-css-mode-hook)))
 
 (defun html/init-tagedit ()
   (use-package tagedit


### PR DESCRIPTION
I realised this feature was turned off while writing `.vue` files. Using the web-mode is the (currently) best mode to work and since you write a lot of script, having the smartparens makes it much better:
![web-mode-smartparens](https://cloud.githubusercontent.com/assets/664177/21962802/b8d3ad10-db2e-11e6-8e7e-f437e035ec06.gif)
