### PR TITLE
New layer for all-the-icons

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -364,6 +364,7 @@ sane way, here is the complete list of changed key bindings
 - ietf (thanks to Christian Hopps and Robby O'Connor)
 - multiple-cursors (thanks to Codruț Constantin Gușoi and Thomas de Beauchêne)
 - parinfer (thanks to Tianshu Shi)
+- all-the-icons (thanks to Steven Allen)
 **** Music
 - pianobar (thanks to Leo Littlebook)
 - tidalcycles (thanks to rbino)

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -16,7 +16,6 @@
         ac-ispell
         company
         (company-box :toggle auto-completion-use-company-box)
-        (all-the-icons :toggle auto-completion-use-company-box)
         (company-quickhelp :toggle auto-completion-enable-help-tooltip)
         (company-statistics :toggle auto-completion-enable-sort-by-usage)
         counsel
@@ -150,59 +149,10 @@
        (unless (eq auto-completion-enable-help-tooltip 'manual)
          (company-quickhelp-mode))))))
 
-(defun auto-completion/init-all-the-icons ()
-  (use-package all-the-icons
-    :after company
-    :config
-    (progn
-      (eval-and-compile
-        ;; Icons selected by liguangsheng
-        ;; https://github.com/liguangsheng/emacsd/blob/master/lisp/init-completion.el
-        (defun my-company-box-icon (family icon &rest args)
-          "Defines icons using `all-the-icons' for `company-box'."
-          (when icon
-            (let ((icon (pcase family
-                          ('octicon (all-the-icons-octicon icon :height 0.8 :v-adjust -0.05 args))
-                          ('faicon (all-the-icons-faicon icon :height 0.8 :v-adjust -0.0575))
-                          ('material (all-the-icons-material icon :height 0.8 :v-adjust -0.225 args))
-                          ('alltheicon (all-the-icons-alltheicon icon :height 0.8 args)))))
-              (unless (symbolp icon)
-                (concat icon
-                        (propertize " " 'face 'variable-pitch)))))))
-      (setq company-box-icons-all-the-icons
-            `((Unknown . ,(my-company-box-icon 'octicon "file-text"))
-              (Text . ,(my-company-box-icon 'faicon "file-text-o"))
-              (Method . ,(my-company-box-icon 'faicon "cube"))
-              (Function . ,(my-company-box-icon 'faicon "cube"))
-              (Constructor . ,(my-company-box-icon 'faicon "cube"))
-              (Field . ,(my-company-box-icon 'faicon "tag"))
-              (Variable . ,(my-company-box-icon 'faicon "tag"))
-              (Class . ,(my-company-box-icon 'faicon "cog"))
-              (Interface . ,(my-company-box-icon 'faicon "cogs"))
-              (Module . ,(my-company-box-icon 'alltheicon "less"))
-              (Property . ,(my-company-box-icon 'faicon "wrench"))
-              (Unit . ,(my-company-box-icon 'faicon "tag"))
-              (Value . ,(my-company-box-icon 'faicon "tag"))
-              (Enum . ,(my-company-box-icon 'faicon "file-text-o"))
-              (Keyword . ,(my-company-box-icon 'material "format_align_center"))
-              (Snippet . ,(my-company-box-icon 'material "content_paste"))
-              (Color . ,(my-company-box-icon 'material "palette"))
-              (File . ,(my-company-box-icon 'faicon "file"))
-              (Reference . ,(my-company-box-icon 'faicon "tag"))
-              (Folder . ,(my-company-box-icon 'faicon "folder"))
-              (EnumMember . ,(my-company-box-icon 'faicon "tag"))
-              (Constant . ,(my-company-box-icon 'faicon "tag"))
-              (Struct . ,(my-company-box-icon 'faicon "cog"))
-              (Event . ,(my-company-box-icon 'faicon "bolt"))
-              (Operator . ,(my-company-box-icon 'faicon "tag"))
-              (TypeParameter . ,(my-company-box-icon 'faicon "cog"))
-              (Template . ,(my-company-box-icon 'octicon "file-code")))))))
-
 (defun auto-completion/init-company-box ()
   (use-package company-box
     :hook '(company-mode . company-box-mode)
     :commands 'company-box-doc-manually
-    :init (setq company-box-icons-alist 'company-box-icons-all-the-icons)
     :config
     (progn
       (spacemacs|hide-lighter company-box-mode)

--- a/layers/+misc/all-the-icons/README.org
+++ b/layers/+misc/all-the-icons/README.org
@@ -1,0 +1,80 @@
+#+TITLE: All The Icons layer
+
+#+TAGS: misc|layer
+
+* Table of Contents                                       :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#usage][Usage]]
+
+* Description
+This layer installs and configures All The Icons.
+
+** Features:
+- Enables and configures icons for dired, ivy, and ibuffer when the appropriate layers are enabled.
+- Defines icon transformers for ivy-rich.
+- Enables icons in company-box.
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =all-the-icons= to the existing =dotspacemacs-configuration-layers= list in
+this file.
+
+After enabling the layer and reloading your configuration (~SPC f e R~), you will
+need to install the all-the-icons font by running the
+=all-the-icons-install-fonts= command:
+
+#+BEGIN_EXAMPLE
+  SPC SPC all-the-icons-install-fonts RET
+#+END_EXAMPLE
+
+* Usage
+Most of the features provided by this layer work out of the box. However, you'll
+need to configure =ivy-rich= yourself.
+
+This layer provides two transformers for customizing =ivy-rich=:
+=ivy-rich-buffer-icon= and =ivy-rich-file-icon=. They can be used to iconize
+your ivy-rich results as follows.
+
+#+BEGIN_SRC elisp
+  (setq ivy-rich-display-transformers-list
+        '(ivy-switch-buffer
+          (:columns
+           ((ivy-rich-buffer-icon (:width 2))
+            (ivy-rich-candidate (:width 100))
+            (ivy-rich-switch-buffer-indicators (:width 4 :face error :align right))
+            (ivy-rich-switch-buffer-project (:width 15 :face success))
+            (ivy-rich-switch-buffer-path (:width
+                                          (lambda (x)
+                                            (ivy-rich-switch-buffer-shorten-path
+                                             x (ivy-rich-minibuffer-width 0.3))))))
+           :predicate (lambda (cand) (get-buffer cand)))
+          counsel-find-file
+          (:columns
+           ((ivy-read-file-transformer)
+            (ivy-rich-counsel-find-file-truename (:face font-lock-doc-face))))
+          counsel-M-x
+          (:columns
+           ((counsel-M-x-transformer (:width 80))
+            (ivy-rich-counsel-function-docstring (:face font-lock-doc-face))))
+          counsel-describe-function
+          (:columns
+           ((counsel-describe-function-transformer (:width 40))
+            (ivy-rich-counsel-function-docstring (:face font-lock-doc-face))))
+          counsel-describe-variable
+          (:columns
+           ((counsel-describe-variable-transformer (:width 40))
+            (ivy-rich-counsel-variable-docstring (:face font-lock-doc-face))))
+          counsel-recentf
+          (:columns
+           ((ivy-rich-file-icon (:width 2))
+            (ivy-rich-candidate (:width 0.8))
+            (ivy-rich-file-last-modified-time (:face font-lock-comment-face))))
+          package-install
+          (:columns
+           ((ivy-rich-candidate (:width 30))
+            (ivy-rich-package-version (:width 16 :face font-lock-comment-face))
+            (ivy-rich-package-archive-summary (:width 7 :face font-lock-builtin-face))
+            (ivy-rich-package-install-summary (:face font-lock-doc-face))))))
+#+END_SRC

--- a/layers/+misc/all-the-icons/packages.el
+++ b/layers/+misc/all-the-icons/packages.el
@@ -1,0 +1,129 @@
+;;; packages.el --- all-the-icons layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author:  <Steven Allen <steven@stebalien.com>>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst all-the-icons-packages
+  '(
+    (all-the-icons :protected t)
+    ivy-rich
+    (all-the-icons-ivy :toggle (configuration-layer/package-used-p 'ivy))
+    (all-the-icons-ibuffer :toggle (configuration-layer/package-used-p 'ibuffer))
+    (all-the-icons-dired :toggle (configuration-layer/package-used-p 'dired))
+    company-box)
+  "The list of Lisp packages required by the all-the-icons layer.")
+
+(defun all-the-icons/init-all-the-icons ()
+  (use-package all-the-icons
+    :defer t
+    :config
+    ;; EXWM
+    (add-to-list 'all-the-icons-mode-icon-alist
+                 '(exwm-mode all-the-icons-octicon "browser" :face all-the-icons-dsilver))
+    ;; Notmuch
+    (add-to-list 'all-the-icons-mode-icon-alist
+                  '(notmuch-show-mode all-the-icons-octicon "mail-read" :face all-the-icons-lblue))
+    (add-to-list 'all-the-icons-mode-icon-alist
+                  '(notmuch-search-mode all-the-icons-material "inbox" :face all-the-icons-blue))
+    (add-to-list 'all-the-icons-mode-icon-alist
+                  '(notmuch-message-mode all-the-icons-material "email" :face all-the-icons-orange))
+
+    ;; Missing directory type (for ivy)
+    (add-to-list 'all-the-icons-icon-alist '("/$" all-the-icons-octicon "file-directory"))
+
+    ;; Switch to a go icon that shows up. The default one is practically invisible.
+    (add-to-list 'all-the-icons-mode-icon-alist '(go-mode all-the-icons-fileicon "go" :face all-the-icons-lblue))
+    (add-to-list 'all-the-icons-icon-alist '("\\.go$" all-the-icons-fileicon "go" :face all-the-icons-lblue))
+
+    ;; systemd
+    (add-to-list 'all-the-icons-mode-icon-alist '(systemd-mode all-the-icons-faicon "cogs" :face all-the-icons-dred))
+    (add-to-list 'all-the-icons-icon-alist `(,systemd-autoload-regexp all-the-icons-faicon "cogs" :face all-the-icons-dred))
+
+    ;; matrix
+    (add-to-list 'all-the-icons-mode-icon-alist '(matrix-client-mode all-the-icons-material "chat" :face all-the-icons-dcyan))
+
+    ;; Spacemacs home
+    (add-to-list 'all-the-icons-mode-icon-alist
+                  '(spacemacs-buffer-mode all-the-icons-material "home" :face all-the-icons-purple))))
+
+(defun all-the-icons/init-all-the-icons-dired ()
+    (use-package all-the-icons-dired
+      :defer t
+      :init
+      (add-hook 'dired-mode-hook 'all-the-icons-dired-mode)))
+
+(defun all-the-icons/init-all-the-icons-ibuffer ()
+  (use-package all-the-icons-ibuffer
+    :defer t
+    :init
+    (add-hook 'ibuffer-mode-hook 'all-the-icons-ibuffer-mode)))
+
+(defun all-the-icons/init-all-the-icons-ivy ()
+    (use-package all-the-icons-ivy
+      :after ivy
+      :config
+      (all-the-icons-ivy-setup)))
+
+(defun all-the-icons/post-init-ivy-rich ()
+  (with-eval-after-load 'ivy-rich
+    (defun ivy-rich-file-icon (candidate)
+      (let ((icon (all-the-icons-icon-for-file candidate)))
+        (if (symbolp icon)
+            (all-the-icons-icon-for-mode 'fundamental-mode)
+          icon)))
+    (defun ivy-rich-buffer-icon (candidate)
+      (let ((icon (all-the-icons-icon-for-mode
+                   (buffer-local-value 'major-mode (get-buffer candidate)))))
+        (if (symbolp icon)
+            (all-the-icons-icon-for-mode 'fundamental-mode)
+          icon)))))
+
+(defun all-the-icons/post-init-company-box ()
+  (setq company-box-icons-alist 'company-box-icons-all-the-icons)
+  (with-eval-after-load 'company-box
+    ;; Icons selected by liguangsheng
+    ;; https://github.com/liguangsheng/emacsd/blob/master/lisp/init-completion.el
+      (defun spacemacs/company-box-icon (family icon &rest args)
+        (when icon
+          (let ((icon (pcase family
+                        ('octicon (all-the-icons-octicon icon :height 0.8 :v-adjust -0.05 args))
+                        ('faicon (all-the-icons-faicon icon :height 0.8 :v-adjust -0.0575))
+                        ('material (all-the-icons-material icon :height 0.8 :v-adjust -0.225 args))
+                        ('alltheicon (all-the-icons-alltheicon icon :height 0.8 args)))))
+            (unless (symbolp icon)
+              (concat icon
+                      (propertize " " 'face 'variable-pitch))))))
+      (setq company-box-icons-all-the-icons
+            `((Unknown . ,(spacemacs/company-box-icon 'octicon "file-text"))
+              (Text . ,(spacemacs/company-box-icon 'faicon "file-text-o"))
+              (Method . ,(spacemacs/company-box-icon 'faicon "cube"))
+              (Function . ,(spacemacs/company-box-icon 'faicon "cube"))
+              (Constructor . ,(spacemacs/company-box-icon 'faicon "cube"))
+              (Field . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Variable . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Class . ,(spacemacs/company-box-icon 'faicon "cog"))
+              (Interface . ,(spacemacs/company-box-icon 'faicon "cogs"))
+              (Module . ,(spacemacs/company-box-icon 'alltheicon "less"))
+              (Property . ,(spacemacs/company-box-icon 'faicon "wrench"))
+              (Unit . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Value . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Enum . ,(spacemacs/company-box-icon 'faicon "file-text-o"))
+              (Keyword . ,(spacemacs/company-box-icon 'material "format_align_center"))
+              (Snippet . ,(spacemacs/company-box-icon 'material "content_paste"))
+              (Color . ,(spacemacs/company-box-icon 'material "palette"))
+              (File . ,(spacemacs/company-box-icon 'faicon "file"))
+              (Reference . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Folder . ,(spacemacs/company-box-icon 'faicon "folder"))
+              (EnumMember . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Constant . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (Struct . ,(spacemacs/company-box-icon 'faicon "cog"))
+              (Event . ,(spacemacs/company-box-icon 'faicon "bolt"))
+              (Operator . ,(spacemacs/company-box-icon 'faicon "tag"))
+              (TypeParameter . ,(spacemacs/company-box-icon 'faicon "cog"))
+              (Template . ,(spacemacs/company-box-icon 'octicon "file-code"))))))


### PR DESCRIPTION
This change introduces a new "all-the-icons" layer to configure all-the-icons and related packages.

This layer:

* Configures all the icons for dired, ivy, company-box, and ibuffer
* Defines icon transformers for ivy-rich but doesn't use them by default.
* Defines additional icons for some common spacemacs modes.