### PR TITLE
Keep ~C-h~ binding in =counsel-find-map= only for hjkl navigation

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1870,6 +1870,8 @@ Other:
   of =counsel-find-file= (thanks to Hong Xu)
 - Fixed broken =ivy-occur= (thanks to Carlos Ibáñez)
 - Fixed =counsel-git-grep= with input ~SPC s g P~ (thanks to Carlos Ibáñez)
+- Keep ~C-h~ binding in =counsel-find-map= only for hjkl navigation (thanks to
+  Hong Xu)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -131,7 +131,6 @@
        'counsel-find-file
        spacemacs--ivy-file-actions)
 
-      (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory)
       (define-key read-expression-map (kbd "C-r") 'counsel-minibuffer-history)
       ;; remaps built-in commands that have a counsel replacement
       (counsel-mode 1)

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -199,6 +199,7 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
                        ivy-switch-buffer-map))
       (define-key map (kbd "C-j") 'ivy-next-line)
       (define-key map (kbd "C-k") 'ivy-previous-line))
+    (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory)
     (define-key ivy-minibuffer-map (kbd "C-h") (kbd "DEL"))
     ;; Move C-h to C-S-h
     (define-key ivy-minibuffer-map (kbd "C-S-h") help-map)


### PR DESCRIPTION
It has already been bound to <kbd>C-backspace</kbd> and <kbd>C-delete</kbd>. Such an
additional binding is redundant (if hjkl navigation is not used) and makes the original <kbd>C-h</kbd> binding
(help) unavailable.