### PR TITLE
[Clojure] keybinding for updated repl jack-in commands

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1192,6 +1192,13 @@ Other:
   - ~SPC m e v~ to evaluate s-expression at point (=cider-eval-sexp-at-point=)
   - ~SPC m s u~  require Clojure utils into current namespace
     i.e. functions =doc= =source= (thanks to John Stevenson)
+  - ~SPC m s j c~ updated to call =cider-jack-in-clj= rather than old alias
+    =cider-jack-in= (thanks to John Stevenson)
+  - ~SPC m s j f~ new keybinding to call =cider-jack-in-clj&cjls=
+    (thanks to John Stevenson)
+  - ~SPC m s j s~ updated to call =cider-jack-in-cljs= rather than old alias
+    =cider-jack-in-clojurescript= which is deprecated
+    (thanks to John Stevenson)
 - Fixes:
   - Remove `cider.nrepl/cider-middleware` in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -276,29 +276,30 @@ As this state works the same for all files, the documentation is in global
 
 *** REPL
 
-| Key binding | Description                                                                    |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m ,~   | handle shortcut (cider-repl-handle-shortcut)                                   |
-| ~SPC m s b~ | send and eval buffer in REPL                                                   |
-| ~SPC m s B~ | send and eval buffer and switch to REPL in =insert state=                      |
-| ~SPC m s c~ | connect to REPL (cider-connect) or clear repl buffer (cider-repl-clear-buffer) |
-| ~SPC m s C~ | clear REPL (cider-find-and-clear-repl-output)                                  |
-| ~SPC m s e~ | send and eval last sexp in REPL                                                |
-| ~SPC m s E~ | send and eval last sexp and switch to REPL in =insert state=                   |
-| ~SPC m s f~ | send and eval function in REPL                                                 |
-| ~SPC m s F~ | send and eval function and switch to REPL in =insert state=                    |
-| ~SPC m s i~ | start REPL (cider-jack-in)                                                     |
-| ~SPC m s I~ | start clojurescript REPL (cider-jack-in-clojurescript)                         |
-| ~SPC m s n~ | send and eval ns form in REPL                                                  |
-| ~SPC m s N~ | send and eval ns form and switch to REPL in =insert state=                     |
-| ~SPC m s q~ | kill REPL (cider-quit)                                                         |
-| ~SPC m s o~ | switch to other repl instance (cider-repl-switch-to-other)                     |
-| ~SPC m s r~ | send and eval region in REPL                                                   |
-| ~SPC m s R~ | send and eval region and switch to REPL in =insert state=                      |
-| ~SPC m s s~ | switch to REPL or jump to last file or last clj buffer from repl (cider-repl)  |
-| ~SPC m s u~ | require Clojure utils into current namespace - i.e. functions =doc= =source=   |
-| ~SPC m s x~ | refresh REPL                                                                   |
-| ~SPC m s X~ | restart REPL                                                                   |
+| Key binding   | Description                                                                    |
+|---------------+--------------------------------------------------------------------------------|
+| ~SPC m ,~     | handle shortcut (cider-repl-handle-shortcut)                                   |
+| ~SPC m s b~   | send and eval buffer in REPL                                                   |
+| ~SPC m s B~   | send and eval buffer and switch to REPL in =insert state=                      |
+| ~SPC m s c~   | connect to REPL (cider-connect) or clear repl buffer (cider-repl-clear-buffer) |
+| ~SPC m s C~   | clear REPL (cider-find-and-clear-repl-output)                                  |
+| ~SPC m s e~   | send and eval last sexp in REPL                                                |
+| ~SPC m s E~   | send and eval last sexp and switch to REPL in =insert state=                   |
+| ~SPC m s f~   | send and eval function in REPL                                                 |
+| ~SPC m s F~   | send and eval function and switch to REPL in =insert state=                    |
+| ~SPC m s j c~ | start Clojure REPL (=cider-jack-in-clj=)                                       |
+| ~SPC m s j f~ | start Clojure REPL (=cider-jack-in-clj&cljs=)                                  |
+| ~SPC m s j s~ | start ClojureScript REPL (=cider-jack-in-cljs=)                                |
+| ~SPC m s n~   | send and eval ns form in REPL                                                  |
+| ~SPC m s N~   | send and eval ns form and switch to REPL in =insert state=                     |
+| ~SPC m s q~   | kill REPL (cider-quit)                                                         |
+| ~SPC m s o~   | switch to other repl instance (cider-repl-switch-to-other)                     |
+| ~SPC m s r~   | send and eval region in REPL                                                   |
+| ~SPC m s R~   | send and eval region and switch to REPL in =insert state=                      |
+| ~SPC m s s~   | switch to REPL or jump to last file or last clj buffer from repl (cider-repl)  |
+| ~SPC m s u~   | require Clojure utils into current namespace - i.e. functions =doc= =source=   |
+| ~SPC m s x~   | refresh REPL                                                                   |
+| ~SPC m s X~   | restart REPL                                                                   |
 
 *** Tests
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -62,6 +62,7 @@
                ("mh" . "documentation")
                ("mp" . "profile")
                ("ms" . "repl")
+               ("msj" . "jack-in")
                ("mt" . "test")
                ("mT" . "toggle")
                )))
@@ -103,8 +104,9 @@
             "gs" 'cider-browse-spec
             "gS" 'cider-browse-spec-all
 
-            "'"  'cider-jack-in
-            "\"" 'cider-jack-in-clojurescript
+            "'"  'cider-jack-in-clj
+            "\"" 'cider-jack-in-cljs
+            "\&" 'cider-jack-in-clj&cljs
             "sb" 'cider-load-buffer
             "sB" 'spacemacs/cider-send-buffer-in-repl-and-focus
             "sc" (if (eq m 'cider-repl-mode)
@@ -115,8 +117,9 @@
             "sE" 'spacemacs/cider-send-last-sexp-to-repl-focus
             "sf" 'spacemacs/cider-send-function-to-repl
             "sF" 'spacemacs/cider-send-function-to-repl-focus
-            "si" 'cider-jack-in
-            "sI" 'cider-jack-in-clojurescript
+            "sjc" 'cider-jack-in-clj
+            "sjf" 'cider-jack-in-clj&cljs
+            "sjs" 'cider-jack-in-cljs
             "sn" 'spacemacs/cider-send-ns-form-to-repl
             "sN" 'spacemacs/cider-send-ns-form-to-repl-focus
             "so" 'cider-repl-switch-to-other


### PR DESCRIPTION
Latest CIDER release uses the following commands for starting the REPL from
within Emacs (these commands have been in CIDER for over 6 months already)

`cider-jack-in-clj` to start a Clojure REPL
`cider-jack-in-clj&cljs` to start a Clojure and ClojureScript REPL
`cider-jack-in-cljs` to start a ClojureScript repl

The older aliases are deprecated and are being removed in the latest beta
release of CIDER (the version that Spacemacs uses, so this PR fixes broken keybindings)

`cider-jack-in`
`cider-jack-in-clojurescript`

Keybindings for these jack-in commands have been updated and as there are three
options they have been moved under Clojure mode repl > jack-in menu

The top level of the Clojure mode menu has the existing keybindings updated to
use the new commands.  A third top-level keybinding `&` has been added for
`cider-jack-in-clj&cljs`
