### PR TITLE
[base] Fix evil collection buff menu

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -72,7 +72,9 @@
     :eval-after-load archive-mode))
 
 (defun spacemacs-defaults/init-buffer-menu ()
-  (add-to-list 'spacemacs-evil-collection-allowed-list '(buff-menu "buff-menu")))
+  (with-eval-after-load 'evil-collection
+    (add-to-list
+     'spacemacs-evil-collection-allowed-list '(buff-menu "buff-menu"))))
 
 (defun spacemacs-defaults/init-bookmark ()
   (use-package bookmark


### PR DESCRIPTION
problem
The evil-collection is loaded in the spacemacs-evil layer.
The spacemacs-evil layer isn't enabled by default
on the spacemacs-base distribution.

solution
Add buff-menu to the list: spacemacs-evil-collection-allowed-list
after the evil-collection has loaded.