### PR TITLE
Add toggles for specific persistent which-key keymaps

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -617,6 +617,8 @@ Other:
     =dotspacemacs-emacs-dumper-dump-file= (thanks to Evan Klitzke)
   - Add =spacemacs-scratch-mode-hook= to run functions
     after =spacemacs-scratch-mode= is applied to =*scratch*= buffer (thanks to rayw000)
+  - Add toggles for persistent which-key keymaps, (full)-major/minor mode
+    keymaps and top-level keymap, under prefix ~SPC t k~ (thanks to Daniel Nicolai)
 - Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -114,6 +114,7 @@
   - [[#discovering][Discovering]]
     - [[#key-bindings][Key bindings]]
       - [[#which-key][Which-key]]
+      - [[#which-key-persistent][Which-key persistent]]
       - [[#describe-key-bindings][Describe key bindings]]
     - [[#getting-help][Getting help]]
     - [[#available-layers][Available layers]]
@@ -1982,6 +1983,26 @@ By default the [[https://github.com/justbur/emacs-which-key][which-key]] buffer 
 pressed. You can change the delay by setting the variable
 =dotspacemacs-which-key-delay= to your liking (the value is in seconds).
 
+**** Which-key persistent
+Sometimes it can be handy to show some keymap persistently with which-key,
+especially in buffers with merely evilified keybindings or using Emacs state,
+e.g. Info buffers, gnus, eww etc. The persistent =which-key= state can be
+toggled with ~SPC t k k~. For some specific keymaps, dedicated keybindings are
+also available behind the ~SPC t k~ prefix:
+
+| Key binding | Description                                                         |
+|-------------+---------------------------------------------------------------------|
+| ~SPC t k k~ | toggle which-key persistent state                                   |
+| ~SPC t k m~ | show persistent major-mode keymap. Toggle off with ~SPC t k k~      |
+| ~SPC t k M~ | show persistent full-major-mode keymap. Toggle off with ~SPC t k k~ |
+| ~SPC t k t~ | show persistent top-level keymap. Toggle off with ~SPC t k k~       |
+
+The keybindings just set the =which-key-persistent-popup= to ~t~, hence the
+which-key buffer will keep updating. Therefore the latter 3 keybindings (~SPC t
+k m/M/t~) can be used to return focus to their respective keymaps, while only
+the first keybinding ~SPC t k k~ can be used for toggling off the persistent
+state.
+
 **** Describe key bindings
 It is possible to search for specific key bindings by pressing ~SPC ?~.
 
@@ -2042,8 +2063,8 @@ Navigation key bindings in =help-mode=:
 
 | Key binding  | Description                                         |
 |--------------+-----------------------------------------------------|
-| ~J~          | Scroll up (or next node)                            |
-| ~K~          | Scroll down (or next node)                          |
+| ~J~          | scroll up (or next node)                            |
+| ~K~          | scroll down (or next node)                          |
 | ~g b~ or ~[~ | go back (same as clicking on =[back]= button)       |
 | ~g f~ or ~]~ | go forward (same as clicking on =[forward]= button) |
 | ~g h~        | go to help for symbol under point                   |

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -21,7 +21,7 @@
         (hydra :step bootstrap)
         (use-package :step bootstrap)
         (which-key :step bootstrap)
-        ;; pre packages, initialized aftert the bootstrap packages
+        ;; pre packages, initialized after the bootstrap packages
         ;; these packages can use use-package
         (dotenv-mode :step pre)
         (evil-evilified-state :location local :step pre :protected t)
@@ -341,6 +341,54 @@
     :documentation
     "Display a buffer with available key bindings."
     :evil-leader "tK")
+
+  (spacemacs/declare-prefix "tk" "which-key-persistent")
+  (setq which-key-toggle-of-message
+        "To exit which-key-persistent-mode use `which-key-toggle-persistent'.")
+  
+  (spacemacs|add-toggle which-key-toggle-persistent
+    :status which-key-persistent-popup
+    :on (setq which-key-persistent-popup t)
+    :off (setq which-key-persistent-popup nil)
+    :documentation
+    "Toggle on/off which-key-persistent-popup."
+    :evil-leader "tkk")
+
+  (spacemacs|add-toggle which-key-major-mode-map
+    :status which-key-persistent-popup
+    :on (progn
+          (setq which-key-persistent-popup t)
+          (which-key-show-major-mode))
+    :off (which-key-show-major-mode)
+    :documentation
+    "Show persistent major mode keymap.
+Press \\[which-key-toggle-persistent] to hide."
+    :off-message which-key-toggle-of-message
+    :evil-leader "tkm")
+
+  (spacemacs|add-toggle which-key-full-major-mode-map
+    :status which-key-persistent-popup
+    :on (progn
+          (setq which-key-persistent-popup t)
+          (which-key-show-full-major-mode))
+    :off (which-key-show-full-major-mode)
+    :documentation
+    "Show persistent full major mode keymap.
+Press \\[which-key-toggle-persistent] to hide."
+    :off-message which-key-toggle-of-message
+    :evil-leader "tkM")
+
+  (spacemacs|add-toggle which-key-top-level
+    :status which-key-persistent-popup
+    :on (progn
+          (setq which-key-persistent-popup t)
+          (which-key-show-top-level))
+    :off (which-key-show-top-level)
+    :documentation
+    "Show persistent top level keymap.
+Press \\[which-key-toggle-persistent] to hide."
+    :off-message which-key-toggle-of-message
+    :evil-leader "tkt")
 
   (spacemacs/set-leader-keys "hk" 'which-key-show-top-level)
 


### PR DESCRIPTION
Sometimes it is handy to show keymaps persistently with which-key. For example,
to show navigation keys in Info-mode, gnus, eww etc. This PR implements
handy toggles and documentation for that.

Of course this is just a quick way to implement some kind of alternative hydra transient states.

Also I am always happy about feedback/improvements/discussions, my PR's are merely proposals.