### PR TITLE
replaced one do with cl-do and position with cl-position

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -129,7 +129,7 @@ Cancels autosave on exiting perspectives mode."
           (concat " "
                   (mapconcat (lambda (persp)
                                (spacemacs//layout-format-name
-                                persp (position persp persp-list)))
+                                persp (cl-position persp persp-list)))
                              persp-list " | "))))
     (concat
      formatted-persp-list

--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -110,9 +110,9 @@ Display BUFFER as a popup buffer, according to the settings in
 
 See `purpose-special-action-sequences' for a description of BUFFER and
 ALIST."
-  (do ((display-fns (pupo//actions (cdr (popwin:match-config buffer)))
-                    (cdr display-fns))
-       (window nil (and display-fns (funcall (car display-fns) buffer alist))))
+  (cl-do ((display-fns (pupo//actions (cdr (popwin:match-config buffer)))
+                       (cdr display-fns))
+          (window nil (and display-fns (funcall (car display-fns) buffer alist))))
       ((or window (null display-fns)) window)))
 
 (defun pupo/after-display (window)


### PR DESCRIPTION
Migrate from deprecated `cl` to newer `cl-lib`.  These lines were identified via https://github.com/syl20bnr/spacemacs/issues/13679.
