### PR TITLE
Fix jump handlers conflict for haskell and intero

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -14,7 +14,6 @@
 (setq haskell-modes '(haskell-mode literate-haskell-mode))
 
 (spacemacs|define-jump-handlers haskell-mode haskell-mode-jump-to-def-or-tag)
-(spacemacs|define-jump-handlers intero-mode intero-goto-definition)
 
 (defvar haskell-completion-backend 'ghci
   "Completion backend used by company.

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -114,7 +114,7 @@
       :modes haskell-mode)
     (add-hook 'haskell-mode-hook 'interactive-haskell-mode)
     (add-hook 'haskell-mode-hook 'intero-mode)
-    (add-to-list 'spacemacs-jump-handlers 'intero-goto-definition)
+    (add-to-list 'spacemacs-jump-handlers-haskell-mode 'intero-goto-definition)
     :config
     (progn
       (spacemacs|diminish intero-mode " λ" " \\")


### PR DESCRIPTION
`intero-mode` is a minor mode which is usually active alongside `haskell-mode`. In code as it was previously in my installation hook from define-jump-handlers for haskell-mode ran *after* hook set up for intero-mode so `spacemacs-jump-handlers` got it's final value from `spacemacs-jump-handlers-haskell-mode`, so it did not contain `intero-goto-definition`.

Instead of defining separate `spacemacs-jump-handlers-intero-mode` via macro I modify `spacemacs-jump-handlers-haskell-mode` when initializing intero.