### PR TITLE
Update installation command for Vue language server in Vue Layer

### DIFF
--- a/layers/+frameworks/vue/README.org
+++ b/layers/+frameworks/vue/README.org
@@ -81,10 +81,10 @@ Company backend is set to be very eager in suggestions.
 =eslint= is used for linting.
 
 ** lsp
-Vue language server needed to be installed 
+Vue language server needs to be installed 
 
 #+BEGIN_SRC sh
-  $ npm install -g vue-language-server
+  $ npm install -g vls
 #+END_SRC
 
 This backend provides all the fancy features like: jump to definition,


### PR DESCRIPTION
The npm package for the Vue language server was recently renamed from vue-language-server to vls.

This PR updates the installation documentation for the Vue framework layer.