### PR TITLE
Updated change log (+473)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -190,6 +190,8 @@ Benner and Paweł Siudak):
 - Added experimental support for the emacs dumper; see =EXPERIMENTAL.org=
   (thanks to Sylvain Benner, Compro Prasad and Keith Simmons)
 - Added support for native line numbers in Emacs 26 (thanks to bmag)
+- Extensive use of lazy loading of packages to reduce Spacemacs startup time
+  (thanks to Sylvain Benner)
 *** New layers
 **** Email
 - notmuch (thanks to Francesc Elies Henar, Leonard Lausen, Willian Casarin)
@@ -263,7 +265,7 @@ Benner and Paweł Siudak):
     themes. Supported themes are =spacemacs=, =all-the-icons=, =vim-powerline=,
     =custom=, and =vanilla=. The first three are spaceline themes, =custom= is
     user defined, and =vanilla= is the default Emacs mode-line. (thanks to
-    Sylvain Benner)
+    Sylvain Benner and James Wang)
   - Removed obsolete =:powerline-scale= property from
     =dotspacemacs-default-font= variable (thanks to Muneeb Shaikh and Sylvain
     Benner)
@@ -275,6 +277,31 @@ Benner and Paweł Siudak):
     =dotspacemacs-emacs-dumper-dump-file= and
     =dotspacemacs-enable-emacs-pdumper= to configure dump (thanks to Sylvain
     Benner)
+  - Added =vim-style-visual-feedback= and =hybrid-style-visual-feedback= style
+    variables to enable =evil-goggles= pulse in the Vim and Hybrid editing
+    styles, respectively; disabled by default (thanks to Sylvain Benner)
+  - Renamed style variables for consistency; the old names are still recognized
+    but deprecated (thanks to Sylvain Benner):
+    - =dotspacemacs-remap-Y-to-y$= renamed to =vim-style-remap-Y-to-y$=
+    - =dotspacemacs-retain-visual-state-on-shift= to
+      =vim-style-retain-visual-state-on-shift=
+    - =dotspacemacs-visual-line-move-text= to =vim-style-visual-line-move-text=
+    - =dotspacemacs-ex-substitute-global= to =vim-style-ex-substitute-global=
+    - =hybrid-mode-enable-evilified-state= to
+      =hybrid-style-enable-evilified-state=
+    - =hybrid-mode-enable-hjkl-bindings= to =hybrid-style-enable-hjkl-bindings=
+    - =hybrid-mode-use-evil-search-module= to
+      =hybrid-style-use-evil-search-module=
+    - =hybrid-mode-default-state= to =hybrid-style-default-state=
+  - Renamed helm variables and made them layer variables; the old dotfile
+    variables are still recognized but deprecated (thanks to Sylvain Benner and
+    Kalle Lindqvist):
+    - =dotspacemacs-helm-resize= to =helm-enable-auto-resize=, in the
+      =spacemacs-completion= layer
+    - =dotspacemacs-helm-no-header= to =helm-no-header=, in the =helm= layer
+    - =dotspacemacs-helm-position= to =helm-position=, in the =helm= layer
+    - =dotspacemacs-helm-use-fuzzy= to =helm-use-fuzzy=, in the
+      =spacemacs-completion= layer
 - Can use the univeral prefix argument to open both the =*scratch*= buffer and
   the =*Messages*= buffer in another window (thanks to Thomas de Beauchêne)
 *** Core changes
@@ -378,6 +405,15 @@ Benner and Paweł Siudak):
 - Added =:off-message= keyword to the =spacemacs|add-toggle= macro to allow
   overriding the default toggled-off expression (thanks to bmag)
 - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
+- Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed
+  counter from progress bar, fixed updating, and fixed size when Emacs is
+  started maximized (thanks to Sylvain Benner)
+- Fixed warning about quoted lambda in =core-configuration-layer.el= (thanks to
+  Sylvain Benner)
+- New function =configuration-layer/load-file= to load file silently (thanks to
+  Sylvain Benner)
+- Fixed duplicate "Open quick help..." in the minibuffer at startup (thanks to
+  Sylvain Benner)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:
@@ -573,7 +609,6 @@ Benner and Paweł Siudak):
     to Muneeb Shaikh)
   - Force powerline-scale to be 1 when utf-8 separator is used (thanks to
     Sylvain Benner)
