### PR TITLE
[keyboard-layout] evil-lisp-state

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2389,6 +2389,7 @@ Other:
 - Fixed key remapping after =cl= package deprecation (thanks to Damien Picard)
 - Fixed =bepo= layout, commented out broken evil-window :common bindings
   (thanks to CharlesHD)
+- Added evil-lisp-state mapping (thanks to Damien Picard)
 **** Kivy
 - Added the =kivy= package (thanks to Nasser Alshammari and Ryota Kayanuma)
 **** LaTeX

--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -19,6 +19,7 @@
     evil
     evil-escape
     evil-evilified-state
+    evil-lisp-state
     evil-magit
     evil-surround
     eyebrowse
@@ -228,6 +229,24 @@
       "j"
       "k"
       "l")))
+
+(defun keyboard-layout/pre-init-evil-lisp-state ()
+  (kl|config evil-lisp-state
+    :description
+    "Remap `evil-lisp-state' bindings."
+    :loader
+    (with-eval-after-load 'evil-lisp-state BODY)
+    :common
+    (kl/correct-keys evil-lisp-state-map
+      "h"
+      "j"
+      "k"
+      "l"
+      ;;
+      "H"
+      "J"
+      "K"
+      "L")))
 
 (defun keyboard-layout/pre-init-evil-magit ()
   (kl|config evil-magit


### PR DESCRIPTION
Hi, this patch provides keyboard mappings for the `evil-lisp-state` package. 
It may be related to the unmerged #11625, but this is a different mode altogether.