### PR TITLE
org: org-clock-goto binding

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -269,23 +269,25 @@ To permanently enable mode line display of org clock, add this snippet to your
 * Key bindings
 ** Starting org-mode
 
-| Key Binding   | Description                    |
-|---------------+--------------------------------|
-| ~SPC a o #~   | org agenda list stuck projects |
-| ~SPC a o /~   | org occur in agenda files      |
-| ~SPC a o a~   | org agenda list                |
-| ~SPC a o c~   | org capture                    |
-| ~SPC a o e~   | org store agenda views         |
-| ~SPC a o k i~ | org clock in last              |
-| ~SPC a o k j~ | org jump to current clock      |
-| ~SPC a o k o~ | org clock out                  |
-| ~SPC a o k r~ | org resolve clocks             |
-| ~SPC a o l~   | org store link                 |
-| ~SPC a o m~   | org tags view                  |
-| ~SPC a o o~   | org agenda                     |
-| ~SPC a o s~   | org search view                |
-| ~SPC a o t~   | org todo list                  |
-| ~SPC C c~     | org-capture                    |
+| Key Binding         | Description                    |
+|---------------------+--------------------------------|
+| ~SPC a o #~         | org agenda list stuck projects |
+| ~SPC a o /~         | org occur in agenda files      |
+| ~SPC a o a~         | org agenda list                |
+| ~SPC a o c~         | org capture                    |
+| ~SPC a o e~         | org store agenda views         |
+| ~SPC a o k i~       | org clock in last              |
+| ~SPC a o k j~       | org jump to current clock      |
+| ~SPC a o k g~       | org goto last clocked-in clock |
+| ~SPC u SPC a o k g~ | org goto specific recent clock |
+| ~SPC a o k o~       | org clock out                  |
+| ~SPC a o k r~       | org resolve clocks             |
+| ~SPC a o l~         | org store link                 |
+| ~SPC a o m~         | org tags view                  |
+| ~SPC a o o~         | org agenda                     |
+| ~SPC a o s~         | org search view                |
+| ~SPC a o t~         | org todo list                  |
+| ~SPC C c~           | org-capture                    |
 
 ** Toggles
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -317,6 +317,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "aoc" 'org-capture
         "aoe" 'org-store-agenda-views
         "aoki" 'org-clock-in-last
+        "aokg" 'org-clock-goto
         "aokj" 'org-clock-jump-to-current-clock
         "aoko" 'org-clock-out
         "aokr" 'org-resolve-clocks


### PR DESCRIPTION
Bind `org-clock-goto` to `SPC aokg`

Useful for jumping to recent clocks (via `SPC u` `SPC aokg`), otherwise it jumps to
the current or last clocked in clock