### PR TITLE
Clean .spacemacs.template: Remove dotspacemacs-verbose-loading

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -153,9 +153,6 @@ It should only modify the values of Spacemacs settings."
    ;; (default 'vim)
    dotspacemacs-editing-style 'vim
 
-   ;; If non-nil output loading progress in `*Messages*' buffer. (default nil)
-   dotspacemacs-verbose-loading nil
-
    ;; Specify the startup banner. Default value is `official', it displays
    ;; the official spacemacs logo. An integer value is the index of text
    ;; banner, `random' chooses a random text banner in `core/banners'


### PR DESCRIPTION
dotspacemacs-verbose-loading has been removed in [commit 1623ff6044
](https://github.com/syl20bnr/spacemacs/commit/1623ff60449918298a2c3a5dd0dbd3fd34d0b02b).