### PR TITLE
Update ess-disable-underscore-assign for ESS 18.10

### DIFF
--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -68,7 +68,7 @@
                  ess-nuke-trailing-whitespace-p t
                  ess-default-style 'DEFAULT)
            (when ess-disable-underscore-assign
-             (ess-toggle-underscore nil))
+             (setq ess-smart-S-assign-key nil))
 
            (define-key ess-doc-map "h" 'ess-display-help-on-object)
            (define-key ess-doc-map "p" 'ess-R-dv-pprint)


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/issues/11617#issuecomment-440272037

ess-disable-underscore-assign introduced via #9102 relies on functionality deprecated in ESS 18.10. The deprecated functionality may be removed from ESS soon and as melpa follows ESS master branch, spacemacs should be adapted.