### PR TITLE
json: tell prettier content is to be parsed as json

### DIFF
--- a/layers/+lang/json/funcs.el
+++ b/layers/+lang/json/funcs.el
@@ -32,3 +32,8 @@ If ARG is a numerical prefix argument then specify the indentation level."
     (if (equal start end)
         (save-excursion (json-reformat-region (point-min) (point-max)))
       (json-reformat-region start end))))
+
+(defun spacemacs/json-setup-prettier ()
+  "Tell prettier the content is to be parsed as JSON regardless of any file
+extensions."
+  (setq-local prettier-js-args '("--parser=json")))

--- a/layers/+lang/json/packages.el
+++ b/layers/+lang/json/packages.el
@@ -57,8 +57,9 @@
       "hp" 'jsons-print-path)))
 
 (defun json/pre-init-prettier-js ()
-  (if (eq json-fmt-tool 'prettier)
-      (add-to-list 'spacemacs--prettier-modes 'json-mode)))
+  (when (eq json-fmt-tool 'prettier)
+      (add-to-list 'spacemacs--prettier-modes 'json-mode)
+      (add-hook 'json-mode-hook #'spacemacs/json-setup-prettier)))
 
 (defun json/pre-init-web-beautify ()
   (if (eq json-fmt-tool 'web-beautify)


### PR DESCRIPTION
In json-mode tell prettier the content is always to be parsed as json.
Fixes formatting in orgmode `#+BEGIN_SRC json` blocks as prettier
otherwise expects content as javascript.

Fixes: #11343