### PR TITLE
Fix documentation for selectric, imenu-list and vimscript layers

### DIFF
--- a/layers/+fun/selectric/README.org
+++ b/layers/+fun/selectric/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
 - [[#notes][Notes]]
@@ -12,6 +13,11 @@
 This layer makes your Emacs sound like an IBM Selectric typewriter, for those
 moments when your loud, clicky mechanical keyboard is not at hand, yet, you'd
 still wish to enjoy the sound.
+
+** Features:
+- Brings back fond memories about your first programming job where you started
+  with that big mechanical keyboard and the small monochrom display working on
+  the latest IBM Iseries server.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/vimscript/README.org
+++ b/layers/+lang/vimscript/README.org
@@ -2,11 +2,14 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
-This layer adds syntax highlighting support for vim filetypes, in addition to
-the pentadactyl firefox extension.
+This layer adds basic support for vimscript and pentadactyl config files.
+
+** Features:
+- Syntax highlighting
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/imenu-list/README.org
+++ b/layers/+tools/imenu-list/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#screenshot][Screenshot]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
@@ -13,6 +14,9 @@ This layer uses [[https://github.com/bmag/imenu-list][imenu-list]] to show the c
 
 This is similar to `SPC j i` but displayed in a persistent sidebar instead of
 a completion buffer.
+
+** Features:
+- IDE like outline view of current buffer showing all significant symbols in one view
 
 * Screenshot
 [[file:img/imenu-list-example.png]]


### PR DESCRIPTION
Fixed the documentation for selectric, imenu-list and vimscript layers.
This is part of #9476.