### PR TITLE
feat(clojure-lang): add `cider-eval-sexp-at-point`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1184,6 +1184,7 @@ Other:
     (thanks to John Stevenson)
   - ~SPC m e i~ interrupt the current evaluation (stop long running process)
     (thanks to John Stevenson)
+  - ~SPC m e v~ to evaluate s-expression at point (=cider-eval-sexp-at-point=)
 - Fixes:
   - Remove `cider.nrepl/cider-middleware` in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -258,6 +258,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m e p~ | print last sexp (clojure interaction mode only)           |
 | ~SPC m e P~ | eval last sexp and pretty print result in separate buffer |
 | ~SPC m e u~ | Undefine a symbol from the current namespace              |
+| ~SPC m e v~ | eval sexp around point                                    |
 | ~SPC m e w~ | eval last sexp and replace with result                    |
 
 *** Goto

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -83,6 +83,7 @@
             "eb" 'cider-eval-buffer
             "ee" 'cider-eval-last-sexp
             "ef" 'cider-eval-defun-at-point
+            "ev" 'cider-eval-sexp-at-point
             "ei" 'cider-interrupt
             "em" 'cider-macroexpand-1
             "eM" 'cider-macroexpand-all


### PR DESCRIPTION
Adds a useful CIDER command that doesn't have an idiomatic Spacemacs command.

Ref:
https://cider.readthedocs.io/en/latest/interactive_programming/#using-cider-mode