### PR TITLE
Add `flycheck-package' to `emacs-lip' layer for writing Emacs packages.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1198,6 +1198,7 @@ Other:
 - Disabled nameless by default (thanks to Codruț Constantin Gușoi, Sylvain
   Benner)
 - Activate nameless only in GUI (thanks to Sylvain Benner)
+- Add =flycheck-package= for package metadata linting (thanks to Uroš Perišić)
 **** Emoji
 - Added support for Emoji fonts on macOS and Linux (thanks to CodeFalling )
 - Setup =emojify= cache directory (thanks to Boris Buliga)

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -25,6 +25,7 @@ always be in your dotfile, it is not recommended to uninstall it.
 ** Features:
 - Auto-completion using company
 - Linting using flycheck integration
+- Linting package file metadata using [[https://github.com/purcell/flycheck-package][flycheck-package]]
 - Repl support via =IELM=
 - Support for specific lisp navigation styles via =emacs-lisp-mode=
 - Auto-compile via [[https://github.com/tarsius/auto-compile][auto-compile]] package

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -22,6 +22,7 @@
         evil-cleverparens
         eval-sexp-fu
         flycheck
+        flycheck-package
         ggtags
         counsel-gtags
         helm-gtags
@@ -251,6 +252,12 @@
   ;; Make flycheck recognize packages in loadpath
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))
+
+(defun emacs-lisp/init-flycheck-package ()
+  (use-package flycheck-package
+    :defer t
+    :init (with-eval-after-load 'flycheck
+            (flycheck-pos-tip-mode))))
 
 (defun emacs-lisp/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'emacs-lisp-mode))


### PR DESCRIPTION
For those with MELPA on their mind. It's easier to work when packaging errors
are reported on the fly, and we don't even have `package-lint` integration for
occasional checkups yet.

It adds no unnecessary verbosity as it is only triggered by `Package-Requires`
and `Package-Version` headers.