### PR TITLE
[WIP] Generic and Consistent eval/send across modes

### DIFF
--- a/core/core-generic-ops.el
+++ b/core/core-generic-ops.el
@@ -1,0 +1,144 @@
+(require 'evil)
+
+;; Evaling is for modes who can send text to a repl and receive a response
+
+(defvar spacemacs--generic-eval-region-fallback-to-send t
+  "When truthy, fallback to using spacemacs--generic-send-region-alist if no eval func exists for mode")
+
+(defvar spacemacs--generic-eval-region-alist '()
+  "Alist mapping mode to a 2-arity function which evals from beg to end for the mode")
+
+(defun spacemacs//get-eval-region-for-current-mode ()
+  (interactive)
+  (catch 'break
+    (dolist (test spacemacs--generic-eval-region-alist)
+      (let ((mode (car test))
+            (val (cdr test)))
+        (when (and (symbolp mode)
+                   (derived-mode-p mode)
+                   (symbolp val))
+          (throw 'break val))))))
+
+
+(defun spacemacs//generic-eval-region (beg end)
+  (interactive)
+  (let* ((f (or (spacemacs//get-eval-region-for-current-mode)
+                (when spacemacs--generic-eval-region-fallback-to-send
+                  (spacemacs//get-send-region-for-current-mode)))))
+    (when (functionp f)
+      (funcall f beg end))))
+
+(defvar spacemacs--generic-eval-region-want-flash t)
+(when (and spacemacs--generic-eval-want-flash
+           (require 'eval-sexp-fu nil 'noerror))
+  (define-eval-sexp-fu-flash-command spacemacs//generic-eval-region
+    (eval-sexp-fu-flash (cons beg end))))
+
+(evil-define-operator spacemacs//generic-evil-eval-operator (beg end)
+  (spacemacs//generic-eval-region beg end))
+
+(defun spacemacs//generic-eval-line ()
+  "Evals the current line as though you did (kbd \"ma^ SPC meo $`a\")"
+  (interactive)
+  ;; we don't use execute-kbd-macro here, because popping the mark kills the overlay
+  (save-excursion
+    (let* ((beg (progn (beginning-of-line) (point)))
+           (end (progn (end-of-line) (point))))
+      (spacemacs//generic-eval-region beg end))))
+
+(defun spacemacs//generic-eval-paragraph ()
+  "Evals the current paragraph as though you did (kbd \"ma SPC meo ap`a\")"
+  (interactive)
+  ;; we don't use execute-kbd-macro here, because popping the mark kills the overlay
+  (save-excursion
+    (let* ((graph (evil-inner-paragraph))
+           (beg (first graph))
+           (end (second graph)))
+      (spacemacs//generic-eval-region beg end))))
+
+(defun spacemacs//generic-eval-active-region-or-paragraph ()
+  "Evals the current active region or paragraph"
+  (interactive)
+  (if (use-region-p)
+      (spacemacs//generic-eval-region (region-beginning)
+                                   (region-end))
+    (spacemacs//generic-eval-paragraph)))
+
+(defun spacemacs//generic-eval-buffer ()
+  "Evals the current buffer as though you did (kbd \"ma gg SPC meo VG`a\")"
+  (interactive)
+  ;; we don't use execute-kbd-macro here, because popping the mark kills the overlay
+  (save-excursion
+    (let* ((beg (progn (beginning-of-buffer)
+                       (point)))
+           (end (progn (end-of-buffer)
+                       (point))))
+      (spacemacs//generic-eval-region beg end))))
+
+;; Sending is for modes who are content to schlep some text into a repl buffer
+
+(defvar spacemacs--generic-send-region-fallback-to-eval t
+  "When truthy, fallback to using spacemacs--generic-eval-region-alist if no send func exists for mode")
+
+(defvar spacemacs--generic-send-region-alist '()
+  "Alist mapping mode to a 2-arity function which sends text to a repl buffer from beg to end for the mode")
+
+(defun spacemacs//get-send-region-for-current-mode ()
+  (interactive)
+  (catch 'break
+    (dolist (test spacemacs--generic-send-region-alist)
+      (let ((mode (car test))
+            (val (cdr test)))
+        (when (and (symbolp mode)
+                   (derived-mode-p mode)
+                   (symbolp val))
+          (throw 'break val))))))
+
+(defun spacemacs//generic-send-region (beg end)
+  (interactive)
+  (let ((f (or (spacemacs//get-send-region-for-current-mode)
+               (when spacemacs--generic-send-region-fallback-to-eval
+                 (spacemacs//get-eval-region-for-current-mode)))))
+    (when (functionp f)
+      (funcall f beg end))))
+
+(defun spacemacs//generic-send-line ()
+  "Sends the current line as though you did (kbd \"ma^ SPC mso $`a\")"
+  (interactive)
+  ;; we don't use execute-kbd-macro here, because popping the mark kills the overlay
+  (save-excursion
+    (let* ((beg (progn (beginning-of-line) (point)))
+           (end (progn (end-of-line) (point))))
+      (spacemacs//generic-send-region beg end))))
+
+(defun spacemacs//generic-send-paragraph ()
+  "Sends the current paragraph as though you did (kbd \"ma SPC mso ap`a\")"
+  (interactive)
+  ;; we don't use execute-kbd-macro here, because popping the mark kills the overlay
+  (save-excursion
+    (let* ((graph (evil-inner-paragraph))
+           (beg (first graph))
+           (end (second graph)))
+      (spacemacs//generic-send-region beg end))))
+
+(defun spacemacs//generic-send-active-region-or-paragraph ()
+  "Sends the current active region or paragraph"
+  (interactive)
+  (if (use-region-p)
+      (spacemacs//generic-send-region (region-beginning)
+                                   (region-end))
+    (spacemacs//generic-send-paragraph)))
+
+(defun spacemacs//generic-send-buffer ()
+  "Sends the current buffer as though you did (kbd \"ma gg SPC mso VG`a\")"
+  (interactive)
+  ;; we don't use execute-kbd-macro here, because popping the mark kills the overlay
+  (save-excursion
+    (let* ((beg (progn (beginning-of-buffer)
+                       (point)))
+           (end (progn (end-of-buffer)
+                       (point))))
+      (spacemacs//generic-send-region beg end))))
+
+(evil-define-operator spacemacs//generic-evil-send-operator (beg end)
+  (spacemacs//generic-eval-region beg end))


### PR DESCRIPTION
First, this is a Work In Progress PR intended to gauge whether this feature is still wanted and how I should go about it. This work started life based on #3103 and my gist in that thread. 

This provides two primary functions which abstract the idea of evaling and sending a region to a repl or process. This is done to deduplicate mode-specific eval and send functions. The idea is that instead of building a special `your-mode-eval-region`, `your-mode-eval-buffer`, `your-mode-eval-until-end-of-line`, `your-model-eval-defun`, we can simply implement a function like:

```elisp
(defun your-mode-eval-region (beg end)
   "Evals for your-mode"
   (interactive)
   .....)
```

And then hook it onto spacemacs--generic-eval-region-alist like so:

```elisp
(add-to-list 'spacemacs--generic-eval-region-alist '(your-mode . your-mode-eval-region))
```

In exchange, you get:

* An evil operator for evaling.
* Functions for evaling buffers, defuns, paragraphs, active marked regions, current line, etc.
* Optional highlighting and inline-results via eval-sexp-fu.
* Consistency behavior and capabilities across modes. 

This code makes a distinction between `eval`ing and `send`ing. Eval is when you can talk to a repl or process and get results back. Send is when you're limited to sending text to some other buffer which is hopefully running a REPL. 

This WIP is intended to discover:

* if this is wanted (I've been using my own generic-eval.el for several years now, so I know *I like it*.)
* how to break apart this into reviewable chunks
* what documentation needs to be created
* how badly written this code is (emacs lisp isn't something I use a ton)

So far, this WIP does not cover:

* mode/layer-specific modifications to use these new commands

My intention with not including changes to layers is to be able to shake out the usefulness of this to the community at large before beginning negotiations to rip out a ton of custom, mode-specific eval/send functions. 