### PR TITLE
Update python layer to use pylsp (new maintained fork of pyls)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3136,7 +3136,7 @@ files (thanks to Daniel Nicolai)
 - Added LSP support, which can be enabled by setting the =python= layer's
   =python-backend= variable to =lsp=
   (thanks to Yuan Fu and Sylvain Benner).
-- The LSP backend can use either the =pyls= (default) server or the =mspyls=
+- The LSP backend can use either the =pylsp= (default) server or the =mspyls=
   (Microsoft) implementation, which may be selected by setting the
   =python-lsp-server= layer variable to =mspyls=
   (thanks to Cormac Cannon).

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -13,7 +13,7 @@
 - [[#backends][Backends]]
   - [[#anaconda][Anaconda]]
   - [[#language-server-protocol][Language Server Protocol]]
-    - [[#python-language-server][python-language-server]]
+    - [[#python-lsp-server][python-lsp-server]]
     - [[#microsoft-python-language-server][Microsoft python language server]]
     - [[#microsoft-pyright-language-server][Microsoft pyright language server]]
 - [[#additional-tools][Additional tools]]
@@ -54,7 +54,7 @@ This layer adds support for the Python language.
 - Support for the following backends:
   - [[https://github.com/proofit404/anaconda-mode][anaconda]] (default),
   - [[https://github.com/emacs-lsp/lsp-python-ms][Language Server Protocol]] (experimental - 2 implementations),
-    - python-language-server
+    - python-lsp-server
     - Microsoft python language server
 - Auto-completion
 - Code Navigation
@@ -105,7 +105,7 @@ The available options are:
 | symbol    | description                    |
 |-----------+--------------------------------|
 | 'anaconda | Default                        |
-| 'lsp      | python-language-server package |
+| 'lsp      | python-lsp-server package |
 
 * Backends
 ** Anaconda
@@ -135,13 +135,13 @@ setting your =PYTHONPATH= as explained at
 ** Language Server Protocol
 The =lsp= backend can use either of the following language server implementations:
 
-| symbol   | description                              |
-|----------+------------------------------------------|
-| 'pyls    | python-language-server package (default) |
-| 'mspyls  | [[https://github.com/emacs-lsp/lsp-python-ms][Microsoft python language server]]         |
-| 'pyright | [[https://github.com/emacs-lsp/lsp-pyright][Microsoft pyright language server]]        |
+| symbol   | description                         |
+|----------+-------------------------------------|
+| 'pylsp   | [[https://pypi.org/project/python-lsp-server/][python-lsp-server package]] (default) |
+| 'mspyls  | [[https://github.com/emacs-lsp/lsp-python-ms][Microsoft python language server]]    |
+| 'pyright | [[https://github.com/emacs-lsp/lsp-pyright][Microsoft pyright language server]]   |
 
-=pyls= is used by default - to use the Microsoft python language server, set the
+=pylsp= is used by default - to use the Microsoft python language server, set the
 =python-lsp-server= layer variable as follows:
 
 #+BEGIN_SRC elisp
@@ -154,7 +154,7 @@ To setup the pyright language server instead, use:
   (python :variables python-backend 'lsp python-lsp-server 'pyright)
 #+END_SRC
 
-*** python-language-server
+*** python-lsp-server
 You just have to install python language server package:
 
 #+BEGIN_SRC sh

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -32,8 +32,8 @@ Possible values are `anaconda'and `lsp'.
 If `nil' then `anaconda' is the default backend unless `lsp' layer is used.")
 (put 'python-backend 'safe-local-variable #'symbolp)
 
-(defvar python-lsp-server 'pyls
-  "Language server to use for lsp backend. Possible values are `pyls', `pyright'
+(defvar python-lsp-server 'pylsp
+  "Language server to use for lsp backend. Possible values are `pylsp', `pyright'
 and `mspyls'")
 (put 'python-lsp-server 'safe-local-variable #'symbolp)
 

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -90,7 +90,7 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (require (pcase python-lsp-server
-                   ('pyls 'lsp-pyls)
+                   ('pylsp 'lsp-pylsp)
                    ('mspyls 'lsp-python-ms)
                    ('pyright 'lsp-pyright)
                    (x (user-error "Unknown value for `python-lsp-server': %s" x))))


### PR DESCRIPTION
LSP warns that pyls is unmaintained and the user should install pylsp. This PR updates the python correspondingly.

If still pyls is installed instead of pylsp, then lsp shows a warning that the
user should install/update to the new fork i.e. pylsp.