### PR TITLE
Minibuffer bind C-n C-p to <next>/<previous>-line-or-history-element

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -114,6 +114,10 @@
 (define-key minibuffer-local-must-match-map (kbd "<escape>") 'keyboard-escape-quit)
 (define-key minibuffer-local-isearch-map (kbd "<escape>") 'keyboard-escape-quit)
 
+;; Also bind C-n C-p in minibuffer
+(define-key minibuffer-local-map (kbd "C-n") 'next-line-or-history-element)
+(define-key minibuffer-local-map (kbd "C-p") 'previous-line-or-history-element)
+
 ;; linum margin bindings-------------------------------------------------------
 (global-set-key (kbd "<left-margin> <down-mouse-1>") 'spacemacs/md-select-linum)
 (global-set-key (kbd "<left-margin> <mouse-1>") 'spacemacs/mu-select-linum)


### PR DESCRIPTION
Currently `C-n` `C-p` are bound to `next-line` and `previous-line` in `minibuffer-local-map`. This PR binds them to `next-line-or-history-element` and `previous-line-or-history-element`. This may be handy when using `M-:` to call `eval-expression`.