### PR TITLE
Add support for gruvbox theme variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ This assumes you don't have an existing Emacs setup and want to run Spacemacs as
 your config. If you do have one, look at
 the [full installation instructions](#install) for other options.
 
-    git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d
+* For stable releases:
+  ```shell
+  git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d
+  ```
+
+* For development updates and participation:
+  ```shell
+  git clone -b develop https://github.com/syl20bnr/spacemacs ~/.emacs.d
+  ```
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -171,6 +171,12 @@
     (tao-yang                         . tao-theme)
     (farmhouse-light                  . farmhouse-theme)
     (farmhouse-dark                   . farmhouse-theme)
+    (gruvbox-dark-soft                . gruvbox-theme)
+    (gruvbox-dark-medium              . gruvbox-theme)
+    (gruvbox-dark-hard                . gruvbox-theme)
+    (gruvbox-light-soft               . gruvbox-theme)
+    (gruvbox-light-medium             . gruvbox-theme)
+    (gruvbox-light-hard               . gruvbox-theme)
     )
   "alist matching a theme name with its package name, required when
 package name does not match theme name + `-theme' suffix.")

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -287,20 +287,24 @@ THEME."
       (eval `(spacemacs|do-after-display-system-init
               (load-theme ',theme-name t))))))
 
-(defun spacemacs/cycle-spacemacs-theme ()
-  "Cycle through themes defined in `dotspacemacs-themes.'"
-  (interactive)
-  (when spacemacs--cur-theme
-    ;; if current theme isn't in cycleable themes, start over
-    (setq spacemacs--cycle-themes
-          (or (cdr (memq spacemacs--cur-theme dotspacemacs-themes))
-              dotspacemacs-themes)))
-  (setq spacemacs--cur-theme (pop spacemacs--cycle-themes))
-  (let ((progress-reporter
-         (make-progress-reporter
-          (format "Loading theme %s..." spacemacs--cur-theme))))
-    (spacemacs/load-theme spacemacs--cur-theme nil 'disable)
-    (progress-reporter-done progress-reporter)))
+(defun spacemacs/cycle-spacemacs-theme (&optional backward)
+  "Cycle through themes defined in `dotspacemacs-themes.'
+Does it BACKWARD with universal-argument or negative command argument"
+  (interactive "P")
+  (let* ((reversed (member backward '(t - (4))))
+         (themes (if reversed (reverse dotspacemacs-themes) dotspacemacs-themes)))
+    (when spacemacs--cur-theme
+      (disable-theme spacemacs--cur-theme)
+      ;; if current theme isn't in cycleable themes, start over
+      (setq spacemacs--cycle-themes
+            (or (cdr (memq spacemacs--cur-theme themes))
+                themes)))
+    (setq spacemacs--cur-theme (pop spacemacs--cycle-themes))
+    (let ((progress-reporter
+           (make-progress-reporter
+            (format "Loading theme %s..." spacemacs--cur-theme))))
+      (spacemacs/load-theme spacemacs--cur-theme nil 'disable)
+      (progress-reporter-done progress-reporter))))
 
 (defadvice load-theme (after spacemacs/load-theme-adv activate)
   "Perform post load processing."

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1750,6 +1750,7 @@ Other help key bindings:
 | ~SPC h k~   | show top-level bindings with =which-key=              |
 | ~SPC h m~   | search available man pages                            |
 | ~SPC h n~   | browse emacs news                                     |
+| ~SPC h U~   | update packages                                       |
 
 Navigation key bindings in =help-mode=:
 

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1750,7 +1750,6 @@ Other help key bindings:
 | ~SPC h k~   | show top-level bindings with =which-key=              |
 | ~SPC h m~   | search available man pages                            |
 | ~SPC h n~   | browse emacs news                                     |
-| ~SPC h U~   | update packages                                       |
 
 Navigation key bindings in =help-mode=:
 
@@ -2182,6 +2181,7 @@ navigate between =Emacs= and Spacemacs specific files.
 | ~SPC f e i~ | open the all mighty =init.el=                                   |
 | ~SPC f e l~ | locate an Emacs library                                         |
 | ~SPC f e R~ | resync the dotfile with spacemacs                               |
+| ~SPC f e U~ | update packages                                                 |
 | ~SPC f e v~ | display and copy the spacemacs version                          |
 
 **** Browsing files in completion buffer

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -496,7 +496,7 @@ instance if a used layer A can shadow a used layer B and the layer A is listed
 after the layer B in the dotfile then the layer A replaces the layer B and it is
 like only the layer A is being used.
 
-Examples of fhis mechanism are helm/ivy layers or neotree/treemacs layers.
+Examples of this mechanism are helm/ivy layers or neotree/treemacs layers.
 
 A layer can shadow other layers by calling in its =config.el= file the function
 =configuration-layer/declare-shadow-relation=. This function declares a

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -498,7 +498,7 @@ like only the layer A is being used.
 
 Examples of this mechanism are helm/ivy layers or neotree/treemacs layers.
 
-A layer can shadow other layers by calling in its =config.el= file the function
+A layer can shadow other layers by calling in its =layers.el= file the function
 =configuration-layer/declare-shadow-relation=. This function declares a
 =can-shadow= relation between all the layers.
 

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -497,15 +497,20 @@
 (spacemacs|define-transient-state buffer
   :title "Buffer Selection Transient State"
   :doc (concat "
- [_C-1_.._C-9_] goto nth window            [_n_]^^   next buffer
- [_1_.._9_]     move buffer to nth window  [_N_/_p_] previous buffer
- [_M-1_.._M-9_] swap buffer w/ nth window  [_d_]^^   kill buffer
- ^^^^                                      [_q_]^^   quit")
+ [_C-1_.._C-9_] goto nth window            [_n_/_<right>_]^^  next buffer       [_l_]  buffer list
+ [_1_.._9_]     move buffer to nth window  [_N_/_p_/_<left>_] previous buffer   [_b_]  bury buffer
+ [_M-1_.._M-9_] swap buffer w/ nth window  [_d_]^^^^          kill buffer       [_o_]  other window
+ ^^^^                                      [_q_]^^^^          quit")
   :bindings
   ("n" next-buffer)
-  ("N" previous-buffer)
+  ("<right>" next-buffer)
   ("p" previous-buffer)
+  ("N" previous-buffer)
+  ("o" other-window)
+  ("<left>" previous-buffer)
   ("d" spacemacs/kill-this-buffer)
+  ("b" bury-buffer)
+  ("l" helm-buffers-list)
   ("q" nil :exit t)
   ("1" move-buffer-window-no-follow-1)
   ("2" move-buffer-window-no-follow-2)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -157,8 +157,8 @@
   ("<up>" helm-themes)
   ("<left>" (spacemacs/cycle-spacemacs-theme t))
   ("<right>" spacemacs/cycle-spacemacs-theme))
-(spacemacs/set-leader-keys "Tn" 'spacemacs/cycle-spacemacs-theme)
-(spacemacs/set-leader-keys "TN" 'spacemacs/theme-transient-state/body)
+(spacemacs/set-leader-keys "Tn"
+  'spacemacs/theme-transient-state/spacemacs/cycle-spacemacs-theme)
 ;; errors ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "en" 'spacemacs/next-error

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -227,7 +227,8 @@
   "hdt" 'describe-theme
   "hdv" 'describe-variable
   "hI"  'spacemacs/report-issue
-  "hn"  'view-emacs-news)
+  "hn"  'view-emacs-news
+  "hU"  'configuration-layer/update-packages)
 ;; insert stuff ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "iJ" 'spacemacs/insert-line-below-no-indent

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -497,9 +497,9 @@
 (spacemacs|define-transient-state buffer
   :title "Buffer Selection Transient State"
   :doc (concat "
- [_C-1_.._C-9_] goto nth window            [_n_/_<right>_]^^  next buffer       [_l_]  buffer list
- [_1_.._9_]     move buffer to nth window  [_N_/_p_/_<left>_] previous buffer   [_b_]  bury buffer
- [_M-1_.._M-9_] swap buffer w/ nth window  [_d_]^^^^          kill buffer       [_o_]  other window
+ [_C-1_.._C-9_] goto nth window            [_n_/_<right>_]^^  next buffer       [_b_]   buffer list
+ [_1_.._9_]     move buffer to nth window  [_N_/_p_/_<left>_] previous buffer   [_C-d_] bury buffer
+ [_M-1_.._M-9_] swap buffer w/ nth window  [_d_]^^^^          kill buffer       [_o_]   other window
  ^^^^                                      [_q_]^^^^          quit")
   :bindings
   ("n" next-buffer)
@@ -508,9 +508,9 @@
   ("N" previous-buffer)
   ("o" other-window)
   ("<left>" previous-buffer)
+  ("b" helm-buffers-list)
   ("d" spacemacs/kill-this-buffer)
-  ("b" bury-buffer)
-  ("l" helm-buffers-list)
+  ("C-d" bury-buffer)
   ("q" nil :exit t)
   ("1" move-buffer-window-no-follow-1)
   ("2" move-buffer-window-no-follow-2)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -191,6 +191,7 @@
   "feD" 'spacemacs/ediff-dotfile-and-template
   "feR" 'dotspacemacs/sync-configuration-layers
   "fev" 'spacemacs/display-and-copy-version
+  "feU"  'configuration-layer/update-packages
   "fCd" 'spacemacs/unix2dos
   "fCu" 'spacemacs/dos2unix
   "fg" 'rgrep
@@ -227,8 +228,7 @@
   "hdt" 'describe-theme
   "hdv" 'describe-variable
   "hI"  'spacemacs/report-issue
-  "hn"  'view-emacs-news
-  "hU"  'configuration-layer/update-packages)
+  "hn"  'view-emacs-news)
 ;; insert stuff ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "iJ" 'spacemacs/insert-line-below-no-indent

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -148,7 +148,17 @@
     (spacemacs/set-leader-keys (format "b%i" n)
       (intern (format "buffer-to-window-%s" n)))))
 ;; Cycling settings -----------------------------------------------------------
+(spacemacs|define-transient-state theme
+  :title "Themes Transient State"
+  :doc "\n[_p_/_<left>_] cycles backward,  [_n_/_<right>_] cycles forward, [_<up>_] helm-themes"
+  :bindings
+  ("n" spacemacs/cycle-spacemacs-theme)
+  ("p" (spacemacs/cycle-spacemacs-theme t))
+  ("<up>" helm-themes)
+  ("<left>" (spacemacs/cycle-spacemacs-theme t))
+  ("<right>" spacemacs/cycle-spacemacs-theme))
 (spacemacs/set-leader-keys "Tn" 'spacemacs/cycle-spacemacs-theme)
+(spacemacs/set-leader-keys "TN" 'spacemacs/theme-transient-state/body)
 ;; errors ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "en" 'spacemacs/next-error

--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -45,3 +45,18 @@
 to a major mode, a list of such symbols, or the symbol t,
 acting as default. The values are either integers, symbols
 or lists of these.")
+
+;; State cursors
+(defvar spacemacs-evil-cursors '(("normal" "DarkGoldenrod2" box)
+                                 ("insert" "chartreuse3" (bar . 2))
+                                 ("emacs" "SkyBlue2" box)
+                                 ("hybrid" "SkyBlue2" (bar . 2))
+                                 ("replace" "chocolate" (hbar . 2))
+                                 ("evilified" "LightGoldenrod3" box)
+                                 ("visual" "gray" (hbar . 2))
+                                 ("motion" "plum3" box)
+                                 ("lisp" "HotPink1" box)
+                                 ("iedit" "firebrick1" box)
+                                 ("iedit-insert" "firebrick1" (bar . 2)))
+  "Colors assigned to evil states with cursor definitions.
+To add your own, use `spacemacs/add-evil-curosr'.")

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -34,6 +34,20 @@
                   evil-state)))
     (spacemacs/state-color-face state)))
 
+(defun spacemacs/add-evil-cursor (state color shape)
+  "Define a cursor and face for a new evil state.
+An appropriate entry is added to `spacemacs-evil-cursors', as well."
+  (add-to-list 'spacemacs-evil-cursors (list state color shape))
+  (eval `(defface ,(intern (format "spacemacs-%s-face" state))
+           `((t (:background ,color
+                             :foreground ,(face-background 'mode-line)
+                             :inherit 'mode-line)))
+           (format "%s state face." state)
+           :group 'spacemacs))
+  (set (intern (format "evil-%s-state-cursor" state))
+       (list (when dotspacemacs-colorize-cursor-according-to-state color)
+             shape)))
+
 (defun spacemacs/set-state-faces ()
   (cl-loop for (state color cursor) in spacemacs-evil-cursors
            do

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -57,30 +57,8 @@
 
   (require 'cl)
   ;; State cursors
-  (defvar spacemacs-evil-cursors '(("normal" "DarkGoldenrod2" box)
-                                   ("insert" "chartreuse3" (bar . 2))
-                                   ("emacs" "SkyBlue2" box)
-                                   ("hybrid" "SkyBlue2" (bar . 2))
-                                   ("replace" "chocolate" (hbar . 2))
-                                   ("evilified" "LightGoldenrod3" box)
-                                   ("visual" "gray" (hbar . 2))
-                                   ("motion" "plum3" box)
-                                   ("lisp" "HotPink1" box)
-                                   ("iedit" "firebrick1" box)
-                                   ("iedit-insert" "firebrick1" (bar . 2)))
-    "Colors assigned to evil states with cursor definitions.")
-
-  (cl-loop for (state color cursor) in spacemacs-evil-cursors
-           do
-           (eval `(defface ,(intern (format "spacemacs-%s-face" state))
-                    `((t (:background ,color
-                                      :foreground ,(face-background 'mode-line)
-                                      :inherit 'mode-line)))
-                    (format "%s state face." state)
-                    :group 'spacemacs))
-           (set (intern (format "evil-%s-state-cursor" state))
-                (list (when dotspacemacs-colorize-cursor-according-to-state color)
-                      cursor)))
+  (cl-loop for (state color shape) in spacemacs-evil-cursors
+           do (spacemacs/add-evil-cursor state color shape))
   (add-hook 'spacemacs-post-theme-change-hook 'spacemacs/set-state-faces)
 
   ;; evil ex-command

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -14,6 +14,7 @@
   - [[#gnuplot-support][Gnuplot support]]
   - [[#revealjs-support][Reveal.js support]]
   - [[#org-journal-support][Org-journal support]]
+  - [[#hugo-support][Hugo support]]
   - [[#different-bullets][Different bullets]]
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
@@ -200,6 +201,17 @@ For example:
                                                          org-journal-time-prefix "* "
                                                          org-journal-time-format "")
                                                     )
+#+END_SRC
+
+** Hugo support
+To install the Org exporter [[https://ox-hugo.scripter.co][ox-hugo]] that generates [[https://gohugo.io][Hugo]]-compatible Markdown
+/plus/ TOML/YAML front-matter, set the variable =org-enable-hugo-support= to
+=t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-hugo-support t)))
 #+END_SRC
 
 ** Different bullets

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -541,7 +541,9 @@ are listed bellow.
 | Date        |                     |                                   |
 |-------------+---------------------+-----------------------------------|
 | ~ds~        | schedule            | org-agenda-schedule               |
+| ~dS~        | un-schedule         | org-agenda-schedule               |
 | ~dd~        | set deadline        | org-agenda-deadline               |
+| ~dD~        | remove deadline     | org-agenda-deadline               |
 | ~dt~        | timestamp           | org-agenda-date-prompt            |
 | ~+~         | do later            | org-agenda-do-date-later          |
 | ~-~         | do earlier          | org-agenda-do-date-earlier        |

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -31,3 +31,6 @@ used.")
 
 (defvar org-enable-org-journal-support nil
   "If non-nil org-journal is configured.")
+
+(defvar org-enable-hugo-support nil
+  "If non-nil, Hugo (https://gohugo.io) related packages are configured.")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -37,6 +37,7 @@
                 :toggle org-enable-github-support)
         (ox-reveal :toggle org-enable-reveal-js-support)
         persp-mode
+        (ox-hugo :toggle org-enable-hugo-support)
         ))
 
 (defun org/post-init-company ()
@@ -605,3 +606,6 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "j" 'org-journal-new-entry
         "n" 'org-journal-open-next-entry
         "p" 'org-journal-open-previous-entry))))
+
+(defun org/init-ox-hugo ()
+  (use-package ox-hugo :after ox))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -375,16 +375,16 @@ Will work on both org-mode and any mode that accepts plain html."
       :foreign-keys run
       :doc
       "
-Headline^^            Visit entry^^               Filter^^                    Date^^               Toggle mode^^        View^^             Clock^^        Other^^
---------^^---------   -----------^^------------   ------^^-----------------   ----^^-------------  -----------^^------  ----^^---------    -----^^------  -----^^-----------
-[_ht_] set status     [_SPC_] in other window     [_ft_] by tag               [_ds_] schedule      [_tf_] follow        [_vd_] day         [_cI_] in      [_gr_] reload
-[_hk_] kill           [_TAB_] & go to location    [_fr_] refine by tag        [_dd_] set deadline  [_tl_] log           [_vw_] week        [_cO_] out     [_._]  go to today
-[_hr_] refile         [_RET_] & del other windows [_fc_] by category          [_dt_] timestamp     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
-[_hA_] archive        [_o_]   link                [_fh_] by top headline      [_+_]  do later      [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
-[_h:_] set tags       ^^                          [_fx_] by regexp            [_-_]  do earlier    [_td_] diaries       [_vy_] year        ^^             ^^
-[_hp_] set priority   ^^                          [_fd_] delete all filters   ^^                   ^^                   [_vn_] next span   ^^             ^^
-^^                    ^^                          ^^                          ^^                   ^^                   [_vp_] prev span   ^^             ^^
-^^                    ^^                          ^^                          ^^                   ^^                   [_vr_] reset       ^^             ^^
+Headline^^            Visit entry^^               Filter^^                    Date^^                  Toggle mode^^        View^^             Clock^^        Other^^
+--------^^---------   -----------^^------------   ------^^-----------------   ----^^-------------     -----------^^------  ----^^---------    -----^^------  -----^^-----------
+[_ht_] set status     [_SPC_] in other window     [_ft_] by tag               [_ds_] schedule         [_tf_] follow        [_vd_] day         [_cI_] in      [_gr_] reload
+[_hk_] kill           [_TAB_] & go to location    [_fr_] refine by tag        [_dS_] un-schedule      [_tl_] log           [_vw_] week        [_cO_] out     [_._]  go to today
+[_hr_] refile         [_RET_] & del other windows [_fc_] by category          [_dd_] set deadline     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
+[_hA_] archive        [_o_]   link                [_fh_] by top headline      [_dD_] remove deadline  [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
+[_h:_] set tags       ^^                          [_fx_] by regexp            [_dt_] timestamp        [_td_] diaries       [_vy_] year        ^^             ^^
+[_hp_] set priority   ^^                          [_fd_] delete all filters   [_+_]  do later         ^^                   [_vn_] next span   ^^             ^^
+^^                    ^^                          ^^                          [_-_]  do earlier       ^^                   [_vp_] prev span   ^^             ^^
+^^                    ^^                          ^^                          ^^                      ^^                   [_vr_] reset       ^^             ^^
 [_q_] quit
 "
       :bindings
@@ -405,8 +405,14 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
       ;; Date
       ("ds" org-agenda-schedule)
+      ("dS" (lambda () (interactive)
+             (let ((current-prefix-arg '(4)))
+                  (call-interactively 'org-agenda-schedule))))
       ("dd" org-agenda-deadline)
       ("dt" org-agenda-date-prompt)
+      ("dD" (lambda () (interactive)
+             (let ((current-prefix-arg '(4)))
+                  (call-interactively 'org-agenda-deadline))))
       ("+" org-agenda-do-date-later)
       ("-" org-agenda-do-date-earlier)
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -107,6 +107,7 @@
             org-startup-with-inline-images t
             org-image-actual-width nil
             org-src-fontify-natively t
+            org-src-tab-acts-natively t
             ;; this is consistent with the value of
             ;; `helm-org-headings-max-depth'.
             org-imenu-depth 8)

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -254,9 +254,10 @@ Will work on both org-mode and any mode that accepts plain html."
         ;; Multi-purpose keys
         (or dotspacemacs-major-mode-leader-key ",") 'org-ctrl-c-ctrl-c
         "*" 'org-ctrl-c-star
-        "RET" 'org-ctrl-c-ret
         "-" 'org-ctrl-c-minus
         "#" 'org-update-statistics-cookies
+        "RET"   'org-ctrl-c-ret
+        "M-RET" 'org-meta-return
         ;; attachments
         "A" 'org-attach
         ;; insertion

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -40,7 +40,7 @@ To use this layer, add =treemacs= to the existing
 
 * Configuration
 ** Follow mode
-To have treemacs automatically syncs with your current buffer set the
+To have treemacs automatically sync with your current buffer set the
 layer variable =treemacs-use-follow-mode= to non-nil.
 
 #+BEGIN_SRC emacs-lisp
@@ -51,8 +51,9 @@ layer variable =treemacs-use-follow-mode= to non-nil.
 Default value is =t=.
 
 ** File watch
-To automatically refresh the Treemacs buffer when a buffer changes set
-the layer variable =treemacs-use-filewatch-mode= to non-nil.
+To automatically refresh the Treemacs buffer when there is a change in the
+part of the file system shown by treemacs set the layer variable
+=treemacs-use-filewatch-mode= to non-nil.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
@@ -94,33 +95,33 @@ many other commands.
 
 | Key Binding | Description                                                                                                                           |
 |-------------+---------------------------------------------------------------------------------------------------------------------------------------|
-| ~?~           | Summon the helpful hydra to show you the treemacs keymap.                                                                             |
-| ~j/n~         | Goto next/prev line.                                                                                                                  |
-| ~h~           | Switch treemacs' root directory to current root's parent, if possible.                                                                |
-| ~l~           | Use currently selected directory as new root. Do nothing for files.                                                                   |
-| ~M-j/M-n~     | Select next node at the same depth as currently selected node, if possible.                                                           |
-| ~th~          | Toggle the hiding and displaying of dotfiles.                                                                                         |
-| ~tw~          | Toggle whether the treemacs buffer should have a fixed width.                                                                         |
-| ~tf~          | Toggle treemacs-follow-mode.                                                                                                          |
-| ~ta~          | treemacs-filewatch-mode.                                                                                                              |
-| ~w~           | Reset the width of the treemacs buffer to its default. With a prefix arg set a new default first.                                     |
-| ~TAB~         | Push the button in the current line to open/close the selected node.                                                                  |
-| ~mouse1~      | Do the same as TAB when mouse1 clicking on an icon. Clicking anywhere other than an icon does nothing.                                |
-| ~g/r/gr~      | Refresh and rebuild the treemacs buffer.                                                                                              |
-| ~d~           | Delete node at point. A delete action must always be confirmed. Directories are deleted recursively.                                  |
-| ~cf~          | Create a file.                                                                                                                        |
-| ~cd~          | Create a directory.                                                                                                                   |
-| ~R~           | Rename the currently selected node. Reload buffers visiting renamed files or files in renamed direcotries.                            |
-| ~u~           | Select parent of selected node, if possible.                                                                                          |
-| ~q~           | Hide/show an existing treemacs buffer.                                                                                                |
-| ~Q~           | Kill the treemacs buffer.                                                                                                             |
-| ~RET~         | Do what I mean. (Run the action defined in ~treemacs-default-actions~ for the current button.)                                        |
-| ~ov~          | Open current file or tag by vertically splitting next-window. Stay in current window with a prefix argument.                          |
-| ~oh~          | Open current file or tag by horizontally splitting next-window. Stay in current window with a prefix argument.                        |
-| ~oo/RET~      | Open current file or tag, performing no split and using next-window directly. Stay in current window with a prefix argument.          |
-| ~oaa~         | Open current file or tag, using ace-window to decide which buffer to open the file in. Stay in current window with a prefix argument. |
-| ~oah~         | Open current file or tag by horizontally splitting a buffer selected by ace-window. Stay in current window with a prefix argument.    |
-| ~oav~         | Open current file or tag by vertically splitting a buffer selected by ace-window. Stay in current window with a prefix argument.      |
-| ~ox~          | Open current file or dir, using the xdg-open shell-command.                                                                           |
-| ~yy~          | Copy the absolute path of the node at point.                                                                                          |
-| ~yr~          | Copy the absolute path of the current treemacs root.                                                                                  |
+| ~?~         | Summon the helpful hydra to show you the treemacs keymap.                                                                             |
+| ~j/n~       | Goto next/prev line.                                                                                                                  |
+| ~h~         | Switch treemacs' root directory to current root's parent, if possible.                                                                |
+| ~l~         | Use currently selected directory as new root. Do nothing for files.                                                                   |
+| ~M-j/M-n~   | Select next node at the same depth as currently selected node, if possible.                                                           |
+| ~th~        | Toggle the hiding and displaying of dotfiles.                                                                                         |
+| ~tw~        | Toggle whether the treemacs buffer should have a fixed width.                                                                         |
+| ~tf~        | Toggle treemacs-follow-mode.                                                                                                          |
+| ~ta~        | treemacs-filewatch-mode.                                                                                                              |
+| ~w~         | Reset the width of the treemacs buffer to its default. With a prefix arg set a new default first.                                     |
+| ~TAB~       | Push the button in the current line to open/close the selected node.                                                                  |
+| ~mouse1~    | Do the same as TAB when mouse1 clicking on an icon. Clicking anywhere other than an icon does nothing.                                |
+| ~g/r/gr~    | Refresh and rebuild the treemacs buffer.                                                                                              |
+| ~d~         | Delete node at point. A delete action must always be confirmed. Directories are deleted recursively.                                  |
+| ~cf~        | Create a file.                                                                                                                        |
+| ~cd~        | Create a directory.                                                                                                                   |
+| ~R~         | Rename the currently selected node. Reload buffers visiting renamed files or files in renamed direcotries.                            |
+| ~u~         | Select parent of selected node, if possible.                                                                                          |
+| ~q~         | Hide/show an existing treemacs buffer.                                                                                                |
+| ~Q~         | Kill the treemacs buffer.                                                                                                             |
+| ~RET~       | Do what I mean. (Run the action defined in ~treemacs-default-actions~ for the current button.)                                        |
+| ~ov~        | Open current file or tag by vertically splitting next-window. Stay in current window with a prefix argument.                          |
+| ~oh~        | Open current file or tag by horizontally splitting next-window. Stay in current window with a prefix argument.                        |
+| ~oo/RET~    | Open current file or tag, performing no split and using next-window directly. Stay in current window with a prefix argument.          |
+| ~oaa~       | Open current file or tag, using ace-window to decide which buffer to open the file in. Stay in current window with a prefix argument. |
+| ~oah~       | Open current file or tag by horizontally splitting a buffer selected by ace-window. Stay in current window with a prefix argument.    |
+| ~oav~       | Open current file or tag by vertically splitting a buffer selected by ace-window. Stay in current window with a prefix argument.      |
+| ~ox~        | Open current file or dir, using the xdg-open shell-command.                                                                           |
+| ~yy~        | Copy the absolute path of the node at point.                                                                                          |
+| ~yr~        | Copy the absolute path of the current treemacs root.                                                                                  |

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -63,6 +63,8 @@ part of the file system shown by treemacs set the layer variable
 Default value is =t=.
 
 ** Collapsed directories
+*This feature requires python to be installed*.
+
 Treemacs tries to collapse empty directory names into one name. It is possible
 to control how deep Treemacs will search for empty directories by settings the
 layer variable =treemacs-use-collapsed-directories= to a positive number.
@@ -72,7 +74,7 @@ layer variable =treemacs-use-collapsed-directories= to a positive number.
     (treemacs :variables treemacs-use-collapsed-directories 3)))
 #+END_SRC
 
-Default value is 3.
+Default value is 3 (or 0 when python is not installed).
 
 * Key Bindings
 ** Global

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -15,6 +15,6 @@
 (defvar treemacs-use-filewatch-mode t
   "When non-nil use `treemacs-filewatch-mode'.")
 
-(defvar treemacs-use-collapsed-directories 3
+(defvar treemacs-use-collapsed-directories (if (executable-find "python") 3 0)
   "Number of directories to collapse with `treemacs-collapse-dirs'.
 Must be a number.")

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -34,6 +34,7 @@
       "f C-t" #'treemacs-find-file)
     :config
     (progn
+      (spacemacs/add-evil-cursor "treemacs" "MediumPurple1" '(hbar . 0))
       (setq treemacs-follow-after-init t
             treemacs-width 35
             treemacs-position 'left

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -131,16 +131,18 @@ build your project with ~SPC c c~ key binding.
 
 | Key Binding | Description                                                             |
 |-------------+-------------------------------------------------------------------------|
-| ~SPC m g a~ | open matching file (e.g. switch between .cpp and .h)                    |
-| ~SPC m g A~ | open matching file in another window (e.g. switch between .cpp and .h)  |
+| ~SPC m g a~ | open matching file                                                      |
+|             | (e.g. switch between .cpp and .h, requires a project to work)           |
+| ~SPC m g A~ | open matching file in another window                                    |
+|             | (e.g. switch between .cpp and .h, requires a project to work)           |
 | ~SPC m D~   | disaster: disassemble c/c++ code                                        |
 | ~SPC m r~   | srefactor: refactor thing at point.                                     |
-| ~SPC m p c~ | Run CMake and set compiler flags for auto-completionand flycheck        |
+| ~SPC m p c~ | Run CMake and set compiler flags for auto-completion and flycheck       |
 | ~SPC m p C~ | Run CMake if compilation database JSON file is not found                |
 | ~SPC m p d~ | Remove file connected to current buffer and kill buffer, then run CMake |
 | ~SPC m c c~ | Compile project                                                         |
 
-*Note:*  [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]]  is only available for Emacs 24.4+
+*Note:*  [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]]  is only available for Emacs 24.4+.
 
 ** Debugger (realgud)
 

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -13,7 +13,6 @@
       '(
         ess
         ess-R-data-view
-        ess-R-object-popup
         (ess-smart-equals :toggle ess-enable-smart-equals)
         golden-ratio
         org))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -50,6 +50,13 @@
         (switch-to-buffer-other-window inferior-fsharp-buffer-name)
         (evil-insert-state))
 
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mf" "find")
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "ms" "interpreter")
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mx" "executable")
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mc" "compile")
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mh" "hint")
+
       (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
         ;; Compile
         "cc" 'compile

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -50,7 +50,7 @@
 
 (defun spacemacs-haskell//setup-dante ()
   (spacemacs|add-company-backends
-    :backends (company-dante company-dabbrev-code company-yasnippet)
+    :backends (dante-company company-dabbrev-code company-yasnippet)
     :modes haskell-mode)
   (push 'xref-find-definitions spacemacs-jump-handlers)
   (dante-mode)

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -57,6 +57,7 @@
     :config
     (progn
       (add-hook 'markdown-mode-hook 'orgtbl-mode)
+      (spacemacs|diminish orgtbl-mode)
       (add-hook 'markdown-mode-hook 'spacemacs//cleanup-org-tables-on-save)
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")

--- a/layers/+lang/perl5/README.org
+++ b/layers/+lang/perl5/README.org
@@ -7,16 +7,21 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#auto-completion-plsense][Auto-completion: PlSense]]
 - [[#key-bindings][Key Bindings]]
   - [[#perldoc][Perldoc]]
   - [[#pod-and-here-doc][POD and HERE doc]]
   - [[#find-symbol][Find Symbol]]
+  - [[#formating-code][Formating Code]]
 
 * Description
 This layer adds support for the Perl5 language.
 
 ** Features:
-- syntactic and semantic checking using [[https://github.com/flycheck/flycheck][flycheck]]
+- Syntactic and semantic checking using [[https://github.com/flycheck/flycheck][flycheck]]
+- Auto-completion using [[https://github.com/CeleritasCelery/company-plsense][company-plsense]]
+- Format code with =perltidy=
+- Jump to symbol definition
 
 * Install
 ** Layer
@@ -24,26 +29,37 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =perl5= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+** Auto-completion: PlSense
+=company-plsense= requires installation of the =plsense= server from [[https://github.com/aki2o/plsense#install][here]].
+
 * Key Bindings
 ** Perldoc
 Browse formated perldocs.
 
 | Key Binding | Description                     |
 |-------------+---------------------------------|
-| ~SPC m h p~ | view perldoc of symbol at point |
+| ~SPC m h h~ | view perldoc of symbol at point |
 | ~SPC m h d~ | view perldoc of any symbol      |
 
 ** POD and HERE doc
-select a POD or HERE doc
+Select a POD or HERE doc.
 
 | Key Binding | Description                            |
 |-------------+----------------------------------------|
 | ~SPC m v~   | select entire POD or HERE doc at point |
 
 ** Find Symbol
-jump to symbol definition
+Jump to symbol definition.
 
 | Key Binding | Description                               |
 |-------------+-------------------------------------------|
 | ~SPC m g g~ | jump to symbol definition                 |
 | ~SPC m g G~ | jump to symbol definition in other window |
+
+** Formating Code
+
+| Key Binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC m = =~ | format current line or region |
+| ~SPC m = b~ | format current buffer         |
+| ~SPC m = f~ | format current function       |

--- a/layers/+lang/perl5/config.el
+++ b/layers/+lang/perl5/config.el
@@ -10,3 +10,9 @@
 ;;; License: GPLv3
 
 (spacemacs|define-jump-handlers cperl-mode)
+
+(defvar perl5-perltidy-executable "perltidy"
+  "Location of perltidy executable.")
+
+(defvar perl5-perltidy-options '()
+  "Command line options to pass to perltidy")

--- a/layers/+lang/perl5/funcs.el
+++ b/layers/+lang/perl5/funcs.el
@@ -15,3 +15,36 @@
 
 (defun spacemacs//perl5-spartparens-disable ()
   (define-key cperl-mode-map "{" 'cperl-electric-lbrace))
+
+(defun spacemacs/perltidy-format ()
+  "Format Perl code with perltidy.
+If region is active, operate on it, else operate on line."
+  (interactive)
+  (let ((old-point (point))
+        (pos
+         (if (use-region-p)
+             (cons (region-beginning)
+                   (if (char-equal ?\n (char-before (region-end)))
+                       (region-end)
+                     (save-excursion ;; must including terminating newline
+                       (goto-char (region-end))
+                       (1+ (line-end-position)))))
+           (cons (line-beginning-position)
+                 (1+ (line-end-position))))))
+    (apply #'call-process-region (car pos) (cdr pos) perl5-perltidy-executable t '(t nil)
+           "--quiet"
+           "--standard-error-output"
+           perl5-perltidy-options)
+    (goto-char old-point)))
+
+(defun spacemacs/perltidy-format-buffer ()
+  "Format current buffer with perltidy."
+  (interactive)
+  (mark-whole-buffer)
+  (spacemacs/perltidy-format))
+
+(defun spacemacs/perltidy-format-function ()
+  "Format current function with perltidy."
+  (interactive)
+  (mark-defun)
+  (spacemacs/perltidy-format))

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -14,6 +14,7 @@
         (cperl-mode :location built-in)
         smartparens
         flycheck
+        (company-plsense :requires company)
         ))
 
 (defun perl5/init-cperl-mode ()
@@ -95,16 +96,21 @@
       (add-hook 'cperl-mode-hook
                 (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
 
+
+      (spacemacs/declare-prefix "m=" "format")
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "==" 'spacemacs/perltidy-format)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "=b" 'spacemacs/perltidy-format-buffer)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "=f" 'spacemacs/perltidy-format-function)
+
       (spacemacs/declare-prefix "mh" "perldoc")
-      (spacemacs/declare-prefix "mg" "find-symbol")
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hp" 'cperl-perldoc-at-point)
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hh" 'cperl-perldoc-at-point)
       (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hd" 'cperl-perldoc)
+
+      (spacemacs/declare-prefix "mg" "find-symbol")
       (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "v" 'cperl-select-this-pod-or-here-doc)
 
       (font-lock-add-keywords 'cperl-mode
-                              '(("\\_<const\\|croak\\|carp\\|confess\\|cluck\\_>" . font-lock-keyword-face)))
-      (font-lock-add-keywords 'cperl-mode
-                              '(("\\_<say\\|any\\_>" . cperl-nonoverridable-face))))))
+                              '(("\\_<say\\_>" . cperl-nonoverridable-face))))))
 
 (defun perl5/post-init-smartparens ()
   ;; fixs a bug with electric mode and smartparens https://github.com/syl20bnr/spacemacs/issues/480
@@ -114,3 +120,11 @@
 
 (defun perl5/post-init-flycheck ()
   (spacemacs/enable-flycheck 'cperl-mode))
+
+(defun perl5/init-company-plsense ()
+  (use-package company-plsense
+    :defer t
+    :init
+    (spacemacs|add-company-backends
+     :backends company-plsense
+     :modes cperl-mode)))

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -11,11 +11,19 @@
 
 (setq perl5-packages
       '(
-        (cperl-mode :location built-in)
-        smartparens
-        flycheck
         (company-plsense :requires company)
+        (cperl-mode :location built-in)
+        flycheck
+        smartparens
         ))
+
+(defun perl5/init-company-plsense ()
+  (use-package company-plsense
+    :defer t
+    :init
+    (spacemacs|add-company-backends
+      :backends company-plsense
+      :modes cperl-mode)))
 
 (defun perl5/init-cperl-mode ()
   (use-package cperl-mode
@@ -96,35 +104,25 @@
       (add-hook 'cperl-mode-hook
                 (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
 
-
       (spacemacs/declare-prefix "m=" "format")
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "==" 'spacemacs/perltidy-format)
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "=b" 'spacemacs/perltidy-format-buffer)
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "=f" 'spacemacs/perltidy-format-function)
-
-      (spacemacs/declare-prefix "mh" "perldoc")
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hh" 'cperl-perldoc-at-point)
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "hd" 'cperl-perldoc)
-
       (spacemacs/declare-prefix "mg" "find-symbol")
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode "v" 'cperl-select-this-pod-or-here-doc)
+      (spacemacs/declare-prefix "mh" "perldoc")
+      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode
+        "==" 'spacemacs/perltidy-format
+        "=b" 'spacemacs/perltidy-format-buffer
+        "=f" 'spacemacs/perltidy-format-function
+        "hh" 'cperl-perldoc-at-point
+        "hd" 'cperl-perldoc
+        "v" 'cperl-select-this-pod-or-here-doc)
 
       (font-lock-add-keywords 'cperl-mode
                               '(("\\_<say\\_>" . cperl-nonoverridable-face))))))
+
+(defun perl5/post-init-flycheck ()
+  (spacemacs/enable-flycheck 'cperl-mode))
 
 (defun perl5/post-init-smartparens ()
   ;; fixs a bug with electric mode and smartparens https://github.com/syl20bnr/spacemacs/issues/480
   (with-eval-after-load 'cperl-mode
     (add-hook 'smartparens-enabled-hook 'spacemacs//perl5-smartparens-enable)
     (add-hook 'smartparens-disabled-hook 'spacemacs//perl5-spartparens-disable)))
-
-(defun perl5/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'cperl-mode))
-
-(defun perl5/init-company-plsense ()
-  (use-package company-plsense
-    :defer t
-    :init
-    (spacemacs|add-company-backends
-     :backends company-plsense
-     :modes cperl-mode)))

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -33,6 +33,7 @@
     :init
     (progn
       (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
+      (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "i="  'purescript-mode-format-imports
         "i`"  'purescript-navigate-imports-return

--- a/layers/+lang/python/local/nose/nose.el
+++ b/layers/+lang/python/local/nose/nose.el
@@ -93,7 +93,7 @@ For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-fro
   )
 
 (defun nosetests-nose-command ()
-  (let ((nose "python -u -c \"import nose; nose.run()\""))
+  (let ((nose "python -u -c \"import nose; nose.main()\""))
     (if python-shell-virtualenv-path
         (if (spacemacs/system-is-mswindows)
             (format "%s/Scripts/%s" python-shell-virtualenv-path nose)

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -84,6 +84,10 @@
           (sql-send-region start end)
           (evil-insert-state)))
 
+      (spacemacs/declare-prefix-for-mode 'sql-mode "mb" "buffer")
+      (spacemacs/declare-prefix-for-mode 'sql-mode "mh" "dialects")
+      (spacemacs/declare-prefix-for-mode 'sql-mode "ms" "interactivity")
+      (spacemacs/declare-prefix-for-mode 'sql-mode "ml" "listing")
       (spacemacs/set-leader-keys-for-major-mode 'sql-mode
         "'" 'spacemacs/sql-start
 
@@ -112,6 +116,7 @@
         "la" 'sql-list-all
         "lt" 'sql-list-table)
 
+      (spacemacs/declare-prefix-for-mode 'sql-interactive-mode "mb" "buffer")
       (spacemacs/set-leader-keys-for-major-mode 'sql-interactive-mode
         ;; sqli buffer
         "br" 'sql-rename-buffer

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -37,7 +37,13 @@
         "ggB" 'gist-buffer-private
         "ggl" 'gist-list
         "ggr" 'gist-region
-        "ggR" 'gist-region-private))))
+        "ggR" 'gist-region-private))
+    :config
+    (progn
+      (evilified-state-evilify-map gist-list-mode-map
+        :mode gist-list-mode
+        :bindings
+        (kbd "gr") 'gist-list-reload))))
 
 (defun github/init-github-clone ()
   (use-package github-clone

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -27,10 +27,6 @@
     :defer t
     :init
     (progn
-      (evilified-state-evilify gist-list-mode gist-list-menu-mode-map
-        "f" 'gist-fetch-current
-        "K" 'gist-kill-current
-        "o" 'gist-browse-current-url)
       (spacemacs/declare-prefix "gg" "github gist")
       (spacemacs/set-leader-keys
         "ggb" 'gist-buffer
@@ -40,6 +36,12 @@
         "ggR" 'gist-region-private))
     :config
     (progn
+      (evilified-state-evilify-map gist-list-menu-mode-map
+        :mode gist-list-mode
+        :bindings
+        "f" 'gist-fetch-current
+        "K" 'gist-kill-current
+        "o" 'gist-browse-current-url)
       (evilified-state-evilify-map gist-list-mode-map
         :mode gist-list-mode
         :bindings

--- a/layers/+spacemacs/spacemacs-purpose/README.org
+++ b/layers/+spacemacs/spacemacs-purpose/README.org
@@ -20,7 +20,7 @@ and shouldn't change too much when opening all sorts of buffers.
 
 Regular [[https://github.com/m2ym/popwin-el][popwin]] is not triggered when window-purpose is enabled. However,
 the window-purpose layer provides a =purpose-popwin= extension, which
-brings popwin's behavior towindows-purpose and solves that problem.
+brings popwin's behavior to window-purpose and solves that problem.
 
 ** Features:
 - Window layout is more robust and less likely to change unintentionally
@@ -28,20 +28,20 @@ brings popwin's behavior towindows-purpose and solves that problem.
 - User-defined purposes
 - Extensible window display behavior
 - Empty =purpose-mode-map=, to avoid conflicts with other key maps
-- Replicate popwin behavior for purpose-mode - almost no regression in popup behavior from using windows-purpose.
+- Replicate popwin behavior for purpose-mode - almost no regression in popup behavior from using window-purpose.
 - Reuses popwin's settings: =popwin:special-display-config=, =popwin:popup-window-height= and =popwin:popup-window-width=.
 - Difference from popwin: when several windows are open, popup window is sometimes bigger than with regular popwin in the same situation.
 
 ** Purposes
-windows-purpose contains a configuration which assigns a purpose for each
+window-purpose contains a configuration which assigns a purpose for each
 buffer. Later, when Emacs needs to display a buffer in a window, its purpose
 helps make a better decision of which window to use.
 
 For example, consider the following case: Emacs frame shows three windows - one
 for code, one for a terminal and one general-purpose window. The general window
 is selected and you want to open a code file. How do you ensure that the code
-file will be displayed in the code window? With windows-purpose you don't
-need to worry about it - you open the file and windows-purpose places it in
+file will be displayed in the code window? With window-purpose you don't
+need to worry about it - you open the file and window-purpose places it in
 the correct
 window.
 
@@ -51,7 +51,7 @@ reserved only for buffers that share that purpose.
 ** switch-to-buffer and display-buffer
 In regular Emacs, =switch-to-buffer= follows different rules than the other
 switching and popping commands, because it doesn't use =display-buffer= (which
-the other commands do). With windows-purpose, this behavior is fixed. The
+the other commands do). With window-purpose, this behavior is fixed. The
 result is a better control over how buffers are displayed, since
 =switch-to-buffer= doesn't ignore the user's customizations anymore.
 
@@ -64,7 +64,7 @@ add spacemacs-purpose= to the existing =dotspacemacs-configuration-layers= list 
 this file.
 
 * Usage
-With windows-purpose layer installed, =purpose-mode= and =pupo-mode= are enabled.
+With window-purpose layer installed, =purpose-mode= and =pupo-mode= are enabled.
 You can toggle =purpose-mode= (~SPC : purpose-mode~) at any time to return to
 purpose-less behavior. You can toggle =pupo-mode= (~SPC : pupo-mode~) to turn
 off only the purpose-popwin integration.
@@ -73,14 +73,14 @@ If you change =popwin:special-display-config= in your =dotspacemacs/config=, you
 should call =pupo/update-purpose-config= to update purpose-popwin with those
 changes.
 
-See [[https://github.com/bmag/emacs-purpose/wiki][window-purpose wiki]] to learn more about windows-purpose.
+See [[https://github.com/bmag/emacs-purpose/wiki][window-purpose wiki]] to learn more about window-purpose.
 
 * Key Bindings
 
 | Key Binding | Description                                                                         |
 |-------------+-------------------------------------------------------------------------------------|
 | ~SPC r b~   | Open a buffer. Only buffers with the same purpose as the current buffer are listed. |
-| ~SPC r B~   | Open any buffer and ignore windows-purpose when displaying the buffer.              |
+| ~SPC r B~   | Open any buffer and ignore window-purpose when displaying the buffer.               |
 | ~SPC r d~   | Toggle dedication of selected window to its current purpose.                        |
 | ~SPC r D~   | Delete all non-dedicated windows.                                                   |
 | ~SPC r p~   | Choose a purpose and open a buffer with that purpose.                               |

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -75,7 +75,7 @@
       (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Shell Command Output*" :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*Async Shell Command*"  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
-      (push '("*undo-tree*"            :dedicated t :position right  :stick t :noselect nil :width   60) popwin:special-display-config)
+      (push '(" *undo-tree*"           :dedicated t :position right  :stick t :noselect nil :width   60) popwin:special-display-config)
       (push '("*undo-tree Diff*"       :dedicated t :position bottom :stick t :noselect nil :height 0.3) popwin:special-display-config)
       (push '("*ert*"                  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*grep*"                 :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)

--- a/layers/+themes/themes-megapack/packages.el
+++ b/layers/+themes/themes-megapack/packages.el
@@ -18,7 +18,7 @@
     apropospriate-theme
     anti-zenburn-theme
     ;; contains errors
-    ; badger-theme
+    ;; badger-theme
     badwolf-theme
     birds-of-paradise-plus-theme
     bubbleberry-theme
@@ -95,7 +95,7 @@
     tangotango-theme
     tao-theme
     ;; contains error
-    ; tommyh-theme
+    ;; tommyh-theme
     toxi-theme
     twilight-anti-bright-theme
     twilight-bright-theme
@@ -105,7 +105,6 @@
     white-sand-theme
     zen-and-art-theme
     zenburn-theme
-    zonokai-theme
     ))
 
 ;; define programmatically the init functions

--- a/layers/+tools/cfengine/README.org
+++ b/layers/+tools/cfengine/README.org
@@ -9,8 +9,7 @@
 - [[#configuration][Configuration]]
   - [[#set-file-permission-on-save][Set file permission on save]]
   - [[#indendation][Indendation]]
-  - [[#cfengine3-src-blocks-in-org-mode][=cfengine3= =SRC= blocks in =org-mode=]]
-- [[#execution-of-cfengine3-src-blocks][Execution of =cfengine3= =SRC= blocks]]
+- [[#execution-of-cfengine3-src-blocks][Execution of =cfengine3= SRC blocks]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -57,56 +56,8 @@ from anchor= to =2=. For example:
   }
 #+end_src
 
-** =cfengine3= =SRC= blocks in =org-mode=
-Add cfengine to the list of languages loaded by org-babel.
-
-#+BEGIN_SRC elisp
-  (defun dotspacemacs/user-config ()
-
-    (with-eval-after-load 'org
-
-      (org-babel-do-load-languages
-       'org-babel-load-languages
-       '(
-         (cfengine . t)))
-      )
-    )
-#+END_SRC
-
-Alternatively configure org-mode to load support for any languages encountered
-automatically.
-
-#+BEGIN_SRC elisp
-  (defun dotspacemacs/user-config ()
-
-    (with-eval-after-load 'org
-
-      (defadvice org-babel-execute-src-block (around load-language nil activate)
-        "Load language if needed"
-        (let ((language (org-element-property :language (org-element-at-point))))
-          (unless (cdr (assoc (intern language) org-babel-load-languages))
-            (add-to-list 'org-babel-load-languages (cons (intern language) t))
-            (org-babel-do-load-languages 'org-babel-load-languages org-babel-load-languages))
-          ad-do-it))
-      )
-    )
-#+END_SRC
-
-Enable syntax highlighting and tab stops as if you were editing in the native
-mode within SRC blocks.
-
-#+BEGIN_SRC elisp
-  (defun dotspacemacs/user-config ()
-
-    (with-eval-after-load 'org
-
-      (setq org-src-tab-acts-natively t)
-      (setq org-src-fontify-natively t)
-      )
-    )
-#+END_SRC
-
-* Execution of =cfengine3= =SRC= blocks
+* Execution of =cfengine3= SRC blocks
+This layers add support for =cfengine3= source blocks in org files.
 With the insertion point inside the SRC block press ~,,~ or ~CTRL-c Ctrl-c~
 
 #+BEGIN_SRC cfengine3 :exports both

--- a/layers/+tools/cfengine/README.org
+++ b/layers/+tools/cfengine/README.org
@@ -1,4 +1,5 @@
 #+TITLE: CFEngine layer
+#+PROPERTY: header-args :eval never-export
 
 [[file:./img/agent.png]]
 
@@ -8,13 +9,17 @@
 - [[#configuration][Configuration]]
   - [[#set-file-permission-on-save][Set file permission on save]]
   - [[#indendation][Indendation]]
+  - [[#cfengine3-src-blocks-in-org-mode][=cfengine3= =SRC= blocks in =org-mode=]]
+- [[#execution-of-cfengine3-src-blocks][Execution of =cfengine3= =SRC= blocks]]
 - [[#key-bindings][Key bindings]]
 
 * Description
 This layer makes working with CFEngine policy easier:
+
 - Syntax highlighting
 - On the fly syntax checks (via =syntax-checking= layer)
 - Auto completion (via =auto-completion= layer)
+- Execution of =cfengine3= =SRC= blocks in =org-mode= (via ob-cfengine3 package)
 
 * Install
 Add =cfengine= to the =dotspacemacs-configuration-layers= in your =~/.spacemacs=
@@ -28,13 +33,13 @@ errors like:
 =File ./example.cf (owner 1000) is writable by others (security exception)=
 
 #+BEGIN_SRC elisp
-(defun cfengine-permissions-policy-owner-only ()
-  "If file starts with a shebang, make `buffer-file-name' executable"
-  (save-excursion
-    (set-file-modes buffer-file-name #o600)
-    (message (concat "Made " buffer-file-name " accessibly only by the owner (600)."))))
+  (defun cfengine-permissions-policy-owner-only ()
+    "If file starts with a shebang, make `buffer-file-name' executable"
+    (save-excursion
+      (set-file-modes buffer-file-name #o600)
+      (message (concat "Made " buffer-file-name " accessibly only by the owner (600)."))))
 
-(add-hook 'after-save-hook 'cfengine-permissions-policy-owner-only nil 'make-it-local)
+  (add-hook 'after-save-hook 'cfengine-permissions-policy-owner-only nil 'make-it-local)
 #+END_SRC
 
 ** Indendation
@@ -51,6 +56,77 @@ from anchor= to =2=. For example:
           comment => "Indented 2 spaces from promiser";
   }
 #+end_src
+
+** =cfengine3= =SRC= blocks in =org-mode=
+Add cfengine to the list of languages loaded by org-babel.
+
+#+BEGIN_SRC elisp
+  (defun dotspacemacs/user-config ()
+
+    (with-eval-after-load 'org
+
+      (org-babel-do-load-languages
+       'org-babel-load-languages
+       '(
+         (cfengine . t)))
+      )
+    )
+#+END_SRC
+
+Alternatively configure org-mode to load support for any languages encountered
+automatically.
+
+#+BEGIN_SRC elisp
+  (defun dotspacemacs/user-config ()
+
+    (with-eval-after-load 'org
+
+      (defadvice org-babel-execute-src-block (around load-language nil activate)
+        "Load language if needed"
+        (let ((language (org-element-property :language (org-element-at-point))))
+          (unless (cdr (assoc (intern language) org-babel-load-languages))
+            (add-to-list 'org-babel-load-languages (cons (intern language) t))
+            (org-babel-do-load-languages 'org-babel-load-languages org-babel-load-languages))
+          ad-do-it))
+      )
+    )
+#+END_SRC
+
+Enable syntax highlighting and tab stops as if you were editing in the native
+mode within SRC blocks.
+
+#+BEGIN_SRC elisp
+  (defun dotspacemacs/user-config ()
+
+    (with-eval-after-load 'org
+
+      (setq org-src-tab-acts-natively t)
+      (setq org-src-fontify-natively t)
+      )
+    )
+#+END_SRC
+
+* Execution of =cfengine3= =SRC= blocks
+With the insertion point inside the SRC block press ~,,~ or ~CTRL-c Ctrl-c~
+
+#+BEGIN_SRC cfengine3 :exports both
+  bundle agent main
+  {
+    reports:
+
+        "Hello World!";
+  }
+#+END_SRC
+
+#+RESULTS:
+: R: Hello World!
+
+See the ob-cfengine3 [[https://github.com/nickanderson/ob-cfengine3/blob/master/README.org][README]] for information on controlling inclusion of the
+stdlib, definition of classes and controlling the =bundlesequence= using header
+args.
+
+To suppress the confirmation when executing a block set
+=(setq org-confirm-babel-evaluate nil)= in =dotspacemacs/user-config()=.
 
 * Key bindings
 

--- a/layers/+tools/cfengine/packages.el
+++ b/layers/+tools/cfengine/packages.el
@@ -13,9 +13,10 @@
   '(
     (cfengine3-mode :location built-in)
     company
-    ob-cfengine3
     eldoc
     flycheck
+    (ob-cfengine3 :requires org)
+    org
     ))
 
 (defun cfengine/init-cfengine3-mode ()
@@ -36,5 +37,9 @@
 
 (defun cfengine/init-ob-cfengine3 ()
   (use-package ob-cfengine3
-    :defer t
-    :after org))
+    :defer t))
+
+(defun cfengine/pre-init-org ()
+  (when (configuration-layer/package-used-p 'org)
+    (spacemacs|use-package-add-hook org
+      :post-config (add-to-list 'org-babel-load-languages '(cfengine . t)))))

--- a/layers/+tools/cfengine/packages.el
+++ b/layers/+tools/cfengine/packages.el
@@ -13,6 +13,7 @@
   '(
     (cfengine3-mode :location built-in)
     company
+    ob-cfengine3
     eldoc
     flycheck
     ))
@@ -32,3 +33,8 @@
 
 (defun cfengine/post-init-flycheck ()
   (spacemacs/enable-flycheck 'cfengine3-mode-hook))
+
+(defun cfengine/init-ob-cfengine3 ()
+  (use-package ob-cfengine3
+    :defer t
+    :after org))

--- a/layers/+tools/prodigy/packages.el
+++ b/layers/+tools/prodigy/packages.el
@@ -16,18 +16,21 @@
     :init
     (spacemacs/set-leader-keys "aS" 'prodigy)
     :config
-    (evilified-state-evilify prodigy-mode prodigy-mode-map
-      "c" 'prodigy-view-clear-buffer
-      "h" 'prodigy-first
-      "j" 'prodigy-next
-      "k" 'prodigy-prev
-      "l" 'prodigy-last
-      "H" 'prodigy-display-process
-      "J" 'prodigy-next-with-status
-      "K" 'prodigy-prev-with-status
-      "L" 'prodigy-start
-      "d" 'prodigy-jump-dired
-      "g" 'prodigy-jump-magit
-      "Y" 'prodigy-copy-cmd
-      "R" 'revert-buffer)
-    (evil-define-key 'motion prodigy-view-mode-map (kbd "gf") 'find-file-at-point)))
+    (progn
+      (evilified-state-evilify prodigy-mode prodigy-mode-map
+        "c" 'prodigy-view-clear-buffer
+        "h" 'prodigy-first
+        "j" 'prodigy-next
+        "k" 'prodigy-prev
+        "l" 'prodigy-last
+        "H" 'prodigy-display-process
+        "J" 'prodigy-next-with-status
+        "K" 'prodigy-prev-with-status
+        "L" 'prodigy-start
+        "d" 'prodigy-jump-dired
+        "g" 'prodigy-jump-magit
+        "Y" 'prodigy-copy-cmd
+        "R" 'revert-buffer)
+      (evilified-state-evilify prodigy-view-mode prodigy-view-mode-map
+        "gf" 'find-file-at-point
+        "q" 'quit-window))))

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -160,7 +160,7 @@ Finally you may need to toggle truncated lines for some prompts to work
 correctly, in the function =dotspacemacs/user-config= of your dotfile add:
 
 #+BEGIN_SRC emacs-lisp
-(add-hook 'term-mode-hook 'toggle-truncate-lines)
+(add-hook 'term-mode-hook 'spacemacs/toggle-truncate-lines-on)
 #+END_SRC
 
 * Eshell

--- a/layers/auto-layer.el
+++ b/layers/auto-layer.el
@@ -43,10 +43,11 @@
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.slim\\'\\)" slim-mode))
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.phtml\\'\\|\\.tpl\\.php\\'\\|\\.twig\\'\\|\\.html\\'\\|\\.htm\\'\\|\\.[gj]sp\\'\\|\\.as[cp]x?\\'\\|\\.eex\\'\\|\\.erb\\'\\|\\.mustache\\'\\|\\.handlebars\\'\\|\\.hbs\\'\\|\\.eco\\'\\|\\.ejs\\'\\|\\.djhtml\\'\\)" web-mode))
 (configuration-layer/lazy-install 'idris :extensions '("\\(\\.idr$\\|\\.lidr$\\)" idris-mode))
-;; java
+;; javascript
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.coffee\\'\\|\\.iced\\'\\|Cakefile\\'\\|\\.cson\\'\\)" coffee-mode))
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.js\\'\\)" js2-mode))
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.json$\\)" json-mode))
+(configuration-layer/lazy-install 'react :extensions '("\\(\\.jsx$\\)" react-mode))
 ;; latex
 (configuration-layer/lazy-install 'lua :extensions '("\\(\\.lua$\\|\\.lua\\'\\)" lua-mode))
 (configuration-layer/lazy-install 'nginx :extensions '("\\(nginx\\.conf\\'\\|/nginx/.+\\.conf\\'\\)" nginx-mode))


### PR DESCRIPTION
Adds support for setting the following gruvbox theme variants
as dotspacemacs-theme:

  - gruvbox-dark-soft

  - gruvbox-dark-medium

  - gruvbox-dark-hard

  - gruvbox-light-soft

  - gruvbox-light-medium

  - gruvbox-light-hard
