### PR TITLE
ivy-rich: update config for upstream changes

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -225,14 +225,16 @@
 
 (defun ivy/init-ivy-rich ()
   (use-package ivy-rich
-    :defer t
+    ;; if `counsel' loads after `ivy-rich', it overrides some of `ivy-rich''s
+    ;; transformers
+    :after counsel
     :init
     (progn
-      (setq ivy-rich-abbreviate-paths t
-            ivy-virtual-abbreviate 'full
-            ivy-rich-switch-buffer-align-virtual-buffer t)
-      (ivy-set-display-transformer 'ivy-switch-buffer
-                                   'ivy-rich-switch-buffer-transformer))))
+      (setq ivy-rich-path-style 'abbrev
+            ivy-virtual-abbreviate 'full))
+    :config
+    (progn
+      (ivy-rich-mode))))
 
 (defun ivy/init-ivy-spacemacs-help ()
   (use-package ivy-spacemacs-help


### PR DESCRIPTION
Upstream `ivy-rich` changed significantly and as such its configuration needs to change as well. Variable `ivy-rich-switch-buffer-align-virtual-buffer` has been made obsolete and doesn't have a replacement, so I removed it.