### PR TITLE
Improve slack layer keybindings

### DIFF
--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -66,7 +66,7 @@
       "acsq" 'slack-ws-close)
     (setq slack-enable-emoji t)
     :config
-    (dolist (mode '(slack-mode slack-message-buffer-mode))
+    (dolist (mode '(slack-mode slack-message-buffer-mode slack-thread-message-buffer-mode))
       (spacemacs/set-leader-keys-for-major-mode mode
         "j" 'slack-channel-select
         "g" 'slack-group-select
@@ -82,10 +82,12 @@
         "@" 'slack-message-embed-mention
         "#" 'slack-message-embed-channel
         ")" 'slack-message-add-reaction
-        "(" 'slack-message-remove-reaction))
-    (evil-define-key 'insert slack-mode-map
-      (kbd "@") 'slack-message-embed-mention
-      (kbd "#") 'slack-message-embed-channel)))
+        "(" 'slack-message-remove-reaction)
+      (let ((keymap (symbol-value (intern (concat (symbol-name mode) "-map")))))
+        (evil-define-key 'insert keymap
+          (kbd "@") 'slack-message-embed-mention
+          (kbd "#") 'slack-message-embed-channel
+          (kbd ":") 'slack-insert-emoji)))))
 
 (defun slack/post-init-window-purpose ()
   (purpose-set-extension-configuration


### PR DESCRIPTION
1. Make slack-mode bindings available in slack-thread-message-buffer-mode
2. Bind : to slack-insert-emoji

Let me know if you would prefer I split these into separate patches.