### PR TITLE
Fix loading of Magithub

### DIFF
--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -81,7 +81,6 @@
 
 (defun github/init-magithub ()
   (use-package magithub
-    :defer t
     :after magit
     :init
     (setq magithub-dir (concat spacemacs-cache-directory "magithub/"))


### PR DESCRIPTION
Fix issue #10760: Magithub sections are not added to Magit.

The problem is that the Spacemacs init function's `use-package` form for Magithub specifies both `:after magit` and `:defer t`. It should specify only the former so that Magithub will be loaded when Magit is loaded.

* `layers/+source-control/github/packages.el`: (`github/init-magithub`) Delete `:defer` argument.