### PR TITLE
Rename ms in helm-nav face definition to ts

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/config.el
+++ b/layers/+spacemacs/spacemacs-completion/config.el
@@ -12,7 +12,7 @@
 
 ;; Helm
 
-(defface spacemacs-helm-navigation-ms-face
+(defface spacemacs-helm-navigation-ts-face
   `((t :background ,(face-attribute 'error :foreground)
        :foreground "black"))
   "Face for helm header when helm transient-state is activated."


### PR DESCRIPTION
The `spacemacs//helm-navigation-ts-set-face` function had been changed to call
the face `spacemacs-helm-navigation-ts-face` with `-ts-`, but the face
definition was still called `spacemacs-helm-navigation-ms-face` with `-ms-`.

---
Resolves #8618