### PR TITLE
ivy: Use new API to register additional transient state bindings

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -35,8 +35,8 @@
     ;; add some functions to ahs transient states
     (setq spacemacs--symbol-highlight-transient-state-doc
           (concat spacemacs--symbol-highlight-transient-state-doc
-                  "  [_b_] search buffers [_/_] search proj [_f_] search files [_s_] swiper")
-          spacemacs-symbol-highlight-transient-state-add-bindings
+                  "  [_b_] search buffers [_/_] search proj [_f_] search files [_s_] swiper"))
+    (spacemacs/transient-state-register-add-bindings 'symbol-highlight
           '(("/" spacemacs/search-project-auto-region-or-symbol :exit t)
             ("b" spacemacs/swiper-all-region-or-symbol :exit t)
             ("f" spacemacs/search-auto-region-or-symbol :exit t)


### PR DESCRIPTION
This is a follow-up commit after #8155 has been merged. It applies the same changes to code of the `ivy` layer. It is not part of #8155 because there was no `ivy` layer when that PR was submitted.