### PR TITLE
Make find-init-file compatible with profile switcher

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -729,12 +729,11 @@ variable."
 
 
 
-;; adapted from bozhidar
-;; http://emacsredux.com/blog/2013/05/18/instant-access-to-init-dot-el/
 (defun spacemacs/find-user-init-file ()
   "Edit the `user-init-file', in the current window."
   (interactive)
-  (find-file-existing user-init-file))
+  (find-file-existing
+   (expand-file-name "init.el" user-emacs-directory)))
 
 (defun spacemacs/find-dotfile ()
   "Edit the `dotfile', in the current window."


### PR DESCRIPTION
<SPC f e i> should work with Emacs profile switcher plexus/chemacs

--- 

Hey folks, I recently tried using https://github.com/plexus/chemacs and noticed that `<SPC f e i>` opens chemacs's init.el instead of Spacemacs' init.el.

This tiny change fixes the problem for me, but maybe I'm not alone who wants this behavior, what do you think? 
