### PR TITLE
Haskell: add LSP support via HIE and lsp-haskell

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1353,6 +1353,7 @@ Other:
     (thanks to Magnus Therning)
 - Fixed jump handlers conflict for haskell and intero (thanks to CthulhuDen)
 - Fix haskell jump handler for dante (thanks to cjay)
+- Enable LSP mode using HIE.
 **** Helm
 - Limited =ripgrep= results to 512 columns by default, and added
   =spacemacs-helm-rg-max-column-number= layer variable to configure the above

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -113,6 +113,19 @@ completion, you’ll have to enable the =auto-completion= layer as well.
                   (haskell :variables haskell-completion-backend 'intero)))
 #+END_SRC
 
+Backend can be chosen on a per project basis using directory local variables
+(files named =.dir-locals.el= at the root of a project), an example to use the
+=intero= backend:
+
+#+BEGIN_SRC elisp
+  ;;; Directory Local Variables
+  ;;; For more information see (info "(emacs) Directory Variables")
+
+  ((haskell-mode (haskell-completion-backend . intero)))
+#+END_SRC
+
+*Note:* you can easily add a directory local variable with ~SPC f v d~.
+
 *** =company-ghci=
 [[https://github.com/juiko/company-ghci][company-ghci]] communicates directly with =ghci=, in order to provide completion.
 To use it, you have to call =haskell-process-load-or-reload= (=SPC s b=).

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -14,6 +14,7 @@
     - [[#intero][=intero=]]
     - [[#dante][=dante=]]
     - [[#ghc-mod][=ghc-mod=]]
+    - [[#lsp][=lsp=]]
   - [[#optional-extras][Optional extras]]
     - [[#structured-haskell-mode][structured-haskell-mode]]
     - [[#hindent][hindent]]
@@ -77,6 +78,7 @@ This layer requires some [[https://www.haskell.org/cabal/][cabal]] packages:
 - =hoogle= (optional for =haskell-mode= and =helm-hoogle=)
 - =ghc-mod= (optional for completion)
 - =intero= (optional for completion)
+- =hie= (optional for completion)
 
 To install them, use the following command (or the =stack= equivalent):
 
@@ -100,8 +102,8 @@ For information about setting up =$PATH=, check out the corresponding section in
 the FAQ (~SPC h SPC $PATH RET~).
 
 ** Completion support
-This layer provides several completion backends - =intero=, =dante=, =ghci= and
-=ghc-mod=. =ghci= (=company-ghci=) is used by default, because it doesn’t
+This layer provides several completion backends - =intero=, =dante=, =ghci=,
+=ghc-mod=, and =lsp=. =ghci= (=company-ghci=) is used by default, because it doesn’t
 require any dependencies, and it works with both =stack= and pure =cabal=
 projects. The completion backend can be changed manually, by setting the value
 of the =haskell-completion-backend= variable. Note that in order to enable
@@ -151,6 +153,14 @@ checkout this [[https://github.com/DanielG/ghc-mod/wiki#user-content-known-issue
 Also note that =ghc-mod= only works with the =GHC= version that was used to
 build =ghc-mod=. You can check which version was used by calling
 =ghc-mod --version=.
+
+*** =lsp=
+=lsp= requires an appropriate installation of =hie= to provide the Haskell language server. 
+=hie= is built on =ghc-mod=, so many of the same considerations apply.
+
+Enabling the =lsp= backend requires the =lsp= layer to be enabled, and provides access to
+all the additional =lsp-mode= keybindings. As such it is more of a full backend than just
+a completion backend.
 
 ** Optional extras
 The Haskell layer supports some extra features, which can be enabled through the

--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -17,7 +17,7 @@
 
 (defvar haskell-completion-backend 'ghci
   "Completion backend used by company.
-Available options are `ghci', `intero', `dante', and `ghc-mod'. Default is
+Available options are `ghci', `intero', `dante', `lsp' and `ghc-mod'. Default is
 `ghci'.")
 
 (defvar haskell-enable-hindent nil

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -22,7 +22,58 @@
     (haskell-navigate-imports)
     (haskell-mode-format-imports)))
 
-;; Dante Functions
+
+;; Completion setup functions
+
+(defun spacemacs-haskell//setup-backend ()
+  "Conditionally setup haskell backend."
+  (pcase haskell-completion-backend
+    (`ghci (spacemacs-haskell//setup-ghci))
+    (`intero (spacemacs-haskell//setup-intero))
+    (`dante (spacemacs-haskell//setup-dante))
+    (`ghc-mod (spacemacs-haskell//setup-ghc-mod))))
+
+(defun spacemacs-haskell//setup-company ()
+  "Conditionally setup haskell backend."
+  (pcase haskell-completion-backend
+    (`ghci (spacemacs-haskell//setup-ghci-company))
+    (`intero (spacemacs-haskell//setup-intero-company))
+    (`dante (spacemacs-haskell//setup-dante-company))
+    (`ghc-mod (spacemacs-haskell//setup-ghc-mod-company))))
+
+
+;; ghci functions
+
+(defun spacemacs-haskell//setup-ghci ()
+  (interactive-haskell-mode))
+
+(defun spacemacs-haskell//setup-ghci-company ()
+  (spacemacs|add-company-backends
+    :backends (company-ghci company-dabbrev-code company-yasnippet)
+    :modes haskell-mode))
+
+
+;; ghc-mod functions
+
+(defun spacemacs-haskell//setup-ghc-mod ()
+  (ghc-init))
+
+(defun spacemacs-haskell//setup-ghc-mod-company ()
+  (spacemacs|add-company-backends
+    :backends (company-ghc company-dabbrev-code company-yasnippet)
+    :modes haskell-mode))
+
+
+;; Dante functions
+
+(defun spacemacs-haskell//setup-dante ()
+  (dante-mode)
+  (add-to-list 'spacemacs-jump-handlers-haskell-mode 'xref-find-definitions))
+
+(defun spacemacs-haskell//setup-dante-company ()
+  (spacemacs|add-company-backends
+    :backends (dante-company company-dabbrev-code company-yasnippet)
+    :modes haskell-mode))
 
 (defun spacemacs-haskell//dante-insert-type ()
   (interactive)
@@ -30,6 +81,16 @@
 
 
 ;; Intero functions
+
+(defun spacemacs-haskell//setup-intero ()
+  (interactive-haskell-mode)
+  (intero-mode)
+  (add-to-list 'spacemacs-jump-handlers-haskell-mode 'intero-goto-definition))
+
+(defun spacemacs-haskell//setup-intero-company ()
+  (spacemacs|add-company-backends
+    :backends (company-intero company-dabbrev-code company-yasnippet)
+    :modes haskell-mode))
 
 (defun haskell-intero/insert-type ()
   (interactive)

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -28,6 +28,7 @@
   "Conditionally setup haskell backend."
   (pcase haskell-completion-backend
     (`ghci (spacemacs-haskell//setup-ghci))
+    (`lsp (spacemacs-haskell//setup-lsp))
     (`intero (spacemacs-haskell//setup-intero))
     (`dante (spacemacs-haskell//setup-dante))
     (`ghc-mod (spacemacs-haskell//setup-ghc-mod))))
@@ -36,6 +37,7 @@
   "Conditionally setup haskell backend."
   (pcase haskell-completion-backend
     (`ghci (spacemacs-haskell//setup-ghci-company))
+    (`lsp (spacemacs-haskell//setup-lsp-company))
     (`intero (spacemacs-haskell//setup-intero-company))
     (`dante (spacemacs-haskell//setup-dante-company))
     (`ghc-mod (spacemacs-haskell//setup-ghc-mod-company))))
@@ -49,6 +51,31 @@
   (spacemacs|add-company-backends
     :backends (company-ghci company-dabbrev-code company-yasnippet)
     :modes haskell-mode))
+
+;; LSP functions
+
+(defun spacemacs-haskell//setup-lsp ()
+  "Setup lsp backend"
+  (if (configuration-layer/layer-used-p 'lsp)
+      (progn
+        ;; The functionality we require from this is not an autoload, but rather some
+        ;; top-level code that registers a LSP server type. So we need to load it
+        ;; directly and can't rely on it being autoloaded.
+        (require 'lsp-haskell)
+        (lsp))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs-haskell//setup-lsp-company ()
+  "Setup lsp auto-completion"
+  (if (configuration-layer/layer-used-p 'lsp)
+      (progn
+        (spacemacs|add-company-backends
+          :backends company-lsp
+          :modes haskell-mode
+          :append-hooks nil
+          :call-hooks t)
+        (company-mode))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 ;; ghc-mod functions
 

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -22,7 +22,6 @@
     (haskell-navigate-imports)
     (haskell-mode-format-imports)))
 
-
 ;; Completion setup functions
 
 (defun spacemacs-haskell//setup-backend ()
@@ -41,7 +40,6 @@
     (`dante (spacemacs-haskell//setup-dante-company))
     (`ghc-mod (spacemacs-haskell//setup-ghc-mod-company))))
 
-
 ;; ghci functions
 
 (defun spacemacs-haskell//setup-ghci ()
@@ -52,7 +50,6 @@
     :backends (company-ghci company-dabbrev-code company-yasnippet)
     :modes haskell-mode))
 
-
 ;; ghc-mod functions
 
 (defun spacemacs-haskell//setup-ghc-mod ()
@@ -63,7 +60,6 @@
     :backends (company-ghc company-dabbrev-code company-yasnippet)
     :modes haskell-mode))
 
-
 ;; Dante functions
 
 (defun spacemacs-haskell//setup-dante ()
@@ -79,7 +75,6 @@
   (interactive)
   (dante-type-at :insert))
 
-
 ;; Intero functions
 
 (defun spacemacs-haskell//setup-intero ()

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -34,10 +34,10 @@
     (`ghc-mod (spacemacs-haskell//setup-ghc-mod))))
 
 (defun spacemacs-haskell//setup-company ()
-  "Conditionally setup haskell backend."
+  "Conditionally setup haskell completion backend."
   (pcase haskell-completion-backend
     (`ghci (spacemacs-haskell//setup-ghci-company))
-    (`lsp (spacemacs-haskell//setup-lsp-company))
+    (`lsp nil) ;; nothing to do, auto-configured by lsp-mode
     (`intero (spacemacs-haskell//setup-intero-company))
     (`dante (spacemacs-haskell//setup-dante-company))
     (`ghc-mod (spacemacs-haskell//setup-ghc-mod-company))))
@@ -63,18 +63,6 @@
         ;; directly and can't rely on it being autoloaded.
         (require 'lsp-haskell)
         (lsp))
-    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
-
-(defun spacemacs-haskell//setup-lsp-company ()
-  "Setup lsp auto-completion"
-  (if (configuration-layer/layer-used-p 'lsp)
-      (progn
-        (spacemacs|add-company-backends
-          :backends company-lsp
-          :modes haskell-mode
-          :append-hooks nil
-          :call-hooks t)
-        (company-mode))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 ;; ghc-mod functions

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -26,9 +26,7 @@
         (intero :requires company)
 
         ;; dante completion backend
-        (dante
-         :requires company
-         :toggle (version<= "25" emacs-version))
+        (dante :requires company)
 
         flycheck
         (flycheck-haskell :requires flycheck)

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -47,7 +47,8 @@
     :defer t))
 
 (defun haskell/post-init-company ()
-  (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-company))
+  (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-company)
+  (add-hook 'literate-haskell-mode-local-vars-hook #'spacemacs-haskell//setup-company))
 
 (defun haskell/init-company-cabal ()
   (use-package company-cabal
@@ -156,7 +157,8 @@
     :init (add-hook 'flycheck-mode-hook 'flycheck-haskell-configure)))
 
 (defun haskell/post-init-ggtags ()
-  (add-hook 'haskell-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'haskell-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
+  (add-hook 'literate-haskell-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun haskell/init-haskell-mode ()
   (use-package haskell-mode
@@ -164,6 +166,7 @@
     :init
     (progn
       (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
+      (add-hook 'literate-haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
 
       (defun spacemacs//force-haskell-mode-loading ()
         "Force `haskell-mode' loading when visiting cabal file."

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -16,26 +16,19 @@
         (company-cabal :requires company)
 
         ;; ghci completion backend
-        (company-ghci
-         :requires company
-         :toggle (eq haskell-completion-backend 'ghci))
-
+        (company-ghci :requires company)
+         
         ;; ghc-mod completion backend
-        (company-ghc
-         :requires company
-         :toggle (eq haskell-completion-backend 'ghc-mod))
-        (ghc :toggle (eq haskell-completion-backend 'ghc-mod))
+        (company-ghc :requires company)
+        ghc
 
         ;; intero completion backend
-        (intero
-         :requires company
-         :toggle (eq haskell-completion-backend 'intero))
+        (intero :requires company)
 
         ;; dante completion backend
         (dante
          :requires company
-         :toggle (and (version<= "25" emacs-version)
-                      (eq haskell-completion-backend 'dante)))
+         :toggle (version<= "25" emacs-version))
 
         flycheck
         (flycheck-haskell :requires flycheck)

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -53,7 +53,8 @@
   (use-package cmm-mode
     :defer t))
 
-(defun haskell/post-init-company ())
+(defun haskell/post-init-company ()
+  (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-company))
 
 (defun haskell/init-company-cabal ()
   (use-package company-cabal
@@ -65,12 +66,7 @@
 
 (defun haskell/init-company-ghci ()
   (use-package company-ghci
-    :defer t
-    :init
-    (spacemacs|add-company-backends
-      :backends (company-ghci company-dabbrev-code company-yasnippet)
-      :modes haskell-mode)
-    (add-hook 'haskell-mode-hook 'interactive-haskell-mode)))
+    :defer t))
 
 (defun haskell/init-company-ghc ()
   (use-package company-ghc
@@ -79,11 +75,6 @@
 (defun haskell/init-ghc ()
   (use-package ghc
     :defer t
-    :init
-    (spacemacs|add-company-backends
-      :backends (company-ghc company-dabbrev-code company-yasnippet)
-      :modes haskell-mode)
-    (add-hook 'haskell-mode-hook 'ghc-init)
     :config
     (progn
       (dolist (mode haskell-modes)
@@ -108,13 +99,6 @@
 (defun haskell/init-intero ()
   (use-package intero
     :defer t
-    :init
-    (spacemacs|add-company-backends
-      :backends (company-intero company-dabbrev-code company-yasnippet)
-      :modes haskell-mode)
-    (add-hook 'haskell-mode-hook 'interactive-haskell-mode)
-    (add-hook 'haskell-mode-hook 'intero-mode)
-    (add-to-list 'spacemacs-jump-handlers-haskell-mode 'intero-goto-definition)
     :config
     (progn
       (spacemacs|diminish intero-mode " λ" " \\")
@@ -152,12 +136,6 @@
 (defun haskell/init-dante ()
   (use-package dante
     :defer t
-    :init
-    (spacemacs|add-company-backends
-      :backends (dante-company company-dabbrev-code company-yasnippet)
-      :modes haskell-mode)
-    (add-hook 'haskell-mode-hook 'dante-mode)
-    (add-to-list 'spacemacs-jump-handlers-haskell-mode 'xref-find-definitions)
     :config
     (progn
       (dolist (mode haskell-modes)
@@ -192,6 +170,8 @@
     :defer t
     :init
     (progn
+      (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
+
       (defun spacemacs//force-haskell-mode-loading ()
         "Force `haskell-mode' loading when visiting cabal file."
         (require 'haskell-mode))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -28,6 +28,8 @@
         ;; dante completion backend
         (dante :requires company)
 
+        lsp-haskell
+
         flycheck
         (flycheck-haskell :requires flycheck)
         ggtags
@@ -39,6 +41,10 @@
         hindent
         hlint-refactor
         ))
+
+(defun haskell/init-lsp-haskell()
+  (use-package lsp-haskell
+    :defer t))
 
 (defun haskell/init-cmm-mode ()
   (use-package cmm-mode


### PR DESCRIPTION
This allows the use of the `lsp` layer as a backend for the Haskell layer along with an installation of `hie`.

The first commits are from https://github.com/syl20bnr/spacemacs/pull/11550, which performs some useful preparatory refactorings. All I did was fix the merge conflict (indentation), and get rid of the form-feed characters as requested in the review.

After that it's mostly a matter of just adding the appropriate additional hook.

The existing setup is now a little inconsistent, since we talk about the *completion* backend for the layer, whereas the `lsp` backend provides a bunch of other stuff too. However, I'm not planning to try and change that here.