### PR TITLE
Add bindings for opening eaf applications

### DIFF
--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -54,6 +54,8 @@
       (spacemacs/set-leader-keys "aaj" 'eaf-open-jupyter)
       (spacemacs/set-leader-keys "aao" 'eaf-open-office)
       (spacemacs/set-leader-keys "aat" 'eaf-open-terminal)
+      (spacemacs/set-leader-keys "aas" 'eaf-open-system-monitor)
+      (spacemacs/set-leader-keys "aaM" 'eaf-open-music-player)
 
       (spacemacs/declare-prefix "aab" "browser")
       (spacemacs/set-leader-keys "aabo" 'eaf-open-browser)


### PR DESCRIPTION
EAF recently added a system monitor. Add `SPC a a s` to open it.
Also add `SPC a a M` to open the eaf music player.
