### PR TITLE
Fix call to deleted method in latex layer

### DIFF
--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -29,7 +29,7 @@
 ;; lowercase form, since bind-map uses the value of major-mode...
 (spacemacs|define-jump-handlers latex-mode)
 ;; ...but AUCTeX runs LaTeX-mode-hook rather than latex-mode-hook, so:
-(add-hook 'LaTeX-mode-hook #'spacemacs//init-jump-handlers-latex-mode)
+(add-to-list 'spacemacs-jump-handlers-latex-mode 'LaTeX-mode-hook)
 
 (defvar latex-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'company-auctex)
   "The backend to use for IDE features.


### PR DESCRIPTION
In commit f136f46 spacemacs//init-jump-handlers-MODE was removed,
which is used by the latex layer. Change to call to add-to-list instead.
