### PR TITLE
[+lang/ipython-notebook] Further reduce maintenance

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2111,6 +2111,7 @@ Other:
   - Added ~SPC a y s~ =ein:stop= (thanks to Zach Pearson)
   - Added package dependencies for =ein= (thanks to ft)
   - Fixed keybindings per removal of =ein:notebook-multilang-mode=
+  - DRY and tidiness update by primary EIN developer
 **** Ivy
 - Added =recentf= alt actions to refresh and delete items (thanks to Rich Alesi)
 - Added =projectile= alternate actions to invalidate cache (thanks to Rich Alesi)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2112,7 +2112,7 @@ Other:
   - Added package dependencies for =ein= (thanks to ft)
   - Fixed keybindings per removal of =ein:notebook-multilang-mode=
   - DRY and tidiness update by primary EIN developer
-  - Dynamically generate transient-state docstring.  Remove ob-ipython (ibid.)
+  - Dynamically generate transient-state docstring.  Remove ob-ipython (Ibid.)
 **** Ivy
 - Added =recentf= alt actions to refresh and delete items (thanks to Rich Alesi)
 - Added =projectile= alternate actions to invalidate cache (thanks to Rich Alesi)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2112,6 +2112,7 @@ Other:
   - Added package dependencies for =ein= (thanks to ft)
   - Fixed keybindings per removal of =ein:notebook-multilang-mode=
   - DRY and tidiness update by primary EIN developer
+  - Remove transient menu and ob-ipython (ibid.)
 **** Ivy
 - Added =recentf= alt actions to refresh and delete items (thanks to Rich Alesi)
 - Added =projectile= alternate actions to invalidate cache (thanks to Rich Alesi)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2112,7 +2112,7 @@ Other:
   - Added package dependencies for =ein= (thanks to ft)
   - Fixed keybindings per removal of =ein:notebook-multilang-mode=
   - DRY and tidiness update by primary EIN developer
-  - Remove transient menu and ob-ipython (ibid.)
+  - Dynamically generate transient-state docstring.  Remove ob-ipython (ibid.)
 **** Ivy
 - Added =recentf= alt actions to refresh and delete items (thanks to Rich Alesi)
 - Added =projectile= alternate actions to invalidate cache (thanks to Rich Alesi)

--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -19,6 +19,8 @@
                                "ays" 'ein:stop)
     (spacemacs/declare-prefix "ay" "ipython notebook")
     :config
