### PR TITLE
Counsel jump in buffer and fix missing imenu declaration

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -336,6 +336,15 @@ To prevent this error we just wrap `describe-mode' to defeat the
         ((headline inlinetask)
          (save-excursion (goto-char (org-element-property :begin context))
                          (call-interactively 'counsel-org-tag)) t)))))
+
+(defun spacemacs/counsel-jump-in-buffer ()
+  "Jump in buffer with `counsel-imenu' or `counsel-org-goto' if in in org-mode"
+  (interactive)
+  (call-interactively
+   (cond
+    ((eq major-mode 'org-mode) 'counsel-org-goto)
+    (t 'counsel-imenu))))
+
 
 ;; Ivy
 

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -18,6 +18,7 @@
         evil
         flx
         helm-make
+        imenu
         ivy
         ivy-hydra
         (ivy-rich :toggle ivy-enable-advanced-buffer-information)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -75,7 +75,7 @@
         "ry"  'counsel-yank-pop
         "rm"  'counsel-mark-ring
         ;; jumping
-        "sj"  'counsel-imenu
+        "sj"  'spacemacs/counsel-jump-in-buffer
         ;; themes
         "Ts"  'counsel-load-theme
         ;; search
@@ -175,7 +175,7 @@
         "cm" 'helm-make))))
 
 (defun ivy/post-init-imenu ()
-  (spacemacs/set-leader-keys "ji" 'counsel-imenu))
+  (spacemacs/set-leader-keys "ji" 'spacemacs/counsel-jump-in-buffer))
 
 (defun ivy/init-ivy ()
   (use-package ivy


### PR DESCRIPTION
Hello, this works the same as spacemacs/helm-jump-in-buffer but for counsel/ivy.

I also noticed that imenu was missing from the package declaration in the ivy layer so i fixed that. The ivy/post-init-imenu code was never running and the only reason "ji" called counsel-imenu was because counsel-mode remaps imenu to counsel-imenu.