### PR TITLE
Add keybinding to align by percent

### DIFF
--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -893,6 +893,7 @@ the right."
 (spacemacs|create-align-repeat-x "colon" ":" nil t)
 (spacemacs|create-align-repeat-x "equal" "=")
 (spacemacs|create-align-repeat-x "math-oper" "[+\\-*/]")
+(spacemacs|create-align-repeat-x "percent" "%")
 (spacemacs|create-align-repeat-x "ampersand" "&")
 (spacemacs|create-align-repeat-x "bar" "|")
 (spacemacs|create-align-repeat-x "left-paren" "(")

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -447,6 +447,7 @@
 (defalias 'count-region 'count-words-region)
 
 (spacemacs/set-leader-keys
+  "xa%" 'spacemacs/align-repeat-percent
   "xa&" 'spacemacs/align-repeat-ampersand
   "xa(" 'spacemacs/align-repeat-left-paren
   "xa)" 'spacemacs/align-repeat-right-paren


### PR DESCRIPTION
Add keybinding to align by %. I use this mostly to prettify scala-sbt source files.