### PR TITLE
[git] Restore magit transient args between sessions

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2060,6 +2060,7 @@ Other:
     Magit diff or blame buffer (thanks to duianto and Miciah Masters)
   - Allowed multichar major mode leader key for exiting magit commit edits
     (thanks to tuh8888)
+  - Restore magit transient args between sessions (thanks to duianto)
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -335,17 +335,17 @@
         "gHh" 'smeargle-commits
         "gHt" 'smeargle))))
 
+(defun git/pre-init-transient ()
+  (setq transient-history-file (expand-file-name "transient/history.el"
+                                                 spacemacs-cache-directory))
+  (setq transient-levels-file (expand-file-name "transient/levels.el"
+                                                spacemacs-cache-directory))
+  (setq transient-values-file (expand-file-name "transient/values.el"
+                                                spacemacs-cache-directory)))
+
 (defun git/init-transient ()
   (use-package transient
-    :defer t
-    :init
-    (setq
-     transient-levels-file
-     (expand-file-name "transient/levels.el" spacemacs-cache-directory)
-     transient-values-file
-     (expand-file-name "transient/values.el" spacemacs-cache-directory)
-     transient-history-file
-     (expand-file-name "transient/history.el" spacemacs-cache-directory))))
+    :defer t))
 
 (defun git/init-forge ()
   (use-package forge


### PR DESCRIPTION
problem:
The Magit w (apply patches) arguments are not remembered between sessions.

cause:
Magit reads the transient files:
history.el, levels.el, and values.el
before Spacemacs has redirected them to the .cache directory.

solution:
Redirect the files before magit reads them.