### PR TITLE
Increase gc-cons-threshold during startup

### DIFF
--- a/init.el
+++ b/init.el
@@ -12,9 +12,15 @@
 ;; Without this comment emacs25 adds (package-initialize) here
 ;; (package-initialize)
 
-;; Increase gc-cons-threshold, depending on your system you may set it back to a
-;; lower value in your dotfile (function `dotspacemacs/user-config')
-(setq gc-cons-threshold 100000000)
+;; Avoid garbage collection during startup.
+(setq gc-cons-threshold 402653184
+      gc-cons-percentage 0.6)
+(add-hook 'emacs-startup-hook
+          (lambda ()
+            ;; Increase gc-cons-threshold from default, depending on your system you may set it back to a
+            ;; lower value in your dotfile (function `dotspacemacs/user-config')
+            (setq gc-cons-threshold 100000000
+                  gc-cons-percentage 0.1)))
 
 (load-file (concat (file-name-directory load-file-name)
                    "core/core-versions.el"))


### PR DESCRIPTION
For me, this results in a drop from 9-10 seconds to 8-9 second startup.

Idea borrowed from https://github.com/hlissner/doom-emacs/wiki/FAQ#how-is-dooms-startup-so-fast