### PR TITLE
[dotfile] New var: dotspacemacs-startup-buffer-multi-digit-delay

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -499,6 +499,7 @@ In org-agenda-mode
   - New variable =dotspacemacs-read-process-output-max= to optimise lsp
     performance in emacs 27 (thanks to Maximilian Wolff)
   - New variable =dotspacemacs-show-trailing-whitespace= (thanks to duianto)
+  - New var =dotspacemacs-startup-buffer-multi-digit-delay= (thanks to duianto)
 - Removed Variables:
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -611,6 +611,11 @@ number of recent files to show in each project."
   'boolean
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-startup-buffer-multi-digit-delay 0.4
+  "The minimum delay in seconds between number key presses."
+  'number
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-excluded-packages '()
   "A list of packages that will not be installed and loaded."
   '(repeat symbol)

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1140,10 +1140,6 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
       (search-forward "[")
       (left-char 2))))
 
-(defvar spacemacs-buffer-multi-digit-delay 0.4
-  "This determines how quickly (in seconds)
-the numbers have to be typed.")
-
 (defvar spacemacs-buffer--idle-numbers-timer nil
   "This stores the idle numbers timer.")
 
@@ -1154,9 +1150,9 @@ It's cleared when the idle timer runs.")
 (defun spacemacs-buffer/jump-to-number-startup-list-line ()
   "Jump to the startup list line with the typed number.
 
-The delay between the number key presses,
-can be adjusted (in seconds) with the variable:
-`spacemacs-buffer-multi-digit-delay'."
+The minimum delay in seconds between number key presses,
+can be adjusted with the variable:
+`dotspacemacs-startup-buffer-multi-digit-delay'."
   (interactive)
   (when spacemacs-buffer--idle-numbers-timer
     (cancel-timer spacemacs-buffer--idle-numbers-timer))
@@ -1167,7 +1163,7 @@ can be adjusted (in seconds) with the variable:
       (message "Jump to startup list: %s" spacemacs-buffer--startup-list-number))
     (setq spacemacs-buffer--idle-numbers-timer
           (run-with-idle-timer
-           spacemacs-buffer-multi-digit-delay nil
+           dotspacemacs-startup-buffer-multi-digit-delay nil
            'spacemacs-buffer/stop-waiting-for-additional-numbers))))
 
 (defun spacemacs-buffer//re-line-starts-with-nr-space (nr-string)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -192,6 +192,9 @@ It should only modify the values of Spacemacs settings."
    ;; True if the home buffer should respond to resize events. (default t)
    dotspacemacs-startup-buffer-responsive t
 
+   ;; The minimum delay in seconds between number key presses. (default 0.4)
+   dotspacemacs-startup-buffer-multi-digit-delay 0.4
+
    ;; Default major mode for a new empty buffer. Possible values are mode
    ;; names such as `text-mode'; and `nil' to use Fundamental mode.
    ;; (default `text-mode')


### PR DESCRIPTION
It sets the minimum delay in seconds between number key presses.
On the Spacemacs home buffer.