### PR TITLE
[lsp] Bind `SPC p E` to `helm-lsp-diagnostics`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2610,6 +2610,7 @@ files (thanks to Daniel Nicolai)
 - Added package =helm-lsp=
   - ~SPC m g s~ to find symbol in current project
   - ~SPC m g S~ to find symbol in all projects
+  - ~SPC p E~ to show error list
 - Disabled =helm-lsp= keybindings when =ivy= layer enabled (Cormac Cannon)
 - Deleted =fix-lsp-company-prefix= since =company-lsp= is doing that handling.
 - Fixed a delay when declaring prefixes for mode (thanks to Thanh Vuong)

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -97,7 +97,8 @@
    ((configuration-layer/package-usedp 'helm)
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
       (concat prefix-char "s") #'helm-lsp-workspace-symbol
-      (concat prefix-char "S") #'helm-lsp-global-workspace-symbol))
+      (concat prefix-char "S") #'helm-lsp-global-workspace-symbol)
+    (spacemacs/set-leader-keys "pE" #'helm-lsp-diagnostics))
    ((configuration-layer/package-usedp 'ivy)
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
       (concat prefix-char "s") #'lsp-ivy-workspace-symbol


### PR DESCRIPTION
IMHO this should be global binding, the alternative was `SPC e e` because it can
be used everywhere, e. g. from compilation buffer to find the error causing the
build breakage.