### PR TITLE
[haskell] Remove hayoo from Haskell layer keybindings

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -231,7 +231,6 @@ Documentation commands are prefixed by ~SPC m h~
 | ~SPC m h H~ | do a local Hoogle lookup                                                   |
 | ~SPC m h i~ | gets information for the identifier under the cursor                       |
 | ~SPC m h t~ | gets the type of the identifier under the cursor                           |
-| ~SPC m h y~ | do a Hayoo lookup                                                          |
 
 ** Debug
 Debug commands are prefixed by ~SPC m d~:

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -264,7 +264,6 @@
           "hi"  'haskell-process-do-info
           "ht"  'haskell-process-do-type
           "hT"  'spacemacs/haskell-process-do-type-on-prev-line
-          "hy"  'hayoo
 
           "da"  'haskell-debug/abandon
           "db"  'haskell-debug/break-on-function


### PR DESCRIPTION
The Hayoo site hasn't been available for quite a while now, and it doesn't seem to be coming back any time soon. There isn't much point in having a keybinding for it, I think.