### PR TITLE
[erlang] add DAP support through erlang_ls-dap

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2007,6 +2007,10 @@ Other:
 - erc-view-log related changes (thanks to Mpho Jele)
   - Modified erc-log transient state to open in erc-view-log-mode
   - Added utility to open log buffer/file from erc channel
+**** Erlang
+- Added =lsp= support through erlang-ls backend (thanks to cfclavijo)
+- Added =dap= support through els_dap backend (thanks to cfclavijo)
+- =lsp= layer is a dependency when backend is set to ='lsp= (thanks to cfclavijo)
 **** ESS
 - Key bindings:
   - Change ~SPC m s t~ to ~SPC m s f~ to respect convention (thanks to Yi Liu)

--- a/layers/+lang/erlang/README.org
+++ b/layers/+lang/erlang/README.org
@@ -13,9 +13,11 @@
 - [[#configuration][Configuration]]
   - [[#erlang-mode][erlang-mode]]
   - [[#lsp][LSP]]
+  - [[#debugger][Debugger]]
 - [[#key-bindings][Key bindings]]
   - [[#erlang-mode-1][erlang-mode]]
   - [[#lsp-1][LSP]]
+  - [[#dap][DAP]]
 
 * Description
 This layer adds support for [[https://erlang.org/][Erlang]].
@@ -40,6 +42,7 @@ features following =Language Server Protocol=, through [[https://erlang-ls.githu
 - Outline
 - Workspace Symbols
 - Code Folding
+- Interactive debugger using [[https://github.com/emacs-lsp/dap-mode][dap-mode]]
 
 * Install
 ** Layer
@@ -90,6 +93,29 @@ You can install it:
   make install
 #+END_SRC
 
+** Debugger
+The =dap= backend uses [[https://erlang-ls.github.io/][erlang_ls-dap]] implementation. Information about configuring
+a project to use the debugger can be found [[https://erlang-ls.github.io/articles/tutorial-debugger/][here]].
+
+If you are using =erlang_ls= backend, probably you have =els_dap= already
+installed, otherwise, follow the instructions.
+
+Clone the project to your system and compile it to produce the =els_dap= escript:
+
+#+BEGIN_SRC bash
+  rebar3 as dap escriptize
+#+END_SRC
+
+or
+
+#+BEGIN_SRC bash
+  make
+#+END_SRC
+
+=els_dap= will be found at "erlang_ls/_build/dap/bin/"
+
+*Note:* Ensure you have =els_dap= in your =PATH=...
+
 * Key bindings
 ** erlang-mode
 
@@ -109,3 +135,6 @@ You can install it:
 
 ** LSP
 You will find an overview of all the key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp#key-bindings][lsp layer description]].
+
+** DAP
+You will find an overview of all the key bindings on the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/dap#key-bindings][dap layer description]].

--- a/layers/+lang/erlang/funcs.el
+++ b/layers/+lang/erlang/funcs.el
@@ -41,6 +41,12 @@
       (lsp-deferred)
     (message "`lsp' layer is not installed, please add `lsp' layer to your dotfile.")))
 
+(defun spacemacs//erlang-setup-dap ()
+  "Conditionally setup erlang DAP integration."
+  (if (configuration-layer/layer-used-p 'dap)
+      (require 'dap-erlang)
+    (message "`dsp' layer is not installed, please add `dap' layer to your dotfile.")))
+
 (defun spacemacs//erlang-default ()
   "Default settings for erlang buffers"
 

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -25,6 +25,7 @@
       '(
         company
         erlang
+        dap-mode
         ggtags
         counsel-gtags
         helm-gtags
@@ -56,6 +57,9 @@
       ;;             ))
       (setq erlang-compile-extra-opts '(debug_info)))
     :config (require 'erlang-start)))
+
+(defun erlang/pre-init-dap-mode ()
+  (add-hook 'erlang-mode-local-vars-hook #'spacemacs//erlang-setup-dap))
 
 (defun erlang/post-init-flycheck ()
   (spacemacs/enable-flycheck 'erlang-mode))


### PR DESCRIPTION
Adding support to erlang to debug using DAP.
It requires you to add `dap` layer to your `dotspacemacs-configuration-layers` (which will requires you to also add `lsp` layer).
Regarding the project, you will need to add a `launch.json` configuration to the project's root directory as explained in this [debugger-tutorial](https://erlang-ls.github.io/articles/tutorial-debugger/)