### PR TITLE
Remove line-feed characters

### DIFF
--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -15,7 +15,7 @@
   (let ((msg (format "Spacemacs v.%s" spacemacs-version)))
     (message msg) (kill-new msg)))
 
-
+
 ;; startup debug
 
 (require 'profiler)
@@ -149,7 +149,7 @@ seconds to load")
   ;; Keep debug-on-error on for stuff that is lazily loaded
   (add-hook 'after-init-hook (lambda () (setq debug-on-error t))))
 
-
+
 ;; Report issue
 
 (defun spacemacs//describe-system-info-string ()

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -331,7 +331,7 @@ current frame."
   (let ((comint-buffer-maximum-size 0))
     (comint-truncate-buffer)))
 
-
+
 ;; Generalized next-error system ("gne")
 
 (defun spacemacs/error-delegate ()

--- a/core/libs/package-build.el
+++ b/core/libs/package-build.el
@@ -1325,7 +1325,7 @@ Returns the archive entry for the package."
                                   " "))
       (package-build--url-copy-file badge-url badge-filename t))))
 
-
+
 ;;; Helpers for recipe authors
 
 (defvar package-build-minor-mode-map
@@ -1412,7 +1412,7 @@ Returns the archive entry for the package."
        (package-build--message "%s" (error-message-string err))
        nil))))
 
-
+
 
 ;;;###autoload
 (defun package-build-all ()
@@ -1482,7 +1482,7 @@ If FILE-NAME is not specified, the default archive-contents file is used."
           (setq entries (remove old entries)))
         (add-to-list 'entries new)))))
 
-
+
 
 ;;; Exporting data as json
 

--- a/core/libs/page-break-lines.el
+++ b/core/libs/page-break-lines.el
@@ -91,7 +91,7 @@ is available in that variant of your font, otherwise it may be
 displayed as a junk character."
   :group 'page-break-lines)
 
-
+
 
 ;;;###autoload
 (define-minor-mode page-break-lines-mode
@@ -112,7 +112,7 @@ horizontal line of `page-break-string-char' characters."
                 display-line-numbers-mode-hook))
   (add-hook hook 'page-break-lines--update-display-tables))
 
-
+
 
 (defun page-break-lines--update-display-table (window)
   "Modify a display-table that displays page-breaks prettily.
@@ -146,7 +146,7 @@ its display table will be modified as necessary."
   (unless (minibufferp)
     (mapc 'page-break-lines--update-display-table (window-list frame 'no-minibuffer))))
 
-
+
 
 ;;;###autoload
 (defun page-break-lines-mode-maybe ()

--- a/layers/+chat/erc/funcs.el
+++ b/layers/+chat/erc/funcs.el
@@ -26,7 +26,7 @@
       (erc//servers erc-server-list)
     (message "You must define erc-server-list")))
 
-
+
 ;; persp
 
 (defun spacemacs//erc-persp-filter-save-buffers-function (buffer)

--- a/layers/+chat/erc/local/erc-yank/erc-yank.el
+++ b/layers/+chat/erc/local/erc-yank/erc-yank.el
@@ -22,7 +22,7 @@
 ;; along with GNU Emacs; see the file COPYING.  If not, write to the
 ;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
-
+
 ;;; Commentary:
 
 ;; Automagically create a Gist if pasting more than 5 lines.
@@ -42,7 +42,7 @@
 ;;       (bind-key "C-y" 'erc-yank erc-mode-map)))
 ;;
 ;; This module requires gist.el, from: https://github.com/defunkt/gist.el
-
+
 ;;; Code:
 
 (require 'gist)

--- a/layers/+chat/rcirc/funcs.el
+++ b/layers/+chat/rcirc/funcs.el
@@ -48,7 +48,7 @@
     (start-process "beep-process" nil player sound)))
 
 
-
+
 ;; persp
 
 (defun spacemacs//rcirc-persp-filter-save-buffers-function (buffer)
@@ -61,7 +61,7 @@
   (persp-add-buffer (current-buffer) (persp-get-by-name
                                       rcirc-spacemacs-layout-name)))
 
-
+
 ;; logging
 
 (defun spacemacs//rcirc-write-log (process sender response target text)
@@ -88,7 +88,7 @@
                         t 'quietly))))))
 
 
-
+
 ;; emms
 
 (defun spacemacs/rcirc-insert-current-emms-track ()
@@ -96,7 +96,7 @@
   (insert (emms-track-description (emms-playlist-current-selected-track))))
 
 
-
+
 ;; authinfo
 
 (defun spacemacs//rcirc-authinfo-config ()
@@ -115,7 +115,7 @@ This doesn't support the chanserv auth method. "
              (if (functionp secret) (funcall secret) secret))))))
 
 
-
+
 ;; ZNC with authinfo
 
 (defun spacemacs//znc-auth-source-fetch-password (server)

--- a/layers/+chat/slack/funcs.el
+++ b/layers/+chat/slack/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; persp
 
 (defun spacemacs//slack-persp-filter-save-buffers-function (buffer)

--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 
 (spacemacs|add-toggle auto-completion
   :status
@@ -32,7 +32,7 @@
   :documentation "Enable auto-completion."
   :evil-leader "ta")
 
-
+
 ;; company backends declaration macro
 
 (defmacro spacemacs|add-company-backends (&rest props)
@@ -151,7 +151,7 @@ MODE parameter must match the :modes values used in the call to
     (append (if (consp backend) backend (list backend))
             '(:with company-yasnippet))))
 
-
+
 ;; auto-completion key bindings functions
 
 (defun spacemacs//auto-completion-set-RET-key-behavior (package)
@@ -200,7 +200,7 @@ MODE parameter must match the :modes values used in the call to
                'spacemacs//auto-completion-key-sequence-start))
             (t (message "Not yet implemented for package %S" package))))))
 
-
+
 ;; key sequence to complete selection
 
 (defvar spacemacs--auto-completion-time nil)
@@ -281,7 +281,7 @@ MODE parameter must match the :modes values used in the call to
       second-key
       spacemacs--auto-completion-shadowed-hybrid-binding)))
 
-
+
 ;; Editing style
 
 (defun spacemacs//company-active-navigation (style)
@@ -301,7 +301,7 @@ MODE parameter must match the :modes values used in the call to
       (define-key map (kbd "C-n") 'company-select-next)
       (define-key map (kbd "C-p") 'company-select-previous)))))
 
-
+
 ;; Transformers
 
 (defun spacemacs//company-transformer-cancel (candidates)
@@ -310,7 +310,7 @@ MODE parameter must match the :modes values used in the call to
   (unless (member company-prefix company-mode-completion-cancel-keywords)
     candidates))
 
-
+
 
 (defvar-local company-fci-mode-on-p nil)
 
@@ -322,7 +322,7 @@ MODE parameter must match the :modes values used in the call to
 (defun company-maybe-turn-on-fci (&rest ignore)
   (when company-fci-mode-on-p (fci-mode 1)))
 
-
+
 ;; helm-yas
 
 (defun spacemacs/helm-yas ()
@@ -332,7 +332,7 @@ MODE parameter must match the :modes values used in the call to
   (require 'helm-c-yasnippet)
   (call-interactively 'helm-yas-complete))
 
-
+
 ;; ivy-yas
 
 (defun spacemacs/ivy-yas ()
@@ -342,7 +342,7 @@ MODE parameter must match the :modes values used in the call to
   (require 'ivy-yasnippet)
   (call-interactively 'ivy-yasnippet))
 
-
+
 ;; Yasnippet
 
 (defun spacemacs/load-yasnippet ()
@@ -353,7 +353,7 @@ MODE parameter must match the :modes values used in the call to
   (yas-minor-mode -1)
   (setq yas-dont-activate t))
 
-
+
 ;; Auto-Yasnippet
 
 (defun spacemacs/auto-yasnippet-expand ()
@@ -362,7 +362,7 @@ MODE parameter must match the :modes values used in the call to
   (call-interactively 'aya-expand)
   (evil-insert-state))
 
-
+
 ;; Yasnippet and Smartparens
 
 ;; If enabled, smartparens will mess snippets expanded by `hippie-expand`.

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 
 (defvar spacemacs--helm-popwin-mode nil
   "Temp variable to store `popwin-mode''s value.")
@@ -39,7 +39,7 @@
     (popwin-mode))
   (setq display-buffer-alist spacemacs-display-buffer-alist))
 
