### PR TITLE
Add support for fancy frame title

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -139,6 +139,14 @@ whenever you start Emacs.")
 Press `SPC T n' to cycle to the next theme in the list (works great
 with 2 themes variants, one dark and one light")
 
+(defvar dotspacemacs-frame-title-format "%I@%S"
+  "Default format string for a frame title bar, using the
+  original format spec, and additional customizations.")
+
+(defvar dotspacemacs-icon-title-format nil
+  "Default format string for a icon title bar, using the
+  original format spec, and additional customizations.")
+
 (defvar dotspacemacs-colorize-cursor-according-to-state t
   "If non nil the cursor color matches the state color in GUI Emacs.")
 
@@ -596,6 +604,51 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
         (unless (with-demoted-errors "Error loading .spacemacs: %S"
                   (load dotspacemacs))
           (dotspacemacs/safe-load)))))
+
+(defun spacemacs/title-prepare (title-format)
+  "A string is printed verbatim except for %-constructs.
+  %a -- prints the `abbreviated-file-name', or `buffer-name'
+  %t -- prints `projectile-project-name'
+  %I -- prints `invocation-name'
+  %S -- prints `system-name'
+  %U -- prints contents of $USER
+  %b -- prints buffer name
+  %f -- prints visited file name
+  %F -- prints frame name
+  %s -- prints process status
+  %p -- prints percent of buffer above top of window, or Top, Bot or All
+  %P -- prints percent of buffer above bottom of window, perhaps plus Top, or
+  print Bottom or All
+  %m -- prints mode name
+  %n -- prints Narrow if appropriate
+  %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
+  %Z -- like %z, but including the end-of-line format"
+  (let* ((fs (format-spec-make
+              ?a (abbreviate-file-name (or (buffer-file-name) (buffer-name)))
+              ?t (if (boundp 'projectile-mode) (projectile-project-name) "-")
+              ?S system-name
+              ?I invocation-name
+              ?U (or (getenv "USER") "")
+              ?b "%b"
+              ?f "%f"
+              ?F "%F"
+              ?* "%*"
+              ?+ "%+"
+              ?s "%s"
+              ?l "%l"
+              ?c "%c"
+              ?p "%p"
+              ?P "%P"
+              ?m "%m"
+              ?n "%n"
+              ?z "%z"
+              ?Z "%Z"
+              ?[ "%["
+              ?] "%]"
+              ?% "%%"
+              ?- "%-"
+              )))
+    (format-spec title-format fs)))
 
 (defun dotspacemacs/safe-load ()
   "Error recovery from malformed .spacemacs.

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -104,6 +104,12 @@ the final step of executing code in `emacs-startup-hook'.")
   (setq dotspacemacs-editing-style (dotspacemacs//read-editing-style-config
                                     dotspacemacs-editing-style))
   (configuration-layer/initialize)
+  ;; frame title init
+  (when (and (display-graphic-p) dotspacemacs-frame-title-format)
+    (setq frame-title-format '((:eval (spacemacs/title-prepare dotspacemacs-frame-title-format))))
+    (if dotspacemacs-icon-title-format
+        (setq icon-title-format '((:eval (spacemacs/title-prepare dotspacemacs-icon-title-format))))
+      (setq icon-title-format frame-title-format)))
   ;; theme
   (spacemacs/load-default-theme spacemacs--fallback-theme)
   ;; font

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -291,6 +291,26 @@ values."
    ;; specified with an installed package.
    ;; Not used for now. (default nil)
    dotspacemacs-default-package-repository nil
+   ;; Format specification for setting the frame title.
+   ;; %a - the `abbreviated-file-name', or `buffer-name'
+   ;; %t - `projectile-project-name'
+   ;; %I - `invocation-name'
+   ;; %S - `system-name'
+   ;; %U - contents of $USER
+   ;; %b - buffer name
+   ;; %f - visited file name
+   ;; %F - frame name
+   ;; %s - process status
+   ;; %p - percent of buffer above top of window, or Top, Bot or All
+   ;; %P - percent of buffer above bottom of window, perhaps plus Top, or Bot or All
+   ;; %m - mode name
+   ;; %n - Narrow if appropriate
+   ;; %z - mnemonics of buffer, terminal, and keyboard coding systems
+   ;; %Z - like %z, but including the end-of-line format
+   dotspacemacs-frame-title-format "%I@%S"
+   ;; Format specification for setting the icon title format
+   ;; (default nil - same as frame-title-format)
+   dotspacemacs-icon-title-format nil
    ;; Delete whitespace while saving buffer. Possible values are `all'
    ;; to aggressively delete empty line and long sequences of whitespace,
    ;; `trailing' to delete only the whitespace at end of lines, `changed' to

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -77,6 +77,8 @@
        - [[#powerline-separators][Powerline separators]]
        - [[#minor-modes][Minor Modes]]
        - [[#customizing-the-mode-line][Customizing the mode-line]]
+   - [[#frame-title][Frame title]]
+     - [[#iconified-tabified-title][Iconified (tabified) title]]
  - [[#layouts-and-workspaces][Layouts and workspaces]]
    - [[#layouts][Layouts]]
      - [[#the-default-layout][The default layout]]
@@ -1391,6 +1393,39 @@ For example to undo diminish for =company=:
 Note that we use a =use-package= post init hook to be sure to override any
 lazily diminished lighters (see [[file:LAYERS.org][layers documentation]] for more information
 about lazy loading).
+
+** Frame title
+Default frame title displays name of current process and hostname of system. You
+can include more information (like name of current file, name of current project
+etc) by setting =dotspacemacs-frame-title-format= variable.
+
+Following format short codes are avialable:
+
+| Code | Description                                                                  |
+|------+------------------------------------------------------------------------------|
+| =%a= | the `abbreviated-file-name', or `buffer-name'                                |
+| =%t= | `projectile-project-name'                                                    |
+| =%I= | `invocation-name'                                                            |
+| =%S= | `system-name'                                                                |
+| =%U= | contents of $USER                                                            |
+| =%b= | buffer name                                                                  |
+| =%f= | visited file name                                                            |
+| =%F= | frame name                                                                   |
+| =%s= | process status                                                               |
+| =%p= | percent of buffer above top of window, or Top, Bot or All                    |
+| =%P= | percent of buffer above bottom of window, perhaps plus Top, or Bottom or All |
+| =%m= | mode name                                                                    |
+| =%n= | Narrow if appropriate                                                        |
+| =%z= | mnemonics of buffer, terminal, and keyboard coding systems                   |
+| =%Z= | like %z, but including the end-of-line format"                               |
+
+*** Iconified (tabified) title
+If you are using tiling window manager with tab support you may want to display
+different title for inactive tabs with =dotspacemacs-icon-title-format=
+variable. Short codes are same as for frame title.
+
+If this variable is set to =nil= (default) its value will be same as
+=dotspacemacs-frame-title-format=.
 
 * Layouts and workspaces
 Layouts are window configurations with buffer isolation, each layout can define


### PR DESCRIPTION
Hi,

I would like to finish and re-submit the change by @cviebig from PR #5924 (originating in @usharf PRs #2299 and #2139) for merging into current `develop`.

I addressed @syl20bnr request for documentation. As I'm not native english speaker I'll welcome any suggestions to fix mistakes (or complete rewrite of my text).

@usharf addressed only frame-title which isn't enough according to discussion in #5924 and also according to my experience (I'm using xmonad as my window manager). I modified code to support also icon-title with same format and documented this behaviour.

Thanks for any feedback.


