### PR TITLE
Automatically choose the `lsp' as python-formatter when lsp-layer is enabled

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2638,6 +2638,7 @@ Other:
 - Fix lazy loading of =lsp-python-ms= (thanks to lsp-ableton)
 - Fix =Ipython= path on windows (thanks to Daniel K)
 - Make =inferior-python-mode= do not use tabs (thanks to tsoernes)
+- Automatic use the =lsp= as =python-formater= when =lsp= is enabled (thanks sunlin7)
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -236,6 +236,9 @@ One of [[https://github.com/google/yapf][YAPF]] (the default), [[https://github.
     (python :variables python-formatter 'yapf)))
 #+END_SRC
 
+Alternatively the =lsp= formatter will be automatically chosen if the layer =lsp=
+is used and you did not specify any value for =python-formatter=.
+
 The key binding ~SPC m =~ invokes the selected formatter on the current buffer
 when in non LSP python mode otherwise ~SPC m ==~ is used.
 

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -29,7 +29,7 @@ and `mspyls'")
 (defvar python-pipenv-activate nil
   "If non-nil, activate pipenv before enabling backend")
 
-(defvar python-formatter 'yapf
+(defvar python-formatter nil
   "The formatter to use. Possible values are `yapf',
   `black' and 'lsp'.")
 

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -17,6 +17,14 @@
      ((configuration-layer/layer-used-p 'lsp) 'lsp)
      (t 'anaconda))))
 
+(defun spacemacs//python-formatter ()
+  "Returns selected backend."
+  (if python-formatter
+      python-formatter
+    (cond
+     ((configuration-layer/layer-used-p 'lsp) 'lsp)
+     (t 'yapf))))
+
 (defun spacemacs//python-setup-backend ()
   "Conditionally setup python backend."
   (when python-pipenv-activate (pipenv-activate))
@@ -381,7 +389,7 @@ Bind formatter to '==' for LSP and '='for all other backends."
 (defun spacemacs/python-format-buffer ()
   "Bind possible python formatters."
   (interactive)
-  (pcase python-formatter
+  (pcase (spacemacs//python-formatter)
     (`yapf (yapfify-buffer))
     (`black (blacken-buffer))
     (`lsp (lsp-format-buffer))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -106,7 +106,7 @@
     (progn
       (spacemacs//bind-python-formatter-keys)
       (when (and python-format-on-save
-                 (eq 'black python-formatter))
+                 (eq 'black (spacemacs//python-formatter)))
         (add-hook 'python-mode-hook 'blacken-mode)))
     :config (spacemacs|hide-lighter blacken-mode)))
 
@@ -425,7 +425,7 @@ fix this issue."
     (progn
       (spacemacs//bind-python-formatter-keys)
       (when (and python-format-on-save
-                 (eq 'yapf python-formatter))
+                 (eq 'yapf (spacemacs//python-formatter)))
         (add-hook 'python-mode-hook 'yapf-mode)))
     :config (spacemacs|hide-lighter yapf-mode)))
 


### PR DESCRIPTION
Hi,
The python-backend will automatically switch to lsp when lsp-layer is enabled, but the python-formatter dosen't present similar behavior. 
This PR will make python-formatter automatically switch to lsp when lsp-layer is enabled.

@smile13241324 Could you please review this PR? Thank you.