### PR TITLE
Check package updates from Spacemacs home buffer

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2125,6 +2125,7 @@ LAYER must not be the owner of PKG."
 If called with a prefix argument or NO-CONFIRMATION is non-nil then assume yes
 to update."
   (interactive "P")
+  (switch-to-buffer spacemacs-buffer-name)
   (spacemacs-buffer/insert-page-break)
   (spacemacs-buffer/append "\nUpdating package archives, please wait...\n")
   (configuration-layer/retrieve-package-archives nil 'force)


### PR DESCRIPTION
**problem:**
`SPC f e U` checks if packages have updates.
But if the current buffer isn't the Spacemacs home buffer,
then the minibuffer just shows:
>Do you want to update 1 package(s)? (y or n)

There's no information about which packages have updates.

Canceling the prompt with: `n`
and switching to the messages buffer `SPC b m`, does list them.
>(Spacemacs) --> Found 1 package(s) to update:
>
>(Spacemacs) dap-mode

But it doesn't work to switch to the home buffer,
because that information was erased when the home buffer was refreshed.

**solution:**
Switch to the home buffer before checking for updates.