### PR TITLE
Clear both / and C-s search highlights with SPC s c

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -47,9 +47,8 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
 (defun spacemacs/evil-search-clear-highlight ()
   "Clear evil-search or evil-ex-search persistent highlights."
   (interactive)
-  (case evil-search-module
-    ('isearch (evil-search-highlight-persist-remove-all))
-    ('evil-search (evil-ex-nohighlight))))
+  (evil-search-highlight-persist-remove-all) ; `C-s' highlights
+  (evil-ex-nohighlight))                     ; `/' highlights
 
 (defun spacemacs//adaptive-evil-highlight-persist-face ()
   (set-face-attribute 'evil-search-highlight-persist-highlight-face nil


### PR DESCRIPTION
When `evil-search-module` is set to:
evil-search:
Then `/` search highlights are cleared by pressing: `SPC s c`,
and `C-s` highlights are cleared with `:noh`.

isearch:
Then `/` highlights are cleared with `M-x evil-ex-nohighlight`,
and `C-s` highlights are cleared with both `SPC s c` and `:noh`.