### PR TITLE
[core] Allow text-files to be referenced as startup banner.

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -179,6 +179,14 @@ Cate special text banner can de reachable via `998', `cat' or `random*'.
              (spacemacs-buffer/warning (format "could not find banner %s"
                                                dotspacemacs-startup-banner))
              (spacemacs-buffer//get-banner-path 1)))
+          ((and dotspacemacs-startup-banner
+                (string= "txt" (intern (file-name-extension
+                                        dotspacemacs-startup-banner))))
+           (if (file-exists-p dotspacemacs-startup-banner)
+               dotspacemacs-startup-banner
+               (spacemacs-buffer/warning (format "could not find banner %s"
+                                                 dotspacemacs-startup-banner))
+             (spacemacs-buffer//get-banner-path 1)))
           (t (spacemacs-buffer//get-banner-path 1)))))
 
 (defvar spacemacs-buffer--random-banner nil


### PR DESCRIPTION
I added a new cond-step to allow a user to reference custom text-banners as startup-banner.

Before it was only possible to reference a custom image file for example:
 `(setq dotspacemacs-startup-banner "~/my-banners/custom.png")`)

With this patch it is possible to reference text files ending on .txt:
`(setq dotspacemacs-startup-banner "~/my-banners/custom.txt")`

I had a look at the `tests` folder, but couldn't find any tests related to loading a banner. If I have overlooked anything, please let me know!