### PR TITLE
[Filetree layers] bind C-x w 0 to open the filtree

### DIFF
--- a/layers/+filetree/neotree/packages.el
+++ b/layers/+filetree/neotree/packages.el
@@ -118,5 +118,7 @@ Navigation^^^^             Actions^^         Visual actions/config^^^
     :post-config
     ;; window 0 is reserved for file trees
     (spacemacs/set-leader-keys "0" #'neotree-show)
-    (define-key winum-keymap (kbd "M-0") #'neotree-show)
+    (define-key winum-keymap [remap winum-select-window-0-or-10] #'neotree-show)
+    (push '((nil . "winum-select-window-0-or-10") . (nil . "neotree-show"))
+          which-key-replacement-alist)
     (add-to-list 'winum-assign-functions #'spacemacs//winum-neotree-assign-func)))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -72,4 +72,6 @@
     (progn
       ;; window 0 is reserved for file trees
       (spacemacs/set-leader-keys "0" 'treemacs-select-window)
-      (define-key winum-keymap (kbd "M-0") 'treemacs-select-window))))
+      (define-key winum-keymap [remap winum-select-window-0-or-10] 'treemacs-select-window)
+      (push '((nil . "winum-select-window-0-or-10") . (nil . "treemacs-select-window"))
+            which-key-replacement-alist))))


### PR DESCRIPTION
problem:
`C-x w 0` is bound to `winum-select-window-0-or-10`, this differs from the
`SPC 0` and `M-0` bindings that open the current filetree: neotree or treemacs

solution:
Bind `C-x w 0` in both filetree layers to match the other bindings.