### PR TITLE
Load org-projectile lazily, after org-capture

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -549,7 +549,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (spacemacs/set-leader-keys
         "aop" 'org-projectile/capture
         "po" 'org-projectile/goto-todos)
-      (require 'org-projectile))
+      (with-eval-after-load 'org-capture
+        (require 'org-projectile)))
     :config
     (if (file-name-absolute-p org-projectile-file)
         (progn


### PR DESCRIPTION
Fixes #9367 and prevents org from loading on startup. This was a regression from https://github.com/syl20bnr/spacemacs/commit/6063466231ce5e209aacd2de612e53390a25c442

@IvanMalison was there a reason this change needed to be made? I was still able to use org-projectile after restoring this.