### PR TITLE
neotree: Use ~SPC 0~ to open the tree

### DIFF
--- a/layers/+filetree/neotree/README.org
+++ b/layers/+filetree/neotree/README.org
@@ -76,11 +76,11 @@ See https://github.com/jaypei/emacs-neotree/issues/126 for more information.
 This layer provides a quick and simple way to navigate in an unknown project
 file tree with [[https://github.com/jaypei/emacs-neotree][NeoTree]].
 
-To toggle the =NeoTree= buffer press ~SPC f t~ or ~SPC p t~ (the latter open
+To toggle the =NeoTree= buffer, press ~SPC f t~ or ~SPC p t~ (the latter opens
 NeoTree with the root set to the projectile project root).
 
-The NeoTree window always has the number =0= so it does not shift the current
-number of the other windows. To select the NeoTree window you then use ~SPC 0~.
+To select the NeoTree window, press ~SPC 0~. The NeoTree window always has the
+number =0= so it does not shift the current number of the other windows.
 
 VCS integration is supported, the file color will change depending on its
 current state. With default =spacemacs-dark= theme:

--- a/layers/+filetree/neotree/packages.el
+++ b/layers/+filetree/neotree/packages.el
@@ -9,11 +9,11 @@
 ;;
 ;;; License: GPLv3
 
-(setq neotree-packages
-      '(
-        neotree
-        winum
-        ))
+(defconst neotree-packages
+  '(
+    neotree
+    winum
+    ))
 
 (defun neotree/init-neotree ()
   (use-package neotree
@@ -103,7 +103,6 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
 
       (spacemacs/set-leader-keys
         "ft" 'neotree-toggle
-        "fT" 'neotree-show
         "pt" 'neotree-find-project-root))
     :config
     (spacemacs//neotree-key-bindings)))
@@ -112,3 +111,8 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
   (spacemacs|use-package-add-hook winum
     :post-config
     (add-to-list 'winum-assign-functions #'spacemacs//winum-neotree-assign-func)))
+
+(defun neotree/post-init-winum ()
+  (spacemacs/set-leader-keys
+    ;; window 0 is reserved for file trees
+    "0" 'neotree-show))

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -81,8 +81,8 @@ Default value is 3 (or 0 when python is not installed).
 
 | Key Binding | Description                                                                                                                                    |
 |-------------+------------------------------------------------------------------------------------------------------------------------------------------------|
+| ~SPC 0~     | Open treemacs in the current directory. When not visiting a file use $HOME as fallback. With a prefix arg manually select the root instead.    |
 | ~SPC f t~   | Hide/show existing treemacs buffer. Create one for the current directory if no buffer exists.                                                  |
-| ~SPC f T~   | Open treemacs in the current directory. When not visiting a file use $HOME as fallback. With a prefix arg manually select the root instead.    |
 | ~SPC f p~   | Same as ~SPC f t~, but when creating a new buffer open it in the current project's root.                                                       |
 | ~SPC f P~   | Open treemacs in the current project's root. With a prefix arg manually select the project instead.                                            |
 | ~SPC f B~   | Find and select a bookmark. If it cannot be found rebuild view with the bookmark's location as root. Also open the bookmark with a prefix arg. |

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -29,7 +29,6 @@
     :init
     (spacemacs/set-leader-keys
       "ft"    #'treemacs-toggle
-      "fT"    #'treemacs
       "fB"    #'treemacs-bookmark
       "f C-t" #'treemacs-find-file)
     :config
@@ -72,3 +71,7 @@
   (spacemacs|use-package-add-hook winum
     :post-config
     (add-to-list 'winum-assign-functions #'treemacs--window-number-ten)))
+
+(defun treemacs/post-init-winum ()
+  ;; window 0 is reserved for file trees
+  (spacemacs/set-leader-keys "0" #'treemacs))


### PR DESCRIPTION
Resolve #9313

Neotree is always on window 0. Let's override the winum-select-window-0-or-10
function with neo-tree-show since neo-tree-show always selects the neo-tree
buffer and will open neo-tree if necessary.