### PR TITLE
[#1598] Fix missing mu4e-modes error

### DIFF
--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -35,10 +35,14 @@
 
 (defvar mu4e-list-modes
   '(mu4e-main-mode mu4e-headers-mode)
-  "Modes that are associated with mu4e buffers.")
+  "Modes that are associated with mu4e's listing buffers.")
 
 (defvar mu4e-view-modes
   '(mu4e-view-mode mu4e-compose-mode mu4e-loading-mode)
+  "Modes that are associated with mu4e's view/compose buffers.")
+
+(defvar mu4e-modes
+  '(append 'mu4e-list-modes 'mu4e-view-modes)
   "Modes that are associated with mu4e buffers.")
 
 (when mu4e-installation-path


### PR DESCRIPTION
The previous PR ( #13331 ) failed to handle everywhere `mu4e-modes` list is being used. So this will bring it back, but still use the added lists for `purpose` setup.