### PR TITLE
[mu4e] Fix for value of `mu4e-modes` being void

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -137,7 +137,7 @@
 (defun mu4e/init-helm-mu ()
   (use-package helm-mu
     :defer t
-    :init (dolist (m mu4e-modes)
+    :init (dolist (m (append mu4e-list-modes mu4e-view-modes))
             (spacemacs/set-leader-keys-for-major-mode m
               "S" 'helm-mu
               "/" 'helm-mu


### PR DESCRIPTION
It looks like `mu4e-modes` was split into two variables, `mu4e-list-modes` and `mu4e-view-modes` without the use of the variable being adjusted.

This change silences the startup error

```
Error (use-package): helm-mu/:init: Symbol’s value as variable is void: mu4e-modes
```