### PR TITLE
Fix some errors in lsp/README.org

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -62,7 +62,7 @@ under the derived mode t prefix by =(spacemacs/lsp-bind-keys-for-mode mode)=
 
 | Variable name                        | Default                              | Description                                                                                                     |
 |--------------------------------------+--------------------------------------+-----------------------------------------------------------------------------------------------------------------|
-| =lsp-headerline-breadcrumb-enable=   | nil                                  | When non-nil, shows breadcrumb on headerline.                                                                   |
+| =lsp-headerline-breadcrumb-enable=   | t                                    | When non-nil, shows breadcrumb on headerline.                                                                   |
 | =lsp-headerline-breadcrumb-segments= | `'(path-up-to-project file symbols)' | Display the path to the root of project, the name of the current file, and also its symbols. See details below. |
 | =lsp-lens-enable=                    | nil                                  | When non-nil, shows code lens when it's supported.                                                              |
 | =lsp-modeline-diagnostics-enable=    | t                                    | When non-nil, shows error diagnostics in modeline.                                                              |
@@ -85,7 +85,7 @@ To always display code lens,
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-                '((lsp :variables lsp-lens-enable nil)))
+                '((lsp :variables lsp-lens-enable t)))
 #+END_SRC
 
 This doesn't have any effect when code lens is not supported by current language server.


### PR DESCRIPTION
This fixes two errors in the lsp docs:
 * `lsp-headerline-bredcrumb-enable` was recently defaulted to `t` upstream (in https://github.com/emacs-lsp/lsp-mode/pull/2416)
 * The example for `lsp-lens-enable` says it shows how to enable code lens, but it actually shows how to disable it