### PR TITLE
Add alex-hhh's sql-indent in place of mepla sql-indent

### DIFF
--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -13,7 +13,10 @@
       '(
         company
         sql
-        sql-indent
+        (sql-indent :location (recipe
+                               :fetcher github
+                               :repo "alex-hhh/emacs-sql-indent"
+                               :files ("sql-indent.el")))
         (sqlup-mode :toggle sql-capitalize-keywords)
         ))
 
@@ -126,7 +129,11 @@
 
 (defun sql/init-sql-indent ()
   (use-package sql-indent
-    :defer t))
+    :init (progn (add-hook 'sql-mode-hook 'sqlind-minor-mode))
+    ;; breaks the mode-line globally
+    ;; :config (progn (spacemacs|diminish 'sqlind-minor-mode))
+    )
+  )
 
 (defun sql/init-sqlup-mode ()
   (use-package sqlup-mode

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -13,10 +13,7 @@
       '(
         company
         sql
-        (sql-indent :location (recipe
-                               :fetcher github
-                               :repo "alex-hhh/emacs-sql-indent"
-                               :files ("sql-indent.el")))
+        (sql-indent :location elpa)
         (sqlup-mode :toggle sql-capitalize-keywords)
         ))
 
@@ -129,11 +126,9 @@
 
 (defun sql/init-sql-indent ()
   (use-package sql-indent
+    :defer t
     :init (progn (add-hook 'sql-mode-hook 'sqlind-minor-mode))
-    ;; breaks the mode-line globally
-    ;; :config (progn (spacemacs|diminish 'sqlind-minor-mode))
-    )
-  )
+    :config (progn (spacemacs|diminish sqlind-minor-mode))))
 
 (defun sql/init-sqlup-mode ()
   (use-package sqlup-mode


### PR DESCRIPTION
This replaces the MELPA sql-indent with a supported and far more featureful implementation: https://github.com/alex-hhh/emacs-sql-indent

