### PR TITLE
Add go-benchmark function, binding and documentation.

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -174,27 +174,28 @@ You have a few options to ensure you always get up to date suggestions:
 * Working with Go
 ** Go commands (start with =m=):
 
-| Key Binding   | Description                                                                           |
-|---------------+---------------------------------------------------------------------------------------|
-| ~SPC m e b~   | go-play buffer                                                                        |
-| ~SPC m e d~   | download go-play snippet                                                              |
-| ~SPC m e r~   | go-play region                                                                        |
-| ~SPC m g a~   | jump to matching test file or back from test to code file                             |
-| ~SPC m g c~   | open a clone of the current buffer with a coverage info (=go tool cover -h= for help) |
-| ~SPC m g g~   | go jump to definition                                                                 |
-| ~SPC m h h~   | godoc at point                                                                        |
-| ~SPC m i a~   | add import                                                                            |
-| ~SPC m i g~   | goto imports                                                                          |
-| ~SPC m i r~   | remove unused import                                                                  |
-| ~SPC m r n~   | go rename                                                                             |
-| ~SPC m t P~   | run "go test" for the current package and all packages under it                       |
-| ~SPC m t g f~ | generate tests for all exported functions                                             |
-| ~SPC m t g F~ | generate tests for all functions                                                      |
-| ~SPC m t g g~ | DWIM generate test for the function in the active region                              |
-| ~SPC m t p~   | run "go test" for the current package                                                 |
-| ~SPC m t s~   | run "go test" for the suite you're currently in (requires gocheck)                    |
-| ~SPC m t t~   | run "go test" for the function you're currently in (while you're in a _.test.go file) |
-| ~SPC m x x~   | run "go run" for the current 'main' package                                           |
+| Key Binding   | Description                                                                            |
+|---------------+----------------------------------------------------------------------------------------|
+| ~SPC m e b~   | go-play buffer                                                                         |
+| ~SPC m e d~   | download go-play snippet                                                               |
+| ~SPC m e r~   | go-play region                                                                         |
+| ~SPC m g a~   | jump to matching test file or back from test to code file                              |
+| ~SPC m g c~   | open a clone of the current buffer with a coverage info (=go tool cover -h= for help)  |
+| ~SPC m g g~   | go jump to definition                                                                  |
+| ~SPC m h h~   | godoc at point                                                                         |
+| ~SPC m i a~   | add import                                                                             |
+| ~SPC m i g~   | goto imports                                                                           |
+| ~SPC m i r~   | remove unused import                                                                   |
+| ~SPC m r n~   | go rename                                                                              |
+| ~SPC m t P~   | run "go test" for the current package and all packages under it                        |
+| ~SPC m t g f~ | generate tests for all exported functions                                              |
+| ~SPC m t g F~ | generate tests for all functions                                                       |
+| ~SPC m t g g~ | DWIM generate test for the function in the active region                               |
+| ~SPC m t b~   | run "go test -bench ." for the current package (optional "-count" with positive ~C-u~) |
+| ~SPC m t p~   | run "go test" for the current package                                                  |
+| ~SPC m t s~   | run "go test" for the suite you're currently in (requires gocheck)                     |
+| ~SPC m t t~   | run "go test" for the function you're currently in (while you're in a _.test.go file)  |
+| ~SPC m x x~   | run "go run" for the current 'main' package                                            |
 
 ** Go Guru
 

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -28,6 +28,14 @@
   (compilation-start (concat "go test " args " " go-use-test-args)
                      nil (lambda (n) go-test-buffer-name) nil))
 
+(defun spacemacs/go-run-package-benchmarks (count &optional args)
+  (interactive "P")
+  (spacemacs/go-run-tests (concat "-bench . "
+                                  (if (and current-prefix-arg (> (prefix-numeric-value count) 0))
+                                      (concat "-count " (number-to-string (prefix-numeric-value current-prefix-arg)))
+                                    "")
+                                  args)))
+
 (defun spacemacs/go-run-package-tests ()
   (interactive)
   (spacemacs/go-run-tests ""))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -129,6 +129,7 @@
         "ia" 'go-import-add
         "ig" 'go-goto-imports
         "ir" 'go-remove-unused-imports
+        "tb" 'spacemacs/go-run-package-benchmarks
         "tP" 'spacemacs/go-run-package-tests-nested
         "tp" 'spacemacs/go-run-package-tests
         "ts" 'spacemacs/go-run-test-current-suite


### PR DESCRIPTION
(Fair warning, I'm an emacs newbie/convert from vim, so this is more or less the first emacs func I've written.)

Adds a function / keybinding for "go test -bench ." with optional
numeric argument for indicating a count.