### PR TITLE
The mu4e maildirs extension is now optional

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -1,6 +1,8 @@
 #+TITLE: Mu4e layer
 
 * Table of Contents                                         :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#commands][Commands]]
   - [[#global-bindings][Global bindings]]
@@ -15,6 +17,13 @@
     - [[#mode-line-notifications][Mode-line notifications]]
   - [[#spacemacs-layout-integration][Spacemacs layout integration]]
 - [[#see-also][See also]]
+
+* Description
+  This layer adds support for the [[https://www.djcbsoftware.nl/code/mu/mu4e.html][Mu4e]] email-client.
+
+** Features:
+- Maildir summary using [[https://github.com/agpchil/mu4e-maildirs-extension][mu4e-mailidrs-extension]]
+- Notifications using [[https://github.com/iqbalansari/mu4e-alert][mu4e-alert]]
 
 * Install
 In order to use this layer you must install mu and mu4e separately. Typically
@@ -69,13 +78,18 @@ example configuration.  Refer to mu4e's manual for more detailed configuration
 instructions.
 
 ** Maildirs extension
-The maildirs extension adds a list of all your maildirs to the main mu4e view
+The [[https://github.com/agpchil/mu4e-maildirs-extension][maildirs extension]] adds a list of all your maildirs to the main mu4e view
 that by default shows the unread and total mail counts for all your mail under
 your base mail directory.
 
-This extension is enabled by default, you can deactivate (and uninstall) it by
-adding the package =mu4e-maildirs-extension= to your dotfile variable
-=dotspacemacs-excluded-packages=.
+The maildirs extension is not enabled by default. To activate it, change the
+variable =mu4e-use-maildirs-extension= to a non-nil value:
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((mu4e :variables
+                        mu4e-use-maildirs-extension t)))
+#+end_src
 
 ** Multiple Accounts
 With `mu 0.9.16`, mu4e comes with a native contexts feature for managing

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -24,5 +24,8 @@
 (defvar mu4e-enable-mode-line nil
   "If non-nil, enable display of unread emails in mode-line.")
 
+(defvar mu4e-use-maildirs-extension nil
+  "Use mu4e-maildirs-extension package if value is non-nil.")
+
 (when mu4e-installation-path
   (push mu4e-installation-path load-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -91,8 +91,10 @@
               (mu4e-alert-enable-mode-line-display)))))
 
 (defun mu4e/init-mu4e-maildirs-extension ()
+  "If mu4e-use-maildirs-extension is non-nil, set
+mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
   (use-package mu4e-maildirs-extension
-    :defer t
+    :if mu4e-use-maildirs-extension
     :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load))))
 
 (defun mu4e/pre-init-org ()


### PR DESCRIPTION
I was wondering why #4892 never led to anything, but it seems that I never actually created a PR for this.