### PR TITLE
Change order of evaluating template directories

### DIFF
--- a/layers/+completion/templates/packages.el
+++ b/layers/+completion/templates/packages.el
@@ -17,8 +17,8 @@
     :init
     (progn
       (setq yatemplate-dir
-            (or (concat dotspacemacs-directory "templates/")
-                templates-private-directory))
+            (or templates-private-directory
+                (concat dotspacemacs-directory "templates/")))
       (unless templates-use-default-templates
         (setq auto-insert-alist nil)))
     :config


### PR DESCRIPTION
The user defined template directory was never taken into account even though it was set and the default directory was always used.
