### PR TITLE
Changed 'the value is in second' to 'the value is in seconds'.

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1714,7 +1714,7 @@ It lists the available key bindings and their associated commands.
 
 By default the [[https://github.com/justbur/emacs-which-key][which-key]] buffer will be displayed quickly after the key has been
 pressed. You can change the delay by setting the variable
-=dotspacemacs-which-key-delay= to your liking (the value is in second).
+=dotspacemacs-which-key-delay= to your liking (the value is in seconds).
 
 **** Describe key bindings
 It is possible to search for specific key bindings by pressing ~SPC ?~.


### PR DESCRIPTION
A minor grammatical correction where I changed 'the value is in second' to 'the value is in seconds'.