### PR TITLE
Allow users to enable treemacs-tag-follow-mode as initial setup.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2722,6 +2722,7 @@ Other:
   Breen)
 - Made sure treemacs' minor modes will be disabled when they are configured
   to be off.
+- Add =tag= as an accepted value for option =treemacs-use-follow-mode=.
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -37,7 +37,7 @@ readme]]. In a short summary Treemacs offers the following:
 - Optionally fontifying files based on their git status.
 - Optionally collapsing single-dir-child directories into one.
 - Doing both asynchronously for an imperceptible performance cost.
-- Optional =follow-mode= to automatically focus the currently selected file.
+- Optional =follow-mode= to automatically focus the currently selected file or tag.
 - Optional =filewatch-mode= to automatically refresh the view after (and only
   after) changes to the shown filesystem.
 
@@ -47,12 +47,14 @@ To use this layer, add =treemacs= to the existing
 
 * Configuration
 ** Follow mode
-To have treemacs automatically sync with your current buffer set the
-layer variable =treemacs-use-follow-mode= to non-nil.
+To have treemacs automatically sync with your current buffer's file set the layer variable
+=treemacs-use-follow-mode= to =t=. To have treemacs automatically sync with your current tag set the
+layer variable =treemacs-use-follow-mode= to =tag=.
+
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (treemacs :variables treemacs-use-follow-mode t)))
+    (treemacs :variables treemacs-use-follow-mode 'tag)))
 #+END_SRC
 
 Default is =t=.

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -1,8 +1,9 @@
 ;;; packages.el --- treemacs Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
 ;;
 ;; Author: Alexander Miller <alexanderm@web.de>
+;;         Hong Xu <hong@topbug.net>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -65,9 +66,12 @@
       (spacemacs/define-evil-state-face "treemacs" "MediumPurple1")
       ;; minor modes are enabled by default, so they must be explicitly
       ;; turned off
-      (if treemacs-use-follow-mode
+      (if (eq treemacs-use-follow-mode t)
           (treemacs-follow-mode t)
         (treemacs-follow-mode -1))
+      (if (eq treemacs-use-follow-mode 'tag)
+          (treemacs-tag-follow-mode t)
+        (treemacs-tag-follow-mode -1))
       (if treemacs-use-filewatch-mode
           (treemacs-filewatch-mode t)
         (treemacs-filewatch-mode -1))


### PR DESCRIPTION
By adding `'tag` option to `treemacs-use-follow-mode`.