### PR TITLE
recentf : use recentf-expand-file-name to generate recentf-exclude

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -232,8 +232,8 @@
     :config
     (progn
       (add-to-list 'recentf-exclude
-                   (file-truename spacemacs-cache-directory))
-      (add-to-list 'recentf-exclude (file-truename package-user-dir))
+                   (recentf-expand-file-name spacemacs-cache-directory))
+      (add-to-list 'recentf-exclude (recentf-expand-file-name package-user-dir))
       (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'"))))
 
 (defun spacemacs-defaults/init-savehist ()


### PR DESCRIPTION
I don't know what problem #8005 has solved.
I think he has changed `recentf-filename-handlers`.
It's better to use recentf-expand-file-name to do it.