### PR TITLE
Work around bug in eshell's preoutput-filter code.

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -83,6 +83,13 @@
       (add-hook 'eshell-mode-hook 'spacemacs/disable-hl-line-mode))
     :config
     (progn
+      (define-advice eshell-output-filter (:around (fn process string) with-buffer)
+        (let ((proc-buf (if process (process-buffer process)
+                          (current-buffer))))
+          (when proc-buf
+            (with-current-buffer proc-buf
+              (funcall fn process string)))))
+
       (require 'esh-opt)
 
       ;; quick commands


### PR DESCRIPTION
Eshell doesn't call preoutput-filter functions in the context of the eshell buffer. This breaks the xterm color filtering when the eshell buffer is updated when the eshell buffer is not currently focused.

I intend to submit this fix upstream when I get a chance but an advice fixes it for now. The other fix is to move the xterm color filter to a output-filter function (instead of preoutput-filter) but those operate on strings that have already been inserted into the buffer.