### PR TITLE
Use keymap based replacement for prefixes.

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -42,53 +42,23 @@ gui, translate to [C-i]. Otherwise, [9] (TAB)."
 ;;     [C-m] [?\C-m]))
 ;; (define-key key-translation-map [?\C-m] 'spacemacs/translate-C-m)
 
-(defun spacemacs/declare-prefix (prefix name &optional long-name)
+(defun spacemacs/declare-prefix (prefix name &optional _)
   "Declare a prefix PREFIX. PREFIX is a string describing a key
-sequence. NAME is a string used as the prefix command.
-LONG-NAME if given is stored in `spacemacs/prefix-titles'."
-  (let* ((command name)
-         (full-prefix (concat dotspacemacs-leader-key " " prefix))
-         (full-prefix-emacs (concat dotspacemacs-emacs-leader-key " " prefix))
-         (full-prefix-lst (listify-key-sequence (kbd full-prefix)))
-         (full-prefix-emacs-lst (listify-key-sequence
-                                 (kbd full-prefix-emacs))))
-    ;; define the prefix command only if it does not already exist
-    (unless long-name (setq long-name name))
-    (which-key-add-key-based-replacements
-      full-prefix-emacs (cons name long-name)
-      full-prefix (cons name long-name))))
+sequence. NAME is a string used as the prefix command."
+  (which-key-add-keymap-based-replacements spacemacs-default-map
+    prefix name))
 (put 'spacemacs/declare-prefix 'lisp-indent-function 'defun)
 
-(defun spacemacs/declare-prefix-for-mode (mode prefix name &optional long-name)
+(defun spacemacs/declare-prefix-for-mode (mode prefix name &optional _)
   "Declare a prefix PREFIX. MODE is the mode in which this prefix command should
 be added. PREFIX is a string describing a key sequence. NAME is a symbol name
 used as the prefix command."
-  (let  ((command (intern (concat (symbol-name mode) name)))
-         (full-prefix (concat dotspacemacs-leader-key " " prefix))
-         (full-prefix-emacs (concat dotspacemacs-emacs-leader-key " " prefix))
-         (is-major-mode-prefix (string-prefix-p "m" prefix))
-         (major-mode-prefix (concat dotspacemacs-major-mode-leader-key
-                                    " " (substring prefix 1)))
-         (major-mode-prefix-emacs
-          (concat dotspacemacs-major-mode-emacs-leader-key
-                  " " (substring prefix 1))))
-    (unless long-name (setq long-name name))
-    (let ((prefix-name (cons name long-name))
-          (is-minor-mode-prefix (not is-major-mode-prefix))
-          (smap (intern (format "spacemacs-%s-map" mode))))
-      (if (spacemacs//init-leader-mode-map mode smap is-minor-mode-prefix)
-          (which-key-add-keymap-based-replacements (symbol-value smap)
-            (if is-major-mode-prefix (substring prefix 1) prefix) `(,name))
-        (which-key-add-major-mode-key-based-replacements mode
-          full-prefix-emacs prefix-name
-          full-prefix prefix-name)
-        (when is-major-mode-prefix
-          (when dotspacemacs-major-mode-leader-key
-            (which-key-add-major-mode-key-based-replacements
-              mode major-mode-prefix prefix-name))
-          (when dotspacemacs-major-mode-emacs-leader-key
-            (which-key-add-major-mode-key-based-replacements
-              mode major-mode-prefix-emacs prefix-name)))))))
+  (let* ((is-major-mode-prefix (string-prefix-p "m" prefix))
+         (is-minor-mode-prefix (not is-major-mode-prefix))
+         (smap (intern (format "spacemacs-%s-map" mode))))
+    (when (spacemacs//init-leader-mode-map mode smap is-minor-mode-prefix)
+      (which-key-add-keymap-based-replacements (symbol-value smap)
+        (if is-major-mode-prefix (substring prefix 1) prefix) name))))
 (put 'spacemacs/declare-prefix-for-mode 'lisp-indent-function 'defun)
 
 (defun spacemacs/set-leader-keys (key def &rest bindings)


### PR DESCRIPTION
Looks like we don't need all of this code anymore. Besides it should have better performance.  Except `long-name` aren't supported, but we don't use them much anyway.