### PR TITLE
perl5: Fix local vars

### DIFF
--- a/core/core-spacebind.el
+++ b/core/core-spacebind.el
@@ -24,7 +24,7 @@
 (require 'core-keybindings)
 
 (defvar spacebind--eager-bind t
-  "If true bind keys right after `spacmeacs|spacebind' macro-expanse.
+  "If true bind keys right after `spacemacs|spacebind' macro-expanse.
 Otherwise binding happens at the next event loop.")
 
 ;;;; Binding stacks

--- a/layers/+lang/perl5/config.el
+++ b/layers/+lang/perl5/config.el
@@ -33,3 +33,6 @@
   "The backend to use for IDE features.
 Possible values are `lsp' and `company-plsense'.
 If `nil' then 'company-plsense` is the default backend unless `lsp' layer is used")
+(dolist (v '(lsp company-plsense))
+  (add-to-list 'safe-local-variable-values
+               (cons 'perl5-backend v)))

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -32,12 +32,10 @@
     smartparens))
 
 (defun perl5/pre-init-dap-mode ()
-  (when (eq perl5-backend 'lsp)
-    (add-to-list 'spacemacs--dap-supported-modes 'cperl-mode)
-    (add-hook 'cperl-mode-hook #'dap-mode)))
+  (add-hook 'cperl-mode-local-vars-hook #'spacemacs//perl5-setup-dap))
 
 (defun perl5/post-init-company ()
-  (spacemacs//perl5-setup-company))
+  (add-hook 'cperl-mode-local-vars-hook #'spacemacs//perl5-setup-company))
 
 (defun perl5/init-company-plsense ()
   (use-package company-plsense
@@ -49,89 +47,34 @@
     :mode "\\.\\(p[lm]x?\\|P[LM]X?\\)\\'"
     :interpreter "perl"
     :interpreter "perl5"
-    :init
-    (progn
-      (setq
-       ;; highlight all scalar variables not just the instantiation
-       cperl-highlight-variables-indiscriminately t
-       cperl-indent-level 4        ; 4 spaces is the standard indentation
-       cperl-close-paren-offset -4 ; indent the closing paren back four spaces
-       cperl-continued-statement-offset 4 ; if a statement continues indent it to four spaces
-       cperl-indent-parens-as-block t) ; parentheses are indented with the block and not with scope
-      (add-hook 'cperl-mode-hook #'spacemacs//perl5-setup-backend))
+    :hook (cperl-mode-local-vars . spacemacs//perl5-setup-backend)
+    :custom
+    (cperl-highlight-variables-indiscriminately
+     t "highlight all scalar variables not just the instantiation")
+    (cperl-indent-level 4 "4 spaces is the standard indentation")
+    (cperl-close-paren-offset -4 "indent the closing paren back four spaces")
+    (cperl-continued-statement-offset
+     4 "if a statement continues indent it to four spaces")
+    (cperl-indent-parens-as-block
+     t "parentheses are indented with the block and not with scope")
     :config
     (progn
-      ;; Don't highlight arrays and hashes in comments
-      (font-lock-remove-keywords
-       'cperl-mode
-       '(("\\(\\([@%]\\|\\$#\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)" 1
-          (if (eq (char-after (match-beginning 2)) 37)
-              'cperl-hash-face 'cperl-array-face) t)
-         ("\\(\\([$@]+\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)[ \t]*\\([[{]\\)" 1
-          (if (= (- (match-end 2) (match-beginning 2)) 1)
-              (if (eq (char-after (match-beginning 3)) 123)
-                  'cperl-hash-face 'cperl-array-face)
-            font-lock-variable-name-face) t)
-         ("\\([]}\\\\%@>*&]\\|\\$[a-zA-Z0-9_:]*\\)[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}"
-          (2 font-lock-string-face t)
-          ("\\=[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}" nil nil
-           (1 font-lock-string-face t)))
-         ("[[ \t{,(]\\(-?[a-zA-Z0-9_:]+\\)[ \t]*=>" 1 font-lock-string-face t)))
-
-      (font-lock-add-keywords
-       'cperl-mode
-       '(("\\(\\([@%]\\|\\$#\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)" 1
-          (if (nth 4 (syntax-ppss))
-              'font-lock-comment-face
-            (if (eq (char-after (match-beginning 2)) ?%)
-                'cperl-hash-face
-              'cperl-array-face)) t)
-         ("\\(\\([$@]+\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)[ \t]*\\([[{]\\)" 1
-          (if (nth 4 (syntax-ppss))
-              'font-lock-comment-face
-            (if (= (- (match-end 2) (match-beginning 2)) 1)
-                (if (eq (char-after (match-beginning 3)) ?{)
-                    'cperl-hash-face
-                  'cperl-array-face)
-              font-lock-variable-name-face)) t)
-         ("\\([]}\\\\%@>*&]\\|\\$[a-zA-Z0-9_:]*\\)[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}"
-          (2 (if (nth 4 (syntax-ppss))
-                 'font-lock-comment-face
-               'font-lock-string-face) t)
-          ("\\=[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}" nil nil
-           (1 (if (nth 4 (syntax-ppss))
-                  'font-lock-comment-face
-                'font-lock-string-face) t)))
-         ("[[ \t{,(]\\(-?[a-zA-Z0-9_:]+\\)[ \t]*=>" 1
-          (if (nth 4 (syntax-ppss))
-              'font-lock-comment-face
-            'font-lock-string-face) t)))
-
-      ;; Use less horrible colors for cperl arrays and hashes
-      (set-face-attribute 'cperl-array-face nil
-                          :foreground  "#DD7D0A"
-                          :background  'unspecified
-                          :weight 'unspecified)
-      (set-face-attribute 'cperl-hash-face nil
-                          :foreground "OrangeRed3"
-                          :background 'unspecified
-                          :weight 'unspecified)
-
       ;; tab key will ident all marked code when tab key is pressed
       (add-hook 'cperl-mode-hook
                 (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
 
-      (unless (eq perl5-backend 'lsp)
-        (spacemacs/declare-prefix-for-mode 'cperl-mode "m=" "format")
-        (spacemacs/declare-prefix-for-mode 'cperl-mode "mg" "find-symbol")
-        (spacemacs/declare-prefix-for-mode 'cperl-mode "mh" "perldoc"))
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode
-        "hh" 'cperl-perldoc-at-point
-        "==" 'spacemacs/perltidy-format
-        "=b" 'spacemacs/perltidy-format-buffer
-        "=f" 'spacemacs/perltidy-format-function
-        "hd" 'cperl-perldoc
-        "v" 'cperl-select-this-pod-or-here-doc)
+      (spacemacs//perl5-setup-binding
+       ;; general bindings
+       '("hh" 'cperl-perldoc-at-point
+         "==" 'spacemacs/perltidy-format
+         "=b" 'spacemacs/perltidy-format-buffer
+         "=f" 'spacemacs/perltidy-format-function
+         "hd" 'cperl-perldoc
+         "v" 'cperl-select-this-pod-or-here-doc)
+        ;; non-lsp prefix
+        '("m=" "format"
+          "mg" "find-symbol"
+          "mh" "perldoc"))
 
       (font-lock-add-keywords 'cperl-mode
                               '(("\\_<say\\_>" . cperl-nonoverridable-face))))))


### PR DESCRIPTION
- Fixed a typo in `core-spacebind`
- Labelled `perl5-backend` as safe local variable.
- Added local variable hooks of `perl5-mode`:
  - `spacemacs//perl5-setup-backend`
  - `spacemacs//perl5-setup-company`
  - `spacemacs//perl5-setup-dap`
- Added functions that setup prefix and bindings:
  - `spacmeacs//perl5-setup-binding`
- Moved a ugly chunk of regex to func.el. At the bottom.

See: https://github.com/syl20bnr/spacemacs/issues/14653

-------

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!