### PR TITLE
Hide helm modeline indicator text

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -144,6 +144,7 @@
     :config
     (progn
       (helm-mode)
+      (spacemacs|hide-lighter helm-mode)
       (advice-add 'helm-grep-save-results-1 :after 'spacemacs//gne-init-helm-grep)
       ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
       (helm-locate-set-command)


### PR DESCRIPTION
Resolves #11233

---

### Question
Should `(spacemacs|hide-lighter helm-mode)` that's commented out in the `:init` section be removed? Or maybe all five lines that are commented out could be removed, if they only were used for hiding the helm modeline text.
https://github.com/syl20bnr/spacemacs/blob/f5243bb69a764d5a44c83ee6dbaee910621d8dfd/layers/%2Bcompletion/helm/packages.el#L66-L70

They were commented out in this commit: [Truly lazy load helm based on key bindings](https://github.com/syl20bnr/spacemacs/commit/e24be2186adcbf1bafafd3ca2ea4e31d8919c760)
