### PR TITLE
Fix typos

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -151,7 +151,7 @@
       (helm-mode)
       (spacemacs|hide-lighter helm-mode)
       (advice-add 'helm-grep-save-results-1 :after 'spacemacs//gne-init-helm-grep)
-      ;; helm-locate uses es (from everything on windows which doesnt like fuzzy)
+      ;; helm-locate uses es (from everything on windows which doesn't like fuzzy)
       (helm-locate-set-command)
       (setq helm-locate-fuzzy-match (string-match "locate" helm-locate-command))
       (setq helm-boring-buffer-regexp-list

--- a/layers/+distributions/spacemacs-docker/deps-install/README.org
+++ b/layers/+distributions/spacemacs-docker/deps-install/README.org
@@ -11,7 +11,7 @@ Dependency installation scripts for Spacemacs layers
 in Docker environment.
 
 ** Features:
-- Add Spacemacs to your Docker enviroment so you can build, ship, and run apps, anywhere
+- Add Spacemacs to your Docker environment so you can build, ship, and run apps, anywhere
 
 * Supported layers
 1. [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bdistributions/spacemacs-docker/deps-install/installers/clojure/README.org][Clojure]]

--- a/layers/+distributions/spacemacs-docker/deps-install/installers/go/install.el
+++ b/layers/+distributions/spacemacs-docker/deps-install/installers/go/install.el
@@ -34,7 +34,7 @@
                              ($ "go version")))
         (progn (setq silient nil)
                (! (v "Golang installation failed!\n"
-                     (l "Expected verison %s but got %s"
+                     (l "Expected version %s but got %s"
                         go-version
                         ($ "go version")))))
       (! "Building Golang tools...")

--- a/layers/+lang/asm/funcs.el
+++ b/layers/+lang/asm/funcs.el
@@ -24,7 +24,7 @@
 ;; colon and the original point the colon was inserted.
 ;;
 ;; These functions solve that problem. First, check whether we have any
-;; space or tab after point. If so, don't do anything becuase the spaces are
+;; space or tab after point. If so, don't do anything because the spaces are
 ;; there intentionally. If not, we delete all trailing spaces between
 ;; point and colon.
 (defvar asm-colon-has-space nil)

--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -29,7 +29,7 @@
     :config
     (progn
       ;; We need to insert a non-indented line, otherwise it's annoying
-      ;; everytime we insert a comment for a routine
+      ;; every time we insert a comment for a routine
       (define-key asm-mode-map (kbd "C-j") 'newline)
       (add-hook 'asm-mode-hook #'asm-generic-setup))))
 
@@ -48,7 +48,7 @@
     :config
     (progn
       ;; We need to insert a non-indented line, otherwise it's annoying
-      ;; everytime we insert a comment for a routine
+      ;; every time we insert a comment for a routine
       (define-key nasm-mode-map (kbd "C-j") 'newline)
       ;; we use the advised `asm-colon' because `nasm-colon indents the whole line, even
       ;; inside a comment

--- a/layers/+lang/factor/README.org
+++ b/layers/+lang/factor/README.org
@@ -52,7 +52,7 @@ To use this layer, add it to your =./spacemacs= file. Add =factor= to the
 | ~SPC m r r~ | Extract region as separate word                     |
 | ~SPC m r v~ | Create new Vocab with words in region               |
 | ~SPC m r i~ | Inline word                                         |
-| ~SPC m r w~ | Rename all occurences of word                       |
+| ~SPC m r w~ | Rename all occurrences of word                      |
 | ~SPC m r a~ | Extract region as new ARTICLE form                  |
 | ~SPC m r g~ | Turn current definition into generic word           |
 | ~SPC m r u~ | Update USING: line according to actually used words |

--- a/layers/+lang/reasonml/README.org
+++ b/layers/+lang/reasonml/README.org
@@ -84,4 +84,4 @@ The main key bindings, see =packages.el= for the main list.
 | ~SPC m = r m~ | Refmt: convert re syntax to ml syntax |
 
 * Thanks
-Special thanks to [[https://github.com/fredyr/][fredyr]] who wrote the initial verison of this layer.
+Special thanks to [[https://github.com/fredyr/][fredyr]] who wrote the initial version of this layer.

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -16,7 +16,7 @@
 
 (defvar typescript-fmt-tool 'tide
   "The name of the tool to be used for TypeScript source code formatting.
-Currently avaliable 'tide (default), 'typescript-formatter and 'prettier.")
+Currently available 'tide (default), 'typescript-formatter and 'prettier.")
 
 (defvar typescript-backend nil
   "The backend to use for IDE features.

--- a/layers/+readers/dash/packages.el
+++ b/layers/+readers/dash/packages.el
@@ -47,5 +47,5 @@
             "dd" 'zeal-at-point
             "dD" 'zeal-at-point-set-docset))
     :config
-    ;; This lets users seach in multiple docsets
+    ;; This lets users search in multiple docsets
     (add-to-list 'zeal-at-point-mode-alist '(web-mode . "html,css,javascript"))))

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -254,7 +254,7 @@
       (when dotspacemacs-line-numbers
         ;; delay the initialization of number lines when opening Spacemacs
         ;; normally. If opened via the command line with a file to visit then
-        ;; load it immediatly
+        ;; load it immediately
         (add-hook 'emacs-startup-hook
                   (lambda ()
                     (if (string-equal "*scratch*" (buffer-name))

--- a/layers/+spacemacs/spacemacs-visual/local/zoom-frm/zoom-frm.el
+++ b/layers/+spacemacs/spacemacs-visual/local/zoom-frm/zoom-frm.el
@@ -61,7 +61,7 @@
 ;;
 ;;    Frame parameter changes, such as font size, can be saved for
 ;;    future use by all frames or all frames of a certain kind.  For
-;;    that, you must change the frame parameters of the correponding
+;;    that, you must change the frame parameters of the corresponding
 ;;    frame-alist variable.
 ;;
 ;;    There is no single variable for saving changes to parameters of

--- a/layers/+tools/bm/packages.el
+++ b/layers/+tools/bm/packages.el
@@ -23,7 +23,7 @@
             (setq bm-cycle-all-buffers t)
             ;; save bookmarks
             (setq-default bm-buffer-persistence t)
-            ;; where to store persistant files
+            ;; where to store persistent files
             (setq bm-repository-file (format "%sbm-repository"
                                              spacemacs-cache-directory))
             (spacemacs|define-transient-state bm


### PR DESCRIPTION
A reworking of https://github.com/syl20bnr/spacemacs/pull/13008 , from "develop" instead of "master".

Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.