### PR TITLE
Modified Clojure layer's major leader binding sl to be smarter and fi…

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1455,6 +1455,8 @@ Other:
   - Added ability to use multiple linters together (thanks to didibus)
   - Added `spacemacs/cider-eval-sexp-end-of-line` to match lisp functionality
     (thanks to John Stevenson)
+  - Added `spacemacs/cider-find-and-clear-repl-buffer` which allows you to find
+    and clear the associated cider repl buffer (thanks to didibus)
 - Key bindings:
   - ~SPC m e ;~ to eval sexp and show result as comment
     (thanks to John Stevenson)
@@ -1500,7 +1502,7 @@ Other:
   - ~C-return~ to =cider-repl-newline-and-indent= in REPL evil insert state
     (thanks to Gia Thanh Vuong)
   - changed clear repl buffer of evaluation to match terminal clear key
-    ~SPC s s l~ 'cider-repl-clear-buffer
+    ~SPC s s l~ 'cider-find-and-clear-repl-buffer
     ~SPC s s L~ 'cider-find-and-clear-repl-output
     (thanks to John Stevenson)
   - Add sesman session management keybindings to ~SPC m m~

--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -232,3 +232,10 @@ in your Spacemacs configuration:
   (if (company-tooltip-visible-p)
       (company-select-previous)
     (cider-repl-previous-input)))
+
+(defun spacemacs/cider-find-and-clear-repl-buffer ()
+  "Calls cider-find-and-clear-repl-output interactively with C-u prefix
+set so that it clears the whole REPL buffer, not just the output."
+  (interactive)
+  (let ((current-prefix-arg '(4)))
+    (call-interactively 'cider-find-and-clear-repl-output)))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -175,7 +175,7 @@
             "sjj" 'cider-jack-in-clj
             "sjm" 'cider-jack-in-clj&cljs
             "sjs" 'cider-jack-in-cljs
-            "sl" 'cider-repl-clear-buffer
+            "sl" 'spacemacs/cider-find-and-clear-repl-buffer
             "sL" 'cider-find-and-clear-repl-output
             "sn" 'spacemacs/cider-send-ns-form-to-repl
             "sN" 'spacemacs/cider-send-ns-form-to-repl-focus


### PR DESCRIPTION
…nd the associated repl when in a non cider repl buffer and clear it, instead of throwing an exception, which is what it currently did.

In Clojure major mode, `sl` used to be set to a command that would clear the cider repl buffer, but it only worked if you were currently in the cider repl buffer. If you were in another buffer, it would throw an exception.

I changes it so that if you are not in the cider buffer, it will now try to find the cider buffer using the associated cider buffer info of the buffer you are in, and clear the cider repl buffer.