### PR TITLE
treemacs: fix default sorting

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -43,7 +43,7 @@
             treemacs-silent-refresh nil
             treemacs-indentation 2
             treemacs-change-root-without-asking nil
-            treemacs-sorting 'alphabetic-desc
+            treemacs-sorting 'alphabetic-asc
             treemacs-show-hidden-files t
             treemacs-never-persist nil
             treemacs-goto-tag-strategy 'refetch-index)

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -36,9 +36,7 @@
     :defer t
     :init
     (progn
-      (setq treemacs-follow-after-init t
-            treemacs-change-root-without-asking nil
-            treemacs-never-persist nil)
+      (setq treemacs-follow-after-init t)
       (add-hook 'treemacs-mode-hook
                 #'spacemacs/treemacs-setup-width-lock)
       (spacemacs/set-leader-keys

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -37,16 +37,8 @@
     :init
     (progn
       (setq treemacs-follow-after-init t
-            treemacs-width 35
-            treemacs-position 'left
-            treemacs-is-never-other-window nil
-            treemacs-silent-refresh nil
-            treemacs-indentation 2
             treemacs-change-root-without-asking nil
-            treemacs-sorting 'alphabetic-asc
-            treemacs-show-hidden-files t
-            treemacs-never-persist nil
-            treemacs-goto-tag-strategy 'refetch-index)
+            treemacs-never-persist nil)
       (add-hook 'treemacs-mode-hook
                 #'spacemacs/treemacs-setup-width-lock)
       (spacemacs/set-leader-keys


### PR DESCRIPTION
I would expect the default sort order in treemacs to be alphabetically
ascending, and indeed until recently it appeared to be so (it has recently 
started being the opposite for me!). But the
setting in spacemacs is `alphabetic-desc`, and has been ever since the
layer was introduced. How did this work?

The answer is https://github.com/Alexander-Miller/treemacs/pull/577.
Until recently the alphabetical ascending/descending orders were swapped
accidentally. So we need to now (more logically) set the sort order to
`alphabetic-asc`.

After that, we are setting a number of variables to their default value (which stops us from following upstream, which would have saved us from this bug), or setting non-existent variables (which does nothing), so I removed all of those.