### PR TITLE
Evilify special-mode by default

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -585,7 +585,9 @@ Press \\[which-key-toggle-persistent] to hide."
 ;; pre packages
 
 (defun spacemacs-bootstrap/init-evil-evilified-state ()
-  (use-package evil-evilified-state)
+  (use-package evil-evilified-state
+    :config
+    (add-to-list 'evil-evilified-state-modes 'special-mode))
   (define-key evil-evilified-state-map (kbd dotspacemacs-leader-key)
     spacemacs-default-map))
 


### PR DESCRIPTION
Due to the `org-roam v2` warning buffer, I realized that special modes do not get `evilified` by default.
As I am not aware of any case where this is not desired, I created this PR as a suggestion.

It change should probably get documented also (before getting accepted), but I would be happy to fix that.

As special-mode is a read-only mode, it could be evilified by default.
I am not aware of any case where this is not desired.



Closes #14988 
