### PR TITLE
Change org-roam keybindings to use new v2 format

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -1116,16 +1116,13 @@ Key binding prefixes:
 | Key binding   | Description                           |
 |---------------+---------------------------------------|
 | ~SPC m r l~   | Toggle org-roam links visibility      |
-| ~SPC m r f~   | Find file in org-roam                 |
-| ~SPC m r i~   | Insert file into org-roam             |
-| ~SPC m r I~   | Immediately insert file into org-roam |
+| ~SPC m r f~   | Find node in org-roam             |
+| ~SPC m r i~   | Insert node into org-roam        |
 | ~SPC m r g~   | Visualize org-roam graph              |
-| ~SPC m r b~   | Switch org-roam buffer                |
 | ~SPC m r d y~ | Open yesterday's daily note           |
 | ~SPC m r d t~ | Open today's daily note               |
 | ~SPC m r d T~ | Open tomorrow's daily note            |
 | ~SPC m r d d~ | Open daily note via calendar view     |
-| ~SPC m r t a~ | Add org-roam tag to file              |
-| ~SPC m r t d~ | Delete org-roam tag from file         |
-| ~SPC m r a~   | Add org-roam alias to file            |
-| ~SPC m r s~   | Start org-roam server mode            |
+| ~SPC m r t a~ | Add org-roam tag to node          |
+| ~SPC m r t d~ | Delete org-roam tag from node     |
+| ~SPC m r a~   | Add org-roam alias to node        |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -931,35 +931,32 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (spacemacs/declare-prefix "aord" "org-roam-dailies")
       (spacemacs/declare-prefix "aort" "org-roam-tags")
       (spacemacs/set-leader-keys
-        "aordy" 'org-roam-dailies-find-yesterday
-        "aordt" 'org-roam-dailies-find-today
-        "aordT" 'org-roam-dailies-find-tomorrow
-        "aordd" 'org-roam-dailies-find-date
-        "aorf" 'org-roam-find-file
+        "aordy" 'org-roam-dailies-goto-yesterday
+        "aordt" 'org-roam-dailies-goto-today
+        "aordT" 'org-roam-dailies-goto-tomorrow
+        "aordd" 'org-roam-dailies-goto-date
+        "aorf" 'org-roam-node-find
         "aorg" 'org-roam-graph
-        "aori" 'org-roam-insert
-        "aorI" 'org-roam-insert-immediate
-        "aorl" 'org-roam-buffer-toggle-display
+        "aori" 'org-roam-node-insert
+        "aorl" 'org-roam-buffer-toggle
         "aorta" 'org-roam-tag-add
-        "aortd" 'org-roam-tag-delete
+        "aortd" 'org-roam-tag-remove
         "aora" 'org-roam-alias-add)
 
       (spacemacs/declare-prefix-for-mode 'org-mode "mr" "org-roam")
       (spacemacs/declare-prefix-for-mode 'org-mode "mrd" "org-roam-dailies")
       (spacemacs/declare-prefix-for-mode 'org-mode "mrt" "org-roam-tags")
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "rb" 'org-roam-switch-to-buffer
-        "rdy" 'org-roam-dailies-find-yesterday
-        "rdt" 'org-roam-dailies-find-today
-        "rdT" 'org-roam-dailies-find-tomorrow
-        "rdd" 'org-roam-dailies-find-date
-        "rf" 'org-roam-find-file
+        "rdy" 'org-roam-dailies-goto-yesterday
+        "rdt" 'org-roam-dailies-goto-today
+        "rdT" 'org-roam-dailies-goto-tomorrow
+        "rdd" 'org-roam-dailies-goto-date
+        "rf" 'org-roam-node-find
         "rg" 'org-roam-graph
-        "ri" 'org-roam-insert
-        "rI" 'org-roam-insert-immediate
-        "rl" 'org-roam-buffer-toggle-display
+        "ri" 'org-roam-node-insert
+        "rl" 'org-roam-buffer-toggle
         "rta" 'org-roam-tag-add
-        "rtd" 'org-roam-tag-delete
+        "rtd" 'org-roam-tag-remove
         "ra" 'org-roam-alias-add))
     :config
     (progn
@@ -1023,14 +1020,6 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (setq org-appear-autolinks t
             org-appear-autoemphasis t
             org-appear-autosubmarkers t))))
-
-(defun org/init-org-roam-server()
-  (use-package org-roam-server
-    :defer t
-    :init
-    (progn
-      (spacemacs/set-leader-keys "aors" 'org-roam-server-mode)
-      (spacemacs/set-leader-keys-for-major-mode 'org-mode "rs" 'org-roam-server-mode))))
 
 (defun org/init-ox-asciidoc ()
   (use-package ox-asciidoc


### PR DESCRIPTION
org-roam v2 is out, and has replaced org-roam v1 on melpa

Users that update packages will be brought to org-roam v2 now, and their
keybindings will refer to nonexistent functions, or depreciated functions. This
change should update all functions that have v2 versions.

Also, org-roam-server isn't yet supported, so I removed it.

I wasn't sure how to update the changelog, but it's not too important to me. I didn't see other PRs do it, anyway :P 

