### PR TITLE
Add yasnippet-snippets-dir to yas-snippet-dirs in auto-compl layer

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -350,4 +350,7 @@
 
     :config (spacemacs|diminish yas-minor-mode " ⓨ" " y")))
 
-(defun auto-completion/init-yasnippet-snippets ())
+(defun auto-completion/init-yasnippet-snippets ()
+  (use-package yasnippet-snippets
+    :after yasnippet
+    :config (yasnippet-snippets-initialize)))


### PR DESCRIPTION
The auto-completion layer installs the yasnippet-snippets collection by default.
However, it does make the snippets available, which makes no sense.
This commit fixes it by simply making the snippets available.