### PR TITLE
Rename ms in func ahs-ms-on-exit to ts

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -111,7 +111,7 @@
   (spacemacs/symbol-highlight-transient-state/body)
   (spacemacs/integrate-evil-search nil))
 
-(defun spacemacs//ahs-ms-on-exit ()
+(defun spacemacs//ahs-ts-on-exit ()
   ;; Restore user search direction state as ahs has exitted in a state
   ;; good for <C-s>, but not for 'n' and 'N'"
   (setq isearch-forward spacemacs--ahs-searching-forward))

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -110,7 +110,7 @@
       (spacemacs|define-transient-state symbol-highlight
         :title "Symbol Highlight Transient State"
         :dynamic-hint (spacemacs//symbol-highlight-ts-doc)
-        :before-exit (spacemacs//ahs-ms-on-exit)
+        :before-exit (spacemacs//ahs-ts-on-exit)
         :bindings
         ("d" ahs-forward-definition)
         ("D" ahs-backward-definition)


### PR DESCRIPTION
`ms` is an abbreviation for a micro state, which was the previous name for a
transient state.