### PR TITLE
Fix eslint not available for typescript-tsx-mode

### DIFF
--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -70,16 +70,15 @@
 
 (defun typescript/set-lsp-linter ()
   (with-eval-after-load 'lsp-ui
-    (with-eval-after-load 'lsp
-      (with-eval-after-load 'flycheck
-        (pcase typescript-linter
-          ('tslint (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))
-          ;; This sets tslint unconditionally for all lsp clients which is wrong
-          ;; Must be set for respective modes only, see go layer for examples.
-          ('eslint (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
-                   (flycheck-add-mode 'javascript-eslint 'typescript-mode))
-          (_ (message
-              "Invalid typescript-layer configuration, no such linter: %s" typescript-linter)))))))
+    (with-eval-after-load 'flycheck
+      (pcase typescript-linter
+        ('tslint (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))
+        ;; This sets tslint unconditionally for all lsp clients which is wrong
+        ;; Must be set for respective modes only, see go layer for examples.
+        ('eslint (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
+                 (flycheck-add-mode 'javascript-eslint 'typescript-mode))
+        (_ (message
+            "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))))
 
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)


### PR DESCRIPTION
The bug is that when using the following typescript layer configuration, flycheck doesn't have any checker available in typescript-tsx-mode.
```emacs-lisp
  (typescript :variables
              typescript-backend 'lsp
              typescript-linter 'eslint
              typescript-lsp-linter nil)
```


The root cause is that the `(pcase ...)` code, in typescript/packages.el, never got executed . Removing the surrounding `(with-eval-after-load 'lsp` fixes it. 

Given  `(pcase ..)` never executed, typescript-mode still have some flycheck checkers available because flycheck has eslint configured for typescript-mode by default, see flycheck.el line [9773](https://github.com/flycheck/flycheck/blob/f8c679fff349850c80541a31de50009c3c15d4c9/flycheck.el#L9773) and line [12254](https://github.com/flycheck/flycheck/blob/f8c679fff349850c80541a31de50009c3c15d4c9/flycheck.el#L12254). So the bug is not reproducible in typescript-mode.

Using lsp as checker still work after removing `(with-eval-after-load 'lsp` in this PR, because lsp for checker is turned on in typescript/funcs.el line [52](https://github.com/syl20bnr/spacemacs/blob/b1f54b337109dd6988b102de59d43e71641f5c34/layers/+lang/typescript/funcs.el#L52).