### PR TITLE
lsp: add call hierarchy binding

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -195,6 +195,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
     to follow the keybindings convention (thanks to Magnus Therning)
   - Use ~lsp-ivy~ when ~ivy~ layer is present.
   - added  ~lsp-use-lsp-ui~ variable to control whether ~lsp-ui~ is installed or not.
+  - added ~SPC m g h~ to go to call hierarchy.
 ***** IPython notebook
 - Key bindings;
   - Change prefix from ~SPC a i~ to ~SPC a y~ (thanks to Swaroop C H)

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -183,13 +183,6 @@ The key bindings are grouped under the following prefixes:
 | ~SPC m T l~ | lsp           | Toggle LSP backend features (documentation / symbol info overlays etc.)    |
 | ~SPC m x~   | text (source) | Text (source) document related bindings                                    |
 
-Some navigation key bindings (i.e. ~SPC m g~ / ~SPC m G~) use an additional level of grouping:
-
-| prefix          | name             | functional area                                           |
-|-----------------+------------------+-----------------------------------------------------------|
-| ~SPC m <g/G> h~ | hierarchy        | Hierarchy (i.e. call/inheritance hierarchy etc. )         |
-| ~SPC m <g/G> m~ | member hierarchy | Class/namespace members (functions, nested classes, vars) |
-
 ** Core key bindings
 The lsp minor mode bindings are:
 

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -210,6 +210,7 @@ The lsp minor mode bindings are:
 | ~SPC m g K~   | goto viewport symbol (=avy=) (See Note 1)                                        |
 | ~SPC m g e~   | browse flycheck errors (=lsp-treemacs=)                                          |
 | ~SPC m g M~   | browse file symbols (=lsp-ui-imenu=)                                             |
+| ~SPC m g h~   | goto call hierachy (=lsp-mode=)                                                  |
 |---------------+----------------------------------------------------------------------------------|
 | Note          | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ is ~'peek~ /      |
 | ~SPC m g i~   | find implementations (=lsp-mode=)                                                |

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -93,6 +93,7 @@
     "gk" #'spacemacs/lsp-avy-goto-word
     "gK" #'spacemacs/lsp-avy-goto-symbol
     "gM" #'lsp-ui-imenu
+    "gh" #'lsp-treemacs-call-hierarchy
     ;; help
     "h" "help"
     "hh" #'lsp-describe-thing-at-point

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -125,10 +125,9 @@
     "xh" #'lsp-document-highlight
     "xl" #'lsp-lens-show
     "xL" #'lsp-lens-hide)
-  (when (configuration-layer/package-used-p 'treemacs)
+  (when (configuration-layer/package-used-p 'lsp-treemacs)
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
-      "gh" #'lsp-treemacs-call-hierarchy))
-  )
+      "gh" #'lsp-treemacs-call-hierarchy)))
 
 (defun spacemacs//lsp-bind-simple-navigation-functions (prefix-char)
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -93,7 +93,6 @@
     "gk" #'spacemacs/lsp-avy-goto-word
     "gK" #'spacemacs/lsp-avy-goto-symbol
     "gM" #'lsp-ui-imenu
-    "gh" #'lsp-treemacs-call-hierarchy
     ;; help
     "h" "help"
     "hh" #'lsp-describe-thing-at-point
@@ -125,7 +124,11 @@
     "x" "text/code"
     "xh" #'lsp-document-highlight
     "xl" #'lsp-lens-show
-    "xL" #'lsp-lens-hide))
+    "xL" #'lsp-lens-hide)
+  (when (configuration-layer/package-used-p 'treemacs)
+    (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
+      "gh" #'lsp-treemacs-call-hierarchy))
+  )
 
 (defun spacemacs//lsp-bind-simple-navigation-functions (prefix-char)
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode


### PR DESCRIPTION
This has been in `lsp-mode` for ages, we just need to expose the keybinding.

I also removed a misleading readme segment that seemed to imply there was a group of bindings relating to call/method hierarchies, which there isn't.
