### PR TITLE
Add transient state keys _, j, k

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -782,6 +782,12 @@ Other:
     - ~q~ exits the transient state
       (thanks to kenkangxgwe)
   - Added =link-hint-copy-link= to ~SPC x y~ (thanks to William Casarin)
+  - Added key bindings (thanks to duianto):
+    - Evil numbers ~SPC n _~ decrease number at point
+      and in the transient state ~j~ and ~k~
+    - Font scaling ~SPC z x _~ scale down
+    - Frame transparency ~SPC T T _~ decrease transparency
+    - Zoom frame ~SPC z f _~ zoom frame out
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1616,7 +1616,7 @@ In the transient state:
 | Key binding   | Description                    |
 |---------------+--------------------------------|
 | ~+~, ~=~, ~k~ | increase transparency          |
-| ~-~, ~j~      | decrease transparency          |
+| ~-~, ~_~, ~j~ | decrease transparency          |
 | ~T~           | toggle transparency on and off |
 | ~q~           | quit transient state           |
 
@@ -2963,7 +2963,7 @@ The font size of the current buffer can be adjusted with the commands:
 | Key binding                           | Description                                                                    |
 |---------------------------------------+--------------------------------------------------------------------------------|
 | ~SPC z x +~, ~SPC z x =~, ~SPC z x k~ | scale up the font and initiate the font scaling transient state                |
-| ~SPC z x -~, ~SPC z x j~              | scale down the font and initiate the font scaling transient state              |
+| ~SPC z x -~, ~SPC z x _~, ~SPC z x j~ | scale down the font and initiate the font scaling transient state              |
 | ~SPC z x 0~                           | reset the font size (no scaling) and initiate the font scaling transient state |
 
 In the transient state:
@@ -2971,8 +2971,9 @@ In the transient state:
 | Key binding   | Description            |
 |---------------+------------------------|
 | ~+~, ~=~, ~k~ | increase the font size |
-| ~-~, ~j~      | decrease the font size |
+| ~-~, ~_~, ~j~ | decrease the font size |
 | ~0~           | reset the font size    |
+| ~q~           | quit transient state   |
 
 Note that /only/ the text of the current buffer is scaled, the other buffers,
 the mode-line and the minibuffer are not affected. To zoom the whole content of
@@ -2984,34 +2985,38 @@ You can zoom in and out the whole content of the frame with the commands:
 | Key binding                           | Description                                                                 |
 |---------------------------------------+-----------------------------------------------------------------------------|
 | ~SPC z f +~, ~SPC z f =~, ~SPC z f k~ | zoom in the frame content and initiate the frame scaling transient state    |
-| ~SPC z f -~, ~SPC z f j~              | zoom out the frame content and initiate the frame scaling transient state   |
+| ~SPC z f -~, ~SPC z f _~, ~SPC z f j~ | zoom out the frame content and initiate the frame scaling transient state   |
 | ~SPC z f 0~                           | reset the frame content size and initiate the frame scaling transient state |
 
 In the transient state:
 
