### PR TITLE
Add flag to allow adding node_modules/.bin path to exec-path.

### DIFF
--- a/layers/+lang/purescript/README.org
+++ b/layers/+lang/purescript/README.org
@@ -8,6 +8,7 @@
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#add-import-on-completion][Add import on completion]]
+  - [[#node-modules][Node Modules]]
   - [[#error-popup][Error popup]]
 - [[#key-bindings][Key bindings]]
   - [[#purescript][Purescript]]

--- a/layers/+lang/purescript/README.org
+++ b/layers/+lang/purescript/README.org
@@ -39,6 +39,17 @@ can be found [[https://github.com/purescript/documentation/blob/master/guides/Ge
 Set =purescript-add-import-on-completion= to nil to make =psc-ide= stop adding
 imports on completion. Default value is =t=.
 
+** Node Modules
+If you would like =node_modules/.bin= to be automatically added to the buffer
+local =exec_path=, e.g. to support project local purs/pulp installations, set the
+=node-add-modules-path= variable in the =purescript= config section. Note that
+doing this [[https://stackoverflow.com/questions/9679932#comment33532258_9683472][introduces a security risk]]:
+
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers
+    '((purescript :variables node-add-modules-path t)))
+#+END_SRC
+
 ** Error popup
 If you set =purescript-enable-rebuild-on-save= to non-nil, you will get a popup
 buffer showing you your current warnings/errors one at a time. This is primarily

--- a/layers/+lang/purescript/layers.el
+++ b/layers/+lang/purescript/layers.el
@@ -1,0 +1,12 @@
+;;; layers.el --- Purescript Layer layers File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Ryan L. Bell
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(configuration-layer/declare-layers '(node))

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -11,6 +11,7 @@
 
 (setq purescript-packages
       '(
+        add-node-modules-path
         company
         flycheck
         purescript-mode
@@ -18,6 +19,9 @@
         psc-ide
         popwin
         ))
+
+(defun purescript/post-init-add-node-modules-path ()
+  (add-hook 'purescript-mode-hook 'add-node-modules-path))
 
 (defun purescript/post-init-company ()
   (when (configuration-layer/package-used-p 'psc-ide)


### PR DESCRIPTION
This is needed to get psc-ide working without installing purescript globally.