### PR TITLE
[emacs-lisp] make `SPC m h h` and jump handlers work in `ielm`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -134,7 +134,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   (thanks to Cormac Cannon)
 - Removed cquery.
 ***** EPUB
-- Add ~J/K~ for scrolling down/up (thanks to Daniel Nicolai) 
+- Add ~J/K~ for scrolling down/up (thanks to Daniel Nicolai)
 ***** ESS
 - ESS key bindings were re-organised in the following list
   (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):
@@ -1880,6 +1880,7 @@ Other:
 - Added =elm-test-runner= (thanks to Juan Edi)
 **** Emacs Lisp
 - Key bindings:
+  - Make ~SPC m h h~ and jump handlers work in =ielm= (thanks to Keith Pinson)
   - Added ~c~ to continue in edebug mode (thanks to hodge)
   - Added ~SPC m g b~ to jump back to previous point (thanks to Magnus Therning)
 - Identify Cask files as emacs lisp ones (thanks to Adrien Becchis)

--- a/layers/+lang/emacs-lisp/config.el
+++ b/layers/+lang/emacs-lisp/config.el
@@ -18,6 +18,7 @@
 
 (spacemacs|define-jump-handlers emacs-lisp-mode)
 (spacemacs|define-jump-handlers lisp-interaction-mode)
+(spacemacs|define-jump-handlers inferior-emacs-lisp-mode)
 
 (defvar emacs-lisp-hide-namespace-prefix nil
   "If non-nil, hide namespace prefixes using nameless-mode.")

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -45,6 +45,14 @@
     :init
     (progn
       (spacemacs/register-repl 'ielm 'ielm)
+      ;; Load better help mode if helpful is installed
+      (if (configuration-layer/layer-used-p 'helpful)
+          (spacemacs/set-leader-keys-for-major-mode 'inferior-emacs-lisp-mode
+            "hh" 'helpful-at-point)
+        (spacemacs/set-leader-keys-for-major-mode 'inferior-emacs-lisp-mode
+          "hh" 'elisp-slime-nav-describe-elisp-thing-at-point))
+      (add-to-list 'spacemacs-jump-handlers-inferior-emacs-lisp-mode
+                   'elisp-slime-nav-find-elisp-thing-at-point)
       (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
         (spacemacs/declare-prefix-for-mode mode "ms" "ielm")
         (spacemacs/set-leader-keys-for-major-mode mode


### PR DESCRIPTION
Like in other Emacs Lisp modes.
