### PR TITLE
[purescript] Add to spacemacs-indent-sensitive-modes

### DIFF
--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -37,6 +37,7 @@
     :defer t
     :init
     (progn
+      (add-to-list 'spacemacs-indent-sensitive-modes 'purescript-mode)
       (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
       (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
       (spacemacs/declare-prefix-for-mode 'purescript-mode "mg" "goto")


### PR DESCRIPTION
Add `purescript-mode` to `spacemacs-indent-sensitive-modes` .

The syntax of PureScript is similar to that of Haskell, which is also registered as an indent sensitive mode.

Without this configuration, auto-indentation is triggered every time when pasting some chunk of code.