### PR TITLE
Added keybindings for group-select (private channels) and select-rooms (channels, ims, and groups)

### DIFF
--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -65,6 +65,8 @@
       (spacemacs/set-leader-keys
         "aCs" 'slack-start
         "aCj" 'slack-channel-select
+        "aCg" 'slack-group-select
+        "aCr" 'slack-select-rooms
         "aCd" 'slack-im-select
         "aCq" 'slack-ws-close)
       (setq slack-enable-emoji t))


### PR DESCRIPTION
Our slack team uses a few private channels, so I added some keybindings to use with those.

It might be worthwhile to just put select-rooms on the j mapping and remove channel, group, and im selection bindings since rooms covers everything...