### PR TITLE
[applications] refactor key bindings to layer categories

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1172,6 +1172,9 @@ Other:
   - Refactor +layers/+tools packages to use prefix ~at~
     migrating most key bindings to lower cases and
     expanding room for further aliases (thanks to John Stevenson)
+  - Refactor layers/+chat|email|fun|readers|web-services packages to use
+    relative key binding, migrating most key bindings to lower cases and
+    expanding room for further aliases (thanks to John Stevenson)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+chat/erc/README.org
+++ b/layers/+chat/erc/README.org
@@ -102,21 +102,21 @@ read that in =:password=.
 
 * Key bindings
 
-| Key binding | Description                                           |
-|-------------+-------------------------------------------------------|
-| ~SPC a i e~ | Starts ERC                                            |
-| ~SPC a i E~ | Starts ERC via TLS/SSL                                |
-| ~SPC a i i~ | Switch to next active ERC buffer                      |
-| ~SPC a i D~ | Start ERC with default servers                        |
-| ~SPC m c~   | Open the log file of the current channel              |
-| ~SPC m b~   | Switch between ERC buffers                            |
-| ~SPC m d~   | Interactively input a user action and send it to IRC. |
-| ~SPC m D~   | Draw Social Graph using [[https://github.com/vibhavp/erc-social-graph][erc-social-graph]]              |
-| ~SPC m j~   | Join a channel, executes the /join command            |
-| ~SPC m n~   | Run "/names #channel" in the current channel.         |
-| ~SPC m l~   | Run the /list command                                 |
-| ~SPC m p~   | Part from the channel                                 |
-| ~SPC m q~   | Quit server                                           |
+| Key binding   | Description                                           |
+|---------------+-------------------------------------------------------|
+| ~SPC a c i e~ | Starts ERC                                            |
+| ~SPC a c i E~ | Starts ERC via TLS/SSL                                |
+| ~SPC a c i i~ | Switch to next active ERC buffer                      |
+| ~SPC a c i D~ | Start ERC with default servers                        |
+| ~SPC m c~     | Open the log file of the current channel              |
+| ~SPC m b~     | Switch between ERC buffers                            |
+| ~SPC m d~     | Interactively input a user action and send it to IRC. |
+| ~SPC m D~     | Draw Social Graph using [[https://github.com/vibhavp/erc-social-graph][erc-social-graph]]              |
+| ~SPC m j~     | Join a channel, executes the /join command            |
+| ~SPC m n~     | Run "/names #channel" in the current channel.         |
+| ~SPC m l~     | Run the /list command                                 |
+| ~SPC m p~     | Part from the channel                                 |
+| ~SPC m q~     | Quit server                                           |
 
 *Note:* If you want to connect securely to an IRC server, you must run =erc-tls=
  command on ~SPC a i E~ instead of the =erc= command.

--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -49,11 +49,11 @@
     :init
     (progn
       (spacemacs/set-leader-keys
-        "aie" 'erc
-        "aiE" 'erc-tls
-        "aii" 'erc-track-switch-buffer
-        "aiD" 'erc/default-servers)
-      (spacemacs/declare-prefix "ai"  "irc")
+        "acie" 'erc
+        "aciE" 'erc-tls
+        "acii" 'erc-track-switch-buffer
+        "aciD" 'erc/default-servers)
+      (spacemacs/declare-prefix "aci"  "irc")
       ;; utf-8 always and forever
       (setq erc-server-coding-system '(utf-8 . utf-8)))
     :config

--- a/layers/+chat/jabber/README.org
+++ b/layers/+chat/jabber/README.org
@@ -28,7 +28,7 @@ file.
 * Key bindings
 
 | Key binding | Description          |
-| ~SPC a j~   | Connect all accounts |
+| ~SPC a c j~ | Connect all accounts |
 
 ** Jabber Roster
 

--- a/layers/+chat/jabber/packages.el
+++ b/layers/+chat/jabber/packages.el
@@ -20,7 +20,7 @@
     :init
     (progn
       (add-hook 'jabber-post-connect-hooks 'spacemacs/jabber-connect-hook)
-      (spacemacs/set-leader-keys "aj" 'jabber-connect-all))
+      (spacemacs/set-leader-keys "acj" 'jabber-connect-all))
     :config
     (progn
       (spacemacs/set-leader-keys-for-major-mode 'jabber-roster-mode

--- a/layers/+chat/rcirc/README.org
+++ b/layers/+chat/rcirc/README.org
@@ -230,13 +230,13 @@ codes, set the variable =rcirc-enable-styles= to =t= in your dotfile:
 
 * Key bindings
 
-| Key binding | Description                                                                   |
-|-------------+-------------------------------------------------------------------------------|
-| ~SPC a i r~ | Open rcirc                                                                    |
-| ~SPC l o i~ | Open rcirc in a custom perspective "@RICRC" (need perspectives layer enabled) |
-| ~SPC m i a~ | Interactively insert a color code (if rcirc-styles is enabled)                |
-| ~SPC m i c~ | Interactively insert a text attribute code (if rcirc-styles is enabled)       |
-| ~SPC m i p~ | Toggle preview in input line (if rcirc-styles is enabled)                     |
+| Key binding   | Description                                                                   |
+|---------------+-------------------------------------------------------------------------------|
+| ~SPC a c i r~ | Open rcirc                                                                    |
+| ~SPC l o i~   | Open rcirc in a custom perspective "@RICRC" (need perspectives layer enabled) |
+| ~SPC m i a~   | Interactively insert a color code (if rcirc-styles is enabled)                |
+| ~SPC m i c~   | Interactively insert a text attribute code (if rcirc-styles is enabled)       |
+| ~SPC m i p~   | Toggle preview in input line (if rcirc-styles is enabled)                     |
 
 In normal state:
 

--- a/layers/+chat/rcirc/packages.el
+++ b/layers/+chat/rcirc/packages.el
@@ -112,8 +112,8 @@
       (spacemacs/add-to-hook 'rcirc-mode-hook '(rcirc-omit-mode
                                                 rcirc-track-minor-mode))
 
-      (spacemacs/set-leader-keys "air" 'spacemacs/rcirc)
-      (spacemacs/declare-prefix "ai"  "irc")
+      (spacemacs/set-leader-keys "acir" 'spacemacs/rcirc)
+      (spacemacs/declare-prefix "aci"  "irc")
       (evil-set-initial-state 'rcirc-mode 'insert)
       (setq rcirc-fill-column 80
             rcirc-buffer-maximum-lines 2048

--- a/layers/+chat/slack/README.org
+++ b/layers/+chat/slack/README.org
@@ -64,24 +64,24 @@ By default the values are:
 
 * Key bindings
 
-| Key binding | Description                             |
-|-------------+-----------------------------------------|
-| ~SPC a C d~ | Direct message someone                  |
-| ~SPC a C g~ | Join a group (private channel)          |
-| ~SPC a C j~ | Join a channel                          |
-| ~SPC a C q~ | Close connection                        |
-| ~SPC a C r~ | Join a channel, group, or direct messge |
-| ~SPC a C s~ | (Re)connects to Slack                   |
-| ~SPC m c~   | Embed mention of channel                |
-| ~SPC m e~   | Edit message at point                   |
-| ~SPC m j~   | Join a channel                          |
-| ~SPC m d~   | Direct message someone                  |
-| ~SPC m m~   | Embed mention of user                   |
-| ~SPC m p~   | Load previous messages                  |
-| ~SPC m )~   | Add reaction (emoji) to a message       |
-| ~SPC m (~   | Remove reaction (emoji) to a message    |
-| ~SPC m t~   | Show or create thread                   |
-| ~SPC m q~   | Quit Slack                              |
+| Key binding   | Description                             |
+|---------------+-----------------------------------------|
+| ~SPC a c s d~ | Direct message someone                  |
+| ~SPC a c s g~ | Join a group (private channel)          |
+| ~SPC a c s j~ | Join a channel                          |
+| ~SPC a c s q~ | Close connection                        |
+| ~SPC a c s r~ | Join a channel, group, or direct messge |
+| ~SPC a c s s~ | (Re)connects to Slack                   |
+| ~SPC m c~     | Embed mention of channel                |
+| ~SPC m e~     | Edit message at point                   |
+| ~SPC m j~     | Join a channel                          |
+| ~SPC m d~     | Direct message someone                  |
+| ~SPC m m~     | Embed mention of user                   |
+| ~SPC m p~     | Load previous messages                  |
+| ~SPC m )~     | Add reaction (emoji) to a message       |
+| ~SPC m (~     | Remove reaction (emoji) to a message    |
+| ~SPC m t~     | Show or create thread                   |
+| ~SPC m q~     | Quit Slack                              |
 
 The following bindings are provided to mimic bindings in the official Slack
 client.

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -56,14 +56,14 @@
     :commands (slack-start)
     :defer t
     :init
-    (spacemacs/declare-prefix "aC" "slack")
+    (spacemacs/declare-prefix "acs" "slack")
     (spacemacs/set-leader-keys
-      "aCs" 'slack-start
-      "aCj" 'slack-channel-select
-      "aCg" 'slack-group-select
-      "aCr" 'slack-select-rooms
-      "aCd" 'slack-im-select
-      "aCq" 'slack-ws-close)
+      "acss" 'slack-start
+      "acsj" 'slack-channel-select
+      "acsg" 'slack-group-select
+      "acsr" 'slack-select-rooms
+      "acsd" 'slack-im-select
+      "acsq" 'slack-ws-close)
     (setq slack-enable-emoji t)
     :config
     (dolist (mode '(slack-mode slack-message-buffer-mode))

--- a/layers/+email/gnus/README.org
+++ b/layers/+email/gnus/README.org
@@ -143,7 +143,7 @@ Basic and Spacemacs specific key bindings can be found in the following table.
 
 | Key binding          | Gnus mode - Description                             |
 |----------------------+-----------------------------------------------------|
-| ~SPC a g~            | Starts Gnus                                         |
+| ~SPC a e g~          | Starts Gnus                                         |
 | ~m~                  | New Message                                         |
 | ~O R~, ~G R~ (emacs) | Group Buffer - Add RSS feed                         |
 | ~g r~                | Group Buffer - Check for new mail                   |

--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -31,12 +31,12 @@
     :commands gnus
     :init
     (progn
-      (spacemacs/declare-prefix "ag" "gnus" "Gnus newsreader")
+      (spacemacs/declare-prefix "aeg" "gnus" "Gnus newsreader")
       (spacemacs/set-leader-keys
-        "agg" 'gnus
-        "ags" 'gnus-slave
-        "agu" 'gnus-unplugged
-        "ago" 'gnus-slave-unplugged)
+        "aegg" 'gnus
+        "aegs" 'gnus-slave
+        "aegu" 'gnus-unplugged
+        "aego" 'gnus-slave-unplugged)
       (spacemacs/declare-prefix-for-mode 'message-mode "mi" "insert")
       (spacemacs/set-leader-keys-for-major-mode 'message-mode
         ;; RFC 1855

--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -64,7 +64,7 @@ existing =dotspacemacs-configuration-layers= list in this file.
 
 | Key binding            | Command                         |
 |------------------------+---------------------------------|
-| ~SPC a M~              | Start mu4e                      |
+| ~SPC a e m~            | Start mu4e                      |
 | ~SPC m S~ or ~SPC m /~ | Search emails (requires helm)   |
 | ~SPC m C~              | Search contacts (requires helm) |
 | ~C-x m~                | Compose new message             |

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -45,7 +45,7 @@
     :commands (mu4e mu4e-compose-new)
     :init
     (progn
-      (spacemacs/set-leader-keys "a M" 'mu4e)
+      (spacemacs/set-leader-keys "aem" 'mu4e)
       (global-set-key (kbd "C-x m") 'mu4e-compose-new)
       (setq mu4e-completing-read-function 'completing-read
             mu4e-use-fancy-chars 't

--- a/layers/+email/notmuch/README.org
+++ b/layers/+email/notmuch/README.org
@@ -94,13 +94,13 @@ Refer to the official notmuch website for more information:
 * Key bindings
 ** Global bindings
 
-| Key binding | Command                                      |
-|-------------+----------------------------------------------|
-| ~SPC a N N~ | Start notmuch                                |
-| ~SPC a N n~ | Start helm notmuch                           |
-| ~SPC a N j~ | Start a notmuch jump search                  |
-| ~SPC a N s~ | Start a notmuch search                       |
-| ~SPC l o n~ | Start notmuch in a custom layout, "@Notmuch" |
+| Key binding   | Command                                      |
+|---------------+----------------------------------------------|
+| ~SPC a e n N~ | Start notmuch                                |
+| ~SPC a e n n~ | Start helm notmuch                           |
+| ~SPC a e n j~ | Start a notmuch jump search                  |
+| ~SPC a e n s~ | Start a notmuch search                       |
+| ~SPC l o n~   | Start notmuch in a custom layout, "@Notmuch" |
 
 ** Show mode
 

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -35,12 +35,12 @@
     :commands notmuch
     :init
     (progn
-      (spacemacs/declare-prefix "aN" "notmuch")
+      (spacemacs/declare-prefix "aen" "notmuch")
       (spacemacs/set-leader-keys
-        "aNN" 'notmuch
-        "aNi" 'spacemacs/notmuch-inbox
-        "aNj" 'notmuch-jump-search
-        "aNs" 'notmuch-search))
+        "aenN" 'notmuch
+        "aeni" 'spacemacs/notmuch-inbox
+        "aenj" 'notmuch-jump-search
+        "aens" 'notmuch-search))
     :config
     (progn
       (dolist (prefix '(("ms" . "stash")

--- a/layers/+fun/emoji/README.org
+++ b/layers/+fun/emoji/README.org
@@ -35,7 +35,7 @@ Linux user could install [[https://zhm.github.io/symbola/][Symbola]] font to get
 
 | Key binding | Description                             |
 |-------------+-----------------------------------------|
-| ~SPC a E~   | open a dedicated buffer to browse Emoji |
+| ~SPC a f e~ | open a dedicated buffer to browse Emoji |
 | ~SPC i e~   | insert Emoji via a helm buffer          |
 
 ** Emoji dedicated buffer

--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -23,7 +23,7 @@
                emoji-cheat-sheet-plus-display-mode)
     :init
     (progn
-      (spacemacs/set-leader-keys "aE" 'emoji-cheat-sheet-plus-buffer)
+      (spacemacs/set-leader-keys "afe" 'emoji-cheat-sheet-plus-buffer)
       (spacemacs/set-leader-keys "ie" 'emoji-cheat-sheet-plus-insert)
       (evilified-state-evilify emoji-cheat-sheet-plus-buffer-mode
         emoji-cheat-sheet-plus-buffer-mode-map

--- a/layers/+fun/games/README.org
+++ b/layers/+fun/games/README.org
@@ -36,7 +36,7 @@ To run a game:
 
 | Key binding | Description                            |
 |-------------+----------------------------------------|
-| ~SPC a G~   | Open an =helm= buffer to select a game |
+| ~SPC a f g~ | Open an =helm= buffer to select a game |
 
 Possible helm actions:
 - run (default)

--- a/layers/+fun/games/packages.el
+++ b/layers/+fun/games/packages.el
@@ -38,8 +38,8 @@
     :commands helm-games
     :init
     (progn
-      (spacemacs/declare-prefix "aG" "games")
-      (spacemacs/set-leader-keys "aG" 'helm-games))))
+      (spacemacs/declare-prefix "afg" "games")
+      (spacemacs/set-leader-keys "afg" 'helm-games))))
 
 (defun games/init-pacmacs ()
   (use-package pacmacs

--- a/layers/+fun/xkcd/README.org
+++ b/layers/+fun/xkcd/README.org
@@ -31,7 +31,7 @@ file.
 
 | Key binding | Description    |
 |-------------+----------------|
-| ~SPC a x~   | Open xkcd mode |
+| ~SPC a f x~ | Open xkcd mode |
 
 ** Okay, what now
 You can now move through the comics with these

--- a/layers/+fun/xkcd/packages.el
+++ b/layers/+fun/xkcd/packages.el
@@ -20,7 +20,7 @@
       (when (not (file-directory-p xkcd-cache-dir))
         (make-directory xkcd-cache-dir))
       (spacemacs/set-leader-keys
-        "ax" 'xkcd)
+        "afx" 'xkcd)
       (evilified-state-evilify xkcd-mode xkcd-mode-map
         "h" 'xkcd-prev
         "j" 'xkcd-next

--- a/layers/+readers/dash/README.org
+++ b/layers/+readers/dash/README.org
@@ -80,9 +80,9 @@ For more details please check [[https://github.com/stanaka/dash-at-point#Usage][
 
 * Key bindings
 
-| Key binding | Description                                                     |
-|-------------+-----------------------------------------------------------------|
-| ~SPC a z d~ | Lookup thing at point in Dash or Zeal                           |
-| ~SPC a z D~ | Lookup thing at point in Dash or Zeal within a specified Docset |
-| ~SPC a z h~ | Lookup thing at point in helm-dash or counsel-dash              |
-| ~SPC a z H~ | Lookup in helm-dash or counsel-dash within a specified Docset   |
+| Key binding   | Description                                                     |
+|---------------+-----------------------------------------------------------------|
+| ~SPC a r z d~ | Lookup thing at point in Dash or Zeal                           |
+| ~SPC a r z D~ | Lookup thing at point in Dash or Zeal within a specified Docset |
+| ~SPC a r z h~ | Lookup thing at point in helm-dash or counsel-dash              |
+| ~SPC a r z H~ | Lookup in helm-dash or counsel-dash within a specified Docset   |

--- a/layers/+readers/dash/packages.el
+++ b/layers/+readers/dash/packages.el
@@ -22,7 +22,7 @@
   (use-package helm-dash
     :defer t
     :init (progn
-            (spacemacs/declare-prefix "az" "zeal/dash docs")
+            (spacemacs/declare-prefix "arz" "zeal/dash docs")
             (spacemacs/set-leader-keys
               "azh" 'helm-dash-at-point
               "azH" 'helm-dash))
@@ -33,10 +33,10 @@
   (use-package counsel-dash
     :defer t
     :init (progn
-            (spacemacs/declare-prefix "az" "zeal/dash docs")
+            (spacemacs/declare-prefix "arz" "zeal/dash docs")
             (spacemacs/set-leader-keys
-              "azh" 'counsel-dash-at-point
-              "azH" 'counsel-dash))
+              "arzh" 'counsel-dash-at-point
+              "arzH" 'counsel-dash))
     :config (when dash-autoload-common-docsets
               (dash//activate-package-docsets dash-docs-docset-newpath))))
 
@@ -44,19 +44,19 @@
   (use-package dash-at-point
     :defer t
     :init (progn
-            (spacemacs/declare-prefix "az" "zeal/dash docs")
+            (spacemacs/declare-prefix "arz" "zeal/dash docs")
             (spacemacs/set-leader-keys
-              "azd" 'dash-at-point
-              "azD" 'dash-at-point-with-docset))))
+              "arzd" 'dash-at-point
+              "arzD" 'dash-at-point-with-docset))))
 
 (defun dash/init-zeal-at-point ()
   (use-package zeal-at-point
     :defer t
     :init (progn
-            (spacemacs/declare-prefix "az" "zeal/dash docs")
+            (spacemacs/declare-prefix "arz" "zeal/dash docs")
             (spacemacs/set-leader-keys
-              "azd" 'zeal-at-point
-              "azD" 'zeal-at-point-set-docset))
+              "arzd" 'zeal-at-point
+              "arzD" 'zeal-at-point-set-docset))
     :config
     ;; This lets users search in multiple docsets
     (add-to-list 'zeal-at-point-mode-alist '(web-mode . "html,css,javascript"))))

--- a/layers/+readers/deft/README.org
+++ b/layers/+readers/deft/README.org
@@ -59,7 +59,7 @@ Just add or substitute your preferred extension.
 
 | Key binding | Description                      |
 |-------------+----------------------------------|
-| ~SPC a n~   | Open Deft (works globally)       |
+| ~SPC a r d~ | Open Deft (works globally)       |
 | ~SPC C d~   | Create new file (works globally) |
 | ~SPC m c~   | Clear deft filter                |
 | ~SPC m d~   | Delete selected note             |
@@ -75,13 +75,13 @@ Zetteldeft key bindings will appear in a few different places as follows:
 
 *** Global
 
-| Key binding               | Description                    |
-|---------------------------+--------------------------------|
-| ~SPC C z~ / ~SPC a n z n~ | New zetteldeft file            |
-| ~SPC a n n~               | Open deft (replaces ~SPC a n~) |
-| ~SPC a n z T~             | Show tag buffer                |
-| ~SPC a n z s~             | Zetteldeft search-at-point     |
-| ~SPC a n z o~             | Zetteldeft find file           |
+| Key binding                 | Description                      |
+|-----------------------------+----------------------------------|
+| ~SPC C z~ / ~SPC a r d z n~ | New zetteldeft file              |
+| ~SPC a r d n~               | Open deft (replaces ~SPC a r d~) |
+| ~SPC a r d z T~             | Show tag buffer                  |
+| ~SPC a r d z s~             | Zetteldeft search-at-point       |
+| ~SPC a r d z o~             | Zetteldeft find file             |
 
 *** Org-mode
 

--- a/layers/+readers/deft/packages.el
+++ b/layers/+readers/deft/packages.el
@@ -23,7 +23,7 @@
     (progn
       (spacemacs/declare-prefix-for-mode 'deft-mode "mz" "zetteldeft")
       (spacemacs/declare-prefix-for-mode 'org-mode "mz" "zetteldeft")
-      (spacemacs/declare-prefix "anz" "zetteldeft")
+      (spacemacs/declare-prefix "ardz" "zetteldeft")
       ;; zetteldeft actions in deft mode
       (spacemacs/set-leader-keys-for-major-mode 'deft-mode
         "zT" 'zetteldeft-tag-buffer
@@ -46,10 +46,10 @@
       ;; new zetteldeft file under capture
       (spacemacs/set-leader-keys "Cz" 'zetteldeft-new-file)
       ;; actions under applications/deft/zetteldeft
-      (spacemacs/set-leader-keys "anzn" 'zetteldeft-new-file)
-      (spacemacs/set-leader-keys "anzT" 'zetteldeft-tag-buffer)
-      (spacemacs/set-leader-keys "anzs" 'zetteldeft-search-at-point)
-      (spacemacs/set-leader-keys "anzo" 'zetteldeft-find-file)
+      (spacemacs/set-leader-keys "ardzn" 'zetteldeft-new-file)
+      (spacemacs/set-leader-keys "ardzT" 'zetteldeft-tag-buffer)
+      (spacemacs/set-leader-keys "ardzs" 'zetteldeft-search-at-point)
+      (spacemacs/set-leader-keys "ardzo" 'zetteldeft-find-file)
     )))
 
 (defun deft/init-deft ()
@@ -64,9 +64,9 @@
       ;; in applications prefix, NOTE: backward incompatible keybindings
       (if deft-zetteldeft
           (progn
-            (spacemacs/declare-prefix "an" "deft")
-            (spacemacs/set-leader-keys "ann" 'spacemacs/deft))
-        (spacemacs/set-leader-keys "an" 'spacemacs/deft))
+            (spacemacs/declare-prefix "ard" "deft")
+            (spacemacs/set-leader-keys "ardn" 'spacemacs/deft))
+        (spacemacs/set-leader-keys "ard" 'spacemacs/deft))
       ;; put in capture prefix
       (spacemacs/set-leader-keys "Cd" 'deft-new-file)
 

--- a/layers/+readers/elfeed/README.org
+++ b/layers/+readers/elfeed/README.org
@@ -109,7 +109,7 @@ In this case you can disable these by setting =elfeed-enable-goodies= to =nil=.
 
 | Key binding | Description  |
 |-------------+--------------|
-| ~SPC a f~   | start elfeed |
+| ~SPC a r e~ | start elfeed |
 
 Use =SPC ?= to discover major-mode key bindings.
 

--- a/layers/+readers/elfeed/packages.el
+++ b/layers/+readers/elfeed/packages.el
@@ -19,7 +19,7 @@
 (defun elfeed/init-elfeed ()
   (use-package elfeed
     :defer t
-    :init (spacemacs/set-leader-keys "af" 'elfeed)
+    :init (spacemacs/set-leader-keys "are" 'elfeed)
     :config
     (progn
       (evilified-state-evilify-map elfeed-search-mode-map

--- a/layers/+readers/speed-reading/README.org
+++ b/layers/+readers/speed-reading/README.org
@@ -23,7 +23,7 @@ file.
 
 | Key binding | Description   |
 |-------------+---------------|
-| ~SPC a R~   | Start Spray   |
+| ~SPC a r s~ | Start Spray   |
 | ~SPC~       | Pause Spray   |
 | ~h~         | Backward word |
 | ~l~         | Forward word  |

--- a/layers/+readers/speed-reading/packages.el
+++ b/layers/+readers/speed-reading/packages.el
@@ -26,7 +26,7 @@
         (evil-insert-state)
         (spray-mode t)
         (internal-show-cursor (selected-window) nil))
-      (spacemacs/set-leader-keys "aR" 'speed-reading/start-spray)
+      (spacemacs/set-leader-keys "ars" 'speed-reading/start-spray)
 
       (defadvice spray-quit (after speed-reading//quit-spray activate)
         "Correctly quit spray."

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -20,6 +20,9 @@
                                        ("/"   "search project")
                                        ("?"   "show keybindings")
                                        ("a"   "applications")
+                                       ("ac"   "chat")
+                                       ("ae"   "email")
+                                       ("af"   "fun")
                                        ("at"  "tools")
                                        ("atg" "geolocation")
                                        ("A"   "other applications")
@@ -177,7 +180,7 @@
    ("y" yank-rectangle "Paste last rectangle"))))
 ;; applications ---------------------------------------------------------------
 (spacemacs/set-leader-keys
-  "ac"  'calc-dispatch
+  "a*"  'calc-dispatch
   "ap"  'list-processes
   "aP"  'proced
   "au"  'undo-tree-visualize)

--- a/layers/+web-services/evernote/README.org
+++ b/layers/+web-services/evernote/README.org
@@ -53,11 +53,11 @@ check out the corresponding section in the FAQ (~SPC h SPC $PATH RET~).
 
 * Key bindings
 
-| Key binding | Description                         |
-|-------------+-------------------------------------|
-| ~SPC a e c~ | create a new note                   |
-| ~SPC a e e~ | edit an existing note               |
-| ~SPC a e f~ | find a note using a keyword         |
-| ~SPC a e s~ | show an existing note               |
-| ~SPC a e r~ | remove an existing note             |
-| ~SPC a e m~ | move a note to a different notebook |
+| Key binding   | Description                         |
+|---------------+-------------------------------------|
+| ~SPC a w e c~ | create a new note                   |
+| ~SPC a w e e~ | edit an existing note               |
+| ~SPC a w e f~ | find a note using a keyword         |
+| ~SPC a w e s~ | show an existing note               |
+| ~SPC a w e r~ | remove an existing note             |
+| ~SPC a w e m~ | move a note to a different notebook |

--- a/layers/+web-services/evernote/packages.el
+++ b/layers/+web-services/evernote/packages.el
@@ -24,11 +24,11 @@
                geeknote-move)
     :init
     (progn
-      (spacemacs/declare-prefix "ae" "applications-evernote")
+      (spacemacs/declare-prefix "awe" "applications-evernote")
       (spacemacs/set-leader-keys
-        "aec" 'geeknote-create
-        "aee" 'geeknote-edit
-        "aef" 'geeknote-find
-        "aes" 'geeknote-show
-        "aer" 'geeknote-remove
-        "aem" 'geeknote-move))))
+        "awec" 'geeknote-create
+        "awee" 'geeknote-edit
+        "awef" 'geeknote-find
+        "awes" 'geeknote-show
+        "awer" 'geeknote-remove
+        "awem" 'geeknote-move))))

--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -51,9 +51,9 @@ file.
 
 * Key bindings
 
-| Evil      | Holy    | Command                                   |
-|-----------+---------+-------------------------------------------|
-| ~SPC a /~ | ~C-c /~ | Summon a Helm buffer to select any engine |
+| Evil        | Holy    | Command                                   |
+|-------------+---------+-------------------------------------------|
+| ~SPC a w /~ | ~C-c /~ | Summon a Helm buffer to select any engine |
 
 * Customize it!
 If you'd rather have emacs use chrome, or firefox or any other thing (=eww=) you

--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -23,7 +23,7 @@
     :init
     (progn
       (spacemacs/set-leader-keys
-        "a/" 'spacemacs/search-engine-select)
+        "aw/" 'spacemacs/search-engine-select)
       (setq search-engine-alist
             `((amazon
                :name "Amazon"


### PR DESCRIPTION
refactor key bindings for applications to provide additional room for
applications and use lower case characters.

Move calc-dispatch to `SPC a *`

Relates to #13503

cc/
@smile13241324 