### PR TITLE
Make ipython notebook work with company-mode

### DIFF
--- a/layers/+tools/ipython-notebook/README.org
+++ b/layers/+tools/ipython-notebook/README.org
@@ -11,6 +11,7 @@
   - [[#deleting-visual-regions-dont-work-find-out-why][Deleting visual regions don't work, find out why]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#choosing-a-backend][Choosing a backend]]
   - [[#dependencies][Dependencies]]
   - [[#what-needs-to-be-run][What needs to be run]]
 - [[#using-the-ipython-notebook][Using the IPython notebook]]
@@ -34,6 +35,7 @@ lots of informative stuff.
 ** Features:
 - Key bindings available through transient-state or leader key
 - Lazy-loading
+- Auto-completion
 
 * List of TODOS
 This is a WIP, feel free to collaborate.
@@ -49,6 +51,16 @@ This is a WIP, feel free to collaborate.
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =ipython-notebook= to the existing =dotspacemacs-configuration-layers= list
 in this file.
+
+** Choosing a backend
+  To choose a default backend set the layer variable =ein-backend=:
+#+BEGIN_SRC elisp
+(ipython-notebook :variables ein-backend 'jupyter)
+#+END_SRC
+
+Currently only jupyter backend is available. If =ein-backend= is set to =jupyter=,
+jupyter backend will be enabled, otherwise no backend will be enabled.
+Jupyter backend currently only supports auto-completion features.
 
 ** Dependencies
 Install IPython Notebook > 3

--- a/layers/+tools/ipython-notebook/config.el
+++ b/layers/+tools/ipython-notebook/config.el
@@ -1,0 +1,17 @@
+;;; funcs.el --- ipython-notebook Layer Configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Senghoo Kim <me@senghoo.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(defvar ein-backend 'nil
+  "The backend to use for IDE features.
+Possible values are `jupyter' and `nil'.
+If `jupyter' then the API provided by jupyter will be used.
+If `nil' the ide feature will not be enabled.")
+

--- a/layers/+tools/ipython-notebook/funcs.el
+++ b/layers/+tools/ipython-notebook/funcs.el
@@ -1,0 +1,48 @@
+;;; funcs.el --- ipython-notebook Layer function File for Spacemacs
+;;
+;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
+;;
+;; Author: Senghoo Kim <me@senghoo.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+(when (configuration-layer/package-used-p 'company)
+
+  (defun spacemacs/ein-company (command &optional arg &rest ignore)
+    (interactive (list 'interactive))
+    (pcase command
+      (`interactive (company-begin-backend 'company-ein))
+      (`prefix
+       (and (--filter (and (boundp it) (symbol-value it) (eql it 'ein:notebook-mode))
+                      minor-mode-list)
+            (company-grab-symbol-cons "\\.\\|->\\|::" 2)))
+      (`candidates
+       (lexical-let ((kernel (ein:get-kernel-or-error))
+                     (arg arg)
+                     (col (current-column)))
+         (cons :async
+               (lambda (cb)
+                 (ein:kernel-complete
+                  kernel
+                  (string-trim-right (thing-at-point 'line t))
+                  col
+                  (list :complete_reply
+                        (list #'spacemacs//ein-company-callback cb))
+                  nil)))))))
+
+  (defun spacemacs//ein-company-callback (args content metadata)
+    (let ((matches (append (plist-get content :matches) nil)))
+      (condition-case err
+          (progn
+            (funcall (car args) matches))
+        (error (error (format "Error %s running ein company completer." err))))))
+  (defun spacemacs//ein-setup-company ()
+    (if (eq ein-backend 'jupyter)
+        (spacemacs|add-company-backends
+          :backends spacemacs/ein-company
+          :modes ein:notebook-mode
+          :append-hooks nil
+          :call-hooks t))))

--- a/layers/+tools/ipython-notebook/packages.el
+++ b/layers/+tools/ipython-notebook/packages.el
@@ -9,7 +9,7 @@
 ;;
 ;;; License: GPLv3
 
-(setq ipython-notebook-packages '(ein))
+(setq ipython-notebook-packages '(ein company))
 
 (defun ipython-notebook/init-ein ()
   (use-package ein
@@ -71,6 +71,9 @@
                          ("q" nil :exit t))
                       bindings
                       `(:doc ,(ipython-notebook/transient-doc bindings))))))))
+
+(defun ipython-notebook/post-init-company ()
+  (add-hook 'ein:notebook-mode-hook #'spacemacs//ein-setup-company))
 
 (defun ipython-notebook/max-by-prefix (alist)
   (seq-reduce (lambda (lst1 lst2) (if (> (cl-second lst1)


### PR DESCRIPTION
By using the Jupyter notebook api, the ipython-notebook layer can be auto-completed by using the company-mode
