### PR TITLE
Fix rust-quick-run function when the user's shell does not support &&

### DIFF
--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -27,7 +27,7 @@ using `cargo-process-run'."
   (let ((input-file-name (buffer-file-name))
         (output-file-name (concat temporary-file-directory (make-temp-name "rustbin"))))
     (compile
-     (format "rustc -o %s %s && %s"
+     (format "sh -c 'rustc -o %s %s && %s'"
              (shell-quote-argument output-file-name)
              (shell-quote-argument input-file-name)
              (shell-quote-argument output-file-name)))))


### PR DESCRIPTION
I use [Fish](https://fishshell.com/) as my shell. Fish doesn't support the `&&` operator so the `rust-quick-run` function fail with an error. This should fix that by running the command via sh.