### PR TITLE
org: Fix evil C-w in org agenda buffer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2582,6 +2582,8 @@ Other:
 - Added =helm-org= package (thanks to Simon Pintarelli)
 - Fixed evil-normal-state ~ESC~ after exiting =org-present-mode=
   (thanks to duianto)
+- Restored ~C-w~ as =evil-window-map= in the org agenda buffer
+  (thanks to duianto)
 **** Osx
 - Fixed OSX mapping issue (thanks to Joey Liu)
 - Added layer variables to customize modifier behaviors on macOS:

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -557,6 +557,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
       ;; TODO add the rule in auto-evilification to ignore C-h (like we do
       ;; with C-g)
       (kbd "C-h") nil
+      (kbd "C-w") 'evil-window-map
       (kbd "M-j") 'org-agenda-next-item
       (kbd "M-k") 'org-agenda-previous-item
       (kbd "M-h") 'org-agenda-earlier


### PR DESCRIPTION
Restore `C-w` as `evil-window-map` in the org agenda buffer.

Fixes #13197 