### PR TITLE
rg: explicitly request line numbers

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -246,7 +246,10 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-files-do-rg (&optional dir)
         "Search in files with `rg'."
         (interactive)
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never"))
+        ;; --line-number forces line numbers (disabled by default on windows)
+        ;; no --vimgrep because it adds column numbers that wgrep can't handle
+        ;; (see https://github.com/syl20bnr/spacemacs/pull/8065)
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number"))
           (helm-do-ag dir)))
 
       (defun spacemacs/helm-files-do-rg-region-or-symbol ()
@@ -309,7 +312,10 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
       (defun spacemacs/helm-buffers-do-rg (&optional _)
         "Search in opened buffers with `rg'."
         (interactive)
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never"))
+        ;; --line-number forces line numbers (disabled by default on windows)
+        ;; no --vimgrep because it adds column numbers that wgrep can't handle
+        ;; (see https://github.com/syl20bnr/spacemacs/pull/8065)
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number"))
           (helm-do-ag-buffers)))
 
       (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -13,12 +13,15 @@
 ;; Variables
 
 (defvar spacemacs--counsel-commands
-  '(("rg" . "rg --smart-case --no-heading --color never %s %S .")
+  '(;; --line-number forces line numbers (disabled by default on windows)
+    ;; no --vimgrep because it adds column numbers that wgrep can't handle
+    ;; (see https://github.com/syl20bnr/spacemacs/pull/8065)
+    ("rg" . "rg --smart-case --no-heading --color never --line-number %s %S .")
     ("ag" . "ag --nocolor --nogroup %s %S .")
     ("pt" . "pt -e --nocolor --nogroup %s %S .")
     ("ack" . "ack --nocolor --nogroup %s %S .")
     ("grep" . "grep -nrP %s %S ."))
-  "Alist of search commands and their corresponding commands
+  "An alist of search commands and their corresponding commands
 with options to run in the shell.")
 
 (defvar spacemacs--counsel-search-max-path-length 30


### PR DESCRIPTION
rg tries to be smart about printing line numbers in its output (if running inside a TTY or not). On Windows, sometimes (always?) it chooses not to print line number. However, we always want line numbers, so we need to pass -n flag.

fixes https://github.com/syl20bnr/spacemacs/pull/8065#issuecomment-285016670