### PR TITLE
Fix magit blame

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -174,10 +174,10 @@
 Press [_b_] again to blame further in the history, [_q_] to go up or quit."
         :on-enter (let (golden-ratio-mode)
                     (unless (bound-and-true-p magit-blame-mode)
-                      (call-interactively 'magit-blame)))
+                      (call-interactively 'magit-blame-addition)))
         :foreign-keys run
         :bindings
-        ("b" magit-blame)
+        ("b" magit-blame-addition)
         ;; here we use the :exit keyword because we should exit the
         ;; micro-state only if the magit-blame-quit effectively disable
         ;; the magit-blame mode.


### PR DESCRIPTION
`magit-blame` was renamed to `magit-blame-addition` in this commit: https://github.com/magit/magit/commit/4f48241fc9189455311ab01632b991e31888a1f3#diff-9c4a10f515ce5f6fe4275bf9694f019a 