### PR TITLE
Use valign to align tables in spacemacs-org layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -778,6 +778,8 @@ Other:
   - Remove package =adaptive-wrap=
   - Added =symbol-overlay= to the =spacemacs-navigation= layer
     (thanks to kenkangxgwe)
+  - Added =valign= package to =spacemacs-org= layer
+    (thanks to rayw000)
 - Key bindings:
   - Evilify =Custom-mode= (thanks to Keith Pinson)
   - Fixed ~M-x~ prefix visualization for ~dotspacemacs-emacs-command-key~

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -25,6 +25,7 @@
     org-superstar
     (space-doc :location local)
     toc-org
+    valign
     ))
 
 (defun spacemacs-org/post-init-flyspell ()
@@ -74,6 +75,14 @@
     (progn
       (setq toc-org-max-depth 10)
       (add-hook 'org-mode-hook 'toc-org-enable))))
+
+(defun spacemacs-org/init-valign ()
+  (use-package valign
+    :init
+    (progn
+      (add-hook 'org-mode-hook 'valign-mode)
+      (add-hook 'valign-mode-hook (lambda () (unless valign-mode
+                                               (valign-remove-advice)))))))
 
 (defun spacemacs-org/init-space-doc ()
   (add-hook 'org-mode-hook 'dotspacemacs//prettify-spacemacs-docs))


### PR DESCRIPTION
Currently org mode tables are not well aligned when they contain non-ascii characters, like this:

![image](https://user-images.githubusercontent.com/69779107/101605008-9eb45800-3a3c-11eb-9c7f-55aa231ebf15.png)

With package [valign](https://github.com/casouri/valign), we can make things better.

![image](https://user-images.githubusercontent.com/69779107/101604916-847a7a00-3a3c-11eb-8e0d-027b7349c46c.png)

