### PR TITLE
Make fcitx.el in Chinese layer work by default.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1103,6 +1103,11 @@ Other:
 - New packages:
   - Added package =chinese-conv= for conversion between simplified and
     traditional Chinese texts (Xiang Ji)
+- Improvements:
+  - Added variable =chinese-fcitx-use-dbus=, and fixed the misinformation about
+    dbus in README.org (thanks to AmaiKinono)
+- Fixes:
+  - Make =fcitx.el= work by default (thanks to AmaiKinono)
 **** Chrome
 - Key bindings:
   - Added =markdown= key bindings to gmail message mode

--- a/layers/+intl/chinese/README.org
+++ b/layers/+intl/chinese/README.org
@@ -99,7 +99,17 @@ with the following configuration.
 
 **** Requirement
 ***** Linux
-You need to install =fcitx= and dbus interface on your machine.
+You need to install =fcitx=  on your machine.
+
+It's recommended to use dbus interface to speed up a little:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '((chinese :variables
+                                                             chinese-enable-fcitx t
+                                                             chinese-fcitx-use-dbus t)))
+#+END_SRC
+
+But notice that [[https://github.com/cute-jumper/fcitx.el/issues/30][this may lead to command lag]].
 
 ***** Mac OS X
 We don't have a =fcitx= in OS X yet but we already added an emulation called

--- a/layers/+intl/chinese/README.org
+++ b/layers/+intl/chinese/README.org
@@ -99,7 +99,7 @@ with the following configuration.
 
 **** Requirement
 ***** Linux
-You need to install =fcitx= and =fcitx-remote= on your machine.
+You need to install =fcitx= and dbus interface on your machine.
 
 ***** Mac OS X
 We don't have a =fcitx= in OS X yet but we already added an emulation called

--- a/layers/+intl/chinese/config.el
+++ b/layers/+intl/chinese/config.el
@@ -23,6 +23,9 @@
 (defvar chinese-enable-fcitx nil
   "Enable fcitx to help writing Chinese in Evil mode.")
 
+(defvar chinese-fcitx-use-dbus nil
+  "Use dbus interface for fcitx.el.")
+
 ;; Set the monospaced font size when mixed Chinese and English words
 (defun spacemacs//set-monospaced-font (english chinese english-size chinese-size)
   (set-face-attribute 'default nil :font

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -32,7 +32,7 @@
     (setq fcitx-active-evil-states '(insert emacs hybrid))
     (fcitx-default-setup)
     (fcitx-prefix-keys-add "M-m" "C-M-m")
-    (if (eq system-type 'gnu/linux)
+    (if chinese-fcitx-use-dbus
         (setq fcitx-use-dbus t)))
   )
 

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -27,7 +27,14 @@
 (defun chinese/init-fcitx ()
   (use-package fcitx
     :init
-    (fcitx-evil-turn-on)))
+    (fcitx-evil-turn-on)
+    :config
+    (setq fcitx-active-evil-states '(insert emacs hybrid))
+    (fcitx-default-setup)
+    (fcitx-prefix-keys-add "M-m" "C-M-m")
+    (if (eq system-type 'gnu/linux)
+        (setq fcitx-use-dbus t)))
+  )
 
 (defun chinese/init-chinese-wbim ()
   "Initialize chinese-wubi"

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -32,7 +32,7 @@
     (setq fcitx-active-evil-states '(insert emacs hybrid))
     (fcitx-default-setup)
     (fcitx-prefix-keys-add "M-m" "C-M-m")
-    (if chinese-fcitx-use-dbus
+    (when chinese-fcitx-use-dbus
         (setq fcitx-use-dbus t)))
   )
 


### PR DESCRIPTION
- Make fcitx.el work by default. fcitx.el was not configured properly in original chinese layer.

- Corrected README.org. It is dbus interface (not fcitx-remote) that is needed for linux.
