### PR TITLE
[helm] add C-o keybinding to open files/buffers in other window for helm-files and helm-buffers

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -138,12 +138,17 @@
       (with-eval-after-load 'helm-files
         (define-key helm-find-files-map
           (kbd "C-c C-e") 'spacemacs/helm-find-files-edit)
+        (define-key helm-find-files-map
+          (kbd "C-o") 'helm-ff-run-switch-other-window)
         (defun spacemacs//add-action-helm-find-files-edit ()
           (helm-add-action-to-source
            "Edit files in dired `C-c C-e'" 'spacemacs//helm-find-files-edit
            helm-source-find-files))
         (add-hook 'helm-find-files-before-init-hook
                   'spacemacs//add-action-helm-find-files-edit))
+      (with-eval-after-load 'helm-buffers
+        (define-key helm-buffer-map
+          (kbd "C-o") 'helm-buffer-switch-other-window))
       ;; Add minibuffer history with `helm-minibuffer-history'
       (define-key minibuffer-local-map (kbd "C-c C-l") 'helm-minibuffer-history)
       ;; Delay this key bindings to override the defaults


### PR DESCRIPTION
Advantage:
- Consistent behavior with helm-files, helm-buffers and helm-bookmarks.

Remarks:
- It may be better to actually use `C-<return>`. This is what I use personally, but I thought it interferes too much with the current setup. Like so, `<return>` opens the buffer/file/bookmark in the current window and `C-<return>` in another one.
