### PR TITLE
[scala] provide an easy way to a small SBT buffer at frame bottom

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3290,6 +3290,9 @@ files (thanks to Daniel Nicolai)
     - ~SPC c s d~ Copy rpms to the phone
     - ~SPC c s i~ Install rpms into target
 **** Scala
+- Provide an easy way to configure SBT to use a small buffer at the bottom of
+  the frame by setting =scala-sbt-window-position= to =bottom= (thanks to Keith
+  Pinson)
 - Move =ensime= to the =java= layer (Tor Hedin Bronner)
 - Key bindings:
   - Evilify =ensime= search in insert/normal mode (thanks to Diego Alvarez)

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -63,6 +63,10 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =scala= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
++ To turn off the Metals tree view side bar, set =scala-auto-treeview= to =nil=.
++ To display SBT in a small buffer at the bottom of the frame, set the
+  =scala-sbt-window-position= layer variable to =bottom=.
+
 * Backends
 The currently supported language backends are:
 - scala-metals

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -17,6 +17,11 @@
 (defvar scala-enable-gtags nil
   "If non nil then gtags is enabled in the scala layer.")
 
+(defvar scala-sbt-window-position nil
+  "Where to position the SBT window.
+If `nil', just let `sbt-mode' figure it out. If `bottom', make a relatively
+small window at the bottom of the frame.")
+
 (defvar scala-auto-insert-asterisk-in-comments nil
   "If non-nil automatically insert leading asterisk in multi-line comments.")
 

--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -59,6 +59,13 @@
   (when (spacemacs//scala-backend-metals-p)
     (add-hook 'scala-mode-hook #'dap-mode)))
 
+(defun spacemacs//scala-display-sbt-at-bottom (buffer args)
+  "Display a short buffer in a dedicated window at frame bottom.
+For use with `sbt:display-buffer-action'."
+  (set-window-dedicated-p
+   (display-buffer-at-bottom buffer (cons '(window-height . 12) args))
+   t))
+
 (defun spacemacs//scala-setup-treeview ()
   "Setup lsp-treemacs for Scala."
   (setq lsp-metals-treeview-show-when-views-received scala-auto-treeview))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -222,6 +222,10 @@
 
       (evil-define-key 'normal scala-mode-map "J" 'spacemacs/scala-join-line)
 
+      (pcase scala-sbt-window-position
+        ('bottom (setq sbt:display-buffer-action
+                       (list #'spacemacs//scala-display-sbt-at-bottom))))
+
       ;; Compatibility with `aggressive-indent'
       (setq scala-indent:align-forms t
             scala-indent:align-parameters t


### PR DESCRIPTION
This feels like the natural place to put the SBT buffer, though we could also extend this with other values in the future. I defaulted this behavior to off in order to not impact folks' current setup.

The window needs to be dedicated because of its strange shape. Most other buffers (e.g. the Magit status buffer) will not look pleasant in it.