### PR TITLE
ruby: add key binding for ruby-send-line

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -115,6 +115,7 @@ directory local variables.
 | ~SPC m s f~ | send function definition                             |
 | ~SPC m s F~ | send function definition and switch to REPL          |
 | ~SPC m s i~ | start REPL                                           |
+| ~SPC m s l~ | send line                                            |
 | ~SPC m s r~ | send region                                          |
 | ~SPC m s R~ | send region and switch to REPL                       |
 | ~SPC m s s~ | switch to REPL                                       |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -164,6 +164,7 @@
           "sf" 'ruby-send-definition
           "sF" 'ruby-send-definition-and-go
           "si" 'robe-start
+          "sl" 'ruby-send-line
           "sr" 'ruby-send-region
           "sR" 'ruby-send-region-and-go
           "ss" 'ruby-switch-to-inf)))))


### PR DESCRIPTION
Add key binding for sending a line to REPL.