### PR TITLE
Add 'image-dired' directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /.my-keybindings.el.swp
 /eww-bookmarks
 /history
+/image-dired
 /network-security.data
 /recentf
 /session.*

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -512,6 +512,7 @@ In org-agenda-mode
 Other:
   - =.gitignore= now ignores tag files and the bbdb database.
   - =.gitignore= now ignores org-journal-cache-file (thanks to Benjamin Hipple)
+  - =.gitignore= now ignores image-dired-dir (thanks to Alfonso Montero)
   - Added =vim-style-visual-feedback= and =hybrid-style-visual-feedback= style
     variables to enable =evil-goggles= pulse in the Vim and Hybrid editing
     styles, respectively; disabled by default (thanks to Sylvain Benner)


### PR DESCRIPTION
-------
Dired's image cache dir shows as untracked in git.
Add to `.gitignore`.