### PR TITLE
lsp layer must depend on yasnippet

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -11,7 +11,7 @@
 
 (defconst lsp-packages
   '(
-    lsp-mode
+    (lsp-mode :requires yasnippet)
     lsp-ui
     (company-lsp :requires company)
     (helm-lsp :requires helm)


### PR DESCRIPTION
- if this line is missing yasnippets might not be loaded because lsp-mode might
load the snippets before the auto-completion layer kick in.

