### PR TITLE
Add keybinding to Clojure layer for eval to comment

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -133,6 +133,7 @@ As this state works the same for all files, the documentation is in global
 
 | Key Binding | Description                                     |
 |-------------+-------------------------------------------------|
+| ~SPC m e ;~ | eval sexp and show result as comment            |
 | ~SPC m e b~ | eval buffer                                     |
 | ~SPC m e e~ | eval last sexp                                  |
 | ~SPC m e f~ | eval function at point                          |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -112,6 +112,7 @@
           "hj" 'cider-javadoc
           "hn" 'cider-browse-ns
 
+          "e;" 'cider-eval-defun-to-comment
           "eb" 'cider-eval-buffer
           "ee" 'cider-eval-last-sexp
           "ef" 'cider-eval-defun-at-point


### PR DESCRIPTION
Added a Spacemacs style keybinding for the function cider-eval-defun-to-comment

This function evaluates and expression and displays the result as a comment on the following line.

The CIDER keybinding is `C-C M-;` so the Spacemacs binding uses the `;` convention, which is also the general character for comments in Emacs.

As this is an evaluation function, the keybinding is placed under the evaluation part of the major mode menu.
