### PR TITLE
Add extension ".wl" for wolfram-mode

### DIFF
--- a/layers/+lang/extra-langs/packages.el
+++ b/layers/+lang/extra-langs/packages.el
@@ -36,8 +36,8 @@
 (defun extra-langs/init-thrift ()
   (use-package thrift :defer t))
 
-;; no associated extension because conflicts with more common Objective-C, manually invoke for .m files.
 (defun extra-langs/init-wolfram-mode ()
   (use-package wolfram-mode
     :defer t
-    :interpreter "\\(Wolfram\\|Mathematica\\)Script\\( -script\\)?"))
+    :interpreter "\\(Wolfram\\|Mathematica\\)Script\\( -script\\)?"
+    :mode "\\.wl\\'"))

--- a/layers/+lang/extra-langs/packages.el
+++ b/layers/+lang/extra-langs/packages.el
@@ -36,6 +36,7 @@
 (defun extra-langs/init-thrift ()
   (use-package thrift :defer t))
 
+;; .m files are not associated because conflict with more common Objective-C and MATLAB/Octave, manually invoke for .m files.
 (defun extra-langs/init-wolfram-mode ()
   (use-package wolfram-mode
     :defer t


### PR DESCRIPTION
I just associated `.wl` with `wolfram-mode` in the `packages.el` of `extra-langs` layer.