### PR TITLE
[treemacs] Check for git and python 3 upstream

### DIFF
--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -21,13 +21,9 @@ Possible values are:
  - `Frames' - to scope treemacs to the current frame
  - `Perspectives' - to scope treemacs in conjunction with `persp-mode'.")
 
-(defvar treemacs-use-git-mode
-  (pcase (cons (not (null (executable-find "git")))
-               (not (null (executable-find "python3"))))
-    (`(t . t) 'deferred)
-    (`(t . _) 'simple))
+(defvar treemacs-use-git-mode nil
   "Type of git integration for `treemacs-git-mode'.
-There are 2 possible values:
+There are 3 possible values:
 1) simple, which highlights only files based on their git status, and is
    slightly faster
 2) extended, which highlights both files and directories, but requires python


### PR DESCRIPTION
problem:
The Treemacs layer is unable to find python 3 in Windows.

cause:
The Treemacs layer looks for "python3", but the executable is called
"python.exe" in Windows.

solution:
Let Treemacs check for python 3 upstream, it has a better method for finding the
python 3 executable in Windows.