### PR TITLE
Python - Change self compiled mspyls directory according to system type

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2786,6 +2786,7 @@ Other:
 - Fix =Ipython= path on windows (thanks to Daniel K)
 - Make =inferior-python-mode= do not use tabs (thanks to tsoernes)
 - Automatic use the =lsp= as =python-formater= when =lsp= is enabled (thanks sunlin7)
+- Fixed directory selection for self compiled mspyls (thanks Jee Lee) 
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -443,6 +443,10 @@ fix this issue."
       (message "lsp-python-ms: Using version at `%s'" lsp-python-ms-dir)
       ;; Use a precompiled exe
       (setq lsp-python-ms-executable (concat lsp-python-ms-dir
+                                             (pcase system-type
+                                               ('gnu/linux "linux-x64/publish/")
+                                               ('darwin "osx-x64/publish/")
+                                               ('windows-nt "win-x64/publish/"))
                                              "Microsoft.Python.LanguageServer"
                                              (and (eq system-type 'windows-nt)
                                                   ".exe"))))))


### PR DESCRIPTION
Microsoft's python-language-server compiles (publish) to different directories depending on the system used.