### PR TITLE
add org-babel support for some of the more popular languages.

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -252,4 +252,3 @@
     :post-init
     (dolist (mode c-c++-modes)
       (spacemacs/set-leader-keys-for-major-mode mode "gi" 'cscope-index-files))))
-

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -35,6 +35,7 @@
     stickyfunc-enhance
     xcscope
     ycmd
+    org
     ))
 
 (defun c-c++/init-cc-mode ()
@@ -247,3 +248,7 @@
     :post-init
     (dolist (mode c-c++-modes)
       (spacemacs/set-leader-keys-for-major-mode mode "gi" 'cscope-index-files))))
+
+(defun c-c++/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(C . t))))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -28,6 +28,7 @@
     helm-gtags
     (helm-rtags :requires helm rtags)
     (ivy-rtags :requires ivy rtags)
+    org
     realgud
     rtags
     semantic
@@ -35,7 +36,6 @@
     stickyfunc-enhance
     xcscope
     ycmd
-    org
     ))
 
 (defun c-c++/init-cc-mode ()
@@ -243,12 +243,13 @@
     (spacemacs/set-leader-keys-for-major-mode mode
       "gG" 'ycmd-goto-imprecise)))
 
+(defun c-c++/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(C . t))))
+
 (defun c-c++/pre-init-xcscope ()
   (spacemacs|use-package-add-hook xcscope
     :post-init
     (dolist (mode c-c++-modes)
       (spacemacs/set-leader-keys-for-major-mode mode "gi" 'cscope-index-files))))
 
-(defun c-c++/pre-init-org ()
-  (spacemacs|use-package-add-hook org
-    :post-config (add-to-list 'org-babel-load-languages '(C . t))))

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -11,6 +11,7 @@
 
 (setq java-packages
       '(
+        org
         company
         (company-emacs-eclim :toggle
                              (configuration-layer/package-used-p 'company))
@@ -443,3 +444,7 @@
         "mcc" 'mvn-compile
         "mcC" 'mvn-clean
         "mcr" 'spacemacs/mvn-clean-compile))))
+
+(defun java/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(java . t))))

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -448,4 +448,3 @@
         "mcc" 'mvn-compile
         "mcC" 'mvn-clean
         "mcr" 'spacemacs/mvn-clean-compile))))
-

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -11,7 +11,6 @@
 
 (setq java-packages
       '(
-        org
         company
         (company-emacs-eclim :toggle
                              (configuration-layer/package-used-p 'company))
@@ -30,6 +29,7 @@
         maven-test-mode
         (meghanada :toggle (not (version< emacs-version "25.1")))
         mvn
+        org
         ))
 
 (defun java/post-init-company ()
@@ -350,6 +350,10 @@
 (defun java/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'java-mode))
 
+(defun java/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(java . t))))
+
 (defun java/init-java-mode ()
   (use-package java-mode
     :defer t
@@ -445,6 +449,3 @@
         "mcC" 'mvn-clean
         "mcr" 'spacemacs/mvn-clean-compile))))
 
-(defun java/pre-init-org ()
-  (spacemacs|use-package-add-hook org
-    :post-config (add-to-list 'org-babel-load-languages '(java . t))))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -11,6 +11,7 @@
 
 (setq javascript-packages
       '(
+        org
         add-node-modules-path
         company
         counsel-gtags
@@ -63,6 +64,10 @@
 (defun javascript/post-init-impatient-mode ()
   (spacemacs/set-leader-keys-for-major-mode 'js2-mode
     "i" 'spacemacs/impatient-mode))
+
+(defun javascript/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(js . t))))
 
 (defun javascript/init-js-doc ()
   (use-package js-doc

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -11,7 +11,6 @@
 
 (setq javascript-packages
       '(
-        org
         add-node-modules-path
         company
         counsel-gtags
@@ -29,6 +28,7 @@
          :requires lsp-mode
          :location (recipe :fetcher github
                            :repo "emacs-lsp/lsp-javascript"))
+        org
         skewer-mode
         tern
         web-beautify

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -11,6 +11,7 @@
 
 (setq perl5-packages
       '(
+        org
         (company-plsense :requires company)
         (cperl-mode :location built-in)
         flycheck
@@ -130,3 +131,7 @@
   (with-eval-after-load 'cperl-mode
     (add-hook 'smartparens-enabled-hook 'spacemacs//perl5-smartparens-enable)
     (add-hook 'smartparens-disabled-hook 'spacemacs//perl5-spartparens-disable)))
+
+(defun perl5/pre-init-org ()
+  (spacemacs|use-package-add-hook org
+    :post-config (add-to-list 'org-babel-load-languages '(perl . t))))

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -11,10 +11,10 @@
 
 (setq perl5-packages
       '(
-        org
         (company-plsense :requires company)
         (cperl-mode :location built-in)
         flycheck
+        org
         realgud
         smartparens
         ))


### PR DESCRIPTION
Trivial PR, because people seem to have problems adding languages to org-babel-load-languages (maybe because it needs to be set before loading org)

#+begin_src perl :results output
print "Hello World!"
#+end_src

#+RESULTS:
: Hello World!

#+begin_src C
  printf ("Hello World!\n");
#+end_src

#+RESULTS:
: Hello World!

#+begin_src C++ :includes <iostream>
  std::cout<<"Hello World!\n";
#+end_src

#+RESULTS:
: Hello World!

#+begin_src D
  writefln ("Hello World!");
#+end_src

#+HEADERS: :classname HelloWorld :cmdline "-cp ."
#+begin_src java
public class HelloWorld {
  public static void main(String[] args) {
    System.out.println("Hello world!");
  }
}
#+end_src

#+RESULTS:
: Hello world!

#+begin_src js
  console.log("Hello World!");
#+end_src

