### PR TITLE
[easypg] keybindings using spacebind

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1008,6 +1008,8 @@ Other:
       - ~n~ =evil-search-next=
       - ~N~ =evil-search-previous=
   - Added ~SPC x d l~ =delete-blank-lines= (thanks to duianto)
+  - Added keybindings for Easy PG built in Emacs application
+   (thanks to John Stevenson)
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -20,6 +20,7 @@ defaults.
   - dired-x
   - display-line-numbers (only in Emacs 26.x and newer)
   - electric-indent-mode
+  - easypg
   - ediff
   - eldoc
   - help-fns+

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -179,6 +179,27 @@
   "ap"  'list-processes
   "aP"  'proced
   "au"  'undo-tree-visualize)
+;; easy pg ----------------------------------------------------------------------
+(spacemacs|spacebind
+ "Encrypt / decrypt files with Easy PG"
+ :global
+ (("a" "applications"
+   ("e"  "easy pg"
+    ("d" epa-decrypt-file "Decrypt file to...")
+    ("D" epa-delete-keys  "Delete keys...")
+    ("e" epa-encrypt-file "Encrypt file...")
+    ("i" epa-insert-keys  "Insert keys...")
+    ("k" epa-list-keys "List keys...")
+    ("K" epa-list-secret-keys "List secret keys...")
+    ("x" epa-export-keys "Export keys...")
+    ("s"  "sign"
+     ("f" epa-sign-file "Sign file...")
+     ("m" epa-sign-mail "Sign mail...")
+     ("r" epa-sign-region "Sign region..."))
+    ("v"  "verify"
+     ("f" epa-verify-file "Verify file...")
+     ("r" epa-verify-region "Verify region...")
+     ("c" epa-verify-cleartext-in-region "Verify cleartext region..."))))))
 ;; buffers --------------------------------------------------------------------
 (spacemacs|spacebind
  "Compare buffers, files and directories."


### PR DESCRIPTION
Add keybindings for the built in Emacs application called Easy PG, that provides
tools to encrypt/decrypt/sign/verify files and regions using PGP encryption.

Keybindings are defined using spacebind.

Resolves #13319 