### PR TITLE
auto-completion: add yasnippet-snippets

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -21,6 +21,7 @@
         (helm-c-yasnippet :requires helm)
         hippie-exp
         yasnippet
+        yasnippet-snippets
         auto-yasnippet
         smartparens
         ))
@@ -173,6 +174,8 @@
   (when (configuration-layer/package-used-p 'yasnippet)
     ;; Try to expand yasnippet snippets based on prefix
     (push 'yas-hippie-try-expand hippie-expand-try-functions-list)))
+
+(defun auto-completion/init-yasnippet-snippets ())
 
 (defun auto-completion/init-yasnippet ()
   (use-package yasnippet


### PR DESCRIPTION
`yasnippet` is no longer bundled with any snippets as of https://github.com/joaotavora/yasnippet/commit/b1ca2197062340d4c9e78442ea38957a96f968d4. Snippets have all been moved to a separate package `yasnippet-snippets` (https://github.com/AndreaCrotti/yasnippet-snippets). This change means that all the snippets previously available with auto-completion layer are gone. This PR adds these snippets back by adding the `yasnippet-snippets` package to auto-completion layer.

Note `yasnippet-snippets` does not need to be initialized with `use-package`; simply installing it and putting it in the load-path is enough for `yasnippet` to find the snippets.