### PR TITLE
[gnus] Make the gnus variables user configurable

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1885,6 +1885,8 @@ Other:
 - Improvements:
   - Added a =@gnus= perspective (~SPC l o g~) to the layouts transient state
     (thanks to Matthew Leach)
+- Fixed:
+  - Made the gnus variables user configurable (thanks to duianto)
 **** Go
 - Deprecated:
   - Dropped support for deprecated =gometalinter= (thanks to pancho horrillo)

--- a/layers/+email/gnus/README.org
+++ b/layers/+email/gnus/README.org
@@ -12,6 +12,7 @@
 - [[#adding-news-sources][Adding news sources]]
 - [[#configuring-gmail][Configuring gmail]]
 - [[#org-mime-in-org-layer][Org MIME in Org layer]]
+- [[#setup-variables][Setup variables]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -104,6 +105,35 @@ It is possible to send beautiful HTML emails using org mode.
 Pressing ~SPC m e m~ in a message buffer will convert the current message
 from org mode to html. An org mode buffer can be sent via html email by pressing
 ~SPC m e m~ in any org mode buffer.
+
+* Setup variables
+The Gnus layer defines the following variables like this:
+
+#+BEGIN_SRC emacs-lisp
+  gnus-summary-line-format "%U%R%z %(%&user-date;  %-15,15f  %B (%c) %s%)\n"
+  gnus-user-date-format-alist '((t . "%Y-%m-%d %H:%M"))
+  gnus-group-line-format "%M%S%p%P%5y:%B %G\n";;"%B%(%g%)"
+  gnus-summary-thread-gathering-function 'gnus-gather-threads-by-references
+  gnus-thread-sort-functions '(gnus-thread-sort-by-most-recent-date)
+  gnus-ignored-newsgroups "^to\\.\\|^[0-9. ]+\\( \\|$\\)\\|^[\”]\”[#’()]"
+  gnus-sum-thread-tree-false-root ""
+  gnus-sum-thread-tree-indent " "
+  gnus-sum-thread-tree-leaf-with-other "├► "
+  gnus-sum-thread-tree-root ""
+  gnus-sum-thread-tree-single-leaf "╰► "
+  gnus-sum-thread-tree-vertical "│"
+  gnus-article-browse-delete-temp t
+  gnus-treat-strip-trailing-blank-lines 'last
+  gnus-keep-backlog 'nil
+  gnus-summary-display-arrow nil ; Don't show that annoying arrow:
+  gnus-mime-display-multipart-related-as-mixed t ; Show more MIME-stuff:
+  gnus-auto-select-first nil ; Don't get the first article automatically:
+  smiley-style 'medium
+  gnus-keep-backlog '0
+#+END_SRC
+
+They can be configured as layer variables or from the =dotspacemacs/user-config=
+section of =.spacemacs=.
 
 * Key bindings
 Gnus has very modal default keybindings.

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -30,39 +30,40 @@
     :defer t
     :commands gnus
     :init
-    (progn (spacemacs/declare-prefix "ag" "gnus" "Gnus newsreader")
-           (spacemacs/set-leader-keys
-             "agg" 'gnus
-             "ags" 'gnus-slave
-             "agu" 'gnus-unplugged
-             "ago" 'gnus-slave-unplugged)
-           (spacemacs/declare-prefix-for-mode 'message-mode "mi" "insert")
-           (spacemacs/set-leader-keys-for-major-mode 'message-mode
-             ;; RFC 1855
-             "miF" 'flame-on)
-           ;; NOTE: If any of the following variables are modified,
-           ;; also update their values in: `gnus/README.org'
-           (setq-default
-            gnus-summary-line-format "%U%R%z %(%&user-date;  %-15,15f  %B (%c) %s%)\n"
-            gnus-user-date-format-alist '((t . "%Y-%m-%d %H:%M"))
-            gnus-group-line-format "%M%S%p%P%5y:%B %G\n";;"%B%(%g%)"
-            gnus-summary-thread-gathering-function 'gnus-gather-threads-by-references
-            gnus-thread-sort-functions '(gnus-thread-sort-by-most-recent-date)
-            gnus-ignored-newsgroups "^to\\.\\|^[0-9. ]+\\( \\|$\\)\\|^[\”]\”[#’()]"
-            gnus-sum-thread-tree-false-root ""
-            gnus-sum-thread-tree-indent " "
-            gnus-sum-thread-tree-leaf-with-other "├► "
-            gnus-sum-thread-tree-root ""
-            gnus-sum-thread-tree-single-leaf "╰► "
-            gnus-sum-thread-tree-vertical "│"
-            gnus-article-browse-delete-temp t
-            gnus-treat-strip-trailing-blank-lines 'last
-            gnus-keep-backlog 'nil
-            gnus-summary-display-arrow nil ; Don't show that annoying arrow:
-            gnus-mime-display-multipart-related-as-mixed t ; Show more MIME-stuff:
-            gnus-auto-select-first nil ; Don't get the first article automatically:
-            smiley-style 'medium
-            gnus-keep-backlog '0))
+    (progn
+      (spacemacs/declare-prefix "ag" "gnus" "Gnus newsreader")
+      (spacemacs/set-leader-keys
+        "agg" 'gnus
+        "ags" 'gnus-slave
+        "agu" 'gnus-unplugged
+        "ago" 'gnus-slave-unplugged)
+      (spacemacs/declare-prefix-for-mode 'message-mode "mi" "insert")
+      (spacemacs/set-leader-keys-for-major-mode 'message-mode
+        ;; RFC 1855
+        "miF" 'flame-on)
+      ;; NOTE: If any of the following variables are modified,
+      ;; also update their values in: `gnus/README.org'
+      (setq-default
+       gnus-summary-line-format "%U%R%z %(%&user-date;  %-15,15f  %B (%c) %s%)\n"
+       gnus-user-date-format-alist '((t . "%Y-%m-%d %H:%M"))
+       gnus-group-line-format "%M%S%p%P%5y:%B %G\n";;"%B%(%g%)"
+       gnus-summary-thread-gathering-function 'gnus-gather-threads-by-references
+       gnus-thread-sort-functions '(gnus-thread-sort-by-most-recent-date)
+       gnus-ignored-newsgroups "^to\\.\\|^[0-9. ]+\\( \\|$\\)\\|^[\”]\”[#’()]"
+       gnus-sum-thread-tree-false-root ""
+       gnus-sum-thread-tree-indent " "
+       gnus-sum-thread-tree-leaf-with-other "├► "
+       gnus-sum-thread-tree-root ""
+       gnus-sum-thread-tree-single-leaf "╰► "
+       gnus-sum-thread-tree-vertical "│"
+       gnus-article-browse-delete-temp t
+       gnus-treat-strip-trailing-blank-lines 'last
+       gnus-keep-backlog 'nil
+       gnus-summary-display-arrow nil ; Don't show that annoying arrow:
+       gnus-mime-display-multipart-related-as-mixed t ; Show more MIME-stuff:
+       gnus-auto-select-first nil ; Don't get the first article automatically:
+       smiley-style 'medium
+       gnus-keep-backlog '0))
     :config
     (progn
       ;; No primary server

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -39,7 +39,30 @@
            (spacemacs/declare-prefix-for-mode 'message-mode "mi" "insert")
            (spacemacs/set-leader-keys-for-major-mode 'message-mode
              ;; RFC 1855
-             "miF" 'flame-on))
+             "miF" 'flame-on)
+           ;; NOTE: If any of the following variables are modified,
+           ;; also update their values in: `gnus/README.org'
+           (setq-default
+            gnus-summary-line-format "%U%R%z %(%&user-date;  %-15,15f  %B (%c) %s%)\n"
+            gnus-user-date-format-alist '((t . "%Y-%m-%d %H:%M"))
+            gnus-group-line-format "%M%S%p%P%5y:%B %G\n";;"%B%(%g%)"
+            gnus-summary-thread-gathering-function 'gnus-gather-threads-by-references
+            gnus-thread-sort-functions '(gnus-thread-sort-by-most-recent-date)
+            gnus-ignored-newsgroups "^to\\.\\|^[0-9. ]+\\( \\|$\\)\\|^[\”]\”[#’()]"
+            gnus-sum-thread-tree-false-root ""
+            gnus-sum-thread-tree-indent " "
+            gnus-sum-thread-tree-leaf-with-other "├► "
+            gnus-sum-thread-tree-root ""
+            gnus-sum-thread-tree-single-leaf "╰► "
+            gnus-sum-thread-tree-vertical "│"
+            gnus-article-browse-delete-temp t
+            gnus-treat-strip-trailing-blank-lines 'last
+            gnus-keep-backlog 'nil
+            gnus-summary-display-arrow nil ; Don't show that annoying arrow:
+            gnus-mime-display-multipart-related-as-mixed t ; Show more MIME-stuff:
+            gnus-auto-select-first nil ; Don't get the first article automatically:
+            smiley-style 'medium
+            gnus-keep-backlog '0))
     :config
     (progn
       ;; No primary server
@@ -55,28 +78,6 @@
       (setq gnus-sorted-header-list
             '("^From:" "^Reply-To" "^Organization:" "^To:" "^Cc:" "^Newsgroups:"
               "^Subject:" "^Date:" "^Gnus"))
-
-      (setq-default
-       gnus-summary-line-format "%U%R%z %(%&user-date;  %-15,15f  %B (%c) %s%)\n"
-       gnus-user-date-format-alist '((t . "%Y-%m-%d %H:%M"))
-       gnus-group-line-format "%M%S%p%P%5y:%B %G\n";;"%B%(%g%)"
-       gnus-summary-thread-gathering-function 'gnus-gather-threads-by-references
-       gnus-thread-sort-functions '(gnus-thread-sort-by-most-recent-date)
-       gnus-ignored-newsgroups "^to\\.\\|^[0-9. ]+\\( \\|$\\)\\|^[\”]\”[#’()]"
-       gnus-sum-thread-tree-false-root ""
-       gnus-sum-thread-tree-indent " "
-       gnus-sum-thread-tree-leaf-with-other "├► "
-       gnus-sum-thread-tree-root ""
-       gnus-sum-thread-tree-single-leaf "╰► "
-       gnus-sum-thread-tree-vertical "│"
-       gnus-article-browse-delete-temp t
-       gnus-treat-strip-trailing-blank-lines 'last
-       gnus-keep-backlog 'nil
-       gnus-summary-display-arrow nil ; Don't show that annoying arrow:
-       gnus-mime-display-multipart-related-as-mixed t ; Show more MIME-stuff:
-       gnus-auto-select-first nil ; Don't get the first article automatically:
-       smiley-style 'medium
-       gnus-keep-backlog '0)
 
       (require 'browse-url)
       (require 'nnrss)


### PR DESCRIPTION
The gnus variables were set in the `gnus/init-gnus`
functions `:config` section, that made them override
any user configurations.

Moving the variable declarations to the `:init`
section made them user configurable.

Fixes #13268

#### Note
The diff doesn't match the description.

The variables were moved up a about 15 lines, but the diff shows the configurations that were above the variables being moved down instead.

---

#### Previous description
(it still applies, but the change described above applies to all the variables that the `gnus` layer configures)

Made `gnus-summary-thread-gathering-function` user changeable
as a layer variable.

---

With the following `gnus` layer variable:
```elisp
     (gnus :variables
           gnus-summary-thread-gathering-function 'gnus-gather-threads-by-subject)
```

### Before this PR

#### Before opening a gnus buffer `SPC a g g`:
>gnus-summary-thread-gathering-function’s value is
‘gnus-gather-threads-by-subject’

#### After opening a gnus buffer:
>gnus-summary-thread-gathering-function is a variable defined in ‘gnus-sum.el’.
Its value is ‘gnus-gather-threads-by-references’
Original value was 
gnus-gather-threads-by-subject

### With this PR

#### Before opening a gnus buffer:
>gnus-summary-thread-gathering-function is a variable defined in ‘config.el’.
Its value is ‘gnus-gather-threads-by-subject’

#### After opening a gnus buffer:
>gnus-summary-thread-gathering-function is a variable defined in ‘gnus-sum.el’.
Its value is ‘gnus-gather-threads-by-subject’