### PR TITLE
Fixes search in helm for org files

### DIFF
--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -44,3 +44,10 @@
 (defun spacemacs//evil-org-mode ()
   (evil-org-mode)
   (evil-normalize-keymaps))
+
+
+
+(defun spacemacs//org-reveal-on-helm-peristent-action ()
+  "reveal content for helm-persistent-action used in an Org file with folded outline"
+  (when (equalp major-mode 'org-mode)
+    (org-reveal)))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -137,6 +137,9 @@
 
       (add-hook 'org-mode-hook 'dotspacemacs//prettify-spacemacs-docs)
 
+      (when (configuration-layer/layer-used-p 'helm)
+        (add-hook 'helm-after-persistent-action-hook 'spacemacs//org-reveal-on-helm-peristent-action))
+
       (let ((dir (configuration-layer/get-layer-local-dir 'org)))
         (setq org-export-async-init-file (concat dir "org-async-init.el")))
       (defmacro spacemacs|org-emphasize (fname char)


### PR DESCRIPTION
When you search with helm in Org files and the outline is collapsed
e.g.: `(setq org-startup-folded t)`, user may not see the results
when executing helm-persistent-action (`TAB` key)

This PR to fix that.