### PR TITLE
[gnus]: map `gnus-group-get-new-news' to `g r'

### DIFF
--- a/layers/+email/gnus/README.org
+++ b/layers/+email/gnus/README.org
@@ -116,6 +116,7 @@ Basic and Spacemacs specific key bindings can be found in the following table.
 | ~SPC a g~   | Starts Gnus                                         |
 | ~m~         | New Message                                         |
 | ~G R~       | Group Buffer - Add RSS feed                         |
+| ~g r~       | Group Buffer - Check for new mail                   |
 | ~^~         | Open Server Buffer. Browse Newsgroups.              |
 | ~T n~       | Group Buffer - new Topic                            |
 | ~T m~       | Group Buffer - Move Group to Topic                  |

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -76,7 +76,8 @@
             (gnus-summary-scroll-up arg))))
       (add-to-list 'nnmail-extra-headers nnrss-url-field)
 
-      (evilified-state-evilify gnus-group-mode gnus-group-mode-map)
+      (evilified-state-evilify gnus-group-mode gnus-group-mode-map
+        (kbd "g r") 'gnus-group-get-new-news)
       (evilified-state-evilify gnus-server-mode gnus-server-mode-map)
       (evilified-state-evilify gnus-browse-mode gnus-browse-mode-map)
       (evilified-state-evilify gnus-article-mode gnus-article-mode-map)


### PR DESCRIPTION
Since the `g` key is remapped in an evilified state for the gnus group buffer, use the combination `g r` to check for new news. This is similarly done in magit.