### PR TITLE
Add key binding for helm-gtags-find-symbol: '<SPC> g y'

### DIFF
--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -268,4 +268,5 @@ the gtags commands.
 | ~SPC m g R~ | resume previous helm-gtags session                        |
 | ~SPC m g s~ | select any tag in a project retrieved by gtags            |
 | ~SPC m g S~ | show stack of visited locations                           |
+| ~SPC m g y~ | find symbols                                              |
 | ~SPC m g u~ | manually update tag database                              |

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -53,6 +53,7 @@ Otherwise does nothing."
       "gR" 'helm-gtags-resume
       "gs" 'helm-gtags-select
       "gS" 'helm-gtags-show-stack
+      "gy" 'helm-gtags-find-symbol
       "gu" 'helm-gtags-update-tags)))
 
 (defun spacemacs/ggtags-mode-enable ()


### PR DESCRIPTION
There was a keybinding for helm-gtags-find-rtag, but no binding for helm-gtags-find-symbol. I added one, and also put the binding in the layer's README. :)