### PR TITLE
Add auto hide tabs feature to tabs layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -329,6 +329,8 @@ sane way, here is the complete list of changed key bindings
   - Move major specific error key bindings to ~SPC m E~ prefix
     (thanks to Sylvain Benner)
   - Changed ~SPC e e~ to ~SPC e b~ for =flycheck-buffer=
+***** Tabs
+- Add auto hide tabs feature (thanks to Daniel Nicolai)
 ***** Vagrant
 - Key bindings:
   - Vagrant key bindings prefix is now ~SPC a V~.
@@ -390,6 +392,7 @@ sane way, here is the complete list of changed key bindings
 - prolog (thanks to Newres Al Haider)
 - reasonml (thanks to fredyr and Dave Aitken)
 - solidity (thanks to Brooklyn Zelenka and Seong Yong-ju)
+- tabs (thanks to Deepu Puthrote)
 - protobuf (thanks to Amol Mandhane)
 - restructuredtext (thanks to Wei-Wei Guo and Kalle Lindqvist)
 - semantic-web (thanks to Andreas Textor)

--- a/layers/+emacs/tabs/README.org
+++ b/layers/+emacs/tabs/README.org
@@ -14,6 +14,7 @@ This layer adds support for tabs. Implementation is done using [[https://github.
 
 ** Features:
 - Sets up tabs using Centaur tabs as backend
+- Optionally auto hide tabs after delay
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -23,6 +24,15 @@ file.
 * Hide tabs
 You can set hooks for buffers in which it isn't desired to have tabs by
 customizing =centaur-tabs-hide-tabs-hooks=
+
+Alternatively you can set ~tabs-auto-hide~ to ~t~ to auto hide tabs after some
+delay ~tabs-auto-hide-delay~ via the :variables keyword in your dotfile:
+#+begin_src emacs-lisp
+     (tabs :variables
+           tabs-auto-hide t
+           tabs-auto-hide-delay 3)
+#+end_src
+
 
 * Key bindings
 

--- a/layers/+emacs/tabs/config.el
+++ b/layers/+emacs/tabs/config.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(defvar tabs-navigation nil
+(defvaralias 'tabs-navigation 'centaur-tabs-cycle-scope
   "*Specify the scope of cyclic navigation through tabs.
 The following scopes are possible:
 
@@ -20,38 +20,44 @@ The following scopes are possible:
 - nil
     Navigate through visible tabs, then through tab groups.")
 
-(defvar tabs-gray-out-unselected nil
-  "When non nil, enable gray icons for unselected buffer.")
+(defvaralias 'tabs-gray-out-unselected 'centaur-tabs-gray-out-icons)
 
-(defvar tabs-height 22
-  "The height of tab")
+(defvaralias 'tabs-height 'centaur-tabs-height)
 
-(defvar tabs-show-icons t
-  "When non nil, show icon from all-the-icons")
+(defvaralias 'tabs-show-icons 'centaur-tabs-set-icons)
 
-(defvar tabs-set-modified-marker t
-  "When non nil, display a marker when buffer is modified")
+(defvaralias 'tabs-set-modified-marker 'centaur-tabs-set-modified-marker)
 
-(defvar tabs-modified-marker "⚠"
-  "Display appearance of modified marker if enabled")
+(defvaralias 'tabs-modified-marker 'centaur-tabs-modified-marker)
 
-(defvar tabs-show-navigation-buttons nil
-  "When non-nil, show buttons for backward/forward tabs")
+(defvaralias 'tabs-show-navigation-buttons 'centaur-tabs-show-navigation-buttons)
 
-(defvar tabs-style "bar"
-  "Style of tab; available values are \"bar\", \"alternate\", \"box\", \"chamfer\", \"rounded\", \"slant\", \"wave\", \"zigzag\" ")
+(defvaralias 'tabs-style 'centaur-tabs-style
+  "Style of tab.
+Available values are \"bar\", \"alternate\", \"box\",
+\"chamfer\", \"rounded\", \"slant\", \"wave\", \"zigzag\" ")
 
-(defvar tabs-group-by-project t
-  "When non-nil, group tabs by projectile project. Default t.
-   If non-nil calls (centaur-tabs-group-by-projectile-project)
-   Otherwise calls (centaur-tabs-group-buffer-groups)")
+(defvaralias 'tabs-set-bar 'centaur-tabs-set-bar)
 
-(defvar tabs-headline-match t
-  "When non-nil, make headline use centaur-tabs-default-face. Default t. Calls (centaur-tabs-headline-match)")
+(defcustom tabs-group-by-project t
+  "When non-nil, group tabs by projectile project.
+Default t. If non-nil calls (tabs-group-by-projectile-project)
+Otherwise calls (tabs-group-buffer-groups)"
+:type '(boolean)
+:group 'tabs)
 
-(defvar tabs-set-bar 'left
-  "When non-nil, display a bar to show currently selected tab.
-  There are three options:
-  - 'left: displays the bar at the left of the currently selected tab.
-  - 'under: displays the bar under the currently selected tab.
-  - 'over: displays the bar over the currently selected tab.")
+(defcustom tabs-headline-match t
+  "When non-nil, make headline use tabs-default-face. Default t.
+Calls (tabs-headline-match)"
+:type '(boolean)
+:group 'tabs)
+
+(defcustom tabs-auto-hide nil
+  "If non-nil hide tabs automatically after TABS-AUTO-HIDE-DELAY seconds."
+  :type '(boolean)
+  :group 'tabs)
+
+(defcustom tabs-auto-hide-delay 2
+  "Tabs auto hide delay in seconds."
+  :type '(float)
+  :group 'tabs)

--- a/layers/+emacs/tabs/funcs.el
+++ b/layers/+emacs/tabs/funcs.el
@@ -1,0 +1,45 @@
+(defun spacemacs//tabs-timer-initialize (secs)
+  (setq spacemacs-tabs-timer (run-with-timer secs nil (lambda () (centaur-tabs-local-mode 1)))))
+
+(defun spacemacs//tabs-timer-hide ()
+  (spacemacs//tabs-timer-initialize tabs-auto-hide-delay))
+
+(defun spacemacs//tabs-switch-and-hide (arg)
+  (cancel-timer spacemacs-tabs-timer)
+  (centaur-tabs-local-mode 1)
+  ;; (if arg
+  ;;     (centaur-tabs-backward)
+  ;;   (centaur-tabs-forward))
+  (pcase arg
+    ('backward (centaur-tabs-backward))
+    ('forward (centaur-tabs-forward))
+    ('backward-group (centaur-tabs-backward-group))
+    ('forward-group (centaur-tabs-forward-group)))
+  (centaur-tabs-local-mode 0)
+  (spacemacs//tabs-timer-hide))
+
+(defun spacemacs//centaur-tabs-forward-and-hide ()
+  (spacemacs//tabs-switch-and-hide 'forward))
+
+(defun spacemacs//centaur-tabs-backward-and-hide ()
+  (spacemacs//tabs-switch-and-hide 'backward))
+
+(defun spacemacs/tabs-forward ()
+  (interactive)
+  (if tabs-auto-hide
+      (spacemacs//centaur-tabs-forward-and-hide)
+    (centaur-tabs-forward)))
+
+(defun spacemacs/tabs-backward ()
+  (interactive)
+  (if tabs-auto-hide
+      (spacemacs//centaur-tabs-backward-and-hide)
+    (centaur-tabs-backward)))
+
+(defun spacemacs/tabs-forward-group-and-hide ()
+  (interactive)
+  (spacemacs//tabs-switch-and-hide 'forward-group))
+
+(defun spacemacs/tabs-backward-group-and-hide ()
+  (interactive)
+  (spacemacs//tabs-switch-and-hide 'backward-group))

--- a/layers/+emacs/tabs/packages.el
+++ b/layers/+emacs/tabs/packages.el
@@ -16,24 +16,24 @@
   (use-package centaur-tabs
     :demand
     :config
-    (setq centaur-tabs-cycle-scope tabs-navigation
-          centaur-tabs-gray-out-icons tabs-gray-out-unselected
-          centaur-tabs-height tabs-height
-          centaur-tabs-modified-marker tabs-modified-marker
-          centaur-tabs-set-bar tabs-set-bar
-          centaur-tabs-set-icons tabs-show-icons
-          centaur-tabs-set-modified-marker tabs-set-modified-marker
-          centaur-tabs-show-navigation-buttons t
-          centaur-tabs-style tabs-style)
+    (setq tabs-show-icons t
+          tabs-set-modified-marker t
+          tabs-modified-marker "⚠"
+          tabs-set-bar 'left)
     (when tabs-headline-match
       (centaur-tabs-headline-match))
     (if tabs-group-by-project
         (centaur-tabs-group-by-projectile-project)
       (centaur-tabs-group-buffer-groups))
     (centaur-tabs-mode t)
+
+    (when tabs-auto-hide
+      (add-hook 'window-setup-hook 'spacemacs//tabs-timer-hide)
+      (add-hook 'find-file-hook 'spacemacs//tabs-timer-hide)
+      (add-hook 'change-major-mode-hook 'spacemacs//tabs-timer-hide))
     :bind
-    ("C-{" . centaur-tabs-backward)
-    ("C-}" . centaur-tabs-forward)
+    ("C-{" . spacemacs/tabs-backward)
+    ("C-}" . spacemacs/tabs-forward)
     ("C-M-{" . centaur-tabs-move-current-tab-to-left)
     ("C-M-}" . centaur-tabs-move-current-tab-to-right)
     ("C-c t s" . centaur-tabs-counsel-switch-group)


### PR DESCRIPTION
Ideally it would be great to implement tabs switch with C-tab (or C-}) that
shows the tabs as long as C is pressed. However Emacs does not support key
release events so this function uses a timer as a workaround.

To me Emacs looks better when tabs are hidden, and also packages like
pdf-continuous-scroll-mode break when tabs are shown.