### PR TITLE
[multiple-cursors] Disable evil-mc-mode in magit-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2628,6 +2628,7 @@ Other:
   - ~grI~ =evil-mc-make-cursor-in-visual-selection-beg=
   - ~grA~ =evil-mc-make-cursor-in-visual-selection-end=
   (thanks to duianto)
+- Disabled =evil-mc-mode= in =magit-mode= (thanks to duianto)
 **** Neotree
 - Made neotree an optional instead of a default layer
 - Move neotree to its own layer in new +filetree folder

--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -24,6 +24,7 @@
       (add-hook 'text-mode-hook 'turn-on-evil-mc-mode))
     :config
     (progn
+      (add-hook 'magit-mode-hook 'turn-off-evil-mc-mode)
       (setq-default evil-mc-one-cursor-show-mode-line-text nil)
       (when (or (spacemacs/system-is-mac) (spacemacs/system-is-mswindows))
         (setq evil-mc-enable-bar-cursor nil))


### PR DESCRIPTION
Resolves #13948

problem:
The p key tries to paste in the read-only magit buffer,
instead of calling magit-push.

After toggling text-mode on and off (C-t or \),
because evil-mc-mode becomes enabled when text-mode is enabled.