### PR TITLE
[julia] Fix inconsistencies in backend configuration

### DIFF
--- a/layers/+lang/julia/README.org
+++ b/layers/+lang/julia/README.org
@@ -43,7 +43,7 @@ for installation, and then install this layer with:
   (setq-default
    dotspacemacs-configuration-layers
    '(
-     (julia :variables julia-mode-enable-lsp t)))
+     (julia :variables julia-backend 'lsp)))
 #+END_SRC
 
 =LanguageServer.jl= tends to have a very long startup time. In the worst case,

--- a/layers/+lang/julia/config.el
+++ b/layers/+lang/julia/config.el
@@ -18,5 +18,5 @@
   "If non-nil, enable ESS in julia-mode buffers and disable julia-repl.")
 
 ;; disabled by default since most won't have lsp-mode working
-(defvar julia-mode-enable-lsp nil
-  "If non-nil, enable lsp-mode in julia-mode buffers.")
+(defvar julia-backend nil
+  "Set to 'lsp to enable use of LanguageServer.jl")

--- a/layers/+lang/julia/funcs.el
+++ b/layers/+lang/julia/funcs.el
@@ -10,18 +10,13 @@
 ;;; License: GPLv3
 
 
-(defun spacemacs//julia-backend ()
-  "Returns selected backend."
-  ;; backend must be choosed explicitly with this layer
-  julia-backend)
-
 (defun spacemacs//julia-setup-backend ()
   "Conditionally setup julia backend."
-  (pcase (spacemacs//julia-backend)
+  (pcase julia-backend
     ('lsp (spacemacs//julia-setup-lsp))))
 
 (defun spacemacs//julia-setup-buffer ()
-  "Setup ESS and/or lsp for buffer depending on config."
+  "Configure julia-mode"
   (when (not julia-mode-enable-ess)
     (spacemacs//julia-setup-repl)))
 

--- a/layers/+lang/julia/packages.el
+++ b/layers/+lang/julia/packages.el
@@ -24,7 +24,7 @@
     :init
     (progn
       (add-hook 'julia-mode-hook #'spacemacs//julia-setup-buffer)
-      (add-hook 'julia-mode-local-vars-hook #'spacemacs//julia-setup-lsp)
+      (add-hook 'julia-mode-local-vars-hook #'spacemacs//julia-setup-backend)
       (if (and (configuration-layer/layer-used-p 'ess)
                julia-mode-enable-ess)
           (add-to-list 'auto-mode-alist


### PR DESCRIPTION
Just wanted to fix a few rough edges in the Julia layer with respect to backend configuration:

- The README (correctly) says to enable LSP by setting `julia-backend` to `'lsp`, but the example snippet suggests (incorrectly) to set `julia-mode-enable-lsp` to `t`. In reality, `julia-mode-enable-lsp` is never actually used by the layer (despite being `defvar`'d). This PR gets rid of `julia-mode-enable-lsp` and gives `julia-backend` a docstring.

- Eliminate trivial `spacemacs//julia-backend` function.

- In `julia-mode-local-vars-hook`, put `spacemacs//julia-setup-backend` instead of `spacemacs//julia-setup-lsp`. The latter will still be called by the former if `julia-backend` is `'lsp`. With this change, if we ever add another backend, it will be properly configured on buffer init (and also, now we don't call `spacemacs//julia-setup-lsp` when we're not using LSP).

- Make the docstring of `spacemacs//julia-setup-buffer` more vague, in case we want to add additional, non-ESS/LSP-related stuff here in the future.