### PR TITLE
[csv] Make tsv-mode inherit csv-mode's leader key bindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -774,6 +774,8 @@ Other:
   - Enabled eager spacebind bindings by default (thanks to JAremko)
   - Add info about requirement to also load additional-package in user-config
     section (thank to Daniel Nicolai)
+  - New function =spacemacs/inherit-leader-keys-from-parent-mode= to
+    inherit leader key bindings from another mode
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:
@@ -1802,6 +1804,7 @@ Other:
 **** CSV
 - Key bindings:
   - ~SPC m h~ to =csv-header-line= (thanks to Francesc Elies Henar)
+  - All key bindings also implemented in tsv-mode (thanks to Aaron Zeng)
 **** D
 - Fixes:
   - Fixed =d-mode= flycheck imports on dub projects (thanks to Dietrich Daroch)

--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -131,6 +131,20 @@ minor-mode, the third argument should be non nil."
               :evil-states (normal motion visual evilified)))
           (boundp prefix)))))
 
+(defun spacemacs/inherit-leader-keys-from-parent-mode (mode &optional parent-mode)
+  "Make derived mode MODE inherit leader key bindings from PARENT-MODE.
+
+If omitted, PARENT-MODE defaults to the parent mode of MODE.
+Signal an error if MODE is not a derived mode."
+  (unless parent-mode
+    (setq parent-mode (or (get mode 'derived-mode-parent)
+                          (error "Mode %s has no parent" mode))))
+  (let ((map (intern (format "spacemacs-%s-map" mode)))
+        (parent-map (intern (format "spacemacs-%s-map" parent-mode))))
+    (when (and (spacemacs//init-leader-mode-map mode map)
+               (spacemacs//init-leader-mode-map parent-mode parent-map))
+      (set-keymap-parent (symbol-value map) (symbol-value parent-map)))))
+
 (defun spacemacs/set-leader-keys-for-major-mode (mode key def &rest bindings)
   "Add KEY and DEF as key bindings under
 `dotspacemacs-major-mode-leader-key' and

--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -133,9 +133,9 @@ minor-mode, the third argument should be non nil."
 
 (defun spacemacs/inherit-leader-keys-from-parent-mode (mode &optional parent-mode)
   "Make derived mode MODE inherit leader key bindings from PARENT-MODE.
-
 If omitted, PARENT-MODE defaults to the parent mode of MODE.
-Signal an error if MODE is not a derived mode."
+Signal an error if MODE is not a derived mode (for example if the
+package defining the mode has not yet been loaded)."
   (unless parent-mode
     (setq parent-mode (or (get mode 'derived-mode-parent)
                           (error "Mode %s has no parent" mode))))

--- a/layers/+lang/csv/packages.el
+++ b/layers/+lang/csv/packages.el
@@ -26,7 +26,7 @@
 (defun csv/init-csv-mode ()
   (use-package csv-mode
     :defer t
-    :init
+    :config
     (progn
       (spacemacs/declare-prefix-for-mode 'csv-mode "ms" "sort")
       (spacemacs/declare-prefix-for-mode 'csv-mode "mv" "yank")
@@ -44,4 +44,5 @@
         "t"  'csv-transpose
         "u"  'csv-unalign-fields
         "vf" 'csv-yank-fields
-        "vt" 'csv-yank-as-new-table))))
+        "vt" 'csv-yank-as-new-table)
+      (spacemacs/inherit-leader-keys-from-parent-mode 'tsv-mode))))


### PR DESCRIPTION
I tried to add a sort of general way to inherit key bindings.  I would have automatically computed the parent mode but it is not known until the package is loaded, so I would have had to move the bindings to `:config`, which would have been worse (key bindings no longer autoload the package).

This is an alternative solution to #14759.