### PR TITLE
ess: Fix local vars

### DIFF
--- a/layers/+lang/ess/config.el
+++ b/layers/+lang/ess/config.el
@@ -27,6 +27,7 @@
 
 (defvar ess-r-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'ess)
   "The backend to use for IDE features. Possible values are `ess' and `lsp'.")
+(put 'ess-r-backend 'safe-local-variable #'symbolp)
 
 (defvar ess-assign-key nil
   "Call `ess-insert-assign'.")

--- a/layers/+lang/ess/funcs.el
+++ b/layers/+lang/ess/funcs.el
@@ -35,6 +35,27 @@
       (lsp)
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
+(defun spacemacs//ess-setup-company()
+  "Conditionally setup company backend. "
+  ;; Julia
+  (spacemacs|add-company-backends
+    :backends company-ess-julia-objects
+    :modes ess-julia-mode inferior-ess-julia-mode)
+  ;; Inferior-R
+  (spacemacs|add-company-backends
+    :backends (company-R-library company-R-args company-R-objects :separate)
+    :modes inferior-ess-r-mode)
+  ;;Set R company to lsp manually to include file completion
+  (add-hook 'ess-r-mode-local-vars-hook
+            (lambda ()
+              (unless (eq ess-r-backend 'lsp)
+                (spacemacs|add-company-backends
+                  :backends (company-R-library
+                             company-R-args
+                             company-R-objects
+                             :separate)
+                  :modes ess-r-mode)))))
+
 
 ;; Key Bindings
 

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -31,20 +31,9 @@
     org))
 
 (defun ess/post-init-company ()
-  ;; Julia
-  (spacemacs|add-company-backends
-    :backends company-ess-julia-objects
-    :modes ess-julia-mode inferior-ess-julia-mode)
-  ;; R
-  (spacemacs|add-company-backends
-    :backends (company-R-library company-R-args company-R-objects :separate)
-    :modes inferior-ess-r-mode)
-
-  ;; Set R company to lsp manually to include file completion
-  (unless (eq ess-r-backend 'lsp)
-    (spacemacs|add-company-backends
-      :backends (company-R-library company-R-args company-R-objects :separate)
-      :modes ess-r-mode)))
+  "Setup company for Julia and Inferior R.
+Additionally setup compnay for R if not using LSP."
+  (spacemacs//ess-setup-company))
 
 (defun ess/post-init-flycheck ()
   (spacemacs/enable-flycheck 'ess-r-mode))

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -79,6 +79,8 @@
            ("\\.[Jj][Oo][Gg]\\'" . ess-jags-mode)
            ("\\.[Jj][Mm][Dd]\\'" . ess-jags-mode))
     :commands (R stata julia SAS ess-julia-mode)
+    :hook (ess-r-mode-local-vars . spacemacs//ess-may-setup-r-lsp)
+          (inferior-ess-mode . spacemacs//ess-fix-read-only-inferior-ess-mode)
     :init
     (progn
       (setq ess-use-company nil
@@ -90,10 +92,6 @@
       (evil-set-initial-state 'ess-help-mode 'motion)
 
       (spacemacs/register-repl 'ess-site #'spacemacs/ess-start-repl)
-
-      (add-hook 'ess-r-mode-hook #'spacemacs//ess-may-setup-r-lsp)
-      (add-hook 'inferior-ess-mode-hook
-                'spacemacs//ess-fix-read-only-inferior-ess-mode)
 
       (with-eval-after-load 'ess-julia
         (spacemacs/ess-bind-keys-for-julia))


### PR DESCRIPTION
- Labelled `ess-backend` as safe local variable.
- Added local variable hooks of ess modes:
  - `spacemacs//ess-may-setup-r-lsp`

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!