### PR TITLE
Improve point handling in perltidy functions

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1959,6 +1959,10 @@ Other:
 - Fixed =spacemacs/run-pandoc= not to reset =pandoc--local-settings=
   (thanks to martian-f)
 - Added declaration for the ~SPC P~ prefix (thanks to Codruț Constantin Gușoi)
+**** Perl5
+- Fixed =spacemacs/perltidy-format-buffer= and
+  =spacemacs/perltidy-format-function= to move the point and window to their
+  original locations.
 **** PHP
 - Added company-php (thanks to jim and Eivind Fonn)
 - Fixed php-company autocompletion (thanks to Dela Anthonio)

--- a/layers/+lang/perl5/funcs.el
+++ b/layers/+lang/perl5/funcs.el
@@ -40,11 +40,19 @@ If region is active, operate on it, else operate on line."
 (defun spacemacs/perltidy-format-buffer ()
   "Format current buffer with perltidy."
   (interactive)
-  (mark-whole-buffer)
-  (spacemacs/perltidy-format))
+  (let ((old-point (point))
+        (old-window-start (window-start)))
+    (mark-whole-buffer)
+    (spacemacs/perltidy-format)
+    (goto-char old-point)
+    (set-window-start (selected-window) old-window-start)))
 
 (defun spacemacs/perltidy-format-function ()
   "Format current function with perltidy."
   (interactive)
-  (mark-defun)
-  (spacemacs/perltidy-format))
+  (let ((old-point (point))
+        (old-window-start (window-start)))
+    (mark-defun)
+    (spacemacs/perltidy-format)
+    (goto-char old-point)
+    (set-window-start (selected-window) old-window-start)))


### PR DESCRIPTION
This will move the point and content of the window close to where you were
before you ran perltidy. Of course if perltidy adds or removes a significant
amount of characters / lines as part of tidying, the point will be moved by that
amount. However in practice this I've found this to be close enough.