### PR TITLE
[evil-better-jumper] Update layer documentation

### DIFF
--- a/layers/+vim/evil-better-jumper/README.org
+++ b/layers/+vim/evil-better-jumper/README.org
@@ -19,7 +19,17 @@ locations.
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =evil-better-jumper= to the existing =dotspacemacs-configuration-layers=
-list in this file.
+list in this file. If =C-i= inserts an indent instead of
+=better-jumper-jump-forward=, please use =M-x describe-variable= to check the value
+of the symbol =dotspacemacs-distinguish-gui-tab= and ensure it is set to true in
+the dotspacemacs file.
+
+#+begin_src emacs-lisp
+  (defun dotspacemacs/user-config ()
+    ;; ...
+    (setq dotspacemacs-distinguish-gui-tab t)
+    )
+#+end_src
 
 * Key bindings
 

--- a/layers/+vim/evil-better-jumper/README.org
+++ b/layers/+vim/evil-better-jumper/README.org
@@ -18,17 +18,16 @@ locations.
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add =evil-better-jumper= to the existing =dotspacemacs-configuration-layers=
-list in this file. If =C-i= inserts an indent instead of
-=better-jumper-jump-forward=, please use =M-x describe-variable= to check the value
-of the symbol =dotspacemacs-distinguish-gui-tab= and ensure it is set to true in
-the dotspacemacs file.
+add =evil-better-jumper= to the existing =dotspacemacs-configuration-layers= list in
+this file. If =C-i= acts like =TAB= instead of =better-jumper-jump-forward=, please
+use =M-x describe-variable= to check the value of the symbol
+=dotspacemacs-distinguish-gui-tab= and ensure it is set to =t= in the dotspacemacs
+file.
 
 #+begin_src emacs-lisp
-  (defun dotspacemacs/user-config ()
+  (defun dotspacemacs/init ()
     ;; ...
-    (setq dotspacemacs-distinguish-gui-tab t)
-    )
+    dotspacemacs-distinguish-gui-tab t)
 #+end_src
 
 * Key bindings


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/issues/5471 helps point out the non obvious default binding of `dotspacemacs-distinguish-gui-tab` to nil, this README update makes it explicit, hopefully saving future users of this new layer some troubleshooting of the `C-i` keybinding.