### PR TITLE
[lsp] set jump handler per lsp-managed buffer

### DIFF
--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -9,11 +9,9 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs//setup-lsp-jump-handler (&rest modes)
+(defun spacemacs//setup-lsp-jump-handler ()
   "Set jump handler for LSP with the given MODE."
-  (dolist (m modes)
-    (add-to-list (intern (format "spacemacs-jump-handlers-%S" m))
-                 '(lsp-ui-peek-find-definitions :async t))))
+    (add-to-list 'spacemacs-jump-handlers '(lsp-ui-peek-find-definitions :async t)))
 
 
 ;; Key bindings

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -28,7 +28,7 @@
       (spacemacs/lsp-bind-keys)
       (add-hook 'lsp-after-open-hook (lambda ()
                                        "Setup xref jump handler and declare keybinding prefixes"
-                                       (spacemacs//setup-lsp-jump-handler major-mode)
+                                       (spacemacs//setup-lsp-jump-handler)
                                        (spacemacs//lsp-declare-prefixes-for-mode major-mode))))))
 
 (defun lsp/init-lsp-ui ()


### PR DESCRIPTION
Previously, this would try to add the lsp jump handler to the mode's jump handler list every time lsp started managing a buffer of that mode. Now, we only use the lsp jump handler for buffers managed by lsp.