### PR TITLE
[java] Add key binding for run last java test

### DIFF
--- a/layers/+lang/java/README.org
+++ b/layers/+lang/java/README.org
@@ -150,6 +150,16 @@ at the root of your project first.
 Using the =dap= layer you'll get access to all the DAP key bindings, see the
 complete list of key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/dap#key-bindings][dap layer description]].
 
+**** Tests
+
+| Key binding   | Description                    |
+|---------------+--------------------------------|
+| ~SPC m d t c~ | Debug test class around point  |
+| ~SPC m d t t~ | Debug test method around point |
+| ~SPC m t c~   | Run test class around point    |
+| ~SPC m t t~   | Run test method around point   |
+| ~SPC m t l~   | Run last test                  |
+
 ** Meghanada
 *** Server
 

--- a/layers/+lang/java/funcs.el
+++ b/layers/+lang/java/funcs.el
@@ -114,7 +114,8 @@
     "dtc" 'dap-java-debug-test-class
     ;; run
     "tt" 'dap-java-run-test-method
-    "tc" 'dap-java-run-test-class))
+    "tc" 'dap-java-run-test-class
+    "tl" 'dap-java-run-last-test))
 
 (defun spacemacs//java-setup-lsp-flycheck ()
   "Setup LSP Java syntax checking."


### PR DESCRIPTION
Add java run last test to the key `SPC m tl` binding to the new method in lsp-java: `dap-java-run-last-test`

https://github.com/emacs-lsp/lsp-java/pull/340

Update java documentation with the java tests related keys for lsp-java.

