### PR TITLE
Updated change log (+753)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -198,7 +198,12 @@ Benner and Paweł Siudak):
 **** WEB services
 - confluence
 **** Spacemacs
-- treemacs (thanks to Alexander Miller)
+- spacemacs-defaults
+- spacemacs-modeline
+- spacemacs-navigation
+- spacemacs-project
+- spacemacs-purpose (thanks to bmag)
+- spacemacs-visual
 **** Tools
 - bm (thanks to Eugene Yaremenko)
 - lsp (thanks to Fangrui Song, 0bl.blwl, and Sylvain Benner)
@@ -207,11 +212,12 @@ Benner and Paweł Siudak):
 - sphinx (thanks to Wei-Wei Guo)
 - transmission (thanks to Eugene Yaremenko)
 - cmake (thanks to Alexander Dalshov and Sylvain Benner)
+- xclipboard (thanks to Charles Weill and Sylvain Benner)
 **** Others
 - japanese (thanks to Kenji Miyazaki)
 - multiple-cursors (thanks to Codruț Constantin Gușoi)
 - parinfer (thanks to Tianshu Shi)
-- spacemacs-purpose (thanks to bmag)
+- treemacs (thanks to Alexander Miller)
 *** Removed layers
 - =extra-langs= (replaced by ad-hoc layers)
 - =evil-cleverparens= (moved to =spacemacs-evil=)
@@ -323,10 +329,16 @@ Benner and Paweł Siudak):
 - Fixed package initialization on Emacs 27 (thanks to Miciah Dashiel Butler
   Masters)
 *** Distribution changes
-- Refactor =spacemacs-ui= and =spacemacs-ui-visual= layers:
-  - new =spacemacs-navigation= layer contains packages whose principal goal is
-    navigation
-  - new =spacemacs-modeline= layer contains packages about mode line
+- Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
+  layers:
+  - The =spacemacs-bootstrap= layer no longer configures built-in packages;
+    instead, the new =spacemacs-defaults= layer configures built-in packages.
+  - The =spacemacs-base= distribution now uses only the new =spacemacs-defaults=
+    layer. As a result, =spacemacs-base= no longer installs any packages, but
+    instead only configures defaults for built-in packages.
+  - The new =spacemacs-navigation= layer configures packages for navigation.
+  - The new =spacemacs-modeline= layer configures packages for the mode line.
+  - The new =spacemacs-project= layer configures =projectile=.
   - Merge =spacemacs-ui= and =spacemacs-ui-visual= into layer =spacemacs-visual=
 - New Packages:
   - Add =evil-lion= package to =spacemacs-evil= layer (thanks to et2010 and
@@ -434,6 +446,8 @@ Benner and Paweł Siudak):
     - ~SPC m t w~ calls =image-transform-fit-to-width=
     - ~SPC m t s~ calls =image-transform-set-scale=
     - ~SPC m t r~ calls =image-transform-rotation=
+  - New ~SPC w 1~ to set the window layout to a single column (thanks to
+    Alejandro Arrufat)
 - Fixes:
   - Disable the paste transient state when using multiple cursors
     (thanks to Koray AL)
@@ -534,6 +548,7 @@ Benner and Paweł Siudak):
   Benner)
 - Switched =center-cursor-mode= to melpa source (thanks to Dieter Komendera)
 - Fix =projectile-switch-project-action= (thanks to John Soo)
+- Configured =golden-ratio= to update after ~[ w~ and ~] w~ (thanks to duianto)
 *** Layer changes and fixes
 **** Ansible
 - Add support for multiple vault password files, see later README.org
@@ -674,6 +689,7 @@ Benner and Paweł Siudak):
 - Kill buffer shall return to *docker-containers* (thanks to Francesc Elies
 - Key bindings:
   - Moved key bindings prefix from ~SPC D~ to ~SPC a D~ (thanks to Ag Ibragimov)
+  - Added ~SPC m c B~ to build image without cache (thanks to Maximilian Wolff)
   Henar)
 - Fix: broken package declaration for dockerfile-mode (thanks to Maximilian Wolff)
 **** Elfeed
@@ -805,6 +821,8 @@ is enabled
   Benner)
 - Add Gradle support (thanks to Johnson Denen)
 - Improve maven and gradle support (thanks to Sylvain Benner)
+- Key bindings:
+  - Added ~SPC m r i~ to add import (thanks to Sylvain Benner)
 **** Gtags
 - Key bindings:
   - Move key binding ~SPC m g c~ to ~SPC m g C~ (regenerate tags)
@@ -843,6 +861,11 @@ is enabled
   candidates by distributing buffers over existing windows until the action has
   either assigned all buffers or run out of windows (thanks to Nir Friedman)
 - Fix signature of =spacemacs//display-helm-window= (thanks to Jack Kamm)
