### PR TITLE
Enable completion in ipython-notebook using ein:company-backend

### DIFF
--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -9,7 +9,13 @@
 ;;
 ;;; License: GPLv3
 
-(setq ipython-notebook-packages '(ein))
+(setq ipython-notebook-packages '(company
+                                  ein))
+
+(defun ipython-notebook/post-init-company ()
+  (spacemacs|add-company-backends
+    :backends ein:company-backend
+    :modes ein:notebook-mode))
 
 (defun ipython-notebook/init-ein ()
   (use-package ein


### PR DESCRIPTION
Enable completion in ipython-notebook layer using ein:company-backend

EIN added a company backend recently.
This will enhance ipython-notebook layer to support completion in spacemacs using ein's company backend.