### PR TITLE
csharp: enable flycheck by default

### DIFF
--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -17,6 +17,7 @@
     ggtags
     helm-gtags
     omnisharp
+    flycheck
     ))
 
 (defun csharp/init-omnisharp ()
@@ -110,3 +111,6 @@
 
 (defun csharp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'csharp-mode))
+
+(defun csharp/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'csharp-mode))


### PR DESCRIPTION
`omnisharp-emacs` supports `flycheck` just fine; – don't know why this wasn't enabled by default before