### PR TITLE
Fixes keybindings for gfm-mode

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -81,64 +81,65 @@ Will work on both org-mode and any mode that accepts plain html."
                         ("mx" . "markdown/text")))
         (spacemacs/declare-prefix-for-mode
          'markdown-mode (car prefix) (cdr prefix)))
-      (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-        ;; Movement
-        "{"   'markdown-backward-paragraph
-        "}"   'markdown-forward-paragraph
-        ;; Completion, and Cycling
-        "]"   'markdown-complete
-        ;; Indentation
-        ">"   'markdown-indent-region
-        "<"   'markdown-exdent-region
-        ;; Buffer-wide commands
-        "c]"  'markdown-complete-buffer
-        "cc"  'markdown-check-refs
-        "ce"  'markdown-export
-        "cm"  'markdown-other-window
-        "cn"  'markdown-cleanup-list-numbers
-        "co"  'markdown-open
-        "cp"  'markdown-preview
-        "cv"  'markdown-export-and-preview
-        "cw"  'markdown-kill-ring-save
-        ;; headings
-        "hi"  'markdown-insert-header-dwim
-        "hI"  'markdown-insert-header-setext-dwim
-        "h1"  'markdown-insert-header-atx-1
-        "h2"  'markdown-insert-header-atx-2
-        "h3"  'markdown-insert-header-atx-3
-        "h4"  'markdown-insert-header-atx-4
-        "h5"  'markdown-insert-header-atx-5
-        "h6"  'markdown-insert-header-atx-6
-        "h!"  'markdown-insert-header-setext-1
-        "h@"  'markdown-insert-header-setext-2
-        ;; Insertion of common elements
-        "-"   'markdown-insert-hr
-        "if"  'markdown-insert-footnote
-        "ii"  'markdown-insert-image
-        "ik"  'spacemacs/insert-keybinding-markdown
-        "iI"  'markdown-insert-reference-image
-        "il"  'markdown-insert-link
-        "iL"  'markdown-insert-reference-link-dwim
-        "iw"  'markdown-insert-wiki-link
-        "iu"  'markdown-insert-uri
-        ;; Element removal
-        "k"   'markdown-kill-thing-at-point
-        ;; List editing
-        "li"  'markdown-insert-list-item
-        ;; region manipulation
-        "xb"  'markdown-insert-bold
-        "xi"  'markdown-insert-italic
-        "xc"  'markdown-insert-code
-        "xC"  'markdown-insert-gfm-code-block
-        "xq"  'markdown-insert-blockquote
-        "xQ"  'markdown-blockquote-region
-        "xp"  'markdown-insert-pre
-        "xP"  'markdown-pre-region
-        ;; Following and Jumping
-        "N"   'markdown-next-link
-        "f"   'markdown-follow-thing-at-point
-        "P"   'markdown-previous-link
-        "<RET>" 'markdown-jump)
+      (dolist (mode '(markdown-mode gfm-mode))
+        (spacemacs/set-leader-keys-for-major-mode mode
+          ;; Movement
+          "{"   'markdown-backward-paragraph
+          "}"   'markdown-forward-paragraph
+          ;; Completion, and Cycling
+          "]"   'markdown-complete
+          ;; Indentation
+          ">"   'markdown-indent-region
+          "<"   'markdown-exdent-region
+          ;; Buffer-wide commands
+          "c]"  'markdown-complete-buffer
+          "cc"  'markdown-check-refs
+          "ce"  'markdown-export
+          "cm"  'markdown-other-window
+          "cn"  'markdown-cleanup-list-numbers
+          "co"  'markdown-open
+          "cp"  'markdown-preview
+          "cv"  'markdown-export-and-preview
+          "cw"  'markdown-kill-ring-save
+          ;; headings
+          "hi"  'markdown-insert-header-dwim
+          "hI"  'markdown-insert-header-setext-dwim
+          "h1"  'markdown-insert-header-atx-1
+          "h2"  'markdown-insert-header-atx-2
+          "h3"  'markdown-insert-header-atx-3
+          "h4"  'markdown-insert-header-atx-4
+          "h5"  'markdown-insert-header-atx-5
+          "h6"  'markdown-insert-header-atx-6
+          "h!"  'markdown-insert-header-setext-1
+          "h@"  'markdown-insert-header-setext-2
+          ;; Insertion of common elements
+          "-"   'markdown-insert-hr
+          "if"  'markdown-insert-footnote
+          "ii"  'markdown-insert-image
+          "ik"  'spacemacs/insert-keybinding-markdown
+          "iI"  'markdown-insert-reference-image
+          "il"  'markdown-insert-link
+          "iL"  'markdown-insert-reference-link-dwim
+          "iw"  'markdown-insert-wiki-link
+          "iu"  'markdown-insert-uri
+          ;; Element removal
+          "k"   'markdown-kill-thing-at-point
+          ;; List editing
+          "li"  'markdown-insert-list-item
+          ;; region manipulation
+          "xb"  'markdown-insert-bold
+          "xi"  'markdown-insert-italic
+          "xc"  'markdown-insert-code
+          "xC"  'markdown-insert-gfm-code-block
+          "xq"  'markdown-insert-blockquote
+          "xQ"  'markdown-blockquote-region
+          "xp"  'markdown-insert-pre
+          "xP"  'markdown-pre-region
+          ;; Following and Jumping
+          "N"   'markdown-next-link
+          "f"   'markdown-follow-thing-at-point
+          "P"   'markdown-previous-link
+          "<RET>" 'markdown-jump))
       (when (eq 'eww markdown-live-preview-engine)
         (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
           "cP"  'markdown-live-preview-mode))


### PR DESCRIPTION
Markdown mode is actually made of two modes:
* `markdown-mode` for the canonical markdown
* `gfm-mode` for github flavoured markdown

This PR enables some of the keybindings available inside `markdown-mode` for the `gfm-mode` as well.

The way I enable `gfm-mode` is by adding this line inside my `dotspacemacs/user-config`
```emacs-lisp
(add-to-list 'auto-mode-alist '("\\.md\\'" . gfm-mode))
```

(Maybe I should create a PR to document this in the layer's Readme?)

There is a lot more configuration going on there that maybe should be enabled for `gfm-mode` as well but since I am a lisp beginner I am not sure of the consequences. Maybe someone with a bit more experience can take a look?

In the meantime, it does not hurt to port functionality to `gfm-mode` bit by bit.

Note that this will conflict with #2160 that extracts the keybinding in a function.
