### PR TITLE
Add meghanada, eln-cache and vimish-fold to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ tags
 .tags
 !tags/
 gtags.files
+eln-cache/
+meghanada/
+vimish-fold/


### PR DESCRIPTION
* meghanada is an LSP client for Java
* eln-cache (gccemacs) is for the native-comp branch of Emacs 28.0
* vimish-fold is there because said package has persistent folds