### PR TITLE
Keyboard-Layout : Quick Fix of issue #11954

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -173,18 +173,18 @@
     "Remap `evil-window' bindings."
     :loader
     (with-eval-after-load 'evil-commands BODY)
-    :common
-    ;; FIXME: Not working
-    (kl/leader-correct-keys
-      "wh"
-      "wj"
-      "wk"
-      "wl"
-      ;;
-      "wH"
-      "wJ"
-      "wK"
-      "wL")
+    ;; :common
+    ;; ;; FIXME: Not working
+    ;; (kl/leader-correct-keys
+    ;;   "wh"
+    ;;   "wj"
+    ;;   "wk"
+    ;;   "wl"
+    ;;   ;;
+    ;;   "wH"
+    ;;   "wJ"
+    ;;   "wK"
+    ;;   "wL")
     :bepo
     (progn
       (spacemacs/set-leader-keys


### PR DESCRIPTION
Issue is referenced [here](https://github.com/syl20bnr/spacemacs/issues/11954).

Note that this is a quick fix. It comments a part of keyboard-layout for evil-window support. But the portion commented is marked as not working. So I suspect there is no harm.