### PR TITLE
Add support for `all-the-icons` in Treemacs layer

### DIFF
--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -15,6 +15,7 @@
   - [[#git-mode][Git mode]]
   - [[#flattening-of-directories][Flattening of directories]]
   - [[#locking-width][Locking width]]
+  - [[#theme][Theme]]
 - [[#key-bindings][Key bindings]]
   - [[#global][Global]]
   - [[#inside-treemacs][Inside Treemacs]]
@@ -129,6 +130,15 @@ resizable through Treemacs commands and key bindings.
 #+END_SRC
 
 Default is =nil=.
+
+** Theme
+To use the `all-the-icons` theme rather than the default one, set the `treemacs-use-all-the-icons-theme` variable:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (treemacs :variables treemacs-use-all-the-icons-theme t)))
+#+END_SRC
+
 
 * Key bindings
 ** Global

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -39,3 +39,6 @@ There are 2 possible values:
 
 (defvar treemacs-use-icons-dired t
   "When non-nil use `treemacs-icons-dired'")
+
+(defvar treemacs-use-all-the-icons-theme nil
+  "Enable the treemacs supported `all-the-icons' theme")

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -16,6 +16,7 @@
     treemacs
     (treemacs-evil :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
     (treemacs-icons-dired :toggle treemacs-use-icons-dired)
+    (treemacs-all-the-icons :toggle treemacs-use-all-the-icons-theme)
     (treemacs-magit :requires magit)
     (treemacs-persp :requires persp-mode)
     treemacs-projectile
@@ -98,6 +99,11 @@
 (defun treemacs/init-treemacs-icons-dired ()
   (use-package treemacs-icons-dired
     :hook (dired-mode . treemacs-icons-dired-mode)))
+
+(defun treemacs/init-treemacs-all-the-icons ()
+  (use-package treemacs-all-the-icons
+    :if treemacs-use-all-the-icons-theme
+    :hook (treemacs-mode . (lambda () (treemacs-load-theme 'all-the-icons)))))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
The author of Treemacs recently published a package enabling [all-the-icons support](https://melpa.org/#/treemacs-all-the-icons). This PR adds a variable to optionally enable this theme.