### PR TITLE
Add ivy support to the gtags layer

### DIFF
--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -15,6 +15,7 @@
         asm-mode
         electric-indent-mode
         ggtags
+        counsel-gtags
         helm-gtags
         nasm-mode
         x86-lookup
@@ -65,6 +66,9 @@
 
 (defun asm/post-init-ggtags ()
   (add-hook 'asm-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun asm/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'asm-mode))
 
 (defun asm/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -22,6 +22,7 @@
     flycheck
     gdb-mi
     ggtags
+    counsel-gtags
     helm-cscope
     helm-gtags
     realgud
@@ -119,6 +120,10 @@
      gdb-many-windows t
      ;; Non-nil means display source file containing the main routine at startup
      gdb-show-main t)))
+
+(defun c-c++/post-init-counsel-gtags ()
+  (dolist (mode c-c++-modes)
+    (spacemacs/counsel-gtags-define-keys-for-mode mode)))
 
 (defun c-c++/post-init-helm-gtags ()
   (dolist (mode c-c++-modes)

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -19,6 +19,7 @@
         company
         eldoc
         ggtags
+        counsel-gtags
         helm-gtags
         org
         parinfer
@@ -310,6 +311,9 @@
 
 (defun clojure/post-init-ggtags ()
   (add-hook 'clojure-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun clojure/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'clojure-mode))
 
 (defun clojure/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'clojure-mode))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -14,6 +14,7 @@
         (common-lisp-snippets :requires yasnippet)
         evil
         ggtags
+        counsel
         helm
         helm-gtags
         parinfer
@@ -43,6 +44,9 @@
 
 (defun common-lisp/post-init-ggtags ()
   (add-hook 'common-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun common-lisp/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'common-lisp-mode))
 
 (defun common-lisp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'common-lisp-mode))

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -15,6 +15,7 @@
     csharp-mode
     evil-matchit
     ggtags
+    counsel-gtags
     helm-gtags
     omnisharp
     flycheck
@@ -115,6 +116,9 @@
 
 (defun csharp/post-init-ggtags ()
   (add-hook 'csharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun csharp/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'csharp-mode))
 
 (defun csharp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'csharp-mode))

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -19,6 +19,7 @@
         flycheck
         (flycheck-dmd-dub :requires flycheck)
         ggtags
+        counsel-gtags
         helm-gtags
         ))
 
@@ -54,6 +55,9 @@
 
 (defun d/post-init-ggtags ()
   (add-hook 'd-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun d/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'd-mode))
 
 (defun d/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'd-mode))

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -18,6 +18,7 @@
     flycheck-mix
     flycheck-credo
     ggtags
+    counsel-gtags
     helm-gtags
     ob-elixir
     popwin
@@ -206,6 +207,9 @@
 
 (defun elixir/post-init-ggtags ()
   (add-hook 'elixir-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun elixir/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'elixir-mode))
 
 (defun elixir/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'elixir-mode))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -21,6 +21,7 @@
         evil
         flycheck
         ggtags
+        counsel-gtags
         helm-gtags
         (ielm :location built-in)
         macrostep
@@ -188,6 +189,9 @@
   ;; Make flycheck recognize packages in loadpath
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))
+
+(defun emacs-lisp/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'emacs-lisp-mode))
 
 (defun emacs-lisp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'emacs-lisp-mode))

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -14,6 +14,7 @@
     company
     erlang
     ggtags
+    counsel-gtags
     helm-gtags
     flycheck
     ))
@@ -47,6 +48,9 @@
 
 (defun erlang/post-init-ggtags ()
   (add-hook 'erlang-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun erlang/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'erlang-mode))
 
 (defun erlang/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'erlang-mode))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -13,6 +13,7 @@
       '(
         fsharp-mode
         ggtags
+        counsel-gtags
         helm-gtags
         ))
 
@@ -72,6 +73,9 @@
 
 (defun fsharp/post-init-ggtags ()
   (add-hook 'fsharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun fsharp/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'fsharp-mode))
 
 (defun fsharp/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'fsharp-mode))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -17,6 +17,7 @@
                                             (configuration-layer/package-used-p
                                              'flycheck)))
         ggtags
+        counsel-gtags
         helm-gtags
         exec-path-from-shell
         go-eldoc
@@ -131,6 +132,9 @@
 
 (defun go/post-init-ggtags ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun go/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'go-mode))
 
 (defun go/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'go-mode))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -21,6 +21,7 @@
     ghc
     haskell-mode
     haskell-snippets
+    counsel-gtags
     helm-gtags
     (helm-hoogle :requires helm)
     hindent
@@ -255,6 +256,9 @@
       (yas-load-directory snip-dir)))
 
   (with-eval-after-load 'yasnippet (haskell-snippets-initialize)))
+
+(defun haskell/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'haskell-mode))
 
 (defun haskell/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'haskell-mode))

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -23,6 +23,7 @@
         flyspell
         ggtags
         gradle-mode
+        counsel-gtags
         helm-gtags
         (java-mode :location built-in)
         (meghanada :toggle (not (version< emacs-version "25.1")))
@@ -324,6 +325,9 @@
 (defun java/init-gradle-mode ()
   (use-package gradle-mode
     :defer t))
+
+(defun java/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'java-mode))
 
 (defun java/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'java-mode))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -18,6 +18,7 @@
         evil-matchit
         flycheck
         ggtags
+        counsel-gtags
         helm-gtags
         impatient-mode
         js-doc
@@ -68,6 +69,9 @@
 
 (defun javascript/post-init-ggtags ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun javascript/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'js2-mode))
 
 (defun javascript/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'js2-mode))

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -19,6 +19,7 @@
         flycheck
         flyspell
         ggtags
+        counsel-gtags
         helm-gtags
         (magic-latex-buffer :toggle latex-enable-magic)
         smartparens
@@ -178,6 +179,9 @@
     "rt"    'reftex-toc
     "rT"    'reftex-toc-recenter
     "rv"    'reftex-view-crossref))
+
+(defun latex/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'latex-mode))
 
 (defun latex/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'latex-mode))

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -15,6 +15,7 @@
         (company-lua :requires company)
         flycheck
         ggtags
+        counsel-gtags
         helm-gtags
         lua-mode
         ))
@@ -50,6 +51,9 @@
 
 (defun lua/post-init-ggtags ()
   (add-hook 'lua-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun lua/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'lua-mode))
 
 (defun lua/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'lua-mode))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -16,6 +16,7 @@
    ;; flycheck
    ;; flycheck-ocaml
     ggtags
+    counsel-gtags
     helm-gtags
     merlin
     ocp-indent
@@ -46,6 +47,9 @@
 
 (defun ocaml/post-init-ggtags ()
   (add-hook 'ocaml-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun ocaml/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'ocaml-mode))
 
 (defun ocaml/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'ocaml-mode))

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -12,6 +12,7 @@
 (setq octave-packages
   '(
     ggtags
+    counsel-gtags
     helm-gtags
     (octave :location built-in)
     ))
@@ -35,6 +36,9 @@
 
 (defun octave/post-init-ggtags ()
   (add-hook 'octave-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun octave/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'octave-mode))
 
 (defun octave/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'octave-mode))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -15,6 +15,7 @@
         eldoc
         flycheck
         ggtags
+        counsel-gtags
         helm-gtags
         php-auto-yasnippets
         (php-extras :location (recipe :fetcher github :repo "arnested/php-extras"))
@@ -36,6 +37,9 @@
 
 (defun php/post-init-ggtags ()
   (add-hook 'php-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun php/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'php-mode))
 
 (defun php/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'php-mode))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -20,6 +20,7 @@
     flycheck
     ggtags
     helm-cscope
+    counsel-gtags
     helm-gtags
     (helm-pydoc :requires helm)
     hy-mode
@@ -112,6 +113,9 @@
   (spacemacs|use-package-add-hook xcscope
     :post-init
     (spacemacs/setup-helm-cscope 'python-mode)))
+
+(defun python/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'python-mode))
 
 (defun python/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'python-mode))

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -3,6 +3,7 @@
     company
     company-quickhelp
     ggtags
+    counsel-gtags
     helm-gtags
     racket-mode
     ))
@@ -24,6 +25,9 @@
 
 (defun racket/post-init-ggtags ()
   (add-hook 'racket-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun racket/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'racket-mode))
 
 (defun racket/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'racket-mode))

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -18,6 +18,7 @@
         evil-matchit
         flycheck
         ggtags
+        counsel-gtags
         helm-gtags
         minitest
         org
@@ -86,6 +87,9 @@
 
 (defun ruby/post-init-ggtags ()
   (add-hook 'ruby-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun ruby/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'ruby-mode))
 
 (defun ruby/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'ruby-mode))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -59,6 +59,9 @@
 (defun rust/post-init-ggtags ()
   (add-hook 'rust-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
+(defun rust/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'rust-mode))
+
 (defun rust/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'rust-mode))
 

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -16,6 +16,7 @@
     flycheck
     flyspell
     ggtags
+    counsel-gtags
     helm-gtags
     noflet
     org
@@ -140,6 +141,9 @@ If it's part of a left arrow (`<-'),replace it with the unicode arrow."
 
 (defun scala/post-init-ggtags ()
   (add-hook 'scala-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun scala/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'scala-mode))
 
 (defun scala/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'scala-mode))

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -14,6 +14,7 @@
         company
         geiser
         ggtags
+        counsel-gtags
         helm-gtags
         ))
 
@@ -77,6 +78,9 @@
 
 (defun scheme/post-init-ggtags ()
   (add-hook 'scheme-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun scheme/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'scheme-mode))
 
 (defun scheme/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'scheme-mode))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -16,6 +16,7 @@
         flycheck
         flycheck-bashate
         ggtags
+        counsel-gtags
         helm-gtags
         insert-shebang
         org
@@ -87,6 +88,9 @@
 
 (defun shell-scripts/post-init-ggtags ()
   (add-hook 'sh-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun shell-scripts/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'sh-mode))
 
 (defun shell-scripts/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'sh-mode))

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -13,6 +13,7 @@
     '(
       vimrc-mode
       ggtags
+      counsel-gtags
       helm-gtags
       dactyl-mode
       ))
@@ -43,6 +44,9 @@
 
 (defun vimscript/post-init-ggtags ()
   (add-hook 'vimrc-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun vimscript/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'vimrc-mode))
 
 (defun vimscript/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'vimrc-mode))

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -13,6 +13,7 @@
   '(
     (dos :location local)
     ggtags
+    counsel-gtags
     helm-gtags
     powershell
     ))
@@ -48,6 +49,9 @@
 
 (defun windows-scripts/post-init-ggtags ()
   (add-hook 'dos-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+
+(defun windows-scripts/post-init-counsel-gtags ()
+  (spacemacs/counsel-gtags-define-keys-for-mode 'dos-mode))
 
 (defun windows-scripts/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'dos-mode))

--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -21,12 +21,14 @@
       - [[#pygments-languages-plus-symbol-and-reference-tags][Pygments languages (plus symbol and reference tags)]]
   - [[#eldoc-integration][Eldoc integration]]
 - [[#key-bindings][Key bindings]]
+  - [[#helm][Helm]]
+  - [[#ivy][Ivy]]
 
 * Description
-=helm-gtags= and =ggtags= are clients for GNU Global. GNU Global is a source
-code tagging system that allows querying symbol locations in source code, such
-as definitions or references. Adding the =gtags= layer enables both of these
-modes.
+=counsel-gtags=, =helm-gtags= and =ggtags= are clients for GNU Global. GNU
+Global is a source code tagging system that allows querying symbol locations in
+source code, such as definitions or references. Adding the =gtags= layer enables
+both of these modes.
 
 ** Features:
 - Select any tag in a project retrieved by gtags
@@ -151,9 +153,10 @@ additional control per project.
 Before using the =gtags=, remember to create a GTAGS database by the following
 methods:
 
-- From within Emacs, runs the command =helm-gtags-create-tags=, which is bound
-  to ~SPC m g c~. If the language is not directly supported by GNU Global, you
-  can choose =ctags= or =pygments= as a backend to generate tag database.
+- From within Emacs, run either =counsel-gtags-create-tags= or
+  =helm-gtags-create-tags=, which are bound to ~SPC m g c~. If the language is
+  not directly supported by GNU Global, you can choose =ctags= or =pygments= as
+  a backend to generate tag database.
 
 - From inside terminal, runs gtags at your project root in terminal:
 
@@ -251,6 +254,12 @@ the gtags commands.
 
 | Key Binding | Description                                               |
 |-------------+-----------------------------------------------------------|
+| ~g d~       | jump to the definitions or references of the selected tag |
+
+** Helm
+
+| Key Binding | Description                                               |
+|-------------+-----------------------------------------------------------|
 | ~SPC m g C~ | create a tag database                                     |
 | ~SPC m g f~ | jump to a file in tag database                            |
 | ~SPC m g g~ | jump to a location based on context                       |
@@ -266,3 +275,20 @@ the gtags commands.
 | ~SPC m g S~ | show stack of visited locations                           |
 | ~SPC m g y~ | find symbols                                              |
 | ~SPC m g u~ | manually update tag database                              |
+
+** Ivy
+=counsel-gtags= is currently missing a few minor features compared to
+=helm-gtags=.
+
+| Key Binding | Description                                    |
+|-------------+------------------------------------------------|
+| ~SPC m g C~ | create a tag database                          |
+| ~SPC m g f~ | jump to a file in tag database                 |
+| ~SPC m g g~ | jump to a location based on context            |
+| ~SPC m g d~ | find definitions                               |
+| ~SPC m g n~ | jump to next location in context stack         |
+| ~SPC m g p~ | jump to previous location in context stack     |
+| ~SPC m g r~ | find references                                |
+| ~SPC m g s~ | select any tag in a project retrieved by gtags |
+| ~SPC m g y~ | find symbols                                   |
+| ~SPC m g u~ | manually update tag database                   |

--- a/layers/+tags/gtags/config.el
+++ b/layers/+tags/gtags/config.el
@@ -12,6 +12,11 @@
 (defvar gtags-enable-by-default t
   "Whether or not to enable ggtags-mode.")
 
+(defvar spacemacs--counsel-gtags-dwim-success nil
+  "Stores the return value of `counsel-gtags-dwim' so it can be
+  passed to the jump handler. This is needed because `buffer' and
+  `point' are not updated after jumping.")
+
 (spacemacs|define-jump-handlers tcl-mode)
 (spacemacs|define-jump-handlers vhdl-mode)
 (spacemacs|define-jump-handlers awk-mode)

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -9,6 +9,49 @@
 ;;
 ;;; License: GPLv3
 
+(defun spacemacs/counsel-gtags-maybe-dwim ()
+  "Runs `counsel-gtags-dwim' if `gtags-enable-by-default' is on.
+Otherwise does nothing."
+  (interactive)
+  (when gtags-enable-by-default
+    (setq spacemacs--counsel-gtags-dwim-success nil)
+    (setq spacemacs--counsel-gtags-dwim-success
+          (call-interactively 'counsel-gtags-dwim))))
+
+(defun spacemacs//counsel-gtags-dwim-success ()
+  "Returns whether or not the last invocation of
+  `spacemacs/counsel-gtags-maybe-dwim' was a success"
+  spacemacs--counsel-gtags-dwim-success)
+
+(defun spacemacs/counsel-gtags-define-keys-for-mode (mode)
+  "Define key bindings for the specific MODE."
+  ;; `counsel-gtags-dwim' is added to the end of the mode-specific jump handlers
+  ;; Some modes have more sophisticated jump handlers that go to the beginning
+  ;; It might be possible to add `counsel-gtags-dwim' instead to the default
+  ;; handlers, if it does a reasonable job in ALL modes.
+  (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode)))
+        (handler '(spacemacs/counsel-gtags-maybe-dwim
+                   :async spacemacs//counsel-gtags-dwim-success)))
+    (when (boundp jumpl) (add-to-list jumpl handler 'append)))
+
+  ;; TODO: Add missing keybindings when new functions get added
+  (spacemacs/set-leader-keys-for-major-mode mode
+    "gC" 'counsel-gtags-create-tags
+    "gd" 'counsel-gtags-dwim
+    ;; "gD" 'helm-gtags-find-tag-other-window
+    "gf" 'counsel-gtags-find-file
+    ;; "gG" 'helm-gtags-dwim-other-window
+    ;; "gi" 'helm-gtags-tags-in-this-function
+    ;; "gl" 'helm-gtags-parse-file
+    "gn" 'counsel-gtags-next-history
+    "gp" 'counsel-gtags-previous-history
+    "gr" 'counsel-gtags-find-reference
+    ;; "gR" 'helm-gtags-resume
+    ;; "gs" 'helm-gtags-select
+    ;; "gS" 'helm-gtags-show-stack
+    "gy" 'counsel-gtags-find-symbol
+    "gu" 'counsel-gtags-update-tags))
+
 (defun helm-gtags-dwim-other-window ()
   "helm-gtags-dwim in the other window"
   (interactive)

--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -13,8 +13,24 @@
 (defconst gtags-packages
   '(
     ggtags
+    (counsel-gtags :requires ivy)
     (helm-gtags :requires helm)
     ))
+
+(defun gtags/init-counsel-gtags ()
+  (use-package counsel-gtags
+    :defer t
+    :init
+    (progn
+      (setq counsel-gtags-ignore-case t
+            counse1-gtags-auto-update t)
+      ;; modes that do not have a layer, define here
+      (spacemacs/counsel-gtags-define-keys-for-mode 'tcl-mode)
+      (spacemacs/counsel-gtags-define-keys-for-mode 'vhdl-mode)
+      (spacemacs/counsel-gtags-define-keys-for-mode 'awk-mode)
+      (spacemacs/counsel-gtags-define-keys-for-mode 'dired-mode)
+      (spacemacs/counsel-gtags-define-keys-for-mode 'compilation-mode)
+      (spacemacs/counsel-gtags-define-keys-for-mode 'shell-mode))))
 
 (defun gtags/init-ggtags ()
   (use-package ggtags


### PR DESCRIPTION
I've added ivy support to the gtags layer through [counsel-gtags](https://github.com/syohex/emacs-counsel-gtags). It's missing a few minor features compared to `helm-gtags` but most of it is there.

There should probably be a single function in the future that calls all three functions (`spacemacs/counsel-gtags-define-keys-for-mode`, `spacemacs/ggtags-mode-enable` and `spacemacs/helm-gtags-define-keys-for-mode`) for us, but that's a job for another time.
