### PR TITLE
[themes] add highly accessible themes - modus-{operandi, vivendi}

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3190,6 +3190,7 @@ Other:
 - Added =chocolate-theme= (thanks to Henrique Jung)
 - Updated =doom-themes= list to reflect upstream
   (thanks to Dominic Pearson, Muneeb Shaikh)
+- Added highly accessible =modus-themes= (thanks to Muneeb Shaikh)
 **** Tmux
 - Prevent =tmux-command= at GUI mode (thanks to Isaac Zeng)
 - Fixed regression in tmux by setting keybindings using =use-package=

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -228,6 +228,8 @@
     (majapahit-light                  . majapahit-theme)
     (material-light                   . material-theme)
     (minimal-light                    . minimal-theme)
+    (modus-operandi                   . modus-operandi-theme)
+    (modus-vivendi                    . modus-vivendi-theme)
     (moe-dark                         . moe-theme)
     (moe-light                        . moe-theme)
     (stekene-dark                     . stekene-theme)

--- a/layers/+themes/themes-megapack/packages.el
+++ b/layers/+themes/themes-megapack/packages.el
@@ -62,6 +62,8 @@
     majapahit-theme
     material-theme
     minimal-theme
+    modus-operandi-theme
+    modus-vivendi-theme
     moe-theme
     molokai-theme
     monokai-theme


### PR DESCRIPTION
[Modus themes](https://gitlab.com/protesilaos/modus-themes) are highly accessible themes for GNU Emacs, conforming with the highest accessibility standard for colour contrast between background and foreground values (WCAG AAA standard).

Screenshots: https://gitlab.com/protesilaos/modus-themes/-/wikis/Screenshots