### PR TITLE
[clojure] Fix jumping backwards after cider-find-var and spacemacs/clj-find-var

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1272,6 +1272,7 @@ Other:
     (thanks to Timo Freiberg)
   - Change run-all-tests alias to run-project-tests (thanks to Timo Freiberg)
   - Fixed post-init of parinfer in the clojure layer (thanks to Martin Račák)
+  - Fixed jumping backwards after =cider-find-var= (thanks to Dieter Komendera)
 **** Coffeescript
 - Improvements:
   - Added basic autocompletion (thanks to Codruț Constantin Gușoi)

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -234,7 +234,7 @@
         (clojure/fancify-symbols 'cider-repl-mode)
         (clojure/fancify-symbols 'cider-clojure-interaction-mode)))
 
-    (defadvice cider-jump-to-var (before add-evil-jump activate)
+    (defadvice cider-find-var (before add-evil-jump activate)
       (evil-set-jump))))
 
 (defun clojure/init-cider-eval-sexp-fu ()


### PR DESCRIPTION
`cider-jump-to-var` was renamed to `cider-find-var` here:
https://github.com/clojure-emacs/cider/commit/ceb2d7df75f09c35ef17a7ac050cd8c4388d32ce#diff-e39c33031dc8d3e78b32ebee83293cd6L809-R846

In https://github.com/syl20bnr/spacemacs/pull/9792/ `spacemacs/clj-find-var` and https://github.com/syl20bnr/spacemacs/commit/cc43d5c898c72e9f7a877e0b11fa78cc0f6a1a34#diff-2a8459f655b4c71c7f7a6c8b773322f9
was added to be used as the jump handler for clojure modes. It uses
`cider-find-var` which doesn't push jump positions onto the evil jump stack so
the no longer current `defadvice` was more apparent.

This can be tested by using `spacemacs/clj-find-var` (`, g g`) with a REPL connected and then jumping back using `evil-jump-backward` (`C-i`).

cc @jr0cket 