### PR TITLE
[ivy-rich] enable ivy-rich-project-root-cache-mode

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -281,7 +281,8 @@
             ivy-virtual-abbreviate 'full))
     :config
     (progn
-      (ivy-rich-mode))))
+      (ivy-rich-mode)
+      (ivy-rich-project-root-cache-mode))))
 
 (defun ivy/init-ivy-spacemacs-help ()
   (use-package ivy-spacemacs-help


### PR DESCRIPTION
which improves performance when many buffers opened.

Ref:
https://github.com/Yevgnen/ivy-rich#project-performance
https://github.com/syl20bnr/spacemacs/issues/10101