### PR TITLE
[ranger] Add 'ranger as an option to ranger-enter-with-minus

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3066,6 +3066,8 @@ files (thanks to Daniel Nicolai)
 - Fixed conflict with =golden-ratio= (thanks to Thomas de Beauchêne)
 - Load =helm= before =ranger= (thanks to duianto)
 - Add instruction to use ranger by default (thanks to Daniel Nicolai)
+- Added ='ranger= as an option to the variable: =ranger-enter-with-minus=
+  (thanks to duianto)
 **** Rcirc
 - New variable =rcirc-enable-late-fix= to enable or disable the included
   =rcirc-late-fix= package (disabled by default).

--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -40,10 +40,13 @@ Most parameters can be toggled on and off and stay within the current emacs
 session. Any settings that are desired on startup should be set below.
 
 ** Customizing
-You toggle the use of =-= to enter ranger with `ranger-enter-with-minus`.
+Toggle the use of =-= to enter deer or ranger with =ranger-enter-with-minus=.
+The possible values are:
+- ='deer= (default)
+- ='ranger=
 
 #+BEGIN_SRC elisp
-  (setq ranger-enter-with-minus t)
+  (setq ranger-enter-with-minus 'deer)
 #+END_SRC
 
 When disabling the mode you can choose to kill the buffers that were opened

--- a/layers/+tools/ranger/config.el
+++ b/layers/+tools/ranger/config.el
@@ -10,5 +10,10 @@
 ;;
 ;;; License: GPLv3
 
-(defvar ranger-enter-with-minus t
-  "Option to enter `deer' when `-' is pressed.  Idea from `vim-vinegar'.")
+(defvar ranger-enter-with-minus 'deer
+  "Option to enter `deer' or `ranger' when `-' is pressed.
+Idea from `vim-vinegar'.
+
+The possible values are:
+'deer (default)
+'ranger")

--- a/layers/+tools/ranger/packages.el
+++ b/layers/+tools/ranger/packages.el
@@ -32,9 +32,8 @@
     (progn
       (ranger//set-leader-keys)
 
-      ;; allow '-' to enter ranger
-      (when ranger-enter-with-minus
-        (define-key evil-normal-state-map (kbd "-") 'deer))
+      (when (memq ranger-enter-with-minus '(deer ranger))
+        (define-key evil-motion-state-map (kbd "-") ranger-enter-with-minus))
 
       ;; set up image-dired to allow picture resize
       (setq image-dired-dir (concat spacemacs-cache-directory "image-dir"))


### PR DESCRIPTION
Added `'ranger` as an option to the variable: `ranger-enter-with-minus`
Changed the default value from: `t` to: `'deer`.
Bound the key to `evil-motion-state-map` instead of `evil-normal-state-map`
so that `-` also works from the Spacemacs home buffer.

Fixes:
Spacemacs ranger layer: use ranger with ranger-enter-with-minus option
#14086