### PR TITLE
Make clj-refactor off by default, update Clojure README

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -8,7 +8,8 @@
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#pretty-symbols][Pretty Symbols]]
-  - [[#cider-and-clj-refactor][CIDER and clj-refactor]]
+  - [[#enabling-sayid-or-clj-refactor][Enabling sayid or clj-refactor]]
+  - [[#starting-clojure-manually-outside-of-emacs][Starting Clojure manually (outside of Emacs)]]
     - [[#quick-start-with-boot][Quick Start with boot]]
     - [[#quick-start-with-lein][Quick Start with lein]]
     - [[#more-details][More details]]
@@ -76,50 +77,102 @@ Or set this variable when loading the configuration layer:
   '((clojure :variables clojure-enable-fancify-symbols t)))
 #+END_SRC
 
-** CIDER and clj-refactor
-Note that recent versions of CIDER automatically inject the required
-dependencies into your boot or leiningen configuration when you connect to the
-REPL. Thus, the configuration instructions below only apply to CIDER 0.10 and
-older. Most users should be able to just run ~SPC m s i~ to connect to the CIDER
-REPL and skip the rest of this section.
+** Enabling sayid or clj-refactor
+The packages sayid (Clojure debugger) and clj-refactor (automatic refactorings)
+are disabled by default. To enable them, add a `:variables` option when enabling
+the `clojure` layer, specifying `clojure-enable-sayid`, or
+`clojure-enable-clj-refactor`, or both.
+
+In your Spacemacs configuration:
+
+#+BEGIN_SRC emacs-lisp
+  ;; before
+  dotspacemacs-configuration-layers
+  '(...
+    clojure
+    )
+
+  ;; after
+  dotspacemacs-configuration-layers
+  '(...
+    (clojure :variables
+             clojure-enable-sayid t
+             clojure-enable-clj-refactor t)
+    )
+#+END_SRC
+
+Enabling either of these packages will cause extra nREPL middleware to be
+injected when jacking in CIDER.
+
+** Starting Clojure manually (outside of Emacs)
+CIDER communicates with your Clojure process through nREPL, and for CIDER to
+function correctly extra nREPL middleware needs to be present
+(cider/cider-nrepl). The same is true for clj-refactor (refactor-nrepl), and for
+sayid (com.billpiel/sayid).
+
+When starting the Clojure process through cider (`cider-jack-in` and friends)
+this will be handled automatically, and so most users should be able to just run
+~SPC m s i~ to connect to the CIDER REPL and skip the rest of this section.
+
+If you are running an older version of CIDER (0.10 or older), or if you are
+starting the Clojure process yourself outside of Emacs, then you need to make
+sure the necessary dependencies are present, and the necessary nREPL middlewares
+are enabled.
 
 *** Quick Start with boot
 - Install =boot= (see https://github.com/boot-clj/boot#user-content-install)
 - Create a file =~/.boot/profile.boot= with the following content:
 
 #+BEGIN_SRC clojure
-(require 'boot.repl)
+  (require 'boot.repl)
 
-(swap! boot.repl/*default-dependencies* conj
-       '[refactor-nrepl "1.2.0-SNAPSHOT"]
-       '[cider/cider-nrepl "0.10.0-SNAPSHOT"])
+  (swap! boot.repl/*default-dependencies* conj
+         ;; When running an older version of CIDER (pre 0.18), use the
+         ;; version that best matches M-x cider-version. For versions since
+         ;; 0.18.0 use whatever version is the most recent.
+         '[cider/cider-nrepl "0.19.0-SNAPSHOT"]
 
-(swap! boot.repl/*default-middleware* conj
-       'refactor-nrepl.middleware/wrap-refactor)
+         ;; Only necessary when using clj-refactor
+         '[refactor-nrepl "2.4.0"]
+
+         ;; Only necessary when using sayid
+         '[com.billpiel/sayid "0.0.17"])
+
+  (swap! boot.repl/*default-middleware* conj
+         'cider.nrepl/cider-middleware
+         'refactor-nrepl.middleware/wrap-refactor
+         'com.billpiel.sayid.nrepl-middleware/wrap-sayid)
 #+END_SRC
-
-- Run ~SPC m s i~ in any of the clojure source files to connect to the CIDER
-  REPL. Note that a build.boot file must be present in your working directory
-  for Cider to recognize the presence of boot.
 
 *** Quick Start with lein
 - Install =lein= version 2.5.2 or newer (see https://leiningen.org/#install)
 - Create a file =~/.lein/profiles.clj= with the following content:
 
 #+BEGIN_SRC clojure
-  {:repl {:plugins [[cider/cider-nrepl "0.10.0-SNAPSHOT"]
-                    [refactor-nrepl "2.0.0-SNAPSHOT"]]
-          :dependencies [[alembic "0.3.2"]
-                         [org.clojure/tools.nrepl "0.2.12"]]}}
-#+END_SRC
+  {:repl
+   {:plugins [;; When running an older version of CIDER (pre 0.18), use the
+              ;; version that best matches M-x cider-version. For versions since
+              ;; 0.18.0 use whatever version is the most recent.
+              [cider/cider-nrepl "0.19.0-SNAPSHOT"]
 
-- After creating your project with ~lein new app <projectname>~ or
-  importing an existing project, run ~SPC m s i~ in any of the clojure
-  source files to connect to the CIDER REPL.
+              ;; Only necessary when using clj-refactor
+              [refactor-nrepl "2.4.0"]
+
+              ;; Only necessary when using sayid
+              [com.billpiel/sayid "0.0.17"]]
+
+    :dependencies [[nrepl "0.4.5"]]
+
+    :repl-options
+    {:nrepl-middleware [cider.nrepl/cider-middleware
+                        refactor-nrepl.middleware/wrap-refactor ;; clj-refactor
+                        com.billpiel.sayid.nrepl-middleware/wrap-sayid ;; sayid
+                        ]}}}
+#+END_SRC
 
 *** More details
 More info regarding installation of nREPL middleware can be found here:
-- CIDER: [[https://github.com/clojure-emacs/cider#installation][cider_install]]
+- CIDER: [[https://cider.readthedocs.io/en/latest/installation/][CIDER installation (official docs)]]
 - clj-refactor: [[https://github.com/clojure-emacs/refactor-nrepl][refactor-nrepl]]
 
 * Usage

--- a/layers/+lang/clojure/config.el
+++ b/layers/+lang/clojure/config.el
@@ -22,3 +22,6 @@
 
 (defvar clojure-enable-sayid nil
   "If non-nil, the Sayid Clojure debugger is enabled.")
+
+(defvar clojure-enable-clj-refactor nil
+  "If non-nil, the clj-refactor is enabled.")

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -10,10 +10,9 @@
 ;;; License: GPLv3
 
 (setq clojure-packages
-      '(
-        cider
+      '(cider
         cider-eval-sexp-fu
-        clj-refactor
+        (clj-refactor :toggle clojure-enable-clj-refactor)
         clojure-cheatsheet
         clojure-mode
         (clojure-snippets :toggle (configuration-layer/layer-used-p 'auto-completion))


### PR DESCRIPTION
As suggested by @bbatsov on #11194 ([comment](https://github.com/syl20bnr/spacemacs/pull/11194#issuecomment-414824521)), it makes sense to give clj-refactor the same treatment as Sayid.

This also updates Clojure's README to document how to use the newly introduced variables to enable sayid or clj-refactor.

I also updated the documentation on adding CIDER-related dependencies. CIDER 0.10
is three years old now, so I think the case where cider middleware isn't
injected automatically is getting rare. However there is still a good use case
for running your Clojure process outside of Emacs/CIDER, meaning you don't get
to benefit from `cider-jack-in`'s magic insjections, so I have focused more on
that case, adding information for clj-refactor's and sayid's middleware, as well
as CIDER's.

@bbatsov could you give this a review? in particular the README changes? Thanks!