### PR TITLE
Keyboard-Layout : after-config hooks for lazy-loaded packages

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -251,7 +251,7 @@
     :description
     "Remap `evil-surround' bindings."
     :loader
-    (spacemacs|use-package-add-hook evil-surround :post-init BODY)
+    (spacemacs|use-package-add-hook evil-surround :post-config BODY)
     :common
     (kl/evil-correct-keys 'visual evil-surround-mode-map "s")))
 
@@ -277,7 +277,7 @@
     :description
     "Remap `flycheck-error-list' bindings."
     :loader
-    (spacemacs|use-package-add-hook flycheck :post-init BODY)
+    (spacemacs|use-package-add-hook flycheck :post-config BODY)
     :common
     (kl/evil-correct-keys 'evilified flycheck-error-list-mode-map
       "j"


### PR DESCRIPTION
Fix for #10865 .
New lazy-loaded packages using spacemacs|add-transient-hook introduced in bd316f4c308931a787236e8b7e4844f25e551a03 have their setup at `:config` phase instead of `:init` phase. That breaks some keyboard-layout expectation of keymap defined at `:init` time. 
This PR update the two impacted packages in keyboard-layout i'm aware of : evil-surround and flycheck.
