### PR TITLE
Render Madoko document using markdown mode

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -59,7 +59,7 @@
 
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
-    :mode ("\\.m[k]d" . markdown-mode)
+    :mode ("\\.m[k]d" . markdown-mode) ("\\.mdk" . markdown-mode)
     :defer t
     :config
     (progn


### PR DESCRIPTION
Madoko is a fast markdown processor with a special .mdk extension
from microsoft research. emacs should use markdown-mode to render
a .mdk file as markdown file.