### PR TITLE
Allow middle mouse click pasting in term mode

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -254,6 +254,8 @@
   ;; hack to fix pasting issue, the paste transient-state won't
   ;; work in term
   (evil-define-key 'normal term-raw-map "p" 'term-paste)
+  (evil-define-key 'normal term-raw-map (kbd "<mouse-2>") 'term-mouse-paste)
+  (evil-define-key 'insert term-raw-map (kbd "<mouse-2>") 'term-mouse-paste)
   (evil-define-key 'insert term-raw-map (kbd "C-c C-d") 'term-send-eof)
   (evil-define-key 'insert term-raw-map (kbd "C-c C-z") 'term-stop-subjob)
   (evil-define-key 'insert term-raw-map (kbd "<tab>") 'term-send-tab)


### PR DESCRIPTION
Middle mouse click does not paste into term mode, i.e. term, ansi-term, multi-term. This fixes the behaviour.