### PR TITLE
Workspaces transient state: create workspace keys

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -34,6 +34,7 @@
  [_0_.._9_]^^     nth/new workspace  [_d_] close current workspace
  [_C-0_.._C-9_]^^ nth/new workspace  [_R_] rename current workspace
  [_<tab>_]^^^^    last workspace     [_?_] toggle help\n
+ [_c_/_C_]^^      create workspace
  [_l_]^^^^        layouts
  [_n_/_C-l_]^^    next workspace
  [_N_/_p_/_C-h_]  prev workspace\n
@@ -69,6 +70,8 @@
         ("<return>" nil :exit t)
         ("TAB" eyebrowse-last-window-config)
         ("RET" nil :exit t)
+        ("c" eyebrowse-create-window-config :exit t)
+        ("C" eyebrowse-create-window-config)
         ("C-h" eyebrowse-prev-window-config)
         ("C-l" eyebrowse-next-window-config)
         ("d" eyebrowse-close-window-config)


### PR DESCRIPTION
Problem:
Creating a new workspace from the workspaces transient state, requires that one
first looks for the next available workspace number, and then presses that
number key.

Solution:
Add the keys: `c` and `C` to create a new workspace. Lowercase exits the state
and uppercase keeps it open.

Notes:
This matches the behaviour of 0..9, which exits the state, and C-0..C-9, which
keeps it open.

This is the last key/command, from the C-c C-w eyebrowse key bindings, that was
missing from the workspaces transient state.