### PR TITLE
helm: Better integration with search tools and etc

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -401,8 +401,9 @@ Possible values are:
 `nil' to disable cleanup.")
 
 (defvar dotspacemacs-search-tools '("rg" "ag" "pt" "ack" "grep")
-  "List of search tool executable names. Spacemacs uses the first installed
-tool of the list. Supported tools are `rg', `ag', `pt', `ack' and `grep'.")
+  "List of search tool executable names.
+Spacemacs uses the first installed tool of the list.
+Supported tools are \"rg\", \"ag\", \"pt\", \"ack\" and \"grep\".")
 
 (defvar dotspacemacs-startup-lists '((recents  . 5)
                                      (projects . 7))

--- a/layers/+completion/helm/config.el
+++ b/layers/+completion/helm/config.el
@@ -7,34 +7,39 @@
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
-;;; License: GPLv3
+;; License: GPLv3
 
-;; Dumper
+;;; Commentary:
+
+;;; Code:
+
+;;;; Dumper
 
 (defun helm/pre-dump ()
+  "Trigger all side effects in a temporaray buffer."
   (spacemacs/dump-modes '(helm-mode)))
 
-;; variables
+;;;; Variables
 
 ;; TODO: remove dotspacemacs variables backward compatbility in version
 ;;       0.400 or later
 
 (defvar helm-no-header (spacemacs|dotspacemacs-backward-compatibility
                         dotspacemacs-helm-no-header nil)
-  "if non nil, the helm header is hidden when there is only one source.")
+  "If non nil, the helm header is hidden when there is only one source.")
 
 (defvar helm-position (spacemacs|dotspacemacs-backward-compatibility
                        dotspacemacs-helm-position bottom)
   "Position in which to show the `helm' mini-buffer.")
 
 (defvar spacemacs-helm-rg-max-column-number 512
-  "Controls the maximum number of columns to display with ripgrep (otherwise
-  omits a line)")
+  "Maximum number of columns to display with \"ripgrep\".")
 
