### PR TITLE
fix autoloading spacemacs/helm-find-files #9826

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -59,7 +59,8 @@
 (defun helm/init-helm ()
   (use-package helm
     :defer 1
-    :commands (spacemacs/helm-find-files)
+    :commands (spacemacs/helm-find-files
+               helm-current-directory)
     :init
     (progn
       (add-hook 'helm-cleanup-hook #'spacemacs//helm-cleanup)


### PR DESCRIPTION
This is a proposed fix for https://github.com/syl20bnr/spacemacs/issues/9826

Despite `spacemacs/helm-find-files` being passed to `:commands`, use-package doesn't seem to autoload helm when it is called, causing the error. I think use-package needs the `:commands` values to actually be part of helm? Not an expert on use-package/autoloading.