### PR TITLE
Hide MMM mode-line indicator

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -163,7 +163,10 @@
     :commands mmm-mode
     :init (add-hook 'markdown-mode-hook 'spacemacs/activate-mmm-mode)
     ;; Automatically add mmm class for languages
-    :config (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)))
+    :config
+    (progn
+      (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)
+      (spacemacs|hide-lighter mmm-mode))))
 
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode


### PR DESCRIPTION
problem: MMM is shown in the mode-line when a .md markdown file is opened.
solution: hide MMM when mmm-mode is configured.