### PR TITLE
Fix breakage of `M-x` caused by Helm lazy load changes.

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -73,6 +73,9 @@
       ;; Use helm to provide :ls, unless ibuffer is used
       (unless (configuration-layer/package-used-p 'ibuffer)
         (evil-ex-define-cmd "buffers" 'helm-buffers-list))
+      ;; use helm by default for M-x, C-x C-f, and C-x b
+      (unless (configuration-layer/layer-usedp 'smex)
+        (global-set-key (kbd "M-x") 'helm-M-x))
       (global-set-key (kbd "C-x C-f") 'spacemacs/helm-find-files)
       (global-set-key (kbd "C-x b") 'helm-buffers-list)
       ;; use helm everywhere


### PR DESCRIPTION
Fix issue where `M-x` no longer brings up `Helm M-x`, caused by helm lazy load changes: a417e3ca856a2a6c885521d35ae1ce72513de978

These 3 lines were removed in that commit, but do not seem to have anything to do with lazy-loading.

AFAIK putting this back should not break lazy-loading, and fixes the issue for me.