### PR TITLE
fixed feature headers in README's

### DIFF
--- a/layers/+chat/jabber/README.org
+++ b/layers/+chat/jabber/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
   - [[#jabber-roster][Jabber Roster]]
@@ -12,7 +13,10 @@
   - [[#joining-rooms][Joining rooms]]
 
 * Description
-This layer adds keybindings for jabber.el. jabber.el is a Jabber (XMPP) client for Emacs
+This layer adds support for the Jabber (XMPP) client for Emacs
+
+** Features:
+- Use Jabber without having to leave Spacemacs
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+distributions/spacemacs-docker/deps-install/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/README.org
@@ -2,12 +2,16 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#supported-layers][Supported layers]]
 - [[#how-it-works][How it works]]
 
 * Description
 Dependency installation scripts for Spacemacs layers
 in Docker environment.
+
+** Features:
+- Add Spacemacs to your Docker enviroment so you can build, ship, and run apps, anywhere
 
 * Supported layers
 1. [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bdistributions/spacemacs-docker/deps-install/installers/clojure/README.org][Clojure]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/clojure/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/clojure/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/clojure/README.org][Clojure layer.]]
+
+** Features:
+- Clojure support for Docker
 
 * List of installed software:
 1. [[http://packages.ubuntu.com/en/xenial/default-jre-headless][default-jre-headless]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/dash/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/dash/README.org
@@ -2,11 +2,15 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 - [[#notes][Notes:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Btools/dash/README.org][Dash layer.]]
+
+** Features:
+- Dash support for Docker
 
 * List of installed software:
 1. [[http://packages.ubuntu.com/en/xenial/zeal][zeal]] - documentation browser.

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/fasd/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/fasd/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Btools/fasd/README.org][fasd layer.]]
+
+** Features:
+- Fasd support for Docker
 
 * List of installed software:
 1. [[https://github.com/clvv/fasd][fasd]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/go/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/go/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/go/README.org][Go layer.]]
+
+** Features:
+- Go support for Docker
 
 * List of installed software:
 1. [[https://golang.org/][Go 1.8]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/gtags/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/gtags/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Btags/gtags/README.org][gtags layer.]]
+
+** Features:
+- Gtags support for Docker
 
 * List of installed software:
 1. [[http://packages.ubuntu.com/en/xenial/python-pygments][python-pygments]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/html/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/html/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/html/README.org][html layer.]]
+
+** Features:
+- HTML support for Docker
 
 * List of installed software:
 1. [[https://rubygems.org][rubygems]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/javascript/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/javascript/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Blang/javascript/README.org][JavaScript layer.]]
+
+** Features:
+- Javascript support for Docker
 
 * List of installed software:
 1. [[https://www.npmjs.com][npm]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/pandoc/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/pandoc/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Btools/pandoc/README.org][pandoc layer.]]
+
+** Features:
+- Pandoc support for Docker
 
 * List of installed software:
 1. [[http://packages.ubuntu.com/xenial/pandoc][pandoc]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/pdf-tools/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/pdf-tools/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/+tools/pdf-tools/README.org][pdf-tools layer.]]
+
+** Features:
+- PDF support for Docker
 
 * List of installed software:
 1. [[https://www.imagemagick.org/script/index.php][imagemagick]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/python/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/python/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/python/README.org][python layer]].
+
+** Features:
+- Python support for Docker
 
 * List of installed software:
 1. [[https://pypi.python.org/pypi/pip][pip]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/spell-checking/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/spell-checking/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bcheckers/spell-checking/README.org][spell-checking  layer.]]
+
+** Features:
+- ispell support for Docker
 
 * List of installed software:
 1. [[http://packages.ubuntu.com/xenial/ispell][ispell]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/typescript/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/typescript/README.org
@@ -2,10 +2,14 @@
 
 * Table of Contents                 :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#list-of-installed-software][List of installed software:]]
 
 * Description
 Dependency installation script for [[https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Blang/typescript/README.org][TypeScript layer.]]
+
+** Features:
+- Typescript support for Docker
 
 * List of installed software:
 1. [[https://www.npmjs.com][npm]]

--- a/layers/+lang/groovy/README.org
+++ b/layers/+lang/groovy/README.org
@@ -4,19 +4,20 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
-  - [[#layer][Layer]]
 - [[#key-bindings][Key bindings]]
   - [[#repl][REPL]]
 
 * Description
 This layer supports [[http://www.groovy-lang.org/][groovy]] development in Spacemacs.
 
-It has basic/non-smart auto-completion with the =syntax-checking= layer
-and REPL integration.
+** Features:
+- Basic dabbrev auto-completion with company
+- Auto-generate imports with [[https://github.com/mbezjak/emacs-groovy-imports][groovy-imports]]
+- Groovy REPL integration
 
 * Install
-** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =groovy= to the existing =dotspacemacs-configuration-layers= list in this
 file.

--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#live-display-in-browser][Live display in browser]]
 - [[#key-bindings][Key Bindings]]
@@ -14,7 +14,7 @@
 * Description
 This layer adds support for editing HTML and CSS.
 
-** Features
+** Features:
 - Editing HTML and CSS file using [[http://web-mode.org/][web-mode]]
 - Support for Sass/Scss and Less files
 - Generate HTML and CSS coding using [[https://github.com/smihica/emmet-mode][emmet-mode]]

--- a/layers/+lang/protobuf/README.org
+++ b/layers/+lang/protobuf/README.org
@@ -4,13 +4,13 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
-- [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
 Highlighting and syntax checking for [[https://developers.google.com/protocol-buffers/][Protocol Buffer]] files.
 
-* Features
+** Features:
 - Syntax highlighting
 - Syntax checking using Flycheck (=protoc= compiler must be available)
 - Correct indentation and commenting

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#dependencies][Dependencies]]
@@ -34,7 +34,7 @@
 * Description
 This layer adds support for the Python language.
 
-** Features
+** Features:
 - Auto-completion using [[https://github.com/proofit404/anaconda-mode][anaconda-mode]]
 - Code Navigation using  [[https://github.com/proofit404/anaconda-mode][anaconda-mode]]
 - Documentation Lookup using  [[https://github.com/proofit404/anaconda-mode][anaconda-mode]]  and [[https://github.com/tsgates/pylookup][pylookup]]

--- a/layers/+lang/rest/README.org
+++ b/layers/+lang/rest/README.org
@@ -2,7 +2,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#sphinx-target][Sphinx target]]
@@ -13,7 +13,7 @@
 The layer adds ReStructuredText (ReST) support to Spacemacs and adds some
 functions to =rst-mode=.
 
-** Features
+** Features:
 - =rst= files are supported via Emacs built-in =rst.el=.
 - Lists are inserted by new functions.
 - Directives can be inserted easily.

--- a/layers/+lang/restructuredtext/README.org
+++ b/layers/+lang/restructuredtext/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#auto-complete][Auto-complete]]
@@ -15,7 +15,7 @@ functions to =rst-mode=.
 
 Note: to add =Sphinx= specific support use the layer =sphinx=.
 
-** Features
+** Features:
 - =rst= files are supported via Emacs built-in =rst.el=.
 - Lists are inserted by new functions.
 - Directives can be inserted easily.

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#racer][Racer]]
@@ -14,7 +15,9 @@
 * Description
 This layer supports [[https://www.rust-lang.org/en-US/][Rust]] development in Spacemacs.
 
-It has auto-completion and navigation support through [[https://github.com/phildawes/racer][Racer]] and supports [[http://doc.crates.io/index.html][Cargo]].
+** Features:
+- Auto-completion and navigation support through [[https://github.com/phildawes/racer][Racer]]
+- support for the Rust package manager [[http://doc.crates.io/index.html][Cargo]]
 
 * Install
 ** Layer

--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
   - [[#compiling][Compiling]]
@@ -13,12 +14,13 @@
   - [[#evaluation][Evaluation]]
 
 * Description
-A spacemacs layer providing Scheme support via [[http://www.nongnu.org/geiser/][Geiser]].
+This layer adds support for Scheme via [[http://www.nongnu.org/geiser/][Geiser]]. Note that combined usage of racket-mode and geiser has not been tested.
+
+** Features:
+- Support the Scheme compiler [[https://www.call-cc.org/][Chicken]]
+- Support for the extension language platform [[https://www.gnu.org/software/guile/][Guile]]
 
 * Install
-The scheme layer currently supports: Chicken and Guile. Combined usage of racket-mode
-and geiser has not been tested.
-
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =scheme= to the existing =dotspacemacs-configuration-layers= list in this
 file.

--- a/layers/+lang/shell-scripts/README.org
+++ b/layers/+lang/shell-scripts/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#linting][Linting]]
   - [[#style-checking][Style checking]]
@@ -19,7 +19,7 @@ Supported scripting files:
 
 *Note:* For Windows scripting see the layer =windows-scripts=
 
-** Features
+** Features:
 - Auto-completion using [[https://github.com/Alexander-Miller/company-shell][company-shell]]
 - =Sh= scripts linting using  [[https://www.shellcheck.net/][shellcheck]]
 - =Sh= scripts style checking using [[https://github.com/openstack-dev/bashate][bashate]]

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -2,7 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
 - [[#configuration][Configuration]]
@@ -15,11 +15,9 @@
 This layers adds general configuration for [[http://www.gnu.org/software/emacs/manual/html_node/emacs/Version-Control.html][Emacs VC]].
 It should work with all VC backends such as Git, Mercurial, Bazaar, SVN, etc...
 
-** Features
-- highlights uncommitted changes in the fringe or margin with [[https://github.com/dgutov/diff-hl][diff-hl]],
-git-gutter, or git-gutter+
-- adds vcs transient-state ~SPC g.~ to allow quick navigation and modification of
-buffer hunks.
+** Features:
+- highlights uncommitted changes in the fringe or margin with [[https://github.com/dgutov/diff-hl][diff-hl]], [[https://github.com/syohex/emacs-git-gutter][git-gutter]], or [[https://github.com/nonsequitur/git-gutter-plus][git-gutter+]]
+- adds vcs transient-state ~SPC g.~ to allow quick navigation and modification of buffer hunks.
 
 * Install
 ** Layer

--- a/layers/+spacemacs/spacemacs-purpose/README.org
+++ b/layers/+spacemacs/spacemacs-purpose/README.org
@@ -2,11 +2,9 @@
 
 * Table of Contents                                                   :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
   - [[#purposes][Purposes]]
   - [[#switch-to-buffer-and-display-buffer][switch-to-buffer and display-buffer]]
-- [[#features][Features]]
-  - [[#windows-purpose-purpose-mode][windows-purpose (purpose-mode)]]
-  - [[#purpose-popwinel-pupo-mode][purpose-popwin.el (pupo-mode)]]
   - [[#misc][misc]]
 - [[#install][Install]]
 - [[#usage][Usage]]
@@ -23,6 +21,16 @@ and shouldn't change too much when opening all sorts of buffers.
 Regular [[https://github.com/m2ym/popwin-el][popwin]] is not triggered when window-purpose is enabled. However,
 the window-purpose layer provides a =purpose-popwin= extension, which
 brings popwin's behavior towindows-purpose and solves that problem.
+
+** Features:
+- Window layout is more robust and less likely to change unintentionally
+- Dedicate window to a purpose
+- User-defined purposes
+- Extensible window display behavior
+- Empty =purpose-mode-map=, to avoid conflicts with other key maps
+- Replicate popwin behavior for purpose-mode - almost no regression in popup behavior from using windows-purpose.
+- Reuses popwin's settings: =popwin:special-display-config=, =popwin:popup-window-height= and =popwin:popup-window-width=.
+- Difference from popwin: when several windows are open, popup window is sometimes bigger than with regular popwin in the same situation.
 
 ** Purposes
 windows-purpose contains a configuration which assigns a purpose for each
@@ -46,22 +54,6 @@ switching and popping commands, because it doesn't use =display-buffer= (which
 the other commands do). With windows-purpose, this behavior is fixed. The
 result is a better control over how buffers are displayed, since
 =switch-to-buffer= doesn't ignore the user's customizations anymore.
-
-* Features
-** windows-purpose (purpose-mode)
-- window layout is more robust and less likely to change unintentionally
-- dedicate window to a purpose
-- user-defined purposes
-- extensible window display behavior
-- empty =purpose-mode-map=, to avoid conflicts with other key maps
-
-** purpose-popwin.el (pupo-mode)
-- replicate popwin behavior for purpose-mode - almost no regression in popup
-  behavior from using windows-purpose.
-- reuses popwin's settings: =popwin:special-display-config=,
-  =popwin:popup-window-height= and =popwin:popup-window-width=.
-- difference from popwin: when several windows are open, popup window is
-  sometimes bigger than with regular popwin in the same situation.
 
 ** misc
 - specialized helm source similar to =helm-source-buffers-list=

--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -2,7 +2,7 @@
 
 * Table of Contents                                          :TOC_4_gh:noexport:
 - [[#description][Description]]
-- [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#gnu-global-gtags][GNU Global (gtags)]]
     - [[#install-on-osx-using-homebrew][Install on OSX using Homebrew]]
@@ -28,7 +28,7 @@ code tagging system that allows querying symbol locations in source code, such
 as definitions or references. Adding the =gtags= layer enables both of these
 modes.
 
-* Features
+** Features:
 - Select any tag in a project retrieved by gtags
 - Resume previous helm-gtags session
 - Jump to a location based on context

--- a/layers/+themes/themes-megapack/README.org
+++ b/layers/+themes/themes-megapack/README.org
@@ -1,14 +1,16 @@
 #+TITLE: Themes Megapack layer
 
 * Table of Contents                                         :TOC_4_gh:noexport:
-- [[#what-is-this][What is this?]]
+- [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
-* What is this?
-This simple layer is an example. It installs around 100 themes
-for Emacs. You can try them easily by invoking helm-themes with: ~SPC T s~.
+* Description
+This layer installs around 100 themes for Emacs.
 
-You can see samples of all included themes in this [[http://themegallery.robdor.com][theme gallery]] from [[http://www.twitter.com/robmerrell][Rob Merrell]].
+** Features:
+- Have access to all included themes in this [[http://themegallery.robdor.com][theme gallery]] from [[http://www.twitter.com/robmerrell][Rob Merrell]].
+- Easily try a theme by invoking helm-themes with: ~SPC T s~.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/chrome/README.org
+++ b/layers/+tools/chrome/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#chrome-extension][Chrome extension]]
@@ -14,7 +14,7 @@
 * Description
 This layer provides some integration with the Google Chrome browser.
 
-** Features
+** Features:
 - Edit text boxes with Emacs using [[https://github.com/stsquad/emacs_chrome][edit-server]]
 - Write markdown in Emacs and realtime show in chrome using [[https://github.com/mola-T/flymd][flymd]]
 - gmail message mode uses standard markdown keybindings

--- a/layers/+tools/pass/README.org
+++ b/layers/+tools/pass/README.org
@@ -2,17 +2,19 @@
 
 * Table of Contents :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
-  - [[#layer][Layer]]
 - [[#key-bindings][Key Bindings]]
 
 * Description
-This layer adds intregration with [[http://www.passwordstore.org/][pass]], the standard unix password manager.
+This layer adds intregration with [[http://www.passwordstore.org/][pass]], the unix password manager.
 You must have ~pass~ installed and available in your path for this layer to
 function properly.
 
+** Features:
+- Use Spacemacs as your password manager
+
 * Install
-** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =pass= to the existing =dotspacemacs-configuration-layers= list in this
 file.

--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -2,7 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-- [[#features][Features]]
+  - [[#features][Features:]]
 - [[#configuration][Configuration]]
   - [[#customizing][Customizing]]
   - [[#parent-options][Parent options]]
@@ -23,7 +23,7 @@ To default with preview enabled when entering ranger:
                        ranger-show-preview t))
 #+END_SRC
 
-* Features
+** Features:
 - use ranger to display dired with ranger like preview and stacked parent windows.
 
 * Configuration

--- a/layers/+tools/rebox/README.org
+++ b/layers/+tools/rebox/README.org
@@ -2,7 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#configuration][Configuration]]
@@ -20,7 +20,7 @@ to easily add ASCII text boxes to a buffer.
 
 A nice video demonstration by the package author can be found [[https://www.youtube.com/watch?v=53YeTdVtDkU][here]].
 
-** Features
+** Features:
 - Auto-wrap correctly in comments,
 - Auto-fill correctly in comments,
 - Boxes auto-adapt as text is inserted or deleted,

--- a/layers/+vim/vinegar/README.org
+++ b/layers/+vim/vinegar/README.org
@@ -2,7 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
   - [[#mouse-bindings][Mouse bindings]]
   - [[#key-bindings][Key bindings]]
 
@@ -14,7 +14,7 @@ A port of tpope's
 with a limited number of details and exposing the ~-~ command in all
 buffers to enter dired.
 
-** Features
+** Features:
 -  navigation up folders with ~-~ key
 -  simplify dired buffer to show only file names
 -  better evil/vim bindings for navigation within dired buffer

--- a/layers/+web-services/twitter/README.org
+++ b/layers/+web-services/twitter/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                                                     :TOC_4_gh:noexport:
 - [[#description][Description]]
-- [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
 - [[#key-bindings][Key Bindings]]
@@ -12,7 +12,7 @@
 * Description
 This layer adds Twitter support to Spacemacs via the package [[https://github.com/hayamiz/twittering-mode][twittering-mode]].
 
-* Features
+** Features:
 - Activities on Twitter
   - Viewing various timelines
     - Home timeline


### PR DESCRIPTION
Updated the `feature` header in README's to match the Spacemacs style guide as requested in #9476. 

Note that we have a spurious error in `circleci`
```
File "/root/project/layers/+source-control/version-control/README.org" has multiply "Features:" lists in the top level "Description" headline
```
which is incorrect. It looks like it is flagging this file because it has the word "feature" in a table. Hopefully @JAremko can fix that.