### PR TITLE
Use JSX header without breaking React

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -63,6 +63,6 @@
   (add-to-list 'auto-mode-alist '("\\.react.js\\'" . react-mode))
   (add-to-list 'auto-mode-alist '("\\index.android.js\\'" . react-mode))
   (add-to-list 'auto-mode-alist '("\\index.ios.js\\'" . react-mode))
-  (add-to-list 'magic-mode-alist '("/\\*\\* @jsx React\\.DOM \\*/" . react-mode))
+  (add-to-list 'magic-mode-alist '("/\\*\\* @jsx .*\\*/" . react-mode))
   (add-to-list 'magic-mode-alist '("import\s+[^\s]+\s+from\s+['\"]react['\"]" . react-mode))
   (add-hook 'react-mode-hook 'spacemacs//setup-react-mode))


### PR DESCRIPTION
Using the header below is now deprecated in React.
```js
/** @jsx React.DOM */
```

However, there are situations where I have to use the *.js extension, and need to tell my text editor that the file has JSX.

I suggest switching to JSX mode if it detects a header starting with `@jsx`. Then I'll be able to do the following without breaking react.

```js
/** @jsx */
