### PR TITLE
Replace org-ref-helm-insert-cite-link with org-ref-insert-link

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1343,6 +1343,10 @@ Other:
 **** Autohotkey
 - Key bindings:
   - Added names to autohotkey mode prefixes (thanks to Ying Qu)
+**** BibTeX
+- Key bindings:
+  - Replaced =org-ref-helm-insert-cite-link= with =org-ref-insert-link=
+    (thanks to Tianshu Wang)
 **** C-C++
 - Breaking changes:
   - Moved =cmake-ide= and cmake script support to separate =cmake= layer

--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -22,11 +22,11 @@
 
 (defun bibtex/post-init-auctex ()
   (spacemacs/set-leader-keys-for-major-mode 'latex-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+    "ic" 'org-ref-insert-link))
 
 (defun bibtex/post-init-org ()
   (spacemacs/set-leader-keys-for-major-mode 'org-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+    "ic" 'org-ref-insert-link))
 
 (defun bibtex/init-org-ref ()
   (use-package org-ref
@@ -79,7 +79,7 @@
 
 (defun bibtex/post-init-markdown-mode ()
   (spacemacs/set-leader-keys-for-major-mode 'markdown-mode
-    "ic" 'org-ref-helm-insert-cite-link))
+    "ic" 'org-ref-insert-link))
 
 (defun bibtex/init-helm-bibtex ())
 (defun bibtex/init-biblio ())


### PR DESCRIPTION
replace `org-ref-helm-insert-cite-link-with` with a more general function `org-ref-insert-link`, incase someone prefers others completion library as `org-ref-completion-library` instead of `org-ref-helm-bibtex`.