### PR TITLE
[terraform] Add LSP support for terraform-lsp

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3279,6 +3279,7 @@ Other:
 - Added opt-in layer variable =terraform-fmt-on-save= to format buffers on save
   with =terraform fmt= (thanks to Harry Hull)
 - Added support for =terraform-company= (thanks to Sylvain Benner)
+- Added LSP support for terraform-lsp
 **** Templates
 - Fixed issue with templates layer ignoring =templates-private-directory=
   (thanks to Seong Yong-ju)

--- a/layers/+tools/terraform/README.org
+++ b/layers/+tools/terraform/README.org
@@ -10,6 +10,7 @@
 - [[#install][Install]]
 - [[#configuration][Configuration]]
   - [[#auto-format-on-save][Auto-format on save]]
+  - [[#lsp][LSP]]
 
 * Description
 This layer provides basic support for Terraform =.tf= files.
@@ -17,6 +18,7 @@ This layer provides basic support for Terraform =.tf= files.
 ** Features:
 - Basic syntax highlighting via [[https://github.com/syohex/emacs-terraform-mode][terraform-mode]]
 - Auto formatting on save via =terraform fmt=
+- LSP support for terraform-lsp via =terraform-backend=
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -33,3 +35,13 @@ layer variable =terraform-auto-format-on-save= to =t=:
 #+BEGIN_SRC emacs-lisp
   (terraform :variables terraform-auto-format-on-save t)
 #+END_SRC
+
+** LSP
+To enable LSP, install [[https://github.com/juliosueiras/terraform-lsp][terraform-lsp]].
+
+And set the layer variable =terraform-backend= to ='lsp= like shown below:
+
+#+BEGIN_SRC emacs-lisp
+  (terraform :variables terraform-backend 'lsp)
+#+END_SRC
+

--- a/layers/+tools/terraform/config.el
+++ b/layers/+tools/terraform/config.el
@@ -13,3 +13,6 @@
 
 (defvar terraform-auto-format-on-save nil
   "If non-nil then call `terraform fmt' before saving the terraform buffer.")
+
+(defvar terraform-backend nil
+  "If 'lsp then use LSP for terraform.")

--- a/layers/+tools/terraform/config.el
+++ b/layers/+tools/terraform/config.el
@@ -15,4 +15,8 @@
   "If non-nil then call `terraform fmt' before saving the terraform buffer.")
 
 (defvar terraform-backend nil
-  "If 'lsp then use LSP for terraform.")
+  "The backend to use for IDE features.
+Possible value is `lsp'.")
+
+(defvar terraform-lsp-server 'terraform-lsp
+  "Language server to use for lsp backend. Possible values are `terraform-lsp'.")

--- a/layers/+tools/terraform/funcs.el
+++ b/layers/+tools/terraform/funcs.el
@@ -1,0 +1,32 @@
+;;; funcs.el --- Terraform Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//terraform-backend ()
+  "Returns selected backend."
+  (if terraform-backend
+      terraform-backend
+    nil))
+
+(defun spacemacs//terraform-setup-backend ()
+  "Conditionally setup terraform backend."
+  (pcase (spacemacs//terraform-backend)
+    (`lsp (spacemacs//terraform-setup-lsp))))
+
+;; lsp
+
+(defun spacemacs//terraform-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (progn
+        (when (eq terraform-lsp-server 'terraform-lsp)
+          (require 'lsp-terraform))
+        (lsp))
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))

--- a/layers/+tools/terraform/layers.el
+++ b/layers/+tools/terraform/layers.el
@@ -1,0 +1,14 @@
+;;; layers.el --- Terraform Layer declarations File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'terraform-backend)
+           (eq terraform-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(dap)))

--- a/layers/+tools/terraform/packages.el
+++ b/layers/+tools/terraform/packages.el
@@ -12,8 +12,6 @@
 (setq terraform-packages
       '(
         (company-terraform :requires company)
-        (lsp-terraform :requires lsp-mode
-                       :toggle (eq terraform-backend 'lsp))
         terraform-mode
         ))
 
@@ -35,6 +33,8 @@
 (defun terraform/init-terraform-mode ()
   (use-package terraform-mode
     :defer t
+    :init (add-hook 'terraform-mode-hook
+                    'spacemacs//terraform-setup-backend)
     :config (when terraform-auto-format-on-save
               (add-hook 'terraform-mode-hook
                         'terraform-format-on-save-mode))))

--- a/layers/+tools/terraform/packages.el
+++ b/layers/+tools/terraform/packages.el
@@ -1,6 +1,6 @@
 ;;; packages.el --- terraform Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2018 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
 ;;
 ;; Author: Brian Hicks <brian@brianthicks.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -12,6 +12,8 @@
 (setq terraform-packages
       '(
         (company-terraform :requires company)
+        (lsp-terraform :requires lsp-mode
+                       :toggle (eq terraform-backend 'lsp))
         terraform-mode
         ))
 
@@ -22,6 +24,13 @@
     (spacemacs|add-company-backends
       :backends company-terraform
       :modes terraform-mode)))
+
+(defun terraform/init-lsp-terraform ()
+  (use-package lsp-terraform
+    :defer t
+    :init
+    (when (eq terraform-backend 'lsp)
+      (add-hook 'terraform-mode-hook #'lsp))))
 
 (defun terraform/init-terraform-mode ()
   (use-package terraform-mode


### PR DESCRIPTION
I added LSP support using lsp-mode at terraform layer.
We can use it through layer configuration:

```emacs-lisp
(terraform :variables
           terraform-backend 'lsp)
```