### PR TITLE
Add `g r` evilified binding to gist-list-mode

### DIFF
--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -37,7 +37,13 @@
         "ggB" 'gist-buffer-private
         "ggl" 'gist-list
         "ggr" 'gist-region
-        "ggR" 'gist-region-private))))
+        "ggR" 'gist-region-private))
+    :config
+    (progn
+      (evilified-state-evilify-map gist-list-mode-map
+        :mode gist-list-mode
+        :bindings
+        (kbd "gr") 'gist-list-reload))))
 
 (defun github/init-github-clone ()
   (use-package github-clone


### PR DESCRIPTION
Fix for https://github.com/syl20bnr/spacemacs/issues/5570

The emacs `g` binding get shadowed in hybrid and vim mode.

This creates an evilified binding for the same command using `g r` which is very consistent with magit.