### PR TITLE
VIMUSERS Elisp doc typo fix

### DIFF
--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -264,7 +264,7 @@ customization. The syntax is simple:
     )
 
   ;; Calling a function
-  (func-name arg1 arg1)
+  (func-name arg1 arg2)
 #+end_src
 
 Here is an example of a function that is useful in real life:


### PR DESCRIPTION
There is a tiny typo in the docs for Vim users. When describing Elisp functions, it says:

```elisp
(defun func-name (arg1 arg2)
  "docstring"
  ;; Body
  )

;; Calling a function
(func-name arg1 arg1)
```

This request replaces the `arg1 arg1` at the end with `arg1 arg2`.