### PR TITLE
Update dash layer to reflect dash-docs merge

### DIFF
--- a/layers/+readers/dash/README.org
+++ b/layers/+readers/dash/README.org
@@ -50,13 +50,13 @@ The result will be displayed in the offline browser’s UI.
 
 However having to leave emacs to have a look at the search results may be a bit awkward.
 To help with this it is also possible to integrate the search results directly in =helm= or =ivy=
-and show the details in a browser. To do so [[https://github.com/areina/helm-dash][helm-dash]] can be used for =helm= and [[https://github.com/nathankot/counsel-dash][counsel-dash]] for =ivy=.
+and show the details in a browser. To do so [[https://github.com/dash-docs-el/helm-dash][helm-dash]] can be used for =helm= and [[https://github.com/dash-docs-el/counsel-dash][counsel-dash]] for =ivy=.
 
-To get them working it is necessary to set =helm-dash-docset-newpath= to the location of your docsets.
+To get them working it is necessary to set =dash-docs-docset-newpath= to the location of your docsets.
 
 #+BEGIN_SRC elisp
   (dash :variables
-        helm-dash-docset-newpath "~/.local/share/Zeal/Zeal/docsets")
+        dash-docs-docset-newpath "~/.local/share/Zeal/Zeal/docsets")
 #+END_SRC
 
 For more details please check [[https://github.com/stanaka/dash-at-point#Usage][dash-at-point-usage]] or [[https://github.com/jinzhu/zeal-at-point][zeal-at-point]].

--- a/layers/+readers/dash/config.el
+++ b/layers/+readers/dash/config.el
@@ -9,5 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(defvar helm-dash-docset-newpath "~/.docsets"
+(defvar dash-docs-docset-newpath "~/.docsets"
   "Path containing dash docsets.")
+
+(defvaralias 'helm-dash-docset-newpath 'dash-docs-docset-newpath)

--- a/layers/+readers/dash/funcs.el
+++ b/layers/+readers/dash/funcs.el
@@ -11,15 +11,7 @@
 (defun dash//activate-package-docsets (path)
   "Add dash docsets from specified PATH."
   (if (not (string-blank-p path))
-      (setq helm-dash-docsets-path path))
-  (setq helm-dash-common-docsets (helm-dash-installed-docsets))
+      (setq dash-docs-docsets-path path))
+  (setq dash-docs-common-docsets (dash-docs-installed-docsets))
   (message (format "activated %d docsets from: %s"
-                   (length helm-dash-common-docsets) path)))
-
-(defun counsel-dash-at-point ()
-  "Counsel dash with selected point"
-  (interactive)
-  (counsel-dash
-   (if (use-region-p)
-       (buffer-substring-no-properties (region-beginning) (region-end))
-     (substring-no-properties (or (thing-at-point 'symbol) "")))))
+                   (length dash-docs-common-docsets) path)))

--- a/layers/+readers/dash/packages.el
+++ b/layers/+readers/dash/packages.el
@@ -15,7 +15,7 @@
            (spacemacs/set-leader-keys
             "dh" 'helm-dash-at-point
             "dH" 'helm-dash))
-    :config (dash//activate-package-docsets helm-dash-docset-newpath)))
+    :config (dash//activate-package-docsets dash-docs-docset-newpath)))
 
 (defun dash/init-counsel-dash ()
   (use-package counsel-dash
@@ -25,7 +25,7 @@
            (spacemacs/set-leader-keys
             "dh" 'counsel-dash-at-point
             "dH" 'counsel-dash))
-    :config (dash//activate-package-docsets helm-dash-docset-newpath)))
+    :config (dash//activate-package-docsets dash-docs-docset-newpath)))
 
 (defun dash/init-dash-at-point ()
   (use-package dash-at-point


### PR DESCRIPTION
This pull request updates the `dash` layer to reflect recent changes to `helm-dash` and `counsel-dash`. Primarily the separation of `helm-dash`'s core functionality into a separate package `dash-docs`, which removed the dependency between `counsel-dash` and `helm-dash`.

This update primarily handles updating variable names from the `helm-dash-*` variant to the common `dash-docs-*` variant.

A few notes:
* I've added an alias for `helm-dash-docset-newpath` to `dash-docs-docset-newpath` to keep existing users' configuration valid.
* I removed the `counsel-dash-at-point` as this function was added to `counsel-dash` during the transition.

Thanks!