### PR TITLE
Bind s to the dired-quick-sort hydra

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1121,6 +1121,7 @@ Other:
     (thanks to Ivan Yonchovski)
   - Added ~SPC x n~ for multi-line transient state
     (thanks to Tristan Harmer)
+  - Added ~s~ =hydra-dired-quick-sort/body= (thanks to duianto)
 - Improvements:
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):

--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -29,6 +29,6 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for conversion between Emacs regexps and PCRE regexps.
 - Support for persistent scratch via =persistent-scratch=.
 - Support for unkillable scratch via =unkillable-scratch=.
-- In =dired-mode=, press ~Shift S~ to select sorting.
+- Support for sorting (press ~s~) via [[https://gitlab.com/xuhdev/dired-quick-sort][=dired-quick-sort=]]
 - Support for =evil-easymotion= if the editing style is =vim= or =hybrid=.
 - Support for cycling between multi line block styles via =multi-line=

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -109,7 +109,9 @@
     (spacemacs|add-transient-hook dired-mode-hook
       (lambda ()
         (let ((dired-quick-sort-suppress-setup-warning 'message))
-          (dired-quick-sort-setup))))))
+          (dired-quick-sort-setup))))
+    :config
+    (evil-define-key 'normal dired-mode-map "s" 'hydra-dired-quick-sort/body)))
 
 (defun spacemacs-editing/init-editorconfig ()
   (use-package editorconfig


### PR DESCRIPTION
The `dired-quick-sort` hydra was bound to: `S`

But the introduction of `evil-collection-dired`
[[evil-collection] support for dired #14333](https://github.com/syl20bnr/spacemacs/pull/14333)

Now binds `S` to: `dired-do-symlink`
https://github.com/emacs-evil/evil-collection/blob/334670e29d964c5f591f75ccbf52b7b5faf4daba/modes/dired/evil-collection-dired.el#L66

It also restored the default evil behavior of: `s`
to: `evil-substitute`

But it isn't useful in the dired buffer since it is: read-only