### PR TITLE
Require avy in `spacemacs-navigation`

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -303,6 +303,7 @@
 (defun spacemacs/ace-buffer-links ()
   "Ace jump to links in `spacemacs' buffer."
   (interactive)
+  (require 'avy)
   (let ((res (avy-with spacemacs/ace-buffer-links
                (avy--process
                 (spacemacs//collect-spacemacs-buffer-links)


### PR DESCRIPTION
When using the `o` keybinding to open links with `ace`, Spacemacs would complain that the `avy-with` symbol's definition was void. This PR fixes that by requiring `avy` explicitly, as it starts to work later on, as then the `avy` package appears to have been loaded.