### PR TITLE
Improved Haskell language layer README.

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -7,13 +7,17 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#quick-start-and-how-to-use-this-readme][Quick start (and how to use this README)]]
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#dependencies][Dependencies]]
   - [[#setup-path][Setup PATH]]
+- [[#configuration][Configuration]]
   - [[#choosing-a-backend][Choosing a backend]]
     - [[#dante][=dante=]]
     - [[#lsp][=lsp=]]
+      - [[#hie][=hie=]]
+      - [[#hls][=hls=]]
   - [[#optional-extras][Optional extras]]
     - [[#structured-haskell-mode][structured-haskell-mode]]
     - [[#hindent][hindent]]
@@ -28,10 +32,8 @@
 - [[#syntax-checking][Syntax checking]]
   - [[#flycheck][Flycheck]]
   - [[#hlint][HLint]]
-  - [[#interactive-haskell-mode][Interactive haskell-mode]]
-  - [[#flymake][Flymake]]
-  - [[#troubleshooting][Troubleshooting]]
 - [[#faq][FAQ]]
+  - [[#dante-reports-missinghidden-imports-for-test-files][Dante reports missing/hidden imports for test files.]]
   - [[#the-repl-doesnt-work][The REPL doesn't work]]
   - [[#the-repl-is-stuck][The REPL is stuck]]
   - [[#indentation-doesnt-reset-when-pressing-return-after-an-empty-line][Indentation doesn't reset when pressing return after an empty line]]
@@ -48,10 +50,20 @@
 This layer adds support for the [[https://www.haskell.org/][Haskell]] language.
 
 ** Features:
-- syntax highlighting for [[https://github.com/haskell/haskell-mode][haskell source]], [[https://github.com/haskell/haskell-mode][cabal files]], [[https://github.com/bgamari/cmm-mode][C-- source]],
-- auto-completion with one of the selected backends (=dante= or =lsp=).
+- syntax highlighting for [[https://github.com/haskell/haskell-mode][haskell source]], [[https://github.com/haskell/haskell-mode][cabal files]], [[https://github.com/bgamari/cmm-mode][C-- source]]
+- auto-completion and syntax-checking with one of the selected backends (=dante= or =lsp=).
 
-*This layer is under construction, it needs your contributions and bug reports.*
+* Quick start (and how to use this README)
+- Follow instructions in *Install* section to correctly install the layer.
+- Ensure that you have =auto-completion= and =syntax-checking= layers enabled.
+- Set backend to =dante= (check *Configuration* section for details). =dante= is default already, but if =lsp= layer is enabled, you will have to set it explicitly.
+- You are ready to go! Open any Haskell project and enjoy syntax-checking, auto-completion and more.
+
+After that, check the rest of the README to:
+- Learn about more powerful (but more complicated to set up) backend: =lsp= with =hie= / =hls=: Check *Configuration* -> *lsp*.
+- Learn about all the functionalities and key bindings: Check *Key bindings* and *Configuration* -> *Optional extras*.
+- Learn about the details of how syntax-checking works and how it can be tweaked: Check *Syntax checking*.
+- Find solutions to common problems in FAQ: Check *FAQ*.
 
 * Install
 ** Layer
@@ -85,13 +97,16 @@ packages. If you are using =cabal= it should be =~/.cabal/bin= or
 =~/Library/Haskell/bin= (for 'Haskell for Mac' users). If you are using =stack=
 then it should be =~/.local/bin=.
 
-For information about setting up =$PATH=, check out the corresponding section in
+For more information about setting up =$PATH=, check out the corresponding section in
 the FAQ (~SPC h SPC $PATH RET~).
 
+* Configuration
 ** Choosing a backend
-First, ensure that you have =auto-completion= layer enabled.
+Language backend is the core component of a language layer - it has the responsibility of compiling/parsing the actual code and reporting errors, warnings, suggesting fixes, auto-completions and more.
 
-To choose a haskell backend, set the haskell layer variable =haskell-completion-backend=:
+To get the most out of the language backend, you will want to ensure that you have =auto-completion= and =syntax-checking= layers enabled.
+
+Then, to choose a haskell backend, set the haskell layer variable =haskell-completion-backend=:
 
 #+BEGIN_SRC emacs-lisp
   (haskell :variables haskell-completion-backend 'dante)
@@ -99,7 +114,7 @@ To choose a haskell backend, set the haskell layer variable =haskell-completion-
 
 Supported values for =haskell-completion-backend= are =dante= and =lsp=.
 
-If you haven't specified any value for =haskell-completion-backend=,
+If you don't specify any value for =haskell-completion-backend=,
 =dante= will be used as default backend, unless the layer =lsp= is enabled,
 in which case =lsp= is used as default backend.
 
@@ -116,28 +131,48 @@ Backend can be chosen on a per project basis using directory local variables
 
 *Note:* you can easily add a directory local variable with ~SPC f v d~.
 
+There are two backends available: =dante= and =lsp=.
+
+=dante= is lightweight, requires no setup and works out of the box in most cases, which is why it is also a default backend.
+
+=lsp= (=hie= or =hls=) is a more ambitious, heavy-weight, cutting-edge backend that is however still somewhat rough on the edges and requires some additional setup.
+
 *** =dante=
-[[https://github.com/jyp/dante][Dante]] is a fork of Intero mode which aims exclusively at providing a convenient frontend to GHCi.
+[[https://github.com/jyp/dante][Dante]] is a lightweight backend which delegates most of its work directly to GHCi.
 
 It brings features like syntax checking, auto completion, hlint suggestions, automatic error fixing, info at point, definition and use sites.
 
 =dante= works for =cabal=, =nix=, =sytx=, and =stack= users and requires no additional setup.
 
-=dante= requires Emacs 25.
-
 *** =lsp=
-=lsp= requires an appropriate installation of =hie=, the official Haskell language server, to work properly.
+[[https://microsoft.github.io/language-server-protocol][Language Server Protocol]] is a standard for implementing language backends.
+
+In Haskell layer, you can use a backend that implements Language Server Protocol for Haskell by specifying =lsp= as backend
+and then installing concrete backend implementation, of which there are two available at the moment: =hie= and =hls=.
+
+Enabling the =lsp= backend requires the =lsp= layer to be enabled, and provides access to
+all the additional =lsp-mode= key bindings.
+
+**** =hie=
+[[https://github.com/haskell/haskell-ide-engine][Haskell Ide Engine]] (=hie=) aims to be the universal interface to a growing number of Haskell tools,
+providing a fully-featured Language Server Protocol server for editors and IDEs that require Haskell-specific functionality.
+
+This is where most of the Haskell community effort is (was - check =hls=) being focused regarding building Haskell IDE / language backend.
+
 =hie= is best installed by building it locally as it requires that the same GHC version has been used to
 compile your code as has been used for =hie=.
 
 To install it please refer to the official installation instructions [[https://github.com/haskell/haskell-ide-engine#installation][here]].
 
-Enabling the =lsp= backend requires the =lsp= layer to be enabled, and provides access to
-all the additional =lsp-mode= key bindings. As such it is more of a full backend than just
-a completion backend.
+NOTE: =hie= is being superseded by =hls=, which is still in early development though.
 
-Alternatively, you can use [[https://github.com/haskell/haskell-language-server][Haskell Language Server]] instead of =hie= (check their docs for installation details).
-Haskell Language Server is meant to completely replace =hie= but it is still in early stages of development.
+**** =hls=
+[[https://github.com/haskell/haskell-language-server][Haskell Language Server]] (=hls=) is integration point for ghcide and =hie=. One IDE to rule them all.
+
+=hls= is meant to supersede =hie= and is therefore the cutting-edge and most ambitious implementation of Haskell language backend.
+However, it is still in early stages of development.
+
+Check their docs for installation details and how to use it with emacs/spacemacs.
 
 ** Optional extras
 The Haskell layer supports some extra features, which can be enabled through the
@@ -280,13 +315,13 @@ Refactor commands are prefixed by ~SPC m r~:
 Only some of the HLint suggestions can be applied.
 
 * Syntax checking
-At the moment there are three components, which can indicate
+There are multiple components that can indicate
 errors and warnings in the code. Those components are:
 - dante (via flycheck)
 - hlint (via flycheck)
-- haskell-mode interactive
+- lsp (via lsp-ui)
 
-Since all of these components can be active at the same time, it can be tricky to
+Since some of these components can be active at the same time, it can be tricky to
 know which component is displaying which message, especially when they disagree,
 or if one isn't working. Only flycheck errors (from ghci and hlint) are displayed in
 the error list and can be navigated between, using the standard Spacemacs key
@@ -307,24 +342,15 @@ if it doesn't work, then you can change it with ~SPC e s~.
 the file) but bad coding style and code smell. The HLint checker is called
 *after* the flycheck GHC checker.
 
-HLint can be configured via .hlint.yaml.
-
-** Interactive haskell-mode
-Finally, interactive haskell-mode (~SPC m s b~) also displays errors. These
-errors can be navigated to, from the interactive buffer (by clicking on the
-error) or using =haskell-goto-next-error= (~M-n~) and =haskell-goto-prev-error=
-(~M-p~).
-
-** Flymake
-An alternative to syntax checking is to build your projects with
-=flymake-compile=. It doesn't highlight errors in the buffer, but it's more
-reliable. The error navigation is similar to interactive haskell-mode.
-
-** Troubleshooting
-Flycheck can fail silently for miscellaneous reasons. See the [[#faq][FAQ]]
-for troubleshooting.
+HLint can be configured per project via .hlint.yaml (check Hlint docs for more details).
 
 * FAQ
+** Dante reports missing/hidden imports for test files.
+The cause might be that Dante is not loading appropriate packages for the test suite target, instead it is loading packages for the library.
+
+Solution is to create =.dir-local.el= in the directory where the test suite (usually =test/= or =tests/=) is and to put the line =((haskell-mode . ((dante-target . "--test"))))= into it.
+This tells Dante to use test suite target when working with test files.
+
 ** The REPL doesn't work
 Usually =haskell-mode= is great at figuring out which interactive process to
 bring up. But if you are experiencing problems with it, then you can help

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2251,8 +2251,6 @@ Features:
 - syntax highlighting for [[https://github.com/haskell/haskell-mode][haskell source]], [[https://github.com/haskell/haskell-mode][cabal files]], [[https://github.com/bgamari/cmm-mode][C-- source]],
 - auto-completion with one of the selected backends (=dante= or =lsp=).
 
-*This layer is under construction, it needs your contributions and bug reports.*
-
 **** Idris
 [[file:+lang/idris/README.org][+lang/idris/README.org]]
 


### PR DESCRIPTION
Improved Haskell README as discussed here https://github.com/syl20bnr/spacemacs/issues/13869 @smile13241324 .

There are a few things I was wondering about:
1. groovy layer README does not mention that user should enable auto-complete or syntax-checking layer. I wonder why is that so?
2. Syntax-checking is still a standalone section. I was considering if I can make it part of Configuration, but it really goes beyond just configuration, it explains how things work, so I decided to leave it as it is for now.
3. I wanted to make it very obvious what the minimal setup is. I am not sure if I managed to do that. Right now, I think new user needs to read Description, which is short, Install, which is straight forward, and then Configuration, and they are ready to go. Key bindings and especially Syntax checking and FAQ are kind of like bonuses and are not required to get started. But is that clear to the user? So I was thinking, maybe we could have a "QuickStart" section at the beginning that would summarize only the critical information from Description, Install and Configuration? But I gave up on that because it still felt like a lot of duplication. I might experiment more with this if I manage to get my brother to use Spacemacs :D, I can observe him then and see where he will get stuck. I am driving this whole point because I felt overwhelmed when I first started reading Haskell README, but now I know it very well so I can't remember exactly what I was confused about.

EDIT: Actually, I just added "Quick start" section which I think could solve the problem I described above under point number three -> it very quickly instructs user how to move around the README and what to look at first. Let me know what you think about it, we can remove it if it is too much. Btw in this Quick start section I tried using internal links to headers in Org, and they worked in emacs, but they don't work when README is read via Github, so I gave up on them and just bolded the names of sections/headings.