### PR TITLE
Unfold an org line from helm-ag and magit

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1594,6 +1594,8 @@ Other:
 - Fixed magit conflicting with golden-ratio (thanks Eric Zhang)
 - Hide with-editor mode-line indicator: =WE= (thanks to duianto)
 - Fixed magit blame in org buffers (thanks to Compro Prasad)
+- Unfolded org headings to a target line when a .org file is opened from a Magit
+  diff or blame buffer (thanks to duianto and Miciah Masters)
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)
@@ -1749,6 +1751,8 @@ Other:
     (thanks to Codruț Constantin Gușoi)
   - Fixed =spacemacs//helm-open-buffers-in-windows= when opening more files than
     available windows (thanks to Juha Jeronen)
+  - Unfolded org headings to a target line when a .org file is opened from
+    Helm-ag (thanks to duianto and Miciah Masters)
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Added =counsel-css= as an =ivy= alternative to =helm-css-scss=

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -71,3 +71,14 @@
 (defun spacemacs/org-clock-jump-to-current-clock ()
   (interactive)
   (org-clock-jump-to-current-clock))
+
+
+
+(defun spacemacs/org-reveal-advice (&rest _args)
+  "Unfold the org headings for a target line.
+This can be used to advice functions that might open .org files.
+
+For example: To unfold from a magit diff buffer, evaluate the following:
+(advice-add 'magit-diff-visit-file :after #'spacemacs/org-reveal-advice)"
+  (when (derived-mode-p 'org-mode)
+    (org-reveal)))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -430,6 +430,14 @@ Will work on both org-mode and any mode that accepts plain html."
         ("e" org-babel-execute-maybe :exit t)
         ("'" org-edit-special :exit t)))))
 
+(defun org/post-init-org ()
+  ;; unfold the org headings for a target line
+  ;; There's a pending upstream PR:
+  ;; Use helm-goto-char to show match and reveal outlines
+  ;; https://github.com/syohex/emacs-helm-ag/pull/304
+  ;; when/if it's accepted, then this advice can be removed.
+  (advice-add 'helm-ag--find-file-action :after #'spacemacs/org-reveal-advice))
+
 (defun org/init-org-agenda ()
   (use-package org-agenda
     :defer t

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -27,6 +27,7 @@
         magit
         magit-gitflow
         magit-svn
+        org
         (orgit :requires org)
         smeargle
         transient
@@ -251,6 +252,13 @@ Press [_b_] again to blame further in the history, [_q_] to go up or quit."
 (defun git/init-orgit ()
   (use-package orgit
     :defer t))
+
+(defun git/post-init-org ()
+  ;; unfold the org headings for a target line
+  (advice-add 'magit-blame-addition :after #'spacemacs/org-reveal-advice)
+  (advice-add 'magit-diff-visit-file :after #'spacemacs/org-reveal-advice)
+  (advice-add 'magit-diff-visit-worktree-file
+              :after #'spacemacs/org-reveal-advice))
 
 (defun git/init-smeargle ()
   (use-package smeargle


### PR DESCRIPTION
Unfold org headings to a target line when opening a .org file from:
helm-ag, magit diff or blame buffers

---

The advice function and helm-ag advice was initially suggested by: Miciah
https://github.com/syl20bnr/spacemacs/issues/10537#issuecomment-406505520

fixes: #10537

There's an upstream pending PR that fixes the helm-ag issue
Use helm-goto-char to show match and reveal outlines https://github.com/syohex/emacs-helm-ag/pull/304
but the repository was last updated two and a half years ago.

If it's accepted then the helm-ag advice can be removed.

#### Notes
In the github diff it looks like there's three empty lines above the `spacemacs/org-reveal-advice` function, but there's a line feed `^L` character on the middle line.