### PR TITLE
Replace org-toggle-latex-fragment with org-latex-preview

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2584,10 +2584,9 @@ Other:
 - Added support for CUSTOM_ID in latex exports (thanks to Compro-Prasad)
 - Added =ox-jira= as org export backend (thanks to Sebastian Nagel)
 - Added =helm-org= package (thanks to Simon Pintarelli)
-- Fixed evil-normal-state ~ESC~ after exiting =org-present-mode=
-  (thanks to duianto)
-- Fixed =org-present=: exiting presentation always removes inline images
-  (thanks to Keith Pinson)
+- Fixed evil-normal-state ~ESC~ after exiting =org-present-mode= (thanks to duianto)
+- Fixed =org-present=: exiting presentation always removes inline images (thanks to Keith Pinson)
+- Replace =org-toggle-latex-fragment= with =org-latex-preview= (thanks to Tianshu Wang)
 **** Osx
 - Fixed OSX mapping issue (thanks to Joey Liu)
 - Added layer variables to customize modifier behaviors on macOS:

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -228,7 +228,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "Tt" 'org-show-todo-tree
         "TT" 'org-todo
         "TV" 'space-doc-mode
-        "Tx" 'org-toggle-latex-fragment
+        "Tx" 'org-latex-preview
 
         ;; More cycling options (timestamps, headlines, items, properties)
         "L" 'org-shiftright


### PR DESCRIPTION
`org-toggle-latex-fragment` is an obsolete command (as of Org 9.3); use `org-latex-preview` instead.