### PR TITLE
 rust: Improved LSP Rust server switch functionality

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3318,6 +3318,7 @@ files (thanks to Daniel Nicolai)
 - Added/Updated instructions on external dependencies, =cargo-edit=,
   =cargo-audit=, =rustfmt=, and =clippy= (thanks to Lucius Hu)
 - Added support for Rusty Object Notation (RON) (thanks to Daniel Hutzley)
+- Improved LSP Rust server switch functionality (thanks to Lucius Hu)
 **** Sailfish-Developer
 - Key bindings:
   - Added =sailfish-scratchbox= key bindings (thanks to Victor Polevoy):

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -81,8 +81,7 @@ To choose the experimental [[https://github.com/rust-analyzer/rust-analyzer][rus
 #+END_SRC
 
 **** Switch to another LSP server
-If both =rls= and =rust-analyzer= server are installed, you can press ~SPC m s s~ to select
-another LSP server backend, and press ~SPC m b r~ to restart the LSP server to finish the switching.
+If both =rls= and =rust-analyzer= server are installed, you can press ~SPC m s s~ to switch to another LSP server backend.
 
 **** Autocompletion
 To enable auto-completion, ensure that the =auto-completion= layer is enabled.

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -40,6 +40,12 @@
   (message (concat "`lsp' layer is not installed, "
                    "please add `lsp' layer to your dotfile.")))
 
+(defun spacemacs//lsp-rust-switch-server ()
+  "Switch between rust-analyzer and rls."
+  (interactive)
+  (lsp-rust-switch-server)
+  (call-interactively 'lsp-workspace-restart))
+
 (defun spacemacs//rust-setup-lsp ()
   "Setup lsp backend"
   (if (configuration-layer/layer-used-p 'lsp)
@@ -47,7 +53,7 @@
         (lsp)
         (spacemacs/declare-prefix-for-mode 'rust-mode "ms" "switch")
         (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-          "ss" 'lsp-rust-switch-server))
+          "ss" 'spacemacs//lsp-rust-switch-server))
     (spacemacs//lsp-layer-not-installed-message)))
 
 (defun spacemacs//rust-setup-lsp-dap ()


### PR DESCRIPTION
Currently, when `lsp` backend is used for `rust` layer, `SPC m s s` is bound to
`lsp-rust-switch-server`, which temporarily changes the preferred LSP server
for `rust-mode`, but it DOES NOT switch the running LSP server. Users need to
call `lsp-workspace-restart` to finish the switching.

This PR introduced a new function `spacemacs//lsp-rust-switch-server`, which is
a wrapper for the two aforementioned functions

