### PR TITLE
Allow 'w' and 'b' movements in evil-numbers-transient-state

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -192,6 +192,10 @@
         ("+" evil-numbers/inc-at-pt)
         ("=" evil-numbers/inc-at-pt)
         ("-" evil-numbers/dec-at-pt)
+        ("_" evil-numbers/dec-at-pt)
+        ("b" evil-backward-word-begin)
+        ("w" evil-forward-word-begin)
+        ;; ^ best would be to move point to the next/prev number in buffer
         ("q" nil :exit t)) 
       (spacemacs/set-leader-keys
         "n+" 'spacemacs/evil-numbers-transient-state/evil-numbers/inc-at-pt


### PR DESCRIPTION
'w' and 'b' evil movements don't quit evil-numbers-transient-state. 'w' is very handy as subsequent addition/subtraction moves automatically to next number in line.