### PR TITLE
[org] Updated 'Archive subtree' key binding to support upstream customisation mechanism

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -259,7 +259,7 @@ sane way, here is the complete list of changed key bindings
   - ~SPC m i t~ org-agenda-set-tags
   - ~SPC m i t~ org-set-tags
   - ~SPC m p~ org-priority
-  - ~SPC m s A~ org-archive-subtree
+  - ~SPC m s A~ org-archive-subtree-default
   - ~SPC m s N~ widen
   - ~SPC m s S~ org-sort
   - ~SPC m s b~ org-tree-to-indirect-buffer

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -256,7 +256,7 @@ Will work on both org-mode and any mode that accepts plain html."
 
         ;; Subtree editing
         "sa" 'org-toggle-archive-tag
-        "sA" 'org-archive-subtree
+        "sA" 'org-archive-subtree-default
         "sb" 'org-tree-to-indirect-buffer
         "sd" 'org-cut-subtree
         "sh" 'org-promote-subtree


### PR DESCRIPTION
Binding ~SPC m s A~ to org-archive-subtree-default rather than existing
org-archive-subtree binding.

The existing org layer keybinding calls `org-archive-subtree` directly, bypassing any user customisation via the upstream mechanism (modifying value of `org-archive-default-command`).

This change will be invisible to most users, as the default value of `org-archive-default-command` IS `org-archive-subtree` (the current binding), but remove a frustration point for users who do want to customise the behaviour (e.g. to preserve hierarchy when archiving - my own use case).

Resolves #13772