### PR TITLE
Update spacemacs-org README on bullet library

### DIFF
--- a/layers/+spacemacs/spacemacs-org/README.org
+++ b/layers/+spacemacs/spacemacs-org/README.org
@@ -12,5 +12,5 @@ This layer tweaks =org-mode= to integrate nicely into Spacemacs.
 ** Features:
 - Configuration for =flyspell= to check =org-buffers= for typos.
 - Support for automatically generated Table-Of-Contents via =toc-org=.
-- Support for custom bullet markers via =org-bullets=.
+- Support for custom bullet markers via =org-superstar=.
 - Support for a special view mode for org documents via =space-doc=.


### PR DESCRIPTION
Hi there! This is just a small fix in the documentation.

In https://github.com/syl20bnr/spacemacs/commit/145126875731e8ee38770b2adf709805f23672f7 org-bullets has been replaced with org-superstar, but the Readme of the `spacemacs-org` layer was not updated.

This commit mentions the correct library that is used to customize bullets.