### PR TITLE
Python jump to definitions

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -58,7 +58,8 @@
         "hh" 'anaconda-mode-show-doc
         "ga" 'anaconda-mode-find-assignments
         "gb" 'xref-pop-marker-stack
-        "gu" 'anaconda-mode-find-references)
+        "gu" 'anaconda-mode-find-references
+        "gg" 'anaconda-mode-find-definitions)
       (setq anaconda-mode-installation-directory
         (concat spacemacs-cache-directory "anaconda-mode")))
     :config


### PR DESCRIPTION
Hello,

When trying to jump to definition, i was being asked for the "TAGS" file, though my virtualenv was active. I looked at the configuration and the line added was missing.

