### PR TITLE
Update Auto-completion docs, removed binding C-f

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -228,7 +228,6 @@ Emacs style:
 
 | Key Binding | Description                                    |
 |-------------+------------------------------------------------|
-| ~C-f~       | (emacs style) complete selection               |
 | ~C-n~       | (emacs style) go down in company dropdown menu |
 | ~C-p~       | (emacs style) go up in company dropdown menu   |
 


### PR DESCRIPTION
The `C-f` binding was removed by this PR:
`Remove mapping <c-f> to select the frist completion.` #10039