### PR TITLE
[clojure] Add cider clojuredocs keybinding, remove grimoire

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1251,6 +1251,8 @@ Other:
     (thanks to John Stevenson)
   - Restore standard =SPC m s i= binding for =cider-jack-in-clj=
     (thanks to Russell Mull)
+  - ~SPC m h d~ new keybinding for =cider-clojuredocs=
+  - Remove ~SPC m h g~ for =grimoire= as it is deprecated
 - Fixes:
   - Remove `cider.nrepl/cider-middleware` in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -237,7 +237,7 @@ As this state works the same for all files, the documentation is in global
 |-------------+-----------------------------|
 | ~SPC m h a~ | cider apropos               |
 | ~SPC m h c~ | clojure cheatsheet          |
-| ~SPC m h g~ | cider grimoire              |
+| ~SPC m h d~ | cider clojuredocs           |
 | ~SPC m h h~ | cider doc                   |
 | ~SPC m h j~ | cider javadoc               |
 | ~SPC m h n~ | cider browse namespace      |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -74,7 +74,7 @@
           (spacemacs/set-leader-keys-for-major-mode m
             "ha" 'cider-apropos
             "hc" 'cider-cheatsheet
-            "hg" 'cider-grimoire
+            "hd" 'cider-clojuredocs
             "hh" 'cider-doc
             "hj" 'cider-javadoc
             "hn" 'cider-browse-ns


### PR DESCRIPTION
It appears that Clojure grimoire is now deprecated and replaced with clojuredocs. https://github.com/clojure-emacs/cider/issues/2663
Spacemacs develop already contains the function `cider-clojuredocs`, but it does not have a major-mode keybinding. This pull-requests adds cider-clojuredocs to `SPC m h d`, it also removes the grimoire keybind that was on `SPC m h g`

This is my first ever pull request to an open-source project, I hope that I didn't mess up too much :)

Thank you for spacemacs!