### PR TITLE
Delete duplicates in history & remove limit

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -31,6 +31,24 @@
   "Regexp used to define buffers that are useful despite matching
 `spacemacs-useless-buffers-regexp'.")
 
+;; Variables to control saving of minibuffer history
+(defvar spacemacs-minibuffer-history-length t
+  "Minibuffer history length. Value of `t' means no limit while `nil' disables
+  history saving. A numerical value limits the history length.")
+(defvar spacemacs-minibuffer-history-objects '(mark-ring
+                                               global-mark-ring
+                                               search-ring
+                                               regexp-search-ring
+                                               extended-command-history)
+  "List of minbuffer history objects that will be saved and reloaded across
+sessions. Possible values:
+`mark-ring', `global-mark-ring' > https://www.gnu.org/software/emacs/manual/html_node/emacs/Mark-Ring.html,
+`search-ring', `regexp-search-ring' > Search history,
+`extended-command-history' > `M-x' history,
+`kill-ring' > Clipboard history")
+(defvar spacemacs-minibuffer-history-save-interval 60
+  "Minibuffer history save interval in seconds.")
+
 ;; no beep pleeeeeease ! (and no visual blinking too please)
 (setq ring-bell-function 'ignore
       visible-bell nil)

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -297,17 +297,15 @@
   (use-package savehist
     :init
     (progn
-      ;; Minibuffer history
-      (setq savehist-file (concat spacemacs-cache-directory "savehist")
-            enable-recursive-minibuffers t ; Allow commands in minibuffers
-            history-length 1000
-            savehist-additional-variables '(mark-ring
-                                            global-mark-ring
-                                            search-ring
-                                            regexp-search-ring
-                                            extended-command-history)
-            savehist-autosave-interval 60)
-      (savehist-mode t))))
+      (setq enable-recursive-minibuffers t) ; Allow commands in minibuffers
+      (when spacemacs-minibuffer-history-length
+        ;; Minibuffer history
+        (setq savehist-file                 (concat spacemacs-cache-directory "savehist")
+              history-length                spacemacs-minibuffer-history-length
+              history-delete-duplicates     t
+              savehist-additional-variables spacemacs-minibuffer-history-objects
+              savehist-autosave-interval    spacemacs-minibuffer-history-save-interval)
+        (savehist-mode t)))))
 
 (defun spacemacs-defaults/init-saveplace ()
   (use-package saveplace


### PR DESCRIPTION
- Removing duplicates is very useful

- Considering that everyone might have varying length of history it is better to preserve it and stop complaining about any limits.

- Saving the kill ring is also beneficial. See https://github.com/syl20bnr/spacemacs/pull/10922#issuecomment-400726974 how to enable it.

Please suggest whether to prioritize kill ring or the history limit.