### PR TITLE
spacemacs-base: Add key bindings for projectile-edit-dir-locals

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3165,6 +3165,7 @@ To search in a project see [[#searching-in-a-project][project searching]].
 | ~SPC p c~   | compile project using =projectile=                      |
 | ~SPC p d~   | find directory                                          |
 | ~SPC p D~   | open project root in =dired=                            |
+| ~SPC p e~   | edit dir-locals.el                                      |
 | ~SPC p f~   | find file                                               |
 | ~SPC p F~   | find file based on path around point                    |
 | ~SPC p g~   | find tags                                               |

--- a/layers/+distributions/spacemacs-base/packages.el
+++ b/layers/+distributions/spacemacs-base/packages.el
@@ -348,6 +348,7 @@
         "pc" 'projectile-compile-project
         "pd" 'projectile-find-dir
         "pD" 'projectile-dired
+        "pe" 'projectile-edit-dir-locals
         "pf" 'projectile-find-file
         "pF" 'projectile-find-file-dwim
         "pg" 'projectile-find-tag


### PR DESCRIPTION
This key binding opens the projects `dir-locals.el` file in a buffer.