### PR TITLE
ipython notebook layer app command changes

### DIFF
--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -14,10 +14,12 @@
 (defun ipython-notebook/init-ein ()
   (use-package ein
     :defer t
-    :commands ein:notebooklist-open
+    :commands (ein:notebooklist-open ein:notebooklist-login)
     :init
     (progn
-      (spacemacs/set-leader-keys "ain" 'ein:notebooklist-open)
+      (spacemacs/set-leader-keys
+        "ail" 'ein:notebooklist-login
+        "ain" 'ein:notebooklist-open)
       (with-eval-after-load 'ein-notebooklist
         (evilified-state-evilify-map ein:notebooklist-mode-map
           :mode ein:notebooklist-mode

--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -19,7 +19,7 @@
     (progn
       (spacemacs/set-leader-keys
         "ail" 'ein:notebooklist-login
-        "ain" 'ein:notebooklist-open)
+        "aio" 'ein:notebooklist-open)
       (with-eval-after-load 'ein-notebooklist
         (evilified-state-evilify-map ein:notebooklist-mode-map
           :mode ein:notebooklist-mode


### PR DESCRIPTION
This adds a new command to login to a notebook which is often required on newer installs of Jupyter these days. 

I also changed the command to open the notebook list from `n` to `o`. Better mnemonics was the motivation behind this change. I'm not sure if `n` was chosen to match another spacemacs convention but I couldn't find any reference to such a convention. I realize that this is change could annoy people use to the previous binding so I can remove this commit from the PR.