### PR TITLE
Fix symbol highlighting

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -58,8 +58,8 @@ If the universal prefix argument is used then kill also the window."
   (interactive)
   (if spacemacs-last-ahs-highlight-p
       (progn (goto-char (nth 1 spacemacs-last-ahs-highlight-p))
-             (spacemacs/ahs-highlight-now-wrapper)
-             (spacemacs/symbol-highlight-transient-state/body))
+             (spacemacs/symbol-highlight-transient-state/body)
+             (spacemacs/ahs-highlight-now-wrapper))
     (message "No symbol has been searched for now.")))
 
 (defun spacemacs/integrate-evil-search (forward)
@@ -88,18 +88,9 @@ If the universal prefix argument is used then kill also the window."
               evil-ex-substitute-pattern `(,(concat isearch-string "\\C")
                                            nil (0 0))))
 
-(defun spacemacs/ensure-ahs-enabled-locally ()
-  "Ensures ahs is enabled for the local buffer."
-  (unless
-      (bound-and-true-p ahs-mode-line)
-    (auto-highlight-symbol-mode)
-    ))
-
 (defun spacemacs/ahs-highlight-now-wrapper ()
   "Safe wrapper for ahs-highlight-now"
-  (eval '(progn
-           (spacemacs/ensure-ahs-enabled-locally)
-           (ahs-highlight-now)) nil))
+  (eval '(ahs-highlight-now) nil))
 
 (defun spacemacs/enter-ahs-forward ()
   "Go to the next occurrence of symbol under point with
@@ -133,23 +124,23 @@ If the universal prefix argument is used then kill also the window."
   (if (eq forward spacemacs--ahs-searching-forward)
       (progn
         (spacemacs/integrate-evil-search t)
-        (spacemacs/ahs-highlight-now-wrapper)
         (evil-set-jump)
         (spacemacs/symbol-highlight-transient-state/body)
+        (spacemacs/ahs-highlight-now-wrapper)
         (ahs-forward))
     (progn
       (spacemacs/integrate-evil-search nil)
-      (spacemacs/ahs-highlight-now-wrapper)
       (evil-set-jump)
       (spacemacs/symbol-highlight-transient-state/body)
+      (spacemacs/ahs-highlight-now-wrapper)
       (ahs-backward))))
 
 (defun spacemacs/symbol-highlight ()
   "Highlight the symbol under point with `auto-highlight-symbol'."
   (interactive)
-  (spacemacs/ahs-highlight-now-wrapper)
   (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p))
   (spacemacs/symbol-highlight-transient-state/body)
+  (spacemacs/ahs-highlight-now-wrapper)
   (spacemacs/integrate-evil-search t))
 
 (defvar-local spacemacs//ahs-was-disabled t)

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -59,7 +59,7 @@ If the universal prefix argument is used then kill also the window."
   (if spacemacs-last-ahs-highlight-p
       (progn (goto-char (nth 1 spacemacs-last-ahs-highlight-p))
              (spacemacs/symbol-highlight-transient-state/body)
-             (spacemacs/ahs-highlight-now-wrapper))
+             (ahs-highlight-now))
     (message "No symbol has been searched for now.")))
 
 (defun spacemacs/integrate-evil-search (forward)
@@ -87,10 +87,6 @@ If the universal prefix argument is used then kill also the window."
         (setq evil-ex-last-was-search nil
               evil-ex-substitute-pattern `(,(concat isearch-string "\\C")
                                            nil (0 0))))
-
-(defun spacemacs/ahs-highlight-now-wrapper ()
-  "Safe wrapper for ahs-highlight-now"
-  (eval '(ahs-highlight-now) nil))
 
 (defun spacemacs/enter-ahs-forward ()
   "Go to the next occurrence of symbol under point with
@@ -126,22 +122,25 @@ If the universal prefix argument is used then kill also the window."
         (spacemacs/integrate-evil-search t)
         (evil-set-jump)
         (spacemacs/symbol-highlight-transient-state/body)
-        (spacemacs/ahs-highlight-now-wrapper)
+        (ahs-highlight-now)
         (ahs-forward))
     (progn
       (spacemacs/integrate-evil-search nil)
       (evil-set-jump)
       (spacemacs/symbol-highlight-transient-state/body)
-      (spacemacs/ahs-highlight-now-wrapper)
+      (ahs-highlight-now)
       (ahs-backward))))
 
 (defun spacemacs/symbol-highlight ()
   "Highlight the symbol under point with `auto-highlight-symbol'."
   (interactive)
-  (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p))
+  (spacemacs//remember-last-ahs-highlight)
   (spacemacs/symbol-highlight-transient-state/body)
-  (spacemacs/ahs-highlight-now-wrapper)
+  (ahs-highlight-now)
   (spacemacs/integrate-evil-search t))
+
+(defun spacemacs//remember-last-ahs-highlight ()
+  (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p)))
 
 (defvar-local spacemacs//ahs-was-disabled t)
 

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -152,10 +152,30 @@ If the universal prefix argument is used then kill also the window."
   (spacemacs/symbol-highlight-transient-state/body)
   (spacemacs/integrate-evil-search t))
 
