### PR TITLE
Add .leex support for the html layer

### DIFF
--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -242,6 +242,7 @@
      ("\\.[gj]sp\\'"     . web-mode)
      ("\\.as[cp]x?\\'"   . web-mode)
      ("\\.eex\\'"        . web-mode)
+     ("\\.leex\\'"       . web-mode)
      ("\\.erb\\'"        . web-mode)
      ("\\.mustache\\'"   . web-mode)
      ("\\.handlebars\\'" . web-mode)

--- a/layers/auto-layer.el
+++ b/layers/auto-layer.el
@@ -54,7 +54,7 @@
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.sass\\'\\)" sass-mode))
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.scss\\'\\)" scss-mode))
 (configuration-layer/lazy-install 'html :extensions '("\\(\\.slim\\'\\)" slim-mode))
-(configuration-layer/lazy-install 'html :extensions '("\\(\\.phtml\\'\\|\\.tpl\\.php\\'\\|\\.twig\\'\\|\\.html\\'\\|\\.htm\\'\\|\\.[gj]sp\\'\\|\\.as[cp]x?\\'\\|\\.eex\\'\\|\\.erb\\'\\|\\.mustache\\'\\|\\.handlebars\\'\\|\\.hbs\\'\\|\\.eco\\'\\|\\.ejs\\'\\|\\.djhtml\\'\\)" web-mode))
+(configuration-layer/lazy-install 'html :extensions '("\\(\\.phtml\\'\\|\\.tpl\\.php\\'\\|\\.twig\\'\\|\\.html\\'\\|\\.htm\\'\\|\\.[gj]sp\\'\\|\\.as[cp]x?\\'\\|\\.eex\\'\\|\\.leex\\'\\|\\.erb\\'\\|\\.mustache\\'\\|\\.handlebars\\'\\|\\.hbs\\'\\|\\.eco\\'\\|\\.ejs\\'\\|\\.djhtml\\'\\)" web-mode))
 (configuration-layer/lazy-install 'idris :extensions '("\\(\\.idr$\\|\\.lidr$\\)" idris-mode))
 ;; javascript
 (configuration-layer/lazy-install 'javascript :extensions '("\\(\\.coffee\\'\\|\\.iced\\'\\|Cakefile\\'\\|\\.cson\\'\\)" coffee-mode))


### PR DESCRIPTION
Register .leex files for web-mode in the html layer, and add .leex to the html lazy-install file extensions list.

.leex files are a variant of .eex files. They are used with the [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view/assigns-eex.html#content) web framework.