### PR TITLE
Allow multichar major mode leader key for exiting magit commit edits

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -221,15 +221,15 @@
         (let ((mm-key dotspacemacs-major-mode-leader-key))
           (dolist (state '(normal motion))
             (evil-define-key state with-editor-mode-map
-              (concat mm-key mm-key) 'with-editor-finish
-              (concat mm-key "a")    'with-editor-cancel
-              (concat mm-key "c")    'with-editor-finish
-              (concat mm-key "k")    'with-editor-cancel)
+              (concat (kbd mm-key) (kbd mm-key)) 'with-editor-finish
+              (concat (kbd mm-key) "a")    'with-editor-cancel
+              (concat (kbd mm-key) "c")    'with-editor-finish
+              (concat (kbd mm-key) "k")    'with-editor-cancel)
             (evil-define-key state magit-log-select-mode-map
-              (concat mm-key mm-key) 'magit-log-select-pick
-              (concat mm-key "a")    'magit-log-select-quit
-              (concat mm-key "c")    'magit-log-select-pick
-              (concat mm-key "k")    'magit-log-select-quit))))
+              (concat (kbd mm-key) (kbd mm-key)) 'magit-log-select-pick
+              (concat (kbd mm-key) "a")    'magit-log-select-quit
+              (concat (kbd mm-key) "c")    'magit-log-select-pick
+              (concat (kbd mm-key) "k")    'magit-log-select-quit))))
       ;; whitespace
       (define-key magit-status-mode-map (kbd "C-S-w")
         'spacemacs/magit-toggle-whitespace)


### PR DESCRIPTION
I use `DEL` as my major-mode leader key and found that the magit bindings during commit message edits weren't recognizing it because it was more than one character (like the default `,`. I think anyone who uses a major mode leader key like `DEL`, `RET` or even `SPC` will appreciate the consistency with org-capture, mu-compose, etc.

The fix just involves wrapping the `mm-key` variable in `kbd` to convert it to a form that can be concatenated and interpreted as expected by `evil-define-key`