### PR TITLE
error-transient-state: n/{Np} for next/prev error inst. of only n/p

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -173,6 +173,7 @@
   :bindings
   ("n" spacemacs/next-error "next")
   ("p" spacemacs/previous-error "prev")
+  ("N" spacemacs/previous-error "prev")
   ("q" nil "quit" :exit t)
   :evil-leader "e.")
 ;; file -----------------------------------------------------------------------


### PR DESCRIPTION
Add <kbd>N</kbd> for `spacemacs/previous-error` to the `error-transient-state` keybindings (in addition to the existing keybinding <kbd>p</kbd>) 