### PR TITLE
[java][lsp] Minor cleanup in lsp-java

### DIFF
--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -133,7 +133,15 @@
 
 (defun spacemacs//java-setup-lsp-dap ()
   "Setup DAP integration."
-  (require 'dap-java))
+  (require 'dap-java)
+  (spacemacs/set-leader-keys-for-major-mode 'java-mode
+    ;; debug
+    "ddj" 'dap-java-debug
+    "dtt" 'dap-java-debug-test-method
+    "dtc" 'dap-java-debug-test-class
+    ;; run
+    "tt" 'dap-java-run-test-method
+    "tc" 'dap-java-run-test-class))
 
 (defun spacemacs//java-setup-lsp-flycheck ()
   "Setup LSP Java syntax checking."

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -213,22 +213,7 @@
         "cc"  'lsp-java-build-project
         "cp"  'lsp-java-spring-initializr
 
-        "an"  'lsp-java-actionable-notifications
-
-        ;; dap-mode
-
-        ;; debug
-        "ddj" 'dap-java-debug
-        "dtt" 'dap-java-debug-test-method
-        "dtc" 'dap-java-debug-test-class
-        ;; run
-        "tt" 'dap-java-run-test-method
-        "tc" 'dap-java-run-test-class)
-
-      (setq lsp-highlight-symbol-at-point nil
-            lsp-ui-sideline-update-mode 'point
-            lsp-eldoc-render-all nil
-            lsp-java-completion-guess-arguments t))))
+        "an"  'lsp-java-actionable-notifications))))
 
 (defun java/init-mvn ()
   (use-package mvn


### PR DESCRIPTION
- Fixed setting dap-java shortcuts - ATM the shortcuts were not enabled due to
the fact that dap-mode configuration was overriding them since it was running
after this piece of code
- removed configuration code about lsp-java since it was either about
missing properties or about setting defaults already set by lsp-mode/lsp-java
(e. g. lsp-eldoc-render-all is now nil by default)

