### PR TITLE
Update change log

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -23,6 +23,11 @@ This file containes the change log for the next major version of Spacemacs.
   Thomas de Beauchêne)
 - Remove ~SPC T N~ and make ~SPC T n~ cycle and start the theme transient state
   (thanks to Sylvain Benner)
+- Changed ~SPC j j~ from =evil-avy-goto-char= to =evil-avy-goto-char-timer=,
+  and removed default binding for =evil-avy-goto-char-2= (thanks to duianto and
+  Sylvain Benner)
+- Changed ~SPC f T~ to ~SPC 0~ for =neotree-show= / =treemacs-select-window= (thanks
+  to Dela Anthonio)
 **** ESS
 ESS key bindings were re-organised in the following list (thanks to Guido
 Kraemer, Yi Liu):
@@ -110,11 +115,11 @@ a sane way, here is the complet list of changed key bindings:
 - Rebind =org-agenda-refile= to ~r~ in transient state (thanks to Muneeb Shaikh)
 **** Python
 - Key bindings (thanks to Danny Freeman):
-  - Chaged ~SPC m s e~ to ~SPC m e e~ for =lisp-eval-last-sexp=
-  - Chaged ~SPC m s f~ to ~SPC m e f~ for =lisp-eval-defun=
-  - Chaged ~SPC m s F~ to ~SPC m e F~ for =lisp-eval-defun-and-go=
-  - Chaged ~SPC m s r~ to ~SPC m e r~ for =lisp-eval-region=
-  - Chaged ~SPC m s R~ to ~SPC m e R~ for =lisp-eval-region-and-go=
+  - Changed ~SPC m s e~ to ~SPC m e e~ for =lisp-eval-last-sexp=
+  - Changed ~SPC m s f~ to ~SPC m e f~ for =lisp-eval-defun=
+  - Changed ~SPC m s F~ to ~SPC m e F~ for =lisp-eval-defun-and-go=
+  - Changed ~SPC m s r~ to ~SPC m e r~ for =lisp-eval-region=
+  - Changed ~SPC m s R~ to ~SPC m e R~ for =lisp-eval-region-and-go=
 - Make =nose= fail compilation when tests fail (thanks to wizmer)
 **** Ruby
 - Key bindings:
