### PR TITLE
[org] Add org-roam support

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2710,6 +2710,7 @@ Other:
   - Added package for =org-sticky-header-mode= (thanks to Langston Barret)
   - Added package =org-jira= (thanks to Kirill A. Korinsky)
   - Added package =org-rich-yank= (thanks to Keith Pinson)
+  - Added package =org-roam= (thanks to Mariusz Klochowicz)
 - Key bindings:
   - ~SPC m T i~ to toggle inline images
   - Move clock related key bindings to ~SPC a o C~
@@ -2804,6 +2805,20 @@ Other:
   - Documented more insertion bindings (thanks to Lorenzo Manacorda):
     - ~C-RET~   Insert heading at end of current subtree
     - ~C-S-RET~ Insert TODO heading at end of current subtree
+  - Changed =helm-org-rifle= keybindings to ~SPC a o /~, falling back to its
+    previous functionality if using ivy (thanks to Mariusz Klochowicz)
+  - Added keybindings for =org-roam= under menu prefix ~SPC a o r~ and ~SPC m r~
+    (thanks to Mariusz Klochowicz)
+    - ~SPC a o r l~   (~SPC m r l~)   Toggle org-roam links visibility 
+    - ~SPC a o r f~   (~SPC m r f~)    Find file in org-roam                 
+    - ~SPC a o r i~   (~SPC m r i~)    Insert file into org-roam             
+    - ~SPC a o r I~   (~SPC m r I~)    Immediately insert file into org-roam 
+    - ~SPC a o r g~   (~SPC m r g~)    Visualize org-roam graph              
+    - ~SPC a o r b~   (~SPC m r b~)   Switch org-roam buffer                
+    - ~SPC a o r d y~ (~SPC m r d y~) Open yesterday's daily note           
+    - ~SPC a o r d t~ (~SPC m r d t~) Open today's daily note               
+    - ~SPC a o r d T~ (~SPC m r d T~) Open tomorrow's daily note            
+    
 - Made =org= layer depend on =spacemacs-org= (thanks to Eivind Fonn)
 - Remove =mu4e= and =notmuch= from =org= (thanks to Sylvain Benner)
 - Use evil-org from MELPA (thanks to Eivind Fonn)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -21,6 +21,7 @@
   - [[#different-bullets][Different bullets]]
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
+  - [[#org-roam-support][Org-roam support]]
   - [[#mode-line-support][Mode line support]]
   - [[#sticky-header-support][Sticky header support]]
   - [[#epub-support][Epub support]]
@@ -57,6 +58,7 @@
     - [[#verb-mode-bindings][Verb-mode bindings]]
     - [[#verb-response-body-mode-bindings][Verb-response-body-mode bindings]]
     - [[#verb-response-headers-mode-bindings][Verb-response-headers-mode bindings]]
+  - [[#org-roam][Org-roam]]
 
 * Description
 This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
@@ -293,6 +295,18 @@ the following snippet.
 ** Org-brain support
 For Emacs 25 or later, support for [[https://kungsgeten.github.io/org-brain.html][org-brain]] is included. See the [[https://github.com/Kungsgeten/org-brain][org-brain
 package documentation]] for more information.
+
+** Org-roam support
+
+To install org-roam support set the variable =org-enable-roam-support= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-roam-support t)))
+#+END_SRC
+
+More information about org-roam package (including manual) can be found at [[https://www.orgroam.com/][Org-roam]] website.
 
 ** Mode line support
 To temporarily enable mode line display of org clock, press ~SPC t m c~.
@@ -753,7 +767,7 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 
 | Key binding | Description                                |
 |-------------+--------------------------------------------|
-| ~SPC a o r~ | Search org files for keywords and headings |
+| ~SPC a o /~ | Search org files for keywords and headings |
 
 ** Org-projectile
 
@@ -883,3 +897,21 @@ are available.
 | Key binding | Description                                         |
 |-------------+-----------------------------------------------------|
 | ~SPC m r q~ | Kill current response headers buffer and its window |
+
+** Org-roam
+
+Key binding prefixes:
+ - ~SPC a o r~ (anywhere)
+ - ~SPC m r~   (in an org-mode buffer)
+
+| Key binding    | Description                           |
+|----------------+---------------------------------------|
+| ~[prefix] r l~   | Toggle org-roam links visibility      |
+| ~[prefix] r f~   | Find file in org-roam                 |
+| ~[prefix] r i~   | Insert file into org-roam             |
+| ~[prefix] r I~   | Immediately insert file into org-roam |
+| ~[prefix] r g~   | Visualize org-roam graph              |
+| ~[prefix] r b~   | Switch org-roam buffer                |
+| ~[prefix] r d y~ | Open yesterday's daily note           |
+| ~[prefix] r d t~ | Open today's daily note               |
+| ~[prefix] r d T~ | Open tomorrow's daily note            |

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -55,3 +55,6 @@ are configured.")
 
 (defvar org-enable-verb-support nil
   "If non-nil, Verb (https://github.com/federicotdn/verb) is configured.")
+
+(defvar org-enable-roam-support nil
+  "If non-nil, org-roam (https://www.orgroam.com/) is configured")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -46,6 +46,7 @@
         (org-trello :toggle org-enable-trello-support)
         (org-sticky-header :toggle org-enable-sticky-header)
         (verb :toggle org-enable-verb-support)
+        (org-roam :toggle org-enable-roam-support)
         ))
 
 (defun org/post-init-company ()
@@ -83,7 +84,7 @@
 (defun org/init-helm-org-rifle ()
   (use-package helm-org-rifle
     :defer t
-    :init (spacemacs/set-leader-keys "aor" 'helm-org-rifle)))
+    :init (spacemacs/set-leader-keys "ao/" 'helm-org-rifle)))
 
 (defun org/init-htmlize ()
   (use-package htmlize
@@ -356,10 +357,11 @@ Will work on both org-mode and any mode that accepts plain html."
       (spacemacs/declare-prefix "ao" "org")
       (spacemacs/declare-prefix "aof" "feeds")
       (spacemacs/declare-prefix "aoC" "clock")
+      ;; org-agenda
+      (when (configuration-layer/layer-used-p 'ivy)
+        (spacemacs/set-leader-keys "ao/" 'org-occur-in-agenda-files))
       (spacemacs/set-leader-keys
-        ;; org-agenda
         "ao#" 'org-agenda-list-stuck-projects
-        "ao/" 'org-occur-in-agenda-files
         "aoa" 'org-agenda-list
         "aoo" 'org-agenda
         "aoc" 'org-capture
@@ -817,6 +819,38 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "mtdc" 'spacemacs/org-trello-pull-card
         "mtub" 'spacemacs/org-trello-push-buffer
         "mtuc" 'spacemacs/org-trello-push-card))))
+
+(defun org/init-org-roam ()
+  (use-package org-roam
+    :init
+    (progn
+      (spacemacs/declare-prefix "aor" "org-roam")
+      (spacemacs/declare-prefix "aord" "org-roam-dailies")
+      (spacemacs/set-leader-keys
+        "aordy" 'org-roam-dailies-yesterday
+        "aordt" 'org-roam-dailies-today
+        "aordT" 'org-roam-dailies-tomorrow
+        "aorf" 'org-roam-find-file
+        "aorg" 'org-roam-graph
+        "aori" 'org-roam-insert
+        "aorI" 'org-roam-insert-immediate
+        "aorl" 'org-roam)
+
+      (spacemacs/declare-prefix-for-mode 'org-mode "mr" "org-roam")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mrd" "org-roam-dailies")
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode
+        "rb" 'org-roam-switch-to-buffer
+        "rdy" 'org-roam-dailies-yesterday
+        "rdt" 'org-roam-dailies-today
+        "rdT" 'org-roam-dailies-tomorrow
+        "rf" 'org-roam-find-file
+        "rg" 'org-roam-graph
+        "ri" 'org-roam-insert
+        "rI" 'org-roam-insert-immediate
+        "rl" 'org-roam))
+    :config
+    (progn
+      (spacemacs|hide-lighter org-roam-mode))))
 
 (defun org/init-org-sticky-header ()
   (use-package org-sticky-header


### PR DESCRIPTION
Add org-roam support with some popular mnemonic keybindings based on the configuration suggested by the maintainer (since then removed from org-roam docs).

More information about the package: https://www.orgroam.com/ 

Solves the open issue:
https://github.com/syl20bnr/spacemacs/issues/13536