### PR TITLE
finance: Remove key-bindings pointing to removed commands

### DIFF
--- a/layers/+tools/finance/README.org
+++ b/layers/+tools/finance/README.org
@@ -56,8 +56,6 @@ your =dotspacemacs/user-config=.  The default value, set in the layer, is =62=.
 | ~SPC m r~   | reconcile an account                          |
 | ~SPC m R~   | display a report                              |
 | ~SPC m t~   | append an effective date to a post            |
-| ~SPC m y~   | set the year for quicker entry                |
-| ~SPC m RET~ | set the month for quicker entry               |
 
 ** Ledger-Reconcile
 

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -43,9 +43,7 @@
          "q" 'ledger-post-align-xact
          "r" 'ledger-reconcile
          "R" 'ledger-report
-         "t" 'ledger-insert-effective-date
-         "y" 'ledger-set-year
-         "RET" 'ledger-set-month)
+         "t" 'ledger-insert-effective-date)
       (spacemacs/set-leader-keys-for-major-mode 'ledger-reconcile-mode
         (or dotspacemacs-major-mode-leader-key ",") 'ledger-reconcile-toggle
         "a" 'ledger-reconcile-add


### PR DESCRIPTION
The ledger-mode maintainers removed ledger-set-month and ledger-set-year to fix
ledger/ledger-mode#36. This was done in commit
782014ae.

The finance layer still had key-bindings pointing to these functions, that are
no longer defined, leading to errors when executing one of those bindings. This
simply removes the bindings to avoid confusion.