### PR TITLE
Don't activate flycheck-pos-tip-mode when loading emacs-lisp-layer.

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -255,9 +255,7 @@
 
 (defun emacs-lisp/init-flycheck-package ()
   (use-package flycheck-package
-    :defer t
-    :init (with-eval-after-load 'flycheck
-            (flycheck-pos-tip-mode))))
+    :defer t))
 
 (defun emacs-lisp/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'emacs-lisp-mode))


### PR DESCRIPTION
The `emacs-lisp` layer explicitly enables` flycheck-pos-tip-mode`. However, this should be owned by the `syntax-checking` layer.