### PR TITLE
python: Add support for `black` formatter

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -14,6 +14,7 @@
 - [[#additional-tools][Additional tools]]
   - [[#syntax-checking][Syntax checking]]
   - [[#test-runner][Test runner]]
+  - [[#buffer-formatting][Buffer formatting]]
   - [[#automatic-buffer-formatting-on-save][Automatic buffer formatting on save]]
   - [[#automatic-save-of-buffer-when-testing][Automatic save of buffer when testing]]
   - [[#autoflake][autoflake]]
@@ -47,7 +48,7 @@ This layer adds support for the Python language.
 - Test Runners using [[https://github.com/syl20bnr/nose.el][nose.el]] or [[https://github.com/ionrock/pytest-el][pytest]]
 - Virtual Environment using [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] and [[https://github.com/yyuu/pyenv][pyenv]]
 - semantic mode is enabled
-- PEP8 compliant formatting via [[https://github.com/google/yapf][YAPF]]
+- PEP8 compliant formatting via [[https://github.com/google/yapf][YAPF]] or [[https://github.com/ambv/black][black]]
 - PEP8 checks with [[https://pypi.python.org/pypi/flake8][flake8]] or [[https://pypi.python.org/pypi/pylint/1.6.4][pylint]]
 - Suppression of unused import with [[https://github.com/myint/autoflake][autoflake]]
 - Use the ~%~ key to jump between blocks with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
@@ -162,13 +163,30 @@ directory local variable in your project root. ~SPC f v d~ in Spacemacs. See
 
 The root of the project is detected with a =.git= directory or a =setup.cfg= file.
 
-** Automatic buffer formatting on save
-To enable automatic buffer formatting on save with [[https://github.com/google/yapf][YAPF]] set the variable
-=python-enable-yapf-format-on-save= to =t=.
+** Buffer formatting
+One of [[https://github.com/google/yapf][YAPF]] (the default) or [[https://github.com/ambv/black][black]] may be selected as the formatter, via
+=python-formatter=, as ='yapf= or ='black= respectively.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (python :variables python-enable-yapf-format-on-save t)))
+    (python :variables python-formatter 'yapf)))
+#+END_SRC
+
+The key binding ~SPC m =~ invokes the selected formatter on the current buffer
+when in python mode.
+
+Note that YAPF and black may also be invoked unconditionally via
+=yapfify-buffer= and =blacken-buffer=, respectively, provided that they are
+installed.
+
+** Automatic buffer formatting on save
+To enable automatic buffer formatting on save set the variable
+=python-format-on-save= to =t=. The formatter specified by =python-formatter=
+will be used.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (python :variables python-format-on-save t)))
 #+END_SRC
 
 ** Automatic save of buffer when testing
@@ -357,7 +375,7 @@ Live coding is provided by the [[https://github.com/donkirkby/live-py-plugin][li
 
 | Key binding   | Description                                                                       |
 |---------------+-----------------------------------------------------------------------------------|
-| ~SPC m =~     | Reformat the buffer according to PEP8 using [[https://github.com/google/yapf][YAPF]]                                  |
+| ~SPC m =~     | reformat the buffer using formatter specified in =python-formatter=               |
 | ~SPC m d b~   | toggle a breakpoint using =wdb=, =ipdb=, =pudb=, =pdb= or =python3.7= (and above) |
 | ~SPC m g a~   | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back)      |
 | ~SPC m g b~   | jump back                                                                         |

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -21,8 +21,13 @@ and `lsp'.")
 (defvar python-pipenv-activate nil
   "If non-nil, activate pipenv before enabling backend")
 
-(defvar python-enable-yapf-format-on-save nil
-  "If non-nil, automatically format code with YAPF on save.")
+(defvar python-formatter 'yapf
+  "The formatter to use. Possible values are `yapf' and
+  `black'.")
+
+(defvar python-format-on-save nil
+  "If non-nil, automatically format code with formatter selected
+  via `python-formatter' on save.")
 
 (defvar python-test-runner 'nose
   "Test runner to use. Possible values are `nose' or `pytest'.")

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -346,6 +346,20 @@ to be called for each testrunner. "
     (py-isort-before-save)))
 
 
+;; Formatters
+
+(defun spacemacs//bind-python-formatter-keys ()
+  (spacemacs/set-leader-keys-for-major-mode 'python-mode
+    "=" 'spacemacs/python-format-buffer))
+
+(defun spacemacs/python-format-buffer ()
+  (interactive)
+  (pcase python-formatter
+    (`yapf (yapfify-buffer))
+    (`black (blacken-buffer))
+    (code (message "Unknown formatter: %S" code))))
+
+
 ;; REPL
 
 (defun spacemacs//inferior-python-setup-hook ()

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -11,6 +11,7 @@
 
 (setq python-packages
       '(
+        blacken
         company
         counsel-gtags
         cython-mode
@@ -95,6 +96,17 @@
     :defer t
     ;; see `spacemacs//python-setup-anaconda-company'
     ))
+
+(defun python/init-blacken ()
+  (use-package blacken
+    :defer t
+    :init
+    (progn
+      (spacemacs//bind-python-formatter-keys)
+      (when (and python-format-on-save
+                 (eq 'black python-formatter))
+        (add-hook 'python-mode-hook 'blacken-mode)))
+    :config (spacemacs|hide-lighter blacken-mode)))
 
 (defun python/init-cython-mode ()
   (use-package cython-mode
@@ -402,8 +414,8 @@ fix this issue."
     :defer t
     :init
     (progn
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "=" 'yapfify-buffer)
-      (when python-enable-yapf-format-on-save
+      (spacemacs//bind-python-formatter-keys)
+      (when (and python-format-on-save
+                 (eq 'yapf python-formatter))
         (add-hook 'python-mode-hook 'yapf-mode)))
     :config (spacemacs|hide-lighter yapf-mode)))


### PR DESCRIPTION
This adds support for the [`black`](https://github.com/ambv/black) formatter to the python layer, and follows the existing YAPF code closely:

- Adds the [`blacken`](https://melpa.org/#/blacken) package
- Provides `blacken-buffer` as an alternative to `yapfify-buffer`
- Provisionally, binds `blacken-buffer` to "-", next to `yapfify-buffer`'s "="
- Adds `python-enable-black-format-on-save` variable
- Updates docs

Both `blacken-buffer` and the format-on-save behavior work for me on 25.2.2/ubuntu18.04.