### PR TITLE
doc: add remark for necessary GitHub login to report issues

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1952,6 +1952,8 @@ Reporting an issue:
 | ~SPC h I~       | Open Spacemacs GitHub issue page with pre-filled information                             |
 | ~SPC u SPC h I~ | Open Spacemacs GitHub issue page with pre-filled information - include last pressed keys |
 
+*Note*: To be able to report an issue you need to be logged into GitHub
+
 *Note*: If these two bindings are used with the =*Backtrace*= buffer open, the
 backtrace is automatically included
 


### PR DESCRIPTION
Added a remark to the general documentation making clear that for opening an issue with spacemacs one has to be logged in into GitHub.

 This is part of #11076.