### PR TITLE
[core] fix broken --timed-requires and --adv-timers under emacs 27 and above

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -663,6 +663,7 @@ Other:
     =spacemacs/show-hide-compilation-window= (thanks to Hans Jang)
   - Avoid unnecessary packages installation of tern layer
   - Fixed terminal mode line indicator overlapping (thanks to duianto)
+  - Fixed broken --timed-requires and --adv-timers under Emacs 27 and above (thanks to Ying Qu)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -82,6 +82,8 @@ seconds to load")
                                              (profiler-report)
                                              (profiler-stop))))))
 
+  (when (version<= "27.0" emacs-version)
+    (require 'time-date))
   (when spacemacs-debug-with-timed-requires
     (with-current-buffer (get-buffer-create "*load-times*")
       (insert (format "Threshold set at %.3f seconds\n\n"


### PR DESCRIPTION
This fixs #13681.

time-date.el requires cl-lib under Emacs 27 and above. Then the around advice
spacemacs//timed-require and spacemacs//load-timer of require will cause
recursive load under emacs 27 and above. The load sequences is: requiring cl-lib
uses autoload function time-since which loads time-date.el and then time-date.el
requires cl-lib.

The solution to break this recursive load sequence is to load time-date.el
before adding the around advice spacemacs//timed-require and
spacemacs//load-timer to require.
