### PR TITLE
git: adds orgit-forge so org links can be stored from forge topics

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2086,6 +2086,8 @@ Other:
   - Allowed multichar major mode leader key for exiting magit commit edits
     (thanks to tuh8888)
   - Restore magit transient args between sessions (thanks to duianto)
+- Improvements:
+  - Added orgit-forge (thanks to Ag Ibragimov)
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -34,7 +34,7 @@
         magit-svn
         org
         (orgit :requires org)
-        (orgit-forge :requires org)
+        (orgit-forge :requires (org forge))
         smeargle
         transient))
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -34,6 +34,7 @@
         magit-svn
         org
         (orgit :requires org)
+        (orgit-forge :requires org)
         smeargle
         transient))
 
@@ -294,6 +295,11 @@
 
 (defun git/init-orgit ()
   (use-package orgit
+    :defer t))
+
+(defun git/init-orgit-forge ()
+  (use-package orgit-forge
+    :after forge
     :defer t))
 
 (defun git/post-init-org ()


### PR DESCRIPTION
Do we need the `:toggle` here as well, as it's [done for](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Bsource-control/git/packages.el#L18) `forge` or this is good?