### PR TITLE
Add variable rcirc-enable-rcirc-late-fix

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -115,6 +115,9 @@ This file containes the change log for the next major version of Spacemacs.
 - Make =org-projectile= integration compatible with the newest version.
 - Add package =helm-org-rifle=, with keybinding ~SPC a o r~ to rifle through
   files.
+**** Rcirc
+- New variable =rcirc-enable-late-fix= to enable or disable the included
+  =rcirc-late-fix= package (disabled by default).
 **** Scala
 - Move =ensime= to the =java= layer (Tor Hedin Bronner)
 **** Syntax-checking

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -7,7 +7,7 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#configuration][Configuration]]
+  - [[#configuring-authentication][Configuring authentication]]
     - [[#storing-the-credentials-in-your-dotfile][Storing the credentials in your dotfile]]
       - [[#example][Example:]]
     - [[#storing-the-credentials-in-your-dropbox][Storing the credentials in your Dropbox]]
@@ -16,6 +16,7 @@
     - [[#connecting-behind-a-znc-bouncer-and-storing-the-credentials-in-authinfo][Connecting behind a ZNC bouncer and storing the credentials in authinfo]]
       - [[#disclaimer][Disclaimer]]
       - [[#note][Note]]
+  - [[#enabling-sfoobar][Enabling =s/foo/bar/=]]
 - [[#key-bindings][Key Bindings]]
 - [[#rcirc-documentation][Rcirc documentation]]
 - [[#spacemacs-layout-support][Spacemacs Layout Support]]
@@ -29,7 +30,7 @@ and ZNC.
 - Support for credentials stored in =~/.authinfo.gpg= (need to have gnutls)
 - Support ZNC support (with optional =~/.authinfo.gpg=)
 - Colored nicknames
-- WIP: Real time change when people use =/s/foo/bar= in the chats
+- Real-time change when people use =s/foo/bar/= in chat
 - Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
   using the =emoji= layer or having a proper font) :clap:
 
@@ -39,7 +40,7 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =rcirc= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** Configuration
+** Configuring authentication
 There are several ways to configure rcirc supported by the layer:
 - By storing your credentials in =rcirc-server-alist= in your dotfile (not
   secured)
@@ -165,6 +166,15 @@ For now authinfo is mandatory to use the ZNC configuration.
           :auth "spacemacs_user/geekshed"
           :channels ("#jupiterbroadcasting"))))
    #+END_SRC
+
+** Enabling =s/foo/bar/=
+To configure rcirc to update buffers when people use =s/foo/bar/=, set the
+variable =rcirc-enable-late-fix= to =t= in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (rcirc :variables rcirc-enable-late-fix t)))
+#+END_SRC
 
 * Key Bindings
 

--- a/layers/+chat/rcirc/config.el
+++ b/layers/+chat/rcirc/config.el
@@ -14,6 +14,9 @@
 (defvar rcirc-enable-authinfo-support nil
   "if non nil then authentication uses authinfo.")
 
+(defvar rcirc-enable-late-fix nil
+  "if non nil then enable rcirc-late-fix to show s/// fixes in rcirc buffers.")
+
 (defvar rcirc-enable-znc-support nil
   "if non nil then znc is enabled.")
 

--- a/layers/+chat/rcirc/local/rcirc-late-fix/rcirc-late-fix.el
+++ b/layers/+chat/rcirc/local/rcirc-late-fix/rcirc-late-fix.el
@@ -44,12 +44,14 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'rcirc)
 
-(add-hook 'rcirc-print-hooks 'rcirc-late-fix-hook)
+(add-hook 'rcirc-print-functions 'rcirc-late-fix-hook)
 
 (defface rcirc-late-fix-face '((t (:underline t :foreground "Blue")))
-  "Face for showing fixed words on the channel buffer.")
+  "Face for showing fixed words on the channel buffer."
+  :group 'rcirc-faces)
 
 (defun rcirc-late-fix-apply (beg end string)
   (save-excursion
@@ -76,13 +78,13 @@
               (setf matches (cons (list (match-beginning 0) (match-end 0)) matches)))
             (when (not (null matches)) ;; there was at least one match
               (if global               ;; global = replace all matches
-                  (mapc '(lambda (x) (rcirc-late-fix-apply (car x) (cadr x) to)) matches)
-                  (rcirc-late-fix-apply (caar matches) (cadar matches) to)))))))))
+                  (dolist (x matches)
+                    (rcirc-late-fix-apply (car x) (cadr x) to))
+                (rcirc-late-fix-apply (caar matches) (cadar matches) to)))))))))
 
 (defun rcirc-late-fix-matching-buffer (name)
   "Find buffer (channel) that starts with NAME."
-  (find-if '(lambda (x) (string-match (concat "^" name) x))
-           (mapcar 'buffer-name (buffer-list))))
+  (cl-find name (mapcar 'buffer-name (buffer-list)) :test #'string-prefix-p))
 
 
 

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -20,6 +20,8 @@
         persp-mode
         rcirc
         rcirc-color
+        (rcirc-late-fix :location local
+                        :toggle rcirc-enable-late-fix)
         rcirc-notify
         ))
 
@@ -103,6 +105,12 @@
 
 (defun rcirc/init-rcirc-color ()
   (use-package rcirc-color :defer t))
+
+(defun rcirc/init-rcirc-late-fix ()
+  (spacemacs|use-package-add-hook rcirc
+    :post-config
+    (when rcirc-enable-late-fix
+      (use-package rcirc-late-fix))))
 
 (defun rcirc/init-rcirc-notify ()
   (use-package rcirc-notify


### PR DESCRIPTION
#### rcirc-late-fix: Fix compiler warnings

Fix the following errors:

    rcirc-late-fix.el:49:12:Warning: ‘rcirc-print-hooks’ is an obsolete
        variable (as of 24.3); use ‘rcirc-print-functions’ instead.

    rcirc-late-fix.el:51:1:Warning: defface for ‘rcirc-late-fix-face’ fails
        to specify containing group

    In rcirc-late-fix-hook:
    rcirc-late-fix.el:79:82:Warning: (lambda (x) ...) quoted with ' rather
        than with #'

    In rcirc-late-fix-matching-buffer:
    rcirc-late-fix.el:85:34:Warning: function ‘find-if’ from cl package
        called at runtime


#### Add variable `rcirc-enable-late-fix` to rcirc layer

Add a configuration variable to enable the included rcirc-late-fix package in the rcirc layer.  The package is still disabled by default.