### PR TITLE
Layout layer: counsel-projectile: requires fix

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -15,7 +15,7 @@
         ivy
         persp-mode
         spaceline
-        (counsel-projectile :requires projectile)))
+        (counsel-projectile :requires ivy)))
 
 
 


### PR DESCRIPTION
Guard `:requires` against `ivy` not `projectile`.` projectile` is already owned by
buil-in `spacemacs-project` layer, so it's always `t`.

This prevents install of `ivy`, `counsel`, `swiper` and `counsel-projectile`
packages regardless of `helm` layer.