### PR TITLE
Fixed the =c-c++-default-mode-for-headers= should not affect the default…

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1143,7 +1143,10 @@ Other:
     (thanks to Fangrui Song and Codruț Constantin Gușoi)
   - Added =org-babel= support (thanks to Michael Rohleder)
   - Added debugger integration via =dap= layer
-  - Added detecting ".ccls" for ccls powered projects.
+  - Added detecting ".ccls" for ccls powered projects (thanks to sunlin7)
+  - Fixed the =c-c++-default-mode-for-headers= should not affect the default
+    behavior that opening a .h file will turn C or C++ mode depending on
+    language used in Emacs > 26.1+ (thanks to Lin Sun)
 - Key bindings:
   - ~SPC m = =~ clang-format current region or buffer (thanks to Dela Anthonio)
   - ~SPC m = f~ clang-format current function (thanks to Dela Anthonio)

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -74,8 +74,9 @@ file.
 *Note:* [[https://github.com/tuhdo/semantic-refactor][semantic-refactor]] is only available for Emacs 24.4+
 
 ** Default mode for header files
-By default header files are opened in =c-mode=, you can open them in =c++-mode=
-by setting the variable =c-c++-default-mode-for-headers= to =c++-mode=.
+Mode for header files is auto detected by `c-or-c++-mode' in Emacs > 26.1+.
+Older Emacs will open header files in =c-mode= by default, you can open them in
+=c++-mode= by setting the variable =c-c++-default-mode-for-headers= as follow.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -51,8 +51,8 @@
   "If non-nil, automatically format code with ClangFormat on
   save. Clang support has to be enabled for this to work.")
 
-(defvar c-c++-default-mode-for-headers 'c-mode
-  "Default mode to open header files. Can be `c-mode' or `c++-mode'.")
+(defvar c-c++-default-mode-for-headers (when (not (functionp 'c-or-c++-mode)) 'c-mode)
+  "Default mode to open header files. Can be `c-mode' or `c++-mode', or `c-or-c++-mode' for Emacs > 26+.")
 
 (defvar c-c++-adopt-subprojects nil
   "When non-nil, projectile will remember project root when visiting files in subprojects")

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -51,8 +51,9 @@
     :defer t
     :init
     (progn
-      (add-to-list 'auto-mode-alist
-        `("\\.h\\'" . ,c-c++-default-mode-for-headers))
+      (when c-c++-default-mode-for-headers
+        (add-to-list 'auto-mode-alist
+                     `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
       (when c-c++-enable-auto-newline
         (add-hook 'c-mode-common-hook 'spacemacs//c-toggle-auto-newline)))
     :config


### PR DESCRIPTION
Fixed the =c-c++-default-mode-for-headers= should not affect the default behavior for Emacs > 26.1+ that mode for header files is auto detected by `c-or-c++-mode'.