### PR TITLE
Use `terraform fmt` by default in the terraform layer

### DIFF
--- a/layers/+tools/terraform/README.org
+++ b/layers/+tools/terraform/README.org
@@ -5,6 +5,7 @@
 * Table of Contents                                         :TOC_4_gh:noexport:
  - [[#description][Description]]
  - [[#install][Install]]
+ - [[#configuration][Configuration]]
 
 * Description
 This layer provides syntax support for Terraform =.tf= files using
@@ -14,3 +15,17 @@ This layer provides syntax support for Terraform =.tf= files using
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =terraform= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+* Configuration
+By default, `terraform fmt` is applied to the terraform buffers before saving.
+If you wish to turn off this feature you may override this setting in your .spacemacs file.
+
+In .spacemacs user-init:
+#+begin_src emacs-lisp
+  (setq terraform-fmt-on-save nil)
+#+end_src
+
+In .spacemacs layers declaration:
+#+begin_src emacs-lisp
+  (terraform :variables terraform-fmt-on-save nil)
+#+end_src

--- a/layers/+tools/terraform/config.el
+++ b/layers/+tools/terraform/config.el
@@ -1,0 +1,15 @@
+;;; config.el -- terraform Layer configuration file for Spacemacs
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Harry Hull <harry.hull1@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; variables
+
+(defvar terraform-fmt-on-save t
+  "If set then use terraform fmt before saving the terraform buffer. Enabled by default.")

--- a/layers/+tools/terraform/packages.el
+++ b/layers/+tools/terraform/packages.el
@@ -13,4 +13,8 @@
 
 (defun terraform/init-terraform-mode ()
   (use-package terraform-mode
-    :defer t))
+    :defer t
+    :config
+    (if terraform-fmt-on-save
+        (add-hook 'terraform-mode-hook 'terraform-format-on-save-mode))
+    ))


### PR DESCRIPTION
Hey.

I wanted to allow terraform layer users to automatically `terraform fmt` when they saved. I updated the layer documentation to show examples of turning it off if they do not wish to use it.

The reason I decided to turn it on by default is because `terraform fmt` is both encouraged and modeled after `go fmt` which is automatically done before a save in the go layer. Please let me know if you disagree.