### PR TITLE
Bound counsel-git to gff and move magit-find-file to gfF.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1577,6 +1577,7 @@ Other:
   - Get git permalink for a region (thanks to Roman Gonzalez):
     - ~SPC g l p~ opens browser with region permalink URL
     - ~SPC g l P~ adds region permalink URL to clipboard
+  - Moved =magit-find-file= from ~SPC g f f~ to ~SPC g f F~ (thanks to Hong Xu)
 - Added feature to toggle =evil-magit= based on editing style
   (thanks to Muneeb Shaikh)
 - Added =use-package= for deferred loading of evil-magit
@@ -1794,6 +1795,7 @@ Other:
   - Added ~SPC h d F~ to list faces (thanks to Muneeb Shaikh)
   - Bind =find-file-other-window= to ~j~ (thanks to James Wang)
   - Added =counsel-mark-ring= to ~rm~ (thanks to bmag)
+  - Added =counsel-git= to ~SPC g f f~ (thanks to Hong Xu)
 - Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
 - Use new API to register additional transient state bindings
   (thanks to Andriy Kmit')

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -62,6 +62,7 @@
         "fL"  'counsel-locate
         ;; help
         "?"   'counsel-descbinds
+        "gff" 'counsel-git
         "hda" 'counsel-apropos
         "hdf" 'counsel-describe-function
         "hdF" 'counsel-describe-face

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -164,7 +164,7 @@
       (spacemacs/set-leader-keys
         "gb"  'spacemacs/git-blame-micro-state
         "gc"  'magit-clone
-        "gff" 'magit-find-file
+        "gfF" 'magit-find-file
         "gfl" 'magit-log-buffer-file
         "gfd" 'magit-diff
         "gi"  'magit-init


### PR DESCRIPTION
counsel-git find a file in the current git repository. "gff" is
currently bound to magit-find-file. While counsel-git seemingly performs the
same functionality as magit-find-file, they are substantially different:
magit-find-file is not intended to find a file, contrary to what the
name indicates. See magit/magit#3967 for
explanation. This is why we need another key binding for counsel-git.