### PR TITLE
Fix sort in insert-lazy-install-configuration

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -489,6 +489,8 @@ Other:
     to Sylvain Benner)
   - New function =configuration-layer/load-file= to load files silently (thanks
     to Sylvain Benner)
+  - Fix configuration-layer/insert-lazy-install-configuration, which has been
+    broken since v0.200.0.
   - Fixed duplicate "Open quick help..." in the minibuffer at startup (thanks to
     Sylvain Benner)
   - Fixed overflow of line in page-break-lines-mode when using line number

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2421,10 +2421,7 @@ depends on it."
   (let ((layer-name
          (intern (completing-read
                   "Choose a used layer"
-                  (sort configuration-layer--used-layers
-                        (lambda (x y)
-                          (string< (oref (cdr x) :name)
-                                   (oref (cdr y) :name))))))))
+                  (sort (copy-list configuration-layer--used-layers) #'string<)))))
     (let ((mode-exts (configuration-layer//lazy-install-extensions-for-layer
                       layer-name)))
       (dolist (x mode-exts)


### PR DESCRIPTION
Commit 1c4f685b13ab606f7ad71299547d22cf3eec6cc2 replaced `configuration-layer--layers` (a list of `cfgl-layer` objects) with `configuration-layer--used-layers` (a list of symbols).  It also changed the `configuration-layer/insert-lazy-install-configuration` function to use the new variable, but it did not change the sort predicate.  Consequently, the function started failing:

    Wrong type argument: listp, spacemacs-purpose

In addition, because `sort` is destructive, the function also deleted values from `configuration-layer--used-layers`.

 This commit fixes the sort predicate so that the function returns the correct value, and it copies the list before sorting to avoid modifying `configuration-layer--used-layers`.

* `core/core-configuration-layer.el` (`configuration-layer/insert-lazy-install-configuration`): Use `string<` as the sort predicate, and give `sort` a copy of the list.