### PR TITLE
Move lexical-binding to first line

### DIFF
--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -1,4 +1,6 @@
-;;; core-debug.el --- Spacemacs Core File  -*- lexical-binding: t; -*-
+;; -*- lexical-binding: t -*-
+;;
+;;; core-debug.el --- Spacemacs Core File
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/core/core-micro-state.el
+++ b/core/core-micro-state.el
@@ -1,4 +1,5 @@
-;;; -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
 ;;; core-micro-state.el --- Spacemacs Core File
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors

--- a/core/core-transient-state.el
+++ b/core/core-transient-state.el
@@ -1,4 +1,5 @@
-;;; -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
 ;;; core-transient-state.el --- Spacemacs Core File
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors

--- a/core/libs/load-env-vars.el
+++ b/core/libs/load-env-vars.el
@@ -1,4 +1,6 @@
-;;; load-env-vars.el --- Load environment variables from files                     -*- lexical-binding: t; -*-
+;; -*- lexical-binding: t -*-
+
+;;; load-env-vars.el --- Load environment variables from files
 
 ;; Copyright (C) 2018  Jorge Dias
 

--- a/layers/+frameworks/react/config.el
+++ b/layers/+frameworks/react/config.el
@@ -1,4 +1,6 @@
-;;; config.el --- react layer config file for Spacemacs. -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
+;;; config.el --- react layer config file for Spacemacs.
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -1,4 +1,6 @@
-;;; funcs.el --- react layer funcs file for Spacemacs. -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
+;;; funcs.el --- react layer funcs file for Spacemacs.
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+frameworks/react/layers.el
+++ b/layers/+frameworks/react/layers.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t -*-
+;;
 ;;; layers.el --- react Layer layers File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -1,4 +1,6 @@
-;;; packages.el --- react layer packages file for Spacemacs. -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
+;;; packages.el --- react layer packages file for Spacemacs.
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+lang/java/local/flycheck-eclim/flycheck-eclim.el
+++ b/layers/+lang/java/local/flycheck-eclim/flycheck-eclim.el
@@ -1,4 +1,6 @@
-;; flycheck-eclim.el --- an interface to the Eclipse IDE. -*- lexical-binding: t; -*-
+;; -*- lexical-binding: t -*-
+;;
+;; flycheck-eclim.el --- an interface to the Eclipse IDE.
 ;;
 ;; Copyright (C) 2015 Łukasz Klich
 ;;

--- a/layers/+spacemacs/spacemacs-editing-visual/local/centered-buffer-mode/centered-buffer-mode.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/local/centered-buffer-mode/centered-buffer-mode.el
@@ -1,4 +1,6 @@
-;;; centered-buffer-mode.el --- Centering minor mode -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
+;;; centered-buffer-mode.el --- Centering minor mode
 ;;
 ;; Copyright (C) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
+++ b/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
@@ -1,4 +1,6 @@
-;;; space-doc.el --- Spacemacs org minor mode. -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+;;
+;;; space-doc.el --- Spacemacs org minor mode.
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -1,4 +1,6 @@
-;;; spacemacs-purpose-popwin.el --- Purpose extension to act like Popwin -*- lexical-binding: t -*-
+;; -*- lexical-binding: t -*-
+
+;;; spacemacs-purpose-popwin.el --- Purpose extension to act like Popwin
 
 ;;; Commentary:
 


### PR DESCRIPTION
problem:
Some files write the lexical binding to the right of the first line, that makes
it seem like it's just part of the layer description.

https://www.emacswiki.org/emacs/LexicalBinding states that:
> enable lexical binding in your elisp library, put a line like this at the top
> of the file:
> ;; -*- lexical-binding: t -*-

which seems to indicate that it should be written by itself.

And possibly the newest layer multiple-cursors writes the lexical binding on the
first line.

solution:
Move the lexical-binding to the first line.

---

### Notes:

#### Semicolon
Three files:
```
core/core-debug.el
core/libs/load-env-vars.el
layers/+lang/java/local/flycheck-eclim/flycheck-eclim.el
```
had a semicolon after `t` like this:
```
;; -*- lexical-binding: t; -*-
```
but it seemed like a mistake so I removed the semicolons.

#### React layer
The react layer enabled the lexical-binding in 3 out of the 4 files:
```
config.el
funcs.el
packages.el
```
I added it to the 4th file `layers.el` as well, for consistency.