### PR TITLE
Fix ivy prompt

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -52,8 +52,9 @@
           (setq display-now t)
           (setq spacemacs--counsel-initial-cands-shown t)))
       (let ((ivy--prompt
-             (format (ivy-state-prompt ivy-last)
-                     size)))
+             (ivy-add-prompt-count
+              (format (ivy-state-prompt ivy-last)
+                      size))))
         (if display-now
             (ivy--insert-minibuffer
              (ivy--format ivy--all-candidates))
@@ -159,17 +160,16 @@ that directory."
           (default-directory
             (or initial-directory (read-directory-name "Start from directory: "))))
     (ivy-read
-     (concat ivy-count-format
-             (format "%s from [%s]: "
-                     tool
-                     (if (< (length default-directory)
-                            spacemacs--counsel-search-max-path-length)
-                         default-directory
-                       (concat
-                        "..." (substring default-directory
-                                         (- (length default-directory)
-                                            spacemacs--counsel-search-max-path-length)
-                                         (length default-directory))))))
+     (format "%s from [%s]: "
+             tool
+             (if (< (length default-directory)
+                    spacemacs--counsel-search-max-path-length)
+                 default-directory
+               (concat
+                "..." (substring default-directory
+                                 (- (length default-directory)
+                                    spacemacs--counsel-search-max-path-length)
+                                 (length default-directory)))))
      (spacemacs//make-counsel-search-function tool)
      :initial-input (when initial-input (rxt-quote-pcre initial-input))
      :dynamic-collection t

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -100,20 +100,20 @@
         "sgF" 'spacemacs/search-grep-region-or-symbol
         "sgp" 'counsel-git-grep
         "sgP" 'spacemacs/counsel-git-grep-region-or-symbol
-        "skd" 'spacemacs/search-ack-grep
-        "skD" 'spacemacs/search-ack-grep-region-or-symbol
+        "skd" 'spacemacs/search-dir-ack
+        "skD" 'spacemacs/search-dir-ack-region-or-symbol
         "skf" 'spacemacs/search-ack
         "skF" 'spacemacs/search-ack-region-or-symbol
         "skp" 'spacemacs/search-project-ack
         "skP" 'spacemacs/search-project-ack-region-or-symbol
-        "srd" 'spacemacs/search-rg-grep
-        "srD" 'spacemacs/search-rg-grep-region-or-symbol
+        "srd" 'spacemacs/search-dir-rg
+        "srD" 'spacemacs/search-dir-rg-region-or-symbol
         "srf" 'spacemacs/search-rg
         "srF" 'spacemacs/search-rg-region-or-symbol
         "srp" 'spacemacs/search-project-rg
         "srP" 'spacemacs/search-project-rg-region-or-symbol
-        "std" 'spacemacs/search-pt-grep
-        "stD" 'spacemacs/search-pt-grep-region-or-symbol
+        "std" 'spacemacs/search-dir-pt
+        "stD" 'spacemacs/search-dir-pt-region-or-symbol
         "stf" 'spacemacs/search-pt
         "stF" 'spacemacs/search-pt-region-or-symbol
         "stp" 'spacemacs/search-project-pt


### PR DESCRIPTION
Closes #12017 
Closes #11750 

The first commit standardizes indentation in ivy/funcs.el, purely cosmetic and makes subsequent edits with aggressive/electric indent easier. 
See the second commit 68d19d535492bee32744da868a41298c394bf0aa for the actual changes, which are quite minor