### PR TITLE
`anaconda-mode-go-back` is replaced with `xref-pop-marker-stack`

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -54,7 +54,7 @@
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "hh" 'anaconda-mode-show-doc
         "ga" 'anaconda-mode-find-assignments
-        "gb" 'anaconda-mode-go-back
+        "gb" 'xref-pop-marker-stack
         "gu" 'anaconda-mode-find-references)
       (setq anaconda-mode-installation-directory
             (concat spacemacs-cache-directory "anaconda-mode")))


### PR DESCRIPTION
`anaconda-mode-go-back` is now not supported in anaconda-mode. 
And it is replaced with `xref-pop-marker-stack`