### PR TITLE
lang/coq: more insertion keybindings

### DIFF
--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -102,9 +102,15 @@ The mnemonic for =a= is "ask".
 |-----------------+-----------------------------------------------------------------|
 | ~SPC m M-RET~   | Insert regular match branch                                     |
 | ~SPC m M-S-RET~ | Insert =match goal with= branch                                 |
+| ~SPC m i c~     | Insert a vernacular command                                     |
 | ~SPC m i e~     | Insert =End <section-name>=                                     |
+| ~SPC m i i~     | Insert =intros= with default variable names                     |
 | ~SPC m i l~     | Extract lemma from current goal - exit with ~C-RET~ (not ~C-j~) |
 | ~SPC m i m~     | Insert =match= on a type                                        |
+| ~SPC m i r~     | Insert a =Require= statement                                    |
+| ~SPC m i s~     | Insert a =Section= or =Module=                                  |
+| ~SPC m i t~     | Insert a tactic                                                 |
+| ~SPC m i T~     | Insert a tactical                                               |
 
 Note the last two are regular =company-coq= bindings, left alone since they are
 most useful in insert mode. The full =company-coq= tutorial showcasing all

--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -95,7 +95,13 @@
         "gl" 'proof-goto-end-of-locked
         "gs" 'proof-goto-command-start
         ;; Insertions
-        "ie" 'coq-end-Section))))
+        "ic" 'coq-insert-command
+        "ie" 'coq-end-Section
+        "ii" 'coq-insert-intros
+        "ir" 'coq-insert-requires
+        "is" 'coq-insert-section-or-module
+        "it" 'coq-insert-tactic
+        "iT" 'coq-insert-tactical))))
 
 (defun coq/post-init-smartparens ()
   (spacemacs/add-to-hooks (if dotspacemacs-smartparens-strict-mode


### PR DESCRIPTION
Just some extra keybindings! The `mi` prefix is a bit bare right now, and these functions can speed things up a bit.