### PR TITLE
[react] Set layer keymaps: javascript as parent to react

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3141,6 +3141,8 @@ files (thanks to Daniel Nicolai)
     - ~SPC m g i~ to go to the module of the variable under cursor
     (thanks to Seong Yong-ju)
   - Added ~SPC m r l t~ for =js2r-log-this= (thanks to Mike Holm)
+  - Set the =javascript= layers keymap as parent to the =react= layers keymap
+    (thanks to duianto)
 - Fixes:
   - Use JSX header without breaking React (thanks to Jam Risser)
   - Fixed React imports when using web beautify. (thanks to Ismael)

--- a/layers/+frameworks/react/README.org
+++ b/layers/+frameworks/react/README.org
@@ -127,6 +127,8 @@ concatenations and contiguous function calls:
 
 * Key bindings
 ** rjsx-mode
+   The =javascript= layers keymap is set as the parent of the =react= layers keymap.
+   Check the [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/+lang/javascript/README.org#key-bindings][javascript layers documentation]] for additional key bindings.
 
 | Key binding   | Description                                                                      |
 |---------------+----------------------------------------------------------------------------------|

--- a/layers/+frameworks/react/packages.el
+++ b/layers/+frameworks/react/packages.el
@@ -77,13 +77,34 @@
     (when javascript-fmt-on-save
       (add-hook 'rjsx-mode-local-vars-hook #'spacemacs//react-fmt-before-save-hook))
 
+    ;; set the javascript layers keymap as parent to the react layers keymap
+    (set-keymap-parent spacemacs-rjsx-mode-map spacemacs-js2-mode-map)
+
     :config
-    ;; declare prefix
-    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mr" "refactor")
+    ;; declare prefixes
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "m="  "format")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mT"  "toggle")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "me"  "eval")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mg"  "goto")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mh"  "documentation")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mr"  "refactor")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mr3" "ternary")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mra" "add/args")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrb" "barf")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrc" "contract")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mre" "expand/extract")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mri" "inline/inject/introduct")
     (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrl" "localize/log")
     (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrr" "rename")
-    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mh" "documentation")
-    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrs" "split/slurp")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrt" "toggle")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mru" "unwrap")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrv" "var")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mrw" "wrap")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "ms"  "skewer")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mx"  "text")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mxm" "move")
+    (spacemacs/declare-prefix-for-mode 'rjsx-mode "mz"  "folding")
 
     (spacemacs/set-leader-keys-for-major-mode 'rjsx-mode "rlt" 'js2r-log-this)
     (spacemacs/set-leader-keys-for-major-mode 'rjsx-mode "rt" 'rjsx-rename-tag-at-point)


### PR DESCRIPTION
Declared key binding prefixes.
And updated the react layer documentation:
- Mentioned the additional key bindings in the javascript layer
- Added a link to the javascript layer

Fixes: 
React layer does not inherit keybindings from javascript layer #14103

Before:
![before](https://user-images.githubusercontent.com/13420573/100014505-be117b00-2dd6-11eb-88de-76da2f904743.png)

After:
![after](https://user-images.githubusercontent.com/13420573/100014518-c1a50200-2dd6-11eb-92af-52cdde47fdd1.png)
