### PR TITLE
fixup! purescript: refactor

### DIFF
--- a/layers/+lang/purescript/funcs.el
+++ b/layers/+lang/purescript/funcs.el
@@ -28,10 +28,12 @@
 
 (defun spacemacs//purescript-setup-company ()
   "Conditionally setup company based on backend."
-  (spacemacs|add-company-backends
-    :backends (pcase purescript-backend
-                ;; Activate lsp company explicitly to activate
-                ;; standard backends as well
-                ('lsp 'company-capf)
-                ('psc-ide 'company-psc-ide-backend))
-    :modes 'purescript-mode))
+  (pcase purescript-backend
+    ('lsp
+     (spacemacs|add-company-backends ;; Activate lsp company explicitly to activate
+       :backends company-capf        ;; standard backends as well
+       :modes purescript-mode))
+    ('psc-ide
+     (spacemacs|add-company-backends
+       :backends company-psc-ide-backend
+       :modes purescript-mode))))


### PR DESCRIPTION
spacemacs|add-company-backends is a macro, so arguments are taken as-is, instead of being evaluated.

The previous refactor would not cause error, but it would not work either.

The arguments to :backends must take the form of:

- One or multiple unquoted symbol
- A list of symbol
- Lists of symbols