### PR TITLE
Modify documentation to reflect that Emacs server is off by default

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -210,7 +210,6 @@
 - [[#emacs-server][Emacs Server]]
   - [[#connecting-to-the-emacs-server][Connecting to the Emacs server]]
   - [[#keeping-the-server-alive][Keeping the server alive]]
-  - [[#disabling-the-emacs-server][Disabling the Emacs server]]
 - [[#troubleshoot][Troubleshoot]]
   - [[#loading-fails][Loading fails]]
   - [[#upgradingdowngrading-emacs-version][Upgrading/Downgrading Emacs version]]
@@ -3634,8 +3633,13 @@ To customize your editorconfig experience, read [[https://github.com/editorconfi
 documentation]].
 
 * Emacs Server
-Spacemacs starts a server at launch. This server is killed whenever you close
-your Emacs windows.
+Spacemacs provides the ability to start a server at launch, and to kill that
+server whenever you close your Emacs windows. This can be enabled by setting the
+variable =dotspacemacs-enable-server= to =t= in your =~./spacemacs=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-enable-server t)
+#+END_SRC
 
 ** Connecting to the Emacs server
 You can open a file in Emacs from the terminal using =emacsclient=. Use
@@ -3688,14 +3692,6 @@ server is to use the following bindings:
 | ~SPC q f~   | Kill the current frame                                                   |
 | ~SPC q t~   | Restart Emacs and debug with --with-timed-requires                       |
 | ~SPC q T~   | Restart Emacs and debug with --adv-timers                                |
-
-** Disabling the Emacs server
-You can disable the built-in server by setting the variable
-=dotspacemacs-enable-server= to =nil= in your =~/.spacemacs=.
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-enable-server nil)
-#+END_SRC
 
 * Troubleshoot
 ** Loading fails


### PR DESCRIPTION
Pull request #10297 made the Emacs server optional, so that it does
not start up unless the init file is modified to enable it. The
documentation, however, indicates that the opposite is true. This
fix updates the documentation to be consistent with the actual
behavior.

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3