### PR TITLE
core: Fix lambda quoted with '

### DIFF
--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -76,7 +76,7 @@ used."
          (prefix-arg-var (plist-get props :prefix))
          (on-message (plist-get props :on-message))
          (evil-leader-for-mode (spacemacs/mplist-get props :evil-leader-for-mode))
-         (supported-modes-string (mapconcat '(lambda (x) (symbol-name (car x)))
+         (supported-modes-string (mapconcat (lambda (x) (symbol-name (car x)))
                                             evil-leader-for-mode ", "))
          (bindkeys (spacemacs//create-key-binding-form props wrapper-func))
          ;; we evaluate condition and status only if they are a list or


### PR DESCRIPTION
Delete the quote preceding the lambda in `spacemacs|add-toggle` to avoid the following warning:

    .emacs.d/core/core-toggle.el: (lambda (x) ...) quoted with ' rather than with #'

While `#'` would be more correct than `'`, there is no need to quote the lambda at all.