### PR TITLE
Fix various typos

### DIFF
--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -15,7 +15,7 @@
   - [[#usage][Usage]]
 
 * Spacemacs dumps using the portable dumper
-The portable dumper is a feature that may be availabe with Emacs 27.1, for now
+The portable dumper is a feature that may be available with Emacs 27.1, for now
 its code is in the =pdumper= branch of the Emacs Git repository, it has not been
 merged to master yet.
 
@@ -91,8 +91,8 @@ After the compiliation finished successfully, you may need to install Emacs.
 #+END_SRC
 
 *** Update your dotfile
-In the function =dotspacemacs/init= add the following variables if you have
-not them already and intialize them:
+In the function =dotspacemacs/init= add the following variables if you don't
+have them already and intialize them:
 
 #+BEGIN_SRC emacs-lisp
 (defun dotspacemacs/init ()
@@ -179,7 +179,7 @@ Emacs source and type:
 =dotspacemacs-emacs-dumper-dump-file=.
 
 A forced dump is executed whenever the configuration is reloaded with
-~SPC f e R~. If a dump is already running then it is cancelled and a new on is
+~SPC f e R~. If a dump is already running then it is cancelled and a new one is
 started. Check the buffer =*spacemacs-dumper*= to see the progress of the
 dumping.
 

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -92,7 +92,7 @@ After the compiliation finished successfully, you may need to install Emacs.
 
 *** Update your dotfile
 In the function =dotspacemacs/init= add the following variables if you don't
-have them already and intialize them:
+have them already and initialize them:
 
 #+BEGIN_SRC emacs-lisp
 (defun dotspacemacs/init ()

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -187,7 +187,7 @@ subdirectory of ROOT is used."
                 :initform nil
                 :type boolean
                 :documentation
-                "Boolean to track wether layers.el has been loaded."))
+                "Boolean to track whether layers.el has been loaded."))
   "A configuration layer.")
 
 (defmethod cfgl-layer-owned-packages ((layer cfgl-layer) &optional props)
@@ -1464,7 +1464,7 @@ discovery."
 (defun configuration-layer/declare-layer (layer-specs)
   "Declare a single layer with spec LAYER-SPECS.
 Set the variable `configuration-layer--declared-layers-usedp' to control
-wether the declared layer is an used one or not."
+whether the declared layer is an used one or not."
   (let* ((layer-name (if (listp layer-specs) (car layer-specs) layer-specs))
          (layer (configuration-layer/get-layer layer-name))
          (usedp configuration-layer--declared-layers-usedp))

--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -135,7 +135,7 @@ seconds to load")
     (advice-add 'require :around #'spacemacs//load-timer)
     (advice-add 'package-initialize
                 :around
-                (spacemacs||make-function-timer package-intialize))
+                (spacemacs||make-function-timer package-initialize))
     (advice-add 'configuration-layer/load
                 :around
                 (spacemacs||make-function-timer configuration-layer/load))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -266,7 +266,7 @@ Insert it in the first line of the buffer, right justified."
 
 (defun spacemacs-buffer//notes-render-framed-text
     (content &optional topcaption botcaption hpadding max-width min-width)
-  "Return a formated string framed with curved lines.
+  "Return a formatted string framed with curved lines.
 The width of the created frame is the width of the content, unless it does not
 satisfy max-width or min-width.  Note that max-width can be limited by the
 window's width.
@@ -350,7 +350,7 @@ WIDTH: current external width of the note's frame."
              ,caption-length 0))))
 
 (defun spacemacs-buffer//notes-render-framed-line (line width hpadding)
-  "Return a formated LINE with borders of a frame on each side.
+  "Return a formatted LINE with borders of a frame on each side.
 WIDTH: external width of the frame.  LINE should be shorter than WIDTH.
 HPADDING: horizontal padding on both sides of the framed string."
   (let ((fill (max 0 (- width 2 hpadding (length line)))))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -266,7 +266,7 @@ Insert it in the first line of the buffer, right justified."
 
 (defun spacemacs-buffer//notes-render-framed-text
     (content &optional topcaption botcaption hpadding max-width min-width)
-  "Return a formated string framed with plained lines.
+  "Return a formated string framed with curved lines.
 The width of the created frame is the width of the content, unless it does not
 satisfy max-width or min-width.  Note that max-width can be limited by the
 window's width.

--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -59,7 +59,7 @@ Available PROPS:
     `:variables' property is used in several calls to this macro for the same
     MODES.
 
-`:apppend-hook BOOLEAN'
+`:append-hook BOOLEAN'
     Advanced property to control whether hooks functions are hooked or not,
     if non-nil hook functions are appended to modes hooks passed as `:modes'.
 

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -37,7 +37,7 @@ file.
 ** General
 You can customize ivy with the following variables:
 
-- =ivy-wrap= Whether C-n and C-p should wrap-around when at the the first or
+- =ivy-wrap= Whether C-n and C-p should wrap-around when at the first or
   last candidate. The default value is =nil=.
 - =ivy-extra-directories= Setting this to =nil= hides . and .. directories from
   file name completion. You can still go up a directory up by ~DEL~.

--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -32,7 +32,7 @@
         (lsp-javascript-typescript-enable)
         (lsp-javascript-flow-enable)
         (spacemacs//setup-lsp-jump-handler 'rjsx-mode))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dofile.")))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 (defun spacemacs//react-setup-lsp-company ()
   "Setup lsp auto-completion."
@@ -46,7 +46,7 @@
           :append-hooks nil
           :call-hooks t)
         (company-mode))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dofile.")))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 
 ;; Emmet

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -144,7 +144,7 @@ set that up like this:
 
 ** Newlines
 You can enable the =Auto-newline= minor mode that automatically adds newlines
-after certain characters by setting the =c-c++-enable-auto-newline= vairable.
+after certain characters by setting the =c-c++-enable-auto-newline= variable.
 
 #+BEGIN_SRC emacs-lisp
      (c-c++ :variables

--- a/layers/+lang/coffeescript/README.org
+++ b/layers/+lang/coffeescript/README.org
@@ -12,7 +12,7 @@
   - [[#repl][REPL]]
 
 * Description
-This layer adds support for CoffeeScript language using [[https://github.com/defunkt/coffee-mode][coffee-mode]].
+This layer adds support for the CoffeeScript language using [[https://github.com/defunkt/coffee-mode][coffee-mode]].
 
 ** Features:
 - Syntax highlighting
@@ -23,12 +23,12 @@ This layer adds support for CoffeeScript language using [[https://github.com/def
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add =javascript= to the existing =dotspacemacs-configuration-layers= list in
+add =coffeescript= to the existing =dotspacemacs-configuration-layers= list in
 this file.
 
 * Configuration
 ** Linting
-To enable linting install [http://www.coffeelint.org/][CoffeeLint] with:
+To enable linting, install [[http://www.coffeelint.org/][CoffeeLint]] with the following command:
 
 #+BEGIN_SRC sh
 npm install -g coffeelint

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -101,7 +101,7 @@ run this command:
 =elm-format= can be used to format elm code according to a standard set of
 rules.
 
-To install =elm-format= follow the the instructions for the version of elm
+To install =elm-format= follow the instructions for the version of elm
 installed: https://github.com/avh4/elm-format
 
 Also, note that if you use homebrew to install =elm-format= the installed exe

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -493,7 +493,7 @@ different you need to reinstall ghc using the command =stack setup
 
 *** The Project root directory is not set properly
 Flycheck launches the GHC command not from the project root directory but from
-the the directory of the file being checked. This is normally not a problem as
+the directory of the file being checked. This is normally not a problem as
 all the paths are set properly, however it could be a problem if some template
 Haskell functions use relative paths (e.g. in Yesod scaffolded projects).
 

--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -23,7 +23,7 @@ This layer adds support for editing HTML and CSS.
 - Support for editing Slim and Pug templates using [[https://github.com/slim-template/emacs-slim][slim-mode]] and [[https://github.com/hlissner/emacs-pug-mode][pug-mode]]
 - See the effects of typed HTML using [[https://github.com/skeeto/impatient-mode][impatient-mode]]
 - imenu support for CSS and Sass through [[https://github.com/hlissner/emacs-counsel-css][counsel-css]]
-- Formating with [[https://github.com/yasuyk/web-beautify][web-beautify]]
+- Formatting with [[https://github.com/yasuyk/web-beautify][web-beautify]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/hy/README.org
+++ b/layers/+lang/hy/README.org
@@ -43,7 +43,7 @@ To install =hy= globally:
 | ~SPC m d t~ | insert pdb threaded |
 
 ** REPL
-Start a Hy inferior repel process with ~SPC m s i~. If =hy= is
+Start a Hy inferior REPL process with ~SPC m s i~. If =hy= is
 available in system executable search paths, =hy= will be used to
 launch the shell. You may change your system executable search path
 by activating a virtual environment.

--- a/layers/+lang/hy/funcs.el
+++ b/layers/+lang/hy/funcs.el
@@ -19,13 +19,13 @@
   (hy-shell-start-or-switch-to-shell))
 
 (defun spacemacs/hy-shell-eval-current-form-and-go ()
-  "Send current buffer to REPL and focus it."
+  "Send current form to REPL and focus it."
   (interactive)
   (hy-shell-eval-current-form)
   (hy-shell-start-or-switch-to-shell))
 
 (defun spacemacs/hy-shell-eval-region-and-go ()
-  "Send current buffer to REPL and focus it."
+  "Send region to REPL and focus it."
   (interactive)
   (hy-shell-eval-region)
   (hy-shell-start-or-switch-to-shell))

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -175,7 +175,7 @@ Eclim workspace (default value is =~/workspace=), as shown below:
    (setq
     ;; Specify the workspace to use by default
     eclimd-default-workspace "/path/to/default/eclipse/workspace"
-    ;; wether autostarting eclimd or not (default nil)
+    ;; whether autostarting eclimd or not (default nil)
     eclimd-autostart t
     ;; Whether or not to block emacs until eclimd is ready (default nil)
     eclimd-wait-for-process t)

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -151,7 +151,7 @@ doing this [[https://stackoverflow.com/questions/9679932#comment33532258_9683472
 ** Refactoring (js2-refactor)
 Bindings should match the plain emacs assignments.
 
-| Key Binding   | Descripti using ternon                                                                                         |
+| Key Binding   | Description                                                                                         |
 |---------------+----------------------------------------------------------------------------------------------------------------|
 | ~SPC m k~     | deletes to the end of the line, but does not cross semantic boundaries                                         |
 | ~SPC m r 3 i~ | converts ternary operator to if-statement                                                                      |

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -31,7 +31,7 @@ This layer adds support for the JavaScript language using [[https://github.com/m
 - Refactoring: done using [[https://github.com/magnars/js2-refactor.el][js2-refactor]].
 - Auto-completion and documentation
 - REPL available via [[https://github.com/skeeto/skewer-mode][skewer-mode]] and [[https://github.com/pandeiro/livid-mode][livid-mode]]
-- Formating with [[https://github.com/yasuyk/web-beautify][web-beautify]]
+- Formatting with [[https://github.com/yasuyk/web-beautify][web-beautify]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -35,7 +35,7 @@
         (lsp-javascript-typescript-enable)
         (lsp-javascript-flow-enable))
     (message (concat "`lsp' layer is not installed, "
-                     "please add `lsp' layer to your dofile."))))
+                     "please add `lsp' layer to your dotfile."))))
 
 (defun spacemacs//javascript-setup-lsp-company ()
   "Setup lsp auto-completion."
@@ -49,7 +49,7 @@
           :call-hooks t)
         (company-mode))
     (message (concat "`lsp' layer is not installed, "
-                     "please add `lsp' layer to your dofile."))))
+                     "please add `lsp' layer to your dotfile."))))
 
 
 ;; js-doc