+(defvar-local spacemacs//ahs-was-disabled t)
+
+(defun spacemacs//ahs-ts-on-enter ()
+  ;; Only remember the `auto-highlight-symbol-mode' state,
+  ;; when entering the Symbol Highlight Transient State,
+  ;; Not when the TS is open and one is navigating
+  ;; to the next or previous symbol.
+  ;; Because the TS is closed and reopened, when navigating
+  ;; to a symbol. With the following commands.
+  (unless (memq this-command '(spacemacs/quick-ahs-forward
+                               spacemacs/quick-ahs-backward))
+    (setq-local spacemacs//ahs-was-disabled
+          (not (bound-and-true-p auto-highlight-symbol-mode))))
+  (auto-highlight-symbol-mode))
+
 (defun spacemacs//ahs-ts-on-exit ()
   ;; Restore user search direction state as ahs has exitted in a state
   ;; good for <C-s>, but not for 'n' and 'N'"
-  (setq isearch-forward spacemacs--ahs-searching-forward))
+  (setq isearch-forward spacemacs--ahs-searching-forward)
+  ;; Don't disable `auto-highlight-symbol-mode', when navigating between symbols
+  (unless (memq this-command '(spacemacs/quick-ahs-forward
+                               spacemacs/quick-ahs-backward))
+    (when spacemacs//ahs-was-disabled
+      (auto-highlight-symbol-mode -1))))
 
 (defun spacemacs/symbol-highlight-reset-range ()
   "Reset the range for `auto-highlight-symbol'."
@@ -174,7 +194,7 @@ If the universal prefix argument is used then kill also the window."
                                (cond ((string= plighter "HS")  "Display")
                                      ((string= plighter "HSA") "Buffer")
                                      ((string= plighter "HSD") "Function"))))
