### PR TITLE
[EPIC] Usability changes for multiple cursors functionality

### DIFF
--- a/layers/+misc/multiple-cursors/funcs.el
+++ b/layers/+misc/multiple-cursors/funcs.el
@@ -11,6 +11,8 @@
 ;;
 ;;; License: GPLv3
 
+;; This is a placeholder change in a placeholder commit!
+
 (defun spacemacs//evil-mc-paste-transient-state-p ()
   "Return non-nil if the paste transient state is enabled."
   (and dotspacemacs-enable-paste-transient-state


### PR DESCRIPTION
Improvements made to multiple cursors support:

- New keybindings <kbd>C-M-j</kbd> and <kbd>C-M-k</kbd> for easier cursor creation while editing (inspired from sublime)
- Functionality extracted into a separate layer, installed by default in the `.spacemacs.template`
- Allow multiple backends (currently `evil-mc` is implemented).

Planning next:
- A transient state to help with complex operations.
- Create cursors from visual selection
- Quickly restore cursors once canceled

This is a WIP, many more goodies to come...

Changes already cherry-picked:
- b2fbd7c207f60848ed06eab56254857ab3266044 - Encapsulates multiple cursors functionality in a layer
- ad6ab57564abc8c7e1be6a5397d099a907d9894d - Renames the multiple cursors paste functions
- f94b51d4e82d4522a6795e7ec801c97bb651a639 - Documentation for multiple cursors
- c5a5ee305ba621a0299f5852a97f93faf54b4377 - Document sublime inspired keybindings