### PR TITLE
[clojure] Add goto end of line eval sexp function and keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1429,6 +1429,8 @@ Other:
   - Autoscroll to end of REPL when sending buffer content
     (thanks to Vitaly Banchenko)
   - Added ability to use multiple linters together (thanks to didibus)
+  - Added `spacemacs/cider-eval-sexp-end-of-line` to match lisp functionality
+    (thanks to John Stevenson)
 - Key bindings:
   - ~SPC m e ;~ to eval sexp and show result as comment
     (thanks to John Stevenson)
@@ -1511,6 +1513,9 @@ Other:
   - added evaluation keybinding - evaluate up to point
     ~SPC m e V~ 'cider-eval-sexp-up-to-point
     (thanks to John Stevenson)
+  - added evaluation keybinding - go to end of line and evaluate sexp
+    ~SPC m e $~ 'spacemacs/cider-eval-sexp-end-of-line
+    ~SPC m e l~ 'spacemacs/cider-eval-sexp-end-of-line
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -482,10 +482,12 @@ Evaluate Clojure code in the source code buffer
 | Key binding | Description                                                       |
 |-------------+-------------------------------------------------------------------|
 | ~SPC m e ;~ | eval sexp and show result as comment                              |
+| ~SPC m e $~ | go to end of line and eval last sexp                              |
 | ~SPC m e b~ | eval buffer                                                       |
 | ~SPC m e e~ | eval last sexp                                                    |
 | ~SPC m e f~ | eval function at point                                            |
 | ~SPC m e i~ | interrupt the current evaluation                                  |
+| ~SPC m e l~ | go to end of line and eval last sexp                              |
 | ~SPC m e m~ | cider macroexpand 1                                               |
 | ~SPC m e M~ | cider macroexpand all                                             |
 | ~SPC m e n~ | refresh namespace (cider-ns-refresh)                              |

--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -34,6 +34,15 @@
                                  (match-end 1) "∈")
                  nil))))))
 
+
+(defun spacemacs/cider-eval-sexp-end-of-line ()
+  "Evaluate the last sexp at the end of the current line."
+  (interactive)
+  (save-excursion
+    (end-of-line)
+    (cider-eval-last-sexp)))
+
+
 (defun spacemacs//cider-eval-in-repl-no-focus (form)
   "Insert FORM in the REPL buffer and eval it."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -102,10 +102,12 @@
 
             ;; evaluate in source code buffer
             "e;" 'cider-eval-defun-to-comment
+            "e$" 'spacemacs/cider-eval-sexp-end-of-line
             "eb" 'cider-eval-buffer
             "ee" 'cider-eval-last-sexp
             "ef" 'cider-eval-defun-at-point
             "ei" 'cider-interrupt
+            "el" 'spacemacs/cider-eval-sexp-end-of-line
             "em" 'cider-macroexpand-1
             "eM" 'cider-macroexpand-all
             "en" 'cider-ns-refresh


### PR DESCRIPTION
Clojure (CIDER) is missing the incredibly useful function that jumps to the end
of the line and evaluates the last s-expression. This function is in Emacs Lisp major mode under `SPC m e $` and `SPC m e l`

The function `spacemacs/cider-eval-sexp-end-of-line` is a copy of
`lisp-state-eval-end-of-line` with the last line replaced to call the equivalent
cider function, `cider-eval-last-sexp`.

The same keybindings are added to the Clojure layer as used for elisp.

The keybindings follow the Spacemacs convention for evaluation, as defined in
https://github.com/syl20bnr/spacemacs/blob/master/doc/CONVENTIONS.org#evaluation

Resolves #4124

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3