### PR TITLE
Add rubocopfmt to format Ruby buffers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2071,6 +2071,7 @@ Other:
   - ~SPC m f f b~ to find job
   - ~SPC m f f w~ to find webpack config
   - ~SPC m f c d~ to run rails destroy
+- Added =rubocopfmt=
 **** Rust
 - Added missing =counsel-gtags= and =smartparens= package declarations
   (thanks to Kalle Lindqvist)

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -144,8 +144,8 @@ directory local variables.
 
 | Key binding   | Description                                          |
 |---------------+------------------------------------------------------|
+| ~SPC m = r~   | Format the current buffer using RuboCop              |
 | ~SPC m r r f~ | Runs RuboCop on the currently visited file           |
-| ~SPC m r r F~ | Runs auto-correct on the currently visited file      |
 | ~SPC m r r d~ | Prompts from a directory on which to run RuboCop     |
 | ~SPC m r r D~ | Prompts for a directory on which to run auto-correct |
 | ~SPC m r r p~ | Runs RuboCop on the entire project                   |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -27,6 +27,7 @@
         robe
         rspec-mode
         rubocop
+        rubocopfmt
         ruby-hash-syntax
         (ruby-mode :location built-in :toggle (not ruby-enable-enh-ruby-mode))
         ruby-refactor
@@ -230,9 +231,20 @@
                 "rrd" 'rubocop-check-directory
                 "rrD" 'rubocop-autocorrect-directory
                 "rrf" 'rubocop-check-current-file
-                "rrF" 'rubocop-autocorrect-current-file
                 "rrp" 'rubocop-check-project
                 "rrP" 'rubocop-autocorrect-project))))
+
+(defun ruby/init-rubocopfmt ()
+  (use-package rubocopfmt
+    :defer t
+    :init
+    (progn
+      (setq-default rubocopfmt-disabled-cops '())
+
+      (dolist (mode '(ruby-mode enh-ruby-mode))
+        (spacemacs/declare-prefix-for-mode mode "m=" "format")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "=r" #'rubocopfmt)))))
 
 (defun ruby/init-ruby-mode ()
   (use-package ruby-mode


### PR DESCRIPTION
Added rubocopfmt for Ruby layer.
`rubocop-autocorrect-current-file` in `rubocop` shows a result buffer on every format, so it's uncomfortable to use it as a formatter.