### PR TITLE
Add org wild notifier to org layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2814,6 +2814,7 @@ files (thanks to Daniel Nicolai)
   - Added package =org-roam= (thanks to Mariusz Klochowicz)
   - Added package =org-contacts= (thanks to Daniel Nicolai)
   - Added package =org-appear= (thanks to winsphinX)
+  - Added package =org-wild-notifier= (thanks to Daniel Nicolai)
 - Key bindings:
   - ~SPC m T i~ to toggle inline images
   - Move clock related key bindings to ~SPC a o C~

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -11,6 +11,7 @@
 - [[#important-note][Important Note]]
 - [[#install][Install]]
   - [[#layer][Layer]]
+  - [[#agenda-notifications][Agenda notifications]]
   - [[#github-support][GitHub support]]
   - [[#twitter-bootstrap-support][Twitter Bootstrap support]]
   - [[#gnuplot-support][Gnuplot support]]
@@ -112,6 +113,40 @@ More details can be found [[https://github.com/syl20bnr/spacemacs/issues/8106][h
 To use this configuration layer: in the main Spacemacs configuration
 file (=~/.spacemacs=), to the existing =dotspacemacs-configuration-layers= list
 add the =org= entry.
+
+** Agenda notifications
+To enable notifications for agenda events, set the variable
+=org-enable-notifications= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-notifications t
+         org-start-notification-daemon-on-startup t)))
+#+END_SRC
+
+This will install and configure the [[https://github.com/akhramov/org-wild-notifier.el][org-wild-notifier]] package. After install run
+the =org-wild-notifier-mode= to start the =org-wild-notifier= notification daemon. To
+start the notification daemon automatically on Spacemacs startup, set the
+variable =org-start-notification-daemon-on-startup= to =t= as shown in the code
+snippet above.
+
+Documentation for how the notifications system can be configured is provided
+[[https://github.com/akhramov/org-wild-notifier.el#configuration][here]] (on GNU/linux and Windows, using the =notifications= style is recommended.
+Note also [[https://github.com/jwiegley/alert/pull/94][this issue]]).
+
+Press =M-S RET= to enter a todo headline and then press =, d t= to add a
+timestamp to the headline (or use the =org-journal-new-scheduled-entry= that
+becomes available by enabling [[Org-journal support]]. By default, the
+=org-wild-notifier= package will scan your =org-agenda-files= (every minute) for
+=TODO= headlines that include a timestamp (configuration options are documented
+[[https://github.com/akhramov/org-wild-notifier.el#configuration][here]]). The default configuration shows a notification 10 minutes before the
+event using the [[https://melpa.org/#/alert][alert]] package. The default behavior can be configured via the
+=org-wild-notifier-alert-time= variable. The notification type can be configured
+via the [[https://github.com/jwiegley/alert#for-users][the alert package its configuration settings]]. Additional notification
+times can be added using the [[https://github.com/akhramov/org-wild-notifier.el#configuration][:WILD_NOTIFIER_NOTIFY_BEFORE:]] keyword (*note* that
+[[https://github.com/akhramov/org-wild-notifier.el/issues/46][this additionally requires a =SCHEDULED:= stamp)]]. Properties can be added with
+=, i p=.
 
 ** GitHub support
 To install GitHub related extensions like [[https://github.com/larstvei/ox-gfm][ox-gfm]] to export to GitHub

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -34,6 +34,12 @@ path, one file per project is used (and the path is relative to
 the project root). If it an absolute path, one global file is
 used.")
 
+(defvar org-enable-notifications nil
+  "If non-nil org-wild-notifier is configured.")
+
+(defvar org-start-notification-daemon-on-startup nil
+  "If non-nil start the notification daemon on startup.")
+
 (defvar org-enable-org-contacts-support nil
   "If non-nil org-contacts is configured.")
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -23,6 +23,8 @@
     (ob :location built-in)
     (org :location built-in)
     (org-agenda :location built-in)
+    (org-wild-notifier
+                :toggle org-enable-notifications)
     (org-contacts :location built-in
                   :toggle org-enable-org-contacts-support)
     (org-vcard :toggle org-enable-org-contacts-support)
@@ -589,6 +591,13 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (kbd "M-RET") 'org-agenda-show-and-scroll-up
       (kbd "M-SPC") 'spacemacs/org-agenda-transient-state/body
       (kbd "s-M-SPC") 'spacemacs/org-agenda-transient-state/body)))
+
+(defun org/init-org-wild-notifier ()
+  (use-package org-wild-notifier
+    :defer t
+    :init
+    (when org-start-notification-daemon-on-startup
+      (org-wild-notifier-mode))))
 
 (defun org/init-org-brain ()
   (use-package org-brain


### PR DESCRIPTION
This PR replaces  #14396. See last comments there for motivation.

I've added instructions to use =org-journal-new-scheduled-entry=, assuming that PR numbers [335](https://github.com/bastibe/org-journal/pull/335), [337](https://github.com/bastibe/org-journal/pull/337) and [338](https://github.com/bastibe/org-journal/pull/338) get merged soon.