### PR TITLE
Adjust eaf layer to newer eaf package

### DIFF
--- a/layers/+tools/eaf/README.org
+++ b/layers/+tools/eaf/README.org
@@ -7,6 +7,7 @@
   - [[#features][Features:]]
 - [[#install][Install]]
 - [[#usage][Usage]]
+  - [[#configuring-applications][Configuring applications]]
   - [[#configuring-key-bindings][Configuring key bindings]]
 - [[#key-bindings][Key bindings]]
   - [[#global][Global]]
@@ -33,13 +34,35 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =eaf= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-Subsequently install the required dependencies with =SPC SPC
-  eaf-install-dependencies=. This command only works for Ubuntu and Fedora based
-distributions. Users of Arch (based) distributions can run the script manually
-in their terminal. If the script does not work for you then [[https://github.com/manateelazycat/emacs-application-framework#dependency-list][install the
-required dependencies manually]].
+Currently the command =SPC SPC eaf-install-dependencies= no longer works, please
+refer to [[https://github.com/manateelazycat/emacs-application-framework#dependency-list][install the required dependencies manually]].
 
 * Usage
+** Configuring applications
+By default, all applications provided by eaf package are loaded, including:
+
+- eaf-jupyter
+- eaf-browser
+- eaf-airshare
+- eaf-file-browser
+- eaf-file-manager
+- eaf-file-sender
+- eaf-music-player
+- eaf-system-monitor
+- eaf-mindmap
+- eaf-org-previewer
+- eaf-terminal
+- eaf-netease-cloud-music
+- eaf-video-player
+- eaf-image-viewer
+- eaf-demo
+- eaf-vue-demo
+- eaf-pdf-viewer
+- eaf-markdown-previewer
+- eaf-camera
+
+To customise applications, please set =eaf=app=
+
 ** Configuring key bindings
 Configuration of EAF key bindings works in a different way than normally in Spacemacs.
 
@@ -48,7 +71,7 @@ required to make leader keys in EAF buffers behave as expected in Spacemacs.
 Therefore it is recommended to keep these default (major-mode-)leader
 keybindings.
 
-For information about configuration of other key bindings for EAF, see [[https://github.com/manateelazycat/emacs-application-framework/wiki/Keybindings][here]]. 
+For information about configuration of other key bindings for EAF, see [[https://github.com/manateelazycat/emacs-application-framework/wiki/Keybindings][here]].
 
 If you do want to modify the leader keys, then information about the tricks
 implemented in this layer can be found [[https://github.com/manateelazycat/emacs-application-framework/issues/498][here]] and [[https://github.com/manateelazycat/emacs-application-framework/pull/500][here]].

--- a/layers/+tools/eaf/README.org
+++ b/layers/+tools/eaf/README.org
@@ -20,14 +20,14 @@
     - [[#pdf-view-mode-pdf-tools][pdf-view-mode (pdf-tools)]]
 
 * Description
-This layer adds support for the [[https://github.com/manateelazycat/emacs-application-framework][Emacs Application Framework (EAF)]].
+This layer adds support for the [[https://github.com/emacs-eaf/emacs-application-framework][Emacs Application Framework (EAF)]].
 
 ** Features:
 - Browse using a full-fledged browser within Emacs
 - PDF viewer (with continuous scroll)
 - Video player
 - Image viewer
-- See [[https://github.com/manateelazycat/emacs-application-framework#launch-eaf-applications][EAF documentation]] for many more features
+- See [[https://github.com/emacs-eaf/emacs-application-framework#launch-eaf-applications][EAF documentation]] for many more features
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
@@ -35,7 +35,7 @@ add =eaf= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 Currently the command =SPC SPC eaf-install-dependencies= no longer works, please
-refer to [[https://github.com/manateelazycat/emacs-application-framework#dependency-list][install the required dependencies manually]].
+refer to [[https://github.com/emacs-eaf/emacs-application-framework#dependency-list][install the required dependencies manually]].
 
 * Usage
 ** Configuring applications
@@ -71,14 +71,14 @@ required to make leader keys in EAF buffers behave as expected in Spacemacs.
 Therefore it is recommended to keep these default (major-mode-)leader
 keybindings.
 
-For information about configuration of other key bindings for EAF, see [[https://github.com/manateelazycat/emacs-application-framework/wiki/Keybindings][here]].
+For information about configuration of other key bindings for EAF, see [[https://github.com/emacs-eaf/emacs-application-framework/wiki/Keybindings][here]].
 
 If you do want to modify the leader keys, then information about the tricks
-implemented in this layer can be found [[https://github.com/manateelazycat/emacs-application-framework/issues/498][here]] and [[https://github.com/manateelazycat/emacs-application-framework/pull/500][here]].
+implemented in this layer can be found [[https://github.com/emacs-eaf/emacs-application-framework/issues/498][here]] and [[https://github.com/emacs-eaf/emacs-application-framework/pull/500][here]].
 
 * Key bindings
 Except for the few Spacemacs specific modifications listed below, all EAF
-keybindings are documented [[https://github.com/manateelazycat/emacs-application-framework/wiki/Keybindings][here.]]
+keybindings are documented [[https://github.com/emacs-eaf/emacs-application-framework/wiki/Keybindings][here.]]
 
 Use ~SPC t k m~ to [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-key-persistent][show the EAF key bindings persistently in which-key]], or use
 ~SPC h d K~ to show the `eaf-mode-map` in a separate buffer.
@@ -88,7 +88,7 @@ Use ~SPC t k m~ to [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-
 
 | Key binding | Description                                                                   |
 |-------------+-------------------------------------------------------------------------------|
-| ~SPC a a f~ | EAF open file ([[https://github.com/manateelazycat/emacs-application-framework#launch-eaf-applications][see EAF doc for supported file types]])                          |
+| ~SPC a a f~ | EAF open file ([[https://github.com/emacs-eaf/emacs-application-framework#launch-eaf-applications][see EAF doc for supported file types]])                          |
 | ~SPC a a s~ | EAF open system monitor                                                       |
 | ~SPC a a M~ | EAF open musik player                                                         |
 | ~SPC t k m~ | Show available key commands in which-key (read [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-key][here]] for more details)         |
@@ -99,7 +99,7 @@ Use ~SPC t k m~ to [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-
 | Key binding   | Description                                                                           |
 |---------------+---------------------------------------------------------------------------------------|
 | ~SPC a a b o~ | Open url in new buffer                                                                |
-| ~SPC a a b s~ | Search with [[https://github.com/manateelazycat/emacs-application-framework/wiki/Customization#default-search-engine][your favorite search engine]]. Defaults to symbol at point or region string |
+| ~SPC a a b s~ | Search with [[https://github.com/emacs-eaf/emacs-application-framework/wiki/Customization#default-search-engine][your favorite search engine]]. Defaults to symbol at point or region string |
 | ~SPC a a b b~ | Open bookmark in new buffer                                                           |
 | ~SPC a a b h~ | Search and open buffer from history                                                   |
 
@@ -120,7 +120,7 @@ Use ~SPC t k m~ to [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-
 | ~C-s~       | Search/search find next (to enter new search prefix with ~C-g~ |
 | ~C-r~       | Search find previous                                           |
 | ~SPC m h~   | Open new buffer from history                                   |
-| ~SPC m s~   | Search web with [[https://github.com/manateelazycat/emacs-application-framework/wiki/Customization#default-search-engine][favorite search engine]]                         |
+| ~SPC m s~   | Search web with [[https://github.com/emacs-eaf/emacs-application-framework/wiki/Customization#default-search-engine][favorite search engine]]                         |
 
 *** PDF-viewer
 

--- a/layers/+tools/eaf/README.org
+++ b/layers/+tools/eaf/README.org
@@ -61,7 +61,7 @@ By default, all applications provided by eaf package are loaded, including:
 - eaf-markdown-previewer
 - eaf-camera
 
-To customise applications, please set =eaf=app=
+To customise applications, please set the variable =eaf-apps=
 
 ** Configuring key bindings
 Configuration of EAF key bindings works in a different way than normally in Spacemacs.

--- a/layers/+tools/eaf/README.org
+++ b/layers/+tools/eaf/README.org
@@ -35,7 +35,7 @@ add =eaf= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
 Currently the command =SPC SPC eaf-install-dependencies= no longer works, please
-refer to [[https://github.com/emacs-eaf/emacs-application-framework#dependency-list][install the required dependencies manually]].
+refer to [[https://github.com/emacs-eaf/emacs-application-framework#2-installupdate-eaf-applications-and-dependencies][install the required dependencies manually]].
 
 * Usage
 ** Configuring applications

--- a/layers/+tools/eaf/config.el
+++ b/layers/+tools/eaf/config.el
@@ -1,6 +1,6 @@
-;;; packages.el --- eaf configuration file
+;;; config.el --- (const eaf configuration file
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2021 Sylvain Benner & Contributors
 ;;
 ;; Author: Leslie Huang <lesliebinbin19900129@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -20,7 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(defcustom eaf-apps
+(spacemacs|defc eaf-apps
   '(eaf-jupyter
     eaf-browser
     eaf-airshare
@@ -39,9 +39,26 @@
     eaf-vue-demo
     eaf-pdf-viewer
     eaf-markdown-previewer
-    eaf-camera
-    )
-  "Eaf Applications"
-  :group 'eaf
-  :type '(symbol)
-)
+    eaf-camera)
+  "The applications loaded from EAF package"
+  '(set
+    (const eaf-jupyter)
+    (const eaf-browser)
+    (const eaf-airshare)
+    (const eaf-file-browser)
+    (const eaf-file-manager)
+    (const eaf-file-sender)
+    (const eaf-music-player)
+    (const eaf-system-monitor)
+    (const eaf-mindmap)
+    (const eaf-org-previewer)
+    (const eaf-terminal)
+    (const eaf-netease-cloud-music)
+    (const eaf-video-player)
+    (const eaf-image-viewer)
+    (const eaf-demo)
+    (const eaf-vue-demo)
+    (const eaf-pdf-viewer)
+    (const eaf-markdown-previewer)
+    (const eaf-camera))
+  'eaf)

--- a/layers/+tools/eaf/config.el
+++ b/layers/+tools/eaf/config.el
@@ -20,9 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(defcustom eaf-apps "Eaf Applications"
-  :group eaf
-  :type (symbol)
+(defcustom eaf-apps
   '(eaf-jupyter
     eaf-browser
     eaf-airshare
@@ -43,4 +41,7 @@
     eaf-markdown-previewer
     eaf-camera
     )
+  "Eaf Applications"
+  :group 'eaf
+  :type '(symbol)
 )

--- a/layers/+tools/eaf/config.el
+++ b/layers/+tools/eaf/config.el
@@ -1,0 +1,46 @@
+;;; packages.el --- eaf configuration file
+;;
+;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;;
+;; Author: Leslie Huang <lesliebinbin19900129@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defcustom eaf-apps "Eaf Applications"
+  :group eaf
+  :type (symbol)
+  '(eaf-jupyter
+    eaf-browser
+    eaf-airshare
+    eaf-file-browser
+    eaf-file-manager
+    eaf-file-sender
+    eaf-music-player
+    eaf-system-monitor
+    eaf-mindmap
+    eaf-org-previewer
+    eaf-terminal
+    eaf-netease-cloud-music
+    eaf-video-player
+    eaf-image-viewer
+    eaf-demo
+    eaf-vue-demo
+    eaf-pdf-viewer
+    eaf-markdown-previewer
+    eaf-camera
+    )
+)

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -48,6 +48,30 @@
     :defer t
     :init
     (progn
+      (with-eval-after-load 'eaf
+                    (let ((eaf-apps (list 'eaf-jupyter
+                                          'eaf-browser
+                                          'eaf-airshare
+                                          'eaf-file-browser
+                                          'eaf-file-manager
+                                          'eaf-file-sender
+                                          'eaf-music-player
+                                          'eaf-system-monitor
+                                          'eaf-mindmap
+                                          'eaf-org-previewer
+                                          'eaf-terminal
+                                          'eaf-netease-cloud-music
+                                          'eaf-video-player
+                                          'eaf-js-video-player
+                                          'eaf-image-viewer
+                                          'eaf-demo
+                                          'eaf-vue-demo
+                                          'eaf-pdf-viewer
+                                          'eaf-markdown-previewer
+                                          'eaf-camera
+                                          )))
+                      (dolist (app eaf-apps)
+                        (require app nil 'noerror))))
       (spacemacs/declare-prefix "aa" "application-framework")
       (spacemacs/set-leader-keys "aac" 'eaf-open-camera)
       (spacemacs/set-leader-keys "aaf" 'eaf-open)

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -32,11 +32,6 @@
     :defer t
     :init
     (progn
-      (with-eval-after-load
-        'eaf
-        (dolist (app eaf-apps)
-          (require app nil 'noerror))
-      )
       (spacemacs/declare-prefix "aa" "application-framework")
       (spacemacs/set-leader-keys "aac" 'eaf-open-camera)
       (spacemacs/set-leader-keys "aaf" 'eaf-open)
@@ -199,6 +194,8 @@
     ;; ("<C-iso-lefttab>" . "select_right_tab")
     :config
     (progn
+      (dolist (app eaf-apps)
+        (require app nil 'noerror))
       (setq browse-url-browser-function 'eaf-open-browser)
       (setq eaf-browser-enable-adblocker "true")
 

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -22,11 +22,7 @@
 
 
 (defconst eaf-packages
-  '(ctable
-    deferred
-    epc
-    ;; s
-    (eaf :location (recipe
+  '((eaf :location (recipe
                     :fetcher github
                     :repo  "manateelazycat/emacs-application-framework"
                     :files ("*")))))

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -40,7 +40,6 @@
 
 (defun eaf/init-eaf ()
   (use-package eaf
-    :defer t
     :init
     (progn
       (spacemacs/declare-prefix "aa" "application-framework")

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -49,7 +49,7 @@
     :init
     (progn
       (spacemacs/declare-prefix "aa" "application-framework")
-      (spacemacs/set-leader-keys "aac" 'eaf-camera)
+      (spacemacs/set-leader-keys "aac" 'eaf-open-camera)
       (spacemacs/set-leader-keys "aaf" 'eaf-open)
       (spacemacs/set-leader-keys "aaj" 'eaf-open-jupyter)
       (spacemacs/set-leader-keys "aao" 'eaf-open-office)

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -20,12 +20,23 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 (defconst eaf-packages
-  '((eaf :location (recipe
+  '(ctable
+    deferred
+    epc
+    (eaf :location (recipe
                     :fetcher github
-                    :repo  "manateelazycat/emacs-application-framework"
+                    :repo  "emacs-eaf/emacs-application-framework"
                     :files ("*")))))
+
+(defun eaf/init-ctable ()
+  (use-package ctable))
+
+(defun eaf/init-deferred ()
+  (use-package deferred))
+
+(defun eaf/init-epc ()
+  (use-package epc))
 
 (defun eaf/init-eaf ()
   (use-package eaf

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -31,47 +31,16 @@
                     :repo  "manateelazycat/emacs-application-framework"
                     :files ("*")))))
 
-(defun eaf/init-ctable ()
-  (use-package ctable))
-
-(defun eaf/init-deferred ()
-  (use-package deferred))
-
-(defun eaf/init-epc ()
-  (use-package epc))
-
-;; (defun eaf/init-s ()
-;;   (use-package s))
-
 (defun eaf/init-eaf ()
   (use-package eaf
     :defer t
     :init
     (progn
-      (with-eval-after-load 'eaf
-                    (let ((eaf-apps (list 'eaf-jupyter
-                                          'eaf-browser
-                                          'eaf-airshare
-                                          'eaf-file-browser
-                                          'eaf-file-manager
-                                          'eaf-file-sender
-                                          'eaf-music-player
-                                          'eaf-system-monitor
-                                          'eaf-mindmap
-                                          'eaf-org-previewer
-                                          'eaf-terminal
-                                          'eaf-netease-cloud-music
-                                          'eaf-video-player
-                                          'eaf-js-video-player
-                                          'eaf-image-viewer
-                                          'eaf-demo
-                                          'eaf-vue-demo
-                                          'eaf-pdf-viewer
-                                          'eaf-markdown-previewer
-                                          'eaf-camera
-                                          )))
-                      (dolist (app eaf-apps)
-                        (require app nil 'noerror))))
+      (with-eval-after-load
+        'eaf
+        (dolist (app eaf-apps)
+          (require app nil 'noerror))
+      )
       (spacemacs/declare-prefix "aa" "application-framework")
       (spacemacs/set-leader-keys "aac" 'eaf-open-camera)
       (spacemacs/set-leader-keys "aaf" 'eaf-open)
@@ -235,7 +204,7 @@
     :config
     (progn
       (setq browse-url-browser-function 'eaf-open-browser)
-      (eaf-setq eaf-browser-enable-adblocker "true")
+      (setq eaf-browser-enable-adblocker "true")
 
       (define-key eaf-mode-map* (kbd "C-SPC C-SPC") 'execute-extended-command)
       ;;;; TODO need to consider the current pdf view mode which does not need to be pdf view mode


### PR DESCRIPTION
- Fix leader key for eaf camera, it should be *eaf-open-camera* instead of *eaf-camera*
- Refer to a recent commit: https://github.com/emacs-eaf/emacs-application-framework/commit/044b0b8507a8d022d4e798ccfdbdf1f526fe9365, we should now require each application seperately
