### PR TITLE
Avoid non-idempotent use of push in init code

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1428,7 +1428,7 @@ discovery."
                                  sub)))
                   (spacemacs-buffer/message "-> Discovered category: %S"
                                             category)
-                  (push category configuration-layer-categories)
+                  (add-to-list 'configuration-layer-categories category)
                   (setq search-paths (cons sub search-paths))))
                ((eq 'layer type)
                 (let* ((layer-name-str (file-name-nondirectory sub))

--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -95,10 +95,12 @@ used."
                                    ,condition)
                            t)))
     `(progn
-       (push (append '(,name)
-                     '(:function ,wrapper-func :predicate ,wrapper-func-status)
-                     ',props)
-             spacemacs-toggles)
+       (let ((properties (append '(:function ,wrapper-func :predicate ,wrapper-func-status)
+                                 ',props))
+             (cell (assq ',name spacemacs-toggles)))
+         (if cell
+             (setcdr cell properties)
+           (push (cons ',name properties) spacemacs-toggles)))
        ;; toggle function
        (defun ,wrapper-func ,(if prefix-arg-var (list prefix-arg-var) ())
          ,(format "Toggle %s on and off." (symbol-name name))

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -119,10 +119,10 @@ loaded before their code runs.
 When loaded using =require=, Emacs looks for files in its /load path/. This is
 nothing more than a list of paths where elisp files can be found, and you can
 inspect it through ~SPC h d v load-path~ in Spacemacs. To add to the load path,
-simply push to this list, e.g.
+simply add to this list, e.g.
 
 #+begin_src emacs-lisp
-(push "/some/path/" load-path)
+(add-to-list 'load-path "/some/path/")
 #+end_src
 
 ** Auto-loading

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -9,30 +9,28 @@
 ;;
 ;;; License: GPLv3
 
-(setq erc-packages
-      '(
-        company
-        company-emoji
-        emoji-cheat-sheet-plus
-        erc
-        (erc-gitter :location (recipe
-                               :fetcher github
-                               :repo "jleechpe/erc-gitter")
-                    :excluded t)
-        erc-hl-nicks
-        erc-image
-        (erc-sasl :location local)
-        erc-social-graph
-        (erc-tex :location local)
-        erc-view-log
-        (erc-yank :location local :excluded t)
-        erc-yt
-        linum
-        persp-mode
-        ))
-
-(when (spacemacs/system-is-mac)
-  (push 'erc-terminal-notifier erc-packages))
+(defconst erc-packages
+  '(
+    company
+    company-emoji
+    emoji-cheat-sheet-plus
+    erc
+    (erc-gitter :location (recipe
+                           :fetcher github
+                           :repo "jleechpe/erc-gitter")
+                :excluded t)
+    erc-hl-nicks
+    erc-image
+    (erc-sasl :location local)
+    erc-social-graph
+    (erc-terminal-notifier :toggle (spacemacs/system-is-mac))
+    (erc-tex :location local)
+    erc-view-log
+    (erc-yank :location local :excluded t)
+    erc-yt
+    linum
+    persp-mode
+    ))
 
 (defun erc/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes erc-mode))

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -67,7 +67,7 @@
   (evil-mode 1)
 
   ;; Use evil as a default jump handler
-  (push 'evil-goto-definition spacemacs-default-jump-handlers)
+  (add-to-list 'spacemacs-default-jump-handlers 'evil-goto-definition)
 
   (require 'cl)
   ;; State cursors
@@ -255,7 +255,7 @@
   (define-key evil-inner-text-objects-map "g" 'evil-inner-buffer)
 
   ;; turn off evil in corelv buffers
-  (push '("\\*LV\\*") evil-buffer-regexps)
+  (add-to-list 'evil-buffer-regexps '("\\*LV\\*"))
 
   ;; replace `dired-goto-file' with `helm-find-files', since `helm-find-files'
   ;; can do the same thing and with fuzzy matching and other features.
@@ -315,6 +315,9 @@
 
   ;; Needed to avoid nil variable error before update to recent which-key
   (defvar which-key-replacement-alist nil)
+  ;; Reset to the default or customized value before adding our values in order
+  ;; to make this initialization code idempotent.
+  (custom-reevaluate-setting 'which-key-replacement-alist)
   ;; Replace rules for better naming of functions
   (let ((new-descriptions
          ;; being higher in this list means the replacement is applied later

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -35,4 +35,4 @@
   "Modes that are associated with mu4e buffers.")
 
 (when mu4e-installation-path
-  (push mu4e-installation-path load-path))
+  (add-to-list 'load-path mu4e-installation-path))

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -62,7 +62,7 @@
            (progn (goto-char (match-beginning 1))
                   (not (spacemacs//react-inside-string-or-comment-q)))))
 
-    (push (cons #'+javascript-jsx-file-p 'rjsx-mode) magic-mode-alist)
+    (add-to-list 'magic-mode-alist (cons #'+javascript-jsx-file-p 'rjsx-mode))
 
     ;; setup rjsx backend
     (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-setup-backend)

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -178,7 +178,7 @@
     (progn
       ;; add support for golden-ratio
       (with-eval-after-load 'golden-ratio
-        (push 'cider-popup-buffer-quit-function golden-ratio-extra-commands))
+        (add-to-list 'golden-ratio-extra-commands 'cider-popup-buffer-quit-function))
       ;; add support for evil
       (evil-set-initial-state 'cider-stacktrace-mode 'motion)
       (evil-set-initial-state 'cider-popup-buffer-mode 'motion)

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -26,7 +26,7 @@
 (defun d/post-init-company ()
   ;; Need to convince company that this C-derived mode is a code mode.
   (with-eval-after-load 'company-dabbrev-code
-    (push 'd-mode company-dabbrev-code-modes)))
+    (add-to-list 'company-dabbrev-code-modes 'd-mode)))
 
 (defun d/init-company-dcd ()
   (use-package company-dcd

--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -105,3 +105,11 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
     (save-excursion
       (sp-forward-symbol)
       (call-interactively 'eval-last-sexp))))
+
+
+;; elisp comment text-object definition
+
+(defun spacemacs//define-elisp-comment-text-object ()
+  "Define a text object and a surround pair for elisp comments.
+Intended for use in mode hooks."
+  (spacemacs|define-text-object ";" "elisp-comment" ";; " ""))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -228,9 +228,7 @@
             "th" 'overseer-help)))
 
 (defun emacs-lisp/post-init-evil ()
-  (add-hook 'emacs-lisp-mode-hook
-            (lambda ()
-              (spacemacs|define-text-object ";" "elisp-comment" ";; " ""))))
+  (add-hook 'emacs-lisp-mode-hook #'spacemacs//define-elisp-comment-text-object))
 
 (defun emacs-lisp/pre-init-evil-cleverparens ()
   (spacemacs|use-package-add-hook evil-cleverparens

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -51,7 +51,7 @@
     :pre-config
     (dolist (var '("GOPATH" "GOROOT" "GO15VENDOREXPERIMENT") exec-path-from-shell-variables)
       (unless (or (member var exec-path-from-shell-variables) (getenv var))
-        (push var exec-path-from-shell-variables)))))
+        (add-to-list 'exec-path-from-shell-variables var)))))
 
 (defun go/init-go-mode()
   (use-package go-mode

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -52,7 +52,7 @@
   (spacemacs|add-company-backends
     :backends (dante-company company-dabbrev-code company-yasnippet)
     :modes haskell-mode)
-  (push 'xref-find-definitions spacemacs-jump-handlers)
+  (add-to-list 'spacemacs-jump-handlers 'xref-find-definitions)
   (dante-mode)
   (dolist (mode haskell-modes)
     (spacemacs/set-leader-keys-for-major-mode mode
@@ -68,7 +68,7 @@
   (spacemacs|add-company-backends
     :backends (company-intero company-dabbrev-code company-yasnippet)
     :modes haskell-mode)
-  (push 'intero-goto-definition spacemacs-jump-handlers)
+  (add-to-list 'spacemacs-jump-handlers 'intero-goto-definition)
   (intero-mode)
   (dolist (mode haskell-modes)
     (spacemacs/set-leader-keys-for-major-mode mode

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -104,8 +104,8 @@ If you want to use the Ensime backend, you should modify your =~/.spacemacs= to
 use the recommended Ensime version (Stable). Please add the following lines to
 =dotspacemacs/user-init=:
 #+BEGIN_SRC emacs-lisp
-  (push '("melpa-stable" . "stable.melpa.org/packages/") configuration-layer-elpa-archives)
-  (push '(ensime . "melpa-stable") package-pinned-packages)
+  (add-to-list 'configuration-layer-elpa-archives '("melpa-stable" . "stable.melpa.org/packages/"))
+  (add-to-list 'package-pinned-packages '(ensime . "melpa-stable"))
 #+END_SRC
 
 * Backends

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -296,7 +296,7 @@
 ;;       (progn
 ;;         (spacemacs//ensime-init 'java-mode t nil)
 ;;         (when (configuration-layer/package-used-p 'company)
-;;           (push 'ensime-company company-backends-java-mode)))
+;;           (add-to-list 'company-backends-java-mode 'ensime-company)))
 ;;       :config
 ;;       (progn
 ;;         (spacemacs/ensime-configure-keybindings 'java-mode)))))

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -22,7 +22,7 @@
     :init
     (progn
       (add-hook 'nim-mode-hook 'nimsuggest-mode)
-      (push 'nimsuggest-find-definition spacemacs-jump-handlers-nim-mode))
+      (add-to-list 'spacemacs-jump-handlers-nim-mode 'nimsuggest-find-definition))
     :config
     (progn
       (defun spacemacs/nim-compile-run ()

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -70,7 +70,7 @@
     :defer t
     :init
     (progn
-      (push 'ac-php-find-symbol-at-point spacemacs-jump-handlers-php-mode)
+      (add-to-list 'spacemacs-jump-handlers-php-mode 'ac-php-find-symbol-at-point)
       (add-hook 'php-mode-hook 'ac-php-core-eldoc-setup)
       (spacemacs|add-company-backends
         :modes php-mode

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -57,7 +57,7 @@
       :modes ruby-mode enh-ruby-mode))
   (with-eval-after-load 'company-dabbrev-code
     (dolist (mode '(ruby-mode enh-ruby-mode))
-      (push mode company-dabbrev-code-modes))))
+      (add-to-list 'company-dabbrev-code-modes mode))))
 
 (defun ruby/init-chruby ()
   (use-package chruby

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -96,7 +96,7 @@
     :pre-config
     (let ((var "RUST_SRC_PATH"))
       (unless (or (member var exec-path-from-shell-variables) (getenv var))
-        (push var exec-path-from-shell-variables)))))
+        (add-to-list 'exec-path-from-shell-variables var)))))
 
 (defun rust/init-racer ()
   (use-package racer

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -39,8 +39,8 @@ file.
 Then, you should modify your =~/.spacemacs= to use the recommended Ensime
 version (Stable). Please add the following lines to =dotspacemacs/user-init=:
 #+BEGIN_SRC emacs-lisp
-  (push '("melpa-stable" . "stable.melpa.org/packages/") configuration-layer-elpa-archives)
-  (push '(ensime . "melpa-stable") package-pinned-packages)
+  (add-to-list 'configuration-layer-elpa-archives '("melpa-stable" . "stable.melpa.org/packages/"))
+  (add-to-list 'package-pinned-packages '(ensime . "melpa-stable"))
 #+END_SRC
 
 * Ensime

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -30,7 +30,7 @@
     :init
     (setq desktop-dirname spacemacs-cache-directory)
     :config
-    (push spacemacs-cache-directory desktop-path)))
+    (add-to-list 'desktop-path spacemacs-cache-directory)))
 
 (defun spacemacs-visual/init-fill-column-indicator ()
   (use-package fill-column-indicator
@@ -41,7 +41,7 @@
       (setq fci-rule-color "#D0BF8F")
       ;; manually register the minor mode since it does not define any
       ;; lighter
-      (push '(fci-mode "") minor-mode-alist)
+      (add-to-list 'minor-mode-alist '(fci-mode ""))
       (spacemacs|add-toggle fill-column-indicator
         :status fci-mode
         :on (turn-on-fci-mode)

--- a/layers/+tools/dash/packages.el
+++ b/layers/+tools/dash/packages.el
@@ -38,4 +38,4 @@
             "dD" 'zeal-at-point-set-docset)
     :config
     ;; This lets users seach in multiple docsets
-    (push '(web-mode . "html,css,javascript") zeal-at-point-mode-alist)))
+    (add-to-list 'zeal-at-point-mode-alist '(web-mode . "html,css,javascript"))))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -117,12 +117,12 @@
 
       ;; Visual commands
       (require 'em-term)
-      (mapc (lambda (x) (push x eshell-visual-commands))
+      (mapc (lambda (x) (add-to-list 'eshell-visual-commands x))
             '("el" "elinks" "htop" "less" "ssh" "tmux" "top"))
 
       ;; automatically truncate buffer after output
       (when (boundp 'eshell-output-filter-functions)
-        (push 'eshell-truncate-buffer eshell-output-filter-functions)))))
+        (add-hook 'eshell-output-filter-functions #'eshell-truncate-buffer)))))
 
 (defun shell/init-eshell-prompt-extras ()
   (use-package eshell-prompt-extras


### PR DESCRIPTION
I noticed that saving `.spacemacs` or using `SPC f e R` to reload configuration caused duplicate values to be added to many list variables.  For example, when I start a new Spacemacs session with my configuration file, `(length configuration-layer-categories)` evaluates to 22.  If I reload configuration using `SPC f e R` a few times and check the value of `configuration-layer-categories` again, I can see that repeats of all 22 entries are added on every reload.  Another example is `which-key-replacement-alist`, which adds hundreds of entries on each reload.  In addition, various mode hooks, load-path entries, and more get duplicated.

This PR aims to make Spacemacs's initialization code more idempotent in order to avoid adding duplicate values to list variables.

---

Replace `push` with `add-to-list` in layer init functions and related code.

Modify `spacemacs|add-toggle` to check for and update an existing toggle in `spacemacs-toggles` and only create a new toggle if none already existed.

Replace a conditional `push` onto `erc-packages` with use of `:toggle`.

When initializing which-key, set `which-key-replacement-alist` to its default or customized setting before adding all the Spacemacs replacements.  We want to keep the stock replacements but avoid adding duplicates of the Spacemacs replacements.

Replace the `emacs-lisp-mode-hook` lambda with a named function to avoid adding duplicate hooks (which can add duplicate definitions of the evil-surround pair).

---

Question: Would it be better to use `cl-pushnew` in some cases? It seems like it would be preferable except that it would make `cl-lib` a compile-time requirement (`cl-pushnew` is a macro in the `cl-lib` package).