### PR TITLE
Fix `(void-function smartparens-mode)`

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -393,12 +393,6 @@
             sp-highlight-pair-overlay nil
             sp-highlight-wrap-overlay nil
             sp-highlight-wrap-tag-overlay nil)
-      (spacemacs/add-to-hooks (if dotspacemacs-smartparens-strict-mode
-                                  'smartparens-strict-mode
-                                'smartparens-mode)
-                              '(prog-mode-hook comint-mode-hook))
-      ;; enable smartparens-mode in `eval-expression'
-      (add-hook 'minibuffer-setup-hook 'spacemacs//conditionally-enable-smartparens-mode)
       ;; toggles
       (spacemacs|add-toggle smartparens
         :mode smartparens-mode
@@ -415,6 +409,14 @@
     :config
     (progn
       (require 'smartparens-config)
+
+      (spacemacs/add-to-hooks (if dotspacemacs-smartparens-strict-mode
+                                  'smartparens-strict-mode
+                                'smartparens-mode)
+                              '(prog-mode-hook comint-mode-hook))
+      ;; enable smartparens-mode in `eval-expression'
+      (add-hook 'minibuffer-setup-hook 'spacemacs//conditionally-enable-smartparens-mode)
+
       (spacemacs|diminish smartparens-mode " ⓟ" " p")
       (spacemacs//adaptive-smartparent-pair-overlay-face)
       (add-hook 'spacemacs-post-theme-change-hook


### PR DESCRIPTION
Fixes https://github.com/syl20bnr/spacemacs/issues/14439.

This fixes two+ problems I had, described below. 


1) When loading `emacs -nw ~/.spacemacs`, I would get a message 
`File mode specification error: (void-function smartparens-mode)`.

2) When pressing `M-:` to call `eval-expression`, it would not work.
Instead it would show 
`Symbol’s function definition is void: smartparens-mode` 
in the minibuffer.

3) I think this happened at other random times as well. From the code,
  you can get a sense `smartparens-mode` is getting loaded at strange
  times.

Fair warning: I'm not sure why I had this problem (some others claim 
they didn't experience it), when exactly is the right time to load various
types of code with `use-package`, or whether this create any new problems 
(though it looks pretty safe to me). It does seem to make things work for 
me, though. 
