### PR TITLE
Enhance shell-default-position validation spec

### DIFF
--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -27,7 +27,7 @@
 (spacemacs|defc shell-default-position 'bottom
   "Position of the shell. Possible values are `top', `bottom', `full',
   `left' and `right'."
-  '(choice (const bottom) (const full) (const top)))
+  '(choice (const top) (const bottom) (const full) (const left) (const right)))
 
 (spacemacs|defc shell-default-height 30
   "Height in percents for the shell window."


### PR DESCRIPTION
to match values listed in it's documentation.

I prefer to have my eshell opened to the right of my current window, but it does not seem to be allowed by [recently introduced validation rule](https://github.com/syl20bnr/spacemacs/commit/369cf7519f0bdf90d9e4285d4114b0cd42a49a33). 

@JAremko have you intentionally omitted `(const left)`  and `(const right)` values there (are those values deprecated)? I suppose that it's just an oversight there, so I bothered to create this PR.