### PR TITLE
Add conda layer (to work with anaconda environments)

### DIFF
--- a/layers/+lang/conda/README.org
+++ b/layers/+lang/conda/README.org
@@ -1,0 +1,22 @@
+#+TITLE: Conda Layer
+
+#+TAGS: layer|programming|util
+
+* Description
+This layer integrates [[https://github.com/necaris/conda.el][conda.el]] with Spacemacs's UI, placing shortcuts to its
+functions under =SPC a= (applications). =conda.el= allows users to interact with
+Anaconda and Miniconda environments from Emacs -- this is not the same
+as =anaconda-mode=, which provides IDE-like features for Python.
+
+* Install
+To add this layer to Spacemacs, add =conda= to your
+=dotspacemacs-configuration-layers= list, then set the variable =conda-anaconda-home= to
+the path to your installation of anaconda.
+
+* Keybindings
+| Key Binding | Description                                                       |
+| ~SPC a e A~ | Toggle automatic activation of environments                       |
+| ~SPC a e a~ | Open a =helm= buffer to select an environment                     |
+| ~SPC a e b~ | Activate environment for buffer based on =conda-project-env-name= |
+| ~SPC a e d~ | Deactivate current environment                                    |
+| ~SPC a e l~ | Open a help buffer that lists envs                                |

--- a/layers/+lang/conda/packages.el
+++ b/layers/+lang/conda/packages.el
@@ -1,0 +1,35 @@
+;;; packages.el --- Conda Layer packages File for Spacemacs
+;;
+;; Copyright (C) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Zach Pearson <zach@zjp.codes>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq conda-packages
+	  '(
+		conda
+		))
+
+(defun conda/init-conda ()
+  (use-package conda
+	:defer t
+	:commands (
+			   conda-env-list
+			   conda-env-activate
+			   conda-env-deactivate
+			   conda-env-autoactivate-mode
+			   conda-env-activate-for-buffer
+               )
+	:init
+	(progn
+	  (spacemacs/set-leader-keys
+		"ael" 'conda-env-list
+		"aea" 'conda-env-activate
+		"aed" 'conda-env-deactivate
+		"aeA" 'conda-env-autoactivate-mode
+		"aeb" 'conda-env-activate-for-buffer)
+	  (spacemacs/declare-prefix "ae" "Python conda environments"))))


### PR DESCRIPTION
This is a simple commit based on the existing ipython-notebook layer that provides a way to interact with conda.el through Spacemacs's UI 