### PR TITLE
web-beutify: fix error when resyncing configuration

### DIFF
--- a/layers/+tools/web-beautify/packages.el
+++ b/layers/+tools/web-beautify/packages.el
@@ -16,7 +16,7 @@
     :defer t
     :init
     (dolist (x spacemacs-web-beautify--modes)
-      (spacemacs/set-leader-keys-for-major-mode (car x) "=" (cadr x)))
+      (spacemacs/set-leader-keys-for-major-mode (car x) "=" (cdr x)))
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'js2-mode
         "=" 'web-beautify-js)


### PR DESCRIPTION
Fixes #10697.

`cadr` doesn't seem to to work with dotted pair.