### PR TITLE
Fix: add prefix to org-mode clock options after recent change.

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -325,7 +325,7 @@ Will work on both org-mode and any mode that accepts plain html."
       ;; functionalities – and a few others commands – from any other mode.
       (spacemacs/declare-prefix "ao" "org")
       (spacemacs/declare-prefix "aof" "feeds")
-      (spacemacs/declare-prefix "aok" "clock")
+      (spacemacs/declare-prefix "aoC" "clock")
       (spacemacs/set-leader-keys
         ;; org-agenda
         "ao#" 'org-agenda-list-stuck-projects


### PR DESCRIPTION
The commit #ad8eb85 is great, but with SPC a o C there was not name, it said only "prefix" instead of "clock". I have detected it and fixed it with this small change. 