### PR TITLE
Solves #5395 "ESS layer help.start makes inferior ess read-only"

### DIFF
--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -58,6 +58,10 @@
       ;; Explicitly run prog-mode hooks since ess-mode does not derive from
       ;; prog-mode major-mode
       (add-hook 'ess-mode-hook 'spacemacs/run-prog-mode-hooks)
+      (add-hook 'inferior-ess-mode-hook
+                '(lambda () (progn
+                              (setq-local comint-use-prompt-regexp nil)
+                              (setq-local inhibit-field-text-motion nil))))
       (when (configuration-layer/package-usedp 'company)
           (add-hook 'ess-mode-hook 'company-mode))))
 


### PR DESCRIPTION
This solves https://github.com/syl20bnr/spacemacs/issues/5395, which reported that calling `help.start()` in the R repl causes it to become read-only and unusable. The same issue causes a `shinyApp()` to be unkillable as I reported in the comments, and possibly causes other issues in the R repl. The issue is caused by `(setq comint-prompt-read-only t)` in the shell layer, but can be solved by adding the hooks from https://github.com/emacs-ess/ESS/issues/300#issuecomment-231314374