### PR TITLE
[vagrant] Correctly bind `vagrant-tramp-term`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -313,6 +313,7 @@ sane way, here is the complete list of changed key bindings
 ***** Vagrant
 - Key bindings:
   - Vagrant key bindings prefix is now ~SPC a V~.
+  - Actually use ~SPC a t v t~ for =vagrant-tramp-term=
 ***** YAML
 - Added LSP support (thanks to Seong Yong-ju)
 ***** ycmd

--- a/layers/+tools/vagrant/packages.el
+++ b/layers/+tools/vagrant/packages.el
@@ -39,4 +39,4 @@
         (unless spacemacs--vagrant-tramp-loaded
           (vagrant-tramp-add-method)
           (setq spacemacs--vagrant-tramp-loaded t)))
-      (spacemacs/set-leader-keys "atv" 'vagrant-tramp-term))))
+      (spacemacs/set-leader-keys "atvt" 'vagrant-tramp-term))))


### PR DESCRIPTION
According to the README, `SPC a t v t` should start `vagrant-tramp-term`, but
instead, it seems to have been bound to `SPC a t v`.  This means that it
overrode all of the other vagrant keybindings under the prefix `SPC a t v`.

The issue seems to have been a typo from commit e38c33f.

Relates to #13503.