### PR TITLE
Improves the linum text scaling advice

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1211,12 +1211,18 @@ Decision is based on `dotspacemacs-line-numbers'."
 
 (defun spacemacs//linum-update-window-scale-fix (win)
   "Fix linum for scaled text in the window WIN."
-  (set-window-margins win
-                      (ceiling (* (if (boundp 'text-scale-mode-step)
-                                      (expt text-scale-mode-step
-                                            text-scale-mode-amount)
-                                    1)
-                                  (or (car (window-margins win)) 1)))))
+  (when (display-multi-font-p)
+    (unless (boundp 'text-scale-mode-step)
+      (setq window-initial-margins (window-margins win)))
+    (set-window-margins win
+     (ceiling (* (if (boundp 'text-scale-mode-step)
+                   (expt text-scale-mode-step
+                     text-scale-mode-amount)
+                   1)
+                (or (car (if (boundp 'window-initial-margins)
+                           window-initial-margins
+                           (window-margins win)))
+                  1))))))
 
 (defun spacemacs//linum-backward-compabitility ()
   "Return non-nil if `dotspacemacs-line-numbers' has an old format and if


### PR DESCRIPTION
The first improvement consists of running the scale fix only for
graphical emacs. The scale fix is not needed in the terminal. Also some
poeple still have problems with it in the terminal even though they run
latest emacs master and spacemacs develop.

The second improvement is related to the way the margins are scaled. It
was incorrect to calculate the scale factor and apply it to the current
window margin width, it needed to be applied to the initial margin
width.

Refs #9156 #8654

Also, I saw a commit on emacs master that rewites the line number functionality
and makes linum obsolete. I tried it out a bit and it works great. I guess this means
linum support should be dropped when the minimum emacs version reaches 26 and
the linum fix will be gone as well.