### PR TITLE
[ivy] Fix spacemacs/counsel-search with ag and rg

### DIFF
--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -117,11 +117,15 @@
             (counsel-git-grep-action c))
           next-error-function 'spacemacs/gne-next)))
 
-(defvar spacemacs--counsel-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "<f3>") 'spacemacs//counsel-save-in-buffer)
-    (define-key map (kbd "C-c C-e") 'spacemacs//counsel-edit)
-    map))
+(defun spacemacs//counsel-search-add-extra-bindings (map)
+  "Add extra counsel-search related keybindings to MAP, then return MAP.
+See `spacemacs/counsel-search' and `counsel-ag'."
+  (define-key map (kbd "<f3>") 'spacemacs//counsel-save-in-buffer)
+  (define-key map (kbd "C-c C-e") 'spacemacs//counsel-edit)
+  map)
+
+(defvar spacemacs--counsel-map (spacemacs//counsel-search-add-extra-bindings
+                                (make-sparse-keymap)))
 
 (defun spacemacs/ivy--regex-plus (str)
   "Build a regex sequence from STR.

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -137,6 +137,7 @@
         (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory))
 
       (define-key read-expression-map (kbd "C-r") 'counsel-minibuffer-history)
+      (spacemacs//counsel-search-add-extra-bindings counsel-ag-map)
       ;; remaps built-in commands that have a counsel replacement
       (counsel-mode 1)
       (spacemacs|hide-lighter counsel-mode)


### PR DESCRIPTION
The commit 9c613b8 introduced a regression for ivy users that use ag or rg as
the search tool. It made `C-c C-e` and `F3` keybindings unavailable, and thus
making it impossible to make multi-file edits.

Partially fixes #12838