### PR TITLE
Lots of keybindings for emacs defaults: rectangles, kmacro, timeclock, insert-buffer.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -668,33 +668,33 @@ Other:
     (thanks to Codruț Constantin Gușoi)
   - New key binding ~SPC b H~ to open or select the =*Help*= buffer
     (thanks to duianto)
-  - New ~SPC k m~ prefix and subprefixes to use keyboard macros built-ins:
-    - ~SPC k m 2 c~ kmacro-call-ring-2nd
-    - ~SPC k m 2 C~ kmacro-call-ring-2nd-repeat
-    - ~SPC k m 2 v~ kmacro-view-ring-2nd
-    - ~SPC k m a~ kmacro-add-counter
-    - ~SPC k m b~ kmacro-bind-to-key
-    - ~SPC k m c~ kmacro-call-macro
-    - ~SPC k m d~ kmacro-delete-ring-head
-    - ~SPC k m e m~ kmacro-edit-macro
-    - ~SPC k m e r~ kmacro-edit-macro-repeat
-    - ~SPC k m e~ kmacro-step-edit-macro
-    - ~SPC k m <f4>~ kmacro-end-or-call-macro-repeat
-    - ~SPC k m i~ kmacro-insert-counter
-    - ~SPC k m e n~ kmacro-name-last-macro
-    - ~SPC k m e l~ kmacro-edit-lossage
-    - ~SPC k m m~ kmacro-end-call-mouse
-    - ~SPC k m n~ kmacro-cycle-ring-next
-    - ~SPC k m N~ kmacro-cycle-ring-previous
-    - ~SPC k m p~ kmacro-cycle-ring-previous
-    - ~SPC k m r~ helm-register
-    - ~SPC k m s c~ kmacro-set-counter
-    - ~SPC k m s f~ kmacro-set-format
-    - ~SPC k m s r~ kmacro-swap-ring
-    - ~SPC k m v~ kmacro-view-macro
-    - ~SPC k m V~ kmacro-view-macro-repeat
-    - ~SPC k m w~ kmacro-to-register
-    - ~SPC k m y~ jump-to-register
+  - New ~SPC K~ prefix and subprefixes to use keyboard macros built-ins:
+    - ~SPC K 2 c~ kmacro-call-ring-2nd
+    - ~SPC K 2 C~ kmacro-call-ring-2nd-repeat
+    - ~SPC K 2 v~ kmacro-view-ring-2nd
+    - ~SPC K a~ kmacro-add-counter
+    - ~SPC K b~ kmacro-bind-to-key
+    - ~SPC K c~ kmacro-call-macro
+    - ~SPC K d~ kmacro-delete-ring-head
+    - ~SPC K e m~ kmacro-edit-macro
+    - ~SPC K e r~ kmacro-edit-macro-repeat
+    - ~SPC K e~ kmacro-step-edit-macro
+    - ~SPC K <f4>~ kmacro-end-or-call-macro-repeat
+    - ~SPC K i~ kmacro-insert-counter
+    - ~SPC K e n~ kmacro-name-last-macro
+    - ~SPC K e l~ kmacro-edit-lossage
+    - ~SPC K m~ kmacro-end-call-mouse
+    - ~SPC K n~ kmacro-cycle-ring-next
+    - ~SPC K N~ kmacro-cycle-ring-previous
+    - ~SPC K p~ kmacro-cycle-ring-previous
+    - ~SPC K r~ helm-register
+    - ~SPC K s c~ kmacro-set-counter
+    - ~SPC K s f~ kmacro-set-format
+    - ~SPC K s r~ kmacro-swap-ring
+    - ~SPC K v~ kmacro-view-macro
+    - ~SPC K V~ kmacro-view-macro-repeat
+    - ~SPC K w~ kmacro-to-register
+    - ~SPC K y~ jump-to-register
   - New ~SPC R~ prefix to use rectangle manipulation built-ins:
     - ~SPC R c~ close-rectangle
     - ~SPC R !~ clear-rectangle

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -712,7 +712,6 @@ Other:
     - ~SPC R r~ rectangle-right-char
     - ~SPC R s~ string-rectangle
     - ~SPC R t~ transpose-regions
-    - ~SPC R v~ rectangle-preview
     - ~SPC R y~ yank-rectangle
   - New ~SPC E~ prefix for ediff commands:
     - ~SPC E b 3~  ediff-buffers3
