### PR TITLE
[Clojure] Sesman and missing eval / format keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1462,55 +1462,41 @@ Other:
   - Removed ~SPC m h g~ for =grimoire= as it is deprecated (thanks to Sam Hedin)
   - ~C-return~ to =cider-repl-newline-and-indent= in REPL evil insert state
     (thanks to Gia Thanh Vuong)
-  - Moved evaluation sent to repl keybindings to ~SPC m e s~ menu
-    ~esb~ 'spacemacs/cider-send-buffer-in-repl-and-focus
-    ~esc~ 'cider-repl-clear-buffer
-    ~esC~ 'cider-find-and-clear-repl-output
-    ~ese~ 'spacemacs/cider-send-last-sexp-to-repl
-    ~esE~ 'spacemacs/cider-send-last-sexp-to-repl-focus
-    ~esf~ 'spacemacs/cider-send-function-to-repl
-    ~esF~ 'spacemacs/cider-send-function-to-repl-focus
-    ~esn~ 'spacemacs/cider-send-ns-form-to-repl
-    ~esN~ 'spacemacs/cider-send-ns-form-to-repl-focus
-    ~eso~ 'cider-repl-switch-to-other
-    ~esr~ 'spacemacs/cider-send-region-to-repl
-    ~esR~ 'spacemacs/cider-send-region-to-repl-focus
-  - ~eU~ 'cider-repl-require-repl-utils
-    (thanks to John Stevenson)
   - changed clear repl buffer of evaluation to match terminal clear key
-    ~el~ 'cider-repl-clear-buffer
-    ~eL~ 'cider-find-and-clear-repl-output
+    ~SPC s s l~ 'cider-repl-clear-buffer
+    ~SPC s s L~ 'cider-find-and-clear-repl-output
     (thanks to John Stevenson)
-  - Add sesman session management keybindings and refactor
-    jack-in and connect keybindings
-    ~'~ 'sesman-start
-    ~sb~ 'sesman-browser
-    ~scj~ 'cider-connect-clj       ;; Java
-    ~scm~ 'cider-connect-clj&cljs  ;; Multiple repl
-    ~scs~ 'cider-connect-cljs      ;; javaScript
-    ~si~ 'sesman-start ;; convention to use ~i~ to start repl in many Spacemacs
-    layers
-    ~sI~ 'sesman-info
-    ~sjj~ 'cider-jack-in-clj       ;; Java
-    ~sjm~ 'cider-jack-in-clj&cljs  ;; Multiple repl - match cider keybinding
-    ~sjs~ 'cider-jack-in-cljs      ;; javaScript
-    ~slb~ 'sesman-link-with-buffer
-    ~sld~ 'sesman-link-with-directory
-    ~slp~ 'sesman-link-with-project
-    ~slu~ 'sesman-unlink
-    ~ssj~ 'cider-connect-sibling-clj   ;; sibling Java
-    ~sss~ 'cider-connect-sibling-cljs  ;; sibling javaScript
-    ~sr~ 'cider-restart
-    ~sR~ 'sesman-restart
-    ~sq~ 'cider-quit
-    ~sQ~ 'sesman-quit
-    ~sx~ 'cider-ns-refresh
+  - Add sesman session management keybindings to ~SPC m c~
+    ~SPC m c b~ 'sesman-browser
+    ~SPC m c i~ 'sesman-info
+    ~SPC m c g~ 'sesman-goto
+    ~SPC m c l b~ 'sesman-link-buffer
+    ~SPC m c l d~ 'sesman-link-directory
+    ~SPC m c l p~ 'sesman-link-project
+    ~SPC m c l u~ 'sesman-unlink
+    ~SPC m s q q~ 'sesman-quit
+    ~SPC m s q r~ 'sesman-restart
+    ~SPC m c s~ 'sesman-start
+    ~SPC m c S j~ 'cider-connect-sibling-clj
+    ~SPC m c S s~ 'cider-connect-sibling-cljs
     (thanks to John Stevenson)
+  - updated repl shortcut to use sesman-start wrapper, selecting any repl type
+    ~SPC m '~ 'sesman-start
   - changed toggle between source and repl to match key for toggle between code
     and test
