### PR TITLE
Add action for opening persp project in dired

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -520,6 +520,9 @@ Run PROJECT-ACTION on project."
      :mode-line helm-read-file-name-mode-line-string
      :action `(("Switch to Project Perspective" .
                 spacemacs//helm-persp-switch-project-action)
+               ("Switch to Project Perspective and Open Dired" .
+                ,(spacemacs//helm-persp-switch-project-action-maker
+                  (lambda () (dired "."))))
                ("Switch to Project Perspective and Show Recent Files" .
                 ,(spacemacs//helm-persp-switch-project-action-maker
                   'helm-projectile-recentf))


### PR DESCRIPTION
When using `SPC p p` to open a project it's possible to jump straight into dired using `f2`/`C-d`. I miss that ability when using layouts. I can't work out how to get `C-d` to work (keymaps in heml are confusing) but at least I can get `f2` to work :grinning: 