### PR TITLE
Chinese layer: update package name due to upstream renaming

### DIFF
--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -13,7 +13,7 @@
 ;; which require an initialization must be listed explicitly in the list.
 (setq chinese-packages
       '(
-        (chinese-pyim :toggle (eq chinese-default-input-method 'pinyin))
+        (pyim :toggle (eq chinese-default-input-method 'pinyin))
         (chinese-wbim :toggle (eq chinese-default-input-method 'wubi))
         (fcitx :toggle chinese-enable-fcitx)
         find-by-pinyin-dired
@@ -59,18 +59,16 @@
             ;; Enable Chinese word segmentation support
             youdao-dictionary-use-chinese-word-segmentation t))))
 
-(defun chinese/init-chinese-pyim ()
-  (use-package chinese-pyim
+(defun chinese/init-pyim ()
+  (use-package pyim
     :if (eq 'pinyin chinese-default-input-method)
     :init
     (progn
-      (setq pyim-use-tooltip t
+      (setq pyim-page-tooltip t
             pyim-directory (expand-file-name "pyim/" spacemacs-cache-directory)
-            pyim-dicts-directory (expand-file-name "dicts/" pyim-directory)
             pyim-dcache-directory (expand-file-name "dcache/" pyim-directory)
-            pyim-personal-file (expand-file-name "pyim-personal.txt" pyim-directory)
-            default-input-method "chinese-pyim")
-      (evilified-state-evilify pyim-dicts-manager-mode pyim-dicts-manager-mode-map))))
+            default-input-method "pyim")
+      (evilified-state-evilify pyim-dm-mode pyim-dm-mode-map))))
 
 (defun chinese/init-find-by-pinyin-dired ()
   (use-package find-by-pinyin-dired


### PR DESCRIPTION
`chinese-pyim` package of Chinese layer has been renamed to `pyim`. This will use the correct package and variable names to replace the deprecated ones.