### PR TITLE
Diminish the YAPF minor mode indicator

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -445,4 +445,5 @@ fix this issue."
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "=" 'yapfify-buffer)
       (when python-enable-yapf-format-on-save
-        (add-hook 'python-mode-hook 'yapf-mode)))))
+        (add-hook 'python-mode-hook 'yapf-mode))
+      (spacemacs|diminish yapf-mode " Ⓨ" " Y"))))


### PR DESCRIPTION
Some default minor modes are still showing their full indicators, this adds an indicator for yapfify in the Python layer.