### PR TITLE
[lsp] Updated keybindings w.r.t upstream lsp-mode refactoring / additions.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1884,6 +1884,7 @@ Other:
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 **** Language Server Protocol (LSP)
+- Added core keybindings and prefix declarations for all LSP-based language layers, and helper functions to bind server-specific extensions (thanks to Cormac Cannon).
 - Replace lsp-capabilities keybinding with lsp-describe-session
   (thanks to Bryan Tan)
 - Added lsp-prefer-flymake variable (thanks to Juuso Valkeejärvi)
@@ -1899,6 +1900,7 @@ Other:
 - Added package =helm-lsp=
   - ~SPC m g s~ to find symbol in current project
   - ~SPC m g S~ to find symbol in all projects
+- Disabled =helm-lsp= keybindings when =ivy= layer enabled (Cormac Cannon)
 - Deleted =fix-lsp-company-prefix= since =company-lsp= is doing that handling.
 - Fixed a delay when declaring prefixes for mode (thanks to Thanh Vuong)
 - Required =helm= or =treemacs= to download =helm-lsp= or =lsp-treemacs=

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -74,16 +74,17 @@ available in all language layers based on the lsp layer.
 ** Key binding prefixes
 The key bindings are grouped under the following prefixes:
 
-| prefix    | name        | functional area                                                            |
-|-----------+-------------+----------------------------------------------------------------------------|
-| ~SPC m =~ | format      | Source formatting                                                          |
-| ~SPC m g~ | goto        | Source navigation                                                          |
-| ~SPC m G~ | peek        | Source navigation (lsp-ui-peek overlay)                                    |
-| ~SPC m F~ | folder      | Add/remove folders from workspace                                          |
-| ~SPC m h~ | help        | Help                                                                       |
-| ~SPC m b~ | lsp/backend | Catchall. Restart LSP backend, other implementation-specific functionality |
-| ~SPC m r~ | refactor    | What it says on the tin                                                    |
-| ~SPC m T~ | toggle      | Toggle LSP backend features (documentation / symbol info overlays etc.)    |
+| prefix    | name          | functional area                                                            |
+|-----------+---------------+----------------------------------------------------------------------------|
+| ~SPC m =~ | format        | Source formatting                                                          |
+| ~SPC m g~ | goto          | Source navigation                                                          |
+| ~SPC m G~ | peek          | Source navigation (lsp-ui-peek overlay)                                    |
+| ~SPC m F~ | folder        | Add/remove folders from workspace                                          |
+| ~SPC m h~ | help          | Help                                                                       |
+| ~SPC m b~ | lsp/backend   | Catchall. Restart LSP backend, other implementation-specific functionality |
+| ~SPC m r~ | refactor      | What it says on the tin                                                    |
+| ~SPC m T~ | toggle        | Toggle LSP backend features (documentation / symbol info overlays etc.)    |
+| ~SPC m x~ | text (source) | Text (source) document related bindings                                    |
 
 Some navigation key bindings (i.e. ~SPC m g~ / ~SPC m G~) use an additional level of grouping:
 
@@ -95,54 +96,66 @@ Some navigation key bindings (i.e. ~SPC m g~ / ~SPC m G~) use an additional leve
 ** Core key bindings
 The lsp minor mode bindings are:
 
