### PR TITLE
Only remove non system pkg

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2332,15 +2332,25 @@ depends on it."
     (unless (string-empty-p version-string)
       (version-to-list version-string))))
 
+(defun configuration-layer//system-package? (pkg-desc)
+  "Cheks if package is a system package"
+  (not (string-prefix-p
+         (file-name-as-directory
+           (expand-file-name package-user-dir))
+         (expand-file-name
+           (package-desc-dir pkg-desc)))))
+
 (defun configuration-layer//package-delete (pkg-name)
   "Delete package with name PKG-NAME."
   (cond
    ((version<= "25.0.50" emacs-version)
     (let ((p (cadr (assq pkg-name package-alist))))
       ;; add force flag to ignore dependency checks in Emacs25
-      (when p (package-delete p t t))))
+      (when (not (configuration-layer//system-package? p))
+        (package-delete p t t))))
    (t (let ((p (cadr (assq pkg-name package-alist))))
-        (when p (package-delete p))))))
+        (when (not (configuration-layer//system-package? p))
+          (package-delete p))))))
 
 (defun configuration-layer/delete-orphan-packages (packages)
   "Delete PACKAGES if they are orphan."


### PR DESCRIPTION
Added "configuration-layer//system-package?" based on package-delete
(pretty much a direct partial copy-paste) so that
"configuration-layer//package-delete" can check if package is a
system package

No crash on spacemacs boot (with unused system-package present).
Though right now "configuration-layer//package-delete" only ignores system
packagesinstead of reporting them. Not entierly what @nbraud proposed,
but insufficient err-logging is a significantly smaller issue.

Fixes #11160

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3