### PR TITLE
[python] Prefer virtualenv python to compile file

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -341,9 +341,8 @@
         ;; universal argument put compile buffer in comint mode
         (let ((universal-argument t)
               (compile-command (format "%s %s"
-                                       python-shell-interpreter
-                                       (file-name-nondirectory
-                                        buffer-file-name))))
+                                       (spacemacs/pyenv-executable-find python-shell-interpreter)
+                                       (file-name-nondirectory buffer-file-name))))
           (if arg
               (call-interactively 'compile)
             (compile compile-command t)


### PR DESCRIPTION
Otherwise, it falls back to system python which may not have the dependencies used in the imports in the file.