### PR TITLE
Add SPC x d l delete-blank-lines

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -987,6 +987,7 @@ Other:
     - With the =hybrid= editing style in =normal= state:
       - ~n~ =evil-search-next=
       - ~N~ =evil-search-previous=
+  - Added ~SPC x d l~ =delete-blank-lines= (thanks to duianto)
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -647,6 +647,7 @@ respond to this toggle."
   "xa|" 'spacemacs/align-repeat-bar
   "xc"  'count-region
   "xd SPC" 'cycle-spacing
+  "xdl" 'delete-blank-lines
   "xdw" 'delete-trailing-whitespace
   "xjc" 'set-justification-center
   "xjf" 'set-justification-full


### PR DESCRIPTION
Bind `SPC x d l` to `delete-blank-lines` (default: `C-x C-o`)

If the cursor is on a blank line:
- with blank lines above or below, then they are reduced to only one.
- without blank lines above or below, then the blank line is removed.