### PR TITLE
[osx] Use gls in dired regardless of exec-path-from-shell

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2786,6 +2786,8 @@ Other:
   =hyper=, =super= or =alt= (thanks to Binbin Ye)
 - Added a layer variable =osx-swap-option-and-command= defaults to =nil=
   (thanks to Binbin Ye)
+- Enabled GNU =gls= support in dired without requiring
+  =exec-path-from-shell= (thanks to Aaron Zeng)
 **** Pandoc
 - Fixed =spacemacs/run-pandoc= not to reset =pandoc--local-settings=
   (thanks to martian-f)

--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -11,7 +11,6 @@
 
 (setq osx-packages
       '(
-        exec-path-from-shell
         helm
         launchctl
         (osx-dictionary :toggle osx-use-dictionary-app)
@@ -25,18 +24,15 @@
   ;; Enable built-in trash support via finder API if available (only on Emacs
   ;; macOS Port)
   (when (boundp 'mac-system-move-file-to-trash-use-finder)
-    (setq mac-system-move-file-to-trash-use-finder t)))
+    (setq mac-system-move-file-to-trash-use-finder t))
 
-(defun osx/post-init-exec-path-from-shell ()
   ;; Use GNU ls as `gls' from `coreutils' if available.  Add `(setq
   ;; dired-use-ls-dired nil)' to your config to suppress the Dired warning when
-  ;; not using GNU ls.  We must look for `gls' after `exec-path-from-shell' was
-  ;; initialized to make sure that `gls' is in `exec-path'
-  (when (spacemacs/system-is-mac)
-    (let ((gls (executable-find "gls")))
-      (when gls
-        (setq insert-directory-program gls
-              dired-listing-switches "-aBhl --group-directories-first")))))
+  ;; not using GNU ls.
+  (let ((gls (executable-find "gls")))
+    (when gls
+      (setq insert-directory-program gls
+            dired-listing-switches "-aBhl --group-directories-first"))))
 
 (defun osx/pre-init-helm ()
   ;; Use `mdfind' instead of `locate'.


### PR DESCRIPTION
f553b3622d05be0660bc5ffb0578dc73b1f1fa16 indicated that Spacemacs no
longer uses `exec-path-from-shell`, and instead relies on
`spacemacs-env-vars-file` to make sure environment variables are
set correctly.  This caused `gls` not to be used on macOS any more.

This commit re-enables support for automatically using `gls` in dired.

Fix #10957.