### PR TITLE
treemacs: bind M-0 to treemacs window selection.

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -76,4 +76,4 @@
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum
     :post-config
-    (add-to-list 'winum-assign-functions #'treemacs--window-number-ten)))
+    (define-key winum-keymap (kbd "M-0") #'treemacs-select-window)))


### PR DESCRIPTION
Since treemacs supports multiple frames simply giving it a static number is no longer possible. It used to receive window 10, so now M-0 is rebound to directly select treemacs, such that there won't be any de facto change in the keybinds.
When this is merged I'll push a change to treemacs that will add its buffers to winum's ignore list.

This will be another fix for https://github.com/syl20bnr/spacemacs/issues/9798#