### PR TITLE
[core] Toggleable hint for the Scrolling Transient State (~SPC N~)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -121,6 +121,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
     state (thanks to Sylvain Benner)
   - Restricted ~SPC b C-d~ to only kill other buffers in current perspective
     (thanks to Seong Yong-ju)
+  - Toggleable hint for the Scrolling Transient State (~SPC N~)
+    (thanks to Andriy Kmit)
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -186,3 +186,29 @@ Example: (evil-map visual \"<\" \"<gv\")"
   "Custom hint documentation format for keys."
   (format (format "[%%%ds] %%%ds" key-width (- -1 doc-width))
           key doc))
+
+
+
+(defvar spacemacs--scroll-ts-full-hint-toggle t
+  "Toggle the state of the scroll transient state documentation.
+
+Initial value is t so full hint will be shown by default. This is
+to preserve the behavior before hint toggle was implemented for
+the scroll transient state.")
+
+(defvar spacemacs--scroll-ts-full-hint nil
+  "Display full scroll transient state documentation.")
+
+(defun spacemacs//scroll-ts-toggle-hint ()
+  "Toggle the full hint docstring for the scroll transient state."
+  (interactive)
+  (setq spacemacs--scroll-ts-full-hint-toggle
+        (not spacemacs--scroll-ts-full-hint-toggle)))
+
+(defun spacemacs//scroll-ts-hint ()
+  "Return a condensed/full hint for the scroll transient state"
+  (concat
+   " "
+   (if spacemacs--scroll-ts-full-hint-toggle
+       spacemacs--scroll-ts-full-hint
+     (concat "[" (propertize "?" 'face 'hydra-face-red) "] toggle help"))))

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -133,15 +133,20 @@
   (define-key evil-normal-state-map (kbd "gD") 'spacemacs/jump-to-definition-other-window)
 
   ;; scrolling transient state
-  (spacemacs|define-transient-state scroll
-    :title "Scrolling Transient State"
-    :doc "
+  (spacemacs|transient-state-format-hint scroll
+    spacemacs--scroll-ts-full-hint
+    (format "\n[_?_] toggle help
  Line/Column^^^^      Half Page^^^^        Full Page^^ Buffer^^^^    Other
  ───────────^^^^───── ─────────^^^^─────── ─────────^^ ──────^^^^─── ─────^^───
  [_k_]^^   up         [_u_/_K_] up         [_b_] up    [_<_/_g_] beg [_q_] quit
  [_j_]^^   down       [_d_/_J_] down       [_f_] down  [_>_/_G_] end
- [_h_/_l_] left/right [_H_/_L_] left/right"
+ [_h_/_l_] left/right [_H_/_L_] left/right"))
+  (spacemacs|define-transient-state scroll
+    :title "Scrolling Transient State"
+    :hint-is-doc t
+    :dynamic-hint (spacemacs//scroll-ts-hint)
     :bindings
+    ("?" spacemacs//scroll-ts-toggle-hint)
     ;; lines and columns
     ("j" evil-scroll-line-down)
     ("k" evil-scroll-line-up)


### PR DESCRIPTION
By default the full hint is shown, which is consistent with the behavior before
this commit.