### PR TITLE
Ycmd

### DIFF
--- a/layers/+tools/ycmd/funcs.el
+++ b/layers/+tools/ycmd/funcs.el
@@ -1,0 +1,9 @@
+(defun ycmd/manual-semantic-company-completer ()
+  "A useful function that can be bound, if users prefer to trigger company
+completion manually"
+
+  (interactive)
+  (company-cancel)
+  (let ((ycmd-force-semantic-completion (not (company-ycmd--in-include))))
+    (setq company-backend 'company-ycmd)
+    (company-manual-begin)))

--- a/layers/+tools/ycmd/packages.el
+++ b/layers/+tools/ycmd/packages.el
@@ -17,10 +17,6 @@
     ycmd
     ))
 
-(unless (boundp 'ycmd-server-command)
-  (message (concat "YCMD won't work unless you set the ycmd-server-command "
-                   "variable to the path to a ycmd install.")))
-
 (defun ycmd/init-company-ycmd ()
   (use-package company-ycmd
     :defer t


### PR DESCRIPTION
Two small commits for the ycmd layer. The first removes a warning that is supposed to fire when a variable is unset. In my experience this code runs too early and always fires, even when the variable is set. The second adds a function that can be used to trigger semantic completion manually. This is a prerequisite for the cpp2 layer that I'm planning to push soon. On larger C++ projects semantic completion while acceptable isn't lightning fast, so it makes sense to have dabbrev completion trigger automaticalally and manually trigger semantic. Might be a good opportunity to start thinking about a convention, spacemacs wide, for manually triggering completion, for both evil and holy.