### PR TITLE
diff-mode: define key bindings with leader key for vim editing style

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -10,7 +10,7 @@
 - [[#key-bindings][Key Bindings]]
   - [[#vc-directory-buffer-commands][VC Directory buffer commands]]
   - [[#commit-message-editing-buffer][Commit message editing buffer]]
-  - [[#diff-buffer][Diff buffer]]
+  - [[#diff-mode][Diff mode]]
   - [[#log-view-buffer][Log view buffer]]
   - [[#annotation-buffer][Annotation buffer]]
   - [[#version-control-transient-state][Version Control Transient-state]]
@@ -123,19 +123,35 @@ Navigation and interaction commands in the VC Directory buffer:
 In a commit message buffer press ~C-c C-c~ to commit the changes with the entered message.
 Pressing ~C-c C-k~ will discard the commit message and close this buffer.
 
-** Diff buffer
+** Diff mode
 
-| Key Bindings           | Description                                    |
-|------------------------+------------------------------------------------|
-| ~C-j~ or ~M-n~         | next hunk                                      |
-| ~C-k~ or ~M-p~         | previous hunk                                  |
-| ~gj~ or ~J~ or ~TAB~   | next file                                      |
-| ~gk~ or ~K~ or ~S-TAB~ | previous file                                  |
-| ~a~                    | apply a hunk                                   |
-| ~r~                    | revert a hunk                                  |
-| ~S~                    | split the current hunk at point into two hunks |
-| ~D~                    | kill a hunk                                    |
-| ~u~                    | undo killing or splitting                      |
+| Key Bindings | Description                                    |
+|--------------+------------------------------------------------|
+| ~SPC m j~    | next hunk                                      |
+| ~SPC m k~    | previous hunk                                  |
+| ~SPC m J~    | next file                                      |
+| ~SPC m K~    | previous file                                  |
+| ~SPC m a~    | apply a hunk                                   |
+| ~SPC m r~    | revert a hunk                                  |
+| ~SPC m s~    | split the current hunk at point into two hunks |
+| ~SPC m d~    | kill the hunk at point                         |
+| ~SPC m D~    | kill the current file's hunk                   |
+| ~SPC m u~    | undo                                           |
+| ~SPC m e~    | call =ediff-patch-file= on current buffer      |
+| ~SPC m g~    | jump to the corresponding source line          |
+| ~SPC m f c~  | convert unified diffs to context diffs         |
+| ~SPC m f u~  | convert context diffs to unified diffs         |
+| ~SPC m f r~  | reverse the direction of the diffs             |
+| ~SPC m q~    | close the diff window                          |
+
+A transient buffer is also defined, start it with ~SPC m .~ or ~, .~
+
+| Key Bindings | Description   |
+|--------------+---------------|
+| ~j~          | next hunk     |
+| ~k~          | previous hunk |
+| ~J~          | next file     |
+| ~K~          | previous file |
 
 ** Log view buffer
 

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -89,22 +89,35 @@
   (use-package diff-mode
     :defer t
     :config
-    (evilified-state-evilify diff-mode diff-mode-map
-      (kbd "C-j") 'diff-hunk-next
-      (kbd "C-k") 'diff-hunk-prev
-      (kbd "M-n") 'diff-hunk-next
-      (kbd "M-p") 'diff-hunk-prev
-      "J" 'diff-file-next
-      (kbd "<tab>") 'diff-file-next
-      "gj" 'diff-file-next
-      "K" 'diff-file-prev
-      (kbd "<backtab>") 'diff-file-prev
-      "gk" 'diff-file-prev
-      "a" 'diff-apply-hunk
-      "r" 'spacemacs/diff-mode-revert-hunk
-      "S" 'diff-split-hunk
-      "D" 'diff-hunk-kill
-      "u" 'diff-undo)))
+    (progn
+      (spacemacs/declare-prefix-for-mode 'diff-mode "mf" "format")
+      (spacemacs/set-leader-keys-for-major-mode 'diff-mode
+        "a" 'diff-apply-hunk
+        "d" 'diff-hunk-kill
+        "D" 'diff-file-kill
+        "e" 'diff-ediff-patch
+        "fc" 'diff-unified->context
+        "fr" 'diff-reverse-direction
+        "fu" 'diff-context->unified
+        "g" 'diff-goto-source
+        "j" 'diff-hunk-next
+        "J" 'diff-file-next
+        "k" 'diff-hunk-prev
+        "K" 'diff-file-prev
+        "r" 'spacemacs/diff-mode-revert-hunk
+        "s" 'diff-split-hunk
+        "u" 'diff-undo
+        "q" 'quit-window)
+      (spacemacs|define-transient-state diff-mode
+        :title "Diff-mode Transient State"
+        :evil-leader-for-mode (diff-mode . ".")
+        :bindings
+        ("j" diff-hunk-next "next hunk")
+        ("J" diff-file-next "next file")
+        ("k" diff-hunk-prev "previous hunk")
+        ("K" diff-file-prev "previous file")
+        ("q" nil "quit" :exit t)
+        ("<escape>" nil nil :exit t)))))
 
 (defun version-control/init-diff-hl ()
   (use-package diff-hl


### PR DESCRIPTION
This patch defines key bindings with leader key instead of evilified state to
make it easier for people those who edit in vim style to use diff-mode for both
of editing and reviewing files/buffers.

There are two use cases for diff-mode:

(1) to manually edit diff in a patch file
(2) to review diff that is generated by `vc-diff' or similar commands

The evilified state is useful for the case (2), but is confusing for the
case (1). Usually, users of vim editing style expect that they are in normal
state when a new buffer is created. However, when evilified state is used for
the case (1), some keys insert their character in a buffer, which let the users
think they are in insert state and keep hitting keys to edit the buffer, while
other keys invoke commands or change contents of buffer, which let them think
they are in normal state, so finally the user get lost what state they are in if
they don't know evilified state is used for diff-mode.

The changeset 58d521af5 "Unbreak diff-mode", originally written on Apr 2 2017,
tried to avoid the confusion by removing the evilified state configuration.
However, it is overwritten by the other and older changeset 8009e1bf5 "evilify
vc-* buffers", which is written on Feb 22 2016, for some reason.

This patch respects both of the use cases listed above, thus defines key
bindings with leader key instead of just removing the evilified state
configuration.