### PR TITLE
Update Scrolling Transient State

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -867,6 +867,7 @@ Other:
     - ~m~ for toggle maximize
     - ~f~ for toggle fullscreen
     (thanks to Ag Ibragimov)
+  - Updated Scrolling Transient State (thanks to duianto)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -136,18 +136,17 @@
   (spacemacs|define-transient-state scroll
     :title "Scrolling Transient State"
     :doc "
- Buffer^^^^              Full page^^^^     Half page^^^^        Line/column^^^^
- ──────^^^^───────────── ─────────^^^^──── ─────────^^^^─────── ───────────^^^^─────
- [_<_/_>_] beginning/end [_f_/_b_] down/up [_J_/_K_] down/up    [_j_/_k_] down/up
-  ^ ^ ^ ^                 ^ ^ ^ ^          [_H_/_L_] left/right [_h_/_l_] left/right
-  ^ ^ ^ ^                 ^ ^ ^ ^          [_d_/_u_] down/up     ^ ^ ^ ^"
+ Line/column^^^^      Half page^^^^        Full page^^ Buffer^^^^    Other
+ ───────────^^^^───── ─────────^^^^─────── ─────────^^ ──────^^^^─── ─────^^───
+ [_k_]^ ^  up         [_u_/_K_] up         [_b_] up    [_<_/_g_] beg [_q_] quit
+ [_j_]^ ^  down       [_d_/_J_] down       [_f_] down  [_>_/_G_] end
+ [_h_/_l_] left/right [_H_/_L_] left/right"
     :bindings
-    ;; buffer
-    ("<" evil-goto-first-line)
-    (">" evil-goto-line)
-    ;; full page
-    ("f" evil-scroll-page-down)
-    ("b" evil-scroll-page-up)
+    ;; lines and columns
+    ("j" evil-scroll-line-down)
+    ("k" evil-scroll-line-up)
+    ("h" evil-scroll-column-left)
+    ("l" evil-scroll-column-right)
     ;; half page
     ("d" evil-scroll-down)
     ("u" evil-scroll-up)
@@ -155,18 +154,22 @@
     ("K" evil-scroll-up)
     ("H" evil-scroll-left)
     ("L" evil-scroll-right)
-    ;; lines and columns
-    ("j" evil-scroll-line-down)
-    ("k" evil-scroll-line-up)
-    ("h" evil-scroll-column-left)
-    ("l" evil-scroll-column-right))
-  (spacemacs/set-leader-keys
-    ;; buffer
-    "N<" 'spacemacs/scroll-transient-state/evil-goto-first-line
-    "N>" 'spacemacs/scroll-transient-state/evil-goto-line
     ;; full page
-    "Nf" 'spacemacs/scroll-transient-state/evil-scroll-page-down
-    "Nb" 'spacemacs/scroll-transient-state/evil-scroll-page-up
+    ("f" evil-scroll-page-down)
+    ("b" evil-scroll-page-up)
+    ;; buffer
+    ("<" evil-goto-first-line)
+    (">" evil-goto-line)
+    ("g" evil-goto-first-line)
+    ("G" evil-goto-line)
+    ;; other
+    ("q" nil :exit t))
+  (spacemacs/set-leader-keys
+    ;; lines and columns
+    "Nj" 'spacemacs/scroll-transient-state/evil-scroll-line-down
+    "Nk" 'spacemacs/scroll-transient-state/evil-scroll-line-up
+    "Nh" 'spacemacs/scroll-transient-state/evil-scroll-column-left
+    "Nl" 'spacemacs/scroll-transient-state/evil-scroll-column-right
     ;; half page
     "Nd" 'spacemacs/scroll-transient-state/evil-scroll-down
     "Nu" 'spacemacs/scroll-transient-state/evil-scroll-up
@@ -174,11 +177,14 @@
     "NK" 'spacemacs/scroll-transient-state/evil-scroll-up
     "NH" 'spacemacs/scroll-transient-state/evil-scroll-left
     "NL" 'spacemacs/scroll-transient-state/evil-scroll-right
-    ;; lines and columns
-    "Nj" 'spacemacs/scroll-transient-state/evil-scroll-line-down
-    "Nk" 'spacemacs/scroll-transient-state/evil-scroll-line-up
-    "Nh" 'spacemacs/scroll-transient-state/evil-scroll-column-left
-    "Nl" 'spacemacs/scroll-transient-state/evil-scroll-column-right)
+    ;; full page
+    "Nf" 'spacemacs/scroll-transient-state/evil-scroll-page-down
+    "Nb" 'spacemacs/scroll-transient-state/evil-scroll-page-up
+    ;; buffer
+    "N<" 'spacemacs/scroll-transient-state/evil-goto-first-line
+    "N>" 'spacemacs/scroll-transient-state/evil-goto-line
+    "Ng" 'spacemacs/scroll-transient-state/evil-goto-first-line
+    "NG" 'spacemacs/scroll-transient-state/evil-goto-line)
 
   ;; pasting transient-state
   (evil-define-command spacemacs//transient-state-0 ()


### PR DESCRIPTION
Added new key bindings:
- In the Buffer column:
Added "g" and "G":
[</g] beg
[>/G] end
- In a new Other column:
[q] quit

Reordered the columns:
From: Large to small: buffer, full page, half page, line/column
To: Small to large: line/column, half page, full page, buffer

Reason: The most used (first listed) bindings are probably not scroll to the
"beginning" or "end" of the buffer.

Rearranged the half page columns two instances of "down/up" to one "down" and
one "up".

Reduced the TS width:
- Separated the line/column and full page keys to one "down" and one "up", and
the buffer keys to one "beginning" and one "end".
- Renamed "beginning" to "beg".

Reordered the key bindings (TS) logically: "up" above "down".

Reordered the key bindings (code):
Arranged them in the same order as the columns in the TS.