### PR TITLE
Fix ansible layer for upstream changes in ansible minor mode

### DIFF
--- a/layers/+tools/ansible/README.org
+++ b/layers/+tools/ansible/README.org
@@ -35,7 +35,7 @@ password to use somewhere in your =dotspacemacs/user-config= function.
 For instance:
 
 #+BEGIN_SRC emacs-lisp
-  (setq ansible::vault-password-file "path/to/pwd/file")
+  (setq ansible-vault-password-file "path/to/pwd/file")
 #+END_SRC
 
 The default value is the ansible-vault default value: =~/.vault_pass.txt=.
@@ -49,7 +49,7 @@ password file for a given environment. Example:
   ;;; Directory Local Variables
   ;;; For more information see (info "(emacs) Directory Variables")
 
-  ((yaml-mode . ((ansible::vault-password-file . "path/to/vault_file"))))
+  ((yaml-mode . ((ansible-vault-password-file . "path/to/vault_file"))))
 #+END_SRC
 
 *** Automatic encryption and decryption

--- a/layers/+tools/ansible/funcs.el
+++ b/layers/+tools/ansible/funcs.el
@@ -22,7 +22,7 @@
 (defun spacemacs/ansible-auto-decrypt-encrypt-vault ()
   "Auto decrypt/encrypt Vault files."
   (when (spacemacs//ansible-should-enable?)
-    (ansible::auto-decrypt-encrypt)))
+    (ansible-auto-decrypt-encrypt)))
 
 (defun spacemacs/ansible-company-maybe-enable ()
   "Add the ansible company backend only for when ansible mode is active."

--- a/layers/+tools/ansible/packages.el
+++ b/layers/+tools/ansible/packages.el
@@ -19,11 +19,11 @@
 (defun ansible/init-ansible ()
   (use-package ansible
     :defer t
-    :commands ansible::auto-decrypt-encrypt
+    :commands ansible-auto-decrypt-encrypt
     :init
     (progn
       (add-hook 'yaml-mode-hook 'spacemacs/ansible-maybe-enable)
-      (put 'ansible::vault-password-file 'safe-local-variable #'stringp)
+      (put 'ansible-vault-password-file 'safe-local-variable #'stringp)
       (if ansible-auto-encrypt-decrypt
           ;; add this hook to local-vars-hook to allow users to specify
           ;; a password file in directory local variables
@@ -35,8 +35,8 @@
     :config
     (progn
       (spacemacs/set-leader-keys-for-minor-mode 'ansible
-       "bd" 'ansible::decrypt-buffer
-       "be" 'ansible::encrypt-buffer))))
+       "bd" 'ansible-decrypt-buffer
+       "be" 'ansible-encrypt-buffer))))
 
 (defun ansible/init-ansible-doc ()
   (use-package ansible-doc


### PR DESCRIPTION
Ansible minor mode was recently updated to follow emacs-lisp style naming
convention. This commit makes corresponding function name changes to fix 
ansible layer.

Reference:
* https://github.com/k1LoW/emacs-ansible/issues/28
* https://github.com/k1LoW/emacs-ansible/pull/31