### PR TITLE
Fix diff-hl-highlight function is set to nil

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -135,8 +135,7 @@
     (progn
       (spacemacs|do-after-display-system-init
        (setq diff-hl-side (if (eq version-control-diff-side 'left)
-                              'left 'right))
-       (diff-hl-margin-mode -1)))))
+                              'left 'right))))))
 
 (defun version-control/post-init-evil-unimpaired ()
   (define-key evil-normal-state-map (kbd "[ h") 'spacemacs/vcs-previous-hunk)


### PR DESCRIPTION
`diff-hl-margin-mode` is turned off after `display-system-init`, but if `diff-hl-margin-mode` close without opening, it will make `diff-hl-highlight function` set to nil, which cause this issue #10663.

This is my first pull request so feel free to tell if something in this issue should be improved.