### PR TITLE
Add available formatters to typescript readme

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2884,7 +2884,7 @@ Other:
   Thijs Vermeir, Tim Stewart, timor, TinySong, Titov Andrey, Thomas de
   Beauchêne, Tomasz Cichocinski, Trey Merkley, tzhao11, Vincent Taing, Vlad
   Bokov, Vladimir Kochnev, Wieland Hoffmann, Witoslaw Koczewski, Xiang Ji, Yi
-  Liu, Zane Sterling, zer09, Zhige Xin, Serghei Iakovlev)
+  Liu, Zane Sterling, zer09, Zhige Xin, Serghei Iakovlev, Aleksandr Argunov)
 **** Documentation and website
   - Updated DOCUMENTATION.org to fix the example for how to change the separator style
   - README.md:

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -61,7 +61,7 @@ You can choose formatting tool:
                 typescript-fmt-tool 'typescript-formatter)))
 #+END_SRC
 
-Default is ='tide=.
+Available formatters: ='tide= (default), ='prettier=, ='typescript-formatter=.
 
 You can choose either tslint (default) or eslint for linting:
 


### PR DESCRIPTION
Add available formatters to typescript readme. It's better UX to have it listed in README