### PR TITLE
[visual] Pin dap debug buffers to the bottom

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3207,6 +3207,8 @@ Other:
 - Added support for eziam themes (thanks to Benno Fünfstück)
 - Enabled italics in spacemacs theme (thanks to Sylvain Benner)
 - Added support for =doom-dark+= theme (thanks to Ivan Yonchovski)
+**** Visual
+     - use the same window for =dap= log window and for compilation buffer.
 ***** Colors
 - Multiple improvements (thanks to SteveJobzniak):
   - Added ability to set default rainbow-identifiers values

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -92,7 +92,8 @@
       ;; buffers that we manage
       (push '("*Help*"                 :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Process List*"         :dedicated t :position bottom :stick t :noselect nil :height 0.4) popwin:special-display-config)
-      (push '("*compilation*"          :dedicated t :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
+      (push '(compilation-mode         :dedicated nil :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
+      (push '(dap-server-log-mode      :dedicated nil :position bottom :stick t :noselect t   :height 0.4) popwin:special-display-config)
       (push '("*Shell Command Output*" :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*Async Shell Command*"  :dedicated t :position bottom :stick t :noselect nil            ) popwin:special-display-config)
       (push '("*undo-tree*"            :dedicated t :position right  :stick t :noselect nil :width   60) popwin:special-display-config)


### PR DESCRIPTION
- reuse the bottom window for all windows that are in compilation mode and in
dap-server-log-mode. Without this change, you will get two windows on top of each
other when you do `SPC c c` and then `SPC m d d d`

