### PR TITLE
Remove "ph" 'helm-projectile from spacemacs-base

### DIFF
--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -342,7 +342,6 @@
         "pd" 'projectile-find-dir
         "pf" 'projectile-find-file
         "pF" 'projectile-find-file-dwim
-        "ph" 'helm-projectile
         "pr" 'projectile-recentf
         "pp" 'projectile-switch-project
         "pv" 'projectile-vc)


### PR DESCRIPTION
Problem: In the Ivy layer, `SPC p` lists: h -> helm-projectile
but when it's called, then it shows:
`command-execute: Wrong type argument: commandp, helm-projectile`

Solution: Remove "ph" 'helm-projectile from: spacemacs-base/package.el
Because it's also defined in the Helm layer.