### PR TITLE
lazy load lsp-python-ms

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2292,6 +2292,7 @@ Other:
 - Added support for 'black' formatter (thanks to Mike Macpherson)
 - Enabled =eldoc= for =anaconda-mode= (thanks to Vikash Balasubramanian)
 - Various fixes for =lsp-python-ms= setup (thanks to Trapez Breen)
+- Added lazy loading of =lsp-python-ms= (thanks to Ying Qu)
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -61,7 +61,10 @@
 (defun spacemacs//python-setup-lsp ()
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
-      (lsp)
+      (progn
+        (lsp)
+        (when (eq python-lsp-server 'mspyls)
+          (require 'lsp-python-ms)))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile."))
   (if (configuration-layer/layer-used-p 'dap)
     (progn

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -427,6 +427,7 @@ fix this issue."
   (use-package lsp-python-ms
     :if (eq python-lsp-server 'mspyls)
     :ensure nil
+    :defer t
     :config
     (when python-lsp-git-root
       ;; Use dev version of language server checked out from github


### PR DESCRIPTION
Enabling lsp-python-ms on startup will slow down the spacemacs very much since its direct result is the Invalidation of the lazy-loading of python and many other related packages. So it is reasonable to lazy load the lsp-python-ms.

I have tested this change. lsp-python-ms loads correctly both on dump and undumped mode.