### PR TITLE
[ivy] Fix definitions of extra actions R and D for recentf

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -329,11 +329,11 @@
            '(("R" (lambda (arg)
                     (interactive)
                     (recentf-cleanup)
-                    (ivy-recentf)) "refresh list")
+                    (counsel-recentf)) "refresh list")
              ("D" (lambda (arg)
                     (interactive)
                     (setq recentf-list (delete arg recentf-list))
-                    (ivy-recentf)) "delete from list"))))
+                    (counsel-recentf)) "delete from list"))))
   ;; merge recentf and bookmarks into buffer switching. If we set this
   (setq ivy-use-virtual-buffers t))
 


### PR DESCRIPTION
`ivy-recentf` was renamed into `counsel-recentf` upstream.