### PR TITLE
go: Fix local variables

### DIFF
--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -29,6 +29,7 @@
   "The backend to use for IDE features.
 Possible values are `go-mode' and `lsp'.
 If `nil' then `go-mode' is the default backend unless `lsp' layer is used.")
+(put 'go-backend 'safe-local-variable #'symbolp)
 
 (defvar go-use-gocheck-for-testing nil
   "If using gocheck for testing when running the tests -check.f will be used instead of -run to specify the test that will be ran. Gocheck is mandatory for testing suites.")
@@ -38,6 +39,7 @@ If `nil' then `go-mode' is the default backend unless `lsp' layer is used.")
 
 (defvar go-format-before-save nil
   "Use gofmt before save. Set to non-nil to enable gofmt before saving. Default is nil.")
+(put 'go-format-before-save 'safe-local-variable #'symbolp)
 
 (defvar go-tab-width 8
   "Set the `tab-width' in Go mode. Default is 8.")

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -51,6 +51,12 @@
     (require 'dap-go)
     (dap-go-setup)))
 
+(defun spacemacs//go-setup-format ()
+  "Conditionally setup format on save."
+  (if go-format-before-save
+      (add-hook 'before-save-hook 'gofmt-before-save)
+    (remove-hook 'before-save-hook 'gofmt-before-save)))
+
 
 ;; lsp
 

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -64,7 +64,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'go-mode))
 
 (defun go/post-init-eldoc ()
-  (add-hook 'go-mode-hook #'spacemacs//go-setup-eldoc))
+  (add-hook 'go-mode-local-vars-hook #'spacemacs//go-setup-eldoc))
 
 (defun go/post-init-flycheck ()
   (spacemacs/enable-flycheck 'go-mode))
@@ -128,14 +128,13 @@
 
 (defun go/init-go-mode ()
   (use-package go-mode
-    :defer t
+    :hook (go-mode . spacemacs//go-set-tab-width)
+          (go-mode-local-vars . spacemacs//go-setup-backend)
+          (go-mode-local-vars . spacemacs//go-setup-format)
     :init
     (progn
       ;; get go packages much faster
       (setq go-packages-function 'spacemacs/go-packages-gopkgs)
-      (add-hook 'go-mode-hook 'spacemacs//go-set-tab-width)
-      (add-hook 'go-mode-local-vars-hook
-                #'spacemacs//go-setup-backend)
       (dolist (value '(lsp go-mode))
         (add-to-list 'safe-local-variable-values
                      (cons 'go-backend value)))
@@ -147,8 +146,6 @@
         :evil-leader-for-mode (go-mode . "tv")))
     :config
     (progn
-      (when go-format-before-save
-        (add-hook 'before-save-hook 'gofmt-before-save))
       (spacemacs/declare-prefix-for-mode 'go-mode "me" "playground")
       (spacemacs/declare-prefix-for-mode 'go-mode "mg" "goto")
       (spacemacs/declare-prefix-for-mode 'go-mode "mh" "help")


### PR DESCRIPTION
- Labelled `go-backend` and `go-format-on-save` as safe local variable.
- Added local variable hooks of go mode:
  - `spacemacs//go-setup-backend`
  - `spacemacs//go-setup-eldoc`
  - `spacemacs//go-setup-format`

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!