### PR TITLE
spacemacs-evil-cursors: make them easy to configure

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -45,3 +45,18 @@
 to a major mode, a list of such symbols, or the symbol t,
 acting as default. The values are either integers, symbols
 or lists of these.")
+
+;; State cursors
+(defvar spacemacs-evil-cursors '(("normal" "DarkGoldenrod2" box)
+                                 ("insert" "chartreuse3" (bar . 2))
+                                 ("emacs" "SkyBlue2" box)
+                                 ("hybrid" "SkyBlue2" (bar . 2))
+                                 ("replace" "chocolate" (hbar . 2))
+                                 ("evilified" "LightGoldenrod3" box)
+                                 ("visual" "gray" (hbar . 2))
+                                 ("motion" "plum3" box)
+                                 ("lisp" "HotPink1" box)
+                                 ("iedit" "firebrick1" box)
+                                 ("iedit-insert" "firebrick1" (bar . 2)))
+  "Colors assigned to evil states with cursor definitions.
+To add your own, use `spacemacs/add-evil-curosr'.")

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -34,6 +34,18 @@
                   evil-state)))
     (spacemacs/state-color-face state)))
 
+(defun spacemacs/add-evil-cursor (state color shape)
+  (add-to-list 'spacemacs-evil-cursors (list state color shape))
+  (eval `(defface ,(intern (format "spacemacs-%s-face" state))
+           `((t (:background ,color
+                             :foreground ,(face-background 'mode-line)
+                             :inherit 'mode-line)))
+           (format "%s state face." state)
+           :group 'spacemacs))
+  (set (intern (format "evil-%s-state-cursor" state))
+       (list (when dotspacemacs-colorize-cursor-according-to-state color)
+             shape)))
+
 (defun spacemacs/set-state-faces ()
   (cl-loop for (state color cursor) in spacemacs-evil-cursors
            do

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -57,30 +57,8 @@
 
   (require 'cl)
   ;; State cursors
-  (defvar spacemacs-evil-cursors '(("normal" "DarkGoldenrod2" box)
-                                   ("insert" "chartreuse3" (bar . 2))
-                                   ("emacs" "SkyBlue2" box)
-                                   ("hybrid" "SkyBlue2" (bar . 2))
-                                   ("replace" "chocolate" (hbar . 2))
-                                   ("evilified" "LightGoldenrod3" box)
-                                   ("visual" "gray" (hbar . 2))
-                                   ("motion" "plum3" box)
-                                   ("lisp" "HotPink1" box)
-                                   ("iedit" "firebrick1" box)
-                                   ("iedit-insert" "firebrick1" (bar . 2)))
-    "Colors assigned to evil states with cursor definitions.")
-
-  (cl-loop for (state color cursor) in spacemacs-evil-cursors
-           do
-           (eval `(defface ,(intern (format "spacemacs-%s-face" state))
-                    `((t (:background ,color
-                                      :foreground ,(face-background 'mode-line)
-                                      :inherit 'mode-line)))
-                    (format "%s state face." state)
-                    :group 'spacemacs))
-           (set (intern (format "evil-%s-state-cursor" state))
-                (list (when dotspacemacs-colorize-cursor-according-to-state color)
-                      cursor)))
+  (cl-loop for (state color shape) in spacemacs-evil-cursors
+           do (spacemacs/add-evil-cursor state color shape))
   (add-hook 'spacemacs-post-theme-change-hook 'spacemacs/set-state-faces)
 
   ;; evil ex-command


### PR DESCRIPTION
Motivation: so layers with their own evil states (e.g. treemacs) can also
contain their own cursor configuration

Example usage: `(spacemacs/add-evil-cursor "treemacs" "RoyalBlue1" '(hbar . 0))`