### PR TITLE
Fix keybinding `dolist' typos and switch `spacemacs/eval-current-form' docstring to imperative

### DIFF
--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -11,9 +11,10 @@
 
 
 
-;; idea from http://www.reddit.com/r/emacs/comments/312ge1/i_created_this_function_because_i_was_tired_of/
+;; Idea from http://www.reddit.com/r/emacs/comments/312ge1/i_created_this_function_because_i_was_tired_of/
 (defun spacemacs/eval-current-form ()
-  "Looks for the current def* or set* command then evaluates, unlike `eval-defun', does not go to topmost function"
+  "Find and evaluate the current def* or set* command.
+Unlike `eval-defun', this does not go to topmost function."
   (interactive)
   (save-excursion
     (search-backward-regexp "(def\\|(set")

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -58,7 +58,7 @@
     :defer t
     :init (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
             (spacemacs/declare-prefix-for-mode mode "md" "debug")
-            (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
+            (spacemacs/set-leader-keys-for-major-mode mode
               "dt" 'spacemacs/elisp-toggle-debug-expr-and-eval-func))
     :config (evilified-state-evilify-map debugger-mode-map
               :mode debugger-mode)))
@@ -70,7 +70,7 @@
     (progn
       ;; key bindings
       (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
-        (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
+        (spacemacs/set-leader-keys-for-major-mode mode
           "df" 'spacemacs/edebug-instrument-defun-on
           "dF" 'spacemacs/edebug-instrument-defun-off))
       ;; since we evilify `edebug-mode-map' we don't need to intercept it to
@@ -82,20 +82,14 @@
       'evil-make-intercept-map
       (delq (assq 'edebug-mode-map evil-intercept-maps)
             evil-intercept-maps))
-      (evilified-state-evilify-map edebug-mode-map
+     (dolist (mode-map '(edebug-mode-map edebug-eval-mode-map))
+       (evilified-state-evilify-map mode-map
         :eval-after-load edebug
         :bindings
         "a" 'edebug-stop
         "c" 'edebug-go-mode
         "s" 'edebug-step-mode
-        "S" 'edebug-next-mode)
-      (evilified-state-evilify-map edebug-eval-mode-map
-        :eval-after-load edebug
-        :bindings
-        "a" 'edebug-stop
-        "c" 'edebug-go-mode
-        "s" 'edebug-step-mode
-        "S" 'edebug-next-mode)
+        "S" 'edebug-next-mode))
       (advice-add 'edebug-mode :after 'spacemacs//edebug-mode))))
 
 (defun emacs-lisp/post-init-eldoc ()


### PR DESCRIPTION
In 'packages.el', I (hopefully) fixed some typos in the key binding `dolist`s.

In 'funcs.el, I changed the command's documentation string to use imperative phrasing. I also capitalized 'Idea' in the comment above.