### PR TITLE
Bind ~SPC f F~ to =helm-find= for recursive directory search.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1411,6 +1411,7 @@ Other:
   removed upstream.
 - Load helm before read-file-name and completing-read (thanks duianto and thanks
   Miciah for a more elegant solution)
+- Bind ~SPC f F~ to =helm-find= for recursive directory search.
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Added =counsel-css= as an =ivy= alternative to =helm-css-scss= (thanks to Robbert

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -85,7 +85,7 @@
       (spacemacs||set-helm-key "bb"   helm-mini)
       (spacemacs||set-helm-key "Cl"   helm-colors)
       (spacemacs||set-helm-key "ff"   spacemacs/helm-find-files)
-      (spacemacs||set-helm-key "fF"   helm-find-files)
+      (spacemacs||set-helm-key "fF"   helm-find)
       (spacemacs||set-helm-key "fL"   helm-locate)
       (spacemacs||set-helm-key "fr"   helm-recentf)
       (spacemacs||set-helm-key "hda"  helm-apropos)


### PR DESCRIPTION
I realize this may be controversial, but as I understand it (correct me if I'm
wrong), all `SPC f F` does differently compared to `SPC f f` is call the vanilla
version of `helm-find-files` that does take `thing-at-point` into account. But I
presume we removed this feature in `spacemacs/helm-find-files` for a reason.

Also, it makes sense as a *forte* version of `helm-find-files` when you can't
find something in your current directory and decide to drill deeper. This
complies with the general tone of uppercase/lowercase bindings in Spacemacs, and
provides more utility than te subtle distinction between different
implementations of `helm-find-files`.