### PR TITLE
Fix void counsel-find-file-map

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1878,6 +1878,7 @@ Other:
 - Keep ~C-h~ binding in =counsel-find-file-map= only for hjkl navigation
   (thanks to Hong Xu)
 - Optimize =spacemacs/counsel-search= for =ag= and =rg= (thanks to Hong Xu)
+- Fixed void variable =counsel-find-file-map= (thanks to duianto)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -131,6 +131,11 @@
        'counsel-find-file
        spacemacs--ivy-file-actions)
 
+      (when (or (eq 'vim dotspacemacs-editing-style)
+                (and (eq 'hybrid dotspacemacs-editing-style)
+                     hybrid-style-enable-hjkl-bindings))
+        (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory))
+
       (define-key read-expression-map (kbd "C-r") 'counsel-minibuffer-history)
       ;; remaps built-in commands that have a counsel replacement
       (counsel-mode 1)

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -199,7 +199,6 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
                        ivy-switch-buffer-map))
       (define-key map (kbd "C-j") 'ivy-next-line)
       (define-key map (kbd "C-k") 'ivy-previous-line))
-    (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory)
     (define-key ivy-minibuffer-map (kbd "C-h") (kbd "DEL"))
     ;; Move C-h to C-S-h
     (define-key ivy-minibuffer-map (kbd "C-S-h") help-map)


### PR DESCRIPTION
When the ivy package is installed without counsel,
and (require 'ivy) is called, then an error message
appears: void-variable counsel-find-file-map

Fixes #12894