### PR TITLE
Fix exit keyword in symbol-highlight TS

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -142,7 +142,7 @@
         :title "Symbol Highlight Transient State"
         :hint-is-doc t
         :dynamic-hint (spacemacs//symbol-highlight-ts-doc)
-        :before-exit (spacemacs//ahs-ts-on-exit)
+        :on-exit (spacemacs//ahs-ts-on-exit)
         :bindings
         ("d" ahs-forward-definition)
         ("D" ahs-backward-definition)


### PR DESCRIPTION
problem:
The symbol highlight exit function is never called,
after the keyword: `:before-exit`
in the definition of the symbol-highlight transient state (TS).

cause:
The TS definition gets the exit function with the keyword: `:on-exit`

Then it assigns that exit function to the hydra with the keyword: `:before-exit`

That's where the confusion came from.
