### PR TITLE
Update markdown insert link, function renamed

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -103,7 +103,7 @@ To generate a table of contents type on top of the buffer:
 | ~SPC m h 6~ | insert header atx 6                                               |
 | ~SPC m h !~ | insert header setext 1                                            |
 | ~SPC m h @~ | insert header setext 2                                            |
-| ~SPC m i l~ | insert link                                                       |
+| ~SPC m i l~ | insert inline link dwim                                           |
 | ~SPC m i L~ | insert reference link dwim                                        |
 | ~SPC m i u~ | insert uri                                                        |
 | ~SPC m i f~ | insert footnote                                                   |

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -114,7 +114,7 @@
           "ii"  'markdown-insert-image
           "ik"  'spacemacs/insert-keybinding-markdown
           "iI"  'markdown-insert-reference-image
-          "il"  'markdown-insert-link
+          "il"  'markdown-insert-inline-link-dwim
           "iL"  'markdown-insert-reference-link-dwim
           "iw"  'markdown-insert-wiki-link
           "iu"  'markdown-insert-uri


### PR DESCRIPTION
Problem:
The insert link key binding `, i l` shows:
Wrong type argument: commandp, markdown-insert-link

Cause:
The markdown-mode package has renamed the `markdown-insert-link` function to:
`markdown-insert-inline-link-dwim`.

Solution:
Rename the key bindings function name.
Rename documentation to match the function name.

The function was renamed in this commit:
DWIM link insertion and tests
https://github.com/jrblevin/markdown-mode/commit/9cd825df3d9eed911e3c6aa1e019f7dd36358d63