### PR TITLE
Multiple ways to copy file path

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1227,6 +1227,7 @@ and ~T~):
 | ~SPC t L~   | toggle visual lines                                               |
 | ~SPC t n~   | toggle line numbers                                               |
 | ~SPC t v~   | toggle smooth scrolling                                           |
+| ~SPC t z~   | toggle 0/1 based column indexing                                  |
 
 | Key Binding | Description                                                      |
 |-------------+------------------------------------------------------------------|
@@ -2366,7 +2367,10 @@ Files manipulation commands (start with ~f~):
 | ~SPC f v d~ | add a directory variable                                                                               |
 | ~SPC f v f~ | add a local variable to the current file                                                               |
 | ~SPC f v p~ | add a local variable to the first line of the current file                                             |
-| ~SPC f y~   | show and copy current file absolute path in the minibuffer                                             |
+| ~SPC f y c~ | show and copy current file absolute path with line and column number in the minibuffer                 |
+| ~SPC f y d~ | show and copy current directory absolute path in the minibuffer                                        |
+| ~SPC f y l~ | show and copy current file absolute path with line number in the minibuffer                            |
+| ~SPC f y y~ | show and copy current file absolute path in the minibuffer                                             |
 
 **** Frame manipulation key bindings
 Frame manipulation commands (start with ~F~):
