### PR TITLE
c-c++: fix setting flycheck to use c++11

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -112,7 +112,7 @@
   (when c-c++-enable-clang-support
     (spacemacs/add-to-hooks 'spacemacs/c-c++-load-clang-args c-c++-mode-hooks)
     (when c-c++-enable-c++11
-      (setq flycheck-clang-language-standard "c++11"))))
+      (add-hook 'c++-mode-hook (lambda () (setq flycheck-clang-language-standard "c++11"))))))
 
 ;; TODO lazy load this package
 (defun c-c++/init-flycheck-rtags ()


### PR DESCRIPTION
Under certain conditions the `c-c++` layer globally sets `flycheck-clang-language-standard` to "c++11", but this has no effect, as detailed in https://stackoverflow.com/a/30964293/3718509 and https://github.com/flycheck/flycheck/issues/333#issuecomment-34994898. This PR fixes the issue by setting `flycheck-clang-language-standard` locally via a hook, as shown in the linked examples.