### PR TITLE
Fix the rename file and organize import key binding for typescript

### DIFF
--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -84,9 +84,9 @@
                              "gt" spacemacs/typescript-jump-to-type-def
                              "gu" tide-references
                              "hh" tide-documentation-at-point
-                             "ri" 'tide-organize-imports
+                             "ri" tide-organize-imports
                              "rr" tide-rename-symbol
-                             "rf" 'tide-rename-file
+                             "rf" tide-rename-file
                              "sr" tide-restart-server)
             typescriptList (cons 'typescript-mode keybindingList)
             typescriptTsxList (cons 'typescript-tsx-mode


### PR DESCRIPTION
Fix the keybindings introduced in #11435 which were based on the configuration present in `master` rather than the one in `develop`.