### PR TITLE
Revert "Move yas-activate-extra-mode setup to javascript layer"

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -74,3 +74,6 @@ Result depends on syntax table's comment character."
 If optional argument P is present, test this instead of point."
   (or (spacemacs//react-inside-string-q)
       (spacemacs//react-inside-comment-q)))
+
+(defun spacemacs//react-setup-yasnippet ()
+  (yas-activate-extra-mode 'js-mode))

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -21,6 +21,7 @@
     smartparens
     tern
     web-beautify
+    yasnippet
     ))
 
 (defun react/post-init-add-node-modules-path ()
@@ -89,3 +90,6 @@
 
 (defun react/pre-init-web-beautify ()
   (add-to-list 'spacemacs--web-beautify-modes (cons 'rjsx-mode 'web-beautify-js)))
+
+(defun react/post-init-yasnippet ()
+  (add-hook 'rjsx-mode-hook #'spacemacs//react-setup-yasnippet))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -30,9 +30,7 @@
                            :repo "emacs-lsp/lsp-javascript"))
         skewer-mode
         tern
-        web-beautify
-        yasnippet
-        ))
+        web-beautify))
 
 (defun javascript/post-init-add-node-modules-path ()
   (spacemacs/add-to-hooks #'add-node-modules-path '(css-mode-hook
@@ -202,8 +200,3 @@
 
 (defun javascript/pre-init-web-beautify ()
   (add-to-list 'spacemacs--web-beautify-modes (cons 'js2-mode 'web-beautify-js)))
-
-(defun javascript/pre-init-yasnippet ()
-  (spacemacs|use-package-add-hook yasnippet
-    :post-config
-    (yas-activate-extra-mode 'js-mode)))

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -150,3 +150,6 @@
                  (list (point-min) (point-max))))
   (browse-url (concat "http://www.typescriptlang.org/Playground#src="
                       (url-hexify-string (buffer-substring-no-properties start end)))))
+
+(defun spacemacs/typescript-yasnippet-setup ()
+  (yas-activate-extra-mode 'js-mode))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -19,6 +19,7 @@
         tide
         typescript-mode
         web-mode
+        yasnippet
         ))
 
 (defun typescript/post-init-add-node-modules-path ()
@@ -87,6 +88,10 @@
 (defun typescript/post-init-web-mode ()
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . typescript-tsx-mode)))
+
+(defun typescript/post-init-yasnippet ()
+  (spacemacs/add-to-hooks #'spacemacs/typescript-yasnippet-setup '(typescript-mode-hook
+                                                     typescript-tsx-mode-hook)))
 
 (defun typescript/init-typescript-mode ()
   (use-package typescript-mode


### PR DESCRIPTION
This reverts commit e4eca01e827b68447604e0a7a0b7163662334e29.

This made js snippets unavailable in typescript and react modes. They need to be
activated in a hook when the mode starts, not after yasnippet is loaded.