### PR TITLE
Add support for viewing latex fragment in org files

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -350,7 +350,9 @@ Will work on both org-mode and any mode that accepts plain html."
         "xr" (spacemacs|org-emphasize spacemacs/org-clear ? )
         "xs" (spacemacs|org-emphasize spacemacs/org-strike-through ?+)
         "xu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
-        "xv" (spacemacs|org-emphasize spacemacs/org-verbatim ?=))
+        "xv" (spacemacs|org-emphasize spacemacs/org-verbatim ?=)
+        ;; view
+        "vl" 'org-preview-latex-fragment)
 
       ;; Add global evil-leader mappings. Used to access org-agenda
       ;; functionalities – and a few others commands – from any other mode.


### PR DESCRIPTION
I found that there is no keybinding for previewing latex fragments on demand, therefore I had to revert buffer over and over again.

