### PR TITLE
Remove SPARQL from extra-langs

### DIFF
--- a/layers/+lang/extra-langs/packages.el
+++ b/layers/+lang/extra-langs/packages.el
@@ -6,7 +6,6 @@
     qml-mode
     scad-mode
     stan-mode
-    sparql-mode
     thrift
     wolfram-mode
     ))
@@ -39,13 +38,6 @@
 (defun extra-langs/init-stan-mode ()
   (use-package stan-mode
     :defer t))
-
-(defun extra-langs/init-sparql-mode ()
-  (use-package sparql-mode
-    :defer t
-    :mode "\\.sparql\\'")
-    (when (configuration-layer/package-usedp 'company)
-      (spacemacs|add-company-backends :modes sparql-mode)))
 
 (defun extra-langs/init-thrift ()
   (use-package thrift


### PR DESCRIPTION
Support for SPARQL was added with the semantic-web layer in https://github.com/syl20bnr/spacemacs/commit/f7210c30c2fe979eed6033becc14af9af892b431