### PR TITLE
Restore evil-org-additional-bindings in insert mode

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -55,6 +55,7 @@
     :init
     (progn
       (add-hook 'org-mode-hook 'spacemacs//evil-org-mode)
+      (setq evil-org-use-additional-insert t)
       (setq evil-org-key-theme `(textobjects
                                  navigation
                                  additional


### PR DESCRIPTION
Before some time the additional evil-org bindings were available in all three evil modes. However due to a bug in evil-org this seems to have been changed. The bug is fixed now and I have restored the old insert mode bindings by setting evil-org-use-additional-insert to true during package initialization.