### PR TITLE
add support for helm find files edit to helm-navigation transient state

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -150,6 +150,8 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
   (cond
    ((string-equal "*helm-ag*" helm-buffer)
     (helm-ag-edit))
+   ((string-equal "*helm find files*" helm-buffer)
+    (spacemacs/helm-find-files-edit))
    ((string-equal "*Helm Swoop*" helm-buffer)
     (helm-swoop-edit))))
 


### PR DESCRIPTION
We created a function to allow one to edit a directory from `helm-find-files` using `dired`. We should add that to the edit action (`e`) in the `helm-navigation` transient state. 