### PR TITLE
Use `cl-loop` instead of `loop`

### DIFF
--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -37,7 +37,7 @@ than this amount.")
   "Default ivy actions for files.")
 
 (defvar spacemacs--ivy-grep-actions
-  (loop for j in spacemacs--ivy-file-actions
+  (cl-loop for j in spacemacs--ivy-file-actions
         for key = (nth 0 j)
         for func = (nth 1 j)
         for desc = (nth 2 j)


### PR DESCRIPTION
I have no clue what started it, probably an `apt update` (running Emacs 25.2+1-6 as supplied by Ubuntu 18.04) but suddenly I got an initialization-time error about the `loop` invocation here. Some digging around showed that `cl-loop` seems to be the more correct way and indeed, it fixed the error. Seems cleaner than `(require :cl)`

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3