### PR TITLE
Convert remote file name to local name, stripping trampy stuff

### DIFF
--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -69,4 +69,5 @@
   (interactive)
   (shell-command
    (format "go run %s"
-           (shell-quote-argument (buffer-file-name (buffer-base-buffer))))))
+           (shell-quote-argument (or (file-remote-p (buffer-file-name (buffer-base-buffer)) 'localname)
+                                     (buffer-file-name (buffer-base-buffer)))))))


### PR DESCRIPTION
This strips the remote part of a TRAMP path for go run. Fixes functionality of ``SPC m x x`` w/ remote systems