### PR TITLE
[core] fix spacemacs/error-delegate

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -340,8 +340,7 @@ current frame."
 Delegates to flycheck if it is enabled and the next-error buffer
 is not visible. Otherwise delegates to regular Emacs next-error."
   (if (and (bound-and-true-p flycheck-mode)
-           (let ((buf (ignore-errors (next-error-find-buffer))))
-             (not (and buf (get-buffer-window buf)))))
+           (not next-error-function))
       'flycheck
     'emacs))
 


### PR DESCRIPTION
Determine flycheck or emacs error backend using next-error-function instead of
next-error-find-buffer

Currently `spacemacs/error-delegate` uses `next-error-find-buffer` to determine error backends

``` elisp
(defun spacemacs/error-delegate ()
  "Decide which error API to delegate to.
Delegates to flycheck if it is enabled and the next-error buffer
is not visible. Otherwise delegates to regular Emacs next-error."
  (if (and (bound-and-true-p flycheck-mode)
           (let ((buf (ignore-errors (next-error-find-buffer))))
             (not (and buf (get-buffer-window buf)))))
      'flycheck
    'emacs))
```
The problem is that `next-error-find-buffer` seems to look for all opened buffers not the current buffer of interest. This leads to false error call when you also have a org-mode buffer opened in another window. Because of org-mode's design `next-error-find-buffer always returns positive on org-mode buffer like this one https://github.com/syl20bnr/spacemacs/issues/9255

I propose to use the local var next-error-function instead, for a buffer if this var is set then the buffer 
errors are handled by emacs, otherwise try flycheck. The change would be:
```elisp
(defun spacemacs/error-delegate ()
  "Decide which error API to delegate to.
Delegates to flycheck if it is enabled and the next-error buffer
is not visible. Otherwise delegates to regular Emacs next-error."
  (if (and (bound-and-true-p flycheck-mode)
            (not next-error-function))
      'flycheck
    'emacs))

```

Previous discussion: https://github.com/syl20bnr/spacemacs/issues/6639

`next-error-function` doc string
```
  Automatically becomes buffer-local when set.
  This variable may be risky if used as a file-local variable.

Documentation:
Function to use to find the next error in the current buffer.
The function is called with 2 parameters:
ARG is an integer specifying by how many errors to move.
RESET is a boolean which, if non-nil, says to go back to the beginning
of the errors before moving.
Major modes providing compile-like functionality should set this variable
to indicate to ‘next-error’ that this is a candidate buffer and how
to navigate in it.

```