### PR TITLE
[clojure] add namespace eval and reload key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1668,6 +1668,12 @@ Other:
     ~SPC m v l~ 'cider-inspect-last-result
     ~SPC m v v~ 'cider-inspect-expr
     (thanks to John Stevenson)
+  - Add key bindings for existing cider namespace functions
+    ~SPC m e n a~ 'cider-ns-reload-all
+    ~SPC m e n n~ 'cider-eval-ns-form
+    ~SPC m e n r~ 'cider-ns-refresh
+    ~SPC m e n l~ 'cider-ns-reload
+    (thanks to John Stevenson)
 - Fixes:
   - Removed =cider.nrepl/cider-middleware= in lein quick start setting
   - Fixed =cider-inspector-prev-page= binding, also add ~p~ as another key

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -495,8 +495,10 @@ Evaluate Clojure code in the source code buffer
 | ~SPC m e l~   | go to end of line and eval last sexp                              |
 | ~SPC m e m~   | cider macroexpand 1                                               |
 | ~SPC m e M~   | cider macroexpand all                                             |
-| ~SPC m e n~   | refresh namespace (cider-ns-refresh)                              |
-| ~SPC m e N~   | reload namespace (cider-ns-reload), ~SPC u~ (cider-ns-reload-all) |
+| ~SPC m e n a~ | reload all namespaces (cider-ns-reload-all)                       |
+| ~SPC m e n n~ | eval current namespace form (cider-eval-ns-form)                  |
+| ~SPC m e n r~ | refresh namespace (cider-ns-refresh)                              |
+| ~SPC m e n l~ | reload namespace (cider-ns-reload), ~SPC u~ (cider-ns-reload-all) |
 | ~SPC m e p ;~ | eval top-level sexp, pretty print result as a comment             |
 | ~SPC m e p :~ | eval last sexp, pretty print result as a comment                  |
 | ~SPC m e p f~ | eval top-level sexp, pretty print result in separate buffer       |

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -69,6 +69,7 @@
                ("md" . "debug")
                ("mdv" . "inspect values")
                ("me" . "evaluation")
+               ("men" . "namespace")
                ("mep" . "pretty print")
                ("mg" . "goto")
                ("mh" . "documentation")
@@ -117,8 +118,10 @@
             "el" 'spacemacs/cider-eval-sexp-end-of-line
             "em" 'cider-macroexpand-1
             "eM" 'cider-macroexpand-all
-            "en" 'cider-ns-refresh
-            "eN" 'cider-ns-reload  ;; SPC u for cider-ns-reload-all
+            "ena" 'cider-ns-reload-all
+            "enn" 'cider-eval-ns-form
+            "enr" 'cider-ns-refresh
+            "enl" 'cider-ns-reload  ;; SPC u for cider-ns-reload-all
             "ep;" 'cider-pprint-eval-defun-to-comment
             "ep:" 'cider-pprint-eval-last-sexp-to-comment
             "epf" 'cider-pprint-eval-defun-at-point


### PR DESCRIPTION
Add key binding to evaluate the current namespace form (very useful when
starting CIDER as it loads in clojure.core to enable the cider-clojure-docs
functions to work)

Add keybinding to reload all namespaces into the REPL process

Adjusted key bindings to be lower case under `en` sub-menu.