### PR TITLE
Add +tools/lsp-python layer

### DIFF
--- a/layers/+tools/lsp-python/README.org
+++ b/layers/+tools/lsp-python/README.org
@@ -1,0 +1,52 @@
+#+TITLE: lsp-python layer
+
+# The maximum height of the logo should be 200 pixels.
+[[img/lsp-python.png]]
+
+# TOC links should be GitHub style anchors.
+* Table of Contents                                        :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+This layer adds support for python mode based on lsp languange server.
+
+** Features:
+  - Autocomplete
+  - Lint
+  - import sorting
+  - REPL
+  - auto formatting
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =lsp-python= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+For the layer to function, you have to install python languange server.
+#+BEGIN_SRC shell
+# mandatory
+pip install python-language-server
+# for import sorting
+pip install pyls-isort
+# for mypy checking
+pip install pyls-mypy
+#+END_SRC
+
+* Key bindings
+
+| Key Binding | Description                    |
+|-------------+--------------------------------|
+| ~SPC m a~   | activate virtual environment   |
+| ~SPC m d~   | deactivate virtual environment |
+| ~SPC m e~   | execute current script         |
+| ~SPC m k~   | kill python interpreter        |
+| ~SPC m r~   | find references                |
+| ~SPC m d~   | find definitions               |
+
+# Use GitHub URLs if you wish to link a Spacemacs documentation file or its heading.
+# Examples:
+# [[https://github.com/syl20bnr/spacemacs/blob/master/doc/VIMUSERS.org#sessions]]
+# [[https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bfun/emoji/README.org][Link to Emoji layer README.org]]
+# If space-doc-mode is enabled, Spacemacs will open a local copy of the linked file.

--- a/layers/+tools/lsp-python/README.org
+++ b/layers/+tools/lsp-python/README.org
@@ -1,5 +1,9 @@
 #+TITLE: lsp-python layer
 
+# The maximum height of the logo should be 200 pixels.
+[[img/lsp-python.png]]
+
+# TOC links should be GitHub style anchors.
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]

--- a/layers/+tools/lsp-python/README.org
+++ b/layers/+tools/lsp-python/README.org
@@ -1,9 +1,5 @@
 #+TITLE: lsp-python layer
 
-# The maximum height of the logo should be 200 pixels.
-[[img/lsp-python.png]]
-
-# TOC links should be GitHub style anchors.
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]

--- a/layers/+tools/lsp-python/config.el
+++ b/layers/+tools/lsp-python/config.el
@@ -1,0 +1,29 @@
+;;; packages.el --- lsp-python layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Yuan Fu <casouri@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+;; install pyls-mypy for mypy check
+;; (defvar python-enable-mypy nil
+;;   "If non-nil, enable mypy syntax checker.")
+
+;; install pyls-isort for import sort
+;; (defvar python-enable-import-sort nil
+;;   "If non-nil, sort import on save.")
+
+(defvar python-enable-format-on-save nil
+  "If non-nil, format by yapf on save")
+
+;; (defcustom lsp-python-server-install-directory
+;;   "~/.emacs.d/lsp-python-server"
+;;   "Installation directory for lsp python server."
+;;   :type 'directory)
+
+(defvar default-python-interpreter "python3")

--- a/layers/+tools/lsp-python/funcs.el
+++ b/layers/+tools/lsp-python/funcs.el
@@ -1,0 +1,56 @@
+;;; packages.el --- lsp-python layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Yuan Fu <casouri@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+;; (defun ensure-lsp-python-server ()
+;;   (unless (file-directory-p lsp-python-server-install-directory)
+;;     (install-lsp-python-server)
+;;     ))
+
+;; (defun install-lsp-python-server ()
+;;   (shell-command-to-string (concat "pip3 install python-language-server --install-option=\"--prefix=\" --target " lsp-python-server-install-directory))
+;;   (when python-enable-mypy
+;;     (shell-command-to-string (concat "pip3 install pyls-mypy --install-option=\"--prefix=\" --target " lsp-python-server-install-directory)))
+;;   (when python-enable-import-sort
+;;     (shell-command-to-string (concat "pip3 install pyls-isort --install-option=\"--prefix=\" --target " lsp-python-server-install-directory)))
+;;   )
+
+
+(defun spacemacs//add-python-format-on-save ()
+  (add-hook 'before-save-hook 'lsp-format-buffer)
+  )
+
+(defun spacemacs/run-current-file-in-python ()
+  (interactive)
+  (unless (member "#<buffer *Python*>" (buffer-list))
+    (run-python))
+  (python-shell-send-file buffer-file-name)
+  (display-buffer "*Python*")
+  )
+
+(defun spacemacs/kill-python-interpreter ()
+  (interactive)
+  (when (member "#<buffer *Python*>" (buffer-list))
+    (kill-buffer "*Python*"))
+  )
+
+;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
+;; from spacemacs python layer
+(defun spacemacs/python-remove-unused-imports()
+  "Use Autoflake to remove unused function"
+  "autoflake --remove-all-unused-imports -i unused_imports.py"
+  (interactive)
+  (if (executable-find "autoflake")
+      (progn
+        (shell-command (format "autoflake --remove-all-unused-imports -i %s"
+                               (shell-quote-argument (buffer-file-name))))
+        (revert-buffer t t t))
+    (message "Error: Cannot find autoflake executable.")))

--- a/layers/+tools/lsp-python/funcs.el
+++ b/layers/+tools/lsp-python/funcs.el
@@ -28,24 +28,16 @@
   (add-hook 'before-save-hook 'lsp-format-buffer)
   )
 
