### PR TITLE
Do not define an evil cursor for treemacs to fix flashing cursor issue

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -36,17 +36,31 @@
 
 (defun spacemacs/add-evil-cursor (state color shape)
   "Define a cursor and face for a new evil state.
-An appropriate entry is added to `spacemacs-evil-cursors', as well."
+An appropriate entry is added to `spacemacs-evil-cursors', as well.
+
+For evil states that do not need an evil cursor use
+`spacemacs/define-evil-state-face' instead."
   (add-to-list 'spacemacs-evil-cursors (list state color shape))
+  (spacemacs/define-evil-state-face state color)
+  (set (intern (format "evil-%s-state-cursor" state))
+       (list (when dotspacemacs-colorize-cursor-according-to-state color)
+             shape)))
+
+(defun spacemacs/define-evil-state-face (state color)
+  "Define a face for an evil state.
+For evil states that also need an entry to `spacemacs-evil-cursors' use
+`spacemacs/add-evil-cursor' instead."
+  ;; this function and `spacemacs/add-evil-cursor' need to be separate because
+  ;; some states must explicitly *not* have their own evil spacemacs cursor
+  ;; for example treemacs: it needs no cursor since it solely uses hl-line-mode
+  ;; and having an evil cursor defined anyway leads to the cursor sometimes
+  ;; visibly flashing in treemacs buffers
   (eval `(defface ,(intern (format "spacemacs-%s-face" state))
            `((t (:background ,color
                              :foreground ,(face-background 'mode-line)
                              :inherit 'mode-line)))
            (format "%s state face." state)
-           :group 'spacemacs))
-  (set (intern (format "evil-%s-state-cursor" state))
-       (list (when dotspacemacs-colorize-cursor-according-to-state color)
-             shape)))
+           :group 'spacemacs)))
 
 (defun spacemacs/set-state-faces ()
   (cl-loop for (state color cursor) in spacemacs-evil-cursors

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -34,7 +34,7 @@
       "f C-t" #'treemacs-find-file)
     :config
     (progn
-      (spacemacs/add-evil-cursor "treemacs" "MediumPurple1" '(hbar . 0))
+      (spacemacs/define-evil-state-face "treemacs" "MediumPurple1")
       (setq treemacs-follow-after-init t
             treemacs-width 35
             treemacs-position 'left


### PR DESCRIPTION
Adding an evil cursor for treemacs will sometimes cause the cursor to flash. This is especially visible when navigating up and down while the helpful hydra (bound to ?) is open. These changes will fix this issue.

Special thanks to @duianto for helping me track this down.

See discussion at https://github.com/Alexander-Miller/treemacs/commit/ab19aa7b33330d3f5752cb3eb3571b1b728c2408#commitcomment-25718297 for details.