### PR TITLE
Workspaces TS: Add single win workspace key

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -782,6 +782,9 @@ Other:
     - ~q~ exits the transient state
       (thanks to kenkangxgwe)
   - Added =link-hint-copy-link= to ~SPC x y~ (thanks to William Casarin)
+  - Added workspaces transient state key bindings (thanks to duianto):
+    - ~SPC l w s~ =spacemacs/single-win-workspace= (exits the TS)
+    - ~SPC l w S~ =spacemacs/single-win-workspace=
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -627,6 +627,12 @@ STATE is a window-state object as returned by `window-state-get'."
 
 ;; Eyebrowse transient state
 
+(defun spacemacs/single-win-workspace ()
+  "Create a new single window workspace, and show the Spacemacs home buffer."
+  (interactive)
+  (let ((eyebrowse-new-workspace 'spacemacs/home))
+    (eyebrowse-create-window-config)))
+
 (defun spacemacs//workspaces-ts-toggle-hint ()
   "Toggle the full hint docstring for the workspaces transient-state."
   (interactive)

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -29,14 +29,13 @@
       (spacemacs|transient-state-format-hint workspaces
         spacemacs--workspaces-ts-full-hint
         "\n\n
- Go to^^^^^^                         Actions^^
- ─────^^^^^^───────────────────────  ───────^^──────────────────────
- [_0_.._9_]^^     nth/new workspace  [_d_] close current workspace
- [_C-0_.._C-9_]^^ nth/new workspace  [_R_] rename current workspace
- [_<tab>_]^^^^    last workspace     [_?_] toggle help\n
- [_c_/_C_]^^      create workspace
- [_l_]^^^^        layouts
- [_n_/_C-l_]^^    next workspace
+ Go to^^^^^^                           Actions^^^^
+ ─────^^^^^^─────────────────────────  ───────^^^^───────────────────────
+ [_0_.._9_]^^     nth/new workspace    [_c_/_C_] create workspace
+ [_C-0_.._C-9_]^^ nth/new workspace    [_s_/_S_] single win workspace
+ [_<tab>_]^^^^    last workspace       [_d_]^^   close current workspace
+ [_l_]^^^^        layouts              [_R_]^^   rename current workspace
+ [_n_/_C-l_]^^    next workspace       [_?_]^^   toggle help
  [_N_/_p_/_C-h_]  prev workspace\n
  [_w_]^^^^       workspace w/helm/ivy\n")
 
@@ -80,6 +79,8 @@
         ("N" eyebrowse-prev-window-config)
         ("p" eyebrowse-prev-window-config)
         ("R" spacemacs/workspaces-ts-rename :exit t)
+        ("s" spacemacs/single-win-workspace :exit t)
+        ("S" spacemacs/single-win-workspace)
         ("w" eyebrowse-switch-to-window-config :exit t))
       ;; note: we don't need to declare the `SPC l w' binding, it is
       ;; declare in the layout transient state


### PR DESCRIPTION
Updated the Workspaces Transient State `SPC l w`.

Added a new key: `[s/S] single win workspace` to the Actions column.

It creates a new workspace with a single window, that shows the
Spacemacs home buffer.

Moved the existing key: `[c/C] create workspace` to the Actions column.