### PR TITLE
Check for a .clang-format file before formatting buffers on save.

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -40,7 +40,8 @@
 (defun spacemacs//clang-format-on-save ()
   "Format the current buffer with clang-format on save when
 `c-c++-enable-clang-format-on-save' is non-nil."
-  (when c-c++-enable-clang-format-on-save
+  (when (and c-c++-enable-clang-format-on-save
+             (locate-dominating-file (buffer-file-name) ".clang-format"))
     (spacemacs/clang-format-region-or-buffer)))
 
 (defun spacemacs/clang-format-on-save ()


### PR DESCRIPTION
This makes `spacemacs//clang-format-on-save` a little more useful, by first checking that a `.clang-format` file exists before calling `clang-format`. The motivation here is that you can set `c-c++-enable-clang-format-on-save` globally, and then if you work on projects that don't include a `.clang-format` you won't have to disable that option in a `.dir-locals.el` file.

If you want to unconditionally call clang-format on every single C/C++ project regardless of whether they include a `.clang-format` file you can just create `~/.clang-format` which will always be found and used.

I've had this logic in my personal spacemacs layer for a few years now, and have found it to be really useful. Since adding it I've only found one project that required manually overriding `c-c++-enable-clang-format-on-save` (that project has a `.clang-format` file checked in, but most files in the project do not conform to the standard).