### PR TITLE
Clojure layer: fix function usage in clojure layer according to cider changes

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -33,7 +33,7 @@
   "Insert FORM in the REPL buffer and eval it."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
-  (with-current-buffer (cider-current-repl-buffer)
+  (with-current-buffer (cider-current-repl)
     (let ((pt-max (point-max)))
       (goto-char pt-max)
       (insert form)


### PR DESCRIPTION
Clojure layer: fix function usage in clojure layer according to cider changes

The function `cider-current-repl-buffer` does not exist anymore in cider after PR [#2324](https://github.com/clojure-emacs/cider/pull/2324) was merged.
It broke the usage of functions in the clojure layer that used `spacemacs//cider-eval-in-repl-no-focus`, which sends forms to be evaluated in the repl buffer without focusing on it.
The fix is to use `cider-current-repl` instead of `cider-current-repl-buffer`
