### PR TITLE
[ivy] improve key bindings

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -228,6 +228,7 @@
       (define-key ivy-minibuffer-map [escape] 'minibuffer-keyboard-quit)
       (define-key ivy-minibuffer-map (kbd "M-SPC") 'hydra-ivy/body)
       (define-key ivy-minibuffer-map (kbd "C-<return>") #'ivy-alt-done)
+      (define-key ivy-minibuffer-map (kbd "C-SPC") #'ivy-call-and-recenter)
 
       (when ivy-ret-visits-directory
         (define-key ivy-minibuffer-map (kbd "RET") #'ivy-alt-done)
@@ -239,6 +240,9 @@
       ;; Occur
       (evil-set-initial-state 'ivy-occur-grep-mode 'normal)
       (evil-make-overriding-map ivy-occur-mode-map 'normal)
+      (dolist (mode-map (list ivy-occur-mode-map ivy-occur-grep-mode-map))
+        (define-key mode-map "g" nil)
+        (define-key mode-map "U" 'ivy-occur-revert-buffer))
       (ivy-set-occur 'spacemacs/counsel-search
                      'spacemacs//counsel-occur)
       (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode


### PR DESCRIPTION
bind `C-SPC` to  `ivy-call-and-recenter`
this is the closest thing to helm follow mode in ivy world

unbind `g` key and map `U` for
`for ivy-occur-mode-map` and `ivy-occur-grep-mode-map`