### PR TITLE
Fix fasd layer keybindings

### DIFF
--- a/layers/+tools/fasd/README.org
+++ b/layers/+tools/fasd/README.org
@@ -36,6 +36,6 @@ On OS X, it can be installed via [[https://github.com/Homebrew/legacy-homebrew][
 
 | Key Binding | Description                        |
 |-------------+------------------------------------|
-| ~SPC f a s~ | find a file or directory with fasd |
-| ~SPC f a d~ | find a directory with fasd         |
-| ~SPC f a f~ | find a file with fasd              |
+| ~SPC a f f~ | find a file or directory with fasd |
+| ~SPC a f d~ | find a directory with fasd         |
+| ~SPC a f s~ | find a file with fasd              |

--- a/layers/+tools/fasd/packages.el
+++ b/layers/+tools/fasd/packages.el
@@ -1,7 +1,4 @@
-(setq fasd-packages
-  '(
-    fasd
-    ))
+(setq fasd-packages '(fasd))
 
 (defun fasd-find-file-only ()
   (interactive)
@@ -17,13 +14,10 @@
     :init
     (progn
       (global-fasd-mode 1)
-      (spacemacs/declare-prefix "fa" "fasd-find")
-      (spacemacs/set-leader-keys "fad" 'fasd-find-directory-only)
-      (spacemacs/set-leader-keys "faf" 'fasd-find-file-only)
-      (spacemacs/set-leader-keys "fas" 'fasd-find-file)
+      (spacemacs/declare-prefix "af" "fasd-find")
+      (spacemacs/set-leader-keys "afd" 'fasd-find-directory-only)
+      (spacemacs/set-leader-keys "afs" 'fasd-find-file-only)
+      (spacemacs/set-leader-keys "aff" 'fasd-find-file)
 
       ;; we will fall back to using the default completing-read function, which is helm once helm is loaded.
-      (setq fasd-completing-read-function 'nil)
-      )
-    )
-  )
+      (setq fasd-completing-read-function 'nil))))


### PR DESCRIPTION
keybinging conflict introduced in
https://github.com/syl20bnr/spacemacs/commit/c2e377c902ba5cbed9ef6be47c3fa7f45a8bb846
made fasd layer unusable.

This PR proposes a fix.