### PR TITLE
[ocaml] Fix name of layer variable in defvar

### DIFF
--- a/layers/+lang/ocaml/config.el
+++ b/layers/+lang/ocaml/config.el
@@ -25,5 +25,5 @@
 
 (spacemacs|define-jump-handlers tuareg-mode)
 
-(defvar ocaml-format-before-save nil
+(defvar ocaml-format-on-save nil
   "If non-nil, ocamlformat before saving.")

--- a/layers/+lang/ocaml/config.el
+++ b/layers/+lang/ocaml/config.el
@@ -25,5 +25,6 @@
 
 (spacemacs|define-jump-handlers tuareg-mode)
 
+(define-obsolete-variable-alias 'ocaml-format-before-save 'ocaml-format-on-save "May 2021")
 (defvar ocaml-format-on-save nil
   "If non-nil, ocamlformat before saving.")


### PR DESCRIPTION
The variable was renamed in #14728 to match the documentation, but the
defvar was not updated.
