### PR TITLE
Minor changes on `helm` layer

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -297,7 +297,8 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
   ;; --line-number forces line numbers (disabled by default on windows)
   ;; no --vimgrep because it adds column numbers that wgrep can't handle
   ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-  (let ((helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number --max-columns=150"))
+  (let ((helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number --max-columns=150")
+        (helm-ag-success-exit-status '(0 2)))
     (helm-do-ag-buffers)))
 
 (defun spacemacs/helm-buffers-do-rg-region-or-symbol ()

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -302,7 +302,13 @@
 (defun helm/init-helm-ls-git ()
   (use-package helm-ls-git
     :defer t
-    :init (spacemacs/set-leader-keys "gff" 'helm-ls-git-ls)))
+    :init (spacemacs/set-leader-keys "gff" 'helm-ls-git-ls)
+    :config
+    ;; Set `helm-ls-git-status-command' conditonally on `git' layer
+    ;; If `git' is in use, use default `\'magit-status-setup-buffer'
+    ;; Otherwise, use defaault `\'vc-dir'
+    (when (configuration-layer/package-usedp 'magit)
+      (setq helm-ls-git-status-command 'magit-status-setup-buffer))))
 
 (defun helm/init-helm-make ()
   (use-package helm-make


### PR DESCRIPTION
It's been advised by the upstream of `helm-ag` to set
`helm-ag-success-exit-status` to `'(0 2)`.

This PR adopted this suggestion.

ref: https://github.com/emacsorphanage/helm-ag#helm-agel-with-other-searching-tools

---

For `helm-ls-git` package, it's advised to set use `magit`as a bette alternative to
`vcr-dir` as the underlying command for getting `git status`.

This PR adopted this suggestion when `magit` package is in use.

Ref: https://github.com/emacs-helm/helm-ls-git/blob/4da1a53f2f0a078ee2e896a914a1b19c0bf1d5ed/helm-ls-git.el#L184-L189

Signed-off-by: Lucius Hu <lebensterben@users.noreply.github.com>