### PR TITLE
Make golden-ratio global mode and ediff mode coexist harmoniously

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1167,6 +1167,7 @@ Other:
     (thanks to Tristan Harmer)
   - Added ~s~ =hydra-dired-quick-sort/body= (thanks to duianto)
 - Improvements:
+  - Inhibited golden-ratio mode from interfering with ediff windows
   - Rewrote window layout functions for ~SPC w 1~, ~SPC w 2~, ~SPC w 3~, and
     ~SPC w 4~ (thanks to Codruț Constantin Gușoi):
     - Added =spacemacs-window-split-delete-function= variable, which can be used

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -80,6 +80,12 @@ Cancels autosave on exiting perspectives mode."
     (and (boundp 'ediff-this-buffer-ediff-sessions)
          ediff-this-buffer-ediff-sessions)))
 
+(defun spacemacs/ediff-balance-windows ()
+  "Balance the width of ediff windows."
+  (interactive)
+  (ediff-toggle-split)
+  (ediff-toggle-split))
+
 (defun spacemacs/jump-to-last-layout ()
   "Open the previously selected layout, if it exists."
   (interactive)

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -74,6 +74,12 @@ Cancels autosave on exiting perspectives mode."
   "Return non-nil if current layout doesn't contain BUFFER."
   (not (persp-contain-buffer-p buffer)))
 
+(defun spacemacs//ediff-in-comparison-buffer-p (&optional buffer)
+  "Return non-nil if BUFFER is part of an ediff comparison."
+  (with-current-buffer (or buffer (current-buffer))
+    (and (boundp 'ediff-this-buffer-ediff-sessions)
+         ediff-this-buffer-ediff-sessions)))
+
 (defun spacemacs/jump-to-last-layout ()
   "Open the previously selected layout, if it exists."
   (interactive)

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -307,8 +307,12 @@
                    " *which-key*"))
         (add-to-list 'golden-ratio-exclude-buffer-names n))
 
-      (add-to-list 'golden-ratio-inhibit-functions
-                   'spacemacs/no-golden-ratio-guide-key)
+      ;; golden-ratio-inhibit-functions
+      (dolist (f '(spacemacs/no-golden-ratio-guide-key
+                   spacemacs//ediff-in-comparison-buffer-p))
+        (add-to-list 'golden-ratio-inhibit-functions f))
+
+      (add-hook 'ediff-startup-hook 'spacemacs/ediff-balance-windows)
 
       (spacemacs|diminish golden-ratio-mode " ⓖ" " g"))))
 


### PR DESCRIPTION
## Context

Currently, when global `golden-ratio-mode` is active and you enter ediff mode, you'll end up with an unnecessarily huge ediff control buffer and comparison buffers that constantly vary in width as you switch between them.

The correct behavior would be a tiny ediff control buffer (like a single line in height) and comparison buffers that stay fixed in size so you can read them all simultaneously while reading your diffs.

Spacemacs current configuration inhibits golden-ratio mode on the control buffer, correctly preventing it from taking up the majority of the screen space when it's focused. But when a comparison buffer is focused, golden-ratio mode makes the control buffer much larger than it needs to be and gives much greater screen share to one side of the comparison over the other(s).

#### Workaround

You can already work around this by disabling global golden-ratio mode before starting ediff, but I often have multiple Emacs frames open to flip between them and I'd rather not have to disable the auto golden-ratio resizing behavior in buffers that are not part of the ediff window view.

## In this PR

This PR introduces two new functions and a couple configuration changes to make ediff and golden-ratio mode get along harmoniously.

* `spacemacs//ediff-in-comparison-buffer-p` returns non-nil when the current buffer is an ediff comparison buffer, nil otherwise. This function is added to `golden-ratio-inhibit-functions` to inhibit golden-ratio auto resizing in any buffer that's part of the ediff workflow.
* `spacemacs/ediff-balance-windows` reinstates ediff's default visual balance between the windows, and it's added as a hook upon ediff-startup to avoid having the initial window sizes clobbered by global golden-ratio mode.

## Acknowledgements

The golden-ratio-mode wiki provided the [inspiration for these changes.](https://github.com/roman/golden-ratio.el/wiki).