### PR TITLE
Fix issues in ruby layer

### DIFF
--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -42,7 +42,7 @@
   (use-package bundler
     :defer t
     :init (dolist (mode '(ruby-mode enh-ruby-mode))
-            (spacemacs/declare-prefix-for-mode mode "mb" "ruby/bundle")
+            (spacemacs/declare-prefix-for-mode mode "mb" "bundle")
             (spacemacs/set-leader-keys-for-major-mode mode
               "bc" 'bundle-check
               "bi" 'bundle-install
@@ -77,7 +77,13 @@
     :init
     (progn
       (setq enh-ruby-deep-indent-paren nil
-            enh-ruby-hanging-paren-deep-indent-level 2))))
+            enh-ruby-hanging-paren-deep-indent-level 2)
+      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mr" "refactor/RuboCop/robe")
+      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mt" "test")
+      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mT" "toggle"))
+    :config
+    (spacemacs/set-leader-keys-for-major-mode 'enh-ruby-mode
+      "T{" 'enh-ruby-toggle-block)))
 
 (defun ruby/post-init-evil-matchit ()
   (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
@@ -160,9 +166,10 @@
     (progn
       (spacemacs|hide-lighter robe-mode)
       (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "mg" "ruby/goto")
-        (spacemacs/declare-prefix-for-mode mode "mh" "ruby/docs")
-        (spacemacs/declare-prefix-for-mode mode "ms" "ruby/repl")
+        (spacemacs/declare-prefix-for-mode mode "mg" "goto")
+        (spacemacs/declare-prefix-for-mode mode "mh" "docs")
+        (spacemacs/declare-prefix-for-mode mode "mrs" "robe")
+        (spacemacs/declare-prefix-for-mode mode "ms" "repl")
         (spacemacs/set-leader-keys-for-major-mode mode
           "'" 'robe-start
           ;; robe mode specific
@@ -218,7 +225,7 @@
     :init (spacemacs/add-to-hooks 'rubocop-mode '(ruby-mode-hook
                                                   enh-ruby-mode-hook))
     :config (dolist (mode '(ruby-mode enh-ruby-mode))
-              (spacemacs/declare-prefix-for-mode mode "mrr" "ruby/RuboCop")
+              (spacemacs/declare-prefix-for-mode mode "mrr" "RuboCop")
               (spacemacs/set-leader-keys-for-major-mode mode
                 "rrd" 'rubocop-check-directory
                 "rrD" 'rubocop-autocorrect-directory
@@ -234,8 +241,9 @@
            ("Puppetfile" . ruby-mode))
     :init
     (progn
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "ruby/test")
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mT" "ruby/toggle")
+      (spacemacs/declare-prefix-for-mode 'ruby-mode "mr" "refactor/RuboCop/robe")
+      (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "test")
+      (spacemacs/declare-prefix-for-mode 'ruby-mode "mT" "toggle")
       (spacemacs/add-to-hooks
        'spacemacs/ruby-maybe-highlight-debugger-keywords
        '(ruby-mode-local-vars-hook enh-ruby-mode-local-vars-hook)))
@@ -259,7 +267,7 @@
     :config
     (progn
       (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "mrR" "ruby/refactor")
+        (spacemacs/declare-prefix-for-mode mode "mrR" "refactor")
         (spacemacs/set-leader-keys-for-major-mode mode
           "rRm" 'ruby-refactor-extract-to-method
           "rRv" 'ruby-refactor-extract-local-variable
@@ -275,7 +283,7 @@
     (progn
       (spacemacs|hide-lighter ruby-tools-mode)
       (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "mx" "ruby/text")
+        (spacemacs/declare-prefix-for-mode mode "mx" "text")
         (spacemacs/set-leader-keys-for-major-mode mode
           "x\'" 'ruby-tools-to-single-quote-string
           "x\"" 'ruby-tools-to-double-quote-string
@@ -326,6 +334,7 @@
     :defer t
     :init (setq rake-cache-file (concat spacemacs-cache-directory "rake.cache"))
     :config (dolist (mode '(ruby-mode enh-ruby-mode))
+              (spacemacs/declare-prefix-for-mode mode "mk" "rake")
               (spacemacs/set-leader-keys-for-major-mode mode
                 "kk"    'rake
                 "kr"    'rake-rerun


### PR DESCRIPTION
# Changes
* Add a prefix for `rake` and refactor/RuboCop/robe commands.
* Add `test` and `toggle` prefix for `enh-ruby-mode`.
* Use `enh-ruby-toggle-block` in `enh-ruby-mode`, instead of `ruby-toggle-block`.
* Remove the prefix in prefixes `ruby/`.

![enh-ruby-mode](https://user-images.githubusercontent.com/11665236/44956992-7eb19800-af07-11e8-97c7-76a768db371b.png)
