### PR TITLE
fixed typo by changing dired-load to dired-mode

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -97,7 +97,7 @@
 
 (defun treemacs/init-treemacs-icons-dired ()
   (use-package treemacs-icons-dired
-    :hook (dired-load . treemacs-icons-dired-mode)))
+    :hook (dired-mode . treemacs-icons-dired-mode)))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
Fixed a typo to fix treemacs-icons-dired-mode to work, i.e. icons are displayed within dired-mode.

With this fix, treemacs-icons-dired-mode just work first time.  Without this fix, no iconds are shown in dired mode.

I think it was just a typo to use dired-load instead of dired-mode.

First the intent is to enable treemacs-icons-dired-mode whenever dired-mode is setup.  Hence dired-mode-hook is the right place to do that.

Second dired-load is an internal function used within dired code to implement dired-do-load command which is bound to L within dired mode.  Thus dired-load assumes that current mode is dired-mode, extracts the name of the file at current cursor, then calls (load) on that file to load an emacs-lisp file.  Thus dired-load cannot be the correct symbol.
