### PR TITLE
helm: update helm-xref to set the correct xref-show-xrefs-function

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -396,7 +396,7 @@
 
 (defun helm/init-helm-xref ()
   (use-package helm-xref
-    :commands (helm-xref-show-xrefs)
+    :commands (helm-xref-show-xrefs-27 helm-xref-show-xrefs)
     :init
     (progn
       ;; This is required to make `xref-find-references' not give a prompt.
@@ -410,7 +410,9 @@
                                              xref-find-references
                                              spacemacs/jump-to-definition))
       ;; Use helm-xref to display `xref.el' results.
-      (setq xref-show-xrefs-function #'helm-xref-show-xrefs))))
+      (setq xref-show-xrefs-function (if (< emacs-major-version 27)
+                                         #'helm-xref-show-xrefs
+                                       #'helm-xref-show-xrefs-27)))))
 
 
 (defun helm/post-init-imenu ()


### PR DESCRIPTION
This pull requests updates the helm-xref `use-package` definition to set the correct `x-ref-show-xrefs-function` based on the emacs version. helm-xref currently provides two functions and the user is expected to use the correct one based on their emacs version (as 27 uses a different handler for xrefs). Due to lazy loading, the `xref-show-xrefs-function` is not set correctly and must be manually handled in the `use-package` definition.