### PR TITLE
Add keybindings for org-roam-alias-add

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2920,6 +2920,8 @@ files (thanks to Daniel Nicolai)
     (thanks to Mariusz Klochowicz)
     - ~SPC a o r d d~ (~SPC m r d d~) Open daily note via calendar view
     (thanks to Ben Swift)
+    - ~SPC a o r a~ (~SPC m r a~) Add org-roam alias to file
+      (thanks to KjartanOli)
   - Added additional prefix (~SPC m m j~) for org-jira bindings
     (thanks to Mariusz Klochowicz)
   - Added keybindings ~SPC a o C f~ and org/agenda local ~SPC m C f~ keybindings

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -987,3 +987,4 @@ Key binding prefixes:
 | ~[prefix] r d d~ | Open daily note via calendar view     |
 | ~[prefix] r t a~ | add org-roam tag to file              |
 | ~[prefix] r t d~ | delete org-roam tag from file         |
+| ~[prefix] r a~   | add org-roam alias to file            |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -901,7 +901,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "aorI" 'org-roam-insert-immediate
         "aorl" 'org-roam-buffer-toggle-display
         "aorta" 'org-roam-tag-add
-        "aortd" 'org-roam-tag-delete)
+        "aortd" 'org-roam-tag-delete
+        "aora" 'org-roam-alias-add)
 
       (spacemacs/declare-prefix-for-mode 'org-mode "mr" "org-roam")
       (spacemacs/declare-prefix-for-mode 'org-mode "mrd" "org-roam-dailies")
@@ -918,7 +919,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "rI" 'org-roam-insert-immediate
         "rl" 'org-roam-buffer-toggle-display
         "rta" 'org-roam-tag-add
-        "rtd" 'org-roam-tag-delete))
+        "rtd" 'org-roam-tag-delete
+        "rta" 'org-roam-alias-add))
     :config
     (progn
       (spacemacs|hide-lighter org-roam-mode))))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -920,7 +920,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "rl" 'org-roam-buffer-toggle-display
         "rta" 'org-roam-tag-add
         "rtd" 'org-roam-tag-delete
-        "rta" 'org-roam-alias-add))
+        "ra" 'org-roam-alias-add))
     :config
     (progn
       (spacemacs|hide-lighter org-roam-mode))))


### PR DESCRIPTION
Add bindings for org-roam-alias-add as `SPC a o r a` and `SPC m r a`, to make it more convenient to add aliases to org-roam files.