### PR TITLE
Don't use --vimgrep with ripgrep

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -246,7 +246,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-files-do-rg (&optional dir)
         "Search in files with `rg'."
         (interactive)
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --vimgrep"))
+        (let ((helm-ag-base-command "rg --smart-case --no-heading"))
           (helm-do-ag dir)))
 
       (defun spacemacs/helm-files-do-rg-region-or-symbol ()
@@ -309,7 +309,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-buffers-do-rg (&optional _)
         "Search in opened buffers with `rg'."
         (interactive)
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --vimgrep"))
+        (let ((helm-ag-base-command "rg --smart-case --no-heading"))
           (helm-do-ag-buffers)))
 
       (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -13,7 +13,7 @@
 ;; Variables
 
 (defvar spacemacs--counsel-commands
-  '(("rg" . "rg --smart-case --no-heading --vimgrep %s %S .")
+  '(("rg" . "rg --smart-case --no-heading %s %S .")
     ("ag" . "ag --nocolor --nogroup %s %S .")
     ("pt" . "pt -e --nocolor --nogroup %s %S .")
     ("ack" . "ack --nocolor --nogroup %s %S .")


### PR DESCRIPTION
See conversation with @mijoharas at
https://github.com/syl20bnr/spacemacs/issues/7370#issuecomment-280681995
and following conversation with @syohex at
https://github.com/syohex/emacs-helm-ag/issues/293

In a nutshell, emacs-helm-ag recommends --vimgrep to work around a bug
in ag. It doesn't apply to ripgrep.

I also filed a PR against emacs-helm-ag to update their README, see
https://github.com/syohex/emacs-helm-ag/pull/294