### PR TITLE
Put magic-latex-buffer in TeX-update-style-hook instead of LaTeX-mode-hook

### DIFF
--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -210,7 +210,7 @@
     :defer t
     :init
     (progn
-      (add-hook 'LaTeX-mode-hook 'magic-latex-buffer)
+      (add-hook 'TeX-update-style-hook 'magic-latex-buffer)
       (setq magic-latex-enable-block-highlight t
             magic-latex-enable-suscript t
             magic-latex-enable-pretty-symbols t


### PR DESCRIPTION
Currently, `magic-latex-buffer` is run from `LaTeX-mode-hook`. However, `find-file-hook`, which runs after `LaTeX-mode-hook`, calls `TeX-update-style`, which resets `font-lock-keywords`, wiping out some of MLB's modifications.

This PR simply moves `magic-latex-buffer` to `TeX-update-style-hook`.

See https://github.com/zk-phi/magic-latex-buffer/issues/36