### PR TITLE
Allow config syntatx-checking-use-standard-error-navigation.

### DIFF
--- a/layers/+checkers/syntax-checking/config.el
+++ b/layers/+checkers/syntax-checking/config.el
@@ -20,5 +20,8 @@
 (defvar syntax-checking-use-original-bitmaps nil
   "If non-nil, use the original bitmaps from flycheck.")
 
+(defvar syntax-checking-use-standard-error-navigation nil
+  "If non-nil hook into emacs standard error navigation")
+
 ;; Command Prefixes
 

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -25,7 +25,7 @@
         (lambda () (when syntax-checking-enable-by-default
                      (global-flycheck-mode 1)))
         lazy-load-flycheck)
-      (setq flycheck-standard-error-navigation nil
+      (setq flycheck-standard-error-navigation syntax-checking-use-standard-error-navigation
             flycheck-global-modes nil)
       ;; key bindings
       (spacemacs/set-leader-keys


### PR DESCRIPTION
When you select `next-error` (which defaults to `spacemacs/next-error`) it will either call `flycheck-next-error` or emacs `next-error`.

With this variable set, when flycheck mode is enabled, the next-error function will first check for flycheck errors, then check for compilation buffer errors. (Personally i think this should be the default, but I'm preserving behaviour).