### PR TITLE
Some tweak to c-c++ layer

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -84,8 +84,7 @@ Install the RTags server via [[https://formulae.brew.sh/formula/rtags][homebrew]
 N.B. RTags is not supported on Windows at the time of writing, although there is an [[https://github.com/Andersbakken/rtags/issues/770][open issue with some recent activity]] on github.
 
 **** Configuration
-To enable support for =rtags=, set the layer variable
-=c-c++-enable-rtags-support= to =t= in your dotfile.
+To enable support for =rtags=, set the layer variable =c-c++-backend=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -324,30 +324,30 @@ and the arguments for flyckeck-clang based on a project-specific text file."
   (spacemacs//c-c++-lsp-call-function "spacemacs//c-c++-lsp-define-" "-extensions")
 
   (spacemacs/lsp-define-extensions "c-c++" 'vars
-    (spacemacs//c-c++-lsp-string "$" "/vars"))
+    (spacemacs//c-c++-lsp-string "$" "/vars")))
 
+(defun spacemacs//c-c++-lsp-define-cquery-extensions ()
   (spacemacs/lsp-define-extensions "c-c++" 'refs-address
     "textDocument/references"
     '(plist-put (lsp--text-document-position-params) :context '(:role 128)))
-
   (spacemacs/lsp-define-extensions "c-c++" 'refs-read
     "textDocument/references"
     '(plist-put (lsp--text-document-position-params) :context '(:role 8)))
-
   (spacemacs/lsp-define-extensions "c-c++" 'refs-write
     "textDocument/references"
-    '(plist-put (lsp--text-document-position-params) :context '(:role 16))))
-
-(defun spacemacs//c-c++-lsp-define-cquery-extensions ()
+    '(plist-put (lsp--text-document-position-params) :context '(:role 16)))
   (spacemacs/lsp-define-extensions "c-c++" 'callers "$cquery/callers")
   (spacemacs/lsp-define-extensions "c-c++" 'callees "$cquery/callers" '(:callee t))
   (spacemacs/lsp-define-extensions "c-c++" 'base "$cquery/base"))
 
 (defun spacemacs//c-c++-lsp-define-ccls-extensions ()
+  (spacemacs/lsp-define-extensions "c-c++" 'refs-address "textDocument/references" '(:role 128))
+  (spacemacs/lsp-define-extensions "c-c++" 'refs-read "textDocument/references" '(:role 8))
+  (spacemacs/lsp-define-extensions "c-c++" 'refs-write "textDocument/references" '(:role 16))
   (spacemacs/lsp-define-extensions "c-c++" 'callers "$ccls/call")
   (spacemacs/lsp-define-extensions "c-c++" 'callees "$ccls/call" '(:callee t))
-  (spacemacs/lsp-define-extensions "c-c++" 'base "$ccls/inheritance" '(:levels 3))
+  (spacemacs/lsp-define-extensions "c-c++" 'base "$ccls/inheritance")
   ;;ccls features without a cquery analogue...
-  (spacemacs/lsp-define-extensions "c-c++" 'member-classes "$ccls/member" `(:kind 2))
+  (spacemacs/lsp-define-extensions "c-c++" 'member-types "$ccls/member" `(:kind 2))
   (spacemacs/lsp-define-extensions "c-c++" 'member-functions "$ccls/member" `(:kind 3))
   (spacemacs/lsp-define-extensions "c-c++" 'member-vars "$ccls/member" `(:kind 0)))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -294,8 +294,7 @@
       (when c-c++-adopt-subprojects
         (setq projectile-project-root-files-top-down-recurring
           (append '("compile_commands.json"
-                     ".cquery"
-                     ".ccls")
+                     ".cquery")
             projectile-project-root-files-top-down-recurring))))))
 
 ;; END LSP BACKEND PACKAGES


### PR DESCRIPTION
Follow-up of https://github.com/syl20bnr/spacemacs/pull/11242
    
c-c++-enable-rtags-support has been removed in favor of c-c++-backend. Don't mention it in README
    
Delete .ccls from c-c++-adopt-subprojects
      as in ccls, .ccls-root (detected by emacs-ccls) is recommended for this purpose
    
Delete the extra parameter :levels 3 from $ccls/inheritance
      Finding the immediate bases is usually more desired
    
The parameters of refs-* in ccls are not in :context
