### PR TITLE
Replace close-compilation-window with show-hide-compilation-window.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -643,6 +643,7 @@ Other:
     (thanks to aaronjensen)
   - Fixed unexpected behavior in =spacemacs/open-junk-file= (thanks to Matt
     Kramer)
+  - Replace =spacemacs/close-compilation-window= with =spacemacs/show-hide-compilation-window=
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1528,11 +1528,13 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
     (when (evil-evilified-state-p)
       (evil-normal-state))))
 
-(defun spacemacs/close-compilation-window ()
-  "Close the window containing the '*compilation*' buffer."
+(defun spacemacs/show-hide-compilation-window ()
+  "Show/Hide the window containing the '*compilation*' buffer."
   (interactive)
-  (when compilation-last-buffer
-    (delete-windows-on compilation-last-buffer)))
+  (when-let ((buffer compilation-last-buffer))
+    (if (get-buffer-window buffer 'visible)
+        (delete-windows-on buffer)
+      (display-buffer buffer))))
 
 
 ;; Line number

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -433,7 +433,7 @@
   "cC" 'compile
   "ck" 'kill-compilation
   "cr" 'recompile
-  "cd" 'spacemacs/close-compilation-window)
+  "cd" 'spacemacs/show-hide-compilation-window)
 (with-eval-after-load 'compile
   (evil-define-key 'motion compilation-mode-map (kbd "gf") 'find-file-at-point)
   (define-key compilation-mode-map "r" 'recompile)


### PR DESCRIPTION
There is no way to show compilation window at the moment.

This change enables to show/hide the window.
It will also close #3945 
