### PR TITLE
Fix void variable `mu4e-view-mode-map`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2731,6 +2731,7 @@ files (thanks to Daniel Nicolai)
 - Kill mu4e layout on app exit (thanks to Ag Ibragimov)
 - Restore ~gu~ binding for ~mu4e-view-go-to-url~ (thanks to Dominik Schrempf)
 - Updated assigned purpose names
+- Fixed void variable =mu4e-view-mode-map=
 **** Multiple Cursors
 - Disabled Spacemacs paste transient state when pasting to avoid pasting issue
   when there are more than one cursor (thanks to braham-snyder)

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -78,6 +78,7 @@
       (evilified-state-evilify-map
         mu4e-view-mode-map
         :mode mu4e-view-mode
+        :eval-after-load t
         :bindings
         (kbd "C-j") 'mu4e-view-headers-next
         (kbd "C-k") 'mu4e-view-headers-prev


### PR DESCRIPTION
Fixed, the following error, void variable `mu4e-view-mode-map`.

`Error (use-package): mu4e/:config: Symbol’s value as variable is void: mu4e-view-mode-map`
