### PR TITLE
Remapping of twittering-mode was broken in keyboard-layout. Fix it.

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -466,13 +466,13 @@
       "k"
       "l")))
 
-(defun kl/pre-init-twittering-mode ()
+(defun keyboard-layout/pre-init-twittering-mode ()
   (kl|config twittering-mode
     :description
     "Remap navigation keys in `twittering-mode'."
     :loader
-    (spacemacs|use-package-add-hook twittering-mode :post-init BODY)
-    :config
+    (spacemacs|use-package-add-hook twittering-mode :post-config BODY)
+    :common
     (kl/correct-keys twittering-mode-map
       "h"
       "j"


### PR DESCRIPTION
I've just noticed that twittering-mode support for the keyboard-layout layer was broken because the syntax was out of date. This PR fix it.