### PR TITLE
Add org-cut-subtree key-bind to org layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1863,6 +1863,8 @@ Other:
     - ~SPC m i t~ for =org-set-tags-command=
   - Added key binding for org-insert-item (thanks to Emil Petersen)
     - ~SPC m i i~ for =org-insert-item=
+  - Added key binding for org-cut-subtree
+    - ~SPC m s d~ for =org-cut-subtree=
 - Key binding changes for archiving (thanks to Ag Ibragimov):
   - Added ~SPC m s a~ to toggle archive tag for subtree
   - Added ~SPC m s A~ to archive subtree (previously ~SPC m s a~)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -471,6 +471,7 @@ are also available.
 | ~SPC m s a~   | Toggle archive tag for subtree  |
 | ~SPC m s A~   | Archive subtree                 |
 | ~SPC m s b~   | org-tree-to-indirect-buffer     |
+| ~SPC m s d~   | org-cut-subtree                 |
 | ~SPC m s l~   | org-demote-subtree              |
 | ~SPC m s h~   | org-promote-subtree             |
 | ~SPC m s k~   | org-move-subtree-up             |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -239,6 +239,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "sa" 'org-toggle-archive-tag
         "sA" 'org-archive-subtree
         "sb" 'org-tree-to-indirect-buffer
+        "sd" 'org-cut-subtree
         "sh" 'org-promote-subtree
         "sj" 'org-move-subtree-down
         "sk" 'org-move-subtree-up


### PR DESCRIPTION
This binds `org-cut-subtree` to `SPC m s d`, similar in spirit to other 'delete'
bindings in evil-mode emacs.