### PR TITLE
[treemacs] load treemacs-icons-dired-mode earlier

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3296,6 +3296,7 @@ Other:
   variable: =treemacs-use-scope-type= with the possible values:
   ='Frames= (default) or ='Perspectives= (thanks to Alexander Miller)
 - Added integration with =treemacs-icons-dired= package.
+- Loaded =treemacs-icons-dired-mode= earlier (thanks to duianto)
 **** Typescript
 - Key bindings:
   - ~SPC m E e~ is for =tide-fix= which was originally added as ~SPC m r f~

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -97,7 +97,7 @@
 
 (defun treemacs/init-treemacs-icons-dired ()
   (use-package treemacs-icons-dired
-    :hook '(dired-mode . treemacs-icons-dired-mode)))
+    :hook (dired-load . treemacs-icons-dired-mode)))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
Opening a dired buffer from the Treemacs buffer,
right after starting Spacemacs, shows the error message:
>treemacs-icons-dired--display: Wrong type argument: char-or-string-p, nil

Loading `treemacs-icons-dired-mode` from the `dired-load-hook`,
instead of from the `dired-mode-hook`, seems to fix it.

The `dired-load-hook` docstring says:
>Run after loading Dired.

The `dired-mode-hook` docstring says:
>Run at the very end of ‘dired-mode’.

---

A dired buffer can be opened from the Treemacs buffer:
- By pressing `SPC a d` and choosing a directory.
- Or with the cursor on a Treemacs projects directory and pressing: `oo`
