### PR TITLE
When using the meghanada backend with java, there is a small typo

### DIFF
--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -349,7 +349,7 @@
     :config
     (progn
       ;; key bindings
-      (dolist (prefix '(("mc" . "comppile")
+      (dolist (prefix '(("mc" . "compile")
                         ("mD" . "daemon")
                         ("mg" . "goto")
                         ("mr" . "refactor")


### PR DESCRIPTION
This fixes a small typo in the compile prefix. 