### PR TITLE
make shell pop layout local

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/config.el
+++ b/layers/+spacemacs/spacemacs-layouts/config.el
@@ -55,3 +55,12 @@ layout, the 4th for the 4th, and so on until the 10th (aka layout
 number 0). The first list is sepcial - it is a grab-bag for names
 in case none of the regular names can be used for a new layout.")
 
+(defvar layouts-enable-local-variables t
+  "Allow variables to be specified as layout-local (value local to a particular layout).")
+
+(defvar spacemacs--layout-local-variables nil
+  "List of variables that will be local to the current layout.")
+
+(defvar spacemacs--layout-local-map (ht-create)
+  "Map of layouts to their local variable values.")
+

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -689,3 +689,32 @@ containing the buffer."
                (append (persp-parameter 'gui-eyebrowse-window-configs persp)
                        (persp-parameter 'term-eyebrowse-window-configs persp)))
         (eyebrowse--rename-window-config-buffers window-config old new)))))
+
+
+;; layout local variables
+
+(defun spacemacs/make-variable-layout-local (&rest vars)
+  "Make variables become layout-local whenever they are set.
+Accepts a list of VARIABLE, DEFAULT-VALUE pairs.
+
+(spacemacs/make-variable-layout-local 'foo 1 'bar 2)"
+  (cl-loop for (symbol default-value) on vars by 'cddr
+           do (add-to-list 'spacemacs--layout-local-variables (cons symbol default-value))))
+
+(defun spacemacs//load-layout-local-vars (persp-name &rest _)
+  "Load the layout-local values of variables for PERSP-NAME."
+  (let ((layout-local-vars (-filter 'boundp
+                                    (-map 'car
+                                          spacemacs--layout-local-variables))))
+    ;; save the current layout
+    (ht-set! spacemacs--layout-local-map
+             (spacemacs//current-layout-name)
+             (--map (cons it (symbol-value it))
+                    layout-local-vars))
+    ;; load the default values into the new layout
+    (--each layout-local-vars
+      (set it (alist-get it spacemacs--layout-local-variables)))
+    ;; override with the previously bound values for the new layout
+    (--when-let (ht-get spacemacs--layout-local-map persp-name)
+      (-each it
+        (-lambda ((var . val)) (set var val))))))

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -220,6 +220,8 @@
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
       (advice-add 'persp-load-state-from-file :before 'spacemacs//layout-wait-for-modeline)
+      (when layouts-enable-local-variables
+        (advice-add 'persp-switch :before #'spacemacs//load-layout-local-vars))
       (spacemacs/declare-prefix "b" "persp-buffers")
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -189,3 +189,11 @@ is achieved by adding the relevant text properties."
   "Send tab in term mode."
   (interactive)
   (term-send-raw-string "\t"))
+
+(defun spacemacs//shell-pop-restore-window ()
+  "Fixes an issue during `shell-pop-out' where it
+tries to restore a dead buffer or window."
+  (unless (buffer-live-p shell-pop-last-buffer)
+    (setq shell-pop-last-buffer (window-buffer (get-mru-window nil t t))))
+  (unless (window-live-p shell-pop-last-window)
+    (setq shell-pop-last-window (get-buffer-window shell-pop-last-buffer))))

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -72,9 +72,15 @@ SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
            (,func ,shell)
          (shell-pop--set-shell-type
           'shell-pop-shell-type
-          (backquote (,name
-                      ,(concat "*" name "*")
-                      (lambda nil (,func ,shell)))))
+          (list ,name
+                ,(if layouts-enable-local-variables
+                     `(concat "*" (spacemacs//current-layout-name) "-"
+                              (if (file-remote-p default-directory)
+                                  "remote-"
+                                "")
+                              ,name "*")
+                   (concat "*" name "*"))
+                (lambda nil (,func ,shell))))
          (shell-pop index)
          (spacemacs/resize-shell-to-desired-width)))))
 

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -218,6 +218,8 @@
       (make-shell-pop-command multiterm)
       (make-shell-pop-command ansi-term shell-pop-term-shell)
 
+      (spacemacs/make-variable-layout-local 'shell-pop-last-shell-buffer-index 1
+                                            'shell-pop-last-shell-buffer-name "")
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
       (add-hook 'term-mode-hook (lambda () (linum-mode -1)))
 

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -219,7 +219,8 @@
       (make-shell-pop-command ansi-term shell-pop-term-shell)
 
       (spacemacs/make-variable-layout-local 'shell-pop-last-shell-buffer-index 1
-                                            'shell-pop-last-shell-buffer-name "")
+                                            'shell-pop-last-shell-buffer-name ""
+                                            'shell-pop-last-buffer nil)
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
       (add-hook 'term-mode-hook (lambda () (linum-mode -1)))
 
@@ -229,7 +230,9 @@
         "asi" 'spacemacs/shell-pop-shell
         "asm" 'spacemacs/shell-pop-multiterm
         "ast" 'spacemacs/shell-pop-ansi-term
-        "asT" 'spacemacs/shell-pop-term))))
+        "asT" 'spacemacs/shell-pop-term))
+    :config
+    (add-hook 'shell-pop-out-hook #'spacemacs//shell-pop-restore-window)))
 
 (defun shell/init-term ()
   (spacemacs/register-repl 'term 'term)


### PR DESCRIPTION
There are two commits here. The first adds new functionality to allow users to specify certain variables as "layout local" (meaning the the value will be bound to the current layout).

The second commit uses this new mechanism to make shell-pop's shells bound to the current layout. This behavior can be toggled with `layouts-enable-local-variables`.