### PR TITLE
[Clojure] fix repl-buffer autoscroll when send forms.

### DIFF
--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -43,7 +43,9 @@
       (goto-char pt-max)
       (insert form)
       (indent-region pt-max (point))
-      (cider-repl-return))))
+      (cider-repl-return)
+      (with-selected-window (get-buffer-window (cider-current-connection))
+               (goto-char (point-max))))))
 
 (defun spacemacs/cider-send-last-sexp-to-repl ()
   "Send last sexp to REPL and evaluate it without changing


### PR DESCRIPTION
When send form/region/buffer to repl without focus - repl buffer is
not scrolling and result is not visible.

Added scrolling to the end of the repl-buffer after eval.