### PR TITLE
Override read-only when capturing clear in shell

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -188,7 +188,8 @@
              ;; Check for clear command and execute it.
              ((string-match "^[ \t]*clear[ \t]*$" command)
               (comint-send-string proc "\n")
-              (erase-buffer))
+              (let ((inhibit-read-only  t))
+                (erase-buffer)))
              ;; Check for man command and execute it.
              ((string-match "^[ \t]*man[ \t]*" command)
               (comint-send-string proc "\n")


### PR DESCRIPTION
When shell layer intercepts the clear commands and tries to replace it with
erase-buffer, this fails with 'Text is read-only'.
Work around this by using inhibit-read-only.