### PR TITLE
Update 'neo-vc-integration' example in DOCUMENTATION.org

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2273,7 +2273,7 @@ The default is =nil= (do not show source control information), which is recommen
 For example,
 
 #+BEGIN_SRC emacs-lisp
-(setq neo-vc-integration 'face)
+(setq neo-vc-integration '(face))
 #+END_SRC
 
 *Note*: At this time, it is not recommended to set this to anything other


### PR DESCRIPTION
The `neo-vc-integration` takes a list not a single element. The example is misleading

PS and disclaimer: Since it doesn't require any actual code change I base it on `master`. Let me know if that should be changed