### PR TITLE
Add function 'spacemacs/last-error

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -350,6 +350,12 @@ is not visible. Otherwise delegates to regular Emacs next-error."
      ((eq 'flycheck sys) (call-interactively 'flycheck-next-error))
      ((eq 'emacs sys) (call-interactively 'next-error)))))
 
+(defun spacemacs/last-error ()
+  "Go to last flycheck or standard emacs error."
+  (interactive)
+  (spacemacs/next-error)
+  (spacemacs/last-error))
+
 (defun spacemacs/previous-error (&optional n reset)
   "Dispatch to flycheck or standard emacs error."
   (interactive "P")

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -164,6 +164,7 @@
   'spacemacs/theme-transient-state/spacemacs/cycle-spacemacs-theme)
 ;; errors ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
+  "el" 'spacemacs/last-error
   "en" 'spacemacs/next-error
   "eN" 'spacemacs/previous-error
   "ep" 'spacemacs/previous-error)


### PR DESCRIPTION
Sometimes it is useful to go directly to the last error message in the buffer.
This function recursively calls 'spacemacs/next-error until the last error is
reached.
The binding "SPC e l" is associated with it
