### PR TITLE
Add Alda configuration layer

### DIFF
--- a/layers/+lang/alda/README.org
+++ b/layers/+lang/alda/README.org
@@ -1,0 +1,37 @@
+#+TITLE: Alda Layer
+
+* Table of Contents
+ - [[#description][Description]]
+ - [[#install][Install]]
+ - [[#key-bindings][Key bindings]]
+   
+* Description
+Alda is a music composition language allowing music to easily be written and
+edited in a text file.
+
+This layer adds keybindings for =alda-mode='s functions, which allow Alda code
+to be interpreted and played by the running Alda server. It will also start the
+Alda server if it is not running.
+
+** Features:
+- Syntax highlighting for Alda files.
+- Play portions of a buffer, or the entire buffer,
+  through a running Alda server.
+
+* Install
+Add =alda= to the =dotspacemacs-configuration-layers= list in =~/.spacemacs=.
+You will also want to ensure that you have installed [[https://github.com/alda-lang/alda/releases][Alda]] so that =alda-mode=
+can play your code.
+
+* Key bindings
+When alda-mode is active in an Alda file, you can use these keybindings:
+
+| Key Binding | Description                     |
+|-------------+---------------------------------|
+| ~SPC m r~   | Play region (selected text)     |
+| ~SPC m c~   | Play block (paragraph on point) |
+| ~SPC m n~   | Plays the current line          |
+| ~SPC m b~   | Play the entire buffer          |
+
+Note that if the Alda server is not running, =alda-mode= will start the server,
+and you will have to run the command again.

--- a/layers/+lang/alda/packages.el
+++ b/layers/+lang/alda/packages.el
@@ -1,0 +1,30 @@
+;;; packages.el --- Alda Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Andrew Hill <andrew@andrewkhill.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq alda-packages
+  '(
+    alda-mode
+   ))
+
+(defun alda/init-alda-mode ()
+  (use-package alda-mode
+    :defer t
+    :commands (alda-play-region
+               alda-play-block
+               alda-play-line
+               alda-play-buffer)
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'alda-mode
+        "r" 'alda-play-region
+        "c" 'alda-play-block
+        "n" 'alda-play-line
+        "b" 'alda-play-buffer))))


### PR DESCRIPTION
Alda is a music-composition language which has an Emacs major mode but not a Spacemacs layer.