### PR TITLE
Enables eldoc for anaconda-mode

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -26,7 +26,7 @@
   "Conditionally setup eldoc based on backend."
   (pcase python-backend
     ;; lsp setup eldoc on its own
-    (spacemacs//python-setup-anaconda-eldoc)))
+    (`anaconda (spacemacs//python-setup-anaconda-eldoc))))
 
 ;; anaconda
 


### PR DESCRIPTION
Enables eldoc in anaconda mode which was currently not working, because lsp already sets it up on it's own i think ?