### PR TITLE
python-mode: fix indent offset guessing for tab indentation

### DIFF
--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -33,6 +33,9 @@ and `lsp'.")
 (defvar python-tab-width 4
   "Tab width value for python buffers")
 
+(defvar python-spacemacs-indent-guess t
+  "If non-nil, try to guess correct indentation settings for python buffers on opening")
+
 (defvar python-auto-set-local-pyenv-version 'on-visit
   "Automatically set pyenv version from \".python-version\".
 

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -91,6 +91,11 @@ when this mode is enabled since the minibuffer is cleared all the time."
   (setq mode-name "Python"
         tab-width python-tab-width
         fill-column python-fill-column)
+
+  ;; since we changed the tab-width we need to manually cally python-indent-guess-inden-offset herr
+  (when python-spacemacs-indent-guess
+    (python-indent-guess-indent-offset))
+
   (when (version< emacs-version "24.5")
     ;; auto-indent on colon doesn't work well with if statement
     ;; should be fixed in 24.5 and above

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -92,7 +92,7 @@ when this mode is enabled since the minibuffer is cleared all the time."
         tab-width python-tab-width
         fill-column python-fill-column)
 
-  ;; since we changed the tab-width we need to manually cally python-indent-guess-inden-offset herr
+  ;; since we changed the tab-width we need to manually call python-indent-guess-indent-offset here
   (when python-spacemacs-indent-guess
     (python-indent-guess-indent-offset))
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -334,6 +334,9 @@
         "sR" 'spacemacs/python-shell-send-region-switch
         "sr" 'python-shell-send-region)
 
+      ;; we call python-indent-guess-indent-offset ourselves so set to nil to avoid duplicate work
+      (setq-default python-indent-guess-indent-offset nil)
+
       ;; Emacs users won't need these key bindings
       ;; TODO: make these key bindings dynamic given the current style
       ;; Doing it only at init time won't update it if the user switches style

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -334,7 +334,8 @@
         "sR" 'spacemacs/python-shell-send-region-switch
         "sr" 'python-shell-send-region)
 
-      ;; we call python-indent-guess-indent-offset ourselves so set to nil to avoid duplicate work
+      ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
+      ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)
       (setq-default python-indent-guess-indent-offset nil)
 
       ;; Emacs users won't need these key bindings


### PR DESCRIPTION
Since spacemacs changes the python tab width, we need to do the indent guessing after setting
the tab width.