### PR TITLE
Fix typo in DOCUMENTATION.org

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1937,7 +1937,7 @@ can be quickly accessed using =SPC number=.
 | ~SPC 7~     | go to window number 7 |
 | ~SPC 8~     | go to window number 8 |
 | ~SPC 9~     | go to window number 9 |
-| ~SPC 0~     | go to window number 0 |
+| ~SPC 0~     | go to window number 10 |
 
 Windows manipulation commands (start with ~w~):
 


### PR DESCRIPTION
`SPC 0` goes to windows number 10, not 0, as previously stated in the docs.