### PR TITLE
Add some missing key bindings for org-agenda

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -651,9 +651,12 @@ The evilified org agenda supports the following bindings:
 |----------------------+-----------------------------------|
 | ~M-SPC~ or ~s-M-SPC~ | org-agenda transient state        |
 | ~SPC m a~            | org-agenda                        |
+| ~SPC m ,~            | org-agenda-ctrl-c-ctrl-c          |
+| ~SPC m c~            | org-agenda-capture                |
 | ~SPC m C c~          | org-agenda-clock-cancel           |
 | ~SPC m C i~          | org-agenda-clock-in               |
 | ~SPC m C o~          | org-agenda-clock-out              |
+| ~SPC m C j~          | org-agenda-clock-goto             |
 | ~SPC m C p~          | org-pomodoro (if package is used) |
 | ~SPC m d d~          | org-agenda-deadline               |
 | ~SPC m d s~          | org-agenda-schedule               |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -462,10 +462,13 @@ Will work on both org-mode and any mode that accepts plain html."
         (spacemacs/declare-prefix-for-mode 'org-agenda-mode
           (car prefix) (cdr prefix)))
       (spacemacs/set-leader-keys-for-major-mode 'org-agenda-mode
+        (or dotspacemacs-major-mode-leader-key ",") 'org-agenda-ctrl-c-ctrl-c
         "a" 'org-agenda
+        "c" 'org-agenda-capture
         "Cc" 'org-agenda-clock-cancel
         "Ci" 'org-agenda-clock-in
         "Co" 'org-agenda-clock-out
+        "Cj" 'org-agenda-clock-goto
         "dd" 'org-agenda-deadline
         "ds" 'org-agenda-schedule
         "ie" 'org-agenda-set-effort


### PR DESCRIPTION
Adds keybinding for `org-agenda-capture` `org-agenda-clock-goto` and `org-agenda-ctrl-c-ctrl-c`.

These are the same keybindings as in standard `org-mode`.