### PR TITLE
auto-completion: add ivy-yasnippet

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -333,6 +333,16 @@ MODE parameter must match the :modes values used in the call to
   (call-interactively 'helm-yas-complete))
 
 
+;; ivy-yas
+
+(defun spacemacs/ivy-yas ()
+  "Lazy load ivy-yasnippet"
+  (interactive)
+  (spacemacs/load-yasnippet)
+  (require 'ivy-yasnippet)
+  (call-interactively 'ivy-yasnippet))
+
+
 ;; Yasnippet
 
 (defun spacemacs/load-yasnippet ()

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -21,6 +21,7 @@
         (helm-company :requires helm)
         (helm-c-yasnippet :requires helm)
         hippie-exp
+        (ivy-yasnippet :requires ivy)
         smartparens
         yasnippet
         yasnippet-snippets
@@ -188,6 +189,14 @@
   (when (configuration-layer/package-used-p 'yasnippet)
     ;; Try to expand yasnippet snippets based on prefix
     (add-to-list 'hippie-expand-try-functions-list 'yas-hippie-try-expand)))
+
+(defun auto-completion/init-ivy-yasnippet ()
+  (use-package ivy-yasnippet
+    :defer t
+    :init
+    (progn
+      (setq ivy-yasnippet-expand-keys nil)
+      (spacemacs/set-leader-keys "is" 'spacemacs/ivy-yas))))
 
 (defun auto-completion/post-init-smartparens ()
   (with-eval-after-load 'smartparens


### PR DESCRIPTION
Insert snippets with ivy, similar to helm-c-yasnippet.
Closes #7401.
