### PR TITLE
[major-modes] add evil-matchit support for matlab

### DIFF
--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -25,6 +25,7 @@
       '(
         arduino-mode
         (ebuild-mode :location (recipe :fetcher github :repo "emacsmirror/ebuild-mode"))
+        evil-matchit
         (hoon-mode :location (recipe :fetcher github :repo "urbit/hoon-mode.el"))
         (logcat :location (recipe :fetcher github :repo "dcolascione/logcat-mode"))
         matlab-mode
@@ -108,3 +109,6 @@
     :defer t
     :interpreter "\\(Wolfram\\|Mathematica\\)Script\\( -script\\)?"
     :mode "\\.wl\\'"))
+
+(defun major-modes/post-init-evil-matchit ()
+  (add-hook `matlab-mode-hook `turn-on-evil-matchit-mode))

--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -111,4 +111,4 @@
     :mode "\\.wl\\'"))
 
 (defun major-modes/post-init-evil-matchit ()
-  (add-hook `matlab-mode-hook `turn-on-evil-matchit-mode))
+  (add-hook 'matlab-mode-hook 'turn-on-evil-matchit-mode))


### PR DESCRIPTION
If `evil-matchit` is available, configure it for use in `matlab-mode`.

Note: A [PR was recently accepted](https://github.com/redguardtoo/evil-matchit/pull/134) for `evil-matchit` to add support for `matlab-mode`