### PR TITLE
handle .venv created by pipenv correctly

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -207,11 +207,15 @@ as the pyenv version then also return nil. This works around https://github.com/
     (when root-path
       (let* ((file-path (expand-file-name ".venv" root-path))
              (virtualenv
-              (with-temp-buffer
-                (insert-file-contents-literally file-path)
-                (buffer-substring-no-properties (line-beginning-position)
-                                                (line-end-position)))))
-            (pyvenv-workon virtualenv)))))
+               (if (file-directory-p file-path)
+                 file-path
+                 (with-temp-buffer
+                   (insert-file-contents-literally file-path)
+                   (buffer-substring-no-properties (line-beginning-position)
+                     (line-end-position))))))
+        (if (file-directory-p virtualenv)
+          (pyvenv-activate virtualenv)
+          (pyvenv-workon virtualenv))))))
 
 
 ;; Tests


### PR DESCRIPTION
when pipenv is run as...

PIPENV_VENV_IN_PROJECT=1 pipenv ...

a virtualenv directory called `.venv` is installed in the directory as the
`Pipfile`

the current functionality is to look for a file and then tell pyenv to 'workon'
it's contents. doing the above will cause it to blow up.

this change checks to see if it's a directory or file and either calls

pyvenv-activate if directory

or

pyvenv-workon with the contents of the file if file(existing behaviour)

then end result, a virtualenv created local for the project by pipenv will get
activated automatically instead of blowing up like it does now

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3