### PR TITLE
Fix copied dir not in minibuffer, clipboard disabled

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1000,6 +1000,8 @@ Other:
   - Key bindings (thanks to bb2020)
     - ~SPC-j-C~ to =check-parens=
     - ~SPC-,~ to =goto-last-change=
+  - Fixed copied dir/path not shown in minibuffer when =select-enable-clipboard=
+    is =nil= (thanks to duianto)
 *** Layer changes and fixes
 **** Alda
 - Key bindings:

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -583,21 +583,27 @@ variable as a fallback to display the directory, useful in buffers like the
 ones created by `magit' and `dired'."
   (interactive)
   (if-let (directory-path (spacemacs--directory-path))
-      (message "%s" (kill-new directory-path))
+      (progn
+        (kill-new directory-path)
+        (message "%s" directory-path))
     (message "WARNING: Current buffer does not have a directory!")))
 
 (defun spacemacs/copy-file-path ()
   "Copy and show the file path of the current buffer."
   (interactive)
   (if-let (file-path (spacemacs--file-path))
-      (message "%s" (kill-new file-path))
+      (progn
+        (kill-new file-path)
+        (message "%s" file-path))
     (message "WARNING: Current buffer is not attached to a file!")))
 
 (defun spacemacs/copy-file-name ()
   "Copy and show the file name of the current buffer."
   (interactive)
   (if-let (file-name (file-name-nondirectory (spacemacs--file-path)))
-      (message "%s" (kill-new file-name))
+      (progn
+        (kill-new file-name)
+        (message "%s" file-name))
     (message "WARNING: Current buffer is not attached to a file!")))
 
 (defun spacemacs/copy-file-name-base ()
@@ -605,14 +611,18 @@ ones created by `magit' and `dired'."
 buffer."
   (interactive)
   (if-let (file-name (file-name-base (spacemacs--file-path)))
-      (message "%s" (kill-new file-name))
+      (progn
+        (kill-new file-name)
+        (message "%s" file-name))
     (message "WARNING: Current buffer is not attached to a file!")))
 
 (defun spacemacs/copy-file-path-with-line ()
   "Copy and show the file path of the current buffer, including line number."
   (interactive)
   (if-let (file-path (spacemacs--file-path-with-line))
-      (message "%s" (kill-new file-path))
+      (progn
+        (kill-new file-path)
+        (message "%s" file-path))
     (message "WARNING: Current buffer is not attached to a file!")))
 
 (defun spacemacs/copy-file-path-with-line-column ()
@@ -622,7 +632,9 @@ This function respects the value of the `column-number-indicator-zero-based'
 variable."
   (interactive)
   (if-let (file-path (spacemacs--file-path-with-line-column))
-      (message "%s" (kill-new file-path))
+      (progn
+        (kill-new file-path)
+        (message "%s" file-path))
     (message "WARNING: Current buffer is not attached to a file!")))
 
 

--- a/layers/+spacemacs/spacemacs-project/funcs.el
+++ b/layers/+spacemacs/spacemacs-project/funcs.el
@@ -74,21 +74,27 @@ variable as a fallback to display the directory, useful in buffers like the
 ones created by `magit' and `dired'."
   (interactive)
   (if-let (directory-path (spacemacs--projectile-directory-path))
-      (message "%s" (kill-new directory-path))
+      (progn
+        (kill-new directory-path)
+        (message "%s" directory-path))
     (message "WARNING: Current buffer does not have a directory!")))
 
 (defun spacemacs/projectile-copy-file-path ()
   "Copy and show the file path relative to project root."
   (interactive)
   (if-let (file-path (spacemacs--projectile-file-path))
-      (message "%s" (kill-new file-path))
+      (progn
+        (kill-new file-path)
+        (message "%s" file-path))
     (message "WARNING: Current buffer is not visiting a file!")))
 
 (defun spacemacs/projectile-copy-file-path-with-line ()
   "Copy and show the file path relative to project root, including line number."
   (interactive)
   (if-let (file-path (spacemacs--projectile-file-path-with-line))
-      (message "%s" (kill-new file-path))
+      (progn
+        (kill-new file-path)
+        (message "%s" file-path))
     (message "WARNING: Current buffer is not visiting a file!")))
 
 (defun spacemacs/projectile-copy-file-path-with-line-column ()
@@ -98,5 +104,7 @@ This function respects the value of the `column-number-indicator-zero-based'
 variable."
   (interactive)
   (if-let (file-path (spacemacs--projectile-file-path-with-line-column))
-      (message "%s" (kill-new file-path))
+      (progn
+        (kill-new file-path)
+        (message "%s" file-path))
     (message "WARNING: Current buffer is not visiting a file!")))


### PR DESCRIPTION
Fixed the minibuffer showing: `nil`
when `select-enable-clipboard` is `nil` and the current files
path/dir/file/line/column/etc. is copied with the keys under
the prefix: `SPC f y`

Resolves #12426