### PR TITLE
[home] Add button: Close note

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -485,6 +485,19 @@ ADDITIONAL-WIDGETS: a function for inserting a widget under the frame."
                                       (concat spacemacs-docs-directory
                                               "VIMUSERS.org") "^" 'all))
                            :mouse-face 'highlight
+                           :follow-link "\C-m"))
+           (widget-insert " ")
+           (add-to-list
+            'spacemacs-buffer--note-widgets
+            (widget-create 'push-button
+                           :tag (propertize "Close note"
+                                            'face '(:foreground "orangeRed"))
+                           :help-echo "Close note"
+                           :action
+                           (lambda (&rest ignore)
+                             (spacemacs-buffer/toggle-note 'quickhelp)
+                             (search-backward "[?"))
+                           :mouse-face 'highlight
                            :follow-link "\C-m")))))
     (spacemacs-buffer//notes-insert-note (concat spacemacs-info-directory
                                                  "quickhelp.txt")
@@ -510,6 +523,19 @@ ADDITIONAL-WIDGETS: a function for inserting a widget under the frame."
                                       (format "Release %s.x"
                                               spacemacs-buffer-version-info)
                                       'subtree))
+                           :mouse-face 'highlight
+                           :follow-link "\C-m"))
+           (widget-insert " ")
+           (add-to-list
+            'spacemacs-buffer--note-widgets
+            (widget-create 'push-button
+                           :tag (propertize "Close note"
+                                            'face '(:foreground "orangeRed"))
+                           :help-echo "Close note"
+                           :action
+                           (lambda (&rest ignore)
+                             (spacemacs-buffer/toggle-note 'release-note)
+                             (search-backward "[Release"))
                            :mouse-face 'highlight
                            :follow-link "\C-m")))))
     (spacemacs-buffer//notes-insert-note (concat spacemacs-release-notes-directory


### PR DESCRIPTION
problem
It might not be clear how the note can be closed.

solution
Add a button: Close note
to the bottom right of the notes:
Quick Help and Release Notes

---

Quick Help

![emacs_2021-05-08_17-35-04](https://user-images.githubusercontent.com/13420573/117545668-0a6c1280-b027-11eb-866c-8807a498b18d.png)

Release Notes

![emacs_2021-05-08_17-35-31](https://user-images.githubusercontent.com/13420573/117545664-063ff500-b027-11eb-9222-22feb98c268d.png)

