### PR TITLE
Specify configuration layers info pages and add cross links

### DIFF
--- a/.ci/spacedoc-cfg.edn
+++ b/.ci/spacedoc-cfg.edn
@@ -1,4 +1,14 @@
-{:spacetools.spacedoc.config/layers-org-query
+{:spacetools.spacedoc.config/layers-org-title-text "Spacemacs layers list"
+
+ :spacetools.spacedoc.config/layers-org-description
+ "\nTHIS FILE IS AUTO-GENERATED!
+Don't edit it directly. See [[https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org#readmeorg-tags][\"README.org  tags\" section of CONTRIBUTING.org for the instructions]].
+
+This is an overview of Spacemacs configuration layers. For information about
+configuration layer development see [[https://develop.spacemacs.org/doc/LAYERS.html][Configuration layers development]].
+"
+
+ :spacetools.spacedoc.config/layers-org-query
  {"layer" ["chat"
            "checker"
            "completion"

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -1,4 +1,4 @@
-#+TITLE: Configuration layers
+#+TITLE: Configuration layers development
 
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#introduction][Introduction]]
@@ -35,7 +35,8 @@
 This document is intended as a tutorial for users who are interested in writing
 their first configuration layer, whether for private use or for contributing
 upstream. It should help clear up some confusion regarding how layers work and
-how Spacemacs (and Emacs) loads packages.
+how Spacemacs (and Emacs) loads packages. For an overview of configuration
+layers with descriptions see [[https://develop.spacemacs.org/layers/LAYERS.html][Spacemacs layers list]].
 
 * Nomenclature
 Layers and packages. What gives?

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1,7 +1,7 @@
-#+TITLE: Configuration layers
+#+TITLE: Spacemacs layers list
 
 * Table of Contents                     :TOC_5_gh:noexport:
-- [[#this-file-is-auto-generated][THIS FILE IS AUTO GENERATED]]
+- [[#description][Description]]
 - [[#chats][Chats]]
   - [[#erc][ERC]]
   - [[#jabber][Jabber]]
@@ -255,9 +255,13 @@
   - [[#twitter][Twitter]]
   - [[#wakatime][Wakatime]]
 
-* THIS FILE IS AUTO GENERATED
-Don't edit it directly.
-See [[https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org#readmeorg-tags]["README.org tags" section of CONTRIBUTING.org for the instructions]].
+* Description
+
+THIS FILE IS AUTO-GENERATED!
+Don't edit it directly. See [[https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org#readmeorg-tags]["README.org tags" section of CONTRIBUTING.org for the instructions]].
+
+This is an overview of Spacemacs configuration layers. For information about
+configuration layer development see [[https://develop.spacemacs.org/doc/LAYERS.html][Configuration layers development]].
 
 * Chats
 ** ERC
@@ -2511,7 +2515,7 @@ Features:
 This layer loads the necessary packages for spacemacs to start-up.
 
 Features:
-- Loads =evil= key bindings and macros for auto-evilifcation of maps
+- Loads =evil= key bindings and macros for auto-evilification of maps
 - Loads =holy= and =hybrid= modes
 - Loads the official Spacemacs theme
 - Loads =use-package= which is used to load other packages more easily


### PR DESCRIPTION
Searching for information about configuration layers is confusing because both
the overview and development info pages have the same title (try it with
google). Specifying those info pages title names and adding cross links makes
the docs friendlier.

NOTE!!! I have inserted relative links. But I'm afraid they will not work in the website, however I as I can not build the doc pages, I can not test the links. Maybe you could direct me to instructions about how to make 'internal' links (between different pages) in the Spacemacs docs.