+- Fix initialization by calling =helm-mode= when Helm is initialized (thanks to
+  bet4it).
+- Fixed actions in Helm transient state (thanks to Troy Hinckley)
+- Added support for editing the =helm-find-files= buffer from the Helm transient
+  state (thanks to Troy Hinckley)
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Add =counsel-css= as an ivy alternative to =helm-css-scss= (thanks to Robbert
@@ -915,6 +938,9 @@ is enabled
 - Make java layer depend on groovy layer (thanks to Sylvain Benner)
 **** Javascript
 - Leverage js-doc Yasnippet integration if available (thanks to Andriy Kmit')
+- Added LSP support, which can be used by enabling the =lsp= layer and setting
+  the =javascript= layer's =javascript-backend= variable to =lsp= (thanks to
+  Ting Zhou)
 - Key bindings
   - Improve coffeescript support (thanks to Kalle Lindqvist)
     - ~SPC m '~ to create or go to REPL
@@ -1276,6 +1302,8 @@ is enabled
 - Remove zonokai-theme theme as it is unavailable (thanks to nickclasener)
 - Updates to the spacemacs theme (thanks to Nasser Alshammari)
 - Fix the =base16-solarflare= mapping (thanks to Sebastian Nagel)
+- Added support for kaolin themes (thanks to William Roe)
+- Added support for eziam themes (thanks to Benno Fünfstück)
 ***** Colors
 - Add ability to set default rainbow-identifiers values (thanks to SteveJobzniak)
 - Improved resetting of rainbow-identifiers transient-state (thanks to SteveJobzniak)
@@ -1289,6 +1317,7 @@ is enabled
 - Add =white-sand-theme= (thanks to Swaroop C H)
 - Add =exotica= theme (thanks to Bharat Joshi)
 - Remove themes that were deleted from Melpa (thanks to Henrique Jung)
+- Added =eziam-theme= and =kaolin-themes= (thanks to Sylvain Benner)
 **** Tmux
 - Prevent =tmux-command= at GUI mode (thanks to Isaac Zeng)
 **** Typescript
@@ -1298,6 +1327,9 @@ is enabled
 - Adds tide keybindings to tsx web mode (thanks to George Miller)
 - Rewrite hooks for web-mode (thanks to Sylvain Benner)
 - Created a derived mode for TSX files (thanks to Aaron Jensen)
+- Added LSP support, which can be used by enabling the =lsp= layer and setting
+  the =typescript= layer's =typescript-backend= variable to =lsp= (thanks to
+  Ting Zhou)
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)
@@ -1343,7 +1375,8 @@ is enabled
   Yaremenko)
 - Various code style improvements (thanks to bmag, duianto, Eivind Fonn, Eugene
   Yaremenko, Sylvain Benner)
-- Multiple unit test improvements (thanks to Sylvain Benner)
+- Multiple unit test improvements (thanks to Sylvain Benner and Codruț
+  Constantin Gușoi)
 - Various documentation improvements (thanks Aaron Jensen, Aaron Peckham, Adam
   Frey, Adam Kruszewski, Alexander Dalshov, Alexander Iljin, Alexander Kjeldaas,
   Alexandros Kotzias, Anton Latukha, Anurag Sharma, Archenoth, Benjamin
@@ -1366,6 +1399,8 @@ is enabled
   SteveJobzniak, Sunghyun Hwang, Swaroop C H, Sylvain Benner, Szunti, Tim
   Stewart, timor, TinySong, Titov Andrey, Thomas de Beauchêne, Tomasz
   Cichocinski, tzhao11, Vladimir Kochnev, Wieland Hoffmann, Yi Liu, zer09)
+# Add additional names as comma separated lines for easier merging/diffing
+  Philippe Bourdages,
 *** Release notes summarized
   Thanks to: Grant Shangreaux, Songpeng Zu, Igor Almeida, Miciah Dashiel Butler
   Masters


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+753
Started with: cff0bb19bff5ba66b6fa8b60356aa6fa9825a740

New pointer: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+718
Start with: 4cc57dea74b9b3391821b518c5fad76153904972

---

* c-c++: replace toggle-auto-newline lambda by a named function · syl20bnr/spacemacs@cff0bb1

  Skipped; code clean-up by Sylvain.

* Revert "Defer packages by default using use-package-always-defer" · syl20bnr/spacemacs@ebe4c60

  Skipped; see discussion at https://github.com/syl20bnr/spacemacs/pull/11779#discussion_r244628666.

* Call helm-mode when helm is initialized · syl20bnr/spacemacs@b0f7761

  Added under changes to the helm layer.  Note that this change was made for https://github.com/syl20bnr/spacemacs/issues/9826, and the issue has been labeled "Fixed in develop", but several people have since reported that they continue to see the issue, so it may warrant some follow-up changes.  I have asked those people to post a backtrace.

* Fix line separation in README · syl20bnr/spacemacs@2e8727a

  Skipped; docs clean-up by Sylvain.

