### PR TITLE
[ivy] extend highlight for selection in emacs 27

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -254,6 +254,11 @@
       (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
         "w" 'spacemacs/ivy-wgrep-change-to-wgrep-mode
         "s" 'wgrep-save-all-buffers)
+
+      ;; emacs 27 extend line for ivy highlight
+      (setf (alist-get 't ivy-format-functions-alist)
+            #'ivy-format-function-line)
+
       ;; Why do we do this ?
       (ido-mode -1)
 


### PR DESCRIPTION
To have this in standard spacemacs theme:
![image](https://user-images.githubusercontent.com/10945297/108916025-ea61b100-75ea-11eb-8118-2c5db6443e20.png)

