### PR TITLE
Add persistent-scratch and unkillable-scratch into core/spacemacs-editing layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -756,6 +756,10 @@ Other:
     (thanks to Vladimir Kochnev and Eivind Fonn)
   - Added =password-generator= package to =spacemacs-editing= layer
     (thanks to Sylvain Benner)
+  - Added =persistent-scratch= package to =spacemacs-editing= layer
+    (thanks to Ray Wang)
+  - Added =unkillable-scratch= package to =spacemacs-editing= layer
+    (thanks to Ray Wang)
   - Added =symon= package to =spacemacs-modeline= layer
     (thanks to Eugene Yaremenko)
   - Added =evil-goggles= to the =spacemacs-evil= layer

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -456,6 +456,14 @@ and todos. If non nil only the file name is shown.")
   "Subdirectories of `spacemacs-start-directory' to ignore when
 prettifying Org files.")
 
+(defvar dotspacemacs-scratch-buffer-persistent nil
+  "If non-nil, *scratch* buffer will be persistent. Things you write down in
+   *scratch* buffer will be saved automatically.")
+
+(defvar dotspacemacs-scratch-buffer-unkillable nil
+  "If non-nil, `kill-buffer' on *scratch* buffer
+will bury it instead of killing.")
+
 (defun dotspacemacs//prettify-spacemacs-docs ()
   "Run `spacemacs/prettify-org-buffer' if `buffer-file-name'
 looks like Spacemacs documentation."

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -470,7 +470,15 @@ It should only modify the values of Spacemacs settings."
 
    ;; If nil the home buffer shows the full path of agenda items
    ;; and todos. If non nil only the file name is shown.
-   dotspacemacs-home-shorten-agenda-source nil))
+   dotspacemacs-home-shorten-agenda-source nil
+
+   ;; If non-nil, *scratch* buffer will be persistent. Things you write down in
+   ;; *scratch* buffer will be saved automatically.
+   dotspacemacs-scratch-buffer-persistent nil
+
+   ;; If non-nil, `kill-buffer' on *scratch* buffer
+   ;; will bury it instead of killing.
+   dotspacemacs-scratch-buffer-unkillable nil))
 
 (defun dotspacemacs/user-env ()
   "Environment variables setup.

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -196,6 +196,14 @@ It should only modify the values of Spacemacs settings."
    ;; Default major mode of the scratch buffer (default `text-mode')
    dotspacemacs-scratch-mode 'text-mode
 
+   ;; If non-nil, *scratch* buffer will be persistent. Things you write down in
+   ;; *scratch* buffer will be saved and restored automatically.
+   dotspacemacs-scratch-buffer-persistent nil
+
+   ;; If non-nil, `kill-buffer' on *scratch* buffer
+   ;; will bury it instead of killing.
+   dotspacemacs-scratch-buffer-unkillable nil
+
    ;; Initial message in the scratch buffer, such as "Welcome to Spacemacs!"
    ;; (default nil)
    dotspacemacs-initial-scratch-message nil
@@ -470,15 +478,7 @@ It should only modify the values of Spacemacs settings."
 
    ;; If nil the home buffer shows the full path of agenda items
    ;; and todos. If non nil only the file name is shown.
-   dotspacemacs-home-shorten-agenda-source nil
-
-   ;; If non-nil, *scratch* buffer will be persistent. Things you write down in
-   ;; *scratch* buffer will be saved automatically.
-   dotspacemacs-scratch-buffer-persistent nil
-
-   ;; If non-nil, `kill-buffer' on *scratch* buffer
-   ;; will bury it instead of killing.
-   dotspacemacs-scratch-buffer-unkillable nil))
+   dotspacemacs-home-shorten-agenda-source nil))
 
 (defun dotspacemacs/user-env ()
   "Environment variables setup.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -198,6 +198,9 @@
       - [[#emacs-keyboard-macros][Emacs keyboard macros]]
         - [[#macro-counter][Macro counter]]
         - [[#key-bindings-1][Key bindings]]
+    - [[#scratch-buffer][Scratch buffer]]
+      - [[#persistent-scratch][Persistent scratch]]
+      - [[#unkillable-scratch][Unkillable scratch]]
     - [[#mouse-usage][Mouse usage]]
   - [[#comparing-diff][Comparing (diff)]]
   - [[#managing-projects][Managing projects]]
@@ -3474,6 +3477,17 @@ When recording a macro it's possible to insert the current value by pressing:
 | ~SPC K r p~ | cycle to previous macro in ring                                           |
 | ~SPC K r s~ | swap the first two macros in ring                                         |
 | ~SPC K v~   | view last macro string in minibuffer                                      |
+
+*** Scratch buffer
+Some features which could improve editing experience in =*scratch*= buffer.
+
+**** Persistent scratch
+Make your =*scratch*= buffer persistent. Everything you write down in =*scratch*= buffer will be automatically saved and restored.
+You can set variable =dotspacemacs-scratch-buffer-persistent= with a non-nil value in your =.spacemacs= file to enable this feature.
+
+**** Unkillable scratch
+Make your =*scratch*= buffer not killable (bury instead).
+You can set variable =dotspacemacs-scratch-buffer-unkillable= with a non-nil value in your =.spacemacs= file to enable this feature.
 
 *** Mouse usage
 There are some added mouse features set for the line number margin (if shown):

--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -27,3 +27,5 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for converting definitions to certain styles via =string-inflection=.
 - Support for generating UUIDs via =uuidgen=.
 - Support for conversion between Emacs regexps and PCRE regexps.
+- Support for persistent scratch via =persistent-scratch=.
+- Support for unkillable scratch via =unkillable-scratch=.

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -24,12 +24,14 @@
         move-text
         (origami :toggle (eq 'origami dotspacemacs-folding-method))
         password-generator
+        persistent-scratch
         pcre2el
         smartparens
         (evil-swap-keys :toggle dotspacemacs-swap-number-row)
         (spacemacs-whitespace-cleanup :location local)
         string-inflection
         undo-tree
+        unkillable-scratch
         uuidgen
         (vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
         (evil-vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
@@ -510,3 +512,20 @@
                                                                ("0" . ")"))))
         (_ (message "dotspacemacs-swap-number-row %s is not supported." dotspacemacs-swap-number-row)))
       (add-hook 'prog-mode-hook #'evil-swap-keys-swap-number-row))))
+
+(defun spacemacs-editing/init-persistent-scratch ()
+  (use-package persistent-scratch
+    :ensure t
+    :init (when dotspacemacs-scratch-buffer-persistent
+            (setq persistent-scratch-save-file (concat spacemacs-cache-directory ".persistent-scratch")
+                  persistent-scratch-autosave-interval 60
+                  persistent-scratch-what-to-save '(point narrowing))
+            (add-hook 'spacemacs-scratch-mode-hook 'persistent-scratch-mode)
+            (persistent-scratch-autosave-mode t))))
+
+(defun spacemacs-editing/init-unkillable-scratch ()
+  (use-package unkillable-scratch
+    :ensure t
+    :init (when dotspacemacs-scratch-buffer-unkillable
+            (setq unkillable-scratch-do-not-reset-scratch-buffer t)
+            (unkillable-scratch dotspacemacs-scratch-buffer-unkillable))))

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -851,6 +851,8 @@ Features:
 - Support for converting definitions to certain styles via =string-inflection=.
 - Support for generating UUIDs via =uuidgen=.
 - Support for conversion between Emacs regexps and PCRE regexps.
+- Support for persistent scratch via =persistent-scratch=.
+- Support for unkillable scratch via =unkillable-scratch=.
 
 ** Spacemacs-editing-visual
 [[file:+spacemacs/spacemacs-editing-visual/README.org][+spacemacs/spacemacs-editing-visual/README.org]]


### PR DESCRIPTION
### What Changed

Add [persistent-scratch](https://github.com/Fanael/persistent-scratch) and [unkillable-scratch](https://github.com/EricCrosson/unkillable-scratch) packages into `core/spacemacs-editing` layer.

### Why
It will make sense if you want to save your drafts in `*scratch*` buffer temporarily.
Things you write down in `*scratch*` buffer will be automatically saved and restored.

### Note
This feature requests `spacemacs-scratch-mode-hook` introduced in PR #13968 