### PR TITLE
[clojure] keybindings for browsing clojure specs

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1518,6 +1518,9 @@ Other:
   - added evaluation keybinding - go to end of line and evaluate sexp
     ~SPC m e $~ 'spacemacs/cider-eval-sexp-end-of-line
     ~SPC m e l~ 'spacemacs/cider-eval-sexp-end-of-line
+  - added browse-spec keybindings
+    ~SPC m h s~ 'cider-browse-spec
+    ~SPC m h S~ 'cider-browse-spec-all
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -475,6 +475,8 @@ Managing CIDER REPL connections and sessions
 | ~SPC m h j~ | cider javadoc               |
 | ~SPC m h n~ | cider browse namespace      |
 | ~SPC m h N~ | cider browse all namespaces |
+| ~SPC m h s~ | cider-browse-spec           |
+| ~SPC m h S~ | cider-browse-spec-all       |
 
 *** Evaluation
 Evaluate Clojure code in the source code buffer

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -99,6 +99,9 @@
             "hj" 'cider-javadoc
             "hn" 'cider-browse-ns
             "hN" 'cider-browse-ns-all
+            "hs" 'cider-browse-spec
+            "hS" 'cider-browse-spec-all
+
 
             ;; evaluate in source code buffer
             "e;" 'cider-eval-defun-to-comment


### PR DESCRIPTION
Keybindings to browse a specific clojure spec or browse all specs in a project.

Functions already existing, but no keybindings were assigned.