### PR TITLE
Change `helm-apropos` from `SPC h d d` to `SPC h d a`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -653,6 +653,8 @@ Other:
     Takemura)
   - Added ~SPC f y n~ and ~SPC f y N~ to copy the name of a file (thanks to
     Sylvain Benner)
+  - Changed ~SPC h d d~ to ~SPC h d a~ for =helm-apropos=, it's more mnemonic
+    (thanks duianto, and thanks yuhan0 for the suggestion)
   - Added profiling key bindings:
     - ~SPC h P k~ to stop the profiler
     - ~SPC h P r~ to display the profiler report

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1887,9 +1887,9 @@ thusly:
 
 | Key binding | Description                                               |
 |-------------+-----------------------------------------------------------|
+| ~SPC h d a~ | describe current expression under point                   |
 | ~SPC h d b~ | describe bindings                                         |
 | ~SPC h d c~ | describe current character under point                    |
-| ~SPC h d d~ | describe current expression under point                   |
 | ~SPC h d f~ | describe a function                                       |
 | ~SPC h d F~ | describe a face                                           |
 | ~SPC h d k~ | describe a key                                            |

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -87,7 +87,7 @@
       (spacemacs||set-helm-key "fF"   helm-find-files)
       (spacemacs||set-helm-key "fL"   helm-locate)
       (spacemacs||set-helm-key "fr"   helm-recentf)
-      (spacemacs||set-helm-key "hdd"  helm-apropos)
+      (spacemacs||set-helm-key "hda"  helm-apropos)
       (spacemacs||set-helm-key "hdF"  spacemacs/helm-faces)
       (spacemacs||set-helm-key "hi"   helm-info-at-point)
       (spacemacs||set-helm-key "hm"   helm-man-woman)


### PR DESCRIPTION
Change the binding to be more mnemonic.

It calls helm-[a]propos and it pretty much describes [a]ll.

---

This seems to be the commit that added it as `SPC h d d`: 
Add `helm-apropos` on `SPC h d d` https://github.com/syl20bnr/spacemacs/commit/ad448d66832163b387d711e915e04c6b73e5505f

The docstring for these commands say:
- `helm-apropos`
>Preconfigured helm to describe commands, functions, variables and faces.

- `apropos`
>Show all meaningful Lisp symbols whose names match PATTERN.
Symbols are shown if they are defined as functions, variables, or
faces, or if they have nonempty property lists.

There's also a PR for adding `counsel-apropos` to the ivy layer:
Ivy: Add `SPC h d a` counsel-apropos #11969 

`counsel-apropos` docstring says:
>Show all matching symbols.
See `apropos' for further information on what is considered
a symbol and how to search for them.