### PR TITLE
Set go-mode adaptive fill function

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -53,7 +53,15 @@
       (defun spacemacs//go-set-tab-width ()
         "Set the tab width."
         (setq-local tab-width go-tab-width))
-      (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width))
+      (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width)
+
+      (defun spacemacs//go-adaptive-fill ()
+        (looking-at "^[ \t]*// ")
+        (match-string-no-properties 0))
+      (defun spacemacs//go-set-adaptive-fill-function ()
+        "Enable comment aware adaptive fill"
+        (setq-local adaptive-fill-function 'spacemacs//go-adaptive-fill))
+      (add-hook 'go-mode-hook 'spacemacs//go-set-adaptive-fill-function))
     :config
     (progn
       (add-hook 'before-save-hook 'gofmt-before-save)


### PR DESCRIPTION
So that filling lines selected in visual mode that consist of comments works as expected.

Considering the following buffer content (and assuming the Go major mode is enabled):
```
// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi semper ipsum a magna consectetur egestas quis ut odio.
// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi semper ipsum a magna consectetur egestas quis ut odio.
```

Before this change selecting these two lines in visual mode and running `fill-paragraph` produces:
```
// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi semper ipsum a
magna consectetur egestas quis ut odio. // Lorem ipsum dolor sit amet,
consectetur adipiscing elit. Morbi semper ipsum a magna consectetur egestas quis
ut odio.
```

After the change it produces:
```
// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi semper ipsum a
// magna consectetur egestas quis ut odio. Lorem ipsum dolor sit amet,
// consectetur adipiscing elit. Morbi semper ipsum a magna consectetur egestas
// quis ut odio.
```

Running `fill-paragraph` on non comment code or when no selection is made is unaffected by this PR.