### PR TITLE
Call helm-mode when helm is initialized

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -58,8 +58,6 @@
 
 (defun helm/init-helm ()
   (use-package helm
-    :commands (spacemacs/helm-find-files
-               helm-current-directory)
     :init
     (progn
       (add-hook 'helm-cleanup-hook #'spacemacs//helm-cleanup)
@@ -119,10 +117,10 @@
                 (lambda ()
                   (unless (configuration-layer/package-used-p 'smex)
                     (spacemacs/set-leader-keys
-                      dotspacemacs-emacs-command-key 'helm-M-x)))))
+                      dotspacemacs-emacs-command-key 'helm-M-x))))
+      (helm-mode))
     :config
     (progn
-      (helm-mode)
       (advice-add 'helm-grep-save-results-1 :after 'spacemacs//gne-init-helm-grep)
       ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
       (helm-locate-set-command)


### PR DESCRIPTION
If we don't call `helm-mode` when helm is initialized, helm's changing to functions like `completing-read-function` can't take effect before helm is lazy loaded. So if I call functions using `completing-read` like `describe-function`(<kbd>C-h f</kbd>), it won't be taken over with helm.
In commits prior to 29c78ce841ee5a99bb4077a2862afc96c8136107 ,helm was set with `:defer 1` , which means that helm will be initialized after 1 second.(#1967)
However, this way causes many confustion. Functions using `completing-read` will be taken over with helm only after emacs has idled for 1 second. #9826 comes with the same reason.
As `helm-mode` requires `helm-lib`, where `helm-current-directory` locates in, we don't need to specify it now like what #9869 do.
And I still wonder [Should helm be deferred?](https://github.com/syl20bnr/spacemacs/issues/1967)