### PR TITLE
Fix smart-closing-parenthesis extra parenthesis

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing/funcs.el
@@ -22,14 +22,37 @@
   (indent-according-to-mode))
 
 (defun spacemacs/smart-closing-parenthesis ()
+  "Insert a closing pair delimiter or move point past existing delimiter.
+
+If the expression at point is already balanced and there is a
+closing delimiter for that expression on the current line, move
+point forward past the closing delimiter.
+
+If the expression is balanced but there is no closing delimiter
+on the current line, insert a literal ')' character.
+
+If the expression is not balanced, insert a closing delimiter for
+the current expression.
+
+This command uses Smartparens navigation commands and therefore
+recognizes pair delimiters that have been defined using `sp-pair'
+or `sp-local-pair'."
   (interactive)
   (let* ((sp-navigate-close-if-unbalanced t)
          (current-pos (point))
          (current-line (line-number-at-pos current-pos))
-         (next-pos (save-excursion
-                     (sp-up-sexp)
-                     (point)))
-         (next-line (line-number-at-pos next-pos)))
+         next-pos next-line)
+    (save-excursion
+      (let ((buffer-undo-list)
+            (modified (buffer-modified-p)))
+        (unwind-protect
+            (progn
+              (sp-up-sexp)
+              (setq next-pos (point)
+                    next-line (line-number-at-pos)))
+          (primitive-undo (length buffer-undo-list)
+                          buffer-undo-list)
+          (set-buffer-modified-p modified))))
     (cond
      ((and (= current-line next-line)
            (not (= current-pos next-pos)))


### PR DESCRIPTION
Fix issue #9477: `spacemacs/smart-closing-parenthesis` sometimes adds an extra closing parenthesis.

`spacemacs/smart-closing-parenthesis` may call `sp-up-sexp` twice: first to find the position of an existing closing delimiter or the position at which one would be inserted, and second to insert a delimiter if necessary or else move point after the existing closing delimiter.

The problem is that each call to `sp-up-sexp` may insert a delimiter, but `spacemacs/smart-closing-parenthesis` is supposed to insert at most one.

The solution is to undo any edit performed by the first call to `sp-up-sexp`.

* `layers/+spacemacs/spacemacs-editing/funcs.el`: Undo any edit performed by the first call to `sp-up-sexp`.

---

@StreakyCobra, does this change look correct?