### PR TITLE
[layers/+lang/haskell] Make flycheck run hlint checker after dante checker.

### DIFF
--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -138,6 +138,8 @@
     :defer t
     :config
     (progn
+      (add-hook 'dante-mode-hook
+                (lambda () (flycheck-add-next-checker 'haskell-dante '(info . haskell-hlint))))
       (dolist (mode haskell-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
           "gb" 'xref-pop-marker-stack

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -138,8 +138,6 @@
     :defer t
     :config
     (progn
-      (add-hook 'dante-mode-hook
-                (lambda () (flycheck-add-next-checker 'haskell-dante '(info . haskell-hlint))))
       (dolist (mode haskell-modes)
         (spacemacs/set-leader-keys-for-major-mode mode
           "gb" 'xref-pop-marker-stack
@@ -162,7 +160,11 @@
       (spacemacs/set-leader-keys-for-major-mode mode "hf" 'helm-hoogle))))
 
 (defun haskell/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'haskell-mode))
+  (progn
+    (add-hook 'dante-mode-hook
+              (lambda () (flycheck-add-next-checker 'haskell-dante '(warning . haskell-hlint))))
+    (spacemacs/enable-flycheck 'haskell-mode))
+  )
 
 (defun haskell/init-flycheck-haskell ()
   (use-package flycheck-haskell


### PR DESCRIPTION
Currently, when dante is used as backend, hlint is not used at all in flycheck.

Therefore, in this PR I added hlint checker as next checker after dante checker.

I have to admit I wasn't sure at all where to put the code in question. I can confirm that it works currently, but I am considering this first commit more of a first try and I hoping somebody will me guide better where to put it exactly and how to implement this properly.