-               (face (cond ((string= plighter "HS")  ahs-plugin-defalt-face)
+               (face (cond ((string= plighter "HS")  ahs-plugin-default-face)
                            ((string= plighter "HSA") ahs-plugin-whole-buffer-face)
                            ((string= plighter "HSD") ahs-plugin-bod-face))))
           (while (not (string= overlay current-overlay))

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -81,11 +81,31 @@
             ;; current symbol can always be highlighted with `SPC s h'
             ahs-idle-timer 0
             ahs-idle-interval 0.25
-            ahs-inhibit-face-list nil
-            spacemacs--symbol-highlight-transient-state-doc "
+            ahs-inhibit-face-list nil)
+
+      ;; transient state
+      (setq spacemacs--symbol-highlight-transient-state-doc "
  %s
  [_n_] next   [_N_/_p_] prev  [_d_/_D_] next/prev def  [_r_] range  [_R_] reset  [_z_] recenter
  [_e_] iedit")
+      (spacemacs|define-transient-state symbol-highlight
+        :title "Symbol Highlight Transient State"
+        :hint-is-doc t
+        :dynamic-hint (spacemacs//symbol-highlight-ts-doc)
+        :on-enter (spacemacs//ahs-ts-on-enter)
+        :on-exit (spacemacs//ahs-ts-on-exit)
+        :bindings
+        ("d" ahs-forward-definition)
+        ("D" ahs-backward-definition)
+        ("e" spacemacs/ahs-to-iedit :exit t)
+        ("n" spacemacs/quick-ahs-forward)
+        ("N" spacemacs/quick-ahs-backward)
+        ("p" spacemacs/quick-ahs-backward)
+        ("R" ahs-back-to-start)
+        ("r" ahs-change-range)
+        ("z" (progn (recenter-top-bottom)
+                    (spacemacs/symbol-highlight)))
+        ("q" nil :exit t))
 
       ;; since we are creating our own maps,
       ;; prevent the default keymap from getting created
@@ -99,19 +119,11 @@
                     (run-with-idle-timer ahs-idle-interval t
                                          'ahs-idle-function)))
         :off (when (timerp ahs-idle-timer)
-               (auto-highlight-symbol-mode)
+               (auto-highlight-symbol-mode -1)
                (cancel-timer ahs-idle-timer)
                (setq ahs-idle-timer 0))
         :documentation "Automatic highlight of current symbol."
         :evil-leader "tha")
-      (spacemacs/add-to-hooks 'auto-highlight-symbol-mode '(prog-mode-hook
-                                                            markdown-mode-hook)))
-    :config
-    (progn
-      (spacemacs|hide-lighter auto-highlight-symbol-mode)
-      (defvar-local spacemacs-last-ahs-highlight-p nil
-        "Info on the last searched highlighted symbol.")
-      (defvar-local spacemacs--ahs-searching-forward t)
 
       (with-eval-after-load 'evil
         (define-key evil-motion-state-map (kbd "*")
@@ -135,26 +147,13 @@
                    (spacemacs/ahs-highlight-now-wrapper)
                    ad-do-it
                    (spacemacs/ahs-highlight-now-wrapper)
-                   (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p))))))
-
-      ;; transient state
-      (spacemacs|define-transient-state symbol-highlight
-        :title "Symbol Highlight Transient State"
-        :hint-is-doc t
-        :dynamic-hint (spacemacs//symbol-highlight-ts-doc)
-        :on-exit (spacemacs//ahs-ts-on-exit)
-        :bindings
-        ("d" ahs-forward-definition)
-        ("D" ahs-backward-definition)
-        ("e" spacemacs/ahs-to-iedit :exit t)
-        ("n" spacemacs/quick-ahs-forward)
-        ("N" spacemacs/quick-ahs-backward)
-        ("p" spacemacs/quick-ahs-backward)
-        ("R" ahs-back-to-start)
-        ("r" ahs-change-range)
-        ("z" (progn (recenter-top-bottom)
-                    (spacemacs/symbol-highlight)))
-        ("q" nil :exit t)))))
+                   (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p)))))))
+    :config
+    (progn
+      (spacemacs|hide-lighter auto-highlight-symbol-mode)
+      (defvar-local spacemacs-last-ahs-highlight-p nil
+        "Info on the last searched highlighted symbol.")
+      (defvar-local spacemacs--ahs-searching-forward t))))
 
 (defun spacemacs-navigation/init-centered-cursor-mode ()
   (use-package centered-cursor-mode

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -73,13 +73,11 @@
 (defun spacemacs-navigation/init-auto-highlight-symbol ()
   (use-package auto-highlight-symbol
     :defer t
+    :commands (ahs-highlight-p)
     :init
     (progn
       (setq ahs-case-fold-search nil
             ahs-default-range 'ahs-range-whole-buffer
-            ;; by default disable auto-highlight of symbol
-            ;; current symbol can always be highlighted with `SPC s h'
-            ahs-idle-timer 0
             ahs-idle-interval 0.25
             ahs-inhibit-face-list nil)
 
@@ -103,8 +101,7 @@
         ("p" spacemacs/quick-ahs-backward)
         ("R" ahs-back-to-start)
         ("r" ahs-change-range)
-        ("z" (progn (recenter-top-bottom)
-                    (spacemacs/symbol-highlight)))
+        ("z" recenter-top-bottom)
         ("q" nil :exit t))
 
       ;; since we are creating our own maps,
