### PR TITLE
Add a key binding for magit-find-file

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -20,7 +20,7 @@
    - [[#commit-message-editing-buffer][Commit message editing buffer]]
    - [[#interactive-rebase-buffer][Interactive rebase buffer]]
    - [[#quick-guide-for-recurring-use-cases-in-magit][Quick guide for recurring use cases in Magit]]
-   - [[#git-flow][Git-Flow]]
+   - [[#git-flow-1][Git-Flow]]
    - [[#git-time-machine][Git time machine]]
    - [[#git-links-to-web-services][Git links to web services]]
    - [[#repository-list][Repository list]]
@@ -107,6 +107,7 @@ Git commands (start with ~g~):
 |-------------+-----------------------------------------------------|
 | ~SPC g >~   | show submodule prompt                               |
 | ~SPC g b~   | open a =magit= blame                                |
+| ~SPC g f f~ | view a file at a specific branch or commit          |
 | ~SPC g f h~ | show file commits history                           |
 | ~SPC g H c~ | clear highlights                                    |
 | ~SPC g H h~ | highlight regions by age of commits                 |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -127,6 +127,7 @@
       (spacemacs/set-leader-keys
         "gb"  'spacemacs/git-blame-micro-state
         "gc"  'magit-clone
+        "gff" 'magit-find-file
         "gfh" 'magit-log-buffer-file
         "gi"  'magit-init
         "gL"  'magit-list-repositories


### PR DESCRIPTION
```
problem:  currently, viewing a file at a specific branch/commit, requires one to
          type the magit-find-file command, at the M-x prompt
solution: SPC g f f is available and consistent with the SPC f f key binding
```