### PR TITLE
Add argument to specify window when opening from neotree

### DIFF
--- a/layers/+filetree/neotree/funcs.el
+++ b/layers/+filetree/neotree/funcs.el
@@ -9,9 +9,9 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs/neotree-expand-or-open ()
+(defun spacemacs/neotree-expand-or-open (&optional arg)
   "Expand or open a neotree node."
-  (interactive)
+  (interactive "P")
   (let ((node (neo-buffer--get-filename-current-line)))
     (when node
       (if (file-directory-p node)
@@ -21,8 +21,10 @@
             (when neo-auto-indent-point
               (next-line)
               (neo-point-auto-indent)))
-        (let ((mru-winum (winum-get-number (get-mru-window))))
-          (apply 'neotree-enter (list mru-winum)))))))
+        (if arg
+            (neotree-enter arg)
+          (let ((mru-winum (winum-get-number (get-mru-window))))
+            (apply 'neotree-enter (list mru-winum))))))))
 
 (defun spacemacs/neotree-collapse ()
   "Collapse a neotree node."


### PR DESCRIPTION
This PR adds back the default behaviour from Neotree to be able to open a file in a specified window.

Two behaviours are supported now as per the documentation:
1. `RET` and `l` opens the file in the most recently used window.
2. `RET` and `l` accept a window number to open the file in that window.

#9794 can be closed after this PR.