### PR TITLE
bibtex: cleanup layer and add ivy support

### DIFF
--- a/layers/+lang/bibtex/README.org
+++ b/layers/+lang/bibtex/README.org
@@ -51,8 +51,8 @@ to use Zathura:
       (start-process "zathura" "*helm-bibtex-zathura*" "/usr/bin/zathura" fpath)))
 #+end_src
 
-More configuration options are available and are detailed in the =org-ref= and
-=helm-bibtex= package documentations.
+More configuration options are available and are detailed in the =org-ref=,
+=helm-bibtex= and =ivy-bibtex= package documentations.
 
 * Key bindings
 In a Bib(La)TeX file, the following key bindings are added:
@@ -67,7 +67,7 @@ In a Bib(La)TeX file, the following key bindings are added:
 | ~SPC m i~                 | Insert new entry                           |
 | ~SPC m s~                 | Sort entry                                 |
 | ~SPC m h~                 | Various actions on entry                   |
-| ~SPC m m~                 | Manage bibtex library with =helm-bibtex=   |
+| ~SPC m m~                 | Manage bibtex library                      |
 | ~SPC m l a~               | Lookup and add arXiv paper (don't get PDF) |
 | ~SPC m l A~               | Lookup and add arXiv paper (download PDF)  |
 | ~SPC m l d~               | Lookup and add paper by DOI                |

--- a/layers/+lang/bibtex/README.org
+++ b/layers/+lang/bibtex/README.org
@@ -67,6 +67,7 @@ In a Bib(La)TeX file, the following key bindings are added:
 | ~SPC m i~                 | Insert new entry                           |
 | ~SPC m s~                 | Sort entry                                 |
 | ~SPC m h~                 | Various actions on entry                   |
+| ~SPC m m~                 | Manage bibtex library with =helm-bibtex=   |
 | ~SPC m l a~               | Lookup and add arXiv paper (don't get PDF) |
 | ~SPC m l A~               | Lookup and add arXiv paper (download PDF)  |
 | ~SPC m l d~               | Lookup and add paper by DOI                |

--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -13,14 +13,19 @@
       '(
         auctex
         (helm-bibtex :requires helm)
+        (ivy-bibtex :requires ivy)
         markdown-mode
         org
         org-ref
         ))
 
 (defun bibtex/post-init-auctex ()
-  (spacemacs/set-leader-keys-for-major-mode 'latex-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+  (cond ((configuration-layer/layer-used-p 'helm)
+         (spacemacs/set-leader-keys-for-major-mode 'latex-mode
+           "ic" 'org-ref-helm-insert-cite-link))
+        ((configuration-layer/layer-used-p 'ivy)
+         (spacemacs/set-leader-keys-for-major-mode 'latex-mode
+           "ic" 'org-ref-ivy-insert-cite-link))))
 
 (defun bibtex/init-helm-bibtex ()
   (use-package helm-bibtex
@@ -29,19 +34,35 @@
     (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
       "m" 'helm-bibtex)))
 
+(defun bibtex/init-ivy-bibtex ()
+  (use-package ivy-bibtex
+    :defer t
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
+      "m" 'ivy-bibtex)))
+
 (defun bibtex/post-init-markdown-mode ()
-  (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+  (cond ((configuration-layer/layer-used-p 'helm)
+         (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
+           "ic" 'org-ref-helm-insert-cite-link))
+        ((configuration-layer/layer-used-p 'ivy)
+         (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
+           "ic" 'org-ref-ivy-insert-cite-link))))
 
 (defun bibtex/post-init-org ()
-  (spacemacs/set-leader-keys-for-major-mode 'org-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+  (cond ((configuration-layer/layer-used-p 'helm)
+         (spacemacs/set-leader-keys-for-major-mode 'org-mode
+           "ic" 'org-ref-helm-insert-cite-link))
+        ((configuration-layer/layer-used-p 'ivy)
+         (spacemacs/set-leader-keys-for-major-mode 'org-mode
+           "ic" 'org-ref-ivy-insert-cite-link))))
 
 (defun bibtex/init-org-ref ()
   (use-package org-ref
     :defer t
     :commands (org-ref-bibtex-next-entry
                org-ref-bibtex-previous-entry
+               org-ref-ivy-insert-cite-link
                org-ref-open-in-browser
                org-ref-open-bibtex-notes
                org-ref-open-bibtex-pdf
@@ -63,7 +84,6 @@
         "gj" 'org-ref-bibtex-next-entry
         "gk" 'org-ref-bibtex-previous-entry)
 
-      (spacemacs/declare-prefix-for-mode 'bibtex-mode "ml" "lookup utilities")
       (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
         ;; Navigation
         "j" 'org-ref-bibtex-next-entry
@@ -84,4 +104,8 @@
         "lA" 'arxiv-get-pdf-add-bibtex-entry
         "ld" 'doi-utils-add-bibtex-entry-from-doi
         "li" 'isbn-to-bibtex
-        "lp" 'pubmed-insert-bibtex-from-pmid))))
+        "lp" 'pubmed-insert-bibtex-from-pmid))
+    :config
+    ;; override org-ref's default helm completion with ivy
+    (when (configuration-layer/layer-used-p 'ivy)
+      (require 'org-ref-ivy))))

--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -12,16 +12,25 @@
 (setq bibtex-packages
       '(
         auctex
+        (helm-bibtex :requires helm)
+        markdown-mode
         org
         org-ref
-        markdown-mode
-        (helm-bibtex :requires helm)
-        biblio
-        biblio-core
         ))
 
 (defun bibtex/post-init-auctex ()
   (spacemacs/set-leader-keys-for-major-mode 'latex-mode
+    "ic" 'org-ref-helm-insert-cite-link))
+
+(defun bibtex/init-helm-bibtex ()
+  (use-package helm-bibtex
+    :defer t
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
+      "m" 'helm-bibtex)))
+
+(defun bibtex/post-init-markdown-mode ()
+  (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
     "ic" 'org-ref-helm-insert-cite-link))
 
 (defun bibtex/post-init-org ()
@@ -46,12 +55,15 @@
                pubmed-insert-bibtex-from-pmid)
     :init
     (progn
+      (add-hook 'org-mode-hook (lambda () (require 'org-ref)))
+
       (evil-define-key 'normal bibtex-mode-map
         (kbd "C-j") 'org-ref-bibtex-next-entry
         (kbd "C-k") 'org-ref-bibtex-previous-entry
         "gj" 'org-ref-bibtex-next-entry
         "gk" 'org-ref-bibtex-previous-entry)
 
+      (spacemacs/declare-prefix-for-mode 'bibtex-mode "ml" "lookup utilities")
       (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
         ;; Navigation
         "j" 'org-ref-bibtex-next-entry
@@ -73,15 +85,3 @@
         "ld" 'doi-utils-add-bibtex-entry-from-doi
         "li" 'isbn-to-bibtex
         "lp" 'pubmed-insert-bibtex-from-pmid))))
-
-(defun bibtex/pre-init-org-ref ()
-  (add-hook 'org-mode-hook (lambda () (require 'org-ref))))
-
-(defun bibtex/post-init-markdown-mode ()
-  (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-    "ic" 'org-ref-helm-insert-cite-link))
-
-(defun bibtex/init-helm-bibtex ())
-(defun bibtex/init-biblio ())
-(defun bibtex/init-biblio-core ())
-


### PR DESCRIPTION
Was initially just going to add ivy support but did some small cleaning of the layer also:
biblio-/core is pulled in as dependencies by multiple packages in this layer already and their package declarations was empty and undocumented in the readme so i removed them. Users can access the functionality biblio offers from helm/ivy-bibtex. helm-bibtex was downloaded in this layer but given no keybinding so i bound helm-bibtex/ivy-bibtex to SPC mm since it is used to manage your bibtex library.