### PR TITLE
improves spacemacs-jump-handlers for clojure modes

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -176,14 +176,15 @@ If called with a prefix argument, uses the other-window instead."
     (evil-make-overriding-map cider--debug-mode-map 'normal)
     (evil-normalize-keymaps)))
 
-(defun spacemacs/clj-find-var ()
-  "Attempts to jump-to-definition of the symbol-at-point. If CIDER fails, or not available, falls back to dumb-jump"
-  (interactive)
-  (let ((var (cider-symbol-at-point)))
-    (if (and (cider-connected-p) (cider-var-info var))
-        (unless (eq 'symbol (type-of (cider-find-var nil var)))
-          (dumb-jump-go))
-      (dumb-jump-go))))
+(defun spacemacs/clj-find-var (sym-name &optional arg)
+  "Attempts to jump-to-definition of the symbol-at-point.
+
+If CIDER fails, or not available, falls back to dumb-jump."
+  (interactive (list (cider-symbol-at-point)))
+  (if (and (cider-connected-p) (cider-var-info sym-name))
+      (unless (eq 'symbol (type-of (cider-find-var nil sym-name)))
+        (dumb-jump-go))
+    (dumb-jump-go)))
 
 (defun spacemacs/clj-describe-missing-refactorings ()
   "Inform the user to add clj-refactor to configuration"

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -42,17 +42,13 @@
             cider-repl-use-clojure-font-lock t
             cider-repl-history-file (concat spacemacs-cache-directory "cider-repl-history"))
       (add-hook 'clojure-mode-hook 'cider-mode)
+
       (dolist (x '(spacemacs-jump-handlers-clojure-mode
                    spacemacs-jump-handlers-clojurec-mode
                    spacemacs-jump-handlers-clojurescript-mode
                    spacemacs-jump-handlers-clojurex-mode
                    spacemacs-jump-handlers-cider-repl-mode))
-        (add-to-list x 'spacemacs/clj-find-var))
-
-      (add-hook 'clojure-mode-hook #'spacemacs//init-jump-handlers-clojure-mode)
-      (add-hook 'clojurescript-mode-hook #'spacemacs//init-jump-handlers-clojurescript-mode)
-      (add-hook 'clojurec-mode-hook #'spacemacs//init-jump-handlers-clojurec-mode)
-      (add-hook 'cider-repl-mode-hook #'spacemacs//init-jump-handlers-cider-repl-mode)
+        (add-to-list x '(spacemacs/clj-find-var :async t)))
 
       ;; TODO: having this work for cider-macroexpansion-mode would be nice,
       ;;       but the problem is that it uses clojure-mode as its major-mode


### PR DESCRIPTION
makes jump handlers in clojure modes to work correctly for: `, g g` `, g G` `gd` and `gD` 

previously it would annoyingly often fall-back to evil-goto-definition and ignore dumb-jump handler, which made opening definition in other-window very difficult.

It would be nice if `spacemacs/jump-to-definition` could take a prefix argument and pass it to a handler, but it doesn't. That way instead of requiring a separate keybinding could be possible to `SPC u gd` (for example to force result to be displayed in other window). However `,gG` and `gD` to open definition in other window works and I guess it is more consistent with other modes.