### PR TITLE
Fix bug: pushing org-projectile-todo-files to org-agenda-files

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -235,7 +235,10 @@ the following snippet. Note that this may have unintended consequences until
 #+BEGIN_SRC emacs-lisp
   (with-eval-after-load 'org-agenda
     (require 'org-projectile)
-    (push (org-projectile-todo-files) org-agenda-files))
+    (mapcar '(lambda (file)
+                   (when (file-exists-p file)
+                     (push file org-agenda-files)))
+            (org-projectile-todo-files)))
 #+END_SRC
 
 ** Org-brain support


### PR DESCRIPTION
Using `(push (org-projectile-todo-files) org-agenda-files)' would occur error shown below when entering org-agenda-mode.
--error begin
Wrong type argument: stringp, ("~/.emacs.d/TODOs.org" ...)
--error end
`(org-projectile-todo-files)' returns a list of files.
 `push' function would make the list a new ELT of `org-agenda-files' rather than merging members into it.
While `org-file-menu-entry' only accept file path string as parameter.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3