### PR TITLE
Add custom layout for mu4e buffers

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1494,6 +1494,7 @@ Some custom layouts that ship with Spacemacs:
 | Name       | Key Binding | Description                                                                     |
 |------------+-------------+---------------------------------------------------------------------------------|
 | @Spacemacs | ~e~         | Custom perspective containing all buffers of =~/.emacs.d=                       |
+| @Mu4e      | ~m~         | Custom perspective containing all mu4e buffers (needs the mu4e layer enabled)   |
 | @ERC       | ~E~         | Custom perspective containing all ERC buffers (needs the erc layer enabled)     |
 | @RCIRC     | ~i~         | Custom perspective containing all RCIRC buffers (needs the rcirc layer enabled) |
 | @Org       | ~o~         | Custom perspective containing all the =org-agenda= buffers                      |

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -12,6 +12,12 @@
 (defvar mu4e-installation-path nil
   "Installation path for mu4e.")
 
+(defvar mu4e-spacemacs-layout-name "@Mu4e"
+  "Name used in the setup for `spacemacs-layouts' micro-state")
+
+(defvar mu4e-spacemacs-layout-binding "m"
+  "Binding used in the setup for `spacemacs-layouts' micro-state")
+
 (defvar mu4e-account-alist nil
   "Account alist for custom multi-account compose.")
 

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -15,7 +15,24 @@
         mu4e-alert
         mu4e-maildirs-extension
         org
+        persp-mode
         ))
+
+(defun mu4e/post-init-persp-mode ()
+  (spacemacs|define-custom-layout mu4e-spacemacs-layout-name
+    :binding mu4e-spacemacs-layout-binding
+    :body
+    (progn
+      (defun spacemacs-layouts/add-mu4e-buffer-to-persp ()
+        (persp-add-buffer (current-buffer)
+                          (persp-get-by-name
+                           mu4e-spacemacs-layout-name)))
+      (add-hook 'mu4e-main-mode    #'spacemacs-layouts/add-mu4e-buffer-to-persp)
+      (add-hook 'mu4e-headers-mode #'spacemacs-layouts/add-mu4e-buffer-to-persp)
+      (add-hook 'mu4e-view-mode    #'spacemacs-layouts/add-mu4e-buffer-to-persp)
+      (add-hook 'mu4e-compose-mode #'spacemacs-layouts/add-mu4e-buffer-to-persp)
+      (call-interactively 'mu4e)
+      (call-interactively 'mu4e-update-index))))
 
 (defun mu4e/init-mu4e ()
   (use-package mu4e


### PR DESCRIPTION
This commit adds a custom layout for mu4e related buffers. Four different major
modes are used in mu4e buffers based on their purpose, so a function is used to
add buffers in these modes to the new layout. This setup is largely based on
that of the ERC layers custom layout.