### PR TITLE
Bind typescript-format to "==" or "=" depending on backend

### DIFF
--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -168,22 +168,22 @@ then set the variable =typescript-lsp-linter= to =nil=.
 * Key bindings
 ** Typescript Major Mode
 
-| Key binding | Description                                                  |
-|-------------+--------------------------------------------------------------|
-| ~SPC m =~   | reformat the buffer                                          |
-| ~SPC m E d~ | add =tslint:disable-next-line= at point                      |
-| ~SPC m E e~ | fix thing at point                                           |
-| ~SPC m g b~ | jump back                                                    |
-| ~SPC m g g~ | jump to entity's definition                                  |
-| ~SPC m g t~ | jump to entity's type definition                             |
-| ~SPC m g r~ | references                                                   |
-| ~SPC m h h~ | documentation at point                                       |
-| ~SPC m p~   | send selected region or current buffer to the web playground |
-| ~SPC m r i~ | organize imports                                             |
-| ~SPC m r r~ | rename symbol                                                |
-| ~SPC m r f~ | rename file                                                  |
-| ~SPC m S r~ | restart server                                               |
-| ~SPC m S j~ | create a barebone =jsconfig.json= at project root            |
+| Key binding                                   | Description                                                  |
+|-----------------------------------------------+--------------------------------------------------------------|
+| ~SPC m =~ or ~SPC m = =~ if using lsp backend | reformat the buffer                                          |
+|                                               | add =tslint:disable-next-line= at point                      |
+| ~SPC m E e~                                   | fix thing at point                                           |
+| ~SPC m g b~                                   | jump back                                                    |
+| ~SPC m g g~                                   | jump to entity's definition                                  |
+| ~SPC m g t~                                   | jump to entity's type definition                             |
+| ~SPC m g r~                                   | references                                                   |
+| ~SPC m h h~                                   | documentation at point                                       |
+| ~SPC m p~                                     | send selected region or current buffer to the web playground |
+| ~SPC m r i~                                   | organize imports                                             |
+| ~SPC m r r~                                   | rename symbol                                                |
+| ~SPC m r f~                                   | rename file                                                  |
+| ~SPC m S r~                                   | restart server                                               |
+| ~SPC m S j~                                   | create a barebone =jsconfig.json= at project root            |
 
 ** Reference Major Mode
 

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -171,7 +171,7 @@ then set the variable =typescript-lsp-linter= to =nil=.
 | Key binding                                   | Description                                                  |
 |-----------------------------------------------+--------------------------------------------------------------|
 | ~SPC m =~ or ~SPC m = =~ if using lsp backend | reformat the buffer                                          |
-|                                               | add =tslint:disable-next-line= at point                      |
+| ~SPC m E d~                                   | add =tslint:disable-next-line= at point                      |
 | ~SPC m E e~                                   | fix thing at point                                           |
 | ~SPC m g b~                                   | jump back                                                    |
 | ~SPC m g g~                                   | jump to entity's definition                                  |

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -104,7 +104,7 @@
     (add-hook 'typescript-tsx-mode-hook 'spacemacs/typescript-fmt-before-save-hook))
   (spacemacs/set-leader-keys-for-major-mode 'typescript-tsx-mode
     "p" 'spacemacs/typescript-open-region-in-playground)
-  (pcase typescript-backend
+  (pcase (spacemacs//typescript-backend)
     ('lsp (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
             "==" 'spacemacs/typescript-format))
     (_ (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
@@ -128,7 +128,7 @@
           (add-hook 'typescript-mode-hook 'spacemacs/typescript-fmt-before-save-hook))
         (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
           "p" 'spacemacs/typescript-open-region-in-playground)
-        (pcase typescript-backend
+        (pcase (spacemacs//typescript-backend)
           ('lsp (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
                   "==" 'spacemacs/typescript-format))
           (_ (spacemacs/set-leader-keys-for-major-mode 'typescript-mode

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -103,8 +103,12 @@
   (when typescript-fmt-on-save
     (add-hook 'typescript-tsx-mode-hook 'spacemacs/typescript-fmt-before-save-hook))
   (spacemacs/set-leader-keys-for-major-mode 'typescript-tsx-mode
-    "="  'spacemacs/typescript-format
-    "p" 'spacemacs/typescript-open-region-in-playground))
+    "p" 'spacemacs/typescript-open-region-in-playground)
+  (pcase typescript-backend
+    ('lsp (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
+            "==" 'spacemacs/typescript-format))
+    (_ (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
+         "=" 'spacemacs/typescript-format))))
 
 (defun typescript/post-init-yasnippet ()
   (spacemacs/add-to-hooks #'spacemacs/typescript-yasnippet-setup '(typescript-mode-hook
@@ -123,8 +127,12 @@
         (when typescript-fmt-on-save
           (add-hook 'typescript-mode-hook 'spacemacs/typescript-fmt-before-save-hook))
         (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
-          "="  'spacemacs/typescript-format
-          "p" 'spacemacs/typescript-open-region-in-playground)))))
+          "p" 'spacemacs/typescript-open-region-in-playground)
+        (pcase typescript-backend
+          ('lsp (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
+                  "==" 'spacemacs/typescript-format))
+          (_ (spacemacs/set-leader-keys-for-major-mode 'typescript-mode
+               "=" 'spacemacs/typescript-format)))))))
 
 (defun typescript/pre-init-import-js ()
   (if (eq javascript-import-tool 'import-js)


### PR DESCRIPTION
This fixes a problem when using 'lsp backend: the lsp layer binds its own
formatting functions under "=" as a prefix. The spacemacs/typescript-format
function which the typescript layer defines has advantages over these, mainly
it respects the typescript-fmt-tool variable (uses the formatting tool that
theuser specified).

This patch solves this by keybinding leader+"==" to the function when
typescript-backend is set to 'lsp and binding to leader+"=" in any other case.

fixes #13719
N.B. the considerations at the end of that thread

- [ ] If this PR is accepted, I would like to kindly ask you to label this PR with the `hacktoberfest-accepted` label 
(see https://hacktoberfest.digitalocean.com/hacktoberfest-update)
- [x] And my other PR as well :) #14017