### PR TITLE
Fix name of window-purpose in readme

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/README.org
+++ b/layers/+spacemacs/spacemacs-purpose/README.org
@@ -20,7 +20,7 @@ and shouldn't change too much when opening all sorts of buffers.
 
 Regular [[https://github.com/m2ym/popwin-el][popwin]] is not triggered when window-purpose is enabled. However,
 the window-purpose layer provides a =purpose-popwin= extension, which
-brings popwin's behavior towindows-purpose and solves that problem.
+brings popwin's behavior to window-purpose and solves that problem.
 
 ** Features:
 - Window layout is more robust and less likely to change unintentionally
@@ -28,20 +28,20 @@ brings popwin's behavior towindows-purpose and solves that problem.
 - User-defined purposes
 - Extensible window display behavior
 - Empty =purpose-mode-map=, to avoid conflicts with other key maps
-- Replicate popwin behavior for purpose-mode - almost no regression in popup behavior from using windows-purpose.
+- Replicate popwin behavior for purpose-mode - almost no regression in popup behavior from using window-purpose.
 - Reuses popwin's settings: =popwin:special-display-config=, =popwin:popup-window-height= and =popwin:popup-window-width=.
 - Difference from popwin: when several windows are open, popup window is sometimes bigger than with regular popwin in the same situation.
 
 ** Purposes
-windows-purpose contains a configuration which assigns a purpose for each
+window-purpose contains a configuration which assigns a purpose for each
 buffer. Later, when Emacs needs to display a buffer in a window, its purpose
 helps make a better decision of which window to use.
 
 For example, consider the following case: Emacs frame shows three windows - one
 for code, one for a terminal and one general-purpose window. The general window
 is selected and you want to open a code file. How do you ensure that the code
-file will be displayed in the code window? With windows-purpose you don't
-need to worry about it - you open the file and windows-purpose places it in
+file will be displayed in the code window? With window-purpose you don't
+need to worry about it - you open the file and window-purpose places it in
 the correct
 window.
 
@@ -51,7 +51,7 @@ reserved only for buffers that share that purpose.
 ** switch-to-buffer and display-buffer
 In regular Emacs, =switch-to-buffer= follows different rules than the other
 switching and popping commands, because it doesn't use =display-buffer= (which
-the other commands do). With windows-purpose, this behavior is fixed. The
+the other commands do). With window-purpose, this behavior is fixed. The
 result is a better control over how buffers are displayed, since
 =switch-to-buffer= doesn't ignore the user's customizations anymore.
 
@@ -64,7 +64,7 @@ add spacemacs-purpose= to the existing =dotspacemacs-configuration-layers= list 
 this file.
 
 * Usage
-With windows-purpose layer installed, =purpose-mode= and =pupo-mode= are enabled.
+With window-purpose layer installed, =purpose-mode= and =pupo-mode= are enabled.
 You can toggle =purpose-mode= (~SPC : purpose-mode~) at any time to return to
 purpose-less behavior. You can toggle =pupo-mode= (~SPC : pupo-mode~) to turn
 off only the purpose-popwin integration.
@@ -73,14 +73,14 @@ If you change =popwin:special-display-config= in your =dotspacemacs/config=, you
 should call =pupo/update-purpose-config= to update purpose-popwin with those
 changes.
 
-See [[https://github.com/bmag/emacs-purpose/wiki][window-purpose wiki]] to learn more about windows-purpose.
+See [[https://github.com/bmag/emacs-purpose/wiki][window-purpose wiki]] to learn more about window-purpose.
 
 * Key Bindings
 
 | Key Binding | Description                                                                         |
 |-------------+-------------------------------------------------------------------------------------|
 | ~SPC r b~   | Open a buffer. Only buffers with the same purpose as the current buffer are listed. |
-| ~SPC r B~   | Open any buffer and ignore windows-purpose when displaying the buffer.              |
+| ~SPC r B~   | Open any buffer and ignore window-purpose when displaying the buffer.               |
 | ~SPC r d~   | Toggle dedication of selected window to its current purpose.                        |
 | ~SPC r D~   | Delete all non-dedicated windows.                                                   |
 | ~SPC r p~   | Choose a purpose and open a buffer with that purpose.                               |


### PR DESCRIPTION
The name of the package is actually `window-purpose`