### PR TITLE
Add test for org-html export of documentation

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -11,7 +11,7 @@
 ##
 ## License: GPLv3
 
-tests=("core")
+tests=("core" "layers/+org/html-export")
 
 if [ $USER != "travis" ]; then
     echo "This script is not designed to run locally."
@@ -20,16 +20,16 @@ if [ $USER != "travis" ]; then
 fi
 
 if  [ $TRAVIS_SECURE_ENV_VARS = false ] &&
-    [ $TRAVIS_PULL_REQUEST != false ] &&
-    [ $TRAVIS_BRANCH = "master" ]; then
+        [ $TRAVIS_PULL_REQUEST != false ] &&
+        [ $TRAVIS_BRANCH = "master" ]; then
 
-    	printf '=%.0s' {1..70}
-    	printf "\n       し(*･∀･)／   Thanks for the contribution!  ＼(･∀･*)ノ\n"
-    	printf '=%.0s' {1..70}
-    	printf "\n( ＾◡＾)っ Please submit your pull request against the develop branch.\n"
-    	echo   "You can read the contribution guidelines at:"
-    	echo   "https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org"
-    	exit 1
+    printf '=%.0s' {1..70}
+    printf "\n       し(*･∀･)／   Thanks for the contribution!  ＼(･∀･*)ノ\n"
+    printf '=%.0s' {1..70}
+    printf "\n( ＾◡＾)っ Please submit your pull request against the develop branch.\n"
+    echo   "You can read the contribution guidelines at:"
+    echo   "https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org"
+    exit 1
 fi
 
 echo "Pwd $(pwd)"

--- a/spacemacs.mk
+++ b/spacemacs.mk
@@ -14,7 +14,14 @@ TEST_NAME = `basename $(TEST_DIR) | tr a-z A-Z`
 
 all: test
 
-test: unit_tests func_tests
+test: installation unit_tests func_tests
+
+installation:
+	@echo "================================================================="
+	@echo "INSTALLATION OF PACKAGES FOR $(TEST_NAME)"
+	@echo "================================================================="
+	@emacs -batch \
+		$(addprefix -l $(EMACS_DIR)/, $(LOAD_FILES))
 
 ifneq ($(strip $(UNIT_TEST_FILES)),)
 unit_tests:
@@ -22,9 +29,9 @@ unit_tests:
 	@echo "UNIT TESTS FOR $(TEST_NAME)"
 	@echo "================================================================="
 	@emacs -batch -l ert \
-    $(addprefix -l $(EMACS_DIR)/, $(LOAD_FILES)) \
-    $(addprefix -l $(TEST_DIR)/, $(UNIT_TEST_FILES)) \
-    -f ert-run-tests-batch-and-exit
+		$(addprefix -l $(EMACS_DIR)/, $(LOAD_FILES)) \
+		$(addprefix -l $(TEST_DIR)/, $(UNIT_TEST_FILES)) \
+		-f ert-run-tests-batch-and-exit
 endif
 
 ifneq ($(strip $(FUNC_TEST_FILES)),)
@@ -33,9 +40,9 @@ func_tests:
 	@echo "FUNCTIONAL TESTS FOR $(TEST_NAME)"
 	@echo "================================================================="
 	@emacs -batch -l ert \
-    $(addprefix -l $(EMACS_DIR)/, $(LOAD_FILES)) \
-    $(addprefix -l $(TEST_DIR)/, $(FUNC_TEST_FILES)) \
-    -f ert-run-tests-batch-and-exit
+		$(addprefix -l $(EMACS_DIR)/, $(LOAD_FILES)) \
+		$(addprefix -l $(TEST_DIR)/, $(FUNC_TEST_FILES)) \
+		-f ert-run-tests-batch-and-exit
 endif
 
 .PHONY: test unit_tests func_tests

--- a/tests/layers/+org/html-export/Makefile
+++ b/tests/layers/+org/html-export/Makefile
@@ -1,0 +1,19 @@
+## Makefile --- Spacemacs org tests
+##
+## Copyright (c) 2012-2017 Sylvain Benner & Contributors
+##
+## Author: smile13241324 <smile13241324@gmail.com>
+## URL: https://github.com/syl20bnr/spacemacs
+##
+## This file is not part of GNU Emacs.
+##
+## License: GPLv3
+
+TEST_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+LOAD_FILES = init.el
+UNIT_TEST_FILES =
+FUNC_TEST_FILES = \
+org-export-ftest.el
+
+include ../../../../spacemacs.mk

