### PR TITLE
[treemacs] Load projectile key binding with treemacs

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2452,6 +2452,8 @@ Other:
 - Add missing ~SPC p t~ to =readme.org= (thanks to oo6)
 - Remapped =winum-select-window-0-or-10= to =treemacs-select-window= so that
   ~C-x w 0~, ~SPC 0~ and ~M-0~ call the same command (thanks to duianto, Miciah)
+- Loaded =treemacs-projectile= key binding ~C-c C-p p~ with Treemacs
+  (thanks to duianto)
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -79,7 +79,8 @@
 (defun treemacs/init-treemacs-projectile ()
   (use-package treemacs-projectile
     :after treemacs
-    :defer t))
+    :defer t
+    :init (require 'treemacs-projectile)))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
The `C-c C-p p` (`treemacs-projectile`) key binding wasn't loading automatically
with Treemacs, until the command had been called manually.