### PR TITLE
spacemacs-base: Bind "SPC b l" to buffer-menu-other-window

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2092,6 +2092,8 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC b C-D~     | kill buffers using a regular expression                                  |
 | ~SPC b e~       | erase the content of the buffer (ask for confirmation)                   |
 | ~SPC b h~       | open =*spacemacs*= home buffer                                           |
+| ~SPC b l~       | open the Buffer Menu with a list of all buffers                          |
+| ~SPC u SPC b l~ | open the Buffer Menu listing only the buffers that are visiting a file   |
 | ~SPC b n~       | switch to next buffer avoiding special buffers                           |
 | ~SPC b m~       | open =*Messages*= buffer                                                 |
 | ~SPC u SPC b m~ | kill all buffers and windows except the current one                      |

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -138,6 +138,7 @@
   "b N n" 'spacemacs/new-empty-buffer
   "bP"    'spacemacs/copy-clipboard-to-whole-buffer
   "bp"    'previous-buffer
+  "bl"    'buffer-menu-other-window
   "bR"    'spacemacs/safe-revert-buffer
   "bs"    'spacemacs/switch-to-scratch-buffer
   "bu"    'spacemacs/reopen-killed-buffer


### PR DESCRIPTION
buffer-menu-other-window is a built-in function which opens a list of all buffers on the current session of Emacs. With the universal argument, it opens a list of buffers that are visiting a file.

It works much like "SPC g s": it opens the list on a new window, and can be dismissed with "q".

I've been using this binding for a couple of weeks with no issues. It seems the most natural place to put the command, and I was surprised that the keys were unused.