### PR TITLE
FAQ: Set sentence-end-double-space in user-config

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -455,7 +455,7 @@ management), you can use this:
 
 ** Restore the sentence delimiter to two spaces?
 To restore the sentence delimiter to two spaces, add the following code to the
-=dotspacemacs/user-init= function of your =.spacemacs=:
+=dotspacemacs/user-config= function of your =.spacemacs=:
 
 #+BEGIN_SRC emacs-lisp
   (setq sentence-end-double-space t)


### PR DESCRIPTION
The FAQ has an entry for configuring Spacemacs to use double-space as the sentence delimiter.  This FAQ entry instructs the reader to set the `sentence-end-double-space` variable in the `dotspacemacs/user-init` function.

The problem is that the spacemacs-defaults layer sets `sentence-end-double-space` when it loads, and Spacemacs loads layers after calling `dotspacemacs/user-init`, which means the layer overrides any setting for `sentence-end-double-space` in `dotspacemacs/user-init`.

To solve this problem, this commit modifies the FAQ entry to instruct the reader to set the variable in the `dotspacemacs/user-config` function, which Spacemacs runs after loading layers.

The FAQ entry was added in https://github.com/syl20bnr/spacemacs/pull/3835.

* `doc/FAQ.org`: Instruct the reader to set `sentence-end-double-space` in `dotspacemacs/user-init` rather than in `dotspacemacs/user-config`.