### PR TITLE
Add LSP to jump handlers

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -69,7 +69,8 @@ when this mode is enabled since the minibuffer is cleared all the time."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (require 'lsp-python)
-        (lsp-python-enable))
+        (lsp-python-enable)
+        (spacemacs//set-lsp-key-bindings 'python-mode))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dofile.")))
 
 (defun spacemacs//python-setup-lsp-company ()

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -48,4 +48,8 @@
     (progn
       (spacemacs//lsp-sync-peek-face)
       (add-hook 'spacemacs-post-theme-change-hook
-                #'spacemacs//lsp-sync-peek-face))))
+                #'spacemacs//lsp-sync-peek-face)
+      (define-key lsp-ui-mode-map [remap xref-find-definitions]
+        #'lsp-ui-peek-find-definitions)
+      (define-key lsp-ui-mode-map [remap xref-find-references]
+        #'lsp-ui-peek-find-references))))


### PR DESCRIPTION
`spacemacs//set-lsp-key-bindings` function is defined in this [commit](https://github.com/syl20bnr/spacemacs/pull/10628/commits/1c94c234931940122635de18c3199affc4abb5b2).

I added the support for python layer. But it conflicts with `xref` somehow when we have multiple candidates.

Here is an example.
![kapture 2018-04-27 at 23 54 42](https://user-images.githubusercontent.com/16655096/39393217-64407cce-4a77-11e8-8ba8-cdb5d710a1f6.gif)


