### PR TITLE
Add ENSIME jump handlers to the proper modes

### DIFF
--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -68,7 +68,8 @@
 (defun spacemacs//java-setup-ensime ()
   "Setup ENSIME."
   ;; jump handler
-  (add-to-list 'spacemacs-jump-handlers 'ensime-edit-definition)
+  (add-to-list 'spacemacs-jump-handlers-java-mode 'ensime-edit-definition)
+  (add-to-list 'spacemacs-jump-handlers-scala-mode 'ensime-edit-definition)
   ;; ensure the file exists before starting `ensime-mode'
   (cond
    ((and (buffer-file-name) (file-exists-p (buffer-file-name)))

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -11,8 +11,6 @@
 
 (spacemacs|define-jump-handlers scala-mode)
 
-(spacemacs|define-jump-handlers scala-mode)
-
 (defvar scala-enable-eldoc nil
   "If non nil then eldoc-mode is enabled in the scala layer.")
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -25,7 +25,7 @@
         magit-gitflow
         ;; not compatible with magit 2.1 at the time of release
         ;; magit-svn
-        orgit
+        (orgit :toggle (configuration-layer/package-usedp 'org))
         smeargle
         ))
 


### PR DESCRIPTION
This PR adds the `ensime-edit-definition` jump handler to the list of jump handlers for the appropriate modes. This should fix #7144.

Since `scala-setup-ensime` calls `java-setup-ensime`, I opted to add the handler for both modes directly in `java-setup-ensime`, but I'm not sure if it's preferable to add each one individually under each mode hook.