### PR TITLE
lua: Fix local vars

### DIFF
--- a/layers/+lang/lua/config.el
+++ b/layers/+lang/lua/config.el
@@ -29,7 +29,13 @@
   "The backend to use for IDE features.
 Possible values are `lua-mode' and `lsp'.
 If `nil' then `lua-mode' is the default backend unless `lsp' layer is used.")
+(dolist (m '(lsp lua-mode))
+  (add-to-list 'safe-local-variable-values
+               (cons 'lua-backend m)))
 
 (defvar lua-lsp-server 'emmy
   "Language server to use for lsp backend.
 Possible values are `emmy', `lua-language-server', or `lua-lsp'.")
+(dolist (v '(emmy lua-language-server lua-lsp))
+  (add-to-list 'safe-local-variable-values
+               (cons 'lua-lsp-server v)))

--- a/layers/+lang/lua/funcs.el
+++ b/layers/+lang/lua/funcs.el
@@ -38,6 +38,23 @@
        :backends company-capf
        :modes lua-mode))))
 
+(defun spacemacs//lua-setup-binding (common-prefix
+                                     common-binding
+                                     lua-mode-binding)
+  "Conditionally setup prefix and binding."
+  (cl-loop for x on common-prefix
+           by 'cddr
+           do (apply 'spacemacs/declare-prefix-for-mode
+                     'lua-mode
+                     (list (car x) (cadr x))))
+  (apply 'spacemacs/set-leader-keys-for-major-mode
+         'lua-mode common-prefix)
+  (add-hook 'lua-mode-local-vars-hook
+            (lambda ()
+              (when (eq lua-backend 'lua-mode)
+                (apply 'spacemacs/set-leader-keys-for-major-mode
+                       'lua-mode lua-mode-binding)))))
+
 
 ;; LSP Lua
 

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -39,29 +39,28 @@
     :defer t
     :mode ("\\.lua\\'" . lua-mode)
     :interpreter ("lua" . lua-mode)
+    :hook (lua-mode-local-vars . spacemacs//lua-setup-backend)
     :init
     (progn
       (spacemacs/register-repl 'lua #'lua-show-process-buffer "lua")
-      (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-backend)
 
       ;; Set global settings
       (setq lua-indent-level 2
             lua-indent-string-contents t)
 
-      ;; Set general bindings
-      (spacemacs/declare-prefix-for-mode 'lua-mode "ms" "REPL")
-      (spacemacs/set-leader-keys-for-major-mode 'lua-mode
-        "hd" 'lua-search-documentation
-        "sb" 'lua-send-buffer
-        "sf" 'lua-send-defun
-        "sl" 'lua-send-current-line
-        "sr" 'lua-send-region
-        "'" 'lua-show-process-buffer)
-
-      ;; Set lua-mode specific bindings
-      (when (eq lua-backend 'lua-mode)
-        (spacemacs/declare-prefix-for-mode 'lua-mode "mh" "help")
-        (spacemacs/declare-prefix-for-mode 'lua-mode "mg" "goto")))))
+      (spacemacs//lua-setup-binding
+       ;; general prefix
+       '("ms" "REPL")
+       ;; general bindings
+       '("hd" lua-search-documentation
+         "sb" lua-send-buffer
+         "sf" lua-send-defun
+         "sl" lua-send-current-line
+         "sr" lua-send-region
+         "'" lua-show-process-buffer)
+       ;; non-lsp bindings
+       '("mh" "help"
+         "mg" "goto")))))
 
 (defun lua/post-init-company ()
   (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-company))


### PR DESCRIPTION
- Labelled `lua-backend` and `lua-lsp-server`as
  safe local variable.
- Added functions that setup prefix and bindings:
  - `spacmeacs//lua-setup-binding`

All setup functions are already added to local variable hook.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!