### PR TITLE
notmuch improvements, key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2229,6 +2229,7 @@ Other:
 - Disabled add-node-modules-path by default (thanks to Eivind Fonn)
 **** Notmuch
 - Try harder to find GitHub patch URL (thanks to Miciah Masters)
+- Open GitHub patches fullscreen
 **** OCaml
 - Allow initialization without requiring =opam= (thanks to Bernhard Schommer)
 - Fixed misused functions, =merlin= is a package not a layer

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2231,6 +2231,7 @@ Other:
 - Try harder to find GitHub patch URL (thanks to Miciah Masters)
 - Open GitHub patches fullscreen
 - Add next and previous message bindings to notmuch-tree mode
+- Change the C-n and C-p message bindings to their original N and P bindings
 **** OCaml
 - Allow initialization without requiring =opam= (thanks to Bernhard Schommer)
 - Fixed misused functions, =merlin= is a package not a layer

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2230,6 +2230,7 @@ Other:
 **** Notmuch
 - Try harder to find GitHub patch URL (thanks to Miciah Masters)
 - Open GitHub patches fullscreen
+- Add next and previous message bindings to notmuch-tree mode
 **** OCaml
 - Allow initialization without requiring =opam= (thanks to Bernhard Schommer)
 - Fixed misused functions, =merlin= is a package not a layer

--- a/layers/+email/notmuch/funcs.el
+++ b/layers/+email/notmuch/funcs.el
@@ -105,7 +105,7 @@ messages in the current thread"
          (browse-url url)))
       (diff-mode)
       (view-mode 1)
-      (pop-to-buffer (current-buffer)))))
+      (pop-to-buffer-same-window (current-buffer)))))
 
 (defun spacemacs/notmuch-show-open-github-patch ()
   "Open patch from GitHub email."

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -86,18 +86,17 @@
       (evilified-state-evilify-map notmuch-show-mode-map
         :mode notmuch-show-mode
         :bindings
-        ;; In notmuch-show-mode n would be bound to `notmuch-show-next-message`
-        ;; but the evilified state moves the `n' bound function to C-n while
-        ;; it's counterpart `notmuch-show-previous-message` remains bound to
-        ;; `p'. Adding a binding for the previous function to `C-p' becomes
-        ;; handy while navigation messages back and forth.
-        (kbd "C-p")   'notmuch-show-previous-message
+        (kbd "N")   'notmuch-show-next-message
+        (kbd "P")   'notmuch-show-previous-message
+        (kbd "p")   'notmuch-show-previous-open-message
         (kbd "n")   'notmuch-show-next-open-message
         (kbd "o")   'notmuch-show-open-or-close-all
         (kbd "O")   'spacemacs/notmuch-show-close-all)
       (evilified-state-evilify-map notmuch-tree-mode-map
         :mode notmuch-tree-mode
         :bindings
+        (kbd "N") 'notmuch-tree-next-message
+        (kbd "P") 'notmuch-tree-prev-message
         (kbd "d") 'spacemacs/notmuch-message-delete-down
         (kbd "D") 'spacemacs/notmuch-message-delete-up
         (kbd "n") 'notmuch-tree-next-matching-message

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -100,6 +100,8 @@
         :bindings
         (kbd "d") 'spacemacs/notmuch-message-delete-down
         (kbd "D") 'spacemacs/notmuch-message-delete-up
+        (kbd "n") 'notmuch-tree-next-matching-message
+        (kbd "p") 'notmuch-tree-prev-matching-message
         (kbd "M") 'compose-mail-other-frame)
       (evilified-state-evilify-map notmuch-search-mode-map
         :mode notmuch-search-mode


### PR DESCRIPTION
These patches fix an annoyance when viewing github patches, and adds a view missing keybinds to notmuch-tree mode