### PR TITLE
Add a default value for kbd-mac-command

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2066,6 +2066,10 @@ Other:
   - Added ~M-s-h~ to hide other windows (thanks to Bas Veeling)
 - Replace pbcopy by osx-clipboard (thanks to Minh Nguyen-Hue)
 - Fixed key binding issue when Emacs is launched in daemon mode.
+- Added a default value =H-= (hyper) for =kbd-mac-command= if it's neither:
+  =hyper=, =super= or =alt= (thanks to Binbin Ye)
+- Added a layer variable =osx-swap-option-and-command= defaults to =nil=
+  (thanks to Binbin Ye)
 **** Pandoc
 - Fixed =spacemacs/run-pandoc= not to reset =pandoc--local-settings=
   (thanks to martian-f)

--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -47,13 +47,15 @@ The different modifier keys can be set as follows:
                      osx-function-as      nil
                      osx-right-command-as 'left
                      osx-right-option-as  'left
-                     osx-right-control-as 'left))
+                     osx-right-control-as 'left
+                     osx-swap-option-and-command nil))
 #+END_SRC
 
 These are also the default values. Setting the right modifier to =left=
 will equal the left modifier. Allowed values are: =super=, =meta=, =control=,
 =alt= and =nil=.
 Setting =nil= for modifiers will leave the left modifiers as emacs default.
+Setting =osx-swap-option-and-command= to =t= will swap =command= and =option= key.
 
 *** Use with non-US keyboard layouts
 If you need the ~⌥~ key to type common characters such as ={[]}~= which is usual

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -60,6 +60,9 @@
 (defvar osx-use-dictionary-app t
   "If non nil use osx dictionary app instead of wordnet")
 
+(defvar osx-swap-option-and-command nil
+  "If non nil swap option key and command key")
+
 ;; Use the OS X Emoji font for Emoticons
 (when (fboundp 'set-fontset-font)
   (set-fontset-font "fontset-default"

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -45,6 +45,9 @@
              (when (member key-value allowed-values)
                (setf (symbol-value internal-var) key-value))))
 
+  (when osx-swap-option-and-command
+    (cl-rotatef mac-command-modifier mac-option-modifier))
+
   (defun kbd-mac-command (keys)
     "Wraps `kbd' function with Mac OSX compatible Command-key (⌘).
 KEYS should be a string such as \"f\" which will be turned into values
@@ -52,8 +55,8 @@ such as \"H-f\", \"s-f\", or \"A-f\" depending on the value of
 `mac-commmand-modifier' which could be `hyper', `super', or `alt'.
 KEYS with a string of \"C-f\" are also valid and will be turned into
 values such as \"H-C-f\".
-Returns nil if `mac-command-modifier' is set to `none' or something
-other than the three sane values listed above."
+if `mac-command-modifier' is set to `none' or something  other than
+the three sane values listed above,  bind to `H-' by default"
     (let ((found (assoc mac-command-modifier
                         '((hyper . "H-")
                           (super . "s-")

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -58,7 +58,9 @@ other than the three sane values listed above."
                         '((hyper . "H-")
                           (super . "s-")
                           (alt   . "A-")))))
-      (when found (kbd (concat (cdr found) keys)))))
+      (if found
+          (kbd (concat (cdr found) keys))
+        (kbd (concat "H-" keys)))))
 
   ;; Keybindings
   (global-set-key (kbd-mac-command "=") 'spacemacs/scale-up-font)


### PR DESCRIPTION
Support use case setting command to keys other than hyper super or alt. Like when use swaps option and command.

@nixmaniack Closing the previous one and open a new PR with a new branch