### PR TITLE
[core] Add :timeout/:idle for spacemacs|define-transient-state

### DIFF
--- a/core/core-transient-state.el
+++ b/core/core-transient-state.el
@@ -142,6 +142,10 @@ Available PROPS:
     Provide a title in the header of the transient state
 `:columns INTEGER'
     Automatically generate :doc with this many number of columns.
+`:timeout INTEGER'
+    The :timeout key starts a timer for the corresponding amount
+    of seconds that disables the transient state. Calling any
+    head will refresh the timer.
 `:hint BOOLEAN'
     Whether to display hints. Default is nil.
 `:hint-is-doc BOOLEAN'
@@ -183,6 +187,7 @@ used."
          (title (plist-get props :title))
          (hint-var (intern (format "%s/hint" func)))
          (columns (plist-get props :columns))
+         (timeout (plist-get props :timeout))
          (entry-sexp (plist-get props :on-enter))
          (exit-sexp (plist-get props :on-exit))
          (hint (plist-get props :hint))

--- a/core/core-transient-state.el
+++ b/core/core-transient-state.el
@@ -146,6 +146,8 @@ Available PROPS:
     The :timeout key starts a timer for the corresponding amount
     of seconds that disables the transient state. Calling any
     head will refresh the timer.
+`:idle INTEGER'
+    This key can delay the appearance of the hint.
 `:hint BOOLEAN'
     Whether to display hints. Default is nil.
 `:hint-is-doc BOOLEAN'
@@ -188,6 +190,7 @@ used."
          (hint-var (intern (format "%s/hint" func)))
          (columns (plist-get props :columns))
          (timeout (plist-get props :timeout))
+         (idle (plist-get props :idle))
          (entry-sexp (plist-get props :on-enter))
          (exit-sexp (plist-get props :on-exit))
          (hint (plist-get props :hint))
@@ -215,6 +218,8 @@ used."
                 (nil nil
                  :hint ,hint
                  :columns ,columns
+                 :timeout ,timeout
+                 :idle ,idle
                  :foreign-keys ,foreign-keys
                  :body-pre ,entry-sexp
                  :before-exit ,exit-sexp)


### PR DESCRIPTION
This adds a :timeout keyword for spacemacs|define-transient-state, it
make use of :timeout keyword defhydra according to
https://github.com/abo-abo/hydra/wiki/internals.

"The :timeout key starts a timer for the corresponding amount of seconds that disables the hydra. Calling any head will refresh the timer."