### PR TITLE
Change SPC gfd to magit-file-dispatch

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -345,6 +345,7 @@ In org-agenda-mode
 - Key bindings:
   - Changed ~SPC g h o~ to ~SPC g o~ for =browse-at-remote= (thanks to Codruț
     Constantin Gușoi)
+  - Changed ~SPC g f d~ to bind to ~magit-file-dispatch~ (thanks to Ag Ibragimov)
 ***** YAML
 - Added LSP support (thanks to Seong Yong-ju)
 ***** ycmd

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -161,7 +161,7 @@
         "gc"  'magit-clone
         "gfF" 'magit-find-file
         "gfl" 'magit-log-buffer-file
-        "gfd" 'magit-diff
+        "gfd" 'magit-file-dispatch
         "gi"  'magit-init
         "gL"  'magit-list-repositories
         "gm"  'magit-dispatch


### PR DESCRIPTION
I believe `SPC g f d`  should be more "contextual", allowing user to perform operations
associated with the current file. 

For example, if you need to open the diff buffer related  to the exact line at point, there's currently no "Spacemacsy" key to do it quickly. One has to do: `C-c M-g d`.

Current `SPC g f d` keybinding opens "general" magit-diff dialog, not specifically aimed to help with operations related to the current file.

This tiny PR remaps `SPC g f d` to `magit-file-dispatch`, which feels to be exact mnemonic for this thing.
