### PR TITLE
core: implement :depends for package declarations

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -791,7 +791,7 @@ error recovery."
   "Test settings in dotfile for correctness.
  Return non-nil if all the tests passed."
   (interactive)
-  (configuration-layer/discover-layers)
+  (configuration-layer/discover-layers 'refresh-index)
   (let ((min-version "0.0"))
     ;; dotspacemacs-version not implemented yet
     ;; (if (version< dotspacemacs-version min-version)
@@ -815,10 +815,10 @@ error recovery."
           (prog1
               ;; execute all tests no matter what
               (cl-reduce (lambda (x y)
-                        (and (funcall y) x))
-                      '(dotspacemacs//test-dotspacemacs/layers
-                        dotspacemacs//test-dotspacemacs/init)
-                      :initial-value t)
+                           (and (funcall y) x))
+                         '(dotspacemacs//test-dotspacemacs/layers
+                           dotspacemacs//test-dotspacemacs/init)
+                         :initial-value t)
             (goto-char (point-min))))))))
 
 (provide 'core-dotspacemacs)

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -5,7 +5,7 @@
     emoji-cheat-sheet-plus
     flyspell
     (helm-rcirc :location local
-                :toggle (configuration-layer/package-usedp 'helm))
+                :depends helm)
     persp-mode
     rcirc
     rcirc-color

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -17,8 +17,8 @@
         (company-quickhelp :toggle auto-completion-enable-help-tooltip)
         company-statistics
         fuzzy
-        (helm-company :toggle (configuration-layer/package-usedp 'helm))
-        (helm-c-yasnippet :toggle (configuration-layer/package-usedp 'helm))
+        (helm-company :depends helm)
+        (helm-c-yasnippet :depends helm)
         hippie-exp
         yasnippet
         auto-yasnippet

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -14,7 +14,7 @@
         auto-highlight-symbol
         bookmark
         counsel
-        (counsel-projectile :toggle (configuration-layer/package-usedp 'projectile))
+        (counsel-projectile :depends projectile)
         evil
         flx
         helm-make

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -30,7 +30,7 @@
         (org-mime :location built-in)
         org-pomodoro
         org-present
-        (org-projectile :toggle (configuration-layer/package-usedp 'projectile))
+        (org-projectile :depends projectile)
         (ox-twbs :toggle org-enable-bootstrap-support)
         ;; use a for of ox-gfm to fix index generation
         (ox-gfm :location (recipe :fetcher github :repo "syl20bnr/ox-gfm")

--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -13,7 +13,7 @@
       '(
         emoji-cheat-sheet-plus
         emojify
-        (company-emoji :toggle (configuration-layer/package-usedp 'company))
+        (company-emoji :depends company)
         ))
 
 (defun emoji/init-emoji-cheat-sheet-plus ()

--- a/layers/+fun/games/packages.el
+++ b/layers/+fun/games/packages.el
@@ -13,7 +13,7 @@
       '(
         2048-game
         (helm-games :location local
-                    :toggle (configuration-layer/package-usedp 'helm))
+                    :depends helm)
         pacmacs
         (tetris :location built-in)
         sudoku

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -16,7 +16,7 @@
     clang-format
     cmake-mode
     company
-    (company-c-headers :toggle (configuration-layer/package-usedp 'company))
+    (company-c-headers :depends company)
     company-ycmd
     flycheck
     gdb-mi

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -11,14 +11,15 @@
 
 (setq common-lisp-packages
       '(auto-highlight-symbol
-        (common-lisp-snippets :toggle (configuration-layer/package-usedp 'yasnippet))
+        (common-lisp-snippets :depends yasnippet)
         evil
         ggtags
         helm
         helm-gtags
         parinfer
         slime
-        (slime-company :toggle (configuration-layer/package-usedp 'company))))
+        (slime-company :depends company)
+        ))
 
 (defun common-lisp/post-init-auto-highlight-symbol ()
   (with-eval-after-load 'auto-highlight-symbol

--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -11,7 +11,7 @@
 
 (setq coq-packages
       '(
-        (company-coq :toggle (configuration-layer/package-usedp 'company))
+        (company-coq :depends company)
         (proof-general :location (recipe
                                   :fetcher github
                                   :repo "ProofGeneral/PG"

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -14,10 +14,10 @@
 (setq d-packages
       '(
         company
-        (company-dcd :toggle (configuration-layer/package-usedp 'company))
+        (company-dcd :depends company)
         d-mode
         flycheck
-        (flycheck-dmd-dub :toggle (configuration-layer/package-usedp 'flycheck))
+        (flycheck-dmd-dub :depends flycheck)
         ggtags
         helm-gtags
         ))

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -14,7 +14,7 @@
       company
       elm-mode
       flycheck
-      (flycheck-elm :toggle (configuration-layer/package-usedp 'flycheck))
+      (flycheck-elm :depends flycheck)
       popwin
       smartparens
       ))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -11,7 +11,7 @@
 
 (setq go-packages
       '(
-        (company-go :toggle (configuration-layer/package-usedp 'company))
+        (company-go :depends company)
         flycheck
         (flycheck-gometalinter :toggle (and go-use-gometalinter
                                             (configuration-layer/package-usedp

--- a/layers/+lang/gpu/packages.el
+++ b/layers/+lang/gpu/packages.el
@@ -13,8 +13,8 @@
         (company-glsl :location (recipe
                                  :fetcher github
                                  :repo "Kaali/company-glsl")
-                      :toggle (and (configuration-layer/package-usedp 'company)
-                                   (executable-find "glslangValidator")))
+                      :depends company
+                      :toggle (executable-find "glslangValidator"))
         cuda-mode
         glsl-mode
         opencl-mode

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -12,17 +12,17 @@
 (setq haskell-packages
   '(
     cmm-mode
-    (company-cabal :toggle (configuration-layer/package-usedp 'company))
+    (company-cabal :depends company)
     company-ghci
     company-ghc
     flycheck
-    (flycheck-haskell :toggle (configuration-layer/package-usedp 'flycheck))
+    (flycheck-haskell :depends flycheck)
     ggtags
     ghc
     haskell-mode
     haskell-snippets
     helm-gtags
-    (helm-hoogle :toggle (configuration-layer/package-usedp 'helm))
+    (helm-hoogle :depends helm)
     hindent
     hlint-refactor
     intero

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -13,13 +13,13 @@
       '(
         add-node-modules-path
         company
-        (company-web :toggle (configuration-layer/package-usedp 'company))
+        (company-web :depends company)
         css-mode
         emmet-mode
         evil-matchit
         flycheck
         haml-mode
-        (helm-css-scss :toggle (configuration-layer/package-usedp 'helm))
+        (helm-css-scss :depends helm)
         impatient-mode
         less-css-mode
         pug-mode

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -19,7 +19,7 @@
         ensime
         flycheck
         (flycheck-eclim :location local
-                        :toggle (configuration-layer/package-usedp 'flycheck))
+                        :depends flycheck)
         flyspell
         ggtags
         gradle-mode

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -14,7 +14,7 @@
         add-node-modules-path
         coffee-mode
         company
-        (company-tern :toggle (configuration-layer/package-usedp 'company))
+        (company-tern :depends company)
         evil-matchit
         flycheck
         ggtags

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -13,7 +13,7 @@
       '(
         auctex
         (auctex-latexmk :toggle (string= "LatexMk" latex-build-command))
-        (company-auctex :toggle (configuration-layer/package-usedp 'company))
+        (company-auctex :depends company)
         evil-matchit
         (reftex :location built-in)
         flycheck

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -12,7 +12,7 @@
 (setq lua-packages
       '(
         company
-        (company-lua :toggle (configuration-layer/package-usedp 'company))
+        (company-lua :depends company)
         flycheck
         ggtags
         helm-gtags

--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -13,7 +13,7 @@
         stan-mode
         thrift
         vala-mode
-        (vala-snippets :toggle (configuration-layer/package-usedp 'yasnippet))
+        (vala-snippets :depends yasnippet)
         wolfram-mode
         ))
 

--- a/layers/+lang/perl6/packages.el
+++ b/layers/+lang/perl6/packages.el
@@ -13,7 +13,7 @@
   '(company
     evil
     flycheck
-    (flycheck-perl6 :toggle (configuration-layer/package-usedp 'flycheck))
+    (flycheck-perl6 :depends flycheck)
     perl6-mode
     ))
 

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -21,7 +21,7 @@
         php-mode
         phpcbf
         phpunit
-        (company-php :toggle (configuration-layer/package-usedp 'company))
+        (company-php :depends company)
         ))
 
 (defun php/init-drupal-mode ()

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -13,7 +13,7 @@
   '(
     anaconda-mode
     company
-    (company-anaconda :toggle (configuration-layer/package-usedp 'company))
+    (company-anaconda :depends company)
     cython-mode
     eldoc
     evil-matchit
@@ -21,7 +21,7 @@
     ggtags
     helm-cscope
     helm-gtags
-    (helm-pydoc :toggle (configuration-layer/package-usedp 'helm))
+    (helm-pydoc :depends helm)
     hy-mode
     live-py-mode
     (nose :location local)

--- a/layers/+lang/restructuredtext/packages.el
+++ b/layers/+lang/restructuredtext/packages.el
@@ -12,7 +12,7 @@
 (defconst restructuredtext-packages
   '(
     auto-complete
-    (auto-complete-rst :toggle (configuration-layer/package-usedp 'auto-complete))
+    (auto-complete-rst :depends auto-complete)
     linum
     (rst :location built-in)
     (rst-directives :location local)

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -15,7 +15,7 @@
     company
     racer
     flycheck
-    (flycheck-rust :toggle (configuration-layer/package-usedp 'flycheck))
+    (flycheck-rust :depends flycheck)
     ggtags
     exec-path-from-shell
     helm-gtags

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -11,7 +11,7 @@
 
 (setq shell-scripts-packages
       '(
-        (company-shell :toggle (configuration-layer/package-usedp 'company))
+        (company-shell :depends company)
         fish-mode
         flycheck
         flycheck-bashate

--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -4,7 +4,7 @@
         flycheck
         (company-nixos-options :toggle
                                (configuration-layer/package-usedp 'company))
-        (helm-nixos-options :toggle (configuration-layer/package-usedp 'helm))
+        (helm-nixos-options :depends helm)
         nix-mode
         nixos-options
         ))

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -20,12 +20,12 @@
         git-link
         git-messenger
         git-timemachine
-        (helm-gitignore :toggle (configuration-layer/package-usedp 'helm))
+        (helm-gitignore :depends helm)
         magit
         magit-gitflow
         ;; not compatible with magit 2.1 at the time of release
         ;; magit-svn
-        (orgit :toggle (configuration-layer/package-usedp 'org))
+        (orgit :depends org)
         smeargle
         ))
 

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -16,7 +16,7 @@
         popwin
         (spacemacs-purpose-popwin
          :location local
-         :toggle (configuration-layer/package-usedp 'popwin))
+         :depends popwin)
         window-purpose))
 
 (defun spacemacs-purpose/pre-init-eyebrowse ()

--- a/layers/+tags/cscope/packages.el
+++ b/layers/+tags/cscope/packages.el
@@ -11,7 +11,7 @@
 
 (setq cscope-packages
       '(
-        (helm-cscope :toggle (configuration-layer/package-usedp 'helm))
+        (helm-cscope :depends helm)
         xcscope
         ))
 

--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -13,7 +13,7 @@
 (defconst gtags-packages
   '(
     ggtags
-    (helm-gtags :toggle (configuration-layer/package-usedp 'helm))
+    (helm-gtags :depends helm)
     ))
 
 (defun gtags/init-ggtags ()

--- a/layers/+tools/ansible/packages.el
+++ b/layers/+tools/ansible/packages.el
@@ -12,7 +12,7 @@
       '(ansible
         ansible-doc
         company
-        (company-ansible :toggle (configuration-layer/package-usedp 'company))
+        (company-ansible :depends company)
         jinja2-mode
         yaml-mode))
 

--- a/layers/+tools/dash/packages.el
+++ b/layers/+tools/dash/packages.el
@@ -2,8 +2,8 @@
 (setq dash-packages
       '(
         (dash-at-point :toggle (spacemacs/system-is-mac))
-        (helm-dash :toggle (configuration-layer/package-usedp 'helm))
-        (counsel-dash :toggle (configuration-layer/package-usedp 'ivy))
+        (helm-dash :depends helm)
+        (counsel-dash :depends ivy)
         (zeal-at-point :toggle (or (spacemacs/system-is-linux)
                                    (spacemacs/system-is-mswindows)))))
 

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -12,7 +12,7 @@
 (setq finance-packages
   '(
     company
-    (flycheck-ledger :toggle (configuration-layer/package-usedp 'flycheck))
+    (flycheck-ledger :depends flycheck)
     ledger-mode
     ))
 

--- a/layers/+tools/restclient/packages.el
+++ b/layers/+tools/restclient/packages.el
@@ -10,12 +10,12 @@
 ;;; License: GPLv3
 (setq restclient-packages
       '(
-        (company-restclient :toggle (configuration-layer/package-usedp 'company))
+        (company-restclient :depends company)
         golden-ratio
         ob-http
         ob-restclient
         restclient
-        (restclient-helm :toggle (configuration-layer/package-usedp 'helm))
+        (restclient-helm :depends helm)
         ))
 
 (defun restclient/pre-init-golden-ratio ()

--- a/layers/+tools/ycmd/packages.el
+++ b/layers/+tools/ycmd/packages.el
@@ -11,8 +11,8 @@
 
 (setq ycmd-packages
   '(
-    (company-ycmd :toggle (configuration-layer/package-usedp 'company))
-    (flycheck-ycmd :toggle (configuration-layer/package-usedp 'flycheck))
+    (company-ycmd :depends company)
+    (flycheck-ycmd :depends flycheck)
     eldoc
     ycmd
     ))

--- a/layers/+web-services/spotify/packages.el
+++ b/layers/+web-services/spotify/packages.el
@@ -12,7 +12,7 @@
 (setq spotify-packages
       '(
         spotify
-        (helm-spotify :toggle (configuration-layer/package-usedp 'helm))
+        (helm-spotify :depends helm)
         ))
 
 (defun spotify/init-spotify ()

--- a/tests/core/core-configuration-layer-ftest.el
+++ b/tests/core/core-configuration-layer-ftest.el
@@ -20,7 +20,7 @@
                                              (git :variables foo 'bar)))
         configuration-layer--used-layers
         (configuration-layer--indexed-layers (make-hash-table :size 1024)))
-    (configuration-layer/discover-layers)
+    (configuration-layer/discover-layers 'refresh-index)
     (configuration-layer//declare-used-layers dotspacemacs-configuration-layers)
     (should (eq 'spacemacs-bootstrap
                 (first configuration-layer--used-layers)))))
@@ -31,7 +31,7 @@
                                              (git :variables foo 'bar)))
         configuration-layer--used-layers
         (configuration-layer--indexed-layers (make-hash-table :size 1024)))
-    (configuration-layer/discover-layers)
+    (configuration-layer/discover-layers 'refresh-index)
     (configuration-layer//declare-used-layers dotspacemacs-configuration-layers)
     (should (eq 'spacemacs-base (second configuration-layer--used-layers)))))
 


### PR DESCRIPTION
This replaces the older pattern `:toggle (configuration-layer/package-usedp ..)`

This implementation ensures that `:disabled-for` honors dependent packages, i.e. if package a depends on package b, which is owned by layer c, and layer c is disabled for layer d, then neither package a nor b will be configured for layer d. Previously, this was only true for package a, but not b.

This commit also fixes:

- `configuration-layer/describe-package` now shows which post-init and pre-init functions are disabled, if any
- Does not recreate all layer objects unconditionally when calling `configuration-layer/discover-layers`. Previously, this led to all layers being recreated after e.g. `SPC h SPC`, without any of the dotfile information. Since this information is now necessary for `configuration-layer/describe-package`, it’s important that we don’t clear the indexed layers when invoking this function.