### PR TITLE
compilation-finish-function: Set case-fold-search to nil

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -907,17 +907,18 @@ A non-nil argument sorts in reverse order."
 (setq compilation-finish-function
       (lambda (buf str)
 
-        (if (or (string-match "exited abnormally" str)
-                (string-match "FAILED" (buffer-string)))
+        (let ((case-fold-search nil))
+          (if (or (string-match "exited abnormally" str)
+                  (string-match "FAILED" (buffer-string)))
 
-            ;; there were errors
-            (message "There were errors. SPC-e-n to visit.")
-          (unless (or (string-match "Grep finished" (buffer-string))
-                      (string-match "Ag finished" (buffer-string))
-                      (string-match "nosetests" (buffer-name)))
+              ;; there were errors
+              (message "There were errors. SPC-e-n to visit.")
+            (unless (or (string-match "Grep finished" (buffer-string))
+                        (string-match "Ag finished" (buffer-string))
+                        (string-match "nosetests" (buffer-name)))
 
-            ;; no errors
-            (message "compilation ok.")))))
+              ;; no errors
+              (message "compilation ok."))))))
 
 ;; from http://www.emacswiki.org/emacs/WordCount
 (defun spacemacs/count-words-analysis (start end)


### PR DESCRIPTION
The various string-match calls in this function were obviosly written with that
in mind.

This also fixes the case where the compilation buffer contains the output of
`cargo test`, which includes "0 failed". Previously, this was treated as an
error, now it's not.