### PR TITLE
Add escape and M-SPC bindings to ivy

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -164,6 +164,11 @@
        'counsel-recentf
        spacemacs--ivy-file-actions)
 
+      ;; mappings to quit minibuffer or enter transient state
+      (define-key ivy-minibuffer-map [escape] 'minibuffer-keyboard-quit)
+      (define-key ivy-minibuffer-map (kbd "M-SPC") 'hydra-ivy/body)
+      (define-key hydra-ivy/keymap [escape] 'hydra-ivy/keyboard-escape-quit-and-exit)
+
       (ivy-mode 1)
       (global-set-key (kbd "C-c C-r") 'ivy-resume)
       (global-set-key (kbd "<f6>") 'ivy-resume)


### PR DESCRIPTION
Add escape and M-SPC bindings to ivy
- escape quits the minibuffer
- M-SPC enters transient state

See conventions at https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org

#### Issues to be resolved ####
- [x] Pressing escape in hydra-ivy exits minibuffer, but doesn't exit transient state
To reproduce press M-SPC, escape.