### PR TITLE
Make sure eldoc info is not removed when you switch to insert mode

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -143,7 +143,14 @@
       ;; enable eldoc in IELM
       (add-hook 'ielm-mode-hook #'eldoc-mode)
       ;; don't display eldoc on modeline
-      (spacemacs|hide-lighter eldoc-mode))))
+      (spacemacs|hide-lighter eldoc-mode)
+
+      ;; eldoc-message-commands
+      (eldoc-add-command #'evil-insert)
+      (eldoc-add-command #'evil-insert-line)
+      (eldoc-add-command #'evil-append)
+      (eldoc-add-command #'evil-append-line)
+      (eldoc-add-command #'evil-force-normal-state))))
 
 (defun spacemacs-defaults/init-help-fns+ ()
   (use-package help-fns+

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -37,7 +37,7 @@
         (hs-minor-mode :location built-in)
         (linum-relative :toggle (version< emacs-version "26"))
         vi-tilde-fringe
-        ))
+        eldoc))
 
 (defun spacemacs-evil/init-evil-anzu ()
   (use-package evil-anzu
@@ -63,6 +63,12 @@
               status)))
         (setq anzu-mode-line-update-function
               'spacemacs/anzu-update-mode-line)))))
+
+(defun spacemacs-evil/post-init-eldoc ()
+  (eldoc-add-command #'evil-cp-insert)
+  (eldoc-add-command #'evil-cp-insert-at-end-of-form)
+  (eldoc-add-command #'evil-cp-insert-at-beginning-of-form)
+  (eldoc-add-command #'evil-cp-append))
 
 (defun spacemacs-evil/init-evil-args ()
   (use-package evil-args


### PR DESCRIPTION
- This will prevent jumping of eldoc box when you switch to insert mode.