### PR TITLE
Defer loading of theme changer to work around #7563

### DIFF
--- a/layers/+tools/geolocation/packages.el
+++ b/layers/+tools/geolocation/packages.el
@@ -105,6 +105,7 @@ to not have to set these variables manually when enabling this layer."
   "Initialize theme-changer"
   (use-package theme-changer
     :if geolocation-enable-automatic-theme-changer
+    :defer 1
     :config
     (progn
       (when (> (length dotspacemacs-themes) 1)


### PR DESCRIPTION
Add `:defer 1` to `use-package` declaration for the geolocation theme changer to work around issue #7563.