### PR TITLE
dart: Fix local vars

### DIFF
--- a/layers/+lang/dart/config.el
+++ b/layers/+lang/dart/config.el
@@ -27,3 +27,4 @@
 (defvar dart-backend 'lsp
   "The backend to use for IDE features.
 Possible values are `analyzer' and `lsp'.")
+(put 'dart-backend 'safe-local-variable #'symbolp)


### PR DESCRIPTION
- Labelled `dart-backend` as safe local variable.

All setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653