### PR TITLE
Update spacemacs template, paste ts doc string

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -249,8 +249,8 @@ file stored in the cache directory and `nil' to disable auto-saving.
 Default value is `cache'.")
 
 (defvar dotspacemacs-enable-paste-transient-state nil
-  "If non nil the paste transient-state is enabled. While enabled pressing `p`
-several times cycle between the kill ring content.'")
+  "If non-nil, the paste transient-state is enabled. And pressing `p' several
+times, cycles through the elements in the `kill-ring'. (default nil)")
 (defvaralias
   'dotspacemacs-enable-paste-micro-state
   'dotspacemacs-enable-paste-transient-state

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -204,8 +204,8 @@ It should only modify the values of Spacemacs settings."
    ;; source settings. Else, disable fuzzy matching in all sources.
    ;; (default 'always)
    dotspacemacs-helm-use-fuzzy 'always
-   ;; If non-nil the paste micro-state is enabled. When enabled pressing `p'
-   ;; several times cycle between the kill ring content. (default nil)
+   ;; If non-nil, the paste transient-state is enabled. And pressing `p' several
+   ;; times, cycles through the elements in the `kill-ring'. (default nil)
    dotspacemacs-enable-paste-transient-state nil
    ;; Which-key delay in seconds. The which-key buffer is the popup listing
    ;; the commands bound to the current keystroke sequence. (default 0.4)


### PR DESCRIPTION
"micro-state" was the previous name for "transient-state".
Reword the sentence and quote the kill-ring variable.