### PR TITLE
factor-layer: Misc fixes for factor version 0.98

### DIFF
--- a/layers/+lang/factor/README.org
+++ b/layers/+lang/factor/README.org
@@ -32,39 +32,40 @@ To use this layer, add it to your =./spacemacs= file. Add =factor= to the
 * Key bindings
 ** factor-mode (editing source files)
 
-| Key binding | Description                                    |
-|-------------+------------------------------------------------|
-| ~SPC m '~   | Jump to the factor listener, start if required |
-| ~SPC m c c~ | Compile and run the current file               |
-|             |                                                |
-| ~SPC m e f~ | Evaluate definition at point                   |
-| ~SPC m e r~ | Evaluate region                                |
-| ~SPC m e R~ | Evaluate region extended to nearest definition |
-|             |                                                |
-| ~SPC m g g~ | Jump to definition of word (under point)       |
-| ~SPC m g a~ | Cycle between source, test, and documentation  |
-|             |                                                |
-| ~SPC m t a~ | Run tests for current vocab                    |
-|             |                                                |
-| ~SPC m r s~ | Extract innermost sexp as separate word        |
-| ~SPC m r r~ | Extract region as separate word                |
-| ~SPC m r v~ | Create new Vocab with words in region          |
-| ~SPC m r i~ | Inline word                                    |
-| ~SPC m r w~ | Rename all occurences of word                  |
-| ~SPC m r a~ | Extract region as new ARTICLE form             |
-| ~SPC m r g~ | Turn current definition into generic word      |
-|             |                                                |
-| ~SPC m s s~ | Switch to factor listener                      |
-|             |                                                |
-| ~SPC m h h~ | Help for thing at point                        |
-| ~SPC m h e~ | Infer stack effect for sexp/region             |
-| ~SPC m h p~ | Apropos                                        |
-| ~SPC m h v~ | List all words in current file/vocab           |
-| ~SPC m h <~ | Show calling words of current word             |
-| ~SPC m h >~ | Show words called by current word              |
-|             |                                                |
-| ~SPC m S v~ | Scaffold vocab                                 |
-| ~SPC m S h~ | Scaffold help for current vocab                |
+| Key binding | Description                                         |
+|-------------+-----------------------------------------------------|
+| ~SPC m '~   | Jump to the factor listener, start if required      |
+| ~SPC m c c~ | Compile and run the current file                    |
+|             |                                                     |
+| ~SPC m e f~ | Evaluate definition at point                        |
+| ~SPC m e r~ | Evaluate region                                     |
+| ~SPC m e R~ | Evaluate region extended to nearest definition      |
+|             |                                                     |
+| ~SPC m g g~ | Jump to definition of word (under point)            |
+| ~SPC m g a~ | Cycle between source, test, and documentation       |
+|             |                                                     |
+| ~SPC m t a~ | Run tests for current vocab                         |
+|             |                                                     |
+| ~SPC m r s~ | Extract innermost sexp as separate word             |
+| ~SPC m r r~ | Extract region as separate word                     |
+| ~SPC m r v~ | Create new Vocab with words in region               |
+| ~SPC m r i~ | Inline word                                         |
+| ~SPC m r w~ | Rename all occurences of word                       |
+| ~SPC m r a~ | Extract region as new ARTICLE form                  |
+| ~SPC m r g~ | Turn current definition into generic word           |
+| ~SPC m r u~ | Update USING: line according to actually used words |
+|             |                                                     |
+| ~SPC m s s~ | Switch to factor listener                           |
+|             |                                                     |
+| ~SPC m h h~ | Help for thing at point                             |
+| ~SPC m h e~ | Infer stack effect for sexp/region                  |
+| ~SPC m h p~ | Apropos                                             |
+| ~SPC m h v~ | List all words in current file/vocab                |
+| ~SPC m h <~ | Show calling words of current word                  |
+| ~SPC m h >~ | Show words called by current word                   |
+|             |                                                     |
+| ~SPC m S v~ | Scaffold vocab                                      |
+| ~SPC m S h~ | Scaffold help for current vocab                     |
 
 ** fuel-listener-mode
 

--- a/layers/+lang/factor/README.org
+++ b/layers/+lang/factor/README.org
@@ -32,40 +32,39 @@ To use this layer, add it to your =./spacemacs= file. Add =factor= to the
 * Key bindings
 ** factor-mode (editing source files)
 
