### PR TITLE
[org] support rich insert of code from other buffers (org-rich-yank)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2683,6 +2683,7 @@ Other:
     - Added shortcuts for handling scheduled entries (thanks to Daniel Nicolai)
   - Added package for =org-sticky-header-mode= (thanks to Langston Barret)
   - Added package =org-jira= (thanks to Kirill A. Korinsky)
+  - Added package =org-rich-yank= (thanks to Keith Pinson)
 - Key bindings:
   - ~SPC m T i~ to toggle inline images
   - Move clock related key bindings to ~SPC a o C~

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -69,6 +69,7 @@ This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
 - Insertion of images via [[https://github.com/abo-abo/org-download][org-download]]
 - Project-specific TODOs via [[https://github.com/IvanMalison/org-projectile][org-projectile]]
 - Easy insert of URLs from clipboard with org format via [[https://github.com/rexim/org-cliplink][org-cliplink]]
+- Rich insert of code (into a source block with highlighting, and a link) from other buffers via [[https://github.com/unhammer/org-rich-yank][org-rich-yank]]
 
 * BibTeX
 For more extensive support of references through BibTeX files, have a look at
@@ -520,8 +521,8 @@ are also available.
 
 ** Element insertion
 
-| Key binding   | Description                                   |
-|---------------+-----------------------------------------------|
+| Key binding | Description                                   |
+|-------------+-----------------------------------------------|
 | ~C-RET~       | Insert heading at end of current subtree      |
 | ~C-S-RET~     | Insert TODO heading at end of current subtree |
 | ~SPC m i d~   | org-insert-drawer                             |
@@ -537,6 +538,7 @@ are also available.
 | ~SPC m i L~   | insert URL with its page title from clipboard |
 | ~SPC m i n~   | org-add-note                                  |
 | ~SPC m i p~   | org-set-property                              |
+| ~SPC m i r~   | org-rick-yank (paste code into a =src= block)   |
 | ~SPC m i s~   | org-insert-subheading                         |
 | ~SPC m i t~   | org-set-tags                                  |
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -32,6 +32,7 @@
         org-pomodoro
         org-present
         org-cliplink
+        org-rich-yank
         (org-projectile :requires projectile)
         (ox-epub :toggle org-enable-epub-support)
         (ox-twbs :toggle org-enable-bootstrap-support)
@@ -704,6 +705,15 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :init
     (spacemacs/set-leader-keys-for-major-mode 'org-mode
       "iL" 'org-cliplink)))
+
+(defun org/init-org-rich-yank ()
+  (use-package org-rich-yank
+    :defer t
+    :init
+    (spacemacs/set-leader-keys-for-major-mode 'org-mode
+      ;; yank is a misnomer for this function which actually puts/pastes
+      ;; ir = "insert rich"
+      "ir" 'org-rich-yank)))
 
 (defun org/init-org-projectile ()
   (use-package org-projectile


### PR DESCRIPTION
See the animation in the package's [README](https://github.com/unhammer/org-rich-yank/blob/master/README.org). If necessary, I can put this package behind a switch like others are. However it's a small package (133 sloc) which integrates well with what's there so I didn't default to that.

I like that Spacemacs provides a very rich, full-featured experience via layers and I think this fills a niche. I use this package myself regularly when I am studying and analyzing a problem, and want to snip pieces of code out of various files in a code base and put them into one place with commentary, TODOs, &c.