### PR TITLE
Add racket-xp-mode to Racket layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ projectile-bookmarks.eld
 projectile.cache
 python-*-docs-html
 quickurls
+racket-mode/
 semanticdb/
 server/
 tmp/

--- a/layers/+lang/racket/config.el
+++ b/layers/+lang/racket/config.el
@@ -11,4 +11,4 @@
 
 ;; variables
 
-(spacemacs|define-jump-handlers racket-mode racket-visit-definition)
+(spacemacs|define-jump-handlers racket-mode racket-xp-mode racket-xp-visit-definition)

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -54,7 +54,8 @@
     :defer t
     :init
     (progn
-      (spacemacs/register-repl 'racket-mode 'racket-repl "racket"))
+      (spacemacs/register-repl 'racket-mode 'racket-repl "racket")
+      (add-hook 'racket-mode-hook 'racket-xp-mode))
     :config
     (progn
       ;; smartparens configuration
@@ -100,23 +101,36 @@
         (racket-repl)
         (evil-insert-state))
 
-      (dolist (prefix '(("mg" . "navigation")
+      (dolist (prefix '(("mE" . "errors")
+                        ("mg" . "navigation")
                         ("mh" . "doc")
                         ("mi" . "insert")
+                        ("mr" . "refactor")
                         ("ms" . "repl")
                         ("mt" . "tests")))
         (spacemacs/declare-prefix-for-mode 'racket-mode (car prefix) (cdr prefix)))
 
       (spacemacs/set-leader-keys-for-major-mode 'racket-mode
+        ;; errors
+        "En" 'racket-xp-next-error
+        "EN" 'racket-xp-previous-error
         ;; navigation
         "g`" 'racket-unvisit
+        "gg" 'racket-xp-visit-definition
+        "gn" 'racket-xp-next-definition
+        "gN" 'racket-xp-previous-definition
         "gm" 'racket-visit-module
         "gr" 'racket-open-require-path
+        "gu" 'racket-xp-next-use
+        "gU" 'racket-xp-previous-use
         ;; doc
-        "hd" 'racket-describe
-        "hh" 'racket-doc
+        "ha" 'racket-xp-annotate
+        "hd" 'racket-xp-describe
+        "hh" 'racket-xp-documentation
         ;; insert
         "il" 'racket-insert-lambda
+        ;; refactor
+        "mr" 'racket-xp-rename
         ;; REPL
         "'"  'racket-repl
         "sb" 'racket-run
@@ -128,8 +142,8 @@
         "si" 'racket-repl
         "sr" 'racket-send-region
         "sR" 'spacemacs/racket-send-region-focus
-        "ss" 'racket-repl
         ;; Tests
         "tb" 'racket-test
         "tB" 'spacemacs/racket-test-with-coverage)
       (define-key racket-mode-map (kbd "H-r") 'racket-run))))
+


### PR DESCRIPTION
racket-xp-mode is an optional minor mode that enhances the racket-mode to
explain and explore Racket code. The racket-xp-mode is started with a mode-hook
on racket-mode. Deprecated racket-mode functions are replaced with their
racket-xp-mode versions. The remaining racket-xp-mode functions are added to
keybindings as per Spacemacs conventions. This commit also adds the `racket-mode` directory (used to store REPL history etc.) to .gitignore.