### PR TITLE
Added keybinding to htmlize org subtree for emailing

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -229,6 +229,7 @@ sane way, here is the complete list of changed key bindings
   - ~SPC m d s~ org-schedule
   - ~SPC m d t~ org-time-stamp
   - ~SPC m e m~ org-mime-org-buffer-htmlize
+  - ~SPC m e s~ org-mime-org-subtree-htmlize
   - ~SPC m i D s~ org-download-screenshot
   - ~SPC m i D y~ org-download-yank
   - ~SPC m i H~ org-insert-heading-after-current

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -652,7 +652,9 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (spacemacs/set-leader-keys-for-major-mode 'message-mode
         "em" 'org-mime-htmlize)
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "em" 'org-mime-org-buffer-htmlize))))
+        "em" 'org-mime-org-buffer-htmlize)
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode
+        "es" 'org-mime-org-subtree-htmlize))))
 
 (defun org/init-org-pomodoro ()
   (use-package org-pomodoro


### PR DESCRIPTION
~org-mime-htmlize-subtree~ as has the ability to set the email To, From,
Subject, CC, and BCC fields based on properties. If you commonly capture and
email the subtree being able to bake these settings into your template is very
convenient.

https://github.com/org-mime/org-mime#m-x-org-mime-org-subtree-htmlize

~org-mime-org-subtree-htmlize~ is similar to ~org-mime-org-buffer-htmlize~ but
works on subtree. It can also read subtree properties =MAIL_SUBJECT=, =MAIL_TO=,
=MAIL_CC=, and =MAIL_BCC=. Here is the sample of subtree:

  ,* mail one
   :PROPERTIES:
   :MAIL_SUBJECT: mail title
   :MAIL_TO: person1@gmail.com
   :MAIL_CC: person2@gmail.com
   :MAIL_BCC: person3@gmail.com
   :END:
  content ...