### PR TITLE
ess: add updated keybindings to readme

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -66,22 +66,22 @@ Send code to inferior process with these commands:
 
 | Key Binding | Description                                          |
 |-------------+------------------------------------------------------|
-| ~SPC m '~   | start REPL                                           |
+| ~SPC m '​~   | start REPL                                           |
 | ~SPC m s i~ | start REPL                                           |
 | ~SPC m s s~ | switch between file and REPL                         |
 | ~SPC m s S~ | switch the process associate with file               |
-| ~SPC m ,~   | send region, current function, or paragraph and step |
+| ~SPC m ,​~   | send region, current function, or paragraph and step |
 |-------------+------------------------------------------------------|
-| ~SPC m s b~ | send buffer and switch to REPL in insert mode        |
-| ~SPC m e b~ | send buffer and keep code buffer focused             |
+| ~SPC m s b~ | send buffer and keep code buffer focused             |
+| ~SPC m s B~ | send buffer and switch to REPL in insert mode        |
 | ~SPC m s d~ | send region or line and step                         |
 | ~SPC m s D~ | send function or paragraph and step                  |
-| ~SPC m e l~ | send line and keep code buffer focused               |
-| ~SPC m s l~ | send line and focus REPL                             |
-| ~SPC m e r~ | send region and keep code buffer focused             |
-| ~SPC m s r~ | send region and focus REPL                           |
-| ~SPC m e f~ | send function and keep code buffer focused           |
-| ~SPC m s f~ | send function and focus REPL                         |
+| ~SPC m s l~ | send line and keep code buffer focused               |
+| ~SPC m s L~ | send line and focus REPL                             |
+| ~SPC m s r~ | send region and keep code buffer focused             |
+| ~SPC m s R~ | send region and focus REPL                           |
+| ~SPC m s f~ | send function and keep code buffer focused           |
+| ~SPC m s F~ | send function and focus REPL                         |
 
 ** Help
 Get help and helpers for inspecting objects at point are available in R buffers only.

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -78,7 +78,6 @@
     (define-key ess-doc-map "t" 'ess-R-dv-ctable)
     (dolist (mode '(ess-julia-mode ess-mode))
       (spacemacs/declare-prefix-for-mode mode "ms" "repl")
-      (spacemacs/declare-prefix-for-mode mode "me" "eval")
       (spacemacs/declare-prefix-for-mode mode "mh" "help")
       (spacemacs/declare-prefix-for-mode mode "mr" "extra")
       (spacemacs/declare-prefix-for-mode mode "mw" "pkg")


### PR DESCRIPTION
I submitted a PR to fix some keybindings in ess layer the other day (https://github.com/syl20bnr/spacemacs/pull/10200) but forgot to update the Readme. Sorry about that! Here is a second PR to fix it.

(Second attempt for this PR, I messed up my first attempt https://github.com/syl20bnr/spacemacs/pull/10221)