### PR TITLE
add devdocs tool

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -26,6 +26,7 @@
                                        ("bN"  "new empty buffer")
                                        ("c"   "compile/comments")
                                        ("C"   "capture/colors")
+                                       ("d"   "documentation")
                                        ("e"   "errors")
                                        ("f"   "files")
                                        ("fC"  "files/convert")

--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -11,6 +11,7 @@
 
 (setq spacemacs-misc-packages
       '(
+        devdocs
         dumb-jump
         request
         ))
@@ -41,3 +42,11 @@
 (defun spacemacs-misc/init-request ()
   (setq request-storage-directory
         (concat spacemacs-cache-directory "request/")))
+
+(defun spacemacs-misc/init-devdocs ()
+  (use-package devdocs
+    :defer t
+    :init
+    (progn
+      (defalias 'spacemacs/browse-docs-online-at-point 'devdocs-search)
+      (spacemacs/set-leader-keys "db" #'spacemacs/browse-docs-online-at-point))))


### PR DESCRIPTION
A nice tool to have as a backup.  

- - - - - -

[dash layer](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Breaders/dash/packages.el) adds keybindings under "SPC d"  without naming the prefix. So I  defined it more generally  `("d"   "documentation")`