### PR TITLE
Update mu4e to 1.4.x changes.

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -151,8 +151,8 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
     :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load))))
 
 (defun mu4e/pre-init-org ()
-  ;; load org-mu4e when org is actually loaded
-  (with-eval-after-load 'org (require 'org-mu4e nil 'noerror)))
+  ;; load mu4e-org when org is actually loaded
+  (with-eval-after-load 'org (require 'mu4e-org nil 'noerror)))
 
 (defun mu4e/pre-init-window-purpose ()
   (spacemacs|use-package-add-hook window-purpose


### PR DESCRIPTION
From the author of mu4e, org-mu4e.el is not supported anymore. Load the
supported org functionality from mu4e-org.el instead.

mu4e author -- "org-mu4e.el has been obsoleted in mu4e 1.4.x... the supported
parts are in mu4e-org.el now. And there's currently no real expectation you can
load those separately (it might work)."

I believe by separately means loading mu4e-org w/o having loaded mu4e.
