### PR TITLE
[ivy] Add `SPC h m`: search available man pages

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1971,7 +1971,7 @@ Other:
 - Added =recentf= alt actions to refresh and delete items (thanks to Rich Alesi)
 - Added =projectile= alternate actions to invalidate cache (thanks to Rich Alesi)
 - Key bindings:
-  - Added Helm key bindings counterparts: ~SPC f e l~ and ~SPC h i~
+  - Added Helm key bindings counterparts: ~SPC f e l~, ~SPC h m~ and ~SPC h i~
     (thanks to Andriy Kmit')
   - Added ~SPC h d F~ to list faces (thanks to Muneeb Shaikh)
   - Bind =find-file-other-window= to ~j~ (thanks to James Wang)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -69,6 +69,7 @@
         "hdm" 'spacemacs/describe-mode
         "hdv" 'counsel-describe-variable
         "hi"  'counsel-info-lookup-symbol
+        "hm"  'man
         "hR"  'spacemacs/counsel-search-docs
         ;; insert
         "iu"  'counsel-unicode-char


### PR DESCRIPTION
This keybinding is documented in DOCUMENTATION.org, yet was missing in ivy layer.