### PR TITLE
[java] only download meghanada package if needed

### DIFF
--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -19,7 +19,7 @@
     helm-gtags
     (java-mode :location built-in)
     maven-test-mode
-    (meghanada :toggle (not (version< emacs-version "25.1")))
+    (meghanada :toggle (eq (spacemacs//java-backend) 'meghanada))
     mvn
     (lsp-java :requires lsp-mode)
     org
@@ -85,7 +85,6 @@
 (defun java/init-meghanada ()
   (use-package meghanada
     :defer t
-    :if (eq java-backend 'meghanada)
     :init
     (progn
       (setq meghanada-server-install-dir (concat spacemacs-cache-directory


### PR DESCRIPTION
currently toggle `:if` for meghanada with `use-package` only tells `use-package`
not to load `meghanada` but spacemacs still downloads `meghanada`.

also we shouldn't care about emacs 25 anymore.

