### PR TITLE
Clojure layer: Rename cider-refresh to cider-ns-refresh

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -131,7 +131,7 @@
             "ss" (if (eq m 'cider-repl-mode)
                      'cider-switch-to-last-clojure-buffer
                    'cider-switch-to-repl-buffer)
-            "sx" 'cider-refresh
+            "sx" 'cider-ns-refresh
             "sX" 'cider-restart
 
             "Te" 'cider-enlighten-mode


### PR DESCRIPTION
.. it has been renamed on cider's `master` (see [changelog](https://github.com/clojure-emacs/cider/blob/4b7aea3523fb91e8172dfdd538b01da8c0d7686f/CHANGELOG.md#changes))