### PR TITLE
Fix doc for S>-completion and S>-editing-visual layers

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/README.org
+++ b/layers/+spacemacs/spacemacs-completion/README.org
@@ -2,7 +2,12 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-spacemacs-completion-layer-in-this-file][describe spacemacs-completion layer in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe spacemacs-completion layer in this file
+This layer adds basics for providing code-completion for various major modes
+to Spacemacs.
+
+** Features:
+- Preconfiguration of =helm= and =ivy= for other layers to use.
+- Adding of =ido-navigation= configuration and transient state.

--- a/layers/+spacemacs/spacemacs-editing-visual/README.org
+++ b/layers/+spacemacs/spacemacs-editing-visual/README.org
@@ -2,7 +2,16 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-spacemacs-editing-visual-layer-in-this-file][describe spacemacs-editing-visual layer in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe spacemacs-editing-visual layer in this file
+This layer defines a lot of functions used to visually enhance the currently
+edited line in Spacemacs.
+
+** Features:
+- Adaptive wrapping
+- Hiding of comments
+- Highlighting of columns longer than 80 chars
+- Highlighting of different indentations
+- Automatic highlighting of numbers
+- Automatic highlighting of parentheses


### PR DESCRIPTION
Fixed the documentation for the spacemacs-completion and spacemacs-editing-visual layers.
This is part of #9476.