### PR TITLE
Fix up markdown mode specifiers

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -52,9 +52,9 @@
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
     :mode
-    (("\\.m[k]d" . markdown-mode)
-     ("\\.mdk" . markdown-mode)
-     ("\\.mdx" . markdown-mode))
+    (("\\.m[k]d\\'" . markdown-mode)
+     ("\\.mdk\\'" . markdown-mode)
+     ("\\.mdx\\'" . markdown-mode))
     :defer t
     :config
     (progn

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -52,7 +52,7 @@
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
     :mode
-    (("\\.m[k]d\\'" . markdown-mode)
+    (("\\.mkd\\'" . markdown-mode)
      ("\\.mdk\\'" . markdown-mode)
      ("\\.mdx\\'" . markdown-mode))
     :defer t


### PR DESCRIPTION
Simplify the regexps, and make sure they are anchored.