@@ -138,6 +143,9 @@ a sane way, here is the complet list of changed key bindings:
   [[https://github.com/syl20bnr/spacemacs/commit/74fdbb6][commit message of commit 74fdbb6]].
 - The function =add-flycheck-hook= has been renamed to =enable-flycheck=.
 - =shaders= layer has been moved to =gpu= layer.
+- The property =:powerline-scale= of variable =dotspacemacs-default-font= has been
+  removed and replaced by the property =:separator-scale= used in the variable
+  =dotspacemacs-mode-line-theme=.
 *** Hot new feature
 - Improve themes support. Support are now handled like regular packages. The
   list of themes now supports =:location= keyword like in layer list. More
@@ -211,6 +219,8 @@ a sane way, here is the complet list of changed key bindings:
     string for a frame title bar, see docstring of function
     =spacemacs/frame-title-prepare= for more info (thanks to Uri Sharf and Kepi)
   - New variable =dotspacemacs-use-spacelpa= (thanks to Sylvain Benner)
+  - Removed obsolete =:powerline-scale= property from =dotspacemacs-default-font=
+    variable (thanks to Muneeb Shaikh and Sylvain Benner)
 - Can use the univeral prefix argument to open both the =*scratch*= buffer and
   the =*Messages*= buffer in another window (thanks to Thomas de Beauchêne)
 *** Core changes
@@ -360,10 +370,10 @@ a sane way, here is the complet list of changed key bindings:
     - Add ~<right>~ for next-buffer
     - Add ~<left>~ for previous-buffer
     - Add ~o~ for other window
-    - Add ~C-d~ for burry  buffer 
+    - Add ~C-d~ for bury buffer
     - Add ~b~ for helm-buffer-list
   - Update themes transient state (thanks to duianto)
-    - ~t~ or ~<up>~ to open helm-themes to select an installed theme  
+    - ~t~ or ~<up>~ to open helm-themes to select an installed theme
   - Add functionality to move layouts in layout list using the layouts transient
     state (thanks to Linus Marton)
     - Add ~<~ for =spacemacs/move-current-persp-left=
@@ -371,6 +381,7 @@ a sane way, here is the complet list of changed key bindings:
   - New ~SPC f e U~ to update packages (thanks to Codruț Constantin Gușoi)
   - Fix ~h~ key binding in compilation and grep buffers (thanks to Sylvain
     Benner)
+  - New ~SPC t m r~ to toggle responsiveness of the mode-line
 - Fixes:
   - Disable the paste transient state when using multiple cursors
     (thanks to Koray AL)
@@ -464,6 +475,7 @@ a sane way, here is the complet list of changed key bindings:
 - Key bindings
   - Removed ~C-f~ because it interfered with the default key binding for
     =forward-char= (thanks to scturtle and duianto)
+- Add =yasnippet-snippets= package (thanks to Jack Kamm)
 **** Auto-Layer
 - Prompt user to install react-mode if a .jsx file is opened (thanks to Jon
   Hermansen)
@@ -628,7 +640,10 @@ a sane way, here is the complet list of changed key bindings:
 - Conditionally enable ERC notifications via =erc-enable-notifications= (thanks
   to Evan Klitzke)
 **** ESS
-- Fix issue with read-only REPL buffer (thanks to jackkamm)
+- Key bindings:
+  - Change ~SPC m s t~ to ~SPC m s f~ to respect convention (thanks to Yi Liu)
+  - Change ~SPC m s T~ to ~SPC m s F~ to respect convention (thanks to Yi Liu)
+- Fix issue with read-only REPL buffer (thanks to Jack Kamm)
 - Added ess layer variable =ess-disable-underscore-assign= (thanks to Jack Kamm)
 - Remove =ess-R-object-popup= from ess layer (thanks to Naylyn Gaffney)
 - Refactor keybindings for =ess-mode= and =ess-julia-mode= (thanks to Guido Kraemer and bmag)
@@ -718,6 +733,9 @@ is enabled
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Add =counsel-css= as an ivy alternative to =helm-css-scss= (thanks to Robbert
   van der Helm)
+- Fix autoloading bug involving =spacemacs/helm-find-files= (thanks to Jack Kamm)
+- Added impatient-mode under ~SPC m i~ (thanks to geo7)
+- XML files now open with web-mode by default (thanks to Jordan Gwyn)
 **** Hy
 - Add support for virtual envs (thanks to Danny Freeman)
 **** Idris
@@ -773,13 +791,13 @@ is enabled
 - Leverage js-doc Yasnippet integration if available (thanks to Andriy Kmit')
 - Key bindings
   - Improve coffeescript support (thanks to Kalle Lindqvist)
-    - ~SPC m '~ to create or go to REPL                               
-    - ~SPC m c c~ to compile buffer                                     
+    - ~SPC m '~ to create or go to REPL
+    - ~SPC m c c~ to compile buffer
     - ~SPC m c r~ to compile region
-    - ~SPC m s b~ to send buffer to REPL                                
-    - ~SPC m s l~ to send line to REPL                                  
-    - ~SPC m s i~ to create or go to REPL                               
-    - ~SPC m s r~ to send current region to the REPL and stay in buffer 
+    - ~SPC m s b~ to send buffer to REPL
+    - ~SPC m s l~ to send line to REPL
+    - ~SPC m s i~ to create or go to REPL
+    - ~SPC m s r~ to send current region to the REPL and stay in buffer
     - ~SPC m T c~ to toggle compile on save
 - Move REPL live eval toggle to ~SPC m T l~ (thanks to Sylvain Benner)
 **** Keyboard layout
@@ -849,6 +867,7 @@ is enabled
 **** OCaml
 - Allow initialization without requiring =opam= (thanks to Bernhard Schommer)
 - Fix misused function, `merlin' is a package not a layer (thanks to jinyang)
+- Fix issue with OPAM share directory on Windows (thanks to Levi Roth)
 **** Org
 - Load org-mode email integration (mu4e/notmuch) when org is loaded (thanks to
   Steven Allen)
@@ -875,8 +894,8 @@ is enabled
     - add ~SPC m T l~ to toggle link display
   - Add org-agenda commands in org agenda transient state to un-schedule and
     un-deadline tasks (thanks to Jake Zerrer)
-    - add ~dS~ to unschedule org-agenda-schedule
-    - add ~dD~ to remove org-agenda-deadline 
+    - add ~d S~ to unschedule org-agenda-schedule
+    - add ~d D~ to remove org-agenda-deadline
   - Add ~M-RET~ for =org-meta-return= under major mode leader key (thanks to
     Sylvain Benner)
 - Make =org= layer depend on =spacemacs-org= (thanks to Eivind Fonn)
@@ -926,7 +945,7 @@ is enabled
 - Enable =purescript-decl-scan-mode= when loading =purescript-mode= (thanks to
   Bjarke Vad Andersen)
 **** Python
-- Various fixes in =pylookup.py= (thanks to ishestakov)
+- Various fixes in =pylookup.py= (thanks to ishestakov and Shitikanth Kashyap)
 - Hide =yapf-mode= modeline lighter (thanks to Robert ven der Helm)
 - Search for Pylint and Flake8 in the virtualenvs (thanks Alexey Kotlyarov)
 - Highlight wdb breakpoints as well as pdb/ipdb/pudb (thanks to Alexey Kotlyarov)
@@ -986,12 +1005,15 @@ is enabled
   - Add ~SPC m c l~ to run linter with cargo clippy (thanks to Michael Kohl)
   - Add ~SPC m c t~ to run the current test with Cargo, and fix documentation
     for ~SPC m c f~ to format project files (thanks to Luke Alexander Stein)
+  - Add ~SPC m c v~ to run "cargo check" command (thanks to Victor Polevoy)
 **** Scala
 - Move =ensime= to the =java= layer (Tor Hedin Bronner)
 - Key bindings:
   - Evilify =ensime= search in insert/normal mode (thanks to Diego Alvarez)
 - Remove duplicated code (thanks to Tetsuro Takemoto)
 - Add ENSIME jump handlers (thanks to Joao Azevedo)
+**** Semantic
+- Make it possible to exclude stickyfunc (thanks to Sylvain Benner)
 **** Shell
 - Fix xterm colors filtering bug in =eshell= when eshell buffers are updated
   and are not focused (thanks to Steven Allen)
@@ -1043,6 +1065,7 @@ is enabled
   - ~SPC e e~ is now for triggering a syntax check, the old action
     (explain error around point) has been moved to ~SPC e x~.
 - Rename function =add-flycheck-hook= to =enable-flycheck=
+- Use correct error list faces when defining error levels with custom bitmaps (thanks to Alexander Miller)
 **** Swift
 - Update Swift REPL key bindings (thanks to Elliot Bulmer)
 **** Systemd
@@ -1117,7 +1140,10 @@ is enabled
   Kuper, Saulius Menkevičius, sduthil, Shane Kilkelly, Sid Kapur, Somelauw,
   Soobin Rho, SteveJobzniak, Sunghyun Hwang, Swaroop C H, Tim Stewart, TinySong,
   Titov Andrey, Thomas de Beauchêne, Tomasz Cichocinski, tzhao11, Vladimir
-  Kochnev, Wieland Hoffmann, Yi Liu, zer09)
+  Kochnev, Wieland Hoffmann, Yi Liu, zer09,
+deb0ch,
+Raymond Wanyoike,
+)
 
 *** Release notes summarized
   Thanks to: Songpeng Zu, Igor Almeida, Miciah Dashiel Butler Masters


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+963
Starting with: 4fa20328a6de69393f8bbc4e5e90abbad781b965

New pointer: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+928
Start with: 106f98497ea91730cb53ece1733d87bf7fae2e51

Note: many of the commits in this range deal with the newly introduced `dotspacemacs-mode-line-theme` variable, which was already covered in (currently unmerged) PR #11766.

Also corrected a few spelling mistakes.