### PR TITLE
[layout] fix persp-mode integration with helm v3.3

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -104,6 +104,7 @@
 
 
 (defun spacemacs-layouts/post-init-helm ()
+  (with-eval-after-load 'helm (spacemacs//persp-helm-setup))
   (spacemacs/set-leader-keys
     "bB" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))
@@ -229,7 +230,6 @@
         (advice-add fn
                     :around 'spacemacs-layouts//advice-with-persp-buffer-list))
       (spacemacs/declare-prefix "b" "persp-buffers")
-      ;; Override SPC TAB to only change buffers in perspective
       (spacemacs/set-leader-keys
         "ba"   'persp-add-buffer
         "br"   'persp-remove-buffer))))


### PR DESCRIPTION
Helm v3.3 no longer uses ido to get buffer list. So the change perp-mode makes
to ido won't affect helm anymore. Hence helm buffer list commands such as
helm-mini and helm-buffer-list will shows all buffers regardless of current
layout. Also `SPC l l` crashes with new helm.

This PR fixes them. We use the new helm variable helm-buffer-list-reorder-fn
to filter buffers. Because we compose this value users are still able to
customize this variable.