### PR TITLE
org: add key binding for org-toggle-checkbox

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -291,6 +291,7 @@ To permanently enable mode line display of org clock, add this snippet to your
 
 | Key Binding | Description                                   |
 |-------------+-----------------------------------------------|
+| ~SPC m T c~ | org-toggle-checkbox                           |
 | ~SPC m T e~ | org-toggle-pretty-entities                    |
 | ~SPC m T i~ | org-toggle-inline-images                      |
 | ~SPC m T l~ | org-toggle-link-display                       |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -189,6 +189,7 @@ Will work on both org-mode and any mode that accepts plain html."
 
         "a" 'org-agenda
 
+        "Tc" 'org-toggle-checkbox
         "Te" 'org-toggle-pretty-entities
         "Ti" 'org-toggle-inline-images
         "Tl" 'org-toggle-link-display


### PR DESCRIPTION
Problem
---

For basic toggling a checkbox (and adding / removing one with `SPC u`) for list
item at point one can use `,,`. However, there is no spacemacs key binding for
more advanced checkbox editing command `org-toggle-checkbox`.

Compare `C-c C-c` to `C-c C-x C-b` at https://orgmode.org/manual/Checkboxes.html

Solution
---

Add `SPC m T c` key binding for `org-toggle-checkbox`.