### PR TITLE
c-c++: Package cpp-auto-include can be fetched from Melpa

### DIFF
--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -27,9 +27,7 @@
     clang-format
     company
     (company-c-headers :requires company)
-    (cpp-auto-include
-     :location (recipe :fetcher github
-                       :repo "syohex/emacs-cpp-auto-include"))
+    cpp-auto-include
     disaster
     eldoc
     flycheck


### PR DESCRIPTION
The package `cpp-auto-include` is now [in Melpa](https://melpa.org/#/cpp-auto-include) so it doesn't need to be fetched from GitHub (and the github repo it points to redirects now anyway).
