### PR TITLE
Change show-all keybinding to outline-cycle-buffer in pdf layer

### DIFF
--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -189,7 +189,7 @@ differently from the default Evil search. To go to the next match, use ~C-s~.
 
 | *Key binding* | *Description*                                         |
 |---------------+-------------------------------------------------------|
-| ~S-tab~       | Expand all trees                                      |
+| ~S-tab~       | Expand all trees (Cycle trees for >= Emacs 28)        |
 | ~RET~         | Follow link                                           |
 | ~M-RET~       | Follow link and close outline window                  |
 | ~o~           | Go to pdf view window                                 |

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -104,7 +104,9 @@
         "k"                'previous-line
         "gk"               'outline-backward-same-level
         "gj"               'outline-forward-same-level
-        (kbd "<backtab>")  'show-all
+        (kbd "<backtab>")  (if (version< emacs-version "28.0")
+                               'outline-show-all
+                             'outline-cycle-buffer)
         "gh"               'pdf-outline-up-heading
         "gg"               'beginning-of-buffer
         "G"                'pdf-outline-end-of-buffer


### PR DESCRIPTION
Currently there is no keybinding to fold the outline of a pdf. So let's replace
show-all because it is easier to remember a single keybinding for folding and
unfolding then having separate bindings for those (and consistent with
org-mode's global cycle keybinding)