### PR TITLE
[org-mode] [verb] fix binding for verb-response-headers-mode

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -819,7 +819,6 @@ Headline^^            Visit entry^^               Filter^^                    Da
   (use-package verb
     :defer t
     :init
-    (progn
       (spacemacs/set-leader-keys-for-major-mode
         'org-mode
         "rf" #'verb-send-request-on-point
@@ -831,12 +830,14 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "ru" #'verb-export-request-on-point-curl
         "rb" #'verb-export-request-on-point-verb
         "rv" #'verb-set-var)
+    :config
+    (progn
       (spacemacs/set-leader-keys-for-minor-mode
         'verb-response-body-mode
         "rr" #'verb-toggle-show-headers
         "rk" #'verb-kill-response-buffer-and-window
         "rf" #'verb-re-send-request)
-      (spacemacs/set-leader-keys-for-minor-mode
+      (spacemacs/set-leader-keys-for-major-mode
         'verb-response-headers-mode
         "rq" #'verb-kill-buffer-and-window))))
 


### PR DESCRIPTION
for verb-response-headers-mode It's a major mode not a minor one.

lazy keybinding for  verb-response-body-mode

Without this change `C-h k` will crash throwing verb-response-headers-mode
variable is void.
