### PR TITLE
Allow setting of server-socket-dir in .spacemacs

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -343,6 +343,12 @@ restricts line-number to the specified list of major-mode.")
 (defvar dotspacemacs-persistent-server nil
   "If non nil advises quit functions to keep server open when quitting.")
 
+(defvar dotspacemacs-server-socket-dir nil
+  "Set the emacs server socket location.
+If nil, uses whatever the Emacs default is,
+otherwise a directory path like \"~/.emacs.d/server\".
+Has no effect if `dotspacemacs-enable-server' is nil.")
+
 (defvar dotspacemacs-smartparens-strict-mode nil
   "If non-nil smartparens-strict-mode will be enabled in programming modes.")
 

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3254,6 +3254,12 @@ export EDITOR="/Applications/Emacs.app/Contents/MacOS/bin/emacsclient -c"
 Tip: Remember to use ~:wq~ or ~C-x #~ after you are done editing the file in
 Emacs.
 
+You can set the location of the Emacs server socket by setting =dotspacemacs-server-socket-dir= in your =~./spacemacs=:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-server-socket-dir "~/.emacs/server")
+#+END_SRC
+
 See [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Emacs-Server.html][Emacs as a Server]] in the official Emacs manual for more details.
 
 ** Keeping the server alive

--- a/init.el
+++ b/init.el
@@ -35,4 +35,6 @@
     (spacemacs/setup-startup-hook)
     (when dotspacemacs-enable-server
       (require 'server)
+      (when dotspacemacs-server-socket-dir
+        (setq server-socket-dir dotspacemacs-server-socket-dir))
       (unless (server-running-p) (server-start)))))


### PR DESCRIPTION
This allows you to define where to set the socket location in Spacemacs. This is really useful in some cases, since otherwise it can be (for instance) some random temporary file. It's a very small change - 3 lines of code and 4 lines of comments ;)

Now you can add ` dotspacemacs-server-socket-dir "~/.emacs.d/server"` in `dotspacemacs/init` in your `.spacemacs`!

<3