### PR TITLE
Fix typo in templates/README.org

### DIFF
--- a/layers/+completion/templates/README.org
+++ b/layers/+completion/templates/README.org
@@ -39,7 +39,7 @@ It is not part of the final regexp. Therefore, more specific templates should
 come first. For example,
 
 #+BEGIN_EXAMPLE
-00:test_*.py
+00:test_.*.py
 01:.*.py
 #+END_EXAMPLE
 


### PR DESCRIPTION
The sample `00:test_*.py` should read `00:test_.*.py`, as per https://github.com/mineo/yatemplate#description

Hope that it helps.

Cheers!