### PR TITLE
Fix rust layer call to `rustup`

### DIFF
--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -27,7 +27,7 @@ using `cargo-process-run'."
   (let ((input-file-name (buffer-file-name))
         (output-file-name (concat temporary-file-directory (make-temp-name "rustbin"))))
     (compile
-     (format "rustc -o %s %s && %s"
+     (format "sh -c 'rustc -o %s %s  &&  %s'"
              (shell-quote-argument output-file-name)
              (shell-quote-argument input-file-name)
              (shell-quote-argument output-file-name)))))

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -24,10 +24,24 @@ open a junk Rust file, type in some code and quickly run it.
 If you want to use third-party crates, create a a new project using `cargo-process-new' and run
 using `cargo-process-run'."
   (interactive)
-  (let ((input-file-name (buffer-file-name))
-        (output-file-name (concat temporary-file-directory (make-temp-name "rustbin"))))
+  (lexical-let ((input-file-name
+                  (buffer-file-name))
+                (output-file-name
+                  (concat
+                    temporary-file-directory
+                    (file-name-nondirectory (buffer-file-name))
+                    "-"
+                    (md5 (buffer-file-name)))))
+    (add-to-list 'compilation-finish-functions
+                 (lambda (buffer status)
+                   (if (string-match "finished" status)
+                     (shell-command
+                       (shell-quote-argument output-file-name)
+                       buffer)
+                     (message "Compilation failed with: %s" status))))
     (compile
-     (format "sh -c 'rustc -o %s %s  &&  %s'"
-             (shell-quote-argument output-file-name)
-             (shell-quote-argument input-file-name)
-             (shell-quote-argument output-file-name)))))
+      (format "rustc -o %s %s"
+              (shell-quote-argument output-file-name)
+              (shell-quote-argument input-file-name)))
+    )
+  )


### PR DESCRIPTION
Bash compatibility was assumed, which made the shell command to fail on
fish and probably other shells too.