### PR TITLE
Fix broken leader key binding for inferior shell

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -224,7 +224,7 @@
       (spacemacs/set-leader-keys
         "'"   'spacemacs/default-pop-shell
         "ase" 'spacemacs/shell-pop-eshell
-        "asi" 'spacemacs/shell-pop-shell
+        "asi" 'spacemacs/shell-pop-inferior-shell
         "asm" 'spacemacs/shell-pop-multiterm
         "ast" 'spacemacs/shell-pop-ansi-term
         "asT" 'spacemacs/shell-pop-term))))


### PR DESCRIPTION
It seems that I had forgotten to update binding for inferior shell, after
fixing unexpected popup window layout issue(#11422).

This binds the new shell wrapper function to `SPC a s i` binding.