### PR TITLE
fix python/:init: Invalid version syntax: '5.1.0^M' bug

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -42,7 +42,7 @@
 (defun spacemacs//python-setup-shell (&rest args)
   (if (spacemacs/pyenv-executable-find "ipython")
       (progn (setq python-shell-interpreter "ipython")
-             (if (version< (replace-regexp-in-string "\n$" "" (shell-command-to-string "ipython --version")) "5")
+             (if (version< (replace-regexp-in-string "[\r\n|\n]$" "" (shell-command-to-string "ipython --version")) "5")
                  (setq python-shell-interpreter-args "-i")
                (setq python-shell-interpreter-args "--simple-prompt -i")))
     (progn


### PR DESCRIPTION
fix python/:init: Invalid version syntax: '5.1.0^M' bug, for "ipython --version" will return '5.1.0\r\n' on windows with Anaconda3