### PR TITLE
github: Update forge key bindings

### DIFF
--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -109,10 +109,17 @@ In a =magit-status= buffer (~SPC g s~):
 
 | Key binding | Description                                               |
 |-------------+-----------------------------------------------------------|
-| ~F y~       | pull pull-requests and issues for the current repository  |
-| ~F Y~       | pull all notifications for the current repository’s forge |
 | ~b Y~       | create branch from pull-request                           |
 | ~b y~       | create and check out branch from pull-request             |
+| ~F f~       | fetch issues and pull-requests                            |
+| ~F n~       | fetch notifications                                       |
+| ~F p~       | create pull-request                                       |
+| ~F i~       | create issue                                              |
+| ~F F~       | list notifications                                        |
+| ~F P~       | list pull-requests                                        |
+| ~F I~       | list issues                                               |
+| ~p y~       | pull pull-requests and issues for the current repository  |
+| ~p Y~       | pull all notifications for the current repository's forge |
 
 ** gist.el
 


### PR DESCRIPTION
Update the documentation for `forge` per upstream changes to key bindings in [evil-magit](https://github.com/emacs-evil/evil-magit/commit/49978d07d369fa182971890bc75693b2aef3b5bc).

* `layers/+source-control/github/README.org`: Update key bindings for `forge`.