### PR TITLE
Delete helm-wikipedia-suggest key binding

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1365,6 +1365,8 @@ Other:
   bmag)
 - Fixed opening files from buffers without winum (thanks to Codruț Constantin
   Gușoi)
+- Removed ~SPC s w w~ key binding for =helm-wikipedia-suggest=, which was
+  removed upstream.
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Added =counsel-css= as an =ivy= alternative to =helm-css-scss= (thanks to Robbert

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2712,7 +2712,6 @@ directly search into it like with ~SPC s p~.
 | Key binding | Description                                                          |
 |-------------+----------------------------------------------------------------------|
 | ~SPC s w g~ | Get Google suggestions in emacs. Opens Google results in Browser.    |
-| ~SPC s w w~ | Get Wikipedia suggestions in emacs. Opens Wikipedia page in Browser. |
 
 *** Persistent highlighting
 Spacemacs uses =evil-search-highlight-persist= to keep the searched expression

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -110,7 +110,6 @@
       ;; various key bindings
       (spacemacs||set-helm-key "fel" helm-locate-library)
       (spacemacs||set-helm-key "hdm" describe-mode)
-      (spacemacs||set-helm-key "sww" helm-wikipedia-suggest)
       (spacemacs||set-helm-key "swg" helm-google-suggest)
       (with-eval-after-load 'helm-files
         (define-key helm-find-files-map


### PR DESCRIPTION
Helm has removed the `helm-wikipedia-suggest` command, so delete Spacemacs's key binding for the command.

https://github.com/emacs-helm/helm/commit/4ef8299d781715e8b889ab1b57fb77fa38a1156b

* `doc/DOCUMENTATION.org`: Delete documentation for the key binding for `helm-wikipedia-suggest`.
* `layers/+completion/helm/packages.el` (`helm/init-helm`): Delete the key binding for `helm-wikipedia-suggest`.