### PR TITLE
Set start directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ the [full installation instructions](#install) for other options.
     - [Default installation](#default-installation)
     - [Alternative installations](#alternative-installations)
         - [Modify HOME environment variable](#modify-home-environment-variable)
-        - [Modify spacemacs-start-directory variable](#modify-spacemacs-start-directory-variable)
     - [Spacemacs logo](#spacemacs-logo)
 - [Update](#update)
     - [Automatic update (on master branch)](#automatic-update-on-master-branch)
@@ -387,16 +386,6 @@ HOME=~/spacemacs emacs
 
 Note: If you're using the Fish shell, then you'll need to modify the last
 command to: `env HOME=$HOME/spacemacs emacs`
-
-### Modify spacemacs-start-directory variable
-This solution is better suited to "embed" Spacemacs into your own configuration.
-If you've cloned Spacemacs into `~/.emacs.d/spacemacs/`, then drop the following
-lines in the `~/.emacs.d/init.el` file:
-
-```elisp
-(setq spacemacs-start-directory "~/.emacs.d/spacemacs/")
-(load-file (concat spacemacs-start-directory "init.el"))
-```
 
 ## Spacemacs logo
 For Ubuntu users, follow this guide to

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -18,7 +18,7 @@
 ;; paths
 (defvar spacemacs-start-directory
   user-emacs-directory
-  "Spacemacs start directory.")
+  "Spacemacs start directory.  This is set within `init.el'.")
 (defconst spacemacs-core-directory
   (expand-file-name (concat spacemacs-start-directory "core/"))
   "Spacemacs core directory.")

--- a/dump-init.el
+++ b/dump-init.el
@@ -1,7 +1,6 @@
 (setq spacemacs-dump-mode 'dumping)
 ;; load init.el
-(setq spacemacs-start-directory (file-name-directory load-file-name))
-(load (concat spacemacs-start-directory "init.el"))
+(load (concat (file-name-directory load-file-name) "init.el"))
 ;; prepare the dump
 (spacemacs/dump-save-load-path)
 ;; disable undo-tree to prevent from segfaulting when loading the dump

--- a/init.el
+++ b/init.el
@@ -16,6 +16,7 @@
 ;; see `SPC h . dotspacemacs-gc-cons' for more info
 (defconst emacs-start-time (current-time))
 (setq gc-cons-threshold 402653184 gc-cons-percentage 0.6)
+(setq spacemacs-start-directory (file-name-directory load-file-name))
 (load (concat (file-name-directory load-file-name)
               "core/core-versions.el")
       nil (not init-file-debug))


### PR DESCRIPTION
`spacemacs-start-directory` has to be set to only one value, so why not set it within `init.el`?

If spacemacs is "embedded" so that spacemacs is not the same as `user-emacs-directory`, then the user can simply load spacemacs' `init.el` file directly without having to set `spacemacs-start-directory` first, e.g.,
```elisp
(load "path/to/spacemacs/init.el")
```
This is exactly what is done within `dump-init.el`.
