### PR TITLE
org: add `SPC m i n` binding for org-add-note

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -434,6 +434,7 @@ are also available.
 | ~SPC m i h~   | org-insert-heading               |
 | ~SPC m i K~   | spacemacs/insert-keybinding-org  |
 | ~SPC m i l~   | org-insert-link                  |
+| ~SPC m i n~   | org-add-note                     |
 | ~SPC m i p~   | org-set-property                 |
 | ~SPC m i s~   | org-insert-subheading            |
 | ~SPC m i t~   | org-set-tags                     |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -292,6 +292,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "iH" 'org-insert-heading-after-current
         "iK" 'spacemacs/insert-keybinding-org
         "il" 'org-insert-link
+        "in" 'org-add-note
         "ip" 'org-set-property
         "is" 'org-insert-subheading
         "it" 'org-set-tags


### PR DESCRIPTION
Add `SPC m i n` binding for `org-add-note`

Note: the note capturing buffer states `Finish with C-c C-c, or cancel with C-c C-k.` and while I think those should probably be bound to `, c` and `, k` or similar and the note updated accordingly, I don't quite now how to do that exactly.

Further note, `, ,` appears to do the same function as `C-c C-c` already.