### PR TITLE
Fix doc org-contacts

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -161,7 +161,9 @@ Alternatively, add the following line to each =.org= file you want to process:
 #+END_EXAMPLE
 
 ** Org-contacts support
-[[https://github.com/tkf/org-mode/blob/master/contrib/lisp/org-contacts.el][org-contacts]] is a simple contacts management system.
+[[https://github.com/tkf/org-mode/blob/master/contrib/lisp/org-contacts.el][org-contacts]] is a handy contacts management system. It can be used to manage
+(email) addresses (compatible with gnus, mu4e, notmuch etc.), birthdays and
+more. It is simpler than bbdb/ebdb and probably powerful enough for most users.
 
 To install org-contacts, set the variable =org-enable-org-contacts-support= to
 =t=. Optionally, also set the variable =org-contacts-files= and add a capture
@@ -170,12 +172,13 @@ filenames to use as contact sources. If set to =nil= (default) then all your Org
 files will be used. The first file in the =org-contacts-files= list can be
 visited with the keyboard shortcut ~SPC a o C f~.
 #+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-                '((org :variables org-enable-org-contacts-support t
-                                  org=contact-file '("file1.org" "file2.org")
-                                  ("c" "Contacts" entry (file "~/Org/contacts.org")
-                                  "* %(org-contacts-template-name) :PROPERTIES:
-                                  :EMAIL: %(org-contacts-template-email) :END:"))))
+  (org :variables org-enable-org-contacts-support t
+       org-contacts-files '("~/Org/contacts.org" "~/Org/file2.org")
+       org-capture-templates '(("c" "Contacts" entry (file "~/Org/contacts.org")
+                                "* %(org-contacts-template-name)
+  :PROPERTIES:
+  :EMAIL: %(org-contacts-template-email)
+  :END:")))
 #+END_SRC
 A more elaborate capture template can be found in the =org-contacts.el= file.
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -566,6 +566,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
         ("." org-agenda-goto-today)
         ("gd" org-agenda-goto-date)))
     :config
+    (when org-enable-org-contacts-support
+      (use-package org-contacts))
     (evilified-state-evilify-map org-agenda-mode-map
       :mode org-agenda-mode
       :bindings
@@ -802,8 +804,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
                    ))
         (user-error "Error: No agenda files configured, nothing to display.")))))
 
-(defun org/pre-init-org-contacts ()
-  (spacemacs|use-package-add-hook org-agenda :pre-config (require 'org-contacts)))
+;; (defun org/pre-init-org-contacts ()
+;;   (spacemacs|use-package-add-hook org-agenda :post-init (require 'org-contacts)))
 (defun org/init-org-contacts ()
   (use-package org-contacts
     :defer t


### PR DESCRIPTION
I have checked and fixed the docs as requested in  #14297.

Also I have commented out the the org-agenda post/pre-config hook, and put back the conditional `use-package` in the after the :config keyword in `use-package org-agenda` so that it will work correctly. Of course you are welcome to find the trick to reduce the cross-referencing. I have thought about it a little also, but could not quickly come up with another fix.