### PR TITLE
Go: Add key binding to run gofmt manually

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -177,6 +177,7 @@ You have a few options to ensure you always get up to date suggestions:
 
 | Key Binding   | Description                                                                           |
 |---------------+---------------------------------------------------------------------------------------|
+| ~SPC m =  ~   | run "go fmt"                                                                          |
 | ~SPC m e b~   | go-play buffer                                                                        |
 | ~SPC m e d~   | download go-play snippet                                                              |
 | ~SPC m e r~   | go-play region                                                                        |

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -120,6 +120,7 @@
       (spacemacs/declare-prefix-for-mode 'go-mode "mt" "test")
       (spacemacs/declare-prefix-for-mode 'go-mode "mx" "execute")
       (spacemacs/set-leader-keys-for-major-mode 'go-mode
+        "="  'gofmt
         "eb" 'go-play-buffer
         "ed" 'go-download-play
         "er" 'go-play-region


### PR DESCRIPTION
This adds a key binding `SPC m =` to manually run the formatter (just like in Rust layer).

**Reason:**
After https://github.com/syl20bnr/spacemacs/pull/11082 has been merged (which disables `gofmt` before save), I'd like to have a key binding to run `gofmt` manually.