### PR TITLE
ignore /transient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ python-*-docs-html
 /session.*
 /srecode-map.el
 /recentf
+/transient
 .mc-lists.el
 nov-places
 workspace


### PR DESCRIPTION
Adding `/transient` to the ignore list. It seems to have been created and added by magit when adding a dependency on `magit-transient` (https://github.com/magit/transient) with this commit https://github.com/magit/magit/commit/f3b7f7ca7dc17609c61d2528c0762292b14431ee.

`transient-history-file` can be user-customized to put this data in another place if that is a better solution.

The contents of my `./transient/history.el` is:

```
((magit-blame
  ("-w"))
 (magit-branch nil)
 (magit-commit nil)
 (magit-dispatch nil)
 (magit-pull nil)
 (magit-push nil
             ("--force-with-lease"))
 (magit-reset nil))
```