@@ -751,7 +750,7 @@ Other:
     - ~SPC t t r~ timeclock-reread-log
     - ~SPC t t s~ timeclock-status-string
     - ~SPC t t u~ timeclock-update-mode-line
-    - ~SPC t t v~ timeclock-visit
+    - ~SPC t t v~ timeclock-visit-timelog
     - ~SPC t t w~ timeclock-when-to-leave-string
   - New ~SPC i b~ keybinding to insert another buffer's contents into the
     current one.

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -668,6 +668,93 @@ Other:
     (thanks to Codruț Constantin Gușoi)
   - New key binding ~SPC b H~ to open or select the =*Help*= buffer
     (thanks to duianto)
+  - New ~SPC k m~ prefix and subprefixes to use keyboard macros built-ins:
+    - ~SPC k m 2 c~ kmacro-call-ring-2nd
+    - ~SPC k m 2 C~ kmacro-call-ring-2nd-repeat
+    - ~SPC k m 2 v~ kmacro-view-ring-2nd
+    - ~SPC k m a~ kmacro-add-counter
+    - ~SPC k m b~ kmacro-bind-to-key
+    - ~SPC k m c~ kmacro-call-macro
+    - ~SPC k m d~ kmacro-delete-ring-head
+    - ~SPC k m e m~ kmacro-edit-macro
+    - ~SPC k m e r~ kmacro-edit-macro-repeat
+    - ~SPC k m e~ kmacro-step-edit-macro
+    - ~SPC k m <f4>~ kmacro-end-or-call-macro-repeat
+    - ~SPC k m i~ kmacro-insert-counter
+    - ~SPC k m e n~ kmacro-name-last-macro
+    - ~SPC k m e l~ kmacro-edit-lossage
+    - ~SPC k m m~ kmacro-end-call-mouse
+    - ~SPC k m n~ kmacro-cycle-ring-next
+    - ~SPC k m N~ kmacro-cycle-ring-previous
+    - ~SPC k m p~ kmacro-cycle-ring-previous
+    - ~SPC k m r~ helm-register
+    - ~SPC k m s c~ kmacro-set-counter
+    - ~SPC k m s f~ kmacro-set-format
+    - ~SPC k m s r~ kmacro-swap-ring
+    - ~SPC k m v~ kmacro-view-macro
+    - ~SPC k m V~ kmacro-view-macro-repeat
+    - ~SPC k m w~ kmacro-to-register
+    - ~SPC k m y~ jump-to-register
+  - New ~SPC R~ prefix to use rectangle manipulation built-ins:
+    - ~SPC R c~ close-rectangle
+    - ~SPC R !~ clear-rectangle
+    - ~SPC R c~ rectangle-number-lines
+    - ~SPC R d~ delete-rectangle
+    - ~SPC R e~ rectangle-exchange-point-and-mark
+    - ~SPC R i~ copy-rectangle-to-register
+    - ~SPC R k~ kill-rectangle
+    - ~SPC R l~ rectangle-left-char
+    - ~SPC R m~ rectangle-mark-mode
+    - ~SPC R n~ rectangle-next-line
+    - ~SPC R N~ rectangle-previous-line
+    - ~SPC R o~ open-rectangle
+    - ~SPC R p~ rectangle-previous-line
+    - ~SPC R r~ rectangle-right-char
+    - ~SPC R s~ string-rectangle
+    - ~SPC R t~ transpose-regions
+    - ~SPC R v~ rectangle-preview
+    - ~SPC R y~ yank-rectangle
+  - New ~SPC E~ prefix for ediff commands:
+    - ~SPC E b 3~  ediff-buffers3
+    - ~SPC E b b~   ediff-backup
+    - ~SPC E d 3~  ediff-directories3
+    - ~SPC E d d~   ediff-directories
+    - ~SPC E d r~  ediff-directory-revisions
+    - ~SPC E f 3~  ediff-files3
+    - ~SPC E f~   ediff-files
+    - ~SPC E h~   ediff-documentation
+    - ~SPC E m b 3~ ediff-merge-buffers-with-ancestor
+    - ~SPC E m b b~  ediff-merge-buffers
+    - ~SPC E m d 3~ ediff-merge-directories-with-ancestor
+    - ~SPC E m d~  ediff-merge-directories
+    - ~SPC E d .~   spacemacs/ediff-dotfile-and-template
+    - ~SPC E m f 3~ ediff-merge-files-with-ancestor
+    - ~SPC E m f f~  ediff-merge-files
+    - ~SPC E m r 3~ ediff-merge-revisions-with-ancestor
+    - ~SPC E m r~  ediff-merge-revisions
+    - ~SPC E p b~  ediff-patch-buffer
+    - ~SPC E p f~  ediff-patch-file
+    - ~SPC E r v~   ediff-revision
+    - ~SPC E r l~  ediff-regions-linewise
+    - ~SPC E r w~  ediff-regions-wordwise
+    - ~SPC E s~   ediff-show-registry
+    - ~SPC E w l~  ediff-windows-linewise
+    - ~SPC E w w~  ediff-windows-wordwise
+  - New ~SPC t t~ prefix for timeclock clock-in clock-out management:
+    - ~SPC t t c~ timeclock-change
+    - ~SPC t t e~ timeclock-workday-elapsed-string
+    - ~SPC t t g~ timeclock-workday-remaining-string
+    - ~SPC t t i~ timeclock-in
+    - ~SPC t t l~ timeclock-when-to-leave-string
+    - ~SPC t t m~ timeclock-modeline-display
+    - ~SPC t t o~ timeclock-out
+    - ~SPC t t r~ timeclock-reread-log
+    - ~SPC t t s~ timeclock-status-string
+    - ~SPC t t u~ timeclock-update-mode-line
+    - ~SPC t t v~ timeclock-visit
+    - ~SPC t t w~ timeclock-when-to-leave-string
+  - New ~SPC i b~ keybinding to insert another buffer's contents into the
+    current one.
   - New ~SPC b N~ prefix to create an empty buffer:
     - ~SPC b N h~ create new empty buffer in a new window on the left
     - ~SPC b N j~ create new empty buffer in a new window at the bottom

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -679,7 +679,8 @@ Other:
     - ~SPC K e m~ kmacro-edit-macro
     - ~SPC K e r~ kmacro-edit-macro-repeat
     - ~SPC K e~ kmacro-step-edit-macro
