### PR TITLE
swap-buffers-to-window: symbols fun def void

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -241,7 +241,7 @@ Dedicated (locked) windows are left untouched."
       (set-window-buffer w2 b1)
       (unrecord-window-buffer w1 b1)
       (unrecord-window-buffer w2 b2)))
-  (when follow-focus-p (select-window-by-number windownum)))
+  (when follow-focus-p (winum-select-window-by-number windownum)))
 
 (dotimes (i 9)
   (let ((n (+ i 1)))


### PR DESCRIPTION
```
problem:  target window doesn't get focus after buffer swap:
          'symbols function definition is void: select-window-by-number'
solution: missing 'winum-' before 'select-window-by-number'
```

#### Reproduction steps: 
1. Split a frame into 2 or more windows, with different buffers
2. Press `SPC u SPC b <target window nr>` to swap buffers between the current and the target window