### PR TITLE
[defaults] switch frame by displayed buffers names `SPC F s`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -838,6 +838,7 @@ Other:
   - Added =string-edit= package to =spacemacs-editing= layer
     (thanks to Ivan Yonchovski)
 - Key bindings:
+  - Switch frames by displayed buffer names via ~SPC F s~ (thanks to Keith Pinson)
   - Toggle line numbers (i.e. toggle =display-line-numbers-mode=) via ~SPC t n n~
     without having to think about which variant of line numbers you have turned
     on (thanks to Keith Pinson)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2565,6 +2565,7 @@ Frame manipulation commands (start with ~F~):
 | ~SPC F o~   | cycle focus between frames                          |
 | ~SPC F O~   | open a dired buffer in another frame                |
 | ~SPC F n~   | create a new frame                                  |
+| ~SPC F s~   | switch to frame by displayed buffers names          |
 
 **** Emacs and Spacemacs files
 Convenient key bindings are located under the prefix ~SPC f e~ to quickly

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -133,6 +133,25 @@ If not in such a search box, fall back on `Custom-newline'."
 (defalias 'spacemacs/display-buffer-other-frame 'display-buffer-other-frame)
 (defalias 'spacemacs/find-file-and-replace-buffer 'find-alternate-file)
 
+(defun spacemacs/switch-frame-by-buffers ()
+  "Switch to frame selected by user based on names of displayed buffers."
+  (interactive)
+  (let ((frame-alist
+         (mapcar (lambda (frame)
+                   (cons (string-join (mapcar (lambda (window)
+                                                (buffer-name (window-buffer window)))
+                                              (window-list frame))
+                                      " | ")
+                         frame))
+                 (frame-list))))
+    (select-frame-set-input-focus
+     (cdr
+      (assoc (completing-read "Switch to frame: "
+                              frame-alist
+                              nil
+                              t)
+             frame-alist)))))
+
 (defun spacemacs/indent-region-or-buffer ()
   "Indent a region if selected, otherwise the whole buffer."
   (interactive)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -410,7 +410,8 @@
    ("B" spacemacs/display-buffer-other-frame "Display buffer other frame...")
    ("o" other-frame "Switch to other frame")
    ("O" spacemacs/dired-other-frame "Dired other frame...")
-   ("n" make-frame "Make frame"))))
+   ("n" make-frame "Make frame")
+   ("s" spacemacs/switch-frame-by-buffers "Switch frame by displayed buffer names") )))
 ;; help -----------------------------------------------------------------------
 (defalias 'emacs-tutorial 'help-with-tutorial)
 (spacemacs/set-leader-keys


### PR DESCRIPTION
On my Linux box I often have at least four Emacs frames displayed in different
virtual desktops. Switching between them with `SPC F o` is disorienting because I
never know which one is next. I look in vain for a more targeted way to switch,
so I built one. The use of `completing-read` means it should integrate with
whatever completion framework is in use.

If you happen to have two frames up with the same buffers in them, this will not
help you discriminate between them. But that seems like an odd case; why would
you make multiple frames with exactly the same contents?

Used `s` as a mnemonic for switch, select or search (since it using
`completing-read`). I believe this is in line with Spacemacs conventions and it
didn't collide with anything existing.