### PR TITLE
[transmission] Add new keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -350,6 +350,17 @@ In org-agenda-mode
   - Changed ~SPC e e~ to ~SPC e b~ for =flycheck-buffer=
 ***** Tabs
 - Add auto hide tabs feature (thanks to Daniel Nicolai)
+***** Transmission
+- Key bindings (thanks to Arif Er):
+  - Organised and corrected in both =packages.el= and =README.org=.
+  - Change ~SPC m s l~ to ~SPC m s r~ for =transmission-set-ratio= and =transmission-set-torrent-ratio=.
+  - Change ~SPC m r~ to ~SPC m R~ for =transmission-remove=.
+  - Change ~SPC m m~ to ~SPC m r~ for =transmission-move=.
+  - Change ~SPC m r~ to ~SPC m X~ for =transmission-files-command=.
+  - Swap ~SPC m a a~ and ~SPC m a t~ for =transmission-add= and =transmission-trackers-add= respectively.
+  - Change ~SPC m s b~ to ~SPC m s p~ for =transmission-set-bandwidth-priority=.
+  - Change ~SPC m g t~ to ~SPC m g f~ for =transmission-files=.
+  - Change ~SPC m m u~ and ~SPC m m w~ to ~SPC m t u~ and ~SPC m t w~ for =transmission-files-unwant= and =trasnmission-files-want= respectively
 ***** Vagrant
 - Key bindings:
   - Vagrant key bindings prefix is now ~SPC a V~.
@@ -3616,6 +3627,18 @@ files (thanks to Daniel Nicolai)
 - Prevent =tmux-command= at GUI mode (thanks to Isaac Zeng)
 - Fixed regression in tmux by setting keybindings using =use-package=
   (thanks to Aaron Jensen)
+**** Transmission
+- Key bindings (thanks to Arif Er):
+  - ~H/L~ is to move torrent to the top/bottom of the queue.
+  - ~J/K~ is to move torrent down/up the queue.
+  - ~SPC m D~ is to remove and delete torrent at point.
+  - ~SPC m m~ is to mark torrent(s) at point or in region.
+  - ~SPC m S~ is to sort the torrents according to the column at point.
+  - ~SPC m s l~ is to set label(s) for marked torrent(s).
+  - ~SPC m t t~ is to toggle =transmission-turtle-mode=.
+  - ~SPC m s D~ is to set days for =transmission-turtle-mode= to be active.
+  - ~SPC m s S~ is to set speed limits for =transmission-turtle-mode=.
+  - ~SPC m s T~ is to set time range for =transmission-turtle-mode to be active.
 **** Treemacs
 - =Treemacs= replaces =NeoTree= as the default sidebar
 - Added missing ~SPC p t~ to =readme.org= (thanks to oo6)

