### PR TITLE
[dash] Fix dash//activate-package-docsets when using counsel-dash

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1213,6 +1213,9 @@ Other:
 - Fixes:
   - Fixed =d-mode= flycheck imports on dub projects (thanks to Dietrich Daroch)
 **** Dash
+- Fixes:
+  - Fix startup error when using counsel-dash with custom path in
+    helm-dash-docset-newpath (thanks to madand)
 - Improvements:
   - Use default docsets path in =helm-dash= on macos (thanks to ColorFuzzy)
 **** Deft

--- a/layers/+readers/dash/funcs.el
+++ b/layers/+readers/dash/funcs.el
@@ -10,11 +10,11 @@
 
 (defun dash//activate-package-docsets (path)
   "Add dash docsets from specified PATH."
-  (if (not (string-blank-p path))
-      (setq helm-dash-docsets-path path))
-  (setq helm-dash-common-docsets (helm-dash-installed-docsets))
+  (when (not (string-blank-p path))
+      (setq dash-docs-docsets-path (expand-file-name path)))
+  (setq dash-docs-common-docsets (dash-docs-installed-docsets))
   (message (format "activated %d docsets from: %s"
-                   (length helm-dash-common-docsets) path)))
+                   (length dash-docs-common-docsets) path)))
 
 (defun counsel-dash-at-point ()
   "Counsel dash with selected point"


### PR DESCRIPTION
When counsel-dash is installed, but helm-dash isn't, startup error
(void-function dash-docs-installed-docsets) will be triggered.

Since common functionality of both counsel-dash and helm-dash was refactored
into dash-docs, a standalone package, the layer code was updated to use the
variables and functions from that package. This also fixed the mentioned error.