### PR TITLE
[core] Enable pdumper by default if the Emacs build supports it

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -58,10 +58,9 @@ exists. Otherwise, fallback to ~/.spacemacs"))
 `+distributions'. For now available distributions are `spacemacs-base'
 or `spacemacs'.")
 
-(defvar dotspacemacs-enable-emacs-pdumper nil
-  "If non-nil then enable support for the portable dumper. You'll need
-to compile Emacs 27 from source following the instructions in file
-EXPERIMENTAL.org at to root of the git repository.")
+(defvar dotspacemacs-enable-emacs-pdumper t
+  "If non-nil then enable support for the portable dumper if this Emacs build
+supports portable dumping (requires Emacs 27 or later).")
 
 (defvar dotspacemacs-emacs-pdumper-executable-file "emacs"
   "File path pointing to emacs 27 or later executable.")

--- a/core/core-dumper.el
+++ b/core/core-dumper.el
@@ -100,6 +100,7 @@ the end of the loading of the dump file."
 (defun spacemacs/emacs-with-pdumper-set-p ()
   "Return non-nil if a portable dumper capable emacs executable is set."
   (and dotspacemacs-enable-emacs-pdumper
+       (fboundp 'dump-emacs-portable)
        (file-exists-p
         (locate-file (or dotspacemacs-emacs-pdumper-executable-file "emacs")
                      exec-path exec-suffixes 'file-executable-p))))

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -90,6 +90,7 @@ It should only modify the values of Spacemacs settings."
   (setq-default
    ;; If non-nil then enable support for the portable dumper if Emacs supports
    ;; it (requires at least Emacs 27).
+   ;; (default t)
    dotspacemacs-enable-emacs-pdumper t
 
    ;; Name of executable file pointing to emacs 27+. This executable must be

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -88,11 +88,9 @@ It should only modify the values of Spacemacs settings."
   ;; This setq-default sexp is an exhaustive list of all the supported
   ;; spacemacs settings.
   (setq-default
-   ;; If non-nil then enable support for the portable dumper. You'll need
-   ;; to compile Emacs 27 from source following the instructions in file
-   ;; EXPERIMENTAL.org at to root of the git repository.
-   ;; (default nil)
-   dotspacemacs-enable-emacs-pdumper nil
+   ;; If non-nil then enable support for the portable dumper if Emacs supports
+   ;; it (requires at least Emacs 27).
+   dotspacemacs-enable-emacs-pdumper t
 
    ;; Name of executable file pointing to emacs 27+. This executable must be
    ;; in your PATH.


### PR DESCRIPTION
This enables the portable dumper by default if the Emacs instance supports it. If the user is running an older Emacs version, or an Emacs 27 build that was compiled without pdumper support, the Spacemacs configuration will continue to work as before without attempting to pdump. I think this is warranted because:
 * Emacs 27 is now the current stable Emacs major version
 * The portable dumper is no longer considered experimental, it's enabled by default when building Emacs 27+

Besides updating the default definition of `dotspacemacs-enable-emacs-pdumper` to `t`, I've modified `spacemacs/emacs-with-pdumper-set-p` to also check that `dump-emacs-portable` is a bound function (which will only be the case on an Emacs build that supports pdumping).

Of course, Spacemacs users with an old `.spacemacs` file may continue to have the value of `dotspacemacs-enable-emacs-pdumper` set as `nil` until they diff/sync with the upstream template, but that's expected (and desired).

**NOTE:** I'm not sure to do with the file `EXPERIMENTAL.org`, which has the legacy instructions for building Emacs with pdumper support. It arguably could just be removed, but it also has some still relevant instructions about using the pdumper mode (e.g. aliasing emacs to `emacs --dump-file=path/to/spacemacs.dump`). Maybe we need to remove this file and update the README?