### PR TITLE
[spacemacs-bootstrap] Fix mode-line evil state foreground

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1323,6 +1323,7 @@ Other:
   - Fixed ~SPC h f~ =helm-spacemacs-help-faq= (thanks to duianto)
   - Fixed =cl= package deprecated =letf= (thanks to duianto)
   - Fixed origami bindings in normal mode (thanks to Tomasz Kowal)
+  - Fixed mode-line evil state foreground color (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -58,7 +58,8 @@ For evil states that also need an entry to `spacemacs-evil-cursors' use
   ;; visibly flashing in treemacs buffers
   (eval `(defface ,(intern (format "spacemacs-%s-face" state))
            `((t (:background ,color
-                             :foreground ,(face-background 'mode-line)
+                             :foreground ,(spacemacs/get-darker-color-of-face-fg-or-bg
+                                           'mode-line)
                              :inherit 'mode-line)))
            (format "%s state face." state)
            :group 'spacemacs)))
@@ -66,9 +67,37 @@ For evil states that also need an entry to `spacemacs-evil-cursors' use
 (defun spacemacs/set-state-faces ()
   (cl-loop for (state color cursor) in spacemacs-evil-cursors
            do
-           (set-face-attribute (intern (format "spacemacs-%s-face" state))
-                               nil
-                               :foreground (face-background 'mode-line))))
+           (set-face-attribute
+            (intern (format "spacemacs-%s-face" state))
+            nil
+            :foreground (spacemacs/get-darker-color-of-face-fg-or-bg 'mode-line))))
+
+(defun spacemacs/get-darker-color-of-face-fg-or-bg (face)
+  "Return the darker color of the FACE foreground or background,
+based on the luminance of the FACE background.
+
+If the FACE background is brighter than 0.5,
+return the FACE background,
+otherwise return the FACE foreground."
+  (if (> 0.5 (rainbow-x-color-luminance (face-background face)))
+      (face-background face)
+    (face-foreground face)))
+
+;; source: http://elpa.gnu.org/packages/rainbow-mode-1.0.4.el
+(defun rainbow-color-luminance (red green blue)
+  "Calculate the relative luminance of color composed of RED, GREEN and BLUE.
+Return a value between 0 and 1."
+  (/ (+ (* .2126 red) (* .7152 green) (* .0722 blue)) 255))
+
+;; source: http://elpa.gnu.org/packages/rainbow-mode-1.0.4.el
+(defun rainbow-x-color-luminance (color)
+  "Calculate the relative luminance of a color string (e.g. \"#ffaa00\", \"blue\").
+Return a value between 0 and 1."
+  (let* ((values (x-color-values color))
+         (r (/ (car values) 256.0))
+         (g (/ (cadr values) 256.0))
+         (b (/ (caddr values) 256.0)))
+    (rainbow-color-luminance r g b)))
 
 (defun evil-insert-state-cursor-hide ()
   (setq evil-insert-state-cursor '((hbar . 0))))


### PR DESCRIPTION
The evil state foreground color on the mode-line was set to
the mode-line background color.

This caused problems with some themes.
[FEATURE REQUEST] Darker option for mode-line color codes #13731

Solution:
Set the evil state foreground color to the darker of the
mode-line face foreground or background colors.

---

### With the `gruvbox-light-hard` theme

### Spacemacs Home buffer:
#### Before
![before home buffer](https://user-images.githubusercontent.com/13420573/86909738-d2e7bd80-c118-11ea-8f56-28ab0aeb64e7.png)

#### After

![after home buffer](https://user-images.githubusercontent.com/13420573/86909748-d713db00-c118-11ea-9a16-ed19c95498ce.png)

### Scratch buffer:
#### Before

![before scratch buffer](https://user-images.githubusercontent.com/13420573/86909766-e1ce7000-c118-11ea-8e5c-7f55d1782e28.png)

#### After
![after scratch buffer](https://user-images.githubusercontent.com/13420573/86909799-edba3200-c118-11ea-9d6b-6f6aec0c9c9d.png)

I did a quick scan through the `themes-megapack` themes and it seemed to work for all of them.

