### PR TITLE
[defaults] Prevent fullscreen on config reload

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -130,7 +130,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 (setq minibuffer-prompt-properties
       '(read-only t point-entered minibuffer-avoid-prompt face minibuffer-prompt))
 ;; Fullscreen/maximize frame on startup
-(if dotspacemacs-fullscreen-at-startup
+(when (and (not spacemacs-initialized)
+           dotspacemacs-fullscreen-at-startup)
     ;; spacemacs/toggle-fullscreen-frame-on is NOT available during the startup,
     ;; but IS available during the subsequent config reloads
     (if (fboundp 'spacemacs/toggle-fullscreen-frame-on)


### PR DESCRIPTION
problem:
Reloading the configuration: SPC f e R
after changing the variable: dotspacemacs-fullscreen-at-startup
to: t
changes Emacs into fullscreen mode.

solution:
Only check the variable and change to fullscreen mode on startup,
before Spacemacs has been initialized.

Fixes: Reloading config with fullscreen-at-startup t (in macOS) toggles fullscreen mode #13073

Additional change:
`if` was changed to `when`, because there is no else statement.