### PR TITLE
TS formatting: workspaces & layouts

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -939,6 +939,7 @@ Other:
     (thanks to Thanh Vuong)
   - Added a link to =spacemacs|create-align-repeat-x= in the docstring for
      =align-repeat-= commands (thanks to Troy Pracy)
+  - Improved TS formatting: workspaces & layouts (thanks to duianto)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -28,16 +28,16 @@
       ;; transient state
       (spacemacs|transient-state-format-hint workspaces
         spacemacs--workspaces-ts-full-hint
-        "\n\n
- Go to^^^^^^                           Actions^^^^
- ─────^^^^^^─────────────────────────  ───────^^^^───────────────────────
- [_0_.._9_]^^     nth/new workspace    [_c_/_C_] create workspace
- [_C-0_.._C-9_]^^ nth/new workspace    [_s_/_S_] single win workspace
- [_<tab>_]^^^^    last workspace       [_d_]^^   close current workspace
- [_l_]^^^^        layouts              [_R_]^^   rename current workspace
- [_n_/_C-l_]^^    next workspace       [_?_]^^   toggle help
- [_N_/_p_/_C-h_]  prev workspace\n
- [_w_]^^^^       workspace w/helm/ivy\n")
+        "\n
+ Go to^^^^^^                         Actions^^^^
+ ─────^^^^^^───────────────────────  ───────^^^^───────────────────────
+ [_0_.._9_]^^     nth/new workspace  [_c_/_C_] clone workspace
+ [_C-0_.._C-9_]^^ nth/new workspace  [_s_/_S_] single window workspace
+ [_<tab>_]^^^^    last workspace     [_d_]^^   close current workspace
+ [_n_/_C-l_]^^    next workspace     [_R_]^^   rename current workspace
+ [_N_/_p_/_C-h_]  prev workspace     [_?_]^^   toggle help
+ [_w_]^^^^        another workspace
+ [_l_]^^^^        layouts TS")
 
       (spacemacs|define-transient-state workspaces
         :title "Workspaces Transient State"
@@ -136,22 +136,22 @@
       ;; layouts transient state
       (spacemacs|transient-state-format-hint layouts
         spacemacs--layouts-ts-full-hint
-        "\n\n
- Go to^^^^^^                                  Actions^^
- ─────^^^^^^────────────────────────────────  ───────^^──────────────────────────────────────────────────
- [_0_.._9_]^^     nth/new layout              [_a_]^^   add buffer
- [_C-0_.._C-9_]^^ nth/new layout              [_A_]^^   add all from layout
- [_<tab>_]^^^^    last layout                 [_d_]^^   close current layout
- [_b_]^^^^        buffer in layout            [_D_]^^   close other layout
- [_h_]^^^^        default layout              [_L_]^^   load layouts from file
- [_l_]^^^^        layout w/helm/ivy           [_r_]^^   remove current buffer
- [_n_/_C-l_]^^    next layout                 [_R_]^^   rename current layout
- [_N_/_p_/_C-h_]  prev layout                 [_s_/_S_] save all layouts/save by names
- [_o_]^^^^        custom layout               [_t_]^^   show a buffer without adding it to current layout
- [_w_]^^^^        workspaces transient state  [_x_]^^   kill current w/buffers
- ^^^^^^                                       [_X_]^^   kill other w/buffers
- ^^^^^^                                       [_<_/_>_] move layout left/right
- ^^^^^^                                       [_?_]^^   toggle help\n")
+        "\n
+ Go to^^^^^^                        Actions^^^^
+ ─────^^^^^^──────────────────────  ───────^^^^───────────────────────────────
+ [_0_.._9_]^^     nth/new layout    [_a_]^^   add buffer
+ [_C-0_.._C-9_]^^ nth/new layout    [_A_]^^   add all buffers from layout
+ [_<tab>_]^^^^    last layout       [_d_]^^   close current layout
+ [_n_/_C-l_]^^    next layout       [_D_]^^   close other layout
+ [_N_/_p_/_C-h_]  prev layout       [_L_]^^   load layouts from file
+ [_b_]^^^^        buffer in layout  [_r_]^^   remove current buffer
+ [_h_]^^^^        default layout    [_R_]^^   rename current layout
+ [_l_]^^^^        another layout    [_s_/_S_] save all layouts/save by names
+ [_o_]^^^^        custom layout     [_t_]^^   show buffer w/o adding to layout
+ [_w_]^^^^        workspaces TS     [_x_]^^   kill current w/buffers
+ ^^^^^^                             [_X_]^^   kill other w/buffers
+ ^^^^^^                             [_<_/_>_] move layout left/right
+ ^^^^^^                             [_?_]^^   toggle help")
 
       (spacemacs|define-transient-state layouts
         :title "Layouts Transient State"


### PR DESCRIPTION
```
Remove empty lines:
- Two in the Layouts Transients State.
- Three in the Workspaces Transient State.

In the Layouts Transient State:

Move the navigation keys:
[n/C-l]    next layout
[N/p/C-h]  prev layout
closer to the top, to match the order in the Workspaces Transient State.

Change to a more generic description, without mentioning the other
completion name.
From: [l] layout w/helm/ivy
To:   [l] another layout

Shorten the descriptions:
From: [w] workspaces transient state
To:   [w] workspaces TS
and
From: [t] show a buffer without adding it to current layout
To:   [t] show buffer w/o adding to layout

Indicate what's being added:
From: [A] add all from layout
To:   [A] add all buffers from layout

In the Workspaces Transient State:

Rename "create" to "clone, because it's more descriptive and the
docstring for the variable "eyebrowse-new-workspace" says:
"nil: Clone last workspace."
From: [c/C] create workspace
To:   [c/C] clone workspace

Add "TS" to the description to indicate that it switches to the Layouts
Transient State and then it will match "workspaces TS" in the Layouts
Transient State.
From: [l] layouts
To:   [l] layouts TS

Instead of sorting "[l] layouts TS" alphabetically by it's key letter,
move it to the bottom of the "Go to" column. This has two benefits:
- The workspaces navigation keys are grouped together, without having
"[l] layouts TS" in the middle.
- And "[l] layouts TS" will be the last entry in the "Go to" column.
This matches the location of "[w] workspaces TS" in the Layouts
Transient State.

Change to a more generic description, without mentioning the other
completion name.
From: [w] workspace w/helm/ivy
To:   [w] another workspace
```
---

Layouts Transient State, Before and After

![layouts](https://user-images.githubusercontent.com/13420573/64693674-15f4e800-d498-11e9-8579-62577d701d58.png)

Workspaces Transient State, Before and After

![workspaces](https://user-images.githubusercontent.com/13420573/64693689-1ee5b980-d498-11e9-818e-ab9f98d1d1e7.png)
