### PR TITLE
[defaults] Disable line numbers with `SPC t n n`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -838,6 +838,9 @@ Other:
   - Added =string-edit= package to =spacemacs-editing= layer
     (thanks to Ivan Yonchovski)
 - Key bindings:
+  - Toggle line numbers (i.e. toggle =display-line-numbers-mode=) via ~SPC t n n~
+    without having to think about which variant of line numbers you have turned
+    on (thanks to Keith Pinson)
   - Evilify =Custom-mode= (thanks to Keith Pinson)
   - Fixed ~M-x~ prefix visualization for ~dotspacemacs-emacs-command-key~
   - New ~SPC a Q~ prefix for dispatching quickurl

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1279,8 +1279,10 @@ and ~T~):
 | ~SPC t l~   | toggle truncate lines                                             |
 | ~SPC t L~   | toggle visual lines                                               |
 | ~SPC t n~   | toggle line numbers                                               |
-| ~SPC t r~   | toggle relative line numbers                                      |
-| ~SPC t v~   | toggle smooth scrolling                                           |
+| ~SPC t n n~ | toggle line numbers as configured in .spacemacs                   |
+| ~SPC t n a~ | toggle absolute line numbers                                      |
+| ~SPC t n r~ | toggle relative line numbers                                      |
+| ~SPC t n v~ | toggle smooth scrolling                                           |
 | ~SPC t V~   | toggle visual line numbers                                        |
 | ~SPC t z~   | toggle 0/1 based column indexing                                  |
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1663,7 +1663,7 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
 ;; Line number
 
 (defun spacemacs/no-linum (&rest ignore)
-  "Disable linum if current buffer."
+  "Disable linum in current buffer."
   (when (or 'linum-mode global-linum-mode)
     (linum-mode 0)))
 

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -287,18 +287,17 @@
 
       (spacemacs/declare-prefix "tn" "line-numbers")
 
-      ;; backwards compatibility of symbols:
-      ;; keep the spacemacs/toggle-line-numbers & friends around
       (spacemacs|add-toggle line-numbers
         :status (and (featurep 'display-line-numbers)
                      display-line-numbers-mode
-                     (eq display-line-numbers t))
+                     (eq display-line-numbers dotspacemacs-line-numbers))
         :on (prog1 (display-line-numbers-mode)
-              (setq display-line-numbers t))
+              (setq display-line-numbers dotspacemacs-line-numbers))
         :off (display-line-numbers-mode -1)
-        :on-message "Absolute line numbers enabled."
+        :on-message "Line numbers enabled per dotspacemacs-line-numbers."
         :off-message "Line numbers disabled."
-        :documentation "Show the line numbers.")
+        :documentation "Show line numbers as configured in .spacemacs."
+        :evil-leader "tnn")
       (spacemacs|add-toggle absolute-line-numbers
         :status (and (featurep 'display-line-numbers)
                      display-line-numbers-mode
@@ -308,7 +307,7 @@
         :off (display-line-numbers-mode -1)
         :on-message "Absolute line numbers enabled."
         :off-message "Line numbers disabled."
-        :documentation "Show the line numbers."
+        :documentation "Show absolute line numbers."
         :evil-leader "tna")
       (spacemacs|add-toggle relative-line-numbers
         :status (and (featurep 'display-line-numbers)


### PR DESCRIPTION
Toggles are great and all, but the trouble with the various toggles for line
numbers is that they force you to remember and think about the fact that there
are variant forms of line numbers. To beginners or forgetful people the various
combinations of behavior can be unintuitive here (e.g. toggling off relative
line numbers does nothing if you are actual in visual line numbers mode). Though
it doesn't fit exactly into the normal stuff we have for toggles, due to the
complexity of this situation I think it is good to just have a way to say "line
numbers be gone!"

Wasn't sure what keybinding to use, so used a double-tap mnemonic.

If this PR gets rejected, there are a couple minor fixes that should probably be
pulled out and submitted separately.