### PR TITLE
[mercury-layer] Fix documentation for key bindings

### DIFF
--- a/layers/+lang/mercury-layer/README.org
+++ b/layers/+lang/mercury-layer/README.org
@@ -25,5 +25,5 @@ file.
 
 | Key Binding | Description                          |
 |-------------+--------------------------------------|
-| ~SPC c c~   | Compile current buffer file.         |
-| ~SPC c r~   | Compile and run current buffer file. |
+| ~SPC m c b~ | Compile current buffer file.         |
+| ~SPC m c r~ | Compile and run current buffer file. |


### PR DESCRIPTION
* `layers/+lang/mercury-layer/README.org`: Fix key bindings.

----

I noticed the discrepancy between `README.org` and `packages.el` in this layer while reviewing recent changes.  While I'm here, I'd like to ask, should the layer directory be renamed from "mercury-layer" to just "mercury"?