### PR TITLE
[core][tide][lsp] improve spacemacs/set-leader-keys-for-minor-mode and apply it to tide and lsp layers

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -166,12 +166,28 @@ they are in `spacemacs/set-leader-keys'."
 `dotspacemacs-major-mode-emacs-leader-key' for the minor-mode
 MODE. MODE should be a quoted symbol corresponding to a valid
 minor mode. The rest of the arguments are treated exactly like
-they are in `spacemacs/set-leader-keys'."
+they are in `spacemacs/set-leader-keys'. If DEF is string, then
+it is treated as a prefix not a command."
   (let* ((map (intern (format "spacemacs-%s-map" mode))))
     (when (spacemacs//init-leader-mode-map mode map t)
-      (while key
-        (define-key (symbol-value map) (kbd key) def)
-        (setq key (pop bindings) def (pop bindings))))))
+      (let ((map-value (symbol-value map)))
+        (while key
+          (if (stringp def)
+              (which-key-add-keymap-based-replacements map-value key def)
+            (define-key map-value (kbd key) def))
+          (setq key (pop bindings) def (pop bindings)))))))
 (put 'spacemacs/set-leader-keys-for-minor-mode 'lisp-indent-function 'defun)
+
+(defun spacemacs/declare-prefix-for-minor-mode (mode prefix name)
+  "Declare a prefix PREFIX. MODE is the mode in which this prefix command should
+be added. PREFIX is a string describing a key sequence. NAME is a symbol name
+used as the prefix command.
+
+Example:
+  \(spacemacs/declare-prefix-for-minor-mode 'tide-mode \"E\" \"errors\"\)"
+
+  (let* ((map (intern (format "spacemacs-%s-map" mode))))
+    (when (spacemacs//init-leader-mode-map mode map t)
+      (which-key-add-keymap-based-replacements (symbol-value map) prefix name))))
 
 (provide 'core-keybindings)

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -22,7 +22,6 @@
     rjsx-mode
     smartparens
     tern
-    tide
     web-beautify
     yasnippet
     ))
@@ -103,10 +102,6 @@
 
 (defun react/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'rjsx-mode))
-
-(defun react/post-init-tide ()
-  (when (eq (spacemacs//typescript-backend) `tide)
-    (add-to-list 'tide-managed-modes 'rjsx-mode)))
 
 (defun react/pre-init-web-beautify ()
   (when (eq javascript-fmt-tool 'web-beautify)

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -31,7 +31,6 @@
     prettier-js
     skewer-mode
     tern
-    tide
     web-beautify))
 
 (defun javascript/post-init-add-node-modules-path ()
@@ -262,10 +261,6 @@
 
 (defun javascript/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'js2-mode))
-
-(defun javascript/post-init-tide ()
-  (when (eq (spacemacs//typescript-backend) `tide)
-    (add-to-list 'tide-managed-modes 'js2-mode)))
 
 (defun javascript/pre-init-web-beautify ()
   (when (eq javascript-fmt-tool 'web-beautify)

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -20,7 +20,6 @@
         typescript-mode
         import-js
         web-mode
-        tide
         yasnippet
         ))
 
@@ -139,8 +138,3 @@
       (progn
         (add-to-list 'spacemacs--import-js-modes (cons 'typescript-mode 'typescript-mode-hook))
         (add-to-list 'spacemacs--import-js-modes (cons 'typescript-tsx-mode 'typescript-tsx-mode-hook)))))
-
-(defun typescript/post-init-tide ()
-  (when (eq (spacemacs//typescript-backend) 'tide)
-    (add-to-list 'tide-managed-modes 'typescript-mode)
-    (add-to-list 'tide-managed-modes 'typescript-tsx-mode)))

--- a/layers/+tools/lsp/config.el
+++ b/layers/+tools/lsp/config.el
@@ -22,4 +22,3 @@ If `both', binds lightweight navigation functions under `SPC m g' and lsp-ui fun
 (defvar lsp-ui-sideline-enable t "Enable/disable lsp-ui-sideline overlay")
 (defvar lsp-ui-sideline-show-symbol nil "When non-nil, sideline includes symbol info (largely redundant for c modes)")  ; don't show symbol on the right of info
 (defvar lsp-ui-sideline-ignore-duplicate t "Ignore duplicates")
-(defvar lsp-layer--active-mode-list nil "internal variable to store active major modes")

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -36,31 +36,38 @@
 
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
     ;; format
+    "=" "format"
     "=b" #'lsp-format-buffer
     "=r" #'lsp-format-region
     "=o" #'lsp-organize-imports
     ;; code actions
+    "a" "code actions"
     "aa" #'lsp-execute-code-action
     "af" #'spacemacs//lsp-action-placeholder
     "ar" #'spacemacs//lsp-action-placeholder
     "as" #'spacemacs//lsp-action-placeholder
     ;; goto
     ;; N.B. implementation and references covered by xref bindings / lsp provider...
+    "g" "goto"
     "gt" #'lsp-find-type-definition
     "gk" #'spacemacs/lsp-avy-goto-word
     "gK" #'spacemacs/lsp-avy-goto-symbol
     "gM" #'lsp-ui-imenu
     ;; help
+    "h" "help"
     "hh" #'lsp-describe-thing-at-point
     ;; jump
     ;; backend
+    "b" "backend"
     "bd" #'lsp-describe-session
     "br" #'lsp-workspace-restart
     "bs" #'lsp-workspace-shutdown
     "bv" #'lsp-version
     ;; refactor
+    "r" "refactor"
     "rr" #'lsp-rename
     ;; toggles
+    "T" "toggle"
     "Td" #'lsp-ui-doc-mode
     "Ts" #'lsp-ui-sideline-mode
     "TF" #'spacemacs/lsp-ui-doc-func
@@ -68,10 +75,12 @@
     "TI" #'spacemacs/lsp-ui-sideline-ignore-duplicate
     "Tl" #'lsp-lens-mode
     ;; folders
+    "F" "folder"
     "Fs" #'lsp-workspace-folders-switch
     "Fr" #'lsp-workspace-folders-remove
     "Fa" #'lsp-workspace-folders-add
     ;; text/code
+    "x" "text/code"
     "xh" #'lsp-document-highlight
     "xl" #'lsp-lens-show
     "xL" #'lsp-lens-hide))
@@ -97,6 +106,7 @@
 
 (defun spacemacs//lsp-bind-peek-navigation-functions (prefix-char)
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
+    "G" "peek"
     (concat prefix-char "i") #'lsp-ui-peek-find-implementation
     (concat prefix-char "d") #'lsp-ui-peek-find-definitions
     (concat prefix-char "r") #'lsp-ui-peek-find-references
@@ -105,24 +115,6 @@
     (concat prefix-char "b") #'lsp-ui-peek-jump-backward
     (concat prefix-char "e") #'lsp-ui-flycheck-list
     (concat prefix-char "n") #'lsp-ui-peek-jump-forward))
-
-(defun spacemacs//lsp-declare-prefixes-for-mode (mode)
-  "Define key binding prefixes for the specific MODE."
-  (unless (member mode lsp-layer--active-mode-list)
-    (add-to-list 'lsp-layer--active-mode-list mode)
-    (spacemacs/declare-prefix-for-mode mode "m=" "format")
-    (spacemacs/declare-prefix-for-mode mode "ma" "code actions")
-    (spacemacs/declare-prefix-for-mode mode "mb" "backend")
-    (spacemacs/declare-prefix-for-mode mode "mF" "folder")
-    (spacemacs/declare-prefix-for-mode mode "mg" "goto")
-    (spacemacs/declare-prefix-for-mode mode "mG" "peek")
-    (spacemacs/declare-prefix-for-mode mode "mh" "help")
-    (spacemacs/declare-prefix-for-mode mode "mr" "refactor")
-    (spacemacs/declare-prefix-for-mode mode "mT" "toggle")
-    (spacemacs/declare-prefix-for-mode mode "mx" "text/code")
-    (dolist (prefix '("mg" "mG"))
-      (spacemacs/declare-prefix-for-mode mode (concat prefix "h") "hierarchy")
-      (spacemacs/declare-prefix-for-mode mode (concat prefix "m") "members"))))
 
 (defun spacemacs//lsp-bind-extensions-for-mode (mode
                                                 layer-name

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -27,9 +27,8 @@
       (spacemacs/lsp-bind-keys)
       (setq lsp-prefer-capf t)
       (add-hook 'lsp-after-open-hook (lambda ()
-                                       "Setup xref jump handler and declare keybinding prefixes"
-                                       (spacemacs//setup-lsp-jump-handler)
-                                       (spacemacs//lsp-declare-prefixes-for-mode major-mode))))))
+                                       "Setup xref jump handler"
+                                       (spacemacs//setup-lsp-jump-handler))))))
 
 (defun lsp/init-lsp-ui ()
   (use-package lsp-ui

--- a/layers/+tools/tide/config.el
+++ b/layers/+tools/tide/config.el
@@ -10,17 +10,6 @@
 ;;; License: GPLv3
 
 ;; variables
-
-(defvar tide-managed-modes '(
-                            ;; typescript-mode
-                            ;; typescript-tsx-mode
-                            ;; js2-mode
-                            ;; js-mode
-                            ;; rjsx-mode
-                            )
-  "List of major modes that `tide layer` can manage.
-Client layers must add its major-mode to this list")
-
 (defvar tide-jsconfig-content
   "{\n\
     \"compilerOptions\": {\n\

--- a/layers/+tools/tide/funcs.el
+++ b/layers/+tools/tide/funcs.el
@@ -9,29 +9,26 @@
 ;;
 ;;; License: GPLv3
 
-(defun spacemacs//tide-setup-prefix ()
-  "This one should run only once, otherwise `which-key' will become very slow #12455"
-  (dolist (mode tide-managed-modes)
-    (spacemacs/declare-prefix-for-mode mode "mE" "errors")
-    (spacemacs/declare-prefix-for-mode mode "mg" "goto")
-    (spacemacs/declare-prefix-for-mode mode "mh" "help")
-    (spacemacs/declare-prefix-for-mode mode "mn" "name")
-    (spacemacs/declare-prefix-for-mode mode "mr" "refactor")
-    (spacemacs/declare-prefix-for-mode mode "mS" "server")))
-
 (defun spacemacs//tide-setup-bindings ()
   "Define keys bindings for `tide-mode'"
   (spacemacs/set-leader-keys-for-minor-mode 'tide-mode
+    "E" "errors"
     "Ee" #'tide-fix
     "Ed" #'tide-add-tslint-disable-next-line
+    "Ep" #'tide-project-errors
+    "g" "goto"
+    "ge" #'tide-project-errors
     "gb" #'tide-jump-back
     "gg" #'tide-jump-to-definition
     "gt" #'spacemacs/typescript-jump-to-type-def
     "gr" #'tide-references
+    "h" "help"
     "hh" #'tide-documentation-at-point
+    "r" "refactor"
     "ri" #'tide-organize-imports
     "rr" #'tide-rename-symbol
     "rf" #'tide-rename-file
+    "S" "server"
     "Sr" #'tide-restart-server
     "Sj" #'spacemacs//tide-create-jsconfig-file))
 

--- a/layers/+tools/tide/packages.el
+++ b/layers/+tools/tide/packages.el
@@ -18,6 +18,5 @@
     :defer t
     :commands (typescript/jump-to-type-def)
     :config
-    (spacemacs//tide-setup-prefix)
     (spacemacs//tide-setup-bindings)
     (spacemacs//tide-setup-jump-handle)))


### PR DESCRIPTION
There are three commits in this PR. The first one is the most important, the other two are demonstration of the improvement.

## Commit 1
This commit added add a new function defun `spacemacs/declare-prefix-for-minor-mode` and improved `spacemacs/set-leader-keys-for-minor-mode`.

`which-key` package recently introduced a new api `which-key-add-keymap-based-replacements` which improves performance and allows prefix and namings to be stored directly in keymap. This is a great improvement.

With this new api we now make change to `spacemacs/declare-prefix-for-minor-mode` to manage prefix also. For example:
``` elisp
  (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
    "=" "format"
    "=b" #'lsp-format-buffer)
````
Before we had to use another api to bind prefix `spacemacs/declare-prefix-for-mode` which only works on major-mode. As `lsp-mode` is a minor mode this api causes a lot of problems to `which-key` performance. An example is https://github.com/syl20bnr/spacemacs/issues/12455 which led to my hack in https://github.com/syl20bnr/spacemacs/pull/12474.

The improved `spacemacs/set-leader-keys-for-minor-mode` will take care of both prefix and key naming for the minor mode. This will allows us to have a better set up for dynamic minor modes such as `lsp-mode`, `tide-mode` etc.

Also another api is created to make prefix for minor mode: `spacemacs/declare-prefix-for-minor-mode`.

Usage:
```` elisp
(spacemacs/declare-prefix-for-minor-mode 'tide-mode "E" "errors")"
````
## Commit 2 
Apply improved api to tide layer

## Commit 3 
Apply improved api to lsp layer
