### PR TITLE
Adds org-toggle-archive-tag keybinding

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -213,7 +213,8 @@ Will work on both org-mode and any mode that accepts plain html."
         "C-S-k" 'org-shiftcontrolup
 
         ;; Subtree editing
-        "sa" 'org-archive-subtree
+        "sa" 'org-toggle-archive-tag
+        "sA" 'org-archive-subtree
         "sb" 'org-tree-to-indirect-buffer
         "sh" 'org-promote-subtree
         "sj" 'org-move-subtree-down


### PR DESCRIPTION
*Due to the lack of better way of conveying ideas, I thought I would just create a super-small PR*

I think `org-toggle-archive-tag` is an awesome function that doesn't get much respect. The native org-mode keybinding: `C-c C-x a` is a tad inconvenient.

I wonder if it makes sense to have it like this:

    (spacemacs/set-leader-keys-for-major-mode 'org-mode
      "sa" 'org-toggle-archive-tag
      "sA" 'org-archive-subtree)
      
The argument for having it like that:  'archive-subtree' is a much "destructive", bigger operation compared to 'toggle-archive-tag'. On the other hand, maybe some would argue that it should be kept as `<,sa>` - and the new key should be `<,sA>`. 

Let me know what you think.