### PR TITLE
[Clojure] Add keybinding for cider-interrupt

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1155,6 +1155,8 @@ Other:
   - ~SPC m s X~ to restart the REPL (thanks to James Conroy-Finn)
   - ~SPC m e u~ undefine symbol in the current namespace
     (thanks to John Stevenson)
+  - ~SPC m e i~ interrupt the current evaluation (stop long running process)
+    (thanks to John Stevenson)
 - Fixes:
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key
     binding (thanks to Brian Fay)

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -252,6 +252,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e b~ | eval buffer                                               |
 | ~SPC m e e~ | eval last sexp                                            |
 | ~SPC m e f~ | eval function at point                                    |
+| ~SPC m e i~ | interrupt the current evaluation                   |
 | ~SPC m e r~ | eval region                                               |
 | ~SPC m e m~ | cider macroexpand 1                                       |
 | ~SPC m e M~ | cider macroexpand all                                     |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -83,6 +83,7 @@
             "eb" 'cider-eval-buffer
             "ee" 'cider-eval-last-sexp
             "ef" 'cider-eval-defun-at-point
+            "ei" 'cider-interrupt
             "em" 'cider-macroexpand-1
             "eM" 'cider-macroexpand-all
             "eP" 'cider-pprint-eval-last-sexp


### PR DESCRIPTION
Interrupt longer running evaluations without having to kill or reset the REPL connection.

Calls the `cider-interrupt` function, which is not currently mapped to a keybinding.

Placed in the evaluate section, as it is specific to the currently running evaluation.

Tested by evaluating the Clojure expression:

` (range 10000000)`

Then used `, e i` to interrupt the evaluation before it completed.