### PR TITLE
Fixes a small typo in the README for the java layer

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -25,7 +25,7 @@
     - [[#usage-1][Usage]]
     - [[#issues][Issues]]
   - [[#lsp-java][LSP Java]]
-    - [[#instalation][Instalation]]
+    - [[#installation-2][Installation]]
     - [[#configuration-2][Configuration]]
 - [[#key-bindings][Key bindings]]
   - [[#meghanada-1][Meghanada]]
@@ -240,7 +240,7 @@ particular refactoring doesn't work.
 LSP Java is the Java adapter for [[https://github.com/emacs-lsp/lsp-mode][LSP Mode]] which is the Emacs client for [[https://github.com/Microsoft/language-server-protocol][Language
 Server Protocol]].
 
-*** Instalation
+*** Installation
 Download either [[http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz][latest]] or [[http://download.eclipse.org/jdtls/snapshots/?d][a specific version]] of Eclipse JDT Language Server
 distribution to =~/.emacs.d/eclipse.jdt.ls/server/=
 


### PR DESCRIPTION
A small typo was found in the README in the java layer 