### PR TITLE
[haskell] Fix REPL stuck snippets

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1917,6 +1917,8 @@ Other:
   - ~C-k~ switch to previous history item
   - ~C-l~ clear the REPL
   (thanks to Joscha)
+- Reverted the REPL stuck snippets from checking if the =haskell= package is
+  used, to checking if the =haskell= layer is used (thanks to duianto)
 **** Helm
 - New packages:
   - =helm-ls-git= (thanks to duianto)

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -449,7 +449,7 @@ workaround - just add the following snippet to your =dotspacemacs/user-config=
 function:
 
 #+BEGIN_SRC emacs-lisp
-  (when (configuration-layer/package-used-p 'haskell)
+  (when (configuration-layer/layer-used-p 'haskell)
     (add-hook 'haskell-interactive-mode-hook
               (lambda ()
                 (setq-local evil-move-cursor-back nil))))
@@ -463,7 +463,7 @@ Also, some users might want to start the REPL in insert mode. This is done by
 placing the following snippet in your =dotspacemacs/user-config= function:
 
 #+BEGIN_SRC emacs-lisp
-  (when (configuration-layer/package-used-p 'haskell)
+  (when (configuration-layer/layer-used-p 'haskell)
       (defadvice haskell-interactive-switch (after spacemacs/haskell-interactive-switch-advice activate)
         (when (eq dotspacemacs-editing-style 'vim)
           (call-interactively 'evil-insert))))


### PR DESCRIPTION
The snippets seem to have been accidentally changed in this commit:
https://github.com/syl20bnr/spacemacs/commit/a2de9a63afcdab6fcb0a0c2bdedb35a91556394b#diff-75e0388987cdf040d82762426e40e5a5R434

where other instances of checking for a layer, were changed to check for a
package.

It doesn't work to check if the haskell package is used in the user config
section, because the haskell package hasn't loaded yet.

Reverting it to check if the haskell layer is used works.