### PR TITLE
[helm] Fix rg interaction with its config file

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -164,9 +164,9 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   ;; --line-number forces line numbers (disabled by default on windows)
   ;; no --vimgrep because it adds column numbers that wgrep can't handle
   ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-  (let* ((root-helm-ag-base-command "rg --smart-case --no-heading --color never --line-number")
+  (let* ((root-helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number")
          (helm-ag-base-command (if spacemacs-helm-rg-max-column-number
-                                   (concat root-helm-ag-base-command " --max-columns " (number-to-string spacemacs-helm-rg-max-column-number))
+                                   (concat root-helm-ag-base-command " --max-columns=" (number-to-string spacemacs-helm-rg-max-column-number))
                                  root-helm-ag-base-command)))
     (helm-do-ag dir)))
 
@@ -292,7 +292,7 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   ;; --line-number forces line numbers (disabled by default on windows)
   ;; no --vimgrep because it adds column numbers that wgrep can't handle
   ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-  (let ((helm-ag-base-command "rg --smart-case --no-heading --color never --line-number --max-columns 150"))
+  (let ((helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number --max-columns=150"))
     (helm-do-ag-buffers)))
 
 (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()


### PR DESCRIPTION
If a user uses ripgrep persistent configuration file that sets options
helm overrides the argument parser for ripgrep might incorrectly parse
the command line used by helm.

The problem is encountered whenever an argument option occurs multiple
times and the last one is of this form: '--arg value' or '-a v'. If that
last argument is followed by the positional argument (input) then its
value will be treated as the input resulting in error due to too many
positional arguments.

In other worlds, this would fail to be parsed correctly:
    rg --max-columns=10 --max-columns 20 input
    rg --max-columns 10 --max-columns 20 input

While this works as expected:
    rg --max-columns=10 --max-columns=20 input
    rg --max-columns 10 --max-columns=20 input

The solution would be to use arguments in the form of '--arg=value'
which will never be treated as a positional argument.

Fixes #10953