### PR TITLE
The use of word "Whitelist" is offensive!

### DIFF
--- a/layers/+tools/ycmd/README.org
+++ b/layers/+tools/ycmd/README.org
@@ -37,10 +37,10 @@ file.
    a compile_commands.json or a .clang_complete file and get additionnal flags from a
    .ycm_extra_flags file. If you do not like this behaviour, you can write your own
    [[https://github.com/Valloric/YouCompleteMe/blob/master/README.md#c-family-semantic-completion][.ycm_extra_conf.py file]]. See [[#configuration][Configuration]] for more details.
-4) Whitelist the file by adding the following to =.spacemacs=:
+4) Allowlist the file by adding the following to =.spacemacs=:
   #+BEGIN_SRC emacs-lisp
-  ;; In this example we whitelist everything in the Develop folder
-  (setq ycmd-extra-conf-whitelist '("~/Develop/*"))
+  ;; In this example we Allowlist everything in the Develop folder
+  (setq ycmd-extra-conf-allowlist '("~/Develop/*"))
   #+END_SRC
 5) The completion is not going to work automatically until we actually force it:
   #+BEGIN_SRC emacs-lisp


### PR DESCRIPTION
We should change it to allowlist. Let's do it! For a bright future!

Please read: https://twitter.com/andrestaltz/status/1030200563802230786

Software development still has a lot of terminology with a racist or patriarchal background. Let's change that.

- Blacklist ➡ Denylist
- Whitelist ➡ Allowlist
- Killer app ➡ Beloved app
- Master/slave ➡ primary/replica

