### PR TITLE
vc: use smerge-vc-next-conflict instead of smerge-next

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -211,12 +211,12 @@ Use ~SPC g .~ to enter a transient state for quickly navigating between hunks in
 ** Smerge Mode Transient-state
 Movement:
 
-| Key binding                | Description         |
-|----------------------------+---------------------|
-| ~SPC g r n~                | Next hunk           |
-| ~SPC g r N~ or ~SPC g r p~ | Previous hunk       |
-| ~SPC g r j~                | Go to next line     |
-| ~SPC g r k~                | Go to previous line |
+| Key binding                | Description                              |
+|----------------------------+------------------------------------------|
+| ~SPC g r n~                | Next conflict (possibly in another file) |
+| ~SPC g r N~ or ~SPC g r p~ | Previous conflict                        |
+| ~SPC g r j~                | Go to next line                          |
+| ~SPC g r k~                | Go to previous line                      |
 
 Merge Actions:
 

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -279,21 +279,21 @@
       (spacemacs|transient-state-format-hint smerge
         spacemacs--smerge-ts-full-hint
         "\n
- Movement^^^^         Merge Action^^      Diff^^            Other
- ---------------^^^^  ----------------^^  --------------^^  ---------------------------^^
- [_n_]^^   next hunk  [_b_] keep base     [_<_] base/mine   [_C_] combine curr/next hunks
- [_N_/_p_] prev hunk  [_m_] keep mine     [_=_] mine/other  [_u_] undo
- [_j_]^^   next line  [_a_] keep all      [_>_] base/other  [_q_] quit
- [_k_]^^   prev line  [_o_] keep other    [_r_] refine
- ^^^^                 [_c_] keep current  [_e_] ediff       [_?_]^^ toggle help
- ^^^^                 [_K_] kill current")
+ Movement^^^^             Merge Action^^      Diff^^            Other
+ -------------------^^^^  ----------------^^  --------------^^  ---------------------------^^
+ [_n_]^^   next conflict  [_b_] keep base     [_<_] base/mine   [_C_] combine curr/next hunks
+ [_N_/_p_] prev conflict  [_m_] keep mine     [_=_] mine/other  [_u_] undo
+ [_j_]^^   next line      [_a_] keep all      [_>_] base/other  [_q_] quit
+ [_k_]^^   prev line      [_o_] keep other    [_r_] refine
+ ^^^^                     [_c_] keep current  [_e_] ediff       [_?_]^^ toggle help
+ ^^^^                     [_K_] kill current")
       (spacemacs|define-transient-state smerge
         :title "Smerge Transient State"
         :hint-is-doc t
         :dynamic-hint (spacemacs//smerge-ts-hint)
         :bindings
         ;; move
-        ("n" smerge-next)
+        ("n" smerge-vc-next-conflict)
         ("N" smerge-prev)
         ("p" smerge-prev)
         ("j" evil-next-line)


### PR DESCRIPTION
`smerge` recently learned `smerge-vc-next-conflict`, which will jump to the next file with a conflict in it if there are none remaining in the current file. This gives a nice experience, in particular it improves on the `magit` workflow since you no longer need to go back to the `magit` status buffer in order to find the next conflicted file, you can simply keep going to the next conflict.

I considered giving this a new keybinding, but in fact it subsumes the functionality of `smerge-next`, so we might as well just substitute it in.

While I was there I tweaked the help. I think we typically talk about "conflicts" in this context and "hunks" when staging. `smerge` uses "conflicts".