### PR TITLE
dash: provide config option to skip auto-load of all docsets

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -122,6 +122,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 ***** C-C++
 - CMake support has been extracted from the =c-c++= layer into the new =cmake=
   layer.
+***** Dash
+- Added config option `dash-autoload-common-docsets` to toggle init behavior
 ***** ESS
 - ESS key bindings were re-organised in the following list
   (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):

--- a/layers/+readers/dash/README.org
+++ b/layers/+readers/dash/README.org
@@ -13,6 +13,7 @@
   - [[#dash-os-x][Dash (OS X)]]
     - [[#sqlite3][Sqlite3]]
   - [[#zeal-linux--windows][Zeal (Linux & Windows)]]
+- [[#configuration][Configuration]]
 - [[#word-at-point][Word at point]]
 - [[#key-bindings][Key bindings]]
 
@@ -44,6 +45,20 @@ You have to install [[https://zealdocs.org/][zeal]] on your machine.
 
 Then install the docsets you use more frequently
 
+* Configuration
+By default, the dash layer will initialize all installed docsets to be active in
+all buffers. To disable this and opt-in to specific docsets for specific buffers, set:
+#+BEGIN_SRC emacs-lisp
+(dash :variables
+      dash-autoload-common-docsets nil)
+#+END_SRC
+
+To change the location of the installed docsets, set:
+#+BEGIN_SRC elisp
+(dash :variables
+      helm-dash-docset-newpath "~/.docsets")
+#+END_SRC
+
 * Word at point
 =dash-at-point= and =zeal-at-point= will search for the word at point in the respective offline api browser.
 The result will be displayed in the offline browser's UI.
@@ -51,13 +66,6 @@ The result will be displayed in the offline browser's UI.
 However having to leave emacs to have a look at the search results may be a bit awkward.
 To help with this it is also possible to integrate the search results directly in =helm= or =ivy=
 and show the details in a browser. To do so [[https://github.com/areina/helm-dash][helm-dash]] can be used for =helm= and [[https://github.com/nathankot/counsel-dash][counsel-dash]] for =ivy=.
-
-To get them working it is necessary to set =helm-dash-docset-newpath= to the location of your docsets.
-
-#+BEGIN_SRC elisp
-  (dash :variables
-        helm-dash-docset-newpath "~/.local/share/Zeal/Zeal/docsets")
-#+END_SRC
 
 For more details please check [[https://github.com/stanaka/dash-at-point#Usage][dash-at-point-usage]] or [[https://github.com/jinzhu/zeal-at-point][zeal-at-point]].
 

--- a/layers/+readers/dash/config.el
+++ b/layers/+readers/dash/config.el
@@ -9,5 +9,8 @@
 ;;
 ;;; License: GPLv3
 
+(defvar dash-autoload-common-docsets t
+  "If non nil, autoload all installed docsets as common docsets")
+
 (defvar helm-dash-docset-newpath "~/.docsets"
   "Path containing dash docsets.")

--- a/layers/+readers/dash/packages.el
+++ b/layers/+readers/dash/packages.el
@@ -15,7 +15,8 @@
            (spacemacs/set-leader-keys
             "dh" 'helm-dash-at-point
             "dH" 'helm-dash))
-    :config (dash//activate-package-docsets helm-dash-docset-newpath)))
+    :config (when dash-autoload-common-docsets
+              (dash//activate-package-docsets helm-dash-docset-newpath))))
 
 (defun dash/init-counsel-dash ()
   (use-package counsel-dash
@@ -25,7 +26,8 @@
            (spacemacs/set-leader-keys
             "dh" 'counsel-dash-at-point
             "dH" 'counsel-dash))
-    :config (dash//activate-package-docsets helm-dash-docset-newpath)))
+    :config (when dash-autoload-common-docsets
+              (dash//activate-package-docsets helm-dash-docset-newpath))))
 
 (defun dash/init-dash-at-point ()
   (use-package dash-at-point


### PR DESCRIPTION
In the upstream dash-docs and helm-dash documentation, they suggest a workflow
where users leave relatively little in `dash-common-docsets`, and instead add
per-mode hooks to enable specific docsets, since a user is unlikely to want
Python documentation while in a C++ buffer and vice versa. Currently, the
spacemacs dash layer will automatically discover all installed docsets and add
them to `dash-common-docsets`.

This commit adds a config option `dash-autoload-common-docsets` that can be set
to nil to skip the auto-loading and allow users to opt-in.