### PR TITLE
bytecomp stuff

### DIFF
--- a/core/core-compilation.el
+++ b/core/core-compilation.el
@@ -12,6 +12,12 @@
 (require 'cl-lib)
 (require 'subr-x)
 
+(defvar spacemacs--last-emacs-version ""
+  "This variable is set during Emacs initialization to its version.")
+(defconst spacemacs--last-emacs-version-file
+  (expand-file-name (concat spacemacs-cache-directory "last-emacs-version"))
+  "File that sets `spacemacs--last-emacs-version' variable.")
+
 (defconst spacemacs--compiled-files
   '(;; Built-in libs that we changed
     "core/libs/forks/load-env-vars.el"
@@ -53,5 +59,13 @@ File paths are relative to the `spacemacs-start-directory'.")
                        (format "%s.elc"))))
       (when (file-newer-than-file-p file-el file-elc)
         (cl-return t)))))
+
+(defun spacemacs//update-last-emacs-version ()
+  "Update `spacemacs--last-emacs-version' and its saved value."
+  (with-temp-file spacemacs--last-emacs-version-file
+    (insert (format "(setq spacemacs--last-emacs-version %S)"
+                    (setq spacemacs--last-emacs-version emacs-version)))
+    (make-directory (file-name-directory spacemacs--last-emacs-version-file)
+                    t)))
 
 (provide 'core-compilation)

--- a/core/core-compilation.el
+++ b/core/core-compilation.el
@@ -1,4 +1,4 @@
-;;; core-compilation.el --- Spacemacs Core File
+;;; core-compilation.el --- Spacemacs Core File -*- no-byte-compile: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-compilation.el
+++ b/core/core-compilation.el
@@ -44,15 +44,14 @@ File paths are relative to the `spacemacs-start-directory'.")
       (format "%s.elc")
       (delete-file))))
 
-(defun spacemacs//remove-byte-compiled-if-stale (files)
-  "Remove all .elc files corresponding to the source FILES if any is stale."
-  (when (cl-dolist (file files)
-          (let* ((file-el (file-truename file))
-                 (file-elc (thread-last file-el
-                             (file-name-sans-extension)
-                             (format "%s.elc"))))
-            (when (file-newer-than-file-p file-el file-elc)
-              (cl-return t))))
-    (spacemacs//remove-byte-compiled-files files)))
+(defun spacemacs//contains-newer-than-byte-compiled-p (files)
+  "Return true if any file in FILES is newer than its byte-compiled version."
+  (cl-dolist (file files)
+    (let* ((file-el (file-truename file))
+           (file-elc (thread-last file-el
+                       (file-name-sans-extension)
+                       (format "%s.elc"))))
+      (when (file-newer-than-file-p file-el file-elc)
+        (cl-return t)))))
 
 (provide 'core-compilation)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -470,6 +470,9 @@ prettifying Org files.")
   "If non-nil, `kill-buffer' on *scratch* buffer
 will bury it instead of killing.")
 
+(defvar dotspacemacs-byte-compile nil
+  "If non-nil, byte-compile some of Spacemacs files.")
+
 (defun dotspacemacs//prettify-spacemacs-docs ()
   "Run `spacemacs/prettify-org-buffer' if `buffer-file-name'
 looks like Spacemacs documentation."

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -1,4 +1,4 @@
-;;; core-load-paths.el --- Spacemacs Core File
+;;; core-load-paths.el --- Spacemacs Core File  -*- no-byte-compile: t -*-
 ;;
 ;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
 ;;

--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -356,15 +356,13 @@ Example: (1 42 3) = 1 042 003"
         (goto-char 1)
         (setq spacemacs-revision--last (current-word))
         (kill-buffer proc-buffer))))
-  (with-temp-file spacemacs-revision--file
-    (insert (format "(setq spacemacs-revision--last %S)"
-                    spacemacs-revision--last))
-    (make-directory (file-name-directory spacemacs-revision--file) t))
+  (spacemacs/dump-vars-to-file '(spacemacs-revision--last)
+                               spacemacs-revision--file)
   (run-hooks 'spacemacs-revision--changed-hook))
 
 (defun spacemacs//revision-check ()
   "Update saved value of the current revision asynchronously.
-NOTE: If old and new revisions are different `spacemacs-revision--changed-hook'
+If old and new revisions are different `spacemacs-revision--changed-hook'
  will be triggered."
   (when (file-exists-p spacemacs-revision--file)
     (load spacemacs-revision--file nil t))

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -253,9 +253,10 @@ Note: the hooked function is not executed when in dumped mode."
      (unless (version< emacs-version "27")
        (setq read-process-output-max dotspacemacs-read-process-output-max))))
 
-  ;; Ensure that `spacemacs--compiled-files' are byte-compiled.
   (let ((default-directory spacemacs-start-directory))
-    (spacemacs//ensure-byte-compilation spacemacs--compiled-files))
+    (if dotspacemacs-byte-compile
+        (spacemacs//ensure-byte-compilation spacemacs--compiled-files)
+      (spacemacs//remove-byte-compiled-files spacemacs--compiled-files)))
   ;; Check if revision has changed.
   (spacemacs//revision-check))
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -487,7 +487,10 @@ It should only modify the values of Spacemacs settings."
 
    ;; If nil the home buffer shows the full path of agenda items
    ;; and todos. If non nil only the file name is shown.
-   dotspacemacs-home-shorten-agenda-source nil))
+   dotspacemacs-home-shorten-agenda-source nil
+
+   ;; If non-nil then byte-compile some of Spacemacs files.
+   dotspacemacs-byte-compile nil))
 
 (defun dotspacemacs/user-env ()
   "Environment variables setup.

--- a/dump-init.el
+++ b/dump-init.el
@@ -1,3 +1,4 @@
+;; -*- no-byte-compile: t -*-
 (setq spacemacs-dump-mode 'dumping)
 ;; load init.el
 (setq spacemacs-start-directory (file-name-directory load-file-name))

--- a/early-init.el
+++ b/early-init.el
@@ -1,4 +1,4 @@
-;;; early-init.el -*- no-byte-compile: t -*- --- Spacemacs Early Init File
+;;; early-init.el --- Spacemacs Early Init File -*- no-byte-compile: t -*-
 ;;
 ;; Copyright (c) 2020 Sylvain Benner & Contributors
 ;;

--- a/init.el
+++ b/init.el
@@ -28,7 +28,9 @@
 (load (concat spacemacs-core-directory "core-compilation.el")
       nil (not init-file-debug))
 (let ((default-directory spacemacs-start-directory))
-  (spacemacs//remove-byte-compiled-if-stale spacemacs--compiled-files))
+  (when (spacemacs//contains-newer-than-byte-compiled-p
+         spacemacs--compiled-files)
+    (spacemacs//remove-byte-compiled-files spacemacs--compiled-files)))
 
 (if (not (version<= spacemacs-emacs-min-version emacs-version))
     (error (concat "Your version of Emacs (%s) is too old. "

--- a/init.el
+++ b/init.el
@@ -25,12 +25,17 @@
 (load (concat spacemacs-core-directory "core-dumper.el")
       nil (not init-file-debug))
 
+;; Clean compiled files if they become stale or Emacs version has changed.
 (load (concat spacemacs-core-directory "core-compilation.el")
       nil (not init-file-debug))
+(load spacemacs--last-emacs-version-file t (not init-file-debug))
 (let ((default-directory spacemacs-start-directory))
-  (when (spacemacs//contains-newer-than-byte-compiled-p
-         spacemacs--compiled-files)
+  (when (or (not (string= spacemacs--last-emacs-version emacs-version))
+            (spacemacs//contains-newer-than-byte-compiled-p
+             spacemacs--compiled-files))
     (spacemacs//remove-byte-compiled-files spacemacs--compiled-files)))
+(when (not (string= spacemacs--last-emacs-version emacs-version))
+  (spacemacs//update-last-emacs-version))
 
 (if (not (version<= spacemacs-emacs-min-version emacs-version))
     (error (concat "Your version of Emacs (%s) is too old. "

--- a/init.el
+++ b/init.el
@@ -1,4 +1,4 @@
-;;; init.el --- Spacemacs Initialization File
+;;; init.el --- Spacemacs Initialization File -*- no-byte-compile: t -*-
 ;;
 ;; Copyright (c) 2012-2020 Sylvain Benner & Contributors
 ;;


### PR DESCRIPTION
Hopefully those are the last shenanigans needed to make byte compilation of the core libs  bullet proof :thinking: 

Also  now byte-compilation is off by default (controlled by `dotspacemacs-byte-compile` variable in .spacemacs)


*I don't expect noticeable gains from  `byte-compilation` of core files/libs (even if we annotate everything we can with `pure`/`side-effect-free`) but hopefully it will make us prepared for native compilation thingy.*