### PR TITLE
Fix missing package declarations in different layers

### DIFF
--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -13,6 +13,7 @@
       '(
         ;; package names go here
         asm-mode
+        company
         electric-indent-mode
         ggtags
         counsel-gtags

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -20,6 +20,7 @@
     exec-path-from-shell
     helm-gtags
     rust-mode
+    smartparens
     toml-mode
     ))
 

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -13,6 +13,7 @@
   '(
     cargo
     company
+    counsel-gtags
     racer
     flycheck
     (flycheck-rust :requires flycheck)

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -17,6 +17,7 @@
         ggtags
         counsel-gtags
         helm-gtags
+        parinfer
         ))
 
 (defun scheme/post-init-company ()


### PR DESCRIPTION
Yesterday i found that imenu was missing the the package declarations in ivy by mistake when i was trying to improve jump-in-buffer with counsel so i submitted a pull request. Then i realized that there might be more errors like this so i wrote a Python script that went thru all the layers looking for missing package declarations and it found these 4.
I don't use these layers myself but i think it should improve the editing experience for those that does.
Also, as a byproduct the script also found some wonky-ness in the restructuredtext layer that i will submit a pull request for later.