### PR TITLE
[pdf] Change pdf-tools source to maintained fork

### DIFF
--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -22,8 +22,16 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq pdf-packages '(pdf-tools
-                     pdf-view-restore))
+(setq pdf-packages
+      '((pdf-tools :location (recipe
+                              :fetcher github
+                              :repo "vedang/pdf-tools"
+                              :files ("lisp/*.el"
+                                      "README"
+                                      ("build" "Makefile")
+                                      ("build" "server")
+                                      (:exclude "lisp/tablist.el" "lisp/tablist-filter.el"))))
+        pdf-view-restore))
 
 (defun pdf/init-pdf-tools ()
   (use-package pdf-tools


### PR DESCRIPTION
The original repo for pdf-tools at https://github.com/politza/pdf-tools
is no longer maintained, and its maintainer seems to be unreachable,
see the issue https://github.com/politza/pdf-tools/issues/659.

Github user vedang forked the project in order to become its new
maintainer at https://github.com/vedang/pdf-tools.

This commit changes the source of the pdf-tools package and makes it
point to the new repository. This is meant to be a workaround until
either the original maintainer of pdf-tools comes back or the repo used
by the MELPA is updated.

The recipe is based on MELPA’s recipe for pdf-tools:
https://github.com/melpa/melpa/blob/master/recipes/pdf-tools

By the way, should the `setq` be replaced by a `defconst`? I noticed
some layers use the latter rather than the former, and I think it would
make more sense to switch from a `setq` to a `defconst`, but I guess 
this would make more sense for another PR.