### PR TITLE
Remove eshell obsolete variable

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -71,8 +71,6 @@
             eshell-history-size 350
             ;; no duplicates in history
             eshell-hist-ignoredups t
-            ;; buffer shorthand -> echo foo > #'buffer
-            eshell-buffer-shorthand t
             ;; my prompt is easy enough to see
             eshell-highlight-prompt nil
             ;; treat 'echo' like shell echo


### PR DESCRIPTION
`eshell-buffer-shorthand` was removed in Emacs 25, see https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS.25#L1078-L1082