### PR TITLE
wip: Disable evil-escape-mode in evil-mc-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1627,6 +1627,7 @@ Other:
 **** Multiple Cursors
 - Disabled Spacemacs paste transient state when pasting to avoid pasting issue
   when there are more than one cursor (thanks to braham-snyder)
+- Disabled =evil-escape= minor mode in =evil-mc-mode=.
 **** Neotree
 - Made neotree an optional instead of a default layer
 - Move neotree to its own layer in new +filetree folder (thanks to Sylvain

--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -24,6 +24,11 @@
       (when (or (spacemacs/system-is-mac) (spacemacs/system-is-mswindows))
         (setq evil-mc-enable-bar-cursor nil))
 
+      ;; evil-mc is not compatible with evil-escape
+      (add-hook 'evil-mc-mode-hook
+                #'(lambda ()
+                    (add-to-list 'evil-mc-incompatible-minor-modes
+                                 'evil-escape-mode)))
       ;; evil-mc is not compatible with the paste transient state
       (define-key evil-normal-state-map "p" 'spacemacs/evil-mc-paste-after)
       (define-key evil-normal-state-map "P" 'spacemacs/evil-mc-paste-before)


### PR DESCRIPTION
Disable `evil-escape-mode` in `evil-mc-mode` since it doesn't work.