### PR TITLE
Fix keybinding to helm-cscope-find-calling-this-function

### DIFF
--- a/layers/+tags/cscope/packages.el
+++ b/layers/+tags/cscope/packages.el
@@ -48,7 +48,7 @@
       "Setup `helm-cscope' for MODE"
       (spacemacs/set-leader-keys-for-major-mode mode
         "gc" 'helm-cscope-find-called-function
-        "gC" 'helm-cscope-find-calling-this-funtcion
+        "gC" 'helm-cscope-find-calling-this-function
         "gd" 'helm-cscope-find-global-definition
         "ge" 'helm-cscope-find-egrep-pattern
         "gf" 'helm-cscope-find-this-file


### PR DESCRIPTION
Typo which was incorrect before has now been fixed [upstream](https://github.com/alpha22jp/helm-cscope.el/commit/3cc7259ab4989f9f7ca039e703cdac14b907530a). Therefore the `cscope` layer needs this fix as it started throwing an error
