### PR TITLE
Implement C-(S)-tab buffer switch in Ivy layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2354,6 +2354,7 @@ Other:
   - Bound =SPC s l= to =ivy-resume= (thanks to Wieland Hoffmann)
   - Rebind =C-k= to =C-M-k= in =ivy-reverse-i-search= (=C-r= at a prompt)
     (thanks to duianto)
+  - Add =C-(S)-tab= keybindings for buffer switching (thanks to Daniel Nicolai)
 - Removed definitions for =spacemacs/swiper-region-or-symbol= and
   =spacemacs/swiper-all-region-or-symbol= and updated keybindings, because Ivy has
   more advanced implementation via =swiper-thing-at-point= and

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2442,32 +2442,33 @@ The mode can be toggled on and off with ~SPC t g~.
 **** Buffers manipulation key bindings
 Buffer manipulation commands (start with ~b~):
 
-| Key binding     | Description                                                                            |
-|-----------------+----------------------------------------------------------------------------------------|
-| ~SPC TAB~       | switch to alternate buffer in the current window (switch back and forth)               |
-| ~SPC b b~       | switch to a buffer                                                                     |
-| ~SPC b d~       | kill the current buffer (does not delete the visited file)                             |
-| ~SPC u SPC b d~ | kill the current buffer and window (does not delete the visited file)                  |
-| ~SPC b D~       | kill a visible buffer using [[https://github.com/abo-abo/ace-window][ace-window]]                                                 |
-| ~SPC u SPC b D~ | kill a visible buffer and its window using [[https://github.com/abo-abo/ace-window][ace-window]]                                  |
-| ~SPC b C-d~     | kill other buffers                                                                     |
-| ~SPC b C-D~     | kill buffers using a regular expression                                                |
-| ~SPC b e~       | erase the content of the buffer (ask for confirmation)                                 |
-| ~SPC b h~       | open =*spacemacs*= home buffer                                                         |
-| ~SPC b H~       | open or select the =*Help*= buffer                                                     |
-| ~SPC b n~       | switch to next buffer avoiding buffers matching =spacemacs-useless-buffers-regexp=     |
-| ~SPC b m~       | open =*Messages*= buffer                                                               |
-| ~SPC u SPC b m~ | kill all buffers and windows except the current one                                    |
-| ~SPC b M~       | kill all buffers matching the regexp                                                   |
-| ~SPC b p~       | switch to previous buffer avoiding buffers matching =spacemacs-useless-buffers-regexp= |
-| ~SPC b P~       | copy clipboard and replace buffer (useful when pasting from a browser)                 |
-| ~SPC b R~       | revert the current buffer (reload from disk)                                           |
-| ~SPC b s~       | switch to the =*scratch*= buffer (create it if needed)                                 |
-| ~SPC b u~       | reopen the most recently killed file buffer                                            |
-| ~SPC b w~       | toggle read-only (writable state)                                                      |
-| ~SPC b x~       | kill the current buffer and window (does not delete the visited file)                  |
-| ~SPC b Y~       | copy whole buffer to clipboard (useful when copying to a browser)                      |
-| ~z f~           | Make current function or comments visible in buffer as much as possible                |
+| Key binding     | Description                                                                                 |
+|-----------------+---------------------------------------------------------------------------------------------|
+| ~SPC TAB~       | switch to alternate buffer in the current window (switch back and forth)                    |
+| ~C TAB/C-S TAB~ | cycle back/forward over previous buffers while showing them (only supported with Ivy layer) |
+| ~SPC b b~       | switch to a buffer                                                                          |
+| ~SPC b d~       | kill the current buffer (does not delete the visited file)                                  |
+| ~SPC u SPC b d~ | kill the current buffer and window (does not delete the visited file)                       |
+| ~SPC b D~       | kill a visible buffer using [[https://github.com/abo-abo/ace-window][ace-window]]                                                      |
+| ~SPC u SPC b D~ | kill a visible buffer and its window using [[https://github.com/abo-abo/ace-window][ace-window]]                                       |
+| ~SPC b C-d~     | kill other buffers                                                                          |
+| ~SPC b C-D~     | kill buffers using a regular expression                                                     |
+| ~SPC b e~       | erase the content of the buffer (ask for confirmation)                                      |
+| ~SPC b h~       | open =*spacemacs*= home buffer                                                              |
+| ~SPC b H~       | open or select the =*Help*= buffer                                                          |
+| ~SPC b n~       | switch to next buffer avoiding buffers matching =spacemacs-useless-buffers-regexp=          |
+| ~SPC b m~       | open =*Messages*= buffer                                                                    |
+| ~SPC u SPC b m~ | kill all buffers and windows except the current one                                         |
+| ~SPC b M~       | kill all buffers matching the regexp                                                        |
+| ~SPC b p~       | switch to previous buffer avoiding buffers matching =spacemacs-useless-buffers-regexp=      |
+| ~SPC b P~       | copy clipboard and replace buffer (useful when pasting from a browser)                      |
+| ~SPC b R~       | revert the current buffer (reload from disk)                                                |
+| ~SPC b s~       | switch to the =*scratch*= buffer (create it if needed)                                      |
+| ~SPC b u~       | reopen the most recently killed file buffer                                                 |
+| ~SPC b w~       | toggle read-only (writable state)                                                           |
+| ~SPC b x~       | kill the current buffer and window (does not delete the visited file)                       |
+| ~SPC b Y~       | copy whole buffer to clipboard (useful when copying to a browser)                           |
+| ~z f~           | Make current function or comments visible in buffer as much as possible                     |
 
 **** Create a new empty buffer
 

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -210,6 +210,12 @@
         "rl" 'ivy-resume
         "sl" 'ivy-resume
         "bb" 'ivy-switch-buffer)
+      ;; Common Ctrl-TAB buffer switch behavior
+      (with-eval-after-load 'evil
+        (evil-global-set-key 'motion (kbd "<C-tab>") 'ivy-switch-buffer)
+        (evil-global-set-key 'motion (kbd "<C-iso-lefttab>") 'ivy-switch-buffer))
+      (define-key ivy-mode-map (kbd "<C-tab>") 'ivy-next-line-and-call)
+      (define-key ivy-mode-map (kbd "<C-iso-lefttab>") 'ivy-previous-line-and-call)
       ;; Moved C-k to C-M-k
       (define-key ivy-switch-buffer-map (kbd "C-M-k") 'ivy-switch-buffer-kill)
       (define-key ivy-reverse-i-search-map


### PR DESCRIPTION
These keybindings offer a nearly equivalent experience to the common C-tab buffer switching behavior. To me this is still the superior way for switching between previous buffers (more than only one like `SPC-tab`). Also, I think many other users like this behavior, see:
https://stackoverflow.com/questions/4146574/how-to-properly-configure-ctrl-tab-in-emacs
https://stackoverflow.com/questions/4133181/emacs-tab-between-buffers
https://www.reddit.com/r/emacs/comments/9z4faf/ctrltab_buffer_switching/
 (the only downside is that new users maybe will not use `SPC b b` when they should, but I guess they will).

I am not sure if the keystring used in the last defined keybinding is universal, but this one is working for my keyboard.

As far as I know these bindings do not interfere with any other bindings (i.e. they were all still undefined).

It is just a proposal... no need to merge it if you think it does not fit.

The table was outlined using `org-cycle` and `emacs -Q`.
