### PR TITLE
Keybindings for alchemist-phoenix

### DIFF
--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -14,6 +14,7 @@
    - [[#help][Help]]
    - [[#mix][Mix]]
    - [[#project][Project]]
+   - [[#alchemist-phoenix][Alchemist Phoenix]]
    - [[#evaluation-in-place][Evaluation in place]]
    - [[#repl-interactions][REPL interactions]]
    - [[#tests][Tests]]
@@ -128,6 +129,20 @@ You find and overview of all the key-bindings on the [[file:alchemist-refcard.pd
 | ~SPC m p t~ | Open project test directory and list all test files.       |
 | ~SPC m g t~ | Toggle between a file and its tests in the current window. |
 | ~SPC m g T~ | Toggle between a file and its tests in other window.       |
+
+** Alchemist Phoenix
+
+| Key Binding | Description                                          |
+|-------------+------------------------------------------------------|
+| ~SPC m n w~ | List all files available in the =web= directory.     |
+| ~SPC m n c~ | List all controllers in =web/controllers= directory. |
+| ~SPC m n l~ | List all channels in =web/channels= directory.       |
+| ~SPC m n t~ | List all templates in =web/templates= directory.     |
+| ~SPC m n m~ | List all models in =web/models= directory.           |
+| ~SPC m n v~ | List all views in =web/views= directory.             |
+| ~SPC m n s~ | List all files in =web/static= directory.            |
+| ~SPC m n r~ | Open the =router.ex= file from the =web= directory.  |
+| ~SPC m n R~ | Run the Mix task =phoenix.routes=.                   |
 
 ** Evaluation in place
 

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -69,6 +69,16 @@
       "gt" 'alchemist-project-toggle-file-and-tests
       "gT" 'alchemist-project-toggle-file-and-tests-other-window
 
+      "nw" 'alchemist-phoenix-find-web
+      "nc" 'alchemist-phoenix-find-controllers
+      "nl" 'alchemist-phoenix-find-channels
+      "nt" 'alchemist-phoenix-find-templates
+      "nm" 'alchemist-phoenix-find-models
+      "nv" 'alchemist-phoenix-find-views
+      "ns" 'alchemist-phoenix-find-static
+      "nr" 'alchemist-phoenix-router
+      "nR" 'alchemist-phoenix-routes
+
       "h:" 'alchemist-help
       "hH" 'alchemist-help-history
       "hh" 'alchemist-help-search-at-point


### PR DESCRIPTION
Refs #8327

The choice of the `SPC m n` prefix for the keybindings was chosen to be similar with the `C-c a n` one. `SPC m p` seems to have been chosen to mean `project`. Also `n` can be seen as short for `nix` which can be seen as short for `phoenix` :smile:.

If this is not desirable I can switch it to `SPC m p` or `SPC m a p` (but this seems a bit to long), or a better suggestion from the audence.