### PR TITLE
Enable command history navigation in the cider REPL in an insert mode

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -228,6 +228,10 @@
       (evil-define-key 'normal cider-repl-mode-map
         (kbd "C-j") 'cider-repl-next-input
         (kbd "C-k") 'cider-repl-previous-input)
+      
+      (evil-define-key 'insert cider-repl-mode-map
+        (kbd "C-j") 'cider-repl-next-input
+        (kbd "C-k") 'cider-repl-previous-input)
 
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)


### PR DESCRIPTION
This is the same navigation that is used in normal mode. This behavior matches the
one from the elisp REPL.