### PR TITLE
Fix update packages on Emacs 26

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1854,8 +1854,7 @@ to update."
             (let* ((src-dir (configuration-layer//get-package-directory pkg))
                    (dest-dir (expand-file-name
                               (concat rollback-dir
-                                      (file-name-as-directory
-                                       (file-name-nondirectory src-dir))))))
+                                      (file-name-nondirectory src-dir)))))
               (copy-directory src-dir dest-dir 'keeptime 'create 'copy-content)
               (push (cons pkg (file-name-nondirectory src-dir))
                     update-packages-alist))))


### PR DESCRIPTION
Do not convert destination dir to a directory name as the behavior of
copy-directory has changed:

https://github.com/emacs-mirror/emacs/commit/e22794867d878d53675fcc91d2ef1ad2494a2ff2#diff-725cb3c0ff9b6d12e3ace616eb5b0d0d

Fixes #9599 

It would be worth testing this on emacs 25 and maybe on Windows to ensure that this did not introduce any breaks. 