### PR TITLE
cmake: fix cmake-ide mode hook function name

### DIFF
--- a/layers/+tools/cmake/packages.el
+++ b/layers/+tools/cmake/packages.el
@@ -19,12 +19,12 @@
 (defun cmake/init-cmake-ide ()
   (use-package cmake-ide
     :if cmake-enable-cmake-ide-support
-    :commands (cmake-ide-delete-file cmake-ide--mode-hook)
+    :commands (cmake-ide-delete-file cide--mode-hook)
     :init
     (progn
       (dolist (hook '(c-mode-hook c++-mode-hook))
-        ;; append the `cmake-ide--mode-hook' in order to load it last
-        (add-hook hook 'cmake-ide--mode-hook 'append))
+        ;; append the `cide--mode-hook' in order to load it last
+        (add-hook hook 'cide--mode-hook 'append))
       (dolist (mode cmake-modes)
         (spacemacs/declare-prefix-for-mode mode "mc" "compile")
         (spacemacs/declare-prefix-for-mode mode "mp" "project")


### PR DESCRIPTION
`cmake-ide` has changed the hook name:
https://github.com/atilaneves/cmake-ide/commit/26605efce2c866fcf507bf03869228e695294721#diff-5718e36b5fe0a5af87d4af78e6eaa88dR247