-| Key binding | Description                                            |
-|-------------+--------------------------------------------------------|
-| ~SPC m '~   | Jump to the factor listener, start if required         |
-| ~SPC m c c~ | Compile and run the current file                       |
-|             |                                                        |
-| ~SPC m e f~ | Evaluate definition at point                           |
-| ~SPC m e r~ | Evaluate region                                        |
-| ~SPC m e R~ | Evaluate region extended to nearest definition         |
-|             |                                                        |
-| ~SPC m g g~ | Jump to definition of word under point                 |
-| ~SPC m g G~ | Jump to definition of word under point in other window |
-| ~SPC m g a~ | Cycle between source, test, and documentation          |
-|             |                                                        |
-| ~SPC m t a~ | Run tests for current vocab                            |
-|             |                                                        |
-| ~SPC m r s~ | Extract innermost sexp as separate word                |
-| ~SPC m r r~ | Extract region as separate word                        |
-| ~SPC m r v~ | Create new Vocab with words in region                  |
-| ~SPC m r i~ | Inline word                                            |
-| ~SPC m r w~ | Rename all occurences of word                          |
-| ~SPC m r a~ | Extract region as new ARTICLE form                     |
-| ~SPC m r g~ | Turn current definition into generic word              |
-|             |                                                        |
-| ~SPC m s s~ | Switch to factor listener                              |
-|             |                                                        |
-| ~SPC m h h~ | Help for thing at point                                |
-| ~SPC m h e~ | Infer stack effect for sexp/region                     |
-| ~SPC m h p~ | Apropos                                                |
-| ~SPC m h v~ | List all words in current file/vocab                   |
-| ~SPC m h <~ | Show calling words of current word                     |
-| ~SPC m h >~ | Show words called by current word                      |
-|             |                                                        |
-| ~SPC m S v~ | Scaffold vocab                                         |
-| ~SPC m S h~ | Scaffold help for current vocab                        |
+| Key binding | Description                                    |
+|-------------+------------------------------------------------|
+| ~SPC m '~   | Jump to the factor listener, start if required |
+| ~SPC m c c~ | Compile and run the current file               |
+|             |                                                |
+| ~SPC m e f~ | Evaluate definition at point                   |
+| ~SPC m e r~ | Evaluate region                                |
+| ~SPC m e R~ | Evaluate region extended to nearest definition |
+|             |                                                |
+| ~SPC m g g~ | Jump to definition of word (under point)       |
+| ~SPC m g a~ | Cycle between source, test, and documentation  |
+|             |                                                |
+| ~SPC m t a~ | Run tests for current vocab                    |
+|             |                                                |
+| ~SPC m r s~ | Extract innermost sexp as separate word        |
+| ~SPC m r r~ | Extract region as separate word                |
+| ~SPC m r v~ | Create new Vocab with words in region          |
+| ~SPC m r i~ | Inline word                                    |
+| ~SPC m r w~ | Rename all occurences of word                  |
+| ~SPC m r a~ | Extract region as new ARTICLE form             |
+| ~SPC m r g~ | Turn current definition into generic word      |
+|             |                                                |
+| ~SPC m s s~ | Switch to factor listener                      |
+|             |                                                |
+| ~SPC m h h~ | Help for thing at point                        |
+| ~SPC m h e~ | Infer stack effect for sexp/region             |
+| ~SPC m h p~ | Apropos                                        |
+| ~SPC m h v~ | List all words in current file/vocab           |
+| ~SPC m h <~ | Show calling words of current word             |
+| ~SPC m h >~ | Show words called by current word              |
+|             |                                                |
+| ~SPC m S v~ | Scaffold vocab                                 |
+| ~SPC m S h~ | Scaffold help for current vocab                |
 
 ** fuel-listener-mode
 

--- a/layers/+lang/factor/config.el
+++ b/layers/+lang/factor/config.el
@@ -9,4 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(spacemacs|define-jump-handlers factor-mode 'fuel-edit-word)
+(spacemacs|define-jump-handlers factor-mode 'fuel-edit-word-at-point)

--- a/layers/+lang/factor/packages.el
+++ b/layers/+lang/factor/packages.el
@@ -65,6 +65,7 @@
         "rw" 'fuel-refactor-rename-word
         "ra" 'fuel-refactor-extract-article
         "rg" 'fuel-refactor-make-generic
+        "ru" 'fuel-update-usings
 
         "ss" 'run-factor
 
@@ -87,5 +88,7 @@
         "Sv" 'fuel-scaffold-vocab
         )
 
-      (evilified-state-evilify fuel-help-mode fuel-help-mode-map)))
+      (evilified-state-evilify fuel-help-mode fuel-help-mode-map)
+      (dolist (mode '(fuel-debug-uses-mode fuel-debug-mode))
+        (evil-set-initial-state mode 'insert))))
   )

--- a/layers/+lang/factor/packages.el
+++ b/layers/+lang/factor/packages.el
@@ -13,7 +13,7 @@
   '(
     ;; Assume that factor is installed, and emacs lisp files are correctly
     ;; located in site-lisp
-    (factor-mode :location site)
+    (fuel :location site)
     yasnippet
     ))
 
@@ -26,7 +26,7 @@
                t)
   (spacemacs/add-to-hooks 'spacemacs/load-yasnippet '(factor-mode-hook fuel-mode-hook)))
 
-(defun factor/init-factor-mode()
+(defun factor/init-fuel()
   (use-package factor-mode
     :commands factor-mode run-factor fuel-mode
     :mode ("factor\\'" . factor-mode)

--- a/layers/+lang/factor/packages.el
+++ b/layers/+lang/factor/packages.el
@@ -53,8 +53,7 @@
         "er" 'fuel-eval-region
         "eR" 'fuel-eval-extended-region
 
-        "gg" 'fuel-edit-word
-        "gG" 'fuel-edit-word-at-point
+        "gg" 'fuel-edit-word-at-point
         "ga" 'factor-visit-other-file
 
         "ta" 'fuel-test-vocab


### PR DESCRIPTION
Since factor 0.98, `fuel-edit-word` has been removed, since
`fuel-edit-word-at-point` has the same behavior when point is not on a symbol.