### PR TITLE
[which-key] fixup for change to help text for "buffer-to-window-N" so…

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -415,12 +415,12 @@
 
   ;; SPC b- buffers
   ;; rename the buffer-to-window-1 entry, to 1..9
-  (push '(("\\(.*\\)1" . "buffer-to-window-1") .
-          ("\\11..9" . "buffer to window 1..9"))
+  (push '(("\\(.*\\)1" . "Move buffer to window 1") .
+          ("\\11..9" . "Move buffer to window 1..9"))
         which-key-replacement-alist)
 
   ;; hide the "[2-9] -> buffer-to-window-[2-9]" entries
-  (push '((nil . "buffer-to-window-[2-9]") . t)
+  (push '((nil . "Move buffer to window [2-9]") . t)
         which-key-replacement-alist)
 
   ;; SPC k- lisp


### PR DESCRIPTION
… which-key-replacement-alist works again

Fixup for regression introduced in commit #727d45e69 where the which-key text was changed from the function name (`buffer-to-window-1` etc) to a string "Move buffer to window 1".

The associated change to the `which-key-replacement-alist` wasn't made, meaning the previous behaviour of collapsing the 1..9 options of `buffer-to-window-N`  into a single entry was lost.

This change restores that behaviour (while keeping the next string)

