### PR TITLE
Issue #8134 Correctly return non-nil for dotspacemacs-additional-packages

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1447,7 +1447,7 @@ RNAME is the name symbol of another existing layer."
          (not (oref obj :excluded))
          (not (memq nil (mapcar
                          'configuration-layer/package-used-p
-                         (oref obj :requires)))))))
+                         (oref-default obj :requires)))))))
 (defalias 'configuration-layer/package-usedp
   'configuration-layer/package-used-p)
 


### PR DESCRIPTION
`configuration-layer/package-used-p` would not return non-nil for any packages
added via `dotspacemacs-additional-packages`. It appears that the :requires slot
is unbound on such packages so I changed the call to oref-default from oref so
that the proper initform (`nil`) is returned instead.

I did try using some form of `(when (slot-boundp obj 'requires))` to only
perform the check when the slot is bound but for some reason slot-boundp threw
the same error that oref did. I will be investigating this further and
potentially submitting a bug upstream but `oref-default` seems like a fine
solution for this problem.

EDIT:
Putting issue #8134 in the description so it links I thought the subject line would.