### PR TITLE
Evilify geiser-doc-mode-map and add keybindings in scheme layer

### DIFF
--- a/layers/+lang/scheme/README.org
+++ b/layers/+lang/scheme/README.org
@@ -16,7 +16,8 @@
   - [[#macroexpansion][Macroexpansion]]
   - [[#repl-interaction][REPL interaction]]
   - [[#evaluation][Evaluation]]
-  - [[#repl][REPL]]
+  - [[#repl-mode][REPL-mode]]
+  - [[#geiser-doc-mode][Geiser-doc-mode]]
 
 * Description
 This layer adds support for Scheme via [[http://geiser.nongnu.org][Geiser]]. Note that combined usage of racket-mode and geiser has not been tested.
@@ -129,7 +130,7 @@ When enabled the symbol =🆂= should be displayed in the mode-line.
 
 | Key binding | Description         |
 |-------------+---------------------|
-| ~SPC m g g~ | Goto Definition     |
+| ~SPC m g d~ | Goto Definition     |
 | ~SPC m g b~ | Go Back             |
 | ~SPC m g m~ | Goto Module         |
 | ~SPC m g n~ | Goto next error     |
@@ -183,15 +184,38 @@ When enabled the symbol =🆂= should be displayed in the mode-line.
 | ~SPC m e l~ | Evaluate line             |
 | ~SPC m e r~ | Evaluate region           |
 
-** REPL
+** REPL-mode
 
-| Key binding | Description                 |
-|-------------+-----------------------------|
-| ~g j~       | geiser-repl-next-prompt     |
-| ~g k~       | geiser-repl-previous-prompt |
-| ~SPC m h~   | geiser-doc-symbol-at-point  |
-| ~SPC m i~   | geiser-repl-interrupt       |
-| ~SPC m c~   | geiser-repl-clear-buffer    |
-| ~SPC m m~   | geiser-repl-import-module   |
-| ~SPC m u~   | geiser-repl-unload-function |
-| ~SPC m q~   | geiser-repl-exit            |
+*Insert state*
+| Key binding | Description    |
+|-------------+----------------|
+| ~S-RET~     | Insert newline |
+| ~C-l~       | Clear buffer   |
+| ~C-d~       | Exit           |
+
+*Normal state*
+| Key binding  | Description          |
+|--------------+----------------------|
+| ~g j~ / ~]]~ | Goto next prompt     |
+| ~g k~ / ~[[~ | Goto previous prompt |
+
+| ~SPC m h h~ | Show documentation for symbol at point      |
+| ~SPC m C~   | Clear buffer                                |
+| ~SPC m i l~ | Insert lambda                               |
+| ~SPC m i m~ | Import module                               |
+| ~SPC m u~   | Unload function                             |
+| ~SPC m s~   | Toggle surrounding parenthesis <-> brackets |
+| ~SPC m k~   | REPL interrupt                              |
+| ~SPC m q~   | REPL exit                                   |
+
+** Geiser-doc-mode
+| Key binding    | Description           |
+|----------------+-----------------------|
+| ~o~            | Follow link           |
+| ~]]/[[~        | Next/previous-section |
+| ~g p~ / ~<~    | Previous page         |
+| ~g n~ / ~>~    | Next page             |
+| ~g d~          | Goto definition       |
+| ~g z~          | Switch to repl        |
+| ~TAB~ / ~C-j~  | Next button           |
+| S-TAB~ / ~C-k~ | Previous button       |

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -75,7 +75,6 @@
         "el" 'lisp-state-eval-sexp-end-of-line
         "er" 'geiser-eval-region
 
-        "gb" 'geiser-pop-symbol-stack
         "gm" 'geiser-edit-module
         "gn" 'next-error
         "gN" 'previous-error
@@ -90,7 +89,7 @@
 
         "me" 'geiser-expand-last-sexp
         "mf" 'geiser-expand-definition
-        "mx" 'geiser-expand-region
+        "mr" 'geiser-expand-region
 
         "si" 'geiser-mode-switch-to-repl
         "sb" 'geiser-eval-buffer
@@ -102,17 +101,46 @@
         "sR" 'geiser-eval-region-and-go
         "ss" 'geiser-set-scheme)
 
-      (evil-define-key 'normal 'geiser-repl-mode-map
-      "gj" 'geiser-repl-next-prompt
-      "gk" 'geiser-repl-previous-prompt)
+      (evil-define-key 'insert 'geiser-repl-mode-map
+        (kbd "S-<return>") 'geiser-repl--newline-and-indent
+        (kbd "C-l") 'geiser-repl-clear-buffer
+        (kbd "C-d") 'geiser-repl-exit)
 
+      (evil-define-key 'normal 'geiser-repl-mode-map
+        "]]" 'geiser-repl-next-prompt
+        "[[" 'geiser-repl-previous-prompt
+        "gj" 'geiser-repl-next-prompt
+        "gk" 'geiser-repl-previous-prompt)
+
+      (spacemacs/declare-prefix-for-mode 'geiser-repl-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'geiser-repl-mode "mi" "insert")
       (spacemacs/set-leader-keys-for-major-mode 'geiser-repl-mode
-        "q" 'geiser-repl-exit
-        "c" 'geiser-repl-clear-buffer
-        "i" 'geiser-repl-interrupt
-        "m" 'geiser-repl-import-module
+        "C" 'geiser-repl-clear-buffer
+        "k" 'geiser-repl-interrupt
+        "f" 'geiser-load-file
+        "il" 'geiser-insert-lambda
+        "im" 'geiser-repl-import-module
         "u" 'geiser-repl-unload-function
-        "h" 'geiser-doc-symbol-at-point))))
+        "hh" 'geiser-doc-symbol-at-point
+        "s" 'geiser-squarify
+        "q" 'geiser-repl-exit)
+
+      (evilified-state-evilify-map geiser-doc-mode-map
+        :mode geiser-doc-mode
+        :eval-after-load geiser-doc
+        :bindings
+        "o" 'link-hint-open-link
+
+        "]]" 'geiser-doc-next-section
+        "[[" 'geiser-doc-previous-section
+        ">" 'geiser-doc-next
+        "<" 'geiser-doc-previous
+
+        "gp" 'geiser-doc-previous
+        "gn" 'geiser-doc-next
+        "gz" 'geiser-doc-switch-to-repl
+        (kbd "C-j") 'forward-button
+        (kbd "C-k") 'backward-button))))
 
 (defun scheme/post-init-ggtags ()
   (add-hook 'scheme-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
In the scheme REPL, RET is bound to `geiser-repl--maybe-send` which most times
sends the input instead of inserting a newline. Therefore this separate
keybinding for that will always insert the newline is required.

Also the `geiser-doc-mode` is read-only and should get evilified to not shadow its default keybindings.
