### PR TITLE
[layouts] update switch worskpace key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1035,6 +1035,11 @@ Other:
     (thanks to John Stevenson)
   - Added ~SPC c b~ to switch to last compilation buffer
     (thanks to Ivan Yonchovski)
+  - Fixed eyebrowse-next/previous-window-config commands key bindings,
+    over-ridden by tab-bar-switch functions in Emacs 27.1 onward
+   ~g>~ eyebrowse-next-window-config
+   ~g<~ eyebrowse-prev-window-config
+   (thanks to John Stevenson)
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-layouts/README.org
+++ b/layers/+spacemacs/spacemacs-layouts/README.org
@@ -11,6 +11,7 @@
   - [[#kill-buffers-when-killing-current-layout][Kill buffers when killing current layout]]
 - [[#usage][Usage]]
 - [[#key-bindings][Key bindings]]
+  - [[#evil-normal-key-bindings][Evil Normal key bindings]]
 
 * Description
 This layer adds support for distinct layouts/workspaces to Spacemacs.
@@ -160,3 +161,13 @@ See key bindings for more layout commands.
 | ~SPC l w~   | workspaces transient state                |
 | ~SPC l x~   | kill current layout                       |
 | ~SPC l X~   | kill other layout                         |
+
+
+** Evil Normal key bindings
+Evil normal state has the following shortcuts
+to switching between workspaces
+
+| Key binding | Description                  |
+|-------------+------------------------------|
+| ~g >~        | Switch to next workspace     |
+| ~g <~        | Switch to previous workspace |

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -98,8 +98,8 @@
         (add-hook 'persp-after-load-state-functions
                   #'spacemacs/load-eyebrowse-after-loading-layout))
       ;; vim-style tab switching
-      (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
-      (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config))))
+      (define-key evil-motion-state-map "g>" 'eyebrowse-next-window-config)
+      (define-key evil-motion-state-map "g<" 'eyebrowse-prev-window-config))))
 
 
 


### PR DESCRIPTION
Emacs 27.1 has tab bar functionality built in and over-rides the existing
keybindings for `eyebrowse-next-window-config` and
`eyebrowse-previous-window-config`

Change keybindings to `g>` and `g>` so they are no longer over-ridden.

Sorry, had to correct an error in the docs, pushed an updated commit.