### PR TITLE
BugFix: kill buffer shall return to *docker-containers*

### DIFF
--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -34,7 +34,8 @@
         "DP" 'docker-push
         "Dp" 'docker-pause
         "Dr" 'docker-restart
-        "Ds" 'docker-start)))
+        "Ds" 'docker-start)
+      (push "\\*docker.+\\*" spacemacs-useful-buffers-regexp)))
   (with-eval-after-load 'docker-containers
     (evilified-state-evilify-map docker-containers-mode-map
       :mode docker-containers-mode))


### PR DESCRIPTION
Hi,

This PR fixes the bug described below, I'm not sure if this is the right place, I hope is fine.

All best & thanks
Francesc
 
----------------
#### Description :octocat:
After killing a log buffer from the docker layer I see the scratch buffer instead of the previous buffer.

#### Reproduction guide :beetle:
- Start Emacs
- `SPC D c`: open docker containers buffer  =*docker-containers*= 
- `L`:       open log popup for a running container               
- `L`:       open the log                                         
- `SPC b d`: kill the buffer                                      

*Observed behaviour:* :eyes: :broken_heart:
The `scratch` buffer is shown                        

*Expected behaviour:* :heart: :smile:
I would like to see again the `*docker-containers*` buffer               
