### PR TITLE
Fix face name typo: ahs-plugin-defalt-face

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -174,7 +174,7 @@ If the universal prefix argument is used then kill also the window."
                                (cond ((string= plighter "HS")  "Display")
                                      ((string= plighter "HSA") "Buffer")
                                      ((string= plighter "HSD") "Function"))))
-               (face (cond ((string= plighter "HS")  ahs-plugin-defalt-face)
+               (face (cond ((string= plighter "HS")  ahs-plugin-default-face)
                            ((string= plighter "HSA") ahs-plugin-whole-buffer-face)
                            ((string= plighter "HSD") ahs-plugin-bod-face))))
           (while (not (string= overlay current-overlay))


### PR DESCRIPTION
problem:
Trying to switch the range in the `SPC h s`:
symbol highlight transient state

By pressing: `r`

Shows the message:
let*: Symbol’s value as variable is void: ahs-plugin-defalt-face

And the symbol highlight transient state can't be opened again,
until Emacs is restarted.

cause:
The typo in the face name: ahs-plugin-defalt-face
has been fixed upstream.
