### PR TITLE
Limit lines to 80 chars

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -165,8 +165,7 @@ automatically applied to."
 
 (defun spacemacs/swap-windows (window1 window2)
   "Swap two windows.
-WINDOW1 and WINDOW2 must be valid windows. They may contain child
-windows."
+WINDOW1 and WINDOW2 must be valid windows. They may contain child windows."
   (let ((state1 (window-state-get window1))
         (state2 (window-state-get window2)))
     ;; to put state into dedicated windows, we must undedicate them first (not
@@ -226,8 +225,7 @@ Dedicated (locked) windows are left untouched."
 
 (defun spacemacs/move-buffer-to-window (windownum follow-focus-p)
   "Moves a buffer to a window, using the spacemacs numbering. follow-focus-p
-   controls whether focus moves to new window (with buffer), or stays on
-   current"
+controls whether focus moves to new window (with buffer), or stays on current"
   (interactive)
   (let ((b (current-buffer))
         (w1 (selected-window))
@@ -240,8 +238,8 @@ Dedicated (locked) windows are left untouched."
 
 (defun spacemacs/swap-buffers-to-window (windownum follow-focus-p)
   "Swaps visible buffers between active window and selected window.
-   follow-focus-p controls whether focus moves to new window (with buffer), or
-   stays on current"
+follow-focus-p controls whether focus moves to new window (with buffer), or
+stays on current"
   (interactive)
   (let* ((b1 (current-buffer))
          (w1 (selected-window))
@@ -288,7 +286,8 @@ projectile cache when it's possible and update recentf list."
              (error "A buffer named '%s' already exists!" new-name))
             (t
              (let ((dir (file-name-directory new-name)))
-               (when (and (not (file-exists-p dir)) (yes-or-no-p (format "Create directory '%s'?" dir)))
+               (when (and (not (file-exists-p dir))
+                          (yes-or-no-p (format "Create directory '%s'?" dir)))
                  (make-directory dir t)))
              (rename-file filename new-name 1)
              (when buffer
@@ -300,7 +299,8 @@ projectile cache when it's possible and update recentf list."
              (when (and (configuration-layer/package-used-p 'projectile)
                         (projectile-project-p))
                (call-interactively #'projectile-invalidate-cache))
-             (message "File '%s' successfully renamed to '%s'" short-name (file-name-nondirectory new-name)))))))
+             (message "File '%s' successfully renamed to '%s'"
+                      short-name (file-name-nondirectory new-name)))))))
 
 ;; from magnars
 (defun spacemacs/rename-current-buffer-file (&optional arg)
@@ -483,8 +483,8 @@ If the universal prefix argument is used then will the windows too."
 ;; from http://dfan.org/blog/2009/02/19/emacs-dedicated-windows/
 (defun spacemacs/toggle-current-window-dedication ()
   "Toggle dedication state of a window. Commands that change the buffer that a
-  window is displaying will not typically change the buffer displayed by
-  a dedicated window."
+window is displaying will not typically change the buffer displayed by
+a dedicated window."
  (interactive)
  (let* ((window    (selected-window))
         (dedicated (window-dedicated-p window)))
@@ -499,9 +499,9 @@ If the universal prefix argument is used then will the windows too."
 (defun spacemacs--directory-path ()
   "Retrieve the directory path of the current buffer.
 
-If the buffer is not visiting a file, use the `list-buffers-directory'
-variable as a fallback to display the directory, useful in buffers like the
-ones created by `magit' and `dired'.
+If the buffer is not visiting a file, use the `list-buffers-directory' variable
+as a fallback to display the directory, useful in buffers like the ones created
+by `magit' and `dired'.
 
 Returns:
   - A string containing the directory path in case of success.
@@ -530,7 +530,8 @@ Returns:
     (concat file-path ":" (number-to-string (line-number-at-pos)))))
 
 (defun spacemacs--file-path-with-line-column ()
-  "Retrieve the file path of the current buffer, including line and column number.
+  "Retrieve the file path of the current buffer,
+including line and column number.
 
 Returns:
   - A string containing the file path in case of success.
@@ -540,8 +541,8 @@ Returns:
       file-path
       ":"
       (number-to-string (if (and
-                              ;; Emacs 26 introduced this variable.
-                              ;; Remove this check once 26 becomes the minimum version.
+                             ;; Emacs 26 introduced this variable. Remove this
+                             ;; check once 26 becomes the minimum version.
                               (boundp column-number-indicator-zero-based)
                               (not column-number-indicator-zero-based))
                             (1+ (current-column))
@@ -588,7 +589,8 @@ buffer."
     (message "WARNING: Current buffer is not attached to a file!")))
 
 (defun spacemacs/copy-file-path-with-line-column ()
-  "Copy and show the file path of the current buffer, including line and column number.
+  "Copy and show the file path of the current buffer,
+including line and column number.
 
 This function respects the value of the `column-number-indicator-zero-based'
 variable."
@@ -716,9 +718,10 @@ in a new frame."
   "Prefixes for windows that are not deleted when changing split layout.
 
 You can add an entry here by using the following:
-  (add-to-list 'spacemacs-window-split-ignore-prefixes \"Buffer prefix\")")
+(add-to-list 'spacemacs-window-split-ignore-prefixes \"Buffer prefix\")")
 
-(defvar spacemacs-window-split-delete-function 'spacemacs/window-split-default-delete
+(defvar spacemacs-window-split-delete-function
+  'spacemacs/window-split-default-delete
   "Function used to delete other windows when changing layout.
 
 Used as a callback by the following functions:
@@ -739,11 +742,12 @@ Possible values:
 (defun spacemacs/window-split-grid (&optional purge)
   "Set the layout to a 2x2 grid.
 
-Uses the funcion defined in `spacemacs-window-split-delete-function' as a means to
-remove windows.
+Uses the funcion defined in `spacemacs-window-split-delete-function'
+as a means to remove windows.
 
-When called with a prefix argument, it uses `delete-other-windows' as a means
-to remove windows, regardless of the value in `spacemacs-window-split-delete-function'."
+When called with a prefix argument, it uses `delete-other-windows'
+as a means to remove windows, regardless of the value in
+`spacemacs-window-split-delete-function'."
   (interactive "P")
   (if purge
       (let ((ignore-window-parameters t))
@@ -764,11 +768,12 @@ to remove windows, regardless of the value in `spacemacs-window-split-delete-fun
 (defun spacemacs/window-split-triple-columns (&optional purge)
   "Set the layout to triple columns.
 
-Uses the funcion defined in `spacemacs-window-split-delete-function' as a means to
-remove windows.
+Uses the funcion defined in `spacemacs-window-split-delete-function'
+as a means to remove windows.
 
-When called with a prefix argument, it uses `delete-other-windows' as a means
-to remove windows, regardless of the value in `spacemacs-window-split-delete-function'."
+When called with a prefix argument, it uses `delete-other-windows'
+as a means to remove windows, regardless of the value in
+`spacemacs-window-split-delete-function'."
   (interactive "P")
   (if purge
       (let ((ignore-window-parameters t))
@@ -787,11 +792,12 @@ to remove windows, regardless of the value in `spacemacs-window-split-delete-fun
 (defun spacemacs/window-split-double-columns (&optional purge)
   "Set the layout to double columns.
 
-Uses the funcion defined in `spacemacs-window-split-delete-function' as a means to
-remove windows.
+Uses the funcion defined in `spacemacs-window-split-delete-function'
+as a means to remove windows.
 
-When called with a prefix argument, it uses `delete-other-windows' as a means
-to remove windows, regardless of the value in `spacemacs-window-split-delete-function'."
+When called with a prefix argument, it uses `delete-other-windows'
+as a means to remove windows, regardless of the value in
+`spacemacs-window-split-delete-function'."
   (interactive "P")
   (if purge
       (let ((ignore-window-parameters t))
@@ -799,19 +805,21 @@ to remove windows, regardless of the value in `spacemacs-window-split-delete-fun
     (funcall spacemacs-window-split-delete-function))
   (if (spacemacs--window-split-splittable-windows)
       (let* ((previous-files (seq-filter #'buffer-file-name
-                               (delq (current-buffer) (buffer-list)))))
-        (set-window-buffer (split-window-right) (or (car previous-files) "*scratch*"))
+                                         (delq (current-buffer) (buffer-list)))))
+        (set-window-buffer (split-window-right)
+                           (or (car previous-files) "*scratch*"))
         (balance-windows))
     (message "There are no main windows available to split!")))
 
 (defun spacemacs/window-split-single-column (&optional purge)
   "Set the layout to single column.
 
-Uses the funcion defined in `spacemacs-window-split-delete-function' as a means to
-remove windows.
+Uses the funcion defined in `spacemacs-window-split-delete-function'
+as a means to remove windows.
 
-When called with a prefix argument, it uses `delete-other-windows' as a means
-to remove windows, regardless of the value in `spacemacs-window-split-delete-function'."
+When called with a prefix argument, it uses `delete-other-windows'
+as a means to remove windows, regardless of the value in
+`spacemacs-window-split-delete-function'."
   (interactive "P")
   (if purge
       (let ((ignore-window-parameters t))
@@ -949,7 +957,7 @@ toggling fullscreen."
 
 (defun spacemacs/toggle-frame-fullscreen-non-native ()
   "Toggle full screen non-natively. Uses the `fullboth' frame paramerter
-   rather than `fullscreen'. Useful to fullscreen on OSX w/o animations."
+rather than `fullscreen'. Useful to fullscreen on OSX w/o animations."
   (interactive)
   (modify-frame-parameters
    nil
@@ -1002,7 +1010,8 @@ The body of the advice is in BODY."
 (defun spacemacs//open-in-external-app (file-path)
   "Open `file-path' in external application."
   (cond
-   ((spacemacs/system-is-mswindows) (w32-shell-execute "open" (replace-regexp-in-string "/" "\\\\" file-path)))
+   ((spacemacs/system-is-mswindows)
+    (w32-shell-execute "open" (replace-regexp-in-string "/" "\\\\" file-path)))
    ((spacemacs/system-is-mac) (shell-command (format "open \"%s\"" file-path)))
    ((spacemacs/system-is-linux) (let ((process-connection-type nil))
                                   (start-process "" nil "xdg-open" file-path)))))
@@ -1084,7 +1093,8 @@ the right."
                        (justify nil t)))
                 nil))
 
-(defmacro spacemacs|create-align-repeat-x (name regexp &optional justify-right default-after)
+(defmacro spacemacs|create-align-repeat-x
+    (name regexp &optional justify-right default-after)
   (let ((new-func (intern (concat "spacemacs/align-repeat-" name))))
     `(defun ,new-func (start end switch)
        (interactive "r\nP")
@@ -1136,13 +1146,14 @@ With negative N, comment out original line and use the absolute value."
                       (buffer-substring (region-beginning) (region-end))
                     (prog1 (thing-at-point 'line)
                       (end-of-line)
-                      (if (< 0 (forward-line 1)) ; Go to beginning of next line, or make a new one
+                      ;; Go to beginning of next line, or make a new one
+                      (if (< 0 (forward-line 1))
                           (newline))))))
-        (dotimes (i (abs (or n 1)))     ; Insert N times, or once if not specified
+        (dotimes (i (abs (or n 1)))   ; Insert N times, or once if not specified
           (insert text))))
-    (if use-region nil                  ; Only if we're working with a line (not a region)
+    (if use-region nil        ; Only if we're working with a line (not a region)
       (let ((pos (- (point) (line-beginning-position)))) ; Save column
-        (if (> 0 n)                             ; Comment out original with negative arg
+        (if (> 0 n)                     ; Comment out original with negative arg
             (comment-region (line-beginning-position) (line-end-position)))
         (forward-line 1)
         (forward-char pos)))))
@@ -1187,7 +1198,8 @@ A non-nil argument sorts in REVERSE order."
        (>= (1+ (- (line-number-at-pos (region-end))
                   (line-number-at-pos (region-beginning)))) 2))
       (sort-columns reverse (region-beginning) (region-end))
-    (error "Sorting by column requires a block/rect selection on 2 or more lines.")))
+    (error
+     "Sorting by column requires a block/rect selection on 2 or more lines.")))
 
 (defun spacemacs/sort-lines-by-column-reverse ()
 "Sort lines by the selected column in reverse order,
@@ -1403,7 +1415,8 @@ Decision is based on `dotspacemacs-line-numbers'."
 Decision is based on `dotspacemacs-line-numbers'."
   (or (eq dotspacemacs-line-numbers 'relative)
       (and (listp dotspacemacs-line-numbers)
-           (car (spacemacs/mplist-get-values dotspacemacs-line-numbers :relative)))))
+           (car (spacemacs/mplist-get-values dotspacemacs-line-numbers
+                                             :relative)))))
 
 (defun spacemacs//linum-on (origfunc &rest args)
   "Advice function to improve `linum-on' function."
@@ -1437,19 +1450,23 @@ Decision is based on `dotspacemacs-line-numbers'."
 (defun spacemacs//linum-curent-buffer-is-not-too-big ()
   "Return non-nil if buffer size is not too big."
   (not (and (listp dotspacemacs-line-numbers)
-            (spacemacs/mplist-get-values dotspacemacs-line-numbers :size-limit-kb)
+            (spacemacs/mplist-get-values dotspacemacs-line-numbers
+                                         :size-limit-kb)
             (> (buffer-size)
-               (* 1000 (car (spacemacs/mplist-get-values dotspacemacs-line-numbers
-                                                  :size-limit-kb)))))))
+               (* 1000
+                  (car (spacemacs/mplist-get-values dotspacemacs-line-numbers
+                                                    :size-limit-kb)))))))
 
 ;; see tests in tests/layers/+distribution/spacemacs-base/line-numbers-utest.el
 ;; for the different possible cases
 (defun spacemacs//linum-enabled-for-current-major-mode ()
   "Return non-nil if line number is enabled for current major-mode."
-  (let* ((disabled-for-modes (spacemacs/mplist-get-values dotspacemacs-line-numbers
-                                                          :disabled-for-modes))
-         (user-enabled-for-modes (spacemacs/mplist-get-values dotspacemacs-line-numbers
-                                                              :enabled-for-modes))
+  (let* ((disabled-for-modes
+          (spacemacs/mplist-get-values dotspacemacs-line-numbers
+                                       :disabled-for-modes))
+         (user-enabled-for-modes
+          (spacemacs/mplist-get-values dotspacemacs-line-numbers
+                                       :enabled-for-modes))
          ;; default `enabled-for-modes' to '(prog-mode text-mode), because it is
          ;; a more sensible default than enabling in all buffers - including
          ;; Magit buffers, terminal buffers, etc. But don't include prog-mode or


### PR DESCRIPTION
And fix comment indentation. Vertically aligned comments in function
definitions, indents them in the help buffer.