### PR TITLE
Fix elfeed selection bindings in visual state

### DIFF
--- a/layers/+web-services/elfeed/packages.el
+++ b/layers/+web-services/elfeed/packages.el
@@ -40,7 +40,12 @@
         :bindings
         "q" 'quit-window
         (kbd "C-j") 'elfeed-show-next
-        (kbd "C-k") 'elfeed-show-prev))))
+        (kbd "C-k") 'elfeed-show-prev)
+      (evil-define-key 'visual elfeed-search-mode-map
+        "+"  'elfeed-search-tag-all
+        "-"  'elfeed-search-untag-all
+        "b"  'elfeed-search-browse-url
+        "y"  'elfeed-search-yank))))
 
 (defun elfeed/init-elfeed-goodies ()
   (use-package elfeed-goodies


### PR DESCRIPTION
Some elfeed commands can operate on a number of entries, based on the active
selection. When selecting entries with evil (visual state), the bindings for
these commands are shadowed by visual state bindings, and can't be accessed.

To fix this, the affected elfeed bindings are explicitly defined for visual
state.