### PR TITLE
Make global-semantic-stickyfunc-mode configureable

### DIFF
--- a/layers/+emacs/semantic/config.el
+++ b/layers/+emacs/semantic/config.el
@@ -13,6 +13,9 @@
                                     "srecode-map.el"))
 (setq semanticdb-default-save-directory (concat spacemacs-cache-directory
                                                 "semanticdb/"))
+(defvar global-semantic-stickyfunc-mode-turned-on 't
+  "Toggles global-semantic-stickyfunc-mode. If value is non-nil then global-semantic-sticky-func-mode is turned on. (Default)")
+
 (setq semanticdb-find-default-throttle '(file local project))
 (unless (file-exists-p semanticdb-default-save-directory)
   (make-directory semanticdb-default-save-directory))

--- a/layers/+emacs/semantic/packages.el
+++ b/layers/+emacs/semantic/packages.el
@@ -21,8 +21,9 @@
     :defer t
     :config
     (progn
-      (add-to-list 'semantic-default-submodes
-                   'global-semantic-stickyfunc-mode)
+      (if (not (eq nil global-semantic-stickyfunc-mode-turned-on))
+          (add-to-list 'semantic-default-submodes
+                       'global-semantic-stickyfunc-mode))
       (add-to-list 'semantic-default-submodes
                    'global-semantic-idle-summary-mode))))
 


### PR DESCRIPTION
Hello!

I am using emacs's header line functionality for showing tabs (of buffers in project) and not for the semantic stickyfunc mode.

I want the global semantic sticky func to be configurable to show or to hide, because I want to use it for a different purpose (not for semtantic sticky func).

Thanks for any input.
Br, Daniel