### PR TITLE
Fix #10091, which-key interface delay/ lag.

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -470,6 +470,7 @@
         which-key-max-description-length 32
         which-key-sort-order 'which-key-key-order-alpha
         which-key-idle-delay dotspacemacs-which-key-delay
+        which-key-idle-secondary-delay 0.01
         which-key-allow-evil-operators t)
 
   (which-key-mode)


### PR DESCRIPTION
A fix for #10091. The default behaviour for which-key is for 'which-key-idle-delay' to affect both the initial trigger and subsequent actions. By setting 'which-key-idle-secondary-delay' to something non-nil, that delay acts over the subsequent actions instead.

The which-key wiki recommends setting it to a 'non-zero value', as zero could cause issues, so instead set it to 0.01.

Again, I'm not sure if this is desired behavior, if so, please ignore (but maybe something should be added to the readme instead?).