### PR TITLE
[Python][LSP] Fix the issue autocomplete does't work in simple python file or python project with lsp enabled when using lsp as python-backend

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -154,6 +154,8 @@ You just have to install python language server package:
 Additionally you can install the following other packages:
 
 #+BEGIN_SRC sh
+  # for auto-complete when using lsp as backend
+  pip install jedi
   # for import sorting
   pip install pyls-isort
   # for mypy checking (python 3.4+ is needed)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -35,7 +35,8 @@
 (defun spacemacs//python-setup-company ()
   "Conditionally setup company based on backend."
   (pcase (spacemacs//python-backend)
-    (`anaconda (spacemacs//python-setup-anaconda-company))))
+    (`anaconda (spacemacs//python-setup-anaconda-company))
+    (`lsp (spacemacs//python-setup-lsp-company))))
 
 (defun spacemacs//python-setup-dap ()
   "Conditionally setup elixir DAP integration."
@@ -59,6 +60,15 @@
   "Setup anaconda auto-completion."
   (spacemacs|add-company-backends
     :backends company-anaconda
+    :modes python-mode
+    :append-hooks nil
+    :call-hooks t)
+  (company-mode))
+
+(defun spacemacs//python-setup-lsp-company ()
+  "Setup anaconda auto-completion."
+  (spacemacs|add-company-backends
+    :backends company-jedi
     :modes python-mode
     :append-hooks nil
     :call-hooks t)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -44,6 +44,7 @@
         ;; packages for anaconda backend
         anaconda-mode
         (company-anaconda :requires company)
+        (company-jedi :requires company)
         ;; packages for Microsoft LSP backend
         (lsp-python-ms :requires lsp-mode)
         ))
@@ -97,6 +98,12 @@
     :if (eq (spacemacs//python-backend) 'anaconda)
     :defer t
     ;; see `spacemacs//python-setup-anaconda-company'
+    ))
+
+(defun python/init-company-jedi ()
+  (use-package company-jedi
+    :if (eq (spacemacs//python-backend) 'lsp)
+    :defer t
     ))
 
 (defun python/init-blacken ()


### PR DESCRIPTION
When using lsp as python-backend:

1. When I'm editing simple python file without lsp enabled, company doesn't work at all, company-mode is even not enabled, 

2. When I'm editing Python project with lsp enabled, company doens't work as expected, it echoes error message.