### PR TITLE
Replace obsolete lsp-prefer-flymake with lsp-diagnostic-package

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1894,7 +1894,7 @@ Other:
     one =go-linter= (thanks to Robert Zaremba)
 - Improvements:
   - Added =LSP= support (thanks to Lupco Kotev)
-  - Set =lsp-prefer-flymake= to =:none= when =Go= layer is using =LSP=
+  - Set =lsp-diagnostic-package= to =:none= when =Go= layer is using =LSP=
     (thanks to Tim Heckman)
   - Improved go test output buffer behavior (thanks to Denis Bernard)
   - Configurable extra arguments to =go run= (thanks to Enze Chi)
@@ -2330,7 +2330,6 @@ Other:
   (thanks to Cormac Cannon).
 - Replace lsp-capabilities keybinding with lsp-describe-session
   (thanks to Bryan Tan)
-- Added lsp-prefer-flymake variable (thanks to Juuso Valkeejärvi)
 - Added =lsp-treemacs=
   - ~SPC m t g e~ to show error list
 - Fixed missing shortcuts for =lsp-mode=
@@ -2349,6 +2348,9 @@ Other:
 - Required =helm= or =treemacs= to download =helm-lsp= or =lsp-treemacs=
   (thanks to Steven Allen)
 - Required =yasnippet= (thanks to Ivan Yonchovski)
+- Removed the now obsolete variable =lsp-prefer-flymake= (originally added by
+  Juuso Valkeejärvi), the new variable =lsp-diagnostic-package= is handled
+  upstream (thanks to duianto)
 **** Debug Adapter Protocol (DAP)
 - Layer variables:
   - Added variable =dap-enable-mouse-support=

--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -35,7 +35,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (when (not javascript-lsp-linter)
-          (setq-local lsp-prefer-flymake :none))
+          (setq-local lsp-diagnostic-package :none))
         (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 

--- a/layers/+frameworks/vue/funcs.el
+++ b/layers/+frameworks/vue/funcs.el
@@ -31,7 +31,7 @@
       (progn
         ;; error checking from lsp langserver sucks, turn it off
         ;; so eslint won't be overriden
-        (setq-local lsp-prefer-flymake :none)
+        (setq-local lsp-diagnostic-package :none)
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -52,11 +52,11 @@
   "Setup lsp backend"
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        ;; without setting lsp-prefer-flymake to :none
+        ;; without setting lsp-diagnostic-package to :none
         ;; golangci-lint errors won't be reported
         (when go-use-golangci-lint
-          (message "[go] Setting lsp-prefer-flymake :none to enable golangci-lint support.")
-          (setq-local lsp-prefer-flymake :none))
+          (message "[go] Setting lsp-diagnostic-package :none to enable golangci-lint support.")
+          (setq-local lsp-diagnostic-package :none))
         (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -51,7 +51,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (when (not javascript-lsp-linter)
-          (setq-local lsp-prefer-flymake :none))
+          (setq-local lsp-diagnostic-package :none))
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))

--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -52,7 +52,6 @@
 
 (defun spacemacs//scala-setup-metals ()
   "Setup LSP metals for Scala."
-  (setq-local lsp-prefer-flymake nil)
   (add-hook 'scala-mode-hook #'lsp))
 
 (defun spacemacs//scala-disable-flycheck-scala ()

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -71,7 +71,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (when (not typescript-lsp-linter)
-          (setq-local lsp-prefer-flymake :none))
+          (setq-local lsp-diagnostic-package :none))
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -54,15 +54,14 @@ A number of configuration variables have been exposed via the LSP layer =config.
 Sensible defaults have been provided, however they may all be overridden in your .spacemacs, or dynamically using the bindings added
 under the derived mode t prefix by =(spacemacs/lsp-bind-keys-for-mode mode)=
 
