### PR TITLE
Add docs about ace mode in treemacs

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3349,6 +3349,8 @@ Other:
   - README.md:
     - Fixed macOS documentation to install fonts (thanks to Sergio Morales)
     - Updated Windows section, suggest official Emacs (thanks to ghost-420)
+  - layers/+filetree/treemacs/README.org:
+    - Add information about using and configuring ace mode in treemacs
 *** Release notes summarized
   Thanks to: Abhishek(Compro) Prasad, Deepak Khidia, Enze Chi, Grant Shangreaux,
   Igor Almeida, Jiahao Jiang, Miciah Dashiel Butler Masters, Songpeng Zu, Ward

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -17,6 +17,9 @@
 - [[#key-bindings][Key bindings]]
   - [[#global][Global]]
   - [[#inside-treemacs][Inside Treemacs]]
+    - [[#ace-mode-to-open-files][Ace mode to open files]]
+      - [[#set-ace-mode-as-default-action][Set ace mode as default action]]
+      - [[#use-digits-in-ace-mode][Use digits in ace mode]]
 
 * Description
 This layer sets up a file navigation and project explorer side-window via [[https://github.com/Alexander-Miller/treemacs][Treemacs]].
@@ -172,3 +175,30 @@ many other commands.
 | ~tw~        | Toggle whether the treemacs buffer should have a fixed width.                                                    |
 | ~yr~        | Copy the absolute path of the nearest project node at point.                                                     |
 | ~yy~        | Copy the absolute path of the node at point.                                                                     |
+
+*** Ace mode to open files
+   It is possible to open file under cursor in exact window you want.
+
+By default you have to press ~o a a~ to run ace selection mode and choose window with keys ~a s d f~.
+
+That behavior can be changed in two ways. 
+   
+**** Set ace mode as default action
+It is possible to set ace mode as default action for RET pressing on file.
+
+To do this add following configuration to your dotfile.
+
+#+BEGIN_SRC emacs-lisp
+  (treemacs-define-RET-action 'file-node-closed #'treemacs-visit-node-ace)
+  (treemacs-define-RET-action 'file-node-open #'treemacs-visit-node-ace)
+#+END_SRC
+
+**** Use digits in ace mode
+    
+Just add the following to use digits instead of ~a s d f~ in ace (window selection) mode.
+
+Please note that following code change ace mode globally, not only in treemacs
+
+#+BEGIN_SRC emacs-lisp
+  (setq aw-keys '(?1 ?2 ?3 ?4 ?5 ?6 ?7 ?8 ?9 ?0))
+#+END_SRC


### PR DESCRIPTION
There is a popular question about openning file in exact window.
There is an ace mode for that, but it is not so clear how to use
it for new users.

That commmit add information how to use ace mode and how tweak it
based on information from https://github.com/Alexander-Miller/treemacs/issues/266