### PR TITLE
Temporarily disable html export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ deploy:
     on:
       branch: develop
       condition: $TRAVIS_REPO_SLUG = $SPACEMACS_REPO_SLUG
-  - provider: script
-    skip_cleanup: true
-    script: ".travisci/pub_html.sh"
-    on:
-      all_branches: true
-      condition: $TRAVIS_REPO_SLUG = $SPACEMACS_REPO_SLUG
+      #  - provider: script
+      #    skip_cleanup: true
+      #    script: ".travisci/pub_html.sh"
+      #    on:
+      #      all_branches: true
+      #      condition: $TRAVIS_REPO_SLUG = $SPACEMACS_REPO_SLUG

--- a/.travisci/pub_prep.sh
+++ b/.travisci/pub_prep.sh
@@ -59,14 +59,14 @@ if [ $? -ne 0 ]; then
 fi
 fold_end "INSTALLING_DEPENDENCIES"
 
-fold_start "EXPORTING_DOCUMENTATION"
-emacs -batch -l init.el -l core/core-documentation.el \
-      -f spacemacs/publish-doc
-if [ $? -ne 0 ]; then
-    echo "spacemacs/publish-doc failed"
-    exit 2
-fi
-fold_end "EXPORTING_DOCUMENTATION"
+# fold_start "EXPORTING_DOCUMENTATION"
+# emacs -batch -l init.el -l core/core-documentation.el \
+#       -f spacemacs/publish-doc
+# if [ $? -ne 0 ]; then
+#     echo "spacemacs/publish-doc failed"
+#     exit 2
+# fi
+# fold_end "EXPORTING_DOCUMENTATION"
 
 fold_start "INSTALLING_HUB"
 hub_version="2.5.1"


### PR DESCRIPTION
Broken relative links in the new LAYERS file fail html export script and it fails entire CI. 