### PR TITLE
Add toggle control for verbose go test output

### DIFF
--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -36,3 +36,6 @@
 
 (defvar go-use-test-args ""
   "Additional arguments to be supplied to `go test` during runtime.")
+
+(defvar go-test-verbose nil
+  "Control verbosity of `go test` output")

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -74,7 +74,7 @@
 
 (defun spacemacs/go-run-tests (args)
   (interactive)
-  (compilation-start (concat "go test " args " " go-use-test-args)
+  (compilation-start (concat "go test " (when go-test-verbose "-v ") args " " go-use-test-args)
                      nil (lambda (n) go-test-buffer-name) nil))
 
 (defun spacemacs/go-run-package-tests ()

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -125,7 +125,13 @@
                 #'spacemacs//go-setup-backend)
       (dolist (value '(lsp go-mode))
         (add-to-list 'safe-local-variable-values
-                     (cons 'go-backend value))))
+                     (cons 'go-backend value)))
+      (spacemacs|add-toggle go-test-verbose
+        :documentation "Enable verbose test output."
+        :status go-test-verbose
+        :on (setq go-test-verbose t)
+        :off (setq go-test-verbose nil)
+        :evil-leader-for-mode (go-mode . "tv")))
     :config
     (progn
       (when go-format-before-save


### PR DESCRIPTION
This change add toggle variable `go-test-verbose` to control the verbosity of `go test` output. 