### PR TITLE
[core] new function spacemacs/set-root-leader-keys-for-mode

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -39,6 +39,7 @@
   - [[#tables][Tables]]
   - [[#trees][Trees]]
   - [[#element-insertion][Element insertion]]
+  - [[#narrowing][Narrowing]]
   - [[#links][Links]]
   - [[#babel--source-blocks][Babel / Source Blocks]]
     - [[#org-babel-transient-state][Org Babel Transient State]]
@@ -619,6 +620,14 @@ are also available.
 | ~SPC m i r~   | org-rich-yank (paste code into a =src= block) |
 | ~SPC m i s~   | org-insert-subheading                         |
 | ~SPC m i t~   | org-set-tags                                  |
+
+** Narrowing
+ 
+| Key binding | Description           |
+|-------------+-----------------------|
+| ~SPC n b~   | org-narrow-to-block   |
+| ~SPC n e~   | org-narrow-to-element |
+| ~SPC n s~   | org-narrow-to-subtree |
 
 ** Links
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -356,6 +356,11 @@ Will work on both org-mode and any mode that accepts plain html."
         "xu" (spacemacs|org-emphasize spacemacs/org-underline ?_)
         "xv" (spacemacs|org-emphasize spacemacs/org-verbatim ?=))
 
+      (spacemacs/set-root-leader-keys-for-mode 'org-mode nil
+        "nb" 'org-narrow-to-block
+        "ns" 'org-narrow-to-subtree
+        "ne" 'org-narrow-to-element)
+
       ;; Add global evil-leader mappings. Used to access org-agenda
       ;; functionalities – and a few others commands – from any other mode.
       (spacemacs/declare-prefix "ao" "org")


### PR DESCRIPTION
[core] This function allows to bind a mode command behind `dotspacemacs-leader-key' and
`dotspacemacs-emacs-leader-key' when that mode is activate.

[org] apply this function to org narrow commands

motivation:

Currently `spacemacs/set-leader-keys-for-major-mode` and
`spacemacs/set-leader-keys-for-minor-mode` only let us bind command under `spc
m` and `,` That works fine in general. But not all commands should go there. A
mode that deals with compilation or comments when active should have commands
bound behind `spc c` not `spc m`. Another example is org-mode narrow commands
should go to prefix `spc n` not a long and tedious `spc m s b n`.
