### PR TITLE
Fix doc for octave, sql and go layers

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -19,7 +19,7 @@
   - [[#refactoring][Refactoring]]
 
 * Description
-This layer adds extensive support for go.
+This layer adds extensive support for go to Spacemacs.
 
 ** Features:
 - gofmt/goimports on file save
@@ -32,7 +32,7 @@ This layer adds extensive support for go.
 
 * Install
 ** Pre-requisites
-You will need =gocode=, =godef= and =godoctor=:
+You will need =gocode=, =gogetdoc=, =godef= and =godoctor=:
 
 #+BEGIN_SRC sh
   go get -u -v github.com/nsf/gocode
@@ -40,6 +40,7 @@ You will need =gocode=, =godef= and =godoctor=:
   go get -u -v golang.org/x/tools/cmd/guru
   go get -u -v golang.org/x/tools/cmd/gorename
   go get -u -v golang.org/x/tools/cmd/goimports
+  go get -u -v github.com/zmb3/gogetdoc
 #+END_SRC
 
 If you wish to use =gometalinter= set the value of =go-use-gometalinter= to t:
@@ -135,7 +136,25 @@ searching.
 In addition, =GOPATH= must be set prior to =go-guru= initialization.
 
 ** Autocomplete
-=gocode= uses the output from installed binary files to provide its suggestions.
+For auto-completion there are actually two choices. First there is the classic =gocode=.
+This has been around for quite a long time now, however =gocode= has many shortcomings like
+not being able to show documentation for build-in objects or being fully dependent on installed binary
+files to provide its suggestions.
+
+A more modern and complete solution is provided by =gogetdoc= which is able to
+precisely detect all documentations in your go projects independent on where
+they have been added. This is also the choice recommended from =go-mode.el=.
+
+To choose =gocode= nothing more needs to be done. To use =gogetdoc= you need to set
+
+#+begin_src emacs-lisp
+  (go :variables godoc-at-point-function 'godoc-gogetdoc)
+#+end_src
+
+in your =dotfile=.
+
+If you choose to use =gocode= there are some suggestions to improve its results.
+As =gocode= uses the output from installed binary files to provide its suggestions.
 You have a few options to ensure you always get up to date suggestions:
 
 - Run =go install ./...= in your package directory when you make a file change.

--- a/layers/+lang/octave/README.org
+++ b/layers/+lang/octave/README.org
@@ -4,14 +4,20 @@
 
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
   - [[#inferior-repl-process][Inferior REPL process]]
   - [[#helpers][Helpers]]
 
 * Description
-This layer activates [[https://www.gnu.org/software/emacs/manual/html_mono/octave-mode.html][octave-mode]] for files with =.m=
-extensions and configures spacemacs-style key bindings.
+This layer adds support for =GNU Octave= files to Spacemacs.
+
+** Features:
+- Syntax highlighting for =.m= files via [[https://www.gnu.org/software/emacs/manual/html_mono/octave-mode.html][octave-mode]].
+- REPL support
+- Support for directly running =Octave= scripts from emacs.
+- Integration with =Octaves= documentation search function.
 
 * Install
 Make sure that [[https://www.gnu.org/software/octave/][GNU Octave]] is installed and
@@ -28,9 +34,10 @@ Send code to inferior process with these commands:
 
 | Key         | Description                           |
 |-------------+---------------------------------------|
+| ~SPC m '~   | start/switch to REPL inferior process |
+| ~SPC m s i~ |                                       |
 | ~SPC m s b~ | send buffer                           |
 | ~SPC m s f~ | send function                         |
-| ~SPC m s i~ | start/switch to REPL inferior process |
 | ~SPC m s l~ | send line                             |
 | ~SPC m s r~ | send region                           |
 

--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -4,6 +4,7 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#sql-keywords-capitalization][SQL Keywords Capitalization]]
     - [[#sql-interactive-mode][SQL Interactive Mode]]
@@ -16,13 +17,39 @@
   - [[#code-formating][Code Formating]]
 
 * Description
-This layer adds key bindings and configuration for =sql-mode=, which manages
-interactive SQL buffers and highlights a wide range of SQL dialects.
+This layer adds support for a wide range of SQL dialects to Spacemacs.
+
+** Features:
+- Syntax highlighting for the following SQL dialects
+  - ANSI
+  - DB2
+  - Informix
+  - Ingres
+  - Interbase
+  - Linter
+  - Microsoft
+  - MySQL
+  - Oracle
+  - Postgres
+  - Solid
+  - SQLite
+  - Sybase
+  - Vertica
+- Syntax-checking via [[https://github.com/purcell/sqlint][sqlint]] for ANSI SQL.
+- Snippet insertion for the more general SQL constructs.
+- REPL support via =SQLi= buffer.
+- Automatic capitalization of keywords.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =sql= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+For syntax-checking you also need to install [[https://www.ruby-lang.org/en/about/][ruby]] as well as =sqlint=.
+
+#+BEGIN_SRC ruby
+	gem install sqlint
+#+END_SRC
 
 ** SQL Keywords Capitalization
 SQL, by convention, uses upper-case keywords, although lower-case works just as


### PR DESCRIPTION
Fixed the missing features block for octave and sql layer.

Also added some additions to the auto-completion documentation for the go layer
to include an alternative help provider as is suggested in the documentation of `go-mode`.

This is part of #9476