### PR TITLE
spacemacs-modeline: compute height only after display init

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -72,11 +72,16 @@
                      (spacemacs/mode-line-separator))
                 'wave)
             powerline-image-apple-rgb (spacemacs/system-is-mac)
-            powerline-scale (or (spacemacs/mode-line-separator-scale) 1.5)
-            powerline-height (spacemacs/compute-mode-line-height))
+            powerline-scale (or (spacemacs/mode-line-separator-scale) 1.5))
       (spacemacs|do-after-display-system-init
        ;; seems to be needed to avoid weird graphical artefacts with the
        ;; first graphical client
+       ;;
+       ;; It is important that no functions that do font measurements are
+       ;; called outside of this hook or the results will be wrong if spacemacs
+       ;; is started in daemon mode (emacs --daemon). This is why the height
+       ;; is computed here
+       (setq powerline-height (spacemacs/compute-mode-line-height))
        (require 'spaceline)
        (spaceline-compile)))
     :config


### PR DESCRIPTION
Before the display system is initialized, we cannot reliably make font
measurements so the height will be incorrect. This lead to display artefacts
if emacs was started in daemon mode without a graphical interface and later a
graphical client was connected (so for example, if you do `emacs --daemon`
followed by `emacsclient -c`).