### PR TITLE
Partially tame exec-path-from-shell

### DIFF
--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -27,7 +27,10 @@
         evil-visualstar
         ;; some packages need to look for binaries,
         ;; which means the path must be ready by then
-        (exec-path-from-shell :step pre)
+        (exec-path-from-shell :step pre
+                              :toggle (or (spacemacs/system-is-mac)
+                                          (spacemacs/system-is-linux)
+                                          (eq window-system 'x)))
         help-fns+
         (hi-lock :location built-in)
         (holy-mode :location local :step pre)
@@ -183,10 +186,8 @@
 
 (defun spacemacs-base/init-exec-path-from-shell ()
   (use-package exec-path-from-shell
-    :init (when (or (spacemacs/system-is-mac)
-                    (spacemacs/system-is-linux)
-                    (memq window-system '(x)))
-            (exec-path-from-shell-initialize))))
+    :demand t
+    :config (exec-path-from-shell-initialize)))
 
 (defun spacemacs-base/init-help-fns+ ()
   (use-package help-fns+

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -18,6 +18,7 @@
                                              'flycheck)))
         ggtags
         helm-gtags
+        exec-path-from-shell
         go-eldoc
         go-mode
         go-guru
@@ -37,12 +38,14 @@
 (defun go/post-init-flycheck ()
   (spacemacs/enable-flycheck 'go-mode))
 
-(defun go/init-go-mode()
-  (when (memq window-system '(mac ns x))
-    (dolist (var '("GOPATH" "GO15VENDOREXPERIMENT"))
-      (unless (getenv var)
-        (exec-path-from-shell-copy-env var))))
+(defun go/pre-init-exec-path-from-shell ()
+  (spacemacs|use-package-add-hook exec-path-from-shell
+    :pre-config
+    (dolist (var '("GOPATH" "GO15VENDOREXPERIMENT") exec-path-from-shell-variables)
+      (unless (or (member var exec-path-from-shell-variables) (getenv var))
+        (push var exec-path-from-shell-variables)))))
 
+(defun go/init-go-mode()
   (use-package go-mode
     :defer t
     :init

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -17,6 +17,7 @@
     flycheck
     (flycheck-rust :toggle (configuration-layer/package-usedp 'flycheck))
     ggtags
+    exec-path-from-shell
     helm-gtags
     rust-mode
     toml-mode
@@ -83,10 +84,15 @@
     ;; Don't pair lifetime specifiers
     (sp-local-pair 'rust-mode "'" nil :actions nil)))
 
-(defun rust/init-racer ()
-  (when (memq window-system '(mac ns x))
-    (exec-path-from-shell-copy-env "RUST_SRC_PATH"))
 
+(defun rust/pre-init-exec-path-from-shell ()
+  (spacemacs|use-package-add-hook exec-path-from-shell
+    :pre-config
+    (let ((var "RUST_SRC_PATH"))
+      (unless (or (member var exec-path-from-shell-variables) (getenv var))
+        (push var exec-path-from-shell-variables)))))
+
+(defun rust/init-racer ()
   (use-package racer
     :defer t
     :init


### PR DESCRIPTION
1. Make it possible to exclude the package (fix the go and rust layers).
2. Import variables all at once (avoid spawning multiple login shells).
3. Import variables early (during the "pre" package loading stage).
4. Centralize the platform check by using a package toggle in the `spacemacs-base`.
5. Avoid importing already defined variables (except `PATH`/`MANPATH`).

Relates to #8537.

TODO: We can probably trim the platform list to macos only.