### PR TITLE
Python: Fix pyenv-executable-find in presence of pyenv-which-ext.

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -17,12 +17,17 @@
   (highlight-lines-matching-regexp "\\(pdb\\|ipdb\\|pudb\\|wdb\\).set_trace()"))
 
 (defun spacemacs/pyenv-executable-find (command)
-  "Find executable taking pyenv shims into account."
+  "Find executable taking pyenv shims into account.
+If the executable is a system executable and not in the same path
+as the pyenv version then also return nil. This works around https://github.com/pyenv/pyenv-which-ext
+"
   (if (executable-find "pyenv")
       (progn
-        (let ((pyenv-string (shell-command-to-string (concat "pyenv which " command))))
-          (unless (string-match "not found" pyenv-string)
-            (string-trim pyenv-string))))
+        (let ((pyenv-string (shell-command-to-string (concat "pyenv which " command)))
+              (pyenv-version-name (string-trim (shell-command-to-string "pyenv version-name"))))
+          (and (not (string-match "not found" pyenv-string))
+               (string-match pyenv-version-name (string-trim pyenv-string))
+                 (string-trim pyenv-string))))
     (executable-find command)))
 
 (defun spacemacs//python-setup-shell (&rest args)


### PR DESCRIPTION
Pyenv-which-ext falls back to the system executable if a executable is not found in the current environment but is installed on the system. This meant that it would always try to execute e.g. the system `ipython` if `ipython` was not installed in a certain environment. 

This PR should fix the problem since it only selects the pyenv executable if it is in the same path as the currently activated environment.