### PR TITLE
set load-prefer-newer to t

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -209,3 +209,6 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Add buffer reference to internal list of killed buffers on `kill-buffer',
 ;; used for restoring recently killed buffers.
 (add-hook 'kill-buffer-hook #'spacemacs//add-buffer-to-killed-list)
+
+;; Don't load outdated compiled files.
+(setq load-prefer-newer t)


### PR DESCRIPTION
Fixes (frustration of) the following issues:

- [[https://github.com/syl20bnr/spacemacs/issues/10199][syl20bnr/spacemacs#10199]] - org-export broken due to wrong-type-argument listp
- [[https://github.com/syl20bnr/spacemacs/issues/6296][syl20bnr/spacemacs#6296]] - Org-mode export problems.
- [[https://github.com/syl20bnr/spacemacs/issues/8414][syl20bnr/spacemacs#8414]] - Builtin Org mode (8.x) breaking Spacemacs Org mode (9.x)
- [[https://github.com/syl20bnr/spacemacs/issues/7641][syl20bnr/spacemacs#7641]] - Org-Mode Evaluation of code disabled

I wonder if it was intentional.