### PR TITLE
Rebuild spacemacs-sql-startable after running sql-add-product

### DIFF
--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -35,6 +35,7 @@
                                   (lambda (product) (sql-get-product-feature (car product) :sqli-program))
                                   sql-product-alist)))
       (advice-add 'sql-add-product :after #'spacemacs/sql-populate-products-list)
+      (advice-add 'sql-del-product :after #'spacemacs/sql-populate-products-list)
       (spacemacs/sql-populate-products-list)
 
       (defun spacemacs//sql-source (products)

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -23,14 +23,19 @@
     :init (spacemacs/register-repl 'sql 'spacemacs/sql-start "sql")
     :config
     (progn
-      (setq spacemacs-sql-highlightable sql-product-alist
-            spacemacs-sql-startable (remove-if-not
-                                (lambda (product) (sql-get-product-feature (car product) :sqli-program))
-                                sql-product-alist)
-
+      (setq
             ;; should not set this to anything else than nil
             ;; the focus of SQLi is handled by spacemacs conventions
             sql-pop-to-buffer-after-send-region nil)
+      (defun spacemacs/sql-populate-products-list (&rest args)
+        "Update Spacemacs list of sql products"
+        (setq
+         spacemacs-sql-highlightable sql-product-alist
+         spacemacs-sql-startable (remove-if-not
+                                  (lambda (product) (sql-get-product-feature (car product) :sqli-program))
+                                  sql-product-alist)))
+      (advice-add 'sql-add-product :after #'spacemacs/sql-populate-products-list)
+      (spacemacs/sql-populate-products-list)
 
       (defun spacemacs//sql-source (products)
         "return a source for helm selection"


### PR DESCRIPTION
This fixes a small issue with `spacemacs/sql-start`. The layer initialization currently builds the variable `spacemacs-sql-startable` on loading the layer.  However, sql-mode supports adding new products dynamically using the `sql-add-product` function[1], which modifies the referenced `sql-products-alist` variable.  Currently, products added in user-config in an `eval-after-load 'sql` will not appear in the list of products to select with `spacemacs/sql-start`.

This patch wraps the definition of `spacemacs-sql-startable` in a function, and advises the sql-add-product function to call the former after it's done its work.  For completeness, it also advises `sql-del-product` to do the same.

[1]: Typical use cases of this are new SQL dialects not supported by the main package; a github [search](https://github.com/search?l=Emacs+Lisp&q=sql-add-product+&type=Code&utf8=✓) shows a number of examples in wild.  