### PR TITLE
Add support for libvterm

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2467,6 +2467,7 @@ Other:
 - Disabled =semantic-idle-summary-mode= when =gtags= or =lsp= layer is enabled
   (thanks to bet4it)
 **** Shell
+- Improved the integration of centered-cursor-mode (thanks to deb0ch)
 - Fixed xterm colors filtering bug in =eshell= when eshell buffers are updated
   and are not focused (thanks to Steven Allen)
 - Fixed =eshell= clear behavior (thanks to Aidan Nyquist):

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2467,6 +2467,7 @@ Other:
 - Disabled =semantic-idle-summary-mode= when =gtags= or =lsp= layer is enabled
   (thanks to bet4it)
 **** Shell
+- Added support for =vterm= (thanks to deb0ch)
 - Improved the integration of centered-cursor-mode (thanks to deb0ch)
 - Fixed xterm colors filtering bug in =eshell= when eshell buffers are updated
   and are not focused (thanks to Steven Allen)

--- a/layers/+misc/multiple-cursors/config.el
+++ b/layers/+misc/multiple-cursors/config.el
@@ -12,4 +12,5 @@
 ;;; License: GPLv3
 
 (defvar multiple-cursors-backend 'evil-mc
-  "The package used as the backend for multiple cursors functionality.")
+  "The package used as the backend for multiple cursors functionality.
+Possible values are `mc' or `evil-mc'.")

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -162,6 +162,7 @@
       (setq ccm-recenter-at-end-of-file t
             ccm-ignored-commands '(mouse-drag-region
                                    mouse-set-point
+                                   mouse-set-region
                                    widget-button-click
                                    scroll-bar-toolkit-scroll
                                    evil-mouse-drag-region))

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -8,6 +8,15 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#install-vterm][Install vterm]]
+    - [[#check-that-your-emacs-supports-dynamic-modules][Check that your Emacs supports dynamic modules]]
+    - [[#install-cmake-311-or-higher][Install CMake 3.11 or higher]]
+    - [[#install-libtool][Install libtool]]
+      - [[#ubuntu][Ubuntu]]
+    - [[#install-libvterm][Install libvterm]]
+      - [[#macos][MacOS]]
+      - [[#ubuntu-1][Ubuntu]]
+      - [[#windows][Windows]]
 - [[#configuration][Configuration]]
   - [[#default-shell][Default shell]]
   - [[#default-shell-position-width-and-height][Default shell position, width, and height]]
@@ -34,23 +43,67 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =shell= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+** Install vterm
+=vterm= is the latest addition to Emacs' set of terminal emulators and the only
+one to be implemented in C, leveraging =libvterm=. It is the only one in Emacs
+at the moment to be as fast as a standalone terminal with full support for
+=ncurses=, =vim=, =htop= and the likes.
+
+On its first run, =vterm= will automatically compile its dynamic library, for
+which dependencies are needed. For more details, head to the [[https://github.com/akermu/emacs-libvterm][official docs]].
+
+*** Check that your Emacs supports dynamic modules
+You can check if your Emacs supports loading dynamic libraries by checking if
+the =system-configuration-features= variable contains the string =MODULES=. If
+not, you need to get a version of Emacs that supports it or compile it from
+source supplying the =./configure --with-module= option at configure time.
+
+*** Install CMake 3.11 or higher
+
+*** Install libtool
+If the =libtool= command does not exist in your system (usually in
+=/usr/bin/libtool=), you need to install it:
+**** Ubuntu
+#+BEGIN_SRC shell
+sudo apt install libtool-bin
+#+END_SRC
+
+*** Install libvterm
+**** MacOS
+#+BEGIN_SRC shell
+brew install libvterm
+#+END_SRC
+
+**** Ubuntu
+#+BEGIN_SRC shell
+sudo apt install libvterm-dev
+#+END_SRC
+
+In other distros, find it and install it in your favorite package manager.
+
+**** Windows
+Not supported at the moment, [[https://github.com/akermu/emacs-libvterm/issues/12][but possibly coming up]].
+
 * Configuration
+
 ** Default shell
-Emacs supports three types of shell:
-- the Emacs shell
+Emacs supports five types of shells/terminals:
+- the Emacs shell (eshell)
 - the inferior shell
 - the terminal emulator
 - the ANSI terminal emulator
+- the vterm terminal emulator based on the C library libvterm
 
 You can find a quick introductions to them [[https://www.masteringemacs.org/article/running-shells-in-emacs-overview][here]].
 
 To define the default shell you can set the layer variable =shell-default-shell=
 to the following variables:
-- =eshell=
+- =eshell= (default on Windows)
 - =shell=
 - =term=
-- =ansi-term=
+- =ansi-term= (default on Linux/macOS)
 - =multi-term=
+- =vterm=
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
@@ -224,6 +277,7 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~SPC a s T~ | Open, close or go to a =term=                              |
 | ~TAB~       | browse completion with =helm=                              |
 | ~SPC m H~   | browse history with =helm= (works in =eshell= and =shell=) |
+| ~SPC a s v~ | Open, close or go to a =vterm=                             |
 | ~C-j~       | next item in history                                       |
 | ~C-k~       | previous item in history                                   |
 

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -19,11 +19,11 @@
 
 ;; Variables
 
-(defvar shell-default-shell (if (eq window-system 'w32)
+(defvar shell-default-shell (if (spacemacs/system-is-mswindows)
                                 'eshell
                               'ansi-term)
-  "Default shell to use in Spacemacs. Possible values are `eshell', `shell',
-`term', `ansi-term' and `multi-term'.")
+  "Default shell to use in Spacemacs. Possible values are `eshell' (default),
+`shell', `term', `ansi-term', `multi-term' and `vterm'.")
 
 (defvar shell-default-position 'bottom
   "Position of the shell. Possible values are `top', `bottom', `full',

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -208,3 +208,12 @@ is achieved by adding the relevant text properties."
   (interactive)
   (switch-to-buffer "*shell*")
   (shell "*shell*"))
+
+;; https://stackoverflow.com/questions/6837511/automatically-disable-a-global-minor-mode-for-a-specific-major-mode
+(defun spacemacs//inhibit-global-centered-cursor-mode ()
+  "Counter-act `global-centered-cursor-mode'."
+  (add-hook 'after-change-major-mode-hook
+            (lambda ()
+              (centered-cursor-mode 0))
+            :append
+            :local))

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -57,28 +57,28 @@
                                        100)
                                     (window-width)))))
 
-(defmacro make-shell-pop-command (func &optional shell)
+(defmacro make-shell-pop-command (name func &optional shell)
   "Create a function to open a shell via the function FUNC.
 SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
-  (let* ((name (symbol-name func)))
-    `(defun ,(intern (concat "spacemacs/shell-pop-" name)) (index)
-       ,(format (concat "Toggle a popup window with `%S'.\n"
-                        "Multiple shells can be opened with a numerical prefix "
-                        "argument. Using the universal prefix argument will "
-                        "open the shell in the current buffer instead of a "
-                        "popup buffer.") func)
-       (interactive "P")
-       (require 'shell-pop)
-       (if (equal '(4) index)
-           ;; no popup
-           (,func ,shell)
-         (shell-pop--set-shell-type
-          'shell-pop-shell-type
-          (backquote (,name
-                      ,(concat "*" name "*")
-                      (lambda nil (,func ,shell)))))
-         (shell-pop index)
-         (spacemacs/resize-shell-to-desired-width)))))
+  `(defun ,(intern (concat "spacemacs/shell-pop-" name)) (index)
+     ,(format (concat "Toggle a popup window with `%S'.\n"
+                      "Multiple shells can be opened with a numerical prefix "
+                      "argument. Using the universal prefix argument will "
+                      "open the shell in the current buffer instead of a "
+                      "popup buffer.")
+              func)
+     (interactive "P")
+     (require 'shell-pop)
+     (if (equal '(4) index)
+         ;; no popup
+         (,func ,shell)
+       (shell-pop--set-shell-type
+        'shell-pop-shell-type
+        (backquote (,name
+                    ,(concat "*" name "*")
+                    (lambda nil (,func ,shell)))))
+       (shell-pop index)
+       (spacemacs/resize-shell-to-desired-width))))
 
 (defun projectile-multi-term-in-root ()
   "Invoke `multi-term' in the project's root."

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -32,7 +32,9 @@
 
 (defun shell/init-comint ()
   (setq comint-prompt-read-only t)
-  (add-hook 'comint-mode-hook 'spacemacs/disable-hl-line-mode))
+  (add-hook 'comint-mode-hook 'spacemacs/disable-hl-line-mode)
+  (with-eval-after-load 'centered-cursor-mode
+    (add-hook 'comint-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode)))
 
 (defun shell/pre-init-company ()
   ;; support in eshell
@@ -81,7 +83,9 @@
       (autoload 'eshell-delchar-or-maybe-eof "em-rebind")
 
       (add-hook 'eshell-mode-hook 'spacemacs//init-eshell)
-      (add-hook 'eshell-mode-hook 'spacemacs/disable-hl-line-mode))
+      (add-hook 'eshell-mode-hook 'spacemacs/disable-hl-line-mode)
+      (with-eval-after-load 'centered-cursor-mode
+        (add-hook 'eshell-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode)))
     :config
     (progn
 
@@ -214,7 +218,9 @@
              ;; Send other commands to the default handler.
              (t (comint-simple-send proc command))))))
   (add-hook 'shell-mode-hook 'shell-comint-input-sender-hook)
-  (add-hook 'shell-mode-hook 'spacemacs/disable-hl-line-mode))
+  (add-hook 'shell-mode-hook 'spacemacs/disable-hl-line-mode)
+  (with-eval-after-load 'centered-cursor-mode
+    (add-hook 'shell-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode)))
 
 (defun shell/init-shell-pop ()
   (use-package shell-pop
@@ -270,7 +276,9 @@
     (kbd "C-k") 'term-send-up
     (kbd "C-j") 'term-send-down)
 
-  (add-hook 'term-mode-hook 'spacemacs/disable-hl-line-mode))
+  (add-hook 'term-mode-hook 'spacemacs/disable-hl-line-mode)
+  (with-eval-after-load 'centered-cursor-mode
+    (add-hook 'term-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode)))
 
 (defun shell/init-xterm-color ()
   (use-package xterm-color

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -258,24 +258,26 @@
     "Send tab in term mode."
     (interactive)
     (term-send-raw-string "\t"))
-  ;; hack to fix pasting issue, the paste transient-state won't
-  ;; work in term
-  (evil-define-key 'normal term-raw-map "p" 'term-paste)
-  (evil-define-key 'normal term-raw-map (kbd "<mouse-2>") 'term-mouse-paste)
-  (evil-define-key 'insert term-raw-map (kbd "<mouse-2>") 'term-mouse-paste)
-  (evil-define-key 'normal term-raw-map (kbd "<mouse-3>") 'term-mouse-paste)
-  (evil-define-key 'insert term-raw-map (kbd "<mouse-3>") 'term-mouse-paste)
-  (evil-define-key 'insert term-raw-map (kbd "C-c C-d") 'term-send-eof)
-  (evil-define-key 'insert term-raw-map (kbd "C-c C-z") 'term-stop-subjob)
-  (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab)
 
   (when (eq dotspacemacs-editing-style 'vim)
     (evil-define-key 'insert term-raw-map
       (kbd "C-k") 'term-send-up
       (kbd "C-j") 'term-send-down))
+
+  (evil-define-key 'insert term-raw-map
+    (kbd "<mouse-2>") 'term-mouse-paste
+    (kbd "<mouse-3>") 'term-mouse-paste
+    (kbd "C-c C-d") 'term-send-eof
+    (kbd "C-c C-z") 'term-stop-subjob
+    (kbd "<tab>") 'term-send-tab)
+
   (evil-define-key 'normal term-raw-map
+    (kbd "<mouse-2>") 'term-mouse-paste
+    (kbd "<mouse-3>") 'term-mouse-paste
     (kbd "C-k") 'term-send-up
-    (kbd "C-j") 'term-send-down)
+    (kbd "C-j") 'term-send-down
+    ;; hack to fix pasting issue, the paste transient-state won't work in term
+    "p" 'term-paste)
 
   (add-hook 'term-mode-hook 'spacemacs/disable-hl-line-mode)
   (with-eval-after-load 'centered-cursor-mode

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -231,7 +231,8 @@
       (setq shell-pop-window-position shell-default-position
             shell-pop-window-size     shell-default-height
             shell-pop-term-shell      shell-default-term-shell
-            shell-pop-full-span       shell-default-full-span)
+            shell-pop-full-span       shell-default-full-span
+            shell-pop-in-after-hook   #'evil-insert-state)
       (make-shell-pop-command "eshell" eshell)
       (make-shell-pop-command "term" term shell-pop-term-shell)
       (make-shell-pop-command "ansi-term" ansi-term shell-pop-term-shell)

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -28,6 +28,7 @@
         (term :location built-in)
         xterm-color
         vi-tilde-fringe
+        (vterm :toggle (not (spacemacs/system-is-mswindows)))
         ))
 
 (defun shell/init-comint ()
@@ -231,14 +232,13 @@
             shell-pop-window-size     shell-default-height
             shell-pop-term-shell      shell-default-term-shell
             shell-pop-full-span       shell-default-full-span)
-      (make-shell-pop-command eshell)
-      (make-shell-pop-command term shell-pop-term-shell)
-      (make-shell-pop-command ansi-term shell-pop-term-shell)
-      (make-shell-pop-command inferior-shell)
-      (make-shell-pop-command multiterm)
+      (make-shell-pop-command "eshell" eshell)
+      (make-shell-pop-command "term" term shell-pop-term-shell)
+      (make-shell-pop-command "ansi-term" ansi-term shell-pop-term-shell)
+      (make-shell-pop-command "inferior-shell" inferior-shell)
+      (make-shell-pop-command "multiterm" multiterm)
 
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
-      (add-hook 'term-mode-hook (lambda () (linum-mode -1)))
 
       (spacemacs/set-leader-keys
         "'"   'spacemacs/default-pop-shell
@@ -296,3 +296,32 @@
                             eshell-mode-hook
                             shell-mode-hook
                             term-mode-hook)))
+
+(defun shell/init-vterm ()
+  (use-package vterm
+    :defer t
+    :commands (vterm vterm-other-window)
+
+    :init
+    (progn
+      (make-shell-pop-command "vterm" vterm)
+      (spacemacs/set-leader-keys "asv" 'spacemacs/shell-pop-vterm)
+      (spacemacs/register-repl 'vterm 'vterm))
+
+    :config
+    (progn
+      (evil-define-key 'normal vterm-mode-map
+        [escape] 'vterm--self-insert
+        [return] 'vterm--self-insert)
+
+      (add-hook 'vterm-mode-hook 'spacemacs/disable-hl-line-mode)
+
+      (with-eval-after-load 'centered-cursor-mode
+        (add-hook 'vterm-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode))
+
+      (with-eval-after-load 'window-purpose
+        (purpose-set-extension-configuration
+         :vterm
+         (purpose-conf "vterm"
+                       :mode-purposes
+                       '((vterm-mode . terminal))))))))


### PR DESCRIPTION
Add support for https://github.com/akermu/emacs-libvterm in Spacemacs.

I also made some fixes that are related to the shell layer but not to vterm and would be cherry-pickable without the vterm support, for instance disabling `global-center-cursor-mode` in terminals as it made them flicker.
 