### PR TITLE
Update pyls install command to use quotes

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3798,6 +3798,9 @@ files (thanks to Daniel Nicolai)
   - private/local/README.md
     - Improved instructions on how to use private/local directory for packages
       (thanks to Daniel Nicolai)
+  - layers/+lang/python/README.org
+    - Corrected typo in python language server install command (thanks to Zach
+      Pearson)
 *** Release notes summarized
   Thanks to: Abhishek(Compro) Prasad, Deepak Khidia, Enze Chi, Grant Shangreaux,
   Igor Almeida, Jiahao Jiang, Miciah Dashiel Butler Masters, Songpeng Zu, Ward

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -158,7 +158,7 @@ To setup the pyright language server instead, use:
 You just have to install python language server package:
 
 #+BEGIN_SRC sh
-  pip install python-language-server[all]
+  pip install 'python-language-server[all]'
 #+END_SRC
 
 Additionally you can install the following other packages:


### PR DESCRIPTION
This commit reflects pip's own documentation. Quotes are required
around 'python-language-server[all]' to install it correctly.
