### PR TITLE
Add quickurl layer on SPC Q.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -342,6 +342,7 @@ sane way, here is the complete list of changed key bindings
 - pass (thanks to Andrew Oppenlander, Kepi, Kalle Lindqvist, and Evan Klitzke)
 - phoenix (thanks to Lyuben Petrov)
 - prettier (thanks to Seong Yong-ju)
+- quickurl (thanks to Spenser "equwal" Truex)
 - sailfish-developer (thanks to Victor Polevoy)
 - sphinx (thanks to Wei-Wei Guo)
 - tern (thanks to Sylvain Benner and Juuso Valkeejärvi)
@@ -616,6 +617,13 @@ Other:
   - Added =symbol-overlay= to the =spacemacs-navigation= layer
     (thanks to kenkangxgwe)
 - Key bindings:
+  - New ~SPC Q~ prefix for dispatching quickurl
+    (thanks to Spenser "equwal" Truex:)
+    - ~SPC Q l~ List quickurls
+    - ~SPC Q Q~ Expand quickurl abbrev at point
+    - ~SPC Q i~ Ask for which quickurl to insert
+    - ~SPC Q e~ Edit quickurls
+    - ~SPC Q b~ Ask to browse some url from those stored (with completion).
   - New evil text objects =«=, =｢=, =‘= and =“=.
   - Improved buffer transient state with extra bindings and new commands:
     - Added ~<right>~ for next-buffer

--- a/layers/+tools/quickurl/README.org
+++ b/layers/+tools/quickurl/README.org
@@ -1,0 +1,27 @@
+#+TITLE: quickurl layer
+#+TAGS: layer
+* Table of Contents                                        :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+  Quickurl is a package in vanilla emacs for saving and inserting URLs. These
+  are keybindings for the various methods of insertion, which are not bound by
+  default.
+** Features
+   - Keybindings to dispatch Quickurl (which is in vanilla Emacs).
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =quickurl= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key bindings
+| Key Binding | Description                                                 |
+|-------------+-------------------------------------------------------------|
+| ~SPC Q l~   | List quickurls                                              |
+| ~SPC Q Q~   | Expand quickurl abbrev at point                             |
+| ~SPC Q i~   | Ask for which quickurl to insert                            |
+| ~SPC Q e~   | Edit quickurls                                              |
+| ~SPC Q b~   | Ask to browse some url from those stored (with completion). |

--- a/layers/+tools/quickurl/keybindings.el
+++ b/layers/+tools/quickurl/keybindings.el
@@ -1,0 +1,21 @@
+;;; keybindings.el --- Quickurl dispatch layer.
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Spenser Truex <web@spensertruex.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Keybindings to use Quickurl, including mode-local ones for the listing.
+
+(spacemacs/declare-prefix "Q" "quickurl")
+(spacemacs/set-leader-keys
+  "Ql" 'quickurl-list
+  "QQ" 'quickurl
+  "Qi" 'quickurl-ask
+  "Qe" 'quickurl-edit-urls
+  "Qa" 'quickurl-add-url
+  "Qb" 'quickurl-browse-url-ask)


### PR DESCRIPTION
Add keybindings to dispatch the quickurl (built-in) function and list.

Once in the list, there are keybindings available by default.
 `SPC Q l`    List quickurls                                              
 `SPC Q Q`    Expand quickurl abbrev at point                             
 `SPC Q i`    Ask for which quickurl to insert                            
 `SPC Q e`    Edit quickurls                                              
 `SPC Q b`    Ask to browse some url from those stored (with completion). 




