### PR TITLE
Add clip2org layer

### DIFF
--- a/layers/+tools/clip2org/README.org
+++ b/layers/+tools/clip2org/README.org
@@ -1,0 +1,23 @@
+#+TITLE: clip2org
+
+* Table of Contents                                        :TOC_4_gh:noexport:
+- [[#description][Description]]
+- [[#install][Install]]
+- [[#configuration][Configuration]]
+
+* Description
+This package converts Kindle’s “My Clippings.txt” to a format usable in Org
+mode. The result will be sorted by book title and displayed in a temporary
+buffer named ”*clippings*”.
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =test= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Configuration
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+  '((clip2org :variables
+          clip2org-clippings-file "~/Dropbox/Books/My Clippings.txt")))
+#+END_SRC

--- a/layers/+tools/clip2org/packages.el
+++ b/layers/+tools/clip2org/packages.el
@@ -1,0 +1,20 @@
+;;; packages.el --- clip2org layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author:  <leonard@lausen.nl>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst clip2org-packages
+  '((clip2org :location (recipe
+                         :fetcher github
+                         :repo "thamer/clip2org"))))
+
+(defun clip2org/init-clip2org ()
+  (use-package clip2org))
+
+;;; packages.el ends here


### PR DESCRIPTION
This pull request adds a layer for the clip2org.el package. Note that this package is not on melpa due to https://github.com/thamer/clip2org/pull/1 so it can't simply be installed by adding it to `dotspacemacs-additional-packages` (i.e. it seems not possible to add the `recipe:` to `dotspacemacs-additional-packages`?).

The proposed configuration is
```
(setq-default dotspacemacs-configuration-layers
  '((clip2org :variables
          clip2org-clippings-file "~/Dropbox/Books/My Clippings.txt")))
```

where `clip2org-clippings-file` is a variable defined by clip2org.el and not by a potential `config.el` file. Is this considered ok? It works at least..

