### PR TITLE
fixed emacs major mode leader key binding

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -475,6 +475,9 @@ Other:
   - Removed obsolete =:powerline-scale= property from
     =dotspacemacs-default-font= variable
     (thanks to Muneeb Shaikh and Sylvain Benner)
+  - Modified =dotspacemacs-major-mode-leader-key= so that =M-RET= key works in
+    org-mode as well as in terminal and GUI modes. =C-M-m= still works in
+    terminal mode, but no longer in GUI mode. (emacs18)
 *** Core changes
 - Improvements:
   - Display time spent in =user-config= in home buffer (thanks to Sylvain Benner)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -234,8 +234,10 @@ It should only modify the values of Spacemacs settings."
    dotspacemacs-major-mode-leader-key ","
 
    ;; Major mode leader key accessible in `emacs state' and `insert state'.
-   ;; (default "C-M-m")
-   dotspacemacs-major-mode-emacs-leader-key "C-M-m"
+   ;; (default "C-M-m" for terminal mode, "<M-return>" for GUI mode).
+   ;; Thus M-RET should work as leader key in both GUI and terminal modes.
+   ;; C-M-m also should work in terminal mode, but not in GUI mode.
+   dotspacemacs-major-mode-emacs-leader-key (if window-system "<M-return>" "C-M-m")
 
    ;; These variables control whether separate commands are bound in the GUI to
    ;; the key pairs `C-i', `TAB' and `C-m', `RET'.


### PR DESCRIPTION
Allow M-RET key to work as major mode emacs leader key for both GUI and terminal modes.
This should fix #13374.

The current value of "C-M-m" as leader key works only in terminal mode, but not in GUI mode.
That is why we set this to "<M-return>" for GUI mode, and to "C-M-m" for terminal mode.

