### PR TITLE
Updated change log (+718)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -197,6 +197,8 @@ Benner and Paweł Siudak):
 - protobuf (thanks to Amol Mandhane)
 - restructuredtext (thanks to Wei-Wei Guo)
 - semantic-web (thanks to Andreas Textor)
+- coffeescript (thanks to Sylvain Benner)
+- json (thanks to Sylvain Benner)
 **** WEB services
 - confluence
 **** Spacemacs
@@ -214,7 +216,8 @@ Benner and Paweł Siudak):
 - sphinx (thanks to Wei-Wei Guo)
 - transmission (thanks to Eugene Yaremenko)
 - cmake (thanks to Alexander Dalshov and Sylvain Benner)
-- xclipboard (thanks to Charles Weill and Sylvain Benner)
+- xclipboard (thanks to Charles Weill, Sylvain Benner, and Alex Palaistras)
+- debug (thanks to Troy Hinckley and Sylvain Benner)
 **** Others
 - japanese (thanks to Kenji Miyazaki)
 - multiple-cursors (thanks to Codruț Constantin Gușoi)
@@ -333,6 +336,8 @@ Benner and Paweł Siudak):
 - Lazy load =diff-hl= and move =lsp-ui-mode= hook (thanks to Sylvain Benner)
 - Wrap init with =file-name-handler-alist nil= to speed up init (thanks to Aaron
   Jensen)
+- Added optional =append= and =local= parameters to =spacemacs/add-to-hooks=
+  (thanks to Sylvain Benner)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:
@@ -455,6 +460,8 @@ Benner and Paweł Siudak):
     (thanks to Alexander Miller)
   - New ~SPC w 1~ to set the window layout to a single column (thanks to
     Alejandro Arrufat)
+  - New ~SPC w 4~ to set the window layout to a 2x2 grid (thanks to Alejandro
+    Arrufat, Codruț Constantin Gușoi, and bmag).
 - Fixes:
   - Disable the paste transient state when using multiple cursors
     (thanks to Koray AL)
@@ -614,6 +621,7 @@ Benner and Paweł Siudak):
 - Fix publish in README (thanks to Eugene Yaremenko)
 - Add =ob-cfengine3= (thanks to Nick Anderson)
 - Configure =org-babel= for cfengine source blocks (thanks to Sylvain Benner)
+- Fixed flycheck initialization for syntax checking (thanks to Nick Anderson)
 **** Chinese
 - Add package =chinese-conv= for conversion between simplified and traditional
   Chinese texts (Xiang Ji)
@@ -949,7 +957,7 @@ is enabled
 - Leverage js-doc Yasnippet integration if available (thanks to Andriy Kmit')
 - Added LSP support, which can be used by enabling the =lsp= layer and setting
   the =javascript= layer's =javascript-backend= variable to =lsp= (thanks to
-  Ting Zhou)
+  Ting Zhou and Sylvain Benner)
 - Key bindings
   - Improve coffeescript support (thanks to Kalle Lindqvist)
     - ~SPC m '~ to create or go to REPL
@@ -1359,8 +1367,11 @@ is enabled
     (thanks to Simon Altschuler)
 - Added LSP support, which can be used by enabling the =lsp= layer and setting
   the =typescript= layer's =typescript-backend= variable to =lsp= (thanks to
-  Ting Zhou)
->>>>>>> a7f0331cd... Updated change log
+  Ting Zhou and Sylvain Benner)
+- Changed =company-minimum-prefix-length= from 0 to 2 to avoid spurious
+  autocompletion (thanks to Andrea Moretti)
+- Enabled snippets using yasnippet (thanks to Andrea Moretti)
+- Enabled =smartparens-mode= (thanks to Andrea Moretti)
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+718
Started with: 4cc57dea74b9b3391821b518c5fad76153904972

New pointer: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+683
Start with: 5b70ac500963390c0343bd78eafa6ead177f0405

---

* Fix automatic syntax checking for cfengine · syl20bnr/spacemacs@4cc57de

  Added under changes to the cfengine layer.

* Fix `l` keybinding in neotree to open in MRU window · syl20bnr/spacemacs@7982406

  Skipped; fix by Sylvain for a regression against the last release.

* Fix: remove buggy hooks in javascript and typescript · syl20bnr/spacemacs@5c14486

  Skipped; fix-up by the original author of the code (who is already credited).

* xclipboard: Fix keybindings for copy and page · syl20bnr/spacemacs@70c1737

  Added author of this commit to the "thanks to" for the new layer.

* javascript: add default value for tern-command and remove toggle · syl20bnr/spacemacs@f9968bf

  Added; this is a clean-up/fix-up for the LSP support in the javascript layer, so I added the commit author (Sylvain) to the "thanks to" for LSP support in that layer.

* Fix: use recipe for lsp-javascript-typescript · syl20bnr/spacemacs@5a92c43

  Skipped; this is a fix-up to the LSP support in the javascript layer by the original author of that code.

