### PR TITLE
fixup fixup fixup #14715

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -57,8 +57,8 @@
     :post-config
     (add-to-list 'golden-ratio-exclude-buffer-names " *transient*")))
 
-(when (spacemacs//support-evilified-buffer-p)
-  (defun git/pre-init-evil-collection ()
+(defun git/pre-init-evil-collection ()
+  (when (spacemacs//support-evilified-buffer-p)
     (add-to-list 'spacemacs-evil-collection-allowed-list 'magit)))
 
 (defun git/post-init-fill-column-indicator ()


### PR DESCRIPTION
funcs.el is loaded after packages.el so `spacemacs//support-evilified-buffer-p` is undefined at this point.

moved it inside the `defun` block and it should work.