### PR TITLE
fix bm as bm-load-and-restore removed in upstream

### DIFF
--- a/layers/+tools/bm/packages.el
+++ b/layers/+tools/bm/packages.el
@@ -17,6 +17,8 @@
     :defer t
     :commands (bm-buffer-restore)
     :init (progn
+            ;; restore on load (even before you require bm)
+            (setq bm-restore-repository-on-load t)
             ;; Allow cross-buffer 'next'
             (setq bm-cycle-all-buffers t)
             ;; save bookmarks
@@ -42,7 +44,6 @@
             (advice-add 'spacemacs/bm-transient-state/body
                         :before #'bm-buffer-restore))
     :config (progn
-              (bm-load-and-restore)
               ;; Saving bookmarks
               (add-hook 'kill-buffer-hook #'bm-buffer-save)
               ;; Saving the repository to file when on exit.


### PR DESCRIPTION
Use official recommended way to init bm package.