### PR TITLE
Add instruction how to use ranger by default

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3003,6 +3003,7 @@ Other:
   - Added ~-~ to enter (thanks to Rich Alesi)
 - Fixed conflict with =golden-ratio= (thanks to Thomas de Beauchêne)
 - Load =helm= before =ranger= (thanks to duianto)
+- Add instruction to use ranger by default (thanks to Daniel Nicolai)
 **** Rcirc
 - New variable =rcirc-enable-late-fix= to enable or disable the included
   =rcirc-late-fix= package (disabled by default).

--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -18,11 +18,17 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =ranger= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-To default with preview enabled when entering ranger:
+To use ranger/deer by default set ~ranger-override-dired~ to ~ranger/deer~ like
+shown in the example below (setting this via customize as explained by the
+original [[https://github.com/ralesi/ranger.el#installation][ranger installation instructions]] will not work). To default with
+preview enabled when entering ranger set ~ranger-show-preview~ to ~t~. The following
+example code shows how you can set both variables at once via the
+~dotspacemacs-configuration-layers~ of your dotfiles as follows:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
                 '(ranger :variables
+                         ranger-override-dired 'ranger
                          ranger-show-preview t))
 #+END_SRC
 


### PR DESCRIPTION
The ranger layer does not describe yet how to actually use ranger by default, while also the [instructions for the original ranger package](https://github.com/ralesi/ranger.el#setting-as-default-directory-handler) don't work (i.e. setting `ranger-override-dired` via customize does not work in Spacemacs).

I created a feature branch but forgot to check it out (still need to get used to magit). I hope it is fine that I create this PR now directly (and be more careful/wiser next time).