### PR TITLE
Make spacemacs theme handling support ewal themes (second try)

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -221,6 +221,10 @@ Note: the hooked function is not executed when in dumped mode."
                              "Calling dotfile user config...")
      (dotspacemacs|call-func dotspacemacs/emacs-custom-settings
                              "Calling dotfile Emacs custom settings...")
+     (defconst spacemacs-original-spacemacs-custom-colors (when (boundp 'spacemacs-theme-custom-colors) spacemacs-theme-custom-colors)
+       "Value of spacemacs-theme-custom-colors as it was after running user-config.
+  Needs to be saved as some themes customise this variable and we can otherwise not restore the original setting.")
+
      ;; don't write custom settings into the dotfile before loading them,
      ;; otherwise https://github.com/syl20bnr/spacemacs/issues/10504 happens
      (spacemacs/initialize-custom-file-sync)

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -370,6 +370,7 @@ THEME."
   "Cycle through themes defined in `dotspacemacs-themes'.
 When BACKWARD is non-nil, or with universal-argument, cycle backwards."
   (interactive "P")
+  (setq spacemacs-theme-custom-colors spacemacs-original-spacemacs-custom-colors)
   (let* ((themes (if backward (reverse dotspacemacs-themes) dotspacemacs-themes))
          (next-theme (car (or (cdr (memq spacemacs--cur-theme themes))
                               ;; if current theme isn't in cycleable themes, start

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -114,8 +114,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   (interactive)
   (call-interactively
    (spacemacs//helm-do-search-find-tool "helm-file-do"
-                                 dotspacemacs-search-tools
-                                 default-inputp)))
+                                        dotspacemacs-search-tools
+                                        default-inputp)))
 
 (defun spacemacs/helm-file-smart-do-search-region-or-symbol ()
   "Search in current file using `dotspacemacs-search-tools' with
@@ -183,8 +183,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   (interactive)
   (call-interactively
    (spacemacs//helm-do-search-find-tool "helm-files-do"
-                                 dotspacemacs-search-tools
-                                 default-inputp)))
+                                        dotspacemacs-search-tools
+                                        default-inputp)))
 
 (defun spacemacs/helm-files-smart-do-search-region-or-symbol ()
   "Search in files using `dotspacemacs-search-tools' with default input.
@@ -242,8 +242,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   (interactive)
   (call-interactively
    (spacemacs//helm-do-search-find-tool "helm-dir-do"
-                                 dotspacemacs-search-tools
-                                 default-inputp)))
+                                        dotspacemacs-search-tools
+                                        default-inputp)))
 
 (defun spacemacs/helm-dir-smart-do-search-region-or-symbol ()
   "Search in current directory using `dotspacemacs-search-tools'.
@@ -308,8 +308,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   (interactive)
   (call-interactively
    (spacemacs//helm-do-search-find-tool "helm-buffers-do"
-                                 dotspacemacs-search-tools
-                                 default-inputp)))
+                                        dotspacemacs-search-tools
+                                        default-inputp)))
 
 (defun spacemacs/helm-buffers-smart-do-search-region-or-symbol ()
   "Search in opened buffers using `dotspacemacs-search-tools' with
@@ -407,8 +407,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   (let ((projectile-require-project-root nil))
     (call-interactively
      (spacemacs//helm-do-search-find-tool "helm-project-do"
-                                   dotspacemacs-search-tools
-                                   default-inputp))))
+                                          dotspacemacs-search-tools
+                                          default-inputp))))
 
 (defun spacemacs/helm-project-smart-do-search-region-or-symbol ()
   "Search in current project using `dotspacemacs-search-tools' with
@@ -595,9 +595,9 @@ to buffers)."
   (with-current-buffer "*helm ag results*"
     (setq spacemacs--gne-min-line 5
           spacemacs--gne-max-line (save-excursion
-            (goto-char (point-max))
-            (previous-line)
-            (line-number-at-pos))
+                                    (goto-char (point-max))
+                                    (previous-line)
+                                    (line-number-at-pos))
           spacemacs--gne-line-func
           (lambda (c)
             (helm-ag--find-file-action
@@ -621,5 +621,6 @@ to buffers)."
 (defun spacemacs/helm-themes ()
   "Remove limit on number of candidates on `helm-themes'"
   (interactive)
+  (setq spacemacs-theme-custom-colors spacemacs-original-spacemacs-custom-colors)
   (let (helm-candidate-number-limit)
     (helm-themes)))


### PR DESCRIPTION
Ewal themes customise spacemacs-theme-custom-colors which
changes the appearance of all spacemacs-theme based
themes. To avoid permanent changes on the theme and
still allow custom color themes we need to save
the original setting after having run user-config.
This we then restore everytime we switch a theme.

This restores 5f308b0306d44b20d200ee2bc490540e1c9ee149