### PR TITLE
Add shortcut for cargo clippy

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -55,6 +55,7 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | ~SPC m c e~ | run benchmarks with Cargo                   |
 | ~SPC m c f~ | run the current test with Cargo             |
 | ~SPC m c i~ | create a new project with Cargo (init)      |
+| ~SPC m c l~ | run linter ([[https://github.com/arcnmx/cargo-clippy][cargo-clippy]]) with Cargo        |
 | ~SPC m c n~ | create a new project with Cargo (new)       |
 | ~SPC m c o~ | run all tests in current file with Cargo    |
 | ~SPC m c s~ | search for packages on crates.io with Cargo |

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -40,6 +40,7 @@
         "cf" 'cargo-process-current-test
         "cf" 'cargo-process-fmt
         "ci" 'cargo-process-init
+        "cl" 'cargo-process-clippy
         "cn" 'cargo-process-new
         "co" 'cargo-process-current-file-tests
         "cs" 'cargo-process-search


### PR DESCRIPTION
Just adding a shortcut for the [rust-clippy](https://github.com/Manishearth/rust-clippy) linter. "cc" was taken, so I went for "cl" as in "lint".