### PR TITLE
Change kill-other-buffers from `b C-d` to `b D`. Mnemonics maintained!

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2103,10 +2103,10 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC TAB~       | switch to alternate buffer in the current window (switch back and forth) |
 | ~SPC b b~       | switch to a buffer                                                       |
 | ~SPC b d~       | kill the current buffer (does not delete the visited file)               |
+| ~SPC b D~       | kill other buffers                                                       |
 | ~SPC u SPC b d~ | kill the current buffer and window (does not delete the visited file)    |
 | ~SPC b D~       | kill a visible buffer using [[https://github.com/abo-abo/ace-window][ace-window]]                                   |
 | ~SPC u SPC b D~ | kill a visible buffer and its window using [[https://github.com/abo-abo/ace-window][ace-window]]                    |
-| ~SPC b C-d~     | kill other buffers                                                       |
 | ~SPC b C-D~     | kill buffers using a regular expression                                  |
 | ~SPC b e~       | erase the content of the buffer (ask for confirmation)                   |
 | ~SPC b h~       | open =*spacemacs*= home buffer                                           |

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -123,9 +123,9 @@
 (spacemacs/set-leader-keys
   "TAB"   'spacemacs/alternate-buffer
   "bd"    'spacemacs/kill-this-buffer
+  "bD"    'spacemacs/kill-other-buffers
   "be"    'spacemacs/safe-erase-buffer
   "bh"    'spacemacs/home
-  "b C-d" 'spacemacs/kill-other-buffers
   "b C-S-d" 'spacemacs/kill-matching-buffers-rudely
   "bn"    'next-buffer
   "bm"    'spacemacs/switch-to-messages-buffer


### PR DESCRIPTION
I have been using 'SPC b m' for a long time to kill-other-buffers like scratch, home, those opened by magit and others...
But after that being changed recently to 'C-d' in #7733 I strongly felt that for such a common use case using combination-keys would be uncomfortable. There is no issue related to this change.

If it is mandatory for an issue to be present for all pull requests I will be happy to raise one.

I hope this change is welcome by members of the community.