### PR TITLE
[git] Only load evil-collection in vim or hybrid mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -172,6 +172,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Key bindings;
   - Changed ~SPC g f h~ to ~SPC g f l~ for 'git log' of current file
     (thanks to Ag Ibragimov)
+- Fixed rebase mode displaying incorrect keybindings when using emacs editing style
 ***** gtags
 - Key bindings;
   - Regenerate tags are now under ~SPC m g C~ instead of ~SPC m g c~.

--- a/layers/+source-control/git/funcs.el
+++ b/layers/+source-control/git/funcs.el
@@ -73,11 +73,10 @@
   (let (git-link-open-in-browser)
     (call-interactively 'git-link-commit)))
 
-
-(defun spacemacs//support-evilified-buffer-p (style)
-  "Return non-nil if evil navigation should be enabled for STYLE."
-  (or (eq style 'vim)
-      (and (eq style 'hybrid)
+(defun spacemacs//support-evilified-buffer-p ()
+  "Return non-nil if evil navigation should be enabled."
+  (or (eq dotspacemacs-editing-style 'vim)
+      (and (eq dotspacemacs-editing-style 'hybrid)
            hybrid-style-enable-evilified-state)))
 
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -23,7 +23,7 @@
 
 (setq git-packages
       '(
-        evil-collection
+        (evil-collection :toggle (spacemacs//support-evilified-buffer-p))
         fill-column-indicator
         ;; forge requires a C compiler on Windows so we disable
         ;; it by default on Windows.
@@ -242,7 +242,7 @@
       (define-key magit-status-mode-map (kbd "C-S-w")
         'spacemacs/magit-toggle-whitespace)
       ;; Add missing which-key prefixes using the new keymap api
-      (when (spacemacs//support-evilified-buffer-p dotspacemacs-editing-style)
+      (when (spacemacs//support-evilified-buffer-p)
         (which-key-add-keymap-based-replacements magit-status-mode-map
           "gf"  "jump-to-unpulled"
           "gp"  "jump-to-unpushed"))


### PR DESCRIPTION
As described in #9169, when using the emacs editing style the comment inserted at the bottom of a git rebase shows the incorrect key bindings. This is apparently due to `evil-collection` [changing the `git-rebase-mode-hook`](https://github.com/emacs-evil/evil-collection/blob/3ed92cadda7ff1c2d9bc43ec2352e5b02d9e6477/modes/magit/evil-collection-magit.el#L523-L524).

We can fix the issue by only loading `evil-collection` if we're using an evil-style editing mode.