### PR TITLE
Set VIRTUAL_ENV environment variable when switching to new pyenv

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -221,7 +221,9 @@ as the pyenv version then also return nil. This works around https://github.com/
                                        (line-beginning-position)
                                        (line-end-position)))))))
         (if (member version (pyenv-mode-versions))
-            (pyenv-mode-set version)
+            (progn
+              (setenv "VIRTUAL_ENV" version)
+              (pyenv-mode-set version))
           (message "pyenv: version `%s' is not installed (set by %s)"
                    version file-path))))))
 


### PR DESCRIPTION
This environment variable is used by python LSP to determine
the pyenv virtual environment to use. When switching to a different
project using projectile 'switch-to-project', it should only be
necessary to restart the LSP server but a restart will only
work if this VIRTUAL_ENV changes value too.