### PR TITLE
[layer/+lang/c-c++] Introduction of shortcut for rtags-symbol-type

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -449,8 +449,9 @@ A ~[ccls]~ suffix indicates that the binding is for the indicated backend only.
 | ~SPC m g R~ | rename symbol                   |
 | ~SPC m g s~ | print source arguments          |
 | ~SPC m g S~ | display summary                 |
-| ~SPC m g t~ | display include dependency tree |
+| ~SPC m g t~ | symbol tpype                    |
 | ~SPC m g T~ | taglist                         |
+| ~SPC m g u~ | display include dependency tree |
 | ~SPC m g v~ | find virtuals at point          |
 | ~SPC m g V~ | print enum value at point       |
 | ~SPC m g X~ | fix fixit at point              |

--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -449,7 +449,7 @@ A ~[ccls]~ suffix indicates that the binding is for the indicated backend only.
 | ~SPC m g R~ | rename symbol                   |
 | ~SPC m g s~ | print source arguments          |
 | ~SPC m g S~ | display summary                 |
-| ~SPC m g t~ | symbol tpype                    |
+| ~SPC m g t~ | symbol type                     |
 | ~SPC m g T~ | taglist                         |
 | ~SPC m g u~ | display include dependency tree |
 | ~SPC m g v~ | find virtuals at point          |

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -210,8 +210,9 @@
       "gR" 'rtags-rename-symbol
       "gs" 'rtags-print-source-arguments
       "gS" 'rtags-display-summary
-      "gt" 'rtags-dependency-tree
+      "gt" 'rtags-symbol-type
       "gT" 'rtags-taglist
+      "gu" 'rtags-dependency-tree 
       "gv" 'rtags-find-virtuals-at-point
       "gV" 'rtags-print-enum-value-at-point
       "gX" 'rtags-fix-fixit-at-point


### PR DESCRIPTION
Introduction of <SPC/M-m> g t shortcut for rtags-symbol-type.
Replacement of previous <SPC/M-m> g t into <SPC/M-m> g u for rtags-dependency-tree