### PR TITLE
Make nimsuggest-doc-mode-map as overlay

### DIFF
--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -25,6 +25,8 @@
       (push 'nimsuggest-find-definition spacemacs-jump-handlers-nim-mode))
     :config
     (progn
+      (evil-make-intercept-map nimsuggest-doc-mode-map)
+
       (defun spacemacs/nim-compile-run ()
         (interactive)
         (shell-command "nim compile --run main.nim"))


### PR DESCRIPTION
Raise the `nimsuggest-doc-mode-map` to overlay map priority.

This is a special-mode map, which only appears in Nim quick documentation buffers and should have overlay bindings.