### PR TITLE
fix cut-and-paste error by using correct google hook function name

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -173,7 +173,7 @@
     :if (or 'c-c++-enable-google-style 'c-c++-enable-google-newline)
     :config (progn
     (when 'c-c++-enable-google-style (add-hook 'c-mode-common-hook 'google-set-c-style))
-    (when 'c-c++-enable-google-newline (add-hook 'c-mode-common-hook 'google-set-c-style)))))
+    (when 'c-c++-enable-google-newline (add-hook 'c-mode-common-hook 'google-make-newline-indent)))))
 
 (defun c-c++/post-init-semantic ()
   (spacemacs/add-to-hooks 'semantic-mode c-c++-mode-hooks))


### PR DESCRIPTION
Use google-make-newline-indent rather than google-set-c-style.
