### PR TITLE
Use native line numbers in Emacs 26

### DIFF
--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -56,6 +56,9 @@ Available PROPS:
 `:on-message EXPRESSION'
     EXPRESSION is evaluated and displayed when the \"on\" toggle is activated.
 
+`:off-message EXPRESSION'
+    EXPRESSION is evaluated and displayed when the \"off\" toggle is activated.
+
 `:mode SYMBOL'
     If given, must be a minor mode. This overrides `:on', `:off' and `:status'.
 
@@ -75,6 +78,7 @@ used."
          (off-body (if mode `((,mode -1)) (spacemacs/mplist-get props :off)))
          (prefix-arg-var (plist-get props :prefix))
          (on-message (plist-get props :on-message))
+         (off-message (plist-get props :off-message))
          (evil-leader-for-mode (spacemacs/mplist-get props :evil-leader-for-mode))
          (supported-modes-string (mapconcat (lambda (x) (symbol-name (car x)))
                                             evil-leader-for-mode ", "))
@@ -114,7 +118,7 @@ used."
                (if (,wrapper-func-status)
                    (progn ,@off-body
                           (when (called-interactively-p 'any)
-                            (message ,(format "%s disabled." name))))
+                            (message ,(or off-message (format "%s disabled." name)))))
                  ,@on-body
                  (when (called-interactively-p 'any)
                    (message ,(or on-message (format "%s enabled." name))))))

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1213,6 +1213,13 @@ Available properties:
 | =:relative=           | if non-nil, line numbers are relative to the position of the cursor                          |
 | =:size-limit-kb=      | size limit in kilobytes after which line numbers are not activated                           |
 
+Note that if =:enabled-for-modes= is =nil= or not specified, then the default is
+to enable line numbers in any =prog-mode= and =text-mode= that wasn't explicitly
+disabled via =:disabled-for-modes=. To enable line numbers in a major mode that
+doesn't derive from =prog-mode= or =text-mode=, you must specify it directly in
+=:enabled-for-modes=. To enable line numbers even in non-prog-mode and
+non-text-mode buffers, set =:enabled-for-modes= to =all=.
+
 Examples:
 
 Disable line numbers in dired-mode, doc-view-mode, markdown-mode, org-mode,
@@ -1252,6 +1259,12 @@ Enable line numbers only in programming modes, except for c-mode and c++ mode:
                                              :enabled-for-modes prog-mode
                                              :disabled-for-modes c-mode c++-mode
                                              :size-limit-kb (* dotspacemacs-large-file-size 1000))
+#+END_SRC
+
+Enable line numbers everywhere, even in non-prog-mode and non-text-mode buffers:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-line-numbers '(:enabled-for-modes 'all))
 #+END_SRC
 
 ** Mode-line

--- a/layers/+misc/nlinum/README.org
+++ b/layers/+misc/nlinum/README.org
@@ -5,7 +5,13 @@
   - [[#features][Features:]]
 
 * Description
-This layer provides various styles of line numbering in Spacemacs.
+This layer provides various styles of line numbering in Spacemacs. It replaces
+=linum= and =linum-relative= with the improved =nlinum= and =nlinum-relative=
+packages.
+
+Please note that on Emacs 26 and newer, this layer also replaces the new native
+line numbers mode (=display-line-numbers-mode=), and because of that it is not
+recommended to use =nlinum= layer on Emacs 26 or newer.
 
 ** Features:
 - Support for classic ascending line numbering.

--- a/layers/+misc/nlinum/packages.el
+++ b/layers/+misc/nlinum/packages.el
@@ -13,6 +13,7 @@
   '(
     (linum :excluded t)
     (linum-relative :excluded t)
+    (display-line-numbers :excluded t)
     nlinum
     nlinum-relative
     ))
