### PR TITLE
Support optional set-namespace argument to Clojure layer's `, s B`

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -94,12 +94,12 @@ the focus."
   (cider-insert-ns-form-in-repl t)
   (evil-insert-state))
 
-(defun spacemacs/cider-send-buffer-in-repl-and-focus ()
+(defun spacemacs/cider-send-buffer-in-repl-and-focus (&optional set-namespace)
   "Send the current buffer in the REPL and switch to the REPL in
-`insert state'."
-  (interactive)
+`insert state'. When set-namespace, also change into the namespace of the buffer."
+  (interactive "P")
   (cider-load-buffer)
-  (cider-switch-to-repl-buffer)
+  (cider-switch-to-repl-buffer set-namespace)
   (evil-insert-state))
 
 (defun spacemacs/cider-test-run-focused-test ()


### PR DESCRIPTION
The spacemacs analogue of cider-load-buffer-and-switch-to-repl-buffer
doesn't accept an argument to set the namespace while you are switching
to the repl buffer. This adds support for an argument, invokable with
the universal argument, for setting up the namespace as well. This will
eliminate an extra `(in-ns ...)` or `, s n` call as long as you invoke
`, s B` prefixed by the universal argument: `SPC u , s B`.