### PR TITLE
Add the dotspacemacs-directory (~/.spacemacs.d) to the load-path

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -35,6 +35,10 @@
 SPACEMACSDIR environment variable. If neither of these
 directories exist, this variable will be nil.")
 
+  ;; add dotspacemacs-directory to the load-path if present
+  (when dotspacemacs-directory
+    (add-to-load-path dotspacemacs-directory))
+
   (defvar dotspacemacs-filepath
     (let ((spacemacs-dir-init (when dotspacemacs-directory
                                  (concat dotspacemacs-directory


### PR DESCRIPTION
Users who choose to store they dotfile in ~/.spacemacs.d most likely store there also other files and want an ability to load them. Enabling it during startup makes the overall experience better.