### PR TITLE
layers/+spacemacs/spacemacs-completion/funcs.el: fix helm breakage

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -104,7 +104,7 @@
 
 ;; Helm Window position
 
-(defun spacemacs//display-helm-window (buffer)
+(defun spacemacs//display-helm-window (buffer &optional _resume)
   "Display the Helm window respecting `helm-position'."
   (let ((display-buffer-alist
          (list spacemacs-helm-display-help-buffer-regexp


### PR DESCRIPTION
A recent change in helm broke spacemacs helm integration. It was
caused by  https://github.com/emacs-helm/helm/issues/1951 where an
additional `_resume` parameter may now be passed to
`helm-display-function`.