### PR TITLE
haskell: Fix local vars

### DIFF
--- a/layers/+lang/haskell/config.el
+++ b/layers/+lang/haskell/config.el
@@ -23,7 +23,7 @@
 
 ;; Variables
 
-(setq haskell-modes '(haskell-mode haskell-literate-mode))
+(defconst haskell-modes '(haskell-mode haskell-literate-mode))
 
 (spacemacs|define-jump-handlers haskell-mode haskell-mode-jump-to-def-or-tag)
 
@@ -31,6 +31,7 @@
   "Completion backend used by company.
 Available options are `dante' and `lsp'.
 If `nil' then `dante' is the default backend unless `lsp' layer is used.")
+(put 'haskell-completion-backend 'safe-local-variable #'symbolp)
 
 (defvar haskell-enable-hindent nil
   "Formatting with hindent; If t hindent is enabled.")

--- a/layers/+lang/haskell/funcs.el
+++ b/layers/+lang/haskell/funcs.el
@@ -35,6 +35,18 @@
   (when (eq haskell-completion-backend 'dante)
     (spacemacs-haskell//setup-dante-company)))
 
+(defun spacemacs-haskell//setup-binding (common lsp dante)
+  "Conditionally setup haskell bindings."
+  (dolist (mode haskell-modes)
+    (apply 'spacemacs/set-leader-keys-for-major-mode mode common)
+    (add-hook (intern (format "%s-local-vars-hook" mode))
+              (lambda ()
+                (pcase haskell-completion-backend
+                  ('lsp (apply 'spacemacs/set-leader-keys-for-major-mode
+                               mode lsp))
+                  ('dante (apply 'spacemacs/set-leader-keys-for-major-mode
+                                 mode dante)))))))
+
 
 ;; LSP functions
 

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -183,51 +183,45 @@
       (spacemacs/register-repl 'haskell
                                'haskell-interactive-switch "haskell")
 
-      (dolist (mode haskell-modes)
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "sb"  'haskell-process-load-file
-          "sc"  'haskell-interactive-mode-clear
-          "sS"  'spacemacs/haskell-interactive-bring
-          "ss"  'haskell-interactive-switch
-          "st"  'haskell-session-change-target
-          "'"   'haskell-interactive-switch
+      (spacemacs-haskell//setup-binding
+        '("sb"  haskell-process-load-file
+          "sc"  haskell-interactive-mode-clear
+          "sS"  spacemacs/haskell-interactive-bring
+          "ss"  haskell-interactive-switch
+          "st"  haskell-session-change-target
+          "'"   haskell-interactive-switch
 
-          "ca"  'haskell-process-cabal
-          "cb"  'haskell-process-cabal-build
-          "cc"  'haskell-compile
-          "cv"  'haskell-cabal-visit-file
+          "ca"  haskell-process-cabal
+          "cb"  haskell-process-cabal-build
+          "cc"  haskell-compile
+          "cv"  haskell-cabal-visit-file
 
-          "hd"  'inferior-haskell-find-haddock
-          "hi"  'haskell-process-do-info
-          "ht"  'haskell-process-do-type
-          "hT"  'spacemacs/haskell-process-do-type-on-prev-line
+          "hd"  inferior-haskell-find-haddock
+          "hi"  haskell-process-do-info
+          "ht"  haskell-process-do-type
+          "hT"  spacemacs/haskell-process-do-type-on-prev-line
 
-          "da"  'haskell-debug/abandon
-          "db"  'haskell-debug/break-on-function
-          "dB"  'haskell-debug/delete
-          "dc"  'haskell-debug/continue
-          "dd"  'haskell-debug
-          "dn"  'haskell-debug/next
-          "dN"  'haskell-debug/previous
-          "dp"  'haskell-debug/previous
-          "dr"  'haskell-debug/refresh
-          "ds"  'haskell-debug/step
-          "dt"  'haskell-debug/trace
+          "da"  haskell-debug/abandon
+          "db"  haskell-debug/break-on-function
+          "dB"  haskell-debug/delete
+          "dc"  haskell-debug/continue
+          "dd"  haskell-debug
+          "dn"  haskell-debug/next
+          "dN"  haskell-debug/previous
+          "dp"  haskell-debug/previous
+          "dr"  haskell-debug/refresh
+          "ds"  haskell-debug/step
+          "dt"  haskell-debug/trace
 
-          "ri"  'spacemacs/haskell-format-imports)
-        (if (eq haskell-completion-backend 'lsp)
-            (spacemacs/set-leader-keys-for-major-mode mode
-              "gl"  'haskell-navigate-imports
-              "S"   'haskell-mode-stylish-buffer
-
-              "hg"  'hoogle
-              "hG"  'haskell-hoogle-lookup-from-local)
-          (spacemacs/set-leader-keys-for-major-mode mode
-            "gi"  'haskell-navigate-imports
-            "F"   'haskell-mode-stylish-buffer
-
-            "hh"  'hoogle
-            "hG"  'haskell-hoogle-lookup-from-local)))
+          "ri"  spacemacs/haskell-format-imports)
+        '("gl"  haskell-navigate-imports
+          "S"   haskell-mode-stylish-buffer
+          "hg"  hoogle
+          "hG"  haskell-hoogle-lookup-from-local)
+        '("gi"  haskell-navigate-imports
+          "F"   haskell-mode-stylish-buffer
+          "hh"  hoogle
+          "hG"  haskell-hoogle-lookup-from-local))
 
       (evilified-state-evilify haskell-debug-mode haskell-debug-mode-map
         "RET" 'haskell-debug/select


### PR DESCRIPTION
- Labelled `haskell-completion-backend` as safe local variable.
- Added `spacemacs-haskell//setup-binding` to set the binding according to `haskell-completion-backend`
- Added local varible hooks of haskell modes:
  `spacemacs-haskell//setup-binding`

All setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!