### PR TITLE
Add describe evil ex-command functionality

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -635,6 +635,7 @@ Other:
     after =spacemacs-scratch-mode= is applied to =*scratch*= buffer (thanks to rayw000)
   - Add toggles for persistent which-key keymaps, (full)-major/minor mode
     keymaps and top-level keymap, under prefix ~SPC t k~ (thanks to Daniel Nicolai)
+  - Add =describe-ex-command= on ~SPC h d x~ (thanks to Daniel Nicolai)
 - Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/core/core-debug.el
+++ b/core/core-debug.el
@@ -236,6 +236,22 @@ seconds to load")
                      "You can paste it in the gitter chat.\n"
                      "Check the *Messages* buffer if you need to review it"))))
 
+(defun spacemacs/describe-ex-command (ex-command)
+  (interactive (list (completing-read "Describe ex-command: " evil-ex-commands)))
+  (let* ((func (alist-get ex-command evil-ex-commands nil nil 'string=))
+         (prompt (if (stringp func)
+                     "The ex-command :%s is an alias for the ex-command :%s. Describe :%s?"
+                   "The ex-command :%s calls %s. Describe %s?")))
+    (when (y-or-n-p (format prompt
+                            ex-command
+                            func
+                            func))
+      (if (stringp func)
+          (spacemacs/describe-ex-command func)
+        (if (configuration-layer/layer-usedp 'helpful)
+            (helpful-callable func)
+          (describe-function func))))))
+
 (defun spacemacs/report-issue (arg)
   "Open a spacemacs/report-issue-mode buffer prepopulated with
    issue report template and system information.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2037,6 +2037,7 @@ thusly:
 | ~SPC h d t~ | describe text properties                                  |
 | ~SPC h d T~ | describe a theme                                          |
 | ~SPC h d v~ | describe a variable                                       |
+| ~SPC h d x~ | describe an evil ex-command                               |
 
 Other help key bindings:
 

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -166,12 +166,13 @@ backslash, an actual space and a lowercase ~b~.
 =Describe functions= are powerful Emacs introspection commands to get information
 about functions, variables, modes etc. These commands are bound thusly:
 
-| Key binding | Description       |
-|-------------+-------------------|
-| ~SPC h d f~ | describe-function |
-| ~SPC h d k~ | describe-key      |
-| ~SPC h d m~ | describe-mode     |
-| ~SPC h d v~ | describe-variable |
+| Key binding | Description              |
+|-------------+--------------------------|
+| ~SPC h d f~ | describe-function        |
+| ~SPC h d k~ | describe-key             |
+| ~SPC h d m~ | describe-mode            |
+| ~SPC h d v~ | describe-variable        |
+| ~SPC h d x~ | describe-ex-command      |
 
 * How-To's
 Some quick =how-to's= are compiled in the [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/FAQ.org#how-do-i][FAQ.]]

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -133,6 +133,7 @@
       ;; various key bindings
       (spacemacs||set-helm-key "fel" helm-locate-library)
       (spacemacs||set-helm-key "hdm" describe-mode)
+      (spacemacs||set-helm-key "hdx" spacemacs/describe-ex-command)
       (spacemacs||set-helm-key "swg" helm-google-suggest)
       (with-eval-after-load 'helm-files
         (define-key helm-find-files-map

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -81,6 +81,7 @@
         "hdF" 'counsel-describe-face
         "hdm" 'spacemacs/describe-mode
         "hdv" 'counsel-describe-variable
+        "hdx" 'spacemacs/describe-ex-command
         "hi"  'counsel-info-lookup-symbol
         "hm"  (if (spacemacs/system-is-mswindows) 'woman 'man)
         "hR"  'spacemacs/counsel-search-docs


### PR DESCRIPTION
For introspection purposes it can be nice to have this functionality. Also this
function can be used to get an overview of which ex-commands are available.
