### PR TITLE
Fix errors in rcirc and slack layers

### DIFF
--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -36,14 +36,12 @@
     (progn
       (add-to-list 'persp-filter-save-buffers-functions
                    'spacemacs//rcirc-persp-filter-save-buffers-function)
-      (spacemacs|define-custom-layout erc-spacemacs-layout-name
-        :binding erc-spacemacs-layout-binding
+      (spacemacs|define-custom-layout rcirc-spacemacs-layout-name
+        :binding rcirc-spacemacs-layout-binding
         :body
         (progn
-          (add-hook 'erc-mode-hook #'spacemacs//rcirc-buffer-to-persp)
-          (if erc-server-list
-              (erc/default-servers)
-            (call-interactively 'erc)))))))
+          (add-hook 'rcirc-mode-hook #'spacemacs//rcirc-buffer-to-persp)
+          (call-interactively #'spacemacs/rcirc))))))
 
 (defun rcirc/init-rcirc ()
   (use-package rcirc

--- a/layers/+chat/slack/funcs.el
+++ b/layers/+chat/slack/funcs.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Python Layer functions File for Spacemacs
+;;; funcs.el --- slack layer functions file for Spacemacs
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;


### PR DESCRIPTION
Fix errors that were introduced into the rcirc and slack layers by commit fea035f413bb6022326b88a74376f7185c344507.

Change the header for the slack layer's `funcs.el` to refer to the correct layer.

Change the custom layout definition for rcirc to use the correct name and binding for the layout and the correct invocation for rcirc.