### PR TITLE
add transpose sexps keybinding

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2783,6 +2783,7 @@ Text related commands (start with ~x~):
 | ~SPC x o~     | use avy to select a link in the frame and open it             |
 | ~SPC x O~     | use avy to select multiple links in the frame and open them   |
 | ~SPC x t c~   | swap (transpose) the current character with the previous one  |
+| ~SPC x t e~   | swap (transpose) the current sexp with the previous one       |
 | ~SPC x t l~   | swap (transpose) the current line with the previous one       |
 | ~SPC x t p~   | swap (transpose) the current paragraph with the previous one  |
 | ~SPC x t s~   | swap (transpose) the current sentence with the previous one   |

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -492,10 +492,10 @@
   "xlS" 'spacemacs/sort-lines-reverse
   "xlu" 'spacemacs/uniquify-lines
   "xtc" 'transpose-chars
+  "xte" 'transpose-sexps
   "xtl" 'transpose-lines
   "xtp" 'transpose-paragraphs
   "xts" 'transpose-sentences
-  "xte" 'transpose-sexps
   "xtw" 'transpose-words
   "xU"  'upcase-region
   "xu"  'downcase-region

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -495,6 +495,7 @@
   "xtl" 'transpose-lines
   "xtp" 'transpose-paragraphs
   "xts" 'transpose-sentences
+  "xte" 'transpose-sexps
   "xtw" 'transpose-words
   "xU"  'upcase-region
   "xu"  'downcase-region


### PR DESCRIPTION
the transpose keybindings do not contain a binding for `'transpose-sexps`, the original emacs keybinding `C-M-t` is still available, but on most linux desktops this will be bound to launch a terminal.