-    - ~SPC K <f4>~ kmacro-end-or-call-macro-repeat
+    - ~SPC K (~ kmacro-start-macro-or-insert-counter
+    - ~SPC K )~ kmacro-end-or-call-macro-repeat
     - ~SPC K i~ kmacro-insert-counter
     - ~SPC K e n~ kmacro-name-last-macro
     - ~SPC K e l~ kmacro-edit-lossage
@@ -698,7 +699,6 @@ Other:
   - New ~SPC R~ prefix to use rectangle manipulation built-ins:
     - ~SPC R c~ close-rectangle
     - ~SPC R !~ clear-rectangle
-    - ~SPC R c~ rectangle-number-lines
     - ~SPC R d~ delete-rectangle
     - ~SPC R e~ rectangle-exchange-point-and-mark
     - ~SPC R i~ copy-rectangle-to-register
@@ -706,7 +706,7 @@ Other:
     - ~SPC R l~ rectangle-left-char
     - ~SPC R m~ rectangle-mark-mode
     - ~SPC R n~ rectangle-next-line
-    - ~SPC R N~ rectangle-previous-line
+    - ~SPC R N~ rectangle-number-lines
     - ~SPC R o~ open-rectangle
     - ~SPC R p~ rectangle-previous-line
     - ~SPC R r~ rectangle-right-char
@@ -715,10 +715,12 @@ Other:
     - ~SPC R y~ yank-rectangle
   - New ~SPC E~ prefix for ediff commands:
     - ~SPC E b 3~  ediff-buffers3
-    - ~SPC E b b~   ediff-backup
+    - ~SPC e b b~ ediff-buffers
+    - ~SPC E B~   ediff-backup
     - ~SPC E d 3~  ediff-directories3
     - ~SPC E d d~   ediff-directories
     - ~SPC E d r~  ediff-directory-revisions
+    - ~SPC E f .~   spacemacs/ediff-dotfile-and-template
     - ~SPC E f 3~  ediff-files3
     - ~SPC E f~   ediff-files
     - ~SPC E h~   ediff-documentation
