### PR TITLE
Hide single cursor evil-mc lighter "emc" globally

### DIFF
--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -20,7 +20,7 @@
   (use-package evil-mc
     :config
     (progn
-      (setq evil-mc-one-cursor-show-mode-line-text nil)
+      (setq-default evil-mc-one-cursor-show-mode-line-text nil)
       (when (or (spacemacs/system-is-mac) (spacemacs/system-is-mswindows))
         (setq evil-mc-enable-bar-cursor nil))
 


### PR DESCRIPTION
---
### Question:

There's already an entry in the `changelog.develop`:
>  - Hide multiple cursor text when there's only one cursor (thanks to duianto)

It's referring to when the variable was first added:
init-evil-mc: 1 cursor hide mode line text variable https://github.com/syl20bnr/spacemacs/commit/aada9702dc76042b2cd2c7a02da5d961fa1e0109

Is that message enough for both the previous commit and for this PR or should there be a separate entry for this PR as well? It could say something like this:
>  - Hide single cursor =evil-mc= lighter "emc" globally (thanks to duianto)

### Possible cause
The single cursor lighter "emc" might have appeared again when the variable was moved from `:init` to `:config` in:
```
(use-package evil-mc
```

In this commit:
Encapsulates multiple cursors functionality in a layer https://github.com/syl20bnr/spacemacs/commit/5c6057226ea031a43b1a815d2ab5e08c6cb671ba

That seams to have caused the `evil-mc-one-cursor-show-mode-line-text` variable to only be set locally in the `*spacemacs*` buffer.
