### PR TITLE
Improves jump-to-definition for Clojure modes

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -170,3 +170,12 @@ If called with a prefix argument, uses the other-window instead."
   (when (memq dotspacemacs-editing-style '(hybrid vim))
     (evil-make-overriding-map cider--debug-mode-map 'normal)
     (evil-normalize-keymaps)))
+
+(defun spacemacs/clj-find-var ()
+  "Attempts to jump-to-definition of the symbol-at-point. If CIDER fails, or not available, falls back to dumb-jump"
+  (interactive)
+  (let ((var (cider-symbol-at-point)))
+    (if (and (cider-connected-p) (cider-var-info var))
+        (unless (eq 'symbol (type-of (cider-find-var nil var)))
+          (dumb-jump-go))
+      (dumb-jump-go))))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -46,7 +46,12 @@
                    spacemacs-jump-handlers-clojurescript-mode
                    spacemacs-jump-handlers-clojurex-mode
                    spacemacs-jump-handlers-cider-repl-mode))
-        (add-to-list x 'cider-find-var))
+        (add-to-list x 'spacemacs/clj-find-var))
+
+      (add-hook 'clojure-mode-hook #'spacemacs//init-jump-handlers-clojure-mode)
+      (add-hook 'clojurescript-mode-hook #'spacemacs//init-jump-handlers-clojurescript-mode)
+      (add-hook 'clojurec-mode-hook #'spacemacs//init-jump-handlers-clojurec-mode)
+      (add-hook 'cider-repl-mode-hook #'spacemacs//init-jump-handlers-cider-repl-mode)
 
       ;; TODO: having this work for cider-macroexpansion-mode would be nice,
       ;;       but the problem is that it uses clojure-mode as its major-mode


### PR DESCRIPTION
### What does this PR do?

Improves/fixes jump-to-definition for Clojure layer

### Rationale

Jump to definition in Clojure modes doesn't work reliably.

- CIDER's default `cider-find-var` only works when CIDER is connected or jacked-in and even then it doesn't always work. 
  - it doesn't work in cljs, cljc files and cider-repl-mode
  - sometimes it doesn't correctly recognize symbol-at-point and prompts user to enter one

The idea is to use `cider-find-var` whenever possible. If it is not available, or if it fails: use the fallback option - `dumb-jump-go`, it is simple and it works reliably in most cases (but CIDER's fn still preferable).

### How to test?

- Open any Clojure/Clojurescript project
- try using `g d` and `, g g` 
- try in Clojure, Clojurescript and .cljc files if possible
- execute M-x `cider-jack-in`
- wait for CIDER to get connected to the REPL
- try using `g d` and `, g g` again