### PR TITLE
[compleseus] Fix keys

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -96,6 +96,12 @@
   (interactive)
   (spacemacs/compleseus-search nil (projectile-project-root)))
 
+(defun spacemacs/compleseus-find-file ()
+  "This solves the problem:
+Binding a key to: `find-file' calls: `ido-find-file'"
+  (interactive)
+  (call-interactively 'find-file))
+
 ;; persp-mode stuff
 (defun spacemacs/compleseus-spacemacs-layout-layouts ()
   (interactive)

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -136,8 +136,10 @@
       "/" #'spacemacs/compleseus-search-projectile-auto
       "bb" #'spacemacs/compleseus-switch-to-buffer
       "bB" #'consult-buffer
-      "ff" #'find-file
+      "fb" #'consult-bookmark
+      "ff" #'spacemacs/compleseus-find-file
       "fr" #'consult-recent-file
+      "hda" #'consult-apropos
       "jm" #'consult-mark
       "jM" #'consult-global-mark
       "sb" #'consult-line-multi
@@ -223,6 +225,7 @@
      ("C-h B" . embark-bindings)) ;; alternative for `describe-bindings'
 
     :init
+    (spacemacs/set-leader-keys "?" #'embark-bindings)
     ;; Optionally replace the key help with a completing-read interface
     (setq prefix-help-command #'embark-prefix-help-command)
 


### PR DESCRIPTION
problem
- `SPC h d a` is undefined
- `SPC ?` shows: SPC ?-  which-key: There are no keys to show
- `SPC f b` calls: `bookmark-jump`. Setting a bookmark, requires typing the
bookmark name and calling an embark action:
 M-o                    ;; embark-act
 s                      ;; bookmark-set
- `SPC f f` is bound to `find-file` but it calls `ido-find-file`

solution
- `SPC h d a` `consult-apropos`
- `SPC ?` `embark-bindings`
- `SPC f b` `consult-bookmark`, it allows for jumping to a bookmark
(just like `bookmark-jump`), but a bookmark can be set by just typing a new
name. If there is a bookmark with a similar name, then the selection can be
moved up to the prompt. (the embark action method also works here)
- `SPC f f` `spacemacs/compleseus-find-file` (it calls `find-file`)