### PR TITLE
Fixed bug so hy commands work when hy is installed on a virtualenv

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -214,6 +214,7 @@
     :defer t
     :init
     (progn
+      (add-hook 'pyvenv-post-activate-hooks 'python/init-hy-mode)
       (pcase python-auto-set-local-pyvenv-virtualenv
         (`on-visit
          (spacemacs/add-to-hooks 'spacemacs//pyvenv-mode-set-local-virtualenv

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -129,23 +129,25 @@
     :init
     (spacemacs/set-leader-keys-for-major-mode 'python-mode "hd" 'helm-pydoc)))
 
+(defun python/find-hy-executable ()
+  (setq-local hy-mode-inferior-lisp-command (concat (spacemacs/pyenv-executable-find "hy") " --spy")))
+
 (defun python/init-hy-mode ()
   (use-package hy-mode
     :defer t
     :init
     (progn
-      (let ((hy-path (executable-find "hy")))
-        (when hy-path
-          (setq hy-mode-inferior-lisp-command (concat hy-path " --spy"))
-          (spacemacs/set-leader-keys-for-major-mode 'hy-mode
-            "si" 'inferior-lisp
-            "sb" 'lisp-load-file
-            "sB" 'switch-to-lisp
-            "se" 'lisp-eval-last-sexp
-            "sf" 'lisp-eval-defun
-            "sF" 'lisp-eval-defun-and-go
-            "sr" 'lisp-eval-region
-            "sR" 'lisp-eval-region-and-go))))))
+      (add-hook 'hy-mode-hook 'python/find-hy-executable)
+      (add-hook 'pyvenv-post-activate-hooks 'python/find-hy-executable)
+      (spacemacs/set-leader-keys-for-major-mode 'hy-mode
+        "si" 'inferior-lisp
+        "sb" 'lisp-load-file
+        "sB" 'switch-to-lisp
+        "se" 'lisp-eval-last-sexp
+        "sf" 'lisp-eval-defun
+        "sF" 'lisp-eval-defun-and-go
+        "sr" 'lisp-eval-region
+        "sR" 'lisp-eval-region-and-go))))
 
 (defun python/init-live-py-mode ()
   (use-package live-py-mode
@@ -214,7 +216,6 @@
     :defer t
     :init
     (progn
-      (add-hook 'pyvenv-post-activate-hooks 'python/init-hy-mode)
       (pcase python-auto-set-local-pyvenv-virtualenv
         (`on-visit
          (spacemacs/add-to-hooks 'spacemacs//pyvenv-mode-set-local-virtualenv

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -130,7 +130,8 @@
     (spacemacs/set-leader-keys-for-major-mode 'python-mode "hd" 'helm-pydoc)))
 
 (defun python/find-hy-executable ()
-  (setq-local hy-mode-inferior-lisp-command (concat (spacemacs/pyenv-executable-find "hy") " --spy")))
+  (setq-local hy-executable (or (spacemacs/pyenv-executable-find "hy") "hy"))
+  (setq-local hy-mode-inferior-lisp-command (concat hy-executable " --spy")))
 
 (defun python/init-hy-mode ()
   (use-package hy-mode


### PR DESCRIPTION
Hy is typically installed on a python virtual environment, not globally. When
that is the case, the init-hy-mode function doesn't set any leader keys for hy 
since it can't find the hy executable on the path. When a new virtual 
environment is activated, init-hy-mode is run again to see if it can find a hy
executable and setup the leader keys for hy.