### PR TITLE
markdown: fix M-h, M-j, M-k, M-l bindings.

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -188,12 +188,12 @@ To generate a table of contents type on top of the buffer:
 
 ** Promotion, Demotion
 
-| Key Binding | Description        |
-|-------------+--------------------|
-| ~M-k~       | markdown-move-up   |
-| ~M-j~       | markdown-move-down |
-| ~M-h~       | markdown-promote   |
-| ~M-l~       | markdown-demote    |
+| Evil  | Holy        | Command            |
+|-------+-------------+--------------------|
+| ~M-k~ | ~C-c C-x u~ | markdown-move-up   |
+| ~M-j~ | ~C-c C-x d~ | markdown-move-down |
+| ~M-h~ | ~C-c C-x l~ | markdown-promote   |
+| ~M-l~ | ~C-c C-x r~ | markdown-demote    |
 
 ** Toggles
 

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -143,10 +143,13 @@
         ;; next visible heading is not exactly what we want but close enough
         "gl" 'outline-next-visible-heading)
       ;; Promotion, Demotion
-      (define-key markdown-mode-map (kbd "M-h") 'markdown-promote)
-      (define-key markdown-mode-map (kbd "M-j") 'markdown-move-down)
-      (define-key markdown-mode-map (kbd "M-k") 'markdown-move-up)
-      (define-key markdown-mode-map (kbd "M-l") 'markdown-demote))))
+      (mapc (lambda (state)
+              (evil-define-key state markdown-mode-map
+                (kbd "M-h") 'markdown-promote
+                (kbd "M-j") 'markdown-move-down
+                (kbd "M-k") 'markdown-move-up
+                (kbd "M-l") 'markdown-demote))
+            '(normal insert)))))
 
 (defun markdown/init-markdown-toc ()
   (use-package markdown-toc


### PR DESCRIPTION
These key bindings are very useful in emacs-editing mode and should not be
overwrited.

This fixes #10640.
