### PR TITLE
[shell] Update vterm binding in README

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -299,7 +299,7 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~SPC a t s T~ | Open, close or go to a =term=                              |
 | ~TAB~         | browse completion with =helm=                              |
 | ~SPC m H~     | browse history with =helm= (works in =eshell= and =shell=) |
-| ~SPC a s v~   | Open, close or go to a =vterm=                             |
+| ~SPC a t s v~ | Open, close or go to a =vterm=                             |
 | ~C-j~         | next item in history                                       |
 | ~C-k~         | previous item in history                                   |
 


### PR DESCRIPTION
Back in commit ac3752ffd, the binding for `vterm` was updated to fit in with the
rest of the `shell` layer bindings (under `SPC a t s v`).  However, the `README`
was not updated to match.  This PR updates the `README` for the `shell` layer.

Relates to #13503.