### PR TITLE
Move known temporary files of LSP into `spacemacs-cache-directory`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 .emacs.desktop
 .emacs.desktop.lock
 .extension
-.lsp-session-*
 .mc-lists.el
 .places
 .python-environments/

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -22,6 +22,15 @@
 (defun lsp/init-lsp-mode ()
   (use-package lsp-mode
     :defer t
+    :init
+    (setq lsp-cache-dir (concat spacemacs-cache-directory "lsp/")
+          lsp-server-install-dir lsp-cache-dir
+          lsp-session-file (concat lsp-cache-dir (file-name-nondirectory ".lsp-session-v1"))
+          lsp-eslint-library-choices-file (concat lsp-cache-dir ".lsp-eslint-choices")
+          lsp-yaml-schema-store-local-db (concat lsp-cache-dir "lsp-yaml-schemas.json")
+          lsp-vetur-global-snippets-dir (concat lsp-cache-dir ".snippets/vetur")
+          ;; If you find something else should be ignored, you could also set them here
+          )
     :config
     (progn
       (spacemacs/lsp-bind-keys)


### PR DESCRIPTION
Move known temporary files of LSP into `spacemacs-cache-directory`.

Original post:
> Ignore auto-generated `.lsp-eslint-choices` file.
> (Or, would it be better if we move this file into `spacemacs-cache-directory`/`lsp` by setting variable `lsp-eslint-library-choices-file`?)