### PR TITLE
[core] Fix package update restart message

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2172,8 +2172,11 @@ to update."
         (spacemacs-buffer/append
          (format
           (concat "\nEmacs has to be restarted to actually install the "
-                  "new version of the packages%s.\n")
-          (if (member "restart-emacs" update-packages) "" " (SPC q r)")))
+                  "new version of the packages %s.\n")
+          (if (member 'restart-emacs update-packages)
+              (concat "\n(SPC q r) won't work this time, "
+                      "because the restart-emacs package is being updated")
+            "(SPC q r)")))
         (configuration-layer//cleanup-rollback-directory)
         (spacemacs//redisplay)))
     (when (eq upgrade-count 0)


### PR DESCRIPTION
### Problem:
When the restart-emacs package is being updated.

The update packages restart message, still shows the (SPC q r) key binding even
though it doesn't work.

### Cause:
The member function compared a string against a list of symbols.

### A possible improvement:
Explain that the key binding won't work this time.

### Before:
Emacs has to be restarted to actually install the new version of the packages (SPC q r).

### After:
Emacs has to be restarted to actually install the new version of the packages
(SPC q r) won't work this time, because the restart-emacs package is being updated.