### PR TITLE
Ignore tags files from gtags, ctags, and etags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,20 @@ private/
 /games/
 /doc/COMMUNITY.org
 /doc/CONTRIBUTING.org
+
+# Ignore tags created by etags, ctags, gtags (GNU global) and cscope
+TAGS
+.TAGS
+!TAGS/
+tags
+.tags
+!tags/
+gtags.files
+GTAGS
+GRTAGS
+GPATH
+GSYMS
+cscope.files
+cscope.out
+cscope.in.out
+cscope.po.out

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -395,6 +395,7 @@ sane way, here is the complete list of changed key bindings
     (thanks to Eugene Yaremenko and Sylvain Benner)
   - New variable =dotspacemacs-undecorated-at-startup= (thanks to bb2020)
 Other:
+  - =.gitignore= now ignores tag files.
   - Added =vim-style-visual-feedback= and =hybrid-style-visual-feedback= style
     variables to enable =evil-goggles= pulse in the Vim and Hybrid editing
     styles, respectively; disabled by default (thanks to Sylvain Benner)


### PR DESCRIPTION
I only added the three lines to the `.gitignore`. Normally you would not want to watch these; they are binary files.

I've tested all three, these are the default names.