### PR TITLE
[spacemacs/sudo-edit] Fix sudo-edit on TRAMP & [spacemacs/counsel-search] Fix wrong initial directory

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -169,10 +169,10 @@ that directory."
                                   spacemacs--counsel-search-max-path-length)
                                (length default-directory))))))
     (cond ((string= tool "ag")
-           (counsel-ag initial-input initial-directory nil
+           (counsel-ag initial-input default-directory nil
                        (format "ag from [%s]: " display-directory)))
           ((string= tool "rg")
-           (counsel-rg initial-input initial-directory nil
+           (counsel-rg initial-input default-directory nil
                        (format "rg from [%s]: " display-directory)))
           (t
            (ivy-read

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -512,19 +512,30 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
        (with-parsed-tramp-file-name fname parsed
          (when (equal parsed-user "root")
            (error "Already root!"))
-         (let* ((new-hop (tramp-make-tramp-file-name parsed-method
-                                                     parsed-user
-                                                     parsed-host
-                                                     nil
-                                                     parsed-hop
-                                                     ))
+         (let* ((new-hop (tramp-make-tramp-file-name
+                          ;; Try to retrieve a tramp method suitable for
+                          ;; multi-hopping
+                          (cond ((tramp-get-method-parameter
+                                  parsed 'tramp-login-program))
+                                ((tramp-get-method-parameter
+                                  parsed 'tramp-copy-program))
+                                (t parsed-method))
+                          parsed-user
+                          parsed-domain
+                          parsed-host
+                          parsed-port
+                          nil
+                          parsed-hop))
                 (new-hop (substring new-hop 1 -1))
                 (new-hop (concat new-hop "|"))
-                (new-fname (tramp-make-tramp-file-name "sudo"
-                                                       "root"
-                                                       parsed-host
-                                                       parsed-localname
-                                                       new-hop)))
+                (new-fname (tramp-make-tramp-file-name
+                            "sudo"
+                            parsed-user
+                            parsed-domain
+                            parsed-host
+                            parsed-port
+                            parsed-localname
+                            new-hop)))
            new-fname))))))
 
 ;; check when opening large files - literal file open


### PR DESCRIPTION
Hi!

Here's a pull request fixing #11329

Btw, the indentation was changed in the second tramp-make-tramp-file-name for consistency with the first tramp-make-tramp-file-name.