### PR TITLE
[core-themes] Add support for doom-monokai-pro

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -190,6 +190,7 @@
     (doom-material                    . doom-themes)
     (doom-molokai                     . doom-themes)
     (doom-monokai-classic             . doom-themes)
+    (doom-monokai-pro                 . doom-themes)
     (doom-moonlight                   . doom-themes)
     (doom-nord                        . doom-themes)
     (doom-nord-light                  . doom-themes)


### PR DESCRIPTION
Add support for `doom-monokai-pro` theme.