### PR TITLE
Updated change log

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -51,8 +51,9 @@ Kraemer, Yi Liu):
 - Key bindings:
   - Change prefix from "ai" to "ay" (thanks to Swaroop C H)
 **** Org
-Org key bindings were all over the place and we needed to reorganize them in
-a sane way, here is the complet list of changed key bindings:
+Org key bindings were all over the place and we needed to reorganize them in a
+sane way, here is the complete list of changed key bindings (thanks to Sylvain
+Benner and Paweł Siudak):
 - New prefixes:
   - ~SPC C~ clocks
   - ~SPC d~ dates
@@ -168,6 +169,7 @@ a sane way, here is the complet list of changed key bindings:
 - unicode-fonts (thanks to Aaron Jensen)
 **** Languages
 - coq
+- factor (thanks to timor)
 - forth (thanks to Tim Jaeger)
 - gpu (thanks to Evan Klitzke)
 - groovy (thanks to Sylvain Benner)
@@ -185,11 +187,13 @@ a sane way, here is the complet list of changed key bindings:
 - treemacs (thanks to Alexander Miller)
 **** Tools
 - bm (thanks to Eugene Yaremenko)
+- lsp (thanks to Fangrui Song, 0bl.blwl, and Sylvain Benner)
 - node (thanks to jupl)
 - pass (thanks to Andrew Oppenlander and Kepi)
 - sphinx (thanks to Wei-Wei Guo)
 - transmission (thanks to Eugene Yaremenko)
 **** Others
+- japanese (thanks to Kenji Miyazaki)
 - multiple-cursors (thanks to Codruț Constantin Gușoi)
 - parinfer (thanks to Tianshu Shi)
 - spacemacs-purpose (thanks to bmag)
@@ -211,6 +215,7 @@ a sane way, here is the complet list of changed key bindings:
     string for a frame title bar, see docstring of function
     =spacemacs/frame-title-prepare= for more info (thanks to Uri Sharf and Kepi)
   - New variable =dotspacemacs-use-spacelpa= (thanks to Sylvain Benner)
+  - New variable =dotspacemacs-enable-server= (thanks to Tad Fisher)
 - Can use the univeral prefix argument to open both the =*scratch*= buffer and
   the =*Messages*= buffer in another window (thanks to Thomas de Beauchêne)
 *** Core changes
@@ -278,6 +283,8 @@ a sane way, here is the complet list of changed key bindings:
   warning (thanks to Miciah Dashiel Butler Masters)
 - Escape left and right bracket character literals to avoid warning (thanks to
   Miciah Dashiel Butler Masters)
+- Fixed package initialization on Emacs 27 (thanks to Miciah Dashiel Butler
+  Masters)
 *** Distribution changes
 - Refactor =spacemacs-ui= and =spacemacs-ui-visual= layers:
   - new =spacemacs-navigation= layer contains packages whose principal goal is
@@ -516,11 +523,22 @@ a sane way, here is the complet list of changed key bindings:
     Michael van der Nest)
   - Fix =cider-inspector-prev-page= binding, also add ~p~ as another key binding
     (thanks to Brian Fay)
+- Added key bindings for profiling and spec browsing (thanks to Luo Tian):
+  - ~SPC m g s~ to browse spec
+  - ~SPC m g S~ to browse all specs
+  - ~SPC m p +~ to display or set current max-sample-count
+  - ~SPC m p c~ to clear profile
+  - ~SPC m p n~ to toggle namespace profiling
+  - ~SPC m p s~ to get profile summary for variable under point
+  - ~SPC m p S~ to get summary of all currently collected profile data
+  - ~SPC m p t~ to toggle variable profiling
+  - ~SPC m p v~ to display or set profiling status of variable
 - Store cider repl history in spacemacs cache (thanks to Ryan Fowler)
 - Fix Clojure layer cider-repl-mode keybindings (thanks to Corey Ling)
 - Remove backtick from smartparens pairs for Clojure (thanks to Erwin Kroon and
   Eivind Fonn)
 - Improved =jump-to-definition= for Clojure modes (thanks to Ag Ibragimov)
+- Compatibility fix for CIDER 0.9.0 (thanks to nijohando)
 **** Coffeescript
 - Adds basic autocompletion (thanks to Codruț Constantin Gușoi)
 - Key bindings (thanks to Kalle Lindqvist):
@@ -696,8 +714,10 @@ is enabled
 - Rename =haskell-enable-hindent-style= to =haskell-enable-hindent= and make it
   a Boolean option in accordance with upstream changes (thanks to PierreR)
 **** Helm
-- Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
-- Key bindinds for directory search (thanks to Tim Jäger and Eivind Fonn):
+- Limited =ripgrep= results to 512 columns by default, and added
+  =spacemacs-helm-rg-max-column-number= layer variable to configure the above
+  limit (thanks to Aaron Jensen, Michael Hauser-Raspe, and Sylvain Benner)
+- Key bindings for directory search (thanks to Tim Jäger and Eivind Fonn):
   - ~SPC s d for =spacemacs/helm-dir-smart-do-search=
   - ~SPC s D for =spacemacs/helm-dir-smart-do-search-region-or-symbol=
   - ~SPC s a d for =spacemacs/helm-dir-do-ag=
@@ -718,6 +738,7 @@ is enabled
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Add =counsel-css= as an ivy alternative to =helm-css-scss= (thanks to Robbert
   van der Helm)
+- Added =helm-xref= (thanks to Fangrui Song and Sylvain Benner)
 **** Hy
 - Add support for virtual envs (thanks to Danny Freeman)
 **** Idris
@@ -754,6 +775,7 @@ is enabled
 - Rotate ivy re builders rather than toggle (thanks to Tomasz Kołodziejski)
 - Follow upstream ivy/counsel and remove use of variable =counsel--git-dir=
   (thanks to Chirantan Ekbote)
+- Added =ivy-xref= (thanks to Fangrui Song and Sylvain Benner)
 **** Java
 - Add support for multiple backends. Supported backends are: =megahnada=,
   =eclim= and =ensime=. The default backend is =meghanada=.
@@ -919,6 +941,7 @@ is enabled
 - Add company-php (thanks to jim and Eivind Fonn)
 - Fix php-company autocompletion (thanks to Dela Anthonio)
 **** Prodigy
+- Compatibility fix for upstream change (thanks to Francesc Elies)
 - Key bindings:
   - add ~c~ to clear the buffer (thanks to Francesc Elies)
   - bind ~q~ to quit-window in view mode (thanks to Saulius Menkevičius)
@@ -947,6 +970,11 @@ is enabled
 - Add key binding ~SPC m r f~ to fix missing import statements (thanks to
   Volodymyr Vitvitskyi)
 - Use =python-mode= for SCons script files (thanks to shanemikel)
+- Added LSP support, which can be used by enabling the =lsp= layer and setting
+  the =python= layer's =python-backend= variable to =lsp= (thanks to Yuan Fu and
+  Sylvain Benner)
+- Added ~SPC m t l~ key binding to re-run the last test command (thanks to
+  Benoit Coste).
 - Key bindings:
   - Update invalid cython mode keybindings (thanks to Muneeb Shaikh)
   - New =anaconda-view-mode= keybindings (thanks to Muneeb Shaikh)
@@ -980,6 +1008,8 @@ is enabled
     - Add ~SPC m r R v~ to extract local variable.
     - Add ~SPC m r R c~ to extract constant.
     - Add ~SPC m r R l~ to extract to =let=.
+- Added ~SPC m s b~ key binding to send buffer to the Ruby console (thanks to
+  Alejandro Arrufat)
 **** Rust
 - Key bindings:
   - Add ~SPC m c D~ to open Cargo docs (thanks to Matthew J. Berger)
@@ -1077,6 +1107,7 @@ is enabled
 - Declare =tide-jump-to-definition= as async (thanks to Sylvain Benner)
 - Adds tide keybindings to tsx web mode (thanks to George Miller)
 - Rewrite hooks for web-mode (thanks to Sylvain Benner)
+- Created a derived mode for TSX files (thanks to Aaron Jensen)
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)
@@ -1118,6 +1149,11 @@ is enabled
   Soobin Rho, SteveJobzniak, Sunghyun Hwang, Swaroop C H, Tim Stewart, TinySong,
   Titov Andrey, Thomas de Beauchêne, Tomasz Cichocinski, tzhao11, Vladimir
   Kochnev, Wieland Hoffmann, Yi Liu, zer09)
+# Add additional names as comma separated lines for easier merging/diffing
+Rhommel Lamas,
+Adam Frey,
+Nicolas Forgerit,
+Olivier Verdier,
 
 *** Release notes summarized
   Thanks to: Songpeng Zu, Igor Almeida, Miciah Dashiel Butler Masters


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+823
Started with: 87cbef1952e0659b6f180285540fd0c548b642ac

New pointer:
https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+788
Start with: 29fa494053cf3029be1f17741b77971e3ce0d6bb

---

* Fix docs for rcirc layer where :user-name is the right value · syl20bnr/spacemacs@87cbef1

  Added author under "Various documentation improvements".

* Fix typo in clojure/README · syl20bnr/spacemacs@5da9325

  Added author under "Various documentation improvements".

* fix: Rename deprecated cider function · syl20bnr/spacemacs@d4ae5a3

  Added as "Compatibility fix for CIDER 0.9.0" under changes to the clojure layer.

* Fix typo · syl20bnr/spacemacs@c73844f

  Added author under "Various documentation improvements".

