### PR TITLE
Replace `counsel-unquote-regex-parens`

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -79,7 +79,7 @@
                                (prog1 (pop split)
                                  (setq string (mapconcat #'identity split " -- "))))
                            ""))
-                   (regex (counsel-unquote-regex-parens
+                   (regex (counsel--elisp-to-pcre
                            (setq ivy--old-re
                                  (ivy--regex string)))))
               (setq spacemacs--counsel-search-cmd (format base-cmd args regex))


### PR DESCRIPTION
The function `counsel-unquote-regex-parens` was replaced by `counsel--elisp-to-pcre' in https://github.com/abo-abo/swiper/commit/58bf1b94c8.

Fixes #11757 