### PR TITLE
[core] add keybinding hdT for describe-text-properties

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -518,6 +518,8 @@ Other:
     terminal mode, but no longer in GUI mode. (emacs18)
 *** Core changes
 - Improvements:
+  - Make =describe-text-properties= available in the help -> describe menu via
+    ~SPC h d T~ (thanks to Keith Pinson)
   - Bind ~SPC c n~ to ~:cn~ / ~next-error~ and ~SPC c N~ to ~:cN~ / ~previous-error~
     (thanks to Keith Pinson)
   - Display time spent in =user-config= in home buffer (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -404,6 +404,7 @@
   "hdP" 'configuration-layer/describe-package
   "hds" 'spacemacs/describe-system-info
   "hdt" 'describe-theme
+  "hdT" 'describe-text-properties
   "hdv" 'describe-variable
   "hI"  'spacemacs/report-issue
   "hn"  'view-emacs-news


### PR DESCRIPTION
This is to bundle it with other describe functions. The hope is to make the help -> describe menu more complete.