### PR TITLE
[java] extend config and fix company backends

### DIFF
--- a/layers/+lang/java/config.el
+++ b/layers/+lang/java/config.el
@@ -19,3 +19,12 @@ and `meghanada'.")
 
 (defvar java--ensime-modes '(java-mode)
   "Modes using ensime. Mainly used to define ENSIME key bindings.")
+
+(defvar java-enable-backend-company t
+  "If non-nil enable company backends for the given java layer backend.
+   Default: t.")
+
+(defvar java-autoenable-backend nil
+  "If non nil the chosen backend mode will be automatically activated when entering
+   java mode.
+   Default: nil.")

--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -189,10 +189,6 @@
 
 (defun spacemacs//java-setup-eclim-company ()
   "Setup Eclim auto-completion."
-  (spacemacs|add-company-backends
-    :backends company-emacs-eclim
-    :modes eclim-mode
-    :hooks nil)
   ;; call manualy generated functions by the macro
   (spacemacs//init-company-eclim-mode)
   (set (make-variable-buffer-local 'company-idle-delay) 0.5)
@@ -242,7 +238,8 @@
 
 (defun spacemacs//java-setup-meghanada-company ()
   "Setup Meghanada auto-completion."
-  (meghanada-company-enable))
+  (meghanada-company-enable)
+  (company-mode))
 
 (defun spacemacs//java-setup-meghanada-flycheck ()
   "Setup Meghanada syntax checking."


### PR DESCRIPTION
This PR fixes a few issues I had with the updated java layer.

1. Got some warnings in *messages* of eager loading void variable  `spacemacs-default-company-backends`.
2. The company-backends when using the different java backends was not being properly activated and did not include yasnippets. It also completely erased the default fallback backends.
3. It was not possible to enable backend modes by default.

IMO this PR does not accomplish to fix all this 100%. It accomplishes the following:

Problem 1: Move adding backends from funcs.el into packages.el -> :init so no more warnings.
Problem 2: All company-backends now include snippets and default fallback company-backends. A toggle var `java-enable-backend-company` is also provided. If nil then the java-backend company-backend is not added to company and the defaults are used.

Problem 3: A new toggle `java-autoenable-backend` is provided and if non nil a hook is added to java-mode to autoload the backend mode.

The main defects for this PR are for Problem 3:

1. The company-backends are not loaded when the mode is autoenabled. One has to toggle on/off for it to be properly loaded.
2. Autoenable is not possible for the ensime backend as this will start a new process every time the buffer is reloaded.

If anyone want to build on this PR and fix the problems this would be welcome.

Also I do not understand the hook:
`(add-hook` 'java-mode-local-vars-hook #'spacemacs//java-setup-company)``

When is this hook activated? I think this might be deprecated if this PR is merged as company is setup differently.