### PR TITLE
ESS disable underscore assignment, create layer variable. (attempt 2)

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -52,16 +52,16 @@ Helpers for inspecting objects at point are available in R buffers only.
 
 * Options
 
-To turn off the automatic replacement of underscores by =<-=,
+To disable the default ESS behavior of 
+replacing underscores by =<-=,
 set in your =~/.spacemacs=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-disable-underscore-assign t)))
+                                                         ess-enable-underscore-assign nil)))
 #+END_SRC
 
-Alternatively you may enable =ess-smart-equals=, which also disables
-replacement of underscores by =<-=, and additionally replace the equals sign with
+Alternatively you may enable =ess-smart-equals=, which instead replaces the equals sign with
 =<-= when appropriate:
 
 #+BEGIN_SRC emacs-lisp

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -51,19 +51,20 @@ Helpers for inspecting objects at point are available in R buffers only.
 | ~SPC m h t~ | view table using [ess-R-data-view][ess-R-data-view]                 |
 
 * Options
-=ess-smart-equals= is disabled by default. In order to enable it, set in your
-=~/.spacemacs=
+
+To turn off the automatic replacement of underscores by =<-=,
+set in your =~/.spacemacs=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((ess :variables
+                                                         ess-disable-underscore-assign t)))
+#+END_SRC
+
+Alternatively you may enable =ess-smart-equals=, which also disables
+replacement of underscores by =<-=, and additionally replace the equals sign with
+=<-= when appropriate:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '((ess :variables
                                                          ess-enable-smart-equals t)))
 #+END_SRC
-
-To turn off the automatic replacement of underscores by =<-=, add the following
-hook:
-
-#+begin_src emacs-lisp
-  (add-hook 'ess-mode-hook
-            (lambda ()
-              (ess-toggle-underscore nil)))
-#+end_src

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -52,13 +52,13 @@ Helpers for inspecting objects at point are available in R buffers only.
 
 * Options
 
-To disable the default ESS behavior of 
-replacing underscores by =<-=,
+The ESS behavior of replacing underscores by =<-= is disabled
+by default. To reenable this behavior,
 set in your =~/.spacemacs=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-enable-underscore-assign nil)))
+                                                         ess-enable-underscore-assign t)))
 #+END_SRC
 
 Alternatively you may enable =ess-smart-equals=, which instead replaces the equals sign with

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -14,5 +14,5 @@
 (defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")
 
-(defvar ess-enable-underscore-assign t
+(defvar ess-enable-underscore-assign nil
   "If non-nil, disables underscore _ being a shortcut for assignment <-")

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -14,5 +14,5 @@
 (defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")
 
-(defvar ess-disable-underscore-assign nil
+(defvar ess-enable-underscore-assign t
   "If non-nil, disables underscore _ being a shortcut for assignment <-")

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -13,3 +13,6 @@
 
 (defvar ess-enable-smart-equals nil
   "If non-nil smart-equal support is enabled")
+
+(defvar ess-disable-underscore-assign nil
+  "If non-nil, disables underscore _ being a shortcut for assignment <-")

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -71,7 +71,7 @@
           ess-expression-offset 2
           ess-nuke-trailing-whitespace-p t
           ess-default-style 'DEFAULT)
-    (if ess-disable-underscore-assign
+    (unless ess-enable-underscore-assign
       (ess-toggle-underscore nil))
 
     (spacemacs/set-leader-keys-for-major-mode 'ess-julia-mode

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -71,6 +71,8 @@
           ess-expression-offset 2
           ess-nuke-trailing-whitespace-p t
           ess-default-style 'DEFAULT)
+    (if ess-disable-underscore-assign
+      (ess-toggle-underscore nil))
 
     (spacemacs/set-leader-keys-for-major-mode 'ess-julia-mode
       "'"  'julia


### PR DESCRIPTION
This PR disables the default ESS behavior of replacing the underscore symbol `_` with the assignment operator `<-` in R code. It also adds the layer variable `ess-enable-underscore-assign`  to reenable the behavior, and edits the Readme to remove obsolete instructions on how to achieve this effect with a manual hook in `dotspacemacs/user-config`.

The default ESS behavior is a relic of earlier R style that rarely used underscore. In modern R style the underscore is ubiquitous and the default ESS behavior gets in the way. In my experience, disabling this ESS behavior is the first customization for most R users.

I raised an issue to solicit discussion in https://github.com/syl20bnr/spacemacs/issues/8841. Related discussion in https://github.com/syl20bnr/spacemacs/issues/3222 (which added the Readme hook instructions).