### PR TITLE
Fix key bindings for wgrep

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -99,7 +99,7 @@
 (defun spacemacs//counsel-edit ()
   "Edit the current search results in a buffer using wgrep."
   (interactive)
-  (run-with-idle-timer 0 nil 'ivy-wgrep-change-to-wgrep-mode)
+  (run-with-idle-timer 0 nil 'spacemacs/ivy-wgrep-change-to-wgrep-mode)
   (ivy-occur))
 
 (defun spacemacs//gne-init-counsel ()
@@ -322,6 +322,10 @@ To prevent this error we just wrap `describe-mode' to defeat the
                       (let ((repl (cdr (assoc candidate spacemacs-repl-list))))
                         (require (car repl))
                         (call-interactively (cdr repl))))))
+
+(defun spacemacs/ivy-wgrep-change-to-wgrep-mode ()
+  (ivy-wgrep-change-to-wgrep-mode)
+  (evil-normal-state))
 
 ;; Evil
 

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -203,7 +203,8 @@
       (ivy-set-occur 'spacemacs/counsel-search
                      'spacemacs//counsel-occur)
       (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
-        "w" 'ivy-wgrep-change-to-wgrep-mode)
+        "w" 'spacemacs/ivy-wgrep-change-to-wgrep-mode
+        "s" 'wgrep-save-all-buffers)
       ;; Why do we do this ?
       (ido-mode -1)
 


### PR DESCRIPTION
The problem was not with the existing bindings, but rather:

1. `C-x C-e` (`spacemacs//counsel-edit` -- from an ivy completion session) would
land you in an `ivy-occur` buffer with wgrep enabled but in motion state.  This
meant the spacemacs key bindings for wgrep were not available.  In particular,
the usual routine is:

* (enter ivy completion session, e.g. with `SPC s a P`)
* `C-c C-e`
* edit the buffer as needed
* `, ,` (`wgrep-finish-edit`)
* `, s` (`wgrep-save-all-buffers`)

2. That last binding (`, s`) was not there.

One issue is that `, s` is available before `wgrep-finish-edit` is called, which is
confusing because I don't think it has any useful function at that point in
time.