### PR TITLE
[better-defaults] Remap `M-\` to `cycle-spacing`

### DIFF
--- a/layers/+emacs/better-defaults/README.org
+++ b/layers/+emacs/better-defaults/README.org
@@ -58,3 +58,4 @@ Choose if ~C-e~ first brings you to the end of the line or the end of the code
 | ~C-w~       | backward kill word or region                                                     |
 | ~C-y~       | Automatically indenting after pasting. With prefix argument, paste text as it is |
 | ~M-q~       | fill or unfill current paragraph                                                 |
+| ~M-\~       | cycle spacing between one space, no spaces and original consecutively            |

--- a/layers/+emacs/better-defaults/keybindings.el
+++ b/layers/+emacs/better-defaults/keybindings.el
@@ -10,3 +10,4 @@
 ;;; License: GPLv3
 
 (global-set-key (kbd "C-w") 'spacemacs/backward-kill-word-or-region)
+(global-set-key (kbd "M-\\") 'cycle-spacing)


### PR DESCRIPTION
`cycle-spacing` combines three whitespace commands into a single binding. It is described in [EmacsWiki](https://www.emacswiki.org/emacs/EmacsNiftyTricks).