### PR TITLE
shell: move eshell key bindings definition into a hook function

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -137,9 +137,13 @@ is achieved by adding the relevant text properties."
     (eshell-send-input))
   ;; Caution! this will erase buffer's content at C-l
   (define-key eshell-mode-map (kbd "C-l") 'spacemacs/eshell-clear-keystroke)
-  (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof))
+  (define-key eshell-mode-map (kbd "C-d") 'eshell-delchar-or-maybe-eof)
 
-
+  ;; These don't work well in normal state
+  ;; due to evil/emacs cursor incompatibility
+  (evil-define-key 'insert eshell-mode-map
+    (kbd "C-k") 'eshell-previous-matching-input-from-input
+    (kbd "C-j") 'eshell-next-matching-input-from-input))
 
 (defun spacemacs/helm-eshell-history ()
   "Correctly revert to insert state after selection."

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -122,13 +122,7 @@
 
       ;; automatically truncate buffer after output
       (when (boundp 'eshell-output-filter-functions)
-        (push 'eshell-truncate-buffer eshell-output-filter-functions))
-
-      ;; These don't work well in normal state
-      ;; due to evil/emacs cursor incompatibility
-      (evil-define-key 'insert eshell-mode-map
-        (kbd "C-k") 'eshell-previous-matching-input-from-input
-        (kbd "C-j") 'eshell-next-matching-input-from-input))))
+        (push 'eshell-truncate-buffer eshell-output-filter-functions)))))
 
 (defun shell/init-eshell-prompt-extras ()
   (use-package eshell-prompt-extras


### PR DESCRIPTION
Problem
---

`C-j` and `C-k` key bindings don't work in eshell buffers except the first one.

Solution
---

`eshell-mode-map` is buffer-local, so key bindings have to be defined in a hook
function.