### PR TITLE
Update of `evil-org-mode`.

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -40,7 +40,7 @@
 This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
 
 ** Features:
-- Vim inspired key bindings are provided by [[https://github.com/edwtjo/evil-org-mode][evil-org-mode]]
+- Vim inspired key bindings are provided by [[https://github.com/Somelauw/evil-org-mode][evil-org-mode]]
 - Nicer bullet via [[https://github.com/sabof/org-bullets][org-bullets]]
 - A [[https://cirillocompany.de/pages/pomodoro-technique][pomodoro method]] integration via [[https://github.com/lolownia/org-pomodoro][org-pomodoro]]
 - Presentation mode via [[https://github.com/rlister/org-present][org-present]]

--- a/layers/+emacs/org/local/evil-org/evil-org.el
+++ b/layers/+emacs/org/local/evil-org/evil-org.el
@@ -50,11 +50,11 @@
     (org-insert-item))
   )
 
-(defun evil-org-eol-call (fun)
+(defun evil-org-eol-call (fun &optional arg)
   "Go to end of line and call provided function.
-FUN function callback"
+FUN function callback. Optionally, apply prefix argument ARG."
   (end-of-visible-line)
-  (funcall fun)
+  (funcall fun arg)
   (evil-append nil)
   )
 

--- a/layers/+emacs/org/local/evil-org/evil-org.el
+++ b/layers/+emacs/org/local/evil-org/evil-org.el
@@ -43,11 +43,11 @@
 
 (add-hook 'org-mode-hook 'evil-org-mode) ;; only load with org-mode
 
-(defun clever-insert-item ()
+(defun clever-insert-item (&optional arg)
   "Clever insertion of org item."
   (if (not (org-in-item-p))
       (insert "\n")
-    (org-insert-item))
+    (org-insert-item arg))
   )
 
 (defun evil-org-eol-call (fun &optional arg)
@@ -133,7 +133,7 @@ FUN function callback. Optionally, apply prefix argument ARG."
   "gl" 'outline-next-visible-heading
   "t" 'org-todo
   "T" '(lambda () (interactive) (evil-org-eol-call (lambda() (org-insert-todo-heading nil))))
-  "o" '(lambda () (interactive) (evil-org-eol-call 'clever-insert-item))
+  "o" '(lambda (arg) (interactive "P") (evil-org-eol-call 'clever-insert-item arg))
   "O" '(lambda () (interactive) (evil-org-eol-call 'org-insert-heading))
   "$" 'org-end-of-line
   "^" 'org-beginning-of-line


### PR DESCRIPTION
Change `evil-org-mode` link to the new maintained GitHub repository.

Add the ability to process prefix arguments with `evil-org-eol-call`.

Use this ability to create list items with checkboxes with `clever-insert-item`.

I just saw that there is another pull request about `evil-org-mode` that asks for replacement with `worf`. I do not know `worf` but still provide this code in case it is needed.

Further, wouldn't it be better to use a submodule for `evil-org-mode` so that the spacemacs version does not diverge from the maintained one?