### PR TITLE
Fix excessive memory usage on first startup

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2372,9 +2372,9 @@ The URL of the descriptor is patched to be the passed URL"
       (error "Opening output file: File already exists, %s" newname))
   (cond
    ((executable-find "wget")
-    (shell-command (concat "wget -O " (shell-quote-argument newname) (shell-quote-argument url))))
+    (shell-command (concat "wget -O " (shell-quote-argument newname) " " (shell-quote-argument url))))
    ((executable-find "curl")
-    (shell-command (concat "curl -o " (shell-quote-argument newname) (shell-quote-argument url))))
+    (shell-command (concat "curl -o " (shell-quote-argument newname) " " (shell-quote-argument url))))
    ;; (t (url-copy-file url newname 'ok-if-already-exists))))
    (t (message (concat "Neither curl nor wget found found; please install")))))
 


### PR DESCRIPTION
I experienced this reproducibly when spacemacs reached the stage where it shows
the message in the mode line starting like this:

"Downloading stable ELPA repository: "

Without this change I was unable to start spacemacs and in fact had to reboot my
machine multiple times. Emacs 25.1.1, Ubuntu 17.04, no swap configured.

Obviously this needs cleaning up a bit...

Also fixed an extraneous 'kkj' which I assume is a typo (actually I thought this
was my typo but turns out to be syl20bnr himself :-)