-  - Disable evil-goggles pulse (thanks to Sylvain Benner)
   - =spacemacs/integrate-evil-search= also updates =evil-ex-search-direction=
     (thanks to Thanh Vuong)
 - Enable =evil-search= search module in evil state.
@@ -648,6 +683,8 @@ Benner and Paweł Siudak):
     =spacemacs-window-split-ignore-prefixes=.
 - Fixed =evil-escape= lighter being shown in the mode line (thanks to Sylvain
   Benner)
+- Fixed ~TAB~ to toggle occurrences in iedit state in Vim and Hybrid editing
+  styles (thanks to Sylvain Benner)
 *** Layer changes and fixes
 **** Ansible
 - Add support for multiple vault password files, see later README.org
@@ -655,6 +692,8 @@ Benner and Paweł Siudak):
   Gușoi)
 - Fix error void function ansible: auto-decrypt-encrypt (thanks to Sylvain
   Benner)
+**** Asm
+- Added missing =company= package declaration (thanks to Kalle Lindqvist)
 **** Auto-completion
 - Prefer =.spacemacs.d/snippets= over =.emacs.d/private/snippets= (thanks to
   Aaron Jensen)
@@ -929,11 +968,24 @@ Benner and Paweł Siudak):
     - Add ~SPC m r e~ to extract
     - Add ~SPC m r t~ to toggle
     - Add ~SPC m r d~ for godoc
- - Adds GOROOT to list of variables copied from shell environment (thanks to
-   Andy Lindeman)
- - Convert remote file name to local name, stripping trampy stuff (thanks to
-   Josh Santos)
+- Adds =GOROOT= to list of variables copied from shell environment (thanks to
+  Andy Lindeman)
+- Convert remote file name to local name, stripping trampy stuff (thanks to
+  Josh Santos)
 - Added =go-tag= (thanks to brantou)
+- Added =go-gen-test= (thanks to Cosmin Cojocar and Sylvain Benner):
+  - Key bindings:
+    - ~SPC m t g g~ to generate tests for the function in the active region
+    - ~SPC m t g f~ to generate tests for all exported functions
+    - ~SPC m t g F~ to generate tests for all functions
+- Configure =go-mode= to use the =gopkgs= tool to find available Go packages
+  faster (thanks to Cosmin Cojocar)
+- Added =go-fill-struct= and key binding ~SPC m r s~ to fill struct with default
+  values (thanks to Cosmin Cojocar)
+- Added =go-impl= and key binding ~SPC m r i~ to generate method stubs for an
+  interface (thanks to Cosmin Cojocar)
+- Fixed loading of the =GOPATH=, =GOROOT=, and =GO15VENDOREXPERIMENT=
+  environment variables (thanks to Joshua Santos)
 **** Groovy
 - Update =indent-variable-alist= to support new groovy-mode (thanks to Sylvain
   Benner)
@@ -1405,6 +1457,10 @@ Benner and Paweł Siudak):
   mode instead of =ruby-mode= and =enh-ruby-mode= so that the key bindings will
   work in view file windows (thanks to Adam Sokolnicki)
 **** Rust
+- Added missing =counsel-gtags= and =smartparens= package declarations (thanks
+  to Kalle Lindqvist)
+- Fixed loading of the =RUST_SRC_PATH= environment variable (thanks to Joshua
+  Santos)
 - Key bindings:
   - Add ~SPC m c D~ to open Cargo docs (thanks to Matthew J. Berger)
   - Add ~SPC m c l~ to run linter with cargo clippy (thanks to Michael Kohl)
