### PR TITLE
Improved emacs lisp layer

### DIFF
--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -9,7 +9,9 @@
 - [[#auto-compile][Auto-compile]]
 - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
 - [[#debugging-elisp][Debugging Elisp]]
+- [[#nameless][Nameless]]
 - [[#key-bindings][Key bindings]]
+  - [[#additional-testing-functions-with-overseer][Additional testing functions with overseer]]
   - [[#additional-evaluation-functions][Additional evaluation functions]]
   - [[#format-code][Format code]]
   - [[#debugging][Debugging]]
@@ -25,6 +27,8 @@ always be in your dotfile, it is not recommended to uninstall it.
 - Support for specific lisp navigation styles via =emacs-lisp-mode=
 - Auto-compile via [[https://github.com/tarsius/auto-compile][auto-compile]] package
 - Debuggin via [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Edebug.html#Edebug][edebug]]
+- Ert test runner with [[https://github.com/tonini/overseer.el][overseer]]
+- Nameless package prefix with [[https://github.com/Malabarba/Nameless][nameless]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -93,6 +97,13 @@ function or press ~o~ to go out of it.
 
 7) Press ~a~ to stop debugging.
 
+* Nameless
+Nameless hides package namespaces in your emacs-lisp code, adn replace it by leading ~:~
+It can be toggled by ~SPC m~.
+
+To have it automatically on, you need to add ~(setq nameless-auto-mode t)~ in ~dotspacemacs/user-init~.
+Further configuration can be done with variable ~nameless-global-aliases~, cf [[https://github.com/Malabarba/Nameless#requiring-other-packages-as-aliases][original library documentation]]
+
 * Key bindings
 
 | Key Binding                | Description                                            |
@@ -112,6 +123,22 @@ function or press ~o~ to go out of it.
 | ~SPC m t b~                | run tests of current buffer                            |
 | ~SPC m t q~                | run =ert=                                              |
 | ~SPC m d m~                | open [[https://github.com/joddie/macrostep][macrostep]] transient-state                         |
+| ~SPC m :~                  | toggle nameless minor mode                             |
+
+** Additional testing functions with overseer
+Function related to test are present under the ~SPC m t~ prefix:
+
+| Key Binding | Description   |
+|-------------+---------------|
+| ~SPC m t a~ | overseer test |
+| ~SPC m t A~ | test debug    |
+| ~SPC m t t~ | run test      |
+| ~SPC m t b~ | test buffer   |
+| ~SPC m t f~ | test file     |
+| ~SPC m t g~ | test tags     |
+| ~SPC m t p~ | test prompt   |
+| ~SPC m t q~ | test quiet    |
+| ~SPC m t h~ | test help     |
 
 ** Additional evaluation functions
 If =smartparens= is used the following additional key bindings are available:

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -98,11 +98,13 @@ function or press ~o~ to go out of it.
 7) Press ~a~ to stop debugging.
 
 * Nameless
-Nameless hides package namespaces in your emacs-lisp code, adn replace it by leading ~:~
-It can be toggled by ~SPC m~.
+Nameless hides package namespaces in your emacs-lisp code, and replaces it by leading ~:~
+It can be toggled by ~SPC m :~.
 
-To have it automatically on, you need to add ~(setq nameless-auto-mode t)~ in ~dotspacemacs/user-init~.
-Further configuration can be done with variable ~nameless-global-aliases~, cf [[https://github.com/Malabarba/Nameless#requiring-other-packages-as-aliases][original library documentation]]
+To have it automatically on, you need to define a layer variable:
+=(emacs-lisp :variables emacs-lisp-nameless-mode t)= in =.spacemacs= =dotspacemacs/layers=
+
+Further configuration can be done with the custom variable =nameless-global-aliases=, cf [[https://github.com/Malabarba/Nameless#requiring-other-packages-as-aliases][original library documentation]]
 
 * Key bindings
 

--- a/layers/+lang/emacs-lisp/config.el
+++ b/layers/+lang/emacs-lisp/config.el
@@ -13,3 +13,6 @@
 
 (spacemacs|define-jump-handlers emacs-lisp-mode)
 (spacemacs|define-jump-handlers lisp-interaction-mode)
+
+(defvar emacs-lisp-nameless-mode nil
+  "If non-nil, nameless-mode is automatically turn on for emacs-lisp buffers.")

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -24,6 +24,7 @@
         helm-gtags
         (ielm :location built-in)
         macrostep
+        nameless
         overseer
         parinfer
         semantic
@@ -176,6 +177,17 @@
         ("q" macrostep-collapse-all :exit t))
       (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
         "dm" 'spacemacs/macrostep-transient-state/body))))
+
+(defun emacs-lisp/init-nameless ()
+  (use-package nameless
+    :defer t
+    :init (progn
+            (add-hook 'emacs-lisp-mode-hook 'nameless-mode-from-hook)
+            (spacemacs|add-toggle nameless
+              :status nameless-mode
+              :on (nameless-mode)
+              :off (nameless-mode -1)
+              :evil-leader-for-mode (emacs-lisp-mode . ":")))))
 
 (defun emacs-lisp/init-overseer ()
   (use-package overseer

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -181,14 +181,15 @@
 (defun emacs-lisp/init-nameless ()
   (use-package nameless
     :defer t
-    :init (progn
-            (when (bound-and-true-p nameless-auto-mode)
-             (add-hook 'emacs-lisp-mode-hook 'nameless-mode-from-hook))
-            (spacemacs|add-toggle nameless
-              :status nameless-mode
-              :on (nameless-mode)
-              :off (nameless-mode -1)
-              :evil-leader-for-mode (emacs-lisp-mode . ":")))))
+    :init
+    (progn
+      (when emacs-lisp-nameless-mode
+        (add-hook 'emacs-lisp-mode-hook 'nameless-mode-from-hook))
+      (spacemacs|add-toggle nameless
+        :status nameless-mode
+        :on (nameless-mode)
+        :off (nameless-mode -1)
+        :evil-leader-for-mode (emacs-lisp-mode . ":")))))
 
 (defun emacs-lisp/init-overseer ()
   (use-package overseer

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -182,7 +182,8 @@
   (use-package nameless
     :defer t
     :init (progn
-            (add-hook 'emacs-lisp-mode-hook 'nameless-mode-from-hook)
+            (when (bound-and-true-p nameless-auto-mode)
+             (add-hook 'emacs-lisp-mode-hook 'nameless-mode-from-hook))
             (spacemacs|add-toggle nameless
               :status nameless-mode
               :on (nameless-mode)

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -24,6 +24,7 @@
         helm-gtags
         (ielm :location built-in)
         macrostep
+        overseer
         parinfer
         semantic
         smartparens
@@ -175,6 +176,21 @@
         ("q" macrostep-collapse-all :exit t))
       (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
         "dm" 'spacemacs/macrostep-transient-state/body))))
+
+(defun emacs-lisp/init-overseer ()
+  (use-package overseer
+    :defer t
+    :init (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
+            "ta" 'overseer-test
+            "tt" 'overseer-test-run-test
+            "tb" 'overseer-test-this-buffer
+            "tf" 'overseer-test-file
+            "tg" 'overseer-test-tags
+            "tp" 'overseer-test-prompt
+            "tA" 'overseer-test-debug
+            "tq" 'overseer-test-quiet
+            "tv" 'overseer-test-verbose
+            "th" 'overseer-help)))
 
 (defun emacs-lisp/post-init-evil ()
   (add-hook 'emacs-lisp-mode-hook

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -158,7 +158,8 @@
 (defun emacs-lisp/init-macrostep ()
   (use-package macrostep
     :defer t
-    :mode ("\\*.el\\'" . emacs-lisp-mode)
+    :mode (("\\*.el\\'" . emacs-lisp-mode)
+           ("Cask\\'" . emacs-lisp-mode))
     :init
     (progn
       (evil-define-key 'normal macrostep-keymap "q" 'macrostep-collapse-all)


### PR DESCRIPTION
This PR improves the emacs-layer by:

- identifying `Cask` files as emacs-lisp file
- addign the overseer package, and bindings it's commands to run test to the <kbd>,t</kbd> prefix