### PR TITLE
Add `spacemacs/python-shell-send-statement' for sending statement

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2985,6 +2985,7 @@ Other:
 - Fixed directory selection for self compiled mspyls (thanks Jee Lee)
 - Add python-test-last support for pytest runner
 - Added --last-failed support for pytest (thanks to Jaakko Luttinen)
+- Added =spacemacs/python-shell-send-statement= support (thanks to Lin Sun)
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -438,18 +438,20 @@ search path by activating a virtual environment.
 
 Send code to inferior process commands:
 
-| Key binding | Description                                     |
-|-------------+-------------------------------------------------|
-| ~SPC m s b~ | send buffer and keep code buffer focused        |
-| ~SPC m s B~ | send buffer and switch to REPL in insert mode   |
-| ~SPC m s f~ | send function and keep code buffer focused      |
-| ~SPC m s F~ | send function and switch to REPL in insert mode |
-| ~SPC m s i~ | start inferior REPL process                     |
-| ~SPC m s l~ | send line and keep code buffer focused          |
-| ~SPC m s r~ | send region and keep code buffer focused        |
-| ~SPC m s R~ | send region and switch to REPL in insert mode   |
-| ~CTRL+j~    | next item in REPL history                       |
-| ~CTRL+k~    | previous item in REPL history                   |
+| Key binding | Description                                      |
+|-------------+--------------------------------------------------|
+| ~SPC m s b~ | send buffer and keep code buffer focused         |
+| ~SPC m s B~ | send buffer and switch to REPL in insert mode    |
+| ~SPC m s e~ | send statement and keep code buffer focused      |
+| ~SPC m s E~ | send statement and switch to REPL in insert mode |
+| ~SPC m s f~ | send function and keep code buffer focused       |
+| ~SPC m s F~ | send function and switch to REPL in insert mode  |
+| ~SPC m s i~ | start inferior REPL process                      |
+| ~SPC m s l~ | send line and keep code buffer focused           |
+| ~SPC m s r~ | send region and keep code buffer focused         |
+| ~SPC m s R~ | send region and switch to REPL in insert mode    |
+| ~CTRL+j~    | next item in REPL history                        |
+| ~CTRL+k~    | previous item in REPL history                    |
 
 ** Running Python Script in shell
 To run a Python script like you would in the shell press ~SPC m c c~

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -447,8 +447,26 @@ Bind formatter to '==' for LSP and '='for all other backends."
 	(let ((python-mode-hook nil)
 	       (start (point-at-bol))
 	       (end (point-at-eol)))
-	      (python-shell-send-region start end))
-	)
+	      (python-shell-send-region start end)))
+
+(defun spacemacs/python-shell-send-statement ()
+	"Send the current statement to shell, same as `python-shell-send-statement' in Emacs27."
+	(interactive)
+  (if (fboundp 'python-shell-send-statement)
+      (call-interactively #'python-shell-send-statement)
+    (if (region-active-p)
+        (call-interactively #'python-shell-send-region)
+      (let ((python-mode-hook nil))
+	      (python-shell-send-region
+         (save-excursion (python-nav-beginning-of-statement))
+         (save-excursion (python-nav-end-of-statement)))))))
+
+(defun spacemacs/python-shell-send-statement-switch ()
+  "Send statement to shell and switch to it in insert mode."
+  (interactive)
+  (call-interactively #'spacemacs/python-shell-send-statement)
+  (python-shell-switch-to-shell)
+  (evil-insert-state))
 
 (defun spacemacs/python-start-or-switch-repl ()
   "Start and/or switch to the REPL."

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -351,6 +351,8 @@
         "ri" 'spacemacs/python-remove-unused-imports
         "sB" 'spacemacs/python-shell-send-buffer-switch
         "sb" 'spacemacs/python-shell-send-buffer
+        "sE" 'spacemacs/python-shell-send-statement-switch
+        "se" 'spacemacs/python-shell-send-statement
         "sF" 'spacemacs/python-shell-send-defun-switch
         "sf" 'spacemacs/python-shell-send-defun
         "si" 'spacemacs/python-start-or-switch-repl


### PR DESCRIPTION
Hi @smile13241324 ,

The Emacs-27 had a new function `python-shell-send-statement` for sending statement under cursor to python shell, I add it to Spacemacs and compatible with Emacs < 27. Please review it. Thanks.

B.R.
Lin