### PR TITLE
[html][vue] Improve Transient States

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1947,6 +1947,7 @@ Other:
   (thanks to Anton Alekseev)
 - Added support for =.svelte= files (thanks to Javier Candeira)
 - Added =lsp= support for =html= buffers (thanks to Thanh Vuong)
+- Added a toggle state minified/full to the transient state (thanks to duianto)
 **** Hy
 - Added support for pipenv (thanks to Cazim Hysi)
 - Updated Hy layer to current Hy mode (thanks to Cazim Hysi)
@@ -3080,6 +3081,8 @@ Other:
 - Avoid loading all the diff packages (thanks to Sylvain Benner)
 - Fixed error on =diff-hl-margin-mode= function being nil during startup
   (thanks to Voleking)
+**** Vue
+- Added a toggle state minified/full to the transient state (thanks to duianto)
 **** Xclipboard
 - Added Requirements documentation (thanks to Chris Glass)
 - Added =cliphist= with the following bindings: (thanks to Hong Xu)

--- a/layers/+frameworks/vue/funcs.el
+++ b/layers/+frameworks/vue/funcs.el
@@ -111,26 +111,71 @@
     "rk" 'web-mode-element-kill
     "rn" 'web-mode-element-rename
     "rw" 'web-mode-element-wrap
