### PR TITLE
[version-control] Use :toggle to avoid installation of unused packages

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3127,7 +3127,7 @@ Other:
 - New packages:
   - =browse-at-remote= which replaces =github-browse-file=
   (thanks Eugene Yaremenko)
-- Avoid loading all the diff packages (thanks to Sylvain Benner)
+- Avoid loading all the diff packages (thanks to Sylvain Benner, Andriy Kmit)
 - Fixed error on =diff-hl-margin-mode= function being nil during startup
   (thanks to Voleking)
 **** Vue

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -14,12 +14,12 @@
         browse-at-remote
         (vc :location built-in)
         diff-mode
-        diff-hl
+        (diff-hl :toggle (eq 'diff-hl version-control-diff-tool))
         evil-unimpaired
-        git-gutter
-        git-gutter+
-        git-gutter-fringe
-        git-gutter-fringe+
+        (git-gutter :toggle (eq 'git-gutter version-control-diff-tool))
+        (git-gutter-fringe :toggle (eq 'git-gutter version-control-diff-tool))
+        (git-gutter+ :toggle (eq 'git-gutter+ version-control-diff-tool))
+        (git-gutter-fringe+ :toggle (eq 'git-gutter+ version-control-diff-tool))
         (smerge-mode :location built-in)
         ))
 
@@ -121,7 +121,6 @@
 
 (defun version-control/init-diff-hl ()
   (use-package diff-hl
-    :if (eq version-control-diff-tool 'diff-hl)
     :defer t
     :init
     (progn
@@ -143,7 +142,6 @@
 
 (defun version-control/init-git-gutter ()
   (use-package git-gutter
-    :if (eq version-control-diff-tool 'git-gutter)
     :defer t
     :init
     (progn
@@ -165,7 +163,6 @@
 
 (defun version-control/init-git-gutter-fringe ()
   (use-package git-gutter-fringe
-    :if (eq version-control-diff-tool 'git-gutter)
     :defer t
     :init
     (progn
@@ -222,7 +219,6 @@
 
 (defun version-control/init-git-gutter-fringe+ ()
   (use-package git-gutter-fringe+
-    :if (eq version-control-diff-tool 'git-gutter+)
     :defer t
     :init
     (progn


### PR DESCRIPTION
Usage of the `:if` keyword with `use-package` does not prevent Spacemacs form
installing the package, it only prevents the loading in run-time. This commit
employs the `:toggle` feature of the configuration layer system to prevent the
unneeded packages from being installed in the first place.

This further improves upon 31324f68bb883550f927ef731d432e26ccc208e0