### PR TITLE
[shell] fix eshell-z home pollution

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2129,6 +2129,8 @@ Other:
   - ~SPC m C~ switch multi-term to char mode
   - ~SPC m l~ switch multi-term to line mode
   - ~SPC m N~ go to previous multi-term
+- Moved =eshell-z-freq-dir-hash-table-file-name= into cache dir
+  (thanks to bb2020)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -135,8 +135,11 @@
   (use-package eshell-z
     :defer t
     :init
-    (with-eval-after-load 'eshell
-      (require 'eshell-z))))
+    (progn
+      (setq eshell-z-freq-dir-hash-table-file-name
+            (concat spacemacs-cache-directory "eshell/.z"))
+      (with-eval-after-load 'eshell
+        (require 'eshell-z)))))
 
 (defun shell/pre-init-helm ()
   (spacemacs|use-package-add-hook helm


### PR DESCRIPTION
`eshell-z-freq-dir-hash-table-file-name` has the value of `~/.z` and writes into user home directory. It should be moved into spacemacs cache.