### PR TITLE
shell: add support for vim/hybrid styles in term/ansi-term buffers.

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -182,3 +182,29 @@ is achieved by adding the relevant text properties."
   "Send tab in term mode."
   (interactive)
   (term-send-raw-string "\t"))
+
+(defun spacemacs//term-enable-line-mode ()
+  "Enable `term-line-mode' when in `term-mode' buffer."
+  (when (eq major-mode 'term-mode)
+    (term-line-mode)))
+
+(defun spacemacs//term-enable-char-mode-maby-goto-prompt ()
+  "Enable `term-char-mode' when in a `term-mode' buffer.
+
+Will also put cursor on prompt position if called when cursor is not on the same
+line as prompt."
+  (when (eq major-mode 'term-mode)
+    (when (get-buffer-process (current-buffer))
+      (term-char-mode)
+      (if (not (eq (line-number-at-pos (point))
+                   (line-number-at-pos (marker-position (term-process-mark)))))
+          (goto-char (term-process-mark))))))
+
+(defun spacemacs//init-term-vim-hybrid ()
+  "Enable term support for vim and hybrid editing-styles."
+  (add-hook 'evil-insert-state-entry-hook
+            'spacemacs//term-enable-char-mode-maby-goto-prompt)
+  (add-hook 'evil-hybrid-state-entry-hook
+            'spacemacs//term-enable-char-mode-maby-goto-prompt)
+  (add-hook 'evil-normal-state-entry-hook
+            'spacemacs//term-enable-line-mode))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -242,6 +242,10 @@
   (evil-define-key 'insert term-raw-map (kbd "C-c C-z") 'term-stop-subjob)
   (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab)
 
+  (when (not (eq dotspacemacs-editing-style 'emacs))
+    (setq term-char-mode-point-at-process-mark nil)
+    (add-hook 'term-mode-hook 'spacemacs//init-term-vim-hybrid))
+
   (when (eq dotspacemacs-editing-style 'vim)
     (evil-define-key 'insert term-raw-map
       (kbd "C-k") 'term-send-up


### PR DESCRIPTION
I was trying out the vim editing style today and noticed that the cursor is stuck in normal/visual mode in term buffers, you can't move around and you cant edit/copy anything. This solves it. 
This commit also ensured the cursor goes to the prompt if the cursor enters insert/hybrid mode from a different line than the prompt line. 
Fixes:  #10779.