### PR TITLE
[ruby-layer] Adding rufo.el package for automatic formatting

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -19,6 +19,7 @@
     - [[#minitest-mode][minitest-mode]]
   - [[#rake][Rake]]
   - [[#refactor][Refactor]]
+  - [[#formatting][Formatting]]
 - [[#layer-options][Layer options]]
 
 * Description
@@ -54,6 +55,7 @@ based on your version manager):
 - =pry= and =pry-doc= are required for *jump to definition* and *code documentation* (=robe-mode=)
 - =ruby_parser= is required for *goto-step_definition* in =feature-mode=
 - =rubocop= is required for rubocop integration
+- =rufo= is required for code formatting
 
 You can install the gems in the context of your current project by
 adding them to the =Gemfile=, e.g.:
@@ -198,6 +200,12 @@ When =ruby-test-runner= equals =minitest=.
 | ~SPC m r R v~ | Extract local variable |
 | ~SPC m r R c~ | Extract constant       |
 | ~SPC m r R l~ | Extract to let (rspec) |
+
+** Formatting
+
+| Key binding | Description   |
+|-------------+---------------|
+| ~SPC m =~   | Format buffer |
 
 * Layer options
 

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -14,6 +14,7 @@
         bundler
         chruby
         company
+        rufo
         (enh-ruby-mode :toggle ruby-enable-enh-ruby-mode)
         evil-matchit
         flycheck
@@ -65,6 +66,13 @@
     :defer t
     :init (spacemacs/add-to-hooks 'chruby-use-corresponding
                                   '(ruby-mode-hook enh-ruby-mode-hook))))
+
+(defun ruby/init-rufo ()
+  (use-package rufo
+    :init (dolist (mode '(ruby-mode enh-ruby-mode))
+            (add-hook (intern (concat (symbol-name mode) "-hook")) 'rufo-minor-mode)
+            (spacemacs/set-leader-keys-for-major-mode mode
+              "=" 'rufo-format))))
 
 (defun ruby/init-enh-ruby-mode ()
   (use-package enh-ruby-mode


### PR DESCRIPTION
This adds [rufo.el](https://github.com/danielma/rufo.el) to ruby modes for automatic code formatting upon save (like `gofmt`).