### PR TITLE
Provide a switch to auto run mu4e at emacs startup

### DIFF
--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -51,5 +51,8 @@
 (defvar mu4e-org-compose-support nil
   "If non-nil org-mu4e is configured.")
 
+(defvar mu4e-autorun-background-at-startup nil
+  "If non-nil, mu4e will automatically run in background at emacs startup.")
+
 (when mu4e-installation-path
   (add-to-list 'load-path mu4e-installation-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -102,6 +102,9 @@
       (when (fboundp 'imagemagick-register-types)
         (imagemagick-register-types))
 
+      (when mu4e-autorun-background-at-startup
+        (mu4e t))
+
       (add-to-list 'mu4e-view-actions
                    '("View in browser" . mu4e-action-view-in-browser) t)
 


### PR DESCRIPTION
Currently `mu4e` does not run automatically at startup. Users will not get email notification until they run `mu4e` command explicitly. This PR provide a switch to make `mu4e` auto run in background at emacs startup.