### PR TITLE
update to flyspell-correct v0.5

### DIFF
--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -120,13 +120,14 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 
 * Key Bindings
 
-| Key Binding | Description              |
-|-------------+--------------------------|
-| ~SPC S b~   | flyspell whole buffer    |
-| ~SPC S c~   | flyspell correct         |
-| ~SPC S d~   | change dictionary        |
-| ~SPC S n~   | flyspell goto next error |
-| ~SPC t S~   | toggle flyspell          |
+| Key Binding     | Description                            |
+|-----------------+----------------------------------------|
+| ~SPC S b~       | flyspell whole buffer                  |
+| ~SPC S c~       | flyspell correct                       |
+| ~SPC u SPC S c~ | flyspell correct all errors one by one |
+| ~SPC S d~       | change dictionary                      |
+| ~SPC S n~       | flyspell goto next error               |
+| ~SPC t S~       | toggle flyspell                        |
 
 ** Spell Checking Transient-state
 

--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -90,10 +90,10 @@ Spell Commands^^             Other
 
 (defun spell-checking/init-flyspell-correct ()
   (use-package flyspell-correct
-    :commands (flyspell-correct-word-generic
-               flyspell-correct-previous-word-generic)
+    :commands (flyspell-correct-at-point
+               flyspell-correct-wrapper)
     :init
-    (spacemacs/set-leader-keys "Sc" 'flyspell-correct-previous-word-generic)))
+    (spacemacs/set-leader-keys "Sc" #'flyspell-correct-wrapper)))
 
 (defun spell-checking/init-flyspell-correct-ivy ()
   (use-package flyspell-correct-ivy


### PR DESCRIPTION
`flyspell-correct-word-generic` and `flyspell-correct-previous-word-generic` are
deprecated and replaced by `flyspell-correct-at-point` and
`flyspell-correct-wrapper` respectively.

`flyspell-correct-wrapper` has a so-called 'rapid' mode, where you can correct
multiple words in a single run.