### PR TITLE
alternate-buffer without purpose

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -306,7 +306,8 @@ current window."
     (switch-to-buffer
      (cl-find-if (lambda (buffer)
                    (not (eq buffer current-buffer)))
-                 (mapcar #'car (window-prev-buffers window))))))
+                 (mapcar #'car (window-prev-buffers window)))
+     nil t)))
 
 (defun spacemacs/alternate-window ()
   "Switch back and forth between current and last window in the


### PR DESCRIPTION
`<SPC> tab` is supposed to alternate to the previous buffer that was displayed in the current window, although that won't happen if you are using `purpose` and the previous buffer had a different purpose: it will get sent to another window.

`<SPC> tab` should, as its docs states, be very simple:
```
Switch back and forth between current and last buffer in the
current window.
```
Making it ignore `purpose` makes it match its documentation again, and gain back its very simple behavior 😺 