### PR TITLE
fix spelling of variable in documentation

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1178,7 +1178,7 @@ Disable line numbers in dired-mode, doc-view-mode, markdown-mode, org-mode,
 pdf-view-mode, text-mode as well as buffers over 1Mb:
 
 #+BEGIN_SRC emacs-lisp
-(setq-default dotspacemacs-lines-numbers '(:relative nil
+(setq-default dotspacemacs-line-numbers '(:relative nil
                                            :disabled-for-modes dired-mode
                                                                doc-view-mode
                                                                markdown-mode
@@ -1191,7 +1191,7 @@ pdf-view-mode, text-mode as well as buffers over 1Mb:
 Relative line numbers only in c-mode and c++ mode with a size limit of =dotspacemacs-large-file-size=:
 
 #+BEGIN_SRC emacs-lisp
-(setq-default dotspacemacs-lines-numbers '(:relative t
+(setq-default dotspacemacs-line-numbers '(:relative t
                                            :enabled-for-modes c-mode
                                                               c++-mode
                                            :size-limit-kb (* dotspacemacs-large-file-size 1000))
@@ -1200,14 +1200,14 @@ Relative line numbers only in c-mode and c++ mode with a size limit of =dotspace
 Enable line numbers everywhere, except for buffers over 1Mb:
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-lines-numbers '(:relative nil
+  (setq-default dotspacemacs-line-numbers '(:relative nil
                                              :size-limit-kb 1000))
 #+END_SRC
 
 Enable line numbers only in programming modes, except for c-mode and c++ mode:
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-lines-numbers '(:relative nil
+  (setq-default dotspacemacs-line-numbers '(:relative nil
                                              :enabled-for-modes prog-mode
                                              :disabled-for-modes c-mode c++-mode
                                              :size-limit-kb (* dotspacemacs-large-file-size 1000))


### PR DESCRIPTION
dotspacemacs-lines-numbers -> dotspacemacs-line-numbers

