### PR TITLE
Set default shell on Pylookup makefile

### DIFF
--- a/layers/+lang/python/local/pylookup/makefile
+++ b/layers/+lang/python/local/pylookup/makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/sh
 VER := $(shell python --version 2>&1 | grep -o "[0-9].[0-9].[0-9]*")
 MAJOR_VERSION = $(shell python --version 2>&1 | grep -o "Python [0-9]" | grep -o "[0-9]")
 ZIP := python-${VER}-docs-html.zip


### PR DESCRIPTION
This should fix #11647