### PR TITLE
fix documentation in markdown layer

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -169,8 +169,8 @@ In order to use =orgtabl-mode=, add =org= layer to your =~/.spacemacs=.
 
 | Key binding | Description    |
 |-------------+----------------|
-| ~SPC m \>~  | indent region  |
-| ~SPC m \<~  | outdent region |
+| ~SPC m >~   | indent region  |
+| ~SPC m <~   | outdent region |
 
 ** Header navigation
 


### PR DESCRIPTION
A small fix in the documentation of the markdown layer. indent/outdent region does not have a \ in the keybinding.