### PR TITLE
[evilified-state] Map C-w to evil-window-map

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -166,6 +166,7 @@ Needed to bypass keymaps set as text properties."
 (define-key evil-evilified-state-map (kbd "C-d") 'evil-scroll-down)
 (define-key evil-evilified-state-map (kbd "C-u") 'evil-scroll-up)
 (define-key evil-evilified-state-map (kbd "C-z") 'evil-emacs-state)
+(define-key evil-evilified-state-map (kbd "C-w") 'evil-window-map)
 (setq evil-evilified-state-map-original (copy-keymap evil-evilified-state-map))
 
 ;; old macro


### PR DESCRIPTION
Fix https://github.com/syl20bnr/spacemacs/issues/13197

Motivation: https://github.com/syl20bnr/spacemacs/issues/13197#issuecomment-577051372
> the evil-state in the agenda buffer is evilified where C-w isn't bound, therefore it seems to use the default Emacs command from the global-map, kill-region, but it has no effect since the agenda buffer is in read-only state. It doesn't seem like an appropriate command for the agenda buffer anyway.