### PR TITLE
python: fix pylookup location

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -325,10 +325,7 @@
         "hH" 'pylookup-lookup))
     :config
     (progn
-      (let ((dir (configuration-layer/get-layer-local-dir 'python)))
-        (setq pylookup-dir (concat dir "pylookup/")
-              pylookup-program (concat pylookup-dir "pylookup.py")
-              pylookup-db-file (concat pylookup-dir "pylookup.db")))
+      (setq pylookup-db-file (concat pylookup-root "pylookup.db"))
       (setq pylookup-completing-read 'completing-read))))
 
 (defun python/init-pytest ()


### PR DESCRIPTION
- `pylookup-program` defaults to the correct path so it doesn't needs to be set.
- Set `pylookup-db-file` to the correct value.

closes https://github.com/syl20bnr/spacemacs/issues/14544
