### PR TITLE
Call tsfmt with extension of current buffer for TSX formatting

### DIFF
--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -13,7 +13,8 @@
   "Format buffer with tsfmt."
   (interactive)
   (if (executable-find "tsfmt")
-      (let*  ((tmpfile (make-temp-file "~fmt-tmp" nil ".ts"))
+      (let*  ((extension (file-name-extension (or buffer-file-name "tmp.ts") t))
+              (tmpfile (make-temp-file "~fmt-tmp" nil extension))
               (coding-system-for-read 'utf-8)
               (coding-system-for-write 'utf-8)
               (outputbuf (get-buffer-create "*~fmt-tmp.ts*")))


### PR DESCRIPTION
Addresses #8297 for the tsfmt backend. However, does not fix tide issue, and automatic major mode formatting (`SPC m =`) does not work in TSX files as they are opened in web mode.