### PR TITLE
c-c++: Fix file specific layer configuration

### DIFF
--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -29,6 +29,7 @@
 (defvar c-c++-backend (when (configuration-layer/layer-used-p 'lsp) 'lsp-clangd)
   "The backend to use for IDE features.
 Possible values are `lsp-ccls', `lsp-clangd', `rtags' and `ycmd'.")
+(put 'c-c++-backend 'safe-local-variable #'symbolp)
 
 
 ;; lsp
@@ -47,14 +48,14 @@ By default `font-lock' is used to highlight the text, set the variable to
 
 
 ;; dap
-
-(defvar c-c++-dap-adapters '(dap-cpptools)
-  "Debug adapters to use for IDE debug features.
+(define-obsolete-variable-alias 'c-c++-dap-adapters 'c-c++-dap-adaptors "April 17, 2021")
+(defvar c-c++-dap-adaptors '(dap-cpptools)
+  "Debug adaptors to use for IDE debug features.
 
 By default only `dap-cpptools' is used.
 
 Add `dap-cpptools' for the official Microsoft C/C++ Extension for VSCode.
-Add `dap-lldb' for the official LLDB project adapter.
+Add `dap-lldb' for the official LLDB project adaptor.
 Add `dap-gdb-lldb' for the WebFreak Native Debug extension.")
 
 
@@ -75,6 +76,7 @@ Add `dap-gdb-lldb' for the WebFreak Native Debug extension.")
 (define-obsolete-variable-alias 'c++-enable-organize-includes-on-save 'c-c++-enable-organize-includes-on-save nil)
 (defvar c-c++-enable-organize-includes-on-save nil
   "If non-nil then automatically organize the includes on save C++ buffer.")
+(put 'c-c++-enable-organize-includes-on-save 'safe-local-variable #'symbolp)
 
 (defvar c-c++-enable-auto-newline nil
   "If non nil then enables the `Auto-newline' minor mode.")

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -43,7 +43,10 @@
   ;; currently DAP is only available using LSP
   (pcase c-c++-backend
     ('lsp-clangd (spacemacs//c-c++-setup-lsp-dap))
-    ('lsp-ccls (spacemacs//c-c++-setup-lsp-dap))))
+    ('lsp-ccls (spacemacs//c-c++-setup-lsp-dap))
+    (_ (user-error "Unknown `c-c++-backend': %s" c-c++-backend)))
+  (setq-local spacemacs--dap-supported-modes
+              '(c-mode c++-mode)))
 
 (defun spacemacs//c-c++-setup-eldoc ()
   "Conditionally setup C/C++ eldoc integration based on backend."
@@ -169,7 +172,7 @@
 
 (defun spacemacs//c-c++-setup-lsp-dap ()
   "Setup DAP integration."
-  (mapc #'require c-c++-dap-adapters))
+  (mapc #'require c-c++-dap-adaptors))
 
 
 ;; rtags
@@ -393,10 +396,12 @@
 (defun spacemacs//c-c++-organize-includes-on-save ()
   "Organize the includes on save when `c-c++-enable-organize-includes-on-save'
 is non-nil."
-  (when c-c++-enable-organize-includes-on-save
-    (spacemacs/c-c++-organize-includes)))
+  (spacemacs/c-c++-organize-includes))
 
-(defun spacemacs/c-c++-organize-includes-on-save ()
-  "Add before-save hook for c-c++-organize-includes."
-  (add-hook 'before-save-hook
-            #'spacemacs//c-c++-organize-includes-on-save nil t))
+(defun spacemacs//c-c++-organize-includes-on-save-hook ()
+  "Conditionally enable `spacemacs/c-c++-organize-includes'.
+When `c-c++-enable-organize-includes-on-save' is non-nil, add before-save hook for
+`c-c++-organize-includes'."
+  (when c-c++-enable-organize-includes-on-save
+    (add-hook 'before-save-hook
+              #'spacemacs//c-c++-organize-includes-on-save nil t)))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -67,7 +67,6 @@
     (progn
       (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-backend)
       (add-hook 'c++-mode-local-vars-hook #'spacemacs//c-c++-setup-backend)
-      (put 'c-c++-backend 'safe-local-variable 'symbolp)
       (when c-c++-default-mode-for-headers
         (add-to-list 'auto-mode-alist
                      `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
@@ -90,7 +89,7 @@
 
 (defun c-c++/init-clang-format ()
   (use-package clang-format
-    :init (spacemacs//c-c++-setup-clang-format)))
+    :hook ((c-mode-local-vars c++-mode-local-vars) . spacemacs//c-c++-setup-format)))
 
 (defun c-c++/post-init-company ()
   (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-company)
@@ -121,8 +120,7 @@
     :defer t
     :init
     (progn
-      (when c-c++-enable-organize-includes-on-save
-        (add-hook 'c++-mode-hook #'spacemacs/c-c++-organize-includes-on-save))
+      (add-hook 'c++-mode-local-vars-hook #'spacemacs//c-c++-organize-includes-on-save-hook)
 
       (spacemacs/declare-prefix-for-mode 'c++-mode
         "mr" "refactor")
@@ -130,11 +128,6 @@
         "ri" #'spacemacs/c++-organize-includes))))
 
 (defun c-c++/pre-init-dap-mode ()
-  (pcase c-c++-backend
-    ('lsp-clangd (add-to-list 'spacemacs--dap-supported-modes 'c-mode)
-                 (add-to-list 'spacemacs--dap-supported-modes 'c++-mode))
-    ('lsp-ccls (add-to-list 'spacemacs--dap-supported-modes 'c-mode)
-               (add-to-list 'spacemacs--dap-supported-modes 'c++-mode)))
   (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-dap)
   (add-hook 'c++-mode-local-vars-hook #'spacemacs//c-c++-setup-dap))
 


### PR DESCRIPTION
- Labelled `c-c++-backend`, `c-c++-enable-organize-includes-on-save`
  as safe local variable.
- Added local variable hooks of c/c++ modes:
  - `spacemacs//c-c++-setup-clang-format`.
  - `spacemacs//c-c++-organize-includes-on-save-hook`
- Improved `spacemacs//c-c++-setup-dap`
- Improved `c-c++-organize-includes` related functions.
- Declared `c-c++-dap-adapters` as obsolete variable alias for
  `c-c++-dap-adaptors` because of misspelling.

All other setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!