### PR TITLE
emacs-lisp: resets to evil-normal after edebug session

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1884,6 +1884,7 @@ Other:
 - Fixed flycheck initialization (thanks to Kevin W. van Rooijen)
 - Added =elm-test-runner= (thanks to Juan Edi)
 **** Emacs Lisp
+- Fix: after edebug session, get out of evil-evilified (thanks to Ag Ibragimov)
 - Key bindings:
   - Make ~SPC m h h~ and jump handlers work in =ielm= (thanks to Keith Pinson)
   - Added ~c~ to continue in edebug mode (thanks to hodge)

--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -60,14 +60,17 @@ Unlike `eval-defun', this does not go to topmost function."
 
 (defun spacemacs//edebug-mode (&rest args)
   "Additional processing when `edebug-mode' is activated or deactivated."
-  (let ((evilified (or (eq 'vim dotspacemacs-editing-style)
-                       (and (eq 'hybrid dotspacemacs-editing-style)
-                            hybrid-style-enable-evilified-state))))
+  (let ((evilified? (or (eq 'vim dotspacemacs-editing-style)
+                        (and (eq 'hybrid dotspacemacs-editing-style)
+                             hybrid-style-enable-evilified-state))))
     (if (not edebug-mode)
         ;; disable edebug-mode
-        (when evilified (evil-normal-state))
+        (when evilified?
+          (remove-hook 'pre-command-hook 'evilified-state--pre-command-hook)
+          (define-key evil-normal-state-map [escape] 'evil-force-normal-state)
+          (evil-normal-state))
       ;; enable edebug-mode
-      (when evilified (evil-evilified-state))
+      (when evilified? (evil-evilified-state))
       (evil-normalize-keymaps)
       (when (and (fboundp 'golden-ratio-mode)
                  golden-ratio-mode)


### PR DESCRIPTION
This one annoyed me for quite some time. Finally, I got too tired of it.

Basically, right after edebug session Spacemacs gets stuck in evil-evilified-state. 

To reproduce:

- instrument any function `M-x spacemacs/edebug-instrument-defun-on`
- run the function, edebug session starts
- quit the session, or step through the function, whatever (it doesn't matter)
- after edebug session keys are in evilified state (where not all normal evil keys work as expected)
  - e.g. you press `<escape>` - cursor turns yellow (should be orange)
