### PR TITLE
Updated keybindings for dap-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1581,6 +1581,9 @@ Other:
 - Added package =helm-lsp=
   - ~SPC m g s~ to find symbol in current project
   - ~SPC m g S~ to find symbol in all projects
+**** Debug Adapter Protocol (DAP)
+- Key bindings
+  - ~SPC m d d e~ to edit debug template
 **** Markdown
 - New layer variable =markdown-mmm-auto-modes= which is a list of language names
   or lists of language and mode names that are supported in source blocks, you

--- a/layers/+tools/dap/README.org
+++ b/layers/+tools/dap/README.org
@@ -62,6 +62,7 @@ The default bindings are listed below. Derived layers should extend this list:
 
 | Key binding   | Description                     |
 |---------------+---------------------------------|
+| ~SPC m d d e~ | edit debug template             |
 | ~SPC m d d d~ | start debugging                 |
 | ~SPC m d d l~ | debug last configuration        |
 | ~SPC m d d r~ | debug recent configuration      |

--- a/layers/+tools/dap/funcs.el
+++ b/layers/+tools/dap/funcs.el
@@ -22,6 +22,7 @@
 
   (spacemacs/set-leader-keys-for-major-mode mode
     ;; debuging/running
+    "dde" #'dap-debug-edit-template
     "ddd" #'dap-debug
     "ddl" #'dap-debug-last
     "ddr" #'dap-debug-recent


### PR DESCRIPTION
- dap-debug-edit-template is very important for some of the debug adapters so it
  is important to have a keybinding for it to improve the discoverability

