### PR TITLE
[rust] Fix: broken rust-quick-run command

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2815,6 +2815,7 @@ Other:
 - Added debugger integration via =dap= layer
 - Fixed rust dap integration (thanks to Tommi Komulainen)
 - Make ~rustup~ call shell agnostic (thanks to Dietrich Daroch)
+- Fixed ~rust-quick-run~ command (thanks to Grant Shangreaux)
 **** Sailfish-Developer
 - Key bindings:
   - Added =sailfish-scratchbox= key bindings (thanks to Victor Polevoy):

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -82,6 +82,23 @@ If `help-window-select' is non-nil, also select the help window."
 
 ;; Misc
 
+(defvar spacemacs/rust-quick-run-tmp-file nil
+  "Stores filename for the rust-quick-run function")
+
+(defun spacemacs//rust-quick-run-generate-tmp-file-name (input-file-name)
+  (concat temporary-file-directory
+          (file-name-nondirectory (buffer-file-name))
+          "-"
+          (md5 (buffer-file-name))))
+
+(defun spacemacs//rust-quick-run-compilation-finish-function (buffer status)
+  (if (and (string-match "finished" status)
+           (with-current-buffer buffer
+             (string-match (concat "rustc -o " temporary-file-directory) (buffer-string))))
+      (progn
+        (newline)
+        (shell-command (shell-quote-argument spacemacs/rust-quick-run-tmp-file) t))))
+
 (defun spacemacs/rust-quick-run ()
   "Quickly run a Rust file using rustc.
 Meant for a quick-prototype flow only - use `spacemacs/open-junk-file' to
@@ -89,17 +106,10 @@ open a junk Rust file, type in some code and quickly run it.
 If you want to use third-party crates, create a new project using `cargo-process-new' and run
 using `cargo-process-run'."
   (interactive)
-  (let ((input-file-name (buffer-file-name))
-        (output-file-name (concat temporary-file-directory
-                                  (file-name-nondirectory (buffer-file-name))
-                                  "-"
-                                  (md5 (buffer-file-name)))))
-    (add-to-list 'compilation-finish-functions
-                 (lambda (buffer status)
-                   (if (string-match "finished" status)
-                       (shell-command (shell-quote-argument output-file-name) buffer)
-                     (message "Compilation failed with: %s" status))))
-    (compile
-     (format "rustc -o %s %s"
-             (shell-quote-argument output-file-name)
-             (shell-quote-argument input-file-name)))))
+  (setq spacemacs/rust-quick-run-tmp-file
+        (spacemacs//rust-quick-run-generate-tmp-file-name(buffer-file-name)))
+
+  (compile
+   (format "rustc -o %s %s"
+           (shell-quote-argument spacemacs/rust-quick-run-tmp-file)
+           (shell-quote-argument buffer-file-name))))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -102,7 +102,8 @@
       (spacemacs/declare-prefix-for-mode 'rust-mode "m=" "format")
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
         "==" 'rust-format-buffer
-        "q" 'spacemacs/rust-quick-run))))
+        "q" 'spacemacs/rust-quick-run)
+      (add-to-list 'compilation-finish-functions 'spacemacs//rust-quick-run-compilation-finish-function))))
 
 (defun rust/post-init-smartparens ()
   (with-eval-after-load 'smartparens


### PR DESCRIPTION
removing the `lexical-let` caused the intended closure to be invalid. the
filename being compiled was nil when the compilation-finish-function was
run.

this adds a special var to hold the temp file being compiled instead, and
tries to narrow down the compilation-finish-function to only run when the
compilation buffer includes the "rustc -o /tmp" regexp

attempts to address #13111 which seems to have been caused by beff6ec9149cc4954a41bcb5cbf4d02c8af8103f