### PR TITLE
[helm] Add `S-RET` keybinding for helm modes to open in other window

### DIFF
--- a/layers/+completion/helm/README.org
+++ b/layers/+completion/helm/README.org
@@ -18,6 +18,8 @@
 - [[#key-bindings][Key bindings]]
   - [[#hjkl-navigation][hjkl navigation]]
   - [[#transient-state][Transient state]]
+  - [[#files][Files]]
+  - [[#buffers][Buffers]]
   - [[#bookmarks][Bookmarks]]
   - [[#colorsfaces][Colors/Faces]]
   - [[#c-z-and-tab-switch][C-z and Tab switch]]
@@ -137,7 +139,7 @@ Helm buffers with ~hjkl~.
 | ~C-H~       | describe key (replace ~C-h~) |
 | ~C-j~       | go to previous candidate     |
 | ~C-k~       | go to next candidate         |
-| ~C-l~       | same as ~return~             |
+| ~C-l~       | same as ~<return>~           |
 
 ** Transient state
 Spacemacs defines a transient state for =Helm= to make it work like [[https://github.com/Shougo/unite.vim][Vim's Unite]]
@@ -171,15 +173,29 @@ Initiate the transient state with ~M-SPC~ or ~s-M-SPC~ while in a =Helm= buffer.
 | ~T~                  | mark all candidates                                  |
 | ~v~                  | execute persistent action                            |
 
+** Files
+In the =helm-files= buffer:
+
+| Key binding  | Description                            |
+|--------------+----------------------------------------|
+| ~S-<return>~ | open the selected file in other window |
+
+** Buffers
+In the =helm-buffers= buffer:
+
+| Key binding  | Description                              |
+|--------------+------------------------------------------|
+| ~S-<return>~ | open the selected buffer in other window |
+
 ** Bookmarks
 In the =helm-bookmarks= buffer:
 
-| Key binding | Description                                  |
-|-------------+----------------------------------------------|
-| ~C-d~       | delete the selected bookmark                 |
-| ~C-e~       | edit the selected bookmark                   |
-| ~C-f~       | toggle filename location                     |
-| ~C-o~       | open the selected bookmark in another window |
+| Key binding  | Description                                |
+|--------------+--------------------------------------------|
+| ~C-d~        | delete the selected bookmark               |
+| ~C-e~        | edit the selected bookmark                 |
+| ~C-f~        | toggle filename location                   |
+| ~S-<return>~ | open the selected bookmark in other window |
 
 ** Colors/Faces
 
@@ -214,7 +230,7 @@ modifications to the buffer.
 ** Universal argument
 ~SPC u~ is not working before =helm-M-x= (~SPC SPC~). Instead, call =helm-M-x=
 first, select the command you want to run, and press ~C-u~ before pressing
-~RETURN~. For instance: ~SPC SPC org-reload C-u RET~
+~<return>~. For instance: ~SPC SPC org-reload C-u RET~
 
 ** Replacing text in several files
 If you have =rg=, =ag=, =pt= or =ack= installed, replacing an occurrence of text

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -138,12 +138,17 @@
       (with-eval-after-load 'helm-files
         (define-key helm-find-files-map
           (kbd "C-c C-e") 'spacemacs/helm-find-files-edit)
+        (define-key helm-find-files-map
+          (kbd "S-<return>") 'helm-ff-run-switch-other-window)
         (defun spacemacs//add-action-helm-find-files-edit ()
           (helm-add-action-to-source
            "Edit files in dired `C-c C-e'" 'spacemacs//helm-find-files-edit
            helm-source-find-files))
         (add-hook 'helm-find-files-before-init-hook
                   'spacemacs//add-action-helm-find-files-edit))
+      (with-eval-after-load 'helm-buffers
+        (define-key helm-buffer-map
+          (kbd "S-<return>") 'helm-buffer-switch-other-window))
       ;; Add minibuffer history with `helm-minibuffer-history'
       (define-key minibuffer-local-map (kbd "C-c C-l") 'helm-minibuffer-history)
       ;; Delay this key bindings to override the defaults
@@ -197,7 +202,7 @@
         (define-key helm-bookmark-map
           (kbd "C-f") 'helm-bookmark-toggle-filename)
         (define-key helm-bookmark-map
-          (kbd "C-o") 'helm-bookmark-run-jump-other-window)
+          (kbd "S-<return>") 'helm-bookmark-run-jump-other-window)
         (define-key helm-bookmark-map (kbd "C-/") 'helm-bookmark-help))
       (with-eval-after-load 'helm-bookmark
         (simpler-helm-bookmark-keybindings))


### PR DESCRIPTION
Remove `C-o` keybinding from helm-bookmarks.

Add `S-RET` keybinding to open file/buffer/bookmark in other window for
helm-files helm-buffers and helm-bookmarks.

Advantage: Consistent behavior. It is pretty cumbersome to use the persistent
action provided by helm to open files/buffers/bookmarks in the other window.

I renamed the branch, so the other PR https://github.com/syl20bnr/spacemacs/pull/14781 was closed.