### PR TITLE
[agda] Fix #9429: Make agda layer retain indentation on paste.

### DIFF
--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -58,6 +58,9 @@
            (agda2-highlight-record-face                . font-lock-type-face))))
       :config
       (progn
+        ; don't lose indentation on paste
+        (add-to-list 'spacemacs-indent-sensitive-modes 'agda2-mode)
+
         (spacemacs|define-transient-state goal-navigation
           :title "Goal Navigation Transient State"
           :doc "\n[_f_] next [_b_] previous [_q_] quit"


### PR DESCRIPTION
I have added the suggested line into the `:config` attribute of the call to `use-package agda2-mode`  and that has fixed the issue. Since I have no prior elisp expirience I'm not sure if that's the optimal solution, maybe someone could verify that?