### PR TITLE
fixup! lua: refactor

### DIFF
--- a/layers/+lang/lua/funcs.el
+++ b/layers/+lang/lua/funcs.el
@@ -28,11 +28,15 @@
 
 (defun spacemacs//lua-setup-company ()
   "Conditionally setup company based on backend."
-  (spacemacs|add-company-backends
-    :backends (pcase lua-backend
-                ('lua-mode 'company-lua)
-                ('lsp 'company-capf))
-    :modes lua-mode))
+  (pcase lua-backend
+    ('lua-mode
+     (spacemacs|add-company-backends
+       :backends company-lua
+       :modes lua-mode))
+    ('lsp
+     (spacemacs|add-company-backends
+       :backends company-capf
+       :modes lua-mode))))
 
 
 ;; LSP Lua


### PR DESCRIPTION
spacemacs|add-company-backends is a macro, so arguments are taken as-is, instead of being evaluated.

The previous refactor would not cause error, but it would not work either.

The arguments to :backends must take the form of:

- One or multiple unquoted symbol
- A list of symbol
- Lists of symbols