### PR TITLE
org: Delete duplicate defmacro for org-emphasize

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -143,10 +143,6 @@
 
       (let ((dir (configuration-layer/get-layer-local-dir 'org)))
         (setq org-export-async-init-file (concat dir "org-async-init.el")))
-      (defmacro spacemacs|org-emphasize (fname char)
-        "Make function for setting the emphasis in org mode"
-        `(defun ,fname () (interactive)
-                (org-emphasize ,char)))
 
       ;; Insert key for org-mode and markdown a la C-h k
       ;; from SE endless http://emacs.stackexchange.com/questions/2206/i-want-to-have-the-kbd-tags-for-my-blog-written-in-org-mode/2208#2208


### PR DESCRIPTION
Delete the duplicate definition of the `spacemacs|org-emphasize` macro.  Commit 8b0c69c8cd321753c108ea6f1ddf7d6937af2599 added the duplicate.