### PR TITLE
Enable prettier formatter for HTML buffers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1547,6 +1547,7 @@ Other:
 - Added missing prefixes for =web-mode= and =css-mode= (thanks to Uroš Perišić)
 - Fixed ~TAB~ indenting in =web-mode= (thanks to Christopher Eames)
 - Added =lsp= support for =css-mode=, =less-css-mode=, and =scss-mode=
+- Added support for =prettier= formatter in HTML buffers 
 **** Hy
 - Added support for virtual envs (thanks to Danny Freeman)
 - Key bindings:

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -158,7 +158,7 @@
 
 (defun html/pre-init-prettier-js ()
   (when (eq web-fmt-tool 'prettier)
-    (dolist (mode '(css-mode less-css-mode scss-mode))
+    (dolist (mode '(css-mode less-css-mode scss-mode web-mode))
       (add-to-list 'spacemacs--prettier-modes mode))))
 
 (defun html/init-pug-mode ()
@@ -292,6 +292,5 @@
                                                       slim-mode)))
 (defun html/pre-init-web-beautify ()
   (when (eq web-fmt-tool 'web-beautify)
-    (add-to-list 'spacemacs--web-beautify-modes (cons 'css-mode 'web-beautify-css)))
-  ;; always use web-beautify for a .html file
-  (add-to-list 'spacemacs--web-beautify-modes (cons 'web-mode 'web-beautify-html)))
+    (add-to-list 'spacemacs--web-beautify-modes (cons 'css-mode 'web-beautify-css))
+    (add-to-list 'spacemacs--web-beautify-modes (cons 'web-mode 'web-beautify-html))))


### PR DESCRIPTION
This PR enables `prettier` formatter for HTML buffers. Currently, `web-beautify` is being used, despite `(html :variables web-fmt-tool 'prettier)` set in `dotspacemacs/layers`. HTML is supported by `prettier` since [version 1.15.0](https://prettier.io/blog/2018/11/07/1.15.0.html).