### PR TITLE
Added clojure-cheatsheet to clojure documentation.

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -127,13 +127,14 @@ As this state works the same for all files, the documentation is in global
 ** Leader
 *** Documentation
 
-| Key Binding | Description     |
-|-------------+-----------------|
-| ~SPC m h a~ | cider apropos   |
-| ~SPC m h g~ | cider grimoire  |
-| ~SPC m h h~ | cider doc       |
-| ~SPC m h j~ | cider javadoc   |
-| ~SPC m h n~ | cider browse ns |
+| Key Binding | Description        |
+|-------------+--------------------|
+| ~SPC m h a~ | cider apropos      |
+| ~SPC m h c~ | clojure cheatsheet |
+| ~SPC m h g~ | cider grimoire     |
+| ~SPC m h h~ | cider doc          |
+| ~SPC m h j~ | cider javadoc      |
+| ~SPC m h n~ | cider browse ns    |
 
 *** Evaluation
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -25,7 +25,8 @@
         popwin
         sayid
         smartparens
-        subword))
+        subword
+        clojure-cheatsheet))
 
 
 (defun clojure/init-cider ()
@@ -75,6 +76,7 @@
             "hg" 'cider-grimoire
             "hj" 'cider-javadoc
             "hn" 'cider-browse-ns
+            "hc" 'clojure-cheatsheet
 
             "e;" 'cider-eval-defun-to-comment
             "eb" 'cider-eval-buffer
@@ -388,3 +390,23 @@
                clojurescript-mode-hook
                clojurex-mode-hook))
     (add-hook m 'parinfer-mode)))
+
+(defun clojure/init-clojure-cheatsheet ()
+  (use-package clojure-cheatsheet
+    :defer t
+    :init
+    (progn
+      (setq sayid--key-binding-prefixes
+            '(("mhc" . "clojure-cheatsheet")))
+      (dolist (m '(clojure-mode
+                   clojurec-mode
+                   clojurescript-mode
+                   clojurex-mode
+                   cider-repl-mode
+                   cider-clojure-interaction-mode))
+        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                            m (car x) (cdr x)))
+              sayid--key-binding-prefixes)
+        (spacemacs/set-leader-keys-for-major-mode m
+          "hc" 'clojure-cheatsheet)))))
+ 


### PR DESCRIPTION
I added clojure-cheatsheet (https://github.com/clojure-emacs/clojure-cheatsheet) to clojure documentation.

In a clojure file, select , h c to see the cheatsheet/