### PR TITLE
Add :evil-init, :holy-init, :evil-config and :holy-config to use-package keywords

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -304,7 +304,58 @@
   (setq use-package-verbose init-file-debug
         ;; inject use-package hooks for easy customization of stock package
         ;; configuration
-        use-package-inject-hooks t))
+        use-package-inject-hooks t)
+
+
+  (add-to-list 'use-package-keywords :evil-init t)
+  (defalias 'use-package-normalize/:evil-init 'use-package-normalize-forms)
+  (defun use-package-handler/:evil-init (name-symbol keyword arg rest state)
+    (when (bound-and-true-p evil-mode)
+      (let ((body (use-package-process-keywords name rest state)))
+        (use-package-concat
+         ;; The user's initializations for evil-mode
+         (let ((init-body
+                (use-package-hook-injector (use-package-as-string name)
+                                           :init arg)))
+           init-body)
+         body))))
+  (add-to-list 'use-package-keywords :evil-config t)
+  (defalias 'use-package-normalize/:evil-config 'use-package-normalize-forms)
+  (defun use-package-handler/:evil-config (name-symbol keyword arg rest state)
+    (when (bound-and-true-p evil-mode)
+      (let ((body (use-package-process-keywords name rest state)))
+        (use-package-concat
+         ;; The user's configurations for evil-mode
+         (let ((config-body
+                (use-package-hook-injector (use-package-as-string name)
+                                           :config arg)))
+           config-body)
+         body))))
+  (add-to-list 'use-package-keywords :holy-init t)
+  (defalias 'use-package-normalize/:holy-init 'use-package-normalize-forms)
+  (defun use-package-handler/:holy-init (name-symbol keyword arg rest state)
+    (when (bound-and-true-p holy-mode)
+      (let ((body (use-package-process-keywords name rest state)))
+        (use-package-concat
+         ;; The user's initializations for holy-mode
+         (let ((init-body
+                (use-package-hook-injector (use-package-as-string name)
+                                           :init arg)))
+           init-body)
+         body))))
+  (add-to-list 'use-package-keywords :holy-config t)
+  (defalias 'use-package-normalize/:holy-config 'use-package-normalize-forms)
+  (defun use-package-handler/:holy-config (name-symbol keyword arg rest state)
+    (when (bound-and-true-p holy-mode)
+      (let ((body (use-package-process-keywords name rest state)))
+        (use-package-concat
+         ;; The user's configurations for holy-mode
+         (let ((config-body
+                (use-package-hook-injector (use-package-as-string name)
+                                           :config arg)))
+           config-body)
+         body))))
+  )
 
 (defun spacemacs-bootstrap/init-which-key ()
   (require 'which-key)


### PR DESCRIPTION
This PR would close https://github.com/syl20bnr/spacemacs/issues/903.

Please check it out - I'm not very sure of the interface with use-package (do you need to place your keywords in a specific place in `use-package-keywords`?). The code also isn't very DRY or lispy - please forgive me and let me know what the best way to do this would be. I'm particularly unsure of the location of my changes.

Hopefully it'll simplify package inits/configs for some packages!

Basically, this will let you do:

```elisp
(defun helpful-layer/init-helpful()
    (use-package helpful
      :evil-init (evil-define-key whatever) ;more evil specific init here
      :holy-config (holy-something ;holy specific config
)))
```

or `:evil-config` or `:holy-config`.

I suppose this could become a bigger PR, changing layers and other `use-package` uses to use this paradigm, but I wanted to get feedback first! I personally don't even know if this is particularly useful, since the original issue hasn't been touched in a Long Time. Let me know! ♥️