### PR TITLE
do not filter for alternating buffers

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -306,19 +306,13 @@ buffer."
   "Switch back and forth between current and last buffer in the
 current window."
   (interactive)
-  (let ((current-buffer (window-buffer window))
-        (buffer-predicate
-         (frame-parameter (window-frame window) 'buffer-predicate)))
-    ;; switch to first buffer previously shown in this window that matches
-    ;; frame-parameter `buffer-predicate'
+  (let ((current-buffer (window-buffer window)))
+    ;; if no window is found in the windows history, `switch-to-buffer' will
+    ;; default to calling `other-buffer'.
     (switch-to-buffer
-     (or (cl-find-if (lambda (buffer)
-                       (and (not (eq buffer current-buffer))
-                            (or (null buffer-predicate)
-                                (funcall buffer-predicate buffer))))
-                     (mapcar #'car (window-prev-buffers window)))
-         ;; `other-buffer' honors `buffer-predicate' so no need to filter
-         (other-buffer current-buffer t)))))
+     (cl-find-if (lambda (buffer)
+                   (not (eq buffer current-buffer)))
+                 (mapcar #'car (window-prev-buffers window))))))
 
 (defun spacemacs/alternate-window ()
   "Switch back and forth between current and last window in the

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -46,13 +46,6 @@ Cancels autosave on exiting perspectives mode."
                        *persp-hash* 'non-existent))
     (persp-switch spacemacs--last-selected-layout)))
 
-(defun spacemacs/alternate-buffer-in-persp ()
-  "Switch back and forth between current and last buffer in the
-current perspective."
-  (interactive)
-  (with-persp-buffer-list ()
-                          (switch-to-buffer (other-buffer (current-buffer) t))))
-
 (defun spacemacs-layouts/non-restricted-buffer-list-helm ()
   (interactive)
   (let ((ido-make-buffer-list-hook (remove #'persp-restrict-ido-buffers ido-make-buffer-list-hook)))

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -210,7 +210,6 @@
       (spacemacs/declare-prefix "B" "global-buffers")
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
-        "TAB"  'spacemacs/alternate-buffer-in-persp
         "ba"   'persp-add-buffer
         "br"   'persp-remove-buffer))))
 


### PR DESCRIPTION
Hey hey !

Now that I'm done taking care of my responsive Spaceline PR I'm back into business, so I stopped deffering it and fixed #7104 (and felt a little stupid as it was so quick to do) !

@syl20bnr if I understood you right I'm sure you will like this one 😸 

I also removed the `spacemacs/alternate-buffer-in-persp` function that wasn't used or bound, and that we don't want anyways because it has that same behaviour that was so annoying of filtering out buffers.