### PR TITLE
counsel-find-file: Bind `find-file-other-window' to "j"

### DIFF
--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -32,7 +32,7 @@ than this amount.")
 
 (defvar spacemacs--ivy-file-actions
   '(("f" find-file-other-frame "other frame")
-    ("w" find-file-other-window "other window")
+    ("j" find-file-other-window "other window")
     ("v" spacemacs/find-file-vsplit "in vertical split")
     ("s" spacemacs/find-file-split "in horizontal split")
     ("l" find-file-literally "literally")


### PR DESCRIPTION
By default, "M-o w" binding has already been used by ivy:

![image](https://user-images.githubusercontent.com/11584902/26857112-e53d39e2-4b5a-11e7-906b-481ab433dab4.png)



So we bind `find-file-other-window' to "M-o j" here.