### PR TITLE
Support importmagic in the Python layer

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -46,6 +46,7 @@ This layer adds support for the Python language.
 - Suppression of unused import with [[https://github.com/myint/autoflake][autoflake]]
 - Use the ~%~ key to jump between blocks with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 - Sort imports with [[https://pypi.python.org/pypi/isort][isort]]
+- Fix a missing import statement with [[https://github.com/anachronic/importmagic.el][importmagic]]
 
 * Install
 ** Layer
@@ -249,6 +250,7 @@ function with a prefix argument, for example ~SPC u SPC m t a~.
 |-------------+--------------------------------------|
 | ~SPC m r i~ | remove unused imports with [[https://github.com/myint/autoflake][autoflake]] |
 | ~SPC m r I~ | sort imports with [[https://pypi.python.org/pypi/isort][isort]]              |
+| ~SPC m r f~ | fix a missing import statement with [[https://pypi.python.org/pypi/importmagic][importmagic]] |
 
 ** Live coding
 Live coding is provided by the [[https://github.com/donkirkby/live-py-plugin][live-py-plugin.]]

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -246,10 +246,10 @@ function with a prefix argument, for example ~SPC u SPC m t a~.
 
 ** Refactoring
 
-| Key Binding | Description                          |
-|-------------+--------------------------------------|
-| ~SPC m r i~ | remove unused imports with [[https://github.com/myint/autoflake][autoflake]] |
-| ~SPC m r I~ | sort imports with [[https://pypi.python.org/pypi/isort][isort]]              |
+| Key Binding | Description                                     |
+|-------------+-------------------------------------------------|
+| ~SPC m r i~ | remove unused imports with [[https://github.com/myint/autoflake][autoflake]]            |
+| ~SPC m r I~ | sort imports with [[https://pypi.python.org/pypi/isort][isort]]                         |
 | ~SPC m r f~ | fix a missing import statement with [[https://pypi.python.org/pypi/importmagic][importmagic]] |
 
 ** Live coding

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -368,7 +368,6 @@ fix this issue."
 
 (defun python/init-importmagic ()
   (use-package importmagic
-    :ensure t
     :init
     (progn
       (add-hook 'python-mode-hook 'importmagic-mode)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -38,6 +38,7 @@
     stickyfunc-enhance
     xcscope
     yapfify
+    importmagic
     ))
 
 (defun python/init-anaconda-mode ()
@@ -364,3 +365,12 @@ fix this issue."
       (when python-enable-yapf-format-on-save
         (add-hook 'python-mode-hook 'yapf-mode)))
     :config (spacemacs|hide-lighter yapf-mode)))
+
+(defun python/init-importmagic ()
+  (use-package importmagic
+    :ensure t
+    :init
+    (progn
+      (add-hook 'python-mode-hook 'importmagic-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'python-mode
+        "rf" 'importmagic-fix-symbol-at-point))))


### PR DESCRIPTION
Problem
-------
If the symbol is not resolved due to a missing import there is no automatic way
in the Python layer to import it.

Solution
--------
Use 'importmagic' package.

Pressing `SPC m r f` at point that requires an import will suggest a list of
possible options.