### PR TITLE
 Fixed a bug in notmuch-tree which was preventing d/D bindings to work

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2796,6 +2796,7 @@ files (thanks to Daniel Nicolai)
   (thanks to jupl)
 - Disabled add-node-modules-path by default (thanks to Eivind Fonn)
 **** Notmuch
+- Fixed a bug in notmuch-tree which was preventing ~d~/~D~ bindings to work (thanks to Daniel Nicolai, alexey0308, inwit)
 - Try harder to find GitHub patch URL (thanks to Miciah Masters)
 - Open GitHub patches fullscreen
 - Add next and previous message bindings to notmuch-tree mode

--- a/layers/+email/notmuch/funcs.el
+++ b/layers/+email/notmuch/funcs.el
@@ -44,26 +44,43 @@
   (notmuch-search-previous-thread)
   (notmuch-search-previous-thread))
 
-(defun spacemacs//notmuch-message-delete (go-next)
+(defun spacemacs//notmuch-tree-message-delete (go-next)
+  "Delete message and select GO-NEXT message."
+  (notmuch-tree-tag notmuch-message-deleted-tags)
+  (if (eq 'up go-next)
+      (notmuch-tree-prev-thread)
+    (notmuch-tree-next-thread)))
+
+(defun spacemacs/notmuch-tree-message-delete-down ()
+  "Delete a message and select the next message."
+  (interactive)
+  (spacemacs//notmuch-tree-message-delete 'down))
+
+(defun spacemacs/notmuch-tree-message-delete-up ()
+  "Delete a message and select the previous message."
+  (interactive)
+  (spacemacs//notmuch-tree-message-delete 'up))
+
+(defun spacemacs//notmuch-search-message-delete (go-next)
   "Delete message and select GO-NEXT message."
   (notmuch-search-tag notmuch-message-deleted-tags)
   (if (eq 'up go-next)
       (notmuch-search-previous-thread)
     (notmuch-search-next-thread)))
 
+(defun spacemacs/notmuch-search-message-delete-down ()
+  "Delete a message and select the next message."
+  (interactive)
+  (spacemacs//notmuch-search-message-delete 'down))
+
+(defun spacemacs/notmuch-search-message-delete-up ()
+  "Delete a message and select the previous message."
+  (interactive)
+  (spacemacs//notmuch-search-message-delete 'up))
+
 (defun spacemacs/notmuch-show-as-patch ()
   (interactive)
   (notmuch-show-choose-mime-of-part "text/x-patch"))
-
-(defun spacemacs/notmuch-message-delete-down ()
-  "Delete a message and select the next message."
-  (interactive)
-  (spacemacs//notmuch-message-delete 'down))
-
-(defun spacemacs/notmuch-message-delete-up ()
-  "Delete a message and select the previous message."
-  (interactive)
-  (spacemacs//notmuch-message-delete 'up))
 
 (defun spacemacs/notmuch-show-close-all ()
   "Close all."

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -127,8 +127,8 @@
         :bindings
         (kbd "N") 'notmuch-tree-next-message
         (kbd "P") 'notmuch-tree-prev-message
-        (kbd "d") 'spacemacs/notmuch-message-delete-down
-        (kbd "D") 'spacemacs/notmuch-message-delete-up
+        (kbd "d") 'spacemacs/notmuch-tree-message-delete-down
+        (kbd "D") 'spacemacs/notmuch-tree-message-delete-up
         (kbd "n") 'notmuch-tree-next-matching-message
         (kbd "p") 'notmuch-tree-prev-matching-message
         (kbd "M") 'compose-mail-other-frame)
@@ -137,8 +137,8 @@
         :bindings
         (kbd "a") 'spacemacs/notmuch-search-archive-thread-down
         (kbd "A") 'spacemacs/notmuch-search-archive-thread-up
-        (kbd "d") 'spacemacs/notmuch-message-delete-down
-        (kbd "D") 'spacemacs/notmuch-message-delete-up
+        (kbd "d") 'spacemacs/notmuch-search-message-delete-down
+        (kbd "D") 'spacemacs/notmuch-search-message-delete-up
         (kbd "J") 'notmuch-jump-search
         (kbd "L") 'notmuch-search-filter
         (kbd "gg") 'notmuch-search-first-thread


### PR DESCRIPTION
The bindings `d`/`D` were not working in `notmuch-tree-mode`.

The cause is that `spacemacs/notmuch-message-delete` calls `notmuch-search-tag` and this function does not work in tree-mode. 

The solution is to duplicate `spacemacs/notmuch-message-delete` into `spacemacs/notmuch-search-message-delete` and `spacemacs/notmuch-tree-message-delete`, adapting the inner calls to the corresponding functions of each mode.