### PR TITLE
Maximized windows now restore when neotree is active.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -65,6 +65,7 @@ This file containes the change log for the next major version of Spacemacs.
   the =*Messages*= buffer in another window (thanks to deb0ch)
 *** Core changes
 - 39667d3 | * Don't suggest `SPC q r` if restart-emacs is missing (Keshav Kini)
+- Fix maximizing/restoring a window when neotree is active (only affects emacs >= 26).
 *** Distribution changes
 - Enable =evil-search= search module in evil state.
 - Partially tame =exec-path-from-shell= (Steven Allen):

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -106,9 +106,14 @@ automatically applied to."
 (defun spacemacs/toggle-maximize-buffer ()
   "Maximize buffer"
   (interactive)
-  (if (and (= 1 (length (window-list)))
-           (assoc ?_ register-alist))
-      (jump-to-register ?_)
+  (if (let ((window-count (length (window-list))))
+        (and
+         (or ( = 1 window-count)
+             (and
+              ( = 2 window-count)
+              (neo-global--window-exists-p)))
+         (assoc ?_ register-alist)))
+      (jump-to-register ?_) ;; This will restore neotree state as well.
     (progn
       (window-configuration-to-register ?_)
       (delete-other-windows))))
@@ -1459,4 +1464,3 @@ Decision is based on `dotspacemacs-line-numbers'."
           enabled-for-parent            ; mode is one of default allowed modes
           disabled-for-modes
           (not disabled-for-parent)))))
-


### PR DESCRIPTION
This fixes #8107. It's worth noting this fix only has an effect in emacs >= 26, although it doesn't break anything in earlier versions. Looks like this is because `no-delete-other-windows` is not available in emacs < 26.
