### PR TITLE
jabber: Fix missing optional argument for the alert jabber-alert-echo function

### DIFF
--- a/layers/+chat/jabber/funcs.el
+++ b/layers/+chat/jabber/funcs.el
@@ -15,6 +15,6 @@
   ;; Disable the minibuffer getting jabber messages when active
   ;; See http://www.emacswiki.org/JabberEl
   (define-jabber-alert echo "Show a message in the echo area"
-    (lambda (msg)
+    (lambda (msg &optional title)
       (unless (minibuffer-prompt)
-        (message "%s" msg)))))
+        (message "%s" (or title msg))))))


### PR DESCRIPTION
Jabber alert function should accept an optional second argument containing a title of
the message. The function mimic the default implementation of jabber-alert-echo
by showing the title if it is present and a message body otherwise.

This PR fixes an error which is thrown when jabber.el receives a notification. 

Example of backtrace demonstrating an error is below:

```
Debugger entered--Lisp error: (wrong-number-of-arguments (lambda (msg) (if (minibuffer-prompt) nil (message "%s" msg))) 2)
  (lambda (msg) (if (minibuffer-prompt) nil (message "%s" msg)))(nil #("user@server.com is now Error" 32 37 (face jabber-roster-user-error)))
  funcall((lambda (msg) (if (minibuffer-prompt) nil (message "%s" msg))) nil #("user@server.com is now Error" 32 37 (face jabber-roster-user-error)))
  (progn (funcall (function (lambda (msg) (if (minibuffer-prompt) nil (message "%s" msg)))) statustext title))
  (if title (progn (funcall (function (lambda (msg) (if (minibuffer-prompt) nil (message "%s" msg)))) statustext title)))
  (when title (funcall (function (lambda (msg) (if (minibuffer-prompt) nil (message "%s" msg)))) statustext title))
  jabber-presence-echo(user@server\.com nil "error" nil #("user@server.com is now Error" 32 37 (face jabber-roster-user-error)))
  run-hook-with-args(jabber-presence-echo user@server\.com nil "error" nil #("user@server.com is now Error" 32 37 (face jabber-roster-user-error)))
  jabber-process-presence(fsm-jabber-connection-3135 (presence ((type . "error") (to . "me@server.com/32ef1693-185c-457b-bcad-9578b1968ebd") (from . "user@server.com")) (error ((type . "cancel")) (remote-server-not-found ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas"))) (text ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas")) "Server-to-server connection failed: Connecting failed: connection timeout"))))
  jabber-process-input(fsm-jabber-connection-3135 (presence ((type . "error") (to . "me@server.com/32ef1693-185c-457b-bcad-9578b1968ebd") (from . "user@server.com")) (error ((type . "cancel")) (remote-server-not-found ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas"))) (text ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas")) "Server-to-server connection failed: Connecting failed: connection timeout"))))
  #[(fsm state-data event callback) "")
  fsm-send-sync(fsm-jabber-connection-3135 (:stanza (presence ((type . "error") (to . "me@server.com/32ef1693-185c-457b-bcad-9578b1968ebd") (from . "user@server.com")) (error ((type . "cancel")) (remote-server-not-found ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas"))) (text ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas")) "Server-to-server connection failed: Connecting failed: connection timeout")))) nil)
  apply(fsm-send-sync (fsm-jabber-connection-3135 (:stanza (presence ((type . "error") (to . "me@server.com/32ef1693-185c-457b-bcad-9578b1968ebd") (from . "user@server.com")) (error ((type . "cancel")) (remote-server-not-found ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas"))) (text ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas")) "Server-to-server connection failed: Connecting failed: connection timeout")))) nil))
  timer-event-handler([t 23216 62567 435553 nil fsm-send-sync (fsm-jabber-connection-3135 (:stanza (presence ((type . "error") (to . "me@server.com/32ef1693-185c-457b-bcad-9578b1968ebd") (from . "user@server.com")) (error ((type . "cancel")) (remote-server-not-found ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas"))) (text ((xmlns . "urn:ietf:params:xml:ns:xmpp-stanzas")) "Server-to-server connection failed: Connecting failed: connection timeout")))) nil) nil 70000])

```

