### PR TITLE
Make clang-format hook work in the first opened C/C++ buffer

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -430,7 +430,8 @@
 (defun spacemacs//c-c++-setup-clang-format ()
   "Setup clang format."
   (when c-c++-enable-clang-format-on-save
-    (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks))
+    (spacemacs/add-to-hooks 'spacemacs/clang-format-on-save c-c++-mode-hooks)
+    (spacemacs/clang-format-on-save))
   (dolist (mode c-c++-modes)
     (spacemacs/declare-prefix-for-mode mode "m=" "format")
     (spacemacs/set-leader-keys-for-major-mode mode


### PR DESCRIPTION
This fixes a subtle bug introduced in d536b36d154708d195d903fe8538fb501c3c43b8, whereby clang-format on save doesn't work on the first opened C or C++ buffer (but does work on any subsequent buffers, or when re-opening the first buffer). To reproduce on develop:
 * Launch a new Spacemacs process
 * Open a C or C++ file, introduce some bad formatting (e.g. extraneous whitespace at the beginning of a line)
 * Save the file
 * You should see that the bad formatting was *not* fixed by clang-format
 * Re-open the file
 * Save the file
 * You should see that the bad formatting is fixed by clang-format!

The logic for all of these clang-format hooks is pretty confusing and hard to follow, but here's what I found when debugging the issue. In develop the first time a C++ file is opened the following functions run:
 * spacemacs//c-c++-setup-format
 * spacemacs//c-c++-setup-clang-format

Upon re-opening the file, the same functions run *plus* spacemacs/clang-format-on-save, which actually installs spacemacs//clang-format-on-save as a before-save-hook. So the issue is that spacemacs/clang-format-on-save is installed into c-c++-mode-hooks when opening the first C++ buffer, but isn't actually run. Arguably we should just always install spacemacs/clang-format-on-save as a before-save-hook because the spacemacs//clang-format-on-save function it installs already checks if c-++-enable-clang-format-on-save is set before invoking spacemacs/clang-format-region-or-buffer, but I'll defer that decision to someone else.