+    (require 'seq)
+    (require 'subr-x)
     (mapc
      (lambda (mode)
        (evil-define-minor-mode-key
@@ -45,7 +47,7 @@
                         ("o" ein:worksheet-insert-cell-below-km)
                         ("O" ein:worksheet-insert-cell-above-km)
                         ("t" ein:worksheet-toggle-cell-type-km)
-                        ("C-m" ein:worksheet-execute-cell-km)
+                        ("RET" ein:worksheet-execute-cell-km)
                         ("l" ein:worksheet-clear-output-km)
                         ("L" ein:worksheet-clear-all-output-km)
                         ("C-s" ein:notebook-save-notebook-command-km)
@@ -62,4 +64,117 @@
                       (display-warning
                        'warn (format "ipython-notebook/init-ein: undefined %s"
                                      (cl-second bind))))))
-                (copy-tree bindings)))))))
+                (copy-tree bindings)))
+	(eval (append '(spacemacs|define-transient-state
+			ipython-notebook
+			:title "iPython Notebook Transient State"
+			:evil-leader-for-mode (ein:notebook-mode . ".")
+			:bindings
+			("q" nil :exit t))
+		      bindings
+			`(:doc ,(ipython-notebook/transient-doc bindings))))))))
+
+(defun ipython-notebook/max-by-prefix (alist)
+  (seq-reduce (lambda (lst1 lst2) (if (> (cl-second lst1)
+					 (cl-second lst2))
+				      lst1 lst2))
+	      (cdr alist) (car alist)))
+
+(defun ipython-notebook/count-by-prefix (alist)
+  (mapcar (lambda (lst)
+	    (cons (car lst) (list (length (cdr lst)))))
+	  alist))
+
+(defun ipython-notebook/commands-by-prefix-alist (commands)
+  "Return ((P1 P1-CMD1 P1-CMD2) (P2 P2-CMD1 P2-CMD2) ... )"
+  (let* ((commands (if (symbolp (car commands))
+		       (mapcar #'symbol-name commands)
+		     commands))
+	 (upto (ipython-notebook/prefix commands))
+	 result)
+    (cl-flet ((get-prefix
+	       (command)
+	       (intern (mapconcat #'identity
+				  (subseq (split-string command (regexp-quote "-"))
+					  0 (1+ upto))
+				  "-"))))
+      (mapc (lambda (command)
+	      (let ((lst (alist-get (get-prefix command) result)))
+		(setf (alist-get (get-prefix command) result)
+		      (cons (intern command) lst))))
+	    commands)
+      result)))
+
+(cl-defun ipython-notebook/prefix (commands &key (separator "-") (suffix-p nil))
+  "Return index of first different prefix among COMMANDS if each were split on SEPARATOR.
+For example, return 2 if COMMANDS are '(ein:notebook-foo ein:notebook-foo-bar)."
+  (let* ((commands (if (symbolp (car commands))
+		       (mapcar #'symbol-name commands)
+		     commands))
+	 (split-up (mapcar (lambda (command)
+			     (funcall (if suffix-p #'reverse #'identity)
+				      (split-string command (regexp-quote separator))))
+			   commands)))
+    (cl-loop for result from 0
+	     for bogey = (nth result (car split-up))
+	     if (or (null bogey)
+		    (null (cdr split-up))
+		    (cl-some (lambda (lst) (not (string= bogey (nth result lst))))
+			     (cdr split-up)))
+	     return (funcall (if suffix-p #'- #'identity) result)
+	     end)))
+
+(defun ipython-notebook/transient-doc (bindings)
+  (let* ((commands-by (ipython-notebook/commands-by-prefix-alist (mapcar #'cl-second bindings)))
+	 (counts-by (ipython-notebook/count-by-prefix commands-by))
+	 (max-by (ipython-notebook/max-by-prefix counts-by))
+	 (main (cl-first max-by))
+	 (n-main (cl-second max-by))
+	 (n-other (apply #'+ (mapcar (lambda (lst) (if (eq (cl-first lst) main)
+						       0 (cl-second lst)))
+				     counts-by)))
+	 (max-col 3)
+	 (spread (min max-col (ceiling (/ n-main (* 1.3 n-other)))))
+	 (main-commands (cdr (assq main commands-by)))
+	 (other-commands (cl-mapcan #'cdr (remove-if (lambda (lst)
+						       (eq (car lst) main))
+						     commands-by)))
+	 (other-from (ipython-notebook/prefix other-commands))
+	 (other-to (ipython-notebook/prefix other-commands :suffix-p t))
+	 (main-from (ipython-notebook/prefix main-commands))
+	 (main-to (ipython-notebook/prefix main-commands :suffix-p t)))
+    (cl-flet ((get-key (command) (car (rassoc (list command) bindings)))
+	      (massage (command from to)
+		       (let ((toks (split-string (symbol-name command) (regexp-quote "-"))))
+			 (mapconcat #'identity
+				    (subseq toks from (+ (length toks) to))
+				    "-"))))
+      (cl-macrolet ((rescol
+		     (result commands from to)
+		     `(let* ((key-width 10)
+			     (col-width 20)
+			     (format-str (format "%%-%ds%%-%ds" key-width col-width)))
+			(if-let ((command (pop ,commands)))
+			    (let ((massaged (massage command ,from ,to)))
+			      (setq ,result
+				    (concat ,result
+					    (format format-str
+						    (format "[_%s_]^^" (get-key command))
+						    (subseq massaged 0
+							    (min (length massaged) col-width))))))
+			  (setq ,result (concat ,result (format format-str "" "")))))))
+	(cl-loop
+	 with result = "\n"
+	 with betw = (make-string 1 ? )
+	 with col = 1
+	 if (= col spread)
+	 do (rescol result other-commands other-from other-to)
+	 and do (setq result (concat result "\n"))
+	 and do (setq col 1)
+	 else
+	 do (rescol result main-commands main-from main-to)
+	 and do (setq result (concat result betw))
+	 and do (cl-incf col)
+	 end
+	 until (and (null other-commands) (null main-commands))
+	 finally return result)))))

--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -26,6 +26,10 @@
         (kbd "<C-return>") 'ein:worksheet-execute-cell-km
         (kbd "<S-return>") 'ein:worksheet-execute-cell-and-goto-next-km))
      '(insert hybrid normal))
+    (evil-define-minor-mode-key
+     'normal 'ein:notebook-mode
+     "gj" 'ein:worksheet-goto-next-input-km
+     "gk" 'ein:worksheet-goto-prev-input-km)
     (with-eval-after-load 'ein-notebook
       (evil-define-key nil ein:notebooklist-mode-map "o" 'spacemacs/ace-buffer-links)
       (let ((bindings '(("j" ein:worksheet-goto-next-input-km)

--- a/layers/+lang/ipython-notebook/packages.el
+++ b/layers/+lang/ipython-notebook/packages.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(setq ipython-notebook-packages '(ein ob-ipython))
+(setq ipython-notebook-packages '(ein))
 
 (defun ipython-notebook/init-ein ()
   (use-package ein
@@ -58,18 +58,4 @@
                       (display-warning
                        'warn (format "ipython-notebook/init-ein: undefined %s"
                                      (cl-second bind))))))
-                (copy-tree bindings)))
-        (eval (append '(spacemacs|define-transient-state
-                        ipython-notebook
-                        :title "iPython Notebook Transient State"
-                        :bindings
-                        ("q" nil :exit t))
-                      bindings))))))
-
-(defun ipython-notebook/pre-init-ob-ipython ()
-  (spacemacs|use-package-add-hook org
-    :post-config
-    (use-package ob-ipython
-      :init (add-to-list 'org-babel-load-languages '(ipython . t)))))
-
-(defun ipython-notebook/init-ob-ipython ())
+                (copy-tree bindings)))))))


### PR DESCRIPTION
~Remove transient menu that requires expansive docstring.~
Reinstate transient menu with autogen docstring.
Remove unmaintained ob-ipython in favor of maintained ob-ein.
Reinstate `gk` and `gj`.