### PR TITLE
Fix signatures of spacemacs/evil-mc-paste-{after,before}

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -84,14 +84,14 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
        (or (not (fboundp 'evil-mc-get-cursor-count))
            (eq (evil-mc-get-cursor-count) 1))))
 
-(defun spacemacs/evil-mc-paste-after (&optional count &optional register)
+(defun spacemacs/evil-mc-paste-after (&optional count register)
   "Disable paste transient state if there is more that 1 cursor."
   (interactive "p")
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-after)
     (evil-paste-after count register)))
 
-(defun spacemacs/evil-mc-paste-before (&optional count &optional register)
+(defun spacemacs/evil-mc-paste-before (&optional count register)
   "Disable paste transient state if there is more that 1 cursor."
   (interactive "p")
   (if (spacemacs//paste-transient-state-p)


### PR DESCRIPTION
Fixes the error reported in #8672:
```
Debugger entered--Lisp error: (invalid-function (lambda (&optional count &optional register) "Disable paste transient state if there is more that 1 cursor." (interactive "p") (if (spacemacs//paste-transient-state-p) (spacemacs/paste-transient-state/evil-paste-after) (evil-paste-after count register))))
  spacemacs/evil-mc-paste-after(1)
  funcall-interactively(spacemacs/evil-mc-paste-after 1)
  call-interactively(spacemacs/evil-mc-paste-after nil nil)
  command-execute(spacemacs/evil-mc-paste-after)
```