### PR TITLE
org-mode: Document more insertion bindings

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -507,6 +507,8 @@ are also available.
 
 | Key binding   | Description                                   |
 |---------------+-----------------------------------------------|
+| ~C-RET~       | Insert heading at end of current subtree      |
+| ~C-S-RET~     | Insert TODO at end of current subtree         |
 | ~SPC m i d~   | org-insert-drawer                             |
 | ~SPC m i D s~ | Take screenshot                               |
 | ~SPC m i D y~ | Yank image url                                |


### PR DESCRIPTION
`C-RET` and `C-S-RET`, from https://orgmode.org/manual/Structure-editing.html.