### PR TITLE
Add j/k to evil-numbers transient state

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -897,6 +897,7 @@ Other:
     - ~G~ go to last candidate
     (thanks to duianto)
   - Added support for visual line numbers (thanks to jcaw)
+  - Updated evil-numbers transient state to run foreign keys (thanks to Jake Romer)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -283,6 +283,7 @@
         :title "Evil Numbers Transient State"
         :doc
         "\n[_+_/_=_] increase number  [_-_] decrease  [0..9] prefix  [_q_] quit"
+        :foreign-keys run
         :bindings
         ("+" evil-numbers/inc-at-pt)
         ("=" evil-numbers/inc-at-pt)


### PR DESCRIPTION
A common use case for vim's / evil-mode's `inc-at-point`/`dec-at-point` is to change numbers across several lines, as in numbered lists. This patch adds `next-line` / `previous-line` to `evil-numbers-transient-state` to enable incrementing across lines without having to exist and restart the transient state.

#### Before

![demo-before](https://user-images.githubusercontent.com/4433943/60745196-2abc7900-9f47-11e9-9c54-7012f560c3c5.gif)

#### After

![demo-after](https://user-images.githubusercontent.com/4433943/60745835-f7c7b480-9f49-11e9-8f1f-1c3e6b3faaed.gif)
