### PR TITLE
New powerline colour space fix for osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ color than the rest of the line, then you can add the following snippet to the
 `dotspacemacs/user-config` section in your `~/.spacemacs` file:
 
 ```elisp
-(setq ns-use-srgb-colorspace nil)
+(setq powerline-image-apple-rgb t)
 ```
 
 Keep in mind that this is not an ideal solution as it affects all colours in


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/issues/4426

The old fix for this modeline issue was to change the emacs colour space, but that kinda sucked because it would change all of the colours in the app, and everything would look a little bit off. This new fix, added to powerline in this commit: https://github.com/milkypostman/powerline/commit/8a246902e86a0c59015bb897a9c59be9729ef5c4 , instead changes the separator image colours to Apple RGB.

Sorry, this is a bad commit message, [I'm literally in a tent](https://toughsoles.ie)
