### PR TITLE
Add Prolog layer.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -309,6 +309,7 @@ Benner and Paweł Siudak):
 - pact (thanks to Colin Woodbury)
 - perl5 (thanks to Troy Hinckley, Jinseop Kim and Michael Rohleder)
 - perl6 (thanks to Bahtiar Gadimov and yuhan0)
+- prolog (thanks to Newres Al Haider)
 - protobuf (thanks to Amol Mandhane)
 - restructuredtext (thanks to Wei-Wei Guo and Kalle Lindqvist)
 - semantic-web (thanks to Andreas Textor)

--- a/layers/+lang/prolog/README.org
+++ b/layers/+lang/prolog/README.org
@@ -1,0 +1,77 @@
+#+TITLE: prolog layer
+
+* Table of Contents                                       :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+  - [[#consulting][Consulting]]
+  - [[#compiling][Compiling]]
+  - [[#formatting][Formatting]]
+  - [[#inserting][Inserting]]
+  - [[#help][Help]]
+  - [[#evaluating][Evaluating]]
+
+* Description
+This layer adds support for Prolog using the bundled Prolog mode for Emacs. In addition it also adds ediprolog support for better interaction with SWI-Prolog. 
+
+** Features:
+  - Designed for SWI-Prolog as a default, but can be used with other Prologs that Prolog mode supports. 
+  - Interactive consulting and compiling.
+  - Auto-formatting.
+  - Apropos and help lookup.
+
+    
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =prolog= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key bindings
+  
+** Consulting
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m s b~ | Consult Buffer    |
+| ~SPC m s f~ | Consult File      |
+| ~SPC m s p~ | Consult Predicate |
+| ~SPC m s r~ | Consult Region    |
+
+** Compiling
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m c b~ | Compile Buffer    |
+| ~SPC m c f~ | Compile File      |
+| ~SPC m c p~ | Compile Predicate |
+| ~SPC m c r~ | Compile Region    |
+| ~SPC m c c~ | Compile File      |
+
+** Formatting 
+
+| Key Binding | Description   |
+|-------------+---------------|
+| ~SPC m =~   | Indent Buffer |
+
+** Inserting
+
+| Key Binding | Description                                        |
+|-------------+----------------------------------------------------|
+| ~SPC m i m~ | Insert a Modeline for Module Specification         |
+| ~SPC m i n~ | Insert Newline and the Name for the Current Clause |
+| ~SPC m i p~ | Insert Predicate Template for the Current Clause   |
+| ~SPC m i s~ | Insert Predicate Spec                              |
+
+** Help
+
+| Key Binding | Description                           |
+|-------------+---------------------------------------|
+| ~SPC m h a~ | Prolog Apropos for a Given String     |
+| ~SPC m h p~ | Online Help for the Atom under Cursor |
+
+** Evaluating 
+
+| Key Binding | Description                               |
+|-------------+-------------------------------------------|
+| ~SPC m e e~ | Context Sensitive SWI-Prolog Interaction. |

--- a/layers/+lang/prolog/config.el
+++ b/layers/+lang/prolog/config.el
@@ -1,0 +1,23 @@
+;;; config.el --- prolog layer config File for Spacemacs
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Newres Al Haider <newrescode@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; variables
+
+(defvar prolog-system `swi
+  "The type of Prolog system used when setting up the Prolog layer. A number of configuration values are derived from this, notably in prolog-mode. The default value is `swi for SWI-Prolog. The recognized symbol values are:
+swi     - SWI Prolog
+sicstus - SICStus Prolog
+eclipse - Eclipse Prolog
+xsb     - XSB <http://xsb.sourceforge.net>
+gnu     - GNU Prolog
+yap     - YAP Prolog")
+
+;;; config.el ends here

--- a/layers/+lang/prolog/packages.el
+++ b/layers/+lang/prolog/packages.el
@@ -1,0 +1,74 @@
+;;; packages.el --- prolog layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Newres Al Haider <newrescode@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst prolog-packages
+  '(
+    (prolog :location built-in)
+    (ediprolog)
+    ))
+
+
+(defun prolog/init-prolog ()
+    (use-package prolog
+      :defer t
+      :init
+      (progn
+        (autoload 'run-prolog "prolog" "Start a Prolog sub-process." t)
+        (autoload 'prolog-mode "prolog" "Major mode for editing Prolog programs." t)
+        (setq auto-mode-alist (append '(("\\.pl$" . prolog-mode))
+                                      auto-mode-alist))        )
+      :config
+      (progn
+        (spacemacs/set-leader-keys-for-major-mode 'prolog-mode
+          ;;Key Mappings
+          ;;Consulting
+          "sb" 'prolog-consult-buffer
+          "sf" 'prolog-consult-file
+          "sp" 'prolog-consult-predicate
+          "sr" 'prolog-consult-region
+          ;;Compiling
+          "cb" 'prolog-compile-buffer
+          "cf" 'prolog-compile-file
+          "cp" 'prolog-compile-predicate
+          "cr" 'prolog-compile-region
+          ;;Dublicate keybinding to match expected convention.
+          "cc" 'prolog-compile-file
+          ;;Formatting
+          "=" 'prolog-indent-buffer
+          ;;Insert
+          "im" 'prolog-insert-module-modeline
+          "in" 'prolog-insert-next-clause
+          "ip" 'prolog-insert-predicate-template
+          "is" 'prolog-insert-predspec
+          ;;Help
+          "ha" 'prolog-help-apropos
+          "hp" 'prolog-help-on-predicate
+          )
+
+        (dolist (prefix '(("ms" . "consulting")
+                          ("mc" . "compiling")
+                          ("mh" . "help")
+                          ("mi" . "inserting")
+                          ))
+          (spacemacs/declare-prefix-for-mode 'prolog-mode (car prefix) (cdr prefix))))
+      ))
+
+(defun prolog/init-ediprolog ()
+  (use-package ediprolog
+    :hook prolog-mode
+    :config
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'prolog-mode
+        ;;Key Mappings
+        "ee" 'ediprolog-dwim)
+      (spacemacs/declare-prefix-for-mode 'prolog-mode "me" "evaluating" ))))
+
+;;; packages.el ends here


### PR DESCRIPTION
Aiming to add a layer for the Prolog language. The layer is setup to work with SWI-Prolog by default, but can be customized for a number of other Prologs. 