### PR TITLE
layers: git: doc: fx,rw Repository list

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -59,13 +59,10 @@ To display the =magit status= buffer in fullscreen set the variable
 Magit auto-complete feature is enabled. For this feature to work best you
 have to setup your Git repository directory in your =dotspacemacs/user-config=
 function, this is the folder where you keep all your git-controlled projects
-(the path should end up with a ~/~ to respect Emacs conventions):
 
 #+BEGIN_SRC emacs-lisp
   (setq magit-repository-directories '("~/repos/"))
 #+END_SRC
-
-For more information, see [[http://magit.vc/manual/magit.html#Status-buffer][Magit-User-Manual#Status-buffer]]
 
 ** Magit SVN plugin
 The magit SVN plugin shows commits which were not pushed to svn yet.
@@ -292,8 +289,12 @@ stanza insert the following with the directories of your choice:
         '("~/Development"))
 #+END_SRC
 
+The DIRECTORY should end up with a ~/~ to respect Emacs conventions.
+
 | Key binding | Description                                         |
 |-------------+-----------------------------------------------------|
 | ~SPC g L~   | start git repo list                                 |
 | ~RET~       | show the git status window for the selected project |
 | ~gr~        | refresh the project list                            |
+
+For more information, look into [[http://magit.vc/manual/magit.html#Status-Buffer][Magit-User-Manual#Status-Buffer]]

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -285,10 +285,12 @@ configuration within your `.spacemacs` config. In the `dotspacemacs/user-config(
 stanza insert the following with the directories of your choice:
 
 #+BEGIN_SRC emacs-lisp
-  (setq magit-repository-directories
-        '("~/Development"))
+(setq magit-repository-directories
+      '(("~/Development/" . 2) ("~/src/" . 2)))
 #+END_SRC
 
+Where each element has the form =(DIRECTORY . DEPTH)=, when DEPTH is ~0~ - then
+only add DIRECTORY itself.
 The DIRECTORY should end up with a ~/~ to respect Emacs conventions.
 
 | Key binding | Description                                         |

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -56,13 +56,8 @@ To display the =magit status= buffer in fullscreen set the variable
 #+END_SRC
 
 ** Magit auto-complete
-Magit auto-complete feature is enabled. For this feature to work best you
-have to setup your Git repository directory in your =dotspacemacs/user-config=
-function, this is the folder where you keep all your git-controlled projects
-
-#+BEGIN_SRC emacs-lisp
-  (setq magit-repository-directories '("~/repos/"))
-#+END_SRC
+Magit auto-complete feature is enabled by default.
+For this feature to work best - setup [[#repository-list][magit repository list]].
 
 ** Magit SVN plugin
 The magit SVN plugin shows commits which were not pushed to svn yet.
@@ -280,9 +275,10 @@ or lines in a file hosted on Git web services like GitHub, GitLab, Bitbucket...
   =nil=.
 
 ** Repository list
-This feature will show a list of git directories. The feature needs slight
-configuration within your `.spacemacs` config. In the `dotspacemacs/user-config()`
-stanza insert the following with the directories of your choice:
+Feature displays a status-list of git repositories.
+Within your =.spacemacs= config, in the =dotspacemacs/user-config()= stanza
+configure =magit-repository-directories= to target Emacs to directories to look
+into.
 
 #+BEGIN_SRC emacs-lisp
 (setq magit-repository-directories


### PR DESCRIPTION
1. `magit-repository-directories` no longer handles directory-only entries, only special form _(DIRECTORY . DEPTH)_ is accepted:

```elisp
(defcustom magit-repository-directories nil
  "List of directories that are or contain Git repositories.

Each element has the form (DIRECTORY . DEPTH).  DIRECTORY has
to be a directory or a directory file-name, a string.  DEPTH,
an integer, specifies the maximum depth to look for Git
repositories.  If it is 0, then only add DIRECTORY itself."
  :package-version '(magit . "2.8.0")
  :group 'magit-essentials
:type '(repeat (cons directory (integer :tag "Depth"))))
```
(From https://github.com/magit/magit/blob/59e3891fde37b2b0937b54ffdd685703614360ad/lisp/magit-repos.el#L40-L49)

Additional info:
* Relevant doc issue that is solved upstream: https://github.com/magit/magit/issues/3475
* Magit manual: https://magit.vc/manual/magit.html#Status-Buffer

2. `Magit auto-complete` and `Repository list` doc entries had descriptions of same configuration processes. Now  after some rewrite - `Magit auto-complete` points to relevant info in `Repository list`. 