### PR TITLE
[org-roam] Add "r" key to refresh org-roam links list buffer

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -1130,4 +1130,7 @@ Key binding prefixes:
 | ~SPC m r t r~ | Remove a tag from file            |
 
 *org-roam buffer*
-| ~o~ | Follow link |
+| Key binding | Description             |
+|-------------+-------------------------|
+| ~o~         | Follow link             |
+| ~r~         | Refresh org-roam buffer |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -970,7 +970,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
       (evilified-state-evilify-map org-roam-mode-map
         :mode org-roam-mode
         :bindings
-        "o" 'link-hint-open-link))))
+        "o" 'link-hint-open-link
+        "r" 'org-roam-buffer-refresh))))
 
 (defun org/init-org-sticky-header ()
   (use-package org-sticky-header


### PR DESCRIPTION
This matches the org-agenda key, and is doubly important since we need to
refresh regularly to workaround the page-break-lines bug, as described here
https://github.com/syl20bnr/spacemacs/issues/14969#issuecomment-894624932