### PR TITLE
c-c++: Add clang-format functions and key bindings

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -9,12 +9,13 @@
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#default-mode-for-header-files][Default mode for header files]]
-  - [[#enable-clang-support][Enable Clang support]]
+  - [[#clang-configuration][Clang Configuration]]
     - [[#clang-format][clang-format]]
     - [[#company-clang-and-flycheck][Company-clang and flycheck]]
   - [[#cmake-configuration][CMake configuration]]
 - [[#key-bindings][Key Bindings]]
-  - [[#debugger-realgud][Debugger (realgud)]]
+  - [[#debugging-realgud][Debugging (realgud)]]
+  - [[#formatting-clang-format][Formatting (clang-format)]]
 
 * Description
 This layer adds configuration for C/C++ language as well support for [[https://cmake.org/][CMake]]
@@ -61,8 +62,8 @@ by setting the variable =c-c++-default-mode-for-headers= to =c++-mode=.
 variable at the root of your project. More info on directory local variables
 can be found in the [[http://www.gnu.org/software/emacs/manual/html_node/elisp/Directory-Local-Variables.html][dir-locals]].
 
-** Enable Clang support
-To enable Clang support set the layer variable =c-c++-enable-clang-support=
+** Clang Configuration
+To enable Clang support, set the layer variable =c-c++-enable-clang-support=
 to =t= in the dotfile:
 
 #+BEGIN_SRC emacs-lisp
@@ -72,23 +73,11 @@ to =t= in the dotfile:
 
 *** clang-format
 [[http://clang.llvm.org/docs/ClangFormat.html][clang-format]] allows reformatting either a selected region of code
-(=clang-format-region=) or a whole buffer (=clang-format-buffer=) to make it
-conform to a style defined in a =.clang-format= file. This file is either
-located in the same directory as the file being edited, or in any of its parent
-directories (otherwise a default style will be used).
-
-You can add snippets similar to the following to bind clang-format to either a
-particular mode or all modes in your =dotspacemacs/user-config= (within your
-=~/.spacemacs=):
-
-#+BEGIN_SRC emacs-lisp
-  ;; Bind clang-format-region to C-M-tab in all modes:
-  (global-set-key [C-M-tab] 'clang-format-region)
-  ;; Bind clang-format-buffer to tab on the c++-mode only:
-  (add-hook 'c++-mode-hook 'clang-format-bindings
-            (defun clang-format-bindings ()
-              (define-key c++-mode-map [tab] 'clang-format-buffer)))
-#+END_SRC
+(=clang-format-region=) or a whole buffer (=clang-format-buffer=)
+according to a style defined in a =.clang-format= file. This file
+is either located in the same directory as the file being edited,
+or any of its parent directories. If no =.clang-format= is found,
+then a default style will be used.
 
 To enable automatic buffer formatting on save, set the variable
 =c-c++-enable-clang-format-on-save= to =t=:
@@ -142,7 +131,7 @@ build your project with ~SPC c c~ key binding.
 
 *Note:*  [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]]  is only available for Emacs 24.4+
 
-** Debugger (realgud)
+** Debugging (realgud)
 
  | Key Binding | Description     |
  |-------------+-----------------|
@@ -158,3 +147,10 @@ build your project with ~SPC c c~ key binding.
  | ~r~         | restart         |
  | ~q~         | quit debug      |
  | ~S~         | goto cmd buffer |
+
+** Formatting (clang-format)
+
+| Key Binding | Description                     |
+|-------------+---------------------------------|
+| ~SPC m = =~ | format current region or buffer |
+| ~SPC m = f~ | format current function         |

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -9,13 +9,37 @@
 ;;
 ;;; License: GPLv3
 
+;; clang
+
+(defun spacemacs/clang-format-function (&optional style)
+  "Format the current function with clang-format according to STYLE."
+  (interactive)
+  (save-excursion
+    (c-mark-function)
+    (clang-format (region-beginning) (region-end) style)
+    (deactivate-mark) ; If the function is already formatted, then remove the mark
+    (message "Formatted function %s" (c-defun-name))))
+
+(defun spacemacs/clang-format-region-or-buffer (&optional style)
+  "Format the current region or buffer with clang-format according to STYLE."
+  (interactive)
+  (save-excursion
+    (if (region-active-p)
+        (progn
+          (clang-format (region-beginning) (region-end) style)
+          (message "Formatted region"))
+      (progn
+        (clang-format (point-min) (point-max) style)
+        (message "Formatted buffer %s" (buffer-name))))))
+
 (defun spacemacs//clang-format-on-save ()
-  "Format buffers with ClangFormat when they get saved."
+  "Format the current buffer with clang-format on save when
+`c-c++-enable-clang-format-on-save' is non-nil."
   (when c-c++-enable-clang-format-on-save
-    (clang-format-buffer)))
+    (spacemacs/clang-format-buffer)))
 
 (defun spacemacs/clang-format-on-save ()
-  "Add auto-save hook for ClangFormat."
+  "Add before-save hook for clang-format."
   (add-hook 'before-save-hook 'spacemacs//clang-format-on-save nil t))
 
 (defun spacemacs/company-more-than-prefix-guesser ()

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -65,8 +65,14 @@
   (use-package clang-format
     :if c-c++-enable-clang-support
     :init
-    (when c-c++-enable-clang-format-on-save
-      (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks))))
+    (progn
+      (when c-c++-enable-clang-format-on-save
+        (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks))
+      (dolist (mode c-c++-modes)
+        (spacemacs/declare-prefix-for-mode mode "m=" "format")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "==" 'spacemacs/clang-format-region-or-buffer
+          "=f" 'spacemacs/clang-format-function)))))
 
 (defun c-c++/init-cmake-ide ()
   (use-package cmake-ide)


### PR DESCRIPTION
Solve part of #7628. Additionally, #7629 is no longer needed.

Add support for formatting lines, functions, and buffers with clang-format. 
Each function produces a clear message on success.

The README was updated to reflect the usage of the new key bindings. References
to binding clang-format to the tab key were removed.
