### PR TITLE
Re-enable Wolfram-mode, since it is added back to Melpa.

### DIFF
--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -14,9 +14,7 @@
         thrift
         vala-mode
         (vala-snippets :requires yasnippet)
-        ;; removed from MELPA (https://github.com/syl20bnr/spacemacs/issues/9795)
-        ;; TODO re-enable this mode when it is added back to MELPA
-        ;; wolfram-mode
+        wolfram-mode
         ))
 
 (defun major-modes/init-arduino-mode ())


### PR DESCRIPTION
Wolfram-mode was added back to Melpa, so let us enable it. See #9795.