### PR TITLE
Implement inspector package to emacs-lisp layer see #15039

### DIFF
--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -11,6 +11,7 @@
 - [[#auto-compile][Auto-compile]]
 - [[#working-with-lisp-files-barfage-slurpage--more][Working with lisp files (barfage, slurpage & more)]]
 - [[#debugging-elisp][Debugging Elisp]]
+  - [[#using-the-inspector][Using the inspector]]
 - [[#nameless][Nameless]]
   - [[#aliases][Aliases]]
 - [[#structurally-safe-editing][Structurally safe editing]]
@@ -20,6 +21,7 @@
   - [[#format-code][Format code]]
   - [[#debugging][Debugging]]
   - [[#refactoring-with-emr][Refactoring with emr]]
+  - [[#inspector][Inspector]]
 
 * Description
 This layer gathers all the configuration related to emacs-lisp. This should
@@ -107,6 +109,10 @@ displayed in the mode line.
 
 function or press ~o~ to go out of it.
 6) Press ~a~ to stop debugging.
+
+** Using the inspector
+   This layer adds the [[https://github.com/mmontone/emacs-inspector][inspector]] package to provide an easy way for inspecting
+   data structures. Find more information about its usage [[https://github.com/mmontone/emacs-inspector][here]] and see keybindings [ 
 
 * Nameless
 Nameless hides package namespaces in your emacs-lisp code, and replaces it by
@@ -306,3 +312,15 @@ line)
 | ~SPC m r d l~ | delete let binding form   |
 | ~SPC m r d d~ | delete unused definition  |
 | ~SPC m e w~   | eval and replace          |
+
+** Inspector
+
+*inspector buffer*
+| Key binding | Description                 |
+|-------------+-----------------------------|
+| ~RET~       | inspect object              |
+| ~L~         | navigate to previous object |
+| ~q~         | quit inspector              |
+
+*backtrace buffer*
+| ~i~ | inspect object |

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -40,6 +40,9 @@
     counsel-gtags
     helm-gtags
     (ielm :location built-in)
+    (inspector :location (recipe
+                          :fetcher github
+                          :repo "mmontone/emacs-inspector"))
     macrostep
     nameless
     overseer
@@ -371,3 +374,10 @@
       "rdd" #'emr-el-delete-unused-definition
 
       "ew"  #'emr-el-eval-and-replace)))
+
+(defun emacs-lisp/init-inspector ()
+  (use-package inspector
+    :commands (inspect-expression inspect-last-sexp)
+    :config
+    (evilified-state-evilify-map inspector-mode-map
+      :mode inspector-mode)))


### PR DESCRIPTION
This is a PR in response to #15039.

I have just implemented it isnthe most straightforward way. We might want to remap the `inspector-pop` from `L` to a more mnemonic/consistent (with other inspectors) key.