### PR TITLE
Add editorconfig layer.

### DIFF
--- a/layers/+tools/editorconfig/packages.el
+++ b/layers/+tools/editorconfig/packages.el
@@ -1,0 +1,21 @@
+;;; packages.el --- editorconfig Layer Packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Vladimir Kochnev <hashtable@yandex.ru>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq editorconfig-packages '(editorconfig))
+
+(defun editorconfig/init-editorconfig ()
+  (use-package editorconfig
+    :ensure t
+    :config
+    (editorconfig-mode t)
+    :init
+    (progn
+      (spacemacs|diminish editorconfig-mode " Ⓔ" " E"))))


### PR DESCRIPTION
Sometime in the past editorconfig layer has been deleted.

Commit: 5887344.
Related PR: #1526.

Explanation was that layer was so simple that everything you need to get editorconfig to work is just add it to `dotspacemacs-additional-packages`.

However it's not quite true.

- `(editorconfig-mode t)` should be performed manually.
- it looks ugly in modeline.