### PR TITLE
Change the frame-killer mapping to `SPC q f`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3193,7 +3193,7 @@ server is to use the following bindings:
 | ~SPC q Q~  | Quit Emacs and kill the server, lose all unsaved changes.                |
 | ~SPC q r~  | Restart both Emacs and the server, prompting to save any changed buffers |
 | ~SPC q s~  | Save the buffers, quit Emacs and kill the server                         |
-| ~SPC q z~  | Kill the current frame                                                   |
+| ~SPC q f~  | Kill the current frame                                                   |
 
 ** Troubleshoot
 *** Loading fails

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -348,7 +348,7 @@
   "qs" 'spacemacs/save-buffers-kill-emacs
   "qq" 'spacemacs/prompt-kill-emacs
   "qQ" 'spacemacs/kill-emacs
-  "qz" 'spacemacs/frame-killer)
+  "qf" 'spacemacs/frame-killer)
 ;; window ---------------------------------------------------------------------
 (defun split-window-below-and-focus ()
   "Split the window vertically and focus the new window."


### PR DESCRIPTION
It was `SPC q z` but:

1. 'z' is not a mnemonic for "frame" (although it may be more familiar to vim users).
2. More importantly, it's *really hard* to type 'qz' on a qwerty keyboard.