### PR TITLE
[erlang] add LSP support through erlang_ls

### DIFF
--- a/layers/+lang/erlang/README.org
+++ b/layers/+lang/erlang/README.org
@@ -8,16 +8,104 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
+  - [[#choosing-a-backend][Choosing a backend]]
+- [[#configuration][Configuration]]
+  - [[#erlang-mode][erlang-mode]]
+  - [[#lsp][LSP]]
+- [[#key-bindings][Key bindings]]
+  - [[#erlang-mode-1][erlang-mode]]
+  - [[#lsp-1][LSP]]
 
 * Description
-This layer adds very basic support for Erlang to Spacemacs.
+This layer adds support for [[https://erlang.org/][Erlang]].
+
+Enabling [[https://github.com/emacs-lsp/lsp-mode][Lsp-mode]] brings IDE like
+features following =Language Server Protocol=, through [[https://erlang-ls.github.io/][erlang_ls]]
 
 ** Features:
 - Syntax highlighting
 - Syntax checking via =Flycheck= integration
 - Auto-completion via =Company= integration
+- Code Completion
+- Go To Definition
+- Go To Implementation for OTP Behaviours
+- Signature Suggestions
+- Compiler Diagnostics
+- [[https://erlang.org/doc/man/dialyzer.html][Dialyzer]] Diagnostics
+- [[https://github.com/inaka/elvis][Elvis]] Diagnostics
+- [[http://erlang.org/doc/apps/edoc/chapter.html][Edoc]]
+- Navigation for Included Files
+- Find/Peek References
+- Outline
+- Workspace Symbols
+- Code Folding
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =erlang= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** Choosing a backend
+=company-erlang= uses gtags to provide a very basic working environment, it is
+the default backend.
+
+You can improve the IDE-like experience by choosing the =lsp= backend, to do so,
+first add the =lsp= layer to =dotspacemacs-configuration-layers=, then, set the
+layer variable =erlang-backend=:
+
+#+begin_src elisp
+  (erlang :variables erlang-backend 'lsp)
+#+end_src
+
+Alternatively the =lsp= backend will be automatically chosen if the layer =lsp=
+is used and you did not specify any value for =erlang-backend=.
+
+* Configuration
+** erlang-mode
+To find the manual page for the function under the cursor you can either set
+=erlang-man-root-dir= to erlang man root directory path in the layer definition:
+
+#+BEGIN_SRC elisp
+(erlang :variables erlang-man-root-dir "*path_to_folder*/otp_22/lib/erlang/man")
+#+END_SRC
+
+or let =erlang-mode= download it by executing ~M-x erlang-man-download-ask~.
+
+** LSP
+The =lsp= backend uses [[https://erlang-ls.github.io/][erlang_ls]] as its language server implementation.
+
+Clone the project to your system and compile it:
+
+#+BEGIN_SRC bash
+  make
+#+END_SRC
+
+*Note:* Ensure you have =erlang_ls= in your =PATH=...
+
+You can install it:
+
+#+BEGIN_SRC bash
+  make install
+#+END_SRC
+
+* Key bindings
+** erlang-mode
+
+| Key binding | Description                                                     |
+|-------------+-----------------------------------------------------------------|
+| ~C-c C-a~   | Align arrows ("->")                                             |
+| ~C-c C-c~   | Comment region                                                  |
+| ~C-c C-d~   | Display function manual at point                                |
+| ~C-c C-j~   | Generate a new clause                                           |
+| ~C-c C-q~   | Indent function                                                 |
+| ~C-c C-u~   | Uncomment region                                                |
+| ~C-c C-y~   | Insert, at the point, the argument list of the previous clause. |
+| ~C-c C-z~   | Display the erlang-shell or start a new                         |
+| ~C-c M-a~   | Move backward to previous start of clause.                      |
+| ~C-c M-e~   | Move to the end of the current clause.                          |
+| ~C-c M-h~   | Put mark at end of clause, point at beginning.                  |
+
+** LSP
+You will find an overview of all the key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp#key-bindings][lsp layer description]].

--- a/layers/+lang/erlang/config.el
+++ b/layers/+lang/erlang/config.el
@@ -12,3 +12,13 @@
 ;; variables
 
 (spacemacs|define-jump-handlers erlang-mode)
+
+(defvar erlang-fill-column 80
+  "Column beyond which automatic line-wrapping should happen.")
+
+;; lsp - erlang_ls
+
+(defvar erlang-backend nil
+  "The backend to use for IDE features.
+Possible values are `lsp' or `company-erlang'.
+If `nil' then `company-erlang' is the default backend unless `lsp' layer is used.")

--- a/layers/+lang/erlang/funcs.el
+++ b/layers/+lang/erlang/funcs.el
@@ -1,0 +1,46 @@
+;;; funcs.el --- Erlang Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Carlos F. Clavijo <arkan1313@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//erlang-backend ()
+  "Returns selected backend."
+  (if erlang-backend
+      erlang-backend
+    (cond
+     ((configuration-layer/layer-used-p 'lsp) 'lsp)
+     (t 'company-erlang))))
+
+(defun spacemacs//erlang-setup-backend ()
+  "Conditionally setup erlang backend."
+  (pcase (spacemacs//erlang-backend)
+    (`lsp (spacemacs//erlang-setup-lsp)))
+  )
+
+(defun spacemacs//erlang-setup-company ()
+  "Conditionally setup company based on backend."
+  (pcase (spacemacs//erlang-backend)
+    ;; Activate lsp company explicitly to activate
+    ;; standard backends as well
+    (`lsp (spacemacs|add-company-backends
+            :backends company-capf
+            :modes erlang-mode
+            :append-hooks t))))
+
+(defun spacemacs//erlang-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//erlang-default ()
+  "Default settings for erlang buffers"
+
+  ;; Use a custom fill-column for erlang buffers
+  (set-fill-column erlang-fill-column))

--- a/layers/+lang/erlang/layers.el
+++ b/layers/+lang/erlang/layers.el
@@ -1,0 +1,14 @@
+;;; layers.el --- Erlang Layer declarations File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Carlos F. Clavijo <arkan1313@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'erlang-backend)
+           (eq erlang-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -20,7 +20,8 @@
         ))
 
 (defun erlang/post-init-company ()
-  (add-hook 'erlang-mode-hook 'company-mode))
+  ;; backend specific
+  (spacemacs//erlang-setup-company))
 
 (defun erlang/init-erlang ()
   (use-package erlang
@@ -29,7 +30,10 @@
     (progn
       ;; explicitly run prog-mode hooks since erlang mode does is not
       ;; derived from prog-mode major-mode
-      (add-hook 'erlang-mode-hook 'spacemacs/run-prog-mode-hooks)
+      (spacemacs/add-to-hook 'erlang-mode-hook
+                             '(spacemacs/run-prog-mode-hooks
+                               spacemacs//erlang-setup-backend
+                               spacemacs//erlang-default))
       ;; (setq erlang-root-dir "/usr/lib/erlang/erts-5.10.3")
       ;; (add-to-list 'exec-path "/usr/lib/erlang/erts-5.10.3/bin")
       ;; (setq erlang-man-root-dir "/usr/lib/erlang/erts-5.10.3/man")
@@ -40,8 +44,7 @@
       ;;             (setq inferior-erlang-machine-options '("-sname" "syl20bnr"))
       ;;             ))
       (setq erlang-compile-extra-opts '(debug_info)))
-    :config
-    (require 'erlang-start)))
+    :config (require 'erlang-start)))
 
 (defun erlang/post-init-flycheck ()
   (spacemacs/enable-flycheck 'erlang-mode))


### PR DESCRIPTION
Basic changes to add LSP support for erlang layer using [erlang_ls](https://erlang-ls.github.io/) backend.
Supported [features](https://erlang-ls.github.io/features/) 
Example of my `dotspacemacs-configuration-layers`
```
(erlang :variables
             erlang-backend 'lsp
             erlang-root-dir "/home/carlosrendon/.otp_builds/otp_22_kred/lib/erlang"
             erlang-man-root-dir "/home/carlosrendon/.otp_builds/otp_22_kred/lib/erlang/man"
             erlang-ls-path "/home/carlosrendon/.erlang_ls/_build/default/bin/"
             erlang-fill-column 100
             company-minimum-prefix-length 1
             lsp-ui-doc-position 'bottom
             projectile-enable-caching t)
```

Thank you <3