### PR TITLE
Disable nameless by default

### DIFF
--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -104,12 +104,15 @@ function or press ~o~ to go out of it.
 Nameless hides package namespaces in your emacs-lisp code, and replaces it by
 leading ~>~ It can be toggled with ~SPC m T n~.
 
-By default =nameless= is activated, to disable it set the layer variable
-=emacs-lisp-hide-namespace-prefix= to =nil=
+By default =nameless= is deactivated, to enable it set the layer variable
+=emacs-lisp-hide-namespace-prefix= to =t=.
+
+NOTE: =nameless= is known to cause problems when spacemacs is used inside a
+terminal window, use with caution.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (emacs-lisp :variables emacs-lisp-hide-namespace-prefix nil)))
+    (emacs-lisp :variables emacs-lisp-hide-namespace-prefix t)))
 #+END_SRC
 
 ** Aliases

--- a/layers/+lang/emacs-lisp/config.el
+++ b/layers/+lang/emacs-lisp/config.el
@@ -14,5 +14,5 @@
 (spacemacs|define-jump-handlers emacs-lisp-mode)
 (spacemacs|define-jump-handlers lisp-interaction-mode)
 
-(defvar emacs-lisp-hide-namespace-prefix t
+(defvar emacs-lisp-hide-namespace-prefix nil
   "If non-nil, hide namespace prefixes using nameless-mode.")


### PR DESCRIPTION
A workaround to deal with #10118 until nameless works inside a terminal.

I honestly belive such a package should not be enabled by default. Also the configuration for this reads really weird... to enable it you set the hiding variable to true... positive, negative, positive... Better if it was just `emacs-lisp-enable-nameless`, default `nil` and let the experienced users set it to `t` if they want to. 

Since even beginners are expected to be able to edit an emacs lisp file regularly, the `.spacemacs`, this package adds unnecessary complexity and offputting behaviour.