### PR TITLE
[helpful] Keybinding: `o` (`link-hint-open-link`)

### DIFF
--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -26,4 +26,5 @@
               'append)
     :config
     (evil-set-initial-state 'helpful-mode 'normal)
+    (evil-define-key 'normal helpful-mode-map (kbd "o") 'link-hint-open-link)
     (evil-define-key 'normal helpful-mode-map (kbd "q") 'quit-window)))


### PR DESCRIPTION
Trivial binding for the same link behavior as Spacemacs does for the default `help-mode`.