### PR TITLE
ivy: add ivy-rich display transformer for ivy-switch-buffer

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -20,6 +20,7 @@
         helm-make
         ivy
         ivy-hydra
+        ivy-rich
         (ivy-spacemacs-help :location local)
         persp-mode
         projectile
@@ -269,6 +270,15 @@
 
   ;; merge recentf and bookmarks into buffer switching. If we set this
   (setq ivy-use-virtual-buffers t))
+
+(defun ivy/init-ivy-rich ()
+  (use-package ivy-rich
+    :defer t
+    :init (progn
+            (setq ivy-rich-abbreviate-paths t
+                  ivy-virtual-abbreviate 'full
+                  ivy-rich-switch-buffer-align-virtual-buffer t)
+            (ivy-set-display-transformer 'ivy-switch-buffer 'ivy-rich-switch-buffer-transformer))))
 
 (defun ivy/init-ivy-spacemacs-help ()
   (use-package ivy-spacemacs-help


### PR DESCRIPTION
This change adds the ivy-rich package to the ivy layer and configures it by default (https://github.com/Yevgnen/ivy-rich)

As you can see from the package github page this adds very useful contextual information to ivy-switch-buffer.