### PR TITLE
make spacemacs/counsel-search with proper highlighting

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -125,7 +125,8 @@
 (defun spacemacs-completion/init-default-ivy-config ()
   (with-eval-after-load 'ivy
     (setq ivy-height 15
-          ivy-re-builders-alist '((t . ivy--regex-ignore-order)))
+          ivy-re-builders-alist '((spacemacs/counsel-search . spacemacs/ivy--regex-plus)
+                                  (t . ivy--regex-ignore-order)))
     (spacemacs|hide-lighter ivy-mode)
     ;; setup hooks
     (add-hook 'spacemacs-editing-style-hook 'spacemacs//ivy-hjkl-navigation)


### PR DESCRIPTION
We can specify the `spacemacs/counsel-search` function using `spacemacs/ivy--regex-plus` in order to have proper hightlighting.

Tested on `rg`, `ack`, `pt`, `ag`. `grep` doesn't have proper highlighting on my machine. 

Shown in the image below.

![image](https://user-images.githubusercontent.com/16655096/44807160-a908fb80-ab7d-11e8-806c-c0a320a42c62.png)

While we don't have highlighting before.
![image](https://user-images.githubusercontent.com/16655096/44807220-d786d680-ab7d-11e8-99ba-57f9fcd0c0d8.png)

