### PR TITLE
Only disable eyebrowse advice if it exists

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -24,8 +24,9 @@
     ;; perspective parameters.  We need to replace eyebrowse's advice with
     ;; perspective-aware advice in order to ensure that window
     ;; configurations for inactive perspectives get updated.
-    (ad-disable-advice 'rename-buffer 'around 'eyebrowse-fixup-window-configs)
-    (ad-activate 'rename-buffer)
+    (when (ad-find-advice 'rename-buffer 'around 'eyebrowse-fixup-window-configs)
+      (ad-disable-advice 'rename-buffer 'around 'eyebrowse-fixup-window-configs)
+      (ad-activate 'rename-buffer))
     (advice-add 'rename-buffer :around #'spacemacs//fixup-window-configs)))
 
 (defun spacemacs//layout-wait-for-modeline (&rest _)


### PR DESCRIPTION
Fix issue #11207.

Only try to disable eyebrowse's advice on rename-buffer if we can find that advice.  If eyebrowse is older than version 0.7.6 (2017-11-22), the advice will not exist, and attempting to delete it will cause an error:

    ad-disable-advice: rename-buffer is not advised

* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs//activate-persp-mode`): Only disable the `eyebrowse-fixup-window-configs` advice for `rename-buffer` if the advice exists.