### PR TITLE
removed lsp-clients.el in lsp-mode package - fixes #13857

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -23,7 +23,11 @@
     :defer t
     :config
     (progn
-      (require 'lsp-clients)
+      (require 'lsp-mode)
+      (require 'dash)
+      (require 'dash-functional)
+      (require 'rx)
+      (require 'cl-lib)
       (spacemacs/lsp-bind-keys)
       (setq lsp-prefer-capf t)
       (add-hook 'lsp-after-open-hook (lambda ()


### PR DESCRIPTION
Hello, 

lsp-mode removed lsp-clients.el which contained a couple of (require '...)
The consequence is that now starting spacemacs results in an error due to
(require 'lsp-clients)  in packages.el 

and a not fully functional lsp-mode (major mode commands are missing)

my pull request removes this require statement and replaces it with the require
statements in the now non-existing lsp-clients.el.

So the sequence of events on loading layer lsp is the same as before.

Thank you <3