### PR TITLE
Fix C-k in company with tooltip

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1137,6 +1137,7 @@ Other:
 - Key bindings:
   - Removed ~C-f~ because it interfered with the default key binding for
     =forward-char= (thanks to scturtle and duianto)
+  - Fixed ~C-k~ in company with tooltip (thanks to duianto)
 **** Autohotkey
 - Key bindings:
   - Added names to autohotkey mode prefixes (thanks to Ying Qu)

--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -294,8 +294,14 @@ MODE parameter must match the :modes values used in the call to
       (define-key map (kbd "C-j") 'company-select-next)
       (define-key map (kbd "C-k") 'company-select-previous)
       (define-key map (kbd "C-l") 'company-complete-selection))
-    (when (require 'company-quickhelp nil 'noerror)
-      (evil-define-key 'insert company-quickhelp-mode-map (kbd "C-k") 'company-select-previous)))
+    ;; Fix company-quickhelp Evil C-k
+    (defun spacemacs//set-C-k-company-select-previous (&rest args)
+      (define-key evil-insert-state-map (kbd "C-k") 'company-select-previous))
+    (defun spacemacs//restore-C-k-evil-insert-digraph (&rest args)
+      (define-key evil-insert-state-map (kbd "C-k") 'evil-insert-digraph))
+    (add-hook 'company-completion-started-hook 'spacemacs//set-C-k-company-select-previous)
+    (add-hook 'company-completion-finished-hook 'spacemacs//restore-C-k-evil-insert-digraph)
+    (add-hook 'company-completion-cancelled-hook 'spacemacs//restore-C-k-evil-insert-digraph))
    (t
     (let ((map company-active-map))
       (define-key map (kbd "C-n") 'company-select-next)


### PR DESCRIPTION
Got the idea for the fix from this comment:
https://github.com/expez/company-quickhelp/issues/17#issuecomment-526783169

I simplified it to only un/define C-k, since C-j worked without the fix.

Fixes #2974