### PR TITLE
Fix typo in cscope find-calling-this-function binding

### DIFF
--- a/layers/+tags/cscope/packages.el
+++ b/layers/+tags/cscope/packages.el
@@ -48,7 +48,7 @@
       "Setup `helm-cscope' for MODE"
       (spacemacs/set-leader-keys-for-major-mode mode
         "gc" 'helm-cscope-find-called-function
-        "gC" 'helm-cscope-find-calling-this-funtcion
+        "gC" 'helm-cscope-find-calling-this-function
         "gd" 'helm-cscope-find-global-definition
         "ge" 'helm-cscope-find-egrep-pattern
         "gf" 'helm-cscope-find-this-file


### PR DESCRIPTION
Fixes a small typo in the cscope layer for the helm-cscope-find-calling-this-function binding