### PR TITLE
Update Vue layer README to fix the link formatting

### DIFF
--- a/layers/+frameworks/vue/README.org
+++ b/layers/+frameworks/vue/README.org
@@ -162,4 +162,4 @@ A transient-state is also defined, start it with ~SPC m .~ or ~, .~
 | ~SPC m G~   | jump to definition for the given name                |
 
 ** Lsp key bindings
-See the [=lsp= layer]([[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp]]).
+See the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp][lsp layer]].


### PR DESCRIPTION
A trivial change, the link to the LSP layer was broken.