### PR TITLE
[markdown] fix: mmm clobbering comment-start in Markdown Git commit

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2592,6 +2592,8 @@ files (thanks to Daniel Nicolai)
 - Improvements:
   - Evilfied =dap= debug windows
 **** Markdown
+- Disable =mmm-mode= in Git commit buffers, in order to allow the use of Markdown
+  mode when committing (thanks to Keith Pinson)
 - New layer variable =markdown-mmm-auto-modes= which is a list of language names
   or lists of language and mode names that are supported in source blocks, you
   can add you own modes, see layer README.org for more info

--- a/layers/+lang/markdown/funcs.el
+++ b/layers/+lang/markdown/funcs.el
@@ -10,8 +10,9 @@
 ;;; License: GPLv3
 
 (defun spacemacs/activate-mmm-mode ()
+  (unless git-commit-mode
   ;; Enable `mmm-mode'.
-  (mmm-mode 1))
+    (mmm-mode 1)))
 
 ;; stolen from http://stackoverflow.com/a/26297700
 ;; makes markdown tables saner via orgtbl-mode


### PR DESCRIPTION
Fixes #14195; see there for details.

I'm open to a higher-fidelity way to check that it is performing a Git commit.
