### PR TITLE
allow dynamic width lock setup for treemacs

### DIFF
--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -21,8 +21,9 @@
       (treemacs-do-add-project-to-workspace path name)
       (treemacs-select-window))))
 
-(defun spacemacs/treemacs-toggle-locked-width-off ()
-  "Unlock the manual resizing of the treemacs window."
+(defun spacemacs/treemacs-setup-width-lock ()
+  "Setup the width lock of treemacs buffer based on
+`treemacs-lock-width'."
   (interactive)
-  (when treemacs--width-is-locked
+  (when (xor treemacs--width-is-locked treemacs-lock-width)
     (treemacs-toggle-fixed-width)))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -41,9 +41,8 @@
             treemacs-never-persist nil
             treemacs-goto-tag-strategy 'refetch-index
             treemacs-collapse-dirs treemacs-use-collapsed-directories)
-      (unless treemacs-lock-width
-        (add-hook 'treemacs-mode-hook
-                  'spacemacs/treemacs-toggle-locked-width-off))
+      (add-hook 'treemacs-mode-hook
+                #'spacemacs/treemacs-setup-width-lock)
       (spacemacs/set-leader-keys
         "ft"    'treemacs
         "fB"    'treemacs-bookmark


### PR DESCRIPTION
Following #11384

Right now treemacs-lock-width variable affects width lock only during treemacs
initialisation. Any later modifications have no effect on treemacs behaviour.
This commit changes it by moving evaluation of treemacs-lock-width to the
treemacs-mode-hook.

CC @deb0ch 