### PR TITLE
Restore evil-visual-state-map on edebug exit

### DIFF
--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -65,13 +65,9 @@ Unlike `eval-defun', this does not go to topmost function."
                              hybrid-style-enable-evilified-state))))
     (if (not edebug-mode)
         ;; disable edebug-mode
-        (when evilified?
-          (remove-hook 'pre-command-hook 'evilified-state--pre-command-hook)
-          (define-key evil-normal-state-map [escape] 'evil-force-normal-state)
-          (evil-normal-state))
+        (when evilified? (evil-evilified-state-exit))
       ;; enable edebug-mode
       (when evilified? (evil-evilified-state))
-      (evil-normalize-keymaps)
       (when (and (fboundp 'golden-ratio-mode)
                  golden-ratio-mode)
         (golden-ratio)))))


### PR DESCRIPTION
### problem:
Exiting `edebug-mode`, leaves the `evil-visual-state-map`
with only the two key bindings that are defined in:
`evilified-state--setup-visual-state-keymap`
```
y       evil-yank
escape  evil-exit-visual-state
```

### solution:
Restore the `evil-visual-state-map` when exiting `edebug-mode`.

Added an alias for the new exit function:
`evilified-state--evilified-state-on-exit`

called: `evil-evilified-state-exit`
the opposite of: `evil-evilified-state`
