### PR TITLE
Fix compilation finish hook

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -63,6 +63,9 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Scroll compilation to first error or end
 (setq compilation-scroll-output 'first-error)
 
+;; Print the key binding for spacemacs/next-error on errors.
+(add-hook 'compilation-finish-functions #'spacemacs/compilation-finish-function)
+
 ;; Don't try to ping things that look like domain names
 (setq ffap-machine-p-known 'reject)
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1217,7 +1217,9 @@ In case of errors, show the key binding for spacemacs/next-error."
             (string-match "FAILED" (buffer-string)))
 
         ;; there were errors
-        (message "There were errors. SPC-e-n to visit.")
+        (message "%s"
+                 (substitute-command-keys
+                  "There were errors. Use \\[spacemacs/next-error] to visit."))
       (unless (or (string-match "Grep finished" (buffer-string))
                   (string-match "Ag finished" (buffer-string))
                   (string-match "nosetests" (buffer-name)))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1210,22 +1210,14 @@ using a visual block/rectangle selection."
 
 ;; From http://xugx2007.blogspot.ca/2007/06/benjamin-rutts-emacs-c-development-tips.html
 (defun spacemacs/compilation-finish-function (buf str)
-  "Print a message indicating whether the compilation succeeded.
+  "Print a message if compilation encountered errors.
 In case of errors, show the key binding for spacemacs/next-error."
   (let ((case-fold-search nil))
-    (if (or (string-match "exited abnormally" str)
-            (string-match "FAILED" (buffer-string)))
-
-        ;; there were errors
-        (message "%s"
-                 (substitute-command-keys
-                  "There were errors. Use \\[spacemacs/next-error] to visit."))
-      (unless (or (string-match "Grep finished" (buffer-string))
-                  (string-match "Ag finished" (buffer-string))
-                  (string-match "nosetests" (buffer-name)))
-
-        ;; no errors
-        (message "compilation ok.")))))
+    (when (or (string-match "exited abnormally" str)
+              (string-match "FAILED" (buffer-string)))
+      (message "%s"
+               (substitute-command-keys
+                "There were errors. Use \\[spacemacs/next-error] to visit.")))))
 
 ;; from http://www.emacswiki.org/emacs/WordCount
 (defun spacemacs/count-words-analysis (start end)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1209,21 +1209,21 @@ using a visual block/rectangle selection."
 ;; END linum mouse helpers
 
 ;; From http://xugx2007.blogspot.ca/2007/06/benjamin-rutts-emacs-c-development-tips.html
-(setq compilation-finish-function
-      (lambda (buf str)
+(defun spacemacs/compilation-finish-function (buf str)
+  "Print a message indicating whether the compilation succeeded.
+In case of errors, show the key binding for spacemacs/next-error."
+  (let ((case-fold-search nil))
+    (if (or (string-match "exited abnormally" str)
+            (string-match "FAILED" (buffer-string)))
 
-        (let ((case-fold-search nil))
-          (if (or (string-match "exited abnormally" str)
-                  (string-match "FAILED" (buffer-string)))
+        ;; there were errors
+        (message "There were errors. SPC-e-n to visit.")
+      (unless (or (string-match "Grep finished" (buffer-string))
+                  (string-match "Ag finished" (buffer-string))
+                  (string-match "nosetests" (buffer-name)))
 
-              ;; there were errors
-              (message "There were errors. SPC-e-n to visit.")
-            (unless (or (string-match "Grep finished" (buffer-string))
-                        (string-match "Ag finished" (buffer-string))
-                        (string-match "nosetests" (buffer-name)))
-
-              ;; no errors
-              (message "compilation ok."))))))
+        ;; no errors
+        (message "compilation ok.")))))
 
 ;; from http://www.emacswiki.org/emacs/WordCount
 (defun spacemacs/count-words-analysis (start end)


### PR DESCRIPTION
#### Fix compilation finish hook

Use `compilation-finish-functions` instead of `compilation-finish-function`.

Spacemacs assigns an anonymous function to the `compilation-finish-function` variable, which was deprecated in Emacs 22.1 and removed in Emacs 27.1 in favor of the `compilation-finish-functions` hook.  This commit deletes this assignment, replaces the anonymous function with a named function, and adds the newly named function to `compilation-finish-functions`.

* `layers/+spacemacs/spacemacs-defaults/funcs.el` (`compilation-finish-function`): Delete assignment of an anonymous function.
(`spacemacs/compilation-finish-function`): New defun based on the old anonymous function.
* `layers/+spacemacs/spacemacs-defaults/config.el` (`compilation-finish-functions`): Add `spacemacs/compilation-finish-function`.

#### Avoid hardcoded key binding in compilation message

* `layers/+spacemacs/spacemacs-defaults/funcs.el` (`spacemacs/compilation-finish-function`): Use `substitute-command-keys` to replace the hardcoded key binding in the message that is printed when there are errors.

#### Delete redundant "compilation ok" message

The compile command already prints "Compilation finished" if there are no errors.

* `layers/+spacemacs/spacemacs-defaults/funcs.el` (`spacemacs/compilation-finish-function`): Delete "compilation ok" message.

---

Really, the compilation finish hook does not seem especially useful—all it adds is printing the key binding for `spacemacs/next-error`, and it prevents the echo line from showing the default output.  For example, my `*Messages*` buffer shows the following after I enter `:make false`:

    Compilation exited abnormally with code 1
    There were errors. Use SPC e n to visit.

Because Spacemacs prints its "There were errors" message immediately after Emacs prints its "Compilation exited abnormally" message, the latter is obscured.

Do we want to keep this hook at all?