### PR TITLE
Fix broken link to CONTRIBUTE.org in documentation to fix #8290

### DIFF
--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -54,6 +54,13 @@
           (insert (format "\n%s %s\n" level pretty-name))
           (spacemacs//generate-layers-from-path c (concat level "*")))))))
 
+(defun spacemacs//fetch-docs-from-root (project-plist)
+  "Add missing CONTRIBUTING and COMMUNITY files to doc folder for publishing.
+   Have been moved out of the doc folder to let github show the documentation.
+   See commit 315528c89fd351d559a262bb88bd15ed961e4b4e"
+  (copy-file (concat spacemacs-start-directory "CONTRIBUTING.org") (concat spacemacs-docs-directory "CONTRIBUTE.org") "overwrite-existing-file")
+  (copy-file (concat spacemacs-start-directory "COMMUNITY.org") (concat spacemacs-docs-directory "COMMUNITY.org") "overwrite-existing-file"))
+
 (defun spacemacs/generate-layers-file (project-plist)
   "Generate the layers list file."
   (interactive)
@@ -230,6 +237,7 @@ preprocessors for the exported .org files."
              :base-extension "org"
              :publishing-directory ,(concat publish-target "doc/")
              :publishing-function org-html-publish-to-html
+             :preparation-function spacemacs//fetch-docs-from-root
              :headline-levels 4
              :html-head ,header)
             ("layers-doc"


### PR DESCRIPTION
In 2015 a file CONTRIBUTE.org was existing in the /doc folder.
In addition a CONTRIBUTING.md file was existing in the project root folder.
This was merged into a CONTRIBUTING.org file, which is still located in the project root.
However the documentation publishing system was still looking only in the doc folder.
In addition the external documentation is still referring to the old CONTRIBUTE.html which is not longer existing.

I have now included a new function called prior to publishing
which is copying the documents from the projects root into the doc folder.
As a side effect it renames the CONTRIBUTING.org to the old CONTRIBUTE.org
to support the external documentation.

See commit 315528c89fd351d559a262bb88bd15ed961e4b4e