### PR TITLE
Add C-RET keybinding for ivy-alt-done

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2271,6 +2271,7 @@ Other:
   - Add ~d~ to create a project perspective and open a project root dired
     buffer, from the ~SPC p l~ persp switch project prompt
     (thanks to Magnus Therning and Muneeb Shaikh)
+  - Add C-RET for ivy-alt-done (thanks to Daniel Nicolai)
 - Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
 - Use new API to register additional transient state bindings
   (thanks to Andriy Kmit')

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -77,17 +77,18 @@ In case you don't want to read everything, at least familiarise with
 
 Some useful key bindings are presented in the following table.
 
-| Key binding | Description                                                                                          |
-|-------------+------------------------------------------------------------------------------------------------------|
-| ~RET~       | call default action on current candidate                                                             |
-| ~M-RET~     | the same as ~RET~ but doesn't close completion minibuffer                                            |
-| ~C-M-j~     | use current input immediately (this can be used to create a new file in Find File)                   |
-| ~TAB~       | complete partially                                                                                   |
-| ~M-o~       | show the list of valid actions on current candidate (then press any of described keys to execute it) |
-| ~C-M-o~     | the same as ~M-o~ but doesn't close completion minibuffer                                            |
-| ~C-'~       | use avy to quickly select completion on current page (sometimes faster than using arrows)            |
-| ~<ESC>~     | close minibuffer                                                                                     |
-| ~C-M-k~     | kill buffer (in =ivy-switch-buffer= (~SPC b b~))                                                     |
+| Key binding | Description                                                                                                                                           |
+|-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ~RET~         | call default action on current candidate                                                                                                            |
+| ~M-RET~       | the same as ~RET~ but doesn't close completion minibuffer                                                                                           |
+| C-RET         | when completing file names, selects the current directory candidate and starts a new completion session there, otherwise it is the same as ivy-done |
+| ~C-M-j~       | use current input immediately (this can be used to create a new file in Find File)                                                                  |
+| ~TAB~         | complete partially                                                                                                                                  |
+| ~M-o~         | show the list of valid actions on current candidate (then press any of described keys to execute it)                                                |
+| ~C-M-o~       | the same as ~M-o~ but doesn't close completion minibuffer                                                                                           |
+| ~C-'~         | use avy to quickly select completion on current page (sometimes faster than using arrows)                                                           |
+| ~<ESC>~       | close minibuffer                                                                                                                                    |
+| ~C-M-k~       | kill buffer (in =ivy-switch-buffer= (~SPC b b~))                                                                                                    |
 
 ** Transient state
 Press ~M-SPC~ (~m-M-SPC~ [[https://github.com/syl20bnr/spacemacs/blob/cb48ec74c1f401bd2945760799633c0e81e69088/doc/CONVENTIONS.org#transient-state][on macOS]]) anytime in Ivy to get into the transient state. Additional actions

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -224,6 +224,7 @@
       ;; mappings to quit minibuffer or enter transient state
       (define-key ivy-minibuffer-map [escape] 'minibuffer-keyboard-quit)
       (define-key ivy-minibuffer-map (kbd "M-SPC") 'hydra-ivy/body)
+      (define-key ivy-minibuffer-map (kbd "C-<return>") #'ivy-alt-done)
 
       (when ivy-ret-visits-directory
         (define-key ivy-minibuffer-map (kbd "RET") #'ivy-alt-done)


### PR DESCRIPTION
Currently there is only the option to use `ivy-alt-done` by rebinding `ivy-done` to `C-j` with setting `ivy-ret-visits-directory` to `t`.
In ivy, `ivy-alt-done` is bound to `C-j` which of course in Spacemacs is used for selecting the next entry (in ivy minibuffer). However, `C-RET` is still free, so this PR binds `ivy-alt-done` to `C-RET`.

I prefer `ivy-alt-done` over `TAB-TAB` to browse into directories. Also, this setting enables to go into directories with Ivy (instead of opening the directory in dired) when using e.g the `fasd` package.