### PR TITLE
Fix doc for tmux, c-c++, faust, node and docker layer

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -52,8 +52,7 @@ by setting the variable =c-c++-default-mode-for-headers= to =c++-mode=.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-    '((c-c++ :variables
-             c-c++-default-mode-for-headers 'c++-mode)))
+    '((c-c++ :variables c-c++-default-mode-for-headers 'c++-mode)))
 #+END_SRC
 
 *Note:* To set the variable for a given project, create a directory local

--- a/layers/+lang/faust/README.org
+++ b/layers/+lang/faust/README.org
@@ -4,12 +4,16 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This simple layer adds support for the [[https://en.wikipedia.org/wiki/FAUST_(programming_language)][faust language]].
-It adds =faust-mode= as well as integrating it with =auto-completion= layer.
+This layer adds support for the [[https://en.wikipedia.org/wiki/FAUST_(programming_language)][faust language]] to Spacemacs.
+
+** Features:
+- Syntax highlighting
+- Auto-completion
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/docker/README.org
+++ b/layers/+tools/docker/README.org
@@ -4,22 +4,29 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#usage][Usage]]
   - [[#tramp-access-to-docker-containers][TRAMP access to docker containers]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer provides syntax highlighting and build functionality for Docker files
-as well as TRAMP access to running docker containers.
+This layer integrates basic container management into Spacemacs.
 
-It also includes basic Docker container and image management provided by
-[[https://github.com/Silex/docker.el][docker.el.]]
+** Features:
+- Syntax highlighting for =Docker= files
+- =Docker= build integration
+- =TRAMP= access to running Docker containers
+- =Docker= container and image management via [[https://github.com/Silex/docker.el][docker.el]]
+- Syntax checking via [[https://github.com/hadolint/hadolint][hadolint]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =docker= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+You will also need the native package [[https://www.docker.com/][Docker]] for the actual container management.
+For syntax checking the external library =hadolint= is also necessary.
 
 * Usage
 ** TRAMP access to docker containers
@@ -27,7 +34,7 @@ This relies on the [[https://github.com/emacs-pe/docker-tramp.el][docker-tramp]]
 docker versions > 1.3.
 
 =docker-tramp= adds a new prefix =/docker:= that you can use with ~SPC f f~,
-this prefix allows to acces your docker containers and also provides
+this prefix allows to access your docker containers and also provides
 auto-completion of the running containers.
 
 * Key bindings

--- a/layers/+tools/node/README.org
+++ b/layers/+tools/node/README.org
@@ -4,7 +4,11 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 
 * Description
 This layer introduces packages that target Node.js. Currently this layer should
 not be used directly, as it will be used by other layers.
+
+** Features:
+- Integration of packages necessary to execute node.js modules from other layers.

--- a/layers/+tools/tmux/README.org
+++ b/layers/+tools/tmux/README.org
@@ -1,8 +1,29 @@
 #+TITLE: Tmux layer
 
 * Table of Contents                                         :TOC_4_gh:noexport:
-- [[#what-is-this][What is this]]
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key Bindings]]
 
-* What is this
-This is an extension to support [[https://github.com/keith/evil-tmux-navigator][evil-tmux-navigator]]. It requires a little
-configuration for tmux, so check the upstream documentation.
+* Description
+This layer adds basic =tmux= keybindings to Spacemacs.
+
+** Features:
+- Calling of =tmux= navigation commands directly from emacs via [[https://github.com/keith/evil-tmux-navigator][evil-tmux-navigator]].
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =tmux= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+For this to work you will also need to install the native package =tmux= on your system.
+
+* Key Bindings
+
+| Key Binding | Description     |
+|-------------+-----------------|
+| ~C-h~       | Call tmux left  |
+| ~C-j~       | Call tmux right |
+| ~C-k~       | Call tmux up    |
+| ~C-l~       | Call tmux down  |


### PR DESCRIPTION
Fixed the documentation for the tmux, faust, node, and docker layers.
Also fixed a wrong "source block" in the README.org of the c-c++ layer.

This is part of #9476.