### PR TITLE
Add doom-gruvbox-light theme

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3296,6 +3296,7 @@ Other:
 - Updated =doom-themes= list to reflect upstream
   (thanks to Dominic Pearson, Muneeb Shaikh)
 - Added highly accessible =modus-themes= (thanks to Muneeb Shaikh)
+- Added =doom-gruvbox-light= theme (thanks to John Stevenson)
 **** Tmux
 - Prevent =tmux-command= at GUI mode (thanks to Isaac Zeng)
 - Fixed regression in tmux by setting keybindings using =use-package=

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -184,6 +184,7 @@
     (doom-ephemeral                   . doom-themes)
     (doom-fairy-floss                 . doom-themes)
     (doom-gruvbox                     . doom-themes)
+    (doom-gruvbox-light               . doom-themes)
     (doom-horizon                     . doom-themes)
     (doom-laserwave                   . doom-themes)
     (doom-manegarm                    . doom-themes)


### PR DESCRIPTION
Add doom-gruvbox-light theme to prevent Spacemacs from trying to download a
package with the same name from elpa (and failing because there is no such
package).

`doom-gruvbox-theme` can now be included in `dotspacemacs-themes` configuration
without generating an error or trying to download a non-existent package.

Related to #7373 #8090 #8871 #11380 #13515