### PR TITLE
[clojure] add c-k c-j bindings company dropdown menu in repl

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -207,3 +207,17 @@ in your Spacemacs configuration:
                  cider-repl-mode
                  cider-clojure-interaction-mode))
      ,@body))
+
+(defun spacemacs//clj-repl-wrap-c-j ()
+  "Dynamically dispatch c-j to company or repl functions."
+  (interactive)
+  (if (company-tooltip-visible-p)
+      (company-select-next)
+    (cider-repl-next-input)))
+
+(defun spacemacs//clj-repl-wrap-c-k ()
+  "Dynamically dispatch c-k to company or repl functions."
+  (interactive)
+  (if (company-tooltip-visible-p)
+      (company-select-previous)
+    (cider-repl-previous-input)))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -227,9 +227,13 @@
         (kbd "C-k") 'cider-repl-previous-input
         (kbd "RET") 'cider-repl-return)
 
-      (evil-define-key 'insert cider-repl-mode-map
-        (kbd "C-j") 'cider-repl-next-input
-        (kbd "C-k") 'cider-repl-previous-input)
+      (if (package-installed-p 'company)
+          (evil-define-key 'insert cider-repl-mode-map
+            (kbd "C-j") 'spacemacs//clj-repl-wrap-c-j
+            (kbd "C-k") 'spacemacs//clj-repl-wrap-c-k)
+        (evil-define-key 'insert cider-repl-mode-map
+          (kbd "C-j") 'cider-repl-next-input
+          (kbd "C-k") 'cider-repl-previous-input))
 
       (when clojure-enable-fancify-symbols
         (clojure/fancify-symbols 'cider-repl-mode)


### PR DESCRIPTION
Make `c-j` and `c-k` bind to down and up in company dropdown menu when it shows up in clojure repl.

Currently users must use tab key to select a completion in company dropdown menu in the clojure repl (`, s s`).