### PR TITLE
[perforce] Add p4-shelve and p4-unshelve commands with keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -291,6 +291,12 @@ In org-agenda-mode
   - Add consistent keybinding ~SPC m .~ to enter transient-state (thanks to Daniel Nicolai)
   - Removed ~C-h~ binding in =org-agenda-mode= (thanks to Ag Ibragimov)
   - Rebind =org-agenda-refile= to ~r~ in transient state (thanks to Muneeb Shaikh)
+***** Perforce
+- Added =p4-shelve= and =p4-unshelve= commands from =p4= package
+  (thanks to Binary-Eater)
+- Key bindings:
+  - New ~SPC p 4 [~ to shelve changes
+  - New ~SPC p 4 ]~ to select a changelist to unshelve
 ***** Python
 - fix/implement pyvenv-tracking-mode (thanks to Daniel Nicolai)
 - Key bindings (thanks to Danny Freeman):

--- a/layers/+source-control/perforce/README.org
+++ b/layers/+source-control/perforce/README.org
@@ -40,6 +40,8 @@ Don't forget to setup the environment variables:
 | ~SPC p 4 r~ | revert a file                                                |
 | ~SPC p 4 R~ | refresh content of an file. =sync -f=                        |
 | ~SPC p 4 S~ | submit CL                                                    |
+| ~SPC p 4 [~ | shelve CL                                                    |
+| ~SPC p 4 ]~ | unshelve specified CL                                        |
 | ~SPC p 4 b~ | create, modify, or delete a branch view specification        |
 | ~SPC p 4 B~ | display list of branch specifications                        |
 | ~SPC p 4 c~ | create or edit a client workspace specification and its view |

--- a/layers/+source-control/perforce/packages.el
+++ b/layers/+source-control/perforce/packages.el
@@ -44,9 +44,11 @@
                p4-revert
                p4-refresh
                p4-resolve
+               p4-shelve
                p4-status
                p4-submit
                p4-toggle-vc-mode
+               p4-unshelve
                p4-user
                p4-users
                p4-version
@@ -95,6 +97,8 @@
         "p4y" 'p4-resolve
         "p4s" 'p4-status
         "p4S" 'p4-submit
+        "p4[" 'p4-shelve
+        "p4]" 'p4-unshelve
         "p4t" 'p4-toggle-vc-mode
         "p4u" 'p4-user
         "p4U" 'p4-users


### PR DESCRIPTION
Shelving and unshelving changelists are operations commonly used when
choosing Perforce as a VCS solution. Package consumed by the "perforce"
layer already provides "p4-shelve" and "p4-unshelve" commands that can
be exposed by the layer. Provide keybindings for these two commands as
well.