### PR TITLE
Go: Add toggle to disable gofmt before save

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -22,7 +22,7 @@
 This layer adds extensive support for go to Spacemacs.
 
 ** Features:
-- gofmt/goimports on file save
+- gofmt/goimports on file save (to enable, see [[#configuration][Configuration]])
 - Auto-completion using [[https://github.com/nsf/gocode/tree/master/emacs][go-autocomplete]] (with the =auto-completion= layer)
 - Source analysis using [[https://docs.google.com/document/d/1_Y9xCEMj5S-7rv2ooHpZNH15JgRT5iM742gJkw5LtmQ][go-guru]]
 - Refactoring with [[http://gorefactor.org/][godoctor]]
@@ -93,8 +93,13 @@ add =go= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 * Configuration
-By default, go buffers are run through =gofmt= on save. To use a different
-formatter, set the value of =gofmt-command=, e.g.
+To run =gofmt= before save, set the value to a non-nil, e.g.
+
+#+begin_src emacs-lisp
+  (setq go-format-before-save t)
+#+end_src
+
+To use a different formatter, set the value of =gofmt-command=, e.g.
 
 #+begin_src emacs-lisp
   (setq gofmt-command "goimports")

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -16,6 +16,9 @@
 (defvar go-use-gocheck-for-testing nil
   "If using gocheck for testing when running the tests -check.f will be used instead of -run to specify the test that will be ran. Gocheck is mandatory for testing suites.")
 
+(defvar go-format-before-save nil
+  "Use gofmt before save. Set to non-nil to enable gofmt before saving. Default is nil.")
+
 (defvar go-tab-width 8
   "Set the `tab-width' in Go mode. Default is 8.")
 

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -111,7 +111,8 @@
       (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width))
     :config
     (progn
-      (add-hook 'before-save-hook 'gofmt-before-save)
+      (when go-format-before-save
+        (add-hook 'before-save-hook 'gofmt-before-save))
       (spacemacs/declare-prefix-for-mode 'go-mode "me" "playground")
       (spacemacs/declare-prefix-for-mode 'go-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'go-mode "mh" "help")


### PR DESCRIPTION
I added a toggle to disable `gofmt` before saving a file. I set the default to on / true.

**Reason:**
I configured my editor to save on certain commands such as exiting from Evil/Vi Insert Mode. Because of this, `gofmt` is very intrusive.