### PR TITLE
Replace function aliases with their real names

### DIFF
--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -58,4 +58,4 @@ Can show completions at point for COMMAND using helm"
 
 ;; Other utilities
 (defun exwm//flatenum (i ls)
-  (if ls (cons i (cons (first ls) (exwm//flatenum  (1+ i) (cdr ls)))) (list)))
+  (if ls (cons i (cons (car ls) (exwm//flatenum  (1+ i) (cdr ls)))) (list)))

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -71,8 +71,8 @@
     ;; At the user's option, begin with even more workspaces
     (setq exwm-workspace-number
           (if exwm-workspace-number
-              (max exwm-workspace-number (list-length exwm--randr-displays))
-              (list-length exwm--randr-displays)))
+              (max exwm-workspace-number (length exwm--randr-displays))
+              (length exwm--randr-displays)))
     ;; The first workspaces will match the order in RandR
     (setq exwm-randr-workspace-output-plist
           (exwm//flatenum 0 exwm--randr-displays))


### PR DESCRIPTION
`first` and `list-length` are aliases for `car` and `cl-list-length`
respectively. Using these aliases causes emacs to error with a `symbol's function
definition is void` error, but using their real names causes no error.

