### PR TITLE
ivy: counsel-faces -> counsel-describe-face

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -54,7 +54,7 @@
         ;; help
         "?"   'counsel-descbinds
         "hdf" 'counsel-describe-function
-        "hdF" 'counsel-faces
+        "hdF" 'counsel-describe-face
         "hdm" 'spacemacs/describe-mode
         "hdv" 'counsel-describe-variable
         "hi"  'counsel-info-lookup-symbol


### PR DESCRIPTION
Mistakenly added `counsel-faces` while the intended command that should go under
`SPC h d F` is `counsel-describe-face`.
