### PR TITLE
Add keybind to reload Rust-Analyzer workspace

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3299,6 +3299,7 @@ files (thanks to Daniel Nicolai)
   - Modified ~SPC m c X~ for =cargo run --bin= command, instead of
     =cargo run --example= (thanks to Lucius Hu)
   - Added ~SPC m c E~ for =cargo run --example= (thanks to Lucius Hu)
+  - Added ~SPC m b R~ to reload Rust-Analyzer workspace
 - Added rust lsp completion with company and bindings (thanks to Justin)
 - Added debugger integration via =dap= layer
 - Fixed rust dap integration (thanks to Tommi Komulainen)

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -131,6 +131,7 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | Key binding | Description                                                 |
 |-------------+-------------------------------------------------------------|
 | ~SPC m = =~ | reformat the buffer                                         |
+| ~SPC m b R~ | reload Rust-Analyzer workspace                              |
 | ~SPC m c .~ | repeat the last Cargo command                               |
 | ~SPC m c a~ | add a new dependency with cargo-edit                        |
 | ~SPC m c A~ | audit dependencies for known vulnerability with cargo-audit |

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -62,9 +62,9 @@
         (mapcar 'lsp--client-server-id)
         (member 'rust-analyzer))
       (progn
-       (lsp-rust-analyzer-reload-workspace)
-       (message "Reloaded Rust-Analyzer workspace"))
-    (message "Can only reload Rust-Analyzer workspaces, consider restarting workspace instead")))
+        (lsp-rust-analyzer-reload-workspace)
+        (message "Reloaded workspace"))
+    (message "RLS reloads automatically, and doesn't require an explicit reload")))
 
 
 ;; racer

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -47,13 +47,24 @@
         (lsp)
         (spacemacs/declare-prefix-for-mode 'rust-mode "ms" "switch")
         (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-          "bR" 'lsp-rust-analyzer-reload-workspace
+          "bR" 'spacemacs//lsp-rust-analyzer-reload-workspace
           "ss" 'lsp-rust-switch-server))
     (spacemacs//lsp-layer-not-installed-message)))
 
 (defun spacemacs//rust-setup-lsp-dap ()
   "Setup DAP integration."
   (require 'dap-gdb-lldb))
+
+(defun spacemacs//lsp-rust-analyzer-reload-workspace ()
+  (interactive)
+  (if (->> (lsp-workspaces)
+        (mapcar 'lsp--workspace-client)
+        (mapcar 'lsp--client-server-id)
+        (member 'rust-analyzer))
+      (progn
+       (lsp-rust-analyzer-reload-workspace)
+       (message "Reloaded Rust-Analyzer workspace"))
+    (message "Can only reload Rust-Analyzer workspaces, consider restarting workspace instead")))
 
 
 ;; racer

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -47,6 +47,7 @@
         (lsp)
         (spacemacs/declare-prefix-for-mode 'rust-mode "ms" "switch")
         (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+          "bR" 'lsp-rust-analyzer-reload-workspace
           "ss" 'lsp-rust-switch-server))
     (spacemacs//lsp-layer-not-installed-message)))
 


### PR DESCRIPTION
Allows you to pick up new Cargo dependencies without a (slooow) full server restart.

~Should not be merged before https://github.com/emacs-lsp/lsp-mode/pull/2728 is.~