### PR TITLE
mu4e-compose: add some convenient major mode bindings

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -55,8 +55,9 @@
         "," 'message-send-and-exit
         "c" 'message-send-and-exit
         "k" 'message-kill-buffer
+        "a" 'message-kill-buffer
         "s" 'message-dont-send         ; saves as draft
-        "a" 'mml-attach-file)
+        "f" 'mml-attach-file)
 
       (setq mu4e-completing-read-function 'completing-read)
 

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -51,6 +51,13 @@
                    (interactive)
                     (mu4e-view-mark-thread '(read))))
 
+      (spacemacs/set-leader-keys-for-major-mode 'mu4e-compose-mode
+        "," 'message-send-and-exit
+        "c" 'message-send-and-exit
+        "k" 'message-kill-buffer
+        "s" 'message-dont-send         ; saves as draft
+        "a" 'mml-attach-file)
+
       (setq mu4e-completing-read-function 'completing-read)
 
       (add-to-list 'mu4e-view-actions


### PR DESCRIPTION
I'm missing some nice shortcuts for sending mail, attaching files etc. These bindings are similar to that of magit. Open to further discussion