### PR TITLE
[WIP] Add pippel to Python layer

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -27,6 +27,7 @@
     (nose :location local)
     org
     pip-requirements
+    pippel
     py-isort
     pyenv-mode
     (pylookup :location local)
@@ -171,6 +172,15 @@
 (defun python/init-pip-requirements ()
   (use-package pip-requirements
     :defer t))
+
+(defun python/init-pippel ()
+  (use-package pippel
+    :defer t
+    :init
+    (spacemacs/set-leader-keys "al" 'pippel-list-packages)
+    :config
+    (evilified-state-evilify-map pippel-package-menu-mode-map
+      :mode pippel-package-menu-mode)))
 
 (defun python/init-py-isort ()
   (use-package py-isort


### PR DESCRIPTION
Add pippel for Python package management.

> This package is an Emacs frontend for the Python package manager pip. As pippel also uses tabulated-list-mode, it provides a similiar package menu like package-list-packages.

Here is a screenshot:

![image](https://cloud.githubusercontent.com/assets/11584902/24078005/849f5506-0c9a-11e7-9fe2-5effb2b00b1a.png)

I'm not so sure about the <kbd>SPC a l</kbd> keybinding. If you got a better idea, please let me know.
