### PR TITLE
[gitignore] ignode bbdb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ eclipse.jdt.ls
 .extension
 mspyls/
 transient/
+bbdb
 
 # Private directory
 private/

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -409,7 +409,7 @@ sane way, here is the complete list of changed key bindings
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)
 Other:
-  - =.gitignore= now ignores tag files.
+  - =.gitignore= now ignores tag files and the bbdb database.
   - Added =vim-style-visual-feedback= and =hybrid-style-visual-feedback= style
     variables to enable =evil-goggles= pulse in the Vim and Hybrid editing
     styles, respectively; disabled by default (thanks to Sylvain Benner)


### PR DESCRIPTION
Ignore the BBDB file as by default it is stored in ~/.emacs.d.