### PR TITLE
Unify packages list parentheses style

### DIFF
--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -1,16 +1,16 @@
 (setq rcirc-packages
-  '(
-    company
-    company-emoji
-    emoji-cheat-sheet-plus
-    flyspell
-    (helm-rcirc :location local
-                :requires helm)
-    persp-mode
-    rcirc
-    rcirc-color
-    rcirc-notify
-    ))
+      '(
+        company
+        company-emoji
+        emoji-cheat-sheet-plus
+        flyspell
+        (helm-rcirc :location local
+                    :requires helm)
+        persp-mode
+        rcirc
+        rcirc-color
+        rcirc-notify
+        ))
 
 (defun rcirc/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes rcirc-mode))

--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -18,7 +18,8 @@
     (flyspell-correct-helm :toggle (configuration-layer/layer-used-p 'helm))
     (flyspell-correct-popup :toggle (and (not (configuration-layer/layer-used-p 'ivy))
                                          (not (configuration-layer/layer-used-p 'helm))))
-    (flyspell-popup :toggle enable-flyspell-auto-completion)))
+    (flyspell-popup :toggle enable-flyspell-auto-completion)
+    ))
 
 (defun spell-checking/init-auto-dictionary ()
   (use-package auto-dictionary

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -10,11 +10,11 @@
 ;;; License: GPLv3
 
 (setq syntax-checking-packages
-  '(
-    flycheck
-    flycheck-pos-tip
-    popwin
-    ))
+      '(
+        flycheck
+        flycheck-pos-tip
+        popwin
+        ))
 
 (defun syntax-checking/init-flycheck ()
   (use-package flycheck

--- a/layers/+completion/templates/packages.el
+++ b/layers/+completion/templates/packages.el
@@ -9,8 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(setq templates-packages
-      '(yatemplate))
+(setq templates-packages '(yatemplate))
 
 (defun templates/init-yatemplate ()
   (use-package yatemplate

--- a/layers/+emacs/better-defaults/packages.el
+++ b/layers/+emacs/better-defaults/packages.el
@@ -10,8 +10,10 @@
 ;;; License: GPLv3
 
 (defconst better-defaults-packages
-  '(mwim
-    unfill)
+  '(
+    mwim
+    unfill
+    )
   "The list of Lisp packages required by the mwim layer.")
 
 (defun better-defaults/init-mwim ()

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -15,8 +15,8 @@
         (helm-notmuch :requires helm)
         notmuch
         org
-        persp-mode)
-      )
+        persp-mode
+        ))
 
 (defun notmuch/init-counsel-notmuch ()
   (use-package counsel-notmuch

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -10,11 +10,13 @@
 ;;; License: GPLv3
 
 (defconst treemacs-packages
-  '(golden-ratio
+  '(
+    golden-ratio
     treemacs
     (treemacs-evil :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
     treemacs-projectile
-    winum))
+    winum
+    ))
 
 (defun treemacs/pre-init-golden-ratio ()
   (spacemacs|use-package-add-hook golden-ratio

--- a/layers/+fonts/unicode-fonts/packages.el
+++ b/layers/+fonts/unicode-fonts/packages.el
@@ -12,8 +12,10 @@
 ;;; Code:
 
 (defconst unicode-fonts-packages
-  '(unicode-fonts
-    persistent-soft))
+  '(
+    unicode-fonts
+    persistent-soft
+    ))
 
 (defun unicode-fonts/init-persistent-soft ()
   (use-package persistent-soft

--- a/layers/+frameworks/django/packages.el
+++ b/layers/+frameworks/django/packages.el
@@ -9,10 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(setq django-packages
-  '(
-    pony-mode
-    ))
+(setq django-packages '(pony-mode))
 
 (defun django/init-pony-mode ()
   (use-package pony-mode

--- a/layers/+frameworks/emberjs/packages.el
+++ b/layers/+frameworks/emberjs/packages.el
@@ -14,8 +14,10 @@
 ;;; Code:
 
 (defconst emberjs-packages
-  '(ember-mode
-    ember-yasnippets))
+  '(
+    ember-mode
+    ember-yasnippets
+    ))
 
 (defun emberjs/init-ember-mode ()
   (use-package ember-mode

--- a/layers/+frameworks/phoenix/packages.el
+++ b/layers/+frameworks/phoenix/packages.el
@@ -9,8 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(defconst phoenix-packages
-  '(alchemist))
+(defconst phoenix-packages '(alchemist))
 
 (defun phoenix/post-init-alchemist ()
   (progn

--- a/layers/+frameworks/ruby-on-rails/packages.el
+++ b/layers/+frameworks/ruby-on-rails/packages.el
@@ -10,11 +10,11 @@
 ;;; License: GPLv3
 
 (setq ruby-on-rails-packages
-  '(
-    feature-mode
-    projectile-rails
-    which-key
-    ))
+      '(
+        feature-mode
+        projectile-rails
+        which-key
+        ))
 
 (defun ruby-on-rails/init-projectile-rails ()
   (use-package projectile-rails

--- a/layers/+intl/japanese/packages.el
+++ b/layers/+intl/japanese/packages.el
@@ -8,16 +8,19 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; License: GPLv3
+
 ;; List of all packages to install and/or initialize. Built-in packages
 ;; which require an initialization must be listed explicitly in the list.
 (setq japanese-packages
-      '(evil-tutor-ja
+      '(
+        evil-tutor-ja
         migemo
         avy-migemo
         ddskk
         japanese-holidays
         pangu-spacing
-        org))
+        org
+        ))
 
 (defun japanese/init-evil-tutor-ja ()
   (use-package evil-tutor-ja

--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -10,9 +10,11 @@
 ;;; License: GPLv3
 
 (setq agda-packages
-      '((agda :location local)
+      '(
+        (agda :location local)
         company
-        golden-ratio))
+        golden-ratio
+        ))
 
 (defun agda/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes agda2-mode))

--- a/layers/+lang/autohotkey/packages.el
+++ b/layers/+lang/autohotkey/packages.el
@@ -10,8 +10,7 @@
 ;;
 ;;; License: GPLv3
 
-(setq autohotkey-packages
-  '(ahk-mode))
+(setq autohotkey-packages '(ahk-mode))
 
 (defun autohotkey/init-ahk-mode ()
   (use-package ahk-mode

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -10,36 +10,37 @@
 ;;; License: GPLv3
 
 (setq c-c++-packages
-  '(
-     cc-mode
-     clang-format
-     company
-     (company-c-headers :requires company)
-     (company-rtags :requires company rtags)
-     company-ycmd
-     counsel-gtags
-     disaster
-     flycheck
-     (flycheck-rtags :requires flycheck rtags)
-     gdb-mi
-     ggtags
-     google-c-style
-     helm-cscope
-     helm-gtags
-     (helm-rtags :requires helm rtags)
-     (ivy-rtags :requires ivy rtags)
-     org
-     realgud
-     rtags
-     semantic
-     srefactor
-     stickyfunc-enhance
-     xcscope
-     ycmd
-     ;;lsp-backend
-     (cquery :requires lsp-mode)
-     (ccls :requires lsp-mode)
-     projectile))
+      '(
+        cc-mode
+        clang-format
+        company
+        (company-c-headers :requires company)
+        (company-rtags :requires company rtags)
+        company-ycmd
+        counsel-gtags
+        disaster
+        flycheck
+        (flycheck-rtags :requires flycheck rtags)
+        gdb-mi
+        ggtags
+        google-c-style
+        helm-cscope
+        helm-gtags
+        (helm-rtags :requires helm rtags)
+        (ivy-rtags :requires ivy rtags)
+        org
+        realgud
+        rtags
+        semantic
+        srefactor
+        stickyfunc-enhance
+        xcscope
+        ycmd
+        ;;lsp-backend
+        (cquery :requires lsp-mode)
+        (ccls :requires lsp-mode)
+        projectile
+        ))
 
 
 (defun c-c++/init-cc-mode ()

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -10,7 +10,8 @@
 ;;; License: GPLv3
 
 (setq clojure-packages
-      '(cider
+      '(
+        cider
         cider-eval-sexp-fu
         (clj-refactor :toggle clojure-enable-clj-refactor)
         clojure-cheatsheet
@@ -27,7 +28,8 @@
         popwin
         (sayid :toggle clojure-enable-sayid)
         smartparens
-        subword))
+        subword
+        ))
 
 
 (defun clojure/init-cider ()

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -10,7 +10,8 @@
 ;;; License: GPLv3
 
 (setq common-lisp-packages
-      '(auto-highlight-symbol
+      '(
+        auto-highlight-symbol
         (common-lisp-snippets :requires yasnippet)
         evil
         evil-cleverparens

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -10,16 +10,16 @@
 ;;; License: GPLv3
 
 (setq csharp-packages
-  '(
-    company
-    csharp-mode
-    evil-matchit
-    ggtags
-    counsel-gtags
-    helm-gtags
-    omnisharp
-    flycheck
-    ))
+      '(
+        company
+        csharp-mode
+        evil-matchit
+        ggtags
+        counsel-gtags
+        helm-gtags
+        omnisharp
+        flycheck
+        ))
 
 (defun csharp/init-omnisharp ()
   ;; Load omnisharp-mode with csharp-mode,

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -10,20 +10,20 @@
 ;;; License: GPLv3
 
 (setq elixir-packages
-  '(
-    alchemist
-    company
-    elixir-mode
-    flycheck
-    flycheck-mix
-    flycheck-credo
-    ggtags
-    counsel-gtags
-    helm-gtags
-    ob-elixir
-    popwin
-    smartparens
-    ))
+      '(
+        alchemist
+        company
+        elixir-mode
+        flycheck
+        flycheck-mix
+        flycheck-credo
+        ggtags
+        counsel-gtags
+        helm-gtags
+        ob-elixir
+        popwin
+        smartparens
+        ))
 
 (defun elixir/post-init-company ()
   (when (configuration-layer/package-used-p 'alchemist)

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -32,7 +32,8 @@
         parinfer
         semantic
         smartparens
-        srefactor))
+        srefactor
+        ))
 
 (defun emacs-lisp/init-ielm ()
   (use-package ielm

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -10,14 +10,14 @@
 ;;; License: GPLv3
 
 (setq erlang-packages
-  '(
-    company
-    erlang
-    ggtags
-    counsel-gtags
-    helm-gtags
-    flycheck
-    ))
+      '(
+        company
+        erlang
+        ggtags
+        counsel-gtags
+        helm-gtags
+        flycheck
+        ))
 
 (defun erlang/post-init-company ()
   (add-hook 'erlang-mode-hook 'company-mode))

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -15,7 +15,8 @@
         ess-R-data-view
         (ess-smart-equals :toggle ess-enable-smart-equals)
         golden-ratio
