### PR TITLE
Fixes attempt to use non-existent function

### DIFF
--- a/layers/+lang/go/local/go-rename/go-rename.el
+++ b/layers/+lang/go/local/go-rename/go-rename.el
@@ -37,7 +37,7 @@ the `gorename' tool."
                                   (string= (file-name-extension (buffer-file-name)) ".go"))))
   (let* ((posflag (format "-offset=%s:#%d"
                           (expand-file-name buffer-file-truename)
-                          (1- (go--position-bytes (point)))))
+                          (1- (position-bytes (point)))))
          (env-vars (go-root-and-paths))
          (goroot-env (concat "GOROOT=" (car env-vars)))
          (gopath-env (concat "GOPATH=" (mapconcat #'identity (cdr env-vars) ":")))


### PR DESCRIPTION
Since https://github.com/dominikh/go-mode.el/commit/d13feb239b13b910ec4db19356f34c3801299407, `go--position-bytes` no longer exists.