### PR TITLE
Fix SPC-TAB in spacemacs-base distribution

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -523,7 +523,7 @@ Other:
   - Use a unique variable for each transient state's full-hint toggle function
     so that toggling the full hint in one transient state does not affect other
     transient states (thanks to Miciah Dashiel Butler Masters)
-- Fixed:
+- Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed
     counter from progress bar, fixed updating, and fixed size when Emacs is
@@ -604,6 +604,7 @@ Other:
   - Removed Unicode triple dot in both =dotspacemacs-smart-closing-parenthesis=
     variable comments in favor of the ASCII one (thanks to nshadov)
   - Fixed home buffer version insertion removing first line (thanks to duianto)
+  - Fixed ~SPC TAB~ in =spacemacs-base= distribution (thanks to duianto)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -324,7 +324,7 @@ If `spacemacs-layouts-restrict-spc-tab' is `t' then this only switches between
 the current layouts buffers."
   (interactive)
   (destructuring-bind (buf start pos)
-      (if spacemacs-layouts-restrict-spc-tab
+      (if (bound-and-true-p spacemacs-layouts-restrict-spc-tab)
           (let ((buffer-list (persp-buffer-list))
                 (my-buffer (window-buffer window)))
             ;; find buffer of the same persp in window


### PR DESCRIPTION
Problem:
The variable `spacemacs-layouts-restrict-spc-tab` is defined in:
`~/.emacs.d/layers/+spacemacs/spacemacs-layouts/config.el`
But the `spacemacs-layouts` layer isn't loaded by default in `spacemacs-base`.

Solution:
Check if the variable is bound.