### PR TITLE
document better way of activating evil-mc

### DIFF
--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -12,8 +12,9 @@
 ;;; License: GPLv3
 
 (setq multiple-cursors-packages
-  '(evil-mc
-     ))
+      '(
+        evil-mc
+        ))
 
 (defun multiple-cursors/init-evil-mc ()
   (use-package evil-mc

--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -32,5 +32,5 @@
         (dolist (keybinding `((,(kbd "C-M-j") . evil-mc-make-cursor-move-next-line)
                               (,(kbd "C-M-k") . evil-mc-make-cursor-move-prev-line)))
           (define-key state-map (car keybinding) (cdr keybinding))))
-
-      (global-evil-mc-mode 1))))
+      (add-hook 'prog-mode-hook 'turn-on-evil-mc-mode)
+      (add-hook 'text-mode-hook 'turn-on-evil-mc-mode))))

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -10,7 +10,8 @@
 ;;; License: GPLv3
 
 (setq spacemacs-evil-packages
-      '(evil-anzu
+      '(
+        evil-anzu
         evil-args
         evil-cleverparens
         evil-ediff


### PR DESCRIPTION
As per #5324 and my own experience, the currently documented way of activating `evil-mc` conflicts with (at least) Magit and Treemacs `gr` binding.