### PR TITLE
fixed helm transient state swoop edit

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -159,7 +159,9 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
   (interactive)
   (cond
    ((string-equal "*helm-ag*" helm-buffer)
-    (helm-ag-edit))))
+    (helm-ag-edit))
+   ((string-equal "*Helm Swoop*" helm-buffer)
+    (helm-swoop-edit))))
 
 (defun spacemacs//helm-navigation-ts-on-enter ()
   "Initialization of helm transient-state."


### PR DESCRIPTION
As mentioned in #9322 the `edit occurrences` command of the helm transient state is not calling `helm-swoop-edit` when using helm swoop. This fixes that.