### PR TITLE
Fix modeline colors on emacs-mac port

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -71,7 +71,7 @@
                            '(spacemacs custom))
                      (spacemacs/mode-line-separator))
                 'wave)
-            powerline-image-apple-rgb (spacemacs/system-is-mac)
+            powerline-image-apple-rgb (eq window-system 'ns)
             powerline-scale (or (spacemacs/mode-line-separator-scale) 1.5))
       (spacemacs|do-after-display-system-init
        ;; seems to be needed to avoid weird graphical artefacts with the


### PR DESCRIPTION
In 665c09b modeline separators colors have been fixed for cocoa emacs, but it has broken colors on emacs-mac port. This commit sets `powerline-image-apple-rgb` to `t` only if `window-system` is `ns`, as suggested in https://github.com/syl20bnr/spacemacs/pull/9550#issuecomment-365807703