### PR TITLE
Add missing key prefixes for java-mode, gradle-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1497,6 +1497,7 @@ Other:
 - Added LSP Java backend (thanks to Ivan Yonchovski)
 - Added =.dap-breakpoints= and =.lsp-session-*= (java lsp tempfiles) to .gitignore
   (thanks to Uroš Perišić)
+- Fixed prefixes for =java-mode= and =gradle-mode=
 **** Javascript
 - Improvements:
   - Leverage js-doc Yasnippet integration if available (thanks to Andriy Kmit')

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -317,12 +317,12 @@
       (when (configuration-layer/package-used-p 'groovy-mode)
         (add-hook 'groovy-mode-hook 'gradle-mode)
         (spacemacs/declare-prefix-for-mode 'groovy-mode "ml" "gradle")
-        (spacemacs/declare-prefix-for-mode 'groovy-mode "mc" "compile")
+        (spacemacs/declare-prefix-for-mode 'groovy-mode "mlc" "compile")
         (spacemacs/declare-prefix-for-mode 'groovy-mode "mlt" "tests"))
       (when (configuration-layer/package-used-p 'java-mode)
         (add-hook 'java-mode-hook 'gradle-mode)
         (spacemacs/declare-prefix-for-mode 'java-mode "ml" "gradle")
-        (spacemacs/declare-prefix-for-mode 'groovy-mode "mc" "compile")
+        (spacemacs/declare-prefix-for-mode 'java-mode "mlc" "compile")
         (spacemacs/declare-prefix-for-mode 'java-mode "mlt" "tests")))
     :config
     (progn
@@ -438,34 +438,41 @@
       (dolist (prefix '(("mc" . "compile")
                         ("mg" . "goto")
                         ("mr" . "refactor")
-                        ("mq" . "lsp")))
-        (spacemacs/set-leader-keys-for-major-mode 'java-mode
-          "pu"  'lsp-java-update-user-settings
-          "roi" 'lsp-java-organize-imports
-          "rai" 'lsp-java-add-import
-          "ram" 'lsp-java-add-unimplemented-methods
-          "rcp" 'lsp-java-create-parameter
-          "rcf" 'lsp-java-create-field
-          "rec" 'lsp-java-extract-to-constant
-          "rel" 'lsp-java-extract-to-local-variable
-          "rem" 'lsp-java-extract-method
-          "cc"  'lsp-java-build-project
-          "an"  'lsp-java-actionable-notifications
+                        ("mra" . "add")
+                        ("mrc" . "create")
+                        ("mre" . "extract")
+                        ("mq" . "lsp")
+                        ("mt" . "test")
+                        ("mx" . "execute")))
+        (spacemacs/declare-prefix-for-mode
+          'java-mode (car prefix) (cdr prefix)))
+      (spacemacs/set-leader-keys-for-major-mode 'java-mode
+        "pu"  'lsp-java-update-user-settings
+        "ro" 'lsp-java-organize-imports
+        "rai" 'lsp-java-add-import
+        "ram" 'lsp-java-add-unimplemented-methods
+        "rcp" 'lsp-java-create-parameter
+        "rcf" 'lsp-java-create-field
+        "rec" 'lsp-java-extract-to-constant
+        "rel" 'lsp-java-extract-to-local-variable
+        "rem" 'lsp-java-extract-method
+        "cc"  'lsp-java-build-project
+        "an"  'lsp-java-actionable-notifications
 
-          ;; dap-mode
+        ;; dap-mode
 
-          ;; debug
-          "ddj" 'dap-java-debug
-          "dtt" 'dap-java-debug-test-method
-          "dtc" 'dap-java-debug-test-class
-          ;; run
-          "tt" 'dap-java-run-test-method
-          "tc" 'dap-java-run-test-class)
+        ;; debug
+        "ddj" 'dap-java-debug
+        "dtt" 'dap-java-debug-test-method
+        "dtc" 'dap-java-debug-test-class
+        ;; run
+        "tt" 'dap-java-run-test-method
+        "tc" 'dap-java-run-test-class)
 
-        (setq lsp-highlight-symbol-at-point nil
-              lsp-ui-sideline-update-mode 'point
-              lsp-eldoc-render-all nil
-              lsp-java-completion-guess-arguments t)))))
+      (setq lsp-highlight-symbol-at-point nil
+            lsp-ui-sideline-update-mode 'point
+            lsp-eldoc-render-all nil
+            lsp-java-completion-guess-arguments t))))
 
 (defun java/init-mvn ()
   (use-package mvn


### PR DESCRIPTION
lsp-java backend config is actually broken.
This PR fixes it and adds other missing prefixes.