### PR TITLE
python layer - corrected keybinding collision (format buffer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ eclipse.jdt.ls
 .lsp-session-*
 .trello
 .extension
+mspyls/
 
 # Private directory
 private/

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -447,7 +447,7 @@ Live coding is provided by the [[https://github.com/donkirkby/live-py-plugin][li
 
 | Key binding   | Description                                                                       |
 |---------------+-----------------------------------------------------------------------------------|
-| ~SPC m =~     | reformat the buffer using formatter specified in =python-formatter=               |
+| ~SPC m ==~    | reformat the buffer using formatter specified in =python-formatter=               |
 | ~SPC m d b~   | toggle a breakpoint using =wdb=, =ipdb=, =pudb=, =pdb= or =python3.7= (and above) |
 | ~SPC m g a~   | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back)      |
 | ~SPC m g b~   | jump back                                                                         |

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -349,7 +349,7 @@ to be called for each testrunner. "
 
 (defun spacemacs//bind-python-formatter-keys ()
   (spacemacs/set-leader-keys-for-major-mode 'python-mode
-    "=" 'spacemacs/python-format-buffer))
+    "==" 'spacemacs/python-format-buffer))
 
 (defun spacemacs/python-format-buffer ()
   (interactive)


### PR DESCRIPTION
`spacemacs/python-format-buffer` was bound to '='
Subsequently clobbered by lsp layer declaration of = as prefix with subsidiary
keybindings.
Resolved by moving `spacemacs/python-format-buffer` binding to '=='

Opportunistically added 'mspyls' dir to .gitignore
