### PR TITLE
Introduce 'defaults special value in dotspacemacs-line-numbers

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1331,6 +1331,13 @@ Enable *line numbers* everywhere, even in non-prog-mode and non-text-mode buffer
   (setq-default dotspacemacs-line-numbers '(:enabled-for-modes 'all))
 #+END_SRC
 
+Enable *line numbers* in tuareg-mode, but keep the enabled-by-default ones:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-line-numbers '(:enabled-for-modes defaults
+                                                               tuareg-mode))
+#+END_SRC
+
 ** Mode-line
 *** Mode-line themes
 Spacemacs supports different mode-line themes. The mode-line theme is set in the

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1475,7 +1475,9 @@ Decision is based on `dotspacemacs-line-numbers'."
          ;; a more sensible default than enabling in all buffers - including
          ;; Magit buffers, terminal buffers, etc. But don't include prog-mode or
          ;; text-mode if they're explicitly disabled by user
-         (enabled-for-modes (or user-enabled-for-modes
+         (enabled-for-modes (or (if (memq 'defaults user-enabled-for-modes)
+                                    (cons 'prog-mode (cons 'text-mode user-enabled-for-modes))
+                                  user-enabled-for-modes)
                                 (seq-difference '(prog-mode text-mode)
                                                 disabled-for-modes
                                                 #'eq)))


### PR DESCRIPTION
While I was struggling to make `display-line-numbers-mode` trigger in `tuareg-mode`, which does not derive from neither `prog-mode` nor `text-mode`, I realized that such a thing could be useful. Please let me know what you think.