### PR TITLE
[org] Add major mode keybindings for org-jira

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2804,6 +2804,8 @@ Other:
   - Documented more insertion bindings (thanks to Lorenzo Manacorda):
     - ~C-RET~   Insert heading at end of current subtree
     - ~C-S-RET~ Insert TODO heading at end of current subtree
+  - Added additional prefix (~SPC m m j~) for org-jira bindings 
+    (thanks to Mariusz Klochowicz)
 - Made =org= layer depend on =spacemacs-org= (thanks to Eivind Fonn)
 - Remove =mu4e= and =notmuch= from =org= (thanks to Sylvain Benner)
 - Use evil-org from MELPA (thanks to Eivind Fonn)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -837,23 +837,26 @@ are available.
 | ~r~         | Rename this, or another, entry        |
 
 ** Org-jira
+Key binding prefixes:
+- ~SPC a o J~ (everywhere)
+- ~SPC m m j~ (in an org-mode buffer)
 
-| Key binding     | Description                                      |
-|-----------------+--------------------------------------------------|
-| ~SPC a o J p g~ | Get projects list                                |
-| ~SPC a o J i b~ | Open the current issue in a WWW browser          |
-| ~SPC a o J i g~ | Get issues                                       |
-| ~SPC a o J i h~ | Get only head of issues                          |
-| ~SPC a o J i f~ | Get only head of issues from filter              |
-| ~SPC a o J i u~ | Update an issue at point                         |
-| ~SPC a o J i w~ | Progress an issue at point                       |
-| ~SPC a o J i r~ | Refresh an issue at point                        |
-| ~SPC a o J i c~ | Create an issue at point                         |
-| ~SPC a o J i y~ | Copy current issue key                           |
-| ~SPC a o J s c~ | Create a subtask                                 |
-| ~SPC a o J s g~ | Get subtasks                                     |
-| ~SPC a o J c u~ | Update the comment at point or add a new comment |
-| ~SPC a o J t j~ | Convert the TODO item at point to a Jira ticket  |
+| Key binding  | Description                                      |
+|--------------+--------------------------------------------------|
+| ~[prefix] p g~ | Get projects list                                |
+| ~[prefix] i b~ | Open the current issue in a WWW browser          |
+| ~[prefix] i g~ | Get issues                                       |
+| ~[prefix] i h~ | Get only head of issues                          |
+| ~[prefix] i f~ | Get only head of issues from filter              |
+| ~[prefix] i u~ | Update an issue at point                         |
+| ~[prefix] i w~ | Progress an issue at point                       |
+| ~[prefix] i r~ | Refresh an issue at point                        |
+| ~[prefix] i c~ | Create an issue at point                         |
+| ~[prefix] i y~ | Copy current issue key                           |
+| ~[prefix] s c~ | Create a subtask                                 |
+| ~[prefix] s g~ | Get subtasks                                     |
+| ~[prefix] c u~ | Update the comment at point or add a new comment |
+| ~[prefix] t j~ | Convert the TODO item at point to a Jira ticket  |
 
 ** Verb
 *** Verb-mode bindings

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -644,7 +644,28 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "aoJsc" 'org-jira-create-subtask
         "aoJsg" 'org-jira-get-subtasks
         "aoJcu" 'org-jira-update-comment
-        "aoJtj" 'org-jira-todo-to-jira))))
+        "aoJtj" 'org-jira-todo-to-jira)
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmj" "jira")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmjp" "projects")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmji" "issues")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmjs" "subtasks")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmjc" "comments")
+      (spacemacs/declare-prefix-for-mode 'org-mode "mmjt" "todos")
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode
+        "mjpg" 'org-jira-get-projects
+        "mjib" 'org-jira-browse-issue
+        "mjig" 'org-jira-get-issues
+        "mjih" 'org-jira-get-issues-headonly
+        "mjif" 'org-jira-get-issues-from-filter-headonly
+        "mjiu" 'org-jira-update-issue
+        "mjiw" 'org-jira-progress-issue
+        "mjir" 'org-jira-refresh-issue
+        "mjic" 'org-jira-create-issue
+        "mjiy" 'org-jira-copy-current-issue-key
+        "mjsc" 'org-jira-create-subtask
+        "mjsg" 'org-jira-get-subtasks
+        "mjcu" 'org-jira-update-comment
+        "mjtj" 'org-jira-todo-to-jira))))
 
 (defun org/init-org-mime ()
   (use-package org-mime


### PR DESCRIPTION
org-jira is typically used from org major mode - new keybindings add a more
convenient way of invoking its functions.

The new org-jira submenu is available under "mj" - using the same pattern as
org-trello.

The existing keybindings (<spc> a o J ....) are inconvenient to use due to uppercase "J" and involving more keypresses.

PS I have considered using "j" instead of "mj", but I didn't want to potentially hog up keybinding that might be use for other extensions, e.g. org-journal.