### PR TITLE
Update key bindings for vterm

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3179,6 +3179,7 @@ Other:
   - variable: =layouts-enable-local-variables=
   - function: =spacemacs/make-variable-layout-local=
   (thanks to JAremko and duianto)
+- Better keybindings for ~ESC~ and ~RET~ in vterm =evil-normal-state= (thanks to kenkangxgwe)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -343,8 +343,8 @@
       (evil-define-key 'insert vterm-mode-map (kbd "C-y") 'vterm-yank)
 
       (evil-define-key 'normal vterm-mode-map
-        [escape] 'vterm--self-insert
-        [return] 'vterm--self-insert
+        [escape] 'vterm-send-escape
+        [return] 'vterm-send-return
         (kbd "p") 'vterm-yank
         (kbd "u") 'vterm-undo)
 


### PR DESCRIPTION
Two issues this PR tries to solve:

* Sending <kbd>Esc</kbd> to vterm using `vterm--self-insert` results in `1;5u`. 
Is this intended? If not I suggest using `evil-force-normal-state` instead.
* <kbd>Ret</kbd> is not sent by `vterm--self-insert`.
Is this intended? If not I suggest using `vterm-send-return` instead.