### PR TITLE
Fix the broken python repl invocation through SPC a '

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -262,7 +262,7 @@
     :defer t
     :init
     (progn
-      (spacemacs/register-repl 'python 'python-start-or-switch-repl "python")
+      (spacemacs/register-repl 'python 'spacemacs/python-start-or-switch-repl "python")
       (add-hook 'inferior-python-mode-hook
                 #'spacemacs//inferior-python-setup-hook)
       (add-hook 'python-mode-hook #'spacemacs//python-default)


### PR DESCRIPTION
SPC a ' <python> will end up with the following error without this change:
  'Wrong type argument: commandp, python-start-or-switch-repl'
