### PR TITLE
[keyboard-layout] Fix colemak-hneio next/prev line in magit

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -453,7 +453,15 @@
     :colemak-jkhl
     (kl/evil-correct-keys 'visual magit-mode-map
       "j"
-      "k")))
+      "k")
+    :colemak-hnei
+    (progn
+      (kl/evil-correct-keys 'normal magit-mode-map
+        "j"
+        "k")
+      (kl/evil-correct-keys 'visual magit-mode-map
+        "j"
+        "k"))))
 
 (defun keyboard-layout/pre-init-mu4e ()
   (kl|config mu4e


### PR DESCRIPTION
Fixes: Broken Colemak bindings for Magit status buffer #14366