### PR TITLE
[dap] add dap-edge and dap-node for javascript debugging

### DIFF
--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -38,6 +38,8 @@
       (progn
         (require 'dap-firefox)
         (require 'dap-chrome)
+        (require 'dap-edge)
+        (require 'dap-node)
         (spacemacs/dap-bind-keys-for-mode 'js2-mode))
     (message "`dap' layer is not installed, please add `dap' layer to your dotfile.")))
 


### PR DESCRIPTION
Since dap-mode has Microsoft-edge and native-nodejs, adding them to js layer.

[emacs-lsp/dap-mode](https://github.com/emacs-lsp/dap-mode#javascript-1)