### PR TITLE
Fix evil-matchit % jump in web mode

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -111,6 +111,7 @@
       (spacemacs|hide-lighter emmet-mode))))
 
 (defun html/post-init-evil-matchit ()
+  (evilmi-load-plugin-rules '(web-mode) '(simple template html))
   (add-hook 'web-mode-hook 'turn-on-evil-matchit-mode))
 
 (defun html/post-init-flycheck ()


### PR DESCRIPTION
problem
With the cursor on a parenthesis in js code in a .html document,
pressing:
```
%                      ;; evilmi-jump-items
```
jumps to the buffers last line.

solution from upstream issue
Jump to end when current line has a "if" keyword in web-mode and html-mode
https://github.com/redguardtoo/evil-matchit/issues/119