### PR TITLE
Add ranger-mode to golden-ratio-exclude-modes

### DIFF
--- a/layers/+spacemacs/spacemacs-ui-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/packages.el
@@ -86,6 +86,7 @@
                    "gdb-inferior-io-mode"
                    "gdb-disassembly-mode"
                    "gdb-memory-mode"
+                   "ranger-mode"
                    "speedbar-mode"
                    ))
         (add-to-list 'golden-ratio-exclude-modes m))


### PR DESCRIPTION
Ranger manages window sizing in a way that conflicts messily with golden-ratio