### PR TITLE
Fix ediprolog error message in prolog layer

### DIFF
--- a/layers/+lang/prolog/packages.el
+++ b/layers/+lang/prolog/packages.el
@@ -61,7 +61,6 @@
 
 (defun prolog/init-ediprolog ()
   (use-package ediprolog
-    :hook prolog-mode
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'prolog-mode


### PR DESCRIPTION
No need for hook.