### PR TITLE
Document helm and ivy color key bindings

### DIFF
--- a/layers/+completion/helm/README.org
+++ b/layers/+completion/helm/README.org
@@ -19,6 +19,7 @@
   - [[#hjkl-navigation][hjkl navigation]]
   - [[#transient-state][Transient state]]
   - [[#bookmarks][Bookmarks]]
+  - [[#colorsfaces][Colors/Faces]]
   - [[#c-z-and-tab-switch][C-z and Tab switch]]
   - [[#helm-focus][Helm focus]]
   - [[#helm-swoop][Helm-swoop]]
@@ -179,6 +180,13 @@ In the =helm-bookmarks= buffer:
 | ~C-e~       | edit the selected bookmark                   |
 | ~C-f~       | toggle filename location                     |
 | ~C-o~       | open the selected bookmark in another window |
+
+** Colors/Faces
+
+| Key binding | Description            |
+|-------------+------------------------|
+| ~SPC C l~   | =helm-colors=          |
+| ~SPC h d F~ | =spacemacs/helm-faces= |
 
 ** C-z and Tab switch
 The command bound to ~C-z~ is much more useful than the one bound to Tab, so it

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -11,6 +11,7 @@
   - [[#advanced-buffer-information][Advanced buffer information]]
 - [[#key-bindings][Key bindings]]
   - [[#transient-state][Transient state]]
+  - [[#colorsfaces][Colors/Faces]]
 
 * Description
 This layer enables Ivy for completion. It will replace the default completion by
@@ -98,3 +99,12 @@ Press ~M-SPC~ anytime in Ivy to get into the transient state.
 | ~d~         | call default action on candidate                        |
 | ~g~         | the same as ~d~ but doesn't close completion minibuffer |
 | ~o~         | leave transient state                                   |
+
+** Colors/Faces
+
+| Key binding | Description             |
+|-------------+-------------------------|
+| ~SPC C e~   | =counsel-colors-emacs=  |
+| ~SPC C f~   | =counsel-colors-faces=  |
+| ~SPC C w~   | =counsel-colors-web=    |
+| ~SPC h d F~ | =counsel-describe-face= |


### PR DESCRIPTION
Helm:
`SPC C l`   calls `helm-colors`
`SPC h d F` calls `spacemacs/helm-faces`

Ivy:
`SPC C e`   calls `counsel-colors-emacs`
`SPC C f`   calls `counsel-colors-faces`
`SPC C w`   calls `counsel-colors-web`
`SPC h d F` calls `counsel-describe-face`

Thanks Miciah for the `SPC h d F` suggestion.