### PR TITLE
[csv] Bind csv-mode keys also in tsv-mode

### DIFF
--- a/layers/+lang/csv/packages.el
+++ b/layers/+lang/csv/packages.el
@@ -28,20 +28,21 @@
     :defer t
     :init
     (progn
-      (spacemacs/declare-prefix-for-mode 'csv-mode "ms" "sort")
-      (spacemacs/declare-prefix-for-mode 'csv-mode "mv" "yank")
-      (spacemacs/set-leader-keys-for-major-mode 'csv-mode
-        "a"  'csv-align-fields
-        "d"  'csv-kill-fields
-        "h"  'csv-header-line
-        "i"  'csv-toggle-invisibility
-        "n"  'csv-forward-field
-        "p"  'csv-backward-field
-        "r"  'csv-reverse-region
-        "sf" 'csv-sort-fields
-        "sn" 'csv-sort-numeric-fields
-        "so" 'csv-toggle-descending
-        "t"  'csv-transpose
-        "u"  'csv-unalign-fields
-        "vf" 'csv-yank-fields
-        "vt" 'csv-yank-as-new-table))))
+      (dolist (mode '(csv-mode tsv-mode))
+        (spacemacs/declare-prefix-for-mode mode "ms" "sort")
+        (spacemacs/declare-prefix-for-mode mode "mv" "yank")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "a"  'csv-align-fields
+          "d"  'csv-kill-fields
+          "h"  'csv-header-line
+          "i"  'csv-toggle-invisibility
+          "n"  'csv-forward-field
+          "p"  'csv-backward-field
+          "r"  'csv-reverse-region
+          "sf" 'csv-sort-fields
+          "sn" 'csv-sort-numeric-fields
+          "so" 'csv-toggle-descending
+          "t"  'csv-transpose
+          "u"  'csv-unalign-fields
+          "vf" 'csv-yank-fields
+          "vt" 'csv-yank-as-new-table)))))


### PR DESCRIPTION
tsv-mode is a derived mode of csv-mode, and supports all of the same
commands, but didn't have any of the key bindings.

I'm not confident this is the idiomatic way of providing these key bindings for derived modes, but there wasn't anything in `core/core-keybindings.el` relating to derived modes so this seemed like the most straightforward option.