### PR TITLE
set ivy-use-selectable-prompt to t

### DIFF
--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -26,13 +26,15 @@ file.
 You can customize ivy with the following variables:
 
 - =ivy-wrap= Whether C-n and C-p should wrap-around when at the the first or
-  last candidate. The default value is nil.
+  last candidate. The default value is =nil=.
 - =ivy-extra-directories= Setting this to =nil= hides . and .. directories from
   file name completion. You can still go up a directory up by ~DEL~.
   The default value is ("../", "./").
 - =ivy-use-virtual-buffers= Add bookmarks and recent files to buffer completion
   menu. The Spacemacs default is t.
 - =ivy-height= The height of the minibuffer. The Spacemacs default is 15.
+- =ivy-use-selectable-prompt= When non-nil, make the prompt line selectable like
+  a candidate. The Spacemacs default value is =t=.
 
 * Key Bindings
 If you choose =ivy= as completion system, make sure to read the [[http://oremacs.com/swiper/][official manual]].

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -205,7 +205,10 @@
       (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
         "w" 'ivy-wgrep-change-to-wgrep-mode)
       ;; Why do we do this ?
-      (ido-mode -1))))
+      (ido-mode -1)
+
+      ;; allow to select prompt in some ivy functions
+      (setq ivy-use-selectable-prompt t))))
 
 (defun ivy/init-ivy-hydra ()
   (use-package ivy-hydra)


### PR DESCRIPTION
Following #8571.

---

I think it's a good default. It doesn't make anyone suffer, but most importantly, might save someone from struggle while renaming file to a new name that is a prefix of old name. Just an example 😸 

Let me know if you have any objections or suggestions.