### PR TITLE
clojure: Fix face name of fancified symbols

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -13,15 +13,15 @@
   "Pretty symbols for Clojure's anonymous functions and sets,
    like (λ [a] (+ a 5)), ƒ(+ % 5), and ∈{2 4 6}."
   (font-lock-add-keywords mode
-    `(("(\\(fn\\)[\[[:space:]]"
+    `(("(\\(fn\\)[[[:space:]]"
        (0 (progn (compose-region (match-beginning 1)
                                  (match-end 1) "λ")
                  nil)))
-      ("(\\(partial\\)[\[[:space:]]"
+      ("(\\(partial\\)[[[:space:]]"
        (0 (progn (compose-region (match-beginning 1)
                                  (match-end 1) "Ƥ")
                  nil)))
-      ("(\\(comp\\)[\[[:space:]]"
+      ("(\\(comp\\)[[[:space:]]"
        (0 (progn (compose-region (match-beginning 1)
                                  (match-end 1) "∘")
                  nil)))

--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -15,19 +15,24 @@
   (font-lock-add-keywords mode
     `(("(\\(fn\\)[\[[:space:]]"
        (0 (progn (compose-region (match-beginning 1)
-                                 (match-end 1) "λ"))))
+                                 (match-end 1) "λ")
+                 nil)))
       ("(\\(partial\\)[\[[:space:]]"
        (0 (progn (compose-region (match-beginning 1)
-                                 (match-end 1) "Ƥ"))))
+                                 (match-end 1) "Ƥ")
+                 nil)))
       ("(\\(comp\\)[\[[:space:]]"
        (0 (progn (compose-region (match-beginning 1)
-                                 (match-end 1) "∘"))))
+                                 (match-end 1) "∘")
+                 nil)))
       ("\\(#\\)("
        (0 (progn (compose-region (match-beginning 1)
-                                 (match-end 1) "ƒ"))))
+                                 (match-end 1) "ƒ")
+                 nil)))
       ("\\(#\\){"
        (0 (progn (compose-region (match-beginning 1)
-                                 (match-end 1) "∈")))))))
+                                 (match-end 1) "∈")
+                 nil))))))
 
 (defun spacemacs//cider-eval-in-repl-no-focus (form)
   "Insert FORM in the REPL buffer and eval it."


### PR DESCRIPTION
### clojure: Fix face name of fancified symbols

Fix issue #9271: Setting `clojure-enable-fancify-symbols` to `t` causes the following to the be printed repeatedly in the message buffer:

    invalid face reference: t

The problem is that the `clojure/fancify-symbols` function adds font-lock keywords with highlight forms containing face-name expressions that evaluate to the return value of `compose-region`, which apparently is `t`; this value is interpreted as a face name.

The solution to this problem is that the face-name expressions should evaluate to `nil`, which will be interpreted as an empty list of properties instead of a face name.

* `layers/+lang/clojure/funcs.el` (`clojure/fancify-symbols`): Define keywords using face-name expressions that evaluate to `nil`.

### clojure: Delete bogus escaping in font-lock regexps

* `layers/+lang/clojure/funcs.el` (`clojure/fancify-symbols`): Delete bogus backslashes.