### PR TITLE
[treemacs] Use deferred git-mode by default.

### DIFF
--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -22,13 +22,15 @@ Must be a number.")
 (defvar treemacs-use-git-mode
   (pcase (cons (not (null (executable-find "git")))
                (not (null (executable-find "python3"))))
-    (`(t . t) 'extended)
+    (`(t . t) 'deferred)
     (`(t . _) 'simple))
   "Type of git integration for `treemacs-git-mode'.
 There are 2 possible values:
 1) simple, which highlights only files based on their git status, and is
    slightly faster
-2) extended, which highlights both files and directories, but requires python")
+2) extended, which highlights both files and directories, but requires python
+3) deferred, which is the same is extended, but delays highlighting for improved
+   performance")
 
 (defvar treemacs-lock-width nil
   "When non-nil the treemacs window will not be manually resizable by default.")

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -66,7 +66,7 @@
         (treemacs-follow-mode t))
       (when treemacs-use-filewatch-mode
         (treemacs-filewatch-mode t))
-      (when (memq treemacs-use-git-mode '(simple extended))
+      (when (memq treemacs-use-git-mode '(simple extended deferred))
         (treemacs-git-mode treemacs-use-git-mode))
       (add-to-list 'spacemacs-window-split-ignore-prefixes
                    treemacs--buffer-name-prefix))))


### PR DESCRIPTION
Deferred git-mode adds a 0.5s delay to fontification, so treemacs will almost never have to wait for a git process to finish.