### PR TITLE
Fix major-mode set key prefix documentation

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1115,11 +1115,12 @@ key-discovery tools can use (e.g., which-key).
 Example to create binding in major mode:
 
 #+BEGIN_SRC emacs-lisp
-  (spacemacs/declare-prefix-for-mode 'org-mode "o" "custom")
+  (spacemacs/declare-prefix-for-mode 'org-mode "mo" "custom")
   (spacemacs/set-leader-keys-for-major-mode 'org-mode "oi" 'org-id-get-create)
 #+END_SRC
 
-This would add binding as ~, oi~ and ~SPC moi~.
+This would add binding as ~, oi~ and ~SPC moi~ (note that the "m" in the prefix
+declaration must be include).
 
 There is much more to say about bindings keys, but these are the basics. Keys
 can be bound in your =~/.spacemacs= file or in individual layers.


### PR DESCRIPTION
The documentation for setting a prefix for major-mode keybinding is wrong.
Although it would be logical when using `spacemacs/declare-prefix-for-mode` to omit the "m" (for `SPC m` or `,`) in the keybinding definition, it currently does not work that way. Omitting the "m" results in a prefix named "prefix" instead of the desired prefix name. Because all (correct functioning) layers (e.g. org and pdf layer) define the prefix including the "m", it is probably best to just correct the documentation (instead of correcting the `spacemacs/declare-prefix-for-mode` function definition)