### PR TITLE
Replace pbcopy by osx-clipboard

### DIFF
--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -16,9 +16,7 @@
         launchctl
         (osx-dictionary :toggle osx-use-dictionary-app)
         osx-trash
-        ;; disabled because it introduces input latency with some
-        ;; actions when using emacs -daemon and opening a GUI client
-        ;; pbcopy
+        osx-clipboard
         reveal-in-osx-finder
         term
         ))
@@ -105,15 +103,21 @@
              (not (boundp 'mac-system-move-file-to-trash-use-finder)))
     :init (osx-trash-setup)))
 
-;; TODO: find a way to enable it in terminal with a dumped Spacemacs
-;; if this package is activate while dumping it makes some action lag
-;; like 'dd' to delete a line etc...
-;; (defun osx/init-pbcopy ()
-;;   (use-package pbcopy
-;;     :if (and (spacemacs/system-is-mac)
-;;              (not (display-graphic-p))
-;;              (not (spacemacs-is-dumping-p)))
-;;     :init (turn-on-pbcopy)))
+(defun osx/init-osx-clipboard ()
+  (use-package osx-clipboard
+    :if (spacemacs/system-is-mac)
+    :commands
+    (osx-clipboard-paste-function osx-clipboard-cut-function)
+    :init
+    (progn
+      (setq interprogram-cut-function '(lambda (text &rest ignore)
+                                        (if (display-graphic-p)
+                                            (gui-select-text text)
+                                          (osx-clipboard-cut-function text)))
+            interprogram-paste-function '(lambda ()
+                                          (if (display-graphic-p)
+                                              (gui-selection-value)
+                                            (osx-clipboard-paste-function)))))))
 
 (defun osx/init-reveal-in-osx-finder ()
   (use-package reveal-in-osx-finder


### PR DESCRIPTION
Issue: https://github.com/syl20bnr/spacemacs/issues/10896#issuecomment-415563095

Why:

* When using emacs >= 26, pbcopy has latency actions in terminal.

This change addresses the need by:

* Replace pbcopy by osx-clipboard