### PR TITLE
Added missing cider-connect-cljs keybinding

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -109,7 +109,8 @@
             "sc" (if (eq m 'cider-repl-mode)
                      'cider-repl-clear-buffer
                    'cider-connect)
-            "sC" 'cider-find-and-clear-repl-output
+            "sC" 'cider-connect-cljs
+            "sd" 'cider-find-and-clear-repl-output
             "se" 'spacemacs/cider-send-last-sexp-to-repl
             "sE" 'spacemacs/cider-send-last-sexp-to-repl-focus
             "sf" 'spacemacs/cider-send-function-to-repl


### PR DESCRIPTION
Add missing cider-connect-cljs key binding for connecting to cljs repl.