### PR TITLE
Fix issue #8823: evil-paste-pop doesn't work `previous command was not an evil paste.`

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -85,15 +85,17 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
            (eq (evil-mc-get-cursor-count) 1))))
 
 (defun spacemacs/evil-mc-paste-after (&optional count register)
-  "Disable paste transient state if there is more that 1 cursor."
+  "Disable paste transient state if there is more than 1 cursor."
   (interactive "p")
+  (setq this-command 'evil-paste-after)
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-after)
     (evil-paste-after count (or register evil-this-register))))
 
 (defun spacemacs/evil-mc-paste-before (&optional count register)
-  "Disable paste transient state if there is more that 1 cursor."
+  "Disable paste transient state if there is more than 1 cursor."
   (interactive "p")
+  (setq this-command 'evil-paste-before)
   (if (spacemacs//paste-transient-state-p)
       (spacemacs/paste-transient-state/evil-paste-before)
     (evil-paste-before count (or register evil-this-register))))

--- a/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
+++ b/layers/+spacemacs/spacemacs-evil/local/evil-unimpaired/evil-unimpaired.el
@@ -54,11 +54,13 @@
 
 (defun evil-unimpaired/paste-above ()
   (interactive)
+  (setq this-command 'evil-paste-after)
   (evil-insert-newline-above)
   (evil-paste-after 1))
 
 (defun evil-unimpaired/paste-below ()
   (interactive)
+  (setq this-command 'evil-paste-after)
   (evil-insert-newline-below)
   (evil-paste-after 1))
 


### PR DESCRIPTION
@duianto, @bmag. A simpler fix than was [previously proposed](https://github.com/syl20bnr/spacemacs/pull/9056): Use `this-command` (ref. [emacs: command loop info](https://www.gnu.org/software/emacs/manual/html_node/elisp/Command-Loop-Info.html)) to ensure `evil-paste-pop` works correctly after `spacemacs/evil-mc-paste-{after,before}` and `evil-unimpaired/paste-{above,below}`.