### PR TITLE
[clojure] refactor namespace key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1591,6 +1591,11 @@ Other:
     (thanks to John Stevenson)
   - Changed evaluation keybinding - cider-clojure-interaction-mode
     ~SPC m e p l~ 'cider-eval-print-last-sexp
+  - Add refactor namespace key bindings
+    ~ran~ 'clojure-insert-ns-form
+    ~raN~ 'clojure-insert-ns-form-at-point
+    ~rsn~ 'clojure-sort-ns
+    (thanks to John Stevenson)
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -604,6 +604,8 @@ The following refactoring key bindings are enabled by default in clojure-mode:
 
 | Key binding   | Description                                                    |
 |---------------+----------------------------------------------------------------|
+| ~SPC m r a n~ | insert a namespace form at the beginning of the buffer         |
+| ~SPC m r a N~ | insert a namespace form at point                               |
 | ~SPC m r c i~ | cycle between if and if-not forms                              |
 | ~SPC m r c p~ | cycle privacy of defn and def forms                            |
 | ~SPC m r c (~ | convert coll to list                                           |
@@ -611,6 +613,7 @@ The following refactoring key bindings are enabled by default in clojure-mode:
 | ~SPC m r c {~ | convert coll to map                                            |
 | ~SPC m r c #~ | convert coll to set                                            |
 | ~SPC m r c [~ | convert coll to vector                                         |
+| ~SPC m r s n~ | sort namespaces inside the ns form                             |
 | ~SPC m r t f~ | rewrite the following form to use the -> (thread first) macro. |
 | ~SPC m r t l~ | rewrite the following form to use the ->> (thread last) macro. |
 | ~SPC m r t h~ | thread another form into the surrounding threading macro       |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -352,6 +352,8 @@
                 clj-refactor--key-binding-prefixes)
           (spacemacs/set-leader-keys-for-major-mode m
             "=l" 'clojure-align
+            "ran" 'clojure-insert-ns-form
+            "raN" 'clojure-insert-ns-form-at-point
             "rci" 'clojure-cycle-if
             "rcp" 'clojure-cycle-privacy
             "rc#" 'clojure-convert-collection-to-set
@@ -360,6 +362,7 @@
             "rc[" 'clojure-convert-collection-to-vector
             "rc{" 'clojure-convert-collection-to-map
             "rc:" 'clojure-toggle-keyword-string
+            "rsn" 'clojure-sort-ns
             "rtf" 'clojure-thread-first-all
             "rth" 'clojure-thread
             "rtl" 'clojure-thread-last-all


### PR DESCRIPTION
Add key bindings to refactor namespace forms for existing functions in clojure-mode

"ran" 'clojure-insert-ns-form
"raN" 'clojure-insert-ns-form-at-point
"rsn" 'clojure-sort-ns