### PR TITLE
[clojure] key binding for cider eval list around point

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1633,6 +1633,10 @@ Other:
     ~raN~ 'clojure-insert-ns-form-at-point
     ~rsn~ 'clojure-sort-ns
     (thanks to John Stevenson)
+  - Add key binding for new function cider-eval-list-around-point
+    added in CIDER 0.26
+    ~SPC m e (~ 'cider-eval-list-at-point
+    (thanks to John Stevenson)
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -487,6 +487,7 @@ Evaluate Clojure code in the source code buffer
 |---------------+-------------------------------------------------------------------|
 | ~SPC m e ;~   | eval sexp and show result as comment                              |
 | ~SPC m e $~   | go to end of line and eval last sexp                              |
+| ~SPC m e (~   | eval 'list' around point (sequence, list, vector, map, set)       |
 | ~SPC m e b~   | eval buffer                                                       |
 | ~SPC m e e~   | eval last sexp                                                    |
 | ~SPC m e f~   | eval function at point                                            |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -108,6 +108,7 @@
             ;; evaluate in source code buffer
             "e;" 'cider-eval-defun-to-comment
             "e$" 'spacemacs/cider-eval-sexp-end-of-line
+            "e(" 'cider-eval-list-at-point
             "eb" 'cider-eval-buffer
             "ee" 'cider-eval-last-sexp
             "ef" 'cider-eval-defun-at-point


### PR DESCRIPTION
New command added to CIDER in version 0.26 to evaluate the list around the
current point, different to evaluate sexp around point which also evaluates
symbols.

This command is useful for evaluating nested expressions without having to jump to the end of the expression.  It will evaluate function calls as well as evaluate collections as functions (lists, maps, vectors, sets).

https://github.com/clojure-emacs/cider/pull/2881

Thank you <3