### PR TITLE
evilified-state: Restore normal state keymap on exit

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -145,7 +145,8 @@ Needed to bypass keymaps set as text properties."
 
 (add-hook 'evil-evilified-state-entry-hook
           'evilified-state--evilified-state-on-entry)
-
+(add-hook 'evil-evilified-state-exit-hook
+          'evilified-state--restore-normal-state-keymap)
 ;; default key bindings for all evilified buffers
 (define-key evil-evilified-state-map "/" 'evil-search-forward)
 (define-key evil-evilified-state-map ":" 'evil-ex)


### PR DESCRIPTION
When a buffer in evil-evilified-state switches to evil-normal-state, the
keymap in the evil-normal-state has then a peculiar mapping of an
escape key that, when pressed, switches the buffer back to the
evil-evilified-state.

This behavior is not very convenient, for example, when you use the
debug mode for debugging your code. During the debug session, the
buffers with debugged source code are in evil-evilified-state and after
finishing the debugging all those buffers suffer from the escape
returning to evil-evilified-state issue described above.

Restoring the saved normal state keymap when exiting the evilified state
solves the issue.