### PR TITLE
[core] add z$ as Evil keybinding for set-selective-display

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -521,6 +521,10 @@ Other:
     terminal mode, but no longer in GUI mode. (emacs18)
 *** Core changes
 - Improvements:
+  - Make =set-selective-display=, which is a kind of built-in Emacs quick-n-dirty
+    whole-file folding mechanism for indentation-based syntaxes, more
+    discoverable for Evil users by placing it in the folding menu as ~z f~ (thanks
+    to Keith Pinson)
   - Provide keybindings for using narrow with an indirect buffer for when you
     want narrowing multiple times in the same base buffer:
     - ~SPC n F~ for narrow to function

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -523,8 +523,8 @@ Other:
 - Improvements:
   - Make =set-selective-display=, which is a kind of built-in Emacs quick-n-dirty
     whole-file folding mechanism for indentation-based syntaxes, more
-    discoverable for Evil users by placing it in the folding menu as ~z f~ (thanks
-    to Keith Pinson)
+    discoverable for Evil users by placing it (with a small DWIM wrapper) in the
+    folding menu as ~z $~ (thanks to Keith Pinson)
   - Provide keybindings for using narrow with an indirect buffer for when you
     want narrowing multiple times in the same base buffer:
     - ~SPC n F~ for narrow to function

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -230,3 +230,18 @@ the scroll transient state.")
       (use-package-concat
        body
        `((spacemacs|spacebind ,@args))))))
+
+
+
+;; As suggested in the Emacs wiki https://www.emacswiki.org/emacs/HideShow#toc5
+(defun spacemacs/toggle-selective-display (column)
+  "Toggle selective display by column, a.k.a. folding by indentation.
+
+Invokes `set-selective-display', but if a prefix argument is not supplied and
+`selective-display' is not already true, source the prefix argument from the
+column."
+  (interactive "P")
+  (set-selective-display
+   (or column
+       (unless selective-display
+         (1+ (current-column))))))

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -94,7 +94,7 @@
   ;; Make the current definition and/or comment visible.
   (define-key evil-normal-state-map "zf" 'reposition-window)
   ;; Make set-selective-display more discoverable to Evil folks
-  (define-key evil-normal-state-map "z$" 'set-selective-display)
+  (define-key evil-normal-state-map "z$" 'spacemacs/toggle-selective-display)
   ;; toggle maximize buffer
   (define-key evil-window-map (kbd "o") 'spacemacs/toggle-maximize-buffer)
   (define-key evil-window-map (kbd "C-o") 'spacemacs/toggle-maximize-buffer)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -93,6 +93,8 @@
 
   ;; Make the current definition and/or comment visible.
   (define-key evil-normal-state-map "zf" 'reposition-window)
+  ;; Make set-selective-display more discoverable to Evil folks
+  (define-key evil-normal-state-map "z$" 'set-selective-display)
   ;; toggle maximize buffer
   (define-key evil-window-map (kbd "o") 'spacemacs/toggle-maximize-buffer)
   (define-key evil-window-map (kbd "C-o") 'spacemacs/toggle-maximize-buffer)


### PR DESCRIPTION
This is a feature whose equivalent I had looked for previously and not found. I bumped into it in [this excellent article](https://karthinks.com/software/batteries-included-with-emacs/) which is a survey of "batteries included" parts of Emacs. He mentions Spacemacs (in a positive light) in the article, but the article is about what you can do _without_ distributions like Spacemacs, Doom, or Prelude. As such, this seems like an opportunity to make Spacemacs even better---i.e. by making these relatively unknown batteries that are already present in Emacs more discoverable in Spacemacs.

I put it in the folding menu `z` because that fits its usecase. I used `$` because:
* the out-of-the-box Emacs keybindings is `C-x $`.
* the menu is already fairly saturated
* I didn't know what else to base the mnemonic on because
  * I'm not aware of a Vim equivalent
  * The name of the Emacs function itself is nondescriptive of its behavior

I couldn't find any keybinding documentation table to add it to. Please let me know if I missed something.