### PR TITLE
Remove `cider.nrepl/cider-middleware` in lein quick start setting

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1136,6 +1136,7 @@ Other:
   - ~SPC m e u~ undefine symbol in the current namespace
     (thanks to John Stevenson)
 - Fixes:
+  - Remove `cider.nrepl/cider-middleware` in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key
     binding (thanks to Brian Fay)
   - Fixed Clojure layer cider-repl-mode keybindings (thanks to Corey Ling)

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -168,8 +168,7 @@ are enabled.
       :dependencies [[nrepl "0.4.5"]]
 
       :repl-options
-      {:nrepl-middleware [cider.nrepl/cider-middleware
-                          refactor-nrepl.middleware/wrap-refactor ;; clj-refactor
+      {:nrepl-middleware [refactor-nrepl.middleware/wrap-refactor ;; clj-refactor
                           com.billpiel.sayid.nrepl-middleware/wrap-sayid ;; sayid
                           ]}}}
   #+END_SRC


### PR DESCRIPTION
Don't need this `cider.nrepl/cider-middleware` in lein profiles.clj.
    
It will result in error, the `cider.nrepl/cider-middleware` not middleware but a vector of all cider-nrepl middlewares:
    
> https://github.com/clojure-emacs/cider-nrepl/blob/master/src/cider/nrepl.clj#L483