### PR TITLE
Extract env. vars from *login* shell

### DIFF
--- a/core/core-env.el
+++ b/core/core-env.el
@@ -34,7 +34,7 @@ If FORCE is non-nil then force the initialization of the file, note that the
 current contents of the file will be overwritten."
   (when (or force (not (file-exists-p spacemacs-env-vars-file)))
     (with-temp-file spacemacs-env-vars-file
-      (let ((shell-command-switch "-ic"))
+      (let ((shell-command-switch "-ilc"))
         (insert
          (concat
           "# ---------------------------------------------------------------------------\n"


### PR DESCRIPTION
Bash needs the `-l` flag, as pointed out in https://github.com/syl20bnr/spacemacs/commit/6220ace290b247265de8fac66bd9e84bef388326#r29480946 and https://github.com/syl20bnr/spacemacs/issues/10906#issuecomment-402184237.

I haven't had time to test this particular way of passing `-l` but I remember this was discussed before, and since it hasn't been fixed in 8 days I thought a PR could help. @mkleehammer can you test this since you suffer from the bug? I'm not tracking `master` for now.