### PR TITLE
Fix typo on org-brain-add-friendship binding.

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -567,7 +567,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "Bac" 'org-brain-add-child
         "Bv" 'org-brain-visualize
         "Bap" 'org-brain-add-parent
-        "Baf" 'org-brain-add-fiendship
+        "Baf" 'org-brain-add-friendship
         "Bgc" 'org-brain-goto-child
         "Bgp" 'org-brain-goto-parent
         "Bgf" 'org-brain-goto-friend


### PR DESCRIPTION
Simply fixing a typo on the key binding definition for org-brain-add-friendship in org layer.