### PR TITLE
racket: Function-quote company-mode-hook function

### DIFF
--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -42,10 +42,10 @@
   ;; Bug exists in Racket company backend that opens docs in new window when
   ;; company-quickhelp calls it. Note hook is appendended for proper ordering.
   (add-hook 'company-mode-hook
-            '(lambda ()
-               (when (and (equal major-mode 'racket-mode)
-                          (bound-and-true-p company-quickhelp-mode))
-                 (company-quickhelp-mode -1))) t))
+            (lambda ()
+              (when (and (equal major-mode 'racket-mode)
+                         (bound-and-true-p company-quickhelp-mode))
+                (company-quickhelp-mode -1))) t))
 
 (defun racket/post-init-ggtags ()
   (add-hook 'racket-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
At least in Emacs >= 28.0.50 a warning occurs at startup when enabling racket
mode:
`.emacs.d/profiles/spacemacs/layers/+lang/racket/packages.el: Warning: (lambda nil \.\.\.) quoted with ' rather than with #'`

In 27.2 the warning does not appear.

In any case, the warning is fair and the change does not really affect anything
apart from the anonymous function being compiled potentially.
