### PR TITLE
README: allow people to go `stable` or participate in `develop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ This assumes you don't have an existing Emacs setup and want to run Spacemacs as
 your config. If you do have one, look at
 the [full installation instructions](#install) for other options.
 
-    git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d
+* For stable releases:
+  ```shell
+  git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d
+  ```
 
+* For development updates and participation:
+  ```shell
+  git clone -b develop https://github.com/syl20bnr/spacemacs ~/.emacs.d
+  ```
+  
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ the [full installation instructions](#install) for other options.
   ```shell
   git clone -b develop https://github.com/syl20bnr/spacemacs ~/.emacs.d
   ```
-  
+
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 


### PR DESCRIPTION
With this easy change:

* Every newcomer decide - to use `stable` or to go participate in `develop`
* Users automagically get informed there in Spacemacs this process, and where `stable` is and where is `develop` happening.
* People will know to look in `develop`, and over time `stable` people would create less bugreports already fixed in `develop`, so you also will get less bugreport duplicates from `stable` users that does not knew about `develop`.
* More testing and community participation in development. `develop` is now closed from eyes of users, make it more known and open.

Thank you for Spacemacs.