### PR TITLE
Updated hy-mode lisp eval keys to match spacemacs conventions

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -138,11 +138,11 @@
         "si" 'inferior-lisp
         "sb" 'lisp-load-file
         "sB" 'switch-to-lisp
-        "se" 'lisp-eval-last-sexp
-        "sf" 'lisp-eval-defun
-        "sF" 'lisp-eval-defun-and-go
-        "sr" 'lisp-eval-region
-        "sR" 'lisp-eval-region-and-go)
+        "ee" 'lisp-eval-last-sexp
+        "ef" 'lisp-eval-defun
+        "eF" 'lisp-eval-defun-and-go
+        "er" 'lisp-eval-region
+        "eR" 'lisp-eval-region-and-go)
       ;; call `spacemacs//python-setup-hy' once, don't put it in a hook (see issue #5988)
       (spacemacs//python-setup-hy))))
 


### PR DESCRIPTION
Updated hy-mode leader keys to match the conventions listed [here](https://github.com/syl20bnr/spacemacs/blob/develop/doc/CONVENTIONS.org#evaluation).

Now functions related to lisp evaluation start with `SPC m e` and functions
related to the hy repl start with `SPC m s`.

This was suggested in pull request #6357