### PR TITLE
Makes all markdown keybindings available in gfm-mode

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -23,12 +23,16 @@
     ))
 
 (defun markdown/post-init-company ()
-  (spacemacs|add-company-backends :backends company-capf :modes markdown-mode))
+  (dolist (mode markdown--key-bindings-modes)
+    (spacemacs|add-company-backends
+      :backends company-capf
+      :modes mode)))
 
 (defun markdown/post-init-company-emoji ()
-  (spacemacs|add-company-backends
-    :backends company-emoji
-    :modes markdown-mode))
+  (dolist (mode markdown--key-bindings-modes)
+    (spacemacs|add-company-backends
+      :backends company-emoji
+      :modes mode)))
 
 (defun markdown/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'markdown-mode-hook 'emoji-cheat-sheet-plus-display-mode))
@@ -37,8 +41,9 @@
   (use-package gh-md
     :defer t
     :init
-    (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-      "cr"  'gh-md-render-buffer)))
+    (dolist (mode markdown--key-bindings-modes)
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "cr" 'gh-md-render-buffer))))
 
 (defun markdown/post-init-smartparens ()
   (add-hook 'markdown-mode-hook 'smartparens-mode))
@@ -55,7 +60,8 @@
                                :submode submode
                                :front front
                                :back back)))
-    (mmm-add-mode-ext-class 'markdown-mode nil class)))
+    (dolist (mode markdown--key-bindings-modes)
+      (mmm-add-mode-ext-class mode nil class))))
 
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
@@ -73,10 +79,9 @@
                         ("mi" . "markdown/insert")
                         ("ml" . "markdown/lists")
                         ("mx" . "markdown/text")))
-        (spacemacs/declare-prefix-for-mode
-         'markdown-mode (car prefix) (cdr prefix)))
-      ;; note: `gfm-mode' is part of `markdown-mode.el' so we can define its key
-      ;; bindings here
+        (dolist (mode markdown--key-bindings-modes)
+          (spacemacs/declare-prefix-for-mode
+            mode (car prefix) (cdr prefix))))
       (dolist (mode markdown--key-bindings-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
           ;; Movement
@@ -140,10 +145,10 @@
           "N"   'markdown-next-link
           "f"   'markdown-follow-thing-at-point
           "P"   'markdown-previous-link
-          "<RET>" 'markdown-jump))
-      (when (eq 'eww markdown-live-preview-engine)
-        (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-          "cP"  'markdown-live-preview-mode))
+          "<RET>" 'markdown-jump)
+        (when (eq 'eww markdown-live-preview-engine)
+          (spacemacs/set-leader-keys-for-major-mode mode
+            "cP" 'markdown-live-preview-mode)))
       ;; Header navigation in normal state movements
       (evil-define-key 'normal markdown-mode-map
         "gj" 'outline-forward-same-level
@@ -160,8 +165,10 @@
 (defun markdown/init-markdown-toc ()
   (use-package markdown-toc
     :defer t
-    :init (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-            "it"  'markdown-toc-generate-toc)))
+    :init
+    (dolist (mode markdown--key-bindings-modes)
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "it" 'markdown-toc-generate-toc))))
 
 (defun markdown/init-mmm-mode ()
   (use-package mmm-mode
@@ -173,5 +180,7 @@
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode
     :defer t
-    :init (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-            "cP" 'vmd-mode)))
+    :init
+    (dolist (mode markdown--key-bindings-modes)
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "cP" 'vmd-mode))))


### PR DESCRIPTION
Continuing on #8356, this PR makes all `markdown-mode` keybindings available for `gfm-mode`.

The only problem I encountered was a message with the following text:
```
Not enabling jit-lock: it does not work in indirect buffer [2 times]
```

This is related to:
```diff
-    (mmm-add-mode-ext-class 'markdown-mode nil class)))
+    (dolist (mode markdown--key-bindings-modes)
+      (mmm-add-mode-ext-class mode nil class))))
```

Not sure how to solve this yet...

I would also like to make the preffered markdown mode (either `markdown-mode` or `gfm-mode`) configurable, either from a layer `:variable` or from a `setq` inside the `user-config` but failed so far, any hints on how to do that?

