### PR TITLE
Add support for the org-roam-server package

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -3953,6 +3953,7 @@ Improve loading robustness:
 + Fix ~SPC m l~ by calling =org-open-at-point= instead of =evil-org-open-links=
   (thanks to TheBB)
 + Fix org-repo-todo loading (thanks to TheBB)
++ Add =org-roam-server= package to visualise a =org-roam= database (thanks to KjartanOli)
 
 **** Osx
 - Re-factor and expand support for trash can (thanks to usharf)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -25,6 +25,7 @@
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
   - [[#org-roam-support][Org-roam support]]
+    - [[#org-roam-server-support][Org-roam-server support]]
   - [[#mode-line-support][Mode line support]]
   - [[#sticky-header-support][Sticky header support]]
   - [[#epub-support][Epub support]]
@@ -389,6 +390,10 @@ To install org-roam support set the variable =org-enable-roam-support= to =t=.
 
 More information about org-roam package (including manual) can be found at [[https://www.orgroam.com/][Org-roam]] website.
 
+*** Org-roam-server support
+ To install support for [[https://github.com/org-roam/org-roam-server][org-roam-server]] set the variable =org-enable-roam-server=
+ to =t=.
+ 
 ** Mode line support
 To temporarily enable mode line display of org clock, press ~SPC t m c~.
 

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -77,7 +77,7 @@ are configured.")
 (defvar org-enable-verb-support nil
   "If non-nil, Verb (https://github.com/federicotdn/verb) is configured.")
 
-(defvar org-enable-roam-support nil
+(defvar org-enable-roam-support (when org-enable-roam-server t)
   "If non-nil, org-roam (https://www.orgroam.com/) is configured")
 
 (defvar org-persp-startup-org-file nil
@@ -92,3 +92,6 @@ ATTENTION: `valign-mode' will be laggy working with tables contain more than 100
 
 (defvar org-enable-appear-support nil
   "If non-nil, enable org-appear in org-mode buffers.")
+
+(defvar org-enable-roam-server nil
+  "if non-nil, enable org-roam-server support")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -65,7 +65,8 @@
     (verb :toggle org-enable-verb-support)
     (org-roam :toggle org-enable-roam-support)
     (valign :toggle org-enable-valign)
-    (org-appear :toggle org-enable-appear-support)))
+    (org-appear :toggle org-enable-appear-support)
+    (org-roam-server :require org-roam :toggle org-enable-roam-server)))
 
 (defun org/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes org-mode))
@@ -1003,3 +1004,11 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (setq org-appear-autolinks t
             org-appear-autoemphasis t
             org-appear-autosubmarkers t))))
+
+(defun org/init-org-roam-server()
+  (use-package org-roam-server
+    :defer t
+    :init
+    (progn
+      (spacemacs/set-leader-keys "aors" 'org-roam-server-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode "rs" 'org-roam-server-mode))))


### PR DESCRIPTION
Add support for the [org-roam-server](https://github.com/org-roam/org-roam-server) package. Which provides a convinient way of visualising the org-roam database.

Currently this PR requires the user to manually enable org-roam support by setting `org-enable-roam-support`. Any suggestions on how to make that automatic are welcome.