### PR TITLE
[semantic] Moved toggle keys to the layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2780,6 +2780,7 @@ Other:
   system databases to speed up semantic (thanks to bet4it)
 - Disabled =semantic-idle-summary-mode= when =gtags= or =lsp= layer is enabled
   (thanks to bet4it)
+- Moved the toggle key bindings to the semantic layer (thanks to duianto)
 **** Shell
 - Key bindings:
   - Added =vterm= bindings:

--- a/layers/+emacs/semantic/README.org
+++ b/layers/+emacs/semantic/README.org
@@ -39,6 +39,8 @@ file.
 
 * Key bindings
 
-| Key binding | Description                         |
-|-------------+-------------------------------------|
-| ~SPC m r~   | srefactor: refactor thing at point. |
+| Key binding | Description                              |
+|-------------+------------------------------------------|
+| ~SPC m r~   | srefactor: refactor thing at point.      |
+| ~SPC T S~   | toggle =semantic-stickyfunc-mode=        |
+| ~SPC T C-S~ | toggle =global-semantic-stickyfunc-mode= |

--- a/layers/+emacs/semantic/packages.el
+++ b/layers/+emacs/semantic/packages.el
@@ -29,8 +29,20 @@
   (spacemacs|use-package-add-hook semantic
     :post-init (add-to-list 'semantic-default-submodes
                             'global-semantic-stickyfunc-mode)))
+
 (defun semantic/init-stickyfunc-enhance ()
-  (use-package stickyfunc-enhance :defer t))
+  (use-package stickyfunc-enhance
+    :defer t
+    :init
+    (progn
+      (spacemacs|add-toggle semantic-stickyfunc
+        :mode semantic-stickyfunc-mode
+        :documentation "Enable semantic-stickyfunc."
+        :evil-leader "TS")
+      (spacemacs|add-toggle semantic-stickyfunc-globally
+        :mode global-semantic-stickyfunc-mode
+        :documentation "Enable semantic-stickyfunc globally."
+        :evil-leader "T C-S"))))
 
 (defun spacemacs//disable-semantic-idle-summary-mode ()
   (semantic-idle-summary-mode 0))

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -535,14 +535,6 @@ respond to this toggle."
   :mode menu-bar-mode
   :documentation "Display the menu bar."
   :evil-leader "Tm")
-(spacemacs|add-toggle semantic-stickyfunc
-  :mode semantic-stickyfunc-mode
-  :documentation "Enable semantic-stickyfunc."
-  :evil-leader "TS")
-(spacemacs|add-toggle semantic-stickyfunc-globally
-  :mode global-semantic-stickyfunc-mode
-  :documentation "Enable semantic-stickyfunc globally."
-  :evil-leader "T C-S")
 ;; quit -----------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "qs" 'spacemacs/save-buffers-kill-emacs


### PR DESCRIPTION
`SPC T S` and `SPC T C-S` showed void variable
semantic-stickyfunc messages when the semantic
layer wasn't installed.

Fixes: #13011