### PR TITLE
[org] Update org-enable-valign

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -26,6 +26,7 @@
   - [[#sticky-header-support][Sticky header support]]
   - [[#epub-support][Epub support]]
   - [[#jira-support][Jira support]]
+  - [[#valign-support][Valign support]]
   - [[#verb-support][Verb support]]
 - [[#key-bindings][Key bindings]]
   - [[#starting-org-mode][Starting org-mode]]
@@ -72,6 +73,7 @@ This layer enables [[http://orgmode.org/][org mode]] for Spacemacs.
 - Project-specific TODOs via [[https://github.com/IvanMalison/org-projectile][org-projectile]]
 - Easy insert of URLs from clipboard with org format via [[https://github.com/rexim/org-cliplink][org-cliplink]]
 - Rich insert of code (into a source block with highlighting, and a link) from other buffers via [[https://github.com/unhammer/org-rich-yank][org-rich-yank]]
+- Pixel-perfect visual alignment for Org and Markdown tables via [[https://github.com/casouri/valign][valign]]
 
 * BibTeX
 For more extensive support of references through BibTeX files, have a look at
@@ -354,6 +356,18 @@ you connect, add your authentication credentials to =~/.authinfo.gpg= or
 #+BEGIN_SRC authinfo
   machine yourcompany.atlassian.net login you@example.com password yourPassword port 443
 #+END_SRC
+
+** Valign support
+To install [[https://github.com/casouri/valign][valign]]. Which provides:
+Pixel-perfect visual alignment for Org and Markdown tables.
+Set the variable =org-enable-valign= to =t=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+   '((org :variables org-enable-valign t)))
+#+END_SRC
+
+[[https://github.com/casouri/valign#valignel][Known problem: Rendering large tables (≥100 lines) is laggy.]]
 
 ** Verb support
 To install [[https://github.com/federicotdn/verb][Verb]], an HTTP client based on Org mode, set the

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -58,3 +58,7 @@ are configured.")
 
 (defvar org-enable-roam-support nil
   "If non-nil, org-roam (https://www.orgroam.com/) is configured")
+
+(defvar org-enable-valign nil
+  "If non-nil, enable valign-mode in org-mode buffers.
+ATTENTION: `valign-mode' will be laggy working with tables contain more than 100 lines.")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -47,6 +47,7 @@
         (org-sticky-header :toggle org-enable-sticky-header)
         (verb :toggle org-enable-verb-support)
         (org-roam :toggle org-enable-roam-support)
+        (valign :toggle org-enable-valign)
         ))
 
 (defun org/post-init-company ()
@@ -935,3 +936,11 @@ Headline^^            Visit entry^^               Filter^^                    Da
 (defun org/pre-init-verb ()
   (spacemacs|use-package-add-hook org
     :post-config (add-to-list 'org-babel-load-languages '(verb . t))))
+
+(defun org/init-valign ()
+  (use-package valign
+    :init
+    (progn
+      (add-hook 'org-mode-hook 'valign-mode)
+      (add-hook 'valign-mode-hook (lambda () (unless valign-mode
+                                               (valign-remove-advice)))))))

--- a/layers/+spacemacs/spacemacs-org/config.el
+++ b/layers/+spacemacs/spacemacs-org/config.el
@@ -10,7 +10,3 @@
 ;;; License: GPLv3
 
 ;; Variables
-
-(defvar org-enable-valign nil
-  "If non-nil, enable valign-mode in org-mode buffers.
-ATTENTION: `valign-mode' will be laggy working with tables contain more than 100 lines.")

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -25,7 +25,6 @@
     org-superstar
     (space-doc :location local)
     toc-org
-    (valign :toggle org-enable-valign)
     ))
 
 (defun spacemacs-org/post-init-flyspell ()
@@ -75,14 +74,6 @@
     (progn
       (setq toc-org-max-depth 10)
       (add-hook 'org-mode-hook 'toc-org-enable))))
-
-(defun spacemacs-org/init-valign ()
-  (use-package valign
-    :init
-    (progn
-      (add-hook 'org-mode-hook 'valign-mode)
-      (add-hook 'valign-mode-hook (lambda () (unless valign-mode
-                                               (valign-remove-advice)))))))
 
 (defun spacemacs-org/init-space-doc ()
   (add-hook 'org-mode-hook 'dotspacemacs//prettify-spacemacs-docs))


### PR DESCRIPTION
Document the variable: `org-enable-valign`
and move both the variable definition and the `valign` package setup to the `org` layer.

---

I asked the maintainers if the variable also should end in `-support`, like most of the other org layer variables.

But JAremko pointed out that:
>adding -support hints at some kind of integration
and this is not integration
>
>I would name it something like `org-force-table-alignment`
name like this hints at potential incontestability.
or `org-enable-forced-table-alignment`
kinda long-ish

JAremko also suggested that:
>maybe author of the mode can introduce option to alight only small tables ?
or like give end user a choice with integer variable or something

and:
>he also can add table annotation that controls alignment

If someone with more knowledge about valign agrees, then the variable can be changed. And feel free to suggest the other improvements upstream.