### PR TITLE
[clojure] Change leader key to fix warning

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1568,6 +1568,8 @@ Other:
     ~SPC m e p f~ 'cider-pprint-eval-defun-at-point
     ~SPC m e p e~ 'cider-pprint-eval-last-sexp
     (thanks to John Stevenson)
+  - Changed evaluation keybinding - cider-clojure-interaction-mode
+    ~SPC m e p l~ 'cider-eval-print-last-sexp
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -222,7 +222,7 @@
       (spacemacs/set-leader-keys-for-major-mode 'cider-repl-mode
         "," 'cider-repl-handle-shortcut)
       (spacemacs/set-leader-keys-for-major-mode 'cider-clojure-interaction-mode
-        "ep" 'cider-eval-print-last-sexp))
+        "epl" 'cider-eval-print-last-sexp))
     :config
     (progn
       ;; add support for golden-ratio


### PR DESCRIPTION
I changed key sequence of `cider-eval-print-last-sexp` from `ep` to `epl`.
This PR fixes this warning when reloading spacemacs configuration:

```
Error (use-package): cider/:init: Key sequence e p ; starts with non-prefix key e p
```

If anyone have the better way than this PR to resolve above warning, I would like to agree it.

Thanks for Spacemacs which is a wonderful distribution.