### PR TITLE
[Clojure] keybinding spacemacs/clj-find-var

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1198,6 +1198,8 @@ Other:
     (thanks to John Stevenson)
   - ~SPC m s j s~ updated to call =cider-jack-in-cljs= rather than old alias
     =cider-jack-in-clojurescript= which is deprecated
+  - ~SPC m g g~ changed to =spacemacs/clj-find-var=, a wrapper for
+    =cider-find-var= if REPL running, otherwise =dumb-jump-go=
     (thanks to John Stevenson)
 - Fixes:
   - Remove `cider.nrepl/cider-middleware` in lein quick start setting

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -263,16 +263,16 @@ As this state works the same for all files, the documentation is in global
 
 *** Goto
 
-| Key binding | Description      |
-|-------------+------------------|
-| ~SPC m g b~ | go back          |
-| ~SPC m g C~ | browse classpath |
-| ~SPC m g g~ | goto var         |
-| ~SPC m g e~ | goto error       |
-| ~SPC m g n~ | goto namespace   |
-| ~SPC m g r~ | goto resource    |
-| ~SPC m g s~ | browse spec      |
-| ~SPC m g S~ | browse all specs |
+| Key binding | Description                                  |
+|-------------+----------------------------------------------|
+| ~SPC m g b~ | go back                                      |
+| ~SPC m g C~ | browse classpath                             |
+| ~SPC m g g~ | goto var definition =spacemacs/clj-find-var= |
+| ~SPC m g e~ | goto error                                   |
+| ~SPC m g n~ | goto namespace                               |
+| ~SPC m g r~ | goto resource                                |
+| ~SPC m g s~ | browse spec                                  |
+| ~SPC m g S~ | browse all specs                             |
 
 *** REPL
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -98,6 +98,7 @@
 
             "gb" 'cider-pop-back
             "gc" 'cider-classpath
+            "gg" 'spacemacs/clj-find-var
             "ge" 'cider-jump-to-compilation-error
             "gn" 'cider-find-ns
             "gr" 'cider-find-resource


### PR DESCRIPTION
Update the existing `SPC m g g` keybinding to use the command
`spacemacs/clj-find-var`.  

This makes finding a function definition a much
better experience as you dont have to have the REPL running to find a
definition, but when it is you can use a CIDER specific function.

`spacemacs/clj-find-var` is a wrapper that calls `cider-find-var` if the REPL is
running, otherwise it uses `dump-jump-go`.

Wrapper added in #9792
