### PR TITLE
 Fix jedi requirements on python documentation

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -94,7 +94,7 @@ opening a python buffer:
 To fix this, install the =anaconda-mode= [[https://github.com/proofit404/anaconda-mode/wiki][anaconda-deps]] by hand:
 
 #+BEGIN_SRC sh
-  pip install --upgrade "jedi>=0.9.0" "json-rpc>=1.8.1" "service_factory>=0.1.5"
+  pip install --upgrade "jedi>=0.9.0,<0.11.0" "json-rpc>=1.8.1" "service_factory>=0.1.5"
 #+END_SRC
 
 If you encounter problems with Jedi 1.0 consider downgrading to 0.9.0. See [[https://github.com/davidhalter/jedi/issues/873][this


### PR DESCRIPTION
Right now on a fresh install anaconda-mode will not work with the give instructions because jedi>=0.12 breaks import compatibility.

So I just added the right version that needs to be installed in order to make it work.
I will try to send a PR to anaconda-mode to support newer jedi versions.