### PR TITLE
Add LSP backend support for YAML

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -297,6 +297,8 @@ sane way, here is the complete list of changed key bindings
 ***** Vagrant
 - Key bindings:
   - Vagrant key bindings prefix is now ~SPC a V~.
+***** YAML
+- Added LSP support (thanks to Seong Yong-ju)
 ***** ycmd
 - The =ycmd= layer has been deleted and moved to the =c-c++= layer.
 *** New layers

--- a/layers/+lang/yaml/README.org
+++ b/layers/+lang/yaml/README.org
@@ -6,6 +6,8 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
+  - [[#lsp][LSP]]
 - [[#syntax-checking-with-flycheck][Syntax checking with flycheck]]
 
 * Description
@@ -16,9 +18,24 @@ This layer provides support for the YAML file format.
 - Syntax checking via [[http://www.flycheck.org/en/latest/languages.html#yaml][flycheck]]
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =yaml= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** LSP
+To enable LSP, install [[https://github.com/redhat-developer/yaml-language-server][yaml-language-server]]:
+
+#+BEGIN_SRC sh
+   npm i -g yaml-language-server
+#+END_SRC
+
+And set the layer variable =yaml-enable-lsp= to =t= like shown below:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((yaml :variables yaml-enable-lsp t)))
+#+END_SRC
 
 * Syntax checking with flycheck
 Flycheck checks YAML files with either:

--- a/layers/+lang/yaml/config.el
+++ b/layers/+lang/yaml/config.el
@@ -1,0 +1,15 @@
+;;; config.el --- YAML Layer Configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Seong Yong-ju <sei40kr@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(spacemacs|define-jump-handlers yaml-mode)
+
+(defvar yaml-enable-lsp nil
+  "If non-nil, enable lsp-mode in YAML buffers.")

--- a/layers/+lang/yaml/funcs.el
+++ b/layers/+lang/yaml/funcs.el
@@ -1,0 +1,16 @@
+;;; funcs.el --- YAML Layer Functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2019 Sylvain Benner & Contributors
+;;
+;; Author: Seong Yong-ju <sei40kr@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//setup-lsp-for-yaml-buffer ()
+  "Start lsp-mode and configure for buffer."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))

--- a/layers/+lang/yaml/packages.el
+++ b/layers/+lang/yaml/packages.el
@@ -13,7 +13,8 @@
                       yaml-mode))
 
 (defun yaml/post-init-company ()
-  (spacemacs|add-company-backends :modes yaml-mode))
+  (unless yaml-enable-lsp
+    (spacemacs|add-company-backends :modes yaml-mode)))
 
 (defun yaml/post-init-flycheck ()
   (spacemacs/enable-flycheck 'yaml-mode))
@@ -23,6 +24,9 @@
   (use-package yaml-mode
     :mode (("\\.\\(yml\\|yaml\\)\\'" . yaml-mode)
            ("Procfile\\'" . yaml-mode))
+    :init
+    (when yaml-enable-lsp
+      (add-hook 'yaml-mode-hook #'spacemacs//setup-lsp-for-yaml-buffer))
     :config (add-hook 'yaml-mode-hook
                       '(lambda ()
                          (define-key yaml-mode-map "\C-m" 'newline-and-indent)))))

--- a/layers/+tools/ansible/packages.el
+++ b/layers/+tools/ansible/packages.el
@@ -63,12 +63,12 @@
   (use-package company-ansible
     :defer t
     :init
-    (progn
-     ;; append this hook at the end to execute it last so `company-backends'
-     ;; variable is buffer local
-     (add-hook 'yaml-mode-hook 'spacemacs/ansible-company-maybe-enable t)
-     (spacemacs|add-company-backends :backends company-ansible
-                                     :modes ansible))))
+    (unless yaml-enable-lsp
+      ;; append this hook at the end to execute it last so `company-backends'
+      ;; variable is buffer local
+      (add-hook 'yaml-mode-hook 'spacemacs/ansible-company-maybe-enable t)
+      (spacemacs|add-company-backends :backends company-ansible
+                                      :modes ansible))))
 
 (defun ansible/init-jinja2-mode ()
   (use-package jinja2-mode


### PR DESCRIPTION
Added LSP backend support for YAML.

Code completions for GitHub Workflow:
![lsp-yaml](https://user-images.githubusercontent.com/11665236/70859779-12bc3d00-1f5c-11ea-9d06-d84cbccbe55a.png)


Please also see:
- [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
- [lsp-yaml.el in lsp-mode](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-yaml.el)
- [JSON Schema Store](http://schemastore.org/json)