### PR TITLE
[core] Fix 'append nesting in transient-state-format-hint macro

### DIFF
--- a/core/core-transient-state.el
+++ b/core/core-transient-state.el
@@ -118,8 +118,8 @@ effect if called after that point."
                                :columns ,prop-columns
                                :foreign-keys ,prop-foreign-keys
                                :body-pre ,prop-entry-sexp
-                               :before-exit ,prop-exit-sexp)))
-                 'append))))
+                               :before-exit ,prop-exit-sexp)))))
+             'append))
 
 (defface spacemacs-transient-state-title-face
   `((t :inherit mode-line))


### PR DESCRIPTION
See comment: https://github.com/syl20bnr/spacemacs/commit/bfec25422108952598010a50babb87565f9ba935#r49828503