### PR TITLE
Improve coffeescript support

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -19,6 +19,7 @@
   - [[#auto-complete-and-documentation-tern][Auto-complete and documentation (tern)]]
   - [[#json][JSON]]
   - [[#repl-skewer-mode][REPL (skewer-mode)]]
+  - [[#coffee-mode][coffee-mode]]
 
 * Description
 This layer adds support for the JavaScript language using [[https://github.com/mooz/js2-mode][js2-mode]].
@@ -211,3 +212,16 @@ You can check more [[https://github.com/mooz/js-doc/][here]]
 | ~SPC m s r~ | send current region to the skewer REPL                                             |
 | ~SPC m s R~ | send current region to the skewer REPL and switch to it in insert state            |
 | ~SPC m s s~ | switch to REPL                                                                     |
+
+** coffee-mode
+
+| Key Binding | Description                                        |
+|-------------+----------------------------------------------------|
+| ~SPC m '~   | Create or go to REPL                               |
+| ~SPC m c c~ | Compile buffer                                     |
+| ~SPC m c r~ | Compile region                                     |
+| ~SPC m s b~ | Send buffer to REPL                                |
+| ~SPC m s l~ | Send line to REPL                                  |
+| ~SPC m s i~ | Create or go to REPL                               |
+| ~SPC m s r~ | send current region to the REPL and stay in buffer |
+| ~SPC m T c~ | Toggle compile on save                             |

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -42,6 +42,19 @@
     :defer t
     :init
     (progn
+      (spacemacs/register-repl 'coffee-mode 'coffee-repl "coffeescript")
+      ;; keybindings
+      (spacemacs/declare-prefix-for-mode 'coffee-mode "mc" "compile")
+      (spacemacs/declare-prefix-for-mode 'coffee-mode "ms" "REPL")
+      (spacemacs/set-leader-keys-for-major-mode 'coffee-mode
+        "'"  'coffee-repl
+        "cc" 'coffee-compile-buffer
+        "cr" 'coffee-compile-region
+        "sb" 'coffee-send-buffer
+        "sl" 'coffee-send-line
+        "si" 'coffee-repl
+        "sr" 'coffee-send-region
+        "Tc" 'coffee-cos-mode)
       ;; indent to right position after `evil-open-below' and `evil-open-above'
       (add-hook 'coffee-mode-hook
                 '(lambda ()


### PR DESCRIPTION
Register REPL and add major-mode bindings.

Spacemacs got coffeescript support in the javascript layer but it does not add any keybindings and does not register the REPL.