### PR TITLE
[org] Enable org-habit module.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2737,6 +2737,8 @@ Other:
   (thanks to Keith Pinson)
 - Replace =org-toggle-latex-fragment= with =org-latex-preview=
   (thanks to Tianshu Wang)
+- Enabled =org-habit= module
+  (thanks to Mariusz Klochowicz)
 **** Osx
 - Key bindings:
   - Added key bindings to use ~command-1..9~ for selecting window

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -132,6 +132,9 @@
             ;; `helm-org-headings-max-depth'.
             org-imenu-depth 8)
 
+      (with-eval-after-load 'org-agenda
+      (add-to-list 'org-modules 'org-habit))
+
       (with-eval-after-load 'org-indent
         (spacemacs|hide-lighter org-indent-mode))
 


### PR DESCRIPTION
Enable missing org-module.

fixes the open bug: 
https://github.com/syl20bnr/spacemacs/issues/13252

Last year's open discussion that touches similar topic:
https://github.com/syl20bnr/spacemacs/issues/12003

I believe that enabling it is a reasonable default, if org-agenda shows "Habit" enabled in the bottom of its UI and `org-habit` variables and functions are visible for the user. 