### PR TITLE
Fix doc for graphviz, deft and finance layer

### DIFF
--- a/layers/+lang/graphviz/README.org
+++ b/layers/+lang/graphviz/README.org
@@ -4,20 +4,27 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This contains a forked version of [[https://github.com/ppareit/graphviz-dot-mode][graphviz-dot-mode]] that enables a live-reload
-type work flow for editing `.dot` files. When live-preview is enabled, saving
-the file will automatically trigger a compilation and reload of the image buffer
-associated with the file.
+This layer adds support for the open-source graph declaration system graphviz to Spacemacs.
+
+** Features:
+- Syntax highlighting for =.dot= files
+- Integration of a live-preview of =.dot= files via [[https://github.com/ppareit/graphviz-dot-mode][graphviz-dot-mode]].
+- Control of the graphviz compiler directly from emacs.
+- Support for formatting =.dot= files automatically.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =graphviz= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+To get the compilation working, you will also need the native package [[http://graphviz.org/][graphviz]] installed
+in your system.
 
 * Configuration
 If the live preview is not always updating the rendered image properly, you can

--- a/layers/+lang/plantuml/README.org
+++ b/layers/+lang/plantuml/README.org
@@ -33,8 +33,10 @@ robbyoconnor->theOtherPerson : And they thinks it's funny? Yup, they definitely 
 [[file:img/dia.png]]
 
 ** Features:
-  - Diagram preview in various output formats
-  - Embedding into org documents
+- Syntax highlighting
+- Diagram preview in various output formats
+- Embedding into org documents
+- Controlling the =Plantuml= compiler directly from emacs
 
 * Install
 To use this contribution add it to your =~/.spacemacs=
@@ -43,9 +45,23 @@ To use this contribution add it to your =~/.spacemacs=
   (setq-default dotspacemacs-configuration-layers '(plantuml))
 #+end_src
 
+To control the =Plantuml= compiler you also need to download the [[http://plantuml.com/download][Plantuml jar]]
+and configure the =plantuml-jar-path= respectively:
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((plantuml :variables plantuml-jar-path "~/plantUml.jar")))
+#+end_src
+
+To get the full range of =Plantuml= compilations working, you will also need
+the native package [[http://graphviz.org/][graphviz]] installed on your system.
+
 * Org-Babel Integration
 To enable the execution of embedded plantuml code blocks within [[http://orgmode.org/][Org-Mode]]
-documents, define a value for =org-plantuml-jar-path= in your =~/.spacemacs=.
+documents, define a value for =org-plantuml-jar-path= in your =~/.spacemacs=:
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((plantuml :variables org-plantuml-jar-path "~/plantUml.jar")))
+#+end_src
 
 * Key bindings
 

--- a/layers/+tools/deft/README.org
+++ b/layers/+tools/deft/README.org
@@ -2,28 +2,19 @@
 
 * Table of Content                                          :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#differences-from-default][Differences from default]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#configuration][Configuration]]
 - [[#key-bindings][Key Bindings]]
 
 * Description
-[[http://jblevins.org/projects/deft/][Deft]] is an Emacs mode inspired by =Notational Velocity= for quickly
-browsing and creating notes.
+This layer adds a search driven note taking system into Spacemacs.
 
-** Differences from default
-This layer sets the default to use filenames for note titles as well as
-=org-mode= for editing. The default extension is =org=. The default
-configuration is set to recognize =org=, =md=, and =txt= extensions. If
-you prefer that =Deft= recognize other extensions set an alternate
-configuration by adding the following in your config file:
-
-#+Begin_SRC emacs-lisp
-  (setq deft-extensions '("org" "md" "txt"))
-#+END_SRC
-
-Just add or substitute your preferred extension.
+** Features:
+- Browsing and creating notes with a powerfull search function via [[http://jblevins.org/projects/deft/][Deft]].
+- Integration of =org-mode= as note editor.
+- Configurable list of extensions to recognize as notes.
 
 * Install
 ** Layer
@@ -33,11 +24,22 @@ file.
 
 ** Configuration
 By default deft tries to put notes in =~/.deft= but you can change
-this like so in your =dotspacemacs/user-config= function:
+this in your =dotspacemacs/user-config= function:
 
 #+BEGIN_SRC emacs-lisp
-(setq deft-directory "~/Dropbox/notes")
+   (setq deft-directory "~/Dropbox/notes")
 #+END_SRC
+
+By default =Deft= uses filenames for note titles and =org-mode= for editing.
+The default extension for new notes is =org=. However also =md= and =txt=
+files are recognized as notes. Which extensions are used for notes discovery
+can be configured in your =dotfile=:
+
+#+Begin_SRC emacs-lisp
+  (setq deft-extensions '("org" "md" "txt"))
+#+END_SRC
+
+Just add or substitute your preferred extension.
 
 * Key Bindings
 

--- a/layers/+tools/finance/README.org
+++ b/layers/+tools/finance/README.org
@@ -1,7 +1,10 @@
 #+TITLE: Finance layer
 
+[[file:img/ledger.png]]
+
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
 - [[#configuration][Configuration]]
@@ -11,16 +14,21 @@
   - [[#ledger-reconcile][Ledger-Reconcile]]
 
 * Description
-This layer adds finance related packages:
-- [[https://github.com/ledger/ledger][ledger]] support via [[https://www.emacswiki.org/emacs/LedgerMode][ledger-mode]]
+This layer integrates a full fledged accounting system into Spacemacs.
 
-[[file:img/ledger.png]]
+** Features:
+- Support for maintaining a double-entry accounting system run by text files via [[https://www.emacswiki.org/emacs/LedgerMode][ledger-mode]].
+- Display of finance reports directly within emacs.
+- Integration of emacs calculator mode for editing post amounts.
+- Support for easy account reconciliation via =Ledger-Reconcile=.
 
 * Install
 ** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =finance= to the existing =dotspacemacs-configuration-layers= list in this
-file. This layer adds support for [[http://ledger-cli.org/download.html][ledger]], which must be installed separately.
+file.
+
+For this layer to work properly you also need to install the native package [[https://github.com/ledger/ledger][ledger]].
 
 * Configuration
 ** Ledger


### PR DESCRIPTION
Fixed the missing features block for the graphviz, deft and finance layer.
I have also revised the Plantuml layer a bit, mostly to make installing and configuring
plantuml easier.

This is part of #9476