### PR TITLE
adapt ess layer to recent changes in ESS

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -24,7 +24,6 @@ This layer adds support for statistical programming languages to Spacemacs.
 - Syntax-checking via [[https://github.com/jimhester/lintr][lintr]]
 - Additional data viewer for R via [[https://github.com/myuhe/ess-R-data-view.el][ess-R-data-view]]
 - Support for Org-Babel
-- Better ’equals’ behavior via [[https://github.com/genovese/ess-smart-equals][ess-smart-equals]]
 - Showing of inline help for =R= constructs
 - Repl support via =R terminal=
 - Support for =S=, =SAS= and =R=
@@ -46,18 +45,11 @@ To do so start the R terminal and type below code.
 To turn off the automatic replacement of underscores by =<-=, set in your
 =~/.spacemacs=:
 
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-disable-underscore-assign t)))
-#+END_SRC
-
-Alternatively you may enable =ess-smart-equals=, which also disables replacement
-of underscores by =<-=, and additionally replace the equals sign with =<-= when
-appropriate:
+Use a key-binding to insert =<-=:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '((ess :variables
-                                                         ess-enable-smart-equals t)))
+                                                         ess-assign-key "\M--")))
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -11,8 +11,5 @@
 
 ;; Variables
 
-(defvar ess-enable-smart-equals nil
-  "If non-nil smart-equal support is enabled")
-
-(defvar ess-disable-underscore-assign nil
-  "If non-nil, disables underscore _ being a shortcut for assignment <-")
+(defvar ess-assign-key nil
+  "Call `ess-insert-assign'.")

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -13,7 +13,6 @@
       '(
         ess
         ess-R-data-view
-        (ess-smart-equals :toggle ess-enable-smart-equals)
         golden-ratio
         org
         ))
@@ -57,7 +56,7 @@
       (add-hook 'inferior-ess-mode-hook
                 'spacemacs//ess-fix-read-only-inferior-ess-mode)
       (when (configuration-layer/package-used-p 'company)
-        (add-hook 'ess-mode-hook 'company-mode))))
+        (add-hook 'ess-r-mode-hook 'company-mode))))
 
   ;; R --------------------------------------------------------------------------
   (setq spacemacs/ess-config
@@ -68,13 +67,12 @@
                  ess-expression-offset 2
                  ess-nuke-trailing-whitespace-p t
                  ess-default-style 'DEFAULT)
-           (when ess-disable-underscore-assign
-             (setq ess-smart-S-assign-key nil))
+
 
            (define-key ess-doc-map "h" 'ess-display-help-on-object)
            (define-key ess-doc-map "p" 'ess-R-dv-pprint)
            (define-key ess-doc-map "t" 'ess-R-dv-ctable)
-           (dolist (mode '(ess-julia-mode ess-mode))
+           (dolist (mode '(ess-julia-mode ess-r-mode))
              (spacemacs/declare-prefix-for-mode mode "ms" "repl")
              (spacemacs/declare-prefix-for-mode mode "mh" "help")
              (spacemacs/declare-prefix-for-mode mode "mr" "extra")
@@ -130,7 +128,11 @@
                "d" 'ess-dev-map))
            (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
            (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
-           (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)))
+           (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)
+
+           (when ess-assign-key
+             (define-key ess-r-mode-map          ess-assign-key #'ess-insert-assign)
+             (define-key inferior-ess-r-mode-map ess-assign-key #'ess-insert-assign))))
 
   (eval-after-load "ess-r-mode" spacemacs/ess-config)
   (eval-after-load "ess-julia" spacemacs/ess-config)
@@ -142,14 +144,6 @@
   (evilified-state-evilify-map ess-help-mode-map))
 
 (defun ess/init-ess-R-data-view ())
-
-(defun ess/init-ess-smart-equals ()
-  (use-package ess-smart-equals
-    :defer t
-    :init
-    (progn
-      (add-hook 'ess-mode-hook 'ess-smart-equals-mode)
-      (add-hook 'inferior-ess-mode-hook 'ess-smart-equals-mode))))
 
 (defun ess/pre-init-golden-ratio ()
   (spacemacs|use-package-add-hook golden-ratio


### PR DESCRIPTION
Fixes the layer to work with the recently refactored ess again.
- Removed support for `ess-smart-equals-mode` because I have no idea what it actually does, the melpa package has not been updated since 2015 and in light of the recent changes to `ESS` seems a liability.
- `ESS` removed support for  the old `ess-disable-underscore-assign`  and replaced it with `ess-assign-key` which, if not `nil`, will be the key to use for assignment.

This should take care of a number of issues, #11831, #11617, #11371, #11122, and maybe more.
