### PR TITLE
Allow customization of slack custom layout name and binding

### DIFF
--- a/layers/+chat/slack/config.el
+++ b/layers/+chat/slack/config.el
@@ -1,0 +1,18 @@
+;;; config.el --- slack layer configuration file for Spacemacs
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Benjamin Reynolds <breyno127@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar slack-spacemacs-layout-name "@Slack"
+  "Name used in the setup for `spacemacs-layouts' micro-state")
+
+(defvar slack-spacemacs-layout-binding "s"
+  "Binding used in the setup for `spacemacs-layouts' micro-state")

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -40,8 +40,8 @@
   (add-hook 'slack-mode-hook 'spacemacs/no-linum))
 
 (defun slack/post-init-persp-mode ()
-  (spacemacs|define-custom-layout "@Slack"
-    :binding "s"
+  (spacemacs|define-custom-layout slack-spacemacs-layout-name
+    :binding slack-spacemacs-layout-binding
     :body
     (progn
       (add-hook 'slack-mode #'(lambda ()


### PR DESCRIPTION
This commit adds two configuration variables to the slack layer allowing a user
to customize the name and keybinding of the slack custom layout, following the
conventions from the erc and mu4e layouts.