### PR TITLE
helm/ivy: Limit rg results to 150 columns (fix emacs freeze)

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -250,7 +250,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         ;; --line-number forces line numbers (disabled by default on windows)
         ;; no --vimgrep because it adds column numbers that wgrep can't handle
         ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number"))
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number --max-columns 150"))
           (helm-do-ag dir)))
 
       (defun spacemacs/helm-files-do-rg-region-or-symbol ()
@@ -316,7 +316,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         ;; --line-number forces line numbers (disabled by default on windows)
         ;; no --vimgrep because it adds column numbers that wgrep can't handle
         ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number"))
+        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number --max-columns 150"))
           (helm-do-ag-buffers)))
 
       (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -16,7 +16,7 @@
   '(;; --line-number forces line numbers (disabled by default on windows)
     ;; no --vimgrep because it adds column numbers that wgrep can't handle
     ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-    ("rg" . "rg --smart-case --no-heading --color never --line-number %s %S .")
+    ("rg" . "rg --smart-case --no-heading --color never --line-number --max-columns 150 %s %S .")
     ("ag" . "ag --nocolor --nogroup %s %S .")
     ("pt" . "pt -e --nocolor --nogroup %s %S .")
     ("ack" . "ack --nocolor --nogroup %s %S .")


### PR DESCRIPTION
Emacs doesn't handle long line lengths very well. If you accidentally rg a file
a file that has very long line lengths it can freeze emacs. This prevents rg
from returning any results with more than 150 characters. Instead, it will
indicate that there were results in that file but they were elided.

I could imagine this being configurable, but it'd probably be better to wait and see if someone requests it since it is possible to override it manually, at least with ivy.