### PR TITLE
Rename c++-enable-organize-includes-on-save to c-c++-enable-organize-includes-on-save

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1337,7 +1337,7 @@ Other:
     (thanks to Alexander Dalshov)
 - New packages:
   - =cpp-auto-include= Insert and delete C++ header files automatically:
-    - Added variable: =++-enable-organize-includes-on-save=
+    - Added variable: =c-c++-enable-organize-includes-on-save=
     - Added key binding: ~SPC m r i~ organize includes
 - Improvements:
   - Added =lsp= support using either =clangd=, =ccls= or =cquery= backends

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -277,11 +277,11 @@ can be found in the manual: [[http://www.gnu.org/software/emacs/manual/html_node
 
 ** Organize file header includes on save
 To organize the file header includes on save, set the layer variable
-=c++-enable-organize-includes-on-save= to =t= in the dotfile:
+=c-c++-enable-organize-includes-on-save= to =t= in the dotfile:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-                '((c-c++ :variables c++-enable-organize-includes-on-save t)))
+                '((c-c++ :variables c-c++-enable-organize-includes-on-save t)))
 #+END_SRC
 
 ** clang-format

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -55,7 +55,7 @@ If it is a relative path then it is relative to the project root.")
 
 ;; style
 
-(defvar c++-enable-organize-includes-on-save nil
+(defvar c-c++-enable-organize-includes-on-save nil
   "If non-nil then automatically organize the includes on save C++ buffer.")
 
 (defvar c-c++-enable-auto-newline nil

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -493,15 +493,15 @@
 
 ;; cpp-auto-include
 
-(defalias 'spacemacs/c++-organize-includes 'cpp-auto-include)
+(defalias 'spacemacs/c-c++-organize-includes 'cpp-auto-include)
 
-(defun spacemacs//c++-organize-includes-on-save ()
-  "Organize the includes on save when `c++-enable-organize-includes-on-save'
+(defun spacemacs//c-c++-organize-includes-on-save ()
+  "Organize the includes on save when `c-c++-enable-organize-includes-on-save'
 is non-nil."
-  (when c++-enable-organize-includes-on-save
-    (spacemacs/c++-organize-includes)))
+  (when c-c++-enable-organize-includes-on-save
+    (spacemacs/c-c++-organize-includes)))
 
-(defun spacemacs/c++-organize-includes-on-save ()
-  "Add before-save hook for c++-organize-includes."
+(defun spacemacs/c-c++-organize-includes-on-save ()
+  "Add before-save hook for c-c++-organize-includes."
   (add-hook 'before-save-hook
-            #'spacemacs//c++-organize-includes-on-save nil t))
+            #'spacemacs//c-c++-organize-includes-on-save nil t))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -109,8 +109,8 @@
     :defer t
     :init
     (progn
-      (when c++-enable-organize-includes-on-save
-        (add-hook 'c++-mode-hook #'spacemacs/c++-organize-includes-on-save))
+      (when c-c++-enable-organize-includes-on-save
+        (add-hook 'c++-mode-hook #'spacemacs/c-c++-organize-includes-on-save))
 
       (spacemacs/declare-prefix-for-mode 'c++-mode
         "mr" "refactor")


### PR DESCRIPTION
The logic that includes and enables the `cpp-auto-include` package is guarded by the variable `c++-enable-organize-includes-on-save`. This name kind of makes sense because it's only enabled in `c++-mode`, but on the other hand it doesn't make sense because naming the config variable and related functions with a leading `c++-` instead of `c-c++-` breaks the naming convention used by the layer.

This is kind of a subjective matter, but I think using a common naming convention for variables and functions within the layer is important and the variable/functions should thus be named accordingly. The `cpp-auto-include` stuff is still only enabled in `c++-mode` with this change, only the names of things have changed.

This also fixes a typo about the variable in CHANGELOG.develop (which should be fixed even if this change is rejected).