### PR TITLE
added dollar to match only function name

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -76,7 +76,7 @@
                                  "-run")))
               (save-excursion
                   (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Test[[:alnum:]_]+\\)(.*)")
-                  (spacemacs/go-run-tests (concat test-method "='" (match-string-no-properties 2) "'"))))
+                  (spacemacs/go-run-tests (concat test-method "='" (match-string-no-properties 2) "$'"))))
           (message "Must be in a _test.go file to run go-run-test-current-function")))
 
       (defun spacemacs/go-run-test-current-suite ()


### PR DESCRIPTION
the check.f and run functions use regular expressions, without the dollar sign it will run not only function _2, but also _21, etc.