### PR TITLE
Add consistent org-agenda transient-state keybinding

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -277,8 +277,6 @@ sane way, here is the complete list of changed key bindings
   - ~SPC m s r~ org-refile
   - ~SPC m s s~ org-sparse-tree
   - ~SPC m x o~ org-open-at-point
-- Removed ~C-h~ binding in =org-agenda-mode= (thanks to Ag Ibragimov)
-- Rebind =org-agenda-refile= to ~r~ in transient state (thanks to Muneeb Shaikh)
 - Moved =org-trello= keys from ~SPC m o~ to ~SPC m m t~
   (thanks to Magnus Therning)
 - New keybindings for push and pull (thanks to Magnus Therning):
@@ -288,6 +286,10 @@ sane way, here is the complete list of changed key bindings
   - ~SPC m t u c~ for =spacemacs/org-trello-push-card=
 - New keybinding for =org-table-field-info= ~SPC m t f~
   (thanks to Dominik Schrempf)
+In org-agenda-mode
+  - Add consistent keybinding ~SPC m .~ to enter transient-state (thanks to Daniel Nicolai)
+  - Removed ~C-h~ binding in =org-agenda-mode= (thanks to Ag Ibragimov)
+  - Rebind =org-agenda-refile= to ~r~ in transient state (thanks to Muneeb Shaikh)
 ***** Python
 - fix/implement pyvenv-tracking-mode (thanks to Daniel Nicolai)
 - Key bindings (thanks to Danny Freeman):

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -673,10 +673,10 @@ The evilified org agenda supports the following bindings:
 | ~M-RET~              | org-agenda-show-and-scroll-up     |
 
 *** Org agenda transient state
-Use ~M-SPC~ or ~s-M-SPC~ in an org agenda buffer to activate its transient state.
-The transient state aims to list the most useful org agenda commands and
-visually organize them by category. The commands associated with each binding
-are listed bellow.
+Use ~SPC m .~, ~M-SPC~ or ~s-M-SPC~ in an org agenda buffer to activate its
+transient state. The transient state aims to list the most useful org agenda
+commands and visually organize them by category. The commands associated with
+each binding are listed bellow.
 
 | Key binding | Description         | Command                           |
 |-------------+---------------------+-----------------------------------|

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -477,6 +477,7 @@ Will work on both org-mode and any mode that accepts plain html."
         :title "Org-agenda transient state"
         :on-enter (setq which-key-inhibit t)
         :on-exit (setq which-key-inhibit nil)
+        :evil-leader-for-mode (org-agenda-mode . ".")
         :foreign-keys run
         :doc
         "


### PR DESCRIPTION
I do not see any reason why the keybinding to enter transient-state in
 org-agenda-mode should not be on `, .`. Therefore I propose here to
make that keybinding consistent with the keybindings for entering
transient states in most/all other modes.