### PR TITLE
Adds magit-diff-buffer-file-popup key

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -106,7 +106,7 @@ Git commands (start with ~g~):
 |-------------+-----------------------------------------------------|
 | ~SPC g b~   | open a =magit= blame                                |
 | ~SPC g f f~ | view a file at a specific branch or commit          |
-| ~SPC g f h~ | show file commits history                           |
+| ~SPC g f l~ | commits log for current file                        |
 | ~SPC g H c~ | clear highlights                                    |
 | ~SPC g H h~ | highlight regions by age of commits                 |
 | ~SPC g H t~ | highlight regions by last updated time              |

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -107,6 +107,7 @@ Git commands (start with ~g~):
 | ~SPC g b~   | open a =magit= blame                                |
 | ~SPC g f f~ | view a file at a specific branch or commit          |
 | ~SPC g f l~ | commits log for current file                        |
+| ~SPC g f d~ | diff commands for current file                      |
 | ~SPC g H c~ | clear highlights                                    |
 | ~SPC g H h~ | highlight regions by age of commits                 |
 | ~SPC g H t~ | highlight regions by last updated time              |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -136,7 +136,7 @@
         "gb"  'spacemacs/git-blame-micro-state
         "gc"  'magit-clone
         "gff" 'magit-find-file
-        "gfh" 'magit-log-buffer-file
+        "gfl" 'magit-log-buffer-file
         "gi"  'magit-init
         "gL"  'magit-list-repositories
         "gm"  'magit-dispatch-popup

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -137,6 +137,7 @@
         "gc"  'magit-clone
         "gff" 'magit-find-file
         "gfl" 'magit-log-buffer-file
+        "gfd" 'magit-diff-buffer-file-popup
         "gi"  'magit-init
         "gL"  'magit-list-repositories
         "gm"  'magit-dispatch-popup


### PR DESCRIPTION
Sorry for a minuscule PR, this keybinding I think makes sense. ~I also tried to update layer's readme, but there's no section on `g f` keybindings. I wasn't sure where to add one~.

and while we're at it, can we please consider changing `g f h` to `g f l` maybe?