### PR TITLE
Keybindings for kill buffer and window

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -142,6 +142,7 @@
   "bR"    'spacemacs/safe-revert-buffer
   "bs"    'spacemacs/switch-to-scratch-buffer
   "bu"    'spacemacs/reopen-killed-buffer
+  "bx"    'kill-buffer-and-window
   "bY"    'spacemacs/copy-whole-buffer-to-clipboard
   "bw"    'read-only-mode)
 (dotimes (i 9)

--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -440,6 +440,7 @@
   "wv"  'split-window-right
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
+  "wx"  'kill-buffer-and-window
   "w/"  'split-window-right
   "w="  'balance-windows-area
   "w+"  'spacemacs/window-layout-toggle


### PR DESCRIPTION
Adds keybindings for `kill-buffer-and-window` both under the `buffer` and `window` prefix. 

I've created two commits for easy cherry-picking in case only one is needed.

I presonally would prefer to have them both available for convenience, in case I already pressed either `SPC b` or `SPC w` with that intent, I should not need to cancel the current action and repeat. Currently the same behaviour takes to many keystrokes to execute.