### PR TITLE
Fix markdown table cleanup hook

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -64,7 +64,9 @@
     :config
     (progn
       (add-hook 'markdown-mode-hook 'orgtbl-mode)
-      (add-hook 'markdown-mode-hook 'spacemacs//cleanup-org-tables nil 'local)
+      (add-hook 'markdown-mode-hook
+        (lambda()
+          (add-hook 'before-save-hook 'spacemacs//cleanup-org-tables nil 'local)))
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")
                         ("mh" . "markdown/header")


### PR DESCRIPTION
The org table cleanup must be executed at the `before-save-hook` for it to take effect on tables inside a markdown document. The commit that changed this already working behaviour was 4fd895a9170b45f5959e4971c1565561303f0fd4. 

In order to test this out you need to create a `test.md` file with the following contests:
```markdown
| A | B |
|---+---|
| a | b |
```

Replace one of the letters, let's say `A` with `C` and then save.

**Before this PR**: The `+` is not replaced by a `|`.
**After this PR**: The `+` is replaced by a `|`.
