### PR TITLE
layers/+os/nixos: disable electric-indent-mode

### DIFF
--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -1,4 +1,4 @@
-(setq nixos-packages
+(defconst nixos-packages
       '(
         company
         (company-nixos-options :toggle
@@ -27,8 +27,12 @@
       "h>" 'helm-nixos-options)))
 
 (defun nixos/init-nix-mode ()
-  (use-package nix-mode)
-  (add-to-list 'spacemacs-indent-sensitive-modes 'nix-mode))
+  (use-package nix-mode
+    :defer t
+    :init
+    (add-to-list 'spacemacs-indent-sensitive-modes 'nix-mode)
+    :config
+    (electric-indent-mode -1)))
 
 (defun nixos/init-nixos-options ()
   (use-package nixos-options))


### PR DESCRIPTION
See commit message. Tested manually.

cc @CestDiego 