### PR TITLE
[git] Hacktoberfest 2019: Add spacemacs/git-permalink functionality

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1573,6 +1573,9 @@ Other:
   - Log selection buffer (thanks to yuhan0):
     - ~SPC m c~ or ~SPC m ,~ select the commit at point and act on it
     - ~SPC m a~ or ~SPC m k~ abort selecting and don't act on any commit
+  - Get git permalink for a region (thanks to Roman Gonzalez):
+    - ~SPC g l p~ opens browser with region permalink URL
+    - ~SPC g l P~ adds region permalink URL to clipboard
 - Added feature to toggle =evil-magit= based on editing style
   (thanks to Muneeb Shaikh)
 - Added =use-package= for deferred loading of evil-magit

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -272,12 +272,15 @@ A log selection buffer is presented as an interactive way of selecting a recent 
 These key bindings allow to quickly construct URLs pointing to a given commit
 or lines in a file hosted on Git web services like GitHub, GitLab, Bitbucket...
 
-| Key binding | Description                                                            |
-|-------------+------------------------------------------------------------------------|
-| ~SPC g l c~ | on a commit hash, browse to the current file at this commit            |
-| ~SPC g l C~ | on a commit hash, create link to the file at this commit and copy it   |
-| ~SPC g l l~ | on a region, browse to file at current lines position                  |
-| ~SPC g l L~ | on a region, create a link to the file highlighting the selected lines |
+| Key binding | Description                                                                                   |
+|-------------+-----------------------------------------------------------------------------------------------|
+| ~SPC g l c~ | on a commit hash, browse to the current file at this commit                                   |
+| ~SPC g l C~ | on a commit hash, create link to the file at this commit and copy it                          |
+| ~SPC g l l~ | on a region, browse to file at current lines position                                         |
+| ~SPC g l L~ | on a region, create a link to the file highlighting the selected lines                        |
+| ~SPC g l p~ | on a region, browse to file at current lines position (using permalink link)                  |
+| ~SPC g l P~ | on a region, create a link to the file highlighting the selected lines (using permalink link) |
+|             |                                                                                               |
 
 *Notes:*
 - You can use the universal argument ~SPC u~ to select a remote repository.

--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -36,6 +36,19 @@
                   magit-diff-section-arguments)))
   (magit-refresh))
 
+(defun spacemacs/git-permalink ()
+  "Allow the user to get a permalink via git-link in a git-timemachine buffer."
+  (interactive)
+  (let ((git-link-use-commit t))
+    (call-interactively 'spacemacs/git-link-commit)))
+
+(defun spacemacs/git-permalink-copy-url-only ()
+  "Allow the user to get a permalink via git-link in a git-timemachine buffer."
+  (interactive)
+  (let (git-link-open-in-browser
+        (git-link-use-commit t))
+    (call-interactively 'spacemacs/git-link-commit)))
+
 (defun spacemacs/git-link-copy-url-only ()
   "Only copy the generated link to the kill ring."
   (interactive)

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -79,8 +79,11 @@
       (spacemacs/set-leader-keys
         "gll" 'spacemacs/git-link
         "glL" 'spacemacs/git-link-copy-url-only
+        "glp" 'spacemacs/git-permalink
+        "glP" 'spacemacs/git-permalink-copy-url-only
         "glc" 'spacemacs/git-link-commit
         "glC" 'spacemacs/git-link-commit-copy-url-only)
+
       ;; default is to open the generated link
       (setq git-link-open-in-browser t))))
 


### PR DESCRIPTION
### Context:

When using org files, one normally tends to add Github code links to an
algorithm/bug explanation so that readers are able to follow along with a PR
change.

The current `<SPC> g l L` command gets us the URL to the current branch; given
the code is in flux, the link becomes non-sensical rather quickly, loosing value
when trying to build a document with explanations about the code.

This PR allows us to get the Permalink (e.g. link associated to the commit, not
the branch); using this, the URL contents will never change with new commits
submitted to the repository.

### Changes:

  * Add two new functions with associated keybindings:

    - `<SPC> g l p` maps to `spacemacs/git-permalink`

    - `<SPC> g l P` maps to `spacemacs/git-permalink-copy-url-only`

  * The above changes rely on mechanisms of `git-link`, so no new code needs to
    be introduced