### PR TITLE
Fix: remove buggy hooks in javascript and typescript

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -70,7 +70,7 @@
     :defer t))
 
 (defun javascript/post-init-company ()
-  (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-company)
+  (spacemacs//javascript-setup-company)
   (spacemacs|add-company-backends
     :backends company-capf
     :modes coffee-mode))
@@ -105,7 +105,7 @@
       ;; Required to make imenu functions work correctly
       (add-hook 'js2-mode-hook 'js2-imenu-extras-mode)
       ;; setup javascript backend
-      (add-hook 'js2-mode-hook 'spacemacs//javascript-setup-backend))
+      (spacemacs//javascript-setup-backend))
     :config
     (progn
       ;; prefixes

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -25,8 +25,7 @@
   (add-hook 'typescript-tsx-mode-hook #'add-node-modules-path))
 
 (defun typescript/post-init-company ()
-  (add-hook 'typescript-mode-hook #'spacemacs//typescript-setup-company)
-  (add-hook 'typescript-tsx-mode-hook #'spacemacs//typescript-setup-company))
+  (spacemacs//typescript-setup-company))
 
 (defun typescript/pre-init-eldoc ()
   (spacemacs|use-package-add-hook tide :post-init
@@ -84,8 +83,7 @@
     :defer t
     :init
     ;; setup javascript backend
-    (add-hook 'typescript-mode-hook 'spacemacs//typescript-setup-backend)
-    (add-hook 'typescript-tsx-mode-hook 'spacemacs//typescript-setup-backend)
+    (spacemacs//typescript-setup-backend)
     :config
     (progn
       (when typescript-fmt-on-save

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -82,7 +82,7 @@
   (use-package typescript-mode
     :defer t
     :init
-    ;; setup javascript backend
+    ;; setup typescript backend
     (spacemacs//typescript-setup-backend)
     :config
     (progn


### PR DESCRIPTION
There are several recursive hooks in Javascript and Typescript layer [causing backends does not start properly](https://github.com/syl20bnr/spacemacs/issues/10662#issuecomment-388172951). I removed those buggy hooks. And it should be good now.

Examples like:
```
(add-hook 'js2-mode-hook 'spacemacs//javascript-setup-backend))
```
While in `spacemacs//javascript-setup-backend`, it has `spacemacs//javascript-setup-tern` which hooks `tern-mode` to the `js2-mode`.
```
(defun spacemacs//javascript-setup-tern ()
  "Setup tern backend."
  (add-hook 'js2-mode-hook 'tern-mode)
  (progn
    (spacemacs|hide-lighter tern-mode)
    (when javascript-disable-tern-port-files
      (add-to-list 'tern-command "--no-port-file" 'append))
    (spacemacs//set-tern-key-bindings 'js2-mode)))
```
