### PR TITLE
improve the elixir and phoenix layers

### DIFF
--- a/layers/+frameworks/phoenix/README.org
+++ b/layers/+frameworks/phoenix/README.org
@@ -21,14 +21,16 @@ file.
 
 * Key bindings
 
-| Key binding   | Description        |
-|---------------+--------------------|
-| ~SPC m f r~   | Shows routes       |
-| ~SPC m f f w~ | Find in web folder |
-| ~SPC m f f v~ | Find view          |
-| ~SPC m f f c~ | Find controller    |
-| ~SPC m f f C~ | Find channel       |
-| ~SPC m f f t~ | Find template      |
-| ~SPC m f f m~ | Find model         |
-| ~SPC m f f s~ | Find static        |
-| ~SPC m f f r~ | Find router        |
+| Key binding   | Description                 |
+|---------------+-----------------------------|
+| ~SPC m f r~   | Shows routes                |
+| ~SPC m f x~   | Run phoenix server with mix |
+| ~SPC m f d~   | Run phoenix server with iex |
+| ~SPC m f f w~ | Find in web folder          |
+| ~SPC m f f v~ | Find view                   |
+| ~SPC m f f c~ | Find controller             |
+| ~SPC m f f C~ | Find channel                |
+| ~SPC m f f t~ | Find template               |
+| ~SPC m f f m~ | Find model                  |
+| ~SPC m f f s~ | Find static                 |
+| ~SPC m f f r~ | Find router                 |

--- a/layers/+frameworks/phoenix/funcs.el
+++ b/layers/+frameworks/phoenix/funcs.el
@@ -1,0 +1,23 @@
+;;; packages.el --- phoenix layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Mykhailo Panarin <mykhailopanarin@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs/phoenix-server-start ()
+  "Start phoenix server with `mix'"
+  (interactive)
+  (alchemist-mix-execute "phoenix.server"))
+
+(defun spacemacs/phoenix-server-iex ()
+  "Start phoenix server in `iex', to allow prying"
+  (interactive)
+  (if (alchemist-project-p)
+      (let ((default-directory (alchemist-project-root)))
+        (pop-to-buffer (process-buffer (alchemist-iex-process " -S mix phoenix.server"))))
+    (message "No mix.exs file available. Please use `alchemist-iex-run' instead.")))

--- a/layers/+frameworks/phoenix/packages.el
+++ b/layers/+frameworks/phoenix/packages.el
@@ -24,4 +24,6 @@
       "ffm" 'alchemist-phoenix-find-models
       "ffs" 'alchemist-phoenix-find-static
       "ffr" 'alchemist-phoenix-router
-      "fr" 'alchemist-phoenix-routes)))
+      "fr" 'alchemist-phoenix-routes
+      "fx" 'spacemacs/phoenix-server-start
+      "fd" 'spacemacs/phoenix-server-iex)))

--- a/layers/+lang/elixir/README.org
+++ b/layers/+lang/elixir/README.org
@@ -25,6 +25,7 @@
   - [[#hex-packages][Hex (packages)]]
   - [[#macro-expand][Macro expand]]
   - [[#formatting][Formatting]]
+  - [[#debug][Debug]]
 
 * Description
 This layer adds support for [[http://elixir-lang.org/][Elixir]].
@@ -250,3 +251,9 @@ Hex is the package manager for Elixir & Erlang ecosystem. See [[https://hex.pm]]
 | Key binding | Description               |
 |-------------+---------------------------|
 | ~SPC m =~   | Format the current buffer |
+
+** Debug
+
+| Key Binding | Description                  |
+|-------------+------------------------------|
+| ~SPC m d b~ | Place an IEx.pry debug point |

--- a/layers/+lang/elixir/funcs.el
+++ b/layers/+lang/elixir/funcs.el
@@ -37,3 +37,21 @@
     (flycheck-mix-setup)
     ;; enable credo only if there are no compilation errors
     (flycheck-add-next-checker 'elixir-mix '(warning . elixir-credo))))
+
+(defun spacemacs/elixir-annotate-pry ()
+  "Highlight breakpoint lines."
+  (interactive)
+  (highlight-lines-matching-regexp "require IEx; IEx.pry"))
+
+(defun spacemacs/elixir-toggle-breakpoint ()
+  "Add a breakpoint, highlight it."
+  (interactive)
+  (let ((trace "require IEx; IEx.pry")
+        (line (thing-at-point 'line)))
+    (if (and line (string-match trace line))
+        (kill-whole-line)
+      (progn
+        (back-to-indentation)
+        (insert trace)
+        (insert "\n")
+        (indent-for-tab-command)))))

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -38,6 +38,8 @@
     (progn
       (spacemacs/register-repl 'alchemist 'alchemist-iex-run "alchemist")
       (add-hook 'elixir-mode-hook 'alchemist-mode)
+      (spacemacs/add-to-hook 'elixir-mode-hook
+                             '(spacemacs/elixir-annotate-pry))
       (setq alchemist-project-compile-when-needed t
             alchemist-test-status-modeline nil)
       (add-to-list 'spacemacs-jump-handlers-elixir-mode
@@ -54,6 +56,7 @@
     (spacemacs/declare-prefix-for-mode 'elixir-mode "ms" "iex")
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mt" "test")
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mx" "execute")
+    (spacemacs/declare-prefix-for-mode 'elixir-mode "md" "debug")
     (spacemacs/set-leader-keys-for-major-mode 'elixir-mode
       "el" 'alchemist-eval-current-line
       "eL" 'alchemist-eval-print-current-line
@@ -131,7 +134,9 @@
       "oi" 'alchemist-macroexpand-once-region
       "oI" 'alchemist-macroexpand-once-print-region
       "or" 'alchemist-macroexpand-region
-      "oR" 'alchemist-macroexpand-print-region)
+      "oR" 'alchemist-macroexpand-print-region
+
+      "db" 'spacemacs/elixir-toggle-breakpoint)
 
     (dolist (mode (list alchemist-compile-mode-map
                         alchemist-eval-mode-map


### PR DESCRIPTION
add `SPC m d b` shortcut to elixir layer that toggles a breakpoint
added a functions for that
add `SPC m f x` and `SPC m f d` to phoenix layer to run server +
according functions

By the example of python mode, I added the breakpoint toggle as well as some handy shortcuts, that, I think, are essential.