### PR TITLE
layouts: Add free buffers to current layout

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -119,7 +119,8 @@
   (use-package persp-mode
     :init
     (progn
-      (setq persp-auto-resume-time (if (or dotspacemacs-auto-resume-layouts
+      (setq persp-add-buffer-on-after-change-major-mode 'free
+            persp-auto-resume-time (if (or dotspacemacs-auto-resume-layouts
                                            spacemacs-force-resume-layouts)
                                        1 -1)
             persp-is-ibc-as-f-supported nil


### PR DESCRIPTION
This fixes issue #5776.

* `layers/+spacemacs/spacemacs-layouts/packages.el` (`spacemacs-layouts/init-persp-mode`): Set `persp-add-buffer-on-after-change-major-mode` to `'free`.