### PR TITLE
[org] Activate insert state after some org-insert-* commands

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2895,6 +2895,9 @@ files (thanks to Daniel Nicolai)
 - Enabled =org-habit= module
   (thanks to Mariusz Klochowicz)
 - Fixed evil paste in a =org-src-mode= table (thanks to duianto)
+- Implemented automatic activation of evil insert state after
+  =org-insert-drawer=, =org-insert-heading=, =org-insert-item= and
+  =org-insert-structure-template= commands (thanks to Andriy Kmit')
 **** Osx
 - Key bindings:
   - Added key bindings to use ~command-1..9~ for selecting window

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -50,6 +50,14 @@
     (add-to-list 'evil-surround-pairs-alist '(?: . spacemacs//surround-drawer))
     (add-to-list 'evil-surround-pairs-alist '(?# . spacemacs//surround-code))))
 
+(defun spacemacs//org-maybe-activate-evil-insert (&rest _)
+  "Switch to evil insert state if the current state is normal.
+Useful as an :after advice for commands that insert something
+into buffer, but are not Evil-aware (e.g. `org-insert-item')."
+  (when (and (member dotspacemacs-editing-style '(vim hybrid))
+             (evil-normal-state-p))
+    (evil-insert-state)))
+
 
 
 (defun spacemacs/org-trello-pull-buffer ()

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -391,6 +391,13 @@ Will work on both org-mode and any mode that accepts plain html."
       (define-key global-map "\C-cc" 'org-capture))
     :config
     (progn
+      ;; Activate evil insert state after these commands.
+      (dolist (fn '(org-insert-drawer
+                    org-insert-heading
+                    org-insert-item
+                    org-insert-structure-template))
+        (advice-add fn :after #'spacemacs//org-maybe-activate-evil-insert))
+
       ;; We add this key mapping because an Emacs user can change
       ;; `dotspacemacs-major-mode-emacs-leader-key' to `C-c' and the key binding
       ;; C-c ' is shadowed by `spacemacs/default-pop-shell', effectively making


### PR DESCRIPTION
Having to manually press i after using any of these commands is annoying to say
the least. This commit affects the following commands:
- org-insert-drawer
- org-insert-heading
- org-insert-item
- org-insert-structure-template

Change to org-insert-heading also affects other commands that use it
internally (e.g. org-insert-subheading).