### PR TITLE
Add defun spacemacs/python-test-last

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -181,6 +181,11 @@ to be called for each testrunner. "
       (user-error "This test function is not available with the `%S' runner."
                   test-runner))))
 
+(defun spacemacs/python-test-last (arg)
+  "Re-run the last test command"
+  (interactive "P")
+  (spacemacs//python-call-correct-test-function arg '((nose . nosetests-again))))
+
 (defun spacemacs/python-test-all (arg)
   "Run all tests."
   (interactive "P")
@@ -237,6 +242,7 @@ to be called for each testrunner. "
     "ta" 'spacemacs/python-test-all
     "tB" 'spacemacs/python-test-pdb-module
     "tb" 'spacemacs/python-test-module
+    "tl" 'spacemacs/python-test-last
     "tT" 'spacemacs/python-test-pdb-one
     "tt" 'spacemacs/python-test-one
     "tM" 'spacemacs/python-test-pdb-module

--- a/layers/+lang/python/local/nose/nose.el
+++ b/layers/+lang/python/local/nose/nose.el
@@ -61,12 +61,15 @@
                                   ".git"))
 (defvar nose-project-root-test 'nose-project-root)
 (defvar nose-use-verbose t)
+(defvar nose--last-run-params nil
+  "Stores the last parameters passed to run-nose")
 
 (defun run-nose (&optional tests suite debug failed)
   "run nosetests by calling python instead of nosetests script.
 To be able to debug on Windows platform python output must be not buffered.
 For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-from-within-emacs.html
 "
+  (setq nose--last-run-params (list tests suite debug failed))
   (let* ((nose (nosetests-nose-command))
          (where (nose-find-project-root))
          (args (concat (if debug "--pdb" "")
@@ -99,6 +102,11 @@ For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-fro
             (format "%s/Scripts/%s" python-shell-virtualenv-path nose)
          (format "%s/bin/%s" python-shell-virtualenv-path nose))
       nose)))
+
+(defun nosetests-again ()
+  "runs the most recently executed 'nosetests' command again"
+  (interactive)
+  (apply 'run-nose nose--last-run-params))
 
 (defun nosetests-all (&optional debug failed)
   "run all tests"


### PR DESCRIPTION
It is a wrapper around the nosetests-again defun.
It will call the latest called nosetest function.
I've also added a binding for it: leader key + "t l" (mnemonic = test last)