### PR TITLE
Make react layer respect js fmt on save

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -81,3 +81,7 @@ If optional argument P is present, test this instead of point."
 
 (defun spacemacs//react-setup-yasnippet ()
   (yas-activate-extra-mode 'js-mode))
+
+;; Format
+(defun spacemacs/react-fmt-before-save-hook ()
+  (add-hook 'before-save-hook 'spacemacs/javascript-format t t))

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -72,6 +72,9 @@
     (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-setup-backend)
     ;; set next-error-function to nil because we use flycheck
     (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-setup-next-error-fn)
+    ;; setup fmt on save
+    (when javascript-fmt-on-save
+      (add-hook 'rjsx-mode-local-vars-hook 'spacemacs/react-fmt-before-save-hook))
 
     :config
     ;; declare prefix


### PR DESCRIPTION
The react layer relies on the javascript layer and uses multiple values
from it including definition of a formatter. However, the react layer
does not respect the javascript layer setting for formatting a file on
save.

This patch configures the react layer to add a before save hook that
calls the javascript layer formatting function when the
`javascript-fmt-on-save` variable is enabled.