### PR TITLE
Fix spacemacs/swiper-all-region-or-symbol function

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -442,14 +442,8 @@ around point as the initial input."
   "Run `swiper-all' with the selected region or the symbol
 around point as the initial input."
   (interactive)
-  (ivy-read "Swiper: " (swiper--multi-candidates
-                        (cl-remove-if-not
-                         #'buffer-file-name
-                         (buffer-list)))
-            :initial-input (if (region-active-p)
-                               (buffer-substring-no-properties
-                                (region-beginning) (region-end))
-                             (thing-at-point 'symbol t))
-            :action 'swiper-multi-action-2
-            :unwind #'swiper--cleanup
-            :caller 'swiper-multi))
+  (let ((input (if (region-active-p)
+                   (buffer-substring-no-properties
+                    (region-beginning) (region-end))
+                 (thing-at-point 'symbol t))))
+    (swiper-all input)))


### PR DESCRIPTION
spacemacs/swiper-all-region-or-symbol function doesn't work properly. It breaks for search in other buffers. This is probably due to using old swiper api which has changed.