### PR TITLE
html layer: use web-mode for `.xml` files

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -266,6 +266,7 @@
     (("\\.phtml\\'"      . web-mode)
      ("\\.tpl\\.php\\'"  . web-mode)
      ("\\.twig\\'"       . web-mode)
+     ("\\.xml\\'"        . web-mode)
      ("\\.html\\'"       . web-mode)
      ("\\.htm\\'"        . web-mode)
      ("\\.[gj]sp\\'"     . web-mode)


### PR DESCRIPTION
open `xml` files in `web-mode` by default in `html` layer

that's the behavior i'd expect/prefer and [i'm not <sup>totally</sup> alone](https://github.com/syl20bnr/spacemacs/issues/5483#issuecomment-196277122) @TheBB 