### PR TITLE
configure racket-describe-mode keybindings

### DIFF
--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -70,6 +70,9 @@
       (add-hook 'racket-mode-hook 'racket-xp-mode))
     :config
     (progn
+      (add-to-list 'evil-evilified-state-modes 'racket-describe-mode)
+      (evil-define-key 'evilified 'racket-describe-mode-map
+        "o" 'link-hint-open-link)
       ;; smartparens configuration
       (with-eval-after-load 'smartparens
         (add-to-list 'sp--lisp-modes 'racket-mode)


### PR DESCRIPTION
`racket-describe-mode` is a read-only mode that comes with its own keybinding (i.e. `q` for quit).
To make those keybindings available, this PR makes the mode open in evilified state.
Additionally, it contains links, so this PR binds `o` to `link-hint-open-link`
(`ace-link` does not support this mode)