### PR TITLE
feat: mnemonic, ergonomic keybindings for next-error, previous-error

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -513,6 +513,8 @@ Other:
     terminal mode, but no longer in GUI mode. (emacs18)
 *** Core changes
 - Improvements:
+  - Bind ~SPC c n~ to ~:cn~ / ~next-error~ and ~SPC c N~ to ~:cN~ / ~previous-error~
+    (thanks to Keith Pinson)
   - Display time spent in =user-config= in home buffer (thanks to Sylvain Benner)
   - Added dotfile function =dotspacemacs/user-load= (thanks to Sylvain Benner)
   - Added dotfile function =dotspacemacs/user-env= (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -441,6 +441,8 @@
   "cC" 'compile
   "ck" 'kill-compilation
   "cr" 'recompile
+  "cn" 'next-error
+  "cN" 'previous-error
   "cd" 'spacemacs/show-hide-compilation-window
   "cb" 'spacemacs/switch-to-compilation-buffer)
 (with-eval-after-load 'compile


### PR DESCRIPTION
When Spacemacs' fancy logic works well, it is breathtaking. Sometimes, however,
you may need a way to reach in for something a little more raw: in this case,
going straight to `next-error` rather than `spacemacs/next-error`.

I chose `cn`/`cN` because:

* They seem to be unused thus far
* It makes sense to put these keybinding under compile, since they are
  associated with Emac's base functionality for compilation.
* The analogous Ex commands are `:cn` and `:cN`. They work this way even in
  Spacemacs (but I am trying to wean myself off Ex mode, since I see the
  Spacemacs keybindings as far superior most scenarios).
* `cp` was already taken, so `cN` had to be used for going back.

Fixes #13815.