### PR TITLE
Add docker-compose keybinding to Docker layer

### DIFF
--- a/layers/+tools/docker/README.org
+++ b/layers/+tools/docker/README.org
@@ -18,6 +18,7 @@ This layer integrates basic container management into Spacemacs.
 - =Docker= build integration
 - =TRAMP= access to running Docker containers
 - =Docker= container and image management via [[https://github.com/Silex/docker.el][docker.el]]
+- =docker-compose= integration via [[https://github.com/Silex/docker.el][docker.el]]
 - Syntax checking via [[https://github.com/hadolint/hadolint][hadolint]]
 
 * Install
@@ -39,18 +40,19 @@ auto-completion of the running containers.
 
 * Key bindings
 
-| Key Binding | Description                        |
-|-------------+------------------------------------|
-| ~SPC m c b~ | build current buffer               |
-| ~SPC m c B~ | build current buffer without cache |
-| ~SPC a D c~ | list docker containers             |
-| ~SPC a D d~ | delete image                       |
-| ~SPC a D e~ | unpause container                  |
-| ~SPC a D F~ | pull image                         |
-| ~SPC a D i~ | list docker images                 |
-| ~SPC a D k~ | delete container                   |
-| ~SPC a D o~ | stop container                     |
-| ~SPC a D p~ | pause container                    |
-| ~SPC a D P~ | push image                         |
-| ~SPC a D r~ | restart container                  |
-| ~SPC a D s~ | start container                    |
+| Key Binding | Description                                 |
+|-------------+---------------------------------------------|
+| ~SPC m c b~ | build current buffer                        |
+| ~SPC m c B~ | build current buffer without cache          |
+| ~SPC a D c~ | list docker containers                      |
+| ~SPC a D C~ | docker-compose commands for current project |
+| ~SPC a D d~ | delete image                                |
+| ~SPC a D e~ | unpause container                           |
+| ~SPC a D F~ | pull image                                  |
+| ~SPC a D i~ | list docker images                          |
+| ~SPC a D k~ | delete container                            |
+| ~SPC a D o~ | stop container                              |
+| ~SPC a D p~ | pause container                             |
+| ~SPC a D P~ | push image                                  |
+| ~SPC a D r~ | restart container                           |
+| ~SPC a D s~ | start container                             |

--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -25,6 +25,7 @@
       (spacemacs/declare-prefix "aD" "Docker")
       (evil-leader/set-key
         "aDc" 'docker-containers
+        "aDC" 'docker-compose
         "aDd" 'docker-rmi
         "aDe" 'docker-unpause
         "aDF" 'docker-pull


### PR DESCRIPTION
After merging [this PR](https://github.com/Silex/docker.el/pull/39), the
`docker.el` package now supports integration with `docker-compose`. This
commit adds a keybinding for `docker-compose`, which allows us to
interact with compose files for the current project.