### PR TITLE
Configure rg max column number for search.

### DIFF
--- a/layers/+completion/helm/config.el
+++ b/layers/+completion/helm/config.el
@@ -37,6 +37,9 @@ values."
   in all non-asynchronous sources. If set to `source', preserve individual
   source settings. Else, disable fuzzy matching in all sources.")
 
+(defvar spacemacs-helm-rg-max-column-number 150
+  "Controls the maximum number of columns to display with ripgrep (otherwise omits a line)")
+
 ;; internals
 
 ;; for Helm Window position

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -250,7 +250,10 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
         ;; --line-number forces line numbers (disabled by default on windows)
         ;; no --vimgrep because it adds column numbers that wgrep can't handle
         ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-        (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number --max-columns 150"))
+        (let* ((root-helm-ag-base-command "rg --smart-case --no-heading --color never --line-number")
+               (helm-ag-base-command (if spacemacs-helm-rg-max-column-number
+                                        (concat root-helm-ag-base-command " --max-columns " (number-to-string spacemacs-helm-rg-max-column-number))
+                                      root-helm-ag-base-command)))
           (helm-do-ag dir)))
 
       (defun spacemacs/helm-files-do-rg-region-or-symbol ()


### PR DESCRIPTION
Allow user configuration of max-column setting for searching by `ripgrep`.

Otherwise, `C-c C-e` (edit all) will swap a bunch of lines to be `[Omitted long line with n matches]`.