### PR TITLE
clojure: add missing argument to cider-test-run-project-tests

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -123,19 +123,19 @@ the focus."
   "Run namespace test."
   (interactive)
   (cider-load-buffer)
-  (cider-test-run-ns-tests nil))
+  (call-interactively #'cider-test-run-ns-tests))
 
 (defun spacemacs/cider-test-run-loaded-tests ()
   "Run loaded tests."
   (interactive)
   (cider-load-buffer)
-  (cider-test-run-loaded-tests))
+  (call-interactively #'cider-test-run-loaded-tests))
 
 (defun spacemacs/cider-test-run-project-tests ()
   "Run project tests."
   (interactive)
   (cider-load-buffer)
-  (cider-test-run-project-tests))
+  (call-interactively #'cider-test-run-project-tests))
 
 (defun spacemacs/cider-test-rerun-failed-tests ()
   "Rerun failed tests."


### PR DESCRIPTION
Both `cider-test-run-loaded-tests` and `cider-test-run-project-tests` have 1 mandatory argument, so I added a `nil` argument

(see https://github.com/clojure-emacs/cider/blob/master/cider-test.el#L714 and https://github.com/clojure-emacs/cider/blob/master/cider-test.el#L721)
