### PR TITLE
rust and lsp: better integration of lsp-rust-analyzer-reload-workspace

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -15,13 +15,15 @@
       - [[#switch-to-another-lsp-server][Switch to another LSP server]]
       - [[#autocompletion][Autocompletion]]
       - [[#debugger-dap-integration][Debugger (dap integration)]]
+      - [[#automatically-reload-workspace][Automatically Reload Workspace]]
   - [[#cargo][Cargo]]
     - [[#cargo-edit][cargo-edit]]
     - [[#cargo-audit][cargo-audit]]
+    - [[#cargo-outdated][cargo-outdated]]
   - [[#rustfmt][Rustfmt]]
   - [[#clippy][Clippy]]
 - [[#key-bindings][Key bindings]]
-  - [[#debugger][debugger]]
+  - [[#debugger][Debugger]]
 
 * Description
 This layer supports [[https://www.rust-lang.org][Rust]] development in Spacemacs.
@@ -77,7 +79,8 @@ The default LSP server for Rust is [[https://github.com/rust-lang/rls][rls]], i.
 To choose the experimental [[https://github.com/rust-analyzer/rust-analyzer][rust-analyzer]], you need to set the layer variable =lsp-rust-server= of =lsp= layer:
 
 #+BEGIN_SRC elisp
-  (lsp :variables lsp-rust-server 'rust-analyzer)
+  (setq-default dotspacemacs-configuration-layers
+                 '(lsp :variables lsp-rust-server 'rust-analyzer))
 #+END_SRC
 
 **** Switch to another LSP server
@@ -90,6 +93,22 @@ By default, currently [[https://github.com/phildawes/racer][Racer]] is the only 
 
 **** Debugger (dap integration)
 To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are on Linux or download it manually from [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][Native Debug]] and adjust =dap-gdb-lldb-path=.
+
+**** Automatically Reload Workspace
+When the LSP server is =rust-analyzer=, it may needs to reload the workspace to pickup changes made in =Cargo.toml=.
+You can call =spacemacs/lsp-rust-analyzer-reload-workspace=, which would be faster than restarting the LSP backend.
+
+You can also set =cargo-process-reload-on-modify= to =t=, then it will automatically reload the workspace after
+one of the following is run:
+- =cargo-process-add=
+- =cargo-process-rm=
+- =cargo-process-upgrade=
+
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers
+                 '(lsp :variables lsp-rust-server 'rust-analyzer
+                                  cargo-process-reload-on-modify t))
+#+END_SRC
 
 ** Cargo
 [[http://doc.crates.io/index.html][Cargo]] is a project management command line tool for Rust. Installation
@@ -107,6 +126,13 @@ instructions can be found on the main page of [[http://doc.crates.io/index.html]
 
 #+BEGIN_SRC sh
   cargo install cargo-audit
+#+END_SRC
+
+*** cargo-outdated
+[[https://github.com/kbknapp/cargo-outdated][cargo-outdated]] displays dependencies that have new version available.
+
+#+BEGIN_SRC sh
+  cargo install cargo-outdated
 #+END_SRC
 
 ** Rustfmt
@@ -132,32 +158,33 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | ~SPC m = =~ | reformat the buffer                                         |
 | ~SPC m b R~ | reload Rust-Analyzer workspace                              |
 | ~SPC m c .~ | repeat the last Cargo command                               |
+| ~SPC m c /~ | search for packages on crates.io with Cargo                 |
+| ~SPC m c =~ | format all project files with rustfmt                       |
 | ~SPC m c a~ | add a new dependency with cargo-edit                        |
 | ~SPC m c A~ | audit dependencies for known vulnerability with cargo-audit |
-| ~SPC m c C~ | remove build artifacts                                      |
 | ~SPC m c c~ | compile project                                             |
-| ~SPC m c D~ | generate documentation and open it in default browser       |
+| ~SPC m c C~ | remove build artifacts                                      |
 | ~SPC m c d~ | generate documentation                                      |
-| ~SPC m c E~ | run a project example                                       |
+| ~SPC m c D~ | generate documentation and open it in default browser       |
 | ~SPC m c e~ | run benchmarks                                              |
-| ~SPC m c f~ | format all project files with rustfmt                       |
+| ~SPC m c E~ | run a project example                                       |
 | ~SPC m c i~ | initialise a new project with Cargo (init)                  |
 | ~SPC m c l~ | run linter ([[https://github.com/arcnmx/cargo-clippy][cargo-clippy]])                                   |
 | ~SPC m c n~ | create a new project with Cargo (new)                       |
-| ~SPC m c o~ | run all tests in current file with Cargo                    |
+| ~SPC m c o~ | display outdated dependencies ([[https://github.com/kbknapp/cargo-outdated][cargo-outdated]])              |
 | ~SPC m c r~ | remove a dependency with cargo-edit                         |
-| ~SPC m c s~ | search for packages on crates.io with Cargo                 |
-| ~SPC m c t~ | run the current test with Cargo                             |
 | ~SPC m c u~ | update dependencies with Cargo                              |
 | ~SPC m c U~ | upgrade dependencies to LATEST version with cargo-edit      |
 | ~SPC m c v~ | check (verify) a project with Cargo                         |
-| ~SPC m c X~ | execute a specific binary                                   |
 | ~SPC m c x~ | execute the default binary                                  |
+| ~SPC m c X~ | execute a specific binary                                   |
 | ~SPC m g g~ | jump to definition                                          |
 | ~SPC m h h~ | describe symbol at point                                    |
 | ~SPC m s s~ | switch to other LSP server backend                          |
-| ~SPC m t~   | run tests with Cargo                                        |
+| ~SPC m t a~ | test current project                                        |
+| ~SPC m t t~ | run the current test                                        |
+| ~SPC m t b~ | run all tests in current buffe                              |
 
-** debugger
+** Debugger
 Using the =dap= layer you'll get access to all the DAP key bindings, see the
 complete list of key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/dap#key-bindings][dap layer description]].

--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -17,3 +17,6 @@
   "The backend to use for completion.
 Possible values are `lsp' `racer'.
 If `nil' then `racer' is the default backend unless `lsp' layer is used.")
+
+(defvar cargo-process-reload-on-modify nil
+  "When non-nil, reload workspace after a cargo-process command modifies Cargo.toml.")

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -40,37 +40,73 @@
   (message (concat "`lsp' layer is not installed, "
                    "please add `lsp' layer to your dotfile.")))
 
-(defun spacemacs//lsp-rust-switch-server ()
+(defun spacemacs/lsp-rust-switch-server ()
   "Switch between rust-analyzer and rls."
   (interactive)
   (lsp-rust-switch-server)
   (call-interactively 'lsp-workspace-restart))
 
 (defun spacemacs//rust-setup-lsp ()
-  "Setup lsp backend"
+  "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (lsp)
         (spacemacs/declare-prefix-for-mode 'rust-mode "ms" "switch")
         (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-          "ss" 'spacemacs//lsp-rust-switch-server
-          "bR" 'spacemacs//lsp-rust-analyzer-reload-workspace))
+          "ss" 'spacemacs/lsp-rust-switch-server
+          "bR" 'spacemacs/lsp-rust-analyzer-reload-workspace))
     (spacemacs//lsp-layer-not-installed-message)))
 
 (defun spacemacs//rust-setup-lsp-dap ()
   "Setup DAP integration."
   (require 'dap-gdb-lldb))
 
-(defun spacemacs//lsp-rust-analyzer-reload-workspace ()
+(defun spacemacs/lsp-rust-analyzer-reload-workspace ()
+  "Reload workspaces to pick up changes in Cargo.toml.
+Only applies to rust-analyzer, since rls automatically picks up changes already."
   (interactive)
-  (if (->> (lsp-workspaces)
-        (mapcar 'lsp--workspace-client)
-        (mapcar 'lsp--client-server-id)
-        (member 'rust-analyzer))
+  (if (member 'rust-analyzer (spacemacs//lsp-client-server-id))
       (progn
         (lsp-rust-analyzer-reload-workspace)
         (message "Reloaded workspace"))
     (message "RLS reloads automatically, and doesn't require an explicit reload")))
+
+(when (configuration-layer/package-used-p 'cargo)
+  (defun spacemacs//cargo-maybe-reload ()
+    "Reload the workspace conditionally.
+When one of the following is true, it won't reload:
+- Backend is not rust-analyzer.
+- `cargo-process-reload-on-modify' is nil."
+    (when (and cargo-process-reload-on-modify
+               (eq rust-backend 'lsp)
+               (member 'rust-analyzer (spacemacs//lsp-client-server-id)))
+       (lsp-rust-analyzer-reload-workspace)))
+
+  (defun spacemacs/cargo-process-repeat ()
+    "Run last cargo process command, and conditionally reload the workspace."
+    (interactive)
+    (call-interactively 'cargo-process-repeat)
+    (when (member (car cargo-process-last-command)
+                  '("Add" "Remove" "Upgrade"))
+      (spacemacs//cargo-maybe-reload)))
+
+  (defun spacemacs/cargo-process-add ()
+    "Run the cargo add command, and conditionally reload the workspace."
+    (interactive)
+    (call-interactively 'cargo-process-add)
+    (spacemacs//cargo-maybe-reload))
+
+  (defun spacemacs/cargo-process-rm()
+    "Run the cargo rm command, and conditionally reload the workspace."
+    (interactive)
+    (call-interactively 'cargo-process-rm)
+    (spacemacs//cargo-maybe-reload))
+
+  (defun spacemacs/cargo-process-upgrade()
+    "Run the cargo upgrade command, and conditionally reload the workspace."
+    (interactive)
+    (call-interactively 'cargo-process-upgrade)
+    (spacemacs//cargo-maybe-reload)))
 
 
 ;; racer

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -31,9 +31,12 @@
     :init
     (progn
       (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
+      (spacemacs/declare-prefix-for-mode 'rust-mode "mt" "tests")
       (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "c." 'cargo-process-repeat
-        "ca" 'cargo-process-add
+        "c." 'spacemacs/cargo-process-repeat
+        "c/" 'cargo-process-search
+        "c=" 'cargo-process-fmt
+        "ca" 'spacemacs/cargo-process-add
         "cA" 'cargo-process-audit
         "cc" 'cargo-process-build
         "cC" 'cargo-process-clean
@@ -41,20 +44,19 @@
         "cD" 'cargo-process-doc-open
         "ce" 'cargo-process-bench
         "cE" 'cargo-process-run-example
-        "cf" 'cargo-process-fmt
         "ci" 'cargo-process-init
         "cl" 'cargo-process-clippy
         "cn" 'cargo-process-new
-        "co" 'cargo-process-current-file-tests
-        "cr" 'cargo-process-rm
-        "cs" 'cargo-process-search
-        "ct" 'cargo-process-current-test
+        "co" 'cargo-process-outdated
+        "cr" 'spacemacs/cargo-process-rm
         "cu" 'cargo-process-update
-        "cU" 'cargo-process-upgrade
+        "cU" 'spacemacs/cargo-process-upgrade
+        "cv" 'cargo-process-check
         "cx" 'cargo-process-run
         "cX" 'cargo-process-run-bin
-        "cv" 'cargo-process-check
-        "t" 'cargo-process-test))))
+        "ta" 'cargo-process-test
+        "tt" 'cargo-process-current-test
+        "tb" 'cargo-process-current-file-tests))))
 
 (defun rust/post-init-company ()
   ;; backend specific

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -263,6 +263,10 @@ EXTRA is an additional parameter that's passed to the LSP function"
   (interactive)
   (message "Not supported yet... (to be implemented in 'lsp-mode')"))
 
+(defun spacemacs//lsp-client-server-id ()
+  "Return the ID of the LSP server associated with current project."
+  (mapcar 'lsp--client-server-id (mapcar 'lsp--workspace-client (lsp-workspaces))))
+
 
 ;; ivy integration
 


### PR DESCRIPTION
- Introduced a new command cargo-process-outdated
- Certain commands are known to change Cargo.toml and needs to reload workspace,
  wrapper functions that automatically reload workspace are added.
  - spacemacs/cargo-process-add
  - spacemacs/cargo-process-rm
  - spacemacs/cargo-process-outdated
- Added a layer variable for rust layer, cargo-process-reload-on-modify,
  which toggle the aforementioned behaviour.
- Added a new utility function in LSP layer, which returns server ID associated
  with current project.
  - spacemacs//lsp-client-server-id
- Rearranged keybindings for rust layers (see table below for details)

Commands wrapped with auto-reload functionality:

|Command                  |Binding      |
|-------------------------|-------------|
|`cargo-process-repeat`   |`SPC m c .`  |
|`cargo-process-add`      |`SPC m c a`  |
|`cargo-process-rm`       |`SPC m c r`  |
|`cargo-process-upgrade`  |`SPC m c U`  |

Commands with new bindings:

|Command                            |Old Binding |New Binding |
|-----------------------------------|------------|------------|
|`cargo-process-search`             |`SPC m c s` |`SPC m c /` |
|`cargo-process-fmt`                |`SPC m c f` |`SPC m c =` |
|`cargo-process-current-file-tests` |`SPC m c o` |`SPC m t b` |
|`cargo-process-current-test`       |`SPC m c t` |`SPC m t t` |
|`cargo-process-test`               |`SPC m t`   |`SPC m t a` |