### PR TITLE
go: add support for go-impl in refactoring menu

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -41,6 +41,7 @@ You will need =gocode=, =gogetdoc=, =godef= and =godoctor=:
   go get -u -v golang.org/x/tools/cmd/gorename
   go get -u -v golang.org/x/tools/cmd/goimports
   go get -u -v github.com/zmb3/gogetdoc
+  go get -u github.com/josharian/impl
 #+END_SRC
 
 If you wish to use =gometalinter= set the value of =go-use-gometalinter= to t:
@@ -204,12 +205,13 @@ You have a few options to ensure you always get up to date suggestions:
 
 ** Refactoring
 
-| Key Binding | Description                       |
-|-------------+-----------------------------------|
-| ~SPC m r d~ | Add comment stubs                 |
-| ~SPC m r e~ | Extract code as new function      |
-| ~SPC m r f~ | Add field tags                    |
-| ~SPC m r F~ | Remove field tags                 |
-| ~SPC m r n~ | Rename (with =godoctor=)          |
-| ~SPC m r N~ | Rename (with =go-rename=)         |
-| ~SPC m r t~ | Toggle declaration and assignment |
+| Key Binding | Description                                                    |
+|-------------+----------------------------------------------------------------|
+| ~SPC m r d~ | Add comment stubs                                              |
+| ~SPC m r e~ | Extract code as new function                                   |
+| ~SPC m r f~ | Add field tags                                                 |
+| ~SPC m r F~ | Remove field tags                                              |
+| ~SPC m r i~ | Generate method subs for implementing an interface (=go-impl=) |
+| ~SPC m r n~ | Rename (with =godoctor=)                                       |
+| ~SPC m r N~ | Rename (with =go-rename=)                                      |
+| ~SPC m r t~ | Toggle declaration and assignment                              |

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -27,6 +27,7 @@
         godoctor
         go-tag
         popwin
+        go-impl
         ))
 
 
@@ -132,6 +133,13 @@
     (spacemacs/set-leader-keys-for-major-mode 'go-mode
       "rf" 'go-tag-add
       "rF" 'go-tag-remove)))
+
+(defun go/init-go-impl()
+  (use-package go-impl
+    :init
+    (spacemacs/declare-prefix-for-mode 'go-mode "mr" "refactoring")
+    (spacemacs/set-leader-keys-for-major-mode 'go-mode
+      "ri" 'go-impl)))
 
 (defun go/init-flycheck-gometalinter ()
   (use-package flycheck-gometalinter


### PR DESCRIPTION
Go layer: Add support for [go-impl](https://github.com/syohex/emacs-go-impl) in refactoring menu.