### PR TITLE
haskell: reworked

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -23,14 +23,46 @@
 
 ;; Variables
 
-(setq haskell-modes '(haskell-mode haskell-literate-mode))
+(defconst spacemacs--haskell-modes '(haskell-mode haskell-literate-mode))
 
 (spacemacs|define-jump-handlers haskell-mode haskell-mode-jump-to-def-or-tag)
+(spacemacs|define-jump-handlers haskell-literate-mode haskell-mode-jump-to-def-or-tag)
 
 (defvar haskell-completion-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'dante)
   "Completion backend used by company.
 Available options are `dante' and `lsp'.
-If `nil' then `dante' is the default backend unless `lsp' layer is used.")
+If nil then `dante' is the default backend unless `lsp' layer is used.")
 
+;; TODO: verify whether `stylish-haskell' breaks flycheck highlighting
+;; reported by taksuyu 2015-10-06
+(defvar haskell-formatter-backend (cond
+                                   (haskell-enable-hindent 'hindent)
+                                   ((executable-find "brittany") 'brittany)
+                                   ((executable-find "ormolu") 'ormolu)
+                                   ((and (executable-find "fourmolu")
+                                         (eq haskell-completion-backend 'lsp))
+                                    'fourmolu)
+                                   ((and (executable-find "floskell")
+                                         (eq haskell-completion-backend 'lsp))
+                                    'floskell))
+  "Formatter backend for `haskell-mode' and `haskell-literate-mode'.
+Valid values are: `brittany', `hindent', `ormolu', `stylish-haskell',
+`fourmolu', `floskell' and nil. `fourmolu' and `floskell' are valid only when
+`haskell-completion-backend' is `lsp'.
+For backward compatibility, defaults to `hindent' when `haskell-enable-hindent'
+is set.
+Otherwise, use the first formatter found in `brittany', `ormolu', `fourmolu' and
+and `floskell'.
+`stylish-haskell' is never used as default due to past report of issues.")
+
+(defvar haskell-enable-cmm-mode nil
+  "When non-nil, enable cmm-mode for C-- language.")
+
+(defvar haskell-enable-hlint t
+  "When non-nil, enable hlint integration.
+When `haskell-completion-backend' is `lsp', use its builtin support.
+When it's `dante', use `hlint-refactor-mode'.")
+
+;; This should be deprecated at some point, use haskell-formatter-backend instead
 (defvar haskell-enable-hindent nil
-  "Formatting with hindent; If t hindent is enabled.")
+  "When non-nil, use hindent as formatter.")

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -32,6 +32,7 @@
 
 (defun spacemacs-haskell//setup-company ()
   "Conditionally setup haskell completion backend."
+  ;; nothing to do for lsp-mode, auto-configured to `company-capf`
   (when (eq haskell-completion-backend 'dante)
     (spacemacs-haskell//setup-dante-company)))
 
@@ -39,7 +40,7 @@
 ;; LSP functions
 
 (defun spacemacs-haskell//setup-lsp ()
-  "Setup lsp backend"
+  "Setup LSP backend."
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         ;; The functionality we require from this is not an autoload, but rather some
@@ -59,17 +60,38 @@
 (defun spacemacs-haskell//setup-dante-company ()
   (spacemacs|add-company-backends
     :backends (dante-company company-dabbrev-code company-yasnippet)
-    :modes haskell-mode))
+    :modes haskell-mode haskell-literate-mode))
 
-(defun spacemacs-haskell//dante-insert-type ()
+(defun spacemacs-haskell/dante-insert-type ()
+  "Insert the type of current selection or symbol at point in current buffer."
   (interactive)
   (dante-type-at :insert))
 
 
+;; commands
+(defun spacemacs/haskell-interactive-bring ()
+  "Bring up the interactive mode for this session without switching to it."
+  (interactive)
+  (let* ((session (haskell-session))
+         (buffer (haskell-session-interactive-buffer session)))
+    (display-buffer buffer)))
+
+(defun spacemacs/haskell-process-do-type-on-prev-line ()
+  "Print the type of the expression on previous line.."
+  (interactive)
+  (haskell-process-do-type 1))
+
+
 ;; misc
 
-(defun spacemacs-haskell//disable-electric-indent ()
-  "Disable electric indent mode if available"
+;; NOTE: when cheaper reloading function is available (like rust-analyzer's), use that instead
+(defun spacemacs//force-haskell-mode-loading ()
+  "Force `haskell-mode' loading when visiting cabal file."
+  (require 'haskell-mode))
+
+(defun spacemacs//haskell-disable-electric-indent ()
+  "Disable electric indent mode if available."
+  ;; Haskell cabal files interact badly with electric-indent-mode
   ;; use only internal indentation system from haskell
   (if (fboundp 'electric-indent-local-mode)
       (electric-indent-local-mode -1)))


### PR DESCRIPTION
- Improved formatting capability via `format-all` and/or `lsp`.
  - Supported backends are:
    - `brittany`
    - `hindent`
    - `ormolu`
    - `stylish-haskell`
    - `fourmolu` (only work with `lsp`)
    - `floskell` (only work with `lsp`)
  - Added new layer variable `haskell-formatter-backend`.
  - The old layer variable `haskell-enable-hindent` is superseded, but for backward compatibility, if `haskell-formatter-backend` is not set explicitly, it defaults to `hindent` should `haskell-enable-hindent` is non-nil.
  - Also, the package `hindent` is superseded by `format-all`.
  - When `lsp` layer is enabled, the chosen formattr backend is also registered with `lsp`.
- Added new layer variable `haskell-enable-cmm-mode` and `haskell-enable-hlint`
  - Both integrations are available for a long time, and this PR just make them optional.
- Improved support for `haskell-literate-mode`
  - When using `dante`, company backend is enabled.
  - `gtags` integration is added (via `helm-gtags` and ``counsel-gtags` respectively).
  - `yasnippet` integration.
  - The obsolete name `literate-haskell-mode` is removed.
- Updated `yasnippet` initialization:
  - The old way of loading `yasnippet` is still valid, but this PR simplifies it by calling the the functions in upstream package.
- Fixed key-binding problems:
  - Many bindings are missing due to wrong settings in `prefix`. This PR fixed them. Prefixes should work with both `lsp` and `dante`.
- Moved `defun` forms in `packages.el` to `funcs.el`
- Other minor modifications in style.