### PR TITLE
Show *lsp-help* in a popup window using popwin

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1859,6 +1859,7 @@ Other:
     - ~SPC m t d~ convert region to table
 - Bound major mode leader key and ~M-RET~ to =markdown-insert-list-item= for
   terminal users (thanks to AmaiKinono)
+- Made =*lsp-help*= buffer shown in a popup window using popwin
 **** Major modes
 - Added SPARQL-mode (thanks to Dietrich Daroch)
 - Move =extra-langs= to =major-modes= (thanks to Eivind Fonn)

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -16,6 +16,7 @@
     (company-lsp :requires company)
     helm-lsp
     lsp-treemacs
+    popwin
     ))
 
 (defun lsp/init-lsp-mode ()
@@ -56,3 +57,7 @@
 
 (defun lsp/init-lsp-treemacs ()
   (use-package lsp-treemacs :defer t))
+
+(defun lsp/post-init-popwin ()
+  (push '("*lsp-help*" :dedicated t :position bottom :stick t :noselect t :height 0.4)
+        popwin:special-display-config))


### PR DESCRIPTION
Show `*lsp-help*` buffer in a popup window using popwin.