### PR TITLE
Frame title setting doesn't need to depend on environment (gui/cli)

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -103,7 +103,7 @@ the final step of executing code in `emacs-startup-hook'.")
                                     dotspacemacs-editing-style))
   (configuration-layer/initialize)
   ;; frame title init
-  (when (and (display-graphic-p) dotspacemacs-frame-title-format)
+  (when dotspacemacs-frame-title-format
     (require 'format-spec)
     (setq frame-title-format '((:eval (spacemacs/title-prepare dotspacemacs-frame-title-format))))
     (if dotspacemacs-icon-title-format


### PR DESCRIPTION
remove `display-graphic-p` from conditional that sets `frame-title-format`. Take this example:
- you run `emacs -daemon`, it loads everything and `display-graphic-p` at the time returns `nil`
- you run `emacslient -c ` which launches a gui emacs frame but now your `frame-title` is not set
  because it was dependent on `display-graphic-p` returning a true value.
We certainly do not want this. Moreover, the are no dire effects to setting the `frame-title` in a `CLI`