### PR TITLE
Use python-mode for SCons script files

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -256,6 +256,7 @@
 (defun python/init-python ()
   (use-package python
     :defer t
+    :mode (("SConstruct\\'" . python-mode) ("SConscript\\'" . python-mode))
     :init
     (progn
       (spacemacs/register-repl 'python 'python-start-or-switch-repl "python")


### PR DESCRIPTION
The SCons build system uses Python build scripts conventionally named:
* SConstruct
* SConscript

This commit would make python-mode load by default for these files.