### PR TITLE
[treemacs] Turn off treemacs' minor modes when they are configured to be disabled.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2684,6 +2684,8 @@ Other:
   (thanks to duianto)
 - Handle ~SPC p t~ when =projectile-project-root= is nil (thanks to Trapez
   Breen)
+- Made sure treemacs' minor modes will be disabled when they are configured
+  to be off.
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -63,12 +63,17 @@
     :config
     (progn
       (spacemacs/define-evil-state-face "treemacs" "MediumPurple1")
-      (when treemacs-use-follow-mode
-        (treemacs-follow-mode t))
-      (when treemacs-use-filewatch-mode
-        (treemacs-filewatch-mode t))
-      (when (memq treemacs-use-git-mode '(simple extended deferred))
-        (treemacs-git-mode treemacs-use-git-mode))
+      ;; minor modes are enabled by default, so they must be explicitly
+      ;; turned off
+      (if treemacs-use-follow-mode
+          (treemacs-follow-mode t)
+        (treemacs-follow-mode -1))
+      (if treemacs-use-filewatch-mode
+          (treemacs-filewatch-mode t)
+        (treemacs-filewatch-mode -1))
+      (if (memq treemacs-use-git-mode '(simple extended deferred))
+          (treemacs-git-mode treemacs-use-git-mode)
+        (treemacs-git-mode -1))
       (add-to-list 'spacemacs-window-split-ignore-prefixes
                    treemacs--buffer-name-prefix))))
 


### PR DESCRIPTION
Treemacs' minor modes will activate by default, so when their config variables are nil they must be turned off explicitly.