### PR TITLE
Fix updating buffer names in window configurations

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -668,3 +668,14 @@ FRAME defaults to the current frame."
                                         (eyebrowse--get 'last-slot frame))
                                   (get-frame-persp frame)
                                   frame))
+
+(defun spacemacs//fixup-window-configs (orig-fn newname &optional unique)
+  "Update the buffer's name in the eyebrowse window-configs of any perspectives
+containing the buffer."
+  (let* ((old (buffer-name))
+         (new (funcall orig-fn newname unique)))
+    (dolist (persp (persp--buffer-in-persps (current-buffer)))
+      (dolist (window-config
+               (append (persp-parameter 'gui-eyebrowse-window-configs persp)
+                       (persp-parameter 'term-eyebrowse-window-configs persp)))
+        (eyebrowse--rename-window-config-buffers window-config old new)))))

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -95,7 +95,16 @@
         (add-hook 'persp-before-save-state-to-file-functions
                   #'spacemacs/update-eyebrowse-for-perspective)
         (add-hook 'persp-after-load-state-functions
-                  #'spacemacs/load-eyebrowse-after-loading-layout))
+                  #'spacemacs/load-eyebrowse-after-loading-layout)
+        ;; eyebrowse's advice for rename-buffer only updates workspace window
+        ;; configurations that are stored in frame properties, but Spacemacs's
+        ;; persp-mode integration saves workspace window configurations in
+        ;; perspective parameters.  We need to replace eyebrowse's advice with
+        ;; perspective-aware advice in order to ensure that window
+        ;; configurations for inactive perspectives get updated.
+        (ad-disable-advice 'rename-buffer 'around 'eyebrowse-fixup-window-configs)
+        (ad-activate 'rename-buffer)
+        (advice-add 'rename-buffer :around #'spacemacs//fixup-window-configs))
       ;; vim-style tab switching
       (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
       (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config))))


### PR DESCRIPTION
### Fix updating buffer names in window configurations

Eyebrowse stores window configurations for workspaces in frame properties. These window configurations reference buffers by name, which means that these references must be updated when a buffer is renamed.  To this end, eyebrowse advises `rename-buffer`.

Spacemacs integrates eyebrowse with persp-mode by saving the eyebrowse workspaces for a perspective as a parameter for that perspective so that Spacemacs can restore a perspective's workspaces when switching to that perspective.  However, eyebrowse's advice for `rename-buffer` fails to update inactive workspaces, for which the window configurations are stored in perspective parameters and not frame properties.

This commit disables eyebrowse's advice and adds perspective-aware advice to update buffer references in workspace window configurations.

* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs//fixup-window-configs`): New.
(`rename-buffer`): Remove `eyebrowse-fixup-window-configs` advice and advise with `spacemacs//fixup-window-configs`.

This  commit fixes #10183.