### PR TITLE
Org layer: Bind org-update-statistics-cookies

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -246,6 +246,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "-" 'org-ctrl-c-minus
         "^" 'org-sort
         "/" 'org-sparse-tree
+        "#" 'org-update-statistics-cookies
         "I" 'org-clock-in
         ;; insertion
         "ia" 'org-attach


### PR DESCRIPTION
Add a binding for `org-update-statistics-cookies` as `, #`, which mimics the original `C-c #` binding.