### PR TITLE
Recompiling Elpa: don't skip missing .elc files

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -258,11 +258,18 @@ result, incrementing passed-tests and total-tests."
      (concat "Hidden Mode Line Mode enabled.  "
              "Use M-x hidden-mode-line-mode to make the mode-line appear."))))
 
-(defun spacemacs/recompile-elpa ()
-  "Recompile packages in elpa directory. Useful if you switch
-Emacs versions."
-  (interactive)
-  (byte-recompile-directory package-user-dir nil t))
+;; https://github.com/syl20bnr/spacemacs/issues/8414
+(defun spacemacs/recompile-elpa (arg)
+  "Compile or recompile packages in elpa directory, if needed, that is
+    if the corresponding .elc file is either missing or outdated.
+
+      If ARG is non-nil, also recompile every `.el' file, regardless of date.
+
+      Useful if you switch Emacs versions."
+  (interactive "P")
+  ;; First argument must be 0 (not nil) to get missing .elc files rebuilt.
+  ;; Bonus: Optionally force recompilation with universal ARG
+  (byte-recompile-directory package-user-dir 0 arg))
 
 (defun spacemacs/register-repl (feature repl-func &optional tag)
   "Register REPL-FUNC to the global list of REPLs SPACEMACS-REPL-LIST.


### PR DESCRIPTION
#### Addressing several issues arising after emacs/spacemacs upgrade

This could be a follow up of issues like #8414 , #7641 and may help with several
others where recompilation is involved.

A commonly proposed solution is to delete all byte-compiled modules to force
their recompilation, but it may not work as expected.
Thank you for contributing to Spacemacs!

#### Reproduction guide :beetle:
- Upgrade emacs or spacemacs.

*Observed behaviour:* :eyes: :broken_heart:
Mostly issues related with org-contrib packages,
e.g. source code blocks evaluation (org-babel).

Recompilation skips many packages, and version conflicts still cause issues.

*Expected behaviour:* :heart: :smile:
A smooth transistion towards a better world for everyone ?
#### About `spacemacs/recompile-elpa`

Given the docstring of
[`byte-recompile-directory`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Compilation-Functions.html#Compilation-Functions#index-byte_002drecompile_002ddirectory-1161
"link to gnu manual") :

    (byte-recompile-directory DIRECTORY &optional ARG FORCE)

> Recompile every ‘.el’ file in DIRECTORY that needs recompilation.
> This happens when a ‘.elc’ file exists but is older than the ‘.el’ file.
> Files in subdirectories of DIRECTORY are processed also.
>
> If the ‘.elc’ file does not exist, normally this function **does not**
> compile the corresponding ‘.el’ file.  However, if the prefix argument
> ARG is 0, that means do compile all those files.  A nonzero
> ARG means ask the user, for each such ‘.el’ file, whether to
> compile it.  A nonzero ARG also means ask about each subdirectory
> before scanning it.
>
> If the third argument FORCE is non-nil, recompile every ‘.el’ file
> that already has a ‘.elc’ file.

I think that `spacemacs/recompile-elpa` could be rewritten like this:

```elisp
      (defun spacemacs/recompile-elpa (arg)
        "Compile or recompile packages in elpa directory, if needed, that is
    if the corresponding .elc file is either missing or outdated.

      If ARG is non-nil, also recompile every `.el' file, regardless of date.

      Useful if you switch Emacs versions."
        (interactive "P")
        (byte-recompile-directory package-user-dir 0 arg))
```

Currently, it just calls

```elisp
  (byte-recompile-directory package-user-dir nil t)
```

which means that *missing .elc files won't be rebuilt*, but existing
ones will be recompiled over and over each time (time-consuming for often no improvement).
