### PR TITLE
Enable scrolling in mu4e main mode

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -56,7 +56,9 @@
       (evilified-state-evilify-map mu4e-main-mode-map
         :mode mu4e-main-mode
         :bindings
-        (kbd "j") 'mu4e~headers-jump-to-maildir)
+        (kbd "j") 'mu4e~headers-jump-to-maildir
+        (kbd "C-j") 'next-line
+        (kbd "C-k") 'previous-line)
 
       (evilified-state-evilify-map
        mu4e-headers-mode-map


### PR DESCRIPTION
In mu4e main mode it's currently not possible to scroll without using the arrow keys. This PR binds `C-j` and `C-k` to scrolling functions.

Note: It's useful to be able to scroll in the main mode when using the maildirs extension, otherwise most things are available with shortcuts. It still feels odd not to be able scroll though.