@@ -1417,6 +1473,8 @@ Benner and Paweł Siudak):
   - Evilify =ensime= search in insert/normal mode (thanks to Diego Alvarez)
 - Remove duplicated code (thanks to Tetsuro Takemoto)
 - Add ENSIME jump handlers (thanks to Joao Azevedo)
+**** Scheme
+- Added missing =parinfer= package declaration (thanks to Kalle Lindqvist)
 **** Semantic
 - Make it possible to exclude stickyfunc (thanks to Sylvain Benner)
 **** Shell

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -273,14 +273,14 @@ You have a few options to ensure you always get up to date suggestions:
 
 ** Refactoring
 
-| Key Binding | Description                                                    |
-|-------------+----------------------------------------------------------------|
-| ~SPC m r d~ | Add comment stubs                                              |
-| ~SPC m r e~ | Extract code as new function                                   |
-| ~SPC m r f~ | Add field tags                                                 |
-| ~SPC m r F~ | Remove field tags                                              |
-| ~SPC m r i~ | Generate method subs for implementing an interface (=go-impl=) |
-| ~SPC m r n~ | Rename (with =godoctor=)                                       |
-| ~SPC m r N~ | Rename (with =go-rename=)                                      |
-| ~SPC m r s~ | Fill structure with default values                             |
-| ~SPC m r t~ | Toggle declaration and assignment                              |
+| Key Binding | Description                                                     |
+|-------------+-----------------------------------------------------------------|
+| ~SPC m r d~ | Add comment stubs                                               |
+| ~SPC m r e~ | Extract code as new function                                    |
+| ~SPC m r f~ | Add field tags                                                  |
+| ~SPC m r F~ | Remove field tags                                               |
+| ~SPC m r i~ | Generate method stubs for implementing an interface (=go-impl=) |
+| ~SPC m r n~ | Rename (with =godoctor=)                                        |
+| ~SPC m r N~ | Rename (with =go-rename=)                                       |
+| ~SPC m r s~ | Fill structure with default values                              |
+| ~SPC m r t~ | Toggle declaration and assignment                               |


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+473
Started with: https://github.com/syl20bnr/spacemacs/commit/7238e232aed6217d33c6900e064567d00e4b3329

New pointer: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+438
Start with: https://github.com/syl20bnr/spacemacs/commit/c41a122b24a609d17cdc4f30c67650d43ade0c5f

---

