### PR TITLE
Enable experimental support for lsp within the shell-scripts layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2551,6 +2551,8 @@ Other:
 - Added insert commands from sh-script package to major mode menu
   (thanks to Maximilian Wolff)
 - Added org-mode support (thanks to Josh Santos)
+- Added LSP support, which can be used by enabling the =lsp= layer and setting
+  the =shell-scripts= layer's =shell-scripts-backend= variable to =lsp=
 **** Slack
 - New layer variable =slack-spacemacs-layout-name= to customize the name of
   the custom layer for Slack buffers (thanks to Benjamin Reynolds)

--- a/layers/+lang/shell-scripts/README.org
+++ b/layers/+lang/shell-scripts/README.org
@@ -8,8 +8,12 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
   - [[#linting][Linting]]
   - [[#style-checking][Style checking]]
+  - [[#setting-the-backend][Setting the backend]]
+- [[#backend][Backend]]
+  - [[#language-server-protocol][Language Server Protocol]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -25,8 +29,10 @@ Supported scripting files:
 - Auto-completion using [[https://github.com/Alexander-Miller/company-shell][company-shell]]
 - =Sh= scripts linting using [[https://www.shellcheck.net/][shellcheck]]
 - =Sh= scripts style checking using [[https://github.com/openstack-dev/bashate][bashate]]
+- Support for the [[https://langserver.org/][Language Server Protocol]] (experimental)
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =shell-scripts= to the existing =dotspacemacs-configuration-layers= list in this
 file.
@@ -36,6 +42,26 @@ In order to enable =sh= scripts linting, install [[https://www.shellcheck.net/][
 
 ** Style checking
 In order to enable =sh= scripts style checking, install [[https://github.com/openstack-dev/bashate][bashate]].
+
+** Setting the backend
+To activate the backend set the layer variable =shell-scripts-backend=:
+
+#+BEGIN_SRC elisp
+  (shell-scripts :variables shell-scripts-backend 'lsp)
+#+END_SRC
+
+For spacemacs to use lsp you also need to add =lsp= to the
+=dotspacemacs-configuration-layers= in your =~/.spacemacs= file.
+
+* Backend
+** Language Server Protocol
+You have to install the bash language server:
+
+#+BEGIN_SRC sh
+  npm i -g bash-language-server
+#+END_SRC
+
+You can find further information on the project's [[https://github.com/mads-hartmann/bash-language-server][GitHub page]].
 
 * Key bindings
 

--- a/layers/+lang/shell-scripts/config.el
+++ b/layers/+lang/shell-scripts/config.el
@@ -12,3 +12,6 @@
 ;; variables
 
 (spacemacs|define-jump-handlers sh-mode)
+
+(defvar shell-scripts-backend nil
+  "The backend to use for IDE features. Possible values are `lsp'.")

--- a/layers/+lang/shell-scripts/funcs.el
+++ b/layers/+lang/shell-scripts/funcs.el
@@ -18,3 +18,35 @@
   (require 'insert-shebang)
   (insert-shebang-get-extension-and-insert
    (file-name-nondirectory (buffer-file-name))))
+
+
+;; lsp
+
+(defun spacemacs//shell-scripts-setup-backend ()
+  "Conditionally setup shell-scripts backend."
+  (pcase shell-scripts-backend
+    (`lsp (spacemacs//shell-scripts-setup-lsp))))
+
+(defun spacemacs//shell-scripts-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//shell-scripts-setup-company ()
+  "Conditionally setup company based on backend."
+  (message "%s setting up company" shell-scripts-backend)
+  (pcase shell-scripts-backend
+    (`lsp (spacemacs//shell-scripts-setup-lsp-company))))
+
+(defun spacemacs//shell-scripts-setup-lsp-company ()
+  "Setup lsp auto-completion."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (progn
+        (spacemacs|add-company-backends
+          :backends company-lsp
+          :modes sh-mode
+          :append-hooks nil
+          :call-hooks t)
+        (company-mode))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))

--- a/layers/+lang/shell-scripts/funcs.el
+++ b/layers/+lang/shell-scripts/funcs.el
@@ -32,21 +32,3 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (lsp)
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
-
-(defun spacemacs//shell-scripts-setup-company ()
-  "Conditionally setup company based on backend."
-  (message "%s setting up company" shell-scripts-backend)
-  (pcase shell-scripts-backend
-    (`lsp (spacemacs//shell-scripts-setup-lsp-company))))
-
-(defun spacemacs//shell-scripts-setup-lsp-company ()
-  "Setup lsp auto-completion."
-  (if (configuration-layer/layer-used-p 'lsp)
-      (progn
-        (spacemacs|add-company-backends
-          :backends company-lsp
-          :modes sh-mode
-          :append-hooks nil
-          :call-hooks t)
-        (company-mode))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -35,9 +35,6 @@
         :backends (company-shell company-shell-env company-fish-shell)
         :modes fish-mode))))
 
-(defun shell-scripts/post-init-company ()
-  (add-hook 'sh-mode-local-vars-hook #'spacemacs//shell-scripts-setup-company))
-
 (defun shell-scripts/post-init-flycheck ()
   (spacemacs/enable-flycheck 'sh-mode))
 

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -35,6 +35,9 @@
         :backends (company-shell company-shell-env company-fish-shell)
         :modes fish-mode))))
 
+(defun shell-scripts/post-init-company ()
+  (add-hook 'sh-mode-local-vars-hook #'spacemacs//shell-scripts-setup-company))
+
 (defun shell-scripts/post-init-flycheck ()
   (spacemacs/enable-flycheck 'sh-mode))
 
@@ -84,7 +87,8 @@
         (when (and buffer-file-name
                    (string-match-p "\\.zsh\\'" buffer-file-name))
           (sh-set-shell "zsh")))
-      (add-hook 'sh-mode-hook 'spacemacs//setup-shell))))
+      (add-hook 'sh-mode-hook 'spacemacs//setup-shell)
+      (add-hook 'sh-mode-hook 'spacemacs//shell-scripts-setup-backend))))
 
 (defun shell-scripts/post-init-ggtags ()
   (add-hook 'sh-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
Note that this is only valid for bash scripts, since it uses the
`bash-language-server` defined in `lsp-clients.el`

Adds LSP support for `bash` shell scripts.

Inspired by the python implementation.

Completion and jump to definition are working in first tests.

Still TODO:

Further testing

Since this is my first work on `spacemacs` and also coding in `elisp` I'm grateful for all comments.