### PR TITLE
typescript: Fix jump handling with multiple backends

### DIFF
--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -40,10 +40,6 @@
       (kbd "C-k") 'tide-find-previous-reference
       (kbd "C-j") 'tide-find-next-reference
       (kbd "C-l") 'tide-goto-reference)
-    (add-to-list 'spacemacs-jump-handlers-typescript-tsx-mode
-                 '(tide-jump-to-definition :async t))
-    (add-to-list 'spacemacs-jump-handlers-typescript-mode
-                 '(tide-jump-to-definition :async t))
     (tide-setup)))
 
 (defun spacemacs//typescript-setup-tide-company ()

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -46,8 +46,9 @@
       (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))))
 
 (defun typescript/post-init-lsp-javascript-typescript ()
-  (spacemacs//setup-lsp-jump-handler 'typescript-mode
-                                     'typescript-tsx-mode))
+  (when (eq typescript-backend 'lsp)
+    (spacemacs//setup-lsp-jump-handler 'typescript-mode
+                                'typescript-tsx-mode)))
 
 (defun typescript/post-init-smartparens ()
   (if dotspacemacs-smartparens-strict-mode
@@ -93,7 +94,13 @@
                                     (cons "gg" (cons 'tide-jump-to-definition
                                                      keybindingList ))))
       (apply 'spacemacs/set-leader-keys-for-major-mode typescriptList)
-      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptTsxList))))
+      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptTsxList)))
+
+  (add-to-list 'spacemacs-jump-handlers-typescript-tsx-mode
+               (add-to-list 'spacemacs-jump-handlers '(tide-jump-to-definition :async t))
+               '(tide-jump-to-definition :async t))
+  (add-to-list 'spacemacs-jump-handlers-typescript-mode
+               '(tide-jump-to-definition :async t)))
 
 (defun typescript/post-init-web-mode ()
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")


### PR DESCRIPTION
Because the setup functions run after local vars are set, setting jump handlers needs to happen directly. Otherwise setting them only applies to the next typescript file that is opened, which may or may not even have the same backend.