### PR TITLE
Update which-key popup: key/command grouping

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -342,13 +342,97 @@
       (push (cons (cons nil (concat "\\`" (car nd) "\\'")) (cons nil (cdr nd)))
             which-key-replacement-alist)))
 
-  (push '(("\\(.*\\) 0" . "select-window-0") . ("\\1 0..9" . "window 0..9"))
+  ;; Group together sequence and identical key entries in the which-key popup
+  ;; SPC h k- Top-level bindings
+  ;; Remove spaces around the two dots ".."
+  (push '(("\\(.*\\)1 .. 9" . "digit-argument") .
+          ("\\11..9" . "digit-argument"))
         which-key-replacement-alist)
-  (push '((nil . "select-window-[1-9]") . t) which-key-replacement-alist)
 
-  (push '(("\\(.*\\) 1" . "buffer-to-window-1") . ("\\1 1..9" . "buffer to window 1..9"))
+  ;; And remove the modifier key(s) before the last nr in the sequence
+  (push '(("\\(.*\\)C-0 .. C-5" . "digit-argument") .
+          ("\\1C-0..5" . "digit-argument"))
         which-key-replacement-alist)
-  (push '((nil . "buffer-to-window-[2-9]") . t) which-key-replacement-alist)
+
+  (push '(("\\(.*\\)C-7 .. C-9" . "digit-argument") .
+          ("\\1C-7..9" . "digit-argument"))
+        which-key-replacement-alist)
+
+  (push '(("\\(.*\\)C-M-0 .. C-M-9" . "digit-argument") .
+          ("\\1C-M-0..9" . "digit-argument"))
+        which-key-replacement-alist)
+
+  ;; Rename the entry for M-0 in the SPC h k Top-level bindings,
+  ;; and for 0 in the SPC- Spacemacs root
+  (push '(("\\(.*\\)0" . "winum-select-window-0-or-10") .
+          ("\\10" . "select window 0 or 10"))
+        which-key-replacement-alist)
+
+  ;; Rename the entry for M-1 in the SPC h k Top-level bindings,
+  ;; and for 1 in the SPC- Spacemacs root, to 1..9
+  (push '(("\\(.*\\)1" . "winum-select-window-1") .
+          ("\\11..9" . "select window 1..9"))
+        which-key-replacement-alist)
+
+  ;; Hide the entries for M-[2-9] in the SPC h k Top-level bindings,
+  ;; and for [2-9] in the SPC- Spacemacs root
+  (push '((nil . "winum-select-window-[2-9]") . t)
+        which-key-replacement-alist)
+
+  ;; SPC- Spacemacs root
+  ;; Combine the ` (backtick) and ² (superscript 2) key entries
+  (push '(("\\(.*\\)`" . "winum-select-window-by-number") .
+          ("\\1`,²" . "select window by number"))
+        which-key-replacement-alist)
+
+  ;; hide the "² -> winum-select-window-by-number" entry
+  (push '(("\\(.*\\)²" . nil) . t)
+        which-key-replacement-alist)
+
+  ;; SPC b- buffers
+  ;; rename the buffer-to-window-1 entry, to 1..9
+  (push '(("\\(.*\\)1" . "buffer-to-window-1") .
+          ("\\11..9" . "buffer to window 1..9"))
+        which-key-replacement-alist)
+
+  ;; hide the "[2-9] -> buffer-to-window-[2-9]" entries
+  (push '((nil . "buffer-to-window-[2-9]") . t)
+        which-key-replacement-alist)
+
+  ;; SPC k- lisp
+  ;; rename "1 .. 9 -> digit-argument" to "1..9 -> digit-argument"
+  (push '(("\\(.*\\)1 .. 9" . "evil-lisp-state-digit-argument") .
+          ("\\11..9" . "digit-argument"))
+        which-key-replacement-alist)
+
+  ;; C-c C-w-
+  ;; rename the eyebrowse-switch-to-window-config-0 entry, to 0..9
+  (push '(("\\(.*\\)0" . "eyebrowse-switch-to-window-config-0") .
+          ("\\10..9" . "eyebrowse-switch-to-window-config-0..9"))
+        which-key-replacement-alist)
+
+  ;; hide the "[1-9] -> eyebrowse-switch-to-window-config-[1-9]" entries
+  (push '((nil . "eyebrowse-switch-to-window-config-[1-9]") . t)
+        which-key-replacement-alist)
+
+  ;; Combine the c and C-c key entries
+  (push '(("\\(.*\\)C-c C-w c" . "eyebrowse-create-window-config") .
+          ("\\1c,C-c" . "eyebrowse-create-window-config"))
+        which-key-replacement-alist)
+
+  ;; hide the "C-c -> eyebrowse-create-window-config" entry
+  (push '(("\\(.*\\)C-c C-w C-c" . "eyebrowse-create-window-config") . t)
+          which-key-replacement-alist)
+
+  ;; C-c C-d-
+  ;; Combine the d and C-d key entries
+  (push '(("\\(.*\\)C-c C-d d" . "elisp-slime-nav-describe-elisp-thing-at-point") .
+          ("\\1d,C-d" . "elisp-slime-nav-describe-elisp-thing-at-point"))
+        which-key-replacement-alist)
+
+  ;; hide the "C-d -> elisp-slime-nav-describe-elisp-thing-at-point" entry
+  (push '(("\\(.*\\)C-c C-d C-d" . "elisp-slime-nav-describe-elisp-thing-at-point") . t)
+          which-key-replacement-alist)
 
   (dolist (leader-key `(,dotspacemacs-leader-key ,dotspacemacs-emacs-leader-key))
     (which-key-add-key-based-replacements


### PR DESCRIPTION
Comment the code and group the keys/commands based on the
which-key section they appear in.

Reduce the width of the listed keys:
By removing spaces around the two dots `..` in the key sequences, and
by removing the modifier keys before the last number in a sequence.

Update the `renamed select-window-[1-9]` command name, to the new
`winum-select-window-[1-9]` name.

Combine keys that call the same command.