### PR TITLE
Fix disabled scrollbar remains

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -158,13 +158,13 @@ the final step of executing code in `emacs-startup-hook'.")
 (defun spacemacs//removes-gui-elements ()
   "Remove the menu bar, tool bar and scroll bars."
   ;; removes the GUI elements
+  (when (and (fboundp 'scroll-bar-mode) (not (eq scroll-bar-mode -1)))
+    (scroll-bar-mode -1))
   (when (and (fboundp 'tool-bar-mode) (not (eq tool-bar-mode -1)))
     (tool-bar-mode -1))
   (unless (spacemacs/window-system-is-mac)
     (when (and (fboundp 'menu-bar-mode) (not (eq menu-bar-mode -1)))
       (menu-bar-mode -1)))
-  (when (and (fboundp 'scroll-bar-mode) (not (eq scroll-bar-mode -1)))
-    (scroll-bar-mode -1))
   ;; tooltips in echo-aera
   (when (and (fboundp 'tooltip-mode) (not (eq tooltip-mode -1)))
     (tooltip-mode -1)))


### PR DESCRIPTION
When starting a new emacs instance, there is this ugly bar on the right side(spotted by @greenbigfrog):

![Ugly scrollbar remains](http://i.imgur.com/UcGgyZt.png)

Although it disappears on resizing the emacs frame, it's still an annoying visual bug.

Luckily it can be easily fixed by disabling scrollbar before any other UI elements.