### PR TITLE
Fix broken links to missing README files in layers list to fix #8291

### DIFF
--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -35,14 +35,16 @@
          (categories (-filter
                       (lambda (p)
                         (eq 'category (configuration-layer//directory-type p)))
-                              all-subs)))
+                      all-subs)))
     (message "%S" layers)
     (dolist (l layers)
       (let ((layer-name (file-name-nondirectory l))
-            (target-path (concat (file-relative-name
-                                  l (concat spacemacs-start-directory "layers"))
-                                 "/README.org")))
-        (insert (format "- [[file:%s][%s]]\n" target-path layer-name))))
+            (layer-readme (concat l "/README.org")))
+        (if (file-exists-p layer-readme)
+            (insert (format "- [[file:%s][%s]]\n" (file-relative-name
+                                                   layer-readme
+                                                   (concat spacemacs-start-directory "layers"))
+                            layer-name)))))
     (dolist (c categories)
       (let* ((category-name (substring (file-name-nondirectory c) 1))
              (pretty-name
@@ -50,9 +52,8 @@
                   (s-capitalize (replace-regexp-in-string
                                  "-" " " category-name)))))
         (message "%S" category-name)
-        (unless (string= "distribution" category-name)
-          (insert (format "\n%s %s\n" level pretty-name))
-          (spacemacs//generate-layers-from-path c (concat level "*")))))))
+        (insert (format "\n%s %s\n" level pretty-name))
+        (spacemacs//generate-layers-from-path c (concat level "*"))))))
 
 (defun spacemacs/generate-layers-file (project-plist)
   "Generate the layers list file."

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -35,13 +35,8 @@
 
 * Completion
 - [[file:+completion/auto-completion/README.org][auto-completion]]
-- [[file:+completion/helm/README.org][helm]]
-- [[file:+completion/ivy/README.org][ivy]]
 
 * Distributions
-- [[file:+distributions/spacemacs/README.org][spacemacs]]
-- [[file:+distributions/spacemacs-base/README.org][spacemacs-base]]
-- [[file:+distributions/spacemacs-bootstrap/README.org][spacemacs-bootstrap]]
 - [[file:+distributions/spacemacs-docker/README.org][spacemacs-docker]]
 
 * Emacs
@@ -129,7 +124,6 @@
 - [[file:+lang/yaml/README.org][yaml]]
 
 * Misc
-- [[file:+misc/nlinum/README.org][nlinum]]
 
 * Operating systems
 - [[file:+os/nixos/README.org][nixos]]
@@ -145,17 +139,7 @@
 - [[file:+source-control/version-control/README.org][version-control]]
 
 * Spacemacs distribution layers
-- [[file:+spacemacs/spacemacs-completion/README.org][spacemacs-completion]]
-- [[file:+spacemacs/spacemacs-editing/README.org][spacemacs-editing]]
-- [[file:+spacemacs/spacemacs-editing-visual/README.org][spacemacs-editing-visual]]
-- [[file:+spacemacs/spacemacs-evil/README.org][spacemacs-evil]]
-- [[file:+spacemacs/spacemacs-language/README.org][spacemacs-language]]
-- [[file:+spacemacs/spacemacs-layouts/README.org][spacemacs-layouts]]
-- [[file:+spacemacs/spacemacs-misc/README.org][spacemacs-misc]]
-- [[file:+spacemacs/spacemacs-org/README.org][spacemacs-org]]
 - [[file:+spacemacs/spacemacs-purpose/README.org][spacemacs-purpose]]
-- [[file:+spacemacs/spacemacs-ui/README.org][spacemacs-ui]]
-- [[file:+spacemacs/spacemacs-ui-visual/README.org][spacemacs-ui-visual]]
 
 * Tags
 - [[file:+tags/cscope/README.org][cscope]]


### PR DESCRIPTION
Some of the layers do not supply a README.org file which caused invalid links in the layer list. To avoid this I have changed spacemacs//generate-layers-from-path to only add links to layers with a valid README.org file.

I have also removed an invalid check to exclude the non existing directory "distribution" from the layers list. I think that originally the folder "distributions" should have been excluded but this is not longer a feasible action as there is at least one layer with a valid README.org file in there today. So now we add links to all layers providing a README.org file independent of their category.