### PR TITLE
Fix handling of java-backend

### DIFF
--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -162,7 +162,7 @@
 (defun java/init-lsp-java ()
   (use-package lsp-java
     :defer t
-    :if (eq java-backend 'lsp)
+    :if (eq (spacemacs//java-backend) 'lsp)
     :config
     (progn
       ;; key bindings


### PR DESCRIPTION
- Without this line the lsp-java package won't be enabled when java-backend is
nil and lsp layer is present
