### PR TITLE
Enable backward theme cycling and add dedicated transient-state

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -281,20 +281,24 @@ THEME."
       (eval `(spacemacs|do-after-display-system-init
               (load-theme ',theme-name t))))))
 
-(defun spacemacs/cycle-spacemacs-theme ()
-  "Cycle through themes defined in `dotspacemacs-themes.'"
-  (interactive)
-  (when spacemacs--cur-theme
-    ;; if current theme isn't in cycleable themes, start over
-    (setq spacemacs--cycle-themes
-          (or (cdr (memq spacemacs--cur-theme dotspacemacs-themes))
-              dotspacemacs-themes)))
-  (setq spacemacs--cur-theme (pop spacemacs--cycle-themes))
-  (let ((progress-reporter
-         (make-progress-reporter
-          (format "Loading theme %s..." spacemacs--cur-theme))))
-    (spacemacs/load-theme spacemacs--cur-theme nil 'disable)
-    (progress-reporter-done progress-reporter)))
+(defun spacemacs/cycle-spacemacs-theme (&optional backward)
+  "Cycle through themes defined in `dotspacemacs-themes.'
+Does it BACKWARD with universal-argument or negative command argument"
+  (interactive "P")
+  (let* ((reversed (member backward '(t - (4))))
+         (themes (if reversed (reverse dotspacemacs-themes) dotspacemacs-themes)))
+    (when spacemacs--cur-theme
+      (disable-theme spacemacs--cur-theme)
+      ;; if current theme isn't in cycleable themes, start over
+      (setq spacemacs--cycle-themes
+            (or (cdr (memq spacemacs--cur-theme themes))
+                themes)))
+    (setq spacemacs--cur-theme (pop spacemacs--cycle-themes))
+    (let ((progress-reporter
+           (make-progress-reporter
+            (format "Loading theme %s..." spacemacs--cur-theme))))
+      (spacemacs/load-theme spacemacs--cur-theme nil 'disable)
+      (progress-reporter-done progress-reporter))))
 
 (defadvice load-theme (after spacemacs/load-theme-adv activate)
   "Perform post load processing."

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -148,7 +148,17 @@
     (spacemacs/set-leader-keys (format "b%i" n)
       (intern (format "buffer-to-window-%s" n)))))
 ;; Cycling settings -----------------------------------------------------------
+(spacemacs|define-transient-state theme
+  :title "Themes Transient State"
+  :doc "\n[_p_/_<left>_] cycles backward,  [_n_/_<right>_] cycles forward, [_<up>_] helm-themes"
+  :bindings
+  ("n" spacemacs/cycle-spacemacs-theme)
+  ("p" (spacemacs/cycle-spacemacs-theme t))
+  ("<up>" helm-themes)
+  ("<left>" (spacemacs/cycle-spacemacs-theme t))
+  ("<right>" spacemacs/cycle-spacemacs-theme))
 (spacemacs/set-leader-keys "Tn" 'spacemacs/cycle-spacemacs-theme)
+(spacemacs/set-leader-keys "TN" 'spacemacs/theme-transient-state/body)
 ;; errors ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "en" 'spacemacs/next-error


### PR DESCRIPTION
+ Enable to cycle backward using negative or universal Argument
+ Add a transient state bound to <kbd>SPC T N</kbd> to quickly navigate through the themes

Original Commit List
- update cycle-spacemacs-theme function to work backward with universal arg
- add a transient-state hydra to cycle through the modes
- move the transient-state definition in the +distribution spacemacs-base
- refactor using hydra syntax for expression as command
- modified cycle-theme to handle negative command argument
- add keybing for helm-themes in the transient-state
