### PR TITLE
 Check for universal argument before paste

### DIFF
--- a/layers/+lang/swift/packages.el
+++ b/layers/+lang/swift/packages.el
@@ -25,14 +25,14 @@
     :defer t
     :init
     (progn
-      (spacemacs|advise-commands "store-initial-buffer-name"
-                                 (swift-mode-run-repl) around
-       "Store current buffer bane in bufffer local variable,
+      (defun spacemacs//swift-store-initial-buffer-name (func &rest args)
+        "Store current buffer bane in bufffer local variable,
 before activiting or switching to REPL."
-       (let ((initial-buffer (current-buffer)))
-         ad-do-it
-         (with-current-buffer swift-repl-buffer
-           (setq swift-repl-mode-previous-buffer initial-buffer))))
+        (let ((initial-buffer (current-buffer)))
+          (apply func args)
+          (with-current-buffer swift-repl-buffer
+            (setq swift-repl-mode-previous-buffer initial-buffer))))
+      (advice-add 'swift-mode-run-repl :around #'spacemacs//swift-store-initial-buffer-name)
 
       (defun spacemacs/swift-repl-mode-hook ()
         "Hook to run when starting an interactive swift mode repl"

--- a/layers/+misc/multiple-cursors/funcs.el
+++ b/layers/+misc/multiple-cursors/funcs.el
@@ -19,7 +19,7 @@
 
 (defun spacemacs/evil-mc-paste-after (&optional count register)
   "Disable paste transient state if there is more than 1 cursor."
-  (interactive "p")
+  (interactive "*P")
   (setq this-command 'evil-paste-after)
   (if (spacemacs//evil-mc-paste-transient-state-p)
     (spacemacs/paste-transient-state/evil-paste-after)
@@ -27,7 +27,7 @@
 
 (defun spacemacs/evil-mc-paste-before (&optional count register)
   "Disable paste transient state if there is more than 1 cursor."
-  (interactive "p")
+  (interactive "*P")
   (setq this-command 'evil-paste-before)
   (if (spacemacs//evil-mc-paste-transient-state-p)
     (spacemacs/paste-transient-state/evil-paste-before)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1309,21 +1309,25 @@ Compare them on count first,and in case of tie sort them alphabetically."
   (if (<= (- end beg) spacemacs-yank-indent-threshold)
       (indent-region beg end nil)))
 
-(spacemacs|advise-commands
- "indent" (yank yank-pop evil-paste-before evil-paste-after) around
- "If current mode is not one of spacemacs-indent-sensitive-modes
- indent yanked text (with universal arg don't indent)."
- (evil-start-undo-step)
- ad-do-it
- (if (and (not (equal '(4) (ad-get-arg 0)))
-          (not (member major-mode spacemacs-indent-sensitive-modes))
-          (or (derived-mode-p 'prog-mode)
-              (member major-mode spacemacs-indent-sensitive-modes)))
-     (let ((transient-mark-mode nil)
-           (save-undo buffer-undo-list))
-       (spacemacs/yank-advised-indent-function (region-beginning)
-                                               (region-end))))
- (evil-end-undo-step))
+(defun spacemacs//yank-indent-region (yank-func &rest args)
+  "If current mode is not one of spacemacs-indent-sensitive-modes
+indent yanked text (with universal arg don't indent)."
+  (evil-start-undo-step)
+  (let ((prefix (car args)))
+    (setcar args (unless (equal '(4) prefix) prefix))
+    (apply yank-func args)
+    (if (and (not (equal '(4) prefix))
+             (not (member major-mode spacemacs-indent-sensitive-modes))
+             (or (derived-mode-p 'prog-mode)
+                 (member major-mode spacemacs-indent-sensitive-modes)))
+        (let ((transient-mark-mode nil)
+              (save-undo buffer-undo-list))
+          (spacemacs/yank-advised-indent-function (region-beginning)
+                                                  (region-end)))))
+  (evil-end-undo-step))
+
+(dolist (func '(yank yank-pop evil-paste-before evil-paste-after))
+  (advice-add func :around #'spacemacs//yank-indent-region))
 
 ;; find file functions in split
 (defun spacemacs//display-in-split (buffer alist)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -979,18 +979,6 @@ toggling fullscreen."
 		 'maximized)
 	   'fullboth)))))
 
-;; taken from Prelude: https://github.com/bbatsov/prelude
-(defmacro spacemacs|advise-commands (advice-name commands class &rest body)
-  "Apply advice named ADVICE-NAME to multiple COMMANDS.
-The body of the advice is in BODY."
-  `(progn
-     ,@(mapcar (lambda (command)
-                 `(defadvice ,command
-                      (,class ,(intern (format "%S-%s" command advice-name))
-                              activate)
-                    ,@body))
-               commands)))
-
 (defun spacemacs/safe-revert-buffer ()
   "Prompt before reverting the file."
   (interactive)

--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -61,7 +61,6 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
       (evil-escape-mode t)
     (evil-escape-mode -1)))
 
-
 (defun spacemacs/linum-relative-toggle ()
   (interactive)
   (if (not (bound-and-true-p linum-relative-mode))


### PR DESCRIPTION
We should use `(interactive "*P")` in `spacemacs/evil-mc-paste-before` and `spacemacs/evil-mc-paste-after` to get the raw prefix argument.

`evil-paste-before` and `evil-paste-after` don't support plain prefix argument, so if we press <kbd>SPC u p</kbd> in `spacemacs`, we want to paste one time without indenting.
But there is already a meaning of <kbd>C-u C-y</kbd> in `emacs`, which is _put point at beginning, and mark at end_ when yanking. So it's ambiguous when we trigger <kbd>C-u C-y</kbd> in `spacemacs`.We may want to yank with the point at beginning or just yank without indenting.
We do both of them before, which looks like a misuse. After this pull request, <kbd>C-u C-y</kbd> will only yank without indenting. There may be some `emacs` users confuse with it, but if they don't work on `spacemacs-indent-sensitive-modes`, they should also be confused before.
And as there is only one `universal-argument` in `emacs`, we couldn't do something like _paste four times with auto indent disabled temporarily_. So maybe we should find another way to temporarily disable auto indent?

By the way, as `defadvice` is obsolete, I replace the use of `spacemacs|advise-commands` with `advice-add`.

