### PR TITLE
[doc] Fix broken link

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -439,7 +439,7 @@ Example:
 #+END_SRC
 
 **** Overriding a layer package
-See [[https://www.spacemacs.org/doc/FAQ.html#how-to-override-a-layer-package][this answer in the FAQ's]].
+See [[https://develop.spacemacs.org/doc/FAQ.html#how-to-override-a-layer-package][this answer in the FAQ's]].
 
 *** Without a layer
 Sometimes a layer can be an unnecessary overhead, this is the case if you just


### PR DESCRIPTION
The link that this commit fixes does not exist in the master branch FAQ
documentation.