### PR TITLE
Search Engine layer: Allow customization of Amazon site TLD.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -324,7 +324,8 @@ In org-agenda-mode
     to avoid conflicts with key bindings in the =web-mode= layer
     (thanks to Adam Sokolnicki)
 ***** Search-engine
-- Add Debian & Ubuntu package search engines (thanks to Alfonso Montero).
+  - Add Debian & Ubuntu package search engines (thanks to Alfonso Montero).
+  - Allow to configure a TLD other than =.com= for Amazon searches (thanks to Alfonso Montero).
 ***** Spacemacs-navigation
 - Key bindings:
   - Add ~J/K~ to scroll up/down (or next/previous node) in Info-mode

--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -69,6 +69,13 @@ your =dotspacemacs/user-config=:
         browse-url-generic-program "google-chrome")
 #+END_SRC
 
+The Amazon search engine defaults to use the =.com= [[https://en.wikipedia.org/wiki/TLD][TLD]]. If you want it to search on
+another country's website, you can specify a different one:
+#+BEGIN_SRC emacs-lisp
+  ;; Use amazon.es site (Spain)
+  (setq-default search-engine-amazon-tld "es")
+#+END_SRC
+
 If you want more control of how various search engines are handled
 or you want to add additional ones you can do so by setting the
 following datastructure to =search-engine-config-list= in your =dotspacemacs/user-config=.

--- a/layers/+web-services/search-engine/config.el
+++ b/layers/+web-services/search-engine/config.el
@@ -25,3 +25,6 @@
 
 (defvar search-engine-config-list nil
   "Set additional search engines")
+
+(defvar search-engine-amazon-tld "com"
+  "Amazon website TLD to use for searching.")

--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -38,7 +38,9 @@
       (setq search-engine-alist
             `((amazon
                :name "Amazon"
-               :url "https://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%%3Daps&field-keywords=%s")
+               :url (concat "https://www.amazon."
+                            search-engine-amazon-tld
+                            "/s/ref=nb_sb_noss?url=search-alias%%3Daps&field-keywords=%s"))
               (bing
                :name "Bing"
                :url "https://www.bing.com/search?q=%s")


### PR DESCRIPTION
Amazon search engine is of limited use if you live overseas :)