### PR TITLE
fixup! terraform: refactor

### DIFF
--- a/layers/+tools/terraform/funcs.el
+++ b/layers/+tools/terraform/funcs.el
@@ -23,13 +23,15 @@
 
 (defun spacemacs//terraform-setup-company ()
   "Conditionally setup company based on backend."
-  (spacemacs|add-company-backends
-    :backends (pcase terraform-backend
-                ('company-terraform 'company-terraform)
-                ;; Activate lsp company explicitly to activate
-                ;; standard backends as well
-                ('lsp 'company-capf))
-    :modes terraform-mode))
+  (pcase terraform-backend
+    ('lsp
+     (spacemacs|add-company-backends ;; Activate lsp company explicitly to activate
+       :backends company-capf        ;; standard backends as well
+       :modes terraform-mode))
+    ('company-terraform
+     (spacemacs|add-company-backends
+       :backends company-terraform
+       :modes terraform-mode))))
 
 (defun spacemacs//terraform-setup-backend ()
   "Conditionally setup terraform backend."


### PR DESCRIPTION
spacemacs|add-company-backends is a macro, so arguments are taken as-is, instead of being evaluated.

The previous refactor would not cause error, but it would not work either.

The arguments to :backends must take the form of:

- One or multiple unquoted symbol
- A list of symbol
- Lists of symbols