### PR TITLE
core: Ugly fix for set-default-font

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -95,6 +95,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - The property =:powerline-scale= of variable =dotspacemacs-default-font= has
   been removed and replaced by the property =:separator-scale= used in the new
   dotfile variable =dotspacemacs-mode-line-theme=.
+- Fixup =dotspacemacs-default-font- to properly set the configured font.  
 **** Layers
 ***** Spacemacs distribution layers
 - Key bindings:

--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -34,7 +34,7 @@ The return value is nil if no font was found, truthy otherwise."
                             (spacemacs/mplist-remove props :powerline-scale)
                             :powerline-offset))
                (fontspec (apply 'font-spec :name font font-props)))
-          (spacemacs-buffer/message "Setting font \"%s\"..." font)
+          (message "Using font: [%s]" fontspec)
           (set-frame-font fontspec nil t)
           (push `(font . ,(frame-parameter nil 'font)) default-frame-alist)
           ;; fallback font for unicode characters used in spacemacs


### PR DESCRIPTION
Since my elisp knowledge is pretty limited, I'm not really sure why but it turns out this small change makes `dotspacemacs-default-font` working as expected.

Either by:
 1) using `spacemacs-buffer/message` to print `fontspec`
    or
 2) using `message` to print font
is not working, unless emacs is started with `--debug-init`.

The change above is the only (nonsense) combination which makes fonts settings working in my setup. With that change, I can successfully both change font (among the installed ones) and its size. Without that change, whatever settings I try the font is not set.

So, the patch is ugly because it "fixes" an issue without really pointing out what's the issue. Nevertheless, I hope the above change can help more knowledgable folks to pinpoint the real problem.