### PR TITLE
Do not delete window on closing term

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -17,6 +17,7 @@
   - [[#enable-em-smart-in-eshell][Enable em-smart in Eshell]]
   - [[#protect-your-eshell-prompt][Protect your Eshell prompt]]
   - [[#fish-shell-and-ansi-term][Fish shell and ansi-term]]
+  - [[#close-window-with-terminal][Close window with terminal]]
 - [[#eshell][Eshell]]
 - [[#key-bindings][Key bindings]]
   - [[#multi-term][Multi-term]]
@@ -182,6 +183,17 @@ correctly, in the function =dotspacemacs/user-config= of your dotfile add:
 #+BEGIN_SRC emacs-lisp
   (add-hook 'term-mode-hook 'spacemacs/toggle-truncate-lines-on)
 #+END_SRC
+
+** Close window with terminal
+If you want its window to close when the terminal terminates, set the following
+layer variable to non-nil:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((shell :variables close-window-with-terminal t)))
+#+END_SRC
+
+This is only applied to =term= and =ansi-term= modes.
 
 * Eshell
 Some advanced configuration is setup for =eshell= in this layer:

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -46,3 +46,7 @@ prompts and the prompt is made read-only")
 
 (defvar shell-default-full-span t
   "If non-nil, the `shell' buffer spans full width of a frame.")
+
+(defvar close-window-with-terminal nil
+  "If non-nil, the window is closed when the terminal is stopped.
+This is only applied to `term' and `ansi-term' modes.")

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -37,7 +37,8 @@
                             (when (string-match "\\(finished\\|exited\\)"
                                                 change)
                               (kill-buffer (process-buffer proc))
-                              (when (> (count-windows) 1)
+                              (when (and close-window-with-terminal
+                                         (> (count-windows) 1))
                                 (delete-window)))))))
 
 (defun spacemacs/default-pop-shell ()


### PR DESCRIPTION
When term or ansi-term mode buffer is closing, its window is also deleted. This
somewhat surprises the user. In addition, this does not applied to multi-term
mode and eshell mode. Users who split windows on purpose wouldn't like this
behavior. And since pop shell mode exists, users have an option.