### PR TITLE
Replaced doom-molokai with doom-monokai-classic

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -188,7 +188,7 @@
     (doom-laserwave                   . doom-themes)
     (doom-manegarm                    . doom-themes)
     (doom-material                    . doom-themes)
-    (doom-molokai                     . doom-themes)
+    (doom-monokai-classic             . doom-themes)
     (doom-moonlight                   . doom-themes)
     (doom-nord                        . doom-themes)
     (doom-nord-light                  . doom-themes)


### PR DESCRIPTION
Fixes #13370 .

Theme was replaced by another one upstream.