### PR TITLE
rcirc: Fix using multiple .authinfo lines for authentication.

### DIFF
--- a/layers/+chat/rcirc/funcs.el
+++ b/layers/+chat/rcirc/funcs.el
@@ -18,7 +18,8 @@ Allow rcirc to read authinfo from ~/.authinfo.gpg via the auth-source API.
 This doesn't support the chanserv auth method. "
   (require 'auth-source)
   (dolist (p (auth-source-search :port '("nickserv" "bitlbee" "quakenet")
-                                 :require '(:port :user :secret)))
+                                 :require '(:port :user :secret)
+                                 :max (length rcirc-server-alist)))
     (let ((secret (plist-get p :secret))
           (method (intern (plist-get p :port))))
       (add-to-list


### PR DESCRIPTION
The auth-source-search function has an implied :max parameter with value 1. In
the case of connecting to multiple irc servers, only the first line in .authinfo
was applied. Thus, we should pass a value for :max to auth-source-search that is
guaranteed to at least be able to fit all our credentials.

Considerations: one might of course have irc-related lines in `.authinfo` which are not configured in spacemacs. In such a case, it is possible that some relevant `.authinfo` lines will never be seen by spacemacs. It would also be possible to replace the `(length rcirc-server-alist)` by a reasonably high number, or perhaps expose the value passed to `:max` in `auth-source-search` as a layer-specific variable.
