### PR TITLE
[gnus] add `O` prefix for gnus-group-group-map

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1555,6 +1555,8 @@ Other:
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)
+  - Added ~O~ prefix in evil state for =gnus-group-group-map= (thanks to Matthew
+    Leach)
 **** Go
 - Improved go test output buffer behavior (thanks to Denis Bernard)
 - Configurable extra arguments to go run (thanks to Enze Chi)

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -77,7 +77,8 @@
       (add-to-list 'nnmail-extra-headers nnrss-url-field)
 
       (evilified-state-evilify gnus-group-mode gnus-group-mode-map
-        (kbd "g r") 'gnus-group-get-new-news)
+        (kbd "g r") 'gnus-group-get-new-news
+        (kbd "O") 'gnus-group-group-map)
       (evilified-state-evilify gnus-server-mode gnus-server-mode-map)
       (evilified-state-evilify gnus-browse-mode gnus-browse-mode-map)
       (evilified-state-evilify gnus-article-mode gnus-article-mode-map)


### PR DESCRIPTION
Since the `O` key is not used in the `group-group-mode-map` use it as a prefix
for the `group-group-group-map` in evilifed state.