### PR TITLE
Fix bindings in imenu-list

### DIFF
--- a/layers/+tools/imenu-list/README.org
+++ b/layers/+tools/imenu-list/README.org
@@ -37,3 +37,4 @@ this file.
 | ~RET~       | go to current entry                                    |
 | ~d~         | display current entry, keep focus on imenu-list window |
 | ~f~         | fold/unfold current section                            |
+| ~r~         | refresh imenu-list window                              |

--- a/layers/+tools/imenu-list/packages.el
+++ b/layers/+tools/imenu-list/packages.el
@@ -27,10 +27,10 @@
     (progn
       (setq imenu-list-focus-after-activation t
             imenu-list-auto-resize t)
-      (spacemacs/set-leader-keys "bi" #'imenu-list-minor-mode))
+      (spacemacs/set-leader-keys "bi" #'imenu-list-smart-toggle))
     :config
     (evilified-state-evilify-map imenu-list-major-mode-map
       :mode imenu-list-major-mode
       :bindings
       "d" #'imenu-list-display-entry
-      "q" #'imenu-list-minor-mode)))
+      "r" #'imenu-list-refresh)))


### PR DESCRIPTION
According to bmag/imenu-list@9cbe6baa55c301ffc21c621ca16d1faea96540aa, we don't need to add binding to quit imenu-list window specifically, and we can add binding to refresh imenu-list window.

According to bmag/imenu-list@8f6538c68b45f678e13d517c6cb82246950aeecb, it is better to toggle imenu-list by `imenu-list-smart-toggle` rather than `imenu-list-minor-mode`.