### PR TITLE
Fix home buffer ace links

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -258,16 +258,17 @@ If the universal prefix argument is used then kill also the window."
 
 ;; ace-link
 
-(defvar spacemacs--link-pattern "~?/.+\\|\s\\[")
-
 (defun spacemacs//collect-spacemacs-buffer-links ()
-  (let ((end (window-end))
-        points)
+  "Return a list of widget-button positions."
+  (let (widget-button-positions)
     (save-excursion
       (goto-char (window-start))
-      (while (re-search-forward spacemacs--link-pattern end t)
-        (push (+ (match-beginning 0) 1) points))
-      (nreverse points))))
+      (while (< (point) (window-end))
+        (when (eq (car (get-char-property-and-overlay (point) 'face))
+                  'widget-button)
+          (push (point) widget-button-positions))
+        (goto-char (next-overlay-change (point)))))
+    (nreverse widget-button-positions)))
 
 (defun spacemacs/ace-buffer-links ()
   "Ace jump to links in `spacemacs' buffer."


### PR DESCRIPTION
Pressing o `(spacemacs/ace-buffer-links)`
on the Spacemacs home buffer `SPC b h`.

Adds an ace link (one or more highlighted letters),
at the menu buttons, and the startup list entries.

### problem:
The text: `[S P A C E M A C S]` gets an ace link,
but it isn't a button.

When the [?] button has been pressed, and the Quick Help
is open, then ace links appear on the open square brackets
for each key binding, but they aren't buttons.

In the lists: recent files, projects, etc.
The ace links appear before the first / (slash).
This means that in windows they appear after `c:`.

### solution:
Add the ace links at the beginning of each widget-button.


### Before
![emacs_2021-02-12_15-16-56](https://user-images.githubusercontent.com/13420573/107781027-b44d4300-6d47-11eb-9cac-f5a8b7e8fc98.png)

![emacs_2021-02-12_15-17-05](https://user-images.githubusercontent.com/13420573/107781032-b7e0ca00-6d47-11eb-9c83-0c91ddc457fe.png)

### After
![emacs_2021-02-12_15-24-18](https://user-images.githubusercontent.com/13420573/107781078-c8914000-6d47-11eb-84b5-0e01bb3560c8.png)

![emacs_2021-02-12_15-24-23](https://user-images.githubusercontent.com/13420573/107781087-caf39a00-6d47-11eb-821b-6cdc786e0836.png)
