### PR TITLE
fix bug with evil-pasted object

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -247,7 +247,7 @@
   (spacemacs|define-text-object "“" "double-quotation-mark" "“" "”")
   (evil-define-text-object evil-pasted (count &rest args)
     (list (save-excursion (evil-goto-mark ?\[) (point))
-          (save-excursion (evil-goto-mark ?\]) (point))))
+          (save-excursion (evil-goto-mark ?\]) (1+ (point)))))
   (define-key evil-inner-text-objects-map "P" 'evil-pasted)
   ;; define text-object for entire buffer
   (evil-define-text-object evil-inner-buffer (count &optional beg end type)


### PR DESCRIPTION
Simple bug fix. the `evil-pasted` text object always fails to get the last character of the paste. This is because the mark `]` moves to the last character of the paste, which put the point at the beginning of character instead of at the end. 

fixes #10741