### PR TITLE
fixup! fixup! perl5: refactor

### DIFF
--- a/layers/+lang/perl5/funcs.el
+++ b/layers/+lang/perl5/funcs.el
@@ -23,13 +23,15 @@
 
 (defun spacemacs//perl5-setup-company ()
   "Conditionally setup company based on backend."
-  (spacemacs|add-company-backends
-    :backends (pcase perl5-backend
-                ;; Activate lsp company explicitly to activate
-                ;; standard backends as well
-                ('lsp 'company-capf)
-                ('company-plsense 'company-plsense))
-    :modes cperl-mode))
+  (pcase perl5-backend
+    ('lsp
+     (spacemacs|add-company-backends ;; Activate lsp company explicitly to activate
+       :backends 'company-capf       ;; standard backends as well
+       :modes cperl-mode))
+    ('company-plsense
+     (spacemacs|add-company-backends
+       :backends 'company-plsense
+       :modes cperl-mode))))
 
 (defun spacemacs//perl5-setup-backend ()
   "Conditionally setup perl5 backend."


### PR DESCRIPTION
spacemacs|add-company-backends is a macro, so arguments are taken as-is, instead of being evaluated.

The previous refactor would not cause error, but it would not work either.

The arguments to :backends must take the form of:

- One or multiple unquoted symbol
- A list of symbol
- Lists of symbols