### PR TITLE
dap-layer implementation

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -61,6 +61,8 @@
     - [[#tests-1][Tests]]
     - [[#repl][REPL]]
   - [[#lsp-java-1][LSP Java]]
+    - [[#code-intelligence-shorcuts][Code intelligence shorcuts]]
+    - [[#debugger-shorcuts][Debugger shorcuts]]
   - [[#maven][Maven]]
   - [[#gradle][Gradle]]
 
@@ -534,7 +536,7 @@ and ask you which projects you want to import.
 | ~SPC m s R~ | send region to the REPL and focus the REPL buffer in =insert state= |
 
 ** LSP Java
-
+*** Code intelligence shorcuts
 | Key Binding   | Description                           |
 |---------------+---------------------------------------|
 | ~SPC m g g~   | Go to definition                      |
@@ -560,7 +562,58 @@ and ask you which projects you want to import.
 | ~SPC m c c~   | Build project                         |
 | ~SPC m a n~   | Actionable notifications              |
 | ~SPC m =~     | Format code                           |
-
+*** Debugger shorcuts
+| Key Binding   | Description                     |
+|---------------+---------------------------------|
+| ~SPC m d t t~ | Debug test method               |
+| ~SPC m d t c~ | Debug test class                |
+| ~SPC m d j~   | Debug java class(main method).  |
+|---------------+---------------------------------|
+| ~SPC m t t~   | Run test method                 |
+| ~SPC m t c~   | Run test class                  |
+|---------------+---------------------------------|
+| ~SPC m d d d~ | start debugging                 |
+| ~SPC m d d l~ | debug last configuration        |
+| ~SPC m d d r~ | debug recent configuration      |
+|---------------+---------------------------------|
+| ~SPC m d c~   | continue                        |
+| ~SPC m d i~   | step in                         |
+| ~SPC m d o~   | step out                        |
+| ~SPC m d s~   | next step                       |
+| ~SPC m d v~   | inspect value at point          |
+| ~SPC m d r~   | restart frame                   |
+|---------------+---------------------------------|
+| ~SPC m d .~   | debug transient state           |
+|---------------+---------------------------------|
+| ~SPC m d a~   | abandon current session         |
+| ~SPC m d A~   | abandon all process             |
+|---------------+---------------------------------|
+| ~SPC m d e e~ | eval                            |
+| ~SPC m d e r~ | eval region                     |
+| ~SPC m d e t~ | eval value at point             |
+|---------------+---------------------------------|
+| ~SPC m d S s~ | switch session                  |
+| ~SPC m d S t~ | switch thread                   |
+| ~SPC m d S f~ | switch frame                    |
+|---------------+---------------------------------|
+| ~SPC m d I i~ | inspect                         |
+| ~SPC m d I r~ | inspect region                  |
+| ~SPC m d I t~ | inspect value at point          |
+|---------------+---------------------------------|
+| ~SPC m d b b~ | toggle a breakpoint             |
+| ~SPC m d b c~ | change breakpoint condition     |
+| ~SPC m d b l~ | change breakpoint log condition |
+| ~SPC m d b h~ | change breakpoint hit count     |
+| ~SPC m d b a~ | add a breakpoint                |
+| ~SPC m d b d~ | delete a breakpoint             |
+| ~SPC m d b D~ | clear all breakpoints           |
+|---------------+---------------------------------|
+| ~SPC m d '_~  | Run debug REPL                  |
+|---------------+---------------------------------|
+| ~SPC m d w l~ | list local variables            |
+| ~SPC m d w o~ | goto output buffer if present   |
+| ~SPC m d w s~ | list sessions                   |
+| ~SPC m d w b~ | list breakpoints                |
 ** Maven
 
 | Key Binding     | Description                                          |

--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -302,7 +302,12 @@
         (require 'lsp-java)
         (require 'company-lsp)
         (lsp-java-enable))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile."))
+  (if (configuration-layer/layer-used-p 'dap)
+      (progn
+        (require 'dap-java)
+        (spacemacs/dap-bind-keys-for-mode 'java-mode))
+    (message "`dap' layer is not installed, please add `dap' layer to your dotfile.")))
 
 (defun spacemacs//java-setup-lsp-company ()
   "Setup lsp auto-completion."

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -29,7 +29,7 @@
         maven-test-mode
         (meghanada :toggle (not (version< emacs-version "25.1")))
         mvn
-        (lsp-java :requires lsp-mode lsp-ui company-lsp)
+        (lsp-java :requires lsp-mode lsp-ui company-lsp dap-mode)
         org
         ))
 
@@ -439,35 +439,44 @@
                         ("mg" . "goto")
                         ("mr" . "refactor")
                         ("mq" . "lsp")))
-      (spacemacs/set-leader-keys-for-major-mode 'java-mode
-        "gg"  'xref-find-definitions
-        "gr"  'xref-find-references
-        "gR"  'lsp-ui-peek-find-references
-        "ga"  'xref-find-apropos
-        "gA"  'lsp-ui-peek-find-workspace-symbol
-        "gd"  'lsp-goto-type-definition
-        "hh"  'lsp-describe-thing-at-point
-        "el"  'lsp-ui-flycheck-list
-        "pu"  'lsp-java-update-user-settings
-        "ea"  'lsp-execute-code-action
-        "qr"  'lsp-restart-workspace
-        "roi" 'lsp-java-organize-imports
-        "rr" 'lsp-rename
-        "rai" 'lsp-java-add-import
-        "ram" 'lsp-java-add-unimplemented-methods
-        "rcp" 'lsp-java-create-parameter
-        "rcf" 'lsp-java-create-field
-        "rec" 'lsp-java-extract-to-constant
-        "rel" 'lsp-java-extract-to-local-variable
-        "rem" 'lsp-java-extract-method
-        "cc"  'lsp-java-build-project
-        "an"  'lsp-java-actionable-notifications
-        "="   'lsp-format-buffer)
+        (spacemacs/set-leader-keys-for-major-mode 'java-mode
+          "gg"  'xref-find-definitions
+          "gr"  'xref-find-references
+          "gR"  'lsp-ui-peek-find-references
+          "ga"  'xref-find-apropos
+          "gA"  'lsp-ui-peek-find-workspace-symbol
+          "gd"  'lsp-goto-type-definition
+          "hh"  'lsp-describe-thing-at-point
+          "el"  'lsp-ui-flycheck-list
+          "pu"  'lsp-java-update-user-settings
+          "ea"  'lsp-execute-code-action
+          "qr"  'lsp-restart-workspace
+          "roi" 'lsp-java-organize-imports
+          "rr" 'lsp-rename
+          "rai" 'lsp-java-add-import
+          "ram" 'lsp-java-add-unimplemented-methods
+          "rcp" 'lsp-java-create-parameter
+          "rcf" 'lsp-java-create-field
+          "rec" 'lsp-java-extract-to-constant
+          "rel" 'lsp-java-extract-to-local-variable
+          "rem" 'lsp-java-extract-method
+          "cc"  'lsp-java-build-project
+          "an"  'lsp-java-actionable-notifications
+          "="   'lsp-format-buffer
 
-      (setq lsp-highlight-symbol-at-point nil
-            lsp-ui-sideline-update-mode 'point
-            lsp-eldoc-render-all nil
-            lsp-java-completion-guess-arguments t)))))
+          ;; dap-mode
+          ;; debug
+          "ddj" 'dap-java-debug
+          "dtt" 'dap-java-debug-test-method
+          "dtc" 'dap-java-debug-test-class
+          ;; run
+          "tt" 'dap-java-run-test-method
+          "tc" 'dap-java-run-test-class)
+
+        (setq lsp-highlight-symbol-at-point nil
+              lsp-ui-sideline-update-mode 'point
+              lsp-eldoc-render-all nil
+              lsp-java-completion-guess-arguments t)))))
 
 (defun java/init-mvn ()
   (use-package mvn

--- a/layers/+tools/dap/README.org
+++ b/layers/+tools/dap/README.org
@@ -1,0 +1,106 @@
+#+TITLE: DAP layer
+
+* Table of Contents                      :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#layer-installation][Layer installation]]
+  - [[#features][Features:]]
+- [[#configuration][Configuration]]
+  - [[#derived-layers][Derived layers]]
+    - [[#declared-prefixes][Declared prefixes]]
+    - [[#default-keybindings][Default keybindings]]
+- [[#references][References]]
+
+* Description
+  Experimental integrated visual debugger using [[https://code.visualstudio.com/docs/extensionAPI/api-debugging][Debug Adapter Protocol]].
+
+  [[https://code.visualstudio.com/docs/extensionAPI/api-debugging][Debug Adapter Protocol]] is a wire protocol for communication between client and
+  Debug Server. It similar to the [[https://github.com/Microsoft/language-server-protocol][LSP]] but providers integration with debug
+  server.
+** Layer installation
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =dap= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+** Features:
+   Fully featured IDE-like debugger providing:
+   - Launch/Attach
+   - Breakpoints
+   - Exceptions
+   - Pause & Continue
+   - Step In/Out/Over
+   - Callstacks
+   - Threads
+   - Multiple simultaneous debug sessions
+   - Evaluating statements
+   - Debug/Run configurations
+   - Debug REPL
+* Configuration
+** Derived layers
+   Derived layer should provide information how to configure the language
+   specific debug adapter and the language specific bindings(e. g. debug
+   application, debug test, etc). The package declares function
+   ~spacemacs/dap-bind-keys-for-mode~ which should be used by the derived layers
+   to configure the shortcuts.
+*** Declared prefixes
+    The following prefixes have been declared:
+
+    | prefix  | name              |
+    |---------+-------------------|
+    | ~SPC m d~   | debug             |
+    | ~SPC m d d~ | launching         |
+    | ~SPC m d b~ | breakpoints       |
+    | ~SPC m d l~ | debug windows     |
+    | ~SPC m d S~ | context switching |
+    | ~SPC m d e~ | eval              |
+    | ~SPC m d I~ | inspect           |
+
+*** Default keybindings
+    The default bindings are listed below. Derived layers should extend this list:
+
+    | Key Binding   | Description                     |
+    |---------------+---------------------------------|
+    | ~SPC m d d d~ | start debugging                 |
+    | ~SPC m d d l~ | debug last configuration        |
+    | ~SPC m d d r~ | debug recent configuration      |
+    |---------------+---------------------------------|
+    | ~SPC m d c~   | continue                        |
+    | ~SPC m d i~   | step in                         |
+    | ~SPC m d o~   | step out                        |
+    | ~SPC m d s~   | next step                       |
+    | ~SPC m d v~   | inspect value at point          |
+    | ~SPC m d r~   | restart frame                   |
+    |---------------+---------------------------------|
+    | ~SPC m d .~   | debug transient state           |
+    |---------------+---------------------------------|
+    | ~SPC m d a~   | abandon current session         |
+    | ~SPC m d A~   | abandon all process             |
+    |---------------+---------------------------------|
+    | ~SPC m d e e~ | eval                            |
+    | ~SPC m d e r~ | eval region                     |
+    | ~SPC m d e t~ | eval value at point             |
+    |---------------+---------------------------------|
+    | ~SPC m d S s~ | switch session                  |
+    | ~SPC m d S t~ | switch thread                   |
+    | ~SPC m d S f~ | switch frame                    |
+    |---------------+---------------------------------|
+    | ~SPC m d I i~ | inspect                         |
+    | ~SPC m d I r~ | inspect region                  |
+    | ~SPC m d I t~ | inspect value at point          |
+    |---------------+---------------------------------|
+    | ~SPC m d b b~ | toggle a breakpoint             |
+    | ~SPC m d b c~ | change breakpoint condition     |
+    | ~SPC m d b l~ | change breakpoint log condition |
+    | ~SPC m d b h~ | change breakpoint hit count     |
+    | ~SPC m d b a~ | add a breakpoint                |
+    | ~SPC m d b d~ | delete a breakpoint             |
+    | ~SPC m d b D~ | clear all breakpoints           |
+    |---------------+---------------------------------|
+    | ~SPC m d '_~  | Run debug REPL                  |
+    |---------------+---------------------------------|
+    | ~SPC m d w l~ | list local variables            |
+    | ~SPC m d w o~ | goto output buffer if present   |
+    | ~SPC m d w s~ | list sessions                   |
+    | ~SPC m d w b~ | list breakpoints                |
+
+* References
+  - [[https://github.com/yyoncho/dap-mode][dap-mode repo]]
+  - [[https://github.com/emacs-lsp/lsp-mode][lsp-mode repo]]

--- a/layers/+tools/dap/config.el
+++ b/layers/+tools/dap/config.el
@@ -1,0 +1,10 @@
+;;; packages.el --- DAP mode functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ivan Yonchovski (yyoncho@gmail.com)
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3

--- a/layers/+tools/dap/funcs.el
+++ b/layers/+tools/dap/funcs.el
@@ -1,0 +1,66 @@
+;;; packages.el --- DAP mode functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ivan Yonchovski (yyoncho@gmail.com)
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/dap-bind-keys-for-mode (mode)
+  "Define key bindings for the specific MODE."
+
+  (spacemacs/declare-prefix-for-mode mode "md" "debug")
+  (spacemacs/declare-prefix-for-mode mode "mdd" "debuging")
+  (spacemacs/declare-prefix-for-mode mode "mdb" "breakpoints")
+  (spacemacs/declare-prefix-for-mode mode "mdw" "debug windows")
+  (spacemacs/declare-prefix-for-mode mode "mdS" "switch")
+  (spacemacs/declare-prefix-for-mode mode "mdI" "inspect")
+  (spacemacs/declare-prefix-for-mode mode "mde" "eval")
+
+  (spacemacs/set-leader-keys-for-major-mode mode
+    ;; debuging/running
+    "ddd" #'dap-debug
+    "ddl" #'dap-debug-last
+    "ddr" #'dap-debug-recent
+    ;; stepping
+    "dc" #'dap-continue
+    "di" #'dap-step-in
+    "do" #'dap-step-out
+    "ds" #'dap-next
+    "dv" #'dap-ui-inspect-thing-at-point
+    "dr" #'dap-restart-frame
+    ;; transient state
+    "d." #'dap-hydra
+    ;; abandon
+    "da" #'dap-disconnect
+    "dA" #'dap-delete-all-sessions
+    ;; eval
+    "dee" #'dap-eval
+    "der" #'dap-eval-region
+    "det" #'dap-eval-thing-at-point
+    ;; switching
+    "dSs" #'dap-switch-session
+    "dSt" #'dap-switch-thread
+    "dSf" #'dap-switch-frame
+    ;; inspect
+    "dIi" #'dap-ui-inspect
+    "dIr" #'dap-ui-inspect-region
+    "dIt" #'dap-ui-inspect-thing-at-point
+    ;; breakpoints
+    "dbb" #'dap-breakpoint-toggle
+    "dbc" #'dap-breakpoint-condition
+    "dbl" #'dap-breakpoint-log-message
+    "dbh" #'dap-breakpoint-hit-condition
+    "dba" #'dap-breakpoint-add
+    "dbd" #'dap-breakpoint-delete
+    "dbD"  #'dap-breakpoint-delete-all
+    ;; repl
+    "d'"  #'dap-ui-repl
+    ;; windows
+    "dwo" #'dap-go-to-output-buffer
+    "dwl" #'dap-ui-locals
+    "dws" #'dap-ui-sessions
+    "dwb" #'dap-ui-breakpoints))

--- a/layers/+tools/dap/packages.el
+++ b/layers/+tools/dap/packages.el
@@ -1,0 +1,20 @@
+;;; packages.el --- DAP mode functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ivan Yonchovski (yyoncho@gmail.com)
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst dap-packages
+  '(dap-mode))
+
+(defun dap/init-dap-mode ()
+  (use-package dap-mode
+    :after (lsp-mode)
+    :config
+    (dap-mode 1)
+    (dap-ui-mode 1)))


### PR DESCRIPTION
- I had some issues related to finding the corresponding shortcuts for each of
the commands and I am looking for suggestions for improvements.

- updated the lsp-java readme since the server installation is now automatic. If
you already have jdt server installation, please run lsp-java-update-server
which will download the related dap-mode related stuff.

- Make sure that you have latest melpa versions of lsp-java, lsp-ui and dap-mode
since several issues related to the java integration were fixed lately.

- dap-mode is pretty young package and it is not extensively tested

- dap-hydra which will be used as a transient state for the breakpoints and
debugging, in general, is not synched with the shortcuts in the layer. I will sync
them once there is agreement on the shortcuts configuration. Also, I have not
updated lsp-java README.org with the corresponding shortcuts for the same
reason.

- The debug integration with the python lsp layer will be implemented in
separate PR.

- There will be few more functions that are going to be added to the dap-mode at
some point and they would require shortcuts too:
* suspend/kill thread I guess - "m d t s" "m d t k"?
* watches - "m d l w"
* exception breakpoints - I have to figure out how it will look like on emacs
  side.
* goto point "m d H"?