### PR TITLE
Add labeled prefix for dash layer

### DIFF
--- a/layers/+readers/dash/packages.el
+++ b/layers/+readers/dash/packages.el
@@ -10,32 +10,40 @@
 (defun dash/init-helm-dash ()
   (use-package helm-dash
     :defer t
-    :init (spacemacs/set-leader-keys
+    :init (progn
+           (spacemacs/declare-prefix "d" "docs")
+           (spacemacs/set-leader-keys
             "dh" 'helm-dash-at-point
-            "dH" 'helm-dash)
+            "dH" 'helm-dash))
     :config (dash//activate-package-docsets helm-dash-docset-newpath)))
 
 (defun dash/init-counsel-dash ()
   (use-package counsel-dash
     :defer t
-    :init (spacemacs/set-leader-keys
+    :init (progn
+           (spacemacs/declare-prefix "d" "docs")
+           (spacemacs/set-leader-keys
             "dh" 'counsel-dash-at-point
-            "dH" 'counsel-dash)
+            "dH" 'counsel-dash))
     :config (dash//activate-package-docsets helm-dash-docset-newpath)))
 
 (defun dash/init-dash-at-point ()
   (use-package dash-at-point
     :defer t
-    :init (spacemacs/set-leader-keys
+    :init (progn
+           (spacemacs/declare-prefix "d" "docs")
+           (spacemacs/set-leader-keys
             "dd" 'dash-at-point
-            "dD" 'dash-at-point-with-docset)))
+            "dD" 'dash-at-point-with-docset))))
 
 (defun dash/init-zeal-at-point ()
   (use-package zeal-at-point
     :defer t
-    :init (spacemacs/set-leader-keys
+    :init (progn
+           (spacemacs/declare-prefix "d" "docs")
+           (spacemacs/set-leader-keys
             "dd" 'zeal-at-point
-            "dD" 'zeal-at-point-set-docset)
+            "dD" 'zeal-at-point-set-docset))
     :config
     ;; This lets users seach in multiple docsets
     (add-to-list 'zeal-at-point-mode-alist '(web-mode . "html,css,javascript"))))


### PR DESCRIPTION
Currently the "d" prefix in the which-key menu is displayed as "prefix". This patch replaces that with "docs".

