### PR TITLE
replace deprecated clojure-cheatsheet with helm-cider

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -13,7 +13,7 @@
     - [[#quick-start-with-lein][Quick Start with lein]]
     - [[#more-details][More details]]
 - [[#usage][Usage]]
-  - [[#cheatsheet][Cheatsheet]]
+  - [[#advanced-help][Advanced help]]
   - [[#structuraly-safe-editing][Structuraly safe editing]]
 - [[#key-bindings][Key Bindings]]
   - [[#working-with-clojure-files-barfage-slurpage--more][Working with clojure files (barfage, slurpage & more)]]
@@ -49,7 +49,7 @@ This layer adds support for [[https://clojure.org/][Clojure]] language using [[h
 - Refactoring via [[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]]
 - Aligning of code forms via [[https://github.com/clojure-emacs/clojure-mode][clojure-mode]]
 - Debugging with [[https://bpiel.github.io/sayid/][sayid]]
-- Clojure cheatsheet
+- Advanced help with [[https://github.com/clojure-emacs/helm-cider][helm-cider]]
 - Structuraly safe editing using optional [[https://github.com/luxbock/evil-cleverparens][evil-cleverparens]]
 
 * Install
@@ -123,12 +123,13 @@ More info regarding installation of nREPL middleware can be found here:
 - clj-refactor: [[https://github.com/clojure-emacs/refactor-nrepl][refactor-nrepl]]
 
 * Usage
-** Cheatsheet
-This layers installs the [[https://github.com/clojure-emacs/clojure-cheatsheet][clojure-cheatsheet]] package which embeds this useful
-[[https://clojure.org/api/cheatsheet][cheatsheet]] into Emacs.
+** Advanced help
+This layer installs the [[https://github.com/clojure-emacs/helm-cider][helm-cider]]  package which provide helm integration
+with cider apropos. It also embeds clojure cheatsheet
 
+Type ~SPC m h a~ to display advanced apropos window.
 Type ~SPC m h c~ to display the cheatsheet then type in some terms (space
-separated) to narrow down the list. For example, try typing in sort map to see
+separated) to narrow down the list. for example, try typing in sort map to see
 some functions that deal with sorting maps.
 
 ** Structuraly safe editing
@@ -168,7 +169,7 @@ As this state works the same for all files, the documentation is in global
 | Key Binding | Description                 |
 |-------------+-----------------------------|
 | ~SPC m h a~ | cider apropos               |
-| ~SPC m h c~ | clojure cheatsheet          |
+| ~SPC m h c~ | helm cider cheatsheet       |
 | ~SPC m h g~ | cider grimoire              |
 | ~SPC m h h~ | cider doc                   |
 | ~SPC m h j~ | cider javadoc               |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -14,7 +14,7 @@
         cider
         cider-eval-sexp-fu
         clj-refactor
-        clojure-cheatsheet
+        (helm-cider :toggle (configuration-layer/layer-used-p 'helm))
         clojure-mode
         (clojure-snippets :toggle (configuration-layer/layer-used-p 'auto-completion))
         company
@@ -80,7 +80,6 @@
 
           (spacemacs/set-leader-keys-for-major-mode m
             "ha" 'cider-apropos
-            "hc" 'clojure-cheatsheet
             "hg" 'cider-grimoire
             "hh" 'cider-doc
             "hj" 'cider-javadoc
@@ -288,13 +287,14 @@
                 (spacemacs/set-leader-keys-for-major-mode m
                   (concat "r" binding) func)))))))))
 
-(defun clojure/init-clojure-cheatsheet ()
-  (use-package clojure-cheatsheet
+(defun clojure/init-helm-cider ()
+  (use-package helm-cider
     :defer t
     :init
     (progn
+      (add-hook 'clojure-mode-hook 'helm-cider-mode)
       (setq sayid--key-binding-prefixes
-            '(("mhc" . "clojure-cheatsheet")))
+            '(("mhc" . "helm-cider-cheatsheet")))
       (dolist (m '(clojure-mode
                    clojurec-mode
                    clojurescript-mode
@@ -305,7 +305,7 @@
                             m (car x) (cdr x)))
               sayid--key-binding-prefixes)
         (spacemacs/set-leader-keys-for-major-mode m
-          "hc" 'clojure-cheatsheet)))))
+          "hc" 'helm-cider-cheatsheet)))))
 
 (defun clojure/init-clojure-mode ()
   (use-package clojure-mode


### PR DESCRIPTION
Hello.

Clojure layer currently integrates [clojure-cheatsheet](https://github.com/clojure-emacs/clojure-cheatsheet) which has been merged upstream to CIDER.
This PR removes clojure-cheatsheet and adds helm-cider which provides some CIDER integration with helm.

The goto was to provide helm-cider only when helm is present and update the cheatsheet shortcut to point to helm-cider cheatsheet.

As I'm new to emacs hacking and spacemacs environment, some things maybe wrong, feel free to comment on what can be improved.

Regards