### PR TITLE
Wrong type argument: commandp, TeX-comment-or-uncomment-region

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2229,6 +2229,7 @@ Other:
     (thanks to Olivier Verdier)
 - Fixed README to say auto-fill on by default. (thanks to Max Willsey)
 - Added ConTeXt mode to the key bindings (thanks to ft)
+- Fixed ~SPC m ;~ binding (thanks to Tianshu Wang)
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 - Added support for =LSP= (EmmyLua-LS-all) (thanks to Lin.Sun)

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -57,7 +57,7 @@
           "\\"  'TeX-insert-macro                            ;; C-c C-m
           "-"   'TeX-recenter-output-buffer                  ;; C-c C-l
           "%"   'TeX-comment-or-uncomment-paragraph          ;; C-c %
-          ";"   'TeX-comment-or-uncomment-region             ;; C-c ; or C-c :
+          ";"   'comment-or-uncomment-region                 ;; C-c ; or C-c :
           ;; TeX-command-run-all runs compile and open the viewer
           "a"   'TeX-command-run-all                         ;; C-c C-a
           "b"   'latex/build


### PR DESCRIPTION
#### Description :octocat:
Wrong type argument: commandp, TeX-comment-or-uncomment-region

#### Reproduction guide :beetle:
- Start Emacs
- open a new tex file
- ,-;

*Observed behaviour:* :eyes: :broken_heart:
command-execute: Wrong type argument: commandp, TeX-comment-or-uncomment-region

*Expected behaviour:* :heart: :smile:
set ,-; to C-c ; or C-c : binding function, i.e. comment-or-uncomment-region?

#### System Info :computer:
- OS: darwin
- Emacs: 26.3
- Spacemacs: 0.300.0
- Spacemacs branch: develop (rev. 3d39b98e9)
- Graphic display: t
- Distribution: spacemacs
- Editing style: vim
- Completion: ivy
- Layers:
```elisp
((spacemacs-layouts :variables spacemacs-layouts-restrict-spc-tab t)
 (ivy :variables ivy-re-builders-alist
      '((spacemacs/counsel-search . spacemacs/ivy--regex-plus)
        (counsel-M-x . ivy--regex-fuzzy)
        (t . ivy--regex-ignore-order))
      ivy-initial-inputs-alist nil ivy-enable-advanced-buffer-information t)
 osx
 (chinese :variables chinese-enable-fcitx t)
 dash
 (version-control :variables version-control-diff-tool 'diff-hl)
 (git :variables magit-wip-mode t)
 (github :variables forge-topic-list-limit
         '(60 . 5))
 (pandoc :variables pandoc-data-dir "~/.spacemacs.d/pandoc-mode")
 lsp dap
 (c-c++ :variables c-c++-default-mode-for-headers 'c++-mode c++-enable-organize-includes-on-save t c-c++-backend 'lsp-clangd)
 emacs-lisp
 (python :variables python-backend 'anaconda python-sort-imports-on-save t python-test-runner
         '(pytest nose)
         python-formatter 'black python-format-on-save nil blacken-fast-unsafe t python-fill-column 88)
 (conda :variables conda-anaconda-home "/usr/local/anaconda3")
 (markdown :variables markdown-command "pandoc -f markdown+smart -t html5 --mathjax --highlight-style=pygments --toc --toc-depth 3 --template github.html5 --shift-heading-level-by=-1 --quiet" markdown-live-preview-engine 'pandoc)
 (org :variables org-agenda-files
      '("~/Documents/Org")
      org-directory '"~/Documents/Org" org-projectile-file "TODOs.org" org-want-todo-bindings t org-enable-hugo-support nil org-enable-reveal-js-support nil org-enable-org-journal-support t org-journal-dir "~/Documents/Org/Journals/")
 (latex :variables latex-enable-auto-fill nil latex-enable-folding t latex-enable-magic nil)
 (bibtex :variables org-ref-default-bibliography
         '("~/Dropbox/Documents/Zotero/refs.bib")
         org-ref-pdf-directory "~/Dropbox/Documents/Zotero/" org-ref-bibliography-notes "~/Dropbox/Documents/Zotero/notes.org")
 (deft :variables deft-directory "~/Documents/Org/Notes" deft-recursive t deft-extensions
   '("org" "md" "txt")
   deft-org-mode-title-prefix t deft-use-filename-as-title nil deft-use-filter-string-for-filename t deft-auto-save-interval 0 deft-file-naming-rules
   '((noslash . "-")
     (nospace . "-")
     (case-fn . downcase))
   deft-strip-summary-regexp
   (concat "\\(" "[\n	]" "\\|^#\\+[[:upper:]_]+:.*$" "\\|^#\\+[[:alnum:]_]+:.*$" "\\)"))
 (auto-completion :variables auto-completion-enable-help-tooltip 'manual auto-completion-use-company-box t auto-completion-enable-snippets-in-popup nil auto-completion-enable-sort-by-usage t)
 (templates :variables templates-private-directory "~/.spacemacs.d/templates")
 (syntax-checking :variables syntax-checking-enable-by-default nil)
 (pdf :variables pdf-view-use-scaling t)
 (wakatime :variables wakatime-cli-path "/usr/local/bin/wakatime")
 (geolocation :variables geolocation-enable-automatic-theme-changer t geolocation-enable-location-service t)
 imenu-list evil-commentary helpful unicode-fonts cfg)
```
- System configuration features: NOTIFY ACL GNUTLS LIBXML2 ZLIB TOOLKIT_SCROLL_BARS THREADS


#### Backtrace :paw_prints:
```
<<BACKTRACE IF RELEVANT>>
```
