### PR TITLE
account for new /elpa<branch>/ dir in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 auto-save-list/
-elpa/
+/elpa*/
 export/
 !/core/tools/export/
 ac-comphist.dat


### PR DESCRIPTION
just noticed the `/elpadevelop/` dir keeps showing up in untracked files
seemed related to the changed [around here](https://github.com/syl20bnr/spacemacs/commit/a363f85)
tried to reflect that in the `.gitignore`