### PR TITLE
Update renaming, move and/or rename messages

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -953,6 +953,8 @@ Other:
   - Fix doom-modeline in the messages buffer (thanks to duianto)
   - Fix void function error when recentf-save-list is undefined
     (thanks to Compro-Prasad)
+  - Fixed =spacemacs/rename-current-buffer-file=, separate messages for
+    move & rename, just move and just rename (thanks to duianto)
 *** Layer changes and fixes
 **** Ansible
 - Improvements:

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -339,7 +339,11 @@ initialized with the current directory instead of filename."
     (if (and filename (file-exists-p filename))
         ;; the buffer is visiting a file
         (let* ((dir (file-name-directory filename))
-               (new-name (read-file-name "New name: " (if arg dir filename))))
+               (new-name (read-file-name "New name: " (if arg dir filename)))
+               (new-dir (file-name-directory new-name))
+               (new-short-name (file-name-nondirectory new-name))
+               (file-moved-p (not (string-equal new-dir dir)))
+               (file-renamed-p (not (string-equal new-short-name name))))
           (cond ((get-buffer new-name)
                  (error "A buffer named '%s' already exists!" new-name))
                 (t
@@ -358,8 +362,18 @@ initialized with the current directory instead of filename."
                  (when (and (configuration-layer/package-used-p 'projectile)
                             (projectile-project-p))
                    (call-interactively #'projectile-invalidate-cache))
-                 (message "File '%s' successfully renamed to '%s'"
-                          name (file-name-nondirectory new-name)))))
+                 (message (cond ((and file-moved-p file-renamed-p)
+                                 (concat "File Moved & Renamed\n"
+                                         "From: " filename "\n"
+                                         "To:   " new-name))
+                                (file-moved-p
+                                 (concat "File Moved\n"
+                                         "From: " filename "\n"
+                                         "To:   " new-name))
+                                (file-renamed-p
+                                 (concat "File Renamed\n"
+                                         "From: " name "\n"
+                                         "To:   " new-short-name)))))))
       ;; the buffer is not visiting a file
       (let ((key))
         (while (not (memq key '(?s ?r)))
@@ -384,8 +398,9 @@ initialized with the current directory instead of filename."
                          (setq new-name (read-string "New buffer name: "))
                        (keyboard-quit)))
                    (rename-buffer new-name)
-                   (message "Buffer '%s' successfully renamed to '%s'"
-                            name new-name)))
+                   (message (concat "Buffer Renamed\n"
+                                    "From: " name "\n"
+                                    "To:   " new-name))))
                 ;; ?\a = C-g, ?\e = Esc and C-[
                 ((memq key '(?\a ?\e)) (keyboard-quit))))))))
 


### PR DESCRIPTION
problem:
the rename command shows the same message:
"File 'old-file-name' successfully renamed to 'new-file-name'"
(without the directory path) for all three file operations:
move, rename and both move & rename

solution:
show messages that fit the file operation,
and align the from and to paths, to make it easier to see how the paths changed.

---
#### Question
Does the `cond` need a default `t` condition?
I don't know what to put there, because the only case I can think of right now that ends up there, is if one tries to rename to the current file name again, but I have a separate PR that handles that issue:
Update file renaming, handle same new and old name #11473 

If it's accepted, then that issue shouldn't reach this `cond`.

Without that same name PR applied then nothing seems to happen when one tries to rename to the same name with this PR applied.