### PR TITLE
[jsonnet] readme.org: fix keybinding table

### DIFF
--- a/layers/+lang/jsonnet/README.org
+++ b/layers/+lang/jsonnet/README.org
@@ -23,12 +23,12 @@ add =jsonnet= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 To use some of the additional formatting and evaluation features, you'll need
-to [[http://jsonnet.org/index.html][the jsonnet binary]]
+[[http://jsonnet.org/index.html][the jsonnet binary]]
 
 * Key bindings
 
-| Key Binding  | Description                                              |
-|--------------+----------------------------------------------------------|
-| ~SPC m = ~   | format the buffer using `jsonnet fmt`                    |
-| ~SPC m g g ~ | jump to the definition of a given identifier             |
-| ~SPC m s b ~ | show the result of running jsonnet on the current buffer |
+| Key Binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC m =~   | format the buffer using `jsonnet fmt`                    |
+| ~SPC m g g~ | jump to the definition of a given identifier             |
+| ~SPC m s b~ | show the result of running jsonnet on the current buffer |


### PR DESCRIPTION
problem: a space before the closing ~, breaks the formatting
solution: remove the space to hide the ~ signs

And remove a word: "to"