### PR TITLE
Add and configure `nodejs-repl` package to `javascript` layer.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1661,6 +1661,7 @@ Other:
   - Added =org-babel= support (thanks to Michael Rohleder)
   - Added debug support via =dap= layer (Firefox and Google Chrome)
   - Added format on save option. (thanks to Trapez Breen)
+  - Add =nodejs-repl= support (thanks to Uroš Perišić)
 - Key bindings
   - Improved coffeescript support (thanks to Kalle Lindqvist):
     - ~SPC m '~ to create or go to REPL
@@ -1686,6 +1687,7 @@ Other:
     (thanks to Sylvain Benner and Juuso Valkeejärvi)
   - Check if =tern= exists before using it (thanks to Codruț Constantin Gușoi)
   - Fixed hook value to enable =evil-matchit= (thanks to Thanh Vuong)
+  - Fix hook value to enable =evil-matchit= (thanks to Thanh Vuong)
 **** Keyboard layout
 - Added support for Colemak layout (thanks to Daniel Mijares, Lyall Cooper and
   Eivind Fonn)

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -20,7 +20,9 @@
 - [[#configuration][Configuration]]
   - [[#indentation][Indentation]]
   - [[#repl][REPL]]
-  - [[#node-modules][Node Modules]]
+  - [[#node][Node]]
+    - [[#node-modules][Node Modules]]
+    - [[#node-externs][Node Externs]]
 - [[#key-bindings][Key bindings]]
   - [[#js2-mode][js2-mode]]
   - [[#folding-js2-mode][Folding (js2-mode)]]
@@ -29,6 +31,7 @@
     - [[#documentation-js-doc][Documentation (js-doc)]]
   - [[#repl-skewer-mode][REPL (skewer-mode)]]
   - [[#debugger-dap-mode][debugger (dap mode)]]
+  - [[#nodejs-repl-nodejs-repl][NodeJS REPL (nodejs-repl)]]
 
 * Description
 This layer adds support for the JavaScript language using [[https://github.com/mooz/js2-mode][js2-mode]].
@@ -39,6 +42,7 @@ This layer adds support for the JavaScript language using [[https://github.com/m
 - Refactoring: done using [[https://github.com/magnars/js2-refactor.el][js2-refactor]].
 - Auto-completion and documentation
 - REPL available via [[https://github.com/skeeto/skewer-mode][skewer-mode]] and [[https://github.com/pandeiro/livid-mode][livid-mode]]
+- NodeJS REPL with [[https://github.com/abicky/nodejs-repl.el][nodejs-repl]]
 - Formatting with [[https://github.com/yasuyk/web-beautify][web-beautify]]
 
 * Install
@@ -185,7 +189,8 @@ in your javascript buffer. If you want to inject it in your own page, follow
 [[https://github.com/skeeto/skewer-mode#skewering-with-cors][these instructions]] (install the Greasemonkey script and then click the triangle
 in the top-right corner - if it turns green, you're good to go).
 
-** Node Modules
+** Node
+*** Node Modules
 If you would like =node_modules/.bin= to be automatically added to the buffer
 local =exec_path=, e.g. to support project local eslint installations, set the
 =node-add-modules-path= variable in the =javascript= config section. Note that
@@ -194,6 +199,16 @@ doing this [[https://stackoverflow.com/questions/9679932#comment33532258_9683472
 #+BEGIN_SRC elisp
   (setq-default dotspacemacs-configuration-layers
     '((javascript :variables node-add-modules-path t)))
+#+END_SRC
+
+*** Node Externs
+If you want =js2-mode= to presume =node= variables are defined by the host
+system (for completion purposes /i.a./) set the =js2-include-node-exters=
+variable to =t= in the =javascript= config section:
+
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers
+    '((javascript :variables js2-include-node-externs t)))
 #+END_SRC
 
 * Key bindings
@@ -334,3 +349,17 @@ You can check more [[https://github.com/mooz/js-doc/][here]]
 | ~SPC m d w o~ | goto output buffer if present   |
 | ~SPC m d w s~ | list sessions                   |
 | ~SPC m d w b~ | list breakpoints                |
+
+** NodeJS REPL (nodejs-repl)
+
+| Key binding | Description                                                        |
+|-------------+--------------------------------------------------------------------|
+| ~SPC m s n i~ | Switch to NodeJS REPL if one has been started, otherwise start one |
+| ~SPC m s n e~ | Send last expression to NodeJS REPL                                |
+| ~SPC m s n E~ | Send last expression to NodeJS REPL and switch to REPL             |
+| ~SPC m s n b~ | Send current buffer to NodeJS REPL                                 |
+| ~SPC m s n B~ | Send current buffer to NodeJS REPL and switch to REPL              |
+| ~SPC m s n l~ | Send current line to NodeJS REPL                                   |
+| ~SPC m s n L~ | Send current line to NodeJS REPL and switch to REPL                |
+| ~SPC m s n r~ | Send active region to NodeJS REPL                                  |
+| ~SPC m s n R~ | Send active region to NodeJS REPL and switch to REPL               |

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -30,6 +30,7 @@
         skewer-mode
         tern
         web-beautify
+        nodejs-repl
         ))
 
 (defun javascript/post-init-add-node-modules-path ()
@@ -202,6 +203,44 @@
         "sr" 'spacemacs/skewer-eval-region
         "sR" 'spacemacs/skewer-eval-region-and-focus
         "ss" 'skewer-repl))))
+
+(defun javascript/init-nodejs-repl ()
+  (use-package nodejs-repl
+    :defer nil
+    :init
+    (spacemacs/register-repl 'nodejs-repl
+                              'nodejs-repl
+                              "nodejs-repl")
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'js2-mode "msn" "nodejs-repl")
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+        "sni" 'nodejs-repl-switch-to-repl
+        "sne" 'nodejs-repl-send-last-expression
+        "snE" (lambda ()
+               (nodejs-repl-send-last-expression)
+               (nodejs-repl-switch-to-repl))
+        "snb" 'nodejs-repl-send-buffer
+        "snB" (lambda ()
+               (nodejs-repl-send-buffer)
+               (nodejs-repl-switch-to-repl))
+        "snl" 'nodejs-repl-send-line
+        "snL" (lambda ()
+               (nodejs-repl-send-line)
+               (nodejs-repl-switch-to-repl))
+        "snr" 'nodejs-repl-send-region
+        "snR" (lambda ()
+               (nodejs-repl-send-region)
+               (nodejs-repl-switch-to-repl)))
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msnE" "nodejs-send-last-expression-and-focus")
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msnB" "nodejs-send-buffer-and-focus")
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msnL" "nodejs-send-line-and-focus")
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msnR" "nodejs-send-region-and-focus")
+      )))
 
 (defun javascript/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'js2-mode))


### PR DESCRIPTION
Add relevant keybindings and documentation, including a setting
`js2-include-node-externs` as a configuration variable for those that intend to
use `Spacemacs` for node projects, as it currently seems to be mostly aimed at
pure JS (https://github.com/syl20bnr/spacemacs/issues/483).