### PR TITLE
adds global evil-leader mappings `aokr` for `org-resolve-clocks`

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -265,6 +265,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC a o k i~ | org clock in last              |
 | ~SPC a o k j~ | org jump to current clock      |
 | ~SPC a o k o~ | org clock out                  |
+| ~SPC a o k r~ | org resolve clocks             |
 | ~SPC a o l~   | org store link                 |
 | ~SPC a o m~   | org tags view                  |
 | ~SPC a o o~   | org agenda                     |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -290,6 +290,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "aoki" 'org-clock-in-last
         "aokj" 'org-clock-jump-to-current-clock
         "aoko" 'org-clock-out
+        "aokr" 'org-resolve-clocks
         "aol" 'org-store-link
         "aom" 'org-tags-view
         "aoo" 'org-agenda


### PR DESCRIPTION
Hi,

I find `org-resolve-clocks` quite useful and  I would like to add a global evil-leader mapping for `aokr`.

Would you be fine with this addition?

Best wishes & thank in advance for your time