### PR TITLE
Clojure layer: fix regression for pinned cider

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -33,7 +33,7 @@
   "Insert FORM in the REPL buffer and eval it."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
-  (with-current-buffer (cider-current-repl)
+  (with-current-buffer (cider-current-connection)
     (let ((pt-max (point-max)))
       (goto-char pt-max)
       (insert form)


### PR DESCRIPTION
Fixes a regression I introduced in PR #10954 for people who have cider pinned to the stable version.

I made it use `cider-current-repl` since this is the new command, but I did not take into account the possibility of people still using cider 0.17.

In the commit where `cider-current-repl` was introduced, an alias `cider-current-connection` was also introduced to mantain backwards compatibility.
https://github.com/vspinu/cider/commit/24db03d135475c9f451ad1b7bbe16d3ec8ddfe3a#diff-1d74a90af3008c8072afc63f23ae8392