### PR TITLE
Updates org-layer key bindings for Org 9.2 release

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -306,6 +306,7 @@ Will work on both org-mode and any mode that accepts plain html."
         ;; attachments
         "A" 'org-attach
         ;; insertion
+        "ib" 'org-insert-structure-template
         "id" 'org-insert-drawer
         "ie" 'org-set-effort
         "if" 'org-footnote-new
@@ -316,7 +317,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "in" 'org-add-note
         "ip" 'org-set-property
         "is" 'org-insert-subheading
-        "it" 'org-set-tags
+        "it" 'org-set-tags-command
         ;; region manipulation
         "xb" (spacemacs|org-emphasize spacemacs/org-bold ?*)
         "xc" (spacemacs|org-emphasize spacemacs/org-code ?~)


### PR DESCRIPTION
## Changes
This PR addresses my comment in issues #11788. 

The new Org 9.2 release seems to have changed the functionality of `org-set-tags`, reserving it only for lisp calls, and added a new interactive function `org-set-tags-command`. The method of interacting with org easy-templates was also changed. 

I updated the `, i t` binding to use `org-set-tags-command`, and I also added a new `, i x` binding for template expansion. (The old method of template expansion could be enabled with org-tempo, but I like the new style so I didn't look it into adding that to the layer).