### PR TITLE
Enable colors in magit-log

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -200,7 +200,8 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
         'spacemacs/magit-toggle-whitespace)
       ;; full screen magit-status
       (when git-magit-status-fullscreen
-        (setq magit-display-buffer-function 'magit-display-buffer-fullframe-status-v1)))))
+        (setq magit-display-buffer-function 'magit-display-buffer-fullframe-status-v1))
+      (add-to-list 'magit-log-arguments "--color"))))
 
 (defun git/init-magit-gitflow ()
   (use-package magit-gitflow


### PR DESCRIPTION
Colors makes it so much easier to visually differentiate and track the ascii lines representing the commit histories of the different branches 🌈 