### PR TITLE
Defer orgit package

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -231,7 +231,9 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
               (spacemacs|diminish magit-svn-mode "SVN")
               (define-key magit-mode-map "~" 'magit-svn-popup))))
 
-(defun git/init-orgit ())
+(defun git/init-orgit ()
+  (use-package orgit
+    :defer t))
 
 (defun git/init-smeargle ()
   (use-package smeargle


### PR DESCRIPTION
Just a simple change to optimize startup times - without deferring it was adding 6-7 seconds to the total startup because of `(require 'org)` and `(require 'magit)`