### PR TITLE
haskell: Add function for proper import reformatting

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -285,6 +285,7 @@ Refactor commands are prefixed by ~SPC m r~:
 | ~SPC m r b~ | apply all HLint suggestions in the current buffer |
 | ~SPC m r r~ | apply the HLint suggestion under the cursor       |
 | ~SPC m r s~ | list all Intero suggestions                       |
+| ~SPC m r i~ | reformat imports from anywhere in the buffer      |
 
 Only some of the HLint suggestions can be applied.
 

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -103,6 +103,16 @@
   (if (fboundp 'electric-indent-local-mode)
       (electric-indent-local-mode -1)))
 
+
+(defun spacemacs-haskell//format-imports ()
+  "Sort and align import statements from anywhere in the source file."
+  (interactive)
+  (save-excursion
+    (haskell-navigate-imports)
+    (haskell-mode-format-imports)
+    )
+  )
+
 ;; Dante Functions
 
 (defun spacemacs-haskell//dante-insert-type ()

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -176,7 +176,9 @@
           "dp"  'haskell-debug/previous
           "dr"  'haskell-debug/refresh
           "ds"  'haskell-debug/step
-          "dt"  'haskell-debug/trace))
+          "dt"  'haskell-debug/trace
+
+          "ri"  'spacemacs-haskell//format-imports))
 
       (evilified-state-evilify haskell-debug-mode haskell-debug-mode-map
         "RET" 'haskell-debug/select


### PR DESCRIPTION
### TODO 

- [x] Add new formatting function and keybinding
- [x] Document new keybinding

### Motivation

The functions `haskell-align-imports` `haskell-sort-imports` and `haskell-mode-format-imports` only succeed if `point` is touching the block of import statements. This PR adds a function `spacemacs-haskell//format-imports` and the keybinding `SPC m r i` to make import reformatting work properly from anywhere in the source file.
