### PR TITLE
Fix: use recipe for lsp-javascript-typescript

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -30,7 +30,7 @@
         web-beautify
         skewer-mode
         livid-mode
-        (lsp-javascript-typescript :requires lsp-mode)
+        (lsp-javascript-typescript :requires lsp-mode :location (recipe :fetcher github :repo "emacs-lsp/lsp-javascript"))
         ))
 
 (defun javascript/post-init-add-node-modules-path ()


### PR DESCRIPTION
Melpa pulled off some libraries from `lsp-javascript` ([link](https://github.com/melpa/melpa/commit/97b6ddeb34297aacfefdd4c227ad520b70a12bc6#commitcomment-28940048) here). However, the author doesn't really want to split these libraries ([link](https://github.com/emacs-lsp/lsp-javascript/issues/12#issuecomment-388491329) here).

I guess we need to use recipe to install `lsp-javascript` for now.