### PR TITLE
[go] Drop support for gometalinter

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1598,6 +1598,7 @@ Other:
   one =go-linter= (thanks to Robert Zaremba)
 - Added Testify support (thanks to Mathieu Post)
 - Added setup instructions for =gopls= (thanks to pancho horrillo)
+- Dropped support for deprecated =gometalinter= (thanks to pancho horrillo)
 **** Graphviz
 - Use graphviz package from melpa (thanks to Matthew Boston)
 **** Groovy

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -30,7 +30,7 @@ This layer adds extensive support for go to Spacemacs.
 - Source analysis using [[https://docs.google.com/document/d/1_Y9xCEMj5S-7rv2ooHpZNH15JgRT5iM742gJkw5LtmQ][go-guru]]
 - Refactoring with [[http://gorefactor.org/][godoctor]]
 - Edit struct field tag with [[https://github.com/fatih/gomodifytags][gomodifytags]]
-- Linting with flycheck's built-in checkers or flycheck-gometalinter
+- Linting with flycheck's built-in checkers or [[https://github.com/golangci/golangci-lint][flycheck-golangci-lint]]
 - Coverage profile visualization
 - Test generation with [[https://github.com/s-kostyaev/go-gen-test][go-gen-test]]
 - Get packages faster with [[https://github.com/haya14busa/gopkgs][gopkgs]]
@@ -56,28 +56,10 @@ to get all the goodies of this layer:
   go get -u github.com/josharian/impl
 #+END_SRC
 
-If you wish to use a linters aggregator tool, you can enable =gometalinter= or =golangci-lint=.
-
-If you wish to use =gometalinter= set the value of =go-linter= to ='gometalinter=:
+If you wish to use =golangci-lint=, set the following layer variable to non-nil:
 
 #+BEGIN_SRC emacs-lisp
-  (go :variables go-linter 'gometalinter)
-#+END_SRC
-
-and install the tool:
-
-#+BEGIN_SRC sh
-  go get -u -v github.com/alecthomas/gometalinter
-  gometalinter --install --update
-#+END_SRC
-
-For more information read [[https://github.com/alecthomas/gometalinter/blob/master/README.md][gometalinter README.md]]
-and [[https://github.com/favadi/flycheck-gometalinter/blob/master/README.md][flycheck-gometalinter README.md]]
-
-If you wish to use =golangci-lint= set the value of =go-linter= to ='golangci-lint=:
-
-#+BEGIN_SRC emacs-lisp
-  (go :variables go-linter 'golangci-lint)
+  (go :variables go-use-golangci-lint t)
 #+END_SRC
 
 and install the tool:
@@ -86,8 +68,7 @@ and install the tool:
   go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 #+END_SRC
 
-For more information read [[https://github.com/golangci/golangci-lint][golangci-lint README.md]]
-and [[https://github.com/weijiangan/flycheck-golangci-lint][flycheck-golangci-lint README.md]]
+Check [[https://github.com/golangci/golangci-lint][golangci-lint]] and [[https://github.com/weijiangan/flycheck-golangci-lint][flycheck-golangci-lint]] for more details.
 
 If you wish to use =godoctor= for refactoring, install it too:
 

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -28,9 +28,8 @@
 (defvar go-tab-width 8
   "Set the `tab-width' in Go mode. Default is 8.")
 
-(defvar go-linter nil
-  "The linter to use for go code. Possible values are:
-`gometalinter' and `golangci-lint'.")
+(defvar go-use-golangci-lint nil
+  "Use `golangci-lint' if the variable has non-nil value.")
 
 (defvar go-test-buffer-name "*go test*"
   "Name of the buffer for go test output. Default is *go test*.")

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -40,7 +40,7 @@
       (progn
         ;; without setting lsp-prefer-flymake to :none
         ;; golangci-lint errors won't be reported
-        (when (eq go-linter 'golangci-lint)
+        (when go-use-golangci-lint
           (message "[go] Setting lsp-prefer-flymake :none to enable golangci-lint support.")
           (setq-local lsp-prefer-flymake :none))
         (lsp))
@@ -58,20 +58,15 @@
         (company-mode))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
-(defun spacemacs//go-enable-flycheck-extra ()
-  "Enable enhanced linter and disable overlapping `flycheck' linters."
-  (when go-linter
-    (setq flycheck-disabled-checkers '(go-gofmt
-                                       go-golint
-                                       go-vet
-                                       go-build
-                                       go-test
-                                       go-errcheck))
-    (pcase go-linter
-      ('gometalinter  (flycheck-gometalinter-setup)
-                      (message "go-linter: using gometalinter"))
-      ('golangci-lint (flycheck-golangci-lint-setup)
-                      (message "go-linter: using golangci-lint")))))
+(defun spacemacs//go-enable-flycheck-golangci-lint ()
+  "Enable `flycheck-golangci-linter' and disable overlapping `flycheck' linters."
+  (setq flycheck-disabled-checkers '(go-gofmt
+                                     go-golint
+                                     go-vet
+                                     go-build
+                                     go-test
+                                     go-errcheck))
+  (flycheck-golangci-lint-setup))
 
 (defun spacemacs/go-run-tests (args)
   (interactive)

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -15,10 +15,7 @@
         (company-go :requires company)
         counsel-gtags
         flycheck
-        (flycheck-gometalinter :toggle (and (eq go-linter 'gometalinter)
-                                            (configuration-layer/package-used-p
-                                             'flycheck)))
-        (flycheck-golangci-lint :toggle (and (eq go-linter 'golangci-lint)
+        (flycheck-golangci-lint :toggle (and go-use-golangci-lint
                                              (configuration-layer/package-used-p
                                               'flycheck)))
         ggtags
@@ -51,15 +48,10 @@
 (defun go/post-init-flycheck ()
   (spacemacs/enable-flycheck 'go-mode))
 
-(defun go/init-flycheck-gometalinter ()
-  (use-package flycheck-gometalinter
-    :defer t
-    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-flycheck-extra t)))
-
 (defun go/init-flycheck-golangci-lint ()
   (use-package flycheck-golangci-lint
     :defer t
-    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-flycheck-extra t)))
+    :init (add-hook 'go-mode-hook 'spacemacs//go-enable-flycheck-golangci-lint t)))
 
 (defun go/post-init-ggtags ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1706,7 +1706,7 @@ Features:
 - Source analysis using [[https://docs.google.com/document/d/1_Y9xCEMj5S-7rv2ooHpZNH15JgRT5iM742gJkw5LtmQ][go-guru]]
 - Refactoring with [[http://gorefactor.org/][godoctor]]
 - Edit struct field tag with [[https://github.com/fatih/gomodifytags][gomodifytags]]
-- Linting with flycheck's built-in checkers or flycheck-gometalinter
+- Linting with flycheck's built-in checkers or flycheck-golangci-lint
 - Coverage profile visualization
 - Test generation with [[https://github.com/s-kostyaev/go-gen-test][go-gen-test]]
 - Get packages faster with [[https://github.com/haya14busa/gopkgs][gopkgs]]


### PR DESCRIPTION
Good 'ole `gometalinter` [was deprecated](https://github.com/alecthomas/gometalinter/commit/4698afe5ab5592d5fa82031cf08f4f5df64a1746) on 2019-02-28, [in favor](https://github.com/alecthomas/gometalinter/commit/32416ab75314da538e4a51cdf3c6189b66fe3de4) of the more advanced [golangci-lint](https://github.com/golangci/golangci-lint).

I've dropped support for `gometalinter` and simplified the logic to assume only that `golangci-lint` is selectable.

This removes clutter and, hopefully, simplifies the setup instructions.