### PR TITLE
Create `backup' layer to enable auto backup behavior in spacemacs

### DIFF
--- a/layers/+misc/backup/README.org
+++ b/layers/+misc/backup/README.org
@@ -1,0 +1,54 @@
+#+TITLE: backup layer
+
+* Table of Contents                                       :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#acknowledgments][Acknowledgments]]
+
+* Description
+This layer adds support for automatic backups.
+
+Emacs default behavior is [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Backup.html][to backup a file first time it is saved]]. This behavior
+results in a lot of =file_name.ext~= files being automatically created. Many
+people find this annoying and spacemacs turns the auto backup off.
+
+This layer re-enables and extends the automatic backups.
+
+** Features:
+   
+- per-session backups
+
+  Similar to emacs default behavior, make a backup first time it is saved from
+  emacs session.
+
+- per-save backups
+
+  Make a backup every time file is saved.
+
+- better defaults
+
+  Do not clutter working directories with the backups:
+
+  - Store per-session backup in =~/.emacs.d/.cache/backups/per-session=
+    (customize variable =backup-per-session-directory= to override).
+  - Store per-save backup in =~/.emacs.d/.cache/backups/per-save= (customize
+    variable =backup-per-save-directory= to override).
+
+  Sane defaults for the backup files:
+
+  - Backup files under version control.
+  - Keep the last 10 per-save backups and last 3 per-session backups.
+  - Backup by copying.
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =backup= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Acknowledgments
+
+Inner workings of this layer is based on description by @GregorySchwartz in
+syl20bnr/spacemacs#8947. Which is in turn inspired by a [[https://stackoverflow.com/questions/151945/how-do-i-control-how-emacs-makes-backup-files][StackOverflow discussion]]
+on the subject.
+

--- a/layers/+misc/backup/config.el
+++ b/layers/+misc/backup/config.el
@@ -1,0 +1,34 @@
+;;; config.el --- backup layer config file for Spacemacs.
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Igor Kupczyński <igor@kupczynski.info>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; based on https://github.com/syl20bnr/spacemacs/issues/8947
+
+;;; Variables:
+(defvar backup-per-save-directory "~/.emacs.d/.cache/backups/per-save"
+  "Directory to store per-save backups")
+
+(defvar backup-per-session-directory "~/.emacs.d/.cache/backups/per-session"
+  "Directory to store per-session backups")
+
+;;; Defaults:
+(setq make-backup-files t)     ;; Enable backups
+
+(setq version-control t        ;; Use version numbers for backups.
+      kept-new-versions 10     ;; Number of newest versions to keep.
+      kept-old-versions 0      ;; Number of oldest versions to keep.
+      delete-old-versions t    ;; Don't ask to delete excess backup versions.
+      backup-by-copying t)     ;; Copy all files, don't rename them.
+(setq vc-make-backup-files t)  ;; Do backups also for version controlled files
+
+(setq backup-directory-alist
+      `(("" . ,backup-per-save-directory)))
+
+;;; config.el ends here

--- a/layers/+misc/backup/funcs.el
+++ b/layers/+misc/backup/funcs.el
@@ -1,0 +1,52 @@
+;;; funcs.el --- backup layer funcs file for Spacemacs.
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Igor Kupczyński <igor@kupczynski.info>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Code:
+(defun backup-force-backup-of-buffer ()
+  "Make sure emacs backs up buffers on every save, not just the first time.
+
+By default, emacs backups the file only first time it is saved:
+
+> Emacs makes a backup for a file only the first time the file is
+> saved from a buffer. No matter how many times you subsequently
+> save the file, its backup remains unchanged. However, if you
+> kill the buffer and then visit the file again, a new backup
+> file will be made.
+
+Src: https://www.gnu.org/software/emacs/manual/html_node/emacs/Backup.html
+
+This function, if installed as a before-save-hook, extends that
+behavior to save a backup copy each time a file is
+saved (per-save backup). It also preserves the first-time only
+behavior (per-session backup).
+
+per-save and per-session backups are stored in different
+directories.
+"
+  ;; Make "per session" backup at the first save of each emacs session.
+  (when (not buffer-backed-up)
+    ;; Override the default parameters for per-session backups as we don't need
+    ;; to keep as many copies.
+    (let ((backup-directory-alist `(("" . ,backup-per-session-directory)))
+          (kept-new-versions 3))
+      (backup-buffer)))
+  ;; Make a "per save" backup on each save. The first save results in both a
+  ;; per-session and a per-save backup, to keep the numbering of per-save
+  ;; backups consistent.
+  (let ((buffer-backed-up nil))
+    (backup-buffer)))
+
+;;; Setup:
+(add-hook 'before-save-hook  'backup-force-backup-of-buffer)
+(if (eq dotspacemacs-auto-save-file-location 'original)
+    (add-hook 'auto-save-hook 'backup-force-backup-of-buffer))
+
+;;; funcs.el ends here


### PR DESCRIPTION
# Create `backup` layer to enable auto backup behavior in spacemacs

Related to https://github.com/syl20bnr/spacemacs/issues/8947

*Note: my first PR against spacemacs, happy to learn why this change sucks and how I can it*

This layer adds support for automatic backups.

Emacs default behavior is [to backup a file first time it is saved](https://www.gnu.org/software/emacs/manual/html_node/emacs/Backup.html). This behavior results in a lot of `#file_name.ext#` files being automatically created. Many people find this annoying and spacemacs turns the auto backup off.

This layer re-enables and extends the automatic backups.

## Features:<a id="sec-1-1"></a>

### per-session backups<a id="sec-1-1-1"></a>

Similar to emacs default behavior, make a backup first time it is saved from emacs session.

### per-save backups<a id="sec-1-1-2"></a>

Make a backup every time file is saved.

### better defaults<a id="sec-1-1-3"></a>

Do not clutter working directories with the backups:

-   Store per-session backup in `~/.emacs.d/.cache/backups/per-session` (customize variable `backup-per-session-directory` to override).
-   Store per-save backup in `~/.emacs.d/.cache/backups/per-save` (customize variable `backup-per-save-directory` to override).

Sane defaults for the backup files:

-   Backup files under version control.
-   Keep the last 10 per-save backups and last 3 per-session backups.
-   Backup by copying.

# Install<a id="sec-2"></a>

To use this configuration layer, add it to your `~/.spacemacs`. You will need to add `backup` to the existing `dotspacemacs-configuration-layers` list in this file.

# Acknowledgments<a id="sec-3"></a>

Inner workings of this layer is based on description by @GregorySchwartz in syl20bnr/spacemacs#8947. Which is in turn inspired by a [StackOverflow discussion](https://stackoverflow.com/questions/151945/how-do-i-control-how-emacs-makes-backup-files) on the subject.
