### PR TITLE
Lenient pkg delete

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2398,11 +2398,12 @@ depends on it."
 
 (defun configuration-layer//package-delete (pkg-name)
   "Delete package with name PKG-NAME."
-  (let ((p (cadr (assq pkg-name package-alist))))
-    ;; add force flag to ignore dependency checks in Emacs25
-    (if (not (configuration-layer//system-package-p p))
-        (package-delete p t t)
-      (message "Would have removed package %s but this is a system package so it has not been changed." pkg-name))))
+  (if-let ((pkg (car (alist-get pkg-name package-alist))))
+      ;; add force flag to ignore dependency checks in Emacs25
+      (if (configuration-layer//system-package-p pkg)
+          (message "Would have removed package %s but this is a system package so it has not been changed." pkg-name)
+        (package-delete pkg t t))
+    (message "Can't remove package %s since it isn't installed." pkg-name)))
 
 (defun configuration-layer/delete-orphan-packages (packages)
   "Delete PACKAGES if they are orphan."


### PR DESCRIPTION
I had the problem described in https://github.com/syl20bnr/spacemacs/issues/14820

During a package update on an emacs 26, the devdocs package failed to install an updated version because it now requires emacs 27.1. This prompted me to do a package rollback.

Upon package rollback, spacemacs tried to uninstall the current devdocs package in preparation for restoring the old devdocs package. Since the new package devdocs isn't installed at all, the deletion failed, and with it the whole rollback.

The changes in this PR allow the rollback to continue by having package-delete not fail hard, but instead just output a message.