### PR TITLE
Layer +fun/emoji: Enable company-emoji-insert-unicode

### DIFF
--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -50,7 +50,6 @@
     :defer t
     :init
     (progn
-      (setq company-emoji-insert-unicode nil)
       ;; For when Emacs is started in GUI mode:
       (spacemacs//set-emoji-font nil)
       ;; Hook for when a frame is created with emacsclient


### PR DESCRIPTION
This PR makes emoji completion actually insert the emoji character instead of leaving the :emoji: syntax.