### PR TITLE
[ror] add key binding to find serializer

### DIFF
--- a/layers/+frameworks/ruby-on-rails/README.org
+++ b/layers/+frameworks/ruby-on-rails/README.org
@@ -38,6 +38,7 @@ file.
 | ~SPC m r f p~ | find spec file                                                  |
 | ~SPC m r f r~ | find rake task                                                  |
 | ~SPC m r f s~ | find stylesheet file                                            |
+| ~SPC m r f S~ | find serializer file                                            |
 | ~SPC m r f t~ | find test                                                       |
 | ~SPC m r f u~ | find fixture                                                    |
 | ~SPC m r f v~ | find view                                                       |

--- a/layers/+frameworks/ruby-on-rails/packages.el
+++ b/layers/+frameworks/ruby-on-rails/packages.el
@@ -40,6 +40,7 @@
           "rfp" 'projectile-rails-find-spec
           "rfr" 'projectile-rails-find-rake-task
           "rfs" 'projectile-rails-find-stylesheet
+          "rfS" 'projectile-rails-find-serializer
           "rft" 'projectile-rails-find-test
           "rfu" 'projectile-rails-find-fixture
           "rfv" 'projectile-rails-find-view


### PR DESCRIPTION
Fixes #9239

---

Fortunately, `projectile-rails` already has request functionality, so I have just bound that function to `SPC m r f S` (since `s` was already taken). 

Haven't tested, cause don't use RoR, so I'll wait a little bit before merging. Hope someone could test it 😸 