### PR TITLE
Update renamed helm split window variable

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -21,7 +21,7 @@
   (setq helm-prevent-escaping-from-minibuffer t
         helm-bookmark-show-location t
         helm-display-header-line nil
-        helm-split-window-in-side-p t
+        helm-split-window-inside-p t
         helm-always-two-windows t
         helm-echo-input-in-header-line t
         helm-imenu-execute-action-at-once-if-one nil


### PR DESCRIPTION
The `helm-split-window-in-side-p` variable has been renamed to:
`helm-split-window-inside-p` here: https://github.com/emacs-helm/helm/commit/8b5df59a14496ab1d407989230231004b3c6c044

This caused the following variable `helm-always-two-windows` to become enabled.

---
This PR fixes the issue where opening a helm buffer hides all but one window, and restores the previous windows when helm is closed. But there's another possible change that could be made:

The doc-string for the `helm-always-two-windows` variable, states that:
>Note: this has no effect when ‘helm-split-window-inside-p’ is non-‘nil’,
or when ‘helm-split-window-default-side’ is set to ’same.

Since `helm-split-window-inside-p` is set to `t` here:
https://github.com/syl20bnr/spacemacs/blob/36c15b79f6d490a4733cfca3278c0c837fdc2cff/layers/%2Bspacemacs/spacemacs-completion/packages.el#L24-L25

Should the following `helm-always-two-windows` variable be removed?
