### PR TITLE
html: fix indenting for emacs editing style

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -96,8 +96,6 @@
     (progn
       (evil-define-key 'insert emmet-mode-keymap (kbd "TAB") 'spacemacs/emmet-expand)
       (evil-define-key 'insert emmet-mode-keymap (kbd "<tab>") 'spacemacs/emmet-expand)
-      (evil-define-key 'emacs emmet-mode-keymap (kbd "TAB") 'spacemacs/emmet-expand)
-      (evil-define-key 'emacs emmet-mode-keymap (kbd "<tab>") 'spacemacs/emmet-expand)
       (evil-define-key 'hybrid emmet-mode-keymap (kbd "TAB") 'spacemacs/emmet-expand)
       (evil-define-key 'hybrid emmet-mode-keymap (kbd "<tab>") 'spacemacs/emmet-expand)
       (spacemacs|hide-lighter emmet-mode))))


### PR DESCRIPTION
When using Emacs style you use tab to indent. This binding in the html-layer make's tab either expand text or do nothing when editing html or jsx (React) code. I think using C-j (the default) for emmet is fine for Emacs style and the html-layer even links to the emmet documentation that says that C-j is used for expansion.