### PR TITLE
ruby: add key bindings for ruby-send-{buffer,line}-and-go

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -112,10 +112,12 @@ directory local variables.
 | ~SPC m g g~ | go to definition (robe-jump)                         |
 | ~SPC m h h~ | show documentation for method at point (robe-doc)    |
 | ~SPC m s b~ | send buffer                                          |
+| ~SPC m s B~ | send buffer and switch to REPL                       |
 | ~SPC m s f~ | send function definition                             |
 | ~SPC m s F~ | send function definition and switch to REPL          |
 | ~SPC m s i~ | start REPL                                           |
 | ~SPC m s l~ | send line                                            |
+| ~SPC m s L~ | send line and switch to REPL                         |
 | ~SPC m s r~ | send region                                          |
 | ~SPC m s R~ | send region and switch to REPL                       |
 | ~SPC m s s~ | switch to REPL                                       |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -161,10 +161,12 @@
           "rsr" 'robe-rails-refresh
           ;; inf-enh-ruby-mode
           "sb" 'ruby-send-buffer
+          "sB" 'ruby-send-buffer-and-go
           "sf" 'ruby-send-definition
           "sF" 'ruby-send-definition-and-go
           "si" 'robe-start
           "sl" 'ruby-send-line
+          "sL" 'ruby-send-line-and-go
           "sr" 'ruby-send-region
           "sR" 'ruby-send-region-and-go
           "ss" 'ruby-switch-to-inf)))))


### PR DESCRIPTION
Add key bindings for recently added `ruby-send-buffer-and-go` and
`ruby-send-line-and-go` commands.