### PR TITLE
Change Frame delete bindings from c/C to d/D

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2162,11 +2162,12 @@ Frame manipulation commands (start with ~F~):
 | Key Binding | Description                                         |
 |-------------+-----------------------------------------------------|
 | ~SPC F f~   | open a file in another frame                        |
-| ~SPC F c~   | delete the current frame (unless it’s the only one) |
-| ~SPC F C~   | delete all other frames                             |
+| ~SPC F d~   | delete the current frame (unless it’s the only one) |
+| ~SPC F D~   | delete all other frames                             |
 | ~SPC F b~   | open a buffer in another frame                      |
 | ~SPC F B~   | open a buffer in another frame (but don’t switch)   |
 | ~SPC F o~   | cycle focus between frames                          |
+| ~SPC F O~   | open a dired buffer in another frame                |
 | ~SPC F n~   | create a new frame                                  |
 
 **** Emacs and Spacemacs files

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -218,12 +218,12 @@
 ;; frame ----------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "Ff" 'find-file-other-frame
-  "Fc" 'delete-frame
-  "FC" 'delete-other-frames
+  "Fd" 'delete-frame
+  "FD" 'delete-other-frames
   "Fb" 'switch-to-buffer-other-frame
   "FB" 'display-buffer-other-frame
-  "Fd" 'dired-other-frame
   "Fo" 'other-frame
+  "FO" 'dired-other-frame
   "Fn" 'make-frame)
 ;; help -----------------------------------------------------------------------
 (spacemacs/set-leader-keys


### PR DESCRIPTION
The Frame delete bindings SPC F c and C, are inconsistent with the delete window
and buffer bindings, that use: d and D

---

I don't know what `"Fd" 'dired-other-frame` should be changed to, so I just commented it out.

I can change it if someone has a suggestion.