### PR TITLE
Make the Emacs server optional

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -337,6 +337,9 @@ This variable can also be set to a property list for finer control:
 The property `:enabled-for-modes' takes priority over `:disabled-for-modes' and
 restricts line-number to the specified list of major-mode.")
 
+(defvar dotspacemacs-enable-server t
+  "If non-nil, start an Emacs server if one is not already running.")
+
 (defvar dotspacemacs-persistent-server nil
   "If non nil advises quit functions to keep server open when quitting.")
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -377,6 +377,9 @@ It should only modify the values of Spacemacs settings."
    ;; emphasis the current one). (default 'all)
    dotspacemacs-highlight-delimiters 'all
 
+   ;; If non-nil, start an Emacs server if one is not already running.
+   dotspacemacs-enable-server t
+
    ;; If non-nil, advise quit functions to keep server open when quitting.
    ;; (default nil)
    dotspacemacs-persistent-server nil

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -190,6 +190,7 @@
 - [[#emacs-server][Emacs Server]]
   - [[#connecting-to-the-emacs-server][Connecting to the Emacs server]]
   - [[#keeping-the-server-alive][Keeping the server alive]]
+  - [[#disabling-the-emacs-server][Disabling the Emacs server]]
 - [[#troubleshoot][Troubleshoot]]
   - [[#loading-fails][Loading fails]]
   - [[#upgradingdowngrading-emacs-version][Upgrading/Downgrading Emacs version]]
@@ -3275,6 +3276,14 @@ server is to use the following bindings:
 | ~SPC q f~  | Kill the current frame                                                   |
 | ~SPC q t~  | Restart Emacs and debug with --with-timed-requires                       |
 | ~SPC q T~  | Restart Emacs and debug with --adv-timers                                |
+
+** Disabling the Emacs server
+You can disable the built-in server by setting the variable
+=dotspacemacs-enable-server= to =nil= in your =~/.spacemacs=.
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-enable-server nil)
+#+END_SRC
 
 * Troubleshoot
 ** Loading fails

--- a/init.el
+++ b/init.el
@@ -31,5 +31,6 @@
   (configuration-layer/load)
   (spacemacs-buffer/display-startup-note)
   (spacemacs/setup-startup-hook)
-  (require 'server)
-  (unless (server-running-p) (server-start)))
+  (when dotspacemacs-enable-server
+    (require 'server)
+    (unless (server-running-p) (server-start))))


### PR DESCRIPTION
Add `dotspacemacs-enable-server`, which if non-nil prevents Spacemacs from
calling `(server-start)` at init.

This is useful for cases in which automatically starting a server is undesirable.