### PR TITLE
c++ ccls[lsp] - rename cacheDirectory cacheFormat to cache.{directory,format}

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -249,8 +249,8 @@ and the arguments for flyckeck-clang based on a project-specific text file."
               '(:cacheFormat "msgpack"))))
         ('lsp-ccls (setq ccls-initialization-options
                      (if c-c++-lsp-initialization-options
-                       (append c-c++-lsp-initialization-options `(:cacheDirectory ,c-c++-lsp-cache-dir))
-                       `(:cacheDirectory ,c-c++-lsp-cache-dir)))))
+                       (append c-c++-lsp-initialization-options `(:cache (:directory ,c-c++-lsp-cache-dir)))
+                       `(:cache (:directory ,c-c++-lsp-cache-dir ))))))
 
       (when c-c++-lsp-sem-highlight-rainbow
         (unless c-c++-lsp-sem-highlight-method


### PR DESCRIPTION
Align c++ ccls options passing with ccls changes (https://github.com/MaskRay/ccls/commit/2fc2d1b16ca239f4d56ced02cbdb885ef345dce1) 
>> rename cacheDirectory cacheFormat to cache.{directory,format}