### PR TITLE
dumb-jump: Replace obsolete interface with xref-backend

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2228,7 +2228,6 @@ The ~SPC j~ prefix is for jumping, joining and splitting.
 | ~SPC j j~   | jump to one or more characters in the buffer (works as an evil motion)            |
 | ~SPC j k~   | jump to next line and indent it using auto-indent rules                           |
 | ~SPC j l~   | jump to a line with avy (works as an evil motion)                                 |
-| ~SPC j q~   | show the dumb-jump quick look tooltip                                             |
 | ~SPC j u~   | jump to a URL in the current buffer                                               |
 | ~SPC j U~   | select a URL in the current buffer and follow it                                  |
 | ~SPC j v~   | jump to the definition/declaration of an Emacs Lisp variable                      |

--- a/layers/+frameworks/vue/funcs.el
+++ b/layers/+frameworks/vue/funcs.el
@@ -38,7 +38,7 @@
 
 ;; dumb
 
-(defun spacemacs//vue-setup-dumb-imenu ()
+(defun spacemacs//vue-setup-dumb ()
   (setq imenu-generic-expression '(("html" "^<template>$" 0)
                                    ("js" "^<script>$" 0)
                                    ("js" "^\\s-*\\(data\\).*()\\s-?{" 1)
@@ -52,10 +52,6 @@
                                    ("js" "^\\s-*\\(props\\):\\s-?{" 1)
                                    ("css" "^<css>$" 0))
         imenu-create-index-function #'imenu-default-create-index-function))
-
-(defun spacemacs//vue-setup-dumb ()
-  (add-to-list 'spacemacs-jump-handlers-vue-mode 'dumb-jump-go)
-  (spacemacs//vue-setup-dumb-imenu))
 
 (defun spacemacs//vue-setup-dumb-company ()
   (spacemacs|add-company-backends :backends (company-web-html company-css company-files company-dabbrev)

--- a/layers/+lang/clojure/funcs.el
+++ b/layers/+lang/clojure/funcs.el
@@ -200,12 +200,12 @@ If called with a prefix argument, uses the other-window instead."
 (defun spacemacs/clj-find-var (sym-name &optional arg)
   "Attempts to jump-to-definition of the symbol-at-point.
 
-If CIDER fails, or not available, falls back to dumb-jump."
+If CIDER fails, or not available, falls back to dumb-jump's xref interface."
   (interactive (list (cider-symbol-at-point)))
   (if (and (cider-connected-p) (cider-var-info sym-name))
       (unless (eq 'symbol (type-of (cider-find-var nil sym-name)))
-        (dumb-jump-go))
-    (dumb-jump-go)))
+        (xref-find-definitions))
+    (xref-find-definitions)))
 
 (defun spacemacs/clj-describe-missing-refactorings ()
   "Inform the user to add clj-refactor to configuration"

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -15,7 +15,7 @@
 ;; will still be bound to 'latex-mode (since AUCTeX uses an advice to override
 ;; latex-mode with TeX-latex-mode), so the keymap's name should use the
 ;; lowercase form, since bind-map uses the value of major-mode...
-(spacemacs|define-jump-handlers latex-mode dumb-jump-go)
+(spacemacs|define-jump-handlers latex-mode)
 ;; ...but AUCTeX runs LaTeX-mode-hook rather than latex-mode-hook, so:
 (add-hook 'LaTeX-mode-hook #'spacemacs//init-jump-handlers-latex-mode)
 

--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -13,20 +13,14 @@
       '(
         devdocs
         dumb-jump
-        request
-        ))
+        request))
+
 
 (defun spacemacs-misc/init-dumb-jump ()
   (use-package dumb-jump
     :defer t
     :init
     (progn
-      ;; not activating `dumb-jump-mode' because it only adds key bindings, and
-      ;; they conflict with existing bindings (see
-      ;; https://github.com/syl20bnr/spacemacs/issues/7107)
-
-      (spacemacs/set-leader-keys "jq" #'dumb-jump-quick-look)
-
       ;; Use Helm or Ivy as the selector for dumb-jump.
       (cond
        ((configuration-layer/layer-used-p 'ivy)
@@ -34,10 +28,9 @@
        ((configuration-layer/layer-used-p 'helm)
         (setq dumb-jump-selector 'helm)))
 
-      ;; Since it's dumb, we add it to the end of the default jump handlers. At
-      ;; the time of writing it is the only default jump handler. (gtags remains
-      ;; mode-local)
-      (add-to-list 'spacemacs-default-jump-handlers 'dumb-jump-go 'append))))
+      ;; Enable xref-backend of dumb-jump. It's chosen only when no better
+      ;; options is available
+      (add-hook 'xref-backend-functions #'dumb-jump-xref-activate))))
 
 (defun spacemacs-misc/init-request ()
   (setq request-storage-directory


### PR DESCRIPTION
- Add `dumb-jump-xref-activate` hook to `xref-backend-functions`, which
  add a fallback option, i.e. `dumb-jump`, when no better alternatives
  is available
- Removed the obsolete interface `dumb-jump-go` from the following layers:
  - clojure
  - latex
  - vue
- The global binding `SPC j q` requires the obsolete function
  `dumb-jump-quick-look` and is therefore removed