### PR TITLE
javascript: Fix local vars

### DIFF
--- a/layers/+lang/javascript/config.el
+++ b/layers/+lang/javascript/config.el
@@ -29,12 +29,20 @@
   "The backend to use for IDE features.
 Possible values are `tern', `tide' and `lsp'.
 If `nil' then `tern' is the default backend unless `lsp' layer is used.")
+;; safe values for backend to be used in directory file variables
+(dolist (value '(lsp tern tide))
+  (add-to-list 'safe-local-variable-values
+               (cons 'javascript-backend value)))
 
 (defvar javascript-fmt-tool 'web-beautify
   "The formatter to format a JavaScript file. Possible values are `web-beautify' and `prettier'.")
+(dolist (value '(web-beautify prettier))
+  (add-to-list 'safe-local-variable-values
+               (cons 'javascript-fmt-tool value)))
 
 (defvar javascript-import-tool nil
   "The import backend to import modules. Possible values are `import-js' and `nil' to disable.")
+(put 'javascript-import-tool 'safe-local-variable #'symbolp)
 
 (defvar javascript-fmt-on-save nil
   "Run formatter on buffer save.")

--- a/layers/+lang/javascript/funcs.el
+++ b/layers/+lang/javascript/funcs.el
@@ -40,6 +40,7 @@
   "Conditionally setup elixir DAP integration."
   ;; currently DAP is only available using LSP
   (when (eq javascript-backend 'lsp)
+    (add-to-list 'spacemacs--dap-supported-modes 'js2-mode)
     (spacemacs//javascript-setup-lsp-dap)))
 
 (defun spacemacs//javascript-setup-next-error-fn ()
@@ -152,3 +153,8 @@
 
 (defun spacemacs/javascript-fmt-before-save-hook ()
   (add-hook 'before-save-hook 'spacemacs/javascript-format t t))
+
+(defun spacemacs//setup-import-js ()
+  "Conditionally enable/disable `import-js` mode."
+  (when (eq javascript-import-tool 'import-js)
+    (add-to-list 'spacemacs--import-js-modes (cons 'js2-mode 'js2-mode-hook))))

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -57,12 +57,10 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'js2-mode))
 
 (defun javascript/pre-init-dap-mode ()
-  (when (eq javascript-backend 'lsp)
-    (add-to-list 'spacemacs--dap-supported-modes 'js2-mode))
   (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-dap))
 
 (defun javascript/post-init-evil-matchit ()
-  (add-hook `js2-mode-hook `turn-on-evil-matchit-mode))
+  (add-hook 'js2-mode-hook 'turn-on-evil-matchit-mode))
 
 (defun javascript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'js2-mode)
@@ -100,8 +98,7 @@
     "I" 'spacemacs/impatient-mode))
 
 (defun javascript/pre-init-import-js ()
-  (when (eq javascript-import-tool 'import-js)
-    (add-to-list 'spacemacs--import-js-modes (cons 'js2-mode 'js2-mode-hook))))
+  (add-hook 'js2-mode-local-vars-hook #'spacemacs//setup-import-js))
 
 (defun javascript/init-js-doc ()
   (use-package js-doc
@@ -113,14 +110,9 @@
   (use-package js2-mode
     :defer t
     :mode (("\\.m?js\\'"  . js2-mode))
-    :init
-    (progn
-      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
-      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-next-error-fn)
-      ;; safe values for backend to be used in directory file variables
-      (dolist (value '(lsp tern tide))
-        (add-to-list 'safe-local-variable-values
-                     (cons 'javascript-backend value))))
+    :hook
+    ((js2-mode-local-vars . spacemacs//javascript-setup-backend)
+     (js2-mode-local-vars . spacemacs//javascript-setup-next-error-fn))
     :config
     (progn
       (when javascript-fmt-on-save


### PR DESCRIPTION
- Labelled `javascript-backend`, `javascript-fmt-tool`, and
  `javascript-import-tool` as safe local variables.
- Added local variable hooks of `js2-mode`:
  - `spacemacs//javascript-setup-import-js`
- Improved `spacemacs//javascript-setup-dap`
- Added `spacemacs//javascript-setup-import-js`

All other setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!