### PR TITLE
git: disable evil-magit in holy mode (emacs style)

### DIFF
--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -70,3 +70,19 @@
                    (car git-timemachine-revision))))
         (call-interactively 'git-link-commit))
     (call-interactively 'git-link-commit)))
+
+
+(defun spacemacs//support-evilified-buffer-p (style)
+  "Return non-nil if evil navigation should be enabled for STYLE."
+  (or (eq style 'vim)
+      (and (eq style 'hybrid)
+           hybrid-mode-enable-evilified-state)))
+
+(defun spacemacs//magit-evil-magit-bindings (style)
+  "Set `evil-magit' bindings for the given editing STYLE."
+  (cond
+   ((spacemacs//support-evilified-buffer-p style)
+    (evil-magit-init))
+   (t
+    (when (featurep 'evil-magit)
+      (evil-magit-revert)))))

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -30,10 +30,13 @@
         ))
 
 (defun git/init-evil-magit ()
-  (with-eval-after-load 'magit
-    (require 'evil-magit)
+  (spacemacs|use-package-add-hook magit
+    :post-config
+    (when (spacemacs//support-evilified-buffer-p dotspacemacs-editing-style)
+      (evil-magit-init))
     (evil-define-key 'motion magit-mode-map
-      (kbd dotspacemacs-leader-key) spacemacs-default-map)))
+      (kbd dotspacemacs-leader-key) spacemacs-default-map))
+  (add-hook 'spacemacs-editing-style-hook 'spacemacs//magit-evil-magit-bindings))
 
 (defun git/post-init-fill-column-indicator ()
   (add-hook 'git-commit-mode-hook 'fci-mode))


### PR DESCRIPTION
Fix #10078
Fix #10054

~Although this commit fixes the issue for emacs mode, further improvements are
needed to make sure `C-z` works consistently. Switching between editing styles
in current situation won't dynamically load/switch keys.~

Edit: Updated commit based on syl20bnr's [suggestion](https://github.com/syl20bnr/spacemacs/pull/10090#issuecomment-356197873).
  