### PR TITLE
Add indent toggle to sql-model

### DIFF
--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -9,6 +9,7 @@
   - [[#sql-keywords-capitalization][SQL Keywords Capitalization]]
     - [[#sql-interactive-mode][SQL Interactive Mode]]
     - [[#blacklisting-keywords][Blacklisting keywords]]
+  - [[#auto-indent][Auto-Indent]]
 - [[#key-bindings][Key bindings]]
   - [[#highlighting][Highlighting]]
   - [[#inferior-process-interactions-sqli][Inferior Process Interactions (SQLi)]]
@@ -83,6 +84,16 @@ a list with keywords to ignore, e.g.
 
 This layer is blacklisting =name= by default as it is a very common name for
 column and NAME is non-reserved SQL keyword.
+
+** Auto-Indent
+This mode use [[https://github.com/alex-hhh/emacs-sql-indent][sql-indent]] to indent the code. You can check the package's README
+to adjust the rules. If that's not what you want, you can also disable
+auto-indent by setting the variable =sql-auto-indent= to =nil=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (sql :variables sql-auto-indent nil)))
+#+END_SRC
 
 * Key bindings
 ** Highlighting

--- a/layers/+lang/sql/config.el
+++ b/layers/+lang/sql/config.el
@@ -17,3 +17,6 @@
 
 (defvar sql-capitalize-keywords-blacklist '("name")
   "List of keywords to ignore during capitalization.")
+
+(defvar sql-auto-indent t
+  "If non nil use sql-indent.")

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -134,6 +134,7 @@
 
 (defun sql/init-sql-indent ()
   (use-package sql-indent
+    :if sql-auto-indent
     :defer t
     :init (add-hook 'sql-mode-hook 'sqlind-minor-mode)
     :config (spacemacs|hide-lighter sqlind-minor-mode)))


### PR DESCRIPTION
ref #11108 

This PR adds a variable `sql-auto-indent` to enable/disable the use of `sql-indent` in **sql-mode**, with a brief documentation.