### PR TITLE
Bind `SPC s l` to ivy-resume

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -208,6 +208,7 @@
         "Cw" 'counsel-colors-web
         "fr" 'counsel-recentf
         "rl" 'ivy-resume
+        "sl" 'ivy-resume
         "bb" 'ivy-switch-buffer)
       ;; Moved C-k to C-M-k
       (define-key ivy-switch-buffer-map (kbd "C-M-k") 'ivy-switch-buffer-kill))


### PR DESCRIPTION
Helm already has spacemacs/resume-last-search-buffer bound to it and is in my
muscle memory. spacemacs/resume-last-search-buffer doesn't work with ivy, so
just use ivy-resume.