### PR TITLE
Updated change log (+648)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -189,7 +189,7 @@ Benner and Paweł Siudak):
 - forth (thanks to Tim Jaeger)
 - gpu (thanks to Evan Klitzke)
 - groovy (thanks to Sylvain Benner)
-- hy (thanks to TODO: add author here)
+- hy (thanks to Sylvain Benner)
 - jr (thanks to Philippe Baron)
 - koltin (thanks to Shanavas M)
 - perl5 (thanks to Troy Hinckley)
@@ -218,11 +218,13 @@ Benner and Paweł Siudak):
 - cmake (thanks to Alexander Dalshov and Sylvain Benner)
 - xclipboard (thanks to Charles Weill, Sylvain Benner, and Alex Palaistras)
 - debug (thanks to Troy Hinckley and Sylvain Benner)
+- web-beautify (thanks to Sylvain Benner and Juuso Valkeejärvi)
+- tern (thanks to Sylvain Benner and Juuso Valkeejärvi)
 **** Others
 - japanese (thanks to Kenji Miyazaki)
 - multiple-cursors (thanks to Codruț Constantin Gușoi)
 - parinfer (thanks to Tianshu Shi)
-- treemacs (thanks to Alexander Miller)
+- treemacs (thanks to Alexander Miller and Sylvain Benner)
 *** Removed layers
 - =extra-langs= (replaced by ad-hoc layers)
 - =evil-cleverparens= (moved to =spacemacs-evil=)
@@ -338,6 +340,12 @@ Benner and Paweł Siudak):
   Jensen)
 - Added optional =append= and =local= parameters to =spacemacs/add-to-hooks=
   (thanks to Sylvain Benner)
+- Fixed bugs that could cause =layers.el= and =packages.el= files to be loaded
+  multiple times (thanks to Sylvain Benner)
+- Changed startup to hide loading message unless =--debug-init= is specified
+  (thanks to Sylvain Benner)
+- Added support for dumping Spacemacs; see =EXPERIMENTAL.org= (thanks to Sylvain
+  Benner).
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:
@@ -563,6 +571,7 @@ Benner and Paweł Siudak):
 - Switched =center-cursor-mode= to melpa source (thanks to Dieter Komendera)
 - Fix =projectile-switch-project-action= (thanks to John Soo)
 - Configured =golden-ratio= to update after ~[ w~ and ~] w~ (thanks to duianto)
+- Fixed spaceline colors on emacs-mac port (thanks to Paweł Siudak)
 *** Layer changes and fixes
 **** Ansible
 - Add support for multiple vault password files, see later README.org
@@ -780,10 +789,9 @@ Benner and Paweł Siudak):
 - Reorganize key bindings ( refer to =ESS= section in Breaking Changes above )
 **** Evil snipe
 - Must always explicitly enable =evil-snipe-mode= even when
-  =evil-snipe-override-mode= (thanks to Sylvain Benner)
+  =evil-snipe-override-mode= is enabled (thanks to Sylvain Benner)
 **** FSharp
 - Added prefixes for key bindings (thanks to David Millar-Durrant)
-is enabled
 **** Geolocation
 - Add deferred theme changer activation function. (thanks to Thadeus Fleming)
 - Fix geolocation layer on non-macos systems (thanks to Boris Buliga)
