### PR TITLE
Use a more consistent keybinding for flycheck-buffer

### DIFF
--- a/layers/+checkers/syntax-checking/README.org
+++ b/layers/+checkers/syntax-checking/README.org
@@ -57,8 +57,8 @@ variable =syntax-checking-use-original-bitmaps= to =t=:
 
 | Key Binding | Description                                                  |
 |-------------+--------------------------------------------------------------|
+| ~SPC e b~   | check for errors now                                         |
 | ~SPC e c~   | clear errors                                                 |
-| ~SPC e e~   | check for errors now                                         |
 | ~SPC e h~   | describe flycheck checker                                    |
 | ~SPC e l~   | display a list of all the errors                             |
 | ~SPC e L~   | display a list of all the errors and focus the errors buffer |

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -84,8 +84,8 @@
 
       ;; key bindings
       (spacemacs/set-leader-keys
+        "eb" 'flycheck-buffer
         "ec" 'flycheck-clear
-        "ee" 'flycheck-buffer
         "eh" 'flycheck-describe-checker
         "el" 'spacemacs/toggle-flycheck-error-list
         "eL" 'spacemacs/goto-flycheck-error-list


### PR DESCRIPTION
Changed `flycheck-buffer` keybinding for `SPC e b` (was `SPC e e`) to be more consistent with `flyspell-buffer` keybinding (`SPC S b`).