### PR TITLE
Add a tutorials section to SPC h T

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -859,6 +859,9 @@ Other:
   - New variable =spacemacs-yank-indent-modes= to enable auto indent in modes
     not derived from =prog-mode= (thanks to bet4it)
   - Remap ~M-SPC~ and ~SPC-x-d-SPC~ to =cycle-spacing= (thanks to bb2020)
+  - Added a =tutorials= section at ~SPC h T~ (thanks to duianto):
+    - ~SPC h T e~ for =emacs-tutorial= (aliased from =help-with-tutorial=)
+    - ~SPC h T v~ for =evil-tutor-start=
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/doc/BEGINNERS_TUTORIAL.org
+++ b/doc/BEGINNERS_TUTORIAL.org
@@ -96,10 +96,10 @@ fingers from your home row (the row where your fingers lie in rest when
 touch-typing) and without using modifier keys.
 
 ** Start the Vim tutorial
-The modal editing features of Spacemacs originate from a text editor called Vi,
-and thus the modal editing tutorial is called eVIl tutor. Press ~SPC h T~ (that
-is, the spacebar followed by ~h~ and ~T~) to familiarize yourself with
-modal editing.
+The modal editing features of Spacemacs originate from a text editor called [[https://en.wikipedia.org/wiki/Vi][Vi]],
+and thus the modal editing tutorial is called eVIl tutor. Press ~SPC h T v~
+(that is, the ~spacebar~ followed by ~h~, ~T~ and ~v~) to familiarize yourself
+with modal editing.
 
 ** Using the spacebar to launch commands
 Now that you are familiar with writing and editing text it is time to put the

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1770,9 +1770,9 @@ There are also some handy globally available key bindings related to workspaces:
 
 * Commands
 ** Vim key bindings
-Spacemacs is based on =Vim= modal user interface to navigate and edit text. If
-you are not familiar with the =Vim= way of editing text you can try the
-[[https://github.com/syl20bnr/evil-tutor][evil-tutor]] lessons by pressing ~SPC h T~ at any time.
+Spacemacs is based on the =Vim= modal user interface to navigate and edit text.
+If you are not familiar with the =Vim= way of editing text, then you can try the
+[[https://github.com/syl20bnr/evil-tutor][evil-tutor]] lessons by pressing ~SPC h T v~ at any time.
 
 *** Escaping
 Spacemacs uses [[https://github.com/syl20bnr/evil-escape][evil-escape]] to

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -127,7 +127,7 @@ where all the major-mode specific commands are bound.
 
 ** Evil-tutor
 If you are willing to learn the Vim key bindings (highly recommended since
-you can benefit from them even in =emacs= style), press ~SPC h T~
+you can benefit from them even in =emacs= style), press ~SPC h T v~
 to begin an Evil-adapted Vimtutor.
 
 ** Universal argument

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -37,6 +37,7 @@
                                        ("h"   "help")
                                        ("hd"  "help-describe")
                                        ("hP"  "profiler")
+                                       ("hT"  "tutorials")
                                        ("i"   "insertion")
                                        ("j"   "jump/join/split")
                                        ("jj"  "avy timer")
@@ -260,6 +261,7 @@
   "FO" 'spacemacs/dired-other-frame
   "Fn" 'make-frame)
 ;; help -----------------------------------------------------------------------
+(defalias 'emacs-tutorial 'help-with-tutorial)
 (spacemacs/set-leader-keys
   "hdb" 'describe-bindings
   "hdc" 'describe-char
@@ -276,7 +278,8 @@
   "hPs" 'profiler-start
   "hPk" 'profiler-stop
   "hPr" 'profiler-report
-  "hPw" 'profiler-report-write-profile)
+  "hPw" 'profiler-report-write-profile
+  "hTe" 'emacs-tutorial)
 ;; insert stuff ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "iJ" 'spacemacs/insert-line-below-no-indent

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -332,7 +332,7 @@
     (progn
       (setq evil-tutor-working-directory
             (concat spacemacs-cache-directory ".tutor/"))
-      (spacemacs/set-leader-keys "hT" 'evil-tutor-start))))
+      (spacemacs/set-leader-keys "hTv" 'evil-tutor-start))))
 
 (defun spacemacs-evil/init-evil-unimpaired ()
   ;; No laziness here, unimpaired bindings should be available right away.


### PR DESCRIPTION
`SPC h T e` for `emacs-tutorial` (aliased from `help-with-tutorial` for a more
descriptive name)
`SPC h T v` for `evil-tutor-start`

Added a wikipedia link to the `vi` article, where the origins of modal editing
is discussed.