### PR TITLE
Add eslint_d support for javascript, react, typescript layers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -177,6 +177,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - CoffeeScript support has been extracted from the =javascript= layer into the
   new =coffeescript= layer.
 - Added missing prefix for =js2-mode=
+- Added =eslint_d= support (thanks to Seong Yong-ju)
 ***** Markdown
 - Key bindings:
   - Removed ~SPC m i I~ for =markdown-insert-reference-image=
@@ -2515,6 +2516,7 @@ Other:
   - Open =.jsx= files with =rjsx-mode= (thanks to Thomas de Beauchêne)
   - Made =react= layer respect =javascript= layers variable
     =javascript-fmt-on-save= (thanks to Tommy Groshong)
+  - Added =eslint_d= support (thanks to Seong Yong-ju)
 - Key bindings:
   - Added =import-js= support with key bindings:
     - ~SPC m i i~ to mport the module for the variable under the cursor
@@ -2857,6 +2859,7 @@ Other:
 - Added a =typescript-lsp-linter= variable to allow for disabling =lsp= as a
   linter, when =lsp= is set as the backend (thanks to Thanh Vuong)
 - Fix =tide= with =tsx= files (thanks to Aaron Jensen)
+- Added =eslint_d= support (thanks to Seong Yong-ju)
 **** Vagrant
 - Key bindings:
   - move key bindings prefix to ~SPC a V~ (thanks to Thomas de Beauchêne)

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -42,7 +42,8 @@
   (with-eval-after-load 'flycheck
     (dolist (checker '(javascript-eslint javascript-standard))
       (flycheck-add-mode checker 'rjsx-mode)))
-  (spacemacs/enable-flycheck 'rjsx-mode))
+  (spacemacs/enable-flycheck 'rjsx-mode)
+  (add-hook 'rjsx-mode-hook #'spacemacs//javascript-setup-checkers 'append))
 
 (defun react/pre-init-import-js ()
   (when (eq javascript-import-tool 'import-js)

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -153,6 +153,10 @@
 
 ;; Others
 
+(defun spacemacs//javascript-setup-checkers ()
+  (when-let* ((found (executable-find "eslint_d")))
+    (set (make-local-variable 'flycheck-javascript-eslint-executable) found)))
+
 (defun spacemacs/javascript-format ()
   "Call formatting tool specified in `javascript-fmt-tool'."
   (interactive)

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -52,7 +52,8 @@
   (add-hook `js2-mode-hook `turn-on-evil-matchit-mode))
 
 (defun javascript/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'js2-mode))
+  (spacemacs/enable-flycheck 'js2-mode)
+  (add-hook 'js2-mode-hook #'spacemacs//javascript-setup-checkers 'append))
 
 (defun javascript/post-init-ggtags ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -175,3 +175,7 @@
   (dolist (value values)
     (add-to-list 'safe-local-variable-values
                  (cons 'typescript-backend value))))
+
+(defun spacemacs//typescript-setup-checkers ()
+  (when-let* ((found (executable-find "eslint_d")))
+    (set (make-local-variable 'flycheck-javascript-eslint-executable) found)))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -59,16 +59,23 @@
              (message
               "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))))
 
+(defun typescript/set-lsp-linter ()
+  (with-eval-after-load 'lsp-ui
+    (with-eval-after-load 'flycheck
+      (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
+      (flycheck-add-mode 'javascript-eslint 'typescript-mode))))
+
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)
   (spacemacs/enable-flycheck 'typescript-tsx-mode)
   (cond ((eq (spacemacs//typescript-backend) `tide)
          (typescript/set-tide-linter))
         ((eq (spacemacs//typescript-backend) `lsp)
-         (with-eval-after-load 'lsp-ui
-           (with-eval-after-load 'flycheck
-             (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
-             (flycheck-add-mode 'javascript-eslint 'typescript-mode))))))
+         (typescript/set-lsp-linter)))
+
+  (spacemacs/add-to-hooks #'spacemacs//typescript-setup-checkers
+                          '(typescript-mode-hook typescript-tsx-mode-hook)
+                          t))
 
 (defun typescript/post-init-smartparens ()
   (if dotspacemacs-smartparens-strict-mode


### PR DESCRIPTION
# Description

Add eslint_d support for javascript, react, typescript layers.

## eslint_d
https://github.com/mantoni/eslint_d.js

# Related PRs

- https://github.com/syl20bnr/spacemacs/pull/10806
- https://github.com/syl20bnr/spacemacs/pull/11842

I've sent a similar PR in the past, and I reverted it.
But I like to merge this again, since eslint_d now supports recent versions of ESLint.