### PR TITLE
extract tide layer and add tide support to javascript and react layer

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -14,12 +14,14 @@
 (defun spacemacs//react-setup-backend ()
   "Conditionally setup react backend."
   (pcase javascript-backend
+    (`tide (spacemacs//tide-setup-tide))
     (`tern (spacemacs/tern-setup-tern))
     (`lsp (spacemacs//react-setup-lsp))))
 
 (defun spacemacs//react-setup-company ()
   "Conditionally setup company based on backend."
   (pcase javascript-backend
+    (`tide (spacemacs//tide-setup-tide-company 'rjsx-mode))
     (`tern (spacemacs/tern-setup-tern-company 'rjsx-mode))
     (`lsp (spacemacs//react-setup-lsp-company))))
 

--- a/layers/+frameworks/react/layers.el
+++ b/layers/+frameworks/react/layers.el
@@ -9,4 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(configuration-layer/declare-layers '(javascript node prettier tern web-beautify))
+(configuration-layer/declare-layers '(javascript node prettier tern tide web-beautify))

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -22,6 +22,7 @@
     rjsx-mode
     smartparens
     tern
+    tide
     web-beautify
     yasnippet
     ))
@@ -46,6 +47,10 @@
   (with-eval-after-load 'flycheck
     (dolist (checker '(javascript-eslint javascript-standard))
       (flycheck-add-mode checker 'rjsx-mode)))
+  ;; configure jsx-tide checker to run after your default jsx checker
+  (with-eval-after-load 'tide
+    (with-eval-after-load 'flycheck
+      (flycheck-add-next-checker 'javascript-eslint 'jsx-tide 'append)))
   (spacemacs/enable-flycheck 'rjsx-mode)
   (add-hook 'rjsx-mode-hook #'spacemacs//javascript-setup-eslint t))
 
@@ -98,6 +103,10 @@
 
 (defun react/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'rjsx-mode))
+
+(defun react/post-init-tide ()
+  (add-to-list 'tide--key-bindings-modes 'rjsx-mode)
+  (spacemacs//tide-set-leader-keys-for-major-modes 'rjsx-mode))
 
 (defun react/pre-init-web-beautify ()
   (if (eq javascript-fmt-tool 'web-beautify)

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -62,10 +62,11 @@ See [[file:../../+tools/web-beautify/README.org][web-beautify layer]] documentat
 See [[file:../../+tools/prettier/README.org][prettier layer]] documentation.
 
 ** Choosing a backend
-To choose a default backend set the layer variable =javascript-backend=:
+To choose a default backend set the layer variable =javascript-backend=.
+You can select from =tide=, =tern=, and =lsp=. Default is =tide=.
 
 #+BEGIN_SRC elisp
-(javascript :variables javascript-backend 'tern)
+(javascript :variables javascript-backend 'tide)
 #+END_SRC
 
 Backend can be chosen on a per project basis using directory local variables

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -13,8 +13,8 @@
 
 (spacemacs|define-jump-handlers js2-mode)
 
-(defvar javascript-backend 'tern
-  "The backend to use for IDE features. Possible values are `tern' and `lsp'.")
+(defvar javascript-backend 'tide
+  "The backend to use for IDE features. Possible values are `tide', `tern' and `lsp'.")
 
 (defvar javascript-fmt-tool 'web-beautify
   "The formatter to format a JavaScript file. Possible values are `web-beautify' and `prettier'.")

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -15,12 +15,14 @@
 (defun spacemacs//javascript-setup-backend ()
   "Conditionally setup javascript backend."
   (pcase javascript-backend
+    (`tide (spacemacs//tide-setup-tide))
     (`tern (spacemacs//javascript-setup-tern))
     (`lsp (spacemacs//javascript-setup-lsp))))
 
 (defun spacemacs//javascript-setup-company ()
   "Conditionally setup company based on backend."
   (pcase javascript-backend
+    (`tide (spacemacs//tide-setup-tide-company 'js2-mode))
     (`tern (spacemacs//javascript-setup-tern-company))
     (`lsp (spacemacs//javascript-setup-lsp-company))))
 

--- a/layers/+lang/javascript/layers.el
+++ b/layers/+lang/javascript/layers.el
@@ -9,4 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(configuration-layer/declare-layers '(json node prettier tern web-beautify))
+(configuration-layer/declare-layers '(json node prettier tide tern web-beautify))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -29,6 +29,7 @@
         prettier-js
         skewer-mode
         tern
+        tide
         web-beautify))
 
 (defun javascript/post-init-add-node-modules-path ()
@@ -46,7 +47,11 @@
 
 (defun javascript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'js2-mode)
-  (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-eslint t))
+  (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-eslint t)
+  ;; configure javascript-tide checker to run after your default javascript checker
+  (with-eval-after-load 'tide
+    (with-eval-after-load 'flycheck
+      (flycheck-add-next-checker 'javascript-eslint 'javascript-tide 'append))))
 
 (defun javascript/post-init-ggtags ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
@@ -79,7 +84,7 @@
     (progn
       (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
       ;; safe values for backend to be used in directory file variables
-      (dolist (value '(lsp tern))
+      (dolist (value '(lsp tern tide))
         (add-to-list 'safe-local-variable-values
                      (cons 'javascript-backend value))))
     :config
@@ -204,6 +209,10 @@
 
 (defun javascript/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'js2-mode))
+
+(defun javascript/post-init-tide ()
+  (add-to-list 'tide--key-bindings-modes 'js2-mode)
+  (spacemacs//tide-set-leader-keys-for-major-modes 'js2-mode))
 
 (defun javascript/pre-init-web-beautify ()
   (if (eq javascript-fmt-tool 'web-beautify)

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -101,14 +101,19 @@ Backend can be chosen on a per project basis using directory local variables
 * Backends
 ** Tide
 Tide comes with an embedded Typescript server, it is recommended to use the
-server intalled by =npm= instead. To do so set the variable
-=tide-tsserver-executable= to the path of the =tsserver= executable.
+server installed by =npm= instead.
+#+BEGIN_SRC sh
+  npm install -g typescript
+#+END_SRC
+
+To do so set the variable =tide-tsserver-executable= to the path of the
+=tsserver= executable.
 
 For example:
 
 #+BEGIN_SRC emacs-lisp
 (setq-default dotspacemacs-configuration-layers '(
-  (typescript :variables
+  (tide :variables
               tide-tsserver-executable "/usr/local/bin/tsserver")))
 #+END_SRC
 

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -102,6 +102,7 @@ Backend can be chosen on a per project basis using directory local variables
 ** Tide
 Tide comes with an embedded Typescript server, it is recommended to use the
 server installed by =npm= instead.
+
 #+BEGIN_SRC sh
   npm install -g typescript
 #+END_SRC

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -15,49 +15,20 @@
 (defun spacemacs//typescript-setup-backend ()
   "Conditionally setup typescript backend."
   (pcase typescript-backend
-    (`tide (spacemacs//typescript-setup-tide))
+    (`tide (spacemacs//tide-setup-tide))
     (`lsp (spacemacs//typescript-setup-lsp))))
 
 (defun spacemacs//typescript-setup-company ()
   "Conditionally setup company based on backend."
   (pcase typescript-backend
-    (`tide (spacemacs//typescript-setup-tide-company))
+    (`tide (spacemacs//tide-setup-tide-company 'typescript-mode 'typescript-tsx-mode))
     (`lsp (spacemacs//typescript-setup-lsp-company))))
 
 (defun spacemacs//typescript-setup-eldoc ()
   "Conditionally setup eldoc based on backend."
   (pcase typescript-backend
-    (`tide (spacemacs//typescript-setup-tide-eldoc))
+    (`tide (spacemacs//tide-setup-tide-eldoc))
     (`lsp (spacemacs//typescript-setup-lsp-eldoc))))
-
-
-;; tide
-
-(defun spacemacs//typescript-setup-tide ()
-  "Setup tide backend."
-  (progn
-    (evilified-state-evilify tide-references-mode tide-references-mode-map
-      (kbd "C-k") 'tide-find-previous-reference
-      (kbd "C-j") 'tide-find-next-reference
-      (kbd "C-l") 'tide-goto-reference)
-    (add-to-list 'spacemacs-jump-handlers-typescript-tsx-mode
-                 '(tide-jump-to-definition :async t))
-    (add-to-list 'spacemacs-jump-handlers-typescript-mode
-                 '(tide-jump-to-definition :async t))
-    (tide-setup)))
-
-(defun spacemacs//typescript-setup-tide-company ()
-  "Setup tide auto-completion."
-  (spacemacs|add-company-backends
-    :backends company-tide
-    :modes typescript-mode typescript-tsx-mode
-    :variables
-    company-minimum-prefix-length 2)
-  (company-mode))
-
-(defun spacemacs//typescript-setup-tide-eldoc ()
-  "Setup eldoc for tide."
-  (eldoc-mode))
 
 
 ;; lsp

--- a/layers/+lang/typescript/layers.el
+++ b/layers/+lang/typescript/layers.el
@@ -9,4 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(configuration-layer/declare-layers '(node javascript prettier))
+(configuration-layer/declare-layers '(node javascript prettier tide))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -56,42 +56,10 @@
     (spacemacs/add-to-hooks #'smartparens-mode '(typescript-mode-hook
                                           typescript-tsx-mode-hook))))
 
-(defun typescript/init-tide ()
-  (use-package tide
-    :defer t
-    :commands (typescript/jump-to-type-def)
-    :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mE" "errors")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mE" "errors")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mn" "name")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mn" "name")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mS" "server")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mS" "server")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "ms" "send")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "ms" "send")
-
-      (setq keybindingList '("Ee" tide-fix
-                             "Ed" tide-add-tslint-disable-next-line
-                             "gb" tide-jump-back
-                             "gg" tide-jump-to-definition
-                             "gt" spacemacs/typescript-jump-to-type-def
-                             "gu" tide-references
-                             "hh" tide-documentation-at-point
-                             "rr" tide-rename-symbol
-                             "sr" tide-restart-server)
-            typescriptList (cons 'typescript-mode keybindingList)
-            typescriptTsxList (cons 'typescript-tsx-mode
-                                    (cons "gg" (cons 'tide-jump-to-definition
-                                                     keybindingList ))))
-      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptList)
-      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptTsxList))))
+(defun typescript/post-init-tide ()
+  (add-to-list 'tide--key-bindings-modes 'typescript-mode)
+  (add-to-list 'tide--key-bindings-modes 'typescript-tsx-mode)
+  (spacemacs//tide-set-leader-keys-for-major-modes 'typescript-mode 'typescript-tsx-mode))
 
 (defun typescript/post-init-web-mode ()
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")

--- a/layers/+tools/tide/README.org
+++ b/layers/+tools/tide/README.org
@@ -1,0 +1,106 @@
+#+TITLE: Tide layer
+
+
+* Table of Contents                                         :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+  - [[#prerequisites][Prerequisites]]
+- [[#configuration][Configuration]]
+  - [[#custom-tsserver][Custom tsserver]]
+  - [[#xref-remap][Xref remap]]
+  - [[#jsx][JSX]]
+- [[#key-bindings][Key Bindings]]
+  - [[#tide-references-mode-map][=tide-references-mode-map=]]
+
+* Description
+This layer adds support for [[https://github.com/ananthakumaran/tide][tide]] stand-alone code-analysis engine for
+JavaScript and Typescript.
+
+** Features:
+- ElDoc
+- Auto complete
+- Flycheck
+- Jump to definition, Jump to type definition
+- Find occurrences
+- Rename symbol
+- Imenu
+- Compile On Save
+- Highlight Identifiers
+- Code Fixes
+- Code Refactor
+- Organize Imports
+
+* Install
+Tide layer is a necessity for Javascript, React, and Typescript layer. You don't
+need to define =tide= specifically in =dotspacemacs-configuration-layers=.
+
+** Prerequisites
+1. Install node.js v0.12.0 or greater.
+2. Make sure [[http://www.typescriptlang.org/docs/handbook/tsconfig-json.html][tsconfig.json]] or [[https://code.visualstudio.com/docs/languages/jsconfig][jsconfig.json]] is present in the root folder of the project.
+3. Install Typescript globally.
+   #+BEGIN_SRC sh
+     $ npm install -g typescript
+   #+END_SRC
+
+* Configuration
+** Custom tsserver
+Windows users may need to set the variable =tide-tsserver-executable= in order for emacs to
+locate and launch tsserver successfully. See [[https://github.com/ananthakumaran/tide#faq][this FAQ for more
+details]]. The variable can be set by adding the =tide= layer with this
+configuration layer:
+
+#+BEGIN_SRC emacs-lisp
+  (tide :variables tide-tsserver-executable "node_modules/typescript/bin/tsserver")
+#+END_SRC
+
+** Xref remap
+By setting =tide-remap-xref-keybindings= to =t=, xref keybindings remapped to =tide-jump-to-definition=
+and =tide-references=:
+
+#+BEGIN_SRC emacs-lisp
+  (tide :variables tide-remap-xref-keybindings t)
+#+END_SRC
+
+** JSX
+Create =jsconfig.json= in the root folder of your project. =jsconfig.json= is
+=tsconfig.json= with allowJs attribute set to true.
+
+="allowSyntheticDefaultImports": true= is necessary to enable synthetic imports
+for proper jumping to definition.
+
+Here is a =jsconfig.json= example file.
+
+#+BEGIN_SRC json
+  {
+    "compilerOptions": {
+      "target": "es2017",
+      "allowSyntheticDefaultImports": true,
+      "noEmit": true,
+      "checkJs": true,
+      "jsx": "react",
+      "lib": [ "dom", "es2017" ]
+
+    }
+  }
+#+END_SRC
+
+* Key Bindings
+
+| Key Binding   | Description                                                   |
+|---------------+---------------------------------------------------------------|
+| ~SPC m E e~   | apply code fix for the error at point                         |
+| ~SPC m E d~   | Add a tslint flag to disable rules generating errors at point |
+| ~SPC m g b~   | Pop back to where M-. was last invoked                        |
+| ~SPC m g g~   | jump to the definition of the thing under the cursor          |
+| ~SPC m g t~   | jump to the definition of the thing under the cursor          |
+| ~SPC m g u~   | List all references to the symbol at point                    |
+| ~SPC m r r s~ | Show documentation of the symbol at point                     |
+| ~SPC m s r~   | Restarts tsserver                                             |
+
+** =tide-references-mode-map=
+| Key Binding | Description                               |
+|-------------+-------------------------------------------|
+| ~C-k~       | tide find previous reference              |
+| ~C-j~       | tide find next reference                  |
+| ~C-l~       | tide go to the reference under the cursor |

--- a/layers/+tools/tide/README.org
+++ b/layers/+tools/tide/README.org
@@ -1,6 +1,5 @@
 #+TITLE: Tide layer
 
-
 * Table of Contents                                         :TOC_4_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
@@ -55,8 +54,8 @@ configuration layer:
 #+END_SRC
 
 ** Xref remap
-By setting =tide-remap-xref-keybindings= to =t=, xref keybindings remapped to =tide-jump-to-definition=
-and =tide-references=:
+By setting =tide-remap-xref-keybindings= to =t=, xref keybindings remapped to
+=tide-jump-to-definition= and =tide-references=:
 
 #+BEGIN_SRC emacs-lisp
   (tide :variables tide-remap-xref-keybindings t)
@@ -66,8 +65,8 @@ and =tide-references=:
 Create =jsconfig.json= in the root folder of your project. =jsconfig.json= is
 =tsconfig.json= with allowJs attribute set to true.
 
-="allowSyntheticDefaultImports": true= is necessary to enable synthetic imports
-for proper jumping to definition.
+=allowSyntheticDefaultImports= is necessary to enable synthetic imports for
+proper jumping to definition.
 
 Here is a =jsconfig.json= example file.
 
@@ -99,6 +98,7 @@ Here is a =jsconfig.json= example file.
 | ~SPC m s r~   | Restarts tsserver                                             |
 
 ** =tide-references-mode-map=
+
 | Key Binding | Description                               |
 |-------------+-------------------------------------------|
 | ~C-k~       | tide find previous reference              |

--- a/layers/+tools/tide/config.el
+++ b/layers/+tools/tide/config.el
@@ -1,0 +1,16 @@
+;;; funcs.el --- Tide Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ting Zhou <ztlevi1993@gmail.coom>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar tide-remap-xref-keybindings nil
+  "When non-nil, xref keybindings remapped to tide-jump-to-definition and tide-references")
+
+(defvar tide--key-bindings-modes nil
+  "List of major modes where tide key-bindings must be defined.")

--- a/layers/+tools/tide/funcs.el
+++ b/layers/+tools/tide/funcs.el
@@ -1,0 +1,74 @@
+;;; funcs.el --- Tide Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ting Zhou <ztlevi1993@gmail.coom>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//tide-setup-tide ()
+  "Setup tide backend."
+  (progn
+    (evilified-state-evilify tide-references-mode tide-references-mode-map
+      (kbd "C-k") 'tide-find-previous-reference
+      (kbd "C-j") 'tide-find-next-reference
+      (kbd "C-l") 'tide-goto-reference)
+    (tide-setup)
+    (unless (tide-current-server)
+      (tide-restart-server))
+    (tide-hl-identifier-mode +1)))
+
+(defun spacemacs//tide-setup-tide-company (&rest modes)
+  "Setup tide auto-completion."
+  (spacemacs|add-company-backends
+    :backends company-tide
+    :modes ,@modes
+    :variables
+    company-minimum-prefix-length 2
+    company-tooltip-align-annotations t)
+  (company-mode))
+
+(defun spacemacs//tide-setup-tide-eldoc ()
+  "Setup eldoc for tide."
+  (eldoc-mode))
+
+(defun spacemacs//tide-set-leader-keys-for-major-modes (&rest modes)
+  "Set tide key bindings for major modes"
+  (setq keybindingList '("Ee" tide-fix
+                         "Ed" tide-add-tslint-disable-next-line
+                         "gb" tide-jump-back
+                         "gg" tide-jump-to-definition
+                         "gt" spacemacs/typescript-jump-to-type-def
+                         "gu" tide-references
+                         "hh" tide-documentation-at-point
+                         "rrs" tide-rename-symbol
+                         "sr" tide-restart-server))
+  (dolist (m modes)
+    (setq tideList (cons m keybindingList))
+    (apply 'spacemacs/set-leader-keys-for-major-mode tideList)))
+
+(defun spacemacs//tide-project-root ()
+  "Resolve to `projectile-project-root' if `tide-project-root' fails."
+  (or tide-project-root
+      (or (locate-dominating-file default-directory "tsconfig.json")
+          (locate-dominating-file default-directory "jsconfig.json"))
+      (projectile-project-root)
+      "."))
+
+(defun +javascript|cleanup-tide-processes ()
+  "Clean up dangling tsserver processes if there are no more buffers with
+`tide-mode' active that belong to that server's project."
+  (when tide-mode
+    (unless (cl-loop with project-name = (tide-project-name)
+                     for buf in (delq (current-buffer) (buffer-list))
+                     if (and (buffer-local-value 'tide-mode buf)
+                             (with-current-buffer buf
+                               (string= (tide-project-name) project-name)))
+                     return buf)
+      (kill-process (tide-current-server)))))
+
+(defun kill-tide-hook ()
+  (add-hook 'kill-buffer-hook #'+javascript|cleanup-tide-processes nil t))

--- a/layers/+tools/tide/packages.el
+++ b/layers/+tools/tide/packages.el
@@ -1,0 +1,52 @@
+;;; packages.el --- Tide Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ting Zhou <ztlevi1993@gmail.coom>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+(setq tide-packages
+      '(tide))
+
+(defun tide/init-tide ()
+  (use-package tide
+    :defer t
+    :commands (typescript/jump-to-type-def)
+    :config
+    (progn
+      (setq tide-completion-detailed t
+            tide-always-show-documentation t)
+
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mE" "errors")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mE" "errors")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mn" "name")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mn" "name")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mr" "refactor")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mr" "refactor")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "mS" "server")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mS" "server")
+      (spacemacs/declare-prefix-for-mode 'typescript-mode "ms" "send")
+      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "ms" "send")
+
+      (spacemacs|hide-lighter tide-mode)
+      ;; Set jump handler for tide with the given MODE.
+      (dolist (m tide--key-bindings-modes)
+        (add-to-list (intern (format "spacemacs-jump-handlers-%S" m))
+                     '(tide-jump-to-definition :async t)))
+
+      (if tide-remap-xref-keybindings
+          (progn
+            (define-key tide-mode-map [remap xref-find-definitions] #'tide-jump-to-definition)
+            (define-key tide-mode-map [remap xref-find-references] #'tide-references)))
+
+      (advice-add #'tide-project-root :override #'spacemacs//tide-project-root)
+
+      ;; cleanup tsserver when no tide buffers are left
+      (add-hook 'tide-mode-hook 'kill-tide-hook))))


### PR DESCRIPTION
`tide` is great for javascript as well especially for `npm intellisense`. It works just like in `vscode`. I extract tide from typescript layer to a stand-alone layer. 

I made `tide` as the default backend for `javascript` and `react` as well because it's really amazing. For `react` support, as I mentioned in the `tide` layer doc, `jsconfig.json` is necessary and `allowSyntheticDefaultImports` can help to enable the proper jumping to the definition.