### PR TITLE
[csharp] add support for the alternative `lsp' backend

### DIFF
--- a/layers/+lang/csharp/README.org
+++ b/layers/+lang/csharp/README.org
@@ -7,10 +7,11 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
-- [[#packages-included][Packages Included]]
+- [[#backends][Backends]]
 - [[#install][Install]]
+  - [[#omnisharp-backend][Omnisharp backend]]
 - [[#caveats][Caveats]]
-- [[#key-bindings][Key bindings]]
+- [[#key-bindings-for-the-omnisharp-backend][Key bindings for the omnisharp backend]]
   - [[#navigation][Navigation]]
   - [[#helpers-documentation-info][Helpers (documentation, info)]]
   - [[#refactoring][Refactoring]]
@@ -18,11 +19,9 @@
   - [[#tests][Tests]]
 
 * Description
-This layer adds support for C# language using the [[https://github.com/OmniSharp/omnisharp-roslyn][omnisharp-roslyn]] language
-server and corresponding [[https://github.com/OmniSharp/omnisharp-emacs][omnisharp-emacs]] package.
-
-Please report any issues encountered to [[https://github.com/OmniSharp/omnisharp-emacs/issues][omnisharp-emacs issue page on github]].
-PRs are welcome too!
+This layer adds support for the C# language using the [[https://github.com/OmniSharp/omnisharp-roslyn][omnisharp-roslyn]]
+language server with either the [[https://github.com/OmniSharp/omnisharp-emacs][omnisharp-emacs]]
+or the [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] packages.
 
 ** Features:
 - Syntax checking with flycheck (when =syntax-checking= layer is used)
@@ -31,32 +30,51 @@ PRs are welcome too!
 - Navigation to cross-references
 - Inspecting types in metadata
 
-* Packages Included
-- [[https://github.com/OmniSharp/omnisharp-emacs][omnisharp]]
+* Backends
+There are two backends available for this layer, one based on the =omnisharp-emacs=
+package and a new one based on =lsp-mode= (language server protocol) package.
+
+Both backends use the omnisharp-roslyn server under the hood however different
+features are available. The =omnisharp= backend might be more stable at this 
+moment (late 2019).
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =csharp= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-Before you can work with C# files you will need to install the server by invoking
-~SPC m s i~ (or =M-x omnisharp-install-server=). Otherwise, if this fails for
-you, please see [[https://github.com/OmniSharp/omnisharp-emacs/blob/master/doc/server-installation.md][omnisharp-emacs/doc/server-installation.md]].
+You can also choose between one of the two available backends by setting 
+the =csharp-backend= variable when configuring the layer:
+ - =omnisharp= (the default), or
+ - =lsp= (testing)
 
-While the server will start automatically where possible if the
-server needs to be started manually use ~SPC m s s~ (or
-=M-x omnisharp-start-omnisharp-server=). It will prompt a path to your .cpsroj
-or .sln file.
+To use the lsp backend, add `csharp' layer with =csharp-backend= variable set to 'lsp:
+#+BEGIN_SRC elisp
+  (csharp :variables csharp-backend 'lsp)
+#+END_SRC
+
+** Omnisharp backend
+Before you can work with C# files you will need to install the server by invoking
+~SPC m s i~ (or =M-x omnisharp-install-server=). Otherwise, if this fails for you, please see
+[[https://github.com/OmniSharp/omnisharp-emacs/blob/master/doc/server-installation.md][omnisharp-emacs/doc/server-installation.md]].
+
+While the server will start automatically it may still be required for you to start
+it manually using ~SPC m s s~ (or =M-x omnisharp-start-omnisharp-server=). It will 
+prompt a path to your .csproj or .sln file.
 
 * Caveats
 - You should use =dotnet= CLI tool from [[https://www.microsoft.com/net/download/core][.NET Core download page]] or an IDE like
   Visual Studio or Xamarin Studio to manage solution and project files.
 - Debugging on command line is possible using [[https://github.com/mono/sdb][SDB]].
-- There can be *only one server* running at the same time. To switch to a different
-  solution/project you need to invoke ~SPC m s S~ and ~SPC m s s~ to stop
+- There can be *only one server* running at the same time using the =omnisharp= backend.
+  To switch to a different solution/project you need to invoke ~SPC m s S~ and ~SPC m s s~ to stop
   current server and start another one pointing to another solution/project.
+- LSP backend supports multiple concurrent language servers/projects loaded.
 
-* Key bindings
+* Key bindings for the omnisharp backend
+The following key bindings are available when using the =omnisharp= backend.
+LSP-backend uses keybindings that are common for all layers/languages using the =lsp= layer.
+
 ** Navigation
 
 | Key binding | Description                                   |

--- a/layers/+lang/csharp/README.org
+++ b/layers/+lang/csharp/README.org
@@ -47,6 +47,7 @@ You can also choose between one of the two available backends by setting
 the =csharp-backend= variable when configuring the layer:
  - =omnisharp= (the default), or
  - =lsp= (testing)
+ - =nil= (to not use any language server)
 
 To use the lsp backend, add `csharp' layer with =csharp-backend= variable set to 'lsp:
 #+BEGIN_SRC elisp

--- a/layers/+lang/csharp/config.el
+++ b/layers/+lang/csharp/config.el
@@ -13,7 +13,7 @@
 
 (spacemacs|define-jump-handlers csharp-mode)
 
-(defvar csharp-backend 'nil
+(defvar csharp-backend 'omnisharp
   "The backend to use for IDE features.
 Possible values are `omnisharp' and `lsp'.
-If `nil' then `omnisharp' is the default backend.")
+If `nil' then no backend is enabled.")

--- a/layers/+lang/csharp/config.el
+++ b/layers/+lang/csharp/config.el
@@ -1,6 +1,6 @@
 ;;; packages.el --- C# Layer configuration File for Spacemacs
 ;;
-;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -12,3 +12,8 @@
 ;; variables
 
 (spacemacs|define-jump-handlers csharp-mode)
+
+(defvar csharp-backend 'nil
+  "The backend to use for IDE features.
+Possible values are `omnisharp' and `lsp'.
+If `nil' then `omnisharp' is the default backend.")

--- a/layers/+lang/csharp/funcs.el
+++ b/layers/+lang/csharp/funcs.el
@@ -12,26 +12,20 @@
 
 ;; backend
 
-(defun spacemacs//csharp-backend ()
-  "Returns selected backend."
-  (if csharp-backend
-      csharp-backend
-    'omnisharp))
-
 (defun spacemacs//csharp-setup-backend ()
   "Conditionally setup layer csharp based on backend."
-  (pcase (spacemacs//csharp-backend)
+  (pcase csharp-backend
     (`omnisharp (spacemacs//csharp-setup-omnisharp))
     (`lsp (spacemacs//csharp-setup-lsp))))
 
 (defun spacemacs//csharp-setup-company ()
   "Conditionally setup company based on backend."
-  (pcase (spacemacs//csharp-backend)
+  (pcase csharp-backend
     (`omnisharp (spacemacs//csharp-setup-omnisharp-company))))
 
 (defun spacemacs//csharp-configure ()
   "Conditionally configure csharp layer based on backend."
-  (pcase (spacemacs//csharp-backend)
+  (pcase csharp-backend
     (`omnisharp (spacemacs//csharp-configure-omnisharp))))
 
 

--- a/layers/+lang/csharp/funcs.el
+++ b/layers/+lang/csharp/funcs.el
@@ -1,0 +1,128 @@
+;;; funcs.el --- C# Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Muneeb Shaikh <muneeb@reversehack.in>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+;; backend
+
+(defun spacemacs//csharp-backend ()
+  "Returns selected backend."
+  (if csharp-backend
+      csharp-backend
+    'omnisharp))
+
+(defun spacemacs//csharp-setup-backend ()
+  "Conditionally setup layer csharp based on backend."
+  (pcase (spacemacs//csharp-backend)
+    (`omnisharp (spacemacs//csharp-setup-omnisharp))
+    (`lsp (spacemacs//csharp-setup-lsp))))
+
+(defun spacemacs//csharp-setup-company ()
+  "Conditionally setup company based on backend."
+  (pcase (spacemacs//csharp-backend)
+    (`omnisharp (spacemacs//csharp-setup-omnisharp-company))))
+
+(defun spacemacs//csharp-configure ()
+  "Conditionally configure csharp layer based on backend."
+  (pcase (spacemacs//csharp-backend)
+    (`omnisharp (spacemacs//csharp-configure-omnisharp))))
+
+
+;; omnisharp
+
+(defun spacemacs//csharp-setup-omnisharp ()
+  (when (configuration-layer/package-used-p 'omnisharp)
+    ;; Load omnisharp-mode with csharp-mode,
+    ;; this should start the omnisharp server automatically
+    (add-hook 'csharp-mode-hook 'omnisharp-mode)
+
+    (add-to-list 'spacemacs-jump-handlers-csharp-mode
+                 '(omnisharp-go-to-definition :async t))))
+
+(defun spacemacs//csharp-setup-omnisharp-company ()
+  "Setup omnisharp auto-completion."
+  (when (configuration-layer/package-used-p 'omnisharp)
+    (spacemacs|add-company-backends
+      :backends company-omnisharp
+      :modes csharp-mode)))
+
+(defun spacemacs//csharp-configure-omnisharp ()
+  (progn
+    ;; [missing in roslyn] (spacemacs/declare-prefix-for-mode 'csharp-mode "mc" "csharp/compile")
+    ;; [missing in roslyn] (spacemacs/declare-prefix-for-mode 'csharp-mode "mf" "csharp/file")
+    (spacemacs/declare-prefix-for-mode 'csharp-mode "mg" "csharp/navigation")
+    (spacemacs/declare-prefix-for-mode 'csharp-mode "mh" "csharp/documentation")
+    (spacemacs/declare-prefix-for-mode 'csharp-mode "mr" "csharp/refactoring")
+    (spacemacs/declare-prefix-for-mode 'csharp-mode "ms" "csharp/server")
+    (spacemacs/declare-prefix-for-mode 'csharp-mode "mt" "csharp/tests")
+
+    (spacemacs/set-leader-keys-for-major-mode 'csharp-mode
+      ;; Compile
+      ;; Only one compile command so use top-level
+      ;; [missing in roslyn] "cc" 'omnisharp-build-in-emacs
+
+      ;; Solution/project manipulation
+      ;; [missing in roslyn] "fa" 'omnisharp-add-to-solution-current-file
+      ;; [missing in roslyn] "fA" 'omnisharp-add-to-solution-dired-selected-files
+      ;; [missing in roslyn] "fr" 'omnisharp-remove-from-project-current-file
+      ;; [missing in roslyn] "fR" 'omnisharp-remove-from-project-dired-selected-files
+
+      ;; [missing in roslyn] "pl" 'omnisharp-add-reference
+
+      ;; Navigation
+      "ge"   'omnisharp-solution-errors
+      "gG"   'omnisharp-go-to-definition-other-window
+      "gu"   'omnisharp-helm-find-usages
+      "gU"   'omnisharp-find-usages-with-ido
+      "gs"   'omnisharp-helm-find-symbols
+      "gi"   'omnisharp-find-implementations
+      "gI"   'omnisharp-find-implementations-with-ido
+      "gr"   'omnisharp-navigate-to-region
+      "gm"   'omnisharp-navigate-to-solution-member
+      "gM"   'omnisharp-navigate-to-solution-member-other-window
+      "gf"   'omnisharp-navigate-to-solution-file
+      "gF"   'omnisharp-navigate-to-solution-file-then-file-member
+      "gc"   'omnisharp-navigate-to-current-file-member
+
+      ;; Help, documentation, info
+      "ht" 'omnisharp-current-type-information
+      "hT" 'omnisharp-current-type-information-to-kill-ring
+
+      ;; Refactoring
+      "rm" 'omnisharp-rename
+      ;; [Broken in roslyn] "rM" 'omnisharp-rename-interactively
+      "rr" 'omnisharp-run-code-action-refactoring
+
+      ;; Server manipulation, inspired spacemacs REPL bindings since C# does
+      ;; not provice a REPL
+      "ss" 'omnisharp-start-omnisharp-server
+      "sS" 'omnisharp-stop-server
+      "sr" 'omnisharp-reload-solution
+      "si" 'omnisharp-install-server
+
+      ;; Tests
+      ;; [missing in roslyn] "ta" 'omnisharp-unit-test-all
+      "tb" 'omnisharp-unit-test-buffer
+      "tl" 'omnisharp-unit-test-last
+      "tt" 'omnisharp-unit-test-at-point
+
+      ;; Code manipulation
+      "u" 'omnisharp-auto-complete-overrides
+      "i" 'omnisharp-fix-usings
+      ;; [missing in roslyn] "=" 'omnisharp-code-format
+      )
+    (spacemacs|hide-lighter omnisharp-mode)))
+
+
+;; lsp
+
+(defun spacemacs//csharp-setup-lsp ()
+  "Setup lsp backend."
+  (add-hook 'csharp-mode-hook #'lsp))

--- a/layers/+lang/csharp/layers.el
+++ b/layers/+lang/csharp/layers.el
@@ -1,0 +1,14 @@
+;;; layers.el --- C# Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'csharp-backend)
+           (eq csharp-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -1,6 +1,6 @@
-;;; packages.el --- csharp Layer packages File for Spacemacs
+;;; packages.el --- C# Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -22,86 +22,16 @@
         ))
 
 (defun csharp/init-omnisharp ()
-  ;; Load omnisharp-mode with csharp-mode,
-  ;; this should start the omnisharp server automatically
-  (add-hook 'csharp-mode-hook 'omnisharp-mode)
   (use-package omnisharp
     :defer t
     :init
-    (add-to-list 'spacemacs-jump-handlers-csharp-mode
-                 '(omnisharp-go-to-definition :async t))
+    (spacemacs//csharp-setup-backend)
     :config
-    (progn
-      ;; [missing in roslyn] (spacemacs/declare-prefix-for-mode 'csharp-mode "mc" "csharp/compile")
-      ;; [missing in roslyn] (spacemacs/declare-prefix-for-mode 'csharp-mode "mf" "csharp/file")
-      (spacemacs/declare-prefix-for-mode 'csharp-mode "mg" "csharp/navigation")
-      (spacemacs/declare-prefix-for-mode 'csharp-mode "mh" "csharp/documentation")
-      (spacemacs/declare-prefix-for-mode 'csharp-mode "mr" "csharp/refactoring")
-      (spacemacs/declare-prefix-for-mode 'csharp-mode "ms" "csharp/server")
-      (spacemacs/declare-prefix-for-mode 'csharp-mode "mt" "csharp/tests")
-
-      (spacemacs/set-leader-keys-for-major-mode 'csharp-mode
-        ;; Compile
-        ;; Only one compile command so use top-level
-        ;; [missing in roslyn] "cc" 'omnisharp-build-in-emacs
-
-        ;; Solution/project manipulation
-        ;; [missing in roslyn] "fa" 'omnisharp-add-to-solution-current-file
-        ;; [missing in roslyn] "fA" 'omnisharp-add-to-solution-dired-selected-files
-        ;; [missing in roslyn] "fr" 'omnisharp-remove-from-project-current-file
-        ;; [missing in roslyn] "fR" 'omnisharp-remove-from-project-dired-selected-files
-
-        ;; [missing in roslyn] "pl" 'omnisharp-add-reference
-
-        ;; Navigation
-        "ge"   'omnisharp-solution-errors
-        "gG"   'omnisharp-go-to-definition-other-window
-        "gu"   'omnisharp-helm-find-usages
-        "gU"   'omnisharp-find-usages-with-ido
-        "gs"   'omnisharp-helm-find-symbols
-        "gi"   'omnisharp-find-implementations
-        "gI"   'omnisharp-find-implementations-with-ido
-        "gr"   'omnisharp-navigate-to-region
-        "gm"   'omnisharp-navigate-to-solution-member
-        "gM"   'omnisharp-navigate-to-solution-member-other-window
-        "gf"   'omnisharp-navigate-to-solution-file
-        "gF"   'omnisharp-navigate-to-solution-file-then-file-member
-        "gc"   'omnisharp-navigate-to-current-file-member
-
-        ;; Help, documentation, info
-        "ht" 'omnisharp-current-type-information
-        "hT" 'omnisharp-current-type-information-to-kill-ring
-
-        ;; Refactoring
-        "rm" 'omnisharp-rename
-        ;; [Broken in roslyn] "rM" 'omnisharp-rename-interactively
-        "rr" 'omnisharp-run-code-action-refactoring
-
-        ;; Server manipulation, inspired spacemacs REPL bindings since C# does
-        ;; not provice a REPL
-        "ss" 'omnisharp-start-omnisharp-server
-        "sS" 'omnisharp-stop-server
-        "sr" 'omnisharp-reload-solution
-        "si" 'omnisharp-install-server
-
-        ;; Tests
-        ;; [missing in roslyn] "ta" 'omnisharp-unit-test-all
-        "tb" 'omnisharp-unit-test-buffer
-        "tl" 'omnisharp-unit-test-last
-        "tt" 'omnisharp-unit-test-at-point
-
-        ;; Code manipulation
-        "u" 'omnisharp-auto-complete-overrides
-        "i" 'omnisharp-fix-usings
-        ;; [missing in roslyn] "=" 'omnisharp-code-format
-        )
-      (spacemacs|hide-lighter omnisharp-mode))))
+    (spacemacs//csharp-configure)
+    ))
 
 (defun csharp/post-init-company ()
-  (when (configuration-layer/package-used-p 'omnisharp)
-    (spacemacs|add-company-backends
-      :backends company-omnisharp
-      :modes csharp-mode)))
+  (spacemacs//csharp-setup-company))
 
 (defun csharp/init-csharp-mode ()
   (use-package csharp-mode


### PR DESCRIPTION
This add support for the lsp package-based backend to `csharp` layer. A variable can be set when importing a layer to use an alternative (lsp) backend, in which case `lsp' layer is pulled in and omnisharp-emacs is not used.

I could not find a way to declare optional package dependency, like I did it for the `lsp` layer using  `configuration-layer/declare-layer-dependencies` – which would be nice to do to avoid pulling in the `omnisharp-emacs` package when using `lsp` backend.