### PR TITLE
[ci] fix ws in patches and use git apply

### DIFF
--- a/.circleci/apply_patch
+++ b/.circleci/apply_patch
@@ -25,7 +25,7 @@ else
     cd "/tmp/${PUBLISH}"
 
     echo_headline "Patching"
-    git am < "/tmp/${PUBLISH}.patch"
+    git apply --reject --whitespace=fix "/tmp/${PUBLISH}.patch"
     if [ $? -ne 0 ]; then
         echo "Failed to apply \"/tmp/${PUBLISH}.patch\"."
         exit 2

--- a/.circleci/built_in/maybe_pr
+++ b/.circleci/built_in/maybe_pr
@@ -10,6 +10,8 @@
 ##
 ## License: GPLv3
 
+cd "/tmp/${PUBLISH}"
+
 export GITHUB_TOKEN=$UPD_BOT_GIT_TK
 echo_headline "Opening PR to ${UPD_BOT_LOGIN}/${UPD_BOT_REPO} repo"
 echo "[bot] Built-in auto-update" > msg

--- a/.circleci/org/maybe_pr
+++ b/.circleci/org/maybe_pr
@@ -10,6 +10,8 @@
 ##
 ## License: GPLv3
 
+cd "/tmp/${PUBLISH}"
+
 export GITHUB_TOKEN=$UPD_BOT_GIT_TK
 echo_headline "Opening PR to ${UPD_BOT_LOGIN}/${UPD_BOT_REPO} repo"
 echo "[bot] Documentation fixes" > msg

--- a/.circleci/push
+++ b/.circleci/push
@@ -10,6 +10,8 @@
 ##
 ## License: GPLv3
 
+cd "/tmp/${PUBLISH}"
+
 echo_headline "Creating fork under bot account"
 export GITHUB_TOKEN=$UPD_BOT_GIT_TK
 git checkout -b "${PUBLISH}"


### PR DESCRIPTION
Seems like white spaces can trip patching process. Lets see if this fixes the problem.

Also add a couple of `cd` instructions to make sure that the expected directory won't change.