### PR TITLE
Update README of Spotify layer

### DIFF
--- a/layers/+web-services/spotify/README.org
+++ b/layers/+web-services/spotify/README.org
@@ -22,5 +22,10 @@ file.
 | ~SPC a m s p~ | Play or pause Spotify    |
 | ~SPC a m s n~ | Go to the next track     |
 | ~SPC a m s N~ | Go to the previous track |
-| ~SPC a m s g~ | Search for a new track   |
 | ~SPC a m s Q~ | Quit Spotify             |
+
+If [[https://github.com/emacs-helm/helm][Helm]] layer is enabled, you can also use the following binding(s):
+
+| Key Binding   | Description            |
+|---------------+------------------------|
+| ~SPC a m s g~ | Search for a new track |


### PR DESCRIPTION
As "searching for a new track" feature is only provided by `helm-spotify`, I added a description about Helm only key bindings. It would be less confusing for non Helm layer configured users.