### PR TITLE
Add defvar python-save-before-test

### DIFF
--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -20,6 +20,9 @@
 (defvar python-test-runner 'nose
   "Test runner to use. Possible values are `nose' or `pytest'.")
 
+(defvar python-save-before-test t
+  "If non nil, current buffer will be save before call a test function")
+
 (defvar python-fill-column 79
   "Fill column value for python buffers")
 

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -165,6 +165,8 @@ when this mode is enabled since the minibuffer is cleared all the time."
 ARG is the universal-argument which chooses between the main and
 the secondary test runner. FUNCALIST is an alist of the function
 to be called for each testrunner. "
+  (when python-save-before-test
+      (save-buffer))
   (let* ((test-runner (if arg
                           (spacemacs//python-get-secondary-testrunner)
                         (spacemacs//python-get-main-testrunner)))


### PR DESCRIPTION
If true, buffer is automatically saved when calling
python-test-* functions
