### PR TITLE
Correct function-format keybinding in EL layer

### DIFF
--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -207,7 +207,7 @@ The [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bemacs/semanti
 | Key binding | Description             |
 |-------------+-------------------------|
 | ~SPC m = b~ | format current buffer   |
-| ~SPC m = f~ | format current function |
+| ~SPC m = d~ | format current function |
 | ~SPC m = o~ | format all on one line  |
 | ~SPC m = s~ | format current sexp     |
 


### PR DESCRIPTION
It appears that the illustrated keybinding isn't defined in the layer; I think [SPC m = d](https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Blang/emacs-lisp/packages.el#L213) was intended.