### PR TITLE
Keep find-ert-test-buffer from moving point.

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -752,7 +752,8 @@ The body of the advice is in BODY."
 
 (defun spacemacs//find-ert-test-buffer (ert-test)
   "Return the buffer where ERT-TEST is defined."
-  (car (find-definition-noselect (ert-test-name ert-test) 'ert-deftest)))
+  (save-excursion
+    (car (find-definition-noselect (ert-test-name ert-test) 'ert-deftest))))
 
 (defun spacemacs/ert-run-tests-buffer ()
   "Run all the tests in the current buffer."


### PR DESCRIPTION
`spacemacs/ert-run-tests-buffer` has an annoying habit of moving point to somewhere else from where it is run. This change will fix it.

I moved the change one level down on the call stack to make for a more general solution - I don't know if `find-ert-test-buffer` is also used elsewhere - but its purpose is to only get a reference to a buffer and it's explicitly calling a -noselect function, so putting the change here should be fine.