### PR TITLE
[ocaml] Fixed variable name to make ocamlformat properly working on save

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2821,6 +2821,7 @@ files (thanks to Daniel Nicolai)
 - Fixed backspace delete (thanks to Hasan Alirajpurwala)
 - Fixed flycheck-ocaml not initialized warning (thanks to Artur Juraszek)
 - Added =dune= support via =dune-mode= (thanks to Lyman Gillispie)
+- Fixed ocamlformat not properly initialized by following do (thanks to Nicolas Raymond)
 **** Org
 - Load org-mode email integration (mu4e/notmuch) when org is loaded
   (thanks to Steven Allen)

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -157,7 +157,7 @@
   (use-package ocamlformat
     :defer t
     :init
-    (when ocaml-format-before-save
+    (when ocaml-format-on-save
       (add-hook 'before-save-hook 'ocamlformat-before-save))))
 
 (defun ocaml/init-ocp-indent ()


### PR DESCRIPTION
According to https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/ocaml/packages.el#L160, the documentation could not be followed to make `ocamlformat` properly work when saving a file.
