### PR TITLE
Add twitch layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -477,6 +477,7 @@ In org-agenda-mode
 - xclipboard (thanks to Charles Weill, Sylvain Benner, and Alex Palaistras)
 **** WEB services
 - confluence
+- twitch
 *** Renamed layers
 - =extra-langs= renamed to =major-modes= (thanks to Eivind Fonn)
 - =pdf-tools= renamed to =pdf=

--- a/layers/+web-services/twitch/README.org
+++ b/layers/+web-services/twitch/README.org
@@ -1,0 +1,53 @@
+#+TITLE: twitch layer
+#+TAGS: layer|web service
+
+* Table of Contents                                       :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#configuration][Configuration]]
+- [[#key-bindings][Key bindings]]
+  - [[#twitch-helm][Twitch helm]]
+
+* Description
+This layer adds support for twitch. You can search for streamers and open the stream in the browser.
+If the =erc= layer is enabled you are able to connect to twitch irc and join the streamer channel.
+If the =streamlink= layer is enabled the streams are opened with streamlink.
+
+** Features:
+  - Connect to Twitch irc via erc
+  - Join streamer channel
+  - Start watching stream via streamlink
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =twitch= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Configuration
+You can get an OAUTH token for twitch [[http://twitchapps.com/tmi/][here]]. Remove =oauth:= from the token.
+
+#+BEGIN_SRC emacs-lisp
+  erc ;; optional
+  streamlink ;; optional
+  (twitch :variables
+          twitch-api-username "USERNAME"
+          twitch-api-oauth-token "TOKEN") ;; remove oauth: prefix
+#+END_SRC
+
+* Key bindings
+
+| Key Binding   | Description                              |
+|---------------+------------------------------------------|
+| ~SPC a c i t~ | Connect to Twitch irc via erc            |
+| ~SPC a w s h~ | Start twitch helm and search for streams |
+
+** Twitch helm
+When enabling =erc= and =streamlink= layers helm-twitch has the following keybindings.
+   
+| Key Binding   | Description                             |
+|---------------+-----------------------------------------|
+| ~SPC a w s h~ | Start twitch helm                       |
+| ~F1~ or ~RET~ | Open stream in streamlink               |
+| ~F2~          | Join this stream in irc Twitch channel  |
+| ~F3~          | Open this stream in a browser (default) |

--- a/layers/+web-services/twitch/config.el
+++ b/layers/+web-services/twitch/config.el
@@ -1,0 +1,28 @@
+;;; config.el --- erc Layer configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;;
+;; Author: Benedikt Broich <b.broich@posteo.de>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+(defvar helm-twitch-enable-livestreamer-actions nil
+  "If non nil then the livestreamer action will be shown.")
+
+(defvar helm-twitch-enable-chat-actions nil
+  "If non nil then the join irc channel action will be shown.")

--- a/layers/+web-services/twitch/packages.el
+++ b/layers/+web-services/twitch/packages.el
@@ -24,7 +24,6 @@
 
 (defconst twitch-packages
   '(
-    ;; (erc-twitch :toggle (configuration-layer/package-usedp 'erc))
     (twitch-api :location (recipe :fetcher github
                                   :repo "benediktbroich/twitch-api"))
     (helm-twitch :location (recipe :fetcher github

--- a/layers/+web-services/twitch/packages.el
+++ b/layers/+web-services/twitch/packages.el
@@ -29,8 +29,7 @@
                                   :repo "benediktbroich/twitch-api"))
     (helm-twitch :location (recipe :fetcher github
                                    :repo "benediktbroich/helm-twitch")
-                 ;; :toggle (configuration-layer/package-usedp 'helm)
-                 )))
+                 :requires helm)))
 
 (defun twitch/init-twitch-api ()
   (use-package twitch-api

--- a/layers/+web-services/twitch/packages.el
+++ b/layers/+web-services/twitch/packages.el
@@ -1,0 +1,52 @@
+;;; packages.el --- twitch layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;;
+;; Author: Benedikt Broich <b.broich@posteo.de>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(defconst twitch-packages
+  '(
+    ;; (erc-twitch :toggle (configuration-layer/package-usedp 'erc))
+    (twitch-api :location (recipe :fetcher github
+                                  :repo "benediktbroich/twitch-api"))
+    (helm-twitch :location (recipe :fetcher github
+                                   :repo "benediktbroich/helm-twitch")
+                 ;; :toggle (configuration-layer/package-usedp 'helm)
+                 )))
+
+(defun twitch/init-twitch-api ()
+  (use-package twitch-api
+    :init (progn
+            (when (configuration-layer/package-usedp 'erc)
+              (spacemacs/set-leader-keys
+                "acit" 'twitch-api-erc-tls)))))
+
+(defun twitch/init-helm-twitch ()
+  (use-package helm-twitch
+    :defer t
+    :init (progn
+            (spacemacs/declare-prefix "aws" "stream")
+            (spacemacs/set-leader-keys
+              "awst" 'helm-twitch)
+            (when (configuration-layer/package-usedp 'streamlink)
+              (setq helm-twitch-enable-livestreamer-actions t))
+            (when (configuration-layer/package-usedp 'erc)
+              (setq helm-twitch-enable-chat-actions t)))))


### PR DESCRIPTION
This layer adds support for twitch. You can search for streamers and open the stream in the browser.
If the =erc= layer is enabled you are able to connect to twitch irc and join the streamer channel.
If the =streamlink= layer is enabled the streams are opened with streamlink. (Pull request is open)