### PR TITLE
Declare all prefixes for `nim` layer.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1558,6 +1558,8 @@ Other:
   Liepiņš)
 - Replace =company-capf= with =company-nimsuggest= in
   =company-backends-nim-mode= to improve responsiveness (thanks to Uroš Perišić)
+- Declare all prefix names (='(compile goto help)=) for =nim-mode= (thanks to
+  Uroš Perišić)
 **** Node
 - Use add-node-modules-path to automatically find local executables (thanks to
   jupl)

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -42,6 +42,10 @@
         (interactive)
         (shell-command "nim compile --run main.nim"))
 
+      (spacemacs/declare-prefix-for-mode 'nim-mode "mc" "compile")
+      (spacemacs/declare-prefix-for-mode 'nim-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'nim-mode "mh" "help")
+
       (spacemacs/set-leader-keys-for-major-mode 'nim-mode
         "cr" 'spacemacs/nim-compile-run
         "gb" 'pop-tag-mark


### PR DESCRIPTION
All prefixes for `nim-mode` were previously unnamed, and simply stated `+prefix`.