### PR TITLE
[compleseus] Fix junk file function

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -354,19 +354,35 @@ if it was disabled before a symbol was highlighted."
 ;; junk-file
 
 (defun spacemacs/open-junk-file (&optional arg)
-  "Open junk file using helm or ivy.
+  "Create a junk file with the initial name that's based on the variable
+`open-junk-file-format'
+`~/.emacs.d/.cache/junk/%Y/%m/%d-%H%M%S.'
 
-Interface choice depends on whether the `ivy' layer is used or
-not.
+Or erase the name and open an existing junk file.
 
-When ARG is non-nil search in junk files."
+When ARG is non-nil, search in the junk files.
+
+The interface depends on the current completion layer:
+compleseus
+helm
+ivy"
   (interactive "P")
   (let* ((fname (format-time-string open-junk-file-format (current-time)))
          (rel-fname (file-name-nondirectory fname))
          (junk-dir (file-name-directory fname))
          (default-directory junk-dir))
     (make-directory junk-dir t)
-    (cond ((and arg (configuration-layer/layer-used-p 'ivy))
+    (cond ((and arg (configuration-layer/layer-used-p 'compleseus))
+           (cond ((executable-find "rg") (consult-ripgrep junk-dir))
+                 ((executable-find "grep") (consult-grep junk-dir))
+                 (t (message "Couldn't find either executable: rg or grep"))))
+          ((configuration-layer/layer-used-p 'compleseus)
+           (find-file
+            (completing-read
+             junk-dir
+             (directory-files junk-dir nil directory-files-no-dot-files-regexp)
+             nil nil rel-fname)))
+          ((and arg (configuration-layer/layer-used-p 'ivy))
            (spacemacs/counsel-search dotspacemacs-search-tools nil junk-dir))
           ((configuration-layer/layer-used-p 'ivy)
            (require 'counsel)


### PR DESCRIPTION
problem
`SPC f J` (`spacemacs/open-junk-file`) shows:
cond: Cannot open load file: No such file or directory, helm

cause
`spacemacs/open-junk-file`
expects the completion layer to be either: `helm` or `ivy`

notes
The junk file function searches through the junk files,
when the ARG parameter is non-nil
(when it's called with a prefix argument: `SPC u SPC f J`)

The helm and ivy search functions might be choosing the search tool,
based on the first search tool it finds in the variable:
`dotspacemacs-search-tools`
`("rg" "ag" "pt" "ack" "grep")`

The consult package has these two search functions:
`consult-grep`
`consult-ripgrep`

This fix only uses those two for searching.
It checks for the executable: `rg` before `grep`