### PR TITLE
[git] Delete old git-link and git-timemachine code

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1594,6 +1594,8 @@ Other:
 - Fixed magit conflicting with golden-ratio (thanks Eric Zhang)
 - Hide with-editor mode-line indicator: =WE= (thanks to duianto)
 - Fixed magit blame in org buffers (thanks to Compro Prasad)
+- Deleted git-link and git-timemachine integration that has been superseded
+  by upstream changes (thanks to Miciah Dashiel Butler Masters)
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)

--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -53,36 +53,12 @@
   "Only copy the generated link to the kill ring."
   (interactive)
   (let (git-link-open-in-browser)
-    (call-interactively 'spacemacs/git-link)))
+    (call-interactively 'git-link)))
 
 (defun spacemacs/git-link-commit-copy-url-only ()
   "Only copy the generated link to the kill ring."
   (interactive)
   (let (git-link-open-in-browser)
-    (call-interactively 'spacemacs/git-link-commit)))
-
-(defun spacemacs/git-link ()
-  "Allow the user to run git-link in a git-timemachine buffer."
-  (interactive)
-  (require 'git-link)
-  (if (and (boundp 'git-timemachine-revision)
-           git-timemachine-revision)
-      (cl-letf (((symbol-function 'git-link--branch)
-                 (lambda ()
-                   (car git-timemachine-revision))))
-        (call-interactively 'git-link))
-    (call-interactively 'git-link)))
-
-(defun spacemacs/git-link-commit ()
-  "Allow the user to run git-link-commit in a git-timemachine buffer."
-  (interactive)
-  (require 'git-link)
-  (if (and (boundp 'git-timemachine-revision)
-           git-timemachine-revision)
-      (cl-letf (((symbol-function 'word-at-point)
-                 (lambda ()
-                   (car git-timemachine-revision))))
-        (call-interactively 'git-link-commit))
     (call-interactively 'git-link-commit)))
 
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -77,7 +77,7 @@
     (progn
       (spacemacs/declare-prefix "gl" "links")
       (spacemacs/set-leader-keys
-        "gll" 'spacemacs/git-link
+        "gll" 'git-link
         "glL" 'spacemacs/git-link-copy-url-only
         "glp" 'spacemacs/git-permalink
         "glP" 'spacemacs/git-permalink-copy-url-only


### PR DESCRIPTION
Delete integration code for git-link and git-timemachine, which is superseded by upstream changes to git-link committed in August 2016: https://github.com/sshaw/git-link/commit/433ba1dba7d108f60fb4c8ee2c6a74ecf3ad9f7e

* `CHANGELOG.develop`: Add an entry for this change.
* `layers/+source-control/git/funcs.el` (`spacemacs/git-link-copy-url-only`): Replace call to `spacemacs/git-link` with a call to `git-link`.
(`spacemacs/git-link-commit-copy-url-only`): Replace call to `spacemacs/git-link-commit` with a call to `git-link-commit`.
(`spacemacs/git-link`, `spacemacs/git-link-commit`): Delete functions.
* `layers/+source-control/git/packages.el` (`git/init-git-link`): Replace binding to `spacemacs/git-link` with a binding to `git-link`.