### PR TITLE
Julia: Add instructions for compiling language server. Fix typo.

### DIFF
--- a/layers/+lang/julia/README.org
+++ b/layers/+lang/julia/README.org
@@ -33,12 +33,12 @@ Warning: enabling the LSP functionality within this package can cause emacs to
 hang for significant lengths of time when opening a Julia file. See tip below on
 using PackageCompiler.jl to mitigate this issue.
 
-This layer can be used with [[https://github.com/JuliaEditorSupport/LanguageServer.jl][=LanguageServer.jl=]] and emacs [[https://github.com/emacs-lsp/lsp-mode][=lsp-mode=]] to provide
+This layer can be used with [[https://github.com/JuliaEditorSupport/LanguageServer.jl][ =LanguageServer.jl= ]] and emacs [[https://github.com/emacs-lsp/lsp-mode][ =lsp-mode= ]] to provide
 richer, IDE-like capabilities. To use this layer with lsp, you must do the
 following:
 
 1. Add =lsp= to =dotspacemacs-configuration-layers=.
-2. Install =LanguageServer.jl= by invoking =Pkg.add("LanguageServer") in the
+2. Install =LanguageServer.jl= by invoking =Pkg.add("LanguageServer")= in the
    Julia REPL.
 3. Enable layer integration with lsp as described in section below.
 
@@ -46,8 +46,14 @@ following:
 =lsp-mode= might give up on the language server before its started, but
 regardless usage of =lsp-mode= with Julia can cause long delays when first
 opening files. To mitigate this issue, you can try compiling =LanguageServer.jl=
-ahead of time using [[https://github.com/JuliaLang/PackageCompiler.jl][=PackageCompiler.jl=]] this drastically reduces startup time
-if successful.
+ahead of time using [[https://github.com/JuliaLang/PackageCompiler.jl][ =PackageCompiler.jl= ]]. This drastically reduces startup time
+if successful:
+
+#+BEGIN_SRC julia
+julia> Pkg.add("PackageCompiler")
+julia> using PackageCompiler
+julia> compile_package("LanguageServer")
+#+END_SRC
 
 * Options
 While =julia-mode= is perfectly usable without configuration or other packages,


### PR DESCRIPTION
Add instructions for compiling language server for the Julia layer. Fix typo in the README file.