### PR TITLE
Fix the "wrong type argument" in git blame

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -174,10 +174,10 @@
 Press [_b_] again to blame further in the history, [_q_] to go up or quit."
         :on-enter (let (golden-ratio-mode)
                     (unless (bound-and-true-p magit-blame-mode)
-                      (call-interactively 'magit-blame-addition)))
+                      (call-interactively 'magit-blame)))
         :foreign-keys run
         :bindings
-        ("b" magit-blame-addition)
+        ("b" magit-blame)
         ;; here we use the :exit keyword because we should exit the
         ;; micro-state only if the magit-blame-quit effectively disable
         ;; the magit-blame mode.


### PR DESCRIPTION
Revert "'magit-blame' renamed to 'magit-blame-addition'"

It reverts commit cb4a1560878626ddcceb1a4cb831bd08e5f55316.

This is to fix the issue described at https://github.com/syl20bnr/spacemacs/issues/11568.