### PR TITLE
osx: add option to separate OSX pasteboard from kill-ring

### DIFF
--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -4,21 +4,46 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#philosophy][Philosophy]]
 - [[#install][Install]]
   - [[#layer][Layer]]
     - [[#use-with-non-us-keyboard-layouts][Use with non-US keyboard layouts]]
     - [[#define-words-using-os-x-dictionary][Define words using OS X Dictionary]]
+    - [[#separate-osx-and-spacemacs-clipboards][Separate OSX and spacemacs clipboards]]
   - [[#coreutils][Coreutils]]
 - [[#key-bindings][Key Bindings]]
 - [[#future-work][Future Work]]
 
 * Description
-Spacemacs is not just emacs+vim. It can have OSX keybindings too! This layer
-globally defines common OSX keybindings. ~⌘~ is set to ~hyper~ and ~⌥~ is set to
-~meta~. Aside from that, there's nothing much, really.
 
-While in =dired= this layer will try to use =gls= instead of =ls=.
+Spacemacs is not just emacs+vim. It can have OSX keybindings too! This layer
+adds tools for better integration in OSX.
+
+** Features:
+
+- Provides common OSX keybindings, such as: ~⌘ =~ and ~⌘ -~ to change font size;
+  ~⌘ q~ to quit Spacemacs; ~⌘ c~, ~⌘ x~ and ~⌘ v~ for copy/cut/paste; ~⌘ a~ for
+  select all. Refer to the overview of keybindings below.
+
+- Provides closer integration with OSX, such as: reveal files in Finder; use the
+  OSX trash via the Finder API (only on Emacs from MacPorts); use =mdfind=
+  instead of =locate= in helm.
+
+- Enables remapping of the modifier keys found on Mac keyboards, with the option
+  to treat the right modifier key differently from the left one. By default ~⌘~
+  is set to ~hyper~ and ~⌥~ is set to ~meta~.
+
+- Provides a transient interface to =launchctl=, mapped by default to ~SPC a l~.
+
+- Provides option to use the OSX dictionary as default instead of wordnet.
+
+- Provides option to unify or separate the OSX pasteboard from the spacemacs
+  kill-ring. By default they are unified, both in graphical and text mode.
+
+- While in =dired= this layer will try to use =gls= instead of =ls=.
+
+- Uses the OSX Emoji font for emoticons.
 
 * Philosophy
 While this layer enables common OSX bindings, it does not implement OSX
@@ -93,6 +118,41 @@ You can disable it by setting =osx-use-dictionary-app= variable to =nil=:
      (osx :variables osx-use-dictionary-app nil)))
 #+END_SRC
 
+*** Separate OSX and spacemacs clipboards
+
+By default this layer treats the OSX pasteboard and the spacemacs kill-ring as a
+single clipboard. It supports treating them as separate clipboards by setting
+the =osx-use-separate-clipboards= variable to =t=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+     (osx :variables osx-use-separate-clipboards t)))
+#+END_SRC
+
+This setting can be toggled with ~SPC t R~.
+
+When this feature is disabled, this layer treats the OSX system pasteboard and
+the spacemacs kill-ring as a single clipboard: a region killed in spacemacs will
+be readily available for pasting into another application, and conversely a text
+copied from another application can be readily yanked into spacemacs. The usual
+OSX keybindings (~⌘ c~, ~⌘ x~ and ~⌘ v~) and the spacemacs commands can be used
+interchangeably to operate on the clipboard.
+
+When this feature is enabled, the keybindings ~⌘ c~, ~⌘ x~ and ~⌘ v~ operate on
+the OSX pasteboard, while the spacemacs commands operate on the spacemacs
+kill-ring.
+
+NOTE: when spacemacs is started in graphical mode, the value of this setting has
+no impact on spacemacs commands that directly operate on the system clipboard,
+such as ="+y= and ="+d= -- they will always operate on the system clipboard.
+
+NOTE: when spacemacs is started in text mode (i.e. in a terminal), the
+keybindings involving the command key (~⌘~) are not propagated from the terminal
+to spacemacs, meaning the keybindings ~⌘ c~, ~⌘ x~ and ~⌘ v~ do not work.
+Therefore, when the feature is enabled (i.e. separate clipboards), you will have
+to use the capabilities of your terminal to copy/paste. ="+y= and ="+d= do not
+work.
+
 ** Coreutils
 To get =gls= install coreutils homebrew:
 
@@ -102,25 +162,29 @@ To get =gls= install coreutils homebrew:
 
 * Key Bindings
 
-| Key Binding | Description                 |
-|-------------+-----------------------------|
-| ~⌘ =~       | Scale up text               |
-| ~⌘ -~       | Scale down text             |
-| ~⌘ q~       | Quit                        |
-| ~⌘ v~       | Paste                       |
-| ~⌘ c~       | Copy                        |
-| ~⌘ x~       | Cut                         |
-| ~⌘ a~       | Select all                  |
-| ~⌘ w~       | Close window                |
-| ~⌘ W~       | Close frame                 |
-| ~⌘ n~       | New frame                   |
-| ~⌘ `~       | Other frame                 |
-| ~⌘ z~       | Undo                        |
-| ~⌘ Z~       | Redo                        |
-| ~⌃ ⌘ f~     | Toggle fullscreen           |
-| ~SPC x w d~ | Define word under the point |
+| Key Binding | Description                              |
+|-------------+------------------------------------------|
+| ~⌘ =~       | Scale up text                            |
+| ~⌘ -~       | Scale down text                          |
+| ~⌘ 0~       | Reset text size                          |
+| ~⌘ q~       | Quit                                     |
+| ~⌘ v~       | Paste                                    |
+| ~⌘ c~       | Copy                                     |
+| ~⌘ x~       | Cut                                      |
+| ~⌘ a~       | Select all                               |
+| ~⌘ w~       | Close window                             |
+| ~⌘ W~       | Close frame                              |
+| ~⌘ n~       | New frame                                |
+| ~⌘ `~       | Other frame                              |
+| ~⌘ z~       | Undo                                     |
+| ~⌘ Z~       | Redo                                     |
+| ~⌘ s~       | Save buffer                              |
+| ~⌘ N~       | Select window N (N between 1 and 9)      |
+| ~⌃ ⌘ f~     | Toggle fullscreen                        |
+| ~SPC x w d~ | Define word under the point              |
+| ~SPC a l~   | Open transient interface for =launchctl= |
+| ~SPC t R~   | Toggle separate clipboards               |
 
 * Future Work
 - Allow user to choose from either ~hyper~ or ~super~ as ~⌘~. This is an option
   that is supported cross-platform.
-- Configurable option to keep the OSX and spacemacs clipboards separate

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -60,6 +60,26 @@
 (defvar osx-use-dictionary-app t
   "If non nil use osx dictionary app instead of wordnet")
 
+(defvar osx-use-separate-clipboards nil
+  "If non nil emacs kill-ring is separate from system clipboard.
+   With separate clipboards command-x/c/v interact with system
+   clipboard, while other commands interact with emacs kill-ring.
+   Default: `nil'.")
+
+;; Initialize sane defaults
+(if osx-use-separate-clipboards
+    (osx/enable-separate-clipboards)
+  (osx/disable-separate-clipboards))
+
+;; Add spacemacs toggle for separate clipboards
+(spacemacs|add-toggle separate-clipboards
+  :status osx-use-separate-clipboards
+  :on (osx/enable-separate-clipboards)
+  :off (osx/disable-separate-clipboards)
+  :documentation "Toggle treating OSX pasteboard and spacemacs kill-ring as
+separate clipboards."
+  :evil-leader "tR")
+
 ;; Use the OS X Emoji font for Emoticons
 (when (fboundp 'set-fontset-font)
   (set-fontset-font "fontset-default"

--- a/layers/+os/osx/funcs.el
+++ b/layers/+os/osx/funcs.el
@@ -16,3 +16,27 @@ Useful when setting `osx-dictionary-dictionary-choice'."
   (interactive)
   (message (shell-command-to-string
      (format "%s -l" (osx-dictionary-cli-find-or-recompile)))))
+
+(defun osx/enable-separate-clipboards ()
+  "Enable treating OSX pasteboard and spacemacs kill-ring as
+separate clipboards."
+  (interactive)
+  (when (and (spacemacs/system-is-mac)
+             (not (display-graphic-p))
+             (fboundp 'turn-off-pbcopy))
+    (turn-off-pbcopy))
+  (setq select-enable-clipboard nil)
+  (setq osx-use-separate-clipboards t)
+  (message "Now using separate clipboards."))
+
+(defun osx/disable-separate-clipboards ()
+  "Disable treating OSX pasteboard and spacemacs kill-ring as
+separate clipboards."
+  (interactive)
+  (when (and (spacemacs/system-is-mac)
+             (not (display-graphic-p))
+             (fboundp 'turn-on-pbcopy))
+    (turn-on-pbcopy))
+  (setq select-enable-clipboard t)
+  (setq osx-use-separate-clipboards nil)
+  (message "Now using a unified clipboard."))

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -63,20 +63,24 @@ other than the three sane values listed above."
                             (alt   . "A-")))))
         (when found (kbd (concat (cdr found) keys)))))
 
+    ;; Keybindings for copy/cut/paste
+    ;; Uses the + register to operate on the system pasteboard
+    (global-set-key (kbd-mac-command "v") (kbd "C-r +"))
+    (global-set-key (kbd-mac-command "c") (kbd "\"+y"))
+    (global-set-key (kbd-mac-command "x") (kbd "\"+d"))
+
     ;; Keybindings
     (global-set-key (kbd-mac-command "=") 'spacemacs/scale-up-font)
     (global-set-key (kbd-mac-command "-") 'spacemacs/scale-down-font)
     (global-set-key (kbd-mac-command "0") 'spacemacs/reset-font-size)
     (global-set-key (kbd-mac-command "q") 'save-buffers-kill-terminal)
-    (global-set-key (kbd-mac-command "v") 'yank)
-    (global-set-key (kbd-mac-command "c") 'evil-yank)
     (global-set-key (kbd-mac-command "a") 'mark-whole-buffer)
-    (global-set-key (kbd-mac-command "x") 'kill-region)
     (global-set-key (kbd-mac-command "w") 'delete-window)
     (global-set-key (kbd-mac-command "W") 'delete-frame)
     (global-set-key (kbd-mac-command "n") 'make-frame)
     (global-set-key (kbd-mac-command "`") 'other-frame)
     (global-set-key (kbd-mac-command "z") 'undo-tree-undo)
+    (global-set-key (kbd-mac-command "Z") 'undo-tree-redo)
     (global-set-key (kbd-mac-command "s")
                     (lambda ()
                       (interactive)
@@ -93,7 +97,6 @@ other than the three sane values listed above."
     (global-set-key (kbd-mac-command "8") 'winum-select-window-8)
     (global-set-key (kbd-mac-command "9") 'winum-select-window-9)
 
-    (global-set-key (kbd-mac-command "Z") 'undo-tree-redo)
     (global-set-key (kbd-mac-command "C-f") 'spacemacs/toggle-frame-fullscreen)
     (global-set-key (kbd "M-s-h") 'ns-do-hide-others)
 

--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -105,7 +105,9 @@
 
 (defun osx/init-pbcopy ()
   (use-package pbcopy
-    :if (and (spacemacs/system-is-mac) (not (display-graphic-p)))
+    :if (and (spacemacs/system-is-mac)
+             (not (display-graphic-p))
+             (not osx-use-separate-clipboards))
     :init (turn-on-pbcopy)))
 
 (defun osx/init-reveal-in-osx-finder ()


### PR DESCRIPTION
This commit adds a new option `osx-use-separate-clipboards` to the `osx`
layer. When set to non nil, the layer treats the OSX pasteboard separate
from the spacemacs kill-ring. Default is `nil`, which is the same
behaviour as without this commit, hence not expecting any breaking
changes.

This commit also includes changes to the README file, in response to a
previously failing test (document must have a `Features:` section).

Fixes #6533
Fixes #5750