### PR TITLE
Update obsolete `cider-refresh` alias to `cider-ns-refresh`

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -131,7 +131,7 @@
             "ss" (if (eq m 'cider-repl-mode)
                      'cider-switch-to-last-clojure-buffer
                    'cider-switch-to-repl-buffer)
-            "sx" 'cider-refresh
+            "sx" 'cider-ns-refresh
             "sX" 'cider-restart
 
             "Te" 'cider-enlighten-mode


### PR DESCRIPTION
`cider-refresh` is an obsolete alias:

https://github.com/clojure-emacs/cider/blob/8b8309d9702a98dbfb1804de3d643b36b188057b/cider-ns.el#L204