### PR TITLE
Additional documentation for spacemacs/toggle-current-window-dedication

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -468,7 +468,9 @@ If the universal prefix argument is used then will the windows too."
 
 ;; from http://dfan.org/blog/2009/02/19/emacs-dedicated-windows/
 (defun spacemacs/toggle-current-window-dedication ()
-  "Toggle dedication state of a window."
+  "Toggle dedication state of a window. Commands that change the buffer that a
+  window is displaying will not typically change the buffer displayed by
+  a dedicated window."
  (interactive)
  (let* ((window    (selected-window))
         (dedicated (window-dedicated-p window)))


### PR DESCRIPTION
Add additional user documentation to the `spacemacs/toggle-current-window-dedication` function. The additional documentation is meant to aid discovery of the meaning of this function (via `SPC h d f spacemacs/toggle-current-window-dedication`) for users that are not yet completely familiar with Emacs.

Description is based on content from: http://www.gnu.org/software/emacs/manual/html_node/elisp/Dedicated-Windows.html