### PR TITLE
shell mode: resize-shell-to-desired-width check for shell buffer before changing size

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -49,10 +49,10 @@
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 
 (defun spacemacs/resize-shell-to-desired-width ()
+  (if (string= (buffer-name) shell-pop-last-shell-buffer-name)
   (enlarge-window-horizontally (-
                                 (/ (* (frame-width) shell-default-width) 100)
-                                (window-width)))
-)
+                                (window-width)))))
 
 (defmacro make-shell-pop-command (func &optional shell)
   "Create a function to open a shell via the function FUNC.


### PR DESCRIPTION
This PR is to fix issued introduced by commit 4ad2f719fa9e87c24ffec03efe1aa38393a42961 (Add shell-default-width configuration option for left/right side). That commit added new function `spacemacs/resize-shell-to-desired-width` which gets called everytime shell buffer is toggled (`spc '`, `spc ase`, `spc ast` ...) 

The problem is when toggling to close shell buffer, this function will act on last active window other than shell buffer window, thus undesirably changing its size. If the current layout has more than one windows in columns, their sizes will be changed.  

To see an example do `spc w 2` to have two windows side by side. Now do `spc '` to have shell buffer show up. `spc '` again to turn it off. The two windows now become unbalanced.

This PR adds a check on `resize-shell-to-desired-width` to make sure that it will only do change on shell buffer.