### PR TITLE
Disable valign in default

### DIFF
--- a/layers/+spacemacs/spacemacs-org/config.el
+++ b/layers/+spacemacs/spacemacs-org/config.el
@@ -11,5 +11,6 @@
 
 ;; Variables
 
-(defvar org-enable-valign t
-  "If non-nil, enable valign-mode in org-mode buffers.")
+(defvar org-enable-valign nil
+  "If non-nil, enable valign-mode in org-mode buffers.
+ATTENTION: `valign-mode' will be laggy working with tables contain more than 100 lines.")

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -25,7 +25,7 @@
     org-superstar
     (space-doc :location local)
     toc-org
-    valign
+    (valign :toggle org-enable-valign)
     ))
 
 (defun spacemacs-org/post-init-flyspell ()
@@ -80,8 +80,7 @@
   (use-package valign
     :init
     (progn
-      (when org-enable-valign
-        (add-hook 'org-mode-hook 'valign-mode))
+      (add-hook 'org-mode-hook 'valign-mode)
       (add-hook 'valign-mode-hook (lambda () (unless valign-mode
                                                (valign-remove-advice)))))))
 


### PR DESCRIPTION
Due to laggy working with tables containing more than 100 lines, `valign-mode` should be disabled in default.

Fix: https://github.com/syl20bnr/spacemacs/issues/14223