### PR TITLE
Fix completely broken helm

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -104,7 +104,7 @@
 
 ;; Helm Window position
 
-(defun spacemacs//display-helm-window (buffer)
+(defun spacemacs//display-helm-window (buffer &optional resume)
   "Display the Helm window respecting `helm-position'."
   (let ((display-buffer-alist
          (list spacemacs-helm-display-help-buffer-regexp


### PR DESCRIPTION
All helm commands break with the following error as of the most recent update:
```
helm-display-buffer: Wrong number of arguments: (lambda (buffer) "Display the Helm window respecting `helm-position'." (let ((display-buffer-alist (list spacemacs-helm-display-help-buffer-regexp spacemacs-helm-display-buffer-regexp))) (helm-default-display-buffer buffer))), 2
```
This affects helm-find-files, helm-M-x, etc., and is due to this upstream commit: https://github.com/emacs-helm/helm/commit/97020d189f1b4e0220e6ba50532d99b1d18ad14c

This PR provides a quick fix so that helm works as before, by adding a dummy second argument to  `spacemacs//display-helm-window`.

The reason is that helm has changed the signature of `helm-display-buffer` to have 2 arguments. However, spacemacs overrides `helm-display-buffer` with `spacemacs//display-helm-window` which only takes 1 argument. So when helm tries to call `helm-display-buffer` there is wrong number of arguments.