### PR TITLE
Fix rust layer performance

### DIFF
--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -13,5 +13,5 @@
 
 (spacemacs|define-jump-handlers rust-mode)
 
-(defvar rust-backend 'racer
-  "The backend to use for completion. Possible values are `lsp' `racer'.")
+;; (defvar rust-backend 'racer
+;;   "The backend to use for completion. Possible values are `lsp' `racer'.")

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -9,64 +9,64 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs/racer-describe ()
-  "Show a *Racer Help* buffer for the function or type at point.
-If `help-window-select' is non-nil, also select the help window."
-  (interactive)
-  (let ((window (racer-describe)))
-    (when help-window-select
-      (select-window window))))
+;; (defun spacemacs/racer-describe ()
+;;   "Show a *Racer Help* buffer for the function or type at point.
+;; If `help-window-select' is non-nil, also select the help window."
+;;   (interactive)
+;;   (let ((window (racer-describe)))
+;;     (when help-window-select
+;;       (select-window window))))
 
-(defun spacemacs/rust-quick-run ()
-  "Quickly run a Rust file using rustc.
-Meant for a quick-prototype flow only - use `spacemacs/open-junk-file' to
-open a junk Rust file, type in some code and quickly run it.
-If you want to use third-party crates, create a new project using `cargo-process-new' and run
-using `cargo-process-run'."
-  (interactive)
-  (let ((input-file-name (buffer-file-name))
-        (output-file-name (concat temporary-file-directory (make-temp-name "rustbin"))))
-    (compile
-     (format "rustc -o %s %s && %s"
-             (shell-quote-argument output-file-name)
-             (shell-quote-argument input-file-name)
-             (shell-quote-argument output-file-name)))))
+;; (defun spacemacs/rust-quick-run ()
+;;   "Quickly run a Rust file using rustc.
+;; Meant for a quick-prototype flow only - use `spacemacs/open-junk-file' to
+;; open a junk Rust file, type in some code and quickly run it.
+;; If you want to use third-party crates, create a new project using `cargo-process-new' and run
+;; using `cargo-process-run'."
+;;   (interactive)
+;;   (let ((input-file-name (buffer-file-name))
+;;         (output-file-name (concat temporary-file-directory (make-temp-name "rustbin"))))
+;;     (compile
+;;      (format "rustc -o %s %s && %s"
+;;              (shell-quote-argument output-file-name)
+;;              (shell-quote-argument input-file-name)
+;;              (shell-quote-argument output-file-name)))))
 
