### PR TITLE
Fix 'o' on folded headings

### DIFF
--- a/layers/+emacs/org/local/evil-org/evil-org.el
+++ b/layers/+emacs/org/local/evil-org/evil-org.el
@@ -53,7 +53,7 @@
 (defun evil-org-eol-call (fun)
   "Go to end of line and call provided function.
 FUN function callback"
-  (end-of-line)
+  (end-of-visible-line)
   (funcall fun)
   (evil-append nil)
   )


### PR DESCRIPTION
This fixes an issue when using 'o' on folded sections in org-mode.