### PR TITLE
Add tR hotkey for org-table-recalculate-buffer-tables

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -473,36 +473,37 @@ are also available.
 
 ** Tables
 
-| Key binding   | Description                                                                |
-|---------------+----------------------------------------------------------------------------|
-| ~SPC m t a~   | Align the table at point by aligning all vertical bars                     |
-| ~SPC m t b~   | Blank the current table field or active region                             |
-| ~SPC m t c~   | Convert from =org-mode= table to table.el and back                         |
-| ~SPC m t d c~ | Delete a column from the table                                             |
-| ~SPC m t d r~ | Delete the current row or horizontal line from the table                   |
-| ~SPC m t e~   | Replace the table field value at the cursor by the result of a calculation |
-| ~SPC m t E~   | Export table to a file, with configurable format                           |
-| ~SPC m t f~   | Show table field info                                                      |
-| ~SPC m t h~   | Go to the previous field in the table                                      |
-| ~SPC m t H~   | Move column to the left                                                    |
-| ~SPC m t i c~ | Insert a new column into the table                                         |
-| ~SPC m t i h~ | Insert a horizontal-line below the current line into the table             |
-| ~SPC m t i H~ | Insert a hline and move to the row below that line                         |
-| ~SPC m t i r~ | Insert a new row above the current line into the table                     |
-| ~SPC m t I~   | Import a file as a table                                                   |
-| ~SPC m t j~   | Go to the next row (same column) in the current table                      |
-| ~SPC m t J~   | Move table row down                                                        |
-| ~SPC m t K~   | Move table row up                                                          |
-| ~SPC m t l~   | Go to the next field in the current table, creating new lines as needed    |
-| ~SPC m t L~   | Move column to the right                                                   |
-| ~SPC m t n~   | Query for a size and insert a table skeleton                               |
-| ~SPC m t N~   | Use the table.el package to insert a new table                             |
-| ~SPC m t p~   | Plot the table using org-plot/gnuplot                                      |
-| ~SPC m t r~   | Recalculate the current table line by applying all stored formulas         |
-| ~SPC m t s~   | Sort table lines according to the column at point                          |
-| ~SPC m t t f~ | Toggle the formula debugger in tables                                      |
-| ~SPC m t t o~ | Toggle the display of Row/Column numbers in tables                         |
-| ~SPC m t w~   | Wrap several fields in a column like a paragraph                           |
+| Key binding   | Description                                                                  |
+|---------------+------------------------------------------------------------------------------|
+| ~SPC m t a~   | Align the table at point by aligning all vertical bars                       |
+| ~SPC m t b~   | Blank the current table field or active region                               |
+| ~SPC m t c~   | Convert from =org-mode= table to table.el and back                           |
+| ~SPC m t d c~ | Delete a column from the table                                               |
+| ~SPC m t d r~ | Delete the current row or horizontal line from the table                     |
+| ~SPC m t e~   | Replace the table field value at the cursor by the result of a calculation   |
+| ~SPC m t E~   | Export table to a file, with configurable format                             |
+| ~SPC m t f~   | Show table field info                                                        |
+| ~SPC m t h~   | Go to the previous field in the table                                        |
+| ~SPC m t H~   | Move column to the left                                                      |
+| ~SPC m t i c~ | Insert a new column into the table                                           |
+| ~SPC m t i h~ | Insert a horizontal-line below the current line into the table               |
+| ~SPC m t i H~ | Insert a hline and move to the row below that line                           |
+| ~SPC m t i r~ | Insert a new row above the current line into the table                       |
+| ~SPC m t I~   | Import a file as a table                                                     |
+| ~SPC m t j~   | Go to the next row (same column) in the current table                        |
+| ~SPC m t J~   | Move table row down                                                          |
+| ~SPC m t K~   | Move table row up                                                            |
+| ~SPC m t l~   | Go to the next field in the current table, creating new lines as needed      |
+| ~SPC m t L~   | Move column to the right                                                     |
+| ~SPC m t n~   | Query for a size and insert a table skeleton                                 |
+| ~SPC m t N~   | Use the table.el package to insert a new table                               |
+| ~SPC m t p~   | Plot the table using org-plot/gnuplot                                        |
+| ~SPC m t r~   | Recalculate the current table line by applying all stored formulas           |
+| ~SPC m t R~   | Recalculate all tables in the current buffer by applying all stored formulas |
+| ~SPC m t s~   | Sort table lines according to the column at point                            |
+| ~SPC m t t f~ | Toggle the formula debugger in tables                                        |
+| ~SPC m t t o~ | Toggle the display of Row/Column numbers in tables                           |
+| ~SPC m t w~   | Wrap several fields in a column like a paragraph                             |
 
 ** Trees
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -290,6 +290,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "tn" 'org-table-create
         "tN" 'org-table-create-with-table.el
         "tr" 'org-table-recalculate
+        "tR" 'org-table-recalculate-buffer-tables
         "ts" 'org-table-sort-lines
         "ttf" 'org-table-toggle-formula-debugger
         "tto" 'org-table-toggle-coordinate-overlays


### PR DESCRIPTION
Add tR hotkey for org-table-recalculate-buffer-tables. Without this
hotkey, there isn't an easy way to recalculate all of the calculated
fields within a table at once.

The tr hotkey for org-table-recalculate is only for recalculating a
single field within the table.

I used this page from the manual as a reference:
https://orgmode.org/manual/Updating-the-table.html#Updating-the-table
