### PR TITLE
Fix doc for nginx, jr, nlinum and systemd layer

### DIFF
--- a/layers/+lang/jr/README.org
+++ b/layers/+lang/jr/README.org
@@ -4,11 +4,15 @@
 
 * Table of Contents                                       :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
 This layer adds syntax highlighting for the [[http://web.cs.ucdavis.edu/~olsson/research/jr/][JR Concurrent Programming Language]].
 JR is the implementation of the [[https://www2.cs.arizona.edu/sr/][SR]] language for Java.
+
+** Features:
+- Syntax highlighting
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+misc/nlinum/README.org
+++ b/layers/+misc/nlinum/README.org
@@ -2,7 +2,11 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-nlinum-layer-in-this-file][describe nlinum layer in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe nlinum layer in this file
+This layer provides various styles of line numbering in Spacemacs.
+
+** Features:
+- Support for classic ascending line numbering.
+- Support for line numbering relative to the current cursor position.

--- a/layers/+tools/nginx/README.org
+++ b/layers/+tools/nginx/README.org
@@ -4,11 +4,16 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
-[[https://github.com/ajc/nginx-mode][nginx-mode]] for editing [[http://nginx.org][nginx]] configuration files.
-It adds basic syntax highlighting and syntax-aware tabbing.
+This layer adds support for configuring [[http://nginx.org][nginx]] a powerful alternative for
+the apache web server.
+
+** Features:
+- Syntax highlighting of nginx configuration files via [[https://github.com/ajc/nginx-mode][nginx-mode]].
+- Syntax-aware indentation
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/systemd/README.org
+++ b/layers/+tools/systemd/README.org
@@ -2,12 +2,17 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer provides syntax highlighting for systemd files and completion through
-=company= if the =auto-completion= layer is used.
+This layer adds support for editing =systemd= configuration files in Spacemacs.
+
+** Features:
+- Syntax highlighting
+- Auto completion
+- Syntax checking via =systemd-analyze=
 
 * Install
 To use this contribution add it to your =~/.spacemacs=


### PR DESCRIPTION
Fixed the missing features block for nginx, jr, nlinum and systemd layers.
This is part of #9476.