### PR TITLE
fix for #12989 to use cl-lib instead of obsolete cl

### DIFF
--- a/core/libs/ht.el
+++ b/core/libs/ht.el
@@ -27,8 +27,6 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl)) ;; dolist
-
 (defmacro ht (&rest pairs)
   "Create a hash table with the key-value pairs given.
 Keys are compared with `equal'.

--- a/core/libs/mocker.el
+++ b/core/libs/mocker.el
@@ -29,7 +29,7 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (require 'eieio)
 
@@ -64,7 +64,7 @@
    (records :initarg :records :initform nil :type list)))
 
 (defmethod constructor :static ((mock mocker-mock) newname &rest args)
-  (let* ((obj (call-next-method))
+  (let* ((obj (cl-call-next-method))
          (recs (oref obj :records))
          (func (oref obj :function)))
     (oset obj :orig-def (when (fboundp func) (symbol-function func)))
@@ -164,7 +164,7 @@
    (-sym :initarg :-sym)))
 
 (defmethod constructor :static ((rec mocker-record-base) newname &rest args)
-  (let* ((obj (call-next-method))
+  (let* ((obj (cl-call-next-method))
          (occur (oref obj :occur)))
     (when occur
       (oset obj :min-occur (max (oref obj :min-occur)
@@ -213,7 +213,7 @@
    (input-matcher :initarg :input-matcher :initform nil)))
 
 (defmethod constructor :static ((rec mocker-input-record) newname &rest args)
-  (let* ((obj (call-next-method)))
+  (let* ((obj (cl-call-next-method)))
     (when (or (not (slot-boundp obj :max-occur))
               (and (oref obj :max-occur)
                    (< (oref obj :max-occur)
@@ -250,7 +250,7 @@
   ((output :initarg :output :initform nil)))
 
 (defmethod constructor :static ((rec mocker-stub-record) newname &rest args)
-  (let* ((obj (call-next-method)))
+  (let* ((obj (cl-call-next-method)))
     (unless (slot-boundp obj :min-occur)
       (oset obj :min-occur 0))
     (unless (slot-boundp obj :max-occur)

--- a/layers/+chat/erc/local/erc-sasl/erc-sasl.el
+++ b/layers/+chat/erc/local/erc-sasl/erc-sasl.el
@@ -37,7 +37,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defvar erc-sasl-use-sasl t
   "Set to nil to disable SASL auth")

--- a/layers/+chat/erc/local/erc-tex/erc-tex.el
+++ b/layers/+chat/erc/local/erc-tex/erc-tex.el
@@ -39,7 +39,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 (require 'erc)
 
 
@@ -93,7 +93,7 @@
                  ;; Return a string which stand for COLOR in the format that
                  ;; dvipng understands.
                  (let ((max (car (color-values "#ffffff"))))
-                   (destructuring-bind (r g b)
+                   (cl-destructuring-bind (r g b)
                        (color-values color)
                      (format "rgb %.02f %.02f %.02f"
                              (/ (float r) max)

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -26,7 +26,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'ht)
 (require 'helm)
 (require 'helm-command)

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -26,7 +26,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'ht)
 (require 'ivy)
 (require 'core-configuration-layer)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -70,7 +70,7 @@
   ;; Use evil as a default jump handler
   (add-to-list 'spacemacs-default-jump-handlers 'evil-goto-definition)
 
-  (require 'cl)
+  (require 'cl-lib)
   ;; State cursors
   (cl-loop for (state color shape) in spacemacs-evil-cursors
            do (spacemacs/add-evil-cursor state color shape))

--- a/layers/+distributions/spacemacs-docker/deps-install/lib/deps-install-helpers.el
+++ b/layers/+distributions/spacemacs-docker/deps-install/lib/deps-install-helpers.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(require 'cl)
+(require 'cl-lib)
 (require 'package)
 
 (load (format (concat "%s/.emacs.d/"
@@ -127,7 +127,7 @@ NOTE: Duplicates are removed."
                                    vals))
                    separator))
          (res-val (mapconcat 'identity
-                             (remove-duplicates (split-string new-val
+                             (cl-remove-duplicates (split-string new-val
                                                               separator)
                                                 :test 'string=)
                              separator)))
@@ -252,8 +252,8 @@ Remove folder if BODY throws error.
 during BODY evaluation and return its value.
 Remove newly installed packages if BODY throws error."
   (declare (indent 1))
-  `(let* ((pkgs (sort (remove-duplicates (mapcar 'symbol-name
-                                                 '(,@packages)))
+  `(let* ((pkgs (sort (cl-remove-duplicates (mapcar 'symbol-name
+                                                    '(,@packages)))
                       'string<))
           (pkgs-only-installed
            (let ((silent t))
@@ -337,7 +337,7 @@ defun that matched REGEXP in the `spacemacs-docker-dotfile-fp'."
 ignoring comments and docstrings."
   (let ((name (symbol-name symbol)))
     (with-temp-buffer
-      (block nil
+      (cl-block nil
         (insert-file-contents spacemacs-docker-dotfile-fp)
         (goto-char (point-min))
         (while (re-search-forward (regexp-quote name)
@@ -350,7 +350,7 @@ ignoring comments and docstrings."
                      (string= (thing-at-point 'symbol
                                               t)
                               name))
-            (return t)))))))
+            (cl-return t)))))))
 
 (defun get-config (config-varible)
   "Return used Spacemacs layer CONFIG-VARIABLE value."

--- a/layers/+emacs/org/local/org-async-init.el
+++ b/layers/+emacs/org/local/org-async-init.el
@@ -6,5 +6,5 @@
 (require 'ox)
 (require 'ox-beamer)
 (require 'ox-latex)
-(require 'cl)
+(require 'cl-lib)
 (setq org-export-async-debug nil)

--- a/layers/+lang/python/local/nose/nose.el
+++ b/layers/+lang/python/local/nose/nose.el
@@ -53,7 +53,7 @@
 ;;             (local-set-key "\C-cpm" 'nosetests-pdb-module)
 ;;             (local-set-key "\C-cp." 'nosetests-pdb-one)))
 
-(require 'cl) ;; for "reduce"
+(require 'cl-lib) ;; for "cl-reduce"
 
 (defvar nose-project-root-files '(".projectile"
                                   "setup.cfg"
@@ -187,7 +187,7 @@ For more details: http://pswinkels.blogspot.ca/2010/04/debugging-python-code-fro
              (file-name-directory (directory-file-name dn)))))))
 
 (defun nose-project-root (dirname)
-  (reduce '(lambda (x y) (or x y))
+  (cl-reduce '(lambda (x y) (or x y))
           (mapcar (lambda (d) (member d (directory-files dirname)))
                   nose-project-root-files)))
 

--- a/layers/+lang/python/local/pylookup/pylookup.el
+++ b/layers/+lang/python/local/pylookup/pylookup.el
@@ -27,7 +27,7 @@
 (eval-when-compile
   (require 'browse-url)
   (require 'simple)
-  (require 'cl)
+  (require 'cl-lib)
   (require 'ido))
 
 ;;=================================================================
@@ -235,7 +235,7 @@
                 (setq module (concat module " " (car iter)))
                 (setq iter (cdr iter)))
 
-              (incf index)
+              (cl-incf index)
               (insert (format " %03d) %-25s %-30s %10s"
                   index
                   (pylookup-trim api 25)

--- a/layers/+misc/ietf/local/irfc/irfc.el
+++ b/layers/+misc/ietf/local/irfc/irfc.el
@@ -333,7 +333,6 @@
 ;;
 
 ;;; Require
-(eval-when-compile (require 'cl))
 (require 'url-vars)
 (require 'thingatpt)
 

--- a/layers/+spacemacs/spacemacs-defaults/local/help-fns+/help-fns+.el
+++ b/layers/+spacemacs/spacemacs-defaults/local/help-fns+/help-fns+.el
@@ -393,7 +393,7 @@
 (when (or (> emacs-major-version 23)  (and (= emacs-major-version 23)  (> emacs-minor-version 1)))
   (require 'info)) ;; Info-virtual-files
 
-(eval-when-compile (require 'cl)) ;; case, gentemp
+(eval-when-compile (require 'cl-lib)) ;; case, gentemp
 
 
 ;; Quiet the byte-compiler.
@@ -2444,7 +2444,7 @@ anything else (default): `inherit'
 
 VARIABLE's current value cannot satisfy a regexp type: it is
 impossible to know which concrete types a value must match."
-  (case mode
+  (cl-case mode
     ((nil inherit)     (help-var-inherits-type-p variable types))
     (inherit-or-value  (or (help-var-inherits-type-p variable types)
                            (help-var-val-satisfies-type-p variable types)))
@@ -2790,7 +2790,7 @@ Non-interactively:
                                                       (throw 'describe-keymap symb)))))
                        nil)))
         (unless sym
-          (setq sym  (gentemp "KEYMAP OBJECT (no variable) "))
+          (setq sym  (cl-gentemp "KEYMAP OBJECT (no variable) "))
           (set sym keymap))
         (setq keymap  sym))))
   (setq keymap  (or (condition-case nil (indirect-variable keymap) (error nil))  keymap)) ; Follow aliasing.

--- a/layers/+spacemacs/spacemacs-navigation/local/info+/info+.el
+++ b/layers/+spacemacs/spacemacs-navigation/local/info+/info+.el
@@ -899,7 +899,7 @@
 ;;; Code:
 
 (require 'info)
-(eval-when-compile (require 'cl)) ;; case
+(eval-when-compile (require 'cl-lib)) ;; cl-case
 
 ;; These are optional, for cosmetic purposes.
 (require 'thingatpt nil t) ;; (no error if not found): symbol-at-point
@@ -1725,7 +1725,7 @@ A bookmarked node name has the form \"(MANUAL) NODE\", referring to
 NODE in MANUAL.
 Optional arg LOCALP means read a node name from the current manual."
     (let* ((completion-ignore-case  t)
-           (bmks                    (remove-if-not
+           (bmks                    (cl-remove-if-not
                                      (lambda (bmk) (bmkp-string-match-p (if (and localp  Info-current-file)
                                                                        (format "\\`(%s) "
                                                                                (file-name-sans-extension
@@ -4438,7 +4438,7 @@ Syntax class:\\|User Option:\\|Variable:\\)\\(.*\\)\\([\n]          \\(.*\\)\\)*
                             nil t)
     (let ((symb  (intern (match-string 1))))
       (put-text-property (match-beginning 1) (match-end 1)
-                         'font-lock-face (case symb
+                         'font-lock-face (cl-case symb
                                            ('Constant:       'info-constant-ref-item)
                                            ('Command:        'info-command-ref-item)
                                            ('Function:       'info-function-ref-item)

--- a/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
+++ b/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
@@ -549,7 +549,7 @@
 ;;
 ;;; Code:
 
-(eval-when-compile (require 'cl)) ;; case, incf (plus, for Emacs 20: dolist, dotimes)
+(eval-when-compile (require 'cl-lib)) ;; case, incf (plus, for Emacs 20: dolist, dotimes)
 (require 'frame-fns) ;; frame-geom-value-cons, frame-geom-value-numeric, frames-on, get-frame-name,
                      ;; get-a-frame, read-frame
 (require 'strings nil t) ;; (no error if not found) read-buffer
@@ -1215,7 +1215,7 @@ In Lisp code:
                                (frame-geom-value-numeric 'height new-height))
                (cons 'restore-height orig-height)))))
     (show-frame frame)
-    (incf fr-origin (if (eq direction 'horizontal) fr-pixel-width fr-pixel-height))))
+    (cl-incf fr-origin (if (eq direction 'horizontal) fr-pixel-width fr-pixel-height))))
 
 ;;;###autoload
 (unless (fboundp 'restore-frame-horizontally)
@@ -1281,7 +1281,7 @@ In Lisp code:
         (orig-height     (frame-parameter frame 'height))
         (horiz           (memq direction '(horizontal both)))
         (vert            (memq direction '(vertical both))))
-    (case direction
+    (cl-case direction
       (both        (unless (and restore-left  restore-width  restore-top  restore-height)
                      (maximize-frame 'both frame)))
       (vertical    (unless (and restore-top  restore-height) (maximize-frame-vertically frame)))
@@ -1420,7 +1420,7 @@ the pixel width and height of the rectangle."
         (fr-origin        (if (eq direction 'horizontal)
                               (or x-min-pix  (car (frcmds-effective-screen-pixel-bounds)))
                             (or y-min-pix  (cadr (frcmds-effective-screen-pixel-bounds))))))
-    (case direction                     ; Size of frame in pixels.
+    (cl-case direction                     ; Size of frame in pixels.
       (horizontal  (setq fr-pixel-width   (/ fr-pixel-width  (length visible-frames))))
       (vertical    (setq fr-pixel-height  (/ fr-pixel-height (length visible-frames))))
       (otherwise   (error "`frcmds-tile-frames': DIRECTION must be `horizontal' or `vertical'")))
@@ -1458,7 +1458,7 @@ the pixel width and height of the rectangle."
                           (if (eq direction 'horizontal) (or y-min-pix  0) fr-origin))
       (show-frame fr)
       ;; Move over the width or height of one frame, and add one border width.
-      (incf fr-origin (+ (or (cdr (assq 'border-width (frame-parameters fr)))  0)
+      (cl-incf fr-origin (+ (or (cdr (assq 'border-width (frame-parameters fr)))  0)
                          (if (eq direction 'horizontal) fr-pixel-width fr-pixel-height))))))
 
 (defun frcmds-extra-pixels-width (frame)


### PR DESCRIPTION
Replaced (require 'cl) with (require 'cl-lib) and made other necessary changes to support this change.

This is to fix PR #12989.
