### PR TITLE
c-c++: Unquote google-set-c-style layer variables

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -253,8 +253,8 @@
   (use-package google-c-style
     :if (or 'c-c++-enable-google-style 'c-c++-enable-google-newline)
     :config (progn
-    (when 'c-c++-enable-google-style (add-hook 'c-mode-common-hook 'google-set-c-style))
-    (when 'c-c++-enable-google-newline (add-hook 'c-mode-common-hook 'google-make-newline-indent)))))
+    (when c-c++-enable-google-style (add-hook 'c-mode-common-hook 'google-set-c-style))
+    (when c-c++-enable-google-newline (add-hook 'c-mode-common-hook 'google-make-newline-indent)))))
 
 (defun c-c++/post-init-semantic ()
   (spacemacs/add-to-hooks 'semantic-mode c-c++-mode-hooks))


### PR DESCRIPTION
The google-set-c-style functions are added to `c-mode-common-hook`
regardless of their value.

Fix #10080

So there's not much to say about this besides the commit message. Due to my `elisp` inexperience ignorance I apologize for any unforeseen dangers this may cause. It does seem to clean up my `c-mode-common-hook` as intended though.