### PR TITLE
[auto-completion] Set company-minimum-prefix-length to 1 per upstream recommendation

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -90,7 +90,7 @@
     :init
     (progn
       (setq company-idle-delay auto-completion-idle-delay
-            company-minimum-prefix-length 2
+            company-minimum-prefix-length 1
             company-require-match nil
             company-dabbrev-ignore-case nil
             company-dabbrev-downcase nil)


### PR DESCRIPTION
In the `emacs-lsp` plugin, it recommends setting this to 1:
https://github.com/emacs-lsp/lsp-mode/#recomended-settings-for-lsp-mode-related-packages

Having set it to 1 myself and used it for a day or two, it feels much more
useful, as the autocompletion popping up earlier reminds you to use it more!