### PR TITLE
Improving org-mu4e integration

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -10,6 +10,7 @@
   - [[#global-bindings][Global bindings]]
   - [[#headers-mode][Headers mode]]
   - [[#view-mode][View mode]]
+  - [[#compose-mode][Compose mode]]
 - [[#configuration][Configuration]]
   - [[#maildirs-extension][Maildirs extension]]
   - [[#multiple-accounts][Multiple Accounts]]
@@ -20,6 +21,9 @@
     - [[#os-notifications][OS notifications]]
     - [[#mode-line-notifications][Mode-line notifications]]
   - [[#spacemacs-layout-integration][Spacemacs layout integration]]
+  - [[#org-mu4e-integration][Org-mu4e integration]]
+    - [[#mu4e-link-support-in-org-mode][Mu4e link support in Org mode]]
+    - [[#composing-org-mode-messages-in-mu4e][Composing Org mode messages in mu4e]]
 - [[#see-also][See also]]
 
 * Description
@@ -84,6 +88,16 @@ existing =dotspacemacs-configuration-layers= list in this file.
 | ~J~         | Go to next unread thread marking other mail read on the way |
 | ~C-j~       | Next header                                                 |
 | ~C-k~       | Previous header                                             |
+
+** Compose mode
+
+| Key binding            | Command                        |
+|------------------------+--------------------------------|
+| ~SPC m c~ or ~SPC m ,~ | Send the message and exit      |
+| ~SPC m k~ or ~SPC m a~ | Kill the message buffer        |
+| ~SPC m s~              | Auto-save and bury the message |
+| ~SPC m f~              | Add file as attachment         |
+| ~SPC m o~              | Compose in Org-mode syntax    |
 
 * Configuration
 Configuration varies too much to give precise instructions. What follows is one
@@ -279,6 +293,37 @@ By default the values are:
                         mu4e-spacemacs-layout-binding "m"
                         mu4e-spacemacs-kill-layout-on-exit t)))
 #+END_SRC
+
+** Org-mu4e integration
+
+*** Mu4e link support in Org mode
+
+Feature ~mu4e-org~ supports links to mu4e messages in Org mode in the form of
+~[[mu4e:msgid::***][link text]]~. Enabled by default. You can disable it by
+setting the ~mu4e-org-link-support~ variable when including the layer.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((mu4e :variables
+                        mu4e-org-link-support nil)))
+#+END_SRC
+
+*** Composing Org mode messages in mu4e
+
+Feature ~org-mu4e~ supports composing emails in Org mode format. Disabled by
+default. You can enable it by setting the ~mu4e-org-compose-support~ variable
+when including the layer.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((mu4e :variables
+                        mu4e-org-compose-support t)))
+#+END_SRC
+
+Then when composing, hit keys ~SPC m o~ to enable the
+~org-mu4e-compose-org-mode~ mode. Note that you need to set the variable
+~org-mu4e-convert-to-html~ if you want the message to be converted before
+sending.
 
 * See also
 Refer to the official =mu= and =mu4e= documentation for additional info.

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -45,5 +45,11 @@
   '(append 'mu4e-list-modes 'mu4e-view-modes)
   "Modes that are associated with mu4e buffers.")
 
+(defvar mu4e-org-link-support t
+  "If non-nil mu4e-org is configured.")
+
+(defvar mu4e-org-compose-support nil
+  "If non-nil org-mu4e is configured.")
+
 (when mu4e-installation-path
   (add-to-list 'load-path mu4e-installation-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -50,7 +50,8 @@
       (setq mu4e-completing-read-function 'completing-read
             mu4e-use-fancy-chars 't
             mu4e-view-show-images 't
-            message-kill-buffer-on-exit 't)
+            message-kill-buffer-on-exit 't
+            mu4e-org-support nil)
       (let ((dir "~/Downloads"))
         (when (file-directory-p dir)
           (setq mu4e-attachment-dir dir))))
@@ -150,10 +151,20 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
     :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load))))
 
 (defun mu4e/pre-init-org ()
-  ;; load mu4e-org when org is actually loaded
-  (with-eval-after-load 'org
-    (require 'mu4e nil 'noerror)
-    (require 'mu4e-org nil 'noerror)))
+  (if mu4e-org-link-support
+      (with-eval-after-load 'org
+        (require 'mu4e-org)
+        ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
+        ;; Note that this bug prevents lazy-loading.
+        (require 'mu4e-meta)
+        (if (version<= mu4e-mu-version "1.4.13")
+            (require 'mu4e))))
+  (if mu4e-org-compose-support
+      (progn
+        (spacemacs/set-leader-keys-for-major-mode 'mu4e-compose-mode
+          "o" 'org-mu4e-compose-org-mode)
+        (autoload 'org-mu4e-compose-org-mode "org-mu4e")
+        )))
 
 (defun mu4e/post-init-window-purpose ()
   (let ((modes))


### PR DESCRIPTION
This pull request addresses issue #13913.

Changes:
1. Added two configuration variables for the mu4e layer to control mu4e-org integration.
2. Optionally configures mu4e compose mode to support Org-mode syntax.
3. Improves lazy-loading of relevant features. E.g. loading org-mode does not automatically trigger loading of mu4e.