### PR TITLE
bibtex: add key bindings

### DIFF
--- a/layers/+lang/bibtex/README.org
+++ b/layers/+lang/bibtex/README.org
@@ -78,3 +78,11 @@ key binding added:
 | Key Binding | Description     |
 |-------------+-----------------|
 | ~SPC m i c~ | Insert citation |
+
+Besides that, =org-mode= has some extra key bindings:
+
+| Key Binding | Description      |
+|-------------+------------------|
+| ~SPC m i b~ | Insert label     |
+| ~SPC m i r~ | Insert reference |
+

--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -26,7 +26,9 @@
 
 (defun bibtex/post-init-org ()
   (spacemacs/set-leader-keys-for-major-mode 'org-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+    "ic" 'org-ref-helm-insert-cite-link
+    "ir" 'org-ref-helm-insert-ref-link
+    "ib" 'org-ref-helm-insert-label-link))
 
 (defun bibtex/init-org-ref ()
   (use-package org-ref


### PR DESCRIPTION
IMHO, the `org-ref-helm-insert-ref` and `org-ref-helm-insert-label` are both important commands of org-ref. This commit adds keybindings for them.