### PR TITLE
Default enabel smartparen in SLIME REPL

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -54,11 +54,11 @@
       (setq slime-complete-symbol*-fancy t)
       (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
       ;; enabel smartparen in code buffer and SLIME REPL
-      ;; (add-hook 'slime-repl-mode-hook #'smartparens-strict-mode)
-      (defun slime/disable-smartparens ()
-        (smartparens-strict-mode -1)
-        (turn-off-smartparens-mode))
-      (add-hook 'slime-repl-mode-hook #'slime/disable-smartparens)
+      (add-hook 'slime-repl-mode-hook #'smartparens-strict-mode)
+      ;;(defun slime/disable-smartparens ()
+      ;;  (smartparens-strict-mode -1)
+      ;;  (turn-off-smartparens-mode))
+      ;;(add-hook 'slime-repl-mode-hook #'slime/disable-smartparens)
       (spacemacs/add-to-hooks 'slime-mode '(lisp-mode-hook)))
     :config
     (progn


### PR DESCRIPTION
**smartparens** provide many useful features, is there any special reason disable the smartparens in SLIME REPL?