### PR TITLE
Improvements to Window Manipulation Transient state

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2192,6 +2192,10 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w w~              | cycle and focus between windows                                             |
 | ~SPC w W~              | select window using [[https://github.com/abo-abo/ace-window][ace-window]]                                              |
 | ~SPC w x~              | delete a window and its current buffer (does not delete the file)           |
+| ~SPC w [~              | shrink window horizontally (enter transient state)                          |
+| ~SPC w ]~              | enlarge window horizontally (enter transient state)                         |
+| ~SPC w {~              | shrink window vertically (enter transient state)                            |
+| ~SPC w }~              | enlarge window vertically (enter transient state)                           |
 
 Split the current window into multiple ones, deleting all others using the
 following commands:

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2262,6 +2262,8 @@ window resizing.
 | ~9~         | go to window number 9                                         |
 | ~/~         | vertical split                                                |
 | ~-~         | horizontal split                                              |
+| ~\vert~     | maximize window vertically                                    |
+| ~_~         | maximize window horizontally                                  |
 | ~[~         | shrink window horizontally                                    |
 | ~]~         | enlarge window horizontally                                   |
 | ~{~         | shrink window vertically                                      |
@@ -2277,6 +2279,7 @@ window resizing.
 | ~J~         | move window to the bottom                                     |
 | ~K~         | move bottom to the top                                        |
 | ~L~         | move window to the right                                      |
+| ~m~         | toggle maximization of current window                         |
 | ~o~         | focus other frame                                             |
 | ~r~         | rotate windows forward                                        |
 | ~R~         | rotate windows backward                                       |

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -628,22 +628,46 @@ respond to this toggle."
   (interactive "p")
   (enlarge-window delta t))
 
-(spacemacs|define-transient-state window-manipulation
-  :title "Window Manipulation Transient State"
-  :doc (concat "
+(defun spacemacs//window-manipulation-ts-toggle-hint ()
+  "Toggle the full hint docstring for the window manipulation transient-state."
+  (interactive)
+  (setq spacemacs--ts-full-hint-toggle
+        (logxor spacemacs--ts-full-hint-toggle 1)))
+
+(defun spacemacs//window-manipulation-ts-hint ()
+  "Return a condensed/full hint for the window manipulation transient state"
+  (concat
+   " "
+   (if (equal 1 spacemacs--ts-full-hint-toggle)
+       spacemacs--window-manipulation-ts-full-hint
+     (concat spacemacs--window-manipulation-ts-minified-hint
+             "  ([" (propertize "?" 'face 'hydra-face-red) "] help)"))))
+
+(spacemacs|transient-state-format-hint window-manipulation
+  spacemacs--window-manipulation-ts-minified-hint "
+Select: _w_ _h_ _j_ _k_ _l_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s_ _v_ Resize: _[_ _]_ _{_ _}_")
+
+(spacemacs|transient-state-format-hint window-manipulation
+  spacemacs--window-manipulation-ts-full-hint
+  (format "\n [_?_] toggle help
  Select^^^^               Move^^^^              Split^^               Resize^^             Other^^
  ──────^^^^─────────────  ────^^^^────────────  ─────^^─────────────  ──────^^───────────  ─────^^──────────────────
  [_j_/_k_]  down/up       [_J_/_K_] down/up     [_s_] horizontal      [_[_] shrink horiz   [_u_] restore prev layout
  [_h_/_l_]  left/right    [_H_/_L_] left/right  [_S_] horiz & follow  [_]_] enlarge horiz  [_U_] restore next layout
  [_0_.._9_] window 0..9   [_r_]^^   rotate fwd  [_v_] vertical        [_{_] shrink verti   [_d_] close current
  [_w_]^^    other window  [_R_]^^   rotate bwd  [_V_] verti & follow  [_}_] enlarge verti  [_D_] close other
- [_o_]^^    other frame   ^^^^                  ^^                    ^^                   "
-               (if (configuration-layer/package-used-p 'golden-ratio)
-                   "[_g_] golden-ratio %`golden-ratio-mode"
-                 "")
-               "\n ^^^^                     ^^^^                  ^^                    ^^                   [_q_] quit")
+ [_o_]^^    other frame   ^^^^                  ^^                    %s^^^^^^^^^^^^^^^^^^ [_q_] quit"
+          (if (configuration-layer/package-used-p 'golden-ratio)
+              "[_g_] golden-ratio  "
+            "^^^^                  ")))
+
+(spacemacs|define-transient-state window-manipulation
+  :title "Window Manipulation TS"
+  :hint-is-doc t
+  :dynamic-hint (spacemacs//window-manipulation-ts-hint)
   :bindings
   ("q" nil :exit t)
+  ("?" spacemacs//window-manipulation-ts-toggle-hint)
   ("0" winum-select-window-0)
   ("1" winum-select-window-1)
   ("2" winum-select-window-2)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -688,8 +688,12 @@ respond to this toggle."
   ("v" split-window-right)
   ("V" split-window-right-and-focus)
   ("w" other-window))
-(spacemacs/set-leader-keys "w."
-  'spacemacs/window-manipulation-transient-state/body)
+(spacemacs/set-leader-keys
+  "w." 'spacemacs/window-manipulation-transient-state/body
+  "w[" 'spacemacs/window-manipulation-transient-state/spacemacs/shrink-window-horizontally
+  "w]" 'spacemacs/window-manipulation-transient-state/spacemacs/enlarge-window-horizontally
+  "w{" 'spacemacs/window-manipulation-transient-state/spacemacs/shrink-window
+  "w}" 'spacemacs/window-manipulation-transient-state/spacemacs/enlarge-window)
 
 ;; end of Window Manipulation Transient State
 

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -645,18 +645,18 @@ respond to this toggle."
 
 (spacemacs|transient-state-format-hint window-manipulation
   spacemacs--window-manipulation-ts-minified-hint "
-Select: _w_ _h_ _j_ _k_ _l_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s_ _v_ Resize: _[_ _]_ _{_ _}_")
+Select: _w_ _h_ _j_ _k_ _l_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s_ _v_ Resize: _[_ _]_ _{_ _}_ _m_ _|_ ___")
 
 (spacemacs|transient-state-format-hint window-manipulation
   spacemacs--window-manipulation-ts-full-hint
   (format "\n [_?_] toggle help
- Select^^^^               Move^^^^              Split^^               Resize^^             Other^^
- ──────^^^^─────────────  ────^^^^────────────  ─────^^─────────────  ──────^^───────────  ─────^^──────────────────
- [_j_/_k_]  down/up       [_J_/_K_] down/up     [_s_] horizontal      [_[_] shrink horiz   [_u_] restore prev layout
- [_h_/_l_]  left/right    [_H_/_L_] left/right  [_S_] horiz & follow  [_]_] enlarge horiz  [_U_] restore next layout
- [_0_.._9_] window 0..9   [_r_]^^   rotate fwd  [_v_] vertical        [_{_] shrink verti   [_d_] close current
- [_w_]^^    other window  [_R_]^^   rotate bwd  [_V_] verti & follow  [_}_] enlarge verti  [_D_] close other
- [_o_]^^    other frame   ^^^^                  ^^                    %s^^^^^^^^^^^^^^^^^^ [_q_] quit"
+ Select^^^^               Move^^^^              Split^^^^^^               Resize^^             Other^^
+ ──────^^^^─────────────  ────^^^^────────────  ─────^^^^^^─────────────  ──────^^───────────  ─────^^──────────────────
+ [_j_/_k_]  down/up       [_J_/_K_] down/up     [_s_]^^^^ horizontal      [_[_] shrink horiz   [_u_] restore prev layout
+ [_h_/_l_]  left/right    [_H_/_L_] left/right  [_S_]^^^^ horiz & follow  [_]_] enlarge horiz  [_U_] restore next layout
+ [_0_.._9_] window 0..9   [_r_]^^   rotate fwd  [_v_]^^^^ vertical        [_{_] shrink verti   [_d_] close current
+ [_w_]^^    other window  [_R_]^^   rotate bwd  [_V_]^^^^ verti & follow  [_}_] enlarge verti  [_D_] close other
+ [_o_]^^    other frame   ^^^^                  [_m_/_|_/___] maximize    %s^^^^^^^^^^^^^^^^^^ [_q_] quit"
           (if (configuration-layer/package-used-p 'golden-ratio)
               "[_g_] golden-ratio  "
             "^^^^                  ")))
@@ -711,6 +711,9 @@ Select: _w_ _h_ _j_ _k_ _l_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s_ _v
   ("U" winner-redo)
   ("v" split-window-right)
   ("V" split-window-right-and-focus)
+  ("m" spacemacs/toggle-maximize-buffer)
+  ("_" spacemacs/maximize-horizontally)
+  ("|" spacemacs/maximize-vertically)
   ("w" other-window))
 (spacemacs/set-leader-keys
   "w." 'spacemacs/window-manipulation-transient-state/body


### PR DESCRIPTION
- Adds `SPC w [`, `SPC w ]`, `SPC w {`, `SPC w }` leader key bindings for easier entry into transient state resizing

- Allow window transient state to be collapsed via "?" for more accurate presentation of layouts during the TS.

- Add `m`, `|` and `_` bindings to the transient state for consistency with the `SPC w` bindings