### PR TITLE
Fix react layer fmt on save

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -83,5 +83,5 @@ If optional argument P is present, test this instead of point."
   (yas-activate-extra-mode 'js-mode))
 
 ;; Format
-(defun spacemacs/react-fmt-before-save-hook ()
+(defun spacemacs//react-fmt-before-save-hook ()
   (add-hook 'before-save-hook 'spacemacs/javascript-format t t))

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -74,7 +74,7 @@
     (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-setup-next-error-fn)
     ;; setup fmt on save
     (when javascript-fmt-on-save
-      (add-hook 'rjsx-mode-local-vars-hook 'spacemacs/react-fmt-before-save-hook))
+      (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-fmt-before-save-hook))
 
     :config
     ;; declare prefix


### PR DESCRIPTION
Fixes a function naming bug in the react layer so it will again start formatting files on save if the appropriate config variable is set.