### PR TITLE
shell: Adjust popup shell width only for left/right

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -49,10 +49,11 @@
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 
 (defun spacemacs/resize-shell-to-desired-width ()
-  (if (string= (buffer-name) shell-pop-last-shell-buffer-name)
-  (enlarge-window-horizontally (-
-                                (/ (* (frame-width) shell-default-width) 100)
-                                (window-width)))))
+  (when (and (string= (buffer-name) shell-pop-last-shell-buffer-name)
+             (memq shell-pop-window-position '(left right)))
+    (enlarge-window-horizontally (- (/ (* (frame-width) shell-default-width)
+                                       100)
+                                    (window-width)))))
 
 (defmacro make-shell-pop-command (func &optional shell)
   "Create a function to open a shell via the function FUNC.


### PR DESCRIPTION
Fix issue #11037: Do not adjust the width of a popup shell's window unless its position is left or right.

* `layers/+tools/shell/funcs.el`: Check that `shell-pop-window-position` is `'left` or `'right` before adjusting the window's width.