### PR TITLE
[python] Fix keybinding in README

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -366,9 +366,9 @@ by the [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] package. It provides
 
 | Key binding | Description                                     |
 |-------------+-------------------------------------------------|
-| ~SPC m V a~ | activate a virtual environment in any directory |
-| ~SPC m V d~ | deactivate active virtual environment           |
-| ~SPC m V w~ | work on virtual environment in =WORKON_HOME=    |
+| ~SPC m v a~ | activate a virtual environment in any directory |
+| ~SPC m v d~ | deactivate active virtual environment           |
+| ~SPC m v w~ | work on virtual environment in =WORKON_HOME=    |
 
 *** Automatic activation of local virtual environment
 By default Spacemacs uses the [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] package to manage virtual environments.


### PR DESCRIPTION
Fix the keybindings used for `pyvenv` in the README file. The corresponding
lines in `packages.el` are lines [323](https://github.com/syl20bnr/spacemacs/blob/2fd3eb3edbc7c09b825892ce53721120bb999504/layers/%2Blang/python/packages.el#L322)--[325](https://github.com/syl20bnr/spacemacs/blob/2fd3eb3edbc7c09b825892ce53721120bb999504/layers/%2Blang/python/packages.el#L325).