### PR TITLE
Optimize =spacemacs/counsel-search= for =ag= and =rg=

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1877,6 +1877,7 @@ Other:
 - Fixed =counsel-git-grep= with input ~SPC s g P~ (thanks to Carlos Ibáñez)
 - Keep ~C-h~ binding in =counsel-find-file-map= only for hjkl navigation
   (thanks to Hong Xu)
+- Optimize =spacemacs/counsel-search= for =ag= and =rg= (thanks to Hong Xu)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -1,6 +1,6 @@
 ;;; funcs.el --- Ivy Layer functions File for Spacemacs
 ;;
-;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -158,28 +158,37 @@ that directory."
                       (throw 'tool tool)))
                   (throw 'tool "grep")))
           (default-directory
-            (or initial-directory (read-directory-name "Start from directory: "))))
-    (ivy-read
-     (format "%s from [%s]: "
-             tool
-             (if (< (length default-directory)
-                    spacemacs--counsel-search-max-path-length)
-                 default-directory
-               (concat
-                "..." (substring default-directory
-                                 (- (length default-directory)
-                                    spacemacs--counsel-search-max-path-length)
-                                 (length default-directory)))))
-     (spacemacs//make-counsel-search-function tool)
-     :initial-input (when initial-input (rxt-quote-pcre initial-input))
-     :dynamic-collection t
-     :history 'counsel-git-grep-history
-     :action #'counsel-git-grep-action
-     :caller 'spacemacs/counsel-search
-     :keymap spacemacs--counsel-map
-     :unwind (lambda ()
-               (counsel-delete-process)
-               (swiper--cleanup)))))
+            (or initial-directory (read-directory-name "Start from directory: ")))
+          (display-directory
+           (if (< (length default-directory)
+                  spacemacs--counsel-search-max-path-length)
+               default-directory
+             (concat
+              "..." (substring default-directory
+                               (- (length default-directory)
+                                  spacemacs--counsel-search-max-path-length)
+                               (length default-directory))))))
+    (cond ((eq tool "ag")
+           (counsel-ag initial-input initial-directory nil
+                       (format "ag from [%s]: " display-directory)))
+          ((eq tool "rg")
+           (counsel-rg initial-input initial-directory nil
+                       (format "rg from [%s]: " display-directory)))
+          (t
+           (ivy-read
+            (format "%s from [%s]: "
+                    tool
+                    display-directory)
+            (spacemacs//make-counsel-search-function tool)
+            :initial-input (when initial-input (rxt-quote-pcre initial-input))
+            :dynamic-collection t
+            :history 'counsel-git-grep-history
+            :action #'counsel-git-grep-action
+            :caller 'spacemacs/counsel-search
+            :keymap spacemacs--counsel-map
+            :unwind (lambda ()
+                      (counsel-delete-process)
+                      (swiper--cleanup)))))))
 
 ;; Define search functions for each tool
 (cl-loop


### PR DESCRIPTION
Use =counsel-ag= and =counsel-rg= when possible. They have more
optimizations, such as switching directory, the ability to turn on and off casefold, etc. Counsel will also carry
future improvement with these two functions, and spacemacs will
automatically benefit from it.