### PR TITLE
Revert "Fix which-key entries: gr and gs in dired and magit"

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -269,14 +269,7 @@
       (evil-define-key 'normal magit-section-mode-map (kbd "M-6") 'spacemacs/winum-select-window-6)
       (evil-define-key 'normal magit-section-mode-map (kbd "M-7") 'spacemacs/winum-select-window-7)
       (evil-define-key 'normal magit-section-mode-map (kbd "M-8") 'spacemacs/winum-select-window-8)
-      (evil-define-key 'normal magit-section-mode-map (kbd "M-9") 'spacemacs/winum-select-window-9)
-      ;; Remove inherited bindings from evil-mc and evil-easymotion
-      ;; do this after the config to make sure the keymap is available
-      (which-key-add-keymap-based-replacements magit-mode-map
-        "<normal-state> g r" nil
-        "<visual-state> g r" nil
-        "<normal-state> g s" nil
-        "<visual-state> g s" nil))))
+      (evil-define-key 'normal magit-section-mode-map (kbd "M-9") 'spacemacs/winum-select-window-9))))
 
 (defun git/init-magit-delta ()
   (use-package magit-delta

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -133,14 +133,6 @@ If not in such a search box, fall back on `Custom-newline'."
 (defalias 'spacemacs/display-buffer-other-frame 'display-buffer-other-frame)
 (defalias 'spacemacs/find-file-and-replace-buffer 'find-alternate-file)
 
-(defun spacemacs/dired-remove-evil-mc-gr-which-key-entry ()
-  ;; Remove inherited bindings from evil-mc
-  ;; do this after the config to make sure the keymap is available
-  (with-eval-after-load 'dired
-    (which-key-add-keymap-based-replacements dired-mode-map
-      "<normal-state> g r" nil
-      "<visual-state> g r" nil)))
-
 (defun spacemacs/indent-region-or-buffer ()
   "Indent a region if selected, otherwise the whole buffer."
   (interactive)

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -144,9 +144,7 @@
     (evil-define-key 'normal dired-mode-map (kbd "N") 'evil-ex-search-previous))
   (when (eq 'hybrid dotspacemacs-editing-style)
     (evil-define-key 'normal dired-mode-map (kbd "n") 'evil-search-next)
-    (evil-define-key 'normal dired-mode-map (kbd "N") 'evil-search-previous))
-  (add-hook 'spacemacs-post-user-config-hook
-            'spacemacs/dired-remove-evil-mc-gr-which-key-entry))
+    (evil-define-key 'normal dired-mode-map (kbd "N") 'evil-search-previous)))
 
 (defun spacemacs-defaults/init-dired-x ()
   (use-package dired-x


### PR DESCRIPTION
Fixes: Error at init time after updating which-key package #14865

This reverts commit ec57b21a924d88fa0f7e1d747f091c349cca0170.

A which-key change caused issues with this fix.
And the fix doesn't seem to be needed anymore.

The correct which-key entries appear without the fix.
