### PR TITLE
Remove gradle-mode to stop it breaking bindings of other major modes

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2325,7 +2325,7 @@ Other:
   - Added support for multiple backends. Supported backends are: =meghanada=,
     =eclim=. The default backend is =meghanada=. (thanks to Ivan Yonchovski)
   - Added =ENSIME= jump handlers (thanks to Joao Azevedo)
-  - Improved =maven= and =gradle= support (thanks to Sylvain Benner)
+  - Improved =maven= (thanks to Sylvain Benner)
   - Made =java= layer depend on =groovy= layer (thanks to Sylvain Benner)
   - Added =org-babel= support (thanks to Michael Rohleder)
   - Remove broken =ENSIME= key bindings (thanks to Bjarke Vad Andersen)
@@ -2337,6 +2337,7 @@ Other:
   - Added /** */ smartparens pair (thanks to Ivan Yonchovski)
   - Added the prefix name "actionable" to ~SPC m a~ (thanks to duianto)
 - Fixes:
+  - Removed =gradle-mode= which is unsupported and was breaking other major modes
   - Replace usage of =ensime-print-type-at-point= by =ensime-type-at-point=
     (thanks to Joao Azevedo)
   - Added defalias for =ensime-type-at-point= for compatibility
@@ -2344,7 +2345,7 @@ Other:
   - Fixed syntax typo in configuration (thanks to EMayej)
   - Fixed yanking types (thanks to Bjarke Vad Andersen)
   - Fixed gtags related initialization (thanks to Guido Kraemer)
-  - Fixed prefixes for =java-mode= and =gradle-mode= (thanks to Seong Yong-ju)
+  - Fixed prefixes for =java-mode= (thanks to Seong Yong-ju)
   - Enabled =lsp-java= when the =java-backend= is =nil= and the =lsp= layer is
     enabled (thanks to Ivan Yonchovski)
   - Fixed =dap-java= shortcuts (thanks to Ivan Yonchovski)

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -28,7 +28,6 @@
     - [[#refactoring][Refactoring]]
     - [[#tasks][Tasks]]
   - [[#maven][Maven]]
-  - [[#gradle][Gradle]]
 
 * Description
 This layer adds support for the Java language.
@@ -39,7 +38,7 @@ This layer adds support for the Java language.
   - [[https://github.com/mopemope/meghanada-emacs][Meghanada]] client/server
 - Auto-completion using company
 - Linting using flycheck integration
-- Maven and Gradle integration
+- Maven integration
 - Interactive debugger using [[https://github.com/emacs-lsp/dap-mode][dap-mode]]
 
 * Layer Installation
@@ -217,15 +216,3 @@ complete list of key bindings on the [[https://github.com/syl20bnr/spacemacs/tre
 | ~SPC m m t b~   | Run current buffer tests                             |
 | ~SPC m m t i~   | Test and install                                     |
 | ~SPC m m t t~   | Run a specific test                                  |
-
-** Gradle
-
-| Key binding   | Description              |
-|---------------+--------------------------|
-| ~SPC m l c c~ | Compile                  |
-| ~SPC m l c C~ | Clean                    |
-| ~SPC m l c r~ | Clean and compile        |
-| ~SPC m l t a~ | Run all tests            |
-| ~SPC m l t b~ | Run current buffer tests |
-| ~SPC m l t t~ | Run a specific test      |
-| ~SPC m l x~   | Execute a Gradle task    |

--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -82,24 +82,6 @@
   (mvn-compile))
 
 
-;; Gradle
-
-(defun spacemacs/gradle-clean ()
-  "Execute 'gradle clean' command."
-  (interactive)
-  (gradle-execute "clean"))
-
-(defun spacemacs/gradle-clean-build ()
-  "Execute 'gradle clean build' command."
-  (interactive)
-  (gradle-execute "clean build"))
-
-(defun spacemacs/gradle-test-buffer ()
-  "Execute 'gradle test' command against current buffer tests."
-  (interactive)
-  (gradle-single-test (file-name-base (buffer-file-name))))
-
-
 ;; Misc
 
 (defun spacemacs//java-delete-horizontal-space ()

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -15,7 +15,6 @@
     dap-mode
     flycheck
     ggtags
-    gradle-mode
     counsel-gtags
     helm-gtags
     (java-mode :location built-in)
@@ -43,33 +42,6 @@
 (defun java/post-init-smartparens ()
   (with-eval-after-load 'smartparens
     (sp-local-pair 'java-mode "/** " " */" :trigger "/**")))
-
-(defun java/init-gradle-mode ()
-  (use-package gradle-mode
-    :defer t
-    :init
-    (progn
-      (when (configuration-layer/package-used-p 'groovy-mode)
-        (add-hook 'groovy-mode-hook 'gradle-mode)
-        (spacemacs/declare-prefix-for-mode 'groovy-mode "ml" "gradle")
-        (spacemacs/declare-prefix-for-mode 'groovy-mode "mlc" "compile")
-        (spacemacs/declare-prefix-for-mode 'groovy-mode "mlt" "tests"))
-      (when (configuration-layer/package-used-p 'java-mode)
-        (add-hook 'java-mode-hook 'gradle-mode)
-        (spacemacs/declare-prefix-for-mode 'java-mode "ml" "gradle")
-        (spacemacs/declare-prefix-for-mode 'java-mode "mlc" "compile")
-        (spacemacs/declare-prefix-for-mode 'java-mode "mlt" "tests")))
-    :config
-    (progn
-      (spacemacs|hide-lighter gradle-mode)
-      (spacemacs/set-leader-keys-for-minor-mode 'gradle-mode
-        "lcc" 'gradle-build
-        "lcC" 'spacemacs/gradle-clean
-        "lcr" 'spacemacs/gradle-clean-build
-        "lta" 'gradle-test
-        "ltb" 'spacemacs/gradle-test-buffer
-        "ltt" 'gradle-single-test
-        "lx" 'gradle-execute))))
 
 (defun java/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'java-mode))


### PR DESCRIPTION
After using Java mode, Gradle keybindings infect or even clobber keybindings of any subsequently used major-mode. For example, the critical Agda major mode keybinding of `l` as `agda2-load` gets with a Gradle menu!

The cause, found by @duianto, is that `emacs-gradle-mode` sets itself to a [global](https://github.com/jacobono/emacs-gradle-mode/blob/e4d665d5784ecda7ddfba015f07c69be3cfc45f2/gradle-mode.el#L176-L183) minor mode. The docs for `define-minor-mode` say about `:global:`:

> If non-nil specifies that the minor mode is not meant to be
> buffer-local, so don't make the variable MODE buffer-local.
> By default, the mode is buffer-local.

I don't know why `gradle-mode` is doing this; presumably there is some reason or need for it. But the author of that package hasn't been on GitHub since 2017, and the last update of the package itself is from early 2015. To seal the deal, `gradle-mode` hasn't been working anyway (at least, I've never got it to work). I've been running Gradle by launching a terminal within Emacs.

Fixes #13750.