### PR TITLE
Remap org-attach to ,A

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -24,6 +24,7 @@ This file containes the change log for the next major version of Spacemacs.
   README.org file of the =auto-completion= layer, also you can read
   [[https://github.com/syl20bnr/spacemacs/commit/74fdbb6][commit message of commit 74fdbb6]].
 - The function =add-flycheck-hook= has been renamed to =enable-flycheck=.
+- Remap =org-attach= from ~SPC m i a~ to ~SPC m A~.
 *** Hot new feature
 - Improve themes support. Support are now handled like regular packages. The
   list of themes now supports =:location= keyword like in layer list. More
@@ -93,6 +94,7 @@ This file containes the change log for the next major version of Spacemacs.
 - Move clock related key bindings to ~SPC a o k~
 - Add key bindings ~SPC a o k i~ to clock in last and ~SPC a o k j~
   to jump to current clock (thanks to darkfeline)
+- Remap =org-attach= from ~SPC m i a~ to ~SPC m A~.
 **** Scala
 - Move =ensime= to the =java= layer (Tor Hedin Bronner)
 **** Syntax-checking

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -285,6 +285,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC m -~                                    | org-ctrl-c-minus                             |
 | ~SPC m '​~                                    | org-edit-special                             |
 | ~SPC m a~                                    | org-agenda                                   |
+| ~SPC m A~                                    | org-attach                                   |
 | ~SPC m c~                                    | org-capture                                  |
 | ~SPC m C c~                                  | org-clock-cancel                             |
 | ~SPC m C g~                                  | evil-org-recompute-clocks                    |
@@ -388,7 +389,6 @@ Please see the [[https://github.com/Somelauw/evil-org-mode/blob/master/doc/keyth
 
 | Key Binding   | Description                      |
 |---------------+----------------------------------|
-| ~SPC m i a~   | org-attach                       |
 | ~SPC m i d~   | org-insert-drawer                |
 | ~SPC m i D s~ | Take screenshot                  |
 | ~SPC m i D y~ | Yank image url                   |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -246,8 +246,9 @@ Will work on both org-mode and any mode that accepts plain html."
         "RET" 'org-ctrl-c-ret
         "-" 'org-ctrl-c-minus
         "#" 'org-update-statistics-cookies
+        ;; attachments
+        "A" 'org-attach
         ;; insertion
-        "ia" 'org-attach
         "id" 'org-insert-drawer
         "ie" 'org-set-effort
         "if" 'org-footnote-new


### PR DESCRIPTION
It was mapped to ,ia but it's used for more than inserting attachments.

Fixes #9050