### PR TITLE
rust: fix LSP/DAP integration so it doesn't depend on java layer

### DIFF
--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -33,7 +33,7 @@
   "Conditionally setup elixir DAP integration."
   ;; currently DAP is only available using LSP
   (pcase (spacemacs//rust-backend)
-    (`lsp (spacemacs//java-setup-lsp-dap))))
+    (`lsp (spacemacs//rust-setup-lsp-dap))))
 
 
 ;; lsp


### PR DESCRIPTION
Fixes error with rust files when java layer isn't loaded:
```
File local-variables error: (void-function spacemacs//java-setup-lsp-dap)
```