### PR TITLE
`(format (concat go-run-command)` modification

### DIFF
--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -144,12 +144,12 @@
 (defun spacemacs/go-run-main ()
   (interactive)
   (shell-command
-   (format (concat go-run-command " .")
+   (format (concat go-run-command " ." go-run-args)
            (shell-quote-argument (or (file-remote-p (buffer-file-name (buffer-base-buffer)) 'localname)
                                      (buffer-file-name (buffer-base-buffer))))
            go-run-args)))
 
-
+
 ;; misc
 
 (defun spacemacs/go-packages-gopkgs ()

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -144,7 +144,7 @@
 (defun spacemacs/go-run-main ()
   (interactive)
   (shell-command
-   (format (concat go-run-command " %s %s")
+   (format (concat go-run-command " .")
            (shell-quote-argument (or (file-remote-p (buffer-file-name (buffer-base-buffer)) 'localname)
                                      (buffer-file-name (buffer-base-buffer))))
            go-run-args)))


### PR DESCRIPTION
Changed `(format (concat go-run-command " %s %s .")` to `(format (concat go-run-command " .")` (space dot), to allow `main.go` running when functions are invoked from another file, so that `go-run-main` runs `go run .`, as suggested here: 
https://github.com/microsoft/vscode-go/issues/3096