### PR TITLE
Add LSP docs for JavasScript to README.org

### DIFF
--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -161,6 +161,15 @@ Default is =’web-beautify=.
 See [[file:../../+tools/tern/README.org][tern layer]] documentation.
 
 ** Language Server Protocol
+To use an LSP server with JavaScript, add it as a =javascript-backend= to your
+=~/.spacemacs=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((javascript :variables
+                              javascript-backend 'lsp)))
+
+*** TypeScript
 You have to install =typescript-language-server= (recommended) or
 =javascript-typescript-langserver= language server packages via
 
@@ -172,6 +181,13 @@ or
 
 #+BEGIN_SRC sh
   npm i -g typescript javascript-typescript-langserver
+#+END_SRC
+
+*** Flow
+You have to install =flow-bin=.
+
+#+BEGIN_SRC sh
+  npm i -g flow-bin
 #+END_SRC
 
 *** Debugger (dap integration)


### PR DESCRIPTION
Add docs for:
- Enabling `lsp` in the `javascript` layer.
- Using `flow`

This PR was prompted by [this request](https://github.com/syl20bnr/spacemacs/pull/7208#issuecomment-569397532).