### PR TITLE
spacemacs-layouts: Fix adding buffers to new persp

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -510,7 +510,16 @@ Other:
   - Fixed bug that could overwrites customize variables (thanks to bmag)
   - Don't suggest ~SPC q r~ if =restart-emacs= package is missing after an
     update (thanks to Keshav Kini)
-  - spacemacs-layouts: Add Projectile project buffers to new perspectives.
+  - spacemacs-layouts: Improvements to ~SPC l l~ (=spacemacs/helm-perspectives=
+    or =spacemacs/ivy-spacemacs-layouts=):
+    - If the user selects a project that does not already have a layout and then
+      quits without selecting a file or buffer, kill the new layout.
+    - When creating a new layout, add any buffers that belong to the project.
+  - spacemacs-layouts: Improvements to ~SPC p l~
+    (=spacemacs/helm-persp-switch-project= or
+    =spacemacs/ivy-persp-switch-project=):
+    - Fixed the default action to display the home buffer in the new layout.
+    - Added actions to copy the current layout or create a new project layout.
   - Resolve symlinks in warning message about duplicate layers
     (thanks to Ben Gamari)
   - Check toggle condition in status function (thanks to Eivind Fonn)

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -413,6 +413,8 @@ If match is found
 \(default) Select layout
 c: Close Layout(s) <- mark with C-SPC to close more than one-window
 k: Kill Layout(s)
+n: Copy current layout
+p: Create project layout
 
 If match is not found
 <enter> Creates layout
@@ -422,13 +424,7 @@ Closing doesn't kill buffers inside the layout while killing layouts does."
   (ivy-read "Layouts: "
             (persp-names)
             :caller 'spacemacs/ivy-spacemacs-layouts
-            :action (lambda (name)
-                      (let ((persp-reset-windows-on-nil-window-conf t))
-                        (persp-switch name)
-                        (unless
-                            (member name
-                                    (persp-names-current-frame-fast-ordered))
-                          (spacemacs/home))))))
+            :action 'spacemacs//create-persp-with-home-buffer))
 
 (defun spacemacs/ivy-spacemacs-layout-buffer ()
   "Switch to layout buffer using ivy."

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -300,7 +300,10 @@
   (ivy-set-actions
    'spacemacs/ivy-spacemacs-layouts
    '(("c" persp-kill-without-buffers "Close layout(s)")
-     ("k" persp-kill  "Kill layout(s)")))
+     ("k" persp-kill  "Kill layout(s)")
+     ("n" persp-copy "Copy Current Layout")
+     ("p" spacemacs//create-persp-with-current-project-buffers
+      "Create Project Layout")))
   ;; TODO: better handling of C and X bindings for ivy
   ;;       check ivy/pre-init-persp-mode
   (spacemacs/transient-state-register-remove-bindings 'layouts

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -219,8 +219,6 @@
       (defadvice persp-activate (before spacemacs//save-toggle-layout activate)
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
-      (add-hook 'persp-created-functions
-                #'spacemacs//add-project-buffers-to-persp)
       (advice-add 'persp-load-state-from-file :before 'spacemacs//layout-wait-for-modeline)
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys


### PR DESCRIPTION
Delete the hook that https://github.com/syl20bnr/spacemacs/pull/11642 added to `persp-created-functions`, and change `spacemacs/ivy-spacemacs-layouts`, `spacemacs/helm-perspectives`, `spacemacs/helm-persp-switch-project`, and `spacemacs/ivy-persp-switch-project` to achieve the intended goal of adding the desired buffers after creating a new perspective.

Change `spacemacs/helm-persp-switch-project` and `spacemacs/ivy-persp-switch-project` as follows: If the user selects a project but then quits without selecting a file or buffer, the new perspective is now immediately killed.  Otherwise, if the perspective did not already exist, any buffers that belong to the selected project are added to the perspective.

Add the following actions to `spacemacs/ivy-spacemacs-layouts` and `spacemacs/helm-perspectives`:

* Create a new perspective with the Spacemacs home buffer (default action).
* Create a new perspective with the buffers that belong to the current buffer's project.
* Create a new perspective with the buffers that belong to the current perspective (i.e., make a copy of the current perspective).

This commit resolves the problem reported in https://github.com/syl20bnr/spacemacs/commit/9fcf8c898dd1069ef362f1ede320e85065358ac6#commitcomment-33343455.

This commit also fixes a problem with the default action for `spacemacs/ivy-spacemacs-layouts` and `spacemacs/helm-perspectives`.  According to https://github.com/syl20bnr/spacemacs/pull/4077, the default action is supposed to display the home buffer if the action creates a new perspective, which was determined by checking whether the perspective was missing from the list of perspectives _before_ switching.  However, commit eb7ca651fe72241a5784c289543f73b6c273faf4 changed this logic so it was checking whether the perspective was missing from the list of perspectives _after_ switching.  This commit restores the correct logic.

* `CHANGELOG.develop`: Update.
* `layers/+completion/ivy/funcs.el` (`spacemacs/ivy-spacemacs-layouts`): Add "Copy Current Layout" and "Create Project Layout" actions to the docstring.  Use `spacemacs//create-persp-with-home-buffer` for the default action.
* `layers/+completion/ivy/packages.el` (`ivy/post-init-persp-mode`): Add actions for `spacemacs//create-persp-with-current-project-buffers` and `persp-copy`.
* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs||switch-layout`): New macro.  Switch to the named perspective, and initialize it using the provided forms if the perspective is new.
(`spacemacs//create-persp-with-current-project-buffers`): New function.  Create a new perspective with the current project's buffers.
(`spacemacs||switch-project-persp`): New macro.  Switch to the named perspective, and evaluate the provided forms with `projectile-after-switch-project-hook` bound with a hook that adds the current project's buffers to the perspective.  If the user quits during the evaluation of the forms, kill the perspective.
(`spacemacs//create-persp-with-home-buffer`): New function.  Switch to the named perspective, and go to the Spacemacs home buffer if the perspective is new.
(`spacemacs/helm-perspectives`): Use `spacemacs//create-persp-with-home-buffer` for the default action.  Add actions for `spacemacs//create-persp-with-current-project-buffers` and `persp-copy`.
(`spacemacs//helm-persp-switch-project-action`): New function.  Switch to the named perspective and call `projectile-switch-project-by-name`, using the new `spacemacs||switch-project-persp` macro.  Bind `helm-quit-hook` with a hook that kills the new perspective if the user quits `projectile-switch-project-by-name`.
(`spacemacs/helm-persp-switch-project`): Use `spacemacs//helm-persp-switch-project-action`.
(`spacemacs//ivy-persp-switch-project-action`): New function.  Switch to the named perspective and call `counsel-projectile-switch-project-action` with a hook to add the project's buffers to the new perspective.
(`spacemacs/ivy-persp-switch-project`): Delete advice for `counsel-projectile-switch-project-action`.  Use `spacemacs//ivy-persp-switch-project-action` instead.
(`spacemacs//add-project-buffers-to-persp`): Deleted.
* `layers/+spacemacs/spacemacs-layouts/packages.el`
(`spacemacs-layouts/init-persp-mode`): Don't add a hook to `persp-created-functions`.
