### PR TITLE
Fix the projectile layer

### DIFF
--- a/layers/+spacemacs/spacemacs-project/packages.el
+++ b/layers/+spacemacs/spacemacs-project/packages.el
@@ -82,5 +82,5 @@
         "pv" 'projectile-vc))
     :config
     (progn
-      (projectile-global-mode)
+      (projectile-mode)
       (spacemacs|hide-lighter projectile-mode))))


### PR DESCRIPTION
The projectile layer is broken with the newest projectile-mode. This PR addresses the issue with projectile-global-mode variable not found.