### PR TITLE
adds prodigy-view-clear-buffer leader key binding

### DIFF
--- a/layers/+tools/prodigy/packages.el
+++ b/layers/+tools/prodigy/packages.el
@@ -16,6 +16,7 @@
     :init
     (spacemacs/set-leader-keys "aS" 'prodigy)
     :config
+    (evil-define-key 'motion prodigy-view-mode-map "c" 'prodigy-view-clear-buffer)
     (evilified-state-evilify prodigy-mode prodigy-mode-map
       "h" 'prodigy-first
       "j" 'prodigy-next


### PR DESCRIPTION
Hello,

When I am in a buffer with `Prodigy-view` I would like to have a key binding to clear the buffer.

This makes `,c` to clear the the buffer by calling `prodigy-view-clear-buffer`.

Do you think this is useful?

Thanks in advance