### PR TITLE
Fix  #10394 -- helm-layer init-helm-xref

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -716,6 +716,7 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
 (defun helm/init-helm-xref ()
   (use-package helm-xref
     :defer t
+    :commands (helm-xref-show-xrefs)
     :init
     (progn
       ;; This is required to make `xref-find-references' not give a prompt.


### PR DESCRIPTION
Issue reported here:
https://github.com/syl20bnr/spacemacs/issues/10394

helm-layer helm/init-helm-xref sets xref-show-xrefs-function to helm-xref-show-xrefs in use-package :init, but doesn't export the symbol in :commands, resulting in a symbol-function-definition-is-void error when show-xrefs is invoked.

The fix just adds a :commands section to the relevant use-package invocation
