### PR TITLE
Load helm before read-file-name and completing-read

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -63,11 +63,12 @@
     :defer (spacemacs/defer)
     :init
     (progn
-      ;; (spacemacs|add-transient-hook minibuffer-setup-hook
-      ;;   (lambda ()
-      ;;     (require 'helm-mode)
-      ;;     (spacemacs|hide-lighter helm-mode))
-      ;;   lazy-load-helm)
+      (spacemacs|add-transient-hook read-file-name
+        (lambda (&rest _args) (require 'helm))
+        lazy-load-helm-for-read-file-name)
+      (spacemacs|add-transient-hook completing-read
+        (lambda (&rest _args) (require 'helm))
+        lazy-load-helm-for-completing-read)
       (add-hook 'helm-cleanup-hook #'spacemacs//helm-cleanup)
       ;; key bindings
       ;; Use helm to provide :ls, unless ibuffer is used

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -103,7 +103,6 @@
 
 
 (defun spacemacs-layouts/post-init-helm ()
-  (spacemacs||set-helm-key "l" spacemacs/layouts-transient-state/body)
   (spacemacs/set-leader-keys
     "bB" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))


### PR DESCRIPTION
Fixes helm not being loaded before calls to:
read-file-name and completing-read.

These are some commands that call either of those two functions:
spacemacs/rename-current-buffer-file (SPC f R)

In a Treemacs window:
treemacs-add-project-to-workspace (C-p a)

In a Magit buffer:
magit-checkout (b b)

Thanks Miciah for a more elegant solution.

This commit also reverts:
Fix helm loading for layouts transient state #11705
because it's not needed anymore.

And the previously commented out transient hook minibuffer-setup-hook (it
doesn't seem to ever have been used) is removed because:
- It loads helm after a command is called that uses helm (instead of before)
- (spacemacs|hide-lighter helm-mode) has previously been moved to the
helm/init-helm :config section.
