### PR TITLE
fix misused function in OCaml layer

### DIFF
--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -25,7 +25,7 @@
     ))
 
 (defun ocaml/post-init-company ()
-  (when (configuration-layer/layer-used-p 'merlin)
+  (when (configuration-layer/package-used-p 'merlin)
     (spacemacs|add-company-backends
       :backends merlin-company-backend
       :modes merlin-mode


### PR DESCRIPTION
`merlin' is a package, not a layer.