### PR TITLE
Fix helm-bookmark initialization

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -15,7 +15,6 @@
         auto-highlight-symbol
         helm
         helm-ag
-        helm-bookmark
         helm-descbinds
         helm-flx
         helm-make

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -13,9 +13,9 @@
       '(
         ace-jump-helm-line
         auto-highlight-symbol
-        bookmark
         helm
         helm-ag
+        helm-bookmark
         helm-descbinds
         helm-flx
         helm-make
@@ -53,7 +53,18 @@
         ("f" spacemacs/helm-files-smart-do-search-region-or-symbol :exit t)
         ("s" spacemacs/helm-swoop-region-or-symbol :exit t)))))
 
-(defun helm/post-init-bookmark ()
+(defun helm/post-init-helm-bookmark ()
+  ;; alter helm-bookmark key bindings to be simpler
+  ;; TODO check if there is a more elegant solution to setup these bindings
+  (defun simpler-helm-bookmark-keybindings ()
+    (define-key helm-bookmark-map (kbd "C-d") 'helm-bookmark-run-delete)
+    (define-key helm-bookmark-map (kbd "C-e") 'helm-bookmark-run-edit)
+    (define-key helm-bookmark-map
+      (kbd "C-f") 'helm-bookmark-toggle-filename)
+    (define-key helm-bookmark-map
+      (kbd "C-o") 'helm-bookmark-run-jump-other-window)
+    (define-key helm-bookmark-map (kbd "C-/") 'helm-bookmark-help))
+  (add-hook 'helm-mode-hook 'simpler-helm-bookmark-keybindings)
   (spacemacs/set-leader-keys "fb" 'helm-filtered-bookmarks))
 
 (defun helm/init-helm ()
@@ -127,17 +138,6 @@
       ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
       (helm-locate-set-command)
       (setq helm-locate-fuzzy-match (string-match "locate" helm-locate-command))
-      ;; alter helm-bookmark key bindings to be simpler
-      ;; TODO check if there is a more elegant solution to setup these bindings
-      (defun simpler-helm-bookmark-keybindings ()
-        (define-key helm-bookmark-map (kbd "C-d") 'helm-bookmark-run-delete)
-        (define-key helm-bookmark-map (kbd "C-e") 'helm-bookmark-run-edit)
-        (define-key helm-bookmark-map
-          (kbd "C-f") 'helm-bookmark-toggle-filename)
-        (define-key helm-bookmark-map
-          (kbd "C-o") 'helm-bookmark-run-jump-other-window)
-        (define-key helm-bookmark-map (kbd "C-/") 'helm-bookmark-help))
-      (add-hook 'helm-mode-hook 'simpler-helm-bookmark-keybindings)
       (with-eval-after-load 'helm-mode ; required
         (spacemacs|hide-lighter helm-mode)))))
 


### PR DESCRIPTION
The helm layer depended on `bookmark` directly instead of through `helm-bookmark`, and initialization was in the wrong place, resulting in *symbol's value as varable is void* errors about `helm-bookmark-map`.