### PR TITLE
elixir: Fix file local vars

### DIFF
--- a/layers/+lang/elixir/config.el
+++ b/layers/+lang/elixir/config.el
@@ -27,6 +27,7 @@
   "The backend to use for IDE features.
 Possible values are `alchemist' and `lsp'.
 If `nil' then `alchemist' is the default backend unless `lsp' layer is used.")
+(put 'elixir-backend 'safe-local-variable #'symbolp)
 
 (defvar elixir-ls-path "~/elixir-ls/release"
   "The path to the folder that contains the elixir-ls release, start scripts (language_server.sh/language_server.bat).")

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -172,12 +172,10 @@
 (defun elixir/init-elixir-mode ()
   (use-package elixir-mode
     :defer t
-    :init (spacemacs/add-to-hook 'elixir-mode-hook
-                                 '(spacemacs//elixir-setup-backend
-                                   spacemacs//elixir-default))
-    :config
-    (spacemacs/set-leader-keys-for-major-mode 'elixir-mode
-      "=" 'elixir-format)))
+    :hook (elixir-mode . spacemacs//elixir-default)
+          (elixir-mode-local-vars . spacemacs//elixir-setup-backend)
+    :config (spacemacs/set-leader-keys-for-major-mode 'elixir-mode
+              "=" 'elixir-format)))
 
 (defun elixir/post-init-flycheck ()
   (spacemacs/enable-flycheck 'elixir-mode))


### PR DESCRIPTION
- Labelled `elixir-backend` as safe local variable.
- Added local variable hooks of elixir mode:
  - `spacemacs//elixir-setup-backend`

All other setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653