### PR TITLE
Perl5 keybindings and bug fix

### DIFF
--- a/layers/+lang/perl5/README.org
+++ b/layers/+lang/perl5/README.org
@@ -7,6 +7,10 @@
   - [[#features][Features]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+- [[#key-bindings][Key Bindings]]
+  - [[#perldoc][Perldoc]]
+  - [[#pod-and-here-doc][POD and HERE doc]]
+  - [[#find-symbol][Find Symbol]]
 
 * Description
 This layer adds support for the Perl5 language.
@@ -19,3 +23,28 @@ This layer adds support for the Perl5 language.
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =perl5= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+* Key Bindings
+
+** Perldoc
+Browse formated perldocs.
+
+| Key Binding | Description                     |
+|-------------+---------------------------------|
+| ~SPC m h p~ | view perldoc of symbol at point |
+| ~SPC m h d~ | view perldoc of any symbol      |
+
+** POD and HERE doc
+select a POD or HERE doc
+
+| Key Binding | Description                            |
+|-------------+----------------------------------------|
+| ~SPC m v~   | select entire POD or HERE doc at point |
+
+** Find Symbol
+jump to symbol definition
+
+| Key Binding | Description                               |
+|-------------+-------------------------------------------|
+| ~SPC m g g~ | jump to symbol definition                 |
+| ~SPC m g G~ | jump to symbol definition in other window |

--- a/layers/+lang/perl5/config.el
+++ b/layers/+lang/perl5/config.el
@@ -1,0 +1,12 @@
+;;; config.el --- Perl5 Layer config File for Spacemacs
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Troy Hinckley <troyhinckley@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(spacemacs|define-jump-handlers cperl-mode)

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -114,4 +114,3 @@
 
 (defun perl5/post-init-flycheck ()
   (spacemacs/enable-flycheck 'cperl-mode))
-

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -91,8 +91,18 @@
                           :background 'unspecified
                           :weight 'unspecified)
 
+      ;; tab key will ident all marked code when tab key is pressed
+      (add-hook 'cperl-mode-hook
+                (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
+
+      (spacemacs/declare-prefix "mh" "perldoc")
+      (spacemacs/declare-prefix "mg" "find-symbol")
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hp" 'cperl-perldoc-at-point)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hd" 'cperl-perldoc)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "v" 'cperl-select-this-pod-or-here-doc)
+
       (font-lock-add-keywords 'cperl-mode
-                              '(("\\_<const\\|croak\\_>" . font-lock-keyword-face)))
+                              '(("\\_<const\\|croak\\|carp\\|confess\\|cluck\\_>" . font-lock-keyword-face)))
       (font-lock-add-keywords 'cperl-mode
                               '(("\\_<say\\|any\\_>" . cperl-nonoverridable-face))))))
 
@@ -104,3 +114,4 @@
 
 (defun perl5/post-init-flycheck ()
   (spacemacs/enable-flycheck 'cperl-mode))
+


### PR DESCRIPTION
- added keybindings for POD and HERE doc selection
- added keybindings for perldoc's
- added dump jump support
- fixed tab command. In my initial PR #9046 I had included this fix but then removed it believing it was not necessary. However I have found that the default `cperl-indent-command` is not sufficient and won't work properly when indenting blocks of unaligned code.