-
+
 ;; REPLs integration
 
 (defun helm-available-repls ()
@@ -57,7 +57,7 @@
 
 
 
-
+
 ;; Search tools integration
 
 (defun spacemacs//helm-do-ag-region-or-symbol (func &optional dir)
@@ -517,7 +517,7 @@ Removes the automatic guessing of the initial value based on thing at point. "
     (set-text-properties 0 (length input) nil input)
     (helm-find-files-1 input)))
 
- ;; Key bindings
+ ;; Key bindings
 
 (defmacro spacemacs||set-helm-key (keys func)
   "Define a key bindings for FUNC using KEYS.
@@ -532,7 +532,7 @@ Ensure that helm is required before calling FUNC."
          (call-interactively ',func))
        (spacemacs/set-leader-keys ,keys ',func-name))))
 
- ;; Find files tweaks
+ ;; Find files tweaks
 
 (defun spacemacs//helm-find-files-edit (candidate)
   "Opens a dired buffer and immediately switches to editable mode."
@@ -588,7 +588,7 @@ to buffers)."
             (buffers (mapcar 'find-file-noselect files)))
        (spacemacs//helm-open-buffers-in-windows buffers)))))
 
-
+
 ;; Generalized next-error interface
 
 (defun spacemacs//gne-init-helm-ag (&rest args)
@@ -615,7 +615,7 @@ to buffers)."
           spacemacs--gne-line-func 'helm-grep-action
           next-error-function 'spacemacs/gne-next)))
 
-
+
 ;; theme
 
 (defun spacemacs/helm-themes ()

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -10,13 +10,13 @@
 ;;; License: GPLv3
 
 
-
+
 ;; Layer Variables
 
 (defvar ivy-enable-advanced-buffer-information nil
   "If non-nil, enable `ivy-rich' which adds information on buffers.")
 
-
+
 ;; Private Variables
 
 (defvar spacemacs--counsel-commands

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; Counsel
 
 ;; async
@@ -359,7 +359,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
     ((eq major-mode 'org-mode) 'counsel-org-goto)
     (t 'counsel-imenu))))
 
-
+
 ;; Ivy
 
 (defun spacemacs//ivy-command-not-implemented-yet (key)
@@ -449,7 +449,7 @@ Closing doesn't kill buffers inside the layout while killing layouts does."
             (persp-names)
             :action 'persp-kill))
 
-
+
 ;; Swiper
 
 (defun spacemacs/swiper-region-or-symbol ()

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -10,7 +10,7 @@
 ;;; License: GPLv3
 
 
-
+
 
 (defun spacemacs/state-color-face (state)
   "Return the symbol of the face for the given STATE."
@@ -180,7 +180,7 @@ Example: (evil-map visual \"<\" \"<gv\")"
     (cl-loop for (mode uni nouni) in spacemacs--diminished-minor-modes
              do (diminish mode (if unicodep uni nouni)))))
 
-
+
 
 (defun spacemacs//hydra-key-doc-function (key key-width doc doc-width)
   "Custom hint documentation format for keys."

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -22,14 +22,14 @@
   (interactive)
   (org-projectile-goto-location-for-project (projectile-project-name)))
 
-
+
 
 (defun spacemacs/ob-fix-inline-images ()
   "Fix redisplay of inline images after a code block evaluation."
   (when org-inline-image-overlays
     (org-redisplay-inline-images)))
 
-
+
 
 (defun spacemacs//surround-drawer ()
   (let ((dname (read-from-minibuffer "" "")))
@@ -39,7 +39,7 @@
   (let ((dname (read-from-minibuffer "" "")))
     (cons (format "#+BEGIN_SRC %s" (or dname "")) "#+END_SRC")))
 
-
+
 
 (defun spacemacs//evil-org-mode ()
   (evil-org-mode)
@@ -50,7 +50,7 @@
     (add-to-list 'evil-surround-pairs-alist '(?: . spacemacs//surround-drawer))
     (add-to-list 'evil-surround-pairs-alist '(?# . spacemacs//surround-code))))
 
-
+
 
 (defun spacemacs/org-trello-pull-buffer ()
   (interactive)

--- a/layers/+emacs/org/local/ox-gfm/ox-gfm.el
+++ b/layers/+emacs/org/local/ox-gfm/ox-gfm.el
@@ -31,7 +31,7 @@
 (require 'ox-md)
 
 
-
+
 ;;; User-Configurable Variables
 
 (defgroup org-export-gfm nil
@@ -41,7 +41,7 @@
   :version "24.4"
   :package-version '(Org . "8.0"))
 
-
+
 ;;; Define Back-End
 
 (org-export-define-derived-backend 'gfm 'md
@@ -61,7 +61,7 @@
                      (src-block . org-gfm-src-block)))
 
 
-
+
 ;;; Transcode Functions
 
 ;;;; Src Block
@@ -116,7 +116,7 @@ holding export options."
     (concat toc-string toc-tail contents)))
 
 
-
+
 ;;; Interactive function
 
 ;;;###autoload

--- a/layers/+email/notmuch/funcs.el
+++ b/layers/+email/notmuch/funcs.el
@@ -60,7 +60,7 @@
   (let ((current-prefix-arg '(4)))
     (call-interactively 'notmuch-show-open-or-close-all)))
 
-
+
 ;; git
 
 (defun spacemacs/notmuch-git-apply-patch (entire-thread)
@@ -79,7 +79,7 @@ messages in the current thread"
      (lambda ()
        (mm-pipe-part (notmuch-show-current-part-handle mime-type) "git am")))))
 
-
+
 ;; GitHub
 
 ;; Thanks to Kyle Meyer (@kyleam)
@@ -113,7 +113,7 @@ messages in the current thread"
   (with-current-notmuch-show-message
    (spacemacs//notmuch-open-github-patch (current-buffer))))
 
-
+
 ;; persp
 
 (defun spacemacs//notmuch-persp-filter-save-buffers-function (buffer)

--- a/layers/+filetree/neotree/funcs.el
+++ b/layers/+filetree/neotree/funcs.el
@@ -60,7 +60,7 @@
   (when (get-buffer-window (neo-global--get-buffer))
     (neo-global--attach)))
 
-
+
 ;; winum
 
 (defun spacemacs//winum-neotree-assign-func ()

--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; Backend
 (defun spacemacs//react-setup-backend ()
   "Conditionally setup react backend."
@@ -23,7 +23,7 @@
     (`tern (spacemacs/tern-setup-tern-company 'rjsx-mode))
     (`lsp (spacemacs//react-setup-lsp-company))))
 
-
+
 ;; LSP
 (defun spacemacs//react-setup-lsp ()
   "Setup lsp backend."
@@ -45,14 +45,14 @@
         (fix-lsp-company-prefix))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-
+
 ;; Emmet
 (defun spacemacs/react-emmet-mode ()
   "Activate `emmet-mode' and configure it for local buffer."
   (emmet-mode)
   (setq-local emmet-expand-jsx-className? t))
 
-
+
 ;; Others
 (defun spacemacs//react-inside-string-q ()
   "Returns non-nil if inside string, else nil.

--- a/layers/+fun/games/funcs.el
+++ b/layers/+fun/games/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 
 (defun spacemacs/tetris-quit-game ()
   "Correctly quit tetris by killng the game buffer."
@@ -21,7 +21,7 @@
         (kill-buffer "*Tetris*"))
     (tetris-pause-game)))
 
-
+
 
 (defun spacemacs/games-start-typit-beginner ()
   "Start `typit' game in beginner difficulty."
@@ -41,4 +41,3 @@
       (evil-insert-state)
       (funcall (intern (format "typit-%S-test" type))))))
 
-

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -16,7 +16,7 @@
   "Toggle auto-newline."
   (c-toggle-auto-newline 1))
 
-
+
 ;; clang
 
 (defun spacemacs/clang-format-function (&optional style)
@@ -138,7 +138,7 @@ and the arguments for flyckeck-clang based on a project-specific text file."
                             (spacemacs//c-c++-get-standard-include-paths "c"))
                           idirafter-paths)))))
 
-
+
 ;; rtags
 
 (defun spacemacs/c-c++-use-rtags (&optional useFileManager)

--- a/layers/+lang/common-lisp/funcs.el
+++ b/layers/+lang/common-lisp/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; Helm integration
 
 (defun spacemacs//slime-helm-source (&optional table)
@@ -24,7 +24,7 @@
   (let ((command (helm :sources (spacemacs//slime-helm-source))))
     (and command (slime (intern command)))))
 
-
+
 ;; Evil integration
 
 (defun spacemacs/slime-eval-sexp-end-of-line ()
@@ -33,7 +33,7 @@
   (move-end-of-line 1)
   (slime-eval-last-expression))
 
-
+
 
 ;; Functions are taken from the elisp layer `eval-last-sexp' was replaced with
 ;; its slime equivalent `slime-eval-last-expression'

--- a/layers/+lang/elm/funcs.el
+++ b/layers/+lang/elm/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; elm-mode
 
 (defun spacemacs/elm-compile-buffer-output ()

--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 
 ;; Idea from http://www.reddit.com/r/emacs/comments/312ge1/i_created_this_function_because_i_was_tired_of/
 (defun spacemacs/eval-current-form ()
@@ -31,7 +31,7 @@ Unlike `eval-defun', this does not go to topmost function."
         (find-variable-other-window symb)
       (find-function-at-point))))
 
-
+
 ;; edebug
 
 (defun spacemacs/edebug-instrument-defun-on ()
@@ -73,7 +73,7 @@ Unlike `eval-defun', this does not go to topmost function."
                  golden-ratio-mode)
         (golden-ratio)))))
 
-
+
 ;; smartparens integration
 
 (defun spacemacs/eval-current-form-sp (&optional arg)
@@ -106,7 +106,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
       (sp-forward-symbol)
       (call-interactively 'eval-last-sexp))))
 
-
+
 ;; elisp comment text-object definition
 
 (defun spacemacs//define-elisp-comment-text-object ()

--- a/layers/+lang/groovy/funcs.el
+++ b/layers/+lang/groovy/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; REPL
 
 (defun spacemacs/groovy-send-region-switch (start end)

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -22,7 +22,7 @@
     (haskell-navigate-imports)
     (haskell-mode-format-imports)))
 
-
+
 ;; Completion setup functions
 
 (defun spacemacs-haskell//setup-backend ()
@@ -43,7 +43,7 @@
     (`dante (spacemacs-haskell//setup-dante-company))
     (`ghc-mod (spacemacs-haskell//setup-ghc-mod-company))))
 
-
+
 ;; ghci functions
 
 (defun spacemacs-haskell//setup-ghci ()
@@ -67,7 +67,7 @@
         (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-
+
 ;; ghc-mod functions
 
 (defun spacemacs-haskell//setup-ghc-mod ()
@@ -78,7 +78,7 @@
     :backends (company-ghc company-dabbrev-code company-yasnippet)
     :modes haskell-mode))
 
-
+
 ;; Dante functions
 
 (defun spacemacs-haskell//setup-dante ()
@@ -94,7 +94,7 @@
   (interactive)
   (dante-type-at :insert))
 
-
+
 ;; Intero functions
 
 (defun spacemacs-haskell//setup-intero ()

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -17,7 +17,7 @@
 
         ;; ghci completion backend
         (company-ghci :requires company)
-         
+
         ;; ghc-mod completion backend
         (company-ghc :requires company)
         ghc

--- a/layers/+lang/hy/funcs.el
+++ b/layers/+lang/hy/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; REPL
 
 (defun spacemacs/hy-shell-eval-buffer-and-go ()

--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -60,7 +60,7 @@
     (`ensime (spacemacs//java-setup-ensime-eldoc))))
 
 
-
+
 ;; ensime
 
 (autoload 'ensime-config-find-file "ensime-config")
@@ -179,7 +179,7 @@
   (interactive)
   (ensime-type-at-point '(4) t))
 
-
+
 ;; eclim
 
 (defun spacemacs//java-setup-eclim ()
@@ -225,7 +225,7 @@
     (when (s-matches? (buffer-substring (- curr 2) (- curr 1)) ":")
       (company-emacs-eclim 'interactive))))
 
-
+
 ;; meghanada
 
 (defun spacemacs//java-setup-meghanada ()
@@ -257,7 +257,7 @@
   "Return non-nil if the Meghanada server is up."
   (and meghanada--client-process (process-live-p meghanada--client-process)))
 
-
+
 ;; Maven
 
 (defun spacemacs/mvn-clean-compile ()
@@ -266,7 +266,7 @@
   (mvn-clean)
   (mvn-compile))
 
-
+
 ;; Gradle
 
 (defun spacemacs/gradle-clean ()
@@ -284,7 +284,7 @@
   (interactive)
   (gradle-single-test (file-name-base (buffer-file-name))))
 
-
+
 ;; Misc
 
 (defun spacemacs//java-delete-horizontal-space ()
@@ -292,7 +292,7 @@
                     (buffer-substring (line-beginning-position) (point)))
     (delete-horizontal-space t)))
 
-
+
 ;; LSP Java
 
 (defun spacemacs//java-setup-lsp ()

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; backend
 
 (defun spacemacs//javascript-setup-backend ()
@@ -24,7 +24,7 @@
     (`tern (spacemacs//javascript-setup-tern-company))
     (`lsp (spacemacs//javascript-setup-lsp-company))))
 
-
+
 ;; lsp
 
 (defun spacemacs//javascript-setup-lsp ()
@@ -55,7 +55,7 @@
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))
 
-
+
 ;; tern
 (defun spacemacs//javascript-setup-tern ()
   (if (configuration-layer/layer-used-p 'tern)
@@ -71,7 +71,7 @@
     (message (concat "Tern was configured as the javascript backend but "
                      "the `tern' layer is not present in your `.spacemacs'!"))))
 
-
+
 ;; js-doc
 
 (defun spacemacs/js-doc-require ()
@@ -89,14 +89,14 @@
             'js-doc-insert-function-doc)
     "rdt" 'js-doc-insert-tag
     "rdh" 'js-doc-describe-tag))
-
+
 ;; js-refactor
 
 (defun spacemacs/js2-refactor-require ()
   "Lazy load js2-refactor"
   (require 'js2-refactor))
 
-
+
 ;; skewer
 
 (defun spacemacs/skewer-start-repl ()
@@ -131,7 +131,7 @@
   (skewer-repl)
   (evil-insert-state))
 
-
+
 ;; Others
 
 (defun spacemacs/javascript-format ()

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -28,7 +28,7 @@
     ;; lsp setup eldoc on its own
     (`anaconda (spacemacs//python-setup-anaconda-eldoc))))
 
-
+
 ;; anaconda
 
 (defun spacemacs//python-setup-anaconda ()
@@ -56,7 +56,7 @@
   (forward-button 1)
   (call-interactively #'push-button))
 
-
+
 ;; lsp
 
 (defun spacemacs//python-setup-lsp ()
@@ -83,7 +83,7 @@
         (company-mode))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-
+
 ;; others
 
 (defun spacemacs//python-default ()
@@ -229,7 +229,7 @@ as the pyenv version then also return nil. This works around https://github.com/
             (pyvenv-activate virtualenv)
           (pyvenv-workon virtualenv))))))
 
-
+
 ;; Tests
 
 (defun spacemacs//python-imenu-create-index-use-semantic-maybe ()
@@ -345,7 +345,7 @@ to be called for each testrunner. "
              (derived-mode-p 'python-mode))
     (py-isort-before-save)))
 
-
+
 ;; Formatters
 
 (defun spacemacs//bind-python-formatter-keys ()
@@ -359,7 +359,7 @@ to be called for each testrunner. "
     (`black (blacken-buffer))
     (code (message "Unknown formatter: %S" code))))
 
-
+
 ;; REPL
 
 (defun spacemacs//inferior-python-setup-hook ()

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; rbenv
 
 (defun spacemacs//enable-rbenv ()
@@ -26,7 +26,7 @@
                            "from .ruby-version file.")))
       (message "[rbenv] Using the currently activated ruby."))))
 
-
+
 ;; rspec
 
 (defun spacemacs//ruby-enable-rspec-mode ()
@@ -44,7 +44,7 @@ Called interactively it prompts for a directory."
   "Automatically enters inf-ruby-mode in ruby modes' debugger breakpoints."
   (add-hook 'compilation-filter-hook 'inf-ruby-auto-enter nil t))
 
-
+
 ;; ruby-test
 
 (defun spacemacs//ruby-enable-ruby-test-mode ()
@@ -52,7 +52,7 @@ Called interactively it prompts for a directory."
   (when (eq 'ruby-test ruby-test-runner)
     (ruby-test-mode)))
 
-
+
 ;; minitest
 
 (defun spacemacs//ruby-enable-minitest-mode ()
@@ -60,7 +60,7 @@ Called interactively it prompts for a directory."
   (when (eq 'minitest ruby-test-runner)
     (minitest-enable-appropriate-mode)))
 
-
+
 ;; highlight debugger keywords
 
 (defun spacemacs/ruby-maybe-highlight-debugger-keywords ()

--- a/layers/+lang/shell-scripts/funcs.el
+++ b/layers/+lang/shell-scripts/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; shebang
 
 (defun spacemacs/insert-shebang ()

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; backend
 
 (defun spacemacs//typescript-setup-backend ()
@@ -30,7 +30,7 @@
     (`tide (spacemacs//typescript-setup-tide-eldoc))
     (`lsp (spacemacs//typescript-setup-lsp-eldoc))))
 
-
+
 ;; tide
 
 (defun spacemacs//typescript-setup-tide ()
@@ -55,7 +55,7 @@
   "Setup eldoc for tide."
   (eldoc-mode))
 
-
+
 ;; lsp
 
 (defun spacemacs//typescript-setup-lsp ()
@@ -84,7 +84,7 @@
   "Setup eldoc for LSP."
   (eldoc-mode))
 
-
+
 ;; Others
 
 (defun spacemacs/typescript-tsfmt-format-buffer ()

--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; magit
 
 (defun spacemacs/magit-toggle-whitespace ()

--- a/layers/+source-control/github/funcs.el
+++ b/layers/+source-control/github/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; Forge
 
 (defun spacemacs/forge-get-info-from-fetched-notification-error (err)

--- a/layers/+spacemacs/spacemacs-completion/config.el
+++ b/layers/+spacemacs/spacemacs-completion/config.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; Helm
 
 (defvar helm-use-fuzzy (spacemacs|dotspacemacs-backward-compatibility

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -10,7 +10,7 @@
 ;;; License: GPLv3
 
 
-
+
 ;; Helm
 
 (defun spacemacs/helm-faces ()
@@ -186,7 +186,7 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
   (call-interactively 'helm-select-action)
   (spacemacs//helm-navigation-ts-set-face))
 
-
+
 ;; Ivy
 
 (defun spacemacs//ivy-hjkl-navigation (style)
@@ -212,7 +212,7 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
 (defun spacemacs//ivy-matcher-desc ()
   (replace-regexp-in-string "ivy--" "" (format "%s" ivy--regex-function)))
 
-
+
 ;; Ido
 
 (defun spacemacs//ido-minibuffer-setup ()

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -521,7 +521,7 @@ If the universal prefix argument is used then will the windows too."
             (if dedicated "no longer " "")
             (buffer-name))))
 
-
+
 ;; Copy file path
 
 (defun spacemacs--directory-path ()
@@ -625,7 +625,7 @@ variable."
       (message "%s" (kill-new file-path))
     (message "WARNING: Current buffer is not attached to a file!")))
 
-
+
 
 ;; adapted from bozhidar
 ;; http://emacsredux.com/blog/2013/05/18/instant-access-to-init-dot-el/
@@ -706,7 +706,7 @@ in a new frame."
   (split-window-horizontally)
   (other-window 1))
 
-
+
 ;; Window Split
 
 (defun spacemacs--window-split-splittable-windows ()
@@ -847,7 +847,7 @@ to remove windows, regardless of the value in `spacemacs-window-split-delete-fun
     (funcall spacemacs-window-split-delete-function))
   (balance-windows))
 
-
+
 
 (defun spacemacs/insert-line-above-no-indent (count)
   "Insert a new line above with no indentation."
@@ -1402,7 +1402,7 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
   (when compilation-last-buffer
     (delete-windows-on compilation-last-buffer)))
 
-
+
 ;; Line number
 
 (defun spacemacs/no-linum (&rest ignore)

--- a/layers/+spacemacs/spacemacs-editing/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; smartparens
 
 (defun spacemacs/smartparens-pair-newline (id action context)
@@ -72,7 +72,7 @@ or `sp-local-pair'."
                       :background nil
                       :foreground nil))
 
-
+
 ;; uuidgen
 ;; TODO spacemacs/uuidgen-3 and spacemacs/uuidgen-5
 

--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -67,7 +67,7 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
       (linum-mode))
   (linum-relative-toggle))
 
-
+
 ;; vi-tilde-fringe
 
 (defun spacemacs/disable-vi-tilde-fringe ()
@@ -79,7 +79,7 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
   (when buffer-read-only
     (spacemacs/disable-vi-tilde-fringe)))
 
-
+
 ;; lisp state
 
 (defun spacemacs//load-evil-lisp-state ()

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; General Persp functions
 
 (defun spacemacs//activate-persp-mode ()
@@ -80,7 +80,7 @@ Cancels autosave on exiting perspectives mode."
   (let ((ivy-ignore-buffers (remove #'spacemacs//layout-not-contains-buffer-p ivy-ignore-buffers)))
     (ivy-switch-buffer)))
 
-
+
 ;; Persp transient-state
 
 (defvar spacemacs--persp-display-buffers-func 'ignore
@@ -239,7 +239,7 @@ ask the user if a new layout should be created."
                            (spacemacs//current-layout-name)
                            persp-names-cache)))
 
-
+
 ;; Custom Persp transient-state
 
 (defun spacemacs//custom-layout-func-name (name)
@@ -327,7 +327,7 @@ format so they are supported by the
              :bindings
              ,@bindings))))
 
-
+
 ;; Persp and Projectile integration
 
 (defmacro spacemacs||switch-layout (name &rest props)
@@ -386,7 +386,7 @@ the new perspective will be killed."
              ,@body)
          (quit (persp-kill-without-buffers ,name))))))
 
-
+
 ;; Helm and Ivy common functions
 
 (defun spacemacs//create-persp-with-home-buffer (name)
@@ -397,7 +397,7 @@ the Spacemacs home buffer.  If the perspective already exists,
 just switch to it."
   (spacemacs||switch-layout name :init (spacemacs/home)))
 
-
+
 ;; Helm integration
 
 (defun spacemacs/persp-helm-mini ()
@@ -506,7 +506,7 @@ perspectives does."
                 spacemacs//helm-persp-switch-project-action)))
    :buffer "*Helm Projectile Layouts*"))
 
-
+
 ;; Ivy integration
 (defun spacemacs//ivy-persp-switch-project-action (project)
   "Default action for `spacemacs/ivy-persp-switch-project'."
@@ -525,7 +525,7 @@ perspectives does."
             :action #'spacemacs//ivy-persp-switch-project-action
             :caller 'spacemacs/ivy-persp-switch-project))
 
-
+
 ;; Eyebrowse
 
 ;; Eyebrowse uses window-state objects (as returned by `window-state-get') to
@@ -624,7 +624,7 @@ STATE is a window-state object as returned by `window-state-get'."
                            display-buffer-same-window)
                           (inhibit-same-window . nil))))
 
-
+
 ;; Eyebrowse transient state
 
 (defun spacemacs//workspaces-ts-toggle-hint ()
@@ -663,7 +663,7 @@ STATE is a window-state object as returned by `window-state-get'."
              (propertize "?" 'face 'hydra-face-red)
              "] help)"))))
 
-
+
 ;; Eyebrowse and Persp integration
 
 (defun spacemacs//get-persp-workspace (&optional persp frame)

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -17,7 +17,7 @@
         spaceline
         (counsel-projectile :requires projectile)))
 
-
+
 
 (defun spacemacs-layouts/init-eyebrowse ()
   (use-package eyebrowse
@@ -100,20 +100,20 @@
       (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
       (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config))))
 
-
+
 
 (defun spacemacs-layouts/post-init-helm ()
   (spacemacs/set-leader-keys
     "bB" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))
 
-
+
 
 (defun spacemacs-layouts/post-init-ivy ()
   (spacemacs/set-leader-keys
     "bB" 'spacemacs-layouts/non-restricted-buffer-list-ivy))
 
- 
+
 
 (defun spacemacs-layouts/init-persp-mode ()
   (use-package persp-mode
@@ -225,13 +225,13 @@
         "ba"   'persp-add-buffer
         "br"   'persp-remove-buffer))))
 
-
+
 
 (defun spacemacs-layouts/post-init-spaceline ()
   (setq spaceline-display-default-perspective
         dotspacemacs-display-default-layout))
 
-
+
 
 (defun spacemacs-layouts/init-counsel-projectile ()
   (use-package counsel-projectile

--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -29,7 +29,7 @@ Return nil if no scale is defined."
     (when (listp dotspacemacs-mode-line-theme)
       (plist-get (cdr dotspacemacs-mode-line-theme) :separator-scale))))
 
-
+
 ;; spaceline
 
 (defun spacemacs/customize-powerline-faces ()
@@ -72,7 +72,7 @@ Excluding which-key."
                           (if ascii ascii unicode))))
               (diminish mode dim))))))))
 
-
+
 ;; Vim powerline
 
 (defun spacemacs//set-vimish-powerline-for-startup-buffers ()

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; ace-window
 
 (defun spacemacs/ace-delete-window (&optional arg)
@@ -37,7 +37,7 @@ If the universal prefix argument is used then kill also the window."
        (with-selected-window window
          (spacemacs/kill-this-buffer arg))))))
 
-
+
 ;; auto-highlight symbol
 
 (defun spacemacs/goto-last-searched-ahs-symbol ()
@@ -197,7 +197,7 @@ If the universal prefix argument is used then kill also the window."
    (format spacemacs--symbol-highlight-transient-state-doc
            (spacemacs//symbol-highlight-doc))))
 
-
+
 ;; symbol overlay
 
 (defun spacemacs/symbol-overlay ()
@@ -230,7 +230,7 @@ If the universal prefix argument is used then kill also the window."
    (format spacemacs--symbol-overlay-transient-state-doc
            (spacemacs//symbol-overlay-doc))))
 
-
+
 ;; golden ratio
 
 (defun spacemacs/no-golden-ratio-for-buffers (bufname)
@@ -242,7 +242,7 @@ If the universal prefix argument is used then kill also the window."
   (or (spacemacs/no-golden-ratio-for-buffers " *guide-key*")
       (spacemacs/no-golden-ratio-for-buffers " *popwin-dummy*")))
 
-
+
 ;; smooth scrolling
 
 (defun spacemacs/enable-smooth-scrolling ()
@@ -255,7 +255,7 @@ If the universal prefix argument is used then kill also the window."
   (interactive)
   (setq scroll-conservatively 0))
 
-
+
 ;; ace-link
 
 (defvar spacemacs--link-pattern "~?/.+\\|\s\\[")
@@ -281,7 +281,7 @@ If the universal prefix argument is used then kill also the window."
       (goto-char (1+ res))
       (widget-button-press (point)))))
 
-
+
 ;; doc-view
 
 (defun spacemacs/doc-view-search-new-query ()
@@ -302,7 +302,7 @@ If the universal prefix argument is used then kill also the window."
       (doc-view-last-page)
     (doc-view-goto-page count)))
 
-
+
 ;; junk-file
 
 (defun spacemacs/open-junk-file (&optional arg)
@@ -331,7 +331,7 @@ When ARG is non-nil search in junk files."
            (let (helm-ff-newfile-prompt-p)
              (helm-find-files-1 fname))))))
 
-
+
 ;; paradox
 
 (defun spacemacs/paradox-list-packages ()
@@ -353,7 +353,7 @@ When ARG is non-nil search in junk files."
                                      paradox-token)))))
   (paradox-list-packages nil))
 
-
+
 ;; restart-emacs
 
 (defun spacemacs/restart-emacs (&optional args)

--- a/layers/+spacemacs/spacemacs-project/funcs.el
+++ b/layers/+spacemacs/spacemacs-project/funcs.el
@@ -65,7 +65,7 @@ Returns:
                             (1+ (current-column))
                           (current-column))))))
 
-
+
 (defun spacemacs/projectile-copy-directory-path ()
   "Copy and show the directory path relative to project root.
 

--- a/layers/+spacemacs/spacemacs-purpose/funcs.el
+++ b/layers/+spacemacs/spacemacs-purpose/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; eyebrowse integration
 
 (defun spacemacs/window-purpose-sync-eyebrowse ()
@@ -43,7 +43,7 @@ windows correctly."
   ;; buffer)
   (delete-other-windows))
 
-
+
 ;; Popwin integration
 
 (defun spacemacs/window-purpose-sync-popwin ()

--- a/layers/+spacemacs/spacemacs-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-visual/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; ansi-colors
 
 (defun spacemacs-visual//compilation-buffer-apply-ansi-colors ()
@@ -17,7 +17,7 @@
     (goto-char compilation-filter-start)
     (ansi-color-apply-on-region (line-beginning-position) (point-max))))
 
-
+
 ;; popwin
 
 (defun spacemacs/remove-popwin-display-config (str)
@@ -27,7 +27,7 @@
                                  (string-match str (car x))))
                  popwin:special-display-config)))
 
-
+
 ;; zoom
 
 (defun spacemacs//zoom-frm-powerline-reset ()

--- a/layers/+themes/colors/funcs.el
+++ b/layers/+themes/colors/funcs.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-
+
 ;; rainbow-identifiers
 
 (defun colors//rainbow-identifiers-mode-maybe ()

--- a/layers/+themes/colors/local/nyan-mode/nyan-mode.el
+++ b/layers/+themes/colors/local/nyan-mode/nyan-mode.el
@@ -79,7 +79,7 @@
 (defun nyan-start-music ()
   (interactive)
   (start-process-shell-command "nyan-music" "nyan-music" (concat "mplayer " +nyan-music+ " -loop 0")))
- 
+
 (defun nyan-stop-music ()
   (interactive)
   (kill-process "nyan-music"))


### PR DESCRIPTION
Remove line-feeds from the elisp files -- I noticed the ^L all over the place

Used the following to do it:

``` shell
find -type f -name *.el -not -path "./.cache/*" -not -path "./elpa/*" -exec sed -i 's/\f$//' {} \; -print
find -type f -name *.el -not -path "./.cache/*" -not -path "./elpa/*" -exec sed -i 's/\r$//' {} \; -print
find -type f -name *.el -not -path "./.cache/*"  -not -path "./elpa/*" -not -path "./tests/*" -exec sed -i 's/[[:space:]]*$//'  {} \; -print
```