### PR TITLE
[multiple-cursors] Update key bind doc according to evil-mc changes

### DIFF
--- a/layers/+misc/multiple-cursors/README.org
+++ b/layers/+misc/multiple-cursors/README.org
@@ -44,7 +44,8 @@ The =evil-mc= package provides the following key bindings:
 | ~g r P~     | evil-mc-skip-and-goto-prev-cursor  |
 | ~g r r~     | evil-mc-resume-cursors             |
 | ~g r s~     | evil-mc-pause-cursors              |
-| ~g r u~     | evil-mc-undo-all-cursors           |
+| ~g r q~     | evil-mc-undo-all-cursors           |
+| ~g r u~     | evil-mc-undo-last-added-cursor     |
 
 For easy navigation you also have the following:
 


### PR DESCRIPTION
Commit gabesoft/evil-mc@041b9044755a633b7d4d1275822b4785ed0ea5c0 changed
the default key bind of `g r u` to a different (new) function. The old
behaviour is now available at `g r q`.