### PR TITLE
Fix documentation for speed-reading, restclient and pandoc layer

### DIFF
--- a/layers/+tools/pandoc/README.org
+++ b/layers/+tools/pandoc/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#pandoc][Pandoc]]
@@ -15,7 +16,9 @@ Pandoc is a universal document converter. It makes it easy to e.g. convert a
 Markdown file to org mode or vice versa. It can also export your text to PDF or
 DOCX.
 
-This layer automatically install an org exporter using the [[https://github.com/kawabata/ox-pandoc][ox-pandoc]].
+** Features:
+- Mode independent document conversions via =global pandoc menu=
+- =Org-export= integration via [[https://github.com/kawabata/ox-pandoc][ox-pandoc]]
 
 * Install
 ** Layer

--- a/layers/+tools/restclient/README.org
+++ b/layers/+tools/restclient/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
 - [[#restclient][Restclient]]
@@ -9,8 +10,11 @@
 - [[#ob-http][ob-http]]
 
 * Description
-This layer lets you have a REPL-like interface for http requests using a
-[[https://github.com/pashky/restclient.el][restclient]] buffer or an =org= buffer.
+This layer provides a REPL-like interface for http requests.
+
+** Features:
+- REPL for http requests via [[https://github.com/pashky/restclient.el][restclient]]
+- Alternative =org= integration via [[http://github.com/zweifisch/ob-http][ob-http]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/speed-reading/README.org
+++ b/layers/+tools/speed-reading/README.org
@@ -2,11 +2,15 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
 A speed reading mode for Emacs.
+
+** Features:
+- Support for =speed-reading= of arbitrary texts
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
Fixed missing features block for speed-reading, restclient and pandoc layer.
This is part of #9476.