### PR TITLE
Update file renaming, handle same new and old name

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -951,6 +951,8 @@ Other:
   - Improved Window Manipulation Transient state (thanks to yuhan0)
   - Exclude which-key from layer sync powerline restore (thanks to Doug Wilson)
   - Fix doom-modeline in the messages buffer (thanks to duianto)
+  - Fixed =spacemacs/rename-current-buffer-file= handle same new and old name
+    (thanks to duianto)
 *** Layer changes and fixes
 **** Ansible
 - Improvements:

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -342,6 +342,10 @@ initialized with the current directory instead of filename."
                (new-name (read-file-name "New name: " (if arg dir filename))))
           (cond ((get-buffer new-name)
                  (error "A buffer named '%s' already exists!" new-name))
+                ((string-equal new-name filename)
+                 (spacemacs/show-hide-helm-or-ivy-prompt-msg
+                  "Rename failed! Same new and old name" 1.5)
+                 (spacemacs/rename-current-buffer-file))
                 (t
                  (let ((dir (file-name-directory new-name)))
                    (when (and (not (file-exists-p dir))
@@ -388,6 +392,36 @@ initialized with the current directory instead of filename."
                             name new-name)))
                 ;; ?\a = C-g, ?\e = Esc and C-[
                 ((memq key '(?\a ?\e)) (keyboard-quit))))))))
+
+(defun spacemacs/show-hide-helm-or-ivy-prompt-msg (msg sec)
+  "Show a MSG at the helm or ivy prompt for SEC.
+With Helm, remember the path, then restore it after SEC.
+With Ivy, the path isn't editable, just remove the MSG after SEC."
+  (run-at-time
+   0 nil
+   #'(lambda (msg sec)
+       (let* ((prev-prompt-contents
+               (buffer-substring (line-beginning-position)
+                                 (line-end-position)))
+              (prev-prompt-contents-p
+               (not (string= prev-prompt-contents "")))
+              (helmp (fboundp 'helm-mode)))
+         (when prev-prompt-contents-p
+           (delete-region (line-beginning-position)
+                          (line-end-position)))
+         (insert (propertize msg 'face 'warning))
+         ;; stop checking for candidates
+         ;; and update the helm prompt
+         (when helmp (helm-suspend-update t))
+         (sit-for sec)
+         (delete-region (line-beginning-position)
+                        (line-end-position))
+         (when prev-prompt-contents-p
+           (insert prev-prompt-contents)
+           ;; start checking for candidates
+           ;; and update the helm prompt
+           (when helmp (helm-suspend-update nil)))))
+   msg sec))
 
 (defun spacemacs/delete-file (filename &optional ask-user)
   "Remove specified file or directory.


### PR DESCRIPTION
problem:
renaming a file to it's current name, results in the message:
"File 'current-name' successfully renamed to 'current-name'"

solution:
when the new and old names are the same, show a rename failed message, and call
the rename function again

---
### Issue:
This method of showing the file renaming failed message with the `(sit-for 2)` command isn't optimal, because the helm rename buffer closes, then the failed message is shown in the minibuffer, and finally the helm rename buffer opens again.

Without the `sit-for` command, the helm rename buffer stays open after pressing `RET`, but the failed rename message only gets shown in the minibuffer for a split second.

Is it possible to show the failed rename message in the helm rename buffer?