### PR TITLE
add yas-activate-extra-mode command when init yasnippet

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -198,7 +198,7 @@
 
 (defun auto-completion/init-yasnippet ()
   (use-package yasnippet
-    :commands (yas-global-mode yas-minor-mode)
+    :commands (yas-global-mode yas-minor-mode yas-activate-extra-mode)
     :init
     (progn
       ;; We don't want undefined variable errors


### PR DESCRIPTION
Since we use this method to enable yasnippet in react-mode setup [here](https://github.com/ztlevi/spacemacs/blob/develop/layers/+frameworks/react/funcs.el#L21). This command might need to be added when init yasnippet.