### PR TITLE
Add LSP backend support for R

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1679,6 +1679,11 @@ Other:
     - ~SPC m r~ for predefined keymap =ess-extra-map=
     - ~SPC m w~ for predefined keymap =ess-r-package-dev-map=
     - ~SPC m d~ for predefined keymap =ess-dev-map=
+  - Change some leader keys (thanks to Seong Yong-ju)
+    - ~SPC m E~ for predefined keymap =ess-extra-map=
+    - ~SPC m D~ for predefined keymap =ess-r-package-dev-map=
+    - ~SPC m d~ for predefined keymap =ess-dev-map=
+  - Removed noweb bindings since it no longer works (thanks to Seong Yong-ju)
 - Fixed issue with read-only REPL buffer (thanks to Jack Kamm)
 - Added ess layer variable =ess-disable-underscore-assign= (thanks to Jack Kamm)
 - Remove =ess-R-object-popup= from ess layer (thanks to Naylyn Gaffney)
@@ -1690,6 +1695,7 @@ Other:
 - Added =xref= integration (thanks to Guido Kraemer)
 - Update ess-disable-underscore-assign for ESS 18.10 (thanks to Leonard Lausen)
 - Update layer with the latest upstream changes (thanks to Guido Kraemer)
+- Added LSP support for R (thanks to Seong Yong-ju)
 **** Evil snipe
 - Must always explicitly enable =evil-snipe-mode= even when
   =evil-snipe-override-mode= is enabled (thanks to Sylvain Benner)

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -8,6 +8,9 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
+  - [[#linting][Linting]]
+  - [[#lsp][LSP]]
 - [[#options][Options]]
 - [[#key-bindings][Key bindings]]
   - [[#inferior-repl-process][Inferior REPL process]]
@@ -15,7 +18,6 @@
   - [[#more-interaction-with-the-repl][More interaction with the REPL]]
   - [[#r-devtools][R devtools]]
   - [[#debugging][Debugging]]
-  - [[#editing-markdown][Editing Markdown]]
 
 * Description
 This layer adds support for statistical programming languages to Spacemacs.
@@ -32,15 +34,34 @@ This layer adds support for statistical programming languages to Spacemacs.
 - Much more via the [[https://ess.r-project.org/Manual/ess.html#Current-Features][ESS Project]]
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =ess= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-Also install [[https://github.com/jimhester/lintr][lintr]] library via the R terminal to enable syntax checking.
+** Linting
+Install [[https://github.com/jimhester/lintr][lintr]] library via the R terminal to enable syntax checking.
 To do so start the R terminal and type below code.
 
 #+BEGIN_SRC R
   install.packages("lintr")
+#+END_SRC
+
+** LSP
+This backend uses an external server to provide the various IDE integrations
+and a more modern UI integration in =spacemacs=.
+
+It requires installing the external server via:
+
+#+BEGIN_SRC R
+  install.packages('languageserver')
+#+END_SRC
+
+Enable the =lsp= layer to activate this backend as well as setting the layer
+variable =ess-r-backend=:
+
+#+BEGIN_SRC elisp
+  (ess :variables ess-r-backend 'lsp)
 #+END_SRC
 
 * Options
@@ -99,32 +120,32 @@ Helpers that provide further interaction with the REPL.
 
 | Key binding   | Description                                           |
 |---------------+-------------------------------------------------------|
-| ~SPC m r /~   | set working directory                                 |
-| ~SPC m r TAB~ | install package                                       |
-| ~SPC m r d~   | edit object source or dump() object into a new buffer |
-| ~SPC m r e~   | execute a command in the ESS process                  |
-| ~SPC m r i~   | install package                                       |
-| ~SPC m r l~   | load installed package                                |
-| ~SPC m r r~   | reload ESS process                                    |
-| ~SPC m r s~   | set source style                                      |
-| ~SPC m r t~   | build tags for directory                              |
-| ~SPC m r w~   | set "width" option                                    |
+| ~SPC m E /~   | set working directory                                 |
+| ~SPC m E TAB~ | install package                                       |
+| ~SPC m E d~   | edit object source or dump() object into a new buffer |
+| ~SPC m E e~   | execute a command in the ESS process                  |
+| ~SPC m E i~   | install package                                       |
+| ~SPC m E l~   | load installed package                                |
+| ~SPC m E r~   | reload ESS process                                    |
+| ~SPC m E s~   | set source style                                      |
+| ~SPC m E t~   | build tags for directory                              |
+| ~SPC m E w~   | set "width" option                                    |
 
 ** R devtools
 Interaction with the =R= =devtools= package.
 
 | Key binding   | Description                              |
 |---------------+------------------------------------------|
-| ~SPC m w TAB~ | interface for =devtools::install()=      |
-| ~SPC m w a~   | ask for a devtools command and runs it   |
-| ~SPC m w c~   | interface for =devtools::check()=        |
-| ~SPC m w d~   | interface for =devtools::document()=     |
-| ~SPC m w i~   | interface for =devtools::install()=      |
-| ~SPC m w l~   | interface for =devtools::load_all()=     |
-| ~SPC m w r~   | interface for =devtools::revdep_check()= |
-| ~SPC m w s~   | set a package for ESS r-package commands |
-| ~SPC m w t~   | interface for =devtools::tests()=        |
-| ~SPC m w u~   | interface for =devtools::unload()=       |
+| ~SPC m D TAB~ | interface for =devtools::install()=      |
+| ~SPC m D a~   | ask for a devtools command and runs it   |
+| ~SPC m D c~   | interface for =devtools::check()=        |
+| ~SPC m D d~   | interface for =devtools::document()=     |
+| ~SPC m D i~   | interface for =devtools::install()=      |
+| ~SPC m D l~   | interface for =devtools::load_all()=     |
+| ~SPC m D r~   | interface for =devtools::revdep_check()= |
+| ~SPC m D s~   | set a package for ESS r-package commands |
+| ~SPC m D t~   | interface for =devtools::tests()=        |
+| ~SPC m D u~   | interface for =devtools::unload()=       |
 
 ** Debugging
 Tools for debugging
@@ -150,15 +171,3 @@ Tools for debugging
 | ~SPC m d t~  | toggle tracebug                                                   |
 | ~SPC m d u~  | unflag function for debug                                         |
 | ~SPC m d w~  | trigger ESS watch mode                                            |
-
-** Editing Markdown
-Edit Markdown files
-
-| Key binding | Description                                               |
-|-------------+-----------------------------------------------------------|
-| ~SPC m c C~ | send knitr/sweave chunk and switch to REPL in insert mode |
-| ~SPC m c c~ | send knitr/sweave chunk and keep buffer focused           |
-| ~SPC m c d~ | send knitr/sweave chunk and step to next chunk            |
-| ~SPC m c m~ | mark knitr/sweave chunk around point                      |
-| ~SPC m c n~ | next knitr/sweave chunk                                   |
-| ~SPC m c N~ | previous knitr/sweave chunk                               |

--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -9,7 +9,12 @@
 ;;
 ;;; License: GPLv3
 
+(spacemacs|define-jump-handlers ess-r-mode)
+
 ;; Variables
+
+(defvar ess-r-backend 'lsp
+  "The backend to use for IDE features. Possible values are `ess' and `lsp'.")
 
 (defvar ess-assign-key nil
   "Call `ess-insert-assign'.")

--- a/layers/+lang/ess/funcs.el
+++ b/layers/+lang/ess/funcs.el
@@ -9,6 +9,91 @@
 ;;
 ;;; License: GPLv3
 
+
+;; R
+
+(defun spacemacs//ess-r-backend ()
+  "Returns selected backend."
+  (if ess-r-backend
+      ess-r-backend
+    (cond ((configuration-layer/layer-used-p 'lsp) 'lsp)
+          (t 'ess))))
+
+(defun spacemacs//ess-may-setup-r-lsp ()
+  "Conditionally setup LSP based on backend."
+  (when (eq (spacemacs//ess-r-backend) 'lsp)
+    (spacemacs//ess-setup-r-lsp)))
+
+(defun spacemacs//ess-setup-r-lsp ()
+  "Setup LSP backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+
+;; Key Bindings
+
+(defun spacemacs//ess-bind-keys-for-mode (mode)
+  "Bind the keys in MODE."
+  (spacemacs/declare-prefix-for-mode mode "md" "debug")
+  (spacemacs/declare-prefix-for-mode mode "mD" "devtools")
+  (spacemacs/declare-prefix-for-mode mode "mDc" "check")
+  (spacemacs/declare-prefix-for-mode mode "mE" "extra")
+  (spacemacs/declare-prefix-for-mode mode "mh" "help")
+  (spacemacs/set-leader-keys-for-major-mode mode
+    "h" 'ess-doc-map              ;; help
+    "d" 'ess-dev-map              ;; debug
+    "D" 'ess-r-package-dev-map    ;; devtools
+    "E" 'ess-extra-map            ;; extra
+    ))
+
+(defun spacemacs//ess-bind-repl-keys-for-mode (mode)
+  "Set the REPL keys in MODE."
+  (spacemacs/declare-prefix-for-mode mode "ms" "repl")
+  (spacemacs/set-leader-keys-for-major-mode mode
+    ","  #'ess-eval-region-or-function-or-paragraph-and-step
+    "'"  #'spacemacs/ess-start-repl
+    "si" #'spacemacs/ess-start-repl
+    "ss" #'ess-switch-to-inferior-or-script-buffer
+    "sS" #'ess-switch-process
+    "sB" #'ess-eval-buffer-and-go
+    "sb" #'ess-eval-buffer
+    "sd" #'ess-eval-region-or-line-and-step
+    "sD" #'ess-eval-function-or-paragraph-and-step
+    "sL" #'ess-eval-line-and-go
+    "sl" #'ess-eval-line
+    "sR" #'ess-eval-region-and-go
+    "sr" #'ess-eval-region
+    "sF" #'ess-eval-function-and-go
+    "sf" #'ess-eval-function))
+
+(defun spacemacs/ess-bind-keys-for-julia ()
+  (spacemacs//ess-bind-keys-for-mode 'ess-julia-mode)
+  (spacemacs//ess-bind-repl-keys-for-mode 'ess-julia-mode))
+
+(defun spacemacs/ess-bind-keys-for-r ()
+  (when ess-assign-key
+    (define-key ess-r-mode-map ess-assign-key #'ess-insert-assign))
+
+  (spacemacs//ess-bind-keys-for-mode 'ess-r-mode)
+  (spacemacs//ess-bind-repl-keys-for-mode 'ess-r-mode))
+
+(defun spacemacs/ess-bind-keys-for-inferior ()
+  (define-key inferior-ess-mode-map (kbd "C-j") #'comint-next-input)
+  (define-key inferior-ess-mode-map (kbd "C-k") #'comint-previous-input)
+  (when ess-assign-key
+    (define-key inferior-ess-r-mode-map ess-assign-key #'ess-insert-assign))
+
+  (spacemacs/declare-prefix-for-mode 'inferior-ess-mode "ms" "repl")
+  (spacemacs/declare-prefix-for-mode 'inferior-ess-mode "me" "eval")
+  (spacemacs/declare-prefix-for-mode 'inferior-ess-mode "mg" "xref")
+  (spacemacs/set-leader-keys-for-major-mode 'inferior-ess-mode
+    ","  #'ess-smart-comma
+    "ss" #'ess-switch-to-inferior-or-script-buffer))
+
+
+;; REPL
+
 (defun spacemacs/ess-start-repl ()
   "Start a REPL corresponding to the ess-language of the current buffer."
   (interactive)

--- a/layers/+lang/ess/layers.el
+++ b/layers/+lang/ess/layers.el
@@ -1,0 +1,13 @@
+;;; layers.el ---  ESS Layer declarations File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Seong Yong-ju <sei40kr@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'ess-r-backend) (eq ess-r-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -11,11 +11,26 @@
 
 (setq ess-packages
       '(
+        company
+        flycheck
         ess
         ess-R-data-view
         golden-ratio
         org
         ))
+
+(defun ess/post-init-company ()
+  ;; Julia
+  (spacemacs|add-company-backends
+    :backends company-ess-julia-objects
+    :modes ess-julia-mode inferior-ess-julia-mode)
+  ;; R
+  (spacemacs|add-company-backends
+    :backends (company-R-library company-R-args company-R-objects :separate)
+    :modes ess-r-mode inferior-ess-r-mode))
+
+(defun ess/post-init-flycheck ()
+  (spacemacs/enable-flycheck 'ess-r-mode))
 
 (defun ess/init-ess ()
   (use-package ess-site
@@ -49,101 +64,43 @@
     :commands (R stata julia SAS ess-julia-mode)
     :init
     (progn
-      (spacemacs/register-repl 'ess-site 'julia)
-      (spacemacs/register-repl 'ess-site 'R)
-      (spacemacs/register-repl 'ess-site 'SAS)
-      (spacemacs/register-repl 'ess-site 'stata)
+      (setq ess-use-company nil
+            ;; Follow Hadley Wickham's R style guide
+            ess-first-continued-statement-offset 2
+            ess-continued-statement-offset 0
+            ess-expression-offset 2
+            ess-nuke-trailing-whitespace-p t
+            ess-default-style 'DEFAULT)
+
+      (spacemacs/register-repl 'ess-site #'spacemacs/ess-start-repl)
+
+      (add-hook 'ess-r-mode-hook #'spacemacs//ess-may-setup-r-lsp)
       (add-hook 'inferior-ess-mode-hook
                 'spacemacs//ess-fix-read-only-inferior-ess-mode)
-      (when (configuration-layer/package-used-p 'company)
-        (add-hook 'ess-r-mode-hook 'company-mode))))
 
-  ;; R --------------------------------------------------------------------------
-  (setq spacemacs/ess-config
-        '(progn
-           ;; Follow Hadley Wickham's R style guide
-           (setq ess-first-continued-statement-offset 2
-                 ess-continued-statement-offset 0
-                 ess-expression-offset 2
-                 ess-nuke-trailing-whitespace-p t
-                 ess-default-style 'DEFAULT)
-
-
-           (define-key ess-doc-map "h" 'ess-display-help-on-object)
-           (define-key ess-doc-map "p" 'ess-R-dv-pprint)
-           (define-key ess-doc-map "t" 'ess-R-dv-ctable)
-           (dolist (mode '(ess-julia-mode ess-r-mode))
-             (spacemacs/declare-prefix-for-mode mode "ms" "repl")
-             (spacemacs/declare-prefix-for-mode mode "mh" "help")
-             (spacemacs/declare-prefix-for-mode mode "mr" "extra")
-             (spacemacs/declare-prefix-for-mode mode "mw" "pkg")
-             (spacemacs/declare-prefix-for-mode mode "md" "dev")
-             (spacemacs/declare-prefix-for-mode mode "mc" "noweb")
-             (spacemacs/set-leader-keys-for-major-mode
-               mode
-               ","  'ess-eval-region-or-function-or-paragraph-and-step
-               "'"  'spacemacs/ess-start-repl
-               "si" 'spacemacs/ess-start-repl
-               "ss" 'ess-switch-to-inferior-or-script-buffer
-               "sS" 'ess-switch-process
-               ;; REPL
-               "sB" 'ess-eval-buffer-and-go
-               "sb" 'ess-eval-buffer
-               "sd" 'ess-eval-region-or-line-and-step
-               "sD" 'ess-eval-function-or-paragraph-and-step
-               "sL" 'ess-eval-line-and-go
-               "sl" 'ess-eval-line
-               "sR" 'ess-eval-region-and-go
-               "sr" 'ess-eval-region
-               "sF" 'ess-eval-function-and-go
-               "sf" 'ess-eval-function
-               ;; predefined keymaps
-               "h" 'ess-doc-map
-               "r" 'ess-extra-map
-               "w" 'ess-r-package-dev-map
-               "d" 'ess-dev-map
-               ;; noweb
-               "cC" 'ess-eval-chunk-and-go
-               "cc" 'ess-eval-chunk
-               "cd" 'ess-eval-chunk-and-step
-               "cm" 'ess-noweb-mark-chunk
-               "cN" 'ess-noweb-previous-chunk
-               "cn" 'ess-noweb-next-chunk))
-           (dolist (mode '(inferior-ess-mode))
-             (spacemacs/declare-prefix-for-mode mode "ms" "repl")
-             (spacemacs/declare-prefix-for-mode mode "me" "eval")
-             (spacemacs/declare-prefix-for-mode mode "mg" "xref")
-             (spacemacs/declare-prefix-for-mode mode "mh" "help")
-             (spacemacs/declare-prefix-for-mode mode "mr" "extra")
-             (spacemacs/declare-prefix-for-mode mode "mw" "pkg")
-             (spacemacs/declare-prefix-for-mode mode "md" "dev")
-             (spacemacs/set-leader-keys-for-major-mode
-               mode
-               ","  'ess-smart-comma
-               "ss" 'ess-switch-to-inferior-or-script-buffer
-               ;; predefined keymaps
-               "h" 'ess-doc-map
-               "r" 'ess-extra-map
-               "w" 'ess-r-package-dev-map
-               "d" 'ess-dev-map))
-           (define-key ess-mode-map (kbd "<s-return>") 'ess-eval-line)
-           (define-key inferior-ess-mode-map (kbd "C-j") 'comint-next-input)
-           (define-key inferior-ess-mode-map (kbd "C-k") 'comint-previous-input)
-
-           (when ess-assign-key
-             (define-key ess-r-mode-map          ess-assign-key #'ess-insert-assign)
-             (define-key inferior-ess-r-mode-map ess-assign-key #'ess-insert-assign))))
-
-  (eval-after-load "ess-r-mode" spacemacs/ess-config)
-  (eval-after-load "ess-julia" spacemacs/ess-config)
+      (with-eval-after-load 'ess-julia
+        (spacemacs/ess-bind-keys-for-julia))
+      (with-eval-after-load 'ess-r-mode
+        (spacemacs/ess-bind-keys-for-r)
+        (unless (eq (spacemacs//ess-r-backend) 'lsp)
+          (spacemacs/declare-prefix-for-mode 'ess-r-mode "mg" "goto")
+          (define-key ess-doc-map "h" #'ess-display-help-on-object)))
+      (with-eval-after-load 'ess-inf-mode
+        (spacemacs/ess-bind-keys-for-inferior)))
+    :config
+    (define-key ess-mode-map (kbd "<s-return>") #'ess-eval-line))
 
   ;; xref integration added with #96ef5a6
   (spacemacs|define-jump-handlers ess-mode 'xref-find-definitions))
 
-(defun ess/init-ess-help ()
-  (evilified-state-evilify-map ess-help-mode-map))
-
-(defun ess/init-ess-R-data-view ())
+(defun ess/init-ess-R-data-view ()
+  (use-package ess-R-data-view
+    :defer t
+    :config
+    (dolist (mode '(ess-julia-mode ess-r-mode inferior-ess-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "hp" #'ess-R-dv-pprint
+        "ht" #'ess-R-dv-ctable))))
 
 (defun ess/pre-init-golden-ratio ()
   (spacemacs|use-package-add-hook golden-ratio


### PR DESCRIPTION
# Description

Add LSP backend support for R.

11/15 FYI I've updated the PR and rename `ess-backend` to `ess-r-backend`.