### PR TITLE
[nix] Add key binding for nix-format-buffer

### DIFF
--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -53,7 +53,10 @@
     :defer t
     :mode "\\.nix\\'"
     :init
-    (add-to-list 'spacemacs-indent-sensitive-modes 'nix-mode)
+    (progn
+      (add-to-list 'spacemacs-indent-sensitive-modes 'nix-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'nix-mode
+        "==" 'nix-format-buffer))
     :config
     (electric-indent-mode -1)))
 


### PR DESCRIPTION
Add key binding `, = =` (nix-format-buffer) in nix-mode buffers.