### PR TITLE
[lsp] remove requirement for yasnippet

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -11,7 +11,7 @@
 
 (defconst lsp-packages
   '(
-    (lsp-mode :requires yasnippet)
+    lsp-mode
     lsp-ui
     (helm-lsp :requires helm)
     (lsp-ivy :requires ivy)


### PR DESCRIPTION
lsp-mode does not require yasnippet in order to function

from [the source](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-mode.el#L60):

```
(require 'yasnippet nil t)
```

This just removes the `:requires` clause from the lsp layer's packages list
