### PR TITLE
Update README.org with correct settings for username and nickname.

### DIFF
--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -60,7 +60,8 @@ is convenient but not recommended.
 #+BEGIN_SRC emacs-lisp
 (setq rcirc-server-alist
   '(("irc.freenode.net"
-      :user "spacemacs_user"
+      :user-name "spacemacs_user"
+      :nick "spacemacs_nickname"
       :port "1337"
       :password "le_passwd"
       :channels ("#emacs"))))


### PR DESCRIPTION
Looking into [documentation](https://www.gnu.org/software/emacs/manual/html_node/rcirc/Configuration.html), `nick` has to be set instead of `user`, otherwise once connected to server (Freenode, in my case), my local login username is used instead.