### PR TITLE
Add option to hide version string in Spacemacs buffer.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -436,6 +436,7 @@ sane way, here is the complete list of changed key bindings
     will obfuscate the current buffer acting like a screen saver.
     (thanks to Eugene Yaremenko and Sylvain Benner)
   - New variable =dotspacemacs-undecorated-at-startup= (thanks to bb2020)
+  - New variable =dotspacemacs-startup-buffer-show-version= (thanks to Zach Pearson)
 - Removed Variables:
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -149,6 +149,10 @@ banner, `random' chooses a random text banner in `core/banners'
 directory. A string value must be a path to a .PNG file.
 If the value is nil then no banner is displayed.")
 
+(defvar dotspacemacs-startup-buffer-show-version t
+  "If bound, show Spacemacs and Emacs version at the top right of the
+Spacemacs buffer.")
+
 (defvar dotspacemacs-scratch-mode 'text-mode
   "Default major mode of the scratch buffer.")
 

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1031,7 +1031,10 @@ If a prefix argument is given, switch to it in an other, possibly new window."
             (let ((inhibit-read-only t))
               (erase-buffer)))
           (spacemacs-buffer/set-mode-line "")
-          (spacemacs-buffer//insert-version)
+          (if dotspacemacs-startup-buffer-show-version
+            (spacemacs-buffer//insert-version)
+            (let ((inhibit-read-only t))
+              (insert "\n")))
           (spacemacs-buffer/insert-banner-and-buttons)
           (when (bound-and-true-p spacemacs-initialized)
             (spacemacs-buffer//notes-redisplay-current-note)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -153,6 +153,11 @@ It should only modify the values of Spacemacs settings."
    ;; (default 'vim)
    dotspacemacs-editing-style 'vim
 
+   ;; If non-nil show the version string in the Spacemacs buffer. It will
+   ;; appear as (spacemacs version)@(emacs version)
+   ;; (default t)
+   dotspacemacs-startup-buffer-show-version t
+
    ;; Specify the startup banner. Default value is `official', it displays
    ;; the official spacemacs logo. An integer value is the index of text
    ;; banner, `random' chooses a random text banner in `core/banners'


### PR DESCRIPTION
This just adds a var to hide the Spacemacs@Emacs(spacemacs) version string at the top right of the dashboard buffer, for those that like minimalism. 