### PR TITLE
Do not delete non existent files

### DIFF
--- a/core/core-compilation.el
+++ b/core/core-compilation.el
@@ -44,11 +44,12 @@ File paths are relative to the `spacemacs-start-directory'.")
 (defun spacemacs//remove-byte-compiled-files (files)
   "Remove .elc files corresponding to the source FILES."
   (dolist (file files)
-    (thread-last file
-      (file-truename)
-      (file-name-sans-extension)
-      (format "%s.elc")
-      (delete-file))))
+    (let ((file-elc (thread-last file
+                      (file-truename)
+                      (file-name-sans-extension)
+                      (format "%s.elc"))))
+      (when (file-exists-p file-elc)
+        (delete-file file-elc)))))
 
 (defun spacemacs//contains-newer-than-byte-compiled-p (files)
   "Return true if any file in FILES is newer than its byte-compiled version."


### PR DESCRIPTION
Fix for #14335

Apparently on some platforms/with some configs `(delete-file "foo/bar")` will report an error if the  file doesn't exist.