### PR TITLE
fix evil-search enabling in evil-state (c7e47de)

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -41,9 +41,10 @@
     :override-mode-name spacemacs-leader-override-mode))
 
 (defun spacemacs-bootstrap/init-evil ()
-  ;; ensure that the search module is set at startup
-  (spacemacs/set-evil-search-module dotspacemacs-editing-style)
-  (add-hook 'spacemacs-editing-style-hook 'spacemacs/set-evil-search-module)
+  (with-eval-after-load 'hybrid-mode
+    ;; ensure that the search module is set at startup
+    (spacemacs/set-evil-search-module dotspacemacs-editing-style)
+    (add-hook 'spacemacs-editing-style-hook 'spacemacs/set-evil-search-module))
 
   ;; evil-mode is mandatory for Spacemacs to work properly
   ;; evil must be require explicitly, the autoload seems to not


### PR DESCRIPTION
There was an error at startup saying that hybrid-mode-use-evil-search-module was
void as a variable, apparently brought by c7e47de.
