### PR TITLE
README.md: fixed wrong flag for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ information.
 consider using instead:
 
 ``` sh
-$ brew install emacs-plus --HEAD --with-natural-title-bars
+$ brew install emacs-plus --HEAD --with-natural-title-bar
 ```
 
 *Note:* after you have completed the [install process](#install) below, it is


### PR DESCRIPTION
In the macOS installation guide the build flag for the `emacs-plus` package is spelled `--with-natural-title-bars` instead of `--with-natural-title-bar`. The correct one is the latter.