### PR TITLE
Fix spacemacs/open-junk-file

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -636,6 +636,8 @@ Other:
   - Ignore nils in dotspacemacs-configuration-layers (thanks to Ag)
   - Fixed redundant package version checking during update
     (thanks to aaronjensen)
+  - Fixed unexpected behavior in =spacemacs/open-junk-file= (thanks to Matt
+    Kramer)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -431,15 +431,23 @@ indent handling like has been reported for `go-mode'.
 If it does deactivate it here.
 (default t)")
 
+(defvar dotspacemacs--pretty-ignore-subdirs
+  '(".cache/junk")
+  "Subdirectories of `spacemacs-start-directory' to ignore when
+  prettifying Org files.")
+
 (defun dotspacemacs//prettify-spacemacs-docs ()
   "Run `spacemacs/prettify-org-buffer' if `buffer-file-name'
-has `spacemacs-start-directory'"
+looks like Spacemacs documentation."
   (when (and dotspacemacs-pretty-docs
              spacemacs-start-directory
-             buffer-file-name
-             (string-prefix-p (expand-file-name spacemacs-start-directory)
-                              (expand-file-name buffer-file-name)))
-    (spacemacs/prettify-org-buffer)))
+             buffer-file-name)
+    (let ((start-dir (expand-file-name spacemacs-start-directory))
+          (buf-path (expand-file-name buffer-file-name)))
+      (when (and (string-prefix-p start-dir buf-path)
+                 (not (--any? (string-prefix-p (expand-file-name it start-dir) buf-path)
+                              dotspacemacs--pretty-ignore-subdirs)))
+        (spacemacs/prettify-org-buffer)))))
 
 ;; only for backward compatibility
 (defalias 'dotspacemacs-mode 'emacs-lisp-mode)

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -322,7 +322,11 @@ When ARG is non-nil search in junk files."
            (spacemacs/counsel-search dotspacemacs-search-tools nil junk-dir))
           ((configuration-layer/layer-used-p 'ivy)
            (require 'counsel)
-           (counsel-find-file rel-fname))
+           ;; HACK: If major-mode is dired, counsel will use
+           ;; (dired-current-directory) instead of default-directory. So, trick
+           ;; counsel by shadowing major-mode.
+           (let ((major-mode nil))
+             (counsel-find-file rel-fname)))
           (arg
            (require 'helm)
            (let (helm-ff-newfile-prompt-p)

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -317,6 +317,7 @@ When ARG is non-nil search in junk files."
          (rel-fname (file-name-nondirectory fname))
          (junk-dir (file-name-directory fname))
          (default-directory junk-dir))
+    (make-directory junk-dir t)
     (cond ((and arg (configuration-layer/layer-used-p 'ivy))
            (spacemacs/counsel-search dotspacemacs-search-tools nil junk-dir))
           ((configuration-layer/layer-used-p 'ivy)


### PR DESCRIPTION
I've encountered three "problems" with `spacemacs/open-junk-file`:

1. If the junk directory doesn't exist, it will *not* be automatically created. Instead, you'll get prompted to create it when you save the junk file. It's not a huge inconvenience, just slightly annoying, but it runs contrary to the behavior of `open-junk-file`, which *does* create the directory. This PR makes `spacemacs/open-junk-file` behave consistently to `open-junk-file`.

2. If you're using Ivy, and you call `spacemacs/open-junk-file` from a Dired buffer, you'll be prompted to create a file within the Dired directory, instead of in the junk directory. This PR uses a one-line hack to force Counsel to use the correct directory.

3. If the junk file is an Org file, and your junk folder is the default (i.e. `.cache/junk`), `spacemacs/prettify-org-buffer` will be called (activating `space-doc-mode` etc.), since the path lies within `spacemacs-start-directory`. Personally I never want space-doc-mode to be active in my personal Org files. This PR adds the variable `dotspacemacs--pretty-ignore-subdirs` with the default value `'(".cache/junk")`, and modifies `dotspacemacs//prettify-spacemacs-docs` accordingly.