### PR TITLE
core: Revert "Inhibit recentf when inserting startupify lists"

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -889,8 +889,7 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
 
 (defun spacemacs-buffer//do-insert-startupify-lists ()
   "Insert the startup lists in the current buffer."
-  (let ((list-separator "\n\n")
-        (recentf-exclude '((lambda (filename) t))))
+  (let ((list-separator "\n\n"))
     (mapc (lambda (els)
             (let ((el (or (car-safe els) els))
                   (list-size


### PR DESCRIPTION
#### Description :octocat:
`recentf-exclude` set temporarily in `spacemacs-buffer//do-insert-startupify-lists` cause the global `recentf-exclude` become `nil`, which should be set in `spacemacs-base/init-recentf` to avoid some files been recorded as recent files like `~/.emacs.d/.cache/layouts/persp-auto-save`.

Because of the lazy load, `recentf-mode` is loaded when `spacemacs-buffer//do-insert-startupify-lists` call `(recentf-mode)`, so as the global variable `recentf-exclude`, but because the local variable `recentf-exclude` set in `spacemacs-buffer//do-insert-startupify-lists` shadow the global variable (Maybe?), the global variable will be cleaned after `spacemacs-buffer//do-insert-startupify-lists`.

As `spacemacs-buffer//do-insert-startupify-lists` use `recentf-list` to get recent file list, during the function `recentf-exclude` is unused, so just revert the commit.

#### Reproduction guide :beetle:
- Start Emacs
- Press <kbd>SPC q R</kbd>

*Observed behaviour:* :eyes: :broken_heart:
`~/.emacs.d/.cache/layouts/persp-auto-save` was in the first of recent files list and the variable `recentf-exclude` is `nil`.

*Expected behaviour:* :heart: :smile:
Files in `~/.emacs.d/.cache/` shouldn't be display in recent files list, and `recentf-exclude` shouldn't be `nil`, as what `spacemacs-base/init-recentf` do.