### PR TITLE
Fix void function error when recentf-save-list is undefined

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -951,6 +951,8 @@ Other:
   - Improved Window Manipulation Transient state (thanks to yuhan0)
   - Exclude which-key from layer sync powerline restore (thanks to Doug Wilson)
   - Fix doom-modeline in the messages buffer (thanks to duianto)
+  - Fix void function error when recentf-save-list is undefined (thanks to
+    Compro-Prasad)
 *** Layer changes and fixes
 **** Ansible
 - Improvements:

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -274,6 +274,7 @@
 (defun spacemacs-defaults/init-recentf ()
   (use-package recentf
     :defer (spacemacs/defer)
+    :commands (recentf-save-list)
     :init
     (progn
       (spacemacs|require 'recentf)


### PR DESCRIPTION
This happens because there is an idle timer which runs `recentf-save-list` every
600 secs.