### PR TITLE
[pdf] Fix pdf-view-jump-to-register

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2684,6 +2684,8 @@ Other:
 - Fixed =spacemacs/run-pandoc= not to reset =pandoc--local-settings=
   (thanks to martian-f)
 - Added declaration for the ~SPC P~ prefix (thanks to Codruț Constantin Gușoi)
+**** Pdf
+- Fixed ~'~ =pdf-view-jump-to-register= (thanks to duianto)
 **** Perl5
 - Fixed =spacemacs/perltidy-format-buffer= and
   =spacemacs/perltidy-format-function= to move the point and window to their

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -123,6 +123,7 @@
         (kbd "C-u") 'pdf-view-scroll-down-or-previous-page
         (kbd "C-d") 'pdf-view-scroll-up-or-next-page
         (kbd "``")  'pdf-history-backward
+        "'" 'pdf-view-jump-to-register
         ;; Search
         "/" 'isearch-forward
         "?" 'isearch-backward


### PR DESCRIPTION
pdf-view-mode being evilified caused:
`'` (single quote) to be bound to: `image-scroll-up`

Fixes: #13270