### PR TITLE
spacemacs/evil-mc-paste-{before,after}: fix multiple cursor paste

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -84,16 +84,16 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
        (or (not (fboundp 'evil-mc-get-cursor-count))
            (eq (evil-mc-get-cursor-count) 1))))
 
-(defun spacemacs/evil-mc-paste-after (&optional count)
+(defun spacemacs/evil-mc-paste-after (&optional count register)
   "Disable paste transient state if there is more that 1 cursor."
   (interactive "p")
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-after)
-    (evil-paste-after count evil-this-register)))
+    (evil-paste-after count (or register evil-this-register))))
 
-(defun spacemacs/evil-mc-paste-before (&optional count)
+(defun spacemacs/evil-mc-paste-before (&optional count register)
   "Disable paste transient state if there is more that 1 cursor."
   (interactive "p")
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-before)
-    (evil-paste-before count evil-this-register)))
+    (evil-paste-before count (or register evil-this-register))))


### PR DESCRIPTION
See the commit mesage for a more succint fix description, but here are the repro steps:

```
trash ~/fresh_spcm
mkdir ~/fresh_spcm
git clone https://github.com/syl20bnr/spacemacs.git ~/fresh_spcm/.emacs.d
cd ~/fresh_spcm/.emacs.d
git checkout develop
env HOME=$HOME/fresh_spcm/ emacs
```

Set `dotspacemacs-enable-paste-transient-state` to `t`

`SPC q r` (was getting some unrelated error about `org-link-types`? this made it go away)

`SPC b s`

Insert, e.g.:
```
test
test
```

`M-x evil-mc-mode`
`C-n`
`yy`
`p`

Only the real cursor successfully pastes anything, since:

```
evil-mc Execute spacemacs/evil-mc-paste-after with evil-mc-execute-default-evil-paste
evil-mc Failed to execute spacemacs/evil-mc-paste-after with error: Wrong number of arguments: (lambda (&optional count) "Disable paste transient state if there is more that 1 cursor." (interactive "p") (if (spacemacs//paste-transient-state-p) (spacemacs/paste-transient-state/evil-paste-after) (evil-paste-after count evil-this-register))), 2
```

Introduced by: https://github.com/syl20bnr/spacemacs/commit/bfb565eea9a395892b9961f970bf76de53754dc8 