### PR TITLE
Fix documentation for parinfer, pdf-tools, yaml, csv and salt layer

### DIFF
--- a/layers/+lang/csv/README.org
+++ b/layers/+lang/csv/README.org
@@ -4,12 +4,22 @@
 
 * Table of Contents                                      :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
 - [[#key-bindings][Key Bindings]]
 
 * Description
 This layer adds tools for better integration of CSV files in Spacemacs.
+
+** Features:
+- Detecting of fields for various separators
+- Aligning of fields
+- Traversal of fields
+- Killing of fields
+- Sorting of rows
+- Transposing of rows/columns
+- Intelligent yanking of fields
 
 * Install
 ** Layer

--- a/layers/+lang/yaml/README.org
+++ b/layers/+lang/yaml/README.org
@@ -2,11 +2,16 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#syntax-checking-with-flycheck][Syntax checking with flycheck]]
 
 * Description
-This layer provides syntax highlighting and syntax checking via [[http://www.flycheck.org/en/latest/languages.html#yaml][flycheck]] for YAML files.
+This layer provides support for the YAML file format.
+
+** Features:
+- Syntax highlighting
+- Syntax checking via [[http://www.flycheck.org/en/latest/languages.html#yaml][flycheck]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -16,3 +21,6 @@ file.
 * Syntax checking with flycheck
 Flycheck checks YAML with yaml-jsyaml or yaml-ruby. The flycheck YAML
 documentation can be found at the [[http://www.flycheck.org/en/latest/languages.html#yaml][flycheck website]].
+
+Please notice that yaml-jsyaml requires node-js package js-yaml and that yaml-ruby requires ruby installed
+on your system to work.

--- a/layers/+misc/parinfer/README.org
+++ b/layers/+misc/parinfer/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
 - [[#key-bindings][Key bindings]]
@@ -11,6 +12,9 @@
 * Description
 This layer provides an implementation of [[https://shaunlebron.github.io/parinfer/][parinfer]], a lisp editing paradigm that
 controls indentation based on parentheses or vice versa.
+
+** Features:
+- Automatic managment of parenthesis in clojure, emacs lisp, common-lisp and scheme following the parinfer editing paradigm.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/pdf-tools/README.org
+++ b/layers/+tools/pdf-tools/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#prerequisites][Prerequisites]]
   - [[#dotfile][Dotfile]]
@@ -27,10 +28,11 @@ key difference is, that pages are not pre-rendered by e.g. ghostscript and
 stored in the file-system, but rather created on-demand and stored in memory."
 #+end_quote
 
-Examples of features that =pdf-tools= provides:
-- Use =occur= in the pdf file;
-- Show all headings in a outline buffer;
+** Features:
+- Searching and slicing with =occur=.
+- Show document headings in outline buffer.
 - Manipulate annotations.
+- Fit PDF to screen.
 
 * Install
 ** Prerequisites

--- a/layers/+tools/salt/README.org
+++ b/layers/+tools/salt/README.org
@@ -4,16 +4,24 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
 This layer provides syntax highlighting for Saltstack files.
 
+** Features:
+- Syntax highlighting
+- Display of salt documentation
+
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =salt= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+To view documentation in Emacs or inline with ElDoc, Python and the Salt Python
+libraries must be installed on the system containing the files being edited.
 
 * Key bindings
 


### PR DESCRIPTION
I have added the missing features block to the parinfer, pdf-tools, yaml, csv and salt layers. In addition I have fixed some small documentation issues like missing installation instructions for certain layer features.

For #9476 