### PR TITLE
Replace counsel--git-dir with (ivy-state-directory ivy-last)

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -72,7 +72,7 @@
         "Grep in the current directory for STRING."
         (if (< (length string) 3)
             (counsel-more-chars 3)
-          (let* ((default-directory counsel--git-dir)
+          (let* ((default-directory (ivy-state-directory ivy-last))
                  (args (if (string-match-p " -- " string)
                            (let ((split (split-string string " -- ")))
                              (prog1 (pop split)
@@ -112,8 +112,7 @@
             (line-number-at-pos))
           spacemacs--gne-line-func
           (lambda (c)
-            (let ((counsel--git-dir default-directory))
-              (counsel-git-grep-action c)))
+            (counsel-git-grep-action c))
           next-error-function 'spacemacs/gne-next)))
 
 (defvar spacemacs--counsel-map
@@ -142,22 +141,21 @@ that directory."
                       (when (and (assoc-string tool spacemacs--counsel-commands)
                                  (executable-find tool))
                         (throw 'tool tool)))
-                    (throw 'tool "grep"))))
-      (setq counsel--git-dir
-            (or initial-directory
-                (read-directory-name "Start from directory: ")))
+                    (throw 'tool "grep")))
+            (default-directory
+              (or initial-directory (read-directory-name "Start from directory: "))))
       (ivy-read
        (concat ivy-count-format
                (format "%s from [%s]: "
                        tool
-                       (if (< (length counsel--git-dir)
+                       (if (< (length default-directory)
                               spacemacs--counsel-search-max-path-length)
-                           counsel--git-dir
+                           default-directory
                          (concat
-                          "..." (substring counsel--git-dir
-                                           (- (length counsel--git-dir)
+                          "..." (substring default-directory
+                                           (- (length default-directory)
                                               spacemacs--counsel-search-max-path-length)
-                                           (length counsel--git-dir))))))
+                                           (length default-directory))))))
        (spacemacs//make-counsel-search-function tool)
        :initial-input (rxt-quote-pcre initial-input)
        :dynamic-collection t
@@ -253,7 +251,7 @@ that directory."
 (defun spacemacs//counsel-occur ()
   "Generate a custom occur buffer for `counsel-git-grep'."
   (ivy-occur-grep-mode)
-  (setq default-directory counsel--git-dir)
+  (setq default-directory (ivy-state-directory ivy-last))
   (let ((cands ivy--old-cands))
     ;; Need precise number of header lines for `wgrep' to work.
     (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n"
@@ -294,7 +292,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
       (let ((file-name (match-string-no-properties 1 x))
             (line-number (match-string-no-properties 2 x)))
         (funcall func
-                 (expand-file-name file-name counsel--git-dir))
+                 (expand-file-name file-name (ivy-state-directory ivy-last)))
         (goto-char (point-min))
         (forward-line (1- (string-to-number line-number)))
         (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)


### PR DESCRIPTION
abo-abo/swiper@4f57b5a9 removed the counsel--git-dir variable.  Code
that used that variable is now expected to use (ivy-state-directory
ivy-last) instead.  Update the code to reflect this change.

Without this change you get the same behavior as #9552.  I did some basic testing and it seems to have fixed the problem for me with ag.  I'm less confident about the grep version.