@@ -41,10 +42,7 @@
     (progn
       (setq nlinum-relative-current-symbol ""
             nlinum-relative-redisplay-delay 0)
-      (when (or (eq dotspacemacs-line-numbers 'relative)
-                (and (listp dotspacemacs-line-numbers)
-                     (car (spacemacs/mplist-get dotspacemacs-line-numbers
-                                                :relative))))
+      (when (spacemacs/relative-line-numbers-p)
         (nlinum-relative-setup-evil)
         (add-hook 'nlinum-mode-hook 'nlinum-relative-on))
       (spacemacs/set-leader-keys "tr" 'spacemacs/nlinum-relative-toggle))))

--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -16,6 +16,7 @@ defaults.
  - conf-mode
  - dired
  - dired-x
+ - display-line-numbers (only in Emacs 26.x and newer)
  - electric-indent-mode
  - ediff
  - eldoc
@@ -23,7 +24,7 @@ defaults.
  - hi-lock
  - image-mode
  - imenu
- - linum
+ - linum (only in Emacs 25.x and older)
  - occur-mode
  - package-menu
  - page-break-lines

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1173,7 +1173,6 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
   "Return non-nil if line numbers should be enabled for current buffer.
 Decision is based on `dotspacemacs-line-numbers'."
   (and dotspacemacs-line-numbers
-       (spacemacs//linum-current-buffer-is-not-special)
        (spacemacs//linum-curent-buffer-is-not-too-big)
        (or (spacemacs//linum-backward-compabitility)
            (and (listp dotspacemacs-line-numbers)
@@ -1214,10 +1213,6 @@ Decision is based on `dotspacemacs-line-numbers'."
        (or (eq dotspacemacs-line-numbers t)
            (eq dotspacemacs-line-numbers 'relative))
        (derived-mode-p 'prog-mode 'text-mode)))
-
-(defun spacemacs//linum-current-buffer-is-not-special ()
-  "Return non-nil if current buffer is not a special buffer."
-  (not (string-match-p "\\*.*\\*" (buffer-name))))
 
 (defun spacemacs//linum-curent-buffer-is-not-too-big ()
   "Return non-nil if buffer size is not too big."

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1176,7 +1176,8 @@ Decision is based on `dotspacemacs-line-numbers'."
        (spacemacs//linum-current-buffer-is-not-special)
        (spacemacs//linum-curent-buffer-is-not-too-big)
        (or (spacemacs//linum-backward-compabitility)
-           (spacemacs//linum-enabled-for-current-major-mode))))
+           (and (listp dotspacemacs-line-numbers)
+                (spacemacs//linum-enabled-for-current-major-mode)))))
 
 (defun spacemacs/relative-line-numbers-p ()
   "Return non-nil if line numbers should be relative.
@@ -1211,7 +1212,8 @@ Decision is based on `dotspacemacs-line-numbers'."
   (and dotspacemacs-line-numbers
        (not (listp dotspacemacs-line-numbers))
        (or (eq dotspacemacs-line-numbers t)
-           (eq dotspacemacs-line-numbers 'relative))))
+           (eq dotspacemacs-line-numbers 'relative))
+       (derived-mode-p 'prog-mode 'text-mode)))
 
 (defun spacemacs//linum-current-buffer-is-not-special ()
   "Return non-nil if current buffer is not a special buffer."
@@ -1225,22 +1227,30 @@ Decision is based on `dotspacemacs-line-numbers'."
                (* 1000 (car (spacemacs/mplist-get dotspacemacs-line-numbers
                                                   :size-limit-kb)))))))
 
+;; if empty, :enabled defaults to '(prog-mode text-mode)
+;; if :enabled is 'all, all modes are considered to be in enabled (even Magit
+;; buffers, terminal buffers, etc.)
 ;; mode in :enabled, not in :disabled ==> t
 ;; mode not in :enabled, in :disabled ==> nil
 ;; mode in :enabled, parent in :disabled ==> t
 ;; parent in :enabled, mode in :disabled ==> nil
-;; not in :enabled, not in :disabled, :enabled is empty ==> t
-;; not in :enabled, not in :disabled, :enabled is not empty ==> nil
-;; both :enabled and :disabled are empty ==> t
+;; mode both in :enabled and :disabled ==> nil
 (defun spacemacs//linum-enabled-for-current-major-mode ()
   "Return non-nil if line number is enabled for current major-mode."
-  (let* ((enabled-for-modes (spacemacs/mplist-get dotspacemacs-line-numbers
-                                                  :enabled-for-modes))
+  ;; default `enabled-for-modes' to '(prog-mode text-mode), because it is a more
+  ;; sensible default than enabling in all buffers - including Magit buffers,
+  ;; terminal buffers, etc.
+  (let* ((enabled-for-modes (or (spacemacs/mplist-get dotspacemacs-line-numbers
+                                                      :enabled-for-modes)
+                                '(prog-mode text-mode)))
          (disabled-for-modes (spacemacs/mplist-get dotspacemacs-line-numbers
                                                    :disabled-for-modes))
-         (enabled-for-parent (apply #'derived-mode-p enabled-for-modes))
+         (enabled-for-parent (or (and (eq enabled-for-modes 'all) 'all)
+                                 (apply #'derived-mode-p enabled-for-modes)))
          (disabled-for-parent (apply #'derived-mode-p disabled-for-modes)))
     (or
+     ;; special case 'all: enable for any mode that isn't specifically disabled
+     (and (eq enabled-for-parent 'all) (not disabled-for-parent))
      ;; current mode or a parent is in :enabled-for-modes, and there isn't a
      ;; more specific parent (or the mode itself) in :disabled-for-modes
      (and enabled-for-parent
@@ -1249,7 +1259,5 @@ Decision is based on `dotspacemacs-line-numbers'."
           ;; enabled-for-parent is the more specific parent (IOW doesn't derive
           ;; from disabled-for-parent)
           (not (spacemacs/derived-mode-p enabled-for-parent disabled-for-parent)))
-     ;; current mode (or parent) not explicitly disabled, and :enabled-for-modes
-     ;; not explicitly specified by user (meaning if it isn't explicitly
-     ;; disabled then it's enabled)
-     (and (null enabled-for-modes) (not disabled-for-parent)))))
+     ;; current mode (or parent) not explicitly disabled
+     (not disabled-for-parent))))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1178,6 +1178,13 @@ Decision is based on `dotspacemacs-line-numbers'."
        (or (spacemacs//linum-backward-compabitility)
            (spacemacs//linum-enabled-for-current-major-mode))))
 
+(defun spacemacs/relative-line-numbers-p ()
+  "Return non-nil if line numbers should be relative.
+Decision is based on `dotspacemacs-line-numbers'."
+  (or (eq dotspacemacs-line-numbers 'relative)
+      (and (listp dotspacemacs-line-numbers)
+           (car (spacemacs/mplist-get dotspacemacs-line-numbers :relative)))))
+
 (defun spacemacs//linum-on (origfunc &rest args)
   "Advice function to improve `linum-on' function."
   (when (spacemacs/enable-line-numbers-p)

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -217,13 +217,12 @@
       (when (spacemacs//linum-backward-compabitility)
         (add-hook 'prog-mode-hook 'display-line-numbers-mode)
         (add-hook 'text-mode-hook 'display-line-numbers-mode))
-      (when dotspacemacs-line-numbers
-        (global-display-line-numbers-mode)))
 
-    :config
-    (progn
-      (advice-add #'display-line-numbers--turn-on
-                  :around #'spacemacs//linum-on))))
+      ;; it's ok to add an advice before the function is defined, and we must
+      ;; add this advice before calling `global-display-line-numbers-mode'
+      (advice-add #'display-line-numbers--turn-on :around #'spacemacs//linum-on)
+      (when dotspacemacs-line-numbers
+        (global-display-line-numbers-mode)))))
 
 (defun spacemacs-defaults/init-linum ()
   (use-package linum

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -194,9 +194,9 @@
       (spacemacs|add-toggle line-numbers
         :status (and (featurep 'display-line-numbers)
                      display-line-numbers-mode
-                     (eq display-line-numbers-type t))
-        :on (progn (setq display-line-numbers-type t)
-                   (display-line-numbers-mode))
+                     (eq display-line-numbers t))
+        :on (prog1 (display-line-numbers-mode)
+              (setq display-line-numbers t))
         :off (display-line-numbers-mode -1)
         :on-message "Absolute line numbers enabled."
         :off-message "Line numbers disabled."
@@ -205,9 +205,9 @@
       (spacemacs|add-toggle relative-line-numbers
         :status (and (featurep 'display-line-numbers)
                      display-line-numbers-mode
-                     (eq display-line-numbers-type 'relative))
-        :on (progn (setq display-line-numbers-type 'relative)
-                   (display-line-numbers-mode))
+                     (eq display-line-numbers 'relative))
+        :on (prog1 (display-line-numbers-mode)
+              (setq display-line-numbers 'relative))
         :off (display-line-numbers-mode -1)
         :documentation "Show relative line numbers."
         :on-message "Relative line numbers enabled."

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -17,6 +17,8 @@
         (conf-mode :location built-in)
         (dired :location built-in)
         (dired-x :location built-in)
+        (display-line-numbers :location built-in
+                              :toggle (version<= "26" emacs-version))
         (electric-indent-mode :location built-in)
         (ediff :location built-in)
         (eldoc :location built-in)
@@ -24,7 +26,7 @@
         (hi-lock :location built-in)
         (image-mode :location built-in)
         (imenu :location built-in)
-        (linum :location built-in)
+        (linum :location built-in :toggle (version< emacs-version "26"))
         (occur-mode :location built-in)
         (package-menu :location built-in)
         ;; page-break-lines is shipped with spacemacs core
@@ -178,6 +180,50 @@
   (use-package imenu
     :defer t
     :init (spacemacs/set-leader-keys "ji" 'imenu)))
+
+(defun spacemacs-defaults/init-display-line-numbers ()
+  (use-package display-line-numbers
+    :defer t
+    :init
+    (progn
+      (setq-default display-line-numbers-width 4)
+      (if (spacemacs/relative-line-numbers-p)
+          (setq display-line-numbers-type 'relative)
+        (setq display-line-numbers-type t))
+
+      (spacemacs|add-toggle line-numbers
+        :status (and (featurep 'display-line-numbers)
+                     display-line-numbers-mode
+                     (eq display-line-numbers-type t))
+        :on (progn (setq display-line-numbers-type t)
+                   (display-line-numbers-mode))
+        :off (display-line-numbers-mode -1)
+        :on-message "Absolute line numbers enabled."
+        :off-message "Line numbers disabled."
+        :documentation "Show the line numbers."
+        :evil-leader "tn")
+      (spacemacs|add-toggle relative-line-numbers
+        :status (and (featurep 'display-line-numbers)
+                     display-line-numbers-mode
+                     (eq display-line-numbers-type 'relative))
+        :on (progn (setq display-line-numbers-type 'relative)
+                   (display-line-numbers-mode))
+        :off (display-line-numbers-mode -1)
+        :documentation "Show relative line numbers."
+        :on-message "Relative line numbers enabled."
+        :off-message "Line numbers disabled."
+        :evil-leader "tr")
+
+      (when (spacemacs//linum-backward-compabitility)
+        (add-hook 'prog-mode-hook 'display-line-numbers-mode)
+        (add-hook 'text-mode-hook 'display-line-numbers-mode))
+      (when dotspacemacs-line-numbers
+        (global-display-line-numbers-mode)))
+
+    :config
+    (progn
+      (advice-add #'display-line-numbers--turn-on
+                  :around #'spacemacs//linum-on))))
 
 (defun spacemacs-defaults/init-linum ()
   (use-package linum

--- a/layers/+spacemacs/spacemacs-evil/README.org
+++ b/layers/+spacemacs/spacemacs-evil/README.org
@@ -10,7 +10,7 @@ througout the entirety of Spacemacs.
 
 ** Features:
 - Add evil tutorial with =evil-tutor=
-- Add relative line number with =linun-relative=
+- Add relative line number with =linun-relative= (only in Emacs 25.x and older)
 - Add escaping under ~fd~ by default with =evil-escape=
 - Add occurences count in mode-line when searching a buffer
 - Add support for lisp structure manipulation with =evil-lisp-state=

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -37,7 +37,7 @@
         evil-visual-mark-mode
         evil-visualstar
         (hs-minor-mode :location built-in)
-        linum-relative
+        (linum-relative :toggle (version< emacs-version "26"))
         vi-tilde-fringe
         ))
 
@@ -313,10 +313,7 @@
     :commands (linum-relative-toggle linum-relative-on)
     :init
     (progn
-      (when (or (eq dotspacemacs-line-numbers 'relative)
-                (and (listp dotspacemacs-line-numbers)
-                     (car (spacemacs/mplist-get dotspacemacs-line-numbers
-                                                :relative))))
+      (when (spacemacs/relative-line-numbers-p)
         (add-hook 'spacemacs-post-user-config-hook 'linum-relative-on))
       (spacemacs/set-leader-keys "tr" 'spacemacs/linum-relative-toggle))
     :config


### PR DESCRIPTION
Note to other maintainers: don't merge this yet, I might need to make a few more changes

Emacs 26.1 will introduce a new minor mode for native line numbers: `display-line-numbers-mode`. It is meant to replace linum and friends (including linum-relative). This PR causes Spacemacs to use `display-line-numbers-mode` in Emacs 26, and `linum-mode` in Emacs 25. If `nlinum` layer is enabled by the user, then `nlinum-mode` will be used instead of `display-line-numbers-mode`. Users of `nlinum` layer are recommended to use `display-line-numbers-mode` in Emacs 26.

There's a small issue that `display-line-numbers-type` is a "global" variable (not buffer-local), so toggling between absolute and relative line numbers in one buffer may affect other buffers. If you test this PR and want to comment about how it behaves, please do.

Currently, the `SPC t n` and `SPC t r` toggles for the three different line numbers solutions behave differently. I'm not sure which behavior is the best, so I'd like to hear what other people prefer. The different behaviors are as follows:

(this summary shows state transitions for line numbers status. "off" means no line numbers are shown, "absolute" means absolute line numbers are shown, "relative" means relative line numbers are shown)
linum:
- `SPC t n`: (state before key press --> state after key press)
  - off (variant 1) --> absolute
  - off (variant 2) --> relative
  - absolute --> off (variant 1)
  - relative --> off (variant 2)
- `SPC t r`:
  - off (variant 1) --> relative
  - off (variant 2) --> off (variant 1)
  - absolute --> relative
  - relative --> off (variant 1)

nlinum:
- `SPC t n`:
  - off (variant 1) --> absolute
  - off (variant 2) --> relative
  - absolute --> off (variant 1)
  - relative --> off (variant 2)
- `SPC t r`:
  - off (variant 1) --> off (variant 2)
  - off (variant 2) --> off (variant 1)
  - absolute --> relative
  - relative --> absolute

display-line-numbers:
- `SPC t n`:
  - off --> absolute
  - absolute --> off
  - relative --> absolute
- SPC t r:
  - off --> relative
  - absolute --> relative
  - relative --> off