### PR TITLE
Fix #14492 don't change the selected window in delete-window

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
+++ b/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
@@ -794,9 +794,10 @@ A negative prefix arg deiconifies all iconified frames."
 ;; If WINDOW is the only one in its frame, `delete-frame'.
 (defadvice delete-window (around delete-frame-if-one-win activate)
   "If WINDOW is the only one in its frame, then `delete-frame' too."
-  (save-current-buffer
-    (select-window (or (ad-get-arg 0)  (selected-window)))
-    (if (one-window-p t) (delete-frame) ad-do-it)))
+  (let ((window (or (ad-get-arg 0) (selected-window))))
+    (if (with-selected-window window (one-window-p t))
+        (delete-frame (window-frame window))
+      ad-do-it)))
 
 ;;;###autoload
 (defun delete-windows-for (&optional buffer)


### PR DESCRIPTION
Before this commit, when delete-window was called with a window
argument, this advice changed the selected window and did not restore
it.  This could cause strange effects when the selected window was a
minibuffer window, because `one-window-p` is called with NOMINI.

Instead, we limit the dynamic extent of the selected window change to
the call to `one-window-p`.  Using `with-selected-window` also ensures
that the current buffer and selected window remain consistent after
the advice.