### PR TITLE
Fix: exiting org-present presentation always removes inline images

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -692,7 +692,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (defun spacemacs//org-present-end ()
         "Terminate `org-present' mode"
         (org-present-small)
-        (org-remove-inline-images)
+        (if (not org-startup-with-inline-images)
+            (org-remove-inline-images))
         (org-present-show-cursor)
         (org-present-read-write))
       (add-hook 'org-present-mode-hook 'spacemacs//org-present-start)


### PR DESCRIPTION
Spacemacs configures `org-present` to inline images while presenting. That much
makes sense. But it has a hook to turn them off unconditionally when exiting
presentation mode. This causes a problem if you just want images to show in and
out of presentation mode.

# Steps to Reproduce
1. Create an Org file
2. Add a link to a file
3. Set `#+STARTUP: inlineimages`
4. `M-x org-present`
5. Exit presentation mode

# Expected
Because of `#+STARTUP: inlineimages` images are still inlined.

# Actual
The inline images have been removed upon exiting the presentation mode.

# Fix
Check `org-startup-with-inline-images` on exiting presentation mode and only
remove the inline images if it is false.

# Testing
To ensure that this did not introduce a regression of the converse behavior, I
also tested with `#+STARTUP: noinlineimages`, and it still turned off the images
when exiting the presentation.