### PR TITLE
put vagrant bindings under `a` prefix

### DIFF
--- a/layers/+tools/vagrant/packages.el
+++ b/layers/+tools/vagrant/packages.el
@@ -18,15 +18,15 @@
     (progn
       (spacemacs/declare-prefix "V" "vagrant")
       (spacemacs/set-leader-keys
-        "VD" 'vagrant-destroy
-        "Ve" 'vagrant-edit
-        "VH" 'vagrant-halt
-        "Vp" 'vagrant-provision
-        "Vr" 'vagrant-resume
-        "VR" 'vagrant-reload
-        "Vs" 'vagrant-status
-        "VS" 'vagrant-suspend
-        "VV" 'vagrant-up))))
+        "aVD" 'vagrant-destroy
+        "aVe" 'vagrant-edit
+        "aVH" 'vagrant-halt
+        "aVp" 'vagrant-provision
+        "aVr" 'vagrant-resume
+        "aVR" 'vagrant-reload
+        "aVs" 'vagrant-status
+        "aVS" 'vagrant-suspend
+        "aVV" 'vagrant-up))))
 
 (defun vagrant/init-vagrant-tramp ()
   (use-package vagrant-tramp


### PR DESCRIPTION
:octocat: 