### PR TITLE
Always return `t` from use-package pre/post hooks.

### DIFF
--- a/core/core-use-package-ext.el
+++ b/core/core-use-package-ext.el
@@ -44,7 +44,7 @@ override lazy-loaded settings."
           (let ((hook (intern (format "use-package--%S--%s-hook"
                                       name-symbol
                                       (substring (format "%s" keyword) 1)))))
-            (push `(add-hook ',hook (lambda nil ,@body)) expanded-forms)))))
+            (push `(add-hook ',hook (lambda nil ,@body t)) expanded-forms)))))
     `(progn ,@expanded-forms)))
 
 (provide 'core-use-package-ext)


### PR DESCRIPTION
Hooks that don't do this will prevent any further configuration of the package.

Docs: https://github.com/jwiegley/use-package/blob/53bf803f1d3efc61653f94fe56ff30a72304861e/use-package.el#L125
Context: https://github.com/syl20bnr/spacemacs/pull/8543/files#r106792261