### PR TITLE
Add +tools/lsp layer for lsp-mode & lsp-ui

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -1,0 +1,33 @@
+#+TITLE: LSP layer
+
+* Table of Contents                      :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#configuration][Configuration]]
+
+* Description
+This layer adds support for basic language server protocol packages speaking [[https://microsoft.github.io/language-server-protocol/specification][language server protocol]].
+
+** Features:
+- Cross references (definitions, references, document symbol, workspace symbol search and others)
+- Workspace-wide symbol rename
+- Symbol highlighting
+- Flycheck
+- Completion with =company-lsp=
+- Signature help with eldoc
+- Symbol documentation in a child frame (=lsp-ui-doc=)
+
+Each language server may support the language server protocol in varying degree and they may also provide extensions, check the language server's website for details.
+=M-x lsp-capabilities= in a LSP buffer to list capabilities of the server.
+
+* Configuration
+The LSP ecosystem is based on two packages: [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] and [[https://github.com/emacs-lsp/lsp-ui][lsp-ui]].
+Please check out their documentation.
+
+If you add =lsp-*-enable= to major mode hooks for auto initialization of language clients, customize =lsp-project-whitelist= =lsp-project-blacklist= to disable projects you don't want to enable LSP.
+
+If some features doe not work as intended, here is a common check list.
+
+- =M-x lsp-capabilities= If the LSP workspace is initialized correctly
+- =M-: xref-backend-functions= should be =(lsp--xref-backend)= for cross references
+- =M-: completion-at-point-functions= should be =(lsp-completion-at-point)= for completion

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -1,0 +1,19 @@
+(defun lsp//sync-peek-face ()
+  "Synchronize the face used in lsp-ui peek window according to the theme."
+  (set-face-attribute 'lsp-ui-peek-list nil
+                      :background (face-attribute 'hl-line :background nil t))
+  (set-face-attribute 'lsp-ui-peek-peek nil
+                      :background (face-attribute 'hl-line :background nil t))
+  (set-face-attribute 'lsp-ui-peek-selection nil
+                      :background (face-attribute 'highlight :background nil t)
+                      :foreground (face-attribute 'default :foreground nil t))
+  (set-face-attribute 'lsp-ui-peek-filename nil
+                      :foreground (face-attribute 'font-lock-constant-face :foreground nil t))
+  (set-face-attribute 'lsp-ui-peek-highlight nil
+                      :background (face-attribute 'highlight :background nil t)
+                      :foreground (face-attribute 'highlight :foreground nil t)
+                      :distant-foreground (face-attribute 'highlight :foreground nil t))
+  (set-face-attribute 'lsp-ui-peek-header nil
+                      :background (face-attribute 'highlight :background nil t)
+                      :foreground (face-attribute 'default :foreground nil t))
+  )

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -1,0 +1,67 @@
+(defconst lsp-packages
+  '(
+    (company-lsp :requires company)
+    (helm-xref :requires helm)
+    (ivy-xref :requires ivy)
+    lsp-mode
+    lsp-ui
+    ))
+
+(defun lsp/init-company-lsp ()
+  (use-package company-lsp
+    :defer t
+    :init
+    ;; Language servers have better idea filtering and sorting,
+    ;; don't filter results on the client side.
+    (setq company-transformers nil
+          company-lsp-async t
+          company-lsp-cache-candidates nil)
+    ;; (spacemacs|add-company-backends :backends company-lsp :modes c-mode-common)
+    ))
+
+(defun lsp/init-helm-xref ()
+  (use-package helm-xref
+    :defer t
+    :init
+    (progn
+      ;; This is required to make xref-find-references not give a prompt.
+      ;; xref-find-references asks the identifier (which has no text property) and then passes it to lsp-mode, which requires the text property at point to locate the references.
+      ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=29619
+      (setq xref-prompt-for-identifier
+            '(not xref-find-definitions xref-find-definitions-other-window xref-find-definitions-other-frame xref-find-references spacemacs/jump-to-definition))
+
+      ;; Use helm-xref to display xref.el results.
+      (setq xref-show-xrefs-function #'helm-xref-show-xrefs)
+      )))
+
+(defun lsp/init-ivy-xref ()
+  (use-package ivy-xref
+    :defer t
+    :init
+    (progn
+      (setq xref-prompt-for-identifier
+            '(not xref-find-definitions xref-find-definitions-other-window xref-find-definitions-other-frame xref-find-references spacemacs/jump-to-definition))
+
+      ;; Use ivy-xref to display xref.el results.
+      (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
+      )))
+
+(defun lsp/init-lsp-mode ()
+  (use-package lsp-mode
+    :config
+    (progn
+      (add-hook 'lsp-mode-hook #'lsp-ui-mode)
+
+      ;; Disable lsp-flycheck.el in favor of lsp-ui-flycheck.el
+      (setq lsp-enable-flycheck nil)
+
+      (spacemacs|diminish lsp-mode " Ⓛ" " L")
+      )))
+
+(defun lsp/init-lsp-ui ()
+  (use-package lsp-ui
+    :config
+    (progn
+      (lsp//sync-peek-face)
+      (add-hook 'spacemacs-post-theme-change-hook #'lsp//sync-peek-face)
+      )))


### PR DESCRIPTION
This is a starting point to bring LSP ecosystem into spacemacs, as the initial step to address https://github.com/syl20bnr/spacemacs/issues/10134

This PR adds a new layer, without changing anything default, so it is safe to merge. Based on it, we can integrate [lsp-rust](https://github.com/emacs-lsp/lsp-rust) [lsp-haskell](https://github.com/emacs-lsp/lsp-haskell)+[haskell-ide-engine](https://github.com/haskell/haskell-ide-engine) and many others.

I recently raised a [topic about C++ language server on Reddit](https://www.reddit.com/r/emacs/comments/7qyl39/c_language_server_cquery/). Many Emacs users expressed their interests. I am certainly confident this lsp + cquery combo works brilliantly well (refer to the Wiki [definition/references](https://github.com/jacobdufault/cquery/wiki/Emacs#find-definitionsreferences) and [other cross references and fancy use of definition/references](https://github.com/jacobdufault/cquery/wiki/FAQ#cqueryvars). But they also complain that LSP toolchain is difficult to set up. spacemacs is definitely a best place to collect these fragments and make the code navigation experience wonderful.

I also hope you appreciate references and other types of cross references as much as you do to find-definition https://github.com/syl20bnr/spacemacs/pull/9911  The C++ language server [cquery](https://github.com/jacobdufault/cquery/wiki/Emacs#find-definitionsreferences) I am working on has some nice features. I'd also like to add a cquery layer based on this, after [cquery.el is integrated into Melpa](https://github.com/melpa/melpa/pull/5235).

My elisp-fu is still too shabby to push forward everything. I'm seeking help from you.