### PR TITLE
[Helm] Pick up the symbol at point when do smart search with "rg"

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2022,8 +2022,8 @@ Other:
   - Added guard to check if =winum= is loaded (thanks to Dan Girshovich)
   - Updated =helm-xref= to set the correct =xref-show-xrefs-function= for
     Emacs 27 (thanks to Junxuan)
-  - Make "rg" backend pick up symbol at point for 
-    =spacemacs/helm-project-smart-do-search= (thanks to Lin Sun)
+  - Made the spacemacs/helm-files-do-rg pickup sympol at point to follow 
+    the behavior of spacemacs/helm-files-do-grep (thanks to Lin Sun)
 - Key bindings:
   - Added Key bindings for directory search:
     - ~SPC s d for =spacemacs/helm-dir-smart-do-search=

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2022,6 +2022,8 @@ Other:
   - Added guard to check if =winum= is loaded (thanks to Dan Girshovich)
   - Updated =helm-xref= to set the correct =xref-show-xrefs-function= for
     Emacs 27 (thanks to Junxuan)
+  - Make "rg" backend pick up symbol at point for 
+    =spacemacs/helm-project-smart-do-search= (thanks to Lin Sun)
 - Key bindings:
   - Added Key bindings for directory search:
     - ~SPC s d for =spacemacs/helm-dir-smart-do-search=

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -165,6 +165,7 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   ;; no --vimgrep because it adds column numbers that wgrep can't handle
   ;; see https://github.com/syl20bnr/spacemacs/pull/8065
   (let* ((root-helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number")
+         (helm-ag-insert-at-point (or helm-ag-insert-at-point 'symbol))
          (helm-ag-base-command (if spacemacs-helm-rg-max-column-number
                                    (concat root-helm-ag-base-command " --max-columns=" (number-to-string spacemacs-helm-rg-max-column-number))
                                  root-helm-ag-base-command)))


### PR DESCRIPTION
The `spacemacs/helm-project-smart-do-search' will pick up the symbol at point
when searching with "grep" backend, but pick up nothing when searching with "rg"
backend, here we make the "rg" backend has similar behavior as default backend.