### PR TITLE
Move docker keys into `SPC a`

### DIFF
--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -22,19 +22,19 @@
     :defer t
     :init
     (progn
-      (spacemacs/declare-prefix "D" "Docker")
+      (spacemacs/declare-prefix "aD" "Docker")
       (evil-leader/set-key
-        "Dc" 'docker-containers
-        "Dd" 'docker-rmi
-        "De" 'docker-unpause
-        "DF" 'docker-pull
-        "Dk" 'docker-rm
-        "Di" 'docker-images
-        "Do" 'docker-stop
-        "DP" 'docker-push
-        "Dp" 'docker-pause
-        "Dr" 'docker-restart
-        "Ds" 'docker-start)
+        "aDc" 'docker-containers
+        "aDd" 'docker-rmi
+        "aDe" 'docker-unpause
+        "aDF" 'docker-pull
+        "aDk" 'docker-rm
+        "aDi" 'docker-images
+        "aDo" 'docker-stop
+        "aDP" 'docker-push
+        "aDp" 'docker-pause
+        "aDr" 'docker-restart
+        "aDs" 'docker-start)
       (push "\\*docker.+\\*" spacemacs-useful-buffers-regexp)))
   (with-eval-after-load 'docker-containers
     (evilified-state-evilify-map docker-containers-mode-map


### PR DESCRIPTION
Most of the tools we have are accessible through `SPC a`, maybe it makes sense to have docker-layer keys there as well?