### PR TITLE
Mark alchemist jump handler as async

### DIFF
--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -41,7 +41,7 @@
       (setq alchemist-project-compile-when-needed t
             alchemist-test-status-modeline nil)
       (add-to-list 'spacemacs-jump-handlers-elixir-mode
-                'alchemist-goto-definition-at-point))
+                '(alchemist-goto-definition-at-point :async t)))
     :config
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mX" "hex")
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mc" "compile")


### PR DESCRIPTION
Right now `alchemist-goto-definition-at-point` is marked as sync, which
sometimes shows message "No jump handler was able to find this symbol." before jumping to correct definition.

[`alchemist-goto--open-definition`](https://github.com/tonini/alchemist.el/blob/master/alchemist-goto.el#L215) calls alchemist server before jumping to definition, which I think justifies marking this as async.

The downside is that next jump handler won't ever be called if alchemist fails to jump.

I have very little experience with either Emacs, or Spacemacs, so let me
know if there's anything I can clarify and/or test before this commit gets
merged :)