### PR TITLE
Fix incorrect shell-pop window splitting for 'shell' option

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -44,8 +44,8 @@
   "Open the default shell in a popup."
   (interactive)
   (let ((shell (case shell-default-shell
-                 ('multi-term 'spacemacs//multiterm)
-                 ('shell 'spacemacs//shell)
+                 ('multi-term 'multiterm)
+                 ('shell 'inferior-shell)
                  (t . shell-default-shell))))
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 
@@ -181,12 +181,12 @@ is achieved by adding the relevant text properties."
   (term-send-raw-string "\t"))
 
 ;; Wrappers for non-standard shell commands
-(defun spacemacs//multiterm (&optional ARG)
+(defun multiterm (&optional ARG)
   "Wrapper to be able to call multi-term from shell-pop"
   (interactive)
   (multi-term))
 
-(defun spacemacs//shell (&optional ARG)
+(defun inferior-shell (&optional ARG)
   "Wrapper to open shell in current window"
   (switch-to-buffer "*shell*")
   (shell "*shell*"))

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -44,7 +44,7 @@
   "Open the default shell in a popup."
   (interactive)
   (let ((shell (case shell-default-shell
-                 ('multi-term 'multiterm)
+                 ('multi-term 'spacemacs//multiterm)
                  ('shell 'spacemacs//shell)
                  (t . shell-default-shell))))
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
@@ -120,11 +120,6 @@ is achieved by adding the relevant text properties."
                       read-only t
                       front-sticky (field inhibit-line-move-field-capture)))))
 
-(defun spacemacs//shell (&optional ARG)
-  "Wrapper to open shell in current window"
-  (switch-to-buffer "*shell*")
-  (shell "*shell*"))
-
 (defun spacemacs//init-eshell ()
   "Stuff to do when enabling eshell."
   (setq pcomplete-cycle-completions nil)
@@ -180,12 +175,18 @@ is achieved by adding the relevant text properties."
   (define-key eshell-mode-map
     (kbd "M-l") 'spacemacs/helm-eshell-history))
 
-(defun multiterm (_)
-  "Wrapper to be able to call multi-term from shell-pop"
-  (interactive)
-  (multi-term))
-
 (defun term-send-tab ()
   "Send tab in term mode."
   (interactive)
   (term-send-raw-string "\t"))
+
+;; Wrappers for non-standard shell commands
+(defun spacemacs//multiterm (&optional ARG)
+  "Wrapper to be able to call multi-term from shell-pop"
+  (interactive)
+  (multi-term))
+
+(defun spacemacs//shell (&optional ARG)
+  "Wrapper to open shell in current window"
+  (switch-to-buffer "*shell*")
+  (shell "*shell*"))

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -43,9 +43,10 @@
 (defun spacemacs/default-pop-shell ()
   "Open the default shell in a popup."
   (interactive)
-  (let ((shell (if (eq 'multi-term shell-default-shell)
-                   'multiterm
-                 shell-default-shell)))
+  (let ((shell (case shell-default-shell
+                 ('multi-term 'multiterm)
+                 ('shell 'spacemacs//shell)
+                 (t . shell-default-shell))))
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 
 (defun spacemacs/resize-shell-to-desired-width ()
@@ -118,6 +119,11 @@ is achieved by adding the relevant text properties."
                       field output
                       read-only t
                       front-sticky (field inhibit-line-move-field-capture)))))
+
+(defun spacemacs//shell (&optional ARG)
+  "Wrapper to open shell in current window"
+  (switch-to-buffer "*shell*")
+  (shell "*shell*"))
 
 (defun spacemacs//init-eshell ()
   "Stuff to do when enabling eshell."

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -188,5 +188,6 @@ is achieved by adding the relevant text properties."
 
 (defun inferior-shell (&optional ARG)
   "Wrapper to open shell in current window"
+  (interactive)
   (switch-to-buffer "*shell*")
   (shell "*shell*"))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -215,8 +215,8 @@
       (make-shell-pop-command eshell)
       (make-shell-pop-command term shell-pop-term-shell)
       (make-shell-pop-command ansi-term shell-pop-term-shell)
-      (make-shell-pop-command spacemacs//shell)
-      (make-shell-pop-command spacemacs//multiterm)
+      (make-shell-pop-command inferior-shell)
+      (make-shell-pop-command multiterm)
 
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
       (add-hook 'term-mode-hook (lambda () (linum-mode -1)))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -213,10 +213,10 @@
             shell-pop-term-shell      shell-default-term-shell
             shell-pop-full-span       shell-default-full-span)
       (make-shell-pop-command eshell)
-      (make-shell-pop-command spacemacs//shell)
       (make-shell-pop-command term shell-pop-term-shell)
-      (make-shell-pop-command multiterm)
       (make-shell-pop-command ansi-term shell-pop-term-shell)
+      (make-shell-pop-command spacemacs//shell)
+      (make-shell-pop-command spacemacs//multiterm)
 
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
       (add-hook 'term-mode-hook (lambda () (linum-mode -1)))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -213,7 +213,7 @@
             shell-pop-term-shell      shell-default-term-shell
             shell-pop-full-span       shell-default-full-span)
       (make-shell-pop-command eshell)
-      (make-shell-pop-command shell)
+      (make-shell-pop-command spacemacs//shell)
       (make-shell-pop-command term shell-pop-term-shell)
       (make-shell-pop-command multiterm)
       (make-shell-pop-command ansi-term shell-pop-term-shell)


### PR DESCRIPTION
Currently `shell` command, when switching to non-existing buffer, will
create a new window automatically. This behavior does not play will with
`shell-pop` package, as it already prepares window for shell to use.

This behavior can be prevented by creating a new buffer, before calling
the `shell` command.

Related issues: 
- #11388
- #7691