### PR TITLE
Add toggle key docs to docstring and which-key mouseover

### DIFF
--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -103,7 +103,9 @@ used."
            (push (cons ',name properties) spacemacs-toggles)))
        ;; toggle function
        (defun ,wrapper-func ,(if prefix-arg-var (list prefix-arg-var) ())
-         ,(format "Toggle %s on and off." (symbol-name name))
+         ,(format "Toggle %s on and off.%s"
+                  (symbol-name name)
+                  (if doc (concat "\n\n" doc) ""))
          ,(if prefix-arg-var '(interactive "P") '(interactive))
          (if ,condition-eval
              ;; check if current buffer major mode supports the toggle


### PR DESCRIPTION
Added spacemacs|add-toggle key binding documentation strings:
- To the toggle keys function docstring
- And to it's which-key mouseover minibuffer text