### PR TITLE
Support running graphical Factor listener from Spacemacs and reloading relevant elisp code

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1864,6 +1864,9 @@ Other:
   =evil-snipe-override-mode= is enabled (thanks to Sylvain Benner)
 **** Factor
 - Misc fixes for factor version 0.98 (thanks to timor)
+- Support running graphical Factor listener instances from Spacemacs
+- Support reloading factor-mode/fuel-mode code when connecting to different
+  Factor versions
 **** Finance
 - Remove key-bindings pointing to removed commands (thanks to Alexander Baier)
 - Added =evil-ledger= package (thanks to Alexander Miller)

--- a/layers/+lang/factor/README.org
+++ b/layers/+lang/factor/README.org
@@ -12,6 +12,7 @@
   - [[#factor-mode-editing-source-files][factor-mode (editing source files)]]
   - [[#fuel-listener-mode][fuel-listener-mode]]
 - [[#snippets][Snippets]]
+- [[#starting-a-graphical-listener][Starting a Graphical Listener]]
 
 * Description
 A spacemacs layer for Factor language support.
@@ -22,6 +23,8 @@ A spacemacs layer for Factor language support.
 - Auto-Completion in REPL
 - Scaffolding support
 - Refactoring support
+- Running graphical Listeners
+- Reloading emacs-lisp portion of FUEL
 
 * Install
 This layer depends on the elisp files that are bundled with factor. To use this
@@ -85,3 +88,23 @@ after typing a single ~:~. Note that you might have
 to set =yas-triggers-in-field= to nil if you use =x= for stack effect
 declaration elements a lot, as this will trigger a builtin snippet from
 prog-mode instead of advancing to the next field when pressing =<TAB>=.
+
+* Starting a Graphical Listener
+
+The command =factor/start-ui-listener= can be used to run a Factor process which
+sets up a FUEL server on the standard port and runs the graphical listener.  If successful, the
+command =connect-to-factor= will connect to that factor instance.
+
+This procedure can be influenced with the following variables, which can also be
+set as directory-local variables to make it easier to work with projects which
+require different Factor versions, for example.  (See their respective
+documentation for details)
+
+- =fuel-factor-root-dir=
+- =fuel-listener-factor-binary=
+- =fuel-listener-factor-image=
+- =factor-ui-listener-args=
+
+Note that the commands described in the [[#key-bindings][Key bindings]] section which start a
+factor listener are supplied by FUEL and don't take the last of these variables,
+=factor-ui-listener-args= into account.

--- a/layers/+lang/factor/config.el
+++ b/layers/+lang/factor/config.el
@@ -10,3 +10,6 @@
 ;;; License: GPLv3
 
 (spacemacs|define-jump-handlers factor-mode 'fuel-edit-word-at-point)
+
+(defvar factor-ui-listener-args ""
+  "Extra arguments to the factor VM binary when starting the graphical listener.")

--- a/layers/+lang/factor/funcs.el
+++ b/layers/+lang/factor/funcs.el
@@ -9,10 +9,115 @@
 ;;
 ;;; License: GPLv3
 
+(autoload 'feature-file "loadhist")
+(autoload 'file-requires "loadhist")
+
+(defvar factor--ui-listener-process nil
+  "Holds the factor process which serves the current fuel connection.")
+
 (defun factor//fuel-stack-effect ()
   "Small wrapper around factors stack effect help. If region is
-  active, use that, otherwise use sexp under point."
+active, use that, otherwise use sexp under point."
   (interactive)
   (if (region-active-p)
       (call-interactively 'fuel-stack-effect-region)
     (call-interactively 'fuel-stack-effect-sexp)))
+
+(defun factor//fuel-elisp-dir ()
+  "Get the directory of the currently loaded fuel implementation."
+  (expand-file-name (concat (feature-file 'factor-mode)
+                           "/..")))
+
+(defun factor//fuel-feature-p (fuel-directory feature)
+  "Check if FEATURE is provided by a file under FUEL-DIRECTORY."
+  (string-prefix-p fuel-directory (feature-file feature)))
+
+(defun factor//loaded-fuel-features ()
+  "Recursively determine all loaded features that belong to the
+currently loaded fuel implementation."
+  (cl-loop with fuel-directory = (factor//fuel-elisp-dir)
+           for fuel-features = '(fuel-mode factor-mode)
+           then (cl-union fuel-features new-features)
+           for next-features = (cl-remove-duplicates
+                                (cl-reduce 'cl-union
+                                           (mapcar (lambda(f) (file-requires (feature-file f)))
+                                                   fuel-features)))
+           for new-features = (cl-remove-if-not
+                               (lambda(f) (and (featurep f)
+                                               (factor//fuel-feature-p fuel-directory f)))
+                               (cl-set-difference next-features fuel-features))
+           while new-features
+           finally (return fuel-features)))
+
+(defun factor//unload-fuel ()
+  "Close fuel connection and unload fuel code.
+
+Will stop current fuel connection if applicable."
+  (when (and (featurep 'fuel-listener)
+             fuel-listener--buffer)
+    (kill-buffer fuel-listener--buffer))
+  (cl-loop for f in (factor//loaded-fuel-features) do
+           (unload-feature f t)))
+
+(defun factor//load-fuel-from-path (path)
+  "Load emacs lisp fuel implementation from the specified PATH."
+  (let ((load-path (cons path load-path)))
+    (require 'fuel-mode)
+    (require 'factor-mode)))
+
+(defun factor//reload-fuel-from-path (path)
+  "Unload current emacs lisp fuel implementation and load the on from PATH.
+
+Since unloading switches buffers which were in factor-mode back
+to fundamental mode, this re-enables factor-mode in these buffers
+afterwards."
+  (let ((factor-buffers (cl-loop for b being the buffers
+                                 if (eq (buffer-local-value 'major-mode b)
+                                        'factor-mode)
+                                 collect b)))
+    (factor//unload-fuel)
+    (factor//load-fuel-from-path path)
+    (cl-loop for b in factor-buffers do
+             (with-current-buffer b
+               (factor-mode)))))
+
+(defun factor/start-connect-factor (factor-binary factor-image fuel-path &optional cmd-line-options)
+  "Start a graphical Factor listener at FACTOR-ROOT.
+
+If non-nil IMAGE-NAME denotes a path to the desired factor image
+relative to FACTOR-ROOT, if no absolute path is given. Connect to
+it using the fuel-mode implementation in FUEL-PATH, if non-nil. Returns the
+process object.
+
+Will append the value of `factor-ui-listener-args' to the command line options.
+
+Returns the process object.
+"
+  (when fuel-path
+    (factor//reload-fuel-from-path fuel-path))
+  (setq factor--ui-listener-process
+        (start-process-shell-command
+         "Factor-UI-Listener" "*Factor-UI-Listener*"
+         (format "%s -image='%s' -e='USING: fuel.remote ; fuel-start-remote-listener* \"ui.tools\" run ' %s"
+                 factor-binary
+                 factor-image
+                 (or cmd-line-options "")))))
+
+(defun factor/start-ui-listener ()
+  "Run the graphical factor listener with fuel support and connect to it.
+
+If `fuel-factor-root-dir' is set,
+unloads the current fuel implementation and reloads fuel from there.
+"
+  (interactive)
+  (when (and (process-live-p factor--ui-listener-process)
+             (y-or-n-p "Graphical listener already running.  Kill process?"))
+    (delete-process factor--ui-listener-process))
+  (let* ((factor-process (factor/start-connect-factor
+                          (fuel-listener-factor-binary)
+                          (fuel-listener-factor-image)
+                          (expand-file-name "misc/fuel" fuel-factor-root-dir))))
+    ;; This check will only catch immediate failures:
+    (unless (process-live-p factor-process)
+      (error "Listener process exited with code: %d"
+             (process-exit-status factor-process)))))


### PR DESCRIPTION
Fuel mode is responsible to connect to a Factor instance.  This change extends
the Factor layer to handle a graphical listener process, to which fuel can
connect afterwards.

A major motivation is also to make it easier to develop with different Factor
versions, which can be specified with (project-/directory-specific) variables.
When starting a Factor listener in a certain location this way, the elisp code
for fuel/factor mode is reloaded from that location.
