### PR TITLE
Add paths to exec-path in correct order

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -35,7 +35,7 @@
              (spacemacs-buffer/message "  - %s=%s" k v)
              (when (string-equal "PATH" k)
                (let ((paths (split-string v path-separator)))
-                 (dolist (p paths)
+                 (dolist (p (reverse paths))
                    (add-to-list 'exec-path p))))
              (setenv k v))))
      ;; be sure we keep the default shell in this Emacs session


### PR DESCRIPTION
`add-to-list` prepends items to a list by default.  So, calling it sequentially
on directories in $PATH results in the user's directories appearing in
`exec-path` in the opposite order in which the appear in her $PATH.  This can
result in unexpected behavior.

This should resolve #10935
