### PR TITLE
Adds GOROOT to list of variables copied from shell environment

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -47,7 +47,7 @@
 (defun go/pre-init-exec-path-from-shell ()
   (spacemacs|use-package-add-hook exec-path-from-shell
     :pre-config
-    (dolist (var '("GOPATH" "GO15VENDOREXPERIMENT") exec-path-from-shell-variables)
+    (dolist (var '("GOPATH" "GOROOT" "GO15VENDOREXPERIMENT") exec-path-from-shell-variables)
       (unless (or (member var exec-path-from-shell-variables) (getenv var))
         (push var exec-path-from-shell-variables)))))
 


### PR DESCRIPTION
From <https://golang.org/doc/install> "Installing to a custom location"

> The Go binary distributions assume they will be installed in /usr/local/go
> (or c:\Go under Windows), but it is possible to install the Go tools to a
> different location. In this case you must set the GOROOT environment variable
> to point to the directory in which it was installed.