### PR TITLE
Remove stray characters from output-dir argument

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2354,7 +2354,7 @@ The URL of the descriptor is patched to be the passed URL"
   )
 
 (defun configuration-layer//download-elpa-file
-    (pkg-name filename archive-url output-dirkkj
+    (pkg-name filename archive-url output-dir
               &optional signaturep readmep)
   "Download FILENAME from distant ELPA repository to OUTPUT-DIR.
 


### PR DESCRIPTION
The output-dir argument seems to have gotten some stray characters.

---

This was brought to my attention by @sdwolf in the chat:
https://gitter.im/syl20bnr/spacemacs?at=59f59330614889d47513b400