### PR TITLE
lsp layer -- allow deferred loading of lsp-ui package (resolves issue #10407)

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -43,6 +43,7 @@
 (defun lsp/init-lsp-ui ()
   (use-package lsp-ui
     :init (add-hook 'lsp-mode-hook #'lsp-ui-mode)
+    :commands (lsp-ui-mode)
     :config
     (progn
       (spacemacs//lsp-sync-peek-face)


### PR DESCRIPTION
lsp layer was broken when use-package default changed to deferred loading

Resolved by adding a :command lsp-ui-mode parameter to the use package call.