### PR TITLE
[search-engine]: Add latex's CTAN archive as new search engine

### DIFF
--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -97,6 +97,9 @@
               (wolfram-alpha
                :name "Wolfram Alpha"
                :url "https://www.wolframalpha.com/input/?i=%s")
+              (ctan
+               :name "CTAN"
+               :url "https://ctan.org/search?phrase=%s")
               ,@search-engine-config-list))
       (dolist (engine search-engine-alist)
         (let ((func (intern (format "engine/search-%S" (car engine)))))


### PR DESCRIPTION
Add latex's CTAN archive https://ctan.org to list of search engines.