### PR TITLE
add keybinding for markdown-insert-kbd to markdown layer

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -128,6 +128,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "xb"  'markdown-insert-bold
         "xi"  'markdown-insert-italic
         "xc"  'markdown-insert-code
+        "xk"  'markdown-insert-kbd
         "xC"  'markdown-insert-gfm-code-block
         "xq"  'markdown-insert-blockquote
         "xQ"  'markdown-blockquote-region


### PR DESCRIPTION
There's no keybinding for `markdown-insert-kbd` alongside all the other `markdown-insert-*` keybindings, this patch adds one using the same `,x` convention (specifically `,xk`).
