### PR TITLE
Improve multiple-cursors layer

### DIFF
--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -18,6 +18,10 @@
 
 (defun multiple-cursors/init-evil-mc ()
   (use-package evil-mc
+    :init
+    (progn
+      (add-hook 'prog-mode-hook 'turn-on-evil-mc-mode)
+      (add-hook 'text-mode-hook 'turn-on-evil-mc-mode))
     :config
     (progn
       (setq-default evil-mc-one-cursor-show-mode-line-text nil)
@@ -25,15 +29,13 @@
         (setq evil-mc-enable-bar-cursor nil))
 
       ;; evil-mc is not compatible with the paste transient state
-      (define-key evil-normal-state-map "p" 'spacemacs/evil-mc-paste-after)
-      (define-key evil-normal-state-map "P" 'spacemacs/evil-mc-paste-before)
+      (evil-define-key 'normal evil-mc-key-map
+        "p" #'spacemacs/evil-mc-paste-after
+        "P" #'spacemacs/evil-mc-paste-before)
 
-      (dolist (state-map `(,evil-normal-state-map ,evil-insert-state-map))
-        (dolist (keybinding `((,(kbd "C-M-j") . evil-mc-make-cursor-move-next-line)
-                              (,(kbd "C-M-k") . evil-mc-make-cursor-move-prev-line)))
-          (define-key state-map (car keybinding) (cdr keybinding))))
-      (add-hook 'prog-mode-hook 'turn-on-evil-mc-mode)
-      (add-hook 'text-mode-hook 'turn-on-evil-mc-mode))))
+      (evil-define-key '(normal insert) evil-mc-key-map
+        (kbd "C-M-j") #'evil-mc-make-cursor-move-next-line
+        (kbd "C-M-k") #'evil-mc-make-cursor-move-prev-line))))
 
 (defun multiple-cursors/init-multiple-cursors ()
   (use-package multiple-cursors


### PR DESCRIPTION
* Fix evil-mc-mode won't start automatically
* Add evil-mc key bindings to `evil-mc-mode`, not global keymap
* Undo all cursors by escape in normal state

May conflict with https://github.com/syl20bnr/spacemacs/pull/12910