### PR TITLE
SpacemacsOS: provide new layer variables for systray and autostart

### DIFF
--- a/layers/+window-management/exwm/README.org
+++ b/layers/+window-management/exwm/README.org
@@ -11,7 +11,8 @@
   - [[#note-about-display-managers][Note about Display Managers]]
   - [[#not-having-display-managers][Not having Display Managers]]
   - [[#osx][OSX]]
-  - [[#autostart][Autostart]]
+  - [[#system-tray-integratios][System Tray Integratios]]
+  - [[#xdg-autostart][XDG Autostart]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -60,13 +61,16 @@ details.
 If you are an OSX user, please report back on whether this works with xQuartz,
 always back up your data before attempting to try stuff like this.
 
-** Autostart
-If ~exwm-autostart-xdg-applications~ is non-nil, ~.desktop~ files in
-=$XDG_CONFIG_HOME/autostart= and ~XDG_CONFIG_DIRS~ will be used to run applications at
+** System Tray Integratios
+To enable system tray integration, set =exwm-enable-systray= to =t=.
+
+** XDG Autostart
+If =exwm-autostart-xdg-applications= is non-nil, =.desktop= files in
+=$XDG_CONFIG_HOME/autostart= and =XDG_CONFIG_DIRS= will be used to run applications at
 startup. (See [[https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html][Specification]] for details).
 
 For the purpose of controlling whether an entry should be run under SpacemacsOS,
-the ~OnlyShowIn~ and ~NotShotIn~ keys are checked for the string ~EXWM~.
+the =OnlyShowIn= and =NotShotIn= keys are checked for the string =EXWM=.
 
 This is disabled per default.
 

--- a/layers/+window-management/exwm/README.org
+++ b/layers/+window-management/exwm/README.org
@@ -11,6 +11,7 @@
   - [[#note-about-display-managers][Note about Display Managers]]
   - [[#not-having-display-managers][Not having Display Managers]]
   - [[#osx][OSX]]
+  - [[#autostart][Autostart]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -58,6 +59,16 @@ details.
 ** OSX
 If you are an OSX user, please report back on whether this works with xQuartz,
 always back up your data before attempting to try stuff like this.
+
+** Autostart
+If ~exwm-autostart-xdg-applications~ is non-nil, ~.desktop~ files in
+=$XDG_CONFIG_HOME/autostart= and ~XDG_CONFIG_DIRS~ will be used to run applications at
+startup. (See [[https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html][Specification]] for details).
+
+For the purpose of controlling whether an entry should be run under SpacemacsOS,
+the ~OnlyShowIn~ and ~NotShotIn~ keys are checked for the string ~EXWM~.
+
+This is disabled per default.
 
 * Key bindings
 As other window managers the ~s~ or *Super* key (Windows Key) is the one that

--- a/layers/+window-management/exwm/config.el
+++ b/layers/+window-management/exwm/config.el
@@ -32,6 +32,15 @@
 (defvar exwm-leader-key nil
   "Key to use for EXWM global commands")
 
+(defvar exwm-enable-systray nil
+  "Whether to enable EXWM's bundled system tray implementation.")
+
+(defvar exwm-autostart-xdg-applications nil
+  "Whether to run $XDG_USER_HOME/autostart applications after initialization.")
+
+(defvar exwm-custom-init nil
+  "This can be set to a function that runs after all other EXWM initialization.")
+
 (defvar exwm-workspace-switch-wrap t
   "Whether `exwm/exwm-workspace-next' and `exwm/exwm-workspace-prev' should wrap.")
 

--- a/layers/+window-management/exwm/config.el
+++ b/layers/+window-management/exwm/config.el
@@ -33,16 +33,17 @@
   "Key to use for EXWM global commands")
 
 (defvar exwm-enable-systray nil
-  "Whether to enable EXWM's bundled system tray implementation.")
+  "When non-nil, enable system tray integration for EXWM.")
 
 (defvar exwm-autostart-xdg-applications nil
-  "Whether to run $XDG_USER_HOME/autostart applications after initialization.")
-
-(defvar exwm-custom-init nil
-  "This can be set to a function that runs after all other EXWM initialization.")
+  "When non-nil, autostart applications in  $XDG_USER_HOME/autostart directory.")
 
 (defvar exwm-workspace-switch-wrap t
-  "Whether `exwm/exwm-workspace-next' and `exwm/exwm-workspace-prev' should wrap.")
+  "When non-nil, `exwm/exwm-workspace-next' and `exwm/exwm-workspace-prev' should wrap.")
+
+(defvar exwm-autostart-process-list nil
+  "List of processes to run during autostart.
+This is a list of strings used as shell commands.")
 
 (defvar exwm-workspace-number nil
   "Number of workspaces. Defaults to the number of connected displays if `nil'.")

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -78,6 +78,68 @@ Can show completions at point for COMMAND using helm"
   (interactive)
   (start-process "" nil exwm-locking-command))
 
+
+(defvar exwm//autostart-process-list nil
+  "List of processes run during autostart.")
+
+(defun exwm/autostart-process (name command &optional directory)
+  "Can be used during initialization to run COMMAND as a process
+  with NAME and add it to the list of autostarted processes.
+
+DIRECTORY can be set to a string which will be used as working directory for the
+process.  If not supplied, will be set to `user-home-directory'.
+"
+  (push (let ((default-directory (or directory user-home-directory)))
+          (start-process-shell-command name nil command))
+        exwm//autostart-process-list))
+
+(defun exwm//start-desktop-application (basename xdg)
+  "Autostart an application from a XDG desktop entry specification."
+  (let* ((type (gethash "Type" xdg))
+         ;; (name (gethash "Name" xdg))
+         (cmd (gethash "Exec" xdg))
+         (hidden (gethash "Hidden" xdg))
+         (include (gethash "OnlyShowIn" xdg))
+         (exclude (gethash "NotShowIn" xdg))
+         (try-exec (gethash "TryExec" xdg))
+         (exec-directory (gethash "Path" xdg))
+         ;; (dbus-p (gethash "DBusActivatable" xdg)) ; TODO: support
+         (included-p (cond (include (member "EXWM" (split-string include ";" t)))
+                           (exclude (not (member "EXWM" (split-string exclude ";" t))))
+                           (t)))
+         (should-exec-p (and
+                         (string= type "Application")
+                         included-p
+                         (if try-exec
+                             (executable-find try-exec)
+                           t))))
+    (when should-exec-p (exwm/autostart-process basename cmd exec-directory))))
+
+(defun exwm//read-xdg-autostart-files ()
+  "Return a hashtable for autostart applications as defined by the freedesktop specification."
+  (cl-loop with xdg-specs = (make-hash-table :test 'equal)
+           for dir in (append (xdg-config-dirs) (list (xdg-config-home)))
+           for autostart-dir = (expand-file-name "autostart/" dir)
+           for autostart-files = (when (file-exists-p autostart-dir)
+                                   (directory-files autostart-dir t (rx (1+ word) ".desktop")))
+           do
+           (cl-loop for file in autostart-files do
+                    (setf (gethash (file-name-base file) xdg-specs) (xdg-desktop-read-file file)))
+           finally (return xdg-specs)))
+
+(defun exwm//autostart-xdg-applications ()
+  "Run the autostart applications as defined by the freedesktop autostart specification."
+  (unless exwm//autostart-process-list
+    (cl-loop for basename being the hash-keys of
+             (exwm//read-xdg-autostart-files)
+             using (hash-values xdg) do
+             (exwm//start-desktop-application basename xdg))))
+
+(defun exwm//kill-autostart-processes ()
+  (cl-loop for p in exwm//autostart-process-list do
+           (when (process-live-p p) (kill-process p)))
+  (setq exwm//autostart-process-list nil))
+
 ;; Other utilities
 (defun exwm//flatenum (i ls)
   (if ls (cons i (cons (car ls) (exwm//flatenum  (1+ i) (cdr ls)))) (list)))

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -31,12 +31,15 @@
       (exwm :location (recipe :fetcher github
                               :repo "ch11ng/exwm")
             :step pre)
+      (xdg :location built-in)
       (desktop-environment
        :location (recipe :fetcher github
-                         :repo "DamienCassou/desktop-environment"
-                         :upgrade t
-                         :commit "cd5145288944f4bbd7b2459e4b55a6a95e37f06d"))))
+                         :repo "DamienCassou/desktop-environment"))))
 
+(defun exwm/init-xdg ()
+  (use-package xdg
+    :defer t
+    :commands (xdg-config-dirs xdg-config-home xdg-desktop-read-file)))
 
 (defun exwm/init-desktop-environment ()
   (use-package desktop-environment
@@ -213,8 +216,6 @@
       (exwm-systemtray-enable))
     (when exwm-autostart-xdg-applications
       (add-hook 'exwm-init-hook 'exwm//autostart-xdg-applications t))
-    (when exwm-custom-init
-      (add-hook 'exwm-init-hook exwm-custom-init t))
 
     (if exwm-randr-command
      (start-process-shell-command


### PR DESCRIPTION
I'm not sure how best to start doing this, but the branch over at
timor:spacemacsOS has moved ahead a bit.  I've grown used to a lot of these
changes, and would like to see them moved to the main develop branch.  But, the
pull request (formed by merging in CestDiego:spacemacs/SpacemacsOS in #3321)
started diverging.

Again, I'm not sure how to approach moving together these two changes.  Maybe
@timor can help somehow??

This at the least moves in some little things from Timor's branch:

- Can enable exwm-systemtray with `exwm-enable-systray`
- Can enable running XDG autostart applications (only in XDG_USER_HOME/autostart
  for now) with `exwm-autostart-xdg-applications`
- Support for reading `.desktop` files and XDG autostart.
- Can specify additional code appended to exwm-init hook with `exwm-custom-init`