### PR TITLE
[treemacs] give names to which-key +prefix entries

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -44,7 +44,15 @@
         "ft"    'treemacs
         "fB"    'treemacs-bookmark
         "fT"    'treemacs-find-file
-        "f M-t" 'treemacs-find-tag))
+        "f M-t" 'treemacs-find-tag)
+      (which-key-add-major-mode-key-based-replacements 'treemacs-mode
+        "c"     "treemacs-create"
+        "o"     "treemacs-visit-node"
+        "oa"    "treemacs-visit-node-ace"
+        "t"     "treemacs-toggles"
+        "y"     "treemacs-copy"
+        "C-p"   "treemacs-projects"
+        "C-p c" "treemacs-projects-collapse"))
     :config
     (progn
       (spacemacs/define-evil-state-face "treemacs" "MediumPurple1")


### PR DESCRIPTION
problem:
Which-key subgroups get the default name `+prefix`. The subgroup has to be
opened to find out which keys it contains.

solution:
Add more descriptive names:
```
c      treemacs-create
o      treemacs-visit-node
oa     treemacs-visit-node-ace
t      treemacs-toggles
y      treemacs-copy
C-p    treemacs-projects
C-p c  treemacs-projects-collapse
```