### PR TITLE
Make valign-mode opt-out in org-mode-hook

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1238,6 +1238,8 @@ Other:
   - Refactor layers/+chat|email|fun|readers|web-services packages to use
     relative key binding, migrating most key bindings to lower cases and
     expanding room for further aliases (thanks to John Stevenson)
+  - Added a =org-enable-valign= variable to make =valign-mode= opt-out
+    in org-mode-hook (thanks to Claude Ray)
 - Fixed:
   - Fixed ~h~ key binding in compilation and grep buffers
     (thanks to Sylvain Benner)

--- a/layers/+spacemacs/spacemacs-org/config.el
+++ b/layers/+spacemacs/spacemacs-org/config.el
@@ -12,4 +12,4 @@
 ;; Variables
 
 (defvar org-enable-valign t
-  "If non-nil, enable valign-mode in org-mode buffers by default.")
+  "If non-nil, enable valign-mode in org-mode buffers.")

--- a/layers/+spacemacs/spacemacs-org/config.el
+++ b/layers/+spacemacs/spacemacs-org/config.el
@@ -1,0 +1,15 @@
+;;; config.el --- spacemacs-org layer configuration file for Spacemacs.
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;; Variables
+
+(defvar org-enable-valign t
+  "If non-nil, enable valign-mode in org-mode buffers by default.")

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -80,7 +80,8 @@
   (use-package valign
     :init
     (progn
-      (add-hook 'org-mode-hook 'valign-mode)
+      (when org-enable-valign
+        (add-hook 'org-mode-hook 'valign-mode))
       (add-hook 'valign-mode-hook (lambda () (unless valign-mode
                                                (valign-remove-advice)))))))
 


### PR DESCRIPTION
valign-mode is nice, but it could affect the performance when scaling in a big org buffer.

Add an opt-out for people who want to toggle valign-mode manually. 
