### PR TITLE
Add persp-mode integration in treemacs layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3075,6 +3075,7 @@ Other:
 - Deprecated =treemacs-use-collapsed-directories=. Flattening directories should
   be controlled by directly setting =treemacs-collapse-dirs=.
 - Fixed "width (un)locked" message appearing when treemacs is loaded.
+- Add =persp-mode= integration (thanks to Seong Yong-ju)
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -16,6 +16,7 @@
     treemacs
     (treemacs-evil :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
     (treemacs-magit :requires magit)
+    (treemacs-persp :requires persp-mode)
     treemacs-projectile
     winum
     ))
@@ -28,7 +29,9 @@
 
 (defun treemacs/init-treemacs ()
   (use-package treemacs
-    :commands (treemacs-select-window treemacs--window-number-ten
+    :commands (treemacs-select-window
+               treemacs-select-scope-type
+               treemacs--window-number-ten
                treemacs-current-visibility)
     :defer t
     :init
@@ -90,6 +93,9 @@
     :after treemacs
     :defer t
     :init (require 'treemacs-projectile)))
+
+(defun treemacs/init-treemacs-persp ()
+  (use-package treemacs-persp :after treemacs))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
## Description

Treemacs now supports Perspective as the Treemacs buffer scope.

[treemacs-persp] https://github.com/Alexander-Miller/treemacs/blob/master/src/extra/treemacs-persp.el
[discussion] https://github.com/Alexander-Miller/treemacs/issues/222

To set Perspective as the Treemacs buffer scope, execute `treemacs-select-scope-type` and choose `Perspective`.