### PR TITLE
[chrome] Add link to more details about chrome jquery workaround in docs

### DIFF
--- a/layers/+tools/chrome/README.org
+++ b/layers/+tools/chrome/README.org
@@ -74,3 +74,4 @@ The following example works on macOS:
 | ~SPC a F~   | flymd-flyit |
 
 *Note:* You need to kill all google chrome process before using =flymd-flyit=.
+For details, see the upstream [[https://github.com/mola-T/flymd/blob/master/browser.md][flymd browser compatibility notes]].


### PR DESCRIPTION
We probably want to update the `markdown` layer to be able to do this directly
with `firefox`; having to kill and restart all of your `chrome` processes before
using `flymd` is a little clunky! It's nice that we have the upstream workaround
inlined in spacemacs, though.