### PR TITLE
use-package-always-defer: fix regressions in spacemacs-editing

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -85,6 +85,7 @@
 
 (defun spacemacs-editing/init-clean-aindent-mode ()
   (use-package clean-aindent-mode
+    :demand t
     :config (clean-aindent-mode)))
 
 (defun spacemacs-editing/init-editorconfig ()


### PR DESCRIPTION
`clean-aindent-mode` was previously loaded unconditionally at init time.  This re-enables that behavior.