### PR TITLE
Add 'prettier to error msg of spacemacs/typescript-format

### DIFF
--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -136,7 +136,7 @@
    ((eq typescript-fmt-tool 'prettier)
     (call-interactively 'prettier-js))
    (t (error (concat "%s isn't valid typescript-fmt-tool value."
-                     " It should be 'tide or 'typescript-formatter."
+                     " It should be 'tide, 'typescript-formatter or 'prettier."
                      (symbol-name typescript-fmt-tool))))))
 
 (defun spacemacs/typescript-fmt-before-save-hook ()


### PR DESCRIPTION
When the user doesn't specify a valid `typescript-formatter`, `spacemacs/typescript-format` prints a helpful error message with possible options. This change includes the recently-added option `'prettier` in the message.