### PR TITLE
[core] fix failure message when `user-emacs-directory' not exists

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -100,7 +100,7 @@
 
 ;; ~/.emacs.d/.cache
 (defconst spacemacs-cache-directory
-  (concat user-emacs-directory ".cache/")
+  (locate-user-emacs-file ".cache/")
   "Spacemacs storage area for persistent files.")
 
 ;; ~/.emacs.d/.cache/auto-save


### PR DESCRIPTION
*core-load-paths.el: use function `locate-user-emacs-file` replace create
directory manually.

The Spacemacs will failed for creating `~/.emacs.d/.cache/` when `~/.emacs.d` dose *NOT* exist.
You can reproduce this issue by removing `~/.emacs.d` and installing Spacemacs in `~/.spacemacs/`, loading the `init.el` from `~/.emacs`.