### PR TITLE
Transient states wording etc

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -131,13 +131,13 @@
       - [[#joining-and-splitting][Joining and splitting]]
     - [[#window-manipulation][Window manipulation]]
       - [[#window-manipulation-key-bindings][Window manipulation key bindings]]
-      - [[#window-manipulation-transient-state][Window manipulation transient state]]
+      - [[#window-transient-state][Window transient state]]
       - [[#golden-ratio][Golden ratio]]
     - [[#buffers-and-files][Buffers and Files]]
       - [[#buffers-manipulation-key-bindings][Buffers manipulation key bindings]]
       - [[#create-a-new-empty-buffer][Create a new empty buffer]]
-      - [[#buffers-manipulation-transient-state][Buffers manipulation transient state]]
-      - [[#files-manipulations-key-bindings][Files manipulations key bindings]]
+      - [[#buffers-transient-state][Buffers transient state]]
+      - [[#file-manipulation-key-bindings][File manipulation key bindings]]
       - [[#frame-manipulation-key-bindings][Frame manipulation key bindings]]
       - [[#emacs-and-spacemacs-files][Emacs and Spacemacs files]]
       - [[#browsing-files-in-completion-buffer][Browsing files in completion buffer]]
@@ -164,7 +164,7 @@
     - [[#listing-symbols-by-semantic][Listing symbols by semantic]]
   - [[#editing][Editing]]
     - [[#paste-text][Paste text]]
-      - [[#paste-transient-state][Paste Transient-state]]
+      - [[#paste-transient-state][Paste transient state]]
       - [[#auto-indent-pasted-text][Auto-indent pasted text]]
     - [[#text-manipulation-commands][Text manipulation commands]]
     - [[#text-insertion-commands][Text insertion commands]]
@@ -2347,10 +2347,9 @@ define your own deletion function:
   (setq spacemacs-window-split-delete-function 'my-delete-other-windows)
 #+END_SRC
 
-**** Window manipulation transient state
-A convenient window manipulation transient state allows performing most of the
-actions listed above. The transient state allows additional actions as well like
-window resizing.
+**** Window transient state
+A convenient window transient state allows for performing most of the actions
+listed above. For example window resizing.
 
 | Key binding     | Description                                                   |
 |-----------------+---------------------------------------------------------------|
@@ -2450,9 +2449,9 @@ Buffer manipulation commands (start with ~b~):
 | ~SPC b N l~   | create new empty buffer in a new window below                                                   |
 | ~SPC b N n~   | create new empty buffer in current window                                                       |
 
-**** Buffers manipulation transient state
-A convenient buffer manipulation transient state allows to quickly cycles through
-the opened buffer and kill them.
+**** Buffers transient state
+A convenient buffer transient state allows for quickly cycling through the
+open buffers and closing them.
 
 | Key binding            | Description                                                                                |
 |------------------------+--------------------------------------------------------------------------------------------|
@@ -2467,6 +2466,7 @@ the opened buffer and kill them.
 | ~N~ or ~p~ or ~<left>~ | go to previous buffer (avoid buffers matching =spacemacs-useless-buffers-regexp=)          |
 | ~o~                    | switch focus to other window                                                               |
 | ~z~                    | recenter buffer in window                                                                  |
+| ~q~                    | quit transient state                                                                       |
 
 Unlike vim, emacs creates many buffers that most people do not need to see. Some
 examples are the =*Messages*= and =*Compile-Log*= buffers. Spacemacs tries to
@@ -2474,8 +2474,8 @@ automatically ignore buffers that are not useful. However, you may want to
 change the way Spacemacs marks buffers as useful. For instructions, see the
 [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/FAQ.org#change-special-buffer-rules][special buffer howto]].
 
-**** Files manipulations key bindings
-Files manipulation commands (start with ~f~):
+**** File manipulation key bindings
+File manipulation commands (start with ~f~):
 
 | Key binding | Description                                                                                            |
 |-------------+--------------------------------------------------------------------------------------------------------|
@@ -2905,7 +2905,7 @@ To list all the symbols of a buffer press ~SPC s j~
 
 ** Editing
 *** Paste text
-**** Paste Transient-state
+**** Paste transient state
 The paste transient state can be enabled by setting the variable
 =dotspacemacs-enable-paste-transient-state= to =t=. By default it is disabled.
 

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -21,7 +21,7 @@
       (pdf-tools-install)
 
       (spacemacs|define-transient-state pdf-tools
-        :title "PDF-tools transient state"
+        :title "PDF-tools Transient State"
         :on-enter (setq which-key-inhibit t)
         :on-exit (setq which-key-inhibit nil)
         :evil-leader-for-mode (pdf-view-mode . ".")

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -662,31 +662,31 @@ respond to this toggle."
   (interactive "p")
   (enlarge-window delta t))
 
-(defvar spacemacs--window-manipulation-ts-full-hint-toggle nil
-  "Display window-manipulation transient-state documentation.")
+(defvar spacemacs--window-ts-full-hint-toggle nil
+  "Display window transient state documentation.")
 
-(defun spacemacs//window-manipulation-ts-toggle-hint ()
-  "Toggle the full hint docstring for the window manipulation transient-state."
+(defun spacemacs//window-ts-toggle-hint ()
+  "Toggle the full hint docstring for the window transient state."
   (interactive)
-  (setq spacemacs--window-manipulation-ts-full-hint-toggle
-        (not spacemacs--window-manipulation-ts-full-hint-toggle)))
+  (setq spacemacs--window-ts-full-hint-toggle
+        (not spacemacs--window-ts-full-hint-toggle)))
 
-(defun spacemacs//window-manipulation-ts-hint ()
-  "Return a condensed/full hint for the window manipulation transient state"
+(defun spacemacs//window-ts-hint ()
+  "Return a condensed/full hint for the window transient state"
   (concat
    " "
-   (if spacemacs--window-manipulation-ts-full-hint-toggle
-       spacemacs--window-manipulation-ts-full-hint
+   (if spacemacs--window-ts-full-hint-toggle
+       spacemacs--window-ts-full-hint
      (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"
-             spacemacs--window-manipulation-ts-minified-hint))))
+             spacemacs--window-ts-minified-hint))))
 
-(spacemacs|transient-state-format-hint window-manipulation
-  spacemacs--window-manipulation-ts-minified-hint "\n
+(spacemacs|transient-state-format-hint window
+  spacemacs--window-ts-minified-hint "\n
 Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s_ _v_ Resize: _[_ _]_ _{_ _}_ _m_ _|_ ___")
 
-(spacemacs|transient-state-format-hint window-manipulation
-  spacemacs--window-manipulation-ts-full-hint
-  (format "\n[_?_] hide help
+(spacemacs|transient-state-format-hint window
+  spacemacs--window-ts-full-hint
+  (format "\n[_?_] toggle help
  Select^^^^               Move^^^^              Split^^^^^^               Resize^^             Other^^
  ──────^^^^─────────────  ────^^^^────────────  ─────^^^^^^─────────────  ──────^^───────────  ─────^^──────────────────
  [_j_/_k_]  down/up       [_J_/_K_] down/up     [_s_]^^^^ horizontal      [_[_] shrink horiz   [_d_] close current
@@ -701,12 +701,12 @@ Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s
               "[_g_] golden-ratio "
             "^^                 ")))
 
-(spacemacs|define-transient-state window-manipulation
+(spacemacs|define-transient-state window
   :title "Window Transient State"
   :hint-is-doc t
-  :dynamic-hint (spacemacs//window-manipulation-ts-hint)
+  :dynamic-hint (spacemacs//window-ts-hint)
   :bindings
-  ("?" spacemacs//window-manipulation-ts-toggle-hint)
+  ("?" spacemacs//window-ts-toggle-hint)
   ;; Select
   ("j" evil-window-down)
   ("<down>" evil-window-down)
@@ -762,11 +762,11 @@ Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s
   ("U" winner-redo)
   ("q" nil :exit t))
 (spacemacs/set-leader-keys
-  "w." 'spacemacs/window-manipulation-transient-state/body
-  "w[" 'spacemacs/window-manipulation-transient-state/spacemacs/shrink-window-horizontally
-  "w]" 'spacemacs/window-manipulation-transient-state/spacemacs/enlarge-window-horizontally
-  "w{" 'spacemacs/window-manipulation-transient-state/spacemacs/shrink-window
-  "w}" 'spacemacs/window-manipulation-transient-state/spacemacs/enlarge-window)
+  "w." 'spacemacs/window-transient-state/body
+  "w[" 'spacemacs/window-transient-state/spacemacs/shrink-window-horizontally
+  "w]" 'spacemacs/window-transient-state/spacemacs/enlarge-window-horizontally
+  "w{" 'spacemacs/window-transient-state/spacemacs/shrink-window
+  "w}" 'spacemacs/window-transient-state/spacemacs/enlarge-window)
 
 ;; end of Window Transient State
 

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -195,7 +195,7 @@
   "eN" 'spacemacs/previous-error
   "ep" 'spacemacs/previous-error)
 (spacemacs|define-transient-state error
-  :title "Error transient state"
+  :title "Error Transient State"
   :hint-is-doc t
   :dynamic-hint
   (let ((sys (spacemacs/error-delegate)))
@@ -588,7 +588,7 @@ respond to this toggle."
 ;; Buffer transient state
 
 (spacemacs|define-transient-state buffer
-  :title "Buffer Selection Transient State"
+  :title "Buffer Transient State"
   :doc "
  [_C-1_.._C-9_] goto nth window            [_n_/_<right>_]^^  next buffer       [_b_]   buffer list
  [_1_.._9_]     move buffer to nth window  [_N_/_p_/_<left>_] previous buffer   [_C-d_] bury buffer
@@ -638,9 +638,9 @@ respond to this toggle."
   ("C-9" winum-select-window-9))
 (spacemacs/set-leader-keys "b." 'spacemacs/buffer-transient-state/body)
 
-;; end of Buffer transient state
+;; end of Buffer Transient State
 
-;; Window Manipulation Transient State
+;; Window Transient State
 
 (defun spacemacs/shrink-window-horizontally (delta)
   "Wrap `spacemacs/shrink-window-horizontally'."
@@ -677,16 +677,16 @@ respond to this toggle."
    " "
    (if spacemacs--window-manipulation-ts-full-hint-toggle
        spacemacs--window-manipulation-ts-full-hint
-     (concat spacemacs--window-manipulation-ts-minified-hint
-             "  ([" (propertize "?" 'face 'hydra-face-red) "] help)"))))
+     (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"
+             spacemacs--window-manipulation-ts-minified-hint))))
 
 (spacemacs|transient-state-format-hint window-manipulation
-  spacemacs--window-manipulation-ts-minified-hint "
+  spacemacs--window-manipulation-ts-minified-hint "\n
 Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s_ _v_ Resize: _[_ _]_ _{_ _}_ _m_ _|_ ___")
 
 (spacemacs|transient-state-format-hint window-manipulation
   spacemacs--window-manipulation-ts-full-hint
-  (format "\n [_?_] toggle help
+  (format "\n[_?_] hide help
  Select^^^^               Move^^^^              Split^^^^^^               Resize^^             Other^^
  ──────^^^^─────────────  ────^^^^────────────  ─────^^^^^^─────────────  ──────^^───────────  ─────^^──────────────────
  [_j_/_k_]  down/up       [_J_/_K_] down/up     [_s_]^^^^ horizontal      [_[_] shrink horiz   [_d_] close current
@@ -702,7 +702,7 @@ Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s
             "^^                 ")))
 
 (spacemacs|define-transient-state window-manipulation
-  :title "Window Manipulation TS"
+  :title "Window Transient State"
   :hint-is-doc t
   :dynamic-hint (spacemacs//window-manipulation-ts-hint)
   :bindings
@@ -768,9 +768,9 @@ Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s
   "w{" 'spacemacs/window-manipulation-transient-state/spacemacs/shrink-window
   "w}" 'spacemacs/window-manipulation-transient-state/spacemacs/enlarge-window)
 
-;; end of Window Manipulation Transient State
+;; end of Window Transient State
 
-;; text Manipulation Transient State
+;; Text Transient State
 
 (defun spacemacs/scale-up-or-down-font-size (direction)
   "Scale the font. If DIRECTION is positive or zero the font is scaled up,
@@ -813,7 +813,7 @@ otherwise it is scaled down."
 
 (spacemacs/set-leader-keys "zx" 'spacemacs/scale-font-transient-state/body)
 
-;; end of Text Manipulation Transient State
+;; end of Text Transient State
 
 ;; Transparency transient-state
 

--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -33,7 +33,7 @@
     :defer t
     :init
     (spacemacs|define-transient-state centered-buffer-mode
-      :title "Centered buffer Transient State"
+      :title "Centered Buffer Transient State"
       :bindings
       ("[" writeroom-decrease-width "shrink")
       ("]" writeroom-increase-width "enlarge")

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -212,7 +212,7 @@
     :defer t
     :init
     (progn
-      (spacemacs/transient-state-register-add-bindings 'window-manipulation
+      (spacemacs/transient-state-register-add-bindings 'window
         '(("g" spacemacs/toggle-golden-ratio)))
       (spacemacs|add-toggle golden-ratio
         :status golden-ratio-mode


### PR DESCRIPTION
- Removed the word `Manipulation` from the transient state titles:
  - Buffer Manipulation Transient State and Window Manipulation TS
  - Expanded the TS abbreviation to Transient State
- Documented the Buffer Transient State key binding:
  `q` to quit the transient state
- Capitalized `Transient State` in the titles
- Window Transient State:
  - Added a line break after the title in the folded hint.
    This allows for more keys to be visible horizontally.
  - Moved up the [?] help key after the title, so that
    it's in the same place in both the folded and full
    transient state.


Renamed window transient state related variables and functions,
from: `*window-manipulation*`
to:   `*window*`.

---

I left it as two commits, so that the variable/function renaming commit can be reverted if any related issues are discovered. Although it's probably fine. I tested all the transient state key bindings and they still work as expected.
