### PR TITLE
Revert "Disable evil-ediff for now"

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -13,8 +13,7 @@
       '(evil-anzu
         evil-args
         evil-cleverparens
-        ;; this package has been moved, need to import it to Spacemacs
-        ;; evil-ediff
+        evil-ediff
         evil-escape
         evil-exchange
         evil-goggles


### PR DESCRIPTION
This reverts commit 4dbd5e6110210e849aa395f73cf40a5c984b5cd8.

As evil-ediff is long time back in melpa. 
https://github.com/syl20bnr/spacemacs/issues/10972
https://melpa.org/#/evil-ediff