### PR TITLE
Fill the current filename as a suggestion of spacemacs/rename-current…

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -301,8 +301,7 @@ be saved to a file, or just renamed."
          (filename (buffer-file-name)))
     (if (and filename (file-exists-p filename))
         ;; the buffer is visiting a file
-        (let* ((dir (file-name-directory filename))
-               (new-name (read-file-name "New name: " dir)))
+        (let ((new-name (read-file-name "New name: " filename)))
           (cond ((get-buffer new-name)
                  (error "A buffer named '%s' already exists!" new-name))
                 (t


### PR DESCRIPTION
Hi,

When using the function `spacemacs/rename-current-buffer-file` (`SPC-f-R`), I realize that most of the time, I create a new file name by modifying the current file name. 

Would it make sense to change the current file name suggestion (which is the folder path containing the current file), to the new file name suggestion, which is the entire file path? 

I create a PR for this suggestion, and there are two reasons for this modification:

- Deleting some words/character, and then writing some new words/characters is normally faster than writing the entire new name (of course, when using Emacs strokes).

- If we write a new name from scratch, the fuzzy matching feature of Helm sometimes suggests existing file names that we don't want, so we have to move the cursor to the new file name beginning with `[?]` (in Helm window). That takes more effort to write a new name.

Please let me know your opinion about this PR.
Thanks!
