### PR TITLE
add key bindings julia layer evil-surround

### DIFF
--- a/layers/+lang/julia/packages.el
+++ b/layers/+lang/julia/packages.el
@@ -17,6 +17,7 @@
                                  :repo "non-Jedi/lsp-julia"))
     flycheck
     company-lsp
+    evil-surround
     ))
 
 (defun julia/init-julia-mode ()
@@ -63,6 +64,13 @@
                 "sl" 'julia-repl-send-line
                 "sr" 'julia-repl-send-region-or-line
                 "em" 'julia-repl-macroexpand))))
+
+(defun julia/post-init-evil-surround ()
+  (with-eval-after-load 'evil-surround
+    (add-to-list 'evil-surround-pairs-alist '(?b . ("begin " . " end")))
+    (add-to-list 'evil-surround-pairs-alist '(?q . ("quote " . " end")))
+    (add-to-list 'evil-surround-pairs-alist '(?: . (":("     .    ")")))
+    (add-to-list 'evil-surround-pairs-alist '(?l . ("let "   . " end")))))
 
 (defun julia/init-lsp-julia ()
   (use-package lsp-julia


### PR DESCRIPTION
I added the key bindings for evil-surround that did not make it into #10444.
There are the following issues, which I did not manage to solve:
- The keybindings are not active in the first buffer opened in julia mode.
- The `s:` keybinding does not work, it worked before, when I had
```
   (with-eval-after-load 'evil-surround ;'julia-mode-hook
     (push '(?b . ("begin" . "end")) evil-surround-pairs-alist)
     (push '(?q . ("quote" . "end")) evil-surround-pairs-alist)
     (push '(?l . ("let"   . "end")) evil-surround-pairs-alist)
     (push '(?: . (":("    . ")"))   evil-surround-pairs-alist))
```
in my user-init, suggestions welcome.