### PR TITLE
Fix and update eshell's clear features

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -125,15 +125,21 @@ is achieved by adding the relevant text properties."
   (when (configuration-layer/package-usedp 'semantic)
     (semantic-mode -1))
   ;; Caution! this will erase buffer's content at C-l
-  (define-key eshell-mode-map (kbd "C-l") 'eshell/clear)
+  (define-key eshell-mode-map (kbd "C-l") (funcall 'eshell-clear-keystroke))
   (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof))
 
-;; This is an eshell alias
-(defun eshell/clear ()
-  (interactive)
-  (let ((inhibit-read-only t))
-    (erase-buffer))
-  (eshell-send-input))
+(eval-after-load 'eshell
+  '(progn
+     ;; This is an eshell alias
+     (defun eshell/clear ()
+       (let ((inhibit-read-only t))
+         (erase-buffer)))
+     ;; This is a key-command
+     (defun eshell-clear-keystroke ()
+       (lambda ()
+         (interactive)
+         (eshell/clear)
+         (eshell-send-input)))))
 
 (defun spacemacs/helm-eshell-history ()
   "Correctly revert to insert state after selection."

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -129,12 +129,13 @@ is achieved by adding the relevant text properties."
     (let ((inhibit-read-only t))
       (erase-buffer)))
   ;; This is a key-command
-  (defun spacemacs/eshell-clear-keystroke () (lambda ()
-                                               (interactive)
-                                               (eshell/clear)
-                                               (eshell-send-input)))
+  (defun spacemacs/eshell-clear-keystroke ()
+    (interactive)
+    (let ()
+      (eshell/clear)
+      (eshell-send-input)))
  ;; Caution! this will erase buffer's content at C-l
-  (define-key eshell-mode-map (kbd "C-l") (funcall 'spacemacs/eshell-clear-keystroke))
+  (define-key eshell-mode-map (kbd "C-l") 'spacemacs/eshell-clear-keystroke)
   (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof))
 
 

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -134,7 +134,7 @@ is achieved by adding the relevant text properties."
     (interactive)
     (eshell/clear)
     (eshell-send-input))
- ;; Caution! this will erase buffer's content at C-l
+  ;; Caution! this will erase buffer's content at C-l
   (define-key eshell-mode-map (kbd "C-l") 'spacemacs/eshell-clear-keystroke)
   (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof))
 

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -132,9 +132,8 @@ is achieved by adding the relevant text properties."
   (defun spacemacs/eshell-clear-keystroke ()
     "Allow for keystrokes to invoke eshell/clear"
     (interactive)
-    (let ()
-      (eshell/clear)
-      (eshell-send-input)))
+    (eshell/clear)
+    (eshell-send-input))
  ;; Caution! this will erase buffer's content at C-l
   (define-key eshell-mode-map (kbd "C-l") 'spacemacs/eshell-clear-keystroke)
   (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof))

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -124,22 +124,20 @@ is achieved by adding the relevant text properties."
               'spacemacs//eshell-auto-end nil t))
   (when (configuration-layer/package-usedp 'semantic)
     (semantic-mode -1))
-  ;; Caution! this will erase buffer's content at C-l
-  (define-key eshell-mode-map (kbd "C-l") (funcall 'eshell-clear-keystroke))
+  ;; This is an eshell alias
+  (defun eshell/clear ()
+    (let ((inhibit-read-only t))
+      (erase-buffer)))
+  ;; This is a key-command
+  (defun spacemacs/eshell-clear-keystroke () (lambda ()
+                                               (interactive)
+                                               (eshell/clear)
+                                               (eshell-send-input)))
+ ;; Caution! this will erase buffer's content at C-l
+  (define-key eshell-mode-map (kbd "C-l") (funcall 'spacemacs/eshell-clear-keystroke))
   (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof))
 
-(eval-after-load 'eshell
-  '(progn
-     ;; This is an eshell alias
-     (defun eshell/clear ()
-       (let ((inhibit-read-only t))
-         (erase-buffer)))
-     ;; This is a key-command
-     (defun eshell-clear-keystroke ()
-       (lambda ()
-         (interactive)
-         (eshell/clear)
-         (eshell-send-input)))))
+
 
 (defun spacemacs/helm-eshell-history ()
   "Correctly revert to insert state after selection."

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -130,6 +130,7 @@ is achieved by adding the relevant text properties."
       (erase-buffer)))
   ;; This is a key-command
   (defun spacemacs/eshell-clear-keystroke ()
+    "Allow for keystrokes to invoke eshell/clear"
     (interactive)
     (let ()
       (eshell/clear)


### PR DESCRIPTION

Modify the default behavior for eshell's clear functionality.

 - Make eshell `clear RET` _similar_ to `C-l`
   - `clear RET` is eshell/clear
   - `C-l` is eshell-clear-stroke
 - Prevent `C-l` clearing cycle
 - Prevent `clear RET` inserting a page of white-space
 - Prevent duplicate insert lines from `clear RET`
 - Make eshell-clear-keystroke that is dependent on eshell/clear
   - Load both after eshell is initialized to prevent them from being overwritten

This fixes #5424, fixes #5419

Thank you for looking at my code.
Constructive critisicm is deeply appreciated. 
I'm sorry if I missed something.
I'm only a beginner. 😅 
