### PR TITLE
Run `set-fontset-font` only if it is available (for emoji layer)

### DIFF
--- a/layers/+fun/emoji/funcs.el
+++ b/layers/+fun/emoji/funcs.el
@@ -13,15 +13,16 @@
 ;; Mac OS X and using the Cocoa version of Emacs
 (defun spacemacs//set-emoji-font (frame)
   "Adjust the font settings of FRAME so Emacs can display emoji properly."
-  (cond
-   ((spacemacs/system-is-mac)
-    (set-fontset-font t 'symbol
-                      (font-spec :family "Apple Color Emoji")
-                      frame 'prepend))
-   ((spacemacs/system-is-linux)
-    (set-fontset-font t 'symbol
-                      (font-spec :family "Symbola")
-                      frame 'prepend))))
+  (when (fboundp 'set-fontset-font)
+    (cond
+     ((spacemacs/system-is-mac)
+      (set-fontset-font t 'symbol
+                        (font-spec :family "Apple Color Emoji")
+                        frame 'prepend))
+     ((spacemacs/system-is-linux)
+      (set-fontset-font t 'symbol
+                        (font-spec :family "Symbola")
+                        frame 'prepend)))))
 
 (defun spacemacs//set-emoji-font-for-current-frame ()
   "Adjust the font settings of current frame so Emacs can display emoji


### PR DESCRIPTION
Got the following error when I am using a version of Emacs **not** compiled with a windows system.

`company-emoji :init: Symbol's function definition is void: set-fontset-font`

Then I saw this in the `company-emoji.el` https://github.com/dunn/company-emoji/blob/master/company-emoji.el

```el
;; **NB:** The `set-fontset-font` function is apparently only available
;;  when Emacs has been compiled with a window system.
```

I also found a similar fix for the osx layer in one of the merged PRs, https://github.com/syl20bnr/spacemacs/pull/4035.