### PR TITLE
purpose: disable popwin-mode at startup

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -82,7 +82,13 @@
                              do (purpose-set-window-purpose-dedicated-p
                                  window t))))
       (add-hook 'purpose-mode-hook #'spacemacs/window-purpose-sync-popwin)
-      (spacemacs/window-purpose-sync-popwin))))
+      (spacemacs/window-purpose-sync-popwin)
+      ;; can't have both `purpose-mode' and `popwin-mode' active at the same
+      ;; time (see https://github.com/syl20bnr/spacemacs/issues/9593), but we
+      ;; use `popwin' for its configuration so we can't just exclude it, so
+      ;; current solution is to disable `popwin-mode' (which is enabled in
+      ;; popwin's :config block)
+      (popwin-mode -1))))
 
 (defun spacemacs-purpose/init-spacemacs-purpose-popwin ()
   (use-package spacemacs-purpose-popwin


### PR DESCRIPTION
Fixes #9593 

`popwin-mode` is disable in popwin's use-package's `:config` block, so we disable it immediately afterwards. A better solution is to not install popwin at all when window-purpose is used, but currently we rely on popwin's configuration even for popup windows powered by window-purpose.