### PR TITLE
[core] Workaround for buffer-list-update-hook performance issue.

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -684,10 +684,14 @@ If ARG is non nil then Ask questions to the user before installing the dotfile."
   %n -- prints Narrow if appropriate
   %z -- prints mnemonics of buffer, terminal, and keyboard coding systems
   %Z -- like %z, but including the end-of-line format"
+  ;; save-match-data to work around Emacs bug, see
+  ;; https://github.com/syl20bnr/spacemacs/issues/9700
   (save-match-data
-    ;; save-match-data to work around Emacs bug, see
-    ;; https://github.com/syl20bnr/spacemacs/issues/9700
-    (let* ((project-name (when (string-match-p "%t" title-format)
+    ;; disable buffer-list-update-hook to work around recursive invocations caused
+    ;; by the temp-buffer used by `format-spec' below, see
+    ;; https://github.com/syl20bnr/spacemacs/issues/12387
+    (let* ((buffer-list-update-hook nil)
+           (project-name (when (string-match-p "%t" title-format)
                            (if (boundp 'spacemacs--buffer-project-name)
                                spacemacs--buffer-project-name
                              (set (make-local-variable 'spacemacs--buffer-project-name)


### PR DESCRIPTION
The call to `format-spec` at the end of `spacemacs/title-prepare` creates
a temporary buffer which invokes `buffer-list-update-hook`. This in turn is
caught by treemacs' follow-mode and can lead to an action that requires a
recalculation of the frame-title, which again creates a new temp-buffer, and
so on.

The result is that in some situations Emacs will put full load on a CPU
core while it is idle (though the UI does remain responsive). The disabling
of the hook for the calculation of the frame title prevents this feedback
loop from forming.

See also https://debbugs.gnu.org/db/34/34765.html

Fixes #12387