### PR TITLE
Shell scripts: add new company-shell environment variable backend.

### DIFF
--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -26,10 +26,10 @@
     :init
     (progn
       (spacemacs|add-company-backends
-        :backends company-shell
+        :backends (company-shell company-shell-env)
         :modes sh-mode)
       (spacemacs|add-company-backends
-        :backends (company-shell company-fish-shell)
+        :backends (company-shell company-shell-env company-fish-shell)
         :modes fish-mode))))
 
 (defun shell-scripts/post-init-flycheck ()


### PR DESCRIPTION
Simple change to make the shell scripts layer use company-shell's new environment variable backend.