### PR TITLE
fixed helm action in helm transient state

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -141,7 +141,7 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
           (doc (format "Select helm action #%d" n)))
       (eval `(defun ,func ()
                ,doc
-               (intern)
+               (interactive)
                (helm-select-nth-action ,(1- n)))))))
 
 (defun spacemacs/helm-ts-edit ()


### PR DESCRIPTION
The `spacemacs/helm-action-n` functions in the helm transient state are currently broken. Looks like a typo. This simple correction gets them working. This fixes #9789. 