### PR TITLE
[auto-completion] List feature pkg company-quickhelp

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -31,6 +31,7 @@ This layer adds auto-completion to all supported language layers.
 - Frequency-based suggestions via [[https://github.com/company-mode/company-statistics][company-statistics]] for =company=
 - Integration with [[https://github.com/capitaomorte/yasnippet][yasnippet]] and [[https://github.com/abo-abo/auto-yasnippet][auto-yasnippet]]
 - Automatic configuration of [[https://www.emacswiki.org/emacs/HippieExpand][hippie-expand]]
+- Automatic docstring tooltips are provided by [[https://github.com/expez/company-quickhelp][company-quickhelp]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
The company-quickhelp package wasn't mentioned in the auto-completion readme.

And the variable name auto-completion-enable-help-tooltip that enables the
package doesn't mention the package name either (which is fine).

This just makes it somewhat easier to see/find that the company-quickhelp
package is related to tooltips and that it's part of the auto-completion layer.