### PR TITLE
Enable purescript-decl-scan-mode when loading purescript-mode

### DIFF
--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -33,6 +33,7 @@
     :init
     (progn
       (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
+      (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "i="  'purescript-mode-format-imports
         "i`"  'purescript-navigate-imports-return


### PR DESCRIPTION
This should fix `SPC j i` for PureScript