### PR TITLE
Fix doc for coq, semantic-web, source-control, evil-commentary and spotify layer

### DIFF
--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -4,21 +4,29 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#coq][Coq]]
+- [[#troubleshooting][Troubleshooting]]
+  - [[#there-are-empty-square-boxes-in-place-of-math-operators][There are empty square boxes in place of math operators]]
 - [[#key-bindings][Key bindings]]
   - [[#laying-out-windows][Laying out windows]]
   - [[#managing-prover-process][Managing prover process]]
   - [[#prover-queries][Prover queries]]
   - [[#moving-the-point][Moving the point]]
   - [[#inserting][Inserting]]
-- [[#faq][FAQ]]
-  - [[#there-are-empty-square-boxes-in-place-of-math-operators][There are empty square boxes in place of math operators]]
 
 * Description
-This layer adds support for the [[https://coq.inria.fr/][Coq]] proof assistant (adapted from
-[[https://github.com/tchajed/spacemacs-coq]]).
+This layer adds support for the [[https://coq.inria.fr/][Coq]] proof assistant (adapted from [[https://github.com/tchajed/spacemacs-coq][spacemacs-coq]]) to Spacemacs.
+
+** Features:
+- Syntax highlighting
+- Syntax-checking
+- Auto-completion
+- Debugging of mathematical proofs from within emacs using a special proof layout
+- Replacement of certain constants with the correct mathematical signs
+- Inserting of certain preconfigured proof elements
 
 * Install
 ** Layer
@@ -30,6 +38,19 @@ Official installers for MacOS and Windows are available from:
 [[https://coq.inria.fr/download]].
 
 Linux users can build from source or consult with their own package managers.
+
+* Troubleshooting
+** There are empty square boxes in place of math operators
+Math symbols present in your buffer (e.g. forall exists) will attempt to be
+prettified, if you are seeing empty square boxes this means an appropriate math
+symbol cannot be found in your *font*. You can either install a appropriate math
+font, or disable the feature by adding the following snippet to the your
+=dotspacemacs/user-config=.
+
+#+BEGIN_SRC emacs-lisp
+(with-eval-after-load 'company-coq
+  (add-to-list 'company-coq-disabled-features 'prettify-symbols))
+#+END_SRC
 
 * Key bindings
 ** Laying out windows
@@ -89,16 +110,3 @@ Note the last two are regular =company-coq= bindings, left alone since they are
 most useful in insert mode. The full =company-coq= tutorial showcasing all
 available =company-coq= keybindings can be accessed at any time using =SPC SPC
 company-coq-tutorial=.
-
-* FAQ
-** There are empty square boxes in place of math operators
-Math symbols present in your buffer (e.g. forall exists) will attempt to be
-prettified, if you are seeing empty square boxes this means an appropriate math
-symbol cannot be found in your *font*. You can either install a appropriate math
-font, or disable the feature by adding the following snippet to the your
-=dotspacemacs/user-config=.
-
-#+BEGIN_SRC emacs-lisp
-(with-eval-after-load 'company-coq
-  (add-to-list 'company-coq-disabled-features 'prettify-symbols))
-#+END_SRC

--- a/layers/+lang/semantic-web/README.org
+++ b/layers/+lang/semantic-web/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
@@ -15,6 +16,9 @@ SPARQL-mode supports the execution of queries. When first called, you will be
 prompted for a SPARQL HTTP endpoint in the minibuffer, which defaults to
 http://localhost:2020/. Once set, it will be used for all subsequent queries in
 that buffer. Results will be displayed in another buffer in CSV format.
+
+** Features:
+- Provides an alternative way to search the web using SPARQL queries.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -3,7 +3,7 @@
 [[file:img/git.png]]
 
 * Table of Contents                                         :TOC_4_gh:noexport:
-- [[#descriptions][Descriptions]]
+- [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
@@ -25,8 +25,8 @@
   - [[#git-links-to-web-services][Git links to web services]]
   - [[#repository-list][Repository list]]
 
-* Descriptions
-This layers adds extensive support for [[http://git-scm.com/][git]].
+* Description
+This layers adds extensive support for [[http://git-scm.com/][git]] to Spacemacs.
 
 ** Features:
 - git repository management the indispensable [[http://magit.vc/][magit]] package

--- a/layers/+vim/evil-commentary/README.org
+++ b/layers/+vim/evil-commentary/README.org
@@ -2,6 +2,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
@@ -9,12 +10,8 @@
 This layer replaces [[https://github.com/redguardtoo/evil-nerd-commenter][evil-nerd-commenter]] with [[https://github.com/linktohack/evil-commentary][evil-commentary]] for those
 who prefer the behaviour of [[https://github.com/tpope/vim-commentary][vim-commentary]].
 
-- Use ~gcc~ to comment out a line (takes a count),
-- ~gc~ to comment out the target of a motion (for example,
-- ~gcap~ to comment out a paragraph), ~gc~ in visual
-  mode to comment out the selection.
-
-For more details see the [[https://github.com/linktohack/evil-commentary][evil-commentary]] repository.
+** Features:
+- Provides the original vim behaviour for commenting out lines via [[https://github.com/linktohack/evil-commentary][evil-commentary]].
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -23,10 +20,11 @@ file.
 
 * Key bindings
 
-| Key Binding | Description                   |
-|-------------+-------------------------------|
-| ~SPC ;~     | comment operator              |
-| ~gcc~       | comment current line          |
-| ~gcap~      | comment paragraphs            |
-| ~gc SPC y~  | comment up to a line with avy |
-| ~gy~        | comment and yank              |
+| Key Binding | Description                        |
+|-------------+------------------------------------|
+| ~SPC ;~     | comment operator                   |
+| ~gcc~       | comment current line               |
+| ~gcap~      | comment paragraphs                 |
+| ~gc~        | comment out the target of a motion |
+| ~gc SPC y~  | comment up to a line with avy      |
+| ~gy~        | comment and yank                   |

--- a/layers/+web-services/spotify/README.org
+++ b/layers/+web-services/spotify/README.org
@@ -4,11 +4,15 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer adds key bindings for controlling Spotify from inside Emacs.
+This layer integrates an online music service into Spacemacs.
+
+** Features:
+- Support for listening to music from within Emacs via [[https://www.spotify.com][Spotify]].
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
Fixed the documents for coq, semantic-web, source-control, evil-commentary and spotify layer.
This is part of #9476