### PR TITLE
[lsp] add option to bind commands to lsp-command-map

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -18,6 +18,7 @@
   - [[#language-specific-key-binding-extensions][Language-specific key binding extensions]]
     - [[#spacemacslsp-define-extensions-layer-name-kind-request-optional-extra-parameters][~spacemacs/lsp-define-extensions layer-name kind request &optional extra-parameters~]]
     - [[#spacemacslsp-bind-extensions-for-mode][~spacemacs/lsp-bind-extensions-for-mode~]]
+  - [[#bind-to-lsp-upstreams][Bind to lsp upstreams]]
 - [[#dap-integration][DAP integration]]
 - [[#diagnostics][Diagnostics]]
 - [[#references][References]]
@@ -319,6 +320,24 @@ whereas with ~lsp-navigation~ set to ~'peek~, this is equivalent to:
 #+END_SRC
 
 etc.
+
+** Bind to lsp upstreams
+Alternative to the binding shemes above. If you set ~lsp-use-upstream-bindings~
+to ~t~ then Spacemacs will bind all ~lsp-command-map~ behind ~SPC m~, ~,~ and
+~M-m~. This way the bidings will be managed by upstream ~lsp-mode~ which is
+documented at https://emacs-lsp.github.io/lsp-mode/page/keybindings/. Spacemacs
+only replaces the prefix ~s-l~ with ~SPC m~. For example:
+
+| lsp binding | Spacemacs binding                   |
+|-------------+-------------------------------------|
+| ~s-l w s~   | ~SPC m w s~ or ~, w s~ or ~M-m w s~ |
+
+As ~lsp-mode~ and has a deep integration into ~Spacemacs~. ~Spacemacs~ hackers
+should pay attention to avoid any binding collision with ~lsp-mode~.
+
+#+begin_src elisp
+  (lsp :variables lsp-use-upstream-bindings t)
+#+end_src
 
 * DAP integration
 =lsp-mode= integrates with =dap-mode=, which implements DAP(Debugger Adapter Protocol). See documentation on =DAP= layer for details.

--- a/layers/+tools/lsp/config.el
+++ b/layers/+tools/lsp/config.el
@@ -36,3 +36,5 @@ If `both', binds lightweight navigation functions under `SPC m g' and lsp-ui fun
 (defvar lsp-ui-sideline-ignore-duplicate t "Ignore duplicates")
 
 (defvar lsp-use-lsp-ui t "When non-nil, use `lsp-ui' package.")
+
+(defvar lsp-use-upstream-bindings nil "When non-nil, map keys to `lsp-command-map'.")

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -37,6 +37,24 @@
     (setq key (pop bindings)
           def (pop bindings))))
 
+(defun spacemacs/lsp-bind-upstream-keys ()
+  "Bind upstream `lsp-command-map' behind \"SPC m\" and the likes."
+  (bind-map lsp-command-map
+    :minor-modes (lsp-mode)
+    :keys ((concat dotspacemacs-emacs-leader-key " m") dotspacemacs-major-mode-emacs-leader-key)
+    :evil-keys ((concat dotspacemacs-leader-key " m") dotspacemacs-major-mode-leader-key)
+    :evil-states (normal motion visual evilified))
+  (dolist (it '(("=" . "format")
+                ("F" . "folder")
+                ("T" . "toggle")
+                ("g" . "goto")
+                ("h" . "help")
+                ("r" . "refactor")
+                ("w" . "workspace")
+                ("a" . "actions")
+                ("G" . "peek")))
+    (which-key-add-keymap-based-replacements lsp-command-map (car it) (cdr it))))
+
 (defun spacemacs/lsp-bind-keys ()
   "Define key bindings for the lsp minor mode."
   (cl-ecase lsp-navigation

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -36,7 +36,9 @@
     :defer t
     :config
     (progn
-      (spacemacs/lsp-bind-keys)
+      (if lsp-use-upstream-bindings
+          (spacemacs/lsp-bind-upstream-keys)
+        (spacemacs/lsp-bind-keys))
       (setq lsp-prefer-capf t)
       (add-hook 'lsp-after-open-hook (lambda ()
                                        "Setup xref jump handler"


### PR DESCRIPTION
`lsp-use-upstream-bindings` set to `t` then Spacemacs will bind 
`lsp-command-map` behind `SPC m`, `,` and `M-m`. This way the bindings will be
managed by upstream `lsp-mode` which is documented at
https://emacs-lsp.github.io/lsp-mode/page/keybindings/.

Spacemacs only replaces the prefix `s-l` with `SPC m`. For example:
```
| lsp binding | Spacemacs binding                   |
|-------------+-------------------------------------|
| `s-l s s`   | `SPC m s s` or `, s s` or `M-m s s` |
```

It is assumed in this PR we trust @yyoncho and his gang to manage the bindings for us to save time and effort. Of course, there is a mismatch such as we have `, b` for backend but `lsp-mode` prefer `, s` for session.
