### PR TITLE
Fix bug in `spacemacs//python-setup-backend ()`

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -31,8 +31,8 @@
 
 (defun spacemacs//python-setup-backend ()
   "Conditionally setup python backend."
-  (when python-pipenv-activate (pipenv-activate)
-        python-poetry-activate (spacemacs//poetry-activate))
+  (when python-pipenv-activate (pipenv-activate))
+  (when python-poetry-activate (spacemacs//poetry-activate))
   (pcase python-backend
     ('anaconda (spacemacs//python-setup-anaconda))
     ('lsp (spacemacs//python-setup-lsp))))


### PR DESCRIPTION
The PR splits the single `when` into two so that `python-poetry-activate` is actually checked. In the current implementation `(spacemacs//poetry-activate)` is called regardless of the value of `python-poetry-activate`.