### PR TITLE
[shell] Enable `helm-esh-pcomplete` for eshell tab completion

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2132,6 +2132,7 @@ Other:
   - ~SPC m N~ go to previous multi-term
 - Moved =eshell-z-freq-dir-hash-table-file-name= into cache dir
   (thanks to bb2020)
+- Enabled ~TAB~ completion in =eshell= with =Helm= (thanks to bb2020)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -210,6 +210,7 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~SPC a s m~ | Open, close or go to a =multi-term=                        |
 | ~SPC a s t~ | Open, close or go to a =ansi-term=                         |
 | ~SPC a s T~ | Open, close or go to a =term=                              |
+| ~TAB~       | browse completion with =helm=                              |
 | ~SPC m H~   | browse history with =helm= (works in =eshell= and =shell=) |
 | ~C-j~       | next item in history                                       |
 | ~C-k~       | previous item in history                                   |

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -168,8 +168,7 @@ is achieved by adding the relevant text properties."
 
 (defun spacemacs/init-helm-eshell ()
   "Initialize helm-eshell."
-  ;; this is buggy for now
-  ;; (define-key eshell-mode-map (kbd "<tab>") 'helm-esh-pcomplete)
+  (define-key eshell-mode-map (kbd "<tab>") 'helm-esh-pcomplete)
   (spacemacs/set-leader-keys-for-major-mode 'eshell-mode
     "H" 'spacemacs/helm-eshell-history)
   (define-key eshell-mode-map


### PR DESCRIPTION
I am using `helm-esh-pcomplete` over a year and it seems stable. I think it is not broken anymore and ready for prime time.