@@ -126,19 +123,14 @@
         "sh" 'spacemacs/symbol-highlight
         "sH" 'spacemacs/goto-last-searched-ahs-symbol)
 
-      ;; micro-state to easily jump from a highlighted symbol to the others
+      ;; Advice ahs jump functions to remember the last highlighted symbol
       (dolist (sym '(ahs-forward
                      ahs-forward-definition
                      ahs-backward
                      ahs-backward-definition
                      ahs-back-to-start
                      ahs-change-range))
-        (let* ((advice (intern (format "spacemacs/%s" (symbol-name sym)))))
-          (eval `(defadvice ,sym (around ,advice activate)
-                   (spacemacs/ahs-highlight-now-wrapper)
-                   ad-do-it
-                   (spacemacs/ahs-highlight-now-wrapper)
-                   (setq spacemacs-last-ahs-highlight-p (ahs-highlight-p)))))))
+        (advice-add sym :after #'spacemacs//remember-last-ahs-highlight)))
     :config
     (progn
       (spacemacs|hide-lighter auto-highlight-symbol-mode)

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -112,16 +112,7 @@
       (setq auto-highlight-symbol-mode-map (make-sparse-keymap))
 
       (spacemacs|add-toggle automatic-symbol-highlight
-        :status (timerp ahs-idle-timer)
-        :on (progn
-              (auto-highlight-symbol-mode)
-              (setq ahs-idle-timer
-                    (run-with-idle-timer ahs-idle-interval t
-                                         'ahs-idle-function)))
-        :off (when (timerp ahs-idle-timer)
-               (auto-highlight-symbol-mode -1)
-               (cancel-timer ahs-idle-timer)
-               (setq ahs-idle-timer 0))
+        :mode auto-highlight-symbol-mode
         :documentation "Automatic highlight of current symbol."
         :evil-leader "tha")
 


### PR DESCRIPTION
Fixes: How to disable auto highlighting of all matching words #14880

Recent updates to the `auto-highlight-symbol` package,
broke the Spacemacs configurations for the package.

Problems:
- The symbols under the cursor gets highlighted on startup.
- The highlight isn't cleared when the Symbol Highlight Transient State is closed.
- The `SPC t h a` symbol highlighting toggle, shows the same message every time:
`automatic-symbol-highlight disabled.`
but the symbols are still being highlighted.

This PR fixes these issues above, but there are some issues with the toggling (see below).

There might be more issues, according to this upstream comment:
https://github.com/jcs-elpa/auto-highlight-symbol/issues/7#issuecomment-873092710
>iedit, isearch, and symbol-overlay is no longer working as expected

I have not been able to reproduce any issues with either `iedit`, `isearch` or `symbol-overlay`.
@alexalekseyenko Could you provide some reproduction steps?

### Toggling issues
There are some issues when toggling the highlighting.

The first time it's toggled on, then the minibuffer shows
a message that highlighting has been disabled.
It should be enabled the first time since the symbols weren't being highlighted before trying to toggle its state.

In the disabled state, the symbol highlight transient state key bindings:
`#`, `*`, `SPC s h` and `SPC s H` do open the transient state,
but when one tries to jump between the symbols,
then it shows this message:
`ahs-select: Wrong type argument: overlayp, nil`

Toggling to the enabled state, works as expected,
and it keeps highlighting when the cursor is moved.

But the highlight disappears when the transient state is closed.
If the symbol highlighting was enabled, then they should remain,
enabled after closing the TS.

The toggling should be fixed, but in this PR's current state,
it probably already is better than the current behavior.

### Notes:
This PR also includes the transient state exit fix:
from: `:before-exit`
to: `on-exit`
That's open in a separate PR:
Fix exit keyword in symbol-highlight TS #14890