### PR TITLE
Fix magit conflicting with golden-ratio

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -21,6 +21,7 @@
         git-link
         git-messenger
         git-timemachine
+        golden-ratio
         (helm-git-grep :requires helm)
         (helm-gitignore :requires helm)
         magit
@@ -30,6 +31,11 @@
         smeargle
         transient
         ))
+
+(defun git/pre-init-golden-ratio ()
+  (spacemacs|use-package-add-hook golden-ratio
+    :post-config
+    (add-to-list 'golden-ratio-exclude-buffer-names " *transient*")))
 
 (defun git/pre-init-evil-magit ()
   (spacemacs|use-package-add-hook magit


### PR DESCRIPTION
When I enabled `golden-ratio-mode` globally, the magit's transient window always takes half of my screen like this.

<img width="1552" alt="38C32E36-D78F-49AC-B373-87D9C3038C50" src="https://user-images.githubusercontent.com/1946663/54089080-02a97880-43a0-11e9-93f3-6d775c2688e4.png">


This PR fixes it!


Related code in magit transient:
https://github.com/magit/transient/blob/a6295fa7eea2d7a95c705684064e82ea47e27e44/lisp/transient.el#L2290
