### PR TITLE
json: Fix local vars

### DIFF
--- a/layers/+lang/json/config.el
+++ b/layers/+lang/json/config.el
@@ -25,11 +25,14 @@
 
 (defvar json-fmt-tool 'web-beautify
   "The formatter to format a JSON file. Possible values are `web-beautify' and `prettier'.")
+(put 'json-fmt-tool 'safe-local-variable #'symbolp)
 
 (defvar json-fmt-on-save nil
   "Run formatter on buffer save.")
+(put 'json-fmt-on-save 'safe-local-variable #'symbolp)
 
 (defvar json-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'company-json)
   "The backend to use for IDE features.
 Possible values are `lsp' and `company-json'.
 If `nil' then 'company-json` is the default backend unless `lsp' layer is used")
+(put 'json-backend 'safe-local-variable #'symbolp)

--- a/layers/+lang/json/packages.el
+++ b/layers/+lang/json/packages.el
@@ -34,7 +34,7 @@
         web-beautify))
 
 (defun json/post-init-company ()
-  (spacemacs//json-setup-company))
+  (add-hook 'json-mode-local-vars-hook #'spacemacs//json-setup-company))
 
 (defun json/post-init-add-node-modules-path ()
   (add-hook 'json-mode-hook #'add-node-modules-path))
@@ -45,13 +45,8 @@
 (defun json/init-json-mode ()
   (use-package json-mode
     :defer t
-    :init
-    (progn
-      (unless (eq json-backend 'lsp)
-        (spacemacs/declare-prefix-for-mode 'json-mode "mT" "toggle")
-        (spacemacs/declare-prefix-for-mode 'json-mode "mh" "help")
-        (spacemacs/declare-prefix-for-mode 'json-mode "m=" "format"))
-      (add-hook 'json-mode-hook #'spacemacs//json-setup-backend))))
+    :init (add-hook 'json-mode-local-vars-hook
+                    #'spacemacs//json-setup-backend)))
 
 (defun json/init-json-navigator ()
   (use-package json-navigator
@@ -78,17 +73,9 @@
       "hp" 'jsons-print-path)))
 
 (defun json/pre-init-prettier-js ()
-  (when (eq json-fmt-tool 'prettier)
-    (add-to-list 'spacemacs--prettier-modes 'json-mode)
-    (add-hook 'json-mode-hook #'spacemacs/json-setup-prettier)
-    (when (eq json-fmt-on-save t)
-      (add-hook 'json-mode-hook 'prettier-js-mode))))
+  (add-to-hook 'json-mode-local-vars-hook
+               #'spacemacs//json-setup-formatter))
 
 (defun json/pre-init-web-beautify ()
-  (when (eq json-fmt-tool 'web-beautify)
-    (add-to-list 'spacemacs--web-beautify-modes
-                 (cons 'json-mode 'web-beautify-js))
-    (when (eq json-fmt-on-save t)
-      (add-hook 'json-mode-hook
-                (lambda ()
-                  (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))))
+  (add-to-hook 'json-mode-local-vars-hook
+               #'spacemacs//json-setup-formatter))


### PR DESCRIPTION
- Labelled `json-backend`, `json-fmt-tool`, and `json-format-on-save`
  as safe local variables.
- Added local variable hooks of `json-mode`:
  - `spacemacs//json-setup-company`
  - `spacemacs//json-setup-formatter`
- Improved `spacemacs//json-setup-backend`.
- Added `spacemacs//json-setup-formatter` and
  `spacemacs//json-web-beautify`.
- Improved `spacemacs/json-setup-prettier` and renamed it to
  `spacemacs//json-setup-prettier-js`.

All other setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!