### PR TITLE
Fix broken package declaration for dockerfile-mode

### DIFF
--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -47,7 +47,8 @@
     :defer t))
 
 (defun docker/init-dockerfile-mode ()
-  (use-package docker-mode
+  (use-package dockerfile-mode
     :defer t
-    :config (evil-leader/set-key-for-mode 'dockerfile-mode
-              "mcb" 'dockerfile-build-buffer)))
+    :config (progn
+              (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode "cb" 'dockerfile-build-buffer)
+              (spacemacs/declare-prefix-for-mode 'dockerfile-mode "mc" "compile"))))


### PR DESCRIPTION
In the docker layer a package `dockerfile-mode` is loaded to provide features for editing `dockerfiles` however the `use-package` declaration did not load the right package, causing it to skip the `:config` part of the declaration.

This did not bind the `dockerfile-build-buffer` function.