### PR TITLE
[core] add `spacemacs-scratch-mode-hook`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -595,6 +595,8 @@ Other:
     (thanks to duianto)
   - Add =emacs-version= to the default value for
     =dotspacemacs-emacs-dumper-dump-file= (thanks to Evan Klitzke)
+  - Add =spacemacs-scratch-mode-hook= to run functions
+    after =spacemacs-scratch-mode= is applied to =*scratch*= buffer (thanks to rayw000)
 - Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -43,6 +43,8 @@
   "Hook run after dotspacemacs/user-config")
 (defvar spacemacs-post-user-config-hook-run nil
   "Whether `spacemacs-post-user-config-hook' has been run")
+(defvar spacemacs-scratch-mode-hook nil
+  "Hook run on buffer *scratch* after `dotspacemacs-scratch-mode' is invoked.")
 
 (defvar spacemacs--default-mode-line mode-line-format
   "Backup of default mode line format.")
@@ -230,7 +232,8 @@ Note: the hooked function is not executed when in dumped mode."
      (setq spacemacs-post-user-config-hook-run t)
      (when (fboundp dotspacemacs-scratch-mode)
        (with-current-buffer "*scratch*"
-         (funcall dotspacemacs-scratch-mode)))
+         (funcall dotspacemacs-scratch-mode)
+         (run-hooks 'spacemacs-scratch-mode-hook)))
      (when spacemacs--delayed-user-theme
        (spacemacs/load-theme spacemacs--delayed-user-theme
                              spacemacs--fallback-theme t))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1515,7 +1515,8 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
     (when (and (not exists)
                (not (eq major-mode dotspacemacs-scratch-mode))
                (fboundp dotspacemacs-scratch-mode))
-      (funcall dotspacemacs-scratch-mode))))
+      (funcall dotspacemacs-scratch-mode)
+      (run-hooks 'spacemacs-scratch-mode-hook))))
 
 (defvar spacemacs--killed-buffer-list nil
   "List of recently killed buffers.")


### PR DESCRIPTION
### What Changed

Add hook `spacemacs-scratch-mode-hook` which runs on buffer `*scratch*` after applying `dotspacemacs-scratch-mode`.

### Why

Sometimes we may need to do something to buffer `*scratch*` after it is loaded, for example enabling a minor mode which only makes sense in `*scratch*` buffer. 

I tried to do this by creating a custom layer, but layers are loaded before https://github.com/syl20bnr/spacemacs/blob/dd94a13a48b40562a76c4aca1073796619077d0f/core/core-spacemacs.el#L233

That means my buffer specified enabled minor modes are turned off after this line.

That's why I'd like to add a `hook` to run after `dotspacemacs-scratch-mode` was enabled, no matter what the actually `major-mode` is.

Or, if you have some way better to achieve this, please let me know. 😃

Thanks!