### PR TITLE
Various improvements when indent code

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -821,7 +821,9 @@ Other:
   - Added =go-run-args= to pass command line arguments to `go run`
   - Editing: Enable smartparens in eldoc-eval-expression
     (thanks to Aaron Jensen)
-  - Check for universal argument before paste (thanks to Bet4)
+  - Check for universal argument before paste (thanks to bet4it)
+  - New variable =spacemacs-yank-indent-modes= to enable auto indent in modes
+    not derived from =prog-mode= (thanks to bet4it)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers (thanks to Sylvain
     Benner)
@@ -1596,6 +1598,8 @@ Other:
   buffers, see README.org for more info (thanks to benquebec)
 - Put magic-latex-buffer in TeX-update-style-hook instead of LaTeX-mode-hook
   (thanks to Matt Kramer)
+- Enable auto indent when paste. Remote =latex-mode= from
+  =spacemacs-yank-indent-modes= to disable it (thanks to bet4it)
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 **** Language Server Protocol (LSP)


### PR DESCRIPTION
This pull request includes various improvements when indent code:
- When we use `spacemacs/indent-region-or-buffer` ( <kbd>SPC j =</kbd> ) to indent region or buffer explicitly, don't check for `spacemacs-indent-sensitive-modes`.
- Make variable `spacemacs-indent-sensitive-modes` customized.
- New variable `spacemacs-yank-indent-modes` to enable auto indent in modes not derived from `prog-mode`. Set default value to `latex-mode`.

This pull request also changes the behavior of `spacemacs//yank-indent-region`. This function was taken from `Prelude`, but there are some errors when imported it, which has already been pointed out in https://github.com/syl20bnr/spacemacs/pull/1485#issuecomment-335436702. And it is ambiguous when we trigger <kbd>C-u C-y</kbd> ( details described in https://github.com/syl20bnr/spacemacs/pull/11340#issue-216498370 ). This pull request changes this function's  behavior to:

- When current mode should be auto indented when paste:
  - <kbd>p</kbd> in evil mode or <kbd>C-y</kbd> in emacs mode: paste code with indentation.
  - <kbd>SPC u p</kbd> in evil mode or <kbd>C-u C-y</kbd> in emacs mode: paste code without indentation.

- When current mode shouldn't be auto indented when paste:
  - <kbd>p</kbd> in evil mode or <kbd>C-y</kbd> in emacs mode: paste code with normal behavior.
  - <kbd>C-u C-y</kbd> in emacs mode: paste code and put point at beginning, as what vanilla emacs do.
  - <kbd>SPC u p</kbd> in evil mode: undefined behavior as what vanilla evil mode do.

This pull request also fixes a bug in #11340. Close #12237.