### PR TITLE
Don't lazy load keybindings for evil surround

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -297,6 +297,10 @@
     :defer t
     :init
     (progn
+      ;; `s' for surround instead of `substitute'
+      ;; see motivation for this change in the documentation
+      (evil-define-key 'visual evil-surround-mode-map "s" 'evil-surround-region)
+      (evil-define-key 'visual evil-surround-mode-map "S" 'evil-substitute)
       (spacemacs|add-transient-hook evil-visual-state-entry-hook
         (lambda () (require 'evil-surround))
         lazy-load-evil-surround)
@@ -305,10 +309,6 @@
         lazy-load-evil-surround-2))
     :config
     (progn
-      ;; `s' for surround instead of `substitute'
-      ;; see motivation for this change in the documentation
-      (evil-define-key 'visual evil-surround-mode-map "s" 'evil-surround-region)
-      (evil-define-key 'visual evil-surround-mode-map "S" 'evil-substitute)
       (global-evil-surround-mode 1))))
 
 (defun spacemacs-evil/init-evil-terminal-cursor-changer ()


### PR DESCRIPTION
The snippet to swap the keybindings for evil-surround in visual mode in the documentation [here](https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#the-vim-surround-case) does not work. I previously made a PR to change the snippets in #11944, but as pointed out by @yuhan0, the root cause is that the keybindings are lazy loaded, and hence cannot be overridden in the user-config. 

With this PR, the snippet in the documentation works again.