### PR TITLE
[go] Update build instructions for golangci-lint

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -76,6 +76,7 @@ to get all the goodies of this layer:
 
 #+BEGIN_SRC sh
   GO111MODULE=on go get -v golang.org/x/tools/gopls@latest
+  GO111MODULE=on CGO_ENABLED=0 go get -v -trimpath -ldflags '-s -w' github.com/golangci/golangci-lint/cmd/golangci-lint
   go get -u -v golang.org/x/tools/cmd/godoc
   go get -u -v golang.org/x/tools/cmd/goimports
   go get -u -v golang.org/x/tools/cmd/gorename
@@ -84,7 +85,6 @@ to get all the goodies of this layer:
   go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct
   go get -u -v github.com/fatih/gomodifytags
   go get -u -v github.com/godoctor/godoctor
-  go get -u -v github.com/golangci/golangci-lint/cmd/golangci-lint
   go get -u -v github.com/haya14busa/gopkgs/cmd/gopkgs
   go get -u -v github.com/josharian/impl
   go get -u -v github.com/mdempsky/gocode


### PR DESCRIPTION
See #10825.

Try to match more closely the build process followed upstream:

- Force module build mode, which builds the latest stable release (not master),
and takes care of module replacements.

- Disable cgo.

- The -trimpath argument to go get requires go >= 1.13, which is also needed
because go <= 1.12 has a bug that causes problems with golangci-lint², as
explained in the golangci-lint installation instructions².

Note that the only thing that is missing to exactly match the upstream build
process is the addition of some -X variables, which only affect the data
reported by golangci-lint version.

¹: https://github.com/golang/go/issues/29612
²: https://github.com/golangci/golangci-lint#install

Thanks to @dbriemann and @seriousben for reporting and clarifying this issue!