-;; internals
+;;;; Internals
 
 ;; for Helm Window position
 (defvar spacemacs-helm-display-help-buffer-regexp '("*.*Helm.*Help.**"))
+
 (defvar spacemacs-helm-display-buffer-regexp
   `("*.*helm.**"
     (display-buffer-in-side-window)
@@ -42,4 +47,11 @@
     (side . ,helm-position)
     (window-width . 0.6)
     (window-height . 0.4)))
-(defvar spacemacs-display-buffer-alist nil)
+
+(defvar spacemacs-display-buffer-alist nil
+  "Temp variables to store `display-buffer-alist'.")
+
+(defvar spacemacs--helm-popwin-mode nil
+  "Temp variable to store `popwin-mode''s value.")
+
+;;; config.el ends here

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -7,12 +7,17 @@
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
-;;; License: GPLv3
+;; License: GPLv3
 
-
+;;; Commentary:
 
-(defvar spacemacs--helm-popwin-mode nil
-  "Temp variable to store `popwin-mode''s value.")
+;;; Code:
+
+(require 'core-funcs)
+(require 'dash)
+(require 'dired)
+
+;;;; Helper functions
 
 (defun spacemacs//helm-cleanup ()
   "Cleanup some helm related states when quitting."
@@ -32,15 +37,14 @@
     (popwin-mode -1)))
 
 (defun spacemacs//helm-restore-display ()
+  "Not documented."
   ;; we must enable popwin-mode first then restore `display-buffer-alist'
   ;; Otherwise, popwin keeps adding up its own buffers to
   ;; `display-buffer-alist' and could slow down Emacs as the list grows
-  (when spacemacs--helm-popwin-mode
-    (popwin-mode))
+  (when spacemacs--helm-popwin-mode (popwin-mode))
   (setq display-buffer-alist spacemacs-display-buffer-alist))
 
-
-;; REPLs integration
+;;;; REPLs Integration
 
 (defun helm-available-repls ()
   "Show all the repls available."
@@ -55,449 +59,243 @@
     (helm :sources '(helm-available-repls)
           :buffer "*helm repls*")))
 
+;;;; Search Tools Integration
 
+(defun spacemacs//helm-search-dispatcher (scope &optional tool default-input-p)
+  "Call an appropriate search function.
+- SCOPE The scope of the search:
+  - \"buffer\" Search within all opened buffers.
+  - \"dir\" Search within current directory.
+  - \"project\" Search within current project.
+- TOOL A string specifies the search tool to use. It must be found on \"PATH\"
+  When nil, use the first search tool in `dotspacemacs-search-tools' found on
+  \"PATH\".
+- DEFAULT-INPUT-P When non-nil, use current region or symbol as default input.
 
-
-;; Search tools integration
+In addition, when called with prefix argument, it has special behaviour that
+depends on SCOPE:
+- For \"buffer\", prompt for a buffer to search.
+- For \"dir\", prompt for a directory to search.
+- For \"project\", prompt for a project to the search."
+  (require 'helm-files)
+  (require 'helm-mode)
+  (require 'projectile)
+  (cl-letf
+      (;; whether called with C-u
+       (prefix-p current-prefix-arg)
+       ;; when TOOL is non-nil, verify it exist
+       ;; otherwise it's smart-search, and use the first one found
+       (search-tool
+        (if-let ((tool-found
+                  (seq-find 'executable-find
+                            (if (stringp tool)
+                                (list tool)
+                              dotspacemacs-search-tools))))
+            tool-found
+          (user-error (if (stringp tool)
+                          "Can't find %s in your PATH"
+                        "Can't find any search tool in your PATH")
+                      tool)))
+       ((symbol-function 'current-project-root)
+        (lambda ()
+          (if-let ((root (projectile-project-root)))
+              root
+            (user-error (if default-directory
+                            (projectile-prepend-project-name
+                             "is not in a project")
+                          "You're not in a project")
+                        default-directory))))
+       ((symbol-function 'ask-dir-name)
+        (lambda ()
+          (helm-read-file-name
+           "Directory name: "
+           :name "Directory to search"
+           :marked-candidates t
+           :test 'file-directory-p
+           :preselect
+           (when-let ((preselection (or (dired-get-filename nil t)
+                                        (buffer-file-name))))
+             (if helm-ff-transformer-show-only-basename
+                 (helm-basename preselection)
+               preselection)))))
+       ((symbol-function 'ask-project-dir)
+        (lambda ()
+          (if (projectile-project-p)
+              (let
+                  ((project
+                    (helm
+                     :sources
+                     (helm-build-sync-source "Projectile projects"
+                       :candidates
+                       (lambda ()
+                         (with-helm-current-buffer projectile-known-projects))
+                       :fuzzy-match helm-projectile-fuzzy-match
+                       :mode-line helm-read-file-name-mode-line-string)
+                     :buffer (concat "*helm-projectile: "
+                                     (projectile-project-name) "*")
+                     :prompt (projectile-prepend-project-name
+                              "Project to search: "))))
+                (if (file-exists-p project)
+                    project
+                  (projectile-remove-known-project project)
+                  (user-error "Selected project doesn't exist: %s")))
+            (user-error "You're not in a project"))))
+       ((symbol-function 'helm-grep-wrapper)
+        (lambda (targets default-input-p)
+          (let ((current-prefix-arg nil))
+            (when default-input-p
+              (cl-letf*
+                  (((symbol-function 'this-fn) (symbol-function 'helm-do-grep-1))
+                   ((symbol-function 'helm-do-grep-1)
+                    (lambda (thing)
+                      (let ((res (if (region-active-p)
+                                     (buffer-substring-no-properties
+                                      (region-beginning) (region-end))
+                                   (thing-at-point 'symbol t))))
+                        (this-fn thing nil nil nil nil
+                                 (when res (rxt-quote-pcre res)))))))))
+            (helm-do-grep-1 targets))))
+       ((symbol-function 'helm-ag-wrapper)
+        (lambda (func default-input-p args)
+          (let ((current-prefix-arg nil))
+            (when default-input-p
+              (cl-letf* ((helm-ag-insert-at-point 'symbol)
+                         ((symbol-function 'this-fn)
+                          (symbol-function 'thing-at-point))
+                         ((symbol-function 'thing-at-point)
+                          (lambda (thing)
+                            (let ((res (if (region-active-p)
+                                           (buffer-substring-no-properties
+                                            (region-beginning) (region-end))
+                                         (this-fn thing))))
+                              (when res (rxt-quote-pcre res))))))))
+            (funcall func args)))))
+    (pcase search-tool
+      ("grep"
+       (require 'helm-grep)
+       (let
+           ((targets
+             (pcase scope
+               ("buffer" (if prefix-p
+                             (list (buffer-file-name))
+                             (seq-filter #'identity
+                                         (mapcar #'buffer-file-name
+                                                 (buffer-list)))))
+               ("dir" (seq-filter #'file-regular-p
+                                  (directory-files (if prefix-p
+                                                       (ask-dir-name)
+                                                     default-directory)
+                                                   t)))
+               ("project" (seq-filter #'file-regular-p
+                                      (directory-files (if prefix-p
+                                                           (ask-project-dir)
+                                                         (current-project-root))
+                                                       t))))))
+         (helm-grep-wrapper targets default-input-p)))
+      ((pred (lambda (x) (member x '("rg" "ag" "pt" "ack" "grep"))))
+       (require 'helm-ag)
+       (pcase-let (;; setup appropriate base command and exit status
+                   (helm-ag-base-command
+                    (pcase search-tool
+                      ("rg"
+                       (concat "rg --smart-case --no-heading --color=never --line-number"
+                               (when-let
+                                   ((maxcol spacemacs-helm-rg-max-column-number)
+                                    (_ (> maxcol 0)))
+                                 (format " --max-columns=%d" maxcol))))
+                      ((and "ag" (pred (lambda (_) (memq system-type '(ms-dos windows-nt)))))
+                       "ag --vimgrep")
+                      (val
+                       (format "%s --nocolor --nogroup" (if (string= val "pt")
+                                                            "pt -e"
+                                                          val)))))
+                   (helm-ag-success-exit-status
+                    (when (string= search-tool "rg")
+                      (list 0 2)))
+                   ;; function to call and additional args
+                   (`(,func ,args)
+                    (pcase scope
+                      ("buffer" (list (if prefix-p
+                                          #'helm-do-ag-this-file
+                                          #'helm-do-ag-buffers)
+                                      nil))
+                      ("dir" (list #'helm-do-ag
+                                   (if prefix-p
+                                       (ask-dir-name)
+                                     default-directory)))
+                      ("project" (list #'helm-do-ag
+                                       (if prefix-p
+                                           (ask-project-dir)
+                                         (current-project-root)))))))
+         (helm-ag-wrapper func default-input-p args)))
+      (_ (user-error "Not a valid search tool %s" search-tool)))))
 
