### PR TITLE
Add new test binding + improve documentation

### DIFF
--- a/layers/+lang/csharp/README.org
+++ b/layers/+lang/csharp/README.org
@@ -13,6 +13,7 @@
   - [[#helpers-documentation-info][Helpers (documentation, info)]]
   - [[#refactoring][Refactoring]]
   - [[#omnisharp-server-interaction][OmniSharp server interaction]]
+  - [[#tests][Tests]]
 
 * Description
 This layer adds support for C# language using the [[https://github.com/OmniSharp/omnisharp-roslyn][omnisharp-roslyn]] language
@@ -40,10 +41,10 @@ Before you can work with C# files you will need to install the server by invokin
 ~SPC m s i~ (or =M-x omnisharp-install-server=). Otherwise, if this fails for
 you, please see [[https://github.com/OmniSharp/omnisharp-emacs/blob/master/doc/server-installation.md][omnisharp-emacs/doc/server-installation.md]].
 
-The server needs to be started manually with ~SPC m s s~ (or with
+While the server will start automatically where possible if the
+server needs to be started manually use ~SPC m s s~ (or
 =M-x omnisharp-start-omnisharp-server=). It will prompt a path to your .cpsroj
-or .sln file. In the future the server will be started automatically however for
-now this is required.
+or .sln file.
 
 * Caveats
 - You should use =dotnet= CLI tool from [[https://www.microsoft.com/net/download/core][.NET Core download page]] or an IDE like
@@ -96,3 +97,9 @@ now this is required.
 | ~SPC m s r~ | Reload the solution        |
 | ~SPC m s s~ | Start the OmniSharp server |
 | ~SPC m s S~ | Stop the OmniSharp server  |
+
+** Tests
+
+| Key Binding | Description                 |
+|-------------+-----------------------------|
+| ~SPC m t b~ | Run tests in current buffer |

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -74,7 +74,7 @@
 
         ;; Refactoring
         "rm" 'omnisharp-rename
-        "rM" 'omnisharp-rename-interactively
+        ;; [Broken in roslyn] "rM" 'omnisharp-rename-interactively
         "rr" 'omnisharp-run-code-action-refactoring
 
         ;; Server manipulation, inspired spacemacs REPL bindings since C# does
@@ -86,12 +86,12 @@
 
         ;; Tests
         ;; [missing in roslyn] "ta" 'omnisharp-unit-test-all
-        ;; [missing in roslyn] "tb" 'omnisharp-unit-test-fixture
+        "tb" 'omnisharp-unit-test-buffer
         ;; [missing in roslyn] "tt" 'omnisharp-unit-test-single
 
         ;; Code manipulation
-        ;; [missing in roslyn] "u" 'omnisharp-auto-complete-overrides
-        ;; [missing in roslyn] "i" 'omnisharp-fix-usings
+        "u" 'omnisharp-auto-complete-overrides
+        "i" 'omnisharp-fix-usings
         ;; [missing in roslyn] "=" 'omnisharp-code-format
 ))))
 


### PR DESCRIPTION
Adds ability to run csharp tests from buffer as implemented in omnisharp-emacs https://github.com/OmniSharp/omnisharp-emacs/pull/436

Also contains minor documentation updates as omnisharp-emacs will start the server automatically if it is able to.