### PR TITLE
Fix issue #14250 by unshadowing 'K'

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -564,6 +564,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
       :bindings
       "j" 'org-agenda-next-line
       "k" 'org-agenda-previous-line
+      "K" nil
       ;; C-h should not be rebound by evilification so we unshadow it manually
       ;; TODO add the rule in auto-evilification to ignore C-h (like we do
       ;; with C-g)


### PR DESCRIPTION
Unshadows 'K' in agenda-mode-map such that 'K' still maps to `org-habit-toggle-display-in-agenda`