### PR TITLE
[evilified] Visual state text objects, exchange point/mark

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -120,7 +120,10 @@ Needed to bypass keymaps set as text properties."
     (setq-local evilified-state--visual-state-map
                 (copy-keymap evil-visual-state-map)))
   (setq-local evil-visual-state-map
-              (cons 'keymap (list (cons ?y 'evil-yank)
+              (cons 'keymap (list (cons ?a evil-outer-text-objects-map)
+                                  (cons ?i evil-inner-text-objects-map)
+                                  (cons ?o 'exchange-point-and-mark)
+                                  (cons ?y 'evil-yank)
                                   (cons 'escape 'evil-exit-visual-state)))))
 
 (defun evilified-state--restore-visual-state-keymap ()


### PR DESCRIPTION
In evilified visual state.
- Add the inner: `i` and outer `a` text objects.
- Add `o` to exchange the point and mark
  (jump between the start and end of the region)