| Commit                                                                                             | Action                                                                                             |
|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
| Fix EXPERIMENTAL.org TOC · syl20bnr/spacemacs@7238e23                                              | Skipped; this is a docs clean-up by Sylvain.                                                       |
| iedit: fix TAB in Vim and Hybrid states to toggle occurrences · syl20bnr/spacemacs@1833c9c         | Added entry under "Distribution changes".                                                          |
| scheme: add missing parinfer package declaration · syl20bnr/spacemacs@4af9169                      | Added entry under changes to the scheme layer.                                                     |
| rust: add missing smartparens package declaration · syl20bnr/spacemacs@961e448                     | Added entry under changes to the rust layer.                                                       |
| rust: add missing counsel-gtags package declaration · syl20bnr/spacemacs@b9f1228                   | Added by amending previous entry under changes to the rust layer.                                  |
| asm: add missing company package declaration · syl20bnr/spacemacs@309b154                          | Added entry under changes to the asm layer.                                                        |
| Add vim-style-visual-feedback variable and documentation · syl20bnr/spacemacs@e39b349              | Added entry under "Dotfile changes"; deleted entry for evil-goggles, which this change supersedes. |
| Rename Vim style related variable to vim-style-xxxxx · syl20bnr/spacemacs@9539e42                  | Added entry under "Dotfile changes".                                                               |
| Set default value of vim-style-visual-feedback to nil · syl20bnr/spacemacs@2b4d90b                 | Added by amending the earlier entry for the new vim-style-visual-feedback variable.                |
| Rename hybrid-mode-xxxx variables to hybrid-style-xxxx · syl20bnr/spacemacs@434df17                | Added by amending the earlier entry for renaming vim style variables.                              |
| Use dotspacemacs backward compatibility macro instead of aliases · syl20bnr/spacemacs@b282e55      | Added by amending the entry for renaming style variables.                                          |
| Remove dotspacemacs-helm-xxxx variables from templates · syl20bnr/spacemacs@3a2740f                | Added entry for renaming helm variables and making them layer variables under "Dotfile changes".   |
| Add hybrid-style-visual-feedback variable · syl20bnr/spacemacs@5004e05                             | Added to the existing entry for the Vim style equivalent.                                          |
| Fix editing style test · syl20bnr/spacemacs@f393ca2                                                | Added author, James Wang, to the "thanks to" for support for mode-line themes.                     |
| Update conventions for test generation · syl20bnr/spacemacs@1ddd843                                | Skipped; this is a docs clean-up by Sylvain                                                        |
| Add support to generate go tests with go-gen-test · syl20bnr/spacemacs@359960a                     | Added under changes to the go layer.  (Also fixed the formatting of some neareby entries.)         |
| go: change test generation key bindings according to conventions · syl20bnr/spacemacs@0fd13ae      | Added by amending the entry for the previous commit.                                               |
| Configure the go-packages-functions to use the gopkgs tool · syl20bnr/spacemacs@938155c            | Added under changes to the go layer.                                                               |
| go: reformat spacemacs/go-packages-gopkgs · syl20bnr/spacemacs@7951d76                             | Skipped; this is a code clean-up by Sylvain.                                                       |
| go: remove unused function load-gopath-file · syl20bnr/spacemacs@0e0d508                           | Skipped; this is a code clean-up by Sylvain.                                                       |
| go: update feature section with gopkgs · syl20bnr/spacemacs@ae53d96                                | Skipped; this is docs fix-up by Sylvain.                                                           |
| go: add option in refactoring to fill a structure with default values · syl20bnr/spacemacs@80dbae3 | Added under changes to the go layer.                                                               |
| go: sort packages.el and update README · syl20bnr/spacemacs@f12b849                                | Skipped; this is a code clean-up and docs fix-up by Sylvain.                                       |
| go: add support for go-impl in refactoring menu · syl20bnr/spacemacs@d47f926                       | Added under changes to the go layer.                                                               |
| go: cleanup layer sorting stuff and using idiomatic constructs · syl20bnr/spacemacs@aedcedd        | Skipped; this is a code clean-up by Sylvain.                                                     |
| go: fix bad quoting of go-packages-function · syl20bnr/spacemacs@9fc1883                           | Skipped; this is a code fix-up by Sylvain to an earlier change he made.                            |
| go: defer loading of various packages · syl20bnr/spacemacs@b04cce0                                 | Added entry for lazy loading under "Hot new feature".                                              |
| Fix environment variable setting for go and rust layers · syl20bnr/spacemacs@7944ed2               | Added entries under changes to go layer and under changes to rust layer.                           |
| core: refactor the progress bar · syl20bnr/spacemacs@a0a3ff0                                       | Added entry under "Core changes".                                                                  |
| core: fix warning about quoted lambda in core-configuration-layer.el · syl20bnr/spacemacs@39bf9e5  | Added entry under "Core changes".                                                                  |
| core: new function configuration-layer/load-file · syl20bnr/spacemacs@c2211b3                      | Added entry under "Core changes".                                                                  |
| core: avoid unecessary output in message buffer at startup · syl20bnr/spacemacs@ac24739            | Skipped; already have an entry for reducing loading messages on startup.                           |
| core: move point before [ S P A C E M A C S ] at startup · syl20bnr/spacemacs@86b4e6f              | Added entry under "Core changes".                                                                  |
| Lazy load eval-sexp-fu · syl20bnr/spacemacs@9951013                                                | Skipped; this is another lazy-loading fix by Sylvain.                                              |
| Lazy load lsp-ui · syl20bnr/spacemacs@699c1da                                                      | Skipped; this is another lazy-loading fix by Sylvain.                                              |

Bonus: Fixed a typo in `layers/+lang/go/README.org`.