### PR TITLE
[vinegar] Support custom dired hide details mode by default.

### DIFF
--- a/layers/+vim/vinegar/README.org
+++ b/layers/+vim/vinegar/README.org
@@ -1,10 +1,23 @@
 #+TITLE: Vinegar layer
 
 * Table of Contents                     :TOC_4_gh:noexport:
+- [[#configuration][Configuration]]
 - [[#description][Description]]
   - [[#features][Features:]]
   - [[#mouse-bindings][Mouse bindings]]
   - [[#key-bindings][Key bindings]]
+
+* Configuration
+
+The default configuration of this layer is:
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers '(
+  (vinegar :variables
+           vinegar-reuse-dired-buffer nil
+           vinegar-dired-hide-details t)
+  ))
+#+END_SRC
 
 * Description
 This layer is a port layer for vim-vinegar for emacs.

--- a/layers/+vim/vinegar/config.el
+++ b/layers/+vim/vinegar/config.el
@@ -13,3 +13,6 @@
 
 (defvar vinegar-reuse-dired-buffer nil
   "If non-nil, reuses one dired buffer for navigation.")
+
+(defvar vinegar-dired-hide-details t
+  "If non-nil, enable dired hide details mode.")

--- a/layers/+vim/vinegar/funcs.el
+++ b/layers/+vim/vinegar/funcs.el
@@ -99,7 +99,7 @@
   (setq dired-hide-details-hide-symlink-targets nil)
 
   ;; hide details by default
-  (dired-hide-details-mode t)
+  (if vinegar-dired-hide-details (dired-hide-details-mode t))
   ;; omit the .. in dired
   (dired-omit-mode t)
 


### PR DESCRIPTION
I'm using vinegar. It simplifies `dired` and is useful. But the dired details is hidden by default, and there is no config can custom dired-hide-details-mode. So I add a variable `vinegar-dired-hide-details` to support that. The default value is `t`, it will not break the previous behavior, and you can set it as below:

```emacs-lisp
(vinegar :variables vinegar-dired-hide-details nil)
```