### PR TITLE
replace custom ivy hydra-menu by original hydra-menu

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2146,6 +2146,8 @@ Other:
 - Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
 - Use new API to register additional transient state bindings
   (thanks to Andriy Kmit')
+- Replaced custom hydra-menu by original and updated hydra-menu, introducing
+  marking feature (thanks to Daniel Nicolai)
 - Initiate the transient state with ~M-SPC~ while in a =ivy= buffer
   (thanks to Rich Alesi)
 - Set =ivy-use-selectable-prompt= to =t= (thanks to Boris Buliga)

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -90,15 +90,21 @@ Some useful key bindings are presented in the following table.
 | ~C-M-k~     | kill buffer (in =ivy-switch-buffer= (~SPC b b~))                                                     |
 
 ** Transient state
-Press ~M-SPC~ anytime in Ivy to get into the transient state.
+Press ~M-SPC~ (~s-M-SPC~ [[https://github.com/syl20bnr/spacemacs/blob/cb48ec74c1f401bd2945760799633c0e81e69088/doc/CONVENTIONS.org#transient-state][on macOS]]) anytime in Ivy to get into the transient state. Additional actions
+are found in [[https://oremacs.com/swiper/#minibuffer-key-bindings][the Hydra section of the official manual]].
+
 
 | Key binding | Description                                             |
 |-------------+---------------------------------------------------------|
 | ~j~         | select next candidate                                   |
 | ~k~         | select previous candidate                               |
 | ~d~         | call default action on candidate                        |
+| ~f~         | call alternative action on candidate                    |
 | ~g~         | the same as ~d~ but doesn't close completion minibuffer |
 | ~o~         | leave transient state                                   |
+| ~m~         | mark candidate                                          |
+| ~u~         | unmark candidate                                        |
+| ~t~         | toggle marks                                            |
 
 ** Colors/Faces
 

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -135,63 +135,13 @@
     ;; key bindings
     ;; ensure that the correct bindings are set at startup
     (spacemacs//ivy-hjkl-navigation dotspacemacs-editing-style)
-    ;; Transient state
-    ;; ivy-hydra disabled for now, waiting to see how the dependency management
-    ;; evolves upstream
-    ;; (require 'ivy-hydra)
-    (spacemacs|define-transient-state ivy
-      :doc "
- Move/Resize^^^^      | Select Action^^^^   |  Call^^          |  Cancel^^    | Toggles
---^-^-^-^-------------|--^-^-^-^------------|--^---^-----------|--^-^---------|---------------------
- [_j_/_k_] by line    | [_s_/_w_] next/prev | [_RET_] & done   | [_i_] & ins  | [_C_] calling: %s(if ivy-calling \"on\" \"off\")
- [_g_/_G_] first/last | [_a_]^ ^  list all  | [_TAB_] alt done | [_q_] & quit | [_m_] matcher: %s(spacemacs//ivy-matcher-desc)
- [_d_/_u_] pg down/up |  ^ ^ ^ ^            | [_c_]   & cont   |  ^ ^         | [_f_] case-fold: %`ivy-case-fold-search
- [_<_/_>_] resize     |  ^ ^ ^ ^            | [_o_]   occur    |  ^ ^         | [_t_] truncate: %`truncate-lines
- [_h_/_l_] out/in dir |  ^ ^ ^ ^            |  ^ ^             |  ^ ^         |  ^ ^
-
-Current Action: %s(ivy-action-name)
-"
-      :foreign-keys run
-      :bindings
-      ;; arrows
-      ("j" ivy-next-line)
-      ("k" ivy-previous-line)
-      ("l" ivy-alt-done)
-      ("h" spacemacs/counsel-up-directory-no-error)
-      ("g" ivy-beginning-of-buffer)
-      ("G" ivy-end-of-buffer)
-      ("d" ivy-scroll-up-command)
-      ("u" ivy-scroll-down-command)
-      ;; actions
-      ("q" keyboard-escape-quit :exit t)
-      ("C-g" keyboard-escape-quit :exit t)
-      ("<escape>" keyboard-escape-quit :exit t)
-      ("i" nil)
-      ("C-o" nil)
-      ("M-SPC" nil)
-      ("TAB" ivy-alt-done :exit nil)
-      ;; ("C-j" ivy-alt-done :exit nil)
-      ;; ("d" ivy-done :exit t)
-      ("RET" ivy-done :exit t)
-      ("c" ivy-call)
-      ("C-m" ivy-done :exit t)
-      ("C" ivy-toggle-calling)
-      ("m" ivy-rotate-preferred-builders)
-      (">" ivy-minibuffer-grow)
-      ("<" ivy-minibuffer-shrink)
-      ("w" ivy-prev-action)
-      ("s" ivy-next-action)
-      ("a" ivy-read-action)
-      ("t" (setq truncate-lines (not truncate-lines)))
-      ("f" ivy-toggle-case-fold)
-      ("o" ivy-occur :exit t))
-    (define-key ivy-minibuffer-map "\C-o" 'spacemacs/ivy-transient-state/body)
-    (define-key ivy-minibuffer-map (kbd "M-SPC")
-      'spacemacs/ivy-transient-state/body)
-    (define-key ivy-minibuffer-map (kbd "s-M-SPC")
-      'spacemacs/ivy-transient-state/body)
-    (define-key ivy-minibuffer-map (kbd "s-M-SPC")
-      'spacemacs/ivy-transient-state/body)))
+    ;; load ivy-hydra
+    (require 'ivy-hydra)
+    ;; Using the original ivy-hydra might lead to some buggy behavior. Therefore
+    ;; previously a customized transient state was found here. This customized
+    ;; transient state was removed after commit
+    ;; d46eacd83842815b24afcb2e1fee5c80c38187c5
+    ))
 
 (defun spacemacs-completion/init-flx-ido ()
   (use-package flx-ido


### PR DESCRIPTION
Replaced the custom ivy hydra menu with the original (and updated) ivy hydra menu. Additionally checked parts of the documentation that required modification and applied them accordingly (no modifications were needed, only some additions)