### PR TITLE
[vue] Update package name for vue-language-server

### DIFF
--- a/layers/+frameworks/vue/README.org
+++ b/layers/+frameworks/vue/README.org
@@ -84,7 +84,7 @@ Company backend is set to be very eager in suggestions.
 Vue language server needed to be installed 
 
 #+BEGIN_SRC sh
-  $ npm install -g vue-language-server
+  $ npm install -g vls
 #+END_SRC
 
 This backend provides all the fancy features like: jump to definition,


### PR DESCRIPTION
The package `vue-language-server` has been renamed to `vls`.

See https://github.com/vuejs/vetur/tree/master/server

Trying to use the old package would result in an error: https://github.com/neoclide/coc-vetur/issues/28