### PR TITLE
[layers/+emacs/tabs] introduces tabs layer with Centaur backend

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -343,6 +343,7 @@ sane way, here is the complete list of changed key bindings
 - templates (thanks to YasuharuIida and Eivind Fonn)
 **** Emacs
 - helpful (thanks to Johnson Denen, Andriy Kmit)
+- tabs (thanks to Deepu Mohan Puthrote)
 - verb (thanks to Federico Tedin)
 **** Email
 - notmuch (thanks to Francesc Elies Henar, Leonard Lausen, Willian Casarin,

--- a/layers/+emacs/tabs/README.org
+++ b/layers/+emacs/tabs/README.org
@@ -1,0 +1,39 @@
+#+TITLE: Tabs layer
+#+TAGS: layer|spacemacs|emacs
+
+# TOC links should be GitHub style anchors.
+* Table of Contents                                        :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#hide-tabs][Hide tabs]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+This layer adds support for tabs. Implementation is done using [[https://github.com/ema2159/centaur-tabs][Centaur Tabs]].
+
+** Features:
+ - Sets up tabs using Centaur tabs as backend
+
+* Install
+
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =tabs= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Hide tabs
+
+You can set hooks for buffers in which it isn't desired to have tabs by
+customizing =centaur-tabs-hide-tabs-hooks=
+
+* Key bindings
+
+| Key binding | Description                                           |
+|-------------+-------------------------------------------------------|
+| ~C-{~       | Select the previous available tab                     |
+| ~C-}~       | Select the next available tab                         |
+| ~C-M-{~     | Move current tabe to left                             |
+| ~C-M-}~     | Move current tabe to right                            |
+| ~C-c t s~   | Display a list of current buffer groups using Counsel |
+| ~C-c t p~   | Group buffer tabs by projectile                       |
+| ~C-c t g~   | Group buffer tabs by groups                           |

--- a/layers/+emacs/tabs/config.el
+++ b/layers/+emacs/tabs/config.el
@@ -1,0 +1,57 @@
+;;; config.el --- Org configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar tabs-navigation nil
+  "*Specify the scope of cyclic navigation through tabs.
+The following scopes are possible:
+
+- `tabs'
+    Navigate through visible tabs only.
+- `groups'
+    Navigate through tab groups only.
+- nil
+    Navigate through visible tabs, then through tab groups.")
+
+(defvar tabs-gray-out-unselected nil
+  "When non nil, enable gray icons for unselected buffer.")
+
+(defvar tabs-height 22
+  "The height of tab")
+
+(defvar tabs-show-icons t
+  "When non nil, show icon from all-the-icons")
+
+(defvar tabs-set-modified-marker t
+  "When non nil, display a marker when buffer is modified")
+
+(defvar tabs-modified-marker "⚠"
+  "Display appearance of modified marker if enabled")
+
+(defvar tabs-show-navigation-buttons nil
+  "When non-nil, show buttons for backward/forward tabs")
+
+(defvar tabs-style "bar"
+  "Style of tab; available values are \"bar\", \"alternate\", \"box\", \"chamfer\", \"rounded\", \"slant\", \"wave\", \"zigzag\" ")
+
+(defvar tabs-group-by-project t
+  "When non-nil, group tabs by projectile project. Default t.
+   If non-nil calls (centaur-tabs-group-by-projectile-project)
+   Otherwise calls (centaur-tabs-group-buffer-groups)")
+
+(defvar tabs-headline-match t
+  "When non-nil, make headline use centaur-tabs-default-face. Default t. Calls (centaur-tabs-headline-match)")
+
+(defvar tabs-set-bar 'left
+  "When non-nil, display a bar to show currently selected tab.
+  There are three options:
+  - 'left: displays the bar at the left of the currently selected tab.
+  - 'under: displays the bar under the currently selected tab.
+  - 'over: displays the bar over the currently selected tab.")

--- a/layers/+emacs/tabs/packages.el
+++ b/layers/+emacs/tabs/packages.el
@@ -1,0 +1,41 @@
+;;; packages.el --- tabs layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018, 2020 Sylvain Benner & Contributors
+;;
+;; Author: Deepu Puthrote <git@deepumohan.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defconst tabs-packages
+  '(centaur-tabs))
+
+(defun tabs/init-centaur-tabs ()
+  (use-package centaur-tabs
+    :demand
+    :config
+    (setq centaur-tabs-cycle-scope tabs-navigation
+          centaur-tabs-gray-out-icons tabs-gray-out-unselected
+          centaur-tabs-height tabs-height
+          centaur-tabs-modified-marker tabs-modified-marker
+          centaur-tabs-set-bar tabs-set-bar
+          centaur-tabs-set-icons tabs-show-icons
+          centaur-tabs-set-modified-marker tabs-set-modified-marker
+          centaur-tabs-show-navigation-buttons t
+          centaur-tabs-style tabs-style)
+    (when tabs-headline-match
+      (centaur-tabs-headline-match))
+    (if tabs-group-by-project
+        (centaur-tabs-group-by-projectile-project)
+      (centaur-tabs-group-buffer-groups))
+    (centaur-tabs-mode t)
+    :bind
+    ("C-{" . centaur-tabs-backward)
+    ("C-}" . centaur-tabs-forward)
+    ("C-M-{" . centaur-tabs-move-current-tab-to-left)
+    ("C-M-}" . centaur-tabs-move-current-tab-to-right)
+    ("C-c t s" . centaur-tabs-counsel-switch-group)
+    ("C-c t p" . centaur-tabs-group-by-projectile-project)
+    ("C-c t g" . centaur-tabs-group-buffer-groups)))


### PR DESCRIPTION
Adding `tabs` layer with `Centaur` tabs as backend

This layer is without customisation now with default values

Starting with a draft PR to gather comments/opinions 