### PR TITLE
[helpful] Add missing global key bindings

### DIFF
--- a/layers/+emacs/helpful/README.org
+++ b/layers/+emacs/helpful/README.org
@@ -36,7 +36,10 @@ by this layer.
 | =SPC m h h= | Open helpful buffer for item under point in elisp mode |
 | =SPC h d k= | Open helpful buffer for key binding                    |
 | =SPC h d f= | Open helpful buffer for any callable object            |
-| =SPC h h v= | Open helpful buffer for variable                       |
+| =SPC h d v=  | Open helpful buffer for variable                       |
+| =C-h k=     | Open helpful buffer for key binding                    |
+| =C-h f=     | Open helpful buffer for any callable object            |
+| =C-h v=     | Open helpful buffer for variable                       |
 
 ** Helpful mode bindings
 Additional key bindings available in the helpful-mode buffers.

--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -25,7 +25,10 @@
                 (spacemacs/set-leader-keys
                   "hdk" #'helpful-key
                   "hdf" #'helpful-callable
-                  "hdv" #'helpful-variable))
+                  "hdv" #'helpful-variable)
+                (global-set-key (kbd "C-h k") 'helpful-key)
+                (global-set-key (kbd "C-h f") 'helpful-callable)
+                (global-set-key (kbd "C-h v") 'helpful-variable))
               'append)
     :config
     (evil-set-initial-state 'helpful-mode 'normal)


### PR DESCRIPTION
- In addition to the spacemacs leader keys, also replace the default emacs
keybindings under `C-h`

- Fix a documentation copy-paste mistake for `SPC h d v`
