### PR TITLE
Cache expensive computations in spacemacs/title-prepare

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -681,14 +681,22 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
   %n -- prints Narrow if appropriate
   %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
   %Z -- like %z, but including the end-of-line format"
-  (let* ((fs (format-spec-make
-              ?a (when (string-match-p "%a" title-format)
-                   (abbreviate-file-name (or (buffer-file-name)
-                                             (buffer-name))))
-              ?t (if (and (string-match-p "%t" title-format)
-                          (fboundp 'projectile-project-name))
-                     (projectile-project-name)
-                   "-")
+  (let* ((project-name (when (string-match-p "%t" title-format)
+                         (if (boundp 'spacemacs--buffer-project-name)
+                             spacemacs--buffer-project-name
+                           (set (make-local-variable 'spacemacs--buffer-project-name)
+                                (if (fboundp 'projectile-project-name)
+                                    (projectile-project-name)
+                                  "-")))))
+         (abbreviated-file-name (when (string-match-p "%a" title-format)
+                                  (if (boundp 'spacemacs--buffer-abbreviated-filename)
+                                      spacemacs--buffer-abbreviated-filename
+                                    (set (make-local-variable 'spacemacs--buffer-abbreviated-filename)
+                                         (abbreviate-file-name (or (buffer-file-name)
+                                                                   (buffer-name)))))))
+         (fs (format-spec-make
+              ?a abbreviated-file-name
+              ?t project-name
               ?S system-name
               ?I invocation-name
               ?U (or (getenv "USER") "")


### PR DESCRIPTION
This is a follow up to https://github.com/syl20bnr/spacemacs/commit/2e50f8c6fc922ffe2def5a69f2383e3995b37574

I recently modified `spacemacs/title-prepare` myself to improve performance, but went the way of caching the expensive calculations in buffer local variables. 

Would a combination of my approach with the one from https://github.com/syl20bnr/spacemacs/commit/2e50f8c6fc922ffe2def5a69f2383e3995b37574 be of interest? If yes, I'm happy to rebase my commit to accommodate the recent changes.

cc @d12frosted @madand 

