### PR TITLE
[helpful] Bindings and documentation improvement

### DIFF
--- a/layers/+emacs/helpful/README.org
+++ b/layers/+emacs/helpful/README.org
@@ -7,6 +7,8 @@
   - [[#features][Features:]]
 - [[#install][Install]]
 - [[#key-bindings][Key bindings]]
+  - [[#global-bindings][Global bindings]]
+  - [[#helpful-mode-bindings][Helpful mode bindings]]
 
 * Description
 This layer replaces the existing emacs related help buffers with more detailed ones.
@@ -23,6 +25,7 @@ add =helpful= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 * Key bindings
+** Global bindings
 This layer aims to silently replace the standard emacs help key bindings
 with improved versions. So it does not introduce new bindings.
 For the sake of completion you can find below all keys which are replaced
@@ -34,3 +37,14 @@ by this layer.
 | =SPC h d k= | Open helpful buffer for key binding                    |
 | =SPC h d f= | Open helpful buffer for any callable object            |
 | =SPC h h v= | Open helpful buffer for variable                       |
+
+
+** Helpful mode bindings
+Additional keybindings available in the helpful-mode buffers.
+
+| Key binding | Description                                        |
+|-------------+----------------------------------------------------|
+| =SPC m q=   | Close all helpful-mode buffers                     |
+| =gr=        | Reload the buffer (e.g. to see new variable value) |
+| =o=         | Open link with Avy                                 |
+| =q=         | Close window (buffer is kept in background)        |

--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -12,6 +12,7 @@
 (defconst helpful-packages
   '(
     helpful
+    link-hint
     popwin
     ))
 
@@ -29,8 +30,14 @@
               'append)
     :config
     (evil-set-initial-state 'helpful-mode 'normal)
-    (evil-define-key 'normal helpful-mode-map (kbd "o") 'link-hint-open-link)
+    (spacemacs/set-leader-keys-for-major-mode 'helpful-mode
+      (kbd "q") 'helpful-kill-buffers)
+    (evil-define-key 'normal helpful-mode-map (kbd "gr") 'helpful-update)
     (evil-define-key 'normal helpful-mode-map (kbd "q") 'quit-window)))
+
+(defun helpful/post-init-link-hint ()
+  (with-eval-after-load 'helpful
+    (evil-define-key 'normal helpful-mode-map (kbd "o") 'link-hint-open-link)))
 
 (defun helpful/post-init-popwin ()
   (push '(helpful-mode :dedicated t :position bottom :stick t :noselect t :height 0.4)


### PR DESCRIPTION
New bindings:
`gr` - `helpful-update`, reload helpful buffer.
`SPC m q` - `helpful-kill-buffers`, kill all helpful buffers.

Move `o` binding definition into separate post-init function, so the binding
is defined only if the `link-hint` package is actually installed.

Add documentation of the added bindings.

