### PR TITLE
Add useful tips for react layer

### DIFF
--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -32,6 +32,21 @@ file.
 
 React layer uses the same backend defined in javascript layer. Options are =tern= and =lsp=.
 
+If you are using =lsp=, create =jsconfig.json= in the root folder of your project. =jsconfig.json= is =tsconfig.json= with =allowJs= attribute set to true. Here is an example file.
+
+#+BEGIN_SRC json
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "checkJs": true,
+    "jsx": "react",
+    "lib": [ "dom", "es2017" ]
+  }
+}
+#+END_SRC
+
 To use the on-the-fly syntax checking, install =eslint= with babel and react
 support:
 

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -96,6 +96,9 @@ Backend can be chosen on a per project basis using directory local variables
 ((typescript-mode (typescript-backend . lsp)))
 #+END_SRC
 
+And you might need to add ="allowSyntheticDefaultImports": true= in `tsconfig.json`'s
+=compilerOptions= to Allow default imports from modules with no default export.
+
 *Note:* you can easily add a directory local variable with ~SPC f v d~.
 
 * Backends


### PR DESCRIPTION
`jsconfig.json` and `tsconfig.json` tips are useful to retrieve better auto completion and jumping to definition. 

In practice, I could jump to `React` module's source code from `import React, { Component } from 'react';`.