### PR TITLE
Update core-dotspacemacs.el default font size

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -226,7 +226,7 @@ emacs.")
 ;; emacs.")
 
 (defvar dotspacemacs-default-font '("Source Code Pro"
-                                    :size 13
+                                    :size 10.0
                                     :weight normal
                                     :width normal)
   "Default font, or prioritized list of fonts. This setting has no effect when


### PR DESCRIPTION
0ffdb353f9db507320495d19f71759ec819d267a changed the default config template to use a point size instead of a pixel size.  Change the defvar declaration as well.