### PR TITLE
A note about user-config and files supplied via command line arguments

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -151,6 +151,10 @@ in =user-init=, and any variable that Spacemacs explicitly sets but you wish to
 
 Anything that isn’t just setting a variable should 99% be in =user-config=.
 
+Note that at time of writing files supplied as command line arguments to emacs
+will be read before =user-config= is executed.  (Hence to yield consistent
+behaviour, mode hooks should be set in =user-init=.)
+
 ** Why do some of my =org=-related settings cause problems?
 Since version 0.104, spacemacs uses the =org= version from the org ELPA
 repository instead of the one shipped with emacs. Then, any =org= related code


### PR DESCRIPTION
I'd argue that user-config getting executed after files have been opened is not expected behaviour and should be mentioned in the docs more prominently (took me some time to stumble over #8849).