### PR TITLE
Add docstring to align-repeat-x commands

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -882,11 +882,14 @@ the right."
                 nil))
 
 (defmacro spacemacs|create-align-repeat-x (name regexp &optional justify-right default-after)
-  (let ((new-func (intern (concat "spacemacs/align-repeat-" name))))
-    `(defun ,new-func (start end switch)
-       (interactive "r\nP")
-       (let ((after (not (eq (if switch t nil) (if ,default-after t nil)))))
-         (spacemacs/align-repeat start end ,regexp ,justify-right after)))))
+  (let* ((new-func (intern (concat "spacemacs/align-repeat-" name)))
+         (new-func-defn
+          `(defun ,new-func (start end switch)
+             (interactive "r\nP")
+             (let ((after (not (eq (if switch t nil) (if ,default-after t nil)))))
+               (spacemacs/align-repeat start end ,regexp ,justify-right after)))))
+    (put new-func 'function-documentation "Created by `spacemacs|create-align-repeat-x'.")
+    new-func-defn))
 
 (spacemacs|create-align-repeat-x "comma" "," nil t)
 (spacemacs|create-align-repeat-x "semicolon" ";" nil t)


### PR DESCRIPTION
Update `spacemacs|create-align-repeat-x` macro to add a docstring to created
functions. The docstring refers the user to the macro, providing a link to
the source code.

Currently, calling `describe-function` on `spacemacs|align-repeat-` commands is not very helpful. It has no link to the definition, only to the top of the `funcs.el` file. Worse, if a user employs the macro in their init file to create custom align-repeat commands (I know I do), the help for those functions doesn't even identify the file where they were defined. There's no obvious way to fix this, but we can identify the defining macro itself, which is usually more important. Having the name of macro makes it easier to search for the definitions which call that macro, and the user can jump from the macro's documentation to its source code.

This commit adds the following docstring to each generated command.

    Created by `spacemacs|create-align-repeat-x'.