### PR TITLE
Detecting the '.ccls' for c-c++ project powered by ccls.

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -309,7 +309,8 @@
       (when c-c++-adopt-subprojects
         (setq projectile-project-root-files-top-down-recurring
           (append '("compile_commands.json"
-                     ".cquery")
+                    ".cquery"
+                    ".ccls")
             projectile-project-root-files-top-down-recurring))))))
 
 ;; END LSP BACKEND PACKAGES


### PR DESCRIPTION
The ccls use `.ccls` for its project-file.