### PR TITLE
[themes-megapack] Delete themes recently removed from Melpa

### DIFF
--- a/layers/+themes/themes-megapack/packages.el
+++ b/layers/+themes/themes-megapack/packages.el
@@ -37,7 +37,6 @@
     dracula-theme
     espresso-theme
     farmhouse-theme
-    firebelly-theme
     flatland-theme
     flatui-theme
     gandalf-theme
@@ -64,14 +63,12 @@
     monochrome-theme
     mustang-theme
     naquadah-theme
-    niflheim-theme
     noctilux-theme
     obsidian-theme
     occidental-theme
     omtose-phellack-theme
     oldlace-theme
     organic-green-theme
-    pastels-on-dark-theme
     phoenix-dark-mono-theme
     phoenix-dark-pink-theme
     planet-theme
@@ -99,7 +96,6 @@
     ;; contains error
     ; tommyh-theme
     toxi-theme
-    tronesque-theme
     twilight-anti-bright-theme
     twilight-bright-theme
     twilight-theme


### PR DESCRIPTION
It seems Melpa has deleted packages that were not license compatible:

https://github.com/melpa/melpa/commit/c3366117f3399660509f62849a88dc8be56a1fef
https://github.com/melpa/melpa/commit/cf92ce1a2bc92c73071d157e7e223982bbd3f818
