### PR TITLE
Add a binding to return from definition in intero mode

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -28,6 +28,7 @@
   - [[#refactor][Refactor]]
   - [[#ghc-mod-1][Ghc-mod]]
     - [[#insert-template][Insert template]]
+  - [[#intero-1][Intero]]
 - [[#syntax-checking][Syntax checking]]
   - [[#flycheck][Flycheck]]
   - [[#hlint][HLint]]
@@ -319,6 +320,15 @@ inferred type is inserted. On a symbol =foo= without definition, =foo =
 undefined= is inserted or a proper module is imported. ~SPC m m u~ inserts a
 hole in this case. On a variable, the case is split. When checking with hlint,
 original code is replaced with hlint's suggestion if possible.
+
+** Intero
+This command is only available when intero is enabled.
+
+This top-level command is prefixed by ~SPC m~:
+
+| Key Binding | Description            |
+|-------------+------------------------|
+| ~SPC m g b~ | return from definition |
 
 * Syntax checking
 At the moment there are four components which can check the syntax and indicates

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -72,6 +72,7 @@
   (intero-mode)
   (dolist (mode haskell-modes)
     (spacemacs/set-leader-keys-for-major-mode mode
+      "gb" 'xref-pop-marker-stack
       "hi" 'intero-info
       "ht" 'intero-type-at
       "hT" 'haskell-intero/insert-type


### PR DESCRIPTION
Currently there is only a binding for `jump-to-definition` (via the spacemacs jump handlers), but there is no binding for returning. It turns out that Intero's jump-to-definition function uses the `xref` cross-referencing functions, so adding a return-from-definition is as simple as adding a binding for `xref-pop-marker-stack`.