### PR TITLE
rust: Added key-bindings and Updated README

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2939,6 +2939,13 @@ Other:
   - Added ~SPC m c t~ to run the current test with Cargo, and fix documentation
     for ~SPC m c f~ to format project files (thanks to Luke Alexander Stein)
   - Added ~SPC m c v~ to run "cargo check" command (thanks to Victor Polevoy)
+  - Added key bindings for =cargo-edit= plugin
+    - ~SPC m c a~ for =cargo add=
+    - ~SPC m c r~ for =cargo rm=
+    - ~SPC m c U~ for =cargo upgrade=
+  - Added ~SPC m c A~ for =cargo audit= plugin
+  - Modified ~SPC m c X~ for =cargo run --bin= command, instead of =cargo run --example=
+  - Added ~SPC m c E~ for =cargo run --example=
 - Added rust lsp completion with company and bindings (thanks to Justin)
 - Added debugger integration via =dap= layer
 - Fixed rust dap integration (thanks to Tommi Komulainen)

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -16,7 +16,10 @@
       - [[#autocompletion][Autocompletion]]
       - [[#debugger-dap-integration][Debugger (dap integration)]]
   - [[#cargo][Cargo]]
+    - [[#cargo-edit][cargo-edit]]
+    - [[#cargo-audit][cargo-audit]]
   - [[#rustfmt][Rustfmt]]
+  - [[#clippy][Clippy]]
 - [[#key-bindings][Key bindings]]
   - [[#debugger][debugger]]
 
@@ -92,6 +95,12 @@ To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are o
 [[http://doc.crates.io/index.html][Cargo]] is a project management command line tool for Rust. Installation
 instructions can be found on the main page of [[http://doc.crates.io/index.html][Cargo]].
 
+*** cargo-edit
+[[https://github.com/killercup/cargo-edit][cargo-edit]] allows you to add, remove, and upgrade dependencies by modifying your =Cargo.toml` file.
+
+*** cargo-audit
+[[https://github.com/RustSec/cargo-audit][cargo-audit]] audits =Cargo.lock= files for crates with security vulnerabilities.
+
 ** Rustfmt
 Format Rust code according to style guidelines using [[https://github.com/rust-lang-nursery/rustfmt][rustfmt]].
 
@@ -101,31 +110,40 @@ Format Rust code according to style guidelines using [[https://github.com/rust-l
 
 To enable automatic buffer formatting on save, set the variable =rust-format-on-save= to =t=.
 
+** Clippy
+[[https://github.com/rust-lang/rust-clippy][Clippy]] provides a collection of lints to to catch common mistakes and improve your code.
+
 * Key bindings
 
-| Key binding | Description                                 |
-|-------------+---------------------------------------------|
-| ~SPC m = =~ | reformat the buffer                         |
-| ~SPC m c .~ | repeat the last Cargo command               |
-| ~SPC m c C~ | remove build artifacts with Cargo           |
-| ~SPC m c X~ | execute a project example with Cargo        |
-| ~SPC m c c~ | compile project with Cargo                  |
-| ~SPC m c d~ | generate documentation with Cargo           |
-| ~SPC m c e~ | run benchmarks with Cargo                   |
-| ~SPC m c f~ | format all project files with rustfmt       |
-| ~SPC m c i~ | create a new project with Cargo (init)      |
-| ~SPC m c l~ | run linter ([[https://github.com/arcnmx/cargo-clippy][cargo-clippy]]) with Cargo        |
-| ~SPC m c n~ | create a new project with Cargo (new)       |
-| ~SPC m c o~ | run all tests in current file with Cargo    |
-| ~SPC m c s~ | search for packages on crates.io with Cargo |
-| ~SPC m c t~ | run the current test with Cargo             |
-| ~SPC m c u~ | update dependencies with Cargo              |
-| ~SPC m c x~ | execute a project with Cargo                |
-| ~SPC m c v~ | check (verify) a project with Cargo         |
-| ~SPC m g g~ | jump to definition                          |
-| ~SPC m h h~ | describe symbol at point                    |
-| ~SPC m s s~ | switch to other LSP server backend          |
-| ~SPC m t~   | run tests with Cargo                        |
+| Key binding | Description                                                            |
+|-------------+------------------------------------------------------------------------|
+| ~SPC m = =~ | reformat the buffer                                                    |
+| ~SPC m c .~ | repeat the last Cargo command                                          |
+| ~SPC m c a~ | add a new dependency with cargo-edit                                   |
+| ~SPC m c A~ | audit dependencies for known vulnerability with cargo-audit            |
+| ~SPC m c C~ | remove build artifacts                                                 |
+| ~SPC m c c~ | compile project                                                        |
+| ~SPC m c D~ | generate documentation and open it in default browser                  |
+| ~SPC m c d~ | generate documentation                                                 |
+| ~SPC m c E~ | run a project example                                                  |
+| ~SPC m c e~ | run benchmarks                                                         |
+| ~SPC m c f~ | format all project files with rustfmt                                  |
+| ~SPC m c i~ | initialise a new project with Cargo (init)                             |
+| ~SPC m c l~ | run linter ([[https://github.com/arcnmx/cargo-clippy][cargo-clippy]])  |
+| ~SPC m c n~ | create a new project with Cargo (new)                                  |
+| ~SPC m c o~ | run all tests in current file with Cargo                               |
+| ~SPC m c r~ | remove a dependency with cargo-edit                                    |
+| ~SPC m c s~ | search for packages on crates.io with Cargo                            |
+| ~SPC m c t~ | run the current test with Cargo                                        |
+| ~SPC m c u~ | update dependencies with Cargo                                         |
+| ~SPC m c U~ | upgrade dependencies to LATEST version with cargo-edit                 |
+| ~SPC m c v~ | check (verify) a project with Cargo                                    |
+| ~SPC m c X~ | execute a specific binary                                              |
+| ~SPC m c x~ | execute the default binary                                             |
+| ~SPC m g g~ | jump to definition                                                     |
+| ~SPC m h h~ | describe symbol at point                                               |
+| ~SPC m s s~ | switch to other LSP server backend                                     |
+| ~SPC m t~   | run tests with Cargo                                                   |
 
 ** debugger
 Using the =dap= layer you'll get access to all the DAP key bindings, see the

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -33,21 +33,26 @@
       (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
         "c." 'cargo-process-repeat
-        "cC" 'cargo-process-clean
-        "cX" 'cargo-process-run-example
+        "ca" 'cargo-process-add
+        "cA" 'cargo-process-audit
         "cc" 'cargo-process-build
+        "cC" 'cargo-process-clean
         "cd" 'cargo-process-doc
         "cD" 'cargo-process-doc-open
         "ce" 'cargo-process-bench
+        "cE" 'cargo-process-run-example
         "cf" 'cargo-process-fmt
         "ci" 'cargo-process-init
         "cl" 'cargo-process-clippy
         "cn" 'cargo-process-new
         "co" 'cargo-process-current-file-tests
+        "cr" 'cargo-process-rm
         "cs" 'cargo-process-search
         "ct" 'cargo-process-current-test
         "cu" 'cargo-process-update
+        "cU" 'cargo-process-upgrade
         "cx" 'cargo-process-run
+        "cX" 'cargo-process-run-bin
         "cv" 'cargo-process-check
         "t" 'cargo-process-test))))
 


### PR DESCRIPTION
Key-bindings:
- `SPC m c a` for `cargo add`
- `SPC m c r` for `cargo rm`
- `SPC m c U` for `cargo upgrade`
- `SPC m c A` for `cargo audit`
- `SPC m c X` is for `cargo run --bin` now, instead of `cargo run --example`,
  which is binded to `SPC m c E`

README.org:
- Added new sections on `cargo-edit`, `cargo-audit`, and `Clippy`,
  which are used for several key-bindings in this layer.
- Re-ordered the `Key bindings` section, added entries for new bidings,
  and improved description.