### PR TITLE
Fix #8823: evil-paste-pop doesn't work `previous command was not an evil-paste.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2706,8 +2706,10 @@ Text related commands (start with ~x~):
 | ~SPC x g T~   | reverse source and target languages                           |
 | ~SPC x i i~   | cycle symbol naming styles                                    |
 | ~SPC x i u~   | change symbol style to ~under_score~                          |
+| ~SPC x i _~   | change symbol style to ~under_score~                          |
 | ~SPC x i U~   | change symbol style to ~UP_CASE~                              |
 | ~SPC x i k~   | change symbol style to ~kebab-case~                           |
+| ~SPC x i -~   | change symbol style to ~kebab-case~                           |
 | ~SPC x i c~   | change symbol style to ~lowerCamelCase~                       |
 | ~SPC x i C~   | change symbol style to ~UpperCamelCase~                       |
 | ~SPC x j c~   | set the justification to center                               |

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2704,7 +2704,7 @@ Text related commands (start with ~x~):
 | ~SPC x g l~   | set languages used by translate commands                      |
 | ~SPC x g t~   | translate current word using Google Translate                 |
 | ~SPC x g T~   | reverse source and target languages                           |
-| ~SPC x i i~   | cycle symbol naming styles                                    |
+| ~SPC x i i~   | cycle symbol naming styles (~i~ to keep cycling)              |
 | ~SPC x i u~   | change symbol style to ~under_score~                          |
 | ~SPC x i _~   | change symbol style to ~under_score~                          |
 | ~SPC x i U~   | change symbol style to ~UP_CASE~                              |

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2705,13 +2705,13 @@ Text related commands (start with ~x~):
 | ~SPC x g t~   | translate current word using Google Translate                 |
 | ~SPC x g T~   | reverse source and target languages                           |
 | ~SPC x i i~   | cycle symbol naming styles (~i~ to keep cycling)              |
