### PR TITLE
binds `org-resolve-clocks` to =, C r=

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -298,6 +298,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC m C g~                                  | evil-org-recompute-clocks                    |
 | ~SPC m C i~                                  | org-clock-in                                 |
 | ~SPC m C o~                                  | org-clock-out                                |
+| ~SPC m C r~                                  | org-resolve-clocks                           |
 | ~SPC m d d~                                  | org-deadline                                 |
 | ~SPC m d s~                                  | org-schedule                                 |
 | ~SPC m d t~                                  | org-time-stamp                               |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -179,6 +179,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "Cc" 'org-clock-cancel
         "Ci" 'org-clock-in
         "Co" 'org-clock-out
+        "Cr" 'org-resolve-clocks
         "dd" 'org-deadline
         "ds" 'org-schedule
         "dt" 'org-time-stamp


### PR DESCRIPTION
Hi

This PR Binds `org-resolve-clocks` to `, C r`

What do you think?