-| Key binding   | Description      |
-|---------------+------------------|
-| ~+~, ~=~, ~k~ | zoom frame in    |
-| ~-~, ~j~      | zoom frame out   |
-| ~0~           | reset frame zoom |
+| Key binding   | Description          |
+|---------------+----------------------|
+| ~+~, ~=~, ~k~ | zoom frame in        |
+| ~-~, ~_~, ~j~ | zoom frame out       |
+| ~0~           | reset frame zoom     |
+| ~q~           | quit transient state |
 
 *** Increase/Decrease numbers
 Spacemacs uses [[https://github.com/cofi/evil-numbers][evil-numbers]] to easily increase or decrease numbers.
 
-| Key binding | Description                                                         |
-|-------------+---------------------------------------------------------------------|
-| ~SPC n +~   | increase the number under point by one and initiate transient state |
-| ~SPC n -~   | decrease the number under point by one and initiate transient state |
+| Key binding          | Description                                                         |
+|----------------------+---------------------------------------------------------------------|
+| ~SPC n +~, ~SPC n =~ | increase the number under point by one and initiate transient state |
+| ~SPC n -~, ~SPC n _~ | decrease the number under point by one and initiate transient state |
 
 In the transient state:
 
-| Key binding | Description                            |
-|-------------+----------------------------------------|
-| ~+~         | increase the number under point by one |
-| ~-~         | decrease the number under point by one |
+| Key binding   | Description                            |
+|---------------+----------------------------------------|
+| ~+~, ~=~, ~k~ | increase the number under point by one |
+| ~-~, ~_~, ~j~ | decrease the number under point by one |
+| ~0..9~        | add a number prefix argument           |
+| ~q~           | quit transient state                   |
 
-*Tips:* you can increase or decrease a value by more that once by using a prefix
-argument (i.e. ~10 SPC n +~ will add 10 to the number under point).
+*Tips:* You can increase or decrease a number by more than one at a time, by
+using a prefix argument (i.e. ~10 SPC n +~ will add =10= to the number under
+point).
 
 *** Spell checking
 Spell checking is enabled by including the [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bcheckers/spell-checking/README.org][spell

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -412,6 +412,25 @@
           ("\\11..9" . "digit-argument"))
         which-key-replacement-alist)
 
+  ;; SPC n- narrow/numbers
+  ;; Combine + and =
+  (push '(("\\(.*\\)+" . "evil-numbers/inc-at-pt") .
+          ("\\1+,=" . "evil-numbers/inc-at-pt"))
+        which-key-replacement-alist)
+
+  ;; hide "= -> evil-numbers/inc-at-pt" entry
+  (push '(("\\(.*\\)=" . "evil-numbers/inc-at-pt") . t)
+        which-key-replacement-alist)
+
+  ;; Combine - and _
+  (push '(("\\(.*\\)-" . "evil-numbers/dec-at-pt") .
+          ("\\1-,_" . "evil-numbers/dec-at-pt"))
+        which-key-replacement-alist)
+
+  ;; hide "_ -> evil-numbers/dec-at-pt" entry
+  (push '(("\\(.*\\)_" . "evil-numbers/dec-at-pt") . t)
+        which-key-replacement-alist)
+
   ;; SPC x i- inflection
   ;; rename "k -> string-inflection-kebab-case"
   ;; to "k,- -> string-inflection-kebab-case"

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -771,12 +771,13 @@ otherwise it is scaled down."
 
 (spacemacs|define-transient-state scale-font
   :title "Font Scaling Transient State"
-  :doc "\n[_+_/_=_/_k_] scale up [_-_/_j_] scale down [_0_] reset font [_q_] quit"
+  :doc "\n[_+_/_=_/_k_] scale up [_-_/___/_j_] scale down [_0_] reset font [_q_] quit"
   :bindings
   ("+" spacemacs/scale-up-font)
-  ("k" spacemacs/scale-up-font)
   ("=" spacemacs/scale-up-font)
+  ("k" spacemacs/scale-up-font)
   ("-" spacemacs/scale-down-font)
+  ("_" spacemacs/scale-down-font)
   ("j" spacemacs/scale-down-font)
   ("0" spacemacs/reset-font-size)
   ("q" nil :exit t))
