### PR TITLE
shell: allow evil normal-mode movement in terminal buffer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2437,6 +2437,8 @@ Other:
   - ~M-l~ =spacemacs/ivy-eshell-history=
   - ~TAB~ =spacemacs/pcomplete-std-complete=
 - Enabled mouse based pasting into term shells (thanks to Sheng Yang)
+- Set =term-char-mode-point-at-process-mark= to =nil= to allow evil normal-mode
+  movement in term shells on emacs 26.1
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -14,6 +14,9 @@
 ;; move point to the end of buffer on new output
 (setq comint-move-point-for-output t)
 
+;; allow moving around the buffer in emacs >= 26.1 in evil's normal mode
+(setq term-char-mode-point-at-process-mark nil)
+
 ;; Variables
 
 (defvar shell-default-shell (if (eq window-system 'w32)


### PR DESCRIPTION
As mentioned in https://github.com/syl20bnr/spacemacs/issues/10779#issuecomment-427712967,
emacs 26.1 changed the default behavior for term-char-mode to prevent cursor
movement. This commit restores consistent behavior on all versions of emacs and
allows normal-mode motions to work again.

Note that the buffer is still read-only while in normal-mode, so operators that
change the line (such as `C`, `D`, `S`) still don't work.

Fixes #10956
Fixes #10779