### PR TITLE
spacemacs-layouts: fix S/ivy-persp-switch-project

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -14,7 +14,7 @@
         auto-highlight-symbol
         bookmark
         counsel
-        (counsel-projectile :requires projectile)
+        counsel-projectile
         evil
         flx
         helm-make
@@ -153,8 +153,6 @@
         "pd"    'counsel-projectile-find-dir
         "pp"    'counsel-projectile-switch-project
         "pf"    'counsel-projectile-find-file))))
-(defun ivy/init-counsel-projectile ()
-  (use-package counsel-projectile :defer t))
 
 (defun ivy/post-init-evil ()
   (spacemacs/set-leader-keys

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -409,24 +409,17 @@ perspectives does."
 
 ;; Ivy integration
 
-(defun spacemacs/ivy-persp-switch-project-advice (project)
-  (let ((persp-reset-windows-on-nil-window-conf t))
-    (persp-switch project)))
-
 (defun spacemacs/ivy-persp-switch-project (arg)
   (interactive "P")
-  (advice-add 'counsel-projectile-switch-project-action
-              :before #'spacemacs/ivy-persp-switch-project-advice)
+  (require 'counsel-projectile)
   (ivy-read "Switch to Project Perspective: "
             (if (projectile-project-p)
                 (cons (abbreviate-file-name (projectile-project-root))
                       (projectile-relevant-known-projects))
               projectile-known-projects)
-            :action #'counsel-projectile-switch-project-action
+            :action counsel-projectile-switch-project-action
             :require-match t
-            :caller 'spacemacs/ivy-persp-switch-project)
-  (advice-remove 'counsel-projectile-switch-project-action
-                 'spacemacs/ivy-persp-switch-project-advice))
+            :caller 'spacemacs/ivy-persp-switch-project))
 
 
 ;; Eyebrowse

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -15,7 +15,7 @@
         ivy
         persp-mode
         spaceline
-        swiper))
+        (counsel-projectile :requires projectile)))
 
 
 
@@ -238,6 +238,7 @@
 
 
 
-(defun spacemacs-layouts/post-init-swiper ()
-  (ivy-set-actions 'spacemacs/ivy-persp-switch-project counsel-projectile-switch-project-actions)
-  (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project))
+(defun spacemacs-layouts/init-counsel-projectile ()
+  (use-package counsel-projectile
+    :defer t
+    :init (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)))


### PR DESCRIPTION
Fix #10177

`counsel-projectile` has [updated custom actions mechanism](https://github.com/ericdanan/counsel-projectile/commit/a4e9a34d7f040a8e4f50b45537ffe211e676bd6d) and
`counsel-projectile-switch-project-actions` is no more defined

Also,
 - moved `counsel-projectile` into `spacemacs-layouts` from `ivy` layer as
 perspective/layout based project switching depends on it instead of `swiper`
 - removed `swiper` from `spacemacs-layouts`