### PR TITLE
Replace Depreciated Package in Perl6 Layer

### DIFF
--- a/layers/+lang/perl6/packages.el
+++ b/layers/+lang/perl6/packages.el
@@ -33,7 +33,7 @@
   (with-eval-after-load 'flycheck
     (require 'flycheck-perl6)))
 
-(defun perl6/init-perl6-mode()
-  (use-package perl6-mode
+(defun perl6/init-raku-mode()
+  (use-package raku-mode
     :defer t
     :mode (("/perl6/site/sources/" . perl6-mode))))

--- a/layers/+lang/perl6/packages.el
+++ b/layers/+lang/perl6/packages.el
@@ -15,7 +15,7 @@
     evil
     flycheck
     (flycheck-perl6 :requires flycheck)
-    perl6-mode
+    raku-mode
     ))
 
 (defun perl6/post-init-company ()


### PR DESCRIPTION
# Replacing Depreciated Package in Perl6 Layer

### Synopsis
In the *perl6 layer* exists a package called `perl6-mode` which no longer exists. This PR replaces it with `raku-mode` as recommended by the authors of `perl6-mode`

---

This PR should probably be merged ASAP, as the *perl6 layer* is **non-functional** without it.