### PR TITLE
Improve editing-style toggles

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -592,9 +592,13 @@ Press \\[which-key-toggle-persistent] to hide."
         (spacemacs|add-toggle holy-mode
           :status holy-mode
           :on (progn (when (bound-and-true-p hybrid-mode)
-                       (hybrid-mode -1))
-                     (holy-mode))
-          :off (holy-mode -1)
+                       (hybrid-mode -1)
+                       (spacemacs/declare-prefix "tEh" "hybrid (hybrid-mode)"))
+                     (holy-mode)
+                     (spacemacs/declare-prefix "tEe" "vim (evil-mode"))
+          :off (progn (holy-mode -1)
+                      (spacemacs/declare-prefix "tEe" "emacs (holy-mode)"))
+          :off-message "evil-mode enabled."
           :documentation "Globally toggle holy mode."
           :evil-leader "tEe")
         (spacemacs|diminish holy-mode " Ⓔe" " Ee")))))
@@ -608,9 +612,13 @@ Press \\[which-key-toggle-persistent] to hide."
         (spacemacs|add-toggle hybrid-mode
           :status hybrid-mode
           :on (progn (when (bound-and-true-p holy-mode)
-                       (holy-mode -1))
-                     (hybrid-mode))
-          :off (hybrid-mode -1)
+                       (holy-mode -1)
+                       (spacemacs/declare-prefix "tEe" "emacs (holy-mode)"))
+                     (hybrid-mode)
+                     (spacemacs/declare-prefix "tEh" "vim (evil-mode)"))
+          :off (progn (hybrid-mode -1)
+                      (spacemacs/declare-prefix "tEh" "hybrid (hybrid-mode)"))
+          :off-message "evil-mode enabled."
           :documentation "Globally toggle hybrid mode."
           :evil-leader "tEh")
         (spacemacs|diminish hybrid-mode " Ⓔh" " Eh")))))


### PR DESCRIPTION
Fixes: There is no keybinding to toggle vim/evil mode #13511

### problem:
The toggle editing style prefix: `SPC t E`
always shows the same names:
```
e -> emacs (holy-mode)
h -> hybrid (hybrid-mode)
```

This causes some confusion about how to
switch to the vim (evil-mode) editing style,
from emacs or hybrid state.

### solution:
Show which editing styles one will switch to:

In evil-mode:
```
e -> emacs (holy-mode)
h -> hybrid (hybrid-mode)
```
In holy-mode:
```
e -> vim (evil-mode)
h -> hybrid (hybrid-mode)
```
In hybrid-mode:
```
e -> emacs (holy-mode)
h -> vim (evil-mode)
```