### PR TITLE
haskell: disable electric indent for cabal-mode

### DIFF
--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -81,6 +81,12 @@
   (evil-define-key '(insert normal) intero-mode-map
     (kbd "M-.") 'intero-goto-definition))
 
+(defun spacemacs-haskell//disable-electric-indent ()
+  "Disable electric indent mode if available"
+  ;; use only internal indentation system from haskell
+  (if (fboundp 'electric-indent-local-mode)
+      (electric-indent-local-mode -1)))
+
 
 ;; Intero functions
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -92,6 +92,11 @@
       (add-hook 'haskell-cabal-mode-hook
                 'spacemacs//force-haskell-mode-loading)
 
+      ;; Haskell cabal files interact badly with electric-indent-mode
+      ;; note: we cannot add this hook in :config, since haskell-mode might
+      ;; only be loaded after cabal-mode hooks are already run (see add-hook above)
+      (add-hook 'haskell-cabal-mode-hook #'spacemacs-haskell//disable-electric-indent)
+
       (setq
        ;; Use notify.el (if you have it installed) at the end of running
        ;; Cabal commands or generally things worth notifying.
@@ -106,11 +111,8 @@
        haskell-stylish-on-save nil))
     :config
     (progn
-      ;; Haskell main editing mode key bindings.
       (defun spacemacs/init-haskell-mode ()
-        ;; use only internal indentation system from haskell
-        (if (fboundp 'electric-indent-local-mode)
-            (electric-indent-local-mode -1)))
+        (spacemacs-haskell//disable-electric-indent))
 
       (defun spacemacs/haskell-interactive-bring ()
         "Bring up the interactive mode for this session without


### PR DESCRIPTION
Electric-indent mode in cabal-mode is annoying, as it messes up existing indentation.
For example, if you have:

```
  build-depends:
    base,
    foo,|
```

And press enter, then that ends up as:

```
  build-depends:
    base,
                 foo
                 |
```

(`|` is cursor)

This PR fixes that issue.