### PR TITLE
Switch off `spacemacs-purpose` if not enabled from .spacemacs

### DIFF
--- a/layers/+distributions/spacemacs/layers.el
+++ b/layers/+distributions/spacemacs/layers.el
@@ -17,7 +17,6 @@
                                       spacemacs-evil
                                       spacemacs-language
                                       spacemacs-misc
-                                      spacemacs-purpose
                                       spacemacs-ui
                                       spacemacs-ui-visual
                                       spacemacs-org))

--- a/layers/+spacemacs/spacemacs-purpose/README.org
+++ b/layers/+spacemacs/spacemacs-purpose/README.org
@@ -68,7 +68,7 @@ result is a better control over how buffers are displayed, since
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add spacemacs-purpose= to the existing =dotspacemacs-configuration-layers= list in
+add =spacemacs-purpose= to the existing =dotspacemacs-configuration-layers= list in
 this file.
 
 * Usage


### PR DESCRIPTION
The README says to enable it, add `spacemacs-purpose` to the dotfile.