### PR TITLE
Disable php-extras when the php layer backend is lsp

### DIFF
--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -20,7 +20,7 @@
     counsel-gtags
     helm-gtags
     php-auto-yasnippets
-    (php-extras :location (recipe :fetcher github :repo "arnested/php-extras"))
+    (php-extras :location (recipe :fetcher github :repo "arnested/php-extras") :toggle (not (eq php-backend 'lsp)))
     php-mode
     phpcbf
     phpunit


### PR DESCRIPTION
This conflicts with `company-capf` and you don't get any company completions
from the lsp-mode

Fix issue #13524 