### PR TITLE
[ESS] Fix: remove obsolete variables in ESS

### DIFF
--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -70,9 +70,9 @@
     :init
     (progn
       (setq ess-use-company nil
-						ess-offset-continued 'straght
+						ess-offset-continued 'straight
             ess-nuke-trailing-whitespace-p t
-            ess-style 'DEFAULT)
+            ess-default-style 'DEFAULT)
 
       ;; add support for evil states
       (evil-set-initial-state 'ess-help-mode 'motion)

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -70,12 +70,9 @@
     :init
     (progn
       (setq ess-use-company nil
-            ;; Follow Hadley Wickham's R style guide
-            ess-first-continued-statement-offset 2
-            ess-continued-statement-offset 0
-            ess-expression-offset 2
+						ess-offset-continued 'straght
             ess-nuke-trailing-whitespace-p t
-            ess-default-style 'DEFAULT)
+            ess-style 'DEFAULT)
 
       ;; add support for evil states
       (evil-set-initial-state 'ess-help-mode 'motion)


### PR DESCRIPTION
- use ess-offset-continued to replace the obsolete variables (from ESS 15.04):
  ess-first-continued-statement-offset and ess-continued-statement-offset

- remove ess-expression-offset: no such variable now
