### PR TITLE
Replaced obsolete function doom-modeline-init

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1091,6 +1091,8 @@ Other:
     move & rename, just move and just rename (thanks to duianto)
   - Fixed =spacemacs/rename-current-buffer-file= handle same new and old name
     (thanks to duianto)
+  - Replaced obsolete function =doom-modeline-init= with =doom-modeline-mode=
+    (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -35,7 +35,7 @@
   (use-package doom-modeline
     :defer t
     :if (eq (spacemacs/get-mode-line-theme-name) 'doom)
-    :init (doom-modeline-init)))
+    :init (doom-modeline-mode)))
 
 (defun spacemacs-modeline/init-fancy-battery ()
   (use-package fancy-battery


### PR DESCRIPTION
doom-modeline-init was marked as obsolete in version: 1.6.0.
Add new mode: doom-modeline-mode.
seagle0128/doom-modeline@868f1bb

The doom-modeline package is currently at version: 2.6.2.