### PR TITLE
Fix ipython-notebook layer instructions

### DIFF
--- a/layers/+lang/ipython-notebook/README.org
+++ b/layers/+lang/ipython-notebook/README.org
@@ -47,14 +47,16 @@ in this file.
 
 ** Dependencies
 Install IPython Notebook > 3
+
+Note that IPython Notebook has now been renamed to [[https://jupyter.org/install][Jupyter Notebook]].
 #+begin_src sh
-  pip install ipython[notebook]
+  pip install jupyter
 #+end_src
 
 ** What needs to be run
 Have an IPython notebook running
 #+begin_src sh
-  ipython notebook
+  jupyter notebook
 #+end_src
 
 * Using the IPython notebook


### PR DESCRIPTION
Now `pip install jupyter` is needed instead of `pip install ipython[notebook]`.
Otherwise `ob-ipython` package will not work. I encountered errors when trying to open org files after installing the layer.