### PR TITLE
[core] fix warnings about overwriting by aliasing

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -630,6 +630,7 @@ Other:
   - Add toggles for persistent which-key keymaps, (full)-major/minor mode
     keymaps and top-level keymap, under prefix ~SPC t k~ (thanks to Daniel Nicolai)
 - Fixes:
+  - Don't use a mode's hook before the mode is even loaded (thanks to Keith Pinson)
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed
     counter from progress bar, fixed updating, and fixed size when Emacs is

--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -33,7 +33,8 @@ sets `spacemacs-jump-handlers' in buffers of that mode."
          (setq spacemacs-jump-handlers
                (append ,handlers-list
                        spacemacs-default-jump-handlers)))
-       (add-hook ',mode-hook ',func)
+       (with-eval-after-load ',mode
+         (add-hook ',mode-hook ',func))
        (with-eval-after-load 'bind-map
          (spacemacs/set-leader-keys-for-major-mode ',mode
            "gg" 'spacemacs/jump-to-definition


### PR DESCRIPTION
Fixes this warning which annoying pops up a warning buffer on the launching
IELM:

> Warning (defvaralias): Overwriting value of ‘inferior-emacs-lisp-mode-hook’ by aliasing to ‘ielm-mode-hook’

On the one hand, this change scares me, because it impacts a lot of modes and I
have no idea how to regression test it. Someone with deeper Spacemacs knowledge
should be able to reassure me or tell me why this is bad.

On the other hand, I cannot see how it makes sense to use a mode's hook before
the mode has even been loaded; though the problem here only seems to emerge due
to the use of an alias, in my case for `ielm-mode`, which adds
`inferior-emacs-lisp-mode-hook` as an alias for `ielm-mode-hook`.
