### PR TITLE
Add a formatter for sql-mode

### DIFF
--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -37,6 +37,7 @@ This layer adds support for a wide range of SQL dialects to Spacemacs.
   - Sybase
   - Vertica
 - Syntax-checking via [[https://github.com/purcell/sqlint][sqlint]] for ANSI SQL.
+- Format code with =sqlfmt=
 - Snippet insertion for the more general SQL constructs.
 - REPL support via =SQLi= buffer.
 - Automatic capitalization of keywords.

--- a/layers/+lang/sql/local/sqlfmt/sqlfmt.el
+++ b/layers/+lang/sql/local/sqlfmt/sqlfmt.el
@@ -1,0 +1,28 @@
+(defcustom sqlfmt-executable
+  "sqlfmt"
+  "Location of sqlfmt executable."
+  :type 'string)
+
+(defcustom sqlfmt-options
+  '("-u")
+  "Command line options to pass to sqlfmt."
+  :type '(repeat string))
+
+(defun sqlfmt-buffer ()
+  (interactive)
+  (let* ((orig-buffer (current-buffer))
+         (orig-point (point))
+         (tmpbuf (generate-new-buffer "*sqlfmt*"))
+         (status-code (apply #'call-process-region (point-min) (point-max)
+                             sqlfmt-executable nil tmpbuf nil
+                             sqlfmt-options)))
+    (deactivate-mark)
+    (with-current-buffer tmpbuf
+      (setq buffer-read-only t))
+    (if (eq status-code 0)
+        (progn
+          (with-current-buffer tmpbuf
+            (copy-to-buffer orig-buffer (point-min) (point-max)))
+          (kill-buffer tmpbuf)
+          (goto-char orig-point))
+      (error "sqlfmt failed, see %s buffer for details." (buffer-name tmpbuf)))))

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -22,6 +22,7 @@
                                :fetcher github
                                :repo "alex-hhh/emacs-sql-indent"
                                :files ("sql-indent.el")))
+        (sqlfmt :location local)
         (sqlup-mode :toggle sql-capitalize-keywords)
         ))
 
@@ -138,6 +139,13 @@
     :defer t
     :init (add-hook 'sql-mode-hook 'sqlind-minor-mode)
     :config (spacemacs|hide-lighter sqlind-minor-mode)))
+
+(defun sql/init-sqlfmt ()
+  (use-package sqlfmt
+    :commands sqlfmt-buffer
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'sql-mode
+      "=" 'sqlfmt-buffer)))
 
 (defun sql/init-sqlup-mode ()
   (use-package sqlup-mode


### PR DESCRIPTION
# Changes

* Use `sqlfmt` as a formatter for sql-mode (`, m =`)

# TODOs

- [x] Update README
- [ ] ~Add a layer option to enable format-on-save~
- [x] Fix a bug the buffer gets cleared when shfmt returned an error
- [x] Treat the error buffer as a special buffer