### PR TITLE
Clojure: eval -> pretty-print

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -147,6 +147,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e m~ | cider macroexpand 1                             |
 | ~SPC m e M~ | cider macroexpand all                           |
 | ~SPC m e p~ | print last sexp (clojure interaction mode only) |
+| ~SPC m e P~ | eval last sexp and pretty print result in separate buffer |
 | ~SPC m e w~ | eval last sexp and replace with result          |
 
 *** Goto

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -137,18 +137,18 @@ As this state works the same for all files, the documentation is in global
 
 *** Evaluation
 
-| Key Binding | Description                                     |
-|-------------+-------------------------------------------------|
-| ~SPC m e ;~ | eval sexp and show result as comment            |
-| ~SPC m e b~ | eval buffer                                     |
-| ~SPC m e e~ | eval last sexp                                  |
-| ~SPC m e f~ | eval function at point                          |
-| ~SPC m e r~ | eval region                                     |
-| ~SPC m e m~ | cider macroexpand 1                             |
-| ~SPC m e M~ | cider macroexpand all                           |
-| ~SPC m e p~ | print last sexp (clojure interaction mode only) |
+| Key Binding | Description                                               |
+|-------------+-----------------------------------------------------------|
+| ~SPC m e ;~ | eval sexp and show result as comment                      |
+| ~SPC m e b~ | eval buffer                                               |
+| ~SPC m e e~ | eval last sexp                                            |
+| ~SPC m e f~ | eval function at point                                    |
+| ~SPC m e r~ | eval region                                               |
+| ~SPC m e m~ | cider macroexpand 1                                       |
+| ~SPC m e M~ | cider macroexpand all                                     |
+| ~SPC m e p~ | print last sexp (clojure interaction mode only)           |
 | ~SPC m e P~ | eval last sexp and pretty print result in separate buffer |
-| ~SPC m e w~ | eval last sexp and replace with result          |
+| ~SPC m e w~ | eval last sexp and replace with result                    |
 
 *** Goto
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -72,6 +72,7 @@
             "em" 'cider-macroexpand-1
             "eM" 'cider-macroexpand-all
             "er" 'cider-eval-region
+            "eP" 'cider-pprint-eval-last-sexp
             "ew" 'cider-eval-last-sexp-and-replace
 
             "="  'cider-format-buffer


### PR DESCRIPTION
I find this behavior useful. Displays the result of evaluation in a separate buffer, pretty-printed according to Clojure rules.