### PR TITLE
[spacemacs-base] Fix void layout local variable and function

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3153,6 +3153,10 @@ Other:
 - Prevented =shell-pop-out= from restoring a dead buffer or window
   (thanks to CeleritasCelery, fauxsoup)
 - Made =pop-shell= layout local (thanks to CeleritasCelery, fauxsoup)
+- Checked that the following are bound in =spacemacs-base=:
+  - variable: =layouts-enable-local-variables=
+  - function: =spacemacs/make-variable-layout-local=
+  (thanks to JAremko and duianto)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -75,7 +75,7 @@ SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
         (shell-pop--set-shell-type
         'shell-pop-shell-type
         (list ,name
-            ,(if layouts-enable-local-variables
+            ,(if (bound-and-true-p layouts-enable-local-variables)
                     `(concat "*" (spacemacs//current-layout-name) "-"
                             (if (file-remote-p default-directory)
                                 "remote-"

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -240,9 +240,11 @@
              (initial-shell-mode (intern initial-shell-mode-name)))
         (evil-set-initial-state initial-shell-mode 'insert))
 
-      (spacemacs/make-variable-layout-local 'shell-pop-last-shell-buffer-index 1
-                                            'shell-pop-last-shell-buffer-name ""
-                                            'shell-pop-last-buffer nil)
+      (when (fboundp 'spacemacs/make-variable-layout-local)
+        (spacemacs/make-variable-layout-local 'shell-pop-last-shell-buffer-index 1
+                                              'shell-pop-last-shell-buffer-name ""
+                                              'shell-pop-last-buffer nil))
+
       (add-hook 'term-mode-hook 'ansi-term-handle-close)
 
       (spacemacs/set-leader-keys


### PR DESCRIPTION
The variable: layouts-enable-local-variables
and function: spacemacs/make-variable-layout-local
are defined in the layer: spacemacs-layouts

But the spacemacs-layouts layer isn't loaded
in the distribution: spacemacs-base