### PR TITLE
[agda] Fix: typo in agda layer setup documentation

### DIFF
--- a/layers/+lang/agda/README.org
+++ b/layers/+lang/agda/README.org
@@ -42,7 +42,7 @@ load path, otherwise set it to the path at which =agda2.el= can be found. For
 example,
 
 #+BEGIN_SRC emacs-lisp
-  (agda2 :variables agda-mode-path "/some/path/to/agda2.el")
+  (agda :variables agda-mode-path "/some/path/to/agda2.el")
 #+END_SRC
 
 * Key bindings


### PR DESCRIPTION
This is a one-character change in the README for the `agda` layer.

I noticed this while trying to help a new user resolve issue #10996, which can probably be closed.