### PR TITLE
shell: Tell vterm to respect `shell-default-term-shell` setting

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -313,6 +313,8 @@
 
     :config
     (progn
+      (setq vterm-shell shell-default-term-shell)
+
       (evil-define-key 'normal vterm-mode-map
         [escape] 'vterm--self-insert
         [return] 'vterm--self-insert)


### PR DESCRIPTION
Effectively, this forces `vterm` to spawn a shell set in a `shell-default-term-shell` variable i/o default value from "shell-file-name" - just like other shells from `shell-pop` do.