### PR TITLE
[source-control] Add Git Blame Transient State

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3196,6 +3196,7 @@ Other:
 - Install orgit only when org package is used (thanks to Boris Buliga)
 - Defer git-gutter loading (thanks to Aaron Jensen)
 - Remove redundant arg from git-gutter timer (thanks to bmag)
+- Added Git Blame Transient State (thanks to duianto)
 **** Spotify
 - Replaced helm-spotify package with helm-spotify-plus
   (thanks to Leonard Lausen)

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -23,6 +23,7 @@
   - [[#log-selection-buffer][Log selection buffer]]
   - [[#interactive-rebase-buffer][Interactive rebase buffer]]
   - [[#quick-guide-for-recurring-use-cases-in-magit][Quick guide for recurring use cases in Magit]]
+  - [[#git-blame-transient-state][Git Blame Transient State]]
   - [[#git-flow-1][Git-Flow]]
   - [[#git-time-machine][Git time machine]]
   - [[#git-links-to-web-services][Git links to web services]]
@@ -247,6 +248,27 @@ A log selection buffer is presented as an interactive way of selecting a recent 
 - Pull changes from upstream (the parent repository you have forked) and push:
   - ~F -r C-u F~ and choose =upstream= or the name you gave to it
   - ~P P~ to push the commit to =origin=
+
+** Git Blame Transient State
+
+| Key binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC g b~   | start magit-blame and open the git blame transient state |
+| ~?~         | toggle hint                                              |
+| ~p~         | prev chunk                                               |
+| ~P~         | prev chunk same commit                                   |
+| ~n~         | next chunk                                               |
+| ~N~         | next chunk same commit                                   |
+| ~RET~       | show commit                                              |
+| ~b~         | show commits with adding lines                           |
+| ~r~         | show commits with removing lines                         |
+| ~f~         | show last commits that still have lines                  |
+| ~e~         | show line revision info in echo area (not read only)     |
+| ~q~         | kill recursive blame buffer or disable magit-blame-mode  |
+| ~c~         | cycle style                                              |
+| ~Y~         | copy hash                                                |
+| ~B~         | magit-blame (magit transient)                            |
+| ~Q~         | quit transient state                                     |
 
 ** Git-Flow
 [[https://github.com/jtatarik/magit-gitflow][magit-gitflow]] provides git-flow commands in its own magit menu.

--- a/layers/+source-control/git/config.el
+++ b/layers/+source-control/git/config.el
@@ -16,3 +16,6 @@
 
 (defvar git-magit-status-fullscreen nil
   "If non nil magit-status buffer is displayed in fullscreen.")
+
+(defvar spacemacs--git-blame-ts-full-hint-toggle nil
+  "Display git blame transient state documentation.")

--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -76,3 +76,35 @@
    (t
     (when (featurep 'evil-magit)
       (evil-magit-revert)))))
+
+
+;; git blame transient state
+
+(defun spacemacs//git-blame-ts-toggle-hint ()
+  "Toggle the full hint docstring for the git blame transient state."
+  (interactive)
+  (setq spacemacs--git-blame-ts-full-hint-toggle
+        (not spacemacs--git-blame-ts-full-hint-toggle)))
+
+(defun spacemacs//git-blame-ts-hint ()
+  "Return a condensed/full hint for the git-blame transient state"
+  (concat
+   " "
+   (if spacemacs--git-blame-ts-full-hint-toggle
+       spacemacs--git-blame-ts-full-hint
+     (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"
+             spacemacs--git-blame-ts-minified-hint))))
+
+(spacemacs|transient-state-format-hint git-blame
+  spacemacs--git-blame-ts-minified-hint "\n
+Chunks: _n_ _N_ _p_ _P_ _RET_ Commits: _b_ _r_ _f_ _e_ _q_")
+
+(spacemacs|transient-state-format-hint git-blame
+  spacemacs--git-blame-ts-full-hint
+  (format "\n[_?_] toggle help
+Chunks^^^^                   Commits^^                     Other
+[_p_/_P_] prev /same commit  [_b_] adding lines            [_c_] cycle style
+[_n_/_N_] next /same commit  [_r_] removing lines          [_Y_] copy hash
+[_RET_]^^ show commit        [_f_] last commit with lines  [_B_] magit-blame
+^^^^                         [_e_] echo                    [_Q_] quit TS
+^^^^                         [_q_] quit blaming"))

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -164,7 +164,7 @@
       ;; key bindings
       (spacemacs/declare-prefix "gf" "file")
       (spacemacs/set-leader-keys
-        "gb"  'spacemacs/git-blame-micro-state
+        "gb"  'spacemacs/git-blame-transient-state/body
         "gc"  'magit-clone
         "gfF" 'magit-find-file
         "gfl" 'magit-log-buffer-file
@@ -175,26 +175,35 @@
         "gs"  'magit-status
         "gS"  'magit-stage-file
         "gU"  'magit-unstage-file)
-      ;; transient state
-      ;; TODO use transient state instead of old micro-state, IIRC we continue
-      ;; to use micro-state because of the re-entry keyword :on-enter which is
-      ;; not available in transient state
-      (spacemacs|define-micro-state git-blame
+      (spacemacs|define-transient-state git-blame
         :title "Git Blame Transient State"
-        :doc "
-Press [_b_] again to blame further in the history, [_q_] to go up or quit."
+        :hint-is-doc t
+        :dynamic-hint (spacemacs//git-blame-ts-hint)
         :on-enter (let (golden-ratio-mode)
                     (unless (bound-and-true-p magit-blame-mode)
                       (call-interactively 'magit-blame-addition)))
-        :foreign-keys run
         :bindings
+        ("?" spacemacs//git-blame-ts-toggle-hint)
+        ;; chunks
+        ("p" magit-blame-previous-chunk)
+        ("P" magit-blame-previous-chunk-same-commit)
+        ("n" magit-blame-next-chunk)
+        ("N" magit-blame-next-chunk-same-commit)
+        ("RET" magit-show-commit)
+        ;; commits
         ("b" magit-blame-addition)
-        ;; here we use the :exit keyword because we should exit the
-        ;; micro-state only if the magit-blame-quit effectively disable
-        ;; the magit-blame mode.
-        ("q" nil :exit (progn (when (bound-and-true-p magit-blame-mode)
-                                (magit-blame-quit))
-                              (not (bound-and-true-p magit-blame-mode))))))
+        ("r" magit-blame-removal)
+        ("f" magit-blame-reverse)
+        ("e" magit-blame-echo)
+        ;; q closes any open blame buffers, one at a time,
+        ;; closing the last blame buffer disables magit-blame-mode,
+        ;; pressing q in this state closes the git blame TS
+        ("q" magit-blame-quit :exit (not (bound-and-true-p magit-blame-mode)))
+        ;; other
+        ("c" magit-blame-cycle-style)
+        ("Y" magit-blame-copy-hash)
+        ("B" magit-blame :exit t)
+        ("Q" nil :exit t)))
     :config
     (progn
       ;; seems to be necessary at the time of release


### PR DESCRIPTION
Minified hint:
`Chunks: n N p P RET Commits: b r f e q`

Full hint:
```
Chunks                   Commits                     Other
[p/P] prev /same commit  [b] adding lines            [c] cycle style
[n/N] next /same commit  [r] removing lines          [Y] copy hash
[RET] show commit        [f] last commit with lines  [B] magit-blame
                         [e] echo                    [Q] quit TS
                         [q] quit blaming
```

---

`q` is used in other transient states to close the transient state, but `magit-blame` uses it to close blame buffers and to disable `magit-blame-mode` from the last blame buffer.

Therefore I bound `Q` to close the transient state.

`q` can also be used to close the transient state when `magit-blame-mode` is disabled, it just requires `q` to be pressed one more time after the last blame buffer has been closed.
