### PR TITLE
fix problem: c-c++-enable-clang-format-on-save not work

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -71,6 +71,8 @@
     :if c-c++-enable-clang-support
     :init
     (progn
+      (when c-c++-enable-clang-format-on-save
+        (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks))
       (dolist (mode c-c++-modes)
         (spacemacs/declare-prefix-for-mode mode "m=" "format")
         (spacemacs/set-leader-keys-for-major-mode mode


### PR DESCRIPTION
fix problem: when c-c++-enable-clang-format-on-save is set in c-c++ layer, but it didn't work.
