### PR TITLE
Switch recreated messages buffer to evil-normal-state

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1062,6 +1062,7 @@ Other:
   - Fixed =search-engine= layer customization issue (thanks to Haisheng Wu)
   - Replaced deprecated =avy--generic-jump= with =avy-jump=
     (thanks to Dominik Schrempf)
+  - Switch recreated messages buffer to =evil-normal-state= (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1427,7 +1427,9 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
     (goto-char (point-max))
     (if arg
         (switch-to-buffer-other-window (current-buffer))
-      (switch-to-buffer (current-buffer)))))
+      (switch-to-buffer (current-buffer)))
+    (when (evil-evilified-state-p)
+      (evil-normal-state))))
 
 (defun spacemacs/close-compilation-window ()
   "Close the window containing the '*compilation*' buffer."


### PR DESCRIPTION
If the messages buffer is deleted.
When it's recreated, then it opens in evil-evilified-state
where the evil keys `w` and `b` are undefined.