### PR TITLE
[layers/+tools/languagetool] Allow HTTP server instead of binary

### DIFF
--- a/layers/+tools/languagetool/README.org
+++ b/layers/+tools/languagetool/README.org
@@ -47,8 +47,8 @@ LanguageTool and JRE 8+ are required to use this layer. You can install
 LanguageTool using your system's package manager or by extracting the standalone
 archive found on [[https://www.languagetool.org/][LanguageTool's website]]. You can tell the layer where
 LanguageTool is installed by setting the =langtool-language-tool-jar= variable
-to the location of =languagetool-commandline.jar= or by setting
-=langtool-java-classpath=:
+to the location of =languagetool-commandline.jar=, by setting
+=langtool-java-classpath=, or setting a host and port for a running server:
 
 #+BEGIN_SRC elisp
   ;; Standalone installation
@@ -60,6 +60,12 @@ to the location of =languagetool-commandline.jar= or by setting
   (setq-default dotspacemacs-configuration-layers
                 '((languagetool :variables
                                 langtool-java-classpath "/usr/share/languagetool:/usr/share/java/languagetool/*")))
+
+  ;; Server running in background
+  (setq-default dotspacemacs-configuration-layers
+                '((languagetool :variables
+                                langtool-http-server-host "localhost"
+                                langtool-http-server-port 8081)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+tools/languagetool/funcs.el
+++ b/layers/+tools/languagetool/funcs.el
@@ -43,6 +43,8 @@
 (defun spacemacs//languagetool-detect ()
   "Detects whether the LanguageTool binary exists."
   (cond ((boundp 'langtool-java-classpath) t)
+        ((and (boundp 'langtool-http-server-host)
+              (boundp 'langtool-http-server-port)) t)
         ((boundp 'langtool-language-tool-jar)
          (if (file-readable-p langtool-language-tool-jar)
              t


### PR DESCRIPTION
The `langtool` package can also work against a running server instead of a LanguageTool binary/classpath. Accordingly, the `spacemacs//languagetool-detect` function should check whether the server variables are set. I added a check and a description in the `README.md`.