### PR TITLE
auto-complete: Ensure hjkl bindings are respected during company search/filter

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1485,6 +1485,9 @@ Other:
     (thanks to Sylvain Benner)
   - Removed the assumption that ~C-k~ was bound to =evil-insert-digraph= after
     closing/finishing a company completion (thanks to lovrolu)
+  - Make ~C-j~ and ~C-k~ work when searching/filtering =company= results if in
+    `vim` mode or `hybrid` mode with `hybrid-style-enable-hjkl-bindings` set to
+    `t` (thanks to dankessler)
 - Key bindings:
   - Removed ~C-f~ because it interfered with the default key binding for
     =forward-char= (thanks to scturtle and duianto)

--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -302,7 +302,7 @@ MODE parameter must match the :modes values used in the call to
    ((or (eq 'vim style)
         (and (eq 'hybrid style)
              hybrid-style-enable-hjkl-bindings))
-    (let ((map company-active-map))
+    (dolist (map (list company-active-map company-search-map))
       (define-key map (kbd "C-j") 'company-select-next)
       (define-key map (kbd "C-k") 'company-select-previous)
       (define-key map (kbd "C-l") 'company-complete-selection))
@@ -317,7 +317,7 @@ MODE parameter must match the :modes values used in the call to
     (add-hook 'company-completion-finished-hook 'spacemacs//restore-C-k-evil-insert-digraph)
     (add-hook 'company-completion-cancelled-hook 'spacemacs//restore-C-k-evil-insert-digraph))
    (t
-    (let ((map company-active-map))
+    (dolist (map (list company-active-map company-search-map))
       (define-key map (kbd "C-n") 'company-select-next)
       (define-key map (kbd "C-p") 'company-select-previous)))))
 


### PR DESCRIPTION
At present, if using vim style (or hybrid with
`hybrid-style-enable-hjkl-bindings` set to t), then the `auto-completion` layer
will map `C-j` and `C-k` to `company-select-next` and `company-select-previous`,
respectively on the `company-active-map` keymap. However, if one filters the
results (for example using `C-M-/` or by searching with `C-s`), then `C-j` and
`C-k` cause the filtering to stop and returns the completion list to what it was
pre-filtering. This seems undesirable as presumably one would want to use `C-j`
and `C-k` to navigate the filtered list rather than having to switch to arrow
keys or `C-n` and `C-p`.

When searching (or having filtered), a new keymap called `company-search-map` is
active, which does not have `C-j` or `C-k` bound on it explicitly, and has a
default key mapping that causes this fallback behavior.

Add `C-j` and `C-k` to the `company-search-map`. For some reason,
this same function adds `C-n` and `C-p` to the `company-active-map` when not
using vim or hybrid bindings with `hybrid-style-enable-hjkl-bindings` set to
`nil` (this seems redundant since they're already on the keymap but perhaps I
misunderstand something). This commit also does the same thing for
`company-search-map` in case it might suffer from the same issues.
