### PR TITLE
Categorize languagetool layer as "checker"

### DIFF
--- a/layers/+tools/languagetool/README.org
+++ b/layers/+tools/languagetool/README.org
@@ -1,6 +1,6 @@
 #+TITLE: LanguageTool layer
 
-#+TAGS: layer|uncategorized
+#+TAGS: layer|checker
 
 [[file:img/languagetool.png]]
 


### PR DESCRIPTION
I think that's fine because it's a "grammar checker" and then it appears in the category as spell checking.

Why this is a draft PR:
Does this mean the layer should be moved to the `+checker` directory? If you want, I can add this change to this commit here but I was not sure if I can simply move layers without breaking things. Do I need to change anything else?