### PR TITLE
add .spacemacs config for the initial scratch message

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -121,6 +121,9 @@ If the value is nil then no banner is displayed.")
 (defvar dotspacemacs-scratch-mode 'text-mode
   "Default major mode of the scratch buffer.")
 
+(defvar dotspacemacs-initial-scratch-message 'nil
+  "Initial message in the scratch buffer.")
+
 (defvar dotspacemacs-check-for-update nil
   "If non nil then spacemacs will check for updates at startup
 when the current branch is not `develop'. Note that checking for

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -122,6 +122,8 @@ It should only modify the values of Spacemacs settings."
    dotspacemacs-startup-buffer-responsive t
    ;; Default major mode of the scratch buffer (default `text-mode')
    dotspacemacs-scratch-mode 'text-mode
+   ;; Initial message in the scratch buffer, such as "Welcome to Spacemacs!" (default nil)
+   dotspacemacs-initial-scratch-message nil
    ;; List of themes, the first of the list is loaded when spacemacs starts.
    ;; Press `SPC T n' to cycle to the next theme in the list (works great
    ;; with 2 themes variants, one dark and one light)

--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -153,7 +153,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; ---------------------------------------------------------------------------
 
 ;; scratch buffer empty
-(setq initial-scratch-message nil)
+(setq initial-scratch-message dotspacemacs-initial-scratch-message)
 ;; don't create backup~ files
 (setq make-backup-files nil)
 


### PR DESCRIPTION
This allows configuration of the initial scratch buffer contents, closing #5906.

I personally don't know why you'd want to put a message in there, but evidently some people do, so this will allow that to happen. I guess you could combine it with setting the `dotspacemacs-scratch-mode` to `org-mode` and put your basic notes outline into the scratch message. I dunno!

Anyway, this'll allow that to happen. ♥️