### PR TITLE
Improve better-dafault docs about possible bindings shadowed

### DIFF
--- a/layers/+emacs/better-defaults/README.org
+++ b/layers/+emacs/better-defaults/README.org
@@ -16,9 +16,9 @@ This layer enhances the default commands of Emacs and is primarily intended to
 be used with the =emacs= editing style as it does not change anything in the Vim
 key bindings.
 
-However the =emacs= editing style is not required, you can still use this layer
+However the =emacs= editing style is not required. You can still use this layer
 while you are using the =vim= editing style if you have some kind of mixed
-style.
+style, but some of the layer bindings might be shadowed by the evil keybindings.
 
 The commands defined in this layer are taken from various sources like [[https://github.com/bbatsov/prelude][Prelude]].
 


### PR DESCRIPTION
Just some small clarification due to some confusion on Gitter about the `C-e` behavior