### PR TITLE
[base] Fix void spacemacs-evil-collection-allowed-list

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -301,7 +301,8 @@
               (define-key magit-mode-map "~" 'magit-svn))))
 
 (defun git/pre-init-magit-todos ()
-  (add-to-list 'spacemacs-evil-collection-allowed-list 'magit-todos))
+  (when (configuration-layer/layer-used-p 'spacemacs-evil)
+    (add-to-list 'spacemacs-evil-collection-allowed-list 'magit-todos)))
 
 (defun git/init-magit-todos ()
   (use-package magit-todos


### PR DESCRIPTION
problem
In the `spacemacs-base` distribution.

When the `git-enable-magit-todos-plugin`
layer variable is enabled.

Then the following message appears on startup:
>An error occurred while pre-configuring magit-todos in layer git (error: (void-variable spacemacs-evil-collection-allowed-list))

cause
The `spacemacs-evil-collection-allowed-list` variable
is assigned in the `git` layer.

But it's defined in the `spacemacs-evil` layer.

The `spacemacs-evil` layer isn't used by default
in the `spacemacs-base` distribution.

solution
Check that the `spacemacs-evil` layer is used
before adding to the variable.