### PR TITLE
c-c++: Fix clang format on save

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -36,7 +36,7 @@
   "Format the current buffer with clang-format on save when
 `c-c++-enable-clang-format-on-save' is non-nil."
   (when c-c++-enable-clang-format-on-save
-    (spacemacs/clang-format-buffer)))
+    (clang-format-buffer)))
 
 (defun spacemacs/clang-format-on-save ()
   "Add before-save hook for clang-format."


### PR DESCRIPTION
Resolve #10041

The spacemacs/clang-format-buffer function doesn't exist. It should be replaced
with clang-format-buffer. This error was introduced in 01ddc98cef203f1bc671fa7fe7fed0496e737041.
