### PR TITLE
[spell-checking] Add keybinding for flyspell-correct-at-point

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2356,6 +2356,8 @@ Other:
   - ~SPC S . B~ Add word to dict (buffer)
   - ~SPC S . G~ Add word to dict (global)
   - ~SPC S . S~ Add word to dict (session)
+- Added key bindings (thanks to John Stevenson):
+  - ~SPC S s~ Correct word at point (buffer)
 **** Syntax-checking
 - Key bindings:
   - ~SPC e e~ is now for triggering a syntax check, the old action

--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -129,6 +129,7 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 | ~SPC S a s~     | Add word to dict (session)             |
 | ~SPC S b~       | Flyspell whole buffer                  |
 | ~SPC S c~       | Flyspell correct                       |
+| ~SPC S s~       | Flyspell correct at point              |
 | ~SPC u SPC S c~ | Flyspell correct all errors one by one |
 | ~SPC S d~       | Change dictionary                      |
 | ~SPC S n~       | Flyspell goto next error               |

--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -53,7 +53,9 @@ Spell Commands^^          Add To Dictionary^^               Other
 [_b_] check whole buffer  [_B_] add word to dict (buffer)   [_t_] toggle spell check
 [_d_] change dictionary   [_G_] add word to dict (global)   [_q_] exit
 [_n_] next spell error    [_S_] add word to dict (session)  [_Q_] exit and disable spell check
-[_c_] correct word"
+[_c_] correct words
+[_s_] correct at point
+"
         :on-enter (flyspell-mode)
         :bindings
         ("B" spacemacs/add-word-to-dict-buffer)
@@ -65,6 +67,7 @@ Spell Commands^^          Add To Dictionary^^               Other
         ("Q" flyspell-mode :exit t)
         ("q" nil :exit t)
         ("S" spacemacs/add-word-to-dict-session)
+        ("s" flyspell-correct-at-point)
         ("t" spacemacs/toggle-spelling-checking))
 
       (spacemacs/set-leader-keys "S." 'spacemacs/spell-checking-transient-state/body)


### PR DESCRIPTION
Add a keybinding to provide a simple way to correct the spelling of a word at
the current point.  This enables fixing the spelling mistake as it happens with
low ceremony.

`SPC S s` calls `flyspell-correct-at-point` to check the current word under the cursor.