-(defun spacemacs//helm-do-ag-region-or-symbol (func &optional dir)
-  "Search with `ag' with a default input."
-  (require 'helm-ag)
-  (cl-letf* (((symbol-value 'helm-ag-insert-at-point) 'symbol)
-             ;; make thing-at-point choosing the active region first
-             ((symbol-function 'this-fn) (symbol-function 'thing-at-point))
-             ((symbol-function 'thing-at-point)
-              (lambda (thing)
-                (let ((res (if (region-active-p)
-                               (buffer-substring-no-properties
-                                (region-beginning) (region-end))
-                             (this-fn thing))))
-                  (when res (rxt-quote-pcre res))))))
-    (funcall func dir)))
+(byte-compile 'spacemacs//helm-search-dispatcher)
 
-(defun spacemacs//helm-do-search-find-tool (base tools default-inputp)
-  "Create a cond form given a TOOLS string list and evaluate it."
-  (eval
-   `(cond
-     ,@(mapcar
-        (lambda (x)
-          `((executable-find ,x)
-            ',(let ((func
-                     (intern
-                      (format (if default-inputp
-                                  "spacemacs/%s-%s-region-or-symbol"
-                                "spacemacs/%s-%s")
-                              base x))))
-                (if (fboundp func)
-                    func
-                  (intern (format "%s-%s"  base x))))))
-        tools)
-     (t 'helm-do-grep))))
+(defmacro spacemacs||helm-search-command (spec tool default-input-p)
+  "Template for generic spacemacs helm search commands.
+- SPEC A list of strings in the form of \"(SCOPE . DOC)\"
+  - SCOPE The scope of the search.
+  - DOC Extra documentation appended to the generic docstring.
+- TOOL When nil, use the first search tool in variable
+  `dotspacemacs-search-tools' whose excutable is found on \"PATH\".
+  When non-nil, use the specified search tool if it's found on \"PATH\".
+- DEFAULT-INPUT-P When non-nil, use current region or symbol as default input."
+  (pcase-let*
+      ((`(,scope ,doc) spec)
+       (func-name
+        (intern
+         (format
+          "spacemacs/helm-%s-%s%s"
+          (or tool "smart-search")
+          scope
+          (if default-input-p "-with-input" ""))))
+       (docstring
+        (format
+         "Search in %s with %s%s.\nWhen prefixed with universal argument, %s."
+         scope
+         (or tool
+             "the first search tool in variable \`dotspacemacs-search-tools\' \
+that is found in PATH")
+         (if default-input-p " using a default input" "")
+         doc)))
+    `(;;;###autoload
+      defun ,func-name ()
+      ,docstring
+      (interactive)
+      (spacemacs//helm-search-dispatcher ,scope ,tool ,default-input-p))))
 
-;; Search in current file ----------------------------------------------
+(--each
+    (-table-flat
+     'list
+     '(spacemacs||helm-search-command)
+     '(("buffer" "search in a specified buffers") ; spec, i.e. (scope doc)
+       ("dir" "search in a specified directory")
+       ("project" "search in a specified project"))
+     '("rg" "ag" "pt" "ack" "grep" nil)           ; tool
+     '(t nil))                                    ; default-input-p
+  (eval it))
 
-(defun spacemacs/helm-file-do-ag (&optional _)
-  "Wrapper to execute `helm-ag-this-file.'"
-  (interactive)
-  (helm-do-ag-this-file))
+;;;; helm-projectile integration
 
