### PR TITLE
fix: lsp-ui-peek-find-definitions is an async jump handler

### DIFF
--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -35,7 +35,7 @@
   "Set jump handler for LSP with the given MODE."
   (dolist (m modes)
     (add-to-list (intern (format "spacemacs-jump-handlers-%S" m))
-                 #'lsp-ui-peek-find-definitions)))
+                 '(lsp-ui-peek-find-definitions :async t))))
 
 (defun fix-lsp-company-prefix ()
   "fix lsp-javascript company prefix


### PR DESCRIPTION
To avoid multiple peek popup situation:

![image](https://user-images.githubusercontent.com/1206493/47996983-54fa3480-e135-11e8-91d4-bfbb7bab371b.png)
