### PR TITLE
Coq layer: toggle the electric terminator setting.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1564,6 +1564,9 @@ Other:
   - Fixed ~SPC m e~ key bindings to behave like in Emacs Lisp
     (thanks to Boris Avdeev)
   - Fixed initialization of =counsel-gtags= (thanks to Sylvain Benner)
+**** Coq
+- Key bindings:
+  - ~SPC m T e~ Toggle electric terminator (thanks to Ignat Insarov)
 **** Cscope
 - Key bindings:
   - Fixed key binding ~g C~ (thanks to dubnde)

--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -127,3 +127,9 @@ Note the last two are regular =company-coq= bindings, left alone since they are
 most useful in insert mode. The full =company-coq= tutorial showcasing all
 available =company-coq= key bindings can be accessed at any time using =SPC SPC
 company-coq-tutorial=.
+
+** Options
+
+| Key binding     | Description                 |
+|-----------------+-----------------------------|
+| ~SPC m T e~     | Toggle electric terminator. |

--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -104,7 +104,9 @@
         "ir" 'coq-insert-requires
         "is" 'coq-insert-section-or-module
         "it" 'coq-insert-tactic
-        "iT" 'coq-insert-tactical))))
+        "iT" 'coq-insert-tactical
+        ;; Options
+        "Te" 'proof-electric-terminator-toggle))))
 
 (defun coq/post-init-smartparens ()
   (spacemacs/add-to-hooks (if dotspacemacs-smartparens-strict-mode


### PR DESCRIPTION
Make a new binding for the Coq layer.

This binding toggles the electric terminator setting of Proof General.

Strategically, I propose we add all kinds of settings in the same place.