### PR TITLE
[org] SPC m s N -> SPC m s w to match mnemonics of SPC n w

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2809,6 +2809,8 @@ files (thanks to Daniel Nicolai)
   - Key binding changes for archiving (thanks to Ag Ibragimov):
     - Added ~SPC m s a~ to toggle archive tag for subtree
     - Added ~SPC m s A~ to archive subtree (previously ~SPC m s a~)
+  - Change key binding for widening from Org menu from ~SPC m s N~ to ~SPC m s w~
+    to match mnemonics of regular binding ~SPC n w~ (thanks to Keith Pinson)
   - Added ~SPC m i L~ as =org-cliplink= into =org= layer (thanks to bb2020)
   - Added ~SPC m e s~ =org-mime-org-subtree-htmlize= (thanks to Nick Anderson)
   - Documented more insertion bindings (thanks to Lorenzo Manacorda):

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -528,7 +528,7 @@ are also available.
 | ~SPC m s k~   | org-move-subtree-up             |
 | ~SPC m s j~   | org-move-subtree-down           |
 | ~SPC m s n~   | org-narrow-to-subtree           |
-| ~SPC m s N~   | widen narrowed subtree          |
+| ~SPC m s w~   | widen narrowed subtree          |
 | ~SPC m s r~   | org-refile                      |
 | ~SPC m s s~   | show sparse tree                |
 | ~SPC m s S~   | sort trees                      |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -261,7 +261,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "sk" 'org-move-subtree-up
         "sl" 'org-demote-subtree
         "sn" 'org-narrow-to-subtree
-        "sN" 'widen
+        "sw" 'widen
         "sr" 'org-refile
         "ss" 'org-sparse-tree
         "sS" 'org-sort


### PR DESCRIPTION
I chose to go this way rather than the other way because:

* Whenever you can avoid holding down a modifier key, great!
* It seems like the more specific should yield to the more general

This may be a controversial change, because it could break some folks' finger
memory. However I consider this a very unpleasant inconsistency that inhibits
the development of finger memory, so I thought I would at least suggest it as
the default for Spacemacs.