### PR TITLE
Delete unexpected chars within pairs of ~

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -125,7 +125,7 @@ to the following variables:
     '((shell :variables shell-default-shell 'eshell)))
 #+END_SRC
 
-The default shell is quickly accessible via a the default shortcut key ~SPC '​~.
+The default shell is quickly accessible via a the default shortcut key ~SPC '~.
 
 ** Default shell position, width, and height
 It is possible to choose where the shell should pop up by setting the variable
@@ -289,10 +289,10 @@ Some advanced configuration is setup for =eshell= in this layer:
 
 | Key binding   | Description                                                |
 |---------------+------------------------------------------------------------|
-| ~SPC '​~       | Open, close or go to the default shell                     |
-| ~SPC "​~       | Open external terminal emulator in current directory       |
-| ~SPC p '​~     | Open a shell in the project's root                         |
-| ~SPC p "​~     | Open external terminal emulator in project root            |
+| ~SPC '~        | Open, close or go to the default shell                     |
+| ~SPC "~        | Open external terminal emulator in current directory       |
+| ~SPC p '~      | Open a shell in the project's root                         |
+| ~SPC p "~      | Open external terminal emulator in project root            |
 | ~SPC a t s e~ | Open, close or go to an =eshell=                           |
 | ~SPC a t s i~ | Open, close or go to a =shell=                             |
 | ~SPC a t s m~ | Open, close or go to a =multi-term=                        |
@@ -305,10 +305,10 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~C-k~         | previous item in history                                   |
 
 *Note:* You can open multiple shells using a numerical prefix argument,
-for instance pressing ~2 SPC '​~ will a second default shell, the
+for instance pressing ~2 SPC '~ will a second default shell, the
 number of shell is indicated on the mode-line.
 
-*Note:* Use the universal prefix argument ~SPC u SPC '​~ to open the shell
+*Note:* Use the universal prefix argument ~SPC u SPC '~ to open the shell
 in the current buffer instead of a popup.
 
 ** Multi-term


### PR DESCRIPTION
Unexpected chars break style of quoted key bindings in documents. For example: https://develop.spacemacs.org/layers/+tools/shell/README.html#key-bindings

![image](https://user-images.githubusercontent.com/69779107/109800475-2edaf580-7c58-11eb-93d4-c5e88124d3c6.png)


More similar commits will come later after this one gets approved.
