### PR TITLE
Add the transient/ directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ eclipse.jdt.ls
 .trello
 .extension
 mspyls/
+transient/
 
 # Private directory
 private/


### PR DESCRIPTION
While packages are being updated, a directory 'transient' is created, and used as a temp working directory. If those exist, the 'Update Spacemacs' process fails, because `.emacs.d` has local modifications. Adding this directory and it's contents to `.gitignore` fixes that.