### PR TITLE
fixup! Validate .spacemacs variables.

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -171,7 +171,7 @@ a layer lazily."
 wrapped in a layer. If you need some configuration for these
 packages then consider to create a layer, you can also put the
 configuration in `dotspacemacs/user-config'."
-  '(repeat symbol)
+  '(repeat (choice symbol (cons symbol sexp)))
   'spacemacs-dotspacemacs-layers)
 
 (defvar dotspacemacs--additional-theme-packages '()


### PR DESCRIPTION
This PR simple makes the type of `dotspacemacs-additional-packages` same as `dotspacemacs-configuration-layers`'s.

fixes #14535 #14537 #14529 https://github.com/syl20bnr/spacemacs/issues/10638#issuecomment-803247326
