### PR TITLE
Add evilification of mini-buffer, including helm

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -174,6 +174,19 @@ Example: (evil-map visual \"<\" \"<gv\")"
     (cl-loop for (mode uni nouni) in spacemacs--diminished-minor-modes
              do (diminish mode (if unicodep uni nouni)))))
 
+(defun spacemacs//evil-minibuffer-insert ()
+  "Switch to insert state.
+This function is meant to be hooked in the minibuffer:
+  (add-hook 'minibuffer-setup-hook 'evil-collection-minibuffer-insert)
+`evil-set-initial-state' can not be used for the minibuffer since
+it does not have a mode."
+  (set (make-local-variable 'evil-echo-state) nil)
+  ;; (evil-set-initial-state 'mode 'insert) is the evil-proper
+  ;; way to do this, but the minibuffer doesn't have a mode.
+  ;; The alternative is to create a minibuffer mode (here), but
+  ;; then it may conflict with other packages' if they do the same.
+  (evil-insert 1))
+
 
 
 (defun spacemacs//hydra-key-doc-function (key key-width doc doc-width)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -270,7 +270,31 @@
 
   ;; ignore repeat
   (evil-declare-ignore-repeat 'spacemacs/next-error)
-  (evil-declare-ignore-repeat 'spacemacs/previous-error))
+  (evil-declare-ignore-repeat 'spacemacs/previous-error)
+
+  ;; setup evil-minibuffer
+  ;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Text-from-Minibuffer.html
+  ;; WARNING: With lexical binding, lambdas from `mapc' and `dolist' become
+  ;; closures in which we must use `evil-define-key*' instead of
+  ;; `evil-define-key'.
+  (dolist (map (list minibuffer-local-map
+                     minibuffer-local-ns-map
+                     minibuffer-local-completion-map
+                     minibuffer-local-must-match-map
+                     minibuffer-local-isearch-map))
+    (evil-define-key* 'normal map (kbd "<escape>") 'abort-recursive-edit)
+    (evil-define-key* 'normal map (kbd "<return>") 'exit-minibuffer)
+    ;; C-r and C-s to search forward/backward are important in minibuffer
+    (evil-define-key* 'insert map (kbd "C-r") 'isearch-backward)
+    (evil-define-key* 'insert map (kbd "C-s") 'isearch-forward))
+
+  (add-hook 'minibuffer-setup-hook 'spacemacs//evil-minibuffer-insert)
+  ;; Because of the above minibuffer-setup-hook, some evil-ex bindings need be reset.
+  (evil-define-key 'normal evil-ex-completion-map (kbd "<escape>") 'abort-recursive-edit)
+  (evil-define-key 'insert evil-ex-completion-map (kbd "C-p") 'previous-complete-history-element)
+  (evil-define-key 'insert evil-ex-completion-map (kbd "C-n") 'next-complete-history-element)
+  (evil-define-key 'normal evil-ex-completion-map (kbd "C-p") 'previous-history-element)
+  (evil-define-key 'normal evil-ex-completion-map (kbd "C-n") 'next-history-element))
 
 (defun spacemacs-bootstrap/init-hydra ()
   (require 'hydra)

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -94,7 +94,9 @@
         (define-key keymap (kbd "C-l") 'helm-execute-persistent-action)
         (define-key keymap (kbd "C-h") 'helm-find-files-up-one-level)
         ;; rebind `describe-key' for convenience
-        (define-key keymap (kbd "C-S-h") 'describe-key))))
+        (define-key keymap (kbd "C-S-h") 'describe-key)))
+    ;; Rebind C-k in minibuffer map; conflict with evil minibuffer
+    (evil-define-key 'insert helm-map (kbd "C-k") 'helm-previous-line))
    (t
     (define-key helm-map (kbd "C-j") 'helm-execute-persistent-action)
     (define-key helm-map (kbd "C-k") 'helm-delete-minibuffer-contents)


### PR DESCRIPTION
This PR should not be merged as is. It's more of a starting point to discuss what's possible. It introduces evil state to the mini buffer. It works very well, in ivy as well (from the little I tested it). In helm however there are a few issues. One issue in both helm and the minibuffer generally is that some important bindings get overwritten. In particular, C-k in helm, and C-r in the normal minibuffer which are both pretty crucial. I restore these, but there may be other important bindings we want to restore.

The more serious issue is that while everything works in helm, there's a pretty annoying visual glitch, where the cursor is shown both in the place you type, and at the bottom where the mini buffer usually is. Ideally, we would resolve this issue, or at least minimize it reasonably. Failing that, we could simply disable the evilifcation of helm, though that's a real shame considering it actually works quite well (visual glitchiness aside).