### PR TITLE
Make Treemacs resizable by default

### DIFF
--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -10,6 +10,7 @@
   - [[#follow-mode][Follow mode]]
   - [[#file-watch][File watch]]
   - [[#collapsed-directories][Collapsed directories]]
+  - [[#locking-width][Locking width]]
 - [[#key-bindings][Key Bindings]]
   - [[#global][Global]]
   - [[#inside-treemacs][Inside Treemacs]]
@@ -53,7 +54,7 @@ layer variable =treemacs-use-follow-mode= to non-nil.
     (treemacs :variables treemacs-use-follow-mode t)))
 #+END_SRC
 
-Default value is =t=.
+Default is =t=.
 
 ** File watch
 To automatically refresh the Treemacs buffer when there is a change in the
@@ -65,7 +66,7 @@ part of the file system shown by treemacs set the layer variable
     (treemacs :variables treemacs-use-filewatch-mode t)))
 #+END_SRC
 
-Default value is =t=.
+Default is =t=.
 
 ** Collapsed directories
 *This feature requires python to be installed*.
@@ -79,7 +80,19 @@ layer variable =treemacs-use-collapsed-directories= to a positive number.
     (treemacs :variables treemacs-use-collapsed-directories 3)))
 #+END_SRC
 
-Default value is 3 (or 0 when python is not installed).
+Default is 3 (or 0 when python is not installed).
+
+** Locking width
+To have the width of the treemacs window locked by default, meaning not manually
+resizable, set the variable =treemacs-lock-width= to non-nil. It will still be
+resizable through Treemacs commands and keybindings.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (treemacs :variables treemacs-lock-width t)))
+#+END_SRC
+
+Default is =nil=.
 
 * Key Bindings
 ** Global

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -29,3 +29,6 @@ There are 2 possible values:
 1) simple, which highlights only files based on their git status, and is
    slightly faster
 2) extended, which highlights both files and directories, but requires python")
+
+(defvar treemacs-lock-width nil
+  "When non-nil the treemacs window will not be manually resizable by default.")

--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -20,3 +20,9 @@
         (treemacs--find-workspace))
       (treemacs-do-add-project-to-workspace path name)
       (treemacs-select-window))))
+
+(defun spacemacs/treemacs-toggle-locked-width-off ()
+  "Unlock the manual resizing of the treemacs window."
+  (interactive)
+  (when treemacs--width-is-locked
+    (treemacs-toggle-fixed-width)))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -67,7 +67,8 @@
         (treemacs-filewatch-mode t))
       (when (memq treemacs-use-git-mode '(simple extended))
         (treemacs-git-mode treemacs-use-git-mode))
-      (add-to-list 'spacemacs-window-split-ignore-prefixes treemacs--buffer-name-prefix))))
+      (add-to-list 'spacemacs-window-split-ignore-prefixes
+                   treemacs--buffer-name-prefix))))
 
 (defun treemacs/init-treemacs-evil ()
   (use-package treemacs-evil

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -41,6 +41,9 @@
             treemacs-never-persist nil
             treemacs-goto-tag-strategy 'refetch-index
             treemacs-collapse-dirs treemacs-use-collapsed-directories)
+      (unless treemacs-lock-width
+        (add-hook 'treemacs-mode-hook
+                  'spacemacs/treemacs-toggle-locked-width-off))
       (spacemacs/set-leader-keys
         "ft"    'treemacs
         "fB"    'treemacs-bookmark


### PR DESCRIPTION
The treemacs window is not resizable by default and it is very annoying when having long file names and/or a deep directory structure.

I don't understand why the width of this window is locked by default, I think it is more sensible to have it unlocked.