### PR TITLE
use evil normal mode as default for ivy-occur-grep-mode

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -202,6 +202,7 @@
       (global-set-key (kbd "C-c C-r") 'ivy-resume)
       (global-set-key (kbd "<f6>") 'ivy-resume)
       ;; Occur
+      (evil-set-initial-state 'ivy-occur-grep-mode 'normal)
       (evil-make-overriding-map ivy-occur-mode-map 'normal)
       (ivy-set-occur 'spacemacs/counsel-search
                      'spacemacs//counsel-occur)


### PR DESCRIPTION
Recent updates break default using `evil-normal-state` for `ivy-occur-grep-mode`. In order to use `evil-normal-state` after invoking `spacemacs//counsel-edit (C-c C-e)` under `ivy-minibuffer`, this commit hooks it.

I tried `evil-make-overriding-map` for `ivy-occur-grep-mode` but it's still ended with `evil-motion-state`.