### PR TITLE
Remove obsolete purpose-conf name argument

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -185,8 +185,7 @@ Popwin's settings are taken from `popwin:special-display-config'."
                 (cond ((symbolp pattern) mode-purposes)
                       ((plist-get settings :regexp) regexp-purposes)
                       (t name-purposes))))
-    (purpose-conf "pupo"
-                  :mode-purposes mode-purposes
+    (purpose-conf :mode-purposes mode-purposes
                   :name-purposes name-purposes
                   :regexp-purposes regexp-purposes)))
 


### PR DESCRIPTION
This message is shown when Spacemacs starts:
>../../Users/Username/AppData/Roaming/.emacs.d/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el: Obsolete name arg "pupo" to constructor purpose-conf

The name argument, seems to only be needed for Emacs <= 24.3, according to this
line in the emacs-purpose package:
>;; the name arg ("purpose-x-code1") is necessary for Emacs 24.3 and older

source:
https://github.com/bmag/emacs-purpose/blob/00ddafcf4802e7430ca709769b888656a6eb421b/window-purpose-x.el#L71

The minimum version supported by Spacemacs is 24.4.