### PR TITLE
Remove post-init and use :commands to optimise loading of counsel-spo…

### DIFF
--- a/layers/+music/spotify/packages.el
+++ b/layers/+music/spotify/packages.el
@@ -35,12 +35,16 @@
   (use-package counsel-spotify
     :defer t
     :init (progn
+            (spacemacs/declare-prefix "amss" "counsel-spotify-search")
+            (spacemacs/declare-prefix "amssT" "search-tracks-by...")
             (spacemacs/set-leader-keys
               "amssa" 'counsel-spotify-search-artist
               "amssA" 'counsel-spotify-search-album
               "amsst" 'counsel-spotify-search-track
               "amssTa" 'counsel-spotify-search-tracks-by-artist
-              "amssTA" 'counsel-spotify-search-tracks-by-album))))
-
-(defun spotify/post-init-counsel-spotify ()
-  (load-library "counsel-spotify"))
+              "amssTA" 'counsel-spotify-search-tracks-by-album))
+    :commands (counsel-spotify-search-artist
+               counsel-spotify-search-album
+               counsel-spotify-search-track
+               counsel-spotify-search-tracks-by-artist
+               counsel-spotify-search-tracks-by-album)))

--- a/layers/+music/spotify/packages.el
+++ b/layers/+music/spotify/packages.el
@@ -34,17 +34,17 @@
 (defun spotify/init-counsel-spotify ()
   (use-package counsel-spotify
     :defer t
+    :commands (counsel-spotify-search-artist
+               counsel-spotify-search-album
+               counsel-spotify-search-track
+               counsel-spotify-search-tracks-by-artist
+               counsel-spotify-search-tracks-by-album)
     :init (progn
-            (spacemacs/declare-prefix "amss" "counsel-spotify-search")
-            (spacemacs/declare-prefix "amssT" "search-tracks-by...")
+            (spacemacs/declare-prefix "amss" "search")
+            (spacemacs/declare-prefix "amssT" "tracks")
             (spacemacs/set-leader-keys
               "amssa" 'counsel-spotify-search-artist
               "amssA" 'counsel-spotify-search-album
               "amsst" 'counsel-spotify-search-track
               "amssTa" 'counsel-spotify-search-tracks-by-artist
-              "amssTA" 'counsel-spotify-search-tracks-by-album))
-    :commands (counsel-spotify-search-artist
-               counsel-spotify-search-album
-               counsel-spotify-search-track
-               counsel-spotify-search-tracks-by-artist
-               counsel-spotify-search-tracks-by-album)))
+              "amssTA" 'counsel-spotify-search-tracks-by-album))))


### PR DESCRIPTION
- Don't use `load-library` in `post-init`
- Don't use `post-init`
- Use `:commands` in `use-package` to mark functions as autoload 

For more details please see https://github.com/syl20bnr/spacemacs/commit/534785ad3d89839f23fd9f435e0aa7673a7cdc06#comments