### PR TITLE
Add gtags to enh-ruby-mode as well as ruby-mode

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -87,13 +87,16 @@
   (spacemacs/enable-flycheck 'enh-ruby-mode))
 
 (defun ruby/post-init-ggtags ()
-  (add-hook 'ruby-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+  (spacemacs/add-to-hooks 'spacemacs/ggtags-mode-enable
+                          '(ruby-mode-local-vars-hook
+                            enh-ruby-mode-local-vars-hook)))
 
 (defun ruby/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'ruby-mode))
 
 (defun ruby/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'ruby-mode))
+  (dolist (mode '(ruby-mode enh-ruby-mode))
+    (spacemacs/helm-gtags-define-keys-for-mode mode)))
 
 (defun ruby/init-minitest ()
   (use-package minitest


### PR DESCRIPTION
gtags is not getting initialized in enh-ruby-mode. This PR fixes that. Thanks!