### PR TITLE
Fix one diminish pattern in a list in :spacediminish

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -309,7 +309,7 @@ the scroll transient state.")
   (let ((body (use-package-process-keywords name rest state)))
     (use-package-concat
      `((when (fboundp 'spacemacs|diminish)
-         ,@(if (consp (cadr arg)) ;; e.g. ((MODE1 FOO BAR) (MODE2 BAZ XYZ))
+         ,@(if (consp (car arg)) ;; e.g. ((MODE FOO BAR) ...)
                (mapcar #'(lambda (var) `(spacemacs|diminish ,@var))
                        arg)
              `((spacemacs|diminish ,@arg))))) ;; e.g. (MODE FOO BAR)


### PR DESCRIPTION
The code changed here wants to distinguish the cases of whether `arg` is a list
with one set of args to `spacemacs|diminish` or a list of a list of such args.
It used to look at the second element of `args` to make that distinction.
Consequently, if you want to specify a list of a list of args for
`:spacediminish`, you'd have to have at least two such lists of args in the list.

However in
https://github.com/syl20bnr/spacemacs/commit/38f582d785627fe996141d15aa54cdba2c3167a4
a usage with a list of just one list of args was introduced.

This fixes changes the detection so that it looks at the first element of `arg`.
If that's a list, `arg` is assumed to be a list of lists of args to
`spacemacs|diminish`. If it's not, it's assumed to be just a list of args to
`spacemacs|diminish`. That works well because the first argument to
`spacemacs|diminish` is a symbol.

Fixes #14726

