### PR TITLE
Update auto-completion layer readme.org: dead link

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -25,7 +25,7 @@ This layer provides auto-completion to Spacemacs.
 
 The following completion engines are supported:
 - [[http://company-mode.github.io/][company]]
-- [[http://auto-complete.org/][auto-complete]]
+- [[https://github.com/auto-complete/auto-complete][auto-complete]]
 
 Snippets are supported via [[https://github.com/capitaomorte/yasnippet][yasnippet]] and [[https://github.com/abo-abo/auto-yasnippet][auto-yasnippet]].
 


### PR DESCRIPTION
Problem:  The auto-complete link: auto-complete.org leads to a domain
          for sale page.
Solution: Change the link to the auto-complete github page.