### PR TITLE
Add grip-mode to github layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1962,6 +1962,7 @@ Other:
     (thanks to Sylvain Benner)
   - Remove package =github-browse-file= which has been replaced by
    =browse-at-remote= in =version-control= layer
+  - Added package =grip=mode= (thanks to Daniel Nicolai)
 - Key bindings:
   - Added ~g r~ evilified binding to gist-list-mode
     (thanks to Jean-Sebastien A. Beaudry)
@@ -1971,6 +1972,8 @@ Other:
   - Forge-post buffer (thanks to Miciah Masters and yuhan0):
     - ~SPC m c~ or ~SPC m ,~ submit post
     - ~SPC m k~ or ~SPC m k~ cancel post
+  - md/org buffer (thanks to Daniel Nicolai)
+    - ~SPC g h p~ (toggle) grip-mode
 - Replace =evilified-state-evilify= by =evilified-state-evilify-map=
   (thanks to Sylvain Benner)
 - Disabled status, issues, and PRs by default (thanks to Miciah Masters)

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -11,10 +11,12 @@
   - [[#layer][Layer]]
   - [[#git-configuration][Git configuration]]
   - [[#forge][Forge]]
+  - [[#grip-mode][grip-mode]]
 - [[#key-bindings][Key bindings]]
   - [[#forge-1][Forge]]
   - [[#gistel][gist.el]]
   - [[#clone-repositories][Clone repositories]]
+  - [[#grip-mode-1][Grip-mode]]
 
 * Description
 This layers adds support for [[http://github.com][GitHub]].
@@ -24,6 +26,7 @@ This layers adds support for [[http://github.com][GitHub]].
 - [[https://github.com/defunkt/gist.el][gist.el]]: full-featured mode to browse and post GitHub gists.
 - [[https://github.com/sshaw/git-link][git-link]]: quickly generate URLs for commits or files.
 - [[https://github.com/dgtized/github-clone.el][github-clone]] allows for easy cloning and forking of repositories.
+- [[https://github.com/seagle0128/grip-mode][grip-mode]] Github-flavored Markdown/Org preview using [[https://github.com/joeyespo/grip][Grip]].
 
 * Install
 ** Layer
@@ -55,6 +58,10 @@ dotfile:
   (dotspacemacs-additional-packages '((forge :toggle t)))
 #+END_SRC
 
+** grip-mode
+Grip-mode [[https://github.com/seagle0128/grip-mode#prerequisite][requires python and the python package grip]] to be installed on the
+system. Grip can usually be installed with the command =pip3 install grip=.
+   
 * Key bindings
 ** Forge
 In a =magit-status= buffer (~SPC g s~):
@@ -127,3 +134,9 @@ In the gist list buffer:
 | ~SPC g h c r~ | add a remote that is an existing fork of selected remote |
 | ~SPC g h c f~ | fork remote in current user namespace                    |
 | ~SPC g h c u~ | add upstream as remote                                   |
+
+** Grip-mode
+
+| Key binding | Description                                                 |
+|-------------+-------------------------------------------------------------|
+| ~SPC g p~   | toggle github flavored mb/org buffer preview in web-browser |

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -17,6 +17,7 @@
         gist
         github-clone
         github-search
+        grip-mode
         ;; this package does not exits, we need it to wrap
         ;; the call to spacemacs/declare-prefix.
         (spacemacs-github :location built-in)
@@ -79,6 +80,14 @@
   (use-package github-search
     :commands (github-search-clone-repo github-search-user-clone-repo)
     :init (spacemacs/set-leader-keys "ghc/" 'github-search-clone-repo)))
+
+(defun github/init-grip-mode ()
+  (use-package grip-mode
+    :defer t
+    :init
+    (progn
+      (spacemacs/set-leader-keys
+        "ghp" 'grip-mode))))
 
 (defun github/init-spacemacs-github ()
   (spacemacs/declare-prefix "gh" "github"))


### PR DESCRIPTION
Grip-mode renders a preview of github README files locally, so you can check how they look before pushing to github.
I figured that more people would like it, and that it would be great to have this as standard functionality in the github layer.
I've added it under keybindings `SPC g h p` (toggle grip mode)