### PR TITLE
[evil-cleverparens] `evil-cp-change' should move the point

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -93,7 +93,10 @@
                :evil-leader-for-mode
                ,@(mapcar (lambda (x) (cons x "Ts"))
                          evil-lisp-safe-structural-editing-modes)))
-      (spacemacs|diminish evil-cleverparens-mode " 🆂" " [s]"))))
+      (spacemacs|diminish evil-cleverparens-mode " 🆂" " [s]"))
+    :config
+    ;; `evil-cp-change' should move the point, see https://github.com/luxbock/evil-cleverparens/pull/71
+    (evil-set-command-properties 'evil-cp-change :move-point t)))
 
 (defun spacemacs-evil/init-evil-ediff ()
   (use-package evil-ediff


### PR DESCRIPTION
I have a PR for that https://github.com/luxbock/evil-cleverparens/pull/71 but it
is not reviewed for a long time. Without this change when you do `ci"` the
cursor won't go in the "".