### PR TITLE
Fix keybindings in documentation of spell checking transient state

### DIFF
--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -132,13 +132,13 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 
 | Key Binding | Description                                      |
 |-------------+--------------------------------------------------|
-| ~SPC g . b~ | Rerun spell check for the whole buffer           |
-| ~SPC g . d~ | Change dictionary                                |
-| ~SPC g . n~ | Go to next spelling error                        |
-| ~SPC g . c~ | Correct word under cursor                        |
-| ~SPC g . t~ | Toggle spell check                               |
-| ~SPC g . q~ | Quit transient state                             |
-| ~SPC g . Q~ | Quit transient state and disable =flyspell-mode= |
+| ~SPC S . b~ | Rerun spell check for the whole buffer           |
+| ~SPC S . d~ | Change dictionary                                |
+| ~SPC S . n~ | Go to next spelling error                        |
+| ~SPC S . c~ | Correct word under cursor                        |
+| ~SPC S . t~ | Toggle spell check                               |
+| ~SPC S . q~ | Quit transient state                             |
+| ~SPC S . Q~ | Quit transient state and disable =flyspell-mode= |
 
 * Known issues
 Vim-empty-lines layer seems incompatible with spell-checking inside org-mode. If


### PR DESCRIPTION
In the documentation `SPC g .` instead of the actually bound `SPC S .` was documented.