### PR TITLE
Add leader key prefixes for sql-mode and sql-interactive-mode

### DIFF
--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -84,6 +84,11 @@
           (sql-send-region start end)
           (evil-insert-state)))
 
+      (spacemacs/declare-prefix-for-mode 'sql-mode "mb" "buffer")
+      (spacemacs/declare-prefix-for-mode 'sql-mode "mh" "dialects")
+      (spacemacs/declare-prefix-for-mode 'sql-mode "ms" "interactivity")
+      (spacemacs/declare-prefix-for-mode 'sql-mode "ml" "listing")
+
       (spacemacs/set-leader-keys-for-major-mode 'sql-mode
         "'" 'spacemacs/sql-start
 
@@ -111,6 +116,8 @@
         ;; listing
         "la" 'sql-list-all
         "lt" 'sql-list-table)
+
+      (spacemacs/declare-prefix-for-mode 'sql-interactive-mode "mb" "buffer")
 
       (spacemacs/set-leader-keys-for-major-mode 'sql-interactive-mode
         ;; sqli buffer


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/issues/9730

I named the prefix of both major modes found in the SQL layer.
I reused the names from the comments above their declaration.