### PR TITLE
Make nose fail compilation when tests fail

### DIFF
--- a/layers/+lang/python/local/nose/nose.el
+++ b/layers/+lang/python/local/nose/nose.el
@@ -93,7 +93,7 @@ For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-fro
   )
 
 (defun nosetests-nose-command ()
-  (let ((nose "python -u -c \"import nose; nose.run()\""))
+  (let ((nose "python -u -c \"import nose; nose.main()\""))
     (if python-shell-virtualenv-path
         (if (spacemacs/system-is-mswindows)
             (format "%s/Scripts/%s" python-shell-virtualenv-path nose)


### PR DESCRIPTION
While nose.run() returns a boolean, nose.main() returns 0 or 1 depending of the test results.
This number can be used to set the status of the `*compilation*` buffer.
So now if the tests fail, the `*compilation*` buffer will be in state `exited abnormally`
