### PR TITLE
sql: Add default jump handlers for SQL layer

### DIFF
--- a/layers/+lang/sql/config.el
+++ b/layers/+lang/sql/config.el
@@ -9,6 +9,8 @@
 ;;
 ;;; License: GPLv3
 
+(spacemacs|define-jump-handlers sql-mode)
+
 (defvar sql-capitalize-keywords nil
   "Capitalize keywords in SQL mode.")
 


### PR DESCRIPTION
Recent versions of `dumb-jump` have support for jumping to definitions for generic SQL buffers, and
support in Spacemacs requires that we enable these in the `sql` layer.