### PR TITLE
javascript, typescript and react layers: linter option, next-error-function fix

### DIFF
--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -47,6 +47,9 @@ If your project do not use a custom =.eslintrc= file I strongly advice you to
 try out this one by Airbnb:
 [[https://github.com/airbnb/javascript/blob/master/linters/.eslintrc][.eslintrc]]
 
+When =lsp= is set as the backend, but you don't want to use lsp as the linter, set the variable
+=javascript-lsp-linter= to =nil= in the Javascript layer.
+
 React layer uses the same formatter defined in javascript layer. Options are
 =web-beautify= and =prettier=.
 To use automatic code formatting you need to install ~js-beautify~ or ~prettier~

--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -23,12 +23,20 @@
     (`tern (spacemacs/tern-setup-tern-company 'rjsx-mode))
     (`lsp (spacemacs//react-setup-lsp-company))))
 
+(defun spacemacs//react-setup-next-error-fn ()
+  "If the `syntax-checking' layer is enabled, disable `rjsx-mode''s
+`next-error-function', and let `flycheck' handle any errors."
+  (when (configuration-layer/layer-used-p 'syntax-checking)
+    (setq-local next-error-function nil)))
 
 ;; LSP
 (defun spacemacs//react-setup-lsp ()
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
-      (lsp)
+      (progn
+        (when (not javascript-lsp-linter)
+          (setq-local lsp-prefer-flymake :none))
+        (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
 (defun spacemacs//react-setup-lsp-company ()

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -70,6 +70,8 @@
 
     ;; setup rjsx backend
     (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-setup-backend)
+    ;; set next-error-function to nil because we use flycheck
+    (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-setup-next-error-fn)
 
     :config
     ;; declare prefix

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -106,6 +106,13 @@ Backend can be chosen on a per project basis using directory local variables
   ((js2-mode (javascript-backend . lsp)))
 #+END_SRC
 
+When =lsp= is set as the backend, but you don't want to use lsp as the linter, set the variable =javascript-lsp-linter= to =nil=.
+
+#+BEGIN_SRC elisp
+   (javascript :variables
+               javascript-backend 'lsp
+               javascript-lsp-linter nil)
+#+END_SRC
 ** Choosing a formatter
 To choose a formatter, set the layer variable =javascript-fmt-tool=:
 

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -27,3 +27,7 @@
 
 (defvar javascript-repl 'skewer
   "Repl to be configured by the layer, `skewer' for browser based javascript, `nodejs' for server based development.")
+
+(defvar javascript-lsp-linter t
+  "If the backend is `lsp', and this variable is non-nil, then use lsp as the linter, otherwise
+let flycheck choose the best linter that's available.")

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -24,6 +24,11 @@
     (`tern (spacemacs//javascript-setup-tern-company))
     (`lsp (spacemacs//javascript-setup-lsp-company))))
 
+(defun spacemacs//javascript-setup-next-error-fn ()
+  "If the `syntax-checking' layer is enabled, then disable `js2-mode''s
+`next-error-function', and let `flycheck' handle any errors."
+  (when (configuration-layer/layer-used-p 'syntax-checking)
+    (setq-local next-error-function nil)))
 
 ;; lsp
 
@@ -31,6 +36,8 @@
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
+        (when (not javascript-lsp-linter)
+          (setq-local lsp-prefer-flymake :none))
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile.")))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -79,6 +79,7 @@
     :init
     (progn
       (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
+      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-next-error-fn)
       ;; safe values for backend to be used in directory file variables
       (dolist (value '(lsp tern))
         (add-to-list 'safe-local-variable-values

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -149,6 +149,16 @@ restart server after editing it.
 You also need to install the Typescript Language Server.
 Consult the installation command for the desired language server found at [[https://www.github.com/emacs-lsp/lsp-mode/][lsp-mode]] for instructions.
 
+By default lsp will explicitly set itself as the linter, if you don't want that, then set
+the variable =typescript-lsp-linter= to `nil'.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (typescript :variables
+                typescript-backend 'lsp
+                typescript-lsp-linter nil)))
+#+END_SRC
+
 * Key bindings
 ** Typescript Major Mode
 

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -25,5 +25,9 @@ Currently avaliable 'tide (default), 'typescript-formatter and 'prettier.")
 (defvar typescript-linter 'tslint
   "The linter to use for typescript. Possible values are `tslint' `eslint'")
 
+(defvar typescript-lsp-linter t
+  "If the backend is `lsp', and this variable is non-nil, then use lsp as the linter, otherwise
+let flycheck choose the best linter that's available.")
+
 (spacemacs|define-jump-handlers typescript-mode)
 (spacemacs|define-jump-handlers typescript-tsx-mode)

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -61,7 +61,10 @@
 (defun spacemacs//typescript-setup-lsp ()
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
-      (lsp)
+      (progn
+        (when (not typescript-lsp-linter)
+          (setq-local lsp-prefer-flymake :none))
+        (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
 


### PR DESCRIPTION
this PR does two things for js-related layers:

(i) add option to disable lsp linter
javascript-lsp-linter for javascript and react layers
typescript-lsp-linter for typescript layer
when the value is t, lsp linter will be used in the layer
when nil, let flycheck pick up the best linters available such
as eslint

(ii) when syntax-checking(flycheck) layer is installed, then set
next-error-function value in react and javascript layers to nil, so that
spacemacs next-error, previous-error work A desciption of this issue can be
found at https://github.com/syl20bnr/spacemacs/issues/8078
