### PR TITLE
Change browse-at-remote to "SPC go" sicne it is not github specific

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -326,6 +326,10 @@ sane way, here is the complete list of changed key bindings
 - Key bindings:
   - Vagrant key bindings prefix is now ~SPC a V~.
   - Actually use ~SPC a t v t~ for =vagrant-tramp-term=
+***** Version Control
+- Key bindings:
+  - Changed ~SPC g h o~ to ~SPC g o~ for =browse-at-remote= (thanks to Codruț
+    Constantin Gușoi)
 ***** YAML
 - Added LSP support (thanks to Seong Yong-ju)
 ***** ycmd

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -81,8 +81,8 @@ VC commands:
 | Key binding | Description                                            |
 |-------------+--------------------------------------------------------|
 | ~SPC g .~   | Version control transient-state                        |
+| ~SPC g o~   | Browser at remote                                      |
 | ~SPC g r~   | Smerge mode transient-state                            |
-| ~SPC g h o~ | Browser at remote                                      |
 | ~SPC g v =~ | Open a hunk under the point in the diff buffer         |
 | ~SPC g v D~ | Compare the entire working tree with head              |
 | ~SPC g v e~ | Show diff against current head using ediff             |

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -307,4 +307,4 @@
 (defun version-control/init-browse-at-remote ()
   (use-package browse-at-remote
     :defer t
-    :init (spacemacs/set-leader-keys "gho" 'browse-at-remote)))
+    :init (spacemacs/set-leader-keys "go" 'browse-at-remote)))


### PR DESCRIPTION
Recently discovered `browse-at-remote` and it seems to not be tied to github, it handles many other websites, so this change makes the key binding simpler.