--- a/tests/layers/+org/html-export/dotspacemacs.el
+++ b/tests/layers/+org/html-export/dotspacemacs.el
@@ -1,0 +1,20 @@
+(defun dotspacemacs/layers ()
+  (setq-default
+   dotspacemacs-distribution 'spacemacs
+   dotspacemacs-configuration-layers '(
+                                       (org :variables
+                                            org-enable-github-support t
+                                            org-enable-bootstrap-support t
+                                            org-enable-reveal-js-support t
+                                            )
+                                       bibtex
+                                       (latex :variables
+                                              latex-enable-auto-fill t
+                                              latex-enable-folding t
+                                              )
+                                       html
+                                       )))
+(defun dotspacemacs/init ())
+(defun dotspacemacs/user-init ())
+(defun dotspacemacs/config ())
+(defun dotspacemacs/user-config ())

--- a/tests/layers/+org/html-export/org-export-ftest.el
+++ b/tests/layers/+org/html-export/org-export-ftest.el
@@ -1,0 +1,93 @@
+;;; org-export-ftest.el --- Spacemacs Org Export Functional Test File
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: smile13241324 <smile13241324@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+(require 'mocker)
+(require 'org)
+(require 'core-documentation)
+
+;; Replacement for directory-files-recursively for emacs < 25.1.1
+(defun directory-files-recursive_ForOldEmacs (directory match maxdepth ignore)
+  "List files in DIRECTORY and in its sub-directories.
+   Return files that match the regular expression MATCH but ignore
+   files and directories that match IGNORE (IGNORE is tested before MATCH. Recurse only
+   to depth MAXDEPTH. If zero or negative, then do not recurse"
+  (let* ((files-list '())
+         (current-directory-list
+          (directory-files directory t)))
+    ;; while we are in the current directory
+    (while current-directory-list
+      (let ((f (car current-directory-list)))
+        (cond
+         ((and
+           ignore ;; make sure it is not nil
+           (string-match ignore f))
+                                        ; ignore
+          nil
+          )
+         ((and
+           (file-regular-p f)
+           (file-readable-p f)
+           (not(file-directory-p f))
+           (string-match match f))
+          (setq files-list (cons f files-list))
+          )
+         ((and
+           (file-directory-p f)
+           (file-readable-p f)
+           (not (string-equal ".." (substring f -2)))
+           (not (string-equal "." (substring f -1)))
+           (> maxdepth 0))
+          ;; recurse only if necessary
+          (setq files-list (append files-list (directory-files-recursive_ForOldEmacs f match (- maxdepth -1) ignore)))
+          )
+         (t)
+         )
+        )
+      (setq current-directory-list (cdr current-directory-list)))
+    files-list))
+
+;; ---------------------------------------------------------------------------
+;; Spacemacs Documentation HTML Export Test
+;; Currently checks whether all org documentation files can be converted to html
+;; ---------------------------------------------------------------------------
+(ert-deftest test-spacemacs-html-export ()
+  (spacemacs/publish-doc)
+  ;; Activate this to check all external links, beware don't try this on travis bandwith limits will prevent this from finishing
+  ;;
+  ;; (let ((allFiles (directory-files-recursive_ForOldEmacs (concat spacemacs-start-directory "export/") "\\.html" 9999 "NeverIgnore")))
+  ;;   (dolist (file allFiles)
+  ;;     (when (file-readable-p file)
+  ;;        (with-temp-buffer
+  ;;          (message "%s" file)
+  ;;          (insert-file-contents file)
+  ;;          (while (re-search-forward "\\(?:href\\|src\\)[ \n]*=[ \n]*\"\\([^\"]+?\\)\"" nil t)
+
+  ;;              ;;Start url validation
+  ;;              (let ((url (match-string 1))
+  ;;                    (p-current (point))
+  ;;                    (p-mb (match-beginning 0)))
+  ;;                (save-excursion
+  ;;                  (search-backward "<" nil t)
+  ;;                  (setq p1 (point))
+  ;;                  (search-forward ">" nil t)
+  ;;                  (setq p2 (point)))
+
+  ;;                (when (and (< p1 p-mb) (< p-current p2) ) ; the “href="…"” is inside <…>
+  ;;                  (if (string-match "^http://\\|^https://" url)
+  ;;                      (progn
+  ;;                        ;; (message "%s%s" "Checking " url)
+  ;;                        (url-retrieve-synchronously url t t)
+  ;;                        )
+  ;;                        ;; Checking for internal links not done yet
+  ;;                        ;; (progn
+  ;;                        ;;   (message "%s%s" "Checking " (concat "file://" url))
+  ;;                        ;;   (url-retrieve-synchronously (concat "file://" url) t))
+  ;;                        ))))))))
+  )


### PR DESCRIPTION
To avoid further issues with the publishing of documentations I have written a test to ensure that
all documentation files can be exported to html.

To avoid issues with loading the right org version after package installation I have also slightly
modified the test workflow to include a dedicated package installation target done prior to executing
any tests.