### PR TITLE
Use fundanmental-mode to open minified file

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -108,6 +108,9 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Prompt to open file literally if large file.
 (add-hook 'find-file-hook 'spacemacs/check-large-file)
 
+;; Use fundamental-mode to open minified file
+(add-to-list 'magic-mode-alist (cons #'spacemacs/check-minified-file 'fundamental-mode))
+
 ;; ---------------------------------------------------------------------------
 ;; UI
 ;; ---------------------------------------------------------------------------

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -451,7 +451,7 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
   (and
    (not (member (file-name-extension (buffer-file-name))
                 '("org" "md" "markdown" "txt" "rtf")))
-   (> (spacemacs/get-nth-line-length 1) 500)))
+   (> (spacemacs/get-nth-line-length 1) 1000)))
 
 (defun spacemacs/delete-window (&optional arg)
   "Delete the current window.

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -451,7 +451,8 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
   (and
    (not (member (file-name-extension (buffer-file-name))
                 '("org" "md" "markdown" "txt" "rtf")))
-   (> (spacemacs/get-nth-line-length 1) 1000)))
+   (member t (cl-loop for i from 1 to 20
+                      collect (> (spacemacs/get-nth-line-length i) 1000)))))
 
 (defun spacemacs/delete-window (&optional arg)
   "Delete the current window.

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -436,6 +436,23 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
       (buffer-disable-undo)
       (fundamental-mode))))
 
+;; get nth line length
+(defun spacemacs/get-nth-line-length (n)
+  "Length of the Nth line."
+  (save-excursion
+    (goto-char (point-min))
+    (if (zerop (forward-line (1- n)))
+        (- (line-end-position)
+           (line-beginning-position)))))
+
+;; check if the file has been minified
+;; disable for text-mode files
+(defun spacemacs/check-minified-file ()
+  (and
+   (not (member (file-name-extension (buffer-file-name))
+                '("org" "md" "markdown" "txt" "rtf")))
+   (> (spacemacs/get-nth-line-length 1) 500)))
+
 (defun spacemacs/delete-window (&optional arg)
   "Delete the current window.
 If the universal prefix argument is used then kill the buffer too."
@@ -1378,4 +1395,3 @@ Decision is based on `dotspacemacs-line-numbers'."
           enabled-for-parent            ; mode is one of default allowed modes
           disabled-for-modes
           (not disabled-for-parent)))))
-


### PR DESCRIPTION
This commit aims to solve the freezing problem when Emacs editing minified files. It's very simple by just checking the first line's length.

And it's disabled for `text-mode` files.