### PR TITLE
tags-table-mode should be in spacemacs-large-file-modes-list

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1070,6 +1070,8 @@ Other:
     - ~SPC j c~ to =goto-last-change=
   - Excluded =fundamental-mode= from =spacemacs/check-large-file=
     (thanks to Alexander Miller)
+  - Excluded =tags-table-mode= from =spacemacs/check-large-file=
+    (thanks to Hong Xu)
   - Fixed copied dir/path not shown in minibuffer when =select-enable-clipboard=
     is =nil= (thanks to duianto)
   - Used return value from advised function in =spacemacs//yank-indent-region=

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -89,7 +89,7 @@ Only modes that don't derive from `prog-mode' should be listed here."
 (defcustom spacemacs-large-file-modes-list
   '(archive-mode tar-mode jka-compr git-commit-mode image-mode
                  doc-view-mode doc-view-mode-maybe ebrowse-tree-mode
-                 pdf-view-mode fundamental-mode)
+                 pdf-view-mode tags-table-mode fundamental-mode)
   "Major modes which `spacemacs/check-large-file' will not be
 automatically applied to."
   :group 'spacemacs


### PR DESCRIPTION
It is light-weight and it is common that tags are large.