### PR TITLE
Add ibuffer square brackets filter group motion

### DIFF
--- a/layers/+emacs/ibuffer/README.org
+++ b/layers/+emacs/ibuffer/README.org
@@ -49,8 +49,8 @@ Example:
 
 ** IBuffer
 
-| Key binding | Description                   |
-|-------------+-------------------------------|
-| ~g r~       | update IBuffer (“refresh”)    |
-| ~g j~       | move to next filter group     |
-| ~g k~       | move to previous filter group |
+| Key binding                   | Description                   |
+|-------------------------------+-------------------------------|
+| ~g r~                         | update IBuffer (“refresh”)    |
+| ~g j~ / ~]~ / ~TAB~ / ~M-n~   | move to next filter group     |
+| ~g k~ / ~[~ / ~S-TAB~ / ~M-p~ | move to previous filter group |

--- a/layers/+emacs/ibuffer/packages.el
+++ b/layers/+emacs/ibuffer/packages.el
@@ -36,7 +36,9 @@
       :bindings
       "gr" 'ibuffer-update
       "gj" 'ibuffer-forward-filter-group
-      "gk" 'ibuffer-backward-filter-group)))
+      "]"  'ibuffer-forward-filter-group
+      "gk" 'ibuffer-backward-filter-group
+      "["  'ibuffer-backward-filter-group)))
 
 (defun ibuffer/init-ibuffer-projectile()
     (use-package ibuffer-projectile


### PR DESCRIPTION
Match the magit buffer section/sibling navigation keys (bound in evil-magit) and
the evil-collections motion section also suggests using [ and ] for navigation
between sections.

And list the default ibuffer filter group motion bindings:
Forward: TAB and M-n
Backward: S-TAB and M-p