### PR TITLE
Fix documentation for sphinx, confluence, helm and ivy layer

### DIFF
--- a/layers/+completion/helm/README.org
+++ b/layers/+completion/helm/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#alternative-layers][Alternative layers]]
 - [[#configuration][Configuration]]
@@ -32,6 +33,14 @@ used to manage buffers, projects, search results, configuration layers, toggles
 and more...
 
 Mastering your choice of completion system will make you a Spacemacs power user.
+
+** Features:
+- Project wide =grep= like text search via =helm-dir-smart-do-search=
+- Project wide text replacements using =helm-edit-mode=
+- Buffer wide dynamic text search via =helm-swoop=
+- Fuzzy matching for most =helm-sources=
+- Detailed configuration parameters for helms appearance
+- Intuitive =transient state=
 
 * Install
 Helm is part of the standard distribution of Spacemacs so you don't have to do

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
 - [[#key-bindings][Key Bindings]]
@@ -16,6 +17,13 @@ used to manage buffers, projects, search results, configuration layers, toggles
 and more...
 
 Mastering your choice of completion system will make you a Spacemacs power user.
+
+** Features:
+- Project wide =grep= like text search via =search-auto=
+- Project wide text replacements using =counsel-imenu=
+- Buffer wide dynamic text search via =swiper=
+- Detailed configuration parameters for ivy appearance
+- Intuitive =transient state=
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/sphinx/README.org
+++ b/layers/+tools/sphinx/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#sphinx-target][Sphinx target]]
@@ -11,8 +12,13 @@
 - [[#key-bindings][Key bindings]]
 
 * Description
-The layer adds =Sphinx= support to Spacemacs. It will automatically also install
+The layer adds support for the documentation generation system =Sphinx= to
 the =restructuredtext= layer.
+
+** Features:
+- Support for =Sphinx= project compilation
+- Support for opening =Sphinx= project target
+- Support for opening =Sphinx= config file
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+web-services/confluence/README.org
+++ b/layers/+web-services/confluence/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
 - [[#configuration][Configuration]]
@@ -13,8 +14,11 @@
   - [[#org][Org]]
 
 * Description
-This layer add support for Atlassian [[https://www.atlassian.com/software/confluence][Confluence]] to create/edit Confluence pages
-and export org buffers to Confluence =wiki= format.
+This layer adds support for Atlassian [[https://www.atlassian.com/software/confluence][Confluence]].
+
+** Features:
+- Creating/editing of Confluence pages
+- Exporting of org buffers to Confluence =wiki= format
 
 * Install
 ** Layer


### PR DESCRIPTION
Added the missing feature block to the sphinx, confluence, helm and ivy layer.
This is part of #9476.