### PR TITLE
[org] add keybinding for org-copy-tree as with org-cut-tree

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2816,6 +2816,7 @@ files (thanks to Daniel Nicolai)
   - Added package =org-appear= (thanks to winsphinX)
   - Added package =org-wild-notifier= (thanks to Daniel Nicolai)
 - Key bindings:
+  - ~SPC m s y~ for =org-copy-subtree= (thanks to Keith Pinson)
   - ~SPC m T i~ to toggle inline images
   - Move clock related key bindings to ~SPC a o C~
   - Key bindings (thanks to darkfeline and Langston Barrett):

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -631,6 +631,7 @@ are also available.
 | ~SPC m s A~   | Archive subtree                 |
 | ~SPC m s b~   | org-tree-to-indirect-buffer     |
 | ~SPC m s d~   | org-cut-subtree                 |
+| ~SPC m s y~   | org-copy-subtree                |
 | ~SPC m s l~   | org-demote-subtree              |
 | ~SPC m s h~   | org-promote-subtree             |
 | ~SPC m s k~   | org-move-subtree-up             |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -263,6 +263,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "sA" 'org-archive-subtree-default
         "sb" 'org-tree-to-indirect-buffer
         "sd" 'org-cut-subtree
+        "sy" 'org-copy-subtree
         "sh" 'org-promote-subtree
         "sj" 'org-move-subtree-down
         "sk" 'org-move-subtree-up


### PR DESCRIPTION
Used `y` as a mnemonic for yank (in the Vim, not the Emacs, sense).
