### PR TITLE
[python] Fix directory specific python-backend

### DIFF
--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -30,10 +30,12 @@
   "The backend to use for IDE features.
 Possible values are `anaconda'and `lsp'.
 If `nil' then `anaconda' is the default backend unless `lsp' layer is used.")
+(put 'python-backend 'safe-local-variable #'symbolp)
 
 (defvar python-lsp-server 'pyls
   "Language server to use for lsp backend. Possible values are `pyls', `pyright'
 and `mspyls'")
+(put 'python-lsp-server 'safe-local-variable #'symbolp)
 
 (defvar python-lsp-git-root nil
   "If non-nil, use a development version of the language server in this folder")
@@ -54,6 +56,7 @@ If nil then `yapf' is the default formatter unless `lsp' layer is used.")
 
 (defvar python-test-runner 'nose
   "Test runner to use. Possible values are `nose' or `pytest'.")
+(put 'python-test-runner 'safe-local-variable #'symbolp)
 
 (defvar python-save-before-test t
   "If non nil, current buffer will be save before call a test function")

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -364,9 +364,8 @@
       (spacemacs/register-repl 'python
                                'spacemacs/python-start-or-switch-repl "python")
       (spacemacs//bind-python-repl-keys)
-      (spacemacs/add-to-hook 'python-mode-hook
-                             '(spacemacs//python-setup-backend
-                               spacemacs//python-default))
+      (add-hook 'python-mode-local-vars-hook 'spacemacs//python-setup-backend)
+      (add-hook 'python-mode-hook 'spacemacs//python-default)
       ;; call `spacemacs//python-setup-shell' once, don't put it in a hook
       ;; (see issue #5988)
       (spacemacs//python-setup-shell))


### PR DESCRIPTION
This is a regression we have in multiple languages. We need to add the backend setup function to `<major-mode>-local-vars-hook` so that people can override a language backend in a given project. See the Emacs documentation on this wonderfully named variable [hack-local-variables](https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Local-Variables.html).

For instance with the following `.dir-locals.el` at the root of a git repository I can choose to use `anaconda` instead of `lsp` (useful for legacy python projects):

```.emacs
;;; Directory Local Variables
;;; For more information see (info "(emacs) Directory Variables")

((python-mode . ((python-test-runner . pytest)
                 (python-backend . anaconda))))
```

This feature is explained in the README.org files of all the languages supporting multiple backends. Example in the Python README: https://github.com/syl20bnr/spacemacs/tree/develop/layers/+lang/python#choosing-a-backend

This PR only fixes it for Python.

cc @lebensterben 