### PR TITLE
[layers/+lang/c-c++]Add RTags shortcuts for trees and dead functions

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -436,6 +436,7 @@ A ~[ccls]~ suffix indicates that the binding is for the indicated backend only.
 | ~SPC m g D~ | diagnostics                     |
 | ~SPC m g e~ | reparse file                    |
 | ~SPC m g E~ | preprocess file                 |
+| ~SPC m g f~ | find dead functions             |
 | ~SPC m g F~ | fixit                           |
 | ~SPC m g G~ | guess function at point         |
 | ~SPC m g h~ | print class hierarchy           |
@@ -444,9 +445,11 @@ A ~[ccls]~ suffix indicates that the binding is for the indicated backend only.
 | ~SPC m g M~ | symbol info                     |
 | ~SPC m g O~ | goto offset                     |
 | ~SPC m g p~ | set current project             |
+| ~SPC m g r~ | display reference tree at point |
 | ~SPC m g R~ | rename symbol                   |
 | ~SPC m g s~ | print source arguments          |
 | ~SPC m g S~ | display summary                 |
+| ~SPC m g t~ | display include dependency tree |
 | ~SPC m g T~ | taglist                         |
 | ~SPC m g v~ | find virtuals at point          |
 | ~SPC m g V~ | print enum value at point       |

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -197,6 +197,7 @@
       "gD" 'rtags-diagnostics
       "ge" 'rtags-reparse-file
       "gE" 'rtags-preprocess-file
+      "gf" 'rtags-find-dead-functions
       "gF" 'rtags-fixit
       "gG" 'rtags-guess-function-at-point
       "gh" 'rtags-print-class-hierarchy
@@ -205,9 +206,11 @@
       "gM" 'rtags-symbol-info
       "gO" 'rtags-goto-offset
       "gp" 'rtags-set-current-project
+      "gr" 'rtags-references-tree
       "gR" 'rtags-rename-symbol
       "gs" 'rtags-print-source-arguments
       "gS" 'rtags-display-summary
+      "gt" 'rtags-dependency-tree
       "gT" 'rtags-taglist
       "gv" 'rtags-find-virtuals-at-point
       "gV" 'rtags-print-enum-value-at-point


### PR DESCRIPTION
The change will add 3 shortcuts for dependency, references trees and for finding dead functions.
