### PR TITLE
[makrdown] use orgtbl-mode only when org layer is used

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -12,6 +12,7 @@
   - [[#automatic-mmm-mode-generation][Automatic MMM-Mode Generation]]
 - [[#usage][Usage]]
   - [[#generate-a-toc][Generate a TOC]]
+  - [[#editing-tables][Editing tables]]
 - [[#key-bindings][Key bindings]]
   - [[#element-insertion][Element insertion]]
   - [[#element-removal][Element removal]]
@@ -86,6 +87,12 @@ new languages instead of overriding the variable in your dotfile.
 ** Generate a TOC
 To generate a table of contents type on top of the buffer:
 ~SPC SPC markdown-toc-generate-toc RET~
+
+** Editing tables
+While =markdown-mode= provides functionality to edit tables, users of =org=
+layer benefit from more sophisticated =orgtbl-mode=.
+
+In order to use =orgtabl-mode=, add =org= layer to your =~/.spacemacs=.
 
 * Key bindings
 ** Element insertion

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -20,6 +20,7 @@
     mmm-mode
     smartparens
     (vmd-mode :toggle (eq 'vmd markdown-live-preview-engine))
+    org
     ))
 
 (defun markdown/post-init-company ()
@@ -56,9 +57,6 @@
     :defer t
     :config
     (progn
-      (add-hook 'markdown-mode-hook 'orgtbl-mode)
-      (spacemacs|diminish orgtbl-mode)
-      (add-hook 'markdown-mode-hook 'spacemacs//cleanup-org-tables-on-save)
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")
                         ("mh" . "markdown/header")
@@ -172,3 +170,9 @@
     (dolist (mode markdown--key-bindings-modes)
       (spacemacs/set-leader-keys-for-major-mode mode
         "cP" 'vmd-mode))))
+
+(defun markdown/post-init-org ()
+  (when (configuration-layer/layer-used-p 'org)
+    (add-hook 'markdown-mode-hook 'orgtbl-mode)
+    (spacemacs|diminish orgtbl-mode)
+    (add-hook 'markdown-mode-hook 'spacemacs//cleanup-org-tables-on-save)))


### PR DESCRIPTION
1. Fixes #6535 - when org layer is not used, user will see an error upon
   visiting markdown file.
2. Mention orgtbl-mode in readme.