### PR TITLE
[haskell] Add a binding to change the target for the session

### DIFF
--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -269,6 +269,7 @@ REPL commands are prefixed by ~SPC m s~:
 | ~SPC m s c~ | clear the REPL                                  |
 | ~SPC m s s~ | show and switch to the REPL                     |
 | ~SPC m s S~ | show the REPL without switching to it           |
+| ~SPC m s t~ | change the target for the REPL                  |
 | ~C-j~       | switch to next history item                     |
 | ~C-k~       | switch to previous history item                 |
 | ~C-l~       | clear the REPL                                  |

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -178,6 +178,7 @@
           "sc"  'haskell-interactive-mode-clear
           "sS"  'spacemacs/haskell-interactive-bring
           "ss"  'haskell-interactive-switch
+          "st"  'haskell-session-change-target
           "'"   'haskell-interactive-switch
 
           "ca"  'haskell-process-cabal


### PR DESCRIPTION
Using the correct target for the Haskell session is required when working on a
project with more than one target defined in the Cabal file.