### PR TITLE
remove "SPC d" binding

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -30,7 +30,6 @@
                                        ("aw"  "web-services")
                                        ("c"   "compile/comments")
                                        ("C"   "capture/colors")
-                                       ("d"   "documentation")
                                        ("e"   "errors")
                                        ("g"   "git/versions-control")
                                        ("h"   "help")


### PR DESCRIPTION
"SPC d" was used for documentation related keybindings, such as in `dash`
layer.
But it's now used for `dap` layer exclusively.
Removing this won't cause any issue as `dap` layer would correctly set
the keybindings once it's loaded.