### PR TITLE
Add a format binding for RuboCop format

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -142,6 +142,7 @@ directory local variables.
 
 | Key binding   | Description                                          |
 |---------------+------------------------------------------------------|
+| ~SPC m = r~   | Runs RuboCop on the currently visited file           |
 | ~SPC m r r f~ | Runs RuboCop on the currently visited file           |
 | ~SPC m r r F~ | Runs auto-correct on the currently visited file      |
 | ~SPC m r r d~ | Prompts from a directory on which to run RuboCop     |

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -45,6 +45,13 @@ Called interactively it prompts for a directory."
   (add-hook 'compilation-filter-hook 'inf-ruby-auto-enter nil t))
 
 
+;; rubocop
+
+(defun spacemacs/rubocop-format ()
+  (interactive)
+  (rubocop-autocorrect-current-file))
+
+
 ;; ruby-test
 
 (defun spacemacs//ruby-enable-ruby-test-mode ()

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -225,8 +225,10 @@
     :init (spacemacs/add-to-hooks 'rubocop-mode '(ruby-mode-hook
                                                   enh-ruby-mode-hook))
     :config (dolist (mode '(ruby-mode enh-ruby-mode))
+              (spacemacs/declare-prefix-for-mode mode "m=" "format")
               (spacemacs/declare-prefix-for-mode mode "mrr" "RuboCop")
               (spacemacs/set-leader-keys-for-major-mode mode
+                "=r"  'spacemacs/rubocop-format
                 "rrd" 'rubocop-check-directory
                 "rrD" 'rubocop-autocorrect-directory
                 "rrf" 'rubocop-check-current-file


### PR DESCRIPTION
Bind `SPC m =` ( `, =` ) to `rubocop-autocorrect-current-file`.