### PR TITLE
Document cabal-new-repl as a valid haskell-process-type

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -395,6 +395,7 @@ bring up. But if you are experiencing problems with it, then you can help
 Available options are:
 - ghci
 - cabal-repl
+- cabal-new-repl
 - cabal-dev
 - cabal-ghci
 - stack-ghci


### PR DESCRIPTION
This allows use of `cabal new-repl`.

See
https://github.com/haskell/haskell-mode/commit/5b9a3e3688ff9f53eef190407568e851549b8c98
