### PR TITLE
Add golangci-lint support for go layer

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -53,6 +53,8 @@ to get all the goodies of this layer:
   go get -u github.com/josharian/impl
 #+END_SRC
 
+If you with to use a linters aggregator tool, you can enable =gometalinter= or =golangci-lint=.
+
 If you wish to use =gometalinter= set the value of =go-use-gometalinter= to t:
 
 #+begin_src emacs-lisp
@@ -68,6 +70,21 @@ and install the tool:
 
 For more information read [[https://github.com/alecthomas/gometalinter/blob/master/README.md][gometalinter README.md]]
 and [[https://github.com/favadi/flycheck-gometalinter/blob/master/README.md][flycheck-gometalinter README.md]]
+
+If you wish to use =golangci-lint= set the value of =go-use-golangci-lint= to t:
+
+#+begin_src emacs-lisp
+  (go :variables go-use-golangci-lint t)
+#+end_src
+
+and install the tool:
+
+#+BEGIN_SRC sh
+  go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+#+END_SRC
+
+For more information read [[https://github.com/golangci/golangci-lint][golangci-lint README.md]]
+and [[https://github.com/weijiangan/flycheck-golangci-lint][flycheck-golangci-lint README.md]]
 
 If you wish to use =godoctor= for refactoring, install it too:
 

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -28,6 +28,9 @@
 (defvar go-use-gometalinter nil
   "Use gometalinter if the variable has non-nil value.")
 
+(defvar go-use-golangci-lint nil
+  "Use golangci-lint if the variable has non-nil value.")
+
 (defvar go-test-buffer-name "*go test*"
   "Name of the buffer for go test output. Default is *go test*.")
 

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -64,6 +64,16 @@
                                       go-errcheck))
    (flycheck-gometalinter-setup))
 
+(defun spacemacs//go-enable-golangci-lint ()
+  "Enable `flycheck-golangci-lint' and disable overlapping `flycheck' linters."
+  (setq flycheck-disabled-checkers '(go-gofmt
+                                     go-golint
+                                     go-vet
+                                     go-build
+                                     go-test
+                                     go-errcheck))
+  (flycheck-golangci-lint-setup))
+
 (defun spacemacs/go-run-tests (args)
   (interactive)
   (compilation-start (concat "go test " args " " go-use-test-args)

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -18,6 +18,9 @@
         (flycheck-gometalinter :toggle (and go-use-gometalinter
                                             (configuration-layer/package-used-p
                                              'flycheck)))
+        (flycheck-golangci-lint :toggle (and go-use-golangci-lint
+                                             (configuration-layer/package-used-p
+                                              'flycheck)))
         ggtags
         helm-gtags
         go-eldoc
@@ -61,6 +64,11 @@
   (use-package flycheck-gometalinter
     :defer t
     :init (add-hook 'go-mode-hook 'spacemacs//go-enable-gometalinter t)))
+
+(defun go/init-flycheck-golangci-lint ()
+  (use-package flycheck-golangci-lint
+    :defer t
+    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-golangci-lint t)))
 
 (defun go/post-init-ggtags ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
This PR adds support for [golangci-lint](https://github.com/golangci/golangci-lint) with [flycheck-golangci-lint](https://github.com/weijiangan/flycheck-golangci-lint).

Fixes this issue (request): #10825 