### PR TITLE
Turn off ability to convert to unicode arrows which are deprecated in Scala

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3084,6 +3084,8 @@ Other:
 - Disabled =sbt-supershell= in =sbt-mode= (thanks to Rodolfo Hansen)
 - Enable new DAP and lsp-treemacs integration via metals
   (thanks to Rodolfo Hansen)
+- Turn off ability to convert to Unicode arrows deprecated in Scala (and remove
+  =scala-use-unicode-arrows= variable)
 **** Scheme
 - Added missing =parinfer= package declaration (thanks to Kalle Lindqvist)
 - Update install docs for Chicken 5 changes (thanks to Grant Shangreaux)

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -20,7 +20,7 @@
 - [[#enable-debug-adapter-protocol-dap][Enable Debug Adapter Protocol (DAP)]]
 - [[#automatically-show-the-type-of-the-symbol-under-the-cursor][Automatically show the type of the symbol under the cursor]]
 - [[#automatically-insert-asterisk-in-multiline-comments][Automatically insert asterisk in multiline comments]]
-- [[#automatically-replace-arrows-with-unicode-ones][Automatically replace arrows with unicode ones]]
+- [[#deprecated-automatic-replacement-of-arrows-with-unicode-ones][Deprecated: Automatic replacement of arrows with Unicode ones]]
 - [[#enable-gtags-as-a-fallback-navigation-utility][Enable GTags as a fallback navigation utility]]
 - [[#auto-start][Auto-start]]
 - [[#key-bindings][Key bindings]]
@@ -202,17 +202,22 @@ variable =scala-auto-insert-asterisk-in-comments= to =t=.
     (scala :variables scala-auto-insert-asterisk-in-comments t)))
 #+END_SRC
 
-* Automatically replace arrows with unicode ones
-To replace ~=>~, =->= and =<-= with unicode arrows =⇒=, =→= and =←=, set the
-variable =scala-use-unicode-arrows= to =t=.
-
-If in some occasions you don't want the arrows replaced (for example when
-defining compound operators like ~=>>~), you can always undo the change and get
-the ascii arrows back.
+* Deprecated: Automatic replacement of arrows with Unicode ones
+Scala used to support Unicode arrows =⇒=, =→= as aliases for ~=>~, =->= and =<-= , and the
+Scala layer would do the conversion to Unicode for you if you set
+=scala-use-unicode-arrows= to =t=. As the Unicode arrows are now [[https://github.com/scala/scala/pull/7540][deprecated]] in
+Scala, this variable has been dropped from the Scala layer. If it is still in
+your Scala layer variables like so:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (scala :variables scala-use-unicode-arrows t)))
+#+END_SRC
+
+Then you will need to remove it:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(scala))
 #+END_SRC
 
 * Enable GTags as a fallback navigation utility

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -20,9 +20,6 @@
 (defvar scala-auto-insert-asterisk-in-comments nil
   "If non-nil automatically insert leading asterisk in multi-line comments.")
 
-(defvar scala-use-unicode-arrows nil
-  "If non-nil then `->`, `=>` and `<-` are replaced with unicode arrows.")
-
 (defconst scala-backends '(scala-ensime scala-metals)
   "Backend server implementation to enable advanced IDE language features")
 

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -220,46 +220,6 @@
       (evil-define-key 'insert scala-mode-map
         (kbd "RET") 'scala/newline-and-indent-with-asterisk)
 
-      ;; Automatically replace arrows with unicode ones when enabled
-      (defconst scala-unicode-arrows-alist
-        '(("=>" . "⇒")
-          ("->" . "→")
-          ("<-" . "←")))
-
-      (defun scala/replace-arrow-at-point ()
-        "Replace the arrow before the point (if any) with unicode ones.
-An undo boundary is inserted before doing the replacement so that
-it can be undone."
-        (let* ((end (point))
-               (start (max (- end 2) (point-min)))
-               (x (buffer-substring start end))
-               (arrow (assoc x scala-unicode-arrows-alist)))
-          (when arrow
-            (undo-boundary)
-            (backward-delete-char 2)
-            (insert (cdr arrow)))))
-
-      (defun scala/gt ()
-        "Insert a `>' to the buffer.
-If it's part of a right arrow (`->' or `=>'),replace it with the corresponding
-unicode arrow."
-        (interactive)
-        (insert ">")
-        (scala/replace-arrow-at-point))
-
-      (defun scala/hyphen ()
-        "Insert a `-' to the buffer.
-If it's part of a left arrow (`<-'),replace it with the unicode arrow."
-        (interactive)
-        (insert "-")
-        (scala/replace-arrow-at-point))
-
-      (when scala-use-unicode-arrows
-        (define-key scala-mode-map
-          (kbd ">") 'scala/gt)
-        (define-key scala-mode-map
-          (kbd "-") 'scala/hyphen))
-
       (evil-define-key 'normal scala-mode-map "J" 'spacemacs/scala-join-line)
 
       ;; Compatibility with `aggressive-indent'


### PR DESCRIPTION
As of Scala 2.13, Unicode arrows are deprecated:

* https://github.com/scala/scala/pull/7540
* https://github.com/scala/scala-dev/issues/585
* https://github.com/scala/bug/issues/11210

Using one will give a deprecation warnings like so:

> The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to
> display it as one character, consider using a font with programming ligatures
> such as Fira Code.

As such the Scala layer's version slick capability to replace ASCII arrows with
Unicode ones is no longer useful, and I have removed it.

Based on my tests it doesn't seem that there is a need for a more graceful way
to deprecate this: i.e. nothing fails if there is extra junk in `:variables`.