### PR TITLE
Set doom-modeline-display-default-perspective-name

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -35,7 +35,11 @@
   (use-package doom-modeline
     :defer t
     :if (eq (spacemacs/get-mode-line-theme-name) 'doom)
-    :init (doom-modeline-init)))
+    :init
+    (progn
+      (setq-default doom-modeline-display-default-persp-name
+                    dotspacemacs-display-default-layout)
+      (doom-modeline-init))))
 
 (defun spacemacs-modeline/init-fancy-battery ()
   (use-package fancy-battery


### PR DESCRIPTION
When initializing doom-modeline, sets `doom-modeline-display-default-persp-name` to maintain parity with `dotspacemacs-display-default-layout`. 

This enables doom-modeline to respect `dotspacemacs-display-default-layout`, which it currently doesn't.

Related: https://github.com/seagle0128/doom-modeline/pull/262

Fixes #12955