--- a/layers/+tools/transmission/README.org
+++ b/layers/+tools/transmission/README.org
@@ -16,6 +16,7 @@
   - [[#transmission-info-mode][=transmission-info-mode=]]
   - [[#transmission-files-mode][=transmission-files-mode=]]
   - [[#transmission-peers-mode][=transmission-peers-mode=]]
+  - [[#transmission-turtle-mode][=transmission-turtle-mode=]]
 
 * Description
 This layer integrates a BitTorrent client into Spacemacs.
@@ -63,52 +64,99 @@ Add =(transmission :variables transmission-auto-refresh-all t)= to
 
 ** =transmission-mode=
 
-| Key binding | Description                                                   |
-|-------------+---------------------------------------------------------------|
-| ~SPC m g t~ | Open a `transmission-files-mode' buffer for torrent at point. |
-| ~SPC m a t~ | Add torrent by filename, URL, magnet link, or info hash.      |
-| ~SPC m s d~ | Set global download speed limit in kB/s.                      |
-| ~SPC m g p~ | Open a =transmission-peers-mode= buffer for torrent at point. |
-| ~SPC m g i~ | Open a =transmission-info-mode= buffer for torrent at point.  |
-| ~SPC m s l~ | Set global seed ratio limit.                                  |
-| ~SPC m m~   | Move torrent at point or in region to a new location.         |
-| ~SPC m r~   | Prompt to remove torrent at point or torrents in region.      |
-| ~SPC m t s~ | Toggle torrent between started and stopped.                   |
-| ~SPC m a a~ | Add announce URLs to torrent or torrents.                     |
-| ~SPC m s u~ | Set global upload speed limit in kB/s.                        |
-| ~SPC m v~   | Verify torrent at point or in region.                         |
-| ~SPC m q~   | Quit and bury the buffer.                                     |
-| ~SPC m s b~ | Set bandwidth priority of torrent(s) at point or in region.   |
+| Key binding  | Description                                                       |
+|--------------+-------------------------------------------------------------------|
+| ~J/K~        | Move torrent down/up the queue by one.                            |
+| ~H/L~        | Move torrent to the top/bottom of the queue.                      |
+| ~SPC m D~    | Delete from disk and remove torrent(s) at point or in region.     |
+| ~SPC m m~    | Toggle mark on torrent(s) at point or in region.                  |
+| ~SPC m q~    | Quit and bury the buffer.                                         |
+| ~SPC m r~    | Relocate torrent save directory at point or in region.            |
+| ~SPC m R~    | Remove torrent(s) at point or in region.                          |
+| ~SPC m S~    | Sort torrents according to the column at point.                   |
+| ~SPC m v~    | Verify torrent at point or in region.                             |
+|--------------+-------------------------------------------------------------------|
+| Add          |                                                                   |
+|--------------+-------------------------------------------------------------------|
+| ~SPC m a a~  | Add torrent by filename, URL, magnet link, or info hash.          |
+| ~SPC m a t~  | Add announce URLs to marked torrent(s) or torrent at point.       |
+|--------------+-------------------------------------------------------------------|
+| Go to mode   |                                                                   |
+|--------------+-------------------------------------------------------------------|
+| ~SPC m g i~  | Open a =transmission-info-mode= buffer for torrent at point.      |
+| ~SPC m g f~  | Open a =transmission-files-mode= buffer for torrent at point.     |
+| ~SPC m g p~  | Open a =transmission-peers-mode= buffer for torrent at point.     |
+|--------------+-------------------------------------------------------------------|
+| Set property |                                                                   |
+|--------------+-------------------------------------------------------------------|
+| ~SPC m s d~  | Set global download speed limit in kB/s.                          |
+| ~SPC m s l~  | Set label(s) for marked torrent(s) or torrent at point.           |
+| ~SPC m s p~  | Set bandwidth priority of torrent(s) at point or in region.       |
+| ~SPC m s r~  | Set global seed ratio limit.                                      |
+| ~SPC m s u~  | Set global upload speed limit in kB/s.                            |
+|--------------+-------------------------------------------------------------------|
+| Toggle       |                                                                   |
+|--------------+-------------------------------------------------------------------|
+| ~SPC m t s~  | Toggle torrent(s) at point or region between started and stopped. |
+| ~SPC m t t~  | Toggle =transmission-turtle-mode=.                                |
 
 ** =transmission-info-mode=
 
-| Key binding | Description                                                   |
-|-------------+---------------------------------------------------------------|
-| ~SPC m c~   | Copy magnet link of current torrent.                          |
-| ~SPC m s d~ | Set download limit of torrent(s) at point in kB/s.            |
-| ~SPC m g p~ | Open a =transmission-peers-mode= buffer for torrent at point. |
-| ~SPC m s l~ | Set seed ratio limit of torrent(s) at point.                  |
-| ~SPC m m~   | Move torrent at point or in region to a new location.         |
-| ~SPC m a a~ | Add announce URLs to torrent or torrents.                     |
-| ~SPC m T~   | Remove trackers from torrent at point by ID or announce URL.  |
-| ~SPC m s u~ | Set upload limit of torrent(s) at point in kB/s.              |
-| ~SPC m s p~ | Set bandwidth priority of torrent(s) at point or in region.   |
+| Key binding  | Description                                                  |
+|--------------+--------------------------------------------------------------|
+| ~SPC m a~    | Add announce URLs to current torrent.                        |
+| ~SPC m c~    | Copy magnet link of current torrent.                         |
+| ~SPC m r~    | Relocate current torrent save directory.                     |
+| ~SPC m T~    | Remove trackers from current torrent by ID or announce URL.  |
+|--------------+--------------------------------------------------------------|
+| Go to mode   |                                                              |
+|--------------+--------------------------------------------------------------|
+| ~SPC m g f~  | Open a =transmission-files-mode= buffer for current torrent. |
+| ~SPC m g p~  | Open a =transmission-peers-mode= buffer for current torrent. |
+|--------------+--------------------------------------------------------------|
+| Set property |                                                              |
+|--------------+--------------------------------------------------------------|
+| ~SPC m s d~  | Set download limit of current torrent in kB/s.               |
+| ~SPC m s l~  | Set label(s) of current torrent.                             |
+| ~SPC m s p~  | Set bandwidth priority of current torrent.                   |
+| ~SPC m s r~  | Set seed ratio limit of current torrent.                     |
+| ~SPC m s u~  | Set upload limit of current torrent in kB/s.                 |
 
 ** =transmission-files-mode=
 
-| Key binding | Description                                                   |
-|-------------+---------------------------------------------------------------|
-| ~SPC m g f~ | Visit the file at point with =find-file-read-only=.           |
-| ~SPC m r~   | Run a command on the file at point.                           |
-| ~SPC m g p~ | Open a =transmission-peers-mode= buffer for torrent at point. |
-| ~SPC m g i~ | Open a =transmission-info-mode= buffer for torrent at point.  |
-| ~SPC m m~   | Move torrent at point or in region to a new location.         |
-| ~SPC m m u~ | Mark file(s) at point or in region as unwanted.               |
-| ~SPC m m w~ | Mark file(s) at point or in region as wanted.                 |
-| ~SPC s p~   | Set bandwidth priority on file(s) at point or in region.      |
+| Key binding  | Description                                                  |
+|--------------+--------------------------------------------------------------|
+| ~SPC m m~    | Toggle mark on the file at point.                            |
+| ~SPC m X~    | Run a command on the file at point.                          |
+|--------------+--------------------------------------------------------------|
+| Go to mode   |                                                              |
+|--------------+--------------------------------------------------------------|
+| ~SPC m g f~  | Visit the file at point with =find-file-read-only=.          |
+| ~SPC m g i~  | Open a =transmission-info-mode= buffer for current torrent.  |
+| ~SPC m g p~  | Open a =transmission-peers-mode= buffer for current torrent. |
+|--------------+--------------------------------------------------------------|
+| Set property |                                                              |
+|--------------+--------------------------------------------------------------|
+| ~SPC m s p~  | Set bandwidth priority on file(s) at point or in region.     |
+|--------------+--------------------------------------------------------------|
+| Toggle       |                                                              |
+|--------------+--------------------------------------------------------------|
+| ~SPC m m u~  | Mark file(s) at point or in region as unwanted.              |
+| ~SPC m m w~  | Mark file(s) at point or in region as wanted.                |
 
 ** =transmission-peers-mode=
 
 | Key binding | Description                                                  |
 |-------------+--------------------------------------------------------------|
+| Go to mode  |                                                              |
+|-------------+--------------------------------------------------------------|
 | ~SPC m g i~ | Open a =transmission-info-mode= buffer for torrent at point. |
+
+** =transmission-turtle-mode=
+| Key binding  | Description                                                 |
+|--------------+-------------------------------------------------------------|
+| Set property |                                                             |
+|--------------+-------------------------------------------------------------|
+| ~SPC m s D~  | Set days for =transmission-turtle-mode= to be active.       |
+| ~SPC m s S~  | Set global speed limits for =transmission-turtle-mode=.     |
+| ~SPC m s T~  | Set time range for =transmission-turtle-mode= to be active. |

--- a/layers/+tools/transmission/packages.el
+++ b/layers/+tools/transmission/packages.el
@@ -27,56 +27,98 @@
 (defun transmission/init-transmission ()
   (use-package transmission
     :defer t
-    :init (progn
-            (spacemacs/set-leader-keys "att" 'transmission)
-            (spacemacs/declare-prefix-for-mode 'transmission-mode "ma" "add")
-            (spacemacs/declare-prefix-for-mode 'transmission-mode "mg" "goto")
-            (spacemacs/declare-prefix-for-mode 'transmission-mode "ms" "set")
-            (spacemacs/declare-prefix-for-mode 'transmission-mode "mt" "toggle")
-            (spacemacs/set-leader-keys-for-major-mode 'transmission-mode
-              "gt" 'transmission-files
-              "at" 'transmission-add
-              "sd" 'transmission-set-download
-              "gp" 'transmission-peers
-              "gi" 'transmission-info
-              "sl" 'transmission-set-ratio
-              "m"  'transmission-move
-              "r"  'transmission-remove
-              "ts" 'transmission-toggle
-              "aa" 'transmission-trackers-add
-              "su" 'transmission-set-upload
-              "v"  'transmission-verify
-              "q"  'transmission-quit
-              "sb" 'transmission-set-bandwidth-priority)
-            (spacemacs/declare-prefix-for-mode 'transmission-info-mode "ma" "add")
-            (spacemacs/declare-prefix-for-mode 'transmission-info-mode "mg" "goto")
-            (spacemacs/declare-prefix-for-mode 'transmission-info-mode "ms" "set")
-            (spacemacs/set-leader-keys-for-major-mode 'transmission-info-mode
-              "c"  'transmission-copy-magnet
-              "sd" 'transmission-set-torrent-download
-              "gp" 'transmission-peers
-              "sl" 'transmission-set-torrent-ratio
-              "m"  'transmission-move
-              "aa" 'transmission-trackers-add
-              "T"  'transmission-trackers-remove
-              "su" 'transmission-set-torrent-upload
-              "sp" 'transmission-set-bandwidth-priority)
-            (spacemacs/declare-prefix-for-mode 'transmission-files-mode "mg" "goto")
-            (spacemacs/declare-prefix-for-mode 'transmission-files-mode "mm" "mark")
-            (spacemacs/declare-prefix-for-mode 'transmission-files-mode "ms" "set")
-            (spacemacs/set-leader-keys-for-major-mode 'transmission-files-mode
-              "gf" 'transmission-find-file
-              "r"  'transmission-files-command
-              "gp" 'transmission-peers
-              "gi" 'transmission-info
-              "mm" 'transmission-move
-              "mu" 'transmission-files-unwant
-              "mw" 'transmission-files-want
-              "sp" 'transmission-files-priority)
-            (spacemacs/set-leader-keys-for-major-mode 'transmission-peers-mode
-              "i" 'transmission-info))
-    :config (when transmission-auto-refresh-all
-              (setq transmission-refresh-modes '(transmission-mode
-                                                 transmission-files-mode
-                                                 transmission-info-mode
-                                                 transmission-peers-mode)))))
+    :init (spacemacs/set-leader-keys "att" 'transmission)
+    :config
+    (progn
+      (spacemacs/declare-prefix-for-mode 'transmission-mode "ma" "add")
+      (spacemacs/declare-prefix-for-mode 'transmission-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'transmission-mode "ms" "set")
+      (spacemacs/declare-prefix-for-mode 'transmission-mode "mt" "toggle")
+      (spacemacs/set-leader-keys-for-major-mode 'transmission-mode
+        "D"  'transmission-delete
+        "m"  'transmission-toggle-mark
+        "q"  'transmission-quit
+        "r"  'transmission-move
+        "R"  'transmission-remove
+        "S"  'tabulated-list-sort
+        "v"  'transmission-verify
+
+        ;; add
+        "aa" 'transmission-add
+        "at" 'transmission-trackers-add
+
+        ;; goto
+        "gi" 'transmission-info
+        "gf" 'transmission-files
+        "gp" 'transmission-peers
+
+        ;; set
+        "sd" 'transmission-set-download
+        "sl" 'transmission-label
+        "sp" 'transmission-set-bandwidth-priority
+        "sr" 'transmission-set-ratio
+        "su" 'transmission-set-upload
+
+        ;; toggle
+        "ts" 'transmission-toggle
+        "tt" 'transmission-turtle-mode)
+
+      (evil-define-key 'normal transmission-mode-map
+        "H" 'transmission-queue-move-top
+        "J" 'transmission-queue-move-down
+        "K" 'transmission-queue-move-up
+        "L" 'transmission-queue-move-bottom)
+
+      (spacemacs|diminish transmission-turtle-mode " 🐢" " [T]")
+      (spacemacs/declare-prefix-for-minor-mode 'transmission-turtle-mode "ms" "set")
+      (spacemacs/set-leader-keys-for-minor-mode 'transmission-turtle-mode
+        ;; set
+        "sD" 'transmission-turtle-set-days
+        "sS" 'transmission-turtle-set-speeds
+        "sT" 'transmission-turtle-set-times)
+
+      (spacemacs/declare-prefix-for-mode 'transmission-info-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'transmission-info-mode "ms" "set")
+      (spacemacs/set-leader-keys-for-major-mode 'transmission-info-mode
+        "a"  'transmission-trackers-add
+        "c"  'transmission-copy-magnet
+        "r"  'transmission-move
+        "T"  'transmission-trackers-remove
+
+        ;; goto
+        "gf" 'transmission-files
+        "gp" 'transmission-peers
+
+        ;; set
+        "sd" 'transmission-set-torrent-download
+        "sl" 'transmission-label
+        "sp" 'transmission-set-bandwidth-priority
+        "sr" 'transmission-set-torrent-ratio
+        "su" 'transmission-set-torrent-upload)
+
+      (spacemacs/declare-prefix-for-mode 'transmission-files-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'transmission-files-mode "ms" "set")
+      (spacemacs/declare-prefix-for-mode 'transmission-files-mode "mm" "toggle")
+      (spacemacs/set-leader-keys-for-major-mode 'transmission-files-mode
+        "m"  'transmission-toggle-mark
+        "X"  'transmission-files-command
+
+        ;; goto
+        "gf" 'transmission-find-file
+        "gi" 'transmission-info
+        "gp" 'transmission-peers
+
+        ;; set
+        "sp" 'transmission-files-priority
+
+        ;; toggle
+        "tu" 'transmission-files-unwant
+        "tw" 'transmission-files-want)
+
+      (spacemacs/set-leader-keys-for-major-mode 'transmission-peers-mode
+        "i" 'transmission-info)
+      (when transmission-auto-refresh-all
+        (setq transmission-refresh-modes '(transmission-mode
+                                           transmission-files-mode
+                                           transmission-info-mode
+                                           transmission-peers-mode))))))


### PR DESCRIPTION
This commit adds 3 sets of keybindings and organises the keybindings so that it can be read easier.

1. Marking and labelling
   =SPC m t m= marks a torrent and =SPC m s l= sets the labels for marked torrents. The old command bound to =SPC m s l=, =transmission-set-ratio=, is bound to =SPC m s r= instead.
2. Queueing
   Keybindings under a new prefix are added to ~transmission-mode~ to manipulate how the torrents are queued. A keybinding to sort logically by columns is also added.
3. Turtle mode
   A new keybinding while in =transmission-mode= toggles the =transmission-turtle-mode= minor mode. When it is active, a new set of 3 keybindings will be active to change the settings of the minor mode. The bindings used are uppercase letters since there are already defined bindings using the lowercases.

Although there is a keybinding for =transmission-remove= in =transmission-mode=, a new keybinding for =transmission-delete= is also added. This is done since =transmission-remove= merely removes the torrent from Transmission but does not delete the file(s).

The changes are added to =CHANGELOG.develop=