### PR TITLE
shell: Wrap terminal-here in use-package

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -295,14 +295,16 @@
       (add-hook 'eshell-mode-hook 'spacemacs/init-eshell-xterm-color))))
 
 (defun shell/init-terminal-here ()
-  :defer t
-  :init
-  (progn
-    (spacemacs/register-repl 'terminal-here 'terminal-here)
-    (spacemacs/set-leader-keys
-      "\"" 'terminal-here-launch
-      "p \"" 'terminal-here-project-launch)
-    ))
+  (use-package terminal-here
+    :defer t
+    :commands (terminal-here-launch terminal-here-project-launch)
+    :init
+    (progn
+      (spacemacs/register-repl 'terminal-here 'terminal-here)
+      (spacemacs/set-leader-keys
+        "\"" 'terminal-here-launch
+        "p \"" 'terminal-here-project-launch)
+      )))
 
 (defun shell/post-init-vi-tilde-fringe ()
   (spacemacs/add-to-hooks 'spacemacs/disable-vi-tilde-fringe


### PR DESCRIPTION
Introduced in PR #11949, terminal-here wasn't wrapped in `use-package`. This made it impossible to use `spacemacs|use-package-add-hook` to customize it.

Thanks!