### PR TITLE
Fix .spacemacs validation choices

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -265,7 +265,7 @@ can be a symbol or a list with additional properties like '(all-the-icons
 (spacemacs|defc dotspacemacs-frame-title-format "%I@%S"
   "Default format string for a frame title bar, using the
 original format spec, and additional customizations."
-  'string
+  '(choice (const nil) string)
   'spacemacs-dotspacemacs-init)
 
 (spacemacs|defc dotspacemacs-icon-title-format nil
@@ -292,7 +292,7 @@ original format spec, and additional customizations."
 (spacemacs|defc dotspacemacs-major-mode-leader-key ","
   "Major mode leader key is a shortcut key which is the equivalent of
 pressing `<leader> m`. Set it to `nil` to disable it."
-  'string
+  '(choice (const nil) string)
   'spacemacs-dotspacemacs-init)
 
 (spacemacs|defc dotspacemacs-major-mode-emacs-leader-key

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -264,7 +264,11 @@ can be a symbol or a list with additional properties like '(all-the-icons
 
 (spacemacs|defc dotspacemacs-frame-title-format "%I@%S"
   "Default format string for a frame title bar, using the
-original format spec, and additional customizations."
+original format spec, and additional customizations.
+
+If nil then Spacemacs uses default `frame-title-format' instead of
+calculating the frame title by `spacemacs/title-prepare' all the time.
+This can help to avoid performance issues."
   '(choice (const nil) string)
   'spacemacs-dotspacemacs-init)
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -450,6 +450,9 @@ It should only modify the values of Spacemacs settings."
    ;; %n - Narrow if appropriate
    ;; %z - mnemonics of buffer, terminal, and keyboard coding systems
    ;; %Z - like %z, but including the end-of-line format
+   ;; If nil then Spacemacs uses default `frame-title-format' to avoid
+   ;; performance issues, instead of calculating the frame title by
+   ;; `spacemacs/title-prepare' all the time.
    ;; (default "%I@%S")
    dotspacemacs-frame-title-format "%I@%S"
 


### PR DESCRIPTION
Add choices for variables that are allowed to be nil