### PR TITLE
Add godoc installation into go layer README

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -46,6 +46,7 @@ to get all the goodies of this layer:
   go get -u -v golang.org/x/tools/cmd/guru
   go get -u -v golang.org/x/tools/cmd/gorename
   go get -u -v golang.org/x/tools/cmd/goimports
+  go get -u -v golang.org/x/tools/cmd/godoc
   go get -u -v github.com/zmb3/gogetdoc
   go get -u -v github.com/cweill/gotests/...
   go get -u github.com/haya14busa/gopkgs/cmd/gopkgs


### PR DESCRIPTION
go-mode uses multiple tools for doc view, and `godoc-at-point` (`, hh`) uses `godoc` only, so added godoc installation into README.