### PR TITLE
melpa: Resurrect `ac-ispell'

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -13,11 +13,7 @@
       '(
         auto-yasnippet
         auto-complete
-        ;; Disabled since tha package was missing from melpa
-        ;; TODO: Enable it when the issue is cloded.
-        ;; https://github.com/melpa/melpa/issues/5657
-        ;;
-        ;; ac-ispell
+        ac-ispell
         company
         (company-quickhelp :toggle auto-completion-enable-help-tooltip)
         company-statistics


### PR DESCRIPTION
Since `ac-ispell` is now present in there :tada: 
https://github.com/melpa/melpa/issues/5657#issuecomment-410990552

This reverts commit c290645261d9ad7a6e62ec78d7edcbceda321d7b.