### PR TITLE
wip: Enable emmet-mode in typescript-tsx-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2124,6 +2124,7 @@ Other:
   Kramer)
 - Fixed jump handling with multiple backends (thanks to Aaron Jensen)
 - Fixed =typescript/jump-to-type-def= for npm modules (thanks to Jam Risser)
+- Enabled =emmet-mode= in =typescript-tsx-mode=
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -85,6 +85,13 @@
   (eldoc-mode))
 
 
+;; Emmet
+(defun spacemacs/typescript-emmet-mode ()
+  "Activate `emmet-mode' and configure it for local buffer."
+  (emmet-mode)
+  (setq-local emmet-expand-jsx-className? t))
+
+
 ;; Others
 
 (defun spacemacs/typescript-tsfmt-format-buffer ()

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -14,6 +14,7 @@
         add-node-modules-path
         company
         eldoc
+        emmet-mode
         flycheck
         smartparens
         tide
@@ -35,6 +36,9 @@
   (spacemacs/add-to-hooks #'spacemacs//typescript-setup-eldoc
                    '(typescript-mode-local-vars-hook
                      typescript-tsx-mode-local-vars-hook) t))
+
+(defun typescript/post-init-emmet-mode ()
+  (add-hook 'typescript-tsx-mode-hook #'spacemacs/typescript-emmet-mode))
 
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)


### PR DESCRIPTION
Enable Emmet in `typescript-tsx-mode`.

Emmet is used in `html-mode`, `react-mode`, and `typescript-tsx-mode`. (use-package in `html` layer)
Perhaps we should move `emmet-mode` to a separated layer.