### PR TITLE
ruby: change documentation lookup key binding

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -107,7 +107,7 @@ directory local variables.
 | ~SPC m '​~   | toggle quotes of current string (only built-in mode) |
 | ~SPC m {~   | toggle style of current block (only built-in mode)   |
 | ~SPC m g g~ | go to definition (robe-jump)                         |
-| ~SPC m h d~ | go to Documentation                                  |
+| ~SPC m h h~ | show documentation for method at point (robe-doc)    |
 | ~SPC m s f~ | send function definition                             |
 | ~SPC m s F~ | send function definition and switch to REPL          |
 | ~SPC m s i~ | start REPL                                           |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -149,7 +149,7 @@
         (spacemacs/set-leader-keys-for-major-mode mode
           "'" 'robe-start
           ;; robe mode specific
-          "hd" 'robe-doc
+          "hh" 'robe-doc
           "rsr" 'robe-rails-refresh
           ;; inf-enh-ruby-mode
           "sf" 'ruby-send-definition


### PR DESCRIPTION
`SPC m h h` is conventional key binding to show documentation for thing under
point. It is called by `spacemacs/evil-smart-doc-lookup`, so this change makes
`K` in normal state work as expected.