### PR TITLE
Also run `treemacs-load-theme` on `dired-mode-hook`

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -103,7 +103,7 @@
 (defun treemacs/init-treemacs-all-the-icons ()
   (use-package treemacs-all-the-icons
     :if treemacs-use-all-the-icons-theme
-    :hook (treemacs-mode . (lambda () (treemacs-load-theme 'all-the-icons)))))
+    :hook ((treemacs-mode dired-mode) . (lambda () (treemacs-load-theme 'all-the-icons)))))
 
 (defun treemacs/pre-init-winum ()
   (spacemacs|use-package-add-hook winum


### PR DESCRIPTION
Icons in `dired-mode` buffer are inconsistent with `treemacs-use-all-the-icons-theme` implied. Currently we can only see expected icons in `dired-mode` buffer ***after running command `treemacs` explicitly***.

Better if we can see corrent icon style in `dired-mode`, no matter whether `treemacs-mode` buffer is initialized. It should just depend on the variable `treemacs-use-all-the-icons-theme`.