### PR TITLE
Fix repeating jumping to errors using the '.' command

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -240,7 +240,12 @@
 
 (defun spacemacs-evil/init-evil-unimpaired ()
   ;; No laziness here, unimpaired bindings should be available right away.
-  (use-package evil-unimpaired))
+  (use-package evil-unimpaired
+    :init
+    (progn
+      ;; Jumping to an error should not be repeated when pressing the '.' key
+      (evil-declare-ignore-repeat 'spacemacs/next-error)
+      (evil-declare-ignore-repeat 'spacemacs/previous-error))))
 
 (defun spacemacs-evil/init-evil-visual-mark-mode ()
   (use-package evil-visual-mark-mode


### PR DESCRIPTION
The unimpaired keybindings `[ q` and `] q` can be used to jump to flycheck
errors in the current buffer. Because evil-repeat treated them as regular
operations, they were repeated when pressing the `.` key. This made it harder to
refactor errors as you'd have to manually repeat your edits.

This fixes #8083.