### PR TITLE
Improve & apply conventions to multi-term keybinds

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2008,6 +2008,10 @@ Other:
 - Wrap 'shell' command to start in current buffer (thanks to Valts Liepiņš)
 - Fixed shell popup broken on macOS (thanks to Daniel Rivas Perez)
 - Fixed broken leader key binding for inferior shell (thanks to Valts Liepiņš)
+- Added =term-mode= bindings (Thanks to Emil Petersen):
+  - ~SPC m C~ switch multi-term to char mode
+  - ~SPC m l~ switch multi-term to line mode
+  - ~SPC m N~ go to previous multi-term
 **** Shell Scripts
 - Added new company-shell environment variable backend (thanks to
   Alexander-Miller)

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -221,12 +221,14 @@ in the current buffer instead of a popup.
 
 ** Multi-term
 
-| Key binding | Description                  |
-|-------------+------------------------------|
-| ~SPC m c~   | create a new multi-term      |
-| ~SPC m n~   | go to next multi-term        |
-| ~SPC m p~   | go to previous multi-term    |
-| ~SPC p $ t~ | run multi-term shell in root |
+| Key binding            | Description                    |
+|------------------------+--------------------------------|
+| ~SPC m c~              | create a new multi-term        |
+| ~SPC m C~              | switch multi-term char mode    |
+| ~SPC m l~              | switch multi-term to line mode |
+| ~SPC m n~              | go to next multi-term          |
+| ~SPC m N~ or ~SPC m p~ | go to previous multi-term      |
+| ~SPC p $ t~            | run multi-term shell in root   |
 
 ** Eshell
 

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -165,8 +165,11 @@
       ;; multi-term commands to create terminals and move through them.
       (spacemacs/set-leader-keys-for-major-mode 'term-mode
         "c" 'multi-term
-        "p" 'multi-term-prev
-        "n" 'multi-term-next))))
+        "C" 'term-char-mode
+        "l" 'term-line-mode
+        "n" 'multi-term-next
+        "N" 'multi-term-prev
+        "p" 'multi-term-prev))))
 
 (defun shell/pre-init-org ()
   (spacemacs|use-package-add-hook org


### PR DESCRIPTION
Hi,

I think this change will be positive, as it adheres to the Navigation conventions when users are in hybrid or vim mode.

It also adds shortcuts for term-line-mode and term-char-mode, which are handy for navigating terminal output to both editing styles.
