### PR TITLE
Go linters

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -58,10 +58,10 @@ to get all the goodies of this layer:
 
 If you wish to use a linters aggregator tool, you can enable =gometalinter= or =golangci-lint=.
 
-If you wish to use =gometalinter= set the value of =go-use-gometalinter= to t:
+If you wish to use =gometalinter= set the value of =go-linter= to ='gometalinter=:
 
 #+BEGIN_SRC emacs-lisp
-  (go :variables go-use-gometalinter t)
+  (go :variables go-linter 'gometalinter)
 #+END_SRC
 
 and install the tool:
@@ -74,10 +74,10 @@ and install the tool:
 For more information read [[https://github.com/alecthomas/gometalinter/blob/master/README.md][gometalinter README.md]]
 and [[https://github.com/favadi/flycheck-gometalinter/blob/master/README.md][flycheck-gometalinter README.md]]
 
-If you wish to use =golangci-lint= set the value of =go-use-golangci-lint= to t:
+If you wish to use =golangci-lint= set the value of =go-linter= to ='golangci-lint=:
 
 #+BEGIN_SRC emacs-lisp
-  (go :variables go-use-golangci-lint t)
+  (go :variables go-linter 'golangci-lint)
 #+END_SRC
 
 and install the tool:

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -25,11 +25,8 @@
 (defvar go-tab-width 8
   "Set the `tab-width' in Go mode. Default is 8.")
 
-(defvar go-use-gometalinter nil
-  "Use gometalinter if the variable has non-nil value.")
-
-(defvar go-use-golangci-lint nil
-  "Use golangci-lint if the variable has non-nil value.")
+(defvar go-linter nil
+  "The linter to use for go code. Possible values are: `gometalinter' and `golangci-lint'.")
 
 (defvar go-test-buffer-name "*go test*"
   "Name of the buffer for go test output. Default is *go test*.")

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -40,7 +40,7 @@
       (progn
         ;; without setting lsp-prefer-flymake to :none
         ;; golangci-lint errors won't be reported
-        (when go-use-golangci-lint
+        (when (eq go-linter 'golangci-lint)
           (message "[go] Setting lsp-prefer-flymake :none to enable golangci-lint support.")
           (setq-local lsp-prefer-flymake :none))
         (lsp))
@@ -58,25 +58,18 @@
         (company-mode))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-(defun spacemacs//go-enable-gometalinter ()
-   "Enable `flycheck-gometalinter' and disable overlapping `flycheck' linters."
-   (setq flycheck-disabled-checkers '(go-gofmt
-                                      go-golint
-                                      go-vet
-                                      go-build
-                                      go-test
-                                      go-errcheck))
-   (flycheck-gometalinter-setup))
-
-(defun spacemacs//go-enable-golangci-lint ()
-  "Enable `flycheck-golangci-lint' and disable overlapping `flycheck' linters."
-  (setq flycheck-disabled-checkers '(go-gofmt
-                                     go-golint
-                                     go-vet
-                                     go-build
-                                     go-test
-                                     go-errcheck))
-  (flycheck-golangci-lint-setup))
+(defun spacemacs//go-enable-flycheck-extra ()
+  "Enable enhanced linter and disable overlapping `flycheck' linters."
+  (when go-linter
+    (setq flycheck-disabled-checkers '(go-gofmt
+                                       go-golint
+                                       go-vet
+                                       go-build
+                                       go-test
+                                       go-errcheck))
+    (pcase go-linter
+      ('gometalinter    (flycheck-gometalinter-setup)  (message "go-linter: using gometalinter"))
+      ('golangci-lint   (flycheck-golangci-lint-setup) (message "go-linter: using golangci-lint")))))
 
 (defun spacemacs/go-run-tests (args)
   (interactive)

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -15,10 +15,10 @@
         (company-go :requires company)
         counsel-gtags
         flycheck
-        (flycheck-gometalinter :toggle (and go-use-gometalinter
+        (flycheck-gometalinter :toggle (and (eq go-linter 'gometalinter)
                                             (configuration-layer/package-used-p
                                              'flycheck)))
-        (flycheck-golangci-lint :toggle (and go-use-golangci-lint
+        (flycheck-golangci-lint :toggle (and (eq go-linter 'golangci-lint)
                                              (configuration-layer/package-used-p
                                               'flycheck)))
         ggtags
@@ -54,12 +54,12 @@
 (defun go/init-flycheck-gometalinter ()
   (use-package flycheck-gometalinter
     :defer t
-    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-gometalinter t)))
+    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-flycheck-extra t)))
 
 (defun go/init-flycheck-golangci-lint ()
   (use-package flycheck-golangci-lint
     :defer t
-    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-golangci-lint t)))
+    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-flycheck-extra t)))
 
 (defun go/post-init-ggtags ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
`layers/+lang/go`: refactore the extra flycheck linter setup.

It doesn't make sense to have two variables: `go-use-gometalinter` and `go-use-golangci-lint` as only one of them can be in use. 