### PR TITLE
Update references to macOS

### DIFF
--- a/EXPERIMENTAL.org
+++ b/EXPERIMENTAL.org
@@ -7,7 +7,7 @@
     - [[#clone-emacs][Clone Emacs]]
     - [[#simple-patch-of-emacs-source-code][Simple patch of Emacs source code]]
     - [[#compile-emacs-from-source][Compile Emacs from source]]
-      - [[#macos][MacOS]]
+      - [[#macos][macOS]]
       - [[#ubuntu][Ubuntu]]
       - [[#windows][Windows]]
     - [[#install-emacs][Install Emacs]]
@@ -20,7 +20,7 @@
 
 * Spacemacs dumps using the portable dumper
 The portable dumper is a feature that will be available with Emacs 27. This new
-dumper should theoretically work on all the three major OSes: GNU/Linux, MacOS
+dumper should theoretically work on all the three major OSes: GNU/Linux, macOS
 and Windows.
 
 ** Setup
@@ -69,7 +69,7 @@ double the number of slots by replacing 32 with 64:
 This step depends on your OS (please create a PR to add the instructions for
 your OS).
 
-**** MacOS
+**** macOS
 In the root directory of your freshly cloned Emacs repository in the =master=
 branch as the current branch:
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This installs a pre-built package from https://emacsformacosx.com/
 
 If you're not comfortable with the ways mentioned above, then
 [EmacsWiki](https://www.emacswiki.org/emacs/EmacsForMacOS#toc12) lists down
-a few ways to install Emacs for Mac OS.
+a few ways to install Emacs for macOS.
 
 #### Install Source Code Pro font
 
@@ -380,7 +380,7 @@ lines in the `~/.emacs.d/init.el` file:
 For Ubuntu users, follow this guide to
 [change the logo in Unity][cpaulik-unity-icon].
 
-For Mac users, you need to [download the .icns version of the logo][icon-repository],
+For macOS users, you need to [download the .icns version of the logo][icon-repository],
 then [change the logo on the Dock][icon-mac-instructions].
 
 # Update

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -298,7 +298,7 @@ to boost the loading time.")
 
 (defvar dotspacemacs-fullscreen-use-non-native nil
   "If non nil `spacemacs/toggle-fullscreen' will not use native fullscreen. Use
-to disable fullscreen animations in OSX.")
+to disable fullscreen animations on macOS.")
 
 (defvar dotspacemacs-maximized-at-startup nil
   "If non nil the frame is maximized when Emacs starts up (Emacs 24.4+ only).

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -81,8 +81,8 @@ Transient states are generally put behin the dot key ~.~, for instance the
 windows manipulation transient state in ~SPC w .~.
 
 When it is not possible to use the ~.~ (like in =helm= buffers) transient states
-should be enabled with ~M-SPC~ and ~s-M-SPC~. We need the latter bindings on OS
-X since ~M-SPC~ is used by the OS for spotlight.
+should be enabled with ~M-SPC~ and ~s-M-SPC~. We need the latter bindings on
+macOS since ~M-SPC~ is used by the OS for spotlight.
 
 It is recommended to make sure that ~q~ allows to leave the transient-state.
 

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -3286,7 +3286,7 @@ The key bindings start with ~SPC x r~ and have the following mnemonic structure:
 *** Deleting files
 Deletion is configured to send deleted files to system trash.
 
-On OS X the =trash= program is required. It can be installed with [[https://brew.sh/][homebrew]] with
+On macOS the =trash= program is required. It can be installed with [[https://brew.sh/][homebrew]] with
 the following command:
 
 #+BEGIN_SRC sh
@@ -3520,15 +3520,15 @@ You can open a file in Emacs from the terminal using =emacsclient=. Use
 file in Emacs within the terminal. If you set Emacs server socket by setting =dotspacemacs-server-socket-dir=,
 then pass its location as =-s ~/.emacs.d/server/server= additionally.
 
-If you want your Linux/OS X system to use Emacs by default for any prompt, you
-need to set it in your shell configuration, e.g. =~/.bashrc= or =~/.zshrc=:
+If you want your Linux or macOS system to use Emacs by default for any prompt,
+you need to set it in your shell configuration, e.g. =~/.bashrc= or =~/.zshrc=:
 
 #+BEGIN_SRC sh-mode
   export EDITOR="emacsclient -c"
 #+END_SRC
 
-Note that if you're on OS X, you may have to refer to the emacsclient that comes
-with your GUI Emacs, e.g.:
+Note that if you're using macOS, you may have to refer to the emacsclient that
+comes with your GUI Emacs, e.g.:
 
 #+BEGIN_SRC sh-mode
   export EDITOR="/Applications/Emacs.app/Contents/MacOS/bin/emacsclient -c"

--- a/layers/+chat/erc/README.org
+++ b/layers/+chat/erc/README.org
@@ -7,7 +7,7 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#os-x][OS X]]
+  - [[#macos][macOS]]
   - [[#social-graph][Social graph]]
   - [[#disable-notifications][Disable notifications]]
   - [[#enable-sasl-authentication][Enable SASL authentication]]
@@ -38,9 +38,9 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =erc= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** OS X
+** macOS
 It's recommended to install the [[https://github.com/alloy/terminal-notifier][terminal-notifier gem]] so that you get
-notifications via the OS X Notification Center.
+notifications via the macOS Notification Center.
 
 ** Social graph
 [[https://github.com/vibhavp/erc-social-graph][erc-social-graph]] needs graphviz to be installed on your system.

--- a/layers/+distributions/spacemacs-docker/README.org
+++ b/layers/+distributions/spacemacs-docker/README.org
@@ -143,7 +143,7 @@ Or allow local connection from the container's host-name
 
 ** With Xpra on any of the OSes and via web-browser
 *** Pros
-- Xpra has a client for GNU/Linux, Windows and macOS + can work via web browser
+- Xpra has a client for GNU/Linux, Windows and macOS and can work via web browser
 - Persistent server (you can connect and disconnect without disrupting Emacs)
 - Interactive screen sharing [[https://imgur.com/ijdSuX6][demo]]
 - Read/write rss/email with Emacs in web-browser (O_O) [[https://imgur.com/wDLDMZN][demo]]

--- a/layers/+distributions/spacemacs-docker/README.org
+++ b/layers/+distributions/spacemacs-docker/README.org
@@ -8,7 +8,7 @@
 - [[#screenshots][Screenshots]]
 - [[#how-to-setup][How to setup]]
 - [[#how-to-use][How to use]]
-  - [[#macos][MacOS]]
+  - [[#macos][macOS]]
   - [[#windows][Windows]]
   - [[#gnulinux][GNU/Linux]]
   - [[#with-xpra-on-any-of-the-oses-and-via-web-browser][With Xpra on any of the OSes and via web-browser]]
@@ -26,7 +26,7 @@ with GUI support on all major platforms and even [[https://i.imgur.com/wDLDMZN.g
 
 ** Features:
 - Automatically get Spacemacs layers dependency installed with [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bdistributions/spacemacs-docker/deps-install/README.org][installer scripts]]
-- Reap the benefit of Emacs and other GNU/Linux tools on Windows/MacOS machines
+- Reap the benefit of Emacs and other GNU/Linux tools on Windows or macOS machines
 - Use [[https://hub.docker.com/][docker hub]] to auto-build your environment and store full backups for free
 - Build once and work with the same development environment everywhere
 - Run untrusted/risky code in the tunable sandbox with CPU/network/disk quotas
@@ -40,7 +40,7 @@ with GUI support on all major platforms and even [[https://i.imgur.com/wDLDMZN.g
 * Screenshots
 [[file:img/MAC_SP.jpg]]
 
-[[https://i.imgur.com/VcuqReF.jpg][HD MacOS image]]
+[[https://i.imgur.com/VcuqReF.jpg][HD macOS image]]
 
 [[file:img/LN_SP.jpg]]
 
@@ -62,7 +62,7 @@ With one of the methods below replace =spacemacs/develop= with your images.
 NOTE: The guide assumes that you want to run Docker and connect to it from
 the same machine.
 
-** MacOS
+** macOS
 Get [[https://www.xquartz.org][XQuartz]] and =open -a XQuartz= In the XQuartz preferences go to the "Security"
 tab and make sure you've got "Allow connections from network clients" ticked
 
@@ -143,7 +143,7 @@ Or allow local connection from the container's host-name
 
 ** With Xpra on any of the OSes and via web-browser
 *** Pros
-- Xpra has a client for GNU/Linux, Windows and MacOS + can work via web browser
+- Xpra has a client for GNU/Linux, Windows and macOS + can work via web browser
 - Persistent server (you can connect and disconnect without disrupting Emacs)
 - Interactive screen sharing [[https://imgur.com/ijdSuX6][demo]]
 - Read/write rss/email with Emacs in web-browser (O_O) [[https://imgur.com/wDLDMZN][demo]]

--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -39,7 +39,7 @@ In order to use this layer you must install =mu= and =mu4e= separately.
 Typically =mu4e= will be bundled with =mu= (this is the case on many Linux
 distributions).
 
-If you're on OS X and install =mu= using Homebrew, you must specify the
+If you're on macOS and install =mu= using Homebrew, you must specify the
 location of your Emacs binary at install time using the EMACS environment
 variable, as well as passing the =--with-emacs= option:
 
@@ -243,9 +243,9 @@ installed libraries:
     ;; Enable Desktop notifications
     (mu4e-alert-set-default-style 'notifications)) ; For linux
     ;; (mu4e-alert-set-default-style 'libnotify))  ; Alternative for linux
-    ;; (mu4e-alert-set-default-style 'notifier))   ; For Mac OSX (through the
+    ;; (mu4e-alert-set-default-style 'notifier))   ; For macOS (through the
                                                    ; terminal notifier app)
-    ;; (mu4e-alert-set-default-style 'growl))      ; Alternative for Mac OSX
+    ;; (mu4e-alert-set-default-style 'growl))      ; Alternative for macOS
 #+END_SRC
 
 *** Mode-line notifications

--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -241,11 +241,11 @@ installed libraries:
 #+BEGIN_SRC emacs-lisp
   (with-eval-after-load 'mu4e-alert
     ;; Enable Desktop notifications
-    (mu4e-alert-set-default-style 'notifications)) ; For linux
-    ;; (mu4e-alert-set-default-style 'libnotify))  ; Alternative for linux
+    (mu4e-alert-set-default-style 'notifications)) ; For Linux.
+    ;; (mu4e-alert-set-default-style 'libnotify))  ; Alternative for Linux
     ;; (mu4e-alert-set-default-style 'notifier))   ; For macOS (through the
-                                                   ; terminal notifier app)
-    ;; (mu4e-alert-set-default-style 'growl))      ; Alternative for macOS
+                                                   ; terminal notifier app).
+    ;; (mu4e-alert-set-default-style 'growl))      ; Alternative for macOS.
 #+END_SRC
 
 *** Mode-line notifications

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -164,7 +164,7 @@ many other commands.
 | ~oaa~       | Open current file or tag, using ace-window to decide which window to open the file in.                         |
 | ~oah~       | Open current file or tag by horizontally splitting a window selected by ace-window.                            |
 | ~oav~       | Open current file or tag by vertically splitting a window selected by ace-window.                              |
-| ~ox~        | Open current file according to its mime type in an external application. Linux, Windows and Mac are supported. |
+| ~ox~        | Open current file according to its mime type in an external application. Linux, Windows and macOS are supported. |
 | ~ta~        | Toggle ~treemacs-filewatch-mode~.                                                                              |
 | ~tf~        | Toggle ~treemacs-follow-mode~.                                                                                 |
 | ~th~        | Toggle the hiding and displaying of dotfiles.                                                                  |

--- a/layers/+fonts/unicode-fonts/README.org
+++ b/layers/+fonts/unicode-fonts/README.org
@@ -14,7 +14,7 @@ install the fonts listed in the [[https://github.com/rolandwalker/unicode-fonts#
 ** Features:
 - Display unicode glyphs using the best available font.
 - Easily override glyphs or sections of glyphs.
-- Display color emoji on both the Mac port version of Emacs and emacs-plus (with
+- Display color emoji on both the macOS port version of Emacs and emacs-plus (with
   =unicode-fonts-force-multi-color-on-mac= set to non nil).
 
 * Install

--- a/layers/+fonts/unicode-fonts/config.el
+++ b/layers/+fonts/unicode-fonts/config.el
@@ -13,4 +13,4 @@
   "If non nil unicode-fonts will enable multi-color fonts (emoji)
   on macs. This should only be set when using the multi-color
   patch as emacs-plus does. It is unnecessary to set this when
-  using the Mac port version.")
+  using the macOS port version.")

--- a/layers/+fun/emoji/funcs.el
+++ b/layers/+fun/emoji/funcs.el
@@ -10,7 +10,7 @@
 ;;; License: GPLv3
 
 ;; From https://github.com/dunn/company-emoji/README.md for Linux, or on
-;; Mac OS X and using the Cocoa version of Emacs
+;; macOS and using the Cocoa version of Emacs
 (defun spacemacs//set-emoji-font (frame)
   "Adjust the font settings of FRAME so Emacs can display emoji properly."
   (when (fboundp 'set-fontset-font)

--- a/layers/+intl/chinese/README.org
+++ b/layers/+intl/chinese/README.org
@@ -16,7 +16,7 @@
     - [[#enable-fcitx][Enable fcitx]]
       - [[#requirement][Requirement]]
         - [[#linux][Linux]]
-        - [[#mac-os-x][Mac OS X]]
+        - [[#macos][macOS]]
         - [[#windows][Windows]]
     - [[#enable-youdao-有道-dictionary-激活有道字典][Enable YouDao (有道) Dictionary (激活有道字典)]]
     - [[#set-monospaced-font-size-设置等宽字体][Set monospaced font size (设置等宽字体)]]
@@ -111,8 +111,8 @@ It's recommended to use the dbus interface to speed up =fcitx= a little:
 
 But notice that [[https://github.com/cute-jumper/fcitx.el/issues/30][this may lead to command lag]].
 
-***** Mac OS X
-We don't have a =fcitx= in OS X yet but we already added an emulation called
+***** macOS
+We don't have a =fcitx= in macOS yet but we already added an emulation called
 =fcitx-remote= to make you happy with other Chinese input-methods.
 
 You can install [[https://github.com/CodeFalling/fcitx-remote-for-osx][fcitx-remote-for-osx]] from homebrew.
@@ -152,8 +152,8 @@ your own Chinese font name in =dotspacemacs/user-config= function.
 Example configuration:
 
 #+BEGIN_SRC emacs-lisp
-  ;; Note: The Hiragino Sans GB is bundled with MacOS X.
-  ;; If you are not using MacOS X, you should change it to another Chinese font name.
+  ;; Note: The Hiragino Sans GB is bundled with macOS.
+  ;; If you are not using macOS, you should change it to another Chinese font name.
   (spacemacs//set-monospaced-font   "Source Code Pro" "Hiragino Sans GB" 14 16)
 #+END_SRC
 

--- a/layers/+intl/chinese/config.el
+++ b/layers/+intl/chinese/config.el
@@ -36,6 +36,6 @@
 
 ;; If the Hiragino Sans GB font is not found in your system, you could call this
 ;; method in dotspacemacs/user-config function with a different Chinese font name.
-;; If you are using mac, you could put the following code in your dotspacemacs/user-config function.
+;; If you are using macOS, you could put the following code in your dotspacemacs/user-config function.
 ;; (when (spacemacs/system-is-mac)
 ;;   (spacemacs//set-monospaced-font "Source Code Pro" "Hiragino Sans GB" 14 16))

--- a/layers/+intl/japanese/README.org
+++ b/layers/+intl/japanese/README.org
@@ -47,7 +47,7 @@ By default, the variable ~evil-tutor-working-ja-directory~ is assigned =~/.emacs
 
 *** migemo
 By default, the variable ~migemo-dictionary~ is assigned
-~/usr/local/share/migemo/utf-8/migemo-dict~ in MacOS, or ~/usr/local/cmigemo/utf-8/migemo-dict~ in linux.
+~/usr/local/share/migemo/utf-8/migemo-dict~ in macOS, or ~/usr/local/cmigemo/utf-8/migemo-dict~ in linux.
 If you want it to be another directory, you must re-set the variable.
 For example, if you install [[https://www.kaoriya.net/software/cmigemo/][C/Migemo for Windows 64bit]] in the directory ~c:\app\cmigemo-default-win64~, you should add:
 

--- a/layers/+intl/japanese/README.org
+++ b/layers/+intl/japanese/README.org
@@ -40,30 +40,30 @@ add =japanese= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 ** Configuration
-For a basic configuration, add this to your =~/.spacemacs= inside ~dotspacemacs/user-config~:
+For a basic configuration, add this to your =~/.spacemacs= inside =dotspacemacs/user-config=:
 
 *** evil-tutor-ja
-By default, the variable ~evil-tutor-working-ja-directory~ is assigned =~/.emacs.d/.tutor-ja=.
+By default, the variable =evil-tutor-working-ja-directory= is assigned =~/.emacs.d/.tutor-ja=.
 
 *** migemo
-By default, the variable ~migemo-dictionary~ is assigned
-~/usr/local/share/migemo/utf-8/migemo-dict~ in macOS, or ~/usr/local/cmigemo/utf-8/migemo-dict~ in linux.
+By default, the variable =migemo-dictionary= is assigned
+=/usr/local/share/migemo/utf-8/migemo-dict= in macOS, or =/usr/local/cmigemo/utf-8/migemo-dict= in Linux.
 If you want it to be another directory, you must re-set the variable.
-For example, if you install [[https://www.kaoriya.net/software/cmigemo/][C/Migemo for Windows 64bit]] in the directory ~c:\app\cmigemo-default-win64~, you should add:
+For example, if you install [[https://www.kaoriya.net/software/cmigemo/][C/Migemo for Windows 64bit]] in the directory =c:\app\cmigemo-default-win64=, you should add:
 
 #+BEGIN_SRC emacs-lisp
   (with-eval-after-load "migemo"
     (setq migemo-dictionary "c:/app/cmigemo-default-win64/dict/utf-8/migemo-dict"))
 #+END_SRC
 
-inside ~dotspacemacs/user-config~, or
+inside =dotspacemacs/user-config=, or
 
 #+begin_src emacs-lisp
   (japanese :variables
             migemo-dictionary "c:/app/cmigemo-default-win64/dict/utf-8/migemo-dict")
 #+end_src
 
-inside ~dotspacemacs-configuration-layers~.
+inside =dotspacemacs-configuration-layers=.
 
 *** helm-with-migemo
 If you want to use helm with migemo, you should add:
@@ -73,22 +73,22 @@ If you want to use helm with migemo, you should add:
     (helm-migemo-mode 1))
 #+END_SRC
 
-inside ~dotspacemacs/user-config~, or
+inside =dotspacemacs/user-config=, or
 
 #+begin_src emacs-lisp
   (japanese :variables
              helm-migemo-mode 1)
 #+end_src
 
-inside ~dotspacemacs-configuration-layers~. Note that you may find in a package called
-~helm-migemo.el~ in MELPA. However, this package is deprecated and not supported
+inside =dotspacemacs-configuration-layers=. Note that you may find in a package called
+=helm-migemo.el= in MELPA. However, this package is deprecated and not supported
 by helm.
 
 *** avy-migemo
-Note that ~avy-migemo~ in MELPA does not work
-currently, so you had better use a [[https://github.com/tam17aki/avy-migemo][forked version]] alternatively.
+Note that =avy-migemo= in MELPA does not work
+currently, so you had better use a [[https://github.com/tam17aki/avy-migemo][forked version]] instead.
 
-By default, you can use ~avy-migemo~ for ~helm-mode~. For ~ivy-mode~, you should add:
+By default, you can use =avy-migemo= for =helm-mode=. For =ivy-mode=, you should add:
 
 #+BEGIN_SRC emacs-lisp
   (with-eval-after-load "migemo"
@@ -97,21 +97,21 @@ By default, you can use ~avy-migemo~ for ~helm-mode~. For ~ivy-mode~, you should
     (require 'avy-migemo-e.g.counsel))
 #+END_SRC
 
-inside ~dotspacemacs/user-config~.
+inside =dotspacemacs/user-config=.
 
 *** ddskk
-You can write a configuration file ~​~/.skk~. For detailed configuration, see
+You can write a configuration file =​~/.skk=. For detailed configuration, see
 some [[https://skk-dev.github.io/ddskk/skk.html][documents]].
 
 *** pangu-spacing
-By default, ~pangu-spacing-mode~ is applied to ~text-mode~. If you prefer the
+By default, =pangu-spacing-mode= is applied to =text-mode=. If you prefer the
 mode globally, add:
 
 #+BEGIN_SRC emacs-lisp
   (global-pangu-spacing-mode 1)
 #+END_SRC
 
-inside ~dotspacemacs/user-config~.
+inside =dotspacemacs/user-config=.
 
 * Key bindings
-By default, ~C-x j~ toggles ~skk-mode~.
+By default, ~C-x j~ toggles =skk-mode=.

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -130,7 +130,7 @@ indexing large code bases.
 - Completion with =company-lsp=
 - Semantic highlighting
 - See more on [[https://github.com/cquery-project/cquery/wiki/Emacs]]
-- Cross-platform - functional on Windows, Linux and OSX.
+- Cross-platform - functional on Windows, Linux and macOS.
 
 **** External dependencies
 Install one (or both) of the following:

--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -37,7 +37,7 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =coq= to the existing =dotspacemacs-configuration-layers= list in this file.
 
 ** Coq
-Official installers for MacOS and Windows are available from:
+Official installers for macOS and Windows are available from:
 [[https://coq.inria.fr/download]].
 
 Linux users can build from source or consult with their own package managers.

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -10,7 +10,7 @@
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#elm-platform][Elm Platform]]
-    - [[#os-x-and-windows-installers][OS X and Windows installers]]
+    - [[#macos-and-windows-installers][macOS and Windows installers]]
     - [[#universal-installer-using-npm][Universal installer using npm]]
     - [[#source-code][Source code]]
   - [[#elm-oracle][elm-oracle]]
@@ -63,7 +63,7 @@ The =elm-platform= is a bundle of tools, including the =elm-compiler=,
 Depending on the method of installation, the =elm-mode= package would need to be
 able to access commands such as =elm-reactor= or =elm-make=.
 
-*** OS X and Windows installers
+*** macOS and Windows installers
 Official installers for these operating systems are available from:
 [[https://guide.elm-lang.org/install.html][https://guide.elm-lang.org/install.html]]
 
@@ -81,7 +81,7 @@ the corresponding directory created by the installer.
 If you are facing problems with previewing a buffer with =elm-reactor= ensure
 that the absolute path of the npm global bin file is on your path within emacs
 
-OS X Users facing problems with =elm-reactor= failing to properly install or
+MacOS users facing problems with =elm-reactor= failing to properly install or
 run, see this issue [[https://github.com/kevva/elm-bin/issues/28][https://github.com/kevva/elm-bin/issues/28]].
 
 *** Source code

--- a/layers/+lang/racket/README.org
+++ b/layers/+lang/racket/README.org
@@ -102,4 +102,4 @@ When enabled the symbol =🆂= should be displayed in the mode-line.
 | Key binding | Description                                                                     |
 |-------------+---------------------------------------------------------------------------------|
 | ~SPC m i l~ | Insert lambda character                                                         |
-| ~H-r~       | Run current file and open REPL (=H= is hyper, *may* be bound to command on OSX) |
+| ~H-r~       | Run current file and open REPL (=H= is hyper, *may* be bound to command on macOS) |

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -137,7 +137,7 @@ You will then have the common LSP key bindings; see [[http://develop.spacemacs.o
 provided by Flycheck.
 
 To use scalastyle, it must be present as an executable in your =PATH=.
-- OSX users: =brew install scalastyle=
+- macOS users: =brew install scalastyle=
 - Linux, please see [[http://www.scalastyle.org/command-line.html]]
 
 To test if =scalastyle= executable is in your path, run =scalastyle= in a new

--- a/layers/+lang/swift/README.org
+++ b/layers/+lang/swift/README.org
@@ -27,7 +27,7 @@ general purpose scripting language.
 * Install
 First check that you are able to run this from the command line:
 
-On OS X:
+On macOS:
 
 #+BEGIN_SRC sh
   xcrun swift

--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -11,14 +11,14 @@
 - [[#install][Install]]
   - [[#layer][Layer]]
     - [[#use-with-non-us-keyboard-layouts][Use with non-US keyboard layouts]]
-    - [[#define-words-using-os-x-dictionary][Define words using OS X Dictionary]]
+    - [[#define-words-using-macos-dictionary][Define words using macOS Dictionary]]
   - [[#coreutils][Coreutils]]
 - [[#key-bindings][Key bindings]]
 - [[#future-work][Future Work]]
 
 * Description
-Spacemacs is not just emacs+vim. It can have OSX key bindings too! This layer
-globally defines common OSX key bindings.
+Spacemacs is not just emacs+vim. It can have macOS key bindings too! This layer
+globally defines common macOS key bindings.
 
 ** Features:
 - ~⌘~ is set to ~hyper~ and ~⌥~ is set to ~meta~
@@ -26,7 +26,7 @@ globally defines common OSX key bindings.
 - Fix separator colors of Spaceline mode-line
 
 * Philosophy
-While this layer enables common OSX bindings, it does not implement OSX
+While this layer enables common macOS bindings, it does not implement macOS
 navigation key bindings. Spacemacs is meant to be used with evil, and we
 encourage you to do so :)
 
@@ -78,8 +78,8 @@ key.
                      osx-right-option-as 'none)))
 #+END_SRC
 
-*** Define words using OS X Dictionary
-This layer by default enables defining words under point ~SPC x w d~ using OS X
+*** Define words using macOS Dictionary
+This layer by default enables defining words under point ~SPC x w d~ using macOS
 Dictionary. In some cases you might want to manually setup dictionary to use.
 For example,
 
@@ -128,4 +128,4 @@ To get =gls= install coreutils homebrew:
 * Future Work
 - Allow user to choose from either ~hyper~ or ~super~ as ~⌘~. This is an option
   that is supported cross-platform.
-- Configurable option to keep the OSX and spacemacs clipboards separate
+- Configurable option to keep the macOS and Spacemacs clipboards separate.

--- a/layers/+os/osx/README.org
+++ b/layers/+os/osx/README.org
@@ -17,8 +17,8 @@
 - [[#future-work][Future Work]]
 
 * Description
-Spacemacs is not just emacs+vim. It can have macOS key bindings too! This layer
-globally defines common macOS key bindings.
+Spacemacs is not just Emacs plus Vim. It can have macOS key bindings too! This
+layer globally defines common macOS key bindings.
 
 ** Features:
 - ~⌘~ is set to ~hyper~ and ~⌥~ is set to ~meta~
@@ -27,7 +27,7 @@ globally defines common macOS key bindings.
 
 * Philosophy
 While this layer enables common macOS bindings, it does not implement macOS
-navigation key bindings. Spacemacs is meant to be used with evil, and we
+navigation key bindings. Spacemacs is meant to be used with Evil, and we
 encourage you to do so :)
 
 * Install

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -18,7 +18,7 @@
 
 (defvar osx-command-as 'hyper
   "Sets the key binding of the `COMMAND' key on macOS.
-   Possible values are `super' `meta' `hyper' `alt' `none'.
+   Possible values are `super', `meta', `hyper', `alt', and `none'.
    Default: `hyper'.")
 ;; There are problems setting osx-command-as to `alt' and `super',
 ;; so we use `hyper' as a default instead because, for example:
@@ -58,7 +58,7 @@
    Default: `left'.")
 
 (defvar osx-use-dictionary-app t
-  "If non nil use macOS dictionary app instead of wordnet")
+  "Use the macOS dictionary app instead of Wordnet.")
 
 (defvar osx-swap-option-and-command nil
   "If non nil swap option key and command key")

--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -17,7 +17,7 @@
    Default: `deprecated'")
 
 (defvar osx-command-as 'hyper
-  "Sets the key binding of the `COMMAND' key on OSX.
+  "Sets the key binding of the `COMMAND' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `none'.
    Default: `hyper'.")
 ;; There are problems setting osx-command-as to `alt' and `super',
@@ -26,44 +26,44 @@
 ;;   - Using `super': Control-Command-f produces keycode: <C-s-268632078>
 ;; Setting to `hyper' seems to avoid both types of the above problems.
 ;; Also, while it is possible, it is not recommended to set to `meta'
-;; since standard OSX shortcuts would overshadow important keys such
+;; since standard macOS shortcuts would overshadow important keys such
 ;; as M-x.
 
 (defvar osx-option-as 'meta
-  "Sets the key binding of the `OPTION' key on OSX.
+  "Sets the key binding of the `OPTION' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `none'.
    Default: `meta'.
    For backwards compatibility the variable `osx-use-option-as-meta'
    takes precedence is set to t.")
 (defvar osx-function-as nil
-  "Sets the key binding of the `FUNCTION' key on OSX.
+  "Sets the key binding of the `FUNCTION' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `nil'.
    Default: `nil'.")
 (defvar osx-control-as 'control
-  "Sets the key binding of the `CONTROL' key on OSX.
+  "Sets the key binding of the `CONTROL' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `none'.
    Default: `control'.")
 
 (defvar osx-right-control-as 'left
-  "Sets the key binding of the `RIGHT CONTROL' key on OSX.
+  "Sets the key binding of the `RIGHT CONTROL' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `left' `none'.
    Default: `left'.")
 (defvar osx-right-command-as 'left
-  "Sets the key binding of the `RIGHT COMMAND' key on OSX.
+  "Sets the key binding of the `RIGHT COMMAND' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `left' `none'.
    Default: `left'.")
 (defvar osx-right-option-as 'left
-  "Sets the key binding of the `RIGHT OPTION' key on OSX.
+  "Sets the key binding of the `RIGHT OPTION' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `left' `none'.
    Default: `left'.")
 
 (defvar osx-use-dictionary-app t
-  "If non nil use osx dictionary app instead of wordnet")
+  "If non nil use macOS dictionary app instead of wordnet")
 
 (defvar osx-swap-option-and-command nil
   "If non nil swap option key and command key")
 
-;; Use the OS X Emoji font for Emoticons
+;; Use the macOS Emoji font for Emoticons.
 (when (fboundp 'set-fontset-font)
   (set-fontset-font "fontset-default"
                     '(#x1F600 . #x1F64F)

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -49,14 +49,17 @@
     (cl-rotatef mac-command-modifier mac-option-modifier))
 
   (defun kbd-mac-command (keys)
-    "Wraps `kbd' function with macOS compatible Command-key (⌘).
-KEYS should be a string such as \"f\" which will be turned into values
-such as \"H-f\", \"s-f\", or \"A-f\" depending on the value of
-`mac-commmand-modifier' which could be `hyper', `super', or `alt'.
-KEYS with a string of \"C-f\" are also valid and will be turned into
-values such as \"H-C-f\".
-if `mac-command-modifier' is set to `none' or something other than
-the three sane values listed above, bind to `H-' by default"
+    "Call `kbd' with a macOS-compatible Command-key (⌘) prefixed.
+KEYS should be a string suitable as input to `kbd'.
+`mac-commmand-modifier' determines which prefix will be added; it
+should be set to one of `hyper', `super', or `alt'.  For example,
+if KEYS is the string `f', it will be prefixed as `H-f', `s-f',
+or `A-f' accordingly.  If KEYS is of the form `C-f', it likewise
+will be prefixed as `H-C-f', `s-C-f', or `A-C-f'.
+
+If `mac-command-modifier' is set to `none' or something other
+than the three values listed above, `H-' will be used as the
+default."
     (let ((found (assoc mac-command-modifier
                         '((hyper . "H-")
                           (super . "s-")

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -49,7 +49,7 @@
     (cl-rotatef mac-command-modifier mac-option-modifier))
 
   (defun kbd-mac-command (keys)
-    "Wraps `kbd' function with Mac OSX compatible Command-key (⌘).
+    "Wraps `kbd' function with macOS compatible Command-key (⌘).
 KEYS should be a string such as \"f\" which will be turned into values
 such as \"H-f\", \"s-f\", or \"A-f\" depending on the value of
 `mac-commmand-modifier' which could be `hyper', `super', or `alt'.

--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -23,7 +23,7 @@
 
 (when (spacemacs/system-is-mac)
   ;; Enable built-in trash support via finder API if available (only on Emacs
-  ;; Mac Port)
+  ;; macOS Port)
   (when (boundp 'mac-system-move-file-to-trash-use-finder)
     (setq mac-system-move-file-to-trash-use-finder t)))
 

--- a/layers/+readers/dash/README.org
+++ b/layers/+readers/dash/README.org
@@ -18,13 +18,13 @@
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer integrates offline api browsers into Emacs. It provides one for macOS, Linux and Windows.
+This layer integrates offline API browsers into Emacs. It provides one for macOS, Linux and Windows.
 
 ** Features:
-- Searching for word at point in offline api browser's UI.
-- Integration of offline api browser search results in helm and ivy.
-- Support for [[https://kapeli.com/dash][dash]] offline api browser for macOS.
-- Support for [[https://zealdocs.org/][zeal]] offline api browser for Linux.
+- Searching for word at point in offline API browser's UI.
+- Integration of offline API browser search results in Helm and Ivy.
+- Support for [[https://kapeli.com/dash][dash]] offline API browser for macOS.
+- Support for [[https://zealdocs.org/][zeal]] offline API browser for Linux.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -62,7 +62,7 @@ To change the location of the installed docsets, set:
 #+END_SRC
 
 * Word at point
-=dash-at-point= and =zeal-at-point= will search for the word at point in the respective offline api browser.
+=dash-at-point= and =zeal-at-point= will search for the word at point in the respective offline API browser.
 The result will be displayed in the offline browser's UI.
 
 However having to leave emacs to have a look at the search results may be a bit awkward.

--- a/layers/+readers/dash/README.org
+++ b/layers/+readers/dash/README.org
@@ -10,7 +10,7 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
-  - [[#dash-os-x][Dash (OS X)]]
+  - [[#dash-macos][Dash (macOS)]]
     - [[#sqlite3][Sqlite3]]
   - [[#zeal-linux--windows][Zeal (Linux & Windows)]]
 - [[#configuration][Configuration]]
@@ -18,12 +18,12 @@
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer integrates offline api browsers into Emacs. It provides one for OS X, Linux and Windows.
+This layer integrates offline api browsers into Emacs. It provides one for macOS, Linux and Windows.
 
 ** Features:
 - Searching for word at point in offline api browser's UI.
 - Integration of offline api browser search results in helm and ivy.
-- Support for [[https://kapeli.com/dash][dash]] offline api browser for OS X.
+- Support for [[https://kapeli.com/dash][dash]] offline api browser for macOS.
 - Support for [[https://zealdocs.org/][zeal]] offline api browser for Linux.
 
 * Install
@@ -31,7 +31,7 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =dash= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** Dash (OS X)
+** Dash (macOS)
 You have to install [[https://kapeli.com/dash][dash]] on your machine.
 
 It is recommended to set the =HUD mode= in your Dash application preferences

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -39,7 +39,7 @@ According to the official repository:
 * Install
 ** Prerequisites
 Linux is the only operating system officially supported, but it's possible to
-use =pdf-tools= on OS X as well, and possibly on other Unix flavors.
+use =pdf-tools= on macOS as well, and possibly on other Unix flavors.
 
 You'll need to install a few libraries. Check the [[https://github.com/politza/pdf-tools#server-prerequisites][instructions]] on
 =pdf-tools= page. Note that compiling from source might not be necessary, as

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -83,7 +83,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 
 ;; Use system trash for file deletion
 ;; should work on Windows and Linux distros
-;; on OS X, see contrib/osx layer
+;; on macOS, see contrib/osx layer
 (setq delete-by-moving-to-trash t)
 
 ;; auto fill breaks line beyond buffer's fill-column

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -81,9 +81,9 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Text
 (setq longlines-show-hard-newlines t)
 
-;; Use system trash for file deletion
-;; should work on Windows and Linux distros
-;; on macOS, see contrib/osx layer
+;; Use system trash for file deletion.
+;; This should work on Windows and Linux distros.
+;; For macOS, see the osx layer.
 (setq delete-by-moving-to-trash t)
 
 ;; auto fill breaks line beyond buffer's fill-column

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1013,8 +1013,9 @@ toggling fullscreen."
      (when (not (frame-parameter nil 'fullscreen)) 'fullscreen)))))
 
 (defun spacemacs/toggle-frame-fullscreen-non-native ()
-  "Toggle full screen non-natively. Uses the `fullboth' frame paramerter
-rather than `fullscreen'. Useful to fullscreen on macOS w/o animations."
+  "Toggle full screen using the `fullboth' frame parameter.
+Using the `fullboth' frame parameter rather than `fullscreen' is
+useful to use full screen on macOS without animations."
   (interactive)
   (modify-frame-parameters
    nil

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1014,7 +1014,7 @@ toggling fullscreen."
 
 (defun spacemacs/toggle-frame-fullscreen-non-native ()
   "Toggle full screen non-natively. Uses the `fullboth' frame paramerter
-rather than `fullscreen'. Useful to fullscreen on OSX w/o animations."
+rather than `fullscreen'. Useful to fullscreen on macOS w/o animations."
   (interactive)
   (modify-frame-parameters
    nil

--- a/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
+++ b/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
@@ -619,7 +619,7 @@ Candidates include `jump-to-frame-config-register' and `show-buffer-menu'."
 
 ;; Use `cond', not `case', for Emacs 20 byte-compiler.
 (defcustom window-mgr-title-bar-pixel-height (cond ((eq window-system 'mac) 22)
-                                                   ;; For older versions of OS X, 40 might be better.
+                                                   ;; For older versions of macOS, 40 might be better.
 						   ((eq window-system 'ns)  50)
 						   (t  27))
   "*Height of frame title bar provided by the window manager, in pixels.
@@ -1470,7 +1470,7 @@ the pixel width and height of the rectangle."
   (- (frame-pixel-height frame) (* (frame-char-height frame) (frame-height frame))))
 
 (defun frcmds-smart-tool-bar-pixel-height (&optional frame)
-  "Pixel height of Mac smart tool bar."
+  "Pixel height of macOS smart tool bar."
   (if (and (boundp 'mac-tool-bar-display-mode)  (> (frame-parameter frame 'tool-bar-lines) 0))
       (if (eq mac-tool-bar-display-mode 'icons) 40 56)
     0))
@@ -1512,7 +1512,7 @@ the pixel width and height of the rectangle."
   "Returns a value of the same form as option `available-screen-pixel-bounds'.
 This represents the currently available screen area."
   (or available-screen-pixel-bounds     ; Use the option value, if available.
-      (if (fboundp 'mac-display-available-pixel-bounds) ; Mac-OS-specific.
+      (if (fboundp 'mac-display-available-pixel-bounds) ; macOS-specific.
           (mac-display-available-pixel-bounds)
         (list 0 0 (x-display-pixel-width) (x-display-pixel-height)))))
 

--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -8,7 +8,7 @@
 - [[#install][Install]]
   - [[#gnu-global-gtags][GNU Global (gtags)]]
     - [[#install-on-ubuntu][Install on Ubuntu]]
-    - [[#install-on-osx-using-homebrew][Install on OSX using Homebrew]]
+    - [[#install-on-macos-using-homebrew][Install on macOS using Homebrew]]
     - [[#install-on-nix-from-source][Install on *nix from source]]
       - [[#install-recommended-dependencies][Install recommended dependencies]]
       - [[#install-with-recommended-features][Install with recommended features]]
@@ -64,7 +64,7 @@ recommend installing from source.
   sudo apt-get install global
 #+END_SRC
 
-*** Install on OSX using Homebrew
+*** Install on macOS using Homebrew
 #+BEGIN_SRC sh
   brew install global --with-pygments --with-ctags
 #+END_SRC

--- a/layers/+tools/chrome/README.org
+++ b/layers/+tools/chrome/README.org
@@ -61,7 +61,7 @@ If you want Emacs to switch focus to Chrome after done editing, you can utilize
 Emacs cannot control focus of windows for external apps, so you need to use some
 sort of command line window manager like =wmctrl=.
 
-The following example works on OS X:
+The following example works on macOS:
 
 #+BEGIN_SRC emacs-lisp
   (add-hook 'edit-server-done-hook (lambda () (shell-command "open -a \"Google Chrome\"")))

--- a/layers/+tools/fasd/README.org
+++ b/layers/+tools/fasd/README.org
@@ -28,7 +28,7 @@ file.
 [[https://github.com/clvv/fasd][fasd]] must be installed on your system. The general installation
 instructions can be found in the repository [[https://github.com/clvv/fasd#install][README]]
 
-On OS X, it can be installed via [[https://github.com/Homebrew/legacy-homebrew][homebrew]]:
+On macOS, it can be installed via [[https://github.com/Homebrew/legacy-homebrew][homebrew]]:
 
 #+BEGIN_SRC sh
   $ brew install fasd

--- a/layers/+tools/geolocation/README.org
+++ b/layers/+tools/geolocation/README.org
@@ -8,7 +8,7 @@
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#location][Location]]
-  - [[#osx-location][OSX-location]]
+  - [[#macos-location][macOS Location]]
   - [[#theme-changer][Theme-changer]]
   - [[#sunshine-weather-forecast][Sunshine (weather forecast)]]
 - [[#key-bindings][Key bindings]]
@@ -21,7 +21,7 @@ This layer offers location sensitive adjustments to Emacs.
 - Supports the following adjustments:
   - Automatic switching between light (day) and dark (night) themes via [[https://github.com/hadronzoo/theme-changer][theme-changer]]
   - Local weather forecast via [[https://github.com/aaronbieber/sunshine.el/blob/master/sunshine.el][sunshine]]
-  - Integration with OS X's CoreLocation service via [[https://github.com/purcell/osx-location][osx-location]]
+  - Integration with macOS's CoreLocation service via [[https://github.com/purcell/osx-location][osx-location]]
   - Manual location setting via variables in your dotfile
 
 * Install
@@ -49,8 +49,8 @@ Set location manually by setting the following variables in your dotfile:
         calendar-longitude 1.80)
 #+END_SRC
 
-** OSX-location
-Mac users can take adavantage of automatic geogrphical discovery using the OS's
+** macOS Location
+MacOS users can take advantage of automatic geographical discovery using the OS's
 CoreLocation system service, implemented as a long running background process.
 In order to enable it, set =geolocation-enable-location-service= to =t= as
 explained in installation instructions.

--- a/layers/+tools/geolocation/config.el
+++ b/layers/+tools/geolocation/config.el
@@ -13,7 +13,7 @@
   "If non nil enable the automatic change of theme based on the current time.")
 
 (defvar geolocation-enable-location-service nil
-  "If non nil enable the OS X location service support.")
+  "If non nil enable the macOS location service support.")
 
 (defvar geolocation-enable-weather-forecast nil
   "If non nil enable the weather forecast service.")

--- a/layers/+tools/geolocation/packages.el
+++ b/layers/+tools/geolocation/packages.el
@@ -68,7 +68,7 @@ to not have to set these variables manually when enabling this layer."
         (kbd "q") 'quit-window
         (kbd "i") 'sunshine-toggle-icons)
 
-      ;; just in case location was not set by user, or on OS X,
+      ;; just in case location was not set by user, or on macOS,
       ;; if wasn't set up automatically, will not work with Emacs'
       ;; default for `calendar-location-name'
       (unless (boundp 'sunshine-location)

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -11,11 +11,11 @@
   - [[#install-vterm][Install vterm]]
     - [[#check-that-your-emacs-supports-dynamic-modules][Check that your Emacs supports dynamic modules]]
     - [[#install-cmake-311-or-higher][Install CMake 3.11 or higher]]
-      - [[#macos][MacOS]]
+      - [[#macos][macOS]]
     - [[#install-libtool][Install libtool]]
       - [[#ubuntu][Ubuntu]]
     - [[#install-libvterm][Install libvterm]]
-      - [[#macos-1][MacOS]]
+      - [[#macos-1][macOS]]
       - [[#ubuntu-1][Ubuntu]]
       - [[#windows][Windows]]
 - [[#configuration][Configuration]]
@@ -60,7 +60,7 @@ not, you need to get a version of Emacs that supports it or compile it from
 source supplying the =./configure --with-module= option at configure time.
 
 *** Install CMake 3.11 or higher
-**** MacOS
+**** macOS
 #+BEGIN_SRC shell
 brew install cmake
 #+END_SRC
@@ -74,7 +74,7 @@ sudo apt install libtool-bin
 #+END_SRC
 
 *** Install libvterm
-**** MacOS
+**** macOS
 #+BEGIN_SRC shell
 brew install libvterm
 #+END_SRC

--- a/layers/+tools/xclipboard/README.org
+++ b/layers/+tools/xclipboard/README.org
@@ -16,18 +16,18 @@
 ** Features:
 - adds copy support to the X-clipboard from the terminal.
 - adds paste support to the X-clipboard from the terminal.
-- [[https://github.com/redguardtoo/cliphist][cliphist]] package: integration with clipboard managers on Linux and Mac.
+- [[https://github.com/redguardtoo/cliphist][cliphist]] package: integration with clipboard managers on Linux and macOS.
 
 * Requirements
 This layer depends on a few platform-specific command-line tools:
-- on OSX, this layer calls =pbcopy=
+- on macOS, this layer calls =pbcopy=
 - on Windows, this layer calls =clip.exe=
 - on GNU/Linux systems, this layer relies on =xsel= to be available.
 
 Note that =xsel= might not be installed by default on e.g. Ubuntu systems.
 
 Clipboard manager integration requires [[http://parcellite.sourceforge.net/][Parcellite]] or [[https://github.com/CristianHenzel/ClipIt][ClipIt]] installed on Linux
-and [[https://github.com/TermiT/Flycut][Flycut]] installed on MacOS.
+and [[https://github.com/TermiT/Flycut][Flycut]] installed on macOS.
 
 * Usage
 ** Clipboard Manager Integration

--- a/layers/+tools/xclipboard/local/spacemacs-xclipboard/spacemacs-xclipboard.el
+++ b/layers/+tools/xclipboard/local/spacemacs-xclipboard/spacemacs-xclipboard.el
@@ -29,7 +29,7 @@
       type \"$command\" >/dev/null 2>&1
     }
 
-    # Installing reattach-to-user-namespace is recommended on OS X
+    # Installing reattach-to-user-namespace is recommended on macOS.
     if command_exists \"pbcopy\"; then
         if command_exists \"reattach-to-user-namespace\"; then
             printf \"reattach-to-user-namespace pbcopy\"
@@ -51,7 +51,7 @@
       type \"$command\" >/dev/null 2>&1
     }
 
-    # Installing reattach-to-user-namespace is recommended on OS X
+    # Installing reattach-to-user-namespace is recommended on macOS.
     if command_exists \"pbpaste\"; then
         if command_exists \"reattach-to-user-namespace\"; then
             printf \"reattach-to-user-namespace pbpaste\"


### PR DESCRIPTION
Apple renamed "Mac OS X" to "OS X" in 2012 and then to "macOS" in 2016.  Update references to use the current name.

#### Various documentation copy-edits

Follow up the changes in the previous commit with some minor improvements to formatting, grammar, spelling, and wording.