-(defun spacemacs//rust-setup-lsp ()
-  "Setup lsp backend"
-  (if (configuration-layer/layer-used-p 'lsp)
-      (lsp)
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+;; (defun spacemacs//rust-setup-lsp ()
+;;  "Setup lsp backend"
+;;  (if (configuration-layer/layer-used-p 'lsp)
+;;      (lsp)
+;;    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-(defun spacemacs//rust-setup-racer ()
-  "Setup racer backend"
-  (progn
-    (racer-mode)))
+;; (defun spacemacs//rust-setup-racer ()
+;;   "Setup racer backend"
+;;   (progn
+;;     (racer-mode)))
 
-(defun spacemacs//rust-setup-backend ()
-  "Conditionally setup rust backend."
-  (pcase rust-backend
-    (`racer (spacemacs//rust-setup-racer))
-    (`lsp (spacemacs//rust-setup-lsp))))
+;; (defun spacemacs//rust-setup-backend ()
+;;   "Conditionally setup rust backend."
+;;   (pcase rust-backend
+;;     (`racer (spacemacs//rust-setup-racer))
+;;     (`lsp (spacemacs//rust-setup-lsp))))
 
-(defun spacemacs//rust-setup-lsp-company ()
-  "Setup lsp auto-completion."
-  (if (configuration-layer/layer-used-p 'lsp)
-      (progn
-        (spacemacs|add-company-backends
-          :backends company-lsp
-          :modes rust-mode))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+;; (defun spacemacs//rust-setup-lsp-company ()
+;;   "Setup lsp auto-completion."
+;;   (if (configuration-layer/layer-used-p 'lsp)
+;;       (progn
+;;         (spacemacs|add-company-backends
+;;           :backends company-lsp
+;;           :modes rust-mode))
+;;     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-(defun spacemacs//rust-setup-racer-company ()
-  "Setup racer auto-completion."
-        (spacemacs|add-company-backends
-          :backends company-capf
-          :modes rust-mode
-          :variables company-tooltip-align-annotations t))
+;; (defun spacemacs//rust-setup-racer-company ()
+;;   "Setup racer auto-completion."
+;;         (spacemacs|add-company-backends
+;;           :backends company-capf
+;;           :modes rust-mode
+;;           :variables company-tooltip-align-annotations t))
 
-(defun spacemacs//rust-setup-company ()
-  "Conditionally setup company based on backend."
-  (pcase rust-backend
-    (`racer (spacemacs//rust-setup-racer-company))
-    (`lsp (spacemacs//rust-setup-lsp-company))))
+;; (defun spacemacs//rust-setup-company ()
+;;   "Conditionally setup company based on backend."
+;;   (pcase rust-backend
+;;     (`racer (spacemacs//rust-setup-racer-company))
+;;     (`lsp (spacemacs//rust-setup-lsp-company))))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -11,93 +11,94 @@
 
 (setq rust-packages
       '(
-        cargo
-        company
+        ; cargo
+        ; company
         counsel-gtags
-        racer
-        flycheck
-        (flycheck-rust :requires flycheck)
+        ; racer
+        ; flycheck
+        ; (flycheck-rust :requires flycheck)
         ggtags
         helm-gtags
         rust-mode
-        smartparens
+        ; smartparens
         toml-mode
         ))
 
-(defun rust/init-cargo ()
-  (use-package cargo
-    :defer t
-    :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "c." 'cargo-process-repeat
-        "cC" 'cargo-process-clean
-        "cX" 'cargo-process-run-example
-        "cc" 'cargo-process-build
-        "cd" 'cargo-process-doc
-        "cD" 'cargo-process-doc-open
-        "ce" 'cargo-process-bench
-        "cf" 'cargo-process-fmt
-        "ci" 'cargo-process-init
-        "cl" 'cargo-process-clippy
-        "cn" 'cargo-process-new
-        "co" 'cargo-process-current-file-tests
-        "cs" 'cargo-process-search
-        "ct" 'cargo-process-current-test
-        "cu" 'cargo-process-update
-        "cx" 'cargo-process-run
-        "cv" 'cargo-process-check
-        "t" 'cargo-process-test))))
+;; (defun rust/init-cargo ()
+;;   (use-package cargo
+;;     :defer t
+;;     :init
+;;     (progn
+;;       (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
+;;       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+;;         "c." 'cargo-process-repeat
+;;         "cC" 'cargo-process-clean
+;;         "cX" 'cargo-process-run-example
+;;         "cc" 'cargo-process-build
+;;         "cd" 'cargo-process-doc
+;;         "cD" 'cargo-process-doc-open
+;;         "ce" 'cargo-process-bench
+;;         "cf" 'cargo-process-fmt
+;;         "ci" 'cargo-process-init
+;;         "cl" 'cargo-process-clippy
+;;         "cn" 'cargo-process-new
+;;         "co" 'cargo-process-current-file-tests
+;;         "cs" 'cargo-process-search
+;;         "ct" 'cargo-process-current-test
+;;         "cu" 'cargo-process-update
+;;         "cx" 'cargo-process-run
+;;         "cv" 'cargo-process-check
+;;         "t" 'cargo-process-test))))
 
 (defun rust/init-rust-mode ()
   (use-package rust-mode
     :defer t
     :init
     (progn
-      (spacemacs/add-to-hook 'rust-mode-hook '(spacemacs//rust-setup-backend))
+      ; (spacemacs/add-to-hook 'rust-mode-hook '(spacemacs//rust-setup-backend))
       (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'rust-mode "mh" "help")
       (spacemacs/declare-prefix-for-mode 'rust-mode "m=" "format")
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
         "==" 'rust-format-buffer
-        "q" 'spacemacs/rust-quick-run))))
+        ;"q" 'spacemacs/rust-quick-run
+        ))))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode
     :mode "/\\(Cargo.lock\\|\\.cargo/config\\)\\'"))
 
-(defun rust/init-racer ()
-  (use-package racer
-    :defer t
-    :commands racer-mode
-    :config
-    (progn
-      (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
-      (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
-      (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "hh" 'spacemacs/racer-describe)
-      (spacemacs|hide-lighter racer-mode)
-      (evilified-state-evilify-map racer-help-mode-map
-        :mode racer-help-mode))))
+;; (defun rust/init-racer ()
+;;   (use-package racer
+;;     :defer t
+;;     :commands racer-mode
+;;     :config
+;;     (progn
+;;       (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
+;;       (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
+;;       (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
+;;       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+;;         "hh" 'spacemacs/racer-describe)
+;;       (spacemacs|hide-lighter racer-mode)
+;;       (evilified-state-evilify-map racer-help-mode-map
+;;         :mode racer-help-mode))))
 
-(defun rust/init-flycheck-rust ()
-  (use-package flycheck-rust
-    :defer t
-    :init (add-hook 'flycheck-mode-hook #'flycheck-rust-setup)))
+;; (defun rust/init-flycheck-rust ()
+;;   (use-package flycheck-rust
+;;     :defer t
+;;     :init (add-hook 'flycheck-mode-hook #'flycheck-rust-setup)))
 
-(defun rust/post-init-company ()
-  ;; backend specific
-  (spacemacs//rust-setup-company))
+;; (defun rust/post-init-company ()
+;;  ;; backend specific
+;;  (spacemacs//rust-setup-company))
 
-(defun rust/post-init-smartparens ()
-  (with-eval-after-load 'smartparens
-    ;; Don't pair lifetime specifiers
-    (sp-local-pair 'rust-mode "'" nil :actions nil)))
+;; (defun rust/post-init-smartparens ()
+;;   (with-eval-after-load 'smartparens
+;;     ;; Don't pair lifetime specifiers
+;;     (sp-local-pair 'rust-mode "'" nil :actions nil)))
 
-(defun rust/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'rust-mode))
+;; (defun rust/post-init-flycheck ()
+;;   (spacemacs/enable-flycheck 'rust-mode))
 
 (defun rust/post-init-ggtags ()
   (add-hook 'rust-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
This closes #11241 #11622 #11623 #11794 by reverting all changes that automatically enable broken and/or extremely poorly performing functionality in the Rust layer by default. 

The main things this disables are:

* auto-completion: Racer is a program that must be optionally installed by the user, and so is the Rust Language Server. Racer is slow on medium size projects, and gives incorrect autocompletions. The RLS crashes a lot, consumes a lot of memory, and is pretty much unusable on non-tiny projects. Enabling any of these by default, even if they are installed, as well as forcing the user to choose between one or another made spacemacs unusably slow for some of the projects i work on. 

    Those users who want to use them should opt-into these in their `.spacemacs` configuration files. In particular, given how often they crash, and how slow they can get, it doesn't really make sense to enable these unless their query always happen asynchronously in a different cancelable process that doesn't block the main editor thread and that cannot become a zombie to prevent dozens of zombie instances of the RLS consuming ~1Gb of RAM. 

* cargo, flycheck, and all other similar utilities: these are broken by design. Building a project and executing tests in Rust requires invoking `cargo build`, `cargo test`, or some other `cargo` sub-command. These won't run if some other process takes the lock of the project directory. Having these enabled in emacs running in the background prevents me from building my projects, running tests, etc. forcing me to kill all emacs rust buffers to release the lock. This makes for a horrible development experience. Those who want it should, again, opt into it, but a better design for this should make sure that the lock is not taken often, and when it is taken, then only for very brief periods of time and released immediately. 

* smartparens: completely freezes the editor for 5 seconds on tiny files O(1000k LOC) trying to match parentheses when editing code inside large-ish O(100LOC) Rust macros. The proposed solution (https://github.com/Fuco1/smartparens/issues/897) appears to be putting an upper bound of 1 second on the freezes. Freezing the editor for 1 or more seconds just to highlight parentheses in colors is not worth it. Users that want this should opt into this, and honestly, this is another computation that should run asynchronously instead of blocking the UI thread. 

I'm not against adding support for all of these things as opt-ins, but all new functionality appears to be added to this layer as "enabled by default without an option to disable it". Users of the rust-layer should not have to pay for things they don't or can't (e.g. because the tools don't cope well with project size) use.