### PR TITLE
In SPC h d P, print :toggle expression using Elisp syntax

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -993,7 +993,7 @@ a new object."
         (princ (if (cfgl-package-toggled-p pkg t) "on" "off"))
         (princ " because the following expression evaluates to ")
         (princ (if (cfgl-package-toggled-p pkg t) "t:\n" "nil:\n"))
-        (princ (oref pkg :toggle))
+        (prin1 (oref pkg :toggle))
         (princ "\n"))
       (when (oref pkg :requires)
         (princ "\nThis package requires the following packages: ")


### PR DESCRIPTION
This prints out an expression in valid Lisp syntax, so that, e.g.,
strings in the expression are quoted.

For example, I had the following in `dotspacemacs-additional-packages`:

```
(direnv :toggle (executable-find "direnv"))
```

Without this patch, the `:toggle` expression is printed as `(executable-find direnv)`, which looks like it is reading a variable called `direnv`.