### PR TITLE
Update Hy key maps and `use-package` settings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1486,6 +1486,10 @@ Other:
 - Added missing prefixes for =web-mode= and =css-mode= (thanks to Uroš Perišić)
 **** Hy
 - Added support for virtual envs (thanks to Danny Freeman)
+- Key bindings:
+  - Added ~SPC m h~ prefix for =help=
+  - Added ~SPC m e~ prefix to mirror the eval bindings of other Lisps
+  - Changed ~SPC m s s~ (i.e. =start-or-switch-to-shell=) to ~SPC m '~
 **** Idris
 - Update author email for Idris layer (thanks to Timothy Jones)
 - Enabled =idris-simple-indent= (thanks to Xuan Bi)

--- a/layers/+lang/hy/packages.el
+++ b/layers/+lang/hy/packages.el
@@ -34,23 +34,34 @@
 (defun hy/init-hy-mode ()
   (use-package hy-mode
     :defer t
-    :init
+    :mode ("\\.hy\\'" . hy-mode)
+    :interpreter ("hy" . hy-mode)
+    :config
     (progn
-      ;; need to do this as they are not auloaded by the package
-      (add-to-list 'auto-mode-alist '("\\.hy\\'" . hy-mode))
-      (add-to-list 'interpreter-mode-alist '("hy" . hy-mode))
       ;; Disable this unless using special branch
       (setq hy-shell-use-control-codes? nil)
       ;; key bindings
-      (spacemacs/declare-prefix-for-mode 'hy-mode "me" "eval")
       (spacemacs/declare-prefix-for-mode 'hy-mode "md" "debug")
       (spacemacs/declare-prefix-for-mode 'hy-mode "mt" "test")
+      (spacemacs/declare-prefix-for-mode 'hy-mode "me" "eval")
       (spacemacs/declare-prefix-for-mode 'hy-mode "ms" "REPL")
       (spacemacs/declare-prefix-for-mode 'hy-mode "mv" "pyvenv")
+      (spacemacs/declare-prefix-for-mode 'hy-mode "mh" "help")
       (spacemacs/set-leader-keys-for-major-mode 'hy-mode
+        "'" 'hy-shell-start-or-switch-to-shell
+
         "dd" 'hy-insert-pdb
         "dt" 'hy-insert-pdb-threaded
         "hh" 'hy-describe-thing-at-point
+
+        "eb" 'hy-shell-eval-buffer
+        "eB" 'spacemacs/hy-shell-eval-buffer-and-go
+        "ec" 'hy-shell-eval-current-form
+        "eC" 'spacemacs/hy-shell-eval-current-form-and-go
+        "ei" 'hy-shell-start-or-switch-to-shell
+        "er" 'hy-shell-eval-region
+        "eR" 'spacemacs/hy-shell-eval-region-and-go
+
         "sb" 'hy-shell-eval-buffer
         "sB" 'spacemacs/hy-shell-eval-buffer-and-go
         "sc" 'hy-shell-eval-current-form
@@ -58,7 +69,7 @@
         "si" 'hy-shell-start-or-switch-to-shell
         "sr" 'hy-shell-eval-region
         "sR" 'spacemacs/hy-shell-eval-region-and-go
-        "ss" 'hy-shell-start-or-switch-to-shell
+
         "tA" 'spacemacs/python-test-pdb-all
         "ta" 'spacemacs/python-test-all
         "tM" 'spacemacs/python-test-pdb-module


### PR DESCRIPTION
These changes adjust the `hy-mode` key-map and make use of `use-package`'s `:mode` and `:interpreter` settings.

Regarding key-maps, the REPL prefix `s` has been added alongside `e`, since `s` seems at least as conventional among layers as `e`.  For example, `e` is used for Elisp and Clojure, while `s` is used by Python and Racket.  Scheme appears to use both, so there's some precedence for the approach taken here.