### PR TITLE
Fix key bindings in ruby-on-rails layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1939,6 +1939,7 @@ Other:
 - Changed leader keys to be configured for the =projectile-rails-mode= minor
   mode instead of =ruby-mode= and =enh-ruby-mode= so that the key bindings will
   work in view file windows (thanks to Adam Sokolnicki)
+- Added missing prefixes for =ruby-mode= and =enh-ruby-mode=
 - Added key bindings: (thanks to Adam Sokolnicki)
   - ~SPC m f f b~ to find job
   - ~SPC m f f w~ to find webpack config

--- a/layers/+frameworks/ruby-on-rails/packages.el
+++ b/layers/+frameworks/ruby-on-rails/packages.el
@@ -73,7 +73,10 @@
         "fRx" 'projectile-rails-extract-region)
 
       (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "mf" "rails/rubocop")
+        (spacemacs/declare-prefix-for-mode mode "mf" "rails")
+        (spacemacs/declare-prefix-for-mode mode "mfc" "generate/destroy")
+        (spacemacs/declare-prefix-for-mode mode "mfR" "extract")
+        (spacemacs/declare-prefix-for-mode mode "mfx" "server")
         (spacemacs/declare-prefix-for-mode mode "mff" "file")
         (spacemacs/declare-prefix-for-mode mode "mfg" "goto"))
 


### PR DESCRIPTION
Add missing prefixes.
Remove rake because it also exists in ruby layer.