### PR TITLE
Fix doom-modeline in the messages buffer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -921,6 +921,7 @@ Other:
   - Fixed evil surround bindings (thanks to Hoyon Mak)
   - Improved Window Manipulation Transient state (thanks to yuhan0)
   - Exclude which-key from layer sync powerline restore (thanks to Doug Wilson)
+  - Fix doom-modeline in the messages buffer (thanks to duianto)
 *** Layer changes and fixes
 **** Ansible
 - Improvements:

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -35,7 +35,7 @@
   (use-package doom-modeline
     :defer t
     :if (eq (spacemacs/get-mode-line-theme-name) 'doom)
-    :init (add-hook 'after-init-hook 'doom-modeline-init)))
+    :init (doom-modeline-init)))
 
 (defun spacemacs-modeline/init-fancy-battery ()
   (use-package fancy-battery


### PR DESCRIPTION
problem:
the doom-modeline isn't applied to the messages buffer

solution:
call `(doom-modeline-init)` without a hook

Resolves #11404 

---

### Possible cause

The `doom-modeline-init` function sets the modeline to `main` in the `*Messages*` buffer, if the `after-init-time` variable is `nil`, but it's `(23507 65018 227374 0)` when the `after-init-hook` runs.

```elisp
(defun doom-modeline-init ()
  "Initialize doom mode-line."
  ;; Create bars
  (doom-modeline-refresh-bars)
  (unless after-init-time
    ;; These buffers are already created and don't get modelines. For the love
    ;; of Emacs, someone give the man a modeline!
    (dolist (bname '("*scratch*" "*Messages*"))
      (with-current-buffer bname
        (doom-modeline-set-modeline 'main)))))
```
https://github.com/seagle0128/doom-modeline/blob/cb1727d95623e178b7bc0cb8559ca5b352ced886/doom-modeline.el#L1136
