### PR TITLE
remove package `mercury-mode` which no more exist

### DIFF
--- a/layers/+lang/mercury/packages.el
+++ b/layers/+lang/mercury/packages.el
@@ -14,7 +14,6 @@
                                    :fetcher github
                                    :repo "ahungry/metal-mercury-mode"
                                    :commit "99e2d8fb7177cae3bfa2dec2910fc28216d5f5a8"))
-    (mercury-mode :excluded t)
     flycheck
     (flycheck-mercury :requires flycheck)
     smartparens))


### PR DESCRIPTION
`mercury-mode` had been replaced by `metal-mercury-mode`. Now `mercury-mode` can't be found from all sources so it needs to be removed.