### PR TITLE
custom setting: don't write to dotfile before loading all of them

### DIFF
--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -14,13 +14,13 @@
                                        ".custom-settings"))
 
 (defun spacemacs/initialize-custom-file ()
-  "Initialize the custom file."
+  "Initialize the custom file.
+Does not initialize writing the custom file into the dotfile. To
+complete that part see `spacemacs/initialize-custom-file-sync'."
   ;; setup auto-rewrite of custom settings only if custom-file
   ;; has not been set by the user
   (when (null custom-file)
-    (setq custom-file spacemacs--custom-file)
-    (advice-add 'custom-save-all :after
-                #'spacemacs/write-custom-settings-to-dotfile))
+    (setq custom-file spacemacs--custom-file))
   ;; initialize the cache file contents
   (unless (or (not (string-equal custom-file spacemacs--custom-file))
               (file-exists-p spacemacs--custom-file))
@@ -31,6 +31,12 @@
 ;; Spacemacs will copy its content to your dotfile automatically in the
 ;; function `dotspacemacs/emacs-custom-settings'.
 ;; Do not alter this file, use Emacs customize interface instead.\n\n")))))
+
+(defun spacemacs/initialize-custom-file-sync ()
+  "Initialize syncing of the custom file to the dotfile."
+  (when (string-equal custom-file spacemacs--custom-file)
+    (advice-add 'custom-save-all :after
+                #'spacemacs/write-custom-settings-to-dotfile)))
 
 (defun spacemacs//delete-emacs-custom-settings ()
   "Delete function `dotspacemacs/emacs-custom-settings' from dotfile.

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -211,6 +211,9 @@ Note: the hooked function is not executed when in dumped mode."
                    "Calling dotfile user config...")
      (dotspacemacs|call-func dotspacemacs/emacs-custom-settings
                    "Calling dotfile Emacs custom settings...")
+     ;; don't write custom settings into the dotfile before loading them,
+     ;; otherwise https://github.com/syl20bnr/spacemacs/issues/10504 happens
+     (spacemacs/initialize-custom-file-sync)
      (run-hooks 'spacemacs-post-user-config-hook)
      (setq spacemacs-post-user-config-hook-run t)
      (when (fboundp dotspacemacs-scratch-mode)


### PR DESCRIPTION
Fixes a bug where saving a custom variable (e.g. package-selected-packages) before reading the custom settings from dotspacemacs/emacs-custom-settings could overwrite the stored settings.

Should fix #10504.