### PR TITLE
Adds a convenient keybinding for correcting word at point

### DIFF
--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -128,6 +128,7 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 | ~SPC S d~       | change dictionary                      |
 | ~SPC S n~       | flyspell goto next error               |
 | ~SPC t S~       | toggle flyspell                        |
+| ~SPC x x~       | correct word at point                  |
 
 ** Spell Checking Transient-state
 

--- a/layers/+checkers/spell-checking/keybindings.el
+++ b/layers/+checkers/spell-checking/keybindings.el
@@ -1,0 +1,13 @@
+;;; keybindigs.el --- Spell Checking Layer keybindigs File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(spacemacs/set-leader-keys
+  "xx" #'ispell-word)


### PR DESCRIPTION
Adds a `SPC x x` keybinding supplemental to `z=`

## Rationale: 

- `z=` is not a very convenient binding for quickly spell-checking word at point
- having an easily triggered action under `SPC` seems to be more efficient

*To be honest this comes from my personal experience. I am a sloppy typist, I need to correct my mistakes all the time. One could say: "just add it to your own config", which I did. It still makes annoyingly difficult for me when I am pairing with someone at work and working on their computer.*