### PR TITLE
Configure emmet-mode for typescript-tsx-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2268,6 +2268,7 @@ Other:
 - Fixed jump handling with multiple backends (thanks to Aaron Jensen)
 - Fixed =typescript/jump-to-type-def= for npm modules (thanks to Jam Risser)
 - Added the same setup to tsx files as to ts files (thanks to Trapez Breen)
+- Configured =emmet-mode= for =typescript-tsx-mode=
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -85,6 +85,13 @@
   (eldoc-mode))
 
 
+;; Emmet
+
+(defun spacemacs/typescript-emmet-mode ()
+  "Configure `emmet-mode' for local buffer."
+  (setq-local emmet-expand-jsx-className? t))
+
+
 ;; Others
 
 (defun spacemacs/typescript-tsfmt-format-buffer ()

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -14,6 +14,7 @@
         add-node-modules-path
         company
         eldoc
+        emmet-mode
         flycheck
         smartparens
         tide
@@ -36,6 +37,9 @@
   (spacemacs/add-to-hooks #'spacemacs//typescript-setup-eldoc
                    '(typescript-mode-local-vars-hook
                      typescript-tsx-mode-local-vars-hook) t))
+
+(defun typescript/post-init-emmet-mode ()
+  (add-hook 'typescript-tsx-mode-hook #'spacemacs/typescript-emmet-mode))
 
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)


### PR DESCRIPTION
In `typescript-tsx-mode` buffer, `emmet-mode` is enabled (derived from `web-mode`), but it was not configured for TSX syntax.