### PR TITLE
Fix pyenv using system Python

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -124,6 +124,8 @@ as the pyenv version then also return nil. This works around https://github.com/
                           (< i (length pyenv-version-names)))
                 (if (string-match (elt pyenv-version-names i) (string-trim pyenv-string))
                     (setq executable (string-trim pyenv-string)))
+                (if (string-match (elt pyenv-version-names i) "system")
+                    (setq executable (string-trim (executable-find command))))
                 (setq i (1+ i))))
           executable))
     (executable-find command)))


### PR DESCRIPTION
This PR tries to fix the invalid Python executables being found on systems that have pyenv installed, but use system Python instead of a Python installed in a virtual environment.

Maybe @cpaulik (who wrote the code being changed) or @vv111y or @kccai (who commented on the isue hopefully fixed here in commit #0c878ae) can comment on this PR.