### PR TITLE
[html] add lsp for html buffer

### DIFF
--- a/layers/+lang/html/README.org
+++ b/layers/+lang/html/README.org
@@ -50,6 +50,7 @@ To enable the LSP set the layer variables below:
 - =css-enable-lsp=
 - =less-enable-lsp=
 - =scss-enable-lsp=
+- =html-enable-lsp=
 
 ** web-beautify
 See [[file:../../+tools/web-beautify/README.org][web-beautify layer]] documentation.
@@ -79,11 +80,19 @@ Formatter can be chosen on a per project basis using directory local variables
 
 * Backends
 ** Language Server Protocol
-You have to install =vscode-css-languageserver-bin= via
+For css files, you have to install =vscode-css-languageserver-bin= via
 
 #+BEGIN_SRC sh
   npm i -g vscode-css-languageserver-bin
 #+END_SRC
+
+For html files you will need to install =vscode-html-languageserver-bin=
+
+#+BEGIN_SRC sh
+  npm install -g vscode-html-languageserver-bin
+#+END_SRC
+
+Don't forget to set the corresponding layer variables mentioned above to =t=
 
 * Live display in browser
 Use ~SPC m I~ to enable impatient mode, opening a live view of a HTML file in

--- a/layers/+lang/html/config.el
+++ b/layers/+lang/html/config.el
@@ -12,6 +12,7 @@
 (spacemacs|define-jump-handlers css-mode)
 (spacemacs|define-jump-handlers less-css-mode)
 (spacemacs|define-jump-handlers scss-mode)
+(spacemacs|define-jump-handlers web-mode)
 
 (defvar web-fmt-tool 'web-beautify
   "The formatter to format a CSS/SCSS/Less file. Possible values are `web-beautify' and `prettier'.")
@@ -24,3 +25,6 @@
 
 (defvar scss-enable-lsp nil
   "If non-nil, enable lsp-mode in scss-mode buffers.")
+
+(defvar html-enable-lsp nil
+  "If non-nil, enable lsp-mode in web-mode html buffers having.")

--- a/layers/+lang/html/funcs.el
+++ b/layers/+lang/html/funcs.el
@@ -21,7 +21,7 @@
   (if (bound-and-true-p impatient-mode)
       (impatient-mode -1)
     (unless (process-status "httpd")
-        (httpd-start))
+      (httpd-start))
     (impatient-mode)
     (when (string-match-p "\\.html\\'" (buffer-name))
       (imp-visit-buffer))))
@@ -49,8 +49,17 @@
   (while (not (looking-at "}"))
     (join-line -1)))
 
