### PR TITLE
Fix spacemacs/kill-other-buffers to kill only buffers in the persp

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -117,6 +117,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - ~SPC q z~ is now ~SPC q f~ to kill a frame.
   - Remove ~SPC T N~ and make ~SPC T n~ cycle and start the theme transient
     state (thanks to Sylvain Benner)
+  - Fixed ~SPC b C-d~ not to kill foreign buffers (thanks to Seong Yong-ju)
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -567,7 +567,10 @@ If the universal prefix argument is used then will the windows too."
   (interactive "P")
   (when (yes-or-no-p (format "Killing all buffers except \"%s\"? "
                              (buffer-name)))
-    (mapc 'kill-buffer (delq (current-buffer) (buffer-list)))
+    (let* ((buffers-to-kill (if (bound-and-true-p persp-mode)
+                                (persp-buffer-list)
+                              (buffer-list))))
+      (mapc 'kill-buffer (delq (current-buffer) buffers-to-kill)))
     (when (equal '(4) arg) (delete-other-windows))
     (message "Buffers deleted!")))
 


### PR DESCRIPTION
## Description

`SPC b C-d` currently kills buffers in other persps too.