### PR TITLE
[ivy] Add counsel colors and faces key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1791,6 +1791,10 @@ Other:
   - Added ~SPC h d F~ to list faces (thanks to Muneeb Shaikh)
   - Bind =find-file-other-window= to ~j~ (thanks to James Wang)
   - Added =counsel-mark-ring= to ~rm~ (thanks to bmag)
+  - Added counsel color and faces key bindings (thanks to duianto):
+    - ~SPC C e~ =counsel-colors-emacs=
+    - ~SPC C f~ =counsel-faces=
+    - ~SPC C w~ =counsel-colors-web=
 - Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
 - Use new API to register additional transient state bindings
   (thanks to Andriy Kmit')

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -191,6 +191,9 @@
       ;; Key bindings
       (spacemacs/set-leader-keys
         "a'" 'spacemacs/ivy-available-repls
+        "Ce" 'counsel-colors-emacs
+        "Cf" 'counsel-faces
+        "Cw" 'counsel-colors-web
         "fr" 'counsel-recentf
         "rl" 'ivy-resume
         "bb" 'ivy-switch-buffer)


### PR DESCRIPTION
`SPC C e` calls `counsel-colors-emacs`
`SPC C f` calls `counsel-faces`
`SPC C w` calls `counsel-colors-web`