* typescript: avoid 0 char autocomplete · syl20bnr/spacemacs@8081d51

  Added under changes to the typescript layer.  This commit actually snuck in two changes, one to set `company-minimum-prefix-length` to 2 and another to enable yasnippets, so I added two entries to the change log.

* core: add optional append local paremeters to spacemacs/add-to-hooks · syl20bnr/spacemacs@d8479b8

  Added under "Core changes".

* add smartparens mode · syl20bnr/spacemacs@3a51643

  Added under changes to the typescript layer.

* typescript: use spacemacs/add-to-hooks function · syl20bnr/spacemacs@14a5b8c

  Skipped; this is a code clean-up by Sylvain.

* auto-completion: fix variables not set with multiple modes · syl20bnr/spacemacs@439dafb

  Skipped; this is a fix by Sylvain to `spacemacs|add-company-backends`, which is new since the last release (and already has a change log entry).

* auto-completion: fix duplicate addtion of backends · syl20bnr/spacemacs@40f28c7

  Skipped; this is another fix by Sylvain to `spacemacs|add-company-backends`.

* auto-completion: add :call-hooks and rename :hooks to :append-hooks · syl20bnr/spacemacs@40f4176

  Skipped; this is another change by Sylvain to `spacemacs|add-company-backends`.

* typescript: fix hooks to take into account directory variables · syl20bnr/spacemacs@883f57e

  Added the commit author, Sylvain, to the "thanks to" for LSP support under changes to the typescript layer.

* typescript, java: use new :append-hooks and :call-hooks · syl20bnr/spacemacs@0877f2f

  Skipped; this appears to be a fix by Sylvain to the multiple backends support that Sylvain originally authored, which is new since the last release (and already has a change log entry).

* typescript: fix usage of hooks in multiple backends setup · syl20bnr/spacemacs@f422354

  Skipped; this is another fix by Sylvain to code added as part of the LSP support in the typescript layer.

* typescript: add safe values for typescript-backend variable · syl20bnr/spacemacs@1a5664e

  Skipped; this is another fix by Sylvain to LSP support in the typescript layer.

* create debug layer · syl20bnr/spacemacs@6e68473

  Added under New layers/Tools.

* Sort packages alphabetically and add spacemacs function prefix · syl20bnr/spacemacs@5cdc1ed

  Added author, Sylvain, to the "thanks to" for the new debug layer.

* debug: fix doc for eval variable and sort key bindings · syl20bnr/spacemacs@0a32d33

  Skipped; this is another clean-up by Sylvain to the new debug layer.

* javascript: fix multiple backends · syl20bnr/spacemacs@9820484

  Skipped; this is more fixes to LSP support and general clean-up by Sylvain in the javascript and typescript layers.

* javascript: sort packages · syl20bnr/spacemacs@7d6fd4f

  Skipped; this is another clean-up by Sylvain.

* javascript: add safe values for javascript backend · syl20bnr/spacemacs@1a0e5e3

  Skipped; this is a fix-up by Sylvain related to LSP support in the javascript and typescript layers.

* javascript: fix post-init-imenu func name · syl20bnr/spacemacs@17b8e9d

  Skipped; this is a fix-up by Sylvain to syl20bnr/spacemacs@9820484.

* typescript: fix backend name in typescript-setup-eldoc · syl20bnr/spacemacs@9123ffc

  Skipped; this is a fix-up by Sylvain to syl20bnr/spacemacs@f422354.

* New layer coffeescript (extracted from javacript layer) · syl20bnr/spacemacs@ca07366

  Added under New layers/Languages.

* coffeescript: add jump handler · syl20bnr/spacemacs@e7c103b

  Skipped; this is a fix-up by Sylvain to the new layer that he added in the previous commit.

* python: fix company when opening a buffer for the 1st time · syl20bnr/spacemacs@996cc91

  Skipped; this is a fix by Sylvain for a regression against the last release.  (The issue report that is referenced in the commit message is against the develop branch, and I was not able to reproduce the issue on the master branch.)

* coffeescript: add org-babel integration · syl20bnr/spacemacs@c3ebeb2

  Skipped; this is an addition to the new coffeescript layer by the original author (Sylvain) of that layer.

* coffeescript: fix doc. tests · syl20bnr/spacemacs@eeec23b

  Skipped; this is a docs clean-up by Sylvain.

* javascript: remove references about coffeescript in README.org · syl20bnr/spacemacs@9164407

  Skipped; this is a docs clean-up by Sylvain.

* java: enable flycheck for meghanada backend only if possible · syl20bnr/spacemacs@ac4b268

  Skipped; this is a fix by Sylvain to the multiple backends support that Sylvain originally authored, which is new since the last release (and already has a change log entry).

* Create new json layer extracted from javascript layer · syl20bnr/spacemacs@e481894

  Added under New layers/Languages.

* Add 2x2 grid layout shortcut · syl20bnr/spacemacs@cbf6de8

  Added under "Distribution changes".

* Split windows as @bmag suggested. · syl20bnr/spacemacs@d4c8513

  Added commit author (Codruț Constantin Gușoi) and bmag (credited in the commit message) to the "thanks to" for the change in the previous commit.