### PR TITLE
Fix GNU Global install instructions for macOS

### DIFF
--- a/layers/+tags/gtags/README.org
+++ b/layers/+tags/gtags/README.org
@@ -66,7 +66,7 @@ recommend installing from source.
 
 *** Install on macOS using Homebrew
 #+BEGIN_SRC sh
-  brew install global --with-pygments --with-ctags
+  brew install global
 #+END_SRC
 
 *** Install on *nix from source


### PR DESCRIPTION
Original command throws error. Previously optional features are now enabled by default.