### PR TITLE
[html] fix indent-command.

### DIFF
--- a/layers/+lang/html/funcs.el
+++ b/layers/+lang/html/funcs.el
@@ -11,9 +11,10 @@
 
 (defun spacemacs/emmet-expand ()
   (interactive)
-  (if (bound-and-true-p yas-minor-mode)
-      (call-interactively 'emmet-expand-yas)
-    (call-interactively 'emmet-expand-line)))
+  (unless (if (bound-and-true-p yas-minor-mode)
+              (call-interactively 'emmet-expand-yas)
+            (call-interactively 'emmet-expand-line))
+    (indent-for-tab-command)))
 
 (defun spacemacs/impatient-mode ()
   (interactive)


### PR DESCRIPTION
Had an issue with tab not indenting in web-mode. It was only calling emmet-expand. Found this as well. (https://emacs.stackexchange.com/questions/30295/spacemacs-web-mode-cannot-indent).

Function will now redirect to indent function correctly.