### PR TITLE
[shell] Simplify loading logic for eshell-z

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -139,13 +139,10 @@
 
 (defun shell/init-eshell-z ()
   (use-package eshell-z
-    :defer t
+    :after eshell
     :init
-    (progn
-      (setq eshell-z-freq-dir-hash-table-file-name
-            (concat spacemacs-cache-directory "eshell/.z"))
-      (with-eval-after-load 'eshell
-        (require 'eshell-z)))))
+    (setq eshell-z-freq-dir-hash-table-file-name
+          (concat spacemacs-cache-directory "eshell/.z"))))
 
 (defun shell/pre-init-helm ()
   (spacemacs|use-package-add-hook helm


### PR DESCRIPTION
* `layers/+tools/shell/packages.el` (`shell/init-eshell-z`): Replace use of `with-eval-after-load` by using use-package's `:after` keyword to load eshell-z when eshell is loaded.