### PR TITLE
fix: ignore nil values in dotspacemacs-configuration-layers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -625,6 +625,7 @@ Other:
     (thanks to Mpho Jele)
   - Replaced =destructuring-bind= with =cl-destructuring-bind=
     (thanks to duianto)
+  - Ignore nils in dotspacemacs-configuration-layers (thanks to Ag)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1496,7 +1496,7 @@ whether the declared layer is an used one or not."
   (setq configuration-layer--used-layers nil)
   (let ((configuration-layer--declared-layers-usedp t))
     (unless configuration-layer-exclude-all-layers
-      (dolist (layer-specs layers-specs)
+      (dolist (layer-specs (remove nil layers-specs))
         (let* ((layer-name (if (listp layer-specs)
                                (car layer-specs)
                              layer-specs))


### PR DESCRIPTION
otherwise it throws warnings when layers introduced imperatively, e.g.:

    dotspacemacs-configuration-layers
    `(
      ,(when (eq system-type 'darwin) 'osx)
      ,(when (eq system-type 'gnu/linux) 'exwm))

