### PR TITLE
Prefer downloading org-appear from melpa

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -53,8 +53,7 @@
     (verb :toggle org-enable-verb-support)
     (org-roam :toggle org-enable-roam-support)
     (valign :toggle org-enable-valign)
-    (org-appear :location (recipe :fetcher github :repo "awth13/org-appear")
-                :toggle org-enable-appear-support)))
+    (org-appear :toggle org-enable-appear-support)))
 
 (defun org/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes org-mode))


### PR DESCRIPTION
Since org-appear is [on melpa](https://melpa.org/#/org-appear), it should be preferred. 
