### PR TITLE
Add deferred theme changer activation function.

### DIFF
--- a/layers/+tools/geolocation/packages.el
+++ b/layers/+tools/geolocation/packages.el
@@ -105,11 +105,18 @@ to not have to set these variables manually when enabling this layer."
   "Initialize theme-changer"
   (use-package theme-changer
     :if geolocation-enable-automatic-theme-changer
-    :config
+    :init
     (progn
-      (when (> (length dotspacemacs-themes) 1)
-        (change-theme (nth 0 dotspacemacs-themes)
-                      (nth 1 dotspacemacs-themes))))))
+      (defun geolocation//activate-theme-changer ()
+        (when (> (length dotspacemacs-themes) 1)
+          (change-theme (nth 0 dotspacemacs-themes)
+                        (nth 1 dotspacemacs-themes)))
+        )
+      (spacemacs/defer-until-after-user-config #'geolocation//activate-theme-changer)
+      )
+    )
+  )
+
 
 (defun geolocation/post-init-popwin ()
   ;; Pin the weather forecast to the bottom window


### PR DESCRIPTION
Per @TheBB’s suggestion, adds a function to set up the theme changer, and uses `spacemacs/defer-until-after-user-config` to ensure it’s not called until `dotspacemacs-themes` is defined. 

Fixes #7563. Replaces proposed workaround in #8212.
