### PR TITLE
Remove mapping <c-f> to select the frist completion.

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -284,8 +284,7 @@ MODE parameter must match the :modes values used in the call to
    (t
     (let ((map company-active-map))
       (define-key map (kbd "C-n") 'company-select-next)
-      (define-key map (kbd "C-p") 'company-select-previous)
-      (define-key map (kbd "C-f") 'company-complete-selection)))))
+      (define-key map (kbd "C-p") 'company-select-previous)))))
 
 
 ;; Transformers


### PR DESCRIPTION
This ruined my life. Most of the time, I just want to move beyond the `)`.