-        org))
+        org
+        ))
 
 (defun ess/init-ess ()
   (use-package ess-site

--- a/layers/+lang/factor/packages.el
+++ b/layers/+lang/factor/packages.el
@@ -2,7 +2,6 @@
 ;;
 ;; This file is not part of GNU Emacs.
 
-
 (defconst factor-packages
   '(
     ;; Assume that factor is installed, and emacs lisp files are correctly

--- a/layers/+lang/faust/packages.el
+++ b/layers/+lang/faust/packages.el
@@ -12,9 +12,11 @@
 ;;; Code:
 
 (defconst faust-packages
-  '(company
+  '(
+    company
     faust-mode
-    yasnippet))
+    yasnippet
+    ))
 
 (defun faust/post-init-company ()
   (spacemacs|add-company-backends :modes faust-mode))

--- a/layers/+lang/forth/packages.el
+++ b/layers/+lang/forth/packages.el
@@ -9,8 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(defconst forth-packages
-  '(forth-mode))
+(defconst forth-packages '(forth-mode))
 
 (defun forth/init-forth-mode ()
   (use-package forth-mode

--- a/layers/+lang/graphviz/packages.el
+++ b/layers/+lang/graphviz/packages.el
@@ -10,10 +10,12 @@
 ;;; License: GPLv3
 
 (defconst graphviz-packages
-  '((graphviz-dot-mode :location (recipe :fetcher github
+  '(
+    (graphviz-dot-mode :location (recipe :fetcher github
                                          :repo "luxbock/graphviz-dot-mode"))
     org
-    smartparens))
+    smartparens
+    ))
 
 (defun graphviz/init-graphviz-dot-mode ()
   (use-package graphviz-dot-mode

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -10,44 +10,44 @@
 ;;; License: GPLv3
 
 (setq haskell-packages
-  '(
-    cmm-mode
-    company
-    (company-cabal :requires company)
+      '(
+        cmm-mode
+        company
+        (company-cabal :requires company)
 
-    ;; ghci completion backend
-    (company-ghci
-     :requires company
-     :toggle (eq haskell-completion-backend 'ghci))
+        ;; ghci completion backend
+        (company-ghci
+         :requires company
+         :toggle (eq haskell-completion-backend 'ghci))
 
-    ;; ghc-mod completion backend
-    (company-ghc
-     :requires company
-     :toggle (eq haskell-completion-backend 'ghc-mod))
-    (ghc :toggle (eq haskell-completion-backend 'ghc-mod))
+        ;; ghc-mod completion backend
+        (company-ghc
+         :requires company
+         :toggle (eq haskell-completion-backend 'ghc-mod))
+        (ghc :toggle (eq haskell-completion-backend 'ghc-mod))
 
-    ;; intero completion backend
-    (intero
-     :requires company
-     :toggle (eq haskell-completion-backend 'intero))
+        ;; intero completion backend
+        (intero
+         :requires company
+         :toggle (eq haskell-completion-backend 'intero))
 
-    ;; dante completion backend
-    (dante
-     :requires company
-     :toggle (and (version<= "25" emacs-version)
-                  (eq haskell-completion-backend 'dante)))
+        ;; dante completion backend
+        (dante
+         :requires company
+         :toggle (and (version<= "25" emacs-version)
+                      (eq haskell-completion-backend 'dante)))
 
-    flycheck
-    (flycheck-haskell :requires flycheck)
-    ggtags
-    haskell-mode
-    haskell-snippets
-    counsel-gtags
-    helm-gtags
-    (helm-hoogle :requires helm)
-    hindent
-    hlint-refactor
-    ))
+        flycheck
+        (flycheck-haskell :requires flycheck)
+        ggtags
+        haskell-mode
+        haskell-snippets
+        counsel-gtags
+        helm-gtags
+        (helm-hoogle :requires helm)
+        hindent
+        hlint-refactor
+        ))
 
 (defun haskell/init-cmm-mode ()
   (use-package cmm-mode

--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -9,10 +9,12 @@
 ;;
 ;;; License: GPLv3
 
-(setq ipython-notebook-packages '(company
-                                  ein
-                                  ob-ipython
-                                  ))
+(setq ipython-notebook-packages
+      '(
+        company
+        ein
+        ob-ipython
+        ))
 
 (defun ipython-notebook/post-init-company ()
   (spacemacs|add-company-backends

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -29,7 +29,8 @@
         prettier-js
         skewer-mode
         tern
-        web-beautify))
+        web-beautify
+        ))
 
 (defun javascript/post-init-add-node-modules-path ()
   (spacemacs/add-to-hooks #'add-node-modules-path '(css-mode-hook

--- a/layers/+lang/json/packages.el
+++ b/layers/+lang/json/packages.el
@@ -9,7 +9,6 @@
 ;;
 ;;; License: GPLv3
 
-
 (setq json-packages
       '(
         add-node-modules-path

--- a/layers/+lang/jsonnet/packages.el
+++ b/layers/+lang/jsonnet/packages.el
@@ -9,7 +9,11 @@
 ;;
 ;;; License: GPLv3
 
-(setq jsonnet-packages '(jsonnet-mode flycheck))
+(setq jsonnet-packages
+      '(
+        jsonnet-mode
+        flycheck
+        ))
 
 (defun javascript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'jsonnet-mode))

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -10,17 +10,17 @@
 ;;; License: GPLv3
 
 (setq markdown-packages
-  '(
-    company
-    company-emoji
-    emoji-cheat-sheet-plus
-    gh-md
-    markdown-mode
-    markdown-toc
-    mmm-mode
-    smartparens
-    (vmd-mode :toggle (eq 'vmd markdown-live-preview-engine))
-    ))
+      '(
+        company
+        company-emoji
+        emoji-cheat-sheet-plus
+        gh-md
+        markdown-mode
+        markdown-toc
+        mmm-mode
+        smartparens
+        (vmd-mode :toggle (eq 'vmd markdown-live-preview-engine))
+        ))
 
 (defun markdown/post-init-company ()
   (dolist (mode markdown--key-bindings-modes)

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -1,8 +1,10 @@
 (setq nim-packages
-      '(company
+      '(
+        company
         flycheck
         flycheck-nim
-        nim-mode))
+        nim-mode
+        ))
 
 (defun nim/post-init-company ()
   (spacemacs|add-company-backends

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -10,20 +10,20 @@
 ;;; License: GPLv3
 
 (setq ocaml-packages
-  '(
-    ;; auto-complete
-    company
-    flycheck
-    flycheck-ocaml
-    ggtags
-    counsel-gtags
-    helm-gtags
-    merlin
-    ocp-indent
-    smartparens
-    tuareg
-    utop
-    ))
+      '(
+        ;; auto-complete
+        company
+        flycheck
+        flycheck-ocaml
+        ggtags
+        counsel-gtags
+        helm-gtags
+        merlin
+        ocp-indent
+        smartparens
+        tuareg
+        utop
+        ))
 
 (defun ocaml/post-init-company ()
   (when (configuration-layer/package-used-p 'merlin)

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -10,12 +10,12 @@
 ;;; License: GPLv3
 
 (setq octave-packages
-  '(
-    ggtags
-    counsel-gtags
-    helm-gtags
-    (octave :location built-in)
-    ))
+      '(
+        ggtags
+        counsel-gtags
+        helm-gtags
+        (octave :location built-in)
+        ))
 
 (defun octave/init-octave ()
   (use-package octave

--- a/layers/+lang/perl6/packages.el
+++ b/layers/+lang/perl6/packages.el
@@ -10,7 +10,8 @@
 ;;; License: GPLv3
 
 (defconst perl6-packages
-  '(company
+  '(
+    company
     evil
     flycheck
     (flycheck-perl6 :requires flycheck)

--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -13,11 +13,12 @@
 ;;
 ;;; License: GPLv3
 
-
 ;;; Code:
 (defconst plantuml-packages
-  '(org
-    plantuml-mode))
+  '(
+    org
+    plantuml-mode
+    ))
 
 (defun plantuml/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/protobuf/packages.el
+++ b/layers/+lang/protobuf/packages.el
@@ -10,10 +10,10 @@
 ;;; License: GPLv3
 
 (defconst protobuf-packages
-      '(
-        flycheck
-        protobuf-mode
-        ))
+  '(
+    flycheck
+    protobuf-mode
+    ))
 
 (defun protobuf/post-init-flycheck ()
   (spacemacs/enable-flycheck 'protobuf-mode))

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -9,14 +9,15 @@
 ;;
 ;;; License: GPLv3
 
-
 (setq purescript-packages
-  '(company
-    flycheck
-    purescript-mode
-    psci
-    psc-ide
-    popwin))
+      '(
+        company
+        flycheck
+        purescript-mode
+        psci
+        psc-ide
+        popwin
+        ))
 
 (defun purescript/post-init-company ()
   (when (configuration-layer/package-used-p 'psc-ide)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -10,41 +10,41 @@
 ;;; License: GPLv3
 
 (setq python-packages
-  '(
-    company
-    counsel-gtags
-    cython-mode
-    eldoc
-    evil-matchit
-    flycheck
-    ggtags
-    helm-cscope
-    helm-gtags
-    (helm-pydoc :requires helm)
-    importmagic
-    live-py-mode
-    (nose :location local)
-    org
-    pip-requirements
-    pipenv
-    pippel
-    py-isort
-    pyenv-mode
-    (pylookup :location local)
-    pytest
-    (python :location built-in)
-    pyvenv
-    semantic
-    smartparens
-    stickyfunc-enhance
-    xcscope
-    yapfify
-    ;; packages for anaconda backend
-    anaconda-mode
-    (company-anaconda :requires company)
-    ;; packages for lsp backend
-    (lsp-python :requires lsp-mode)
-    ))
+      '(
+        company
+        counsel-gtags
+        cython-mode
+        eldoc
+        evil-matchit
+        flycheck
+        ggtags
+        helm-cscope
+        helm-gtags
+        (helm-pydoc :requires helm)
+        importmagic
+        live-py-mode
+        (nose :location local)
+        org
+        pip-requirements
+        pipenv
+        pippel
+        py-isort
+        pyenv-mode
+        (pylookup :location local)
+        pytest
+        (python :location built-in)
+        pyvenv
+        semantic
+        smartparens
+        stickyfunc-enhance
+        xcscope
+        yapfify
+        ;; packages for anaconda backend
+        anaconda-mode
+        (company-anaconda :requires company)
+        ;; packages for lsp backend
+        (lsp-python :requires lsp-mode)
+        ))
 
 (defun python/init-anaconda-mode ()
   (use-package anaconda-mode

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -1,13 +1,13 @@
 (setq racket-packages
-  '(
-    company
-    company-quickhelp
-    ggtags
-    counsel-gtags
-    evil-cleverparens
-    helm-gtags
-    racket-mode
-    ))
+      '(
+        company
+        company-quickhelp
+        ggtags
+        counsel-gtags
+        evil-cleverparens
+        helm-gtags
+        racket-mode
+        ))
 
 (defun racket/post-init-company ()
   ;; this is the only thing to do to enable company in racket-mode

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -10,21 +10,21 @@
 ;;; License: GPLv3
 
 (setq rust-packages
-  '(
-    cargo
-    company
-    counsel-gtags
-    racer
-    flycheck
-    (flycheck-rust :requires flycheck)
-    ggtags
-    helm-gtags
-    rust-mode
-    smartparens
-    toml-mode
-    ;; packages for lsp-rust
-    (lsp-rust :requires lsp-mode)
-    ))
+      '(
+        cargo
+        company
+        counsel-gtags
+        racer
+        flycheck
+        (flycheck-rust :requires flycheck)
+        ggtags
+        helm-gtags
+        rust-mode
+        smartparens
+        toml-mode
+        ;; packages for lsp-rust
+        (lsp-rust :requires lsp-mode)
+        ))
 
 (defun rust/init-cargo ()
   (use-package cargo

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -10,19 +10,19 @@
 ;;; License: GPLv3
 
 (setq scala-packages
-  '(
-    eldoc
-    ensime
-    flycheck
-    flyspell
-    ggtags
-    counsel-gtags
-    helm-gtags
-    noflet
-    org
-    scala-mode
-    sbt-mode
-    ))
+      '(
+        eldoc
+        ensime
+        flycheck
+        flyspell
+        ggtags
+        counsel-gtags
+        helm-gtags
+        noflet
+        org
+        scala-mode
+        sbt-mode
+        ))
 
 (defun scala/post-init-eldoc ()
   (when scala-enable-eldoc

--- a/layers/+lang/semantic-web/packages.el
+++ b/layers/+lang/semantic-web/packages.el
@@ -10,11 +10,11 @@
 ;;; License: GPLv3
 
 (setq semantic-web-packages
-  '(
-    ttl-mode
-    sparql-mode
-    org
-    ))
+      '(
+        ttl-mode
+        sparql-mode
+        org
+        ))
 
 (defun semantic-web/init-ttl-mode ()
   (use-package ttl-mode

--- a/layers/+lang/sml/packages.el
+++ b/layers/+lang/sml/packages.el
@@ -10,11 +10,11 @@
 ;;; License: GPLv3
 
 (setq sml-packages
-  '(
-    sml-mode
-    ob-sml
-    smartparens
-    ))
+      '(
+        sml-mode
+        ob-sml
+        smartparens
+        ))
 
 (defun sml/init-sml-mode ()
   (use-package sml-mode


### PR DESCRIPTION
problem:
some layer packages lists have the open and closing parentheses on the same line
as the first and last listed package, but most seem to have them on a separate
lines.

solution:
put the open and close parentheses on separate lines, except for lists with only
a single package, they are written on the same line as the variable name and
parentheses.

fix the lists indentation