### PR TITLE
fix #8985

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -122,6 +122,7 @@ itself.
 
 *** =dante=
 =dante= works for =cabal=, =nix=, =sytx=, and =stack= users.
+=dante= requires Emacs 25.
 
 *** =ghc-mod=
 [[http://www.mew.org/~kazu/proj/ghc-mod/][ghc-mod]] enhances =haskell-mode= with for example code completion, templates,

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -26,7 +26,7 @@
     hindent
     hlint-refactor
     intero
-    dante
+    (dante :toggle (version<= "25" emacs-version))
     ))
 
 (defun haskell/init-cmm-mode ()


### PR DESCRIPTION
Disable `dante` package if  Emacs version is less than `25`