### PR TITLE
Fix void destructuring-bind after cl pkg deprecation

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -619,6 +619,8 @@ Other:
   - Fixed ~SPC TAB~ in =spacemacs-base= distribution (thanks to duianto)
   - Frame title setting doesn't need to depend on environment (gui/cli)
     (thanks to Mpho Jele)
+  - Replaced =destructuring-bind= with =cl-destructuring-bind=
+    (thanks to duianto)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -323,7 +323,7 @@ current window.
 If `spacemacs-layouts-restrict-spc-tab' is `t' then this only switches between
 the current layouts buffers."
   (interactive)
-  (destructuring-bind (buf start pos)
+  (cl-destructuring-bind (buf start pos)
       (if (bound-and-true-p spacemacs-layouts-restrict-spc-tab)
           (let ((buffer-list (persp-buffer-list))
                 (my-buffer (window-buffer window)))

--- a/layers/+chat/rcirc/funcs.el
+++ b/layers/+chat/rcirc/funcs.el
@@ -120,9 +120,9 @@ This doesn't support the chanserv auth method. "
 
 (defun spacemacs//znc-auth-source-fetch-password (server)
   "Given a server with at least :host :port :login, return the :password"
-  (destructuring-bind (&key host auth &allow-other-keys)
+  (cl-destructuring-bind (&key host auth &allow-other-keys)
       (cdr server)
-    (destructuring-bind (&key secret &allow-other-keys)
+    (cl-destructuring-bind (&key secret &allow-other-keys)
         (car (auth-source-search :host host
                                  :port "irc"
                                  :user auth
@@ -150,7 +150,7 @@ This doesn't support the chanserv auth method. "
   (cl-loop
    for s in rcirc-server-alist
    collect
-   (destructuring-bind (&key host
+   (cl-destructuring-bind (&key host
                              (port rcirc-default-port)
                              (nick rcirc-default-nick)
                              (user-name rcirc-default-user-name)


### PR DESCRIPTION
`destructuring-bind` is a macro in the deprecated package: `cl`

`SPC-TAB` calls: `spacemacs/alternate-buffer`
In the `spacemacs-base` distribution, it shows the message:
>spacemacs/alternate-buffer: Symbol’s function definition is void: destructuring-bind

Also renamed three instances of `destructuring-bind` in the `rirc` layer.