### PR TITLE
Fix "erg-journal" typo introduced in 48ac607e71

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -223,7 +223,7 @@ For example:
     (org :variables
         org-enable-org-journal-support t
         org-journal-dir "~/org/journal/"
-        erg-journal-file-format "%Y-%m-%d"
+        org-journal-file-format "%Y-%m-%d"
         org-journal-date-prefix "#+TITLE: "
         org-journal-date-format "%A, %B %d %Y"
         org-journal-time-prefix "* "


### PR DESCRIPTION
This typo was introduced in 48ac607e71ceca347eef985a40ca73550e3e99b5