### PR TITLE
fixed asciidoc export

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3005,6 +3005,7 @@ files (thanks to Daniel Nicolai)
 - Implemented automatic activation of evil insert state after
   =org-insert-drawer=, =org-insert-heading=, =org-insert-item= and
   =org-insert-structure-template= commands (thanks to Andriy Kmit')
+- Added =ox-asciidoc= as org export backend (thanks to Christian "West" Westrom)
 **** Osx
 - Key bindings:
   - Added key bindings to use ~command-1..9~ for selecting window

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -1023,5 +1023,4 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
 (defun org/init-ox-asciidoc ()
   (use-package ox-asciidoc
-    :after ox
-    :defer t))
+    :after ox))


### PR DESCRIPTION
Fixed ox-asciidoc as per issue #14695
I just deleted one line, tested it, and it works again.