### PR TITLE
Fix typos

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -69,7 +69,7 @@ the final step of executing code in `emacs-startup-hook'.")
   (hidden-mode-line-mode)
   (spacemacs//removes-gui-elements)
   (spacemacs//setup-ido-vertical-mode)
-  ;; explicitly set the prefered coding systems to avoid annoying prompt
+  ;; explicitly set the preferred coding systems to avoid annoying prompt
   ;; from emacs (especially on Microsoft Windows)
   (prefer-coding-system 'utf-8)
   ;; TODO move these variables when evil is removed from the bootstrapped

--- a/core/tools/spacefmt/spacefmt
+++ b/core/tools/spacefmt/spacefmt
@@ -20,7 +20,7 @@ then
     exit 1
 fi
 
-#Use "sed" or "gsed" if avaliable.
+#Use "sed" or "gsed" if available.
 seder="sed"
 if hash gsed 2>/dev/null; then
     seder="gsed"

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -293,7 +293,7 @@ Before initializing that package, Spacemacs will add this folder to the load
 path for you.
 
 ** layers.el
-This file is the first file to be loaded and this is the place where addtional
+This file is the first file to be loaded and this is the place where additional
 layers can be declared.
 
 For instance is layer A depends on some functionality of layer B then in the

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -82,7 +82,7 @@
 
       (require 'notifications)
       (defun erc-global-notify (match-type nick message)
-        "Notify when a message is recieved."
+        "Notify when a message is received."
         (notifications-notify
          :title nick
          :body message

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -123,7 +123,7 @@
     (progn
       (helm-mode)
       (advice-add 'helm-grep-save-results-1 :after 'spacemacs//gne-init-helm-grep)
-      ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
+      ;; helm-locate uses es (from everything on windows which doesn't like fuzzy)
       (helm-locate-set-command)
       (setq helm-locate-fuzzy-match (string-match "locate" helm-locate-command))
       ;; alter helm-bookmark key bindings to be simpler

--- a/layers/+distributions/spacemacs-base/config.el
+++ b/layers/+distributions/spacemacs-base/config.el
@@ -70,7 +70,7 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Edit
 ;; ---------------------------------------------------------------------------
 
-;; start scratch in text mode (usefull to get a faster Emacs load time
+;; start scratch in text mode (useful to get a faster Emacs load time
 ;; because it avoids autoloads of elisp modes)
 (setq initial-major-mode 'text-mode)
 

--- a/layers/+lang/asm/funcs.el
+++ b/layers/+lang/asm/funcs.el
@@ -24,7 +24,7 @@
 ;; colon and the original point the colon was inserted.
 ;;
 ;; These functions solve that problem. First, check whether we have any
-;; space or tab after point. If so, don't do anything becuase the spaces are
+;; space or tab after point. If so, don't do anything because the spaces are
 ;; there intentionally. If not, we delete all trailing spaces between
 ;; point and colon.
 (defvar asm-colon-has-space nil)

--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -27,7 +27,7 @@
     :config
     (progn
       ;; We need to insert a non-indented line, otherwise it's annoying
-      ;; everytime we insert a comment for a routine
+      ;; every time we insert a comment for a routine
       (define-key asm-mode-map (kbd "C-j") 'newline)
       (add-hook 'asm-mode-hook #'asm-generic-setup))))
 
@@ -46,7 +46,7 @@
     :config
     (progn
       ;; We need to insert a non-indented line, otherwise it's annoying
-      ;; everytime we insert a comment for a routine
+      ;; every time we insert a comment for a routine
       (define-key nasm-mode-map (kbd "C-j") 'newline)
       ;; we use the advised `asm-colon' because `nasm-colon indents the whole line, even
       ;; inside a comment

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -17,7 +17,7 @@
 (defvar typescript-fmt-tool 'tide
   "The name of the tool to be used
 for TypeScript source code formatting.
-Currently avaliable 'tide (default)
+Currently available 'tide (default)
 and 'typescript-formatter .")
 
 (spacemacs|define-jump-handlers typescript-mode)

--- a/layers/+spacemacs/spacemacs-ui-visual/local/zoom-frm/zoom-frm.el
+++ b/layers/+spacemacs/spacemacs-ui-visual/local/zoom-frm/zoom-frm.el
@@ -61,7 +61,7 @@
 ;;
 ;;    Frame parameter changes, such as font size, can be saved for
 ;;    future use by all frames or all frames of a certain kind.  For
-;;    that, you must change the frame parameters of the correponding
+;;    that, you must change the frame parameters of the corresponding
 ;;    frame-alist variable.
 ;;
 ;;    There is no single variable for saving changes to parameters of

--- a/layers/+spacemacs/spacemacs-ui/local/centered-cursor/centered-cursor-mode.el
+++ b/layers/+spacemacs/spacemacs-ui/local/centered-cursor/centered-cursor-mode.el
@@ -89,7 +89,7 @@
 ;;   * not recentering at end of buffer
 ;;   * defvar animate-first-start-p
 ;; 2007-09-14  andre-r
-;;   * inital release
+;;   * initial release
 
 ;; This file is *NOT* part of GNU Emacs.
 

--- a/layers/+tools/dash/packages.el
+++ b/layers/+tools/dash/packages.el
@@ -55,6 +55,6 @@
       "dd" 'zeal-at-point
       "dD" 'zeal-at-point-set-docset)
     :config
-    ;; This lets users seach in multiple docsets
+    ;; This lets users search in multiple docsets
     (push '(web-mode . "html,css,javascript") zeal-at-point-mode-alist)
     ))


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.