### PR TITLE
Updated read-me

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This might also be true for other linux distributions.
 ```
 brew tap d12frosted/emacs-plus
 brew install emacs-plus
-ln -s /usr/local/Cellar/emacs-plus/*/Emacs.app/ /Applications/
+brew link emacs-plus
 ```
 
 ##### Using emacs-mac
@@ -164,7 +164,7 @@ ln -s /usr/local/Cellar/emacs-plus/*/Emacs.app/ /Applications/
 ```
 brew tap railwaycat/emacsmacport
 brew install emacs-mac
-ln -s /usr/local/Cellar/emacs-mac/*/Emacs.app/ /Applications/
+brew link emacs-mac
 ```
 
 ##### Using cask
@@ -206,9 +206,9 @@ After completing the Spacemacs [install process](#install), then it's also
 recommended to add the [osx layer][] to your [dotfile][]. Installation
 instructions are available in the documentation for the [osx layer][].
 
-Depending on the installed version of GnuTLS securely installing emacs 
-packages may fail. In this case it is possible to install using 
-`emacs --insecure`. However be aware that this means your packages will 
+Depending on the installed version of GnuTLS securely installing emacs
+packages may fail. In this case it is possible to install using
+`emacs --insecure`. However be aware that this means your packages will
 be transferred using http, use at your own risk.
 
 You might also have some issues when doing some search on your projects, you
@@ -247,9 +247,9 @@ For efficient searches we recommend installing `pt` ([the platinum searcher][]).
 `pt` version 1.7.7 or higher is required.
 
 **Notes:**
-Depending on the installed version of GnuTLS securely installing emacs 
-packages may fail. In this case it is possible to install using 
-`emacs --insecure`. However be aware that this means your packages will 
+Depending on the installed version of GnuTLS securely installing emacs
+packages may fail. In this case it is possible to install using
+`emacs --insecure`. However be aware that this means your packages will
 be transferred using http, use at your own risk.
 
 # Install
@@ -274,11 +274,11 @@ be transferred using http, use at your own risk.
    ```
 
    Or
-   
+
    ```sh
    git clone --depth 1 https://github.com/syl20bnr/spacemacs ~/.emacs.d
    ```
-   
+
    In case you have a limited internet connection or speed.
 
    `master` is the stable branch and it is _immutable_, **DO NOT** make any


### PR DESCRIPTION
- Added brew specific commands for creating a symbolic link on Mac. The changes on this diff should fix [this section](https://github.com/syl20bnr/spacemacs/blob/develop/README.md#macos).

- Removed trailing white space chars

---
Edited by duianto
- Fixed the `this section` link, it redirected to the `master` branch,
now it leads to the `develop` branch.