### PR TITLE
Customization which allows pupo to split the active window or the entire frame

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -6,6 +6,12 @@
 
 (require 'window-purpose)
 
+(defcustom pupo-split-active-window nil
+  "Non-nil if Pupo splits the active window.
+Nil if Pupo splits the entire frame."
+  :type '(boolean)
+  :group 'pupo)
+
 (defconst pupo--direction-to-purpose '((left . popl)
                                        (right . popr)
                                        (top . popt)
@@ -46,8 +52,9 @@ width or height depending on POSITION."
                  ('top 'above)
                  ('bottom 'below))))
     (lambda (buffer alist)
-      (let ((window (ignore-errors
-                      (split-window (frame-root-window) size side))))
+      (let* ((main-window (if pupo-split-active-window (selected-window)
+                            (frame-root-window)))
+             (window (ignore-errors (split-window main-window size side))))
         (when window
           (purpose-change-buffer buffer window 'window alist))))))
 


### PR DESCRIPTION
Hi,

I add a customization to the `pupo` mode, which allows Spacemacs to split the popup-window either inside the active window or inside the entire frame.

This patch addresses an issue in [Stackoverflow ](https://emacs.stackexchange.com/questions/27711/how-to-make-pop-up-window-appear-in-the-divided-portion-of-the-frame) and also the issue https://github.com/syl20bnr/spacemacs/issues/9016 of Spacemacs.

In the patch, the variable `pupo-split-active-window` is set by default to `nil`, which doesn't change the default behavior of `pupo`.

If this variable is set to `t`, then `pupo` will split only the active window.

Please advise if the fix is useful?

Thanks!

