### PR TITLE
Fix counsel-search

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -71,7 +71,7 @@
       (lambda (string &optional _pred &rest _unused)
         "Grep in the current directory for STRING."
         (if (< (length string) 3)
-            (counsel-more-chars 3)
+            (counsel-more-chars)
           (let* ((default-directory (ivy-state-directory ivy-last))
                  (args (if (string-match-p " -- " string)
                            (let ((split (split-string string " -- ")))


### PR DESCRIPTION
With recent ivy updates, counsel-search is broken. This should fix it.