### PR TITLE
add a feature to save file as a new file and open it in a new buffer

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -353,6 +353,24 @@ initialized with the current filename."
                 ;; ?\a = C-g, ?\e = Esc and C-[
                 ((memq key '(?\a ?\e)) (keyboard-quit))))))))
 
+(defun spacemacs/save-file-as-and-open (filename)
+  "Save current buffer into file FILENAME and open it in a new buffer."
+  (interactive
+   (list (if buffer-file-name
+             (read-file-name "Save file as and open: " buffer-file-name)
+           (read-file-name "Save file as and open: " default-directory))))
+  (or (null filename) (string-equal filename "")
+      (progn
+        (let ((dir (file-name-directory filename)))
+          (when (and (not (file-exists-p dir))
+                     (yes-or-no-p (format "Create directory '%s'?" dir)))
+            (make-directory dir t)))
+        (and (file-exists-p filename)
+             (or (y-or-n-p (format "File `%s' exists; overwrite? " filename))
+                 (error "Canceled")))
+        (write-region (point-min) (point-max) filename )
+        (find-file filename))))
+
 (defun spacemacs/delete-file (filename &optional ask-user)
   "Remove specified file or directory.
 

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -179,6 +179,7 @@
   :evil-leader "e.")
 ;; file -----------------------------------------------------------------------
 (spacemacs/set-leader-keys
+  "fa" 'spacemacs/save-file-as-and-open
   "fc" 'spacemacs/copy-file
   "fD" 'spacemacs/delete-current-buffer-file
   "fei" 'spacemacs/find-user-init-file


### PR DESCRIPTION
Hi,

I added a feature which allows saving the current buffer into a new file, and open the new file into a new buffer, without closing the current buffer.

This resolves the issue in [StackOverflow](https://stackoverflow.com/questions/5168262/emacs-write-buffer-to-new-file-but-keep-this-file-open), where quite a number of people need this feature.

I add the key binding as `SPC f a`, which `a` reminds of `as` in `Save as`.

Please let me know your opinion about this feature?

Thanks!

