### PR TITLE
Remove themes that were deleted from Melpa

### DIFF
--- a/layers/+themes/themes-megapack/packages.el
+++ b/layers/+themes/themes-megapack/packages.el
@@ -37,7 +37,6 @@
     dracula-theme
     espresso-theme
     farmhouse-theme
-    firebelly-theme
     flatland-theme
     flatui-theme
     gandalf-theme
@@ -64,14 +63,12 @@
     monochrome-theme
     mustang-theme
     naquadah-theme
-    niflheim-theme
     noctilux-theme
     obsidian-theme
     occidental-theme
     omtose-phellack-theme
     oldlace-theme
     organic-green-theme
-    pastels-on-dark-theme
     phoenix-dark-mono-theme
     phoenix-dark-pink-theme
     planet-theme
@@ -99,7 +96,6 @@
     ;; contains error
     ; tommyh-theme
     toxi-theme
-    tronesque-theme
     twilight-anti-bright-theme
     twilight-bright-theme
     twilight-theme


### PR DESCRIPTION
This makes Spacemacs stop checking their existence every time it starts,
which performs a refresh of every package archive and makes startup
slower.

firebelly, niflheim and tronesque were all removed from MELPA because
they either don't have licenses or have licenses that are incompatible
with GPL3.

The relevant commits on MELPA are

melpa/melpa@cf92ce1a2bc92c73071d157e7e223982bbd3f818
melpa/melpa@c3366117f3399660509f62849a88dc8be56a1fef

If the themes are added again in the future, we can simply uncomment the
lines.