### PR TITLE
Add evil consistent navigate history keybindings to pdf-layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2966,6 +2966,8 @@ files (thanks to Daniel Nicolai)
 - Fixed ~'~ =pdf-view-jump-to-register= (thanks to duianto)
 - Key bindings:
   - Added to pdf-view mode and transient state
+    - ~C-o~ history-backward (previous view)
+    - ~C-i~ history-forward (next view)
     - ~[~ history-backward (previous view)
     - ~]~ history-forward (next view)
     - ~?~ toggle transient sate documentation hint (shown by default)

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -121,8 +121,8 @@ If you use Emacs editing style, check the key bindings at the [[https://github.c
 | ~m~                  | Set mark                                  |
 | ~'~                  | Go to mark                                |
 | ~y~                  | Yank selected region                      |
-| ~[~                  | History back                              |
-| ~]~                  | History forward                           |
+| ~C-o~ or ~[~         | History back                              |
+| ~C-i~ or ~]~         | History forward                           |
 |----------------------+-------------------------------------------|
 | *Search*             |                                           |
 |----------------------+-------------------------------------------|

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -72,6 +72,8 @@
         (kbd "C-u") 'pdf-view-scroll-down-or-previous-page
         (kbd "C-d") 'pdf-view-scroll-up-or-next-page
         (kbd "``")  'pdf-history-backward
+        (kbd "C-o") 'pdf-history-backward
+        (kbd "C-i") 'pdf-history-forward
         "["  'pdf-history-backward
         "]"  'pdf-history-forward
         "'" 'pdf-view-jump-to-register


### PR DESCRIPTION
The `C-o` and `C-i` are free in the pdf-view mode, and these keybindings are probably more intuitive to evil users for jumping the history.

The current keybindings for jumping the history, `[` and `]`, were also added by me. I thought back then that `C-o` and `C-i` were not available (don't know how I got that idea). Those keybindings can be removed, but I chose to keep them here.

Although this PR binds `C-i` and even though I have set `dotspacemacs-distinguish-gui-tab t` in my dotfile, pressing `C-i` tells me that the keybinding is undefined while `TAB` does work. Anyway, I think the definitions in this PR are consistent with evil. 