### PR TITLE
Actually configure SPC m b to switch between ERC buffers.

### DIFF
--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -94,6 +94,7 @@
 
       ;; keybindings
       (spacemacs/set-leader-keys-for-major-mode 'erc-mode
+        "b" 'erc-switch-to-buffer
         "d" 'erc-input-action
         "j" 'erc-join-channel
         "n" 'erc-channel-names


### PR DESCRIPTION
The documentation for the ERC layer already says that `SPC m b` is supposed to switch between buffers, but it's not actually set up to do that. This change fixes the issue.