### PR TITLE
Make query-replace work when frame is split

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -681,45 +681,48 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
   %n -- prints Narrow if appropriate
   %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
   %Z -- like %z, but including the end-of-line format"
-  (let* ((project-name (when (string-match-p "%t" title-format)
-                         (if (boundp 'spacemacs--buffer-project-name)
-                             spacemacs--buffer-project-name
-                           (set (make-local-variable 'spacemacs--buffer-project-name)
-                                (if (fboundp 'projectile-project-name)
-                                    (projectile-project-name)
-                                  "-")))))
-         (abbreviated-file-name (when (string-match-p "%a" title-format)
-                                  (if (boundp 'spacemacs--buffer-abbreviated-filename)
-                                      spacemacs--buffer-abbreviated-filename
-                                    (set (make-local-variable 'spacemacs--buffer-abbreviated-filename)
-                                         (abbreviate-file-name (or (buffer-file-name)
-                                                                   (buffer-name)))))))
-         (fs (format-spec-make
-              ?a abbreviated-file-name
-              ?t project-name
-              ?S system-name
-              ?I invocation-name
-              ?U (or (getenv "USER") "")
-              ?b "%b"
-              ?f "%f"
-              ?F "%F"
-              ?* "%*"
-              ?+ "%+"
-              ?s "%s"
-              ?l "%l"
-              ?c "%c"
-              ?p "%p"
-              ?P "%P"
-              ?m "%m"
-              ?n "%n"
-              ?z "%z"
-              ?Z "%Z"
-              ?\[ "%["
-              ?\] "%]"
-              ?% "%%"
-              ?- "%-"
-              )))
-    (format-spec title-format fs)))
+  (save-match-data
+    ;; save-match-data to work around Emacs bug, see
+    ;; https://github.com/syl20bnr/spacemacs/issues/9700
+    (let* ((project-name (when (string-match-p "%t" title-format)
+                           (if (boundp 'spacemacs--buffer-project-name)
+                               spacemacs--buffer-project-name
+                             (set (make-local-variable 'spacemacs--buffer-project-name)
+                                  (if (fboundp 'projectile-project-name)
+                                      (projectile-project-name)
+                                    "-")))))
+           (abbreviated-file-name (when (string-match-p "%a" title-format)
+                                    (if (boundp 'spacemacs--buffer-abbreviated-filename)
+                                        spacemacs--buffer-abbreviated-filename
+                                      (set (make-local-variable 'spacemacs--buffer-abbreviated-filename)
+                                           (abbreviate-file-name (or (buffer-file-name)
+                                                                     (buffer-name)))))))
+           (fs (format-spec-make
+                ?a abbreviated-file-name
+                ?t project-name
+                ?S system-name
+                ?I invocation-name
+                ?U (or (getenv "USER") "")
+                ?b "%b"
+                ?f "%f"
+                ?F "%F"
+                ?* "%*"
+                ?+ "%+"
+                ?s "%s"
+                ?l "%l"
+                ?c "%c"
+                ?p "%p"
+                ?P "%P"
+                ?m "%m"
+                ?n "%n"
+                ?z "%z"
+                ?Z "%Z"
+                ?\[ "%["
+                ?\] "%]"
+                ?% "%%"
+                ?- "%-"
+                )))
+      (format-spec title-format fs))))
 
 (defun dotspacemacs/safe-load ()
   "Error recovery from malformed .spacemacs.


### PR DESCRIPTION
Fixes #9700 and #10938

This works around an issue in Emacs which results in `args-out-or-range` errors when
trying to query-replace in frames which are split vertically or horizontally.

See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=31586
