### PR TITLE
go: add option in refactoring to fill a structure with default values

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -205,14 +205,14 @@ You have a few options to ensure you always get up to date suggestions:
 
 ** Refactoring
 
-| Key Binding | Description                         |
-|-------------+-------------------------------------|
-| ~SPC m r d~ | Add comment stubs                   |
-| ~SPC m r e~ | Extract code as new function        |
-| ~SPC m r f~ | Add field tags                      |
-| ~SPC m r F~ | Remove field tags                   |
-| ~SPC m r n~ | Rename (with =godoctor=)            |
-| ~SPC m r N~ | Rename (with =go-rename=)           |
-| ~SPC m r N~ | Rename (with =go-rename=)           |
-| ~SPC m r s~ | Fill structure with default values  |
-| ~SPC m r t~ | Toggle declaration and assignment   |
+| Key Binding | Description                        |
+|-------------+------------------------------------|
+| ~SPC m r d~ | Add comment stubs                  |
+| ~SPC m r e~ | Extract code as new function       |
+| ~SPC m r f~ | Add field tags                     |
+| ~SPC m r F~ | Remove field tags                  |
+| ~SPC m r n~ | Rename (with =godoctor=)           |
+| ~SPC m r N~ | Rename (with =go-rename=)          |
+| ~SPC m r N~ | Rename (with =go-rename=)          |
+| ~SPC m r s~ | Fill structure with default values |
+| ~SPC m r t~ | Toggle declaration and assignment  |

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -41,6 +41,7 @@ You will need =gocode=, =gogetdoc=, =godef= and =godoctor=:
   go get -u -v golang.org/x/tools/cmd/gorename
   go get -u -v golang.org/x/tools/cmd/goimports
   go get -u -v github.com/zmb3/gogetdoc
+  go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct
 #+END_SRC
 
 If you wish to use =gometalinter= set the value of =go-use-gometalinter= to t:
@@ -204,12 +205,14 @@ You have a few options to ensure you always get up to date suggestions:
 
 ** Refactoring
 
-| Key Binding | Description                       |
-|-------------+-----------------------------------|
-| ~SPC m r d~ | Add comment stubs                 |
-| ~SPC m r e~ | Extract code as new function      |
-| ~SPC m r f~ | Add field tags                    |
-| ~SPC m r F~ | Remove field tags                 |
-| ~SPC m r n~ | Rename (with =godoctor=)          |
-| ~SPC m r N~ | Rename (with =go-rename=)         |
-| ~SPC m r t~ | Toggle declaration and assignment |
+| Key Binding | Description                         |
+|-------------+-------------------------------------|
+| ~SPC m r d~ | Add comment stubs                   |
+| ~SPC m r e~ | Extract code as new function        |
+| ~SPC m r f~ | Add field tags                      |
+| ~SPC m r F~ | Remove field tags                   |
+| ~SPC m r n~ | Rename (with =godoctor=)            |
+| ~SPC m r N~ | Rename (with =go-rename=)           |
+| ~SPC m r N~ | Rename (with =go-rename=)           |
+| ~SPC m r s~ | Fill structure with default values  |
+| ~SPC m r t~ | Toggle declaration and assignment   |

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -27,6 +27,7 @@
         godoctor
         go-tag
         popwin
+        go-fill-struct
         ))
 
 
@@ -132,6 +133,13 @@
     (spacemacs/set-leader-keys-for-major-mode 'go-mode
       "rf" 'go-tag-add
       "rF" 'go-tag-remove)))
+
+(defun go/init-go-fill-struct ()
+  (use-package go-fill-struct
+    :init
+    (spacemacs/declare-prefix-for-mode 'go-mode "mr" "refactoring")
+    (spacemacs/set-leader-keys-for-major-mode 'go-mode
+      "rs" 'go-fill-struct)))
 
 (defun go/init-flycheck-gometalinter ()
   (use-package flycheck-gometalinter


### PR DESCRIPTION
Add option in refactoring to fill a structure with default values using the [fillstruct](https://github.com/davidrjenni/reftools/tree/master/cmd/fillstruct) tool.