### PR TITLE
[typescript] Use tslint and tsserver from node_modules if available

### DIFF
--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -64,3 +64,27 @@
                  (list (point-min) (point-max))))
   (browse-url (concat "http://www.typescriptlang.org/Playground#src="
                       (url-hexify-string (buffer-substring-no-properties start end)))))
+
+(defun spacemacs//typescript-use-tslint-from-node-modules ()
+  (let* ((root (locate-dominating-file
+                (or (buffer-file-name) default-directory)
+                "node_modules"))
+         (global-tslint (executable-find "tslint"))
+         (local-tslint (expand-file-name "node_modules/.bin/tslint"
+                                         root))
+         (tslint (if (file-executable-p local-tslint)
+                     local-tslint
+                   global-tslint)))
+    (setq-local flycheck-typescript-tslint-executable tslint)))
+
+(defun spacemacs//typescript-use-tsserver-from-node-modules ()
+  (let* ((root (locate-dominating-file
+                (or (buffer-file-name) default-directory)
+                "node_modules"))
+         (global-tsserver (executable-find "tsserver"))
+         (local-tsserver (expand-file-name "node_modules/.bin/tsserver"
+                                           root))
+         (tsserver (if (file-executable-p local-tsserver)
+                       local-tsserver
+                     global-tsserver)))
+    (setq-local tide-tsserver-executable tsserver)))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -29,7 +29,8 @@
   (add-hook 'typescript-mode-hook 'eldoc-mode))
 
 (defun typescript/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'typescript-mode))
+  (spacemacs/enable-flycheck 'typescript-mode)
+  (add-hook 'typescript-mode-hook #'spacemacs//typescript-use-tslint-from-node-modules))
 
 (defun typescript/init-tide ()
   (use-package tide
@@ -42,7 +43,8 @@
         (kbd "C-j") 'tide-find-next-reference
         (kbd "C-l") 'tide-goto-reference)
       (add-hook 'typescript-mode-hook 'tide-setup)
-      (add-to-list 'spacemacs-jump-handlers-typescript-mode 'tide-jump-to-definition))
+      (add-to-list 'spacemacs-jump-handlers-typescript-mode 'tide-jump-to-definition)
+      (add-hook 'typescript-mode-hook #'spacemacs//typescript-use-tsserver-from-node-modules))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")


### PR DESCRIPTION
Because different projects can have specific versions of typescript and/or tslint, it makes sense to use node_modules if available to avoid version clashing.