### PR TITLE
shell: Set initial shell state better

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -231,13 +231,16 @@
       (setq shell-pop-window-position shell-default-position
             shell-pop-window-size     shell-default-height
             shell-pop-term-shell      shell-default-term-shell
-            shell-pop-full-span       shell-default-full-span
-            shell-pop-in-after-hook   #'evil-insert-state)
+            shell-pop-full-span       shell-default-full-span)
       (make-shell-pop-command "eshell" eshell)
       (make-shell-pop-command "term" term shell-pop-term-shell)
       (make-shell-pop-command "ansi-term" ansi-term shell-pop-term-shell)
       (make-shell-pop-command "inferior-shell" inferior-shell)
       (make-shell-pop-command "multiterm" multiterm)
+
+      (let* ((initial-shell-mode-name (format "%S-mode" shell-default-shell))
+             (initial-shell-mode (intern initial-shell-mode-name)))
+        (evil-set-initial-state initial-shell-mode 'insert))
 
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
 


### PR DESCRIPTION
After recent Spacemacs update I was quite surprised to find my `(spacemacs/default-pop-shell)` to spawn a new shell in an `evil-insert-state`, even though I've previously configured it to run in `emacs-state` :slightly_smiling_face: 

Took a while for me to chase down the cause and fix it - as an end-user, I'd have to specifically remove this function from a `shell-pop-in-after-hook`, which is kinda less obvious than defining initial state directly

The configuration I've been happily using locally:
```
(evil-set-initial-state 'vterm-mode 'emacs)
```
The configuration that was required to reconfigure the shell back to running in `emacs-state`:
```
(remove-hook 'shell-pop-in-after-hook #'evil-insert-state)
```

on the sidenote: setting a whole `'shell-pop-in-after-hook` value to a single function doesn't seem like a proper thing to me neither 🤔
