### PR TITLE
shell: Restore correct value for company-idle-delay

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -67,8 +67,9 @@ layer variables:
    to wait for the auto-completion key sequence to be entered. The default value
    is 0.1 seconds.
 
-5. =auto-completion-idle-delay= is the number of seconds to wait before
-   suggesting completions. The default value is 0.2 seconds.
+5. =auto-completion-idle-delay= is the number of seconds to wait before suggesting
+   completions. The default value is 0.2 seconds.  Set to =nil= to disable
+   automatic suggestions (the ~TAB~ key will still perform completion).
 
 The default configuration of the layer is:
 

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -82,7 +82,7 @@ connections the delay is often annoying, so it's better to let
 the user activate the completion manually."
   (if (file-remote-p default-directory)
       (setq-local company-idle-delay nil)
-    (setq-local company-idle-delay 0.2)))
+    (setq-local company-idle-delay auto-completion-idle-delay)))
 
 (defun spacemacs//eshell-switch-company-frontend ()
   "Sets the company frontend to `company-preview-frontend' in e-shell mode."


### PR DESCRIPTION
Automatic suggestions annoy me.  I can disable them by setting `auto-completion-idle-delay` to `nil`.  However, this customization is not documented, and the shell layer overrides any custom value.  This PR fixes both problems.

I refer to completion-after-a-delay as "automatic suggestions", but perhaps it would be better to use the phrase "auto-completion" for completion-after-a-delay and "tab-completion" for completion-on-tab-key.  I am open to suggestions on the wording.

#### shell: Restore correct value for `company-idle-delay`

In `spacemacs//toggle-shell-auto-completion-based-on-path`, re-enable automatic suggestions by restoring `company-idle-delay` to the value of `auto-completion-idle-delay` rather than to a hardcoded value.


#### Document how to disable automatic suggestions

Document how to disable automatic suggestions, and mention that the Tab key will still perform completion even with automatic suggestions disabled.