### PR TITLE
spacemacs-layouts: Add project buffers to new persp

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -500,6 +500,7 @@ Other:
   - Fixed bug that could overwrites customize variables (thanks to bmag)
   - Don't suggest ~SPC q r~ if =restart-emacs= package is missing after an
     update (thanks to Keshav Kini)
+  - spacemacs-layouts: Add Projectile project buffers to new perspectives.
   - Resolve symlinks in warning message about duplicate layers
     (thanks to Ben Gamari)
   - Check toggle condition in status function (thanks to Eivind Fonn)

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -689,3 +689,11 @@ containing the buffer."
                (append (persp-parameter 'gui-eyebrowse-window-configs persp)
                        (persp-parameter 'term-eyebrowse-window-configs persp)))
         (eyebrowse--rename-window-config-buffers window-config old new)))))
+
+
+;; Persp and Projectile integration
+
+(defun spacemacs//add-project-buffers-to-persp (persp _persp-hash)
+  (if-let ((buffers (and (projectile-project-p)
+                         (projectile-project-buffers))))
+      (persp-add-buffer buffers persp nil nil)))

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -220,6 +220,8 @@
       (defadvice persp-activate (before spacemacs//save-toggle-layout activate)
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
+      (add-hook 'persp-created-functions
+                #'spacemacs//add-project-buffers-to-persp)
       (advice-add 'persp-load-state-from-file :before 'spacemacs//layout-wait-for-modeline)
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys


### PR DESCRIPTION
Fix issue #11282.

When a new perspective (layout) is created and we are in a Projectile project, add all buffers belonging to that project to the perspective.

* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs//add-project-buffers-to-persp`): Add new function.
* `layers/+spacemacs/spacemacs-layouts/packages.el` (`spacemacs-layouts/init-persp-mode`): Add `spacemacs//add-project-buffers-to-persp` to `persp-created-functions`.
