### PR TITLE
Fix display of notes in home buffer

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -382,7 +382,7 @@ ADDITIONAL-WIDGETS: a function for inserting a widget under the frame."
                                                                      80))))
       (save-restriction
         (narrow-to-region (point) (point))
-        (add-to-list 'spacemacs-buffer--note-widgets (widget-create 'text note))
+        (add-to-list 'spacemacs-buffer--note-widgets (widget-create 'text :format "%v" note))
         (let* ((width (spacemacs-buffer//get-buffer-width))
                (padding (max 0 (floor (/ (- spacemacs-buffer--window-width
                                             width) 2)))))


### PR DESCRIPTION
Quickhelp and Release Notes are currently not correctly displayed in the home buffer. This fixes it.

