### PR TITLE
Add `.dap-breakpoints` and `.lsp-session-*` to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ python-*-docs-html
 nov-places
 workspace
 eclipse.jdt.ls
+.dap-breakpoints
+.lsp-session-*
 .trello
 
 # Private directory

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1486,6 +1486,8 @@ Other:
 - Fixed yanking types (thanks to Bjarke Vad Andersen)
 - Fixed gtags related initialization (thanks to Guido Kraemer)
 - Added LSP Java backend (thanks to Ivan Yonchovski)
+- Add =.dap-breakpoints= and =.lsp-session-*= (java lsp tempfiles) to .gitignore
+  (thanks to Uroš Perišić)
 **** Javascript
 - Leverage js-doc Yasnippet integration if available (thanks to Andriy Kmit')
 - Added LSP support, which can be used by enabling the =lsp= layer and setting


### PR DESCRIPTION
The `LSP Java` backend produces these tempfiles to preserve session state. The
glob in `lsp-session-*` is needed as multiple session files are produced when
working on multiple projects. There is no reason for these files to be kept
under version control.