### PR TITLE
Remove which-key replacement: `SPC 0` and `M-0`

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -371,12 +371,6 @@
           ("\\1C-M-0..9" . "digit-argument"))
         which-key-replacement-alist)
 
-  ;; Rename the entry for M-0 in the SPC h k Top-level bindings,
-  ;; and for 0 in the SPC- Spacemacs root
-  (push '(("\\(.*\\)0" . "winum-select-window-0-or-10") .
-          ("\\10" . "select window 0 or 10"))
-        which-key-replacement-alist)
-
   ;; Rename the entry for M-1 in the SPC h k Top-level bindings,
   ;; and for 1 in the SPC- Spacemacs root, to 1..9
   (push '(("\\(.*\\)1" . "winum-select-window-1") .


### PR DESCRIPTION
Problem:
The previous which-key replacement for both `SPC 0` and `M-0`,
renamed: `winum-select-window-0-or-10` to: `select window 1 or 10`,
but the replacement gets overwritten by the filetree layers that show:
neotree: `neotree-show`
treemacs: `treemacs-select-window`

Solution:
Remove the previous which-key replacement, it's not needed anymore.