### PR TITLE
javascript: Add variable to disable tern warning at startup

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -85,6 +85,9 @@ layer:
   (javascript :variables tern-command '("node" "/path/to/tern/bin/tern"))
 #+END_SRC
 
+If you don't use tern and/or do not wish to install it, you can disable the
+spacemacs initialization warning by setting =javascript-disable-tern-warning=.
+
 ** Indentation
 To change how js2-mode indents code, set the variable =js2-basic-offset=, as
 such:

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -15,3 +15,7 @@
 
 (defvar javascript-disable-tern-port-files t
   "Stops tern from creating tern port files.")
+
+(defvar javascript-disable-tern-warning nil
+  "If true, disables the warning at init time if you don't wish to install tern
+when using the javascript layer.")

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -95,8 +95,11 @@
     "ht" 'tern-get-type))
 
 (defun spacemacs//tern-detect ()
-  "Detect tern binary and warn if not found."
+  "Detect tern binary and warn if not found. Setting
+`javascript-disable-tern-warning' to true disables the warning."
   (let ((found (executable-find "tern")))
-    (unless found
+    (unless (or found
+                ;; dotspacemacs-disable-tern-warning
+                javascript-disable-tern-warning)
       (spacemacs-buffer/warning "tern binary not found!"))
     found))


### PR DESCRIPTION
This PR adds `javascript-disable-tern-warning` to the `javascript` layer, which allows users to disable the warning if they don't wish to install tern (so that there's no need to rely on the exclude-package hack).

This should be useful for instance to folks who use the javascript layer just for `json-mode`.