### PR TITLE
add "counsel-spotify" to Spotify layer for ivy users

### DIFF
--- a/layers/+music/spotify/packages.el
+++ b/layers/+music/spotify/packages.el
@@ -11,8 +11,9 @@
 
 (setq spotify-packages
       '(
-        spotify
-        (helm-spotify-plus :requires helm)
+        (spotify :toggle (configuration-layer/package-usedp 'helm))
+        (helm-spotify-plus :toggle (configuration-layer/package-usedp 'helm))
+        (counsel-spotify :toggle (configuration-layer/package-usedp 'ivy))
         ))
 
 (defun spotify/init-spotify ()
@@ -32,3 +33,23 @@
   (use-package helm-spotify-plus
     :defer t
     :init (spacemacs/set-leader-keys "amsg" 'helm-spotify-plus)))
+
+(defun spotify/init-counsel-spotify ()
+  (use-package counsel-spotify
+    :defer t
+    :init
+    (progn
+      (spacemacs/declare-prefix "am" "music")
+      (spacemacs/declare-prefix "ams" "Spotify")
+      (spacemacs/set-leader-keys
+        "amsp" 'counsel-spotify-toggle-play-pause
+        "amsn" 'counsel-spotify-next
+        "amsN" 'counsel-spotify-previous
+        "amsst" 'counsel-spotify-search-track
+        "amssa" 'counsel-spotify-search-artist
+        "amssA" 'counsel-spotify-search-album
+        ))))
+
+(defun spotify/post-init-counsel-spotify ()
+  (load-library "counsel-spotify")
+  )


### PR DESCRIPTION
Hello, thank you for the greatest editor.
I usually use spacemacs with ivy.

I want to search tracks as helm users can.
So I have used "counsel-spotify".
I hope it will be help for ivy users.

counsel-spotify
https://github.com/Lautaro-Garcia/counsel-spotify

Best reagrds.