### PR TITLE
c-c++: remove c-c++-enable-c++11

### DIFF
--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -39,9 +39,6 @@
   "If non-nil, automatically format code with ClangFormat on
   save. Clang support has to be enabled for this to work.")
 
-(defvar c-c++-enable-c++11 nil
-  "If non nil then c++11 related features will be enabled")
-
 (spacemacs|define-jump-handlers c++-mode)
 (spacemacs|define-jump-handlers c-mode)
 

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -77,8 +77,6 @@
   (when c-c++-enable-clang-support
     (spacemacs|add-company-backends :backends company-clang
       :modes c-mode-common)
-    (when c-c++-enable-c++11
-      (setq company-clang-arguments '("-std=c++11")))
     (setq company-clang-prefix-guesser 'spacemacs/company-more-than-prefix-guesser)
     (spacemacs/add-to-hooks 'spacemacs/c-c++-load-clang-args c-c++-mode-hooks)))
 
@@ -122,9 +120,7 @@
   (dolist (mode c-c++-modes)
     (spacemacs/enable-flycheck mode))
   (when c-c++-enable-clang-support
-    (spacemacs/add-to-hooks 'spacemacs/c-c++-load-clang-args c-c++-mode-hooks)
-    (when c-c++-enable-c++11
-      (setq flycheck-clang-language-standard "c++11"))))
+    (spacemacs/add-to-hooks 'spacemacs/c-c++-load-clang-args c-c++-mode-hooks)))
 
 ;; TODO lazy load this package
 (defun c-c++/init-flycheck-rtags ()


### PR DESCRIPTION
This config variable does not make sense.

There are c++11 c++14 c++17 c++2a gnu++11 gnu++14 gnu++17 gnu++2a. `-std=c++11` will actually disable some features, for example, generic lambda.

The language option is also a per-project option, it should not be global.

https://github.com/syl20bnr/spacemacs/issues/10143