### PR TITLE
OSX: Fix the function keys not working correctly

### DIFF
--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -35,10 +35,10 @@
    Default: `meta'.
    For backwards compatibility the variable `osx-use-option-as-meta'
    takes precedence is set to t.")
-(defvar osx-function-as 'none
+(defvar osx-function-as nil
   "Sets the key binding of the `FUCTION' key on OSX.
-   Possible values are `super' `meta' `hyper' `alt' `none'.
-   Default: `none'.")
+   Possible values are `super' `meta' `hyper' `alt' `nil'.
+   Default: `nil'.")
 (defvar osx-control-as 'control
   "Sets the key binding of the `CONTROL' key on OSX.
    Possible values are `super' `meta' `hyper' `alt' `none'.


### PR DESCRIPTION
page up and page down were not working correctly and this allows the normal emacs handling of system function keys.

Fixes bug #9006