### PR TITLE
Fix typo in multiple-cursors readme

### DIFF
--- a/layers/+misc/multiple-cursors/README.org
+++ b/layers/+misc/multiple-cursors/README.org
@@ -19,7 +19,7 @@ file.
 
 * Configuration
 Currently the only supported backend is =evil-mc=, but more backends will be
-availabe in the future.
+available in the future.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(


### PR DESCRIPTION
This fixes a misspelling in the multiple-cursors readme.