### PR TITLE
Bind org-meta-return for graphical display

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -316,6 +316,12 @@ Will work on both org-mode and any mode that accepts plain html."
         (kbd (concat dotspacemacs-major-mode-emacs-leader-key " '"))
         'org-edit-src-exit)
 
+      ;; In graphical mode, the default value for
+      ;; `dotspacemacs-major-mode-emacs-leader-key', "C-M-m", will
+      ;; override org-mode's binding for "M-RET".
+      (when (display-graphic-p)
+        (define-key org-mode-map (kbd "M-<return>") 'org-meta-return))
+
       ;; Evilify the calendar tool on C-c .
       (unless (eq 'emacs dotspacemacs-editing-style)
         (define-key org-read-date-minibuffer-local-map (kbd "M-h")


### PR DESCRIPTION
Org mode binds org-meta-return to M-RET, but in graphical mode
Spacemacs will use M-RET as the major mode leader.

https://github.com/syl20bnr/spacemacs/issues/9603

(I don't use Spacemacs any more, but I requested the Org mode change so I thought I should fix this downstream issue in Spacemacs.)