### PR TITLE
Add variables to enable emojify-mode, erc-image, erc-tweet, erc-yt, and rcirc-styles in rcirc layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1812,6 +1812,8 @@ Other:
 **** Rcirc
 - New variable =rcirc-enable-late-fix= to enable or disable the included
   =rcirc-late-fix= package (disabled by default).
+- New variable =rcirc-enable-emojify= to enable or disable emojify-mode
+  in rcirc buffers (disabled by default).
 - Fixed using multiple lines in =.authinfo= (thanks to Jelle Licht)
 - Fixed logging where the channel name has =/= in it (thanks to Abdo
   Roig-Maranges)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1821,6 +1821,8 @@ Other:
   package in rcirc for showing linked images in chat (disabled by default).
 - New variable =rcirc-enable-erc-tweet= to enable or disable the =erc-tweet=
   package in rcirc for showing linked tweets in chat (disabled by default).
+- New variable =rcirc-enable-erc-yt= to enable or disable the =erc-yt= package
+  in rcirc for showing previews for YouTube links (disabled by default).
 - Fixed using multiple lines in =.authinfo= (thanks to Jelle Licht)
 - Fixed logging where the channel name has =/= in it (thanks to Abdo
   Roig-Maranges)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1817,6 +1817,8 @@ Other:
 - New variable =rcirc-enable-styles= to enable or disable the =rcirc-styles=
   package for displaying and inserting color and text attribute codes (disabled
   by default).
+- New variable =rcirc-enable-erc-image= to enable or disable the =erc-image=
+  package in rcirc for showing linked images in chat (disabled by default).
 - Fixed using multiple lines in =.authinfo= (thanks to Jelle Licht)
 - Fixed logging where the channel name has =/= in it (thanks to Abdo
   Roig-Maranges)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1819,6 +1819,8 @@ Other:
   by default).
 - New variable =rcirc-enable-erc-image= to enable or disable the =erc-image=
   package in rcirc for showing linked images in chat (disabled by default).
+- New variable =rcirc-enable-erc-tweet= to enable or disable the =erc-tweet=
+  package in rcirc for showing linked tweets in chat (disabled by default).
 - Fixed using multiple lines in =.authinfo= (thanks to Jelle Licht)
 - Fixed logging where the channel name has =/= in it (thanks to Abdo
   Roig-Maranges)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1814,6 +1814,9 @@ Other:
   =rcirc-late-fix= package (disabled by default).
 - New variable =rcirc-enable-emojify= to enable or disable emojify-mode
   in rcirc buffers (disabled by default).
