### PR TITLE
Optionally activate pipenv before enabling python layer backend.

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -122,6 +122,11 @@ Additionally you can install the following other packages:
   pip install pyls-mypy
 #+END_SRC
 
+If you've installed the language server and related packages as development
+dependencies in a pipenv environment, you'll want to set the ~python-pipenv-activate~
+config variable to ~t~. This activates your pipenv before enabling the
+lsp backend.
+
 * Additional tools
 ** Syntax checking
 Syntax checking uses =flake8= package:

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -18,6 +18,9 @@
   "The backend to use for IDE features. Possible values are `anaconda'
 and `lsp'.")
 
+(defvar python-pipenv-activate nil
+  "If non-nil, activate pipenv before enabling backend")
+
 (defvar python-enable-yapf-format-on-save nil
   "If non-nil, automatically format code with YAPF on save.")
 

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -11,6 +11,7 @@
 
 (defun spacemacs//python-setup-backend ()
   "Conditionally setup python backend."
+  (when python-pipenv-activate (pipenv-activate))
   (pcase python-backend
     (`anaconda (spacemacs//python-setup-anaconda))
     (`lsp (spacemacs//python-setup-lsp))))


### PR DESCRIPTION
Added this config variable to allow the use of the python language server installed as a dev dependency in a project pipenv. The setting defaults to nil, and doesn't appear to cause any problems with non pipenv projects when non-nil.

To activate, just
``` elisp
       (python :variables
         python-backend 'lsp
         python-pipenv-activate t)
```
