### PR TITLE
Add ox-hugo

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -14,6 +14,7 @@
   - [[#gnuplot-support][Gnuplot support]]
   - [[#revealjs-support][Reveal.js support]]
   - [[#org-journal-support][Org-journal support]]
+  - [[#hugo-support][Hugo support]]
   - [[#different-bullets][Different bullets]]
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
@@ -200,6 +201,17 @@ For example:
                                                          org-journal-time-prefix "* "
                                                          org-journal-time-format "")
                                                     )
+#+END_SRC
+
+** Hugo support
+To install the Org exporter [[https://ox-hugo.scripter.co][ox-hugo]] that generates [[https://gohugo.io][Hugo]]-compatible Markdown
+/plus/ TOML/YAML front-matter, set the variable =org-enable-hugo-support= to
+=t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-hugo-support t)))
 #+END_SRC
 
 ** Different bullets

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -31,3 +31,6 @@ used.")
 
 (defvar org-enable-org-journal-support nil
   "If non-nil org-journal is configured.")
+
+(defvar org-enable-hugo-support nil
+  "If non-nil, Hugo (https://gohugo.io) related packages are configured.")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -37,6 +37,7 @@
                 :toggle org-enable-github-support)
         (ox-reveal :toggle org-enable-reveal-js-support)
         persp-mode
+        (ox-hugo :toggle org-enable-hugo-support)
         ))
 
 (defun org/post-init-company ()
@@ -605,3 +606,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "j" 'org-journal-new-entry
         "n" 'org-journal-open-next-entry
         "p" 'org-journal-open-previous-entry))))
+
+(defun org/init-ox-hugo ()
+  (use-package ox-hugo
+    :after ox))


### PR DESCRIPTION
About `ox-hugo`: https://ox-hugo.scripter.co

Resolves https://github.com/syl20bnr/spacemacs/issues/9663

Tested to work on a created-from-scratch spacemacs-base config created with
Emacs-style preference.

I just added below to dotspacemacs-configuration-layers

    (org :variables
         org-enable-hugo-support t)

@amosbird See if you can try out this PR on the develop branch of Spacemacs. I
wasted few hours trying to get this to work on the master/stable branch.. (which
is very buggy.. tries to install org-plus-contrib from GNU Elpa instead of Org
Elpa.)

After this PR, C-c C-e in an Org file shows the Hugo export options.
