### PR TITLE
[tiny pr] binds flycheck-copy-errors-as-kill to `SPC e y`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3344,6 +3344,7 @@ Errors management commands (start with ~e~):
 | ~SPC e l~   | toggle the display of the =flycheck= list of errors/warnings          |
 | ~SPC e n~   | go to the next error                                                  |
 | ~SPC e p~   | go to the previous error                                              |
+| ~SPC e y~   | copy each error at cursor position into kill ring                     |
 | ~SPC e v~   | verify flycheck setup (useful to debug 3rd party tools configuration) |
 | ~SPC e .~   | error transient state                                                 |
 

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -37,6 +37,7 @@
         "es" 'flycheck-select-checker
         "eS" 'flycheck-set-checker-executable
         "ev" 'flycheck-verify-setup
+        "ey" 'flycheck-copy-errors-as-kill
         "ex" 'flycheck-explain-error-at-point)
       (spacemacs|add-toggle syntax-checking
         :mode flycheck-mode


### PR DESCRIPTION
I find `flycheck-copy-errors-as-kill` quite handy when I want to google for certain error, would you welcome to bind this function to `spc e k`?