### PR TITLE
[hy] Add auto-completion installation instructions

### DIFF
--- a/layers/+lang/hy/README.org
+++ b/layers/+lang/hy/README.org
@@ -9,6 +9,7 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#auto-completion][Auto-completion]]
 - [[#key-bindings][Key bindings]]
   - [[#debug][Debug]]
   - [[#repl][REPL]]
@@ -34,7 +35,16 @@ add =hy= to the existing =dotspacemacs-configuration-layers= list in this file.
 To install =hy= globally:
 
 #+BEGIN_SRC sh
-  pip install hy
+  pip3 install hy
+#+END_SRC
+
+** Auto-completion
+=[[https://github.com/hylang/hy-mode][hy-mode]]= relies on =[[https://github.com/ekaschalk/jedhy][jedhy]]= for auto-completion.
+
+=jedhy= can be installed with:
+
+#+BEGIN_SRC
+pip3 install jedhy
 #+END_SRC
 
 * Key bindings


### PR DESCRIPTION
hy-mode relies on jedhy for auto-completion

Fixes #12624

---

This also changes the `hy` installation instructions to use `pip3` instead of `pip`, 
because at least in PopOS 20.04, `pip3` works, but `pip` is not found:
>username@pop-os ~ % pip --version
zsh: command not found: pip

>username@pop-os ~ % pip3 --version                      
pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)

In Windows 1903, both `pip` and `pip3` works.
>C:\Users\username>pip --version
pip 20.2 from c:\users\username\appdata\local\programs\python\python38\lib\site-packages\pip (python 3.8)

>C:\Users\username>pip3 --version
pip 20.2 from c:\users\username\appdata\local\programs\python\python38\lib\site-packages\pip (python 3.8)