### PR TITLE
Remove ess-R-object-popup from ess layer.

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -43,11 +43,10 @@ Send code to inferior process with these commands:
 ** Helpers
 Helpers for inspecting objects at point are available in R buffers only.
 
-| Key Binding | Description                                                         |
-|-------------+---------------------------------------------------------------------|
-| ~SPC m h d~ | view data under point using [ess-R-data-view][ess-R-data-view]      |
-| ~SPC m h i~ | object introspection popup [ess-R-object-popup][ess-R-object-popup] |
-| ~SPC m h t~ | view table using [ess-R-data-view][ess-R-data-view]                 |
+| Key Binding | Description                                                    |
+|-------------+----------------------------------------------------------------|
+| ~SPC m h d~ | view data under point using [ess-R-data-view][ess-R-data-view] |
+| ~SPC m h t~ | view table using [ess-R-data-view][ess-R-data-view]            |
 
 * Options
 To turn off the automatic replacement of underscores by =<-=, set in your

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -13,7 +13,6 @@
       '(
         ess
         ess-R-data-view
-        ess-R-object-popup
         (ess-smart-equals :toggle ess-enable-smart-equals)
         golden-ratio
         org))
@@ -100,7 +99,6 @@
       "sf" 'ess-eval-function
       ;; R helpers
       "hd" 'ess-R-dv-pprint
-      "hi" 'ess-R-object-popup
       "ht" 'ess-R-dv-ctable
       )
     (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
@@ -108,8 +106,6 @@
     (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)))
 
 (defun ess/init-ess-R-data-view ())
-
-(defun ess/init-ess-R-object-popup ())
 
 (defun ess/init-ess-smart-equals ()
   (use-package ess-smart-equals


### PR DESCRIPTION
As described in #9694, this package was removed from melpa for not having a GPL compatible license (it doesn't have any license at all) and is causing an error every time spacemacs starts.

A pull request myuhe/ess-R-object-popup.el#4 to add a license has been made in the original repository however it has sat for nearly a month unmerged, so I suggest removing the package from the layer in the meantime.

Alternatively it could be included directly into spacemacs as it's < 100 SLOC. Could there be licensing issues if we did that?