### PR TITLE
Fix symbol highlight ts counter

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -90,7 +90,6 @@
         :title "Symbol Highlight Transient State"
         :hint-is-doc t
         :dynamic-hint (spacemacs//symbol-highlight-ts-doc)
-        :on-enter (spacemacs//ahs-ts-on-enter)
         :on-exit (spacemacs//ahs-ts-on-exit)
         :bindings
         ("d" ahs-forward-definition)


### PR DESCRIPTION
problem
The Symbol Highlight Transient State (`SPC s h`) counter
ex: [2/7]

Shows: [0/0]
when opening the TS, either with `SPC s h`, `SPC s H`
or when navigating between symbols with: `#` or `*`

cause
The symbols haven't been counted yet, when the TS is opened.

And the counter is reset when `auto-highlight-symbol-mode` is disabled,
this happens when the TS is restarted, which happens when navigating to the
next/previous symbol with `#` and `*`.

solution
Highlight the symbol before opening the TS.
And only disable `auto-highlight-symbol-mode` when the TS is closed.
(when the TS buffer `" *LV*"` doesn't exist)

notes
This also shows the "No previously searched for symbol found" message,
when the variable `spacemacs-last-ahs-highlight-p` is void on startup.