### PR TITLE
Make auto-completion triggers more friendly in "react" layer

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -22,4 +22,6 @@
   ;; Force jsx content type
   (web-mode-set-content-type "jsx")
   ;; Don't auto-quote attribute values
-  (setq-local web-mode-enable-auto-quoting nil))
+  (setq-local web-mode-enable-auto-quoting nil)
+  ;; See https://github.com/syl20bnr/spacemacs/issues/8222
+  (set (make-local-variable 'company-minimum-prefix-length) 2))


### PR DESCRIPTION
Auto completion menu triggers too frequently in react-mode, for example, the
completion menu will pop up right after user finishes typing a javascript
statement.

The root cause is that the 'company-minimum-prefix-length variable has been set
to 0 in "html" layer, which is used by "react" layer.

Overriding this variable to 2, as defined in "auto-completion" layer, will
resolve this issue.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3