### PR TITLE
Add dotnet cli layer

### DIFF
--- a/layers/+tools/dotnet/README.org
+++ b/layers/+tools/dotnet/README.org
@@ -1,0 +1,40 @@
+#+TITLE: Dotnet layer
+
+* Table of Contents                                         :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#packages-included][Packages Included]]
+- [[#install][Install]]
+- [[#key-bindings][Key Bindings]]
+
+* Description
+This layer adds support for the dotnet cli package.
+
+** Features:
+- dotnet operations
+
+* Packages Included
+- [[https://github.com/julienXX/dotnet.el][dotnet]]
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =dotnet= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key Bindings
+
+| Key Binding   | Description                                   |
+|---------------+-----------------------------------------------|
+| ~SPC m d a p~ | Add package to the current dotnet project     |
+| ~SPC m d a r~ | Add reference to the current dotnet project   |
+| ~SPC m d b~   | Build the current dotnet project              |
+| ~SPC m d c~   | Clean the current dotnet project              |
+| ~SPC m d n~   | Create a new dotnet project                   |
+| ~SPC m d p~   | Publish the current dotnet project            |
+| ~SPC m d r a~ | Run the current dotnet project with arguments |
+| ~SPC m d r r~ | Restore the current dotnet project            |
+| ~SPC m d s a~ | Add to the current dotnet solution            |
+| ~SPC m d s l~ | List the current dotnet solution              |
+| ~SPC m d s n~ | Create a new dotnet solution                  |
+| ~SPC m d s r~ | Remove from the current dotnet solution       |
+| ~SPC m d t~   | Run tests for the current dotnet project      |

--- a/layers/+tools/dotnet/packages.el
+++ b/layers/+tools/dotnet/packages.el
@@ -1,0 +1,33 @@
+;;; packages.el --- Dotnet Layer packages File for Spacemacs
+;;
+;; Author: Jordan Kaye <jordan.kaye2@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq dotnet-packages
+      '(
+        dotnet
+        ))
+
+(defun dotnet/init-dotnet ()
+  (use-package dotnet
+    :defer t
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
+      "dap" 'dotnet-add-package
+      "dar" 'dotnet-add-reference
+      "db" 'dotnet-build
+      "dc" 'dotnet-clean
+      "dn" 'dotnet-new
+      "dp" 'dotnet-publish
+      "dra" 'dotnet-run-with-args
+      "drr" 'dotnet-run
+      "drs" 'dotnet-restore
+      "dsa" 'dotnet-sln-add
+      "dsl" 'dotnet-sln-list
+      "dsn" 'dotnet-sln-new
+      "dsr" 'dotnet-sln-remove
+      "dt" 'dotnet-test)))


### PR DESCRIPTION
Added a layer to support the `dotnet` cli tool. This should allow users of the fsharp and csharp layers to more easily leverage .NET Core tooling.