### PR TITLE
[Scala] Update to default behaviour

### DIFF
--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -61,6 +61,12 @@ where =0.9.8= can be replaced with the current version of [[https://scalameta.or
     -o /usr/local/bin/metals-emacs -f
 #+END_SRC
 
+Notice that the layer by default overwrites Metals-scala tree view to nil
+#+begin_example elisp
+(defvar scala-auto-treeview nil
+#+end_example
+This to avoid issues with buffers when rendering VSCode like view, issue described [[https://github.com/syl20bnr/spacemacs/pull/14470][Here]].
+
 You will then have the common LSP key bindings; see
 [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp#key-bindings][LSP#key-bindings]] for more details.
 

--- a/layers/+lang/scala/config.el
+++ b/layers/+lang/scala/config.el
@@ -29,5 +29,5 @@ small window at the bottom of the frame.")
   "Backend used to trigger IDE language features.
 Only `scala-metals' is currently supported.")
 
-(defvar scala-auto-treeview t
+(defvar scala-auto-treeview nil
   "If non-nil automatically show treeview when views are recieved by metals.")


### PR DESCRIPTION
When working long hours with Metals and saving and moving between buffers. This feature of automatically showing and writing in buffers breaks HELM, and buffer management stops, rendering Emacs useless. Furthermore, this feature is not that useful. In VIM LSP is off by default. The purpose of this is to make the experience of Scala Developers with Metals a nice one, rather than having Emacs breaking all the time, as has been happening to me. This has saved me hours.

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!