-(defun spacemacs/helm-file-do-ag-region-or-symbol ()
-  "Search in current file with `ag' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-file-do-ag))
-
-(defun spacemacs/helm-file-smart-do-search (&optional default-inputp)
-  "Search in current file using `dotspacemacs-search-tools'.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'
-If DEFAULT-INPUTP is non nil then the current region or symbol at point
- are used as default input."
-  (interactive)
-  (call-interactively
-   (spacemacs//helm-do-search-find-tool "helm-file-do"
-                                        dotspacemacs-search-tools
-                                        default-inputp)))
-
-(defun spacemacs/helm-file-smart-do-search-region-or-symbol ()
-  "Search in current file using `dotspacemacs-search-tools' with
- default input.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'."
-  (interactive)
-  (spacemacs/helm-file-smart-do-search t))
-
-;; Search in files -----------------------------------------------------
-
-(defun spacemacs/helm-files-do-ag (&optional dir)
-  "Search in files with `ag' using a default input."
-  (interactive)
-  (helm-do-ag dir))
-
-(defun spacemacs/helm-files-do-ag-region-or-symbol ()
-  "Search in files with `ag' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-ag))
-
-(defun spacemacs/helm-files-do-ack (&optional dir)
-  "Search in files with `ack'."
-  (interactive)
-  (let ((helm-ag-base-command "ack --nocolor --nogroup"))
-    (helm-do-ag dir)))
-
-(defun spacemacs/helm-files-do-ack-region-or-symbol ()
-  "Search in files with `ack' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-ack))
-
-(defun spacemacs/helm-files-do-pt (&optional dir)
-  "Search in files with `pt'."
-  (interactive)
-  (let ((helm-ag-base-command "pt -e --nocolor --nogroup"))
-    (helm-do-ag dir)))
-
-(defun spacemacs/helm-files-do-pt-region-or-symbol ()
-  "Search in files with `pt' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-pt))
-
-(defun spacemacs/helm-files-do-rg (&optional dir)
-  "Search in files with `rg'."
-  (interactive)
-  ;; --line-number forces line numbers (disabled by default on windows)
-  ;; no --vimgrep because it adds column numbers that wgrep can't handle
-  ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-  (let* ((root-helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number")
-         (helm-ag-base-command (if spacemacs-helm-rg-max-column-number
-                                   (concat root-helm-ag-base-command " --max-columns=" (number-to-string spacemacs-helm-rg-max-column-number))
-                                 root-helm-ag-base-command)))
-    (helm-do-ag dir)))
-
-(defun spacemacs/helm-files-do-rg-region-or-symbol ()
-  "Search in files with `rg' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-rg))
-
-(defun spacemacs/helm-files-smart-do-search (&optional default-inputp)
-  "Search in files using `dotspacemacs-search-tools'.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'
-If DEFAULT-INPUTP is non nil then the current region or symbol at point
- are used as default input."
-  (interactive)
-  (call-interactively
-   (spacemacs//helm-do-search-find-tool "helm-files-do"
-                                        dotspacemacs-search-tools
-                                        default-inputp)))
-
-(defun spacemacs/helm-files-smart-do-search-region-or-symbol ()
-  "Search in files using `dotspacemacs-search-tools' with default input.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'."
-  (interactive)
-  (spacemacs/helm-files-smart-do-search t))
-
-;; Search in current dir -----------------------------------------------
-
-(defun spacemacs/helm-dir-do-ag ()
-  "Search in current directory with `ag'."
-  (interactive)
-  (spacemacs/helm-files-do-ag default-directory))
-
-(defun spacemacs/helm-dir-do-ag-region-or-symbol ()
-  "Search in current directory with `ag' with a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-ag default-directory))
-
-(defun spacemacs/helm-dir-do-ack ()
-  "Search in current directory with `ack'."
-  (interactive)
-  (spacemacs/helm-files-do-ack default-directory))
-
-(defun spacemacs/helm-dir-do-grep ()
-  "Search in current directory with `grep'."
-  (interactive)
-  (spacemacs//helm-do-grep-region-or-symbol (list default-directory) nil))
-
-(defun spacemacs/helm-dir-do-ack-region-or-symbol ()
-  "Search in current directory with `ack' with a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-ack default-directory))
-
-(defun spacemacs/helm-dir-do-pt ()
-  "Search in current directory with `pt'."
-  (interactive)
-  (spacemacs/helm-files-do-pt default-directory))
-
-(defun spacemacs/helm-dir-do-pt-region-or-symbol ()
-  "Search in current directory with `pt' with a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-pt default-directory))
-
-(defun spacemacs/helm-dir-do-rg ()
-  "Search in current directory with `rg'."
-  (interactive)
-  (spacemacs/helm-files-do-rg default-directory))
-
-(defun spacemacs/helm-dir-do-rg-region-or-symbol ()
-  "Search in current directory with `rg' with a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-files-do-rg default-directory))
-
-(defun spacemacs/helm-dir-smart-do-search (&optional default-inputp)
-  "Search in current directory using `dotspacemacs-search-tools'.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'
-If DEFAULT-INPUTP is non nil then the current region or symbol at point
- are used as default input."
-  (interactive)
-  (call-interactively
-   (spacemacs//helm-do-search-find-tool "helm-dir-do"
-                                        dotspacemacs-search-tools
-                                        default-inputp)))
-
-(defun spacemacs/helm-dir-smart-do-search-region-or-symbol ()
-  "Search in current directory using `dotspacemacs-search-tools'.
- with default input.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'."
-  (interactive)
-  (spacemacs/helm-dir-smart-do-search t))
-
-;; Search in buffers ---------------------------------------------------
-
-(defun spacemacs/helm-buffers-do-ag (&optional _)
-  "Wrapper to execute `helm-ag-buffers.'"
-  (interactive)
-  (helm-do-ag-buffers))
-
-(defun spacemacs/helm-buffers-do-ag-region-or-symbol ()
-  "Search in opened buffers with `ag' with a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-buffers-do-ag))
-
-(defun spacemacs/helm-buffers-do-ack (&optional _)
-  "Search in opened buffers with `ack'."
-  (interactive)
-  (let ((helm-ag-base-command "ack --nocolor --nogroup"))
-    (helm-do-ag-buffers)))
-
-(defun spacemacs/helm-buffers-do-ack-region-or-symbol ()
-  "Search in opened buffers with `ack' with a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-buffers-do-ack))
-
-(defun spacemacs/helm-buffers-do-pt (&optional _)
-  "Search in opened buffers with `pt'."
-  (interactive)
-  (let ((helm-ag-base-command "pt -e --nocolor --nogroup"))
-    (helm-do-ag-buffers)))
-
-(defun spacemacs/helm-buffers-do-pt-region-or-symbol ()
-  "Search in opened buffers with `pt' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-buffers-do-pt))
-
-(defun spacemacs/helm-buffers-do-rg (&optional _)
-  "Search in opened buffers with `rg'."
-  (interactive)
-  ;; --line-number forces line numbers (disabled by default on windows)
-  ;; no --vimgrep because it adds column numbers that wgrep can't handle
-  ;; see https://github.com/syl20bnr/spacemacs/pull/8065
-  (let ((helm-ag-base-command "rg --smart-case --no-heading --color=never --line-number --max-columns=150")
-        (helm-ag-success-exit-status '(0 2)))
-    (helm-do-ag-buffers)))
-
-(defun spacemacs/helm-buffers-do-rg-region-or-symbol ()
-  "Search in opened buffers with `rg' using a default input."
-  (interactive)
-  (spacemacs//helm-do-ag-region-or-symbol 'spacemacs/helm-buffers-do-rg))
-
-(defun spacemacs/helm-buffers-smart-do-search (&optional default-inputp)
-  "Search in opened buffers using `dotspacemacs-search-tools'.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'
-If DEFAULT-INPUTP is non nil then the current region or symbol at point
- are used as default input."
-  (interactive)
-  (call-interactively
-   (spacemacs//helm-do-search-find-tool "helm-buffers-do"
-                                        dotspacemacs-search-tools
-                                        default-inputp)))
-
-(defun spacemacs/helm-buffers-smart-do-search-region-or-symbol ()
-  "Search in opened buffers using `dotspacemacs-search-tools' with
- default input.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'."
-  (interactive)
-  (spacemacs/helm-buffers-smart-do-search t))
-
-;; Search in project ---------------------------------------------------
-
-(defun spacemacs/helm-project-smart-do-search-in-dir (dir)
+(defun spacemacs//helm-project-smart-search-in-dir (dir)
+  "Action to call `spacemacs/helm-smart-search-project' on DIR."
   (interactive)
   (let ((default-directory dir))
-    (spacemacs/helm-project-smart-do-search)))
+    (spacemacs/helm-smart-search-project)))
 
 (defun spacemacs/helm-projectile-grep ()
-  "Replace `helm-projectile-grep' to actually use `ag', `pt' etc.."
-  (interactive)
-  (helm-exit-and-execute-action
-   'spacemacs/helm-project-smart-do-search-in-dir))
-
-(defun spacemacs/helm-project-do-ag ()
-  "Search in current project with `ag'."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (helm-do-ag dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-ag-region-or-symbol ()
-  "Search in current project with `ag' using a default input."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs//helm-do-ag-region-or-symbol 'helm-do-ag dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-ack ()
-  "Search in current project with `ack'."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs/helm-files-do-ack dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-ack-region-or-symbol ()
-  "Search in current project with `ack' using a default input."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs//helm-do-ag-region-or-symbol
-         'spacemacs/helm-files-do-ack dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-pt ()
-  "Search in current project with `pt'."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs/helm-files-do-pt dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-pt-region-or-symbol ()
-  "Search in current project with `pt' using a default input."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs//helm-do-ag-region-or-symbol
-         'spacemacs/helm-files-do-pt dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-rg ()
-  "Search in current project with `rg'."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs/helm-files-do-rg dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-do-rg-region-or-symbol ()
-  "Search in current project with `rg' using a default input."
-  (interactive)
-  (let ((dir (projectile-project-root)))
-    (if dir
-        (spacemacs//helm-do-ag-region-or-symbol
-         'spacemacs/helm-files-do-rg dir)
-      (message "error: Not in a project."))))
-
-(defun spacemacs/helm-project-smart-do-search (&optional default-inputp)
-  "Search in current project using `dotspacemacs-search-tools'.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'
-If DEFAULT-INPUTP is non nil then the current region or symbol at point
- are used as default input."
-  (interactive)
-  (let ((projectile-require-project-root nil))
-    (call-interactively
-     (spacemacs//helm-do-search-find-tool "helm-project-do"
-                                          dotspacemacs-search-tools
-                                          default-inputp))))
-
-(defun spacemacs/helm-project-smart-do-search-region-or-symbol ()
-  "Search in current project using `dotspacemacs-search-tools' with
- default input.
- Search for a search tool in the order provided by `dotspacemacs-search-tools'."
-  (interactive)
-  (spacemacs/helm-project-smart-do-search t))
-
-;; grep
-
-(defun spacemacs//helm-do-grep-region-or-symbol
-    (&optional targs use-region-or-symbol-p)
-  "Version of `helm-do-grep' with a default input."
+  "Replace `helm-projectile-grep' to use `spacemacs/helm-smart-search-project'."
   (interactive)
   (require 'helm)
-  (cl-letf*
-      (((symbol-function 'this-fn) (symbol-function 'helm-do-grep-1))
-       ((symbol-function 'helm-do-grep-1)
-        (lambda (targets &optional recurse zgrep exts
-                         default-input region-or-symbol-p)
-          (let* ((new-input (when region-or-symbol-p
-                              (if (region-active-p)
-                                  (buffer-substring-no-properties
-                                   (region-beginning) (region-end))
-                                (thing-at-point 'symbol t))))
-                 (quoted-input (when new-input
-                                 (rxt-quote-pcre new-input))))
-            (this-fn targets recurse zgrep exts
-                     default-input quoted-input))))
-       (preselection (or (dired-get-filename nil t)
-                         (buffer-file-name (current-buffer))))
-       (targets   (if targs
-                      targs
-                    (helm-read-file-name
-                     "Search in file(s): "
-                     :marked-candidates t
-                     :preselect (when preselection
-                                  (if helm-ff-transformer-show-only-basename
-                                      (helm-basename preselection)
-                                    preselection))))))
-    (helm-do-grep-1 targets nil nil nil nil use-region-or-symbol-p)))
+  (helm-exit-and-execute-action 'spacemacs//helm-project-smart-search-in-dir))
 
-(defun spacemacs/helm-file-do-grep ()
-  "Search in current file with `grep' using a default input."
-  (interactive)
-  (spacemacs//helm-do-grep-region-or-symbol
-   (list (buffer-file-name (current-buffer))) nil))
-
-(defun spacemacs/helm-file-do-grep-region-or-symbol ()
-  "Search in current file with `grep' using a default input."
-  (interactive)
-  (spacemacs//helm-do-grep-region-or-symbol
-   (list (buffer-file-name (current-buffer))) t))
-
-(defun spacemacs/helm-files-do-grep ()
-  "Search in files with `grep'."
-  (interactive)
-  (spacemacs//helm-do-grep-region-or-symbol nil nil))
-
-(defun spacemacs/helm-files-do-grep-region-or-symbol ()
-  "Search in files with `grep' using a default input."
-  (interactive)
-  (spacemacs//helm-do-grep-region-or-symbol nil t))
-
-(defun spacemacs/helm-buffers-do-grep ()
-  "Search in opened buffers with `grep'."
-  (interactive)
-  (let ((buffers (cl-loop for buffer in (buffer-list)
-                          when (buffer-file-name buffer)
-                          collect (buffer-file-name buffer))))
-    (spacemacs//helm-do-grep-region-or-symbol buffers nil)))
-
-(defun spacemacs/helm-buffers-do-grep-region-or-symbol ()
-  "Search in opened buffers with `grep' with a default input."
-  (interactive)
-  (let ((buffers (cl-loop for buffer in (buffer-list)
-                          when (buffer-file-name buffer)
-                          collect (buffer-file-name buffer))))
-    (spacemacs//helm-do-grep-region-or-symbol buffers t)))
+;;;; Helm Last Buffer
 
 (defun spacemacs/resume-last-search-buffer ()
-  "open last helm-ag or hgrep buffer."
+  "Open last \"helm-ag\" or \"helm-grep\" buffer."
   (interactive)
+  (require 'helm)
   (cond ((get-buffer "*helm ag results*")
          (switch-to-buffer-other-window "*helm ag results*"))
         ((get-buffer "*helm-ag*")
@@ -505,15 +303,22 @@ If DEFAULT-INPUTP is non nil then the current region or symbol at point
         ((get-buffer "*hgrep*")
          (switch-to-buffer-other-window "*hgrep*"))
         (t
-         (message "No previous search buffer found"))))
+         (message "no previous search buffer found"))))
+
+;;;; Helm Find Files
 
 (defun spacemacs/helm-find-files (arg)
-  "Custom spacemacs implementation for calling helm-find-files-1.
-Removes the automatic guessing of the initial value based on thing at point. "
+  "Custom spacemacs implementation for calling `helm-find-files-1'.
+This removes the automatic guessing of the initial value based on thing at
+point.
+
+ARG An existing file."
   (interactive "P")
   ;; fixes #10882 and #11270
   (require 'helm-files)
-  (let* ((hist (and arg helm-ff-history (helm-find-files-history)))
+  (let* ((hist (and arg
+                    helm-ff-history
+                    (helm-find-files-history arg)))
          (default-input hist)
          (input (cond ((and (eq major-mode 'dired-mode) default-input)
                        (file-name-directory default-input))
@@ -523,7 +328,11 @@ Removes the automatic guessing of the initial value based on thing at point. "
     (set-text-properties 0 (length input) nil input)
     (helm-find-files-1 input)))
 
- ;; Key bindings
+(byte-compile 'spacemacs/helm-find-files)
+
+(defalias 'spacemacs/helm-find-files-with-guess 'helm-find-files)
+
+;;;; Key-bindings
 
 (defmacro spacemacs||set-helm-key (keys func)
   "Define a key bindings for FUNC using KEYS.
@@ -534,21 +343,22 @@ Ensure that helm is required before calling FUNC."
          ,(format "Wrapper to ensure that `helm' is loaded before calling %s."
                   (symbol-name func))
          (interactive)
-         (require 'helm)
          (call-interactively ',func))
        (spacemacs/set-leader-keys ,keys ',func-name))))
 
- ;; Find files tweaks
+;;;; Helm Actions
 
 (defun spacemacs//helm-find-files-edit (candidate)
-  "Opens a dired buffer and immediately switches to editable mode."
+  "Open a dired buffer and immediately switch to editable mode.
+CANDIDATE File to be opened."
   (dired (file-name-directory candidate))
   (dired-goto-file candidate)
   (dired-toggle-read-only))
 
 (defun spacemacs/helm-find-files-edit ()
-  "Exits helm, opens a dired buffer and immediately switches to editable mode."
+  "Exit helm, open a dired buffer and immediately switch to editable mode."
   (interactive)
+  (require 'helm)
   (helm-exit-and-execute-action 'spacemacs//helm-find-files-edit))
 
 (defun spacemacs/helm-jump-in-buffer ()
@@ -556,20 +366,29 @@ Ensure that helm is required before calling FUNC."
   (interactive)
   (call-interactively
    (cond
-    ((eq major-mode 'org-mode) 'helm-org-in-buffer-headings)
-    (t 'helm-semantic-or-imenu))))
+    ((eq major-mode 'org-mode)
+     (require 'helm-org)
+     'helm-org-in-buffer-headings)
+    (t
+     (require 'helm-semantic)
+     'helm-semantic-or-imenu))))
 
 (defun spacemacs//helm-open-buffers-in-windows (buffers)
-  "This function allows a different default action, on marking multiple
+  "Open buffers across already-opened windows.
+This function allows a different default action, on marking multiple
 candidate buffers/files for helm. By default, helm either opens all
-files/buffers in the same window, or creates splits. This function instead
-opens the buffers (or files) across different already-open windows. The first
-selected buffer is opened in the current window, the next is opened in the
-window with higher number, etc. This will make a loop around, so with 4
-windows, and window 2 active, opening 4 buffers will open them in windows
+files/buffers in the same window, or creates splits.
+
+This function instead opens the buffers (or files) across different already-open
+windows. The first selected buffer is opened in the current window, the next is
+opened in the window with higher number, etc. This will make a loop around, so
+with 4 windows, and window 2 active, opening 4 buffers will open them in windows
 2 3 4 1. If more buffers are opened than windows available, the remainder are
 not set to any window (but in the case of files, they are still opened
-to buffers)."
+to buffers).
+
+BUFFERS Buffers to be opened."
+  (require 'winum)
   (let ((num-buffers (length buffers))
         (num-windows (length (winum--window-list)))
         (cur-win (or (winum-get-number) (winum-get-number (other-window 1))))
@@ -581,28 +400,35 @@ to buffers)."
              (cl-incf num-buffers-placed))))
 
 (defun spacemacs/helm-find-buffers-windows ()
+  "Action to open the window with the specified buffer in `helm-buffers-list'."
   (interactive)
+  (require 'helm)
+  (unless (helm-marked-candidates) (user-error "Not in `helm-buffers-list'"))
   (helm-exit-and-execute-action
    (lambda (candidate)
      (spacemacs//helm-open-buffers-in-windows (helm-marked-candidates)))))
 
 (defun spacemacs/helm-find-files-windows ()
+  "Action to open the window with the specified file in a `helm' buffer."
   (interactive)
+  (require 'helm)
+  (unless (helm-marked-candidates) (user-error "Not in `helm' buffer"))
   (helm-exit-and-execute-action
    (lambda (candidate)
      (let* ((files (helm-marked-candidates))
             (buffers (mapcar 'find-file-noselect files)))
        (spacemacs//helm-open-buffers-in-windows buffers)))))
 
-
-;; Generalized next-error interface
+;;;; Generalized Next-Error Interface
 
-(defun spacemacs//gne-init-helm-ag (&rest args)
+(defun spacemacs//gne-init-helm-ag ()
+  "Generalized `next-error' interface with `helm-ag' integration."
+  (require 'helm-ag)
   (with-current-buffer "*helm ag results*"
     (setq spacemacs--gne-min-line 5
           spacemacs--gne-max-line (save-excursion
                                     (goto-char (point-max))
-                                    (previous-line)
+                                    (forward-line -1)
                                     (line-number-at-pos))
           spacemacs--gne-line-func
           (lambda (c)
@@ -610,39 +436,47 @@ to buffers)."
              c 'find-file helm-ag--search-this-file-p))
           next-error-function 'spacemacs/gne-next)))
 
-(defun spacemacs//gne-init-helm-grep (&rest args)
+(defun spacemacs//gne-init-helm-grep ()
+  "Generalized `next-error' interface with `helm-grep' integration."
+  (require 'helm-grep)
   (with-current-buffer "*hgrep*"
     (setq spacemacs--gne-min-line 5
           spacemacs--gne-max-line
           (save-excursion
             (goto-char (point-max))
-            (previous-line)
+            (forward-line -1)
             (line-number-at-pos))
           spacemacs--gne-line-func 'helm-grep-action
           next-error-function 'spacemacs/gne-next)))
 
-
-;; theme
+;;;; Helm Themes
 
 (defun spacemacs/helm-themes ()
-  "Remove limit on number of candidates on `helm-themes'"
+  "Theme selection with helm interface.
+Wrapper of `helm-themes' that removes limit on number of candidates."
   (interactive)
+  (require 'helm-themes)
   (let (helm-candidate-number-limit)
     (helm-themes)))
 
-;; Buffers ---------------------------------------------------------------------
+;;;; Helm Buffers List
 
 (defun spacemacs/helm-buffers-list-unfiltered ()
   "Helm buffers without filtering."
   (interactive)
+  (require 'helm-buffers)
   (let ((helm-boring-buffer-regexp-list nil))
     (call-interactively #'helm-buffers-list)))
 
-;; Command search ---------------------------------------------------------------------
+;;;; Helm Command Search
 
 (defun spacemacs/helm-M-x-fuzzy-matching ()
-  "Helm M-x with fuzzy matching enabled"
+  "Helm \\[helm-M-x-fuzzy-matching] with fuzzy matching enabled."
   (interactive)
+  (require 'helm-command)
   (let ((completion-styles completion-styles))
-    (add-to-list 'completion-styles `,(if (version< emacs-version "27") 'helm-flex 'flex) t)
+    (add-to-list 'completion-styles
+                 `,(if (version< emacs-version "27") 'helm-flex 'flex) t)
     (call-interactively 'helm-M-x)))
+
+;;; funcs.el ends here

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -54,13 +54,8 @@
                                        ("q"   "quit")
                                        ("r"   "registers/rings/resume")
                                        ("s"   "search/symbol")
-                                       ("sa"  "ag")
-                                       ("sg"  "grep")
-                                       ("sk"  "ack")
                                        ("sp"  "search project")
                                        ("sP"  "search project w/input")
-                                       ("sr"  "ripgrep")
-                                       ("st"  "pt")
                                        ("sw"  "web")
                                        ("t"   "toggles")
                                        ("tC"  "colors")
@@ -87,6 +82,16 @@
                                        ("xt"  "transpose")
                                        ("xw"  "words")
                                        ("z"   "zoom")))
+
+;; Only add selected search-tools to key-binding-prefix
+(nconc spacemacs/key-binding-prefixes
+       (seq-filter (lambda (x) (member (cadr x) dotspacemacs-search-tools))
+                   '(("sr" "rg")
+                     ("sa" "ag")
+                     ("st" "pt")
+                     ("sk" "ack")
+                     ("sg" "grep"))))
+
 (mapc (lambda (x) (apply #'spacemacs/declare-prefix x))
       spacemacs/key-binding-prefixes)
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -144,17 +144,17 @@
             (cl-pushnew
              '("/" (lambda ()
                      (call-interactively
-                      'spacemacs/helm-project-smart-do-search-region-or-symbol)))
+                      'spacemacs/helm-smart-search-project-with-input)))
              new-bindings)
             (cl-pushnew
              '("f" (lambda ()
                      (call-interactively
-                      'spacemacs/helm-files-smart-do-search-region-or-symbol)))
+                      'spacemacs/helm-smart-search-files-with-input)))
              new-bindings)
             (cl-pushnew
              '("b" (lambda ()
                      (call-interactively
-                      'spacemacs/helm-buffers-smart-do-search-region-or-symbol)))
+                      'spacemacs/helm-smart-search-buffers-with-input)))
              new-bindings)
             (setq ad-return-value (cons new-msg new-bindings)))))
       (setq expand-region-contract-fast-key "V"

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -544,7 +544,7 @@ Run PROJECT-ACTION on project."
                   'helm-projectile-recentf))
                ("Switch to Project Perspective and Search" .
                 ,(spacemacs//helm-persp-switch-project-action-maker
-                  'spacemacs/helm-project-smart-do-search))))
+                  'spacemacs/helm-smart-search-project))))
    :buffer "*Helm Projectile Layouts*"))
 
 (defun spacemacs//make-helm-list-reorder-fn (fn)

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -330,7 +330,7 @@ When ARG is non-nil search in junk files."
           (arg
            (require 'helm)
            (let (helm-ff-newfile-prompt-p)
-             (spacemacs/helm-files-smart-do-search)))
+             (spacemacs/helm-smart-search-files)))
           (t
            (require 'helm)
            (let (helm-ff-newfile-prompt-p)


### PR DESCRIPTION
This commit includes multiple changes to `helm` layer. Aside from documentation
and reformatting, nontrivial changes are listed below.

- Changed search tool integration interface.
  - Currently, supported search TOOLs are `rg`, `ag`, `pt`, `ack` and `grep`.
    And the following search functions are implemented:
    - `spacemacs/helm-buffers-do-<TOOL>`: Search within all opened buffers.
    - `spacemacs/helm-dir-do-<TOOL>`: Search within current directory.
    - `spacemacs/helm-files-do-<TOOL>`: Search within a specified directory.
    - `spacemacs/helm-file-do-<TOOL>`: Search within current file/buffer.
    - `spacemacs/helm-project-do-<TOOL>`: Search within current project.
    - For each search SCOPE, i.e. one of BUFFERS, FILES, FILE, PROJECT, there is
      a variant that choose the first search tool found,
      `spacemacs/helm-<SCOPE>-smart-do-search`.
    - For every combinations of search TOOL and search SCOPE, there is a variant
      that uses the symbol at point or current selection as default input,
      `spacemacs/helm-<SCOPE>-<TOOL>-region-or-symbol`.
  - This commit renamed those functions from
    `spacemacs/helm-<SCOPE>-<smart-do-search|do-TOOL>[-with-region-or-symbol]`
    to `spacemacs/helm-<smart-search|TOOL>-<SCOPE>[-with-input]`.
    - The new names are shorter than the old ones, and uses `SVO` order instead
      of the less common `SOV` order, where subject is `helm`, verb is the
      search tool, and object is the scope.
  - This commit also added missing functionalities, so that feature parity is
    achieved for all supported search tools
    - Currently only `ag` and `grep` supports searching within the current
      file/buffer. This commits adds this functionality to all search tools.
  - The new search functions behaves **differently** from the old ones:
    - `spacemacs/helm-<smart-search|TOOL>-buffer[-with-input]`: Search in
      current buffer. When prefixed with universal argument, search within all
      opened buffers.
    - `spacemacs/helm-<smart-search|TOOL>-dir[-with-input]`: Search in current
      directory. When prefixed with universal argument, prompt for a directory
      and search within it.
    - `spacemacs/helm-<smart-search|TOOL>-project[-with-input]`: Search in
      current project. When prefixed with universal argument, prompt for string
      input as additional command-line arguments passed to the search tool.
    - A comparison of the interfaces is attached in the end of this commit
      message.
  - ALL aforementioned search interfaces are combined into a monolithic
    dispatcher function, `spacemacs-helm-search-dispatcher`.
    - The dispatcher itself is byte compiled. Key bindings are registered for
      thin wrappers of the dispatcher.
  - Proper error handling is implemented (the first two are new additions from
    this commit):
    - Reports an error if no search tool is found when calling one of the
      smart search function.
    - Reports an error if the search tool is not found when calling one of the
      search functions which has a specified search tool.
    - Reports an error if the current directory is not a project directory
      when calling one of the project-scope search function.
- Added filtering when adding per-search-tool key bindings.
  - Currently regardless of the value of `dotspacemacs-search-tools`, all
    supported search tools have their search functions declared and key bindings
    registered.
  - This commit still declares all search functions for all supported search
    tools, but only register key bindings for those listed in
    `dotspacemacs-search-tools`. E.g., if its value is `'(rg)`, then only those
    under `SPC s r` are added.
  - In other words, users can still invoke all supported search functions via
    `M-x` interface, but only those of the search tools they specified would
    have key bindings.
  - Since this commit also achieved feature parity across all supported search
    tools, in the future we might not add any search-tool-specific at all.

Comparison of the old and new interfaces, using smart search without default
input as examples:

|Scope                        |New Interface|Old Interface                     |
|-----------------------------|-------------|----------------------------------|
|All opened buffers           |`SPC s b`    |`SPC s b`                         |
|Current buffer               |`C-u SPC s b`|Only available for `ag` and `grep`|
|Current directory            |`SPC s d`    |`SPC s d`                         |
|Specified directory          |`C-u SPC s d`|`SPC s f`                         |
|Current project              |`SPC s p`    |`SPC s p`                         |
|Current project w/ extra args|`C-u SPC s p`|Not supported                     |

Signed-off-by: Lucius Hu <lebensterben@users.noreply.github.com>