--- a/layers/+lang/json/README.org
+++ b/layers/+lang/json/README.org
@@ -22,7 +22,7 @@ This layer adds support for JSON files with [[https://github.com/joshwnj/json-mo
 - Auto-completion
 - Get the path to a JSON value with [[https://github.com/Sterlingg/json-snatcher][json-snatcher]]
 - Navigate JSON hierarchy with [[https://github.com/DamienCassou/json-navigator][json-nagivator]]
-- Formating with [[https://github.com/yasuyk/web-beautify][web-beautify]]
+- Formatting with [[https://github.com/yasuyk/web-beautify][web-beautify]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -43,7 +43,7 @@ Use the universal prefix argument to print decoded strings, for instance:
 #+BEGIN_EXAMPLE json
 {"name":"foo\"bar","nick":"foo \u00e4 bar","description":"<pre>\nbaz\n</pre>","home":"/home/foobar"}
 
-Will be reformated:
+Will be reformatted:
 
 {
   "name": "foo\"bar",

--- a/layers/+lang/json/funcs.el
+++ b/layers/+lang/json/funcs.el
@@ -22,7 +22,7 @@ If ARG is a universal prefix argument then display the hierarchy after point."
 (defun spacemacs/json-reformat-dwim (arg &optional start end)
   "Reformat the whole buffer of the active region.
 If ARG is non-nil (universal prefix argument) then try to decode the strings.
-If ARG is a numerical prefix argument then specify the indendation level."
+If ARG is a numerical prefix argument then specify the indentation level."
   (interactive "P\nr")
   (let ((json-reformat:indent-width js-indent-level)
         (json-reformat:pretty-string? nil))

--- a/layers/+lang/perl5/README.org
+++ b/layers/+lang/perl5/README.org
@@ -12,7 +12,7 @@
   - [[#perldoc][Perldoc]]
   - [[#pod-and-here-doc][POD and HERE doc]]
   - [[#find-symbol][Find Symbol]]
-  - [[#formating-code][Formating Code]]
+  - [[#formatting-code][Formatting Code]]
 
 * Description
 This layer adds support for the Perl5 language.
@@ -35,7 +35,7 @@ file.
 
 * Key Bindings
 ** Perldoc
-Browse formated perldocs.
+Browse formatted perldocs.
 
 | Key Binding | Description                     |
 |-------------+---------------------------------|
@@ -57,7 +57,7 @@ Jump to symbol definition.
 | ~SPC m g g~ | jump to symbol definition                 |
 | ~SPC m g G~ | jump to symbol definition in other window |
 
-** Formating Code
+** Formatting Code
 
 | Key Binding | Description                   |
 |-------------+-------------------------------|

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -73,7 +73,7 @@ when this mode is enabled since the minibuffer is cleared all the time."
       (progn
         (require 'lsp-python)
         (lsp-python-enable))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dofile.")))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 (defun spacemacs//python-setup-lsp-company ()
   "Setup lsp auto-completion."
@@ -85,7 +85,7 @@ when this mode is enabled since the minibuffer is cleared all the time."
           :append-hooks nil
           :call-hooks)
         (company-mode))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dofile.")))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 
 ;; others

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -21,7 +21,7 @@ If `help-window-select' is non-nil, also select the help window."
   "Quickly run a Rust file using rustc.
 Meant for a quick-prototype flow only - use `spacemacs/open-junk-file' to
 open a junk Rust file, type in some code and quickly run it.
-If you want to use third-party crates, create a a new project using `cargo-process-new' and run
+If you want to use third-party crates, create a new project using `cargo-process-new' and run
 using `cargo-process-run'."
   (interactive)
   (let ((input-file-name (buffer-file-name))

--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -14,7 +14,7 @@
   - [[#inferior-process-interactions-sqli][Inferior Process Interactions (SQLi)]]
     - [[#send-sql-queries-to-sqli][Send SQL queries to SQLi:]]
   - [[#sqli-buffer][SQLi buffer]]
-  - [[#code-formating][Code Formating]]
+  - [[#code-formatting][Code Formatting]]
 
 * Description
 This layer adds support for a wide range of SQL dialects to Spacemacs.
@@ -121,6 +121,6 @@ column and NAME is non-reserved SQL keyword.
 | ~SPC m b r~ | rename buffer (follow up in the SQL buffer with ~SPC m b s~) |
 | ~SPC m b S~ | save the current connection                                  |
 
-** Code Formating
+** Code Formatting
 
 | ~SPC m = c~ | capitalize SQL keywords in region (if capitalize is enabled) |

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -70,7 +70,7 @@
                                     'typescript-tsx-mode)
         (lsp-javascript-typescript-enable))
     (message (concat "`lsp' layer is not installed, "
-                     "please add `lsp' layer to your dofile."))))
+                     "please add `lsp' layer to your dotfile."))))
 
 (defun spacemacs//typescript-setup-lsp-company ()
   "Setup lsp auto-completion."
@@ -85,7 +85,7 @@
           :call-hooks t)
         (company-mode))
     (message (concat "`lsp' layer is not installed, "
-                     "please add `lsp' layer to your dofile."))))
+                     "please add `lsp' layer to your dotfile."))))
 
 (defun spacemacs//typescript-setup-lsp-eldoc ()
   "Setup eldoc for LSP."

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1031,7 +1031,7 @@ using a visual block/rectangle selection."
   (interactive "r")
   (let (words
         alist_words_compare
-        (formated "")
+        (formatted "")
         (overview (call-interactively 'count-words)))
     (save-excursion
       (goto-char start)
@@ -1056,12 +1056,12 @@ Compare them on count first,and in case of tie sort them alphabetically."
       (let* ((word (pop words))
              (name (car word))
              (count (cdr word)))
-        (setq formated (concat formated (format "[%s: %d], " name count)))))
+        (setq formatted (concat formatted (format "[%s: %d], " name count)))))
     (when (interactive-p)
-      (if (> (length formated) 2)
+      (if (> (length formatted) 2)
           (message (format "%s\nWord count: %s"
                            overview
-                           (substring formated 0 -2)))
+                           (substring formatted 0 -2)))
         (message "No words.")))
     words))
 

--- a/layers/+tools/cfengine/README.org
+++ b/layers/+tools/cfengine/README.org
@@ -9,7 +9,7 @@
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#set-file-permission-on-save][Set file permission on save]]
-  - [[#indendation][Indendation]]
+  - [[#indentation][Indentation]]
 - [[#execution-of-cfengine3-src-blocks][Execution of =cfengine3= SRC blocks]]
 - [[#key-bindings][Key bindings]]
 
@@ -43,7 +43,7 @@ errors like:
   (add-hook 'after-save-hook 'cfengine-permissions-policy-owner-only nil 'make-it-local)
 #+END_SRC
 
-** Indendation
+** Indentation
 If you like attributes to be intended from the promiser set =Indentation amount
 from anchor= to =2=. For example:
 

--- a/layers/+tools/geolocation/README.org
+++ b/layers/+tools/geolocation/README.org
@@ -61,7 +61,7 @@ activated.
 ** Theme-changer
 This layer implement a simple "theme changer" which, when enabled, will switch
 between first two themes the user has setup in ~dotspacemacs-themes~. First
-theme listed will be used as light variant, while the second as the the dark.
+theme listed will be used as the light variant, while the second as the dark.
 Other themes will be ignored by this layer, though they are still available for
 cycling, etc.
 

--- a/news/news01.org
+++ b/news/news01.org
@@ -364,7 +364,7 @@ configuration:
   =--debug-init= fed in for you
 - press ~SPC q D~ to restart Emacs with a selected list of packages to load,
   in this mode Spacemacs is completely disabled so you get the perfect way
-  to test wether a bug comes from Spacemacs configuration or not
+  to test whether a bug comes from Spacemacs configuration or not
 - press ~SPC h I~ to open an org buffer with an issue template, fill it then
   press ~C-c C-c~ to submit it with your default internet browser.
 


### PR DESCRIPTION
This PR corrects various typos.  The first commit fixes some one-off typos.  Subsequent commits group fixes by typo (in case where grepping revealed multiple instances of the same typo) or file.

Please let me know if it would be less annoying to squash, submit separate PRs, or take another approach!

#### Fix various isolated typos

"apppend" -> "append"

"availabe" -> "available"

"Descripti using ternon" -> "Description"

"you have not them" -> "you don't have them"

"new on" -> "new one"

"plained" -> "curved"

"repel" -> "REPL"

"vairable" -> "variable"

#### Fix a few errors in the CoffeeScript layer readme

Add a missing "the".

Correct a reference to the layer as "javascript" to "coffeescript".

Fix the syntax on the link to CoffeeLint.

#### Fix typos: "dofile" -> "dotfile"

#### Fix typos: "formated" and "formating"

"formated" -> "formatted"

"formating" -> "formatting"

#### hy: Fix docstrings in funcs.el

Fix copy-and-pasted docstring text for `spacemacs/hy-shell-eval-current-form-and-go` and `spacemacs/hy-shell-eval-region-and-go`.

#### Fix typos: "indendation" -> "indentation"

#### Fix typos: "intialize" -> "initialize"

#### Fix typos: "the the", "a a"

Fix duplicated (or misplaced) articles.

#### Fix typos: "wether" -> "whether"
