### PR TITLE
[ivy] add ivy-avy

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -20,6 +20,7 @@
         helm-make
         imenu
         ivy
+        ivy-avy
         ivy-hydra
         (ivy-rich :toggle ivy-enable-advanced-buffer-information)
         (ivy-spacemacs-help :location local)
@@ -245,6 +246,9 @@
 
       ;; allow to select prompt in some ivy functions
       (setq ivy-use-selectable-prompt t))))
+
+(defun ivy/init-ivy-avy ()
+  (use-package ivy-avy))
 
 (defun ivy/init-ivy-hydra ()
   (use-package ivy-hydra)


### PR DESCRIPTION
In the doc ivy-avy makes it possible to select a candidate with avy by using C-' in an ivy minibuffer.

This functionality used to come with swiper, but it was split: https://github.com/melpa/melpa/pull/6951

Copy pasta from our sister project Doom: https://github.com/hlissner/doom-emacs/pull/3414