### PR TITLE
[tabs] Fix typo

### DIFF
--- a/layers/+emacs/tabs/config.el
+++ b/layers/+emacs/tabs/config.el
@@ -1,4 +1,4 @@
-;;; config.el --- Org configuration File for Spacemacs
+;;; config.el --- tabs configuration File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
 ;;


### PR DESCRIPTION
Fix a typo in the tabs layer `config.el` file