### PR TITLE
Do not use tabs in inferior python mode

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -370,10 +370,6 @@ Bind formatter to '==' for LSP and '='for all other backends."
 
 ;; REPL
 
-(defun spacemacs//inferior-python-setup-hook ()
-  "Setup REPL for python inferior process buffer."
-  (setq indent-tabs-mode t))
-
 (defun spacemacs/python-shell-send-buffer-switch ()
   "Send buffer content to shell and switch to it in insert mode."
   (interactive)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -460,3 +460,11 @@ Bind formatter to '==' for LSP and '='for all other backends."
 (when (version< emacs-version "25")
   (advice-add 'wisent-python-default-setup :after
               #'spacemacs//python-imenu-create-index-use-semantic-maybe))
+
+(defun spacemacs//bind-python-repl-keys ()
+  "Bind the keys for testing in Python."
+  (spacemacs/declare-prefix-for-mode 'inferior-python-mode "mv" "virtualenv")
+  (spacemacs/set-leader-keys-for-major-mode 'inferior-python-mode
+    "c" 'comint-clear-buffer
+    "r" 'pyvenv-restart-python
+    "vw" 'pyvenv-workon))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -309,6 +309,7 @@
     (progn
       (spacemacs/register-repl 'python
                                'spacemacs/python-start-or-switch-repl "python")
+      (spacemacs//bind-python-repl-keys)
       (spacemacs/add-to-hook 'python-mode-hook
                              '(spacemacs//python-setup-backend
                                spacemacs//python-default))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -309,8 +309,6 @@
     (progn
       (spacemacs/register-repl 'python
                                'spacemacs/python-start-or-switch-repl "python")
-      (add-hook 'inferior-python-mode-hook
-                'spacemacs//inferior-python-setup-hook)
       (spacemacs/add-to-hook 'python-mode-hook
                              '(spacemacs//python-setup-backend
                                spacemacs//python-default))


### PR DESCRIPTION
The problem with using tabs is that if you paste code from anywhere, which is likely to use
spaces which is the PEP standard, and then modify that pasted code, you'll
end up with a mix of tabs and spaces, which the python interpreter throws
an error at.

Also:
Add keybindings for inferior python mode (clearing the repl; restarting the repl; changing virtualenv)