-| binding     | function                                                                       |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m = b~ | format buffer (lsp)                                                            |
-| ~SPC m = r~ | format region (lsp)                                                            |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m g t~ | goto type-definition (lsp)                                                     |
-| ~SPC m g k~ | goto viewport word (avy) (See Note 1)                                          |
-| ~SPC m g K~ | goto viewport symbol (avy) (See Note 1)                                        |
-| ~SPC m g e~ | browse flycheck errors (lsp-treemacs)                                          |
-| ~SPC m g M~ | browse file symbols (lsp-ui-imenu)                                             |
-|-------------+--------------------------------------------------------------------------------|
-| Note        | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ == ='peek=/     |
-| ~SPC m g i~ | find implementations (lsp)                                                     |
-| ~SPC m g d~ | find definitions (xref/lsp)                                                    |
-| ~SPC m g r~ | find references (xref/lsp)                                                     |
-| ~SPC m g s~ | find symbol in project (helm-lsp)                                              |
-| ~SPC m g S~ | find symbol in all projects (helm-lsp)                                         |
-| ~SPC m g p~ | goto previous (xref-pop-marker-stack)                                          |
-|-------------+--------------------------------------------------------------------------------|
-| Note        | /Omitted when ~lsp-navigation~ == ='peek= or ='simple=/                        |
-|             | /Bound under ~SPC m g~ rather than ~SPC m G~ when ~lsp-navigation~ == ='peek=/ |
-| ~SPC m G i~ | find implementation (lsp-ui-peek)                                              |
-| ~SPC m G d~ | find definitions (lsp-ui-peek)                                                 |
-| ~SPC m G r~ | find references (lsp-ui-peek)                                                  |
-| ~SPC m G s~ | find-workspace-symbol (lsp-ui-peek)                                            |
-| ~SPC m G p~ | goto previous (lsp-ui-peek stack - see Note 2)                                 |
-| ~SPC m G n~ | goto next (lsp-ui-peek stack - see Note 2)                                     |
-| ~SPC m G E~ | browse flycheck errors (lsp-ui)                                                |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m h h~ | describe thing at point                                                        |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m b s~ | lsp-shutdown-workspace                                                         |
-| ~SPC m b r~ | lsp-restart-workspace                                                          |
-| ~SPC m b a~ | execute code action                                                            |
-| ~SPC m b d~ | lsp-describe-session                                                           |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m r r~ | rename                                                                         |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m T d~ | toggle documentation overlay                                                   |
-| ~SPC m T F~ | toggle documentation overlay function signature                                |
-| ~SPC m T s~ | toggle symbol info overlay                                                     |
-| ~SPC m T S~ | toggle symbol info overlay symbol name                                         |
-| ~SPC m T I~ | toggle symbol info overlay duplicates                                          |
-| ~SPC m T l~ | toggle lenses                                                                  |
-|-------------+--------------------------------------------------------------------------------|
-| ~SPC m F r~ | Remove workspace folder                                                        |
-| ~SPC m F a~ | Add workspace folder                                                           |
-| ~SPC m F s~ | Switch workspace folder                                                        |
+| binding     | function                                                                         |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m = b~ | format buffer (lsp)                                                              |
+| ~SPC m = r~ | format region (lsp)                                                              |
+| ~SPC m = o~ | format (organise) imports                                                        |
+|-------------+----------------------------------------------------------------------------------|
+| Note        | /The ~f~, ~r~ and ~s~ actions are placeholders for imminent ~lsp-mode~ features/ |
+| ~SPC m a a~ | Execute code action                                                              |
+| ~SPC m a f~ | Execute fix action                                                               |
+| ~SPC m a r~ | Execute refactor action                                                          |
+| ~SPC m a s~ | Execute source action                                                            |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m g t~ | goto type-definition (lsp)                                                       |
+| ~SPC m g k~ | goto viewport word (avy) (See Note 1)                                            |
+| ~SPC m g K~ | goto viewport symbol (avy) (See Note 1)                                          |
+| ~SPC m g e~ | browse flycheck errors (lsp-treemacs)                                            |
+| ~SPC m g M~ | browse file symbols (lsp-ui-imenu)                                               |
+|-------------+----------------------------------------------------------------------------------|
+| Note        | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ == ='peek=/       |
+| ~SPC m g i~ | find implementations (lsp)                                                       |
+| ~SPC m g d~ | find definitions (xref/lsp)                                                      |
+| ~SPC m g r~ | find references (xref/lsp)                                                       |
+| ~SPC m g s~ | find symbol in project (helm-lsp)                                                |
+| ~SPC m g S~ | find symbol in all projects (helm-lsp)                                           |
+| ~SPC m g p~ | goto previous (xref-pop-marker-stack)                                            |
+|-------------+----------------------------------------------------------------------------------|
+| Note        | /Omitted when ~lsp-navigation~ == ='peek= or ='simple=/                          |
+|             | /Bound under ~SPC m g~ rather than ~SPC m G~ when ~lsp-navigation~ == ='peek=/   |
+| ~SPC m G i~ | find implementation (lsp-ui-peek)                                                |
+| ~SPC m G d~ | find definitions (lsp-ui-peek)                                                   |
+| ~SPC m G r~ | find references (lsp-ui-peek)                                                    |
+| ~SPC m G s~ | find workspace symbol (lsp-ui-peek)                                              |
+| ~SPC m G S~ | goto workspace symbol (lsp-treemacs-symbols)                                     |
+| ~SPC m G p~ | goto previous (lsp-ui-peek stack - see Note 2)                                   |
+| ~SPC m G n~ | goto next (lsp-ui-peek stack - see Note 2)                                       |
+| ~SPC m G E~ | browse flycheck errors (lsp-ui)                                                  |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m h h~ | describe thing at point                                                          |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m b s~ | lsp-workspace-shutdown                                                           |
+| ~SPC m b r~ | lsp-workspace-restart                                                            |
+| ~SPC m b d~ | lsp-describe-session                                                             |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m r r~ | rename                                                                           |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m T d~ | toggle documentation overlay                                                     |
+| ~SPC m T F~ | toggle documentation overlay function signature                                  |
+| ~SPC m T s~ | toggle symbol info overlay                                                       |
+| ~SPC m T S~ | toggle symbol info overlay symbol name                                           |
+| ~SPC m T I~ | toggle symbol info overlay duplicates                                            |
+| ~SPC m T l~ | toggle lenses                                                                    |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m F r~ | Remove workspace folder                                                          |
+| ~SPC m F a~ | Add workspace folder                                                             |
+| ~SPC m F s~ | Switch workspace folder                                                          |
+|-------------+----------------------------------------------------------------------------------|
+| ~SPC m x h~ | Highlight all instances of symbol under point                                    |
+| ~SPC m x l~ | Show code lenses                                                                 |
+| ~SPC m x L~ | Hide code lenses                                                                 |
+
 
 Note 1: Your language server may not distinguish between the word and symbol variants of this binding.
 Note 2: There is a window local jump list dedicated to cross references.

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -28,7 +28,14 @@
     ;; format
     "=b" #'lsp-format-buffer
     "=r" #'lsp-format-region
