### PR TITLE
[spacemacs-evil] add evil-collection

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -64,6 +64,8 @@
   ;; evil-mode is mandatory for Spacemacs to work properly
   ;; evil must be require explicitly, the autoload seems to not
   ;; work properly sometimes.
+  ;; `evil-collection' wants this value
+  (setq evil-want-keybinding nil)
   (require 'evil)
   (evil-mode 1)
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -11,7 +11,7 @@
 
 (setq git-packages
       '(
-        evil-magit
+        evil-collection
         fill-column-indicator
         ;; forge requires a C compiler on Windows so we disable
         ;; it by default on Windows.
@@ -43,26 +43,8 @@
     :post-config
     (add-to-list 'golden-ratio-exclude-buffer-names " *transient*")))
 
-(defun git/pre-init-evil-magit ()
-  (spacemacs|use-package-add-hook magit
-    :post-config
-    (when (spacemacs//support-evilified-buffer-p dotspacemacs-editing-style)
-      (evil-magit-init))
-    (evil-define-key 'motion magit-mode-map
-      (kbd dotspacemacs-leader-key) spacemacs-default-map)
-    ;; Remove inherited bindings from evil-mc and evil-easymotion
-    ;; do this after the config to make sure the keymap is available
-    (which-key-add-keymap-based-replacements magit-mode-map
-      "<normal-state> g r" nil
-      "<visual-state> g r" nil
-      "<normal-state> g s" nil
-      "<visual-state> g s" nil)))
-
-(defun git/init-evil-magit ()
-  (use-package evil-magit
-    :defer t
-    :init (add-hook 'spacemacs-editing-style-hook
-                    'spacemacs//magit-evil-magit-bindings)))
+(defun git/pre-init-evil-collection ()
+  (add-to-list 'spacemacs-evil-collection-allowed-list 'magit))
 
 (defun git/post-init-fill-column-indicator ()
   (add-hook 'git-commit-mode-hook 'fci-mode))

--- a/layers/+spacemacs/spacemacs-evil/README.org
+++ b/layers/+spacemacs/spacemacs-evil/README.org
@@ -5,6 +5,8 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#install][Install]]
+- [[#note-about-evil-collection][Note about evil-collection]]
 
 * Description
 This layer adds various adjustments to packages to create an evilified experience
@@ -31,3 +33,34 @@ throughout the entirety of Spacemacs.
 - Improves the comment function to be able to also do the inverse operation
 - Persistent highlight of searched text with =evil-search-highlight-persist=
 - Display tildes in non-buffer area with =vi-tilde-fringe=
+- Add =evil-collection=
+  
+* Install
+The =spacemacs-evil= layer is included by default in the Spacemacs distribution.
+
+* Note about evil-collection
+[[https://github.com/emacs-evil/evil-collection][evil-collection]] is a collection of Evil bindings for the parts of Emacs that
+Evil does not cover properly by default, such as help-mode, M-x calendar, Eshell
+and more.
+
+However, there is a large overlap of features provided by both =Spacemacs= and
+=evil-collection=. For the same feature, =Spacemacs= implementation is often better
+than =evil-collection=.
+
+That's said, when =evil-collection= is used carefully we can reduce the amount of
+effort wasted on ~reinventing the wheel~ on =Spacemacs= side.
+
+Spacemacs provides a layer variable =spacemacs-evil-collection-allowed-list= for
+users and layer hackers to enable evil-collection on their desired modes.
+
+For users, if you want to enable evil-collection on =eglot=, then you will need
+to declare this layer with it variable explicitly:
+
+#+begin_example elisp
+  (spacemacs-evil :variables
+                      spacemacs-evil-collection-allowed-list
+                     '(eglot))
+#+end_example
+
+For Spacemacs hackers check out git layer to see how we apply =evil-collection= to
+=magit.=

--- a/layers/+spacemacs/spacemacs-evil/config.el
+++ b/layers/+spacemacs/spacemacs-evil/config.el
@@ -18,3 +18,6 @@
 
 (defvar evil-lisp-safe-structural-editing-modes '()
   "A list of major mode symbols where safe structural editing is supported.")
+
+(defvar spacemacs-evil-collection-allowed-list '(eww)
+  "List of modes Spacemacs will allow to be evilified by ‘evil-collection-init’.")

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -13,6 +13,7 @@
       '(
         evil-anzu
         evil-args
+        evil-collection
         evil-cleverparens
         evil-ediff
         evil-escape
@@ -98,6 +99,14 @@
   (use-package evil-ediff
     :after (ediff)
     :if (memq dotspacemacs-editing-style '(hybrid vim))))
+
+
+(defun spacemacs-evil/init-evil-collection ()
+  (use-package evil-collection
+    :after evil
+    :config
+    (setq evil-collection-mode-list spacemacs-evil-collection-allowed-list)
+    (evil-collection-init)))
 
 (defun spacemacs-evil/init-evil-escape ()
   (use-package evil-escape

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -17,6 +17,7 @@
     (eshell :location built-in)
     eshell-prompt-extras
     eshell-z
+    evil-collection
     helm
     ivy
     magit
@@ -129,6 +130,9 @@
       ;; automatically truncate buffer after output
       (when (boundp 'eshell-output-filter-functions)
         (add-hook 'eshell-output-filter-functions #'eshell-truncate-buffer)))))
+
+(defun shell/pre-init-evil-collection ()
+  (add-to-list 'spacemacs-evil-collection-allowed-list 'vterm))
 
 (defun shell/init-eshell-prompt-extras ()
   (use-package eshell-prompt-extras


### PR DESCRIPTION
It is impossible to ignore `evil-collection` anymore. `evil-magit` has been
deprecated recently and moved to `evil-collection`.

It will save time and effort for both Spacemacs and Evil to share and contribute
to `evil-collection` imo.

However I strongly prefer Spacemacs binding scheme over evil-collection's one.
We should only pick what we need from `evil-collection`.

This PR add mechanism to embrace `evil-collection` and apply it to shell layer (`vterm`)
and git layer.

Note: I still have a bug with git rebase binding. `C-j` and `C-k` are note bound to move commits. Must use `C-n` and C-p` instead. Not sure if it is our bug or `evil-collection's