### PR TITLE
Remove "pr" 'projectile-recentf from ivy layer

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -121,8 +121,7 @@
           "pb"    'counsel-projectile-switch-to-buffer
           "pd"    'counsel-projectile-find-dir
           "pp"    'counsel-projectile-switch-project
-          "pf"    'counsel-projectile-find-file
-          "pr"    'projectile-recentf)))))
+          "pf"    'counsel-projectile-find-file)))))
 
 (defun ivy/post-init-evil ()
   (spacemacs/set-leader-keys


### PR DESCRIPTION
problem: "pr" 'projectile-recentf is defined in both the Ivy layer
and spacemacs-base/packages.el

solution: remove it from the Ivy layer.