### PR TITLE
[keyboard-layout] Add ediff remapping

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2395,6 +2395,7 @@ Other:
 - Fixed =bepo= layout, commented out broken evil-window :common bindings
   (thanks to CharlesHD)
 - Added evil-lisp-state mapping (thanks to Damien Picard)
+- Added ediff mapping (thanks to iv-nn)
 **** Kivy
 - Added the =kivy= package (thanks to Nasser Alshammari and Ryota Kayanuma)
 **** LaTeX

--- a/layers/+intl/keyboard-layout/README.org
+++ b/layers/+intl/keyboard-layout/README.org
@@ -243,6 +243,7 @@ The available configurations are:
 - avy
 - comint
 - company
+- ediff
 - elfeed
 - evil
 - evil-escape

--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -15,6 +15,7 @@
     avy
     comint
     company
+    ediff
     elfeed
     evil
     evil-cleverparens
@@ -104,6 +105,20 @@
       "C-j"
       "C-k"
       "C-l")))
+
+(defun keyboard-layout/pre-init-ediff ()
+  (kl|config ediff
+    :description
+    "Remap `ediff' bindings."
+    :loader
+    ;; HACK: ediff-mode-map is only defined when ediff is started
+    (add-hook 'ediff-startup-hook #'(lambda () BODY))
+    :common
+    (kl/correct-keys ediff-mode-map
+      "h"
+      "j"
+      "k"
+      "l")))
 
 (defun keyboard-layout/pre-init-elfeed ()
   (kl|config elfeed


### PR DESCRIPTION
Add `ediff` support to the `keyboard-layout` layer.

It works well using the bepo layout and should work with the other layouts but is untested with those.

`ediff-mode-map` is only defined once ediff is started, that's why I used `ediff-startup-hook` instead of `spacemacs|use-package-add-hook` or `with-eval-after-load` as I read in this issue: noctuid/general.el#59 but there may be another way. I'm new to emacs and spacemacs and this is my first time writing elisp so I'm not entirely sure.

See also this issue: https://github.com/emacs-evil/evil-collection/issues/196#issuecomment-419681661
