### PR TITLE
Fix handling of keymap property when it's symbol valued

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -80,7 +80,10 @@
 Needed to bypass keymaps set as text properties."
   (unless (bound-and-true-p isearch-mode)
     (when (memq evil-state '(evilified visual))
-      (let* ((map (get-char-property (point) 'keymap))
+      (let* ((map-or-symbol (get-char-property (point) 'keymap))
+             (map (if (and (symbolp map-or-symbol) (boundp map-or-symbol))
+                      (symbol-value map-or-symbol)
+                    map-or-symbol))
              (evilified-map (when map (cdr (assq 'evilified-state map))))
              (command (when (and evilified-map
                                  (eq 1 (length (this-command-keys))))


### PR DESCRIPTION
The previous code would only handle the case when the property was a keymap. But
it can also be a symbol representing a keymap.