### PR TITLE
Update change log with breaking layer moves

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -30,6 +30,9 @@ This file containes the change log for the next major version of Spacemacs.
   (thanks to Dela Anthonio)
 - Move major specific error key bindings to ~SPC m E~ prefix (thanks to Sylvain
   Benner)
+**** C
+- CMake support has been extracted from the =c-c++= layer into the new =cmake=
+  layer.
 **** ESS
 ESS key bindings were re-organised in the following list (thanks to Guido
 Kraemer, Yi Liu, and Jack Kamm):
@@ -66,6 +69,9 @@ Kraemer, Yi Liu, and Jack Kamm):
 **** IPython notebook
 - Key bindings:
   - Change prefix from "ai" to "ay" (thanks to Swaroop C H)
+**** JavaScript
+- CoffeeScript support has been extracted from the =javascript= layer into the
+  new =coffeescript= layer.
 **** Markdown
 - Key bindings:
   - Removed ~SPC m i I~ for =markdown-insert-reference-image= (folded into ~SPC m i i~)
@@ -147,6 +153,7 @@ Benner and Paweł Siudak):
   - ~SPC m t u b~ for =spacemacs/org-trello-push-buffer=
   - ~SPC m t u c~ for =spacemacs/org-trello-push-card=
 **** Python
+- Hy support has been extracted from the =python= layer into the new =hy= layer.
 - Key bindings (thanks to Danny Freeman):
   - Changed ~SPC m s e~ to ~SPC m e e~ for =lisp-eval-last-sexp=
   - Changed ~SPC m s f~ to ~SPC m e f~ for =lisp-eval-defun=
@@ -184,6 +191,8 @@ Benner and Paweł Siudak):
   variable =dotspacemacs-mode-line-theme=.
 - The =nlinum= layer is deprecated on Emacs 26.1 and newer in favor of native
   line number support.
+- Support for multiple cursors is now encapsulated in the =multiple-cursors=
+  layer.
 *** Hot new feature
 - Improve themes support. Support are now handled like regular packages. The
   list of themes now supports =:location= keyword like in layer list. More
@@ -236,7 +245,7 @@ Benner and Paweł Siudak):
 - json (thanks to Sylvain Benner)
 - jsonnet (thanks to liztio and Robby O'Connor)
 - julia (thanks to Adam Beckmeyer and Guido Kraemer)
-- koltin (thanks to Shanavas M)
+- kotlin (thanks to Shanavas M)
 - pact (thanks to Colin Woodbury)
 - perl5 (thanks to Troy Hinckley, Jinseop Kim and Michael Rohleder)
 - perl6 (thanks to Bahtiar Gadimov)
@@ -266,7 +275,7 @@ Benner and Paweł Siudak):
 - transmission (thanks to Eugene Yaremenko)
 - cmake (thanks to Alexander Dalshov, Sylvain Benner and Jonas Jelten)
 - xclipboard (thanks to Charles Weill, Sylvain Benner, and Alex Palaistras)
-- debug (thanks to Troy Hinckley and Sylvain Benner)
+- debug (thanks to Hodge Shen, Troy Hinckley, and Sylvain Benner)
 - web-beautify (thanks to Sylvain Benner and Juuso Valkeejärvi)
 - tern (thanks to Sylvain Benner and Juuso Valkeejärvi)
 - emberjs (thanks to Robert O'Connor)

--- a/layers/+tools/cmake/config.el
+++ b/layers/+tools/cmake/config.el
@@ -1,4 +1,4 @@
-;;; config.el --- CMake Layer config File for Spacemacs
+;;; config.el --- CMake layer config file for Spacemacs.
 ;;
 ;; Copyright (c) 2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+tools/cmake/packages.el
+++ b/layers/+tools/cmake/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- CMake layer packages  fuke for Spacemacs
+;;; packages.el --- CMake layer packages file for Spacemacs.
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;

--- a/layers/+tools/debug/README.org
+++ b/layers/+tools/debug/README.org
@@ -12,7 +12,7 @@
   - [[#debugger][Debugger]]
 
 * Description
-This layer adds interactive debuggers for mulitple languages using [[https://github.com/realgud/realgud][realgud]].
+This layer adds interactive debuggers for multiple languages using [[https://github.com/realgud/realgud][realgud]].
 
 ** Features:
 - Modern rewrite of the Emacs GUD debugger family


### PR DESCRIPTION
Add entries to the change log under the "Breaking Changes" heading for functionality that has been extracted from existing layers and put into new layers since  the last release:

* CMake support was in the `c-c++` layer but is now in the `debug` layer.
* CoffeeScript support was in the `javascript` layer but is now in the `coffeescript` layer.
* Hy support was in the `python` layer but is now in the `hy` layer.
* Support for multiple cursors is now in the `multiple-cursors` layer.

Several other new layers were extracted from the `javascript` layer (namely `json`, `tern`, and `web-beautify`), but the `javascript` layer declares a dependency on these layers, so enabling the `javascript` layer also enables these layers (and thus enables the related functionality), meaning that these extractions are not breaking changes.

Several other layers were created since last release by extracting functionality from existing layers, but the extracted functionality had been added since the last release, so these extractions also are not breaking changes.  Namely, Groovy support was added to the `java` layer and later extracted to the `groovy` layer, and RealGUD support was added to the `c-c++` layer and later extracted to the `debug` layer.

Fix a typo in the change log: "koltin" → "kotlin".

Added a missing attribution for Hodge Shen to the change log entry for the `debug` layer, which was initially added by Hodge Shen in commit d5c4bb8b9af2ede210f17e1b4ca82357eea8afd3, then merged into the `c-c++` layer by Sylvain in commit 7d215cb08963b24f51ae5ec2a97da7141f1a9cb0, and then re-introduced as a separate layer by CeleritasCelery in commit 6e684739cbcf825df12df151fc5a0a898414c51c.

Fix a typo and formatting in the `cmake` layer file headers: "fuke" → "file".

Fix a typo in the `debug` layer readme: "mulitple" → "multiple".