### PR TITLE
Filter useless buffers in Helm-mini, add command to unfiltered list buffers

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -623,3 +623,11 @@ to buffers)."
   (interactive)
   (let (helm-candidate-number-limit)
     (helm-themes)))
+
+;; Buffers ---------------------------------------------------------------------
+
+(defun spacemacs/helm-buffers-list-unfiltered ()
+  "Helm buffers without filtering."
+  (interactive)
+  (let ((helm-boring-buffer-regexp-list nil))
+    (call-interactively #'helm-buffers-list)))

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -86,6 +86,7 @@
       (spacemacs||set-helm-key "<f1>" helm-apropos)
       (spacemacs||set-helm-key "a'"   helm-available-repls)
       (spacemacs||set-helm-key "bb"   helm-mini)
+      (spacemacs||set-helm-key "bU"   spacemacs/helm-buffers-list-unfiltered)
       (spacemacs||set-helm-key "Cl"   helm-colors)
       (spacemacs||set-helm-key "ff"   spacemacs/helm-find-files)
       (spacemacs||set-helm-key "fF"   helm-find-files)

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -152,6 +152,12 @@
       ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
       (helm-locate-set-command)
       (setq helm-locate-fuzzy-match (string-match "locate" helm-locate-command))
+      (setq helm-boring-buffer-regexp-list
+            (append helm-boring-buffer-regexp-list
+                    spacemacs-useless-buffers-regexp))
+      (setq helm-white-buffer-regexp-list
+            (append helm-white-buffer-regexp-list
+                    spacemacs-useful-buffers-regexp))
       ;; alter helm-bookmark key bindings to be simpler
       (defun simpler-helm-bookmark-keybindings ()
         (define-key helm-bookmark-map (kbd "C-d") 'helm-bookmark-run-delete)


### PR DESCRIPTION
Part of the work for #11545 