### PR TITLE
Idris layer: ignore *.ibc files in helm-projectile

### DIFF
--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -110,7 +110,11 @@
   ;; open special buffers in motion state so they can be closed with ~q~
   (evil-set-initial-state 'idris-compiler-notes-mode 'motion)
   (evil-set-initial-state 'idris-hole-list-mode 'motion)
-  (evil-set-initial-state 'idris-info-mode 'motion))
+  (evil-set-initial-state 'idris-info-mode 'motion)
+
+  ;; make sure projectile ignores .ibc files
+  (with-eval-after-load 'helm-projectile
+    (push ".ibc" projectile-globally-ignored-file-suffixes)))
 
 (defun idris/pre-init-golden-ratio ()
   (spacemacs|use-package-add-hook golden-ratio


### PR DESCRIPTION
Idris projects end up with one .ibc file for every .idr (source) file, but they're not human readable so you always have to skip over them in projectile. This commit adds the suffix to `projectile-globally-ignored-file-suffixes` so they'll just be invisible.