* reorganize spacemacs-base distribution into +spacemacs/spacemacs-xxx · syl20bnr/spacemacs@0fa3658

  Added spacemacs-defaults and spacemacs-project under New layers/Spacemacs, and added details under "Distribution changes".

  I also added spacemacs-modeline, spacemacs-navigation, and spacemacs-visual, which were added in earlier commits, under New layers/Spacemacs.  @sdwolfz, was it an oversight to omit these layers from the list of new layers, or should I not be adding the new spacemacs-* layers that resulted from refactorings? I figured it would be easier to delete unwanted entries than to add missing entries, so I went ahead and added everything.

  These changes are rather complex, so apologies if I muddled things up, and let me know if I can make the changes clearer.

  I also noticed that the change log entry for the spacemacs-purpose layer was under New layers/Others, so I moved the entry under New layers/Spacemacs.

  I also noticed that the change log entry for the treemacs layer was under New layers/Spacemacs even though the layer is under the layers/+filetree/ directory.  There is no other new layer under layers/+filetree/, so rather than create a new New layers/Filetree subsection with only one entry, I moved treemacs to New layers/Others in the change log.

* Make sure that docs pass formatting cheques. · syl20bnr/spacemacs@d4017b1

  Skipped; docs clean-up by JAremko.

* groovy: add import for symbol key binding · syl20bnr/spacemacs@fcd9d31

  Added under changes to the groovy layer.

* core: update Quelpa to last version · syl20bnr/spacemacs@2be6e4e

  Skipped; there is already an entry for updating Quelpa crediting Sylvain (who also authored his commit), and there is a more recent change that also updates Quelpa, so it is not worth adding the specific version of Quelpa for this change.

* Add: add lsp-javascript backend for javascript layer · syl20bnr/spacemacs@f3ee2ed

  Added under changes to the javascript layer.

* Fix: remove unnecessary comments · syl20bnr/spacemacs@64cd095

  Skipped; fix-up to the previous commit by the author of that commit.

* Clean: rename lsp prefix fix function names · syl20bnr/spacemacs@a7982de

  Skipped; another fix-up by the same author.

* Clean: move spacemacs//set-lsp-key-bindings to lsp layer · syl20bnr/spacemacs@8df99c4

  Skipped; another fix-up by the same author.

* Docs: fix javascript doc · syl20bnr/spacemacs@aaa8c93

  Skipped; another fix-up by the same author.

* lsp: fix typo · syl20bnr/spacemacs@4eaf160

  Skipped; docs clean-up by Sylvain.

* Fix Typescript key binding typo · syl20bnr/spacemacs@4ac8e4e

  Added author under "Various documentation improvements".

* Add: lsp-typescript support · syl20bnr/spacemacs@59e0c56

  Added under changes to the typescript layer.

* typescript: update README.org for multiple backends · syl20bnr/spacemacs@522eafb

  Skipped; docs clean-up by Sylvain.

* javascript: minor update of README.org · syl20bnr/spacemacs@ed80e41

  Skipped; docs clean-up by Sylvain.

* Rename set-lsp-key-bindings and make it accept a list of modes · syl20bnr/spacemacs@7596a15

  Skipped; code clean-up by Sylvain.

* Fixes CI failure · syl20bnr/spacemacs@0d9b349

  Added Codruț Constantin Gușoi to the "thanks to" under "Multiple unit test improvements".

* Fixes TOC formatting for python layer · syl20bnr/spacemacs@775fb50

  Skipped; docs clean-up by sdwolfz.

* Add keybinding to docker layer to build image without cache · syl20bnr/spacemacs@bf61b15

  Added under changes to the docker layer.

* Add kaolin themes to spacemacs-theme-name-to-package · syl20bnr/spacemacs@4acf1cd

  Added under changes to themes.

* core-themes-support.el: add eziam theme names · syl20bnr/spacemacs@d0833bc

  Added under changes to themes.

* fixed helm action in helm transient state · syl20bnr/spacemacs@aa5bc03

  Added under changes to the helm layer.

* pcre2el: move ownership to bootstrap · syl20bnr/spacemacs@260c3d9

  Skipped; code clean-up by bmag, related to the spacemacs-bootstrap refactoring.

* Add function and keybinding for single column window layer. · syl20bnr/spacemacs@5ea833f

  Added under "Distribution changes".

* Reenable magithub · syl20bnr/spacemacs@4053010

  Skipped; it is a trivial change that reverts an earlier change.

* add support for helm find files edit to helm-navigation transient state · syl20bnr/spacemacs@19b7d40

  Added under changes to the helm layer.

* Add golden-ratio support to evil-unimpaired · syl20bnr/spacemacs@a64417b

  Added under "Distribution changes".

* Add eziam and kaolin themes to themes-megapack layer · syl20bnr/spacemacs@df90ec6

  Added under changes to "Themes Megapack".

* Add SPC w 1..3 key bindings to documentation · syl20bnr/spacemacs@901fd09

  Skipped; docs fix by Sylvain.

* Add X clipboard support layer to terminal emacs. · syl20bnr/spacemacs@e4cb2b3

  Added under New layers/Tools.

* Move xclipboard to a local package · syl20bnr/spacemacs@1befcad

  Added author (Sylvain) to the "thanks to" for the new layer.

* Fix xclipboard local package name · syl20bnr/spacemacs@bb84c4a

  Skipped; fix-up by Sylvain to the previous commit.