### PR TITLE
Add org-contacts to org layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2787,6 +2787,7 @@ files (thanks to Daniel Nicolai)
   - Added package =org-jira= (thanks to Kirill A. Korinsky)
   - Added package =org-rich-yank= (thanks to Keith Pinson)
   - Added package =org-roam= (thanks to Mariusz Klochowicz)
+  - Added package =org-contacts= (thanks to Daniel Nicolai)
 - Key bindings:
   - ~SPC m T i~ to toggle inline images
   - Move clock related key bindings to ~SPC a o C~
@@ -2898,6 +2899,8 @@ files (thanks to Daniel Nicolai)
     (thanks to Mariusz Klochowicz)
   - Added additional prefix (~SPC m m j~) for org-jira bindings
     (thanks to Mariusz Klochowicz)
+  - Added keybindings ~SPC a o C f~ and org/agenda local ~SPC m C f~ keybindings
+    and changed =clocks= prefixes to =clocks/contacts=
 - Made =org= layer depend on =spacemacs-org= (thanks to Eivind Fonn)
 - Remove =mu4e= and =notmuch= from =org= (thanks to Sylvain Benner)
 - Use evil-org from MELPA (thanks to Eivind Fonn)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -15,6 +15,8 @@
   - [[#twitter-bootstrap-support][Twitter Bootstrap support]]
   - [[#gnuplot-support][Gnuplot support]]
   - [[#revealjs-support][Reveal.js support]]
+  - [[#org-contacts-support][Org-contacts support]]
+    - [[#v-card-importexport][V-Card import/export]]
   - [[#org-journal-support][Org-journal support]]
   - [[#hugo-support][Hugo support]]
   - [[#trello-support][Trello support]]
@@ -154,6 +156,42 @@ Alternatively, add the following line to each =.org= file you want to process:
 #+BEGIN_EXAMPLE
   #+REVEAL_ROOT: https://cdn.jsdelivr.net/npm/reveal.js@3.8.0
 #+END_EXAMPLE
+
+** Org-contacts support
+[[https://github.com/tkf/org-mode/blob/master/contrib/lisp/org-contacts.el][org-contacts]] is a simple contacts management system.
+
+To install org-contacts, set the variable =org-enable-org-contacts-support= to
+=t=. Optionally, also set the variable =org-contacts-files= and add a capture
+template. The value of the =org-contacts-files= variable should be a list with
+filenames to use as contact sources. If set to =nil= (default) then all your Org
+files will be used. The first file in the =org-contacts-files= list can be
+visited with the keyboard shortcut ~SPC a o C f~.
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((org :variables org-enable-org-contacts-support t
+                       org=contact-file '("file1.org" "file2.org")
+                       ("c" "Contacts" entry (file "~/Org/contacts.org")
+                        "* %(org-contacts-template-name)
+  :PROPERTIES:
+  :EMAIL: %(org-contacts-template-email)
+  :END:"))))
+#+END_SRC
+A more elaborate capture template can be found in the =org-contacts.el= file.
+
+Contacts can include the :BIRTHDAY: keyword. To include the birthdays in your
+org-agenda add ~%%(org-contacts-anniversaries)~ to one of your contacts files.
+It is important that this is inserted after a heading an that it has no
+preceding whitespace. So probably the best way is to add
+#+begin_src emacs-lisp
+  * Birthdays
+  %%(org-contacts-anniversaries)
+#+end_src
+to the beginning or the end of one of your contacts files.
+
+*** V-Card import/export
+Importing/exporting contacts can be done via the `org-vcard-import/export`
+commands provided by the [[https://github.com/flexibeast/org-vcard][org-vcard]] package. This package gets installed
+automatically after enabling org contacts support.
 
 ** Org-journal support
 [[https://github.com/bastibe/org-journal][org-journal]] is a simple journal management system that:

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -34,6 +34,9 @@ path, one file per project is used (and the path is relative to
 the project root). If it an absolute path, one global file is
 used.")
 
+(defvar org-enable-org-contacts-support nil
+  "If non-nil org-contacts is configured.")
+
 (defvar org-enable-org-journal-support nil
   "If non-nil org-journal is configured.")
 

--- a/layers/+emacs/org/funcs.el
+++ b/layers/+emacs/org/funcs.el
@@ -12,6 +12,19 @@
 ;; Autoload space-doc-mode
 (autoload 'space-doc-mode "space-doc" nil 'interactive)
 
+(defun org-clocks-prefix ()
+  (if org-enable-org-contacts-support
+      "clocks/contacts"
+    "clocks"))
+
+(defun org-contacts-find-file ()
+  (interactive)
+  (if org-contacts-files
+      (find-file (car org-contacts-files))
+    (message "No specific org-contacts-files defined. Org-contacts uses all org files.")))
+
+
+
 (defun org-projectile/capture (&optional arg)
   (interactive "P")
   (if arg


### PR DESCRIPTION
Org-contacts is a handy contacts management system. It can be used to manage
(email) addresses (compatible with gnus, mu4e, notmuch etc.), birthdays and
more. It is much simpler than bbdb/ebdb and probably powerful enough for most
users.