### PR TITLE
CI allow_failures for doc tests (Emacs 24.4 Emacs 24.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: TESTS=core EVM_EMACS=emacs-git-snapshot-travis
+  - env: TESTS=doc EVM_EMACS=emacs-24.4-travis
+  - env: TESTS=doc EVM_EMACS=emacs-24.5-travis
   - env: TESTS=doc EVM_EMACS=emacs-git-snapshot-travis
 script: "./.travis-build.sh"


### PR DESCRIPTION
These tests are not important now because we are exporting documentation automatically with Emacs 25.1