### PR TITLE
Add support to start external terminal emulators in context.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1884,6 +1884,7 @@ Other:
 - Wrap 'shell' command to start in current buffer (thanks to Valts Liepiņš)
 - Fixed shell popup broken on macOS (thanks to Daniel Rivas Perez)
 - Fix broken leader key binding for inferior shell (thanks to Valts Liepiņš)
+- Add support to start external terminal emulators (thanks to Uroš Perišić)
 **** Shell Scripts
 - Add new company-shell environment variable backend (thanks to
   Alexander-Miller)

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -9,6 +9,7 @@
 - [[#configuration][Configuration]]
   - [[#default-shell][Default shell]]
   - [[#default-shell-position-width-and-height][Default shell position, width, and height]]
+  - [[#external-terminal-emulator][External terminal emulator]]
   - [[#set-shell-for-term-and-ansi-term][Set shell for term and ansi-term]]
   - [[#set-shell-for-multi-term][Set shell for multi-term]]
   - [[#width-of-the-shell-popup-buffers][Width of the shell popup buffers]]
@@ -25,6 +26,7 @@ This layer configures the various shells available in Emacs.
 
 ** Features:
 - Shell integration
+- Running external terminal emulator in current/project directory
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -77,6 +79,16 @@ your shell is positioned on the left or the right.
              shell-default-width 40)))
 #+END_SRC
 
+** External terminal emulator
+This layer supports opening an external terminal emulator using [[https://github.com/davidshepherd7/terminal-here][terminal-here]].
+Please see the documentation there for further details. At the very least, you
+should set =terminal-here-terminal-command= before use.
+
+#+BEGIN_SRC emacs-lisp :tangle yes
+  (setq-default dotspacemacs-configuration-layers
+    '((shell :variables
+             terminal-here-terminal-command '(termite))))
+#+END_SRC
 ** Set shell for term and ansi-term
 The default shell can be set by setting the variable =shell-default-term-shell=.
 Default value is =/bin/bash=.
@@ -202,7 +214,9 @@ Some advanced configuration is setup for =eshell= in this layer:
 | Key binding | Description                                                |
 |-------------+------------------------------------------------------------|
 | ~SPC '​~     | Open, close or go to the default shell                     |
+| ~SPC "​~     | Open external terminal emulator in current directory       |
 | ~SPC p '​~   | Open a shell in the project’s root                         |
+| ~SPC p "​~   | Open external terminal emulator in project root            |
 | ~SPC a s e~ | Open, close or go to an =eshell=                           |
 | ~SPC a s i~ | Open, close or go to a =shell=                             |
 | ~SPC a s m~ | Open, close or go to a =multi-term=                        |

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -26,6 +26,7 @@
         shell-pop
         (term :location built-in)
         xterm-color
+        terminal-here
         vi-tilde-fringe
         ))
 
@@ -262,6 +263,16 @@
       (setq comint-output-filter-functions
             (remove 'ansi-color-process-output comint-output-filter-functions))
       (add-hook 'eshell-mode-hook 'spacemacs/init-eshell-xterm-color))))
+
+(defun shell/init-terminal-here ()
+  :defer t
+  :init
+  (progn
+    (spacemacs/register-repl 'terminal-here 'terminal-here)
+    (spacemacs/set-leader-keys
+      "\"" 'terminal-here-launch
+      "p \"" 'terminal-here-project-launch)
+    ))
 
 (defun shell/post-init-vi-tilde-fringe ()
   (spacemacs/add-to-hooks 'spacemacs/disable-vi-tilde-fringe


### PR DESCRIPTION
Integrated terminal emulators/integrated shells get the job done for
quick-and-dirty shell commands, but a lot of people take great care to tweak
their terminal workflow exactly to their liking. This makes it possible to
switch to that workflow seamlessly, by opening their terminal emulator of
choosing in the current directory or at the project root, and even supports
working over `ssh` using `tramp`.