### PR TITLE
proof-general is added in MELPA

### DIFF
--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -12,10 +12,7 @@
 (setq coq-packages
       '(
         (company-coq :requires company)
-        (proof-general :location (recipe
-                                  :fetcher github
-                                  :repo "ProofGeneral/PG"
-                                  :files ("*")))
+        proof-general
         smartparens
         vi-tilde-fringe
         ))


### PR DESCRIPTION
`proof-general` is added to MELPA as per https://github.com/ProofGeneral/PG/commit/ff1cb6c2c355082076d99de1f560fa0c4bbcd86c