### PR TITLE
Fix docs

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -133,7 +133,6 @@
       - [[#buffers-manipulation-key-bindings][Buffers manipulation key bindings]]
       - [[#create-a-new-empty-buffer][Create a new empty buffer]]
       - [[#buffers-manipulation-transient-state][Buffers manipulation transient state]]
-      - [[#special-buffers-usefuluseless-buffers][Special Buffers (useful/useless buffers)]]
       - [[#files-manipulations-key-bindings][Files manipulations key bindings]]
       - [[#frame-manipulation-key-bindings][Frame manipulation key bindings]]
       - [[#emacs-and-spacemacs-files][Emacs and Spacemacs files]]

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -236,11 +236,11 @@ ENSIME is originally built for Scala, so support for java is not complete, in
 particular refactoring doesn’t work.
 
 ** LSP Java
-   LSP Java is the Java adapter for [[https://github.com/emacs-lsp/lsp-mode][LSP Mode]] which is the Emacs client for [[https://github.com/Microsoft/language-server-protocol][Language Server Protocol]].
+LSP Java is the Java adapter for [[https://github.com/emacs-lsp/lsp-mode][LSP Mode]] which is the Emacs client for [[https://github.com/Microsoft/language-server-protocol][Language Server Protocol]].
 
 *** Usage
-    Open a java file and the ~lsp-java~ will automatically download the server
-    and ask you which projects you want to import.
+Open a java file and the ~lsp-java~ will automatically download the server
+and ask you which projects you want to import.
 
 * Key bindings
 ** Meghanada

--- a/layers/+misc/multiple-cursors/README.org
+++ b/layers/+misc/multiple-cursors/README.org
@@ -1,7 +1,8 @@
 #+TITLE: multiple-cursors layer
 
-* Table of Contents                                       :TOC_4_gh:noexport:
+* Table of Contents                     :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 - [[#configuration][Configuration]]
 - [[#key-bindings][Key bindings]]
@@ -21,13 +22,12 @@ Currently the only supported backend is =evil-mc=, but more backends will be
 availabe in the future.
 
 #+BEGIN_SRC emacs-lisp
-(setq-default dotspacemacs-configuration-layers '(
-  (multiple-cursors :variables multiple-cursors-backend 'evil-mc))
+  (setq-default dotspacemacs-configuration-layers '(
+    (multiple-cursors :variables multiple-cursors-backend 'evil-mc))
 #+END_SRC
 
 * Key bindings
 ** =evil-mc=
-
 The =evil-mc= package provides the following key bindings:
 
 | Key Binding | Description                        |

--- a/layers/+misc/multiple-cursors/README.org
+++ b/layers/+misc/multiple-cursors/README.org
@@ -8,7 +8,8 @@
   - [[#evil-mc][=evil-mc=]]
 
 * Description
-This layer adds support for multiple cursors.
+** Features:
+- support for multiple cursors.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -9,10 +9,10 @@
     - [[#extended-navigation-functions-for-derived-layers][Extended navigation functions for derived layers]]
       - [[#spacemacslsp-define-extensions-layer-name-kind-request-optional-extra-parameters][~spacemacs/lsp-define-extensions layer-name kind request &optional extra-parameters~]]
       - [[#spacemacslsp-bind-extensions-for-mode][~spacemacs/lsp-bind-extensions-for-mode~]]
-  - [[#core-keybindings-for-derived-layers][Core keybindings for derived layers]]
+  - [[#core-key-bindings-for-derived-layers][Core key bindings for derived layers]]
     - [[#declared-prefixes][Declared prefixes]]
       - [[#navigation-prefixes][Navigation prefixes]]
-    - [[#default-keybindings][Default keybindings]]
+    - [[#default-key-bindings][Default key bindings]]
   - [[#diagnostics][Diagnostics]]
 - [[#future-additionsimprovements][Future additions/improvements]]
   - [[#make-spacemacslsp-bind-keys-for-mode-bind-conditionally][Make =spacemacs/lsp-bind-keys-for-mode= bind conditionally]]
@@ -53,8 +53,8 @@ under the derived mode t prefix by =(spacemacs/lsp-bind-keys-for-mode mode)=
 
 | Variable name                   | Default | Description                                                                               |
 |---------------------------------+---------+-------------------------------------------------------------------------------------------|
-| =lsp-navigation=                | `both'  | `simple' or `peek' to bind xref OR lsp-ui-peek navigation functions                       |
-| =lsp-ui-remap-xref-keybindings= | nil     | When non-nil, xref keybindings remapped to lsp-ui-peek-find-{definition,references}       |
+| =lsp-navigation=                | `both’  | `simple’ or `peek’ to bind xref OR lsp-ui-peek navigation functions                       |
+| =lsp-ui-remap-xref-keybindings= | nil     | When non-nil, xref key bindings remapped to lsp-ui-peek-find-{definition,references}      |
 | =lsp-ui-doc-enable=             | t       | When non-nil, the documentation overlay is displayed                                      |
 | =lsp-ui-doc-include-signature=  | nil     | When nil, signature omitted from lsp-ui-doc overlay (this is usually redundant)           |
 | =lsp-ui-sideline-enable=        | t       | When non-nil, the symbol information overlay is displayed                                 |
@@ -63,7 +63,7 @@ under the derived mode t prefix by =(spacemacs/lsp-bind-keys-for-mode mode)=
 ** Navigation mode
 The ~lsp-navigation~ variable defined in =config.el= allows you to define a preference for lightweight or pretty
 (using =lsp-ui-peek=) source navigation styles. By default, the lightweight functions are bound under ~SPC m g~
-and the =lsp-ui-peek= variants under ~SPC m G~. Setting ~lsp-navigation~ to either  ~'simple~ or ~'peek~ eliminates
+and the =lsp-ui-peek= variants under ~SPC m G~. Setting ~lsp-navigation~ to either ~'simple~ or ~'peek~ eliminates
 the bindings under ~SPC m G~ and creates bindings under ~SPC m g~ according to the specified preference.
 
 *** Extended navigation functions for derived layers
@@ -115,6 +115,7 @@ With ~lsp-navigation~ set to ~'both~ (the default), this is equivalent to:
     "GC" 'c-c++/peek-callees
     "Gv" 'c-c++/peek-vars)
 #+END_SRC
+
 whereas with ~lsp-navigation~ set to ~'peek~, this is equivalent to:
 
 #+BEGIN_SRC elisp
@@ -129,7 +130,7 @@ whereas with ~lsp-navigation~ set to ~'peek~, this is equivalent to:
 
 etc.
 
-** Core keybindings for derived layers
+** Core key bindings for derived layers
 The ~spacemacs/lsp-bind-keys-for-mode mode~ function binds keys to a number of lsp features useful for all/most modes
 for the given major mode. It also declares some relevant keyboard shortcut prefixes.
 
@@ -147,60 +148,59 @@ The following prefixes have been declared:
 | ~SPC m T~ | toggle      | Toggle LSP backend features (documentation / symbol info overlays etc.)    |
 
 **** Navigation prefixes
- The following prefixes have been declared under each of the navigation prefixes (i.e. ~SPC m g~ / ~SPC m G~)
+The following prefixes have been declared under each of the navigation prefixes (i.e. ~SPC m g~ / ~SPC m G~)
 
 | prefix          | name             | functional area                                          |
 |-----------------+------------------+----------------------------------------------------------|
 | ~SPC m <g/G> h~ | hierarchy        | Heirarchy (i.e. call/inheritance hierarchy etc. )        |
 | ~SPC m <g/G> m~ | member hierarchy | Class/namespace members (functions, nested classes, vars |
 
-*** Default keybindings
+*** Default key bindings
 The default bindings are listed below. Derived language server layers should extend this list.
 
-| binding     | function                                                                     |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m = b~ | format buffer (lsp)                                                          |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m g t~ | goto type-definition (lsp)                                                   |
-| ~SPC m g k~ | goto viewport symbol (avy)                                                   |
-| ~SPC m g e~ | browse flycheck errors                                                       |
-| ~SPC m g M~ | browse file symbols (lsp-ui-imenu)                                           |
-|-------------+------------------------------------------------------------------------------|
-| Note        | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ == 'peek/     |
-| ~SPC m g i~ | find implementations (lsp)                                                   |
-| ~SPC m g d~ | find definitions (xref/lsp)                                                  |
-| ~SPC m g r~ | find references (xref/lsp)                                                   |
-| ~SPC m g s~ | find-workspace-symbol (lsp-ui)                                               |
-| ~SPC m g p~ | goto previous (xref-pop-marker-stack)                                        |
-|-------------+------------------------------------------------------------------------------|
-| Note        | /Omitted when ~lsp-navigation~ == 'peek or 'simple/                          |
-|             | /Bound under ~SPC m g~ rather than ~SPC m G~ when ~lsp-navigation~ == 'peek/ |
-| ~SPC m G i~ | find implementation (lsp-ui-peek)                                            |
-| ~SPC m G d~ | find definitions (lsp-ui-peek)                                               |
-| ~SPC m G r~ | find references (lsp-ui-peek)                                                |
-| ~SPC m G s~ | find-workspace-symbol (lsp-ui-peek)                                          |
-| ~SPC m G p~ | goto previous (lsp-ui-peek stack - see Note 1)                               |
-| ~SPC m G n~ | goto next (lsp-ui-peek stack - see Note 1)                                   |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m h h~ | describe thing at point                                                      |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m b r~ | lsp-restart-workspace                                                        |
-| ~SPC m b a~ | execute code action                                                          |
-| ~SPC m b c~ | lsp-capabilities                                                             |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m r r~ | rename                                                                       |
-|-------------+------------------------------------------------------------------------------|
-| ~SPC m T d~ | toggle documentation overlay                                                 |
-| ~SPC m T F~ | toggle documentation overlay function signature                              |
-| ~SPC m T s~ | toggle symbol info overlay                                                   |
-| ~SPC m T S~ | toggle symbol info overlay symbol name                                       |
-| ~SPC m T I~ | toggle symbol info overlay duplicates                                        |
+| binding     | function                                                                       |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC m = b~ | format buffer (lsp)                                                            |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC m g t~ | goto type-definition (lsp)                                                     |
+| ~SPC m g k~ | goto viewport symbol (avy)                                                     |
+| ~SPC m g e~ | browse flycheck errors                                                         |
+| ~SPC m g M~ | browse file symbols (lsp-ui-imenu)                                             |
+|-------------+--------------------------------------------------------------------------------|
+| Note        | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ == ='peek=/     |
+| ~SPC m g i~ | find implementations (lsp)                                                     |
+| ~SPC m g d~ | find definitions (xref/lsp)                                                    |
+| ~SPC m g r~ | find references (xref/lsp)                                                     |
+| ~SPC m g s~ | find-workspace-symbol (lsp-ui)                                                 |
+| ~SPC m g p~ | goto previous (xref-pop-marker-stack)                                          |
+|-------------+--------------------------------------------------------------------------------|
+| Note        | /Omitted when ~lsp-navigation~ == ='peek= or ='simple=/                        |
+|             | /Bound under ~SPC m g~ rather than ~SPC m G~ when ~lsp-navigation~ == ='peek=/ |
+| ~SPC m G i~ | find implementation (lsp-ui-peek)                                              |
+| ~SPC m G d~ | find definitions (lsp-ui-peek)                                                 |
+| ~SPC m G r~ | find references (lsp-ui-peek)                                                  |
+| ~SPC m G s~ | find-workspace-symbol (lsp-ui-peek)                                            |
+| ~SPC m G p~ | goto previous (lsp-ui-peek stack - see Note 1)                                 |
+| ~SPC m G n~ | goto next (lsp-ui-peek stack - see Note 1)                                     |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC m h h~ | describe thing at point                                                        |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC m b r~ | lsp-restart-workspace                                                          |
+| ~SPC m b a~ | execute code action                                                            |
+| ~SPC m b c~ | lsp-capabilities                                                               |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC m r r~ | rename                                                                         |
+|-------------+--------------------------------------------------------------------------------|
+| ~SPC m T d~ | toggle documentation overlay                                                   |
+| ~SPC m T F~ | toggle documentation overlay function signature                                |
+| ~SPC m T s~ | toggle symbol info overlay                                                     |
+| ~SPC m T S~ | toggle symbol info overlay symbol name                                         |
+| ~SPC m T I~ | toggle symbol info overlay duplicates                                          |
 
 Note 1: There is a window local jump list dedicated to cross references
 
 ** Diagnostics
 If some features do not work as expected, here is a common check list.
-
 - =M-x lsp-capabilities= If the LSP workspace is initialized correctly
 - =M-: xref-backend-functions= should be =(lsp--xref-backend)= for cross
   references


### PR DESCRIPTION
Travis wasn't failing when the early stage of auto formatting was impossible (.org file was missing `Features:` list - it can't be auto-fixed)  So we have accumulated some malformed things.