### PR TITLE
Add variables for configuration of startup of the @Org perspective.

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -27,6 +27,7 @@
   - [[#epub-support][Epub support]]
   - [[#jira-support][Jira support]]
   - [[#verb-support][Verb support]]
+  - [[#spacemacs-layout-integration][Spacemacs layout integration]]
 - [[#key-bindings][Key bindings]]
   - [[#starting-org-mode][Starting org-mode]]
   - [[#toggles][Toggles]]
@@ -363,6 +364,12 @@ To install [[https://github.com/federicotdn/verb][Verb]], an HTTP client based o
   (setq-default dotspacemacs-configuration-layers
    '((org :variables org-enable-verb-support t)))
 #+END_SRC
+
+** Spacemacs layout integration
+A [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#layouts-and-workspaces][Spacemacs custom layout]] =@Org=  is defined by the layer and accessible via =SPC l o=. The startup behavior can be customized with the following layer variables:
+- =org-persp-startup-org-file= Defines the org file buffer that should be opened after startup. Defaults to the first file in =org-agenda-files=, if =org-persp-startup-org-file= is set to =nil=.
+- =org-persp-startup-with-agenda= If non-nil, sets initial buffer to the specified (custom) org-agenda buffer, e.g. =(setq org-persp-startup-with-agenda "a")= opens =org-agenda-list=.
+
 
 * Key bindings
 ** Starting org-mode

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -58,3 +58,9 @@ are configured.")
 
 (defvar org-enable-roam-support nil
   "If non-nil, org-roam (https://www.orgroam.com/) is configured")
+
+(defvar org-persp-startup-org-file nil
+  "If non-nil, opens the specified file instead of the first in org-agenda-files")
+
+(defvar org-persp-startup-with-agenda nil
+  "If non-nil, opens the specified agenda custom view")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -790,7 +790,9 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :body
     (let ((agenda-files (org-agenda-files)))
       (if agenda-files
-          (find-file (first agenda-files))
+          (progn (find-file (if org-persp-startup-org-file org-persp-startup-org-file (first agenda-files)))
+                 (if org-persp-startup-with-agenda (org-agenda nil org-persp-startup-with-agenda)
+                 ))
         (user-error "Error: No agenda files configured, nothing to display.")))))
 
 (defun org/init-org-journal ()


### PR DESCRIPTION
Added two variables 
`org-persp-startup-org-file` and `org-persp-startup-with-agenda` initialized to `nil` with no changes to the current behavior.
These variables can be set by the user to initialize the @<!-- -->Org perspective with a specified file and/or a (custom) agenda view.

Docs will be updated, once the PR is accepted.