### PR TITLE
update go layer README.md

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -55,7 +55,7 @@ For more information read [[https://github.com/alecthomas/gometalinter/blob/mast
 and [[https://github.com/favadi/flycheck-gometalinter/blob/master/README.md][flycheck-gometalinter README.md]]
 
 Make sure that =gocode= executable is in your PATH. For information about
-setting up =$PATH=, check out the corresponding section in the FAQ (~SPC h SPC
+setting up =$PATH=, check out the corresponding section in the FAQ (~SPC h f
 $PATH RET~).
 
 For best results, make sure that the =auto-completion= and =syntax-checking=


### PR DESCRIPTION
ivy-spacemacs-help-faq command's shortcut has turned into ~SPC h f~,but go layer README.md no update