### PR TITLE
Add ubuntu section in experimental doc (for pdumper)

### DIFF
--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -60,7 +60,7 @@ In the root directory of your freshly cloned Emacs repository and with the
 #+END_SRC
 
 **** Ubuntu
-/Note: This tested on Ubuntu 17.10./
+/Note: This is tested on Ubuntu 17.10./
 
 In the root directory of your freshly cloned Emacs repository and with the
 =pdumper= branch as the current branch:
@@ -189,5 +189,3 @@ command:
 #+BEGIN_SRC shell
   ./emacs --dump-file=/Users/sylvain/.emacs.d/.cache/dumps/spacemacs.pdmp &
 #+END_SRC
-
-

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -60,6 +60,8 @@ In the root directory of your freshly cloned Emacs repository and with the
 #+END_SRC
 
 **** Ubuntu
+/Note: This tested on Ubuntu 17.10./
+
 In the root directory of your freshly cloned Emacs repository and with the
 =pdumper= branch as the current branch:
 

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -80,7 +80,7 @@ need to install the following packages:
    sudo apt-get install libtiff5-dev libgif-dev libpng-dev libxpm-dev libgtk-3-dev libgnutls28-dev
 #+END_SRC
 
-*** Install Emacs 
+*** Install Emacs
 After the compiling finished successfully, you will need to install Emacs.
 
 #+BEGIN_SRC shell

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -7,6 +7,7 @@
     - [[#simple-patch-of-emacs-source-code][Simple patch of Emacs source code]]
     - [[#compile-emacs-from-source][Compile Emacs from source]]
       - [[#macos][MacOS]]
+      - [[#ubuntu][Ubuntu]]
     - [[#update-your-dotfile][Update your dotfile]]
     - [[#test][Test]]
     - [[#report-issues][Report issues]]
@@ -54,7 +55,24 @@ In the root directory of your freshly cloned Emacs repository and with the
 
 #+BEGIN_SRC shell
   ./autogen.sh
+  ./configure --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules --prefix="${HOME}/local"
+#+END_SRC
+
+**** Ubuntu
+In the root directory of your freshly cloned Emacs repository and with the
+=pdumper= branch as the current branch:
+
+#+BEGIN_SRC shell
+  ./autogen.sh
   ./configure --with-ns --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules
+#+END_SRC
+
+If you have never compile Emacs from source on your machine then you probably
+need to install the following packages:
+
+#+BEGIN_SRC shell
+   sudo apt-get install build-essential automake texinfo libjpeg-dev libncurses5-dev
+   sudo apt-get install libtiff5-dev libgif-dev libpng-dev libxpm-dev libgtk-3-dev libgnutls28-dev
 #+END_SRC
 
 *** Update your dotfile

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -55,7 +55,7 @@ In the root directory of your freshly cloned Emacs repository and with the
 
 #+BEGIN_SRC shell
   ./autogen.sh
-  ./configure --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules --prefix="${HOME}/local"
+  ./configure --with-ns --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules
 #+END_SRC
 
 **** Ubuntu
@@ -64,7 +64,7 @@ In the root directory of your freshly cloned Emacs repository and with the
 
 #+BEGIN_SRC shell
   ./autogen.sh
-  ./configure --with-ns --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules
+  ./configure --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules --prefix="$HOME/.local"
 #+END_SRC
 
 If you have never compile Emacs from source on your machine then you probably

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -8,6 +8,7 @@
     - [[#compile-emacs-from-source][Compile Emacs from source]]
       - [[#macos][MacOS]]
       - [[#ubuntu][Ubuntu]]
+    - [[#install-emacs][Install Emacs]]
     - [[#update-your-dotfile][Update your dotfile]]
     - [[#test][Test]]
     - [[#report-issues][Report issues]]
@@ -37,7 +38,7 @@ Clone Emacs from [[https://git.savannah.gnu.org/git/emacs.git]]:
 We need to increase the number of =remember_data= slots in =src/pdumper.c=, we
 double the number of slots by replacing 32 with 64:
 
-#+BEGIN_SRC c
+#+BEGIN_SRC C
 static struct
 {
   void *mem;
@@ -64,7 +65,9 @@ In the root directory of your freshly cloned Emacs repository and with the
 
 #+BEGIN_SRC shell
   ./autogen.sh
+  # Pick one. The first one will install Emacs locally and the second one will install it globally.
   ./configure --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules --prefix="$HOME/.local"
+  ./configure --with-dbus --with-gnutls --with-imagemagick --with-rsvg  --with-mailutils --with-xml2 --with-modules
 #+END_SRC
 
 If you have never compile Emacs from source on your machine then you probably
@@ -73,6 +76,15 @@ need to install the following packages:
 #+BEGIN_SRC shell
    sudo apt-get install build-essential automake texinfo libjpeg-dev libncurses5-dev
    sudo apt-get install libtiff5-dev libgif-dev libpng-dev libxpm-dev libgtk-3-dev libgnutls28-dev
+#+END_SRC
+
+*** Install Emacs 
+After the compiling finished successfully, you will need to install Emacs.
+
+#+BEGIN_SRC shell
+  make
+  make install       # if you configure Emacs to install locally
+  sudo make install  # if globally
 #+END_SRC
 
 *** Update your dotfile
@@ -122,6 +134,10 @@ in the dump."
   )
 #+END_SRC
 
+*Friendly suggestions:* If you have a lot of personal configuration in =user-init= and
+=user-config=, you can try to move them into =user-load= as this can reduce the
+time to load those customized configurations.
+
 *** Test
 Restart Emacs. Each time Emacs starts, Spacemacs will check if the list of your
 layers has changed, if it has changed then Emacs will be automatically dumped
@@ -163,3 +179,13 @@ A forced dump is executed whenever the configuration is reloaded with
 ~SPC f e R~. If a dump is already running then it is cancelled and a new on is
 started. Check the buffer =*spacemacs-dumper*= to see the progress of the
 dumping.
+
+After you can generate a portable dumper of your Emacs and you can start that
+pdumper file successfully, you can alias the way you usually start Emacs to the
+command:
+
+#+BEGIN_SRC shell
+  ./emacs --dump-file=/Users/sylvain/.emacs.d/.cache/dumps/spacemacs.pdmp &
+#+END_SRC
+
+


### PR DESCRIPTION
Documentation for getting pdumper work with Ubuntu. I am using ubuntu 17.10 but I think it should work for most of the up-to-date Ubuntu. It would be great if someone can add the labels for it.

Happy to take suggestions etc. 

Additionally, perf improvement:
        `vanila: 5.263 sec -> 1.509 sec`