### PR TITLE
scala/java: Remove broken ensime key bindings and fix yanking types

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -426,10 +426,9 @@ particular refactoring doesn't work.
 
 *** Typecheck
 
-| Key Binding | Description                     |
-|-------------+---------------------------------|
-| ~SPC m c t~ | type check the current file     |
-| ~SPC m c T~ | type check all the open buffers |
+| Key Binding | Description                 |
+|-------------+-----------------------------|
+| ~SPC m c t~ | type check the current file |
 
 *** Debug
 
@@ -455,16 +454,13 @@ particular refactoring doesn't work.
 | Key Binding | Description                                        |
 |-------------+----------------------------------------------------|
 | ~SPC m e e~ | print error at point                               |
-| ~SPC m e l~ | show all errors and warnings                       |
 | ~SPC m e s~ | switch to buffer containing the stack trace parser |
 
 *** Goto
 
-| Key Binding | Description          |
-|-------------+----------------------|
-| ~SPC m g g~ | go to definition     |
-| ~SPC m g i~ | go to implementation |
-| ~SPC m g t~ | go to test           |
+| Key Binding | Description      |
+|-------------+------------------|
+| ~SPC m g g~ | go to definition |
 
 *** Print and yank types
 
@@ -480,9 +476,6 @@ particular refactoring doesn't work.
 |-------------+----------------------------------------|
 | ~SPC m h h~ | show documentation for symbol at point |
 | ~SPC m h u~ | show uses for symbol at point          |
-| ~SPC m i i~ | inspect type at point                  |
-| ~SPC m i I~ | inspect type in other frame            |
-| ~SPC m i p~ | inspect project package                |
 
 *** Server
 
@@ -497,7 +490,6 @@ particular refactoring doesn't work.
 | Key Binding | Description                                                          |
 |-------------+----------------------------------------------------------------------|
 | ~SPC m r a~ | add type annotation                                                  |
-| ~SPC m r f~ | format source                                                        |
 | ~SPC m r d~ | get rid of an intermediate variable (=ensime-refactor-inline-local=) |
 | ~SPC m r D~ | get rid of an intermediate variable (=ensime-undo-peek=)             |
 | ~SPC m r i~ | organize imports                                                     |

--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -169,12 +169,12 @@
 (defun spacemacs/ensime-yank-type-at-point ()
   "Yank to kill ring and print short type name at point to the minibuffer."
   (interactive)
-  (ensime-type-at-point t nil))
+  (ensime-type-at-point '(4)))
 
 (defun spacemacs/ensime-yank-type-at-point-full-name ()
   "Yank to kill ring and print full type name at point to the minibuffer."
   (interactive)
-  (ensime-type-at-point t t))
+  (ensime-type-at-point '(4) t))
 
 
 ;; eclim

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -198,7 +198,6 @@
           "br"     'ensime-sbt-do-run
 
           "ct"     'ensime-typecheck-current-buffer
-          "cT"     'ensime-typecheck-all
 
           "dA"     'ensime-db-attach
           "db"     'ensime-db-set-break
@@ -218,26 +217,18 @@
           "Ds"     'ensime
 
           "Ee"     'ensime-print-errors-at-point
-          "El"     'ensime-show-all-errors-and-warnings
           "Es"     'ensime-stacktrace-switch
 
           "gp"     'ensime-pop-find-definition-stack
-          "gi"     'ensime-goto-impl
-          "gt"     'ensime-goto-test
 
           "hh"     'ensime-show-doc-for-symbol-at-point
           "hT"     'ensime-type-at-point-full-name
           "ht"     'ensime-type-at-point
           "hu"     'ensime-show-uses-of-symbol-at-point
 
-          "ii"     'ensime-inspect-type-at-point
-          "iI"     'ensime-inspect-type-at-point-other-frame
-          "ip"     'ensime-inspect-project-package
-
           "ra"     'ensime-refactor-add-type-annotation
           "rd"     'ensime-refactor-diff-inline-local
           "rD"     'ensime-undo-peek
-          "rf"     'ensime-format-source
           "ri"     'ensime-refactor-diff-organize-imports
           "rm"     'ensime-refactor-diff-extract-method
           "rr"     'ensime-refactor-diff-rename


### PR DESCRIPTION
A bunch of functions were removed from https://github.com/ensime/ensime-emacs/ but Spacemacs still has keybindings for those. This PR removes those. 
Included is a fix to `spacemacs/ensime-yank-type-at-point`.