### PR TITLE
org layer: add support for org-sticky-header-mode

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -20,6 +20,7 @@
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
   - [[#mode-line-support][Mode line support]]
+  - [[#sticky-header-support][Sticky header support]]
 - [[#key-bindings][Key bindings]]
   - [[#starting-org-mode][Starting org-mode]]
   - [[#toggles][Toggles]]
@@ -288,6 +289,16 @@ To permanently enable mode line display of org clock, add this snippet to your
 
 #+BEGIN_SRC elisp
   (setq spaceline-org-clock-p t)
+#+END_SRC
+
+** Sticky header support
+
+To install sticky header support set the variable =org-enable-sticky-header= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-sticky-header t)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -32,6 +32,9 @@ used.")
 (defvar org-enable-org-journal-support nil
   "If non-nil org-journal is configured.")
 
+(defvar org-enable-sticky-header nil
+  "If non-nil org-sticky-header is configured.")
+
 (defvar org-enable-hugo-support nil
   "If non-nil, Hugo (https://gohugo.io) related packages are configured.")
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -39,6 +39,7 @@
         persp-mode
         (ox-hugo :toggle org-enable-hugo-support)
         (org-trello :toggle org-enable-trello-support)
+        (org-sticky-header :toggle org-enable-sticky-header)
         ))
 
 (defun org/post-init-company ()
@@ -715,3 +716,10 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "mtdc" 'spacemacs/org-trello-pull-card
         "mtub" 'spacemacs/org-trello-push-buffer
         "mtuc" 'spacemacs/org-trello-push-card))))
+
+(defun org/init-org-sticky-header ()
+  (use-package org-sticky-header
+    :defer t
+    :init
+    (add-hook 'org-mode-hook 'org-sticky-header-mode)))
+


### PR DESCRIPTION
This helps you keep track of what header you're editing in longer org files