### PR TITLE
Fix 'projectile-keymap-prefix for counsel-projectile

### DIFF
--- a/layers/+spacemacs/spacemacs-project/config.el
+++ b/layers/+spacemacs/spacemacs-project/config.el
@@ -1,0 +1,21 @@
+;;; config.el --- Projectile Layer Configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+;; Layer Variables
+
+(defvar projectile-keymap-prefix (kbd "C-c C-p")
+  "Default projectile-keymap-prefix.
+   Required by counsel-projectile to work.
+   Must not be nil")
+
+
+;; Private Variables


### PR DESCRIPTION
The newest commit in projectile breaks compatibility of projectile-counsel because of fact that it set's the projectile-keymap-prefix to nil. Projectile-counsel uses that variable, therefore, it needs to be set.

This PR addresses the issue #11152 