### PR TITLE
notmuch: Add custom layout for notmuch buffers

### DIFF
--- a/layers/+email/notmuch/README.org
+++ b/layers/+email/notmuch/README.org
@@ -19,6 +19,7 @@
     - [[#search-mode][Search mode]]
     - [[#show-mode-1][Show mode]]
     - [[#tree-mode][Tree mode]]
+- [[#spacemacs-layout-integration][Spacemacs layout integration]]
 
 * Description
 Notmuch offers a fast, global-search and tag-based email system to
@@ -74,12 +75,13 @@ https://notmuchmail.org/
 * Key bindings
 ** Global bindings
 
-| Keybinding  | Command                     |
-|-------------+-----------------------------|
-| ~SPC a N N~ | Start notmuch               |
-| ~SPC a N n~ | Start helm notmuch          |
-| ~SPC a N j~ | Start a notmuch jump search |
-| ~SPC a N s~ | Start a notmuch search      |
+| Keybinding  | Command                                      |
+|-------------+----------------------------------------------|
+| ~SPC a N N~ | Start notmuch                                |
+| ~SPC a N n~ | Start helm notmuch                           |
+| ~SPC a N j~ | Start a notmuch jump search                  |
+| ~SPC a N s~ | Start a notmuch search                       |
+| ~SPC l o n~ | Start notmuch in a custom layout, "@Notmuch" |
 
 ** Show mode
 
@@ -157,3 +159,19 @@ https://notmuchmail.org/
 | ~+~        | [Message] Add tags        |
 | ~-~        | [Message] Remove tags     |
 | ~a~        | [Message] Archive         |
+
+* Spacemacs layout integration
+
+This layer defines a [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#layouts-and-workspaces][Spacemacs custom layout]] and automatically adds notmuch
+buffers to this layout.  The name and the key binding for the layout can be
+customized with the following layer variables:
+- =notmuch-spacemacs-layout-name= for the layout name,
+- =notmuch-spacemacs-layout-binding= for the key binding.
+
+The following example configures the layout with the default name and binding:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(
+  (notmuch :variables notmuch-spacemacs-layout-name "@Notmuch"
+                      notmuch-spacemacs-layout-binding "n")))
+#+END_SRC

--- a/layers/+email/notmuch/config.el
+++ b/layers/+email/notmuch/config.el
@@ -1,0 +1,24 @@
+;;; config.el --- notmuch Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Miciah Dashiel Butler Masters <miciah.masters@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar notmuch-spacemacs-layout-name "@Notmuch"
+  "Name used in the setup for `spacemacs-layouts' micro-state")
+
+(defvar notmuch-spacemacs-layout-binding "n"
+  "Binding used in the setup for `spacemacs-layouts' micro-state")
+
+(defvar notmuch-modes
+  '(notmuch-hello-mode
+    notmuch-message-mode
+    notmuch-search-mode
+    notmuch-show-mode
+    notmuch-tree-mode)
+  "Modes that are associated with notmuch buffers.")

--- a/layers/+email/notmuch/funcs.el
+++ b/layers/+email/notmuch/funcs.el
@@ -107,3 +107,9 @@ messages in the current thread"
   (with-current-notmuch-show-message
    (spacemacs//notmuch-open-github-patch (current-buffer))))
 
+
+;; persp
+
+(defun spacemacs-layouts/add-notmuch-buffer-to-persp ()
+  (persp-add-buffer (current-buffer)
+                    (persp-get-by-name notmuch-spacemacs-layout-name)))

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -16,7 +16,8 @@
                                            :repo "fuxialexander/counsel-notmuch"))
         (helm-notmuch :reuiqres helm)
         notmuch
-        org)
+        org
+        persp-mode)
       )
 
 (defun notmuch/init-counsel-notmuch ()
@@ -119,3 +120,18 @@
 (defun notmuch/pre-init-org ()
   (spacemacs|use-package-add-hook org
     :post-config (require 'org-notmuch)))
+
+(defun notmuch/post-init-persp-mode ()
+  (with-eval-after-load 'persp-mode
+    (push (lambda (b) (with-current-buffer b (memq major-mode notmuch-modes)))
+          persp-filter-save-buffers-functions))
+
+  (spacemacs|define-custom-layout notmuch-spacemacs-layout-name
+    :binding notmuch-spacemacs-layout-binding
+    :body
+    (progn
+      (dolist (mode notmuch-modes)
+        (let ((hook (intern (concat (symbol-name mode) "-hook"))))
+          (add-hook hook #'spacemacs-layouts/add-notmuch-buffer-to-persp)))
+
+      (call-interactively 'notmuch))))


### PR DESCRIPTION
Define a new custom layout with binding "n" for notmuch buffers.  The custom layout's name can be customized using the new `notmuch-spacemacs-layout-name` variable. The custom layout's binding can be customized using the new `notmuch-spacemacs-layout-binding` variable.



  