### PR TITLE
GO: Improve go test output buffer behavior.

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -98,6 +98,10 @@ function testing to work.
 the coverage buffer. See [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Choosing-Window.html][=display-buffer=]] for a list of possible functions.
 The default value is =display-buffer-reuse-window=.
 
+Tests are run in a compilation buffer displayed in a popup window that can be
+closed by pressing ~C-g~ from any other window. The variable
+=go-test-buffer-name= can be customized to set the output buffer name.
+
 ** Guru
 
 Go Oracle has been deprecated as of October 1, 2016, it's replacement is =go-guru=.

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -21,3 +21,6 @@
 
 (defvar go-use-gometalinter nil
   "Use gometalinter if the variable has non-nil value.")
+
+(defvar go-test-buffer-name "*go test*"
+  "Name of the buffer for go test output. Default is *go test*.")

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -11,8 +11,13 @@
         go-mode
         go-guru
         (go-rename :location local)
+        popwin
         ))
 
+
+(defun go/post-init-popwin ()
+  (push (cons go-test-buffer-name '(:dedicated t :position bottom :stick t :noselect t :height 0.4))
+        popwin:special-display-config))
 
 (defun go/init-company-go ()
   (use-package company-go
@@ -46,8 +51,7 @@
 
       (defun spacemacs/go-run-tests (args)
         (interactive)
-        (save-selected-window
-          (async-shell-command (concat "go test " args))))
+        (compilation-start (concat "go test " args) nil (lambda (n) go-test-buffer-name) nil))
 
       (defun spacemacs/go-run-package-tests ()
         (interactive)


### PR DESCRIPTION
The current implementation  runs tests in an async shell window. If any errors occur or any source file is otherwise referenced in the output, the user has to manually load the file/goto line. 

- Use compilation-start to get highlighting of compilation or runtime errors.
- Configure output window in popwin and window-purpose.
- Configurable buffer name.

Now <kbd>C</kbd>-<kbd>g</kbd> closes the output window, <kbd>C</kbd>-<kbd>x</kbd> <kbd>`</kbd> jumps to the first error. This will also be very handy for people who do not use flycheck.