### PR TITLE
add eslint-fix to javascript layer, run on save in js2-mode

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -11,6 +11,7 @@
   - [[#indentation][Indentation]]
   - [[#repl][REPL]]
   - [[#node-modules][Node Modules]]
+  - [[#auto-formatting][Auto Formatting]]
 - [[#key-bindings][Key Bindings]]
   - [[#js2-mode][js2-mode]]
   - [[#folding-js2-mode][Folding (js2-mode)]]
@@ -126,6 +127,20 @@ doing this [[https://stackoverflow.com/questions/9679932#comment33532258_9683472
 #+BEGIN_SRC elisp
 (setq-default dotspacemacs-configuration-layers
   '((javascript :variables node-add-modules-path t)))
+#+END_SRC
+
+** Auto Formatting
+If you would like to format your js on save, set the
+=javascript-eslint-fix-on-save= variable in the =javascript= config section.
+
+#+BEGIN_SRC elisp
+(setq-default dotspacemacs-configuration-layers
+  '((javascript :variables javascript-eslint-fix-on-save t)))
+#+END_SRC
+
+You'll need to install =eslint= somewhere that emacs can find it.
+#+BEGIN_SRC sh
+  $ npm install -g eslint
 #+END_SRC
 
 * Key Bindings

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -15,3 +15,6 @@
 
 (defvar javascript-disable-tern-port-files t
   "Stops tern from creating tern port files.")
+
+(defvar javascript-eslint-fix-on-save nil
+  "When non-nil, run eslint-fix after save.")

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -15,6 +15,7 @@
         coffee-mode
         company
         (company-tern :requires company)
+        eslint-fix
         evil-matchit
         flycheck
         ggtags
@@ -96,6 +97,16 @@
   (use-package js-doc
     :defer t
     :init (spacemacs/js-doc-set-key-bindings 'js2-mode)))
+
+(defun javascript/init-eslint-fix ()
+  (use-package eslint-fix
+    :if javascript-eslint-fix-on-save
+    :config
+    (progn
+      (add-hook
+       'js2-mode-hook
+       (lambda ()
+         (add-hook 'after-save-hook 'eslint-fix nil t))))))
 
 (defun javascript/init-js2-mode ()
   (use-package js2-mode


### PR DESCRIPTION
this change adds config to the javascript layer to run `eslint --fix` on your code before saving the file. 