### PR TITLE
Add import-js to javascript layer

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -16,6 +16,7 @@
     emmet-mode
     evil-matchit
     flycheck
+    import-js
     js-doc
     prettier-js
     rjsx-mode
@@ -46,6 +47,11 @@
     (dolist (checker '(javascript-eslint javascript-standard))
       (flycheck-add-mode checker 'rjsx-mode)))
   (spacemacs/enable-flycheck 'rjsx-mode))
+
+(defun react/post-init-import-js ()
+  (progn
+    (add-hook 'rjsx-mode-hook #'run-import-js)
+    (spacemacs/import-js-set-key-bindings 'rjsx-mode)))
 
 (defun react/post-init-js-doc ()
   (add-hook 'rjsx-mode-hook 'spacemacs/js-doc-require)

--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -67,11 +67,11 @@ Formatter can be chosen on a per project basis using directory local variables
 *Note:* you can easily add a directory local variable with ~SPC f v d~.
 
 * Live display in browser
-Use ~SPC m i~ to enable impatient mode, opening a live view of a HTML file in
+Use ~SPC m I~ to enable impatient mode, opening a live view of a HTML file in
 your browser. You may wish to enable impatient mode in referenced CSS or JS
 files, too.
 
-When the underlying file is an HTML file, ~SPC m i~ automatically opens the page
+When the underlying file is an HTML file, ~SPC m I~ automatically opens the page
 in the browser. For other buffers, a list of available views can be found on
 [[http://localhost:8080/imp]].
 
@@ -84,7 +84,7 @@ For more information visit the [[https://github.com/skeeto/impatient-mode/blob/m
 |-------------+-----------------------------------------------------------|
 | ~SPC m g p~ | quickly navigate CSS rules using =helm=                   |
 | ~SPC m e h~ | highlight DOM errors                                      |
-| ~SPC m i~   | open live view in browser                                 |
+| ~SPC m I~   | open live view in browser                                 |
 | ~SPC m g b~ | go to the beginning of current element                    |
 | ~SPC m g c~ | go to the first child element                             |
 | ~SPC m g p~ | go to the parent element                                  |

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -136,7 +136,7 @@
     :init
     (progn
       (dolist (mode '(web-mode css-mode))
-        (spacemacs/set-leader-keys-for-major-mode 'web-mode "i" 'spacemacs/impatient-mode)))))
+        (spacemacs/set-leader-keys-for-major-mode 'web-mode "I" 'spacemacs/impatient-mode)))))
 
 (defun html/init-less-css-mode ()
   (use-package less-css-mode

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -20,6 +20,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#js2-mode][js2-mode]]
   - [[#folding-js2-mode][Folding (js2-mode)]]
+  - [[#importing-import-js][Importing (import-js)]]
   - [[#refactoring-js2-refactor][Refactoring (js2-refactor)]]
     - [[#documentation-js-doc][Documentation (js-doc)]]
   - [[#repl-skewer-mode][REPL (skewer-mode)]]
@@ -39,6 +40,12 @@ This layer adds support for the JavaScript language using [[https://github.com/m
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =javascript= to the existing =dotspacemacs-configuration-layers= list in
 this file.
+
+To enable the importing helper, install the =ImportJS=:
+
+#+BEGIN_SRC sh
+  $ npm install -g import-js
+#+END_SRC
 
 To activate error checking using flycheck, install one of the [[http://www.flycheck.org/en/latest/languages.html#javascript][available linters]]
 such as =ESLint= or =JSHint=:
@@ -174,6 +181,14 @@ doing this [[https://stackoverflow.com/questions/9679932#comment33532258_9683472
 | ~SPC m z e~ | toggle hide/show element |
 | ~SPC m z F~ | toggle hide functions    |
 | ~SPC m z C~ | toggle hide comments     |
+
+** Importing (import-js)
+
+| Key Binding | Description                                                         |
+|-------------+---------------------------------------------------------------------|
+| ~SPC m i i~ | Import the module for the variable under the cursor                 |
+| ~SPC m i f~ | Import any missing modules and remove any modules that are not used |
+| ~SPC m g i~ | Go to the module of the variable under cursor                       |
 
 ** Refactoring (js2-refactor)
 Bindings should match the plain emacs assignments.

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -66,6 +66,32 @@
                      "the `tern' layer is not present in your `.spacemacs'!"))))
 
 
+;; import-js
+
+(defun spacemacs/import-js-set-key-bindings (mode)
+  "Setup the key bindings for `import-js' for the given MODE."
+  (progn
+    (spacemacs/declare-prefix-for-mode mode "mi" "import")
+    (spacemacs/set-leader-keys-for-major-mode mode
+      "if" #'spacemacs/import-js-fix
+      "ii" #'spacemacs/import-js-import
+      "gi" #'import-js-goto)))
+
+(defun spacemacs/import-js-fix ()
+  (interactive)
+  (require 'import-js)
+  (import-js-fix)
+  (if (bound-and-true-p flycheck-mode)
+      (flycheck-buffer)))
+
+(defun spacemacs/import-js-import ()
+  (interactive)
+  (require 'import-js)
+  (import-js-import)
+  (if (bound-and-true-p flycheck-mode)
+      (flycheck-buffer)))
+
+
 ;; js-doc
 
 (defun spacemacs/js-doc-require ()

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -20,6 +20,7 @@
         helm-gtags
         imenu
         impatient-mode
+        import-js
         js-doc
         js2-mode
         js2-refactor
@@ -59,7 +60,15 @@
 
 (defun javascript/post-init-impatient-mode ()
   (spacemacs/set-leader-keys-for-major-mode 'js2-mode
-    "i" 'spacemacs/impatient-mode))
+    "I" 'spacemacs/impatient-mode))
+
+(defun javascript/init-import-js ()
+  (use-package import-js
+    :defer t
+    :init
+    (progn
+      (add-hook 'js2-mode-hook #'run-import-js)
+      (spacemacs/import-js-set-key-bindings 'js2-mode))))
 
 (defun javascript/pre-init-org ()
   (spacemacs|use-package-add-hook org


### PR DESCRIPTION
# Description
Add an importing helper, ImportJS to javascript layer.

# import-js
https://github.com/Galooshi/import-js

# Key Bindings

| Key Binding | Description                                                         |
|-------------|---------------------------------------------------------------------|
| `SPC m i i` | Import the module for the variable under the cursor                 |
| `SPC m i f` | Import any missing modules and remove any modules that are not used |
| `SPC m g i` | Go to the module of the variable under cursor                       |

# Changes
* Add import-js
* Add some key bindings for import-js
* Add `run-import-js` to js2-mode hooks.
* Change the key binding for impatient-mode
* Update README