### PR TITLE
github: Add forge

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -82,7 +82,7 @@ This file containes the change log for the next major version of Spacemacs.
 - New key binding ~SPC f i~ for =insert-file=.
 *** Layer changes
 **** GitHub
-- Add new package =magithub=
+- Add new packages =forge= and =magithub=
 - Remove package =github-browse-file= which has been replaced by
   =browse-at-remote= in =version-control= layer
 **** Git

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -13,6 +13,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#magit-gh-pulls][magit-gh-pulls]]
   - [[#magithub][magithub]]
+  - [[#forge][forge]]
   - [[#gistel][gist.el]]
   - [[#clone-repositories][Clone repositories]]
 
@@ -21,7 +22,8 @@ This layers adds support for [[http://github.com][GitHub]].
 
 ** Features:
 - [[https://github.com/sigma/magit-gh-pulls][magit-gh-pulls]]: handy =magit= add-on to manage GitHub pull requests.
-- [[https://github.com/vermiculus/magithub][magithub]]: magit integrated interface to [[https://hub.github.com/][hub]] command line
+- [[https://github.com/vermiculus/magithub][magithub]]: Magit-integrated interface to [[https://hub.github.com/][hub]] command line
+- [[https://github.com/magit/forge][forge]]: integration with various forges, such as GitHub and GitLab.
 - [[https://github.com/defunkt/gist.el][gist.el]]: full-featured mode to browse and post GitHub gists.
 - [[https://github.com/sshaw/git-link][git-link]]: quickly generate URLs for commits or files.
 - [[https://github.com/dgtized/github-clone.el][github-clone]] allows for easy cloning and forking of repositories.
@@ -101,6 +103,16 @@ possible.
 | ~@ f~       | create a fork of an existing repository          |
 | ~@ p~       | submit pull request upstream                     |
 | ~@ i~       | create an issue                                  |
+
+** forge
+In a =magit-status= buffer (~SPC g s~):
+
+| Key binding | Description                                               |
+|-------------+-----------------------------------------------------------|
+| ~F y~       | pull pull-requests and issues for the current repository  |
+| ~F Y~       | pull all notifications for the current repository's forge |
+| ~b Y~       | create branch from pull-request                           |
+| ~b y~       | create and check out branch from pull-request             |
 
 ** gist.el
 

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -11,6 +11,7 @@
 
 (setq github-packages
       '(
+        forge
         gist
         github-clone
         github-search
@@ -20,6 +21,12 @@
         ;; the call to spacemacs/declare-prefix.
         (spacemacs-github :location built-in)
         ))
+
+(defun github/init-forge ()
+  (use-package forge
+    :after magit
+    :init (setq forge-database-file (concat spacemacs-cache-directory
+                                            "forge-database.sqlite"))))
 
 (defun github/init-gist ()
   (use-package gist
@@ -94,7 +101,13 @@
         (magit-set "false" "--global" "magithub.status.includeStatusHeader")
         (magit-set "false" "--global" "magithub.status.includePullRequestsSection")
         (magit-set "false" "--global" "magithub.status.includeIssuesSection"))
-      (magithub-feature-autoinject t)
+      (magithub-feature-autoinject `(,@(when (not (package-installed-p 'forge))
+                                         '(issues-section
+                                           pull-requests-section))
+                                     completion
+                                     status-checks-header
+                                     commit-browse
+                                     pull-request-merge))
       (define-key magit-status-mode-map "@" #'magithub-dispatch-popup))))
 
 (defun github/init-spacemacs-github ()


### PR DESCRIPTION
Note that Forge binds the <kbd>'</kbd> key to the Forge dispatch popup, but evil-magit binds the <kbd>'</kbd> key to the submodule dispatch popup (see https://github.com/emacs-evil/evil-magit/issues/54), and evil-magit's key binding takes precedence with the vim editing style.  Because Forge's key binding does not always work, it is omitted from the README.

Note also that Magit binds the <kbd>%</kbd> key to its worktree dispatch popup, but Spacemacs binds the <kbd>%</kbd> key to the magit-gitflow popup, and Spacemacs's key binding takes precedence.  Because there is no available key binding for the worktree dispatch popup, Forge's key binding under that dispatch popup is omitted from the README.

* `layers/+source-control/github/README.org`: Update.
* `layers/+source-control/github/packages.el` (`github-packages`): Add `forge`.
(`github/init-forge`): Load `forge` after `magit`. Configure `forge` to use `spacemacs-cache-directory`.
(`github/init-magithub`): Disabling injecting issues and pull-requests sections if `forge` is installed.