### PR TITLE
Use string= instead of eq when comparing strings.

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -168,10 +168,10 @@ that directory."
                                (- (length default-directory)
                                   spacemacs--counsel-search-max-path-length)
                                (length default-directory))))))
-    (cond ((eq tool "ag")
+    (cond ((string= tool "ag")
            (counsel-ag initial-input initial-directory nil
                        (format "ag from [%s]: " display-directory)))
-          ((eq tool "rg")
+          ((string= tool "rg")
            (counsel-rg initial-input initial-directory nil
                        (format "rg from [%s]: " display-directory)))
           (t


### PR DESCRIPTION
This is a follow-up of #12885, in which I used the wrong operator.

Sorry about the error