### PR TITLE
[c-c++] Fix "Wrong number of arguments" on Emacs 28

### DIFF
--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -72,7 +72,7 @@ Add `dap-gdb-lldb' for the WebFreak Native Debug extension.")
 
 
 ;; style
-(define-obsolete-variable-alias 'c++-enable-organize-includes-on-save 'c-c++-enable-organize-includes-on-save)
+(define-obsolete-variable-alias 'c++-enable-organize-includes-on-save 'c-c++-enable-organize-includes-on-save nil)
 (defvar c-c++-enable-organize-includes-on-save nil
   "If non-nil then automatically organize the includes on save C++ buffer.")
 


### PR DESCRIPTION
Closes https://github.com/syl20bnr/spacemacs/issues/14631

Since Spacemacs doesn't really have versions I figure `nil` is the best we can do?