### PR TITLE
Fix documentation for nim, fsharp, forth, dash and fasd layer

### DIFF
--- a/layers/+lang/forth/README.org
+++ b/layers/+lang/forth/README.org
@@ -2,19 +2,25 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer supports developing in the Forth family of languages. It provides
-shortcuts to a basic set of commands for interactive development.
+This layer adds basic support for the Forth family of languages to spacemacs.
+
+** Features:
+- Syntax highlighting
+- Showing meaning of objects in context of the current =Forth= session.
+- Eval of entire files or regions in current =Forth= session.
+- Passing interactive commands to current =Forth= session.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =forth= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-A local installation of Forth needs to be present as well. /GNU Forth/ is
+A local installation of =Forth= needs to be present as well. =GNU Forth= is
 commonly available on Unix systems via the package manager. To bypass the query
 when calling ~run-forth~, the default Forth can be configured by setting the
 appropriate variable.
@@ -25,8 +31,6 @@ appropriate variable.
 #+END_SRC
 
 * Key bindings
-All Forth specific bindings are prefixed with the major-mode leader
-~SPC m~.
 
 | Key Binding | Description                                                       |
 |-------------+-------------------------------------------------------------------|

--- a/layers/+lang/fsharp/README.org
+++ b/layers/+lang/fsharp/README.org
@@ -4,16 +4,20 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-- [[#packages-included][Packages Included]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
   - [[#repl][REPL]]
 
 * Description
-This layer adds support for F# language using [[https://github.com/fsharp/fsharpbinding][fsharpbinding]].
+This layer adds support for F# language using [[https://github.com/fsharp/fsharpbinding][fsharpbinding]] and [[https://github.com/fsharp/fsharpbinding][fsharp-mode]].
 
-* Packages Included
-- [[https://github.com/fsharp/fsharpbinding][fsharp-mode]]
+** Features:
+- Syntax highlighting
+- Code completion
+- Flycheck integration
+- REPL
+- Compile/Run/Interpreter and info tooltip shortcuts
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/nim/README.org
+++ b/layers/+lang/nim/README.org
@@ -4,13 +4,15 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#working-with-nim][Working with Nim]]
   - [[#nim-commands-start-with-m][Nim commands (start with =m=):]]
 
 * Description
-This layer provides the following features for Nim:
+This layer adds support for the multi-paradigm language =Nim=.
 
+** Features:
 - Code completion.
 - Jump to definition.
 - Syntax checking.

--- a/layers/+tools/dash/README.org
+++ b/layers/+tools/dash/README.org
@@ -6,28 +6,22 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#dash-os-x][Dash (OS X)]]
-  - [[#sqlite3][Sqlite3]]
+    - [[#sqlite3][Sqlite3]]
   - [[#zeal-linux--windows][Zeal (Linux & Windows)]]
-  - [[#check-documentation-for-x-at-point][Check Documentation for x-at-point]]
+- [[#word-at-point][Word at point]]
 - [[#key-bindings][Key bindings]]
-  - [[#helm-dash-and-counsel-dash][helm-dash and counsel-dash]]
 
 * Description
-- [[https://kapeli.com/dash][dash]] :: Is a great tool for quick access to various sets of documentation,
-          only available in OS X.
+This layer integrates offline api browsers into emacs. It provides one for OS X, Linux and Windows.
 
-- [[https://github.com/stanaka/dash-at-point][dash-at-point]] :: Is the package used to integrate =dash= in Emacs. It will try
-                   to intelligently guess specific docsets to use based off of
-                   your current mode.
-
-- [[https://zealdocs.org/][zeal]] :: Zeal is an offline documentation browser inspired by Dash,
-          available for Linux and Windows.
-
-- [[https://github.com/jinzhu/zeal-at-point][zeal-at-point]] :: Run zeal-at-point to search the word at point (or string in
-                   region), then Zeal is launched and search the word. Use
-                   prefix argument C-u to edit the search string first.
+** Features:
+- Searching for word at point in offline api browser's UI.
+- Integration of offline api browser search results in helm and ivy.
+- Support for [[https://kapeli.com/dash][dash]] offline api browser for OS X.
+- Support for [[https://zealdocs.org/][zeal]] offline api browser for Linux.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -40,7 +34,7 @@ You have to install [[https://kapeli.com/dash][dash]] on your machine.
 It is recommended to set the =HUD mode= in your Dash application preferences
 when using this layer.
 
-** Sqlite3
+*** Sqlite3
 Helm Dash [[https://github.com/areina/helm-dash#user-content-requirements][requires]] sqlite3 to be installed to function properly.
 
 ** Zeal (Linux & Windows)
@@ -48,9 +42,22 @@ You have to install [[https://zealdocs.org/][zeal]] on your machine.
 
 Then install the docsets you use more frequently
 
-** Check Documentation for x-at-point
-See the documentation [[https://github.com/stanaka/dash-at-point#Usage][dash-at-point-usage]] , or [[https://github.com/jinzhu/zeal-at-point][zeal-at-point]] for more
-information on customizing specific docsets for modes.
+* Word at point
+=dash-at-point= and =zeal-at-point= will search for the word at point in the respective offline api browser.
+The result will be displayed in the offline browser's UI.
+
+However having to leave emacs to have a look at the search results may be a bit awkward.
+To help with this it is also possible to integrate the search results directly in =helm= or =ivy=
+and show the details in a browser. To do so [[https://github.com/areina/helm-dash][helm-dash]] can be used for =helm= and [[https://github.com/nathankot/counsel-dash][counsel-dash]] for =ivy=.
+
+To get them working it is necessary to set =helm-dash-docset-newpath= to the location of your docsets.
+
+ #+BEGIN_SRC elisp
+   (dash :variables
+         helm-dash-docset-newpath "~/.local/share/Zeal/Zeal/docsets")
+ #+END_SRC
+
+For more details please check [[https://github.com/stanaka/dash-at-point#Usage][dash-at-point-usage]] or [[https://github.com/jinzhu/zeal-at-point][zeal-at-point]].
 
 * Key bindings
 
@@ -60,12 +67,3 @@ information on customizing specific docsets for modes.
 | ~SPC d D~   | Lookup thing at point in Dash or Zeal within a specified Docset |
 | ~SPC d h~   | Lookup thing at point in helm-dash or counsel-dash              |
 | ~SPC d H~   | Lookup in helm-dash or counsel-dash within a specified Docset   |
-
-** helm-dash and counsel-dash
-=dash-at-point= is linked to the GUI app and is only available for OSX. On
-linux, you can use =zeal-at-point= which is linked to the GUI app too, but it's
-open source.
-
-Or you can use [[https://github.com/areina/helm-dash][helm-dash]] when using =helm= and [[https://github.com/nathankot/counsel-dash][counsel-dash]] when using =ivy=,
-which requires no additional application. You can use
-=dash/helm-dash-docset-newpath= to set the location path of your docsets.

--- a/layers/+tools/fasd/README.org
+++ b/layers/+tools/fasd/README.org
@@ -2,16 +2,19 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#fasd][fasd]]
 - [[#keybindings][Keybindings]]
 
 * Description
-This layer adds integration of [[https://github.com/clvv/fasd][fasd]] which is a command line tool
-to quickly jump between locations in a POSIX shell.
+This layer integrates the [[https://github.com/clvv/fasd][fasd]] command line tool into spacemacs.
 
-The integration is implemented in the package [[https://github.com/steckerhalter/emacs-fasd][emacs-fasd]].
+** Features:
+- Adds easy shortcuts to reference recent files and directories.
+- Provides =fasd= with recent open file lists from emacs.
+- Allows to filter =fasd= results with =helm= or =ivy=.
 
 * Install
 ** Layer


### PR DESCRIPTION
Fixed the documentations for nim, fsharp, forth and fasd layer.

Also I have massively reworked the documentation of the dash layer to make clear
that this feature is not OS X specific and actually quite useful.

This is part of #9476.
  