### PR TITLE
[org] add keybinding for org-roam-dailies-find-date

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2898,6 +2898,8 @@ files (thanks to Daniel Nicolai)
     - ~SPC a o r d t~ (~SPC m r d t~) Open today's daily note
     - ~SPC a o r d T~ (~SPC m r d T~) Open tomorrow's daily note
     (thanks to Mariusz Klochowicz)
+    - ~SPC a o r d d~ (~SPC m r d d~) Open daily note via calendar view
+    (thanks to Ben Swift)
   - Added additional prefix (~SPC m m j~) for org-jira bindings
     (thanks to Mariusz Klochowicz)
 - Made =org= layer depend on =spacemacs-org= (thanks to Eivind Fonn)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -941,5 +941,6 @@ Key binding prefixes:
 | ~[prefix] r d y~ | Open yesterday's daily note           |
 | ~[prefix] r d t~ | Open today's daily note               |
 | ~[prefix] r d T~ | Open tomorrow's daily note            |
+| ~[prefix] r d d~ | Open daily note via calendar view     |
 | ~[prefix] r t a~ | add org-roam tag to file              |
 | ~[prefix] r t d~ | delete org-roam tag from file         |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -865,6 +865,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
                org-roam-dailies-find-yesterday
                org-roam-dailies-find-today
                org-roam-dailies-find-tomorrow
+               org-roam-dailies-find-date
                org-roam-tag-add
                org-roam-tag-delete)
     :init
@@ -876,6 +877,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "aordy" 'org-roam-dailies-find-yesterday
         "aordt" 'org-roam-dailies-find-today
         "aordT" 'org-roam-dailies-find-tomorrow
+        "aordd" 'org-roam-dailies-find-date
         "aorf" 'org-roam-find-file
         "aorg" 'org-roam-graph
         "aori" 'org-roam-insert
@@ -892,6 +894,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "rdy" 'org-roam-dailies-find-yesterday
         "rdt" 'org-roam-dailies-find-today
         "rdT" 'org-roam-dailies-find-tomorrow
+        "rdd" 'org-roam-dailies-find-date
         "rf" 'org-roam-find-file
         "rg" 'org-roam-graph
         "ri" 'org-roam-insert


### PR DESCRIPTION
There are org-roam "daily" keybindings for yesterday/today/tomorrow, but the (useful) `org-roam-dailies-find-date` function doesn't have a keybinding in the org layer. This pull adds these keybindings under `[prefix] r d d` (final `d` for "date"), and notes the new keybinding in `README.org`