### PR TITLE
Open javascript files in js2 mode

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -57,7 +57,8 @@
     ;; enable rjsx mode by using magic-mode-alist
     (defun +javascript-jsx-file-p ()
       (and buffer-file-name
-           (equal (file-name-extension buffer-file-name) "js")
+           (or (equal (file-name-extension buffer-file-name) "js")
+               (equal (file-name-extension buffer-file-name) "jsx"))
            (re-search-forward "\\(^\\s-*import React\\|\\( from \\|require(\\)[\"']react\\)"
                               magic-mode-regexp-match-limit t)
            (progn (goto-char (match-beginning 1))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -75,7 +75,7 @@
 (defun javascript/init-js2-mode ()
   (use-package js2-mode
     :defer t
-    :mode "\\.m?js\\'"
+    :mode (("\\.m?js\\'"  . js2-mode) ("\\.jsx\\'" . js2-mode))
     :init
     (progn
       (add-hook 'js2-mode-local-vars-hook


### PR DESCRIPTION
The javascript layer configures a lot of things for js2-mode, but as it doesn't change the default mode for js files none of it is effective when just activating the layer. And as it is not documented, some research is necessary to benefit the features, more or less painful according to your proficiency with (spac)emacs, that more or less users will have the courage to go through.

I also included `.jsx` files, as it is a common extension for javascript files when using React. It is the recommended extension in the Airbnb coding style, the seemingly most widely adopted coding style among the Javascript community.