### PR TITLE
Add support for visual line numbers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -875,6 +875,7 @@ Other:
     - ~m~ for toggle maximize
     - ~f~ for toggle fullscreen
     (thanks to Ag Ibragimov)
+  - Added support for visual line numbers (thanks to jcaw)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -340,10 +340,14 @@ It should only modify the values of Spacemacs settings."
    dotspacemacs-smooth-scrolling t
 
    ;; Control line numbers activation.
-   ;; If set to `t' or `relative' line numbers are turned on in all `prog-mode' and
-   ;; `text-mode' derivatives. If set to `relative', line numbers are relative.
+   ;; If set to `t', `relative' or `visual' then line numbers are enabled in all
+   ;; `prog-mode' and `text-mode' derivatives. If set to `relative', line
+   ;; numbers are relative. If set to `visual', line numbers are also relative,
+   ;; but lines are only visual lines are counted. For example, folded lines
+   ;; will not be counted and wrapped lines are counted as multiple lines.
    ;; This variable can also be set to a property list for finer control:
    ;; '(:relative nil
+   ;;   :visual nil
    ;;   :disabled-for-modes dired-mode
    ;;                       doc-view-mode
    ;;                       markdown-mode
@@ -351,6 +355,8 @@ It should only modify the values of Spacemacs settings."
    ;;                       pdf-view-mode
    ;;                       text-mode
    ;;   :size-limit-kb 1000)
+   ;; When used in a plist, the `visual' option takes precedence over
+   ;; `relative'.
    ;; (default nil)
    dotspacemacs-line-numbers nil
 

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1285,17 +1285,25 @@ If it is set to =relative=, line numbers are show in a relative way:
   (setq-default dotspacemacs-line-numbers 'relative)
 #+END_SRC
 
+If it is set to =visual=, line numbers are shown in a relative way, but wrapped
+lines will be treated as multiple lines:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-line-numbers 'visual)
+#+END_SRC
+
 =dotspacemacs-line-numbers= can also be set to a property list for finer control
 over line numbers activation.
 
 Available properties:
 
-| Property              | Description                                                                                  |
-|-----------------------+----------------------------------------------------------------------------------------------|
-| =:disabled-for-modes= | list of major modes where line numbering is inhibited                                        |
-| =:enabled-for-modes=  | disable for all major modes except those listed. Takes precedence over =:disabled-for-modes= |
-| =:relative=           | if non-nil, line numbers are relative to the position of the cursor                          |
-| =:size-limit-kb=      | size limit in kilobytes after which line numbers are not activated                           |
+| Property              | Description                                                                                                                                                                                                                                     |
+|-----------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| =:disabled-for-modes= | list of major modes where line numbering is inhibited                                                                                                                                                                                           |
+| =:enabled-for-modes=  | disable for all major modes except those listed. Takes precedence over =:disabled-for-modes=                                                                                                                                                    |
+| =:relative=           | if non-nil, line numbers are relative to the position of the cursor                                                                                                                                                                             |
+| =:visual=             | if non-nil, line numbers are relative to the position of the cursor, but lines are separated by visual state - a wrapped line, for example, will be treated as more than one line. When set to t, this option takes precedence over =:relative= |
+| =:size-limit-kb=      | size limit in kilobytes after which line numbers are not activated                                                                                                                                                                              |
 
 Note that if =:enabled-for-modes= is =nil= or not specified, then the default is
 to enable line numbers in any =prog-mode= and =text-mode= that wasn't explicitly

--- a/layers/+misc/nlinum/packages.el
+++ b/layers/+misc/nlinum/packages.el
@@ -30,7 +30,8 @@
           :config
           (progn
             (if (or (eq dotspacemacs-line-numbers t)
-                    (eq dotspacemacs-line-numbers 'relative))
+                    (eq dotspacemacs-line-numbers 'relative)
+                    (eq dotspacemacs-line-numbers 'visual))
                 (progn
                   (add-hook 'prog-mode-hook 'nlinum-mode)
                   (add-hook 'text-mode-hook 'nlinum-mode))
@@ -44,7 +45,8 @@
           (progn
             (setq nlinum-relative-current-symbol ""
                   nlinum-relative-redisplay-delay 0)
-            (when (spacemacs/relative-line-numbers-p)
+            (when (or (spacemacs/visual-line-numbers-p)
+                      (spacemacs/relative-line-numbers-p))
               (nlinum-relative-setup-evil)
               (add-hook 'nlinum-mode-hook 'nlinum-relative-on))
             (spacemacs/set-leader-keys "tr" 'spacemacs/nlinum-relative-toggle)))))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1426,6 +1426,16 @@ Decision is based on `dotspacemacs-line-numbers'."
       (and (listp dotspacemacs-line-numbers)
            (car (spacemacs/mplist-get-values dotspacemacs-line-numbers :relative)))))
 
