### PR TITLE
[lsp] Remove mention of `lsp-clients`

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -23,7 +23,7 @@
     :defer t
     :config
     (progn
-      (require 'lsp-clients)
+      (require 'lsp)
       (spacemacs/lsp-bind-keys)
       (setq lsp-prefer-capf t)
       (add-hook 'lsp-after-open-hook (lambda ()


### PR DESCRIPTION
This PR fixes the recent `lsp` layer breakage.