### PR TITLE
Add dtrt-indent layer for automatic indentation detection

### DIFF
--- a/layers/+misc/dtrt-indent/README.org
+++ b/layers/+misc/dtrt-indent/README.org
@@ -1,0 +1,24 @@
+#+TITLE: dtrt-indent layer
+
+Spacemacs layer wrapping the Emacs package [[https://github.com/jscheid/dtrt-indent][dtrt-indent]].
+This package enables automatic detection and switching of indentation style to match the current file.
+See the [[https://github.com/jscheid/dtrt-indent][dtrt-indent]] repo for more details.
+
+# TOC links should be GitHub style anchors.
+* Table of Contents                                        :TOC_4_gh:noexport:
+- [[#description][Description]]
+- [[#install][Install]]
+
+* Description
+
+This is a simple layer wrapping the dtrt-indent Emacs package for automatic detection and switching of indentation style.
+
+It is automatically enabled using the method [[https://github.com/syl20bnr/spacemacs/issues/3203#issuecomment-264175032][suggested here]].
+
+* Install
+
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =dtrt-indent= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+

--- a/layers/+misc/dtrt-indent/README.org
+++ b/layers/+misc/dtrt-indent/README.org
@@ -7,6 +7,7 @@ See the [[https://github.com/jscheid/dtrt-indent][dtrt-indent]] repo for more de
 # TOC links should be GitHub style anchors.
 * Table of Contents                                        :TOC_4_gh:noexport:
 - [[#description][Description]]
+  - [[#features][Features:]]
 - [[#install][Install]]
 
 * Description
@@ -14,6 +15,9 @@ See the [[https://github.com/jscheid/dtrt-indent][dtrt-indent]] repo for more de
 This is a simple layer wrapping the dtrt-indent Emacs package for automatic detection and switching of indentation style.
 
 It is automatically enabled using the method [[https://github.com/syl20bnr/spacemacs/issues/3203#issuecomment-264175032][suggested here]].
+
+** Features:
+   - Indentation style detection and automatic configuration to match file in open buffer.
 
 * Install
 

--- a/layers/+misc/dtrt-indent/packages.el
+++ b/layers/+misc/dtrt-indent/packages.el
@@ -1,0 +1,71 @@
+;;; packages.el --- dtrt-indent layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2017 Sylvain Benner & Contributors
+;;
+;; Author: Kevin Doherty <kjd@csail.mit.edu>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;; See the Spacemacs documentation and FAQs for instructions on how to implement
+;; a new layer:
+;;
+;;   SPC h SPC layers RET
+;;
+;;
+;; Briefly, each package to be installed or configured by this layer should be
+;; added to `dtrt-indent-packages'. Then, for each package PACKAGE:
+;;
+;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
+;;   function `dtrt-indent/init-PACKAGE' to load and initialize the package.
+
+;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
+;;   define the functions `dtrt-indent/pre-init-PACKAGE' and/or
+;;   `dtrt-indent/post-init-PACKAGE' to customize the package as it is loaded.
+
+;;; Code:
+
+(defconst dtrt-indent-packages
+  '((dtrt-indent :location (recipe
+                           :fetcher github
+                           :repo "jscheid/dtrt-indent")))
+  "The list of Lisp packages required by the dtrt-indent layer.
+
+Each entry is either:
+
+1. A symbol, which is interpreted as a package to be installed, or
+
+2. A list of the form (PACKAGE KEYS...), where PACKAGE is the
+    name of the package to be installed or loaded, and KEYS are
+    any number of keyword-value-pairs.
+
+    The following keys are accepted:
+
+    - :excluded (t or nil): Prevent the package from being loaded
+      if value is non-nil
+
+    - :location: Specify a custom installation location.
+      The following values are legal:
+
+      - The symbol `elpa' (default) means PACKAGE will be
+        installed using the Emacs package manager.
+
+      - The symbol `local' directs Spacemacs to load the file at
+        `./local/PACKAGE/PACKAGE.el'
+
+      - A list beginning with the symbol `recipe' is a melpa
+        recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
+
+(defun dtrt-indent/init-dtrt-indent ()
+  (use-package dtrt-indent
+    :hook (prog-mode .
+              (lambda ()
+                (modify-syntax-entry ?_ "w")
+                (dtrt-indent-mode)
+                (dtrt-indent-adapt)))))
+
+;;; packages.el ends here


### PR DESCRIPTION
This layer is a simple wrapper around the [dtrt-indent](https://github.com/jscheid/dtrt-indent) Emacs package. It automatically detects the indentation style in a file and sets defaults to match.

This solution is based on [this suggestion](https://github.com/syl20bnr/spacemacs/issues/3203#issuecomment-264175032).

This is essentially just a package with an added hook, though, and as per the guidelines:
> Layer with no associated configuration will be rejected. For instance a layer with just a package and a hook can be easily replaced by the usage of the variable dotspacemacs-additional-packages.

That said, this has been an open issue since 2015 (see #3203), so I thought maybe this could be helpful to people.