### PR TITLE
Fix doc for cscope, geolocation, wakatime, prodigy and smex layer

### DIFF
--- a/layers/+emacs/smex/README.org
+++ b/layers/+emacs/smex/README.org
@@ -4,13 +4,15 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer replaces =helm-M-x= by [[https://github.com/nonsequitur/smex][smex]] which is built on top of =ido=.
-=ido= can perform flex matching with the [[https://github.com/lewang/flx][flx-ido]] mode which is already
-activated in the Spacemacs layer.
+This layer provides a more traditional alternative to =helm-M-x= based on =ido=.
+
+** Features:
+- Provides an alternative way for =helm-M-x= based on =ido= and [[https://github.com/nonsequitur/smex][smex]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -21,5 +23,5 @@ file.
 
 | Key Binding | Description                                |
 |-------------+--------------------------------------------|
-| ~SPC :~     | all Emacs commands (interactive functions) |
+| ~SPC SPC~   | all Emacs commands (interactive functions) |
 | ~SPC m :~   | current major mode commands                |

--- a/layers/+tags/cscope/README.org
+++ b/layers/+tags/cscope/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#cscope][Cscope]]
@@ -14,9 +15,11 @@
 * Description
 This layer provides bindings for using [[http://cscope.sourceforge.net][Cscope]] and [[https://github.com/portante/pycscope][PyCscope]] in Spacemacs.
 
-=Cscope= provides indexing and searching capabilities for C and C++ code.
-=PyCscope= extends these capabilities for Python code as well. See
-[[https://github.com/OpenGrok/OpenGrok/wiki/Comparison-with-Similar-Tools][here]] for a comparison between =Cscope= and other similar tools (such as gtags).
+See [[https://github.com/OpenGrok/OpenGrok/wiki/Comparison-with-Similar-Tools][here]] for a comparison between =Cscope= and other similar tools (such as gtags).
+
+** Features:
+- Tag indexing and searching for C-C++ via [[http://cscope.sourceforge.net][Cscope]]
+- Tag indexing and searching for python via [[https://github.com/portante/pycscope][PyCscope]]
 
 * Install
 ** Layer

--- a/layers/+tools/geolocation/README.org
+++ b/layers/+tools/geolocation/README.org
@@ -2,26 +2,25 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#supported-packages-in-this-layer][Supported packages in this layer]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#location][Location]]
-  - [[#osx-location][osx-location]]
-  - [[#theme-changer][theme-changer]]
-  - [[#sunshine-weather-forecast][sunshine (weather forecast)]]
+  - [[#osx-location][OSX-location]]
+  - [[#theme-changer][Theme-changer]]
+  - [[#sunshine-weather-forecast][Sunshine (weather forecast)]]
 - [[#key-bindings][Key Bindings]]
   - [[#weather][Weather]]
 
 * Description
-This layer offers few location sensitive adjustment to Emacs, such as
-automatically switching between light (day) and dark (night) themes, weather
-forecast and on OS X, also automatic tracking of location, using OS X's
-CoreLocation services.
+This layer offers location sensitive adjustments to Emacs.
 
-** Supported packages in this layer
-- [[https://github.com/aaronbieber/sunshine.el/blob/master/sunshine.el][sunshine]]
-- [[https://github.com/purcell/osx-location][osx-location]]
-- [[https://github.com/hadronzoo/theme-changer][theme-changer]]
+** Features:
+- Supports the following adjustments:
+  - Automatic switching between light (day) and dark (night) themes via [[https://github.com/hadronzoo/theme-changer][theme-changer]]
+  - Local weather forecast via [[https://github.com/aaronbieber/sunshine.el/blob/master/sunshine.el][sunshine]]
+  - Integration with OS X's CoreLocation service via [[https://github.com/purcell/osx-location][osx-location]]
+  - Manual location setting via variables in your dotfile
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -40,8 +39,7 @@ something like this:
 
 * Configuration
 ** Location
-Set location manually by setting the following variables to the
-=dotspacemacs/user-config= function of your dotfile:
+Set location manually by setting the following variables in your dotfile:
 
 #+BEGIN_SRC emacs-lisp
   (setq calendar-location-name "Barcelona, Spain"
@@ -49,7 +47,7 @@ Set location manually by setting the following variables to the
         calendar-longitude 1.80)
 #+END_SRC
 
-** osx-location
+** OSX-location
 Mac users can take adavantage of automatic geogrphical discovery using the OS'
 CoreLocation system service, implemented as a long running background process.
 In order to enable it, set =geolocation-enable-location-service= to =t= as
@@ -60,7 +58,7 @@ activated.
 
 [[file:img/emacs-location-helper.jpg]]
 
-** theme-changer
+** Theme-changer
 This layer implement a simple "theme changer" which, when enabled, will switch
 between first two themes the user has setup in ~dotspacemacs-themes~. First
 theme listed will be used as light variant, while the second as the the dark.
@@ -69,7 +67,7 @@ cycling, etc.
 
 Note that =theme-changer= *requires* location to be set.
 
-** sunshine (weather forecast)
+** Sunshine (weather forecast)
 Sunshine display local weather forecast.
 
 Setup [[https://home.openweathermap.org/users/sign_in][OpenWeatherMap]] API key. Set ~sunshine-appid~ to some hash string from the

--- a/layers/+tools/prodigy/README.org
+++ b/layers/+tools/prodigy/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
   - [[#spawn-prodigy][Spawn prodigy]]
@@ -15,6 +16,11 @@ within Emacs, check the package's documentation for more details.
 
 It is recommended to put your prodigy services in the =dotspacemacs/user-config=
 part of your =~/.spacemacs= file.
+
+** Features:
+- Managing of pre-declared services from within emacs
+- Showing of process output in special buffers
+- Filtering of processes for tags or names
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+web-services/wakatime/README.org
+++ b/layers/+web-services/wakatime/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#wakatime-program][Wakatime Program]]
   - [[#layer][Layer]]
@@ -19,6 +20,9 @@ timer? WakaTime uses open-source text editor plugins to automatically track the
 time you spend programming so you never have to manually track it again!
 
 P.S. wakati means time in Swahili
+
+** Features:
+- Integration with Wakatime cloud based time tracking service
 
 * Install
 ** Wakatime Program


### PR DESCRIPTION
Added the missing "Features:" block to the above mentioned layers. 
This is part of #9476.