### PR TITLE
Fix pylookup issues with new sphinx template

### DIFF
--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -136,7 +136,7 @@ class IndexProcessor(HTMLParser):
         self.dirn = dirn
         self.entry = ""
         self.desc = ""
-        self.list_entry = False
+        self.level = 0
         self.one_entry = False
         self.num_of_a = 0
         self.desc_cnt = 0
@@ -145,19 +145,19 @@ class IndexProcessor(HTMLParser):
     def handle_starttag(self, tag, attrs):
         self.tag = tag
         attrs = dict(attrs)
-        if self.tag == 'dd':
-            self.list_entry = True
-        elif self.tag == 'dt':
+        if tag in ['dd', 'dl', 'ul']:
+            self.level += 1
+        elif tag in ['dt', 'li']:
             self.one_entry = True
             self.num_of_a = 0
-        elif self.tag == 'a':
+        elif tag == 'a':
             if self.one_entry:
                 self.url = join(self.dirn, attrs['href'])
 
     def handle_endtag(self, tag):
-        if tag == 'dd':
-            self.list_entry = False
-        if tag == 'dt':
+        if tag in ['dd', 'dl', 'ul']:
+            self.level -= 1
+        elif tag in ['dt', 'li']:
             self.one_entry = False
 
     def handle_data(self, data):
@@ -175,7 +175,7 @@ class IndexProcessor(HTMLParser):
                                               self.desc.ljust(80)))
                     # extract fist element
                     #  ex) __and__() (in module operator)
-                    if not self.list_entry:
+                    if self.level == 1:
                         self.entry = re.sub("\([^)]+\)", "", self.desc)
 
                         # clean up PEP

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -137,7 +137,6 @@ class IndexProcessor(HTMLParser):
         self.entry = ""
         self.desc = ""
         self.list_entry = False
-        self.do_entry = False
         self.one_entry = False
         self.num_of_a = 0
         self.desc_cnt = 0
@@ -158,8 +157,6 @@ class IndexProcessor(HTMLParser):
     def handle_endtag(self, tag):
         if tag == 'dd':
             self.list_entry = False
-        elif tag == 'dt':
-            self.do_entry = False
 
     def handle_data(self, data):
         if self.tag == 'a':

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -157,6 +157,8 @@ class IndexProcessor(HTMLParser):
     def handle_endtag(self, tag):
         if tag == 'dd':
             self.list_entry = False
+        if tag == 'dt':
+            self.one_entry = False
 
     def handle_data(self, data):
         if self.tag == 'a':

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -155,12 +155,14 @@ class IndexProcessor(HTMLParser):
             if self.one_entry:
                 self.url = join(self.dirn, attrs['href'])
 
-    def handle_data(self, data):
-        if self.tag == 'dd':
+    def handle_endtag(self, tag):
+        if tag == 'dd':
             self.list_entry = False
-        elif self.tag == 'dt':
+        elif tag == 'dt':
             self.do_entry = False
-        elif self.tag == 'a':
+
+    def handle_data(self, data):
+        if self.tag == 'a':
             global VERBOSE
             if self.one_entry:
                 if self.num_of_a == 0:

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -24,11 +24,11 @@ except:
     import pickle
 
 if sys.version_info[0] == 3:
-    import html.parser as htmllib
+    from html.parser import HTMLParser
     import urllib.parse as urlparse
     import urllib.request as urllib
 else:
-    import htmllib
+    from HTMLParser import HTMLParser
     import urllib
     import urlparse
     import formatter
@@ -122,16 +122,16 @@ def get_matcher(insensitive=True, desc=True):
     return getattr(Element, "match{0}{1}".format(_in_entry, _sensitive))
 
 
-class IndexProcessor(htmllib.HTMLParser):
+class IndexProcessor(HTMLParser):
     """
     Extract the index links from a Python HTML documentation index.
     """
 
     def __init__(self, writer, dirn):
         try:
-            htmllib.HTMLParser.__init__(self)
+            HTMLParser.__init__(self)
         except TypeError:
-            htmllib.HTMLParser.__init__(self, formatter.NullFormatter())
+            HTMLParser.__init__(self, formatter.NullFormatter())
         self.writer = writer
         self.dirn = dirn
         self.entry = ""
@@ -143,11 +143,7 @@ class IndexProcessor(htmllib.HTMLParser):
         self.desc_cnt = 0
         self.tag = None
 
-    def handle_starttag(self, tag, *args):
-        if sys.version_info[0] == 3:
-            attrs = args[0]
-        else:
-            attrs = args[1]
+    def handle_starttag(self, tag, attrs):
         self.tag = tag
         attrs = dict(attrs)
         if self.tag == 'dd':

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -29,7 +29,7 @@ if sys.version_info[0] == 3:
     import urllib.request as urllib
 else:
     from HTMLParser import HTMLParser
-    import urllib
+    import urllib2 as urllib
     import urlparse
     import formatter
 

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -228,9 +228,11 @@ def update(db, urls, append=False):
                 # guess index URLs
                 # for stdlib, this is genindex-all.html
                 # for django, numpy, etc. it's genindex.html
+                # for flask, requests, it's genindex/
                 url = url.rstrip("/")
                 potential_urls.append(url + "/genindex-all.html")
                 potential_urls.append(url + "/genindex.html")
+                potential_urls.append(url + "/genindex/")
 
             success = False
             for index_url in potential_urls:

--- a/layers/+lang/python/local/pylookup/pylookup.py
+++ b/layers/+lang/python/local/pylookup/pylookup.py
@@ -155,6 +155,7 @@ class IndexProcessor(HTMLParser):
                 self.url = join(self.dirn, attrs['href'])
 
     def handle_endtag(self, tag):
+        self.tag = None
         if tag in ['dd', 'dl', 'ul']:
             self.level -= 1
         elif tag in ['dt', 'li']:


### PR DESCRIPTION
List of bugs fixed:

- Pylookup update would generate empty index on new style sphinx documentation (for instance with latest online documentation of Python 2.7 and Python 3.6) (Ref #9866)
- The elements were being generated incorrectly, so `./pylookup.py --cache` was broken.
- Non link DOM elements were detected as links if they were preceded by other links. This incorrectly added the same link several times on some pages.
- The last index item would get associated with all the links following it (including those in the footer of the page)
- For online documentation, pylookup update would incorrectly succeed on 404, instead of trying the next candidate url. 

Tested to work with documentation of Python 2.6, Python 2.7, Python 3.4, Python 3.5, Python 3.6, and latest stable releases for SciPy, NumPy, Matplotlib, and Flask.