### PR TITLE
Set evil-undo-system to undo-tree

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1361,6 +1361,7 @@ Other:
   - Fixed ~SPC h f~ =helm-spacemacs-help-faq= (thanks to duianto)
   - Fixed =cl= package deprecated =letf= (thanks to duianto)
   - Fixed origami bindings in normal mode (thanks to Tomasz Kowal)
+  - Set =evil-undo-system= to =undo-tree= (thanks to duianto)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -67,6 +67,8 @@
   (require 'evil)
   (evil-mode 1)
 
+  (evil-set-undo-system 'undo-tree)
+
   ;; Use evil as a default jump handler
   (add-to-list 'spacemacs-default-jump-handlers 'evil-goto-definition)
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -416,13 +416,16 @@
 (defun spacemacs-editing/init-undo-tree ()
   (use-package undo-tree
     :defer t
-    :init (setq undo-tree-visualizer-timestamps t
-                undo-tree-visualizer-diff t
-                ;; 10X bump of the undo limits to avoid issues with premature
-                ;; Emacs GC which truncages the undo history very aggresively
-                undo-limit 800000
-                undo-strong-limit 12000000
-                undo-outer-limit 120000000)
+    :init
+    (progn
+      (setq undo-tree-visualizer-timestamps t
+            undo-tree-visualizer-diff t
+            ;; 10X bump of the undo limits to avoid issues with premature
+            ;; Emacs GC which truncages the undo history very aggresively
+            undo-limit 800000
+            undo-strong-limit 12000000
+            undo-outer-limit 120000000)
+      (global-undo-tree-mode))
     :config
     (progn
       ;; restore diff window after quit.  TODO fix upstream


### PR DESCRIPTION
https://github.com/emacs-evil/evil made `undo-tree` optional:
Make undo-tree an optional dependency https://github.com/emacs-evil/evil/pull/1360

Issue:
This doesn't work in the `spacemacs-base` distribution:
>evil-undo: Symbol’s function definition is void: undo-tree-undo
evil-redo: Symbol’s function definition is void: undo-tree-redo

Because `undo-tree` is loaded in the `spacemacs-editing` layer,
but it isn't used by default in `spacemacs-base`.

The variable `configuration-layer--used-layers` only lists these spacemacs layers:
```
spacemacs-bootstrap
spacemacs-defaults
spacemacs-base
spacemacs-org
```