### PR TITLE
[rust] remove compilation buffer string match on rust-quick-run

### DIFF
--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -93,9 +93,7 @@ If `help-window-select' is non-nil, also select the help window."
 
 (defun spacemacs//rust-quick-run-compilation-finish-function (buffer status)
   (setq compilation-finish-functions (delete 'spacemacs//rust-quick-run-compilation-finish-function compilation-finish-functions))
-  (if (and (string-match "finished" status)
-           (with-current-buffer buffer
-             (string-match (concat "rustc -o " temporary-file-directory) (buffer-string))))
+  (if (string-match "finished" status)
       (progn
         (newline)
         (shell-command (shell-quote-argument spacemacs//rust-quick-run-tmp-file) t))))


### PR DESCRIPTION
this removes the (now unnecessary) check for the string `(concat "rustc -o " temporary-file-directory)` in the compilation finish function.  it should make this work on Windows now @duianto 