### PR TITLE
polish lsp-python and anaconda-mode

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -32,9 +32,7 @@
 
 (defun spacemacs//python-setup-anaconda ()
   "Setup anaconda backend."
-  (anaconda-mode)
-  (add-to-list 'spacemacs-jump-handlers-python-mode
-               '(anaconda-mode-find-definitions :async t)))
+  (anaconda-mode))
 
 (defun spacemacs//python-setup-anaconda-company ()
   "Setup anaconda auto-completion."
@@ -70,7 +68,6 @@ when this mode is enabled since the minibuffer is cleared all the time."
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (require 'lsp-python)
         (lsp-python-enable))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -51,7 +51,6 @@
     :defer t
     :init
     (progn
-      (add-hook 'python-mode-hook 'anaconda-mode)
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "hh" 'anaconda-mode-show-doc
         "ga" 'anaconda-mode-find-assignments
@@ -73,7 +72,9 @@
           (kbd "RET") 'spacemacs/anaconda-view-forward-and-push))
       (spacemacs|hide-lighter anaconda-mode)
       (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
-        (evil--jumps-push)))))
+        (evil--jumps-push))
+      (add-to-list 'spacemacs-jump-handlers-python-mode
+                   '(anaconda-mode-find-definitions :async t)))))
 
 (defun python/post-init-company ()
   ;; backend specific
@@ -133,8 +134,6 @@
     :init
     (spacemacs/set-leader-keys-for-major-mode 'python-mode "hd" 'helm-pydoc)))
 
-
-
 (defun python/init-importmagic ()
   (use-package importmagic
     :defer t
@@ -155,7 +154,7 @@
 (defun python/init-lsp-python ()
   (use-package lsp-python
     :commands lsp-python-enable
-    :init (add-hook 'python-mode-hook 'lsp-mode)))
+    :config (spacemacs//setup-lsp-jump-handler 'python-mode)))
 
 (defun python/init-nose ()
   (use-package nose


### PR DESCRIPTION
Thanks to manateelazycat's post [here](https://www.emacswiki.org/emacs/init-company-mode.el). He mentioned we shouldn't hook the `lsp-mode` with major modes. Instead, we should hook enable functions like `lsp-python-enable` directly. 

This commit removes the `lsp-mode` hook with `python-mode` and put jump handler binding to the packages config session.