### PR TITLE
+tools/lsp: remove lsp-ui-peek-expand-by-default

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -107,7 +107,6 @@
    | =lsp-ui-doc-include-signature=  | nil     | When nil, signature omitted from lsp-ui-doc overlay (this is usually redundant)           |
    | =lsp-ui-sideline-enable=        | t       | When non-nil, the symbol information overlay is displayed                                 |
    | =lsp-ui-sideline-show-symbol=   | nil     | When non-nil, the symbol information overlay includes symbol name (redundant for c-modes) |
-   | =lsp-ui-peek-expand-by-default= | nil     | When non-nil, =lsp-ui-peek= expands file matches automatically (may degrade performance)  |
 
 ** Diagnostics
    If some features do not work as expected, here is a common check list.

--- a/layers/+tools/lsp/config.el
+++ b/layers/+tools/lsp/config.el
@@ -11,7 +11,6 @@
 
 ;; ;; These all have toggles bound under 't' in spacemacs/lsp-define-keys-for-mode
 (defvar lsp-ui-remap-xref-keybindings nil "When non-nil, xref keybindings remapped to lsp-ui-peek-find-*")
-(defvar lsp-ui-peek-expand-by-default t "Expand lsp-ui-peek by default (may have performance implications)")
 (defvar lsp-ui-doc-enable t "Enable/disable lsp-ui-doc overlay")
 (defvar lsp-ui-doc-include-signature nil "When non-nil, type signature included in the lsp-ui-doc overlay")
 (defvar lsp-ui-sideline-enable t "Enable/disable lsp-ui-sideline overlay")

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -55,9 +55,6 @@
       (spacemacs//lsp-sync-peek-face)
       (add-hook 'spacemacs-post-theme-change-hook #'spacemacs//lsp-sync-peek-face)
 
-      (if lsp-ui-peek-expand-by-default
-        (setq lsp-ui-peek-expand-function (lambda (xs) (mapcar #'car xs))))
-
       (if lsp-ui-remap-xref-keybindings
         (progn (define-key lsp-ui-mode-map [remap xref-find-definitions] #'lsp-ui-peek-find-definitions)
           (define-key lsp-ui-mode-map [remap xref-find-references] #'lsp-ui-peek-find-references)))


### PR DESCRIPTION
lsp-ui has switched to (defcustom lsp-ui-peek-fontify 'on-demand ...) https://github.com/emacs-lsp/lsp-ui/pull/148 . This is no longer needed.