+    "=o" #'lsp-organize-imports
+    ;; code actions
+    "aa" #'lsp-execute-code-action
+    "af" #'spacemacs//lsp-action-placeholder
+    "ar" #'spacemacs//lsp-action-placeholder
+    "as" #'spacemacs//lsp-action-placeholder
     ;; goto
+    ;; N.B. implementation and references covered by xref bindings / lsp provider...
     "gt" #'lsp-find-type-definition
     "gk" #'spacemacs/lsp-avy-goto-word
     "gK" #'spacemacs/lsp-avy-goto-symbol
@@ -37,10 +44,9 @@
     "hh" #'lsp-describe-thing-at-point
     ;; jump
     ;; backend
-    "ba" #'lsp-execute-code-action
     "bd" #'lsp-describe-session
-    "br" #'lsp-restart-workspace
-    "bs" #'lsp-shutdown-workspace
+    "br" #'lsp-workspace-restart
+    "bs" #'lsp-workspace-shutdown
     ;; refactor
     "rr" #'lsp-rename
     ;; toggles
@@ -53,7 +59,12 @@
     ;; folders
     "Fs" #'lsp-workspace-folders-switch
     "Fr" #'lsp-workspace-folders-remove
-    "Fa" #'lsp-workspace-folders-add))
+    "Fa" #'lsp-workspace-folders-add
+    ;; text/code
+    "xh" #'lsp-document-highlight
+    "xl" #'lsp-lens-show
+    "xL" #'lsp-lens-hide
+    ))
 
 (defun spacemacs//lsp-bind-simple-navigation-functions (prefix-char)
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
@@ -61,9 +72,14 @@
     (concat prefix-char "d") #'xref-find-definitions
     (concat prefix-char "r") #'xref-find-references
     (concat prefix-char "e") #'lsp-treemacs-errors-list
-    (concat prefix-char "s") #'helm-lsp-workspace-symbol
-    (concat prefix-char "S") #'helm-lsp-global-workspace-symbol
-    (concat prefix-char "p") #'xref-pop-marker-stack))
+    (concat prefix-char "p") #'xref-pop-marker-stack)
+  (if (configuration-layer/package-usedp 'helm)
+      (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
+        (concat prefix-char "s") #'helm-lsp-workspace-symbol
+        (concat prefix-char "S") #'helm-lsp-global-workspace-symbol)
+    (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
+      (concat prefix-char "s") #'lsp-ui-find-workspace-symbol))
+  )
 
 (defun spacemacs//lsp-bind-peek-navigation-functions (prefix-char)
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
@@ -71,6 +87,7 @@
     (concat prefix-char "d") #'lsp-ui-peek-find-definitions
     (concat prefix-char "r") #'lsp-ui-peek-find-references
     (concat prefix-char "s") #'lsp-ui-peek-find-workspace-symbol
+    (concat prefix-char "S") #'lsp-treemacs-symbols
     (concat prefix-char "p") #'lsp-ui-peek-jump-backward
     (concat prefix-char "e") #'lsp-ui-flycheck-list
     (concat prefix-char "n") #'lsp-ui-peek-jump-forward))
@@ -80,13 +97,15 @@
   (unless (member mode lsp-layer--active-mode-list)
     (push mode lsp-layer--active-mode-list)
     (spacemacs/declare-prefix-for-mode mode "m=" "format")
-    (spacemacs/declare-prefix-for-mode mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode mode "ma" "code actions")
     (spacemacs/declare-prefix-for-mode mode "mb" "backend")
-    (spacemacs/declare-prefix-for-mode mode "mr" "refactor")
-    (spacemacs/declare-prefix-for-mode mode "mT" "toggle")
+    (spacemacs/declare-prefix-for-mode mode "mF" "folder")
     (spacemacs/declare-prefix-for-mode mode "mg" "goto")
     (spacemacs/declare-prefix-for-mode mode "mG" "peek")
-    (spacemacs/declare-prefix-for-mode mode "mF" "folder")
+    (spacemacs/declare-prefix-for-mode mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode mode "mr" "refactor")
+    (spacemacs/declare-prefix-for-mode mode "mT" "toggle")
+    (spacemacs/declare-prefix-for-mode mode "mx" "text/code")
     (dolist (prefix '("mg" "mG"))
       (spacemacs/declare-prefix-for-mode mode (concat prefix "h") "hierarchy")
       (spacemacs/declare-prefix-for-mode mode (concat prefix "m") "members"))))
@@ -165,6 +184,10 @@ a find extension defined using `lsp-define-extensions'"
 (defun spacemacs/lsp-avy-goto-symbol ()
   (interactive)
   (spacemacs//lsp-avy-document-symbol nil))
+
+(defun spacemacs//lsp-action-placeholder ()
+  (interactive)
+  (message "Watch this space... (to be implemented in 'lsp-mode)"))
 
 ;; From https://github.com/MaskRay/Config/blob/master/home/.config/doom/autoload/misc.el#L118
 (defun spacemacs//lsp-avy-document-symbol (all)


### PR DESCRIPTION
lsp-mode had renamed lsp-shutdown-workspace and lsp-restart-workspace.

Added bindings for the following newer interactive lsp-mode functions:
- lsp-organize-imports
- lsp-document-highlight
- lsp-lens-show
- lsp-lens-hide

Declared a new major mode prefix (x: text/code).
Moved execute-code-action binding under new prefix

Tidy-up in preparation for a c-c++ layer update (adding clangd support)