### PR TITLE
javascript: leverage js-doc Yasnippet integration if available

### DIFF
--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -22,7 +22,9 @@
   (spacemacs/declare-prefix-for-mode mode "mrd" "documentation")
   (spacemacs/set-leader-keys-for-major-mode mode
     "rdb" 'js-doc-insert-file-doc
-    "rdf" 'js-doc-insert-function-doc
+    "rdf" (if (configuration-layer/package-usedp 'yasnippet)
+              'js-doc-insert-function-doc-snippet
+            'js-doc-insert-function-doc)
     "rdt" 'js-doc-insert-tag
     "rdh" 'js-doc-describe-tag))
 


### PR DESCRIPTION
js-doc provides an alternative function for generating function doc comments
that makes use of Yasnippet to easily jump between the comment sections/tags.

This commit enables use of that function, if Yasnippet package is active.