### PR TITLE
[haskell] Include attrap when dante is used

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -27,6 +27,8 @@
 
         ;; dante completion backend
         (dante :requires company)
+        ;; dante auto refactor companion
+        (attrap :requires dante)
 
         lsp-haskell
 
@@ -144,6 +146,11 @@
           "rs" 'dante-auto-fix
           "se" 'dante-eval-block
           "sr" 'dante-restart)))))
+
+(defun haskell/init-attrap ()
+  (use-package attrap
+  :defer t)
+  )
 
 (defun haskell/init-helm-hoogle ()
   (use-package helm-hoogle


### PR DESCRIPTION
attrap is a companion package for dante implementing  autofix functionality