### PR TITLE
Add transpose sentences and transpose paragraphs keybindings.

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -455,6 +455,8 @@
   "xtc" 'transpose-chars
   "xtl" 'transpose-lines
   "xtw" 'transpose-words
+  "xts" 'transpose-sentences
+  "xtp" 'transpose-paragraphs
   "xU"  'upcase-region
   "xu"  'downcase-region
   "xwc" 'spacemacs/count-words-analysis


### PR DESCRIPTION
Notice that transpose sentences (and paragraphs) was missing from the SPC-x-t shortcut family. They can be handy when writing in org-mode.