### PR TITLE
Regression fix: Allow new project perspectives

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -418,7 +418,6 @@ perspectives does."
                       (projectile-relevant-known-projects))
               projectile-known-projects)
             :action counsel-projectile-switch-project-action
-            :require-match t
             :caller 'spacemacs/ivy-persp-switch-project))
 
 


### PR DESCRIPTION
Before the commit https://github.com/syl20bnr/spacemacs/commit/4b111f7701ffea8e724666471a64867fe0c7af22 it was possible to create new perspectives from projects not available on the list.

It would be possible to provide a path to a project that has not been open previously by emacs, and have the perspective created. Now that a match is required, it is not possible anymore, as the path provided is not one of the possible matches on the list.

This commit changes the behavior back to allow accessing projects that have not been visited before. Without this change, one needs to open a specific project first, using `C-x C-e` or `SPC f f` and then switch to the layout.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3