### PR TITLE
Add `z` binding to transient states to recenter buffer

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -133,7 +133,6 @@
       - [[#buffers-manipulation-key-bindings][Buffers manipulation key bindings]]
       - [[#create-a-new-empty-buffer][Create a new empty buffer]]
       - [[#buffers-manipulation-transient-state][Buffers manipulation transient state]]
-      - [[#special-buffers-usefuluseless-buffers][Special Buffers (useful/useless buffers)]]
       - [[#files-manipulations-key-bindings][Files manipulations key bindings]]
       - [[#frame-manipulation-key-bindings][Frame manipulation key bindings]]
       - [[#emacs-and-spacemacs-files][Emacs and Spacemacs files]]
@@ -189,6 +188,8 @@
   - [[#managing-projects][Managing projects]]
   - [[#registers][Registers]]
   - [[#errors-handling][Errors handling]]
+    - [[#error-transient-state][Error transient state]]
+    - [[#custom-fringe-bitmaps][Custom fringe bitmaps]]
   - [[#compiling][Compiling]]
 - [[#editorconfig][EditorConfig]]
 - [[#emacs-server][Emacs Server]]
@@ -1676,34 +1677,31 @@ selected layout.
 
 Press ~?~ to toggle the full help.
 
-| Key Binding  | Description                                                |
-|--------------+------------------------------------------------------------|
-| ~SPC l~      | activate the transient- state                              |
-| ~?~          | toggle the documentation                                   |
-| ~[0..9]~     | switch to nth layout                                       |
-| ~[C-0..C-9]~ | switch to nth layout and keep the transient state active   |
-| ~<tab>~      | switch to the latest layout                                |
-| ~a~          | add a buffer to the current layout                         |
-| ~A~          | add all the buffers from another layout in the current one |
-| ~b~          | select a buffer in the current layout                      |
-| ~d~          | delete the current layout and keep its buffers             |
-| ~D~          | delete the other layouts and keep their buffers            |
-| ~h~          | go to default layout                                       |
-| ~C-h~        | previous layout in list                                    |
-| ~l~          | select/create a layout                                     |
-| ~L~          | load layouts from file                                     |
-| ~C-l~        | next layout in list                                        |
-| ~n~          | next layout in list                                        |
-| ~N~          | previous layout in list                                    |
-| ~o~          | open a custom layout                                       |
-| ~p~          | previous layout in list                                    |
-| ~r~          | remove current buffer from layout                          |
-| ~R~          | rename current layout                                      |
-| ~s~          | save layouts                                               |
-| ~t~          | display a buffer without adding it to the current layout   |
-| ~w~          | workspaces transient state (needs eyebrowse layer enabled) |
-| ~x~          | kill current layout with its buffers                       |
-| ~X~          | kill other layouts with their buffers                      |
+| Key Binding         | Description                                                |
+|---------------------+------------------------------------------------------------|
+| ~SPC l~             | initiate transient state                                   |
+| ~?~                 | toggle the documentation                                   |
+| ~[0..9]~            | switch to nth layout                                       |
+| ~[C-0..C-9]~        | switch to nth layout and keep the transient state active   |
+| ~<tab>~             | switch to the latest layout                                |
+| ~a~                 | add a buffer to the current layout                         |
+| ~A~                 | add all the buffers from another layout in the current one |
+| ~b~                 | select a buffer in the current layout                      |
+| ~d~                 | delete the current layout and keep its buffers             |
+| ~D~                 | delete the other layouts and keep their buffers            |
+| ~h~                 | go to default layout                                       |
+| ~l~                 | select/create a layout                                     |
+| ~L~                 | load layouts from file                                     |
+| ~n~ or ~C-l~        | next layout in list                                        |
+| ~N~ or ~p~ or ~C-h~ | previous layout in list                                    |
+| ~o~                 | open a custom layout                                       |
+| ~r~                 | remove current buffer from layout                          |
+| ~R~                 | rename current layout                                      |
+| ~s~                 | save layouts                                               |
+| ~t~                 | display a buffer without adding it to the current layout   |
+| ~w~                 | workspaces transient state (needs eyebrowse layer enabled) |
+| ~x~                 | kill current layout with its buffers                       |
+| ~X~                 | kill other layouts with their buffers                      |
 
 ** Workspaces
 Workspaces are sub-layouts, they allow to define multiple layouts into a given
@@ -1733,7 +1731,7 @@ Press ~?~ to toggle the full help.
 
 | Key Binding       | Description                                                 |
 |-------------------+-------------------------------------------------------------|
-| ~SPC l w~         | activate the transient state                                |
+| ~SPC l w~         | initiate transient state                                    |
 | ~?~               | toggle the documentation                                    |
 | ~[0..9]~          | switch to nth workspace                                     |
 | ~[C-0..C-9]~      | switch to nth workspace and keep the transient state active |
@@ -2240,48 +2238,47 @@ A convenient window manipulation transient state allows performing most of the
 actions listed above. The transient state allows additional actions as well like
 window resizing.
 
-| Key Binding   | Description                                                   |
-|---------------+---------------------------------------------------------------|
-| ~SPC w .~     | initiate transient state                                      |
-| ~?~           | display the full documentation in minibuffer                  |
-| ~0~           | go to window number 0                                         |
-| ~1~           | go to window number 1                                         |
-| ~2~           | go to window number 2                                         |
-| ~3~           | go to window number 3                                         |
-| ~4~           | go to window number 4                                         |
-| ~5~           | go to window number 5                                         |
-| ~6~           | go to window number 6                                         |
-| ~7~           | go to window number 7                                         |
-| ~8~           | go to window number 8                                         |
-| ~9~           | go to window number 9                                         |
-| ~/~           | vertical split                                                |
-| ~-~           | horizontal split                                              |
-| ~[~           | shrink window horizontally                                    |
-| ~]~           | enlarge window horizontally                                   |
-| ~{~           | shrink window vertically                                      |
-| ~}~           | enlarge window vertically                                     |
-| ~d~           | delete window                                                 |
-| ~D~           | delete other windows                                          |
-| ~g~           | toggle =golden-ratio= on and off                              |
-| ~h~           | go to window on the left                                      |
-| ~j~           | go to window below                                            |
-| ~k~           | go to window above                                            |
-| ~l~           | go to window on the right                                     |
-| ~H~           | move window to the left                                       |
-| ~J~           | move window to the bottom                                     |
-| ~K~           | move bottom to the top                                        |
-| ~L~           | move window to the right                                      |
-| ~o~           | focus other frame                                             |
-| ~r~           | rotate windows forward                                        |
-| ~R~           | rotate windows backward                                       |
-| ~s~           | horizontal split                                              |
-| ~S~           | horizontal split and focus new window                         |
-| ~u~           | undo window layout (used to effectively undo a closed window) |
-| ~U~           | redo window layout                                            |
-| ~v~           | vertical split                                                |
-| ~V~           | vertical split and focus new window                           |
-| ~w~           | focus other window                                            |
-| Any other key | leave the transient state                                     |
+| Key Binding | Description                                                   |
+|-------------+---------------------------------------------------------------|
+| ~SPC w .~   | initiate transient state                                      |
+| ~?~         | display the full documentation in minibuffer                  |
+| ~0~         | go to window number 0                                         |
+| ~1~         | go to window number 1                                         |
+| ~2~         | go to window number 2                                         |
+| ~3~         | go to window number 3                                         |
+| ~4~         | go to window number 4                                         |
+| ~5~         | go to window number 5                                         |
+| ~6~         | go to window number 6                                         |
+| ~7~         | go to window number 7                                         |
+| ~8~         | go to window number 8                                         |
+| ~9~         | go to window number 9                                         |
+| ~/~         | vertical split                                                |
+| ~-~         | horizontal split                                              |
+| ~[~         | shrink window horizontally                                    |
+| ~]~         | enlarge window horizontally                                   |
+| ~{~         | shrink window vertically                                      |
+| ~}~         | enlarge window vertically                                     |
+| ~d~         | delete window                                                 |
+| ~D~         | delete other windows                                          |
+| ~g~         | toggle =golden-ratio= on and off                              |
+| ~h~         | go to window on the left                                      |
+| ~j~         | go to window below                                            |
+| ~k~         | go to window above                                            |
+| ~l~         | go to window on the right                                     |
+| ~H~         | move window to the left                                       |
+| ~J~         | move window to the bottom                                     |
+| ~K~         | move bottom to the top                                        |
+| ~L~         | move window to the right                                      |
+| ~o~         | focus other frame                                             |
+| ~r~         | rotate windows forward                                        |
+| ~R~         | rotate windows backward                                       |
+| ~s~         | horizontal split                                              |
+| ~S~         | horizontal split and focus new window                         |
+| ~u~         | undo window layout (used to effectively undo a closed window) |
+| ~U~         | redo window layout                                            |
+| ~v~         | vertical split                                                |
+| ~V~         | vertical split and focus new window                           |
+| ~w~         | focus other window                                            |
 
 **** Golden ratio
 If you resize windows like crazy you may want to give a try to [[https://github.com/roman/golden-ratio.el][golden-ratio]].
@@ -2336,13 +2333,13 @@ Buffer manipulation commands (start with ~b~):
 A convenient buffer manipulation transient state allows to quickly cycles through
 the opened buffer and kill them.
 
-| Key Binding   | Description                                                                       |
-|---------------+-----------------------------------------------------------------------------------|
-| ~SPC b .~     | initiate transient state                                                          |
-| ~K~           | kill current buffer                                                               |
-| ~n~           | go to next buffer (avoid buffers matching =spacemacs-useless-buffers-regexp=)     |
-| ~N~           | go to previous buffer (avoid buffers matching =spacemacs-useless-buffers-regexp=) |
-| Any other key | leave the transient state                                                         |
+| Key Binding | Description                                                                       |
+|-------------+-----------------------------------------------------------------------------------|
+| ~SPC b .~   | initiate transient state                                                          |
+| ~K~         | kill current buffer                                                               |
+| ~n~         | go to next buffer (avoid buffers matching =spacemacs-useless-buffers-regexp=)     |
+| ~N~         | go to previous buffer (avoid buffers matching =spacemacs-useless-buffers-regexp=) |
+| ~z~         | recenter buffer in window                                                         |
 
 Unlike vim, emacs creates many buffers that most people do not need to see. Some
 examples are the =*Messages*= and =*Compile-Log*= buffers. Spacemacs tries to
@@ -2614,7 +2611,7 @@ called =pt=.
 
 When results have been saved in a regular buffer with ~F3~, that buffer supports
 browsing through the matches with Spacemacs’ =next-error= and =previous-error=
-bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e~).
+bindings (~SPC e n~ and ~SPC e p~) as well as the error transient state (~SPC e .~).
 
 **** Searching in current file
 
@@ -2734,34 +2731,36 @@ Navigation between the highlighted symbols can be done with the commands:
 | ~SPC s H~   | go to the last searched occurrence of the last highlighted symbol                  |
 | ~SPC t h a~ | toggle automatic highlight of symbol under point after =ahs-idle-interval= seconds |
 
-In “Spacemacs” highlight symbol transient state:
+During the symbol highlight transient state, the following bindings are active:
 
-| Key Binding   | Description                                                   |
-|---------------+---------------------------------------------------------------|
-| ~e~           | edit occurrences (*)                                          |
-| ~n~           | go to next occurrence                                         |
-| ~N~           | go to previous occurrence                                     |
-| ~d~           | go to next definition occurrence                              |
-| ~D~           | go to previous definition occurrence                          |
-| ~r~           | change range (=function=, =display area=, =whole buffer=)     |
-| ~R~           | go to home occurrence (reset position to starting occurrence) |
-| Any other key | leave the navigation transient state                          |
+| Key Binding | Description                                                   |
+|-------------+---------------------------------------------------------------|
+| ~e~         | edit occurrences (*)                                          |
+| ~n~         | go to next occurrence                                         |
+| ~N~ or ~p~  | go to previous occurrence                                     |
+| ~d~         | go to next definition occurrence                              |
+| ~D~         | go to previous definition occurrence                          |
+| ~r~         | change range (=function=, =display area=, =whole buffer=)     |
+| ~R~         | go to home occurrence (reset position to starting occurrence) |
+| ~s~         | search current buffer for symbol using ivy / helm             |
+| ~b~         | search all open buffers for symbol using ivy / helm           |
+| ~f~         | search files for symbol                                       |
+| ~/~         | search current project for symbol                             |
+| ~z~         | recenter buffer in window                                     |
 
-(*) using [[https://github.com/tsdh/iedit][iedit]] or the default implementation
-of =auto-highlight-symbol=
+(*) using [[https://github.com/tsdh/iedit][iedit]] or the default implementation of =auto-highlight-symbol=
 
-The transient state text in minibuffer display the following information:
+The minibuffer displays the following information during the transient state:
 
 #+BEGIN_EXAMPLE
-  <M> [6/11]* press (n/N) to navigate, (e) to edit, (r) to change range or (R)
-  for reset
+  Buffer [6/11]*
 #+END_EXAMPLE
 
-Where =<M> [x/y]*= is:
-- M: the current range mode
-- =<B>=: whole buffer range
-- =<D>=: current display range
-- =<F>=: current function range
+Where =M [x/y]*= indicates:
+- =M=: the current search scope, which is one of the following:
+  - =Buffer=: whole buffer range
+  - =Display=: current display range
+  - =Function=: current function range (dependent on the programming language major mode)
 - =x=: the index of the current highlighted occurrence
 - =y=: the total number of occurrences
 - =*=: appears if there is at least one occurrence which is not currently visible.
@@ -2791,12 +2790,11 @@ text on the kill ring.
 For example if you copy =foo= and =bar= then press ~p~ the text =bar= will
 be pasted, pressing ~C-j~ will replace =bar= with =foo=.
 
-| Key Binding   | Description                                                                   |
-|---------------+-------------------------------------------------------------------------------|
-| ~p~ or ~P~    | paste the text before or after point and initiate the =paste= transient state |
-| ~C-j~         | in transient state: replace paste text with the previously copied one         |
-| ~C-k~         | in transient state: replace paste text with the next copied one               |
-| Any other key | leave the transient state                                                     |
+| Key Binding | Description                                                                   |
+|-------------+-------------------------------------------------------------------------------|
+| ~p~ or ~P~  | paste the text before or after point and initiate the =paste= transient state |
+| ~C-j~       | in transient state: replace paste text with the previously copied one         |
+| ~C-k~       | in transient state: replace paste text with the next copied one               |
 
 **** Auto-indent pasted text
 By default any pasted text will be auto-indented. To paste text un-indented use
@@ -2908,17 +2906,21 @@ It is possible to enable it easily for /all programming modes/ with the variable
 **** Text
 The font size of the current buffer can be adjusted with the commands:
 
-| Key Binding   | Description                                                                    |
-|---------------+--------------------------------------------------------------------------------|
-| ~SPC z x +~   | scale up the font and initiate the font scaling transient state                |
-| ~SPC z x =~   | scale up the font and initiate the font scaling transient state                |
-| ~SPC z x -~   | scale down the font and initiate the font scaling transient state              |
-| ~SPC z x 0~   | reset the font size (no scaling) and initiate the font scaling transient state |
-| ~+~           | increase the font size                                                         |
-| ~=~           | increase the font size                                                         |
-| ~-~           | decrease the font size                                                         |
-| ~0~           | reset the font size                                                            |
-| Any other key | leave the font scaling transient state                                         |
+| Key Binding | Description                                                                    |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC z x +~ | scale up the font and initiate the font scaling transient state                |
+| ~SPC z x =~ | scale up the font and initiate the font scaling transient state                |
+| ~SPC z x -~ | scale down the font and initiate the font scaling transient state              |
+| ~SPC z x 0~ | reset the font size (no scaling) and initiate the font scaling transient state |
+
+In the transient state:
+
+| Key Binding | Description            |
+|-------------+------------------------|
+| ~+~         | increase the font size |
+| ~=~         | increase the font size |
+| ~-~         | decrease the font size |
+| ~0~         | reset the font size    |
 
 Note that /only/ the text of the current buffer is scaled, the other buffers,
 the mode-line and the minibuffer are not affected. To zoom the whole content of
@@ -2927,17 +2929,16 @@ a frame use the =zoom frame= bindings (see next section).
 **** Frame
 You can zoom in and out the whole content of the frame with the commands:
 
-| Key Binding   | Description                                                                 |
-|---------------+-----------------------------------------------------------------------------|
-| ~SPC z f +~   | zoom in the frame content and initiate the frame scaling transient state    |
-| ~SPC z f =~   | zoom in the frame content and initiate the frame scaling transient state    |
-| ~SPC z f -~   | zoom out the frame content and initiate the frame scaling transient state   |
-| ~SPC z f 0~   | reset the frame content size and initiate the frame scaling transient state |
-| ~+~           | zoom in                                                                     |
-| ~=~           | zoom in                                                                     |
-| ~-~           | zoom out                                                                    |
-| ~0~           | reset zoom                                                                  |
-| Any other key | leave the zoom frame transient state                                        |
+| Key Binding | Description                                                                 |
+|-------------+-----------------------------------------------------------------------------|
+| ~SPC z f +~ | zoom in the frame content and initiate the frame scaling transient state    |
+| ~SPC z f =~ | zoom in the frame content and initiate the frame scaling transient state    |
+| ~SPC z f -~ | zoom out the frame content and initiate the frame scaling transient state   |
+| ~SPC z f 0~ | reset the frame content size and initiate the frame scaling transient state |
+| ~+~         | zoom in                                                                     |
+| ~=~         | zoom in                                                                     |
+| ~-~         | zoom out                                                                    |
+| ~0~         | reset zoom                                                                  |
 
 *** Increase/Decrease numbers
 Spacemacs uses [[https://github.com/cofi/evil-numbers][evil-numbers]] to easily increase or decrease numbers.
@@ -2947,13 +2948,12 @@ Spacemacs uses [[https://github.com/cofi/evil-numbers][evil-numbers]] to easily 
 | ~SPC n +~   | increase the number under point by one and initiate transient state |
 | ~SPC n -~   | decrease the number under point by one and initiate transient state |
 
-In transient state:
+In the transient state:
 
-| Key Binding   | Description                            |
-|---------------+----------------------------------------|
-| ~+~           | increase the number under point by one |
-| ~-~           | decrease the number under point by one |
-| Any other key | leave the transient state              |
+| Key Binding | Description                            |
+|-------------+----------------------------------------|
+| ~+~         | increase the number under point by one |
+| ~-~         | decrease the number under point by one |
 
 *Tips:* you can increase or decrease a value by more that once by using a prefix
 argument (i.e. ~10 SPC n +~ will add 10 to the number under point).
@@ -3342,7 +3342,17 @@ browse errors from flycheck as well as errors from compilation buffers, and
 indeed anything that supports Emacs’ =next-error= API. This includes for example
 search results that have been saved to a separate buffer.
 
-Custom fringe bitmaps:
+*** Error transient state
+The following key bindings are active in the error transient state:
+
+| Key Binding | Description               |
+|-------------+---------------------------|
+| ~n~         | jump to next error        |
+| ~N~ or ~p~  | jump to previous error    |
+| ~z~         | recenter buffer in window |
+
+
+*** Custom fringe bitmaps
 
 | Symbol                   | Description |
 |--------------------------+-------------|

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -520,6 +520,7 @@ execution. During that state, the following bindings are active:
 | ~g~         | jump to named source block    |
 | ~j~         | jump to next source block     |
 | ~k~         | jump to previous source block |
+| ~z~         | recenter buffer in window     |
 | ~q~         | leave transient state         |
 
 ** Emphasis

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -404,13 +404,14 @@ Will work on both org-mode and any mode that accepts plain html."
         :title "Org Babel Transient state"
         :doc "
 [_j_/_k_] navigate src blocks         [_e_] execute src block
-[_g_] goto named block                [_'_] edit src block
-[_q_] quit"
+[_g_]^^   goto named block            [_'_] edit src block
+[_z_]^^   recenter screen             [_q_] quit"
         :bindings
         ("q" nil :exit t)
         ("j" org-babel-next-src-block)
         ("k" org-babel-previous-src-block)
         ("g" org-babel-goto-named-src-block)
+        ("z" recenter-top-bottom)
         ("e" org-babel-execute-maybe :exit t)
         ("'" org-edit-special :exit t)))))
 

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -180,26 +180,27 @@ A transient buffer is also defined, start it with ~SPC m .~ or ~, .~
 | ~f~          | show in a buffer the file revision indicated by the current line               |
 
 ** Version Control Transient-state
+Use ~SPC g .~ to enter a transient state for quickly navigating between hunks in a buffer.  During that state, the following bindings are active:
 
 | Key Binding | Description                  |
 |-------------+------------------------------|
-| ~SPC g . h~ | Show diff of hunk            |
-| ~SPC g . n~ | Next hunk                    |
-| ~SPC g . N~ | Previous hunk                |
-| ~SPC g . p~ | Previous hunk                |
-| ~SPC g . r~ | Revert hunk                  |
-| ~SPC g . s~ | Stage hunk                   |
-| ~SPC g . t~ | Toggle margin indicators     |
-| ~SPC g . w~ | Stage file                   |
-| ~SPC g . u~ | Unstage file                 |
-| ~SPC g . d~ | Repo diff popup              |
-| ~SPC g . D~ | Show diffs of unstaged hunks |
-| ~SPC g . c~ | Commit with popup            |
-| ~SPC g . C~ | Commit                       |
-| ~SPC g . P~ | Push repo with popup         |
-| ~SPC g . f~ | Fetch for repo with popup    |
-| ~SPC g . F~ | Pull repo with popup         |
-| ~SPC g . l~ | Show repo log                |
+| ~h~         | Show diff of hunk            |
+| ~n~         | Next hunk                    |
+| ~N~ or ~p~  | Previous hunk                |
+| ~r~         | Revert hunk                  |
+| ~s~         | Stage hunk                   |
+| ~t~         | Toggle margin indicators     |
+| ~w~         | Stage file                   |
+| ~u~         | Unstage file                 |
+| ~d~         | Repo diff popup              |
+| ~D~         | Show diffs of unstaged hunks |
+| ~c~         | Commit with popup            |
+| ~C~         | Commit                       |
+| ~P~         | Push repo with popup         |
+| ~f~         | Fetch for repo with popup    |
+| ~F~         | Pull repo with popup         |
+| ~l~         | Show repo log                |
+| ~z~         | Recenter buffer in window    |
 
 ** Smerge Mode Transient-state
 

--- a/layers/+source-control/version-control/keybindings.el
+++ b/layers/+source-control/version-control/keybindings.el
@@ -12,10 +12,10 @@
 (spacemacs|define-transient-state vcs
   :title "VCS Transient State"
   :doc "
- Hunk Commands^^^^^^                 Magit Commands
-----------------------------^^^^^^  ------------------------------------------
- [_n_]^^^^      next hunk            [_w_/_u_]^^    stage/unstage in current file
- [_N_/_p_]^^    previous hunk        [_c_/_C_]^^    commit with popup/direct commit
+ Hunk Commands^^^^^^                 Magit Commands^^^^^^                             Others
+----------------------------^^^^^^  ------------------------------------------^^^^^^  ------------^^
+ [_n_]^^^^      next hunk            [_w_/_u_]^^    stage/unstage in current file     [_z_] recenter
+ [_N_/_p_]^^    previous hunk        [_c_/_C_]^^    commit with popup/direct commit   [_q_] quit
  [_r_/_s_/_h_]  revert/stage/show    [_f_/_F_/_P_]  fetch/pull/push popup
  [_t_]^^^^      toggle diff signs    [_l_/_D_]^^    log/diff popup"
   :on-enter (spacemacs/vcs-enable-margin)
@@ -37,6 +37,7 @@
   ("s" spacemacs/vcs-stage-hunk)
   ("h" spacemacs/vcs-show-hunk)
   ("t" spacemacs/toggle-version-control-margin)
+  ("z" recenter-top-bottom)
   ("q" nil :exit t))
 (spacemacs/set-leader-keys "g." 'spacemacs/vcs-transient-state/body)
 

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -196,6 +196,7 @@
   ("n" spacemacs/next-error "next")
   ("p" spacemacs/previous-error "prev")
   ("N" spacemacs/previous-error "prev")
+  ("z" recenter-top-bottom "recenter")
   ("q" nil "quit" :exit t)
   :evil-leader "e.")
 ;; file -----------------------------------------------------------------------
@@ -552,11 +553,11 @@ respond to this toggle."
 
 (spacemacs|define-transient-state buffer
   :title "Buffer Selection Transient State"
-  :doc (concat "
+  :doc "
  [_C-1_.._C-9_] goto nth window            [_n_/_<right>_]^^  next buffer       [_b_]   buffer list
  [_1_.._9_]     move buffer to nth window  [_N_/_p_/_<left>_] previous buffer   [_C-d_] bury buffer
  [_M-1_.._M-9_] swap buffer w/ nth window  [_d_]^^^^          kill buffer       [_o_]   other window
- ^^^^                                      [_q_]^^^^          quit")
+ ^^^^                                      [_z_]^^^^          recenter          [_q_]   quit"
   :bindings
   ("n" next-buffer)
   ("<right>" next-buffer)
@@ -567,6 +568,7 @@ respond to this toggle."
   ("b" helm-buffers-list)
   ("d" spacemacs/kill-this-buffer)
   ("C-d" bury-buffer)
+  ("z" recenter-top-bottom)
   ("q" nil :exit t)
   ("1" move-buffer-window-no-follow-1)
   ("2" move-buffer-window-no-follow-2)

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -69,7 +69,7 @@
             spacemacs--symbol-highlight-transient-state-doc "
  %s
  [_n_] next   [_N_/_p_] prev  [_d_/_D_] next/prev def  [_r_] range  [_R_] reset
- [_e_] iedit")
+ [_e_] iedit  [_z_] recenter")
 
       ;; since we are creating our own maps,
       ;; prevent the default keymap from getting created
@@ -136,6 +136,8 @@
         ("p" spacemacs/quick-ahs-backward)
         ("R" ahs-back-to-start)
         ("r" ahs-change-range)
+        ("z" (progn (recenter-top-bottom)
+                    (spacemacs/symbol-highlight)))
         ("q" nil :exit t)))))
 
 (defun spacemacs-navigation/init-centered-cursor-mode ()


### PR DESCRIPTION
By analogy with the "zz", "zb", "zt" vim / evil bindings, this adds an
additional key binding "z" for `recenter-top-bottom` to the following
transient states which navigate around the buffer in large jumps:
- auto-symbol-highlight
- error
- buffer
- vcs
- org-babel

This allows for repositioning of the buffer for visibility without having to
exit the transient state.

Some updates are also made to the documentation of other transient states (98bd369)