### PR TITLE
doc: DOCUMENTATION.org: upd Binding keys: add meaningful examples, refer to CONVENTIONS

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1077,12 +1077,12 @@ for that matter. For example, ~SPC a~ points to key bindings for “applications
 like ~SPC a c~ for =calc-dispatch=. Nesting bindings is easy.
 
 #+BEGIN_SRC emacs-lisp
-  (spacemacs/declare-prefix "]" "bracket-prefix")
-  (spacemacs/set-leader-keys "]]" 'double-bracket-command)
+  (spacemacs/declare-prefix "o" "custom")
+  (spacemacs/set-leader-keys "oc" 'my-custom-command)
 #+END_SRC
 
-The first line declares ~SPC ]~ to be a prefix and the second binds the key
-sequence ~SPC ]]~ to the corresponding command. The first line is actually
+The first line declares ~SPC o~ to be a prefix and the second binds the key
+sequence ~SPC oc~ to the corresponding command. The first line is actually
 unnecessary to create the prefix, but it will give your new prefix a name that
 key-discovery tools can use (e.g., which-key).
 

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1036,6 +1036,10 @@ If you don’t create such function then Spacemacs assumes you are using the
 default behavior described above.
 
 * Binding keys
+To be compatibile with all Spacemacs bindings, please refer to [[https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org#key-bindings-conventions][Conventions]].
+In brief, ~SPC o~ reserved for user custom bindings in =global-map=,
+and ~SPC m o~ in major mode.
+
 Key sequences are bound to commands in Emacs in various keymaps. The most basic
 map is the =global-map=. Setting a key binding in the =global-map= is achieved
 with the function =global-set-key=. Example to bind a key to the command

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1086,6 +1086,15 @@ sequence ~SPC oc~ to the corresponding command. The first line is actually
 unnecessary to create the prefix, but it will give your new prefix a name that
 key-discovery tools can use (e.g., which-key).
 
+Example to create binding in major mode:
+
+#+begin_src emacs-lisp
+  (spacemacs/declare-prefix-for-mode 'org-mode "o" "custom")
+  (spacemacs/set-leader-keys-for-major-mode 'org-mode "oi" 'org-id-get-create)
+#+end_src
+
+This would add binding as ~, oi~ and ~SPC moi~.
+
 There is much more to say about bindings keys, but these are the basics. Keys
 can be bound in your =~/.spacemacs= file or in individual layers.
 


### PR DESCRIPTION
In my config was setting major mode custom keys, and had some hustle with it, and seen that the `spacemacs/declare-prefix-for-mode` not mentioned in docs.
Also seen in the internet only few and not particularly great examples, people binding random keys.

It is good to direct user towards `SPC o` & `SPC mo`. And also mention related info in Conventions.