### PR TITLE
[lua] Ignore EmmyLua-LS-all.jar in .emacs.d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ eclipse.jdt.ls
 edts/
 elnode/
 elpa/
+EmmyLua-LS-all.jar
 eproject.lst
 eshell/alias
 eshell/history

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2470,6 +2470,7 @@ Other:
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 - Added support for =LSP= (EmmyLua-LS-all) (thanks to Lin.Sun)
+- Added =EmmyLua-LS-all.jar= to =.gitignore= (thanks to duianto)
 **** Language Server Protocol (LSP)
 - Added core keybindings and prefix declarations for all LSP-based language
   layers, and helper functions to bind server-specific extensions


### PR DESCRIPTION
The Lua readme: https://github.com/syl20bnr/spacemacs/tree/develop/layers/+lang/lua
and lsp-mode instructions: https://github.com/emacs-lsp/lsp-mode/wiki/Install-EmmyLua-Language-server
suggest adding `EmmyLua-LS-all.jar` to `~/.emacs.d`

That makes the file appear as an untracked file in magit.