### PR TITLE
Add Gradle support to the Groovy layer

### DIFF
--- a/layers/+lang/groovy/README.org
+++ b/layers/+lang/groovy/README.org
@@ -7,10 +7,11 @@
   - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
+  - [[#gradle][Gradle]]
   - [[#repl][REPL]]
 
 * Description
-This layer supports [[http://www.groovy-lang.org/][groovy]] development in Spacemacs.
+This layer supports [[http://www.groovy-lang.org/][Groovy]] development in Spacemacs.
 
 ** Features:
 - Basic dabbrev auto-completion with company
@@ -23,6 +24,17 @@ add =groovy= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 * Key bindings
+** Gradle
+
+| Key Binding | Description              |
+|-------------+--------------------------|
+| ~SPC m c c~ | Compile                  |
+| ~SPC m c r~ | Clean and compile        |
+| ~SPC m c t~ | Execute a Gradle task    |
+| ~SPC m t a~ | Run all tests            |
+| ~SPC m t b~ | Run current buffer tests |
+| ~SPC m t t~ | Run a specific test      |
+
 ** REPL
 
 | Key Binding | Description                                           |

--- a/layers/+lang/groovy/funcs.el
+++ b/layers/+lang/groovy/funcs.el
@@ -10,6 +10,19 @@
 ;;; License: GPLv3
 
 
+;; Gradle
+
+(when (configuration-layer/package-used-p 'gradle-mode)
+  (defun spacemacs/gradle-clean-build ()
+    "Execute 'gradle clean build' command."
+    (interactive)
+    (gradle-execute "clean build"))
+
+  (defun spacemacs/gradle-test-buffer ()
+    "Execute 'gradle test' command against current buffer tests."
+    (interactive)
+    (gradle-single-test (file-name-base (buffer-file-name)))))
+
 ;; REPL
 
 (defun spacemacs/groovy-send-region-switch (start end)

--- a/layers/+lang/groovy/packages.el
+++ b/layers/+lang/groovy/packages.el
@@ -12,6 +12,7 @@
 (setq groovy-packages
       '(
         company
+        gradle-mode
         groovy-imports
         groovy-mode
         org
@@ -19,6 +20,19 @@
 
 (defun groovy/post-init-company ()
   (spacemacs|add-company-backends :modes groovy-mode))
+
+(defun groovy/init-gradle-mode ()
+  (use-package gradle-mode
+    :defer t
+    :config
+    (progn
+      (spacemacs/set-leader-keys-for-minor-mode 'gradle-mode
+        "cc" 'gradle-build
+        "cr" 'spacemacs/gradle-clean-build
+        "ct" 'gradle-execute
+        "ta" 'gradle-test
+        "tb" 'spacemacs/gradle-test-buffer
+        "tt" 'gradle-single-test))))
 
 (defun groovy/init-groovy-imports ()
   (use-package groovy-imports
@@ -30,6 +44,10 @@
     :init
     (progn
       (spacemacs/declare-prefix-for-mode 'groovy-mode "ms" "REPL")
+      (when (configuration-layer/package-used-p 'gradle-mode)
+        (add-hook 'groovy-mode-hook 'gradle-mode)
+        (spacemacs/declare-prefix-for-mode 'groovy-mode "mc" "build")
+        (spacemacs/declare-prefix-for-mode 'groovy-mode "mt" "test"))
       (spacemacs/set-leader-keys-for-major-mode 'groovy-mode
         "'"  'run-groovy
         "sB" 'spacemacs/groovy-load-file-switch


### PR DESCRIPTION
* Adds support for [gradle-mode](https://github.com/jacobono/emacs-gradle-mode)
* Adds functions for `clean build` and buffer specific `test` tasks
* Adds keybindings to `groovy-mode` for building, task running, and testing with Gradle