* org: tidy prefixes · syl20bnr/spacemacs@670a483

  Added a "thanks to" to the existing entry for the Org Mode key bindings clean-up.  The existing entry was for work that Sylvain had done, and Sylvain was uncredited, so I added a "thanks to" for both Sylvain and and author of this commit, Paweł Siudak.

* Add Layer for the Factor Programming Language · syl20bnr/spacemacs@2c4ac9b

  Added under New layers/Languages.

* Don't add final semicolon to template · syl20bnr/spacemacs@05623c4

  Skipped; this was a follow-up commit by the author of the layer that the previous commit introduced.

* Clarify Snippet usage · syl20bnr/spacemacs@f4a8d60

  Skipped; another follow-up by the original author.

* Add features section · syl20bnr/spacemacs@ba13869

  Skipped; another follow-up by the original author.

* Add +tools/lsp layer for lsp-mode & lsp-ui · syl20bnr/spacemacs@d99cb00

  Added under New layers/Tools, crediting the commit author (Fangrui Song) as well as 0bl.blwl, who is credited in the commit message.

* lsp: move helm-xref and ivy-xref ownership to helm and ivy layers · syl20bnr/spacemacs@2a5670e

  Added entries under helm and under ivy, crediting Fangrui Song (who added helm-xref and ivy-xref as part of the new lsp layer in the previous commit) and Sylvain Benner (who moved them to the Helm and Ivy layers in this commit).

* lsp: respect 80 chars per line in README.org · syl20bnr/spacemacs@db04cdb

  Added Sylvain, who authored this and several other clean-ups, to the "thanks to" for the new layer.

* lsp: add files header and rename lsp// functions · syl20bnr/spacemacs@ba66562

  Skipped; this commit is code-style improvements by Sylvain, who is already listed under "Various code style improvements" and under the "thanks to" for the lsp layer.

* lsp: hide lighter · syl20bnr/spacemacs@1c49c7f

  Skipped; more clean-up by Sylvain.

* lsp: create logical package flycheck-lsp · syl20bnr/spacemacs@be6db59

  Skipped; more clean-up by Sylvain.

* Add lsp-python layer · syl20bnr/spacemacs@66afcce

  Added under changes to the python layer (see the next commit).

* python: add support for Language Server Protocol · syl20bnr/spacemacs@81a931f

  Added author to the entry for the previous commit; in this commit, Sylvain took Yuan Fu's lsp-python layer and integrated it into the existing Python layer.

* Fix doc for first bunch of internal spacemacs layers · syl20bnr/spacemacs@d526121

  Skipped; author, Maximilian Wolff, is already listed under "Various documentation improvements".

* Fix doc for S>-completion and S>-editing-visual layers · syl20bnr/spacemacs@93ec421

  Skipped; same author.

* factor: rename snippet file · syl20bnr/spacemacs@671701f

  Skipped; this was another follow-up commit by the author of the layer.

* Latest updates for spacemacs-theme · syl20bnr/spacemacs@abda284

  Skipped; there is already an entry for spacemacs-theme crediting the same author.

* Key sequence to access FAQ · syl20bnr/spacemacs@ef36dbb

  Added author under "Various documentation improvements".

* Fix package initialization on Emacs 27 · syl20bnr/spacemacs@8395465

  Added under Core Changes.

* [prodigy] renames jump function · syl20bnr/spacemacs@d2458eb

  Added as "Compatibility fix for upstream change" under changes to the prodigy layer.

* add key bindings for profiling and spec browsing · syl20bnr/spacemacs@280c7b4

  Added key bindings under changes to the clojure layer.

* clojure: sort key bindings alphabetically · syl20bnr/spacemacs@a40b79a

  Skipped; docs clean-up by Sylvain.

* typescript: create derived mode for tsx · syl20bnr/spacemacs@6ec6af8

  Added under changes to the typescript layer.

* Add Japanese Layer · syl20bnr/spacemacs@570f7ef

  Added under New layers/Others (this is the only intl layer added in this release).

* japanese: add image and format README.org · syl20bnr/spacemacs@982308fo

  Skipped; docs clean-up by Sylvain.

* Make the Emacs server optional · syl20bnr/spacemacs@662b732

  Added under "Dotfile changes".

* Add defun spacemacs/python-test-last · syl20bnr/spacemacs@262c8ee

  Added under changes to the python layer.

* python: add doc for SPC m t l · syl20bnr/spacemacs@e99ca55

  Skipped; docs fix-up by Sylvain for the previous commit.

* Feature: Add "send to buffer" leader key in ruby layer · syl20bnr/spacemacs@f93fb22

  Added under changes to the ruby layer.

* Configure rg max column number for search. · syl20bnr/spacemacs@658c34b

  Added to the existing entry for the change that set an initial (non-configurable) ripgrep max column number of 150.

* helm: change default rg max-columns value to 512 and add doc · syl20bnr/spacemacs@13961e8

  Added to/amended the existing entry for ripgrap max column number.