### PR TITLE
[html] revert: set company min. prefix length to 0 for company-web backend

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -57,10 +57,7 @@
     (progn
       (spacemacs|add-company-backends
         :backends (company-web-html company-css)
-        :modes web-mode
-        :variables
-        ;; see https://github.com/osv/company-web/issues/4
-        company-minimum-prefix-length 0)
+        :modes web-mode)
       (spacemacs|add-company-backends
         :backends company-web-jade
         :modes pug-mode)


### PR DESCRIPTION
This commit reverts ab34cc2d9dd53f7c31ba1c7af01b6f5e6c67aad5. Setting
company-minimum-prefix-length to 0 causes issues indicated in issue #8222. While
the user is free to set company-minimum-prefix-length to 0 if they please, doing
so affects editing any files that also use web-mode such as jsx files.
Additionally, new users to Spacemacs may be confused by this behavior since no
other layer sets company-minimum-prefix-length to 0.
