### PR TITLE
fixup spelling of emacs-plus configuration option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ information.
 consider using instead:
 
 ``` sh
-$ brew install emacs-plus --HEAD --with-natural-title-bars
+$ brew install emacs-plus --HEAD --with-natural-title-bar
 ```
 
 *Note:* after you have completed the [install process](#install) below, it is


### PR DESCRIPTION
fixup spelling of emacs-plus configuration option. see: https://github.com/d12frosted/homebrew-emacs-plus/blob/master/Formula/emacs-plus.rb#L39