### PR TITLE
core: mocker: Fall back on cl-flet instead of flet

### DIFF
--- a/core/libs/mocker.el
+++ b/core/libs/mocker.el
@@ -38,7 +38,7 @@
   (if (require 'dflet nil t)
       (defalias 'mocker-flet 'dflet)
     ;; fallback to regular flet, hoping it's still there
-    (defalias 'mocker-flet 'flet)))
+    (defalias 'mocker-flet 'cl-flet)))
 
 (defvar mocker-mock-default-record-cls 'mocker-record)
 


### PR DESCRIPTION
The `flet` function has been deprecated and has been replaced with `cl-flet`.