### PR TITLE
Add line text object using `evil-textobj-line`.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -432,6 +432,7 @@ Other:
     Kmit')
   - More robust =dotspacemacs/add-layer= implementation (thanks to Eivind Fonn)
   - Improved issue reporting (thanks to Eugene Yaremenko)
+  - Add line text object using =evil-textobj-line= (thanks to Uroš Perišić)
 
 - Fixes:
   - Fix loading of themes having dependencies (thanks to Benno Fünfstück)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1831,6 +1831,7 @@ Additional text objects are defined in Spacemacs:
 |---------+----------------------------|
 | ~a~     | an argument                |
 | ~g~     | the entire buffer          |
+| ~l~     | a line                     |
 | ~$~     | text between =$=           |
 | ~*~     | text between =*=           |
 | ~8~     | text between =/*= and =*/= |

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -30,6 +30,7 @@
         ;; https://github.com/7696122/evil-terminal-cursor-changer/issues/8
         ;; evil-terminal-cursor-changer
         evil-tutor
+        evil-textobj-line
         (evil-unimpaired :location (recipe :fetcher local))
         evil-visual-mark-mode
         evil-visualstar
@@ -327,6 +328,10 @@
       (setq evil-tutor-working-directory
             (concat spacemacs-cache-directory ".tutor/"))
       (spacemacs/set-leader-keys "hT" 'evil-tutor-start))))
+
+(defun spacemacs-evil/init-evil-textobj-line ()
+  ;; No laziness here, the line text object should be available right away.
+  (use-package evil-textobj-line))
 
 (defun spacemacs-evil/init-evil-unimpaired ()
   ;; No laziness here, unimpaired bindings should be available right away.


### PR DESCRIPTION
As there are already two packages implementing this in Vim, and one in Emacs, I
figured this would be a nice addition. The sequence of `0 v g _` gets rather
tiring for selecting an inner line, and is just as useful (if not more) than the
buffer text object.