### PR TITLE
[treemacs] Complete treemacs + persp-mode integration.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3248,6 +3248,7 @@ Other:
 - Deleted default values to track upstream behavior
   (thanks to Michael Peyton Jones)
 - Removed obsolete options (thanks to Michael Peyton Jones)
+- Finished =treemacs-persp= integration and made it opt-in.
 **** Typescript
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -11,6 +11,7 @@
 - [[#configuration][Configuration]]
   - [[#follow-mode][Follow mode]]
   - [[#file-watch][File watch]]
+  - [[#scope-settings][Scope Settings]]
   - [[#git-mode][Git mode]]
   - [[#flattening-of-directories][Flattening of directories]]
   - [[#locking-width][Locking width]]
@@ -72,6 +73,23 @@ part of the file system shown by treemacs set the layer variable
 #+END_SRC
 
 Default is =t=.
+
+** Scope Settings
+By default treemacs buffers and their workspaces will be uniquely scoped within
+the current frame. As an alternative it is possible to scope treemacs to the
+currently active perspective, including the automatic creation of a workspace
+for every perspective. The scope type is determined by setting the layer
+variable =treemacs-use-scope-type= to either ='Frames= or ='Perspectives=.
+
+Note that persective-based scoping will only take effect when =persp-mode= is
+actually first used.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (treemacs :variables treemacs-use-persp-scope 'Perspectives)))
+#+END_SRC
+
+Default is ='Frames=.
 
 ** Git mode
 To enable Treemacs to check for the git status information of files and directories

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -15,6 +15,12 @@
 (defvar treemacs-use-filewatch-mode t
   "When non-nil use `treemacs-filewatch-mode'.")
 
+(defvar treemacs-use-scope-type 'Frames
+  "Determines the scope of treemacs buffers and workspaces.
+Possible values are:
+ - `Frames' - to scope treemacs to the current frame
+ - `Perspectives' - to scope treemacs in conjunction with `persp-mode'.")
+
 (defvar treemacs-use-git-mode
   (pcase (cons (not (null (executable-find "git")))
                (not (null (executable-find "python3"))))

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -89,7 +89,10 @@
     :init (require 'treemacs-projectile)))
 
 (defun treemacs/init-treemacs-persp ()
-  (use-package treemacs-persp :after treemacs))
+  (use-package treemacs-persp
+    :after treemacs persp-mode
+    :config (when (eq treemacs-use-scope-type 'Perspectives)
+              (treemacs-set-scope-type 'Perspectives))))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
Finished treemacs-persp integration by actually changing the scope type - I don't think that option was available when treemacs-persp was first added to spacemacs.

Not sure about making it opt-in, since the previous setup did attempt to activate it by default, but given that perspective-scoping was never actually enabled until now I thought the default should stay as is.