### PR TITLE
[base] Add cl- prefix to letf and letf*

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1266,6 +1266,7 @@ Other:
   - Fixed =evilified-state=, mapped ~C-w~ to =evil-window-map=
     (thanks to Muneeb Shaikh)
   - Fixed ~SPC h f~ =helm-spacemacs-help-faq= (thanks to duianto)
+  - Fixed =cl= package deprecated =letf= (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes
@@ -2154,6 +2155,7 @@ Other:
   (thanks to Carlos Ibáñez and Juuso Valkeejärvi)
 - Fix visual selection expansion across the buffer on `SPC s S` and `SPC s B`
   (thanks to Andriy Kmit)
+- Fixed =cl= package deprecated =letf*= (thanks to duianto)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -148,29 +148,29 @@ around point as the initial input. If DIR is non nil start in
 that directory."
   (interactive)
   (require 'counsel)
-  (letf* ((initial-input (if use-initial-input
-                             (if (region-active-p)
-                                 (buffer-substring-no-properties
-                                  (region-beginning) (region-end))
-                               (thing-at-point 'symbol t))
-                           ""))
-          (tool (catch 'tool
-                  (dolist (tool tools)
-                    (when (and (assoc-string tool spacemacs--counsel-commands)
-                               (executable-find tool))
-                      (throw 'tool tool)))
-                  (throw 'tool "grep")))
-          (default-directory
-            (or initial-directory (read-directory-name "Start from directory: ")))
-          (display-directory
-           (if (< (length default-directory)
-                  spacemacs--counsel-search-max-path-length)
-               default-directory
-             (concat
-              "..." (substring default-directory
-                               (- (length default-directory)
-                                  spacemacs--counsel-search-max-path-length)
-                               (length default-directory))))))
+  (cl-letf* ((initial-input (if use-initial-input
+                                (if (region-active-p)
+                                    (buffer-substring-no-properties
+                                     (region-beginning) (region-end))
+                                  (thing-at-point 'symbol t))
+                              ""))
+             (tool (catch 'tool
+                     (dolist (tool tools)
+                       (when (and (assoc-string tool spacemacs--counsel-commands)
+                                  (executable-find tool))
+                         (throw 'tool tool)))
+                     (throw 'tool "grep")))
+             (default-directory
+               (or initial-directory (read-directory-name "Start from directory: ")))
+             (display-directory
+              (if (< (length default-directory)
+                     spacemacs--counsel-search-max-path-length)
+                  default-directory
+                (concat
+                 "..." (substring default-directory
+                                  (- (length default-directory)
+                                     spacemacs--counsel-search-max-path-length)
+                                  (length default-directory))))))
     (cond ((string= tool "ag")
            (counsel-ag initial-input default-directory nil
                        (format "ag from [%s]: " display-directory)))

--- a/layers/+spacemacs/spacemacs-editing-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/funcs.el
@@ -14,21 +14,21 @@
 (defun spacemacs/toggle-centered-buffer ()
   "Toggle visual centering of the current buffer."
   (interactive)
-  (letf ((writeroom-maximize-window nil)
+  (cl-letf ((writeroom-maximize-window nil)
          (writeroom-mode-line t))
     (call-interactively 'writeroom-mode)))
 
 (defun spacemacs/toggle-distraction-free ()
   "Toggle visual distraction free mode."
   (interactive)
-  (letf ((writeroom-maximize-window t)
+  (cl-letf ((writeroom-maximize-window t)
          (writeroom-mode-line nil))
     (call-interactively 'writeroom-mode)))
 
 (defun spacemacs/centered-buffer-transient-state ()
   "Center buffer and enable centering transient state."
   (interactive)
-  (letf ((writeroom-maximize-window nil)
+  (cl-letf ((writeroom-maximize-window nil)
          (writeroom-mode-line t))
     (writeroom-mode 1)
     (spacemacs/centered-buffer-mode-transient-state/body)))


### PR DESCRIPTION
The `cl` package has been deprecated.

It had aliases for `cl-` prefixed commands without the `cl-` prefix.
Ex: `letf` or `letf*` instead of `cl-letf` or `cl-letf*`

On the `spacemacs-base` distribution, with the `ivy` layer.
When one tries to search with `SPC /`
(which calls `spacemacs/counsel-search`)

Then this error message is shown:
>spacemacs/counsel-search: Symbol’s function definition is void: letf*

It doesn't happen with the `helm` layer,
because it's search commands already has the `cl-` prefix.

There are also three instances of: `letf`
in the `spacemacs-editing-visual` layers functions:
- `spacemacs/toggle-centered-buffer` (`SPC w c c`)
- `spacemacs/toggle-distraction-free` (`SPC w c C`)
- `spacemacs/centered-buffer-transient-state` (`SPC w c .`)

Without the `cl-` prefix they show the error message:
>Symbol’s function definition is void: letf