### PR TITLE
Fix typo found in commit ab4877f218def9ad1d90a1b625db6ff44c394286

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -153,7 +153,7 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
 (defun mu4e/pre-init-org ()
   (if mu4e-org-link-support
       (with-eval-after-load 'org
-        (require 'mu4e-org)
+        (require 'org-mu4e)
         ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
         ;; Note that this bug prevents lazy-loading.
         (require 'mu4e-meta)


### PR DESCRIPTION
Resolved typo in the above commit,

Open Issue with more detail here: https://github.com/syl20bnr/spacemacs/issues/14275

This is all very new to me, let me know if I missed anything important!