### PR TITLE
Add support in `+lang/ocaml` for `dune`.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1773,6 +1773,7 @@ Other:
 - Enabled flycheck-ocaml (thanks to Dave Aitken)
 - Fixed backspace delete (thanks to Hasan Alirajpurwala)
 - Fixed flycheck-ocaml not initialized warning (thanks to Artur Juraszek)
+- Added =dune= support via =dune-mode= (thanks to Lyman Gillispie)
 **** Org
 - Load org-mode email integration (mu4e/notmuch) when org is loaded
   (thanks to Steven Allen)

--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -13,6 +13,7 @@
   - [[#opam-packages][OPAM packages]]
 - [[#key-bindings][Key bindings]]
   - [[#repl-utop][REPL (utop)]]
+  - [[#dune][Dune]]
 - [[#layer-improvements-list][layer improvements list]]
 
 * Description
@@ -23,6 +24,7 @@ This is a very basic layer for editing ocaml files.
 - Error reporting, completion and type display via [[https://github.com/ocaml/merlin][merlin]]
 - auto-completion with company mode via [[https://github.com/ocaml/merlin][merlin]]
 - syntax-checking via [[https://github.com/flycheck/flycheck-ocaml][flycheck-ocaml]] (or alternatively [[https://github.com/ocaml/merlin][merlin]])
+- =dune= file syntax highlighting and template insertion via [[https://github.com/ocaml/dune/][dune-mode]]
 
 * Install
 ** Layer
@@ -82,6 +84,8 @@ Make sure opam is initialized and configured.
 | ~SPC m h t~ | Highlight identifier under cursor and print its type     |
 | ~SPC m h T~ | Prompt for expression and show its type                  |
 | ~SPC m r d~ | Case analyze the current enclosing                       |
+| ~SPC m t p~ | Dune run tests and promote.                              |
+| ~SPC m t P~ | Dune promote.                                            |
 
 ** REPL (utop)
 
@@ -96,6 +100,27 @@ Make sure opam is initialized and configured.
 | ~SPC m s R~ | Send region to the REPL and switch to the REPL in =insert state= |
 | ~C-j~       | (in REPL) next item in history                                   |
 | ~C-k~       | (in REPL) previous item in history                               |
+
+** Dune
+
+| Key binding | Description                    |
+|-------------+--------------------------------|
+| ~SPC m c c~ | Compile.                       |
+| ~SPC m i l~ | Insert ~library~ stanza.       |
+| ~SPC m i e~ | Insert ~executable~ stanza.    |
+| ~SPC m i x~ | Insert ~executables~ stanza.   |
+| ~SPC m i r~ | Insert ~rule~ stanza.          |
+| ~SPC m i p~ | Insert ~ocamllex~ stanza.      |
+| ~SPC m i y~ | Insert ~ocamlyacc~ stanza.     |
+| ~SPC m i m~ | Insert ~menhir~ stanza.        |
+| ~SPC m i a~ | Insert ~alias~ stanza.         |
+| ~SPC m i i~ | Insert ~install~ stanza.       |
+| ~SPC m i c~ | Insert ~copyfiles~ stanza.     |
+| ~SPC m i t~ | Insert ~tests~ stanza.         |
+| ~SPC m i v~ | Insert ~env~ stanza.           |
+| ~SPC m i d~ | Insert ignored subdirs stanza. |
+| ~SPC m t p~ | Dune run tests and promote.    |
+| ~SPC m t P~ | Dune promote.                  |
 
 * TODO layer improvements list
 1. Add more proper spacemacs key bindings for basic merlin tasks

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -13,6 +13,7 @@
       '(
         ;; auto-complete
         company
+        dune
         flycheck
         (flycheck-ocaml :toggle (configuration-layer/layer-used-p 'syntax-checking))
         ggtags
@@ -31,6 +32,38 @@
       :backends merlin-company-backend
       :modes merlin-mode
       :variables merlin-completion-with-doc t)))
+
+(defun ocaml/init-dune ()
+  (use-package dune
+    :defer t
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+        "tP" 'dune-promote
+        "tp" 'dune-runtest-and-promote)
+      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mt" "test")
+      (spacemacs/set-leader-keys-for-major-mode 'dune-mode
+        "il" 'dune-insert-library-form
+        "ie" 'dune-insert-executable-form
+        "ix" 'dune-insert-executables-form
+        "ir" 'dune-insert-rule-form
+        "ip" 'dune-insert-ocamllex-form
+        "iy" 'dune-insert-ocamlyacc-form
+        "im" 'dune-insert-menhir-form
+        "ia" 'dune-insert-alias-form
+        "ii" 'dune-insert-install-form
+        "ic" 'dune-insert-copyfiles-form
+        "it" 'dune-insert-tests-form
+        "iv" 'dune-insert-env-form
+        "id" 'dune-insert-ignored-subdirs-form
+        "tP" 'dune-promote
+        "tp" 'dune-runtest-and-promote
+        "cc" 'compile)
+      (spacemacs/declare-prefix-for-mode 'dune-mode "mc" "compile/check")
+      (spacemacs/declare-prefix-for-mode 'dune-mode "mi" "insert-form")
+      (spacemacs/declare-prefix-for-mode 'dune-mode "mt" "test")
+      (add-to-list 'auto-mode-alist
+                   '("\\(?:\\`\\|/\\)dune\\(?:\\.inc\\)?\\'" . dune-mode)))))
 
 (defun ocaml/post-init-flycheck ()
   (spacemacs/enable-flycheck 'tuareg-mode))


### PR DESCRIPTION
Dune is a popular build-tool for OCaml projects, the `dune` package adds:
 - Adds syntax highlighting
 - Template insertion
 - Some testing/compilation functions