### PR TITLE
Modify default eshell pcomplete interface to helm.

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -112,7 +112,6 @@
       (evil-define-key 'insert eshell-mode-map
         (kbd "C-k") 'eshell-previous-matching-input-from-input
         (kbd "C-j") 'eshell-next-matching-input-from-input
-        (kbd "<tab>") 'helm-esh-pcomplete
         ))))
 
 

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -111,7 +111,10 @@
       ;; due to evil/emacs cursor incompatibility
       (evil-define-key 'insert eshell-mode-map
         (kbd "C-k") 'eshell-previous-matching-input-from-input
-        (kbd "C-j") 'eshell-next-matching-input-from-input))))
+        (kbd "C-j") 'eshell-next-matching-input-from-input
+        (kbd "<tab>") 'helm-esh-pcomplete
+        ))))
+
 
 (defun shell/init-eshell-prompt-extras ()
   (use-package eshell-prompt-extras


### PR DESCRIPTION
Override the keybinding for tab in eshell from pcomplete to helm-esh-pcomplete.
This is a (subjectively) nicer interface.
The results should remain unchanged.

There are [still](https://github.com/syl20bnr/spacemacs/issues/8504) two auto-completion when eshell is running. However, instead of pcomplete and company it is now helm-esh-pcomlete and company. 

Thank you for viewing my pull request, please give feedback if you'de like. 😄 