### PR TITLE
Fix docs for changing vim surround keybinding

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -974,8 +974,10 @@ If you are not convinced, then here is the snippet to revert back to the default
 =Vim + vim-surround= setup (add it to your =dotspacemacs/user-config=):
 
 #+BEGIN_SRC emacs-lisp
-  (evil-define-key 'visual evil-surround-mode-map "s" 'evil-substitute)
-  (evil-define-key 'visual evil-surround-mode-map "S" 'evil-surround-region)
+  (spacemacs|use-package-add-hook evil-surround
+    :post-config
+    (evil-define-key 'visual evil-surround-mode-map "s" 'evil-substitute)
+    (evil-define-key 'visual evil-surround-mode-map "S" 'evil-surround-region))
 #+END_SRC
 
 * Evil plugins


### PR DESCRIPTION
Currently the snippet in the docs to change the vim-surround keybindings to be like in standard vim does not work. 

This PR fixes the doc to include a snippet which does work.

See #11896