### PR TITLE
Add shortcut for the `cargo check` command #9943

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -33,7 +33,8 @@
         "c." 'cargo-process-repeat
         "cC" 'cargo-process-clean
         "cX" 'cargo-process-run-example
-        "cc" 'cargo-process-build
+        "cc" 'cargo-process-check
+        "cb" 'cargo-process-build
         "cd" 'cargo-process-doc
         "cD" 'cargo-process-doc-open
         "ce" 'cargo-process-bench


### PR DESCRIPTION
1. Adds a shortcut for the `cargo check` command as "cc".
2. Remaps a shortcut for `cargo build` command from "cc" to "cb".

Fixes #9943 