### PR TITLE
[c++] dap layer integration

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -977,6 +977,7 @@ Other:
   - Control auto-newline using the =c-c++-enable-auto-newline= variable
     (thanks to Fangrui Song and Codruț Constantin Gușoi)
   - Added =org-babel= support (thanks to Michael Rohleder)
+  - Added debugger integration via =dap= layer
 - Key bindings:
   - ~SPC m = =~ clang-format current region or buffer (thanks to Dela Anthonio)
   - ~SPC m = f~ clang-format current function (thanks to Dela Anthonio)

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -17,6 +17,7 @@
       - [[#external-dependencies-1][External dependencies]]
       - [[#configuration-1][Configuration]]
       - [[#completion][Completion]]
+      - [[#debugger-dap-integration][Debugger (dap integration)]]
   - [[#clang-configuration][Clang Configuration]]
     - [[#clang-format][clang-format]]
     - [[#company-clang-and-flycheck][Company-clang and flycheck]]
@@ -31,6 +32,7 @@
     - [[#goto][goto]]
       - [[#gotohierarchy][goto/hierarchy]]
       - [[#gotomember][goto/member]]
+  - [[#debugger][debugger]]
 
 * Description
 This layer adds configuration for C/C++ language.
@@ -182,6 +184,8 @@ They have good default values. See =config.el= of the layer and the backends’ 
 **** Completion
 =company-lsp= provides completion functionality. Client-side cache and sorting have been disabled in favour of server,
 as recommended by =cquery=/=ccls= wikis.
+**** Debugger (dap integration)
+To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are on Linux or download it manually from [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][Native Debug]] and adjust =dap-gdb-lldb-path=.
 
 ** Clang Configuration
 To enable Clang support, set the layer variable =c-c++-enable-clang-support=
@@ -363,3 +367,49 @@ A ~[ccls]~ or ~[cquery]~ suffix indicates that the binding is for the indicated 
 | ~SPC m g m t~ | member types [ccls]     |
 | ~SPC m g m f~ | member functions [ccls] |
 | ~SPC m g m v~ | member variables [ccls] |
+** debugger
+
+| Key binding   | Description                     |
+|---------------+---------------------------------|
+| ~SPC m d d d~ | start debugging                 |
+| ~SPC m d d l~ | debug last configuration        |
+| ~SPC m d d r~ | debug recent configuration      |
+|---------------+---------------------------------|
+| ~SPC m d c~   | continue                        |
+| ~SPC m d i~   | step in                         |
+| ~SPC m d o~   | step out                        |
+| ~SPC m d s~   | next step                       |
+| ~SPC m d v~   | inspect value at point          |
+| ~SPC m d r~   | restart frame                   |
+|---------------+---------------------------------|
+| ~SPC m d .~   | debug transient state           |
+|---------------+---------------------------------|
+| ~SPC m d a~   | abandon current session         |
+| ~SPC m d A~   | abandon all process             |
+|---------------+---------------------------------|
+| ~SPC m d e e~ | eval                            |
+| ~SPC m d e r~ | eval region                     |
+| ~SPC m d e t~ | eval value at point             |
+|---------------+---------------------------------|
+| ~SPC m d S s~ | switch session                  |
+| ~SPC m d S t~ | switch thread                   |
+| ~SPC m d S f~ | switch frame                    |
+|---------------+---------------------------------|
+| ~SPC m d I i~ | inspect                         |
+| ~SPC m d I r~ | inspect region                  |
+| ~SPC m d I t~ | inspect value at point          |
+|---------------+---------------------------------|
+| ~SPC m d b b~ | toggle a breakpoint             |
+| ~SPC m d b c~ | change breakpoint condition     |
+| ~SPC m d b l~ | change breakpoint log condition |
+| ~SPC m d b h~ | change breakpoint hit count     |
+| ~SPC m d b a~ | add a breakpoint                |
+| ~SPC m d b d~ | delete a breakpoint             |
+| ~SPC m d b D~ | clear all breakpoints           |
+|---------------+---------------------------------|
+| ~SPC m d '_~  | Run debug REPL                  |
+|---------------+---------------------------------|
+| ~SPC m d w l~ | list local variables            |
+| ~SPC m d w o~ | goto output buffer if present   |
+| ~SPC m d w s~ | list sessions                   |
+| ~SPC m d w b~ | list breakpoints                |

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -228,7 +228,6 @@ and the arguments for flyckeck-clang based on a project-specific text file."
 (defun spacemacs//c-c++-lsp-config ()
   "Configure the LSP backend specified by the `c-c++-backend' configuration variable."
     (progn
-      (remhash 'clangd lsp-clients)
       (spacemacs//c-c++-lsp-define-extensions)
       (spacemacs//c-c++-lsp-wrap-functions)
       (setq-default flycheck-disabled-checkers '(c/c++-clang c/c++-gcc))
@@ -266,7 +265,14 @@ and the arguments for flyckeck-clang based on a project-specific text file."
 
       (evil-set-initial-state '(spacemacs//c-c++-lsp-symbol nil "-tree-mode") 'emacs)
       ;;evil-record-macro keybinding clobbers q in cquery-tree-mode-map for some reason?
-      (evil-make-overriding-map (symbol-value (spacemacs//c-c++-lsp-symbol nil "-tree-mode-map")))))
+      (evil-make-overriding-map (symbol-value (spacemacs//c-c++-lsp-symbol nil "-tree-mode-map")))
+
+      (if (configuration-layer/layer-used-p 'dap)
+          (progn
+            (require 'dap-gdb-lldb)
+            (dolist (mode c-c++-modes)
+              (spacemacs/dap-bind-keys-for-mode mode)))
+        (message "`dap' layer is not installed, please add `dap' layer to your dotfile."))))
 
 (defun spacemacs//c-c++-lsp-wrap-functions ()
   "Wrap navigation functions for the LSP backend specified by the `c-c++-backend' configuration variable."


### PR DESCRIPTION
- in addition to that I have removed the line that removes clangd from the
server list since it is not needed in latest lsp-mode since it has smaller
priority than ccls/cquery.
