### PR TITLE
Add python-send-shell-with-output command

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -458,20 +458,21 @@ search path by activating a virtual environment.
 
 Send code to inferior process commands:
 
-| Key binding | Description                                      |
-|-------------+--------------------------------------------------|
-| ~SPC m s b~ | send buffer and keep code buffer focused         |
-| ~SPC m s B~ | send buffer and switch to REPL in insert mode    |
-| ~SPC m s e~ | send statement and keep code buffer focused      |
-| ~SPC m s E~ | send statement and switch to REPL in insert mode |
-| ~SPC m s f~ | send function and keep code buffer focused       |
-| ~SPC m s F~ | send function and switch to REPL in insert mode  |
-| ~SPC m s i~ | start inferior REPL process                      |
-| ~SPC m s l~ | send line and keep code buffer focused           |
-| ~SPC m s r~ | send region and keep code buffer focused         |
-| ~SPC m s R~ | send region and switch to REPL in insert mode    |
-| ~CTRL+j~    | next item in REPL history                        |
-| ~CTRL+k~    | previous item in REPL history                    |
+| Key binding | Description                                                  |
+|-------------+--------------------------------------------------------------|
+| ~SPC m s s~ | send region (or line when region not active) and show output |
+| ~SPC m s b~ | send buffer and keep code buffer focused                     |
+| ~SPC m s B~ | send buffer and switch to REPL in insert mode                |
+| ~SPC m s e~ | send statement and keep code buffer focused                  |
+| ~SPC m s E~ | send statement and switch to REPL in insert mode             |
+| ~SPC m s f~ | send function and keep code buffer focused                   |
+| ~SPC m s F~ | send function and switch to REPL in insert mode              |
+| ~SPC m s i~ | start inferior REPL process                                  |
+| ~SPC m s l~ | send line and keep code buffer focused                       |
+| ~SPC m s r~ | send region and keep code buffer focused                     |
+| ~SPC m s R~ | send region and switch to REPL in insert mode                |
+| ~CTRL+j~    | next item in REPL history                                    |
+| ~CTRL+k~    | previous item in REPL history                                |
 
 ** Running Python Script in shell
 To run a Python script like you would in the shell press ~SPC m c c~

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -477,6 +477,19 @@ Bind formatter to '==' for LSP and '='for all other backends."
   (python-shell-switch-to-shell)
   (evil-insert-state))
 
+(defun spacemacs/python-shell-send-with-output(start end)
+  "Send region content to shell and show output in comint buffer.
+If region is not active then send line."
+  (interactive "r")
+  (let ((python-mode-hook nil)
+        (process-buffer (python-shell-get-process))
+        (line-start (point-at-bol))
+        (line-end (point-at-eol)))
+    (if (region-active-p)
+        (comint-send-region process-buffer start end)
+      (comint-send-region process-buffer line-start line-end))
+    (comint-simple-send process-buffer "\r")))
+
 (defun spacemacs/python-start-or-switch-repl ()
   "Start and/or switch to the REPL."
   (interactive)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -399,7 +399,8 @@
         "si" 'spacemacs/python-start-or-switch-repl
         "sR" 'spacemacs/python-shell-send-region-switch
         "sr" 'spacemacs/python-shell-send-region
-        "sl" 'spacemacs/python-shell-send-line)
+        "sl" 'spacemacs/python-shell-send-line
+        "ss" 'spacemacs/python-shell-send-with-output)
 
       ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
       ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)


### PR DESCRIPTION
Currently when using any python-send-shell command (using either the python or ipython shell),
the output of the evaluation is not shown in the comint shell (see Emacs bug#49822).
This commit adds a simple function to send input and get the output printed in the comint process buffer.