### PR TITLE
adapt to org-brain 0.4

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -624,8 +624,7 @@ are available.
 
 | Key Binding | Description                  |
 |-------------+------------------------------|
-| ~SPC a o b~ | Opens a new org-brain entry  |
-| ~SPC a o B~ | Visualize an org-brain entry |
+| ~SPC a o b~ | Visualize an org-brain entry |
 
 *** Visualization bindings
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -463,8 +463,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :init
     (progn
       (spacemacs/set-leader-keys
-        "aob" 'org-brain-open
-        "aoB" 'org-brain-visualize)
+        "aob" 'org-brain-visualize)
       (evil-set-initial-state 'org-brain-visualize-mode 'emacs))))
 
 (defun org/init-org-expiry ()


### PR DESCRIPTION
Fixes #9329

---

I am not using `org-brain`, so it would be nice if someone reviewed this PR. It seems that the default entry point is `org-brain-visualize` now, so I've just used it 😸 