### PR TITLE
markdown: Update key bindings for Markdown Mode 2.3

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -103,13 +103,11 @@ To generate a table of contents type on top of the buffer:
 | ~SPC m h 6~ | insert header atx 6                                               |
 | ~SPC m h !~ | insert header setext 1                                            |
 | ~SPC m h @~ | insert header setext 2                                            |
-| ~SPC m i l~ | insert inline link dwim                                           |
-| ~SPC m i L~ | insert reference link dwim                                        |
+| ~SPC m i l~ | insert link                                                       |
 | ~SPC m i u~ | insert uri                                                        |
 | ~SPC m i f~ | insert footnote                                                   |
 | ~SPC m i w~ | insert wiki link                                                  |
 | ~SPC m i i~ | insert image                                                      |
-| ~SPC m i I~ | insert reference image                                            |
 | ~SPC m i t~ | insert Table of Contents (toc)                                    |
 | ~SPC m x b~ | make region bold or insert bold                                   |
 | ~SPC m x i~ | make region italic or insert italic                               |
@@ -137,14 +135,14 @@ To generate a table of contents type on top of the buffer:
 | Key Binding | Description           |
 |-------------+-----------------------|
 | ~SPC m o~   | follow thing at point |
-| ~SPC m j~   | jump                  |
+| ~RET~       | jump (markdown-do)    |
 
 ** Indentation
 
-| Key Binding | Description   |
-|-------------+---------------|
-| ~SPC m \>~  | indent region |
-| ~SPC m \<~  | exdent region |
+| Key Binding | Description    |
+|-------------+----------------|
+| ~SPC m \>~  | indent region  |
+| ~SPC m \<~  | outdent region |
 
 ** Header navigation
 
@@ -201,5 +199,6 @@ To generate a table of contents type on top of the buffer:
 |-------------+----------------------|
 | ~SPC m t i~ | toggle inline images |
 | ~SPC m t l~ | toggle hidden urls   |
+| ~SPC m t m~ | toggle markup hiding |
 | ~SPC m t t~ | toggle checkbox      |
 | ~SPC m t w~ | toggle wiki links    |

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -77,7 +77,7 @@
           "]"   'markdown-complete
           ;; Indentation
           ">"   'markdown-indent-region
-          "<"   'markdown-exdent-region
+          "<"   'markdown-outdent-region
           ;; Buffer-wide commands
           "c]"  'markdown-complete-buffer
           "cc"  'markdown-check-refs
@@ -104,9 +104,7 @@
           "if"  'markdown-insert-footnote
           "ii"  'markdown-insert-image
           "ik"  'spacemacs/insert-keybinding-markdown
-          "iI"  'markdown-insert-reference-image
-          "il"  'markdown-insert-inline-link-dwim
-          "iL"  'markdown-insert-reference-link-dwim
+          "il"  'markdown-insert-link
           "iw"  'markdown-insert-wiki-link
           "iu"  'markdown-insert-uri
           ;; Element removal
@@ -115,6 +113,7 @@
           "li"  'markdown-insert-list-item
           ;; Toggles
           "ti"  'markdown-toggle-inline-images
+          "tm"  'markdown-toggle-markup-hiding
           "tl"  'markdown-toggle-url-hiding
           "tt"  'markdown-toggle-gfm-checkbox
           "tw"  'markdown-toggle-wiki-links
@@ -131,7 +130,7 @@
           "N"   'markdown-next-link
           "f"   'markdown-follow-thing-at-point
           "P"   'markdown-previous-link
-          "<RET>" 'markdown-jump)
+          "<RET>" 'markdown-do)
         (when (eq 'eww markdown-live-preview-engine)
           (spacemacs/set-leader-keys-for-major-mode mode
             "cP" 'markdown-live-preview-mode)))


### PR DESCRIPTION
Update key bindings to reflect some changes in Markdown Mode 2.3:

* `markdown-exdent-region` was renamed to `markdown-outdent-region`.
* `markdown-insert-reference-image` (<kbd>SPC m i I</kbd>) was folded into `markdown-insert-image` (<kbd>SPC m i i</kbd>).
* `markdown-insert-inline-link-dwim` (<kbd>SPC m i l</kbd>) and `markdown-insert-reference-link-dwim` (<kbd>SPC m i L</kbd>) were replaced by `markdown-insert-link` (<kbd>SPC m i l</kbd>).
* `markdown-toggle-markup-hiding` (<kbd>SPC m t m</kbd>) was added.
* `markdown-jump` (<kbd>SPC m RET</kbd>) was replaced by `markdown-do` (same).

Note that the documentation listed an incorrect key binding for `markdown-jump`; this has been corrected.

* `layers/+lang/markdown/packages.el` (`markdown/init-markdown-mode`):
* `layers/+lang/markdown/README.org`: Update key bindings.
