### PR TITLE
Prefer eslint_d to eslint

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -44,7 +44,8 @@
   (with-eval-after-load 'flycheck
     (dolist (checker '(javascript-eslint javascript-standard))
       (flycheck-add-mode checker 'rjsx-mode)))
-  (spacemacs/enable-flycheck 'rjsx-mode))
+  (spacemacs/enable-flycheck 'rjsx-mode)
+  (add-hook 'rjsx-mode-hook #'spacemacs//javascript-setup-eslint t))
 
 (defun react/post-init-js-doc ()
   (add-hook 'rjsx-mode-hook 'spacemacs/js-doc-require)

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -67,6 +67,12 @@
     (message (concat "Tern was configured as the javascript backend but "
                      "the `tern' layer is not present in your `.spacemacs'!"))))
 
+
+;; flycheck
+
+(defun spacemacs//javascript-setup-eslint ()
+  (when-let ((found (executable-find "eslint_d")))
+    (set (make-local-variable 'flycheck-javascript-eslint-executable) found)))
 
 
 ;; js-doc

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -47,7 +47,8 @@
   (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-company))
 
 (defun javascript/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'js2-mode))
+  (spacemacs/enable-flycheck 'js2-mode)
+  (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-eslint t))
 
 (defun javascript/post-init-ggtags ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
Use eslint_d instead of eslint. Find the eslint_d executable on opening javascript buffers.

# eslint_d
https://github.com/mantoni/eslint_d.js/

# Description
eslint_d runs eslint as a daemon, and provides the fastest lint for .js files.