### PR TITLE
Haskell: use intero-goto-definition for jump handler if intero-mode is enabled.

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -14,6 +14,7 @@
 (setq haskell-modes '(haskell-mode literate-haskell-mode))
 
 (spacemacs|define-jump-handlers haskell-mode haskell-mode-jump-to-def-or-tag)
+(spacemacs|define-jump-handlers intero-mode intero-goto-definition)
 
 (defvar haskell-completion-backend 'ghci
   "Completion backend used by company.


### PR DESCRIPTION
Haskell: use intero-goto-definition for jump handler if intero-mode is enabled.