### PR TITLE
Add switch-to-help-buffer function and keybinding

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2144,6 +2144,7 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC b C-D~     | kill buffers using a regular expression                                  |
 | ~SPC b e~       | erase the content of the buffer (ask for confirmation)                   |
 | ~SPC b h~       | open =*spacemacs*= home buffer                                           |
+| ~SPC b H~       | open or select the =*Help*= buffer                                       |
 | ~SPC b n~       | switch to next buffer avoiding special buffers                           |
 | ~SPC b m~       | open =*Messages*= buffer                                                 |
 | ~SPC u SPC b m~ | kill all buffers and windows except the current one                      |

--- a/layers/+distributions/spacemacs-base/funcs.el
+++ b/layers/+distributions/spacemacs-base/funcs.el
@@ -1144,6 +1144,13 @@ a split-side entry, its value must be usable as the SIDE argument for
   (let ((buffer (find-file-noselect file)))
     (pop-to-buffer buffer '(spacemacs//display-in-split (split-side . below)))))
 
+(defun spacemacs/switch-to-help-buffer ()
+  "Open or select the `*Help*' buffer, if it exists."
+  (interactive)
+  (if (get-buffer "*Help*")
+      (switch-to-buffer (help-buffer))
+    (message "No previous Help buffer found")))
+
 (defun spacemacs/switch-to-scratch-buffer (&optional arg)
   "Switch to the `*scratch*' buffer, creating it first if needed.
 if prefix argument ARG is given, switch to it in an other, possibly new window."

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -127,6 +127,7 @@
   "bd"    'spacemacs/kill-this-buffer
   "be"    'spacemacs/safe-erase-buffer
   "bh"    'spacemacs/home
+  "bH"    'spacemacs/switch-to-help-buffer
   "b C-d" 'spacemacs/kill-other-buffers
   "b C-S-d" 'spacemacs/kill-matching-buffers-rudely
   "bn"    'next-buffer


### PR DESCRIPTION
`SPC b H` is available, for opening or selecting the help buffer (if it
exists). This makes it much easier to open the help buffer, than having
to open the buffer list (`SPC b b`), then typing one or more characters,
to select the help buffer, and finally pressing `RET`.