### PR TITLE
Add +tools/cquery layer

### DIFF
--- a/layers/+tools/cquery/README.org
+++ b/layers/+tools/cquery/README.org
@@ -1,0 +1,47 @@
+#+TITLE: cquery layer
+
+* Table of Contents                      :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+  - [[#cquery-server][cquery server]]
+  - [[#layer][Layer]]
+- [[#configuration][Configuration]]
+
+* Description
+This layer adds [[https://github.com/cquery-project/cquery][cquery]] support.
+
+** Features:
+- Cross references (definitions, references, base/derived classes/methods, type instances, ...)
+- Workspace symbol search
+- Workspace-wide symbol rename
+- Diagnostics
+- Completion with =company-lsp=
+- Rainbow semantic highlighting
+- Signature help and documentation
+- Code lens
+- See more on [[https://github.com/cquery-project/cquery/wiki/Emacs]]
+
+Some features are implemented on the server side but not available in the Emacs plugin, e.g. type hierarchy, member hierarchy, call tree.
+
+* Install
+** cquery server
+Install the =cquery= server. [[https://github.com/cquery-project/cquery/wiki/Getting-started][Instructions]].
+
+** Layer
+1) Add =cquery= to the =dotspacemacs-configuration-layers= list in =~/.spacemacs=.
+2)
+   #+BEGIN_SRC emacs-lisp
+   (setq cquery-executable "/path/to/bin/cquery")
+   #+END_SRC emacs-lisp
+   If you need to expand =~= in the path, you can use =file-truename= like
+   #+BEGIN_SRC emacs-lisp
+   (setq cquery-executable (file-truename "~/cquery/build/release/bin/cquery"))
+   #+END_SRC
+
+* Configuration
+cquery needs to know where to store index cache (=cquery-cache-dir=), which defaults to =.cquery_cached_index= in the project root.
+You may change it to an absolute path to have cache from different projects reside in the same directory.
+
+Many behaviors do not have correponding elisp variables and should be tuned via initialization options, such as the number of indexer threads, cache serialization format. They have good default values.
+Refer to [[https://github.com/cquery-project/cquery/wiki/Initialization-options][Initialization options]] and set =cquery-extra-init-params= for more customization.

--- a/layers/+tools/cquery/config.el
+++ b/layers/+tools/cquery/config.el
@@ -1,0 +1,2 @@
+;; See https://github.com/cquery-project/cquery/wiki/Initialization-options
+(defvar cquery-extra-init-params '(:cacheFormat "msgpack"))

--- a/layers/+tools/cquery/funcs.el
+++ b/layers/+tools/cquery/funcs.el
@@ -1,0 +1,4 @@
+(defun cquery//enable ()
+  (condition-case nil
+      (lsp-cquery-enable)
+    (user-error nil)))

--- a/layers/+tools/cquery/layers.el
+++ b/layers/+tools/cquery/layers.el
@@ -1,0 +1,1 @@
+(configuration-layer/declare-layer 'lsp)

--- a/layers/+tools/cquery/packages.el
+++ b/layers/+tools/cquery/packages.el
@@ -1,0 +1,10 @@
+(defconst cquery-packages '((cquery)))
+
+;; See also https://github.com/cquery-project/cquery/wiki/Emacs
+(defun cquery/init-cquery ()
+  (use-package cquery
+    :commands lsp-cquery-enable
+    :init
+    ;; Customize `lsp-project-whitelist' `lsp-project-blacklist' to disable auto initialization.
+    (add-hook 'c-mode-common-hook #'cquery//enable)
+    ))


### PR DESCRIPTION
tl;dr https://github.com/cquery-project/cquery/wiki/Emacs
https://www.reddit.com/r/emacs/comments/806mgw/recent_improvement_of_cquery_and_emacscquery/

[cquery](https://github.com/cquery-project/cquery) is a low-latency language server supporting multi-million line C++ code-bases, powered by libclang.

Since [current c-c++ layer needs cleanup](https://github.com/syl20bnr/spacemacs/issues/10143) and I am not an experienced elisp or spacemacs user, I decide to put it into `+tools/` instead of `+lang/c-c++/`. Another reason doing this is that cquery also supports Objective-C as libclang supports it, though probably with many issues because of the lack of Objective-C users 😜 Anyway, I hope more experienced user can move it into `+lang/c-c++` or elsewhere that is appropriate.

+tools/cquery depends on +tools/lsp, which is added in another PR https://github.com/syl20bnr/spacemacs/pull/10211

![](https://camo.githubusercontent.com/b1c45436d96f046f4fc39f20413d7b2aef5c6c70/68747470733a2f2f707470622e70772f7141574e2e6a7067)