### PR TITLE
Add JSX header without breaking React

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -68,6 +68,6 @@
   (add-to-list 'auto-mode-alist '("\\.react.js\\'" . react-mode))
   (add-to-list 'auto-mode-alist '("\\index.android.js\\'" . react-mode))
   (add-to-list 'auto-mode-alist '("\\index.ios.js\\'" . react-mode))
-  (add-to-list 'magic-mode-alist '("/\\*\\* @jsx React\\.DOM \\*/" . react-mode))
+  (add-to-list 'magic-mode-alist '("/\\*\\* @jsx.+\\*/" . react-mode))
   (add-to-list 'magic-mode-alist '("^import React" . react-mode))
   (add-hook 'react-mode-hook 'spacemacs//setup-react-mode))


### PR DESCRIPTION
Using the header below is now deprecated in React.
```js
/** @jsx React.DOM */
```

However, there are situations where I have to use the *.js extension, and need to tell my text editor that the file has JSX.

I suggest switching to JSX mode if it detects a header starting with `@jsx`.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3