### PR TITLE
Clean up transient states' toggles; show conflicts in smerge hint

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2813,6 +2813,8 @@ Other:
   - Added smerge transient state key bindings (thanks to duianto):
     ~SPC g r e >~ ediff
     ~SPC g r K >~ kill current
+  - Added current and total conflicts to smerge transient state's hint
+    (thanks to Miciah Dashiel Butler Masters)
 - New packages:
   - =browse-at-remote= which replaces =github-browse-file=
   (thanks Eugene Yaremenko)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -501,6 +501,9 @@ Other:
   - Added a =spacemacs-layouts-restrict-spc-tab= variable to
     =spacemacs/alternate-buffer= that restricts ~SPC-TAB~ to the current layouts
     buffers (default: =nil=) (thanks to Thanh Vuong)
+  - Use a unique variable for each transient state's full-hint toggle function
+    so that toggling the full hint in one transient state does not affect other
+    transient states (thanks to Miciah Dashiel Butler Masters)
 - Fixed:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/layers/+source-control/version-control/config.el
+++ b/layers/+source-control/version-control/config.el
@@ -9,6 +9,9 @@
 ;;
 ;;; License: GPLv3
 
+(defvar spacemacs--smerge-ts-full-hint-toggle nil
+  "Display smerge transient-state documentation.")
+
 (defvar version-control-global-margin t
   "If non-nil, will show diff margins globally.")
 

--- a/layers/+source-control/version-control/funcs.el
+++ b/layers/+source-control/version-control/funcs.el
@@ -128,3 +128,27 @@
   :off (spacemacs/vcs-disable-margin-globally)
   :documentation "Enable diff margins globally."
   :evil-leader "T C-d")
