### PR TITLE
Add a new keybinding for org-preview-latex-fragment

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -298,6 +298,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC m R~                                    | org-refile                                    |
 | ~SPC m s~                                    | org-schedule                                  |
 | ~SPC m T~                                    | org-show-todo-tree                            |
+| ~SPC m X~                                    | org-preview-latex-fragment                    |
 | ~SPC m L~                                    | org-shiftright                                |
 | ~SPC m H~                                    | org-shiftleft                                 |
 | ~SPC m K~                                    | org-shiftup                                   |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -188,6 +188,8 @@ Will work on both org-mode and any mode that accepts plain html."
         "." 'org-time-stamp
         "!" 'org-time-stamp-inactive
 
+        "X" 'org-preview-latex-fragment
+
         ;; headings
         "hi" 'org-insert-heading-after-current
         "hI" 'org-insert-heading


### PR DESCRIPTION
The keybinding I chose is `<space> m X`. `l`, `L` and `x` were taken already, and the X can be remembered by LaTe**X**.

I'm unsure if I put it in the right place in the docs but there didn't seem to be any other more relevant section.