### PR TITLE
[git] fix magit-mode-map void value

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -148,14 +148,6 @@
     (spacemacs/set-leader-keys
       "gfi" 'gitignore-templates-new-file)))
 
-(defun git/post-init-magit ()
-  ;; Remove inherited bindings from evil-mc and evil-easymotion
-  (which-key-add-keymap-based-replacements magit-mode-map
-    "<normal-state> g r" nil
-    "<visual-state> g r" nil
-    "<normal-state> g s" nil
-    "<visual-state> g s" nil))
-
 (defun git/init-magit ()
   (use-package magit
     :defer (spacemacs/defer)
@@ -271,7 +263,13 @@
       (evil-define-key 'normal magit-section-mode-map (kbd "M-6") 'winum-select-window-6)
       (evil-define-key 'normal magit-section-mode-map (kbd "M-7") 'winum-select-window-7)
       (evil-define-key 'normal magit-section-mode-map (kbd "M-8") 'winum-select-window-8)
-      (evil-define-key 'normal magit-section-mode-map (kbd "M-9") 'winum-select-window-9))))
+      (evil-define-key 'normal magit-section-mode-map (kbd "M-9") 'winum-select-window-9)
+      ;; Remove inherited bindings from evil-mc and evil-easymotion
+      (which-key-add-keymap-based-replacements magit-mode-map
+        "<normal-state> g r" nil
+        "<visual-state> g r" nil
+        "<normal-state> g s" nil
+        "<visual-state> g s" nil))))
 
 (defun git/init-magit-delta ()
   (use-package magit-delta


### PR DESCRIPTION
Minor fix for regression from https://github.com/syl20bnr/spacemacs/commit/be908875cb2d7f5f7210c19101aed01c747bb7df

use-package is lazy so post-init-magit will not see magit-mode-map value

