### PR TITLE
Pass: support for ivy and fix undefined dostpacemacs-use-ido

### DIFF
--- a/layers/+tools/pass/funcs.el
+++ b/layers/+tools/pass/funcs.el
@@ -10,13 +10,8 @@
 ;;; License: GPLv3
 
 (defun spacemacs//pass-completing-read ()
-  "Read a password entry in the minibuffer, with completion.
-
-This method is overridden to allow use of the dotspacemacs-use-ido variable."
-  ;; TODO update this to works with ivy
-  (if dotspacemacs-use-ido
-      (ido-completing-read "Password entry: " (password-store-list))
-    (helm-comp-read "Password entry: " (password-store-list))))
+  "Read a password entry in the minibuffer, with completion."
+  (completing-read "Password entry: " (password-store-list)))
 
 (defun spacemacs/pass-copy-and-describe (entry)
   "Copy the password to the clipboard, and show the multiline description for ENTRY"


### PR DESCRIPTION
Looks like pass is trying to use variable which isn't available for some time,
at least there are no other packages using it.

`completing-read` should be universal for all completing needs I hope.