### PR TITLE
Ivy: Add keybinding for counsel-minibuffer-history

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -124,6 +124,7 @@
        spacemacs--ivy-file-actions)
 
       (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory)
+      (define-key read-expression-map (kbd "C-r") 'counsel-minibuffer-history)
       ;; remaps built-in commands that have a counsel replacement
       (counsel-mode 1)
       (spacemacs|hide-lighter counsel-mode)


### PR DESCRIPTION
Currently, the function bound to C-r is `helm-minibuffer-history` even if ivy layer is chosen.