### PR TITLE
Add "features" block to doc of plantuml, shell and search-engine layer

### DIFF
--- a/layers/+lang/plantuml/README.org
+++ b/layers/+lang/plantuml/README.org
@@ -3,6 +3,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#org-babel-integration][Org-Babel Integration]]
 - [[#key-bindings][Key bindings]]
@@ -30,6 +31,10 @@ robbyoconnor->theOtherPerson : And they thinks it's funny? Yup, they definitely 
 #+END_SRC
 
 [[file:img/dia.png]]
+
+** Features:
+  - Diagram preview in various output formats
+  - Embedding into org documents
 
 * Install
 To use this contribution add it to your =~/.spacemacs=

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#default-shell][Default shell]]
@@ -20,6 +21,9 @@
 
 * Description
 This layer configures the various shells available in Emacs.
+
+** Features:
+  - Shell integration
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
   - [[#supported-search-engines][Supported search engines]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
@@ -11,6 +12,9 @@
 
 * Description
 This layer adds support for the [[https://github.com/hrs/engine-mode][Search Engine]] package.
+
+** Features:
+  - Browser search integration
 
 ** Supported search engines
 - Amazon


### PR DESCRIPTION
Added the missing "features" block to the plantuml, shell and search-engine layer documentation as requested in #9476.