### PR TITLE
Add keybinding for calendar

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -114,6 +114,7 @@
 ;; applications ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "ac"  'calc-dispatch
+  "aC"  'calendar
   "ap"  'list-processes
   "aP"  'proced
   "au"  'undo-tree-visualize)


### PR DESCRIPTION
Bind "SPC aC" to `calendar`.

The `calendar` command displays a small popup calendar showing the previous,
current, and next month by default.

The primary drawback is that we will probably, eventually, add a full calendar
layer that may want to use the "SPC aC" keybinding.