### PR TITLE
fix: removes nils from layers list

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -828,7 +828,7 @@ error recovery."
                           "exists in filesystem" "path")
     (setq dotspacemacs-configuration-layers
           (mapcar (lambda (l) (if (listp l) (car l) l))
-                  dotspacemacs-configuration-layers))
+                  (remove nil dotspacemacs-configuration-layers)))
     (spacemacs//test-list 'configuration-layer/get-layer-path
                           'dotspacemacs-configuration-layers
                           "can be found" "layer")


### PR DESCRIPTION
Spacemacs allows to define layers declaratively, like so:

    dotspacemacs-configuration-layers
    `(,(when (eq system-type 'darwin) 'osx))

The problem - in Linux that would add a nil element into the list, which then
makes it unable to run `dotspacemacs/sync-configuration-layers <SPC f e R>`, the
tests won't pass.
