### PR TITLE
[fix] org-clock-jump-to-current-clock

### DIFF
--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -67,3 +67,8 @@
 (defun spacemacs/org-trello-push-card ()
   (interactive)
   (org-trello-sync-card))
+
+(defun spacemacs/org-clock-jump-to-current-clock ()
+  (interactive)
+  (autoload #'org-clock-jump-to-current-clock "org-clock")
+  (org-clock-jump-to-current-clock))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -194,7 +194,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "Cg" 'org-clock-goto
         "Ci" 'org-clock-in
         "CI" 'org-clock-in-last
-        "Cj" 'org-clock-jump-to-current-clock
+        "Cj" 'spacemacs/org-clock-jump-to-current-clock
         "Co" 'org-clock-out
         "CR" 'org-clock-report
         "Cr" 'org-resolve-clocks
@@ -351,7 +351,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "aoCg" 'org-clock-goto
         "aoCi" 'org-clock-in
         "aoCI" 'org-clock-in-last
-        "aoCj" 'org-clock-jump-to-current-clock
+        "aoCj" 'spacemacs/org-clock-jump-to-current-clock
         "aoCo" 'org-clock-out
         "aoCr" 'org-resolve-clocks
 


### PR DESCRIPTION
After orgmode v9.1.12 `org-clock-resolve-clock` is no longer an
`interactive` function, this change broke bindings like `SPC a o C j`.

This pr fixes that

---
Edit 2019-03-16:
corrected error in the description, replaced `org-clock-resolve-clock` with `org-clock-jump-to-current-clock`
