### PR TITLE
Add support for org-roam-protocol

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -3954,6 +3954,7 @@ Improve loading robustness:
   (thanks to TheBB)
 + Fix org-repo-todo loading (thanks to TheBB)
 + Add =org-roam-server= package to visualise a =org-roam= database (thanks to KjartanOli)
++ Add =org-roam-protocol= support (thanks to KjartanOli)
 
 **** Osx
 - Re-factor and expand support for trash can (thanks to usharf)

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -27,6 +27,7 @@
   - [[#org-brain-support][Org-brain support]]
   - [[#org-roam-support][Org-roam support]]
     - [[#org-roam-server-support][Org-roam-server support]]
+    - [[#org-roam-protocol-support][Org-roam-protocol support]]
   - [[#mode-line-support][Mode line support]]
   - [[#sticky-header-support][Sticky header support]]
   - [[#epub-support][Epub support]]
@@ -422,6 +423,18 @@ More information about org-roam package (including manual) can be found at [[htt
 *** Org-roam-server support
 To install support for [[https://github.com/org-roam/org-roam-server][org-roam-server]] set the variable =org-enable-roam-server=
 to =t=.
+
+*** Org-roam-protocol support
+To enable support for [[https://www.orgroam.com/manual.html#Roam-Protocol][Org Roam Protocol]] set the variable
+=org-enable-roam-protocol= to =t=.
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-roam-protocol t)))
+#+end_src
+
+And create a desktop file as described in the [[https://www.orgroam.com/manual.html#Roam-Protocol][org-roam manual]].
 
 ** Mode line support
 To temporarily enable mode line display of org clock, press ~SPC t m c~.

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -94,4 +94,7 @@ ATTENTION: `valign-mode' will be laggy working with tables contain more than 100
   "If non-nil, enable org-appear in org-mode buffers.")
 
 (defvar org-enable-roam-server nil
-  "if non-nil, enable org-roam-server support")
+  "If non-nil, enable org-roam-server support")
+
+(defvar org-enable-roam-protocol nil
+  "If non-nil, enable org-roam-protocol (https://www.orgroam.com/manual.html#Roam-Protocol)")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -951,7 +951,10 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "ra" 'org-roam-alias-add))
     :config
     (progn
-      (spacemacs|hide-lighter org-roam-mode))))
+      (spacemacs|hide-lighter org-roam-mode)
+      (when org-enable-roam-protocol
+          (add-hook 'org-roam-mode-hook (lambda ()
+                                          (require 'org-roam-protocol)))))))
 
 (defun org/init-org-sticky-header ()
   (use-package org-sticky-header


### PR DESCRIPTION
Org-Roam provides org-roam-protocol, a feature that allows the graphs generated by `org-roam-graph` and org-roam-server to contain cilckable links, which open the corresponding  org-roam file.