-    ~sa~ (if (eq m 'cider-repl-mode)
+    ~SPC m s a~ (if (eq m 'cider-repl-mode)
                      'cider-switch-to-last-clojure-buffer
                    'cider-switch-to-repl-buffer)
+    (thanks to John Stevenson)
+  - added formatting command not previously included
+    ~SPC m f d~ 'cider-format-defun
+    ~SPC m f e b~ 'cider-format-buffer
+    ~SPC m f e e~ 'cider-format-last-sexp
+    ~SPC m f e r~ 'cider-format-region
+    ~SPC m f r~ 'cider-format-defun
+    (thanks to John Stevenson)
+  - added evaluation keybinding - evaluate up to point
+    ~SPC m e V~ 'cider-eval-sexp-up-to-point
     (thanks to John Stevenson)
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -8,9 +8,11 @@
 - [[#description][Description]]
   - [[#features][Features:]]
     - [[#recommended-optional-features][Recommended optional features]]
+    - [[#related-layers][Related layers]]
     - [[#other-optional-features][Other optional features]]
+  - [[#references][References]]
 - [[#install][Install]]
-  - [[#add-the-clojure-layer][Add the Clojure Layer]]
+  - [[#add-the-clojure-layer-manually][Add the Clojure Layer manually]]
   - [[#optional-features][Optional features]]
     - [[#enabling-automatic-linting][Enabling Automatic Linting]]
       - [[#enable-clj-kondo-linter][Enable clj-kondo linter]]
@@ -32,10 +34,12 @@
 - [[#key-bindings][Key bindings]]
   - [[#working-with-clojure-files-barfage-slurpage--more][Working with clojure files (barfage, slurpage & more)]]
   - [[#leader][Leader]]
+    - [[#shortcuts][Shortcuts]]
+    - [[#repl-connections][REPL connections]]
     - [[#documentation][Documentation]]
     - [[#evaluation][Evaluation]]
     - [[#goto][Goto]]
-    - [[#repl-sessions][REPL Sessions]]
+    - [[#send-code-to-repl][Send code to REPL]]
     - [[#tests][Tests]]
     - [[#toggles][Toggles]]
     - [[#debugging][Debugging]]
@@ -55,7 +59,8 @@
   - [[#indentation][Indentation]]
 
 * Description
-This layer adds support for [[https://clojure.org/][Clojure]] language using [[https://github.com/clojure-emacs/cider][CIDER]].
+This layer adds support for [[https://clojure.org/][Clojure]] language using [[https://github.com/clojure-emacs/cider][CIDER]], providing Clojure REPL management
+and a full suite of tooling for Clojure development.
 
 ** Features:
 - REPL via [[https://github.com/clojure-emacs/cider][CIDER]]
@@ -69,12 +74,25 @@ This layer adds support for [[https://clojure.org/][Clojure]] language using [[h
 - Structuraly safe editing using optional [[https://github.com/luxbock/evil-cleverparens][evil-cleverparens]]
 - Linting via [[https://github.com/borkdude/clj-kondo][clj-kondo]] ([[https://github.com/candid82/joker][joker]] and [[https://github.com/clojure-emacs/squiggly-clojure][squiggly-clojure]] also available)
 
+*** Related layers
+The following Spacemacs layers should also be added for a complete experience.
+- auto-completion
+- syntax-checking (provides flycheck for linter support)
+
 *** Other optional features
 - Refactoring via [[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]]
 - Debugging with [[https://github.com/clojure-emacs/sayid][sayid]] (beta)
 
+** References
+- [[https://docs.cider.mx/cider/][CIDER documentation]]
+- [[https://practicalli.github.io/spacemacs][Practicalli Spacemacs]]
+
 * Install
-** Add the Clojure Layer
+Spacemacs will prompt to install the Clojure layer automatically when opening a file ending in =.clj=
+=.cljs=, =.cljc= or =.edn=. Replying ~y~ will download all the packages for the Clojure layer.
+Restarting Spacemacs, ~SPC q r~, is recommended to ensure all changes are loaded.
+
+** Add the Clojure Layer manually
 Edit the =~/.spacemacs= file and add the word =clojure= to the existing
 =dotspacemacs-configuration-layers= list.
 
@@ -90,11 +108,11 @@ correctness of your code as you write it.
 
 Fancify symbols replaces fn, #{} and partial with representative characters =λ= =ƒ= and =Ƥ=
 
-clj-refactor provides Clojure specific refactor commands. The refactor commands are being
+[[https://github.com/clojure-emacs/clj-refactor.el][clj-refactor]] provides Clojure specific refactor commands. The refactor commands are being
 migrated into CIDER clojure-mode. clj-refactor is not actively maintained, so use with caution.
 
-sayid is a comprehensive debugger that analyses an entire project. Projects need to compile
-fully or issues may occur. sayid is not as actively maintained as CIDER and may cause issues.
+[[https://github.com/clojure-emacs/sayid][sayid]] is a comprehensive debugger that analyses an entire project.  Projects need to compile
+fully or issues may occur.  sayid is not as actively maintained as CIDER and may cause issues.
 
 *** Enabling Automatic Linting
 [[https://github.com/borkdude/clj-kondo][clj-kondo]], [[https://github.com/candid82/joker][joker]] and [[https://github.com/clojure-emacs/squiggly-clojure][squiggly-clojure]] provide automated linting via =flycheck=.
@@ -228,8 +246,9 @@ Or set this variable when loading the configuration layer:
 #+END_SRC
 
 *** Enabling sayid or clj-refactor
+
 The packages sayid (Clojure debugger) and clj-refactor (automatic refactorings)
-are disabled by default. These packages are less active than the CIDER project
+are disabled by default.  These packages are less active that the CIDER project
 and may cause issues when running CIDER.
 
 To enable them, add a =:variables= option when enabling the =clojure= layer,
@@ -260,15 +279,15 @@ If you are experiencing issues when running a REPL, try disabling these
 packages first and restart Spacemacs to see if the error persists.
 
 * Usage
-Read the key bindings section to see all the functionality available, or simply
+Read the keybindings section to see all the functionality available, or simply
 use the ~,~ or ~SPC m~ to open the which-key menu for the Clojure layer.
 
 ** Starting a REPL from Spacemacs
-Open a Clojure file (.clj, .cljs, .cljc, .edn) and start a Clojure REPL,
+Open a Clojure file (=.clj=, =.cljs=, =.cljc=, =.edn=) and start a Clojure REPL,
 choosing the REPL session type (Clojure, ClojureScript or both Clojure & ClojureScript).
 
 ~, '~ and ~, s i~ calls the ~sesman-start~ command, a wrapper for all the
-~jack-in~ and ~connect~ commands. A prompt appears allowing you to choose the
+~jack-in~ and ~connect~ commands.  A prompt appears allowing you to choose the
 type of REPL session required.
 
 ~, s j~ opens the cider-jack-in menu, providing commands to start specific REPL sessions,
@@ -304,10 +323,9 @@ to the type of REPL you wish to start.
 ~, s c~ opens the cider-connect menu, providing key bindings for connecting too the
 different REPL session types.
 
-CIDER communicates with your Clojure process through nREPL, and for CIDER to
-function correctly extra nREPL middleware needs to be present
-(cider/cider-nrepl). The same is true for clj-refactor (refactor-nrepl), and for
-sayid (com.billpiel/sayid).
+CIDER communicates with your Clojure process through nREPL and for CIDER to
+function correctly extra nREPL middleware is needed (cider/cider-nrepl).
+The same is true for clj-refactor (refactor-nrepl), and for sayid (com.billpiel/sayid).
 
 *** Quick Start with boot
 - Install =boot= 2.8.2 or newer (see [[https://github.com/boot-clj/boot#user-content-install]])
@@ -368,9 +386,12 @@ More info regarding installation of nREPL middleware can be found here:
 Sesman is used for [[https://docs.cider.mx/cider/usage/managing_connections.html][managing REPL connections]] when working simultaneously on
 multiple projects or have multiple connections opened for the same project
 
-Files, directories and projects can be linked to an existing session.
+~SPC m c i~ provides information about the current REPL.
+~SPC m c b~ shows information about all REPLs currently active.
 
-See the REPL connections key bindings section for all the commands.
+~SPC m c l~ menu links files, directories and projects to an existing session.
+
+See REPL connections in the key bindings section for all the commands.
 
 ** Cheatsheet
 This layers installs the [[https://github.com/clojure-emacs/clojure-cheatsheet][clojure-cheatsheet]] package which embeds this useful
@@ -381,26 +402,25 @@ separated) to narrow down the list. For example, try typing in sort map to see
 some functions that deal with sorting maps.
 
 ** Structuraly safe editing
-This layer adds support for =evil-cleverparens= which allows to safely edit
+The Clojure layer adds support for =evil-cleverparens= which allows to safely edit
 lisp code by keeping the s-expressions balanced.
 
-By default this mode is not activated. You can turn it on locally on the active
-buffer with ~SPC m T s~ (=s= for safe).
+ ~SPC m T s~ will toggle safe structured editing, off by default.
 
-To turn it on automatically for all =clojure= buffers call the following
-function in your =dotspacemacs/user-config= function:
+Enable safe structural editing for all =clojure= buffers using the following
+in the =dotspacemacs/user-config= function of your .spacemacs file
 
 #+BEGIN_SRC emacs-lisp
   (spacemacs/toggle-evil-safe-lisp-structural-editing-on-register-hook-clojure-mode)
 #+END_SRC
 
-or to enable it for all supported modes:
+Or enable safe structural editing for all supported modes:
 
 #+BEGIN_SRC emacs-lisp
   (spacemacs/toggle-evil-safe-lisp-structural-editing-on-register-hooks)
 #+END_SRC
 
-When enabled the symbol =🆂= should be displayed in the mode-line.
+When enabled the symbol =🆂= will displayed in the mode-line.
 
 * Key bindings
 ** Working with clojure files (barfage, slurpage & more)
@@ -412,6 +432,32 @@ As this state works the same for all files, the documentation is in global
 [[https://github.com/syl20bnr/spacemacs/blob/master/doc/DOCUMENTATION.org#lisp-key-bindings][DOCUMENTATION.org]]. In general, use ~SPC k~ to interact with the lisp-state.
 
 ** Leader
+*** Shortcuts
+Shortcut keybindings for regularly used commands.
+
+| Key binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC m '~   | start a REPL - prompted for REPL type (sesman-start)     |
+| ~SPC m ,~   | command menu in REPL buffer (cider-repl-handle-shortcut) |
+
+*** REPL connections
+Managing CIDER REPL connections and sessions
+
+| Key binding   | Description                                                      |
+|---------------+------------------------------------------------------------------|
+| ~SPC m c b~   | browse all REPL session (sesman-browser)                         |
+| ~SPC m c i~   | current REPL information, ~SPC u~ for all sessions (sesman-info) |
+| ~SPC m c g~   | go to most relevant REPL session (sesman-goto)                   |
+| ~SPC m c l b~ | link buffer to REPL session (seman-link-with-buffer)             |
+| ~SPC m c l d~ | link directory to REPL session (seman-link-with-directory)       |
+| ~SPC m c l p~ | link project to REPL session (seman-link-with-project)           |
+| ~SPC m c l u~ | unlink from REPL session (seman-unlink)                          |
+| ~SPC m c S j~ | connect as sibling to existing Clojure REPL                      |
+| ~SPC m c S s~ | connect as sibling to existing ClojureScript REPL                |
+| ~SPC m c s~   | start a REPL - prompted for REPL type (sesman-start)             |
+| ~SPC m c q q~ | quit REPL session (sesman-quit)                                  |
+| ~SPC m c q r~ | restart REPL (sesman-restart)                                    |
+
 *** Documentation
 
 | Key binding | Description                 |
@@ -425,34 +471,25 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m h N~ | cider browse all namespaces |
 
 *** Evaluation
+Evaluate Clojure code in the source code buffer
 
-| Key binding   | Description                                                        |
-|---------------+--------------------------------------------------------------------|
-| ~SPC m e ;~   | eval sexp and show result as comment                               |
-| ~SPC m e B~   | send and eval buffer and switch to REPL in =insert state=          |
-| ~SPC m e b~   | eval buffer                                                        |
-| ~SPC m e e~   | eval last sexp                                                     |
-| ~SPC m e f~   | eval function at point                                             |
-| ~SPC m e i~   | interrupt the current evaluation                                   |
-| ~SPC m e l~   | clear REPL buffer (cider-repl-clear-buffer)                        |
-| ~SPC m e L~   | clear REPL buffer (cider-find-and-clear-repl-output)               |
-| ~SPC m e m~   | cider macroexpand 1                                                |
-| ~SPC m e M~   | cider macroexpand all                                              |
-| ~SPC m e p~   | print last sexp (clojure interaction mode only)                    |
-| ~SPC m e P~   | eval last sexp and pretty print result in separate buffer          |
-| ~SPC m e r~   | eval region                                                        |
-| ~SPC m e s e~ | send and eval last sexp in REPL                                    |
-| ~SPC m e s E~ | send and eval last sexp and switch to REPL in =insert state=       |
-| ~SPC m e s f~ | send and eval function in REPL                                     |
-| ~SPC m e s F~ | send and eval function and switch to REPL in =insert state=        |
-| ~SPC m e s n~ | send and eval ns form in REPL                                      |
-| ~SPC m e s N~ | send and eval ns form and switch to REPL in =insert state=         |
-| ~SPC m e s r~ | send and eval region in REPL                                       |
-| ~SPC m e s R~ | send and eval region and switch to REPL in =insert state=          |
-| ~SPC m e u~   | Undefine a symbol from the current namespace                       |
-| ~SPC m e U~   | require Clojure utils into current namespace - i.e. =doc= =source= |
-| ~SPC m e v~   | eval sexp around point                                             |
-| ~SPC m e w~   | eval last sexp and replace with result                             |
+| Key binding | Description                                                        |
+|-------------+--------------------------------------------------------------------|
+| ~SPC m e ;~ | eval sexp and show result as comment                               |
+| ~SPC m e b~ | eval buffer                                                        |
+| ~SPC m e e~ | eval last sexp                                                     |
+| ~SPC m e f~ | eval function at point                                             |
+| ~SPC m e i~ | interrupt the current evaluation                                   |
+| ~SPC m e m~ | cider macroexpand 1                                                |
+| ~SPC m e M~ | cider macroexpand all                                              |
+| ~SPC m e n~ | refresh namespace (cider-ns-refresh)                               |
+| ~SPC m e N~ | reload namespace (cider-ns-reload), ~SPC u~ (cider-ns-reload-all)  |
+| ~SPC m e p~ | eval top-level sexp, pretty print result in separate buffer        |
+| ~SPC m e P~ | eval last sexp, pretty print result in separate buffer             |
+| ~SPC m e r~ | eval region                                                        |
+| ~SPC m e u~ | Undefine a symbol from the current namespace                       |
+| ~SPC m e v~ | eval sexp around point                                             |
+| ~SPC m e w~ | eval last sexp and replace with result                             |
 
 *** Goto
 
@@ -467,34 +504,39 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m g s~ | browse spec                                  |
 | ~SPC m g S~ | browse all specs                             |
 
-*** REPL Sessions
+*** Send code to REPL
+Use these keybindings when working directly with a REPL buffer.
+Use the Evaluation keybindings when evaluating in source code buffer.
 
-| Key binding   | Description                                                                     |
-|---------------+---------------------------------------------------------------------------------|
-| ~SPC m ,~     | command menu in REPL buffer (cider-repl-handle-shortcut)                        |
-| ~SPC m '~     | start a REPL connection (helm selection of REPL type)                           |
-| ~SPC m s a~   | switch between REPL and last Clojure source code buffer (cider-repl)            |
-| ~SPC m s b~   | browse REPL session (sesman-browser)                                            |
-| ~SPC m s c j~ | connect to a running Clojure REPL (cider-connect-clj)                           |
-| ~SPC m s c m~ | connect to a running Clojure & ClojureScript REPL (cider-connect-clj&cljs)      |
-| ~SPC m s c s~ | connect to a running ClojureScript REPL (cider-connect-cljs)                    |
-| ~SPC m s i~   | start a REPL connection (helm selection of REPL type)                           |
-| ~SPC m s I~   | current REPL session information, prefix ~SPC u~ for all sessions (sesman-info) |
-| ~SPC m s j j~ | start Clojure REPL (=cider-jack-in-clj=)                                        |
-| ~SPC m s j m~ | start Clojure REPL (=cider-jack-in-clj&cljs=)                                   |
-| ~SPC m s j s~ | start ClojureScript REPL (=cider-jack-in-cljs=)                                 |
-| ~SPC m s l b~ | link buffer to REPL session (seman-link-with-buffer)                            |
-| ~SPC m s l d~ | link directory to REPL session (seman-link-with-directory)                      |
-| ~SPC m s l p~ | link project to REPL session (seman-link-with-project)                          |
-| ~SPC m s l u~ | unlink from REPL session (seman-unlink)                                         |
-| ~SPC m s o~   | switch to other repl instance (cider-repl-switch-to-other)                      |
-| ~SPC m s s j~ | connect as sibling to existing Clojure REPL                                     |
-| ~SPC m s s s~ | connect as sibling to existing ClojureScript REPL                               |
-| ~SPC m s r~   | restart REPL (cider-restart)                                                    |
-| ~SPC m s R~   | restart REPL Session (sesman-restart)                                           |
-| ~SPC m s q~   | quit REPL (cider-quit)                                                          |
-| ~SPC m s Q~   | quit REPL session (sesman-quit)                                                 |
-| ~SPC m s x~   | refresh REPL (cider-ns-refresh)                                                 |
+| Key binding   | Description                                                                |
+|---------------+----------------------------------------------------------------------------|
+| ~SPC m s a~   | switch between REPL and last Clojure source code buffer (cider-repl)       |
+| ~SPC m s b~   | send and eval buffer in REPL                                               |
+| ~SPC m s B~   | send and eval buffer and switch to REPL in =insert state=                  |
+| ~SPC m s c j~ | connect to a running Clojure REPL (cider-connect-clj)                      |
+| ~SPC m s c m~ | connect to a running Clojure & ClojureScript REPL (cider-connect-clj&cljs) |
+| ~SPC m s c s~ | connect to a running ClojureScript REPL (cider-connect-cljs)               |
+| ~SPC m s e~   | send and eval last sexp in REPL                                            |
+| ~SPC m s E~   | send and eval last sexp and switch to REPL in =insert state=               |
+| ~SPC m s f~   | send and eval function in REPL                                             |
+| ~SPC m s F~   | send and eval function and switch to REPL in =insert state=                |
+| ~SPC m s i~   | start a REPL - prompt for REPL type (sesman-start)                         |
+| ~SPC m s j j~ | start Clojure REPL (=cider-jack-in-clj=)                                   |
+| ~SPC m s j m~ | start Clojure REPL (=cider-jack-in-clj&cljs=)                              |
+| ~SPC m s j s~ | start ClojureScript REPL (=cider-jack-in-cljs=)                            |
+| ~SPC m l~     | clear REPL buffer (cider-repl-clear-buffer)                                |
+| ~SPC m L~     | clear and switch to REPL buffer (cider-find-and-clear-repl-output)         |
+| ~SPC m s n~   | send and eval ns form in REPL                                              |
+| ~SPC m s N~   | send and eval ns form and switch to REPL in =insert state=                 |
+| ~SPC m s o~   | switch to other repl instance (cider-repl-switch-to-other)                 |
+| ~SPC m s q n~ | reload namespace in REPL (cider-ns-reload)                                 |
+| ~SPC m s q N~ | reload all namespace in REPL (cider-ns-reload-all)                         |
+| ~SPC m s q q~ | quit REPL (cider-quit)                                                     |
+| ~SPC m s q r~ | restart REPL (cider-restart)                                               |
+| ~SPC m s r~   | send and eval region in REPL                                               |
+| ~SPC m s R~   | send and eval region and switch to REPL in =insert state=                  |
+| ~SPC m e u~   | require Clojure utils into current namespace - i.e. =doc= =source=         |
+| ~SPC m s p~   | print last sexp (clojure interaction mode only)                            |
 
 *** Tests
 
@@ -515,6 +557,7 @@ As this state works the same for all files, the documentation is in global
 | ~SPC m T t~ | toggle auto test mode       |
 
 *** Debugging
+TODO: separate clojure-mode and sayid keybindings
 
 | Key binding   | Description                                        |
 |---------------+----------------------------------------------------|
@@ -607,8 +650,11 @@ The following refactorings require cljr-refactor to be enabled and generally dep
 | Key binding              | Description             |
 |--------------------------+-------------------------|
 | ~SPC m f b~ or ~SPC m =~ | reformat current buffer |
+| ~SPC m f d~              | reformat current sexp   |
+| ~SPC m f e b~            | reformat edn buffer     |
+| ~SPC m f e e~            | reformat edn last sexp  |
+| ~SPC m f e r~            | reformat edn region     |
 | ~SPC m f l~              | realign current form    |
-|                          |                         |
 
 *** Profiling
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -63,19 +63,21 @@
       ;; TODO: having this work for cider-macroexpansion-mode would be nice,
       ;;       but the problem is that it uses clojure-mode as its major-mode
       (let ((cider--key-binding-prefixes
-             '(("md" . "debug")
-               ("msc" . "connect repl")
+             '(("mc" . "repl connections")
+               ("mcl" . "link session")
+               ("mcS" . "sibling sessions")
+               ("mcq" . "sibling sessions")
+               ("md" . "debug")
                ("me" . "evaluation")
-               ("mes" . "send-to-repl-buffer")
                ("mf" . "format")
+               ("mfe" . "edn")
                ("mg" . "goto")
                ("mh" . "documentation")
                ("mp" . "profile")
-               ("ms" . "repl")
+               ("ms" . "send to repl")
+               ("msc" . "connect repl")
+               ("msq" . "quit/restart repl")
                ("msj" . "jack-in")
-               ("ms" . "repl sessions")
-               ("msl" . "link session")
-               ("mss" . "sibling sessions")
                ("mt" . "test")
                ("mT" . "toggle")
                )))
@@ -85,6 +87,26 @@
                 cider--key-binding-prefixes)
 
           (spacemacs/set-leader-keys-for-major-mode m
+
+            ;; shortcuts
+            "'"  'sesman-start
+            "="  'cider-format-buffer
+
+            ;; cider connections / sesman
+            "cb" 'sesman-browser
+            "ci" 'sesman-info
+            "cg" 'sesman-goto
+            "clb" 'sesman-link-with-buffer
+            "cld" 'sesman-link-with-directory
+            "clu" 'sesman-unlink
+            "cqq" 'sesman-quit
+            "cqr" 'sesman-restart
+            "clp" 'sesman-link-with-project
+            "cSj" 'cider-connect-sibling-clj
+            "cSs" 'cider-connect-sibling-cljs
+            "cs" 'sesman-start
+
+            ;; help / documentation
             "ha" 'cider-apropos
             "hc" 'cider-cheatsheet
             "hd" 'cider-clojuredocs
@@ -93,34 +115,34 @@
             "hn" 'cider-browse-ns
             "hN" 'cider-browse-ns-all
 
+            ;; evaluate in source code buffer
             "e;" 'cider-eval-defun-to-comment
-            "eB" 'spacemacs/cider-send-buffer-in-repl-and-focus
             "eb" 'cider-eval-buffer
             "ee" 'cider-eval-last-sexp
             "ef" 'cider-eval-defun-at-point
             "ei" 'cider-interrupt
-            "el" 'cider-repl-clear-buffer
-            "eL" 'cider-find-and-clear-repl-output
             "em" 'cider-macroexpand-1
             "eM" 'cider-macroexpand-all
+            "en" 'cider-ns-refresh
+            "eN" 'cider-ns-reload  ;; SPC u for cider-ns-reload-all
+            "ep" 'cider-pprint-eval-defun-at-point
             "eP" 'cider-pprint-eval-last-sexp
             "er" 'cider-eval-region
-            "ese" 'spacemacs/cider-send-last-sexp-to-repl
-            "esE" 'spacemacs/cider-send-last-sexp-to-repl-focus
-            "esf" 'spacemacs/cider-send-function-to-repl
-            "esF" 'spacemacs/cider-send-function-to-repl-focus
-            "esn" 'spacemacs/cider-send-ns-form-to-repl
-            "esN" 'spacemacs/cider-send-ns-form-to-repl-focus
-            "esr" 'spacemacs/cider-send-region-to-repl
-            "esR" 'spacemacs/cider-send-region-to-repl-focus
             "eu" 'cider-undef
-            "eU" 'cider-repl-require-repl-utils
             "ev" 'cider-eval-sexp-at-point
+            "eV" 'cider-eval-sexp-up-to-point
             "ew" 'cider-eval-last-sexp-and-replace
 
-            "="  'cider-format-buffer
+            ;; format code style
             "fb" 'cider-format-buffer
+            "fd" 'cider-format-defun
+            "feb" 'cider-format-edn-buffer
+            "fee" 'cider-format-edn-last-sexp
+            "fer" 'cider-format-edn-region
+            "fl" 'clojure-align
+            "fr" 'cider-format-region
 
+            ;; goto
             "gb" 'cider-pop-back
             "gc" 'cider-classpath
             "gg" 'spacemacs/clj-find-var
@@ -130,37 +152,43 @@
             "gs" 'cider-browse-spec
             "gS" 'cider-browse-spec-all
 
-            "'"  'sesman-start
+            ;; send code - spacemacs convention
             "sa" (if (eq m 'cider-repl-mode)
                      'cider-switch-to-last-clojure-buffer
                    'cider-switch-to-repl-buffer)
-            "sb" 'sesman-browser
+            "sb" 'cider-load-buffer
+            "sB" 'spacemacs/cider-send-buffer-in-repl-and-focus
             "scj" 'cider-connect-clj
             "scm" 'cider-connect-clj&cljs
             "scs" 'cider-connect-cljs
+            "se" 'spacemacs/cider-send-last-sexp-to-repl
+            "sE" 'spacemacs/cider-send-last-sexp-to-repl-focus
+            "sf" 'spacemacs/cider-send-function-to-repl
+            "sF" 'spacemacs/cider-send-function-to-repl-focus
             "si" 'sesman-start
-            "sI" 'sesman-info
             "sjj" 'cider-jack-in-clj
             "sjm" 'cider-jack-in-clj&cljs
             "sjs" 'cider-jack-in-cljs
-            "slb" 'sesman-link-with-buffer
-            "sld" 'sesman-link-with-directory
-            "slp" 'sesman-link-with-project
-            "slu" 'sesman-unlink
+            "sl" 'cider-repl-clear-buffer
+            "sL" 'cider-find-and-clear-repl-output
+            "sn" 'spacemacs/cider-send-ns-form-to-repl
+            "sN" 'spacemacs/cider-send-ns-form-to-repl-focus
             "so" 'cider-repl-switch-to-other
-            "ssj" 'cider-connect-sibling-clj
-            "sss" 'cider-connect-sibling-cljs
-            "sr" 'cider-restart
-            "sR" 'sesman-restart
-            "sq" 'cider-quit
-            "sQ" 'sesman-quit
-            "sx" 'cider-ns-refresh
+            "sqq" 'cider-quit
+            "sqr" 'cider-restart
+            "sqn" 'cider-ns-reload
+            "sqN" 'cider-ns-reload-all
+            "sr" 'spacemacs/cider-send-region-to-repl
+            "sR" 'spacemacs/cider-send-region-to-repl-focus
+            "su" 'cider-repl-require-repl-utils
 
+            ;; toggle options
             "Te" 'cider-enlighten-mode
             "Tf" 'spacemacs/cider-toggle-repl-font-locking
             "Tp" 'spacemacs/cider-toggle-repl-pretty-printing
             "Tt" 'cider-auto-test-mode
 
+            ;; cider-tests
             "ta" 'spacemacs/cider-test-run-all-tests
             "tb" 'cider-test-show-report
             "tl" 'spacemacs/cider-test-run-loaded-tests
@@ -169,6 +197,7 @@
             "tr" 'spacemacs/cider-test-rerun-failed-tests
             "tt" 'spacemacs/cider-test-run-focused-test
 
+            ;; cider-debug
             "db" 'cider-debug-defun-at-point
             "de" 'spacemacs/cider-display-error-buffer
             "dv" 'cider-inspect


### PR DESCRIPTION
Added keybindings for the Sesman REPL session management commands to the Clojure
layer.
https://docs.cider.mx/cider/0.23/usage/managing_connections.html

Sesman has been a part of CIDER for many versions now and provides session
management for nREPL connections (in fact any connections).

Sesman keybinds are placed in the `SPC m c` menu, providing a cleaner separation
between sending code to the repl and session management.

See issue #12593 and PR #13140 which covers the background for the design of
these additional keybindings.

Formatting the region and defun keybinds have been added, along with formatting
for edn files.

Evaluation up to point keybinding has also been added.

Documentation in the README has been updated to complete the description of the
existing Clojure layer, as well as including details specific to the new
keybindings.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3