### PR TITLE
[clojure] Pretty print evaluation keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1533,6 +1533,12 @@ Other:
   - added browse-spec keybindings
     ~SPC m h s~ 'cider-browse-spec
     ~SPC m h S~ 'cider-browse-spec-all
+  - added evaluation keybinding - pretty print // as comment
+    ~SPC m e p ;~ 'cider-pprint-eval-defun-to-comment
+    ~SPC m e p :~ 'cider-pprint-eval-last-sexp-to-comment
+    ~SPC m e p f~ 'cider-pprint-eval-defun-at-point
+    ~SPC m e p e~ 'cider-pprint-eval-last-sexp
+    (thanks to John Stevenson)
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -481,25 +481,27 @@ Managing CIDER REPL connections and sessions
 *** Evaluation
 Evaluate Clojure code in the source code buffer
 
-| Key binding | Description                                                       |
-|-------------+-------------------------------------------------------------------|
-| ~SPC m e ;~ | eval sexp and show result as comment                              |
-| ~SPC m e $~ | go to end of line and eval last sexp                              |
-| ~SPC m e b~ | eval buffer                                                       |
-| ~SPC m e e~ | eval last sexp                                                    |
-| ~SPC m e f~ | eval function at point                                            |
-| ~SPC m e i~ | interrupt the current evaluation                                  |
-| ~SPC m e l~ | go to end of line and eval last sexp                              |
-| ~SPC m e m~ | cider macroexpand 1                                               |
-| ~SPC m e M~ | cider macroexpand all                                             |
-| ~SPC m e n~ | refresh namespace (cider-ns-refresh)                              |
-| ~SPC m e N~ | reload namespace (cider-ns-reload), ~SPC u~ (cider-ns-reload-all) |
-| ~SPC m e p~ | eval top-level sexp, pretty print result in separate buffer       |
-| ~SPC m e P~ | eval last sexp, pretty print result in separate buffer            |
-| ~SPC m e r~ | eval region                                                       |
-| ~SPC m e u~ | Undefine a symbol from the current namespace                      |
-| ~SPC m e v~ | eval sexp around point                                            |
-| ~SPC m e w~ | eval last sexp and replace with result                            |
+| Key binding   | Description                                                       |
+|---------------+-------------------------------------------------------------------|
+| ~SPC m e ;~   | eval sexp and show result as comment                              |
+| ~SPC m e $~   | go to end of line and eval last sexp                              |
+| ~SPC m e b~   | eval buffer                                                       |
+| ~SPC m e e~   | eval last sexp                                                    |
+| ~SPC m e f~   | eval function at point                                            |
+| ~SPC m e i~   | interrupt the current evaluation                                  |
+| ~SPC m e l~   | go to end of line and eval last sexp                              |
+| ~SPC m e m~   | cider macroexpand 1                                               |
+| ~SPC m e M~   | cider macroexpand all                                             |
+| ~SPC m e n~   | refresh namespace (cider-ns-refresh)                              |
+| ~SPC m e N~   | reload namespace (cider-ns-reload), ~SPC u~ (cider-ns-reload-all) |
+| ~SPC m e p ;~ | eval top-level sexp, pretty print result as a comment             |
+| ~SPC m e p :~ | eval last sexp, pretty print result as a comment                  |
+| ~SPC m e p f~ | eval top-level sexp, pretty print result in separate buffer       |
+| ~SPC m e p e~ | eval last sexp, pretty print result in separate buffer            |
+| ~SPC m e r~   | eval region                                                       |
+| ~SPC m e u~   | Undefine a symbol from the current namespace                      |
+| ~SPC m e v~   | eval sexp around point                                            |
+| ~SPC m e w~   | eval last sexp and replace with result                            |
 
 *** Goto
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -67,6 +67,7 @@
                ("m=e" . "edn")
                ("md" . "debug")
                ("me" . "evaluation")
+               ("mep" . "pretty print")
                ("mg" . "goto")
                ("mh" . "documentation")
                ("mm" . "manage repls")
@@ -115,8 +116,10 @@
             "eM" 'cider-macroexpand-all
             "en" 'cider-ns-refresh
             "eN" 'cider-ns-reload  ;; SPC u for cider-ns-reload-all
-            "ep" 'cider-pprint-eval-defun-at-point
-            "eP" 'cider-pprint-eval-last-sexp
+            "ep;" 'cider-pprint-eval-defun-to-comment
+            "ep:" 'cider-pprint-eval-last-sexp-to-comment
+            "epf" 'cider-pprint-eval-defun-at-point
+            "epe" 'cider-pprint-eval-last-sexp
             "er" 'cider-eval-region
             "eu" 'cider-undef
             "ev" 'cider-eval-sexp-at-point


### PR DESCRIPTION
Show results of evaluating Clojure code in the same format they would be written
in the source code.  This is especially useful for results that are
collections and nested collections.

Pretty print results as a comment.
