### PR TITLE
Fix reversed search direction after highlighting

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -138,7 +138,7 @@ If the universal prefix argument is used then kill also the window."
   (spacemacs/ahs-highlight-now-wrapper)
   (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p))
   (spacemacs/symbol-highlight-transient-state/body)
-  (spacemacs/integrate-evil-search nil))
+  (spacemacs/integrate-evil-search t))
 
 (defun spacemacs//ahs-ts-on-exit ()
   ;; Restore user search direction state as ahs has exitted in a state


### PR DESCRIPTION
To reproduce the problem:

- Start on a text buffer with the following text
```
aaa
aaa
aaa
aaa
```
- Place the cursor on the second line and enter symbol highlight transient state (`SPC s h`)
- Exit the transient state (by pressing `ESC` for example)
- Press `n`

At this point, I would expect the third line to be highlighted, but the cursor goes to the first one. Repeatedly pressing `n` after that makes it evident that we're stuck searching backwards.

I couldn't trace the purpose of that `nil` being set there, so may be missing something but TBH I don't see any reason for it being there instead of `t`. This change seems to be working fine for me but I'd still appreciate input on how to test for regressions!