### PR TITLE
Add `:demand t` to fix loading treemacs-evil package

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -61,6 +61,7 @@
 
 (defun treemacs/init-treemacs-evil ()
   (use-package treemacs-evil
+    :demand t
     :after treemacs
     :if (memq dotspacemacs-editing-style '(vim hybrid))))
 


### PR DESCRIPTION
It appears that 29c78ce changed `:defer t` to be the default for use-package, and that previously the `treemacs` and `treemacs-projectile` packages in treemacs/packages.el specified `:defer t`, but *not* `treemacs-evil`.  Restoring `:demand t` (previously the default) to `treemacs-evil` appears to fix #10422.

I'm still pretty new to spacemacs and emacs in general and I don't fully understand everything that's going on here, so take my description with a grain of salt.  This does, however, appear to fix #10422.