### PR TITLE
Support other keywords in recipe of local fetcher

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -866,7 +866,7 @@ a new object."
                                         layer-name)
                                        pkg-name-str))))
                     (cfgl-package-set-property
-                     obj :location `(recipe :fetcher file :path ,path))))
+                     obj :location `(recipe :fetcher file :path ,path ,@(spacemacs/mplist-remove (cdr location) :fetcher)))))
            ((eq 'dotfile layer-name) nil))
         (cfgl-package-set-property obj :location location)))
     ;; cannot override protected packages


### PR DESCRIPTION
Currently, when the fetcher is local, all keywords following
`:fetcher local` are dropped.

With this fix, the following recipe with extra keywords like `:files`
works as expected:

    (pyim-wbdict :toggle (eq chinese-default-input-method 'wubi)
        :location (recipe :fetcher local
                          :files (:defaults "*.pyim" "*.pyim.gz")))