### PR TITLE
Feature sql improvements

### DIFF
--- a/layers/+lang/sql/README.org
+++ b/layers/+lang/sql/README.org
@@ -104,12 +104,13 @@ auto-indent by setting the variable =sql-auto-indent= to =nil=.
 
 ** Inferior Process Interactions (SQLi)
 
-| Key binding | Description                 |
-|-------------+-----------------------------|
-| ~SPC m b b~ | show the SQLi buffer name   |
-| ~SPC m b s~ | set the SQLi buffer         |
-| ~SPC m l a~ | List all objects            |
-| ~SPC m l t~ | list all objects in a table |
+| Key binding | Description                                          |
+|-------------+------------------------------------------------------|
+| ~SPC m b b~ | show the SQLi buffer name                            |
+| ~SPC m b s~ | set the SQLi buffer                                  |
+| ~SPC m b c~ | connect to a SQLi buffer from your saved buffer list |
+| ~SPC m l a~ | List all objects                                     |
+| ~SPC m l t~ | list all objects in a table                          |
 
 *** Send SQL queries to SQLi:
 

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -101,6 +101,7 @@
         ;; sqli buffer
         "bb" 'sql-show-sqli-buffer
         "bs" 'sql-set-sqli-buffer
+        "bc" 'sql-connect
 
         ;; dialects
         "hk" 'spacemacs/sql-highlight


### PR DESCRIPTION
add sql-connect function as it allows you to select from saved sql connections.

NOTE:

I have some things in my private spacemacs and I'm wondering if I should contribute it along with this Pr:
it would define a predifined place for people to put passwords for specific databases that they connect to. What do you think? should I roll it in and write some docs or not (don't worry, I'd change the function name!)
```
  ;; sql stuff
  (defun mike-load-sql-passwords ()
      (interactive)
      (load-library "~/sql-credentials.el.gpg")
      (setq sql-connection-alist (delete-dups (append sql-connection-alist mike-sql-credentials)))
    )

  (spacemacs/set-leader-keys-for-major-mode 'sql-mode
    "op" 'mike-load-sql-passwords)
```