### PR TITLE
rust: add key binding for `lsp-rust-switch-server`

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -75,6 +75,10 @@ To choose the experimental [[https://github.com/rust-analyzer/rust-analyzer][rus
   (lsp :variables lsp-rust-server 'rust-analyzer)
 #+END_SRC
 
+**** Switch to another LSP server
+
+If both =rls= and =rust-analyzer= server are installed, you can press ~SPC m s s~ to select another LSP server backend, and press ~SPC m b r~ to restart the LSP server to finish the switching.
+
 **** Autocompletion
 To enable auto-completion, ensure that the =auto-completion= layer is enabled.
 
@@ -119,6 +123,7 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | ~SPC m c v~ | check (verify) a project with Cargo         |
 | ~SPC m g g~ | jump to definition                          |
 | ~SPC m h h~ | describe symbol at point                    |
+| ~SPC m s s~ | switch to other LSP server backend          |
 | ~SPC m t~   | run tests with Cargo                        |
 
 ** debugger

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -44,7 +44,11 @@
 (defun spacemacs//rust-setup-lsp ()
   "Setup lsp backend"
   (if (configuration-layer/layer-used-p 'lsp)
-      (lsp)
+      (progn 
+        (lsp)
+        (spacemacs/declare-prefix-for-mode 'rust-mode "ms" "switch")
+        (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+          "ss" 'lsp-rust-switch-server))
     (spacemacs//lsp-layer-not-installed-message)))
 
 (defun spacemacs//rust-setup-lsp-company ()


### PR DESCRIPTION
`lsp-mode` supports two LSP server backend for Rust language, i.e.
`rls` and `rust-analyzer`.

`rust-analyzer` is experimental and lacks certain functionalities
such as `DAP` support.

`lsp-mode` provides a function `lsp-rust-switch-server` that changes
the priority of LSP server backend for *new* LSP session.

The first commit adds a key binding `SPC m s s` to `lsp-rust-switch-server`.
The second commit updates `README.org`.