### PR TITLE
Improve rainbow-identifiers experience for Elisp and CL

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1499,6 +1499,8 @@ Other:
 - Improvements:
   - Added eval-thing-at-point functions to Common Lisp Layer
     (thanks to Lukas Woell)
+  - Make rainbow-identifiers not colorize special operators and macros, so they
+    always visually stand out. (thanks to Andriy Kmit)
 - New packages:
   - Added =slime-asdf= to =slime-contribs= to enabled some slime commands like
     =,load-system= (thanks to Daniel Schoepe)
@@ -1667,6 +1669,8 @@ Other:
   (thanks to Codruț Constantin Gușoi, Sylvain Benner)
 - Activate nameless only in GUI (thanks to Sylvain Benner)
 - Added =flycheck-package= for package metadata linting (thanks to Uroš Perišić)
+- Make rainbow-identifiers not colorize special operators and macros, so they
+  always visually stand out. (thanks to Andriy Kmit)
 **** Emoji
 - Added support for Emoji fonts on macOS and Linux (thanks to CodeFalling)
 - Setup =emojify= cache directory (thanks to Boris Buliga)

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -20,6 +20,7 @@
         helm
         helm-gtags
         parinfer
+        rainbow-identifiers
         slime
         (slime-company :requires company)
         ))
@@ -62,6 +63,9 @@
 
 (defun common-lisp/post-init-parinfer ()
   (add-hook 'lisp-mode-hook 'parinfer-mode))
+
+(defun common-lisp/post-init-rainbow-identifiers ()
+  (add-hook 'lisp-mode-hook #'colors//rainbow-identifiers-ignore-keywords))
 
 (defun common-lisp/pre-init-slime-company ()
   (spacemacs|use-package-add-hook slime

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -32,6 +32,7 @@
         nameless
         overseer
         parinfer
+        rainbow-identifiers
         semantic
         smartparens
         srefactor
@@ -279,6 +280,9 @@
 
 (defun emacs-lisp/post-init-parinfer ()
   (add-hook 'emacs-lisp-mode-hook 'parinfer-mode))
+
+(defun emacs-lisp/post-init-rainbow-identifiers ()
+  (add-hook 'emacs-lisp-mode-hook #'colors//rainbow-identifiers-ignore-keywords))
 
 (defun emacs-lisp/post-init-semantic ()
   (add-hook 'emacs-lisp-mode-hook 'semantic-mode)

--- a/layers/+themes/colors/funcs.el
+++ b/layers/+themes/colors/funcs.el
@@ -17,6 +17,12 @@
   (when (derived-mode-p 'prog-mode)
     (rainbow-identifiers-mode)))
 
+(defun colors//rainbow-identifiers-ignore-keywords ()
+  "Do not colorize stuff with ‘font-lock-keyword-face’."
+  (setq-local rainbow-identifiers-faces-to-override
+              (delq 'font-lock-keyword-face
+                    rainbow-identifiers-faces-to-override)))
+
 (defun colors//tweak-theme-colors (theme)
   "Tweak color themes by adjusting rainbow-identifiers."
   (interactive)


### PR DESCRIPTION
Make `rainbow-identifiers` not colorize special operators and macros, so they
always visually stand out. Rationale behind this change is that special
operators and macros in Lisp may be considered "syntax" elements, so it makes
sense to have them visually distinguished at all times.

![lisp-rainbow-identifiers](https://user-images.githubusercontent.com/2280844/72241593-dbd75680-35ef-11ea-959d-f64cc6ba00ca.png)
