### PR TITLE
mu4e: require mu4e for mu4e-org-link-support

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -159,7 +159,7 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
           (require 'mu4e-org))
         ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
         ;; Note that this bug prevents lazy-loading.
-        (if (version<= mu4e-mu-version "1.4.13")
+        (if (version<= mu4e-mu-version "1.4.15")
             (require 'mu4e))))
   (if mu4e-org-compose-support
       (progn


### PR DESCRIPTION
it looks like it still would throw a message:

"mu4e-org-store-link: Please load mu4e before mu4e-org" if attempted to use
`org-store-link` before loading mu4e (for any kind of link, not just mu4e) 

I'm just going to bump the version number until
someone offers a better solution

