### PR TITLE
Fix run-pandoc resetting settings

### DIFF
--- a/layers/+tools/pandoc/funcs.el
+++ b/layers/+tools/pandoc/funcs.el
@@ -12,5 +12,6 @@
 (defun spacemacs/run-pandoc ()
   "Start pandoc for the buffer and open the menu"
   (interactive)
-  (pandoc-mode)
+  ;; only run pandoc-mode if not active, as it resets pandoc--local-settings
+  (if (not (bound-and-true-p pandoc-mode)) (pandoc-mode))
   (pandoc-main-hydra/body))


### PR DESCRIPTION
When using spacemacs/run-pandoc to open the pandoc hydra, pandoc-mode
is called each time, which will overwrite any previous changes the user
might have done to pandoc--local-settings.

Fix this by calling pandoc-mode only when it is not yet enabled.