### PR TITLE
Fix hybrid-mode error when dumping (fixes #11923)

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/hybrid-mode/hybrid-mode.el
@@ -31,7 +31,7 @@
 
 (require 'evil)
 
-
+;;;###autoload
 (defcustom hybrid-style-default-state
   (spacemacs|dotspacemacs-backward-compatibility
    hybrid-mode-default-state normal)
@@ -39,6 +39,7 @@
   :group 'spacemacs
   :type 'symbol)
 
+;;;###autoload
 (defcustom hybrid-style-enable-hjkl-bindings
   (spacemacs|dotspacemacs-backward-compatibility
    hybrid-mode-enable-hjkl-bindings nil)
@@ -46,6 +47,7 @@
   :group 'spacemacs
   :type 'boolean)
 
+;;;###autoload
 (defcustom hybrid-style-enable-evilified-state
   (spacemacs|dotspacemacs-backward-compatibility
    hybrid-mode-enable-evilified-state t)
@@ -53,6 +55,7 @@
   :group 'spacemacs
   :type 'boolean)
 
+;;;###autoload
 (defcustom hybrid-style-use-evil-search-module
   (spacemacs|dotspacemacs-backward-compatibility
    hybrid-mode-use-evil-search-module nil)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -27,7 +27,7 @@
         (evil-evilified-state :location local :step pre :protected t)
         (pcre2el :step pre)
         (holy-mode :location local :step pre)
-        (hybrid-mode :location local :step pre)
+        (hybrid-mode :location (recipe :fetcher local) :step pre)
         (spacemacs-theme :location built-in)
         ))
 


### PR DESCRIPTION
Hybrid mode is a local package in the `spacemacs-bootstrap` layer. Pdumping process exits with error because some other layers (e.g. `auto-completion`) refer to the `hybrid-style-enable-hjkl-bindings`  variable, which is not properly autoloaded. 

In this PR I add autoload cookies to all (just in case) hybrid mode custom settings and adjust its definition to be build by Quelpa.

fixes #11923