### PR TITLE
remove `brew linkapps` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ font:
 ```sh
 brew tap d12frosted/emacs-plus
 brew install emacs-plus
-brew linkapps emacs-plus
 brew tap caskroom/fonts
 brew cask install font-source-code-pro
 git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d


### PR DESCRIPTION
`brew linkapps` is deprecated (according to homebrew when I tried running it)

