### PR TITLE
[wakatime] readme, note api key in bug reports

### DIFF
--- a/layers/+web-services/wakatime/README.org
+++ b/layers/+web-services/wakatime/README.org
@@ -62,6 +62,9 @@ Example:
                  ))
 #+END_SRC
 
+*** Note about api key and bug submission
+If you use the built in spacemace bug sumission tool it will include the snippit of code above, including your api key, don't forget to remove it before submitting.
+
 ** API Keys
 After this go to your wakatime account and have your API key handy
 [[https://wakatime.com/settings/account?apikey=true]].


### PR DESCRIPTION
In the Wakatime layer add a line to the readme to highlight the fact that having the api key in the main layer config will submit it as part of a bug report. There is probably a better way to achieve this but at least this highlights it for now.