### PR TITLE
Fix misc. compilation warnings in core

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -214,7 +214,7 @@ LAYER has to be installed for this method to work properly."
     (when (and (numberp rank)
                (not (eq 'unspecified shadow-candidates))
                (listp shadow-candidates))
-      (mapcar
+      (mapc
        (lambda (other)
          (let ((orank (cl-position other configuration-layer--used-layers)))
            ;; OTHER shadows LAYER if and only if OTHER's rank is bigger than
@@ -2458,7 +2458,7 @@ depends on it."
   (let ((layer-name
          (intern (completing-read
                   "Choose a used layer"
-                  (sort (copy-list configuration-layer--used-layers) #'string<)))))
+                  (sort (cl-copy-list configuration-layer--used-layers) #'string<)))))
     (let ((mode-exts (configuration-layer//lazy-install-extensions-for-layer
                       layer-name)))
       (dolist (x mode-exts)
@@ -2604,7 +2604,7 @@ Returns nil if the version is unknown."
   (when (file-exists-p configuration-layer--stable-elpa-version-file)
     (with-current-buffer (find-file-noselect
                           configuration-layer--stable-elpa-version-file)
-      (when (called-interactively-p)
+      (when (called-interactively-p 'interactive)
         (message "Stable ELPA repository version is: %s" (buffer-string)))
       (buffer-string))))
 
@@ -2652,7 +2652,7 @@ MSG is an additional message append to the generic error."
   (with-current-buffer (find-file-noselect
                         configuration-layer--stable-elpa-version-file)
     (erase-buffer)
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (insert (format "%s" configuration-layer-stable-elpa-version))
     (save-buffer)))
 

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -543,7 +543,7 @@ the symbol of an editing style and the cdr is a list of keyword arguments like
 Returns non nil if the layer has been effectively inserted."
   (unless (configuration-layer/layer-used-p layer-name)
     (with-current-buffer (find-file-noselect (dotspacemacs/location))
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (let ((insert-point
              (re-search-forward
               "[^`]dotspacemacs-configuration-layers\\s-*\n?[^(]*\\((\\)")))
@@ -758,7 +758,7 @@ If ARG is non nil then ask questions to the user before installing the dotfile."
            (fs (format-spec-make
                 ?a abbreviated-file-name
                 ?t project-name
-                ?S system-name
+                ?S (system-name)
                 ?I invocation-name
                 ?U (or (getenv "USER") "")
                 ?b "%b"

--- a/core/core-env.el
+++ b/core/core-env.el
@@ -87,7 +87,7 @@ current contents of the file will be overwritten."
           (dolist (shell-command-switch shell-command-switches)
             (call-process-shell-command
              (concat executable " > " (shell-quote-argument tmpfile)))
-            (insert-file tmpfile))
+            (insert-file-contents tmpfile))
           (delete-file tmpfile)
           ;; sort the environment variables
           (sort-regexp-fields nil "^.*$" ".*?=" env-point (point-max))

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -416,7 +416,8 @@ set."
         (min spacemacs--gne-max-line
              (max spacemacs--gne-min-line
                   (+ num spacemacs--gne-cur-line))))
-  (goto-line spacemacs--gne-cur-line)
+  (goto-char (point-min))
+  (forward-line (1- spacemacs--gne-cur-line))
   (funcall spacemacs--gne-line-func
            (buffer-substring (point-at-bol) (point-at-eol))))
 


### PR DESCRIPTION
This PR makes minor changes to `core/` Elisp code in order to remove some compilation warnings (e.g. missing arguments, an implicit `cl.el` usage, etc.).