### PR TITLE
Spacemacs buffer in other window with prefix arg

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -535,6 +535,8 @@ Other:
     (thanks to Spenser Truex)
   - Converted =case= to =cl-case= to fix =cl-lib= related errors
     (thanks to Nikita Leshenko)
+  - Open Spacemacs home buffer in other/new window with prefix argument
+    (thanks to duianto)
 - Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1008,7 +1008,9 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
 
 (defun spacemacs-buffer/goto-buffer (&optional refresh)
   "Create the special buffer for `spacemacs-buffer-mode' and switch to it.
-REFRESH if the buffer should be redrawn."
+REFRESH if the buffer should be redrawn.
+
+If a prefix argument is given, switch to it in an other, possibly new window."
   (interactive)
   (let ((buffer-exists (buffer-live-p (get-buffer spacemacs-buffer-name)))
         (save-line nil))
@@ -1045,7 +1047,9 @@ REFRESH if the buffer should be redrawn."
                    (forward-line (1- save-line))
                    (forward-to-indentation 0))
           (spacemacs-buffer/goto-link-line)))
-      (switch-to-buffer spacemacs-buffer-name)
+      (if current-prefix-arg
+          (switch-to-buffer-other-window spacemacs-buffer-name)
+        (switch-to-buffer spacemacs-buffer-name))
       (spacemacs//redisplay))))
 
 (add-hook 'window-setup-hook


### PR DESCRIPTION
This makes `SPC u SPC b h` behave the same for the Spacemacs buffer, as it does for the scratch and messages buffers:
- `SPC u SPC b s` scratch buffer
- `SPC u SPC b m` messages buffer