### PR TITLE
Add keybinding to docker layer to build image without cache

### DIFF
--- a/layers/+tools/docker/README.org
+++ b/layers/+tools/docker/README.org
@@ -39,17 +39,18 @@ auto-completion of the running containers.
 
 * Key bindings
 
-| Key Binding | Description                                        |
-|-------------+----------------------------------------------------|
-| ~SPC m c b~ | build current buffer via =dockerfile-build-buffer= |
-| ~SPC a D c~ | list docker containers                             |
-| ~SPC a D d~ | delete image                                       |
-| ~SPC a D e~ | unpause container                                  |
-| ~SPC a D F~ | pull image                                         |
-| ~SPC a D i~ | list docker images                                 |
-| ~SPC a D k~ | delete container                                   |
-| ~SPC a D o~ | stop container                                     |
-| ~SPC a D p~ | pause container                                    |
-| ~SPC a D P~ | push image                                         |
-| ~SPC a D r~ | restart container                                  |
-| ~SPC a D s~ | start container                                    |
+| Key Binding | Description                        |
+|-------------+------------------------------------|
+| ~SPC m c b~ | build current buffer               |
+| ~SPC m c B~ | build current buffer without cache |
+| ~SPC a D c~ | list docker containers             |
+| ~SPC a D d~ | delete image                       |
+| ~SPC a D e~ | unpause container                  |
+| ~SPC a D F~ | pull image                         |
+| ~SPC a D i~ | list docker images                 |
+| ~SPC a D k~ | delete container                   |
+| ~SPC a D o~ | stop container                     |
+| ~SPC a D p~ | pause container                    |
+| ~SPC a D P~ | push image                         |
+| ~SPC a D r~ | restart container                  |
+| ~SPC a D s~ | start container                    |

--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -54,4 +54,5 @@
       (spacemacs/declare-prefix-for-mode 'dockerfile-mode
         "mc" "compile")
       (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
-        "cb" 'dockerfile-build-buffer))))
+        "cb" 'dockerfile-build-buffer
+        "cB" 'dockerfile-build-no-cache-buffer))))


### PR DESCRIPTION
Made a small change at the docker layer to also provide keybindings for building the image without using the cache as it is sometimes necessary.