### PR TITLE
Fixed go-run-test-current-function for go test and gocheck

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1603,6 +1603,8 @@ Other:
 - Added Testify support (thanks to Mathieu Post)
 - Added setup instructions for =gopls= (thanks to pancho horrillo)
 - Dropped support for deprecated =gometalinter= (thanks to pancho horrillo)
+- Fixed =go-run-test-current-function= for vanilla tests and gocheck suite tests
+  (thanks to Mathieu Post)
 **** Graphviz
 - Use graphviz package from melpa (thanks to Matthew Boston)
 **** Groovy

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -88,8 +88,8 @@
         (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?\\([[:alnum:]]+\\))[ ]+\\)?\\(Test[[:alnum:]_]+\\)(.*)")
         (spacemacs/go-run-tests
          (cond (go-use-testify-for-testing (concat "-run='Test" (match-string-no-properties 2) "' -testify.m='" (match-string-no-properties 3) "'"))
-               (go-use-gocheck-for-testing (concat "-check.f='" (match-string-no-properties 2) "$'"))
-               (t (concat "-run='" (match-string-no-properties 2) "$'")))))
+               (go-use-gocheck-for-testing (concat "-check.f='" (match-string-no-properties 3) "$'"))
+               (t (concat "-run='" (match-string-no-properties 3) "$'")))))
     (message "Must be in a _test.go file to run go-run-test-current-function")))
 
 (defun spacemacs/go-run-test-current-suite ()


### PR DESCRIPTION
Used the wrong matched string in `go-run-test-current-function` for testing with `go test` and `gocheck`.

Fixes https://github.com/syl20bnr/spacemacs/commit/272c96d855bbf4fe90ca896ef15fa25a4dda4d0a#commitcomment-34992834