### PR TITLE
[editing] add binding for multi-line

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1119,6 +1119,8 @@ Other:
     (thanks to John Stevenson)
   - Added ~SPC c b~ to switch to last compilation buffer
     (thanks to Ivan Yonchovski)
+  - Added ~SPC x n~ for multi-line transient state
+    (thanks to Tristan Harmer)
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -31,3 +31,4 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for unkillable scratch via =unkillable-scratch=.
 - In =dired-mode=, press ~Shift S~ to select sorting.
 - Support for =evil-easymotion= if the editing style is =vim= or =hybrid=.
+- Support for cycling between multi line block styles via =multi-line=

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -31,6 +31,7 @@
         (evil-swap-keys :toggle dotspacemacs-swap-number-row)
         (spacemacs-whitespace-cleanup :location local)
         string-inflection
+        multi-line
         undo-tree
         (unkillable-scratch :toggle dotspacemacs-scratch-buffer-unkillable)
         uuidgen
@@ -475,6 +476,18 @@
         "xi_" 'string-inflection-underscore
         "xiu" 'string-inflection-underscore
         "xiU" 'string-inflection-upcase))))
+
+(defun spacemacs-editing/init-multi-line ()
+  (use-package multi-line
+    :init
+    (progn
+      (spacemacs|define-transient-state multi-line
+        :title "Multi-line Transient State"
+        :doc "\n [_n_] cycle"
+        :bindings
+        ("n" multi-line))
+      (spacemacs/set-leader-keys
+        "xn" 'spacemacs/multi-line-transient-state/body))))
 
 (defun spacemacs-editing/init-undo-tree ()
   (use-package undo-tree


### PR DESCRIPTION
Adds support for cycling between multi line block styles via [multi-line](https://github.com/IvanMalison/multi-line).

See also #11309 - thank you @Miciah for the suggestion all those years ago.

Demo:
![CleanShot 2021-02-17 at 10 01 45](https://user-images.githubusercontent.com/1468141/108147912-b7ab4a80-710a-11eb-810d-a73295262291.gif)
