### PR TITLE
Fix spacemacs/c-c++-tags-find-references-at-point

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -160,9 +160,9 @@ and the arguments for flyckeck-clang based on a project-specific text file."
            rtags-last-request-not-indexed)
       (gtags-find-tag)))
 
-(defun spacemacs/c-c++-tags-find-refs-at-point (&optional prefix)
+(defun spacemacs/c-c++-tags-find-references-at-point (&optional prefix)
   (interactive "P")
-  (if (and (not (rtags-find-refs-at-point prefix))
+  (if (and (not (rtags-find-references-at-point prefix))
            rtags-last-request-not-indexed)
       (gtags-find-rtag)))
 


### PR DESCRIPTION
Rename the spacemacs/c-c++-tags-find-references-at-point and
rtags-find-references-at-point to fix the c-c++-modes key binding:
          "g," 'spacemacs/c-c++-tags-find-references-at-point
when c-c++-backend is set to 'rtags.

This changeset reverts some of the changes introduced by
the commit 445f6af93f6d5555bbda7608713bd4838c9b8274.