### PR TITLE
[major modes]: Add keybinding for pkgbuild-update-srcinfo

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2491,6 +2491,7 @@ Other:
 - Added SPARQL-mode (thanks to Dietrich Daroch)
 - Added android logcat (thanks to jiejingzhang)
 - Added pkgbuild (thanks to Sven Fischer)
+- Added keybinding for pkgbuild-update-srcinfo (thanks to pancho horrillo)
 - Added ebuild-mode (thanks to Kai Wohlfahrt)
 - Added the vala programming language (thanks to Steven Allen)
 - Added hoon (thanks to Hunter Haugen)

--- a/layers/+lang/major-modes/README.org
+++ b/layers/+lang/major-modes/README.org
@@ -36,6 +36,7 @@ This layer adds a number of packages for less common languages and major modes.
 | ~SPC m r~   | Increase the pkgrel number |
 | ~SPC m u~   | Browse URL                 |
 | ~SPC m m~   | Update package sums        |
+| ~SPC m s~   | Update .SRCINFO file       |
 | ~SPC m e~   | Build ETAGS file           |
 | ~SPC m a~   | Make a source tarball      |
 

--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -65,6 +65,7 @@
         "a" 'pkgbuild-tar
         "u" 'pkgbuild-browse-url
         "m" 'pkgbuild-update-sums-line
+        "s" 'pkgbuild-update-srcinfo
         "e" 'pkgbuild-etags))))
 
 (defun major-modes/init-qml-mode ()


### PR DESCRIPTION
The function `pkgbuild-update-srcinfo` was just added¹ to `pkgbuild-mode`,
and allows to easily produce a `.SRCINFO` file for a given `PKGBUILD`,
which is a required¹ element of an AUR package.

¹: https://github.com/juergenhoetzel/pkgbuild-mode/pull/18
²: https://wiki.archlinux.org/index.php/.SRCINFO

Cheers!