### PR TITLE
elm: Fix local vars

### DIFF
--- a/layers/+lang/elm/config.el
+++ b/layers/+lang/elm/config.el
@@ -29,3 +29,4 @@
   "The backend to use for IDE features.
 Possible values are `lsp' and `company-elm'.
 If `nil' then 'company-elm` is the default backend unless `lsp' layer is used")
+(put 'elm-backend 'safe-local-variable #'symbolp)

--- a/layers/+lang/elm/funcs.el
+++ b/layers/+lang/elm/funcs.el
@@ -40,6 +40,26 @@
     ('lsp (lsp))
     ('company-elm (elm-oracle-setup-completion))))
 
+(defun spacemacs//elm-setup-binding
+    (common-prefix company-elm-prefix common-binding company-elm-binding)
+  "Conditionally setup prefix and bindings according to `elm-backend'."
+  (cl-loop for x on common-prefix
+           by 'cddr
+           do (apply 'spacemacs/declare-prefix-for-mode 'elm-mode
+                     (list (car x) (cadr x))))
+  (apply 'spacemacs/set-leader-keys-for-major-mode 'elm-mode
+         common-binding)
+  (add-hook 'elm-mode-local-vars-hook
+            (lambda ()
+              (when (eq elm-backend 'company-elm)
+                (cl-loop for x on company-elm-prefix
+                         by 'cddr
+                         do (apply 'spacemacs/declare-prefix-for-mode
+                                   'elm-mode
+                                   (list (car x) (cadr x))))
+                (apply 'spacemacs/set-leader-keys-for-major-mode 'elm-mode
+                       company-elm-binding)))))
+
 
 ;; elm-mode
 

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -32,7 +32,7 @@
     smartparens))
 
 (defun elm/post-init-company ()
-  (spacemacs//elm-setup-company))
+  (add-hook 'elm-mode-local-vars-hook #'spacemacs//elm-setup-company))
 
 (defun elm/post-init-flycheck ()
   (spacemacs/enable-flycheck 'elm-mode))
@@ -47,58 +47,48 @@
   "Initialize elm-mode"
   (use-package elm-mode
     :mode ("\\.elm\\'" . elm-mode)
-    :defer t
-    :init
-    (progn
-      (spacemacs/register-repl 'elm-mode 'elm-repl-load "elm")
-      (add-hook 'elm-mode-hook 'spacemacs//elm-setup-backend))
+    :hook (elm-mode-local-vars . spacemacs//elm-setup-backend)
+    :init (spacemacs/register-repl 'elm-mode 'elm-repl-load "elm")
     :config
     (progn
-      ;; Bind non-lsp keys
-      (when (eq elm-backend 'company-elm)
-        (spacemacs/set-leader-keys-for-major-mode 'elm-mode
-          ;; format
-          "=b" 'elm-format-buffer
+      (spacemacs//elm-setup-binding
+       ;; Common prefix
+       '("mp" "package"
+         "mc" "compile"
+         "mR" "reactor"
+         "ms" "repl")
+       ;; Non-lsp prefix
+       '("m=" "format"
+         "mh" "help"
+         "mg" "goto"
+         "mr" "refactor")
+       ;; Bind general keys
+       '(;; refactoring
+         "ri" elm-sort-imports
+         ;; repl
+         "'"  elm-repl-load
+         "si" elm-repl-load
+         "sf" elm-repl-push-decl
+         "sF" spacemacs/elm-repl-push-decl-focus
+         "sr" elm-repl-push
+         "sR" spacemacs/elm-repl-push-focus
+         ;; make
+         "cb" elm-compile-buffer
+         "cB" spacemacs/elm-compile-buffer-output
+         "cm" elm-compile-main
+         ;; reactor
+         "Rn" elm-preview-buffer
+         "Rm" elm-preview-main
+         ;; package
+         "pi" elm-import
+         "pc" elm-package-catalog
+         "pd" elm-documentation-lookup)
+       ;; Bind non-lsp keys
+       '(;; format
+          "=b" elm-format-buffer
           ;; oracle
-          "hh" 'elm-oracle-doc-at-point
-          "ht" 'elm-oracle-type-at-point)
-
-        ;; Bind prefixes
-        (dolist (x '(("m=" . "format")
-                     ("mh" . "help")
-                     ("mg" . "goto")
-                     ("mr" . "refactor")))
-          (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x))))
-
-      ;; Bind general keys
-      (spacemacs/set-leader-keys-for-major-mode 'elm-mode
-        ;; refactoring
-        "ri" 'elm-sort-imports
-        ;; repl
-        "'"  'elm-repl-load
-        "si" 'elm-repl-load
-        "sf" 'elm-repl-push-decl
-        "sF" 'spacemacs/elm-repl-push-decl-focus
-        "sr" 'elm-repl-push
-        "sR" 'spacemacs/elm-repl-push-focus
-        ;; make
-        "cb" 'elm-compile-buffer
-        "cB" 'spacemacs/elm-compile-buffer-output
-        "cm" 'elm-compile-main
-        ;; reactor
-        "Rn" 'elm-preview-buffer
-        "Rm" 'elm-preview-main
-        ;; package
-        "pi" 'elm-import
-        "pc" 'elm-package-catalog
-        "pd" 'elm-documentation-lookup)
-
-      ;; Bind prefixes
-      (dolist (x '(("mp" . "package")
-                   ("mc" . "compile")
-                   ("mR" . "reactor")
-                   ("ms" . "repl")))
-        (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x)))
+          "hh" elm-oracle-doc-at-point
+          "ht" elm-oracle-type-at-point))
 
       (evilified-state-evilify elm-package-mode elm-package-mode-map
         "g" 'elm-package-refresh


### PR DESCRIPTION
- Labelled `elm-backend` as safe local variable.
- Added local variable hooks of elm modes:
  - `spacemacs//elm-setup-backend`
  - `spacemacs//elm-setup-company`

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!