### PR TITLE
[core] Update dotfile, font :size comment: int vs float

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -227,7 +227,9 @@ It should only modify the values of Spacemacs settings."
    ;; (default t)
    dotspacemacs-colorize-cursor-according-to-state t
 
-   ;; Default font or prioritized list of fonts.
+   ;; Default font or prioritized list of fonts. The `:size' can be specified as
+   ;; a non-negative integer (pixel size), or a floating-point (point size).
+   ;; Point size is recommended, because it's device independent. (default 10.0)
    dotspacemacs-default-font '("Source Code Pro"
                                :size 10.0
                                :weight normal


### PR DESCRIPTION
Add a comment about the font :size difference between:
integer (pixel size)
floating-point (point size)

Point size is recommended, because it's device independent.

source:
https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/XLFD/xlfd.html

Thanks libensterben for the info about point size being device independent.
#14142 (comment)

The font size comment was requested in:
ui/font is too small in default .spacemacs even with all prerequisites #14142