### PR TITLE
[org] Remove obsolete fix, helm-ag unfold org line

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2079,8 +2079,6 @@ Other:
     (thanks to Codruț Constantin Gușoi)
   - Fixed =spacemacs//helm-open-buffers-in-windows= when opening more files than
     available windows (thanks to Juha Jeronen)
-  - Unfolded org headings to a target line when a .org file is opened from
-    Helm-ag (thanks to duianto and Miciah Masters)
   - Fixed searching in a project with ~C-s~ from ~SPC p p~ (thanks to duianto)
   - Fixed ~C-c C-e~ =helm-find-files-edit= action (thanks to duianto)
   - Added =spacemacs/helm-dir-do-grep= to fix #13167 (thanks to Richard Kim)

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -440,14 +440,6 @@ Will work on both org-mode and any mode that accepts plain html."
         ("e" org-babel-execute-maybe :exit t)
         ("'" org-edit-special :exit t)))))
 
-(defun org/post-init-org ()
-  ;; unfold the org headings for a target line
-  ;; There's a pending upstream PR:
-  ;; Use helm-goto-char to show match and reveal outlines
-  ;; https://github.com/syohex/emacs-helm-ag/pull/304
-  ;; when/if it's accepted, then this advice can be removed.
-  (advice-add 'helm-ag--find-file-action :after #'spacemacs/org-reveal-advice))
-
 (defun org/init-org-agenda ()
   (use-package org-agenda
     :defer t


### PR DESCRIPTION
It's been fixed upstream.
Use helm-goto-char to show match and reveal outlines
https://github.com/emacsorphanage/helm-ag/pull/304