### PR TITLE
use url-hexify-string to encode issue report body

### DIFF
--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -295,12 +295,8 @@ that the issue has been created successfully, you can close this buffer.
 
 (defun spacemacs//report-issue-done ()
   (interactive)
-  (let ((url "http://github.com/syl20bnr/spacemacs/issues/new?body="))
-    (setq url (url-encode-url (concat url (buffer-string))))
-    ;; HACK: encode some characters according to HTML URL Encoding Reference
-    ;; http://www.w3schools.com/tags/ref_urlencode.asp
-    (setq url (replace-regexp-in-string "#" "%23" url))
-    (setq url (replace-regexp-in-string ";" "%3B" url))
-    (browse-url url)))
+  (let ((url "http://github.com/syl20bnr/spacemacs/issues/new?body=")
+        (body (url-hexify-string (buffer-string))))
+    (browse-url (url-encode-url (concat url body)))))
 
 (provide 'core-debug)


### PR DESCRIPTION
Fixes #9301

---

Indeed, initially I have just encoded several characters, but it seems that a better solution is to use `url-hexify-string`. Not that only body should be encoded. 

Side note - I wonder why `url-encode-url` doesn't... actually encode?

> The function url-encode-url can be used to convert a URI string containing arbitrary characters to one that is properly percent-encoded in accordance with RFC 3986.

This is what manual states. 

```emacs-lisp
ELISP> (url-encode-url "https://example.com/?body=help%'#")
"https://example.com/?body=help%'#"
ELISP> (url-encode-url (concat "https://example.com/?body=" (url-hexify-string "help%'#")))
"https://example.com/?body=help%25%27%23"
```