### PR TITLE
Stop setting lsp-prefer-flymake to nil in LSP layer initialization

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -22,7 +22,6 @@
     :config
     (progn
       (require 'lsp-clients)
-      (setq lsp-prefer-flymake nil)
       (spacemacs/lsp-bind-keys)
       (add-hook 'lsp-after-open-hook (lambda ()
                                        "Setup xref jump handler and declare keybinding prefixes"


### PR DESCRIPTION
This updates the packages.el file in the LSP layer to not set
`lsp-prefer-flymake` to `nil`. This is because when the value is `nil`,
`lsp-mode` configures `lsp-ui` as the `flycheck-checker` instead of leaving it
`nil`. This causes issues with linters not being ran / errors not being
reported.

This was specifically observed when using the `lsp` backend for the Go layer,
and opening a Go source file directly, in a new Emacs GUI process, launched from
the command line [1]. It was causing the user's configuration to not be seen
when `lsp-mode` was configured.

It may make sense to change this to be an entry in the `config.el` file, and
have it default to `:none` instead of `nil`. However, it seems to work with just
removing this line.

[1] https://github.com/emacs-lsp/lsp-ui/issues/256

Fixes #11680

Signed-off-by: Tim Heckman <t@heckman.io>