### PR TITLE
Add toggle visual-line-navigation-globally

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -306,26 +306,40 @@
   :off (toggle-truncate-lines -1)
   :documentation "Truncate long lines (no wrap)."
   :evil-leader "tl")
+(defun spacemacs//init-visual-line-keys ()
+  (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
+  (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
+  (when (bound-and-true-p evil-escape-mode)
+    (evil-escape-mode -1)
+    (setq evil-escape-motion-state-shadowed-func nil)
+    (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
+    (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
+    (evil-escape-mode))
+  (evil-normalize-keymaps))
 (spacemacs|add-toggle visual-line-navigation
   :status visual-line-mode
   :on
   (progn
     (visual-line-mode)
-    (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
-    (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
-    (when (bound-and-true-p evil-escape-mode)
-      (evil-escape-mode -1)
-      (setq evil-escape-motion-state-shadowed-func nil)
-      (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
-      (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
-      (evil-escape-mode))
-    (evil-normalize-keymaps))
+    (spacemacs//init-visual-line-keys))
   :off
   (progn
     (visual-line-mode -1)
     (evil-normalize-keymaps))
   :documentation "Move point according to visual lines."
   :evil-leader "tL")
+(spacemacs|add-toggle visual-line-navigation-globally
+  :status global-visual-line-mode
+  :on
+  (progn
+    (global-visual-line-mode)
+    (spacemacs//init-visual-line-keys))
+  :off
+  (progn
+    (global-visual-line-mode -1)
+    (evil-normalize-keymaps))
+  :documentation "Move point according to visual lines globally."
+  :evil-leader "t C-L")
 (spacemacs|add-toggle auto-fill-mode
   :status auto-fill-function
   :on (auto-fill-mode)


### PR DESCRIPTION
Given that there's apparently [some interest](https://emacs.stackexchange.com/questions/41798/spacemacs-visual-line-navigation-not-working/44853) in having a global toggle for `visual-line-navigation`, I've thrown one together. Under my testing it seems to work as expected. There are a few questions lingering, though:

- I'm not sure why/whether the `evil-escape` logic is (still?) necessary. `evil-escape-motion-state-shadowed-func` doesn't seem to exist.
- Given that the bindings are being injected directly into `visual-line-mode`, it seems unnecessary to bind them every time the (global or local) mode is toggled, but I could be overlooking some edge case (involving evil-escape?)
- I'm not sure why `evil-normalize-keymaps` is necessary, and I don't think it makes sense to call it for the global case (since `evil-normalize-keymaps` just makes `evil-mode-map-alist` buffer-local), but for the sake of code simplicity I've left it there for both cases. It doesn't seem to hurt.