### PR TITLE
Smarter default alignment with spacemacs/align-repeat (#8309)

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -740,7 +740,22 @@ the right."
                               (concat regexp ws-regexp)
                             (concat ws-regexp regexp)))
          (group (if justify-right -1 1)))
+
     (message "%S" complete-regexp)
+
+    (if (equalp start end)
+        (progn
+          (save-excursion
+            (while (and
+                    (string-match-p complete-regexp (thing-at-point 'line))
+                    (equalp 0 (forward-line -1)))
+              (setq start (point))))
+          (save-excursion
+            (while (and
+                    (string-match-p complete-regexp (thing-at-point 'line))
+                    (equalp 0 (forward-line 1)))
+              (setq end (point))))))
+
     (align-regexp start end complete-regexp group 1 t)))
 
 ;; Modified answer from http://emacs.stackexchange.com/questions/47/align-vertical-columns-of-numbers-on-the-decimal-point


### PR DESCRIPTION
Fixes issue #8309 

This commit modifies `spacemacs/align-repeat` to scan up and down lines in search of smarter start and end points when a region is not specified.  It is inspired from the vim plugin Tabular.

Example:

```
one: 1
two: 2
three: 3
four: 4
```

with `SPC x a :` becomes without the need of selecting the lines you want to align

```
one:   1
two:   2
three: 3
four:  4
```

WARNING: this is my first code in elisp, so I apologize if it is way off mark.
