### PR TITLE
fix a typo error in the 'spacemacs/helm-file-smart-do-search' function

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -199,7 +199,7 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
 are used as default input."
         (interactive)
         (call-interactively
-         (spacemacs//helm-do-search-find-tool "helm-file-do"
+         (spacemacs//helm-do-search-find-tool "helm-files-do"
                                               dotspacemacs-search-tools
                                               default-inputp)))
 


### PR DESCRIPTION
I think there is a bug in [spacemacs/helm-file-smart-do-search](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bcompletion/helm/packages.el#L195-L204) due to a typo error.
It should be "helm-files-do" rather than "helm-file-do".

If it is intended, in advance, i am sorry for annoying you.

"**helm-file-do**":
```emacs-lisp
(let ((base "helm-file-do")
      (tools dotspacemacs-search-tools)
      (default-inputp nil))
  `(cond
    ,@(mapcar
       (lambda (x)
         `((executable-find ,x)
           ',(let ((func
                    (intern
                     (format (if default-inputp
                                 "spacemacs/%s-%s-region-or-symbol"
                               "spacemacs/%s-%s")
                             base x))))
               (if (fboundp func)
                   func
                 (intern (format "%s-%s"  base x))))))
       tools)
    (t 'helm-do-grep)))
(cond ((executable-find "rg") (quote helm-file-do-rg)) ((executable-find "ag") (quote spacemacs/helm-file-do-ag)) ((executable-find "pt") (quote helm-file-do-pt)) ((executable-find "ack") (quote helm-file-do-ack)) ((executable-find "grep") (quote spacemacs/helm-file-do-grep)) (t (quote helm-do-grep)))
```
"**helm-files-do**":
```emacs-lisp
(let ((base "helm-files-do")
      (tools dotspacemacs-search-tools)
      (default-inputp nil))
  `(cond
    ,@(mapcar
       (lambda (x)
         `((executable-find ,x)
           ',(let ((func
                    (intern
                     (format (if default-inputp
                                 "spacemacs/%s-%s-region-or-symbol"
                               "spacemacs/%s-%s")
                             base x))))
               (if (fboundp func)
                   func
                 (intern (format "%s-%s"  base x))))))
       tools)
    (t 'helm-do-grep)))
(cond ((executable-find "rg") (quote spacemacs/helm-files-do-rg)) ((executable-find "ag") (quote spacemacs/helm-files-do-ag)) ((executable-find "pt") (quote spacemacs/helm-files-do-pt)) ((executable-find "ack") (quote spacemacs/helm-files-do-ack)) ((executable-find "grep") (quote spacemacs/helm-files-do-grep)) (t (quote helm-do-grep)))
```
  