### PR TITLE
[ivy] `SPC h m`: fallback to `woman` on Windows

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1994,7 +1994,7 @@ Other:
     - ~SPC f e l~ =counsel-find-library=
     - ~SPC h i~   =counsel-info-lookup-symbol=
       (thanks to Andriy Kmit')
-    - ~SPC h m~ =man= (thanks to madand)
+    - ~SPC h m~ =man=, fallback to =woman= on Widows (thanks to madand)
   - Added ~SPC h d F~ to list faces (thanks to Muneeb Shaikh)
   - Bind =find-file-other-window= to ~j~ (thanks to James Wang)
   - Added =counsel-mark-ring= to ~rm~ (thanks to bmag)

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -69,7 +69,7 @@
         "hdm" 'spacemacs/describe-mode
         "hdv" 'counsel-describe-variable
         "hi"  'counsel-info-lookup-symbol
-        "hm"  'man
+        "hm"  (if (spacemacs/system-is-mswindows) 'woman 'man)
         "hR"  'spacemacs/counsel-search-docs
         ;; insert
         "iu"  'counsel-unicode-char


### PR DESCRIPTION
`man` command displays output from the external program with the same name,
so it will generally fail to work on Windows.

`woman` is a pure elisp parser for manpages, so it will work on Windows. But
`woman` lacks colorizing of manpages, so we only use it as a fallback.