### PR TITLE
add and document org-journal scheduled(-view) shortcuts

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2552,6 +2552,7 @@ Other:
   (thanks to Steven Allen)
 - Packages:
   - Added package =org-journal= (thanks to Nick Anderson)
+    - Added shortcuts for handling scheduled entries (thanks to Daniel Nicolai)
   - Added package for =org-sticky-header-mode= (thanks to Langston Barret)
   - Added package =org-jira= (thanks to Kirill A. Korinsky)
 - Key bindings:

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -767,6 +767,8 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 | ~SPC a o j j~       | New journal entry                               |
 | ~SPC u SPC a o j j~ | Open today's journal without adding a new entry |
 | ~SPC a o j s~       | Search journal entries                          |
+| ~SPC a o j t~       | New scheduled journal entry                     |
+| ~SPC a o j v~       | View scheduled journal entries                  |
 
 Journal entries are highlighted in the calendar. The following key bindings are
 available for =calendar-mode= for navigating and manipulating the journal.

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -761,7 +761,9 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (spacemacs/declare-prefix "aoj" "org-journal")
       (spacemacs/set-leader-keys
         "aojj" 'org-journal-new-entry
-        "aojs" 'org-journal-search-forever)
+        "aojs" 'org-journal-search-forever
+        "aojt" 'org-journal-new-scheduled-entry
+        "aojv" 'org-journal-schedule-view)
 
       (setq spacemacs-org-journal-mode-map (copy-keymap spacemacs-org-mode-map))
 


### PR DESCRIPTION
`org-journal-new-scheduled-entry` and `org-journal-schedule-view` are both basic org-journal features.  `SPC a o j t` adds `t` for TODO under the org-journal prefix (`t` because it adds a TODO). 

Besides providing these shortcuts, their (self-)documentation exposes this functionality to the user.