### PR TITLE
improve recognition of react-mode

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -64,5 +64,5 @@
   (add-to-list 'auto-mode-alist '("\\index.android.js\\'" . react-mode))
   (add-to-list 'auto-mode-alist '("\\index.ios.js\\'" . react-mode))
   (add-to-list 'magic-mode-alist '("/\\*\\* @jsx .*\\*/" . react-mode))
-  (add-to-list 'magic-mode-alist '("import\s+[^\s]+\s+from\s+['\"]react['\"]" . react-mode))
+  (add-to-list 'magic-mode-alist '("import React" . react-mode))
   (add-hook 'react-mode-hook 'spacemacs//setup-react-mode))


### PR DESCRIPTION
Previously it was impossible for react-mode to recognise .js files, with
additional import statements from 'react'.

Example 1: import React, { Component } from 'react';
Example 2: import React, {
  Component
} from 'react';

The fix is a revert of changes introduced in the following commit:
12f823ba3c18d036ecfa8944775324842c3f3b55

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3