### PR TITLE
add pdf-mode keybindings to scroll through history

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2734,6 +2734,10 @@ Other:
 - Added declaration for the ~SPC P~ prefix (thanks to Codruț Constantin Gușoi)
 **** Pdf
 - Fixed ~'~ =pdf-view-jump-to-register= (thanks to duianto)
+-Key bindings:
+  - Added to pdf-view mode and transient state
+    - ~[~ history-backward (previous view)
+    - ~]~ history-forward (next view)
 **** Perl5
 - Fixed =spacemacs/perltidy-format-buffer= and
   =spacemacs/perltidy-format-function= to move the point and window to their

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -101,45 +101,45 @@ If you use Emacs editing style, check the key bindings at the [[https://github.c
 
 ** PDF View
 
-| *Key binding*      | *Description*                               |
-|------------------+-------------------------------------------|
-| *Navigation*       |                                           |
-|------------------+-------------------------------------------|
+| *Key binding*        | *Description*                             |
+|----------------------+-------------------------------------------|
+| *Navigation*         |                                           |
+|----------------------+-------------------------------------------|
 | ~M-SPC~ or ~s-M-SPC~ | pdf-tools transient state                 |
-| ~0/$~              | Left/right full scroll                    |
-| ~J~                | Move to next page                         |
-| ~K~                | Move to previous page                     |
-| ~u~                | Scroll page up                            |
-| ~d~                | Scroll page down                          |
-| ~gg~               | Go to the first page                      |
-| ~G~                | Go to the last page                       |
-| ~gt~               | Go to page                                |
-| ~gl~               | Go to label (usually the line as printed) |
-| ~C-u~              | Scroll up                                 |
-| ~C-d~              | Scroll down                               |
-| ~``~               | Go to last page in the history            |
-| ~m~                | Set mark                                  |
-| ~'~                | Go to mark                                |
-| ~y~                | Yank selected region                      |
-| ~[~                | History back                              |
-| ~]~                | History forward                           |
-|------------------+-------------------------------------------|
-| *Search*           |                                           |
-|------------------+-------------------------------------------|
-| ~/~                | Search forward                            |
-| ~?~                | Search backward                           |
-|------------------+-------------------------------------------|
-| *Actions*          |                                           |
-|------------------+-------------------------------------------|
-| ~o~                | Follow link                               |
-| ~O~                | Show outline                              |
-| ~r~                | Refresh file                              |
-|------------------+-------------------------------------------|
-| *Zoom*             |                                           |
-|------------------+-------------------------------------------|
-| ~+/-~              | Zoom in/out                               |
-| ~zr~               | Reset zoom                                |
-|------------------+-------------------------------------------|
+| ~0/$~                | Left/right full scroll                    |
+| ~J~                  | Move to next page                         |
+| ~K~                  | Move to previous page                     |
+| ~u~                  | Scroll page up                            |
+| ~d~                  | Scroll page down                          |
+| ~gg~                 | Go to the first page                      |
+| ~G~                  | Go to the last page                       |
+| ~gt~                 | Go to page                                |
+| ~gl~                 | Go to label (usually the line as printed) |
+| ~C-u~                | Scroll up                                 |
+| ~C-d~                | Scroll down                               |
+| ~``~                 | Go to last page in the history            |
+| ~m~                  | Set mark                                  |
+| ~'~                  | Go to mark                                |
+| ~y~                  | Yank selected region                      |
+| ~[~                  | History back                              |
+| ~]~                  | History forward                           |
+|----------------------+-------------------------------------------|
+| *Search*             |                                           |
+|----------------------+-------------------------------------------|
+| ~/~                  | Search forward                            |
+| ~?~                  | Search backward                           |
+|----------------------+-------------------------------------------|
+| *Actions*            |                                           |
+|----------------------+-------------------------------------------|
+| ~o~                  | Follow link                               |
+| ~O~                  | Show outline                              |
+| ~r~                  | Refresh file                              |
+|----------------------+-------------------------------------------|
+| *Zoom*               |                                           |
+|----------------------+-------------------------------------------|
+| ~+/-~                | Zoom in/out                               |
+| ~zr~                 | Reset zoom                                |
+|----------------------+-------------------------------------------|
 
 /For evil users/: Note that the search keys activate =isearch=, which works
 differently from the default Evil search. To go to the next match, use ~C-s~.

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -101,43 +101,45 @@ If you use Emacs editing style, check the key bindings at the [[https://github.c
 
 ** PDF View
 
-| *Key binding*        | *Description*                             |
-|----------------------+-------------------------------------------|
-| *Navigation*         |                                           |
-|----------------------+-------------------------------------------|
+| *Key binding*      | *Description*                               |
+|------------------+-------------------------------------------|
+| *Navigation*       |                                           |
+|------------------+-------------------------------------------|
 | ~M-SPC~ or ~s-M-SPC~ | pdf-tools transient state                 |
-| ~0/$~                | Left/right full scroll                    |
-| ~J~                  | Move to next page                         |
-| ~K~                  | Move to previous page                     |
-| ~u~                  | Scroll page up                            |
-| ~d~                  | Scroll page down                          |
-| ~gg~                 | Go to the first page                      |
-| ~G~                  | Go to the last page                       |
-| ~gt~                 | Go to page                                |
-| ~gl~                 | Go to label (usually the line as printed) |
-| ~C-u~                | Scroll up                                 |
-| ~C-d~                | Scroll down                               |
-| ~``~                 | Go to last page in the history            |
-| ~m~                  | Set mark                                  |
-| ~'~                  | Go to mark                                |
-| ~y~                  | Yank selected region                      |
-|----------------------+-------------------------------------------|
-| *Search*             |                                           |
-|----------------------+-------------------------------------------|
-| ~/~                  | Search forward                            |
-| ~?~                  | Search backward                           |
-|----------------------+-------------------------------------------|
-| *Actions*            |                                           |
-|----------------------+-------------------------------------------|
-| ~o~                  | Follow link                               |
-| ~O~                  | Show outline                              |
-| ~r~                  | Refresh file                              |
-|----------------------+-------------------------------------------|
-| *Zoom*               |                                           |
-|----------------------+-------------------------------------------|
-| ~+/-~                | Zoom in/out                               |
-| ~zr~                 | Reset zoom                                |
-|----------------------+-------------------------------------------|
+| ~0/$~              | Left/right full scroll                    |
+| ~J~                | Move to next page                         |
+| ~K~                | Move to previous page                     |
+| ~u~                | Scroll page up                            |
+| ~d~                | Scroll page down                          |
+| ~gg~               | Go to the first page                      |
+| ~G~                | Go to the last page                       |
+| ~gt~               | Go to page                                |
+| ~gl~               | Go to label (usually the line as printed) |
+| ~C-u~              | Scroll up                                 |
+| ~C-d~              | Scroll down                               |
+| ~``~               | Go to last page in the history            |
+| ~m~                | Set mark                                  |
+| ~'~                | Go to mark                                |
+| ~y~                | Yank selected region                      |
+| ~[~                | History back                              |
+| ~]~                | History forward                           |
+|------------------+-------------------------------------------|
+| *Search*           |                                           |
+|------------------+-------------------------------------------|
+| ~/~                | Search forward                            |
+| ~?~                | Search backward                           |
+|------------------+-------------------------------------------|
+| *Actions*          |                                           |
+|------------------+-------------------------------------------|
+| ~o~                | Follow link                               |
+| ~O~                | Show outline                              |
+| ~r~                | Refresh file                              |
+|------------------+-------------------------------------------|
+| *Zoom*             |                                           |
+|------------------+-------------------------------------------|
+| ~+/-~              | Zoom in/out                               |
+| ~zr~               | Reset zoom                                |
+|------------------+-------------------------------------------|
 
 /For evil users/: Note that the search keys activate =isearch=, which works
 differently from the default Evil search. To go to the next match, use ~C-s~.

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -34,7 +34,7 @@
  [_d_/_u_] pg down/up          [_P_] fit to page              [_aD_] delete       [_p_] print
  [_J_/_K_] next/prev pg        [_m_] slice using mouse        [_am_] markup       [_o_] open link
  [_0_/_$_] full scroll l/r     [_b_] slice from bounding box  ^^                  [_r_] revert
- ^^^^                          [_R_] reset slice              ^^                  [_t_] attachments
+ [_[_/_]_] history back/for    [_R_] reset slice              ^^                  [_t_] attachments
  ^^^^                          [_zr_] reset zoom              ^^                  [_n_] night mode
  "
         :bindings
@@ -49,6 +49,8 @@
         ("d"  pdf-view-scroll-up-or-next-page)
         ("0"  image-bol)
         ("$"  image-eol)
+        ("["  pdf-history-backward)
+        ("]"  pdf-history-forward)
         ;; Scale/Fit
         ("W"  pdf-view-fit-width-to-window)
         ("H"  pdf-view-fit-height-to-window)
@@ -123,6 +125,8 @@
         (kbd "C-u") 'pdf-view-scroll-down-or-previous-page
         (kbd "C-d") 'pdf-view-scroll-up-or-next-page
         (kbd "``")  'pdf-history-backward
+        "["  'pdf-history-backward
+        "]"  'pdf-history-forward
         "'" 'pdf-view-jump-to-register
         ;; Search
         "/" 'isearch-forward


### PR DESCRIPTION
Added to pdf-view and pdf-view transient-state `[` and `]` keys to scroll through backward/forward through history. These keys were still free in both states while all other logical alternatives were already taken. Until now there was no key-binding to scroll forward through history, while no history key-bindings were presented at all in the transient-state.