### PR TITLE
Fix searching in the helm-find-file actions

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1244,6 +1244,7 @@ Other:
   - Fixed sudo-edit on TRAMP (thanks to Carlos Ibáñez)
   - Replaced obsolete function =doom-modeline-init= with =doom-modeline-mode=
     (thanks to duianto)
+  - Fixed searching in the =helm-find-file= actions (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -44,6 +44,13 @@
       (plist-put props :fuzzy-match (eq 'always helm-use-fuzzy))))
   (apply f args))
 
+(defun spacemacs//helm-find-files-enable-helm--in-fuzzy ()
+  "Enabling `helm--in-fuzzy' with the hook:
+`helm-find-files-after-init-hook'. Fixes the error:
+Helm issued errors: helm-match-from-candidates in source `Actions': wrong-type-argument (stringp nil)
+When searching in the helm-find-files (`SPC f f') actions (`C-z')."
+  (setq helm--in-fuzzy t))
+
 ;; Helm Header line
 
 (defun spacemacs//helm-hide-minibuffer-maybe ()

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -46,8 +46,10 @@
     (add-hook 'helm-find-files-before-init-hook
               'spacemacs//set-dotted-directory)
     (add-hook 'spacemacs-editing-style-hook 'spacemacs//helm-hjkl-navigation)
+    (add-hook 'helm-find-files-after-init-hook
+              'spacemacs//helm-find-files-enable-helm--in-fuzzy)
     ;; setup advices
-    ;; fuzzy matching for all the sourcess
+    ;; fuzzy matching for all the sources
     (unless (eq helm-use-fuzzy 'source)
       (advice-add 'helm-make-source :around #'spacemacs//helm-make-source))
 


### PR DESCRIPTION
Fixes: #9631

---

If it's overkill to mention the error message it fixes and where the function is used in it's docstring, then I can remove it.