### PR TITLE
Remove spacemacs//c-toggle-auto-newline

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -9,10 +9,6 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs//c-toggle-auto-newline ()
-  "Toggle auto-newline."
-  (c-toggle-auto-newline 1))
-
 
 ;; clang
 

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -43,8 +43,7 @@
     :init
     (progn
       (add-to-list 'auto-mode-alist
-                   `("\\.h\\'" . ,c-c++-default-mode-for-headers))
-      (add-hook 'c-mode-common-hook 'spacemacs//c-toggle-auto-newline))
+                   `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
     :config
     (progn
       (require 'compile)


### PR DESCRIPTION
This is an annoying option that is very hard to override on user's side.

The probably choices are:

```elisp
(add-hook 'after-change-major-mode-hook (lambda() (electric-indent-mode -1)))

;; private layer
(defun my-code/post-init--cc-mode () ... (delq 'spacemacs//c-toggle-auto-newline c-mode-common-hook)
```

Neither is obvious. The wrapper ` (c-toggle-auto-newline 1)` serves no purpose... and at least it should use 0

auto-newline is annoying because people spend more time editing existing code than adding consecutive lines. The auto added new line is oftentimes undesired rather than useful.