### PR TITLE
Add sayid, a debugger, to the clojure layer

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -28,6 +28,10 @@
      - [[#stacktrace-mode][stacktrace-mode]]
      - [[#inspector-mode][inspector-mode]]
      - [[#test-report-mode][test-report-mode]]
+   - [[#sayid-buffers][Sayid Buffers]]
+     - [[#sayid-mode][sayid-mode]]
+     - [[#sayid-traced-mode][sayid-traced-mode]]
+     - [[#sayid-pprint][sayid-pprint]]
  - [[#development-notes][Development Notes]]
    - [[#indentation][Indentation]]
 
@@ -39,7 +43,7 @@ This layer adds support for [[http://clojure.org][Clojure]] language using [[htt
 - Code formatting via [[https://github.com/clojure-emacs/cider][CIDER]] using [[https://github.com/weavejester/cljfmt][Cljfmt]]
 - Refactoring via [[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]]
 - Aligning of code forms via [[https://github.com/clojure-emacs/clojure-mode][clojure-mode]]
-
+- Debugging with [[https://bpiel.github.io/sayid/][sayid]]
 * Install
 ** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -198,12 +202,34 @@ As this state works the same for all files, the documentation is in global
 
 *** Debugging
 
-| Key Binding | Description                    |
-|-------------+--------------------------------|
-| ~SPC m d r~ | reload namepspaces             |
-| ~SPC m d b~ | instrument expression at point |
-| ~SPC m d e~ | display last stacktrace        |
-| ~SPC m d i~ | inspect expression at point    |
+| Key Binding   | Description                                        |
+|---------------+----------------------------------------------------|
+| ~SPC m d b~   | instrument expression at point                     |
+| ~SPC m d e~   | display last stacktrace                            |
+| ~SPC m d r~   | reload namepspaces                                 |
+| ~SPC m d v~   | inspect expression at point                        |
+| ~SPC m d i~   | inspect expression at point                        |
+| ~SPC m d f~   | query form at point                                |
+| ~SPC m d w~   | open sayid workspace window                        |
+| ~SPC m d E~   | one time display of value at cursor                |
+| ~SPC m d !~   | reload traces and clear sayid workspace            |
+| ~SPC m d c~   | clear workspace trace log                          |
+| ~SPC m d x~   | clear workspace traces and log                     |
+| ~SPC m d s~   | show what is currently traced                      |
+| ~SPC m d S~   | show what is currently traced in current namespace |
+| ~SPC m d V~   | set the view                                       |
+| ~SPC m d h~   | show sayid help (keybindings may not be accurate)  |
+| ~SPC m d t y~ | recursively trace every namespace in given dir     |
+| ~SPC m d t p~ | trace namespaces by regex                          |
+| ~SPC m d t b~ | trace current file's namespace                     |
+| ~SPC m d t e~ | enable existing trace on current function          |
+| ~SPC m d t E~ | enable existing trace on all functions             |
+| ~SPC m d t d~ | disable existing trace on current function         |
+| ~SPC m d t D~ | disable existing trace on all functions            |
+| ~SPC m d t n~ | create inner trace on function                     |
+| ~SPC m d t o~ | create outer trace on function                     |
+| ~SPC m d t r~ | remove trace on function                           |
+| ~SPC m d t K~ | remove all traces                                  |
 
 *** Refactoring
 
@@ -258,6 +284,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m f l~               | realign current form    |
 | ~SPC m f b~ or  ~SPC m =~ | reformat current buffer |
 
+
 ** CIDER Buffers
 In general, ~q~ should always quit the popped up buffer.
 
@@ -296,6 +323,7 @@ In general, ~q~ should always quit the popped up buffer.
 
 *** test-report-mode
 
+
 | Key Binding | Description       |
 |-------------+-------------------|
 | ~C-j~       | next result       |
@@ -306,6 +334,56 @@ In general, ~q~ should always quit the popped up buffer.
 | ~r~         | rerun tests       |
 | ~t~         | run test          |
 | ~T~         | run tests         |
+
+
+** Sayid Buffers
+
+*** sayid-mode
+
+| Key Binding        | Description                                       |
+|--------------------+---------------------------------------------------|
+| ~enter~            | pop to function                                   |
+| ~d~                | def value to $s/*                                 |
+| ~f~                | query for calls to function                       |
+| ~F~                | query to calls to function with modifier          |
+| ~i~                | show only this instance                           |
+| ~I~                | show only this instance with modifier             |
+| ~w~                | show full workspace trace                         |
+| ~n~                | jump to next call                                 |
+| ~N~                | jump to previous call                             |
+| ~P~                | pretty print value                                |
+| ~C~                | clear workspace trace log                         |
+| ~L~ or ~Backspace~ | previous buffer state                             |
+| ~Shift-Backspace~  | forward buffer state                              |
+| ~e~                | generate instance expression and put in kill ring |
+| ~H~                | display help (keybindings may not be accurate)    |
+| ~C-s v~            | toggle view                                       |
+| ~C-s V~            | set view                                          |
+
+*** sayid-traced-mode
+
+| Key Binding | Description                                    |
+|-------------+------------------------------------------------|
+| ~enter~     | drill into ns at point                         |
+| ~e~         | enable trace                                   |
+| ~d~         | disable trace                                  |
+| ~E~         | enable all traces                              |
+| ~D~         | disable all traces                             |
+| ~i~         | apply inner trace to function at point         |
+| ~o~         | apply outer trace to function at point         |
+| ~r~         | remove trace at point                          |
+| ~backspace~ | go back to trace overview                      |
+| ~h~         | display help (keybindings may not be accurate) |
+
+*** sayid-pprint
+
+| Key Binding | Description                 |
+|-------------+-----------------------------|
+| ~enter~     | show path in minibuffer     |
+| ~i~         | enter child node            |
+| ~o~         | enter parent node           |
+| ~n~         | enter next sibling node     |
+| ~p~         | enter previous sibling node |
 
 * Development Notes
 ** Indentation

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -13,6 +13,7 @@
     smartparens
     subword
     org
+    sayid
     ))
 
 (defun clojure/init-cider ()
@@ -295,3 +296,62 @@
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(clojure . t))
     (setq org-babel-clojure-backend 'cider)))
+
+(defun clojure/init-sayid ()
+  (use-package sayid
+    :defer t
+    :init
+    (progn
+      (setq sayid--key-binding-prefixes
+            '(("mdt" . "trace")))
+      (dolist (m '(clojure-mode
+                   clojurec-mode
+                   clojurescript-mode
+                   clojurex-mode
+                   cider-repl-mode
+                   cider-clojure-interaction-mode))
+        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                           m (car x) (cdr x)))
+              sayid--key-binding-prefixes)
+        (spacemacs/set-leader-keys-for-major-mode m
+          ;;These keybindings mostly preserved from the default sayid bindings
+          "df" 'sayid-query-form-at-point
+          "dw" 'sayid-get-workspace
+          "dE" 'sayid-eval-last-sexp ;in default sayid bindings this is lowercase e, but that was already used in clojure mode
+          "d!" 'sayid-load-enable-clear
+          "dc" 'sayid-clear-log
+          "dx" 'sayid-reset-workspace
+          "ds" 'sayid-show-traced
+          "dS" 'sayid-show-traced-ns
+          "dV" 'sayid-set-view
+          "dh" 'sayid-show-help
+          "dty" 'sayid-trace-all-ns-in-dir
+          "dtp" 'sayid-trace-ns-by-pattern
+          "dtb" 'sayid-trace-ns-in-file
+          "dte" 'sayid-trace-fn-enable
+          "dtE" 'sayid-trace-enable-all
+          "dtd" 'sayid-trace-fn-disable
+          "dtD" 'sayid-trace-disable-all
+          "dtn" 'sayid-inner-trace-fn
+          "dto" 'sayid-outer-trace-fn
+          "dtr" 'sayid-remove-trace-fn
+          "dtK" 'sayid-kill-all-traces))
+
+      (evilified-state-evilify sayid-mode sayid-mode-map
+        (kbd "H") 'sayid-buf-show-help
+        (kbd "n") 'sayid-buffer-nav-to-next
+        (kbd "N") 'sayid-buffer-nav-to-prev
+        (kbd "C-s v") 'sayid-toggle-view
+        (kbd "C-s V") 'sayid-set-view
+        (kbd "L") 'sayid-buf-back
+        (kbd "e") 'sayid-gen-instance-expr ;Originally this was bound to 'g', but I feel this is still mnemonic and doesn't overlap with evil
+        )
+      (evilified-state-evilify sayid-pprint-mode sayid-pprint-mode-map
+        (kbd "h") 'sayid-pprint-buf-show-help
+        (kbd "n") 'sayid-pprint-buf-next
+        (kbd "N") 'sayid-pprint-buf-prev
+        (kbd "l") 'sayid-pprint-buf-exit)
+
+      (evilified-state-evilify sayid-traced-mode sayid-traced-mode-map
+        (kbd "l") 'sayid-show-traced
+        (kbd "h") 'sayid-traced-buf-show-help))))


### PR DESCRIPTION
"Sayid (siy EED) is a tool for debugging and profiling clojure code."
(https://bpiel.github.io/sayid/) it allows viewing the results of each line of
code in a clojure function, without editing the code at all.

This commit evilifies the plugin and adds its commands to the "debug" submenu
of the main clojure mode menu. 

This should not affect any other features of the clojure layer in a noticeable way.