### PR TITLE
Add symbol-overlay package to spacemacs/navigation layer

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -198,6 +198,39 @@ If the universal prefix argument is used then kill also the window."
            (spacemacs//symbol-highlight-doc))))
 
 
+;; symbol overlay
+
+(defun spacemacs/symbol-overlay ()
+  "Start symbol-overlay-transient-state."
+  (interactive)
+  (symbol-overlay-put)
+  (spacemacs/symbol-overlay-transient-state/body))
+
+(defun spacemacs//symbol-overlay-doc ()
+        (let* ((symbol-at-point (symbol-overlay-get-symbol))
+               (keyword (symbol-overlay-assoc symbol-at-point))
+               (symbol (car keyword))
+	             (before (symbol-overlay-get-list -1 symbol))
+	             (after (symbol-overlay-get-list 1 symbol))
+	             (count (length before))
+               (scope (format "%s"
+                              (if (cadr keyword)
+                                  "Scope"
+                                "Buffer")))
+               (color (cddr keyword))
+               (x/y (format "[%s/%s]" (+ count 1) (+ count (length after)))))
+            (concat
+             (propertize (format " %s " scope) 'face color))
+             (propertize (format " %s " x/y) 'face
+                         `(:foreground "#ffffff" :background "#000000"))))
+
+(defun spacemacs//symbol-overlay-ts-doc ()
+  (spacemacs//transient-state-make-doc
+   'symbol-overlay
+   (format spacemacs--symbol-overlay-transient-state-doc
+           (spacemacs//symbol-overlay-doc))))
+
+
 ;; golden ratio
 
 (defun spacemacs/no-golden-ratio-for-buffers (bufname)

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -23,6 +23,7 @@
         paradox
         restart-emacs
         (smooth-scrolling :location built-in)
+        symbol-overlay
         winum))
 
 (defun spacemacs-navigation/init-ace-link ()
@@ -368,6 +369,48 @@
     :off (spacemacs/disable-smooth-scrolling)
     :documentation "Smooth scrolling."
     :evil-leader "tv"))
+
+(defun spacemacs-navigation/init-symbol-overlay ()
+  (use-package symbol-overlay
+    :init
+    (progn
+      (setq spacemacs--symbol-overlay-transient-state-doc "
+%s
+ [_n_] next   [_N_/_p_] prev      [_d_] def           [_f_/_b_] switch [_t_] scope
+ [_e_] echo   [_o_]^^   unoverlay [_O_] unoverlay all [_c_]^^   copy   [_z_] center
+ [_s_] search [_r_]^^   replace   [_R_] rename        ^^^^             [_q_] quit")
+
+      ;; since we are creating our own maps,
+      ;; prevent the default keymap from getting created
+      (setq symbol-overlay-map (make-sparse-keymap)))
+    :config
+    (progn
+      (spacemacs/set-leader-keys
+        "so" 'spacemacs/symbol-overlay
+        "sO" 'symbol-overlay-remove-all)
+
+      ;; transient state
+      (spacemacs|define-transient-state symbol-overlay
+        :title "Symbol Overlay Transient State"
+        :hint-is-doc t
+        :dynamic-hint (spacemacs//symbol-overlay-ts-doc)
+        :bindings
+        ("b" symbol-overlay-switch-backward)
+        ("c" symbol-overlay-save-symbol)
+        ("d" symbol-overlay-jump-to-definition)
+        ("e" symbol-overlay-echo-mark)
+        ("f" symbol-overlay-switch-forward)
+        ("n" symbol-overlay-jump-next)
+        ("N" symbol-overlay-jump-prev)
+        ("o" symbol-overlay-put)
+        ("O" symbol-overlay-remove-all)
+        ("p" symbol-overlay-jump-prev)
+        ("r" symbol-overlay-query-replace)
+        ("R" symbol-overlay-rename)
+        ("s" symbol-overlay-isearch-literally)
+        ("t" symbol-overlay-toggle-in-scope)
+        ("z" recenter-top-bottom)
+        ("q" nil :exit t)))))
 
 (defun spacemacs-navigation/init-winum ()
   (use-package winum


### PR DESCRIPTION
Defines a transient state for symbol-overlay, and bind it to <kbd>SPC s o</kbd> and <kbd>SPC s O</kbd>. See [symbol-overlay](https://github.com/wolray/symbol-overlay). This package allows multiple symbols highlighted by using the built-in overlay function.