### PR TITLE
[core][keybindings] add select recent buffer transisient state

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -137,6 +137,7 @@
       - [[#buffers-manipulation-key-bindings][Buffers manipulation key bindings]]
       - [[#create-a-new-empty-buffer][Create a new empty buffer]]
       - [[#buffers-transient-state][Buffers transient state]]
+      - [[#select-buffers-transient-state][Select buffers transient state]]
       - [[#file-manipulation-key-bindings][File manipulation key bindings]]
       - [[#frame-manipulation-key-bindings][Frame manipulation key bindings]]
       - [[#emacs-and-spacemacs-files][Emacs and Spacemacs files]]
@@ -2474,11 +2475,19 @@ open buffers and closing them.
 | ~z~                    | recenter buffer in window                                                                  |
 | ~q~                    | quit transient state                                                                       |
 
-Unlike vim, emacs creates many buffers that most people do not need to see. Some
-examples are the =*Messages*= and =*Compile-Log*= buffers. Spacemacs tries to
-automatically ignore buffers that are not useful. However, you may want to
-change the way Spacemacs marks buffers as useful. For instructions, see the
-[[https://github.com/syl20bnr/spacemacs/blob/develop/doc/FAQ.org#change-special-buffer-rules][special buffer howto]].
+**** Select buffers transient state
+Provide quick access to buffers by order of most recent display or selection. On
+initiate state with ~SPC b .~ a single line of layout awared buffer list is
+showed. If the buffer list is too long it will be cut off to fit one line of the
+~minibuffer~ Curent active buffer is not showed in the list. Press the number
+prefixed to the buffer will switch to that buffer. Press ~b~ will show the whole
+normal buffer list.
+
+| Key binding  | Description                         |
+|--------------+-------------------------------------|
+| ~SPC b .~    | initiate transient state            |
+| ~[1..9]~     | move current buffer to nth window   |
+| ~b~          | list all buffers with helm/ivy      |
 
 **** File manipulation key bindings
 File manipulation commands (start with ~f~):

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -1014,3 +1014,73 @@ If FRAME is nil, it defaults to the selected frame."
   'spacemacs/scale-transparency-transient-state/spacemacs/toggle-transparency)
 
 ;; end of Transparency Transient State
+
+;; select buffer transient state
+(defun helm-buffer-p (buffer)
+  (string-prefix-p "*helm"
+                   (buffer-name buffer)))
+
+(defun spacemacs//get-recent-buffers ()
+  (seq-filter  (lambda (buff)
+                 (and
+                  (funcall (frame-parameter nil 'buffer-predicate) buff)
+                  (not (helm-buffer-p buff))))
+               (buffer-list)))
+
+(defun spacemacs//switch-to-buff-by-pos (pos)
+  (let ((my-buff (elt (spacemacs//get-recent-buffers) (+ pos 1))))
+    (message "buffer %s" (buffer-name my-buff)
+             (switch-to-buffer my-buff))))
+
+(dolist (i (number-sequence 9 0 -1))
+  (eval `(defun ,(intern (format "spacemacs/switch-to-buff-%s" i)) nil
+           ,(format "Switch to buffer %s.\n%s"
+                    i "See `spacemacs//switch-to-buff-by-pos' for details.")
+           (interactive)
+           (spacemacs//switch-to-buff-by-pos ,(if (eq 0 i) 9 (1- i))))))
+
+(defun spacemacs//buffers-ts-hint ()
+  (let ((my-index 1)
+        (my-string "")
+        (my-buffer-list (cdr (spacemacs//get-recent-buffers)))
+        (my-first-entry-done nil)
+        (my-max-len (- (frame-total-cols) 35))
+        (my-b-key " [b] list-buffers"))
+    (add-text-properties 2 3 '(face hydra-face-blue) my-b-key)
+    (while (and (< my-index 10) my-buffer-list)
+      (setq my-string (concat my-string
+                              (if my-first-entry-done
+                                  (format " | %s:" (propertize (format "%s" my-index) 'face 'hydra-face-blue))
+                                (setq my-first-entry-done t)
+                                (format " %s:" (propertize (format "%s" my-index) 'face 'hydra-face-blue)))
+                              (buffer-name (car my-buffer-list))))
+      (incf my-index)
+      (setq my-buffer-list (cdr my-buffer-list)))
+    ;; (substring my-string 0 (- (frame-total-cols) 15))))
+    (if (< (length my-string) my-max-len)
+        (concat my-string my-b-key)
+      (concat (substring my-string 0 (- my-max-len 3))
+              "..." my-b-key))))
+
+(spacemacs|define-transient-state buffers
+  :title "Select Buffers:"
+  :hint-is-doc t
+  :dynamic-hint (spacemacs//buffers-ts-hint)
+  :bindings
+  ("b" (cond ((configuration-layer/layer-used-p 'helm)
+              (lazy-helm/helm-mini))
+             ((configuration-layer/layer-used-p 'ivy)
+              (ivy-switch-buffer))) :exit t)
+  ("1" spacemacs/switch-to-buff-1 :exit t)
+  ("2" spacemacs/switch-to-buff-2 :exit t)
+  ("3" spacemacs/switch-to-buff-3 :exit t)
+  ("4" spacemacs/switch-to-buff-4 :exit t)
+  ("5" spacemacs/switch-to-buff-5 :exit t)
+  ("6" spacemacs/switch-to-buff-6 :exit t)
+  ("7" spacemacs/switch-to-buff-7 :exit t)
+  ("8" spacemacs/switch-to-buff-8 :exit t)
+  ("9" spacemacs/switch-to-buff-9 :exit t)
+  ("0" spacemacs/switch-to-buff-0 :exit t))
+
+(spacemacs/set-leader-keys "." 'spacemacs/buffers-transient-state/body)
+;; end select buffer transient state


### PR DESCRIPTION
Inspired by layout `SPC l`. Implement the same one for recent
buffers by order of most recent display or selection. The state is bound to `SPC .`

The buffer list is responsive, it is cut off to fit one line it it is too long.
Press number to switch to buffer. `b` to show the buffer list.