### PR TITLE
Add option for controlling ERC inline image support

### DIFF
--- a/layers/+chat/erc/README.org
+++ b/layers/+chat/erc/README.org
@@ -17,7 +17,7 @@ Layer for [[http://www.emacswiki.org/emacs/ERC][ERC IRC chat]].
 
 * Features
 - Highlight nicks (using [[https://github.com/leathekd/erc-hl-nicks][erc-hl-nicks]])
-- Image inline support (using [[https://github.com/kidd/erc-image.el][erc-image]])
+- Image inline support via the variable =erc-enable-images= (using [[https://github.com/kidd/erc-image.el][erc-image]])
 - Logging to =~/.emacs.d/.cache/erc-logs= and =ViewLogMode= for viewing logs
   (using [[https://github.com/Niluge-KiWi/erc-view-log][erc-view-log]])
 - YouTube videos Thumbnails inline (using [[https://github.com/yhvh/erc-yt][erc-yt]])

--- a/layers/+chat/erc/config.el
+++ b/layers/+chat/erc/config.el
@@ -12,6 +12,9 @@
 (defvar erc-enable-sasl-auth nil
   "If non nil then use SASL authenthication with ERC.")
 
+(defvar erc-enable-images t
+  "If non nil then enable inline images using erc-image.")
+
 (defvar erc-spacemacs-layout-name "@ERC"
   "Name used in the setup for `spacemacs-layouts' micro-state")
 

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -214,6 +214,7 @@
 (defun erc/init-erc-image ()
   (use-package erc-image
     :defer t
+    :if erc-enable-images
     :init (with-eval-after-load 'erc
             (require 'erc-image)
             (add-to-list 'erc-modules 'image))))


### PR DESCRIPTION
This adds a new option `erc-enable-images` which can be used to control whether or not ERC displays inline images. The default value is `t`, to preserve the existing behavior. A user can set this value to `nil` to disable inline images.