### PR TITLE
shell: use toggle-truncate-lines-on in README

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -160,7 +160,7 @@ Finally you may need to toggle truncated lines for some prompts to work
 correctly, in the function =dotspacemacs/user-config= of your dotfile add:
 
 #+BEGIN_SRC emacs-lisp
-(add-hook 'term-mode-hook 'toggle-truncate-lines)
+(add-hook 'term-mode-hook 'spacemacs/toggle-truncate-lines-on)
 #+END_SRC
 
 * Eshell


### PR DESCRIPTION
Fix docs for "Fish shell and ansi-term" and explicitly enable `truncate-lines`.

I was using the suggested hook as well as `(setq-default truncate-lines t)`,
so my fish shell was acting funny because `truncate-lines` was being disabled 
rather than enabled.