### PR TITLE
Update hindent config in haskell layer

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -158,18 +158,13 @@ are warmly welcome!
 reformat your code. You need to install the executable with =cabal
 install hindent= or =stack install hindent=
 
-To enable it you have to set the variable =haskell-enable-hindent-style= to a
-supported style. The available styles are:
-- fundamental
-- johan-tibell
-- chris-done
-- gibiansky
+To enable it you have to toggle the variable =haskell-enable-hindent=.
 
 See examples [[https://github.com/commercialhaskell/hindent/blob/master/TESTS.md][here]].
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers
-  '((haskell :variables haskell-enable-hindent-style "johan-tibell")))
+  '((haskell :variables haskell-enable-hindent t)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -21,7 +21,5 @@
 Available options are `ghci', `intero', `dante', and `ghc-mod'. Default is
 `ghci'.")
 
-(defvar haskell-enable-hindent-style nil
-  "Style to use for formatting with hindent; available are:
-fundamental johan-tibell chris-done gibiansky.
-If nil hindent is disabled.")
+(defvar haskell-enable-hindent nil
+  "Formatting with hindent; If t hindent is enabled.")

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -266,18 +266,18 @@
 (defun haskell/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'haskell-mode))
 
+
 ;; doesn't support literate-haskell-mode :(
 (defun haskell/init-hindent ()
   (use-package hindent
     :defer t
-    :if (stringp haskell-enable-hindent-style)
+    :if haskell-enable-hindent
     :init
     (add-hook 'haskell-mode-hook #'hindent-mode)
     :config
     (progn
-      (setq hindent-style haskell-enable-hindent-style)
       (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
-        "f" 'hindent-reformat-decl))))
+        "f" 'hindent-reformat-decl-or-fill))))
 
 (defun haskell/init-hlint-refactor ()
   (use-package hlint-refactor


### PR DESCRIPTION
Hindent styling is a deprecated feature (with no more effect).
Use a simple bool toggle to activate it.