### PR TITLE
clojure: change spacemacs/cider-test-run-all-tests alias to point to run-project-tests

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -113,11 +113,8 @@ the focus."
   (cider-load-buffer)
   (cider-test-run-test))
 
-(defalias 'spacemacs/cider-test-run-all-tests #'spacemacs/cider-test-run-ns-tests
-  "ns tests are not actually *all* tests;
-        cider-test-run-project-tests would be better here, but
-        there currently is a bug with the function. Replace once
-        it gets fixed.")
+(defalias 'spacemacs/cider-test-run-all-tests #'spacemacs/cider-test-run-project-tests
+  "Runs all tests in all project namespaces.")
 
 (defun spacemacs/cider-test-run-ns-tests ()
   "Run namespace test."


### PR DESCRIPTION
This alias misleadingly pointed to `spacemacs/cider-test-run-ns-tests` because apparently there was a bug with `cider-test-run-project-tests`.
I couldn't easily find out what bug there was, but it seems to work fine now (feedback here please)