### PR TITLE
spacemacs/integrate-evil-search also dupdates evil-ex-search-direction

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -60,6 +60,7 @@ If the universal prefix argument is used then kill also the window."
                 evil-ex-search-pattern (evil-ex-make-search-pattern regexp)))
         ;; Next time "n" is hit, go the correct direction.
         (setq isearch-forward forward)
+        (setq evil-ex-search-direction (if forward 'forward 'backward))
         ;; ahs does a case sensitive search.  We could set
         ;; this, but it would break the user's current
         ;; sensitivity settings.  We could save the setting,


### PR DESCRIPTION
This PR is to have spacemacs/integrate-evil-search update evil-ex-search-direction to have consistency in behavior when using both spacemacs `*`,  `#` commands and evil `/` , `?` commands

Currently evil-ex-search-direction isn't updated when using `*` and `#` 
When spacemacs starts up evil-ex-search-direction is nil, do `*` or `#` on a buffer to have some occurrences. Now escape, hit `n` you will get to the next occurrence and it gets stuck there, hitting `n` won't move to the next one. You have to use `?` or `/` first to initialize evil-ex-search-direction, then it will be ok. Also because of this, search directions in spacemacs are evil are not the same when alternating these commands  