### PR TITLE
Add keybinding for lsp-version command

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -228,6 +228,7 @@ The lsp minor mode bindings are:
 | ~SPC m b s~ | ~lsp-workspace-shutdown~                                                         |
 | ~SPC m b r~ | ~lsp-workspace-restart~                                                          |
 | ~SPC m b d~ | ~lsp-describe-session~                                                           |
+| ~SPC m b v~ | ~lsp-version~                                                                    |
 |-------------+----------------------------------------------------------------------------------|
 | ~SPC m r r~ | rename                                                                           |
 |-------------+----------------------------------------------------------------------------------|

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -57,6 +57,7 @@
     "bd" #'lsp-describe-session
     "br" #'lsp-workspace-restart
     "bs" #'lsp-workspace-shutdown
+    "bv" #'lsp-version
     ;; refactor
     "rr" #'lsp-rename
     ;; toggles


### PR DESCRIPTION
Adds a keybinding for new lsp-version function (https://github.com/emacs-lsp/lsp-mode/pull/2267)

Please add the `hacktoberfest-accepted` label when you're done :3