### PR TITLE
Format symbol highlight transient state

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -45,13 +45,14 @@
     :post-init
     ;; add some functions to ahs transient states
     (setq spacemacs--symbol-highlight-transient-state-doc
-          (concat spacemacs--symbol-highlight-transient-state-doc
-                  "  [_b_] search buffers [_/_] search proj [_f_] search files [_s_] swoop"))
+          (concat
+           spacemacs--symbol-highlight-transient-state-doc
+           "  Search: [_s_] swoop  [_b_] buffers  [_f_] files  [_/_] project"))
     (spacemacs/transient-state-register-add-bindings 'symbol-highlight
-      '(("/" spacemacs/helm-project-smart-do-search-region-or-symbol :exit t)
+      '(("s" spacemacs/helm-swoop-region-or-symbol :exit t)
         ("b" spacemacs/helm-buffers-smart-do-search-region-or-symbol :exit t)
         ("f" spacemacs/helm-files-smart-do-search-region-or-symbol :exit t)
-        ("s" spacemacs/helm-swoop-region-or-symbol :exit t)))))
+        ("/" spacemacs/helm-project-smart-do-search-region-or-symbol :exit t)))))
 
 (defun helm/post-init-bookmark ()
   (spacemacs/set-leader-keys "fb" 'helm-filtered-bookmarks))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -34,13 +34,14 @@
     :post-init
     ;; add some functions to ahs transient states
     (setq spacemacs--symbol-highlight-transient-state-doc
-          (concat spacemacs--symbol-highlight-transient-state-doc
-                  "  [_b_] search buffers [_/_] search proj [_f_] search files [_s_] swiper"))
+          (concat
+           spacemacs--symbol-highlight-transient-state-doc
+           "  Search: [_s_] swiper  [_b_] buffers  [_f_] files  [_/_] project"))
     (spacemacs/transient-state-register-add-bindings 'symbol-highlight
-      '(("/" spacemacs/search-project-auto-region-or-symbol :exit t)
+      '(("s" spacemacs/swiper-region-or-symbol :exit t)
         ("b" spacemacs/swiper-all-region-or-symbol :exit t)
         ("f" spacemacs/search-auto-region-or-symbol :exit t)
-        ("s" spacemacs/swiper-region-or-symbol :exit t)))))
+        ("/" spacemacs/search-project-auto-region-or-symbol :exit t)))))
 
 (defun ivy/init-counsel ()
   (use-package counsel

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -166,8 +166,7 @@
   (spacemacs//transient-state-make-doc
    'symbol-highlight
    (format spacemacs--symbol-highlight-transient-state-doc
-           (spacemacs//symbol-highlight-doc)
-           (make-string (length (spacemacs//symbol-highlight-doc)) 32))))
+           (spacemacs//symbol-highlight-doc))))
 
 
 ;; golden ratio

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -51,10 +51,10 @@
             ahs-idle-timer 0
             ahs-idle-interval 0.25
             ahs-inhibit-face-list nil
-            spacemacs--symbol-highlight-transient-state-doc
-            "
- %s  [_n_] next   [_N_/_p_] previous   [_r_] change range   [_R_] reset   [_e_] iedit
- %s  [_d_/_D_] next/previous definition")
+            spacemacs--symbol-highlight-transient-state-doc "
+ %s
+ [_n_] next   [_N_/_p_] prev  [_d_/_D_] next/prev def  [_r_] range  [_R_] reset
+ [_e_] iedit")
 
       ;; since we are creating our own maps,
       ;; prevent the default keymap from getting created
@@ -109,6 +109,7 @@
       ;; transient state
       (spacemacs|define-transient-state symbol-highlight
         :title "Symbol Highlight Transient State"
+        :hint-is-doc t
         :dynamic-hint (spacemacs//symbol-highlight-ts-doc)
         :before-exit (spacemacs//ahs-ms-on-exit)
         :bindings


### PR DESCRIPTION
Reduce the width of the listed key bindings by:
Moving the range and highlighted symbols counter to the right of the transient
state title.
Shorten some key description names.
Reduce three instances of "search" to just one.

And reorder the listed keys based on their search scope, small to large:
swoop, buffers, files, project.

---
before:
![wider](https://user-images.githubusercontent.com/13420573/29945621-27d557e6-8ea2-11e7-86b9-c3ff8ede9442.png)

after:
![narrower](https://user-images.githubusercontent.com/13420573/29946108-532a1074-8ea4-11e7-91a7-a218cefe7e0c.png)