### PR TITLE
ruby: add ruby-hash-syntax

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -120,6 +120,7 @@ directory local variables.
 | ~SPC m x '​~ | Change symbol or " string to '                       |
 | ~SPC m x "​~ | Change symbol or ' string to "                       |
 | ~SPC m x :~ | Change string to symbol                              |
+| ~SPC m x h~ | toggle hash syntax in active region                  |
 | ~%~         | [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] jumps between blocks                    |
 
 ** Bundler

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -26,6 +26,7 @@
         robe
         rspec-mode
         rubocop
+        ruby-hash-syntax
         (ruby-mode :location built-in :toggle (not ruby-enable-enh-ruby-mode))
         ruby-refactor
         ruby-test-mode
@@ -220,6 +221,14 @@
     :config (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
               "'" 'ruby-toggle-string-quotes
               "{" 'ruby-toggle-block)))
+
+(defun ruby/init-ruby-hash-syntax ()
+  (use-package ruby-hash-syntax
+    :defer t
+    :init
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "xh" 'ruby-hash-syntax-toggle))))
 
 (defun ruby/init-ruby-refactor ()
   (use-package ruby-refactor


### PR DESCRIPTION
Add a command to toggle between old and new hash syntax in the active region.
