### PR TITLE
ocaml: Allow new OPAM command-line syntax

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2862,6 +2862,7 @@ files (thanks to Daniel Nicolai)
 - Fixed flycheck-ocaml not initialized warning (thanks to Artur Juraszek)
 - Added =dune= support via =dune-mode= (thanks to Lyman Gillispie)
 - Fixed ocamlformat not properly initialized by following do (thanks to Nicolas Raymond)
+- Allow new OPAM share commandline syntax (thanks to Cody McKenzie)
 **** Org
 - Provide some sane default strategies for enforcing =TODO= dependencies via
   =org-todo-dependencies-strategy=. (thanks to Keith Pinson)

--- a/layers/+lang/ocaml/funcs.el
+++ b/layers/+lang/ocaml/funcs.el
@@ -23,26 +23,31 @@
 
 (defun spacemacs//init-ocaml-opam ()
   (if (executable-find "opam")
-      (let ((share (string-trim-right
-                    (with-output-to-string
-                      (with-current-buffer
-                          standard-output
-                        (process-file
-                         shell-file-name nil '(t nil) nil shell-command-switch
-                         "opam config var share"))))))
-        (cond ((string= "" share)
-               (spacemacs-buffer/warning
-                "\"opam config var share\" output empty string."))
-              ((not (file-directory-p share))
-               (spacemacs-buffer/warning
-                "opam share directory does not exist."))
-              (t (setq opam-share share
-                       opam-load-path (concat share "/emacs/site-lisp"))
-                 (add-to-list 'load-path opam-load-path))))
+        (let* ((share-dir-from-command (lambda (command)
+                (string-trim-right
+                 (with-output-to-string
+                   (with-current-buffer standard-output
+                                        (process-file shell-file-name nil
+                                        '(t nil)
+                                        nil
+                                        shell-command-switch
+                                        command))))))
+               (share-new (funcall share-dir-from-command "opam var share"))
+               (share (if (string= "" share-new)
+                          (funcall share-dir-from-command "opam config var share")
+                          share-new)))
+          (cond
+           ((string= "" share)
+            (spacemacs-buffer/warning "\"opam config var share\" and \"opam var share\" both output empty string."))
+           ((not (file-directory-p share))
+            (spacemacs-buffer/warning "opam share directory does not exist."))
+           (t (setq opam-share share
+                    opam-load-path
+                    (concat share "/emacs/site-lisp"))
+              (add-to-list 'load-path opam-load-path))))
     (unless (executable-find "ocamlmerlin")
-      (spacemacs-buffer/warning
-       (concat "Cannot find \"opam\" or \"merlin\" executable. "
-               "The ocaml layer won't work properly.")))))
+      (spacemacs-buffer/warning (concat "Cannot find \"opam\" or \"merlin\" executable. "
+                                        "The ocaml layer won't work properly.")))))
 
 (defun spacemacs/merlin-locate ()
   (interactive)


### PR DESCRIPTION
As of OPAM v2.1, `opam config var share` is no longer supported. Instead, the syntax is `opam var share`. To allow both, this checks first with the new syntax, then if that doesn't work, the old is tried. If neither produce any output, it fails as normal.
This should resolve syl20bnr/spacemacs#14392 .

P.S. I'm pretty new to Elisp so criticism, constructive or otherwise is appreciated!  
