### PR TITLE
Add better helm default multi action for files/buffers

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -187,6 +187,41 @@ Ensure that helm is required before calling FUNC."
     ((eq major-mode 'org-mode) 'helm-org-in-buffer-headings)
     (t 'helm-semantic-or-imenu))))
 
+(defun spacemacs//helm-open-buffers-in-windows (buffers)
+  "This function allows a different default action, on marking multiple
+candidate buffers/files for helm. By default, helm either opens all
+files/buffers in the same window, or creates splits. This function instead
+opens the buffers (or files) across different already-open windows. The first
+selected buffer is opened in the current window, the next is opened in the
+window with higher number, etc. This will make a loop around, so with 4
+windows, and window 2 active, opening 4 buffers will open them in windows
+2 3 4 1. If more buffers are opened than windows available, the remainder are
+not set to any window (but in the case of files, they are still opened
+to buffers)."
+(let ((num-buffers (length buffers))
+        (num-windows (length (winum--window-list)))
+        (cur-win (winum-get-number))
+        (num-buffers-placed 0))
+    (cl-loop for buffer in buffers do
+             (when (>= num-buffers-placed num-windows) cl-return)
+             (set-window-buffer (winum-get-window-by-number cur-win) buffer)
+             (setq cur-win (+ 1 (mod cur-win num-windows)))
+             (incf num-buffers-placed))))
+
+(defun spacemacs/helm-find-buffers-windows ()
+  (interactive)
+  (helm-exit-and-execute-action
+   (lambda (candidate)
+     (spacemacs//helm-open-buffers-in-windows (helm-marked-candidates)))))
+
+(defun spacemacs/helm-find-files-windows ()
+  (interactive)
+  (helm-exit-and-execute-action
+   (lambda (candidate)
+     (let* ((files (helm-marked-candidates))
+            (buffers (mapcar 'find-file-noselect files)))
+       (spacemacs//helm-open-buffers-in-windows buffers)))))
+
 
 ;; Generalized next-error interface
 

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -139,7 +139,10 @@
       (with-eval-after-load 'helm-bookmark
         (simpler-helm-bookmark-keybindings))
       (with-eval-after-load 'helm-mode ; required
-        (spacemacs|hide-lighter helm-mode)))))
+        (spacemacs|hide-lighter helm-mode))
+      (define-key helm-buffer-map (kbd "RET") 'spacemacs/helm-find-buffers-windows)
+      (define-key helm-generic-files-map (kbd "RET") 'spacemacs/helm-find-files-windows)
+      (define-key helm-find-files-map (kbd "RET") 'spacemacs/helm-find-files-windows))))
 
 (defun helm/init-helm-ag ()
   (use-package helm-ag
@@ -638,7 +641,9 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
             "ph"  'helm-projectile
             "pp"  'helm-projectile-switch-project
             "pr"  'helm-projectile-recentf
-            "sgp" 'helm-projectile-grep))))))
+            "sgp" 'helm-projectile-grep))))
+    :config
+    (define-key helm-projectile-find-file-map (kbd "RET") 'spacemacs/helm-find-files-windows)))
 
 (defun helm/init-helm-spacemacs-help ()
   (use-package helm-spacemacs-help
@@ -718,4 +723,3 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
 
 (defun helm/post-init-projectile ()
   (setq projectile-completion-system 'helm))
-


### PR DESCRIPTION
As discussed in #9858 . Without this change, when you open `SPC b b`, selecting several buffers (with C-SPC) and hitting Enter would either case buffers to be opened in splits (which rarely looked good), or in some cases might simply try to assign all the buffers to the same window, effectively hiding all but one.

With this change, doing this will cause the following to happen:

1. The first selected buffer will go into the current active window.
2. The second buffer will go into the "next" window, in the spacemacs numbering.
3.  This continues in a modular fashion. So with 4 windows open and 2 active, opening 4 buffers causes 
 the first selected buffer to be placed in window 2, 3, 4, and 1 (note: the order depends on the order in which C-SPC was hit on them, nothing else).
4. If there are N windows open, only the first N buffers get assigned to windows. In the case of files, all the files get opened as buffers, but only the first N get assigned to windows still.

IMHO, this is much more useful default behavior, and actually lets you e.g. use `SPC b b` to rearrange all of your buffers in one go, let's you quickly and efficiently open a source file along with its test file, etc.

This probably needs further testing; I've tried to make sure it behaves correctly with treemacs. It works in `SPC b b` (both buffers and recent files), `SPC p f`, `SPC f f`, and probably more.

If helm were to be opened in a window instead of the mini-buffer (I seem to recall helm supports this), it would probably break; not sure if spacemacs supports that.