### PR TITLE
removed unnecessary custom location for counsel-css package

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -19,8 +19,7 @@
         evil-matchit
         flycheck
         haml-mode
-        (counsel-css :requires ivy
-                     :location (recipe :fetcher github :repo "hlissner/emacs-counsel-css"))
+        (counsel-css :requires ivy)
         (helm-css-scss :requires helm)
         impatient-mode
         less-css-mode


### PR DESCRIPTION
Removed custom package URL, because the custom URL is the same as the default URL in melpa, i.e., 
https://github.com/melpa/melpa/blob/master/recipes/counsel-css

Hence there is no need to specify a custom URL.

