### PR TITLE
typescript: allow to disable eldoc-mode

### DIFF
--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -65,6 +65,15 @@ You can choose formatting tool:
 
 Default is 'tide .
 
+Sometimes eldoc-mode can be very slow, for example when using type inference on a complex data structures.
+You can disable it:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(
+  (typescript :variables
+              typescript-disable-eldoc t)))
+#+END_SRC
+
 ** Notes
 
 This layer uses:

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -14,6 +14,9 @@
 (defvar typescript-fmt-on-save nil
   "Run formatter on buffer save.")
 
+(defvar typescript-disable-eldoc nil
+  "Do not use eldoc.")
+
 (defvar typescript-fmt-tool 'tide
   "The name of the tool to be used
 for TypeScript source code formatting.

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -31,7 +31,10 @@
       :modes typescript-mode)))
 
 (defun typescript/post-init-eldoc ()
-  (add-hook 'typescript-mode-hook 'eldoc-mode))
+  (add-hook 'typescript-mode-hook
+            (lambda ()
+              (when (not typescript-disable-eldoc)
+                (eldoc-mode +1)))))
 
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode))
@@ -78,7 +81,8 @@
                          (string-equal "tsx" (file-name-extension (buffer-file-name))))
                 (tide-setup)
                 (flycheck-mode +1)
-                (eldoc-mode +1)
+                (when (not typescript-disable-eldoc)
+                  (eldoc-mode +1))
                 (when (configuration-layer/package-usedp 'company)
                   (company-mode-on))))))
 


### PR DESCRIPTION
Sometimes eldoc-mode can be very slow, for example when using type inference on a complex data structures. This PR adds the ability to disable it.