### PR TITLE
Fix markdown org table saving

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -59,7 +59,7 @@
       (add-hook 'markdown-mode-hook 'orgtbl-mode)
       (add-hook 'markdown-mode-hook
                 (lambda()
-                  (add-hook 'after-save-hook 'cleanup-org-tables  nil 'make-it-local)))
+                  (add-hook 'before-save-hook 'cleanup-org-tables  nil 'make-it-local)))
       ;; Insert key for org-mode and markdown a la C-h k
       ;; from SE endless http://emacs.stackexchange.com/questions/2206/i-want-to-have-the-kbd-tags-for-my-blog-written-in-org-mode/2208#2208
       (defun spacemacs/insert-keybinding-markdown (key)


### PR DESCRIPTION
When creating a table in `markdown-mode` or `gfm-mode` (both using `orgtbl-mode` beind the scenes) the separator between the header and body use a `+` character to indicate column split:

```markdown
| This | Is | A   | Table |
|------+----+-----+-------|
| this | is | the | body  |
```

The markdown layer has a function to convert those `+` signs to `|` in order to produce valid markdown code but it was previously called after saving the buffer content to file, requiring saving once more to persist the change.

This patch ensures the change is done before saving to eliminate the need for a second save. 
