### PR TITLE
Fix wrong buffer name after file rename

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -418,7 +418,10 @@ projectile cache and updates recentf list."
   (let* ((old-short-name (buffer-name))
          (old-filename (buffer-file-name))
          (old-dir (file-name-directory old-filename))
-         (new-name (read-file-name "New name: " (if arg old-dir old-filename)))
+         (new-name (let ((path (read-file-name "New name: " (if arg old-dir old-filename))))
+                     (if (string= (file-name-nondirectory path) "")
+                         (concat path old-short-name)
+                       path)))
          (new-dir (file-name-directory new-name))
          (new-short-name (file-name-nondirectory new-name))
          (file-moved-p (not (string-equal new-dir old-dir)))
@@ -444,7 +447,7 @@ projectile cache and updates recentf list."
              (recentf-remove-if-non-kept old-filename))
            (when (and (configuration-layer/package-used-p 'projectile)
                       (projectile-project-p))
-             (call-interactively #'projectile-invalidate-cache))
+             (funcall #'projectile-invalidate-cache nil))
            (message (cond ((and file-moved-p file-renamed-p)
                            (concat "File Moved & Renamed\n"
                                    "From: " old-filename "\n"


### PR DESCRIPTION
When providing only the new directory path (i.e. without new filename) while
moving a file to a new directory with `spacemacs/rename-current-buffer-file`,
Spacemacs currently opens the file in a new buffer with the directory name.

Additionally, the `file-renamed-p` gets set to the wrong value. To fix both
issues (with minimal work), it is easiest to just fix the `new-name`
value (alternatively fixing the `rename-buffer` and `set-visited-file-name`
forms later would not fix the wrong `file-renamed-p` value issue).

Finally when called with a universal-argument, then that argument unintended gets 
'passed' in the interactive call to `projectile-invalidate-cache`. So this PR fixes that by changing
the interactive call to a `funcall`.