### PR TITLE
In navigation layer, Bind J/K to scroll up/down in Info-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -317,6 +317,9 @@ sane way, here is the complete list of changed key bindings
   - Changed =projectile-rails= key binding prefix from ~SPC m r~ to ~SPC m f~
     to avoid conflicts with key bindings in the =web-mode= layer
     (thanks to Adam Sokolnicki)
+***** Spacemacs-navigation
+- Key bindings:
+  - Add ~J/K~ to scroll up/down (or next/previous node) in Info-mode
 ***** Shaders
 - =shaders= layer has been moved to =gpu= layer.
 ***** Syntax checking

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2042,6 +2042,8 @@ Navigation key bindings in =help-mode=:
 
 | Key binding  | Description                                         |
 |--------------+-----------------------------------------------------|
+| ~J~          | Scroll up (or next node)                            |
+| ~K~          | Scroll down (or next node)                          |
 | ~g b~ or ~[~ | go back (same as clicking on =[back]= button)       |
 | ~g f~ or ~]~ | go forward (same as clicking on =[forward]= button) |
 | ~g h~        | go to help for symbol under point                   |

--- a/layers/+spacemacs/spacemacs-navigation/local/info+/info+.el
+++ b/layers/+spacemacs/spacemacs-navigation/local/info+/info+.el
@@ -982,6 +982,8 @@
 (define-key Info-mode-map "?"               'describe-mode) ; Don't use `Info-summary'.
 (define-key Info-mode-map "+"               'Info-merge-subnodes)
 (define-key Info-mode-map "."               'Info-save-current-node)
+(define-key Info-mode-map "J"               'Info-scroll-up)
+(define-key Info-mode-map "K"               'Info-scroll-down)
 (define-key Info-mode-map "a"               'info-apropos)
 (define-key Info-mode-map "G"               'Info-goto-node-web)
 (define-key Info-mode-map "O"               'Info-toc-outline)


### PR DESCRIPTION
Spacemacs lacks a keybinding alternative to the most natural way of scrolling
Info pages (i.e. SPC) in vanilla Emacs.
This commit adds J/K to scroll most naturally through info pages.
Currently, in Info-mode, a keybinding for J is not defined while K is bound to
evil-lookup.

Issue #2828 already addresses the inconsistent experience, and in my opinion this
can and should be improved as navigating Info pages is a very crucial part of
using Emacs.

Personally I have bound J/K to scroll page up/down in buffers/pdf/djvu/doc-view,
which I inherited from using the zathura pdf reader, and I think this is a better
default than the default vim alternatives.