### PR TITLE
helm: Fix error from SPC s f on non-file buffers

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -444,9 +444,10 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
                     (helm-read-file-name
                      "Search in file(s): "
                      :marked-candidates t
-                     :preselect (if helm-ff-transformer-show-only-basename
-                                    (helm-basename preselection)
-                                  preselection)))))
+                     :preselect (when preselection
+                                  (if helm-ff-transformer-show-only-basename
+                                      (helm-basename preselection)
+                                    preselection))))))
     (helm-do-grep-1 targets nil nil nil nil use-region-or-symbol-p)))
 
 (defun spacemacs/helm-file-do-grep ()


### PR DESCRIPTION
Fix issue #6416: `SPC s f` (`spacemacs/helm-files-smart-do-search`) in a buffer that is not visiting a file causes an error:

    Wrong type argument: stringp, nil

* `layers/+completion/helm/funcs.el` (`spacemacs//helm-do-grep-region-or-symbol`): Check whether `preselection` is `nil` in order to avoid calling `helm-basename` on a nil value.