### PR TITLE
Add various keycommands to markdown layer.

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -15,6 +15,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#element-insertion][Element insertion]]
   - [[#element-removal][Element removal]]
+  - [[#table-manipulation][Table manipulation]]
   - [[#completion][Completion]]
   - [[#following-and-jumping][Following and Jumping]]
   - [[#indentation][Indentation]]
@@ -112,6 +113,7 @@ To generate a table of contents type on top of the buffer:
 | ~SPC m i I~ | insert reference image                                            |
 | ~SPC m i t~ | insert Table of Contents (toc)                                    |
 | ~SPC m x b~ | make region bold or insert bold                                   |
+| ~SPC m x B~ | insert gfm checkbox                                               |
 | ~SPC m x i~ | make region italic or insert italic                               |
 | ~SPC m x c~ | make region code or insert code                                   |
 | ~SPC m x C~ | make region code or insert code (Github Flavored Markdown format) |
@@ -119,12 +121,29 @@ To generate a table of contents type on top of the buffer:
 | ~SPC m x Q~ | blockquote region                                                 |
 | ~SPC m x p~ | make region or insert pre                                         |
 | ~SPC m x P~ | pre region                                                        |
+| ~SPC m x s~ | make region striked through or insert strikethrough               |
 
 ** Element removal
 
 | Key Binding | Description         |
 |-------------+---------------------|
 | ~SPC m k~   | kill thing at point |
+
+** Table manipulation
+
+| Key Binding | Description             |
+|-------------+-------------------------|
+| ~SPC m t p~ | move row up             |
+| ~SPC m t n~ | move row down           |
+| ~SPC m t f~ | move column right       |
+| ~SPC m t b~ | move column left        |
+| ~SPC m t r~ | insert row              |
+| ~SPC m t R~ | delete row              |
+| ~SPC m t c~ | insert column           |
+| ~SPC m t C~ | delete column           |
+| ~SPC m t s~ | sort lines              |
+| ~SPC m t t~ | transpose table         |
+| ~SPC m t d~ | convert region to table |
 
 ** Completion
 

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -72,6 +72,8 @@
             mode (car prefix) (cdr prefix))))
       (dolist (mode markdown--key-bindings-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
+          ;; rebind this so terminal users can use it
+          "M-RET" 'markdown-insert-list-item
           ;; Movement
           "{"   'markdown-backward-paragraph
           "}"   'markdown-forward-paragraph

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -64,6 +64,8 @@
                         ("mh" . "markdown/header")
                         ("mi" . "markdown/insert")
                         ("ml" . "markdown/lists")
+                        ("mt" . "markdown/table")
+                        ("mT" . "markdown/toggle")
                         ("mx" . "markdown/text")))
         (dolist (mode markdown--key-bindings-modes)
           (spacemacs/declare-prefix-for-mode
@@ -114,18 +116,33 @@
           ;; List editing
           "li"  'markdown-insert-list-item
           ;; Toggles
-          "ti"  'markdown-toggle-inline-images
-          "tl"  'markdown-toggle-url-hiding
-          "tt"  'markdown-toggle-gfm-checkbox
-          "tw"  'markdown-toggle-wiki-links
+          "Ti"  'markdown-toggle-inline-images
+          "Tl"  'markdown-toggle-url-hiding
+          "Tm"  'markdown-toggle-markup-hiding
+          "Tt"  'markdown-toggle-gfm-checkbox
+          "Tw"  'markdown-toggle-wiki-links
+          ;; Table
+          "tp"  'markdown-table-move-row-up
+          "tn"  'markdown-table-move-row-down
+          "tf"  'markdown-table-move-column-right
+          "tb"  'markdown-table-move-column-left
+          "tr"  'markdown-table-insert-row
+          "tR"  'markdown-table-delete-row
+          "tc"  'markdown-table-insert-column
+          "tC"  'markdown-table-delete-column
+          "ts"  'markdown-table-sort-lines
+          "td"  'markdown-table-convert-region
+          "tt"  'markdown-table-transpose
           ;; region manipulation
           "xb"  'markdown-insert-bold
-          "xi"  'markdown-insert-italic
+          "xB"  'markdown-insert-gfm-checkbox
           "xc"  'markdown-insert-code
           "xC"  'markdown-insert-gfm-code-block
-          "xq"  'markdown-insert-blockquote
-          "xQ"  'markdown-blockquote-region
+          "xi"  'markdown-insert-italic
           "xp"  'markdown-insert-pre
+          "xq"  'markdown-insert-blockquote
+          "xs"  'markdown-insert-strike-through
+          "xQ"  'markdown-blockquote-region
           "xP"  'markdown-pre-region
           ;; Following and Jumping
           "N"   'markdown-next-link


### PR DESCRIPTION
Added some keycommands to markdown layer.

The original `SPC m t` (toggle) was moved to `SPC m T` because the convention says table commands should be under `SPC m t`.

Btw, I noticed that `M-RET` seems like calling `markdown-insert-list-item`. That's not right because `M-RET` is the major mode leader key in terminal. But I didn't figure out how it was binded...