### PR TITLE
[idris] Add to spacemacs-indent-sensitive-modes

### DIFF
--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -107,6 +107,9 @@
         "ss" 'idris-pop-to-repl
         "sq" 'idris-quit)))
 
+  ;; To suppress auto-indentation
+  (add-to-list 'spacemacs-indent-sensitive-modes 'idris-mode)
+
   ;; To bind TAB to the indentation command for all Idris buffers
   (add-hook 'idris-mode-hook 'turn-on-idris-simple-indent)
 


### PR DESCRIPTION
Since `idris` is indent-sensitive like Haskell, Python, Agda or PureScript, it should be added to `spacemacs-indent-sensitive-modes`.

Without this configuration, spacemacs inserts indentation when pasting a fragment of codes, which is not desirable.
