### PR TITLE
Fix python backend setup

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2401,8 +2401,6 @@ Other:
 - Fix lazy loading of =lsp-python-ms= (thanks to lsp-ableton)
 - Fix =Ipython= path on windows (thanks to Daniel K)
 - Make =inferior-python-mode= do not use tabs (thanks to tsoernes)
-- Added =anaconda-mode-find-definition= for ~SPC m g g~
-  (thanks to Rakan Alhneiti)
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -366,7 +366,7 @@ to be called for each testrunner. "
   "Bind the python formatter keys.
 Bind formatter to '==' for LSP and '='for all other backends."
   (spacemacs/set-leader-keys-for-major-mode 'python-mode
-    (if (eq python-backend 'lsp)
+    (if (eq (spacemacs//python-backend) 'lsp)
         "=="
       "=") 'spacemacs/python-format-buffer))
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -50,19 +50,18 @@
 
 (defun python/init-anaconda-mode ()
   (use-package anaconda-mode
-    :if (eq python-backend 'anaconda)
+    :if (eq (spacemacs//python-backend) 'anaconda)
     :defer t
     :init
+    (setq anaconda-mode-installation-directory
+      (concat spacemacs-cache-directory "anaconda-mode"))
+    :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'python-mode
         "hh" 'anaconda-mode-show-doc
         "ga" 'anaconda-mode-find-assignments
         "gb" 'xref-pop-marker-stack
         "gu" 'anaconda-mode-find-references)
-      (setq anaconda-mode-installation-directory
-        (concat spacemacs-cache-directory "anaconda-mode")))
-    :config
-    (progn
       ;; new anaconda-mode (2018-06-03) removed `anaconda-view-mode-map' in
       ;; favor of xref. Eventually we need to remove this part.
       (when (boundp 'anaconda-view-mode-map)
@@ -95,7 +94,7 @@
 
 (defun python/init-company-anaconda ()
   (use-package company-anaconda
-    :if (eq python-backend 'anaconda)
+    :if (eq (spacemacs//python-backend) 'anaconda)
     :defer t
     ;; see `spacemacs//python-setup-anaconda-company'
     ))
@@ -114,12 +113,11 @@
 (defun python/init-cython-mode ()
   (use-package cython-mode
     :defer t
-    :init
-    (progn
-      (when (eq python-backend 'anaconda)
-        (spacemacs/set-leader-keys-for-major-mode 'cython-mode
-          "hh" 'anaconda-mode-show-doc
-          "gu" 'anaconda-mode-find-references)))))
+    :config
+    (when (eq (spacemacs//python-backend) 'anaconda)
+      (spacemacs/set-leader-keys-for-major-mode 'cython-mode
+        "hh" 'anaconda-mode-show-doc
+        "gu" 'anaconda-mode-find-references))))
 
 (defun python/pre-init-dap-mode ()
   (add-to-list 'spacemacs--dap-supported-modes 'python-mode)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -58,8 +58,7 @@
         "hh" 'anaconda-mode-show-doc
         "ga" 'anaconda-mode-find-assignments
         "gb" 'xref-pop-marker-stack
-        "gu" 'anaconda-mode-find-references
-        "gg" 'anaconda-mode-find-definitions)
+        "gu" 'anaconda-mode-find-references)
       (setq anaconda-mode-installation-directory
         (concat spacemacs-cache-directory "anaconda-mode")))
     :config


### PR DESCRIPTION
This reverts commit 9bafd3f. `anaconda-mode-find-definitions` is added to `spacemacs-jump-handlers-python-mode` later when configuring the package, which is then used by `jump-to-definition`, which is bound to exactly same shortcut `SPC m g g` .

ac30247811d28e86c4b33d6150d678d5f5824330 broke the backend setup in case when `python-backend` was bound to `nil` since there were still some places that checked the variable directly.

I also moved the leader keys setup from `:init` to `:config` because e.g. `anaconda-mode-find-references` was being overridden to `helm-gtags-update-tags`.