### PR TITLE
Lsp-scala is deprecated in favor of lsp itself

### DIFF
--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -52,7 +52,8 @@
 
 (defun spacemacs//scala-setup-metals ()
   "Setup LSP metals for Scala."
-  (setq-local lsp-prefer-flymake nil))
+  (setq-local lsp-prefer-flymake nil)
+  (add-hook 'scala-mode-hook #'lsp))
 
 (defun spacemacs//scala-disable-flycheck-scala ()
   (push 'scala flycheck-disabled-checkers))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -12,7 +12,7 @@
 (setq scala-packages
       '(
         ensime
-        (lsp-scala :requires lsp-mode)
+        lsp-mode
         ggtags
         counsel-gtags
         helm-gtags
@@ -163,8 +163,7 @@
   ;; Don't use scala checker if ensime mode is active, since it provides
   ;; better error checking.
   (with-eval-after-load 'flycheck
-    (add-hook 'ensime-mode-hook 'spacemacs//scala-disable-flycheck-scala)
-    (add-hook 'lsp-scala-)))
+    (add-hook 'ensime-mode-hook 'spacemacs//scala-disable-flycheck-scala)))
 
 (defun scala/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'scala-mode)
@@ -270,14 +269,9 @@ If it's part of a left arrow (`<-'),replace it with the unicode arrow."
             scala-indent:default-run-on-strategy
             scala-indent:operator-strategy))))
 
-(defun scala/init-lsp-scala ()
-  (use-package lsp-scala
-    :after scala-mode
-    :demand t
-    :if (spacemacs//scala-backend-metals-p)
-    :config
-    (add-hook 'scala-mode-local-vars-hook #'spacemacs//scala-setup-metals)
-    :hook ((scala-mode) . lsp)))
+(defun scala/post-init-lsp-mode ()
+  (when (spacemacs//scala-backend-metals-p)
+    (spacemacs//scala-setup-metals)))
 
 (defun scala/post-init-ggtags ()
   (add-hook 'scala-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
The lsp-scala package is no longer required and has been moved into lsp proper, we should reflect this change.