### PR TITLE
Add Rusty Object Notation (RON) support to the Rust layer

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -19,6 +19,7 @@
     (flycheck-rust :requires flycheck)
     ggtags
     helm-gtags
+    (ron-mode :location (recipe :fetcher github :repo "nabero/ron-mode"))
     racer
     rust-mode
     smartparens
@@ -117,3 +118,8 @@
 (defun rust/init-toml-mode ()
   (use-package toml-mode
     :mode "/\\(Cargo.lock\\|\\.cargo/config\\)\\'"))
+
+(defun rust/init-ron-mode ()
+  (use-package ron-mode
+    :mode "\\.ron\\'" . ron-mode
+    :defer t))


### PR DESCRIPTION
# Add RON Support to Spacemacs
RON (Rusty Object Notation) is a JSON alternative used in the Rust community, and it currently is not available in Spacemacs. This PR Makes it a part of the Rust Layer (Sorry if I call it the "Rust Crate", Rust terminology).

# Why add RON to Spacemacs
1. RON is used in the Amethyst Game Engine to store data and configure it, adding it would make gamedev in Spacemacs easier
2. It's small and lite, so it's not THAT much more disk usage
3. It is only used in Rust, so having it's own layer makes no sense