### PR TITLE
`.python-version` can contain more than one version specified.

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -75,8 +75,9 @@
              (version
               (with-temp-buffer
                 (insert-file-contents-literally file-path)
-                (buffer-substring-no-properties (line-beginning-position)
-                                                (line-end-position)))))
+                (nth 0 (split-string (buffer-substring-no-properties
+                                       (line-beginning-position)
+                                       (line-end-position)))))))
         (if (member version (pyenv-mode-versions))
             (pyenv-mode-set version)
           (message "pyenv: version `%s' is not installed (set by %s)"


### PR DESCRIPTION
https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-local-advanced

This assures that we only take into account the first one.