### PR TITLE
Added support for native fill column indicator in Emacs 27+

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -71,6 +71,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   =EXPERIMENTAL.org=. This allows for instant Spacemacs startup time with
   pre-loaded heavy packages like =Org= and =Helm=
   (thanks to Sylvain Benner, Compro Prasad and Keith Simmons)
+- Added support for native fill column indicator in Emacs 27+ (thanks to
+  Andriy Kmit)
 *** Breaking Changes
 **** Major
 - Support for Emacs 24 has been dropped, the minimal Emacs version is now

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -13,7 +13,10 @@
       '(
         (ansi-colors :location built-in)
         desktop
-        fill-column-indicator
+        ;; `display-fill-column-indicator' is available in Emacs 27+
+        (display-fill-column-indicator :location built-in
+                                       :toggle (boundp 'display-fill-column-indicator))
+        (fill-column-indicator :toggle (not (boundp 'display-fill-column-indicator)))
         hl-todo
         popup
         popwin
@@ -31,6 +34,21 @@
     (setq desktop-dirname spacemacs-cache-directory)
     :config
     (add-to-list 'desktop-path spacemacs-cache-directory)))
+
+(defun spacemacs-visual/init-display-fill-column-indicator ()
+  (spacemacs|add-toggle fill-column-indicator
+    :mode display-fill-column-indicator-mode
+    :documentation "Display the fill column indicator."
+    :evil-leader "tf")
+  (spacemacs|add-toggle fill-column-indicator-globally
+    :mode global-display-fill-column-indicator-mode
+    :documentation "Display the fill column indicator globally."
+    :evil-leader "t C-f")
+  (with-eval-after-load 'display-fill-column-indicator
+    ;; manually register the minor mode since it does not define any
+    ;; lighter
+    (add-to-list 'minor-mode-alist '(display-fill-column-indicator-mode ""))
+    (spacemacs|diminish display-fill-column-indicator-mode " ⓕ" " f")))
 
 (defun spacemacs-visual/init-fill-column-indicator ()
   (use-package fill-column-indicator


### PR DESCRIPTION
`display-fill-column-indicator-mode` is a new native fill column indicator mode implemented on C-level, thus has almost no performance penalty in contrast with the legacy `fci-mode` implemented in elisp.

This commit implements conditional activation of the mentioned mode on Emacs 27+. `fci-mode` will still be available on older versions of Emacs.

Resolves #12884