### PR TITLE
Use timeclock-mode-line-display in default bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -124,6 +124,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
     state (thanks to Sylvain Benner)
   - Restricted ~SPC b C-d~ to only kill other buffers in current perspective
     (thanks to Seong Yong-ju)
+  - Changed ~SPC t t m~ from ~timeclock-modeline-display~ which was deprecated 
+    in Emacs 24.3 to ~timeclock-mode-line-display~ (thanks to Zach Pearson)
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -608,7 +608,7 @@ respond to this toggle."
   "ttg" 'timeclock-workday-remaining-string
   "tti" 'timeclock-in
   "ttl" 'timeclock-when-to-leave-string
-  "ttm" 'timeclock-modeline-display
+  "ttm" 'timeclock-mode-line-display
   "tto" 'timeclock-out
   "ttr" 'timeclock-reread-log
   "tts" 'timeclock-status-string


### PR DESCRIPTION
Currently, if a user tries to use the 'ttm' key combination and their
emacs version is >24.3, timeclock-mode complains that
timeclock-modeline-display is deprecated. Spacemacs itself has
deprecated support for Emacs < 25.1 per CHANGELOG.develop. This commit
thus calls the new function without checking emacs-version for versions
for which the old function should be called.
