### PR TITLE
[doc] Update list of suggested packages to install with python-language-server

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -159,13 +159,6 @@ Additionally you can install the following other packages:
   # for mypy checking (python 3.4+ is needed)
   pip install pyls-mypy
   pip install pyls-black
-  pip install rope
-  pip install pyflakes
-  pip install mccabe
-  pip install pycodestyle
-  pip install pydocstyle
-  pip install autopep8
-  pip install yapf
 #+END_SRC
 
 If you've installed the language server and related packages as development


### PR DESCRIPTION
Removed suggestion to manually install Python packages that are already
dependencies of python-language-server [1].

[1] https://github.com/palantir/python-language-server/blob/6a7eae7600a17b4f076263016639ff2a430b72e3/setup.py#L50-L58