-(defun spacemacs//setup-lsp-for-stylesheet-buffers ()
+(defun spacemacs//setup-lsp-for-web-mode-buffers ()
   "Start lsp-mode and configure for buffer."
   (if (configuration-layer/layer-used-p 'lsp)
       (lsp)
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//setup-lisp-for-html-buffer ()
+  "If buffer extension is html then turn on lsp."
+  (let ((buffer-extension (save-match-data
+                             ;; regex to capture extension part from file.html or file.html<whaterver>
+                             (if (string-match "\\.\\([^.<]*\\)<*[^.]*$" (buffer-name))
+                                 (match-string 1 (buffer-name))))))
+    (when (string= buffer-extension "html")
+      (spacemacs//setup-lsp-for-web-mode-buffers))))

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -76,7 +76,7 @@
 
       (when css-enable-lsp
         (add-hook 'css-mode-hook
-                  #'spacemacs//setup-lsp-for-stylesheet-buffers t))
+                  #'spacemacs//setup-lsp-for-web-mode-buffers t))
 
       ;; Explicitly run prog-mode hooks since css-mode does not derive from
       ;; prog-mode major-mode in Emacs 24 and below.
@@ -128,9 +128,9 @@
   (use-package counsel-css
     :defer t
     :init (cl-loop for (mode . mode-hook) in '((css-mode . css-mode-hook)
-                                            (scss-mode . scss-mode-hook))
-                do (add-hook mode-hook 'counsel-css-imenu-setup)
-                (spacemacs/set-leader-keys-for-major-mode mode "gh" 'counsel-css))))
+                                               (scss-mode . scss-mode-hook))
+                   do (add-hook mode-hook 'counsel-css-imenu-setup)
+                   (spacemacs/set-leader-keys-for-major-mode mode "gh" 'counsel-css))))
 
 (defun html/init-helm-css-scss ()
   (use-package helm-css-scss
@@ -153,7 +153,7 @@
     :init
     (when less-enable-lsp
       (add-hook 'less-css-mode-hook
-                #'spacemacs//setup-lsp-for-stylesheet-buffers t))
+                #'spacemacs//setup-lsp-for-web-mode-buffers t))
     :mode ("\\.less\\'" . less-css-mode)))
 
 (defun html/pre-init-prettier-js ()
@@ -176,7 +176,7 @@
     :defer t
     :init
     (when scss-enable-lsp
-      (add-hook 'scss-mode-hook #'spacemacs//setup-lsp-for-stylesheet-buffers t))
+      (add-hook 'scss-mode-hook #'spacemacs//setup-lsp-for-web-mode-buffers t))
     :mode ("\\.scss\\'" . scss-mode)))
 
 (defun html/init-slim-mode ()
@@ -230,20 +230,20 @@
       ;; (defvar spacemacs--web-mode-ms-doc-toggle 0
       ;;   "Display a short doc when nil, full doc otherwise.")
 
-  ;;     (defun spacemacs//web-mode-ms-doc ()
-  ;;       (if (equal 0 spacemacs--web-mode-ms-doc-toggle)
-  ;;           "[_?_] for help"
-  ;;         "
-  ;; [_?_] display this help
-  ;; [_k_] previous [_j_] next   [_K_] previous sibling [_J_] next sibling
-  ;; [_h_] parent   [_l_] child  [_c_] clone [_d_] delete [_D_] kill [_r_] rename
-  ;; [_w_] wrap     [_p_] xpath
-  ;; [_q_] quit"))
+      ;;     (defun spacemacs//web-mode-ms-doc ()
+      ;;       (if (equal 0 spacemacs--web-mode-ms-doc-toggle)
+      ;;           "[_?_] for help"
+      ;;         "
+      ;; [_?_] display this help
+      ;; [_k_] previous [_j_] next   [_K_] previous sibling [_J_] next sibling
+      ;; [_h_] parent   [_l_] child  [_c_] clone [_d_] delete [_D_] kill [_r_] rename
+      ;; [_w_] wrap     [_p_] xpath
+      ;; [_q_] quit"))
 
-  ;;     (defun spacemacs//web-mode-ms-toggle-doc ()
-  ;;       (interactive)
-  ;;       (setq spacemacs--web-mode-ms-doc-toggle
-  ;;             (logxor spacemacs--web-mode-ms-doc-toggle 1)))
+      ;;     (defun spacemacs//web-mode-ms-toggle-doc ()
+      ;;       (interactive)
+      ;;       (setq spacemacs--web-mode-ms-doc-toggle
+      ;;             (logxor spacemacs--web-mode-ms-doc-toggle 1)))
 
       (spacemacs|define-transient-state web-mode
         :title "Web-mode Transient State"
@@ -285,7 +285,10 @@
      ("\\.eco\\'"        . web-mode)
      ("\\.ejs\\'"        . web-mode)
      ("\\.svelte\\'"     . web-mode)
-     ("\\.djhtml\\'"     . web-mode))))
+     ("\\.djhtml\\'"     . web-mode))
+    :init
+    (when html-enable-lsp
+      (add-hook 'web-mode-hook #'spacemacs//setup-lisp-for-html-buffer t))))
 
 (defun html/post-init-yasnippet ()
   (spacemacs/add-to-hooks 'spacemacs/load-yasnippet '(css-mode-hook


### PR DESCRIPTION
New layer's variable `html-enable-lsp` when `t` then lsp will be enabled for buffers having html extensions.

Unnecessary change: some unrelated parts of Spacemacs code base was indented by auto indent 