### PR TITLE
Fix javascript layer enables lsp-mode even when using tern

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -170,8 +170,6 @@
 (defun javascript/init-lsp-javascript-typescript ()
   (use-package lsp-javascript-typescript
     :commands lsp-javascript-typescript-enable
-    :defer t
-    :init (add-hook 'js2-mode-hook 'lsp-mode)
     :config (require 'lsp-javascript-flow)))
 
 (defun javascript/init-skewer-mode ()


### PR DESCRIPTION
Fix the issue javascript layer enables `lsp-mode` even if the backend is tern.
