### PR TITLE
Adding magit-delta option for magit

### DIFF
--- a/layers/+source-control/git/config.el
+++ b/layers/+source-control/git/config.el
@@ -17,5 +17,9 @@
 (defvar git-magit-status-fullscreen nil
   "If non nil magit-status buffer is displayed in fullscreen.")
 
+(defvar git-enable-magit-delta-plugin nil
+  "If non nil `magit-delta-mode' plugin is enabled.")
+
 (defvar spacemacs--git-blame-ts-full-hint-toggle nil
   "Display git blame transient state documentation.")
+

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -25,6 +25,7 @@
         (helm-git-grep :requires helm)
         (helm-gitignore :requires helm)
         magit
+        (magit-delta :toggle git-enable-magit-delta-plugin)
         magit-gitflow
         magit-section
         magit-svn
@@ -250,6 +251,11 @@
       (evil-define-key 'normal magit-section-mode-map (kbd "M-7") 'winum-select-window-7)
       (evil-define-key 'normal magit-section-mode-map (kbd "M-8") 'winum-select-window-8)
       (evil-define-key 'normal magit-section-mode-map (kbd "M-9") 'winum-select-window-9))))
+
+(defun git/init-magit-delta ()
+  (use-package magit-delta
+    :defer t
+    :init (add-hook 'magit-mode-hook 'magit-delta-mode)))
 
 (defun git/init-magit-gitflow ()
   (use-package magit-gitflow


### PR DESCRIPTION
This PR enables [magit-delta](https://github.com/dandavison/magit-delta) with the new `git-enable-magit-delta-plugin` option.

For example usage, one could write this in their `.spacemacs`:

```emacs-lisp
(setq-default dotspacemacs-configuration-layers
  '( 
    ;; rest of packages here
    (git :variables git-enable-magit-delta-plugin t))
```