### PR TITLE
[exwm] Remove manual XF86 keybindings

### DIFF
--- a/layers/+window-management/exwm/README.org
+++ b/layers/+window-management/exwm/README.org
@@ -85,7 +85,6 @@ you want you can enable it, this layer focuses on less Emacs-y bindings.
 | Key binding           | Description                                    |
 |-----------------------+------------------------------------------------|
 | ~C-q~                 | Send next key pressed to the X window          |
-| ~C-'~                 | Pop shell                                      |
 | ~C-g~                 | Universal GetMeOuttaHere Key from Emacs        |
 | ~C-u~                 | Universal Argument                             |
 | ~C-[0-9]~             | Universal Prefix for [0-9]                     |
@@ -96,7 +95,8 @@ you want you can enable it, this layer focuses on less Emacs-y bindings.
 | ~s-r~                 | Reset window state                             |
 | ~s-SPC~               | App Launcher                                   |
 | ~s-ESC~               | Lock Screen                                    |
-| ~s-:~ and ~s-;~       | Helm M-x (same as ~SCP :~)                     |
+| ~s-RET~               | Pop shell                                      |
+| ~s-:~ and ~s-;~       | Helm M-x (same as ~SPC :~)                     |
 | ~s-u,U~               | Undo, Redo window configurations               |
 | ~s-b~                 | Show all opened buffers                        |
 | ~s-h,j,k,l~           | Switch to left,lower,upper,right window        |

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -53,16 +53,15 @@
       :evil-leader "TD")
 
     :config
-    (progn
-      ;; We bypass desktop-environment's locking functionality for 2 reasons:
-      ;; 1. s-l is most likely needed for window manipulation
-      ;; 2. desktop-environment's locking mechanism does not support registering as session manager
-      ;; The following line would instead assign their locking command to the default binding:
-      ;; (define-key desktop-environment-mode-map (kbd "<s-pause>") (lookup-key desktop-environment-mode-map (kbd "s-l")))
-      (setq desktop-environment-update-exwm-global-keys :prefix)
-      (define-key desktop-environment-mode-map (kbd "s-l") nil)
-      ;; If we don't enable this, exwm/switch-to-buffer-or-run won't move an X window to the current frame
-      (setq exwm-layout-show-all-buffers t))))
+    ;; We bypass desktop-environment's locking functionality for 2 reasons:
+    ;; 1. s-l is most likely needed for window manipulation
+    ;; 2. desktop-environment's locking mechanism does not support registering as session manager
+    ;; The following line would instead assign their locking command to the default binding:
+    ;; (define-key desktop-environment-mode-map (kbd "<s-pause>") (lookup-key desktop-environment-mode-map (kbd "s-l")))
+    (setq desktop-environment-update-exwm-global-keys :prefix)
+    (define-key desktop-environment-mode-map (kbd "s-l") nil)
+    ;; If we don't enable this, exwm/switch-to-buffer-or-run won't move an X window to the current frame
+    (setq exwm-layout-show-all-buffers t))
 
 (defun exwm/init-helm-exwm ()
   ;; when helm is used activate extra EXWM features
@@ -157,15 +156,7 @@
     (easy-menu-add-item exwm-mode-menu '()
                         ["Move X window to" exwm-workspace-move-window])
 
-    (exwm/exwm-bind-command
-     "s-'"  exwm-terminal-command
-     "<s-return>"  exwm-terminal-command
-     "<XF86MonBrightnessUp>"   "light -A 5"
-     "<XF86MonBrightnessDown>" "light -U 5"
-     "<XF86AudioLowerVolume>" "amixer -D pulse -- sset Master unmute 3%-"
-     "<XF86AudioRaiseVolume>" "amixer -D pulse -- sset Master unmute 3%+"
-     "<XF86AudioMute>"        "amixer -D pulse -- sset Master toggle"
-     "<XF86AudioMicMute>"     "amixer -D pulse -- sset Capture toggle")
+    (exwm/exwm-bind-command "<s-return>" exwm-terminal-command)
 
     ;; Pass all keypresses to emacs in line mode.
     (setq exwm-input-line-mode-passthrough t)


### PR DESCRIPTION
Recently, #14714 added `desktop-environment-mode`.  This means that we don't
need to separately define bindings like `<XF86MonBrightnessUp>`, but can instead
lean on the user to enable `desktop-environment-mode` in `init.el`.

`desktop-environment-mode` should not be loaded by default since it is
linux/unix-centric.

Looking at my previous PR, I added `desktop-environment-mode`, then never used
it.  Oops.