### PR TITLE
Add pdf-view-restore to pdf layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3010,6 +3010,7 @@ files (thanks to Daniel Nicolai)
     - ~[~ history-backward (previous view)
     - ~]~ history-forward (next view)
     - ~?~ toggle transient sate documentation hint (shown by default)
+- Add pdf-view-restore (thanks to Daniel Nicolai)
 **** Perl5
 - Fixed =spacemacs/perltidy-format-buffer= and
   =spacemacs/perltidy-format-function= to move the point and window to their

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -87,8 +87,14 @@ Tips:
 - You'll probably want to use =pdf-view-set-slice-from-bounding-box= (bound to
   ~SPC m s b~) This command trims the blank parts of the
   lateral margins, making the useful portion larger.
-- The last visited page is not saved across Emacs sessions. If you want save it,
-  use the bookmarks commands on ~SPC j b~ to save and go to a bookmark.
+- The layer uses the package [[https://github.com/007kevin/pdf-view-restore][pdf-view-restore]] to store and restore last-visited
+  pages. By default the information is stored in the directory of the viewed
+  document (so it can get lost if you use e.g. [[https://calibre-ebook.com/][Calibre]]/[[https://github.com/chenyanming/calibredb.el][calibredb.el]] for your
+  document management). If you would like the information to get stored in a
+  different location then [[https://github.com/chenyanming/calibredb.el][set the variable]] =pdf-view-restore-filename= to the
+  path of the filename to use. Alternatively you can (additionally) use Emacs
+  its [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Bookmarks.html][bookmarks]] system to store and revisit (=SPC f b= for both) any location
+  manually.
 
 * Known Issues
 Due to =image-mode=’s behaviour, the =pdf-tools= buffer might go back to the

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -10,7 +10,8 @@
 ;;
 ;;; License: GPLv3
 
-(setq pdf-packages '(pdf-tools))
+(setq pdf-packages '(pdf-tools
+                     pdf-view-restore))
 
 (defun pdf/init-pdf-tools ()
   (use-package pdf-tools
@@ -118,3 +119,9 @@
         "r"              'pdf-occur-revert-buffer-with-args
         "*"              'spacemacs/enter-ahs-forward
         "?"              'evil-search-backward))))
+
+(defun pdf/init-pdf-view-restore ()
+  (use-package pdf-view-restore
+    :after pdf-tools
+    :config
+    (add-hook 'pdf-view-mode-hook 'pdf-view-restore-mode)))


### PR DESCRIPTION
Accidentally created this commit on develop. However, the addition is so small that I just PR from here.
I think restore last visited page should probably be the default in a pdf-viewer. (pdf-view-restore)[https://github.com/007kevin/pdf-view-restore] does it simple and fine.