### PR TITLE
Add support for golangci-linter to go layer

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -69,6 +69,21 @@ and install the tool:
 For more information read [[https://github.com/alecthomas/gometalinter/blob/master/README.md][gometalinter README.md]]
 and [[https://github.com/favadi/flycheck-gometalinter/blob/master/README.md][flycheck-gometalinter README.md]]
 
+Alternatively, if you wish to use =golangci-lint= set the value of =go-use-golangci-lint= to t:
+
+#+begin_src emacs-lisp
+  (go :variables go-use-golangci-lint t)
+#+end_src
+
+and install the tool:
+
+#+BEGIN_SRC sh
+  go get -u -v github.com/golangci/golangci-lint/cmd
+#+END_SRC
+
+For more information read [[https://github.com/golangci/golangci-lint][golangci-lint README.md]]
+and [[https://github.com/weijiangan/flycheck-golangci-lint][flycheck-golangci-lint README.md]]
+
 If you wish to use =godoctor= for refactoring, install it too:
 
 #+BEGIN_SRC sh

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -25,6 +25,9 @@
 (defvar go-tab-width 8
   "Set the `tab-width' in Go mode. Default is 8.")
 
+(defvar go-use-golangci-lint nil
+  "Use golangci-lint if the variable has non-nil value.")
+
 (defvar go-use-gometalinter nil
   "Use gometalinter if the variable has non-nil value.")
 

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -64,6 +64,16 @@
                                       go-errcheck))
    (flycheck-gometalinter-setup))
 
+(defun spacemacs//go-enable-golangci-lint ()
+  "Enable `flycheck-golangci-lint' and disable overlapping `flycheck' linters."
+  (setq flycheck-disabled-checkers '(go-gofmt
+                                     go-golint
+                                     go-vet
+                                     go-build
+                                     go-test
+                                     go-errcheck))
+  (flycheck-golangci-lint-setup))
+
 (defun spacemacs/go-run-tests (args)
   (interactive)
   (compilation-start (concat "go test " args " " go-use-test-args)

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -18,6 +18,9 @@
         (flycheck-gometalinter :toggle (and go-use-gometalinter
                                             (configuration-layer/package-used-p
                                              'flycheck)))
+        (flycheck-golangci-lint :toggle (and go-use-golangci-lint
+                                            (configuration-layer/package-used-p
+                                             'flycheck)))
         ggtags
         helm-gtags
         go-eldoc
@@ -166,6 +169,15 @@
     :init (spacemacs/set-leader-keys-for-major-mode 'go-mode
             "rf" 'go-tag-add
             "rF" 'go-tag-remove)))
+
+(defun go/init-flycheck-golangci-lint ()
+  (use-package flycheck-golangci-lint
+    :defer t
+    :init
+    (add-hook 'go-mode-hook 'spacemacs//go-enable-golangci-lint t)))
+
+(defun go/post-init-ggtags ()
+  (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun go/init-godoctor ()
   (use-package godoctor


### PR DESCRIPTION
Mostly just a copy-paste of the support for gometalinter using these things:

https://github.com/golangci/golangci-lint
https://github.com/weijiangan/flycheck-golangci-lint