### PR TITLE
Fix helm layer broken with smex package

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -68,7 +68,7 @@
       (unless (configuration-layer/package-used-p 'ibuffer)
         (evil-ex-define-cmd "buffers" 'helm-buffers-list))
       ;; use helm by default for M-x, C-x C-f, and C-x b
-      (unless (configuration-layer/package-used-p 'smex)
+      (unless (configuration-layer/layer-usedp 'smex)
         (global-set-key (kbd "M-x") 'helm-M-x))
       (global-set-key (kbd "C-x C-f") 'spacemacs/helm-find-files)
       (global-set-key (kbd "C-x b") 'helm-buffers-list)
@@ -117,7 +117,7 @@
       ;; to overwrite any key binding
       (add-hook 'emacs-startup-hook
                 (lambda ()
-                  (unless (configuration-layer/package-used-p 'smex)
+                  (unless (configuration-layer/layer-usedp 'smex)
                     (spacemacs/set-leader-keys
                       dotspacemacs-emacs-command-key 'helm-M-x))))
       (helm-mode))


### PR DESCRIPTION
Currently if you add the package `smex` (not the layer) to Spacemacs it will cause `SPC SPC` to be unbound. We should be checking for the smex layer (not package) to be present because the layer defines the proper keybindings and the package does not.