### PR TITLE
Fix sayid clojure debugger documentation typo

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -209,7 +209,7 @@ As this state works the same for all files, the documentation is in global
 |---------------+----------------------------------------------------|
 | ~SPC m d b~   | instrument expression at point                     |
 | ~SPC m d e~   | display last stacktrace                            |
-| ~SPC m d r~   | reload namepspaces                                 |
+| ~SPC m d r~   | reload namespaces                                  |
 | ~SPC m d v~   | inspect expression at point                        |
 | ~SPC m d i~   | inspect expression at point                        |
 | ~SPC m d f~   | query form at point                                |


### PR DESCRIPTION
Fixed small typo introduced in PR #8536 