### PR TITLE
Fix errata in documentation: 'packags' => 'packages'.

### DIFF
--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -51,7 +51,7 @@ automatically all dependencies using =apt-get=.
 After installing the dependencies, add this to your =~/.spacemacs=.
 
 #+begin_src emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(pdf-tools))
+  (setq-default dotspacemacs-configuration-layers '(pdf))
 #+end_src
 
 After that, syncronize your configuration with ~SPC f e R~. This will pop up a

--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -9,7 +9,7 @@ This layer configures mostly Emacs built-in packages to given them better
 defaults.
 
 ** Features:
--  Configures packags:
+-  Configures packages:
  - abbrev
  - archive-mode
  - bookmark


### PR DESCRIPTION
Fixed small errata in the documentation.

- In global README.md: 'packags' => 'packages'. 
- pdf layer: updated layer name in the documentation.