### PR TITLE
[ipython] Fix bindinding for RET in transient state

### DIFF
--- a/layers/+tools/ipython-notebook/packages.el
+++ b/layers/+tools/ipython-notebook/packages.el
@@ -46,7 +46,7 @@
                         ("o" ein:worksheet-insert-cell-below-km)
                         ("O" ein:worksheet-insert-cell-above-km)
                         ("t" ein:worksheet-toggle-cell-type-km)
-                        ("RET" ein:worksheet-execute-cell-km)
+                        ("RET" ein:worksheet-execute-cell-and-goto-next-km)
                         ("l" ein:worksheet-clear-output-km)
                         ("L" ein:worksheet-clear-all-output-km)
                         ("C-s" ein:notebook-save-notebook-command-km)


### PR DESCRIPTION
In the documentation, it says this performs execute cell and goto next, while
the code was just executing the cell.

This desync could be fixed in either direction, but executing and going to next
feels more ergonomic while in the transient state, since we're jumping around
running rather than editing in that mode, so I've fixed it to do that.