### PR TITLE
Fix clang-format-on-save

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -78,8 +78,7 @@
 
 (defun c-c++/init-clang-format ()
   (use-package clang-format
-    :init (spacemacs/add-to-hooks #'spacemacs//c-c++-setup-format
-                                  c-c++-mode-hooks)))
+    :init (spacemacs//c-c++-setup-clang-format)))
 
 (defun c-c++/post-init-company ()
   (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-company)


### PR DESCRIPTION
Howdy!

Currently, `c-c++/init-clang-format` adds `spacemacs//c-c++-setup-format` to c-c++-mode-hooks. This has the effect of only automatically formatting c/c++ files on save _the second time_ I open a buffer, or I refresh the major mode with SPC-h-M.

In other words, the c-c++ layer adds a hook to add a hook when Spacemacs enters a c-c++-mode. This commit simply sets up clang format directly when initializing the package.

I'm not sure if this issue is affecting other Spacemacs users, but #10041 is still open, and I hope this can help everyone.

Thanks!