### PR TITLE
[dired] Add ivy command and replace evil collection key

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -292,13 +292,13 @@
   ;; turn off evil in corelv buffers
   (add-to-list 'evil-buffer-regexps '("\\*LV\\*"))
 
-  ;; replace `dired-goto-file' with `helm-find-files', since `helm-find-files'
-  ;; can do the same thing and with fuzzy matching and other features.
+  ;; replace `dired-goto-file' with equivalent helm and ivy functions:
+  ;; `spacemacs/helm-find-files' fuzzy matching and other features
+  ;; `spacemacs/counsel-find-file' more `M-o' actions
   (with-eval-after-load 'dired
-    (evil-define-key 'normal dired-mode-map "J" 'spacemacs/helm-find-files)
-    (define-key dired-mode-map "j" 'spacemacs/helm-find-files)
-    (evil-define-key 'normal dired-mode-map (kbd dotspacemacs-leader-key)
-      spacemacs-default-map))
+    (define-key dired-mode-map "j"
+      (cond ((configuration-layer/layer-used-p 'helm) 'spacemacs/helm-find-files)
+            ((configuration-layer/layer-used-p 'ivy) 'spacemacs/counsel-find-file))))
 
   ;; support smart 1parens-strict-mode
   (when (configuration-layer/package-used-p 'smartparens)

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -122,7 +122,14 @@
     :config
     (setq evil-collection-mode-list spacemacs-evil-collection-allowed-list)
     (setq evil-collection-want-unimpaired-p nil)
-    (evil-collection-init)))
+    (evil-collection-init)
+    ;; replace `dired-goto-file' with equivalent helm and ivy functions:
+    ;; `spacemacs/helm-find-files' fuzzy matching and other features
+    ;; `spacemacs/counsel-find-file' more `M-o' actions
+    (with-eval-after-load 'dired
+      (evil-define-key 'normal dired-mode-map "J"
+        (cond ((configuration-layer/layer-used-p 'helm) 'spacemacs/helm-find-files)
+              ((configuration-layer/layer-used-p 'ivy) 'spacemacs/counsel-find-file))))))
 
 (defun spacemacs-evil/init-evil-escape ()
   (use-package evil-escape


### PR DESCRIPTION
Fixes: vim layer key binding of "J" in dired mode #14614

problem
The evil collection binds "J" to `dired-go-to-file`

It overrides the Spacemacs `helm` and `ivy` equivalent commands.
`spacemacs/helm-find-files' has fuzzy matching and other features
`spacemacs/counsel-find-file' has more `M-o' actions

And the `ivy` layer uses the `spacemacs/helm-find-files` command.

solution
Move the Spacemacs definitions of "J",
after the evil collection dired keys have been setup
from: `spacemacs-bootstrap/packages.el`
to: `spacemacs-evil/init-evil-collection`

And use `spacemacs/counsel-find-file` in the `ivy` layer.