### PR TITLE
Add Go command variables

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -104,6 +104,14 @@ layers are enabled as well.
 
 * Configuration
 ** Execution
+By default, the go run command is =go run=. If you want to use a different
+command or run with environment variables, set the layer variable
+=go-run-command=.
+
+#+BEGIN_SRC emacs-lisp
+  (go :variables go-run-command "ENV_VAR=foo go run")
+#+END_SRC
+
 To run the current =main= package with command line arguments, set the value of
 =go-run-args= as a file local variable, e.g.
 
@@ -173,6 +181,14 @@ suite testing and to get single function testing to work.
 Tests are run in a compilation buffer displayed in a popup window that can be
 closed by pressing ~C-g~ from any other window. The variable =go-test-buffer-name=
 can be customized to set the output buffer name.
+
+By default, the go test command is =go test=. If you want to use a different
+command or test with environment variables, set the layer variable
+=go-test-command=.
+
+#+BEGIN_SRC emacs-lisp
+  (go :variables go-test-command "ENV_VAR=foo go test")
+#+END_SRC
 
 To provide additional arguments to =go test=, specify =go-use-test-args=.
 

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -44,3 +44,9 @@ If `nil' then `go-mode' is the default backend unless `lsp' layer is used.")
 
 (defvar go-run-args ""
   "Additional arguments to by supplied to `go run` during runtime.")
+
+(defvar go-run-command "go run"
+  "Go run command. Default is `go run`.")
+
+(defvar go-test-command "go test"
+  "Go test command. Default is `go test`.")

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -110,7 +110,7 @@
 
 (defun spacemacs/go-run-tests (args)
   (interactive)
-  (compilation-start (concat "go test " (when go-test-verbose "-v ") args " " go-use-test-args)
+  (compilation-start (concat go-test-command " " (when go-test-verbose "-v ") args " " go-use-test-args)
                      nil (lambda (n) go-test-buffer-name) nil))
 
 (defun spacemacs/go-run-package-tests ()
@@ -148,7 +148,7 @@
 (defun spacemacs/go-run-main ()
   (interactive)
   (shell-command
-   (format "go run %s %s"
+   (format (concat go-run-command " %s %s")
            (shell-quote-argument (or (file-remote-p (buffer-file-name (buffer-base-buffer)) 'localname)
                                      (buffer-file-name (buffer-base-buffer))))
            go-run-args)))


### PR DESCRIPTION
Adding support for customizing `go run` and `go test` commands in case someone (like me) wants to run/test with a different command or run/test with environment variables.