### PR TITLE
Honor custom major-mode in spacemacs/new-empty-buffer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -477,6 +477,8 @@ Other:
   - Added line text object using =evil-textobj-line= (thanks to Uroš Perišić)
   - Added more =kaolin-themes= (thanks to ogdenwebb)
   - Calling ~spacemacs/recompile-elpa~ with an argument nukes all *.elc files (thanks to Ag Ibragimov)
+  - Allow customizing default major mode for new empty buffers in ~SPC b N n~,
+    see =dotspacemacs-new-empty-buffer-major-mode= (thanks to Juha Jeronen)
 - Fixed:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -414,6 +414,9 @@ List sizes may be nil, in which case
   "Run `spacemacs/prettify-org-buffer' when
 visiting README.org files of Spacemacs.")
 
+(defvar dotspacemacs-new-empty-buffer-major-mode nil
+  "Set the major mode for a new empty buffer.")
+
 (defun dotspacemacs//prettify-spacemacs-docs ()
   "Run `spacemacs/prettify-org-buffer' if `buffer-file-name'
 has `spacemacs-start-directory'"

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -176,6 +176,11 @@ It should only modify the values of Spacemacs settings."
    ;; True if the home buffer should respond to resize events. (default t)
    dotspacemacs-startup-buffer-responsive t
 
+   ;; Default major mode for a new empty buffer. Possible values are mode
+   ;; names such as `text-mode'; and `nil' to use Fundamental mode.
+   ;; (default `text-mode')
+   dotspacemacs-new-empty-buffer-major-mode 'text-mode
+
    ;; Default major mode of the scratch buffer (default `text-mode')
    dotspacemacs-scratch-mode 'text-mode
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -647,9 +647,10 @@ variable."
 
 (defun spacemacs/new-empty-buffer (&optional split)
   "Create a new buffer called untitled(<n>).
-A SPLIT argument with the value: `left',
-`below', `above' or `right', opens the new
-buffer in a split window."
+A SPLIT argument with the value: `left', `below', `above' or `right',
+opens the new buffer in a split window.
+If the variable `dotspacemacs-new-empty-buffer-major-mode' has been set,
+then apply that major mode to the new buffer."
   (interactive)
   (let ((newbuf (generate-new-buffer "untitled")))
     (case split
@@ -660,7 +661,9 @@ buffer in a split window."
       ('frame (select-frame (make-frame))))
     ;; Prompt to save on `save-some-buffers' with positive PRED
     (with-current-buffer newbuf
-      (setq-local buffer-offer-save t))
+      (setq-local buffer-offer-save t)
+      (when dotspacemacs-new-empty-buffer-major-mode
+        (funcall dotspacemacs-new-empty-buffer-major-mode)))
     ;; pass non-nil force-same-window to prevent `switch-to-buffer' from
     ;; displaying buffer in another window
     (switch-to-buffer newbuf nil 'force-same-window)))


### PR DESCRIPTION
Here's one possibility how to make Spacemacs honor a Customized default for major-mode when creating a new buffer with `SPC b N n`.

No idea if this is the best or correct approach, but `default-value` should at least retrieve the global value (according to [this](https://stackoverflow.com/questions/3806423/how-can-i-get-a-variables-initial-value-in-elisp)), and funcalling (the function cell of) that symbol obviously runs the mode-setting code. By my (manual) testing it seems the mode takes effect only in the new buffer, as desired.

Fixes #12382.