### PR TITLE
[WIP] Ruby LSP support 

### DIFF
--- a/layers/+lang/ruby/config.el
+++ b/layers/+lang/ruby/config.el
@@ -14,6 +14,9 @@
 (spacemacs|define-jump-handlers enh-ruby-mode)
 (spacemacs|define-jump-handlers ruby-mode)
 
+(defvar ruby-backend nil
+  "The ruby backend for IDE features, possible values are `robe' and `lsp'")
+
 (defvar ruby-enable-enh-ruby-mode nil
   "If non-nil, use `enh-ruby-mode' package instead of the built-in Ruby Mode.")
 

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -70,3 +70,47 @@ Called interactively it prompts for a directory."
     (highlight-lines-matching-regexp "byebug")
     (highlight-lines-matching-regexp "binding.irb")
     (highlight-lines-matching-regexp "binding.pry")))
+
+
+;; LSP
+
+(defun spacemacs//ruby-setup-backend ()
+  "Conditionally setup ruby backend."
+  (pcase ruby-backend
+    ('lsp (spacemacs//ruby-setup-lsp))))
+
+(defun spacemacs//ruby-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+    (progn
+      (lsp-ruby-enable))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//ruby-setup-company ()
+  "Conditionally setup company based on backend."
+  (message "%s settuing up company" ruby-backend)
+  (pcase ruby-backend
+    ('robe (spacemacs//ruby-setup-robe-company))
+    ('lsp (spacemacs//ruby-setup-lsp-company)))
+  (spacemacs//ruby-setup-basic-company))
+
+(defun spacemacs//ruby-setup-robe-company ()
+  "Setup robe auto-completion."
+  (when (configuration-layer/package-used-p 'robe)
+    (spacemacs|add-company-backends
+      :backends company-robe
+      :modes ruby-mode enh-ruby-mode)))
+
+(defun spacemacs//ruby-setup-lsp-company ()
+  "Setup lsp auto-completion."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (spacemacs|add-company-backends
+        :backends company-lsp
+        :modes enh-ruby-mode ruby-mode)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//ruby-setup-basic-company ()
+  "Setup dabbrev auto-completion."
+  (with-eval-after-load 'company-dabbrev-code
+    (let ((mode (if ruby-enable-enh-ruby-mode 'enh-ruby-mode 'ruby-mode)))
+      (add-to-list 'company-dabbrev-code-modes mode))))


### PR DESCRIPTION
Adds ruby LSP support.

Inspired by the java/rust implementation.

It will have 3 available backends:
1. None (because lsp can't be default and robe, while a useful tool, is really annoying).
2. Robe
3. LSP

Currently I can get the LSP server to start, although I need a bigger timeout:
```emacs-lisp
(lsp
  :variables
  lsp-response-timeout 30)
```

Completion and jump to definition is working now.

Still TO DO:
- Solve the key binding conflict with `rubocop`.
- Figure out if documentation can be displayed without needing to execute `yard gems`.
- Document it in the `README.md`.
- Integrate with `rvm`.