### PR TITLE
treemacs: only activate extended git-mode when python3 is installed.

### DIFF
--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -21,7 +21,7 @@ Must be a number.")
 
 (defvar treemacs-use-git-mode
   (pcase (cons (not (null (executable-find "git")))
-               (not (null (executable-find "python"))))
+               (not (null (executable-find "python3"))))
     (`(t . t) 'extended)
     (`(t . _) 'simple))
   "Type of git integration for `treemacs-git-mode'.


### PR DESCRIPTION
Little addendum to the previous fix. The smarter git-mode needs python3, though @quicknir did want to take a look at the python script in question.