### PR TITLE
[julia] Remove warning about LanguageServer.jl not working in version 1.0

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2282,6 +2282,8 @@ Other:
   - Fixed =julia-mode-local-vars-hook= (thanks to Guido Kraemer)
   - Limited =evil-surround-pairs-alist= redefinitions to julia mode
     (thanks to duianto)
+  - Remove warning about LanguageServer.jl not working in 1.0
+    (thanks to Daniel Molina)
 **** Keyboard layout
 - Added support for Colemak layout (thanks to Daniel Mijares, Lyall Cooper and
   Eivind Fonn)

--- a/layers/+lang/julia/README.org
+++ b/layers/+lang/julia/README.org
@@ -46,9 +46,6 @@ for installation, and then install this layer with:
      (julia :variables julia-mode-enable-lsp t)))
 #+END_SRC
 
-Warning: [[https://github.com/JuliaEditorSupport/LanguageServer.jl][LanguageServer.jl]] has not yet been released for Julia 1.0. If you are
-using this layer with Julia 1.0, =julia-mode-enable-lsp= should be set to =nil=.
-
 =LanguageServer.jl= tends to have a very long startup time. In the worst case,
 =lsp-mode= might give up on the language server before its started, but
 regardless usage of =lsp-mode= with Julia can cause long delays when first


### PR DESCRIPTION
Remove warning indicating that LanguageServer.jl is not working in Julia version 1.0, because it was updated and that problem version was fixed.