### PR TITLE
Add function and key binding for single column window layer.

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -572,6 +572,11 @@ in a split window to the right."
   (delete-other-windows)
   (split-window-right))
 
+(defun spacemacs/layout-single-column ()
+  " Set the layout to single column. "
+  (interactive)
+  (delete-other-windows))
+
 (defun spacemacs/insert-line-above-no-indent (count)
   "Insert a new line above with no indentation."
   (interactive "p")

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -404,6 +404,7 @@
 
 (spacemacs/set-leader-keys
   "w TAB"  'spacemacs/alternate-window
+  "w1"  'spacemacs/layout-single-column
   "w2"  'spacemacs/layout-double-columns
   "w3"  'spacemacs/layout-triple-columns
   "wb"  'spacemacs/switch-to-minibuffer-window


### PR DESCRIPTION
We have key bindings to create two and three column
window layers.

This commit makes available a key binding to return to
the default spacemacs window layer, the single column one.