### PR TITLE
[ansible] Fix filename regexp, escape period

### DIFF
--- a/layers/+tools/ansible/config.el
+++ b/layers/+tools/ansible/config.el
@@ -19,4 +19,4 @@ If non-nil then encrypted files are automatically decrypted when opened and
 ;; detect filenames compatible with Ansible's recommended layout.
 ;; http://docs.ansible.com/playbooks_best_practices.html#directory-layout
 (setq spacemacs--ansible-filename-re
-      ".*\\(\\(main\\|site\\|encrypted\\|roles/.+\\)\.yml\\|group_vars/.+\\|host_vars/.+\\)")
+      ".*\\(\\(main\\|site\\|encrypted\\|roles/.+\\)\\.yml\\|group_vars/.+\\|host_vars/.+\\)")


### PR DESCRIPTION
The `\` backslash before `.yml` in the regex has an orange (warning)
color and describe-char says:
There are text properties here:
  face                 (font-lock-warning-face font-lock-string-face)
  fontified            nil
  help-echo            "This \\ has no effect"

Thanks smile13241324 for pointing out that double backslash escapes
a . (period).