### PR TITLE
Enable experimental support for lsp within the php layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2254,6 +2254,8 @@ Other:
 **** PHP
 - Added company-php (thanks to jim and Eivind Fonn)
 - Fixed php-company autocompletion (thanks to Dela Anthonio)
+- Added LSP support, which can be used by enabling the =lsp= layer and setting
+  the =php= layer's =php-backend= variable to =lsp=
 **** PlantUML
 - Added a missing prefix: =compile=
 **** Platinum

--- a/layers/+lang/php/README.org
+++ b/layers/+lang/php/README.org
@@ -8,6 +8,10 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
+  - [[#setting-the-backend][Setting the backend]]
+- [[#backend][Backend]]
+  - [[#language-server-protocol][Language Server Protocol]]
 - [[#key-bindings][Key bindings]]
 - [[#usage][Usage]]
 
@@ -20,14 +24,37 @@ This layer adds PHP language support to Spacemacs.
 - Complete and jump to define with [[https://github.com/xcwen/ac-php][company-php]]
 - Run tests with PHPUnit
 - Reformat code with PHP CBF
+- Support for the [[https://langserver.org/][Language Server Protocol]] (experimental)
 
 The =gtags= layer is recommended to benefit from better =eldoc= and
 =helm-gtags=.
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =php= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** Setting the backend
+To activate the backend set the layer variable =php-backend=:
+
+#+BEGIN_SRC elisp
+  (php :variables php-backend 'lsp)
+#+END_SRC
+
+For spacemacs to use lsp you also need to add =lsp= to the
+=dotspacemacs-configuration-layers= in your =~/.spacemacs= file.
+
+* Backend
+** Language Server Protocol
+You have to install the php language server:
+
+#+BEGIN_SRC sh
+  composer require felixfbecker/language-server
+  composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+#+END_SRC
+
++You can find further information on the project's [[https://github.com/felixfbecker/php-language-server%20][GitHub page]].
 
 * Key bindings
 

--- a/layers/+lang/php/README.org
+++ b/layers/+lang/php/README.org
@@ -12,6 +12,8 @@
   - [[#setting-the-backend][Setting the backend]]
 - [[#backend][Backend]]
   - [[#language-server-protocol][Language Server Protocol]]
+    - [[#intelephense][intelephense]]
+    - [[#php-language-server][php-language-server]]
 - [[#key-bindings][Key bindings]]
 - [[#usage][Usage]]
 
@@ -47,14 +49,25 @@ For spacemacs to use lsp you also need to add =lsp= to the
 
 * Backend
 ** Language Server Protocol
-You have to install the php language server:
+=lsp-mode= currently supports two lsp backends for php. When both are installed,
+the former takes priority over the latter:
+
+*** intelephense
+
+#+BEGIN_SRC sh
+  nmp install -g intelephense
+#+END_SRC
+
+You can find further information on the project's [[http://intelephense.net/][website]] and [[https://github.com/bmewburn/vscode-intelephense][GitHub page]].
+
+*** php-language-server
 
 #+BEGIN_SRC sh
   composer require felixfbecker/language-server
   composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 #+END_SRC
 
-+You can find further information on the project's [[https://github.com/felixfbecker/php-language-server%20][GitHub page]].
+You can find further information on the project's [[https://github.com/felixfbecker/php-language-server%20][GitHub page]].
 
 * Key bindings
 

--- a/layers/+lang/php/config.el
+++ b/layers/+lang/php/config.el
@@ -13,3 +13,6 @@
 
 
 (spacemacs|define-jump-handlers php-mode)
+
+(defvar php-backend nil
+  "The backend to use for IDE features. Possible values are `lsp'.")

--- a/layers/+lang/php/funcs.el
+++ b/layers/+lang/php/funcs.el
@@ -22,21 +22,3 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (lsp)
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
-
-(defun spacemacs//php-setup-company ()
-  "Conditionally setup company based on backend."
-  (message "%s setting up company" php-backend)
-  (pcase php-backend
-    (`lsp (spacemacs//php-setup-lsp-company))))
-
-(defun spacemacs//php-setup-lsp-company ()
-  "Setup lsp auto-completion."
-  (if (configuration-layer/layer-used-p 'lsp)
-      (progn
-        (spacemacs|add-company-backends
-          :backends company-lsp
-          :modes php-mode
-          :append-hooks nil
-          :call-hooks t)
-        (company-mode))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))

--- a/layers/+lang/php/funcs.el
+++ b/layers/+lang/php/funcs.el
@@ -1,0 +1,42 @@
+;;; funcs.el --- PHP Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+;; lsp
+
+(defun spacemacs//php-setup-backend ()
+  "Conditionally setup php backend."
+  (pcase php-backend
+    (`lsp (spacemacs//php-setup-lsp))))
+
+(defun spacemacs//php-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//php-setup-company ()
+  "Conditionally setup company based on backend."
+  (message "%s setting up company" php-backend)
+  (pcase php-backend
+    (`lsp (spacemacs//php-setup-lsp-company))))
+
+(defun spacemacs//php-setup-lsp-company ()
+  "Setup lsp auto-completion."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (progn
+        (spacemacs|add-company-backends
+          :backends company-lsp
+          :modes php-mode
+          :append-hooks nil
+          :call-hooks t)
+        (company-mode))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -78,6 +78,3 @@
       (spacemacs|add-company-backends
         :modes php-mode
         :backends company-ac-php-backend))))
-
-(defun php/post-init-company ()
-  (add-hook 'php-mode-local-vars-hook #'spacemacs//php-setup-company))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -55,7 +55,10 @@
 (defun php/init-php-mode ()
   (use-package php-mode
     :defer t
-    :mode ("\\.php\\'" . php-mode)))
+    :mode ("\\.php\\'" . php-mode))
+    :init
+    (progn
+      (add-hook 'php-mode-hook 'spacemacs//php-setup-backend)))
 
 (defun php/init-phpcbf ()
   (use-package phpcbf
@@ -75,3 +78,6 @@
       (spacemacs|add-company-backends
         :modes php-mode
         :backends company-ac-php-backend))))
+
+(defun php/post-init-company ()
+  (add-hook 'php-mode-local-vars-hook #'spacemacs//php-setup-company))


### PR DESCRIPTION
Adds php LSP support.

Inspired by the python implementation.

Completion and jump to definition are working in first tests.

Still TODO:

- Further testing

Since this is my first work on `spacemacs` and also coding in `elisp` I'm grateful for all comments.