### PR TITLE
[dotfile] new var: dotspacemacs-show-trailing-whitespace

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -490,6 +490,7 @@ In org-agenda-mode
     (thanks to Zach Pearson)
   - New variable =dotspacemacs-read-process-output-max= to optimise lsp
     performance in emacs 27 (thanks to Maximilian Wolff)
+  - New variable =dotspacemacs-show-trailing-whitespace= (thanks to duianto)
 - Removed Variables:
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -391,6 +391,9 @@ If non-nil zone out after the specified number of seconds.")
 Possible values are `any', `current', `all' or `nil'.
 Default is `all' (highlight any scope and emphasize the current one.")
 
+(defvar dotspacemacs-show-trailing-whitespace t
+  "Show trailing whitespace. Default is `t'.")
+
 (defvar dotspacemacs-whitespace-cleanup nil
   "Delete whitespace while saving buffer.
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -452,6 +452,9 @@ It should only modify the values of Spacemacs settings."
    ;; (default nil - same as frame-title-format)
    dotspacemacs-icon-title-format nil
 
+   ;; Show trailing whitespace (default t)
+   dotspacemacs-show-trailing-whitespace t
+
    ;; Delete whitespace while saving buffer. Possible values are `all'
    ;; to aggressively delete empty line and long sequences of whitespace,
    ;; `trailing' to delete only the whitespace at end of lines, `changed' to

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -150,6 +150,22 @@ If not in such a search box, fall back on `Custom-newline'."
         (indent-region (point-min) (point-max))
         (whitespace-cleanup)))))
 
+(defun spacemacs//trailing-whitespace ()
+  (setq show-trailing-whitespace dotspacemacs-show-trailing-whitespace))
+
+(defun spacemacs//set-whitespace-style-for-diff ()
+  "Whitespace configuration for `diff-mode'"
+  (setq-local whitespace-style '(face
+                                 tabs
+                                 tab-mark
+                                 spaces
+                                 space-mark
+                                 trailing
+                                 indentation::space
+                                 indentation::tab
+                                 newline
+                                 newline-mark)))
+
 ;; from https://gist.github.com/3402786
 (defun spacemacs/toggle-maximize-buffer ()
   "Maximize buffer"

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -458,15 +458,11 @@
     :defer t
     :init
     (progn
-      (setq spacemacs-show-trailing-whitespace t)
-      (defun spacemacs//show-trailing-whitespace ()
-        (when spacemacs-show-trailing-whitespace
-          (set-face-attribute 'trailing-whitespace nil
-                              :background
-                              (face-attribute 'font-lock-comment-face
-                                              :foreground))
-          (setq show-trailing-whitespace 1)))
-      (add-hook 'prog-mode-hook 'spacemacs//show-trailing-whitespace)
+      (when dotspacemacs-show-trailing-whitespace
+        (set-face-attribute
+         'trailing-whitespace nil
+         :background (face-attribute 'font-lock-comment-face :foreground)))
+      (add-hook 'prog-mode-hook 'spacemacs//trailing-whitespace)
 
       (spacemacs|add-toggle whitespace
         :mode whitespace-mode
@@ -477,18 +473,6 @@
         :documentation "Display whitespace globally."
         :evil-leader "t C-w")
 
-      (defun spacemacs//set-whitespace-style-for-diff ()
-        "Whitespace configuration for `diff-mode'"
-        (setq-local whitespace-style '(face
-                                       tabs
-                                       tab-mark
-                                       spaces
-                                       space-mark
-                                       trailing
-                                       indentation::space
-                                       indentation::tab
-                                       newline
-                                       newline-mark)))
       (add-hook 'diff-mode-hook 'whitespace-mode)
       (add-hook 'diff-mode-hook 'spacemacs//set-whitespace-style-for-diff))
     :config


### PR DESCRIPTION
Moved the function definitions for:
spacemacs//trailing-whitespace
spacemacs//set-whitespace-style-for-diff

from: spacemacs-default/packages.el
to:   spacemacs-default/funcs.el

Requested in: How to deactivate highlighting of trailing whitespace by default? https://github.com/syl20bnr/spacemacs/issues/13729#issuecomment-751231218