### PR TITLE
fix #12554 goto-flycheck-error-list

### DIFF
--- a/layers/+checkers/syntax-checking/funcs.el
+++ b/layers/+checkers/syntax-checking/funcs.el
@@ -29,6 +29,8 @@ If the error list is visible, hide it.  Otherwise, show it."
 (defun spacemacs/goto-flycheck-error-list ()
   "Open and go to the error list buffer."
   (interactive)
-  (unless (get-buffer-window (get-buffer flycheck-error-list-buffer))
-    (flycheck-list-errors)
-    (switch-to-buffer-other-window flycheck-error-list-buffer)))
+  (if (flycheck-get-error-list-window)
+      (switch-to-buffer flycheck-error-list-buffer)
+    (progn
+      (flycheck-list-errors)
+      (switch-to-buffer-other-window flycheck-error-list-buffer))))


### PR DESCRIPTION
In `spacemacs/goto-flycheck-error-list` we check `(get-buffer-window (get-buffer flycheck-error-list-buffer)` as falsy to decide to do any action.

Problem is when flycheck error buffer does not exist. `(get-buffer flycheck-error-list-buffer)` will return nil. So `(get-buffer-window nil)` as default will return current window which is a truthy value. That means the code doesn't do anything in this case.