### PR TITLE
[racket] Actually switch to insert state in REPL

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2920,6 +2920,7 @@ Other:
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)
 - Add racket-xp-mode to Racket layer (thanks to Shrutarshi Basu)
+- Correctly switch to insert state in REPL
 **** Ranger
 - Key bindings:
   - Added ~j D~ to jump other window (thanks to Rich Alesi)

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -75,7 +75,12 @@
 `insert state'."
         (interactive)
         (racket-run-and-switch-to-repl)
-        (evil-insert-state))
+        (when (buffer-live-p (get-buffer racket-repl-buffer-name))
+          ;; We don't need to worry about the first time the REPL is opened,
+          ;; since the first time, insert state is automatically entered (since
+          ;; it's registered as a REPL?).
+          (with-current-buffer racket-repl-buffer-name
+            (evil-insert-state))))
 
       (defun spacemacs/racket-send-last-sexp-focus ()
         "Call `racket-send-last-sexp' and switch to REPL buffer in


### PR DESCRIPTION
As per the README, `SPC m s B` should put the REPL buffer in insert state, but
the keybinding as defined puts the racket file itself into insert state, not the
REPL.  This means that on returning to the racket file buffer, the cursor is
left in insert state, which means it is easy to accidentally add unwanted text
into the file.

To fix this, a `with-current-buffer` wraps the `evil-insert-state` so that
insert state is enabled in the REPL buffer, not the file being edited.

The first time this is run, `racket-run-and-switch-to-repl` is asynchronous of
`evil-insert-state`, so trying to get the Racket REPL buffer will error.  To fix
this problem, we wrap the `with-current-buffer` with a check to determine that
the Racket REPL buffer is live.  The first time the Racket REPL buffer is
created, the contents will not run, since the Racket REPL buffer will not yet be
live.  This is fine, since we enter the REPL in insert state automagically.

This change does not need to be done to `spacemacs/racket-send-last-sexp-focus`,
`spacemacs/racket-send-definition-focus`, or
`spacemacs/racket-send-region-focus` since these functions follow all of their
racket-send functions with `(racket-repl)` before calling `evil-insert-state`.