### PR TITLE
[eshell] Protect prompt only

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3027,6 +3027,8 @@ Other:
   movement in term shells on emacs 26.1
 - Stopped the cursor from jumping to =point-max= when entering insert state from
   a multi line (thanks to Steven Allen)
+- Stopped input buffered while the previous command was running while protecting
+  the prompt (thanks to Steven Allen).
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -119,7 +119,7 @@ is achieved by adding the relevant text properties."
   (let ((inhibit-field-text-motion t))
     (add-text-properties
      (point-at-bol)
-     (point)
+     eshell-last-output-end
      '(rear-nonsticky t
                       inhibit-line-move-field-capture t
                       field output


### PR DESCRIPTION
If the user enters text while a command is running and the command does not consume the text, eshell will insert this text after it displays the prompt. Unfortunately, that happens after this function was called so this text ends up getting protected along with the prompt text.

This change protects up until the end of the last output (the end of the prompt text), leaving buffered input unprotected.