### PR TITLE
update symbol regex when searching

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -54,7 +54,7 @@ If the universal prefix argument is used then kill also the window."
         ;; isearch-string is last searched item.  Next time
         ;; "n" is hit we will use this.
         (let* ((symbol (evil-find-thing forward 'symbol))
-               (regexp (concat "\\<" symbol "\\>")))
+               (regexp (concat "\\_<" (regexp-quote symbol) "\\_>")))
           (setq isearch-string regexp
                 isearch-regexp regexp
                 evil-ex-search-pattern (evil-ex-make-search-pattern regexp)))


### PR DESCRIPTION
There is a bug when searching for symbols that start with `_` on the transition out of the transient highlight mode and into regular text mode (searching w/ `n` in evil's normal mode).

This PR updates the searching regexp recalled upon `n` after `*` to produce the correct behavior.

The update mirrors the logic in the `auto-hightlight-symbol` package's function `ahs-search-symbol` (without setting a regexp group around the symbol) as `*` seems to do the correct thing.