### PR TITLE
search-engine: add ecosia and make each engine use https

### DIFF
--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -18,16 +18,19 @@ This layer adds support for the [[https://github.com/hrs/engine-mode][Search Eng
 
 ** Supported search engines
 - Amazon
+- Bing
 - Duck Duck Go
+- Ecosia
 - Google
 - Google Images
 - GitHub
 - Google Maps
 - Twitter
-- Project Gutemberg
-- Youtube
+- Project Gutenberg
+- YouTube
 - Stack Overflow
 - Spacemacs Issues
+- Spacemacs Pull Requests
 - Wikipedia
 - Wolfram Alpha
 

--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -12,9 +12,9 @@
 ;; List of all packages to install and/or initialize. Built-in packages
 ;; which require an initialization must be listed explicitly in the list.
 (setq search-engine-packages
-  '(
-    engine-mode
-    ))
+      '(
+        engine-mode
+        ))
 
 (defun search-engine/init-engine-mode ()
   (use-package engine-mode
@@ -27,34 +27,37 @@
       (setq search-engine-alist
             '((amazon
                :name "Amazon"
-               :url "http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%%3Daps&field-keywords=%s")
+               :url "https://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%%3Daps&field-keywords=%s")
               (bing
                :name "Bing"
-               :url "http://www.bing.com/search?q=%s")
+               :url "https://www.bing.com/search?q=%s")
               (duck-duck-go
                :name "Duck Duck Go"
                :url "https://duckduckgo.com/?q=%s")
+              (ecosia
+               :name "Ecosia"
+               :url "https://www.ecosia.org/search?q=%s")
               (google
                :name "Google"
-               :url "http://www.google.com/search?ie=utf-8&oe=utf-8&q=%s")
+               :url "https://www.google.com/search?ie=utf-8&oe=utf-8&q=%s")
               (google-images
                :name "Google Images"
-               :url "http://www.google.com/images?hl=en&source=hp&biw=1440&bih=795&gbv=2&aq=f&aqi=&aql=&oq=&q=%s")
+               :url "https://www.google.com/images?hl=en&source=hp&biw=1440&bih=795&gbv=2&aq=f&aqi=&aql=&oq=&q=%s")
               (github
-               :name "Github"
+               :name "GitHub"
                :url "https://github.com/search?ref=simplesearch&q=%s")
               (google-maps
                :name "Google Maps"
-               :url "http://maps.google.com/maps?q=%s")
+               :url "https://maps.google.com/maps?q=%s")
               (twitter
                :name "Twitter"
                :url "https://twitter.com/search?q=%s")
               (project-gutenberg
                :name "Project Gutenberg"
-               :url "http://www.gutenberg.org/ebooks/search.html/?format=html&default_prefix=all&sort_order=&query=%s")
+               :url "https://www.gutenberg.org/ebooks/search.html/?format=html&default_prefix=all&sort_order=&query=%s")
               (youtube
                :name "YouTube"
-               :url "http://www.youtube.com/results?aq=f&oq=&search_query=%s")
+               :url "https://www.youtube.com/results?aq=f&oq=&search_query=%s")
               (stack-overflow
                :name "Stack Overflow"
                :url "https://stackoverflow.com/search?q=%s")
@@ -66,10 +69,10 @@
                :url "https://github.com/syl20bnr/spacemacs/pulls?utf8=%%E2%%9C%%93&q=is%%3Aissue+is%%3Aopen+%s")
               (wikipedia
                :name "Wikipedia"
-               :url "http://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s")
+               :url "https://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s")
               (wolfram-alpha
                :name "Wolfram Alpha"
-               :url "http://www.wolframalpha.com/input/?i=%s")))
+               :url "https://www.wolframalpha.com/input/?i=%s")))
       (dolist (engine search-engine-alist)
         (let ((func (intern (format "engine/search-%S" (car engine)))))
           (autoload func "engine-mode" nil 'interactive))))


### PR DESCRIPTION
Added "Ecosia - the search engine to plant trees" to search-engine layer. Also I have updated the existing definitions to use HTTPS instead of HTTP when supported by the search provider.