### PR TITLE
[html] Add .svelte files to web-mode auto-mode-alist :mode handler

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1751,6 +1751,7 @@ Other:
 - Fixed ~TAB~ indenting in =web-mode= (thanks to Christopher Eames)
 - Added =lsp= support for =css-mode=, =less-css-mode=, and =scss-mode=
 - Added support for =prettier= formatter in HTML buffers
+- Added support for .svelte files
 **** Hy
 - Added support for virtual envs (thanks to Danny Freeman)
 - Key bindings:

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -284,6 +284,7 @@
      ("\\.hbs\\'"        . web-mode)
      ("\\.eco\\'"        . web-mode)
      ("\\.ejs\\'"        . web-mode)
+     ("\\.svelte\\'"     . web-mode)
      ("\\.djhtml\\'"     . web-mode))))
 
 (defun html/post-init-yasnippet ()


### PR DESCRIPTION
One-line commit that adds the ability to edit .svelte files to html mode.