### PR TITLE
[fasd] Fix bug in fasd-find-directory-only

### DIFF
--- a/layers/+tools/fasd/packages.el
+++ b/layers/+tools/fasd/packages.el
@@ -18,7 +18,7 @@
 
       (defun fasd-find-directory-only ()
         (interactive)
-        (fasd-find-file 1))
+        (fasd-find-file 2))
 
       (global-fasd-mode 1)
       (spacemacs/declare-prefix "fa" "fasd-find")


### PR DESCRIPTION
`fasd-find-file` incorrectly interprets a prefix argument of value 1
as equivalent to nil ([issue][0]).

Work around this bug by just passing another positive number instead.
We choose 2.

[0]: https://framagit.org/steckerhalter/emacs-fasd/-/issues/14