### PR TITLE
[imenu-list] Added keybinding to focus the imenu-list sidebar, creating if necessary.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -173,6 +173,12 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - Swapped key bindings for better usability (thanks to Tony Lotts):
     - ~SPC m s s~ for =haskell-interactive-switch=
     - ~SPC m s S~ for =spacemacs/haskell-interactive-bring=
+***** imenu-list
+- Improvements:
+  - Added function/binding to focus the imenu sidebar, creating it if none found.
+- Key bindings:
+  - Bound new focus function under ~SPC b i~
+  - Moved existing toggle binding to ~SPC T i~ (from ~SPC b t~)
 ***** LSP
 - Key bindings;
   - Change jump back to last mark from ~SPC m g p~ to ~SPC m g b~

--- a/layers/+tools/imenu-list/README.org
+++ b/layers/+tools/imenu-list/README.org
@@ -31,9 +31,10 @@ this file.
 * Key bindings
 ** From any buffer
 
-| Key binding | Description              |
-|-------------+--------------------------|
-| ~SPC b t~   | toggle imenu tree window |
+| Key binding | Description                                      |
+|-------------+--------------------------------------------------|
+| ~SPC b i~   | focus imenu tree sidebar (creating if necessary) |
+| ~SPC T i~   | toggle imenu tree sidebar                        |
 
 ** From imenu-list buffer
 

--- a/layers/+tools/imenu-list/funcs.el
+++ b/layers/+tools/imenu-list/funcs.el
@@ -1,0 +1,9 @@
+(defun spacemacs/imenu-list-smart-focus ()
+  "Focus the `imenu-list' buffer, creating as necessary.
+If the imenu-list buffer is displayed in any window, focus it, otherwise create and focus.
+Note that all the windows in every frame searched, even invisible ones, not
+only those in the selected frame."
+  (interactive)
+  (if (get-buffer-window imenu-list-buffer-name t)
+      (imenu-list-show)
+    (imenu-list-smart-toggle)))

--- a/layers/+tools/imenu-list/packages.el
+++ b/layers/+tools/imenu-list/packages.el
@@ -24,13 +24,15 @@
   (use-package imenu-list
     :defer t
     :init
-    (progn
-      (setq imenu-list-focus-after-activation t
-            imenu-list-auto-resize t)
-      (spacemacs/set-leader-keys "bt" #'imenu-list-smart-toggle))
+    (setq imenu-list-focus-after-activation t
+          imenu-list-auto-resize t)
     :config
     (evilified-state-evilify-map imenu-list-major-mode-map
       :mode imenu-list-major-mode
       :bindings
       "d" #'imenu-list-display-entry
-      "r" #'imenu-list-refresh)))
+      "r" #'imenu-list-refresh)
+    :spacebind
+    (:global
+     (("b" "Buffers" ("i" spacemacs/imenu-list-smart-focus "Focus imenu sidebar"))
+      ("T" "UI toggles/themes" ("i" imenu-list-smart-toggle "Toggle imenu sidebar"))))))


### PR DESCRIPTION
The imenu-list layer currently defines a single global binding, which toggles the imenu tree sidebar.
With only a single buffer open, it's easy to refocus the sidebar using `spc w l` (the created window doesn't get an index for easy navigation), however this gets annoying with multiple buffers open. I've added a new function to focus the sidebar, creating it if it hasn't already been created.

New function bound under `spc b i`.
Existing toggle binding moved under UI toggle prefix: `spc T i` (previously `spc b t`). As this seems more consistent with the project binding mnemonics...

Bindings now using spacebind macro (via use-package keyword mechanism). Because it's shiny and new.