@@ -910,7 +918,7 @@ is enabled
   - Add Helm key bindings counterparts: ~SPC f e l~ and ~SPC h i~
     (thanks to Andriy Kmit')
   - Add ~SPC h d F~ to list faces (thanks to Muneeb Shaikh)
-  - Bind ==find-file-other-window= to ~j~ (thanks to James Wang)
+  - Bind =find-file-other-window= to ~j~ (thanks to James Wang)
   - Add =counsel-mark-ring= to ~rm~ (thanks to bmag)
 - Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
 - Use new API to register additional transient state bindings (thanks to Andriy
@@ -1038,6 +1046,8 @@ is enabled
 - Move neotree to its own layer in new +filetree folder (thanks to Sylvain
   Benner)
 - Add screenshot in neotree layer (thanks to duianto)
+- Allow a prefix argument to ~RET~ / ~l~ (=spacemacs/neotree-expand-or-open=)
+  to specify which window to use to open a file (thanks to Ljupcho Kotev)
 - Key bindings:
   - ~SPC f T~ reinstated for showing file tree with Neotree or Treemacs
     (thanks to bmag)
@@ -1200,6 +1210,8 @@ is enabled
 - Added support for breakpoints for the =trepan3k= python debugger (thanks to
   dangirsh)
 - Added support for =pipenv= with proper keybindings (thanks to jackkamm)
+- Fixed bytecomp warning: =reference to free variable 'smartparens-strict-mode'=
+  (thanks to Nikita Leshenko and Sylvain Benner)
 - Key bindings:
   - Update invalid cython mode keybindings (thanks to Muneeb Shaikh)
   - New =anaconda-view-mode= keybindings (thanks to Muneeb Shaikh)
@@ -1227,6 +1239,8 @@ is enabled
   (thanks to Jan Zdráhal)
 - Use JSX header without breaking React (thanks to Jam Risser)
 - Make auto-completion triggers more friendly (thanks to Cheng,Rong)
+- Configure =emmet-mode= to expand classes using =className= instead of =class=
+  (thanks to Sylvain Benner)
 **** Ruby
 - Add support for =org-babel= (thanks to Muneeb Shaikh)
 - Highlight debugger keywords (thanks to Alexander Berezovsky and Eivind Fonn)
@@ -1246,6 +1260,7 @@ is enabled
   - Add ~SPC m r R v~ to extract local variable.
   - Add ~SPC m r R c~ to extract constant.
   - Add ~SPC m r R l~ to extract to =let=.
+  - Added ~SPC m s l~ to send line to REPL (thanks to Paweł Siudak)
 **** Rust
 - Key bindings:
   - Add ~SPC m c D~ to open Cargo docs (thanks to Matthew J. Berger)


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+648
Started with: 542ada133d76c386efda31bf8fb98f3445ec8d31

New pointer: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+613
Start with: 87dc5f100c1fba0b3dc59155c5ee3183dd10ef96

---

* New layer web-beautify extracted from javascript layer · syl20bnr/spacemacs@542ada1

  Added under New layers/Tools.

* Fix documentation formating · syl20bnr/spacemacs@5f75e61

  Skipped; this is a docs clean-up by Sylvain.

* Fix documentation link to web-beautify layer README · syl20bnr/spacemacs@3976a34

  Skipped; this is a docs fix-up by Sylvain.

* Fix another link in documentation... · syl20bnr/spacemacs@4980a64

  Skipped; this is a docs fix-up by Sylvain.

* treemacs: SPC f T --> SPC f t and SPC f C-t --> SPC f T · syl20bnr/spacemacs@5a91478

  Added author, Sylvain, to the "thanks to" for the new treemacs layer.

* treemacs: sort key bindings · syl20bnr/spacemacs@635a32c

  Skipped; this is a docs clean-up by Sylvain.

* tern: fix issues when loading layer · syl20bnr/spacemacs@fa64eb3

  Added a new entry for the tern layer under New layers/Tools with a "thanks to" crediting the author of the layer (Sylvain) and the author of this commit (Juuso Valkeejärvi).

  The commit that added the tern layer is in the previous batch of commits, which is reserved by @syl20bnr but for which the change log entries are not yet merged, so a conflict should be anticipated here.

* Add argument to specify window when opening from neotree · syl20bnr/spacemacs@214e5a8

  Added under changes to the neotree layer.

* react: set emmet-expand-jsx-className? to t · syl20bnr/spacemacs@8fd934c

  Added under changes to the react layer.

* react: add spacemacs prefix to functions in funcs.el · syl20bnr/spacemacs@30e366f

  Skipped; this is a code clean-up by Sylvain.

* web-beutify: fix error when resyncing configuration · syl20bnr/spacemacs@4deb56c

  Added author to the "thanks to" for the new web-beautify layer.

* web-beautify: fix definition of web-beautify key bindings · syl20bnr/spacemacs@b97ad90

  Skipped; this is a fix to the web-beautify layer by its original author.

* Format documentation. · syl20bnr/spacemacs@958d2e9

  Skipped; this is a docs clean-up by JAremko.

* Use new spacedoc tools in Travis CI. · syl20bnr/spacemacs@2c871ef

  Skipped; this is a CI improvement by JAremko, which is covered by an existing change log entry.

* Remove Emacs24 tests from Circle CI. · syl20bnr/spacemacs@75a2dfe

  Skipped; this is another CI improvement by JAremko.

* Fix travis script. · syl20bnr/spacemacs@63d90cd

  Skipped; this is another CI improvement by JAremko.

* Fix modeline colors on emacs-mac port · syl20bnr/spacemacs@0e7807c

  Added under "Distribution changes".

* ruby: add key binding for ruby-send-line · syl20bnr/spacemacs@000e502

  Added under changes to the ruby layer.

* python: smartparens: Fix bytecomp warning (#10582) · syl20bnr/spacemacs@b374370

  Added under changes to the python layer.

* python: put smartparens advice in a post-config use-package hook · syl20bnr/spacemacs@9f6b452

  Added author, Sylvain, to the "thanks to" for the previous change; this change essentially replaces the previous change with an alternative solution.

* web-beautify: rename spacemacs-web-beautify--modes · syl20bnr/spacemacs@8267b50

  Skipped; this is a fix to the web-beautify layer by its original author.

* core: fix bug where packages.el files were loaded multiple times · syl20bnr/spacemacs@b58a1d7

  Added under "Core changes".

* core: fix bug where layers.el files could be loaded multiple times · syl20bnr/spacemacs@e9b8ed3

  Added by amending the previous change to mention both `layers.el` and `packages.el` files.
  
* core: hide loading message at startup unless --debug-init · syl20bnr/spacemacs@862e81e

  Added under "Core changes".

* New layer Hy extracted from Python layer · syl20bnr/spacemacs@ea8991a

  Added author to existing entry under New layers/Languages.

* hy: fix documentation format · syl20bnr/spacemacs@d14d58d

  Skipped; this is a docs fix-up to the hy layer by its original author.

* core: fix unit tests · syl20bnr/spacemacs@a14060a

  Skipped; the author, Sylvain, is already credited under "Multiple unit test improvements".

* Add support for dumping Spacemacs · syl20bnr/spacemacs@2580e43

  Added under "Core changes", with a reference to `EXPERIMENTAL.org` (which is added in a later commit). 

* dump: remove spaceline-compile hook and force separator to be utf-8 · syl20bnr/spacemacs@378392e

  Skipped; this is a fix-up to dump support by its initial author.

* dump: require magit when dumping · syl20bnr/spacemacs@45e0c08

  Skipped; this is another fix-up to dump support by its initial author.

* dump: require org when dumping · syl20bnr/spacemacs@ecb9888

  Skipped; this is another fix-up to dump support by its initial author.

* dump: require some emacs-lisp modes while dumping · syl20bnr/spacemacs@4a2e04a

  Skipped; this is another fix-up to dump support by its initial author.

* dump: require some helm packages while dumping · syl20bnr/spacemacs@5d830fc

  Skipped; this is another fix-up to dump support by its initial author.

* dump: fix lag when deleting line with dd by disabling pbcopy · syl20bnr/spacemacs@b44506f

  Skipped; this is another fix-up to dump support by its initial author.

* dump: require recentf and eldoc when dumping · syl20bnr/spacemacs@ed91239

  Skipped; this is another fix-up to dump support by its initial author.

* Bonus change: Fixed the change log entry under changes to evil-snipe layer.

* Super bonus change: Deleted a spurious `=` in an entry under the list of changes to the ivy layer: `==find-file-other-window=`.