### PR TITLE
Fix lazy insert point

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -446,7 +446,7 @@ Returns non nil if the layer has been effectively inserted."
     (with-current-buffer (find-file-noselect (dotspacemacs/location))
       (beginning-of-buffer)
       (let ((insert-point (re-search-forward
-                           "dotspacemacs-configuration-layers\\s-*\n?[^(]*\\((\\)")))
+                           "[^`]dotspacemacs-configuration-layers\\s-*\n?[^(]*\\((\\)")))
         (insert (format "%S" layer-name))
         (unless (equal (point) (point-at-eol))
           (insert "\n"))


### PR DESCRIPTION
A recent change in the `.spacemacs.template` made it so that the
`dotspacemacs-configuration-layers` variable name can be found inside a
comment right before the expression that sets it's value. This makes the
lazy insertion fail to detect the proper place to add lazy loaded
layers.

This fix solves the immediate problem but maybe a better solution can
be found.