### PR TITLE
Add dired-quick-sort layer

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -29,3 +29,4 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for conversion between Emacs regexps and PCRE regexps.
 - Support for persistent scratch via =persistent-scratch=.
 - Support for unkillable scratch via =unkillable-scratch=.
+- In =dired-mode=, press ~Shift S~ to select sorting.

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -14,6 +14,7 @@
         avy
         (bracketed-paste :toggle (version<= emacs-version "25.0.92"))
         (clean-aindent-mode :toggle dotspacemacs-use-clean-aindent-mode)
+        dired-quick-sort
         editorconfig
         eval-sexp-fu
         expand-region
@@ -98,6 +99,12 @@
     (progn
       (clean-aindent-mode)
       (add-hook 'prog-mode-hook 'spacemacs//put-clean-aindent-last t))))
+
+(defun spacemacs-editing/init-dired-quick-sort ()
+  (use-package dired-quick-sort
+    :defer t
+    :init
+    (dired-quick-sort-setup)))
 
 (defun spacemacs-editing/init-editorconfig ()
   (use-package editorconfig


### PR DESCRIPTION
This layer helps quickly sorting Dired buffers in various ways, such as
time, size, etc.
I think the underlying package is useful and worth a place in spacemacs.
It has also been promoted by Pragmatic Emacs before (albeit long time
ago): http://pragmaticemacs.com/emacs/speedy-sorting-in-dired-with-dired-quick-sort/

Disclaimer: I'm the author of dired-quick-sort package