### PR TITLE
Fix fsharp-mode auto-completion unreliable

### DIFF
--- a/layers/+lang/fsharp/funcs.el
+++ b/layers/+lang/fsharp/funcs.el
@@ -19,20 +19,16 @@
 
 (defun spacemacs//fsharp-setup-company ()
   "Conditionally setup company based on backend."
-  (pcase (spacemacs//fsharp-backend)
-    ;; Activate lsp company explicitly to activate
-    ;; standard backends as well
-    (`lsp (spacemacs|add-company-backends
-            :backends company-capf
-            :modes fsharp-mode))))
+  ;; Activate lsp company explicitly to activate
+  ;; standard backends as well
+  ;; Eglot and LSP-mode use the same company-backend.
+    (spacemacs|add-company-backends
+      :backends company-capf
+      :modes fsharp-mode
+      :variables company-tooltip-align-annotations t))
 
 (defun spacemacs//fsharp-setup-backend ()
   "Conditionally setup fsharp backend."
   (pcase (spacemacs//fsharp-backend)
     (`lsp (lsp))
-    (_ (spacemacs/fsharp-eglot-jack-in))))
-
-(defun spacemacs/fsharp-eglot-jack-in ()
-  "Start a new Eglot server instance or reconnect."
-  (interactive)
-  (call-interactively 'eglot))
+    (_ (eglot-ensure))))


### PR DESCRIPTION
First off I want to thank @smile13241324 for taking the time to make lsp
working with the fsharp layer!

Unfortunately the eglot configuration for automatically starting a server instance when
opening a file is not quite right. It tries to start the server twice which leads
to more problems down the line. Also the company-backend is not properly setup
so auto-completion does not work reliably when using lsp or eglot.

I also found an upstream issue in fsharp-mode which causes problems with
company-mode. I already created a [pull request](https://github.com/fsharp/emacs-fsharp-mode/pull/255) to fix that and hope that it will be
merged soon.