### PR TITLE
remove brew linkapps, add alternative method for linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The recommended way of installing Emacs on macOS is using [homebrew][]:
 ```sh
 $ brew tap d12frosted/emacs-plus
 $ brew install emacs-plus
-$ brew linkapps emacs-plus
+$ ln -s /usr/local/Cellar/emacs-plus/EMACS_VERSION/Emacs.app /Applications
 ```
 
 *Note:* these homebrew commands will install GNU Emacs, and link it to your


### PR DESCRIPTION
remove [deprecated brew linkapps]( https://github.com/Homebrew/brew/pull/1808) from the readme, add method to add emacs to applications

Not sure if this should be against the develop or master branch as it's just a readme change. Let me know if I need to change it.