### PR TITLE
Remove unnecessary comments in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -10,7 +10,6 @@
 ;;; License: GPLv3
 
 ;; Without this comment emacs25 adds (package-initialize) here
-;; (package-initialize)
 
 ;; Increase gc-cons-threshold, depending on your system you may set it back to a
 ;; lower value in your dotfile (function `dotspacemacs/user-config')


### PR DESCRIPTION
Hello

Thanks for your work. Your work makes more people know and use Emacs. Good job~~

In order to prevent Emacs25  adding "(package-initialize)", we only need to create (package-initialize) anywhere in init.el. Do not need a separate line.

I'm sorry for my very poor English.