### PR TITLE
Prettier support for markdown

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -8,6 +8,7 @@
   - [[#bibtex][BibTeX]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
+  - [[#formatting][Formatting]]
   - [[#live-preview][Live preview]]
   - [[#automatic-mmm-mode-generation][Automatic MMM-Mode Generation]]
 - [[#usage][Usage]]
@@ -45,6 +46,15 @@ add =markdown= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 * Configuration
+** Formatting
+To format markdown files, you need to set =markdown-fmt-tool=. By default, it
+uses =prettier=. You might need to check out prettier layer for more information.
+
+#+BEGIN_SRC emacs-lisp
+  dotspacemacs-configuration-layers '(
+    (markdown :variables markdown-fmt-tool 'prettier))
+#+END_SRC
+
 ** Live preview
 By default the built-in Emacs web browser is used to live preview a markdown
 buffer.

--- a/layers/+lang/markdown/config.el
+++ b/layers/+lang/markdown/config.el
@@ -37,3 +37,6 @@ generate mmm classes.")
 
 (defvar markdown--key-bindings-modes '(markdown-mode gfm-mode)
   "Modes using markdown key bindings.")
+
+(defvar markdown-fmt-tool 'prettier
+  "The formatter to format a JavaScript file.")

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -54,6 +54,11 @@
     (("\\.m[k]d" . markdown-mode)
      ("\\.mdk" . markdown-mode))
     :defer t
+    :init
+    (if (eq markdown-fmt-tool 'prettier)
+        (progn
+          (add-to-list 'spacemacs--prettier-modes 'markdown-mode)
+          (add-to-list 'spacemacs--prettier-modes 'gfm-mode)))
     :config
     (progn
       (add-hook 'markdown-mode-hook 'orgtbl-mode)


### PR DESCRIPTION
Since prettier is great for markdown as well, I added it to markdown layers.

Personally, I really like `prettier-js-mode`. It just a mode bound with `after-save-hook` but really saves me a lot of time, and I believe it's always nice for `C-s/s-s` masters. So maybe it's time to add `prettier-js-mode` to spacemacs.