### PR TITLE
Ensure that .venv is a regular file before trying to source it.

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -105,16 +105,15 @@
 (defun spacemacs//pyvenv-mode-set-local-virtualenv ()
   "Set pyvenv virtualenv from \".venv\" by looking in parent directories."
   (interactive)
-  (let ((root-path (locate-dominating-file default-directory
-                                           ".venv")))
-    (when root-path
-      (let* ((file-path (expand-file-name ".venv" root-path))
-             (virtualenv
-              (with-temp-buffer
-                (insert-file-contents-literally file-path)
-                (buffer-substring-no-properties (line-beginning-position)
-                                                (line-end-position)))))
-            (pyvenv-workon virtualenv)))))
+  (-when-let* ((root-path (locate-dominating-file default-directory ".venv"))
+               (file-path (expand-file-name ".venv" root-path))
+               (venv-is-file (file-regular-p file-path))  ; for side-effects
+               (virtualenv
+                (with-temp-buffer
+                  (insert-file-contents-literally file-path)
+                  (buffer-substring-no-properties (line-beginning-position)
+                                                  (line-end-position)))))
+    (pyvenv-workon virtualenv)))
 
 
 ;; Tests


### PR DESCRIPTION
Until today, I wasn't using virtualenvwrapper.sh, and I was in the habit of creating a directory called `.venv` in my projects that contained my virtualenv. However, virtualenvwrapper.sh uses the convention that instead a file named `.venv` at the root of the directory should contain the name of the virtualenv to activate. This makes Spacemacs be more cautious, by checking that any `.venv` file it finds is actually a regular file before trying to read its contents. This will thus avoid a spurious error that I get currently from Spacemacs, which is like:
```
File mode specification error: (file-error Read error Is a directory /home/evan/code/foo/.venv)
```