### PR TITLE
Add bindings for scrolling the message pane in tree-view

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2833,6 +2833,7 @@ files (thanks to Daniel Nicolai)
   (thanks to jupl)
 - Disabled add-node-modules-path by default (thanks to Eivind Fonn)
 **** Notmuch
+- Added support for scrolling the message pane in notmuch-tree, originally bound to SPC/BKSPC (thanks to inwit).
 - Fixed a bug in notmuch-tree which was preventing ~d~/~D~ bindings to work (thanks to Daniel Nicolai, alexey0308, inwit)
 - Try harder to find GitHub patch URL (thanks to Miciah Masters)
 - Open GitHub patches fullscreen

--- a/layers/+email/notmuch/README.org
+++ b/layers/+email/notmuch/README.org
@@ -188,6 +188,8 @@ Refer to the official notmuch website for more information:
 | ~+~         | [Message] Add tags       |
 | ~-~         | [Message] Remove tags    |
 | ~a~         | [Message] Archive        |
+| ~M-d~       | [Message] Scroll down the message pane |
+| ~M-u~       | [Message] Scroll up the message pane |
 
 * Spacemacs layout integration
 This layer defines a [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#layouts-and-workspaces][Spacemacs custom layout]] and automatically adds notmuch

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -131,6 +131,8 @@
         (kbd "D") 'spacemacs/notmuch-tree-message-delete-up
         (kbd "n") 'notmuch-tree-next-matching-message
         (kbd "p") 'notmuch-tree-prev-matching-message
+        (kbd "M-d") 'notmuch-tree-scroll-message-window
+        (kbd "M-u") 'notmuch-tree-scroll-message-window-back
         (kbd "M") 'compose-mail-other-frame)
       (evilified-state-evilify-map notmuch-search-mode-map
         :mode notmuch-search-mode


### PR DESCRIPTION
In standard notmuch-emacs, one can scroll back and forth the message
pane using `SPC`/`BKSPC`. Obviously, this is not the case in Spacemacs,
where `SPC` is reserved. There was no way to scroll the message pane in
this layer, so I added `M-d` and `M-u` wired to
`notmuch-tree-scroll-message-window` and
`notmuch-tree-scroll-message-window-back`.