### PR TITLE
Add missing prefixes in go-mode

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -136,6 +136,8 @@
       (spacemacs/declare-prefix-for-mode 'go-mode "mi" "imports")
       (spacemacs/declare-prefix-for-mode 'go-mode "mr" "refactoring")
       (spacemacs/declare-prefix-for-mode 'go-mode "mt" "test")
+      (spacemacs/declare-prefix-for-mode 'go-mode "mtg" "generate")
+      (spacemacs/declare-prefix-for-mode 'go-mode "mT" "toggle")
       (spacemacs/declare-prefix-for-mode 'go-mode "mx" "execute")
       (spacemacs/set-leader-keys-for-major-mode 'go-mode
         "="  'gofmt


### PR DESCRIPTION
Add missing prefixes in go-mode.

- `mtg` - **+generate**
- `mT` - **+toggle**