### PR TITLE
repair search highlighting (spacemacs/counsel-search)

### DIFF
--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -47,6 +47,10 @@ You can customize ivy with the following variables:
 - =ivy-height= The height of the minibuffer. The Spacemacs default is 15.
 - =ivy-use-selectable-prompt= When non-nil, make the prompt line selectable like
   a candidate. The Spacemacs default value is =t=.
+- =ivy-re-builders-alist= An alist of regex building functions for each collection function.
+  See ivy documentation for possible choices.
+  Use =spacemacs/ivy--regex-plus= instead of =ivy--regex-plus= to get correct highlighting
+  in the search results
 
 ** Advanced buffer information
 To display more information about buffers set the layer variable

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -121,6 +121,12 @@
     (define-key map (kbd "C-c C-e") 'spacemacs//counsel-edit)
     map))
 
+(defun spacemacs/ivy--regex-plus (str)
+  (if (and (memq (ivy-state-caller ivy-last) '(spacemacs/counsel-search))
+           (string-match-p " -- " str))
+      (ivy--regex-plus (car (last (split-string str " -- "))))
+    (ivy--regex-plus str)))
+
 ;; see `counsel-ag'
 (defun spacemacs/counsel-search
       (&optional tools use-initial-input initial-directory)

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -122,7 +122,7 @@
     map))
 
 (defun spacemacs/ivy--regex-plus (str)
-  (if (and (memq (ivy-state-caller ivy-last) '(spacemacs/counsel-search))
+  (if (and (eq (ivy-state-caller ivy-last) 'spacemacs/counsel-search)
            (string-match-p " -- " str))
       (ivy--regex-plus (car (last (split-string str " -- "))))
     (ivy--regex-plus str)))

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -122,6 +122,10 @@
     map))
 
 (defun spacemacs/ivy--regex-plus (str)
+  "spacemacs/ivy--regex-plus allows users to set ivy-re-builders-alist
+to ((t . spacemacs/ivy--regex-plus)), to build the search pattern and
+get correct highlighting in the search results with using
+spacemacs/counsel-search"
   (if (and (eq (ivy-state-caller ivy-last) 'spacemacs/counsel-search)
            (string-match-p " -- " str))
       (ivy--regex-plus (car (last (split-string str " -- "))))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -194,6 +194,9 @@
        'counsel-recentf
        spacemacs--ivy-file-actions)
 
+      ;; add spacemacs/counsel-search command to ivy-highlight-grep-commands
+      (cl-pushnew #'spacemacs/counsel-search ivy-highlight-grep-commands)
+
       ;; mappings to quit minibuffer or enter transient state
       (define-key ivy-minibuffer-map [escape] 'minibuffer-keyboard-quit)
       (define-key ivy-minibuffer-map (kbd "M-SPC") 'hydra-ivy/body)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -195,7 +195,7 @@
        spacemacs--ivy-file-actions)
 
       ;; add spacemacs/counsel-search command to ivy-highlight-grep-commands
-      (cl-pushnew #'spacemacs/counsel-search ivy-highlight-grep-commands)
+      (add-to-list 'ivy-highlight-grep-commands 'spacemacs/counsel-search)
 
       ;; mappings to quit minibuffer or enter transient state
       (define-key ivy-minibuffer-map [escape] 'minibuffer-keyboard-quit)


### PR DESCRIPTION
Repair search highlighting (spacemacs/counsel-search) with ivy--regex-plus by replaced it with spacemacs/ivy--regex-plus

bug with search highlighting when using extra arguments for searching using ivy--regex-plus
![2018-07-13_09-02-55](https://user-images.githubusercontent.com/13849413/42675316-2b987886-867c-11e8-81db-847b14b0bea9.png)

after fixing
![2018-07-13_09-10-09](https://user-images.githubusercontent.com/13849413/42675402-923c2f38-867c-11e8-9395-d56038aa8080.png)
