### PR TITLE
emacs-lisp: Add company-elisp to company backends

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -54,7 +54,7 @@
           (lisp-indent-line))))))
 
 (defun emacs-lisp/post-init-company ()
-  (spacemacs|add-company-backends :backends company-capf
+  (spacemacs|add-company-backends :backends (company-capf company-elisp)
                                   :modes emacs-lisp-mode)
   (spacemacs|add-company-backends :backends (company-files company-capf)
                                   :modes ielm-mode))


### PR DESCRIPTION
`company-elisp` generally has more helpful suggestions than `company-capf`. The suggestions come much faster than semantic. 