### PR TITLE
[julia] Limit evil-surround redefinitions to julia-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1974,6 +1974,8 @@ Other:
 - Fixes:
   - Loaded =lsp-julia= from melpa (thanks to Guido Kraemer)
   - Fixed =julia-mode-local-vars-hook= (thanks to Guido Kraemer)
+  - Limited =evil-surround-pairs-alist= redefinitions to julia mode
+    (thanks to duianto)
 **** Keyboard layout
 - Added support for Colemak layout (thanks to Daniel Mijares, Lyall Cooper and
   Eivind Fonn)

--- a/layers/+lang/julia/packages.el
+++ b/layers/+lang/julia/packages.el
@@ -88,11 +88,16 @@
 
 
 (defun julia/post-init-evil-surround ()
-  (with-eval-after-load 'evil-surround
-    (add-to-list 'evil-surround-pairs-alist '(?b . ("begin " . " end")))
-    (add-to-list 'evil-surround-pairs-alist '(?q . ("quote " . " end")))
-    (add-to-list 'evil-surround-pairs-alist '(?: . (":("     .    ")")))
-    (add-to-list 'evil-surround-pairs-alist '(?l . ("let "   . " end")))))
+  (use-package evil-surround
+    :config
+    (progn
+      (add-hook
+       'julia-mode-hook
+       #'(lambda ()
+           (add-to-list 'evil-surround-pairs-alist '(?b . ("begin " . " end")))
+           (add-to-list 'evil-surround-pairs-alist '(?q . ("quote " . " end")))
+           (add-to-list 'evil-surround-pairs-alist '(?: . (":("     .    ")")))
+           (add-to-list 'evil-surround-pairs-alist '(?l . ("let "   . " end"))))))))
 
 (defun julia/init-lsp-julia ()
   (use-package lsp-julia


### PR DESCRIPTION
```
problem:  The julia layer redefines evil-surround `b` globally to:
          begin <x> end
solution: Limit the redefinition to julia-mode buffers.
```
---

The issue seems to only occur the first time a file is opened.

For example if the scratch buffer is opened: `SPC b s`
and one types: `abc`
and surrounds it with the evil-surround "key" `b`: `ysiwb`
result: `begin abc end`
expected: `(abc)`

If one now opens `.spacemacs`: `SPC f e d`
then the steps above results in: `(abc)`

The reverse also happens, if `.spacemacs` is opened first, and then the scratch buffer.
then `.spacemacs` shows: `begin abc end`
and the scratch buffer: `(abc)`

After `b` has started surrounding with parentheses, then it also happens in `.jl` julia-mode buffers.
So it wasn't working as expected.