### PR TITLE
Clojure connection browser: add key bindings

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -31,6 +31,7 @@
     - [[#stacktrace-mode][stacktrace-mode]]
     - [[#inspector-mode][inspector-mode]]
     - [[#test-report-mode][test-report-mode]]
+    - [[#cider-connection-browser][cider-connection-browser]]
   - [[#sayid-buffers][Sayid Buffers]]
     - [[#sayid-mode][sayid-mode]]
     - [[#sayid-traced-mode][sayid-traced-mode]]
@@ -380,6 +381,15 @@ In general, ~q~ should always quit the popped up buffer.
 | ~r~         | rerun failed tests |
 | ~t~         | run test           |
 | ~T~         | run tests          |
+
+*** cider-connection-browser
+
+| Key Binding | Description                 |
+|-------------+-----------------------------|
+| ~SPC m k~   | close connection            |
+| ~SPC m RET~ | go to connection            |
+| ~SPC m d~   | make connection the default |
+| ~SPC m g~   | refresh                     |
 
 ** Sayid Buffers
 *** sayid-mode

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -217,7 +217,15 @@
 
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)
-        (clojure/fancify-symbols 'cider-clojure-interaction-mode)))
+        (clojure/fancify-symbols 'cider-clojure-interaction-mode))
+
+      (spacemacs/set-leader-keys-for-major-mode 'cider-connections-buffer-mode
+        "RET" 'cider-connections-goto-connection
+        "?"   'describe-mode
+        "d"   'cider-connections-make-default
+        "g"   'cider-connection-browser
+        "h"   'describe-mode
+        "k"   'cider-connections-close-connection))
 
     (defadvice cider-jump-to-var (before add-evil-jump activate)
       (evil-set-jump))))


### PR DESCRIPTION
The functionality of cider-connection-browser (e.g. "k" for "kill connection")
was being shadowed by evil's default key bindings ("k" for "previous line").
Instead this adds leader key (`SPC m` / `,`) mappings when inside the connection
browser (`cider-connections-buffer-mode`).

This is my first contribution to Spacemacs so not sure if I'm doing this The Right Way™. Feedback welcome! Thanks.