### PR TITLE
Set magit buffers as useless

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -137,6 +137,8 @@
     :defer (spacemacs/defer)
     :init
     (progn
+      (push "magit: .*" spacemacs-useless-buffers-regexp)
+      (push "magit-.*: .*"  spacemacs-useless-buffers-regexp)
       (spacemacs|require 'magit)
       (setq magit-completing-read-function
             (if (configuration-layer/layer-used-p 'ivy)


### PR DESCRIPTION
Magit creates a buffer for almost every possible action that you can do with it. Since recently, these buffers get added to the current perspective, which I find a good and sensible thing. But then, browsing your perspective with `<SPC> b n` or `<SPC> b p` gets tedious as you have to pass all the magit buffers.

I find that setting Magit's buffers as useless makes sense, since these buffers are accessed through Magit's commands (and they get refreshed that way).