### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -346,7 +346,7 @@
       - [[#eyebrowse][Eyebrowse]]
       - [[#games-2][Games]]
       - [[#git-3][Git]]
-      - [[#github-1][Github]]
+      - [[#github-1][GitHub]]
       - [[#go-5][Go]]
       - [[#haskell-5][Haskell]]
       - [[#html-5][Html]]
@@ -448,7 +448,7 @@
       - [[#eyebrowse-2][Eyebrowse]]
       - [[#fsharp][Fsharp]]
       - [[#git-4][Git]]
-      - [[#github-2][Github]]
+      - [[#github-2][GitHub]]
       - [[#gnus-1][Gnus]]
       - [[#go-6][Go]]
       - [[#gtags-1][Gtags]]
@@ -3071,7 +3071,7 @@ Improve loading robustness:
 - Deactivate =evil-snipe= mode which messes with =magit= buffer (thanks to
   cpaulik)
 
-**** Github
+**** GitHub
 - New key binding ~SPC g c~ to clone and optionally fork repository
   (thanks to cpaulik)
 
@@ -3585,7 +3585,7 @@ Improve loading robustness:
   experience. Set the distribution with =dotspacemacs-distribution= variable.
 - Add support for =Quelpa= which allows to use =Melpa= recipes to install
   packages directly from source (i.e. one can now install a package directly
-  from a Github repository).
+  from a GitHub repository).
 - New editing style: =hybrid=. This style is similar to Vim style except that
   all Emacs key bindings are available in hybrid (insert) state instead of Vim
   key bindings. Also in this state, the buffers are evilified like in Vim style.
@@ -3871,7 +3871,7 @@ Improve loading robustness:
 - Evilify =magit-hunk-section-map= (thanks to ralesi)
 - Evilify =magit-stash-mode= (thanks to nixmaniack)
 
-**** Github
+**** GitHub
 - Properly evilify =gist-lists= buffer (thanks to cmccloud)
 
 **** Gnus
@@ -5216,4 +5216,4 @@ a batch of packages.
   conflict with =pt= command line tool from TCL parser tools.
 
 * Previous Releases
-- See Github release page
+- See GitHub release page

--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -282,7 +282,7 @@ seconds to load")
   "Major mode for reporting issues with Spacemacs.
 
 When done editing, you can type \\[spacemacs//report-issue-done] to create the
-issue on Github. You must be logged in already for this to work. After you see
+issue on GitHub. You must be logged in already for this to work. After you see
 that the issue has been created successfully, you can close this buffer.
 
 \\{spacemacs/report-issue-mode-map}

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -620,7 +620,7 @@ REAL-WIDTH: the real width of the line.  If the line contains an image, the size
   (insert " ")
   (widget-create 'url-link
                  :tag (propertize "Homepage" 'face 'font-lock-keyword-face)
-                 :help-echo "Open the Spacemacs Github page in your browser."
+                 :help-echo "Open the Spacemacs GitHub page in your browser."
                  :mouse-face 'highlight
                  :follow-link "\C-m"
                  "http://spacemacs.org")

--- a/core/libs/quelpa.el
+++ b/core/libs/quelpa.el
@@ -1617,7 +1617,7 @@ Return t in each case."
     (setf (cdr (last cache-item)) '(:stable t))))
 
 (defun quelpa-checkout-melpa ()
-  "Fetch or update the melpa source code from Github.
+  "Fetch or update the melpa source code from GitHub.
 If there is no error return non-nil.
 If there is an error but melpa is already checked out return non-nil.
 If there is an error and no existing checkout return nil."

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2072,7 +2072,7 @@ page instead.
 
 Spacemacs uses [[https://github.com/Bruce-Connor/paradox][Paradox]] instead of =package-list-packages= to list available
 ELPA packages. Paradox enhances the package list buffer with better feedbacks,
-new filters and Github information like the number of stars. Optionally you can
+new filters and GitHub information like the number of stars. Optionally you can
 also star packages directly in the buffer.
 
 *Important Note 1*: Installing a new package from =Paradox= won't make it
@@ -2102,7 +2102,7 @@ Spacemacs.
 | ~r~         | refresh                                               |
 | ~S P~       | sort by package name                                  |
 | ~S S~       | sort by status (installed, available, etc...)         |
-| ~S *~       | sort by Github stars                                  |
+| ~S *~       | sort by GitHub stars                                  |
 | ~v~         | =visual state=                                        |
 | ~V~         | =visual-line state=                                   |
 | ~x~         | execute (action flags)                                |
@@ -3583,7 +3583,7 @@ You can disable the built-in server by setting the variable
 If any errors happen during the loading the mode-line will turn red and the
 errors should appear inline in the startup buffer. Spacemacs should still be
 usable; if it is not then restart Emacs with =emacs --debug-init= and open a
-[[https://github.com/syl20bnr/spacemacs/issues][Github issue]] with the backtrace.
+[[https://github.com/syl20bnr/spacemacs/issues][GitHub issue]] with the backtrace.
 
 ** Upgrading/Downgrading Emacs version
 To ensure that packages are correctly compiled for the new Emacs version you
@@ -3593,7 +3593,7 @@ with ~SPC u SPC SPC spacemacs/recompile-elpa~.
 ** General layer errors
 It happens from time to time that some of the layers go stale and stop
 working properly for some commands. If this happens stay calm and try
-to produce a minimal bug report on the [[https://github.com/syl20bnr/spacemacs/issues][Github issue page]].
+to produce a minimal bug report on the [[https://github.com/syl20bnr/spacemacs/issues][GitHub issue page]].
 
 *** Step by step instructions for minimal layer bug reports
 - Load the standard dotfile. You can get it with ~SPC f e D~.

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -177,7 +177,7 @@ functions are the first thing you should refer to.
 
 ** Exploring
 There are a few ways to explore the functionality of Spacemacs. One is to read
-the [[https://github.com/syl20bnr/spacemacs][source code]] on Github. You can begin to feel your way around Emacs Lisp and
+the [[https://github.com/syl20bnr/spacemacs][source code]] on GitHub. You can begin to feel your way around Emacs Lisp and
 how Spacemacs works this way. You can also use the following key bindings to
 explore:
 

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -118,7 +118,7 @@
         (push filename result)))
 
     ;; CONTRIBUTING.org is a special case as it should be at the root of the
-    ;; repository to be linked as the contributing guide on Github.
+    ;; repository to be linked as the contributing guide on GitHub.
     (push "CONTRIBUTING.org" result)
 
     ;; delete DOCUMENTATION.org to make it the first guide
@@ -153,7 +153,7 @@
   (let ((file (if (string= candidate "CONTRIBUTING.org")
                   ;; CONTRIBUTING.org is a special case as it should be at the
                   ;; root of the repository to be linked as the contributing
-                  ;; guide on Github.
+                  ;; guide on GitHub.
                   (concat spacemacs-start-directory candidate)
                 (concat spacemacs-docs-directory candidate))))
     (cond ((and (equal (file-name-extension file) "md")

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -57,7 +57,7 @@
         (push filename result)))
 
     ;; CONTRIBUTING.org is a special case as it should be at the root of the
-    ;; repository to be linked as the contributing guide on Github.
+    ;; repository to be linked as the contributing guide on GitHub.
     (push "CONTRIBUTING.org" result)
 
     ;; delete DOCUMENTATION.org to make it the first guide
@@ -93,7 +93,7 @@
          (file (if (string= candidate "CONTRIBUTING.org")
                    ;; CONTRIBUTING.org is a special case as it should be at the
                    ;; root of the repository to be linked as the contributing
-                   ;; guide on Github.
+                   ;; guide on GitHub.
                    (concat spacemacs-start-directory candidate)
                  (concat spacemacs-docs-directory candidate))))
     (cond ((equal (file-name-extension file) "md")

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -11,7 +11,7 @@
 - [[#important-note][Important Note]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#github-support][Github support]]
+  - [[#github-support][GitHub support]]
   - [[#twitter-bootstrap-support][Twitter Bootstrap support]]
   - [[#gnuplot-support][Gnuplot support]]
   - [[#revealjs-support][Reveal.js support]]
@@ -99,8 +99,8 @@ To use this configuration layer: in the main Spacemacs configuration
 file (=~/.spacemacs=), to the existing =dotspacemacs-configuration-layers= list
 add the =org= entry.
 
-** Github support
-To install Github related extensions like [[https://github.com/larstvei/ox-gfm][ox-gfm]] to export to Github
+** GitHub support
+To install GitHub related extensions like [[https://github.com/larstvei/ox-gfm][ox-gfm]] to export to GitHub
 flavored markdown set the variable =org-enable-github-support= to =t=.
 
 #+BEGIN_SRC emacs-lisp

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -23,7 +23,7 @@
   "If non-nil Twitter Bootstrap related packages are configured.")
 
 (defvar org-enable-github-support nil
-  "If non-nil Github related packages are configured.")
+  "If non-nil GitHub related packages are configured.")
 
 (defvar org-enable-reveal-js-support nil
   "If non-nil, enable export to reveal.js.")

--- a/layers/+emacs/org/local/ox-gfm/ox-gfm.el
+++ b/layers/+emacs/org/local/ox-gfm/ox-gfm.el
@@ -1,4 +1,4 @@
-;;; ox-gfm.el --- Github Flavored Markdown Back-End for Org Export Engine
+;;; ox-gfm.el --- GitHub Flavored Markdown Back-End for Org Export Engine
 
 ;; Copyright (C) 2014 Lars Tveito
 
@@ -36,7 +36,7 @@
 
 (defgroup org-export-gfm nil
   "Options specific to Markdown export back-end."
-  :tag "Org Github Flavored Markdown"
+  :tag "Org GitHub Flavored Markdown"
   :group 'org-export
   :version "24.4"
   :package-version '(Org . "8.0"))
@@ -48,7 +48,7 @@
   :export-block '("GFM" "GITHUB FLAVORED MARKDOWN")
   :filters-alist '((:filter-parse-tree . org-md-separate-elements))
   :menu-entry
-  '(?g "Export to Github Flavored Markdown"
+  '(?g "Export to GitHub Flavored Markdown"
        ((?G "To temporary buffer"
             (lambda (a s v b) (org-gfm-export-as-markdown a s v)))
         (?g "To file" (lambda (a s v b) (org-gfm-export-to-markdown a s v)))
@@ -67,7 +67,7 @@
 ;;;; Src Block
 
 (defun org-gfm-src-block (src-block contents info)
-  "Transcode SRC-BLOCK element into Github Flavored Markdown
+  "Transcode SRC-BLOCK element into GitHub Flavored Markdown
 format. CONTENTS is nil.  INFO is a plist used as a communication
 channel."
   (let* ((lang (org-element-property :language src-block))
@@ -121,7 +121,7 @@ holding export options."
 
 ;;;###autoload
 (defun org-gfm-export-as-markdown (&optional async subtreep visible-only)
-  "Export current buffer to a Github Flavored Markdown buffer.
+  "Export current buffer to a GitHub Flavored Markdown buffer.
 
 If narrowing is active in the current buffer, only export its
 narrowed part.
@@ -150,7 +150,7 @@ non-nil."
 ;;;###autoload
 (defun org-gfm-convert-region-to-md ()
   "Assume the current region has org-mode syntax, and convert it
-to Github Flavored Markdown.  This can be used in any buffer.
+to GitHub Flavored Markdown.  This can be used in any buffer.
 For example, you can write an itemized list in org-mode syntax in
 a Markdown buffer and use this command to convert it."
   (interactive)
@@ -159,7 +159,7 @@ a Markdown buffer and use this command to convert it."
 
 ;;;###autoload
 (defun org-gfm-export-to-markdown (&optional async subtreep visible-only)
-  "Export current buffer to a Github Flavored Markdown file.
+  "Export current buffer to a GitHub Flavored Markdown file.
 
 If narrowing is active in the current buffer, only export its
 narrowed part.

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -34,7 +34,7 @@ This layer adds markdown support to Spacemacs.
 
 ** Features:
 - markdown files support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
-- Fast Github-flavored live preview via [[https://github.com/blak3mill3r/vmd-mode][vmd-mode]]
+- Fast GitHub-flavored live preview via [[https://github.com/blak3mill3r/vmd-mode][vmd-mode]]
 - TOC generation via [[https://github.com/ardumont/markdown-toc][markdown-toc]]
 - Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
   using the =emoji= layer or having a proper font) :clap:
@@ -53,7 +53,7 @@ file.
 By default the built-in Emacs web browser is used to live preview a markdown
 buffer.
 
-To use =vmd= (Github-flavored live preview) instead set the value of the
+To use =vmd= (GitHub-flavored live preview) instead set the value of the
 variable =markdown-live-preview-engine= to =vmd=:
 
 #+BEGIN_SRC emacs-lisp
@@ -123,7 +123,7 @@ In order to use =orgtabl-mode=, add =org= layer to your =~/.spacemacs=.
 | ~SPC m x B~ | insert gfm checkbox                                               |
 | ~SPC m x i~ | make region italic or insert italic                               |
 | ~SPC m x c~ | make region code or insert code                                   |
-| ~SPC m x C~ | make region code or insert code (Github Flavored Markdown format) |
+| ~SPC m x C~ | make region code or insert code (GitHub Flavored Markdown format) |
 | ~SPC m x q~ | make region blockquote or insert blockquote                       |
 | ~SPC m x Q~ | blockquote region                                                 |
 | ~SPC m x p~ | make region or insert pre                                         |

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -180,7 +180,7 @@
   - [[#speed-reading][Speed reading]]
 - [[#source-control][Source control]]
   - [[#git][Git]]
-  - [[#github][Github]]
+  - [[#github][GitHub]]
   - [[#perforce][Perforce]]
   - [[#version-control][Version-control]]
 - [[#spacemacs][Spacemacs]]
@@ -1376,7 +1376,7 @@ This layer adds markdown support to Spacemacs.
 
 Features:
 - markdown files support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
-- Fast Github-flavored live preview via [[https://github.com/blak3mill3r/vmd-mode][vmd-mode]]
+- Fast GitHub-flavored live preview via [[https://github.com/blak3mill3r/vmd-mode][vmd-mode]]
 - TOC generation via [[https://github.com/ardumont/markdown-toc][markdown-toc]]
 - Completion of Emojis using [[https://github.com/dunn/company-emoji][company-emoji]] (still needs a way of showing, either
   using the =emoji= layer or having a proper font) :clap:
@@ -2345,7 +2345,7 @@ Features:
 
 New to Magit? Checkout the [[https://magit.vc/about/][official intro]].
 
-** Github
+** GitHub
 [[file:+source-control/github/README.org][+source-control/github/README.org]]
 
 This layers adds support for [[http://github.com][GitHub]].


### PR DESCRIPTION
This PR changes instances of "Github" to "GitHub", in line with GitHub's brand guidelines.

Since this is such a minor change, I'm not sure if it makes sense adding an entry to `CHANGELOG.develop`. If you'd like me to add an entry, let me know and I'm happy to oblige.