### PR TITLE
[python] Don't start the lsp server until after mspyls is optionally required

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -62,9 +62,9 @@
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        (lsp)
         (when (eq python-lsp-server 'mspyls)
-          (require 'lsp-python-ms)))
+          (require 'lsp-python-ms))
+        (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile."))
   (if (configuration-layer/layer-used-p 'dap)
     (progn


### PR DESCRIPTION
This addresses [this issue](https://github.com/syl20bnr/spacemacs/issues/12742#issue-495302554) that I ran into. It is a simple change to the python layer to make sure that the correct language server is set up before starting lsp.