### PR TITLE
Fix: company-dante -> dante-company

### DIFF
--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -50,7 +50,7 @@
 
 (defun spacemacs-haskell//setup-dante ()
   (spacemacs|add-company-backends
-    :backends (company-dante company-dabbrev-code company-yasnippet)
+    :backends (dante-company company-dabbrev-code company-yasnippet)
     :modes haskell-mode)
   (push 'xref-find-definitions spacemacs-jump-handlers)
   (dante-mode)


### PR DESCRIPTION
The backend is called dante-company by the dante package.