### PR TITLE
[markdown] more document for using markdown-command

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2673,7 +2673,7 @@ files (thanks to Daniel Nicolai)
   terminal users (thanks to AmaiKinono)
 - Made =*lsp-help*= buffer shown in a popup window using popwin
 - Add support for mdx files via markdown-mode (thanks to robbyoconnor)
-- Improve documentation about markdown preview options (thanks to lin.sun)
+- Improve documentation about markdown preview options (thanks to Lin Sun)
 **** Major modes
 - Added SPARQL-mode (thanks to Dietrich Daroch)
 - Added android logcat (thanks to jiejingzhang)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2673,6 +2673,7 @@ files (thanks to Daniel Nicolai)
   terminal users (thanks to AmaiKinono)
 - Made =*lsp-help*= buffer shown in a popup window using popwin
 - Add support for mdx files via markdown-mode (thanks to robbyoconnor)
+- Improve documentation about markdown preview options (thanks to lin.sun)
 **** Major modes
 - Added SPARQL-mode (thanks to Dietrich Daroch)
 - Added android logcat (thanks to jiejingzhang)

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -51,6 +51,27 @@ file.
 
 * Configuration
 ** Live preview
+A live preview can be generated when either of these two executables are in path:
+- =markdown=
+- =pandoc=
+
+A well-knowned =markdown= command is from https://daringfireball.net/projects/markdown/.
+Or follow =pandoc= installation instructions to install pandoc into path:
+https://pandoc.org/installing.html
+
+Another choice is installing =Python-Markdown=:
+
+#+BEGIN_SRC shell
+  pip install --user Markdown
+#+END_SRC
+
+Then setup the =markdown-executable= variable to point to the executable of =Python-Markdown=:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (markdown :variables markdown-executable "~/.local/bin/markdown_py")))
+#+END_SRC
+
 By default the built-in Emacs web browser is used to live preview a markdown
 buffer.
 

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -71,7 +71,7 @@ Then setup the =markdown-executable= variable to point to the executable of =Pyt
   (setq-default dotspacemacs-configuration-layers '(
     (markdown :variables markdown-executable "~/.local/bin/markdown_py")))
 #+END_SRC
-
+Another alternative is to install the `github layer` and use `grip-mode` for live previewing, though this only supports Github flavored markdown.
 By default the built-in Emacs web browser is used to live preview a markdown
 buffer.
 

--- a/layers/+lang/markdown/config.el
+++ b/layers/+lang/markdown/config.el
@@ -14,6 +14,10 @@
 (defvar markdown-live-preview-engine 'eww
   "Possibe values are `eww' (built-in browser) or `vmd' (installed with `npm').")
 
+(defvar markdown-executable nil
+  "When non-nil, use the specified command if it's found on PATH.
+Otherwise, use one of \"markdown\", \"pandoc\", or \"markdown_py\" when it's available.")
+
 (defvar markdown-mmm-auto-modes
   '(
     ;; in alphabetical order, symbols first then lists

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -66,17 +66,16 @@
       ;; use proper syntax highlighting
       (setq markdown-fontify-code-blocks-natively t)
       ;; set the markdown-command
-      (if markdown-executable     ; verify the executable for user defined value
-          (if (executable-find markdown-executable)
-              (setq markdown-command markdown-executable)
-            (warn "Non-exist markdown-executable: %s" markdown-executable))
-        (when (or (null markdown-command) ; markdown-command is nil or not exist
-                  (not (executable-find markdown-command)))
-          ;; try more markdown CLIs
-          (let ((cmd (cl-loop for cmd in '("markdown_py")
-                              when (executable-find cmd)
-                              return (file-name-nondirectory it))))
-            (when cmd (setq markdown-command cmd)))))
+(setq markdown-command
+      (if-let ((command (cl-loop for cmd in (if markdown-executable
+                                                (list markdown-executable))
+                                              (list "markdown" "pandoc" "markdown_py"))
+                                 when (executable-find cmd)
+                                 return (file-name-nondirectory it))))
+          command
+        (user-error (if markdown-executable
+                        (format "Cannot find markdown-executable %s" markdown-executable)
+                      "Please refer to the layer documentation and install a markdown command"))))
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")
                         ("mh" . "markdown/header")

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -65,6 +65,18 @@
       ;; Make markdown-mode behave a bit more like org w.r.t. code blocks i.e.
       ;; use proper syntax highlighting
       (setq markdown-fontify-code-blocks-natively t)
+      ;; set the markdown-command
+      (if markdown-executable     ; verify the executable for user defined value
+          (if (executable-find markdown-executable)
+              (setq markdown-command markdown-executable)
+            (warn "Non-exist markdown-executable: %s" markdown-executable))
+        (when (or (null markdown-command) ; markdown-command is nil or not exist
+                  (not (executable-find markdown-command)))
+          ;; try more markdown CLIs
+          (let ((cmd (cl-loop for cmd in '("markdown_py")
+                              when (executable-find cmd)
+                              return (file-name-nondirectory it))))
+            (when cmd (setq markdown-command cmd)))))
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")
                         ("mh" . "markdown/header")


### PR DESCRIPTION
Hi,

I had try the markdown live preview by following README.org in markdown layer folder, failed with no-error-message, after check the code, found the `markdown-command` is required but no hints in markdown layer documents.

So I add the documentation into README.org in markdown layer folder for configing the live-preview.

Thanks.