### PR TITLE
Add org-notify option to org-layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2800,6 +2800,7 @@ files (thanks to Daniel Nicolai)
   - Added package =org-rich-yank= (thanks to Keith Pinson)
   - Added package =org-roam= (thanks to Mariusz Klochowicz)
   - Added package =org-contacts= (thanks to Daniel Nicolai)
+  - Added package =org=notify= (thanks to Daniel Nicolai)
 - Key bindings:
   - ~SPC m T i~ to toggle inline images
   - Move clock related key bindings to ~SPC a o C~

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -11,6 +11,7 @@
 - [[#important-note][Important Note]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#agenda-notifications][Agenda notifications]]
   - [[#github-support][GitHub support]]
   - [[#twitter-bootstrap-support][Twitter Bootstrap support]]
   - [[#gnuplot-support][Gnuplot support]]
@@ -111,6 +112,37 @@ More details can be found [[https://github.com/syl20bnr/spacemacs/issues/8106][h
 To use this configuration layer: in the main Spacemacs configuration
 file (=~/.spacemacs=), to the existing =dotspacemacs-configuration-layers= list
 add the =org= entry.
+
+** Agenda notifications
+To enable notifications for agenda events, set the variable
+=org-enable-notifications= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-notifications t
+         org-start-notification-daemon-on-startup t)))
+#+END_SRC
+
+This will install and configure the [[https://code.orgmode.org/bzg/org-mode/src/master/contrib/lisp/org-notify.el][org-notify]] package. Run the
+=org-notify-start= command to start the =org-notify= notification daemon. To
+start the notification daemon automatically on Spacemacs startup, set the
+variable =org-start-notification-daemon-on-startup= to =t= as shown in the code
+snippet above.
+
+The notifications system can be configured via the =org-notify-add= function. An
+explanation for how to use this function can be found in the initial comment of
+the =org-notify.el= file (=SPC h d f org-notify-add RET o a=) and in the
+function its docstring.
+
+The =org-notify= package will scan through your =org-agenda-files= for =TODO=
+headlines that include the =DEADLINE:= stamp. Press =M-S RET= to enter a todo
+headline and then press =, d d= to add a deadline stamp to the headline. This
+layer implements a configuration type named =default=. Org-notify automatically
+applies this type to all =TODO= entries with a =DEADLINE:= stamp. To set a
+custom notification type for an item add a =:NOTIFY:= property where its value
+should be the name of a type that you have added via =org-notify-add= function
+(see the explanation in the initial comment of the =org-notify.el=).
 
 ** GitHub support
 To install GitHub related extensions like [[https://github.com/larstvei/ox-gfm][ox-gfm]] to export to GitHub

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -34,6 +34,12 @@ path, one file per project is used (and the path is relative to
 the project root). If it an absolute path, one global file is
 used.")
 
+(defvar org-enable-notifications nil
+  "If non-nil org-notify is configured.")
+
+(defvar org-start-notification-daemon-on-startup nil
+  "If non-nil start the notification daemon on startup.")
+
 (defvar org-enable-org-contacts-support nil
   "If non-nil org-contacts is configured.")
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -23,6 +23,8 @@
     (ob :location built-in)
     (org :location built-in)
     (org-agenda :location built-in)
+    (org-notify :location built-in
+                :toggle org-enable-notifications)
     (org-contacts :location built-in
                   :toggle org-enable-org-contacts-support)
     (org-vcard :toggle org-enable-org-contacts-support)
@@ -587,6 +589,21 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (kbd "M-RET") 'org-agenda-show-and-scroll-up
       (kbd "M-SPC") 'spacemacs/org-agenda-transient-state/body
       (kbd "s-M-SPC") 'spacemacs/org-agenda-transient-state/body)))
+
+(defun org/init-org-notify ()
+  (use-package org-notify
+    :commands org-notify-start
+    :init
+    (when org-start-notification-daemon-on-startup
+      (org-notify-start))
+    :config
+    (org-notify-add 'default
+                    '(:time "-1s" :period "20s" :duration 10
+                            :actions (-message -ding))
+                    '(:time "15m" :period "2m" :duration 100
+                            :actions -notify)
+                    '(:time "2h" :period "5m" :actions -message)
+                    '(:time "3d" :actions -email))))
 
 (defun org/init-org-brain ()
   (use-package org-brain


### PR DESCRIPTION
This PR adds notifications via org-notify as an option to the org layer. Org-notify uses the Emacs [notifications package](https://www.gnu.org/software/emacs/manual/html_node/elisp/Desktop-Notifications.html), which works great with desktop notification systems that communicate via the dbus. Also, it should work well on Windows. I don't know about Mac, but it would be very easy to add some `org-notify-action-alert` function to the org-notify package (a simple copy of the `org-notify-action-message` with `message replaced by alert).