### PR TITLE
Use lexical binding in dotfile template

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -1,5 +1,4 @@
-;; -*- lexical-binding: t -*-
-;; -*- mode: emacs-lisp -*-
+;; -*- mode: emacs-lisp; lexical-binding: t -*-
 ;; This file is loaded by Spacemacs at startup.
 ;; It must be stored in your home directory.
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t -*-
 ;; -*- mode: emacs-lisp -*-
 ;; This file is loaded by Spacemacs at startup.
 ;; It must be stored in your home directory.


### PR DESCRIPTION
Lexical binding is easier to reason about and it's generally recommended for new code. It's faster too.

Dynamic scoping can lead to tricky situations. Example: https://emacs.stackexchange.com/questions/10394/scope-in-lambda

This probably won't break existing code. Most people don't even know the default is dynamic binding.