### PR TITLE
Fix doc for terraform, perforce, elfeed and evil-snipe layer

### DIFF
--- a/layers/+source-control/perforce/README.org
+++ b/layers/+source-control/perforce/README.org
@@ -4,18 +4,22 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer adds support for [[https://www.perforce.com/][Perforce]] (p4).
+This layer integrates =Perforce= SCM system into spacemacs.
+
+** Features:
+- Support for running [[https://www.perforce.com/][Perforce]] (p4) SCM commands directly from emacs.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =perforce= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-You'll have to install the =p4== command line tool from the [[https://www.perforce.com/downloads/helix][download page]].
+You'll have to install the =p4= command line tool from the [[https://www.perforce.com/downloads/helix][download page]].
 
 Don't forget to setup the environment variables:
 - =P4_PORT=

--- a/layers/+tools/terraform/README.org
+++ b/layers/+tools/terraform/README.org
@@ -4,18 +4,24 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#auto-format-on-save][Auto-format on save]]
 
 * Description
-This layer provides syntax support for Terraform =.tf= files using
-[[https://github.com/syohex/emacs-terraform-mode][terraform-mode]].
+This layer provides basic support for Terraform =.tf= files.
+
+** Features:
+- Basic syntax highlighting via [[https://github.com/syohex/emacs-terraform-mode][terraform-mode]]
+- Auto formatting on save via =terraform fmt=
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =terraform= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+You will also need a working native =terraform= installation on your system.
 
 * Configuration
 ** Auto-format on save

--- a/layers/+vim/evil-snipe/README.org
+++ b/layers/+vim/evil-snipe/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#improved-f-and-t-search-behavior][Improved f and t search behavior]]
@@ -13,16 +14,13 @@
 - [[#key-bindings][Key bindings]]
 
 * Description
-The package [[https://github.com/hlissner/evil-snipe][evil-snipe]]
-- enables more efficient searches with ~f~ / ~F~ / ~t~ / ~T~.
-- adds a new, more precise search with ~s/S~
+This layer adds various replacements for vim's default search functions.
 
-Evil-snipe allows you to search more quickly and precisely in the buffer. It
-does so by improving on the built in ~f~ / ~F~ / ~t~ / ~T~ searches and adding another
-search command, namely ~s~ / ~S~.
-
-=evil-snipe= changes ~s/S~ behavior in order to search forward/backwards in the
-buffer with two chars.
+** Features:
+- Alternative implementation of vim's default search operations.
+- Replacement of evil-surround with a two-character search.
+- Support for alternative scopes for default search operations.
+- Support for alternative motions based on configurable regexps.
 
 * Install
 ** Layer
@@ -95,4 +93,13 @@ group of characters. By adding a pair of =(CHAR REGEX)= to the list
               (push '(?: "def .+:") evil-snipe-aliases)))
 #+END_SRC
 
-* TODO Key bindings
+* Key bindings
+
+| Key Binding | Description                                                                             |
+|-------------+-----------------------------------------------------------------------------------------|
+| ~f~         | search forward for the next entered character and set the cursor to it's position       |
+| ~F~         | search backward for the next entered character and set the cursor to it's position      |
+| ~t~         | search forward for the next entered character and set the cursor before it's position   |
+| ~T~         | search backward for the next entered character and set the cursor before it's position  |
+| ~s~         | search forward for the next entered two characters and set the cursor to it's position  |
+| ~S~         | search backward for the next entered two characters and set the cursor to it's position |

--- a/layers/+web-services/elfeed/README.org
+++ b/layers/+web-services/elfeed/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#setup-feeds][Setup feeds]]
@@ -16,9 +17,12 @@
   - [[#queue-timeout-exceeded][Queue timeout exceeded]]
 
 * Description
-This layer enables [[https://github.com/skeeto/elfeed][Elfeed]], a web feeds client which supports both Atom and RSS
-feeds. It'll optionally enable supporting packages, such as =elfeed-web= and
-=elfeed-org=.
+This layer integrates a web feed reader into spacemacs.
+
+** Features:
+- Support for reading RSS and Atom feeds directly within emacs via [[https://github.com/skeeto/elfeed][Elfeed]].
+- Support for managing feeds via org files supplied by [[https://github.com/remyhonig/elfeed-org][elfeed-org]].
+- Support for displaying feed database content in the browser via [[https://github.com/skeeto/elfeed#web-interface][web interface]].
 
 * Install
 ** Layer


### PR DESCRIPTION
Added the missing features block for terraform, perforce, elfeed and evil-snipe layer.
This is part of #9476.