### PR TITLE
Fix helm-spacemacs-help-faq, SPC h f

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1258,6 +1258,7 @@ Other:
   - Fixed searching in the =helm-find-file= actions (thanks to duianto)
   - Fixed =evilified-state=, mapped ~C-w~ to =evil-window-map=
     (thanks to Muneeb Shaikh)
+  - Fixed ~SPC h f~ =helm-spacemacs-help-faq= (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -26,7 +26,7 @@
   - [[#why-are-my-font-settings-not-being-respected][Why are my font settings not being respected?]]
   - [[#why-am-i-getting-a-message-about-environment-variables-on-startup][Why am I getting a message about environment variables on startup?]]
   - [[#i-want-to-learn-elisp-where-do-i-start-][I want to learn elisp, where do I start ?]]
-- [[#how-do-i][How do I:]]
+- [[#how-do-i][How do I]]
   - [[#install-a-package-not-provided-by-a-layer][Install a package not provided by a layer?]]
   - [[#disable-a-package-completely][Disable a package completely?]]
   - [[#disable-a-package-only-for-a-specific-major-mode][Disable a package only for a specific major-mode?]]
@@ -280,7 +280,7 @@ Practical reference with code examples for various situations that you will
 encounter: [[http://caiorss.github.io/Emacs-Elisp-Programming/][http://caiorss.github.io/Emacs-Elisp-Programming/]], more particularly
 sections [[http://caiorss.github.io/Emacs-Elisp-Programming/Elisp_Programming.html][Elisp Programming]] and [[http://caiorss.github.io/Emacs-Elisp-Programming/Elisp_Snippets.html][Elisp code snippets]].
 
-* How do I:
+* How do I
 ** Install a package not provided by a layer?
 Spacemacs provides a variable in the =dotspacemacs/layers= function in
 =.spacemacs= called =dotspacemacs-additional-packages=. Just add a package name


### PR DESCRIPTION
The helm-org-get-candidates function was removed upstream.

Reversed the helm headings list, to match the order of the
questions in FAQ.org, so that the Common questions are
listed first.

Removed the : (colon) after the heading: How do I
in FAQ.org, to match the other parent headings.

Resolves: #13123

---

### Question
This PR proposes two solutions:
- `Version 1` uses the private function: `helm-org--get-candidates-in-file`
- `Version 2` uses `helm-org-build-sources`
This version uses a somewhat convoluted way to drill down to the FAQ.org headings:
`     (dolist (c (aref (aref (cdadar cands) 2) 0))`
Maybe there's a simpler method for accessing the headings.

Is one version better than the other?
Both versions seem to work the same otherwise.

### Issue
With either version, when a helm candidate is chosen, then the cursor always goes to the end of the parent heading, ex: `Common`, `How do I` or `Windows`
instead of to the expected target question.

I don't know how to get it to jump to the marker for the question heading instead of the parent heading.

As noted in the comments before version 1.
While testing, if the version 2 function is evaluated, then the version 1 function won't work until Spacemacs has been restarted, because version 1 adds the prefix `FAQ.org:` before each heading line (internally not in the helm buffer).
After the version 2 function has been evaluated, then the filename prefix won't appear, therefore the string-match regexp won't find the `:` (colon) before the headings.

There probably is a regexp that handles either case, or the regexp could probably be improved, any suggestions for improvements are always welcome.