### PR TITLE
[core] [helm] add action to recompile an elpa package

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -278,6 +278,15 @@ result, incrementing passed-tests and total-tests."
      (directory-files-recursively user-emacs-directory "\\.elc$" t)))
   (byte-recompile-directory package-user-dir 0 arg))
 
+(defun spacemacs//recompile-dir (dir)
+  "Recompile all files inside this `dir'."
+  (seq-do
+   (lambda (fname)
+     (when (file-exists-p fname)
+       (delete-file fname)))
+   (directory-files-recursively dir "\\.elc$" t))
+  (byte-recompile-directory dir 0 arg))
+
 (defun spacemacs/register-repl (feature repl-func &optional tag)
   "Register REPL-FUNC to the global list of REPLs SPACEMACS-REPL-LIST.
 FEATURE will be loaded before running the REPL, in case it is not already

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -210,7 +210,9 @@
     (action . (("Go to configuration function"
                 . helm-spacemacs-help//package-action-goto-config-func)
                ("Describe"
-                . helm-spacemacs-help//package-action-describe)))))
+                . helm-spacemacs-help//package-action-describe)
+               ("Recompile"
+                . helm-spacemacs-help//package-action-recompile)))))
 
 (defun helm-spacemacs-help//package-candidates ()
   "Return the sorted candidates for package source."
@@ -336,6 +338,21 @@
     (string-match "^\\(.+\\)\s(\\(.+\\) layer)$" candidate)
     (let* ((package (match-string 1 candidate)))
       (configuration-layer/describe-package (intern package)))))
+
+(defun helm-spacemacs-help//package-action-recompile (candidate)
+  "Recompile the passed package."
+  (save-match-data
+    (string-match "^\\(.+\\)\s(\\(.+\\) layer)$" candidate)
+    (let* ((package (match-string 1 candidate))
+           (package-dir
+            (condition-case nil
+                ;; when package not found this throw error
+                (configuration-layer//get-package-directory
+                 (intern package))
+              (error nil))))
+      (if package-dir
+          (spacemacs//recompile-dir package-dir)
+        (message "Package not installed or its location not found")))))
 
 (defun helm-spacemacs-help//package-action-goto-config-func (candidate)
   "Open the file `packages.el' and go to the init function."


### PR DESCRIPTION
How to use: `SCP h p` select package then `F3` or `C-z` and choose `Recompile`

Motivation: Some packages when compiling need other packages to be loaded first.
The pacakage maintainers should make sure of this requirement but sommetimes
they don't. It also doesn't help when Spacemacs is lazy loading and compiles
updated pacakges on startup. So the manual fix for this problem is recompile the
package once Spacemacs has fully loaded. This requires user go to the package
install location to delete elc files and then do a `spacemacs/recompile-elpa`.
This commit will do that chore for them.

This will make fixing the problem with `org-plus-contrib` or `dumb-jump` update
every now and then easier.