### PR TITLE
Add flycheck functionality to csharp layer

### DIFF
--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -16,6 +16,7 @@
     evil-matchit
     ggtags
     helm-gtags
+    flycheck
     omnisharp
     flycheck
     ))
@@ -114,3 +115,6 @@
 
 (defun csharp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'csharp-mode))
+
+(defun csharp/post-init-flycheck ()
+  (spacemacs/add-flycheck-hook 'csharp-mode))


### PR DESCRIPTION
Omnisharp supports syntax checking through the use of flycheck.
This patch adds configuration necessary to enable it for the csharp layer.