### PR TITLE
Use the standard elpa gpg homedir

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2687,6 +2687,10 @@ continue with the stable ELPA repository installation."
           (error (setq verification-err
                        (format "GnuPGP doesn't seem to be available. %s"
                                (cdr error)))))
+        (when package-gnupghome-dir
+          (with-file-modes 448
+            (make-directory package-gnupghome-dir t))
+          (setf (epg-context-home-directory context) package-gnupghome-dir))
         (unless verification-err
           (condition-case error
               (epg-import-keys-from-file


### PR DESCRIPTION
This PR makes it so spacemacs uses the same gpg keyring as elpa (under `~/.emacs.d/elpa/gnupg`), instead of using the user's default gpg keyring to verify spacelpa archives.

Closes #13738