### PR TITLE
Add a variable to disable elfeed-goodies

### DIFF
--- a/layers/+readers/elfeed/config.el
+++ b/layers/+readers/elfeed/config.el
@@ -13,3 +13,5 @@
 
 (defvar elfeed-enable-web-interface nil
   "If non nil start a web server to consult the database in a web browser.")
+(defvar elfeed-enable-goodies nil
+  "If non nil enable elfeed-goodies (split-pane...).")

--- a/layers/+readers/elfeed/packages.el
+++ b/layers/+readers/elfeed/packages.el
@@ -46,15 +46,17 @@
         "y"  'elfeed-search-yank))))
 
 (defun elfeed/pre-init-elfeed-goodies ()
-  (spacemacs|use-package-add-hook elfeed
-    :post-config
-    (progn
-      (elfeed-goodies/setup)
-      (evil-define-key 'evilified elfeed-show-mode-map
-        "o" 'elfeed-goodies/show-ace-link))))
+  (when elfeed-enable-goodies
+    (spacemacs|use-package-add-hook elfeed
+      :post-config
+      (progn
+        (elfeed-goodies/setup)
+        (evil-define-key 'evilified elfeed-show-mode-map
+          "o" 'elfeed-goodies/show-ace-link)))))
 
 (defun elfeed/init-elfeed-goodies ()
-  (use-package elfeed-goodies :commands elfeed-goodies/setup))
+  (when elfeed-enable-goodies
+    (use-package elfeed-goodies :commands elfeed-goodies/setup)))
 
 (defun elfeed/pre-init-elfeed-org ()
   (when (boundp 'rmh-elfeed-org-files)


### PR DESCRIPTION
By default, the elfeed layer enables elfeed-goodies.

This commit adds a variable that controls this behavior, so that people can easily disable elfeed-goodies if they don't like it.