### PR TITLE
Fix a missing package name in mu4e documentation

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -75,7 +75,8 @@ that by default shows the unread and total mail counts for all your mail under
 your base mail directory.
 
 This extension is enabled by default, you can deactivate (and uninstall) it by
-adding the package == to your dotfile variable =dotspacemacs-excluded-packages=.
+adding the package =mu4e-maildirs-extension= to your dotfile variable
+=dotspacemacs-excluded-packages=.
 
 ** Multiple Accounts
 This layer includes support for multiple sending accounts.


### PR DESCRIPTION
There was a missing package name in mu4e that messed up the documentation in the **Maildirs extension** subsection.