### PR TITLE
layers/+emacs/org: more clock keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -99,9 +99,19 @@ This file containes the change log for the next major version of Spacemacs.
 - Added a number of =lsp-ui= configuration variables to the layer - see [[file:./layers/+tools/lsp/README.org][LSP layer README]] for details.
 **** Org
 - Add package =org-journal= (Nick Anderson)
-- Move clock related key bindings to ~SPC a o k~
-- Add key bindings ~SPC a o k i~ to clock in last and ~SPC a o k j~
-  to jump to current clock (thanks to darkfeline)
+- Move clock related key bindings to ~SPC a o C~
+- Add key bindings:
+  - From user darkfeline:
+    - ~SPC a o C I~ to clock in last
+    - ~SPC a o C j~ to jump to current clock
+  - From user siddharthist:
+    - ~SPC a o C c~ to cancel the last clock
+    - ~SPC m p~ to change priority
+    - ~SPC m C I~ to clock in last
+    - ~SPC m C d~ to display clocks
+    - ~SPC m C g~ for org-clock-goto
+    - ~SPC m C j~ to jump to current clock
+    - ~SPC m C R~ to insert a clock report
 - Make =org-projectile= integration compatible with the newest version.
 **** Scala
 - Move =ensime= to the =java= layer (Tor Hedin Bronner)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -303,11 +303,13 @@ To permanently enable mode line display of org clock, add this snippet to your
 | ~SPC a o e~   | org store agenda views                                                    |
 | ~SPC a o f i~ | org feed goto inbox                                                       |
 | ~SPC a o f u~ | org feed update all                                                       |
-| ~SPC a o k g~ | org goto last clocked-in clock (go to specific recent clock with ~SPC u~) |
-| ~SPC a o k i~ | org clock in last                                                         |
-| ~SPC a o k j~ | org jump to current clock                                                 |
-| ~SPC a o k o~ | org clock out                                                             |
-| ~SPC a o k r~ | org resolve clocks                                                        |
+| ~SPC a o C c~ | org cancel clock                                                          |
+| ~SPC a o C g~ | org goto last clocked-in clock (go to specific recent clock with ~SPC u~) |
+| ~SPC a o C i~ | org clock in                                                              |
+| ~SPC a o C I~ | org clock in last                                                         |
+| ~SPC a o C j~ | org jump to current clock                                                 |
+| ~SPC a o C o~ | org clock out                                                             |
+| ~SPC a o C r~ | org resolve clocks                                                        |
 | ~SPC a o l~   | org store link                                                            |
 | ~SPC a o m~   | org tags view                                                             |
 | ~SPC a o o~   | org agenda                                                                |
@@ -330,39 +332,44 @@ To permanently enable mode line display of org clock, add this snippet to your
 
 ** Org-mode
 
