### PR TITLE
Fix native full-screen

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -729,7 +729,7 @@ toggling fullscreen."
   (interactive)
   (if dotspacemacs-fullscreen-use-non-native
       (spacemacs/toggle-frame-fullscreen-non-native)
-    (toggle-frame-fullscreen)))
+    (spacemacs/toggle-fullscreen)))
 
 (defun spacemacs/toggle-fullscreen ()
   "Toggle full screen on X11 and Carbon"


### PR DESCRIPTION
I couldn't get native fullscreen on startup working. The relevant dotspacemacs settings previously were as below. With `dotspacemacs-fullscreen-at-startup t` and `dotspacemacs-fullscreen-use-non-native nil` I expected native fullscreen at startup.

``` emacs-lisp
   ;; If non nil the frame is fullscreen when Emacs starts up. (default nil)
   ;; (Emacs 24.4+ only)
   dotspacemacs-fullscreen-at-startup t
   ;; If non nil `spacemacs/toggle-fullscreen' will not use native fullscreen.
   ;; Use to disable fullscreen animations in OSX. (default nil)
   dotspacemacs-fullscreen-use-non-native nil
   ;; If non nil the frame is maximized when Emacs starts up.
   ;; Takes effect only if `dotspacemacs-fullscreen-at-startup' is nil.
   ;; (default nil) (Emacs 24.4+ only)
   dotspacemacs-maximized-at-startup nil
```

Looked at the fullscreen startup code in `layers/+distributions/spacemacs-base/config.el` which calls `spacemacs/toggle-frame-fullscreen`:

```
;; Fullscreen/maximize frame on startup
(if dotspacemacs-fullscreen-at-startup
    ;; spacemacs/toggle-fullscreen-frame-on is NOT available during the startup,
    ;; but IS available during the subsequent config reloads
    (if (fboundp 'spacemacs/toggle-fullscreen-frame-on)
        (spacemacs/toggle-fullscreen-frame-on)
      (spacemacs/toggle-frame-fullscreen)))
```

However in the case where `dotspacemacs-fullscreen-use-non-native` is not true i.e. we want native fullscreen, then `spacemacs/toggle-frame-fullscreen` is called instead of `spacemacs/toggle-fullscreen`.

```
(defun spacemacs/toggle-frame-fullscreen ()
  "Respect the `dotspacemacs-fullscreen-use-non-native' variable when
toggling fullscreen."
  (interactive)
  (if dotspacemacs-fullscreen-use-non-native
      (spacemacs/toggle-frame-fullscreen-non-native)
    (toggle-frame-fullscreen)))
```
