### PR TITLE
Update steps for "Replacing text in several files"

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2852,10 +2852,14 @@ in several files can be performed via [[https://github.com/syohex/emacs-helm-ag]
 Say you want to replace all =foo= occurrences by =bar= in your current
 project:
   - initiate a search with ~SPC /~
-  - enter in edit mode with ~C-c C-e~
+  - show helm actions list with ~C-z~
+  - enter in edit mode by selecting ~[f4] Edit search results~
   - go to the occurrence and enter in =iedit state= with ~SPC s e~
   - edit the occurrences then leave the =iedit state=
   - press ~C-c C-c~
+
+*Note*: In older versions of helm, you might instead use ~C-c C-e~
+instead of ~C-z~ and selecting ~[f4] Edit search results~ after initiating a search.
 
 *Note*: In Spacemacs, =helm-ag= despite its name works with =rg=, =pt= and =ack=
 as well (but not with =grep=).

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2858,7 +2858,7 @@ project:
   - edit the occurrences then leave the =iedit state=
   - press ~C-c C-c~
 
-*Note*: In older versions of helm, you might instead use ~C-c C-e~
+*Note*: In older versions of helm, you might use ~C-c C-e~
 instead of ~C-z~ and selecting ~[f4] Edit search results~ after initiating a search.
 
 *Note*: In Spacemacs, =helm-ag= despite its name works with =rg=, =pt= and =ack=


### PR DESCRIPTION
In the current latest stable version of helm (2.5.0), steps for "Replacing text in several files" don't work. This updates the documentation and also adds a note about doing the same thing on older version of helm.

https://github.com/syl20bnr/spacemacs/issues/8246
