### PR TITLE
Add visual line navigation keys, up and down

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -843,6 +843,9 @@ Other:
     - ~SPC l w S~ =spacemacs/single-win-workspace=
   - Added ~SPC t C-S-l~ =spacemacs/toggle-visual-line-navigation-globally=
     (thanks to Matt Kramer)
+  - Added visual-line-navigation keys (thanks to duianto)
+    - ~up~ =evil-previous-visual-line=
+    - ~down~ =evil-next-visual-line=
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -537,7 +537,9 @@ a dedicated window."
 
 (defun spacemacs//init-visual-line-keys ()
   (evil-define-minor-mode-key 'motion 'visual-line-mode "j" 'evil-next-visual-line)
-  (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line))
+  (evil-define-minor-mode-key 'motion 'visual-line-mode "k" 'evil-previous-visual-line)
+  (evil-define-minor-mode-key 'motion 'visual-line-mode (kbd "<down>") 'evil-next-visual-line)
+  (evil-define-minor-mode-key 'motion 'visual-line-mode (kbd "<up>") 'evil-previous-visual-line))
 
 
 ;; Copy file path


### PR DESCRIPTION
`up`   `evil-previous-visual-line`
`down` `evil-next-visual-line`

Fixes: #6616

This enables the `up` and `down` arrow keys to navigate by visual lines,
when visual line navigation (`SPC t L`) is enabled.

I removed the evil-escape related code, because they don't seem to be relevant any more as discussed in this comment: https://github.com/syl20bnr/spacemacs/pull/11417#issuecomment-491545005
It seems to work fine without it.

---

I tried to use a dolist to reduce the line duplication, but I don't understand how it's supposed to work.
Here's some WIP.
```elisp
    (dolist (key-command '(("j" 'evil-next-visual-line)
                           ("k" 'evil-previous-visual-line)
                           ("<down>" 'evil-next-visual-line)
                           ("<up>" 'evil-previous-visual-line)))
                           ;; ((kbd "<down>") 'evil-next-visual-line)
                           ;; ((kbd "<up>") 'evil-previous-visual-line)))
                           ;; ('(kbd "<down>") 'evil-next-visual-line)
                           ;; ('(kbd "<up>") 'evil-previous-visual-line)))
     (message "%s, %s" (car key-command) (cadr key-command))
     (evil-define-minor-mode-key 'motion 'visual-line-mode
       (kbd (car key-command)) (cadr key-command))
       ;; (car key-command) (cadr key-command))
     )
```