### PR TITLE
gitignore: ignore org-journal.cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ forge-database.sqlite
 url/*
 my-org/
 org-files/
+org-journal.cache
 semanticdb/
 edts/
 .recentf


### PR DESCRIPTION
The org-journal package from the org layer is writing this cache file to more
quickly compute the next journal date. While it's configurable via
`org-journal-cache-file`, by default it goes into the `user-emacs-directory` and
results in a dirty git status on spacemacs.