### PR TITLE
Resolving org version conflicts: removed org-plus-contrib packages from org-layer

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -20,14 +20,15 @@
     htmlize
     mu4e
     ;; ob, org and org-agenda are installed by `org-plus-contrib'
-    (ob :location built-in)
-    (org :location built-in)
-    (org-agenda :location built-in)
-    (org-expiry :location built-in)
+    ;; which is loaded from core layers/+spacemacs/spacemacs-org/packages.el
+    ;; (ob :location built-in)
+    ;; (org :location built-in)
+    ;; (org-agenda :location built-in)
+    ;; (org-expiry :location built-in)
     (org-journal :toggle org-enable-org-journal-support)
     org-download
     ;; org-mime is installed by `org-plus-contrib'
-    (org-mime :location built-in)
+    ;; (org-mime :location built-in)
     org-pomodoro
     org-present
     (org-projectile :toggle (configuration-layer/package-usedp 'projectile))


### PR DESCRIPTION
I've tried to polish my proposal made on #8074 into a PR.
The modules are still available:

```elisp
(require 'ob)
(require 'org)
(require 'org-agenda)
(require 'org-mime)
```
run fine, but now no package is loaded from emacs built-in org-mode.

Here is the [tiny script : lpkg-explorer.el](https://gist.github.com/RockyRoad29/bd4ca6fdb41196a71662986f809e2b1c) that  I used to check that:

To be accurate, I tested it only (but thoroughly) on the master branch only.
When I thought I was ready for PR, I saw your message about develop branch !!! More work then !
On my poor-mans-testing-workbench, more issues arose on the develop branch , so I leave that part to you guys .

But here it is, ready to merge. About testing it, I kinda believe that it could reveal new issues in the rest of the code, that would have been tested against the shadowing built-in modules. 

Thanks to all contributors for this great piece of software and keep up the good job.