### PR TITLE
Update sort-lines-by-column, improvements

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -841,16 +841,24 @@ A non-nil argument sorts in reverse order."
   (spacemacs/sort-lines -1))
 
 (defun spacemacs/sort-lines-by-column (&optional reverse)
-  "Sort lines by the selected column.
-A non-nil argument sorts in reverse order."
+  "Sort lines by the selected column,
+using a visual block/rectangle selection.
+A non-nil argument sorts in REVERSE order."
   (interactive "P")
-  (let* ((region-active (or (region-active-p) (evil-visual-state-p)))
-         (beg (if region-active (region-beginning) (point-min)))
-         (end (if region-active (region-end) (point-max))))
-    (sort-columns reverse beg end)))
+  (if (and
+       ;; is there an active selection
+       (or (region-active-p) (evil-visual-state-p))
+       ;; is it a block or rectangle selection
+       (or (eq evil-visual-selection 'block) (eq rectangle-mark-mode t))
+       ;; is the selection height 2 or more lines
+       (>= (1+ (- (line-number-at-pos (region-end))
+                  (line-number-at-pos (region-beginning)))) 2))
+      (sort-columns reverse (region-beginning) (region-end))
+    (error "Sorting by column requires a block/rect selection on 2 or more lines.")))
 
 (defun spacemacs/sort-lines-by-column-reverse ()
-  "Sort lines by the selected column in reverse order."
+"Sort lines by the selected column in reverse order,
+using a visual block/rectangle selection."
   (interactive)
   (spacemacs/sort-lines-by-column -1))
 


### PR DESCRIPTION
Resolves #8255 

Limit the lines to only get sorted when a block or rectangle
selection is active, on 2 or more lines. Otherwise show a
message stating the requirements for sorting by column.

#### Related PR
This also incorporates the updated doc-string that has it's own separate PR here:
Update sort lines by column, docstrings, how to #8196

I can close the doc-string only PR, if this is accepted.