### PR TITLE
[documentation]: Improved core-load-paths and core-versions

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -118,21 +118,20 @@
 
 ;;;; Load Paths
 
-(defun add-to-load-path (dir)
+(defun spacemacs//add-to-load-path (dir)
   "Prepend DIR to `load-path'."
   (add-to-list 'load-path dir))
 
 ;; FIXME: unused function (Apr 25 2021 Lucius)
-(defun add-to-load-path-if-exists (dir)
+(defun spacemacs//add-to-load-path-if-exists (dir)
   "If DIR exists in the file system, prepend it to `load-path'."
   (when (file-exists-p dir)
-    (add-to-load-path dir)))
+    (spacemacs//add-to-load-path dir)))
 
 (dolist (suffix '(nil "libs/" "libs/spacemacs-theme/" "libs/forks"))
-  (add-to-load-path (concat spacemacs-core-directory suffix)))
+  (spacemacs//add-to-load-path (concat spacemacs-core-directory suffix)))
 
 ;;;; Themes
-
 (add-to-list 'custom-theme-load-path (concat spacemacs-core-directory
                                              "libs/spacemacs-theme/"))
 

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -1,4 +1,4 @@
-;;; core-load-paths.el --- Spacemacs Core File  -*- no-byte-compile: t -*-
+;;; core-load-paths.el --- Spacemacs Core File  -*- no-byte-compile: t; lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;
@@ -21,6 +21,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+;;
 ;;    Define various PATH variables, and set up load path.
 
 ;;; Code:
@@ -117,6 +118,7 @@
 (setq pcache-directory (concat spacemacs-cache-directory "pcache/"))
 
 ;;;; Load Paths
+;; TODO: Since these functions are not called anywhere, consider to inline them (Apr 27 2021 Lucius)
 
 (defun spacemacs//add-to-load-path (dir)
   "Prepend DIR to `load-path'."

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -29,7 +29,7 @@
 
 (defconst user-home-directory
   (expand-file-name "~/")
-  "User home directory (~/).")
+  "User home directory (default ~/).")
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
@@ -110,6 +110,7 @@
 
 ;;;; Setup cache directories
 
+;; TODO: Should also catch any IO error such as permission error (Apr 25 2021 Lucius)
 (unless (file-exists-p spacemacs-cache-directory)
   (make-directory spacemacs-cache-directory))
 
@@ -121,6 +122,7 @@
   "Prepend DIR to `load-path'."
   (add-to-list 'load-path dir))
 
+;; FIXME: unused function (Apr 25 2021 Lucius)
 (defun add-to-load-path-if-exists (dir)
   "If DIR exists in the file system, prepend it to `load-path'."
   (when (file-exists-p dir)

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -20,83 +20,119 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(defun add-to-load-path (dir) (add-to-list 'load-path dir))
+;;; Commentary:
+;;    Define various PATH variables, and set up load path.
 
-(defun add-to-load-path-if-exists (dir)
-  "If DIR exists in the file system, add it to `load-path'."
-  (when (file-exists-p dir)
-      (add-to-load-path dir)))
+;;; Code:
 
-;; paths
-(defvar spacemacs-start-directory
-  user-emacs-directory
-  "Spacemacs start directory.")
-(defconst spacemacs-core-directory
-  (expand-file-name (concat spacemacs-start-directory "core/"))
-  "Spacemacs core directory.")
-(defconst spacemacs-private-directory
-  (expand-file-name (concat spacemacs-start-directory "private/"))
-  "Spacemacs private directory.")
-(defconst spacemacs-info-directory
-  (expand-file-name (concat spacemacs-core-directory "info/"))
-  "Spacemacs info files directory")
-(defconst spacemacs-release-notes-directory
-  (expand-file-name (concat spacemacs-info-directory "release-notes/"))
-  "Spacemacs release notes directory")
-(defconst spacemacs-banner-directory
-  (expand-file-name (concat spacemacs-core-directory "banners/"))
-  "Spacemacs banners directory.")
-(defconst spacemacs-banner-official-png
-  (expand-file-name (concat spacemacs-banner-directory "img/spacemacs.png"))
-  "Spacemacs official banner image.")
-(defconst spacemacs-badge-official-png
-  (expand-file-name (concat spacemacs-banner-directory
-                            "img/spacemacs-badge.png"))
-  "Spacemacs official badge image.")
-(defconst spacemacs-purple-heart-png
-  (expand-file-name (concat spacemacs-banner-directory "img/heart.png"))
-  "Purple heart emoji.")
-(defconst spacemacs-gplv3-official-png
-  (expand-file-name (concat spacemacs-banner-directory "img/gplv3.png"))
-  "GPLv3 official badge image.")
-(defconst spacemacs-cache-directory
-  (expand-file-name (concat user-emacs-directory ".cache/"))
-  "Spacemacs storage area for persistent files")
-(defconst spacemacs-auto-save-directory
-  (expand-file-name (concat spacemacs-cache-directory "auto-save/"))
-  "Spacemacs auto-save directory")
-(defconst spacemacs-docs-directory
-  (expand-file-name (concat spacemacs-start-directory "doc/"))
-  "Spacemacs documentation directory.")
-(defconst spacemacs-news-directory
-  (expand-file-name (concat spacemacs-start-directory "news/"))
-  "Spacemacs News directory.")
-(defconst spacemacs-assets-directory
-  (expand-file-name (concat spacemacs-start-directory "assets/"))
-  "Spacemacs assets directory.")
-(defconst spacemacs-test-directory
-  (expand-file-name (concat spacemacs-start-directory "tests/"))
-  "Spacemacs tests directory.")
+;;;; PATH variables/constants
 
 (defconst user-home-directory
   (expand-file-name "~/")
   "User home directory (~/).")
-(defconst pcache-directory
-  (concat spacemacs-cache-directory "pcache/"))
+
+;; ~/.emacs.d
+(defvar spacemacs-start-directory
+  (expand-file-name user-emacs-directory)
+  "Spacemacs start directory.")
+
+;; ~/.emacs.d/assets
+(defconst spacemacs-assets-directory
+  (concat spacemacs-start-directory "assets/")
+  "Spacemacs assets directory.")
+
+;; ~/.emacs.d/core
+(defconst spacemacs-core-directory
+  (concat spacemacs-start-directory "core/")
+  "Spacemacs core directory.")
+
+;; ~/.emacs.d/core/banners
+(defconst spacemacs-banner-directory
+  (concat spacemacs-core-directory "banners/")
+  "Spacemacs banners directory.")
+
+(defconst spacemacs-banner-official-png
+  (concat spacemacs-banner-directory "img/spacemacs.png")
+  "Spacemacs official banner image.")
+
+(defconst spacemacs-badge-official-png
+  (concat spacemacs-banner-directory "img/spacemacs-badge.png")
+  "Spacemacs official badge image.")
+
+(defconst spacemacs-purple-heart-png
+  (concat spacemacs-banner-directory "img/heart.png")
+  "Purple heart emoji.")
+
+(defconst spacemacs-gplv3-official-png
+  (concat spacemacs-banner-directory "img/gplv3.png")
+  "GPLv3 official badge image.")
+
+;; ~/.emacs.d/core/info
+(defconst spacemacs-info-directory
+  (concat spacemacs-core-directory "info/")
+  "Spacemacs info files directory.")
+
+;; ~/.emacs.d/core/info/release-notes
+(defconst spacemacs-release-notes-directory
+  (concat spacemacs-info-directory "release-notes/")
+  "Spacemacs release notes directory.")
+
+;; ~/.emacs.d/doc
+(defconst spacemacs-docs-directory
+  (concat spacemacs-start-directory "doc/")
+  "Spacemacs documentation directory.")
+
+;; ~/.emacs.d/news
+(defconst spacemacs-news-directory
+  (concat spacemacs-start-directory "news/")
+  "Spacemacs News directory.")
+
+;; ~/.emacs.d/private
+(defconst spacemacs-private-directory
+  (concat spacemacs-start-directory "private/")
+  "Spacemacs private directory.")
+
+;; ~/.emacs.d/tests
+(defconst spacemacs-test-directory
+  (concat spacemacs-start-directory "tests/")
+  "Spacemacs tests directory.")
+
+;; ~/.emacs.d/.cache
+(defconst spacemacs-cache-directory
+  (concat user-emacs-directory ".cache/")
+  "Spacemacs storage area for persistent files.")
+
+;; ~/.emacs.d/.cache/auto-save
+(defconst spacemacs-auto-save-directory
+  (concat spacemacs-cache-directory "auto-save/")
+  "Spacemacs auto-save directory.")
+
+
+;;;; Setup cache directories
+
 (unless (file-exists-p spacemacs-cache-directory)
-    (make-directory spacemacs-cache-directory))
+  (make-directory spacemacs-cache-directory))
 
-;; load paths
-(mapc 'add-to-load-path
-      `(
-        ,spacemacs-core-directory
-        ,(concat spacemacs-core-directory "libs/")
-        ,(concat spacemacs-core-directory "libs/spacemacs-theme/")
-        ,(concat spacemacs-core-directory "libs/forks/")
-        ;; ,(concat spacemacs-core-directory "aprilfool/")
-        ))
+(setq pcache-directory (concat spacemacs-cache-directory "pcache/"))
+
+;;;; Load Paths
 
-;; themes
+(defun add-to-load-path (dir)
+  "Prepend DIR to `load-path'."
+  (add-to-list 'load-path dir))
+
+(defun add-to-load-path-if-exists (dir)
+  "If DIR exists in the file system, prepend it to `load-path'."
+  (when (file-exists-p dir)
+    (add-to-load-path dir)))
+
+(dolist (suffix '(nil "libs/" "libs/spacemacs-theme/" "libs/forks"))
+  (add-to-load-path (concat spacemacs-core-directory suffix)))
+
+;;;; Themes
+
 (add-to-list 'custom-theme-load-path (concat spacemacs-core-directory
                                              "libs/spacemacs-theme/"))
 
+(provide 'core-load-paths)
+;;; core-load-paths.el ends here

--- a/core/core-versions.el
+++ b/core/core-versions.el
@@ -1,4 +1,4 @@
-;;; core-versions.el --- Spacemacs Core File
+;;; core-versions.el --- Spacemacs Core File  -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-versions.el
+++ b/core/core-versions.el
@@ -20,6 +20,14 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Commentary:
+;;
+;;    Define Spacemacs version and minimum supported Emacs version.
+
+;;; Code:
 
 (defconst spacemacs-version          "0.300.0" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "25.1" "Minimal version of Emacs.")
+
+(provide 'core-versions)
+;;; core-versions.el ends here


### PR DESCRIPTION
- Conform to standard ELISP file practice.
- Rearranged the top-level forms s.t. Variables and constants are declared at top.
- Added section markers and documentations.
  - Use three or more `;` as a section header. They work well with built-in outline-mode. `M-j` and `M-k` is the binding to quickly navigate between them.
  - Optionally use `^L` (form-feed) as a divider for the ELISP file. It's rendered as a horizontal divider. And it works with `backward-page` (`C-x [`) and `forward-page` (`C-x ]`)
