### PR TITLE
[org-roam] Fix evil org-roam-node-insert spacing

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -971,7 +971,21 @@ Headline^^            Visit entry^^               Filter^^                    Da
         :mode org-roam-mode
         :bindings
         "o" 'link-hint-open-link
-        "r" 'org-roam-buffer-refresh))))
+        "r" 'org-roam-buffer-refresh))
+
+      ; Workaround an upstream issue with evil, as described in https://github.com/syl20bnr/spacemacs/issues/14137
+      (defadvice org-roam-node-insert (around append-if-in-evil-normal-mode activate compile)
+        "If in evil normal mode and cursor is on a whitespace character, then go into
+         append mode first before inserting the link. This is to put the link after the
+         space rather than before."
+        (let ((is-in-evil-normal-mode (and (bound-and-true-p evil-mode)
+                                          (not (bound-and-true-p evil-insert-state-minor-mode))
+                                          (looking-at "[[:blank:]]"))))
+          (if (not is-in-evil-normal-mode)
+              ad-do-it
+            (evil-append 0)
+            ad-do-it
+            (evil-normal-state))))))
 
 (defun org/init-org-sticky-header ()
   (use-package org-sticky-header


### PR DESCRIPTION
When we're adding links, without this they get smooshed together under the
curser. Tested to work; resolves https://github.com/syl20bnr/spacemacs/issues/14137