### PR TITLE
toggle for doom-modeline package

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -12,7 +12,7 @@
 (setq spacemacs-modeline-packages
       '(
         anzu
-        doom-modeline
+        (doom-modeline :toggle (eq (spacemacs/get-mode-line-theme-name) 'doom))
         fancy-battery
         ;; dependency of spaceline-all-the-icons which came from
         ;; the emacs wiki, we fetch it from Emacs Mirror for now.
@@ -34,7 +34,6 @@
 (defun spacemacs-modeline/init-doom-modeline ()
   (use-package doom-modeline
     :defer t
-    :if (eq (spacemacs/get-mode-line-theme-name) 'doom)
     :init (doom-modeline-mode)))
 
 (defun spacemacs-modeline/init-fancy-battery ()


### PR DESCRIPTION
Even though we have a check if doom is actually set in `dotspacemacs-mode-line-theme` in doom mode line `init` function. `doom-modeline` still adds a bunch functions to hook `after-change-functions` regardless of the value of mode line theme name. So some parts `doom-modeline` still run even when users don't use it. 

Hence we need to put a toggle on the declaration so `doom-modeline` only gets installed when it is actually in use.