### PR TITLE
Checks if tern layer is enabled and tern executable exists before using it

### DIFF
--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -15,13 +15,13 @@
 (defun spacemacs//javascript-setup-backend ()
   "Conditionally setup javascript backend."
   (pcase javascript-backend
-    (`tern (spacemacs/tern-setup-tern))
+    (`tern (spacemacs//javascript-setup-tern))
     (`lsp (spacemacs//javascript-setup-lsp))))
 
 (defun spacemacs//javascript-setup-company ()
   "Conditionally setup company based on backend."
   (pcase javascript-backend
-    (`tern (spacemacs/tern-setup-tern-company 'js2-mode))
+    (`tern (spacemacs//javascript-setup-tern-company))
     (`lsp (spacemacs//javascript-setup-lsp-company))))
 
 
@@ -50,6 +50,23 @@
         (company-mode))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
+
+
+;; tern
+(defun spacemacs//javascript-setup-tern ()
+  (if (configuration-layer/layer-used-p 'tern)
+      (when (locate-file "tern" exec-path)
+        (spacemacs/tern-setup-tern))
+    (message (concat "Tern was configured as the javascript backend but "
+                     "the `tern' layer is not present in your `.spacemacs'!"))))
+
+(defun spacemacs//javascript-setup-tern-company ()
+  (if (configuration-layer/layer-used-p 'tern)
+      (when (locate-file "tern" exec-path)
+        (spacemacs/tern-setup-tern-company 'js2-mode))
+    (message (concat "Tern was configured as the javascript backend but "
+                     "the `tern' layer is not present in your `.spacemacs'!"))))
+
 
 
 ;; js-doc


### PR DESCRIPTION
This fixes errors that appear when navigating between javascript files when using the default javascript layer setup without having the `tern` layer nor the `tern` executable installed.

While the problem is fixed I don't feel 100% satisfied with this solution since these functions are executed every time a javascript file is opened and `(locate-file "tern" exec-path)` will be called every time... but if you have the `tern` layer enabled without the tern executable installed then you probably deserve the extra warnings.

@syl20bnr @ztlevi Please take a look and advise me if you know a better way!