### PR TITLE
Add SPC-m-t-R keybinding for org-table-iterate

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -54,7 +54,7 @@ This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
 
 ** BibTeX
 For more extensive support of references through BibTeX files, have a look at
-the [[../../+lang/bibtex/README.org][BibTeX layer]].
+the [[https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Blang/bibtex/README.org][BibTeX layer]].
 
 ** Important Note
 Since version 0.104, spacemacs uses the =org= version from the org ELPA

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -370,6 +370,7 @@ are also available.
 | ~SPC m t N~   | Use the table.el package to insert a new table                             |
 | ~SPC m t p~   | Plot the table using org-plot/gnuplot                                      |
 | ~SPC m t r~   | Recalculate the current table line by applying all stored formulas         |
+| ~SPC m t R~   | Recalculate the entire current table by applying all stored formulas       |
 | ~SPC m t s~   | Sort table lines according to the column at point                          |
 | ~SPC m t t f~ | Toggle the formula debugger in tables                                      |
 | ~SPC m t t o~ | Toggle the display of Row/Column numbers in tables                         |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -242,6 +242,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "tn" 'org-table-create
         "tN" 'org-table-create-with-table.el
         "tr" 'org-table-recalculate
+        "tR" 'org-table-iterate
         "ts" 'org-table-sort-lines
         "ttf" 'org-table-toggle-formula-debugger
         "tto" 'org-table-toggle-coordinate-overlays


### PR DESCRIPTION
This adds a keybinding for `org-table-iterate`, which recalculates the entire table by iterating over it re-evaluating rows until the table's content does not change.

Currently, Spacemacs only has a binding for org-table-recalculate, which recalculates one row at a time. I thought capital R made sense for this, but am open to suggestions.