### PR TITLE
Set counsel-find-file-at-point to t by default.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -952,6 +952,8 @@ Other:
     - Switch to Project Perspective and Show Recent Files
     - Switch to Project Perspective and Search
     (thanks to Gia Thanh Vuong)
+  - Set =counsel-find-file-at-point= to =t= to enable better auto completion
+    of =counsel-find-file= (thanks to Hong Xu)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -139,7 +139,10 @@
       ;; TODO Commands to port
       (spacemacs//ivy-command-not-implemented-yet "jI")
       ;; Set syntax highlighting for counsel search results
-      (ivy-set-display-transformer 'spacemacs/counsel-search 'counsel-git-grep-transformer))))
+      (ivy-set-display-transformer 'spacemacs/counsel-search 'counsel-git-grep-transformer)
+
+      ;; Enable better auto completion of counsel-find-file by recognizing file at point.
+      (setq counsel-find-file-at-point t))))
 
 (defun ivy/pre-init-counsel-projectile ()
   ;; overwrite projectile settings


### PR DESCRIPTION
This enables better auto completion of =counsel-find-file=.