### PR TITLE
Fix discarded env var values containing "="

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -31,7 +31,7 @@
        (if (string-match "^[a-zA-Z_]+[a-zA-Z0-9_]*=" env)
            (let* ((var (split-string env "="))
                   (k (car var))
-                  (v (cadr var)))
+                  (v (mapconcat #'identity (cdr var) "=")))
              (spacemacs-buffer/message "  - %s=%s" k v)
              (when (string-equal "PATH" k)
                (let ((paths (split-string v path-separator)))


### PR DESCRIPTION
`spacemacs/loadenv` was splitting environment variables beyond the first `=` and discarding/truncating the remaining parts of their values (e.g. `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus` is effectively parsed as `(DBUS_SESSION_BUS_ADDRESS unix:path)`).  This PR (re-)joins everything after the first split.