### PR TITLE
Fix fsharp-mode autocomplete not working

### DIFF
--- a/layers/+lang/fsharp/README.org
+++ b/layers/+lang/fsharp/README.org
@@ -28,11 +28,12 @@ file.
 
 * Key bindings
 
-| Key binding | Description                |
-|-------------+----------------------------|
-| ~SPC m c c~ | Build the project          |
-| ~SPC m g g~ | Go to definition at point  |
-| ~SPC m h t~ | Show tooltip help at point |
+| Key binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC m c c~ | Build the project             |
+| ~SPC m g g~ | Go to definition at point     |
+| ~SPC m h t~ | Show tooltip help at point    |
+| ~SPC m e E~ | Start Eglot (Language Server) |
 
 ** REPL
 

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -22,6 +22,7 @@
     :defer t
     :init
     (progn
+      (require 'eglot-fsharp)
       (setq fsharp-doc-idle-delay .2)
       (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#"))
     :config
@@ -51,6 +52,11 @@
         (switch-to-buffer-other-window inferior-fsharp-buffer-name)
         (evil-insert-state))
 
+      (defun spacemacs/fsharp-eglot-jack-in ()
+        "Start a new Eglot server instance or reconnect."
+        (interactive)
+        (call-interactively 'eglot))
+
       (spacemacs/declare-prefix-for-mode 'fsharp-mode "mf" "find")
       (spacemacs/declare-prefix-for-mode 'fsharp-mode "ms" "interpreter")
       (spacemacs/declare-prefix-for-mode 'fsharp-mode "mx" "executable")
@@ -61,6 +67,8 @@
       (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
         ;; Compile
         "cc" 'compile
+
+        "ej" 'spacemacs/fsharp-eglot-jack-in
 
         "fa" 'fsharp-find-alternate-file
 


### PR DESCRIPTION
Fsharp-mode has recently undergone some major changes. FSAutocomplete is
no longer distributed with Fsharp-mode. Instead Eglot is used as a language
server that pulls in FSAutocomplete. To get auto-completion working
again eglot-fsharp has to be required and an instance of Eglot has to be
started once an F# file is opened.

I'm not quite sure if it would be better if Eglot would start automatically when fsharp-mode is activated?!
But as it is it works for now.