### PR TITLE
[org] Add agenda transient keybinding for org-agenda-show-clocking-issues

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -659,6 +659,7 @@ are listed bellow.
 | ~tl~        | log                 | org-agenda-log-mode               |
 | ~ta~        | archive             | org-agenda-archives-mode          |
 | ~tr~        | clock report        | org-agenda-clockreport-mode       |
+| ~tc~        | clocking issues     | org-agenda-show-clocking-issues   |
 | ~td~        | diaries             | org-agenda-toggle-diary           |
 |-------------+---------------------+-----------------------------------|
 | View        |                     |                                   |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -456,8 +456,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
 [_hk_] kill           [_TAB_] & go to location    [_fr_] refine by tag        [_dS_] un-schedule      [_tl_] log           [_vw_] week        [_cO_] out     [_._]  go to today
 [_hr_] refile         [_RET_] & del other windows [_fc_] by category          [_dd_] set deadline     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
 [_hA_] archive        [_o_]   link                [_fh_] by top headline      [_dD_] remove deadline  [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
-[_h:_] set tags       ^^                          [_fx_] by regexp            [_dt_] timestamp        [_td_] diaries       [_vy_] year        ^^             ^^
-[_hp_] set priority   ^^                          [_fd_] delete all filters   [_+_]  do later         ^^                   [_vn_] next span   ^^             ^^
+[_h:_] set tags       ^^                          [_fx_] by regexp            [_dt_] timestamp        [_tc_] clock issues  [_vy_] year        ^^             ^^
+[_hp_] set priority   ^^                          [_fd_] delete all filters   [_+_]  do later         [_td_] diaries       [_vn_] next span   ^^             ^^
 ^^                    ^^                          ^^                          [_-_]  do earlier       ^^                   [_vp_] prev span   ^^             ^^
 ^^                    ^^                          ^^                          ^^                      ^^                   [_vr_] reset       ^^             ^^
 [_q_] quit
@@ -506,6 +506,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         ("tl" org-agenda-log-mode)
         ("ta" org-agenda-archives-mode)
         ("tr" org-agenda-clockreport-mode)
+        ("tc" org-agenda-show-clocking-issues)
         ("td" org-agenda-toggle-diary)
 
         ;; Filter


### PR DESCRIPTION
As documented upstream [1], the `org-agenda-show-clocking-issues` view can be
used to show overlapping clocks, gaps, etc. on the agenda, and is bound by
default to `v c`. This commit adds a keybinding it in the org-agenda transient mode.

This may not be the best place for it, because it isn't a proper toggle;
upstream says to clear the issues flags by toggling logbook mode itself and does
not provide a clocking issues toggle directly.

[1] https://orgmode.org/manual/Agenda-commands.html#Agenda-commands