### PR TITLE
Update new-empty-buffer: split argument

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -491,11 +491,43 @@ If the universal prefix argument is used then will the windows too."
   (ediff-files (dotspacemacs/location)
                (concat dotspacemacs-template-directory ".spacemacs.template")))
 
-(defun spacemacs/new-empty-buffer ()
-  "Create a new buffer called untitled(<n>)"
+(defun spacemacs/new-empty-buffer (&optional split)
+  "Create a new buffer called untitled(<n>).
+A SPLIT argument with the value: `left',
+`below', `above' or `right', opens the new
+buffer in a split window."
   (interactive)
   (let ((newbuf (generate-new-buffer-name "untitled")))
+    (case split
+      ('left  (split-window-horizontally))
+      ('below (spacemacs/split-window-vertically-and-switch))
+      ('above (split-window-vertically))
+      ('right (spacemacs/split-window-horizontally-and-switch)))
     (switch-to-buffer newbuf)))
+
+(defun spacemacs/new-empty-buffer-left ()
+  "Create a new buffer called untitled(<n>),
+in a split window to the left."
+  (interactive)
+  (spacemacs/new-empty-buffer 'left))
+
+(defun spacemacs/new-empty-buffer-below ()
+  "Create a new buffer called untitled(<n>),
+in a split window below."
+  (interactive)
+  (spacemacs/new-empty-buffer 'below))
+
+(defun spacemacs/new-empty-buffer-above ()
+  "Create a new buffer called untitled(<n>),
+in a split window above."
+  (interactive)
+  (spacemacs/new-empty-buffer 'above))
+
+(defun spacemacs/new-empty-buffer-right ()
+  "Create a new buffer called untitled(<n>),
+in a split window to the right."
+  (interactive)
+  (spacemacs/new-empty-buffer 'right))
 
 ;; from https://gist.github.com/timcharper/493269
 (defun spacemacs/split-window-vertically-and-switch ()

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -124,6 +124,10 @@
   "bh"    'spacemacs/home
   "b C-d" 'spacemacs/kill-other-buffers
   "b C-S-d" 'spacemacs/kill-matching-buffers-rudely
+  "b M-h" 'spacemacs/new-empty-buffer-left
+  "b M-j" 'spacemacs/new-empty-buffer-below
+  "b M-k" 'spacemacs/new-empty-buffer-above
+  "b M-l" 'spacemacs/new-empty-buffer-right
   "bn"    'next-buffer
   "bm"    'spacemacs/switch-to-messages-buffer
   "bN"    'spacemacs/new-empty-buffer


### PR DESCRIPTION
Updated the `spacemacs/new-empty-buffer` function, to accept a `split`
argument, that can have 4 values: `left`, `below`, `above` or `right`.

Added new functions and key bindings (`SPC b M-h`, -j, -k and -l) for
each direction.

#### Questions:
1. Function names
Current: `spacemacs/new-empty-buffer-left`, `-below`, etc.
Would it be better to include `split` in the function names: `spacemacs/new-empty-buffer-split-left`?

2. Key bindings
Current: `SPC b M-h`, `-j`, `-k` and `-l`.
Should they remain unchanged? Or would it be better to use `SPC b C-h`, `-j`, etc.?
I might be missing better key bindings, suggestions are welcome.

3. Buffer transient state `SPC b .`
Which of these three options should be chosen?
First: No `spacemacs/new-empty-buffer-(split-)-left`, etc., keys in the buffer TS.
Second: Keys in both the `SPC b` buffer which-key popup and in the buffer TS.
Third: Only keys in the buffer TS, that would make the `h`, `j`, `k` and `l` keys available.

4. Option to keep the cursor in the pre-split window
Would it be useful to have functions and key bindings that don't move the cursor from the active window? The key bindings could use the uppercase versions `M-H`, `M-J`, etc. If this is a useful feature, then the "default" function names in Q1 above, probably should be renamed to something like: `spacemacs/new-empty-buffer-(split-)left-and-switch`.