### PR TITLE
remove org table lighter in markdown mode

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -57,6 +57,7 @@
     :config
     (progn
       (add-hook 'markdown-mode-hook 'orgtbl-mode)
+      (spacemacs|diminish orgtbl-mode)
       (add-hook 'markdown-mode-hook 'spacemacs//cleanup-org-tables-on-save)
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")


### PR DESCRIPTION
`orgtbl-mode` adds a rather large and unnecessary lighter to `markdown-mode` so we diminish it to keep the look clean. 