### PR TITLE
[#1598] [mu4e] Fix purpose labels for mu4e buffers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2437,6 +2437,7 @@ Other:
 - Enabled scrolling in =mu4e= (thanks to Simon Altschuler)
 - Kill mu4e layout on app exit (thanks to Ag Ibragimov)
 - Restore ~gu~ binding for ~mu4e-view-go-to-url~ (thanks to Dominik Schrempf)
+- Updated assigned purpose names
 **** Multiple Cursors
 - Disabled Spacemacs paste transient state when pasting to avoid pasting issue
   when there are more than one cursor (thanks to braham-snyder)

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -33,8 +33,12 @@
 (defvar mu4e-use-maildirs-extension nil
   "Use mu4e-maildirs-extension package if value is non-nil.")
 
-(defvar mu4e-modes
-  '(mu4e-main-mode mu4e-headers-mode mu4e-view-mode mu4e-compose-mode)
+(defvar mu4e-list-modes
+  '(mu4e-main-mode mu4e-headers-mode)
+  "Modes that are associated with mu4e buffers.")
+
+(defvar mu4e-view-modes
+  '(mu4e-view-mode mu4e-compose-mode mu4e-loading-mode)
   "Modes that are associated with mu4e buffers.")
 
 (when mu4e-installation-path

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -157,5 +157,7 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
 (defun mu4e/pre-init-window-purpose ()
   (spacemacs|use-package-add-hook window-purpose
     :pre-config
-    (dolist (mode mu4e-modes)
-      (add-to-list 'purpose-user-mode-purposes (cons mode 'mail)))))
+    (dolist (mode mu4e-list-modes)
+      (add-to-list 'purpose-user-mode-purposes (cons mode 'mail)))
+    (dolist (mode mu4e-view-modes)
+      (add-to-list 'purpose-user-mode-purposes (cons mode 'mail-view)))))


### PR DESCRIPTION
When purpose mode is enabled, Spacemacs fails to assign correct mu4e buffers to
correct windows when we're in headers view and select an e-mail from the list.

Since `*mu4e-headers*` and `*mu4e-view*` buffers have the same purpose
name (`mail`), and `*mu4e-loading*` buffer is either `fundamental` (or with a
recent version of upstream mu4e `mu4e-loading-mode`) which has the purpose
`general`.

So what happens is, when we select an e-mail from the list, e-mail opens up at
the headers' window, and loading opens up in the lower window which should have
displayed the actual email content.

With this commit, there will be two purpose names which will prevent this issue
from happening.