### PR TITLE
[spell-checking] Add keybinding for flyspell-region

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3279,6 +3279,9 @@ Other:
 - Added key bindings (thanks to John Stevenson):
   - ~SPC S s~ Correct word at point
   - Transient State: ~SPC S . s~ Correct word at point
+- Added key binding:
+  - ~SPC S r~ flyspell-region
+  - Transient State: ~SPC S . r~ flyspell-region
 **** Syntax-checking
 - Key bindings:
   - ~SPC e e~ is now for triggering a syntax check, the old action

--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -128,6 +128,7 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 | ~SPC S a g~     | Add word to dict (global)              |
 | ~SPC S a s~     | Add word to dict (session)             |
 | ~SPC S b~       | Flyspell whole buffer                  |
+| ~SPC S r~       | Flyspell region                        |
 | ~SPC S c~       | Flyspell correct word before point     |
 | ~SPC S s~       | Flyspell correct word at point         |
 | ~SPC u SPC S c~ | Flyspell correct all errors one by one |
@@ -140,6 +141,7 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 | Key binding | Description                                      |
 |-------------+--------------------------------------------------|
 | ~SPC S . b~ | Rerun spell check for the whole buffer           |
+| ~SPC S . r~ | Rerun spell check for the selected region        |
 | ~SPC S . d~ | Change dictionary                                |
 | ~SPC S . n~ | Go to next spelling error                        |
 | ~SPC S . c~ | Correct word before point                        |

--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -51,14 +51,16 @@
 Spell Commands^^            Add To Dictionary^^               Other
 --------------^^----------  -----------------^^-------------  -----^^---------------------------
 [_b_] check whole buffer    [_B_] add word to dict (buffer)   [_t_] toggle spell check
-[_d_] change dictionary     [_G_] add word to dict (global)   [_q_] exit
-[_n_] next spell error      [_S_] add word to dict (session)  [_Q_] exit and disable spell check
+[_r_] check region          [_G_] add word to dict (global)   [_q_] exit
+[_d_] change dictionary     [_S_] add word to dict (session)  [_Q_] exit and disable spell check
+[_n_] next spell error
 [_c_] correct before point
 [_s_] correct at point"
         :on-enter (flyspell-mode)
         :bindings
         ("B" spacemacs/add-word-to-dict-buffer)
         ("b" flyspell-buffer)
+        ("r" flyspell-region)
         ("d" spell-checking/change-dictionary)
         ("G" spacemacs/add-word-to-dict-global)
         ("n" flyspell-goto-next-error)
@@ -93,6 +95,7 @@ Spell Commands^^            Add To Dictionary^^               Other
         "Sag" 'spacemacs/add-word-to-dict-global
         "Sas" 'spacemacs/add-word-to-dict-session
         "Sb" 'flyspell-buffer
+        "Sr" 'flyspell-region
         "Sd" 'spell-checking/change-dictionary
         "Sn" 'flyspell-goto-next-error
         "Ss" 'flyspell-correct-at-point))


### PR DESCRIPTION
`flyspell-region` should have its own keybinding for times when just a comment
needs to be spellchecked and the like.