### PR TITLE
[home] New var dotspacemacs-show-startup-list-numbers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -506,6 +506,7 @@ In org-agenda-mode
   - New variable =dotspacemacs-show-trailing-whitespace= (thanks to duianto)
   - New var =dotspacemacs-startup-buffer-multi-digit-delay= (thanks to duianto)
   - New variable =dotspacemacs-scroll-bar-while-scrolling= (thanks to duianto)
+  - New variable =dotspacemacs-show-startup-list-numbers= (thanks to duianto)
 - Removed Variables:
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -629,6 +629,11 @@ number of recent files to show in each project."
   'boolean
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-show-startup-list-numbers t
+  "Show numbers before the startup list lines."
+  'boolean
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-startup-buffer-multi-digit-delay 0.4
   "The minimum delay in seconds between number key presses."
   'number

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -71,18 +71,22 @@ Allows to keep track of widgets to delete when removing them.")
   "Horizontal position of the home buffer buttons.
 Internal use, do not set this variable.")
 
-(defvar spacemacs-buffer-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "0") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "1") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "2") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "3") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "4") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "5") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "6") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "7") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "8") 'spacemacs-buffer/jump-to-number-startup-list-line)
-    (define-key map (kbd "9") 'spacemacs-buffer/jump-to-number-startup-list-line)
+(defvar spacemacs-buffer-mode-map (make-sparse-keymap)
+  "Keymap for spacemacs buffer mode.")
+
+(defun spacemacs-buffer/key-bindings ()
+  (let ((map spacemacs-buffer-mode-map))
+    (when dotspacemacs-show-startup-list-numbers
+      (define-key map (kbd "0") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "1") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "2") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "3") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "4") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "5") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "6") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "7") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "8") 'spacemacs-buffer/jump-to-number-startup-list-line)
+      (define-key map (kbd "9") 'spacemacs-buffer/jump-to-number-startup-list-line))
 
     (define-key map [down-mouse-1] 'widget-button-click)
     (define-key map (kbd "RET") 'widget-button-press)
@@ -95,9 +99,9 @@ Internal use, do not set this variable.")
     (define-key map (kbd "K") 'widget-backward)
 
     (define-key map (kbd "C-r") 'spacemacs-buffer/refresh)
-    (define-key map "q" 'quit-window)
-    map)
-  "Keymap for spacemacs buffer mode.")
+    (define-key map "q" 'quit-window)))
+
+(add-hook 'emacs-startup-hook 'spacemacs-buffer/key-bindings)
 
 (with-eval-after-load 'evil
   (evil-make-overriding-map spacemacs-buffer-mode-map 'motion))
@@ -811,10 +815,14 @@ by pressing its number key."
     (mapc (lambda (el)
             (insert "\n    ")
             (let* ((button-text-prefix
-                    (format "%2s" (number-to-string
-                                   spacemacs-buffer--startup-list-nr)))
+                    (when dotspacemacs-show-startup-list-numbers
+                      (format "%2s" (number-to-string
+                                     spacemacs-buffer--startup-list-nr))))
                    (button-text
-                    (concat button-text-prefix " " (abbreviate-file-name el))))
+                    (concat
+                     (when dotspacemacs-show-startup-list-numbers
+                       (concat button-text-prefix " "))
+                     (abbreviate-file-name el))))
               (widget-create 'push-button
                              :action `(lambda (&rest ignore)
                                         (find-file-existing ,el))
@@ -837,11 +845,14 @@ GROUPED-LIST: a list of string pathnames made interactive in this function."
     (mapc (lambda (group)
             (insert "\n    ")
             (let* ((button-text-prefix
-                    (format "%2s" (number-to-string
-                                   spacemacs-buffer--startup-list-nr)))
+                    (when dotspacemacs-show-startup-list-numbers
+                      (format "%2s" (number-to-string
+                                     spacemacs-buffer--startup-list-nr))))
                    (button-text-project
-                    (concat button-text-prefix " "
-                            (abbreviate-file-name (car group)))))
+                    (concat
+                     (when dotspacemacs-show-startup-list-numbers
+                       (concat button-text-prefix " "))
+                     (abbreviate-file-name (car group)))))
               (widget-create 'push-button
                              :action `(lambda (&rest ignore)
                                         (find-file-existing ,(car group)))
@@ -854,11 +865,14 @@ GROUPED-LIST: a list of string pathnames made interactive in this function."
                     (1+ spacemacs-buffer--startup-list-nr))
               (mapc (lambda (el)
                       (let* ((button-text-prefix
-                              (format "%2s" (number-to-string
-                                             spacemacs-buffer--startup-list-nr)))
+                              (when dotspacemacs-show-startup-list-numbers
+                                (format "%2s" (number-to-string
+                                               spacemacs-buffer--startup-list-nr))))
                              (button-text-filename
-                              (concat button-text-prefix " "
-                                      (abbreviate-file-name el))))
+                              (concat
+                               (when dotspacemacs-show-startup-list-numbers
+                                 (concat button-text-prefix " "))
+                               (abbreviate-file-name el))))
                         (insert "\n        ")
                         (widget-create 'push-button
                                        :action `(lambda (&rest ignore)
@@ -884,14 +898,17 @@ LIST: a list of string bookmark names made interactive in this function."
             (insert "\n    ")
             (let* ((filename (bookmark-get-filename el))
                    (button-text-prefix
-                    (format "%2s" (number-to-string
-                                   spacemacs-buffer--startup-list-nr)))
+                    (when dotspacemacs-show-startup-list-numbers
+                      (format "%2s" (number-to-string
+                                     spacemacs-buffer--startup-list-nr))))
                    (button-text
-                    (concat button-text-prefix " "
-                            (if filename
-                                (format "%s - %s"
-                                        el (abbreviate-file-name filename))
-                              (format "%s" el)))))
+                    (concat
+                     (when dotspacemacs-show-startup-list-numbers
+                       (concat button-text-prefix " "))
+                     (if filename
+                         (format "%s - %s"
+                                 el (abbreviate-file-name filename))
+                       (format "%s" el)))))
               (widget-create 'push-button
                              :action `(lambda (&rest ignore) (bookmark-jump ,el))
                              :mouse-face 'highlight
@@ -987,20 +1004,23 @@ LIST: list of `org-agenda' entries in the todo list."
     (mapc (lambda (el)
             (insert "\n    ")
             (let* ((button-text-prefix
-                    (format "%2s" (number-to-string
-                                   spacemacs-buffer--startup-list-nr)))
+                    (when dotspacemacs-show-startup-list-numbers
+                      (format "%2s" (number-to-string
+                                     spacemacs-buffer--startup-list-nr))))
                    (button-text
-                    (concat button-text-prefix " "
-                            (format "%s %s %s"
-                                    (let ((filename (cdr (assoc "file" el))))
-                                      (if dotspacemacs-home-shorten-agenda-source
-                                          (file-name-nondirectory filename)
-                                        (abbreviate-file-name filename)))
-                                    (if (not (eq "" (cdr (assoc "time" el))))
-                                        (format "- %s -"
-                                                (cdr (assoc "time" el)))
-                                      "-")
-                                    (cdr (assoc "text" el))))))
+                    (concat
+                     (when dotspacemacs-show-startup-list-numbers
+                       (concat button-text-prefix " "))
+                     (format "%s %s %s"
+                             (let ((filename (cdr (assoc "file" el))))
+                               (if dotspacemacs-home-shorten-agenda-source
+                                   (file-name-nondirectory filename)
+                                 (abbreviate-file-name filename)))
+                             (if (not (eq "" (cdr (assoc "time" el))))
+                                 (format "- %s -"
+                                         (cdr (assoc "time" el)))
+                               "-")
+                             (cdr (assoc "text" el))))))
               (widget-create 'push-button
                              :action `(lambda (&rest ignore)
                                         (spacemacs-buffer//org-jump ',el))

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -192,6 +192,9 @@ It should only modify the values of Spacemacs settings."
    ;; True if the home buffer should respond to resize events. (default t)
    dotspacemacs-startup-buffer-responsive t
 
+   ;; Show numbers before the startup list lines. (default t)
+   dotspacemacs-show-startup-list-numbers t
+
    ;; The minimum delay in seconds between number key presses. (default 0.4)
    dotspacemacs-startup-buffer-multi-digit-delay 0.4
 


### PR DESCRIPTION
This also defines the Spacemacs home buffer key bindings,
in the `emacs-startup-hook`.

Because the keys were being defined to early,
before the new value of: `dotspacemacs-show-startup-list-numbers`
was set in `.spacemacs`.