### PR TITLE
Improve quick-start guide

### DIFF
--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -16,11 +16,28 @@
 
 * Configuration layers
 Spacemacs divides its configuration into self-contained units called
-=configuration layers=. These layers are stacked on top of each other
-to achieve a custom configuration.
+=configuration layers=. These layers are stacked on top of each other to achieve
+a custom configuration.
 
 By default Spacemacs uses a dotfile called =~/.spacemacs= to control which
-layers to load. Within this file you can also configure certain features.
+layers to load. Within this file you can also configure certain features. This
+design makes it extremely easy to turn Spacemacs into a fully integrated
+development environment.
+
+For example to get python support, simply add =python= to the list of
+=dotspacemacs-configuration-layers= in your =~/.spacemacs=. Find the
+=~/.spacemacs= file by pressing =SPC f e d= and then after adding the layer,
+reload it with =SPC f e R=. Now open a =.py= file (=SPC f f=) to find the python
+environment has been fully configured. Some extra configuration might make the
+environment even more powerful, which is very well described in the [[https://develop.spacemacs.org/layers/+lang/python/README.html][layer's
+documentation]] that can be accessed by pressing =SPC h l= and selecting the
+=python= layer entry. For configuration of specific packages within a layer,
+=SPC h SPC= provides quick navigation functionality for jumping directly to the
+relevant location within the configuration files.
+
+A list of pre-configured layers is available [[https://develop.spacemacs.org/layers/LAYERS.html][here]]. If you still would like to
+configure anything not covered by any layer, then it is easy to build a personal
+layer.
 
 A configuration layer is a directory containing at least a =packages.el=
 file which defines and configures packages to be downloaded from Emacs


### PR DESCRIPTION
Although the commit message below is only my opinion, I have written it in a style more suitable for a commit message. Anyway, this PR is only a proposal and if you agree with it then you could merge it (or provide feedback first).

 The [quick-start](https://www.spacemacs.org/doc/QUICK_START.html) starts with
 explaining that users can build their own layers. Instead, it should start by
 showing how easy and straightforward it is to use one of the existing layer,
 then continue about the possibility of creating personal layers. It is only a
 small detail, but it can make a substantial difference for people who peek into
 the quick-start guide and decide if it is worth the trouble to switch to
 Spacemacs (Many newcomers think that even only trying another editor, is
 probably not worth it because they are already using vim).

A guide that starts explainining that you can build your own layers in
Spacemacs that exists of a directory containing a packages.el file, is not a
quick-start guide.

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!
