### PR TITLE
perl5: Fix for leader key prefix name on CPerl mode

### DIFF
--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -104,9 +104,9 @@
       (add-hook 'cperl-mode-hook
                 (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
 
-      (spacemacs/declare-prefix "m=" "format")
-      (spacemacs/declare-prefix "mg" "find-symbol")
-      (spacemacs/declare-prefix "mh" "perldoc")
+      (spacemacs/declare-prefix-for-mode 'cperl-mode "m=" "format")
+      (spacemacs/declare-prefix-for-mode 'cperl-mode "mg" "find-symbol")
+      (spacemacs/declare-prefix-for-mode 'cperl-mode "mh" "perldoc")
       (spacemacs/set-leader-keys-for-major-mode 'cperl-mode
         "==" 'spacemacs/perltidy-format
         "=b" 'spacemacs/perltidy-format-buffer


### PR DESCRIPTION
Fix for using `spacemacs/declare-prefix-for-mode` instead of `spacemacs/declare-prefix` on cperl-mode.
