### PR TITLE
Add keybings to rename the file and organize imports in typescript

### DIFF
--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -143,7 +143,9 @@ You have to install the following dependencies with npm.
 | ~SPC m g t~ | jump to entity’s type definition                             |
 | ~SPC m g u~ | references                                                   |
 | ~SPC m h h~ | documentation at point                                       |
+| ~SPC m r i~ | organize imports
 | ~SPC m r r~ | rename symbol                                                |
+| ~SPC m r f~ | rename file                                            |
 | ~SPC m s p~ | send selected region or current buffer to the web playground |
 | ~SPC m s r~ | restart server                                               |
 

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -84,7 +84,9 @@
                              "gt" spacemacs/typescript-jump-to-type-def
                              "gu" tide-references
                              "hh" tide-documentation-at-point
+                             "ri" 'tide-organize-imports
                              "rr" tide-rename-symbol
+                             "rf" 'tide-rename-file
                              "sr" tide-restart-server)
             typescriptList (cons 'typescript-mode keybindingList)
             typescriptTsxList (cons 'typescript-tsx-mode


### PR DESCRIPTION
Add two key bindings in typescript major mode:

- Rename the current file (`tide-rename-file`)
- Organize the imports (`tide-organize-imports`)

These operations are generic and useful enough to deserve to be set by default.