### PR TITLE
[haskell] Add keybinding for Hoogle that works with LSP

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -244,9 +244,6 @@
 
       (dolist (mode haskell-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
-          "gi"  'haskell-navigate-imports
-          "F"   'haskell-mode-stylish-buffer
-
           "sb"  'haskell-process-load-file
           "sc"  'haskell-interactive-mode-clear
           "sS"  'spacemacs/haskell-interactive-bring
@@ -259,8 +256,6 @@
           "cv"  'haskell-cabal-visit-file
 
           "hd"  'inferior-haskell-find-haddock
-          "hh"  'hoogle
-          "hH"  'haskell-hoogle-lookup-from-local
           "hi"  'haskell-process-do-info
           "ht"  'haskell-process-do-type
           "hT"  'spacemacs/haskell-process-do-type-on-prev-line
@@ -277,7 +272,20 @@
           "ds"  'haskell-debug/step
           "dt"  'haskell-debug/trace
 
-          "ri"  'spacemacs/haskell-format-imports))
+          "ri"  'spacemacs/haskell-format-imports)
+        (if (eq (spacemacs//haskell-backend) 'lsp)
+            (spacemacs/set-leader-keys-for-major-mode mode
+              "gl"  'haskell-navigate-imports
+              "S"   'haskell-mode-stylish-buffer
+
+              "hg"  'hoogle
+              "hG"  'haskell-hoogle-lookup-from-local)
+          (spacemacs/set-leader-keys-for-major-mode mode
+            "gi"  'haskell-navigate-imports
+            "F"   'haskell-mode-stylish-buffer
+
+            "hh"  'hoogle
+            "hG"  'haskell-hoogle-lookup-from-local)))
 
       (evilified-state-evilify haskell-debug-mode haskell-debug-mode-map
         "RET" 'haskell-debug/select


### PR DESCRIPTION
The shortcut ", h h" gets bound to `lsp-describe-thing-at-point` by the LSP
layer. Having a shortcut for Hoogle is still very useful, so bind it to ", h g"
when LSP is activated.

*N.B.* This change doesn't yet contain any logic to limit the change to only when the LSP layer is active. I'd like to add that, but don't know how. I'm hoping some kind soul will let me know how to achieve that :)