### PR TITLE
Add browse at remote

### DIFF
--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -118,4 +118,4 @@ In the gist list buffer:
 
 | Key Binding | Description                                                        |
 |-------------+--------------------------------------------------------------------|
-| ~SPC g h o~ | browse to file on GitHub                                           |
+| ~SPC g h O~ | browse to file on GitHub                                           |

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -42,7 +42,7 @@
 (defun github/init-github-browse-file ()
   (use-package github-browse-file
     :defer t
-    :init (spacemacs/set-leader-keys "gho" 'github-browse-file)))
+    :init (spacemacs/set-leader-keys "ghO" 'github-browse-file)))
 
 (defun github/init-github-clone ()
   (use-package github-clone

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -73,6 +73,7 @@ one over the other:
 | ~SPC g r~   | smerge mode transient-state     |
 | ~SPC T d~   | toggle diff margins             |
 | ~SPC T C-d~ | toggle diff margins globally    |
+| ~SPC g h o~ | browser at remote               |
 
 ** Version Control Transient-state
 

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -11,6 +11,7 @@
 
 (setq version-control-packages
       '(
+        browse-at-remote
         diff-mode
         diff-hl
         evil-unimpaired
@@ -208,3 +209,8 @@
         ("r" smerge-refine)
         ("u" undo-tree-undo)
         ("q" nil :exit t)))))
+
+(defun version-control/init-browse-at-remote ()
+  (use-package browse-at-remote
+    :defer t
+    :init (spacemacs/set-leader-keys "gho" 'browse-at-remote)))


### PR DESCRIPTION
Solve #7186

Instead of removing  `github-browse-file` I simply rebinded it to `ghO` and made `browse-at-remote` `gho` (it seems to be better)