### PR TITLE
Restore SPC gfd for magit-diff, set SPC gfm for magit-file-dispatch

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -345,7 +345,7 @@ In org-agenda-mode
 - Key bindings:
   - Changed ~SPC g h o~ to ~SPC g o~ for =browse-at-remote= (thanks to Codruț
     Constantin Gușoi)
-  - Changed ~SPC g f d~ to bind to ~magit-file-dispatch~ (thanks to Ag Ibragimov)
+  - Add ~SPC g f m~ for ~magit-file-dispatch~ (thanks to Ag Ibragimov and Ilya Grigoriev)
 ***** YAML
 - Added LSP support (thanks to Seong Yong-ju)
 ***** ycmd

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -131,6 +131,7 @@ Git commands (start with ~g~):
 | ~SPC g f f~ | view a file at a specific branch or commit          |
 | ~SPC g f l~ | commits log for current file                        |
 | ~SPC g f d~ | diff for current file                               |
+| ~SPC g f m~ | magit dispatch popup for file operations            |
 | ~SPC g H c~ | clear highlights                                    |
 | ~SPC g H h~ | highlight regions by age of commits                 |
 | ~SPC g H t~ | highlight regions by last updated time              |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -161,7 +161,8 @@
         "gc"  'magit-clone
         "gfF" 'magit-find-file
         "gfl" 'magit-log-buffer-file
-        "gfd" 'magit-file-dispatch
+        "gfd" 'magit-diff
+        "gfm" 'magit-file-dispatch
         "gi"  'magit-init
         "gL"  'magit-list-repositories
         "gm"  'magit-dispatch


### PR DESCRIPTION
Fixes https://github.com/syl20bnr/spacemacs/issues/14434.

Builds upon https://github.com/syl20bnr/spacemacs/pull/14408.