### PR TITLE
Feature: Add "send to buffer" leader key in ruby layer

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -111,6 +111,7 @@ directory local variables.
 | ~SPC m {~   | toggle style of current block (only built-in mode)   |
 | ~SPC m g g~ | go to definition (robe-jump)                         |
 | ~SPC m h h~ | show documentation for method at point (robe-doc)    |
+| ~SPC m s b~ | send buffer                                          |
 | ~SPC m s f~ | send function definition                             |
 | ~SPC m s F~ | send function definition and switch to REPL          |
 | ~SPC m s i~ | start REPL                                           |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -160,6 +160,7 @@
           "hh" 'robe-doc
           "rsr" 'robe-rails-refresh
           ;; inf-enh-ruby-mode
+          "sb" 'ruby-send-buffer
           "sf" 'ruby-send-definition
           "sF" 'ruby-send-definition-and-go
           "si" 'robe-start


### PR DESCRIPTION
Currently ruby-send-to-buffer function is not assigned to any key
it is useful to be able to send the the buffer directly to the ruby
console.

It assigns SPC-msb to ruby-send-to-buffer function