-| Variable name                   | Default | Description                                                                                                                          |
-|---------------------------------+---------+--------------------------------------------------------------------------------------------------------------------------------------|
-| =lsp-navigation=                | `both'  | `simple' or `peek' to bind only xref OR lsp-ui-peek navigation functions                                                             |
-| =lsp-ui-remap-xref-keybindings= | nil     | When non-nil, xref key bindings remapped to lsp-ui-peek-find-{definition,references}                                                 |
-| =lsp-ui-doc-enable=             | t       | When non-nil, the documentation overlay is displayed                                                                                 |
-| =lsp-ui-doc-include-signature=  | nil     | When nil, signature omitted from lsp-ui-doc overlay (this is usually redundant)                                                      |
-| =lsp-ui-sideline-enable=        | t       | When non-nil, the symbol information overlay is displayed                                                                            |
-| =lsp-ui-sideline-show-symbol=   | nil     | When non-nil, the symbol information overlay includes symbol name (redundant for c-modes)                                            |
-| =lsp-prefer-flymake=            | nil     | When non-nil, use flymake. When nil, and =lsp-ui-flycheck= is available, use flycheck. When :none, use neither flymake nor flycheck. |
+| Variable name                   | Default | Description                                                                               |
+|---------------------------------+---------+-------------------------------------------------------------------------------------------|
+| =lsp-navigation=                | `both'  | `simple' or `peek' to bind only xref OR lsp-ui-peek navigation functions                  |
+| =lsp-ui-remap-xref-keybindings= | nil     | When non-nil, xref key bindings remapped to lsp-ui-peek-find-{definition,references}      |
+| =lsp-ui-doc-enable=             | t       | When non-nil, the documentation overlay is displayed                                      |
+| =lsp-ui-doc-include-signature=  | nil     | When nil, signature omitted from lsp-ui-doc overlay (this is usually redundant)           |
+| =lsp-ui-sideline-enable=        | t       | When non-nil, the symbol information overlay is displayed                                 |
+| =lsp-ui-sideline-show-symbol=   | nil     | When non-nil, the symbol information overlay includes symbol name (redundant for c-modes) |
 
 ** Navigation mode
 The ~lsp-navigation~ variable defined in =config.el= allows you to define a preference for lightweight or pretty

--- a/layers/+tools/lsp/config.el
+++ b/layers/+tools/lsp/config.el
@@ -15,11 +15,6 @@
 If `peek' binds lsp-ui navigation functions under `SPC m g'.
 If `both', binds lightweight navigation functions under `SPC m g' and lsp-ui functions under `SPC m G'")
 
-(defvar lsp-prefer-flymake nil
-  "If nil, prefer the lsp flycheck checker.
-If non-nil, prefer the lsp flymake checker.
-If :none, use neither flycheck nor flymake.")
-
 ;; These are config variables exposed by the lsp-ui package
 ;; They all have toggles bound under 't' in spacemacs/lsp-define-keys-for-mode
 (defvar lsp-ui-doc-enable t "Enable/disable lsp-ui-doc overlay")


### PR DESCRIPTION
Fixes: #13261

#### lsp layer
The previous default value of `lsp-prefer-flymake` in Spacemacs was: `nil`
which meant use `flycheck`.

The upstream default value of the new variable `lsp-diagnostic-package` is: `:auto`
which means: 
>Pick flycheck if present and fallback to flymake

Therefore the local definition was removed, so that it's handled upstream.

#### lsp layer readme
Instead of renaming and updating the description for the variable in the lsp/readme variable table:
https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp#variables
that line was removed, since it only seems to be referring to the lsp layer variables in `config.el`
>A number of configuration variables have been exposed via the LSP layer config.el.

#### scala layer
The `scala` layer set the previous variable `lsp-prefer-flymake` to `nil`, this line was removed, because the new variables default behavior is the same.

#### changelog.develop
There was a previous entry in the changelog.develop from when the now obsolete variable was added. That line was removed. The authors name was included as `originally added by` in this new changelog entry.