### PR TITLE
Add keybinding for Rust cargo check

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -41,6 +41,7 @@
         "cf" 'cargo-process-fmt
         "ci" 'cargo-process-init
         "cl" 'cargo-process-clippy
+        "ck" 'cargo-process-check
         "cn" 'cargo-process-new
         "co" 'cargo-process-current-file-tests
         "cs" 'cargo-process-search


### PR DESCRIPTION
Cargo check is a faster alternative to compiling when
developing Rust code that checks syntax and types without
producing a binary. This commit adds a keybinding for Cargo check.
