### PR TITLE
spacemacs-defaults: add a keybind for `find-alternate-file`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2369,6 +2369,7 @@ Files manipulation commands (start with ~f~):
 
 | Key Binding | Description                                                                                            |
 |-------------+--------------------------------------------------------------------------------------------------------|
+| ~SPC f a~   | open a file and replace the current buffer with the new file                                           |
 | ~SPC f b~   | go to file bookmarks                                                                                   |
 | ~SPC f c~   | copy current file to a different location                                                              |
 | ~SPC f C d~ | convert file from unix to dos encoding                                                                 |

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -100,6 +100,7 @@ automatically applied to."
 (defalias 'spacemacs/switch-to-buffer-other-frame 'switch-to-buffer-other-frame)
 (defalias 'spacemacs/insert-file 'insert-file)
 (defalias 'spacemacs/display-buffer-other-frame 'display-buffer-other-frame)
+(defalias 'spacemacs/find-file-and-replace-buffer 'find-alternate-file)
 
 (defun spacemacs/indent-region-or-buffer ()
   "Indent a region if selected, otherwise the whole buffer."

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -200,6 +200,7 @@
   :evil-leader "e.")
 ;; file -----------------------------------------------------------------------
 (spacemacs/set-leader-keys
+  "fa" 'spacemacs/find-file-and-replace-buffer
   "fc" 'spacemacs/copy-file
   "fD" 'spacemacs/delete-current-buffer-file
   "fei" 'spacemacs/find-user-init-file


### PR DESCRIPTION
The function is useful when you mistakenly open a wrong file and want to open a correct one while closing the wrong one. The function is also sometimes recommended to "reload" a file. So let's add a shortcut for the function.

Note: The function is bound to `C-x C-v` by default, but I would like to have it in the leader key menu to make it discoverable and easier to type.