### PR TITLE
update cask install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Homebrew now recommends to use the cask version with the following message:
 version:
 
 ```
-brew install emacs --cask
+brew install --cask emacs
 ```
 
 or in older versions of homebrew

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Homebrew now recommends to use the cask version with the following message:
 version:
 
 ```
+brew install emacs --cask
+```
+
+or in older versions of homebrew
+
+```
 brew cask install emacs
 ```
 


### PR DESCRIPTION
This is a simple update to the documentation:

Recent versions of homebrew use the syntax

```brew install --cask emacs```

instead of

```brew cask install emacs```