### PR TITLE
github: Disable status, issues, and PRs by default

### DIFF
--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -49,21 +49,29 @@ Magithub, follow the installation instructions at hub.github.com. To force hub
 to authenticate, you can use hub browse in a terminal (inside a GitHub repo).
 
 ** Magithub configuration
-Spacemacs configures =Magithub= to be in offline mode by default because loading
+Spacemacs configures =Magithub= to be in offline mode by default and disables
+displaying the GitHub project status, issues, and pull requests because loading
 project data for repositories with many pull requests or issues can be
-exorbitantly slow (see [[https://github.com/syl20bnr/spacemacs/issues/11176][issue #11176]]).  To load project data when in offline
-mode, use ~SPC u g r~ in the =magit status= buffer.  To toggle online mode for the
-current repository, use ~@ C o~.  To enable online mode by default, use the
-following shell command:
+exorbitantly slow (see [[https://github.com/syl20bnr/spacemacs/issues/11176][issue #11176]]).  To toggle online mode and the project
+status, issues, and pull requests sections for the current repository, open in
+the =magit status= buffer (~SPC g s~) and then open the Magithub settings popup
+(~@ C~).  To enable online mode and the project status, pull requests, and
+issues sections by default, use the following shell commands:
 
 #+BEGIN_SRC sh
   git config --global --bool magithub.online true
+  git config --global --bool magithub.status.includeStatusHeader true
+  git config --global --bool magithub.status.includePullRequestsSection true
+  git config --global --bool magithub.status.includeIssuesSection true
 #+END_SRC
 
-Alternatively, use the following Emacs form:
+Alternatively, use the following Emacs forms:
 
 #+BEGIN_SRC emacs-lisp
   (magit-set "true" "--global" "magithub.online")
+  (magit-set "true" "--global" "magithub.status.includeStatusHeader")
+  (magit-set "true" "--global" "magithub.status.includePullRequestsSection")
+  (magit-set "true" "--global" "magithub.status.includeIssuesSection")
 #+END_SRC
 
 * Key Bindings
@@ -87,7 +95,7 @@ possible.
 
 | Key Binding | Description                                      |
 |-------------+--------------------------------------------------|
-| ~@ C~       | configure Magithub                               |
+| ~@ C~       | open the Magithub settings popup                 |
 | ~@ H~       | opens the current repository in the browser      |
 | ~@ c~       | pushes a brand-new local repository up to GitHub |
 | ~@ f~       | create a fork of an existing repository          |

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -90,7 +90,10 @@
       ;; projects with many pull requests or issues can be exorbitantly slow.
       ;; See <https://github.com/syl20bnr/spacemacs/issues/11176>.
       (when (null (magit-get "--global" "magithub.online"))
-        (magit-set "false" "--global" "magithub.online"))
+        (magit-set "false" "--global" "magithub.online")
+        (magit-set "false" "--global" "magithub.status.includeStatusHeader")
+        (magit-set "false" "--global" "magithub.status.includePullRequestsSection")
+        (magit-set "false" "--global" "magithub.status.includeIssuesSection"))
       (magithub-feature-autoinject t)
       (define-key magit-status-mode-map "@" #'magithub-dispatch-popup))))
 


### PR DESCRIPTION
Try again to fix issue #11176.

* `layers/+source-control/github/packages.el` (`github/init-magithub`): Disable the GitHub project status, pull requests, and issues sections by default.
* `layers/+source-control/github/README.org`: Document that these sections are all disabled by default, and how to enable them.