### PR TITLE
add dante support to haskell layer

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -12,6 +12,7 @@
   - [[#completion-support][Completion support]]
     - [[#company-ghci][=company-ghci=]]
     - [[#intero][=intero=]]
+    - [[#dante][=dante=]]
     - [[#ghc-mod][=ghc-mod=]]
   - [[#optional-extras][Optional extras]]
     - [[#structured-haskell-mode][structured-haskell-mode]]
@@ -118,6 +119,9 @@ order to use it you have to call =haskell-process-load-or-reload= (=SPC s b=).
 =Intero= works only for =stack= users. You can manually install =intero= executable by
 calling =stack install intero=, but this step is optional as =Intero= installs
 itself.
+
+*** =dante=
+=dante= works for =cabal=, =nix=, =sytx=, and =stack= users.
 
 *** =ghc-mod=
 [[http://www.mew.org/~kazu/proj/ghc-mod/][ghc-mod]] enhances =haskell-mode= with for example code completion, templates,

--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -18,7 +18,7 @@
 
 (defvar haskell-completion-backend 'ghci
   "Completion backend used by company.
-Available options are `ghci', `intero' and `ghc-mod'. Default is
+Available options are `ghci', `intero', `dante', and `ghc-mod'. Default is
 `ghci'.")
 
 (defvar haskell-enable-hindent-style nil

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -11,15 +11,15 @@
 
 (defun spacemacs-haskell//setup-completion-backend ()
   "Conditionally setup haskell completion backend."
-  (unless (eq haskell-completion-backend 'ghc-mod)
-    (add-hook 'haskell-mode-hook 'interactive-haskell-mode))
   (when (configuration-layer/package-usedp 'company)
     (pcase haskell-completion-backend
       (`ghci (spacemacs-haskell//setup-ghci))
       (`ghc-mod (spacemacs-haskell//setup-ghc-mod))
-      (`intero (spacemacs-haskell//setup-intero)))))
+      (`intero (spacemacs-haskell//setup-intero))
+      (`dante (spacemacs-haskell//setup-dante)))))
 
 (defun spacemacs-haskell//setup-ghci ()
+  (add-hook 'haskell-mode-hook 'interactive-haskell-mode)
   (spacemacs|add-company-backends
     :backends (company-ghci company-dabbrev-code company-yasnippet)
     :modes haskell-mode))
@@ -48,7 +48,22 @@
     (set-face-attribute 'ghc-face-error nil :underline nil)
     (set-face-attribute 'ghc-face-warn nil :underline nil)))
 
+(defun spacemacs-haskell//setup-dante ()
+  (spacemacs|add-company-backends
+    :backends (company-dante company-dabbrev-code company-yasnippet)
+    :modes haskell-mode)
+  (push 'xref-find-definitions spacemacs-jump-handlers)
+  (dolist (mode haskell-modes)
+    (spacemacs/set-leader-keys-for-major-mode mode
+      "ht" 'dante-type-at
+      "hT" 'spacemacs-haskell//dante-insert-type
+      "hi" 'dante-info
+      "rs" 'dante-auto-fix
+      "se" 'dante-eval-block
+      "sr" 'dante-restart)))
+
 (defun spacemacs-haskell//setup-intero ()
+  (add-hook 'haskell-mode-hook 'interactive-haskell-mode)
   (spacemacs|add-company-backends
     :backends (company-intero company-dabbrev-code company-yasnippet)
     :modes haskell-mode)
@@ -86,6 +101,12 @@
   ;; use only internal indentation system from haskell
   (if (fboundp 'electric-indent-local-mode)
       (electric-indent-local-mode -1)))
+
+;; Dante Functions
+
+(defun spacemacs-haskell//dante-insert-type ()
+  (interactive)
+  (dante-type-at :insert))
 
 
 ;; Intero functions

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -26,6 +26,7 @@
     hindent
     hlint-refactor
     intero
+    dante
     ))
 
 (defun haskell/init-cmm-mode ()
@@ -53,6 +54,11 @@
 (defun haskell/init-ghc ()
   (use-package ghc
     :defer t))
+
+(defun haskell/init-dante ()
+  (use-package dante
+    :defer t
+    :init (add-hook 'haskell-mode-hook 'dante-mode)))
 
 (defun haskell/init-intero ()
   (use-package intero


### PR DESCRIPTION
This PR adds [dante](https://github.com/jyp/dante) support to the haskell layer.
Dante has all the features of intero without the dep of stack! It works with plain cabal, nix, styx, and stack projects.