### PR TITLE
[lsp][dart] Fix dart layer

### DIFF
--- a/layers/+lang/dart/packages.el
+++ b/layers/+lang/dart/packages.el
@@ -15,6 +15,7 @@
     (dart-server :toggle (eq dart-backend 'analyzer))
     (flutter (eq dart-backend 'analyzer))
     flycheck
+    (lsp-dart (eq dart-backend 'lsp))
     ))
 
 (defun dart/show-buffer ()
@@ -74,6 +75,10 @@
       (spacemacs/declare-prefix-for-mode 'dart-mode "mx" "flutter")
       (spacemacs/set-leader-keys-for-major-mode 'dart-mode
         "xx" 'flutter-run-or-hot-reload))))
+
+(defun dart/init-lsp-dart ()
+  (use-package lsp-dart
+    :defer t))
 
 (defun dart/post-init-flycheck ()
   (spacemacs/enable-flycheck 'dart-mode))


### PR DESCRIPTION
- lsp-dart was moved into a separate package so it has to be required separately.

