### PR TITLE
Add LSP support for Lua (EmmyLua-LS-all).

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2064,6 +2064,7 @@ Other:
     (thanks to Olivier Verdier)
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
+- Added support for =LSP= (EmmyLua-LS-all) (thanks to Lin.Sun)
 **** Language Server Protocol (LSP)
 - Added core keybindings and prefix declarations for all LSP-based language
   layers, and helper functions to bind server-specific extensions

--- a/layers/+lang/lua/README.org
+++ b/layers/+lang/lua/README.org
@@ -8,25 +8,66 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
+  - [[#backends][Backends]]
+    - [[#lsp][LSP]]
+      - [[#features-1][Features]]
 - [[#key-bindings][Key bindings]]
+  - [[#lsp-1][LSP]]
   - [[#commands][Commands]]
 
 * Description
 This layer adds support for editing Lua.
 
 ** Features:
+- LSP with EmmyLua-LS-all.
 - Editing lua files using [[https://github.com/immerrr/lua-mode][lua-mode]]
 - Sending code to a lua REPL
 - Code linting using [[https://github.com/mpeterv/luacheck][Luacheck]]
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =lua= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 In order to enable code linting, install [[https://github.com/mpeterv/luacheck][Luacheck]].
 
+** Backends
+Supported backends are:
+- =lsp-emmy= using clangd LSP server
+
+*** LSP
+LSP support is provided via the [[file:../../+tools/lsp/README.org][LSP layer]], currently only EmmyLua is supported, 
+- [[https://github.com/EmmyLua/EmmyLua-LanguageServer][lsp-emmy]]
+
+To use the =lsp-emmy= backend, please download the [[https://github.com/EmmyLua/EmmyLua-LanguageServer][EmmyLua-LS-all.jar]] and put
+into =~/.emacs.d/=, then set the layer variables lsp-backend for =lua=:
+#+begin_src elisp
+  (lua :variables lsp-backend 'lsp-emmy)
+#+end_src
+
+The complete layer variables are:
+#+begin_src elisp
+  (lua :variables
+       lsp-backend 'lsp-emmy
+       lua-lsp-emmy-jar-path "~/.emacs.d/EmmyLua-LS-all.jar" ; default path
+       lua-lsp-emmy-enable-file-watchers t)                  ; enabled default
+#+end_src
+
+**** Features
+- Cross references (definitions, references, rename...)
+- Completion with =company-lsp=
+- Syntax checking via flycheck (lsp-ui-flycheck)
+- Cross-platform - functional on Windows, Linux and macOS.
+- Refer https://github.com/EmmyLua/EmmyLua-LanguageServer for details.
+
+
 * Key bindings
+** LSP
+The default key bindings for the LSP implementations are defined and documented in
+the [[file:../../+tools/lsp/README.org][LSP layer]].
+
 ** Commands
 
 | Key binding | Description                                |

--- a/layers/+lang/lua/config.el
+++ b/layers/+lang/lua/config.el
@@ -12,3 +12,17 @@
 ;; variables
 
 (spacemacs|define-jump-handlers lua-mode)
+
+(defvar lua-backend nil
+  "If `lsp-emmy' then enables EmmyLua support")
+
+;; lua-lsp-backend variables
+
+(defvar lua-lsp-emmy-java-path nil
+  "Path to java which will be used for running emmy-lua language server.")
+
+(defvar lua-lsp-emmy-jar-path nil
+  "Path to jar which will be used for running EmmyLua language server.")
+
+(defvar lua-lsp-emmy-enable-file-watchers t
+  "Enabled the EmmyLua file watchers.")

--- a/layers/+lang/lua/funcs.el
+++ b/layers/+lang/lua/funcs.el
@@ -1,0 +1,90 @@
+;;; funcs.el --- Lua Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Lin Sun <sunlin7@yahoo.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//lua-backend ()
+  "Returns selected backend."
+  (or lua-backend
+      (cond
+       ((configuration-layer/layer-used-p 'lsp) 'lsp-emmy))))
+
+(defun spacemacs//lua-setup-backend ()
+  "Conditionally setup lua backend."
+  (setq lua-indent-level 2
+        lua-indent-string-contents t)
+  (spacemacs/set-leader-keys-for-major-mode 'lua-mode
+    "hd" 'lua-search-documentation
+    "sb" 'lua-send-buffer
+    "sf" 'lua-send-defun
+    "sl" 'lua-send-current-line
+    "sr" 'lua-send-region
+    "is" 'lua-show-process-buffer
+    "ih" 'lua-hide-process-buffer)
+
+  (pcase (spacemacs//lua-backend)
+    (`lsp-emmy (spacemacs//lua-setup-lsp-emmy))))
+
+(defun spacemacs//lua-setup-company ()
+  "Conditionally setup company based on backend."
+  (pcase (spacemacs//lua-backend)
+    (`lsp-emmy (spacemacs//lua-setup-lsp-company))
+    (_ (company-mode))))
+
+(defun spacemacs//lua-setup-dap ()
+  "Conditionally setup elixir DAP integration."
+  ;; currently DAP is only available using LSP
+  (pcase (spacemacs//lua-backend)
+    (`lsp-emmy (spacemacs//lua-setup-lsp-dap))))
+
+(defun spacemacs//lua-setup-flycheck ()
+  "Conditionally setup flycheck based on backend."
+  (pcase (spacemacs//lua-backend)
+    (`lsp-emmy (spacemacs//lua-setup-lsp-flycheck))))
+
+
+;; LSP Lua
+(defun spacemacs//lua-setup-lsp-emmy ()
+  "Setup LSP Lua."
+  (if (not (configuration-layer/layer-used-p 'lsp))
+      (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")
+
+    (require 'lsp-clients)
+    (when lua-lsp-emmy-java-path
+      (setq lsp-clients-emmy-lua-java-path lua-lsp-emmy-java-path))
+    (when lua-lsp-emmy-jar-path
+      (setq lsp-clients-emmy-lua-jar-path (expand-file-name lua-lsp-emmy-jar-path)))
+    (setq lsp-enable-file-watchers lua-lsp-emmy-enable-file-watchers)
+
+    (lsp)))
+
+(defun spacemacs//lua-setup-lsp-company ()
+  "Setup lsp auto-completion."
+  (spacemacs|add-company-backends
+    :backends company-lsp
+    :modes c-mode c++-mode
+    :append-hooks nil
+    :call-hooks t)
+  ;; TODO: disable the cache
+  ;; (add-to-list 'company-lsp-filter-candidates '(emmy-lua . t))
+  (company-mode))
+
+(defun spacemacs//lua-setup-lsp-dap ()
+  "Setup DAP integration."
+  )                                     ; TODO: Lua Debug Adapter Protocol
+
+(defun spacemacs//lua-setup-lsp-flycheck ()
+  "Setup LSP Lua syntax checking."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (when (spacemacs/enable-flycheck 'lua-mode)
+        (lsp-ui-flycheck-enable nil)
+        (flycheck-mode))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+

--- a/layers/+lang/lua/funcs.el
+++ b/layers/+lang/lua/funcs.el
@@ -68,7 +68,7 @@
   "Setup lsp auto-completion."
   (spacemacs|add-company-backends
     :backends company-lsp
-    :modes c-mode c++-mode
+    :modes lua-mode
     :append-hooks nil
     :call-hooks t)
   ;; TODO: disable the cache

--- a/layers/+lang/lua/layers.el
+++ b/layers/+lang/lua/layers.el
@@ -1,0 +1,17 @@
+;;; layers.el --- Lua Layer declarations File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Lin Sun <sunlin7@yahoo.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'lua-backend)
+           (string-match-p "^lsp-.*" (symbol-name lua-backend)))
+  (configuration-layer/declare-layer-dependencies '(lsp)))
+
+
+

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -30,17 +30,11 @@
     :interpreter ("lua" . lua-mode)
     :init
     (progn
-      (setq lua-indent-level 2
-            lua-indent-string-contents t)
-      (spacemacs/set-leader-keys-for-major-mode 'lua-mode
-        "d" 'lua-search-documentation
-        "sb" 'lua-send-buffer
-        "sf" 'lua-send-defun
-        "sl" 'lua-send-current-line
-        "sr" 'lua-send-region))))
+      (spacemacs/register-repl 'lua #'lua-show-process-buffer "lua")
+      (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-backend))))
 
 (defun lua/post-init-company ()
-  (add-hook 'lua-mode-hook 'company-mode))
+  (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-company))
 
 (defun lua/init-company-lua ()
   (use-package company-lua
@@ -57,3 +51,4 @@
 
 (defun lua/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'lua-mode))
+

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1806,6 +1806,10 @@ Features:
 - Editing lua files using [[https://github.com/immerrr/lua-mode][lua-mode]]
 - Sending code to a lua REPL
 - Code linting using [[https://github.com/mpeterv/luacheck][Luacheck]]
+- LSP backend support
+  - Cross references (definitions, references, rename...)
+  - Completion with =company-lsp=
+  - Syntax checking via flycheck (lsp-ui-flycheck)
 
 **** Nim
 [[file:+lang/nim/README.org][+lang/nim/README.org]]


### PR DESCRIPTION
Add the LSP support for Lua (EmmyLua-LS-all), and it's easy to extend with other Lua LSP backend.