### PR TITLE
Add insert commands from sh-script package to major mode menu

### DIFF
--- a/layers/+lang/shell-scripts/README.org
+++ b/layers/+lang/shell-scripts/README.org
@@ -40,6 +40,16 @@ In order to enable =sh= scripts style checking, install [[https://github.com/ope
 
 | Key Binding | Description                                               |
 |-------------+-----------------------------------------------------------|
-| ~SPC i !~   | insert shebang in a script file                           |
 | ~SPC m \~   | insert end-of-line backslashes to the lines in the region |
-
+| ~SPC i !~   | insert shebang in a script file                           |
+| ~SPC m i !~ | insert shebang in a script file                           |
+| ~SPC m i c~ | insert switch case statement if supported by shell        |
+| ~SPC m i i~ | insert if statement if supported by shell                 |
+| ~SPC m i f~ | insert function definition if supported by shell          |
+| ~SPC m i o~ | insert for loop if supported by shell                     |
+| ~SPC m i e~ | insert an indexed for loop if supported by shell          |
+| ~SPC m i w~ | insert while loop if supported by shell                   |
+| ~SPC m i r~ | insert repeat loop if supported by shell                  |
+| ~SPC m i s~ | insert select loop if supported by shell                  |
+| ~SPC m i u~ | insert until loop if supported by shell                   |
+| ~SPC m i g~ | insert a getopts while loop if supported by shell         |

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -38,8 +38,8 @@
 
 (defun shell-scripts/init-flycheck-bashate ()
   (use-package flycheck-bashate
-  :defer t
-  :init (add-hook 'sh-mode-hook 'flycheck-bashate-setup)))
+    :defer t
+    :init (add-hook 'sh-mode-hook 'flycheck-bashate-setup)))
 
 (defun shell-scripts/init-fish-mode ()
   (use-package fish-mode
@@ -50,8 +50,23 @@
     :defer t
     :init
     (progn
+      ;; Add meaningful names for prefix categories
+      (spacemacs/declare-prefix-for-mode 'sh-mode "mi" "insert")
+      (spacemacs/declare-prefix-for-mode 'sh-mode "mg" "goto")
+
+      ;; Add standard key bindings for insert commands
       (spacemacs/set-leader-keys-for-major-mode 'sh-mode
-        "\\" 'sh-backslash-region)
+        "\\" 'sh-backslash-region
+        "ic" 'sh-case
+        "ii" 'sh-if
+        "if" 'sh-function
+        "io" 'sh-for
+        "ie" 'sh-indexed-loop
+        "iw" 'sh-while
+        "ir" 'sh-repeat
+        "is" 'sh-select
+        "iu" 'sh-until
+        "ig" 'sh-while-getopts)
 
       ;; Use sh-mode when opening `.zsh' files, and when opening Prezto runcoms.
       (dolist (pattern '("\\.zsh\\'"
@@ -80,7 +95,10 @@
     :defer t
     :init
     (progn
+      ;; Insert shebang must be available for non shell modes like python or
+      ;; groovy but also in the major mode menu with shell specific inserts
+      (spacemacs/set-leader-keys-for-major-mode 'sh-mode
+        "i!" 'spacemacs/insert-shebang)
       (spacemacs/set-leader-keys "i!" 'spacemacs/insert-shebang)
       ;; we don't want to insert shebang lines automatically
       (remove-hook 'find-file-hook 'insert-shebang))))
-


### PR DESCRIPTION
The shell-scripts layer provides the sh-script package which defines a lot of useful functions to insert standard script blocks like case statements or specific loops. However those are not bound to the major-mode menu and will probably be overlooked by all who do not read the mode description.

I have therefore added those to the major mode menu in the category `mi insert`. I have also added a binding to the "insert-shebang" function in there though a binding for this function is already available in `spc i !` I think it should also be mentioned in the major-mode menu as most users will only have a look there.