### PR TITLE
Ruby improvements

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -295,6 +295,18 @@ sane way, here is the complete list of changed key bindings
 ***** Ruby
 - Key bindings:
   - Changed ~SPC m h d~ to ~SPC m h h~ for =robe-doc= (thanks to Paweł Siudak)
+  - Changed ~SPC m T {~ to ~SPC m r {~ for =ruby-toggle-block= (thanks to Codruț
+    Constantin Gușoi)
+  - Changed ~SPC m T '~ to ~SPC m r '~ for =ruby-toggle-string-quotes= (thanks
+    to Codruț Constantin Gușoi)
+  - Added ~SPC m i f~ for =spacemacs/ruby-insert-frozen-string-literal-comment=
+    (thanks to Codruț Constantin Gușoi)
+  - Added ~SPC m i s~ for =spacemacs/ruby-insert-shebang= (thanks to Codruț
+    Constantin Gușoi)
+  - Added ~SPC m r }~ for =ruby-toggle-block= (thanks to Codruț Constantin
+    Gușoi)
+  - Added ~SPC m r "~ for =ruby-toggle-string-quotes= (thanks to Codruț
+    Constantin Gușoi)
 ***** Ruby on Rails
 - Key bindings:
   - New ~SPC m r f S~ to find serializer (thanks to Boris Buliga)

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -137,3 +137,18 @@ Called interactively it prompts for a directory."
     (highlight-lines-matching-regexp "byebug")
     (highlight-lines-matching-regexp "binding.irb")
     (highlight-lines-matching-regexp "binding.pry")))
+
+
+;; Insert text
+
+(defun spacemacs/ruby-insert-frozen-string-literal-comment ()
+  (interactive)
+  (save-excursion
+    (goto-char (point-min))
+    (insert "# frozen_string_literal: true\n")))
+
+(defun spacemacs/ruby-insert-shebang ()
+  (interactive)
+  (save-excursion
+    (goto-char (point-min))
+    (insert "#!/usr/bin/env ruby\n")))

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -93,6 +93,8 @@
                 #'spacemacs/ruby-maybe-highlight-debugger-keywords))
     :config
     (spacemacs/set-leader-keys-for-major-mode 'enh-ruby-mode
+      "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
+      "is"  'spacemacs/ruby-insert-shebang
       "r{" 'enh-ruby-toggle-block
       "r}" 'enh-ruby-toggle-block)))
 
@@ -283,9 +285,7 @@
             ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\|pryrc\\)\\'" . ruby-mode))
     :init
     (progn
-      ;; This might have been important 10 years ago but now it's frustrating.
-      (setq ruby-insert-encoding-magic-comment nil)
-
+      (spacemacs/declare-prefix-for-mode 'ruby-mode "mi" "insert")
       (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "test")
       (spacemacs/declare-prefix-for-mode 'ruby-mode "mT" "toggle")
 
@@ -294,11 +294,18 @@
       (add-hook 'ruby-mode-hook #'spacemacs//ruby-setup-backend)
       (add-hook 'ruby-mode-local-vars-hook
                 #'spacemacs/ruby-maybe-highlight-debugger-keywords))
-    :config (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
-              "r'" 'ruby-toggle-string-quotes
-              "r\"" 'ruby-toggle-string-quotes
-              "r{" 'ruby-toggle-block
-              "r}" 'ruby-toggle-block)))
+    :config
+    (progn
+      ;; This might have been important 10 years ago but now it's frustrating.
+      (setq ruby-insert-encoding-magic-comment nil)
+
+      (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
+        "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
+        "is"  'spacemacs/ruby-insert-shebang
+        "r'"  'ruby-toggle-string-quotes
+        "r\"" 'ruby-toggle-string-quotes
+        "r{"  'ruby-toggle-block
+        "r}"  'ruby-toggle-block))))
 
 (defun ruby/init-ruby-refactor ()
   (use-package ruby-refactor

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -86,6 +86,7 @@
     (progn
       (setq enh-ruby-deep-indent-paren nil
             enh-ruby-hanging-paren-deep-indent-level 2)
+      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mi" "insert")
       (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mt" "test")
 
       (add-hook 'enh-ruby-mode-hook #'spacemacs//ruby-setup-backend)

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -80,7 +80,7 @@
   (use-package enh-ruby-mode
     :mode (("Appraisals\\'" . enh-ruby-mode)
            ("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . enh-ruby-mode)
-           ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\)\\'" . enh-ruby-mode))
+           ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\|pryrc\\)\\'" . enh-ruby-mode))
     :interpreter "ruby"
     :init
     (progn
@@ -279,7 +279,8 @@
   (use-package ruby-mode
     :defer t
     :mode (("Appraisals\\'" . ruby-mode)
-           ("Puppetfile" . ruby-mode))
+            ("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . ruby-mode)
+            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\|pryrc\\)\\'" . ruby-mode))
     :init
     (progn
       (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "test")

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -283,6 +283,9 @@
             ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\|pryrc\\)\\'" . ruby-mode))
     :init
     (progn
+      ;; This might have been important 10 years ago but now it's frustrating.
+      (setq ruby-insert-encoding-magic-comment nil)
+
       (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "test")
       (spacemacs/declare-prefix-for-mode 'ruby-mode "mT" "toggle")
 

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -87,14 +87,14 @@
       (setq enh-ruby-deep-indent-paren nil
             enh-ruby-hanging-paren-deep-indent-level 2)
       (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mt" "test")
-      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mT" "toggle")
 
       (add-hook 'enh-ruby-mode-hook #'spacemacs//ruby-setup-backend)
       (add-hook 'enh-ruby-mode-local-vars-hook
                 #'spacemacs/ruby-maybe-highlight-debugger-keywords))
     :config
     (spacemacs/set-leader-keys-for-major-mode 'enh-ruby-mode
-      "T{" 'enh-ruby-toggle-block)))
+      "r{" 'enh-ruby-toggle-block
+      "r}" 'enh-ruby-toggle-block)))
 
 (defun ruby/post-init-evil-matchit ()
   (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
@@ -292,8 +292,10 @@
       (add-hook 'ruby-mode-local-vars-hook
                 #'spacemacs/ruby-maybe-highlight-debugger-keywords))
     :config (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
-              "T'" 'ruby-toggle-string-quotes
-              "T{" 'ruby-toggle-block)))
+              "r'" 'ruby-toggle-string-quotes
+              "r\"" 'ruby-toggle-string-quotes
+              "r{" 'ruby-toggle-block
+              "r}" 'ruby-toggle-block)))
 
 (defun ruby/init-ruby-refactor ()
   (use-package ruby-refactor


### PR DESCRIPTION
Did some improvements to the ruby layers:
1. Added `.pryrc` file to ruby modes, and the missing ones `enh-ruby-mode` had to `ruby-mode`.
2. Better keybindings for refactoring toggles.
3. Disabled ancient magic comment insertion by default.
4. Added functions and keybindings for common text header insertions (frozen string literals and shebang). 