### PR TITLE
[+layer/c-c++] fix #14579, respect the `c-c++-enable-rtags-completion` setting

### DIFF
--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -232,12 +232,13 @@
 
 (defun spacemacs//c-c++-setup-rtags-company ()
   "Setup rtags auto-completion."
-  (setq rtags-completions-enabled t)
-  (spacemacs|add-company-backends
-    :backends company-rtags
-    :modes c-mode-common
-    :append-hooks nil
-    :call-hooks t))
+  (when c-c++-enable-rtags-completion
+    (setq rtags-completions-enabled t)
+    (spacemacs|add-company-backends
+      :backends company-rtags
+      :modes c-mode-common
+      :append-hooks nil
+      :call-hooks t)))
 
 (defun spacemacs//c-c++-setup-rtags-flycheck ()
   "Setup rtags syntax checking."


### PR DESCRIPTION
Fix #14579. The variable `c-c++-enable-rtags-completion` is for enable/disable the rtags completion.
