### PR TITLE
Allow customizing if ENSIME should print types at point

### DIFF
--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -24,7 +24,8 @@
     ))
 
 (defun scala/post-init-eldoc ()
-  (add-hook 'scala-mode-hook #'spacemacs//java-setup-ensime-eldoc))
+  (when scala-enable-eldoc
+    (add-hook 'scala-mode-hook #'spacemacs//java-setup-ensime-eldoc)))
 
 (defun scala/pre-init-ensime ()
   (spacemacs|use-package-add-hook ensime


### PR DESCRIPTION
According to the [documentation](https://github.com/syl20bnr/spacemacs/blob/dd8508482629c042718681c3fa2df07541a37028/layers/%2Blang/scala/README.org), the `scala-enable-eldoc` variable should be used to determine whether or not ENSIME should print types at point. This makes sure that the `spacemacs//java-setup-ensime-eldoc` hook is only added to `scala-mode-hook` if the variable is non-`nil`.