### PR TITLE
Replace usage of `ensime-print-type-at-point` by `ensime-type-at-point`

### DIFF
--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -93,7 +93,7 @@
   (setq-local eldoc-documentation-function
               (lambda ()
                 (when (ensime-connected-p)
-                  (ensime-print-type-at-point))))
+                  (ensime-type-at-point))))
   (eldoc-mode))
 
 (defun spacemacs//ensime-maybe-start ()

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -77,7 +77,7 @@ To enable =java-doc-style=, set the variable =scala-indent:use-javadoc-style= to
 #+END_SRC
 
 * Automatically show the type of the symbol under the cursor
-To enable the feature =ensime-print-type-at-point= when cursor moves, set the
+To enable the feature =ensime-type-at-point= when cursor moves, set the
 variable =scala-enable-eldoc= to =t=.
 
 #+BEGIN_SRC emacs-lisp


### PR DESCRIPTION
This PR replaces the usage of `ensime-print-type-at-point` by `ensime-type-at-point` as the method name was recently changed in `ensime-emacs` (see ensime/ensime-emacs@8c7f659a170a2af248f912e56ec8ac25453fc867).