### PR TITLE
Update README.md with new Cask syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ the default Source Code Pro font:
 
 ```sh
 brew tap homebrew/cask-fonts
+brew install --cask font-source-code-pro
+```
+
+or in older versions of homebrew
+
+```
+brew tap homebrew/cask-fonts
 brew cask install font-source-code-pro
 ```
 


### PR DESCRIPTION
### Context

I was following the instructions of the README.md for macOS, then while following the [Install Source Code Pro font](https://github.com/syl20bnr/spacemacs/blob/develop/README.md#install-source-code-pro-font) step, I noticed that it was not with the new syntax for cask.

### What changed?

This PR changes the [Install Source Code Pro font](https://github.com/syl20bnr/spacemacs/blob/develop/README.md#install-source-code-pro-font) section with the same disclaimer used in [Emacs installation section](https://github.com/syl20bnr/spacemacs/blob/develop/README.md#using-cask).