### PR TITLE
Added mustache-mode to CFEngine layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1433,6 +1433,7 @@ Other:
 **** Cfengine
 - New packages:
   - Added =ob-cfengine3= (thanks to Nick Anderson)
+  - Added =mustache-mode=
 - Improvements:
   - Configure =org-babel= for =cfengine= source blocks
    (thanks to Sylvain Benner)

--- a/layers/+tools/cfengine/README.org
+++ b/layers/+tools/cfengine/README.org
@@ -20,7 +20,7 @@
 This layer adds support for CFEngine policies to Spacemacs.
 
 ** Features:
-- Syntax highlighting
+- Syntax highlighting (CFEngine DSL, & Mustache)
 - On the fly syntax checking via =flycheck= integration.
 - Auto completion via =company= integration.
 - Execution of =cfengine3= =SRC= blocks in =org-mode= via =ob-cfengine3= package.

--- a/layers/+tools/cfengine/packages.el
+++ b/layers/+tools/cfengine/packages.el
@@ -17,6 +17,7 @@
     flycheck
     (ob-cfengine3 :requires org)
     org
+    mustache-mode
     ))
 
 (defun cfengine/init-cfengine3-mode ()
@@ -43,3 +44,11 @@
   (when (configuration-layer/layer-used-p 'org)
     (spacemacs|use-package-add-hook org
       :post-config (add-to-list 'org-babel-load-languages '(cfengine3 . t)))))
+
+(defun cfengine/init-mustache-mode ()
+  (use-package mustache-mode
+    :defer t))
+
+(defun cfengine/post-init-mustache-mode ()
+  (add-to-list 'auto-mode-alist '("\\.mustache\\'" . mustache-mode)))
+


### PR DESCRIPTION
Mustache is the preferred templating in modern versions of CFEngine and it's
nice to have syntax highlighting when working with templates.

Now, when the CFEngine layer is in use, files ending in .mustache will be opened
in mustache-mode.