### PR TITLE
lang/ocaml: merlin-eldoc, merlin-imenu, merlin-iedit and flycheck-ocaml

### DIFF
--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -32,18 +32,16 @@
       :modes merlin-mode
       :variables merlin-completion-with-doc t)))
 
-(when (configuration-layer/layer-used-p 'syntax-checking)
-  (defun ocaml/post-init-flycheck ()
-    (spacemacs/enable-flycheck 'tuareg-mode))
-  (defun ocaml/init-flycheck-ocaml ()
-    (use-package flycheck-ocaml
-      :if (configuration-layer/package-used-p 'flycheck)
-      :defer t
-      :init
-      (progn
-        (with-eval-after-load 'merlin
-          (setq merlin-error-after-save nil)
-          (flycheck-ocaml-setup))))))
+(defun ocaml/post-init-flycheck ()
+  (spacemacs/enable-flycheck 'tuareg-mode))
+
+(defun ocaml/init-flycheck-ocaml ()
+  (defun ocaml/setup-flycheck ()
+    (when (and buffer-file-name (locate-dominating-file buffer-file-name ".merlin"))
+      (setq merlin-error-after-save nil)
+      (flycheck-ocaml-setup)))
+  (use-package flycheck-ocaml
+    :hook (merlin-mode . ocaml/setup-flycheck)))
 
 (defun ocaml/post-init-ggtags ()
   (add-hook 'ocaml-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -14,7 +14,7 @@
     ;; auto-complete
     company
     flycheck
-    flycheck-ocaml
+    (flycheck-ocaml :requires flycheck)
     ggtags
     counsel-gtags
     helm-gtags

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -18,6 +18,7 @@
     ggtags
     counsel-gtags
     helm-gtags
+    imenu
     merlin
     merlin-eldoc
     ocp-indent

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -59,7 +59,7 @@
     :init
     (progn
       (add-to-list 'spacemacs-jump-handlers-tuareg-mode
-                'spacemacs/merlin-locate)
+                   'spacemacs/merlin-locate)
       (add-hook 'tuareg-mode-hook 'merlin-mode)
       (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
         "cp" 'merlin-project-check
@@ -81,7 +81,13 @@
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mE" "errors")
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor"))))
+      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor")))
+    (use-package merlin-iedit
+      :defer t
+      :commands merlin-iedit-occurrences
+      :init
+      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+        "re"  'merlin-iedit-occurrences)))
 
 (defun ocaml/post-init-imenu ()
   (use-package merlin-imenu

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -81,13 +81,11 @@
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mE" "errors")
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor")))
-    (use-package merlin-iedit
-      :defer t
-      :commands merlin-iedit-occurrences
-      :init
-      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
-        "re"  'merlin-iedit-occurrences)))
+      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor"))
+    :config
+    (require 'merlin-iedit)
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "re"  'merlin-iedit-occurrences)))
 
 (defun ocaml/post-init-imenu ()
   (use-package merlin-imenu

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -19,6 +19,7 @@
     counsel-gtags
     helm-gtags
     merlin
+    merlin-eldoc
     ocp-indent
     smartparens
     tuareg
@@ -81,6 +82,14 @@
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mh" "help")
       (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor"))))
+
+(defun ocaml/post-init-imenu ()
+  (use-package merlin-imenu
+    :hook (merlin-mode . merlin-use-merlin-imenu)))
+
+(defun ocaml/init-merlin-eldoc ()
+  (use-package merlin-eldoc
+   :hook (merlin-mode . merlin-eldoc-setup)))
 
 (defun ocaml/init-ocp-indent ()
   (use-package ocp-indent


### PR DESCRIPTION
Fix flycheck-ocaml so it actually works.
Add support for merlin-eldoc, merlin-imenu and merlin-iedit.

See commit messages on individual commits for details.