### PR TITLE
Creates aligment for brackets

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -773,6 +773,7 @@ the right."
 (spacemacs|create-align-repeat-x "left-paren" "(")
 (spacemacs|create-align-repeat-x "right-paren" ")" t)
 (spacemacs|create-align-repeat-x "backslash" "\\\\")
+(spacemacs|create-align-repeat-x "brackets" "\\(\\s-*\\){" nil t)
 
 ;; END align functions
 

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -424,6 +424,7 @@
   "xa;" 'spacemacs/align-repeat-semicolon
   "xa=" 'spacemacs/align-repeat-equal
   "xa\\" 'spacemacs/align-repeat-backslash
+  "xa{" 'spacemacs/align-repeat-brackets
   "xaa" 'align
   "xac" 'align-current
   "xam" 'spacemacs/align-repeat-math-oper


### PR DESCRIPTION
Defines a function for aligning with the `{` and binds it to `SPC x a {` shortcut