### PR TITLE
add bindings to navigate between errors in tex mode

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -128,6 +128,8 @@ By default, the underlying latex code is echoed in the echo area.
 | ~SPC m k~     | kill TeX job                               |
 | ~SPC m l~     | recenter output buffer                     |
 | ~SPC m m~     | insert LaTeX macro                         |
+| ~SPC m n~     | goto next error                            |
+| ~SPC m N~     | goto previous error                        |
 | ~SPC m s~     | insert LaTeX section                       |
 | ~SPC m v~     | view output                                |
 | ~SPC m h d~   | TeX documentation, can be very slow        |

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -62,6 +62,8 @@
           "k"   'TeX-kill-job                                ;; C-c C-k
           "l"   'TeX-recenter-output-buffer                  ;; C-c C-l
           "m"   'TeX-insert-macro                            ;; C-c C-m
+          "n"   'TeX-next-error                              ;; C-c `
+          "N"   'TeX-previous-error                          ;; M-m g
           "v"   'TeX-view                                    ;; C-c C-v
           ;; TeX-doc is a very slow function
           "hd"  'TeX-doc


### PR DESCRIPTION
Add two bindings to navigate back and forth between errors in tex mode.

Ideally, the binding for the next error should have been something like `SPC m e n`, but `SPC m e` is already taken for environment commands.