### PR TITLE
An attempt to bring some order in the "jump back from definition" mess

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -136,6 +136,8 @@
       (add-hook 'emacs-lisp-mode-hook 'elisp-slime-nav-mode)
       (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
         (spacemacs/declare-prefix-for-mode mode "mg" "find-symbol")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "gb" 'xref-pop-marker-stack)
         (spacemacs/declare-prefix-for-mode mode "mh" "help")
         (spacemacs/set-leader-keys-for-major-mode mode
           "hh" 'elisp-slime-nav-describe-elisp-thing-at-point)

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -140,6 +140,7 @@
     (progn
       (dolist (mode haskell-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
+          "gb" 'xref-pop-marker-stack
           "ht" 'dante-type-at
           "hT" 'spacemacs-haskell//dante-insert-type
           "hi" 'dante-info

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -83,7 +83,7 @@
     (concat prefix-char "d") #'xref-find-definitions
     (concat prefix-char "r") #'xref-find-references
     (concat prefix-char "e") #'lsp-treemacs-errors-list
-    (concat prefix-char "p") #'xref-pop-marker-stack)
+    (concat prefix-char "b") #'xref-pop-marker-stack)
   (if (configuration-layer/package-usedp 'helm)
       (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
         (concat prefix-char "s") #'helm-lsp-workspace-symbol
@@ -98,7 +98,7 @@
     (concat prefix-char "r") #'lsp-ui-peek-find-references
     (concat prefix-char "s") #'lsp-ui-peek-find-workspace-symbol
     (concat prefix-char "S") #'lsp-treemacs-symbols
-    (concat prefix-char "p") #'lsp-ui-peek-jump-backward
+    (concat prefix-char "b") #'lsp-ui-peek-jump-backward
     (concat prefix-char "e") #'lsp-ui-flycheck-list
     (concat prefix-char "n") #'lsp-ui-peek-jump-forward))
 


### PR DESCRIPTION
These changesets only affects the layers for languages I use regularly.

I've noticed that while "SPC m g g" (or ", g g") seems to _always_ jump to the definition of the symbol under the cursor, there is a lack of a common key combination to jump back.

Taking the `lsp` layer as inspiration I've used "SPC m g p" for jumping back:

- haskell was "SPC m g b" (in Intero only)
- elisp was missing
- clojure was "SPC m g b"
- python was "SPC m g b"

I am aware that this will impact users of the `gtags` layer, however since `lsp` already used "gp" I assume that it's all right. I guess the argument would be that `gtags` is more of a backup and if the language-specific layer has direct support for jumping to definition then that's preferred over `gtags`.