### PR TITLE
Revert "Make pylookup.py compatible with Python 2 and 3"

### DIFF
--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Pylookup is to lookup entries from python documentation, especially within
@@ -224,8 +224,8 @@ def update(db, urls, append=False):
             success = False
             for index_url in potential_urls:
                 try:
-                    print("Wait for a few seconds...")
-                    print("Fetching index from '%s'" % index_url)
+                    print "Wait for a few seconds..."
+                    print "Fetching index from '%s'" % index_url
 
                     index = urllib.urlopen(index_url).read()
                     if not issubclass(type(index), str):
@@ -236,14 +236,14 @@ def update(db, urls, append=False):
                         parser.feed(index)
 
                     # success, we don't need to try other potential urls
-                    print("Loaded index from '%s'" % index_url)
+                    print "Loaded index from '%s'" % index_url
                     success = True
                     break
                 except IOError:
-                    print("Error: fetching file from '%s'" % index_url)
+                    print "Error: fetching file from '%s'" % index_url
 
             if not success:
-                print("Failed to load index for input '%s'" % url)
+                print "Failed to load index for input '%s'" % url
 
 
 def lookup(db, key, format_spec, out=sys.stdout, insensitive=True, desc=True):


### PR DESCRIPTION
This reverts commit 9d1b5745541df5ac38d700d0032ba3828cb55cf1.

This commit was apparently not tested with Python 3, since it breaks pylookup entirely when "python" is linked to "python3" instead of "python2". Making it work with Python 3 would require a rewrite of the HTML parsing code, since html.parser in Python 3 handles tags and data differently than htmllib in Python 2. For now, we should just stick to Python 2.