### PR TITLE
[notmuch] rename require to 'ol-notmuch

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2392,6 +2392,7 @@ Other:
 - Open GitHub patches fullscreen
 - Add next and previous message bindings to notmuch-tree mode
 - Change the ~C-n~ and ~C-p~ message keys to their original ~N~ and ~P~ bindings
+- Edit require from =org-notmuch= to =ol-notmuch= as per org-mode update 9.3.1
 **** OCaml
 - Allow initialization without requiring =opam= (thanks to Bernhard Schommer)
 - Fixed misused functions, =merlin= is a package not a layer

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -119,7 +119,7 @@
 
 (defun notmuch/pre-init-org ()
   (spacemacs|use-package-add-hook org
-    :post-config (require 'org-notmuch)))
+    :post-config (require 'ol-notmuch)))
 
 (defun notmuch/pre-init-persp-mode ()
   (spacemacs|use-package-add-hook persp-mode


### PR DESCRIPTION
org has changed its file naming for the notmuch add-on from
org-notmuch to ol-notmuch.
org-mode commit 499c0a50cc4b11e37b91374af23cb27ab8fc20d2.

Fix the require to reflect this change.

Signed-off-by: Loys Ollivier <loys.ollivier@gmail.com>