### PR TITLE
Add missing dependency on javascript layer

### DIFF
--- a/layers/+frameworks/vue/layers.el
+++ b/layers/+frameworks/vue/layers.el
@@ -9,4 +9,4 @@
 ;;
 ;;; License: GPLv3
 
-(configuration-layer/declare-layers '(node html prettier))
+(configuration-layer/declare-layers '(node html prettier javascript))


### PR DESCRIPTION
without this, spacemacs//javascript-setup-checkers in package.el:45 will not be
found unless user has the layer installed already