### PR TITLE
Fix scheme layer support for scheme implementations

### DIFF
--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -6,6 +6,7 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#install-chicken-scheme-example][Install Chicken scheme example]]
 - [[#structurally-safe-editing][Structurally safe editing]]
 - [[#key-bindings][Key bindings]]
   - [[#compiling][Compiling]]
@@ -29,6 +30,32 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =scheme= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+Additionally, before geiser can be used with a scheme implementation, support
+for the implementation must be enabled by adding its name to the list of
+=scheme-implementations=. It is recommended to set the value of the list
+directly in the =dotspacemacs-configuration-layers= list as shown in the
+following example for guile and racket:
+
+#+begin_src elisp
+  dotspacemacs-configuration-layers
+  '((scheme :variables
+             scheme-implementations '(guile racket)))
+#+end_src
+
+Currently support is available for the following scheme implementations:
+chez, chibi, chicken, gambit, gauche, guile, kawa, mit and racket.
+
+Finally, to use a scheme implementation its binary must be available in your
+PATH (or you can manually set the location of the binary as explained in [[https://nongnu.org/geiser/geiser_3.html][this
+section of the geiser documentation]]).
+
+The following subsection shows how to install Chicken scheme and activate geiser
+support.
+
+** Install Chicken scheme example
+
+First add =chicken= to the list of =scheme-implementations= as explained above.
+   
 For full Chicken support, the following commands should be run:
 
 #+BEGIN_SRC shell

--- a/layers/+lang/scheme/config.el
+++ b/layers/+lang/scheme/config.el
@@ -24,3 +24,9 @@
 ;; variables
 
 (spacemacs|define-jump-handlers scheme-mode geiser-edit-symbol-at-point)
+
+(defvar scheme-implementations nil
+  "List of scheme implementations for which support should get enabled.
+The symbols of the list can be any multiple of the by geiser
+  supported scheme implementations: chez, chibi, chicken, gambit,
+  gauche, guile, kawa, mit and/or racket.")

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -21,16 +21,24 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq scheme-packages
-      '(
-        company
-        evil-cleverparens
-        geiser
-        ggtags
-        counsel-gtags
-        helm-gtags
-        parinfer
-        ))
+(defconst scheme-packages
+  '(company
+    evil-cleverparens
+    geiser
+    ggtags
+    counsel-gtags
+    helm-gtags
+    parinfer-rust-mode
+    (geiser-chez    :toggle (memq 'chez    scheme-implementations))
+    (geiser-chibi   :toggle (memq 'chibi   scheme-implementations))
+    (geiser-chicken :toggle (memq 'chicken scheme-implementations))
+    (geiser-gambit  :toggle (memq 'gambit  scheme-implementations))
+    (geiser-gauche  :toggle (memq 'gauche  scheme-implementations))
+    (geiser-guile   :toggle (memq 'guile   scheme-implementations))
+    (geiser-kawa    :toggle (memq 'kawa    scheme-implementations))
+    (geiser-mit     :toggle (memq 'mit     scheme-implementations))
+    (geiser-racket  :toggle (memq 'racket  scheme-implementations))))
+
 
 (defun scheme/post-init-company ()
   ;; Geiser provides completion as long as company mode is loaded.
@@ -104,5 +112,41 @@
 (defun scheme/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'scheme-mode))
 
-(defun scheme/post-init-parinfer ()
-  (add-hook 'scheme-mode-hook 'parinfer-mode))
+(defun scheme/post-init-parinfer-rust-mode ()
+  (add-hook 'scheme-mode-hook 'parinfer-rust-mode))
+
+(defun scheme/init-geiser-chez ()
+  (use-package geiser-chez
+    :defer t))
+
+(defun scheme/init-geiser-chibi ()
+  (use-package geiser-chibi
+    :defer t))
+
+(defun scheme/init-geiser-chicken ()
+  (use-package geiser-chicken
+    :defer t))
+
+(defun scheme/init-geiser-gambit ()
+  (use-package geiser-gambit
+    :defer t))
+
+(defun scheme/init-geiser-gauche ()
+  (use-package geiser-gauche
+    :defer t))
+
+(defun scheme/init-geiser-guile ()
+  (use-package geiser-guile
+    :defer t))
+
+(defun scheme/init-geiser-kawa ()
+  (use-package geiser-kawa
+    :defer t))
+
+(defun scheme/init-geiser-mit ()
+  (use-package geiser-mit
+    :defer t))
+
+(defun scheme/init-geiser-racket ()
+  (use-package geiser-racket
+    :defer t))


### PR DESCRIPTION
The configuration for various scheme implementations has been split out of the
[geiser package](https://gitlab.com/emacs-geiser), breaking the current layer support for the implementations.

This PR adds a simple fix for the scheme implementations support.
Anybody is free to improve the code, but at least the layer will be fixed
