### PR TITLE
major-modes: comment out removed wolfram-mode package

### DIFF
--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -14,7 +14,7 @@
         thrift
         vala-mode
         (vala-snippets :requires yasnippet)
-        wolfram-mode
+        ;; wolfram-mode ; commented out because package was removed from MELPA (https://github.com/syl20bnr/spacemacs/issues/9795)
         ))
 
 (defun major-modes/init-arduino-mode ())


### PR DESCRIPTION
Fixes the non-existant package error