### PR TITLE
Add layer scratch into layers/+emacs/scratch 

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -345,6 +345,7 @@ sane way, here is the complete list of changed key bindings
 - helpful (thanks to Johnson Denen, Andriy Kmit)
 - tabs (thanks to Deepu Mohan Puthrote)
 - verb (thanks to Federico Tedin)
+- scratch (thanks to rayw000)
 **** Email
 - notmuch (thanks to Francesc Elies Henar, Leonard Lausen, Willian Casarin,
   Kalle Lindqvist)

--- a/layers/+emacs/scratch/README.org
+++ b/layers/+emacs/scratch/README.org
@@ -1,0 +1,55 @@
+#+TITLE: scratch layer
+
+#+TAGS: layer|emacs
+
+* Table of Contents                                        :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+- [[#customizations][Customizations]]
+
+* Description
+This layer makes your =*scratch*= buffer persistent and not killable.
+That makes sense if you want to save your drafts in =*scratch*= buffer temporarily.
+Things you write down in =*scratch*= buffer will be automatically saved and restored.
+
+** Features:
+   - This layer makes your =*scratch*= buffer persistent and not killable.
+
+Packages used by this layer:
+[[https://github.com/Fanael/persistent-scratch][persistent-scratch]], [[https://github.com/EricCrosson/unkillable-scratch][unkillable-scratch]]
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =scratch= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key bindings
+
+| Key Binding | Description                       |
+|-------------+-----------------------------------|
+| C-x C-s     | save =*scratch*= buffer temporarily |
+| C-x C-w     | write =*scratch*= buffer to a file |
+
+See URL: https://github.com/Fanael/persistent-scratch
+
+* Customizations
+You can customize this layer by setting variables of package [[https://github.com/Fanael/persistent-scratch][persistent-scratch]] and [[https://github.com/EricCrosson/unkillable-scratch][unkillable-scratch]].
+
+For example, enable =scratch= layer with these following variables configured in =dotspacemacs-configuration-layers= in your =.spacemacs=.
+
+#+BEGIN_SRC emacs-lisp
+  (defun dotspacemacs/layers()
+    (setq-default
+     dotspacemacs-configuration-layers
+     '(
+       ;; other layers...
+       (scratch :variables
+                persistent-scratch-save-file (concat spacemacs-cache-directory ".persistent-scratch")
+                persistent-scratch-autosave-interval 60
+                persistent-scratch-what-to-save '(point narrowing))
+       ;; other layers
+       )
+     ))
+#+END_SRC

--- a/layers/+emacs/scratch/packages.el
+++ b/layers/+emacs/scratch/packages.el
@@ -1,0 +1,76 @@
+;;; packages.el --- Scratch layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Ray Wang <ray@isrc.iscas.ac.cn>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Commentary:
+
+;; See the Spacemacs documentation and FAQs for instructions on how to implement
+;; a new layer:
+;;
+;;   SPC h SPC layers RET
+;;
+;;
+;; Briefly, each package to be installed or configured by this layer should be
+;; added to `scratch-packages'. Then, for each package PACKAGE:
+;;
+;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
+;;   function `scratch/init-PACKAGE' to load and initialize the package.
+
+;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
+;;   define the functions `scratch/pre-init-PACKAGE' and/or
+;;   `scratch/post-init-PACKAGE' to customize the package as it is loaded.
+
+;;; Code:
+
+(defconst scratch-packages
+  '(persistent-scratch
+		unkillable-scratch)
+  "The list of Lisp packages required by the scratch layer.
+
+Each entry is either:
+
+1. A symbol, which is interpreted as a package to be installed, or
+
+2. A list of the form (PACKAGE KEYS...), where PACKAGE is the
+    name of the package to be installed or loaded, and KEYS are
+    any number of keyword-value-pairs.
+
+    The following keys are accepted:
+
+    - :excluded (t or nil): Prevent the package from being loaded
+      if value is non-nil
+
+    - :location: Specify a custom installation location.
+      The following values are legal:
+
+      - The symbol `elpa' (default) means PACKAGE will be
+        installed using the Emacs package manager.
+
+      - The symbol `local' directs Spacemacs to load the file at
+        `./local/PACKAGE/PACKAGE.el'
+
+      - A list beginning with the symbol `recipe' is a melpa
+        recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
+
+
+(defun scratch/init-persistent-scratch ()
+  (use-package persistent-scratch
+    :ensure t
+    :init (add-hook 'spacemacs-scratch-mode-hook
+                    'persistent-scratch-mode)
+    :config (persistent-scratch-autosave-mode t)))
+
+(defun scratch/init-unkillable-scratch ()
+  (use-package unkillable-scratch
+    :ensure t
+    :custom (unkillable-scratch-do-not-reset-scratch-buffer t)
+    :config (unkillable-scratch t)))
+
+;;; packages.el ends here


### PR DESCRIPTION
### What Changed

Add layer scratch which makes your `*scratch*` buffer persistent and unkillable.

### Why
It makes sense if you want to save your drafts in `*scratch*` buffer temporarily.
Things you write down in `*scratch*` buffer will be automatically saved and restored.

### Packages Used
https://github.com/Fanael/persistent-scratch
https://github.com/EricCrosson/unkillable-scratch

### Note
This layer requests `spacemacs-scratch-mode-hook` introduced in PR https://github.com/syl20bnr/spacemacs/pull/13968