### PR TITLE
fix issue #13395

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -136,7 +136,7 @@
     ;; ensure that the correct bindings are set at startup
     (spacemacs//ivy-hjkl-navigation dotspacemacs-editing-style)
     ;; load ivy-hydra
-    (require 'ivy-hydra)
+    ;; (require 'ivy-hydra)
     ;; Using the original ivy-hydra might lead to some buggy behavior. Therefore
     ;; previously a customized transient state was found here. This customized
     ;; transient state was removed after commit


### PR DESCRIPTION
Ivy-hydra is autoloaded so the require statement here is unnecessary. Because this require (commented out) statement was here before I uncommented it in the last PR (#13377), I leave it here (commented out) as it was before that PR.