### PR TITLE
Fix #11523 - Inhibit auto-indentation after reverting hunks

### DIFF
--- a/layers/+source-control/version-control/funcs.el
+++ b/layers/+source-control/version-control/funcs.el
@@ -33,7 +33,8 @@
 
 (defun spacemacs/vcs-revert-hunk ()
   (interactive)
-  (let ((current-prefix-arg t))
+  (let ((current-prefix-arg t)
+        (inhibit-modification-hooks t))
     (call-interactively
      (cl-case version-control-diff-tool
        (diff-hl     'diff-hl-revert-hunk)


### PR DESCRIPTION
Makes it easier to revert changes to non-standard indentation when
aggressive-indent mode is enabled.