### PR TITLE
[c-c++] Add layer variable for DAP adapter selection

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -24,6 +24,10 @@
         - [[#example-dotspacemacs-configuration-layers-entry][Example dotspacemacs-configuration-layers entry]]
       - [[#completion][Completion]]
       - [[#debugger-dap-integration][Debugger (dap integration)]]
+        - [[#adapter-selection][Adapter selection]]
+        - [[#microsoft-adapter-installation][Microsoft adapter installation]]
+        - [[#codefreak-adapter-installation][CodeFreak adapter installation]]
+        - [[#lldb-adapter-installation][LLDB adapter installation]]
     - [[#rtags][rtags]]
       - [[#external-dependencies-1][External dependencies]]
       - [[#configuration-1][Configuration]]
@@ -205,9 +209,39 @@ have been disabled in favour of server,
 as recommended by =ccls= wikis.
 
 **** Debugger (dap integration)
+
+***** Adapter selection
+To select the active adapters, configure the =c-c++-dap-adapters= layer variable.
+By default only the Microsoft extension is available.
+
+| Adapter      | Supported debuggers               | DAP mode       |
+|--------------+-----------------------------------+----------------|
+| Microsoft    | gdb, lldb, Visual Studio Debugger | =dap-cpptools= |
+| CodeFreak    | gdb, lldb                         | =dap-gdb-lldb= |
+| LLVM Project | lldb                              | =dap-lldb=     |
+
+Example configuration with two adapters selected:
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((c-c++ :variables
+                         c-c++-dap-adapters '(dap-lldb dap-cpptools)))
+#+END_SRC
+
+***** Microsoft adapter installation
+To install the debug adapter you may run =M-x dap-cpptools-setup= when you are
+on Linux.
+
+***** CodeFreak adapter installation
 To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are
 on Linux or download it manually from [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][Native Debug]] and adjust the
 =dap-gdb-lldb-path= variable.
+
+***** LLDB adapter installation
+Install the =lldb-vscode= program. It usually comes with =lldb= from your
+distribution's package repository.
+Alternatively build directly following the [[https://github.com/llvm/llvm-project/tree/master/lldb/tools/lldb-vscode#installation-for-visual-studio-code][official installation instructions]].
+
+Adjust the =dap-lldb-debug-program= variable to match the executable.
 
 *** rtags
 rtags is a well established clang-based source code indexing tool.

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -34,6 +34,18 @@ By default `font-lock' is used to highlight the text, set the variable to
 `overlay' if you want to use overlays. Note that overlays can be slower.")
 
 
+;; dap
+
+(defvar c-c++-dap-adapters '(dap-cpptools)
+  "Debug adapters to use for IDE debug features.
+
+By default only `dap-cpptools' is used.
+
+Add `dap-cpptools' for the official Microsoft C/C++ Extension for VSCode.
+Add `dap-lldb' for the official LLDB project adapter.
+Add `dap-gdb-lldb' for the WebFreak Native Debug extension.")
+
+
 ;; rtags
 
 (defvar c-c++-enable-rtags-completion t

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -165,7 +165,7 @@
 
 (defun spacemacs//c-c++-setup-lsp-dap ()
   "Setup DAP integration."
-  (require 'dap-gdb-lldb))
+  (mapc #'require c-c++-dap-adapters))
 
 
 ;; rtags


### PR DESCRIPTION
Require the `dap-mode` adapter to the official LLDB DAP backend (`lldb-vscode`)
by default.