### PR TITLE
Add nim-mode documentation binding

### DIFF
--- a/layers/+lang/nim/README.org
+++ b/layers/+lang/nim/README.org
@@ -35,4 +35,5 @@ and =nimsuggest= binary must be in $PATH.
 | ~SPC m c r~          | =nim compile --run main.nim= |
 | ~SPC m g g~ or ~M-.~ | Jump to definition           |
 | ~SPC m g b~ or ~M-,~ | Jump back                    |
+| ~SPC m h h~          | Show symbol's documentation  |
 |----------------------+------------------------------|

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -31,4 +31,5 @@
 
       (spacemacs/set-leader-keys-for-major-mode 'nim-mode
         "cr" 'spacemacs/nim-compile-run
-        "gb" 'pop-tag-mark))))
+        "gb" 'pop-tag-mark
+        "hh" 'nimsuggest-show-doc))))


### PR DESCRIPTION
Bind `nimsuggest-show-doc` under `SPC m h h`.

This is required for quick documentation lookup via `spacemacs/evil-smart-doc-lookup`.