### PR TITLE
common-lisp: Add slime-asdf to slime-contribs

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -43,7 +43,8 @@
     :init
     (progn
       (spacemacs/register-repl 'slime 'slime)
-      (setq slime-contribs '(slime-fancy
+      (setq slime-contribs '(slime-asdf
+                             slime-fancy
                              slime-indentation
                              slime-sbcl-exts
                              slime-scratch)


### PR DESCRIPTION
Some slime commands such as `,load-system` do not work without `slime-asdf` being loaded. Since ASDF is the main system definition facility used by lisp programs, I think this functionality should be available by default.