### PR TITLE
Late expand completion backends in the `spacemacs|add-company-backends` macro

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -73,7 +73,7 @@ Available PROPS:
             (mode-hook-name (intern (format "%S-hook" mode))))
         ;; declare buffer local company-backends variable
         (push `(defvar ,backends-var-name
-                 ',spacemacs-default-company-backends
+                 spacemacs-default-company-backends
                  ,(format "Company backend list for %S." mode)) result)
         ;; add backends
         (dolist (backend backends)


### PR DESCRIPTION
Otherwise, the Haskell layer throws an eager expansion error because `layers/+lang/haskell/funcs.el`, which calls this macro, is loaded before `layers/+completion/auto-completion/config.el`, which defines `spacemacs-default-company-backends`.

Late expansion may have unintended consequences. Was there a reason this variable was eagerly expanded?