### PR TITLE
fix `prodigy-view-clear-buffer` binding

### DIFF
--- a/layers/+tools/prodigy/README.org
+++ b/layers/+tools/prodigy/README.org
@@ -34,24 +34,24 @@ You start prodigy with this:
 
 ** Navigate through it
 
-| Key Binding | Description                     |
-|-------------+---------------------------------|
-| ~c~         | Clear buffer                    |
-| ~h~         | First service                   |
-| ~j~         | Next service                    |
-| ~k~         | Previous service                |
-| ~l~         | Last service                    |
-| ~H~         | Display current process         |
-| ~J~         | Next service with status        |
-| ~K~         | Previous service with status    |
-| ~L~         | Start prodigy                   |
-| ~S~         | Stop prodigy                    |
-| ~r~         | restart prodigy                 |
-| ~R~         | revert buffer  (refresh list)   |
-| ~d~         | Jump to the dired of service    |
-| ~g~         | Jump to magit-status of service |
-| ~Y~         | Copy prodigy command            |
-| ~o~         | Browse the service              |
-| ~f t~       | Add tag filter                  |
-| ~f n~       | Add name filter                 |
-| ~F~         | Clear filters                   |
+| Key Binding | Description                                             |
+|-------------+---------------------------------------------------------|
+| ~c~         | Clear buffer (only after /Display current process/ ~H~) |
+| ~h~         | First service                                           |
+| ~j~         | Next service                                            |
+| ~k~         | Previous service                                        |
+| ~l~         | Last service                                            |
+| ~H~         | Display current process                                 |
+| ~J~         | Next service with status                                |
+| ~K~         | Previous service with status                            |
+| ~L~         | Start prodigy                                           |
+| ~S~         | Stop prodigy                                            |
+| ~r~         | restart prodigy                                         |
+| ~R~         | revert buffer  (refresh list)                           |
+| ~d~         | Jump to the dired of service                            |
+| ~g~         | Jump to magit-status of service                         |
+| ~Y~         | Copy prodigy command                                    |
+| ~o~         | Browse the service                                      |
+| ~f t~       | Add tag filter                                          |
+| ~f n~       | Add name filter                                         |
+| ~F~         | Clear filters                                           |

--- a/layers/+tools/prodigy/packages.el
+++ b/layers/+tools/prodigy/packages.el
@@ -16,8 +16,8 @@
     :init
     (spacemacs/set-leader-keys "aS" 'prodigy)
     :config
+    (evil-define-key 'motion prodigy-view-mode-map "c" 'prodigy-view-clear-buffer)
     (evilified-state-evilify prodigy-mode prodigy-mode-map
-      "c" 'prodigy-view-clear-buffer
       "h" 'prodigy-first
       "j" 'prodigy-next
       "k" 'prodigy-prev


### PR DESCRIPTION
#### Description :octocat:
Pressing `c` in `Prodigy-view` mode should clear the buffer instead of being closed.

Related Pull Request: https://github.com/syl20bnr/spacemacs/pull/8636

#### Reproduction guide :beetle:
- Start Emacs
- `SPC a S`   | *Open the prodigy buffer*
- Select with the cursor any process you like
- `L`         | *Start prodigy*
- `H`         | *Display current process*
- `c`         | *Clear buffer*

*Observed behaviour:* :eyes: :broken_heart:
- `c`         | Runs *View-leave* and closes the buffer

*Expected behaviour:* :heart: :smile:
- `c`         | Should run *Clear buffer* `prodigy-view-clear-buffer`


Best & thanks in advance for your time
