### PR TITLE
[haskell] fix: keybindings not bound in haskell-literate-mode

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -11,7 +11,7 @@
 
 ;; Variables
 
-(setq haskell-modes '(haskell-mode literate-haskell-mode))
+(setq haskell-modes '(haskell-mode haskell-literate-mode))
 
 (spacemacs|define-jump-handlers haskell-mode haskell-mode-jump-to-def-or-tag)
 


### PR DESCRIPTION
`literate-haskell-mode` was renamed to `haskell-literate-mode` in this commit:

https://github.com/haskell/haskell-mode/commit/7ccb1ab0cc460bbc84e0e4b35719839f2a9dd598

Even though a deprecated alias was added, it broke Spacemacs' keybindings, which
were still all bound w.r.t. the old name.