### PR TITLE
[nixos] add toggle for company-nixos-options

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2380,6 +2380,8 @@ Other:
   function (thanks to Profpatsch)
 - Associate nix-mode with .nix files (thanks to jpathy)
 - Updated layer banner (thanks to kalium)
+- Added option =nixos-enable-company= to toggle company auto-completion (thanks
+  to bhipple)
 **** Nim
 - Added key binding ~SPC m h h~ to show symbol documentation
   (thanks to Valts Liepiņš)

--- a/layers/+os/nixos/README.org
+++ b/layers/+os/nixos/README.org
@@ -26,6 +26,14 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =nixos= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+* Configuration
+Toggle whether =company-nixos-options= completion is enabled (defaults to true).
+
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+              '((nixos :variables nixos-enable-company t)))
+#+END_SRC
+
 * Key bindings
 ** NixOS Options
 

--- a/layers/+os/nixos/config.el
+++ b/layers/+os/nixos/config.el
@@ -1,0 +1,14 @@
+;;; config.el --- NixOS Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2015-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+
+(defvar nixos-enable-company t
+  "Enable company completion via company-nixos-options")

--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -1,24 +1,35 @@
+;;; packages.el --- NixOS Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2015-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
 (defconst nixos-packages
-      '(
-        company
-        flycheck
+      '(company
         (company-nixos-options :requires company)
+        flycheck
         (helm-nixos-options :requires helm)
         nix-mode
-        nixos-options
-        ))
+        nixos-options))
 
 (defun nixos/post-init-company ()
-  (let ((backends '(company-capf)))
-    (when (configuration-layer/package-used-p 'company-nixos-options)
-      (add-to-list 'backends 'company-nixos-options t))
-    (eval `(spacemacs|add-company-backends
-             :backends ,backends
-             :modes nix-mode))))
+  (when nixos-enable-company
+    (let ((backends '(company-capf)))
+      (when (configuration-layer/package-used-p 'company-nixos-options)
+        (add-to-list 'backends 'company-nixos-options t))
+      (eval `(spacemacs|add-company-backends
+               :backends ,backends
+               :modes nix-mode)))))
 
 (defun nixos/init-company-nixos-options ()
-  (use-package company-nixos-options
-    :defer t))
+ (use-package company-nixos-options
+   :if nixos-enable-company
+   :defer t))
 
 (defun nixos/init-helm-nixos-options ()
   (use-package helm-nixos-options


### PR DESCRIPTION
On some Nix setups, company completion via the Nix repl process can be extremely
slow and hang emacs. This commit adds an option toggle to disable it in the
`nixos` layer. The default behavior is unchanged.

Also updates the comment and license headers to be consistent with other layers.
