### PR TITLE
Updated change log (+438)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -190,6 +190,12 @@ Benner and Paweł Siudak):
 - Added experimental support for the emacs dumper; see =EXPERIMENTAL.org=
   (thanks to Sylvain Benner, Compro Prasad and Keith Simmons)
 - Added support for native line numbers in Emacs 26 (thanks to bmag)
+- Extensive use of lazy loading of packages to reduce Spacemacs startup time
+  (thanks to Sylvain Benner and Ben Leggett)
+- Added environment-variable caching. At startup, if the cache does not exist,
+  Spacemacs loads environment variables using =exec-path-from-shell= and writes
+  the cache to be used on next startup (thanks to Sylvain Benner and Codruț
+  Constantin Gușoi)
 *** New layers
 **** Email
 - notmuch (thanks to Francesc Elies Henar, Leonard Lausen, Willian Casarin)
@@ -207,7 +213,7 @@ Benner and Paweł Siudak):
 - perl5 (thanks to Troy Hinckley, Jinseop Kim and Michael Rohleder)
 - perl6 (thanks to Bahtiar Gadimov)
 - protobuf (thanks to Amol Mandhane)
-- restructuredtext (thanks to Wei-Wei Guo)
+- restructuredtext (thanks to Wei-Wei Guo and Kalle Lindqvist)
 - semantic-web (thanks to Andreas Textor)
 - coffeescript (thanks to Sylvain Benner)
 - json (thanks to Sylvain Benner)
@@ -378,6 +384,11 @@ Benner and Paweł Siudak):
 - Added =:off-message= keyword to the =spacemacs|add-toggle= macro to allow
   overriding the default toggled-off expression (thanks to bmag)
 - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
+- Added =spacemacs|add-transient-hook= macro to add hooks that vanish the first
+  time they are executed (thanks to Sylvain Benner)
+- Renamed =spacemacs/mplist-get= function to =spacemacs/mplist-get-values=,
+  renamed =spacemacs/plist-get= function to =spacemacs/mplist-get-value=, and
+  refactored the latter function (thanks to Benjamin Reynolds)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:
@@ -992,6 +1003,7 @@ Benner and Paweł Siudak):
 - Fix winum intergration (thanks to Sylvain Benner)
 - Fixed "Invalid face reference" error in Helm transient state (thanks to
   duianto)
+- Hide lighter (thanks to Sylvain Benner)
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Add =counsel-css= as an ivy alternative to =helm-css-scss= (thanks to Robbert
@@ -1292,6 +1304,8 @@ Benner and Paweł Siudak):
   - =osx-right-option-as=  defaults to left
   - =osx-right-control-as= defaults to left
   (thanks to Christopher Eames, Aaron Culich, and fiveNinePlusR)
+- Disabled =pbcopy= package because it introduced input latency for some actions
+  when using =emacs -daemon= and a GUI client (thanks to Sylvain Benner)
 - Key bindings:
   - Add key bindings to use ~command-1..9~ for selecting window
     (thanks to Liu Joey)
@@ -1607,6 +1621,8 @@ Benner and Paweł Siudak):
   SteveJobzniak, Sunghyun Hwang, Swaroop C H, Sylvain Benner, Szunti, Tim
   Stewart, timor, TinySong, Titov Andrey, Thomas de Beauchêne, Tomasz
   Cichocinski, tzhao11, Vladimir Kochnev, Wieland Hoffmann, Yi Liu, zer09)
+# Add additional names as comma separated lines for easier merging/diffing
+Daniel Molina,
 *** Release notes summarized
   Thanks to: Grant Shangreaux, Songpeng Zu, Igor Almeida, Miciah Dashiel Butler
   Masters, Abhishek(Compro) Prasad, Deepak Khidia, Ward Harris


### PR DESCRIPTION
Summarizing: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+438
Started with: https://github.com/syl20bnr/spacemacs/commit/c41a122b24a609d17cdc4f30c67650d43ade0c5f

New pointer: https://github.com/syl20bnr/spacemacs/commits/develop?before=69a89cc41243cfb189238a2297fde4498d7fcf6d+403
Start with: https://github.com/syl20bnr/spacemacs/commit/697fceb30abf1691721ae6b312e3aaa837e1e454

---

