### PR TITLE
[version-control] Show bound but unlisted VCS TS key: d

### DIFF
--- a/layers/+source-control/version-control/keybindings.el
+++ b/layers/+source-control/version-control/keybindings.el
@@ -29,7 +29,7 @@
  [_n_]^^^^      next hunk            [_w_/_u_]^^    stage/unstage in current file     [_z_] recenter
  [_N_/_p_]^^    previous hunk        [_c_/_C_]^^    commit with popup/direct commit   [_q_] quit
  [_r_/_s_/_h_]  revert/stage/show    [_f_/_F_/_P_]  fetch/pull/push popup
- [_t_]^^^^      toggle diff signs    [_l_/_D_]^^    log/diff popup"
+ [_t_]^^^^      toggle diff signs    [_l_/_d_/_D_]  log/ediff/diff popup"
   :on-enter (spacemacs/vcs-enable-margin)
   :bindings
   ("C" magit-commit :exit t)


### PR DESCRIPTION
In the VCS Transient State (`SPC g .`)
The key: `d` is bound to: `magit-ediff`
But `d` isn't shown in the VCS TS.
