### PR TITLE
Add eval-to-comment elisp-mode function

### DIFF
--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -109,6 +109,25 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
       (sp-forward-symbol)
       (call-interactively 'eval-last-sexp))))
 
+(defun spacemacs/eval-current-form-to-comment-sp (&optional arg)
+  "Same as `spacemacs/eval-current-form-sp' but inserts output as a comment."
+  (interactive "p")
+  (require 'smartparens)
+  (let ((evil-move-beyond-eol t))
+    ;; evil-move-beyond-eol disables the evil advices around eval-last-sexp
+    (save-excursion
+      (let ((max 10))
+        (while (and (> max 0)
+                    (sp-point-in-string-or-comment))
+          (decf max)
+          (sp-up-sexp)))
+      (sp-up-sexp arg)
+      (let ((ret-val (format ";; %S" (call-interactively 'eval-last-sexp))))
+        (goto-char (point-at-eol))
+        (open-line 1)
+        (forward-line 1)
+        (insert ret-val)))))
+
 
 ;; elisp comment text-object definition
 

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -320,6 +320,7 @@
   (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
     (spacemacs/set-leader-keys-for-major-mode mode
       "ec" 'spacemacs/eval-current-form-sp
+      "e;" 'spacemacs/eval-current-form-to-comment-sp
       "es" 'spacemacs/eval-current-symbol-sp)))
 
 (defun emacs-lisp/init-emr ()


### PR DESCRIPTION
Clojure layer has similar function. I miss it in Elisp sometimes. Is it usefull?   That's basically `eval-print-last-sexp` but that also adds `;;`  which is cool since it doesn't break evaluation of the buffer :thinking:  