### PR TITLE
[spacemacs-layouts] Fix return value of `rename-buffer`

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -830,7 +830,8 @@ containing the buffer."
       (dolist (window-config
                (append (persp-parameter 'gui-eyebrowse-window-configs persp)
                        (persp-parameter 'term-eyebrowse-window-configs persp)))
-        (eyebrowse--rename-window-config-buffers window-config old new)))))
+        (eyebrowse--rename-window-config-buffers window-config old new)))
+    new))
 
 
 ;; layout local variables


### PR DESCRIPTION
`spacemacs//fixup-window-configs` is added as an `:around` advice for
`rename-buffer`.  It should preserve `rename-buffer`'s return value,
which is the new name of the buffer.

This pull request makes it do so.