### PR TITLE
Update themes transient state, t for helm-themes

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -64,6 +64,7 @@
   - [[#color-themes][Color themes]]
     - [[#default-theme][Default theme]]
     - [[#choosing-themes][Choosing themes]]
+      - [[#themes-transient-state][Themes Transient State]]
     - [[#browsing-themes][Browsing themes]]
     - [[#notes][Notes]]
   - [[#font][Font]]
@@ -1022,10 +1023,13 @@ files in the directory =private/local/foo-theme=.
 You can cycle between the themes declared in =dotspacemacs-themes= with
 ~SPC T n~ and select an installed theme with ~SPC T s~.
 
-| Key Binding | Description                                           |
-|-------------+-------------------------------------------------------|
-| ~SPC T n~   | switch to next theme listed in =dotspacemacs-themes=. |
-| ~SPC T s~   | select a theme.                                       |
+**** Themes Transient State
+
+| Key Binding      | Description                                   |
+|------------------+-----------------------------------------------|
+| ~n~ or ~<right>~ | change to the next theme                      |
+| ~p~ or ~<left>~  | change to the previous theme                  |
+| ~t~ or ~<up>~    | open helm-themes to select an installed theme |
 
 *** Browsing themes
 You can see samples of all themes included in the =themes-megapack= layer

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -150,13 +150,14 @@
 ;; Cycling settings -----------------------------------------------------------
 (spacemacs|define-transient-state theme
   :title "Themes Transient State"
-  :doc "\n[_p_/_<left>_] cycles backward,  [_n_/_<right>_] cycles forward, [_<up>_] helm-themes"
+  :doc "\n[_n_/_<right>_] next  [_p_/_<left>_] previous  [_t_/_<up>_] helm-themes"
   :bindings
   ("n" spacemacs/cycle-spacemacs-theme)
-  ("p" (spacemacs/cycle-spacemacs-theme t))
+  ("p" (spacemacs/cycle-spacemacs-theme 'backward))
+  ("t" helm-themes)
   ("<up>" helm-themes)
-  ("<left>" (spacemacs/cycle-spacemacs-theme t))
-  ("<right>" spacemacs/cycle-spacemacs-theme))
+  ("<right>" spacemacs/cycle-spacemacs-theme)
+  ("<left>" (spacemacs/cycle-spacemacs-theme 'backward)))
 (spacemacs/set-leader-keys "Tn"
   'spacemacs/theme-transient-state/spacemacs/cycle-spacemacs-theme)
 ;; errors ---------------------------------------------------------------------


### PR DESCRIPTION
Add the key binding: t
to open helm-themes, without having to use the arrow up key.

Reorder/rename: cycles backward and cycles forward
to: next and previous

Next is listed first, because it's the most common action, and it matches the
order in other transient states.

Change the t argument in the call to spacemacs/cycle-spacemacs-theme, to the
symbol 'backward, to make it clear what the argument does.

Add documentation for the Themes Transient State bindings.