### PR TITLE
[shell] new helm/ivy functions to search history and bind it to M-r

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -34,6 +34,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#multi-term][Multi-term]]
   - [[#eshell-1][Eshell]]
+  - [[#vterm][vterm]]
 
 * Description
 This layer configures the various shells available in Emacs.
@@ -326,3 +327,13 @@ in the current buffer instead of a popup.
 | Key binding        | Description                                       |
 |--------------------+---------------------------------------------------|
 | ~SPC m H~ or ~M-l~ | shell commands history using a helm or ivy buffer |
+
+** vterm
+~M-r~ will be bound to to search for command history when variable
+=spacemacs-vterm-history-file-location= is set to path to your shell history file.
+
+For example with bash
+#+begin_src elisp
+     (shell :variables
+            spacemacs-vterm-history-file-location "~/.bash_history")
+#+end_src

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -52,3 +52,6 @@
 (defvar close-window-with-terminal nil
   "If non-nil, the window is closed when the terminal is stopped.
   This is only applied to `term' and `ansi-term' modes.")
+
+(defvar spacemacs-vterm-history-file-location nil
+  "Bash history full file name.")

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -233,3 +233,40 @@ tries to restore a dead buffer or window."
     (setq shell-pop-last-buffer (window-buffer (get-mru-window nil t t))))
   (unless (window-live-p shell-pop-last-window)
     (setq shell-pop-last-window (get-buffer-window shell-pop-last-buffer))))
+
+(defun spacemacs//vterm-make-history-candidates ()
+  (with-temp-buffer
+    (insert-file-contents spacemacs-vterm-history-file-location)
+    (reverse
+     (delete-dups
+      (split-string (buffer-string) "\n")))))
+
+(defun spacemacs/helm-vterm-search-history ()
+  "Narrow down bash history with helm."
+  (interactive)
+  (assert (string-equal mode-name "Vterm") nil "Not in VTerm mode")
+  (helm :sources (helm-build-sync-source "Bash history"
+                                         :candidates (spacemacs//vterm-make-history-candidates)
+                                         :action #'vterm-send-string)
+        :buffer "*helm-bash-history*"
+        :candidate-number-limit 10000))
+
+(defun spacemacs/counsel-vterm-search-history ()
+  "Narrow down bash history with ivy."
+  (interactive)
+  (assert (string-equal mode-name "VTerm") nil "Not in VTerm mode")
+  (ivy-read "Bash history: "
+            (spacemacs//vterm-make-history-candidates)
+            :keymap counsel-describe-map
+            :preselect (ivy-thing-at-point)
+            :history 'spacemacs/counsel-shell-search-history-history
+            :require-match t
+            :action #'vterm-send-string
+            :caller 'spacemacs/counsel-vterm-search-history))
+
+(defun spacemacs//vterm-bind-m-r (mode-map)
+  (cond
+   ((configuration-layer/layer-used-p 'helm)
+    (define-key mode-map (kbd "M-r") 'spacemacs/helm-vterm-search-history))
+   ((configuration-layer/layer-used-p 'ivy)
+    (define-key mode-map (kbd "M-r") 'spacemacs/counsel-vterm-search-history))))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -159,7 +159,9 @@
 (defun shell/pre-init-ivy ()
   (spacemacs|use-package-add-hook ivy
     :post-init
-    (add-hook 'eshell-mode-hook 'spacemacs/init-ivy-eshell)))
+    (add-hook 'eshell-mode-hook 'spacemacs/init-ivy-eshell))
+  (spacemacs/set-leader-keys-for-major-mode 'shell-mode
+    "H" 'counsel-shell-history))
 
 (defun shell/pre-init-magit ()
   (spacemacs|use-package-add-hook magit
@@ -219,6 +221,7 @@
              (t (comint-simple-send proc command))))))
   (add-hook 'shell-mode-hook 'shell-comint-input-sender-hook)
   (add-hook 'shell-mode-hook 'spacemacs/disable-hl-line-mode)
+
   (with-eval-after-load 'centered-cursor-mode
     (add-hook 'shell-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode)))
 
@@ -339,6 +342,8 @@
       (define-key vterm-mode-map (kbd "M-p") 'vterm-send-up)
       (define-key vterm-mode-map (kbd "M-y") 'vterm-yank-pop)
       (define-key vterm-mode-map (kbd "M-/") 'vterm-send-tab)
+      (when spacemacs-vterm-history-file-location
+        (spacemacs//vterm-bind-m-r vterm-mode-map))
 
       (evil-define-key 'insert vterm-mode-map (kbd "C-y") 'vterm-yank)
 


### PR DESCRIPTION
Based on http://xenodium.com/search-bash-history-with-emacs-helm/

<del>
Add new helm/ivy functions `spacemacs/helm-shell-search-history`,
spacemacs/counsel-shell-search-history to search bash history and insert to
vterm/shell

Bind this function to M-r for vterm and shell mode.

New layer variable spacemacs-bash-history-file-locatition to customize bash file

Other thoughts:
- probaly should be opt-in
</del>

Add new helm/ivy functions `spacemacs/helm-vterm-search-history`,
`spacemacs/counsel-vterm-search-history` to search bash history and insert to
vterm/shell

Bind this function to M-r for vterm

New layer variable `spacemacs-vterm-history-file-locatition` to customize bash file

Default is nil.

Also bind add counsel-shell-history to `, H` for shell-mode in the same
convention as helm counterpart.
