### PR TITLE
[c-c++] Added clangd support. Separated lsp server selection from backend.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -122,6 +122,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 ***** C-C++
 - CMake support has been extracted from the =c-c++= layer into the new =cmake=
   layer.
+- LSP code navigation / completion added via clangd, ccls or cquery (thanks to Cormac Cannon)
 ***** ESS
 - ESS key bindings were re-organised in the following list
   (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):
@@ -1145,8 +1146,8 @@ Other:
     - Added variable: =++-enable-organize-includes-on-save=
     - Added key binding: ~SPC m r i~ organize includes
 - Improvements:
-  - Added =lsp= support using either =cquery= or =ccls= backends
-    (thanks to Cormac Cannon, Sergey Litovchuk and Fangrui Song)
+  - Added =lsp= support using either =clangd=, =ccls= or =cquery= backends
+    (thanks to Cormac Cannon, Sergey Litovchuk, Fangrui Song and David Vo)
   - Fixed =lsp= support for =ccls= server (thanks to Alexander Dalshov)
   - Added automatic formatting on save using ClangFormat with the variables
     =c-c++-enable-clang-format-on-save= and =c-c++-enable-clang-support=

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -14,13 +14,15 @@
     - [[#rtags][RTags]]
       - [[#external-dependencies][External dependencies]]
       - [[#configuration][Configuration]]
-    - [[#cquery--ccls-lsp-backends][cquery / ccls (lsp backends)]]
-      - [[#features-1][Features:]]
+    - [[#lsp][LSP]]
+      - [[#features-1][Features]]
       - [[#external-dependencies-1][External dependencies]]
-        - [[#cquery-server][cquery server]]
+        - [[#clangd][clangd]]
         - [[#ccls-server][ccls server]]
+        - [[#cquery-server][cquery server]]
       - [[#configuration-1][Configuration]]
         - [[#basic][Basic]]
+        - [[#selecting-an-alternate-lsp-server][Selecting an alternate LSP server]]
         - [[#setting-path-to-backend-executable][Setting path to backend executable]]
         - [[#semantic-highlighting][Semantic highlighting]]
         - [[#additional-configuration-options][Additional configuration options]]
@@ -37,6 +39,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#formatting-clang-format][Formatting (clang-format)]]
   - [[#rtags-1][RTags]]
+  - [[#lsp-1][LSP]]
   - [[#cquery--ccls][cquery / ccls]]
     - [[#backend-language-server][backend (language server)]]
     - [[#goto][goto]]
@@ -88,8 +91,9 @@ variable at the root of your project. More info on directory local variables
 can be found in the [[http://www.gnu.org/software/emacs/manual/html_node/elisp/Directory-Local-Variables.html][dir-locals]].
 
 ** Backends
-This layer supports the selection of one of 3 available backends for code
-navigation etc via the =c-c++-backend= configuration variable.
+This layer supports the selection of RTags, or one of three available implementations
+of the [[https://github.com/Microsoft/language-server-protocol][Language Server Protocol]]
+for code navigation etc. via the =c-c++-backend= configuration variable.
 
 *** RTags
 RTags is a well established clang-based source code indexing tool.
@@ -119,39 +123,55 @@ set the variable =c-c++-rtags-completion= to =nil=:
                          c-c++-enable-rtags-completion nil)))
 #+END_SRC
 
-*** cquery / ccls (lsp backends)
-[[https://github.com/cquery-project/cquery][cquery]] and [[https://github.com/MaskRay/ccls][ccls]] are alternative implementations of the language server protocol
-based on libclang. They claim to be more efficient than existing tools at
-indexing large code bases.
+*** LSP
+LSP support is provided via the [[file:../../+tools/lsp/README.org][LSP layer]], using one of three available backends (all based on libclang).
+- [[https://clang.llvm.org/extra/clangd/][clangd]]
+- [[https://github.com/cquery-project/cquery][cquery]]
+- [[https://github.com/MaskRay/ccls][ccls]]
+They claim to be more efficient than existing tools at indexing large code bases.
 
-**** Features:
+**** Features
 - Cross references (definitions, references, base/derived classes/methods, type instances, ...)
 - Diagnostics
 - Completion with =company-lsp=
-- Semantic highlighting
+- Semantic highlighting (=cquery=, =ccls=)
 - See more on [[https://github.com/cquery-project/cquery/wiki/Emacs]]
 - Cross-platform - functional on Windows, Linux and OSX.
 
 **** External dependencies
-Install one (or both) of the following:
+Install one (or more) of the following (=clangd= is used by default) :
 
-***** cquery server
-Install the =cquery= server. [[https://github.com/cquery-project/cquery/wiki/Getting-started][Instructions]].
+***** clangd
+Install =clang= using a binary distribution downloaded from the [[http://releases.llvm.org/download.html][LLVM releases page]] or via your package manager.
+This is the default implementation used by the emacs =lsp-mode= package and probably the easiest to install.
+- [[https://clang.llvm.org/extra/clangd/Extensions.html][clangd protocol extensions page]]
 
 ***** ccls server
 Install the =ccls= server. [[https://github.com/MaskRay/ccls/wiki/Getting-started][Instructions]].
+This is currently the most fully featured implementation, including semantic highlighting and some navigation/
+introspection features not provided by clangd.
+
+***** cquery server
+Install the =cquery= server. [[https://github.com/cquery-project/cquery/wiki/Getting-started][Instructions]].
+This implementation appears to be unmaintained, and continued support is provided here purely for existing users.
 
 **** Configuration
 ***** Basic
-Select either =cquery= or =ccls= as the =c-c++= layer backend by adding the
+To use the default =clangd= language server, simply select =lsp= as the =c-c++= layer backend by adding the
 following to your dotfile:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-                '((c-c++ :variables c-c++-backend 'lsp-cquery))) ;or 'lsp-ccls
+                '((c-c++ :variables c-c++-backend 'lsp)))
 #+END_SRC
 
-N.B. The [[file:../../+tools/lsp/README.org][LSP layer]] will be loaded automatically if either backend is selected.
+N.B. The [[file:../../+tools/lsp/README.org][LSP layer]] will be loaded automatically.
+
+***** Selecting an alternate LSP server
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((c-c++ :variables c-c++-backend 'lsp c-c++-lsp-server 'ccls))) ; or 'cquery or 'clangd
+#+END_SRC
 
 ***** Setting path to backend executable
 The basic configuration above should work if the cquery/ccls executable folder
@@ -160,8 +180,9 @@ is present in your path. If not, you can set the path explicitly.
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
                 '((c-c++ :variables
-                         c-c++-backend 'lsp-cquery
-                         c-c++-lsp-executable "/path/to/bin/cquery/or/ccls")))
+                         c-c++-backend 'lsp
+                         c-c++-server 'ccls
+                         c-c++-lsp-executable "/path/to/bin/ccls/clangd/or/cquery")))
 #+END_SRC
 
 If you need to expand =~= in the path, you can use =file-truename= like
@@ -169,34 +190,36 @@ If you need to expand =~= in the path, you can use =file-truename= like
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
                 '((c-c++ :variables
-                         c-c++-backend 'lsp-cquery
-                         c-c++-lsp-executable (file-truename "~/bin/cquery/or/ccls"))))
+                         c-c++-backend 'lsp
+                         c-c++-server 'ccls
+                         c-c++-lsp-executable (file-truename "~/bin/clangd/ccls/or/cquery"))))
 #+END_SRC
 
-***** Semantic highlighting
+***** Semantic highlighting :ccls:cquery:
 Semantic highlighting is disabled by default. To enable, set the
 =c-c++-lsp-sem-highlight-method= variable to either ='font-lock= or ='overlay=.
 To enable the rainbow semantic highlighting colour theme, set
 =c-c++-lsp-sem-highlight-rainbow= to =t=.
 
-***** Additional configuration options
-Both lsp backends are configured to store their index cache in a subdirectory of
-=.emacs.d/cache=. This can be overridden by specifying an explicit
+***** Additional configuration options :ccls:cquery:
+Both lsp backends are configured to store their index cache in a subdirectory of 
+=.emacs.d/cache=. This can be overridden by specifying an explicit 
 =c-c++-lsp-cache-dir=. Setting this value to a relative path will cause the
 index cache to be placed in a subdirectory of your project root.
 
 There are other initialization options such as the number of indexer threads,
-cache serialization format. They have good default values. See =config.el= of
+cache serialization format. They have good default values. See =config.el= of 
 the layer and the backends' respective homepages for more info.
-- [[https://github.com/cquery-project/cquery/wiki/Emacs][Emacs section of =cquery= wiki]]
 - [[https://github.com/MaskRay/ccls/wiki/Emacs][Emacs section of =ccls= wiki]]
+- [[https://github.com/cquery-project/cquery/wiki/Emacs][Emacs section of =cquery= wiki]]
 
 ***** Example dotspacemacs-configuration-layers entry
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
                 '((c-c++ :variables
                          c-c++-adopt-subprojects t
-                         c-c++-backend 'lsp-ccls
+                         c-c++-backend 'lsp
+                         c-c++-server 'ccls
                          c-c++-lsp-executable (file-truename "~/dev/cpp/ccls/Release/ccls")
                          c-c++-lsp-sem-highlight-rainbow t)))
 #+END_SRC
@@ -358,8 +381,11 @@ generally applicable.
 | ~SPC m g X~ | fix fixit at point              |
 | ~SPC m g Y~ | cycle overlays on screen        |
 
+** LSP
+The default key bindings for LSP implementations are defined by/documented in the [[file:../../+tools/lsp/README.org][LSP layer]].
+
 ** cquery / ccls
-The key bindings listed below are in addition to the default key bindings defined by the [[file:../../+tools/lsp/README.org][LSP layer]].
+The key bindings listed below are in addition to
 A ~[ccls]~ or ~[cquery]~ suffix indicates that the binding is for the indicated backend only.
 
 *** backend (language server)

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -20,9 +20,14 @@
 (defconst c-c++-mode-hooks '(c-mode-hook c++-mode-hook)
   "Primary hooks of the `c-c++' layer.")
 
+(defconst c-c++-lsp-servers '(clangd ccls cquery)
+  "Language Server Protocol (LSP) backends supported by the `c-c++' layer.")
+
 (defvar c-c++-backend nil
-  "If `lsp-cquery' or `lsp-ccls' then selects language server protocol backend (cquery or ccls).
-  If `rtags' then enables rtags support")
+  "May be `nil', `rtags' or `lsp'.")
+
+(defvar c-c++-lsp-server 'clangd
+  "May be any member of `c-c++-lsp-servers'")
 
 (defconst c-c++-lsp-backends '(lsp-cquery lsp-ccls)
   "Language Server Protocol (LSP) backends supported by the `c-c++' layer.")
@@ -57,7 +62,7 @@
 (defvar c-c++-adopt-subprojects nil
   "When non-nil, projectile will remember project root when visiting files in subprojects")
 
-;; c-c++-lsp-backend variables
+;; c-c++-lsp-server variables
 (defvar c-c++-lsp-cache-dir nil
   "Cache directory. Absolute and relative paths supported.")
 

--- a/layers/+lang/c-c++/layers.el
+++ b/layers/+lang/c-c++/layers.el
@@ -10,5 +10,5 @@
 ;;; License: GPLv3
 
 (when (and (boundp 'c-c++-backend)
-           (member c-c++-backend '(lsp-cquery lsp-ccls)))
+           (eq c-c++-backend 'lsp))
   (configuration-layer/declare-layer-dependencies '(lsp dap)))


### PR DESCRIPTION
Replaces: #12443
Closes: #12351 

Added support for `clangd` (to the existing `ccls` and `cquery`) as lsp backends to the c-c++ layer.
Updated the backend selection mechanism -- now aligned with the approach used in the python layer, suggested by @sdwolfz during an earlier PR review.

Specifically:
The existing mechanism is to set the `'c-c++-backend` layer variable to one of `nil`, `'rtags`, `'lsp-ccls` or `'lsp-cquery`.
The new/proposed mechanism is to set `'c-c++-backend` to one of `nil`, `'rtags` or `'lsp` and (optionally) set the `'c-c++-lsp-server` layer variable to one of `'clangd`, `'ccls` or `'cquery`. If unspecified, the server selection defaults to `'clangd`.

Re. default backend selection, I personally prefer/use `'ccls`, but opted to leave `'clangd` as the default, as it's the default supported by the upstream `lsp-mode` package and (arguably) easier to install. Use of `'cquery` is no longer recommended, as the project seems to have been abandoned, however support has been left in place for existing users with a functional installation.

Also opportunistically tidied up a few bits of configuration, including eliminating some company-related config that's now done automagically upstream by the `lsp-mode` package.

Thanks to @kvaneesh for some early feedback, and @auscompgeek for accomodating this PR. And @yyoncho and @maskray for all their work on `lsp-mode` and `ccls` respectively.

N.B. there's a clangd-specific find-other-file extension to the LSP which I haven't bound, as...
a) I haven't got it to work (clearly not reading the spec / calling it correctly).
b) I'm perfectly happy with projectile-find-other-file, and using ccls rather than clangd anyway
If anyone else is interested in taking a look while reviewing this PR, it's wrapped in interactive defuns: `c-c++/find-clangd-other-file` and `c-c++/peek-clangd-other-file`. If you do get it to work, it could be bound under `,go`, `,Go` OR replace the existing `,ga` keybinding.
