### PR TITLE
Spacemacs documentation improvements

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -262,8 +262,9 @@ auto-save the file in-place, `cache' to auto-save the file to another
 file stored in the cache directory and `nil' to disable auto-saving.")
 
 (defvar dotspacemacs-enable-paste-transient-state nil
-  "If non-nil, the paste transient-state is enabled. While enabled, pressing
-`p' several times cycles through the elements in the `kill-ring'.")
+  "If non-nil, the paste transient-state is enabled. While enabled, after you
+paste something, pressing `C-j' and `C-k' several times cycles through the
+elements in the `kill-ring'.")
 (defvaralias
   'dotspacemacs-enable-paste-micro-state
   'dotspacemacs-enable-paste-transient-state

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -267,9 +267,9 @@ It should only modify the values of Spacemacs settings."
    ;; Maximum number of rollback slots to keep in the cache. (default 5)
    dotspacemacs-max-rollback-slots 5
 
-   ;; If non-nil, the paste transient-state is enabled. While enabled, pressing
-   ;; `p' several times cycles through the elements in the `kill-ring'.
-   ;; (default nil)
+   ;; If non-nil, the paste transient-state is enabled. While enabled, after you
+   ;; paste something, pressing `C-j' and `C-k' several times cycles through the
+   ;; elements in the `kill-ring'. (default nil)
    dotspacemacs-enable-paste-transient-state nil
 
    ;; Which-key delay in seconds. The which-key buffer is the popup listing

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1921,6 +1921,7 @@ Other help key bindings:
 | Key Binding | Description                                           |
 |-------------+-------------------------------------------------------|
 | ~SPC h SPC~ | discover Spacemacs documentation, layers and packages |
+| ~SPC h f~   | discover the =FAQ=                                    |
 | ~SPC h i~   | search in info pages with the symbol at point         |
 | ~SPC h k~   | show top-level bindings with =which-key=              |
 | ~SPC h m~   | search available man pages                            |
@@ -2417,7 +2418,6 @@ navigate between =Emacs= and Spacemacs specific files.
 | ~SPC f e e~   | open the =~/.spacemacs.env= file where environment variables are set or goes to =dotspacemacs/user-env= |
 | ~SPC f e E~   | reload the environment variables by executing the function =dotspacemacs/user-env=                      |
 | ~SPC f e C-e~ | reinitialize the =~/.spacemacs.env= file by importing system and shell environment variables            |
-| ~SPC f e f~   | discover the =FAQ=                                                                                      |
 | ~SPC f e i~   | open the all mighty =init.el=                                                                           |
 | ~SPC f e l~   | locate an Emacs library                                                                                 |
 | ~SPC f e R~   | resync the dotfile with spacemacs                                                                       |
@@ -2789,14 +2789,15 @@ To list all the symbols of a buffer press ~SPC s j~
 ** Editing
 *** Paste text
 **** Paste Transient-state
-The paste transient state can be enabled by settings the variable
+The paste transient state can be enabled by setting the variable
 =dotspacemacs-enable-paste-transient-state= to =t=. By default it is disabled.
 
-When the transient state is enabled, pressing ~p~ again will replace the pasted text
-with the previous yanked (copied) text on the kill ring.
+When the transient state is enabled, after you paste something, pressing ~C-j~
+or ~C-k~ will replace the pasted text with the previous or next yanked (copied)
+text on the kill ring.
 
 For example if you copy =foo= and =bar= then press ~p~ the text =bar= will
-be pasted, pressing ~p~ again will replace =bar= with =foo=.
+be pasted, pressing ~C-j~ will replace =bar= with =foo=.
 
 | Key Binding   | Description                                                                   |
 |---------------+-------------------------------------------------------------------------------|


### PR DESCRIPTION
`SPC f e f` key binding is no more present, so moved that table entry to
`SPC h f` in DOCUMENTATION.org.

Corrected description of paste transient-state behavior.