### PR TITLE
[prodigy] renames jump function

### DIFF
--- a/layers/+tools/prodigy/packages.el
+++ b/layers/+tools/prodigy/packages.el
@@ -27,7 +27,7 @@
         "J" 'prodigy-next-with-status
         "K" 'prodigy-prev-with-status
         "L" 'prodigy-start
-        "d" 'prodigy-jump-dired
+        "d" 'prodigy-jump-file-manager
         "g" 'prodigy-jump-magit
         "Y" 'prodigy-copy-cmd
         "R" 'revert-buffer)


### PR DESCRIPTION
This function was renamed in https://github.com/rejeep/prodigy.el/pull/110 which has been recently merged to master