### PR TITLE
Adapt agda layer to Agda 2.6.0.0 changes (fixes #12342)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1014,6 +1014,9 @@ Other:
   - Fixed copied dir/path not shown in minibuffer when =select-enable-clipboard=
     is =nil= (thanks to duianto)
 *** Layer changes and fixes
+**** Agda
+- Fixes
+  - Fix auto bind breaking after Agda 2.6.0 api changes
 **** Alda
 - Key bindings:
   - ~SPC m r~ Play region (selected text)

--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -31,6 +31,16 @@
       (setq agda-mode-path (let ((coding-system-for-read 'utf-8))
                              (shell-command-to-string "agda-mode locate"))))
 
+    (progn
+      (setq agda-version-out (let ((coding-system-for-read 'utf-8))
+                               (shell-command-to-string "agda --version")))
+      (string-match "\\([0-9]+\\.\\)*[0-9]+" agda-version-out)
+      (setq agda-version (match-string 0 agda-version-out)))
+
+    (setq agda2-auto (if (string< agda-version "2.6.0")
+                         'agda2-auto
+                       'agda2-auto-maybe-all))
+
     (use-package agda2-mode
       :defer t
       :init (when agda-mode-path (load-file agda-mode-path))
@@ -65,7 +75,7 @@
           ","   'agda2-goal-and-context
           "="   'agda2-show-constraints
           "SPC" 'agda2-give
-          "a"   'agda2-auto
+          "a"   agda2-auto
           "c"   'agda2-make-case
           "d"   'agda2-infer-type-maybe-toplevel
           "e"   'agda2-show-context


### PR DESCRIPTION
It's now `agda2-auto-maybe-all`. They changed the functionality slightly and so have renamed it (it now tries to solve all goals if your cursor is not in a goal.)