### PR TITLE
Add new key bindings for indirect buffer functions

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -790,6 +790,10 @@ Other:
   - Added =link-hint-copy-link= to ~SPC x y~ (thanks to William Casarin)
   - Added =evil-unimpaired= navigation keys prefixed by ~[~ and ~]~ to the
     Spacemacs home buffer (thanks to Sorawee Porncharoenwase)
+  - Added key bindings for indirect buffer functions under ~SPC b c~:
+    - ~n~ calls =make-indirect-buffer=
+    - ~c~ calls =clone-indirect-buffer=
+    - ~w~ calls =clone-indirect-buffer-other-window=
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2345,6 +2345,9 @@ Buffer manipulation commands (start with ~b~):
 |-----------------+----------------------------------------------------------------------------------------|
 | ~SPC TAB~       | switch to alternate buffer in the current window (switch back and forth)               |
 | ~SPC b b~       | switch to a buffer                                                                     |
+| ~SPC b c n~     | create an indirect buffer                                                              |
+| ~SPC b c c~     | create an indirect buffer that is clone of current buffer                              |
+| ~SPC b c w~     | create an indirect buffer that is clone of current buffer, and open it in other window |
 | ~SPC b d~       | kill the current buffer (does not delete the visited file)                             |
 | ~SPC u SPC b d~ | kill the current buffer and window (does not delete the visited file)                  |
 | ~SPC b D~       | kill a visible buffer using [[https://github.com/abo-abo/ace-window][ace-window]]                                                 |

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -23,6 +23,7 @@
                                        ("a"   "applications")
                                        ("A"   "other applications")
                                        ("b"   "buffers")
+                                       ("bc"  "indirect buffers")
                                        ("bN"  "new empty buffer")
                                        ("c"   "compile/comments")
                                        ("C"   "capture/colors")
@@ -143,6 +144,9 @@
 ;; buffers --------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "TAB"   'spacemacs/alternate-buffer
+  "b c n" 'make-indirect-buffer
+  "b c c" 'clone-indirect-buffer
+  "b c w" 'clone-indirect-buffer-other-window-without-purpose
   "bd"    'spacemacs/kill-this-buffer
   "be"    'spacemacs/safe-erase-buffer
   "bh"    'spacemacs/home

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -125,6 +125,12 @@
     :config
     (progn
       (purpose-mode)
+      ;; fix around window-purpose not respecting -other-window requirement
+      ;; of clone-indirect-buffer-other-window
+      ;; see https://github.com/bmag/emacs-purpose/issues/122
+      (defalias 'clone-indirect-buffer-other-window-without-purpose
+        (without-purpose-command #'clone-indirect-buffer-other-window))
+
       ;; change `switch-to-buffer' display preferences according to
       ;; `dotspacemacs-switch-to-buffer-prefers-purpose'. This affects actions
       ;; like `spacemacs/alternate-buffer', and opening buffers from Dired


### PR DESCRIPTION
This one adds Spacemacs-flavoured bindings for [indirect buffer](https://www.gnu.org/software/emacs/manual/html_node/emacs/Indirect-Buffers.html) functions: `make-indirect-buffer`, `clone-indirect-buffer`, `clone-indirect-buffer-other-window` under `SPC b i` prefix.