### PR TITLE
Fix counsel find-file functions to use Spacemacs large file check

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2349,6 +2349,8 @@ Other:
 - Fix visual selection expansion across the buffer on `SPC s S` and `SPC s B`
   (thanks to Andriy Kmit)
 - Fixed =cl= package deprecated =letf*= (thanks to duianto)
+- Fixed counsel find-file functions to use Spacemacs check for opening large
+files (thanks to Daniel Nicolai)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -12,7 +12,7 @@
 
 ;; Counsel
 
-;; async
+;;; async
 
 (defvar spacemacs--counsel-initial-cands-shown nil)
 
@@ -61,7 +61,42 @@
           (ivy--insert-prompt))))
     (setq counsel--async-time (current-time))))
 
-;; search
+;;; find-file functions, leaving large file check to `spacemacs/check-large-file'
+
+(defun spacemacs//counsel-find-file-action (x)
+  "Find file X."
+  (with-ivy-window
+    (cond ((and counsel-find-file-speedup-remote
+                (file-remote-p ivy--directory))
+           (let ((find-file-hook nil))
+             (find-file (expand-file-name x ivy--directory))))
+          ((member (file-name-extension x) counsel-find-file-extern-extensions)
+           (counsel-find-file-extern x))
+          (t
+           (switch-to-buffer (find-file-noselect (expand-file-name x ivy--directory) t nil t))))))
+
+(defun spacemacs/counsel-find-file (&optional initial-input)
+  "Forward to `find-file'.
+When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
+  (interactive)
+  (counsel--find-file-1
+   "Find file: " initial-input
+   #'spacemacs//counsel-find-file-action
+   'counsel-find-file))
+
+(defun spacemacs/counsel-recentf ()
+  "Find a file on `recentf-list'."
+  (interactive)
+  (require 'recentf)
+  (recentf-mode)
+  (ivy-read "Recentf: " (counsel-recentf-candidates)
+            :action (lambda (f)
+                      (with-ivy-window
+                        (switch-to-buffer (find-file-noselect f t nil t))))
+            :require-match t
+            :caller 'counsel-recentf))
+
+;;; search
 
 (defvar spacemacs--counsel-search-cmd)
 
@@ -193,7 +228,7 @@ that directory."
                       (counsel-delete-process)
                       (swiper--cleanup)))))))
 
-;; Define search functions for each tool
+;;; Define search functions for each tool
 (cl-loop
  for (tools tool-name) in '((dotspacemacs-search-tools "auto")
                             ((list "rg") "rg")
@@ -327,7 +362,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
           (swiper--cleanup)
           (swiper--add-overlays (ivy--regex ivy-text)))))))
 
-;; org
+;;; org
 
 ;; see https://github.com/abo-abo/swiper/issues/177
 (defun spacemacs//counsel-org-ctrl-c-ctrl-c-org-tag ()
@@ -373,7 +408,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
     (t 'counsel-imenu))))
 
 
-;; Ivy
+;;; Ivy
 
 (defun spacemacs//ivy-command-not-implemented-yet (key)
   (let ((-key key))
@@ -399,7 +434,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
   (ivy-wgrep-change-to-wgrep-mode)
   (evil-normal-state))
 
-;; Evil
+;;; Evil
 
 (defun spacemacs/ivy-evil-registers ()
   "Show evil registers"
@@ -418,7 +453,7 @@ To prevent this error we just wrap `describe-mode' to defeat the
   (insert (replace-regexp-in-string "\\^J" "\n"
                                     (substring-no-properties candidate 4))))
 
-;; Layouts
+;;; Layouts
 
 (defun spacemacs/ivy-spacemacs-layouts ()
   "Control Panel for Spacemacs layouts. Has many actions.

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -58,7 +58,7 @@
       (spacemacs/set-leader-keys
         dotspacemacs-emacs-command-key 'counsel-M-x
         ;; files
-        "ff"  'counsel-find-file
+        "ff"  'spacemacs/counsel-find-file
         "fel" 'counsel-find-library
         "fL"  'counsel-locate
         ;; help
@@ -206,7 +206,7 @@
         "Ce" 'counsel-colors-emacs
         "Cf" 'counsel-faces
         "Cw" 'counsel-colors-web
-        "fr" 'counsel-recentf
+        "fr" 'spacemacs/counsel-recentf
         "rl" 'ivy-resume
         "sl" 'ivy-resume
         "bb" 'ivy-switch-buffer)


### PR DESCRIPTION
By default Ivy uses `find-file` which uses Emacs `abort-if-file-too-large`
function to check/warn before opening large files. That function however does
not take into account Spacemacs its `spacemacs-large-file-modes-list`. Instead
ivy should use `find-file-noselect` to skip Emacs it large file warning and let
it to Spacemacs its `spacemacs/check-large-file` function. Additionally [Emacs
tips on
comments](https://www.gnu.org/software/emacs/manual/html_node/elisp/Comment-Tips.html)
recommends to use 3 semicolons for comments that function as headings.