### PR TITLE
Fix documentation for elisp, color, ibuffer and windows-scripts

### DIFF
--- a/layers/+emacs/ibuffer/README.org
+++ b/layers/+emacs/ibuffer/README.org
@@ -2,8 +2,8 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
-  - [[#layer][Layer]]
   - [[#grouping-buffers][Grouping buffers]]
 - [[#key-bindings][Key bindings]]
   - [[#global][Global]]
@@ -12,8 +12,11 @@
 * Description
 This layer configures Emacs IBuffer for Spacemacs.
 
+** Features:
+- Grouping of buffers by major-modes
+- Grouping of buffers by projects
+
 * Install
-** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =ibuffer= to the existing =dotspacemacs-configuration-layers= list in this
 file.

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#auto-compile][Auto-compile]]
 - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
@@ -16,6 +17,14 @@
 * Description
 This layer gathers all the configuration related to emacs-lisp. This should
 always be in your dotfile, it is not recommended to uninstall it.
+
+** Features:
+- Auto-completion using company
+- Linting using flycheck integration
+- Repl support via =IELM=
+- Support for specific lisp navigation styles via =emacs-lisp-mode=
+- Auto-compile via [[https://github.com/tarsius/auto-compile][auto-compile]] package
+- Debuggin via [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Edebug.html#Edebug][edebug]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/windows-scripts/README.org
+++ b/layers/+lang/windows-scripts/README.org
@@ -4,18 +4,19 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
-  - [[#powershell][Powershell]]
+  - [[#powershell-powershellel][Powershell (powershell.el)]]
   - [[#batch-dosel][Batch (dos.el)]]
 
 * Description
 This simple layer adds support for the Powershell scripting language as well
 as support for batch files.
 
-Supported windows scription extensions:
-- =.ps1=: [[https://github.com/jschaf/powershell.el][powershell]]
-- =.bat=: [[http://www.emacswiki.org/emacs/dos.el][dos.el]]
+** Features:
+- Syntax highlighting of powershell =.ps1= files via [[https://github.com/jschaf/powershell.el][powershell.el]]
+- Syntax highlighting of batch =.bat= files via [[http://www.emacswiki.org/emacs/dos.el][dos.el]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -23,8 +24,11 @@ add =windows-scripts= to the existing =dotspacemacs-configuration-layers= list i
 file.
 
 * Key Bindings
-** Powershell
-No useful bindings.
+** Powershell (powershell.el)
+
+| Key Binding | Description                      |
+|-------------+----------------------------------|
+| ~SPC m r r~ | Transform marked regexp to regex |
 
 ** Batch (dos.el)
 

--- a/layers/+themes/colors/README.org
+++ b/layers/+themes/colors/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#colorize-identifiers][Colorize identifiers]]
@@ -14,13 +15,16 @@
   - [[#nyan-mode][Nyan Mode]]
 
 * Description
-This layer colors your life with the help of the following packages:
-- [[https://github.com/Fanael/rainbow-identifiers][rainbow-identifiers]] mode will colorize all identifiers (christmas tree mode :-))
-  with mostly unique colors, and the ability to choose saturation and lightness.
-- [[https://github.com/ankurdave/color-identifiers-mode][color-identifiers]] mode will colorize only identifiers recognized as variables.
-- [[https://julien.danjou.info/projects/emacs-packages][rainbow-mode]] displays strings representing colors with the color they
-  represent as background.
-- [[https://github.com/syl20bnr/nyan-mode][nyan-mode]] display a Nyan cat progress bar in the mode-line.
+This layer colors your life by enhancing the existing coloration of identifiers as well as providing you with a more colorful
+process indicator.
+
+** Features:
+- Colorize all identifiers (christmas tree mode :-)) with mostly unique colors, and the ability to choose saturation and lightness
+  with [[https://github.com/Fanael/rainbow-identifiers][rainbow-identifiers]].
+- Colorize only identifiers recognized as variables with [[https://github.com/ankurdave/color-identifiers-mode][color-identifiers]].
+- Colorize strings representing colors with the color they represent as background with
+  [[https://julien.danjou.info/projects/emacs-packages][rainbow-mode]].
+- Display a Nyan cat progress bar in the mode-line with [[https://github.com/syl20bnr/nyan-mode][nyan-mode]].
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
I have added the missing features block to the elisp, color, ibuffer and windows-scripts layers as was requested in #9476.