### PR TITLE
Fix typo that prevents ivy-rich from being enabled

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -37,8 +37,8 @@
         ivy-hydra
         (ivy-rich :toggle (progn
                             (when ivy-enable-icons
-                              (setq ivy-enable-advanced-buffer-information t)
-                              ivy-enable-advanced-buffer-information)))
+                              (setq ivy-enable-advanced-buffer-information t))
+                            ivy-enable-advanced-buffer-information))
         (ivy-spacemacs-help :location local)
         ivy-xref
         org


### PR DESCRIPTION
Fixes a misplaced paren that prevented ivy-rich from being enabled when ```ivy-enable-advanced-buffer-information``` was set but ```ivy-enable-icons``` wasn't.