### PR TITLE
Navigate to project file without toggle

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -222,8 +222,14 @@
 
 (defun neotree-find-project-root ()
   (interactive)
+  (let ((origin-buffer-file-name (buffer-file-name)))
+    (neotree-find (projectile-project-root))
+    (neotree-find origin-buffer-file-name)))
+
+(defun neotree-toggle-project-root ()
+  (interactive)
   (if (neo-global--window-exists-p)
-      (neotree-hide)
+    (neotree-hide)
     (let ((origin-buffer-file-name (buffer-file-name)))
       (neotree-find (projectile-project-root))
       (neotree-find origin-buffer-file-name))))


### PR DESCRIPTION
This is something that was bothering me. If a file was part of a project located in a different tree than the one displayed and I was navigating to it with `SPC f T` then neotree would show it's parent directory and not it's project. But `SPC p t` would close neotree and I'd have to repeat the action to open it's project.

If you don't like the change to the keybind functionality then please consider adding just the function definition so it can be easily configured in a `.spacemacs` file (let me know and I will update the PR). 