### PR TITLE
Add more slack keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3238,6 +3238,8 @@ Other:
   - ~SPC m )~ to add reaction (thanks to Swaroop C H)
   - ~SPC m (~ to remove reaction (thanks to Swaroop C H)
   - ~SPC m t~ to open message thread (thanks to Swaroop C H)
+  - ~SPC m T~ to open all threads in workspace (thanks to wang-d)
+  - ~SPC m u~ to open all unreads in workspace (thanks to wang-d)
 - New layer variable =slack-spacemacs-layout-name= to customize the name of
   the custom layer for Slack buffers (thanks to Benjamin Reynolds)
 - New layer variable =slack-spacemacs-layout-binding= to customize the key used

--- a/layers/+chat/slack/README.org
+++ b/layers/+chat/slack/README.org
@@ -64,34 +64,37 @@ By default the values are:
 
 * Key bindings
 
-| Key binding   | Description                             |
-|---------------+-----------------------------------------|
-| ~SPC a c s d~ | Direct message someone                  |
-| ~SPC a c s g~ | Join a group (private channel)          |
-| ~SPC a c s j~ | Join a channel                          |
-| ~SPC a c s q~ | Close connection                        |
-| ~SPC a c s r~ | Join a channel, group, or direct messge |
-| ~SPC a c s s~ | (Re)connects to Slack                   |
-| ~SPC m c~     | Embed mention of channel                |
-| ~SPC m e~     | Edit message at point                   |
-| ~SPC m j~     | Join a channel                          |
-| ~SPC m d~     | Direct message someone                  |
-| ~SPC m m~     | Embed mention of user                   |
-| ~SPC m p~     | Load previous messages                  |
-| ~SPC m )~     | Add reaction (emoji) to a message       |
-| ~SPC m (~     | Remove reaction (emoji) to a message    |
-| ~SPC m t~     | Show or create thread                   |
-| ~SPC m q~     | Quit Slack                              |
+| Key binding   | Description                              |
+|---------------+------------------------------------------|
+| ~SPC a c s T~ | Show all threads followed in a workspace |
+| ~SPC a c s d~ | Direct message someone                   |
+| ~SPC a c s g~ | Join a group (private channel)           |
+| ~SPC a c s j~ | Join a channel                           |
+| ~SPC a c s q~ | Close connection                         |
+| ~SPC a c s r~ | Join a channel, group, or direct messge  |
+| ~SPC a c s s~ | (Re)connects to Slack                    |
+| ~SPC a c s u~ | Show all unread in a workspace           |
+| ~SPC m (~     | Remove reaction (emoji) to a message     |
+| ~SPC m )~     | Add reaction (emoji) to a message        |
+| ~SPC m c~     | Embed mention of channel                 |
+| ~SPC m d~     | Direct message someone                   |
+| ~SPC m e~     | Edit message at point                    |
+| ~SPC m j~     | Join a channel                           |
+| ~SPC m m~     | Embed mention of user                    |
+| ~SPC m p~     | Load previous messages                   |
+| ~SPC m q~     | Quit Slack                               |
+| ~SPC m t~     | Show or create thread                    |
 
 The following bindings are provided to mimic bindings in the official Slack
 client.
 
 | Key binding | Description              |
 |-------------+--------------------------|
-| ~SPC m @~   | Embed mention of user    |
 | ~SPC m #~   | Embed mention of channel |
 | ~SPC m )~   | Add a rection            |
+| ~SPC m :~   | Embed emoji              |
+| ~SPC m @~   | Embed mention of user    |
 | ~SPC m k~   | Join a channel           |
 
