### PR TITLE
Add option to enable all-the-icons-ivy-rich to ivy layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2478,6 +2478,7 @@ Other:
 - Fixed =cl= package deprecated =letf*= (thanks to duianto)
 - Fixed counsel find-file functions to use Spacemacs check for opening large
 files (thanks to Daniel Nicolai)
+- Add option to configure =all-the-icons-ivy-rich= (thanks to Daniel Nicolai)
 **** Imenu-list
 - Changed ~SPC b i~ to ~SPC b t~ for =imenu= tree view
   (thansk to Sylvain Benner)

--- a/layers/+completion/ivy/README.org
+++ b/layers/+completion/ivy/README.org
@@ -9,6 +9,7 @@
 - [[#configuration][Configuration]]
   - [[#general][General]]
   - [[#advanced-buffer-information][Advanced buffer information]]
+  - [[#icons][Icons]]
 - [[#key-bindings][Key bindings]]
   - [[#transient-state][Transient state]]
   - [[#colorsfaces][Colors/Faces]]
@@ -69,6 +70,24 @@ is disabled by default.
   (setq-default dotspacemacs-configuration-layers '(
     (ivy :variables ivy-enable-advanced-buffer-information t)))
 #+END_SRC
+
+** Icons
+To display icons with [[https://github.com/seagle0128/all-the-icons-ivy-rich][all-the-icons-ivy-rich]], set the layer variable
+=ivy-enable-icons= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (ivy :variables ivy-enable-icons t)))
+#+END_SRC
+
+Because =all-the-icons-ivy-rich= depends on =ivy-rich=, the layer variable
+=ivy-enable-advanced-buffer-information= is automatically set to =t= when ivy
+icon display is enabled.
+
+To display icons correctly, you should run =M-x all-the-icons-install-fonts=
+to install the necessary fonts.
+
+More information about customizing =all-the-icons-ivy-rich= can be found [[=all-the-icons-ivy-rich=][here]].
 
 * Key bindings
 If you choose =ivy= as completion system, make sure to read the [[http://oremacs.com/swiper/][official manual]].

--- a/layers/+completion/ivy/config.el
+++ b/layers/+completion/ivy/config.el
@@ -25,6 +25,9 @@
 
 ;; Layer Variables
 
+(defvar ivy-enable-icons nil
+  "If non-nil, enable icons in `ivy-rich-mode'.")
+
 (defvar ivy-enable-advanced-buffer-information nil
   "If non-nil, enable `ivy-rich' which adds information on buffers.")
 

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -23,6 +23,7 @@
 
 (setq ivy-packages
       '(
+        (all-the-icons-ivy-rich :toggle ivy-enable-icons)
         auto-highlight-symbol
         bookmark
         counsel
@@ -34,7 +35,10 @@
         ivy
         ivy-avy
         ivy-hydra
-        (ivy-rich :toggle ivy-enable-advanced-buffer-information)
+        (ivy-rich :toggle (progn
+                            (when ivy-enable-icons
+                              (setq ivy-enable-advanced-buffer-information t)
+                              ivy-enable-advanced-buffer-information)))
         (ivy-spacemacs-help :location local)
         ivy-xref
         org
@@ -45,6 +49,12 @@
         swiper
         wgrep
         ))
+
+(defun ivy/init-all-the-icons-ivy-rich ()
+  (use-package all-the-icons-ivy-rich
+    :after ivy-rich
+    :config
+    (all-the-icons-ivy-rich-mode)))
 
 (defun ivy/pre-init-auto-highlight-symbol ()
   (spacemacs|use-package-add-hook auto-highlight-symbol


### PR DESCRIPTION
This PR adds an option to configure =all-the-icons-ivy-rich=.

I am not sure if I should add extra logic to make sure that the various required modes get activated in the right order as instructed in [these notes](https://github.com/seagle0128/all-the-icons-ivy-rich#use-package).

Currently, the `all-the-icons-ivy-rich-mode` seems to get activated before `ivy-rich-mode` as instructed in the third point of the notes.
It all seems to work fine (also, I think it will not break anything if activated in the wrong order, just it will not work correctly).