### PR TITLE
Disable warning unless use the nlinum layer

### DIFF
--- a/layers/+misc/nlinum/packages.el
+++ b/layers/+misc/nlinum/packages.el
@@ -52,5 +52,6 @@
             (spacemacs/set-leader-keys "tr" 'spacemacs/nlinum-relative-toggle)))))
 
   (defconst nlinum-packages nil)
-  (spacemacs-buffer/warning (concat "nlinum layer is deprecated for Emacs 26.1 and above."
-                      " You can safely remove it from your dotfile.")))
+  (when (configuration-layer/layer-usedp 'nlium)
+    (spacemacs-buffer/warning (concat "nlinum layer is deprecated for Emacs 26.1 and above."
+                                      " You can safely remove it from your dotfile."))))


### PR DESCRIPTION
Disable warning after run SPC-h-SPC(spacemacs-help) unless use the nlinum layer