### PR TITLE
[WIP] Add npm-and-yarn to node layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1750,6 +1750,7 @@ Other:
 - Use add-node-modules-path to automatically find local executables
   (thanks to jupl)
 - Disabled add-node-modules-path by default (thanks to Eivind Fonn)
+- Added =npm-and-yarn= to enable to install packages in Spacemacs
 **** Notmuch
 - Try harder to find GitHub patch URL (thanks to Miciah Masters)
 **** OCaml

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -18,6 +18,7 @@
     flycheck
     import-js
     js-doc
+    npm-and-yarn
     prettier-js
     rjsx-mode
     smartparens
@@ -51,6 +52,9 @@
 (defun react/post-init-js-doc ()
   (add-hook 'rjsx-mode-hook 'spacemacs/js-doc-require)
   (spacemacs/js-doc-set-key-bindings 'rjsx-mode))
+
+(defun react/pre-init-npm-and-yarn ()
+  (add-to-list 'spacemacs--npm-and-yarn-modes 'rjsx-mode))
 
 (defun react/init-rjsx-mode ()
   (use-package rjsx-mode

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -25,6 +25,7 @@
         js2-mode
         js2-refactor
         livid-mode
+        npm-and-yarn
         org
         prettier-js
         skewer-mode
@@ -61,6 +62,9 @@
 (defun javascript/post-init-impatient-mode ()
   (spacemacs/set-leader-keys-for-major-mode 'js2-mode
     "I" 'spacemacs/impatient-mode))
+
+(defun javascript/pre-init-npm-and-yarn ()
+  (add-to-list 'spacemacs--npm-and-yarn-modes 'js2-mode))
 
 (defun javascript/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -15,6 +15,7 @@
         company
         eldoc
         flycheck
+        npm-and-yarn
         smartparens
         tide
         typescript-mode
@@ -44,6 +45,10 @@
     (with-eval-after-load 'flycheck
       (flycheck-add-mode 'typescript-tide 'typescript-tsx-mode)
       (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))))
+
+(defun typescript/pre-init-npm-and-yarn ()
+  (add-to-list 'spacemacs--npm-and-yarn-modes 'typescript-mode)
+  (add-to-list 'spacemacs--npm-and-yarn-modes 'typescript-tsx-mode))
 
 (defun typescript/post-init-smartparens ()
   (if dotspacemacs-smartparens-strict-mode

--- a/layers/+tools/node/README.org
+++ b/layers/+tools/node/README.org
@@ -7,6 +7,7 @@
 * Table of Contents                     :TOC_4_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#key-bindings][Key bindings]]
 
 * Description
 This layer introduces packages that target Node.js. Currently this layer should
@@ -14,3 +15,12 @@ not be used directly, as it will be used by other layers.
 
 ** Features:
 - Integration of packages necessary to execute node.js modules from other layers.
+
+* Key bindings
+
+| Key binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC m n i~ | install and save a package using npm                     |
+| ~SPC m n I~ | install and save a package to =devDependencies= via npm  |
+| ~SPC m y a~ | install and save a package using yarn                    |
+| ~SPC m y A~ | install and save a package to =devDependencies= via yarn |

--- a/layers/+tools/node/config.el
+++ b/layers/+tools/node/config.el
@@ -13,3 +13,6 @@
 (defvar node-add-modules-path nil
   "Set to true to automatically add node modules to the path.
 Note that this may be a security liability.")
+
+(defvar spacemacs--npm-and-yarn-modes '()
+  "List of mode.")

--- a/layers/+tools/node/local/npm-and-yarn/npm-and-yarn.el
+++ b/layers/+tools/node/local/npm-and-yarn/npm-and-yarn.el
@@ -1,0 +1,54 @@
+;; -*- lexical-binding: t -*-
+
+;;; npm-and-yarn.el
+
+;; Author:   Seong Yong-ju <sei40kr@gmail.com>
+;; Created:  May 10 2019
+;; Version:  0.1.0
+;; Keywords: node, npm, yarn
+
+;;; Commentary:
+
+;;; Code:
+
+;;;###autoload
+(defun npm-and-yarn/npm-install ()
+  (interactive)
+  (when-let* ((dep (read-string "Enter package name: " (thing-at-point 'symbol))))
+    (npm-and-yarn//npm-exec (concat "install --save " (shell-quote-argument dep)))))
+
+;;;###autoload
+(defun npm-and-yarn/npm-install-dev ()
+  (interactive)
+  (when-let* ((dep (read-string "Enter package name: " (thing-at-point 'symbol))))
+    (npm-and-yarn//npm-exec (concat "install --save-dev " (shell-quote-argument dep)))))
+
+;;;###autoload
+(defun npm-and-yarn/yarn-add ()
+  (interactive)
+  (when-let* ((dep (read-string "Enter package name: " (thing-at-point 'symbol))))
+    (npm-and-yarn//yarn-exec (concat "add " (shell-quote-argument dep)))))
+
+;;;###autoload
+(defun npm-and-yarn/yarn-add-dev ()
+  (interactive)
+  (when-let* ((dep (read-string "Enter package name: " (thing-at-point 'symbol))))
+    (npm-and-yarn//yarn-exec (concat "add --dev " (shell-quote-argument dep)))))
+
+(defun npm-and-yarn//npm-exec (npm-args)
+  (compilation-start (concat "npm " npm-args) #'compilation-mode
+                     #'npm-and-yarn//npm-exec-buffer-name))
+
+(defun npm-and-yarn//npm-exec-buffer-name (_)
+  "*npm*")
+
+(defun npm-and-yarn//yarn-exec (yarn-args)
+  (compilation-start (concat "yarn " yarn-args) #'compilation-mode
+                     #'npm-and-yarn//yarn-exec-buffer-name))
+
+(defun npm-and-yarn//yarn-exec-buffer-name (_)
+  "*yarn*")
+
+(provide 'npm-and-yarn)
+
+;;; npm-and-yarn ends here

--- a/layers/+tools/node/packages.el
+++ b/layers/+tools/node/packages.el
@@ -10,9 +10,24 @@
 ;;; License: GPLv3
 
 (setq node-packages
-      '(
-        (add-node-modules-path :toggle node-add-modules-path)
-        ))
+      '((add-node-modules-path :toggle node-add-modules-path)
+        (npm-and-yarn :location local)))
 
 (defun node/init-add-node-modules-path ()
   (use-package add-node-modules-path :defer t))
+
+(defun node/init-npm-and-yarn ()
+  (use-package npm-and-yarn
+    :commands (npm-and-yarn/npm-install
+               npm-and-yarn/npm-install-dev
+               npm-and-yarn/yarn-add
+               npm-and-yarn/yarn-add-dev)
+    :init
+    (dolist (mode spacemacs--npm-and-yarn-modes)
+      (spacemacs/declare-prefix-for-mode mode "mn" "npm")
+      (spacemacs/declare-prefix-for-mode mode "my" "yarn")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "ni" #'npm-and-yarn/npm-install
+        "nI" #'npm-and-yarn/npm-install-dev
+        "ya" #'npm-and-yarn/yarn-add
+        "yA" #'npm-and-yarn/yarn-add-dev))))


### PR DESCRIPTION
Enable to install a Node package in Spacemacs.

# New Key Bindings

| Key binding | Description                                              |
|:-------------|:----------------------------------------------------------|
| `SPC m n i` | install and save a package using npm                     |
| `SPC m n I` | install and save a package to `devDependencies` via npm  |
| `SPC m y a` | install and save a package using yarn                    |
| `SPC m y A` | install and save a package to `devDependencies` via yarn |
