### PR TITLE
Keeps previous position on toggle-maximize-buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -120,12 +120,13 @@ automatically applied to."
 (defun spacemacs/toggle-maximize-buffer ()
   "Maximize buffer"
   (interactive)
-  (if (and (= 1 (length (window-list)))
-           (assoc ?_ register-alist))
-      (jump-to-register ?_)
-    (progn
-      (window-configuration-to-register ?_)
-      (delete-other-windows))))
+  (save-excursion
+    (if (and (= 1 (length (window-list)))
+             (assoc ?_ register-alist))
+        (jump-to-register ?_)
+      (progn
+        (window-configuration-to-register ?_)
+        (delete-other-windows)))))
 
 ;; https://tsdh.wordpress.com/2007/03/28/deleting-windows-vertically-or-horizontally/
 (defun spacemacs/maximize-horizontally ()


### PR DESCRIPTION
Spacemacs doesn't keep the current position on toggle maximize. This PR suggests a dumb and simple fix.

to repro the issue:
- create multiple splits, 
- maximize the window, 
- move cursor around
- toggle maximize-buffer

observed behavior: cursor is not where it was 