### PR TITLE
add key bindings for moving org table cells

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -216,6 +216,7 @@ Will work on both org-mode and any mode that accepts plain html."
       (dolist (prefix `(
                         ("mb" . "babel")
                         ("mC" . ,(org-clocks-prefix))
+                        ("mc" . "cell/convert")
                         ("md" . "dates")
                         ("me" . "export")
                         ("mf" . "feeds")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -301,7 +301,11 @@ Will work on both org-mode and any mode that accepts plain html."
         ;; tables
         "ta" 'org-table-align
         "tb" 'org-table-blank-field
-        "tc" 'org-table-convert
+        "tcc" 'org-table-convert
+        "tch" 'org-table-move-cell-left
+        "tcj" 'org-table-move-cell-down
+        "tck" 'org-table-move-cell-up
+        "tcl" 'org-table-move-cell-right
         "tdc" 'org-table-delete-column
         "tdr" 'org-table-kill-row
         "te" 'org-table-eval-formula


### PR DESCRIPTION
Org mode key `,tc` was bound to `org-table-convert` command.  This is changed so that `,tc` is a prefix key to add four new key bindings for moving current org table cell left, right, up, and down.