### PR TITLE
[osx] Don't initialize osx-dictionary on non-mac systems

### DIFF
--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -57,7 +57,7 @@
    Possible values are `super' `meta' `hyper' `alt' `left' `none'.
    Default: `left'.")
 
-(defvar osx-use-dictionary-app t
+(defvar osx-use-dictionary-app (spacemacs/system-is-mac)
   "Use the macOS dictionary app instead of Wordnet.")
 
 (defvar osx-swap-option-and-command nil


### PR DESCRIPTION
Restore the `SPC x w d` key binding for define-word-at-point, from
spacemacs-language.