### PR TITLE
spacemacs-layout layer: Make commands to work within layouts

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -93,8 +93,8 @@ and its values are removed."
 (defun spacemacs/dump-vars (varlist buffer)
   "insert into buffer the setq statement to recreate the variables in VARLIST"
   (cl-loop for var in varlist do
-        (print (list 'setq var (list 'quote (symbol-value var)))
-               buffer)))
+           (print (list 'setq var (list 'quote (symbol-value var)))
+                  buffer)))
 
 (defvar spacemacs--init-redisplay-count 0
   "The number of calls to `redisplay'")
@@ -129,17 +129,17 @@ Supported properties:
     (append
      (when evil-leader
        `((dolist (key ',evil-leader)
-            (spacemacs/set-leader-keys key ',func))))
+           (spacemacs/set-leader-keys key ',func))))
      (when evil-leader-for-mode
        `((dolist (val ',evil-leader-for-mode)
-          (spacemacs/set-leader-keys-for-major-mode
-            (car val) (cdr val) ',func))))
+           (spacemacs/set-leader-keys-for-major-mode
+             (car val) (cdr val) ',func))))
      (when global-key
        `((dolist (key ',global-key)
-          (global-set-key (kbd key) ',func))))
+           (global-set-key (kbd key) ',func))))
      (when def-key
        `((dolist (val ',def-key)
-          (define-key (eval (car val)) (kbd (cdr val)) ',func)))))))
+           (define-key (eval (car val)) (kbd (cdr val)) ',func)))))))
 
 (defun spacemacs/prettify-org-buffer ()
   "Apply visual enchantments to the current buffer.
@@ -210,7 +210,7 @@ passed-tests and total-tests."
           (when (boundp 'passed-tests) (setq passed-tests (1+ passed-tests)))
           (insert (format "*** PASS: %s\n" var-val)))
       (insert (propertize (format "*** FAIL: %s\n" var-val)
-                                  'font-lock-face 'font-lock-warning-face)))))
+                          'font-lock-face 'font-lock-warning-face)))))
 
 (defun spacemacs//test-list (pred varlist test-desc &optional element-desc)
   "Test PRED against each element of VARLIST and print test
@@ -289,10 +289,10 @@ buffer."
 ;; http://stackoverflow.com/questions/11847547/emacs-regexp-count-occurrences
 (defun spacemacs/how-many-str (regexp str)
   (cl-loop with start = 0
-        for count from 0
-        while (string-match regexp str start)
-        do (setq start (match-end 0))
-        finally return count))
+           for count from 0
+           while (string-match regexp str start)
+           do (setq start (match-end 0))
+           finally return count))
 
 (defun spacemacs/echo (msg &rest args)
   "Display MSG in echo-area without logging it in *Messages* buffer."
@@ -314,10 +314,22 @@ buffer."
 current window."
   (interactive)
   (destructuring-bind (buf start pos)
-      (or (cl-find (window-buffer window) (window-prev-buffers)
-                   :key #'car :test-not #'eq)
-          (list (other-buffer) nil nil ))
-    (set-window-buffer-start-and-point window buf start pos)))
+      (if spacemacs-layouts-restrict-spc-tab
+          (let ((buffer-list (persp-buffer-list))
+                (my-buffer (window-buffer window)))
+            ;; find buffer of the same persp in window
+            (seq-find (lambda (it) ;; predicate
+                        (and (not (eq (car it) my-buffer))
+                             (member (car it) buffer-list)))
+                      (window-prev-buffers)
+                      ;; default if found none
+                      (list nil nil nil)))
+        (or (cl-find (window-buffer window) (window-prev-buffers)
+                     :key #'car :test-not #'eq)
+            (list (other-buffer) nil nil)))
+    (if (not buf)
+        (message "Last buffer not found.")
+      (set-window-buffer-start-and-point window buf start pos))))
 
 (defun spacemacs/alternate-window ()
   "Switch back and forth between current and last window in the

--- a/layers/+spacemacs/spacemacs-layouts/README.org
+++ b/layers/+spacemacs/spacemacs-layouts/README.org
@@ -5,6 +5,7 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#limit-functions-to-the-current-layouts-buffers][Limit functions to the current layout's buffers]]
 
 * Description
 This layer adds support for distinct layouts/workspaces to Spacemacs.
@@ -12,3 +13,35 @@ This layer adds support for distinct layouts/workspaces to Spacemacs.
 ** Features:
 - Support for distinct layouts via =eyebrowse=
 - Integration with =helm= and =ivy= to search for buffers within layouts
+
+* Limit functions to the current layout's buffers
+Besides =helm-mini= and =ivy-switch-buffer= that are aware of a layouts buffers.
+This layer provides variable ~spacemacs-layouts-advice-list~ holding a list of
+functions that need to be limited to current layout's buffers. They will be
+wrapped around by persp-mode ~with-persp-buffer-list~. 
+
+Default value of ~spacemacs-layouts-advice-list~ is
+~'(spacemacs/window-split-double-columns spacemacs/window-split-triple-columns
+spacemacs/window-split-grid)~.
+
+Another variable  ~spacemacs-layouts-restrict-spc-tab~ when set to ~t~ will 
+limit ~spacemacs/alternate-buffer~ (~SPC TAB~) to current layout's buffers.
+
+Default value of ~spacemacs-layouts-restrict-spc-tab~ is nil
+
+If you want to modify them, edit the ~dotspacemacs-configuration-layers~
+section, for example:
+ 
+ #+begin_example elisp
+  (spacemacs-layouts :variables
+                     spacemacs-layouts-restrict-spc-tab t
+                     spacemacs-layouts-advice-list '(spacemacs/window-split-double-columns
+                                                     spacemacs/window-split-triple-columns
+                                                     spacemacs/window-split-grid
+                                                     helm-do-ag-buffers))
+ #+end_example
+
+Note that ~spacemacs-layouts-restrict-spc-tab~ can be toggle on the fly with
+~setq~ or can be set in ~dotspacemacs/user-config~, while
+~spacemacs-layouts-advice-list~ can be changed only at
+~dotspacemacs-configuration-layers~ section

--- a/layers/+spacemacs/spacemacs-layouts/config.el
+++ b/layers/+spacemacs/spacemacs-layouts/config.el
@@ -55,3 +55,11 @@ layout, the 4th for the 4th, and so on until the 10th (aka layout
 number 0). The first list is sepcial - it is a grab-bag for names
 in case none of the regular names can be used for a new layout.")
 
+(defvar spacemacs-layouts-advice-list
+  '(spacemacs/window-split-double-columns
+    spacemacs/window-split-triple-columns
+    spacemacs/window-split-grid)
+  "list of functions to be wrapped by `with-persp-buffer-list'")
+
+(defvar spacemacs-layouts-restrict-spc-tab nil
+  "If `t' then `SPC-TAB' will be limited to the current layouts buffers.")

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -80,6 +80,9 @@ Cancels autosave on exiting perspectives mode."
   (let ((ivy-ignore-buffers (remove #'spacemacs//layout-not-contains-buffer-p ivy-ignore-buffers)))
     (ivy-switch-buffer)))
 
+(defun spacemacs-layouts//advice-with-persp-buffer-list (orig-fun &rest args)
+  "Advice to provide perp buffer list."
+  (with-persp-buffer-list () (apply orig-fun args)))
 
 ;; Persp transient-state
 
@@ -289,7 +292,7 @@ Available PROPS:
                                        ,binding ,already-defined? ,name)
              (setq spacemacs--custom-layout-alist
                    (delete (assoc ,binding spacemacs--custom-layout-alist)
-                     spacemacs--custom-layout-alist))
+                           spacemacs--custom-layout-alist))
              (push '(,binding . ,name) spacemacs--custom-layout-alist))
          (push '(,binding . ,name) spacemacs--custom-layout-alist)))))
 
@@ -351,10 +354,10 @@ buffers that belong to the current buffer's project."
   (if (persp-with-name-exists-p name)
       (message "There is already a perspective named %s" name)
     (if-let ((project (projectile-project-p)))
-      (spacemacs||switch-layout name
-        :init
-        (persp-add-buffer (projectile-project-buffers project)
-                          (persp-get-by-name name) nil nil))
+        (spacemacs||switch-layout name
+          :init
+          (persp-add-buffer (projectile-project-buffers project)
+                            (persp-get-by-name name) nil nil))
       (message "Current buffer does not belong to a project"))))
 
 (defmacro spacemacs||switch-project-persp (name &rest body)

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -220,6 +220,8 @@
         (setq spacemacs--last-selected-layout persp-last-persp-name))
       (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
       (advice-add 'persp-load-state-from-file :before 'spacemacs//layout-wait-for-modeline)
+      (dolist (fn spacemacs-layouts-advice-list)
+        (advice-add fn :around 'spacemacs-layouts//advice-with-persp-buffer-list))
       ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
         "ba"   'persp-add-buffer


### PR DESCRIPTION
spacemacs-layout layer: limit commmands to work within layouts

Add options to restrict some functions to current layout's buffers. Default is off.

Thanks smile13241324 and duianto for suggestions and fixing typos
