### PR TITLE
Change default font size from 13 to 10.0

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -483,6 +483,8 @@ Other:
   - Calling ~spacemacs/recompile-elpa~ with an argument nukes all *.elc files (thanks to Ag Ibragimov)
   - Allow customizing default major mode for new empty buffers in ~SPC b N n~,
     see =dotspacemacs-new-empty-buffer-major-mode= (thanks to Juha Jeronen)
+  - Changed =dotspacemacs-default-font= =:size= from =13= (pixel size) to =10.0=
+    (point size) (thanks to duianto)
 - Fixed:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -209,7 +209,7 @@ It should only modify the values of Spacemacs settings."
 
    ;; Default font or prioritized list of fonts.
    dotspacemacs-default-font '("Source Code Pro"
-                               :size 13
+                               :size 10.0
                                :weight normal
                                :width normal)
 


### PR DESCRIPTION
13 and 10.0 are visually the same, because:
- Integer specifies the pixel size.
- Floating-point specifies the point size.

Using a default floating-point size has two benefits:
- It's clear that the font size can be changed by floating-point values.
- There won't be an unpleasant surprise that `13` and `13.0` are different
  sizes. For example to make the font slightly larger or smaller than `13`.
  Then `10.0` has to be found first by trial and error.

Resolves: #12490