### PR TITLE
keyboard-layout: add evil-cleverparens remapping

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -17,6 +17,7 @@
     company
     elfeed
     evil
+    evil-cleverparens
     evil-escape
     evil-evilified-state
     evil-magit
@@ -203,6 +204,20 @@
     (progn
       (define-key evil-normal-state-map "K" nil)
       (define-key evil-normal-state-map "L" 'spacemacs/evil-smart-doc-lookup))))
+
+(defun keyboard-layout/pre-init-evil-cleverparens ()
+  (kl|config evil-cleverparens
+    :description
+    "Remap `evil-cleverparens' bindings."
+    :loader
+    ;; (spacemacs|use-package-add-hook evil-cleverparens :post-init BODY)
+    (with-eval-after-load 'evil-cleverparens BODY)
+    :common
+    (kl/evil-correct-keys 'normal evil-cleverparens-mode-map
+      "h"
+      "j"
+      "k"
+      "l")))
 
 (defun keyboard-layout/pre-init-evil-escape ()
   (kl|config evil-escape


### PR DESCRIPTION
When you use structurally safe editing, cleverparens is called and provides a different keymap that isn't remapped by keyboard-layout machinery. This problem is stated in #10174 . 

This PR opens the remapping for evil-cleverparens. As I do not use it myself, I think I didn't remap many of important movement bindings. Currently it provides a basic support for HJKL. 

Ideas of keys remapping are welcomed. 