### PR TITLE
[themes][keybindings] Use apt completion framework for loading theme

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -417,6 +417,16 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
       (setq spacemacs--cur-theme theme))
     (spacemacs/post-theme-init theme)))
 
+(defun spacemacs/theme-loader ()
+  "Call appropriate theme loader based on completion framework."
+  (interactive)
+  (cond
+   ((configuration-layer/layer-used-p 'helm)
+    (call-interactively 'spacemacs/helm-themes))
+   ((configuration-layer/layer-used-p 'ivy)
+    (call-interactively 'counsel-load-theme))
+   (t (call-interactively 'load-theme))))
+
 (defun spacemacs/post-theme-init (theme)
   "Some processing that needs to be done when the current theme
 has been changed to THEME."

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -223,13 +223,13 @@
 ;; Cycling settings -----------------------------------------------------------
 (spacemacs|define-transient-state theme
   :title "Themes Transient State"
-  :doc "\n[_n_/_<right>_] next  [_N_/_p_/_<left>_] previous  [_t_/_<up>_] helm-themes"
+  :doc "\n[_n_/_<right>_] next  [_N_/_p_/_<left>_] previous  [_t_/_<up>_] list themes"
   :bindings
   ("n" spacemacs/cycle-spacemacs-theme)
   ("N" spacemacs/cycle-spacemacs-theme-backward)
   ("p" spacemacs/cycle-spacemacs-theme-backward)
-  ("t" helm-themes)
-  ("<up>" helm-themes)
+  ("t" spacemacs/theme-loader)
+  ("<up>" spacemacs/theme-loader)
   ("<right>" spacemacs/cycle-spacemacs-theme)
   ("<left>" spacemacs/cycle-spacemacs-theme-backward))
 (spacemacs/set-leader-keys "Tn"


### PR DESCRIPTION
Theme transient state key-binding `t` is broken if `ivy` completion framework is
used. The binding unconditionally invokes `helm-themes`.

This change adds a new function which takes care of invoking correct
theme-loader function based on completion framework currently in use.

The old binding used `helm-themes` but the new function uses already defined
`spacemacs/helm-themes` which removes the number of candidates limit.