### PR TITLE
add startup support for doom-sourcerer theme

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -163,6 +163,7 @@
     (doom-opera-light                 . doom-themes)
     (doom-peacock                     . doom-themes)
     (doom-spacegrey                   . doom-themes)
+    (doom-sourcerer                   . doom-themes)
     (doom-solarized-light             . doom-themes)
     (doom-tomorrow-day                . doom-themes)
     (doom-tomorrow-night              . doom-themes)


### PR DESCRIPTION
This change allows doom-sourcerer to be used as a startup theme