### PR TITLE
Refactor clang-format-on-save

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -43,12 +43,8 @@
 (defun spacemacs//clang-format-on-save ()
   "Format the current buffer with clang-format on save when
 `c-c++-enable-clang-format-on-save' is non-nil."
-  (when c-c++-enable-clang-format-on-save
+  (when (and c-c++-enable-clang-format-on-save (member major-mode c-c++-modes))
     (spacemacs/clang-format-region-or-buffer)))
-
-(defun spacemacs/clang-format-on-save ()
-  "Add before-save hook for clang-format."
-  (add-hook 'before-save-hook 'spacemacs//clang-format-on-save nil t))
 
 (defun spacemacs/company-more-than-prefix-guesser ()
   (spacemacs/c-c++-load-clang-args)

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -69,7 +69,7 @@
     :init
     (progn
       (when c-c++-enable-clang-format-on-save
-        (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks))
+        (add-hook 'before-save-hook #'spacemacs//clang-format-on-save t))
       (dolist (mode c-c++-modes)
         (spacemacs/declare-prefix-for-mode mode "m=" "format")
         (spacemacs/set-leader-keys-for-major-mode mode


### PR DESCRIPTION
Refactor c-c++ layer to use `before-save-hook` as global variable, because it is noted not to use buffer-local.

~Currently this PR contains unnecessary commits. I'll remove it.~