### PR TITLE
[lsp] Fix lsp-diagnostics-provider name

### DIFF
--- a/layers/+frameworks/react/funcs.el
+++ b/layers/+frameworks/react/funcs.el
@@ -35,7 +35,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (when (not javascript-lsp-linter)
-          (setq-local lsp-diagnostic-package :none))
+          (setq-local lsp-diagnostics-provider :none))
         (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 

--- a/layers/+frameworks/vue/funcs.el
+++ b/layers/+frameworks/vue/funcs.el
@@ -30,7 +30,7 @@
       (progn
         ;; error checking from lsp langserver sucks, turn it off
         ;; so eslint won't be overriden
-        (setq-local lsp-diagnostic-package :none)
+        (setq-local lsp-diagnostics-provider :none)
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -58,11 +58,11 @@
   "Setup lsp backend"
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
-        ;; without setting lsp-diagnostic-package to :none
+        ;; without setting lsp-diagnostics-provider to :none
         ;; golangci-lint errors won't be reported
         (when go-use-golangci-lint
-          (message "[go] Setting lsp-diagnostic-package :none to enable golangci-lint support.")
-          (setq-local lsp-diagnostic-provider :none))
+          (message "[go] Setting lsp-diagnostics-provider :none to enable golangci-lint support.")
+          (setq-local lsp-diagnostics-provider :none))
         (lsp))
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -51,7 +51,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (when (not javascript-lsp-linter)
-          (setq-local lsp-diagnostic-package :none))
+          (setq-local lsp-diagnostics-provider :none))
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -45,7 +45,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (when (not typescript-lsp-linter)
-          (setq-local lsp-diagnostic-package :none))
+          (setq-local lsp-diagnostics-provider :none))
         (lsp))
     (message (concat "`lsp' layer is not installed, "
                      "please add `lsp' layer to your dotfile."))))


### PR DESCRIPTION
`lsp-diagnostic-package` was renamed to `lsp-diagnostics-provider` in
[LSP version 7.0.1](https://github.com/emacs-lsp/lsp-mode/blob/f23159a85f4be5c148ca204cd5935552fa577aaa/CHANGELOG.org#release-701).

Source: https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-diagnostics.el#L30-L41