### PR TITLE
[core-env] #14348 ignore env "DISPLAY" for .spacemacs.env

### DIFF
--- a/core/core-env.el
+++ b/core/core-env.el
@@ -22,6 +22,7 @@
     "GPG_AGENT_INFO"
     "SSH_AGENT_PID"
     "SSH_AUTH_SOCK"
+    "DISPLAY"
     )
   "Ignored environments variables.
 Environment variables with names matching these regexps are not


### PR DESCRIPTION
As discussed in #14348, the env "DISPLAY" should not be stored in `.spacemacs.env`.