### PR TITLE
[base] Fix evil undo

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -714,6 +714,7 @@ Other:
     (thanks to Ag Ibragimov)
   - Fixed duplicate quick help and release notes in home buffer
     (thanks to mark30247)
+  - Fixed evil undo in =spacemacs-base= (thanks to duianto)
 - Other:
   - New function =configuration-layer/message= to display message in
     =*Messages*= buffer (thanks to Sylvain Benner)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -67,7 +67,7 @@
   (require 'evil)
   (evil-mode 1)
 
-  (when (fboundp 'evil-set-undo-system)
+  (when (configuration-layer/package-used-p 'undo-tree)
     (evil-set-undo-system 'undo-tree))
 
   ;; Use evil as a default jump handler


### PR DESCRIPTION
problem:
Pressing: u
in the spacemacs-base distribution, shows:
evil-undo: Symbol’s function definition is void: undo-tree-undo

cause:
The evil undo system is setup as: undo-tree
but undo-tree is loaded in the spacemacs-editing layer,
and the layer isn't used by default in the spacemacs-base distribution.

solution:
Set the evil undo system to undo-tree when the undo-tree package is used.

Now if undo-tree isn't setup, then:
- u   uses the default Emacs undo command.
- C-r says: Customize ‘evil-undo-system’ for redo functionality.