### PR TITLE
notmuch: fix package loading

### DIFF
--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -33,6 +33,7 @@
 (defun notmuch/init-notmuch ()
   (use-package notmuch
     :defer t
+    :commands notmuch
     :init
     (progn
       (spacemacs/declare-prefix "aN" "notmuch")


### PR DESCRIPTION
The notmuch refactor in d4b931e9355ad14843ba072038b9da864553781f broke loading of the notmuch package, this fixes that.

I'm not sure why this is necessary, but it seems to fix it.