### PR TITLE
[Clojure] Keybinding require Clojure repl utils in current namespace

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1190,6 +1190,8 @@ Other:
   - ~SPC m e i~ interrupt the current evaluation (stop long running process)
     (thanks to John Stevenson)
   - ~SPC m e v~ to evaluate s-expression at point (=cider-eval-sexp-at-point=)
+  - ~SPC m s u~  require Clojure utils into current namespace
+    i.e. functions =doc= =source= (thanks to John Stevenson)
 - Fixes:
   - Remove `cider.nrepl/cider-middleware` in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -296,6 +296,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m s r~ | send and eval region in REPL                                                   |
 | ~SPC m s R~ | send and eval region and switch to REPL in =insert state=                      |
 | ~SPC m s s~ | switch to REPL or jump to last file or last clj buffer from repl (cider-repl)  |
+| ~SPC m s u~ | require Clojure utils into current namespace - i.e. functions =doc= =source=   |
 | ~SPC m s x~ | refresh REPL                                                                   |
 | ~SPC m s X~ | restart REPL                                                                   |
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -126,6 +126,7 @@
             "ss" (if (eq m 'cider-repl-mode)
                      'cider-switch-to-last-clojure-buffer
                    'cider-switch-to-repl-buffer)
+            "su" 'cider-repl-require-repl-utils
             "sx" 'cider-ns-refresh
             "sX" 'cider-restart
 


### PR DESCRIPTION
Although the Clojure repl utils (clojure.repl) are including in the `user`
namespace in Clojure projects, they are not available in your application
namespace.

The existing CIDER function `cider-repl-require-repl-utils` adds the Clojure
repl utils into the current namespace, so you can use functions such as `doc`
and `source`.

This is often a source of confusion for those new to Clojure / CIDER.
