### PR TITLE
go-mode set-tab-width conflict with editorconfig

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -119,6 +119,13 @@ the layer variable =go-tab-width=, e.g.
   (go :variables go-tab-width 4)
 #+end_src
 
+If you're using =.editorconfig= in your project, set the value to nil to avoid
+confliction, e.g.
+
+#+begin_src emacs-lisp
+  (go :variables go-tab-width nil)
+#+end_src
+
 ** Tests
 If you're using =gocheck= in your project you can use the
 =go-use-gocheck-for-testing= variable to enable suite testing and to get single

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -11,7 +11,8 @@
 
 (defun spacemacs//go-set-tab-width ()
   "Set the tab width."
-  (setq-local tab-width go-tab-width))
+  (when go-tab-width
+    (setq-local tab-width go-tab-width)))
 
 (defun spacemacs//go-enable-gometalinter ()
    "Enable `flycheck-gometalinter' and disable overlapping `flycheck' linters."


### PR DESCRIPTION
when i use editorconfig, I found it not work for go-mode
and then I found it because the go layer has a function spacemacs//go-set-tab-width
I think it should give me a way to choose to use the config in .editorconfig, so I add condition to the function
then I can define the layer variable to use editorconfig like this:
```elisp
(go :variables
    go-tab-width nil)
```