### PR TITLE
Revert "Fix evil search prompt on mouse leave"

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -140,14 +140,6 @@ current major mode."
                (< 0 shift-width))
       (setq-local evil-shift-width shift-width))))
 
-(defun spacemacs//evil-ex-search-start-session ()
-  (add-hook 'mouse-leave-buffer-hook 'spacemacs//evil-ex-search-stop-session))
-
-(defun spacemacs//evil-ex-search-stop-session ()
-  (remove-hook 'mouse-leave-buffer-hook
-               'spacemacs//evil-ex-search-stop-session)
-  (evil-ex-search-abort))
-
 (defmacro spacemacs|define-text-object (key name start end)
   "Define a text object and a surround pair.
 START and END are strings (not regular expressions) that define

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -319,15 +319,7 @@
 
   ;; ignore repeat
   (evil-declare-ignore-repeat 'spacemacs/next-error)
-  (evil-declare-ignore-repeat 'spacemacs/previous-error)
-
-  ;; Fix for issue: Evil search bug breaks Spacemacs #10410
-  ;; https://github.com/syl20bnr/spacemacs/issues/10410
-  ;; This fix can be removed when/if the upstream PR is merged:
-  ;; Exit search prompt on mouse leave minibuffer
-  ;; https://github.com/emacs-evil/evil/pull/1330
-  (advice-add 'evil-ex-search-start-session
-              :after 'spacemacs//evil-ex-search-start-session))
+  (evil-declare-ignore-repeat 'spacemacs/previous-error))
 
 (defun spacemacs-bootstrap/init-hydra ()
   (require 'hydra)


### PR DESCRIPTION
Reverts syl20bnr/spacemacs#15002

reverting since it's fixed upstream https://github.com/emacs-evil/evil/pull/1330