### PR TITLE
Add dap-go integration

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1936,6 +1936,7 @@ Other:
   - Added setup instructions for =gopls= (thanks to pancho horrillo)
   - Make flycheck disable checkers covered by golangci (thanks to zhuoyikang)
   - Updated build instructions for =golangci-lint= (thanks to pancho horrillo)
+  - Added =dap-go= integration (ljupchokotev)
 - Key bindings
   - =godoctor= key bindings (thanks to TinySong and Eivind Fonn):
     - ~SPC m r n~ to rename

--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -41,6 +41,7 @@ This layer adds extensive support for the [[https://golang.org][Go]] programming
 - List packages faster with [[https://github.com/haya14busa/gopkgs][gopkgs]]
 - Fill a structure with default values using the [[https://github.com/davidrjenni/reftools/tree/master/cmd/fillstruct][fillstruct]]
 - LSP backend (see [[#lsp-backend][LSP backend]])
+- Interactive debugger using [[https://github.com/emacs-lsp/dap-mode][dap-mode]]
 
 * Install
 ** Layer
@@ -222,6 +223,10 @@ The backend can be chosen on a per project basis using directory local variables
 #+END_SRC
 
 *Note:* you can easily add a directory local variable with ~SPC f v d~.
+
+*** Debugger
+
+Using the =dap= layer you'll get access to all the DAP key bindings, see the complete list of key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/dap#key-bindings][dap layer description]].
 
 * Working with Go
 ** Go commands (start with =m=):

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -33,6 +33,13 @@
   (pcase (spacemacs//go-backend)
     ('go-mode (go-eldoc-setup))))
 
+
+(defun spacemacs//go-setup-dap ()
+  "Conditionally setup go DAP integration."
+  ;; currently DAP is only available using LSP
+  (pcase (spacemacs//go-backend)
+    (`lsp (spacemacs//go-setup-lsp-dap))))
+
 
 ;; go-mode
 
@@ -71,6 +78,11 @@
           :call-hooks t)
         (company-mode))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//go-setup-lsp-dap ()
+  "Setup DAP integration."
+  (require 'dap-go)
+  (dap-go-setup))
 
 
 ;; flycheck

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -12,6 +12,7 @@
 (setq go-packages
       '(
         company
+        dap-mode
         (company-go :requires company)
         counsel-gtags
         eldoc
@@ -42,6 +43,10 @@
 
 (defun go/post-init-company ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs//go-setup-company))
+
+(defun go/pre-init-dap-mode ()
+  (add-to-list 'spacemacs--dap-supported-modes 'go-mode)
+  (add-hook 'go-mode-local-vars-hook #'spacemacs//go-setup-lsp-dap))
 
 (defun go/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'go-mode))


### PR DESCRIPTION
Going by the Java layer which already has `dap-mode` integration, adding the same for the `go` layer.