### PR TITLE
Fixes error if parsing ipython dev version

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3146,6 +3146,7 @@ files (thanks to Daniel Nicolai)
 - Added --last-failed support for pytest (thanks to Jaakko Luttinen)
 - Added =spacemacs/python-shell-send-statement= support (thanks to Lin Sun)
 - Added =sphinx-doc= support (thanks to Stefan Ruschke)
+- Fix ipython version parsing for dev branches (thanks to Corentin Risselin)
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -157,7 +157,7 @@ as the pyenv version then also return nil. This works around https://github.com/
 (defun spacemacs//python-setup-shell (&rest args)
   (if (spacemacs/pyenv-executable-find "ipython")
       (progn (setq python-shell-interpreter "ipython")
-             (if (version< (replace-regexp-in-string "[\r\n|\n]$" "" (shell-command-to-string (format "\"%s\" --version" (string-trim (spacemacs/pyenv-executable-find "ipython"))))) "5")
+             (if (version< (replace-regexp-in-string "\\(\\.dev\\)?[\r\n|\n]$" "" (shell-command-to-string (format "\"%s\" --version" (string-trim (spacemacs/pyenv-executable-find "ipython"))))) "5")
                  (setq python-shell-interpreter-args "-i")
                (setq python-shell-interpreter-args "--simple-prompt -i")))
     (progn


### PR DESCRIPTION
ipython versions are usually in the form `X.X.X` but a dev version is installed it is printed as `X.X.X.dev` this makes an error in the python layer initialization.

This is useful as it has been months since `ipython` is not yet released as version 8 while `jedi` moved to version 0.18. The completion API used by `ipython` version 7 is deprecated for more than a year (for `jedi` version 0.17.2 it is still working with deprecation warnings).

Since `jedi` 0.18 the deprecation warning is removed and while spacemacs will correctly complete with `jedi` 0.18 ipython will be broken (crash).

The best course of action is to clone the master branch of https://github.com/ipython/ipython and install it (just `pip install -e .` from the cloned folder). So both ipython command and spacemacs can work.