### PR TITLE
[base] Fix void helm-use-fuzzy

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -161,7 +161,8 @@
       (advice-add 'helm-grep-save-results-1 :after 'spacemacs//gne-init-helm-grep)
       ;; helm-locate uses es (from everything on windows which doesn't like fuzzy)
       (helm-locate-set-command)
-      (setq helm-locate-fuzzy-match (and helm-use-fuzzy (string-match "locate" helm-locate-command)))
+      (setq helm-locate-fuzzy-match (and (bound-and-true-p helm-use-fuzzy)
+                                         (string-match "locate" helm-locate-command)))
       (setq helm-boring-buffer-regexp-list
             (append helm-boring-buffer-regexp-list
                     spacemacs-useless-buffers-regexp))


### PR DESCRIPTION
problem:
The spacemacs-completion layer defines the variable:
helm-use-fuzzy

But the spacemacs-base distribution doesn't use the
spacemacs-completion layer by default.

helm-use-fuzzy is used in the helm layer.

When a helm buffer is opened, for example: `SPC SPC`
Then a warnings buffer opens:
>Error (use-package): helm/:config: Symbol’s value as variable is void: helm-use-fuzzy

solution:
Make sure that helm-use-fuzzy is bound and true.