### PR TITLE
Add convenient scroll keybindings to epub layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -133,6 +133,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - LSP code navigation / completion added via clangd or ccls
   (thanks to Cormac Cannon)
 - Removed cquery.
+***** EPUB
+- Add ~J/K~ for scrolling down/up (thanks to Daniel Nicolai) 
 ***** ESS
 - ESS key bindings were re-organised in the following list
   (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):

--- a/layers/+readers/epub/README.org
+++ b/layers/+readers/epub/README.org
@@ -38,8 +38,8 @@ file.
 | ~<BACKTAB>~ | Previous link       |
 | ~H~ or ~[~  | Previous chapter    |
 | ~L~ or ~]~  | Next chapter        |
-| ~u~         | Scroll up           |
-| ~d~         | Scroll down         |
+| ~K/u~      | Scroll up           |
+| ~J/d~      | Scroll down         |
 | ~g m~       | Display metadata    |
 | ~g r~       | Re-render document  |
 | ~g t~       | Table of contents   |

--- a/layers/+readers/epub/packages.el
+++ b/layers/+readers/epub/packages.el
@@ -25,6 +25,8 @@
       (kbd "]") 'nov-next-document
       (kbd "d") 'nov-scroll-up
       (kbd "u") 'nov-scroll-down
+      (kbd "J") 'nov-scroll-up
+      (kbd "K") 'nov-scroll-down
       (kbd "gm") 'nov-display-metadata
       (kbd "gr") 'nov-render-document
       (kbd "gt") 'nov-goto-toc


### PR DESCRIPTION
Similar to the keybindings added to the info layer in PR #14188, I here propose to add the same
keybindings to the epub layer. These J/K keybindings are currently undefined in the epub
layer. These keybindings are used in the Zathura document reader, they are very
convenient and I guess they feel very natural and are preferred over d/u by most people.