### PR TITLE
Fix #7644

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -17,6 +17,8 @@
         spaceline
         swiper))
 
+(setq persp-is-ibc-as-f-supported nil)
+
 
 
 (defun spacemacs-layouts/init-eyebrowse ()


### PR DESCRIPTION
persp-mode sets initial-buffer-choice to #[nil "�\207" [persp-special-last-buffer] 1] unless persp-is-ibc-as-f-supported is set to nil.

See #7644