### PR TITLE
Defer git-gutter loading

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -54,7 +54,7 @@
       ;; If you enable global minor mode
       (when (and (eq version-control-diff-tool 'git-gutter)
                  version-control-global-margin)
-        (global-git-gutter-mode t))
+        (run-with-idle-timer 1 nil 'global-git-gutter-mode t))
       (setq git-gutter:update-interval 2
             git-gutter:modified-sign " "
             git-gutter:added-sign "+"
@@ -105,14 +105,14 @@
 
 (defun version-control/init-git-gutter+ ()
   (use-package git-gutter+
-    :commands (global-git-gutter+-mode git-gutter+-mode)
+    :commands (global-git-gutter+-mode git-gutter+-mode git-gutter+-refresh)
     :init
     (progn
       ;; If you enable global minor mode
       (when (and (eq version-control-diff-tool 'git-gutter+)
                  version-control-global-margin)
         (add-hook 'magit-pre-refresh-hook 'git-gutter+-refresh)
-        (global-git-gutter+-mode t))
+        (run-with-idle-timer 1 nil 'global-git-gutter+-mode t))
       (setq
        git-gutter+-modified-sign " "
        git-gutter+-added-sign "+"


### PR DESCRIPTION
As it was, git-gutter and git-gutter+ get started as soon as emacs starts if
they're enabled. This added about 500ms to startup time on my machine, so this
will instead defer it until emacs has been idle for 5 seconds.

This could theoretically be an option, but I would guess that most would rather have startup time over an immediate gutter.

I'm also open to other ideas on how to defer its loading.