### PR TITLE
[Markdown] add keybinding for markdown-insert-kbd

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -124,6 +124,7 @@ In order to use =orgtabl-mode=, add =org= layer to your =~/.spacemacs=.
 | ~SPC m x i~ | make region italic or insert italic                               |
 | ~SPC m x c~ | make region code or insert code                                   |
 | ~SPC m x C~ | make region code or insert code (GitHub Flavored Markdown format) |
+| ~SPC m x k~ | make region <kbd> element or insert <kbd> element                 |
 | ~SPC m x q~ | make region blockquote or insert blockquote                       |
 | ~SPC m x Q~ | blockquote region                                                 |
 | ~SPC m x p~ | make region or insert pre                                         |

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -137,6 +137,7 @@
           "xc"  'markdown-insert-code
           "xC"  'markdown-insert-gfm-code-block
           "xi"  'markdown-insert-italic
+          "xk"  'markdown-insert-kbd
           "xp"  'markdown-insert-pre
           "xq"  'markdown-insert-blockquote
           "xs"  'markdown-insert-strike-through


### PR DESCRIPTION
There's no keybinding for `markdown-insert-kbd` alongside all the other markdown-insert-* keybindings, this patch adds one using the same convention (specifically xk), and also updates the README.
