### PR TITLE
Add 'company-irony' to c-c++ layer for auto-completion

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -109,5 +109,6 @@ This file containes the change log for the next major version of Spacemacs.
 **** C-C++
 - Add possible value =no-completion= to =c-c++-enable-rtags-support= flag.
   This adds the option to opt-out of =company-rtags= while enabling Rtags.
+- Add support for =irony= with =c-c++-enable-irony-support=.
 *** Various improvements
 - Various documentation improvements (thanks Carl Lange, Diego Berrocal, Wieland Hoffmann)

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -12,6 +12,7 @@
     - [[#clang-format][clang-format]]
     - [[#company-clang-and-flycheck][Company-clang and flycheck]]
   - [[#rtags-configuration][RTags configuration]]
+  - [[#irony-configuration][Irony configuration]]
   - [[#enable-google-set-c-style][Enable google-set-c-style]]
   - [[#newlines][Newlines]]
 - [[#key-bindings][Key Bindings]]
@@ -37,6 +38,7 @@ This layer adds configuration for C/C++ language.
   company-ycmd (when =ycmd= layer is included).
 - Support for [[https://github.com/realgud/realgud][realgud]] debugger.
 - Support for [[https://github.com/Andersbakken/rtags][rtags]].
+- Support for [[https://github.com/Sarcasm/irony-mode][irony]].
 
 * Install
 ** Layer
@@ -110,6 +112,15 @@ set the variable =c-c++-enable-rtags-support= to ='no-completion=:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
     '((c-c++ :variables c-c++-enable-rtags-support 'no-completion)))
+#+END_SRC
+
+** Irony configuration
+To enable support for =irony=, set the layer variable
+=c-c++-enable-irony-support= to =t= in your dotfile.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((c-c++ :variables c-c++-enable-irony-support t)))
 #+END_SRC
 
 ** Enable google-set-c-style

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -31,6 +31,9 @@
   "If non-nil `google-make-newline-indent' will be added as as
   `c-mode-common-hook'.")
 
+(defvar c-c++-enable-irony-support nil
+  "If non nil Irony related packages and configuration are enabled.")
+
 (defvar c-c++-enable-rtags-support nil
   "If non nil Rtags related packages and configuration are enabled.
   If `no-completion', enable all but completion.")

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -15,6 +15,7 @@
     clang-format
     company
     (company-c-headers :requires company)
+    (company-irony :requires company irony)
     (company-rtags :requires company rtags)
     company-ycmd
     counsel-gtags
@@ -27,6 +28,7 @@
     helm-cscope
     helm-gtags
     (helm-rtags :requires helm rtags)
+    irony
     (ivy-rtags :requires ivy rtags)
     org
     realgud
@@ -82,9 +84,19 @@
 
 (defun c-c++/init-company-c-headers ()
   (use-package company-c-headers
+    :defer t))
+
+(defun c-c++/post-init-company-c-headers ()
+  (spacemacs|add-company-backends
+    :backends company-c-headers
+    :modes c-mode-common))
+
+(defun c-c++/init-company-irony ()
+  (use-package company-irony
+    :if c-c++-enable-irony-support
     :defer t
     :init (spacemacs|add-company-backends
-            :backends company-c-headers
+            :backends company-irony
             :modes c-mode-common)))
 
 (defun c-c++/init-company-rtags ()
@@ -171,6 +183,21 @@
   (use-package ivy-rtags
     :if c-c++-enable-rtags-support
     :init (setq rtags-display-result-backend 'ivy)))
+
+;; TODO lazy load this package
+(defun c-c++/init-irony ()
+  (use-package irony
+    :if c-c++-enable-irony-support
+    :init
+    (progn
+      (add-hook 'c++-mode-hook 'irony-mode)
+      (add-hook 'c-mode-hook 'irony-mode)
+      (add-hook 'objc-mode-hook 'irony-mode)
+
+      (add-hook 'irony-mode-hook 'irony-cdb-autosetup-compile-options)
+      (add-hook 'irony-mode-hook (lambda () (remove-hook 'completion-at-point-functions 'irony-completion-at-point t)) t)
+      (spacemacs|diminish irony-mode)
+      )))
 
 ;; TODO lazy load this package
 (defun c-c++/init-rtags ()


### PR DESCRIPTION
Add the clang-based auto-completion service 'Irony' and it's 'company'
backend. In order to work properly, 'company-c-headers' is now added
to the 'company-backends' in the 'port-init' phase, so to come before
'company-irony' in the list.