### PR TITLE
visual: apply ansi color only on compilation major mode

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-visual/funcs.el
@@ -13,9 +13,10 @@
 ;; ansi-colors
 
 (defun spacemacs-visual//compilation-buffer-apply-ansi-colors ()
-  (let ((inhibit-read-only t))
-    (goto-char compilation-filter-start)
-    (ansi-color-apply-on-region (line-beginning-position) (point-max))))
+  (when (eq major-mode 'compilation-mode)
+    (let ((inhibit-read-only t))
+      (goto-char compilation-filter-start)
+      (ansi-color-apply-on-region (line-beginning-position) (point-max)))))
 
 
 ;; popwin


### PR DESCRIPTION
Some modes have compilation-mode as parent mode but the ansi coloring
scheme is breaking their highlighting.
i.e. https://github.com/Wilfred/ag.el/issues/124

Fix this by applying ansi-colors only when the major mode is
compilation-mode.