### PR TITLE
Revert ess REPL bindings to follow CONVENTIONS.org

### DIFF
--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -92,16 +92,16 @@
         "ss" 'ess-switch-to-inferior-or-script-buffer
         "sS" 'ess-switch-process
         ;; REPL
-        "sb" 'ess-eval-buffer-and-go
-        "eb" 'ess-eval-buffer
+        "sB" 'ess-eval-buffer-and-go
+        "sb" 'ess-eval-buffer
         "sd" 'ess-eval-region-or-line-and-step
         "sD" 'ess-eval-function-or-paragraph-and-step
-        "sl" 'ess-eval-line-and-go
-        "el" 'ess-eval-line
-        "sr" 'ess-eval-region-and-go
-        "er" 'ess-eval-region
-        "sf" 'ess-eval-function-and-go
-        "ef" 'ess-eval-function
+        "sL" 'ess-eval-line-and-go
+        "sl" 'ess-eval-line
+        "sR" 'ess-eval-region-and-go
+        "sr" 'ess-eval-region
+        "sF" 'ess-eval-function-and-go
+        "sf" 'ess-eval-function
         ;; predefined keymaps
         "h" 'ess-doc-map
         "r" 'ess-extra-map


### PR DESCRIPTION
A couple of recent PRs (see https://github.com/syl20bnr/spacemacs/issues/9096) added many useful keybindings to ess layer, but also modified existing REPL keybindings so they no longer follow CONVENTIONS.org. This PR reverts the offending bindings to follow the spacemacs conventions.

More specifically, "evaluate buffer and switch focus to REPL" was moved from `SPC m s B` to `SPC m s b`, while "evaluate buffer without switching focus" was moved from `SPC m s b` to `SPC m e b`. Similarly, `SPC m s r/R` was moved to `SPC m e/s r`, etc.

In the discussion linked above there seems to be some confusion about whether functions like `ess-eval-buffer` should be for "Evaluation" or "REPL" (they have different bindings in CONVENTIONS.org). However, `ess-eval-buffer` is exactly equivalent to `python-shell-send-buffer` in python layer which is mapped to `SPC m s b`. Likewise for the other "evaluation" commands such as `ess-eval-region`, etc. So I think for the sake of maintaining consistency across layers we should revert these bindings.