### PR TITLE
ivy: spacemacs-help: Fix candidate layers with no packages

### DIFF
--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -230,7 +230,7 @@
                           layer
                           (propertize "no packages"
                                       'face 'warning))
-                  layer
+                  (symbol-name layer)
                   nil)
             result))
     (sort result (lambda (a b) (string< (car a) (car b))))))


### PR DESCRIPTION
When a layer doesn't have a package, its name was added to the candidate list
as a symbol instead of a string, breaking actions such as
layer-action-open-packages which expect a string.

Spacemacs is great, keep up the good work :)

Edit: Just noticed the pull request number! Do I get eternal glory now? :P

Edit2:
Steps to reproduce:
1. Start with a clean Spacemacs on develop branch and no .spacemacs.d
2. Upon first start choose `spacemacs-base` for the distribution and `vim` for editing style
3. Open the generated config (`SPC f e d`) and replace `helm` layer with `ivy`
4. Restart Spacemacs to load Ivy
5. Invoke `ivy-spacemacs-help` with `SPC h SPC` and search for `vingar no packages` (Or any other layer that doesn't own any packages)
6. With Ivy still open and vinegar selected, use `M-o p` to open Vinegar's `packages.el`. You will get `Wrong type argument: stringp, vinegar`.