### PR TITLE
Evilify xref--xref-buffer-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -58,6 +58,7 @@
         (visual-line-mode :location built-in)
         (whitespace :location built-in)
         (winner :location built-in)
+        (xref :location built-in)
         (zone :location built-in)))
 
 
@@ -535,6 +536,11 @@
 
       (setq winner-boring-buffers
             (append winner-boring-buffers spacemacs/winner-boring-buffers)))))
+
+(defun spacemacs-defaults/init-xref ()
+  (evilified-state-evilify-map xref--xref-buffer-mode-map
+    :mode xref--xref-buffer-mode
+    :eval-after-load xref))
 
 (defun spacemacs-defaults/init-zone ()
   (use-package zone


### PR DESCRIPTION
When using `spacemacs/jump-to-definition` (`g d`) in e.g. guile source code, Spacemacs opens a xref buffer, which is a read only buffer. Generally read-only buffers should open in evilified state, and indeed here it "unshadows" many of the xref-buffer-mode's convenient default keybindings.