### PR TITLE
[ietf layer] Add RFC files to the auto-mode-alist to use irfc-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -295,7 +295,7 @@ Benner and Paweł Siudak):
 - crystal (thanks to Sylvain Benner)
 - dart (thanks to Bruno Tavares)
 - dhall (thanks to Colin Woodbury)
-- ietf (thanks to Christian Hopps)
+- ietf (thanks to Christian Hopps and Robby O'Connor)
 - factor (thanks to timor)
 - forth (thanks to Tim Jaeger)
 - gpu (thanks to Evan Klitzke)

--- a/layers/+misc/ietf/packages.el
+++ b/layers/+misc/ietf/packages.el
@@ -33,7 +33,11 @@
       (add-to-list 'auto-mode-alist
                    '("/draft-\\([a-z0-9_]+-\\)+[0-9]+.txt" . irfc-mode))
       (add-to-list 'auto-mode-alist
-                   '("/draft-\\([a-z0-9_]+-\\)+[a-z0-9_]+.txt" . irfc-mode)))))
+                   '("/draft-\\([a-z0-9_]+-\\)+[a-z0-9_]+.txt" . irfc-mode))
+      (add-to-list 'auto-mode-alist
+                   '("/rfc-\\([a-z0-9_]+-\\).txt" . irfc-mode)))))
+
+
 
 (defun ietf/pre-init-ox-rfc ()
   (spacemacs|use-package-add-hook org :post-config (require 'ox-rfc)))


### PR DESCRIPTION
the pattern for RFC files from the ietf wasn't setting up the irfc-mode, set it up so it did. 