### PR TITLE
kotlin: Fix local vars

### DIFF
--- a/layers/+lang/kotlin/config.el
+++ b/layers/+lang/kotlin/config.el
@@ -29,6 +29,9 @@
   "The backend to use for IDE features.
 Possible values are `lsp' and `company-kotlin'.
 If `nil' then 'company-kotlin` is the default backend unless `lsp' layer is used")
+(dolist (v '(lsp company-kotlin))
+  (add-to-list 'safe-local-variable-values
+               (cons 'kotlin-backend v)))
 
 (defvar kotlin-lsp-jar-path "~/install/server/bin/kotlin-language-server"
   "The path to the lsp jar file")

--- a/layers/+lang/kotlin/funcs.el
+++ b/layers/+lang/kotlin/funcs.el
@@ -28,7 +28,8 @@
   (when (eq kotlin-backend 'lsp)
     (spacemacs|add-company-backends
       :backends company-capf
-      :modes kotlin-mode)))
+      :modes kotlin-mode)
+    (setq lsp-clients-kotlin-server-executable kotlin-lsp-jar-path)))
 
 (defun spacemacs//kotlin-setup-backend ()
   "Conditionally setup kotlin backend."

--- a/layers/+lang/kotlin/packages.el
+++ b/layers/+lang/kotlin/packages.el
@@ -32,7 +32,7 @@
     kotlin-mode))
 
 (defun kotlin/post-init-company ()
-  (spacemacs//kotlin-setup-company))
+  (add-hook 'kotlin-mode-local-vars-hook #'spacemacs//kotlin-setup-company))
 
 (defun kotlin/post-init-flycheck ()
   (spacemacs/enable-flycheck 'kotlin-mode))
@@ -45,10 +45,7 @@
 (defun kotlin/init-kotlin-mode ()
   (use-package kotlin-mode
     :defer t
-    :init
-    (progn
-      (setq lsp-clients-kotlin-server-executable kotlin-lsp-jar-path)
-      (add-hook 'kotlin-mode-hook #'spacemacs//kotlin-setup-backend))))
+    :hook (kotlin-mode-local-vars . spacemacs//kotlin-setup-backend)))
 
 (defun kotlin/post-init-ggtags ()
   (add-hook 'kotlin-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
- Labelled `kotlin-backend` as safe local variable.
- Added local variable hooks of `kotlin-mode`:
  - `spacemacs//kotlin-setup-backend`
  - `spacemacs//kotlin-setup-company`

All setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!