### PR TITLE
lsp-layer core keybinding amendments

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -6,6 +6,8 @@
 - [[#configuration][Configuration]]
   - [[#derived-layers][Derived layers]]
     - [[#spacemacslsp-bind-keys-for-mode-mode][=spacemacs/lsp-bind-keys-for-mode mode=]]
+      - [[#declared-prefixes][Declared prefixes]]
+      - [[#default-keybindings][Default keybindings]]
   - [[#variables][Variables]]
   - [[#diagnostics][Diagnostics]]
 - [[#future-additionsimprovements][Future additions/improvements]]
@@ -44,23 +46,36 @@
    A number of elisp functions have been added to facilitate development of derived layers.
 
 *** =spacemacs/lsp-bind-keys-for-mode mode=
-    Binds keys to a number of lsp features useful for all/most modes for the given major mode.
+    This function binds keys to a number of lsp features useful for all/most modes for the given major mode.
+    It also declares some relevant keyboard shortcut prefixes.
 
-    The prefix conventions suggested in spacemacs CONVENTIONS.org have been observed, where appropriate.
+**** Declared prefixes
+    The following prefixes have been declared:
 
+    | prefix | name           | functional area                                                            |
+    |--------+----------------+----------------------------------------------------------------------------|
+    | ~m =~  | format         | Source formatting                                                          |
+    | ~m g~  | goto           | Source navigation                                                          |
+    | ~m h~  | help/hierarchy | Help and functions related to hierarchy (class relationships etc.)         |
+    | ~m l~  | lsp/backend    | Catchall. Restart LSP backend, other implementation-specific functionality |
+    | ~m r~  | refactor       | What it says on the tin                                                    |
+    | ~m T~  | toggle         | Toggle LSP backend features (documentation / symbol info overlays etc.)    |
+
+**** Default keybindings
     The default bindings are listed below. Derived language server layers should extend this list.
 
     | binding | function                                        |
     |---------+-------------------------------------------------|
     | ~m = b~ | format buffer (lsp)                             |
     |---------+-------------------------------------------------|
-    | ~m g i~ | goto implementation                             |
-    | ~m g t~ | goto type-definition                            |
-    | ~m g a~ | goto viewport symbol (avy)                      |
+    | ~m g i~ | goto implementation (lsp)                       |
+    | ~m g t~ | goto type-definition (lsp)                      |
+    | ~m g k~ | goto viewport symbol (avy)                      |
     | ~m g m~ | browse file symbols (lsp-ui-imenu)              |
-    | ~m g d~ | find definitions                                |
-    | ~m g r~ | find references                                 |
-    | ~m g s~ | find-workspace-symbol                           |
+    | ~m g d~ | find definitions (lsp-ui-peek)                  |
+    | ~m g l~ | find implementations (lsp-ui-peek)              |
+    | ~m g r~ | find references (lsp-ui-peek)                   |
+    | ~m g s~ | find-workspace-symbol (lsp-ui-peek)             |
     | ~m g p~ | jump prev (lsp-ui-peek stack - see Note 1)      |
     | ~m g n~ | jump next (lsp-ui-peek stack - see Note 1)      |
     | ~m g f~ | jump to flycheck error                          |

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -51,7 +51,7 @@ https://github.com/emacs-lsp/lsp-javascript/issues/9#issuecomment-379515379"
   "Define key bindings for the specific MODE."
   (spacemacs/declare-prefix-for-mode mode "m=" "format")
   (spacemacs/declare-prefix-for-mode mode "mg" "goto")
-  (spacemacs/declare-prefix-for-mode mode "mh" "hierarchy")
+  (spacemacs/declare-prefix-for-mode mode "mh" "help/hierarchy")
   (spacemacs/declare-prefix-for-mode mode "ml" "lsp/backend")
   (spacemacs/declare-prefix-for-mode mode "mr" "refactor")
   (spacemacs/declare-prefix-for-mode mode "mT" "toggle")
@@ -62,9 +62,10 @@ https://github.com/emacs-lsp/lsp-javascript/issues/9#issuecomment-379515379"
     ;;goto
     "gi" #'lsp-goto-implementation
     "gt" #'lsp-goto-type-definition
-    "ga" #'spacemacs/lsp-avy-document-symbol
+    "gk" #'spacemacs/lsp-avy-document-symbol
     "gm" #'lsp-ui-imenu
     "gd" #'lsp-ui-peek-find-definitions
+    "gi" #'lsp-ui-peek-find-implementation
     "gr" #'lsp-ui-peek-find-references
     "gs" #'lsp-ui-peek-find-workspace-symbol
     "gp" #'lsp-ui-peek-jump-backward


### PR DESCRIPTION
`m g a` conventionally used to switch between c/c++ source and header files, but bound to a keyboard symbol navigation function in lsp-layer. Moved lsp-layer binding under `m g k`

