### PR TITLE
Keyword flycheck-ocaml with :toggle instead of using a `when`

### DIFF
--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -14,7 +14,7 @@
         ;; auto-complete
         company
         flycheck
-        flycheck-ocaml
+        (flycheck-ocaml :toggle (configuration-layer/layer-used-p 'syntax-checking))
         ggtags
         counsel-gtags
         helm-gtags
@@ -32,18 +32,18 @@
       :modes merlin-mode
       :variables merlin-completion-with-doc t)))
 
-(when (configuration-layer/layer-used-p 'syntax-checking)
-  (defun ocaml/post-init-flycheck ()
-    (spacemacs/enable-flycheck 'tuareg-mode))
-  (defun ocaml/init-flycheck-ocaml ()
-    (use-package flycheck-ocaml
-      :if (configuration-layer/package-used-p 'flycheck)
-      :defer t
-      :init
-      (progn
-        (with-eval-after-load 'merlin
-          (setq merlin-error-after-save nil)
-          (flycheck-ocaml-setup))))))
+(defun ocaml/post-init-flycheck ()
+  (spacemacs/enable-flycheck 'tuareg-mode))
+
+(defun ocaml/init-flycheck-ocaml ()
+  (use-package flycheck-ocaml
+    :if (configuration-layer/package-used-p 'flycheck)
+    :defer t
+    :init
+    (progn
+      (with-eval-after-load 'merlin
+        (setq merlin-error-after-save nil)
+        (flycheck-ocaml-setup)))))
 
 (defun ocaml/post-init-ggtags ()
   (add-hook 'ocaml-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
The previous way of restricting this `ocaml` layer's package was raising unnecessary warnings.