@@ -839,12 +840,13 @@ If FRAME is nil, it defaults to the selected frame."
 
 (spacemacs|define-transient-state scale-transparency
   :title "Frame Transparency Transient State"
-  :doc "\n[_+_/_=_/_k_] increase transparency [_-_/_j_] decrease [_T_] toggle [_q_] quit"
+  :doc "\n[_+_/_=_/_k_] increase transparency [_-_/___/_j_] decrease [_T_] toggle [_q_] quit"
   :bindings
   ("+" spacemacs/increase-transparency)
-  ("k" spacemacs/increase-transparency)
   ("=" spacemacs/increase-transparency)
+  ("k" spacemacs/increase-transparency)
   ("-" spacemacs/decrease-transparency)
+  ("_" spacemacs/decrease-transparency)
   ("j" spacemacs/decrease-transparency)
   ("T" spacemacs/toggle-transparency)
   ("q" nil :exit t))

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -282,16 +282,20 @@
       (spacemacs|define-transient-state evil-numbers
         :title "Evil Numbers Transient State"
         :doc
-        "\n[_+_/_=_] increase number  [_-_] decrease  [0..9] prefix  [_q_] quit"
+        "\n[_+_/_=_/_k_] increase number  [_-_/___/_j_] decrease  [0..9] prefix  [_q_] quit"
         :bindings
         ("+" evil-numbers/inc-at-pt)
         ("=" evil-numbers/inc-at-pt)
+        ("k" evil-numbers/inc-at-pt)
         ("-" evil-numbers/dec-at-pt)
+        ("_" evil-numbers/dec-at-pt)
+        ("j" evil-numbers/dec-at-pt)
         ("q" nil :exit t))
       (spacemacs/set-leader-keys
         "n+" 'spacemacs/evil-numbers-transient-state/evil-numbers/inc-at-pt
         "n=" 'spacemacs/evil-numbers-transient-state/evil-numbers/inc-at-pt
-        "n-" 'spacemacs/evil-numbers-transient-state/evil-numbers/dec-at-pt))))
+        "n-" 'spacemacs/evil-numbers-transient-state/evil-numbers/dec-at-pt
+        "n_" 'spacemacs/evil-numbers-transient-state/evil-numbers/dec-at-pt))))
 
 (defun spacemacs-evil/init-evil-surround ()
   (use-package evil-surround

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -96,13 +96,14 @@
         :title "Zoom Frame Transient State"
         :doc "
 [_+_/_=_/_k_] zoom frame in   [_m_] max frame
-[_-_/_j_]^^   zoom frame out  [_f_] fullscreen
+[_-_/___/_j_] zoom frame out  [_f_] fullscreen
 [_0_]^^^^     reset zoom      [_q_] quit"
         :bindings
         ("+" spacemacs/zoom-frm-in)
-        ("k" spacemacs/zoom-frm-in)
         ("=" spacemacs/zoom-frm-in)
+        ("k" spacemacs/zoom-frm-in)
         ("-" spacemacs/zoom-frm-out)
+        ("_" spacemacs/zoom-frm-out)
         ("j" spacemacs/zoom-frm-out)
         ("0" spacemacs/zoom-frm-unzoom)
         ("f" spacemacs/toggle-frame-fullscreen-non-native)


### PR DESCRIPTION
Thanks sdwolfz for the suggestion to add underscore to the transient states,
then the shift key doesn't have to be released if it was held down to press `+`.

#### Added key bindings:
Evil numbers:
`SPC n _` decrease number under point
in the transient state:
`j` decrease number under point
`k` increase number under point

`SPC T T _` decrease transparency
`SPC z x _` scale down font
`SPC z f _` zoom out frame

#### Update documentation:
Zoom frame:
`q` quit transient state

#### Evil numbers:
`SPC n =` increase number under point
`SPC n _` decrease number under point
`0..9` add a number prefix argument
`q` quit transient state

Fixed a typo and made a small rewrite of the tip about using a prefix argument.

#### Added keys to transient states:
#### Font scaling:
Added `_` scale down
Reordered `k` assignment to match the order in the transient state

#### Frame transparency:
Added `_` decrease
Reordered `k` assignment to match the order in the transient state

#### Evil numbers:
Added `k` increase
Added `_` and `j` decrease

#### Zoom frame:
Added `_` zoom frame out
Reordered `k` assignment to match the order in the transient state

#### Which-key entries for Evil numbers `SPC n`:
Group together keys that call the same command:
From: `+` and `=`
To:   `+,=`

From: `-` and `_`
To:   `-,_`