### PR TITLE
ipython-notebook: remove spurious leader key

### DIFF
--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -174,12 +174,12 @@
         ("9" ein:notebook-worksheet-open-last)
         ("+" ein:notebook-worksheet-insert-next)
         ("-" ein:notebook-worksheet-delete)
-        ("x" ein:notebook-close))
-      (spacemacs/set-leader-keys "ein" 'spacemacs/ipython-notebook-transient-state/body))))
+        ("x" ein:notebook-close)))))
 
 (defun ipython-notebook/pre-init-ob-ipython ()
   (spacemacs|use-package-add-hook org
     :post-config
     (use-package ob-ipython
       :init (add-to-list 'org-babel-load-languages '(ipython . t)))))
+
 (defun ipython-notebook/init-ob-ipython ())


### PR DESCRIPTION
There is an incorrect leader key being set in the ipython-notebook layer. The transient state leader key had already being define, and in the correct place.