### PR TITLE
Check if dotspacemacs-directory-snippets-dir exists before adding it

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -204,7 +204,10 @@
              (dotspacemacs-directory-snippets-dir (when dotspacemacs-directory
                                                     (expand-file-name
                                                      "snippets"
-                                                     dotspacemacs-directory))))
+                                                     dotspacemacs-directory)))
+             (dotspacemacs-directory-snippets-dir
+              (when (file-accessible-directory-p dotspacemacs-directory-snippets-dir)
+                dotspacemacs-directory-snippets-dir)))
         (setq yas-snippet-dirs nil)
         ;; ~/.emacs.d/layers/auto-completion/snippets
         (push spacemacs-layer-snippets-dir yas-snippet-dirs)


### PR DESCRIPTION
dotspacemacs-directory-snippets-dir contains a path to a directory with yas snippets in ~/.spacemacs.d (or arbitrary picked dotspacemacs direcotry). However, while it's not always present (user has to create it manually), it is always checked when yas is loaded what generates errors.

This diffs forces checking whether the assumed path exists before adding it to the yas-snippet-dirs.