### PR TITLE
Add configurable smartparens for common lisp layer

### DIFF
--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -4,7 +4,10 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#choosing-common-lisp-implementation][Choosing Common Lisp implementation]]
+  - [[#enabling-smartparens-strict-mode-or-smartparens-mode][Enabling smartparens-strict-mode or smartparens-mode]]
 - [[#key-bindings][Key Bindings]]
   - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
   - [[#leader][Leader]]
@@ -16,7 +19,11 @@
     - [[#macroexpansion][Macroexpansion]]
 
 * Description
-A Spacemacs layer providing Common Lisp support via [[https://github.com/slime/slime][SLIME]].
+** Features:
+   - Interactive REPL, debugger, inspector and more via [[https://github.com/slime/slime][SLIME]].
+   - Autocompletion via slime-company.
+   - Support for Common Lisp code snippets, user-made and pre-made, via common-lisp-snippets.
+   - Simple support for parenthesis organization via parinfer
 
 * Install
 If you have previously installed slime in any other way, it is recommended that
@@ -28,12 +35,24 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =common-lisp= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-This layer defaults to using [[http://www.sbcl.org/][sbcl]]. If you want to use a different implementation
-of Common Lisp, you can specify it in your =~/.spacemacs=
+** Choosing Common Lisp implementation
+ This layer defaults to using [[http://www.sbcl.org/][sbcl]]. If you want to use a different implementation
+ of Common Lisp, you can specify it in your =~/.spacemacs=
+
+ #+BEGIN_SRC emacs-lisp
+   (defun dotspacemacs/user-config ()
+     (setq inferior-lisp-program "/path/to/your/lisp"))
+ #+END_SRC
+
+** Enabling smartparens-strict-mode or smartparens-mode
+   This layer supports smartparens-mode. It can work in =normal= or =strict= mode, =normal= being =smartparens-mode=.
+   By default the smartparens-mode is disabled. To change that, you need to provide =common-lisp-smartparens-mode= variable.
+
+   Example to enable =smartparens-strict-mode=:
 
 #+BEGIN_SRC emacs-lisp
-  (defun dotspacemacs/user-config ()
-    (setq inferior-lisp-program "/path/to/your/lisp"))
+(defun dotspacemacs-configuration-layers ()
+   '((common-lisp :variables common-lisp-smartparens-mode 'strict)))
 #+END_SRC
 
 * Key Bindings

--- a/layers/+lang/common-lisp/config.el
+++ b/layers/+lang/common-lisp/config.el
@@ -11,3 +11,7 @@
 
 (spacemacs|define-jump-handlers lisp-mode slime-edit-definition)
 (spacemacs|define-jump-handlers common-lisp-mode)
+
+(defvar common-lisp-enable-smartparens-mode nil
+  "If non nil, smartparens mode will be enabled in SLIME REPL.
+Possible values are `strict' or `normal'.")

--- a/layers/+lang/common-lisp/funcs.el
+++ b/layers/+lang/common-lisp/funcs.el
@@ -32,3 +32,26 @@
   (interactive)
   (move-end-of-line 1)
   (slime-eval-last-expression))
+
+;; Smartparens-mode
+
+(defun common-lisp//enable-smartparens-mode ()
+  (smartparens-mode 1))
+
+;; Smartparens-strict-mode
+
+(defun common-lisp//enable-smartparens-strict-mode ()
+  (smartparens-strict-mode 1))
+
+;; No smartparens
+
+(defun common-lisp//disable-smartparens-mode ()
+  (smartparens-strict-mode -1)
+  (turn-off-smartparens-mode))
+
+(defun common-lisp/maybe-load-smartparens ()
+  (cl-case common-lisp-enable-smartparens-mode
+    ('strict (common-lisp//enable-smartparens-strict-mode))
+    ('normal (common-lisp//enable-smartparens-mode))
+    ((nil) (common-lisp//disable-smartparens-mode))
+    (otherwise nil)))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -72,12 +72,7 @@
       ;; enable fuzzy matching in code buffer and SLIME REPL
       (setq slime-complete-symbol*-fancy t)
       (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
-      ;; enabel smartparen in code buffer and SLIME REPL
-      ;; (add-hook 'slime-repl-mode-hook #'smartparens-strict-mode)
-      (defun slime/disable-smartparens ()
-        (smartparens-strict-mode -1)
-        (turn-off-smartparens-mode))
-      (add-hook 'slime-repl-mode-hook #'slime/disable-smartparens)
+      (add-hook 'slime-repl-mode-hook #'common-lisp/maybe-load-smartparens)
       (spacemacs/add-to-hooks 'slime-mode '(lisp-mode-hook)))
     :config
     (progn


### PR DESCRIPTION
Currently, the Common Lisp layer disables smartparens by default. If user wishes to enable smartparens, he either has to add hook manually or to uncomment the proper line in the source code(and comment out the disabling part).

The commit I'm submitting adds a new variable, `common-lisp-enable-smartparens-mode`. The name is quite long, but I think that the only thing that I could drop is the "enable-" part.

The variable can be provided via :variables to enable smartparens mode. It stays turned off by default.

The usage guideline can be found in README.

Since the Install part of README now contains two separate instructions(for setting Lisp implementation and for setting smartparens mode), I've created a new headers for both. 