### PR TITLE
GLPv3 -> GPLv3 for shaders package

### DIFF
--- a/layers/+lang/shaders/packages.el
+++ b/layers/+lang/shaders/packages.el
@@ -7,7 +7,7 @@
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
-;;; License: GLPv3
+;;; License: GPLv3
 (setq shaders-packages
       '(glsl-mode
         (company-glsl :location (recipe


### PR DESCRIPTION
Fix a small typo in the shaders package. I plan to contribute another small PR against this package, but wanted to split out this change since it's unrelated.