### PR TITLE
cc-mode: move c-toggle-auto-newline to hook

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -42,11 +42,11 @@
     :init
     (progn
       (add-to-list 'auto-mode-alist
-                   `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
+                   `("\\.h\\'" . ,c-c++-default-mode-for-headers))
+      (add-hook 'c-mode-common-hook (lambda () (c-toggle-auto-newline 1))))
     :config
     (progn
       (require 'compile)
-      (c-toggle-auto-newline 1)
       (dolist (mode c-c++-modes)
         (spacemacs/declare-prefix-for-mode mode "mc" "compile")
         (spacemacs/declare-prefix-for-mode mode "mg" "goto")


### PR DESCRIPTION
Without this, the first time cc-mode is required the current major-mode name
gets `//la` appended to it, which is very confusing. This will run
`c-toggle-auto-newline` when a c-mode is enabled, which seems to be more correct
any way.