### PR TITLE
fixed package name from org-super-star to org-superstar

### DIFF
--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -64,7 +64,7 @@
       (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)))))
 
 (defun spacemacs-org/init-org-superstar ()
-  (use-package org-super-star
+  (use-package org-superstar
     :defer t
     :init (add-hook 'org-mode-hook 'org-superstar-mode)))
 


### PR DESCRIPTION
This simply fixes what seems to be a typo in the package name where extra dash is removed between "super" and "star".

The correct name of the package is org-superstar, not org-super-star.
For example MELPA lists only org-superstar, not org-super-star.
I'm puzzled why this typo was not noticed before.
