### PR TITLE
Clojure mode: fix broken cider-inspect-prev-page binding

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -177,7 +177,8 @@
       (evilified-state-evilify cider-inspector-mode cider-inspector-mode-map
         (kbd "L") 'cider-inspector-pop
         (kbd "n") 'cider-inspector-next-page
-        (kbd "N") 'cider-inspector-previous-page
+        (kbd "N") 'cider-inspector-prev-page
+        (kbd "p") 'cider-inspector-prev-page
         (kbd "r") 'cider-inspector-refresh)
 
       (evilified-state-evilify cider-test-report-mode cider-test-report-mode-map


### PR DESCRIPTION
Hello!

I was trying to figure out what key to use to go backwards in the cider-inspector buffer (accessed with `, d v`)

I found that `N` was bound to `'cider-inspector-previous-page`, but that isn't an actual cider command so it was not working - the correct command is `'cider-inspector-prev-page`.

I bound this to both `N` and `p`; the `N` makes sense if you're using vim muscle memory, as if you're searching.

The `p` makes sense if you're using emacs muscle memory and you're thinking about using `C-n`, `C-p` to move to next and previous. Maybe the former is more in line with the spacemacs evil mode philosophy? 