### PR TITLE
Reliable call to `ipython --version`

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -28,7 +28,7 @@
 (defun spacemacs/python-setup-shell (&rest args)
   (if (spacemacs/pyenv-executable-find "ipython")
       (progn (setq python-shell-interpreter "ipython")
-             (if (version< (replace-regexp-in-string "\n$" "" (shell-command-to-string "ipython --version")) "5")
+             (if (version< (replace-regexp-in-string "\n$" "" (shell-command-to-string "unset TERM; ipython --version")) "5")
                  (setq python-shell-interpreter-args "-i")
                (setq python-shell-interpreter-args "--simple-prompt -i")))
     (progn


### PR DESCRIPTION
Problem: `ipython --version` returns a bogus escape character `ESC[?1034h`

This is due to the following behaviour of the readline library:
http://stackoverflow.com/q/15760712
The solution: unset the `TERM` shell variable before calling `ipython --version`
