### PR TITLE
[+intl/chinese] fix warning for quote lambda function

### DIFF
--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -112,7 +112,7 @@
                  (spacemacs|hide-lighter pangu-spacing-mode)
                  ;; Always insert `real' space in org-mode.
                  (add-hook 'org-mode-hook
-                           '(lambda ()
+                           #'(lambda ()
                               (setq-local pangu-spacing-real-insert-separtor t))))))
 
 (defun chinese/init-chinese-conv ()


### PR DESCRIPTION
Fix the warning message:
`layers/+intl/chinese/packages.el: Warning: (lambda nil \.\.\.) quoted with ' rather than with #'`