### PR TITLE
Add force option to spacemacs//init-spacemacs-env call

### DIFF
--- a/core/core-env.el
+++ b/core/core-env.el
@@ -120,7 +120,7 @@ file."
   (interactive "P")
   (setq spacemacs--spacemacs-env-loaded t)
   (when (or force (display-graphic-p))
-    (spacemacs//init-spacemacs-env)
+    (spacemacs//init-spacemacs-env force)
     (load-env-vars spacemacs-env-vars-file)))
 
 (provide 'core-env)


### PR DESCRIPTION
Added a force option to `spacemacs//init-spacemacs-env` call in the `spacemacs/load-spacemacs-env` function. `force` was expected as a parameter, but not passed in the `...//init-spacemacs...` function call.