### PR TITLE
ported Info-find-file from emacs 27 by adding third argument

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/local/info+/info+.el
+++ b/layers/+spacemacs/spacemacs-navigation/local/info+/info+.el
@@ -2572,10 +2572,13 @@ form: `(MANUAL) NODE' (e.g.,`(emacs) Modes')."
 ;;
 (when (or (> emacs-major-version 23)  (and (= emacs-major-version 23)  (> emacs-minor-version 1)))
 
-  (defun Info-find-file (filename &optional noerror)
+  (defun Info-find-file (filename &optional noerror no-pop-to-dir)
     "Return expanded FILENAME, or t if FILENAME is \"dir\".
 Optional second argument NOERROR, if t, means if file is not found
-just return nil (no error)."
+just return nil (no error).
+
+If NO-POP-TO-DIR, don't try to pop to the info buffer if we can't
+find a node."
     ;; Convert filename to lower case if not found as specified.
     ;; Expand it.
     (cond
@@ -2617,7 +2620,10 @@ just return nil (no error)."
              (setq filename  found)
            (if noerror
                (setq filename  nil)
-             (unless Info-current-file (Info-directory)) ; If no previous Info file, go to directory.
+	     ;; If there is no previous Info file, go to the directory.
+             (when (and (not no-pop-to-dir)
+                        (not Info-current-file))
+	       (Info-directory))
              (info-user-error "Info file `%s' does not exist" filename)))
          filename))
       ((member filename '(apropos history toc))  filename))) ; Handle virtual books - `toc'.


### PR DESCRIPTION
Emacs 27 (not yet release version found on master branch of emacs repo)
 added 3rd optional argument to Info-find-file.
However Info-find-file found in info+ local package has only two.
This causes failures in how I use info mode.
Given that the new argument is benign, and Info-find-file is pretty much identical
to Info-find-file found in emacs, this change should be very safe change which
makes the package work for emacs 27 as well as older emacs.

Should I try to get this patch applied to Drew's (the author of info+) version first, 
then try to have that version propagated to spacemacs?
