### PR TITLE
spacemacs-navigation: remove duplicate code

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -223,47 +223,6 @@ If the universal prefix argument is used then kill also the window."
   (setq scroll-conservatively 0))
 
 
-;; zoom
-
-(defun spacemacs//zoom-frm-powerline-reset ()
-  (when (fboundp 'powerline-reset)
-    (setq-default powerline-height (spacemacs/compute-mode-line-height))
-    (powerline-reset)))
-
-(defun spacemacs//zoom-frm-do (arg)
-  "Perform a zoom action depending on ARG value."
-  (let ((zoom-action (cond ((eq arg 0) 'zoom-frm-unzoom)
-                           ((< arg 0) 'zoom-frm-out)
-                           ((> arg 0) 'zoom-frm-in)))
-        (fm (cdr (assoc 'fullscreen (frame-parameters))))
-        (fwp (* (frame-char-width) (frame-width)))
-        (fhp (* (frame-char-height) (frame-height))))
-    (when (equal fm 'maximized)
-      (toggle-frame-maximized))
-    (funcall zoom-action)
-    (set-frame-size nil fwp fhp t)
-    (when (equal fm 'maximized)
-      (toggle-frame-maximized))))
-
-(defun spacemacs/zoom-frm-in ()
-  "zoom in frame, but keep the same pixel size"
-  (interactive)
-  (spacemacs//zoom-frm-do 1)
-  (spacemacs//zoom-frm-powerline-reset))
-
-(defun spacemacs/zoom-frm-out ()
-  "zoom out frame, but keep the same pixel size"
-  (interactive)
-  (spacemacs//zoom-frm-do -1)
-  (spacemacs//zoom-frm-powerline-reset))
-
-(defun spacemacs/zoom-frm-unzoom ()
-  "Unzoom current frame, keeping the same pixel size"
-  (interactive)
-  (spacemacs//zoom-frm-do 0)
-  (spacemacs//zoom-frm-powerline-reset))
-
-
 ;; ace-link
 
 (defvar spacemacs--link-pattern "~?/.+\\|\s\\[")


### PR DESCRIPTION
I think this code was forgotten about during a refactoring. It exists and is in use in spacemacs-visual layer and zoom-frm is initialized there.