### PR TITLE
Fixed haskell documentation about REPL

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -233,8 +233,8 @@ REPL commands are prefixed by ~SPC m s~:
 |-------------+-------------------------------------------------|
 | ~SPC m s b~ | load or reload the current buffer into the REPL |
 | ~SPC m s c~ | clear the REPL                                  |
-| ~SPC m s s~ | show the REPL without switching to it           |
-| ~SPC m s S~ | show and switch to the REPL                     |
+| ~SPC m s s~ | show and switch to the REPL                     |
+| ~SPC m s S~ | show the REPL without switching to it           |
 
 ** Intero REPL
 Intero REPL commands are prefixed by ~SPC m i~:


### PR DESCRIPTION
The haskell layer documentation indicates the following commands
>
SPC m s s | show the REPL without switching to it
-- | --

SPC m s S | show and switch to the REPL
-- | --

However, they respectively call `haskell-interactive-switch` and `haskell-interactive-bring`, which is the opposite of what the documentation states. 

This was due to a change in `layers/+lang/haskell/funcs.el` and ` layers/+lang/haskell/packages.el` in commit 4c4a1a4e13bd191b04a0f34c64edb3208bf564b7  which did not update the documentation.




