### PR TITLE
Bind treemacs-projectile

### DIFF
--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -1,0 +1,22 @@
+;;; packages.el --- Neotree Layer functions File
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/treemacs-project-toggle ()
+  "Toggle and add the current project to treemacs if not already added."
+  (interactive)
+  (if (eq (treemacs-current-visibility) 'visible)
+      (delete-window (treemacs-get-local-window))
+    (let ((path (projectile-project-root))
+          (name (projectile-project-name)))
+      (unless (treemacs-current-workspace)
+        (treemacs--find-workspace))
+      (treemacs-do-add-project-to-workspace path name)
+      (treemacs-select-window))))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -41,10 +41,10 @@
             treemacs-goto-tag-strategy 'refetch-index
             treemacs-collapse-dirs treemacs-use-collapsed-directories)
       (spacemacs/set-leader-keys
-        "ft"    #'treemacs
-        "fB"    #'treemacs-bookmark
-        "fT"    #'treemacs-find-file
-        "f M-t" #'treemacs-find-tag))
+        "ft"    'treemacs
+        "fB"    'treemacs-bookmark
+        "fT"    'treemacs-find-file
+        "f M-t" 'treemacs-find-tag))
     :config
     (progn
       (spacemacs/define-evil-state-face "treemacs" "MediumPurple1")
@@ -71,5 +71,5 @@
     :post-config
     (progn
       ;; window 0 is reserved for file trees
-      (spacemacs/set-leader-keys "0" #'treemacs-select-window)
-      (define-key winum-keymap (kbd "M-0") #'treemacs-select-window))))
+      (spacemacs/set-leader-keys "0" 'treemacs-select-window)
+      (define-key winum-keymap (kbd "M-0") 'treemacs-select-window))))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -24,7 +24,8 @@
 
 (defun treemacs/init-treemacs ()
   (use-package treemacs
-    :commands (treemacs-select-window treemacs--window-number-ten)
+    :commands (treemacs-select-window treemacs--window-number-ten
+               treemacs-current-visibility)
     :defer t
     :init
     (progn
@@ -44,7 +45,8 @@
         "ft"    'treemacs
         "fB"    'treemacs-bookmark
         "fT"    'treemacs-find-file
-        "f M-t" 'treemacs-find-tag))
+        "f M-t" 'treemacs-find-tag
+        "pt"    'spacemacs/treemacs-project-toggle))
     :config
     (progn
       (spacemacs/define-evil-state-face "treemacs" "MediumPurple1")


### PR DESCRIPTION
Adds binding for treemacs-projectile. I also removed some unneeded pound signs i found while editing the treemacs package.el file. I had to remove the `:after` block because it inhibited the `:init` block from running, it should not matter since there is only one interactive command in the `treemacs-projectile.el` file and it's autoloaded.

Initially i created a custom function that would either add the current projectile project to treemacs or toggle treemacs if it's already added, kinda like the neotree version of the "pt" command does but changed my mind and went with the `treemacs-projectile` command instead. The difference is that in `treemacs-projectile` you have to select what project you want to add from all projectile projects and it does not toggle treemacs, it's only for adding new projects to treemacs. If you want me to submit a pull-request with the custom version and close this one then tell me so.