### PR TITLE
No-sync startup flag

### DIFF
--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -16,8 +16,8 @@
 (defvar spacemacs-insecure nil
   "If non-nil force Spacemacs to operate without secured protocols.")
 
-(defvar spacemacs-skip-sync nil
-  "If non-nil skip package synchronization on startup")
+(defvar spacemacs-sync-packages t
+  "If non-nil synchronize packages on startup")
 
 (defun spacemacs//parse-command-line (args)
   "Handle Spacemacs specific command line arguments.
@@ -57,7 +57,7 @@ arguments is that we want to process these arguments as soon as possible."
           ("--resume-layouts"
            (setq spacemacs-force-resume-layouts t))
           ("--no-sync"
-           (setq spacemacs-skip-sync t))
+           (setq spacemacs-sync-packages nil))
           (_ (push arg new-args))))
       (setq i (1+ i)))
     (nreverse new-args)))

--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -16,7 +16,7 @@
 (defvar spacemacs-insecure nil
   "If non-nil force Spacemacs to operate without secured protocols.")
 
-(defvar spacemacs-no-sync nil
+(defvar spacemacs-skip-sync nil
   "If non-nil skip package synchronization on startup")
 
 (defun spacemacs//parse-command-line (args)
@@ -57,7 +57,7 @@ arguments is that we want to process these arguments as soon as possible."
           ("--resume-layouts"
            (setq spacemacs-force-resume-layouts t))
           ("--no-sync"
-           (setq spacemacs-no-sync t))
+           (setq spacemacs-skip-sync t))
           (_ (push arg new-args))))
       (setq i (1+ i)))
     (nreverse new-args)))

--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -16,6 +16,9 @@
 (defvar spacemacs-insecure nil
   "If non-nil force Spacemacs to operate without secured protocols.")
 
+(defvar spacemacs-no-sync nil
+  "If non-nil skip package synchronization on startup")
+
 (defun spacemacs//parse-command-line (args)
   "Handle Spacemacs specific command line arguments.
 The reason why we don't use the Emacs hooks for processing user defined
@@ -53,6 +56,8 @@ arguments is that we want to process these arguments as soon as possible."
                  i (1+ i)))
           ("--resume-layouts"
            (setq spacemacs-force-resume-layouts t))
+          ("--no-sync"
+           (setq spacemacs-no-sync t))
           (_ (push arg new-args))))
       (setq i (1+ i)))
     (nreverse new-args)))

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -436,9 +436,9 @@ refreshed during the current session."
       (package-read-all-archive-contents)
       (unless quiet (spacemacs-buffer/append "\n")))))
 
-(defun configuration-layer/sync (&optional no-install)
+(defun configuration-layer/sync (&optional skip-install)
   "Synchronize declared layers in dotfile with spacemacs.
-If NO-INSTALL is non nil then install steps are skipped."
+If SKIP-INSTALL is non nil then install steps are skipped."
   (run-hooks 'configuration-layer-pre-sync-hook)
   (dotspacemacs|call-func dotspacemacs/layers "Calling dotfile layers...")
   (setq dotspacemacs--configuration-layers-saved
@@ -461,7 +461,7 @@ If NO-INSTALL is non nil then install steps are skipped."
   ;; load layers lazy settings
   (configuration-layer/load-auto-layer-file)
   ;; install and/or uninstall packages
-  (unless no-install
+  (unless skip-install
     (let ((packages
            (append
             ;; install used packages

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -436,9 +436,9 @@ refreshed during the current session."
       (package-read-all-archive-contents)
       (unless quiet (spacemacs-buffer/append "\n")))))
 
-(defun configuration-layer/sync (&optional skip-install)
+(defun configuration-layer/sync (&optional install)
   "Synchronize declared layers in dotfile with spacemacs.
-If SKIP-INSTALL is non nil then install steps are skipped."
+If INSTALL is non nil then install missing packages."
   (run-hooks 'configuration-layer-pre-sync-hook)
   (dotspacemacs|call-func dotspacemacs/layers "Calling dotfile layers...")
   (setq dotspacemacs--configuration-layers-saved
@@ -461,7 +461,7 @@ If SKIP-INSTALL is non nil then install steps are skipped."
   ;; load layers lazy settings
   (configuration-layer/load-auto-layer-file)
   ;; install and/or uninstall packages
-  (unless skip-install
+  (when install
     (let ((packages
            (append
             ;; install used packages

--- a/init.el
+++ b/init.el
@@ -27,7 +27,7 @@
                      "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (spacemacs/init)
-  (configuration-layer/sync spacemacs-no-sync)
+  (configuration-layer/sync spacemacs-skip-sync)
   (spacemacs-buffer/display-startup-note)
   (spacemacs/setup-startup-hook)
   (require 'server)

--- a/init.el
+++ b/init.el
@@ -27,7 +27,7 @@
                      "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (spacemacs/init)
-  (configuration-layer/sync spacemacs-skip-sync)
+  (configuration-layer/sync spacemacs-sync-packages)
   (spacemacs-buffer/display-startup-note)
   (spacemacs/setup-startup-hook)
   (require 'server)

--- a/init.el
+++ b/init.el
@@ -27,7 +27,7 @@
                      "core/core-load-paths.el"))
   (require 'core-spacemacs)
   (spacemacs/init)
-  (configuration-layer/sync)
+  (configuration-layer/sync spacemacs-no-sync)
   (spacemacs-buffer/display-startup-note)
   (spacemacs/setup-startup-hook)
   (require 'server)


### PR DESCRIPTION
This adds a new startup flag `--no-sync`. It will force spacemacs to skip
package synchonization. This can be useful in cases when you're working under
poor or restrictive network.

Thanks, @zaript, for this idea!