### PR TITLE
Add lsp support to latex layer

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -9,8 +9,10 @@
   - [[#features][Features:]]
 - [[#bibtex][BibTeX]]
 - [[#install][Install]]
-  - [[#layer][Layer]]
-  - [[#auto-completion][Auto-completion]]
+- [[#configuration][Configuration]]
+  - [[#choosing-a-backend][Choosing a backend]]
+    - [[#company-auctex][Company-auctex]]
+    - [[#lsp][LSP]]
   - [[#previewing][Previewing]]
   - [[#build-command][Build command]]
   - [[#auto-fill][Auto-fill]]
@@ -25,7 +27,8 @@ This layer adds support for LaTeX files with [[https://savannah.gnu.org/projects
 
 ** Features:
 - Auto-build with [[https://github.com/tom-tan/auctex-latexmk/][auctex-latexmk]]
-- Auto-completion with [[https://github.com/alexeyr/company-auctex][company-auctex]]
+- Syntax highlighting
+- Auto-completion
 - Tags navigation on ~%~ with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 - Labels, references, citations and index entries management with [[http://www.gnu.org/software/emacs/manual/html_node/reftex/index.html][RefTeX]]
 
@@ -34,14 +37,50 @@ For more extensive support of BibTeX files than RefTeX provides, have a look at
 the [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/bibtex/README.org][BibTeX layer]].
 
 * Install
-** Layer
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =latex= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** Auto-completion
-Add the layer =auto-completion= to the variable
-=dotspacemacs-configuration-layers= of your dotfile =~/.spacemacs=.
+* Configuration
+Most layer configurations can be done by setting layer variables in your dotfile.
+Some however require adding lines to your user-config.
+
+** Choosing a backend
+This layer provides two alternative backends to choose from.
+
+*** Company-auctex
+This is the default choice if nothing is set and no lsp layer
+is loaded in your dotfile. This mode only provides very
+limited IDE capabilities. Used best for smaller documents.
+To set explicitly set the following in your
+dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (latex :variables latex-backend 'company-auctex)
+#+END_SRC
+
+*** LSP
+For proper IDE support this backend should be used. It is
+based on an external server which will be started automatically
+by emacs, once a latex file is opened. The key bindings are
+the same for all lsp modes so if you are already familiar with
+one you should be able to work the same in all modes.
+
+To set explicitly do the following in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (latex :variables
+	 latex-backend 'lsp)
+#+END_SRC
+
+For this to work you will also need to obtain
+the latest version of the lsp server from [[https://github.com/latex-lsp/texlab][here]]
+and put it into your =PATH=.
+
+NOTE: Key bindings for LSP are defined in the
+LSP layer. Also it is advisable to have a look
+at the autocomplete layer for an optimal
+intellisense config for LSP.
 
 ** Previewing
 To perform full-document previews (that is, aside from the inline previewing
@@ -114,53 +153,53 @@ By default, the underlying latex code is echoed in the echo area.
 
 * Key bindings
 
-| Key binding   | Description                                |
-|---------------+--------------------------------------------|
-| ~SPC m -~     | recenter output buffer                     |
-| ~SPC m ​,​~     | TeX command on master file                 |
-| ~SPC m .~     | mark LaTeX environment                     |
-| ~SPC m *~     | mark LaTeX section                         |
-| ~SPC m %~     | comment or uncomment a paragraph           |
-| ~SPC m ;~     | comment or uncomment a region              |
-| ~SPC m a~     | run all commands (compile and open viewer) |
-| ~SPC m b~     | build                                      |
-| ~SPC m c~     | close LaTeX environment                    |
-| ~SPC m e~     | insert LaTeX environment                   |
-| ~SPC m i i~   | insert =\item=                             |
-| ~SPC m k~     | kill TeX job                               |
-| ~SPC m l~     | recenter output buffer                     |
-| ~SPC m m~     | insert LaTeX macro                         |
-| ~SPC m n~     | goto next error                            |
-| ~SPC m N~     | goto previous error                        |
-| ~SPC m s~     | insert LaTeX section                       |
-| ~SPC m v~     | view output                                |
-| ~SPC m h d~   | TeX documentation, can be very slow        |
-| ~SPC m f e~   | fill LaTeX environment                     |
-| ~SPC m f p~   | fill LaTeX paragraph                       |
-| ~SPC m f r~   | fill LaTeX region                          |
-| ~SPC m f s~   | fill LaTeX section                         |
-| ~SPC m p r~   | preview region                             |
-| ~SPC m p b~   | preview buffer                             |
-| ~SPC m p d~   | preview document                           |
-| ~SPC m p e~   | preview environment                        |
-| ~SPC m p s~   | preview section                            |
-| ~SPC m p p~   | preview at point                           |
-| ~SPC m p f~   | cache preamble for preview                 |
-| ~SPC m p c~   | clear previews                             |
-| ~SPC m v~     | view                                       |
-| ~SPC m x b~   | make font bold                             |
-| ~SPC m x B~   | make font medium weight                    |
-| ~SPC m x c~   | make font monospaced (for code)            |
-| ~SPC m x e~   | make font emphasised                       |
-| ~SPC m x i~   | make font italic                           |
-| ~SPC m x o~   | make font oblique                          |
-| ~SPC m x r~   | remove font properties                     |
-| ~SPC m x f a~ | use calligraphic font                      |
-| ~SPC m x f c~ | use small-caps font                        |
-| ~SPC m x f f~ | use sans serif font                        |
-| ~SPC m x f n~ | use normal font                            |
-| ~SPC m x f r~ | use serif font                             |
-| ~SPC m x f u~ | use upright font                           |
+| Key binding                       | Description                                |
+|-----------------------------------+--------------------------------------------|
+| ~SPC m -~                         | recenter output buffer                     |
+| ~SPC m ,~                         | TeX command on master file                 |
+| ~SPC m .~                         | mark LaTeX environment                     |
+| ~SPC m *~                         | mark LaTeX section                         |
+| ~SPC m %~                         | comment or uncomment a paragraph           |
+| ~SPC m ;~                         | comment or uncomment a region              |
+| ~SPC m a~ or with LSP ~SPC m a u~ | run all commands (compile and open viewer) |
+| ~SPC m b~ or with LSP ~SPC m c~   | build the document (compile)               |
+| ~SPC m c~ or with LSP ~SPC m i c~ | close LaTeX environment                    |
+| ~SPC m e~ or with LSP ~SPC m i e~ | insert LaTeX environment                   |
+| ~SPC m i i~                       | insert =\item=                             |
+| ~SPC m k~                         | kill TeX job                               |
+| ~SPC m l~                         | recenter output buffer                     |
+| ~SPC m m~                         | insert LaTeX macro                         |
+| ~SPC m n~                         | goto next error                            |
+| ~SPC m N~                         | goto previous error                        |
+| ~SPC m s~                         | insert LaTeX section                       |
+| ~SPC m v~                         | view output                                |
+| ~SPC m h d~                       | TeX documentation, can be very slow        |
+| ~SPC m f e~                       | fill LaTeX environment                     |
+| ~SPC m f p~                       | fill LaTeX paragraph                       |
+| ~SPC m f r~                       | fill LaTeX region                          |
+| ~SPC m f s~                       | fill LaTeX section                         |
+| ~SPC m p r~                       | preview region                             |
+| ~SPC m p b~                       | preview buffer                             |
+| ~SPC m p d~                       | preview document                           |
+| ~SPC m p e~                       | preview environment                        |
+| ~SPC m p s~                       | preview section                            |
+| ~SPC m p p~                       | preview at point                           |
+| ~SPC m p f~                       | cache preamble for preview                 |
+| ~SPC m p c~                       | clear previews                             |
+| ~SPC m v~                         | view                                       |
+| ~SPC m x b~                       | make font bold                             |
+| ~SPC m x B~                       | make font medium weight                    |
+| ~SPC m x c~                       | make font monospaced (for code)            |
+| ~SPC m x e~                       | make font emphasised                       |
+| ~SPC m x i~                       | make font italic                           |
+| ~SPC m x o~                       | make font oblique                          |
+| ~SPC m x r~                       | remove font properties                     |
+| ~SPC m x f a~                     | use calligraphic font                      |
+| ~SPC m x f c~                     | use small-caps font                        |
+| ~SPC m x f f~                     | use sans serif font                        |
+| ~SPC m x f n~                     | use normal font                            |
+| ~SPC m x f r~                     | use serif font                             |
+| ~SPC m x f u~                     | use upright font                           |
 
 ** Folding
 Available only when =latex-enable-folding= is non nil.
@@ -175,18 +214,18 @@ Available only when =latex-enable-folding= is non nil.
 
 ** RefTeX
 
-| Key binding   | Description                           |
-|---------------+---------------------------------------|
-| ~SPC m r c~   | reftex-citation                       |
-| ~SPC m r g~   | reftex-grep-document                  |
-| ~SPC m r i~   | reftex-index-selection-or-word        |
-| ~SPC m r I~   | reftex-display-index                  |
-| ~SPC m r TAB~ | reftex-index                          |
-| ~SPC m r l~   | reftex-label                          |
-| ~SPC m r p~   | reftex-index-phrase-selection-or-word |
-| ~SPC m r P~   | reftex-index-visit-phrases-buffer     |
-| ~SPC m r r~   | reftex-reference                      |
-| ~SPC m r s~   | reftex-search-document                |
-| ~SPC m r t~   | reftex-toc                            |
-| ~SPC m r T~   | reftex-toc-recenter                   |
-| ~SPC m r v~   | reftex-view-crossref                  |
+| Key binding                             | Description                           |
+|-----------------------------------------+---------------------------------------|
+| ~SPC m r c~ or with LSP ~SPC m R c~     | reftex-citation                       |
+| ~SPC m r g~ or with LSP ~SPC m R g~     | reftex-grep-document                  |
+| ~SPC m r i~ or with LSP ~SPC m R i~     | reftex-index-selection-or-word        |
+| ~SPC m r I~ or with LSP ~SPC m R I~     | reftex-display-index                  |
+| ~SPC m r TAB~ or with LSP ~SPC m R TAB~ | reftex-index                          |
+| ~SPC m r l~ or with LSP ~SPC m R l~     | reftex-label                          |
+| ~SPC m r p~ or with LSP ~SPC m R p~     | reftex-index-phrase-selection-or-word |
+| ~SPC m r P~ or with LSP ~SPC m R P~     | reftex-index-visit-phrases-buffer     |
+| ~SPC m r r~ or with LSP ~SPC m R r~     | reftex-reference                      |
+| ~SPC m r s~ or with LSP ~SPC m R s~     | reftex-search-document                |
+| ~SPC m r t~ or with LSP ~SPC m R t~     | reftex-toc                            |
+| ~SPC m r T~ or with LSP ~SPC m R T~     | reftex-toc-recenter                   |
+| ~SPC m r v~ or with LSP ~SPC m R v~     | reftex-view-crossref                  |

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -41,3 +41,8 @@
                            "tabu*"
                            "tikzpicture")
   "List of environment names in which `auto-fill-mode' will be inhibited.")
+
+(defvar latex-backend nil
+  "The backend to use for IDE features.
+Possible values are `lsp' and `company-auctex'.
+If `nil' then 'company-auctex` is the default backend unless `lsp' layer is used")

--- a/layers/+lang/latex/layers.el
+++ b/layers/+lang/latex/layers.el
@@ -1,0 +1,14 @@
+;;; layers.el --- Latex Layer layers File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Maximilian Wolff <smile13241324@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (and (boundp 'latex-backend)
+           (eq latex-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(lsp)))


### PR DESCRIPTION
This commit adds LSP support to the latex layer. As part of this it resolves some of the key conflicts however only if LSP is activated.