### PR TITLE
Add new var treemacs-enable-magit to enable treemacs-magit

### DIFF
--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -34,3 +34,6 @@ There are 2 possible values:
 
 (defvar treemacs-lock-width nil
   "When non-nil the treemacs window will not be manually resizable by default.")
+
+(defvar treemacs-enable-magit nil
+  "When non-nil, enable integration with magit.")

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -14,6 +14,7 @@
     golden-ratio
     treemacs
     (treemacs-evil :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
+    (treemacs-magit :toggle treemacs-enable-magit)
     treemacs-projectile
     winum
     ))
@@ -98,3 +99,9 @@
           (add-to-list 'winum-ignored-buffers
                        (format "%sFramebuffer-%s*"
                                treemacs--buffer-name-prefix n)))))))
+
+(defun treemacs/init-treemacs-magit ()
+  (use-package treemacs-magit
+    :after treemacs magit
+    :defer t
+    :if treemacs-enable-magit))


### PR DESCRIPTION
This adds a new var `treemacs-enable-magit` to enable the `treemacs-magit` package, which lets treemacs know when files are staged/unstaged using magit. I think it would be better to automatically enable this if a user has both the `treemacs` and `magit` layers enabled (rather than using a config variable) but I'm not sure how to do this; if someone wants to give me a pointer I can try to rework the logic.

The `treemacs-magit` package is described in the upstream treemacs README: https://github.com/Alexander-Miller/treemacs

The `treemacs-magit` package is available in MELPA: https://melpa.org/#/treemacs-magit

