### PR TITLE
Remove R repl binding C-d to delete-char

### DIFF
--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -115,7 +115,8 @@
         "cn" 'ess-noweb-next-chunk))
     (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
     (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
-    (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)))
+    (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)
+    (define-key inferior-ess-mode-map (kbd "C-d") nil)))
 
 (defun ess/init-ess-R-data-view ())
 


### PR DESCRIPTION
This removes the keybinding of `C-d` to `delete-char` within the R repl buffer (`inferior-ess-mode`).

Currently, `C-d` is bound to `delete-char` in `inferior-ess-mode-map`, which overrides the vim-style motion `evil-scroll-down` within the R repl buffer. The PR fixes this behavior.