### PR TITLE
nix: enable flycheck

### DIFF
--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -1,6 +1,7 @@
 (setq nixos-packages
       '(
         company
+        flycheck
         (company-nixos-options :toggle
                                (configuration-layer/package-usedp 'company))
         (helm-nixos-options :toggle (configuration-layer/package-usedp 'helm))
@@ -32,3 +33,6 @@
 
 (defun nixos/init-nixos-options ()
   (use-package nixos-options))
+
+(defun nixos/post-init-flycheck ()
+  (spacemacs/enable-flycheck 'nix-mode))


### PR DESCRIPTION
nix syntax checking with nix-instantiate was just merged into flycheck:

  https://github.com/flycheck/flycheck/pull/1164

This enables flycheck support in nix-mode to the nixos layer.