### PR TITLE
Replace company-capf with company-nimsuggest in nim-mode.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1556,6 +1556,8 @@ Other:
 **** Nim
 - Add key binding ~SPC m h h~ to show symbol documentation (thanks to Valts
   Liepiņš)
+- Replace =company-capf= with =company-nimsuggest= in
+  =company-backends-nim-mode= to improve responsiveness (thanks to Uroš Perišić)
 **** Node
 - Use add-node-modules-path to automatically find local executables (thanks to
   jupl)

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -19,7 +19,7 @@
 
 (defun nim/post-init-company ()
   (spacemacs|add-company-backends
-    :backends company-capf
+    :backends company-nimsuggest
     :modes nim-mode nimscript-mode))
 
 (defun nim/post-init-flycheck ()


### PR DESCRIPTION
As described here: https://github.com/nim-lang/nim-mode/issues/159,
company-capf makes nim-mode unusable. I am replacing it with
company-nimsuggest as it is much more responsive. The reason I elected not to
leave company-capf in as a backup is that it would somehow still make it to the
car of company-backends, regardless of position at assignment, thus becoming the
default completion backend. Given that no functionality is lost this way, and
that nimsuggest is now part of the core nim installation
(https://github.com/nim-lang/nimsuggest), I do not think anything has been
sacrificed.