### PR TITLE
Fix git-gutter+ refresh on Magit refresh

### DIFF
--- a/layers/+source-control/version-control/funcs.el
+++ b/layers/+source-control/version-control/funcs.el
@@ -152,3 +152,7 @@ the number of conflicts detected by `smerge-mode'."
   (interactive)
   (setq spacemacs--smerge-ts-full-hint-toggle
         (not spacemacs--smerge-ts-full-hint-toggle)))
+
+(when (configuration-layer/package-used-p 'git-gutter+)
+  (defun spacemacs//git-gutter+-refresh-in-all-buffers ()
+    (git-gutter+-in-all-buffers (when git-gutter+-mode (git-gutter+-refresh)))))

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -205,10 +205,8 @@
     (progn
       ;; If you enable global minor mode
       (when version-control-global-margin
-        ;; (defun spacemacs//git-gutter+-refresh-in-all-buffers ()
-        ;;   (git-gutter+-in-all-buffers (git-gutter+-refresh)))
-        ;; (add-hook 'magit-pre-refresh-hook #'spacemacs//git-gutter+-refresh-in-all-buffers)
-        (add-hook 'magit-pre-refresh-hook 'git-gutter+-refresh)
+        (add-hook 'magit-pre-refresh-hook
+                  #'spacemacs//git-gutter+-refresh-in-all-buffers)
         (run-with-idle-timer 1 nil 'global-git-gutter+-mode))
       (setq
        git-gutter+-modified-sign " "


### PR DESCRIPTION
Fixed `git-gutter+` refresh when a buffer is staged or unstaged in Magit.