### PR TITLE
Fix canceling spacemacs/ace-buffer-links

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -974,6 +974,7 @@ Other:
     - =spacemacs-theme-comment-bg=
     - =spacemacs-theme-org-height=
       (thanks to Dominik Schrempf)
+  - Fixed canceling =spacemacs/ace-buffer-links= (thanks to duianto)
 *** Layer changes and fixes
 **** Alda
 - Key bindings:

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -277,7 +277,7 @@ If the universal prefix argument is used then kill also the window."
                (avy--process
                 (spacemacs//collect-spacemacs-buffer-links)
                 #'avy--overlay-pre))))
-    (when res
+    (when (numberp res)
       (goto-char (1+ res))
       (widget-button-press (point)))))
 


### PR DESCRIPTION
problem:
Canceling "spacemacs/ace-buffer-links" with "C-g" showed the error message:
"goto-char: Wrong type argument: number-or-marker-p, t"

solution:
Only go to and press the link if it's a position (number).

---

#### Reproduction steps:
- Spacemacs home buffer: `SPC b h`
- Ace jump to links: `o`
- Cancel: `C-g`

#### System Info :computer:
- OS: windows-nt
- Emacs: 26.2
- Spacemacs: 0.300.0
- Spacemacs branch: develop (rev. 5cc823cc0)
- Graphic display: t
- Distribution: spacemacs
- Editing style: vim
- Completion: helm
- Layers:
```elisp
(autohotkey emacs-lisp git helm markdown multiple-cursors
            (org :variables org-enable-org-journal-support t)
            spell-checking treemacs version-control)
```
- System configuration features: XPM JPEG TIFF GIF PNG RSVG SOUND NOTIFY ACL GNUTLS LIBXML2 ZLIB TOOLKIT_SCROLL_BARS THREADS LCMS2
