### PR TITLE
Add a way to start an EIN Jupyter server from Spacemacs's UI

### DIFF
--- a/layers/+lang/ipython-notebook/README.org
+++ b/layers/+lang/ipython-notebook/README.org
@@ -69,7 +69,8 @@ Have an IPython notebook running
 * Using the IPython notebook
 ** Open Notebook List
 This layer is lazy loaded so the transient-state will only work after you summon the
-command =ein:notebooklist-open= which is bound to ~SPC a y o~
+command =ein:notebooklist-open= which is bound to ~SPC a y o~ or =ein:run= which is
+bound to ~SPC a y r~.
 
 ** Key bindings
 The key bindings can be used through a transient state or the usual evil-leader.

--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -24,12 +24,14 @@
 (defun ipython-notebook/init-ein ()
   (use-package ein
     :defer t
-    :commands (ein:notebooklist-open ein:notebooklist-login)
+    :commands (ein:notebooklist-open ein:notebooklist-login ein:run ein:stop)
     :init
     (progn
       (spacemacs/set-leader-keys
         "ayl" 'ein:notebooklist-login
-        "ayo" 'ein:notebooklist-open)
+        "ayo" 'ein:notebooklist-open
+        "ayr" 'ein:run
+        "ays" 'ein:stop)
       (spacemacs/declare-prefix "ay" "ipython notebook")
       (with-eval-after-load 'ein-notebooklist
         (evilified-state-evilify-map ein:notebooklist-mode-map


### PR DESCRIPTION
As far as I can tell the current EIN interactions available from Spacemacs's applications tray are limited to interacting with existing Jupyter sessions in some way, but EIN actually provides a way to start and stop Jupyter servers from within Emacs. This provides that functionality through Spacemacs's UI, preventing users from having to manually M-x ein:{run,stop}. 