### PR TITLE
In M-x shell, set tab-width to 8 spaces

### DIFF
--- a/init.el
+++ b/init.el
@@ -32,3 +32,11 @@
   (spacemacs/setup-startup-hook)
   (require 'server)
   (unless (server-running-p) (server-start)))
+
+(defun spacemacs//interactive-shell-set-tab-width ()
+  "set the tab width to 8 for interactive shell"
+  (setq tab-width 8))
+
+(advice-add 'shell :after
+            (lambda (&rest _)
+              (spacemacs//interactive-shell-set-tab-width)))

--- a/init.el
+++ b/init.el
@@ -33,10 +33,4 @@
   (require 'server)
   (unless (server-running-p) (server-start)))
 
-(defun spacemacs//interactive-shell-set-tab-width ()
-  "set the tab width to 8 for interactive shell"
-  (setq tab-width 8))
-
-(advice-add 'shell :after
-            (lambda (&rest _)
-              (spacemacs//interactive-shell-set-tab-width)))
+(advice-add 'shell :after (lambda (&rest _) (shell/init-shell)))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -181,6 +181,11 @@
 
 (defun shell/init-shell ()
   (spacemacs/register-repl 'shell 'shell)
+
+  (defun shell-interactive-shell-set-tab-width ()
+    "set the tab width to 8 for interactive shell"
+    (setq tab-width 8))
+
   (defun shell-comint-input-sender-hook ()
     "Check certain shell commands.
  Executes the appropriate behavior for certain commands."
@@ -202,7 +207,13 @@
              ;; Send other commands to the default handler.
              (t (comint-simple-send proc command))))))
   (add-hook 'shell-mode-hook 'shell-comint-input-sender-hook)
-  (add-hook 'shell-mode-hook 'spacemacs/disable-hl-line-mode))
+  (add-hook 'shell-mode-hook 'spacemacs/disable-hl-line-mode)
+
+  (advice-add 'shell :after
+              (lambda (&rest _)
+                (shell-interactive-shell-set-tab-width))))
+
+
 
 (defun shell/init-shell-pop ()
   (use-package shell-pop

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -213,8 +213,6 @@
               (lambda (&rest _)
                 (shell-interactive-shell-set-tab-width))))
 
-
-
 (defun shell/init-shell-pop ()
   (use-package shell-pop
     :defer t


### PR DESCRIPTION
Certain programs like `ls` expect a `tab-width` of 8 characters. Spacemacs sets the default tab-width to 2. (https://github.com/syl20bnr/spacemacs/blob/bd7ef98e4c35fd87538dd2a81356cc83f5fd02f3/layers/%2Bdistributions/spacemacs-base/config.el#L79)

This is most noticeable under something like `M-x shell`, where `ls` will have the wrong formatting.

I think the cleanest solution would probably be to *not* set the tab-width to 2 in `spacemacs-base/config.el` and instead override it selectively for modes where it makes sense to do that.