-    "z" 'web-mode-fold-or-unfold)
-  (spacemacs|define-transient-state vue-mode
-    :title "Web-mode Transient State"
-    :columns 4
+    "z" 'web-mode-fold-or-unfold))
+
+(defun spacemacs//vue-setup-transient-state ()
+  (defvar spacemacs--vue-ts-full-hint-toggle nil
+    "Toggle the state of the vue transient state documentation.")
+
+  (defvar spacemacs--vue-ts-full-hint nil
+    "Display full vue transient state documentation.")
+
+  (defvar spacemacs--vue-ts-minified-hint nil
+    "Display minified vue transient state documentation.")
+
+  (defun spacemacs//vue-ts-toggle-hint ()
+    "Toggle the full hint docstring for the vue transient state."
+    (interactive)
+    (setq spacemacs--vue-ts-full-hint-toggle
+          (not spacemacs--vue-ts-full-hint-toggle)))
+
+  (defun spacemacs//vue-ts-hint ()
+    "Return a condensed/full hint for the vue transient state"
+    (concat
+     " "
+     (if spacemacs--vue-ts-full-hint-toggle
+         spacemacs--vue-ts-full-hint
+       (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"
+               spacemacs--vue-ts-minified-hint))))
+
+  (spacemacs|transient-state-format-hint vue
+    spacemacs--vue-ts-minified-hint "\n
+Navigate: _j_ _k_ _J_ _K_ _h_ _l_ Element: _c_ _d_ _D_ _r_ _w_ Other: _p_")
+
+  (spacemacs|transient-state-format-hint vue
+    spacemacs--vue-ts-full-hint
+    (format "\n[_?_] toggle help
+Navigate^^^^                 Element^^                    Other
+[_j_/_k_] next/prev element  [_c_] clone                  [_p_] xpath (display path)
+[_J_/_K_] next/prev sibling  [_d_] vanish (keep content)  [_q_] quit
+[_h_/_l_] parent/child       [_D_] kill (inkl. content)
+^^^^                         [_r_] rename
+^^^^                         [_w_] wrap"))
+
+  (spacemacs|define-transient-state vue
+    :title "Vue Transient State"
+    :hint-is-doc t
+    :dynamic-hint (spacemacs//vue-ts-hint)
     :foreign-keys run
     :evil-leader-for-mode (vue-mode . ".")
     :bindings
-    ("D" web-mode-element-kill "kill")
-    ("J" web-mode-element-sibling-next "next sibling")
-    ("K" web-mode-element-sibling-previous "previous sibling")
-    ("c" web-mode-element-clone "clone")
-    ("d" web-mode-element-vanish "delete")
+    ("?" spacemacs//vue-ts-toggle-hint)
+    ;; Navigate
+    ("j"  web-mode-element-next)
+    ("k"  web-mode-element-previous)
+    ("J"  web-mode-element-sibling-next)
     ("gj" web-mode-element-sibling-next)
+    ("K"  web-mode-element-sibling-previous)
     ("gk" web-mode-element-sibling-previous)
-    ("h" web-mode-element-parent "parent")
-    ("j" web-mode-element-next "next")
-    ("k" web-mode-element-previous "previous")
-    ("l" web-mode-element-child "child")
-    ("p" web-mode-dom-xpath "xpath")
-    ("q" nil "quit" :exit t)
-    ("r" web-mode-element-rename "rename" :exit t)
-    ("w" web-mode-element-wrap "wrap")
-    ("<escape>" nil nil :exit t)))
+    ("h"  web-mode-element-parent)
+    ("l"  web-mode-element-child)
+    ;; Element
+    ("c" web-mode-element-clone)
+    ("d" web-mode-element-vanish)
+    ("D" web-mode-element-kill)
+    ("r" web-mode-element-rename)
+    ("w" web-mode-element-wrap)
+    ;; Other
+    ("p" web-mode-dom-xpath)
+    ("q" nil :exit t)
+    ("<escape>" nil :exit t)))

--- a/layers/+frameworks/vue/packages.el
+++ b/layers/+frameworks/vue/packages.el
@@ -25,7 +25,8 @@
   (add-to-list 'auto-mode-alist '("\\.vue\\'" . vue-mode))
   (spacemacs/add-to-hook 'vue-mode-hook '(spacemacs//vue-setup-editor-style
                                           spacemacs//vue-setup-keybindings))
-  (add-hook 'vue-mode-local-vars-hook #'spacemacs//vue-setup-backend))
+  (add-hook 'vue-mode-local-vars-hook #'spacemacs//vue-setup-backend)
+  (spacemacs//vue-setup-transient-state))
 
 (defun vue/post-init-add-node-modules-path ()
   (add-hook 'vue-mode-hook #'add-node-modules-path))

--- a/layers/+lang/html/funcs.el
+++ b/layers/+lang/html/funcs.el
@@ -63,3 +63,70 @@
                                (match-string 1 (buffer-name))))))
     (when (string= buffer-extension "html")
       (spacemacs//setup-lsp-for-web-mode-buffers))))
+
+(defun spacemacs//web-setup-transient-state ()
+  (defvar spacemacs--web-ts-full-hint-toggle nil
+    "Toggle the state of the web transient state documentation.")
+
+  (defvar spacemacs--web-ts-full-hint nil
+    "Display full web transient state documentation.")
+
+  (defvar spacemacs--web-ts-minified-hint nil
+    "Display minified web transient state documentation.")
+
+  (defun spacemacs//web-ts-toggle-hint ()
+    "Toggle the full hint docstring for the web transient state."
+    (interactive)
+    (setq spacemacs--web-ts-full-hint-toggle
+          (not spacemacs--web-ts-full-hint-toggle)))
+
+  (defun spacemacs//web-ts-hint ()
+    "Return a condensed/full hint for the web transient state"
+    (concat
+     " "
+     (if spacemacs--web-ts-full-hint-toggle
+         spacemacs--web-ts-full-hint
+       (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"
+               spacemacs--web-ts-minified-hint))))
+
+  (spacemacs|transient-state-format-hint web
+    spacemacs--web-ts-minified-hint "\n
+Navigate: _j_ _k_ _J_ _K_ _h_ _l_ Element: _c_ _d_ _D_ _r_ _w_ Other: _p_")
+
+  (spacemacs|transient-state-format-hint web
+    spacemacs--web-ts-full-hint
+    (format "\n[_?_] toggle help
+Navigate^^^^                 Element^^                    Other
+[_j_/_k_] next/prev element  [_c_] clone                  [_p_] xpath (display path)
+[_J_/_K_] next/prev sibling  [_d_] vanish (keep content)  [_q_] quit
+[_h_/_l_] parent/child       [_D_] kill (inkl. content)
+^^^^                         [_r_] rename
+^^^^                         [_w_] wrap"))
+
+  (spacemacs|define-transient-state web
+    :title "Web Transient State"
+    :hint-is-doc t
+    :dynamic-hint (spacemacs//web-ts-hint)
+    :foreign-keys run
+    :evil-leader-for-mode (web-mode . ".")
+    :bindings
+    ("?" spacemacs//web-ts-toggle-hint)
+    ;; Navigate
+    ("j"  web-mode-element-next)
+    ("k"  web-mode-element-previous)
+    ("J"  web-mode-element-sibling-next)
+    ("gj" web-mode-element-sibling-next)
+    ("K"  web-mode-element-sibling-previous)
+    ("gk" web-mode-element-sibling-previous)
+    ("h"  web-mode-element-parent)
+    ("l"  web-mode-element-child)
+    ;; Element
+    ("c" web-mode-element-clone)
+    ("d" web-mode-element-vanish)
+    ("D" web-mode-element-kill)
+    ("r" web-mode-element-rename)
+    ("w" web-mode-element-wrap)
+    ;; Other
+    ("p" web-mode-dom-xpath)
+    ("q" nil :exit t)
+    ("<escape>" nil :exit t)))

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -204,6 +204,11 @@
 (defun html/init-web-mode ()
   (use-package web-mode
     :defer t
+    :init
+    (progn
+      (spacemacs//web-setup-transient-state)
+      (when html-enable-lsp
+        (add-hook 'web-mode-hook #'spacemacs//setup-lsp-for-html-buffer t)))
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'web-mode "m=" "format")
@@ -225,49 +230,7 @@
         "rw" 'web-mode-element-wrap
         "z" 'web-mode-fold-or-unfold
         ;; TODO element close would be nice but broken with evil.
-        )
-
-      ;; (defvar spacemacs--web-mode-ms-doc-toggle 0
-      ;;   "Display a short doc when nil, full doc otherwise.")
-
-      ;;     (defun spacemacs//web-mode-ms-doc ()
-      ;;       (if (equal 0 spacemacs--web-mode-ms-doc-toggle)
-      ;;           "[_?_] for help"
-      ;;         "
-      ;; [_?_] display this help
-      ;; [_k_] previous [_j_] next   [_K_] previous sibling [_J_] next sibling
-      ;; [_h_] parent   [_l_] child  [_c_] clone [_d_] delete [_D_] kill [_r_] rename
-      ;; [_w_] wrap     [_p_] xpath
-      ;; [_q_] quit"))
-
-      ;;     (defun spacemacs//web-mode-ms-toggle-doc ()
-      ;;       (interactive)
-      ;;       (setq spacemacs--web-mode-ms-doc-toggle
-      ;;             (logxor spacemacs--web-mode-ms-doc-toggle 1)))
-
-      (spacemacs|define-transient-state web-mode
-        :title "Web-mode Transient State"
-        :columns 4
-        :foreign-keys run
-        :evil-leader-for-mode (web-mode . ".")
-        :bindings
-        ("j" web-mode-element-next "next")
-        ("J" web-mode-element-sibling-next "next sibling")
-        ("gj" web-mode-element-sibling-next)
-        ("k" web-mode-element-previous "previous")
-        ("K" web-mode-element-sibling-previous "previous sibling")
-        ("gk" web-mode-element-sibling-previous)
-        ("h" web-mode-element-parent "parent")
-        ("l" web-mode-element-child "child")
-        ("c" web-mode-element-clone "clone")
-        ("d" web-mode-element-vanish "delete")
-        ("D" web-mode-element-kill "kill")
-        ("r" web-mode-element-rename "rename" :exit t)
-        ("w" web-mode-element-wrap "wrap")
-        ("p" web-mode-dom-xpath "xpath")
-        ("q" nil "quit" :exit t)
-        ("<escape>" nil nil :exit t)))
-
+        ))
     :mode
     (("\\.phtml\\'"      . web-mode)
      ("\\.tpl\\.php\\'"  . web-mode)
@@ -285,10 +248,7 @@
      ("\\.eco\\'"        . web-mode)
      ("\\.ejs\\'"        . web-mode)
      ("\\.svelte\\'"     . web-mode)
-     ("\\.djhtml\\'"     . web-mode))
-    :init
-    (when html-enable-lsp
-      (add-hook 'web-mode-hook #'spacemacs//setup-lsp-for-html-buffer t))))
+     ("\\.djhtml\\'"     . web-mode))))
 
 (defun html/post-init-yasnippet ()
   (spacemacs/add-to-hooks 'spacemacs/load-yasnippet '(css-mode-hook


### PR DESCRIPTION
Added a full/minified transient state toggle.

Grouped backend transient state key bindings by column.

Moved the html/init-web-mode :init section before the :config section.

---

### Before
![before](https://user-images.githubusercontent.com/13420573/70381820-94efa480-1951-11ea-8432-319bafef36e0.gif)

### After
#### Minified
![after minified](https://user-images.githubusercontent.com/13420573/70381828-a5a01a80-1951-11ea-8c2a-a3e011f3509e.gif)

#### Full
![after full](https://user-images.githubusercontent.com/13420573/70381825-9de07600-1951-11ea-97e1-6efccfa3523b.gif)

### Notes
The transient state key bindings in both the `html` and `vue` layers are the same.
It's just the variables, functions and transient state title that use different names `web` vs `vue`.

It's redundant and any key binding modifications will have to be changed in two places (four when including the transient state listings for the keys).

It's probably possible to make a single source for both layers but since this seems to be working it might be better to implement this change now and refactor it in the future.