### PR TITLE
Load org-mode email integration (mu4e/notmuch) when org is loaded.

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -18,7 +18,6 @@
     evil-surround
     gnuplot
     htmlize
-    mu4e
     ;; ob, org and org-agenda are installed by `org-plus-contrib'
     (ob :location built-in)
     (org :location built-in)
@@ -28,6 +27,9 @@
     org-download
     ;; org-mime is installed by `org-plus-contrib'
     (org-mime :location built-in)
+    ;; org-notmuch and org-mu4e are installed by `org-plus-contrib'
+    (org-notmuch :location built-in :toggle (configuration-layer/package-usedp 'notmuch))
+    (org-mu4e :location built-in :toggle (configuration-layer/package-usedp 'mu4e))
     org-pomodoro
     org-present
     (org-projectile :toggle (configuration-layer/package-usedp 'projectile))
@@ -76,10 +78,13 @@
   (use-package htmlize
     :defer t))
 
-(defun org/pre-init-mu4e ()
-  ;; Load org-mu4e when mu4e is actually loaded
-  (spacemacs|use-package-add-hook mu4e
-    :post-config (require 'org-mu4e nil 'noerror)))
+(defun org/init-org-mu4e ()
+  (with-eval-after-load 'org
+    (require 'org-mu4e)))
+
+(defun org/init-org-notmuch ()
+  (with-eval-after-load 'org
+    (require 'org-notmuch)))
 
 (defun org/init-ob ()
   (use-package ob


### PR DESCRIPTION
Before, `org-mu4e` would be loaded when mu4e was. However, as an extension to
org mode, not mu4e, it should be loaded when org mode is.

This commit also adds similar support for notmuch.

This supersedes #7977.