### PR TITLE
Fix erc-log transient state - change it to be in erc-view-log-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1679,6 +1679,9 @@ Other:
 - Conditionally enable ERC notifications via =erc-enable-notifications=
   (thanks to Evan Klitzke)
 - Added spell checking and mIRC colors (thanks to Benjamin Levy)
+- erc-view-log related changes (thanks to Mpho Jele)
+  - Modified erc-log transient state to open in erc-view-log-mode
+  - Added utility to open log buffer/file from erc channel
 **** ESS
 - Key bindings:
   - Change ~SPC m s t~ to ~SPC m s f~ to respect convention (thanks to Yi Liu)

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -101,6 +101,7 @@
         "j" 'erc-join-channel
         "n" 'erc-channel-names
         "l" 'erc-list-command
+        "c" 'spacemacs/erc-find-channel-log
         "p" 'erc-part-from-channel
         "q" 'erc-quit-server))))
 
@@ -213,11 +214,17 @@
       (spacemacs|define-transient-state erc-log
         :title "ERC Log Transient State"
         :doc "\n[_r_] reload the log file  [_>_/_<_] go to the next/prev mention"
-        :evil-leader-for-mode (erc-mode . ".")
+        :evil-leader-for-mode (erc-view-log-mode . ".")
         :bindings
         ("r" erc-view-log-reload-file)
         (">" erc-view-log-next-mention)
-        ("<" erc-view-log-previous-mention)))))
+        ("<" erc-view-log-previous-mention))
+
+      (defun spacemacs/erc-find-channel-log ()
+        "find current erc channel's log file in `erc-view-log-mode'"
+        (interactive)
+        (when (erc-logging-enabled)
+            (find-file-existing (erc-current-logfile)))))))
 
 (defun erc/init-erc-image ()
   (use-package erc-image


### PR DESCRIPTION
With the fix I also added a utility function to open a erc log file/buffer from
a erc chat/channel buffer.
