### PR TITLE
Magit: Fix decrease hunk key in README

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -162,7 +162,7 @@ Here are the often used bindings inside a =status buffer=:
 | ~s~         | on a file or hunk in a diff: stage the file or hunk                 |
 | ~x~         | discard changes                                                     |
 | ~+~         | on a hunk: increase hunk size                                       |
-| ~-~         | on a hunk: decrease hunk size                                       |
+| ~=~         | on a hunk: decrease hunk size                                       |
 | ~S~         | stage all                                                           |
 | ~TAB~       | on a file: expand/collapse diff                                     |
 | ~u~         | on a staged file: unstage                                           |


### PR DESCRIPTION
While giving Spacemacs a whirl, I was confounded by `-` not decreasing the `git` hunk size while in `status` mode. @bleything figured it out after some back and forth on [Twitter](https://mobile.twitter.com/bleything/status/838941473093505024).

I'm all about 1 character PRs :wink: 