### PR TITLE
Added additional tabular environments

### DIFF
--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -30,5 +30,8 @@
                            "align"
                            "align*"
                            "tabular"
+                           "tabular*"
+                           "tabu"
+                           "tabu*"
                            "tikzpicture")
   "List of environment names in which `auto-fill-mode' will be inhibited.")


### PR DESCRIPTION
Added additional tabular environments to latex-nofill-env variable.
This deactivates the automatic fill in a few more tabular environments.