### PR TITLE
ivy: remove evil and helm-make from ivy layer

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -15,7 +15,9 @@
         bookmark
         counsel
         counsel-projectile
+	(evil :toggle (dotspacemacs-editing-style 'evil))
         flx
+	(helm :toggle (configuration-layer/package-used-p 'helm-make))
         imenu
         ivy
         ivy-hydra
@@ -26,7 +28,7 @@
         persp-mode
         projectile
         recentf
-        smex
+        (smex :toggle (configuration-layer/package-used-p 'smex))
         swiper
         wgrep
         ))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -15,9 +15,7 @@
         bookmark
         counsel
         counsel-projectile
-        evil
         flx
-        helm-make
         imenu
         ivy
         ivy-hydra


### PR DESCRIPTION
The `evil` and `helm-make` are not necessary for `ivy` layer, especially if someone is using `emacs` style. This dependencies (evil and helm-make) are included anyway if one is using evil and helm layers.