### PR TITLE
[spacemacs-language] improve google-translate user expirence

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1084,6 +1084,8 @@ Other:
   - Hide =spacemacs//= command prefixes in which-key (thanks to duianto)
   - Prevented removal of =eldoc= info when switching to insert state
     (thanks to Ivan Yonchovski)
+  - Improved google-translate for set source language to "auto" and
+    select target language interactively (thanks to Lin Sun)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-language/README.org
+++ b/layers/+spacemacs/spacemacs-language/README.org
@@ -19,7 +19,8 @@ This layer adds support various language related services to Spacemacs.
 | Key binding | Description                                              |
 |-------------+----------------------------------------------------------|
 | ~SPC x w d~ | Show definition of word at point                         |
-| ~SPC x g l~ | Set the source and target languages for google translate |
+| ~SPC x g l~ | Set the target language for google translate             |
+| ~SPC x g L~ | Set the source and target languages for google translate |
 | ~SPC x g Q~ | Send marked area to google translate as reverse query    |
 | ~SPC x g q~ | Send marked area to google translate as forward query    |
 | ~SPC x g T~ | Send word at point to google translate as reverse query  |

--- a/layers/+spacemacs/spacemacs-language/packages.el
+++ b/layers/+spacemacs/spacemacs-language/packages.el
@@ -25,24 +25,32 @@
     :commands (spacemacs/set-google-translate-languages)
     :init
     (progn
-      (defun spacemacs/set-google-translate-languages (source target)
+      (defun spacemacs/set-google-translate-languages (&optional override-p)
         "Set source language for google translate.
 For instance pass En as source for English."
-        (interactive
-         "sEnter source language (ie. en): \nsEnter target language (ie. en): "
-         source target)
-        (message
-         (format "Set google translate source language to %s and target to %s"
-                 source target))
-        (setq google-translate-default-source-language (downcase source))
-        (setq google-translate-default-target-language (downcase target)))
+        (interactive "P")
+        (autoload 'google-translate-read-args "google-translate-default-ui")
+        (let* ((langs (google-translate-read-args override-p nil))
+               (source-language (car langs))
+               (target-language (cadr langs)))
+          (setq google-translate-default-source-language source-language)
+          (setq google-translate-default-target-language target-language)
+          (message
+           (format "Set google translate source language to %s and target to %s"
+                   source-language target-language))))
+
+      (defun spacemacs/set-google-translate-target-language ()
+        "Set the target language for google translate."
+        (interactive)
+        (spacemacs/set-google-translate-languages nil))
+
       (spacemacs/set-leader-keys
-        "xgl" 'spacemacs/set-google-translate-languages
+        "xgL" 'spacemacs/set-google-translate-languages
+        "xgl" 'spacemacs/set-google-translate-target-language
         "xgQ" 'google-translate-query-translate-reverse
         "xgq" 'google-translate-query-translate
         "xgT" 'google-translate-at-point-reverse
         "xgt" 'google-translate-at-point)
       (setq google-translate-enable-ido-completion t)
       (setq google-translate-show-phonetic t)
-      (setq google-translate-default-source-language "en")
-      (setq google-translate-default-target-language "fr"))))
+      (setq google-translate-default-source-language "auto"))))


### PR DESCRIPTION
Hi @smile13241324 
The layer for google-translate using "en" as source language and using "fr" as target language, it's maybe confused someone who first use the translation feature. 
So I change the source language to "auto" and target language to "nil", that will prompt user select the target language.
User can set the target language by press `SPACE x g l`, or `SPACE x g L` to change both source/target language for google-translate.