### PR TITLE
xclipboard: Fix keybindings for copy and page

### DIFF
--- a/layers/+tools/xclipboard/packages.el
+++ b/layers/+tools/xclipboard/packages.el
@@ -18,5 +18,5 @@
 (defun xclipboard/init-spacemacs-xclipboard ()
   (use-package spacemacs-xclipboard
     :init (spacemacs/set-leader-keys
-            "xp" 'spacemacs/xclipboard-copy
-            "xy" 'spacemacs/xclipboard-paste)))
+            "xy" 'spacemacs/xclipboard-copy
+            "xp" 'spacemacs/xclipboard-paste)))


### PR DESCRIPTION
This commit switches the keybindings for `xclipboard-copy` and `xclipboard-paste` to `SPC x y` and
`SPC x p` respectively, as it appears these were incorrectly assigned the other way around.