### PR TITLE
init-evil-mc: 1 cursor hide mode line text variable

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -111,12 +111,7 @@
       ;; evil-mc is not compatible with the paste transient state
       (define-key evil-normal-state-map "p" 'spacemacs/evil-mc-paste-after)
       (define-key evil-normal-state-map "P" 'spacemacs/evil-mc-paste-before)
-      ;; remove emc prefix when there is not multiple cursors
-      (setq evil-mc-mode-line
-            `(:eval (when (> (evil-mc-get-cursor-count) 1)
-                      (format ,(propertize " %s:%d" 'face 'cursor)
-                              evil-mc-mode-line-prefix
-                              (evil-mc-get-cursor-count))))))))
+      (setq evil-mc-one-cursor-show-mode-line-text nil))))
 
 ;; other commenting functions in funcs.el with keybinds in keybindings.el
 (defun spacemacs-evil/init-evil-nerd-commenter ()


### PR DESCRIPTION
Problem:
Spacemacs rewrites the evil-mc-mode-line variable, to remove the evil-mc mode
line text, when there's only one cursor. The rewrite blocks the recent evil-mc
updates, that made the multi cursor, mode line text, more readable.

Solution:
Use the new evil-mc-one-cursor-show-mode-line-text variable, to only hide the
mode line text, when there's one cursor. This unblocks the current, and any
future updates, that the evil-mc package makes to the mode line text.