### PR TITLE
spacemacs/recompile-elpa with argument deletes all existing *.elc files

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -475,6 +475,7 @@ Other:
     (thanks to Dieter Komendera)
   - Added line text object using =evil-textobj-line= (thanks to Uroš Perišić)
   - Added more =kaolin-themes= (thanks to ogdenwebb)
+  - Calling ~spacemacs/recompile-elpa~ with an argument nukes all *.elc files (thanks to Ag Ibragimov)
 - Fixed:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -269,6 +269,12 @@ result, incrementing passed-tests and total-tests."
   (interactive "P")
   ;; First argument must be 0 (not nil) to get missing .elc files rebuilt.
   ;; Bonus: Optionally force recompilation with universal ARG
+  (when arg
+    (seq-do
+     (lambda (fname)
+       (when (file-exists-p fname)
+         (delete-file fname)))
+     (directory-files-recursively user-emacs-directory "\\.elc$" t)))
   (byte-recompile-directory package-user-dir 0 arg))
 
 (defun spacemacs/register-repl (feature repl-func &optional tag)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3513,7 +3513,7 @@ usable; if it is not then restart Emacs with =emacs --debug-init= and open a
 ** Upgrading/Downgrading Emacs version
 To ensure that packages are correctly compiled for the new Emacs version you
 installed, be sure to run the interactive command =spacemacs/recompile-elpa=
-with ~SPC SPC spacemacs/recompile-elpa~.
+with ~SPC u SPC SPC spacemacs/recompile-elpa~.
 
 * Achievements
 ** Issues


### PR DESCRIPTION
Rationale: very often users required to find and delete all *.elc files
manually. That's a bit tedious.
