### PR TITLE
[enhancement] OSX Layer. add config variables for different OSX modif…

### DIFF
--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -27,27 +27,51 @@ encourage you to do so :)
 
 * Install
 ** Layer
+
+Layer has been updated for new config variables. The variable =osx-use-option-as-meta=
+is still available for backwards compatibility and will take precedence if set.
+
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =osx= to the existing =dotspacemacs-configuration-layers= list in this file.
+The different modifier keys can be set as follows:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-defaults dotspacemacs-configuration-layers '(
+     (osx :variables osx-command-as       'super
+                     osx-option-as        'meta
+                     osx-control-as       'control
+                     osx-function-as      'none
+                     osx-right-command-as 'left
+                     osx-right-option-as  'left
+                     osx-right-control-as 'left))
+#+END_SRC
+
+These are also the default values. Setting the right modifier to =left=
+will equal the left modifier. Allowed values are: =super=, =meta=, =control=,
+=alt= and =none=.
+Setting =nil= for modifiers will leave the left modifiers as emacs default.
 
 *** Use with non-US keyboard layouts
 If you need the ~⌥~ key to type common characters such as ={[]}~= which is usual
 for e.g. Finnish and Swedish keyboard layouts, you'll probably want to leave the
-~⌥~ key unchanged by setting the =osx-use-option-as-meta= variable to =nil=:
+~⌥~ key unchanged by setting the =osx-option-as= variable to =none=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-     (osx :variables osx-use-option-as-meta nil)))
+     (osx :variables osx-option-as 'none)))
 #+END_SRC
 
 If you have problem entering symbols that are behind the ~⌥~ key you may want to
-added this to the user-init in the .spacemacs-File. This will allow you to use
+set the variables as follows. This will allow you to use
 the right ~⌥~ key to write symbols. The left ~⌥~ key can be used as the Meta
 key.
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default mac-right-option-modifier nil)
+  (setq-default dotspacemacs-configuration-layers '(
+     (osx :variables osx-option-as 'meta
+                     osx-right-option-as 'none)))
 #+END_SRC
+
 
 *** Define words using OS X Dictionary
 

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -9,9 +9,44 @@
 ;;
 ;;; License: GPLv3
 
-(defvar osx-use-option-as-meta t
-  "If non nil the option key is mapped to meta. Set to `nil` if you need the
-  option key to type common characters.")
+(defvar osx-use-option-as-meta 'deprecated
+  "DEPRECATED. See README for OSX layer for new variables. If this
+   variable is set it will take precedence (for backwards compatibility).
+   If non nil the option key is mapped to meta. Set to `nil` if you need the
+   option key to type common characters.
+   Default: `deprecated'")
+
+(defvar osx-command-as 'super
+  "Sets the key binding of the `COMMAND' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `super'.")
+(defvar osx-option-as 'meta
+  "Sets the key binding of the `OPTION' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `meta'.
+   For backwards compatibility the variable `osx-use-option-as-meta'
+   takes precedence is set to t.")
+(defvar osx-function-as 'none
+  "Sets the key binding of the `FUCTION' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `none'.")
+(defvar osx-control-as 'control
+  "Sets the key binding of the `CONTROL' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `control'.")
+
+(defvar osx-right-control-as 'left
+  "Sets the key binding of the `RIGHT CONTROL' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `left' `none'.
+   Default: `left'.")
+(defvar osx-right-command-as 'left
+  "Sets the key binding of the `RIGHT COMMAND' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `left' `none'.
+   Default: `left'.")
+(defvar osx-right-option-as 'left
+  "Sets the key binding of the `RIGHT OPTION' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `left' `none'.
+   Default: `left'.")
 
 (defvar osx-use-dictionary-app t
   "If non nil use osx dictionary app instead of wordnet")

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -14,14 +14,39 @@
 
   ;; this is only applicable to GUI mode
   (when (display-graphic-p)
-    ;; Treat command as super
-    (setq mac-command-key-is-meta nil)
-    (setq mac-command-modifier 'super)
 
-    (when osx-use-option-as-meta
-      ;; Treat option as meta
-      (setq mac-option-key-is-meta t))
-    (setq mac-option-modifier (if osx-use-option-as-meta 'meta nil))
+    ;; `Command' key is by default bound to SUPER (s-*).
+    ;; `Option' key is by default bound to META (M-*).
+    ;; `Function' key is by default not rebound.
+    ;; `Control' key is by default not rebound.
+    ;; The right variations of the above keys can
+    ;; also be modified but are not rebound by
+    ;; default.
+
+    ;; `Alist' linking the layer config variables to
+    ;; the internal Emacs variables for the modifier keys.
+    (setq modifier-keys '((osx-command-as       . mac-command-modifier)
+                          (osx-option-as        . mac-option-modifier)
+                          (osx-function-as      . mac-function-modifier)
+                          (osx-control-as       . mac-control-modifier)
+                          (osx-right-command-as . mac-right-command-modifier)
+                          (osx-right-option-as  . mac-right-option-modifier)
+                          (osx-right-control-as . mac-right-control-modifier)))
+
+    ;; The allowed non-nil values for the config variables.
+    (setq allowed-values '(super meta hyper control alt none left))
+
+    ;; Backwards compatibility
+    (case osx-use-option-as-meta
+      ('nil (setf osx-option-as 'none))
+      (deprecated nil)
+      (t (setf osx-option-as 'meta)))
+
+    ;; Set internal variables according to the given config variables
+    (cl-loop for (key-var . internal-var) in modifier-keys do
+             (let ((key-value (symbol-value key-var)))
+               (when (member key-value allowed-values)
+                 (setf (symbol-value internal-var) key-value))))
 
     ;; Keybindings
     (global-set-key (kbd "s-=") 'spacemacs/scale-up-font)


### PR DESCRIPTION
…ier keys.

Added variables to set all different modifier keys. See the README for details.
The commit is also backwards compatible with the previous config and the variable
`osx-use-option-as-meta` will take precedence if set to nil or non-nil value (except if
set to 'deprecated which is the new default).

Although the defaults should be unchanged I am using an Norwegian keyboard so if
anyone disagrees with my defaults please let me know and I will fix that.