### PR TITLE
ch special keys line to more readable form

### DIFF
--- a/doc/BEGINNERS_TUTORIAL.org
+++ b/doc/BEGINNERS_TUTORIAL.org
@@ -111,8 +111,11 @@ Emacs, we will use Emacs conventions for keybinding notation. The most important
 modifier keys are:
 
 ~SPC~ = ~Space~, used as the leader key in Vim editing style.
+
 ~C-~ = ~Ctrl~
-~M-~ (for "meta") = ~Alt~
+
+~M-~ ("meta") = ~Alt~
+
 ~S-~ = ~Shift~
 
 The modifier keys can be used either in a sequence or as key chords by pressing


### PR DESCRIPTION
Form: C- = Ctrl M- (for “meta”) = Alt S- = Shift - is unreadable.

Let's change that, making point on every of this major keys.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3