### PR TITLE
[c-c++]: Fix keybinding for organizing includes

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -127,7 +127,7 @@
       (spacemacs/declare-prefix-for-mode 'c++-mode
         "mr" "refactor")
       (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-        "ri" #'spacemacs/c++-organize-includes))))
+        "ri" #'spacemacs/c-c++-organize-includes))))
 
 (defun c-c++/pre-init-dap-mode ()
   (pcase c-c++-backend


### PR DESCRIPTION
A renaming from `c++-organize-includes` to `c-c++-organize-includes` was done a while ago: https://github.com/syl20bnr/spacemacs/commit/a4eadc97fecaa4f7c5776d24c8ec55379fbc876e

But one keybinding still binds to the old function name. This PR fixes it.