### PR TITLE
[notmuch] interactive search with helm & ivy

### DIFF
--- a/layers/+email/notmuch/funcs.el
+++ b/layers/+email/notmuch/funcs.el
@@ -1,3 +1,7 @@
+(defun spacemacs/notmuch-interactive-search ()
+  (interactive)
+  (funcall spacemacs/notmuch-interactive-search-function))
+
 (defun spacemacs/notmuch-inbox-p (saved-search-property-item)
   (string-equal (plist-get saved-search-property-item :name) "inbox"))
 

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -9,7 +9,14 @@
 ;;
 ;;; License: GPLv3
 
-(setq notmuch-packages '(notmuch helm-notmuch))
+(setq notmuch-packages '(notmuch
+                         (helm-notmuch :toggle (configuration-layer/layer-usedp 'helm))
+                         (counsel-notmuch
+                          :toggle (configuration-layer/layer-usedp 'ivy)
+                          :location (recipe
+                                     :fetcher github
+                                     :repo "fuxialexander/counsel-notmuch")))
+      )
 
 (defun notmuch/init-notmuch ()
   (use-package notmuch
@@ -22,7 +29,8 @@
       (spacemacs/set-leader-keys "aNi" 'spacemacs/notmuch-inbox)
       (spacemacs/set-leader-keys "aNj" 'notmuch-jump-search)
       (spacemacs/set-leader-keys "aNs" 'notmuch-search)
-      (spacemacs/set-leader-keys "aNn" 'helm-notmuch)
+      (spacemacs/set-leader-keys "aNn" 'spacemacs/notmuch-interactive-search
+        )
       (load-library "org-notmuch"))
     :config
     (progn
@@ -125,4 +133,15 @@
 (defun notmuch/init-helm-notmuch ()
   (use-package helm-notmuch
     :defer t
-    :init (with-eval-after-load 'notmuch)))
+    :init (progn
+            (setq spacemacs/notmuch-interactive-search-function
+                  'helm-notmuch)
+            (with-eval-after-load 'notmuch))))
+
+(defun notmuch/init-counsel-notmuch ()
+  (use-package counsel-notmuch
+    :defer t
+    :init (progn
+            (setq spacemacs/notmuch-interactive-search-function
+                  'counsel-notmuch)
+            (with-eval-after-load 'notmuch))))


### PR DESCRIPTION
## Context
Problem: Notmuch layer assumes one is ussing the `helm` package


### Description
This pull request adds support for ivy/helm for notmuch interactive search.
Closes https://github.com/syl20bnr/spacemacs/issues/10012

## Todos
- [x] Installs `helm-notmuch` only if `helm` layer is available
- [x] Installs `counsel-notmuch` only if `ivy` layer is available
- [x] Uses available search function for ` SPC a N n`
