### PR TITLE
Fix flyspell correction on spell-checking layer

### DIFF
--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -60,7 +60,7 @@ Spell Commands^^             Other
         ("b" flyspell-buffer)
         ("d" spell-checking/change-dictionary)
         ("n" flyspell-goto-next-error)
-        ("c" flyspell-correct-previous-word-generic)
+        ("c" flyspell-correct-previous)
         ("Q" flyspell-mode :exit t)
         ("q" nil :exit t)
         ("t" spacemacs/toggle-spelling-checking))


### PR DESCRIPTION
Using the `spell-checking` layer mini-mode `Space S .` would cause an error

```
Wrong type argument: commandp -- flyspell-correct-previous-word-generic
```

According to the [README](https://github.com/d12frosted/flyspell-correct#deprecations-in-v05), it has since moved the command to a new name, which is not available anymore.

This commit changes the command used to point to the new name to make the transient mode work again.