### PR TITLE
ruby: add popwin config for bundler, projectile-rails and rubocop

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -124,9 +124,17 @@
     :post-config (add-to-list 'org-babel-load-languages '(ruby . t))))
 
 (defun ruby/post-init-popwin ()
-  (push '("*rspec-compilation*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
+  (push '("*Bundler*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
+        popwin:special-display-config)
+  (push '("*projectile-rails-compilation*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
+        popwin:special-display-config)
+  (push '("*projectile-rails-generate*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
         popwin:special-display-config)
   (push '("*rake-compilation*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
+        popwin:special-display-config)
+  (push '("*rspec-compilation*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
+        popwin:special-display-config)
+  (push '("^\\*RuboCop.+\\*$" :regexp t :dedicated t :position bottom :stick t :noselect t :height 0.4)
         popwin:special-display-config))
 
 (defun ruby/init-rbenv ()


### PR DESCRIPTION
## Problem
- Open ruby files in two windows in the frame
- Switch to the left window unless it's already active
- Run any command from bundler, projectile-rails or rubocop
- The buffer with command output is displayed in the right window
- To close this buffer, you have to switch to the other window and press `q`
- For bundler buffers, you have to press `ESC` and `SPC b d`
- Closing without switching (`SPC c d`) deletes the right window and breaks the
  layout, also it doesn't work with bundler buffers

## Solution
Similarly to rake and rspec, buffers from bundler, projectile-rails and rubocop
should be managed by popwin, which displays them in a third window at the
bottom. The popup window can be closed with `SPC w p p ` or even better `C-g`.

## Aside
It's beyond the scope of this PR, but I wonder what would be the best way to
remove the duplication and extracting default options (seen repeated also in
other layers) for popwin config.