### PR TITLE
remove automatic call to linum-setup when using git-gutter

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -59,9 +59,6 @@
       (when (and (eq version-control-diff-tool 'git-gutter)
                  version-control-global-margin)
         (global-git-gutter-mode t))
-      ;; If you would like to use git-gutter.el and linum-mode
-      (if dotspacemacs-line-numbers
-          (git-gutter:linum-setup))
       (setq git-gutter:update-interval 2
             git-gutter:modified-sign " "
             git-gutter:added-sign "+"


### PR DESCRIPTION
This pull request removes the automatic invocation of ```git-gutter:linum-setup``` when using ```git-gutter``` with linum mode is enabled globally. As far as I can tell, this fundamentally breaks line numbers in spacemacs resulting in many duplicated line numbers. 

Additionally, ```git-gutter-fringe``` is automatically included and results in the icons being placed in two locations, the fringe and in the line numbers. As it stands there is no way to prevent linum-setup from being called and simply use git-gutter in the fringe.

I chose to remove the call entirely instead of adding an additional layer configuration variable to hide this call because the functionality appears fundamentally broken in spacemacs and an additional configuration value would be specific to ```git-gutter``` and I believe would only serve to confuse users.