### PR TITLE
Fix iedit paste-replace, kill-ring cycling

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -83,6 +83,13 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
 
 ;; multiple-cursors
 
+(defun spacemacs/evil-iedit-state/paste-replace (count)
+  "Enable `C-n' and `C-p' for cycling the kill ring after pasting in
+iedit-state."
+  (interactive "P")
+  (setq this-command 'evil-paste-before)
+  (evil-iedit-state/paste-replace count))
+
 (defun spacemacs//paste-transient-state-p ()
   "Return non-nil if the paste transient state is enabled."
   (and dotspacemacs-enable-paste-transient-state

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -172,7 +172,10 @@
         (kbd dotspacemacs-leader-key) spacemacs-default-map)
       (spacemacs//iedit-insert-state-hybrid dotspacemacs-editing-style)
       (add-hook 'spacemacs-editing-style-hook
-                #'spacemacs//iedit-insert-state-hybrid))))
+                #'spacemacs//iedit-insert-state-hybrid)
+      ;; enable kill ring cycling with `C-n' and `C-p' after pasting
+      (define-key evil-iedit-state-map "p"
+        'spacemacs/evil-iedit-state/paste-replace))))
 
 (defun spacemacs-evil/init-evil-indent-plus ()
   (use-package evil-indent-plus


### PR DESCRIPTION
Problem:
Pressing `C-n` or `C-p` to cycle the kill ring, after pasting in iedit state,
shows the message: `user-error: Previous command was not an evil-paste:
evil-iedit-state/paste-replace`.

Solution:
Set the `this-command` variable to `evil-paste-before`, before calling
`evil-iedit-state/paste-replace`.

Issue:
Sometimes a cycled kill-ring element only appears by the main cursor. I haven't been able to figure out the cause, but more people investigating it will probably help.

It seems to work most of the time, so it's at least better than the current `previous command was not an evil-paste` message.

Advice function:
I haven't looked into how "advicing" a function works, but maybe that would be a simpler solution, than what I came up with.