### PR TITLE
Fix maximizing/restoring a window when neotree is active.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -65,6 +65,7 @@ This file containes the change log for the next major version of Spacemacs.
   the =*Messages*= buffer in another window (thanks to deb0ch)
 *** Core changes
 - 39667d3 | * Don't suggest `SPC q r` if restart-emacs is missing (Keshav Kini)
+- toggle-maximize-window now works with neotree, treemacs and frames
 *** Distribution changes
 - Enable =evil-search= search module in evil state.
 - Partially tame =exec-path-from-shell= (Steven Allen):

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -102,16 +102,19 @@ automatically applied to."
           (message "Indented buffer.")))
       (whitespace-cleanup))))
 
-;; from https://gist.github.com/3402786
 (defun spacemacs/toggle-maximize-buffer ()
   "Maximize buffer"
   (interactive)
-  (if (and (= 1 (length (window-list)))
-           (assoc ?_ register-alist))
-      (jump-to-register ?_)
+  (let ((starting-layout (current-window-configuration))
+        (window-count (length (window-list))))
     (progn
-      (window-configuration-to-register ?_)
-      (delete-other-windows))))
+      (funcall spacemacs-window-split-delete-function)
+      ;; Were we already maximized?
+      ;; We use window count in case window order has changed
+      (if (= window-count (length (window-list)))
+          (let ((saved-layout (frame-parameter nil 'spacemacs--saved-layout)))
+            (when saved-layout (set-window-configuration saved-layout)))
+        (set-frame-parameter nil 'spacemacs--saved-layout starting-layout)))))
 
 ;; https://tsdh.wordpress.com/2007/03/28/deleting-windows-vertically-or-horizontally/
 (defun spacemacs/maximize-horizontally ()
@@ -1459,4 +1462,3 @@ Decision is based on `dotspacemacs-line-numbers'."
           enabled-for-parent            ; mode is one of default allowed modes
           disabled-for-modes
           (not disabled-for-parent)))))
-


### PR DESCRIPTION
This fixes #8107. It's worth noting this fix only has an effect in emacs >= 26, although it doesn't break anything in earlier versions. In emacs < 26, maximize buffer closes the neotree window. Looks like this is because `no-delete-other-windows` is not available in emacs < 26.