### PR TITLE
Add eval-thing-at-point functions to Common Lisp Layer

### DIFF
--- a/layers/+lang/common-lisp/funcs.el
+++ b/layers/+lang/common-lisp/funcs.el
@@ -32,3 +32,50 @@
   (interactive)
   (move-end-of-line 1)
   (slime-eval-last-expression))
+
+
+
+
+;; Functions are taken from the elisp layer `eval-last-sexp' was replaced with
+;; its slime equivalent `slime-eval-last-expression'
+
+(defun spacemacs/cl-eval-current-form ()
+  "Find and evaluate the current def* or set* command.
+Unlike `eval-defun', this does not go to topmost function."
+  (interactive)
+  (save-excursion
+    (search-backward-regexp "(def\\|(set")
+    (forward-list)
+    (call-interactively 'slime-eval-last-expression)))
+
+
+(defun spacemacs/cl-eval-current-form-sp (&optional arg)
+  "Call `eval-last-sexp' after moving out of one level of
+parentheses. Will exit any strings and/or comments first.
+An optional ARG can be used which is passed to `sp-up-sexp' to move out of more
+than one sexp.
+Requires smartparens because all movement is done using `sp-up-sexp'."
+  (interactive "p")
+  (require 'smartparens)
+  (let ((evil-move-beyond-eol t))
+    ;; evil-move-beyond-eol disables the evil advices around eval-last-sexp
+    (save-excursion
+      (let ((max 10))
+        (while (and (> max 0)
+                    (sp-point-in-string-or-comment))
+          (decf max)
+          (sp-up-sexp)))
+      (sp-up-sexp arg)
+      (call-interactively 'slime-eval-last-expression))))
+
+
+(defun spacemacs/cl-eval-current-symbol-sp ()
+  "Call `eval-last-sexp' on the symbol around point.
+Requires smartparens because all movement is done using `sp-forward-symbol'."
+  (interactive)
+  (require 'smartparens)
+  (let ((evil-move-beyond-eol t))
+    ;; evil-move-beyond-eol disables the evil advices around eval-last-sexp
+    (save-excursion
+      (sp-forward-symbol)
+      (call-interactively 'slime-eval-last-expression))))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -141,7 +141,13 @@
         "si" 'slime
         "sq" 'slime-quit-lisp
 
-        "tf" 'slime-toggle-fancy-trace)
+        "tf" 'slime-toggle-fancy-trace
+
+        ;; Add key bindings for custom eval functions
+        "ec" 'spacemacs/cl-eval-current-form-sp
+        "eC" 'spacemacs/cl-eval-current-form
+        "es" 'spacemacs/cl-eval-current-symbol-sp
+        )
       ;; prefix names for which-key
       (mapc (lambda (x)
               (spacemacs/declare-prefix-for-mode 'lisp-mode (car x) (cdr x)))


### PR DESCRIPTION
(This is the same pull request as #11738; I've messed the old one up, accidentally pushed the wrong branch. 
Sorry for the mess won't happen again.)

Add functions equivalent to the custom eval-functions of the elisp layer to the
common-lisp layer.

The functions are copied from the elisp layer only `eval-last-sexp' was replaced
with its slime equivalent `slime-eval-last-expression'.

Keybindings are chosen as they are in the elisp layer.