### PR TITLE
python: add pipenv. unified prefix for pyenv, pyvenv, pipenv

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -334,19 +334,25 @@ Send code to hy REPL commands:
 
 ** Other Python commands
 
-| Key Binding | Description                                                                  |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m =~   | Reformat the buffer according to PEP8 using  [[https://github.com/google/yapf][YAPF]]                            |
-| ~SPC m d b~ | toggle a breakpoint using =wdb=, =ipdb=, =pudb= or =pdb=                     |
-| ~SPC m g g~ | go to definition using =anaconda-mode-find-definitions= (~C-o~ to jump back) |
-| ~SPC m g a~ | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back) |
-| ~SPC m g b~ | jump back                                                                    |
-| ~SPC m g u~ | navigate between usages with =anaconda-mode-find-references=                 |
-| ~SPC m h d~ | look for documentation using =helm-pydoc=                                    |
-| ~SPC m h h~ | quick documentation using anaconda                                           |
-| ~SPC m h H~ | open documentation in =firefox= using [[https://github.com/tsgates/pylookup][pylookup]]                               |
-| ~SPC m v s~ | set a pyenv environment with [[https://github.com/pyenv/pyenv][pyenv]]                                           |
-| ~SPC m v u~ | unset a pyenv environment with [[https://github.com/pyenv/pyenv][pyenv]]                                         |
-| ~SPC m V w~ | work on virtual environment in =WORKON_HOME=                                 |
-| ~SPC m V a~ | activate a virtual environment in any directory                              |
-| ~SPC m V d~ | deactivate active virtual environment                                        |
+| Key Binding   | Description                                                                  |
+|---------------+------------------------------------------------------------------------------|
+| ~SPC m =~     | Reformat the buffer according to PEP8 using  [[https://github.com/google/yapf][YAPF]]                            |
+| ~SPC m d b~   | toggle a breakpoint using =wdb=, =ipdb=, =pudb= or =pdb=                     |
+| ~SPC m g g~   | go to definition using =anaconda-mode-find-definitions= (~C-o~ to jump back) |
+| ~SPC m g a~   | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back) |
+| ~SPC m g b~   | jump back                                                                    |
+| ~SPC m g u~   | navigate between usages with =anaconda-mode-find-references=                 |
+| ~SPC m h d~   | look for documentation using =helm-pydoc=                                    |
+| ~SPC m h h~   | quick documentation using anaconda                                           |
+| ~SPC m h H~   | open documentation in =firefox= using [[https://github.com/tsgates/pylookup][pylookup]]                               |
+| ~SPC m v s~   | set a pyenv environment with [[https://github.com/pyenv/pyenv][pyenv]]                                           |
+| ~SPC m v u~   | unset a pyenv environment with [[https://github.com/pyenv/pyenv][pyenv]]                                         |
+| ~SPC m v w~   | work on virtual environment in =WORKON_HOME=                                 |
+| ~SPC m v a~   | activate a virtual environment in any directory                              |
+| ~SPC m v d~   | deactivate active virtual environment                                        |
+| ~SPC m v p a~ | activate pipenv in current project                                           |
+| ~SPC m v p d~ | deactivate pipenv in current project                                         |
+| ~SPC m v p s~ | launch pipenv shell in current project                                       |
+| ~SPC m v p o~ | open pipenv module in buffer                                                 |
+| ~SPC m v p i~ | install module into pipenv environment                                       |
+| ~SPC m v p u~ | uninstall module from pipenv environment                                     |

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -28,6 +28,7 @@
     live-py-mode
     (nose :location local)
     org
+    pipenv
     pip-requirements
     pippel
     py-isort
@@ -184,6 +185,24 @@
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(python . t))))
 
+(defun python/init-pipenv ()
+  (use-package pipenv
+    :commands (pipenv-activate
+               pipenv-deactivate
+               pipenv-shell
+               pipenv-open
+               pipenv-install
+               pipenv-uninstall)
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'python-mode
+        "vpa" 'pipenv-activate
+        "vpd" 'pipenv-deactivate
+        "vps" 'pipenv-shell
+        "vpo" 'pipenv-open
+        "vpi" 'pipenv-install
+        "vpu" 'pipenv-uninstall))))
+
 (defun python/init-pip-requirements ()
   (use-package pip-requirements
     :defer t))
@@ -242,9 +261,9 @@
                    'spacemacs//pyvenv-mode-set-local-virtualenv)))
       (dolist (mode '(python-mode hy-mode))
         (spacemacs/set-leader-keys-for-major-mode mode
-          "Va" 'pyvenv-activate
-          "Vd" 'pyvenv-deactivate
-          "Vw" 'pyvenv-workon))
+          "va" 'pyvenv-activate
+          "vd" 'pyvenv-deactivate
+          "vw" 'pyvenv-workon))
       ;; setup shell correctly on environment switch
       (dolist (func '(pyvenv-activate pyvenv-deactivate pyvenv-workon))
         (advice-add func :after 'spacemacs/python-setup-everything)))))
@@ -301,8 +320,8 @@
       (spacemacs/declare-prefix-for-mode 'python-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'python-mode "ms" "REPL")
       (spacemacs/declare-prefix-for-mode 'python-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mv" "pyenv")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mV" "pyvenv")
+      (spacemacs/declare-prefix-for-mode 'python-mode "mv" "virtualenv")
+      (spacemacs/declare-prefix-for-mode 'python-mode "mvp" "pipenv")
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "'"  'spacemacs/python-start-or-switch-repl
         "cc" 'spacemacs/python-execute-file


### PR DESCRIPTION
This PR adds `pipenv` to python layer, and also unifies commands for `pyenv`, `pyvenv`, and `pipenv` under a common prefix.

pipenv is the new officially recommended packaging tool for python ([link](https://packaging.python.org/tutorials/managing-dependencies/)). [pipenv.el](https://github.com/pwalsh/pipenv.el) is a package integrating pipenv into emacs.