### PR TITLE
coq: add keybindings for company-coq's documentation functions

### DIFF
--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -73,11 +73,11 @@ font, or disable the feature by adding the following snippet to the your
 
 ** Getting documentation
 
-| Key Binding | Description                                                     |
-|-------------+-----------------------------------------------------------------|
-| ~SPC m h h~ | Show documentation for whatever is below the cursor             |
-| ~SPC m h e~ | Show documentation for the error in the `*response*` buffer     |
-| ~SPC m h E~ | Browse all available documentation for errors                   |
+| Key Binding | Description                                                 |
+|-------------+-------------------------------------------------------------|
+| ~SPC m h h~ | Show documentation for whatever is below the cursor         |
+| ~SPC m h e~ | Show documentation for the error in the `*response*` buffer |
+| ~SPC m h E~ | Browse all available documentation for errors               |
 
 ** Prover queries
 The mnemonic for =a= is "ask".

--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -13,6 +13,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#laying-out-windows][Laying out windows]]
   - [[#managing-prover-process][Managing prover process]]
+  - [[#getting-documentation][Getting documentation]]
   - [[#prover-queries][Prover queries]]
   - [[#moving-the-point][Moving the point]]
   - [[#inserting][Inserting]]
@@ -69,6 +70,14 @@ font, or disable the feature by adding the following snippet to the your
 | ~SPC m p p~ | Process buffer - processes and moves point to end of buffer     |
 | ~SPC m p q~ | Quit prover                                                     |
 | ~SPC m p r~ | Retract buffer - rewinds and moves point to beginning of buffer |
+
+** Getting documentation
+
+| Key Binding | Description                                                     |
+|-------------+-----------------------------------------------------------------|
+| ~SPC m h h~ | Show documentation for whatever is below the cursor             |
+| ~SPC m h e~ | Show documentation for the error in the `*response*` buffer     |
+| ~SPC m h E~ | Browse all available documentation for errors                   |
 
 ** Prover queries
 The mnemonic for =a= is "ask".

--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -32,12 +32,18 @@
     :config
     (progn
       (spacemacs|hide-lighter company-coq-mode)
-      (spacemacs/declare-prefix-for-mode 'coq-mode
-        "mi" "coq/insert")
+      (dolist (prefix '(("mi" . "coq/insert")
+                        ("mh" . "coq/document")))
+        (spacemacs/declare-prefix-for-mode
+          'coq-mode
+          (car prefix) (cdr prefix)))
       (spacemacs/set-leader-keys-for-major-mode 'coq-mode
         "il" 'company-coq-lemma-from-goal
         "im" 'company-coq-insert-match-construct
-        "ao" 'company-coq-occur))))
+        "ao" 'company-coq-occur
+        "he" 'company-coq-document-error
+        "hE" 'company-coq-browse-error-messages
+        "hh" 'company-coq-doc))))
 
 (defun coq/init-proof-general ()
   (use-package proof-site


### PR DESCRIPTION
Extra keybindings for the Coq layer concerning documentation