### PR TITLE
Un evilify org present mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2526,6 +2526,8 @@ Other:
 - Added support for CUSTOM_ID in latex exports (thanks to Compro-Prasad)
 - Added =ox-jira= as org export backend (thanks to Sebastian Nagel)
 - Added =helm-org= package (thanks to Simon Pintarelli)
+- Fixed evil-normal-state ~ESC~ after exiting =org-present-mode=
+  (thanks to duianto)
 **** Osx
 - Fixed OSX mapping issue (thanks to Joey Liu)
 - Added layer variables to customize modifier behaviors on macOS:

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -675,24 +675,26 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :defer t
     :init
     (progn
-      (evilified-state-evilify nil org-present-mode-keymap
-        "h" 'org-present-prev
-        "l" 'org-present-next
-        "q" 'org-present-quit)
       (defun spacemacs//org-present-start ()
         "Initiate `org-present' mode"
         (org-present-big)
         (org-display-inline-images)
         (org-present-hide-cursor)
         (org-present-read-only)
-        (evil-evilified-state))
+        (evil-define-key 'normal org-present-mode-keymap
+          "h"             'org-present-prev
+          (kbd "<left>")  'org-present-prev
+          "l"             'org-present-next
+          (kbd "<right>") 'org-present-next
+          "q"             'org-present-quit)
+        ;; evil-normal-state seems to be required to load the above key bindings
+        (evil-normal-state))
       (defun spacemacs//org-present-end ()
         "Terminate `org-present' mode"
         (org-present-small)
         (org-remove-inline-images)
         (org-present-show-cursor)
-        (org-present-read-write)
-        (evil-normal-state))
+        (org-present-read-write))
       (add-hook 'org-present-mode-hook 'spacemacs//org-present-start)
       (add-hook 'org-present-mode-quit-hook 'spacemacs//org-present-end))))
 


### PR DESCRIPTION
Un-evilified org-present-mode

Because [escape] was bound to evil-evilified-state
after exiting org-present-mode.

The arrow keys switched to the next/prev page before this PR,
but this solution seems to require them to be defined explicitly.

Resolves: #7766

---

### Reproduction steps
- `example.org`:
```org
* one
a b c d e
* two
1 2 3 4 5
* three
I II III III IV
```
- `M-x org-present`
- `q` exits `org-present-mode`
- `ESC`

#### Before
`ESC` has been rebound to `evil-evilified-state`.
It changes `evil-state` to `evilified` where for example:
`w`, `b` and `u` insert the characters.

#### After
`ESC` didn't change, it still calls: `evil-force-normal-state`,
and the evil bindings `w`, `b`, `u`, etc. work as expected.