### PR TITLE
use org and org-contrib packages rather than org-plus-contrib

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -454,9 +454,9 @@ cache folder.")
     (setq package-enable-at-startup nil)
     (package-initialize 'noactivate)
     ;; hack to be sure to enable insalled org from Org ELPA repository
-    (when (package-installed-p 'org-plus-contrib)
+    (when (package-installed-p 'org)
       (spacemacs-buffer/message "Initializing Org early...")
-      (configuration-layer//activate-package 'org-plus-contrib))))
+      (configuration-layer//activate-package 'org))))
 
 (defun configuration-layer//configure-quelpa ()
   "Configure `quelpa' package."
@@ -2605,7 +2605,8 @@ Original code from dochang at https://github.com/dochang/elpa-clone"
   (let (package-archive-contents
         (package-archives '(("melpa" . "https://melpa.org/packages/")
                             ("org"   . "https://orgmode.org/elpa/")
-                            ("gnu"   . "https://elpa.gnu.org/packages/"))))
+                            ("gnu"   . "https://elpa.gnu.org/packages/")
+                            ("nongnu" . "https://elpa.nongnu.org/nongnu/"))))
     (package-refresh-contents)
     (package-read-all-archive-contents)
     (let* ((packages (configuration-layer//get-indexed-elpa-package-names))
@@ -2846,40 +2847,6 @@ files."
 ;; (configuration-layer/create-elpa-repository
 ;;  "spacelpa"
 ;;  spacemacs-cache-directory)
-
-(defun configuration-layer//package-install-org (func &rest args)
-  "Advice around `package-install' to patch package name and dependencies at
-install time in order to replace all `org' package installation by
-`org-plus-contrib'. We avoid installing unecessarily both `org' and
-`org-plus-contrib' at the same time (i.e. we always install `org-plus-contrib')"
-  (let* ((pkg (car args))
-         (patched
-          (cond
-           ;; patch symbol name
-           ((and (symbolp pkg) (eq 'org pkg))
-            (setcar args 'org-plus-contrib)
-            t)
-           ;; patch name in package-desc object
-           ((and (package-desc-p pkg)
-                 (eq 'org (package-desc-name pkg)))
-            (setf (package-desc-name pkg) 'org-plus-contrib)
-            t)
-           ;; patch dependencies in package-desc object
-           ((and (package-desc-p pkg)
-                 (assq 'org (package-desc-reqs pkg)))
-            (setf (car (assq 'org (package-desc-reqs pkg))) 'org-plus-contrib)
-            t))))
-    (let ((name (if (package-desc-p pkg)
-                    (package-desc-name pkg)
-                  pkg)))
-      ;; check manually if `org-plus-contrib' is already installed since
-      ;; package.el may install `org-plus-contrib' more than once.
-      ;; Maybe we could hook somewhere else (at transaction computation time?)
-      (if (or patched (eq 'org-plus-contrib name))
-          (unless (package-installed-p name)
-            (apply func args))
-        (apply func args)))))
-(advice-add 'package-install :around #'configuration-layer//package-install-org)
 
 (defun configuration-layer//increment-error-count ()
   "Increment the error counter."

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -39,6 +39,7 @@
                 :toggle org-enable-notifications)
     (org-contacts :location built-in
                   :toggle org-enable-org-contacts-support)
+    org-contrib
     (org-vcard :toggle org-enable-org-contacts-support)
     org-brain
     (org-expiry :location built-in)
@@ -854,6 +855,10 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "Cf" 'org-contacts-find-file)
       (spacemacs/set-leader-keys
         "aoCf" 'org-contacts-find-file))))
+
+(defun org/init-org-contrib ()
+  (use-package org-contrib
+    :defer t))
 
 (defun org/init-org-vcard ()
   (use-package org-vcard

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -42,8 +42,8 @@
 (defun spacemacs-org/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'org-mode-hook))
 
-;; dummy init function to force installation of `org-plus-contrib'
-(defun spacemacs-org/init-org-plus-contrib ())
+;; dummy init function to force installation of `org'
+(defun spacemacs-org/init-org ())
 
 (defun spacemacs-org/init-default-org-config ()
   (use-package org

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -33,7 +33,8 @@
     ;; layer. So it is easier for users to steal the ownership of the
     ;; `org' package.
     (default-org-config :location built-in)
-    (org-plus-contrib :step pre)
+    (org :step pre)
+    org-contrib
     org-superstar
     (space-doc :location local)
     toc-org
@@ -73,6 +74,10 @@
                     (3 font-lock-comment-face prepend))))
       ;; Open links and files with RET in normal state
       (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)))))
+
+(defun spacemacs-org/init-org-contrib ()
+  (use-package org-contrib
+    :defer t))
 
 (defun spacemacs-org/init-org-superstar ()
   (use-package org-superstar

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -34,7 +34,6 @@
     ;; `org' package.
     (default-org-config :location built-in)
     (org :step pre)
-    org-contrib
     org-superstar
     (space-doc :location local)
     toc-org
@@ -74,10 +73,6 @@
                     (3 font-lock-comment-face prepend))))
       ;; Open links and files with RET in normal state
       (evil-define-key 'normal org-mode-map (kbd "RET") 'org-open-at-point)))))
-
-(defun spacemacs-org/init-org-contrib ()
-  (use-package org-contrib
-    :defer t))
 
 (defun spacemacs-org/init-org-superstar ()
   (use-package org-superstar


### PR DESCRIPTION
The "contrib" portion of `org-plus-contrib` is now available as separate package named `org-contrib` within `nongnu` package archive.
This pull request replaces use of `org-plus-contrib` package with `org` and `org-contrib` packages.

I believe `org-plus-contrib` will no longer be available starting with org version 9.5, so that we need to move away from using it in the near future.
