### PR TITLE
Support --last-failed for pytest. Fixes #12023

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -294,6 +294,16 @@ to be called for each testrunner. "
   (interactive "P")
   (spacemacs//python-call-correct-test-function arg '((nose . nosetests-again))))
 
+(defun spacemacs/python-test-last-failed (arg)
+  "Re-run the tests that last failed."
+  (interactive "P")
+  (spacemacs//python-call-correct-test-function arg '((pytest . pytest-last-failed))))
+
+(defun spacemacs/python-test-pdb-last-failed (arg)
+  "Re-run the tests that last failed in debug mode."
+  (interactive "P")
+  (spacemacs//python-call-correct-test-function arg '((pytest . pytest-pdb-last-failed))))
+
 (defun spacemacs/python-test-all (arg)
   "Run all tests."
   (interactive "P")
@@ -351,6 +361,8 @@ to be called for each testrunner. "
     "tB" 'spacemacs/python-test-pdb-module
     "tb" 'spacemacs/python-test-module
     "tl" 'spacemacs/python-test-last
+    "tf" 'spacemacs/python-test-last-failed
+    "tF" 'spacemacs/python-test-pdb-last-failed
     "tT" 'spacemacs/python-test-pdb-one
     "tt" 'spacemacs/python-test-one
     "tM" 'spacemacs/python-test-pdb-module

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -303,6 +303,8 @@
                pytest-pdb-one
                pytest-all
                pytest-pdb-all
+               pytest-last-failed
+               pytest-pdb-last-failed
                pytest-module
                pytest-pdb-module)
     :init (spacemacs//bind-python-testing-keys)


### PR DESCRIPTION
This adds support for `--last-failed` flag for pytest. Note that the upstream package doesn't yet have that support until this PR (or something similar) has been merged: https://github.com/ionrock/pytest-el/pull/30. **So this shouldn't be merged yet!**

Fixes #12023 . Shortcuts for running the last failed tests are now set as `, t f` and `, t F`.

Not sure if it was ok to still open the PR. Just wanted to share this solution as there's an issue open about this and bring the solution under review. If that PR to pytest-el is never merged, is there some way to make use of that PR in spacemacs if we would want to?

For anyone wanting to use that PR-version of pytest-el, you can add something like this to your `.spacemacs`:

```
   dotspacemacs-additional-packages
   '(
     (pytest :location (recipe :fetcher github :repo "jluttine/pytest-el" :branch "add-last-failed"))
     )
```

(Then, remove existing `pytest` package under `˜/.emacs.d/elpa` and restart Emacs.)

