### PR TITLE
Make spacemacs-light/dark support pdf-view-midnight-minor-mode

### DIFF
--- a/core/libs/spacemacs-theme/spacemacs-common.el
+++ b/core/libs/spacemacs-theme/spacemacs-common.el
@@ -915,7 +915,10 @@ to 'auto, tags may not be properly aligned. "
 
     (custom-theme-set-variables
      theme-name
-     `(ansi-color-names-vector [,bg4 ,red ,green ,yellow ,blue ,magenta ,cyan ,base]))
+     `(ansi-color-names-vector [,bg4 ,red ,green ,yellow ,blue ,magenta ,cyan ,base])
+
+;;;;; pdf-tools
+     `(pdf-view-midnight-colors '(,base . ,bg1)))
 
     ))
 


### PR DESCRIPTION
The `pdf-tools` package has a "midnight mode" with bright text on dark background (`pdf-view-midnight-minor-mode`). Using `spacemacs-light/dark` colors makes it look nicer.