### PR TITLE
fix page-break-lines-mode alias definition

### DIFF
--- a/core/libs/page-break-lines.el
+++ b/core/libs/page-break-lines.el
@@ -106,7 +106,7 @@ horizontal line of `page-break-lines-char' characters."
   (page-break-lines--update-display-tables))
 
 ;;;###autoload
-(define-obsolete-function-alias 'turn-on-page-break-lines-mode 'page-break-lines-mode)
+(define-obsolete-function-alias 'turn-on-page-break-lines-mode 'page-break-lines-mode "2018-07-24")
 
 (dolist (hook '(window-configuration-change-hook
                 window-size-change-functions


### PR DESCRIPTION
This definition requires 3 arguments. Having only two can cause Emacs a
wrong-number-of-arguments error (was reported on gitter). So this PR just
 adds the date when the orginal functions were removed and the alias was
 created. Just a minor fix.