### PR TITLE
[markdown] remove duplicating code which already exists in "markdown-mode"

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -66,12 +66,8 @@ Another choice is installing =Python-Markdown=:
   pip install --user Markdown
 #+END_SRC
 
-Then setup the =markdown-executable= variable to point to the executable of =Python-Markdown=:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(
-    (markdown :variables markdown-executable "~/.local/bin/markdown_py")))
-#+END_SRC
+If your markdown executable is not in the list, please refer the document of
+=markdown-mode= for customizing the =markdown-command=.
 
 Another alternative is to install the `github layer` and use `grip-mode` for live
 previewing, though this only supports Github flavored markdown.

--- a/layers/+lang/markdown/config.el
+++ b/layers/+lang/markdown/config.el
@@ -14,10 +14,6 @@
 (defvar markdown-live-preview-engine 'eww
   "Possibe values are `eww' (built-in browser) or `vmd' (installed with `npm').")
 
-(defvar markdown-executable nil
-  "When non-nil, use the specified command if it's found on PATH.
-Otherwise, use one of \"markdown\", \"pandoc\", or \"markdown_py\" when it's available.")
-
 (defvar markdown-mmm-auto-modes
   '(
     ;; in alphabetical order, symbols first then lists

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -65,17 +65,6 @@
       ;; use proper syntax highlighting
       (setq markdown-fontify-code-blocks-natively t)
 
-      ;; set the markdown-command
-      (setq markdown-command
-            (if-let ((command (cl-loop for cmd in (if markdown-executable
-                                                      (list markdown-executable)
-                                                    (list "markdown" "pandoc" "markdown_py"))
-                                       when (executable-find cmd)
-                                       return (file-name-nondirectory it))))
-                command
-              (when markdown-executable
-                (user-error (format "Cannot find markdown-executable %s" markdown-executable)))))
-
       ;; Declare prefixes and bind keys
       (dolist (prefix '(("mc" . "markdown/command")
                         ("mh" . "markdown/header")


### PR DESCRIPTION
Removing the duplicating code introduced in https://github.com/syl20bnr/spacemacs/pull/14312, as upstream change https://github.com/jrblevin/markdown-mode/pull/602 can cover it.