### PR TITLE
Autocompletion debug

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -66,7 +66,7 @@ opening a python buffer:
 To fix this, install the =anaconda-mode= [[https://github.com/proofit404/anaconda-mode/wiki][anaconda-deps]] by hand:
 
 #+begin_src sh
-    pip install --upgrade "jedi>=0.9.0" "json-rpc>=1.8.1" "service_factory>=0.1.5"
+    pip install --upgrade "jedi==0.9.0" "json-rpc>=1.8.1" "service_factory>=0.1.5"
 #+end_src
 
 Source: https://github.com/proofit404/anaconda-mode#issues


### PR DESCRIPTION
Autcompletion does not handle request properly with jedi 1.0. Until the bug is corrected, one should keep the 0.9 version.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3