### PR TITLE
[helm] Fix searching in projects with C-s from SPC p p

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1900,7 +1900,7 @@ Other:
   - Removed ~SPC s w w~ key binding for =helm-wikipedia-suggest=, which was
     removed upstream.
   - ~SPC g f f~ for =helm-ls-git-ls= (thanks to duianto)
-- Fixes
+- Fixes:
   - Fixed signature of =spacemacs//display-helm-window= (thanks to Jack Kamm)
   - Fixed initialization by calling =helm-mode= when Helm is initialized=
     (thanks to bet4it).
@@ -1921,6 +1921,7 @@ Other:
     available windows (thanks to Juha Jeronen)
   - Unfolded org headings to a target line when a .org file is opened from
     Helm-ag (thanks to duianto and Miciah Masters)
+  - Fixed searching in a project with ~C-s~ from ~SPC p p~ (thanks to duianto)
 **** HTML
 - Added impatient-mode under ~SPC m i~ (thanks to geo7)
 - Added =counsel-css= as an =ivy= alternative to =helm-css-scss=

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -189,7 +189,17 @@
       ;; to search using rg/ag/pt/whatever instead of just grep
       (with-eval-after-load 'helm-projectile
         (define-key helm-projectile-projects-map
-          (kbd "C-s") 'spacemacs/helm-projectile-grep))
+          (kbd "C-s") 'spacemacs/helm-projectile-grep)
+        ;; `spacemacs/helm-projectile-grep' calls:
+        ;; `spacemacs/helm-project-smart-do-search-in-dir'
+        ;; which needs to be an action.
+        ;; Delete the current action.
+        (helm-delete-action-from-source
+         "Grep in projects `C-s'" helm-source-projectile-projects)
+        (helm-add-action-to-source
+         "Search in projects `C-s'"
+         'spacemacs/helm-project-smart-do-search-in-dir
+         helm-source-projectile-projects))
 
       ;; evilify the helm-grep buffer
       (evilified-state-evilify helm-grep-mode helm-grep-mode-map


### PR DESCRIPTION
Fixes #11878

The issue seems to have been caused by helm making sure that
the functions that are called with: `helm-exit-and-execute-action`
are actions.

Ensure action is available before running it
emacs-helm/helm@d6dfb8f