### PR TITLE
Fix C-k ivy-previous-line in ivy-switch-buffer

### DIFF
--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -81,11 +81,12 @@ Some useful key bindings are presented in the following table.
 | ~RET~       | call default action on current candidate                                                             |
 | ~M-RET~     | the same as ~RET~ but doesn't close completion minibuffer                                            |
 | ~C-M-j~     | use current input immediately (this can be used to create a new file in Find File)                   |
-| ~tab~       | complete partially                                                                                   |
+| ~TAB~       | complete partially                                                                                   |
 | ~M-o~       | show the list of valid actions on current candidate (then press any of described keys to execute it) |
 | ~C-M-o~     | the same as ~M-o~ but doesn't close completion minibuffer                                            |
 | ~C-'~       | use avy to quickly select completion on current page (sometimes faster than using arrows)            |
 | ~<ESC>~     | close minibuffer                                                                                     |
+| ~C-M-k~     | kill buffer (in =ivy-switch-buffer= (~SPC b b~))                                                     |
 
 ** Transient state
 Press ~M-SPC~ anytime in Ivy to get into the transient state.

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -193,7 +193,9 @@
         "a'" 'spacemacs/ivy-available-repls
         "fr" 'counsel-recentf
         "rl" 'ivy-resume
-        "bb" 'ivy-switch-buffer))
+        "bb" 'ivy-switch-buffer)
+      ;; Moved C-k to C-M-k
+      (define-key ivy-switch-buffer-map (kbd "C-M-k") 'ivy-switch-buffer-kill))
 
     :config
     (progn

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -195,8 +195,10 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
    ((or (eq 'vim style)
         (and (eq 'hybrid style)
              hybrid-style-enable-hjkl-bindings))
-    (define-key ivy-minibuffer-map (kbd "C-j") 'ivy-next-line)
-    (define-key ivy-minibuffer-map (kbd "C-k") 'ivy-previous-line)
+    (dolist (map (list ivy-minibuffer-map
+                       ivy-switch-buffer-map))
+      (define-key map (kbd "C-j") 'ivy-next-line)
+      (define-key map (kbd "C-k") 'ivy-previous-line))
     (define-key ivy-minibuffer-map (kbd "C-h") (kbd "DEL"))
     ;; Move C-h to C-S-h
     (define-key ivy-minibuffer-map (kbd "C-S-h") help-map)

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -188,7 +188,8 @@ Current Action: %s(ivy-action-name)
       'spacemacs/ivy-transient-state/body)
     (define-key ivy-minibuffer-map (kbd "s-M-SPC")
       'spacemacs/ivy-transient-state/body)
-    ))
+    (define-key ivy-minibuffer-map (kbd "s-M-SPC")
+      'spacemacs/ivy-transient-state/body)))
 
 (defun spacemacs-completion/init-flx-ido ()
   (use-package flx-ido


### PR DESCRIPTION
It applies to the editing styles:
- hybrid with the variable hybrid-style-enable-hjkl-bindings set to t
- vim

Moved the default key binding for ivy-switch-buffer-kill:
From: C-k
To:   C-M-k

Thanks for the suggestion: asok

---
Fixes: #12531