### PR TITLE
Remove flycheck-mix-compile in favour of default lsp and alchemist checkers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -159,6 +159,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Key bindings;
   - Changed ~SPC m p t~ to ~SPC m t F~ for =alchemist-project-find-test=
     (thanks to Lyuben Petrov)
+- Remove flycheck-mix-compile in favour of alchemist and lsp syntax checking
 ***** Git
 - Improvements:
   - Adapted configuration to new transient commands of Magit (thanks to bmag)

--- a/layers/+lang/elixir/funcs.el
+++ b/layers/+lang/elixir/funcs.el
@@ -94,13 +94,6 @@
            (forward-line -1)
            (indent-according-to-mode)))))
 
-(defun spacemacs//elixir-enable-compilation-checking ()
-  "Enable compile checking if `elixir-enable-compilation-checking' is non nil."
-  (when (or elixir-enable-compilation-checking)
-    (flycheck-mix-setup)
-    ;; enable credo only if there are no compilation errors
-    (flycheck-add-next-checker 'elixir-mix '(warning . elixir-credo))))
-
 (defun spacemacs/elixir-annotate-pry ()
   "Highlight breakpoint lines."
   (interactive)

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -19,7 +19,6 @@
     evil-matchit
     flycheck
     flycheck-credo
-    flycheck-mix
     ggtags
     helm-gtags
     ob-elixir
@@ -176,18 +175,6 @@
   (use-package flycheck-credo
     :defer t
     :init (add-hook 'flycheck-mode-hook #'flycheck-credo-setup)))
-
-(defun elixir/init-flycheck-mix ()
-  (use-package flycheck-mix
-    :commands (flycheck-mix-setup)
-    :init
-    (progn
-      (add-to-list 'safe-local-variable-values
-                   (cons 'elixir-enable-compilation-checking nil))
-      (add-to-list 'safe-local-variable-values
-                   (cons 'elixir-enable-compilation-checking t))
-      (add-hook 'elixir-mode-local-vars-hook
-                'spacemacs//elixir-enable-compilation-checking))))
 
 (defun elixir/post-init-ggtags ()
   (add-hook 'elixir-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
Fixes #13632

I tested the PR on Elixir setup with lsp and it automatically picks up lsp checker.

Let me know if the changelog message is in the correct place.