### PR TITLE
Prevent Spacemacs buffer redisplay in filetree window

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -479,6 +479,7 @@ Other:
   - Calling ~spacemacs/recompile-elpa~ with an argument nukes all *.elc files (thanks to Ag Ibragimov)
   - Allow customizing default major mode for new empty buffers in ~SPC b N n~,
     see =dotspacemacs-new-empty-buffer-major-mode= (thanks to Juha Jeronen)
+  - Stopped Spacemacs buffer redisplay in filetree window (thanks to duianto)
 - Fixed:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1060,13 +1060,22 @@ REFRESH if the buffer should be redrawn."
 
 (defun spacemacs-buffer//resize-on-hook ()
   "Hook run on window resize events to redisplay the home buffer."
-  (let ((home-buffer (get-buffer-window spacemacs-buffer-name))
-        (frame-win (frame-selected-window)))
-    (when (and dotspacemacs-startup-buffer-responsive
-               home-buffer
-               (not (window-minibuffer-p frame-win)))
-      (with-selected-window home-buffer
-        (spacemacs-buffer/goto-buffer)))))
+  ;; prevent spacemacs buffer redisplay in the filetree window
+  (unless (memq this-command '(neotree-find-project-root
+                               neotree-show
+                               neotree-toggle
+                               spacemacs/treemacs-project-toggle
+                               treemacs
+                               treemacs-bookmark
+                               treemacs-find-file
+                               treemacs-select-window))
+   (let ((home-buffer (get-buffer-window spacemacs-buffer-name))
+         (frame-win (frame-selected-window)))
+     (when (and dotspacemacs-startup-buffer-responsive
+                home-buffer
+                (not (window-minibuffer-p frame-win)))
+       (with-selected-window home-buffer
+         (spacemacs-buffer/goto-buffer))))))
 
 (defun spacemacs-buffer/refresh ()
   "Force recreation of the spacemacs buffer."


### PR DESCRIPTION
Opening Neotree or Treemacs from the Spacemacs home buffer causes the filetree window to change size 3 times and the Spacemacs buffer gets redisplayed (centered) 3 times, before the filetree buffer appears. This appears as flickering (see animation below).

This PR stops the Spacemacs buffer from being redisplayed when Neotree or Treemacs is opened.

### Issue

It would look better if the Spacemacs buffer window was redisplayed (centered) after the filetree buffer had loaded.

Any suggestions?

### Intermediate steps

![resize frames from gif](https://user-images.githubusercontent.com/13420573/51868931-7d1dbc00-234f-11e9-8461-e9e3ee55d526.jpg)

### Screen recordings

#### Before

![before](https://user-images.githubusercontent.com/13420573/51859247-fb219900-2336-11e9-9214-48591881ff95.gif)

#### After

![after](https://user-images.githubusercontent.com/13420573/51859261-01177a00-2337-11e9-9b97-d9484ce18138.gif)

#### System Info :computer:
- OS: windows-nt
- Emacs: 26.1
- Spacemacs: 0.300.0
- Spacemacs branch: develop (rev. edf3b9d28)
- Graphic display: t
- Distribution: spacemacs
- Editing style: vim
- Completion: helm
- Layers:
```elisp
(autohotkey colors emacs-lisp git helm html ibuffer markdown multiple-cursors org spell-checking treemacs version-control)
```
- System configuration features: XPM JPEG TIFF GIF PNG RSVG SOUND NOTIFY ACL GNUTLS LIBXML2 ZLIB TOOLKIT_SCROLL_BARS THREADS LCMS2
