### PR TITLE
Remove Unicode triple dot in .spacemacs file in favor of ASCII one

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -316,7 +316,7 @@ restricts line-number to the specified list of major-mode.")
 
 (defvar dotspacemacs-smart-closing-parenthesis nil
   "If non-nil pressing the closing parenthesis `)' key in insert mode passes
-  over any automatically added closing parenthesis, bracket, quote, etc…
+  over any automatically added closing parenthesis, bracket, quote, etc...
   This can be temporary disabled by pressing `C-q' before `)'. (default nil)")
 
 (defvar dotspacemacs-highlight-delimiters 'all

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -267,7 +267,7 @@ values."
    ;; (default nil)
    dotspacemacs-smartparens-strict-mode nil
    ;; If non-nil pressing the closing parenthesis `)' key in insert mode passes
-   ;; over any automatically added closing parenthesis, bracket, quote, etc…
+   ;; over any automatically added closing parenthesis, bracket, quote, etc...
    ;; This can be temporary disabled by pressing `C-q' before `)'. (default nil)
    dotspacemacs-smart-closing-parenthesis nil
    ;; Select a scope to highlight delimiters. Possible values are `any',


### PR DESCRIPTION
Remove Unicode triple dot from .spacemacs file in favor of ASCII one. 
Unicode character in comment breaks initialization with message:

"*temp file*" default encoding cannot encode

It's was tricky to debug because of breaking in intermediary "temp file"
and regular error message was unable to point back to original file or
"temp file" contents.