### PR TITLE
Increase compatibility with guix

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -120,7 +120,7 @@ subdirectory of ROOT is used."
   "Hook executed at the end of configuration loading.")
 
 (defconst configuration-layer--elpa-root-directory
-  (concat spacemacs-start-directory "elpa/")
+  (concat user-emacs-directory "elpa/")
   "Spacemacs ELPA root directory.")
 
 (defconst configuration-layer--rollback-root-directory

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -637,19 +637,20 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
     (with-current-buffer (find-file-noselect
                           (concat dotspacemacs-template-directory
                                   ".spacemacs.template"))
-      (dolist (p preferences)
-        (goto-char (point-min))
-        (re-search-forward (car p))
-        (replace-match (cadr p)))
-      (let ((install
-             (if (file-exists-p dotspacemacs-filepath)
-                 (y-or-n-p
-                  (format "%s already exists. Do you want to overwrite it ? "
-                          dotspacemacs-filepath)) t)))
-        (when install
-          (write-file dotspacemacs-filepath)
-          (message "%s has been installed." dotspacemacs-filepath)
-          t))))
+      (let ((inhibit-read-only t))
+        (dolist (p preferences)
+          (goto-char (point-min))
+          (re-search-forward (car p))
+          (replace-match (cadr p)))
+        (let ((install
+               (if (file-exists-p dotspacemacs-filepath)
+                   (y-or-n-p
+                    (format "%s already exists. Do you want to overwrite it ? "
+                            dotspacemacs-filepath)) t)))
+          (when install
+            (write-file dotspacemacs-filepath)
+            (message "%s has been installed." dotspacemacs-filepath)
+            t)))))
   (dotspacemacs/load-file)
   ;; force new wizard values to be applied
   (dotspacemacs/init))

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -17,7 +17,7 @@
 
 ;; paths
 (defvar spacemacs-start-directory
-  user-emacs-directory
+  (file-name-directory (directory-file-name (file-name-directory load-file-name)))
   "Spacemacs start directory.")
 (defconst spacemacs-core-directory
   (expand-file-name (concat spacemacs-start-directory "core/"))

--- a/core/libs/quelpa.el
+++ b/core/libs/quelpa.el
@@ -374,8 +374,10 @@ and return TIME-STAMP, otherwise return OLD-TIME-STAMP."
         (delete-directory dir t)
         (make-directory dir)
         (if (eq type 'file)
-            (copy-file file-path dir t t t t)
-          (copy-directory file-path dir t t t)))
+          (progn (copy-file file-path dir t t t t)
+                 (set-file-modes (expand-file-name (file-name-nondirectory file-path) dir) #o644))
+          (progn (copy-directory file-path dir t t t)
+                 (set-file-modes dir #o755))))
       (quelpa-build--dump new-stamp-info stamp-file)
       (quelpa-file-version file-path type version time-stamp))))
 
@@ -1369,10 +1371,13 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
   (cond
    ((file-regular-p file)
     (quelpa-build--message "%s -> %s" file newname)
-    (copy-file file newname))
+    (copy-file file newname)
+    (set-file-modes newname #o644))
    ((file-directory-p file)
     (quelpa-build--message "%s => %s" file newname)
-    (copy-directory file newname))))
+    (make-directory newname)
+    (set-file-modes newname #o755)
+    (map quelpa-build--copy-file (directory-files file t)))))
 
 (defun quelpa-build--find-source-file (target files)
   "Search for source of TARGET in FILES."
@@ -1566,7 +1571,8 @@ attribute with an URL like \"http://domain.tld/path/to/file.el\"."
     (unless (string= (file-name-extension url) "el")
       (error "<%s> does not end in .el" url))
     (unless (file-directory-p dir)
-      (make-directory dir))
+      (make-directory dir)
+      (set-file-modes dir #o755))
     (url-copy-file url local-path t)
     (quelpa-check-hash name config local-path dir 'url)))
 


### PR DESCRIPTION
 This PR fixes issues that arise when installing spacemacs system-wide.

I am working on a spacemacs package for GNU Guix. The package works by installing the spacemacs repository to a read-only system-wide directory and loading it from site-init.el. There are 4 bugs related to this setup which are fixed in this pull request and described in more detail below/in the commit message (ordering of issue list corresponds to ordering of changes in the diff). The second and third bugs have straightforward fixes that I expect to be non-controversial. The first and fourth changes have potential issues which are discussed in their respective sections below. If you would like me to split this into multiple PRs I will, but I think it makes sense to keep the changes together since they are all related to the same scenario.

1. Variable elpa-root-directory (core-configuration-layer.el)
spacemacs tries to install elpa packages to spacemacs-start-directory. On guix spacemacs-start-directory is a store location, so we set it to user-emacs-dir. This is the location that it gets installed to on vanilla emacs.

It seems like the spacemacs code base tries to refrain from referring directly to emacs variable like user-emacs-dir, so I'm not sure if this is an appropriate solution. However, the other option I see would be to create some new variable like spacemacs-writable-directory which seems like a bigger change, and I'm trying to keep this PR as minimal as possible.

2. Template generation (core-dotspacemacs.el)
When spacemacs-install runs on first boot it copies a template file from spacemacs-start-directory which causes it to be read-only. This causes an error when spacemacs tries to edit the template based on user input. We inhibit read-only after opening the template file. This works because the file is written into dotspacemacs-directory, not to the location it was opened from.

The diff here is mostly whitespace changes. The only real change is to wrap the relevant section in the let statement at the top of the diff.

3. Variable spacemacs-start-directory
spacemacs assumes that spacemacs is installed into `$HOME/.emacs.d`. We need to update it to point to the location in the guix store. Since the variable is defined in spacemacs/core/core-load-paths.el we set it to the second directory above `load-file-name`

This change seems reasonable in the sense that it maintains behavior on current setups and allows for a greater diversity of setups without adding significant complication to the code. However, it may cause issues on setups that symlink ~/.emacs to /unexpected/path/to/spacemacs/init.el.

4. Quelpa
Some quelpa functions do not work on work on spacemacs-for-guix out of the box. When they copy files from the store the files are left as read-only. The only change is to set file permissions after copying a file or directory into Quelpa's build directory, ~/.emacs.d/.cache/quelpa/build

Setting the file modes seems safe based on my useage, but I'm not super familiar with Quelpa's build process so it would be good if someone knowledgeable in Quelpa looked over the changes to make sure. I set files to `rw-r--r--` and directories to `rwxr-xr-x`.