### PR TITLE
Adds the `neotree-quick-look` keybind

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -191,6 +191,7 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
 [_h_]   up/collapse^^      ^^                ^^^
 [_j_]   line down^^        ^^                ^^^
 [_k_]   line up^^          ^^                ^^
+[_'_]   quick look         ^^                ^^
 [_RET_] open               ^^^^              [_?_]   close hints
 "
         :bindings
@@ -199,6 +200,7 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
         ("|" neotree-enter-vertical-split)
         ("-" neotree-enter-horizontal-split)
         ("?" nil :exit t)
+        ("'" neotree-quick-look)
         ("c" neotree-create-node)
         ("C" neotree-copy-node)
         ("d" neotree-delete-node)
@@ -224,6 +226,7 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
           (kbd "RET") 'neotree-enter
           (kbd "|") 'neotree-enter-vertical-split
           (kbd "-") 'neotree-enter-horizontal-split
+          (kbd "'") 'neotree-quick-look
           (kbd "c") 'neotree-create-node
           (kbd "C") 'neotree-copy-node
           (kbd "d") 'neotree-delete-node


### PR DESCRIPTION
Weirdly, the `'` keybind for `neotree-mode-map` was already present when
doing `M-x neotree-quick-look` with the cursor on the neotree window but
I could not find where exactly it was defined.

This commit officially adds it to the `neotree-mode-map` and the neotree
transient state.