### PR TITLE
ISSUE-8992 Fix normal-state keymap is not restored issue

### DIFF
--- a/layers/+distributions/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
@@ -61,7 +61,7 @@
   :enable (emacs)
   :message "-- EVILIFIED BUFFER --"
   :cursor box
-  :exit-hook (list evilified-state--restore-normal-state-keymap))
+  :exit-hook (evilified-state--restore-normal-state-keymap))
 
 (bind-map spacemacs-default-map
   :prefix-cmd spacemacs-cmds

--- a/layers/+distributions/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-base/local/evil-evilified-state/evil-evilified-state.el
@@ -60,7 +60,8 @@
   :tag " <N'> "
   :enable (emacs)
   :message "-- EVILIFIED BUFFER --"
-  :cursor box)
+  :cursor box
+  :exit-hook (list evilified-state--restore-normal-state-keymap))
 
 (bind-map spacemacs-default-map
   :prefix-cmd spacemacs-cmds


### PR DESCRIPTION
As reported in #8992, after exit `evilified-state`, the normal-state keymap is not restored.
This fix adds restore function to exit-hook.