### PR TITLE
[org] Document how to open today's journal

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -722,10 +722,11 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 
 ** Org-journal
 
-| Key binding   | Description            |
-|---------------+------------------------|
-| ~SPC a o j j~ | New journal entry      |
-| ~SPC a o j s~ | Search journal entries |
+| Key binding         | Description                                     |
+|---------------------+-------------------------------------------------|
+| ~SPC a o j j~       | New journal entry                               |
+| ~SPC u SPC a o j j~ | Open today's journal without adding a new entry |
+| ~SPC a o j s~       | Search journal entries                          |
 
 Journal entries are highlighted in the calendar. The following key bindings are
 available for =calendar-mode= for navigating and manipulating the journal.


### PR DESCRIPTION
Fix issue #12168 by documenting that the <kbd>SPC u</kbd> <kbd>SPC a o j j</kbd> key binding can be used to open today's journal without adding a new entry.

* `layers/+emacs/org/README.org`: Add key binding.