### PR TITLE
Move the key definition to the config hook of gh-pulls

### DIFF
--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -75,8 +75,8 @@
     :pre-config
     (progn
       (use-package magit-gh-pulls
-        :init (define-key magit-mode-map "#" 'spacemacs/load-gh-pulls-mode)
         :config
+        (define-key magit-mode-map "#" 'spacemacs/load-gh-pulls-mode)
         (spacemacs|diminish magit-gh-pulls-mode "Github-PR")))))
 
 (defun github/init-magithub ()


### PR DESCRIPTION
The way it's currently set up doesn't work for me. I moved the keybinding to the config hook and it works. Let me know if this is not the way, and maybe I'm doing something wrong myself.