### PR TITLE
Use non-fork of graphviz-dot-mode

### DIFF
--- a/layers/+lang/graphviz/packages.el
+++ b/layers/+lang/graphviz/packages.el
@@ -11,8 +11,7 @@
 
 (defconst graphviz-packages
   '(
-    (graphviz-dot-mode :location (recipe :fetcher github
-                                         :repo "luxbock/graphviz-dot-mode"))
+    graphviz-dot-mode
     org
     smartparens
     ))


### PR DESCRIPTION
Several reasons to accept this PR:

1. Use the non-forked version of `graphviz-dot-mode` now that the live preview feature is merged into the upstream repo.
2. There is a bug in the forked version, https://github.com/luxbock/graphviz-dot-mode/pull/2, which causes loading of this layer to fail for Emacs 26.
3. The upstream is maintained and the forked repo is not maintained; it seems to have only been forked for the purposes of 1 above.