### PR TITLE
Reenable lsp mode lighter

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -28,7 +28,6 @@
     :defer t
     :config
     (progn
-      (spacemacs|hide-lighter lsp-mode)
       (evil-set-command-property 'lsp-goto-type-definition :jump t)
       (evil-set-command-property 'lsp-goto-implementation :jump t))))
 


### PR DESCRIPTION
- The lsp modeline is used to provide information about the server status so it
should not be be hidden.

