### PR TITLE
Add `SPC b u` keybinding for reopening killed buffers

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2118,6 +2118,7 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC b P~       | copy clipboard and replace buffer (useful when pasting from a browser)   |
 | ~SPC b R~       | revert the current buffer (reload from disk)                             |
 | ~SPC b s~       | switch to the =*scratch*= buffer (create it if needed)                   |
+| ~SPC b u~       | reopen the most recently killed file buffer                              |
 | ~SPC b w~       | toggle read-only (writable state)                                        |
 | ~SPC b Y~       | copy whole buffer to clipboard (useful when copying to a browser)        |
 | ~z f~           | Make current function or comments visible in buffer as much as possible  |

--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -205,3 +205,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; hook into `hack-local-variables' in order to allow switching spacemacs
 ;; configurations based on local variables
 (add-hook 'hack-local-variables-hook #'spacemacs//run-local-vars-mode-hook)
+
+;; Add buffer reference to internal list of killed buffers on `kill-buffer',
+;; used for restoring recently killed buffers.
+(add-hook 'kill-buffer-hook #'spacemacs//add-buffer-to-killed-list)

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1153,6 +1153,23 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
                (fboundp dotspacemacs-scratch-mode))
       (funcall dotspacemacs-scratch-mode))))
 
+(defvar spacemacs--killed-buffer-list nil
+  "List of recently killed buffers.")
+
+(defun spacemacs//add-buffer-to-killed-list ()
+  "If buffer is associated with a file name, add that file
+to the `killed-buffer-list' when killing the buffer."
+  (when buffer-file-name
+    (push buffer-file-name spacemacs--killed-buffer-list)))
+
+(add-hook 'kill-buffer-hook #'spacemacs//add-buffer-to-killed-list)
+
+(defun spacemacs/reopen-killed-buffer ()
+  "Reopen the most recently killed file buffer, if one exists."
+  (interactive)
+  (when spacemacs--killed-buffer-list
+    (find-file (pop spacemacs--killed-buffer-list))))
+
 (defun spacemacs/switch-to-messages-buffer (&optional arg)
   "Switch to the `*Messages*' buffer.
 if prefix argument ARG is given, switch to it in an other, possibly new window."

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1162,8 +1162,6 @@ to the `killed-buffer-list' when killing the buffer."
   (when buffer-file-name
     (push buffer-file-name spacemacs--killed-buffer-list)))
 
-(add-hook 'kill-buffer-hook #'spacemacs//add-buffer-to-killed-list)
-
 (defun spacemacs/reopen-killed-buffer ()
   "Reopen the most recently killed file buffer, if one exists."
   (interactive)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -138,6 +138,7 @@
   "bp"    'previous-buffer
   "bR"    'spacemacs/safe-revert-buffer
   "bs"    'spacemacs/switch-to-scratch-buffer
+  "bu"    'spacemacs/reopen-killed-buffer
   "bY"    'spacemacs/copy-whole-buffer-to-clipboard
   "bw"    'read-only-mode)
 (dotimes (i 9)


### PR DESCRIPTION
This is similar to the `Ctrl+Shift+T` keybinding found in major browsers, and helps when accidentally killing a buffer (i.e. fat-fingering `SPC b d` when meaning to press `SPC b s`).

Only buffers that resolve to files (and not ephemeral buffers) will be considered, and stored in a stack which is pushed to and popped from on buffer kill.