### PR TITLE
Improve the use of semantic

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -975,6 +975,7 @@ Other:
     (thanks to Aaron Jensen)
   - Use =counsel-company= to show completion candidates
     (thanks to Kalle Lindqvist)
+  - Added =company-semantic= as a default company backend (thanks to bet4it)
 - Fixes:
   - Check if =dotspacemacs-directory-snippets-dir= exists before adding it
     (thanks to Wojciech Wojtyniak)
@@ -2075,6 +2076,10 @@ Other:
 - Update install docs for Chicken 5 changes (thanks to Grant Shangreaux)
 **** Semantic
 - Made it possible to exclude stickyfunc (thanks to Sylvain Benner)
+- Changed the default throttle for =semanticdb-find= routines. Always don't
+  search system databases to speed up semantic (thanks to bet4it)
+- Disabled =semantic-idle-summary-mode= when =gtags= or =lsp= layer is enabled
+  (thanks to bet4it)
 **** Shell
 - Fixed xterm colors filtering bug in =eshell= when eshell buffers are updated
   and are not focused (thanks to Steven Allen)

--- a/layers/+completion/auto-completion/config.el
+++ b/layers/+completion/auto-completion/config.el
@@ -12,7 +12,7 @@
 ;; Company -------------------------------------------------------------------
 
 (defvar spacemacs-default-company-backends
-  '((company-dabbrev-code company-gtags company-etags company-keywords)
+  '((company-semantic company-dabbrev-code company-gtags company-etags company-keywords)
     company-files company-dabbrev)
   "The list of default company backends used by spacemacs.
 This variable is used to configure mode-specific company backends in spacemacs.

--- a/layers/+emacs/semantic/README.org
+++ b/layers/+emacs/semantic/README.org
@@ -37,10 +37,6 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =semantic= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-By default, Spacemacs sets Semantic to parse only file, local and project scope.
-For a different parsing scope, you can customize the variable
-=semanticdb-find-default-throttle=.
-
 * Key bindings
 
 | Key binding | Description                         |

--- a/layers/+emacs/semantic/config.el
+++ b/layers/+emacs/semantic/config.el
@@ -13,6 +13,5 @@
                                     "srecode-map.el"))
 (setq semanticdb-default-save-directory (concat spacemacs-cache-directory
                                                 "semanticdb/"))
-(setq semanticdb-find-default-throttle '(file local project))
 (unless (file-exists-p semanticdb-default-save-directory)
   (make-directory semanticdb-default-save-directory))

--- a/layers/+emacs/semantic/config.el
+++ b/layers/+emacs/semantic/config.el
@@ -14,5 +14,6 @@
 (setq semanticdb-default-save-directory (concat spacemacs-cache-directory
                                                 "semanticdb/"))
 (setq semanticdb-search-system-databases nil)
+(setq semanticdb-project-root-functions #'projectile-project-root)
 (unless (file-exists-p semanticdb-default-save-directory)
   (make-directory semanticdb-default-save-directory))

--- a/layers/+emacs/semantic/config.el
+++ b/layers/+emacs/semantic/config.el
@@ -13,5 +13,6 @@
                                     "srecode-map.el"))
 (setq semanticdb-default-save-directory (concat spacemacs-cache-directory
                                                 "semanticdb/"))
+(setq semanticdb-search-system-databases nil)
 (unless (file-exists-p semanticdb-default-save-directory)
   (make-directory semanticdb-default-save-directory))

--- a/layers/+emacs/semantic/packages.el
+++ b/layers/+emacs/semantic/packages.el
@@ -31,3 +31,6 @@
                             'global-semantic-stickyfunc-mode)))
 (defun semantic/init-stickyfunc-enhance ()
   (use-package stickyfunc-enhance :defer t))
+
+(defun spacemacs//disable-semantic-idle-summary-mode ()
+  (semantic-idle-summary-mode 0))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -231,7 +231,8 @@
 
 (defun c-c++/post-init-semantic ()
   (spacemacs/add-to-hooks 'semantic-mode c-c++-mode-hooks)
-  (when (configuration-layer/layer-used-p 'gtags)
+  (when (or (configuration-layer/layer-used-p 'gtags)
+            (configuration-layer/layer-used-p 'lsp))
     (spacemacs/add-to-hooks 'spacemacs//disable-semantic-idle-summary-mode c-c++-mode-hooks t)))
 
 (defun c-c++/post-init-srefactor ()

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -230,7 +230,9 @@
     (spacemacs/add-realgud-debugger mode "gdb")))
 
 (defun c-c++/post-init-semantic ()
-  (spacemacs/add-to-hooks 'semantic-mode c-c++-mode-hooks))
+  (spacemacs/add-to-hooks 'semantic-mode c-c++-mode-hooks)
+  (when (configuration-layer/layer-used-p 'gtags)
+    (spacemacs/add-to-hooks 'spacemacs//disable-semantic-idle-summary-mode c-c++-mode-hooks t)))
 
 (defun c-c++/post-init-srefactor ()
   (dolist (mode c-c++-modes)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -56,12 +56,6 @@
   (forward-button 1)
   (call-interactively #'push-button))
 
-(defun spacemacs//disable-semantic-idle-summary-mode ()
-  "Disable semantic-idle-summary in Python mode.
-Anaconda provides more useful information but can not do it properly
-when this mode is enabled since the minibuffer is cleared all the time."
-  (semantic-idle-summary-mode 0))
-
 
 ;; lsp
 


### PR DESCRIPTION
This pull request has the same effects as #9354, except that it works globally rather that only works in `emacs-lisp-mode`, and it's more clear what we have done and what we will lose.
Other language layers are well configured in `spacemacs`, so I don't think we need `semantic` to search system databases for them.

As what has been described in https://github.com/syl20bnr/spacemacs/pull/7736#issuecomment-313320906, the setting in #7736 has been overrided by mode local variables and has no effects. So I revert it.

Resolve #1907.