### PR TITLE
shell layer: set "terminal" purpose on shell buffers

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -27,6 +27,7 @@
         (term :location built-in)
         xterm-color
         vi-tilde-fringe
+        window-purpose
         ))
 
 (defun shell/init-comint ()
@@ -274,3 +275,10 @@
                             eshell-mode-hook
                             shell-mode-hook
                             term-mode-hook)))
+
+(defun shell/post-init-window-purpose ()
+  (purpose-set-extension-configuration
+   :shell-layer
+   (purpose-conf
+    :mode-purposes '((eshell-mode . terminal)
+                     (term-mode . terminal)))))


### PR DESCRIPTION
Sets the `terminal` purpose on `eshell` and `term-mode` buffers.