### PR TITLE
[org-mode]/[org-brain] Add flag to enable org-brain support making it optional

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -445,8 +445,9 @@ the following snippet.
 #+END_SRC
 
 ** Org-brain support
-For Emacs 25 or later, support for [[https://kungsgeten.github.io/org-brain.html][org-brain]] is included. See the [[https://github.com/Kungsgeten/org-brain][org-brain
-package documentation]] for more information.
+For Emacs 25 or later, to install [[https://kungsgeten.github.io/org-brain.html][org-brain]] set the variable =org-enable-org-brain-support= to =t=.
+
+See the [[https://github.com/Kungsgeten/org-brain][org-brain package documentation]] for more information.
 
 ** Org-roam support
 To install org-roam support set the variable =org-enable-roam-support= to =t=.

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -119,3 +119,6 @@ If `semiauto', prompt to change entry state when the state of the subentries
 imply it. This assumes next to nothing about your workflow states, but may
 result in additional, possibly surprising, prompting of the user; and it has no
 intelligence to attempt to determine the destination state.")
+
+(defvar org-enable-org-brain-support nil
+  "If non-nil, enable org-brain")

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -41,7 +41,7 @@
                   :toggle org-enable-org-contacts-support)
     org-contrib
     (org-vcard :toggle org-enable-org-contacts-support)
-    org-brain
+    (org-brain :toggle org-enable-org-brain-support)
     (org-expiry :location built-in)
     ; temporarily point org-journal to dalanicolai fork until dalanicolai's
     ; PR's https://github.com/bastibe/org-journal/pulls get merged


### PR DESCRIPTION
Make org-brain optional using `org-enable-org-brain-support` flag

This is similar to what we have for other packages. 

Reason for this change:
- Give a choice for users who don't use `org-brain`