### PR TITLE
dsm-line-numbers: support parent modes, fix mode restriction

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -293,6 +293,15 @@ buffer."
   (let ((message-log-max nil))
     (apply 'message msg args)))
 
+(defun spacemacs/derived-mode-p (mode &rest modes)
+  "Non-nil if MODE is derived from one of MODES."
+  ;; We could have copied the built-in `derived-mode-p' and modified it a bit so
+  ;; it works on arbitrary modes instead of only the current major-mode. We
+  ;; don't do that because then we will need to modify the function if
+  ;; `derived-mode-p' changes.
+  (let ((major-mode mode))
+    (apply #'derived-mode-p modes)))
+
 (defun spacemacs/alternate-buffer (&optional window)
   "Switch back and forth between current and last buffer in the
 current window."

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1155,8 +1155,7 @@ and ~T~):
 
 **** Global line numbers
 Line numbers can be toggled on in all =prog-mode= and =text-mode= buffers by
-setting the =dotspacemacs-line-numbers= variable in your =~/.spacemacs=
-to something different than =nil=.
+setting the =dotspacemacs-line-numbers= variable in your =~/.spacemacs= to =t=.
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-line-numbers t)
@@ -1180,7 +1179,7 @@ Available properties:
 | =:relative=           | if non-nil, line numbers are relative to the position of the cursor                          |
 | =:size-limit-kb=      | size limit in kilobytes after which line numbers are not activated                           |
 
-Example:
+Examples:
 
 Disable line numbers in dired-mode, doc-view-mode, markdown-mode, org-mode,
 pdf-view-mode, text-mode as well as buffers over 1Mb:
@@ -1203,6 +1202,22 @@ Relative line numbers only in c-mode and c++ mode with a size limit of =dotspace
                                            :enabled-for-modes c-mode
                                                               c++-mode
                                            :size-limit-kb (* dotspacemacs-large-file-size 1000))
+#+END_SRC
+
+Enable line numbers everywhere, except for buffers over 1Mb:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-lines-numbers '(:relative nil
+                                             :size-limit-kb 1000))
+#+END_SRC
+
+Enable line numbers only in programming modes, except for c-mode and c++ mode:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-lines-numbers '(:relative nil
+                                             :enabled-for-modes prog-mode
+                                             :disabled-for-modes c-mode c++-mode
+                                             :size-limit-kb (* dotspacemacs-large-file-size 1000))
 #+END_SRC
 
 ** Mode-line

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1049,10 +1049,7 @@ Decision is based on `dotspacemacs-line-numbers'."
        (spacemacs//linum-current-buffer-is-not-special)
        (spacemacs//linum-curent-buffer-is-not-too-big)
        (or (spacemacs//linum-backward-compabitility)
-           ;; explicitly enabled buffers take priority over explicitly disabled
-           ;; ones
-           (or (spacemacs//linum-enabled-for-current-major-mode)
-               (not (spacemacs//linum-disabled-for-current-major-mode))))))
+           (spacemacs//linum-enabled-for-current-major-mode))))
 
 (defun spacemacs//linum-on (origfunc &rest args)
   "Advice function to improve `linum-on' function."
@@ -1088,14 +1085,31 @@ Decision is based on `dotspacemacs-line-numbers'."
                (* 1000 (car (spacemacs/mplist-get dotspacemacs-line-numbers
                                                   :size-limit-kb)))))))
 
+;; mode in :enabled, not in :disabled ==> t
+;; mode not in :enabled, in :disabled ==> nil
+;; mode in :enabled, parent in :disabled ==> t
+;; parent in :enabled, mode in :disabled ==> nil
+;; not in :enabled, not in :disabled, :enabled is empty ==> t
+;; not in :enabled, not in :disabled, :enabled is not empty ==> nil
+;; both :enabled and :disabled are empty ==> t
 (defun spacemacs//linum-enabled-for-current-major-mode ()
   "Return non-nil if line number is enabled for current major-mode."
-  (let ((modes (spacemacs/mplist-get dotspacemacs-line-numbers
-                                     :enabled-for-modes)))
-    (memq major-mode modes)))
-
-(defun spacemacs//linum-disabled-for-current-major-mode ()
-  "Return non-nil if line number is disabled for current major-mode."
-  (let ((modes (spacemacs/mplist-get dotspacemacs-line-numbers
-                                     :disabled-for-modes)))
-    (memq major-mode modes)))
+  (let* ((enabled-for-modes (spacemacs/mplist-get dotspacemacs-line-numbers
+                                                  :enabled-for-modes))
+         (disabled-for-modes (spacemacs/mplist-get dotspacemacs-line-numbers
+                                                   :disabled-for-modes))
+         (enabled-for-parent (apply #'derived-mode-p enabled-for-modes))
+         (disabled-for-parent (apply #'derived-mode-p disabled-for-modes)))
+    (or
+     ;; current mode or a parent is in :enabled-for-modes, and there isn't a
+     ;; more specific parent (or the mode itself) in :disabled-for-modes
+     (and enabled-for-parent
+          ;; handles the case where current major-mode has a parent both in
+          ;; :enabled-for-modes and in :disabled-for-modes. Return non-nil if
+          ;; enabled-for-parent is the more specific parent (IOW doesn't derive
+          ;; from disabled-for-parent)
+          (not (spacemacs/derived-mode-p enabled-for-parent disabled-for-parent)))
+     ;; current mode (or parent) not explicitly disabled, and :enabled-for-modes
+     ;; not explicitly specified by user (meaning if it isn't explicitly
+     ;; disabled then it's enabled)
+     (and (null enabled-for-modes) (not disabled-for-parent)))))


### PR DESCRIPTION
Specifying parent modes (e.g. `prog-mode`) in `:enabled-for-modes` and `:disabled-for-modes` keys in `dotspacemacs-line-numbers` catches derived modes (e.g. `c-mode`) as well.

Fix bug where an empty `:disabled-for-modes` and a non-empty `:enabled-for-modes` enabled line  umbers everywhere, instead of only in modes specified in `:enabled-for-modes`. (see https://github.com/syl20bnr/spacemacs/issues/8482)