### PR TITLE
Typescript: make linter configurable between tslint/eslint

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2336,6 +2336,7 @@ Other:
 - Fixed jump handling with multiple backends (thanks to Aaron Jensen)
 - Fixed =typescript/jump-to-type-def= for npm modules (thanks to Jam Risser)
 - Added the same setup to tsx files as to ts files (thanks to Trapez Breen)
+- Added configurable =typescript= linter parameter so that users can migrate to eslint
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -26,7 +26,7 @@ This layer adds support for TypeScript and TSX editing.
 - Eldoc-mode
 - Documentation at point
 - Auto complete
-- Flycheck with linter
+- Flycheck with either tslint or eslint
 - Jump to definition, Jump to type definition
 - Find occurrences (Imenu-mode)
 - Rename symbol
@@ -61,14 +61,36 @@ You can choose formatting tool:
 
 Default is ='tide=.
 
+You can choose either tslint (default) or eslint for linting:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (typescript :variables
+                typescript-linter 'tslint)))
+#+END_SRC
+
+
 ** Pre-requisites
 You will need =node.js v0.12.0= or greater.
 
-If you want linting run:
+If you want linting with tslint run:
 
 #+BEGIN_SRC shell
   npm install -g typescript tslint
 #+END_SRC
+
+If you want linting with eslint run:
+
+#+BEGIN_SRC shell
+  npm install eslint
+#+END_SRC
+
+We need to use the project-local eslint installation in order to pick up plugins
+and presets installed locally.
+
+Ensure that the project directory =node_modules/.bin= is added to the buffer 
+local =exec_path= (see the Javascript layer [[file:~/.emacs.d/layers/+lang/javascript/README.org][README]] documentation for more 
+details).
 
 If you want to use typescript-formatter for formatting run:
 

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -22,5 +22,8 @@ Currently avaliable 'tide (default), 'typescript-formatter and 'prettier.")
   "The backend to use for IDE features. Possible values are `tide'
 +and `lsp'.")
 
+(defvar typescript-linter 'tslint
+  "The linter to use for typescript. Possible values are `tslint' `eslint'")
+
 (spacemacs|define-jump-handlers typescript-mode)
 (spacemacs|define-jump-handlers typescript-tsx-mode)

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -37,13 +37,39 @@
                    '(typescript-mode-local-vars-hook
                      typescript-tsx-mode-local-vars-hook) t))
 
+(defun typescript/set-tide-linter ()
+  (with-eval-after-load 'tide
+    (with-eval-after-load 'flycheck
+        (cond ((eq typescript-linter `tslint)
+              (progn
+                (flycheck-add-mode 'typescript-tide 'typescript-tsx-mode)
+                (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode)))
+              ((eq typescript-linter `eslint)
+              (progn
+                (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
+                (flycheck-add-mode 'javascript-eslint 'typescript-mode)
+                (add-to-list 'flycheck-disabled-checkers 'typescript-tslint)
+                (flycheck-disable-checker 'typescript-tslint)
+                (flycheck-add-mode 'tsx-tide 'typescript-tsx-mode)
+                (flycheck-add-next-checker 'typescript-tide 'javascript-eslint 'append)
+                (flycheck-add-next-checker 'tsx-tide 'javascript-eslint 'append)))
+              (t
+                (message
+                "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))))
+
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)
   (spacemacs/enable-flycheck 'typescript-tsx-mode)
-  (with-eval-after-load 'tide
-    (with-eval-after-load 'flycheck
-      (flycheck-add-mode 'typescript-tide 'typescript-tsx-mode)
-      (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))))
+  (cond ((eq typescript-backend `tide)
+         (progn (typescript/set-tide-linter)))
+        ((eq typescript-backend `lsp)
+         (with-eval-after-load 'lsp-ui
+         (with-eval-after-load 'flycheck
+           (progn
+         (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
+         (flycheck-add-mode 'javascript-eslint 'typescript-mode)
+         (flycheck-add-next-checker 'lsp-ui 'javascript-eslint 'append)
+         ))))))
 
 (defun typescript/post-init-smartparens ()
   (if dotspacemacs-smartparens-strict-mode


### PR DESCRIPTION
As tslint is being deprecated (see palantir/tslint#4534), it would be a good idea to support linting with eslint in typescript mode, this PR enables that.