### PR TITLE
[ivy] Fix spacemacs/layouts-ts-close-other

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1079,6 +1079,7 @@ Other:
   - Replaced deprecated =avy--generic-jump= with =avy-jump=
     (thanks to Dominik Schrempf)
   - Switch recreated messages buffer to =evil-normal-state= (thanks to duianto)
+  - Fixed =spacemacs/layouts-ts-close-other= with =ivy= (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -200,7 +200,10 @@ ask the user if a new layout should be created."
 
 (defun spacemacs/layouts-ts-close-other ()
   (interactive)
-  (call-interactively 'spacemacs/helm-persp-close)
+  (cond ((configuration-layer/layer-used-p 'helm)
+         (spacemacs/helm-persp-close))
+        ((configuration-layer/layer-used-p 'ivy)
+         (spacemacs/ivy-spacemacs-layout-close-other)))
   (spacemacs/layouts-transient-state/body))
 
 (defun spacemacs/layouts-ts-kill ()


### PR DESCRIPTION
Problem: It called: `(spacemacs/helm-persp-close)`
Solution: Call `(spacemacs/ivy-spacemacs-layout-close-other)` when `ivy` is used.

---
Fixes #12776

The previous command used `call-interactively`.
But it works to just call the commands directly:
`(spacemacs/helm-persp-close)`
`(spacemacs/ivy-spacemacs-layout-close-other)`

`call-interactively` seems to have been there since the function was introduced:
https://github.com/syl20bnr/spacemacs/commit/50ceba2a6eee695364e5ff7302daafe93ab8196d#diff-9db228b4bfd82f6978ba62d2aba96b74R251

The first paragraph of the docstring for `call-interactively` says:
>Call FUNCTION, providing args according to its interactive calling specs.
Return the value FUNCTION returns.
The function contains a specification of how to do the argument reading.
In the case of user-defined functions, this is specified by placing a call
to the function ‘interactive’ at the top level of the function body.
See ‘interactive’.

Since neither of the helm or ivy close functions take arguments, it seemed like `call-interactively` could be removed.
https://github.com/syl20bnr/spacemacs/blob/fdd38eec9b7bcb5ed92404d3c30401791808e968/layers/%2Bspacemacs/spacemacs-layouts/funcs.el#L452
https://github.com/syl20bnr/spacemacs/blob/fdd38eec9b7bcb5ed92404d3c30401791808e968/layers/%2Bcompletion/ivy/funcs.el#L436

If I'm incorrect, then it can be added back.