### PR TITLE
Fix frame cycling in evil-unimpaired.

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
+++ b/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
@@ -72,11 +72,11 @@
 
 (defun evil-unimpaired/next-frame ()
   (interactive)
-  (raise-frame (next-frame)))
+  (select-frame-set-input-focus (next-frame)))
 
 (defun evil-unimpaired/previous-frame ()
   (interactive)
-  (raise-frame (previous-frame)))
+  (select-frame-set-input-focus (previous-frame)))
 
 ;; from tpope's unimpaired
 (define-key evil-normal-state-map (kbd "[ SPC")


### PR DESCRIPTION
`raise-frame` does not set input focus on selected frame.