### PR TITLE
set initial evil state of ccls-tree-mode to be emacs

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -160,7 +160,7 @@
      "mf" 'member-functions
      "mv" 'member-vars))
 
-  ;;(evil-set-initial-state 'ccls--tree-mode 'emacs)
+  (evil-set-initial-state 'ccls-tree-mode 'emacs)
   ;;(evil-make-overriding-map 'ccls-tree-mode-map)
   (set (make-local-variable 'lsp-disabled-clients) '(clangd))
   (lsp))


### PR DESCRIPTION
Both emacs and vim modes define j and k keys as down and up.

However emacs mode provides added feature of popping up matching source code buffer on left as one traverses within the tree mode buffer on right.

Thus it appears to me that emacs should be the default mode for almost everyone.
