### PR TITLE
Only set undo system if fun. exists.

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -67,7 +67,8 @@
   (require 'evil)
   (evil-mode 1)
 
-  (evil-set-undo-system 'undo-tree)
+  (when (fboundp 'evil-set-undo-system)
+    (evil-set-undo-system 'undo-tree))
 
   ;; Use evil as a default jump handler
   (add-to-list 'spacemacs-default-jump-handlers 'evil-goto-definition)


### PR DESCRIPTION
The PR fixes an issue where spacemacs is in a bad state after upgrading. I suppose what happens is that `evil-set-undo-system` is invoked before `evil` has been upgraded.