### PR TITLE
Do not use the deprecated lexical-let.

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Auto-completion functions File
+;;; funcs.el --- Auto-completion functions File -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;
@@ -295,7 +295,7 @@ MODE parameter must match the :modes values used in the call to
       (define-key map (kbd "C-k") 'company-select-previous)
       (define-key map (kbd "C-l") 'company-complete-selection))
     ;; Fix company-quickhelp Evil C-k
-    (lexical-let ((prev nil))
+    (let ((prev nil))
       (defun spacemacs//set-C-k-company-select-previous (&rest args)
         (setf prev (lookup-key evil-insert-state-map (kbd "C-k")))
         (define-key evil-insert-state-map (kbd "C-k") 'company-select-previous))

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Ivy Layer functions File for Spacemacs
+;;; funcs.el --- Ivy Layer functions File for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
 ;;
@@ -67,8 +67,7 @@
 
 ;; see `counsel-ag-function'
 (defun spacemacs//make-counsel-search-function (tool)
-  (lexical-let ((base-cmd
-                 (cdr (assoc-string tool spacemacs--counsel-commands))))
+  (let ((base-cmd (cdr (assoc-string tool spacemacs--counsel-commands))))
     (lambda (string &optional _pred &rest _unused)
       "Grep in the current directory for STRING."
       ;; `ivy-more-chars' returns non-nil when more chars are needed,
@@ -377,7 +376,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
 ;; Ivy
 
 (defun spacemacs//ivy-command-not-implemented-yet (key)
-  (lexical-let ((-key key))
+  (let ((-key key))
     (spacemacs/set-leader-keys
       -key (lambda ()
              (interactive)


### PR DESCRIPTION
My autocompletions cannot load, since these two files do not `(require 'cl)` here are some cross-references:
`cl` deprecated issue: https://github.com/syl20bnr/spacemacs/issues/12989
Commit switching to `cl-lib`: https://github.com/syl20bnr/spacemacs/commit/da8063437052943f749bc0f14c5ef5a7536aeaac
That pull request: https://github.com/syl20bnr/spacemacs/pull/13059

These are the only places where `lexical-let` gets used. It looks like `let` works lexically unless the variable is already declared specially somewhere else. [Here are the docs on that](https://www.gnu.org/software/emacs/manual/html_node/elisp/Using-Lexical-Binding.html).

I don't think there are any more spurious uses of `cl` functions in the core.
Here is the magic regex I used:
```bash
rg '\((flet|cl-macro-environment|cl-macroexpand-all|macroexpand-all|cl-not-hash-table|cl-builtin-remhash|cl-builtin-clrhash|cl-builtin-maphash|cl-map-keymap|cl-copy-tree|copy-tree|cl-gethash|cl-puthash|cl-remhash|cl-clrhash|cl-maphash|cl-make-hash-table|cl-hash-table-p|cl-hash-table-count|cl-map-intervals|cl--map-intervals|cl-map-extents|cl--map-overlays|cl-set-getf|cl--set-getf|cl-struct-setf-expander|lexical-let|lexical-let\*|labels|define-setf-expander|defsetf|define-modify-macro)'
```
