### PR TITLE
fix typo in cmake-ide by moving a closing parenthesis

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -69,7 +69,7 @@
       (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks))))
 
 (defun c-c++/init-cmake-ide ()
-  (use-package cmake-ide)
+  (use-package cmake-ide
     :config
     (progn
       (cmake-ide-setup)
@@ -78,7 +78,7 @@
           "cc" 'cmake-ide-compile
           "pc" 'cmake-ide-run-cmake
           "pC" 'cmake-ide-maybe-run-cmake
-          "pd" 'cmake-ide-delete-file))))
+          "pd" 'cmake-ide-delete-file)))))
 
 (defun c-c++/init-cmake-mode ()
   (use-package cmake-mode


### PR DESCRIPTION
One closing parenthesis for use-package call is mis-placed.
The fix is trivial.  Just move it to the end of the sexp.

Without this fix, I get "cmake-ide-setup undefined" error.