### PR TITLE
python: add diminish for importmagic

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -141,6 +141,7 @@
     :init
     (progn
       (add-hook 'python-mode-hook 'importmagic-mode)
+      (spacemacs|diminish importmagic-mode " ⓘ" " [i]")
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "rf" 'importmagic-fix-symbol-at-point))))
 


### PR DESCRIPTION
importmangic does not have a diminish character.
Add diminish characters to make the modeline nice(r).

Signed-off-by: Loys Ollivier <loys.ollivier@gmail.com>

--
Not that I don't like importmagic but it is stressing my eyes out to see it written in the modeline when the others have nice symbols to represent them. This should restore the world to a fair and equal atmosphere.