### PR TITLE
Added more tips for avoiding pitfalls when building on windows.

### DIFF
--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -46,8 +46,8 @@ Clone Emacs from [[https://git.savannah.gnu.org/git/emacs.git]]:
   git checkout pdumper
 #+END_SRC
 
-Note: On windows make sure that autocrlf is disabled in git before cloning or else 
-the autoconf.sh script will fail later on. This can be done via: =git config --global 
+Note: On windows make sure that autocrlf is disabled in git before cloning or else
+the autoconf.sh script will fail later on. This can be done via: =git config --global
 core.autocrlf false=
 
 *** Simple patch of Emacs source code
@@ -115,7 +115,7 @@ Run msys2_shell.bat and in the msys2 prompt run:
 #+END_SRC
 
 Quit the msys2 shell and run mingw64.exe in the msys64 install directory.
-In the mingw prompt navigate to the emacs source checkout (=cd /c/= will 
+In the mingw prompt navigate to the emacs source checkout (=cd /c/= will
 get you to the root of the c drive) and run:
 
 #+BEGIN_SRC shell

--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -46,6 +46,10 @@ Clone Emacs from [[https://git.savannah.gnu.org/git/emacs.git]]:
   git checkout pdumper
 #+END_SRC
 
+Note: On windows make sure that autocrlf is disabled in git before cloning or else 
+the autoconf.sh script will fail later on. This can be done via: =git config --global 
+core.autocrlf false=
+
 *** Simple patch of Emacs source code
 We need to increase the number of =remembered_data= slots in =src/pdumper.c=, we
 double the number of slots by replacing 32 with 64:
@@ -111,7 +115,8 @@ Run msys2_shell.bat and in the msys2 prompt run:
 #+END_SRC
 
 Quit the msys2 shell and run mingw64.exe in the msys64 install directory.
-In the mingw prompt run:
+In the mingw prompt navigate to the emacs source checkout (=cd /c/= will 
+get you to the root of the c drive) and run:
 
 #+BEGIN_SRC shell
   ./autogen.sh


### PR DESCRIPTION
I ran into some issues when building the pdumper build of emacs on windows and added some hints to the expiremental.org file to help people avoid them in the future.