### PR TITLE
emacs-lisp: Speed up semantic

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -201,7 +201,10 @@
 (defun emacs-lisp/post-init-semantic ()
   (add-hook 'emacs-lisp-mode-hook 'semantic-mode)
   (with-eval-after-load 'semantic
-    (semantic-default-elisp-setup)))
+    (semantic-default-elisp-setup)
+    (setq-mode-local emacs-lisp-mode
+                     semanticdb-find-default-throttle
+                     '(file local project unloaded system))))
 
 (defun emacs-lisp/post-init-srefactor ()
   (add-hook 'emacs-lisp-mode-hook 'spacemacs/lazy-load-srefactor)


### PR DESCRIPTION
Resolve #1907.

Emacs 25 sets `semanticdb-find-default-throttle` as a mode-local variable in
`emacs-lisp-mode` and includes the `omniscient` throttle which slows down indexing.
Let's override the mode-local variable so it doesn't include the `omniscient`
throttle.

See #7736 for additional context.