### PR TITLE
Introduce key binding `sC` for `helm-swoop-clear-cache`

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -615,8 +615,15 @@ Search for a search tool in the order provided by `dotspacemacs-search-tools'."
                      (if thing thing ""))))))
           (call-interactively 'helm-swoop)))
 
+      (defun spacemacs/helm-swoop-clear-cache ()
+        "Call `helm-swoop--clear-cache' to clear the cache"
+        (interactive)
+        (helm-swoop--clear-cache)
+        (message "helm-swoop cache cleaned."))
+
       (spacemacs/set-leader-keys
         "ss"    'helm-swoop
+        "sC"    'spacemacs/helm-swoop-clear-cache
         "sS"    'spacemacs/helm-swoop-region-or-symbol
         "s C-s" 'helm-multi-swoop-all)
       (defadvice helm-swoop (before add-evil-jump activate)


### PR DESCRIPTION
helm-swoop cannot detect the buffer has changed when calling git checkout to
change the file content, so helm-swoop won't clear the cache, we have to clear
the cache manually by evaluating `helm-swoop--clear-cache`. As it is
inconvenient, so I introduce a new key binding to to this.

Signed-off-by: Yang Qian <yang.qian@citrix.com>

This is a workaround for the issue of helm-swoop: https://github.com/ShingoFukuyama/helm-swoop/issues/112