### PR TITLE
spacemacs-completion: checks variables defined in helm layer

### DIFF
--- a/layers/+completion/helm/config.el
+++ b/layers/+completion/helm/config.el
@@ -14,10 +14,6 @@
 ;; TODO: remove dotspacemacs variables backward compatbility in version
 ;;       0.400 or later
 
-(defvar helm-enable-auto-resize (spacemacs|dotspacemacs-backward-compatibility
-                                 dotspacemacs-helm-resize nil)
-  "If non nil, `helm' will try to minimize the space it uses.")
-
 (defvar helm-no-header (spacemacs|dotspacemacs-backward-compatibility
                         dotspacemacs-helm-no-header nil)
   "if non nil, the helm header is hidden when there is only one source.")
@@ -25,12 +21,6 @@
 (defvar helm-position (spacemacs|dotspacemacs-backward-compatibility
                        dotspacemacs-helm-position bottom)
   "Position in which to show the `helm' mini-buffer.")
-
-(defvar helm-use-fuzzy (spacemacs|dotspacemacs-backward-compatibility
-                        dotspacemacs-helm-use-fuzzy always)
-  "Controls fuzzy matching in helm. If set to `always', force fuzzy matching
-  in all non-asynchronous sources. If set to `source', preserve individual
-  source settings. Else, disable fuzzy matching in all sources.")
 
 (defvar spacemacs-helm-rg-max-column-number 512
   "Controls the maximum number of columns to display with ripgrep (otherwise

--- a/layers/+spacemacs/spacemacs-completion/config.el
+++ b/layers/+spacemacs/spacemacs-completion/config.el
@@ -12,6 +12,16 @@
 
 ;; Helm
 
+(defvar helm-use-fuzzy (spacemacs|dotspacemacs-backward-compatibility
+                        dotspacemacs-helm-use-fuzzy always)
+  "Controls fuzzy matching in helm. If set to `always', force fuzzy matching
+  in all non-asynchronous sources. If set to `source', preserve individual
+  source settings. Else, disable fuzzy matching in all sources.")
+
+(defvar helm-enable-auto-resize (spacemacs|dotspacemacs-backward-compatibility
+                                 dotspacemacs-helm-resize nil)
+  "If non nil, `helm' will try to minimize the space it uses.")
+
 (defface spacemacs-helm-navigation-ts-face
   `((t :background ,(face-attribute 'error :foreground)
        :foreground "black"))


### PR DESCRIPTION
Some variables used in the spacemacs-completion layer are defined in the helm layer, this adds checks to those to make sure they actually exists before using them.

I use spacemacs-base because i don't need the evil. I got all other spacemacs-* layers enabled and use ivy for completion. Whenever something requires helm it will lead to void variable errors and whatever was being loaded fails, in my case it was csharp-mode in the csharp layer and some other(s) i did not identify.

Not sure if this is the right way to go about this, might be a better idea to move the code and variables to the same layer.