### PR TITLE
Prompt user to install react-mode if a .jsx file is opened

### DIFF
--- a/layers/auto-layer.el
+++ b/layers/auto-layer.el
@@ -43,10 +43,11 @@
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.slim\\'\\)" slim-mode))
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.phtml\\'\\|\\.tpl\\.php\\'\\|\\.twig\\'\\|\\.html\\'\\|\\.htm\\'\\|\\.[gj]sp\\'\\|\\.as[cp]x?\\'\\|\\.eex\\'\\|\\.erb\\'\\|\\.mustache\\'\\|\\.handlebars\\'\\|\\.hbs\\'\\|\\.eco\\'\\|\\.ejs\\'\\|\\.djhtml\\'\\)" web-mode))
 (configuration-layer/lazy-install 'idris :extensions '("\\(\\.idr$\\|\\.lidr$\\)" idris-mode))
-;; java
+;; javascript
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.coffee\\'\\|\\.iced\\'\\|Cakefile\\'\\|\\.cson\\'\\)" coffee-mode))
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.js\\'\\)" js2-mode))
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.json$\\)" json-mode))
+(configuration-layer/lazy-install 'react :extensions '("\\(\\.jsx$\\)" react-mode))
 ;; latex
 (configuration-layer/lazy-install 'lua :extensions '("\\(\\.lua$\\|\\.lua\\'\\)" lua-mode))
 (configuration-layer/lazy-install 'nginx :extensions '("\\(nginx\\.conf\\'\\|/nginx/.+\\.conf\\'\\)" nginx-mode))


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Bframeworks/react#description

Automatic prompts for installing modes happened when I opened .js, .rb, and .py files. I thought... why not for JSX files too?

Also fixed a comment that said these modes are for "java".

I tested this change against master + develop branches. When I answer "y" to the prompt, react gets added to my dotspacemacs-configuration-layers in ~/.spacemacs