### PR TITLE
Fix haskell jump handler for dante

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -157,7 +157,7 @@
       :backends (dante-company company-dabbrev-code company-yasnippet)
       :modes haskell-mode)
     (add-hook 'haskell-mode-hook 'dante-mode)
-    (add-to-list 'spacemacs-jump-handlers 'xref-find-definitions)
+    (add-to-list 'spacemacs-jump-handlers-haskell-mode 'xref-find-definitions)
     :config
     (progn
       (dolist (mode haskell-modes)


### PR DESCRIPTION
Analog to d6b1d1674f50a85246eceda32866fd9f93d955d6 which was for intero

See https://github.com/syl20bnr/spacemacs/pull/11562