### PR TITLE
ESS layer option to turn off automatic replacement of underscores

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -51,19 +51,21 @@ Helpers for inspecting objects at point are available in R buffers only.
 | ~SPC m h t~ | view table using [ess-R-data-view][ess-R-data-view]                 |
 
 * Options
-=ess-smart-equals= is disabled by default. In order to enable it, set in your
-=~/.spacemacs=
+
+To turn off the automatic replacement of underscores by =<-=,
+set in your =~/.spacemacs=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((ess :variables
+                                                         ess-disable-underscore-assign t)))
+#+END_SRC
+
+Alternatively you may enable =ess-smart-equals=, which also disables
+replacement of underscores by =<-=, and additionally replace the equals sign with
+=<-= when appropriate:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '((ess :variables
                                                          ess-enable-smart-equals t)))
 #+END_SRC
 
-To turn off the automatic replacement of underscores by =<-=, add the following
-hook:
-
-#+begin_src emacs-lisp
-  (add-hook 'ess-mode-hook
-            (lambda ()
-              (ess-toggle-underscore nil)))
-#+end_src

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -68,4 +68,3 @@ replacement of underscores by =<-=, and additionally replace the equals sign wit
   (setq-default dotspacemacs-configuration-layers '((ess :variables
                                                          ess-enable-smart-equals t)))
 #+END_SRC
-

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -13,3 +13,6 @@
 
 (defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")
+
+(defvar ess-disable-underscore-assign nil
+  "If non-nil, disables underscore _ being a shortcut for assignment <-")

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -71,6 +71,8 @@
           ess-expression-offset 2
           ess-nuke-trailing-whitespace-p t
           ess-default-style 'DEFAULT)
+    (if ess-disable-underscore-assign
+      (ess-toggle-underscore nil))
 
     (spacemacs/set-leader-keys-for-major-mode 'ess-julia-mode
       "'"  'julia

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -160,11 +160,8 @@
   (use-package mmm-mode
     :commands mmm-mode
     :init (add-hook 'markdown-mode-hook 'spacemacs/activate-mmm-mode)
-    :config
-    (progn
-      ;; Automatically add mmm class for languages
-      (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)
-      (setq mmm-global-mode t))))
+    ;; Automatically add mmm class for languages
+    :config (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)))
 
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode


### PR DESCRIPTION
Added variable `ess-disable-underscore-assign` to `ess` layer to disable automatic replacement of underscore with `<-` assignment operator. Also replaced the  instructions in the Readme on how to manually do this with a hook.

Disabling the automatic replacement is a common thing to do by ESS users, and a variable to do this was previously requested in the thread https://github.com/syl20bnr/spacemacs/issues/3222, with a spacemacs maintainer responding that they wouldn't mind such an option, but no PR was ever submitted.

For now I leave the default behavior unchanged, i.e. `ess-disable-underscore-assign` is `nil` by default. However, IMO we should consider changing the default to `t`, the vanilla ESS behavior is from an earlier time when underscore was uncommon in R code, but now it is ubiquitous.