### PR TITLE
Fix pasting ignoring register selection

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -84,16 +84,16 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
        (or (not (fboundp 'evil-mc-get-cursor-count))
            (eq (evil-mc-get-cursor-count) 1))))
 
-(defun spacemacs/evil-mc-paste-after (&optional count register)
+(defun spacemacs/evil-mc-paste-after (&optional count)
   "Disable paste transient state if there is more that 1 cursor."
   (interactive "p")
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-after)
-    (evil-paste-after count register)))
+    (evil-paste-after count evil-this-register)))
 
-(defun spacemacs/evil-mc-paste-before (&optional count register)
+(defun spacemacs/evil-mc-paste-before (&optional count)
   "Disable paste transient state if there is more that 1 cursor."
   (interactive "p")
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-before)
-    (evil-paste-before count register)))
+    (evil-paste-before count evil-this-register)))


### PR DESCRIPTION
Pasting in evil-mode has been broken since 58458f2d2abcc1211444c2060ab598f55e518da4, as `p` and `P` would always paste from the unnamed register instead of the register selected with `"`. I've removed the function's second parameter as it wasn't being used anywhere, and if it's needed in the future it would probably be more idiomatic to use evil's own registers anyway.

This fixes #8759 using @duianto's suggestion.