### PR TITLE
Fix post-init of parinfer in the clojure layer

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -410,5 +410,8 @@
         (kbd "h") 'sayid-traced-buf-show-help))))
 
 (defun clojure/post-init-parinfer ()
-  (spacemacs|forall-clojure-modes m
+  (dolist (m '(clojure-mode-hook
+               clojurec-mode-hook
+               clojurescript-mode-hook
+               clojurex-mode-hook))
     (add-hook m 'parinfer-mode)))


### PR DESCRIPTION
Reverted `clojure/post-init-parinfer` back to a state before the refactor, which introduced `spacemacs|forall-clojure-modes`. That macro deals with modes, not hooks, therefore we can't use it for `add-hook`.

Fixes #11940.