### PR TITLE
Add golden-ratio support to evil-unimpaired

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -275,6 +275,8 @@
                    evil-window-move-far-left
                    evil-window-move-far-right
                    evil-window-move-very-bottom
+                   next-multiframe-window
+                   previous-multiframe-window
                    quit-window
                    winum-select-window-0-or-10
                    winum-select-window-1


### PR DESCRIPTION
Switching window with `[ w` and `] w` didn't activate golden-ratio.

Resolves: #10540