### PR TITLE
python: Initialize inferior-python-mode variables

### DIFF
--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -51,3 +51,8 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
 
 (defvar spacemacs--python-pyvenv-modes nil
   "List of major modes where to add pyvenv support.")
+
+;; inferior-python-mode needs these variables to be defined.  The python
+;; package declares them but does not initialize them.
+(defvar python-shell--interpreter nil)
+(defvar python-shell--interpreter-args nil)


### PR DESCRIPTION
Fix <kbd>SPC m c c</kbd> (`spacemacs/python-execute-file`) and <kbd>SPC m c C</kbd> (`spacemacs/python-execute-file-focus`), which were causing the following errors:

    save-current-buffer: Symbol’s value as variable is void: python-shell--interpreter
    error in process filter: python-shell-comint-end-of-output-p: Wrong type argument: arrayp, nil
    error in process filter: Wrong type argument: arrayp, nil

This commit also fixes issue #9070: `spacemacs/python-execute-file-focus` does not change focus.

The problem is that `spacemacs/python-execute-file-focus` invokes `spacemacs/python-execute-file`, `spacemacs/python-execute-file` invokes `inferior-python-mode`, and `inferior-python-mode` uses the variables `python-shell--interpreter` and `python-shell--interpreter-args`, which the python package declares but does not initialize.

To resolve this problem, this commit initializes both variables to `nil`.

* `layers/+lang/python/config.el`: Initialize `python-shell--interpreter` and `python-shell--interpreter-args` to `nil`.
