### PR TITLE
Add layer scratch into layers/+emacs

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -345,6 +345,7 @@ sane way, here is the complete list of changed key bindings
 - helpful (thanks to Johnson Denen, Andriy Kmit)
 - tabs (thanks to Deepu Mohan Puthrote)
 - verb (thanks to Federico Tedin)
+- scratch (thanks to rayw000)
 **** Email
 - notmuch (thanks to Francesc Elies Henar, Leonard Lausen, Willian Casarin,
   Kalle Lindqvist)

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -297,7 +297,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   ;; --line-number forces line numbers (disabled by default on windows)
   ;; no --vimgrep because it adds column numbers that wgrep can't handle
   ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-  (let ((helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number --max-columns=150"))
+  (let ((helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number --max-columns=150")
+        (helm-ag-success-exit-status '(0 2)))
     (helm-do-ag-buffers)))
 
 (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -302,7 +302,13 @@
 (defun helm/init-helm-ls-git ()
   (use-package helm-ls-git
     :defer t
-    :init (spacemacs/set-leader-keys "gff" 'helm-ls-git-ls)))
+    :init (spacemacs/set-leader-keys "gff" 'helm-ls-git-ls)
+    :config
+    ;; Set `helm-ls-git-status-command' conditonally on `git' layer
+    ;; If `git' is in use, use default `\'magit-status-setup-buffer'
+    ;; Otherwise, use defaault `\'vc-dir'
+    (when (configuration-layer/package-usedp 'magit)
+      (setq helm-ls-git-status-command 'magit-status-setup-buffer))))
 
 (defun helm/init-helm-make ()
   (use-package helm-make

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -251,11 +251,14 @@
       (setq ivy-use-selectable-prompt t))))
 
 (defun ivy/init-ivy-avy ()
-  (use-package ivy-avy))
+  (use-package ivy-avy
+    :after ivy))
 
 (defun ivy/init-ivy-hydra ()
-  (use-package ivy-hydra)
-  (define-key hydra-ivy/keymap [escape] 'hydra-ivy/keyboard-escape-quit-and-exit))
+  (use-package ivy-hydra
+    :after ivy
+    :config
+    (define-key hydra-ivy/keymap [escape] 'hydra-ivy/keyboard-escape-quit-and-exit)))
 
 (defun ivy/init-ivy-rich ()
   (use-package ivy-rich

--- a/layers/+emacs/scratch/README.org
+++ b/layers/+emacs/scratch/README.org
@@ -1,0 +1,55 @@
+#+TITLE: scratch layer
+
+#+TAGS: layer|emacs
+
+* Table of Contents                                        :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+- [[#customizations][Customizations]]
+
+* Description
+This layer makes your =*scratch*= buffer persistent and not killable.
+That makes sense if you want to save your drafts in =*scratch*= buffer temporarily.
+Things you write down in =*scratch*= buffer will be automatically saved and restored.
+
+** Features:
+   - This layer makes your =*scratch*= buffer persistent and not killable.
+
+Packages used by this layer:
+[[https://github.com/Fanael/persistent-scratch][persistent-scratch]], [[https://github.com/EricCrosson/unkillable-scratch][unkillable-scratch]]
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =scratch= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key bindings
+
+| Key Binding | Description                       |
+|-------------+-----------------------------------|
+| C-x C-s     | save =*scratch*= buffer temporarily |
+| C-x C-w     | write =*scratch*= buffer to a file |
+
+See URL: https://github.com/Fanael/persistent-scratch
+
+* Customizations
+You can customize this layer by setting variables of package [[https://github.com/Fanael/persistent-scratch][persistent-scratch]] and [[https://github.com/EricCrosson/unkillable-scratch][unkillable-scratch]].
+
+For example, enable =scratch= layer with these following variables configured in =dotspacemacs-configuration-layers= in your =.spacemacs=.
+
+#+BEGIN_SRC emacs-lisp
+  (defun dotspacemacs/layers()
+    (setq-default
+     dotspacemacs-configuration-layers
+     '(
+       ;; other layers...
+       (scratch :variables
+                persistent-scratch-save-file (concat spacemacs-cache-directory ".persistent-scratch")
+                persistent-scratch-autosave-interval 60
+                persistent-scratch-what-to-save '(point narrowing))
+       ;; other layers
+       )
+     ))
+#+END_SRC

--- a/layers/+emacs/scratch/packages.el
+++ b/layers/+emacs/scratch/packages.el
@@ -1,0 +1,76 @@
+;;; packages.el --- Scratch layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Ray Wang <ray@isrc.iscas.ac.cn>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;; See the Spacemacs documentation and FAQs for instructions on how to implement
+;; a new layer:
+;;
+;;   SPC h SPC layers RET
+;;
+;;
+;; Briefly, each package to be installed or configured by this layer should be
+;; added to `scratch-packages'. Then, for each package PACKAGE:
+;;
+;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
+;;   function `scratch/init-PACKAGE' to load and initialize the package.
+
+;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
+;;   define the functions `scratch/pre-init-PACKAGE' and/or
+;;   `scratch/post-init-PACKAGE' to customize the package as it is loaded.
+
+;;; Code:
+
+(defconst scratch-packages
+  '(persistent-scratch
+		unkillable-scratch)
+  "The list of Lisp packages required by the scratch layer.
+
+Each entry is either:
+
+1. A symbol, which is interpreted as a package to be installed, or
+
+2. A list of the form (PACKAGE KEYS...), where PACKAGE is the
+    name of the package to be installed or loaded, and KEYS are
+    any number of keyword-value-pairs.
+
+    The following keys are accepted:
+
+    - :excluded (t or nil): Prevent the package from being loaded
+      if value is non-nil
+
+    - :location: Specify a custom installation location.
+      The following values are legal:
+
+      - The symbol `elpa' (default) means PACKAGE will be
+        installed using the Emacs package manager.
+
+      - The symbol `local' directs Spacemacs to load the file at
+        `./local/PACKAGE/PACKAGE.el'
+
+      - A list beginning with the symbol `recipe' is a melpa
+        recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
+
+
+(defun scratch/init-persistent-scratch ()
+  (use-package persistent-scratch
+    :ensure t
+    :init (add-hook 'spacemacs-scratch-mode-hook
+                    'persistent-scratch-mode)
+    :config (persistent-scratch-autosave-mode t)))
+
+(defun scratch/init-unkillable-scratch ()
+  (use-package unkillable-scratch
+    :ensure t
+    :custom (unkillable-scratch-do-not-reset-scratch-buffer t)
+    :config (unkillable-scratch t)))
+
+;;; packages.el ends here

--- a/layers/+lang/erlang/README.org
+++ b/layers/+lang/erlang/README.org
@@ -8,16 +8,104 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#layer][Layer]]
+  - [[#choosing-a-backend][Choosing a backend]]
+- [[#configuration][Configuration]]
+  - [[#erlang-mode][erlang-mode]]
+  - [[#lsp][LSP]]
+- [[#key-bindings][Key bindings]]
+  - [[#erlang-mode-1][erlang-mode]]
+  - [[#lsp-1][LSP]]
 
 * Description
-This layer adds very basic support for Erlang to Spacemacs.
+This layer adds support for [[https://erlang.org/][Erlang]].
+
+Enabling [[https://github.com/emacs-lsp/lsp-mode][Lsp-mode]] brings IDE like
+features following =Language Server Protocol=, through [[https://erlang-ls.github.io/][erlang_ls]]
 
 ** Features:
 - Syntax highlighting
 - Syntax checking via =Flycheck= integration
 - Auto-completion via =Company= integration
+- Code Completion
+- Go To Definition
+- Go To Implementation for OTP Behaviours
+- Signature Suggestions
+- Compiler Diagnostics
+- [[https://erlang.org/doc/man/dialyzer.html][Dialyzer]] Diagnostics
+- [[https://github.com/inaka/elvis][Elvis]] Diagnostics
+- [[http://erlang.org/doc/apps/edoc/chapter.html][Edoc]]
+- Navigation for Included Files
+- Find/Peek References
+- Outline
+- Workspace Symbols
+- Code Folding
 
 * Install
+** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =erlang= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+** Choosing a backend
+=company-erlang= uses gtags to provide a very basic working environment, it is
+the default backend.
+
+You can improve the IDE-like experience by choosing the =lsp= backend, to do so,
+first add the =lsp= layer to =dotspacemacs-configuration-layers=, then, set the
+layer variable =erlang-backend=:
+
+#+begin_src elisp
+  (erlang :variables erlang-backend 'lsp)
+#+end_src
+
+Alternatively the =lsp= backend will be automatically chosen if the layer =lsp=
+is used and you did not specify any value for =erlang-backend=.
+
+* Configuration
+** erlang-mode
+To find the manual page for the function under the cursor you can either set
+=erlang-man-root-dir= to erlang man root directory path in the layer definition:
+
+#+BEGIN_SRC elisp
+(erlang :variables erlang-man-root-dir "*path_to_folder*/otp_22/lib/erlang/man")
+#+END_SRC
+
+or let =erlang-mode= download it by executing ~M-x erlang-man-download-ask~.
+
+** LSP
+The =lsp= backend uses [[https://erlang-ls.github.io/][erlang_ls]] as its language server implementation.
+
+Clone the project to your system and compile it:
+
+#+BEGIN_SRC bash
+  make
+#+END_SRC
+
+*Note:* Ensure you have =erlang_ls= in your =PATH=...
+
+You can install it:
+
+#+BEGIN_SRC bash
+  make install
+#+END_SRC
+
+* Key bindings
+** erlang-mode
+
+| Key binding | Description                                                     |
+|-------------+-----------------------------------------------------------------|
+| ~C-c C-a~   | Align arrows ("->")                                             |
+| ~C-c C-c~   | Comment region                                                  |
+| ~C-c C-d~   | Display function manual at point                                |
+| ~C-c C-j~   | Generate a new clause                                           |
+| ~C-c C-q~   | Indent function                                                 |
+| ~C-c C-u~   | Uncomment region                                                |
+| ~C-c C-y~   | Insert, at the point, the argument list of the previous clause. |
+| ~C-c C-z~   | Display the erlang-shell or start a new                         |
+| ~C-c M-a~   | Move backward to previous start of clause.                      |
+| ~C-c M-e~   | Move to the end of the current clause.                          |
+| ~C-c M-h~   | Put mark at end of clause, point at beginning.                  |
+
+** LSP
+You will find an overview of all the key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp#key-bindings][lsp layer description]].

--- a/layers/+lang/erlang/config.el
+++ b/layers/+lang/erlang/config.el
@@ -12,3 +12,13 @@
 ;; variables
 
 (spacemacs|define-jump-handlers erlang-mode)
+
+(defvar erlang-fill-column 80
+  "Column beyond which automatic line-wrapping should happen.")
+
+;; lsp - erlang_ls
+
+(defvar erlang-backend nil
+  "The backend to use for IDE features.
+Possible values are `lsp' or `company-erlang'.
+If `nil' then `company-erlang' is the default backend unless `lsp' layer is used.")

--- a/layers/+lang/erlang/funcs.el
+++ b/layers/+lang/erlang/funcs.el
@@ -1,0 +1,46 @@
+;;; funcs.el --- Erlang Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Carlos F. Clavijo <arkan1313@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defun spacemacs//erlang-backend ()
+  "Returns selected backend."
+  (if erlang-backend
+      erlang-backend
+    (cond
+     ((configuration-layer/layer-used-p 'lsp) 'lsp)
+     (t 'company-erlang))))
+
+(defun spacemacs//erlang-setup-backend ()
+  "Conditionally setup erlang backend."
+  (pcase (spacemacs//erlang-backend)
+    (`lsp (spacemacs//erlang-setup-lsp)))
+  )
+
+(defun spacemacs//erlang-setup-company ()
+  "Conditionally setup company based on backend."
+  (pcase (spacemacs//erlang-backend)
+    ;; Activate lsp company explicitly to activate
+    ;; standard backends as well
+    (`lsp (spacemacs|add-company-backends
+            :backends company-capf
+            :modes erlang-mode
+            :append-hooks t))))
+
+(defun spacemacs//erlang-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp)
+    (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
+
+(defun spacemacs//erlang-default ()
+  "Default settings for erlang buffers"
+
+  ;; Use a custom fill-column for erlang buffers
+  (set-fill-column erlang-fill-column))

--- a/layers/+lang/erlang/layers.el
+++ b/layers/+lang/erlang/layers.el
@@ -1,0 +1,14 @@
+;;; layers.el --- Erlang Layer declarations File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Carlos F. Clavijo <arkan1313@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'erlang-backend)
+           (eq erlang-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -20,7 +20,8 @@
         ))
 
 (defun erlang/post-init-company ()
-  (add-hook 'erlang-mode-hook 'company-mode))
+  ;; backend specific
+  (spacemacs//erlang-setup-company))
 
 (defun erlang/init-erlang ()
   (use-package erlang
@@ -29,7 +30,10 @@
     (progn
       ;; explicitly run prog-mode hooks since erlang mode does is not
       ;; derived from prog-mode major-mode
-      (add-hook 'erlang-mode-hook 'spacemacs/run-prog-mode-hooks)
+      (spacemacs/add-to-hook 'erlang-mode-hook
+                             '(spacemacs/run-prog-mode-hooks
+                               spacemacs//erlang-setup-backend
+                               spacemacs//erlang-default))
       ;; (setq erlang-root-dir "/usr/lib/erlang/erts-5.10.3")
       ;; (add-to-list 'exec-path "/usr/lib/erlang/erts-5.10.3/bin")
       ;; (setq erlang-man-root-dir "/usr/lib/erlang/erts-5.10.3/man")
@@ -40,8 +44,7 @@
       ;;             (setq inferior-erlang-machine-options '("-sname" "syl20bnr"))
       ;;             ))
       (setq erlang-compile-extra-opts '(debug_info)))
-    :config
-    (require 'erlang-start)))
+    :config (require 'erlang-start)))
 
 (defun erlang/post-init-flycheck ()
   (spacemacs/enable-flycheck 'erlang-mode))

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1,7 +1,7 @@
 #+TITLE: Configuration layers
 
 * Table of Contents                     :TOC_5_gh:noexport:
-- [[#this-file-is-auto-generated][THIS FILE IS AUTO GENERATED]]
+- [[#description][Description]]
 - [[#chats][Chats]]
   - [[#erc][ERC]]
   - [[#jabber][Jabber]]
@@ -255,7 +255,8 @@
   - [[#twitter][Twitter]]
   - [[#wakatime][Wakatime]]
 
-* THIS FILE IS AUTO GENERATED
+* Description
+This file is auto-generated!
 Don't edit it directly.
 See [[https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org#readmeorg-tags]["README.org tags" section of CONTRIBUTING.org for the instructions]].
 
@@ -2052,6 +2053,7 @@ Features:
 - auto-completion with company mode via [[https://github.com/ocaml/merlin][merlin]]
 - syntax-checking via [[https://github.com/flycheck/flycheck-ocaml][flycheck-ocaml]] (or alternatively [[https://github.com/ocaml/merlin][merlin]])
 - =dune= file syntax highlighting and template insertion via [[https://github.com/ocaml/dune/][dune-mode]]
+- Automatic formatting via [[https://github.com/ocaml-ppx/ocamlformat][ocamlformat]]
 
 **** Pact
 [[file:+lang/pact/README.org][+lang/pact/README.org]]


### PR DESCRIPTION
### What Changed

Add layer scratch which makes your `*scratch*` buffer persistent and unkillable.

### Why
It makes sense if you want to save your drafts in `*scratch*` buffer temporarily.
Things you write down in `*scratch*` buffer will be automatically saved and restored.

### Packages Used
https://github.com/Fanael/persistent-scratch
https://github.com/EricCrosson/unkillable-scratch

### Note
This layer requests `spacemacs-scratch-mode-hook` introduced in PR https://github.com/syl20bnr/spacemacs/pull/13968