### PR TITLE
Move the Rust RON support to my own package (please read the description, the title may need context)

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -19,7 +19,7 @@
     (flycheck-rust :requires flycheck)
     ggtags
     helm-gtags
-    (ron-mode :location (recipe :fetcher github :repo "nabero/ron-mode"))
+    ron-mode
     racer
     rust-mode
     smartparens


### PR DESCRIPTION
# Moving RON Mode to my own package
Hi, it's me again. A few weeks ago, I added Nabero's ron-mode package to the Spacemacs Rust layer. Since then, I've been working on my own package which adds support for RON to EMACS for a few reasons:

1. Nabero's package is not on MELPA. My new package has finished going through their review process and is now a part of that repository.

2. Nabero's package is a fork of a dead project. My new implementation is built from scratch, which is nessicary for a few purposes (most notably the licensing part, which is discussed in point 3).

3. Nabero's package appears to be unlicensed. This may be problematic in a project as large as Spacemacs (see https://choosealicense.com/no-permission/, GitHub's TOS prevent its use from becoming illegal but it is best to use a properly licensed project). My new package is licensed under the BSD 2-Clause License.

4. Nabero's package has issues disabled, preventing us from getting in contact with him were the package to break or to get it ready. Mine has issues enabled (or at least, Fossil SCM's ticket system since issues is a Git thing).

---
In this PR, I switch Nabero's package out for my own varient, which addresses all above points. The source code is available at https://chiselapp.com/user/Hutzdog/repository/ron-mode/home.
