### PR TITLE
Fix Slack Layer helm menu display

### DIFF
--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -61,6 +61,7 @@
     :defer t
     :init
     (progn
+      (spacemacs/declare-prefix "aC" "slack")
       (spacemacs/set-leader-keys
         "aCs" 'slack-start
         "aCj" 'slack-channel-select


### PR DESCRIPTION
Changed the slack layer to display "+slack" rather than "+prefix"
This matches other layers (i.e. +org, +irc) under <leader> a.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3