### PR TITLE
Set lsp-prefer-flymake to :none when Go layer is using LSP

### DIFF
--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -37,7 +37,13 @@
 (defun spacemacs//go-setup-backend-lsp ()
   "Setup lsp backend"
   (if (configuration-layer/layer-used-p 'lsp)
-      (lsp)
+      (progn
+        ;; without setting lsp-prefer-flymake to :none
+        ;; golangci-lint errors won't be reported
+        (when go-use-golangci-lint
+          (message "[go] Setting lsp-prefer-flymake :none to enable golangci-lint support.")
+          (setq-local lsp-prefer-flymake :none))
+        (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 (defun spacemacs//go-setup-company-lsp ()


### PR DESCRIPTION
When switching the Go layer to use the LSP backend with `golangci-lint`, I
noticed that none of my linter errors were being rendered with my source code.
Digging in further, I eventually learned it was due to `lsp-prefer-flymake`
being set to `nil` and not `:none`.

This change updates the Go layer, when using LSP and golangci-lint, to set
`lsp-prefer-flymake` to `:none`. If this is not set, the golangci-lint errors
will not be reported.

This is an alternative to #12043.

Fixes #11680

Signed-off-by: Tim Heckman <t@heckman.io>

@sdwolfz @thanhvg @yyoncho