### PR TITLE
Fix pyvenv pre-init defun and package names; adjust hy-mode prefixes.

### DIFF
--- a/layers/+lang/hy/packages.el
+++ b/layers/+lang/hy/packages.el
@@ -15,7 +15,7 @@
         hy-mode
         ob-hy
         pyenv-mode
-        pyvenv-mode
+        pyvenv
         smartparens
         ))
 
@@ -39,7 +39,8 @@
       (spacemacs/declare-prefix-for-mode 'hy-mode "me" "eval")
       (spacemacs/declare-prefix-for-mode 'hy-mode "md" "debug")
       (spacemacs/declare-prefix-for-mode 'hy-mode "mt" "test")
-      (spacemacs/declare-prefix-for-mode 'hy-mode "mV" "pyvenv")
+      (spacemacs/declare-prefix-for-mode 'hy-mode "ms" "REPL")
+      (spacemacs/declare-prefix-for-mode 'hy-mode "mv" "pyvenv")
       (spacemacs/set-leader-keys-for-major-mode 'hy-mode
         "dd" 'hy-insert-pdb
         "dt" 'hy-insert-pdb-threaded
@@ -67,7 +68,7 @@
 (defun hy/pre-init-pyenv-mode ()
   (add-to-list 'spacemacs--python-pyenv-modes 'hy-mode))
 
-(defun hy/pre-init-pyvenv-mode ()
+(defun hy/pre-init-pyvenv ()
   (add-to-list 'spacemacs--python-pyvenv-modes 'hy-mode))
 
 (defun hy/post-init-smartparens ()

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -213,6 +213,7 @@
 
 (defun python/pre-init-pyenv-mode ()
   (add-to-list 'spacemacs--python-pyenv-modes 'python-mode))
+
 (defun python/init-pyenv-mode ()
   (use-package pyenv-mode
     :if (executable-find "pyenv")
@@ -234,8 +235,9 @@
         "vu" 'pyenv-mode-unset
         "vs" 'pyenv-mode-set))))
 
-(defun python/pre-init-pyvenv-mode ()
+(defun python/pre-init-pyvenv ()
   (add-to-list 'spacemacs--python-pyvenv-modes 'python-mode))
+
 (defun python/init-pyvenv ()
   (use-package pyvenv
     :defer t


### PR DESCRIPTION
The variable `spacemacs--python-pyvenv-modes` wasn't being set during initialization of the Python and Hy layers, so the keybindings for `pyvenv` were missing.  This PR fixes that.