### PR TITLE
Update reveal.js cdn url for new format and v3.8.0

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -118,7 +118,7 @@ download path, as described in the [[https://github.com/yjwen/org-reveal#obtain-
 to each =.org= file you want to process:
 
 #+BEGIN_EXAMPLE
-#+REVEAL_ROOT: http://cdn.jsdelivr.net/reveal.js/3.0.0/
+#+REVEAL_ROOT: https://cdn.jsdelivr.net/npm/reveal.js@3.8.0
 #+END_EXAMPLE
 
 ** Different bullets


### PR DESCRIPTION
* jsdeliver url format changed from `<project>/<version>/file` to `npm/<project>@<version>/<file>` sometime in 2017.
  The old urls still work, but they aren't getting updated.
* The current reveal.js version is 3.8.0

current CDN version: https://cdn.jsdelivr.net/npm/reveal.js@3.8.0