### PR TITLE
Fix helm loading for layouts transient state

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -103,6 +103,7 @@
 
 
 (defun spacemacs-layouts/post-init-helm ()
+  (spacemacs||set-helm-key "l" spacemacs/layouts-transient-state/body)
   (spacemacs/set-leader-keys
     "bB" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))


### PR DESCRIPTION
Calling the transient state and its functions (particularly `SPC l L` for loading from file) doesn't load helm, so until helm is loaded by something else the default Emacs method is used (I don't remember how it's called).

This makes that helm will always be used for opening layouts from file and all the rest inside the transient state, may there be more currently or in the future.