### PR TITLE
Helm: lazy load helm on dired key bindings

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -81,6 +81,7 @@
       ;; use helm everywhere
       (spacemacs||set-helm-key "<f1>" helm-apropos)
       (spacemacs||set-helm-key "a'"   helm-available-repls)
+      (spacemacs||set-helm-key "ad"   spacemacs/dired)
       (spacemacs||set-helm-key "bb"   helm-mini)
       (spacemacs||set-helm-key "Cl"   helm-colors)
       (spacemacs||set-helm-key "ff"   spacemacs/helm-find-files)


### PR DESCRIPTION
Add to the list of helm lazy loading dired key bindings.
To lazy load helm if not already loaded when invoking dired.

Signed-off-by: Loys Ollivier <loys.ollivier@gmail.com>

--
This fixes #12064 