### PR TITLE
php: Fix php-company autocompletion

### DIFF
--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -70,6 +70,4 @@
       (add-hook 'php-mode-hook 'ac-php-core-eldoc-setup)
       (spacemacs|add-company-backends
         :modes php-mode
-        :variables
-        company-minimum-prefix-length 1000
         :backends company-ac-php-backend))))


### PR DESCRIPTION
Solve #9115.

The company-minimum-prefix-length variable shouldn't be set to 1000. Doing so
prevents the company completion popup from showing. Instead, let the
company-minimum-prefix-length stay at its default value.
