### PR TITLE
Add keybindings for scrolling in epub layer

### DIFF
--- a/layers/+readers/epub/README.org
+++ b/layers/+readers/epub/README.org
@@ -36,6 +36,8 @@ file.
 | ~<BACKTAB>~ | Previous link       |
 | ~H~ or ~[~  | Previous chapter    |
 | ~L~ or ~]~  | Next chapter        |
+| ~u~         | Scroll up           |
+| ~d~         | Scroll down         |
 | ~g m~       | Display metadata    |
 | ~g r~       | Re-render document  |
 | ~g t~       | Table of contents   |

--- a/layers/+readers/epub/packages.el
+++ b/layers/+readers/epub/packages.el
@@ -23,6 +23,8 @@
       (kbd "L") 'nov-next-document
       (kbd "[") 'nov-previous-document
       (kbd "]") 'nov-next-document
+      (kbd "d") 'nov-scroll-up
+      (kbd "u") 'nov-scroll-down
       (kbd "gm") 'nov-display-metadata
       (kbd "gr") 'nov-render-document
       (kbd "gt") 'nov-goto-toc


### PR DESCRIPTION
Add `d` and `u` for scrolling down and up, just like the `pdf` layer.

Note that `up` is actually represented by `nov-scroll-down` and vice-versa (following `pdf` layer convention).