### PR TITLE
Make `spacemacs/nim-compile-run` work with current buffer file.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1556,6 +1556,8 @@ Other:
 **** Nim
 - Add key binding ~SPC m h h~ to show symbol documentation (thanks to Valts
   Liepiņš)
+- Make =spacemacs/nim-compile-run= work with current buffer file instead of
+  defaulting to =main.nim= (thanks to Uroš Perišić)
 - Replace =company-capf= with =company-nimsuggest= in
   =company-backends-nim-mode= to improve responsiveness (thanks to Uroš Perišić)
 **** Node

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -39,8 +39,9 @@
     :config
     (progn
       (defun spacemacs/nim-compile-run ()
+        "Compile current buffer file."
         (interactive)
-        (shell-command "nim compile --run main.nim"))
+        (shell-command (concat "nim compile --run " (buffer-file-name))))
 
       (spacemacs/set-leader-keys-for-major-mode 'nim-mode
         "cr" 'spacemacs/nim-compile-run


### PR DESCRIPTION
Naming the main file `main.nim` is a `C` convention, not a `Nim` convention. In
fact, `Nimble` defaults to naming the main file after the project at
initialization. I will soon add a function that parses the Nimble configuration
for project entry point and compiles that. Until then, this is a solid
compromise between flexibility and reliability. I also added a doc-string to the
function.