### PR TITLE
Add SPC w | binding for split-window-right

### DIFF
--- a/layers/+distributions/spacemacs-base/keybindings.el
+++ b/layers/+distributions/spacemacs-base/keybindings.el
@@ -440,6 +440,7 @@
   "wu"  'winner-undo
   "wv"  'split-window-right
   "wV"  'split-window-right-and-focus
+  "w|"  'split-window-right
   "ww"  'other-window
   "wx"  'kill-buffer-and-window
   "w/"  'split-window-right


### PR DESCRIPTION
Added to match the SPC w - binding for split-window-bottom. 