### PR TITLE
[core] Update quelpa

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -521,6 +521,8 @@ Benner and Paweł Siudak):
   de Beauchêne)
 - Make query-replace work when frame is split (thanks to Dieter Komendera)
 - Don't skip missing .elc files when recompiling Elpa (thanks to RockyRoad29)
+- Update quelpa.el to fix installing of some recipes on macOS (thanks to Dieter
+  Komendera)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:

--- a/core/libs/quelpa.el
+++ b/core/libs/quelpa.el
@@ -415,6 +415,13 @@ if `quelpa-build-timeout-executable' is non-nil."
 Certain package names (e.g. \"@\") may not work properly with a BSD tar."
   :type '(file :must-match t))
 
+(defcustom quelpa-build-explicit-tar-format-p nil
+  "If non-nil pass \"--format=gnu\" option to tar command.
+
+Passing the option is necessary on the systems where the default
+tar format isn't gnu."
+  :type 'boolean)
+
 (defcustom quelpa-build-version-regexp "^[rRvV]?\\(.*\\)$"
   "Default pattern for matching valid version-strings within repository tags.
 The string in the capture group should be parsed as valid by `version-to-list'."
@@ -860,6 +867,9 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
                     (let ((branch (plist-get config :branch)))
                       (when branch
                         (concat "origin/" branch))))))
+    (when (string-match (rx bos "file://" (group (1+ anything))) repo)
+      ;; Expand local file:// URLs
+      (setq repo (expand-file-name (match-string 1 repo))))
     (with-current-buffer (get-buffer-create "*quelpa-build-checkout*")
       (goto-char (point-max))
       (cond
@@ -1086,7 +1096,6 @@ Optionally PRETTY-PRINT the data."
          (get-buffer-create "*quelpa-build-checkout*")
          nil "-cvf"
          file
-         "--format=gnu"
          "--exclude=.svn"
          "--exclude=CVS"
          "--exclude=.git"
@@ -1095,7 +1104,8 @@ Optionally PRETTY-PRINT the data."
          "--exclude=_FOSSIL_"
          "--exclude=.bzr"
          "--exclude=.hg"
-         (or (mapcar (lambda (fn) (concat dir "/" fn)) files) (list dir))))
+         (append (and quelpa-build-explicit-tar-format-p '("--format=gnu"))
+                 (or (mapcar (lambda (fn) (concat dir "/" fn)) files) (list dir)))))
 
 (defun quelpa-build--find-package-commentary (file-path)
   "Get commentary section from FILE-PATH."


### PR DESCRIPTION
Update to latest quelpa version to [`2c17c4f9`](https://framagit.org/steckerhalter/quelpa/commit/2c17c4f97f5d2814015bf64261fc10f590f09f96)

This fixes a bug where some recipes would not install on some systems, for example `cider` via a github recipe on macOS due to an incompatible `tar` flag.