### PR TITLE
Only use lsp-javascript-typescript

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -29,23 +29,21 @@
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (lsp-javascript-typescript-enable)
-        (lsp-javascript-flow-enable)
-        (spacemacs//setup-lsp-jump-handler 'rjsx-mode))
+        (lsp-javascript-typescript-enable))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 (defun spacemacs//react-setup-lsp-company ()
   "Setup lsp auto-completion."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (fix-lsp-company-prefix)
         (spacemacs|add-company-backends
           :backends company-lsp
           :modes rjsx-mode
           :variables company-minimum-prefix-length 2
           :append-hooks nil
           :call-hooks t)
-        (company-mode))
+        (company-mode)
+        (fix-lsp-company-prefix))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -17,6 +17,7 @@
     evil-matchit
     flycheck
     js-doc
+    lsp-javascript-typescript
     rjsx-mode
     smartparens
     tern
@@ -49,6 +50,9 @@
 (defun react/post-init-js-doc ()
   (add-hook 'rjsx-mode-hook 'spacemacs/js-doc-require)
   (spacemacs/js-doc-set-key-bindings 'rjsx-mode))
+
+(defun react/post-init-lsp-javascript-typescript ()
+  (spacemacs//setup-lsp-jump-handler 'rjsx-mode))
 
 (defun react/init-rjsx-mode ()
   (use-package rjsx-mode

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -84,7 +84,7 @@ See [[file:../../+tools/tern/README.org][tern layer]] documentation.
 You just have to install javascript and typescript language server packages:
 
 #+begin_src sh
-npm i -g typescript javascript-typescript-langserver flow-language-server
+npm i -g typescript javascript-typescript-langserver
 #+end_src
 
 * Configuration

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -15,8 +15,8 @@
 (defun spacemacs//javascript-setup-backend ()
   "Conditionally setup javascript backend."
   (pcase javascript-backend
-    (`tern (spacemacs//javascript-setup-tern))
-    (`lsp (spacemacs//javascript-setup-lsp))))
+    (`tern (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-tern))
+    (`lsp (add-hook 'js-mode-hook #'spacemacs//javascript-setup-lsp))))
 
 (defun spacemacs//javascript-setup-company ()
   "Conditionally setup company based on backend."
@@ -31,9 +31,7 @@
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (spacemacs//setup-lsp-jump-handler 'js2-mode)
-        (lsp-javascript-typescript-enable)
-        (lsp-javascript-flow-enable))
+        (lsp-javascript-typescript-enable))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
 
@@ -41,13 +39,13 @@
   "Setup lsp auto-completion."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (fix-lsp-company-prefix)
         (spacemacs|add-company-backends
           :backends company-lsp
           :modes js2-mode
           :append-hooks nil
           :call-hooks t)
-        (company-mode))
+        (company-mode)
+        (fix-lsp-company-prefix))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
 

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -15,8 +15,8 @@
 (defun spacemacs//javascript-setup-backend ()
   "Conditionally setup javascript backend."
   (pcase javascript-backend
-    (`tern (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-tern))
-    (`lsp (add-hook 'js-mode-hook #'spacemacs//javascript-setup-lsp))))
+    (`tern (spacemacs//javascript-setup-tern))
+    (`lsp (spacemacs//javascript-setup-lsp))))
 
 (defun spacemacs//javascript-setup-company ()
   "Conditionally setup company based on backend."

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -24,10 +24,7 @@
         js2-mode
         js2-refactor
         livid-mode
-        (lsp-javascript-typescript
-         :requires lsp-mode
-         :location (recipe :fetcher github
-                           :repo "emacs-lsp/lsp-javascript"))
+        (lsp-javascript-typescript :requires lsp-mode)
         org
         skewer-mode
         tern
@@ -78,8 +75,7 @@
     :mode "\\.m?js\\'"
     :init
     (progn
-      (add-hook 'js2-mode-local-vars-hook
-                #'spacemacs//javascript-setup-backend)
+      (spacemacs//javascript-setup-backend)
       ;; safe values for backend to be used in directory file variables
       (dolist (value '(lsp tern))
         (add-to-list 'safe-local-variable-values
@@ -171,8 +167,7 @@
   (use-package lsp-javascript-typescript
     :commands lsp-javascript-typescript-enable
     :defer t
-    :init (add-hook 'js2-mode-hook 'lsp-mode)
-    :config (require 'lsp-javascript-flow)))
+    :config (spacemacs//setup-lsp-jump-handler 'js2-mode)))
 
 (defun javascript/init-skewer-mode ()
   (use-package skewer-mode

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -75,7 +75,7 @@
     :mode "\\.m?js\\'"
     :init
     (progn
-      (spacemacs//javascript-setup-backend)
+      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
       ;; safe values for backend to be used in directory file variables
       (dolist (value '(lsp tern))
         (add-to-list 'safe-local-variable-values

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -66,8 +66,6 @@
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (spacemacs//setup-lsp-jump-handler 'typescript-mode
-                                    'typescript-tsx-mode)
         (lsp-javascript-typescript-enable))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
@@ -76,14 +74,14 @@
   "Setup lsp auto-completion."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (fix-lsp-company-prefix)
         (spacemacs|add-company-backends
           :backends company-lsp
           :modes typescript-mode typescript-tsx-mode
           :variables company-minimum-prefix-length 2
           :append-hooks nil
           :call-hooks t)
-        (company-mode))
+        (company-mode)
+        (fix-lsp-company-prefix))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
 

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -15,7 +15,7 @@
         company
         eldoc
         flycheck
-        lsp-mode
+        lsp-javascript-typescript
         smartparens
         tide
         typescript-mode
@@ -45,8 +45,9 @@
       (flycheck-add-mode 'typescript-tide 'typescript-tsx-mode)
       (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))))
 
-(defun typescript/post-init-lsp-mode ()
-  (add-hook 'typescript-mode-hook 'lsp-mode))
+(defun typescript/post-init-lsp-javascript-typescript ()
+  (spacemacs//setup-lsp-jump-handler 'typescript-mode
+                                     'typescript-tsx-mode))
 
 (defun typescript/post-init-smartparens ()
   (if dotspacemacs-smartparens-strict-mode

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -35,7 +35,7 @@
   "Set jump handler for LSP with the given MODE."
   (dolist (m modes)
     (add-to-list (intern (format "spacemacs-jump-handlers-%S" m))
-                 '(lsp-ui-peek-find-definitions))))
+                 #'lsp-ui-peek-find-definitions)))
 
 (defun fix-lsp-company-prefix ()
   "fix lsp-javascript company prefix


### PR DESCRIPTION
Mentioned [here](https://github.com/syl20bnr/spacemacs/issues/10670#issuecomment-388653121), the import completion is not properly enabled and it needs to enable lsp backend for `js-mode`. Not sure why is that but I tested and it should be enabled for that. You can take look at the following screenshot about the discussion. So as the `lsp-typescript`, we have to install the npm package and enable it for the related modes.

![image](https://user-images.githubusercontent.com/16655096/40881311-fed96c02-6677-11e8-983e-76a6ac96f6da.png)

Also, I created a method called `spacemacs//lsp-js-setup-backend` and try to hook it with `js-mode`. 
```
(defun spacemacs//lsp-js-setup-backend ()
  "Setup lsp backend for js-mode"
  (if (configuration-layer/layer-used-p 'lsp)
      (progn
        (lsp-javascript-typescript-enable)
        (lsp-javascript-flow-enable)
        (lsp-typescript-enable))
    (message (concat "`lsp' layer is not installed, "
                     "please add `lsp' layer to your dotfile."))))
```
But it doesn't have the proper completion if I did so. But it works if I hook the methods like this 
```
(add-hook 'js-mode-hook #'lsp-javascript-typescript-enable)
(add-hook 'js-mode-hook #'lsp-javascript-flow-enable)
(add-hook 'js-mode-hook #'lsp-typescript-enable)
```
I am really confuesd with this behavior. Do you guys have any idea on this one? @fiveNinePlusR @sdwolfz
