### PR TITLE
[core] Encode emacs-version in dotspacemacs-emacs-dumper-dump-file

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -564,6 +564,8 @@ Other:
     (thanks to Nikita Leshenko)
   - Open Spacemacs home buffer in other/new window with prefix argument
     (thanks to duianto)
+  - Add =emacs-version= to the default value for
+    =dotspacemacs-emacs-dumper-dump-file= (thanks to Evan Klitzke)
 - Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -66,12 +66,13 @@ EXPERIMENTAL.org at to root of the git repository.")
 (defvar dotspacemacs-emacs-pdumper-executable-file "emacs"
   "File path pointing to emacs 27 or later executable.")
 
-(defvar dotspacemacs-emacs-dumper-dump-file "spacemacs.pdmp"
+(defvar dotspacemacs-emacs-dumper-dump-file
+  (format "spacemacs-%s.pdmp" emacs-version)
   "Name of the Spacemacs dump file. This is the file will be created by the
 portable dumper in the cache directory under dumps sub-directory.
 To load it when starting Emacs add the parameter `--dump-file'
 when invoking Emacs 27.1 executable on the command line, for instance:
-./emacs --dump-file=/Users/sylvain/.emacs.d/.cache/dumps/spacemacs.pdmp")
+./emacs --dump-file=$HOME/.emacs.d/.cache/dumps/spacemacs-27.1.pdmp")
 
 (defvar dotspacemacs-gc-cons '(100000000 0.1)
   "Set `gc-cons-threshold' and `gc-cons-percentage' when startup finishes.

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -103,9 +103,9 @@ It should only modify the values of Spacemacs settings."
    ;; portable dumper in the cache directory under dumps sub-directory.
    ;; To load it when starting Emacs add the parameter `--dump-file'
    ;; when invoking Emacs 27.1 executable on the command line, for instance:
-   ;;   ./emacs --dump-file=~/.emacs.d/.cache/dumps/spacemacs.pdmp
-   ;; (default spacemacs.pdmp)
-   dotspacemacs-emacs-dumper-dump-file "spacemacs.pdmp"
+   ;;   ./emacs --dump-file=$HOME/.emacs.d/.cache/dumps/spacemacs-27.1.pdmp
+   ;; (default spacemacs-27.1.pdmp)
+   dotspacemacs-emacs-dumper-dump-file (format "spacemacs-%s.pdmp" emacs-version)
 
    ;; If non-nil ELPA repositories are contacted via HTTPS whenever it's
    ;; possible. Set it to nil if you have no way to use HTTPS in your


### PR DESCRIPTION
I started playing around with Andrea Corallo's `feature/native-comp` branch in upstream Emacs (a.k.a. [gccemacs](http://akrl.sdf.org/gccemacs.html)), and I realized that because his branch is based on Emacs 28, it's probably not going to remain compatible with Emacs 27 pdumps. In general, the layout of core elisp objects in Emacs might change between Emacs releases; for example, there have already been some changes to eieio slots in the Emacs 28 branch compared to what's in Emacs 27. This strategy is similar to how Spacemacs already uses `emacs-version` as the value of `dotspacemacs-elpa-subdirectory`, so that we have different byte-compiled elpa packages for different Emacs major versions.