### PR TITLE
Don't let magit-gitflow mode overwrite `C-f` key binding.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1978,6 +1978,7 @@ Other:
     - ~SPC g l P~ adds region permalink URL to clipboard
   - Moved =magit-find-file= to view a file at a specific branch or commit
     from ~SPC g f f~ to ~SPC g f F~ (thanks to duianto and Hong Xu)
+  - Unbind ~C-f~ from =magit-gitflow-popup= (thanks to rayw000)
 - Fixes:
   - Install magit-svn by default and activate with git-enable-magit-svn-plugin
   - Added feature to toggle =evil-magit= based on editing style

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -254,7 +254,9 @@
 (defun git/init-magit-gitflow ()
   (use-package magit-gitflow
     :defer t
-    :init (add-hook 'magit-mode-hook 'turn-on-magit-gitflow)
+    :init (progn
+            (add-hook 'magit-mode-hook 'turn-on-magit-gitflow)
+            (setq magit-gitflow-popup-key "%"))
     :config
     (progn
       (spacemacs|diminish magit-gitflow-mode "Flow")


### PR DESCRIPTION
In `*magit*` buffer, minor mode `magit-flow` overwrites key `C-f` from `forward-char` to `magit-gitflow-popup`.

It may be confusing that `C-a` `C-e` `C-b` are all cursor motion except `C-f`.

This PR makes `magit-gitflow-popup` only bound to `%`.

Ref:
https://github.com/jtatarik/magit-gitflow/issues/11
https://github.com/jtatarik/magit-gitflow/blob/cc41b561ec6eea947fe9a176349fb4f771ed865b/magit-gitflow.el#L43-L48