### PR TITLE
[gtags] improve

### DIFF
--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -36,33 +36,9 @@ Otherwise does nothing."
   spacemacs--counsel-gtags-dwim-success)
 
 (defun spacemacs/counsel-gtags-define-keys-for-mode (mode)
-  "Define key bindings for the specific MODE."
-  ;; `counsel-gtags-dwim' is added to the end of the mode-specific jump handlers
-  ;; Some modes have more sophisticated jump handlers that go to the beginning
-  ;; It might be possible to add `counsel-gtags-dwim' instead to the default
-  ;; handlers, if it does a reasonable job in ALL modes.
-  (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode)))
-        (handler '(spacemacs/counsel-gtags-maybe-dwim
-                   :async spacemacs//counsel-gtags-dwim-success)))
-    (when (boundp jumpl) (add-to-list jumpl handler 'append)))
-
-  ;; TODO: Add missing keybindings when new functions get added
-  (spacemacs/set-leader-keys-for-major-mode mode
-    "gC" 'counsel-gtags-create-tags
-    "gd" 'counsel-gtags-dwim
-    ;; "gD" 'helm-gtags-find-tag-other-window
-    "gf" 'counsel-gtags-find-file
-    ;; "gG" 'helm-gtags-dwim-other-window
-    ;; "gi" 'helm-gtags-tags-in-this-function
-    ;; "gl" 'helm-gtags-parse-file
-    "gn" 'counsel-gtags-go-forward
-    "gp" 'counsel-gtags-go-backward
-    "gr" 'counsel-gtags-find-reference
-    ;; "gR" 'helm-gtags-resume
-    ;; "gs" 'helm-gtags-select
-    ;; "gS" 'helm-gtags-show-stack
-    "gy" 'counsel-gtags-find-symbol
-    "gu" 'counsel-gtags-update-tags))
+  "Obsolete, does nothing."
+  (message "spacemacs/counsel-gtags-define-keys-for-mode does nothing! %s doesn't have to call it anymore."
+           mode))
 
 (defun helm-gtags-dwim-other-window ()
   "helm-gtags-dwim in the other window"
@@ -73,43 +49,20 @@ Otherwise does nothing."
     (helm-gtags-dwim)))
 
 (defun spacemacs/helm-gtags-maybe-dwim ()
-  "Runs `helm-gtags-dwim' if `gtags-enable-by-default' is on.
-Otherwise does nothing."
+  "helm-gtags-dwim in same window"
   (interactive)
-  (when gtags-enable-by-default
-    (call-interactively 'helm-gtags-dwim)))
+  (call-interactively 'helm-gtags-dwim))
 
 (defun spacemacs/helm-gtags-define-keys-for-mode (mode)
-  "Define key bindings for the specific MODE."
-  ;; The functionality of `helm-gtags-mode' is pretty much entirely superseded
-  ;; by `ggtags-mode', so we don't add this hook
-  ;; (let ((hook (intern (format "%S-hook" mode))))
-  ;;   (add-hook hook 'helm-gtags-mode))
+  "Obsolete, does nothing."
+  (message "spacemacs/helm-gtags-define-keys-for-mode does nothing! %s doesn't have to call it anymore."
+           mode))
 
-  ;; `helm-gtags-dwim' is added to the end of the mode-specific jump handlers
-  ;; Some modes have more sophisticated jump handlers that go to the beginning
-  ;; It might be possible to add `helm-gtags-dwim' instead to the default
-  ;; handlers, if it does a reasonable job in ALL modes.
-  (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode))))
-    (when (boundp jumpl)
-      (add-to-list jumpl 'spacemacs/helm-gtags-maybe-dwim 'append)))
+(defun spacemacs/helm-ggtags-set-jump-handler ()
+  (add-to-list 'spacemacs-jump-handlers 'spacemacs/helm-gtags-maybe-dwim))
 
-  (spacemacs/set-leader-keys-for-major-mode mode
-    "gC" 'helm-gtags-create-tags
-    "gd" 'helm-gtags-find-tag
-    "gD" 'helm-gtags-find-tag-other-window
-    "gf" 'helm-gtags-select-path
-    "gG" 'helm-gtags-dwim-other-window
-    "gi" 'helm-gtags-tags-in-this-function
-    "gl" 'helm-gtags-parse-file
-    "gn" 'helm-gtags-next-history
-    "gp" 'helm-gtags-previous-history
-    "gr" 'helm-gtags-find-rtag
-    "gR" 'helm-gtags-resume
-    "gs" 'helm-gtags-select
-    "gS" 'helm-gtags-show-stack
-    "gy" 'helm-gtags-find-symbol
-    "gu" 'helm-gtags-update-tags))
+(defun spacemacs/counsel-ggtags-set-jump-handler ()
+  (add-to-list 'spacemacs-jump-handlers 'spacemacs/counsel-gtags-maybe-dwim))
 
 (defun spacemacs/ggtags-mode-enable ()
   "Enable ggtags and eldoc mode.

--- a/layers/+tags/gtags/packages.el
+++ b/layers/+tags/gtags/packages.el
@@ -36,24 +36,32 @@
     (progn
       (setq counsel-gtags-ignore-case t
             counsel-gtags-auto-update t)
-      ;; modes that do not have a layer, define here
-      (spacemacs/counsel-gtags-define-keys-for-mode 'tcl-mode)
-      (spacemacs/counsel-gtags-define-keys-for-mode 'vhdl-mode)
-      (spacemacs/counsel-gtags-define-keys-for-mode 'awk-mode)
-      (spacemacs/counsel-gtags-define-keys-for-mode 'dired-mode)
-      (spacemacs/counsel-gtags-define-keys-for-mode 'compilation-mode)
-      (spacemacs/counsel-gtags-define-keys-for-mode 'shell-mode))))
+      (add-hook 'ggtags-mode-hook 'counsel-gtags-mode)
+      (add-hook 'ggtags-mode-hook #'spacemacs/counsel-ggtags-set-jump-handler))
+    :config
+    ;; TODO add mixing commands
+    (spacemacs/set-leader-keys-for-minor-mode 'counsel-gtags-mode
+      "gC" 'counsel-gtags-create-tags
+      "gd" 'counsel-gtags-dwim
+      ;; "gD" 'helm-gtags-find-tag-other-window
+      "gf" 'counsel-gtags-find-file
+      ;; "gG" 'helm-gtags-dwim-other-window
+      ;; "gi" 'helm-gtags-tags-in-this-function
+      ;; "gl" 'helm-gtags-parse-file
+      "gn" 'counsel-gtags-go-forward
+      "gp" 'counsel-gtags-go-backward
+      "gr" 'counsel-gtags-find-reference
+      ;; "gR" 'helm-gtags-resume
+      ;; "gs" 'helm-gtags-select
+      ;; "gS" 'helm-gtags-show-stack
+      "gy" 'counsel-gtags-find-symbol
+      "gu" 'counsel-gtags-update-tags)))
 
 (defun gtags/init-ggtags ()
   (use-package ggtags
     :defer t
     :init
     (progn
-      ;; modes that do not have a layer, add here.
-      (add-hook 'awk-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
-      (add-hook 'shell-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
-      (add-hook 'tcl-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
-      (add-hook 'vhdl-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)
       (spacemacs|add-toggle ggtags-mode
         :status ggtags-mode
         :on (ggtags-mode nil)
@@ -122,10 +130,22 @@
             helm-gtags-auto-update t
             helm-gtags-use-input-at-cursor t
             helm-gtags-pulse-at-cursor t)
-      ;; modes that do not have a layer, define here
-      (spacemacs/helm-gtags-define-keys-for-mode 'tcl-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'vhdl-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'awk-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'dired-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'compilation-mode)
-      (spacemacs/helm-gtags-define-keys-for-mode 'shell-mode))))
+      (add-hook 'ggtags-mode-hook 'helm-gtags-mode)
+      (add-hook 'ggtags-mode-hook #'spacemacs/helm-ggtags-set-jump-handler))
+    :config
+    (spacemacs/set-leader-keys-for-minor-mode 'helm-gtags-mode
+       "gC" 'helm-gtags-create-tags
+       "gd" 'helm-gtags-find-tag
+       "gD" 'helm-gtags-find-tag-other-window
+       "gf" 'helm-gtags-select-path
+       "gG" 'helm-gtags-dwim-other-window
+       "gi" 'helm-gtags-tags-in-this-function
+       "gl" 'helm-gtags-parse-file
+       "gn" 'helm-gtags-next-history
+       "gp" 'helm-gtags-previous-history
+       "gr" 'helm-gtags-find-rtag
+       "gR" 'helm-gtags-resume
+       "gs" 'helm-gtags-select
+       "gS" 'helm-gtags-show-stack
+       "gy" 'helm-gtags-find-symbol
+       "gu" 'helm-gtags-update-tags)))


### PR DESCRIPTION
make bindings stick to minor modes of helm/counsel-gtags-mode not major mode. so
the bindings will only be in force when ggtags-mode is enabled.

deprecate functions spacemacs/counsel-gtags-define-keys-for-mode and
spacemacs/helm-gtags-define-keys-for-mode that add ggtags bindings to major
mode. Next step is to remove these function calls from client layers.
