### PR TITLE
[ivy] Fix visual selection expansion across the buffer on `SPC s S` and `SPC s B`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2053,6 +2053,8 @@ Other:
 - Fixed void variable =counsel-find-file-map= (thanks to duianto)
 - Fixed wrong initial directory in =spacemacs/counsel-search=
   (thanks to Carlos Ibáñez and Juuso Valkeejärvi)
+- Fix visual selection expansion across the buffer on `SPC s S` and `SPC s B`
+  (thanks to Andriy Kmit)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -466,22 +466,27 @@ Closing doesn't kill buffers inside the layout while killing layouts does."
 
 ;; Swiper
 
+(defun spacemacs//counsel-current-region-or-symbol ()
+  "Return contents of the region or symbol at point.
+
+If region is active, mark will be deactivated in order to prevent region
+expansion when jumping around the buffer with counsel. See `deactivate-mark'."
+  (if (region-active-p)
+      (prog1
+          (buffer-substring-no-properties (region-beginning) (region-end))
+        (deactivate-mark))
+    (thing-at-point 'symbol t)))
+
 (defun spacemacs/swiper-region-or-symbol ()
   "Run `swiper' with the selected region or the symbol
 around point as the initial input."
   (interactive)
-  (let ((input (if (region-active-p)
-                   (buffer-substring-no-properties
-                    (region-beginning) (region-end))
-                 (thing-at-point 'symbol t))))
+  (let ((input (spacemacs//counsel-current-region-or-symbol)))
     (swiper input)))
 
 (defun spacemacs/swiper-all-region-or-symbol ()
   "Run `swiper-all' with the selected region or the symbol
 around point as the initial input."
   (interactive)
-  (let ((input (if (region-active-p)
-                   (buffer-substring-no-properties
-                    (region-beginning) (region-end))
-                 (thing-at-point 'symbol t))))
+  (let ((input (spacemacs//counsel-current-region-or-symbol)))
     (swiper-all input)))


### PR DESCRIPTION
When one invokes `spacemacs/swiper-region-or-symbol` (`SPC s S`) or
`spacemacs/swiper-all-region-or-symbol` (`SPC s B`) with active visual selection
(transient-mark-mode), the selection expands over the buffer while one jumps
around with swiper. Thus I believe it is appropriate to deactivate visual
selection within the above command.

Since the mentioned commands both use identical code for getting the text to
operate on, I moved that code into a separate function.

On the following screenshot one can see what happened when I visually select symbol `ivy-read`, then `SPC s S` and then , in swiper, just select the next candidate:
![spacemacs-swiper-visual-bug](https://user-images.githubusercontent.com/2280844/70855583-f37acc80-1ed5-11ea-9782-d481e918dc1f.png)
