### PR TITLE
add key bindings for profiling and spec browsing

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -36,6 +36,7 @@
     - [[#sayid-traced-mode][sayid-traced-mode]]
     - [[#sayid-pprint][sayid-pprint]]
     - [[#cider-repl-mode][cider-repl-mode]]
+    - [[#profiling][Profiling...]]
 - [[#development-notes][Development Notes]]
   - [[#indentation][Indentation]]
 
@@ -198,6 +199,8 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m g r~ | goto resource         |
 | ~SPC m g n~ | browse namespaces     |
 | ~SPC m g N~ | browse all namespaces |
+| ~SPC m g s~ | browse spec           |
+| ~SPC m g S~ | browse all specs      |
 
 *** REPL
 
@@ -435,6 +438,16 @@ In general, ~q~ should always quit the popped up buffer.
 |-------------+----------------|
 | ~C-j~       | next input     |
 | ~C-k~       | previous input |
+
+*** Profiling...
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m p t~ | toggle profile    |
+| ~SPC m p c~ | clear profile     |
+| ~SPC m p s~ | profile summary   |
+| ~SPC m p S~ | summary for all   |
+| ~SPC m p n~ | toggle profile ns |
 
 * Development Notes
 ** Indentation

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -65,7 +65,9 @@
                ("ms" . "repl")
                ("mt" . "test")
                ("mT" . "toggle")
-               ("mf" . "format"))))
+               ("mf" . "format")
+               ("mp" . "profile")
+               )))
         (dolist (m '(clojure-mode
                      clojurec-mode
                      clojurescript-mode
@@ -103,6 +105,8 @@
             "gr" 'cider-find-resource
             "gn" 'cider-browse-ns
             "gN" 'cider-browse-ns-all
+            "gs" 'cider-browse-spec
+            "gS" 'cider-browse-spec-all
 
             "'"  'cider-jack-in
             "\"" 'cider-jack-in-clojurescript
@@ -146,6 +150,15 @@
             "db" 'cider-debug-defun-at-point
             "de" 'spacemacs/cider-display-error-buffer
             "dv" 'cider-inspect
+
+            ;; profile
+            "pt" 'cider-profile-toggle
+            "pc" 'cider-profile-clear
+            "pS" 'cider-profile-summary
+            "ps" 'cider-profile-var-summary
+            "pn" 'cider-profile-ns-toggle
+            "pv" 'cider-profile-var-profiled-p
+            "p+" 'cider-profile-samples
 
             ;; refactorings from clojure-mode
             "rc{" 'clojure-convert-collection-to-map


### PR DESCRIPTION
Add key bindings for cider's new feature (0.17.0-SNAPSHOT):

 * profiling
 * spec browsing