### PR TITLE
Fix Swift REPL leader key bindings

### DIFF
--- a/layers/+lang/swift/packages.el
+++ b/layers/+lang/swift/packages.el
@@ -48,10 +48,10 @@ before activiting or switching to REPL."
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'swift-mode
-        "sS" 'swift-mode-run-repl      ; run or switch to an existing swift repl
-        "ss" 'swift-mode-run-repl
-        "sb" 'swift-mode-send-buffer
-        "sr" 'swift-mode-send-region)
+        "sS" 'swift-mode:run-repl      ; run or switch to an existing swift repl
+        "ss" 'swift-mode:run-repl
+        "sb" 'swift-mode:send-buffer
+        "sr" 'swift-mode:send-region)
 
       (with-eval-after-load 'swift-repl-mode-map
         ;; Switch back to editor from REPL


### PR DESCRIPTION
The `swift-mode` REPL bindings have been updated to use a different
naming convention (e.g. a prefix of `swift-mode:` in the CL style).
Typing `, s s` would trigger this error:

```
command-execute: Wrong type argument: commandp, swift-mode-run-repl
```

This change fixes up the command names so that they are usable again
from the leader key.