### PR TITLE
ivy: Fix error on nil input with counsel search

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -157,7 +157,7 @@ that directory."
                                               spacemacs--counsel-search-max-path-length)
                                            (length default-directory))))))
        (spacemacs//make-counsel-search-function tool)
-       :initial-input (rxt-quote-pcre initial-input)
+       :initial-input (when initial-input (rxt-quote-pcre initial-input))
        :dynamic-collection t
        :history 'counsel-git-grep-history
        :action #'counsel-git-grep-action


### PR DESCRIPTION
### ivy: Fix error on nil input with counsel search

Fix issue #6499: `SPC m` (`spacemacs/search-project-auto-region-or-symbol`) on a blank line causes an error:

    rxt-string->pcre: Wrong type argument: arrayp, nil

* `layers/+completion/ivy/funcs.el` (`spacemacs/counsel-search`): Check whether `initial-input` is `nil` in order to avoid calling `rxt-quote-pcre` on a nil value.