### PR TITLE
Fixes #10723 - Check for executable rather than the file itself

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -60,7 +60,7 @@ or `spacemacs'.")
 to compile Emacs 27 from source following the instructions in file
 EXPERIMENTAL.org at to root of the git repository.")
 
-(defvar dotspacemacs-emacs-pdumper-executable-file "emacs"
+(defvar dotspacemacs-emacs-pdumper-executable-file "emacs-27.0.50"
   "File path pointing to emacs 27.1 executable compiled with support for the
 portable dumper (this is currently the branch pdumper.")
 

--- a/core/core-dumper.el
+++ b/core/core-dumper.el
@@ -60,7 +60,9 @@ You should not used this function, it is reserved for some specific process."
 (defun spacemacs/emacs-with-pdumper-set-p ()
   "Return non-nil if a portable dumper capable emacs executable is set."
   (and dotspacemacs-enable-emacs-pdumper
-       (file-exists-p dotspacemacs-emacs-pdumper-executable-file)))
+       (file-exists-p
+        (locate-file dotspacemacs-emacs-pdumper-executable-file
+                     exec-path exec-suffixes 'file-executable-p))))
 
 (defun spacemacs/dump-emacs ()
   "Dump emacs in a subprocess."


### PR DESCRIPTION
Given the value of `dotspacemacs-emacs-pdumper-executable-file` is "emacs", now
this executable will be auto located as per the PATH environment variable.