### PR TITLE
Unbreak diff-mode

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -24,11 +24,7 @@
 
 (defun version-control/init-diff-mode ()
   (use-package diff-mode
-    :defer t
-    :config
-    (evilified-state-evilify diff-mode diff-mode-map
-      "j" 'diff-hunk-next
-      "k" 'diff-hunk-prev)))
+    :defer t))
 
 (defun version-control/init-diff-hl ()
   (use-package diff-hl


### PR DESCRIPTION
diff-mode is for *editing* diffs. Defaulting to evilified state and binding j/k breaks this.

You can still use TAB/S-TAB to navigate through hunks.