### PR TITLE
grammar fix in core-configuration-layer.el introduced by a85634c.

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1980,7 +1980,7 @@ depends on it."
     ;; (message "orphans: %s" orphans)
     (if orphans
         (progn
-          (spacemacs-buffer/set-mode-line "Uninstalling not used packages...")
+          (spacemacs-buffer/set-mode-line "Uninstalling unused packages...")
           (spacemacs//redisplay)
           (spacemacs-buffer/append
            (format "Found %s orphan package(s) to delete...\n"


### PR DESCRIPTION
The grammar wasn't correct here -- so this fixes it. This was introduced in a85634cd5.