### PR TITLE
[ess] add keybinding for ess-quit

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -137,7 +137,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Add ~J/K~ for scrolling down/up (thanks to Daniel Nicolai)
 ***** ESS
 - ESS key bindings were re-organised in the following list
-  (thanks to Guido Kraemer, Yi Liu, and Jack Kamm):
+  (thanks to Guido Kraemer, Yi Liu, Jack Kamm and Ben Swift):
   - ~SPC m ,~ for =ess-eval-region-or-function-or-paragraph-and-step=
   - ~SPC m d~ for =ess-dev-map=
   - ~SPC m h h~ for =ess-display-help-on-object=
@@ -155,6 +155,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - ~SPC m s f~ for =ess-eval-function=
   - ~SPC m s i~ for =spacemacs/ess-start-repl=
   - ~SPC m s l~ for =ess-eval-line=
+  - ~SPC m s Q~ for =ess-quit=
   - ~SPC m s r~ for =ess-eval-region=
   - ~SPC m s s~ for =ess-switch-to-inferior-or-script-buffer=
   - ~SPC m w~ for =ess-r-package-dev-map=

--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -92,6 +92,7 @@ Send code to inferior process with these commands:
 | ~SPC m s F~ | send function and focus REPL                         |
 | ~SPC m s l~ | send line and keep code buffer focused               |
 | ~SPC m s L~ | send line and focus REPL                             |
+| ~SPC m s Q~ | quit REPL                                            |
 | ~SPC m s r~ | send region and keep code buffer focused             |
 | ~SPC m s R~ | send region and focus REPL                           |
 

--- a/layers/+lang/ess/funcs.el
+++ b/layers/+lang/ess/funcs.el
@@ -62,6 +62,7 @@
     "sD" #'ess-eval-function-or-paragraph-and-step
     "sL" #'ess-eval-line-and-go
     "sl" #'ess-eval-line
+    "sQ" #'ess-quit
     "sR" #'ess-eval-region-and-go
     "sr" #'ess-eval-region
     "sF" #'ess-eval-function-and-go


### PR DESCRIPTION
Add a keybinding (alongside all the other `SPC m s` ones) to quit the current inferior process REPL.