### PR TITLE
[ansible] Fix void-variable company-backends

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1088,6 +1088,7 @@ Other:
   - Fixed =error void function ansible: auto-decrypt-encrypt=
     (thanks to Sylvain Benner)
   - Matched upstream Emacs coding convention names (thanks to Ayush Goyal)
+  - Fixed void-variable =company-backends= (thanks to duianto)
 **** Asm
 - Improvements:
   - Added support for =company= package declaration (thanks to Kalle Lindqvist)

--- a/layers/+tools/ansible/packages.el
+++ b/layers/+tools/ansible/packages.el
@@ -63,9 +63,12 @@
   (use-package company-ansible
     :defer t
     :init
-    ;; append this hook at the end to execute it last so `company-backends'
-    ;; variable is buffer local
-    (add-hook 'yaml-mode-hook 'spacemacs/ansible-company-maybe-enable t)))
+    (progn
+     ;; append this hook at the end to execute it last so `company-backends'
+     ;; variable is buffer local
+     (add-hook 'yaml-mode-hook 'spacemacs/ansible-company-maybe-enable t)
+     (spacemacs|add-company-backends :backends company-ansible
+                                     :modes ansible))))
 
 (defun ansible/init-jinja2-mode ()
   (use-package jinja2-mode


### PR DESCRIPTION
Fixes: #10848

Tested with:

#### System Info :computer:
<details><summary>
Ubuntu 18.04
</summary>
<pre>
#### System Info :computer:
- OS: gnu/linux
- Emacs: 27.0.50
- Spacemacs: 0.300.0
- Spacemacs branch: develop (rev. c5c63f48c)
- Graphic display: t
- Distribution: spacemacs
- Editing style: vim
- Completion: helm
- Layers:
```elisp
(ansible auto-completion emacs-lisp git helm markdown multiple-cursors org spell-checking syntax-checking treemacs version-control yaml)
```
- System configuration features: XPM JPEG TIFF GIF PNG RSVG SOUND GPM DBUS GSETTINGS GLIB NOTIFY INOTIFY ACL LIBSELINUX GNUTLS LIBXML2 FREETYPE HARFBUZZ M17N_FLT LIBOTF XFT ZLIB TOOLKIT_SCROLL_BARS GTK3 X11 XDBE XIM MODULES THREADS XWIDGETS LIBSYSTEMD PDUMPER LCMS2 GMP
</pre>
</details>

<details><summary>
Windows 1903
</summary>
<pre>
#### System Info :computer:
- OS: windows-nt
- Emacs: 26.3
- Spacemacs: 0.300.0
- Spacemacs branch: develop (rev. c5c63f48c)
- Graphic display: t
- Distribution: spacemacs
- Editing style: vim
- Completion: helm
- Layers:
```elisp
(ansible autohotkey auto-completion
         (dart :variables dart-server-sdk-path "C:/tools/dart-sdk/" dart-server-enable-analysis-server t)
         emacs-lisp git helm html lsp multiple-cursors org spell-checking syntax-checking neotree version-control yaml)
```
- System configuration features: XPM JPEG TIFF GIF PNG RSVG SOUND NOTIFY ACL GNUTLS LIBXML2 ZLIB TOOLKIT_SCROLL_BARS THREADS LCMS2
</pre>
</details>