### PR TITLE
Remove CUSTOM ID from documentation to fix #8216

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -25,9 +25,6 @@ Thanks! :heart: :heart: :heart:
  - [[#credits][Credits]]
 
 * Asking for help
-  :PROPERTIES:
-:CUSTOM_ID: asking-for-help
-:END:
 If you want to ask an usage question, be sure to look first into some places as
 it may hold the answer:
 
@@ -40,9 +37,6 @@ discuss it with us :relaxed:. We will direct you to a solution, or ask you to
 open an issue if it is needed.
 
 * Reporting issues
-:PROPERTIES:
-:CUSTOM_ID: reporting-issues
-:END:
 Issues have to be reported on our [[https://github.com/syl20bnr/spacemacs/issues][issues tracker]]. Please:
 
 - Check that the issue has not already been reported.
@@ -62,9 +56,6 @@ Issues have to be reported on our [[https://github.com/syl20bnr/spacemacs/issues
     step guide.
 
 * Contributing code
-:PROPERTIES:
-:CUSTOM_ID: contributing-code
-:END:
 Code contributions are welcome. Please read the following sections carefully. In
 any case, feel free to join us on the [[https://gitter.im/syl20bnr/spacemacs][gitter chat]] to ask questions about
 contributing!

--- a/doc/BEGINNERS_TUTORIAL.org
+++ b/doc/BEGINNERS_TUTORIAL.org
@@ -228,9 +228,6 @@ a very common task and is done with ~SPC f r~. An edited file is saved with
 ~SPC f s~.
 
 * Configuring Spacemacs
-:PROPERTIES:
-:CUSTOM_ID: configuring-spacemacs
-:END:
 ** Adding language support and other features: using layers
 Spacemacs divides its configuration into self-contained units called
 configuration layers. These layers are stacked on top of each other to achieve a

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -329,9 +329,6 @@ and choosing a rollback slot (sorted by date). This button uses the command
 =configuration-layer/rollback=.
 
 * Configuration layers
-  :PROPERTIES:
-  :CUSTOM_ID: configuration-layers
-  :END:
 This section is an overview of layers. A more extensive introduction to writing
 configuration layers can be found [[file:LAYERS.org][here]] (recommended reading!).
 
@@ -508,9 +505,6 @@ Please refer to [[file:LAYERS.org][this]] introduction for some tips on writing 
 best make them fit with the Spacemacs philosophy and loading strategy.
 
 * Dotfile Configuration
-:PROPERTIES:
-:CUSTOM_ID: dotfile-configuration
-:END:
 User configuration can be stored in your =~/.spacemacs= file.
 
 ** Dotfile Installation
@@ -798,9 +792,6 @@ To toggle the hybrid style on and off use ~SPC t E h~ and ~M-m t E h~. When
 off the =vim= style is enabled.
 
 ** States
-:PROPERTIES:
-:CUSTOM_ID: states
-:END:
 Spacemacs has 10 states:
 
 | State        | Default Color | Description                                                                                                |
@@ -869,9 +860,6 @@ to ~SPC u~.
 pressing ~RETURN~. For instance: ~SPC SPC org-reload C-u RET~
 
 ** Transient-states
-   :PROPERTIES:
-   :CUSTOM_ID: transient-states
-   :END:
 Spacemacs defines a wide variety of =transient states= (temporary overlay maps)
 where it makes sense. This prevents one from doing repetitive and tedious
 presses on the ~SPC~ key.
@@ -1457,34 +1445,34 @@ selected layout.
 
 Press ~?~ to toggle the full help.
 
-| Key Binding       | Description                                                |
-|-------------------+------------------------------------------------------------|
-| ~SPC l~           | activate the transient- state                              |
-| ~?~               | toggle the documentation                                   |
-| ~[0..9]~          | switch to nth layout                                       |
-| ~[C-0..C-9]~      | switch to nth layout and keep the transient state active   |
-| ~<tab>~           | switch to the latest layout                                |
-| ~a~               | add a buffer to the current layout                         |
-| ~A~               | add all the buffers from another layout in the current one |
-| ~b~               | select a buffer in the current layout                      |
-| ~d~               | delete the current layout and keep its buffers             |
-| ~D~               | delete the other layouts and keep their buffers            |
-| ~h~               | go to default layout                                       |
-| ~C-h~             | previous layout in list                                    |
-| ~l~               | select/create a layout with helm                           |
-| ~L~               | load layouts from file                                     |
-| ~C-l~             | next layout in list                                        |
-| ~n~               | next layout in list                                        |
-| ~N~               | previous layout in list                                    |
-| ~o~               | open a custom layout                                       |
-| ~p~               | previous layout in list                                    |
-| ~r~               | remove current buffer from layout                          |
-| ~R~               | rename current layout                                      |
-| ~s~               | save layouts                                               |
-| ~t~               | display a buffer without adding it to the current layout   |
-| ~w~               | workspaces transient state (needs eyebrowse layer enabled) |
-| ~x~               | kill current layout with its buffers                       |
-| ~X~               | kill other layouts with their buffers                      |
+| Key Binding  | Description                                                |
+|--------------+------------------------------------------------------------|
+| ~SPC l~      | activate the transient- state                              |
+| ~?~          | toggle the documentation                                   |
+| ~[0..9]~     | switch to nth layout                                       |
+| ~[C-0..C-9]~ | switch to nth layout and keep the transient state active   |
+| ~<tab>~      | switch to the latest layout                                |
+| ~a~          | add a buffer to the current layout                         |
+| ~A~          | add all the buffers from another layout in the current one |
+| ~b~          | select a buffer in the current layout                      |
+| ~d~          | delete the current layout and keep its buffers             |
+| ~D~          | delete the other layouts and keep their buffers            |
+| ~h~          | go to default layout                                       |
+| ~C-h~        | previous layout in list                                    |
+| ~l~          | select/create a layout with helm                           |
+| ~L~          | load layouts from file                                     |
+| ~C-l~        | next layout in list                                        |
+| ~n~          | next layout in list                                        |
+| ~N~          | previous layout in list                                    |
+| ~o~          | open a custom layout                                       |
+| ~p~          | previous layout in list                                    |
+| ~r~          | remove current buffer from layout                          |
+| ~R~          | rename current layout                                      |
+| ~s~          | save layouts                                               |
+| ~t~          | display a buffer without adding it to the current layout   |
+| ~w~          | workspaces transient state (needs eyebrowse layer enabled) |
+| ~x~          | kill current layout with its buffers                       |
+| ~X~          | kill other layouts with their buffers                      |
 
 ** Workspaces
 Workspaces are sub-layouts, they allow to define multiple layouts into a given
@@ -1640,9 +1628,6 @@ If you find yourself unable to return focus to Helm (after a careless
 mouse-click for example), use ~SPC w b~ to return focus to the minibuffer.
 
 **** Helm transient state
-     :PROPERTIES:
-     :CUSTOM_ID: helm-transient-state
-     :END:
 Spacemacs defines a [[#transient-states][transient state]] for =Helm= to make it work like [[https://github.com/Shougo/unite.vim][Vim's Unite]]
 plugin.
 
@@ -1925,7 +1910,7 @@ The ~SPC j~ prefix is for jumping, joining and splitting.
 | ~SPC j J~   | jump to a suite of two characters in the buffer (works as an evil motion)         |
 | ~SPC j k~   | jump to next line and indent it using auto-indent rules                           |
 | ~SPC j l~   | jump to a line with avy (works as an evil motion)                                 |
-| ~SPC j q~   | show the dumb-jump quick look tooltip                                              |
+| ~SPC j q~   | show the dumb-jump quick look tooltip                                             |
 | ~SPC j u~   | jump to a URL in the current buffer                                               |
 | ~SPC j v~   | jump to the definition/declaration of an Emacs Lisp variable                      |
 | ~SPC j w~   | jump to a word in the current buffer (works as an evil motion)                    |
@@ -1964,7 +1949,7 @@ Windows manipulation commands (start with ~w~):
 |------------------------+-----------------------------------------------------------------------------|
 | ~SPC w TAB~            | switch to alternate window in the current frame (switch back and forth)     |
 | ~SPC w =~              | balance split windows                                                       |
-| ~SPC w b~              | force the focus back to the minibuffer (useful with =helm= popups)         |
+| ~SPC w b~              | force the focus back to the minibuffer (useful with =helm= popups)          |
 | ~SPC w c~              | maximize/minimize a window and center it                                    |
 | ~SPC w C~              | maximize/minimize a window and center it using [[https://github.com/abo-abo/ace-window][ace-window]]                   |
 | ~SPC w d~              | delete a window                                                             |
@@ -2097,9 +2082,6 @@ the opened buffer and kill them.
 | Any other key | leave the transient state                     |
 
 **** Special Buffers
-:PROPERTIES:
-:CUSTOM_ID: special-buffers
-:END:
 Unlike vim, emacs creates many buffers that most people do not need to see. Some
 examples are =*Messages*= and =*Compile-Log*=. Spacemacs tries to automatically
 ignore buffers that are not useful. However, you may want to change the way
@@ -2508,10 +2490,6 @@ bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~
 | ~SPC s t F~ | =pt= with default text                              |
 
 **** Searching in a project
-:PROPERTIES:
-:CUSTOM_ID: searching-in-a-project
-:END:
-
 | Key Binding           | Description                                         |
 |-----------------------+-----------------------------------------------------|
 | ~SPC /~  or ~SPC s p~ | search with the first found tool                    |
@@ -2726,9 +2704,6 @@ It is possible to enable it easily for /all programming modes/ with the variable
 
 *** Zooming
 **** Text
-     :PROPERTIES:
-     :CUSTOM_ID: text
-     :END:
 The font size of the current buffer can be adjusted with the commands:
 
 | Key Binding   | Description                                                                    |
@@ -2791,9 +2766,6 @@ Keybindings are listed in the layer documentation.
 Vi =Visual= modes are all supported by =evil=.
 
 **** Expand-region
-:PROPERTIES:
-:CUSTOM_ID: expand-region
-:END:
 Spacemacs adds another =Visual= mode via the [[https://github.com/magnars/expand-region.el][expand-region]] mode.
 
 | Key Binding | Description                              |
@@ -2827,17 +2799,14 @@ There are also ~a~ variants that include whitespace. Example (=|= indicates poin
 The displayed text of a buffer can be narrowed with the commands (start with
 ~n~):
 
-| Key Binding | Description                                |
-|-------------+--------------------------------------------|
-| ~SPC n f~   | narrow the buffer to the current function  |
-| ~SPC n p~   | narrow the buffer to the visible page      |
-| ~SPC n r~   | narrow the buffer to the selected text     |
-| ~SPC n w~   | widen, i.e. show the whole buffer again    |
+| Key Binding | Description                               |
+|-------------+-------------------------------------------|
+| ~SPC n f~   | narrow the buffer to the current function |
+| ~SPC n p~   | narrow the buffer to the visible page     |
+| ~SPC n r~   | narrow the buffer to the selected text    |
+| ~SPC n w~   | widen, i.e. show the whole buffer again   |
 
 *** Replacing text with iedit
-    :PROPERTIES:
-    :CUSTOM_ID: replacing-text-with-iedit
-    :END:
 Spacemacs uses the powerful [[https://github.com/tsdh/iedit][iedit]] mode through [[https://github.com/syl20bnr/evil-iedit-state][evil-iedit-state]] to quickly
 edit multiple occurrences of a symbol or selection.
 
@@ -2999,9 +2968,6 @@ To disable the trash you can set the variable =delete-by-moving-to-trash= to
 =nil= in your =~/.spacemacs=.
 
 *** Editing Lisp code
-    :PROPERTIES:
-    :CUSTOM_ID: editing-lisp-code
-    :END:
 Editing of lisp code is provided by [[https://github.com/syl20bnr/evil-lisp-state][evil-lisp-state]].
 
 Commands will set the current state to =lisp state= where different commands

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -263,9 +263,6 @@ the list =dotspacemacs-excluded-packages= if you prefer setting =exec-path=
 yourself.
 
 * How do I:
-:PROPERTIES:
-:CUSTOM_ID: how-do-i
-:END:
 ** Install a package not provided by a layer?
 Spacemacs provides a variable in the =dotspacemacs/layers= function in
 =.spacemacs= called =dotspacemacs-additional-packages=. Just add a package name
@@ -304,9 +301,6 @@ dotfile. The following snippet disables company for =python-mode=:
 #+END_SRC
 
 ** Change special buffer rules?
-   :PROPERTIES:
-   :CUSTOM_ID: change-special-buffer-rules
-   :END:
 To change the way spacemacs marks buffers as useless, you can customize
 =spacemacs-useless-buffers-regexp= which marks buffers matching the regexp as
 useless. The variable =spacemacs-useful-buffers-regexp= marks buffers matching

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -273,9 +273,6 @@ Use-package supports heaps of useful keywords. Look at the [[https://github.com/
 more.
 
 * Anatomy of a layer
-:PROPERTIES:
-:CUSTOM_ID: anatomy-of-a-layer
-:END:
 A layer is simply a folder somewhere in Spacemacs' layer search path that
 usually contains these files (listed in loading order).
 
@@ -499,9 +496,6 @@ hooks, if the package should be loaded upon some event. It is not unusual to
 have both!
 
 ** Use-package hooks
-:PROPERTIES:
-:CUSTOM_ID: use-package-hooks
-:END:
 Spacemacs includes a macro for adding more code to the =:init= or =:config=
 blocks of a call to =use-package=, after the fact. This is useful for =pre-init=
 or =post-init= functions to "inject" code into the =use-package= call of the
@@ -573,4 +567,3 @@ missing appropriate auto-loads.
 *** Auto-load everything
 Defer everything. You should have a very good reason not to defer the loading
 of a package.
-

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -132,9 +132,6 @@ are located under the ~SPC b~ prefix.
 | ~SPC b .~                 | Buffer transient-state.                              |
 
 **** Special buffers
-:PROPERTIES:
-:CUSTOM_ID: special-buffers
-:END:
 By default Emacs creates a lot of buffers that most people will never need, like
 =*Messages*=. Spacemacs automatically ignores these when using these
 key bindings. More information can be found [[file:DOCUMENTATION.org::#special-buffers][here]].
@@ -190,9 +187,6 @@ explore:
 | ~SPC ?~     | Lists all keybindings.                                        |
 
 * Customization
-:PROPERTIES:
-:CUSTOM_ID: customization
-:END:
 ** The .spacemacs file
 When you first start spacemacs, you will be prompted to choose an editing style.
 If you are reading this, you likely want to choose the vim style. A =.spacemacs=
@@ -292,9 +286,6 @@ Here is an example of a function that is useful in real life:
 #+end_src
 
 ** Activating a Layer
-:PROPERTIES:
-:CUSTOM_ID: activating-a-layer
-:END:
 As said in the terms section, layers provide an easy way to add features.
 Activating a layer is done in the =.spacemacs= file. In the file search for the
 =dotspacemacs-configuration-layers= variable. By default, it should look like
@@ -387,9 +378,6 @@ will be installed when you restart. Loading the package is covered in the next
 [[#loading-packages][section]].
 
 ** Loading packages
-:PROPERTIES:
-:CUSTOM_ID: loading-packages
-:END:
 Ever wonder how Spacemacs can load over a 100 packages in just a few seconds?
 Such low loading times must require some kind of unreadable black magic that no
 one can understand. Thanks to [[https://github.com/jwiegley/use-package][use-package]], this is not true. It is a package
@@ -422,9 +410,6 @@ This is just a very basic overview of =use-package=. There are many other ways
 to control how a package loads using it that aren't covered here.
 
 ** Uninstalling a package
-:PROPERTIES:
-:CUSTOM_ID: uninstalling-a-package
-:END:
 Spacemacs provides a variable in the =dotspacemacs/init= function in
 =.spacemacs= called =dotspacemacs-excluded-packages=. Just add a package name to
 the list and it will be uninstalled when you restart.


### PR DESCRIPTION
In the currently generated web pages for the documentation files we show internal custom id tags. This is caused by `spacemacs//org-heading-annotate-custom-id` which will be adding a duplicate `:PROPERTIES:` tag if one is already existing. 

To solve this I have simply removed the superfluous CUSTOM IDs from the effected documents. As extending the function to reliably detect those `PROPERTIES` drawers I found not really worth the trouble as I cannot find any reason to add those drawers except CUSTOM IDs.