### PR TITLE
Restore standard "si" binding for cider-jack-in-clj in clojure layer

### DIFF
--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -118,6 +118,7 @@
             "sE" 'spacemacs/cider-send-last-sexp-to-repl-focus
             "sf" 'spacemacs/cider-send-function-to-repl
             "sF" 'spacemacs/cider-send-function-to-repl-focus
+            "si" 'cider-jack-in-clj
             "sjc" 'cider-jack-in-clj
             "sjf" 'cider-jack-in-clj&cljs
             "sjs" 'cider-jack-in-cljs


### PR DESCRIPTION
It appears that this is still the common binding across all +lang layers.