### PR TITLE
Make spacemacs/cycle-spacemacs-theme work with themes with keywords

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -390,7 +390,8 @@ THEME."
   "Cycle through themes defined in `dotspacemacs-themes'.
 When BACKWARD is non-nil, or with universal-argument, cycle backwards."
   (interactive "P")
-  (let* ((themes (if backward (reverse dotspacemacs-themes) dotspacemacs-themes))
+  (let* ((theme-names (mapcar 'spacemacs//get-theme-name dotspacemacs-themes))
+         (themes (if backward (reverse theme-names) theme-names))
          (next-theme (car (or (cdr (memq spacemacs--cur-theme themes))
                               ;; if current theme isn't in cycleable themes, start
                               ;; over


### PR DESCRIPTION
Themes can now contain keywords in addition to just the theme name like


```emacs-lisp
   dotspacemacs-themes '((name :location (recipe :fetcher github
                                                 :repo "user/repo"))
                         solarized-light
                         solarized-dark)
```

However, for theme cycling, we first try to detect whether the current
theme (spacemacs--cur-theme) is in the list of cycleable themes and go on from
there. Since spacemacs--cur-theme is just a name, this fails when
spacemacs--cur-theme is the name of theme that's specified with additional keywords in
dotspacemacs-themes.

To fix this, check if spacemacs--cur-theme is in the list of theme names.