### PR TITLE
Extend smerge transient-state with diff keybindings

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -275,9 +275,9 @@
  [_n_]^^    next hunk       [_b_] keep base          [_u_] undo
  [_N_/_p_]  prev hunk       [_m_] keep mine          [_r_] refine
  [_j_/_k_]  move up/down    [_a_] keep all           [_q_] quit
- ^^^^                       [_o_] keep other
- ^^^^                       [_c_] keep current
- ^^^^                       [_C_] combine with next"
+ ^^^^                       [_o_] keep other         [_=<_] diff base to mine
+ ^^^^                       [_c_] keep current       [_==_] diff mine to other
+ ^^^^                       [_C_] combine with next  [_=>_] diff base to other"
         :bindings
         ("n" smerge-next)
         ("p" smerge-prev)
@@ -292,7 +292,10 @@
         ("C" smerge-combine-with-next)
         ("r" smerge-refine)
         ("u" undo-tree-undo)
-        ("q" nil :exit t)))))
+        ("q" nil :exit t)
+        ("=<" smerge-diff-base-mine)
+        ("==" smerge-diff-mine-other)
+        ("=>" smerge-diff-base-other)))))
 
 (defun version-control/init-browse-at-remote ()
   (use-package browse-at-remote


### PR DESCRIPTION
I often use these operations to ask how mine and other have diverged:

=< smerge-diff-base-mine
== smerge-diff-mine-other
=> smerge-diff-base-other

It's awkward to use their global keybindings under C-c ^ because that exits the
smerge transient-state.

Judging from issue GH-7378 there was no principled reason to omit them, only
that the author did not use them himself.