### PR TITLE
Remove eslint_d support

### DIFF
--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -46,8 +46,7 @@
   (with-eval-after-load 'flycheck
     (dolist (checker '(javascript-eslint javascript-standard))
       (flycheck-add-mode checker 'rjsx-mode)))
-  (spacemacs/enable-flycheck 'rjsx-mode)
-  (add-hook 'rjsx-mode-hook #'spacemacs//javascript-setup-eslint t))
+  (spacemacs/enable-flycheck 'rjsx-mode))
 
 (defun react/post-init-js-doc ()
   (add-hook 'rjsx-mode-hook 'spacemacs/js-doc-require)

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -66,13 +66,6 @@
                      "the `tern' layer is not present in your `.spacemacs'!"))))
 
 
-;; flycheck
-
-(defun spacemacs//javascript-setup-eslint ()
-  (when-let ((found (executable-find "eslint_d")))
-    (set (make-local-variable 'flycheck-javascript-eslint-executable) found)))
-
-
 ;; js-doc
 
 (defun spacemacs/js-doc-require ()

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -45,8 +45,7 @@
   (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-company))
 
 (defun javascript/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'js2-mode)
-  (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-eslint t))
+  (spacemacs/enable-flycheck 'js2-mode))
 
 (defun javascript/post-init-ggtags ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
# Summary

Remove eslint_d support because eslint_d seems to support only older versions like ESLint 4+, 5+.
