### PR TITLE
Ocaml layer: enable ocaml-flycheck package via variable

### DIFF
--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -7,6 +7,7 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#using-merlin-for-error-reporting][Using merlin for error reporting]]
   - [[#opam-packages][OPAM packages]]
 - [[#key-bindings][Key Bindings]]
   - [[#repl-utop][REPL (utop)]]
@@ -22,13 +23,23 @@ This is a very basic layer for editing ocaml files.
 - Syntax highlighting (major-mode) via [[https://github.com/ocaml/tuareg][tuareg-mode]]
 - Error reporting, completion and type display via [[https://github.com/ocaml/merlin][merlin]]
 - auto-completion with company mode via [[https://github.com/ocaml/merlin][merlin]]
-- syntax-checking via [[https://github.com/diml/utop][flycheck-ocaml]]
+- syntax-checking via [[https://github.com/ocaml/merlin][merlin]] or [https://github.com/flycheck/flycheck-ocaml][flycheck-ocaml]
 
 * Install
 ** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =ocaml= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** Using merlin for error reporting
+By default [[https://github.com/flycheck/flycheck-ocaml][flycheck-ocaml]] is used for error reporting when the
+=syntax-highlighting= layer is also enabled as this is common throughout spacemacs.
+You can disable this and switch back to [[https://github.com/ocaml/merlin][merlin]]'s default error reporting method
+by adding [[https://github.com/flycheck/flycheck-ocaml][flycheck-ocaml]] to your excluded packages list in =.spacemacs=:
+
+#+BEGIN_SRC emacs-lisp
+dospacemacs-excluded-packages '(... flycheck-ocaml ... )
+#+END_SRC
 
 ** OPAM packages
 This layer requires some [[http://opam.ocaml.org][opam]] packages:

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -13,8 +13,8 @@
   '(
     ;; auto-complete
     company
-   ;; flycheck
-   ;; flycheck-ocaml
+    flycheck
+    flycheck-ocaml
     ggtags
     counsel-gtags
     helm-gtags


### PR DESCRIPTION
This adds a layer variable to the ocaml layer to use flycheck.

The support was already in there, but it seems from discussion here https://github.com/syl20bnr/spacemacs/issues/9489 the recommended way of enabling it was editing the layer file manually to enable the package. This just uses the variable as a package toggle.

I also enabled flycheck automatically for ocaml's tuareg-mode as the optional package is loaded.