### PR TITLE
holy, hybrid: holy-mode and hybrid-mode depend on evil-evilified-state

### DIFF
--- a/layers/+distributions/spacemacs-base/local/holy-mode/holy-mode.el
+++ b/layers/+distributions/spacemacs-base/local/holy-mode/holy-mode.el
@@ -28,6 +28,8 @@
 
 ;;; Code:
 
+(require 'evil-evilified-state)
+
 (defadvice evil-insert-state (around holy-insert-to-emacs-state disable)
   "Forces Emacs state."
   (if (equal -1 (ad-get-arg 0))

--- a/layers/+distributions/spacemacs-base/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distributions/spacemacs-base/local/hybrid-mode/hybrid-mode.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'evil)
+(require 'evil-evilified-state)
 
 (defcustom hybrid-mode-default-state 'normal
   "Value of `evil-default-state' for hybrid-mode."


### PR DESCRIPTION
Both modes make reference to `evil-evilified-state-modes`, which is defined and
initialised in `evil-evilified-state`.

Fixes #10124, a crash on startup if `dotspacemacs-editing-style` is 'hybrid.