### PR TITLE
Replace spacemacs/swiper with better native swiper functions

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2278,6 +2278,15 @@ Other:
   - Add ~d~ to create a project perspective and open a project root dired
     buffer, from the ~SPC p l~ persp switch project prompt
     (thanks to Magnus Therning and Muneeb Shaikh)
+  - Rebind =SPC s S= from =spacemacs/swiper-region-or-symbol= to Ivy native
+    =swiper-thing-at-point=
+  - Rebind =SPC s S= from =spacemacs/swiper-all-region-or-symbol= to Ivy native
+    =swiper-all-thing-at-point=
+    (last two points thanks to Daniel Nicolai)
+- Removed definitions for =spacemacs/swiper-region-or-symbol= and
+  =spacemacs/swiper-all-region-or-symbol= and updated keybindings, because Ivy has
+  more advanced implementation via =swiper-thing-at-point= and
+  =swiper-all-thing-at-point=
 - Limit =ripgrep= results to 150 columns (thanks to Aaron Jensen)
 - Use new API to register additional transient state bindings
   (thanks to Andriy Kmit')

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -461,31 +461,3 @@ Closing doesn't kill buffers inside the layout while killing layouts does."
                     (spacemacs//current-layout-name))
             (persp-names)
             :action 'persp-kill))
-
-
-;; Swiper
-
-(defun spacemacs//counsel-current-region-or-symbol ()
-  "Return contents of the region or symbol at point.
-
-If region is active, mark will be deactivated in order to prevent region
-expansion when jumping around the buffer with counsel. See `deactivate-mark'."
-  (if (region-active-p)
-      (prog1
-          (buffer-substring-no-properties (region-beginning) (region-end))
-        (deactivate-mark))
-    (thing-at-point 'symbol t)))
-
-(defun spacemacs/swiper-region-or-symbol ()
-  "Run `swiper' with the selected region or the symbol
-around point as the initial input."
-  (interactive)
-  (let ((input (spacemacs//counsel-current-region-or-symbol)))
-    (swiper input)))
-
-(defun spacemacs/swiper-all-region-or-symbol ()
-  "Run `swiper-all' with the selected region or the symbol
-around point as the initial input."
-  (interactive)
-  (let ((input (spacemacs//counsel-current-region-or-symbol)))
-    (swiper-all input)))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -43,8 +43,8 @@
            spacemacs--symbol-highlight-transient-state-doc
            "  Search: [_s_] swiper  [_b_] buffers  [_f_] files  [_/_] project"))
     (spacemacs/transient-state-register-add-bindings 'symbol-highlight
-      '(("s" spacemacs/swiper-region-or-symbol :exit t)
-        ("b" spacemacs/swiper-all-region-or-symbol :exit t)
+      '(("s" swiper-thing-at-point :exit t)
+        ("b" swiper-all-thing-at-point :exit t)
         ("f" spacemacs/search-auto-region-or-symbol :exit t)
         ("/" spacemacs/search-project-auto-region-or-symbol :exit t)))))
 
@@ -370,9 +370,9 @@
     (progn
       (spacemacs/set-leader-keys
         "ss" 'swiper
-        "sS" 'spacemacs/swiper-region-or-symbol
+        "sS" 'swiper-thing-at-point
         "sb" 'swiper-all
-        "sB" 'spacemacs/swiper-all-region-or-symbol)
+        "sB" 'swiper-all-thing-at-point)
       (global-set-key "\C-s" 'swiper))))
 
 (defun ivy/init-wgrep ()


### PR DESCRIPTION
Spacemacs uses spacemacs/swiper functions that use the less sophisticated
spacemacs//counsel-current-region-or-symbol instead of ivy's native
ivy-thing-at-point function. This commit removes those spacemacs functions and
rebinds the shortcuts to their better native equivalents.

Again forgot to make a fix branch because I forgot because I am always fighting
with git. Anyway, again I will try to be more alert next time.