### PR TITLE
[agda] Change outdated agsy call

### DIFF
--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -78,7 +78,7 @@
           ","   'agda2-goal-and-context
           "="   'agda2-show-constraints
           "SPC" 'agda2-give
-          "a"   agda2-auto
+          "a"   'agda2-autoOne
           "c"   'agda2-make-case
           "d"   'agda2-infer-type-maybe-toplevel
           "e"   'agda2-show-context


### PR DESCRIPTION
Use the current `agda2-autoOne` command to attempt to auto-prove
instead of the previous `agda2-auto`.