### PR TITLE
[search-engine] Fix typo of "Hoogle" as "Hoggle"

### DIFF
--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -77,7 +77,7 @@
                :name "Npmjs"
                :url "https://www.npmjs.com/search?q=%s")
               (hoogle
-               :name "Hoggle 5"
+               :name "Hoogle 5"
                :url "https://hoogle.haskell.org/?hoogle=%s")
               (haskell-packages
                :name "Hackage Package Search"


### PR DESCRIPTION
* `layers/+web-services/search-engine/packages.el` (`search-engine/init-engine-mode`): Fix typo "Hoggle" for the name of the Hoogle search engine.