### PR TITLE
Advise rename-buffer when persp-mode activated

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -17,7 +17,16 @@
  (e.g. don't re-activate during `dotspacemacs/sync-configuration-layers' -
  see issues #5925 and #3875)"
   (unless (bound-and-true-p persp-mode)
-    (persp-mode)))
+    (persp-mode)
+    ;; eyebrowse's advice for rename-buffer only updates workspace window
+    ;; configurations that are stored in frame properties, but Spacemacs's
+    ;; persp-mode integration saves workspace window configurations in
+    ;; perspective parameters.  We need to replace eyebrowse's advice with
+    ;; perspective-aware advice in order to ensure that window
+    ;; configurations for inactive perspectives get updated.
+    (ad-disable-advice 'rename-buffer 'around 'eyebrowse-fixup-window-configs)
+    (ad-activate 'rename-buffer)
+    (advice-add 'rename-buffer :around #'spacemacs//fixup-window-configs)))
 
 (defun spacemacs//layout-wait-for-modeline (&rest _)
   "Assure the mode-line is loaded before restoring the layouts."

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -95,16 +95,7 @@
         (add-hook 'persp-before-save-state-to-file-functions
                   #'spacemacs/update-eyebrowse-for-perspective)
         (add-hook 'persp-after-load-state-functions
-                  #'spacemacs/load-eyebrowse-after-loading-layout)
-        ;; eyebrowse's advice for rename-buffer only updates workspace window
-        ;; configurations that are stored in frame properties, but Spacemacs's
-        ;; persp-mode integration saves workspace window configurations in
-        ;; perspective parameters.  We need to replace eyebrowse's advice with
-        ;; perspective-aware advice in order to ensure that window
-        ;; configurations for inactive perspectives get updated.
-        (ad-disable-advice 'rename-buffer 'around 'eyebrowse-fixup-window-configs)
-        (ad-activate 'rename-buffer)
-        (advice-add 'rename-buffer :around #'spacemacs//fixup-window-configs))
+                  #'spacemacs/load-eyebrowse-after-loading-layout))
       ;; vim-style tab switching
       (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
       (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config))))


### PR DESCRIPTION
Before this commit, `spacemacs-layouts/init-eyebrowse` advised `rename-buffer` with `spacemacs//fixup-window-config`.  However, this advice causes problems if persp-mode is not activated when a function tries to rename a buffer.

In particular, Spacemacs's CI uses Emacs's batch mode to run `spacemacs/publish-doc`, which uses `rename-buffer`.  In batch mode, persp-mode is not activated, and consequently `spacemacs/publish-doc` was failing:

    Publishing file /home/travis/.emacs.d/news/news01.org using ‘org-html-publish-to-html’
    Skipping check for new version (reason: dotfile)
    Wrong type argument: hash-table-p, nil
    Warning (emacs): recentf mode: Wrong type argument: hash-table-p, nil
    spacemacs/publish-doc failed

In order to avoid problems, this commit moves the advising of `rename-buffer` from `spacemacs-layouts/init-eyebrowse` to `spacemacs//activate-persp-mode`.

* `layers/+spacemacs/spacemacs-layouts/packages.el` (`spacemacs-layouts/init-eyebrowse`): Move advice from here...
* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs//activate-persp-mode`): ...to here.
