### PR TITLE
Proposition: Add key-bindings for jumping forward and backward

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -88,6 +88,11 @@
   ;; bind evil-jump-forward for GUI only.
   (define-key evil-motion-state-map [C-i] 'evil-jump-forward)
 
+  ;; Use '[' and ']' for jumping backward and forward
+  (spacemacs/set-leader-keys
+    "[" 'evil-jump-backward
+    "]" 'evil-jump-forward)
+
   ;; Make the current definition and/or comment visible.
   (define-key evil-normal-state-map "zf" 'reposition-window)
   ;; toggle maximize buffer


### PR DESCRIPTION
In a terminal, the C-i has the same effect as pressing TAB. Since TAB is
used for indentation, completion, etc. it conflicts with the
evil-jump-forward functionality.

This commit proposes a new shortcuts for jumping:
- Forward: \<leader> ]
- Backward: \<leader> [