### PR TITLE
[lua] Remove require lsp-clients

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2470,6 +2470,7 @@ Other:
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 - Added support for =LSP= (EmmyLua-LS-all) (thanks to Lin.Sun)
+- Removed require lsp-clients (thanks to duianto)
 **** Language Server Protocol (LSP)
 - Added core keybindings and prefix declarations for all LSP-based language
   layers, and helper functions to bind server-specific extensions

--- a/layers/+lang/lua/funcs.el
+++ b/layers/+lang/lua/funcs.el
@@ -35,7 +35,6 @@
 ;; LSP Lua
 (defun spacemacs//lua-setup-lsp-emmy ()
   "Setup LSP Lua."
-  (require 'lsp-clients)
   (when lua-lsp-emmy-java-path
     (setq lsp-clients-emmy-lua-java-path lua-lsp-emmy-java-path))
   (when lua-lsp-emmy-jar-path


### PR DESCRIPTION
lsp-clients have been removed upstream as discussed in:
lsp-clients module is gone #13857