### PR TITLE
Show magit-log-select and diff in two windows

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1261,6 +1261,7 @@ Other:
 - Enabled colors in =magit-log= (thanks to Thomas de Beauchêne)
 - Added magit buffers to useless buffers (thanks to Thomas de Beauchêne)
 - Fixed magint blame function name (thanks to Bjarke Vad Andersen)
+- Show magit-log-select and diff in two windows (thanks to duianto)
 **** Go
 - Improved go test output buffer behavior (thanks to Denis Bernard)
 - Configurable extra arguments to go test (thanks to Ian Clark)

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -186,6 +186,7 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
                               (not (bound-and-true-p magit-blame-mode))))))
     :config
     (progn
+      (purpose-x-magit-multi-on)
       ;; seems to be necessary at the time of release
       (require 'git-rebase)
       ;; bind function keys


### PR DESCRIPTION
---

### problem:
In Spacemacs, the Magit commit edit commands (ex: fixup, squash, augment, etc) opens two buffers:
- `magit-log-select <project>`
- `magit-diff <project>`

but only the diff buffer is visible, even though the minibuffer shows the instructions for the log buffer.
>Type C-c C-c on a commit to fixup into it, or C-c C-k to abort

The diff buffer has to be closed `q` first, to get to the log buffer.

### solution:
The purpose-x-magit extension brings back the default Magit behavior of showing both the diff and log buffers at the same time, with the log buffer selected.

#### System Info :computer:
- OS: windows-nt
- Emacs: 26.1
- Spacemacs: 0.300.0
- Spacemacs branch: develop (rev. 4b195ddfc)
- Graphic display: t
- Distribution: spacemacs
- Editing style: vim
- Completion: helm
- Layers:
```elisp
(auto-completion autohotkey emacs-lisp git helm multiple-cursors org treemacs version-control)
```
- System configuration features: XPM JPEG TIFF GIF PNG RSVG SOUND NOTIFY ACL GNUTLS LIBXML2 ZLIB TOOLKIT_SCROLL_BARS THREADS LCMS2
