### PR TITLE
Fix doc for django, scala, sml, floobits, puppet and evernote layer

### DIFF
--- a/layers/+frameworks/django/README.org
+++ b/layers/+frameworks/django/README.org
@@ -4,8 +4,10 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
+  - [[#general-managment][General Managment]]
   - [[#fabric][Fabric]]
   - [[#files][Files]]
   - [[#interactive][Interactive]]
@@ -14,7 +16,15 @@
   - [[#test][Test]]
 
 * Description
-This layer adds support for the Python [[https://www.djangoproject.com/][Django]] framework via [[https://github.com/davidmiller/pony-mode][pony-mode]].
+This layer adds support for the Python web framework [[https://www.djangoproject.com/][Django]] to Spacemacs.
+
+** Features:
+- Test execution directly from emacs
+- Starting/stopping of the Django test server
+- Starting of an interactive Python shell in the current project for debugging
+- Fixed commands to open various Django specific settings files
+- Automatic deployment with [[http://www.fabfile.org][Fabric]] directly from emacs
+- Control of [[http://south.aeracode.org/][South]] database migration tool
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -22,12 +32,14 @@ add =django= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 * Key Bindings
-Django related key bindings uses  [[https://github.com/davidmiller/pony-mode][pony-mode]] and are behind the prefix ~SPC m j~.
+Django related key bindings uses [[https://github.com/davidmiller/pony-mode][pony-mode]] and are behind the prefix ~SPC m j~ in =Python-mode=.
+Various configuration options for =pony-mode= are documented at [[http://www.deadpansincerity.com/docs/pony/configuration.html][deadpansincerity.com]].
 
-Configuration options for pony-mode are documented at
-[[http://www.deadpansincerity.com/docs/pony/configuration.html][deadpansincerity.com]]
+** General Managment
 
-Manage Django with ~SPC m j m~.
+| Key Binding | Description                           |
+|-------------+---------------------------------------|
+| ~SPC m j m~ | Start a =pony-mode= managment session |
 
 ** Fabric
 
@@ -47,10 +59,12 @@ Manage Django with ~SPC m j m~.
 
 ** Interactive
 
-| Key Binding   | Description                                                                                                                                                                                                        |
-|---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ~SPC m j i d~ | Run interpreter for this project's default database as an inferior process                                                                                                                                         |
-| ~SPC m j i s~ | Open a Python shell with the current pony project's context loaded. If the project has the django_extras package installed, then use the excellent =shell_plus= command. Otherwise, fall back to =manage.py shell= |
+| Key Binding   | Description                                                                |
+|---------------+----------------------------------------------------------------------------|
+| ~SPC m j i d~ | Run interpreter for this project's default database as an inferior process |
+| ~SPC m j i s~ | Open a Python shell with the current pony project's context loaded.        |
+|               | If the project has the django_extras package installed, then use the       |
+|               | excellent =shell_plus= command. Otherwise, fall back to =manage.py shell=  |
 
 ** Server
 

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#layer-installation][Layer Installation]]
 - [[#ensime][Ensime]]
 - [[#scalastyle][Scalastyle]]
@@ -15,8 +16,20 @@
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer adds support for the Scala language using the excellent [[http://ensime.org/][ENSIME]]
-client/server.
+This layer adds support for the Scala language to Spacemacs.
+
+** Features:
+- Syntax highlighting
+- Auto-completion
+- Syntax-checking
+- Refactoring
+- Incremental compilation
+- Scala Repl
+- Style linting
+- Eldoc integration
+- Test execution directly from emacs
+- Automatic replacement of ASCII arrows with unicode ones
+- Automatic starting/stopping of [[http://ensime.org/][ENSIME]] IDE server
 
 * Layer Installation
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/sml/README.org
+++ b/layers/+lang/sml/README.org
@@ -4,13 +4,19 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key Bindings]]
   - [[#form-completion][Form Completion]]
   - [[#repl][REPL]]
 
 * Description
-Adds support for the [[http://www.smlnj.org][SML]] programming language.
+Adds support for the [[http://www.smlnj.org][SML]] programming language to Spacemacs.
+
+** Features:
+- Syntax highlighting
+- Integration of the =SML Repl= into emacs
+- Basic completion of SML forms via =sml-electric-space=
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -23,7 +29,7 @@ file.
 | Key Binding | Description                                                                               |
 |-------------+-------------------------------------------------------------------------------------------|
 | ~M-SPC~     | Inserts a space and completes the form before the cursor.                                 |
-| ~\vert~     | Inserts a pipe and adds a double arrow or copies the function name. Generally just works. |
+| ~\vert{}~   | Inserts a pipe and adds a double arrow or copies the function name. Generally just works. |
 
 ** REPL
 

--- a/layers/+pair-programming/floobits/README.org
+++ b/layers/+pair-programming/floobits/README.org
@@ -4,12 +4,19 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
 - [[#key-bindings][Key Bindings]]
 
 * Description
-This layer adds support for peer programming tool [[https://github.com/Floobits/floobits-emacs][floobits]].
+This layer adds support for the peer programming tool [[https://github.com/Floobits/floobits-emacs][floobits]] to Spacemacs.
+
+** Features:
+- Loading of floobits configuration files with fixed commands
+- Creation of floobits workspaces and populating it with content
+- Marking of the current cursor position for all users within the current workspace
+- Follow recent changes by other users
 
 * Install
 ** Layer
@@ -27,6 +34,8 @@ file.
 | ~SPC P j~   | Join an existing floobits workspace.                                                     |
 | ~SPC P l~   | Leave the current workspace.                                                             |
 | ~SPC P R~   | Create a workspace and populate it with the contents of the directory, DIR (or make it). |
+|             | The workspace will be shared privately.                                                  |
 | ~SPC P s~   | Summon everyone in the workspace to your cursor position.                                |
 | ~SPC P t~   | Toggle following of recent changes.                                                      |
 | ~SPC P U~   | Create a workspace and populate it with the contents of the directory, DIR (or make it). |
+|             | The workspace will be shared publicly.                                                   |

--- a/layers/+tools/puppet/README.org
+++ b/layers/+tools/puppet/README.org
@@ -4,16 +4,29 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer aims at providing support for the Puppet DSL using [[https://github.com/voxpupuli/puppet-mode][puppet-mode]].
+This layer provides support for the Puppet DSL to Spacemacs.
+
+** Features:
+- Syntax highlighting via [[https://github.com/voxpupuli/puppet-mode][puppet-mode]]
+- Syntax-checking via [[http://puppet-lint.com/][puppet-lint]]
+- Navigation commands to jump between blocks
+- Applying the content of the current manifest directly from emacs
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =puppet= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+To get syntax checking to work you will also need to install =puppet-lint= by executing:
+
+#+BEGIN_SRC sh
+  $ gem install puppet-lint
+#+END_SRC
 
 * Key bindings
 The following key bindings are available in Puppet Mode:

--- a/layers/+web-services/evernote/README.org
+++ b/layers/+web-services/evernote/README.org
@@ -4,21 +4,21 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#geeknote][geeknote]]
-  - [[#geeknoteel][geeknote.el]]
+  - [[#geeknote][Geeknote]]
+  - [[#geeknoteel][Geeknote.el]]
 - [[#key-bindings][Key Bindings]]
 
 * Description
-This layer groups together packages to work with [[https://evernote.com/][Evernote]].
+This layer adds support for the famous [[https://evernote.com/][Evernote]] note taking service to Spacemacs.
+It does so by grouping together various packages to work with [[https://evernote.com/][Evernote]].
 
-It uses the non official Evernote command line tool [[http://www.geeknote.me][geeknote]] which allows users
-to write notes in markdown, and sync them.
-
-[[https://github.com/avendael/emacs-geeknote][geeknote.el]] is a wrapper for some of the most used =geeknote= commands. By
-default, =geeknote.el= doesn't have key bindings defined. This contribution
-layer provides key bindings for all of geeknote.el's exposed features.
+** Features:
+- Create notes in markdown and sync with [[https://evernote.com/][Evernote]] via [[http://www.geeknote.me][geeknote]].
+- Search for notes using keywords
+- Move notes between notebooks
 
 * Install
 ** Layer
@@ -26,22 +26,26 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =evernote= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** geeknote
-The command =geeknote= is expected to be present in your =$PATH=. To
-obtain this utility, please refer to the official geeknote
-[[http://www.geeknote.me/documentation/][documentation]].
+** Geeknote
+This is the non official =Evernote= command line tool which allows users
+to write notes in markdown, and sync them. The command [[http://www.geeknote.me][geeknote]] is expected
+to be present in your =$PATH=. To obtain this utility, please refer to the
+official =geeknote= [[http://www.geeknote.me/documentation/][documentation]].
 
-** geeknote.el
-=geeknote.el= relies on having a correctly setup geeknote editor. To set
-this up, run the following command in your terminal after successfully
+** Geeknote.el
+[[https://github.com/avendael/emacs-geeknote][geeknote.el]] is a wrapper for some of the most used =geeknote= commands.
+By default, =geeknote.el= doesn't have any key bindings defined.
+This layer provides key bindings for all of =geeknote.el's= exposed features.
+=geeknote.el= relies on having a correctly setup =geeknote= editor.
+To set this up, run the following command in your terminal after successfully
 installing =geeknote=:
 
 #+BEGIN_SRC sh
   $ geeknote settings --editor "emacsclient"
 #+END_SRC
 
-If you would prefer to customize the geeknote command to be used such as
-specifying the path to the geeknote python script, please refer to the
+If you would prefer to customize the =geeknote= command to be used such as
+specifying the path to the =geeknote= python script, please refer to the
 =geeknote.el= [[https://github.com/avendael/emacs-geeknote][documentation]]. For more information about setting up =$PATH=,
 check out the corresponding section in the FAQ (~SPC h SPC $PATH RET~).
 


### PR DESCRIPTION
Fixed the missing features block for the django, scala, sml, floobits, puppet and evernote layers.
This is part of #9476.