### PR TITLE
Fix issue #8823: evil-paste-pop doesn't work `previous command was not an evil paste.`

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -85,15 +85,17 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
            (eq (evil-mc-get-cursor-count) 1))))
 
 (defun spacemacs/evil-mc-paste-after (&optional count register)
-  "Disable paste transient state if there is more that 1 cursor."
+  "Disable paste transient state if there is more than 1 cursor."
   (interactive "p")
+  (setq this-command 'evil-paste-after)
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-after)
     (evil-paste-after count (or register evil-this-register))))
 
 (defun spacemacs/evil-mc-paste-before (&optional count register)
-  "Disable paste transient state if there is more that 1 cursor."
+  "Disable paste transient state if there is more than 1 cursor."
   (interactive "p")
+  (setq this-command 'evil-paste-before)
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-before)
     (evil-paste-before count (or register evil-this-register))))

--- a/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
+++ b/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
@@ -54,11 +54,13 @@
 
 (defun evil-unimpaired/paste-above ()
   (interactive)
+  (setq this-command 'evil-paste-after)
   (evil-insert-newline-above)
   (evil-paste-after 1))
 
 (defun evil-unimpaired/paste-below ()
   (interactive)
+  (setq this-command 'evil-paste-after)
   (evil-insert-newline-below)
   (evil-paste-after 1))
 


### PR DESCRIPTION
Fix issue #8823.

[evil-common.el: evil-paste-pop](https://github.com/emacs-evil/evil/blob/master/evil-common.el#L2604), has the following check:

```
(unless (memq last-command
                '(evil-paste-after
                  evil-paste-before
                  evil-visual-paste))
    (user-error "Previous command was not an evil-paste: %s" last-command))
```
Calls to [spacemacs/evil-mc-paste-after](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bspacemacs/spacemacs-evil/funcs.el#L87) and [spacemacs/evil-mc-paste-before](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bspacemacs/spacemacs-evil/funcs.el#L94) thus break `evil-paste-pop`.  A more idiomatic way to create this functionality is to use [elisp advice](https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html).