-| ~SPC x i u~   | change symbol style to ~under_score~                          |
-| ~SPC x i _~   | change symbol style to ~under_score~                          |
-| ~SPC x i U~   | change symbol style to ~UP_CASE~                              |
-| ~SPC x i k~   | change symbol style to ~kebab-case~                           |
-| ~SPC x i -~   | change symbol style to ~kebab-case~                           |
-| ~SPC x i c~   | change symbol style to ~lowerCamelCase~                       |
-| ~SPC x i C~   | change symbol style to ~UpperCamelCase~                       |
+| ~SPC x i u~   | change symbol style to =under_score=                          |
+| ~SPC x i _~   | change symbol style to =under_score=                          |
+| ~SPC x i U~   | change symbol style to =UP_CASE=                              |
+| ~SPC x i k~   | change symbol style to =kebab-case=                           |
+| ~SPC x i -~   | change symbol style to =kebab-case=                           |
+| ~SPC x i c~   | change symbol style to =lowerCamelCase=                       |
+| ~SPC x i C~   | change symbol style to =UpperCamelCase=                       |
 | ~SPC x j c~   | set the justification to center                               |
 | ~SPC x j f~   | set the justification to full                                 |
 | ~SPC x j l~   | set the justification to left                                 |

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -323,6 +323,7 @@ Please see the [[https://github.com/Somelauw/evil-org-mode/blob/master/doc/keyth
 | ~M-h~ / ~M-l~ | Promote or demote heading       |
 | ~M-J~ / ~M-K~ | Move subtree                    |
 | ~M-H~ / ~M-L~ | Promote or demote subtree       |
+| ~>>~ / ~<<~   | Promote or demote heading       |
 
 ** Tables
 
@@ -358,44 +359,30 @@ Please see the [[https://github.com/Somelauw/evil-org-mode/blob/master/doc/keyth
 
 ** Trees
 
-| Key Binding | Description                                |
-|-------------+--------------------------------------------|
-| ~TAB~       | org-cycle                                  |
-| ~$~         | org-end-of-line                            |
-| ~^~         | org-beginning-of-line                      |
-| ~<~         | org-metaleft                               |
-| ~>~         | org-metaright                              |
-| ~gh~        | outline-up-heading                         |
-| ~gj~        | org-forward-heading-same-level             |
-| ~gk~        | org-backward-heading-same-level            |
-| ~gl~        | outline-next-visible-heading               |
-| ~H~         | org-beginning-of-line                      |
-| ~L~         | org-end-of-line                            |
-| ~o~         | always-insert-item                         |
-| ~O~         | org-open-above                             |
-| ~t~         | org-todo                                   |
-| ~T~         | org-insert-todo-heading nil                |
-| ~M-h~       | org-metaleft                               |
-| ~M-H~       | org-shiftmetaleft                          |
-| ~M-j~       | org-metadown                               |
-| ~M-J~       | org-shiftmetadown                          |
-| ~M-k~       | org-metaup                                 |
-| ~M-K~       | org-shiftmetaup                            |
-| ~M-l~       | org-metaright                              |
-| ~M-L~       | org-shiftmetaright                         |
-| ~M-o~       | org-insert-heading+org-metaright           |
-| ~M-t~       | org-insert-todo-heading nil+ org-metaright |
-| ~SPC m s a~ | org-archive-subtree                        |
-| ~SPC m s b~ | org-tree-to-indirect-buffer                |
-| ~SPC m s l~ | org-demote-subtree                         |
-| ~SPC m s h~ | org-promote-subtree                        |
-| ~SPC m s k~ | org-move-subtree-up                        |
-| ~SPC m s j~ | org-move-subtree-down                      |
-| ~SPC m s n~ | org-narrow-to-subtree                      |
-| ~SPC m s N~ | widen narrowed subtree                     |
-| ~SPC m s r~ | org-refile                                 |
-| ~SPC m s s~ | show sparse tree                           |
-| ~SPC m s S~ | sort trees                                 |
+| Key Binding   | Description                     |
+|---------------+---------------------------------|
+| ~gj~ / ~gk~   | Next/previous element (heading) |
+| ~gh~ / ~gl~   | Parent/child element (heading)  |
+| ~gH~          | Root heading                    |
+| ~ae~          | Element text object             |
+| ~ar~          | Subtree text object             |
+| ~M-j~ / ~M-k~ | Move heading                    |
+| ~M-h~ / ~M-l~ | Promote or demote heading       |
+| ~M-J~ / ~M-K~ | Move subtree                    |
+| ~M-H~ / ~M-L~ | Promote or demote subtree       |
+| ~>>~ / ~<<~   | Promote or demote heading       |
+| ~TAB~         | org-cycle                       |
+| ~SPC m s a~   | org-archive-subtree             |
+| ~SPC m s b~   | org-tree-to-indirect-buffer     |
+| ~SPC m s l~   | org-demote-subtree              |
+| ~SPC m s h~   | org-promote-subtree             |
+| ~SPC m s k~   | org-move-subtree-up             |
+| ~SPC m s j~   | org-move-subtree-down           |
+| ~SPC m s n~   | org-narrow-to-subtree           |
+| ~SPC m s N~   | widen narrowed subtree          |
+| ~SPC m s r~   | org-refile                      |
+| ~SPC m s s~   | show sparse tree                |
+| ~SPC m s S~   | sort trees                      |
 
 ** Element insertion
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -365,8 +365,10 @@
       (spacemacs/set-leader-keys
         "xii" 'string-inflection-all-cycle
         "xiu" 'string-inflection-underscore
+        "xi_" 'string-inflection-underscore
         "xiU" 'string-inflection-upcase
         "xik" 'string-inflection-kebab-case
+        "xi-" 'string-inflection-kebab-case
         "xic" 'string-inflection-lower-camelcase
         "xiC" 'string-inflection-camelcase))))
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -362,8 +362,13 @@
   (use-package string-inflection
     :init
     (progn
+      (spacemacs|define-transient-state string-inflection
+        :title "String inflection transient state"
+        :doc "\n [_i_] cycle"
+        :bindings
+        ("i" string-inflection-all-cycle))
       (spacemacs/set-leader-keys
-        "xii" 'string-inflection-all-cycle
+        "xii" 'spacemacs/string-inflection-transient-state/body
         "xiu" 'string-inflection-underscore
         "xi_" 'string-inflection-underscore
         "xiU" 'string-inflection-upcase

--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -85,15 +85,17 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
            (eq (evil-mc-get-cursor-count) 1))))
 
 (defun spacemacs/evil-mc-paste-after (&optional count register)
-  "Disable paste transient state if there is more that 1 cursor."
+  "Disable paste transient state if there is more than 1 cursor."
   (interactive "p")
+  (setq this-command 'evil-paste-after)
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-after)
     (evil-paste-after count (or register evil-this-register))))
 
 (defun spacemacs/evil-mc-paste-before (&optional count register)
-  "Disable paste transient state if there is more that 1 cursor."
+  "Disable paste transient state if there is more than 1 cursor."
   (interactive "p")
+  (setq this-command 'evil-paste-before)
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-before)
     (evil-paste-before count (or register evil-this-register))))

--- a/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
+++ b/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
@@ -54,11 +54,13 @@
 
 (defun evil-unimpaired/paste-above ()
   (interactive)
+  (setq this-command 'evil-paste-after)
   (evil-insert-newline-above)
   (evil-paste-after 1))
 
 (defun evil-unimpaired/paste-below ()
   (interactive)
+  (setq this-command 'evil-paste-after)
   (evil-insert-newline-below)
   (evil-paste-after 1))
 

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -303,6 +303,7 @@
 (defun spacemacs/ace-buffer-links ()
   "Ace jump to links in `spacemacs' buffer."
   (interactive)
+  (require 'avy)
   (let ((res (avy-with spacemacs/ace-buffer-links
                (avy--process
                 (spacemacs//collect-spacemacs-buffer-links)

--- a/layers/+tags/cscope/README.org
+++ b/layers/+tags/cscope/README.org
@@ -60,7 +60,7 @@ command =cscope/run-pycscope= for Python projects, bound to ~SPC m g i~.
 
 | Key Binding | Description                                   |
 |-------------+-----------------------------------------------|
-| ~SPC m g =~ | Find assignments to a symbol              |
+| ~SPC m g =~ | Find assignments to a symbol                  |
 | ~SPC m g c~ | find which functions are called by a function |
 | ~SPC m g C~ | find where a function is called               |
 | ~SPC m g d~ | find global definition of a symbol            |

--- a/layers/+themes/theming/README.org
+++ b/layers/+themes/theming/README.org
@@ -107,7 +107,6 @@ the symbol =all= to apply it on all themes.
 - =theming-headings-bold= :: sets the =:weight= attribute to bold on all
      headings
 
-
 * Example
 
 An example of how to set the default font colour to be black in a custom theme leuven:

--- a/layers/+tools/bm/README.org
+++ b/layers/+tools/bm/README.org
@@ -1,0 +1,34 @@
+#+TITLE: bm layer
+
+* Table of Contents                                         :TOC_4_gh:noexport:
+- [[#description][Description]]
+- [[#features][Features]]
+- [[#install][Install]]
+- [[#keybindings][Keybindings]]
+
+* Description
+[[https://github.com/joodland/bm/blob/master/README.md][BM]] provides visible, buffer local, bookmarks and the ability to jump forward and backward to the next bookmark.
+
+* Features
+- Auto remove bookmark after jump to it by =bm-next= or =bm-previous=
+- Cycle through bookmarks in all open buffers in LIFO order
+- Toggle bookmarks. Jump to next/previous bookmark.
+- Setting bookmarks based on a regexp. (Useful when searching logfiles.)
+- Mouse navigation.
+- Annotate bookmarks.
+- Different wrapping modes.
+- Different bookmarks styles, line-only, fringe-only or both.
+- Persistent bookmarks.
+- List bookmarks (in all buffers) in a separate buffer.
+- Cycle through bookmarks in all open buffers.
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =fasd= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Keybindings
+
+| Key Binding | Description        |
+|-------------+--------------------|
+| ~SPC a b~   | bm transient state |

--- a/layers/+tools/bm/packages.el
+++ b/layers/+tools/bm/packages.el
@@ -1,0 +1,57 @@
+;;; packages.el --- bm Layer packages File
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Eugene "JAremko" Yaremenko <w3techplayground@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq bm-packages '(bm))
+
+(defun bm/init-bm ()
+  "initializes bm-emacs and adds a key binding to `SPC f z'"
+  (use-package bm
+    :defer t
+    :commands (bm-buffer-restore)
+    :init (progn
+            ;; Allow cross-buffer 'next'
+            (setq bm-cycle-all-buffers t)
+            ;; save bookmarks
+            (setq-default bm-buffer-persistence t)
+            ;; where to store persistant files
+            (setq bm-repository-file (format "%sbm-repository"
+                                             spacemacs-cache-directory))
+            (spacemacs|define-transient-state bm
+              :title "BM Transient State"
+              :doc "
+ Go to bookmark^^^^       Toggle^^                 Other^^
+ ──────────────^^^^─────  ──────^^───────────────  ─────^^───
+ [_n_/_N_] next/previous  [_t_] bookmark at point  [_q_] quit"
+              :bindings
+              ("q" nil :exit t)
+              ;; Go to bookmark
+              ("n" bm-next)
+              ("N" bm-previous)
+              ;; Toggle
+              ("t" bm-toggle))
+            (evil-leader/set-key
+              "ab" 'spacemacs/bm-transient-state/body)
+            (advice-add 'spacemacs/bm-transient-state/body
+                        :before #'bm-buffer-restore))
+    :config (progn
+              (bm-load-and-restore)
+              ;; Saving bookmarks
+              (add-hook 'kill-buffer-hook #'bm-buffer-save)
+              ;; Saving the repository to file when on exit.
+              ;; kill-buffer-hook is not called when Emacs is killed, so we
+              ;; must save all bookmarks first.
+              (add-hook 'kill-emacs-hook #'(lambda nil
+                                             (bm-buffer-save-all)
+                                             (bm-repository-save)))
+              ;; Restoring bookmarks
+              (add-hook 'find-file-hooks   #'bm-buffer-restore)
+              ;; Make sure bookmarks is saved before check-in (and revert-buffer)
+              (add-hook 'vc-before-checkin-hook #'bm-buffer-save))))


### PR DESCRIPTION
@duianto, @bmag. A simpler fix than was [previously proposed](https://github.com/syl20bnr/spacemacs/pull/9056): Use [command loop info](https://www.gnu.org/software/emacs/manual/html_node/elisp/Command-Loop-Info.html) to ensure `evil-paste-pop` works correctly after evil-mc-paste-{after,before} and evil-unimpaired-paste-{above,below}.