### PR TITLE
Update Helm Transient State, show g and G keys

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -867,6 +867,10 @@ Other:
     - ~m~ for toggle maximize
     - ~f~ for toggle fullscreen
     (thanks to Ag Ibragimov)
+  - Revealed already bound Helm Transient State navigation keys:
+    - ~g~ go to first candidate
+    - ~G~ go to last candidate
+    (thanks to duianto)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -70,9 +70,9 @@
     (spacemacs|define-transient-state helm-navigation
       :title "Helm Transient State"
       :doc "
- [_j_/_k_]  next/prev candidate  [_v_]^^     persistent action     [_e_]^^    edit occurrences
- [_h_/_l_]  prev/next source     [_1_.._0_]  action 1..10          [_t_/_T_]  toggle visible/all mark
- [_q_]^^    quit                 [_a_]^^     action selection pg"
+ [_j_/_k_] next/prev candidate   [_v_]^^    persistent action    [_e_]^^   edit occurrences
+ [_h_/_l_] prev/next source      [_1_.._0_] action 1..10         [_t_/_T_] toggle visible/all mark
+ [_g_/_G_] first/last candidate  [_a_]^^    action selection pg  [_q_]^^   quit"
         :foreign-keys run
         :on-enter (spacemacs//helm-navigation-ts-on-enter)
         :on-exit  (spacemacs//helm-navigation-ts-on-exit)


### PR DESCRIPTION
Revealed already bound navigation keys:
- `g` go to first candidate
- `G` go to last candidate

Moved `[q] quit` from bottom left to bottom right, to match other TSs.
Reduced spacing between keys and descriptions from two to one space.