### PR TITLE
Add: lsp-typescript support

### DIFF
--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -7,6 +7,7 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#pre-requisites][Pre-requisites]]
+    - [[#backend][Backend]]
   - [[#layer][Layer]]
   - [[#notes][Notes]]
 - [[#configuration][Configuration]]
@@ -38,6 +39,19 @@ If you want linting run:  =npm install -g typescript=  =npm install -g tslint=
 If you want to use typescript-formatter for formatting run:  =npm install -g typescript-formatter=
 
 For best results, make sure that the =auto-completion= (company) and =html= layers are enabled.
+
+*** Backend
+Pick the backend for typescript-mode. Options are =tide= and =lsp=.
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(
+  (typescript :variables
+              typescript-backend 'tide)))
+#+END_SRC
+
+If you pick =lsp=, you have to install the following dependencies with npm.
+#+BEGIN_SRC shell
+npm i -g typescript javascript-typescript-langserver flow-language-server typescript-language-server
+#+END_SRC
 
 ** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -20,5 +20,9 @@ for TypeScript source code formatting.
 Currently avaliable 'tide (default)
 and 'typescript-formatter .")
 
+(defvar typescript-backend 'tide
+  "The backend to use for IDE features. Possible values are `tide'
++and `lsp'.")
+
 (spacemacs|define-jump-handlers typescript-mode)
 (spacemacs|define-jump-handlers typescript-tsx-mode)

--- a/layers/+lang/typescript/layers.el
+++ b/layers/+lang/typescript/layers.el
@@ -9,4 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(configuration-layer/declare-layers '(node))
+(configuration-layer/declare-layers '(node javascript))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -25,14 +25,13 @@
   (add-hook 'typescript-tsx-mode-hook #'add-node-modules-path))
 
 (defun typescript/post-init-company ()
-  (spacemacs|add-company-backends
-    :backends company-tide
-    :modes typescript-mode typescript-tsx-mode))
+  (add-hook 'typescript-mode-hook #'spacemacs//typescript-setup-company)
+  (add-hook 'typescript-tsx-mode-hook #'spacemacs//typescript-setup-company))
 
 (defun typescript/pre-init-eldoc ()
   (spacemacs|use-package-add-hook tide :post-init
-                           (add-hook 'typescript-tsx-mode-hook 'eldoc-mode t)
-                           (add-hook 'typescript-mode-hook 'eldoc-mode t)))
+                                  (add-hook 'typescript-tsx-mode-hook 'eldoc-mode t)
+                                  (add-hook 'typescript-mode-hook 'eldoc-mode t)))
 
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)
@@ -45,18 +44,6 @@
   (use-package tide
     :defer t
     :commands (typescript/jump-to-type-def)
-    :init
-    (progn
-      (evilified-state-evilify tide-references-mode tide-references-mode-map
-        (kbd "C-k") 'tide-find-previous-reference
-        (kbd "C-j") 'tide-find-next-reference
-        (kbd "C-l") 'tide-goto-reference)
-      (spacemacs/add-to-hooks 'tide-setup '(typescript-mode-hook
-                                            typescript-tsx-mode-hook))
-      (add-to-list 'spacemacs-jump-handlers-typescript-tsx-mode
-                   '(tide-jump-to-definition :async t))
-      (add-to-list 'spacemacs-jump-handlers-typescript-mode
-                   '(tide-jump-to-definition :async t)))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'typescript-mode "mE" "errors")
@@ -95,6 +82,10 @@
 (defun typescript/init-typescript-mode ()
   (use-package typescript-mode
     :defer t
+    :init
+    ;; setup javascript backend
+    (add-hook 'typescript-mode-hook 'spacemacs//typescript-setup-backend)
+    (add-hook 'typescript-tsx-mode-hook 'spacemacs//typescript-setup-backend)
     :config
     (progn
       (when typescript-fmt-on-save


### PR DESCRIPTION
Added lsp-typescript support. It can be tested through this [PR](https://github.com/syl20bnr/spacemacs/pull/10628).

Tested `company`, `spacemacs-jump-handlers-typescript-mode` for both `tide` and `lsp`.