### PR TITLE
Fix bug with keyboard-layout layer an bépo layout

### DIFF
--- a/layers/+intl/keyboard-layout/funcs.el
+++ b/layers/+intl/keyboard-layout/funcs.el
@@ -53,8 +53,7 @@ then `c' will be defined to the old `a' function, not to `b'."
           (dolist (binding bindings)
             (let ((key1 (kbd (car binding)))
                   (key2 (kbd (cdr binding))))
-              (if (keymapp map)
-                  (define-key map key1 (lookup-key map-original key2)))))))))
+              (define-key map key1 (lookup-key map-original key2))))))))
 
 (defun kl//replace-in-list-rec (lst elem repl)
   "Replace recursively all occurrences of `elem' by `repl' in the

--- a/layers/+intl/keyboard-layout/funcs.el
+++ b/layers/+intl/keyboard-layout/funcs.el
@@ -46,12 +46,15 @@ the given MAPS."
   "Define keys to the associated definitions of other ones. All
 remapping are done atomically, i.e. if `a' -> `b' and `c' -> `a',
 then `c' will be defined to the old `a' function, not to `b'."
-  (declare (indent 1))
-  (let ((map-original (copy-tree map)))
-    (dolist (binding bindings)
-      (let ((key1 (kbd (car binding)))
-            (key2 (kbd (cdr binding))))
-        (define-key map key1 (lookup-key map-original key2))))))
+  (if (keymapp map)
+      (progn
+        (declare (indent 1))
+        (let ((map-original (copy-tree map)))
+          (dolist (binding bindings)
+            (let ((key1 (kbd (car binding)))
+                  (key2 (kbd (cdr binding))))
+              (if (keymapp map)
+                  (define-key map key1 (lookup-key map-original key2)))))))))
 
 (defun kl//replace-in-list-rec (lst elem repl)
   "Replace recursively all occurrences of `elem' by `repl' in the


### PR DESCRIPTION
When the bépo layout is set from the `keyboard-layout` layer, the message `(wrong-type-argument keymapp nil)` shows up. After some digging, it turns out Spacemacs tries to set shortcuts for `nil` `map` variables in this function.

This commit ensures it is impossible to try to set a shortcut for an inexisting keymap.

However, I think some investigation should be done as to why Spacemacs tries to set keyboard shortcut for empty keymaps.

This commit has been tested with Emacs 27.0.90 with the latest Spacemacs develop commit at the time of my own commit.