### PR TITLE
[helm] Load helm before completion-at-point

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1528,6 +1528,7 @@ Other:
 - Added key binding `sC` for `helm-swoop-clear-cache` (thanks to Yang Qian)
 - Fixed =spacemacs//helm-open-buffers-in-windows= when opening more files than
   available windows (thanks to Juha Jeronen)
+- Load helm before =completion-at-point= (thanks to duianto)
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Added =counsel-css= as an =ivy= alternative to =helm-css-scss=

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -63,12 +63,15 @@
     :defer (spacemacs/defer)
     :init
     (progn
-      (spacemacs|add-transient-hook read-file-name
-        (lambda (&rest _args) (require 'helm))
-        lazy-load-helm-for-read-file-name)
       (spacemacs|add-transient-hook completing-read
         (lambda (&rest _args) (require 'helm))
         lazy-load-helm-for-completing-read)
+      (spacemacs|add-transient-hook completion-at-point
+        (lambda (&rest _args) (require 'helm))
+        lazy-load-helm-for-completion-at-point)
+      (spacemacs|add-transient-hook read-file-name
+        (lambda (&rest _args) (require 'helm))
+        lazy-load-helm-for-read-file-name)
       (add-hook 'helm-cleanup-hook #'spacemacs//helm-cleanup)
       ;; key bindings
       ;; Use helm to provide :ls, unless ibuffer is used


### PR DESCRIPTION
When trying to complete a path at the `:e ` evil-ex-completion prompt by
pressing `TAB`.

Before: The default Emacs `*Completions*` buffer opens.
After: The `HELM Completion At Point` buffer opens.

And sorted the transient hooks alphabetically.

---

The issue was reported in the gitter chat:
https://gitter.im/syl20bnr/spacemacs?at=5cf3ab63e41fe15e75fc0e9f