### PR TITLE
[hy] Fix broken commands, add pipenv support

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1820,8 +1820,12 @@ Other:
 - Added support for =.svelte= files (thanks to Javier Candeira)
 - Added =lsp= support for =html= buffers (thanks to Thanh Vuong)
 **** Hy
+- Added support for pipenv (thanks to Cazim Hysi)
+- Updated Hy layer to current Hy mode (thanks to Cazim Hysi)
 - Added support for virtual envs (thanks to Danny Freeman)
 - Key bindings:
+  - Added ~SPC m v~ prefix for virtualenvs
+  - Added ~SPC m v p~ prefix for pipenv
   - Added ~SPC m h~ prefix for =help=
   - Added ~SPC m e~ prefix to mirror the eval bindings of other Lisps
   - Changed ~SPC m s s~ (i.e. =start-or-switch-to-shell=) to ~SPC m '~

--- a/layers/+lang/hy/README.org
+++ b/layers/+lang/hy/README.org
@@ -13,6 +13,7 @@
   - [[#debug][Debug]]
   - [[#repl][REPL]]
   - [[#tests][Tests]]
+  - [[#python-environments][Python environments]]
 
 * Description
 This layer adds support for the Hy language based on Python.
@@ -71,3 +72,20 @@ Send code to hy REPL commands:
 | ~SPC m t A~ | launch all tests of the project in debug mode        |
 | ~SPC m t m~ | launch all tests of the current module               |
 | ~SPC m t M~ | launch all tests of the current module in debug mode |
+
+** Python environments
+
+| Key binding   | Description                                     |
+|---------------+-------------------------------------------------|
+| ~SPC m v a~   | activate a virtual environment in any directory |
+| ~SPC m v d~   | deactivate active virtual environment           |
+| ~SPC m v s~   | set a pyenv environment with [[https://github.com/pyenv/pyenv][pyenv]]              |
+| ~SPC m v u~   | unset a pyenv environment with [[https://github.com/pyenv/pyenv][pyenv]]            |
+| ~SPC m v w~   | work on virtual environment in =WORKON_HOME=    |
+| ~SPC m v p a~ | activate pipenv in current project              |
+| ~SPC m v p d~ | deactivate pipenv in current project            |
+| ~SPC m v p i~ | install module into pipenv environment          |
+| ~SPC m v p o~ | open pipenv module in buffer                    |
+| ~SPC m v p s~ | launch pipenv shell in current project          |
+| ~SPC m v p u~ | uninstall module from pipenv environment        |
+

--- a/layers/+lang/hy/funcs.el
+++ b/layers/+lang/hy/funcs.el
@@ -16,16 +16,16 @@
   "Send current buffer to REPL and focus it."
   (interactive)
   (hy-shell-eval-buffer)
-  (hy-shell-start-or-switch-to-shell))
+  (run-hy))
 
 (defun spacemacs/hy-shell-eval-current-form-and-go ()
   "Send current form to REPL and focus it."
   (interactive)
   (hy-shell-eval-current-form)
-  (hy-shell-start-or-switch-to-shell))
+  (run-hy))
 
 (defun spacemacs/hy-shell-eval-region-and-go ()
   "Send region to REPL and focus it."
   (interactive)
   (hy-shell-eval-region)
-  (hy-shell-start-or-switch-to-shell))
+  (run-hy))

--- a/layers/+lang/hy/packages.el
+++ b/layers/+lang/hy/packages.el
@@ -17,6 +17,7 @@
         ob-hy
         pyenv-mode
         pyvenv
+        pipenv
         smartparens
         ))
 
@@ -48,7 +49,7 @@
       (spacemacs/declare-prefix-for-mode 'hy-mode "mv" "pyvenv")
       (spacemacs/declare-prefix-for-mode 'hy-mode "mh" "help")
       (spacemacs/set-leader-keys-for-major-mode 'hy-mode
-        "'" 'hy-shell-start-or-switch-to-shell
+        "'" 'run-hy
 
         "dd" 'hy-insert-pdb
         "dt" 'hy-insert-pdb-threaded
@@ -58,7 +59,7 @@
         "eB" 'spacemacs/hy-shell-eval-buffer-and-go
         "ec" 'hy-shell-eval-current-form
         "eC" 'spacemacs/hy-shell-eval-current-form-and-go
-        "ei" 'hy-shell-start-or-switch-to-shell
+        "ei" 'run-hy
         "er" 'hy-shell-eval-region
         "eR" 'spacemacs/hy-shell-eval-region-and-go
 
@@ -87,6 +88,9 @@
 
 (defun hy/pre-init-pyvenv ()
   (add-to-list 'spacemacs--python-pyvenv-modes 'hy-mode))
+
+(defun hy/pre-init-pipenv ()
+  (add-to-list 'spacemacs--python-pipenv-modes 'hy-mode))
 
 (defun hy/post-init-smartparens ()
   (add-hook 'hy-mode-hook 'smartparens-mode))

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -28,10 +28,12 @@
   - [[#fill-column][Fill column]]
   - [[#sort-imports][Sort imports]]
   - [[#importmagic][Importmagic]]
+  - [[#pyvenv-pyenv-and-pipenv][Pyvenv, pyenv and pipenv]]
 - [[#management-of-python-versions-and-virtual-environments][Management of Python versions and virtual environments]]
   - [[#manage-virtual-environments-with-pyvenv][Manage virtual environments with pyvenv]]
   - [[#manage-multiple-python-versions-with-pyenv][Manage multiple Python versions with pyenv]]
     - [[#automatic-activation-of-local-pyenv-version][Automatic activation of local pyenv version]]
+  - [[#manage-environments-and-packages-with-pipenv][Manage environments and packages with pipenv]]
 - [[#key-bindings][Key bindings]]
   - [[#inferior-repl-process][Inferior REPL process]]
   - [[#running-python-script-in-shell][Running Python Script in shell]]
@@ -55,7 +57,7 @@ This layer adds support for the Python language.
 - Code Navigation
 - Documentation Lookup using [[https://github.com/proofit404/anaconda-mode][anaconda-mode]] and [[https://github.com/tsgates/pylookup][pylookup]]
 - Test Runners using [[https://github.com/syl20bnr/nose.el][nose.el]] or [[https://github.com/ionrock/pytest-el][pytest]]
-- Virtual Environment using [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] and [[https://github.com/yyuu/pyenv][pyenv]]
+- Virtual Environment using [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] and [[https://github.com/yyuu/pyenv][pyenv]] as well as [[https://github.com/pypa/pipenv][pipenv]]
 - semantic mode is enabled
 - PEP8 compliant formatting via [[https://github.com/google/yapf][YAPF]] or [[https://github.com/ambv/black][black]]
 - PEP8 checks with [[https://pypi.python.org/pypi/flake8][flake8]] or [[https://pypi.python.org/pypi/pylint/1.6.4][pylint]]
@@ -307,6 +309,19 @@ Install importmagic and epc for importmagic functionality.
   pip install importmagic epc
 #+END_SRC
 
+** Pyvenv, pyenv and pipenv
+Sometimes, it is convenient to be able to use python virtual environments from
+other modes. For this reason, the python layer provides the variables
+=spacemacs--python-pyenv-modes=, =spacemacs--python-pyvenv-modes= and
+=spacemacs--python-pipenv-modes=. If you wish to be able to access these
+functionalities from other modes, in your user config section, do:
+
+#+BEGIN_SRC elisp
+  (add-to-list 'spacemacs--python-pipenv-mode 'your-mode)
+#+END_SRC
+
+This will allow you to use [[https://github.com/pwalsh/pipenv.el][pipenv]] bindings from the mode your-mode.
+You can add to the other two lists analogously.
 * Management of Python versions and virtual environments
 ** Manage virtual environments with pyvenv
 A virtual environment provides isolation of your Python package versions. For a
@@ -357,6 +372,23 @@ can be set with the variable =python-auto-set-local-pyvenv-virtualenv= to:
 - =on-visit= (default) set the virtualenv when you visit a python buffer,
 - =on-project-switch= set the virtualenv when you switch projects,
 - =nil= to disable.
+
+** Manage environments and packages with pipenv
+[[https://pipenv.kennethreitz.org/en/latest/][Pipenv]] is the new standard tool to manage your virtual environments. It can act as
+a replacement for both =pyenv= and =venv= on a per-repository basis. An overview
+of how to use the tool is provided [[https://pipenv.kennethreitz.org/en/latest/basics/][here]].
+
+Spacemacs integration for pipenv is provided by the [[https://github.com/pwalsh/pipenv.el][pipenv package]].
+It provides the following key bindings:
+
+| Key binding   | Description                                                |
+|---------------+------------------------------------------------------------|
+| ~SPC m v p a~ | activate a pipenv environment with [[https://github.com/pwalsh/pipenv.el][pipenv]]                  |
+| ~SPC m v p d~ | deactivate a pipenv environment with [[https://github.com/pwalsh/pipenv.el][pipenv]]                |
+| ~SPC m v p i~ | install a package into a virtual environment with [[https://github.com/pwalsh/pipenv.el][pipenv]]   |
+| ~SPC m v p o~ | open an installed module in a new buffer with [[https://github.com/pwalsh/pipenv.el][pipenv]]       |
+| ~SPC m v p s~ | open a shell buffer in the current environment with [[https://github.com/pwalsh/pipenv.el][pipenv]] |
+| ~SPC m v p u~ | uninstall a package from a virtual environment with [[https://github.com/pwalsh/pipenv.el][pipenv]] |
 
 * Key bindings
 ** Inferior REPL process

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -71,6 +71,9 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
 (defvar spacemacs--python-pyvenv-modes nil
   "List of major modes where to add pyvenv support.")
 
+(defvar spacemacs--python-pipenv-modes nil
+  "List of major modes where to add pipenv support.")
+
 ;; inferior-python-mode needs these variables to be defined.  The python
 ;; package declares them but does not initialize them.
 (defvar python-shell--interpreter nil)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -190,8 +190,11 @@
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(python . t))))
 
+(defun python/pre-init-pipenv ()
+  (add-to-list 'spacemacs--python-pipenv-modes 'python-mode))
 (defun python/init-pipenv ()
   (use-package pipenv
+    :defer t
     :commands (pipenv-activate
                pipenv-deactivate
                pipenv-shell
@@ -200,13 +203,14 @@
                pipenv-uninstall)
     :init
     (progn
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "vpa" 'pipenv-activate
-        "vpd" 'pipenv-deactivate
-        "vpi" 'pipenv-install
-        "vpo" 'pipenv-open
-        "vps" 'pipenv-shell
-        "vpu" 'pipenv-uninstall))))
+      (dolist (m spacemacs--python-pipenv-modes)
+        (spacemacs/set-leader-keys-for-major-mode m
+          "vpa" 'pipenv-activate
+          "vpd" 'pipenv-deactivate
+          "vpi" 'pipenv-install
+          "vpo" 'pipenv-open
+          "vps" 'pipenv-shell
+          "vpu" 'pipenv-uninstall)))))
 
 (defun python/init-pip-requirements ()
   (use-package pip-requirements


### PR DESCRIPTION
The current version of hy-mode has replaced the command "hy-shall-start-or-switch-to-shell" with "run-hy". This PR fixes the hy layer accordingly.

Additionally, it expands the python layer pipenv support to the hy layer (analogous to pyenv-mode/pyvenv).