### PR TITLE
Replace define-advice with advice-add in the shell layer

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -89,12 +89,16 @@
       ;; buffer. This breaks the xterm color filtering when the eshell buffer is updated
       ;; when it's not currently focused.
       ;; To remove if/when fixed upstream.
-      (define-advice eshell-output-filter (:around (fn process string) with-buffer)
+      (defun eshell-output-filter@spacemacs-with-buffer (fn process string)
         (let ((proc-buf (if process (process-buffer process)
                           (current-buffer))))
           (when proc-buf
             (with-current-buffer proc-buf
               (funcall fn process string)))))
+      (advice-add
+       #'eshell-output-filter
+       :around
+       #'eshell-output-filter@spacemacs-with-buffer)
 
       (require 'esh-opt)
 


### PR DESCRIPTION
`define-advice` requires Emacs 25.

Addresses: https://github.com/syl20bnr/spacemacs/pull/8635#issuecomment-297887734

Really, this should have a regression test. Unfortunately, I have no idea how to add such a thing to spacemacs.