### PR TITLE
[clojure] keybinding - cider-undef - remove symbol from current ns

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1058,6 +1058,7 @@ Other:
   - ~SPC m r c :~ to toggle between a keyword and a string (thanks to John
     Stevenson)
   - ~SPC m s X~ to restart the REPL (thanks to James Conroy-Finn)
+  - ~SPC m e u~ undefine symbol in the current namespace (thanks to John Stevenson)
 - Fixes:
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key
     binding (thanks to Brian Fay)

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -241,6 +241,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e M~ | cider macroexpand all                                     |
 | ~SPC m e p~ | print last sexp (clojure interaction mode only)           |
 | ~SPC m e P~ | eval last sexp and pretty print result in separate buffer |
+| ~SPC m e u~ | Undefine a symbol from the current namespace              |
 | ~SPC m e w~ | eval last sexp and replace with result                    |
 
 *** Goto

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -85,6 +85,7 @@
             "eM" 'cider-macroexpand-all
             "eP" 'cider-pprint-eval-last-sexp
             "er" 'cider-eval-region
+            "eu" 'cider-undef
             "ew" 'cider-eval-last-sexp-and-replace
 
             "="  'cider-format-buffer


### PR DESCRIPTION
Adds `SPC m e u` to the Clojure layer to call `cider-undef`, a function that remove an
existing definition from the current namespace.

This provides a Spacemacs style keybinding for the existing Emacs style keybinding `C-c C-u`