### PR TITLE
[ocaml] Add ocamlformat package and configure format-on-save

### DIFF
--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -11,6 +11,7 @@
   - [[#layer][Layer]]
   - [[#using-merlin-for-error-reporting][Using merlin for error reporting]]
   - [[#opam-packages][OPAM packages]]
+  - [[#enabling-formatting-on-save][Enabling formatting on save]]
 - [[#key-bindings][Key bindings]]
   - [[#repl-utop][REPL (utop)]]
   - [[#dune][Dune]]
@@ -25,6 +26,7 @@ This is a very basic layer for editing ocaml files.
 - auto-completion with company mode via [[https://github.com/ocaml/merlin][merlin]]
 - syntax-checking via [[https://github.com/flycheck/flycheck-ocaml][flycheck-ocaml]] (or alternatively [[https://github.com/ocaml/merlin][merlin]])
 - =dune= file syntax highlighting and template insertion via [[https://github.com/ocaml/dune/][dune-mode]]
+- Automatic formatting via [[https://github.com/ocaml-ppx/ocamlformat][ocamlformat]]
 
 * Install
 ** Layer
@@ -47,11 +49,12 @@ This layer requires some [[http://opam.ocaml.org][opam]] packages:
 - =merlin= for auto-completion
 - =utop=
 - =ocp-indent=
+- =ocamlformat= for auto-formatting
 
 To install them, use the following command:
 
 #+BEGIN_SRC sh
-  opam install merlin utop ocp-indent
+  opam install merlin utop ocp-indent ocamlformat
 #+END_SRC
 
 Make sure opam is initialized and configured.
@@ -59,6 +62,14 @@ Make sure opam is initialized and configured.
 #+BEGIN_SRC sh
   opam init
   opam config setup -a
+#+END_SRC
+
+** Enabling formatting on save
+To enable automatic formatting on save with [[https://github.com/ocaml-ppx/ocamlformat][ocamlformat]], set the layer
+variable =ocaml-format-on-save=, e.g.,
+
+#+BEGIN_SRC emacs-lisp
+  (ocaml :variables ocaml-format-on-save t)
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/ocaml/config.el
+++ b/layers/+lang/ocaml/config.el
@@ -12,3 +12,6 @@
 ;; variables
 
 (spacemacs|define-jump-handlers tuareg-mode)
+
+(defvar ocaml-format-before-save nil
+  "If non-nil, ocamlformat before saving.")

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -21,6 +21,7 @@
     imenu
     merlin
     merlin-eldoc
+    ocamlformat
     ocp-indent
     smartparens
     tuareg
@@ -128,6 +129,13 @@
   (use-package merlin-eldoc
     :defer t
     :hook (merlin-mode . merlin-eldoc-setup)))
+
+(defun ocaml/init-ocamlformat ()
+  (use-package ocamlformat
+    :defer t
+    :init
+    (when ocaml-format-before-save
+      (add-hook 'before-save-hook 'ocamlformat-before-save))))
 
 (defun ocaml/init-ocp-indent ()
   (use-package ocp-indent


### PR DESCRIPTION
This change adds support for automatically formatting OCaml code on save, using the [`ocamlformat`](https://github.com/ocaml-ppx/ocamlformat) tool.  I left it disabled by default, since ocamlformat isn't as universally adopted as, say, gofmt.