### PR TITLE
[latex] Fix jump handlers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2407,6 +2407,7 @@ Other:
 - Fixed README to say auto-fill on by default. (thanks to Max Willsey)
 - Added ConTeXt mode to the key bindings (thanks to ft)
 - Fixed ~SPC m ;~ binding (thanks to Tianshu Wang)
+- Fix jump handlers setup and use dumb-jump as default (thanks to Matt Kramer)
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 - Added support for =LSP= (EmmyLua-LS-all) (thanks to Lin.Sun)

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -15,7 +15,7 @@
 ;; will still be bound to 'latex-mode (since AUCTeX uses an advice to override
 ;; latex-mode with TeX-latex-mode), so the keymap's name should use the
 ;; lowercase form, since bind-map uses the value of major-mode...
-(spacemacs|define-jump-handlers latex-mode)
+(spacemacs|define-jump-handlers latex-mode dumb-jump-go)
 ;; ...but AUCTeX runs LaTeX-mode-hook rather than latex-mode-hook, so:
 (add-hook 'LaTeX-mode-hook #'spacemacs//init-jump-handlers-latex-mode)
 

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -11,7 +11,13 @@
 
 ;; variables
 
+;; Even though AUCTeX uses TeX-latex-mode rather than latex-mode, major-mode
+;; will still be bound to 'latex-mode (since AUCTeX uses an advice to override
+;; latex-mode with TeX-latex-mode), so the keymap's name should use the
+;; lowercase form, since bind-map uses the value of major-mode...
 (spacemacs|define-jump-handlers latex-mode)
+;; ...but AUCTeX runs LaTeX-mode-hook rather than latex-mode-hook, so:
+(add-hook 'LaTeX-mode-hook #'spacemacs//init-jump-handlers-latex-mode)
 
 (defvar latex-build-command (if (executable-find "latexmk") "LatexMk" "LaTeX")
   "The default command to use with `SPC m b'")


### PR DESCRIPTION
Two changes:

1. Manually add `spacemacs//init-jump-handlers-latex-mode` to `LaTeX-mode-hook`. Otherwise it doesn't get run, because `spacemacs|define-jump-handlers` puts it in `latex-mode-hook`, which is only run by the built-in `latex-mode`, not by AUCTeX. (Note that passing `LaTeX-mode` instead of `latex-mode` to `spacemacs|define-jump-handlers` does NOT work; see the commit message for further explanation.) Up to this point, there were no custom jump handlers for LaTeX, so it didn't matter, but see next change! 

2. Make `dumb-jump-go` the primary jump handler for LaTeX. Otherwise, the default is used, which prioritizes `evil-goto-definition` over `dumb-jump-go`. Dumb Jump tends to Just Work, while `evil-goto-definition` doesn't handle LaTeX very well, at least not without a TAGS table.