+(defun spacemacs/visual-line-numbers-p ()
+  "Return non-nil if line numbers should be visual.
+This is similar to relative line numbers, but wrapped lines are
+treated as multiple lines.
+
+Decision is based on `dotspacemacs-line-numbers'."
+  (or (eq dotspacemacs-line-numbers 'visual)
+      (and (listp dotspacemacs-line-numbers)
+           (car (spacemacs/mplist-get-values dotspacemacs-line-numbers :visual)))))
+
 (defun spacemacs//linum-on (origfunc &rest args)
   "Advice function to improve `linum-on' function."
   (when (spacemacs/enable-line-numbers-p)
@@ -1452,7 +1462,8 @@ Decision is based on `dotspacemacs-line-numbers'."
   (and dotspacemacs-line-numbers
        (not (listp dotspacemacs-line-numbers))
        (or (eq dotspacemacs-line-numbers t)
-           (eq dotspacemacs-line-numbers 'relative))
+           (eq dotspacemacs-line-numbers 'relative)
+           (eq dotspacemacs-line-numbers 'visual))
        (derived-mode-p 'prog-mode 'text-mode)))
 
 (defun spacemacs//linum-curent-buffer-is-not-too-big ()

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -187,9 +187,12 @@
     :defer t
     :init
     (progn
-      (if (spacemacs/relative-line-numbers-p)
-          (setq display-line-numbers-type 'relative)
-        (setq display-line-numbers-type t))
+      (cond ((spacemacs/visual-line-numbers-p)
+             (setq display-line-numbers-type 'visual))
+            ((spacemacs/relative-line-numbers-p)
+             (setq display-line-numbers-type 'relative))
+            (t
+             (setq display-line-numbers-type t)))
 
       (spacemacs|add-toggle line-numbers
         :status (and (featurep 'display-line-numbers)
@@ -213,6 +216,17 @@
         :on-message "Relative line numbers enabled."
         :off-message "Line numbers disabled."
         :evil-leader "tr")
+      (spacemacs|add-toggle visual-line-numbers
+        :status (and (featurep 'display-line-numbers)
+                     display-line-numbers-mode
+                     (eq display-line-numbers 'visual))
+        :on (prog1 (display-line-numbers-mode)
+              (setq display-line-numbers 'visual))
+        :off (display-line-numbers-mode -1)
+        :documentation "Show relative visual line numbers."
+        :on-message "Visual line numbers enabled."
+        :off-message "Line numbers disabled."
+        :evil-leader "tV")
 
       (when (spacemacs//linum-backward-compabitility)
         (add-hook 'prog-mode-hook 'display-line-numbers-mode)

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -366,7 +366,8 @@
     :commands (linum-relative-toggle linum-relative-on)
     :init
     (progn
-      (when (spacemacs/relative-line-numbers-p)
+      (when (or (spacemacs/visual-line-numbers-p)
+                (spacemacs/relative-line-numbers-p))
         (add-hook 'spacemacs-post-user-config-hook 'linum-relative-on))
       (spacemacs/set-leader-keys "tr" 'spacemacs/linum-relative-toggle))
     :config


### PR DESCRIPTION
Emacs 26 added built-in support for line numbers, relative line numbers, and
[visual line numbers](https://www.gnu.org/software/emacs/manual/html_node/emacs/Display-Custom.html). Spacemacs supports only absolute and relative, but there is
**no way to access the visual mode.** It's hard to get around this, since Spacemacs
abstracts line numbers. 

Arguably, `visual` is much more useful than `relative` as a display type. Visual
line numbers are like relative line numbers, but only lines that are actually
showing are counted. This means:

  1. Hidden lines are not counted. If a large amount of text is folded, the line
     numbers won't jump from "10" to "546". This is particularly useful in
     buffers like `magit-status`, where a large amount of information is folded
     by default.

  2. Lines that are wrapped are counted as multiple lines, since they're being
     displayed as multiple lines in the editor. Under `relative`, the entire 
     wrapped line is numbered once, meaning numbers skip one or more 
     lines. `visual` labels them all.

With standard relative line numbers, you can't actually navigate using the line
numbers in the sidebar as soon as folded or wrapped lines are introduced, 
since the numbers don't correspond to movements. The actual number of 
lines between your cursor and the target position is different to the number 
displayed. Since this is one of the main use cases for relative line numbers, 
it undermines the mode.

`visual` fixes that problem. Every line that's being displayed is labelled.
Numbers always correspond to the actual number of lines you'd need to 
navigate to reach the target.

This pull request extends Spacemacs' line number interface to provide visual 
line number support.