### PR TITLE
[treemacs] Make sure treemacs' buffers are ignored by winum.

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -87,4 +87,8 @@
     (progn
       ;; window 0 is reserved for file trees
       (spacemacs/set-leader-keys "0" 'treemacs-select-window)
-      (define-key winum-keymap (kbd "M-0") 'treemacs-select-window))))
+      (define-key winum-keymap (kbd "M-0") 'treemacs-select-window)
+      (with-eval-after-load 'treemacs
+        (dolist (n (number-sequence 1 5))
+          (add-to-list 'winum-ignored-buffers
+                       (format "%sFramebuffer-%s*" treemacs--buffer-name-prefix n)))))))


### PR DESCRIPTION
There's a bit of a race condition going on, so that *sometimes* winum's ignored buffers are using their default value (winum's own spacemacs config defines them with setq). It seems to depend on when treemacs is loaded exactly. This change duplicates a small piece of compatibility code from treemacs.

I also silenced the message from the treemacs-toggle-fixed-width. I don't think that change is worth is own PR.