### PR TITLE
Opt-out of `company-rtags` while retaining rtags

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -104,5 +104,8 @@ This file containes the change log for the next major version of Spacemacs.
 - Move key bindings prefix to ~SPC a V~ (deb0ch)
 **** Version-control
 - Add package =browse-at-remote= which replaces =github-browse-file= (thanks JAremko)
+**** C-C++
+- Add possible value =no-completion= to =c-c++-enable-rtags-support= flag.
+  This adds the option to opt-out of =company-rtags= while enabling Rtags.
 *** Various improvements
 - Various documentation improvements (thanks Carl Lange, Diego Berrocal, Wieland Hoffmann)

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -102,6 +102,16 @@ To enable support for =rtags=, set the layer variable
     '((c-c++ :variables c-c++-enable-rtags-support t)))
 #+END_SRC
 
+This will also enable =company-rtags= to be used as a backend for
+auto-completion (when =auto-completion= layer is included).
+To prevent this, while retaining the rest of Rtags functionality,
+set the variable =c-c++-enable-rtags-support= to ='no-completion=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((c-c++ :variables c-c++-enable-rtags-support 'no-completion)))
+#+END_SRC
+
 ** Enable google-set-c-style
 If you have clang enabled with =clang-format= as described earlier in this page
 you may not have a lot of neeed for =google-set-c-style= if you are already

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -32,7 +32,8 @@
   `c-mode-common-hook'.")
 
 (defvar c-c++-enable-rtags-support nil
-  "If non nil Rtags related packages and configuration are enabled.")
+  "If non nil Rtags related packages and configuration are enabled.
+  If `no-completion', enable all but completion.")
 
 (defvar c-c++-enable-clang-format-on-save nil
   "If non-nil, automatically format code with ClangFormat on

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -88,7 +88,8 @@
 
 (defun c-c++/init-company-rtags ()
   (use-package company-rtags
-    :if c-c++-enable-rtags-support
+    :if (and c-c++-enable-rtags-support
+             (not (eq c-c++-enable-rtags-support 'no-completion)))
     :defer t
     :init
     (progn


### PR DESCRIPTION
if 'c-c++-enable-rtags-support' is 'no-completion', keep everything
enabled, but not completion ('company-rtags').