### PR TITLE
Add custom-file to recentf-exclude list

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -407,7 +407,9 @@
       (add-to-list 'recentf-exclude
                    (recentf-expand-file-name spacemacs-cache-directory))
       (add-to-list 'recentf-exclude (recentf-expand-file-name package-user-dir))
-      (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'"))))
+      (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
+      (unless (null custom-file)
+        (add-to-list 'recentf-exclude custom-file)))))
 
 (defun spacemacs-defaults/init-savehist ()
   (use-package savehist


### PR DESCRIPTION
This makes sure custom-file is excluded from the recentf list if it is non-nil. I personally find it annoying when this shows up in my recentf list because it's not a file I edit manually.

There is one slight nuance here: custom-file is both a variable and a function. The difference is that the function (custom-file) can evaluate to user-init-file when custom-file is null. I don't think we want to exclude user-init-file in that case, hence I'm using the custom-file variable (not the function) with a null check.