### PR TITLE
enable eldoc for rust/racer

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -14,7 +14,6 @@
     cargo
     company
     counsel-gtags
-    eldoc
     racer
     flycheck
     (flycheck-rust :requires flycheck)

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -14,6 +14,7 @@
     cargo
     company
     counsel-gtags
+    eldoc
     racer
     flycheck
     (flycheck-rust :requires flycheck)
@@ -97,6 +98,7 @@
     :init
     (progn
       (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
+      (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
       (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
       (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
       (spacemacs/declare-prefix-for-mode 'rust-mode "mh" "help")


### PR DESCRIPTION
enable eldoc-mode for rust layer with racer

according to  https://github.com/racer-rust/emacs-racer , eldoc should be added to racer-mode-hook，not rust-mode-hook 

before commit e246ac1957, it did add to rust-mode-hook, the wrong way

