### PR TITLE
Organize the header file includes in C++ buffer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -121,6 +121,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 ***** C-C++
 - CMake support has been extracted from the =c-c++= layer into the new =cmake=
   layer.
+- Added a feature to automatically organize the includes using
+  =cpp-auto-include=.
 ***** ESS
 - ESS key bindings were re-organised in the following list
   (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -27,6 +27,7 @@
         - [[#example-dotspacemacs-configuration-layers-entry][Example dotspacemacs-configuration-layers entry]]
       - [[#completion][Completion]]
       - [[#debugger-dap-integration][Debugger (dap integration)]]
+  - [[#organize-file-header-includes-on-save][Organize file header includes on save]]
   - [[#clang-configuration][Clang Configuration]]
     - [[#clang-format][clang-format]]
     - [[#company-clang-and-flycheck][Company-clang and flycheck]]
@@ -197,6 +198,15 @@ as recommended by =cquery=/=ccls= wikis.
 **** Debugger (dap integration)
 To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are on Linux or download it manually from [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][Native Debug]] and adjust =dap-gdb-lldb-path=.
 
+** Organize file header includes on save
+To organize the file header includes on save, set the layer variable
+=c++-enable-organize-includes-on-save= to =t= in the dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((c-c++ :variables c++-enable-organize-includes-on-save t)))
+#+END_SRC
+
 ** Clang Configuration
 To enable Clang support, set the layer variable =c-c++-enable-clang-support=
 to =t= in the dotfile:
@@ -290,6 +300,7 @@ generally applicable.
 |             | (e.g. switch between .cpp and .h, requires a project to work) |
 | ~SPC m D~   | disaster: disassemble c/c++ code                              |
 | ~SPC m r .~ | srefactor: refactor thing at point.                           |
+| ~SPC m r i~ | organize includes                                             |
 
 *Note:* [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]] is only available for Emacs 24.4+.
 

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -27,6 +27,9 @@
   "If `lsp-cquery' or `lsp-ccls' then selects language server protocol backend (cquery or ccls).
   If `rtags' then enables rtags support")
 
+(defvar c++-enable-organize-includes-on-save nil
+  "If non-nil then automatically organize the includes on save C++ buffer.")
+
 (defvar c-c++-enable-auto-newline nil
   "If non nil then enables the `Auto-newline' minor mode.")
 

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -139,6 +139,22 @@ and the arguments for flyckeck-clang based on a project-specific text file."
                           idirafter-paths)))))
 
 
+;; cpp-auto-include
+
+(defalias 'spacemacs/c++-organize-includes 'cpp-auto-include)
+
+(defun spacemacs//c++-organize-includes-on-save ()
+  "Organize the includes on save when `c++-enable-organize-includes-on-save'
+is non-nil."
+  (when c++-enable-organize-includes-on-save
+    (spacemacs/c++-organize-includes)))
+
+(defun spacemacs/c++-organize-includes-on-save ()
+  "Add before-save hook for c++-organize-includes."
+  (add-hook 'before-save-hook
+            #'spacemacs//c++-organize-includes-on-save nil t))
+
+
 ;; rtags
 
 (defun spacemacs/c-c++-use-rtags (&optional useFileManager)

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -18,6 +18,9 @@
         (company-rtags :requires company rtags)
         company-ycmd
         counsel-gtags
+        (cpp-auto-include
+         :location (recipe :fetcher github
+                           :repo "syohex/emacs-cpp-auto-include"))
         disaster
         flycheck
         (flycheck-rtags :requires flycheck rtags)
@@ -112,6 +115,19 @@
 (defun c-c++/post-init-counsel-gtags ()
   (dolist (mode c-c++-modes)
     (spacemacs/counsel-gtags-define-keys-for-mode mode)))
+
+(defun c-c++/init-cpp-auto-include ()
+  (use-package cpp-auto-include
+    :defer t
+    :init
+    (progn
+      (when c++-enable-organize-includes-on-save
+        (add-hook 'c++-mode-hook #'spacemacs/c++-organize-includes-on-save))
+
+      (spacemacs/declare-prefix-for-mode 'c++-mode
+        "mr" "refactor")
+      (spacemacs/set-leader-keys-for-major-mode 'c++-mode
+        "ri" #'spacemacs/c++-organize-includes))))
 
 (defun c-c++/init-disaster ()
   (use-package disaster


### PR DESCRIPTION
Organize the header file includes using [cpp-auto-include](https://github.com/syohex/emacs-cpp-auto-include).

# New Key Binding

| Key binding | Description                                                   |
|:-------------|:---------------------------------------------------------------|
| `SPC m r i` | organize includes                                           |
