### PR TITLE
[layers/+lang/haskell] Prolong flycheck popup duration in Haskell layer.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3314,6 +3314,7 @@ Other:
 - Fixed =goto-flycheck-error-list= (thanks to Thanh Vuong)
 - Added lsp support for sqls
   - Added layer variable =sql-lsp-sqls-workspace-config-path= to setting workspace configuration
+- Added layer variable =syntax-checking-auto-hide-tooltips= (thanks to Martin Sosic)
 **** Swift
 - Update Swift REPL key bindings (thanks to Elliot Bulmer)
 **** Systemd

--- a/layers/+checkers/syntax-checking/README.org
+++ b/layers/+checkers/syntax-checking/README.org
@@ -14,6 +14,7 @@
   - [[#enable-flycheck-globally][Enable flycheck globally]]
   - [[#enable-support-for-traditional-error-navigation][Enable support for traditional error navigation]]
   - [[#bitmaps][Bitmaps]]
+  - [[#auto-hide-tooltips][Auto hide tooltips]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -91,6 +92,19 @@ variable =syntax-checking-use-original-bitmaps= to =t=:
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
     '((syntax-checking :variables syntax-checking-use-original-bitmaps t)))
+#+END_SRC
+
+
+** Auto hide tooltips
+You can set time in seconds after which tooltips are automatically hidden by setting
+the variable =syntax-checking-auto-hide-tooltips= to a positive number of seconds.
+
+Default value of =syntax-checking-auto-hide-tooltips= is =nil=, and in that case tooltips
+are kept open until the cursor is moved.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((syntax-checking :variables syntax-checking-auto-hide-tooltips 10)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+checkers/syntax-checking/config.el
+++ b/layers/+checkers/syntax-checking/config.el
@@ -14,6 +14,9 @@
 (defvar syntax-checking-enable-tooltips t
   "If non nil some feedback are displayed in tooltips.")
 
+(defvar syntax-checking-auto-hide-tooltips nil
+  "If non-nil and positive number, auto hide tooltips after number of seconds.")
+
 (defvar syntax-checking-enable-by-default t
   "Enable syntax-checking by default.")
 

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -102,7 +102,8 @@
     :defer t
     :init
     (with-eval-after-load 'flycheck
-      (flycheck-pos-tip-mode))))
+      (flycheck-pos-tip-mode)
+      (setq flycheck-pos-tip-timeout (or syntax-checking-auto-hide-tooltips 0)))))
 
 (defun syntax-checking/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin


### PR DESCRIPTION
While recently using haskell layer, I realized that flycheck popups dissapear after 5 seconds, which was making my development really hard -> error messages in haskell are usually pretty complex and lenghty, and trying to read them in 5 seconds is in most cases impossible, so I would repeatedly have to move and return my cursor on the position of error to see the message again and again.

After some digging and help from people on gitter, I learned that by default flycheck shows popup for 5 seconds (this default is coming from flycheck-pos-tip), and that duration of popup can be modified with `flycheck-pos-tip-timeout` variable. I put it to 20 seconds since I believe that is fairly long, we could even put it to something longer. I am not even sure if this popup timeout is useful at all to be honest.

This is my first commit and I am not very proficient with elisp so I put it is most obvious place and I can confirm that it works, however I don't know if there is a better location to put this command, I am hoping you will tell me!