### PR TITLE
Fix autocompletion in elisp and text mode

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -114,6 +114,7 @@
     (progn
       (spacemacs|diminish company-mode " ⓐ" " a")
 
+      (spacemacs|add-company-backends :modes text-mode)
       ;; key bindings
       (defun spacemacs//company-complete-common-or-cycle-backward ()
         "Complete common prefix or cycle backward."

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -80,7 +80,7 @@
           (lisp-indent-line))))))
 
 (defun emacs-lisp/post-init-company ()
-  (spacemacs|add-company-backends :backends company-capf
+  (spacemacs|add-company-backends :backends (company-capf company-dabbrev-code)
                                   :modes emacs-lisp-mode)
   (spacemacs|add-company-backends :backends (company-files company-capf)
                                   :modes ielm-mode))


### PR DESCRIPTION
Currently, in `emacs-lisp-mode`, most or all auto-completion, using completion-at-point (i.e. the TAB
key), is 'hijacked' by company-capf in emacs-lisp-mode, while in text mode there
is no auto-completion by default at all.

EXAMPLE: In emacs-lisp-mode try typing:
```
(defun test-function ()
  (print "hello"))

(test-fun)
```
and try to auto complete using TAB, no suggestions are given. You can use `M-x company-diag` to find out which backend is used.

or in `text-mode` try to type 
```
foobar
foob
```
and try to complete using TAB (it will insert a TAB instead of suggesting completions)

This commit adds auto-completion for text-mode and slightly improves the
situation for emacs-lisp mode (by grouping `company-capf` with `company-dabbrev(-code)`).

When my question at https://github.com/company-mode/company-mode/discussions/1186#discussioncomment-1322465 gets answered, then I will update the configuration here accordingly.
