### PR TITLE
Fix graphviz erroneous usage of default-tab-width in Emacs 26

### DIFF
--- a/layers/+lang/graphviz/packages.el
+++ b/layers/+lang/graphviz/packages.el
@@ -23,6 +23,10 @@
            ("\\.rackdiag\\'"  . graphviz-dot-mode)
            ("\\.dot\\'"       . graphviz-dot-mode)
            ("\\.gv\\'"        . graphviz-dot-mode))
+    :init
+    (progn
+      (unless (version<= emacs-version "26")
+        (setq graphviz-dot-indent-width tab-width)))
     :config
     (progn
       (spacemacs|add-toggle graphviz-live-reload


### PR DESCRIPTION
default-tab-width is obsolete since Emacs 23 and is removed in Emacs 26. Better
adapt it properly.
