### PR TITLE
[Python] Add python-shell-send-line function

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -433,6 +433,7 @@ Send code to inferior process commands:
 | ~SPC m s f~ | send function and keep code buffer focused      |
 | ~SPC m s F~ | send function and switch to REPL in insert mode |
 | ~SPC m s i~ | start inferior REPL process                     |
+| ~SPC m s l~ | send line and keep code buffer focused          |
 | ~SPC m s r~ | send region and keep code buffer focused        |
 | ~SPC m s R~ | send region and switch to REPL in insert mode   |
 | ~CTRL+j~    | next item in REPL history                       |

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -440,6 +440,15 @@ Bind formatter to '==' for LSP and '='for all other backends."
   (let ((python-mode-hook nil))
     (python-shell-send-region start end)))
 
+(defun spacemacs/python-shell-send-line ()
+	"Send the current line to shell"
+	(interactive)
+	(let* ((python-mode-hook nil)
+				 (start (point-at-bol))
+				 (end (point-at-eol)))
+		(python-shell-send-region start end))
+	)
+
 (defun spacemacs/python-start-or-switch-repl ()
   "Start and/or switch to the REPL."
   (interactive)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -443,10 +443,10 @@ Bind formatter to '==' for LSP and '='for all other backends."
 (defun spacemacs/python-shell-send-line ()
 	"Send the current line to shell"
 	(interactive)
-	(let* ((python-mode-hook nil)
-				 (start (point-at-bol))
-				 (end (point-at-eol)))
-		(python-shell-send-region start end))
+	(let ((python-mode-hook nil)
+	       (start (point-at-bol))
+	       (end (point-at-eol)))
+	      (python-shell-send-region start end))
 	)
 
 (defun spacemacs/python-start-or-switch-repl ()

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -354,7 +354,8 @@
         "sf" 'spacemacs/python-shell-send-defun
         "si" 'spacemacs/python-start-or-switch-repl
         "sR" 'spacemacs/python-shell-send-region-switch
-        "sr" 'spacemacs/python-shell-send-region)
+        "sr" 'spacemacs/python-shell-send-region
+				"sl" 'spacemacs/python-shell-send-line)
 
       ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
       ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -355,7 +355,7 @@
         "si" 'spacemacs/python-start-or-switch-repl
         "sR" 'spacemacs/python-shell-send-region-switch
         "sr" 'spacemacs/python-shell-send-region
-	"sl" 'spacemacs/python-shell-send-line)
+        "sl" 'spacemacs/python-shell-send-line)
 
       ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
       ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -355,7 +355,7 @@
         "si" 'spacemacs/python-start-or-switch-repl
         "sR" 'spacemacs/python-shell-send-region-switch
         "sr" 'spacemacs/python-shell-send-region
-				"sl" 'spacemacs/python-shell-send-line)
+	"sl" 'spacemacs/python-shell-send-line)
 
       ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
       ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)


### PR DESCRIPTION
Add the python-shell-send-line function as in the other language layer, such as ESS. And bind it also as the same key.