+
+(defun spacemacs//smerge-ts-hint ()
+  "Return a hint for the smerge transient state.
+Return a string indicating the index of the current conflict and
+the number of conflicts detected by `smerge-mode'."
+  (concat
+   (cl-loop for ol being the overlays
+            with pos = (point)
+            if (eq (overlay-get ol 'smerge) 'conflict)
+            count ol into total
+            and if (<= (overlay-start ol) pos)
+            count ol into idx
+            finally return (format "conflict [%d/%d]" idx total))
+   (if spacemacs--smerge-ts-full-hint-toggle
+       spacemacs--smerge-ts-full-hint
+     (concat "  (["
+             (propertize "?" 'face 'hydra-face-red)
+             "] help)"))))
+
+(defun spacemacs//smerge-ts-toggle-hint ()
+  "Toggle the full hint docstring for the smerge transient state."
+  (interactive)
+  (setq spacemacs--smerge-ts-full-hint-toggle
+        (not spacemacs--smerge-ts-full-hint-toggle)))

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -263,21 +263,24 @@
     :diminish smerge-mode
     :commands spacemacs/smerge-transient-state/body
     :init
-    (spacemacs/set-leader-keys
-      "gr" 'spacemacs/smerge-transient-state/body)
-    :config
     (progn
-      (spacemacs|define-transient-state smerge
-        :title "Smerge Transient State"
-        :doc "
+      (spacemacs/set-leader-keys
+        "gr" 'spacemacs/smerge-transient-state/body)
+      (spacemacs|transient-state-format-hint smerge
+        spacemacs--smerge-ts-full-hint
+        "\n
  Movement^^^^         Merge Action^^      Diff^^            Other
  ---------------^^^^  ----------------^^  --------------^^  ---------------------------^^
  [_n_]^^   next hunk  [_b_] keep base     [_<_] base/mine   [_C_] combine curr/next hunks
  [_N_/_p_] prev hunk  [_m_] keep mine     [_=_] mine/other  [_u_] undo
  [_j_]^^   next line  [_a_] keep all      [_>_] base/other  [_q_] quit
  [_k_]^^   prev line  [_o_] keep other    [_r_] refine
- ^^^^                 [_c_] keep current  [_e_] ediff
- ^^^^                 [_K_] kill current"
+ ^^^^                 [_c_] keep current  [_e_] ediff       [_?_]^^ toggle help
+ ^^^^                 [_K_] kill current")
+      (spacemacs|define-transient-state smerge
+        :title "Smerge Transient State"
+        :hint-is-doc t
+        :dynamic-hint (spacemacs//smerge-ts-hint)
         :bindings
         ;; move
         ("n" smerge-next)
@@ -301,7 +304,8 @@
         ("C" smerge-combine-with-next)
         ("K" smerge-kill-current)
         ("u" undo-tree-undo)
-        ("q" nil :exit t)))))
+        ("q" nil :exit t)
+        ("?" spacemacs//smerge-ts-toggle-hint)))))
 
 (defun version-control/init-browse-at-remote ()
   (use-package browse-at-remote

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -655,17 +655,20 @@ respond to this toggle."
   (interactive "p")
   (enlarge-window delta t))
 
+(defvar spacemacs--window-manipulation-ts-full-hint-toggle nil
+  "Display window-manipulation transient-state documentation.")
+
 (defun spacemacs//window-manipulation-ts-toggle-hint ()
   "Toggle the full hint docstring for the window manipulation transient-state."
   (interactive)
-  (setq spacemacs--ts-full-hint-toggle
-        (not spacemacs--ts-full-hint-toggle)))
+  (setq spacemacs--window-manipulation-ts-full-hint-toggle
+        (not spacemacs--window-manipulation-ts-full-hint-toggle)))
 
 (defun spacemacs//window-manipulation-ts-hint ()
   "Return a condensed/full hint for the window manipulation transient state"
   (concat
    " "
-   (if spacemacs--ts-full-hint-toggle
+   (if spacemacs--window-manipulation-ts-full-hint-toggle
        spacemacs--window-manipulation-ts-full-hint
      (concat spacemacs--window-manipulation-ts-minified-hint
              "  ([" (propertize "?" 'face 'hydra-face-red) "] help)"))))

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -659,13 +659,13 @@ respond to this toggle."
   "Toggle the full hint docstring for the window manipulation transient-state."
   (interactive)
   (setq spacemacs--ts-full-hint-toggle
-        (logxor spacemacs--ts-full-hint-toggle 1)))
+        (not spacemacs--ts-full-hint-toggle)))
 
 (defun spacemacs//window-manipulation-ts-hint ()
   "Return a condensed/full hint for the window manipulation transient state"
   (concat
    " "
-   (if (equal 1 spacemacs--ts-full-hint-toggle)
+   (if spacemacs--ts-full-hint-toggle
        spacemacs--window-manipulation-ts-full-hint
      (concat spacemacs--window-manipulation-ts-minified-hint
              "  ([" (propertize "?" 'face 'hydra-face-red) "] help)"))))

--- a/layers/+spacemacs/spacemacs-layouts/config.el
+++ b/layers/+spacemacs/spacemacs-layouts/config.el
@@ -21,7 +21,7 @@
 (defvar layouts-autosave-delay 900
   "Delay in seconds between each layouts auto-save.")
 
-(defvar spacemacs--ts-full-hint-toggle 0
+(defvar spacemacs--ts-full-hint-toggle nil
   "Toggle display of transient states documentations.")
 
 (defvar spacemacs--last-selected-layout dotspacemacs-default-layout-name

--- a/layers/+spacemacs/spacemacs-layouts/config.el
+++ b/layers/+spacemacs/spacemacs-layouts/config.el
@@ -21,8 +21,11 @@
 (defvar layouts-autosave-delay 900
   "Delay in seconds between each layouts auto-save.")
 
-(defvar spacemacs--ts-full-hint-toggle nil
-  "Toggle display of transient states documentations.")
+(defvar spacemacs--layouts-ts-full-hint-toggle nil
+  "Toggle display of layouts transient-state documentation.")
+
+(defvar spacemacs--workspaces-ts-full-hint-toggle nil
+  "Toggle display of workspaces transient-state documentation.")
 
 (defvar spacemacs--last-selected-layout dotspacemacs-default-layout-name
   "Previously selected layout.")

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -105,7 +105,7 @@ Cancels autosave on exiting perspectives mode."
   "Toggle the full hint docstring for the layouts transient-state."
   (interactive)
   (setq spacemacs--ts-full-hint-toggle
-        (logxor spacemacs--ts-full-hint-toggle 1)))
+        (not spacemacs--ts-full-hint-toggle)))
 
 (defun spacemacs//layout-format-name (name pos)
   "Format the layout name given by NAME for display in mode-line."
@@ -132,7 +132,7 @@ Cancels autosave on exiting perspectives mode."
                              persp-list " | "))))
     (concat
      formatted-persp-list
-     (if (equal 1 spacemacs--ts-full-hint-toggle)
+     (if spacemacs--ts-full-hint-toggle
          spacemacs--layouts-ts-full-hint
        (concat "  (["
                (propertize "?" 'face 'hydra-face-red)
@@ -656,7 +656,7 @@ STATE is a window-state object as returned by `window-state-get'."
   "Toggle the full hint docstring for the workspaces transient-state."
   (interactive)
   (setq spacemacs--ts-full-hint-toggle
-        (logxor spacemacs--ts-full-hint-toggle 1)))
+        (not spacemacs--ts-full-hint-toggle)))
 
 (defun spacemacs/workspaces-ts-rename ()
   "Rename a workspace and get back to transient-state."
@@ -682,7 +682,7 @@ STATE is a window-state object as returned by `window-state-get'."
    " "
    (mapconcat 'spacemacs//workspace-format-name
               (eyebrowse--get 'window-configs) " | ")
-   (if (equal 1 spacemacs--ts-full-hint-toggle)
+   (if spacemacs--ts-full-hint-toggle
        spacemacs--workspaces-ts-full-hint
      (concat "  (["
              (propertize "?" 'face 'hydra-face-red)

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -104,8 +104,8 @@ Cancels autosave on exiting perspectives mode."
 (defun spacemacs//layouts-ts-toggle-hint ()
   "Toggle the full hint docstring for the layouts transient-state."
   (interactive)
-  (setq spacemacs--ts-full-hint-toggle
-        (not spacemacs--ts-full-hint-toggle)))
+  (setq spacemacs--layouts-ts-full-hint-toggle
+        (not spacemacs--layouts-ts-full-hint-toggle)))
 
 (defun spacemacs//layout-format-name (name pos)
   "Format the layout name given by NAME for display in mode-line."
@@ -132,7 +132,7 @@ Cancels autosave on exiting perspectives mode."
                              persp-list " | "))))
     (concat
      formatted-persp-list
-     (if spacemacs--ts-full-hint-toggle
+     (if spacemacs--layouts-ts-full-hint-toggle
          spacemacs--layouts-ts-full-hint
        (concat "  (["
                (propertize "?" 'face 'hydra-face-red)
@@ -655,8 +655,8 @@ STATE is a window-state object as returned by `window-state-get'."
 (defun spacemacs//workspaces-ts-toggle-hint ()
   "Toggle the full hint docstring for the workspaces transient-state."
   (interactive)
-  (setq spacemacs--ts-full-hint-toggle
-        (not spacemacs--ts-full-hint-toggle)))
+  (setq spacemacs--workspaces-ts-full-hint-toggle
+        (not spacemacs--workspaces-ts-full-hint-toggle)))
 
 (defun spacemacs/workspaces-ts-rename ()
   "Rename a workspace and get back to transient-state."
@@ -682,7 +682,7 @@ STATE is a window-state object as returned by `window-state-get'."
    " "
    (mapconcat 'spacemacs//workspace-format-name
               (eyebrowse--get 'window-configs) " | ")
-   (if spacemacs--ts-full-hint-toggle
+   (if spacemacs--workspaces-ts-full-hint-toggle
        spacemacs--workspaces-ts-full-hint
      (concat "  (["
              (propertize "?" 'face 'hydra-face-red)


### PR DESCRIPTION
#### [core] Use truth values for `spacemacs--ts-full-hint`

Use `nil` and `t` instead of 0 and 1 for `spacemacs--ts-full-hint` values.

* `layers/+spacemacs/spacemacs-layouts/config.el` (`spacemacs--ts-full-hint-toggle`): Define with an initial value of `nil`.
* `layers/+spacemacs/spacemacs-defaults/keybindings.el` (`spacemacs//window-manipulation-ts-toggle-hint`, `spacemacs//window-manipulation-ts-hint`):
* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs//layouts-ts-toggle-hint`, `spacemacs//layouts-ts-hint`, `spacemacs//workspaces-ts-toggle-hint`, `spacemacs//workspaces-ts-hint`): Replace `(logxor ... 1)` and `(equal 1 ...)` with `(not ...)` and a simple truth check.


#### [core] Use a unique `defvar` for each transient state's full-hint toggle

Instead of using a single variable for all transient states' full-hint toggle functions, define a unique variable for each toggle function so that toggling the full hint for one transient state does not affect the others.

* `layers/+spacemacs/spacemacs-defaults/keybindings.el` (`spacemacs--window-manipulation-ts-full-hint-toggle`): New variable.
(`spacemacs//window-manipulation-ts-toggle-hint`, `spacemacs//window-manipulation-ts-hint`): Replace `spacemacs--ts-full-hint-toggle` with `spacemacs--window-manipulation-ts-full-hint-toggle`.
* `layers/+spacemacs/spacemacs-layouts/config.el` (`spacemacs--ts-full-hint-toggle`): Delete variable.
(`spacemacs--layouts-ts-full-hint-toggle`, `spacemacs--workspaces-ts-full-hint-toggle`): New variables.
* `layers/+spacemacs/spacemacs-layouts/funcs.el` (`spacemacs//layouts-ts-toggle-hint`, `spacemacs//layouts-ts-hint`): Replace `spacemacs--ts-full-hint-toggle` with `spacemacs--layouts-ts-full-hint-toggle`.
(`spacemacs//workspaces-ts-toggle-hint`, `spacemacs//workspaces-ts-hint`): Replace `spacemacs--ts-full-hint-toggle` with `spacemacs--workspaces-ts-full-hint-toggle`.


#### [version-control] Show conflicts in smerge transient state's hint

Use a dynamic hint for the smerge transient state in order to show the current and total numbers of conflicts, and make the full hint toggleable.

* `layers/+source-control/version-control/config.el` (`spacemacs--smerge-ts-full-hint-toggle`): New variable.
* `layers/+source-control/version-control/funcs.el` (`spacemacs//smerge-ts-hint`): New function.  Return a string indicating the index of the current conflict and the total number of conflicts detected by smerge-mode.  If `spacemacs--smerge-ts-full-hint-toggle` is true, append the smerge transient state's full hint.
(`spacemacs//smerge-ts-toggle-hint`): Toggle showing the full hint for the smerge transient state.
* `layers/+source-control/version-control/packages.el` (`version-control/init-smerge-mode`): Define the transient state in `:init` so we can use `spacemacs|transient-state-format-hint`.  Use `spacemacs//smerge-ts-hint` to display a dynamic hint.  Bind the <kbd>?</kbd> key to `spacemacs//smerge-ts-toggle-hint`.