### PR TITLE
fixup! latex: refactor

### DIFF
--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -24,29 +24,30 @@
 (defun spacemacs//latex-setup-company ()
   "Conditionally setup company based on backend."
   (pcase latex-backend
-    ;; Activate lsp company explicitly to activate
-    ;; standard backends as well
-    ('lsp (spacemacs|add-company-backends
-            :backends company-capf
-            :modes LaTeX-mode))
-    ('company-auctex (when (configuration-layer/package-used-p 'company-auctex)
-                       (spacemacs|add-company-backends
-                         :backends (if (configuration-layer/package-usedp 'company-math)
-                                       '(company-math-symbols-unicode
-                                         company-math-symbols-latex
-                                         (company-auctex-macros)
-                                         company-auctex-symbols
-                                         company-auctex-environments)
-                                     '(company-auctex-macros
-                                       company-auctex-symbols
-                                       company-auctex-environments))
-                         :modes LaTeX-mode))
-                     (when (configuration-layer/package-used-p 'company-reftex)
-                      (spacemacs|add-company-backends
-                        :backends
-                        company-reftex-labels
-                        company-reftex-citations
-                        :modes LaTeX-mode)))))
+    ('lsp
+     (spacemacs|add-company-backends ;; Activate lsp company explicitly to activate
+       :backends company-capf        ;; standard backends as well
+       :modes LaTeX-mode))
+    ('company-auctex
+     (when (configuration-layer/package-used-p 'company-auctex)
+       (if (configuration-layer/package-used-p 'company-math)
+           (spacemacs|add-company-backends
+             :backends company-math-symbols-unicode
+                       company-math-symbols-latex
+                       company-auctex-macros
+                       company-auctex-symbols
+                       company-auctex-environments
+             :modes LaTeX-mode)
+         (spacemacs|add-company-backends
+           :backends company-auctex-macros
+                     company-auctex-symbols
+                     company-auctex-environments
+           :modes LaTeX-mode)))
+     (when (configuration-layer/package-used-p 'company-reftex)
+      (spacemacs|add-company-backends
+        :backends company-reftex-labels
+                  company-reftex-citations
+        :modes LaTeX-mode)))))
 
 (defun spacemacs//latex-setup-backend ()
   "Conditionally setup latex backend."


### PR DESCRIPTION
spacemacs|add-company-backends is a macro, so arguments are taken as-is, instead of being evaluated.

The previous refactor would not cause error, but it would not work either.

The arguments to :backends must take the form of:

- One or multiple unquoted symbol
- A list of symbol
- Lists of symbols