### PR TITLE
 spacemacs-modeline: colorize hybrid and inactive state for vim-powerline

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/local/vim-powerline/vim-colors.el
+++ b/layers/+spacemacs/spacemacs-modeline/local/vim-powerline/vim-colors.el
@@ -74,7 +74,7 @@
 
            (("state_indicator")
             (normal       ,darkestgreen    ,brightgreen  t)
-            ;;(inactive    ,gray6           ,gray2      t)
+            (inactive     ,gray6           ,gray2        t)
             (insert       ,darkestcyan     ,white        t)
             (visual       ,darkred         ,brightorange t)
             (replace      ,white           ,brightred    t)

--- a/layers/+spacemacs/spacemacs-modeline/local/vim-powerline/vim-colors.el
+++ b/layers/+spacemacs/spacemacs-modeline/local/vim-powerline/vim-colors.el
@@ -82,7 +82,8 @@
             (motion       ,brightpurple    ,mediumpurple t)
             (emacs        ,darkestcyan     ,white        t)
             (iedit        ,darkred         ,brightestred t)
-            (lisp         ,brightpurple    ,mediumpurple t))
+            (lisp         ,brightpurple    ,mediumpurple t)
+            (hybrid       ,darkestblue     ,mediumcyan   t))
 
            (("branch" "scrollpercent" "raw" "filesize")
             (normal      ,gray9           ,gray4)


### PR DESCRIPTION
Commit 1: Colorize `hybrid` state for `vim-powerline`
Commit 2: Colorize `inactive` state for `vim-powerline` (don't know why it was commented out - hence separate commit if this change isn't justified)

It was colored as `normal` state now with this change: 
<img width="1110" alt="screen shot 2018-01-12 at 6 57 00 pm" src="https://user-images.githubusercontent.com/542810/34877257-53f094de-f7cb-11e7-9995-8475e6121331.png">

