### PR TITLE
[core] Improve code formatting

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -388,6 +388,11 @@ Possible values are:
 `changed' to delete only whitespace for changed lines or
 `nil' to disable cleanup.")
 
+(defvar dotspacemacs-format-show-errors 'buffer
+  "Where to display formatter error output.
+It can either be displayed in its own buffer, in the echo area, or not at all.
+Possible values are `buffer' `echo' `nil'.")
+
 (defvar dotspacemacs-search-tools '("rg" "ag" "pt" "ack" "grep")
   "List of search tool executable names. Spacemacs uses the first installed
 tool of the list. Supported tools are `rg', `ag', `pt', `ack' and `grep'.")

--- a/core/core-format.el
+++ b/core/core-format.el
@@ -1,0 +1,146 @@
+;;; core-format.el --- Spacemacs Core File
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Seong Yong-ju <sei40kr@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs-format//format-goto-line (line)
+  "Move cursor to line LINE."
+  (goto-char (point-min))
+  (forward-line (1- line)))
+
+(defun spacemacs-format//format-apply-rcs-patch (patch-buffer)
+  "Apply an RCS-formatted diff from PATCH-BUFFER to the current buffer."
+  (let ((target-buffer (current-buffer))
+        ;; Relative offset between buffer line numbers and line numbers
+        ;; in patch.
+        ;;
+        ;; Line numbers in the patch are based on the source file, so
+        ;; we have to keep an offset when making changes to the
+        ;; buffer.
+        ;;
+        ;; Appending lines decrements the offset (possibly making it
+        ;; negative), deleting lines increments it. This order
+        ;; simplifies the forward-line invocations.
+        (line-offset 0))
+    (save-excursion
+      (with-current-buffer patch-buffer
+        (goto-char (point-min))
+        (while (not (eobp))
+          (unless (looking-at "^\\([ad]\\)\\([0-9]+\\) \\([0-9]+\\)")
+            (error "Invalid rcs patch or internal error in spacemacs-format//format-apply-rcs-patch"))
+          (forward-line)
+          (let ((action (match-string 1))
+                (from (string-to-number (match-string 2)))
+                (len  (string-to-number (match-string 3))))
+            (cond
+             ((equal action "a")
+              (let ((start (point)))
+                (forward-line len)
+                (let ((text (buffer-substring start (point))))
+                  (with-current-buffer target-buffer
+                    (setq line-offset (- line-offset len))
+                    (goto-char (point-min))
+                    (forward-line (- from len line-offset))
+                    (insert text)))))
+             ((equal action "d")
+              (with-current-buffer target-buffer
+                (spacemacs-format//format-goto-line (- from line-offset))
+                (setq line-offset (+ line-offset len))
+                (let ((beg (point)))
+                  (forward-line len)
+                  (delete-region (point) beg))))
+             (t
+              (error "Invalid rcs patch or internal error in spacemacs-format//format-apply-rcs-patch")))))))))
+
+(defun spacemacs-format//format-process-errors (errorfile errbuf)
+  "Process errors using an ERRORFILE and display the output in ERRBUF."
+  (with-current-buffer errbuf
+    (if (eq dotspacemacs-format-show-errors 'echo)
+        (progn
+          (message "%s" (buffer-string))
+          (spacemacs-format//kill-error-buffer errbuf))
+      (insert-file-contents errorfile nil nil nil)
+      (compilation-mode)
+      (display-buffer errbuf))))
+
+(defun spacemacs-format//kill-error-buffer (errbuf)
+  "Kill buffer ERRBUF."
+  (let ((win (get-buffer-window errbuf)))
+    (if win
+        (quit-window t win)
+      (with-current-buffer errbuf
+        (erase-buffer))
+      (kill-buffer errbuf))))
+
+(defun spacemacs-format//format-buffer (name program args)
+  (let* ((ext (file-name-extension buffer-file-name t))
+         (bufferfile (make-temp-file name nil ext))
+         (outputfile (make-temp-file name nil ext))
+         (errorfile (make-temp-file name nil ext))
+         (errbuf (when dotspacemacs-format-show-errors
+                   (get-buffer-create (format "*%s errors*" name))))
+         (patchbuf (get-buffer-create (format "*%s patch*" name)))
+         (coding-system-for-read 'utf-8)
+         (coding-system-for-write 'utf-8))
+    (unwind-protect
+        (save-restriction
+          (widen)
+          (write-region nil nil bufferfile)
+          (when errbuf
+            (with-current-buffer errbuf
+              (setq buffer-read-only nil)
+              (erase-buffer)))
+          (with-current-buffer patchbuf
+            (erase-buffer))
+          (if (zerop (apply 'call-process program bufferfile
+                            (list (list :file outputfile) errorfile)
+                            nil args))
+              (progn
+                (call-process-region (point-min) (point-max)
+                                     "diff" nil patchbuf nil
+                                     "-n" "--strip-trailing-cr" "-" outputfile)
+                (spacemacs-format//format-apply-rcs-patch patchbuf)
+                (message "Applied %s" name)
+                (when errbuf (spacemacs-format//kill-error-buffer errbuf)))
+            (message "Could not apply %s" name)
+            (when errbuf
+              (spacemacs-format//format-process-errors errorfile errbuf))))
+      (kill-buffer patchbuf)
+      (delete-file errorfile)
+      (delete-file bufferfile)
+      (delete-file outputfile))))
+
+(defmacro spacemacs|define-fmt-tool (&rest props)
+  "Generate an interactive format command `spacemacs/xxx-format' where xxx is ID.
+
+Available PROPS:
+
+`:id ID'
+A symbol naming the formatter function. Must be started with the layer name.
+
+`:name NAME'
+The formatter name.
+
+`:program PROGRAM'
+A literal string which holds the program path.
+
+`:args ARGS'
+A list of arguments or a function which evaluates to a list of arguments."
+  (let* ((id      (spacemacs/mplist-get-value props :id))
+         (name    (spacemacs/mplist-get-value props :name))
+         (program (spacemacs/mplist-get-value props :program))
+         (args    (spacemacs/mplist-get-value props :args))
+         (format-func-name (intern (format "spacemacs/%S-format" id))))
+    ;; define format function
+    `(defun ,format-func-name ()
+       (interactive)
+       (let* (,(if (functionp args) `(args (,args)) `(args ',args)))
+         (spacemacs-format//format-buffer ,name ,program args)))))
+
+(provide 'core-format)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -22,6 +22,7 @@
 (require 'core-custom-settings)
 (require 'core-release-management)
 (require 'core-jump)
+(require 'core-format)
 (require 'core-display-init)
 (require 'core-themes-support)
 (require 'core-fonts-support)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -428,6 +428,12 @@ It should only modify the values of Spacemacs settings."
    ;; (default nil)
    dotspacemacs-whitespace-cleanup nil
 
+   ;; Where to display formatter error output.
+   ;; It can either be displayed in its own buffer, in the echo area, or not at all.
+   ;; Possible values are `buffer' `echo' `nil'.
+   ;; (default 'buffer)
+   dotspacemacs-format-show-errors 'buffer
+
    ;; Either nil or a number of seconds. If non-nil zone out after the specified
    ;; number of seconds. (default nil)
    dotspacemacs-zone-out-when-idle nil

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -18,11 +18,9 @@
     flycheck
     import-js
     js-doc
-    prettier-js
     rjsx-mode
     smartparens
     tern
-    web-beautify
     yasnippet
     ))
 
@@ -84,14 +82,11 @@
     (spacemacs/declare-prefix-for-mode 'rjsx-mode "mh" "documentation")
     (spacemacs/declare-prefix-for-mode 'rjsx-mode "mg" "goto")
 
+    (spacemacs//bind-javascript-formatter-keys 'rjsx-mode)
     (spacemacs/set-leader-keys-for-major-mode 'rjsx-mode "rt" 'rjsx-rename-tag-at-point)
 
     (with-eval-after-load 'rjsx-mode
       (define-key rjsx-mode-map (kbd "C-d") nil))))
-
-(defun react/pre-init-prettier-js ()
-  (when (eq javascript-fmt-tool 'prettier)
-    (add-to-list 'spacemacs--prettier-modes 'rjsx-mode)))
 
 (defun react/post-init-smartparens ()
   (if dotspacemacs-smartparens-strict-mode
@@ -100,11 +95,6 @@
 
 (defun react/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'rjsx-mode))
-
-(defun react/pre-init-web-beautify ()
-  (when (eq javascript-fmt-tool 'web-beautify)
-    (add-to-list 'spacemacs--web-beautify-modes
-                 (cons 'rjsx-mode 'web-beautify-js))))
 
 (defun react/post-init-yasnippet ()
   (add-hook 'rjsx-mode-hook #'spacemacs//react-setup-yasnippet))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -115,7 +115,8 @@
     :init
     (progn
       ;; get go packages much faster
-      (setq go-packages-function 'spacemacs/go-packages-gopkgs)
+      (setq gofmt-show-errors    dotspacemacs-format-show-errors
+            go-packages-function 'spacemacs/go-packages-gopkgs)
       (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width)
       (add-hook 'go-mode-local-vars-hook
                 #'spacemacs//go-setup-backend)

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -19,7 +19,8 @@ Possible values are `tern' and `lsp'.
 If `nil' then `tern' is the default backend unless `lsp' layer is used.")
 
 (defvar javascript-fmt-tool 'web-beautify
-  "The formatter to format a JavaScript file. Possible values are `web-beautify' and `prettier'.")
+  "The formatter to format a JavaScript file. Possible values are `web-beautify',
+`eslint_d', `prettier', `prettier-eslint'.")
 
 (defvar javascript-import-tool nil
   "The import backend to import modules. Possible values are `import-js' and `nil' to disable.")

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -28,10 +28,8 @@
         livid-mode
         nodejs-repl
         org
-        prettier-js
         skewer-mode
         tern
-        web-beautify
         ))
 
 (defun javascript/post-init-add-node-modules-path ()
@@ -92,6 +90,7 @@
                      (cons 'javascript-backend value))))
     :config
     (progn
+      (spacemacs//bind-javascript-formatter-keys 'js2-mode)
       (when javascript-fmt-on-save
         (add-hook 'js2-mode-local-vars-hook 'spacemacs/javascript-fmt-before-save-hook))
       ;; prefixes
@@ -226,10 +225,6 @@
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(js . t))))
 
-(defun javascript/pre-init-prettier-js ()
-  (when (eq javascript-fmt-tool 'prettier)
-    (add-to-list 'spacemacs--prettier-modes 'js2-mode)))
-
 (defun javascript/init-skewer-mode ()
   (when (eq javascript-repl 'skewer)
     (use-package skewer-mode
@@ -260,8 +255,3 @@
 
 (defun javascript/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'js2-mode))
-
-(defun javascript/pre-init-web-beautify ()
-  (when (eq javascript-fmt-tool 'web-beautify)
-    (add-to-list 'spacemacs--web-beautify-modes
-                 (cons 'js2-mode 'web-beautify-js))))

--- a/layers/+lang/json/config.el
+++ b/layers/+lang/json/config.el
@@ -12,7 +12,11 @@
 ;; Variables
 
 (defvar json-fmt-tool 'web-beautify
-  "The formatter to format a JSON file. Possible values are `web-beautify' and `prettier'.")
+  "The formatter to format a JSON file. Possible values are `jq', `web-beautify',
+`prettier', `fixjson'.")
+
+(defvar json-fixjson-args '()
+  "Additional arguments to be supplied to `fixjson'.")
 
 (defvar json-fmt-on-save nil
   "Run formatter on buffer save.")

--- a/layers/+lang/json/packages.el
+++ b/layers/+lang/json/packages.el
@@ -17,8 +17,6 @@
         json-navigator
         json-reformat
         json-snatcher
-        prettier-js
-        web-beautify
         ))
 
 (defun json/post-init-add-node-modules-path ()
@@ -29,7 +27,14 @@
 
 (defun json/init-json-mode ()
   (use-package json-mode
-    :defer t))
+    :defer t
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'json-mode "m=" "format")
+      (spacemacs/set-leader-keys-for-major-mode 'json-mode
+        "==" #'spacemacs/json-format)
+      (when json-fmt-on-save
+        (add-hook 'json-mode-hook #'spacemacs/json-setup-fmt-on-save)))))
 
 (defun json/init-json-navigator ()
   (use-package json-navigator
@@ -46,7 +51,8 @@
     :defer t
     :init
     (spacemacs/set-leader-keys-for-major-mode 'json-mode
-      "==" 'spacemacs/json-reformat-dwim)))
+      "=b" #'spacemacs/json-reformat-dwim
+      "=r" #'json-reformat-region)))
 
 (defun json/init-json-snatcher ()
   (use-package json-snatcher
@@ -54,19 +60,3 @@
     :config
     (spacemacs/set-leader-keys-for-major-mode 'json-mode
       "hp" 'jsons-print-path)))
-
-(defun json/pre-init-prettier-js ()
-  (when (eq json-fmt-tool 'prettier)
-    (add-to-list 'spacemacs--prettier-modes 'json-mode)
-    (add-hook 'json-mode-hook #'spacemacs/json-setup-prettier)
-    (when (eq json-fmt-on-save t)
-      (add-hook 'json-mode-hook 'prettier-js-mode))))
-
-(defun json/pre-init-web-beautify ()
-  (when (eq json-fmt-tool 'web-beautify)
-    (add-to-list 'spacemacs--web-beautify-modes
-                 (cons 'json-mode 'web-beautify-js))
-    (when (eq json-fmt-on-save t)
-      (add-hook 'json-mode-hook
-                (lambda ()
-                  (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))))


### PR DESCRIPTION
## Related Issues

- https://github.com/syl20bnr/spacemacs/issues/12933
- https://github.com/syl20bnr/spacemacs/issues/11580
-> supported in this PR
- https://github.com/syl20bnr/spacemacs/issues/11704
-> fixed in this PR

## Description

Add a new macro `spacemacs|define-fmt-tool` to make it easy for developers to add new formatters. There are also example usages for javascript and json layers.

e.g.
```lisp
(spacemacs|define-fmt-tool
  :id json-prettier
  :name "prettier"
  :program "prettier"
  :args (lambda () `("--stdin" "--stdin-filepath" ,buffer-file-name)))

(spacemacs/json-prettier-format)

(spacemacs|define-fmt-tool
  :id json-web-beautify
  :name "web-beautify"
  :program "js-beautify"
  :args ("-f" "-"))

(spacemacs/json-web-beautify-format)
```

It would be helpful if there're unnatural expressions in docstring since English is not my native tongue.

BTW  didn't use [reformatter](https://github.com/purcell/reformatter.el) because it also generates the unwanted `format-region` command even if the formatter don't support it.