### PR TITLE
[eshell] Skip prompt on insert

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -103,7 +103,7 @@ the user activate the completion manually."
   "Move point to end of current prompt when switching to insert state."
   (when (and (eq major-mode 'eshell-mode)
              ;; Not on last line, we might want to edit within it.
-             (not (eq (line-end-position) (point-max)))
+             (not (>= (point) eshell-last-output-end))
              ;; Not on the last sent command if we use smart-eshell so we can
              ;; edit it.
              (not (and shell-enable-smart-eshell


### PR DESCRIPTION
When entering insert mode, don't start editing in the middle of the prompt, even if we're already on the last line.