### PR TITLE
Add elm-test-runner to elm layer

### DIFF
--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -20,10 +20,12 @@
     - [[#imports-sort][Imports sort]]
     - [[#file-format][File format]]
   - [[#indentation][Indentation]]
+  - [[#test-runner-settings][Test runner settings]]
 - [[#key-bindings][Key bindings]]
   - [[#elm-make][elm-make]]
   - [[#elm-repl][elm-repl]]
   - [[#elm-reactor][elm-reactor]]
+  - [[#elm-test-runner][elm-test-runner]]
   - [[#elm-package][elm-package]]
     - [[#package-list-buffer][package list buffer]]
   - [[#elm-oracle-1][elm-oracle]]
@@ -168,6 +170,20 @@ cycle (n)... where n is the number of available indentations to choose from. If
 the automatic indentation level was not the one you expected simply hit TAB to
 cycle through the list (note that hitting any other key will cancel the cycle).
 
+** Test runner settings
+
+You may want to customize the default suffix for test files. For example, if you
+prefer to put your tests in =HelloSpec.elm= instead of =HelloTest.elm=, set the
+following variable:
+
+#+BEGIN_SRC emacs-lisp
+  (elm :variables
+       elm-test-runner-preferred-test-suffix "Spec")
+#+END_SRC
+
+Take a look [[https://github.com/juanedi/elm-test-runner#customization][here]] for more settings, and remember that this can be set by project
+using a =dir-locals.el= file.
+
 * Key bindings
 ** elm-make
 
@@ -193,6 +209,17 @@ cycle through the list (note that hitting any other key will cancel the cycle).
 |-------------+--------------------|
 | ~SPC m R n~ | elm-preview-buffer |
 | ~SPC m R m~ | elm-preview-main   |
+
+** elm-test-runner
+
+| Key Binding   | Description                            |
+|---------------+----------------------------------------|
+| ~SPC m t b~   | elm-test-runner-run                    |
+| ~SPC m t d~   | elm-test-runner-run-directory          |
+| ~SPC m t p~   | elm-test-runner-run-project            |
+| ~SPC m t r~   | elm-test-runner-rerun                  |
+| ~SPC m t w~   | elm-test-runner-watch                  |
+| ~SPC m t TAB~ | elm-test-runner-toggle-test-and-target |
 
 ** elm-package
 

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -13,6 +13,7 @@
     '(
       company
       elm-mode
+      elm-test-runner
       flycheck
       (flycheck-elm :requires flycheck)
       popwin
@@ -91,6 +92,21 @@
         "u" 'elm-package-unmark
         "x" 'elm-package-install
         "q" 'quit-window))))
+
+(defun elm/init-elm-test-runner ()
+  (use-package elm-test-runner
+    :after elm-mode
+    :init
+    (progn
+      (spacemacs/declare-prefix-for-mode 'elm-mode "mt" "test")
+      (spacemacs/set-leader-keys-for-major-mode 'elm-mode
+        "tb" 'elm-test-runner-run
+        "td" 'elm-test-runner-run-directory
+        "tp" 'elm-test-runner-run-project
+        "tr" 'elm-test-runner-rerun
+        "tw" 'elm-test-runner-watch
+        "t TAB" 'elm-test-runner-toggle-test-and-target
+        ))))
 
 (defun elm/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin


### PR DESCRIPTION
The layer just sets up the [elm-test-runner](https://github.com/juanedi/elm-test-runner) package and defines some reasonable keybindings under the `SPC m t` prefix.

The package adds some convenient commands to run elm-test on:

  - a file
  - a directory
  - a projects

It also provides a handy way to toggle between a test and its implementation.