### PR TITLE
remove reference to fixed bug

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -223,8 +223,7 @@ filename, todos will be stored in each project root.
 #+END_SRC
 
 The TODO files are not added to the agenda automatically. You can do this with
-the following snippet. Note that this may have unintended consequences until
-[[https://github.com/IvanMalison/org-projectile/issues/10][this bug]] is fixed.
+the following snippet.
 
 #+BEGIN_SRC emacs-lisp
   (with-eval-after-load 'org-agenda


### PR DESCRIPTION
According to org-projectile's repo, this bug has been fixed:

https://github.com/IvanMalison/org-projectile/issues/10

Recommending the reference be removed from the documentation.