### PR TITLE
Add jump to specific manual keybinding (SPC h j)

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/README.org
+++ b/layers/+spacemacs/spacemacs-navigation/README.org
@@ -5,6 +5,7 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#key-bindings][Key bindings]]
 
 * Description
 This layer adds general navigation functions to all supported layers.
@@ -21,3 +22,8 @@ This layer adds general navigation functions to all supported layers.
 - Support for =paradox= a modern emacs package manager
 - Shortcuts for restarting =emacs=
 - Shortcuts for easily switching between windows
+
+* Key bindings
+| Key Binding | Description    |
+|-------------+----------------|
+| ~SPC h j~   | jump to manual |

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -31,7 +31,7 @@
         (view :location built-in)
         golden-ratio
         (grep :location built-in)
-        (info+ :location local)
+        (info+ :location (recipe :fetcher wiki))
         open-junk-file
         paradox
         restart-emacs
@@ -323,6 +323,7 @@
     :defer t
     :init
     (progn
+      (spacemacs/set-leader-keys "hj" 'info-display-manual)
       (setq Info-fontify-angle-bracketed-flag nil)
       (add-hook 'Info-mode-hook (lambda () (require 'info+))))))
 


### PR DESCRIPTION
This PR is just a suggestion, because I personally frequently like to use this functionality (have it under `SPC h M`).
Of course, you are free to dismiss it...

This keybinding could also go under `SPC h M`, but that is currently taken by
`helm-switch-major-mode` (which seems a quite redundant command to me, as you
can switch major-modes directly using `M-x`/`SPC SPC`).