### PR TITLE
Add a missing prefix for plantuml-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1932,6 +1932,8 @@ Other:
 **** PHP
 - Added company-php (thanks to jim and Eivind Fonn)
 - Fixed php-company autocompletion (thanks to Dela Anthonio)
+**** PlantUML
+- Added a missing prefix
 **** Platinum
 - Added the =.plum= extension to the platinum modes (thanks to Sylvain Benner)
 - Remove automatic indentation on paste (thanks to Sylvain Benner)

--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -35,6 +35,8 @@
         ;; really work, let's disable auto-indentation on paste for
         ;; this mode
         (add-to-list 'spacemacs-indent-sensitive-modes 'plantuml-mode))
+      (spacemacs/declare-prefix-for-mode 'plantuml-mode
+        "mc" "compile")
       (spacemacs/set-leader-keys-for-major-mode 'plantuml-mode
         "cc" 'plantuml-preview
         "co" 'plantuml-set-output-type))))


### PR DESCRIPTION
Added a missing prefix for `SPC m c` in `plantuml-mode`.