### PR TITLE
[osx] use init instead of post-init for exec-path-from-shell.

### DIFF
--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -29,16 +29,22 @@
   (when (boundp 'mac-system-move-file-to-trash-use-finder)
     (setq mac-system-move-file-to-trash-use-finder t)))
 
-(defun osx/post-init-exec-path-from-shell ()
-  ;; Use GNU ls as `gls' from `coreutils' if available.  Add `(setq
-  ;; dired-use-ls-dired nil)' to your config to suppress the Dired warning when
-  ;; not using GNU ls.  We must look for `gls' after `exec-path-from-shell' was
-  ;; initialized to make sure that `gls' is in `exec-path'
-  (when (spacemacs/system-is-mac)
-    (let ((gls (executable-find "gls")))
-      (when gls
-        (setq insert-directory-program gls
-              dired-listing-switches "-aBhl --group-directories-first")))))
+(defun osx/init-exec-path-from-shell ()
+  (use-package exec-path-from-shell
+    :if (spacemacs/system-is-mac)
+    :defer nil
+    :config
+    (progn
+      (exec-path-from-shell-initialize)
+      (when (spacemacs/system-is-mac)
+        ;; Use GNU ls as `gls' from `coreutils' if available.  Add `(setq
+        ;; dired-use-ls-dired nil)' to your config to suppress the Dired warning when
+        ;; not using GNU ls.  We must look for `gls' after `exec-path-from-shell' was
+        ;; initialized to make sure that `gls' is in `exec-path'
+        (let ((gls (executable-find "gls")))
+          (when gls
+            (setq insert-directory-program gls
+                  dired-listing-switches "-aBhl --group-directories-first")))))))
 
 (defun osx/pre-init-helm ()
   ;; Use `mdfind' instead of `locate'.


### PR DESCRIPTION
Small error where a post-init function was defined when the layer actually owns the package.

#10897  might be relevant.