### PR TITLE
spacemacs-layouts: fix projectile-switch-project-action

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -422,7 +422,7 @@ perspectives does."
                 (cons (abbreviate-file-name (projectile-project-root))
                       (projectile-relevant-known-projects))
               projectile-known-projects)
-            :action counsel-projectile-switch-project-action
+            :action #'counsel-projectile-switch-project-action
             :caller 'spacemacs/ivy-persp-switch-project)
   (advice-remove 'counsel-projectile-switch-project-action
                  'spacemacs/ivy-persp-switch-project-advice))


### PR DESCRIPTION
Fix #10177

I'm not sure why this would effect anything aside from `make-ivy-state` being a closure and somehow quoted function-objects may get treated differently by compilation (as in [this stackoverflow question](https://stackoverflow.com/questions/16801396/when-should-emacs-function-syntax-be-used). I'm puzzled as to why this would fix anything, so feel free to deny.