### PR TITLE
[Fix] `dotspacemacs/test-dotfile` complains error on new custom vars

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -1078,7 +1078,11 @@ error recovery."
 (defmacro dotspacemacs||let-init-test (&rest body)
   "Macro to protect dotspacemacs variables"
   `(let ((fpath dotspacemacs-filepath)
-         ,@(dotspacemacs/get-variable-list)
+         ,@(mapcar (lambda (symbol)
+                     `(,symbol ,(let ((v (symbol-value symbol)))
+                                  (if (or (symbolp v) (listp v))
+                                      `',v v))))
+                   (dotspacemacs/get-variable-list))
          (passed-tests 0) (total-tests 0))
      (setq dotspacemacs-filepath fpath)
      (load dotspacemacs-filepath)


### PR DESCRIPTION
After new custom `dotspacemacs-*` variables being introduced in `core/core-dotspacemacs.el`, if one has an old `.spacemacs` without these variables set, `SPC f e R` will complain error messages like
```
Variable: "dotspacemacs-emacs-dumper-dump-file" has value: "nil" that doesn't match its type: "string"...
```
even if these variables have already had initial values.

This is because `dotspacemacs||let-init-test` macro only locally declares these variables without setting them with their current values.

This pull request fixes this issue by expanding `(dotspacemacs/get-variable-list)` into `'((var1 value1) (var2 value2) ...)` list instead of `(var1 var2 ...)`.