### PR TITLE
Fix font loading issue on first instance of emacsclient

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -115,8 +115,8 @@ the final step of executing code in `emacs-startup-hook'.")
    ;; emacsclient, at least if different than their system font. You don't
    ;; believe me? Go ahead, try it. After you'll have notice that this was true,
    ;; increase the counter bellow so next people will give it more confidence.
-   ;; Counter = 1
-   (spacemacs-buffer/message "Setting the font...")
+   ;; Counter = 2
+   (message "Setting the font...")
    (unless (spacemacs/set-default-font dotspacemacs-default-font)
      (spacemacs-buffer/warning
       "Cannot find any of the specified fonts (%s)! Font settings may not be correct."


### PR DESCRIPTION
If you start an emacsclient when no frame is currently available, font loading
will not run without a call to message. Font setting will become correct when
the second emacsclient is started. This was discovered and fixed in commit
 #04267777, and was broken in commit #ac247396, where a call to message is
replaced with a call to spacemacs-buffer/message, which will only print this
message in debug mode.