### PR TITLE
add lsp-javascript-flow to javascript-backends

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -12,13 +12,15 @@
   - [[#choosing-a-formatter][Choosing a formatter]]
 - [[#backends][Backends]]
   - [[#tern][Tern]]
-  - [[#language-server-protocol][Language Server Protocol]]
+  - [[#language-server-protocol-typescript][Language Server Protocol: typescript]]
+  - [[#language-server-protocol-flow][Language Server Protocol: flow]]
 - [[#configuration][Configuration]]
   - [[#indentation][Indentation]]
   - [[#repl][REPL]]
   - [[#node-modules][Node Modules]]
 - [[#key-bindings][Key Bindings]]
   - [[#js2-mode][js2-mode]]
+  - [[#lsp-flow][lsp-flow]]
   - [[#folding-js2-mode][Folding (js2-mode)]]
   - [[#refactoring-js2-refactor][Refactoring (js2-refactor)]]
     - [[#documentation-js-doc][Documentation (js-doc)]]
@@ -103,12 +105,21 @@ Formatter can be chosen on a per project basis using directory local variables
 ** Tern
 See [[file:../../+tools/tern/README.org][tern layer]] documentation.
 
-** Language Server Protocol
+** Language Server Protocol: typescript
 You just have to install javascript and typescript language server packages:
 
 #+BEGIN_SRC sh
   npm i -g typescript javascript-typescript-langserver
 #+END_SRC
+
+** Language Server Protocol: flow
+You just have to install flow-bin and flow language server packages:
+
+#+BEGIN_SRC sh
+  npm i -g flow-bin flow-language-server
+#+END_SRC
+
+
 
 * Configuration
 ** Indentation
@@ -163,6 +174,12 @@ doing this [[https://stackoverflow.com/questions/9679932#comment33532258_9683472
 |-------------+--------------------------------------|
 | ~SPC m w~   | toggle js2-mode warnings and errors  |
 | ~%~         | jump between blockswith [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] |
+
+** lsp-flow
+
+| Key Binding | Description                                        |
+|-------------+----------------------------------------------------|
+| C-c C-j     | jump to definition (flow-minor-jump-to-definition) |
 
 ** Folding (js2-mode)
 

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -16,13 +16,26 @@
   "Conditionally setup javascript backend."
   (pcase javascript-backend
     (`tern (spacemacs//javascript-setup-tern))
+    (`lsp-flow (spacemacs//javascript-setup-lsp-flow))
     (`lsp (spacemacs//javascript-setup-lsp))))
 
 (defun spacemacs//javascript-setup-company ()
   "Conditionally setup company based on backend."
   (pcase javascript-backend
     (`tern (spacemacs//javascript-setup-tern-company))
+    (`lsp-flow (spacemacs//javascript-setup-lsp-company))
     (`lsp (spacemacs//javascript-setup-lsp-company))))
+
+
+;; lsp-flow
+
+(defun spacemacs//javascript-setup-lsp-flow ()
+  "Setup lsp backend."
+  (flow-minor-mode)
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp-javascript-flow-enable)
+    (message (concat "`lsp' layer is not installed, "
+                     "please add `lsp' layer to your dotfile."))))
 
 
 ;; lsp

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -33,7 +33,7 @@
   "Setup lsp backend."
   (flow-minor-mode)
   (if (configuration-layer/layer-used-p 'lsp)
-      (lsp-javascript-flow-enable)
+      (lsp)
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
 

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -26,7 +26,6 @@
         livid-mode
         (lsp-javascript-typescript :requires lsp-mode)
         flow-minor-mode
-        (lsp-javascript-flow :requires lsp-mode flow-minor-mode)
         org
         prettier-js
         skewer-mode
@@ -167,18 +166,6 @@
         :documentation "Live evaluation of JS buffer change."
         :evil-leader-for-mode (js2-mode . "Tl"))
       (spacemacs|diminish livid-mode " 🅻" " [l]"))))
-
-(defun javascript/init-lsp-javascript-typescript ()
-  (use-package lsp-javascript-typescript
-    :commands lsp-javascript-typescript-enable
-    :defer t
-    :config (spacemacs//setup-lsp-jump-handler 'js2-mode)))
-
-(defun javascript/init-lsp-javascript-flow ()
-  (use-package lsp-javascript-flow
-    :commands lsp-javascript-flow-enable
-    :defer t
-    :config (spacemacs//setup-lsp-jump-handler 'js2-mode)))
 
 (defun javascript/init-flow-minor-mode ()
   (use-package flow-minor-mode

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -25,6 +25,8 @@
         js2-refactor
         livid-mode
         (lsp-javascript-typescript :requires lsp-mode)
+        flow-minor-mode
+        (lsp-javascript-flow :requires lsp-mode flow-minor-mode)
         org
         prettier-js
         skewer-mode
@@ -78,9 +80,9 @@
     :mode (("\\.m?js\\'"  . js2-mode))
     :init
     (progn
-      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
+      (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-backend)
       ;; safe values for backend to be used in directory file variables
-      (dolist (value '(lsp tern))
+      (dolist (value '(lsp lsp-flow tern))
         (add-to-list 'safe-local-variable-values
                      (cons 'javascript-backend value))))
     :config
@@ -171,6 +173,18 @@
     :commands lsp-javascript-typescript-enable
     :defer t
     :config (spacemacs//setup-lsp-jump-handler 'js2-mode)))
+
+(defun javascript/init-lsp-javascript-flow ()
+  (use-package lsp-javascript-flow
+    :commands lsp-javascript-flow-enable
+    :defer t
+    :config (spacemacs//setup-lsp-jump-handler 'js2-mode)))
+
+(defun javascript/init-flow-minor-mode ()
+  (use-package flow-minor-mode
+    :defer t
+    :config (define-key js2-mode-map (kbd "C-c C-j") #'flow-minor-jump-to-definition)))
+
 
 (defun javascript/pre-init-prettier-js ()
   (if (eq javascript-fmt-tool 'prettier)


### PR DESCRIPTION
Adding LSP JavaScript Flow backend to the `javascript` layer.
This is highly anticipated feature and was requested many time.