### PR TITLE
[org] Add org-cliplink package

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2137,6 +2137,7 @@ Other:
 - Moved =eshell-z-freq-dir-hash-table-file-name= into cache dir
   (thanks to bb2020)
 - Enabled ~TAB~ completion in =eshell= with =Helm= (thanks to bb2020)
+- Added ~SPC m i L~ as =org-cliplink= into =org= layer (thanks to bb2020)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -494,6 +494,7 @@ are also available.
 | ~SPC m i i~   | org-insert-item                  |
 | ~SPC m i K~   | spacemacs/insert-keybinding-org  |
 | ~SPC m i l~   | org-insert-link                  |
+| ~SPC m i L~   | org-cliplink                     |
 | ~SPC m i n~   | org-add-note                     |
 | ~SPC m i p~   | org-set-property                 |
 | ~SPC m i s~   | org-insert-subheading            |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -30,6 +30,7 @@
         org-mime
         org-pomodoro
         org-present
+        org-cliplink
         (org-projectile :requires projectile)
         (ox-epub :toggle org-enable-epub-support)
         (ox-twbs :toggle org-enable-bootstrap-support)
@@ -644,6 +645,13 @@ Headline^^            Visit entry^^               Filter^^                    Da
         (evil-normal-state))
       (add-hook 'org-present-mode-hook 'spacemacs//org-present-start)
       (add-hook 'org-present-mode-quit-hook 'spacemacs//org-present-end))))
+
+(defun org/init-org-cliplink ()
+  (use-package org-cliplink
+    :defer t
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'org-mode
+      "iL" 'org-cliplink)))
 
 (defun org/init-org-projectile ()
   (use-package org-projectile


### PR DESCRIPTION
`org-cliplink` is amazing. Inserts link from kill ring into `org` buffer with the page's title.

Edit: I just selected an arbitrary binding. Maybe `SPC m i L` would be a better choice.