### PR TITLE
[enhancement] OSX Layer. change osx-command-as default for ⌘ to hyper instead of super

### DIFF
--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -15,7 +15,7 @@
 
 * Description
 Spacemacs is not just emacs+vim. It can have OSX keybindings too! This layer
-globally defines common OSX keybindings. ~⌘~ is set to ~super~ and ~⌥~ is set to
+globally defines common OSX keybindings. ~⌘~ is set to ~hyper~ and ~⌥~ is set to
 ~meta~. Aside from that, there's nothing much, really.
 
 While in =dired= this layer will try to use =gls= instead of =ls=.
@@ -37,7 +37,7 @@ The different modifier keys can be set as follows:
 
 #+BEGIN_SRC emacs-lisp
   (setq-defaults dotspacemacs-configuration-layers '(
-     (osx :variables osx-command-as       'super
+     (osx :variables osx-command-as       'hyper
                      osx-option-as        'meta
                      osx-control-as       'control
                      osx-function-as      'none
@@ -115,6 +115,7 @@ To get =gls= install coreutils homebrew:
 | ~⌘ w~       | Close window                |
 | ~⌘ W~       | Close frame                 |
 | ~⌘ n~       | New frame                   |
+| ~⌘ `~       | Other frame                 |
 | ~⌘ z~       | Undo                        |
 | ~⌘ Z~       | Redo                        |
 | ~⌃ ⌘ f~     | Toggle fullscreen           |

--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -27,27 +27,51 @@ encourage you to do so :)
 
 * Install
 ** Layer
+
+Layer has been updated for new config variables. The variable =osx-use-option-as-meta=
+is still available for backwards compatibility and will take precedence if set.
+
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =osx= to the existing =dotspacemacs-configuration-layers= list in this file.
+The different modifier keys can be set as follows:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-defaults dotspacemacs-configuration-layers '(
+     (osx :variables osx-command-as       'super
+                     osx-option-as        'meta
+                     osx-control-as       'control
+                     osx-function-as      'none
+                     osx-right-command-as 'left
+                     osx-right-option-as  'left
+                     osx-right-control-as 'left))
+#+END_SRC
+
+These are also the default values. Setting the right modifier to =left=
+will equal the left modifier. Allowed values are: =super=, =meta=, =control=,
+=alt= and =none=.
+Setting =nil= for modifiers will leave the left modifiers as emacs default.
 
 *** Use with non-US keyboard layouts
 If you need the ~⌥~ key to type common characters such as ={[]}~= which is usual
 for e.g. Finnish and Swedish keyboard layouts, you'll probably want to leave the
-~⌥~ key unchanged by setting the =osx-use-option-as-meta= variable to =nil=:
+~⌥~ key unchanged by setting the =osx-option-as= variable to =none=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-     (osx :variables osx-use-option-as-meta nil)))
+     (osx :variables osx-option-as 'none)))
 #+END_SRC
 
 If you have problem entering symbols that are behind the ~⌥~ key you may want to
-added this to the user-init in the .spacemacs-File. This will allow you to use
+set the variables as follows. This will allow you to use
 the right ~⌥~ key to write symbols. The left ~⌥~ key can be used as the Meta
 key.
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default mac-right-option-modifier nil)
+  (setq-default dotspacemacs-configuration-layers '(
+     (osx :variables osx-option-as 'meta
+                     osx-right-option-as 'none)))
 #+END_SRC
+
 
 *** Define words using OS X Dictionary
 

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -9,9 +9,44 @@
 ;;
 ;;; License: GPLv3
 
-(defvar osx-use-option-as-meta t
-  "If non nil the option key is mapped to meta. Set to `nil` if you need the
-  option key to type common characters.")
+(defvar osx-use-option-as-meta 'deprecated
+  "DEPRECATED. See README for OSX layer for new variables. If this
+   variable is set it will take precedence (for backwards compatibility).
+   If non nil the option key is mapped to meta. Set to `nil` if you need the
+   option key to type common characters.
+   Default: `deprecated'")
+
+(defvar osx-command-as 'super
+  "Sets the key binding of the `COMMAND' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `super'.")
+(defvar osx-option-as 'meta
+  "Sets the key binding of the `OPTION' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `meta'.
+   For backwards compatibility the variable `osx-use-option-as-meta'
+   takes precedence is set to t.")
+(defvar osx-function-as 'none
+  "Sets the key binding of the `FUCTION' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `none'.")
+(defvar osx-control-as 'control
+  "Sets the key binding of the `CONTROL' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Default: `control'.")
+
+(defvar osx-right-control-as 'left
+  "Sets the key binding of the `RIGHT CONTROL' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `left' `none'.
+   Default: `left'.")
+(defvar osx-right-command-as 'left
+  "Sets the key binding of the `RIGHT COMMAND' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `left' `none'.
+   Default: `left'.")
+(defvar osx-right-option-as 'left
+  "Sets the key binding of the `RIGHT OPTION' key on OSX.
+   Possible values are `super' `meta' `hyper' `alt' `left' `none'.
+   Default: `left'.")
 
 (defvar osx-use-dictionary-app t
   "If non nil use osx dictionary app instead of wordnet")

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -16,10 +16,19 @@
    option key to type common characters.
    Default: `deprecated'")
 
-(defvar osx-command-as 'super
+(defvar osx-command-as 'hyper
   "Sets the key binding of the `COMMAND' key on OSX.
    Possible values are `super' `meta' `hyper' `alt' `none'.
-   Default: `super'.")
+   Default: `hyper'.")
+;; There are problems setting osx-command-as to `alt' and `super',
+;; so we use `hyper' as a default instead because, for example:
+;;   - Using `alt':   Command-x or Command-m inserts, respectively: × µ
+;;   - Using `super': Control-Command-f produces keycode: <C-s-268632078>
+;; Setting to `hyper' seems to avoid both types of the above problems.
+;; Also, while it is possible, it is not recommended to set to `meta'
+;; since standard OSX shortcuts would overshadow important keys such
+;; as M-x.
+
 (defvar osx-option-as 'meta
   "Sets the key binding of the `OPTION' key on OSX.
    Possible values are `super' `meta' `hyper' `alt' `none'.

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -15,7 +15,7 @@
   ;; this is only applicable to GUI mode
   (when (display-graphic-p)
 
-    ;; `Command' key is by default bound to SUPER (s-*).
+    ;; `Command' key is by default bound to HYPER (H-*),
     ;; `Option' key is by default bound to META (M-*).
     ;; `Function' key is by default not rebound.
     ;; `Control' key is by default not rebound.
@@ -48,24 +48,41 @@
                (when (member key-value allowed-values)
                  (setf (symbol-value internal-var) key-value))))
 
+    (defun kbd-mac-command (keys)
+      "Wraps `kbd' function with Mac OSX compatible Command-key (⌘).
+KEYS should be a string such as \"f\" which will be turned into values
+such as \"H-f\", \"s-f\", or \"A-f\" depending on the value of
+`mac-commmand-modifier' which could be `hyper', `super', or `alt'.
+KEYS with a string of \"C-f\" are also valid and will be turned into
+values such as \"H-C-f\".
+Returns nil if `mac-command-modifier' is set to `none' or something
+other than the three sane values listed above."
+      (let ((found (assoc mac-command-modifier
+                          '((hyper . "H-")
+                            (super . "s-")
+                            (alt   . "A-")))))
+        (when found (kbd (concat (cdr found) keys)))))
+
     ;; Keybindings
-    (global-set-key (kbd "s-=") 'spacemacs/scale-up-font)
-    (global-set-key (kbd "s--") 'spacemacs/scale-down-font)
-    (global-set-key (kbd "s-0") 'spacemacs/reset-font-size)
-    (global-set-key (kbd "s-q") 'save-buffers-kill-terminal)
-    (global-set-key (kbd "s-v") 'yank)
-    (global-set-key (kbd "s-c") 'evil-yank)
-    (global-set-key (kbd "s-a") 'mark-whole-buffer)
-    (global-set-key (kbd "s-x") 'kill-region)
-    (global-set-key (kbd "s-w") 'delete-window)
-    (global-set-key (kbd "s-W") 'delete-frame)
-    (global-set-key (kbd "s-n") 'make-frame)
-    (global-set-key (kbd "s-z") 'undo-tree-undo)
-    (global-set-key (kbd "s-s")
+    (global-set-key (kbd-mac-command "=") 'spacemacs/scale-up-font)
+    (global-set-key (kbd-mac-command "-") 'spacemacs/scale-down-font)
+    (global-set-key (kbd-mac-command "0") 'spacemacs/reset-font-size)
+    (global-set-key (kbd-mac-command "q") 'save-buffers-kill-terminal)
+    (global-set-key (kbd-mac-command "v") 'yank)
+    (global-set-key (kbd-mac-command "c") 'evil-yank)
+    (global-set-key (kbd-mac-command "a") 'mark-whole-buffer)
+    (global-set-key (kbd-mac-command "x") 'kill-region)
+    (global-set-key (kbd-mac-command "w") 'delete-window)
+    (global-set-key (kbd-mac-command "W") 'delete-frame)
+    (global-set-key (kbd-mac-command "n") 'make-frame)
+    (global-set-key (kbd-mac-command "`") 'other-frame)
+    (global-set-key (kbd-mac-command "z") 'undo-tree-undo)
+    (global-set-key (kbd-mac-command "s")
                     (lambda ()
                       (interactive)
                       (call-interactively (key-binding "\C-x\C-s"))))
-    (global-set-key (kbd "s-Z") 'undo-tree-redo)
-    (global-set-key (kbd "C-s-f") 'spacemacs/toggle-frame-fullscreen)
+    (global-set-key (kbd-mac-command "Z") 'undo-tree-redo)
+    (global-set-key (kbd-mac-command "C-f") 'spacemacs/toggle-frame-fullscreen)
     ;; Emacs sometimes registers C-s-f as this weird keycode
-    (global-set-key (kbd "<C-s-268632070>") 'spacemacs/toggle-frame-fullscreen)))
+    ;; (global-set-key (kbd "<C-s-268632070>") 'spacemacs/toggle-frame-fullscreen)
+    ))

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -14,14 +14,39 @@
 
   ;; this is only applicable to GUI mode
   (when (display-graphic-p)
-    ;; Treat command as super
-    (setq mac-command-key-is-meta nil)
-    (setq mac-command-modifier 'super)
 
-    (when osx-use-option-as-meta
-      ;; Treat option as meta
-      (setq mac-option-key-is-meta t))
-    (setq mac-option-modifier (if osx-use-option-as-meta 'meta nil))
+    ;; `Command' key is by default bound to SUPER (s-*).
+    ;; `Option' key is by default bound to META (M-*).
+    ;; `Function' key is by default not rebound.
+    ;; `Control' key is by default not rebound.
+    ;; The right variations of the above keys can
+    ;; also be modified but are not rebound by
+    ;; default.
+
+    ;; `Alist' linking the layer config variables to
+    ;; the internal Emacs variables for the modifier keys.
+    (setq modifier-keys '((osx-command-as       . mac-command-modifier)
+                          (osx-option-as        . mac-option-modifier)
+                          (osx-function-as      . mac-function-modifier)
+                          (osx-control-as       . mac-control-modifier)
+                          (osx-right-command-as . mac-right-command-modifier)
+                          (osx-right-option-as  . mac-right-option-modifier)
+                          (osx-right-control-as . mac-right-control-modifier)))
+
+    ;; The allowed non-nil values for the config variables.
+    (setq allowed-values '(super meta hyper control alt none left))
+
+    ;; Backwards compatibility
+    (case osx-use-option-as-meta
+      ('nil (setf osx-option-as 'none))
+      (deprecated nil)
+      (t (setf osx-option-as 'meta)))
+
+    ;; Set internal variables according to the given config variables
+    (cl-loop for (key-var . internal-var) in modifier-keys do
+             (let ((key-value (symbol-value key-var)))
+               (when (member key-value allowed-values)
+                 (setf (symbol-value internal-var) key-value))))
 
     ;; Keybindings
     (global-set-key (kbd "s-=") 'spacemacs/scale-up-font)


### PR DESCRIPTION
This PR builds on #8526 by @Chream

The purpose of this PR is to set the default for ⌘ to `hyper` and to provide the
function `kbd-mac-command` to replace `kbd` when defining keybindings for ⌘ in
case someone decides to explicitly set osx-command-as to `super` or `alt`.

There are problems setting osx-command-as to `alt` and `super`,
so we use `hyper` as a default instead because, for example:
  - Using `alt`:   Command-x or Command-m inserts, respectively: × µ
  - Using `super`: Control-Command-f produces keycode: `<C-s-268632078>`
Setting to `hyper` seems to avoid both types of the above problems.
Also, while it is possible, it is not recommended to set to `meta`
since standard OSX shortcuts would overshadow important keys such
as M-x.

Two other small changes include:

  - Commenting out the code that defines `<C-s-268632078>` (C-s-f) since it is
    unnecessary if we use `hyper` as the default; and if we really want to use
    `super` then we should figure out how to solve the weird keycode issue.

  - add keybinding for ⌘\` (Command-backtick) to `other-window`.
    Emacs usually swallows this keystroke, so other-window basically restores
    the default behavior that most Mac OSX users would expect.
