### PR TITLE
Dap debuging -- one liner easy merge!

### DIFF
--- a/layers/+tools/dap/funcs.el
+++ b/layers/+tools/dap/funcs.el
@@ -13,7 +13,7 @@
   "Define key bindings for the specific MODE."
 
   (spacemacs/declare-prefix-for-mode mode "md" "debug")
-  (spacemacs/declare-prefix-for-mode mode "mdd" "debuging")
+  (spacemacs/declare-prefix-for-mode mode "mdd" "debugging")
   (spacemacs/declare-prefix-for-mode mode "mdb" "breakpoints")
   (spacemacs/declare-prefix-for-mode mode "mdw" "debug windows")
   (spacemacs/declare-prefix-for-mode mode "mdS" "switch")


### PR DESCRIPTION
The prefix description for "debugging" has a spelling mistake
`SPC m d d` now reads "debugging" instead of "debuging"