### PR TITLE
Remove unnecessary company-go function

### DIFF
--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -17,7 +17,6 @@
 (defun spacemacs//go-setup-backend ()
   "Conditionally setup go backend"
   (pcase go-backend
-    ('go-mode (spacemacs//go-setup-backend-go-mode))
     ('lsp (spacemacs//go-setup-backend-lsp))))
 
 (defun spacemacs//go-setup-company ()
@@ -25,9 +24,6 @@
   (pcase go-backend
     ('go-mode (spacemacs//go-setup-company-go))
     ('lsp (spacemacs//go-setup-company-lsp))))
-
-(defun spacemacs//go-setup-backend-go-mode ()
-  (company-go))
 
 (defun spacemacs//go-setup-company-go ()
   (spacemacs|add-company-backends


### PR DESCRIPTION
Fixes #11180 

I've left the same structure in `spacemacs//go-setup-backend` just because we might want to add go-mode back if we need to do additional setup.