### PR TITLE
 [python] fixes spacemacs/python-remove-unused-imports

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -182,8 +182,10 @@ as the pyenv version then also return nil. This works around https://github.com/
 
 ;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
 (defun spacemacs/python-remove-unused-imports()
-  "Use Autoflake to remove unused function"
-  "autoflake --remove-all-unused-imports -i unused_imports.py"
+  "Use Autoflake to remove unused function
+
+Example:
+autoflake --remove-all-unused-imports -i unused_imports.py"
   (interactive)
   (if (executable-find "autoflake")
     (progn


### PR DESCRIPTION
problem: `spacemacs/python-remove-unused-imports` has multiple docstrings. Any call to this function fails.

This pr fixes that.