### PR TITLE
Adds keybinding for updating packages

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1750,6 +1750,7 @@ Other help key bindings:
 | ~SPC h k~   | show top-level bindings with =which-key=              |
 | ~SPC h m~   | search available man pages                            |
 | ~SPC h n~   | browse emacs news                                     |
+| ~SPC h U~   | update packages                                       |
 
 Navigation key bindings in =help-mode=:
 

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -227,7 +227,8 @@
   "hdt" 'describe-theme
   "hdv" 'describe-variable
   "hI"  'spacemacs/report-issue
-  "hn"  'view-emacs-news)
+  "hn"  'view-emacs-news
+  "hU"  'configuration-layer/update-packages)
 ;; insert stuff ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "iJ" 'spacemacs/insert-line-below-no-indent


### PR DESCRIPTION
This is an action I do quite often since I like to have the latest packages (with the latest fixes) but I either have to type the name of the command inside `M-x` or navigate in the home buffer and press `C-m` on the `[Update Packages]` text.

I belive it's time to have a keybinding for this. I chose `SPC h` for it since it was the closest I can find to a spacemacs related prefix. Other that went trough my mind were: `SPC S` (for spacemacs) or `SPC E` (for emacs, or Editor).