### PR TITLE
fixup! windows-scripts: replaced dos.el with bat-mode, added bmx-mode

### DIFF
--- a/layers/+lang/windows-scripts/funcs.el
+++ b/layers/+lang/windows-scripts/funcs.el
@@ -20,11 +20,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(defun windows-scripts/bat-outline-setup ()
-  "Select position by mouse and return to `bat-mode'."
-  (local-set-key [mouse-1] (lambda () (interactive) (bat-mode) (beginning-of-line)))
-  (local-set-key [return] 'bat-mode))
-
 ;;;###autoload
 (defun windows-scripts/bat-outline ()
   "Navigate within Batch script using outline-mode."
@@ -32,4 +27,6 @@
   (setq-local outline-regexp ":[^:]")
   (outline-mode)
   (hide-body)
+  (local-set-key [mouse-1] (lambda () (interactive) (bat-mode) (beginning-of-line)))
+  (local-set-key [return] 'bat-mode)
   (define-key evil-normal-state-local-map (kbd "SPC m z") 'bat-mode))

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -35,7 +35,6 @@
     :commands (bat-cmd-help bat-run bat-run-args bat-template)
     :mode (("\\.bat\\'" . bat-mode)
            ("\\.cmd\\'" . bat-mode))
-    :hook (outline-mode . windows-scripts/bat-outline-setup)
     :init
     (progn
       (spacemacs/declare-prefix-for-mode 'bat-mode "me" "eval")


### PR DESCRIPTION
Fixes #14626 

Now the two convenient bindings are only set when the user explicitly invoke `windows-scripts/bat-outline`