### PR TITLE
Fix lsp find-* functions using peek-navigation

### DIFF
--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -123,7 +123,7 @@ https://github.com/emacs-lsp/lsp-javascript/issues/9#issuecomment-379515379"
   (intern (concat layer-name "/" nav-mode "-" (symbol-name kind))))
 
 (defun spacemacs//lsp-define-custom-extension (layer-name nav-mode kind request &optional extra)
-  (let ((lsp-extension-fn (if (eq nav-mode "find")
+  (let ((lsp-extension-fn (if (equal nav-mode "find")
                             'lsp-find-locations
                             'lsp-ui-peek-find-custom))
          (extension-name (spacemacs//lsp-get-extension-name layer-name nav-mode kind))


### PR DESCRIPTION
With this fix lsp find-* functions correctly use xref (simple-navigation).

Fixes issue #11931.