+- New variable =rcirc-enable-styles= to enable or disable the =rcirc-styles=
+  package for displaying and inserting color and text attribute codes (disabled
+  by default).
 - Fixed using multiple lines in =.authinfo= (thanks to Jelle Licht)
 - Fixed logging where the channel name has =/= in it (thanks to Abdo
   Roig-Maranges)

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -19,6 +19,7 @@
   - [[#enabling-sfoobar][Enabling =s/foo/bar/=]]
   - [[#enabling-emojify-mode][Enabling emojify-mode]]
   - [[#enabling-erc-image][Enabling erc-image]]
+  - [[#enabling-erc-tweet][Enabling erc-tweet]]
   - [[#enabling-rcirc-styles][Enabling rcirc-styles]]
 - [[#key-bindings][Key bindings]]
 - [[#rcirc-documentation][Rcirc documentation]]
@@ -195,6 +196,15 @@ chat, set the variable =rcirc-enable-erc-image= to =t= in your dotfile:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (rcirc :variables rcirc-enable-erc-image t)))
+#+END_SRC
+
+** Enabling erc-tweet
+To enable erc-tweet for fetching and displaying tweets when they are linked in
+chat, set the variable =rcirc-enable-erc-tweet= to =t= in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (rcirc :variables rcirc-enable-erc-tweet t)))
 #+END_SRC
 
 ** Enabling rcirc-styles

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -17,6 +17,7 @@
       - [[#disclaimer][Disclaimer]]
       - [[#note][Note]]
   - [[#enabling-sfoobar][Enabling =s/foo/bar/=]]
+  - [[#enabling-emojify-mode][Enabling emojify-mode]]
 - [[#key-bindings][Key bindings]]
 - [[#rcirc-documentation][Rcirc documentation]]
 - [[#spacemacs-layout-support][Spacemacs Layout Support]]
@@ -174,6 +175,15 @@ variable =rcirc-enable-late-fix= to =t= in your dotfile:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (rcirc :variables rcirc-enable-late-fix t)))
+#+END_SRC
+
+** Enabling emojify-mode
+To enable emojify-mode in rcirc buffers, set the variable =rcirc-enable-emojify=
+to =t= in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (rcirc :variables rcirc-enable-emojify t)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -18,6 +18,7 @@
       - [[#note][Note]]
   - [[#enabling-sfoobar][Enabling =s/foo/bar/=]]
   - [[#enabling-emojify-mode][Enabling emojify-mode]]
+  - [[#enabling-erc-image][Enabling erc-image]]
   - [[#enabling-rcirc-styles][Enabling rcirc-styles]]
 - [[#key-bindings][Key bindings]]
 - [[#rcirc-documentation][Rcirc documentation]]
@@ -185,6 +186,15 @@ to =t= in your dotfile:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (rcirc :variables rcirc-enable-emojify t)))
+#+END_SRC
+
+** Enabling erc-image
+To enable erc-image for fetching and showing images when they are linked to in
+chat, set the variable =rcirc-enable-erc-image= to =t= in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (rcirc :variables rcirc-enable-erc-image t)))
 #+END_SRC
 
 ** Enabling rcirc-styles

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -20,6 +20,7 @@
   - [[#enabling-emojify-mode][Enabling emojify-mode]]
   - [[#enabling-erc-image][Enabling erc-image]]
   - [[#enabling-erc-tweet][Enabling erc-tweet]]
+  - [[#enabling-erc-yt][Enabling erc-yt]]
   - [[#enabling-rcirc-styles][Enabling rcirc-styles]]
 - [[#key-bindings][Key bindings]]
 - [[#rcirc-documentation][Rcirc documentation]]
@@ -205,6 +206,15 @@ chat, set the variable =rcirc-enable-erc-tweet= to =t= in your dotfile:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (rcirc :variables rcirc-enable-erc-tweet t)))
+#+END_SRC
+
+** Enabling erc-yt
+To enable erc-yt for fetching and displaying previews for YouTube links in chat,
+set the variable =rcirc-enable-erc-yt= to =t= in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (rcirc :variables rcirc-enable-erc-yt t)))
 #+END_SRC
 
 ** Enabling rcirc-styles

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -18,6 +18,7 @@
       - [[#note][Note]]
   - [[#enabling-sfoobar][Enabling =s/foo/bar/=]]
   - [[#enabling-emojify-mode][Enabling emojify-mode]]
+  - [[#enabling-rcirc-styles][Enabling rcirc-styles]]
 - [[#key-bindings][Key bindings]]
 - [[#rcirc-documentation][Rcirc documentation]]
 - [[#spacemacs-layout-support][Spacemacs Layout Support]]
@@ -186,12 +187,24 @@ to =t= in your dotfile:
     (rcirc :variables rcirc-enable-emojify t)))
 #+END_SRC
 
+** Enabling rcirc-styles
+To enable rcirc-styles for displaying and inserting color and text attribute
+codes, set the variable =rcirc-enable-styles= to =t= in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (rcirc :variables rcirc-enable-styles t)))
+#+END_SRC
+
 * Key bindings
 
 | Key binding | Description                                                                   |
 |-------------+-------------------------------------------------------------------------------|
 | ~SPC a i r~ | Open rcirc                                                                    |
 | ~SPC l o i~ | Open rcirc in a custom perspective “@RICRC” (need perspectives layer enabled) |
+| ~SPC m i a~ | Interactively insert a color code (if rcirc-styles is enabled)                |
+| ~SPC m i c~ | Interactively insert a text attribute code (if rcirc-styles is enabled)       |
+| ~SPC m i p~ | Toggle preview in input line (if rcirc-styles is enabled)                     |
 
 In normal state:
 

--- a/layers/+chat/rcirc/config.el
+++ b/layers/+chat/rcirc/config.el
@@ -17,6 +17,9 @@
 (defvar rcirc-enable-emojify nil
   "if non nil then automatically enable emojify-mode in rcirc buffers.")
 
+(defvar rcirc-enable-erc-image nil
+  "if non nil then enable erc-image to display images in rcirc.")
+
 (defvar rcirc-enable-late-fix nil
   "if non nil then enable rcirc-late-fix to show s/// fixes in rcirc buffers.")
 

--- a/layers/+chat/rcirc/config.el
+++ b/layers/+chat/rcirc/config.el
@@ -14,6 +14,9 @@
 (defvar rcirc-enable-authinfo-support nil
   "if non nil then authentication uses authinfo.")
 
+(defvar rcirc-enable-emojify nil
+  "if non nil then automatically enable emojify-mode in rcirc buffers.")
+
 (defvar rcirc-enable-late-fix nil
   "if non nil then enable rcirc-late-fix to show s/// fixes in rcirc buffers.")
 

--- a/layers/+chat/rcirc/config.el
+++ b/layers/+chat/rcirc/config.el
@@ -20,6 +20,9 @@
 (defvar rcirc-enable-late-fix nil
   "if non nil then enable rcirc-late-fix to show s/// fixes in rcirc buffers.")
 
+(defvar rcirc-enable-styles nil
+  "if non nil then enable rcirc-styles to parse style markup codes in rcirc.")
+
 (defvar rcirc-enable-znc-support nil
   "if non nil then znc is enabled.")
 

--- a/layers/+chat/rcirc/config.el
+++ b/layers/+chat/rcirc/config.el
@@ -20,6 +20,9 @@
 (defvar rcirc-enable-erc-image nil
   "if non nil then enable erc-image to display images in rcirc.")
 
+(defvar rcirc-enable-erc-tweet nil
+  "if non nil then enable erc-tweet to display tweets in rcirc.")
+
 (defvar rcirc-enable-late-fix nil
   "if non nil then enable rcirc-late-fix to show s/// fixes in rcirc buffers.")
 

--- a/layers/+chat/rcirc/config.el
+++ b/layers/+chat/rcirc/config.el
@@ -23,6 +23,9 @@
 (defvar rcirc-enable-erc-tweet nil
   "if non nil then enable erc-tweet to display tweets in rcirc.")
 
+(defvar rcirc-enable-erc-yt nil
+  "if non nil then enable erc-yt to display YouTube previews in rcirc.")
+
 (defvar rcirc-enable-late-fix nil
   "if non nil then enable rcirc-late-fix to show s/// fixes in rcirc buffers.")
 

--- a/layers/+chat/rcirc/funcs.el
+++ b/layers/+chat/rcirc/funcs.el
@@ -174,8 +174,11 @@ This doesn't support the chanserv auth method. "
 ;; erc-image -----------------------------------------------------------------
 
 (defun spacemacs//rcirc-image-show-url (_sender _response)
-  ;; erc-image's url-queue callback uses erc-fill-prefix, so it must be bound
-  ;; when the callback runs (it would not suffice simply to let-bind it here).
   (unless (boundp 'erc-fill-prefix)
     (setq erc-fill-prefix rcirc-fill-prefix))
   (erc-image-show-url))
+
+;; erc-tweet --------------------------------------------------------------------
+
+(defun spacemacs//rcirc-tweet-show-tweet (_sender _response)
+  (erc-tweet-show-tweet))

--- a/layers/+chat/rcirc/funcs.el
+++ b/layers/+chat/rcirc/funcs.el
@@ -170,3 +170,12 @@ This doesn't support the chanserv auth method. "
                 (rcirc-connect host port nick user-name
                                full-name channels password encryption)))
            (process-put process :rcirc-server server)))))))
+
+;; erc-image -----------------------------------------------------------------
+
+(defun spacemacs//rcirc-image-show-url (_sender _response)
+  ;; erc-image's url-queue callback uses erc-fill-prefix, so it must be bound
+  ;; when the callback runs (it would not suffice simply to let-bind it here).
+  (unless (boundp 'erc-fill-prefix)
+    (setq erc-fill-prefix rcirc-fill-prefix))
+  (erc-image-show-url))

--- a/layers/+chat/rcirc/funcs.el
+++ b/layers/+chat/rcirc/funcs.el
@@ -178,6 +178,11 @@ This doesn't support the chanserv auth method. "
     (setq erc-fill-prefix rcirc-fill-prefix))
   (erc-image-show-url))
 
+;; erc-yt --------------------------------------------------------------------
+
+(defun spacemacs//rcirc-youtube-show-info (_sender _response)
+  (erc-yt-show-info))
+
 ;; erc-tweet --------------------------------------------------------------------
 
 (defun spacemacs//rcirc-tweet-show-tweet (_sender _response)

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -14,6 +14,7 @@
         company
         company-emoji
         emoji-cheat-sheet-plus
+        emojify
         flyspell
         (helm-rcirc :location local
                     :requires helm)
@@ -33,6 +34,13 @@
 
 (defun rcirc/post-init-emoji-cheat-sheet-plus ()
   (add-hook 'rcirc-mode-hook 'emoji-cheat-sheet-plus-display-mode))
+
+(defun rcirc/post-init-emojify ()
+  (spacemacs|use-package-add-hook rcirc
+    :post-config
+    (use-package emojify
+      :hook (rcirc-mode . emojify-mode)
+      :if rcirc-enable-emojify)))
 
 (defun rcirc/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'rcirc-mode-hook))

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -17,6 +17,7 @@
         emojify
         (erc-image :toggle rcirc-enable-erc-image)
         (erc-tweet :toggle rcirc-enable-erc-tweet)
+        (erc-yt :toggle rcirc-enable-erc-yt)
         flyspell
         (helm-rcirc :location local
                     :requires helm)
@@ -68,6 +69,18 @@
               (make-directory erc-tweet-cache-dir t)
               (add-hook 'rcirc-markup-text-functions
                         #'spacemacs//rcirc-tweet-show-tweet)))))
+
+(defun rcirc/init-erc-yt ()
+  (spacemacs|use-package-add-hook rcirc
+    :post-config
+    (use-package erc-yt
+      :if rcirc-enable-erc-yt
+      :init
+      (with-eval-after-load 'rcirc
+        (setq erc-yt-cache-dir (concat spacemacs-cache-directory "erc-yt/"))
+        (make-directory erc-yt-cache-dir t)
+        (add-hook 'rcirc-markup-text-functions
+                  #'spacemacs//rcirc-youtube-show-info)))))
 
 (defun rcirc/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'rcirc-mode-hook))

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -15,6 +15,7 @@
         company-emoji
         emoji-cheat-sheet-plus
         emojify
+        (erc-image :toggle rcirc-enable-erc-image)
         flyspell
         (helm-rcirc :location local
                     :requires helm)
@@ -42,6 +43,18 @@
     (use-package emojify
       :hook (rcirc-mode . emojify-mode)
       :if rcirc-enable-emojify)))
+
+(defun rcirc/init-erc-image ()
+  (spacemacs|use-package-add-hook rcirc
+    :post-config
+    (use-package erc-image
+      :if rcirc-enable-erc-image
+      :init (with-eval-after-load 'rcirc
+              (setq erc-image-images-path (concat spacemacs-cache-directory
+                                                  "erc-image/"))
+              (make-directory erc-image-images-path t)
+              (add-hook 'rcirc-markup-text-functions
+                        #'spacemacs//rcirc-image-show-url)))))
 
 (defun rcirc/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'rcirc-mode-hook))

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -114,14 +114,14 @@
 
       (spacemacs/set-leader-keys "air" 'spacemacs/rcirc)
       (spacemacs/declare-prefix "ai"  "irc")
-      (evil-set-initial-state 'rcirc-mode 'insert))
+      (evil-set-initial-state 'rcirc-mode 'insert)
       (setq rcirc-fill-column 80
             rcirc-buffer-maximum-lines 2048
             rcirc-omit-responses '("JOIN" "PART" "QUIT" "NICK" "AWAY" "MODE")
             rcirc-time-format "%Y-%m-%d %H:%M "
             rcirc-omit-threshold 20
             rcirc-log-directory (concat spacemacs-cache-directory "/rcirc-logs/")
-            rcirc-log-flag t)
+            rcirc-log-flag t))
     :config
     (progn
       ;; (set-input-method "latin-1-prefix")

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -24,6 +24,7 @@
         (rcirc-late-fix :location local
                         :toggle rcirc-enable-late-fix)
         rcirc-notify
+        (rcirc-styles :toggle rcirc-enable-styles)
         ))
 
 (defun rcirc/post-init-company ()
@@ -110,7 +111,14 @@
       ;; dependencies
       ;; will autoload rcirc-notify
       (rcirc-notify-add-hooks)
-      (require 'rcirc-color))))
+      (require 'rcirc-color)
+      (when rcirc-enable-styles
+        (require 'rcirc-styles)
+        (spacemacs/declare-prefix-for-mode 'rcirc-mode "mi" "insert")
+        (spacemacs/set-leader-keys-for-major-mode 'rcirc-mode
+          "ic" 'rcirc-styles-insert-color
+          "ia" 'rcirc-styles-insert-attribute
+          "ip" 'rcirc-styles-toggle-preview)))))
 
 (defun rcirc/init-rcirc-color ()
   (use-package rcirc-color :defer t))
@@ -120,6 +128,9 @@
     :post-config
     (when rcirc-enable-late-fix
       (use-package rcirc-late-fix))))
+
+(defun rcirc/init-rcirc-styles ()
+  (use-package rcirc-styles))
 
 (defun rcirc/init-rcirc-notify ()
   (use-package rcirc-notify

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -16,6 +16,7 @@
         emoji-cheat-sheet-plus
         emojify
         (erc-image :toggle rcirc-enable-erc-image)
+        (erc-tweet :toggle rcirc-enable-erc-tweet)
         flyspell
         (helm-rcirc :location local
                     :requires helm)
@@ -55,6 +56,18 @@
               (make-directory erc-image-images-path t)
               (add-hook 'rcirc-markup-text-functions
                         #'spacemacs//rcirc-image-show-url)))))
+
+(defun rcirc/init-erc-tweet ()
+  (spacemacs|use-package-add-hook rcirc
+    :post-config
+    (use-package erc-tweet
+      :if rcirc-enable-erc-tweet
+      :init (with-eval-after-load 'rcirc
+              (setq erc-tweet-cache-dir (concat spacemacs-cache-directory
+                                                "erc-tweet/"))
+              (make-directory erc-tweet-cache-dir t)
+              (add-hook 'rcirc-markup-text-functions
+                        #'spacemacs//rcirc-tweet-show-tweet)))))
 
 (defun rcirc/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'rcirc-mode-hook))


### PR DESCRIPTION
Add some configuration variables to trick out rcirc:

* Add a variable `rcirc-enable-emojify` to enable [emojify-mode](https://melpa.org/#/emojify) in rcirc buffers.
* Add a variable `rcirc-enable-styles` to enable the [rcirc-styles](https://melpa.org/#/rcirc-styles) package for displaying and inserting color and text attribute codes.
* Add a variable `rcirc-enable-erc-image` to enable the [erc-image](https://melpa.org/#/erc-image) package in rcirc for showing linked images in chat.
* Add a variable `rcirc-enable-erc-tweet` to enable the [erc-tweet](https://melpa.org/#/erc-tweet) package in rcirc for showing linked tweets in chat.
* Add a variable `rcirc-enable-erc-yt` to enable the [erc-yt](https://melpa.org/#/erc-yt) package in rcirc for showing previews for YouTube links.
* Fix a misplaced parenthesis in the `:init` form in `rcirc/init-rcirc`.

I have been using these features for about a year, and they work well for me (aside from Emacs issue [https://debbugs.gnu.org/cgi/bugreport.cgi?bug=33145](#33145), which was causing duplicate previews from erc-yt till it was fixed recently).