### PR TITLE
core: revise core-jump

### DIFF
--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -13,15 +13,24 @@
   "List of jump handlers available in every mode.")
 
 (defvar-local spacemacs-jump-handlers '()
-  "List of jump handlers local to this buffer.")
+  "List of jump handlers local to this buffer.
+
+Jump handlers in this list has the highest priority. A jump
+handler jump-hanlder can add be registered by making this call
+from a mode hook:
+
+\(add-to-list 'spacemacs-jump-handlers 'jump-hanlder\)
+
+Handler in is list is called first so only dynamic handlers like
+`lsp' should use this one. Conventional jump handlers should use
+`spacemacs-jump-handlers-MODE' instead.")
 
 (defmacro spacemacs|define-jump-handlers (mode &rest handlers)
   "Defines jump handlers for the given MODE.
+
 This defines a variable `spacemacs-jump-handlers-MODE' to which
-handlers can be added, and a function added to MODE-hook which
-sets `spacemacs-jump-handlers' in buffers of that mode."
+handlers can be added. MODE must be a major mode."
   (let ((mode-hook (intern (format "%S-hook" mode)))
-        (func (intern (format "spacemacs//init-jump-handlers-%S" mode)))
         (handlers-list (intern (format "spacemacs-jump-handlers-%S" mode))))
     `(progn
        (defvar ,handlers-list ',handlers
@@ -29,11 +38,6 @@ sets `spacemacs-jump-handlers' in buffers of that mode."
                           "These take priority over those in "
                           "`spacemacs-default-jump-handlers'.")
                   mode))
-       (defun ,func ()
-         (setq spacemacs-jump-handlers
-               (append ,handlers-list
-                       spacemacs-default-jump-handlers)))
-       (add-hook ',mode-hook ',func)
        (with-eval-after-load 'bind-map
          (spacemacs/set-leader-keys-for-major-mode ',mode
            "gg" 'spacemacs/jump-to-definition
@@ -62,13 +66,27 @@ sets `spacemacs-reference-handlers' in buffers of that mode."
          (spacemacs/set-leader-keys-for-major-mode ',mode
            "gr" 'spacemacs/jump-to-reference)))))
 
+(defun spacemacs//get-jump-handlers ()
+  "Combine all jump handlers into a list.
+
+They are in order: `spacemacs-jump-handlers',
+`spacemacs-jump-handlers-MAJOR-MODE',
+`spacemacs-default-jump-handlers'."
+  (let ((handlers-major-mode-list (intern (format "spacemacs-jump-handlers-%S"
+                                                  major-mode))))
+    (append spacemacs-jump-handlers
+            (if (boundp handlers-major-mode-list)
+                (symbol-value handlers-major-mode-list)
+              '())
+            spacemacs-default-jump-handlers)))
+
 (defun spacemacs/jump-to-definition ()
   "Jump to definition around point using the best tool for this action."
   (interactive)
   (catch 'done
     (let ((old-buffer (current-buffer))
           (old-point (point)))
-      (dolist (-handler spacemacs-jump-handlers)
+      (dolist (-handler (spacemacs//get-jump-handlers))
         (let ((handler (if (listp -handler) (car -handler) -handler))
               (async (when (listp -handler)
                        (plist-get (cdr -handler) :async))))


### PR DESCRIPTION
`spacemacs|define-jump-handlers` only defines a variable
`spacemacs-jump-handlers-MODE` to which handlers can be added and sets up key
bindings for mode. MODE must be a major mode,. It won't add function to mode
hook anymore.

`jump-to-definition` will walk through the three lists of handlers in the
following order: `spacemacs-jump-handlers`, `spacemacs-jump-handlers-MODE`, and
finally `spacemacs-default-jump-handlers`.

Dynamic handlers like `lsp`, `tide`, `ggtags` use `spacemacs-jump-handlers` to register
``` elisp
(add-to-list 'spacemacs-jump-handlers 'jump-hanlder)
```
Conventional static handlers should use spacemacs-jump-handlers-MODE

This commit fixes the race condition issue found in https://github.com/syl20bnr/spacemacs/commit/2088eb67a9df93260255495af31b36e6b3bb549a.

My discussion on it: https://github.com/syl20bnr/spacemacs/commit/2088eb67a9df93260255495af31b36e6b3bb549a#commitcomment-38206896
