### PR TITLE
latex layer add auto configure pdf-tools and open in split window

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2647,6 +2647,8 @@ files (thanks to Daniel Nicolai)
   to Lucius Hu)
 - Added layer variable =latex-refresh-preview= to refresh the preview buffer when
   compiled PDF is changed (thanks to Lucius Hu)
+- Automatically configure =pdf-tools= as pdf viewer for =TeX-view= command (by default) (Thanks to Daniel Nicolai)
+- Add layer variable to open =pdf-tools= in split window (Thanks to Daniel Nicolai)
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 - Added support for =LSP= (EmmyLua-LS-all, lua-language-server, lua-lsp) (thanks to Lin.Sun)

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -14,6 +14,7 @@
   - [[#choosing-a-backend][Choosing a backend]]
     - [[#lsp][LSP]]
     - [[#company-auctex][Company-auctex]]
+  - [[#pdf-viewer][PDF viewer]]
   - [[#previewing][Previewing]]
   - [[#build-command][Build command]]
   - [[#tex-engine][TeX Engine]]
@@ -45,26 +46,31 @@ file.
 
 * Configuration
 Most layer configurations can be done by setting layer variables in your
-dotfile. Some however require adding lines to your user-config.
+dotfile. Some however require adding lines to your user-config. If the =pdf=
+layer is used, then the layer automatically configures =pdf-tools= as the
+'output-pdf' viewer, see [[PDF viewer]].
 
 ** Variables
 A number of configuration variables have been exposed via the layer =config.el=.
 Sensible defaults have been provided, however they may all be overridden in your
 .spacemacs.
 
-| Variable Name            | Default                                                            | Description                                                                |
-|--------------------------+--------------------------------------------------------------------+----------------------------------------------------------------------------|
-| ~latex-backend~          | ~nil~                                                              | Use LSP backend, unless it's `company-auctex` or =LSP= layer isn't enabled |
-| ~latex-build-command~    | ~'latexmk~ if it's found                                           | Default command to use with ~SPC m b~                                      |
-| ~latex-build-engine~     | ~'xetex~ if it's found and =chinese= / =japanese= layer is enabled | Default TeX engine to use with ~SPC m b~                                   |
-| ~latex-enable-auto-fill~ | ~t~                                                                | When non-nil, enable ~auto-fill-mode~                                      |
-| ~latex-enable-folding~   | ~nil~                                                              | When non-nil, enable ~TeX-fold-mode~                                       |
-| ~latex-enable-magic~     | ~nil~                                                              | When non-nil, enable magic symbols                                         |
-| ~latex-nofill-env~       | See [[#auto-fill][details below]]                                                  | A list of LaTeX environment name where ~auto-fill-mode~ is disabled        |
-| ~latex-refresh-preview~  | ~nil~                                                              | When non-nil, enable refresh preview buffer when file changes              |
+| Variable Name                    | Default                                                            | Description                                                                    |
+|----------------------------------+--------------------------------------------------------------------+--------------------------------------------------------------------------------|
+| ~latex-backend~                  | ~nil~                                                              | Use LSP backend, unless it's `company-auctex` or =LSP= layer isn't enabled     |
+| ~latex-build-command~            | ~'latexmk~ if it's found                                           | Default command to use with ~SPC m b~                                          |
+| ~latex-build-engine~             | ~'xetex~ if it's found and =chinese= / =japanese= layer is enabled | Default TeX engine to use with ~SPC m b~                                       |
+| ~latex-enable-auto-fill~         | ~t~                                                                | When non-nil, enable ~auto-fill-mode~                                          |
+| ~latex-enable-folding~           | ~nil~                                                              | When non-nil, enable ~TeX-fold-mode~                                           |
+| ~latex-enable-magic~             | ~nil~                                                              | When non-nil, enable magic symbols                                             |
+| ~latex-nofill-env~               | See [[#auto-fill][details below]]                                                  | A list of LaTeX environment name where ~auto-fill-mode~ is disabled            |
+| ~latex-refresh-preview~          | ~nil~                                                              | When non-nil, enable refresh preview buffer when file changes                  |
+| ~latex-refresh-preview~          | ~nil~                                                              | When non-nil, enable refresh preview buffer when file changes                  |
+| ~latex-view-with-pdf-tools~      | ~t~ if pdf layer is installed, else ~nil~                          | When non-nil, use =pdf-tools= for viewing output pdf files                     |
+| ~latex-view-pdf-in-split-window~ | ~nil~ setting is neglected if ~latex-view-with-pdf-tools~ is ~nil~ | When non-nil, open =pdf-tools= in split window (when using =TeX-view= command) |
 
 ** Choosing a backend
-This layer provides two alternative backends to choose from.
+   This layer provides two alternative backends to choose from. 
 
 *** LSP
 This is the default backend if =LSP= layer is enabled.
@@ -109,6 +115,15 @@ use =company-auctex= for math symbols completion set the following in your
                 '((latex :packages (not company-math))))
 #+END_SRC
 
+** PDF viewer
+   If the =pdf= layer is used, then the layer automatically configures =pdf-tools=
+   as the 'output-pdf' viewer, see [[PDF viewer]]. To additionally make =pdf-tools=
+   open in a split window, set the layer variable =latex-view-pdf-in-split-window=
+   to =t=.
+
+   If, despite using the pdf layer, you prefer to use another pdf viewer to preview
+   the output pdf's, set the layer variable =latex-view-with-pdf-tools= to =nil=.
+   
 ** Previewing
 =LaTex= layer support full-document previews and inline preview (via ~SPC m p~).
 

--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -31,6 +31,17 @@
 ;; ...but AUCTeX runs LaTeX-mode-hook rather than latex-mode-hook, so:
 (add-to-list 'spacemacs-jump-handlers-latex-mode 'LaTeX-mode-hook)
 
+(defvar latex-view-with-pdf-tools (configuration-layer/layer-used-p 'pdf)
+  "Use pdf-tools for viewing latex output pdf's.
+When the pdf layer is installed, then automatically configure
+Spacemacs to view latex output pdf's with pdf-tools. For using a
+different viewer set this value to `nil' and configure the
+output-pdf viewer in `TeX-view-program-selection'.")
+
+(defvar latex-view-pdf-in-split-window nil
+  "If non-nil then open pdf in split window.
+Requires pdf-tools to be configured as output-pdf viewer.")
+
 (defvar latex-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'company-auctex)
   "The backend to use for IDE features.
 Possible values are `lsp' and `company-auctex'.

--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -56,7 +56,7 @@
     (lsp-deferred)))
 
 (defun spacemacs//latex-setup-pdf-tools ()
-  "Conditionally setup pdf-tools"
+  "Conditionally setup pdf-tools."
   (when latex-view-with-pdf-tools
     (setf (alist-get 'output-pdf TeX-view-program-selection) (list "PDF Tools"))
 

--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -55,6 +55,15 @@
     (require 'lsp-latex)
     (lsp-deferred)))
 
+(defun spacemacs//latex-setup-pdf-tools ()
+  "Conditionally setup pdf-tools"
+  (when latex-view-with-pdf-tools
+    (setf (alist-get 'output-pdf TeX-view-program-selection) (list "PDF Tools"))
+
+    (when latex-view-pdf-in-split-window
+      (require 'pdf-sync)
+      (setq pdf-sync-forward-display-action t))))
+
 (defun latex/build ()
   (interactive)
   (progn

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -75,6 +75,11 @@
     (progn
       ;; otherwise `, p` preview commands doesn't work
       (require 'preview)
+      ;; when `latex-view-with-pdf-tools' is non-nil, configure pdf-tools for
+
+      ;; viewing output pdf's
+      (spacemacs//latex-setup-pdf-tools)
+
       ;; Key bindings for plain TeX
       (dolist (mode '(tex-mode latex-mode context-mode))
         (spacemacs/set-leader-keys-for-major-mode mode
@@ -251,7 +256,9 @@
 
 (defun latex/init-lsp-latex ()
   (use-package lsp-latex
-    :defer t))
+    :defer t
+    :config
+    (spacemacs//latex-setup-pdf-tools)))
 
 (defun latex/init-math-symbol-lists ()
   (use-package math-symbol-lists


### PR DESCRIPTION
Due to some question on Gitter, and some struggle to find the correct answer,
 I propose to add the following sane configuration options to the latex layer
(It is anyway nice to be able to allow for configuring these things with layer variables).

I did not write the documentation because I first "poll" for your opinion. So let me
 know if you think that I should finish this PR.
 
This commit makes the latex layer automatically configure pdf-tools as
latex pdf-viewer if the pdf layer is installed (or use another viewer by setting the
`latex-view-with-pdf-tools` variable to nil). Here I assume that if the pdf layer is
installed, then users would also mostly prefer to use it (otherwise I would anyway
like users to try it).

Additionally, it adds a layer variable for configuring Spacemacs to open pdf-view in a
split-window. (Strangely, finding out how to achieve that is far from trivial,
and also not easy to google, because many hits do not provide the "correct"
answer (see the typical example
[here](https://emacs.stackexchange.com/questions/28056/spacemacs-latex-how-to-make-view-command-tile-vertically-with-emacs-window)).