### PR TITLE
docs: Install goimports from new repository.

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -36,7 +36,7 @@ You will need =gocode= and =godef=:
   go get -u -v github.com/rogpeppe/godef
   go get -u -v golang.org/x/tools/cmd/guru
   go get -u -v golang.org/x/tools/cmd/gorename
-  go get -u -v golang.org/x/tools/cmd/goimports
+  go get -u -v github.com/golang/tools/cmd/goimports
 #+END_SRC
 
 If you wish to use =gometalinter= set the value of =go-use-gometalinter= to t:


### PR DESCRIPTION
The goimports package can't get from golang.org, Use github.com/golang repository instead. #8778