### PR TITLE
Add various slack keybindings

### DIFF
--- a/layers/+chat/slack/README.org
+++ b/layers/+chat/slack/README.org
@@ -42,28 +42,30 @@ stuff elsewhere (like Dropbox for instance) and load the file in your dotfile.
 
 * Key bindings
 
-| Key Binding | Description              |
-|-------------+--------------------------|
-| ~SPC a C s~ | (Re)connects to Slack    |
-| ~SPC a C j~ | Join a channel           |
-| ~SPC a C d~ | Direct message someone   |
-| ~SPC a C q~ | Close connection         |
-| ~SPC m j~   | Join a channel           |
-| ~SPC m d~   | Direct message someone   |
-| ~SPC m p~   | Load previous messages   |
-| ~SPC m e~   | Edit message at point    |
-| ~SPC m q~   | Quit Slack               |
-| ~SPC m m~   | Embed mention of user    |
-| ~SPC m c~   | Embed mention of channel |
+| Key Binding | Description                             |
+|-------------+-----------------------------------------|
+| ~SPC a C s~ | (Re)connects to Slack                   |
+| ~SPC a C j~ | Join a channel                          |
+| ~SPC a C g~ | Join a group (private channel)          |
+| ~SPC a C r~ | Join a channel, group, or direct messge |
+| ~SPC a C d~ | Direct message someone                  |
+| ~SPC a C q~ | Close connection                        |
+| ~SPC m j~   | Join a channel                          |
+| ~SPC m d~   | Direct message someone                  |
+| ~SPC m p~   | Load previous messages                  |
+| ~SPC m e~   | Edit message at point                   |
+| ~SPC m q~   | Quit Slack                              |
+| ~SPC m m~   | Embed mention of user                   |
+| ~SPC m c~   | Embed mention of channel                |
 
 The following bindings are provided to mimic bindings in the official Slack
 client.
 
-| Key Binding | Description              |
-|-------------+--------------------------|
-| ~SPC m k~ | Join a channel           |
-| ~SPC m @~ | Embed mention of user    |
-| ~SPC m #~ | Embed mention of channel |
+| Key Binding | Description                               |
+|-------------+-------------------------------------------|
+| ~<SPC> m k~ | Join a channel, group, and direct message |
+| ~<SPC> m @~ | Embed mention of user                     |
+| ~<SPC> m #~ | Embed mention of channel                  |
 
 In insert state, one can also use ~@~ and ~#~ directly without the leader key
 prefix.

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -65,6 +65,8 @@
       (spacemacs/set-leader-keys
         "aCs" 'slack-start
         "aCj" 'slack-channel-select
+        "aCg" 'slack-group-select
+        "aCr" 'slack-select-rooms
         "aCd" 'slack-im-select
         "aCq" 'slack-ws-close)
       (setq slack-enable-emoji t))
@@ -72,13 +74,15 @@
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'slack-mode
         "j" 'slack-channel-select
+        "g" 'slack-group-select
+        "r" 'slack-select-rooms
         "d" 'slack-im-select
         "p" 'slack-room-load-prev-messages
         "e" 'slack-message-edit
         "q" 'slack-ws-close
         "mm" 'slack-message-embed-mention
         "mc" 'slack-message-embed-channel
-        "k" 'slack-channel-select
+        "k" 'slack-select-rooms
         "@" 'slack-message-embed-mention
         "#" 'slack-message-embed-channel)
       (evil-define-key 'insert slack-mode-map


### PR DESCRIPTION
The only readily available keybinding for joining channels in slack is for
joining public channels. This commit adds bindings for joining private
channels, (called groups in emacs-slack) as well as a keybinding for
slack-select-rooms which allows joining a channel, group, or DM.

This commit also rebinds the major mode `k` to slack-select-rooms, which puts it
more in line with how the related keybinding in the slack client works.