### PR TITLE
Add ace-link-man keybinding to navigation layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -320,6 +320,7 @@ sane way, here is the complete list of changed key bindings
 ***** Spacemacs-navigation
 - Key bindings:
   - Add ~J/K~ to scroll up/down (or next/previous node) in Info-mode
+  - Add ~o~ to link-hint-open-link in woman-mode
 ***** Shaders
 - =shaders= layer has been moved to =gpu= layer.
 ***** Syntax checking

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2174,9 +2174,9 @@ selecting an avy candidate.
 Similar to =avy=, [[https://github.com/abo-abo/ace-link][ace-link]] allows one to jump to any link in
 =help-mode= and =info-mode=.
 
-| Key binding | Description                                           |
-|-------------+-------------------------------------------------------|
-| ~o~         | initiate ace link mode in =help-mode= and =info-mode= |
+| Key binding | Description                                                 |
+|-------------+-------------------------------------------------------------|
+| ~o~         | initiate ace link mode in =help-=, =info-= and =woman-mode= |
 
 *** Unimpaired bindings
 Spacemacs comes with a built-in port of [[https://github.com/tpope/vim-unimpaired][tpope's vim-unimpaired]].

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -34,12 +34,14 @@
     (progn
       (define-key spacemacs-buffer-mode-map "o" 'spacemacs/ace-buffer-links)
       (with-eval-after-load 'info
-        (define-key Info-mode-map "o" 'ace-link-info))
+        (define-key Info-mode-map "o" 'ace-link))
       (with-eval-after-load 'help-mode
-        (define-key help-mode-map "o" 'ace-link-help))
+        (define-key help-mode-map "o" 'ace-link))
+      (with-eval-after-load 'woman
+        (define-key woman-mode-map "o" 'link-hint-open-link))
       (with-eval-after-load 'eww
-        (define-key eww-link-keymap "o" 'ace-link-eww)
-        (define-key eww-mode-map "o" 'ace-link-eww)))))
+        (define-key eww-link-keymap "o" 'ace-link)
+        (define-key eww-mode-map "o" 'ace-link)))))
 
 (defun spacemacs-navigation/init-ace-window ()
   (use-package ace-window


### PR DESCRIPTION
Initially I added an ace-link-man keybinding to Man-mode. However, `ace-link-man` (as well as `ace-link`) only activates links to other man pages, but not url's. Therefore I changed it to `link-hint-open-link` in woman-mode as with this combination all links are activated correctly (using this command in man-mode also does not activate url's). An example man page that contains links to other man pages as well as url's is the ocrodjvu man page.