### PR TITLE
clojure: Enable safe structural editing for cljs and cljc

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -313,7 +313,11 @@
 (defun clojure/pre-init-evil-cleverparens ()
   (spacemacs|use-package-add-hook evil-cleverparens
     :pre-init
-    (add-to-list 'evil-lisp-safe-structural-editing-modes 'clojure-mode)))
+    (dolist (m '(clojure-mode
+                 clojurec-mode
+                 clojurescript-mode
+                 clojurex-mode))
+      (add-to-list 'evil-lisp-safe-structural-editing-modes m))))
 
 (defun clojure/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin


### PR DESCRIPTION
`evil-lisp-safe-structural-editing-modes` was introduced in https://github.com/syl20bnr/spacemacs/commit/2cb98447afa3230d579d349b42e03c23017f43f5#diff-43a23dbec19deb02144c5310368c065e for `clojure-mode` only.

`clojurescript-mode` and `clojurec-mode` are variants of `clojure-mode` used for .cljs and .cljc files
respectively, which should always be balanced and thus have safe structural
editing enabled.

This is my first PR here. Feedback very welcome!
