### PR TITLE
auto-completion: use counsel-company to show completion candidates

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -213,7 +213,7 @@ For nicer-looking faces, try adding the following to `custom-set-faces` in your 
 | Key Binding | Description                                                                                          |
 |-------------+------------------------------------------------------------------------------------------------------|
 | ~C-d~       | open minibuffer with documentation of thing at point in company dropdown                             |
-| ~C-/~       | show candidates in Helm (for fuzzy searching)                                                        |
+| ~C-/~       | show candidates in Helm or Ivy (for fuzzy searching)                                                 |
 | ~C-M-/~     | filter the company dropdown menu                                                                     |
 | ~M-h~       | show current candidate's documentation in a tooltip (requires =auto-completion-enable-help-tooltip=) |
 

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -156,13 +156,14 @@
       (spacemacs/set-leader-keys "is" 'spacemacs/helm-yas)
       (setq helm-c-yas-space-match-any-greedy t))))
 
-(defun auto-completion/init-helm-company ()
-  (use-package helm-company
-    :if (configuration-layer/package-used-p 'company)
-    :defer t
-    :init
-    (with-eval-after-load 'company
+(defun auto-completion/pre-init-helm-company ()
+  (spacemacs|use-package-add-hook company
+    :post-config
+    (use-package helm-company
+      :defer t
+      :init
       (define-key company-active-map (kbd "C-/") 'helm-company))))
+(defun auto-completion/init-helm-company ())
 
 (defun auto-completion/init-hippie-exp ()
   ;; replace dabbrev-expand

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -129,7 +129,7 @@
                                             "company-statistics-cache.el"))
       (add-hook 'company-mode-hook 'company-statistics-mode))))
 
-(defun auto-completion/post-init-counsel ()
+(defun auto-completion/pre-init-counsel ()
     (spacemacs|use-package-add-hook company
       :post-config
       (define-key company-active-map (kbd "C-/") 'counsel-company)))

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -17,6 +17,7 @@
         company
         (company-quickhelp :toggle auto-completion-enable-help-tooltip)
         company-statistics
+        counsel
         fuzzy
         (helm-company :requires helm)
         (helm-c-yasnippet :requires helm)
@@ -127,6 +128,11 @@
       (setq company-statistics-file (concat spacemacs-cache-directory
                                             "company-statistics-cache.el"))
       (add-hook 'company-mode-hook 'company-statistics-mode))))
+
+(defun auto-completion/post-init-counsel ()
+    (spacemacs|use-package-add-hook company
+      :post-config
+      (define-key company-active-map (kbd "C-/") 'counsel-company)))
 
 (defun auto-completion/init-fuzzy ()
   (use-package fuzzy :defer t))


### PR DESCRIPTION
Trying to get the ivy layer up to par with helm.