### PR TITLE
Fix several dumper issues

### DIFF
--- a/core/core-dumper.el
+++ b/core/core-dumper.el
@@ -117,7 +117,7 @@ the end of the loading of the dump file."
          :command
          (list dotspacemacs-emacs-pdumper-executable-file
                "--batch"
-               "-l" "~/.emacs.d/dump-init.el"
+               "-l" (concat spacemacs-start-directory "dump-init.el")
                "-eval" (concat "(dump-emacs-portable \""
                                (concat spacemacs-dump-directory
                                        dotspacemacs-emacs-dumper-dump-file)

--- a/core/core-dumper.el
+++ b/core/core-dumper.el
@@ -1,4 +1,4 @@
-;;; core-dumper.el --- Spacemacs Core File
+;;; core-dumper.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
 ;;
@@ -110,18 +110,33 @@ the end of the loading of the dump file."
     (with-current-buffer spacemacs-dump-buffer-name
       (erase-buffer)))
   (make-directory spacemacs-dump-directory t)
-  (setq spacemacs-dump-process
-        (make-process
-         :name "spacemacs-dumper"
-         :buffer spacemacs-dump-buffer-name
-         :command
-         (list dotspacemacs-emacs-pdumper-executable-file
-               "--batch"
-               "-l" (concat spacemacs-start-directory "dump-init.el")
-               "-eval" (concat "(dump-emacs-portable \""
-                               (concat spacemacs-dump-directory
-                                       dotspacemacs-emacs-dumper-dump-file)
-                               "\")")))))
+  (let* ((dump-file (concat spacemacs-dump-directory dotspacemacs-emacs-dumper-dump-file))
+         (dump-file-temp (concat dump-file ".new")))
+    (setq spacemacs-dump-process
+          (make-process
+           :name "spacemacs-dumper"
+           :buffer spacemacs-dump-buffer-name
+           :sentinel
+           (lambda (proc event)
+             (cond
+              ((process-live-p proc) nil)
+              ((and (eq (process-status proc) 'exit)
+                    (= (process-exit-status proc) 0))
+               (with-current-buffer spacemacs-dump-buffer-name
+                 (rename-file dump-file-temp dump-file t)
+                 (goto-char (point-max))
+                 (insert (format "Done!\n" dump-file-temp dump-file))))
+              (t
+               (with-current-buffer spacemacs-dump-buffer-name
+                 (delete-file dump-file-temp nil)
+                 (goto-char (point-max))
+                 (insert "Failed\n")))))
+           :command
+           (list dotspacemacs-emacs-pdumper-executable-file
+                 "--batch"
+                 "-l" (concat spacemacs-start-directory "dump-init.el")
+                 "-eval" (concat "(dump-emacs-portable \"" dump-file-temp "\")"))))
+    (pop-to-buffer spacemacs-dump-buffer-name)))
 
 (defun spacemacs/dump-eval-delayed-functions ()
   "Evaluate delayed functions."

--- a/dump-init.el
+++ b/dump-init.el
@@ -1,6 +1,7 @@
 (setq spacemacs-dump-mode 'dumping)
 ;; load init.el
-(load (concat (file-name-directory load-file-name) "init.el"))
+(setq spacemacs-start-directory (file-name-directory load-file-name))
+(load (concat spacemacs-start-directory "init.el"))
 ;; prepare the dump
 (spacemacs/dump-save-load-path)
 ;; disable undo-tree to prevent from segfaulting when loading the dump


### PR DESCRIPTION
* Make the dumper work even when the spacemacs home isn't in ~/.emacs
* Dump to a temporary file and rename it instead of overwriting the dump file. This way:
  * We're less likely to end up with a bad dump.
  * Nothing will look at the dump till we're finished.
* Cleanup the dumper process variable when we're done so we can dump again.