### PR TITLE
Fix a misspelling ("usefull" in spacemacs-base/config.el)

### DIFF
--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -70,7 +70,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Edit
 ;; ---------------------------------------------------------------------------
 
-;; start scratch in text mode (usefull to get a faster Emacs load time
+;; Start with the *scratch* buffer in text mode (speeds up Emacs load time,
 ;; because it avoids autoloads of elisp modes)
 (setq initial-major-mode 'text-mode)
 


### PR DESCRIPTION
This fixes a misspelling in a comment. I've also rephrased the comment and capitalized the start of it, to match the style in the rest of the file.