### PR TITLE
 Fix the base16-solarflare theme mapping

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -102,7 +102,7 @@
     (base16-seti                      . base16-theme)
     (base16-seti-ui                   . base16-theme)
     (base16-shapeshifter              . base16-theme)
-    (base16-solar-flare               . base16-theme)
+    (base16-solarflare                . base16-theme)
     (base16-solarized-dark            . base16-theme)
     (base16-solarized-light           . base16-theme)
     (base16-spacemacs                 . base16-theme)


### PR DESCRIPTION
It seems the `base16-theme` package lists this theme as `base16-solareflare`.