### PR TITLE
Move org-trello keys to "SPC m m"

### DIFF
--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -59,3 +59,11 @@
 (defun spacemacs/org-trello-push-buffer ()
   (interactive)
   (org-trello-sync-buffer))
+
+(defun spacemacs/org-trello-pull-card ()
+  (interactive)
+  (org-trello-sync-card 1))
+
+(defun spacemacs/org-trello-push-card ()
+  (interactive)
+  (org-trello-sync-card))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -164,6 +164,7 @@ Will work on both org-mode and any mode that accepts plain html."
                         ("mf" . "feeds")
                         ("mi" . "insert")
                         ("miD" . "download")
+                        ("mm" . "more")
                         ("ms" . "trees/subtrees")
                         ("mT" . "toggles")
                         ("mt" . "tables")
@@ -671,12 +672,12 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :after org
     :config
     (progn
-      (spacemacs/declare-prefix-for-mode 'org-mode "mo" "trello")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmt" "trello")
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "oI" 'org-trello-install-key-and-token
-        "oa" 'org-trello-archive-card
-        "oc" 'org-trello-create-board-and-install-metadata
-        "od" 'spacemacs/org-trello-pull-buffer
-        "oi" 'org-trello-install-board-metadata
-        "om" 'org-trello-update-board-metadata
-        "ou" 'spacemacs/org-trello-push-buffer))))
+        "mtI" 'org-trello-install-key-and-token
+        "mta" 'org-trello-archive-card
+        "mtc" 'org-trello-create-board-and-install-metadata
+        "mti" 'org-trello-install-board-metadata
+        "mtm" 'org-trello-update-board-metadata
+        "mtd" 'spacemacs/org-trello-pull-buffer
+        "mtu" 'spacemacs/org-trello-push-buffer))))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -673,11 +673,15 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'org-mode "mmt" "trello")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmtd" "sync down")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmtu" "sync up")
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
         "mtI" 'org-trello-install-key-and-token
         "mta" 'org-trello-archive-card
         "mtc" 'org-trello-create-board-and-install-metadata
         "mti" 'org-trello-install-board-metadata
         "mtm" 'org-trello-update-board-metadata
-        "mtd" 'spacemacs/org-trello-pull-buffer
-        "mtu" 'spacemacs/org-trello-push-buffer))))
+        "mtdb" 'spacemacs/org-trello-pull-buffer
+        "mtdc" 'spacemacs/org-trello-pull-card
+        "mtub" 'spacemacs/org-trello-push-buffer
+        "mtuc" 'spacemacs/org-trello-push-card))))


### PR DESCRIPTION
As was mentioned in https://github.com/syl20bnr/spacemacs/pull/11244#issuecomment-418482770 "SPC m o" was a bad choice for mapping in _org-trello_ functionality. This moves it to "SPC m m t", adding the "SPC m m" layer on the way.

The second changeset maps a few more useful functions.