### PR TITLE
[core] Restore point in spacemacs/alternate-buffer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -559,6 +559,7 @@ Other:
     (thanks to Alexander Miller)
   - Added missing force argument to the =spacemacs//init-spacemacs-env= call in
     the function =spacemacs/load-spacemacs-env= (thanks to sergeiz2)
+  - Fixed =spacemacs/alternate-buffer= to restore point.
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -313,14 +313,11 @@ buffer."
   "Switch back and forth between current and last buffer in the
 current window."
   (interactive)
-  (let ((current-buffer (window-buffer window)))
-    ;; if no window is found in the windows history, `switch-to-buffer' will
-    ;; default to calling `other-buffer'.
-    (switch-to-buffer
-     (cl-find-if (lambda (buffer)
-                   (not (eq buffer current-buffer)))
-                 (mapcar #'car (window-prev-buffers window)))
-     nil t)))
+  (destructuring-bind (buf start pos)
+      (or (cl-find (window-buffer window) (window-prev-buffers)
+                   :key #'car :test-not #'eq)
+          (list (other-buffer) nil nil ))
+    (set-window-buffer-start-and-point window buf start pos)))
 
 (defun spacemacs/alternate-window ()
   "Switch back and forth between current and last window in the


### PR DESCRIPTION
* `core/core-funcs.el` (`spacemacs/alternate-buffer`): Instead of using `switch-to-buffer`, use `set-window-buffer-start-and-point`, specifying the previous window start position and point if known.  Replace use of `cl-find-if` with `cl-find`.
* `CHANGELOG.develop`: Add entry for change to `spacemacs/alternate-buffer`.