### PR TITLE
Revert "haskell: refactor"

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -27,7 +27,7 @@
 
 (spacemacs|define-jump-handlers haskell-mode haskell-mode-jump-to-def-or-tag)
 
-(defvar haskell-completion-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'dante)
+(defvar haskell-completion-backend nil
   "Completion backend used by company.
 Available options are `dante' and `lsp'.
 If `nil' then `dante' is the default backend unless `lsp' layer is used.")

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -24,16 +24,25 @@
 
 ;; Completion setup functions
 
+(defun spacemacs//haskell-backend ()
+  "Returns selected backend."
+  (if haskell-completion-backend
+      haskell-completion-backend
+    (cond
+     ((configuration-layer/layer-used-p 'lsp) 'lsp)
+     (t 'dante))))
+
 (defun spacemacs-haskell//setup-backend ()
   "Conditionally setup haskell backend."
-  (pcase haskell-backend
-    ('lsp (spacemacs-haskell//setup-lsp))
-    ('dante (spacemacs-haskell//setup-dante))))
+  (pcase (spacemacs//haskell-backend)
+    (`lsp (spacemacs-haskell//setup-lsp))
+    (`dante (spacemacs-haskell//setup-dante))))
 
 (defun spacemacs-haskell//setup-company ()
   "Conditionally setup haskell completion backend."
-  (when (eq haskell-backend 'dante)
-    (spacemacs-haskell//setup-dante-company)))
+  (pcase (spacemacs//haskell-backend)
+    (`lsp nil) ;; nothing to do, auto-configured by lsp-mode
+    (`dante (spacemacs-haskell//setup-dante-company))))
 
 
 ;; LSP functions

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -43,7 +43,8 @@
         helm-gtags
         (helm-hoogle :requires helm)
         hindent
-        hlint-refactor))
+        hlint-refactor
+        ))
 
 (defun haskell/init-lsp-haskell ()
   (use-package lsp-haskell
@@ -97,8 +98,8 @@
   (progn
     (add-hook 'dante-mode-hook
               (lambda () (flycheck-add-next-checker 'haskell-dante '(warning . haskell-hlint))))
-    (spacemacs/enable-flycheck 'haskell-mode)))
-
+    (spacemacs/enable-flycheck 'haskell-mode))
+  )
 
 (defun haskell/init-flycheck-haskell ()
   (use-package flycheck-haskell
@@ -215,7 +216,7 @@
           "dt"  'haskell-debug/trace
 
           "ri"  'spacemacs/haskell-format-imports)
-        (if (eq haskell-backend 'lsp)
+        (if (eq (spacemacs//haskell-backend) 'lsp)
             (spacemacs/set-leader-keys-for-major-mode mode
               "gl"  'haskell-navigate-imports
               "S"   'haskell-mode-stylish-buffer


### PR DESCRIPTION
This reverts commit 2eda5371d8cf11a805c92e4ecaf92a8953e3f0bd.

It totally broke LSP usage, saying "haskell-backend" variable is void.
