### PR TITLE
[core] Shorten package update restart message

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2170,13 +2170,11 @@ to update."
         (spacemacs-buffer/append
          (format "\n--> %s package(s) to be updated.\n" upgraded-count))
         (spacemacs-buffer/append
-         (format
-          (concat "\nEmacs has to be restarted to actually install the "
-                  "new version of the packages %s.\n")
-          (if (member 'restart-emacs update-packages)
-              (concat "\n(SPC q r) won't work this time, "
-                      "because the restart-emacs package is being updated")
-            "(SPC q r)")))
+         (format "\nRestart Emacs to install the updated packages. %s\n"
+                 (if (member 'restart-emacs update-packages)
+                     (concat "\n(SPC q r) won't work this time, because the"
+                             "\nrestart-emacs package is being updated.")
+                   "(SPC q r)")))
         (configuration-layer//cleanup-rollback-directory)
         (spacemacs//redisplay)))
     (when (eq upgrade-count 0)


### PR DESCRIPTION
problem:
When the Emacs frame has the default window width (80 characters).

Then the current restart to update message:
Emacs has to be restarted to actually install the new version of the packages (SPC q r)

is cut off at the Emacs frames right edge:
Emacs has to be restarted to actually install the new version of the packages (S

solution:
Shortening the message:
Restart Emacs to install the updated packages. (SPC q r)

says the same thing, and keeps it within 80 characters.