### PR TITLE
[core] support recents-by-project in dotspacemacs-startup-lists

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -529,6 +529,9 @@ Other:
     terminal mode, but no longer in GUI mode. (emacs18)
 *** Core changes
 - Improvements:
+  - Support =recents-by-project= in =dotspacemacs-startup-lists=, which allows
+    combining the existing =recents= and =projects= into one coherent view (thanks
+    to Keith Pinson)
   - Make =set-selective-display=, which is a kind of built-in Emacs quick-n-dirty
     whole-file folding mechanism for indentation-based syntaxes, more
     discoverable for Evil users by placing it (with a small DWIM wrapper) in the

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -410,9 +410,12 @@ tool of the list. Supported tools are `rg', `ag', `pt', `ack' and `grep'.")
 `(list-type . list-size)`. If nil it is disabled.
 
 Possible values for list-type are:
-`recents' `bookmarks' `projects' `agenda' `todos'.
+`recents' `recents-by-project' `bookmarks' `projects' `agenda' `todos'.
 List sizes may be nil, in which case
-`spacemacs--buffer-startup-lists-length' takes effect.")
+`spacemacs--buffer-startup-lists-length' takes effect.
+In the `recents-by-project' case, the list size should be a `cons' cell whose
+`car' is the maximum number of projects to show, and whose `cdr' is the maximum
+number of recent files to show in each project.")
 
 (defvar dotspacemacs-startup-buffer-responsive t
   "True if the home buffer should respond to resize events.")
@@ -919,16 +922,22 @@ error recovery."
     (lambda (x)
       (let ((el (or (car-safe x) x))
             (list-size (cdr-safe x)))
-        (member el '(recents bookmarks projects todos agenda))))
-    'dotspacemacs-startup-lists (concat "includes \'recents, "
+        (member el '(recents recents-by-project bookmarks projects todos agenda))))
+    'dotspacemacs-startup-lists (concat "includes \'recents, 'recents-by-project, "
                                         "\'bookmarks, \'todos, "
                                         "\'agenda or \'projects"))
    (spacemacs//test-list
     (lambda (x)
       (let ((el (or (car-safe x) x))
             (list-size (cdr-safe x)))
-        (or (null list-size)(numberp list-size))))
-    'dotspacemacs-startup-lists (concat "list size is a number"))
+        (if (eq el 'recents-by-project)
+            (and (consp list-size)
+                 (numberp (car list-size))
+                 (numberp (cdr list-size)))
+          (or (null list-size) (numberp list-size)))))
+    'dotspacemacs-startup-lists (concat "list size is a number, unless "
+                                        "list type is recents-by-project "
+                                        "when it is a pair of numbers"))
    (spacemacs//test-var 'stringp 'dotspacemacs-leader-key "is a string")
    (spacemacs//test-var 'stringp 'dotspacemacs-emacs-leader-key "is a string")
    (spacemacs//test-var

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -179,9 +179,13 @@ It should only modify the values of Spacemacs settings."
    ;; List of items to show in startup buffer or an association list of
    ;; the form `(list-type . list-size)`. If nil then it is disabled.
    ;; Possible values for list-type are:
-   ;; `recents' `bookmarks' `projects' `agenda' `todos'.
+   ;; `recents' `recents-by-project' `bookmarks' `projects' `agenda' `todos'.
    ;; List sizes may be nil, in which case
    ;; `spacemacs-buffer-startup-lists-length' takes effect.
+   ;; The exceptional case is `recents-by-project', where list-type must be a
+   ;; pair of numbers, e.g. `(recents-by-project . (7 .  5))', where the first
+   ;; number is the project limit and the second the limit on the recent files
+   ;; within a project.
    dotspacemacs-startup-lists '((recents . 5)
                                 (projects . 7))
 


### PR DESCRIPTION
`dotspacemacs-startup-lists` by default shows a number of recent files and projects as two separate lists. If I've been working with a lot of files in one project, then all the recent files are from one project, even if I set `recents` to a large amount like 24. This change allows me to see the recent files by project. Suppose, for example, I have a `vegetables` project and a `fruit` project, and set `dotspacemacs-startup-lists` to `(recents-by-file . (2 . 3))`. In the home buffer I will see something like:

    ~/vegetables
        lettuce.el
        squash.el
        tomatoes.el
    ~/fruit
        apple.py
        orange.py
        banana.py

Even though only a subpath is displayed for each file, the click functionality still works---i.e. the link still has the full path under the covers.

I originally asked a [question](https://emacs.stackexchange.com/q/62524/19069) on Emacs StackExchange to see if there were any pointers or if this was already a solved problem. After several days of receiving no answers, and having a little time to poke at it, I figured I'd implement it myself.

What this does not cover: mixing recent files totally outside projects into this list. Today they are just filtered out. That is a usecase I didn't need so I figured that could be done in a subsequent pass if somebody wanted it.