### PR TITLE
fix issue #14919 (force-init-spacemacs-env fails)

### DIFF
--- a/core/core-env.el
+++ b/core/core-env.el
@@ -98,7 +98,8 @@ current contents of the file will be overwritten."
           "\n"
           "# Environment variables:\n"
           "# ----------------------\n"))
-        (let ((env-point (point)))
+        (let ((process-environment initial-environment)
+              (env-point (point)))
           (dolist (shell-command-switch shell-command-switches)
             (call-process-shell-command
              (concat executable " > " (shell-quote-argument tmpfile)))


### PR DESCRIPTION
Currently, when running the env shell-command, Emacs does so using its current
`process-environment`. Instead, we should run the command with the
`initial-environment`, which seems to fix issue #14919 (at least on GNU/linux).