### PR TITLE
Improve purescript keybinding discoverability & ergonomics.

### DIFF
--- a/layers/+lang/purescript/README.org
+++ b/layers/+lang/purescript/README.org
@@ -74,13 +74,13 @@ meant as an alternative to using flycheck. Default value is nil.
 |---------------+---------------------------------------------------------------------------|
 | ~SPC m m s~   | Start psc-ide-server                                                      |
 | ~SPC m m l~   | Load definitions for the modules inside your project                      |
-| ~SPC m h t~   | Show type at point                                                        |
+| ~SPC m t~     | Show type at point                                                        |
 | ~SPC m g g~   | Goto definition for identifier at point                                   |
 | ~SPC m m b~   | Rebuilds the current file and displays any warnings or errors             |
 | ~SPC m m i a~ | Add an import for the identifier at the current cursor position           |
 | ~SPC m m i s~ | Inserts a suggestion for the warning/error at the current cursor position |
 | ~SPC m m t~   | Add a new clause for the function signature at point                      |
-| ~SPC m m c s~ | Casesplits on the identifier at the current cursor position               |
+| ~SPC m m c~   | Casesplits on the identifier at the current cursor position               |
 | ~SPC m m q~   | Quit the current psc-ide-server                                           |
 | ~SPC m m L~   | Load a specific module (This is mostly used for troubleshooting)          |
 

--- a/layers/+lang/purescript/README.org
+++ b/layers/+lang/purescript/README.org
@@ -68,21 +68,21 @@ meant as an alternative to using flycheck. Default value is nil.
 | ~SPC m i n~ | Navigate to the imports                                       |
 
 *** psc-ide
-=psc-ide= command are available under ~SPC m m~:
 
 | Key binding   | Description                                                               |
 |---------------+---------------------------------------------------------------------------|
 | ~SPC m m s~   | Start psc-ide-server                                                      |
+| ~SPC m m q~   | Quit the current psc-ide-server                                           |
 | ~SPC m m l~   | Load definitions for the modules inside your project                      |
-| ~SPC m t~     | Show type at point                                                        |
-| ~SPC m g g~   | Goto definition for identifier at point                                   |
 | ~SPC m m b~   | Rebuilds the current file and displays any warnings or errors             |
-| ~SPC m m i a~ | Add an import for the identifier at the current cursor position           |
-| ~SPC m m i s~ | Inserts a suggestion for the warning/error at the current cursor position |
 | ~SPC m m t~   | Add a new clause for the function signature at point                      |
 | ~SPC m m c~   | Casesplits on the identifier at the current cursor position               |
-| ~SPC m m q~   | Quit the current psc-ide-server                                           |
 | ~SPC m m L~   | Load a specific module (This is mostly used for troubleshooting)          |
+| ~SPC m m i a~ | Add an import for the identifier at the current cursor position           |
+| ~SPC m m i s~ | Inserts a suggestion for the warning/error at the current cursor position |
+| ~SPC m h t~   | Show type at point                                                        |
+| ~SPC m g g~   | Goto definition for identifier at point                                   |
+
 
 ** REPL
 [[https://github.com/ardumont/emacs-psci][psci]] provides a very basic REPL for purescript. The following key

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -39,7 +39,7 @@
     (progn
       (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
       (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
-      (spacemacs/declare-prefix "mg" "jump")
+      (spacemacs/declare-prefix "mg" "goto")
       (spacemacs/declare-prefix "mi" "imports")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "i="  'purescript-mode-format-imports
@@ -54,7 +54,7 @@
     (progn
       (spacemacs/register-repl 'psci 'psci "purescript")
       (add-hook 'purescript-mode-hook 'inferior-psci-mode)
-      (spacemacs/declare-prefix "ms" "psci")
+      (spacemacs/declare-prefix "ms" "repl")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "'"  'psci
         "sb" 'psci/load-current-file!
@@ -74,7 +74,7 @@
       (customize-set-variable 'psc-ide-rebuild-on-save purescript-enable-rebuild-on-save)
 
       (add-to-list 'spacemacs-jump-handlers-purescript-mode 'psc-ide-goto-definition)
-      (spacemacs/declare-prefix "mmi" "imports")
+      (spacemacs/declare-prefix "mmi" "insert/import")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "mt"  'psc-ide-add-clause
         "mc"  'psc-ide-case-split

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -75,6 +75,7 @@
 
       (add-to-list 'spacemacs-jump-handlers-purescript-mode 'psc-ide-goto-definition)
       (spacemacs/declare-prefix "mmi" "insert/import")
+      (spacemacs/declare-prefix "mh" "help")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "mt"  'psc-ide-add-clause
         "mc"  'psc-ide-case-split
@@ -85,7 +86,7 @@
         "mL"  'psc-ide-load-module
         "mia" 'psc-ide-add-import
         "mis" 'psc-ide-flycheck-insert-suggestion
-        "t"  'psc-ide-show-type))))
+        "ht"  'psc-ide-show-type))))
 
 (defun purescript/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -39,6 +39,8 @@
     (progn
       (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
       (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
+      (spacemacs/declare-prefix "mg" "jump")
+      (spacemacs/declare-prefix "mi" "imports")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "i="  'purescript-mode-format-imports
         "i`"  'purescript-navigate-imports-return
@@ -52,6 +54,7 @@
     (progn
       (spacemacs/register-repl 'psci 'psci "purescript")
       (add-hook 'purescript-mode-hook 'inferior-psci-mode)
+      (spacemacs/declare-prefix "ms" "psci")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "'"  'psci
         "sb" 'psci/load-current-file!
@@ -71,9 +74,10 @@
       (customize-set-variable 'psc-ide-rebuild-on-save purescript-enable-rebuild-on-save)
 
       (add-to-list 'spacemacs-jump-handlers-purescript-mode 'psc-ide-goto-definition)
+      (spacemacs/declare-prefix "mmi" "imports")
       (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
         "mt"  'psc-ide-add-clause
-        "mcs" 'psc-ide-case-split
+        "mc"  'psc-ide-case-split
         "ms"  'psc-ide-server-start
         "mb"  'psc-ide-rebuild
         "mq"  'psc-ide-server-quit
@@ -81,7 +85,7 @@
         "mL"  'psc-ide-load-module
         "mia" 'psc-ide-add-import
         "mis" 'psc-ide-flycheck-insert-suggestion
-        "ht"  'psc-ide-show-type))))
+        "t"  'psc-ide-show-type))))
 
 (defun purescript/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin


### PR DESCRIPTION
Added prefix titles and removed some useless nesting to the keybindings of the purescript layer.

I'm pretty new to Spacemacs, and even newer to customizing layers, so let me know if there's a better way to declare prefixes for major-mode keybindings.