### PR TITLE
Add org-journal-open-current-journal-file keybinding

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2773,7 +2773,8 @@ files (thanks to Daniel Nicolai)
   (thanks to Steven Allen)
 - Packages:
   - Added package =org-journal= (thanks to Nick Anderson)
-    - Added shortcuts for handling scheduled entries (thanks to Daniel Nicolai)
+    - Added shortcuts for handling scheduled entries and find journal file
+      (thanks to Daniel Nicolai)
   - Added package for =org-sticky-header-mode= (thanks to Langston Barret)
   - Added package =org-jira= (thanks to Kirill A. Korinsky)
   - Added package =org-rich-yank= (thanks to Keith Pinson)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -781,6 +781,7 @@ org-present must be activated explicitly by typing: ~SPC SPC org-present~
 
 | Key binding         | Description                                     |
 |---------------------+-------------------------------------------------|
+| ~SPC a o j f~       | Visit journal file                              |
 | ~SPC a o j j~       | New journal entry                               |
 | ~SPC u SPC a o j j~ | Open today's journal without adding a new entry |
 | ~SPC a o j s~       | Search journal entries                          |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -801,6 +801,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
     (progn
       (spacemacs/declare-prefix "aoj" "org-journal")
       (spacemacs/set-leader-keys
+        "aojf" 'org-journal-open-current-journal-file
         "aojj" 'org-journal-new-entry
         "aojs" 'org-journal-search-forever
         "aojt" 'org-journal-new-scheduled-entry


### PR DESCRIPTION
This is such an elementary org-journal command that it should have a
keybinding. 