### PR TITLE
 Add `multi-term` to `shell-default-shell` doc

### DIFF
--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -20,7 +20,7 @@
                                 'eshell
                               'ansi-term)
   "Default shell to use in Spacemacs. Possible values are `eshell', `shell',
-`term', `ansi-term', and `multi-term'.")
+`term', `ansi-term' and `multi-term'.")
 
 (defvar shell-default-position 'bottom
   "Position of the shell. Possible values are `top', `bottom', `full',

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -20,7 +20,7 @@
                                 'eshell
                               'ansi-term)
   "Default shell to use in Spacemacs. Possible values are `eshell', `shell',
-`term' and `ansi-term'.")
+`term', `ansi-term', and `multi-term'.")
 
 (defvar shell-default-position 'bottom
   "Position of the shell. Possible values are `top', `bottom', `full',


### PR DESCRIPTION
Previously, `multi-term` was not listed as an available option for `shell-default-shell`.