### PR TITLE
Add basic JSonnet layer provided by jsonnet-mode

### DIFF
--- a/layers/+lang/jsonnet/README.org
+++ b/layers/+lang/jsonnet/README.org
@@ -1,0 +1,27 @@
+#+TITLE: jsonnet layer
+
+# TOC links should be GitHub style anchors.
+* Table of Contents                                        :TOC_4_gh:noexport:
+- [[#description][Description]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+This layer provides basic syntax highlighting and formatting as provided by 
+[[https://github.com/mgyucht/jsonnet-mode][jsonnet-mode]]
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =jsonnet= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+To use some of the additional formatting and evaluation features, you'll need
+to [[http://jsonnet.org/index.html][the jsonnet binary]]
+
+* Key bindings
+
+| Key Binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC m j ~  | jump to the definition of a given identifier             |
+| ~SPC m e ~  | show the result of running jsonnet on the current buffer |
+| ~SPC m f ~  | format the buffer using `jsonnet fmt`                    |

--- a/layers/+lang/jsonnet/packages.el
+++ b/layers/+lang/jsonnet/packages.el
@@ -1,0 +1,75 @@
+;;; packages.el --- jsonnet layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Liz <liz@kazkaan>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;; See the Spacemacs documentation and FAQs for instructions on how to implement
+;; a new layer:
+;;
+;;   SPC h SPC layers RET
+;;
+;;
+;; Briefly, each package to be installed or configured by this layer should be
+;; added to `jsonnet-packages'. Then, for each package PACKAGE:
+;;
+;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
+;;   function `jsonnet/init-PACKAGE' to load and initialize the package.
+
+;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
+;;   define the functions `jsonnet/pre-init-PACKAGE' and/or
+;;   `jsonnet/post-init-PACKAGE' to customize the package as it is loaded.
+
+;;; Code:
+
+(setq jsonnet-packages
+  '(
+    jsonnet-mode
+    )
+
+   "The list of Lisp packages required by the jsonnet layer.
+
+Each entry is either:
+
+1. A symbol, which is interpreted as a package to be installed, or
+
+2. A list of the form (PACKAGE KEYS...), where PACKAGE is the
+    name of the package to be installed or loaded, and KEYS are
+    any number of keyword-value-pairs.
+
+    The following keys are accepted:
+
+    - :excluded (t or nil): Prevent the package from being loaded
+      if value is non-nil
+
+    - :location: Specify a custom installation location.
+      The following values are legal:
+
+      - The symbol `elpa' (default) means PACKAGE will be
+        installed using the Emacs package manager.
+
+      - The symbol `local' directs Spacemacs to load the file at
+        `./local/PACKAGE/PACKAGE.el'
+
+      - A list beginning with the symbol `recipe' is a melpa
+        recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
+
+(defun jsonnet/init-jsonnet-mode ()
+    (use-package jsonnet-mode
+      :defer t
+      :init
+      (progn
+        (spacemacs/set-leader-keys-for-major-mode 'jsonnet-mode
+          "j" 'jsonnet-jump
+          "e" 'jsonnet-eval-buffer
+          "f" 'jsonnet-reformat-buffer
+          ))))
+
+;;; packages.el ends here


### PR DESCRIPTION
JSonnet is a DSL for programatically generating complex JSON documents. This layer is based on mgyucht/jsonnet-mode. 