### PR TITLE
Mu4e add 'gu' key binding to go to urls.

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -82,7 +82,8 @@
        (kbd "C-k") 'mu4e-view-headers-prev
        (kbd "J") (lambda ()
                    (interactive)
-                    (mu4e-view-mark-thread '(read))))
+                   (mu4e-view-mark-thread '(read)))
+       (kbd "gu") 'mu4e-view-go-to-url)
 
       (spacemacs/set-leader-keys-for-major-mode 'mu4e-compose-mode
         dotspacemacs-major-mode-leader-key 'message-send-and-exit


### PR DESCRIPTION
This pull request adds a binding `gu` in `mue-view-mode` to follow URLs. This is usually bound to `g` in mu4e, but evilification removes the original map.