### PR TITLE
Add helm-git-grep to the git layer

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -34,6 +34,7 @@ This layers adds extensive support for [[http://git-scm.com/][git]] to Spacemacs
 - quick in buffer history browsing with [[https://github.com/pidu/git-timemachine][git-timemachine]].
 - quick in buffer last commit message per line with [[https://github.com/syohex/emacs-git-messenger][git-messenger]]
 - colorize buffer line by age of commit with [[https://github.com/syohex/emacs-smeargle][smeargle]]
+- git grep with [[https://github.com/yasuyk/helm-git-grep][helm-git-grep]]
 - gitignore generator with [[https://github.com/jupl/helm-gitignore][helm-gitignore]]
 - org integration with magit via [[https://github.com/magit/orgit][orgit]]
 
@@ -104,6 +105,7 @@ Git commands (start with ~g~):
 
 | Key Binding | Description                                         |
 |-------------+-----------------------------------------------------|
+| ~SPC g /~   | open =helm-git-grep=                                |
 | ~SPC g b~   | open a =magit= blame                                |
 | ~SPC g f f~ | view a file at a specific branch or commit          |
 | ~SPC g f h~ | show file commits history                           |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -20,6 +20,7 @@
         git-link
         git-messenger
         git-timemachine
+        (helm-git-grep :requires helm)
         (helm-gitignore :requires helm)
         magit
         magit-gitflow
@@ -45,6 +46,11 @@
 
 (defun git/post-init-fill-column-indicator ()
   (add-hook 'git-commit-mode-hook 'fci-mode))
+
+(defun git/init-helm-git-grep ()
+  (use-package helm-git-grep
+    :defer t
+    :init (spacemacs/set-leader-keys "g/" 'helm-git-grep)))
 
 (defun git/init-helm-gitignore ()
   (use-package helm-gitignore


### PR DESCRIPTION
Pretty simple: this adds helm-git-grep integration to the git layer, bound to SPC g / naturally. Updated docs as well.