### PR TITLE
Update delete file messages

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -400,13 +400,16 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
         (name (buffer-name)))
     (if (not (and filename (file-exists-p filename)))
         (ido-kill-buffer)
-      (when (yes-or-no-p "Are you sure you want to delete this file? ")
-        (delete-file filename t)
-        (kill-buffer buffer)
-        (when (and (configuration-layer/package-used-p 'projectile)
-                   (projectile-project-p))
-          (call-interactively #'projectile-invalidate-cache))
-        (message "File '%s' successfully removed" filename)))))
+      (if (yes-or-no-p
+            (format "Are you sure you want to delete this file: '%s'?" name))
+          (progn
+            (delete-file filename t)
+            (kill-buffer buffer)
+            (when (and (configuration-layer/package-used-p 'projectile)
+                       (projectile-project-p))
+              (call-interactively #'projectile-invalidate-cache))
+            (message "File deleted: '%s'" filename))
+        (message "Canceled: File deletion")))))
 
 ;; from magnars
 (defun spacemacs/sudo-edit (&optional arg)


### PR DESCRIPTION
problems:
the delete file prompt doesn't show which file it's about to delete,
and when the deletion request is canceled, then the question remains in the
minibuffer (the text disappears when an action updates the minibuffer, like
moving the cursor, but it might be confusing to still be seeing the question
after it's been answered)

solution:
show the file name in the delete file prompt, and show a canceled message