### PR TITLE
Fix conflict between pipenv directory .venv and pyvenv file .venv

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -212,18 +212,22 @@ as the pyenv version then also return nil. This works around https://github.com/
                    version file-path))))))
 
 (defun spacemacs//pyvenv-mode-set-local-virtualenv ()
-  "Set pyvenv virtualenv from \".venv\" by looking in parent directories."
+  "Set pyvenv virtualenv from \".venv\" by looking in parent directories. handle directory or file"
   (interactive)
   (let ((root-path (locate-dominating-file default-directory
                                            ".venv")))
     (when root-path
       (let* ((file-path (expand-file-name ".venv" root-path))
              (virtualenv
-              (with-temp-buffer
-                (insert-file-contents-literally file-path)
-                (buffer-substring-no-properties (line-beginning-position)
-                                                (line-end-position)))))
-            (pyvenv-workon virtualenv)))))
+              (if (file-directory-p file-path)
+                  file-path
+                (with-temp-buffer
+                  (insert-file-contents-literally file-path)
+                  (buffer-substring-no-properties (line-beginning-position)
+                                                  (line-end-position))))))
+        (if (file-directory-p virtualenv)
+            (pyvenv-activate virtualenv)
+          (pyvenv-workon virtualenv))))))
 
 
 ;; Tests


### PR DESCRIPTION
Using `Pipenv` might generate a directory named `.venv` in the project root, which conflicts with `pyvenv`'s `.venv` file.

This is the solution given by the code in #10293.

Issues that may be resolved: #10293, #11145,#10798