### PR TITLE
Add @Slack layout to documented list of default custom layouts

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1496,6 +1496,7 @@ Some custom layouts that ship with Spacemacs:
 | @Spacemacs | ~e~         | Custom perspective containing all buffers of =~/.emacs.d=                       |
 | @ERC       | ~E~         | Custom perspective containing all ERC buffers (needs the erc layer enabled)     |
 | @RCIRC     | ~i~         | Custom perspective containing all RCIRC buffers (needs the rcirc layer enabled) |
+| @Slack     | ~s~         | Custom perspective containing all Slack buffers (needs the slack layer enabled) |
 | @Org       | ~o~         | Custom perspective containing all the =org-agenda= buffers                      |
 
 *** Save/Load layouts into a file


### PR DESCRIPTION
This commit adds the custom layout defined in the Slack layer to the list of
custom layouts that spacemacs ships with in `doc/DOCUMENTATION.org`