### PR TITLE
typescript: re-map keybinding to provide jump to def

### DIFF
--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -153,3 +153,7 @@
 
 (defun spacemacs/typescript-yasnippet-setup ()
   (yas-activate-extra-mode 'js-mode))
+
+(defun spacemacs/typescript-jump-to-type-def ()
+  (interactive)
+  (tide-jump-to-definition t))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -78,7 +78,8 @@
 
       (setq keybindingList '("Ee" tide-fix
                              "gb" tide-jump-back
-                             "gt" typescript/jump-to-type-def
+                             "gg" tide-jump-to-definition
+                             "gt" spacemacs/typescript-jump-to-type-def
                              "gu" tide-references
                              "hh" tide-documentation-at-point
                              "rr" tide-rename-symbol


### PR DESCRIPTION
Hi,

As mentioned on this issue https://github.com/syl20bnr/spacemacs/issues/10870,

it seems to me the function is removed, not sure if the change was to use particular tide function directly.

 one question i have is since ```tide-jump-to-definition``` handles type too, should we just use ```SPC m g g``` and remove ```SPC m g t```