### PR TITLE
Do not use go-eldoc for LSP backend

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1684,6 +1684,7 @@ Other:
     environment variables (thanks to Joshua Santos)
   - Fixed =go-run-test-current-function= for vanilla tests and gocheck suite
     tests (thanks to Mathieu Post)
+  - Fixed =eldoc= setup for LSP backend (thanks to Seong Yong-ju)
 **** Graphviz
 - Use graphviz package from melpa (thanks to Matthew Boston)
 **** Groovy

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -28,6 +28,11 @@
     ('go-mode (spacemacs//go-setup-company-go))
     ('lsp (spacemacs//go-setup-company-lsp))))
 
+(defun spacemacs//go-setup-eldoc ()
+  "Conditionally setup go eldoc based on backend"
+  (pcase (spacemacs//go-backend)
+    ('go-mode (go-eldoc-setup))))
+
 
 ;; go-mode
 

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -14,6 +14,7 @@
         company
         (company-go :requires company)
         counsel-gtags
+        eldoc
         flycheck
         (flycheck-golangci-lint :toggle (and go-use-golangci-lint
                                              (configuration-layer/package-used-p
@@ -45,6 +46,9 @@
 (defun go/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'go-mode))
 
+(defun go/post-init-eldoc ()
+  (add-hook 'go-mode-hook #'spacemacs//go-setup-eldoc))
+
 (defun go/post-init-flycheck ()
   (spacemacs/enable-flycheck 'go-mode))
 
@@ -60,7 +64,7 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'go-mode))
 
 (defun go/init-go-eldoc ()
-  (add-hook 'go-mode-hook 'go-eldoc-setup))
+  (use-package go-eldoc :defer t))
 
 (defun go/init-go-fill-struct ()
   (use-package go-fill-struct


### PR DESCRIPTION
## Description

`go-eldoc` is redundant for LSP backend.