### PR TITLE
[dart] Add dart-server package

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1356,6 +1356,14 @@ Other:
 - Improvements:
   - Added =LSP= support (thanks to Mathieu Post)
   - Added =Flutter= support (thanks to Mathieu Post)
+- Fixes:
+  - Added =dart-server= package (thanks to duianto)
+  - Updated layer variables:
+    - From: =dart-sdk-path= To: =dart-server-sdk-path=
+    - From: =dart-enable-analysis-server=
+      To:   =dart-server-enable-analysis-server=
+    - From: =dart-format-on-save= To: =dart-server-format-on-save=
+      (thanks to duianto)
 **** Dash
 - Improvements:
   - Use default docsets path in =helm-dash= on macos (thanks to ColorFuzzy)

--- a/layers/+lang/dart/README.org
+++ b/layers/+lang/dart/README.org
@@ -36,39 +36,42 @@ add =dart= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 ** Dart SDK location
-The layer itself will use the `dart` executable location if available on the execution path, but it is possible to define the location manually.
-It should point to the folder, and end with `/`.
+The layer itself will use the =dart= executable location if available on the
+execution path, but it is possible to define the location manually. It should
+point to the folder, and end with =/=.
 
 #+BEGIN_SRC elisp
-  (dart :variables dart-sdk-path "~/path/to/dart-sdk/")
+  (dart :variables dart-server-sdk-path "~/path/to/dart-sdk/")
 #+END_SRC
 
 *** Flutter integration
-Flutter comes with a internal Dart SDK, which can be used to provide all the integration tools.
+Flutter comes with a internal Dart SDK, which can be used to provide all the
+integration tools.
 
 #+BEGIN_SRC elisp
-  (dart :variables dart-sdk-path "<flutter-location>/bin/cache/dart-sdk/")
+  (dart :variables dart-server-sdk-path "<flutter-path>/bin/cache/dart-sdk/")
 #+END_SRC
 
 * Configuration
-For more available variables check [[https://github.com/bradyt/dart-mode][dart-mode]] documentation.
+For additional variables check the [[https://github.com/bradyt/dart-server][dart-server]] documentation.
 
 ** Use analysis server
 #+BEGIN_SRC elisp
-  (dart :variables dart-enable-analysis-server t)
+  (dart :variables dart-server-enable-analysis-server t)
 #+END_SRC
 
 ** Format on save
 #+BEGIN_SRC elisp
-  (dart :variables dart-format-on-save t)
+  (dart :variables dart-server-format-on-save t)
 #+END_SRC
 
 * Key bindings
 ** Normal mode
-Some of the commands will instantiate a new Dart Analyzer server if
-necessary, while others work without using a Dart Analyzer connection.
+Some of the commands will instantiate a new Dart Analyzer server if necessary,
+while others work without using a Dart Analyzer connection.
 
-When ~dart-enable-analysis-server~ is enabled, most of the commands become Async, and there might be a delay when executing them.
+When ~dart-server-enable-analysis-server~ is enabled, most of the commands
+become Async, and there might be a delay when executing them.
 
 | Key binding            | Description                                       |
 |------------------------+---------------------------------------------------|

--- a/layers/+lang/dart/config.el
+++ b/layers/+lang/dart/config.el
@@ -11,4 +11,4 @@
 
 ;; Variables
 
-(spacemacs|define-jump-handlers dart-mode)
+(spacemacs|define-jump-handlers dart-server)

--- a/layers/+lang/dart/packages.el
+++ b/layers/+lang/dart/packages.el
@@ -12,18 +12,23 @@
 ;;; Code:
 
 (defconst dart-packages
-  '(dart-mode
-    flutter
+  '(
+    dart-mode
+    dart-server
     company
-    flycheck))
+    flutter
+    flycheck
+    ))
 
 (defun dart/show-buffer ()
-  "Shows information at point on a new buffer"
+  "Shows information at point in a new buffer"
   (interactive)
-  (dart-show-hover 't))
+  (dart-server-show-hover t))
 
-(defun dart/init-dart-mode ()
-  (use-package dart-mode
+(defun dart/init-dart-mode ())
+
+(defun dart/init-dart-server ()
+  (use-package dart-server
     :defer t
     :mode "\\.dart\\'"
     :init
@@ -33,25 +38,30 @@
       (spacemacs/declare-prefix-for-mode 'dart-mode "mf" "find")
       (spacemacs/declare-prefix-for-mode 'dart-mode "mh" "help")
       (spacemacs/set-leader-keys-for-major-mode 'dart-mode
-        "=" 'dart-format
-        "?" 'dart-show-hover
-        "g" 'dart-goto
-        "hh" 'dart-show-hover
+        "=" 'dart-server-format
+        "?" 'dart-server-show-hover
+        "g" 'dart-server-goto
+        "hh" 'dart-server-show-hover
         "hb" 'dart/show-buffer
-        "ff" 'dart-find-refs
-        "fe" 'dart-find-member-decls
-        "fr" 'dart-find-member-refs
-        "fd" 'dart-find-top-level-decls)
+        ;; There's an upstream issue with this command:
+        ;; dart-server-find-refs on int opens a dart buffer that keeps growing in size #11
+        ;; https://github.com/bradyt/dart-server/issues/11
+        ;; "ff" 'dart-server-find-refs
+        "fe" 'dart-server-find-member-decls
+        "fr" 'dart-server-find-member-refs
+        "fd" 'dart-server-find-top-level-decls)
 
-      (add-to-list 'spacemacs-jump-handlers-dart-mode '(dart-goto :async t))
+      (add-to-list 'spacemacs-jump-handlers-dart-server
+                   '(dart-server-goto :async t))
 
-      (evil-define-key 'insert dart-mode-map
-        (kbd "<tab>") 'dart-expand
-        (kbd "C-<tab>") 'dart-expand-parameters)
+      (evil-define-key 'insert dart-server-map
+        (kbd "<tab>") 'dart-server-expand
+        (kbd "C-<tab>") 'dart-server-expand-parameters)
 
-      (evil-set-initial-state 'dart-popup-mode 'motion)
-      (evil-define-key 'motion dart-popup-mode-map
-        (kbd "gr") 'dart-do-it-again))))
+      (evil-set-initial-state 'dart-server-popup-mode 'motion)
+      (evil-define-key 'motion dart-server-popup-mode-map
+        (kbd "gr") 'dart-server-do-it-again))
+    :config (dart-mode)))
 
 (defun dart/init-flutter ()
   (use-package flutter
@@ -59,9 +69,9 @@
     :after dart-mode
     :init
     (progn
+      (spacemacs/declare-prefix-for-mode 'dart-mode "mx" "flutter")
       (spacemacs/set-leader-keys-for-major-mode 'dart-mode
-        "xx" 'flutter-run-or-hot-reload)))
-  )
+        "xx" 'flutter-run-or-hot-reload))))
 
 (defun dart/post-init-company ()
   (add-hook 'dart-mode-local-vars-hook #'spacemacs//dart-setup-company-lsp))


### PR DESCRIPTION
dart-mode has been split into two packages:
- dart-mode, Provides basic syntax highlighting and indentation.
- dart-server, Factors out the features from dart-mode.el that relied on
external executables, thus improving availability, reliability, testing and
development of dart-mode.el.

Closes #12605