### PR TITLE
python: smartparens: Fix bytecomp warning (#10582)

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -387,7 +387,7 @@ fix this issue."
                                               hy-mode-hook))
   (defadvice python-indent-dedent-line-backspace
       (around python/sp-backward-delete-char activate)
-    (let ((pythonp (or (not smartparens-strict-mode)
+    (let ((pythonp (or (not (bound-and-true-p smartparens-strict-mode))
                        (char-equal (char-before) ?\s))))
       (if pythonp
           ad-do-it


### PR DESCRIPTION
The byte compiler doesn't know about `smartparens-strict-mode' because
smartparens is lazy loaded, so wrap the variable reference in `bound-and-true-p'
to silence a warning that appears on Spacemacs startup.

To reproduce:
1. Install a fresh Spacemacs from develop branch
2. Use spacemacs-base distribution
3. Select only these configuration layers: spacemacs-editing python
4. Restart Emacs to install packages
5. Restart Emacs again and observe warning:
   Warning (bytecomp): reference to free variable 'smartparens-strict-mode'