### PR TITLE
Add accept/cancel leader bindings to Forge and Magit log modes

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -18,6 +18,7 @@
   - [[#magit][Magit]]
   - [[#staging-lines][Staging lines]]
   - [[#commit-message-editing-buffer][Commit message editing buffer]]
+  - [[#log-selection-buffer][Log selection buffer]]
   - [[#interactive-rebase-buffer][Interactive rebase buffer]]
   - [[#quick-guide-for-recurring-use-cases-in-magit][Quick guide for recurring use cases in Magit]]
   - [[#git-flow-1][Git-Flow]]
@@ -194,16 +195,25 @@ intended. To work around this, you can use =v= instead (since Magit only stages
 whole lines, in any case).
 
 ** Commit message editing buffer
-In a commit message buffer press ~​,​c~ (if =dotspacemacs-major-mode-leader-key= is ~​,​~)
-or ~C-c C-c~ to commit the changes with the entered message. Pressing ~​,​a~ or ~C-c C-k~
-will discard the commit message.
+In a commit message buffer the following key bindings are active:
 
-| Key binding | Description |
-|-------------+-------------|
-| ~h~         | go left     |
-| ~j~         | go down     |
-| ~k~         | go up       |
-| ~l~         | go right    |
+| Key binding            | Description                                               |
+|------------------------+-----------------------------------------------------------|
+| ~SPC m c~ or ~SPC m ,~ | commit changes with the entered message                   |
+| ~SPC m a~ or ~SPC m k~ | discard message and abort the commit                      |
+| ~g j~ or ~M-n~         | cycle through history to the previous commit message      |
+| ~g k~ or ~M-p~         | save current commit message and cycle to the next message |
+
+In addition, regular commands for saving and killing a buffer such as ~:wq~ and ~ZZ~ can be used to commit changes.
+
+** Log selection buffer
+A log selection buffer is presented as an interactive way of selecting a recent commit that is reachable from HEAD. such as when selecting the beginning of a rebase and when selecting a commit to be squashed into.
+
+| Key binding            | Description                                 |
+|------------------------+---------------------------------------------|
+| ~SPC m c~ or ~SPC m ,~ | select the commit at point and act on it    |
+| ~SPC m a~ or ~SPC m k~ | abort selecting and don't act on any commit |
+
 
 ** Interactive rebase buffer
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -204,7 +204,12 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
               (concat mm-key mm-key) 'with-editor-finish
               (concat mm-key "a")    'with-editor-cancel
               (concat mm-key "c")    'with-editor-finish
-              (concat mm-key "k")    'with-editor-cancel))))
+              (concat mm-key "k")    'with-editor-cancel)
+            (evil-define-key state magit-log-select-mode-map
+              (concat mm-key mm-key) 'magit-log-select-pick
+              (concat mm-key "a")    'magit-log-select-quit
+              (concat mm-key "c")    'magit-log-select-pick
+              (concat mm-key "k")    'magit-log-select-quit))))
       ;; whitespace
       (define-key magit-status-mode-map (kbd "C-S-w")
         'spacemacs/magit-toggle-whitespace)

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -121,6 +121,20 @@ In a =magit-status= buffer (~SPC g s~):
 | ~p y~       | pull pull-requests and issues for the current repository  |
 | ~p Y~       | pull all notifications for the current repository’s forge |
 
+ In a =forge-topic= buffer:
+
+| Key binding | Description     |
+|-------------+-----------------|
+| ~SPC m c~   | create new post |
+| ~SPC m e~   | edit post       |
+
+In a =forge-post= buffer (assuming the major mode leader key is ~,~)
+
+| Key binding            | Description |
+|------------------------+-------------|
+| ~SPC m c~ or ~SPC m ,~ | submit post |
+| ~SPC m k~ or ~SPC m k~ | cancel post |
+
 ** gist.el
 
 | Key binding | Description                                   |

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -25,8 +25,18 @@
 (defun github/init-forge ()
   (use-package forge
     :after magit
-    :init (setq forge-database-file (concat spacemacs-cache-directory
-                                            "forge-database.sqlite"))))
+    :init
+    (progn
+      (setq forge-database-file (concat spacemacs-cache-directory
+                                        "forge-database.sqlite"))
+      (spacemacs/set-leader-keys-for-major-mode 'forge-topic-mode
+        "c" 'forge-create-post
+        "e" 'forge-edit-post)
+      (spacemacs/set-leader-keys-for-major-mode 'forge-post-mode
+        dotspacemacs-major-mode-leader-key 'forge-post-submit
+        "c" 'forge-post-submit
+        "k" 'forge-post-cancel
+        "a" 'forge-post-cancel))))
 
 (defun github/init-gist ()
   (use-package gist


### PR DESCRIPTION

This allows one to use `,c` and `,k` in place of `C-c C-c` and `C-c C-k` in the Magit log mode (e.g. when choosing a commit to fixup into) , and in the Forge post buffer for pull requests and issues.
