### PR TITLE
Add "xi_" (underscore case) and "xi-" (kebab case) to `string-inflection' bindings in `spacemacs-editing'

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -365,8 +365,10 @@
       (spacemacs/set-leader-keys
         "xii" 'string-inflection-all-cycle
         "xiu" 'string-inflection-underscore
+        "xi_" 'string-inflection-underscore
         "xiU" 'string-inflection-upcase
         "xik" 'string-inflection-kebab-case
+        "xi-" 'string-inflection-kebab-case
         "xic" 'string-inflection-lower-camelcase
         "xiC" 'string-inflection-camelcase))))
 


### PR DESCRIPTION
'xi_' for underscore
'xi-' for kebab

Should be self-explanatory.