### PR TITLE
Fix inline `code` styling

### DIFF
--- a/doc/BEGINNERS_TUTORIAL.org
+++ b/doc/BEGINNERS_TUTORIAL.org
@@ -51,7 +51,7 @@ two keys at the same time. ~SPC 1~ is notation for a key sequence and means
 pressing ~Space~ first and pressing ~1~ after it. Key chords are notated by
 writing a ~-~ between the keys. Thus ~C-c~ means pressing ~Ctrl~ and the letter
 ~c~ simultaneously. Key chords and sequences can also be combined: ~C-c a~ means
-"First press ~Ctrl~ and ~c~ simultaneously, then press ~a~”. ~C-c C-a~ means
+"First press ~Ctrl~ and ~c~ simultaneously, then press ~a~". ~C-c C-a~ means
 "First press ~Ctrl~ and ~c~ simultaneously, then press ~Ctrl~ and ~a~
 simultaneously".
 


### PR DESCRIPTION
[Unicode Character 'RIGHT DOUBLE QUOTATION MARK' (U+201D)](https://www.fileformat.info/info/unicode/char/201d/index.htm) breaks inline `code` styling.

Replacing it with [Unicode Character 'QUOTATION MARK' (U+0022)](https://www.fileformat.info/info/unicode/char/0022/index.htm) fixes it.

# Screenshots

## Before

<img width="280" alt="スクリーンショット 2020-06-19 21 58 05" src="https://user-images.githubusercontent.com/10515/85135179-aa3a7980-b278-11ea-9311-16573f6c8ab8.png">

## After

<img width="277" alt="スクリーンショット 2020-06-19 22 00 50" src="https://user-images.githubusercontent.com/10515/85135188-ae669700-b278-11ea-9630-a0301b9ab4e0.png">
