### PR TITLE
[go] Update doc on LSP setup.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1584,6 +1584,7 @@ Other:
 - Refactored two variables =go-use-gometalinter= and =go-use-golangci-lint= to
   one =go-linter= (thanks to Robert Zaremba)
 - Added Testify support (thanks to Mathieu Post)
+- Added setup instructions for =gopls= (thanks to pancho horrillo)
 **** Graphviz
 - Use graphviz package from melpa (thanks to Matthew Boston)
 **** Groovy

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -117,7 +117,14 @@ To enable the LSP backend set the layer variable =go-backend=:
 #+END_SRC
 
 You also need to install the Go Language Server.
-Consult the installation command for the desired language server found at [[https://www.github.com/emacs-lsp/lsp-mode/][lsp-mode]] for instructions.
+
+This is the [[https://github.com/golang/go/wiki/gopls][recommended procedure]] to install =gopls=:
+
+#+BEGIN_SRC sh
+  GO111MODULE=on go get -v golang.org/x/tools/gopls@latest
+#+END_SRC
+
+You can check [[https://www.github.com/emacs-lsp/lsp-mode/][lsp-mode]] for the gory details.
 
 Backend can be chosen on a per project basis using directory local variables
 (files named =.dir-locals.el= at the root of a project), an example to use the


### PR DESCRIPTION
`gopls` is Google’s upcoming Go language server; the other implementation
mentioned in the `lsp-mode` doc¹ has been discontinued².

So, I've added the recommended procedure³ to install `gopls`.

¹: https://github.com/emacs-lsp/lsp-mode/
²: https://github.com/saibing/bingo
³: https://github.com/golang/go/wiki/gopls