### PR TITLE
Add gitignore-templates to git layer

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -16,6 +16,7 @@
         gitattributes-mode
         gitconfig-mode
         gitignore-mode
+        gitignore-templates
         git-commit
         git-link
         git-messenger
@@ -113,6 +114,15 @@
 (defun git/init-gitignore-mode ()
   (use-package gitignore-mode
     :defer t))
+
+(defun git/init-gitignore-templates ()
+  (use-package gitignore-templates
+    :defer t
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'gitignore-mode
+      "i" 'gitignore-templates-insert)
+    (spacemacs/set-leader-keys
+      "gfi" 'gitignore-templates-new-file)))
 
 (defun git/init-magit ()
   (use-package magit


### PR DESCRIPTION
Added gitignore-templates to git layer.

`SPC g f i` for creating gitignore file from a template
`, i` in `gitignore-mode` for inserting template to existed gitignore file