### PR TITLE
[+layer/php] Fix missed packages

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3055,6 +3055,7 @@ files (thanks to Daniel Nicolai)
   - Added LSP support, which can be used by enabling the =lsp= layer and setting
     the =php= layer's =php-backend= variable to =lsp=
     (thanks to Daniel Richtmann)
+  - Fix packages missed in Melpa (thanks to zebradil)
 **** PlantUML
 - Added a missing prefix: =compile= (thanks to Seong Yong-ju)
 - Added instructions for compiling the image locally by setting

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -31,10 +31,10 @@
     ggtags
     counsel-gtags
     helm-gtags
-    php-auto-yasnippets
+    (php-auto-yasnippets :location (recipe :fetcher github :repo "emacs-php/php-auto-yasnippets"))
     (php-extras :location (recipe :fetcher github :repo "arnested/php-extras") :toggle (not (eq php-backend 'lsp)))
     php-mode
-    phpcbf
+    (phpcbf :location (recipe :fetcher github :repo "nishimaki10/emacs-phpcbf"))
     phpunit
     (phpactor :toggle (not (eq php-backend 'lsp)))
     (company-phpactor :requires company :toggle (not (eq php-backend 'lsp)))


### PR DESCRIPTION
Fetch packages, which can't be found in Melpa anymore, from their GitHub repos:

- [phpcbf](https://github.com/nishimaki10/emacs-phpcbf)
- [php-auto-yasnippet](https://github.com/emacs-php/php-auto-yasnippets)

Fixes #14381
