### PR TITLE
Fix ansible layer typos

### DIFF
--- a/layers/+tools/ansible/README.org
+++ b/layers/+tools/ansible/README.org
@@ -8,7 +8,7 @@
  - [[#configuration][Configuration]]
    - [[#ansible-vault][ansible-vault]]
      - [[#password][Password]]
-     - [[#automatic-encryption-and-descryption][Automatic encryption and descryption]]
+     - [[#automatic-encryption-and-decryption][Automatic encryption and decryption]]
  - [[#key-bindings][Key bindings]]
 
 * Description
@@ -23,7 +23,7 @@ file.
 ** ansible-vault
 *** Password
 To use =ansible-vault= you have to provide the path to a file containing the
-password to use somewhere in you =dotspacemacs/user-config= function.
+password to use somewhere in your =dotspacemacs/user-config= function.
 For instance:
 
 #+BEGIN_SRC emacs-lisp
@@ -44,16 +44,16 @@ password file for a given environment. Example:
 ((yaml-mode . ((ansible::vault-password-file . "path/to/vault_file"))))
 #+END_SRC
 
-*** Automatic encryption and descryption
+*** Automatic encryption and decryption
 This layer comes preconfigured with automatic encryption/decryption of
 encrypted files using =ansible-vault= so it is possible to edit seamlessly
 any encrypted files.
 
 If you want to disable this feature then set the layer variable
-=ansible-auto-encrypt-descrypt= to =nil=.
+=ansible-auto-encrypt-decrypt= to =nil=.
 
 #+BEGIN_SRC emacs-lisp
-(ansible :variables ansible-auto-encrypt-descrypt t)
+(ansible :variables ansible-auto-encrypt-decrypt t)
 #+END_SRC
 
 * Key bindings

--- a/layers/+tools/ansible/config.el
+++ b/layers/+tools/ansible/config.el
@@ -11,7 +11,7 @@
 
 ;; variables
 
-(defvar ansible-auto-encrypt-descrypt t
+(defvar ansible-auto-encrypt-decrypt t
   "Set it to non-nil to seamlessly edit `ansible-vault' encrypted files.
 If non-nil then encrypted files are automatically decrypted when opened and
  encrypted when saved.")

--- a/layers/+tools/ansible/packages.el
+++ b/layers/+tools/ansible/packages.el
@@ -23,7 +23,7 @@
     (progn
       (add-hook 'yaml-mode-hook 'spacemacs/ansible-maybe-enable)
       (put 'ansible::vault-password-file 'safe-local-variable #'stringp)
-      (if ansible-auto-encrypt-descrypt
+      (if ansible-auto-encrypt-decrypt
           ;; add this hook to local-vars-hook to allow users to specify
           ;; a password file in directory local variables
           (add-hook 'yaml-mode-local-vars-hook 'ansible::auto-decrypt-encrypt)


### PR DESCRIPTION
* Replace 'descrypt' with 'decrypt'
* Fix 'you' 'your' typo

:heart: