### PR TITLE
Fix reference to cfgl-package-distant-p

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1481,7 +1481,7 @@ wether the declared layer is an used one or not."
                      (let* ((pkg-name (if (listp x) (car x) x))
                             (pkg (configuration-layer/get-package pkg-name)))
                        (cfgl-package-set-property pkg :lazy-install nil)
-                       (when (cfgl-package-is-distant pkg)
+                       (when (cfgl-package-distant-p pkg)
                          pkg-name)))
                    (oref layer :packages)))))
       (let ((last-buffer (current-buffer))


### PR DESCRIPTION
Ran into this when installing the OCaml layer. The function it's calling doesn't seem to be defined, but the commit it's from mentions what I've replaced it with, and fixed the failed layer install.