### PR TITLE
[core] Terminal fix mode line indicator overlap

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -661,6 +661,7 @@ Other:
   - Replace =spacemacs/close-compilation-window= with
     =spacemacs/show-hide-compilation-window= (thanks to Hans Jang)
   - Avoid unnecessary packages installation of tern layer
+  - Fixed terminal mode line indicator overlapping (thanks to duianto)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -101,6 +101,11 @@ The return value is nil if no font was found, truthy otherwise."
 `dotspacemacs-mode-line-unicode-symbols'.
 If ASCII is not provided then UNICODE is used instead. If neither are provided,
 the mode will not show in the mode line."
+  (when (and unicode
+             (not (display-graphic-p)) ; terminal
+             ;; the new indicator is 3 chars (including the space), ex: " Ⓔh"
+             (= (length unicode) 3))
+    (setq unicode (spacemacs/terminal-fix-mode-line-indicator-overlap unicode)))
   `(let ((cell (assq ',mode spacemacs--diminished-minor-modes)))
      (if cell
          (setcdr cell '(,unicode ,ascii))

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -420,4 +420,19 @@ set."
   (funcall spacemacs--gne-line-func
            (buffer-substring (point-at-bol) (point-at-eol))))
 
+(defun spacemacs/terminal-fix-mode-line-indicator-overlap (str)
+  "Add a space between two mode line indicators,
+to fix an overlapping issue, that occurs when
+Spacemacs is started in a terminal,
+and a modes mode line name is diminished to:
+- A unicode character followed by a non unicode character, ex: \" Ⓔh\"
+- Or to two unicode characters, ex: \" Ⓔⓗ\""
+  (let ((first-char (substring str 1 2)) ; first char after the space
+        second-char)
+    (if (equal (char-charset (string-to-char first-char)) 'unicode)
+        (progn
+          (setq second-char (substring str 2 3)) ; second char after the space
+          (concat first-char " " second-char))
+      str)))
+
 (provide 'core-funcs)


### PR DESCRIPTION
In a terminal, when a modes mode line name is diminished,
to two characters, and the first one is a unicode character,
then the second character overlaps the right side of the first character.

Resolves #12016
