### PR TITLE
Add keybindings for `check-parens` and `goto-last-change`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -982,6 +982,9 @@ Other:
     - =spacemacs-theme-comment-bg=
     - =spacemacs-theme-org-height=
       (thanks to Dominik Schrempf)
+  - Key bindings (thanks to bb2020)
+    - ~SPC-j-C~ to =check-parens=
+    - ~SPC-,~ to =goto-last-change=
 *** Layer changes and fixes
 **** Alda
 - Key bindings:
@@ -1925,6 +1928,7 @@ Other:
 - Replace ox-reveal with org-re-reveal (thanks to Magnus Therning)
 - Added epub support (thanks to vishvanath45)
 - Added support for CUSTOM_ID in latex exports (thanks to Compro-Prasad)
+- Added ~SPC m i L~ as =org-cliplink= into =org= layer (thanks to bb2020)
 **** Osx
 - Fixed OSX mapping issue (thanks to Joey Liu)
 - Added layer variables to customize modifier behaviors on macOS:
@@ -2182,7 +2186,6 @@ Other:
 - Moved =eshell-z-freq-dir-hash-table-file-name= into cache dir
   (thanks to bb2020)
 - Enabled ~TAB~ completion in =eshell= with =Helm= (thanks to bb2020)
-- Added ~SPC m i L~ as =org-cliplink= into =org= layer (thanks to bb2020)
 - Added =eshell= =Ivy= completion bindings (thanks to bb2020):
   - ~M-l~ =spacemacs/ivy-eshell-history=
   - ~TAB~ =spacemacs/pcomplete-std-complete=

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -132,6 +132,8 @@
     'universal-argument-more))
 ;; shell command  -------------------------------------------------------------
 (spacemacs/set-leader-keys "!" 'shell-command)
+;; last change  ---------------------------------------------------------------
+(spacemacs/set-leader-keys "," 'goto-last-change)
 ;; applications ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "ac"  'calc-dispatch
@@ -287,6 +289,7 @@
 ;; format ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "jo" 'open-line
+  "jC" 'check-parens
   "j=" 'spacemacs/indent-region-or-buffer
   "jS" 'spacemacs/split-and-new-line
   "jk" 'spacemacs/evil-goto-next-line-and-indent)


### PR DESCRIPTION
Both commands don't have keybindings. `check-parens` is built-in emacs function. `goto-last-change` comes from Evil and assigned as a top-level binding to jump rapidly through edits.