### PR TITLE
Add layer music/pianobar

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -361,6 +361,8 @@ sane way, here is the complete list of changed key bindings
 - ietf (thanks to Christian Hopps and Robby O'Connor)
 - multiple-cursors (thanks to Codruț Constantin Gușoi and Thomas de Beauchêne)
 - parinfer (thanks to Tianshu Shi)
+**** Music
+- pianobar (thanks to Leo Littlebook)
 **** Readers
 - epub (thanks to Jeremy Dormitzer and André Peric Tavares)
 **** Spacemacs

--- a/layers/+music/pianobar/README.org
+++ b/layers/+music/pianobar/README.org
@@ -1,0 +1,61 @@
+#+TITLE: Pianobar layer
+
+#+TAGS: layer|music
+
+* Table of Contents                     :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#configure][Configure]]
+- [[#run][Run]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+This layer integrates an online music service into Spacemacs.
+
+** Features:
+- Support for listening to music from within Emacs via [[https://6xq.net/pianobar/][Pianobar]].
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =pianobar= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+For example:
+#+begin_src emacs-elisp
+dotspacemacs-configuration-layers
+   '((pianobar :variables pianobar-config t))
+#+end_src
+
+* Configure
+Below is an example configuration from MacOS:
+
+#+begin_src bash
+$ cat ~/.config/pianobar/config
+user = foobar@gmail.com
+password = 295TkBbHZiKwnDnQYhJW 
+autostart_station = 30385222902831057
+#+end_src
+
+Relevant links:
+- [[https://github.com/agrif/pianobar.el][pianobar.el]]
+- [[https://github.com/PromyLOPh/pianobar/blob/master/contrib/config-example][Example config file]]
+- [[https://wiki.archlinux.org/index.php/Pianobar][Arch Linux wiki]]
+- [[https://jlk.fjfi.cvut.cz/arch/manpages/man/pianobar.1][Arch man page]]
+
+* Run
+
+~M-x pianobar~
+
+With the above configuration, pianobar will login and start playing the autostart station.
+
+* Key bindings
+
+| Key binding   | Description            |
+|---------------+------------------------|
+| ~SPC a m p p~ | Play or pause Pianobar |
+| ~SPC a m p n~ | Go to the next track   |
+| ~SPC a m p +~ | Love current song      |
+| ~SPC a m p -~ | Ban current song       |
+| ~SPC a m p t~ | Tired of current song  |
+| ~SPC a m p s~ | Switch station         |

--- a/layers/+music/pianobar/config.el
+++ b/layers/+music/pianobar/config.el
@@ -1,0 +1,23 @@
+;;; config.el --- Pianobar Layer config File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Leo Littlebook  <texas.cyberthal@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar pianobar-config 'nil
+  "Set to t if your pianobar config contains your username and
+  password.")
+
+(defvar pianobar-command "pianobar"
+  "If pianobar is not in your path, set this variable to
+  pianobar's path.")
+
+(defvar pianobar-station 'nil
+  "Automatically connect to this station on login. Value must be
+  a string containing the number used to select the station you
+  want through Pianobar. The number is many digits long.")

--- a/layers/+music/pianobar/packages.el
+++ b/layers/+music/pianobar/packages.el
@@ -1,0 +1,30 @@
+;;; packages.el --- pianobar Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;;
+;; Author: Leo Littlebook  <texas.cyberthal@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(setq pianobar-packages
+  '(
+    pianobar
+    ))
+
+(defun pianobar/init-pianobar ()
+  (use-package pianobar
+    :defer t
+    :init (progn
+            (spacemacs/declare-prefix "am" "music")
+            (spacemacs/declare-prefix "amp" "Pianobar")
+            (spacemacs/set-leader-keys
+              "ampp" 'pianobar-play-or-pause
+              "ampn" 'pianobar-next-song
+              "amp+" 'pianobar-love-current-song
+              "amp-" 'pianobar-ban-current-song
+              "ampt" 'pianobar-shelve-current-song
+              "amps" 'pianobar-change-station
+              ))))


### PR DESCRIPTION
Configuration instructions are more detailed than usual, because it requires unusual effort to piece together otherwise.

This should save users a lot of keystrokes and/or configuration fiddling.