### PR TITLE
Work around ido mode remapping spacemacs keys

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -79,6 +79,7 @@ This file containes the change log for the next major version of Spacemacs.
 - Use Helm or Ivy (if one of these is enabled) for ~SPC a d~ (=dired=),
   ~SPC F f~ (=find-file-other-frame=), ~SPC F b~ (=switch-to-buffer-other-frame=),
   ~SPC F B~ (=display-buffer-other-frame=), and ~SPC F O~ (=dired-other-frame=).
+- New key binding ~SPC f i~ for =insert-file=.
 *** Layer changes
 **** GitHub
 - Add new package =magithub=

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -76,6 +76,9 @@ This file containes the change log for the next major version of Spacemacs.
   - Avoid importing already defined variables (except `PATH`/`MANPATH`).
 - Move all scrolling key bindings from ~SPC n~ to ~SPC N~ (Somelauw)
 - Overhaul the scroll transient state on ~SPC N~ prefix (Somelauw)
+- Use Helm or Ivy (if one of these is enabled) for ~SPC a d~ (=dired=),
+  ~SPC F f~ (=find-file-other-frame=), ~SPC F b~ (=switch-to-buffer-other-frame=),
+  ~SPC F B~ (=display-buffer-other-frame=), and ~SPC F O~ (=dired-other-frame=).
 *** Layer changes
 **** GitHub
 - Add new package =magithub=

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -98,6 +98,7 @@ automatically applied to."
 (defalias 'spacemacs/dired 'dired)
 (defalias 'spacemacs/dired-other-frame 'dired-other-frame)
 (defalias 'spacemacs/switch-to-buffer-other-frame 'switch-to-buffer-other-frame)
+(defalias 'spacemacs/insert-file 'insert-file)
 (defalias 'spacemacs/display-buffer-other-frame 'display-buffer-other-frame)
 
 (defun spacemacs/indent-region-or-buffer ()

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -88,6 +88,18 @@ automatically applied to."
   :type '(list symbol))
 
 
+;; ido-mode remaps some commands to ido counterparts.  We want default Emacs key
+;; bindings (those under C-x) to use ido, but we want to use the original
+;; commands in Spacemacs key bindings (those under M-m or SPC) so that they use
+;; `read-file-name-function', `completing-read-function',
+;; `completion-in-region-function', etc. configured by Helm or Ivy etc.  The
+;; following aliases allow us to bind Spacemacs keys to the original commands.
+(defalias 'spacemacs/find-file-other-frame 'find-file-other-frame)
+(defalias 'spacemacs/dired 'dired)
+(defalias 'spacemacs/dired-other-frame 'dired-other-frame)
+(defalias 'spacemacs/switch-to-buffer-other-frame 'switch-to-buffer-other-frame)
+(defalias 'spacemacs/display-buffer-other-frame 'display-buffer-other-frame)
+
 (defun spacemacs/indent-region-or-buffer ()
   "Indent a region if selected, otherwise the whole buffer."
   (interactive)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -220,13 +220,13 @@
   "fy" 'spacemacs/show-and-copy-buffer-filename)
 ;; frame ----------------------------------------------------------------------
 (spacemacs/set-leader-keys
-  "Ff" 'find-file-other-frame
+  "Ff" 'spacemacs/find-file-other-frame
   "Fd" 'delete-frame
   "FD" 'delete-other-frames
-  "Fb" 'switch-to-buffer-other-frame
-  "FB" 'display-buffer-other-frame
+  "Fb" 'spacemacs/switch-to-buffer-other-frame
+  "FB" 'spacemacs/display-buffer-other-frame
   "Fo" 'other-frame
-  "FO" 'dired-other-frame
+  "FO" 'spacemacs/dired-other-frame
   "Fn" 'make-frame)
 ;; help -----------------------------------------------------------------------
 (spacemacs/set-leader-keys

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -207,6 +207,7 @@
   "feU"  'configuration-layer/update-packages
   "fCd" 'spacemacs/unix2dos
   "fCu" 'spacemacs/dos2unix
+  "fi" 'spacemacs/insert-file
   "fg" 'rgrep
   "fl" 'find-file-literally
   "fE" 'spacemacs/sudo-edit

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -72,7 +72,7 @@
 
 (defun spacemacs-defaults/init-dired ()
   (spacemacs/set-leader-keys
-    "ad" 'dired
+    "ad" 'spacemacs/dired
     "fj" 'dired-jump
     "jd" 'dired-jump
     "jD" 'dired-jump-other-window))


### PR DESCRIPTION
#### Work around ido-mode remapping Spacemacs keys

Add aliases for commands that ido-mode remaps that we want to bind to Spacemacs keys, and use these aliases in the Spacemacs key bindings so that these bindings invoke the original commands rather than the ido commands.

See <https://github.com/syl20bnr/spacemacs/issues/10237#issuecomment-359861570>.

#### Bind <kbd>SPC f i</kbd> to `spacemacs/insert-file`



