### PR TITLE
emacs-lisp: load srefactor

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -317,7 +317,7 @@
   (with-eval-after-load 'semantic
     (semantic-default-elisp-setup)))
 
-(defun emacs-lisp/post-init-srefactor ()
+(defun emacs-lisp/init-srefactor ()
   (add-hook 'emacs-lisp-mode-hook 'spacemacs/load-srefactor)
   (use-package srefactor-lisp
     :commands (srefactor-lisp-format-buffer


### PR DESCRIPTION
I wanted to post this as a question, but then I thought: maybe I'll make a tiny PR and ask it here.

For some reason srefactor is not being loaded, does anyone know why? It looks like the handler should be `init` and not `post-init`.
