### PR TITLE
string-inflection: group which-keys, sort code/doc

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2704,14 +2704,14 @@ Text related commands (start with ~x~):
 | ~SPC x g l~   | set languages used by translate commands                      |
 | ~SPC x g t~   | translate current word using Google Translate                 |
 | ~SPC x g T~   | reverse source and target languages                           |
-| ~SPC x i i~   | cycle symbol naming styles (~i~ to keep cycling)              |
-| ~SPC x i u~   | change symbol style to =under_score=                          |
-| ~SPC x i _~   | change symbol style to =under_score=                          |
-| ~SPC x i U~   | change symbol style to =UP_CASE=                              |
-| ~SPC x i k~   | change symbol style to =kebab-case=                           |
-| ~SPC x i -~   | change symbol style to =kebab-case=                           |
 | ~SPC x i c~   | change symbol style to =lowerCamelCase=                       |
 | ~SPC x i C~   | change symbol style to =UpperCamelCase=                       |
+| ~SPC x i i~   | cycle symbol naming styles (~i~ to keep cycling)              |
+| ~SPC x i -~   | change symbol style to =kebab-case=                           |
+| ~SPC x i k~   | change symbol style to =kebab-case=                           |
+| ~SPC x i _~   | change symbol style to =under_score=                          |
+| ~SPC x i u~   | change symbol style to =under_score=                          |
+| ~SPC x i U~   | change symbol style to =UP_CASE=                              |
 | ~SPC x j c~   | set the justification to center                               |
 | ~SPC x j f~   | set the justification to full                                 |
 | ~SPC x j l~   | set the justification to left                                 |

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -413,6 +413,27 @@
           ("\\11..9" . "digit-argument"))
         which-key-replacement-alist)
 
+  ;; SPC x i- inflection
+  ;; rename "k -> string-inflection-kebab-case"
+  ;; to "k,- -> string-inflection-kebab-case"
+  (push '(("\\(.*\\)k" . "string-inflection-kebab-case") .
+          ("\\1k,-" . "string-inflection-kebab-case"))
+        which-key-replacement-alist)
+
+  ;; hide the "- -> string-inflection-kebab-case" entry
+  (push '(("\\(.*\\)-" . "string-inflection-kebab-case") . t)
+        which-key-replacement-alist)
+
+  ;; rename "u -> string-inflection-underscore"
+  ;; to "u,_ -> string-inflection-underscore"
+  (push '(("\\(.*\\)u" . "string-inflection-underscore") .
+          ("\\1u,_" . "string-inflection-underscore"))
+        which-key-replacement-alist)
+
+  ;; hide the "_ -> string-inflection-underscore" entry
+  (push '(("\\(.*\\)_" . "string-inflection-underscore") . t)
+        which-key-replacement-alist)
+
   ;; C-c C-w-
   ;; rename the eyebrowse-switch-to-window-config-0 entry, to 0..9
   (push '(("\\(.*\\)0" . "eyebrowse-switch-to-window-config-0") .

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -363,19 +363,20 @@
     :init
     (progn
       (spacemacs|define-transient-state string-inflection
-        :title "String inflection transient state"
+        :title "String Inflection Transient State"
         :doc "\n [_i_] cycle"
         :bindings
         ("i" string-inflection-all-cycle))
+      (spacemacs/declare-prefix "xi" "inflection")
       (spacemacs/set-leader-keys
-        "xii" 'spacemacs/string-inflection-transient-state/body
-        "xiu" 'string-inflection-underscore
-        "xi_" 'string-inflection-underscore
-        "xiU" 'string-inflection-upcase
-        "xik" 'string-inflection-kebab-case
-        "xi-" 'string-inflection-kebab-case
         "xic" 'string-inflection-lower-camelcase
-        "xiC" 'string-inflection-camelcase))))
+        "xiC" 'string-inflection-camelcase
+        "xii" 'spacemacs/string-inflection-transient-state/body
+        "xi-" 'string-inflection-kebab-case
+        "xik" 'string-inflection-kebab-case
+        "xi_" 'string-inflection-underscore
+        "xiu" 'string-inflection-underscore
+        "xiU" 'string-inflection-upcase))))
 
 (defun spacemacs-editing/init-undo-tree ()
   (use-package undo-tree


### PR DESCRIPTION
Group together the which-key entries that call the same command:
k and - becomes k,-
u and _ becomes u,_

Declare a prefix name for SPC x i, this changes the SPC x entry:
from: "i -> +prefix"
to: "i -> +inflection".

Capitalize the transient state title, so that it matches the other TS titles.

Sort the code and documentation key bindings alphabetically.