### PR TITLE
[core] evilify Custom-mode if dotspacemacs-editing-style is 'vim

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -753,6 +753,7 @@ Other:
   - Added =symbol-overlay= to the =spacemacs-navigation= layer
     (thanks to kenkangxgwe)
 - Key bindings:
+  - Evilify =Custom-mode= (thanks to Keith Pinson)
   - Fixed ~M-x~ prefix visualization for ~dotspacemacs-emacs-command-key~
   - New ~SPC a Q~ prefix for dispatching quickurl
     (thanks to Spenser "equwal" Truex:)

--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -16,6 +16,7 @@ defaults.
   - archive-mode
   - bookmark
   - conf-mode
+  - cus-edit
   - dired
   - dired-x
   - display-line-numbers (only in Emacs 26.x and newer)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -95,6 +95,17 @@ automatically applied to."
   :group 'spacemacs
   :type '(list symbol))
 
+(defun spacemacs/custom-newline (pos)
+  "Make `RET' in a Custom-mode search box trigger that field's action, rather
+than enter an actual newline, which is useless and unexpected in a search box.
+If not in such a search box, fall back on `Custom-newline'."
+  (interactive "d")
+  (let ((w (widget-at)))
+    (if (and w
+             (eq 'editable-field (widget-type w))
+             (string-prefix-p "Search" (widget-get w :help-echo)))
+        (funcall (widget-get w :action) w)
+        (Custom-newline pos))))
 
 ;; ido-mode remaps some commands to ido counterparts.  We want default Emacs key
 ;; bindings (those under C-x) to use ido, but we want to use the original

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -15,6 +15,7 @@
         (archive-mode :location built-in)
         (bookmark :location built-in)
         (conf-mode :location built-in)
+        (cus-edit :location built-in)
         (dired :location built-in)
         (dired-x :location built-in)
         (display-line-numbers :location built-in
@@ -69,6 +70,39 @@
   :init
   ;; explicitly derive conf-mode from text-mode major-mode
   (add-hook 'conf-mode-hook 'spacemacs/run-text-mode-hooks))
+
+(defun spacemacs-defaults/init-cus-edit ()
+  (when (eq 'vim dotspacemacs-editing-style)
+    ;; Arguably a Vim user's first expectation for such a buffer would be a kind
+    ;; of normal mode; besides, `evilified' conflicts with text insertion for
+    ;; search.
+    (evil-set-initial-state 'Custom-mode 'normal)
+    ;; Notes on how this effects the default `custom-mode-map':
+    ;; - `TAB' works as `widget-forward' without modification
+    ;; - `<S-tab>' works as `widget-backward' without modification
+    ;; - `n' as `widget-forward' is redundant with `TAB' and collides with the
+    ;; - `evil-ex-search-next' mapping which is useful here. Omitting
+    ;;   intensionally.
+    ;; - `p' doesn't make any sense without `n' and is redundant with `<S-tab>'.
+    ;;   Omitting intensionally.
+    ;; - `q' as `Custom-buffer-done' conflicts with the Evil record macro
+    ;;   binding, which is, however, of questionable value in a Custom buffer;
+    ;;   and there is precedent in many other Spacemacs contexts to bind it to
+    ;;   quit actions rather than default evil one; choosing to restore.
+    ;; - `SPC' as `scroll-up-command' conflicts with the all-important Spacemacs
+    ;;   menu. Omitting intensionally. Evil `C-u' works instead.
+    ;; - `S-SPC' as `scroll-down-command' makes no sense without `SPC' as
+    ;;   `scroll-up-command'. Evil `C-u' works instead.
+    ;; - `C-x' as a prefix command still works.
+    ;; - `C-c' as a prefix command still works.
+    ;; - `u' as `Custom-goto-parent' conflicts with Evil undo. However it is
+    ;;   questionable whether this will work properly in a Custom buffer;
+    ;;   choosing to restore this binding.
+    (evil-define-key 'normal cus-edit-mode-map (kbd "q") 'Custom-buffer-done)
+    (evil-define-key 'normal cus-edit-mode-map (kbd "u") 'Custom-goto-parent)
+    ;; `RET' does not work well in the search field. Fix:
+    (evil-define-key 'insert cus-edit-mode-map (kbd "RET") 'spacemacs/custom-newline)
+    (evil-define-key 'normal cus-edit-mode-map (kbd "RET") 'spacemacs/custom-newline)))
 
 (defun spacemacs-defaults/init-dired ()
   (spacemacs/set-leader-keys


### PR DESCRIPTION
This has been requested many times but never implemented.

Fixes #6699
Fixes #5668
Fixes #7583
Fixes #13309

The comments describe the rational behind the bindings. Please let me know if you disagree with my choices at all as I am open to changing; this was my attempt to put something together that didn't entirely disregard the default bindings, while making a lot of sense from an Evil perspective.