### PR TITLE
Update doc/LAYERS.org: Fix 2 Use-package titles/links

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -21,7 +21,7 @@
  - [[#case-study-auto-completion][Case study: auto-completion]]
  - [[#layer-tips-and-tricks][Layer tips and tricks]]
    - [[#cross-dependencies][Cross-dependencies]]
-   - [[#use-package-1][Use-package]]
+   - [[#use-package-init-and-config][Use-package init and config]]
    - [[#use-package-hooks][Use-package hooks]]
    - [[#best-practices][Best practices]]
      - [[#package-ownership][Package ownership]]
@@ -480,7 +480,7 @@ For layers that require another layers to be enabled, use the functions
 ensure that layers are enabled even if the user has not enabled them explicitly.
 Calls to these functions must go in the =layers.el= file.
 
-** Use-package
+** Use-package init and config
 In the vast majority of cases, a package =init= function should do nothing but
 call to =use-package=. Again, in the vast majority of cases, all the
 configuration you need to do should be doable within the =:init= or =:config=


### PR DESCRIPTION
```
problem:  The TOC link: Layers tips and tricks > Use-package
          navigates to: The Emacs loading process > Use-package
solution: Rename: Layers tips and tricks > Use-package
          to: Layers tips and tricks > Use-package init and config
```
The issue occurs in Emacs `SPC h r` `Tips on writing layers for Spacemacs` and on both of the pages: http://spacemacs.org/doc/LAYERS.html and http://develop.spacemacs.org/doc/LAYERS.html

But it works as expected here: https://github.com/syl20bnr/spacemacs/blob/develop/doc/LAYERS.org
This is just a guess, but maybe githubs org parser (is that the right word?), reads the id `#use-package-1` from `doc/LAYERS.org`'s TOC, and adds it as a href link to the second occurrence of the "Use package" heading: `Layers tips and tricks` > `Use package`.

This almost resolves syl20bnr/develop.spacemacs.org#10 , the updated doc/LAYERS.org just needs to generate a new doc/LAYERS.html