### PR TITLE
Gnus application start

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -648,6 +648,13 @@ Other:
   - Added =symbol-overlay= to the =spacemacs-navigation= layer
     (thanks to kenkangxgwe)
 - Key bindings:
+  - GNUs keybindings now include *unplugged* and *slave* variants. These are for
+    offline usage and having multiple gnus running, respectively.
+    - ~SPC a g g~ gnus (normal). Not slave, plugged.
+    - ~SPC a g o~ slave & unplugged.
+    - ~SPC a g u~ unplugged (but not slave).
+    - ~SPC a g s~ gnus slave (but plugged).
+  - GNUs layer now includes the message mode insert binding: ~SPC m i F~ for FLAME ON, following [[https://tools.ietf.org/html/rfc1855][RFC 1855]].
   - New evil text objects =«=, =｢=, =‘= and =“=.
   - Improved buffer transient state with extra bindings and new commands:
     - Added ~<right>~ for next-buffer

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -648,14 +648,7 @@ Other:
   - Added =symbol-overlay= to the =spacemacs-navigation= layer
     (thanks to kenkangxgwe)
 - Key bindings:
-  - GNUs keybindings now include *unplugged* and *slave* variants. These are for
-    offline usage and having multiple gnus running, respectively.
-    - ~SPC a g g~ gnus (normal). Not slave, plugged.
-    - ~SPC a g o~ slave & unplugged.
-    - ~SPC a g u~ unplugged (but not slave).
-    - ~SPC a g s~ gnus slave (but plugged).
-  - GNUs layer now includes the message mode insert binding: ~SPC m i F~ for FLAME ON, following [[https://tools.ietf.org/html/rfc1855][RFC 1855]].
-  - New evil text objects =«=, =｢=, =‘= and =“=.
+    - New evil text objects =«=, =｢=, =‘= and =“=.
   - Improved buffer transient state with extra bindings and new commands:
     - Added ~<right>~ for next-buffer
     - Added ~<left>~ for previous-buffer
@@ -1633,6 +1626,14 @@ Other:
     Magit diff or blame buffer (thanks to duianto and Miciah Masters)
 **** Gnus
 - Key bindings:
+  - Add *unplugged* and *slave* variants. These are for offline usage and having
+    multiple gnus running, respectively.
+    - ~SPC a g g~ gnus (normal). Not slave, plugged.
+    - ~SPC a g o~ slave & unplugged.
+    - ~SPC a g u~ unplugged (but not slave).
+    - ~SPC a g s~ gnus slave (but plugged).
+  - Added message mode insert binding: ~SPC m i F~ for FLAME ON, following
+    [[https://tools.ietf.org/html/rfc1855#page-4][RFC 1855]] (thanks to Spenser Truex).
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)
   - Added ~O~ prefix in evil state for =gnus-group-group-map=
     (thanks to Matthew Leach)

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -30,7 +30,7 @@
     :defer t
     :commands gnus
     :init
-    (progn (spacemaccs/declare-prefix "ag" "+gnus" "Gnus newsreader")
+    (progn (spacemacs/declare-prefix "ag" "gnus" "Gnus newsreader")
            (spacemacs/set-leader-keys
              "agg" 'gnus
              "ags" 'gnus-slave

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -30,7 +30,16 @@
     :defer t
     :commands gnus
     :init
-    (spacemacs/set-leader-keys "ag" 'gnus)
+    (progn (spacemaccs/declare-prefix "ag" "+gnus" "Gnus newsreader")
+           (spacemacs/set-leader-keys
+             "agg" 'gnus
+             "ags" 'gnus-slave
+             "agu" 'gnus-unplugged
+             "ago" 'gnus-slave-unplugged)
+           (spacemacs/declare-prefix-for-mode 'message-mode "mi" "insert")
+           (spacemacs/set-leader-keys-for-major-mode 'message-mode
+             ;; RFC 1855
+             "miF" 'flame-on))
     :config
     (progn
       ;; No primary server
@@ -71,6 +80,16 @@
 
       (require 'browse-url)
       (require 'nnrss)
+      (defun spacemacs/gnus-flame-on ()
+        "Most important email function, for RFC1855 compliance."
+        ;; https://tools.ietf.org/html/rfc1855
+        (interactive)
+        (insert "FLAME ON:
+")
+        (insert "FLAME OFF
+")
+        (forward-line -2)
+        (end-of-line))
       (defun spacemacs/browse-nnrss-url (arg)
         "Open RSS Article directy in the browser"
         (interactive "p")

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -84,10 +84,8 @@
         "Most important email function, for RFC1855 compliance."
         ;; https://tools.ietf.org/html/rfc1855
         (interactive)
-        (insert "FLAME ON:
-")
-        (insert "FLAME OFF
-")
+        (insert "FLAME ON:\n")
+        (insert "FLAME OFF\n")
         (forward-line -2)
         (end-of-line))
       (defun spacemacs/browse-nnrss-url (arg)


### PR DESCRIPTION
Add keybindings for Gnus startup, since it is common to need to start it in "slave" mode (for more than one Gnus to run simultaneously) or "unplugged" mode (for offline queueing of mail to send later). Also adds a binding in message mode for FLAME ON, in RFC1855.