### PR TITLE
fix hook value to enable evil-matchit in js layer

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -39,7 +39,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'js2-mode))
 
 (defun javascript/post-init-evil-matchit ()
-  (add-hook `js2-mode `turn-on-evil-matchit-mode))
+  (add-hook `js2-mode-hook `turn-on-evil-matchit-mode))
 
 (defun javascript/post-init-company ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-company))


### PR DESCRIPTION
hook value should be js2-mode-hook instead of js2-mode
Before fix  `%` is bound to `evil-jump-item`
After fix `%` is bound to `evilmi-jump-items`
