### PR TITLE
[python] declare lsp layer dependency when python-backend is 'lsp

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2250,8 +2250,8 @@ Other:
 - Added key binding ~SPC m r f~ to fix missing import statements
   (thanks to Volodymyr Vitvitskyi)
 - Use =python-mode= for SCons script files (thanks to shanemikel)
-- Added LSP support, which can be used by enabling the =lsp= layer and setting
-  the =python= layer's =python-backend= variable to =lsp=
+- Added LSP support, which can be enabled by setting the =python= layer's
+  =python-backend= variable to =lsp=
   (thanks to Yuan Fu and Sylvain Benner).
 - The LSP backend can use either the =pyls= (default) server or the =mspyls=
   (Microsoft) implementation, which may be selected by setting the

--- a/layers/+lang/python/layers.el
+++ b/layers/+lang/python/layers.el
@@ -1,0 +1,14 @@
+;;; layers.el --- Python Layer declarations File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'python-backend)
+           (eq python-backend 'lsp))
+  (configuration-layer/declare-layer 'lsp))


### PR DESCRIPTION
Previously, if a user set `python-backend` to `'lsp`, it would not do anything
unless the user also manually added the `lsp` layer to the spacemacs `init.el`
file. This commit updates the `python` layer to correctly add the dependency
when needed, like the `c-c++` layer does.