### PR TITLE
Load evil-escape only if not in holy-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -41,6 +41,15 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
     (evil-put-property 'evil-state-properties 'iedit-insert
                        :enable states)))
 
+(defun spacemacs//evil-escape-deactivate-in-holy-mode(style)
+  "Deactivate `evil-escape' if STYLE is emacs otherwise enable it."
+  (cond
+   ((or (eq 'vim style)
+        (eq 'hybrid style))
+    (evil-escape-mode t))
+   (t
+    (evil-escape-mode -1))))
+
 
 ;; evil-search-highlight-persist
 

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -96,8 +96,10 @@
 
 (defun spacemacs-evil/init-evil-escape ()
   (use-package evil-escape
-    :init (evil-escape-mode)
-    :config (spacemacs|hide-lighter evil-escape-mode)))
+    :init (progn
+            (spacemacs|hide-lighter evil-escape-mode)
+            (spacemacs//evil-escape-deactivate-in-holy-mode dotspacemacs-editing-style)
+            (add-hook 'spacemacs-editing-style-hook #'spacemacs//evil-escape-deactivate-in-holy-mode))))
 
 (defun spacemacs-evil/init-evil-exchange ()
   (use-package evil-exchange


### PR DESCRIPTION
Fix #10667 by not loading `evil-escape` when editing style is neither `vim` nor `hybrid`.