### PR TITLE
[nlinum] Show deprecation (Emacs 26.1+) warning on startup

### DIFF
--- a/layers/+misc/nlinum/config.el
+++ b/layers/+misc/nlinum/config.el
@@ -1,0 +1,14 @@
+;;; config.el --- nlinum Layer packages File
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (configuration-layer/layer-usedp 'nlinum)
+  (spacemacs-buffer/warning (concat "nlinum layer is deprecated for Emacs 26.1 and above."
+                                    " You can safely remove it from your dotfile.")))

--- a/layers/+misc/nlinum/packages.el
+++ b/layers/+misc/nlinum/packages.el
@@ -50,8 +50,5 @@
               (nlinum-relative-setup-evil)
               (add-hook 'nlinum-mode-hook 'nlinum-relative-on))
             (spacemacs/set-leader-keys "tr" 'spacemacs/nlinum-relative-toggle)))))
-
-  (defconst nlinum-packages nil)
-  (when (configuration-layer/layer-usedp 'nlinum)
-    (spacemacs-buffer/warning (concat "nlinum layer is deprecated for Emacs 26.1 and above."
-                                      " You can safely remove it from your dotfile."))))
+  ;;  Emacs version 26 and above
+  (defconst nlinum-packages nil))


### PR DESCRIPTION
The warning:
nlinum layer is deprecated for Emacs 26.1 and above
wasn't shown until `SPC h SPC` was pressed.

Because the variable: `configuration-layer--used-layers`
wasn't populated before the warning check occurred in
`nlinum/packages.el`.

The solution (suggested by syl20bnr) was to move the
check to a new file: `nlinum/config.el`.
