### PR TITLE
Add outline minor mode bindings to navigation layer

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/README.org
+++ b/layers/+spacemacs/spacemacs-navigation/README.org
@@ -25,6 +25,15 @@ This layer adds general navigation functions to all supported layers.
 
 * Key bindings
 
-| Key binding | Description    |
-|-------------+----------------|
-| ~SPC h j~   | jump to manual |
+| Key binding | Description               |
+|-------------+---------------------------|
+| ~SPC h j~   | jump to manual            |
+| ~SPC t o~   | toggle outline-minor-mode |
+
+*Outline minor mode*
+| ~SPC m o o~   | outline cycle buffer             |
+| ~SPC m o TAB~ | outline cycle (heading)          |
+| ~SPC m o j~   | outline next visible heading     |
+| ~SPC m o k~   | outline previous visible heading |
+| ~SPC m o J~   | outline next heading             |
+| ~SPC m o K~   | outline previous heading         |

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -33,6 +33,7 @@
         (grep :location built-in)
         (info+ :location (recipe :fetcher wiki))
         open-junk-file
+        (outline :location built-in)
         paradox
         restart-emacs
         (smooth-scrolling :location built-in)
@@ -340,6 +341,21 @@
       ;; Since this is not really useful to add hooks to open-junk-files lets remove
       ;; it
       (remove-hook 'find-file-hook 'find-file-hook--open-junk-file))))
+
+(defun spacemacs-navigation/init-outline ()
+  (use-package outline
+    :defer t
+    :init
+    (spacemacs/set-leader-keys
+      "to" 'outline-minor-mode)
+    :config
+    (spacemacs/set-leader-keys-for-minor-mode 'outline-minor-mode
+      "oo"      'outline-cycle-buffer
+      "o <tab>" 'outline-cycle
+      "oj"      'outline-next-visible-heading
+      "ok"      'outline-previous-visible-heading
+      "oJ"      'outline-next-heading
+      "oK"      'outline-previous-heading)))
 
 (defun spacemacs-navigation/init-paradox ()
   (use-package paradox


### PR DESCRIPTION
Outline-minor-mode works better than `hide-show-minor-mode` in some (or maybe
all) cases. E.g. compare in `transient.el` `hs-hide-all` vs
`outline-cycle-buffer`.

Outline mode is useful (and should be used by default) for structuring large
single file elisp packages (which because of its simplicity is often preferable over
splitting the package into multiple files), but it can be used in any other mode
too. For an example, see `transient.el`.

It seems that the bindings don't conflict with any other mode (I have ripgrep
searched through the `layers` dir). So I guess `outline-minor-mode` might as well
be activated by default.