### PR TITLE
Improve regexp for detecting Ansible files

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1,6 +1,6 @@
 #+COMMENT -*- mode: org -*-
 
-This file containes the change log for the next major version of Spacemacs.
+This file contains the change log for the next major version of Spacemacs.
 
 Use the following template structure and fill it in with your changes.
 When a release will be drafted, the notes will be copied at the top of
@@ -1095,6 +1095,8 @@ Other:
   - Added support for multiple vault password files, see the layer =README.org=
     (thanks to Sylvain Benner)
   - Simplified filename matching re (thanks to Anatoli Babenia)
+  - Added additional YAML paths and refactored =spacemacs--ansible-filename-re=
+    (thanks to Brett Campbell)
 - Fixes:
   - Fixed ansible-doc-mode error on ~SPC h d k~
     (thanks to Codruț Constantin Gușoi)

--- a/layers/+tools/ansible/config.el
+++ b/layers/+tools/ansible/config.el
@@ -19,4 +19,4 @@ If non-nil then encrypted files are automatically decrypted when opened and
 ;; detect filenames compatible with Ansible's recommended layout.
 ;; http://docs.ansible.com/playbooks_best_practices.html#directory-layout
 (setq spacemacs--ansible-filename-re
-      ".*\\(\\(main\\|site\\|encrypted\\|roles/.+\\)\\.yml\\|group_vars/.+\\|host_vars/.+\\)")
+      "/\\(main\\|site\\|encrypted\\|\\(\\(roles\\|tasks\\|handlers\\|vars\\|defaults\\|meta\\|group_vars\\|host_vars\\)/.+\\)\\)\\.ya?ml$")


### PR DESCRIPTION
Additional path names are now detected (_e.g._, `./tasks/.+\.yml`, `./handlers/.+\.yml`, _etc_). 

Before describing technical details of the regexp change: I wonder if we should use `(rx)` to describe the pattern, or at least use `(concat)` or similar to break it across multiple lines... I am new to using Emacs full-time--thank you for making my experience so amazing--but I am also a 20-year unix veteran, so I have opinions about maintainability! 😉 

The patterns have been anchored more tightly, meaning they are more accurate, so they will match _less_ slop (this may affect certain edge cases where people unknowingly depended on false-positives, _e.g._,`parasite.yml`).

Technical details about regexp changes:
* Remove unnecessary `.*` at beginning
* Anchor file names with leading `/` to prevent partial matches
    * (_e.g._, don't match `not-main.yml`)
* Restructure capture groups so that `\\.yml` extension is at very end
* Support `.yaml` extensions as well
* Anchor the end with `$`

