### PR TITLE
crystal: Fix file local variable

### DIFF
--- a/layers/+lang/crystal/config.el
+++ b/layers/+lang/crystal/config.el
@@ -27,6 +27,7 @@
 
 (defvar crystal-enable-auto-format nil
   "If non-nil then auto-format on save.")
+(put 'crystal-enable-auto-format 'safe-local-variable #'symbolp)
 
 (defvar crystal-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'company-crystal)
   "The backend to use for IDE features.

--- a/layers/+lang/crystal/config.el
+++ b/layers/+lang/crystal/config.el
@@ -32,3 +32,4 @@
   "The backend to use for IDE features.
 Possible values are `lsp' and `company-crystal'.
 If `nil' then 'company-crystal` is the default backend unless `lsp' layer is used")
+(put 'crystal-backend 'safe-local-variable #'symbolp)

--- a/layers/+lang/crystal/funcs.el
+++ b/layers/+lang/crystal/funcs.el
@@ -47,5 +47,9 @@
                         :variables company-tooltip-align-annotations t))))
 
 (defun spacemacs//crystal-setup-backend ()
-  "Conditionally setup crystal backend."
-  (when (eq crystal-backend 'lsp) (lsp)))
+  "Conditionally setup crystal backend and bindings."
+  (if (eq crystal-backend 'lsp)
+      (lsp)
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "mt" "test")
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "ma" "action")))

--- a/layers/+lang/crystal/packages.el
+++ b/layers/+lang/crystal/packages.el
@@ -51,15 +51,12 @@
 (defun crystal/init-crystal-mode ()
   (use-package crystal-mode
     :defer t
+    :hook
+    (crystal-mode-local-vars . spacemacs//crystal-auto-format-setup)
+    (crystal-mode-local-vars . spacemacs//crystal-setup-backend)
     :init
     (progn
-      (add-hook 'crystal-mode-hook 'spacemacs//crystal-auto-format-setup)
-      (add-hook 'crystal-mode-local-vars-hook #'spacemacs//crystal-setup-backend)
       (spacemacs/declare-prefix-for-mode 'crystal-mode "mu" "tool")
-      (unless (eq crystal-backend 'lsp)
-        (spacemacs/declare-prefix-for-mode 'crystal-mode "mg" "goto")
-        (spacemacs/declare-prefix-for-mode 'crystal-mode "mt" "test")
-        (spacemacs/declare-prefix-for-mode 'crystal-mode "ma" "action"))
       (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
         "ga" 'crystal-spec-switch
         "tb" 'crystal-spec-buffer

--- a/layers/+lang/crystal/packages.el
+++ b/layers/+lang/crystal/packages.el
@@ -34,7 +34,7 @@
     play-crystal))
 
 (defun crystal/post-init-company ()
-  (spacemacs//crystal-setup-company))
+  (add-hook 'crystal-mode-local-vars-hook #'spacemacs//crystal-setup-company))
 
 (defun crystal/init-ameba ()
   (use-package ameba
@@ -54,7 +54,7 @@
     :init
     (progn
       (add-hook 'crystal-mode-hook 'spacemacs//crystal-auto-format-setup)
-      (add-hook 'crystal-mode-hook #'spacemacs//crystal-setup-backend)
+      (add-hook 'crystal-mode-local-vars-hook #'spacemacs//crystal-setup-backend)
       (spacemacs/declare-prefix-for-mode 'crystal-mode "mu" "tool")
       (unless (eq crystal-backend 'lsp)
         (spacemacs/declare-prefix-for-mode 'crystal-mode "mg" "goto")


### PR DESCRIPTION
- Labelled `crystal-backend` and `crystal-enable-auto-format`
  as safe local variable.
- Added local variable hooks of crystal mode:
  - `spacemacs//crystal-setup-backend`
  - `spacemacs//crystal-setup-company`
  - `spacemacs//crystal-auto-format-setup`
- Imprvoed `spacemacs//crystal-setup-backend` to setup bindings
  correctly according to backend.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!