### PR TITLE
Clojure layer: make sayid optional

### DIFF
--- a/layers/+lang/clojure/config.el
+++ b/layers/+lang/clojure/config.el
@@ -18,4 +18,7 @@
 (spacemacs|define-jump-handlers cider-repl-mode)
 
 (defvar clojure-enable-fancify-symbols nil
-  "If non nil the `fancify-symbols' function is enabled.")
+  "If non-nil, the `fancify-symbols' function is enabled.")
+
+(defvar clojure-enable-sayid nil
+  "If non-nil, the Sayid Clojure debugger is enabled.")

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -26,7 +26,7 @@
         org
         parinfer
         popwin
-        sayid
+        (sayid :toggle clojure-enable-sayid)
         smartparens
         subword))
 


### PR DESCRIPTION
The sayid debugger and profiler for Clojure currently has compatibility issues with other packages. It's also a package that only a small percentage of users will use, while having it present slows down Clojure startup for everyone.

The author has agreed to address the compatibility issues, so this will still be useful for people in the future, but it shouldn't be installed by default.

Rather than fully remove it as suggested in #11146, this PR makes it optional using the same pattern used in other layers.

Closes #11146 
