### PR TITLE
Clojure refactor: replace cycle coll with convert to coll

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -216,7 +216,11 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m r a p~ | add project dependency      |
 | ~SPC m r a r~ | add require to ns           |
 | ~SPC m r a u~ | add use to ns               |
-| ~SPC m r c c~ | cycle coll                  |
+| ~SPC m r c (~ | convert coll to list        |
+| ~SPC m r c '~ | convert coll to quoted list |
+| ~SPC m r c {~ | convert coll to map         |
+| ~SPC m r c #~ | convert coll to set         |
+| ~SPC m r c [~ | convert coll to vector      |
 | ~SPC m r c i~ | cycle if                    |
 | ~SPC m r c n~ | clean ns                    |
 | ~SPC m r c p~ | cycle privacy               |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -170,7 +170,14 @@
 
           "db" 'cider-debug-defun-at-point
           "de" 'spacemacs/cider-display-error-buffer
-          "di" 'cider-inspect))
+          "di" 'cider-inspect
+
+          ;; refactorings from clojure-mode
+          "rc{" 'clojure-convert-collection-to-map
+          "rc(" 'clojure-convert-collection-to-list
+          "rc'" 'clojure-convert-collection-to-quoted-list
+          "rc#" 'clojure-convert-collection-to-set
+          "rc[" 'clojure-convert-collection-to-vector))
 
       ;; cider-repl-mode only
       (spacemacs/set-leader-keys-for-major-mode 'cider-repl-mode
@@ -206,7 +213,7 @@
       (setq clj-refactor--key-binding-prefixes
             '(("mr" . "refactor")
               ("mra" . "add")
-              ("mrc" . "cycle/clean")
+              ("mrc" . "cycle/clean/convert")
               ("mrd" . "destructure")
               ("mre" . "extract/expand")
               ("mrf" . "find/function")


### PR DESCRIPTION
Cycle collection type was recently removed from `clj-refactor` as the
feature was migrated and rewritten in `clojure-mode`. The new feature
lets the user convert a collection into a specific collection type
instead of cycling through them.

To added shortcuts correspond to the shortcuts of this feature in
`clojure-mode` and placed in the refactor submenu.

