### PR TITLE
Support relative virtualenv path in .venv file for Python layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2423,6 +2423,7 @@ Other:
   (thanks to Boris Verhovsky)
 - Fixed conflict between pipenv directory .venv and pyvenv file .venv
   (thanks to rgb-24bit)
+- Support relative path in pyvenv file .venv (thanks to Nam Nguyen)
 - Added diminish for importmagic (thanks to Loys Ollivier)
 - Added debugger integration via =dap= layer
 - Added documentation on installing importmagic and epc (thanks to Trapez Breen)

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -350,7 +350,10 @@ the pyenv version. The behavior can be set with the variable
 - =on-project-switch= set the version when you switch projects,
 - =nil= to disable.
 
-The same is also possible on pyvenv with a file called =.venv=. The behavior
+The same is also possible on pyvenv with a file called =.venv= that specifies
+either an absolute or relative path to a virtualenv directory. A relative path
+is checked relative to the location of =.venv=, then relative to
+=pyvenv-workon-home=. =.venv= can also be a virtualenv directory. The behavior
 can be set with the variable =python-auto-set-local-pyvenv-virtualenv= to:
 - =on-visit= (default) set the virtualenv when you visit a python buffer,
 - =on-project-switch= set the virtualenv when you switch projects,


### PR DESCRIPTION
Specifying a relative path in a .venv file did not work properly because it was relative to the current directory. Relative path should be relative to the detected .venv file. 

Manually tested all four cases:
1. .venv virtualenv directory in project root
2. .venv text file containing absolute path to virtualenv directory
3. .venv text file containing path to virtualenv directory relative to project root
4. .venv text file containing path to virtualenv directory relative to `pyvenv-workon-home()` which is ~/.virtualenvs/ by default (See https://github.com/jorgenschaefer/pyvenv/blob/master/pyvenv.el)

Also updated README.org for python layer.