### PR TITLE
Add shell-default-width configuration option for left/right side

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -55,17 +55,25 @@ to the following variables:
 
 The default shell is quickly accessible via a the default shortcut key ~SPC '​~.
 
-** Default shell position and height
+** Default shell position, width, and height
 It is possible to choose where the shell should pop up by setting the variable
 =shell-default-position= to either =top=, =bottom=, =left=, =right=, or =full=.
 Default value is =bottom=. It is also possible to set the default height in
-percents with the variable =shell-default-height=. Default value is =30=.
+percents with the variable =shell-default-height=. Default value is =30=. You
+can also set a default width in percents with the variable
+=shell-default-width=, which has a default value of 30 and will take effect if
+your shell is positioned on the left or the right.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
     '((shell :variables
              shell-default-position 'bottom
              shell-default-height 30)))
+
+  (setq-default dotspacemacs-configuration-layers
+    '((shell :variables
+             shell-default-position 'right
+             shell-default-width 40)))
 #+END_SRC
 
 ** Set shell for term and ansi-term

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -29,6 +29,9 @@
 (defvar shell-default-height 30
   "Height in percents for the shell window.")
 
+(defvar shell-default-width 30
+  "Width in percents for the shell window.")
+
 (defvar shell-default-term-shell shell-file-name
   "Default shell to use in `term' and `ansi-term' shells.")
 

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -48,6 +48,12 @@
                  shell-default-shell)))
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 
+(defun spacemacs/resize-shell-to-desired-width ()
+  (enlarge-window-horizontally (-
+                                (/ (* (frame-width) shell-default-width) 100)
+                                (window-width)))
+)
+
 (defmacro make-shell-pop-command (func &optional shell)
   "Create a function to open a shell via the function FUNC.
 SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
@@ -68,7 +74,8 @@ SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
           (backquote (,name
                       ,(concat "*" name "*")
                       (lambda nil (,func ,shell)))))
-         (shell-pop index)))))
+         (shell-pop index)
+         (spacemacs/resize-shell-to-desired-width)))))
 
 (defun projectile-multi-term-in-root ()
   "Invoke `multi-term' in the project's root."


### PR DESCRIPTION
This adds a `shell-default-width` option to the shell layer, for users that have left/right terminals.

Fixes #9240.