### PR TITLE
Don't hardcode fci-rule-color face

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -38,7 +38,6 @@
     :init
     (progn
       (setq fci-rule-width 1)
-      (setq fci-rule-color "#D0BF8F")
       ;; manually register the minor mode since it does not define any
       ;; lighter
       (push '(fci-mode "") minor-mode-alist)


### PR DESCRIPTION
Faces should be set in themes or by use of the theming layer.

This closes #8917.