### PR TITLE
[treemacs] Fix use of treemacs-use-collapsed-directories.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2822,6 +2822,8 @@ Other:
 - Made sure treemacs' minor modes will be disabled when they are configured
   to be off.
 - Add =tag= as an accepted value for option =treemacs-use-follow-mode=.
+- Deprecated =treemacs-use-collapsed-directories=. Flattening directories should
+  be controlled by directly setting =treemacs-collapse-dirs=.
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2824,6 +2824,7 @@ Other:
 - Add =tag= as an accepted value for option =treemacs-use-follow-mode=.
 - Deprecated =treemacs-use-collapsed-directories=. Flattening directories should
   be controlled by directly setting =treemacs-collapse-dirs=.
+- Fixed "width (un)locked" message appearing when treemacs is loaded.
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -12,7 +12,7 @@
   - [[#follow-mode][Follow mode]]
   - [[#file-watch][File watch]]
   - [[#git-mode][Git mode]]
-  - [[#collapsed-directories][Collapsed directories]]
+  - [[#flattening-directories][Flattening directories]]
   - [[#locking-width][Locking width]]
 - [[#key-bindings][Key bindings]]
   - [[#global][Global]]
@@ -83,16 +83,16 @@ explanation.
 
 Default is =nil=.
 
-** Collapsed directories
+** Flattening directories
 *This feature requires python to be installed*.
 
-Treemacs tries to collapse empty directory names into one name. It is possible
+Treemacs tries to flatten empty directory names into one name. It is possible
 to control how deep Treemacs will search for empty directories by settings the
-layer variable =treemacs-use-collapsed-directories= to a positive number.
+layer variable =treemacs-collapse-dirs= to a positive number.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
-    (treemacs :variables treemacs-use-collapsed-directories 3)))
+    (treemacs :variables treemacs-collapse-dirs 3)))
 #+END_SRC
 
 Default is 3 (or 0 when python is not installed).

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -15,10 +15,6 @@
 (defvar treemacs-use-filewatch-mode t
   "When non-nil use `treemacs-filewatch-mode'.")
 
-(defvar treemacs-use-collapsed-directories (if (executable-find "python") 3 0)
-  "Number of directories to collapse with `treemacs-collapse-dirs'.
-Must be a number.")
-
 (defvar treemacs-use-git-mode
   (pcase (cons (not (null (executable-find "git")))
                (not (null (executable-find "python3"))))

--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -27,4 +27,5 @@
   (interactive)
   (unless (eq (not treemacs--width-is-locked)
               (not treemacs-lock-width))
-    (treemacs-toggle-fixed-width)))
+    (treemacs-without-messages
+     (treemacs-toggle-fixed-width))))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -43,8 +43,7 @@
             treemacs-sorting 'alphabetic-desc
             treemacs-show-hidden-files t
             treemacs-never-persist nil
-            treemacs-goto-tag-strategy 'refetch-index
-            treemacs-collapse-dirs treemacs-use-collapsed-directories)
+            treemacs-goto-tag-strategy 'refetch-index)
       (add-hook 'treemacs-mode-hook
                 #'spacemacs/treemacs-setup-width-lock)
       (spacemacs/set-leader-keys


### PR DESCRIPTION
Treemacs sets its collapse-dirs value at load time, so the spacemacs layer
has to override it the :config section of treemacs' package declaration.