### PR TITLE
[ivy] Rebind C-k to C-M-k in ivy-reverse-i-search

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2293,6 +2293,8 @@ Other:
     =swiper-all-thing-at-point=
     (last two points thanks to Daniel Nicolai)
   - Bound =SPC s l= to =ivy-resume= (thanks to Wieland Hoffmann)
+  - Rebind =C-k= to =C-M-k= in =ivy-reverse-i-search= (=C-r= at a prompt)
+    (thanks to duianto)
 - Removed definitions for =spacemacs/swiper-region-or-symbol= and
   =spacemacs/swiper-all-region-or-symbol= and updated keybindings, because Ivy has
   more advanced implementation via =swiper-thing-at-point= and

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -89,6 +89,7 @@ Some useful key bindings are presented in the following table.
 | ~C-'~       | use avy to quickly select completion on current page (sometimes faster than using arrows)                                                           |
 | ~<ESC>~     | close minibuffer                                                                                                                                    |
 | ~C-M-k~     | kill buffer (in =ivy-switch-buffer= (~SPC b b~))                                                                                                    |
+| ~C-M-k~     | kill buffer (in =ivy-reverse-i-search= (~C-r~ at a prompt))                                                                                         |
 
 ** Transient state
 Press ~M-SPC~ (~m-M-SPC~ [[https://github.com/syl20bnr/spacemacs/blob/cb48ec74c1f401bd2945760799633c0e81e69088/doc/CONVENTIONS.org#transient-state][on macOS]]) anytime in Ivy to get into the transient state. Additional actions

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -211,8 +211,9 @@
         "sl" 'ivy-resume
         "bb" 'ivy-switch-buffer)
       ;; Moved C-k to C-M-k
-      (define-key ivy-switch-buffer-map (kbd "C-M-k") 'ivy-switch-buffer-kill))
-
+      (define-key ivy-switch-buffer-map (kbd "C-M-k") 'ivy-switch-buffer-kill)
+      (define-key ivy-reverse-i-search-map
+        (kbd "C-M-k") 'ivy-reverse-i-search-kill))
     :config
     (progn
       ;; custom actions for recentf

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -203,7 +203,8 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
         (and (eq 'hybrid style)
              hybrid-style-enable-hjkl-bindings))
     (dolist (map (list ivy-minibuffer-map
-                       ivy-switch-buffer-map))
+                       ivy-switch-buffer-map
+                       ivy-reverse-i-search-map))
       (define-key map (kbd "C-j") 'ivy-next-line)
       (define-key map (kbd "C-k") 'ivy-previous-line))
     (define-key ivy-minibuffer-map (kbd "C-h") (kbd "DEL"))


### PR DESCRIPTION
This enables navigating up in the `ivy-reverse-i-search` list with `C-k`.

The same rebinding from `C-k` to `C-M-k` to kill a list entry,
is also done in the `ivy-switch-buffer`.