@@ -726,7 +728,6 @@ Other:
     - ~SPC E m b b~  ediff-merge-buffers
     - ~SPC E m d 3~ ediff-merge-directories-with-ancestor
     - ~SPC E m d~  ediff-merge-directories
-    - ~SPC E d .~   spacemacs/ediff-dotfile-and-template
     - ~SPC E m f 3~ ediff-merge-files-with-ancestor
     - ~SPC E m f f~  ediff-merge-files
     - ~SPC E m r 3~ ediff-merge-revisions-with-ancestor

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -562,7 +562,7 @@ respond to this toggle."
   "ttr" 'timeclock-reread-log
   "tts" 'timeclock-status-string
   "ttu" 'timeclock-update-mode-line
-  "ttv" 'timeclock-visit
+  "ttv" 'timeclock-visit-timelog
   "ttw" 'timeclock-when-to-leave-string)
 ;; window ---------------------------------------------------------------------
 (defun split-window-below-and-focus ()

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -197,7 +197,6 @@
   "Rr" 'rectangle-right-char
   "Rs" 'string-rectangle
   "Rt" 'transpose-regions
-  "Rv" 'rectangle-preview
   "Ry" 'yank-rectangle)
 ;; applications ---------------------------------------------------------------
 (spacemacs/set-leader-keys

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -156,16 +156,17 @@
   "K2c" 'kmacro-call-ring-2nd
   "K2C" 'kmacro-call-ring-2nd-repeat
   "K2v" 'kmacro-view-ring-2nd
-  "K(" 'kmacro-start-macro-or-insert-counter
-  "K)" 'kmacro-end-or-call-macro-repeat
   "Ka" 'kmacro-add-counter
   "Kb" 'kmacro-bind-to-key
   "Kc" 'kmacro-call-macro
   "Kd" 'kmacro-delete-ring-head
+  "Kel" 'kmacro-edit-lossage
   "Kem" 'kmacro-edit-macro
   "Ker" 'kmacro-edit-macro-repeat
+  "Ket" 'kmacro-step-edit-macro
   "Ki" 'kmacro-insert-counter
-  "Kel" 'kmacro-edit-lossage
+  "K)" 'kmacro-end-or-call-macro-repeat
+  "K(" 'kmacro-start-macro-or-insert-counter
   "Km" 'kmacro-end-call-mouse
   "Kn" 'kmacro-cycle-ring-next
   "KN" 'kmacro-name-last-macro
@@ -174,7 +175,6 @@
   "Ksc" 'kmacro-set-counter
   "Ksf" 'kmacro-set-format
   "Ksr" 'kmacro-swap-ring
-  "Ket" 'kmacro-step-edit-macro
   "Kv" 'kmacro-view-macro
   "KV" 'kmacro-view-macro-repeat
   "Kw" 'kmacro-to-register

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -1,6 +1,6 @@
 ;;; keybindings.el --- Spacemacs Defaults Layer key-bindings File
 ;;
-;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -29,6 +29,17 @@
                                        ("C"   "capture/colors")
                                        ("d"   "documentation")
                                        ("e"   "errors")
+                                       ("E"   "ediff")
+                                       ("Eb"  "buffers")
+                                       ("Ed"  "directories")
+                                       ("Ef"  "files")
+                                       ("Em"  "merge")
+                                       ("Emb" "buffers")
+                                       ("Emd" "directories")
+                                       ("Emf" "files")
+                                       ("Emr" "revisions")
+                                       ("Er"  "regions")
+                                       ("Ew"  "windows")
                                        ("f"   "files")
                                        ("fC"  "files/convert")
                                        ("fe"  "emacs(spacemacs)")
@@ -49,6 +60,10 @@
                                        ("k"   "lisp")
                                        ("kd"  "delete")
                                        ("kD"  "delete-backward")
+                                       ("km" "kmacros")
+                                       ("km2" "ring")
+                                       ("kme" "edit")
+                                       ("kms" "set/swap")
                                        ("k`"  "hybrid")
                                        ("m"   "major mode commands")
                                        ("n"   "narrow/numbers")
@@ -57,6 +72,7 @@
                                        ("p"   "projects")
                                        ("q"   "quit")
                                        ("r"   "registers/rings/resume")
+                                       ("R" "rectangles")
                                        ("s"   "search/symbol")
                                        ("sa"  "ag")
                                        ("sg"  "grep")
@@ -73,6 +89,7 @@
                                        ("tEh" "hybrid (hybrid-mode)")
                                        ("th"  "highlight")
                                        ("tm"  "modeline")
+                                       ("tt"  "timeclock")
                                        ("T"   "UI toggles/themes")
                                        ("C-t" "other toggles")
                                        ("u"   "universal arg")
@@ -134,6 +151,54 @@
     'universal-argument-more))
 ;; shell command  -------------------------------------------------------------
 (spacemacs/set-leader-keys "!" 'shell-command)
+;; kmacros --------------------------------------------------------------------
+(spacemacs/set-leader-keys
+  "km2c" 'kmacro-call-ring-2nd
+  "km2C" 'kmacro-call-ring-2nd-repeat
+  "km2v" 'kmacro-view-ring-2nd
+  "kma" 'kmacro-add-counter
+  "kmb" 'kmacro-bind-to-key
+  "kmc" 'kmacro-call-macro
+  "kmd" 'kmacro-delete-ring-head
+  "kmem" 'kmacro-edit-macro
+  "kmer" 'kmacro-edit-macro-repeat
+  "km<f4>" 'kmacro-end-or-call-macro-repeat
+  "kmi" 'kmacro-insert-counter
+  "kmen" 'kmacro-name-last-macro
+  "kmel" 'kmacro-edit-lossage
+  "kmm" 'kmacro-end-call-mouse
+  "kmn" 'kmacro-cycle-ring-next
+  "kmN" 'kmacro-cycle-ring-previous
+  "kmp" 'kmacro-cycle-ring-previous
+  "kmr" 'helm-register
+  "kmsc" 'kmacro-set-counter
+  "kmsf" 'kmacro-set-format
+  "kmsr" 'kmacro-swap-ring
+  "kmet" 'kmacro-step-edit-macro
+  "kmv" 'kmacro-view-macro
+  "kmV" 'kmacro-view-macro-repeat
+  "kmw" 'kmacro-to-register
+  "kmy" 'jump-to-register)
+;; rectangles ------------------------------------------------------------------
+(spacemacs/set-leader-keys
+  "Rc" 'close-rectangle
+  "R!" 'clear-rectangle
+  "Rc" 'rectangle-number-lines
+  "Rd" 'delete-rectangle
+  "Re" 'rectangle-exchange-point-and-mark
+  "Ri" 'copy-rectangle-to-register
+  "Rk" 'kill-rectangle
+  "Rl" 'rectangle-left-char
+  "Rm" 'rectangle-mark-mode
+  "Rn" 'rectangle-next-line
+  "RN" 'rectangle-previous-line
+  "Ro" 'open-rectangle
+  "Rp" 'rectangle-previous-line
+  "Rr" 'rectangle-right-char
+  "Rs" 'string-rectangle
+  "Rt" 'transpose-regions
+  "Rv" 'rectangle-preview
+  "Ry" 'yank-rectangle)
 ;; applications ---------------------------------------------------------------
 (spacemacs/set-leader-keys
   "ac"  'calc-dispatch
@@ -223,6 +288,34 @@
   ("z" recenter-top-bottom "recenter")
   ("q" nil "quit" :exit t)
   :evil-leader "e.")
+;; ediff ----------------------------------------------------------------------
+(spacemacs/set-leader-keys
+  "Eb3"  'ediff-buffers3
+  "Ebb"  'ediff-buffers
+  "Ebp"  'ediff-patch-buffer
+  "Ec"   'ediff-backup
+  "Ed3"  'ediff-directories3
+  "Edd"   'ediff-directories
+  "Edr"  'ediff-directory-revisions
+  "Ed."   'spacemacs/ediff-dotfile-and-template
+  "Ef3"  'ediff-files3
+  "Eff"   'ediff-files
+  "Efp"  'ediff-patch-file
+  "Eh"   'ediff-documentation
+  "Emb3" 'ediff-merge-buffers-with-ancestor
+  "Embb"  'ediff-merge-buffers
+  "Emd3" 'ediff-merge-directories-with-ancestor
+  "Emdd"  'ediff-merge-directories
+  "Emf3" 'ediff-merge-files-with-ancestor
+  "Emff"  'ediff-merge-files
+  "Emr3" 'ediff-merge-revisions-with-ancestor
+  "Emrr"  'ediff-merge-revisions
+  "Erl"  'ediff-regions-linewise
+  "Erw"  'ediff-regions-wordwise
+  "Es"   'ediff-show-registry
+  "Ev"   'ediff-revision
+  "Ewl"  'ediff-windows-linewise
+  "Eww"  'ediff-windows-wordwise)
 ;; file -----------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "fA" 'spacemacs/find-file-and-replace-buffer
@@ -291,7 +384,8 @@
   "iJ" 'spacemacs/insert-line-below-no-indent
   "iK" 'spacemacs/insert-line-above-no-indent
   "ik" 'spacemacs/evil-insert-line-above
-  "ij" 'spacemacs/evil-insert-line-below)
+  "ij" 'spacemacs/evil-insert-line-below
+  "ib" 'insert-buffer)
 ;; format ---------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "j(" 'check-parens
@@ -456,6 +550,20 @@ respond to this toggle."
   "qq" 'spacemacs/prompt-kill-emacs
   "qQ" 'spacemacs/kill-emacs
   "qf" 'spacemacs/frame-killer)
+;; timeclock ------------------------------------------------------------------
+(spacemacs/set-leader-keys
+  "ttc" 'timeclock-change
+  "tte" 'timeclock-workday-elapsed-string
+  "ttg" 'timeclock-workday-remaining-string
+  "tti" 'timeclock-in
+  "ttl" 'timeclock-when-to-leave-string
+  "ttm" 'timeclock-modeline-display
+  "tto" 'timeclock-out
+  "ttr" 'timeclock-reread-log
+  "tts" 'timeclock-status-string
+  "ttu" 'timeclock-update-mode-line
+  "ttv" 'timeclock-visit
+  "ttw" 'timeclock-when-to-leave-string)
 ;; window ---------------------------------------------------------------------
 (defun split-window-below-and-focus ()
   "Split the window vertically and focus the new window."

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -156,19 +156,19 @@
   "K2c" 'kmacro-call-ring-2nd
   "K2C" 'kmacro-call-ring-2nd-repeat
   "K2v" 'kmacro-view-ring-2nd
+  "K(" 'kmacro-start-macro-or-insert-counter
+  "K)" 'kmacro-end-or-call-macro-repeat
   "Ka" 'kmacro-add-counter
   "Kb" 'kmacro-bind-to-key
   "Kc" 'kmacro-call-macro
   "Kd" 'kmacro-delete-ring-head
   "Kem" 'kmacro-edit-macro
   "Ker" 'kmacro-edit-macro-repeat
-  "K<f4>" 'kmacro-end-or-call-macro-repeat
   "Ki" 'kmacro-insert-counter
-  "Ken" 'kmacro-name-last-macro
   "Kel" 'kmacro-edit-lossage
   "Km" 'kmacro-end-call-mouse
   "Kn" 'kmacro-cycle-ring-next
-  "KN" 'kmacro-cycle-ring-previous
+  "KN" 'kmacro-name-last-macro
   "Kp" 'kmacro-cycle-ring-previous
   "Kr" 'helm-register
   "Ksc" 'kmacro-set-counter
@@ -183,7 +183,6 @@
 (spacemacs/set-leader-keys
   "Rc" 'close-rectangle
   "R!" 'clear-rectangle
-  "Rc" 'rectangle-number-lines
   "Rd" 'delete-rectangle
   "Re" 'rectangle-exchange-point-and-mark
   "Ri" 'copy-rectangle-to-register
@@ -191,7 +190,7 @@
   "Rl" 'rectangle-left-char
   "Rm" 'rectangle-mark-mode
   "Rn" 'rectangle-next-line
-  "RN" 'rectangle-previous-line
+  "RN" 'rectangle-number-lines
   "Ro" 'open-rectangle
   "Rp" 'rectangle-previous-line
   "Rr" 'rectangle-right-char
@@ -292,11 +291,11 @@
   "Eb3"  'ediff-buffers3
   "Ebb"  'ediff-buffers
   "Ebp"  'ediff-patch-buffer
-  "Ec"   'ediff-backup
+  "EB"   'ediff-backup
   "Ed3"  'ediff-directories3
   "Edd"   'ediff-directories
   "Edr"  'ediff-directory-revisions
-  "Ed."   'spacemacs/ediff-dotfile-and-template
+  "Ef."   'spacemacs/ediff-dotfile-and-template
   "Ef3"  'ediff-files3
   "Eff"   'ediff-files
   "Efp"  'ediff-patch-file

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -60,10 +60,10 @@
                                        ("k"   "lisp")
                                        ("kd"  "delete")
                                        ("kD"  "delete-backward")
-                                       ("km" "kmacros")
-                                       ("km2" "ring")
-                                       ("kme" "edit")
-                                       ("kms" "set/swap")
+                                       ("K" "kmacros")
+                                       ("K2" "ring")
+                                       ("Ke" "edit")
+                                       ("Ks" "set/swap")
                                        ("k`"  "hybrid")
                                        ("m"   "major mode commands")
                                        ("n"   "narrow/numbers")
@@ -153,32 +153,32 @@
 (spacemacs/set-leader-keys "!" 'shell-command)
 ;; kmacros --------------------------------------------------------------------
 (spacemacs/set-leader-keys
-  "km2c" 'kmacro-call-ring-2nd
-  "km2C" 'kmacro-call-ring-2nd-repeat
-  "km2v" 'kmacro-view-ring-2nd
-  "kma" 'kmacro-add-counter
-  "kmb" 'kmacro-bind-to-key
-  "kmc" 'kmacro-call-macro
-  "kmd" 'kmacro-delete-ring-head
-  "kmem" 'kmacro-edit-macro
-  "kmer" 'kmacro-edit-macro-repeat
-  "km<f4>" 'kmacro-end-or-call-macro-repeat
-  "kmi" 'kmacro-insert-counter
-  "kmen" 'kmacro-name-last-macro
-  "kmel" 'kmacro-edit-lossage
-  "kmm" 'kmacro-end-call-mouse
-  "kmn" 'kmacro-cycle-ring-next
-  "kmN" 'kmacro-cycle-ring-previous
-  "kmp" 'kmacro-cycle-ring-previous
-  "kmr" 'helm-register
-  "kmsc" 'kmacro-set-counter
-  "kmsf" 'kmacro-set-format
-  "kmsr" 'kmacro-swap-ring
-  "kmet" 'kmacro-step-edit-macro
-  "kmv" 'kmacro-view-macro
-  "kmV" 'kmacro-view-macro-repeat
-  "kmw" 'kmacro-to-register
-  "kmy" 'jump-to-register)
+  "K2c" 'kmacro-call-ring-2nd
+  "K2C" 'kmacro-call-ring-2nd-repeat
+  "K2v" 'kmacro-view-ring-2nd
+  "Ka" 'kmacro-add-counter
+  "Kb" 'kmacro-bind-to-key
+  "Kc" 'kmacro-call-macro
+  "Kd" 'kmacro-delete-ring-head
+  "Kem" 'kmacro-edit-macro
+  "Ker" 'kmacro-edit-macro-repeat
+  "K<f4>" 'kmacro-end-or-call-macro-repeat
+  "Ki" 'kmacro-insert-counter
+  "Ken" 'kmacro-name-last-macro
+  "Kel" 'kmacro-edit-lossage
+  "Km" 'kmacro-end-call-mouse
+  "Kn" 'kmacro-cycle-ring-next
+  "KN" 'kmacro-cycle-ring-previous
+  "Kp" 'kmacro-cycle-ring-previous
+  "Kr" 'helm-register
+  "Ksc" 'kmacro-set-counter
+  "Ksf" 'kmacro-set-format
+  "Ksr" 'kmacro-swap-ring
+  "Ket" 'kmacro-step-edit-macro
+  "Kv" 'kmacro-view-macro
+  "KV" 'kmacro-view-macro-repeat
+  "Kw" 'kmacro-to-register
+  "Ky" 'jump-to-register)
 ;; rectangles ------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "Rc" 'close-rectangle


### PR DESCRIPTION
All these bindings are for functions which are in emacs by default, and which I
think deserve keybindings. I have been using these as personal layers for
awhile, but I think others might benefit from them.

Changes: Add ediff binding
 Add rectangle [ keybinding
 Add kmacro bindings
 Add timeclock keybindings
 Add insert-buffer keybinding -- slurp another buffer in this one