| Commit                                                                                                | Action                                                                                                                                         |
|-------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| Lazy load diff-hl · syl20bnr/spacemacs@c41a122                                                        | Added entry for lazy loading under "Hot new feature" (will conflict with #11819).                                                              |
| Lazy load info+ · syl20bnr/spacemacs@2ff642e                                                          | Skipped; part of Sylvain's lazy loading work.                                                                                                  |
| Lazy load inf-crystal · syl20bnr/spacemacs@bd160f5                                                    | Skipped; same reason.                                                                                                                          |
| Delay loading of windows purpose · syl20bnr/spacemacs@e0ad4e3                                         | Skipped; same reason.                                                                                                                          |
| Lazy load lsp-mode · syl20bnr/spacemacs@49b1659                                                       | Skipped; same reason.                                                                                                                          |
| core: add new macro add-transient-hook · syl20bnr/spacemacs@bd316f4                                   | Added entry under "Core changes".                                                                                                              |
| Lazy load helm · syl20bnr/spacemacs@a417e3c                                                           | Skipped; part of Sylvain's lazy loading work.                                                                                                  |
| Also defer helm loading on idle · syl20bnr/spacemacs@6a51d55                                          | Skipped; same reason.                                                                                                                          |
| Use transient hook to load window-purpose · syl20bnr/spacemacs@6d9c559                                | Skipped; same reason.                                                                                                                          |
| Lazy load anaconda-mode · syl20bnr/spacemacs@d48ecea                                                  | Skipped; same reason.                                                                                                                          |
| Lazy load volatile-highlights · syl20bnr/spacemacs@0b787eb                                            | Skipped; same reason.                                                                                                                          |
| Lazy load importmagic · syl20bnr/spacemacs@adf10d6                                                    | Skipped; same reason.                                                                                                                          |
| Lazy load helm-ctest · syl20bnr/spacemacs@f26f0db                                                     | Skipped; same reason.                                                                                                                          |
| Lazy load color-identifiers-mode · syl20bnr/spacemacs@4ddf464                                         | Skipped; same reason.                                                                                                                          |
| Remove evil-search-highlight-persist as it seems uneeded now · syl20bnr/spacemacs@095a838             | Skipped; code clean-up by Sylvain, partially reverted by https://github.com/syl20bnr/spacemacs/commit/8ad78ca7d39f36321073b5993cff9c458d37adbe |
| Lazy load flycheck · syl20bnr/spacemacs@19b478e                                                       | Skipped; part of Sylvain's lazy loading work.                                                                                                  |
| Lazy load flycheck-crystal · syl20bnr/spacemacs@80bf864                                               | Skipped; same reason.                                                                                                                          |
| crystal: fix key bindings not available for play-crystal · syl20bnr/spacemacs@50804ed                 | Skipped; this is a fix-up to the new crystal layer by its original author (Sylvain).                                                           |
| Lazy load evil-lisp-state · syl20bnr/spacemacs@41b90e4                                                | Skipped; part of Sylvain's lazy loading work.                                                                                                  |
| Cache PATH and env vars. fetched with exec-path-from-shell · syl20bnr/spacemacs@c12b720               | Added entry under "Hot new feature".                                                                                                           |
| Defer spaceline loading · syl20bnr/spacemacs@4bb1d6a                                                  | Skipped; part of Sylvain's lazy loading work.                                                                                                  |
| Hide Helm lighter in mode-line · syl20bnr/spacemacs@65018ea                                           | Added entry under changes to the helm layer.                                                                                                   |
| layouts: be sure spaceline is loaded before restoring layouts · syl20bnr/spacemacs@a417d05            | Skipped; fix-up by Sylvain related to lazy loading.                                                                                            |
| spaceline: remove after-display hook · syl20bnr/spacemacs@17ad92b                                     | Skipped; code clean-up by Sylvain. @sdwolfz, I am unsure whether this warrants an entry.                                                       |
| core: improve docstring for dotspacemacs-mode-line-unicode-symbols · syl20bnr/spacemacs@0ce597e       | Skipped; docs improvement by Sylvain.                                                                                                          |
| macOS: disable package pbcopy · syl20bnr/spacemacs@386a8fa                                            | Added under changes to the osx layer.                                                                                                          |
| Fix breakage of `M-x` caused by a417e3ca856a2a6c885521d35ae1ce72513de978 · syl20bnr/spacemacs@1884863 | Added author, Ben Leggett, to the "thanks to" for lazy loading.                                                                                |
| Brings back search highlight clear · syl20bnr/spacemacs@8ad78ca                                       | Skipped; fix-up by sdwolfz for https://github.com/syl20bnr/spacemacs/commit/095a83896ab7f9b3638d84c94a0a8ebc0686814a.                          |
| Fixes errors when env file does not exist at startup · syl20bnr/spacemacs@8754b24                     | Added author, sdwolfz, to the "thanks to" for the environment-variable caching entry.                                                          |
| Rename spacemacs/mplist-get functions to be more descriptive · syl20bnr/spacemacs@594fdc8             | Added entry under "Core changes".                                                                                                              |
| Fix typos · syl20bnr/spacemacs@55e0506                                                                | Added author, Daniel Molina, under "Various documentation improvements".                                                                       |
| Fix typo · syl20bnr/spacemacs@e26f393                                                                 | Skipped; docs improvement by David Florness, who is already under "Various documentation improvements".                                        |
| Move SPC s c to bootsrap layer · syl20bnr/spacemacs@55d18a1                                           | Skipped; code clean-up by Sylvain.                                                                                                             |
| restructuredtext: Fix broken linum codeblock · syl20bnr/spacemacs@3c40283                             | Added author, Kalle Lindqvist, to the "thanks to" for the new restructuredtext layer.                                                          |
| restructuredtext: remove rst-sphinx init block, sphinx-layer owns it · syl20bnr/spacemacs@3472b16     | Added; ditto.                                                                                                                                  |