### PR TITLE
spacemacs-purpose: load pupo after window purpose

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -100,7 +100,9 @@
 (defun spacemacs-purpose/init-spacemacs-purpose-popwin ()
   (use-package spacemacs-purpose-popwin
     ;; defer loading of spacemacs-purpose-popwin
-    :commands pupo-mode))
+    :commands pupo-mode)
+  (spacemacs|use-package-add-hook window-purpose
+    :post-config (pupo-mode)))
 
 (defun spacemacs-purpose/init-window-purpose ()
   (use-package window-purpose


### PR DESCRIPTION
This was reverted in https://github.com/syl20bnr/spacemacs/commit/41e546f040027695d2d230d0608b9c5b49d6d4d4.

Without this, popup windows, basically pop-up anywhere (instead of bottom of the window), without meaningful purpose. 