### PR TITLE
Add null-check for filename before calling file-name-extension func

### DIFF
--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -69,7 +69,9 @@
 (defun spacemacs//typescript-tsx-file-p (&optional filename)
   "Return non-nil if file is a TSX file."
   (let ((filename (or filename buffer-file-name)))
-    (string-equal "tsx" (file-name-extension filename))))
+    ;; So that the file-name-extension doesn't throw an error for buffers that don't have a file-name associated
+    (when filename
+        (string-equal "tsx" (file-name-extension filename)))))
 
 (defun spacemacs//typescript-web-mode-enable-tide ()
   "Enable tide when a .tsx file is opened."


### PR DESCRIPTION
I was having errors when using org-reveal and the typescript layer.

This typescript function would try to run when enabling web-mode in a temp-buffer that had web-mode activated. 

I'm not sure if this can change the behavior of the typescript layer, but given that this will only affect the code when filename is `nil` I'm confident that this wouldn't be a problem.

Please feel free to tag the owner of the typescript layer