### PR TITLE
Added asciidoc support.

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -34,6 +34,7 @@
   - [[#valign-support][Valign support]]
   - [[#org-appear-support][Org-appear support]]
   - [[#verb-support][Verb support]]
+  - [[#asciidoc-support][AsciiDoc support]]
   - [[#spacemacs-layout-integration][Spacemacs layout integration]]
 - [[#key-bindings][Key bindings]]
   - [[#starting-org-mode][Starting org-mode]]
@@ -498,6 +499,15 @@ To install [[https://github.com/federicotdn/verb][Verb]], an HTTP client based o
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
    '((org :variables org-enable-verb-support t)))
+#+END_SRC
+
+** AsciiDoc support
+To install Org exporter [[https://github.com/yashi/org-asciidoc][ox-asciidoc]], that generates AsciiDoc documents, set the
+variable =org-enable-asciidoc-support= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((org :variables org-enable-asciidoc-support t)))
 #+END_SRC
 
 ** Spacemacs layout integration

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -95,3 +95,6 @@ ATTENTION: `valign-mode' will be laggy working with tables contain more than 100
 
 (defvar org-enable-roam-server nil
   "if non-nil, enable org-roam-server support")
+
+(defvar org-enable-asciidoc-support nil
+  "If non-nil, enable ox-asciidoc.")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -70,7 +70,8 @@
     (org-roam :toggle org-enable-roam-support)
     (valign :toggle org-enable-valign)
     (org-appear :toggle org-enable-appear-support)
-    (org-roam-server :require org-roam :toggle org-enable-roam-server)))
+    (org-roam-server :require org-roam :toggle org-enable-roam-server)
+    (ox-asciidoc :toggle org-enable-asciidoc-support)))
 
 (defun org/post-init-company ()
   (spacemacs|add-company-backends :backends company-capf :modes org-mode))
@@ -1016,3 +1017,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
     (progn
       (spacemacs/set-leader-keys "aors" 'org-roam-server-mode)
       (spacemacs/set-leader-keys-for-major-mode 'org-mode "rs" 'org-roam-server-mode))))
+
+(defun org/init-ox-asciidoc ()
+  (use-package ox-asciidoc
+    :after ox
+    :defer t))


### PR DESCRIPTION
You can now export org files as AsciiDoc documents.
Use org-export-dispatch (`C-c C-e` or `SPC e e`) to see options for exporting to AsciiDoc.

```emacs-lisp
(setq-default dotspacemacs-configuration-layers '(
  (org :variables
       org-enable-asciidoc-support t)))
```

Also I don't want credit, so I didn't update the changelog.