### PR TITLE
Fix lazy-loading of ruby-test-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2208,6 +2208,7 @@ Other:
 - Added the =seeing-is-believing= package (thanks to Brandon Conway)
 - Added prefixes for ruby major mode keybindings (thanks to Seong Yong-ju)
 - Added =lsp= and =dap= support (thanks to Billy Kaplan)
+- Fixed lazy loading of =ruby-test-mode= (thanks to Michael Franz Aigner)
 **** Ruby on Rails
 - Changed leader keys to be configured for the =projectile-rails-mode= minor
   mode instead of =ruby-mode= and =enh-ruby-mode= so that the key bindings will

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -304,7 +304,7 @@
 
 (defun ruby/init-ruby-test-mode ()
   "Define keybindings for ruby test mode"
-  (use-package ruby-test-mode)
+  (use-package ruby-test-mode
     :defer t
     :init (spacemacs/add-to-hooks 'spacemacs//ruby-enable-ruby-test-mode
                                   '(ruby-mode-local-vars-hook
@@ -319,7 +319,7 @@
       (dolist (mode '(ruby-mode enh-ruby-mode))
         (spacemacs/set-leader-keys-for-major-mode mode
           "tb" 'ruby-test-run
-          "tt" 'ruby-test-run-at-point))))
+          "tt" 'ruby-test-run-at-point)))))
 
 (defun ruby/init-rvm ()
   (use-package rvm


### PR DESCRIPTION
This change fixes a syntax mistake in the `use-package` declaration of `ruby-test-mode` that causes the package to be loaded immediately, instead of deferring the load until the first ruby file is visited, as is intended.