### PR TITLE
ivy: Fix counsel search

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -79,7 +79,7 @@
                                (prog1 (pop split)
                                  (setq string (mapconcat #'identity split " -- "))))
                            ""))
-                   (regex (counsel-unquote-regex-parens
+                   (regex (counsel--elisp-to-pcre
                            (setq ivy--old-re
                                  (ivy--regex string)))))
               (setq spacemacs--counsel-search-cmd (format base-cmd args regex))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -119,6 +119,11 @@
         "stP" 'spacemacs/search-project-pt-region-or-symbol))
     :config
     (progn
+      ;; Temporarily handle older versions of ivy
+      ;; https://github.com/abo-abo/swiper/pull/1863/files
+      (unless (fboundp 'counsel--elisp-to-pcre)
+        (defalias 'counsel--elisp-to-pcre 'counsel-unquote-regex-parens))
+
       ;; set additional ivy actions
       (ivy-set-actions
        'counsel-find-file


### PR DESCRIPTION
This function was renamed upstream:
https://github.com/abo-abo/swiper/commit/58bf1b94c8346491b906aa306f5ed734be67310c

If we should support both versions, please let me know the best way to do that.