### PR TITLE
Fix org table evil paste

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2815,6 +2815,7 @@ Other:
   (thanks to Tianshu Wang)
 - Enabled =org-habit= module
   (thanks to Mariusz Klochowicz)
+- Fixed evil paste in a =org-src-mode= table (thanks to duianto)
 **** Osx
 - Key bindings:
   - Added key bindings to use ~command-1..9~ for selecting window

--- a/layers/+misc/multiple-cursors/funcs.el
+++ b/layers/+misc/multiple-cursors/funcs.el
@@ -21,9 +21,12 @@
   "Disable paste transient state if there is more than 1 cursor."
   (interactive "*P")
   (setq this-command 'evil-paste-after)
-  (if (spacemacs//evil-mc-paste-transient-state-p)
-    (spacemacs/paste-transient-state/evil-paste-after)
-    (evil-paste-after count (or register evil-this-register))))
+  (cond ((spacemacs//evil-mc-paste-transient-state-p)
+         (spacemacs/paste-transient-state/evil-paste-after))
+        ((and (bound-and-true-p org-src-mode)
+              (get-text-property (point) 'table-cell))
+         (*table--cell-yank))
+        (t (evil-paste-after count (or register evil-this-register)))))
 
 (defun spacemacs/evil-mc-paste-before (&optional count register)
   "Disable paste transient state if there is more than 1 cursor."


### PR DESCRIPTION
Paste using *table--cell-yank, in org-src-mode.

Fixes: Pasting into cells of table.el breaks table #13821