### PR TITLE
Support prettier formatter for Ruby layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3231,6 +3231,8 @@ files (thanks to Daniel Nicolai)
 - Added =dap= support for =enh-ruby-mode= (thanks to Seong Yong-ju)
 - Added missing prefix =seeing-is-believing= for ~SPC m @~
   (thanks to Seong Yong-ju)
+- Added support for prettier formatting (thanks to sidraval)
+  - Added ~SPC m = =~ to format buffer via prettier (thanks to sidraval)
 **** Ruby on Rails
 - Changed leader keys to be configured for the =projectile-rails-mode= minor
   mode instead of =ruby-mode= and =enh-ruby-mode= so that the key bindings will

--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -14,6 +14,7 @@
   - [[#prerequisites][Prerequisites]]
   - [[#ruby-version-management][Ruby version management]]
   - [[#test-runner][Test runner]]
+  - [[#formatting][Formatting]]
 - [[#key-bindings][Key bindings]]
   - [[#ruby-enh-ruby-mode-robe-inf-ruby-ruby-tools][Ruby (enh-ruby-mode, robe, inf-ruby, ruby-tools)]]
   - [[#debugger][Debugger]]
@@ -40,6 +41,7 @@ This layer provides support for the Ruby programming language.
 - Test runner (ruby-test and rspec)
 - Rake runner
 - Linter (rubocop)
+- Formatter (prettier)
 - Interactive REPL and code navigation (robe)
 - Interactive debugger using [[https://github.com/emacs-lsp/dap-mode][dap-mode]]
 
@@ -102,6 +104,7 @@ based on your version manager):
 - =pry= and =pry-doc= are required for *jump to definition* and *code documentation* (=robe-mode=)
 - =ruby_parser= is required for *goto-step_definition* in =feature-mode=
 - =rubocop= is required for rubocop integration
+- =prettier= is required for formatter
 - =seeing_is_believing= helps you evaluate code inline
 - =solargraph= is required for using the language server protocol in =ruby-mode=
 
@@ -152,6 +155,17 @@ Example to set the test runner to =RSpec=:
 =Tip:= You can enable different test runners for different projects by using
 directory local variables.
 
+** Formatting
+If you'd like to use [[https://github.com/prettier/plugin-ruby][prettier/plugin-ruby]] to format on save:
+
+#+BEGIN_SRC emacs-lisp
+  (defun dotspacemacs-configuration-layers ()
+     '((ruby :variables ruby-prettier-on-save t)))
+#+END_SRC
+
+Note that the =prettier= binary must be available in the project's
+=node_modules/.bin/= or on =exec-path=.
+
 * Key bindings
 ** Ruby (enh-ruby-mode, robe, inf-ruby, ruby-tools)
 
@@ -173,6 +187,7 @@ directory local variables.
 | ~SPC m x "​~ | Change symbol or ='= string to ="=                |
 | ~SPC m x :~ | Change string to symbol                           |
 | ~SPC m x h~ | toggle hash syntax in active region               |
+| ~SPC m = =~ | format buffer using prettier                      |
 | ~%~         | [[https://github.com/redguardtoo/evil-matchit][evil-matchit]] jumps between blocks                 |
 
 ** Debugger

--- a/layers/+lang/ruby/config.el
+++ b/layers/+lang/ruby/config.el
@@ -31,3 +31,6 @@ Possible values are `rbenv', `rvm' or `chruby'.)")
 
 (defvar ruby-highlight-debugger-keywords t
   "If non-nil, enable highlight for debugger keywords.")
+
+(defvar ruby-prettier-on-save nil
+  "Use prettier and run on buffer save")

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -157,7 +157,6 @@ Called interactively it prompts for a directory."
 ;; Prettier
 
 (defun spacemacs/ruby-format ()
-  "Call formatting tool specified in `javascript-fmt-tool'."
   (interactive)
   (call-interactively 'prettier-js))
 

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -152,3 +152,14 @@ Called interactively it prompts for a directory."
   (save-excursion
     (goto-char (point-min))
     (insert "#!/usr/bin/env ruby\n")))
+
+
+;; Prettier
+
+(defun spacemacs/ruby-format ()
+  "Call formatting tool specified in `javascript-fmt-tool'."
+  (interactive)
+  (call-interactively 'prettier-js))
+
+(defun spacemacs/ruby-fmt-before-save-hook ()
+  (add-hook 'before-save-hook 'spacemacs/ruby-format t t))

--- a/layers/+lang/ruby/layers.el
+++ b/layers/+lang/ruby/layers.el
@@ -11,4 +11,7 @@
 
 (when (and (boundp 'ruby-backend)
            (eq ruby-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(dap prettier)))
+  (configuration-layer/declare-layer-dependencies '(dap)))
+
+(when (boundp 'ruby-prettier-on-save)
+  (configuration-layer/declare-layer-dependencies '(prettier)))

--- a/layers/+lang/ruby/layers.el
+++ b/layers/+lang/ruby/layers.el
@@ -11,4 +11,4 @@
 
 (when (and (boundp 'ruby-backend)
            (eq ruby-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(dap)))
+  (configuration-layer/declare-layer-dependencies '(dap prettier)))

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -11,6 +11,7 @@
 
 (defconst ruby-packages
   '(
+    add-node-modules-path
     bundler
     chruby
     company
@@ -24,6 +25,7 @@
     minitest
     org
     popwin
+    prettier-js
     rake
     rbenv
     robe
@@ -60,6 +62,9 @@
     :defer t
     :init (spacemacs/add-to-hooks 'chruby-use-corresponding
                                   '(ruby-mode-hook enh-ruby-mode-hook))))
+
+(defun ruby/post-init-add-node-modules-path ()
+  (spacemacs/add-to-hooks #'add-node-modules-path '(ruby-mode-hook)))
 
 (defun ruby/post-init-company ()
   (add-hook 'ruby-mode-local-vars-hook #'spacemacs//ruby-setup-company))
@@ -140,6 +145,10 @@
 (defun ruby/pre-init-org ()
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(ruby . t))))
+
+(defun ruby/pre-init-prettier-js ()
+  (add-to-list 'spacemacs--prettier-modes 'ruby-mode)
+  (add-to-list 'spacemacs--prettier-modes 'enh-ruby-mode))
 
 (defun ruby/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin
@@ -300,6 +309,7 @@
       ;; This might have been important 10 years ago but now it's frustrating.
       (setq ruby-insert-encoding-magic-comment nil)
 
+      (add-hook 'ruby-mode-hook 'spacemacs/ruby-fmt-before-save-hook)
       (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
         "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
         "is"  'spacemacs/ruby-insert-shebang

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -309,7 +309,8 @@
       ;; This might have been important 10 years ago but now it's frustrating.
       (setq ruby-insert-encoding-magic-comment nil)
 
-      (add-hook 'ruby-mode-hook 'spacemacs/ruby-fmt-before-save-hook)
+      (when ruby-prettier-on-save
+        (add-hook 'ruby-mode-hook 'spacemacs/ruby-fmt-before-save-hook))
       (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
         "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
         "is"  'spacemacs/ruby-insert-shebang


### PR DESCRIPTION
This PR adds support for [prettier/plugin-ruby](https://github.com/prettier/plugin-ruby) in spacemacs' Ruby layer. Prettier can be configured to run on buffer save, or run ad-hoc via a keybinding. I tried to follow the implementation used by other layers for autoformatters, e.g. the javascript layer & typescript layer.