### PR TITLE
Add counsel-css as an ivy alternative to helm-css-scss

### DIFF
--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -21,6 +21,7 @@ This layer adds support for editing HTML and CSS.
 - Tags navigation on key ~%~ using [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 - Support for editing Slim and Pug templates using [[https://github.com/slim-template/emacs-slim][slim-mode]] and [[https://github.com/hlissner/emacs-pug-mode][pug-mode]]
 - See the effects of typed HTML using [[https://github.com/skeeto/impatient-mode][impatient-mode]]
+- imenu support for CSS and Sass through [[https://github.com/hlissner/emacs-counsel-css][counsel-css]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -87,8 +88,8 @@ A transient-state is also defined, start it with ~SPC m .~ or ~, .~
 
 ** CSS/SCSS
 
-| Key Binding | Description                             |
-|-------------+-----------------------------------------|
-| ~SPC m g h~ | quickly navigate CSS rules using =helm= |
-| ~SPC m z c~ | fold css statement to one line          |
-| ~SPC m z o~ | unfold css statement to one line        |
+| Key Binding | Description                      |
+|-------------+----------------------------------|
+| ~SPC m g h~ | quickly navigate CSS rules       |
+| ~SPC m z c~ | fold css statement to one line   |
+| ~SPC m z o~ | unfold css statement to one line |

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -19,6 +19,8 @@
         evil-matchit
         flycheck
         haml-mode
+        (counsel-css :requires ivy
+                     :location (recipe :fetcher github :repo "hlissner/emacs-counsel-css"))
         (helm-css-scss :requires helm)
         impatient-mode
         less-css-mode
@@ -138,6 +140,14 @@
 (defun html/init-haml-mode ()
   (use-package haml-mode
     :defer t))
+
+(defun html/init-counsel-css ()
+  (use-package counsel-css
+    :defer t
+    :init
+    (loop for (mode . mode-hook) in '((css-mode . css-mode-hook) (scss-mode . scss-mode-hook))
+          do (add-hook mode-hook 'counsel-css-imenu-setup)
+          (spacemacs/set-leader-keys-for-major-mode mode "gh" 'counsel-css))))
 
 (defun html/init-helm-css-scss ()
   (use-package helm-css-scss


### PR DESCRIPTION
I've added an ivy alternative to `helm-css-scss` to make it easier to navigate CSS though [counsel-css](https://github.com/hlissner/emacs-counsel-css). This also makes adds imenu support to CSS and Sass when using the ivy layer. Perhaps the `SPC m g h` keybinding could be changed to something more fitting, but I can't think of anything.