### PR TITLE
Fix and rename column-indexing toggle

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -366,10 +366,11 @@
   :mode font-lock-mode
   :documentation "Toggle syntax highlighting."
   :evil-leader "ths")
-(spacemacs|add-toggle column-indexing
-  :documentation "Toggle column indexing starting at 1."
-  :on (setq column-number-indicator-zero-based nil)
-  :off (setq column-number-indicator-zero-based t)
+(spacemacs|add-toggle zero-based-column-indexing
+  :documentation "Toggle column indexing starting at 0 versus 1."
+  :status (bound-and-true-p column-number-indicator-zero-based)
+  :on (setq column-number-indicator-zero-based t)
+  :off (setq column-number-indicator-zero-based nil)
   :evil-leader "tz")
 
 (spacemacs|add-toggle transparent-frame


### PR DESCRIPTION
The column-indexing toggle did not have a `:status` property.  As a result, the toggle command would enable the toggle but would not disable it.  In addition, the absence of `:status` prevented `-off` and `-on` commands from being defined.

This commit adds a `:status` property so that the toggle works properly and `-off` and `-on` commands are defined.

This commit also renames the toggle to `zero-based-column-indexing` in order to make its purpose clearer.

* `layers/+spacemacs/spacemacs-defaults/keybindings.el` (`column-indexing`): Add `:status` and rename to `zero-based-column-indexing`.