### PR TITLE
[docs] Update readme, Windows clone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,16 @@ the [full installation instructions](#install) for other options.
   ```shell
   git clone -b develop https://github.com/syl20bnr/spacemacs ~/.emacs.d
   ```
+  * Windows Command Prompt:
+    ```shell
+    git clone -b develop https://github.com/syl20bnr/spacemacs %appdata%/.emacs.d
+    ```
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+    Windows PowerShell:
+    ```shell
+    git clone -b develop https://github.com/syl20bnr/spacemacs $env:appdata/.emacs.d
+    ```
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [Introduction](#introduction)
@@ -58,7 +66,16 @@ the [full installation instructions](#install) for other options.
     - [Emacs](#emacs)
         - [Linux distros](#linux-distros)
         - [macOS](#macos)
+            - [Install emacs](#install-emacs)
+                - [Using emacs-plus](#using-emacs-plus)
+                - [Using emacs-mac](#using-emacs-mac)
+                - [Using cask](#using-cask)
+                - [Other ways](#other-ways)
+            - [Install Source Code Pro font](#install-source-code-pro-font)
+            - [Install Spacemacs](#install-spacemacs)
         - [Windows](#windows)
+            - [Install Spacemacs in Windows](#install-spacemacs-in-windows)
+            - [Notes](#notes)
 - [Install](#install)
     - [Default installation](#default-installation)
     - [Alternative installations](#alternative-installations)
@@ -248,32 +265,66 @@ Download the official 64-bit (x86_64) stable builds from the [GNU FTP][emacs-for
 You'll also need `gzip` and put it in your path, to download it go to the
 [GNUWin32 project page][gzip-for-windows]
 
-Be sure to declare an environment variable named `HOME` that's pointing to your
-user directory `C:\Users\<username>`. Then you can clone Spacemacs into that
-directory.
+#### Install Spacemacs in Windows
+By default Emacs looks for the `.emacs.d` directory in:
+`C:\Users\<username>\AppData\Roaming`
 
-If the following error occurs after starting Emacs:
+* Clone Spacemacs to the Roaming directory:
+  * Windows Command Prompt
+    ```shell
+    git clone -b develop https://github.com/syl20bnr/spacemacs %appdata%/.emacs.d
+    ```
 
-```
-The directory ~/.emacs.d/server is unsafe
-```
+  * Windows PowerShell prompt:
+    ```shell
+    git clone -b develop https://github.com/syl20bnr/spacemacs $env:appdata/.emacs.d
+    ```
 
-Fix it by changing the owner of the directory `~/.emacs.d/server`:
-  - from Properties select the Tab “Security”,
-  - select the button “Advanced”,
-  - select the Tab “Owner”
-  - change the owner to your account name
+* Or if a `HOME` environment variable has been configured, that points to your
+user directory: `C:\Users\<username>`
 
-Source: [Stack Overflow][so-server-unsafe]
+  Clone Spacemacs to the `<username>` directory:
+  * Windows Command Prompt
+    ```shell
+    git clone -b develop https://github.com/syl20bnr/spacemacs %homepath%/.emacs.d
+    ```
 
-For efficient searches we recommend installing `pt` ([the platinum searcher][]).
+  * Windows PowerShell prompt:
+    ```shell
+    git clone -b develop https://github.com/syl20bnr/spacemacs $home/.emacs.d
+    ```
+
+#### Notes
+
+* If the following error occurs after starting Emacs:
+
+  ```
+  The directory ~/.emacs.d/server is unsafe
+  ```
+
+  Fix it by changing the owner of the directory `~/.emacs.d/server`:
+    - from Properties select the Tab “Security”,
+    - select the button “Advanced”,
+    - select the Tab “Owner”
+    - change the owner to your account name
+
+  Source: [Stack Overflow][so-server-unsafe]
+
+* For efficient searches we recommend installing `pt` ([the platinum searcher][]).
 `pt` version 1.7.7 or higher is required.
 
-**Notes:**
-Depending on the installed version of GnuTLS securely installing emacs
+* Depending on the installed version of GnuTLS securely installing emacs
 packages may fail. In this case it is possible to install using
 `emacs --insecure`. However be aware that this means your packages will
 be transferred using http, use at your own risk.
+
+* The period (dot) before a file or folder name, means that it's hidden.
+  To show hidden files and folders:
+  - Press the Windows key
+  - Type `file explorer options`
+  - Select the `View` tab at the top
+  - Check `Show hidden files, folders and drives`
+  - Click `OK`
 
 # Install
 ## Default installation
@@ -292,6 +343,8 @@ be transferred using http, use at your own risk.
 
 2. Clone the repository with [Git][]:
 
+   **Note: Windows users**, see the [Windows section](#install-spacemacs-in-windows) for the correct clone path.
+
    ```sh
    git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d
    ```
@@ -308,17 +361,6 @@ be transferred using http, use at your own risk.
    modification to it or you will break the update mechanism. If you want to
    fork Spacemacs safely, use the `develop` branch where you'll handle updates
    manually.
-
-   **Note for Windows users**
-   If you use windows, then you'll have to modify the git command by inserting
-   the correct path to your `.emacs.d` folder. The dot before the folder means
-   that it's hidden. You'll have to search for hidden files to find the folder.
-   When you have found the folder, substitute the original path with the correct
-   one. The proper code would look something like this:
-
-   ```sh
-   git clone https://github.com/syl20bnr/spacemacs /path/to/your/.emacs.d
-   ```
 
 3. (Optional) Install the default fonts
 


### PR DESCRIPTION
problem:
The clone command doesn't work in Windows:
`git clone -b develop https://github.com/syl20bnr/spacemacs ~/.emacs.d`

It creates a `~` directory in: `C:\Users\username`
that contains: `.emacs.d`

But Emacs looks for `.emacs.d` in: `C:\Users\username\AppData\Roaming`

solution:
Add instructions for cloning to the Roaming directory.

In a Command Prompt:
`git clone -b develop https://github.com/syl20bnr/spacemacs %appdata%/.emacs.d`

In a Windows PowerShell prompt:
`git clone -b develop https://github.com/syl20bnr/spacemacs $env:appdata/.emacs.d`