### PR TITLE
Optimize spacemacs/title-prepare

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -682,9 +682,11 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
   %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
   %Z -- like %z, but including the end-of-line format"
   (let* ((fs (format-spec-make
-              ?a (abbreviate-file-name (or (buffer-file-name)
-                                           (buffer-name)))
-              ?t (if (fboundp 'projectile-project-name)
+              ?a (when (string-match-p "%a" title-format)
+                   (abbreviate-file-name (or (buffer-file-name)
+                                             (buffer-name))))
+              ?t (if (and (string-match-p "%t" title-format)
+                          (fboundp 'projectile-project-name))
                      (projectile-project-name)
                    "-")
               ?S system-name


### PR DESCRIPTION
spacemacs/title-prepare is being called on every frame re-display, so
eager evaluation of values for every possible format specifier can be too
expensive. For example projectile-project-name is very slow in TRAMP buffers.

Before this patch, in TRAMP-enabled buffer:
![before](https://user-images.githubusercontent.com/2280844/46436502-a2176f00-c761-11e8-96d1-b6787c3e8e95.png)

After:
![after](https://user-images.githubusercontent.com/2280844/46436542-bce9e380-c761-11e8-9617-d4377dba7273.png)


