### PR TITLE
[CI] Add linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,22 @@ jobs:
     working_directory: ~/.emacs.d
     <<: *spacemacs_steps
 
+  "Linters (required)":
+    docker:
+      - image: jare/spacemacs-circleci:latest
+    working_directory: ~/.emacs.d
+    steps:
+      - checkout
+      - run:
+          name: Install npm
+          command: apt-get update && apt-get install -y --no-install-recommends npm
+      - run:
+          name: Install eclint
+          command: npm install -g eclint
+      - run:
+          name: Run Linters
+          command: make ci
+
   # Emacs snapshot
   "core Emacs snapshot (optional)":
     docker:
@@ -149,6 +165,9 @@ workflows:
           requires:
             - "Validate PR"
       - "spacemacs dist. Emacs25 (required)":
+          requires:
+            - "Validate PR"
+      - "Linters (required)":
           requires:
             - "Validate PR"
       - "core Emacs snapshot (optional)":

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,61 @@
+root = true
+
+# -------------------------------------------------------------------------------
+# Global config, to be enabled when everything is fixed.
+# -------------------------------------------------------------------------------
+# [*]
+# charset                  = utf-8
+# end_of_line              = lf
+# indent_size              = 2
+# indent_style             = space
+# insert_final_newline     = true
+# tab_width                = 2
+# trim_trailing_whitespace = true
+
+# -------------------------------------------------------------------------------
+# Emacs Lisp
+# -------------------------------------------------------------------------------
+[{core,layers,tests}/**.el]
+charset                  = utf-8
+end_of_line              = lf
+# indent_size              = 2
+# indent_style             = space
+insert_final_newline     = true
+# tab_width                = 2
+trim_trailing_whitespace = true
+
+# -------------------------------------------------------------------------------
+# Make
+# -------------------------------------------------------------------------------
+[**/{Makefile,**.mk}]
+charset                  = utf-8
+end_of_line              = lf
+indent_size              = 2
+indent_style             = tab
+insert_final_newline     = true
+tab_width                = 2
+trim_trailing_whitespace = true
+
+# -------------------------------------------------------------------------------
+# Markdown
+# -------------------------------------------------------------------------------
+[**.md]
+charset                  = utf-8
+end_of_line              = lf
+# indent_size              = 2
+indent_style             = space
+insert_final_newline     = true
+tab_width                = 2
+trim_trailing_whitespace = true
+
+# -------------------------------------------------------------------------------
+# Org
+# -------------------------------------------------------------------------------
+[{core,doc,layers,news,tests}/**.org]
+charset                  = utf-8
+end_of_line              = lf
+# indent_size              = 2
+# indent_style             = space
+insert_final_newline     = true
+# tab_width                = 2
+trim_trailing_whitespace = true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# By default the `help` goal is executed.
+.DEFAULT_GOAL := help
+
+# Displays a help message containing usage instructions and a list of available
+# goals.
+#
+# Usage:
+#
+# To display the help message run:
+# ```sh
+# make help
+# ```
+#
+# This is also the default goal so you can run it as following:
+# ```sh
+# make
+# ```
+.PHONY: help
+help:
+	@echo 'Usage: make [<GOAL_1>, <GOAL_2>, ...]'
+	@echo ''
+	@echo 'Examples:'
+	@echo '  make'
+	@echo '  make ci'
+	@echo '  make ci-eclint'
+	@echo ''
+	@echo 'Goals:'
+	@echo '  - ci:        Runs checks on this repository.'
+	@echo '  - ci-eclint: Runs `eclint`.'
+	@echo ''
+	@echo 'Default goal: help'
+
+# Runs checks on this repository.
+#
+# Usage:
+# ```sh
+# make ci
+# ```
+.PHONY: ci
+ci: ci-eclint
+
+# Runs `eclint`.
+#
+# Usage:
+# ```sh
+# make ci:eclint
+# ```
+.PHONY: ci-eclint
+ci-eclint:
+	@eclint check *

--- a/layers/+themes/colors/local/nyan-mode/nyan-mode.el
+++ b/layers/+themes/colors/local/nyan-mode/nyan-mode.el
@@ -79,7 +79,7 @@
 (defun nyan-start-music ()
   (interactive)
   (start-process-shell-command "nyan-music" "nyan-music" (concat "mplayer " +nyan-music+ " -loop 0")))
- 
+
 (defun nyan-stop-music ()
   (interactive)
   (kill-process "nyan-music"))

--- a/tests/core/Makefile
+++ b/tests/core/Makefile
@@ -13,12 +13,12 @@ TEST_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 LOAD_FILES = core/core-versions.el core/core-load-paths.el
 UNIT_TEST_FILES = \
-  core-configuration-layer-utest.el \
-  core-funcs-utest.el
+	core-configuration-layer-utest.el \
+	core-funcs-utest.el
 FUNC_TEST_FILES = \
-  core-spacemacs-ftest.el \
-  core-spacemacs-buffer-ftest.el \
-  core-configuration-layer-ftest.el \
-  core-release-management-ftest.el
+	core-spacemacs-ftest.el \
+	core-spacemacs-buffer-ftest.el \
+	core-configuration-layer-ftest.el \
+	core-release-management-ftest.el
 
 include ../../spacemacs.mk

--- a/tests/layers/+distribution/spacemacs-base/Makefile
+++ b/tests/layers/+distribution/spacemacs-base/Makefile
@@ -13,9 +13,9 @@ TEST_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 LOAD_FILES = init.el
 UNIT_TEST_FILES = \
-  evil-evilified-state-utest.el \
-  line-numbers-utest.el
+	evil-evilified-state-utest.el \
+	line-numbers-utest.el
 FUNC_TEST_FILES = \
-  evil-evilified-state-ftest.el
+	evil-evilified-state-ftest.el
 
 include ../../../../spacemacs.mk


### PR DESCRIPTION
This is the beginning for adding automatic checks. My idea is to have a place in the CI pipeline where we execute `make ci` and everything else flows as a result of that. Currently `editorconfig` is the only check executed, and it does not have full coverage, but this will be fixed in the future.

- `nyan-mode` layer had `CR` removed from line endings.
- some makefiles were fixed with tabs.

@JAremko Let me know what you think.
