### PR TITLE
[Python] Reflect upstream pytest update to python-test-last.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2855,6 +2855,7 @@ Other:
 - Automatic use the =lsp= as =python-formater= when =lsp= is enabled
   (thanks sunlin7)
 - Fixed directory selection for self compiled mspyls (thanks Jee Lee)
+- Add python-test-last support for pytest runner 
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -289,7 +289,8 @@ to be called for each testrunner. "
 (defun spacemacs/python-test-last (arg)
   "Re-run the last test command"
   (interactive "P")
-  (spacemacs//python-call-correct-test-function arg '((nose . nosetests-again))))
+  (spacemacs//python-call-correct-test-function arg '((pytest . pytest-again)
+                                                      (nose . nosetests-again))))
 
 (defun spacemacs/python-test-all (arg)
   "Run all tests."


### PR DESCRIPTION
Update python-test-last to use pytest-again, which was added recently in the upstream pytest package.