### PR TITLE
Delete compilation finish hook

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1228,23 +1228,6 @@ using a visual block/rectangle selection."
 
 ;; END linum mouse helpers
 
-;; From http://xugx2007.blogspot.ca/2007/06/benjamin-rutts-emacs-c-development-tips.html
-(setq compilation-finish-function
-      (lambda (buf str)
-
-        (let ((case-fold-search nil))
-          (if (or (string-match "exited abnormally" str)
-                  (string-match "FAILED" (buffer-string)))
-
-              ;; there were errors
-              (message "There were errors. SPC-e-n to visit.")
-            (unless (or (string-match "Grep finished" (buffer-string))
-                        (string-match "Ag finished" (buffer-string))
-                        (string-match "nosetests" (buffer-name)))
-
-              ;; no errors
-              (message "compilation ok."))))))
-
 ;; from http://www.emacswiki.org/emacs/WordCount
 (defun spacemacs/count-words-analysis (start end)
   "Count how many times each word is used in the region.


### PR DESCRIPTION
Before this commit, Spacemacs assigned an anonymous function to the `compilation-finish-function` variable.  This variable was deprecated in Emacs 22.1 and removed in Emacs 27.1 in favor of the
`compilation-finish-functions` hook.  Consequently, the assignment has no practical effect in Emacs 27.1.

Although we could add the Spacemacs function to the new `compilation-finish-functions` hook, the function serves little purpose; it prints a generic message when compilation succeeds:

    compilation ok.

and it prints the key binding for `spacemacs/next-error` when compilation fails:

    There were errors. Use SPC e n to visit.

However Emacs already prints messages to indicate success or failure, respectively:

    Compilation finished

or (for example)

    Compilation exited abnormally with code 1

Because the Spacemacs function prints its "There were errors" message immediately after Emacs prints its "Compilation exited abnormally" message, the latter was obscured.  Because the exit code in Emacs's message could be useful and the added value of the Spacemacs function's message is minimal, we can simply delete the Spacemacs function.

* `layers/+spacemacs/spacemacs-defaults/funcs.el` (`compilation-finish-function`): Delete the assignment and anonymous function.

---

This PR supersedes #11059.