### PR TITLE
fix: Rename deprecated cider function

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -100,7 +100,7 @@
             "gb" 'cider-pop-back
             "gc" 'cider-classpath
             "ge" 'cider-jump-to-compilation-error
-            "gr" 'cider-jump-to-resource
+            "gr" 'cider-find-resource
             "gn" 'cider-browse-ns
             "gN" 'cider-browse-ns-all
 


### PR DESCRIPTION
`cider-jump-to-resource` has been renamed `cider-find-resource` in
CIDER 0.9.0
