### PR TITLE
add helpful package to better-default

### DIFF
--- a/layers/+emacs/better-defaults/packages.el
+++ b/layers/+emacs/better-defaults/packages.el
@@ -10,9 +10,19 @@
 ;;; License: GPLv3
 
 (defconst better-defaults-packages
-  '(mwim
+  '(helpful
+    mwim
     unfill)
   "The list of Lisp packages required by the mwim layer.")
+
+(defun better-defaults/init-helpful ()
+  (use-package helpful
+    :defer t
+    :init
+    (global-set-key (kbd "C-h f") #'helpful-callable)
+    (global-set-key (kbd "C-h C") #'helpful-command)
+    (global-set-key (kbd "C-h v") #'helpful-variable)
+    (global-set-key (kbd "C-h k") #'helpful-key)))
 
 (defun better-defaults/init-mwim ()
   (use-package mwim

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -245,14 +245,15 @@
 (spacemacs/set-leader-keys
   "hdb" 'describe-bindings
   "hdc" 'describe-char
-  "hdf" 'describe-function
-  "hdk" 'describe-key
+  "hdf" 'helpful-callable
+  "hdf" 'helpful-command
+  "hdk" 'helpful-key
   "hdl" 'spacemacs/describe-last-keys
   "hdp" 'describe-package
   "hdP" 'configuration-layer/describe-package
   "hds" 'spacemacs/describe-system-info
   "hdt" 'describe-theme
-  "hdv" 'describe-variable
+  "hdv" 'helpful-variable
   "hI"  'spacemacs/report-issue
   "hn"  'view-emacs-news
   "hPs" 'profiler-start


### PR DESCRIPTION
`helpful` package looks good and I added it to the `better-defaults` layer.

`helpful-callable` represents `describe-function`, and `helpful-command` only looks for interactive functions.

More detail can be found [here](https://github.com/Wilfred/helpful)