### PR TITLE
Fix three typos in various files

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -60,7 +60,7 @@ To understand how to best implement a layer, we have to investigate how Emacs
 loads code.
 
 ** Emacs Lisp files
-Emacs Lisp files contains code that can be evaluated. When evaluated, the
+Emacs Lisp files contain code that can be evaluated. When evaluated, the
 functions, macros and modes defined in that file become available to the current
 Emacs session. Henceforth, this will be termed as /loading/ a file.
 

--- a/layers/+distributions/spacemacs-bootstrap/README.org
+++ b/layers/+distributions/spacemacs-bootstrap/README.org
@@ -10,7 +10,7 @@
 This layer loads the necessary packages for spacemacs to start-up.
 
 ** Features:
-- Loads =evil= key bindings and macros for auto-evilifcation of maps
+- Loads =evil= key bindings and macros for auto-evilification of maps
 - Loads =holy= and =hybrid= modes
 - Loads the official Spacemacs theme
 - Loads =use-package= which is used to load other packages more easily

--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -78,7 +78,7 @@ It integrates with =company= and =flycheck=. In addition it also provides
 full graphical debugging support via =DAP mode=.
 
 LSP is the default backend used by this layer, see [[#choosing-a-backend][Choosing a backend]] in
-order to lean how to select a different backend.
+order to learn how to select a different backend.
 
 *** Installation
 The lsp server will be installed automatically whenever a Java file


### PR DESCRIPTION
This commit fixes typos in doc/layers.org and the readme.org files of bootstrap and
java layers.

yes, this is a typo fix PR, please apply the `hacktoberfest-accepted` label here if you want to be so kind, I still need two PRs :)