### PR TITLE
Fix spacelpa public key file name

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -81,7 +81,7 @@ the .lock file at the root of the repository.")
   "Remote location of the signature file for the ELPA stable directory")
 
 (defconst configuration-layer--stable-elpa-gpg-keyring
-  (expand-file-name (concat spacemacs-core-directory "gnupg/spacemacs.pub"))
+  (expand-file-name (concat spacemacs-core-directory "gnupg/spacemacs.gpg"))
   "Absolute path to public GPG key used to signed the ELPA stable repository
 tarballs.")
 


### PR DESCRIPTION
This fixes the issue that users have to import the public key manually
to pass spacelpa archive verification. See #12652
