### PR TITLE
Rename commands for org-roam v2 compatibility

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3038,6 +3038,7 @@ files (thanks to Daniel Nicolai)
   =org-insert-drawer=, =org-insert-heading=, =org-insert-item= and
   =org-insert-structure-template= commands (thanks to Andriy Kmit')
 - Added =ox-asciidoc= as org export backend (thanks to Christian "West" Westrom)
+- Fix org-roam v2 compatibility (thanks to Alex Kapranoff and Caleb Rogers)
 **** Osx
 - Key bindings:
   - Added key bindings to use ~command-1..9~ for selecting window
@@ -3850,4 +3851,3 @@ files (thanks to Daniel Nicolai)
   Thanks to: Abhishek(Compro) Prasad, Deepak Khidia, Enze Chi, Grant Shangreaux,
   Igor Almeida, Jiahao Jiang, Miciah Dashiel Butler Masters, Songpeng Zu, Ward
   Harris
-  

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -464,7 +464,7 @@ To install support for [[https://github.com/org-roam/org-roam-server][org-roam-s
 to =t=.
 
 *** Org-roam-protocol support
-To enable support for [[https://www.orgroam.com/manual.html#Roam-Protocol][Org Roam Protocol]] set the variable
+To enable support for [[https://www.orgroam.com/manual.html#Org_002droam-Protocol][Org Roam Protocol]] set the variable
 =org-enable-roam-protocol= to =t=.
 
 #+BEGIN_SRC emacs-lisp
@@ -473,7 +473,7 @@ To enable support for [[https://www.orgroam.com/manual.html#Roam-Protocol][Org R
          org-enable-roam-protocol t)))
 #+END_SRC
 
-And create a desktop file as described in the [[https://www.orgroam.com/manual.html#Roam-Protocol][org-roam manual]].
+And create a desktop file as described in the [[https://www.orgroam.com/manual.html#Org_002droam-Protocol][org-roam manual]].
 
 ** Mode line support
 To temporarily enable mode line display of org clock, press ~SPC t m c~.
@@ -1116,16 +1116,15 @@ Key binding prefixes:
 | Key binding   | Description                           |
 |---------------+---------------------------------------|
 | ~SPC m r l~   | Toggle org-roam links visibility      |
-| ~SPC m r f~   | Find file in org-roam                 |
-| ~SPC m r i~   | Insert file into org-roam             |
-| ~SPC m r I~   | Immediately insert file into org-roam |
+| ~SPC m r f~   | Find node in org-roam             |
+| ~SPC m r i~   | Insert node into org-roam         |
 | ~SPC m r g~   | Visualize org-roam graph              |
 | ~SPC m r b~   | Switch org-roam buffer                |
 | ~SPC m r d y~ | Open yesterday's daily note           |
 | ~SPC m r d t~ | Open today's daily note               |
 | ~SPC m r d T~ | Open tomorrow's daily note            |
 | ~SPC m r d d~ | Open daily note via calendar view     |
-| ~SPC m r t a~ | Add org-roam tag to file              |
-| ~SPC m r t d~ | Delete org-roam tag from file         |
+| ~SPC m r t a~ | Add a tag to file                     |
+| ~SPC m r t r~ | Remove a tag from file          |
 | ~SPC m r a~   | Add org-roam alias to file            |
 | ~SPC m r s~   | Start org-roam server mode            |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -71,7 +71,6 @@
     (org-roam :toggle org-enable-roam-support)
     (valign :toggle org-enable-valign)
     (org-appear :toggle org-enable-appear-support)
-    (org-roam-server :require org-roam :toggle org-enable-roam-server)
     (ox-asciidoc :toggle org-enable-asciidoc-support)))
 
 (defun org/post-init-company ()
@@ -924,42 +923,41 @@ Headline^^            Visit entry^^               Filter^^                    Da
 (defun org/init-org-roam ()
   (use-package org-roam
     :defer t
-    :hook (after-init . org-roam-mode)
+    :hook (after-init . org-roam-setup)
     :init
     (progn
       (spacemacs/declare-prefix "aor" "org-roam")
       (spacemacs/declare-prefix "aord" "org-roam-dailies")
       (spacemacs/declare-prefix "aort" "org-roam-tags")
       (spacemacs/set-leader-keys
-        "aordy" 'org-roam-dailies-find-yesterday
-        "aordt" 'org-roam-dailies-find-today
-        "aordT" 'org-roam-dailies-find-tomorrow
-        "aordd" 'org-roam-dailies-find-date
-        "aorf" 'org-roam-find-file
+        "aordy" 'org-roam-dailies-goto-yesterday
+        "aordt" 'org-roam-dailies-goto-today
+        "aordT" 'org-roam-dailies-goto-tomorrow
+        "aordd" 'org-roam-dailies-goto-date
+        "aorc" 'org-roam-capture
+        "aorf" 'org-roam-node-find
         "aorg" 'org-roam-graph
-        "aori" 'org-roam-insert
-        "aorI" 'org-roam-insert-immediate
-        "aorl" 'org-roam-buffer-toggle-display
+        "aori" 'org-roam-node-insert
+        "aorl" 'org-roam-buffer-toggle
         "aorta" 'org-roam-tag-add
-        "aortd" 'org-roam-tag-delete
+        "aortr" 'org-roam-tag-remove
         "aora" 'org-roam-alias-add)
 
       (spacemacs/declare-prefix-for-mode 'org-mode "mr" "org-roam")
       (spacemacs/declare-prefix-for-mode 'org-mode "mrd" "org-roam-dailies")
       (spacemacs/declare-prefix-for-mode 'org-mode "mrt" "org-roam-tags")
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "rb" 'org-roam-switch-to-buffer
-        "rdy" 'org-roam-dailies-find-yesterday
-        "rdt" 'org-roam-dailies-find-today
-        "rdT" 'org-roam-dailies-find-tomorrow
-        "rdd" 'org-roam-dailies-find-date
-        "rf" 'org-roam-find-file
+        "rdy" 'org-roam-dailies-goto-yesterday
+        "rdt" 'org-roam-dailies-goto-today
+        "rdT" 'org-roam-dailies-goto-tomorrow
+        "rdd" 'org-roam-dailies-goto-date
+        "rc" 'org-roam-capture
+        "rf" 'org-roam-node-find
         "rg" 'org-roam-graph
-        "ri" 'org-roam-insert
-        "rI" 'org-roam-insert-immediate
-        "rl" 'org-roam-buffer-toggle-display
+        "ri" 'org-roam-node-insert
+        "rl" 'org-roam-buffer-toggle
         "rta" 'org-roam-tag-add
-        "rtd" 'org-roam-tag-delete
+        "rtr" 'org-roam-tag-remove
         "ra" 'org-roam-alias-add))
     :config
     (progn
@@ -1023,14 +1021,6 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (setq org-appear-autolinks t
             org-appear-autoemphasis t
             org-appear-autosubmarkers t))))
-
-(defun org/init-org-roam-server()
-  (use-package org-roam-server
-    :defer t
-    :init
-    (progn
-      (spacemacs/set-leader-keys "aors" 'org-roam-server-mode)
-      (spacemacs/set-leader-keys-for-major-mode 'org-mode "rs" 'org-roam-server-mode))))
 
 (defun org/init-ox-asciidoc ()
   (use-package ox-asciidoc


### PR DESCRIPTION
Fixes #14929

The main org-roam command "org-roam-find-file" was replaced with "org-roam-node-find". I decided to leave 
the old key sequence "a o r f" as an alternative for the new command alongside "a o r n" so that people who don't care about the internal naming of org-roam objects could keep using their muscle memory.