@@ -3255,39 +3259,43 @@ To search in a project see [[#searching-in-a-project][project searching]].
 
 =projectile= commands start with p:
 
-| Key Binding | Description                                             |
-|-------------+---------------------------------------------------------|
-| ~SPC p '​~   | open a shell in project's root (with the =shell= layer) |
-| ~SPC p !~   | run shell command in project's root                     |
-| ~SPC p &~   | run async shell command in project's root               |
-| ~SPC p %~   | replace a regexp                                        |
-| ~SPC p a~   | toggle between implementation and test                  |
-| ~SPC p b~   | switch to project buffer                                |
-| ~SPC p c~   | compile project using =projectile=                      |
-| ~SPC p d~   | find directory                                          |
-| ~SPC p D~   | open project root in =dired=                            |
-| ~SPC p e~   | edit dir-locals.el                                      |
-| ~SPC p f~   | find file                                               |
-| ~SPC p F~   | find file based on path around point                    |
-| ~SPC p g~   | find tags                                               |
-| ~SPC p G~   | regenerate the project's =etags= / =gtags=              |
-| ~SPC p h~   | find file                                               |
-| ~SPC p I~   | invalidate the projectile cache                         |
-| ~SPC p k~   | kill all project buffers                                |
-| ~SPC p o~   | run =multi-occur=                                       |
-| ~SPC p p~   | switch project                                          |
-| ~SPC p r~   | open a recent file                                      |
-| ~SPC p R~   | replace a string                                        |
-| ~SPC p t~   | open =NeoTree= in =projectile= root                     |
-| ~SPC p T~   | test project                                            |
-| ~SPC p v~   | open project root in =vc-dir= or =magit=                |
-| ~SPC /~     | search in project with the best search tool available   |
-| ~SPC s p~   | see [[#searching-in-a-project][searching in a project]]                              |
-| ~SPC s a p~ | run =ag=                                                |
-| ~SPC s g p~ | run =grep=                                              |
-| ~SPC s k p~ | run =ack=                                               |
-| ~SPC s t p~ | run =pt=                                                |
-| ~SPC s r p~ | run =rg=                                                |
+| Key Binding | Description                                                                              |
+|-------------+------------------------------------------------------------------------------------------|
+| ~SPC p '​~   | open a shell in project's root (with the =shell= layer)                                  |
+| ~SPC p !~   | run shell command in project's root                                                      |
+| ~SPC p &~   | run async shell command in project's root                                                |
+| ~SPC p %~   | replace a regexp                                                                         |
+| ~SPC p a~   | toggle between implementation and test                                                   |
+| ~SPC p b~   | switch to project buffer                                                                 |
+| ~SPC p c~   | compile project using =projectile=                                                       |
+| ~SPC p d~   | find directory                                                                           |
+| ~SPC p D~   | open project root in =dired=                                                             |
+| ~SPC p e~   | edit dir-locals.el                                                                       |
+| ~SPC p f~   | find file                                                                                |
+| ~SPC p F~   | find file based on path around point                                                     |
+| ~SPC p g~   | find tags                                                                                |
+| ~SPC p G~   | regenerate the project's =etags= / =gtags=                                               |
+| ~SPC p h~   | find file                                                                                |
+| ~SPC p I~   | invalidate the projectile cache                                                          |
+| ~SPC p k~   | kill all project buffers                                                                 |
+| ~SPC p o~   | run =multi-occur=                                                                        |
+| ~SPC p p~   | switch project                                                                           |
+| ~SPC p r~   | open a recent file                                                                       |
+| ~SPC p R~   | replace a string                                                                         |
+| ~SPC p t~   | open =NeoTree= in =projectile= root                                                      |
+| ~SPC p T~   | test project                                                                             |
+| ~SPC p v~   | open project root in =vc-dir= or =magit=                                                 |
+| ~SPC /~     | search in project with the best search tool available                                    |
+| ~SPC s p~   | see [[#searching-in-a-project][searching in a project]]                                                               |
+| ~SPC s a p~ | run =ag=                                                                                 |
+| ~SPC s g p~ | run =grep=                                                                               |
+| ~SPC s k p~ | run =ack=                                                                                |
+| ~SPC s t p~ | run =pt=                                                                                 |
+| ~SPC s r p~ | run =rg=                                                                                 |
+| ~SPC f y C~ | show and copy current file path relaitve to the project root with line and column number |
+| ~SPC f y D~ | show and copy current directory path relaitve to the project root                        |
+| ~SPC f y L~ | show and copy current file path relaitve to the project root with line number            |
+| ~SPC f y Y~ | show and copy current file path relaitve to the project root                             |
 
 *Note for Windows Users*: To enable fast indexing the GNU ~find~ or
 Cygwin ~find~ must be in your ~PATH~.

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -479,15 +479,96 @@ If the universal prefix argument is used then will the windows too."
             (if dedicated "no longer " "")
             (buffer-name))))
 
-;; http://camdez.com/blog/2013/11/14/emacs-show-buffer-file-name/
-(defun spacemacs/show-and-copy-buffer-filename ()
-  "Show and copy the full path to the current file in the minibuffer."
+
+;; Copy file path
+
+(defun spacemacs--directory-path ()
+  "Retrieve the directory path of the current buffer.
+
+If the buffer is not visiting a file, use the `list-buffers-directory'
+variable as a fallback to display the directory, useful in buffers like the
+ones created by `magit' and `dired'.
+
+Returns:
+  - A string containing the directory path in case of success.
+  - `nil' in case the current buffer does not have a directory."
+  (when-let (directory-name (if-let (file-name (buffer-file-name))
+                                (file-name-directory file-name)
+                              list-buffers-directory))
+    (file-truename directory-name)))
+
+(defun spacemacs--file-path ()
+  "Retrieve the file path of the current buffer.
+
+Returns:
+  - A string containing the file path in case of success.
+  - `nil' in case the current buffer does not have a directory."
+  (when-let (file-path (buffer-file-name))
+    (file-truename file-path)))
+
+(defun spacemacs--file-path-with-line ()
+  "Retrieve the file path of the current buffer, including line number.
+
+Returns:
+  - A string containing the file path in case of success.
+  - `nil' in case the current buffer does not have a directory."
+  (when-let (file-path (spacemacs--file-path))
+    (concat file-path ":" (number-to-string (line-number-at-pos)))))
+
+(defun spacemacs--file-path-with-line-column ()
+  "Retrieve the file path of the current buffer, including line and column number.
+
+Returns:
+  - A string containing the file path in case of success.
+  - `nil' in case the current buffer does not have a directory."
+  (when-let (file-path (spacemacs--file-path-with-line))
+    (concat
+      file-path
+      ":"
+      (number-to-string (if (and
+                              ;; Emacs 26 introduced this variable.
+                              ;; Remove this check once 26 becomes the minimum version.
+                              (boundp column-number-indicator-zero-based)
+                              (not column-number-indicator-zero-based))
+                            (1+ (current-column))
+                          (current-column))))))
+
+(defun spacemacs/copy-directory-path ()
+  "Copy and show the directory path of the current buffer.
+
+If the buffer is not visiting a file, use the `list-buffers-directory'
+variable as a fallback to display the directory, useful in buffers like the
+ones created by `magit' and `dired'."
   (interactive)
-  ;; list-buffers-directory is the variable set in dired buffers
-  (let ((file-name (or (buffer-file-name) list-buffers-directory)))
-    (if file-name
-        (message (kill-new file-name))
-      (error "Buffer not visiting a file"))))
+  (if-let (directory-path (spacemacs--directory-path))
+      (message "%s" (kill-new directory-path))
+    (message "WARNING: Current buffer does not have a directory!")))
+
+(defun spacemacs/copy-file-path ()
+  "Copy and show the file path of the current buffer."
+  (interactive)
+  (if-let (file-path (spacemacs--file-path))
+      (message "%s" (kill-new file-path))
+    (message "WARNING: Current buffer is not attached to a file!")))
+
+(defun spacemacs/copy-file-path-with-line ()
+  "Copy and show the file path of the current buffer, including line number."
+  (interactive)
+  (if-let (file-path (spacemacs--file-path-with-line))
+      (message "%s" (kill-new file-path))
+    (message "WARNING: Current buffer is not attached to a file!")))
+
+(defun spacemacs/copy-file-path-with-line-column ()
+  "Copy and show the file path of the current buffer, including line and column number.
+
+This function respects the value of the `column-number-indicator-zero-based'
+variable."
+  (interactive)
+  (if-let (file-path (spacemacs--file-path-with-line-column))
+      (message "%s" (kill-new file-path))
+    (message "WARNING: Current buffer is not attached to a file!")))
+
+
 
 ;; adapted from bozhidar
 ;; http://emacsredux.com/blog/2013/05/18/instant-access-to-init-dot-el/

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -28,6 +28,7 @@
                                        ("fC"  "files/convert")
                                        ("fe"  "emacs(spacemacs)")
                                        ("fv"  "variables")
+                                       ("fy"  "yank path")
                                        ("F"   "frame")
                                        ("g"   "git/versions-control")
                                        ("h"   "help")
@@ -221,7 +222,10 @@
   "fvd" 'add-dir-local-variable
   "fvf" 'add-file-local-variable
   "fvp" 'add-file-local-variable-prop-line
-  "fy" 'spacemacs/show-and-copy-buffer-filename)
+  "fyc" 'spacemacs/copy-file-path-with-line-column
+  "fyd" 'spacemacs/copy-directory-path
+  "fyl" 'spacemacs/copy-file-path-with-line
+  "fyy" 'spacemacs/copy-file-path)
 ;; frame ----------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "Ff" 'find-file-other-frame
@@ -362,6 +366,12 @@
   :mode font-lock-mode
   :documentation "Toggle syntax highlighting."
   :evil-leader "ths")
+(spacemacs|add-toggle column-indexing
+  :documentation "Toggle column indexing starting at 1."
+  :on (setq column-number-indicator-zero-based nil)
+  :off (setq column-number-indicator-zero-based t)
+  :evil-leader "tz")
+
 (spacemacs|add-toggle transparent-frame
   :status nil
   :on (spacemacs/toggle-transparency)

--- a/layers/+spacemacs/spacemacs-project/funcs.el
+++ b/layers/+spacemacs/spacemacs-project/funcs.el
@@ -1,0 +1,102 @@
+;;; funcs.el --- Spacemacs Project Management Layer packages File
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Codruț Constantin Gușoi <codrut.gusoi@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs--projectile-directory-path ()
+  "Retrieve the directory path relative to project root.
+
+If the buffer is not visiting a file, use the `list-buffers-directory'
+variable as a fallback to display the directory, useful in buffers like the
+ones created by `magit' and `dired'.
+
+Returns:
+  - A string containing the directory path in case of success.
+  - `nil' in case the current buffer does not have a directory."
+  (when-let (directory-name (if-let (file-name (buffer-file-name))
+                                (file-name-directory file-name)
+                              list-buffers-directory))
+    (file-relative-name
+      (file-truename directory-name)
+      (projectile-project-root))))
+
+(defun spacemacs--projectile-file-path ()
+  "Retrieve the file path relative to project root.
+
+Returns:
+  - A string containing the file path in case of success.
+  - `nil' in case the current buffer does not visit a file."
+  (when-let (file-name (buffer-file-name))
+    (file-relative-name (file-truename file-name) (projectile-project-root))))
+
+(defun spacemacs--projectile-file-path-with-line ()
+  "Retrieve the file path relative to project root, including line number.
+
+Returns:
+  - A string containing the file path in case of success.
+  - `nil' in case the current buffer does not visit a file."
+  (when-let (file-path (spacemacs--projectile-file-path))
+    (concat file-path ":" (number-to-string (line-number-at-pos)))))
+
+(defun spacemacs--projectile-file-path-with-line-column ()
+  "Retrieve the file path relative to project root, including line and column number.
+
+This function respects the value of the `column-number-indicator-zero-based'
+variable.
+
+Returns:
+  - A string containing the file path in case of success.
+  - `nil' in case the current buffer does not visit a file."
+  (when-let (file-path (spacemacs--projectile-file-path-with-line))
+    (concat
+      file-path
+      ":"
+      (number-to-string (if (and
+                              ;; Emacs 26 introduced this variable.
+                              ;; Remove this check once 26 becomes the minimum version.
+                              (boundp column-number-indicator-zero-based)
+                              (not column-number-indicator-zero-based))
+                            (1+ (current-column))
+                          (current-column))))))
+
+
+(defun spacemacs/projectile-copy-directory-path ()
+  "Copy and show the directory path relative to project root.
+
+If the buffer is not visiting a file, use the `list-buffers-directory'
+variable as a fallback to display the directory, useful in buffers like the
+ones created by `magit' and `dired'."
+  (interactive)
+  (if-let (directory-path (spacemacs--projectile-directory-path))
+      (message "%s" (kill-new directory-path))
+    (message "WARNING: Current buffer does not have a directory!")))
+
+(defun spacemacs/projectile-copy-file-path ()
+  "Copy and show the file path relative to project root."
+  (interactive)
+  (if-let (file-path (spacemacs--projectile-file-path))
+      (message "%s" (kill-new file-path))
+    (message "WARNING: Current buffer is not visiting a file!")))
+
+(defun spacemacs/projectile-copy-file-path-with-line ()
+  "Copy and show the file path relative to project root, including line number."
+  (interactive)
+  (if-let (file-path (spacemacs--projectile-file-path-with-line))
+      (message "%s" (kill-new file-path))
+    (message "WARNING: Current buffer is not visiting a file!")))
+
+(defun spacemacs/projectile-copy-file-path-with-line-column ()
+  "Copy and show the file path relative to project root, including line and column number.
+
+This function respects the value of the `column-number-indicator-zero-based'
+variable."
+  (interactive)
+  (if-let (file-path (spacemacs--projectile-file-path-with-line-column))
+      (message "%s" (kill-new file-path))
+    (message "WARNING: Current buffer is not visiting a file!")))

--- a/layers/+spacemacs/spacemacs-project/packages.el
+++ b/layers/+spacemacs/spacemacs-project/packages.el
@@ -54,6 +54,12 @@
             projectile-known-projects-file (concat spacemacs-cache-directory
                                                    "projectile-bookmarks.eld"))
       (spacemacs/set-leader-keys
+        ;; File path
+        "fyC" 'spacemacs/projectile-copy-file-path-with-line-column
+        "fyD" 'spacemacs/projectile-copy-directory-path
+        "fyL" 'spacemacs/projectile-copy-file-path-with-line
+        "fyY" 'spacemacs/projectile-copy-file-path
+        ;; Project
         "p!" 'projectile-run-shell-command-in-root
         "p&" 'projectile-run-async-shell-command-in-root
         "p%" 'projectile-replace-regexp


### PR DESCRIPTION
Adds a new prefix `SPC f y` which replaces the current `spacemacs/show-and-copy-buffer-filename` keybinding.

The new keybindings will allow you to copy an absolute / relative file path, with added line and column numbers.

I still have some work and documentation to do, so it's a WIP at the moment. Also it would be nice if the spaceline PR was merged first so that toggling column indexing would show up correctly: https://github.com/TheBB/spaceline/pull/194.

/cc @agzam since we discusses a bit about these at work :wink:.