### PR TITLE
add .mjs (ES6 module) extension to init-js2-mode

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -102,7 +102,7 @@
     :defer t
     :init
     (progn
-      (add-to-list 'auto-mode-alist '("\\.[m]*js\\'" . js2-mode))
+      (add-to-list 'auto-mode-alist '("\\.m?js\\'" . js2-mode))
       ;; Required to make imenu functions work correctly
       (add-hook 'js2-mode-hook 'js2-imenu-extras-mode))
     :config

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -102,7 +102,7 @@
     :defer t
     :init
     (progn
-      (add-to-list 'auto-mode-alist '("\\.js\\'" . js2-mode))
+      (add-to-list 'auto-mode-alist '("\\.[m]*js\\'" . js2-mode))
       ;; Required to make imenu functions work correctly
       (add-hook 'js2-mode-hook 'js2-imenu-extras-mode))
     :config

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -125,7 +125,7 @@ pip install pyls-mypy
 #+end_src
 
 * Additional tools
-*** Syntax checking
+** Syntax checking
 Syntax checking uses =flake8= package:
 
 #+begin_src sh

--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -9,5 +9,33 @@ This layer configures mostly Emacs built-in packages to given them better
 defaults.
 
 ** Features:
-See [[file:packages.el][packages.el]] for a list of all configured packages or use Spacemacs help system
-with ~SPC h SPC spacemacs-defaults~ to browse all the configuration for this layer.
+-  Configures packags:
+ - abbrev
+ - archive-mode
+ - bookmark
+ - conf-mode
+ - dired
+ - dired-x
+ - electric-indent-mode
+ - ediff
+ - eldoc
+ - help-fns+
+ - hi-lock
+ - image-mode
+ - imenu
+ - linum
+ - occur-mode
+ - package-menu
+ - page-break-lines
+ - process-menu
+ - recentf
+ - savehist
+ - saveplace
+ - subword
+ - tar-mode
+ - uniquify
+ - url
+ - visual-line-mode
+ - whitespace
+ - winner
+ - zone


### PR DESCRIPTION
adding .mjs extension, which is used by ES6 modules, to the init of the javascript layer. 