-(defun spacemacs/run-current-file-in-python ()
-  (interactive)
-  (unless (member "#<buffer *Python*>" (buffer-list))
-    (run-python))
-  (python-shell-send-file buffer-file-name)
-  (display-buffer "*Python*")
-  )
-
 (defun spacemacs/kill-python-interpreter ()
   (interactive)
   (when (member "#<buffer *Python*>" (buffer-list))
     (kill-buffer "*Python*"))
   )
 
-;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
+;; from https://www.snip2code.com/snippet/127022/emacs-auto-remove-unused-import-statemen
 ;; from spacemacs python layer
 (defun spacemacs/python-remove-unused-imports()
-  "Use Autoflake to remove unused function"
+  "use autoflake to remove unused function"
   "autoflake --remove-all-unused-imports -i unused_imports.py"
   (interactive)
   (if (executable-find "autoflake")

--- a/layers/+tools/lsp-python/keybindings.el
+++ b/layers/+tools/lsp-python/keybindings.el
@@ -1,0 +1,17 @@
+;;; packages.el --- lsp-python layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Yuan Fu <casouri@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "a") #'pyvenv-activate)
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "d") #'pyvenv-deactivate)
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "e") #'spacemacs/run-current-file-in-python)
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "k") #'spacemacs/kill-python-interpreter)
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "r") #'xref-find-references)
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "d") #'xref-find-definitions)

--- a/layers/+tools/lsp-python/keybindings.el
+++ b/layers/+tools/lsp-python/keybindings.el
@@ -11,7 +11,7 @@
 
 (spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "a") #'pyvenv-activate)
 (spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "d") #'pyvenv-deactivate)
-(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "e") #'spacemacs/run-current-file-in-python)
+(spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "e") #'quickrun)
 (spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "k") #'spacemacs/kill-python-interpreter)
 (spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "r") #'xref-find-references)
 (spacemacs/set-leader-keys-for-major-mode 'python-mode (kbd "d") #'xref-find-definitions)

--- a/layers/+tools/lsp-python/layers.el
+++ b/layers/+tools/lsp-python/layers.el
@@ -1,0 +1,12 @@
+;;; packages.el --- lsp-python layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Yuan Fu <casouri@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(configuration-layer/declare-layer 'lsp)

--- a/layers/+tools/lsp-python/packages.el
+++ b/layers/+tools/lsp-python/packages.el
@@ -1,0 +1,39 @@
+;;; packages.el --- lsp-python layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Yuan Fu <casouri@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst lsp-python-packages
+  '(lsp-python
+    pyvenv
+    ))
+
+(defun lsp-python/init-lsp-python ()
+  (use-package lsp-python
+    :config
+    (progn
+      (add-hook 'python-mode-hook #'flycheck-mode)
+      (add-hook 'python-mode-hook #'lsp-python-enable)
+      (when python-enable-format-on-save
+        (add-hook 'python-mode-hook 'spacemacs//add-python-format-on-save))
+      ;; other python settings
+      ;; (ensure-lsp-python-server)
+      ;; (setenv "PATH"
+      ;;         (concat
+      ;;          lsp-python-server-install-directory ";"
+      ;;          (getenv "PATH")
+      ;;          ))
+    )))
+
+(defun lsp-python/init-pyvenv ()
+  (use-package pyvenv
+    ))
+
+
+;;; packages.el ends here

--- a/layers/+tools/lsp-python/packages.el
+++ b/layers/+tools/lsp-python/packages.el
@@ -12,6 +12,7 @@
 (defconst lsp-python-packages
   '(lsp-python
     pyvenv
+    quickrun
     ))
 
 (defun lsp-python/init-lsp-python ()
@@ -34,6 +35,10 @@
 (defun lsp-python/init-pyvenv ()
   (use-package pyvenv
     ))
+
+(defun lsp-python/init-quickrun ()
+  (use-package quickrun
+    :commands (quickrun)))
 
 
 ;;; packages.el ends here


### PR DESCRIPTION
With ongoing support of lsp layer in #10211, I think I can contribute something to lsp-python layer.
This layer is depend on lsp layer. Because I really just a beginner, python-language-server needs to be installed manually by user using pip. But no other configuration is needed.

The functionality is not as versatile as python layer, but most of the daily functionalities are covered well. Autocompletion, jumping, executing script, doc, etc are all covered.