### PR TITLE
Improve clojure layer without clj-refactor

### DIFF
--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -332,6 +332,25 @@ As this state works the same for all files, the documentation is in global
 
 *** Refactoring
 
+The following refactoring key bindings are enabled by default in clojure-mode:
+
+| Key Binding   | Description                                                    |
+|---------------+----------------------------------------------------------------|
+| ~SPC m r c i~ | cycle between if and if-not forms                              |
+| ~SPC m r c p~ | cycle privacy of defn and def forms                            |
+| ~SPC m r c (~ | convert coll to list                                           |
+| ~SPC m r c '~ | convert coll to quoted list                                    |
+| ~SPC m r c {~ | convert coll to map                                            |
+| ~SPC m r c #~ | convert coll to set                                            |
+| ~SPC m r c [~ | convert coll to vector                                         |
+| ~SPC m r t f~ | rewrite the following form to use the -> (thread first) macro. |
+| ~SPC m r t l~ | rewrite the following form to use the ->> (thread last) macro. |
+| ~SPC m r t h~ | thread another form into the surrounding threading macro       |
+| ~SPC m r u a~ | unwind all steps of surrounding threading macro                |
+| ~SPC m r u w~ | unwind threading macro one step at a time                      |
+
+The following refactorings require cljr-refactor to be enabled and generally depend on a connected CIDER session.
+
 | Key Binding   | Description                       |
 |---------------+-----------------------------------|
 | ~SPC m r ?~   | describe refactoring              |
@@ -341,15 +360,8 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m r a p~ | add project dependency            |
 | ~SPC m r a r~ | add require to ns                 |
 | ~SPC m r a u~ | add use to ns                     |
-| ~SPC m r c (~ | convert coll to list              |
-| ~SPC m r c '~ | convert coll to quoted list       |
-| ~SPC m r c {~ | convert coll to map               |
-| ~SPC m r c #~ | convert coll to set               |
-| ~SPC m r c [~ | convert coll to vector            |
 | ~SPC m r c :~ | toggle between keyword and string |
-| ~SPC m r c i~ | cycle if                          |
 | ~SPC m r c n~ | clean ns                          |
-| ~SPC m r c p~ | cycle privacy                     |
 | ~SPC m r d k~ | destructure keys                  |
 | ~SPC m r e c~ | extract constant                  |
 | ~SPC m r e d~ | extract definition                |
@@ -374,12 +386,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m r s p~ | sort project dependencies         |
 | ~SPC m r s r~ | stop referring                    |
 | ~SPC m r s c~ | show changelog                    |
-| ~SPC m r t f~ | thread first all                  |
-| ~SPC m r t h~ | thread                            |
-| ~SPC m r t l~ | thread last all                   |
-| ~SPC m r u a~ | unwind all                        |
 | ~SPC m r u p~ | update project dependencies       |
-| ~SPC m r u w~ | unwind                            |
 
 *** Reformatting
 

--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -184,3 +184,28 @@ If called with a prefix argument, uses the other-window instead."
         (unless (eq 'symbol (type-of (cider-find-var nil var)))
           (dumb-jump-go))
       (dumb-jump-go))))
+
+(defun spacemacs/clj-describe-missing-refactorings ()
+  "Inform the user to add clj-refactor to configuration"
+  (interactive)
+  (with-help-window (help-buffer)
+    (princ "The package clj-refactor is disabled by default.
+To enable it, add the following variable to the clojure layer
+in your Spacemacs configuration:
+
+  dotspacemacs-configuration-layers
+  '(...
+    (clojure :variables
+             clojure-enable-clj-refactor t)
+    ) ")))
+
+(defmacro spacemacs|forall-clojure-modes (m &rest body)
+  "Executes BODY with M bound to all clojure derived modes."
+  (declare (indent 1))
+  `(dolist (,m '(clojure-mode
+                 clojurec-mode
+                 clojurescript-mode
+                 clojurex-mode
+                 cider-repl-mode
+                 cider-clojure-interaction-mode))
+     ,@body))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -29,7 +29,6 @@
         smartparens
         subword))
 
-
 (defun clojure/init-cider ()
   (use-package cider
     :defer t
@@ -67,12 +66,7 @@
                ("mt" . "test")
                ("mT" . "toggle")
                )))
-        (dolist (m '(clojure-mode
-                     clojurec-mode
-                     clojurescript-mode
-                     clojurex-mode
-                     cider-repl-mode
-                     cider-clojure-interaction-mode))
+        (spacemacs|forall-clojure-modes m
           (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
                               m (car x) (cdr x)))
                 cider--key-binding-prefixes)
@@ -158,14 +152,6 @@
             "pS" 'cider-profile-summary
             "pt" 'cider-profile-toggle
             "pv" 'cider-profile-var-profiled-p
-
-            ;; refactorings from clojure-mode
-            "rc#" 'clojure-convert-collection-to-set
-            "rc'" 'clojure-convert-collection-to-quoted-list
-            "rc(" 'clojure-convert-collection-to-list
-            "rc:" 'clojure-toggle-keyword-string
-            "rc[" 'clojure-convert-collection-to-vector
-            "rc{" 'clojure-convert-collection-to-map
             )))
 
       ;; cider-repl-mode only
@@ -252,11 +238,41 @@
     :config
     (progn
       (cljr-add-keybindings-with-prefix "C-c C-f")
-
       ;; Usually we do not set keybindings in :config, however this must be done
       ;; here because it reads the variable `cljr--all-helpers'. Since
       ;; `clj-refactor-mode' is added to the hook, this should trigger when a
       ;; clojure buffer is opened anyway, so there's no "keybinding delay".
+      (spacemacs|forall-clojure-modes m
+        (dolist (r cljr--all-helpers)
+          (let* ((binding (car r))
+                 (func (cadr r)))
+            (when (not (string-prefix-p "hydra" (symbol-name func)))
+              (spacemacs/set-leader-keys-for-major-mode m
+                (concat "r" binding) func))))))))
+
+(defun clojure/init-clojure-cheatsheet ()
+  (use-package clojure-cheatsheet
+    :defer t
+    :init
+    (progn
+      (setq sayid--key-binding-prefixes
+            '(("mhc" . "clojure-cheatsheet")))
+      (spacemacs|forall-clojure-modes m
+        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                            m (car x) (cdr x)))
+              sayid--key-binding-prefixes)
+        (spacemacs/set-leader-keys-for-major-mode m
+          "hc" 'clojure-cheatsheet)))))
+
+(defun clojure/init-clojure-mode ()
+  (use-package clojure-mode
+    :defer t
+    :init
+    (progn
+      (add-to-list 'auto-mode-alist '("\\.boot\\'" . clojure-mode))
+      ;; This regexp matches shebang expressions like `#!/usr/bin/env boot'
+      (add-to-list 'magic-mode-alist '("#!.*boot\\s-*$" . clojure-mode))
+      ;; Define all the prefixes here, although most of them apply only to bindings in clj-refactor
       (let ((clj-refactor--key-binding-prefixes
              '(("mr" . "refactor")
                ("mra" . "add")
@@ -272,55 +288,31 @@
                ("mrs" . "show/sort/stop")
                ("mrt" . "thread")
                ("mru" . "unwind/update"))))
-        (dolist (m '(clojure-mode
-                     clojurec-mode
-                     clojurescript-mode
-                     clojurex-mode
-                     cider-repl-mode
-                     cider-clojure-interaction-mode))
+        (spacemacs|forall-clojure-modes m
           (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
                               m (car x) (cdr x)))
                 clj-refactor--key-binding-prefixes)
-          (dolist (r cljr--all-helpers)
-            (let* ((binding (car r))
-                   (func (cadr r)))
-              (when (not (string-prefix-p "hydra" (symbol-name func)))
-                (spacemacs/set-leader-keys-for-major-mode m
-                  (concat "r" binding) func)))))))))
-
-(defun clojure/init-clojure-cheatsheet ()
-  (use-package clojure-cheatsheet
-    :defer t
-    :init
-    (progn
-      (setq sayid--key-binding-prefixes
-            '(("mhc" . "clojure-cheatsheet")))
-      (dolist (m '(clojure-mode
-                   clojurec-mode
-                   clojurescript-mode
-                   clojurex-mode
-                   cider-repl-mode
-                   cider-clojure-interaction-mode))
-        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                            m (car x) (cdr x)))
-              sayid--key-binding-prefixes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          "hc" 'clojure-cheatsheet)))))
-
-(defun clojure/init-clojure-mode ()
-  (use-package clojure-mode
-    :defer t
-    :init
-    (progn
-      (add-to-list 'auto-mode-alist '("\\.boot\\'" . clojure-mode))
-      ;; This regexp matches shebang expressions like `#!/usr/bin/env boot'
-      (add-to-list 'magic-mode-alist '("#!.*boot\\s-*$" . clojure-mode))
-      (dolist (m '(clojure-mode clojurec-mode clojurescript-mode clojurex-mode))
-        (spacemacs/set-leader-keys-for-major-mode m
-          "fl" 'clojure-align)))
+          (spacemacs/set-leader-keys-for-major-mode m
+            "fl" 'clojure-align
+            "rci" 'clojure-cycle-if
+            "rcp" 'clojure-cycle-privacy
+            "rc#" 'clojure-convert-collection-to-set
+            "rc'" 'clojure-convert-collection-to-quoted-list
+            "rc(" 'clojure-convert-collection-to-list
+            "rc[" 'clojure-convert-collection-to-vector
+            "rc{" 'clojure-convert-collection-to-map
+            "rc:" 'clojure-toggle-keyword-string
+            "rtf" 'clojure-thread-first-all
+            "rth" 'clojure-thread
+            "rtl" 'clojure-thread-last-all
+            "rua" 'clojure-unwind-all
+            "ruw" 'clojure-unwind)
+          (unless clojure-enable-clj-refactor
+            (spacemacs/set-leader-keys-for-major-mode m
+              "r?" 'spacemacs/clj-describe-missing-refactorings)))))
     :config
     (when clojure-enable-fancify-symbols
-      (dolist (m '(clojure-mode clojurescript-mode clojurec-mode clojurex-mode))
+      (spacemacs|forall-clojure-modes m
         (clojure/fancify-symbols m)))))
 
 (defun clojure/post-init-eldoc ()
@@ -331,10 +323,7 @@
 (defun clojure/pre-init-evil-cleverparens ()
   (spacemacs|use-package-add-hook evil-cleverparens
     :pre-init
-    (dolist (m '(clojure-mode
-                 clojurec-mode
-                 clojurescript-mode
-                 clojurex-mode))
+    (spacemacs|forall-clojure-modes m
       (add-to-list 'evil-lisp-safe-structural-editing-modes m))))
 
 (defun clojure/pre-init-popwin ()
@@ -388,14 +377,9 @@
     (progn
       (setq sayid--key-binding-prefixes
             '(("mdt" . "trace")))
-      (dolist (m '(clojure-mode
-                   clojurec-mode
-                   clojurescript-mode
-                   clojurex-mode
-                   cider-repl-mode
-                   cider-clojure-interaction-mode))
-        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                           m (car x) (cdr x)))
+      (spacemacs|forall-clojure-modes m
+        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode m
+                            (car x) (cdr x)))
               sayid--key-binding-prefixes)
         (spacemacs/set-leader-keys-for-major-mode m
           ;;These keybindings mostly preserved from the default sayid bindings
@@ -442,8 +426,5 @@
         (kbd "h") 'sayid-traced-buf-show-help))))
 
 (defun clojure/post-init-parinfer ()
-  (dolist (m '(clojure-mode-hook
-               clojurec-mode-hook
-               clojurescript-mode-hook
-               clojurex-mode-hook))
+  (spacemacs|forall-clojure-modes m
     (add-hook m 'parinfer-mode)))


### PR DESCRIPTION
First commit fixes #11531, adding clojure-mode refactorings and which-key prefixes in default layer configuration.
Later 2 commits are not strictly necessary, could be omitted