### PR TITLE
[markdown] fontify code blocks natively: on by default

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -134,7 +134,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   (thanks to Cormac Cannon)
 - Removed cquery.
 ***** EPUB
-- Add ~J/K~ for scrolling down/up (thanks to Daniel Nicolai) 
+- Add ~J/K~ for scrolling down/up (thanks to Daniel Nicolai)
 ***** ESS
 - ESS key bindings were re-organised in the following list
   (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):
@@ -2610,6 +2610,8 @@ files (thanks to Daniel Nicolai)
 - Improvements:
   - Evilfied =dap= debug windows
 **** Markdown
+- Fontify code blocks natively by default, for parity with the Org layer (thanks
+  to Keith Pinson)
 - Disable =mmm-mode= in Git commit buffers, in order to allow the use of Markdown
   mode when committing (thanks to Keith Pinson)
 - New layer variable =markdown-mmm-auto-modes= which is a list of language names

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -62,6 +62,9 @@
     :defer t
     :config
     (progn
+      ;; Make markdown-mode behave a bit more like org w.r.t. code blocks i.e.
+      ;; use proper syntax highlighting
+      (setq markdown-fontify-code-blocks-natively t)
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")
                         ("mh" . "markdown/header")


### PR DESCRIPTION
I realized this is on by default in Spacemacs for Org. Arguably Spacemacs should have a somewhat consistent default experience between Org and Markdown.

If anyone disagrees, it's no big deal to me. I wasn't even going to suggest upstreaming it until I saw this in `layers/+emacs/org/packages.el`:

```emacs-lisp
(defun org/init-org ()
  (use-package org
    :defer ...
    :commands ...
    :init
    (progn
      ...
      (setq ...
            org-src-fontify-natively t
            ...
```

Though it would be nice for look & feel of Spacemacs out of the box.