### PR TITLE
Fixed a typo in the docs

### DIFF
--- a/doc/BEGINNERS_TUTORIAL.org
+++ b/doc/BEGINNERS_TUTORIAL.org
@@ -115,7 +115,7 @@ Spacemacs, so keep on eye on the different options! ~ESC~ usually breaks the
 combination you don’t want to use.
 
 ** Buffers, windows and frames
-Because Emacs (the extension of which Spacemacs is) was developed in the 80’s
+Because Emacs (the extension of which Spacemacs is) was developed in the '80s
 before the advent of modern graphical user interfaces, Emacs has
 a different name of what we normally call “windows”: in Emacs these are
 called “frames”. A frame is what pops up when you launch Spacemacs from your


### PR DESCRIPTION
Hi, thank you so much for Spacemacs. I was reading the documentation, and it read something along the lines of "Emacs was developed in the 80's." in the Beginner's Tutorial. I changed it to "Emacs was developed in the '80s." If this is wrong, let me know.

Also, it says that I changed 27 of the opening lines, but they look the same to me. I didn't mean to, and since this is a single character edit, it won't be a problem for me to re-submit it if necessary.

I just re-did the pull so it's on the development branch.