-In insert state, one can also use ~@~ and ~#~ directly without the leader key
-prefix.
+In insert state, one can also use ~:~, ~@~, and ~#~ directly without the leader
+key prefix.

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -58,12 +58,14 @@
     :init
     (spacemacs/declare-prefix "acs" "slack")
     (spacemacs/set-leader-keys
+      "acsT" 'slack-all-threads
       "acsd" 'slack-im-select
       "acsg" 'slack-group-select
       "acsj" 'slack-channel-select
       "acsq" 'slack-ws-close
       "acsr" 'slack-select-rooms
-      "acss" 'slack-start)
+      "acss" 'slack-start
+      "acsu" 'slack-all-unreads)
     (setq slack-enable-emoji t)
     :config
     (dolist (mode '(slack-mode slack-message-buffer-mode slack-thread-message-buffer-mode))
@@ -72,6 +74,7 @@
         "(" 'slack-message-remove-reaction
         ")" 'slack-message-add-reaction
         "@" 'slack-message-embed-mention
+        "T" 'slack-all-threads
         "d" 'slack-im-select
         "e" 'slack-message-edit
         "g" 'slack-group-select
@@ -82,7 +85,8 @@
         "p" 'slack-room-load-prev-messages
         "q" 'slack-ws-close
         "r" 'slack-select-rooms
-        "t" 'slack-thread-show-or-create)
+        "t" 'slack-thread-show-or-create
+        "u" 'slack-all-unreads)
       (let ((keymap (symbol-value (intern (concat (symbol-name mode) "-map")))))
         (evil-define-key 'insert keymap
           (kbd "#") 'slack-message-embed-channel

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -58,36 +58,36 @@
     :init
     (spacemacs/declare-prefix "acs" "slack")
     (spacemacs/set-leader-keys
-      "acss" 'slack-start
-      "acsj" 'slack-channel-select
-      "acsg" 'slack-group-select
-      "acsr" 'slack-select-rooms
       "acsd" 'slack-im-select
-      "acsq" 'slack-ws-close)
+      "acsg" 'slack-group-select
+      "acsj" 'slack-channel-select
+      "acsq" 'slack-ws-close
+      "acsr" 'slack-select-rooms
+      "acss" 'slack-start)
     (setq slack-enable-emoji t)
     :config
     (dolist (mode '(slack-mode slack-message-buffer-mode slack-thread-message-buffer-mode))
       (spacemacs/set-leader-keys-for-major-mode mode
-        "j" 'slack-channel-select
-        "g" 'slack-group-select
-        "r" 'slack-select-rooms
-        "d" 'slack-im-select
-        "p" 'slack-room-load-prev-messages
-        "e" 'slack-message-edit
-        "t" 'slack-thread-show-or-create
-        "q" 'slack-ws-close
-        "mm" 'slack-message-embed-mention
-        "mc" 'slack-message-embed-channel
-        "k" 'slack-select-rooms
-        "@" 'slack-message-embed-mention
         "#" 'slack-message-embed-channel
+        "(" 'slack-message-remove-reaction
         ")" 'slack-message-add-reaction
-        "(" 'slack-message-remove-reaction)
+        "@" 'slack-message-embed-mention
+        "d" 'slack-im-select
+        "e" 'slack-message-edit
+        "g" 'slack-group-select
+        "j" 'slack-channel-select
+        "k" 'slack-select-rooms
+        "mc" 'slack-message-embed-channel
+        "mm" 'slack-message-embed-mention
+        "p" 'slack-room-load-prev-messages
+        "q" 'slack-ws-close
+        "r" 'slack-select-rooms
+        "t" 'slack-thread-show-or-create)
       (let ((keymap (symbol-value (intern (concat (symbol-name mode) "-map")))))
         (evil-define-key 'insert keymap
-          (kbd "@") 'slack-message-embed-mention
           (kbd "#") 'slack-message-embed-channel
-          (kbd ":") 'slack-insert-emoji)))))
+          (kbd ":") 'slack-insert-emoji
+          (kbd "@") 'slack-message-embed-mention)))))
 
 (defun slack/post-init-window-purpose ()
   (purpose-set-extension-configuration


### PR DESCRIPTION
Two patches:

1. alphabetize existing keybindings
2. add keybindings for `slack-all-threads` and `slack-all-unreads`

I tested by trying each of the keybindings.

Note that `slack-all-unreads` is buggy for me, which might be an argument for not publicizing it with toplevel keybindings.  But it mostly works, and the bug is unrelated to the keybindings (I can reproduce via `M-x`). I'd like to bind the function now and hope for a fix from upstream later.