### PR TITLE
Update bitbucket evil urls to github evil urls

### DIFF
--- a/layers/+distributions/spacemacs-base/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distributions/spacemacs-base/local/hybrid-mode/hybrid-mode.el
@@ -112,7 +112,7 @@ behavior (for instance it support C-r pasting)."
 
 ;; This code is from evil insert state definition, any change upstream
 ;; should be reflected here
-;; see https://bitbucket.org/lyro/evil/src/a25b848c90c7942fe89d9ec283c6bb44fb7b3cf4/evil-states.el?fileviewer=file-view-default#evil-states.el-74
+;; see https://github.com/emacs-evil/evil/blob/56e92f7cb4e04e665670460093b41f58446b7a2b/evil-states.el#L108
 (evil-define-state hybrid
   "Hybrid state for hybrid mode."
   :tag " <H> "

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -53,7 +53,7 @@
         "t" 'ledger-reconcile-change-target
         "RET" 'ledger-reconcile-finish)
       ;; temporary hack to work-around an issue with evil-define-key
-      ;; more info: https://bitbucket.org/lyro/evil/issues/301/evil-define-key-for-minor-mode-does-not
+      ;; more info: https://github.com/emacs-evil/evil/issues/301
       ;; TODO remove this hack if the limitation is removed upstream
       (add-hook 'ledger-mode-hook 'evil-normalize-keymaps)
       (evilified-state-evilify ledger-report-mode ledger-report-mode-map))))


### PR DESCRIPTION
The issues section in the bitbucket evil repository seems to have been
removed when the evil package was migrated to github.

That caused both bitbucket issue urls to redirect to the bitbucket
sign up page.

This changes the urls to the equivalent issues on github.

And the bitbucket url to the file evil-states.el is eventually going to
become outdated, so it was also updated to link to the github version.

Resolves #8273