### PR TITLE
Fix ahs ts, open prompt

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -151,31 +151,68 @@ before highlighting a symbol."
 when the Symbol Highlight Transient State is closed.
 If ahs mode was disabled before a symbol was highlighted.")
 
+(defun spacemacs//ahs-was-disabled-in-ahs-ts-exit-window-p ()
+  (let ((prev-win (selected-window)))
+    (select-window spacemacs//ahs-ts-exit-window)
+    (prog1 spacemacs//ahs-was-disabled
+      (select-window prev-win))))
+
+(defvar spacemacs//ahs-ts-exit-window nil
+  "Remember the selected window when the
+Symbol Highlight Transient State is closed.
+
+This is used to disable `auto-highlight-symbol-mode',
+in the window where the Symbol Highlight Transient State was closed,
+when the TS was closed by opening a prompt. For example:
+ SPC SPC (or M-x)       ;; spacemacs/helm-M-x-fuzzy-matching
+ SPC ?                  ;; helm-descbinds
+ M-:                    ;; eval-expression
+ :                      ;; evil-ex
+
+ahs mode is only disabled if it was disabled before a symbol was highlighted.")
+
 (defun spacemacs//ahs-ts-on-exit ()
+  (setq spacemacs//ahs-ts-exit-window (selected-window))
   ;; Restore user search direction state as ahs has exitted in a state
   ;; good for <C-s>, but not for 'n' and 'N'"
   (setq isearch-forward spacemacs--ahs-searching-forward)
-  (spacemacs//disable-symbol-highlight-after-ahs-ts-closed))
+  (spacemacs//disable-symbol-highlight-after-ahs-ts-exit))
 
-(defun spacemacs//disable-symbol-highlight-after-ahs-ts-closed ()
+(defun spacemacs//disable-symbol-highlight-after-ahs-ts-exit ()
   "Disable `auto-highlight-symbol-mode', when the
 Symbol Highlight Transient State buffer isn't found.
+This occurs when the TS wasn't restarted.
+It is restarted when navigating to the next or previous symbol.
 
-This occurs when the Symbol Highlight Transient State wasn't restarted.
-It is restarted when navigating to the next or previous symbol."
+ahs mode is only disabled if it was disabled before a symbol was highlighted."
   (run-with-idle-timer
    0 nil
    (lambda ()
      (unless (string= (spacemacs//transient-state-buffer-title)
                       "Symbol Highlight")
-       (spacemacs//disable-symbol-highlight)))))
+       (cond ((and (spacemacs//prompt-opened-from-ahs-ts-p)
+                   (spacemacs//ahs-was-disabled-in-ahs-ts-exit-window-p))
+              (spacemacs//disable-ahs-mode-in-ahs-ts-exit-window))
+             (spacemacs//ahs-was-disabled
+              (spacemacs//disable-symbol-highlight)))))))
+
+(defun spacemacs//prompt-opened-from-ahs-ts-p ()
+  "Was a prompt opened (for example: M-x),
+from the Symbol Highlight Transient State?"
+  (not (eq spacemacs//ahs-ts-exit-window (selected-window))))
+
+(defun spacemacs//disable-ahs-mode-in-ahs-ts-exit-window ()
+  "Disable `auto-highlight-symbol-mode',
+in the window where the Symbol Highlight Transient State was closed."
+  (let ((prev-win (selected-window)))
+    (select-window spacemacs//ahs-ts-exit-window)
+    (spacemacs//disable-symbol-highlight)
+    (setq spacemacs//ahs-ts-exit-window nil)
+    (select-window prev-win)))
 
 (defun spacemacs//disable-symbol-highlight ()
-  "Disable `auto-highlight-symbol-mode',
-if it was disabled before a symbol was highlighted."
-  (when spacemacs//ahs-was-disabled
-    (auto-highlight-symbol-mode -1)
-    (setq-local spacemacs//ahs-was-disabled nil)))
+  (auto-highlight-symbol-mode -1)
+  (setq-local spacemacs//ahs-was-disabled nil))
 
 (defun spacemacs//transient-state-buffer-title ()
   (let ((transient-state-buffer-name " *LV*"))


### PR DESCRIPTION
problem
opening a prompt, ex: `M-x`
while the Symbol Highlight Transient State (`SPC s h`) is open,
leaves `auto-highlight-symbol-mode` enabled

cause
when the idle timer runs,
it tries to disable ahs mode in the prompt window