### PR TITLE
.spacemacs template docstring revision

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -3,9 +3,8 @@
 ;; It must be stored in your home directory.
 
 (defun dotspacemacs/layers ()
-  "Configuration Layers declaration.
-You should not put any user code in this function besides modifying the variable
-values."
+  "Configuration layers:
+This function should only modify layer settings."
   (setq-default
    ;; Base distribution to use. This is a layer contained in the directory
    ;; `+distribution'. For now available distributions are `spacemacs-base'
@@ -69,11 +68,8 @@ values."
    dotspacemacs-install-packages 'used-only))
 
 (defun dotspacemacs/init ()
-  "Initialization function.
-This function is called at the very startup of Spacemacs initialization
-before layers configuration.
-You should not put any user code in there besides modifying the variable
-values."
+  "Initialization function for Spacemacs settings:
+This function is called at the beginning of Spacemacs initialization, before layers configuration. It should only modify the values of Spacemacs settings."
   ;; This setq-default sexp is an exhaustive list of all the supported
   ;; spacemacs settings.
   (setq-default
@@ -326,21 +322,13 @@ values."
    ))
 
 (defun dotspacemacs/user-init ()
-  "Initialization function for user code.
-It is called immediately after `dotspacemacs/init', before layer configuration
-executes.
- This function is mostly useful for variables that need to be set
-before packages are loaded. If you are unsure, you should try in setting them in
-`dotspacemacs/user-config' first."
+  "Initialization function for user code:
+This function is called immediately after `dotspacemacs/init', before layer configuration. It is mostly useful for variables that should be set before packages are loaded. If you are unsure, try setting them in `dotspacemacs/user-config' first."
   )
 
 (defun dotspacemacs/user-config ()
-  "Configuration function for user code.
-This function is called at the very end of Spacemacs initialization after
-layers configuration.
-This is the place where most of your configurations should be done. Unless it is
-explicitly specified that a variable should be set before a package is loaded,
-you should place your code here."
+  "Configuration function for user code:
+This function is called at the very end of Spacemacs initialization, after layers configuration. Put your configuration code here, except for variables that should be set before packages are loaded."
   )
 
 ;; Do not write anything past this comment. This is where Emacs will

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -69,7 +69,8 @@ This function should only modify layer settings."
 
 (defun dotspacemacs/init ()
   "Initialization function for Spacemacs settings:
-This function is called at the beginning of Spacemacs initialization, before layers configuration. It should only modify the values of Spacemacs settings."
+This function is called at the beginning of Spacemacs initialization, before
+layers configuration. It should only modify the values of Spacemacs settings."
   ;; This setq-default sexp is an exhaustive list of all the supported
   ;; spacemacs settings.
   (setq-default
@@ -323,13 +324,18 @@ This function is called at the beginning of Spacemacs initialization, before lay
 
 (defun dotspacemacs/user-init ()
   "Initialization function for user code:
-This function is called immediately after `dotspacemacs/init', before layer configuration. It is mostly useful for variables that should be set before packages are loaded. If you are unsure, try setting them in `dotspacemacs/user-config' first."
-  )
+This function is called immediately after `dotspacemacs/init', before layer
+configuration. It is mostly useful for variables that should be set before
+packages are loaded. If you are unsure, try setting them in
+`dotspacemacs/user-config' first."
+)
 
 (defun dotspacemacs/user-config ()
   "Configuration function for user code:
-This function is called at the very end of Spacemacs initialization, after layers configuration. Put your configuration code here, except for variables that should be set before packages are loaded."
-  )
+This function is called at the very end of Spacemacs initialization, after
+layers configuration. Put your configuration code here, except for variables
+that should be set before packages are loaded."
+)
 
 ;; Do not write anything past this comment. This is where Emacs will
 ;; auto-generate custom variable definitions.


### PR DESCRIPTION
I edited the docstrings of the main functions of the .spacemacs template for grammar and brevity. It makes more sense to me, so I figured I'd share it.