### PR TITLE
Add ctp files to html language

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -247,6 +247,7 @@
      ("\\.eco\\'"        . web-mode)
      ("\\.ejs\\'"        . web-mode)
      ("\\.svelte\\'"     . web-mode)
+     ("\\.ctp\\'"        . web-mode)
      ("\\.djhtml\\'"     . web-mode))))
 
 (defun html/post-init-yasnippet ()


### PR DESCRIPTION
When editing Cakephp template files there is not highlighting. This adds the
`.ctp` files to the html language using web-mode.