### PR TITLE
Add more key bindings for unit test functionality to csharp layer.

### DIFF
--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -87,7 +87,8 @@
         ;; Tests
         ;; [missing in roslyn] "ta" 'omnisharp-unit-test-all
         "tb" 'omnisharp-unit-test-buffer
-        ;; [missing in roslyn] "tt" 'omnisharp-unit-test-single
+        "tp" 'omnisharp-unit-test-at-point
+        "tt" 'omnisharp-unit-test-last
 
         ;; Code manipulation
         "u" 'omnisharp-auto-complete-overrides


### PR DESCRIPTION
This adds a couple of keybindings for unit test functionality in `omnisharp-emacs` to `+lang/csharp` layer.