### PR TITLE
Fix automatic syntax checking for cfengine

### DIFF
--- a/layers/+tools/cfengine/packages.el
+++ b/layers/+tools/cfengine/packages.el
@@ -33,7 +33,7 @@
   (add-hook 'cfengine3-mode-hook 'eldoc-mode))
 
 (defun cfengine/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'cfengine3-mode-hook))
+  (spacemacs/enable-flycheck 'cfengine3-mode))
 
 (defun cfengine/init-ob-cfengine3 ()
   (use-package ob-cfengine3


### PR DESCRIPTION
The wrong mode for cfengine was specified for enabling flycheck. This properly
loads flycheck support when cfengine3 mode is active.