### PR TITLE
Revert helm-ag and helm-grep search results window binding of RET to default

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -211,7 +211,6 @@
 
       ;; evilify the helm-grep buffer
       (evilified-state-evilify helm-grep-mode helm-grep-mode-map
-        (kbd "RET") 'helm-grep-mode-jump-other-window
         (kbd "q") 'quit-window)
 
       (spacemacs/set-leader-keys
@@ -273,7 +272,6 @@
       (advice-add 'helm-ag--save-results :after 'spacemacs//gne-init-helm-ag)
       (evil-define-key 'normal helm-ag-map "SPC" spacemacs-default-map)
       (evilified-state-evilify helm-ag-mode helm-ag-mode-map
-        (kbd "RET") 'helm-ag-mode-jump-other-window
         (kbd "gr") 'helm-ag--update-save-results
         (kbd "q") 'quit-window))))
 


### PR DESCRIPTION
Currently 'helm-ag-mode-jump-other-window is bound both to RET and to C-o (its
original default binding), while 'helm-ag-mode-jump isn't bound at all (its
original default binding is RET).  This commit removes our customization so that
both 'helm-ag-mode-jump-other-window and 'helm-ag-mode-jump have bindings in the
mode.