-| Key Binding                                  | Description                                  |
-|----------------------------------------------+----------------------------------------------|
-| ~SPC m <dotspacemacs-major-mode-leader-key>~ | org-ctrl-c-ctrl-c                            |
-| ~SPC m *~                                    | org-ctrl-c-star                              |
-| ~SPC m RET~                                  | org-ctrl-c-ret                               |
-| ~SPC m -~                                    | org-ctrl-c-minus                             |
-| ~SPC m '​~                                    | org-edit-special                             |
-| ~SPC m a~                                    | org-agenda                                   |
-| ~SPC m A~                                    | org-attach                                   |
-| ~SPC m c~                                    | org-capture                                  |
-| ~SPC m C c~                                  | org-clock-cancel                             |
-| ~SPC m C g~                                  | evil-org-recompute-clocks                    |
-| ~SPC m C i~                                  | org-clock-in                                 |
-| ~SPC m C o~                                  | org-clock-out                                |
-| ~SPC m C r~                                  | org-resolve-clocks                           |
-| ~SPC m d d~                                  | org-deadline                                 |
-| ~SPC m d s~                                  | org-schedule                                 |
-| ~SPC m d t~                                  | org-time-stamp                               |
-| ~SPC m d T~                                  | org-time-stamp-inactive                      |
-| ~SPC m e e~                                  | org-export-dispatch                          |
-| ~SPC m e m~                                  | send current buffer as HTML email message    |
-| ~SPC m f i~                                  | org-feed-goto-inbox                          |
-| ~SPC m f u~                                  | org-feed-update-all                          |
-| ~SPC m l~                                    | org-open-at-point                            |
-| ~SPC m L~                                    | org-shiftright                               |
-| ~SPC m H~                                    | org-shiftleft                                |
-| ~SPC m K~                                    | org-shiftup                                  |
-| ~SPC m J~                                    | org-shiftdown                                |
-| ~SPC m C-S-l~                                | org-shiftcontrolright                        |
-| ~SPC m C-S-h~                                | org-shiftcontrolleft                         |
-| ~SPC m C-S-j~                                | org-shiftcontroldown                         |
-| ~SPC m C-S-k~                                | org-shiftcontrolup                           |
-| ~SPC s j~                                    | spacemacs/jump-in-buffer (jump to a heading) |
+| Key Binding                                  | Description                                   |
+|----------------------------------------------+-----------------------------------------------|
+| ~SPC m <dotspacemacs-major-mode-leader-key>~ | org-ctrl-c-ctrl-c                             |
+| ~SPC m *~                                    | org-ctrl-c-star                               |
+| ~SPC m RET~                                  | org-ctrl-c-ret                                |
+| ~SPC m -~                                    | org-ctrl-c-minus                              |
+| ~SPC m '​~                                    | org-edit-special                              |
+| ~SPC m a~                                    | org-agenda                                    |
+| ~SPC m A~                                    | org-attach                                    |
+| ~SPC m c~                                    | org-capture                                   |
+| ~SPC m C c~                                  | org-clock-cancel                              |
+| ~SPC m C d~                                  | Temporarily show clock times for current file |
+| ~SPC m C e~                                  | org-evaluate-time-range                       |
+| ~SPC m C g~                                  | org-clock-goto                                |
+| ~SPC m C i~                                  | org-clock-in                                  |
+| ~SPC m C I~                                  | org-clock-in-last                             |
+| ~SPC m C j~                                  | Jump to the current clock                     |
+| ~SPC m C o~                                  | org-clock-out                                 |
+| ~SPC m C R~                                  | Insert clock report                           |
+| ~SPC m C r~                                  | org-resolve-clocks                            |
+| ~SPC m d d~                                  | org-deadline                                  |
+| ~SPC m d s~                                  | org-schedule                                  |
+| ~SPC m d t~                                  | org-time-stamp                                |
+| ~SPC m d T~                                  | org-time-stamp-inactive                       |
+| ~SPC m e e~                                  | org-export-dispatch                           |
+| ~SPC m e m~                                  | send current buffer as HTML email message     |
+| ~SPC m f i~                                  | org-feed-goto-inbox                           |
+| ~SPC m f u~                                  | org-feed-update-all                           |
+| ~SPC m l~                                    | org-open-at-point                             |
+| ~SPC m L~                                    | org-shiftright                                |
+| ~SPC m H~                                    | org-shiftleft                                 |
+| ~SPC m K~                                    | org-shiftup                                   |
+| ~SPC m J~                                    | org-shiftdown                                 |
+| ~SPC m C-S-l~                                | org-shiftcontrolright                         |
+| ~SPC m C-S-h~                                | org-shiftcontrolleft                          |
+| ~SPC m C-S-j~                                | org-shiftcontroldown                          |
+| ~SPC m C-S-k~                                | org-shiftcontrolup                            |
+| ~SPC s j~                                    | spacemacs/jump-in-buffer (jump to a heading)  |
 
 ** Org with evil-org-mode
 Please see the [[https://github.com/Somelauw/evil-org-mode/blob/master/doc/keythemes.org][evil-org documentation]] for additional instructions on customizing

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -177,10 +177,20 @@ Will work on both org-mode and any mode that accepts plain html."
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
         "'" 'org-edit-special
         "c" 'org-capture
+
+        ;; Clock
+        ;; These keybindings should match those under the "aoC" prefix (below)
         "Cc" 'org-clock-cancel
+        "Cd" 'org-clock-display
+        "Ce" 'org-evaluate-time-range
+        "Cg" 'org-clock-goto
         "Ci" 'org-clock-in
+        "CI" 'org-clock-in-last
+        "Cj" 'org-clock-jump-to-current-clock
         "Co" 'org-clock-out
+        "CR" 'org-clock-report
         "Cr" 'org-resolve-clocks
+
         "dd" 'org-deadline
         "ds" 'org-schedule
         "dt" 'org-time-stamp
@@ -190,6 +200,8 @@ Will work on both org-mode and any mode that accepts plain html."
         "fu" 'org-feed-update-all
 
         "a" 'org-agenda
+
+        "p" 'org-priority
 
         "Tc" 'org-toggle-checkbox
         "Te" 'org-toggle-pretty-entities
@@ -323,11 +335,17 @@ Will work on both org-mode and any mode that accepts plain html."
         "aoe" 'org-store-agenda-views
         "aofi" 'org-feed-goto-inbox
         "aofu" 'org-feed-update-all
-        "aokg" 'org-clock-goto
-        "aoki" 'org-clock-in-last
-        "aokj" 'org-clock-jump-to-current-clock
-        "aoko" 'org-clock-out
-        "aokr" 'org-resolve-clocks
+
+        ;; Clock
+        ;; These keybindings should match those under the "mC" prefix (above)
+        "aoCc" 'org-clock-cancel
+        "aoCg" 'org-clock-goto
+        "aoCi" 'org-clock-in
+        "aoCI" 'org-clock-in-last
+        "aoCj" 'org-clock-jump-to-current-clock
+        "aoCo" 'org-clock-out
+        "aoCr" 'org-resolve-clocks
+
         "aol" 'org-store-link
         "aom" 'org-tags-view
         "aoo" 'org-agenda


### PR DESCRIPTION
Just some more keybindings!

Also, the current documentation mentions
```
 evil-org-recompute-clocks 
```
which actually isn't bound to that key.