### PR TITLE
eval (require 'helm-config) after activating helm to define helm keymap

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -251,6 +251,11 @@
         (kbd "gr") 'helm-ag--update-save-results
         (kbd "q") 'quit-window))))
 
+(defun helm/pre-init-helm ()
+  ;; This is to define helm keymap which is needed by easy-menu-add-item called
+  ;; within helm-org-autoloads.el while activating helm-org.
+  (require 'helm-config))
+
 (defun helm/init-helm-descbinds ()
   (use-package helm-descbinds
     :defer (spacemacs/defer)


### PR DESCRIPTION
This is to assure that helm keymap is defined to prevent errors while activating helm-org.

Without this change following error can be seen while emacs starts up:

```
Debugger entered--Lisp error: (wrong-type-argument keymapp nil)
  define-key(nil [menu-bar Tools Helm] ("Helm" keymap "Helm"))
  easy-menu-get-map(nil ("Tools" "Helm") nil)
```

This is because helm keymap is not defined when helm is activated.
When helm-org is then activated, then it calls easy-menuj-get-map which fails
due to helm keymap not being defined.