### PR TITLE
[persp] Bind `C-d` to project perspective and dired

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -518,9 +518,17 @@ Run PROJECT-ACTION on project."
                projectile-known-projects))
      :fuzzy-match helm-projectile-fuzzy-match
      :mode-line helm-read-file-name-mode-line-string
+     :keymap (let ((map (make-sparse-keymap)))
+               (define-key map
+                 (kbd "C-d") #'(lambda () (interactive)
+                                 (helm-exit-and-execute-action
+                                  (lambda (project)
+                                    (spacemacs||switch-project-persp project
+                                      (dired project))))))
+               map)
      :action `(("Switch to Project Perspective" .
                 spacemacs//helm-persp-switch-project-action)
-               ("Switch to Project Perspective and Open Dired" .
+               ("Switch to Project Perspective and Open Dired `C-d'" .
                 ,(spacemacs//helm-persp-switch-project-action-maker
                   (lambda () (dired "."))))
                ("Switch to Project Perspective and Show Recent Files" .

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -558,6 +558,11 @@ Run PROJECT-ACTION on project."
             :action #'spacemacs//ivy-persp-switch-project-action
             :caller 'spacemacs/ivy-persp-switch-project))
 
+(defun spacemacs/ivy-switch-project-open-dired (project)
+  (interactive)
+  (spacemacs||switch-project-persp project
+    (dired project)))
+
 
 ;; Eyebrowse
 

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -240,4 +240,7 @@
 (defun spacemacs-layouts/init-counsel-projectile ()
   (use-package counsel-projectile
     :defer t
-    :init (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)))
+    :init (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)
+    :config (ivy-set-actions
+             'spacemacs/ivy-persp-switch-project
+             '(("" spacemacs/ivy-switch-project-open-dired "dired")))))


### PR DESCRIPTION
This change adds a key binding for having `Spc p l` jump to the project in _dired_.

`Ctl-d` is the binding for the corresponding action when using `Spc p p`.