### PR TITLE
Fix (void-variable hydra-ivy/keymap) issue

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -212,7 +212,8 @@
       (setq ivy-use-selectable-prompt t))))
 
 (defun ivy/init-ivy-hydra ()
-  (use-package ivy-hydra)
+  (use-package ivy-hydra
+    :demand t)
   (define-key hydra-ivy/keymap [escape] 'hydra-ivy/keyboard-escape-quit-and-exit))
 
 (defun ivy/init-ivy-rich ()


### PR DESCRIPTION
After change to by default using use-package-always-defer, the ivy layer
complain about (void-variable hydra-ivy/keymap) which should be caused the
variable is used before ivy package is loaded.

Add ":demand t" to ensure ivy package will be loaded first.