### PR TITLE
pycscope: ability to configure the binary name

### DIFF
--- a/layers/+tags/cscope/config.el
+++ b/layers/+tags/cscope/config.el
@@ -1,0 +1,10 @@
+;;; config.el --- cscope configuration File
+;;
+;; Copyright (c) 2019 Sylvain Benner & Contributors
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar pycscope-binary "pycscope"
+"The name of the pycscope binary.")

--- a/layers/+tags/cscope/packages.el
+++ b/layers/+tags/cscope/packages.el
@@ -37,7 +37,8 @@
                                                  (cscope//safe-project-root)))))
         (let ((default-directory directory))
           (shell-command
-           (format "pycscope -R -f '%s'"
+           (format "%s -R -f '%s'"
+                   pycscope-binary
                    (expand-file-name "cscope.out" directory))))))))
 
 (defun cscope/init-helm-cscope ()


### PR DESCRIPTION
By default, cscope uses the "pycscope" command. This new variable
allow one to specify another binary name, e.g: python3-pycscope.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3