### PR TITLE
Re-add org-trello

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ python-*-docs-html
 nov-places
 workspace
 eclipse.jdt.ls
+.trello
 
 # Private directory
 private/

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -15,6 +15,7 @@
   - [[#revealjs-support][Reveal.js support]]
   - [[#org-journal-support][Org-journal support]]
   - [[#hugo-support][Hugo support]]
+  - [[#trello-support][Trello support]]
   - [[#different-bullets][Different bullets]]
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
@@ -226,6 +227,15 @@ To install the Org exporter [[https://ox-hugo.scripter.co][ox-hugo]] that genera
   (setq-default dotspacemacs-configuration-layers '(
     (org :variables
          org-enable-hugo-support t)))
+#+END_SRC
+
+** Trello support
+To install Trello support set the variable =org-enable-trello-support= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-trello-support t)))
 #+END_SRC
 
 ** Different bullets

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -34,3 +34,6 @@ used.")
 
 (defvar org-enable-hugo-support nil
   "If non-nil, Hugo (https://gohugo.io) related packages are configured.")
+
+(defvar org-enable-trello-support nil
+  "My test")

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -36,4 +36,4 @@ used.")
   "If non-nil, Hugo (https://gohugo.io) related packages are configured.")
 
 (defvar org-enable-trello-support nil
-  "My test")
+  "If non-nil org-trello is configured")

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -49,3 +49,13 @@
   (with-eval-after-load 'evil-surround
     (add-to-list 'evil-surround-pairs-alist '(?: . spacemacs//surround-drawer))
     (add-to-list 'evil-surround-pairs-alist '(?# . spacemacs//surround-code))))
+
+
+
+(defun spacemacs/org-trello-pull-buffer ()
+  (interactive)
+  (org-trello-sync-buffer 1))
+
+(defun spacemacs/org-trello-push-buffer ()
+  (interactive)
+  (org-trello-sync-buffer))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -37,6 +37,7 @@
         (ox-reveal :toggle org-enable-reveal-js-support)
         persp-mode
         (ox-hugo :toggle org-enable-hugo-support)
+        (org-trello :toggle org-enable-trello-support)
         ))
 
 (defun org/post-init-company ()
@@ -664,3 +665,24 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
 (defun org/init-ox-hugo ()
   (use-package ox-hugo :after ox))
+
+(defun org/init-org-trello ()
+  (use-package org-trello
+    :defer t
+    :init
+    (progn
+      (defun spacemacs/org-trello-pull-buffer ()
+        (interactive)
+        (org-trello-sync-buffer 1))
+      (defun spacemacs/org-trello-push-buffer ()
+        (interactive)
+        (org-trello-sync-buffer))
+      (spacemacs/declare-prefix-for-mode 'org-mode "mo" "trello")
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode
+        "oI" 'org-trello-install-key-and-token
+        "oa" 'org-trello-archive-card
+        "oc" 'org-trello-create-board-and-install-metadata
+        "od" 'spacemacs/org-trello-pull-buffer
+        "oi" 'org-trello-install-board-metadata
+        "om" 'org-trello-update-board-metadata
+        "ou" 'spacemacs/org-trello-push-buffer))))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -669,14 +669,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
 (defun org/init-org-trello ()
   (use-package org-trello
     :defer t
-    :init
+    :config
     (progn
-      (defun spacemacs/org-trello-pull-buffer ()
-        (interactive)
-        (org-trello-sync-buffer 1))
-      (defun spacemacs/org-trello-push-buffer ()
-        (interactive)
-        (org-trello-sync-buffer))
       (spacemacs/declare-prefix-for-mode 'org-mode "mo" "trello")
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
         "oI" 'org-trello-install-key-and-token


### PR DESCRIPTION
After finding issue #9328 I thought I'd try to add _org-trello_ in the "right" way.

- I'm using the really rather cool `:toggle` option of declaring dependencies.
- The loading should be deferred.
- There's a rather minimal set of spacemacs-style key bindings at the moment, but it should be enough to get started (I think)

Comments and suggestions are most welcome!