### PR TITLE
spell-checking: add words to dictionary functionality

### DIFF
--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -120,13 +120,16 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 
 * Key Bindings
 
-| Key Binding | Description              |
-|-------------+--------------------------|
-| ~SPC S b~   | flyspell whole buffer    |
-| ~SPC S c~   | flyspell correct         |
-| ~SPC S d~   | change dictionary        |
-| ~SPC S n~   | flyspell goto next error |
-| ~SPC t S~   | toggle flyspell          |
+| Key Binding | Description                |
+|-------------+----------------------------|
+| ~SPC S a b~ | add word to dict (buffer)  |
+| ~SPC S a g~ | add word to dict (global)  |
+| ~SPC S a s~ | add word to dict (session) |
+| ~SPC S b~   | flyspell whole buffer      |
+| ~SPC S c~   | flyspell correct           |
+| ~SPC S d~   | change dictionary          |
+| ~SPC S n~   | flyspell goto next error   |
+| ~SPC t S~   | toggle flyspell            |
 
 ** Spell Checking Transient-state
 
@@ -139,6 +142,9 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 | ~SPC S . t~ | Toggle spell check                               |
 | ~SPC S . q~ | Quit transient state                             |
 | ~SPC S . Q~ | Quit transient state and disable =flyspell-mode= |
+| ~SPC S . B~ | Add word to dict (buffer)                        |
+| ~SPC S . G~ | Add word to dict (global)                        |
+| ~SPC S . S~ | Add word to dict (session)                       |
 
 * Known issues
 Vim-empty-lines layer seems incompatible with spell-checking inside org-mode. If

--- a/layers/+checkers/spell-checking/funcs.el
+++ b/layers/+checkers/spell-checking/funcs.el
@@ -22,3 +22,53 @@ auto-dictionary is not used, use the adict version otherwise."
   (if (fboundp 'adict-change-dictionary)
       (adict-change-dictionary)
     (call-interactively 'ispell-change-dictionary)))
+
+(defun spacemacs/add-word-to-dict-buffer ()
+  "Save word at point as correct in current buffer."
+  (interactive)
+  (spacemacs//add-word-to-dict 'buffer))
+
+(defun spacemacs/add-word-to-dict-global ()
+  "Save word at point as a correct word globally."
+  (interactive)
+  (spacemacs//add-word-to-dict 'save))
+
+(defun spacemacs/add-word-to-dict-session ()
+  "Save word at point as correct in current session."
+  (interactive)
+  (spacemacs//add-word-to-dict 'session))
+
+(defun spacemacs//add-word-to-dict (scope)
+  "Save word at point as a correct word. `scope' can be `save' to save
+  globally, `session' to save in current session or `buffer' for buffer local."
+  (let ((current-location (point))
+        (word (flyspell-get-word)))
+    (when (consp word)
+      (if (spacemacs//word-in-dict-p (car word))
+          (error "%s is already in dictionary" (car word))
+        (progn
+          (flyspell-do-correct scope nil (car word) current-location
+                               (cadr word) (caddr word) current-location)
+          (ispell-pdict-save t))))))
+
+(defun spacemacs//word-in-dict-p (word)
+  "Check if `word' is defined in any of the active dictionaries."
+  ;; use the correct dictionary
+  (flyspell-accept-buffer-local-defs)
+  (let (poss ispell-filter)
+    ;; now check spelling of word.
+    (ispell-send-string "%\n")	;put in verbose mode
+    (ispell-send-string (concat "^" word "\n"))
+    ;; wait until ispell has processed word
+    (while (progn
+             (accept-process-output ispell-process)
+             (not (string= "" (car ispell-filter)))))
+    ;; Remove leading empty element
+    (setq ispell-filter (cdr ispell-filter))
+    ;; ispell process should return something after word is sent.
+    ;; Tag word as valid (i.e., skip) otherwise
+    (or ispell-filter
+        (setq ispell-filter '(*)))
+    (if (consp ispell-filter)
+        (setq poss (ispell-parse-output (car ispell-filter))))
+    (or (eq poss t) (stringp poss))))

--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -47,21 +47,24 @@
       (spacemacs|define-transient-state spell-checking
         :title "Spell Checking Transient State"
         :doc "
-Spell Commands^^             Other
---------------^^             -----
-[_b_]  check whole buffer    [_t_]  toggle spell check
-[_d_]  change dictionary     [_q_]  exit
-[_n_]  next spell error      [_Q_]  exit and disable spell check
+Spell Commands^^             Other                                 Add to dict
+--------------^^             -----                                 -----------
+[_b_]  check whole buffer    [_t_]  toggle spell check             [_B_]  Add word to dict (buffer)
+[_d_]  change dictionary     [_q_]  exit                           [_G_]  Add word to dict (global)
+[_n_]  next spell error      [_Q_]  exit and disable spell check   [_S_]  Add word to dict (session)
 [_c_]  correct word
 "
         :on-enter (flyspell-mode)
         :bindings
+        ("B" spacemacs/add-word-to-dict-buffer)
         ("b" flyspell-buffer)
         ("d" spell-checking/change-dictionary)
+        ("G" spacemacs/add-word-to-dict-global)
         ("n" flyspell-goto-next-error)
         ("c" flyspell-correct-previous-word-generic)
         ("Q" flyspell-mode :exit t)
         ("q" nil :exit t)
+        ("S" spacemacs/add-word-to-dict-session)
         ("t" spacemacs/toggle-spelling-checking))
 
       (spacemacs/set-leader-keys "S." 'spacemacs/spell-checking-transient-state/body)
@@ -82,7 +85,11 @@ Spell Commands^^             Other
         :evil-leader "tS")
 
       (spacemacs/declare-prefix "S" "spelling")
+      (spacemacs/declare-prefix "Sa" "add word to dict")
       (spacemacs/set-leader-keys
+        "Sab" 'spacemacs/add-word-to-dict-buffer
+        "Sag" 'spacemacs/add-word-to-dict-global
+        "Sas" 'spacemacs/add-word-to-dict-session
         "Sb" 'flyspell-buffer
         "Sd" 'spell-checking/change-dictionary
         "Sn" 'flyspell-goto-next-error))


### PR DESCRIPTION
When writing documents in latex or any markup language there is soon or later
going to be unrecognized words that get falsely flagged as incorrect. These
functions and key-bindings allows the user to add unrecognized words to the
dictionary so they are recognized as correctly spelled words by ispell/flyspell.
This seems like a must have feature for any application that does any kind of
spell checking.