### PR TITLE
Fix doc for erlang, gpu, ess and vim-empty-lines layer

### DIFF
--- a/layers/+lang/erlang/README.org
+++ b/layers/+lang/erlang/README.org
@@ -4,11 +4,16 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
-Very basic layer for Erlang with support for basic =syntax-checking= and
-=auto-completion= with the corresponding layers.
+This layer adds very basic support for Erlang to Spacemacs.
+
+** Features:
+- Syntax highlighting
+- Syntax checking via =Flycheck= integration
+- Auto-completion via =Company= integration
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -6,6 +6,7 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+- [[#options][Options]]
 - [[#key-bindings][Key Bindings]]
   - [[#inferior-repl-process][Inferior REPL process]]
   - [[#help][Help]]
@@ -13,21 +14,51 @@
   - [[#r-devtools][R devtools]]
   - [[#debugging][Debugging]]
   - [[#editing-markdown][Editing Markdown]]
-- [[#options][Options]]
 
 * Description
-This layer adds support for statistical analysis through [[https://ess.r-project.org/][ESS]].
+This layer adds support for statistical programming languages to Spacemacs.
 
 ** Features:
-- All [[https://ess.r-project.org/Manual/ess.html#Current-Features][ESS features]]
+- Syntax highlighting
+- Auto-completion
+- Syntax-checking via [[https://github.com/jimhester/lintr][lintr]]
 - Additional data viewer for R via [[https://github.com/myuhe/ess-R-data-view.el][ess-R-data-view]]
 - Support for Org-Babel
 - Better 'equals' behavior via [[https://github.com/genovese/ess-smart-equals][ess-smart-equals]]
+- Showing of inline help for =R= constructs
+- Repl support via =R terminal=
+- Support for =S=, =SAS= and =R=
+- Much more via the [[https://ess.r-project.org/Manual/ess.html#Current-Features][ESS Project]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =ess= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+Also install [[https://github.com/jimhester/lintr][lintr]] library via the R terminal to enable syntax checking.
+To do so start the R terminal and type below code.
+
+#+BEGIN_SRC R
+  install.packages("lintr")
+#+END_SRC
+
+* Options
+To turn off the automatic replacement of underscores by =<-=, set in your
+=~/.spacemacs=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((ess :variables
+                                                         ess-disable-underscore-assign t)))
+#+END_SRC
+
+Alternatively you may enable =ess-smart-equals=, which also disables replacement
+of underscores by =<-=, and additionally replace the equals sign with =<-= when
+appropriate:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((ess :variables
+                                                         ess-enable-smart-equals t)))
+#+END_SRC
 
 * Key Bindings
 ** Inferior REPL process
@@ -140,21 +171,3 @@ Edit Markdown files
 | ~SPC m c C~ | send knitr/sweave chunk and switch to REPL in insert mode |
 | ~SPC m c c~ | send knitr/sweave chunk and keep buffer focused           |
 | ~SPC m c d~ | send knitr/sweave chunk and step to next chunk            |
-
-* Options
-To turn off the automatic replacement of underscores by =<-=, set in your
-=~/.spacemacs=:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-disable-underscore-assign t)))
-#+END_SRC
-
-Alternatively you may enable =ess-smart-equals=, which also disables replacement
-of underscores by =<-=, and additionally replace the equals sign with =<-= when
-appropriate:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-enable-smart-equals t)))
-#+END_SRC

--- a/layers/+lang/gpu/README.org
+++ b/layers/+lang/gpu/README.org
@@ -4,27 +4,37 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
-This layer provides support for GPU related languages like shading and computing languages.
-This includes files ending in:
-- =.cl= (OpenCL)
-- =.cu= (CUDA)
-- =.cuh= (CUDA)
-- =.fsh= (Shaders)
-- =.vsh= (Shaders)
-- =.glsl= (Shaders)
-- =.vert= (Shaders)
-- =.frag= (Shaders)
-- =.geom= (Shaders)
--
-Also this layer provides completion for =.vert=, =.tesc=, =.tese=, =.geom=,
-=.frag= and =.comp= shaders via =company-glsl= when [[https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/][=glslangValidator=]] can be
-found on your system and =auto-completion= layer is enabled. Note that
-completion is [[https://github.com/Kaali/company-glsl][rather simple]].
+This layer adds support for GPU related languages like CUDA, OpenCL and various Shader formats to Spacemacs.
+
+** Features:
+- Syntax highlighting for
+  - =.cl= (OpenCL)
+  - =.cu= (CUDA)
+  - =.cuh= (CUDA)
+  - =.fsh= (Shaders)
+  - =.vsh= (Shaders)
+  - =.glsl= (Shaders)
+  - =.vert= (Shaders)
+  - =.frag= (Shaders)
+  - =.comp= (Shaders)
+  - =.geom= (Shaders)
+  - =.tesc= (Shaders)
+  - =.tese= (Shaders)
+- Simple auto-completion via [[https://github.com/Kaali/company-glsl][company-glsl]] for
+  - =.vert= (Shaders)
+  - =.geom= (Shaders)
+  - =.tesc= (Shaders)
+  - =.tese= (Shaders)
+  - =.frag= (Shaders)
+  - =.comp= (Shaders)
 
 * Install
 To use this configuration layer, add it to your =~.spacemacs=. You will need to
 add =gpu= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+For auto-completion you will also need to install [[https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/][=glslangValidator=]].

--- a/layers/+vim/vim-empty-lines/README.org
+++ b/layers/+vim/vim-empty-lines/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
@@ -14,6 +15,10 @@ overlaid in within the buffer as in =vim=, and not in the fringe. The indicator
 behaviour with trailing empty lines matches =vim='s behaviour.
 
 For details, see the [[https://github.com/jmickelin/vim-empty-lines-mode][vim-empty-lines-mode]] repository.
+
+** Features:
+- Emulation of original vim behaviour.
+- Brings you as close to vim as one can be without using vim itself.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
Fixed documentation for erlang, gpu, ess and vim-empty-lines layers.
This is part of #9476.