### PR TITLE
fix #8796

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -47,7 +47,7 @@
 
 (defun common-lisp/init-slime-company ()
   (spacemacs|use-package-add-hook slime
-    :post-init
+    :pre-config
     (progn
       (setq slime-company-completion 'fuzzy)
       (add-to-list 'slime-contribs 'slime-company))))


### PR DESCRIPTION
used `:pre-config` instead `:post-init`, otherwise `slime-company` won't be initialized because `common-lisp/init-slime-company` is called after `common-lisp/init-slime`, and `:post-init` probably won't make effect.