### PR TITLE
revert bug introduced by commit eef1a87

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -41,10 +41,10 @@
     :override-mode-name spacemacs-leader-override-mode))
 
 (defun spacemacs-bootstrap/init-evil ()
-  ;; ensure that the search module is set at startup
-  ;; must be called before evil is required to really take effect.
-  (spacemacs/set-evil-search-module dotspacemacs-editing-style)
-  (add-hook 'spacemacs-editing-style-hook 'spacemacs/set-evil-search-module)
+  (with-eval-after-load 'hybrid-mode
+    ;; ensure that the search module is set at startup
+    (spacemacs/set-evil-search-module dotspacemacs-editing-style)
+    (add-hook 'spacemacs-editing-style-hook 'spacemacs/set-evil-search-module))
 
   ;; evil-mode is mandatory for Spacemacs to work properly
   ;; evil must be require explicitly, the autoload seems to not


### PR DESCRIPTION
Hi, caused by the commit https://github.com/syl20bnr/spacemacs/commit/eef1a87e98d8258c2a295566d954bb7b391942fb. A bug is introduced.

In the current develop branch the `spacemacs/set-evil-search-module` is called before the `hybrid-mode` is loaded, when the `hybrid-mode-use-evil-search-module` is unbounded, and thus always choose `'evil-search` as the search module. This pull request fixes this bug by reverting the change on that single file.