### PR TITLE
autocomplete: Make idle-delay configurable

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#key-bindings][Key bindings]]
@@ -30,6 +31,11 @@ The following completion engines are supported:
 Snippets are supported via [[https://github.com/capitaomorte/yasnippet][yasnippet]] and [[https://github.com/abo-abo/auto-yasnippet][auto-yasnippet]].
 
 This layer also configures =hippie-expand=.
+
+** Features:
+- Completion with =company= or =auto-complete=
+- Frequency-based suggestions via =company-statistics=
+- Integration with =yasnippets=
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -61,6 +67,9 @@ layer variables:
    to wait for the auto-completion key sequence to be entered. The default value
    is 0.1 seconds.
 
+5. =auto-completion-idle-delay= is the number of seconds to wait before
+   suggesting completions. The default value is 0.2 seconds.
+
 The default configuration of the layer is:
 
 #+BEGIN_SRC emacs-lisp
@@ -70,6 +79,7 @@ The default configuration of the layer is:
                    auto-completion-tab-key-behavior 'cycle
                    auto-completion-complete-with-key-sequence nil
                    auto-completion-complete-with-key-sequence-delay 0.1
+                   auto-completion-idle-delay 0.2
                    auto-completion-private-snippets-directory nil)
                    ))
 #+END_SRC

--- a/layers/+completion/auto-completion/config.el
+++ b/layers/+completion/auto-completion/config.el
@@ -38,6 +38,9 @@ selection.")
   "Timeout (seconds) when waiting for the second key of
 `auto-completion-complete-with-key-sequence'.")
 
+(defvar auto-completion-idle-delay 0.2
+  "Delay (seconds) before completions are shown.")
+
 (defvar auto-completion-enable-snippets-in-popup nil
   "If non nil show snippets in the auto-completion popup.")
 

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -43,7 +43,7 @@
     :defer t
     :init
     (setq ac-auto-start 0
-          ac-delay 0.2
+          ac-delay auto-completion-idle-delay
           ac-quick-help-delay 1.
           ac-use-fuzzy t
           ac-fuzzy-enable t
@@ -70,7 +70,7 @@
     :defer t
     :init
     (progn
-      (setq company-idle-delay 0.2
+      (setq company-idle-delay auto-completion-idle-delay
             company-minimum-prefix-length 2
             company-require-match nil
             company-dabbrev-ignore-case nil


### PR DESCRIPTION
Adds an `autocomplete-idle-delay` layer variable that gets passed to `company-idle-delay`
or `ac-delay`.

@Valloric's YouCompleteMe vim plugin inspires a run 'n gun style of heavy autocompletion use by streamlining the user interface enough that users can happily mash TAB for just about every word they type.  @nikital has recently added a "Company Tab and Go" mode (https://github.com/company-mode/company-mode/pull/706) that mimics this fantastic behavior, but to get the most out of it requires a fairly low idle delay (otherwise it's often faster to type 3-5 more characters instead of waiting 200ms for a completion that might not be there).  Conversely, users on slow computers may wish to increase the delay.

I spent a while messing with `auto-completion-complete-with-key-sequence-delay` before realizing that `company-idle-delay` is was what I was looking for, so I figured I'd send a PR and update docs to steer others in the right direction.