### PR TITLE
Update Symbol Highlight TS: Reorder keys

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -68,8 +68,8 @@
             ahs-inhibit-face-list nil
             spacemacs--symbol-highlight-transient-state-doc "
  %s
- [_n_] next   [_N_/_p_] prev  [_d_/_D_] next/prev def  [_r_] range  [_R_] reset
- [_e_] iedit  [_z_] recenter")
+ [_n_] next   [_N_/_p_] prev  [_d_/_D_] next/prev def  [_r_] range  [_R_] reset  [_z_] recenter
+ [_e_] iedit")
 
       ;; since we are creating our own maps,
       ;; prevent the default keymap from getting created


### PR DESCRIPTION
What: Move "[z] recenter" to end of first row.
Why:  Top row (red keys) will not exit, bottom row (blue keys) exits.

---

Before: 

![symbol highlight transient state before](https://user-images.githubusercontent.com/13420573/50722020-42669200-10c9-11e9-9bb2-97fc5ceec4b8.png)

After:

![symbol highlight transient state after](https://user-images.githubusercontent.com/13420573/50722021-498da000-10c9-11e9-9d84-9401e996dcb6.png)
