### PR TITLE
[dap] Provide global keybindings for dap-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -366,6 +366,8 @@ sane way, here is the complete list of changed key bindings
 - ietf (thanks to Christian Hopps and Robby O'Connor)
 - multiple-cursors (thanks to Codruț Constantin Gușoi and Thomas de Beauchêne)
 - parinfer (thanks to Tianshu Shi)
+- Keybinding
+  - Moved ~spacemacs/browse-docs-online-at-point~ from ~SPC d b~ to ~SPC h b d~.
 **** Music
 - pianobar (thanks to Leo Littlebook)
 - tidalcycles (thanks to rbino)
@@ -2400,6 +2402,7 @@ Other:
   - Added variable =dap-enable-mouse-support=
 - Key bindings
   - ~SPC m d d e~ to edit debug template
+  - Added global binding under ~SPC d~
 - Improvements:
   - Evilfied =dap= debug windows
 **** Markdown

--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -49,4 +49,4 @@
     :init
     (progn
       (defalias 'spacemacs/browse-docs-online-at-point 'devdocs-search)
-      (spacemacs/set-leader-keys "db" #'spacemacs/browse-docs-online-at-point))))
+      (spacemacs/set-leader-keys "hbd" #'spacemacs/browse-docs-online-at-point))))

--- a/layers/+tools/dap/README.org
+++ b/layers/+tools/dap/README.org
@@ -47,8 +47,8 @@ file.
 
 * Configuration
 ** DAP configuration in supported layers
-To register =dap-mode= key bindings in a supported layer, the layer must
-register itself using the variable =spacemacs--dap-supported-modes=.
+By default ~dap~ layer registers global keybinding defined under ~SPC m~. If you
+want to have debug bindings under major mode leader you may do the following:
 
 For instance the =java= layer:
 
@@ -69,16 +69,16 @@ See the =java= layer for further example on how to setup correctly =dap-mode=.
 ** Declared prefixes
 The following prefixes have been declared:
 
-| prefix      | name              |
-|-------------+-------------------|
-| ~SPC m d~   | debug             |
-| ~SPC m d b~ | breakpoints       |
-| ~SPC m d d~ | launching         |
-| ~SPC m d e~ | eval              |
-| ~SPC m d I~ | inspect           |
-| ~SPC m d l~ | debug windows     |
-| ~SPC m d S~ | context switching |
-| ~SPC m d T~ | toggles           |
+| prefix    | name              |
+|-----------+-------------------|
+| ~SPC d~   | debug             |
+| ~SPC d b~ | breakpoints       |
+| ~SPC d d~ | launching         |
+| ~SPC d e~ | eval              |
+| ~SPC d I~ | inspect           |
+| ~SPC d l~ | debug windows     |
+| ~SPC d S~ | context switching |
+| ~SPC d T~ | toggles           |
 
 ** Transient state
 Most of the DAP functions can be easily repeated using the built-in DAP
@@ -90,62 +90,62 @@ transient state which can be initiate with ~SPC m d .~.
 
 ** Start/Stop
 
-| Key binding   | Description                |
-|---------------+----------------------------|
-| ~SPC m d A~   | abandon all process        |
-| ~SPC m d a~   | abandon current session    |
-| ~SPC m d d d~ | start debugging            |
-| ~SPC m d d e~ | edit debug template        |
-| ~SPC m d d l~ | debug last configuration   |
-| ~SPC m d d r~ | debug recent configuration |
+| Key binding | Description                |
+|-------------+----------------------------|
+| ~SPC d A~   | abandon all process        |
+| ~SPC d a~   | abandon current session    |
+| ~SPC d d d~ | start debugging            |
+| ~SPC d d e~ | edit debug template        |
+| ~SPC d d l~ | debug last configuration   |
+| ~SPC d d r~ | debug recent configuration |
 
 ** Breakpoints
 
-| Key binding   | Description                     |
-|---------------+---------------------------------|
-| ~SPC m d b b~ | toggle a breakpoint             |
-| ~SPC m d b c~ | change breakpoint condition     |
-| ~SPC m d b l~ | change breakpoint log condition |
-| ~SPC m d b h~ | change breakpoint hit count     |
-| ~SPC m d b a~ | add a breakpoint                |
-| ~SPC m d b d~ | delete a breakpoint             |
-| ~SPC m d b D~ | clear all breakpoints           |
-| ~SPC m d w b~ | list breakpoints                |
+| Key binding | Description                     |
+|-------------+---------------------------------|
+| ~SPC d b b~ | toggle a breakpoint             |
+| ~SPC d b c~ | change breakpoint condition     |
+| ~SPC d b l~ | change breakpoint log condition |
+| ~SPC d b h~ | change breakpoint hit count     |
+| ~SPC d b a~ | add a breakpoint                |
+| ~SPC d b d~ | delete a breakpoint             |
+| ~SPC d b D~ | clear all breakpoints           |
+| ~SPC d w b~ | list breakpoints                |
 
 ** Navigation
 
-| Key binding   | Description                   |
-|---------------+-------------------------------|
-| ~SPC m d c~   | continue                      |
-| ~SPC m d i~   | step in                       |
-| ~SPC m d o~   | step out                      |
-| ~SPC m d s~   | next step                     |
-| ~SPC m d r~   | restart frame                 |
-| ~SPC m d S f~ | switch frame                  |
-| ~SPC m d S s~ | switch session                |
-| ~SPC m d S t~ | switch thread                 |
-| ~SPC m d w o~ | goto output buffer if present |
-| ~SPC m d w s~ | list sessions                 |
+| Key binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC d c~   | continue                      |
+| ~SPC d i~   | step in                       |
+| ~SPC d o~   | step out                      |
+| ~SPC d s~   | next step                     |
+| ~SPC d r~   | restart frame                 |
+| ~SPC d S f~ | switch frame                  |
+| ~SPC d S s~ | switch session                |
+| ~SPC d S t~ | switch thread                 |
+| ~SPC d w o~ | goto output buffer if present |
+| ~SPC d w s~ | list sessions                 |
 
 ** Evaluation and REPL
 
-| Key binding   | Description         |
-|---------------+---------------------|
-| ~SPC m d '_~  | Run debug REPL      |
-| ~SPC m d e e~ | eval                |
-| ~SPC m d e r~ | eval region         |
-| ~SPC m d e t~ | eval value at point |
+| Key binding | Description         |
+|-------------+---------------------|
+| ~SPC d '_~  | Run debug REPL      |
+| ~SPC d e e~ | eval                |
+| ~SPC d e r~ | eval region         |
+| ~SPC d e t~ | eval value at point |
 
 ** Inspection
 
-| Key binding   | Description                               |
-|---------------+-------------------------------------------|
-| ~SPC m d I i~ | inspect                                   |
-| ~SPC m d I r~ | inspect region                            |
-| ~SPC m d I t~ | inspect value at point                    |
-| ~SPC m d v~   | inspect value at point                    |
-| ~SPC m d w l~ | list local variables                      |
-| ~SPC m d T m~ | toggle mouse support for value inspection |
+| Key binding | Description                               |
+|-------------+-------------------------------------------|
+| ~SPC d I i~ | inspect                                   |
+| ~SPC d I r~ | inspect region                            |
+| ~SPC d I t~ | inspect value at point                    |
+| ~SPC d v~   | inspect value at point                    |
+| ~SPC d w l~ | list local variables                      |
+| ~SPC d T m~ | toggle mouse support for value inspection |
 
 * References
 - [[https://github.com/yyoncho/dap-mode][dap-mode repo]]

--- a/layers/+tools/dap/packages.el
+++ b/layers/+tools/dap/packages.el
@@ -33,66 +33,83 @@
         :documentation "Enable mouse support in DAP mode.")
       (when dap-enable-mouse-support
         (spacemacs/toggle-dap-mouse-on))
+
       ;; key bindings
-      (dolist (mode spacemacs--dap-supported-modes)
+      (let ((bindings (list
+                       ;; transient state
+                       "d."  #'dap-hydra
+                       ;; repl
+                       "d'"  #'dap-ui-repl
+                       ;; abandon
+                       "da"  #'dap-disconnect
+                       "dA"  #'dap-delete-all-sessions
+                       ;; breakpoints
+                       "dbb" #'dap-breakpoint-toggle
+                       "dbc" #'dap-breakpoint-condition
+                       "dbl" #'dap-breakpoint-log-message
+                       "dbh" #'dap-breakpoint-hit-condition
+                       "dba" #'dap-breakpoint-add
+                       "dbd" #'dap-breakpoint-delete
+                       "dbD" #'dap-breakpoint-delete-all
+                       ;; debuging/running
+                       "ddd" #'dap-debug
+                       "dde" #'dap-debug-edit-template
+                       "ddl" #'dap-debug-last
+                       "ddr" #'dap-debug-recent
+                       ;; eval
+                       "dee" #'dap-eval
+                       "der" #'dap-eval-region
+                       "det" #'dap-eval-thing-at-point
+                       "det" #'dap-ui-expressions-add
+                       ;; inspect
+                       "dIi" #'dap-ui-inspect
+                       "dIr" #'dap-ui-inspect-region
+                       "dIt" #'dap-ui-inspect-thing-at-point
+                       ;; stepping
+                       "dc"  #'dap-continue
+                       "di"  #'dap-step-in
+                       "do"  #'dap-step-out
+                       "dr"  #'dap-restart-frame
+                       "ds"  #'dap-next
+                       "dv"  #'dap-ui-inspect-thing-at-point
+                       ;; switching
+                       "dSs" #'dap-switch-session
+                       "dSt" #'dap-switch-thread
+                       "dSf" #'dap-switch-frame
+                       ;; toggles
+                       "dTm" 'spacemacs/toggle-dap-mouse
+                       ;; windows
+                       "dwo" #'dap-go-to-output-buffer
+                       "dwl" #'dap-ui-locals
+                       "dws" #'dap-ui-sessions
+                       "dwb" #'dap-ui-breakpoints))
+            (prefixes '(("d"  . "debug")
+                        ("db" . "breakpoints")
+                        ("dd" . "debugging")
+                        ("de" . "eval")
+                        ("dI" . "inspect")
+                        ("dS" . "switch")
+                        ("dT" . "toggles")
+                        ("dw" . "debug windows"))))
 
-        ;; avoid clash with other debug key bindings
-        (spacemacs/set-leader-keys-for-major-mode mode "db" nil)
-        (spacemacs/set-leader-keys-for-major-mode mode "dd" nil)
+        (apply #'spacemacs/set-leader-keys bindings)
 
-        (spacemacs/declare-prefix-for-mode mode "md" "debug")
-        (spacemacs/declare-prefix-for-mode mode "mdb" "breakpoints")
-        (spacemacs/declare-prefix-for-mode mode "mdd" "debugging")
-        (spacemacs/declare-prefix-for-mode mode "mde" "eval")
-        (spacemacs/declare-prefix-for-mode mode "mdI" "inspect")
-        (spacemacs/declare-prefix-for-mode mode "mdS" "switch")
-        (spacemacs/declare-prefix-for-mode mode "mdT" "toggles")
-        (spacemacs/declare-prefix-for-mode mode "mdw" "debug windows")
+        (mapc (lambda (cons)
+                (spacemacs/declare-prefix (car cons) (cdr cons)))
+              prefixes)
 
-        (spacemacs/set-leader-keys-for-major-mode mode
-          ;; transient state
-          "d."  #'dap-hydra
-          ;; repl
-          "d'"  #'dap-ui-repl
-          ;; abandon
-          "da"  #'dap-disconnect
-          "dA"  #'dap-delete-all-sessions
-          ;; breakpoints
-          "dbb" #'dap-breakpoint-toggle
-          "dbc" #'dap-breakpoint-condition
-          "dbl" #'dap-breakpoint-log-message
-          "dbh" #'dap-breakpoint-hit-condition
-          "dba" #'dap-breakpoint-add
-          "dbd" #'dap-breakpoint-delete
-          "dbD" #'dap-breakpoint-delete-all
-          ;; debuging/running
-          "ddd" #'dap-debug
-          "dde" #'dap-debug-edit-template
-          "ddl" #'dap-debug-last
-          "ddr" #'dap-debug-recent
-          ;; eval
-          "dee" #'dap-eval
-          "der" #'dap-eval-region
-          "det" #'dap-eval-thing-at-point
-          ;; inspect
-          "dIi" #'dap-ui-inspect
-          "dIr" #'dap-ui-inspect-region
-          "dIt" #'dap-ui-inspect-thing-at-point
-          ;; stepping
-          "dc"  #'dap-continue
-          "di"  #'dap-step-in
-          "do"  #'dap-step-out
-          "dr"  #'dap-restart-frame
-          "ds"  #'dap-next
-          "dv"  #'dap-ui-inspect-thing-at-point
-          ;; switching
-          "dSs" #'dap-switch-session
-          "dSt" #'dap-switch-thread
-          "dSf" #'dap-switch-frame
-          ;; toggles
-          "dTm" 'spacemacs/toggle-dap-mouse
-          ;; windows
-          "dwo" #'dap-go-to-output-buffer
-          "dwl" #'dap-ui-locals
-          "dws" #'dap-ui-sessions
-          "dwb" #'dap-ui-breakpoints)))))
+        (dolist (mode spacemacs--dap-supported-modes)
+
+          ;; avoid clash with other debug key bindings
+          (spacemacs/set-leader-keys-for-major-mode mode "db" nil)
+          (spacemacs/set-leader-keys-for-major-mode mode "dd" nil)
+
+          (mapc (lambda (cons)
+                  (spacemacs/declare-prefix-for-mode mode (car cons) (cdr cons)))
+                prefixes)
+
+          (apply #'spacemacs/set-leader-keys-for-major-mode mode bindings)
+
+          (mapc (lambda (cons)
+                  (spacemacs/declare-prefix-for-mode mode (car cons) (cdr cons)))
+                prefixes))))))


### PR DESCRIPTION
- added the same bindings you normally have under `SPC m d` under `SPC d`
similar to what Debug layer does. Most of the dap-bindings are not content
sensitive(e. g. rerun last debug session) and it doesn't make sense to restrict
them only to particular major modes.
- Moved `spacemacs/browse-docs-online-at-point` from `SPC d b` to `SPC h b d` to
avoid collisions.

