### PR TITLE
[org] Fix org-habit

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -160,9 +160,6 @@
                     (naive-auto #'spacemacs/org-summary-todo-naive-auto)
                     (semiauto #'spacemacs/org-summary-todo-semiauto))))
 
-      (with-eval-after-load 'org-agenda
-        (add-to-list 'org-modules 'org-habit))
-
       (with-eval-after-load 'org-indent
         (spacemacs|hide-lighter org-indent-mode))
 
@@ -488,6 +485,8 @@ Will work on both org-mode and any mode that accepts plain html."
     :init
     (progn
       (setq org-agenda-restore-windows-after-quit t)
+      (with-eval-after-load 'org
+        (add-to-list 'org-modules 'org-habit))
       (dolist (prefix `(("mC" . ,(org-clocks-prefix))
                         ("md" . "dates")
                         ("mi" . "insert")


### PR DESCRIPTION
Adding `org-habit` to `org-modules` under `(with-eval-after-load 'org-agenda)` in `init-org`
will not properly load it as a module unless `org-agenda` is started before `org`.

Below are some photos of how the issue happens. I have managed to reproduce it on an Arch and Ubuntu distribution with a stock Spacemacs setup.

## Starting `org-agenda` first
Starting `org-agenda` right when Emacs is launched, the `org-habit` graph is displayed just fine. `org-habit` is also seen to be added as a module just fine.
![Starting `org-agenda` first](https://user-images.githubusercontent.com/46054733/121556324-5b1bc480-ca46-11eb-9332-f25a6d775dcd.png)

## Starting `org-mode` first
However, starting an Org file first, the `org-habit` graph no longer appears in the agenda tab even though it appears to be added as a module.
![Starting `org-mode` first](https://user-images.githubusercontent.com/46054733/121556396-6c64d100-ca46-11eb-9d48-d0534dec6e9b.png)

## Fix
The fix that I have made in this commit is to move the appending of `org-habit` to `org-modules` from right after initialising `org` to after initialising `org-agenda`. The reason for this is because I had realised that 

    (use-package org
      :init
      (progn
        ...
        (with-eval-after-load 'org-agenda
          (add-to-list 'org-modules 'org-habit))
        ...))

meant that after initialising `org`, Emacs will only run the code in the wrapper if `org-agenda` had already been loaded. That is not the case for situation 2 where I had first opened up an Org file before checking `org-agenda`. 

Moving it to 

    (use-package org-agenda
      :after org
      :init
       (progn
         ...
         (with-eval-after-load 'org
           (add-to-list 'org-modules 'org-habit)
         ...))

meant that since `org-agenda` would only be loaded after `org` is loaded, `org-habit` would definitely be added as a module. I had tried to do this without the `with-eval-after-load` wrapper but for some reason I know not of, it simply did not work.