### PR TITLE
ui-visual: improve colorization of compilation buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-visual/funcs.el
@@ -14,7 +14,8 @@
 
 (defun spacemacs-visual//compilation-buffer-apply-ansi-colors ()
   (let ((inhibit-read-only t))
-    (ansi-color-apply-on-region compilation-filter-start (point-max))))
+    (goto-char compilation-filter-start)
+    (ansi-color-apply-on-region (line-beginning-position) (point-max))))
 
 
 ;; popwin


### PR DESCRIPTION
Lines containing a carriage return alone, followed by color escape sequences, are not colorized properly.

A carriage return in the compilation buffer is interpreted by erasing contents since the beginning of the line, but `compilation-filter-start` is not updated accordingly before calling the filter-hooks.

Workaround it by always colorizing a region from to the beginning of the line where `compilation-filter-start` points.