### PR TITLE
Add Perl5 Company backend and code formatter 

### DIFF
--- a/layers/+lang/perl5/README.org
+++ b/layers/+lang/perl5/README.org
@@ -7,16 +7,21 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#auto-completion-plsense][Auto-completion: PlSense]]
 - [[#key-bindings][Key Bindings]]
   - [[#perldoc][Perldoc]]
   - [[#pod-and-here-doc][POD and HERE doc]]
   - [[#find-symbol][Find Symbol]]
+  - [[#formating-code][Formating Code]]
 
 * Description
 This layer adds support for the Perl5 language.
 
 ** Features:
-- syntactic and semantic checking using [[https://github.com/flycheck/flycheck][flycheck]]
+- Syntactic and semantic checking using [[https://github.com/flycheck/flycheck][flycheck]]
+- Auto-completion using [[https://github.com/CeleritasCelery/company-plsense][company-plsense]]
+- Format code with =perltidy=
+- Jump to symbol definition
 
 * Install
 ** Layer
@@ -24,26 +29,37 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =perl5= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+** Auto-completion: PlSense
+=company-plsense= requires installation of the =plsense= server from [[https://github.com/aki2o/plsense#install][here]].
+
 * Key Bindings
 ** Perldoc
 Browse formated perldocs.
 
 | Key Binding | Description                     |
 |-------------+---------------------------------|
-| ~SPC m h p~ | view perldoc of symbol at point |
+| ~SPC m h h~ | view perldoc of symbol at point |
 | ~SPC m h d~ | view perldoc of any symbol      |
 
 ** POD and HERE doc
-select a POD or HERE doc
+Select a POD or HERE doc.
 
 | Key Binding | Description                            |
 |-------------+----------------------------------------|
 | ~SPC m v~   | select entire POD or HERE doc at point |
 
 ** Find Symbol
-jump to symbol definition
+Jump to symbol definition.
 
 | Key Binding | Description                               |
 |-------------+-------------------------------------------|
 | ~SPC m g g~ | jump to symbol definition                 |
 | ~SPC m g G~ | jump to symbol definition in other window |
+
+** Formating Code
+
+| Key Binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC m = =~ | format current line or region |
+| ~SPC m = b~ | format current buffer         |
+| ~SPC m = f~ | format current function       |

--- a/layers/+lang/perl5/config.el
+++ b/layers/+lang/perl5/config.el
@@ -10,3 +10,9 @@
 ;;; License: GPLv3
 
 (spacemacs|define-jump-handlers cperl-mode)
+
+(defvar perl5-perltidy-executable "perltidy"
+  "Location of perltidy executable.")
+
+(defvar perl5-perltidy-options '()
+  "Command line options to pass to perltidy")

--- a/layers/+lang/perl5/funcs.el
+++ b/layers/+lang/perl5/funcs.el
@@ -15,3 +15,36 @@
 
 (defun spacemacs//perl5-spartparens-disable ()
   (define-key cperl-mode-map "{" 'cperl-electric-lbrace))
+
+(defun spacemacs/perltidy-format ()
+  "Format Perl code with perltidy.
+If region is active, operate on it, else operate on line."
+  (interactive)
+  (let ((old-point (point))
+        (pos
+         (if (use-region-p)
+             (cons (region-beginning)
+                   (if (char-equal ?\n (char-before (region-end)))
+                       (region-end)
+                     (save-excursion ;; must including terminating newline
+                       (goto-char (region-end))
+                       (1+ (line-end-position)))))
+           (cons (line-beginning-position)
+                 (1+ (line-end-position))))))
+    (apply #'call-process-region (car pos) (cdr pos) perl5-perltidy-executable t '(t nil)
+           "--quiet"
+           "--standard-error-output"
+           perl5-perltidy-options)
+    (goto-char old-point)))
+
+(defun spacemacs/perltidy-format-buffer ()
+  "Format current buffer with perltidy."
+  (interactive)
+  (mark-whole-buffer)
+  (spacemacs/perltidy-format))
+
+(defun spacemacs/perltidy-format-function ()
+  "Format current function with perltidy."
+  (interactive)
+  (mark-defun)
+  (spacemacs/perltidy-format))

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -14,6 +14,7 @@
         (cperl-mode :location built-in)
         smartparens
         flycheck
+        (company-plsense :requires company)
         ))
 
 (defun perl5/init-cperl-mode ()
@@ -95,16 +96,21 @@
       (add-hook 'cperl-mode-hook
                 (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
 
+
+      (spacemacs/declare-prefix "m=" "format")
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "==" 'spacemacs/perltidy-format)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "=b" 'spacemacs/perltidy-format-buffer)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "=f" 'spacemacs/perltidy-format-function)
+
       (spacemacs/declare-prefix "mh" "perldoc")
-      (spacemacs/declare-prefix "mg" "find-symbol")
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hp" 'cperl-perldoc-at-point)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hh" 'cperl-perldoc-at-point)
       (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hd" 'cperl-perldoc)
+
+      (spacemacs/declare-prefix "mg" "find-symbol")
       (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "v" 'cperl-select-this-pod-or-here-doc)
 
       (font-lock-add-keywords 'cperl-mode
-                              '(("\\_<const\\|croak\\|carp\\|confess\\|cluck\\_>" . font-lock-keyword-face)))
-      (font-lock-add-keywords 'cperl-mode
-                              '(("\\_<say\\|any\\_>" . cperl-nonoverridable-face))))))
+                              '(("\\_<say\\_>" . cperl-nonoverridable-face))))))
 
 (defun perl5/post-init-smartparens ()
   ;; fixs a bug with electric mode and smartparens https://github.com/syl20bnr/spacemacs/issues/480
@@ -114,3 +120,11 @@
 
 (defun perl5/post-init-flycheck ()
   (spacemacs/enable-flycheck 'cperl-mode))
+
+(defun perl5/init-company-plsense ()
+  (use-package company-plsense
+    :defer t
+    :init
+    (spacemacs|add-company-backends
+     :backends company-plsense
+     :modes cperl-mode)))


### PR DESCRIPTION
Several Major improvements for the Perl5 layer that address requests in #8804
* added [company-plsense](https://github.com/CeleritasCelery/company-plsense) so we finally have company completion
* use `perltidy` to format code
* updated some keybindings to follow Spacemacs conventions
* removed font lock from nonstandard keywords