### PR TITLE
Add dired evil search next/prev key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -847,6 +847,13 @@ Other:
   - Added visual-line-navigation keys (thanks to duianto)
     - ~up~ =evil-previous-visual-line=
     - ~down~ =evil-next-visual-line=
+  - Added =dired= evil search next/prev key bindings (thanks to duianto):
+    - With the =vim= editing style in =normal= state:
+      - ~n~ =evil-ex-search-next=
+      - ~N~ =evil-ex-search-previous=
+    - With the =hybrid= editing style in =normal= state:
+      - ~n~ =evil-search-next=
+      - ~N~ =evil-search-previous=
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -75,7 +75,16 @@
     "ad" 'spacemacs/dired
     "fj" 'dired-jump
     "jd" 'dired-jump
-    "jD" 'dired-jump-other-window))
+    "jD" 'dired-jump-other-window)
+  ;; The search next/previous commands are different
+  ;; because of the `evil-search-module' values:
+  ;; vim = evil-search, hybrid = isearch
+  (when (eq 'vim dotspacemacs-editing-style)
+    (evil-define-key 'normal dired-mode-map (kbd "n") 'evil-ex-search-next)
+    (evil-define-key 'normal dired-mode-map (kbd "N") 'evil-ex-search-previous))
+  (when (eq 'hybrid dotspacemacs-editing-style)
+    (evil-define-key 'normal dired-mode-map (kbd "n") 'evil-search-next)
+    (evil-define-key 'normal dired-mode-map (kbd "N") 'evil-search-previous)))
 
 (defun spacemacs-defaults/init-dired-x ()
   (use-package dired-x


### PR DESCRIPTION
The search next/previous commands are different
because of the `evil-search-module` values:
`vim`    = `evil-search`
`hybrid` = `isearch`

- With the `vim` editing style in `normal` state:
  - `n` `evil-ex-search-next`
  - `N` `evil-ex-search-previous`
- With the `hybrid` editing style in `normal` state:
  - `n` `evil-search-next`
  - `N` `evil-search-previous`

---

`N` was bound to `dired-man`:
>dired-man is an interactive compiled Lisp function in ‘dired-x.el’.
> 
> It is bound to N.
> 
> (dired-man)
> 
> Run ‘man’ on this file.

I don't know if/where it could be rebound to.