### PR TITLE
[spacemacs-layouts] add details of restricted functions

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1090,6 +1090,7 @@ Other:
                spacemacs/window-split-triple-columns
                spacemacs/window-split-grid)
     (thanks to Thanh Vuong)
+  - Added documentation to use a =spacemacs-layouts-restricted-functions= variables (John Stevenson)
   - Added a link to =spacemacs|create-align-repeat-x= in the docstring for
      =align-repeat-= commands (thanks to Troy Pracy)
   - Improved TS formatting: workspaces & layouts (thanks to duianto)

--- a/layers/+spacemacs/spacemacs-layouts/README.org
+++ b/layers/+spacemacs/spacemacs-layouts/README.org
@@ -5,6 +5,8 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#restrict-functions-to-the-current-layouts-buffers][Restrict functions to the current layout's buffers]]
+- [[#restrict-spc-tab-to-the-current-layouts-buffers][Restrict SPC-TAB to the current layout's buffers]]
 
 * Description
 This layer adds support for distinct layouts/workspaces to Spacemacs.
@@ -12,3 +14,53 @@ This layer adds support for distinct layouts/workspaces to Spacemacs.
 ** Features:
 - Support for distinct layouts via =eyebrowse=
 - Integration with =helm= and =ivy= to search for buffers within layouts
+
+* Restrict functions to the current layout's buffers
+Besides =helm-mini= and =ivy-switch-buffer= that are aware of a layout's
+buffers. This layer also provides a ~spacemacs-layouts-restricted-functions~
+variable that holds a list of functions that will be restricted to the current
+layout's buffers.
+
+Default value of ~spacemacs-layouts-restricted-functions~ is:
+#+begin_example elisp
+'(spacemacs/window-split-double-columns
+  spacemacs/window-split-triple-columns
+  spacemacs/window-split-grid)
+#+end_example
+
+The list can be edited in the ~dotspacemacs-configuration-layers~ variable near
+the top of ~.spacemacs~ like this:
+
+#+begin_example elisp
+(spacemacs-layouts :variables
+                   spacemacs-layouts-restricted-functions
+                   '(spacemacs/window-split-double-columns
+                     spacemacs/window-split-triple-columns
+                     spacemacs/window-split-grid))
+#+end_example
+
+Note that ~spacemacs-layouts-restricted-functions~ can only be changed in the
+~dotspacemacs-configuration-layers~ variable. They can't be edited during the
+current Emacs session. A restart is required.
+
+* Restrict SPC-TAB to the current layout's buffers
+
+When the ~spacemacs-layouts-restrict-spc-tab~ variable is set to ~t~, then
+~SPC-TAB~ (~spacemacs/alternate-buffer~) will be restricted to only switch
+between the current layout's buffers.
+
+Default value of ~spacemacs-layouts-restrict-spc-tab~ is ~nil~.
+
+It can be enabled in the ~dotspacemacs-configuration-layers~ variable near the
+top of ~.spacemacs~ like this:
+
+#+begin_example elisp
+ (spacemacs-layouts :variables spacemacs-layouts-restrict-spc-tab t)
+#+end_example
+
+Note that ~spacemacs-layouts-restrict-spc-tab~ also can be toggle on the fly by
+evaluating it like this:
+
+#+begin_example elisp
+ (setq spacemacs-layouts-restrict-spc-tab t)
+#+end_example


### PR DESCRIPTION
Detail how to use the layer variables to make use of restricted functions and
limit their scope to within a layout.

Documentation copied from the following commit, which did not get included along with the code
https://github.com/syl20bnr/spacemacs/tree/0e9866efcee9915f3418cec11371d02ee619ced2/layers/%2Bspacemacs/spacemacs-layouts