### PR TITLE
Add search-from ivy action to fasd layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1972,6 +1972,8 @@ Other:
 - Support running graphical Factor listener instances from Spacemacs
 - Support reloading factor-mode/fuel-mode code when connecting to different
   Factor versions
+**** FASD
+- Add ~search from~ ivy action (thanks to Daniel Nicolai)
 **** Finance
 - Remove key-bindings pointing to removed commands (thanks to Alexander Baier)
 - Added =evil-ledger= package (thanks to Alexander Miller)

--- a/layers/+tools/fasd/README.org
+++ b/layers/+tools/fasd/README.org
@@ -8,6 +8,7 @@
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#fasd][fasd]]
+- [[#comment][Comment]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -33,6 +34,13 @@ On macOS, it can be installed via [[https://github.com/Homebrew/legacy-homebrew]
 #+BEGIN_SRC sh
   $ brew install fasd
 #+END_SRC
+
+* Comment
+   The fasd package has been updated to support Ivy actions (~M-o~). This layer
+   adds an Ivy action to start a deep search in a directory
+   (~spacemacs/search-auto~) from the fasd results. After the fasd query,
+   instead of enter, type ~M-o~ on some directory then press ~s~ to start a
+   deep search in that directory.
 
 * Key bindings
 

--- a/layers/+tools/fasd/funcs.el
+++ b/layers/+tools/fasd/funcs.el
@@ -1,0 +1,10 @@
+(with-eval-after-load 'fasd
+  (defun ivy-search-from-action (x)
+    (if (file-directory-p x)
+        (spacemacs/counsel-search dotspacemacs-search-tools nil x)
+      (message "Selected item is not a directory path")))
+  
+  (ivy-set-actions
+   'fasd-find-file
+   '(("o" fasd-find-file-action "find-file")
+     ("s" ivy-search-from-action "search-from"))))


### PR DESCRIPTION
If I had known about browsing history in Ivy with `C-r` before
 [I modified the fasd package to implement full ivy support](https://framagit.org/steckerhalter/emacs-fasd/-/commit/c4c04873fd0c8e916186f38a75cd4ab7f8b7ad59),
then I guess I would not have modified it. Anyway, now that "full Ivy support"
has been merged into the fasd package, I could add this 'search-from' action
command to `fasd-find-file` which triggers Spacemacs 'search-auto'. Because fasd
only finds dirs that have been visited before, it probably does not add much to
the `C-r` functionality, but maybe it does (you decide?). Anyway, I hope you can
help decide if this is useful for merging.

So with this PR you can use fasd to find some directory, then use `M-o` to trigger
`search-auto` to search from that directory (I got tired of navigating to often searched directories).

If you think this PR is useful enough then I am happy to 'git amend' documentation
 and add the change to the changelog.