### PR TITLE
mu4e: Fix major-mode leader-key bindings

### DIFF
--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -30,5 +30,9 @@
 (defvar mu4e-use-maildirs-extension nil
   "Use mu4e-maildirs-extension package if value is non-nil.")
 
+(defvar mu4e-modes
+  '(mu4e-main-mode mu4e-headers-mode mu4e-view-mode mu4e-compose-mode)
+  "Modes that are associated with mu4e buffers.")
+
 (when mu4e-installation-path
   (push mu4e-installation-path load-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -129,10 +129,7 @@
 (defun mu4e/init-helm-mu ()
   (use-package helm-mu
     :defer t
-    :init (dolist (m '(mu4e-main-mode-hook
-                       mu4e-headers-mode-hook
-                       mu4e-view-mode-hook
-                       mu4e-compose-mode-hook))
+    :init (dolist (m mu4e-modes)
             (spacemacs/set-leader-keys-for-major-mode m
               "S" 'helm-mu
               "/" 'helm-mu


### PR DESCRIPTION
Instead of specifying `mu4e-foo-mode-hook` to `spacemacs/set-leader-keys-for-major-mode`, specify `mu4e-foo-mode`.