### PR TITLE
[spacemacs-docker] clean .#recentf

### DIFF
--- a/layers/+distributions/spacemacs-docker/deps-install/run
+++ b/layers/+distributions/spacemacs-docker/deps-install/run
@@ -83,4 +83,5 @@
     "/root/.npm"
     "/root/.wget-hsts"
     (l "%s/*" $WORKSPACE)
+    (l "%s/.emacs.d/.cache/.#recentf" $UHOME)
     (l "%s/.emacs.d/.cache/recentf" $UHOME))


### PR DESCRIPTION
Looks like the lock-file of recentf needs to be deleted after dependency installation.