### PR TITLE
Fix doc for S>-bootstrap, S>-navigation, S>-visual and S>-org

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/README.org
+++ b/layers/+distributions/spacemacs-bootstrap/README.org
@@ -2,7 +2,16 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-spacemacs-bootstrap-distribution-in-this-file][describe spacemacs-bootstrap distribution in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe spacemacs-bootstrap distribution in this file
+This layer loads the necessary packages for spacemacs to start-up.
+
+** Features:
+- Loads =evil= key bindings
+- Loads =use-package= which is used to load other packages more easily
+- Loads =hydra= which is used to create transient modes
+- Loads =which-key= which is used to show keybindings in other modes
+- Loads =async= which is used to run background processes
+- Loads =bind-map= and =bind-key= which are used to realise various
+  spacemacs specific keybinding commands

--- a/layers/+spacemacs/spacemacs-navigation/README.org
+++ b/layers/+spacemacs/spacemacs-navigation/README.org
@@ -2,7 +2,20 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-spacemacs-navigation-layer-in-this-file][describe spacemacs-navigation layer in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe spacemacs-navigation layer in this file
+This layer adds general navigation functions to all supported layers.
+
+** Features:
+- Support for ace-links in
+  - =spacemacs= buffer
+  - =info-mode=
+  - =help-mode=
+  - =eww-mode=
+- Support for keeping the cursor centered on the screen
+- Evilified version of =doc-view-mode=
+- Tweaks for =golden-ratio-mode=
+- Support for =paradox= a modern emacs package manager
+- Shortcuts for restarting =emacs=
+- Shortcuts for easily switching between windows

--- a/layers/+spacemacs/spacemacs-org/README.org
+++ b/layers/+spacemacs/spacemacs-org/README.org
@@ -2,7 +2,13 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-spacemacs-org-layer-in-this-file][describe spacemacs-org layer in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe spacemacs-org layer in this file
+This layer tweaks =org-mode= to integrate nicely into Spacemacs.
+
+** Features:
+- Configuration for =flyspell= to check =org-buffers= for typos.
+- Support for automatically generated Table-Of-Contents via =toc-org=.
+- Support for custom bullet markers via =org-bullets=.
+- Support for a special view mode for org documents via =space-doc=.

--- a/layers/+spacemacs/spacemacs-visual/README.org
+++ b/layers/+spacemacs/spacemacs-visual/README.org
@@ -2,7 +2,17 @@
 
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#describe-spacemacs-visual-layer-in-this-file][describe spacemacs-visual layer in this file]]
+  - [[#features][Features:]]
 
 * Description
-** TODO describe spacemacs-visual layer in this file
+This layer adds various modes to enhance Spacemacs visual appearance.
+
+** Features:
+- Automatic colorization of compilation buffers via =ansi-colors=.
+- Support for resuming the last layout when starting Spacemacs via =desktop=.
+- Support for showing a thin vertical line to indicate the fill column
+  via =fill-column-indicator=.
+- Automatic highlighting of =TODO-tags= in programming and text modes
+  via =hl-todo=.
+- Support for temporary windows which close automatically via =popwin=.
+- Support for text zooming via =zoom-frm=.


### PR DESCRIPTION
Fixed the documentation for spacemacs-bootstrap, spacemacs-navigation
spacemacs-visual and spacemacs-org.

This is part of #9476