### PR TITLE
[search-engine] Add `spacemacs/search-engine-default` function

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2145,6 +2145,8 @@ Other:
 **** Scheme
 - Added missing =parinfer= package declaration (thanks to Kalle Lindqvist)
 - Update install docs for Chicken 5 changes (thanks to Grant Shangreaux)
+**** Search Engine
+- Added =search-engine-default= function (thanks to bb2020)
 **** Semantic
 - Made it possible to exclude stickyfunc (thanks to Sylvain Benner)
 - Changed the default throttle for =semanticdb-find= routines. Don't search

--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -43,9 +43,10 @@ file.
 
 * Key bindings
 
-| Evil      | Holy    | Command                                   |
-|-----------+---------+-------------------------------------------|
-| ~SPC a /~ | ~C-c /~ | Summon a Helm buffer to select any engine |
+| Evil      | Holy    | Command                                          |
+|-----------+---------+--------------------------------------------------|
+| ~SPC a /~ | ~C-c /~ | Summon a Helm buffer to select any engine        |
+| ~SPC .~   |         | Search line or region with default search engine |
 
 * Customize it!
 If you’d rather have emacs use chrome, or firefox or any other thing (=eww=) you
@@ -72,3 +73,10 @@ If you’d rather not use helm but would want a specific search engine, remember
 the function generated is always =engine/search-(the name of the search engine
 lower-case and hyphen instead-of-spaces-for-separation)= so you can bind that to
 any key binding you want.
+
+You can Customize the default search engine (for ~SPC .~) during layer configuration.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((search-engine :variables search-engine-default-entry 'wikipedia)))
+#+END_SRC

--- a/layers/+web-services/search-engine/config.el
+++ b/layers/+web-services/search-engine/config.el
@@ -1,0 +1,19 @@
+;;; config.el --- search-engine Layer Configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar search-engine-default-entry 'google
+  "Default engine to use with `spacemacs/search-engine-default'")
+
+(defvar search-engine-default-line-preloaded t
+  "If non-nil then line under point is the default value for
+`spacemacs/search-engine-default'")

--- a/layers/+web-services/search-engine/funcs.el
+++ b/layers/+web-services/search-engine/funcs.el
@@ -42,3 +42,15 @@
   (if (configuration-layer/layer-used-p 'ivy)
       (call-interactively 'spacemacs/ivy-search-engine-select)
     (call-interactively 'spacemacs/helm-search-engine-select)))
+
+(defun spacemacs/search-engine-default ()
+  "Search line or region with default engine."
+  (interactive)
+  (funcall
+   (intern (format "engine/search-%S" search-engine-default-entry))
+   (read-string
+    "Search: "
+    (if (region-active-p)
+        (buffer-substring-no-properties (region-beginning) (region-end))
+      (when search-engine-default-line-preloaded
+        (string-trim (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))))

--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -22,8 +22,8 @@
     :defines search-engine-alist
     :init
     (progn
-      (spacemacs/set-leader-keys
-        "a/" 'spacemacs/search-engine-select)
+      (spacemacs/set-leader-keys "a/" 'spacemacs/search-engine-select)
+      (spacemacs/set-leader-keys "." 'spacemacs/search-engine-default)
       (setq search-engine-alist
             '((amazon
                :name "Amazon"
@@ -40,6 +40,9 @@
               (google
                :name "Google"
                :url "https://www.google.com/search?ie=utf-8&oe=utf-8&q=%s")
+              (google-ncr
+               :name "Google NCR"
+               :url "https://www.google.com/search?q=%s&pws=0&gl=us&gws_rd=cr")
               (google-images
                :name "Google Images"
                :url "https://www.google.com/images?hl=en&source=hp&biw=1440&bih=795&gbv=2&aq=f&aqi=&aql=&oq=&q=%s")


### PR DESCRIPTION
This PR adds `spacemacs/search-engine-default` function into `search-engine` layer and binds it to `SPC .`. It looks like the binding is free. This is very similar to `spacemacs/default-pop-shell` from `shell` layer which is bound to `SPC '`. Default search function reads current line if there is not an active region. Otherwise it just reads the region. This is good for quick web searches with a simple binding. Line searching is great for searching error messages easily (for example, a line from compile log).

The variable `search-engine-default-entry` configures the engine function to call.
`(setq-default dotspacemacs-configuration-layers
'((search-engine :variables search-engine-default-entry 'wikipedia)))`

Also I've added google-ncr source to google search without region redirect. This may not be beneficial for everyone. Waiting for suggestions for that should I remove it and put it into my config.