### PR TITLE
Add undo-tree visualizer mapping into keyboard-layout

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -33,6 +33,7 @@
     org-agenda
     ranger
     twittering-mode
+    undo-tree
     ))
 
 (defun keyboard-layout/pre-init-ace-window ()
@@ -602,3 +603,16 @@
       "J"
       "K"
       "L")))
+
+(defun keyboard-layout/pre-init-undo-tree ()
+  (kl|config undo-tree
+    :description
+    "Remap navigation keys in `undo-tree-visualizer-mode'."
+    :loader
+    (spacemacs|use-package-add-hook undo-tree :post-config BODY)
+    :common
+    (kl/evil-correct-keys 'evilified undo-tree-visualizer-mode-map
+      "h"
+      "j"
+      "k"
+      "l")))


### PR DESCRIPTION
This PR just remaps evilified navigation keys in the undo-tree visualizer which are originally "hjkl" using the keyboard-layout machinery. 

I don't know if I should remap other keys. 

~EDIT : Wait, I messed with my commit history somewhere. I'll fix it.~
EDIT2 : Now it's okay