### PR TITLE
purpose: Add chat and mail purposes

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -55,10 +55,9 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   correctly loads custom settings at the end of the loading process, fixing
   unwanted overriden custom settings by layers. See section =Custom variables=
   in =DOCUMENTATION.org=.
-- Introduction of =spacemacs-purpose= layer in charge of handling Emacs windows
-  assignation for actions opening new buffers. This layer brings more
-  consistency to windows creation by giving them a purpose (i.e. =edit=, =help=,
-  etc...). See [[https://github.com/bmag/emacs-purpose][emacs-purpose]] repository for more info. (thanks to bmag)
+- Introduction of =spacemacs-purpose= layer that assigns newly created buffers
+  to windows based on their inferred purpose (=edit=, =help=, =chat=, =mail=,
+  etc.).  See [[https://github.com/bmag/emacs-purpose][emacs-purpose]] repository for more info (thanks to bmag)
 - New distribution =spacemacs-docker= used to build the official docker image
   for the Spacemacs container (thanks to Eugene Yaremenko)
 - Added support for =ripgrep=. To enable it add =rg= to

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -30,6 +30,7 @@
     erc-yt
     linum
     persp-mode
+    window-purpose
     ))
 
 (defun erc/post-init-company ()
@@ -246,3 +247,6 @@
               (erc/default-servers)
             (call-interactively 'erc)))))))
 
+(defun erc/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config (add-to-list 'purpose-user-mode-purposes '(erc-mode . chat))))

--- a/layers/+chat/jabber/packages.el
+++ b/layers/+chat/jabber/packages.el
@@ -9,7 +9,10 @@
 ;;
 ;;; License: GPLv3
 
-(setq jabber-packages '(jabber))
+(setq jabber-packages '(
+                        jabber
+                        window-purpose
+                        ))
 
 (defun jabber/init-jabber ()
   (use-package jabber
@@ -37,3 +40,11 @@
         "j" 'jabber-go-to-next-roster-item
         "k" 'jabber-go-to-previous-roster-item))))
 
+(defun jabber/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config
+    (dolist (mode '(jabber-browse-mode
+                    jabber-chat-mode
+                    jabber-console-mode
+                    jabber-roster-mode))
+      (add-to-list 'purpose-user-mode-purposes (cons mode 'chat)))))

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -23,6 +23,7 @@
         (rcirc-late-fix :location local
                         :toggle rcirc-enable-late-fix)
         rcirc-notify
+        window-purpose
         ))
 
 (defun rcirc/post-init-company ()
@@ -119,3 +120,7 @@
     :config
     (progn
       (add-hook 'rcirc-notify-page-me-hooks 'spacemacs/rcirc-notify-beep))))
+
+(defun rcirc/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config (add-to-list 'purpose-user-mode-purposes '(rcirc-mode . chat))))

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -23,6 +23,7 @@
     linum
     persp-mode
     slack
+    window-purpose
     ))
 
 (defun slack/init-alert ()
@@ -91,5 +92,10 @@
       (evil-define-key 'insert slack-mode-map
         (kbd "@") 'slack-message-embed-mention
         (kbd "#") 'slack-message-embed-channel))))
+
+(defun slack/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config
+    (add-to-list 'purpose-user-mode-purposes '(slack-mode . chat))))
 
 ;;; packages.el ends here

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -9,7 +9,10 @@
 ;;
 ;;; License: GPLv3
 
-(setq gnus-packages '(gnus))
+(setq gnus-packages '(
+                      gnus
+                      window-purpose
+                      ))
 
 (defun gnus/init-gnus ()
   "Initialize my package"
@@ -81,3 +84,13 @@
         (kbd "J") 'gnus-summary-next-article
         (kbd "K") 'gnus-summary-prev-article
         (kbd "<RET>") 'spacemacs/browse-nnrss-url))))
+
+(defun gnus/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config
+    (dolist (mode '(gnus-group-mode
+                    gnus-server-mode
+                    gnus-browse-mode
+                    gnus-article-mode
+                    gnus-summary-mode))
+      (add-to-list 'purpose-user-mode-purposes (cons mode 'mail)))))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -17,6 +17,7 @@
         (helm-mu :requires helm)
         org
         persp-mode
+        window-purpose
         ))
 
 (defun mu4e/post-init-persp-mode ()
@@ -151,3 +152,9 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
 (defun mu4e/pre-init-org ()
   ;; load org-mu4e when org is actually loaded
   (with-eval-after-load 'org (require 'org-mu4e nil 'noerror)))
+
+(defun mu4e/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config
+    (dolist (mode mu4e-modes)
+      (add-to-list 'purpose-user-mode-purposes (cons mode 'mail)))))

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -16,6 +16,7 @@
         notmuch
         org
         persp-mode
+        window-purpose
         ))
 
 (defun notmuch/init-counsel-notmuch ()
@@ -133,3 +134,9 @@
             (let ((hook (intern (concat (symbol-name mode) "-hook"))))
               (add-hook hook #'spacemacs//notmuch-buffer-to-persp)))
           (call-interactively 'notmuch))))))
+
+(defun notmuch/pre-init-window-purpose ()
+  (spacemacs|use-package-add-hook window-purpose
+    :pre-config
+    (dolist (mode notmuch-modes)
+      (add-to-list 'purpose-user-mode-purposes (cons mode 'mail)))))

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -148,4 +148,8 @@
       ;; with original `C-x C-f', `C-x b', etc. and `semantic' key bindings.
       (setcdr purpose-mode-map nil)
       (spacemacs|diminish purpose-mode)
-      (purpose-x-golden-ratio-setup))))
+      (purpose-x-golden-ratio-setup)
+      ;; Other layers may have modified `purpose-user-mode-purposes' by using
+      ;; `spacemacs|user-package-add-hook' to add pre-config hooks; we want to
+      ;; incorporate any such configuration now.
+      (purpose-compile-user-configuration))))


### PR DESCRIPTION
Map erc, jabber, rcirc, and slack buffers to the "chat" purpose.

Map gnus, mu4e, and notmuch buffers to the "mail" purpose.

---

I tag this PR as WIP because I have not tested erc, jabber, gnus, or mu4e, but notmuch and rcirc buffers seem to work properly, and I would like to get feedback on the idea and approach behind this code.  Does this seem like something that should be included in spacemacs?