### PR TITLE
spacemacs-layouts: Use counsel-projectile-switch-project-action

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -368,18 +368,24 @@ perspectives does."
 
 ;; Ivy integration
 
+(defun spacemacs/ivy-persp-switch-project-advice (project)
+  (let ((persp-reset-windows-on-nil-window-conf t))
+    (persp-switch project)))
+
 (defun spacemacs/ivy-persp-switch-project (arg)
   (interactive "P")
+  (advice-add 'counsel-projectile-switch-project-action
+              :before #'spacemacs/ivy-persp-switch-project-advice)
   (ivy-read "Switch to Project Perspective: "
             (if (projectile-project-p)
                 (cons (abbreviate-file-name (projectile-project-root))
                       (projectile-relevant-known-projects))
               projectile-known-projects)
-            :action (lambda (project)
-                      (let ((persp-reset-windows-on-nil-window-conf t))
-                        (persp-switch project)
-                        (let ((projectile-completion-system 'ivy))
-                          (projectile-switch-project-by-name project))))))
+            :action #'counsel-projectile-switch-project-action
+            :require-match t
+            :caller 'spacemacs/ivy-persp-switch-project)
+  (advice-remove 'counsel-projectile-switch-project-action
+                 'spacemacs/ivy-persp-switch-project-advice))
 
 
 ;; Eyebrowse

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -231,4 +231,5 @@
 
 
 (defun spacemacs-layouts/post-init-swiper ()
+  (ivy-set-actions 'spacemacs/ivy-persp-switch-project counsel-projectile-switch-project-actions)
   (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project))


### PR DESCRIPTION
Use `counsel-projectile-switch-project-action` instead of
`projectile-switch-project-by-name`, to match the additional actions available
via `counsel-projectile-switch-project` ( <kbd>SPC</kbd> <kbd>p</kbd> <kbd>p</kbd> ).