### PR TITLE
fsharp: Fix local vars

### DIFF
--- a/layers/+lang/fsharp/config.el
+++ b/layers/+lang/fsharp/config.el
@@ -27,3 +27,4 @@
   "The backend to use for IDE features.
 Possible values are `lsp' and `eglot'.
 If `nil' then 'eglot` is the default backend unless `lsp' layer is used")
+(put 'fsharp-backend 'safe-local-variable #'symbolp)

--- a/layers/+lang/fsharp/funcs.el
+++ b/layers/+lang/fsharp/funcs.el
@@ -35,7 +35,25 @@
   "Conditionally setup fsharp backend."
   (pcase fsharp-backend
     ('lsp (lsp))
-    ('eglot (eglot-ensure))))
+    ('eglot (eglot-ensure)
+            (require 'eglot-fsharp))))
+
+(defun spacemacs//fsharp-setup-binding
+    (common-prefix eglot-prefix common-binding)
+  (cl-loop for x on common-prefix
+           by 'cddr
+           do (apply 'spacemacs/declare-prefix-for-mode 'fsharp-mode
+                     (list (car x) (cadr x))))
+  (apply 'spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
+         common-binding)
+  (add-hook 'fsharp-mode-local-vars-hoook
+            (lambda ()
+              (when (eq fsharp-backend 'eglot)
+                (cl-loop for x on eglot-prefix
+                         by 'cddr
+                         do (apply 'spacemacs/declare-prefix-for-mode
+                                   'fsharp-mode
+                                   (list (car x) (cadr x))))))))
 
 (defun spacemacs/fsharp-load-buffer-file-focus ()
   "Send the current buffer to REPL and switch to the REPL in `insert state'."

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -50,30 +50,26 @@
 (defun fsharp/init-fsharp-mode ()
   (use-package fsharp-mode
     :defer t
+    :hook (fsharp-mode-local-vars . spacemacs//fsharp-setup-backend)
     :init
     (progn
-      (when (eq fsharp-backend 'eglot)
-        (require 'eglot-fsharp))
       (setq fsharp-doc-idle-delay .2)
-      (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#")
-      (add-hook 'fsharp-mode-hook #'spacemacs//fsharp-setup-backend))
+      (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#"))
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'fsharp-mode "ms" "repl")
-      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mc" "compile")
-      (when (eq fsharp-backend 'eglot)
-        (spacemacs/declare-prefix-for-mode 'fsharp-mode "mg" "goto"))
-      (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
-        "cc" 'compile
-        "ga" 'fsharp-find-alternate-file
-        "sb" 'fsharp-load-buffer-file
-        "sB" 'spacemacs/fsharp-load-buffer-file-focus
-        "si" 'fsharp-show-subshell
-        "sp" 'fsharp-eval-phrase
-        "sP" 'spacemacs/fsharp-eval-phrase-focus
-        "sr" 'fsharp-eval-region
-        "sR" 'spacemacs/fsharp-eval-region-focus
-        "'"  'fsharp-show-subshell))))
+    (spacemacs//fsharp-setup-binding
+     '("ms" "repl"
+       "mc" "compile")
+     '("mg" "goto")
+     '("cc" compile
+       "ga" fsharp-find-alternate-file
+       "sb" fsharp-load-buffer-file
+       "sB" spacemacs/fsharp-load-buffer-file-focus
+       "si" fsharp-show-subshell
+       "sp" fsharp-eval-phrase
+       "sP" spacemacs/fsharp-eval-phrase-focus
+       "sr" fsharp-eval-region
+       "sR" spacemacs/fsharp-eval-region-focus
+       "'"  fsharp-show-subshell))))
 
 (defun fsharp/post-init-ggtags ()
   (add-hook 'fsharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
- Labelled `fsharp-backend` as safe local variable.
- Added local variable hooks of fsharp mode:
  - `spacemacs//fsharp-setup-backend`

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!