### PR TITLE
[feature] tide layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -392,6 +392,7 @@ sane way, here is the complete list of changed key bindings
 - sailfish-developer (thanks to Victor Polevoy)
 - sphinx (thanks to Wei-Wei Guo)
 - tern (thanks to Sylvain Benner and Juuso Valkeejärvi)
+- tide (thanks to Thanh Vuong)
 - transmission (thanks to Eugene Yaremenko)
 - web-beautify (thanks to Sylvain Benner and Juuso Valkeejärvi)
 - xclipboard (thanks to Charles Weill, Sylvain Benner, and Alex Palaistras)

--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -15,12 +15,14 @@
   "Conditionally setup react backend."
   (pcase javascript-backend
     (`tern (spacemacs/tern-setup-tern))
+    (`tide (spacemacs//tide-setup))
     (`lsp (spacemacs//react-setup-lsp))))
 
 (defun spacemacs//react-setup-company ()
   "Conditionally setup company based on backend."
   (pcase javascript-backend
     (`tern (spacemacs/tern-setup-tern-company 'rjsx-mode))
+    (`tide (spacemacs//tide-setup-company 'rjsx-mode))
     (`lsp (spacemacs//react-setup-lsp-company))))
 
 (defun spacemacs//react-setup-next-error-fn ()

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -22,6 +22,7 @@
     rjsx-mode
     smartparens
     tern
+    tide
     web-beautify
     yasnippet
     ))
@@ -100,6 +101,9 @@
 
 (defun react/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'rjsx-mode))
+
+(defun react/post-init-tide ()
+  (add-to-list 'tide-managed-modes 'rjsx-mode))
 
 (defun react/pre-init-web-beautify ()
   (when (eq javascript-fmt-tool 'web-beautify)

--- a/layers/+lang/javascript/README.org
+++ b/layers/+lang/javascript/README.org
@@ -16,6 +16,7 @@
   - [[#format-buffer-before-saving][Format buffer before saving]]
 - [[#backends][Backends]]
   - [[#tern][Tern]]
+  - [[#tide][Tide]]
   - [[#language-server-protocol][Language Server Protocol]]
     - [[#typescript][TypeScript]]
     - [[#flow][Flow]]
@@ -163,6 +164,9 @@ Default is =’web-beautify=.
 * Backends
 ** Tern
 See [[file:../../+tools/tern/README.org][tern layer]] documentation.
+
+** Tide
+See [[file:~/.emacs.d/layers/+tools/tide/README.org][tide layer]] documentation.
 
 ** Language Server Protocol
 To use an LSP server with JavaScript, add it as a =javascript-backend= to your

--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -15,7 +15,7 @@
 
 (defvar javascript-backend 'tern
   "The backend to use for IDE features.
-Possible values are `tern' and `lsp'.
+Possible values are `tern', `tide' and `lsp'.
 If `nil' then `tern' is the default backend unless `lsp' layer is used.")
 
 (defvar javascript-fmt-tool 'web-beautify

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -24,12 +24,14 @@
   "Conditionally setup javascript backend."
   (pcase (spacemacs//javascript-backend)
     (`tern (spacemacs//javascript-setup-tern))
+    (`tide (spacemacs//tide-setup))
     (`lsp (spacemacs//javascript-setup-lsp))))
 
 (defun spacemacs//javascript-setup-company ()
   "Conditionally setup company based on backend."
   (pcase (spacemacs//javascript-backend)
     (`tern (spacemacs//javascript-setup-tern-company))
+    (`tide (spacemacs//tide-setup-company 'js2-mode))
     (`lsp (spacemacs//javascript-setup-lsp-company))))
 
 (defun spacemacs//javascript-setup-dap ()

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -31,6 +31,7 @@
         prettier-js
         skewer-mode
         tern
+        tide
         web-beautify
         ))
 
@@ -87,7 +88,7 @@
       (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
       (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-next-error-fn)
       ;; safe values for backend to be used in directory file variables
-      (dolist (value '(lsp tern))
+      (dolist (value '(lsp tern tide))
         (add-to-list 'safe-local-variable-values
                      (cons 'javascript-backend value))))
     :config
@@ -260,6 +261,9 @@
 
 (defun javascript/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'js2-mode))
+
+(defun javascript/post-init-tide ()
+  (add-to-list 'tide-managed-modes 'js2-mode))
 
 (defun javascript/pre-init-web-beautify ()
   (when (eq javascript-fmt-tool 'web-beautify)

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -176,13 +176,14 @@ then set the variable =typescript-lsp-linter= to =nil=.
 | ~SPC m g b~ | jump back                                                    |
 | ~SPC m g g~ | jump to entity's definition                                  |
 | ~SPC m g t~ | jump to entity's type definition                             |
-| ~SPC m g u~ | references                                                   |
+| ~SPC m g r~ | references                                                   |
 | ~SPC m h h~ | documentation at point                                       |
+| ~SPC m p~   | send selected region or current buffer to the web playground |
 | ~SPC m r i~ | organize imports                                             |
 | ~SPC m r r~ | rename symbol                                                |
 | ~SPC m r f~ | rename file                                                  |
-| ~SPC m s p~ | send selected region or current buffer to the web playground |
-| ~SPC m s r~ | restart server                                               |
+| ~SPC m S r~ | restart server                                               |
+| ~SPC m S j~ | create a barebone =jsconfig.json= at project root            |
 
 ** Reference Major Mode
 

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -23,45 +23,20 @@
 (defun spacemacs//typescript-setup-backend ()
   "Conditionally setup typescript backend."
   (pcase (spacemacs//typescript-backend)
-    (`tide (spacemacs//typescript-setup-tide))
+    (`tide (spacemacs//tide-setup))
     (`lsp (spacemacs//typescript-setup-lsp))))
 
 (defun spacemacs//typescript-setup-company ()
   "Conditionally setup company based on backend."
   (pcase (spacemacs//typescript-backend)
-    (`tide (spacemacs//typescript-setup-tide-company))
+    (`tide (spacemacs//tide-setup-company 'typescript-mode 'typescript-tsx-mode))
     (`lsp (spacemacs//typescript-setup-lsp-company))))
 
 (defun spacemacs//typescript-setup-eldoc ()
   "Conditionally setup eldoc based on backend."
   (pcase (spacemacs//typescript-backend)
-    (`tide (spacemacs//typescript-setup-tide-eldoc))
+    (`tide (spacemacs//tide-setup-eldoc))
     (`lsp (spacemacs//typescript-setup-lsp-eldoc))))
-
-
-;; tide
-
-(defun spacemacs//typescript-setup-tide ()
-  "Setup tide backend."
-  (progn
-    (evilified-state-evilify tide-references-mode tide-references-mode-map
-      (kbd "C-k") 'tide-find-previous-reference
-      (kbd "C-j") 'tide-find-next-reference
-      (kbd "C-l") 'tide-goto-reference)
-    (tide-setup)))
-
-(defun spacemacs//typescript-setup-tide-company ()
-  "Setup tide auto-completion."
-  (spacemacs|add-company-backends
-    :backends company-tide
-    :modes typescript-mode typescript-tsx-mode
-    :variables
-    company-minimum-prefix-length 2)
-  (company-mode))
-
-(defun spacemacs//typescript-setup-tide-eldoc ()
-  "Setup eldoc for tide."
-  (eldoc-mode))
 
 
 ;; lsp

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -17,10 +17,10 @@
         emmet-mode
         flycheck
         smartparens
-        tide
         typescript-mode
         import-js
         web-mode
+        tide
         yasnippet
         ))
 
@@ -84,50 +84,6 @@
     (spacemacs/add-to-hooks #'smartparens-mode '(typescript-mode-hook
                                                  typescript-tsx-mode-hook))))
 
-(defun typescript/init-tide ()
-  (use-package tide
-    :defer t
-    :commands (typescript/jump-to-type-def)
-    :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mE" "errors")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mE" "errors")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mn" "name")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mn" "name")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "mS" "server")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "mS" "server")
-      (spacemacs/declare-prefix-for-mode 'typescript-mode "ms" "send")
-      (spacemacs/declare-prefix-for-mode 'typescript-tsx-mode "ms" "send")
-
-      (setq keybindingList '("Ee" tide-fix
-                             "Ed" tide-add-tslint-disable-next-line
-                             "gb" tide-jump-back
-                             "gg" tide-jump-to-definition
-                             "gt" spacemacs/typescript-jump-to-type-def
-                             "gu" tide-references
-                             "hh" tide-documentation-at-point
-                             "ri" tide-organize-imports
-                             "rr" tide-rename-symbol
-                             "rf" tide-rename-file
-                             "sr" tide-restart-server)
-            typescriptList (cons 'typescript-mode keybindingList)
-            typescriptTsxList (cons 'typescript-tsx-mode
-                                    (cons "gg" (cons 'tide-jump-to-definition
-                                                     keybindingList ))))
-      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptList)
-      (apply 'spacemacs/set-leader-keys-for-major-mode typescriptTsxList)))
-
-  (add-to-list 'spacemacs-jump-handlers-typescript-tsx-mode
-               '(tide-jump-to-definition :async t))
-  (add-to-list 'spacemacs-jump-handlers-typescript-mode
-               '(tide-jump-to-definition :async t)))
-
 (defun typescript/post-init-web-mode ()
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . typescript-tsx-mode))
@@ -139,7 +95,7 @@
     (add-hook 'typescript-tsx-mode-hook 'spacemacs/typescript-fmt-before-save-hook))
   (spacemacs/set-leader-keys-for-major-mode 'typescript-tsx-mode
     "="  'spacemacs/typescript-format
-    "sp" 'spacemacs/typescript-open-region-in-playground))
+    "p" 'spacemacs/typescript-open-region-in-playground))
 
 (defun typescript/post-init-yasnippet ()
   (spacemacs/add-to-hooks #'spacemacs/typescript-yasnippet-setup '(typescript-mode-hook
@@ -159,13 +115,14 @@
           (add-hook 'typescript-mode-hook 'spacemacs/typescript-fmt-before-save-hook))
         (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
           "="  'spacemacs/typescript-format
-          "sp" 'spacemacs/typescript-open-region-in-playground)
-        (spacemacs/set-leader-keys-for-major-mode 'typescript-tsx-mode
-          "="  'spacemacs/typescript-format
-          "sp" 'spacemacs/typescript-open-region-in-playground)))))
+          "p" 'spacemacs/typescript-open-region-in-playground)))))
 
 (defun typescript/pre-init-import-js ()
   (if (eq javascript-import-tool 'import-js)
       (progn
         (add-to-list 'spacemacs--import-js-modes (cons 'typescript-mode 'typescript-mode-hook))
         (add-to-list 'spacemacs--import-js-modes (cons 'typescript-tsx-mode 'typescript-tsx-mode-hook)))))
+
+(defun typescript/post-init-tide ()
+  (add-to-list 'tide-managed-modes 'typescript-mode)
+  (add-to-list 'tide-managed-modes 'typescript-tsx-mode))

--- a/layers/+tools/tide/README.org
+++ b/layers/+tools/tide/README.org
@@ -1,0 +1,91 @@
+#+TITLE: Tide Layer
+
+#+TAGS: layer|tool
+
+* Table of Contents                                       :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+  - [[#major-mode][Major Mode]]
+  - [[#reference-major-mode][Reference Major Mode]]
+
+* Description
+This layer installs [[https://github.com/ananthakumaran/tide][tide]] package which allows communication with 
+[[https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29][standalone typescript server]] =tsserver= for JavaScript/TypeScript development.
+
+** Features:
+  - First class support from =tsserver= just like =vscode=: speed and accuracy
+  - Linter 
+  - Refactor
+  - Go to definition
+  - Find references
+
+* Install
+See [[https://github.com/ananthakumaran/tide][tide]] for details. First you must have `tsserver` installed in your project
+or globally:
+
+#+begin_src sh
+  npm install -g tsserver
+#+end_src
+
+Next enable this layer in your =~/.spacemacs=. You will need to add =tide= to the
+existing =dotspacemacs-configuration-layers= list in this file. Then set the
+backend variables for JavaScript layer, React layer and TypeScript layer to =tide=
+in =dotspacemacs-configuration-layers=
+
+#+begin_src elisp
+  (javascript :variables
+               javascript-backend 'tide)
+
+  (typescript :variables
+              typescript-backend 'tide)
+#+end_src
+
+Both =javascript-backend= and =typescript-backend= can be set per project.
+
+When using this layer, make sure [[http://www.typescriptlang.org/docs/handbook/tsconfig-json.html][tsconfig.json]] or [[https://code.visualstudio.com/docs/languages/jsconfig][jsconfig.json]] is present in
+the root folder of the project.
+
+Example from emacs tide package: For JavaScript projects you may want to create
+=jsconfig.json= in the root folder of your project. =jsconfig.json= is =tsconfig.json=
+with allowjs attribute set to true.
+
+#+begin_src json
+  {
+    "compilerOptions": {
+      "target": "es2017",
+      "allowSyntheticDefaultImports": true,
+      "noEmit": true,
+      "checkJs": true,
+      "jsx": "react",
+      "lib": [ "dom", "es2017" ]
+    }
+  }
+#+end_src
+
+Without this file =tsserver= will pick up current folder as project root.
+* Key bindings
+** Major Mode
+| Key binding | Description                                       |
+|-------------+---------------------------------------------------|
+| ~SPC m E d~ | add =tslint:disable-next-line= at point           |
+| ~SPC m E e~ | fix thing at point                                |
+| ~SPC m g b~ | jump back                                         |
+| ~SPC m g g~ | jump to entity's definition                       |
+| ~SPC m g t~ | jump to entity's type definition                  |
+| ~SPC m g r~ | references                                        |
+| ~SPC m h h~ | documentation at point                            |
+| ~SPC m r i~ | organize imports                                  |
+| ~SPC m r r~ | rename symbol                                     |
+| ~SPC m r f~ | rename file                                       |
+| ~SPC m S r~ | restart server                                    |
+| ~SPC m S j~ | create a barebone =jsconfig.json= at project root |
+
+** Reference Major Mode
+| Key binding | Description             |
+|-------------+-------------------------|
+| ~C-j~       | find previous reference |
+| ~C-k~       | find next reference     |
+| ~C-l~       | goto reference          |
+

--- a/layers/+tools/tide/config.el
+++ b/layers/+tools/tide/config.el
@@ -1,0 +1,35 @@
+;;; config.el --- Tide Layer config file for Spacemacs. -*- lexical-binding: t -*-
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Thanh Vuong <thanhvg@gmail.com>
+;; URL: https://github.com/thanhvg
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; variables
+
+(defvar tide-managed-modes '(
+                            ;; typescript-mode
+                            ;; typescript-tsx-mode
+                            ;; js2-mode
+                            ;; js-mode
+                            ;; rjsx-mode
+                            )
+  "List of major modes that `tide layer` can manage.
+Client layers must add its major-mode to this list")
+
+(defvar tide-jsconfig-content
+  "{\n\
+    \"compilerOptions\": {\n\
+      \"target\": \"es2017\",\n\
+      \"allowSyntheticDefaultImports\": true,\n\
+      \"noEmit\": true,\n\
+      \"checkJs\": true,\n\
+      \"jsx\": \"react\",\n\
+      \"lib\": [ \"dom\", \"es2017\" ]\n\
+    }\n\
+  }"
+  "Content of jsconfig.json file.")

--- a/layers/+tools/tide/funcs.el
+++ b/layers/+tools/tide/funcs.el
@@ -1,0 +1,85 @@
+;;; funcs.el --- Tide  Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Thanh Vuong <thanhvg@gmail.com>
+;; URL: https://github.com/thanhvg
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//tide-setup-prefix ()
+  "This one should run only once, otherwise `which-key' will become very slow #12455"
+  (dolist (mode tide-managed-modes)
+    (spacemacs/declare-prefix-for-mode mode "mE" "errors")
+    (spacemacs/declare-prefix-for-mode mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode mode "mn" "name")
+    (spacemacs/declare-prefix-for-mode mode "mr" "refactor")
+    (spacemacs/declare-prefix-for-mode mode "mS" "server")))
+
+(defun spacemacs//tide-setup-bindings ()
+  "Define keys bindings for `tide-mode'"
+  (spacemacs/set-leader-keys-for-minor-mode 'tide-mode
+    "Ee" #'tide-fix
+    "Ed" #'tide-add-tslint-disable-next-line
+    "gb" #'tide-jump-back
+    "gg" #'tide-jump-to-definition
+    "gt" #'spacemacs/typescript-jump-to-type-def
+    "gr" #'tide-references
+    "hh" #'tide-documentation-at-point
+    "ri" #'tide-organize-imports
+    "rr" #'tide-rename-symbol
+    "rf" #'tide-rename-file
+    "Sr" #'tide-restart-server
+    "Sj" #'spacemacs//tide-create-jsconfig-file))
+
+(defun spacemacs//tide-setup ()
+  "Setup tide backend.
+Must be called by a layer using tide."
+  (evilified-state-evilify tide-references-mode tide-references-mode-map
+    (kbd "C-k") 'tide-find-previous-reference
+    (kbd "C-j") 'tide-find-next-reference
+    (kbd "C-l") 'tide-goto-reference)
+  (tide-hl-identifier-mode +1)
+  (tide-setup))
+
+(defun spacemacs//tide--list-to-string (list)
+  "Convert LIST to string."
+  (cl-reduce (lambda (x y) (concat x " " (symbol-name y)))
+             (cdr list)
+             :initial-value (format "%s" (car list) )))
+
+(defun spacemacs//tide-setup-company (&rest modes)
+  "Setup tide company for MODES.
+Must be called by a layer using tide."
+  (eval `(spacemacs|add-company-backends
+           :backends company-tide
+           :modes ,@modes
+           :append-hooks nil
+           :call-hooks t))
+  (company-mode))
+
+(defun spacemacs//tide-setup-eldoc ()
+  "Setup eldoc for tide."
+  (eldoc-mode))
+
+(defun spacemacs//tide-setup-jump-handle ()
+  "Loop through `tide-managed-modes' and set jump handlers for these modes."
+  (dolist (mode tide-managed-modes)
+    (add-to-list
+     (intern (format "spacemacs-jump-handlers-%S" mode))
+     '(tide-jump-to-definition :async t))))
+
+(defun spacemacs//tide-create-jsconfig-file ()
+  "Create a jsconfig file at project root."
+  (interactive)
+  (let ((jsconfig (cdr (project-current))))
+    (if jsconfig
+        (let ((jsconfig-file (concat jsconfig "jsconfig.json")))
+          (if (file-exists-p jsconfig-file)
+              (message "File exists")
+            (with-temp-file jsconfig-file
+              (insert tide-jsconfig-content))))
+      (message "Project not found"))))

--- a/layers/+tools/tide/packages.el
+++ b/layers/+tools/tide/packages.el
@@ -1,0 +1,23 @@
+;;; packages.el --- Tide Layer packages file for Spacemacs. -*- lexical-binding: t -*-
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Thanh Vuong <thanhvg@gmail.com>
+;; URL: https://github.com/thanhvg
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst tide-packages
+  '(tide)
+  "The list of Lisp packages required by the tide layer.")
+
+(defun tide/init-tide ()
+  (use-package tide
+    :defer t
+    :commands (typescript/jump-to-type-def)
+    :config
+    (spacemacs//tide-setup-prefix)
+    (spacemacs//tide-setup-bindings)
+    (spacemacs//tide-setup-jump-handle)))


### PR DESCRIPTION
Extract `tide-backend` from `typescript` layer to a separate layer named `tide`, so `javascript` and `react` layers can also use `tsserver` provided by this layer as backend sever.

With this commit, there will be three backends for `react` and `javacscript`: `tern`, `lsp` and the new one `tide`. `Typescript` layer still has the same two backends: `lsp` and `tide`.

Motivation: 
We have `lsp` backend which brings `Spacemacs` to the same level as `vsode` and I think `lsp` is the future. However, the performance with `lsp` for JS development can be sometimes sluggish.

Two popular JS lsp servers: `javascript-typescript-stdio` and `typescript-language-server` are missing features or somewhat abandoned.  To my understanding, `vscode` is also cheating when working with JS. It doesn't use any `lsp` server but it talks straight to `tsserver` just like `tide` does. The result is that the performance is better and all the features are available. 

This commit allows `Spacemacs` to have the same access to `tsserver` for JS dev as an alternative choice until the `lsp` project clears all these problems. 
 