### PR TITLE
Make python-remove-unused-imports tramp-aware.

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -168,15 +168,18 @@ as the pyenv version then also return nil. This works around https://github.com/
         (insert "\n")
         (python-indent-line)))))
 
-;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
+;; based on https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
 (defun spacemacs/python-remove-unused-imports()
   "Use Autoflake to remove unused function"
   "autoflake --remove-all-unused-imports -i unused_imports.py"
   (interactive)
   (if (executable-find "autoflake")
-      (progn
+      (let ((file-name (if (tramp-tramp-file-p (buffer-file-name))
+                           (with-parsed-tramp-file-name (buffer-file-name) file
+                             file-localname)
+                         (buffer-file-name))))
         (shell-command (format "autoflake --remove-all-unused-imports -i %s"
-                               (shell-quote-argument (buffer-file-name))))
+                               (shell-quote-argument  file-name)))
         (revert-buffer t t t))
     (message "Error: Cannot find autoflake executable.")))
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -37,6 +37,7 @@
     semantic
     smartparens
     stickyfunc-enhance
+    (tramp :location built-in)
     xcscope
     yapfify
     ;; packages for anaconda backend


### PR DESCRIPTION
Hi all,

first of all, thanks for building such a great editor/distribution!

I ran into small issue and I thought I'd send a fix. It's my first contribution here
so please let me know what I messed up. The problem was:

When running python-remove-unused-imports on a remote file opened via tramp,
(buffer-file-name) might return something like /ssh:user@host:/path/to/file.
This cannot be directly passed to autoflake, as it will complain that no such file exists.

Fixed this by:

- Checking if the current buffer is a tramp file

- If yes, decoding (buffer-file-name) and only using the actual path to
  the file.

- If the file is a local file, using (buffer-file-name) as is.

Thanks for reviewing, and let me know if I should fix/change something.

Best wishes,

Stepan