### PR TITLE
Fix (activate) company-emoji completion

### DIFF
--- a/layers/+fun/emoji/README.org
+++ b/layers/+fun/emoji/README.org
@@ -8,6 +8,8 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+  - [[#configuration][Configuration]]
+    - [[#unicode-or-short-names][Unicode or short-names]]
 - [[#key-bindings][Key bindings]]
   - [[#emoji-dedicated-buffer][Emoji dedicated buffer]]
 
@@ -30,6 +32,17 @@ Linux user could install [[https://zhm.github.io/symbola/][Symbola]] font to get
 #+BEGIN_SRC shell
   apt-get install ttf-ancient-fonts
 #+END_SRC
+
+** Configuration
+*** Unicode or short-names
+By default, company-emoji is configured only for =text-mode= and inserts
+unicode. To insert short-names set =company-emoji-insert-unicode= to =nil= as
+follows:
+#+BEGIN_SRC emacs-lisp
+  (auto-completion :variables
+                   company-emoji-insert-unicode nil)
+#+END_SRC
+
 
 * Key bindings
 

--- a/layers/+fun/emoji/funcs.el
+++ b/layers/+fun/emoji/funcs.el
@@ -48,3 +48,9 @@ properly."
   ;; If we directly call the emoji mode at hook runtime then some
   ;; text properties are not applied correctly.
   (run-at-time 0.1 nil 'emoji-cheat-sheet-plus-display-mode))
+
+(defun spacemacs/emoji-insert-and-possibly-complete (_)
+  "Use company-emoji to complete 'to' unicode."
+  (when company-emoji-insert-unicode
+    (delete-char -1)
+    (company-complete)))

--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -58,4 +58,8 @@
       (spacemacs//set-emoji-font nil)
       ;; Hook for when a frame is created with emacsclient
       (spacemacs|do-after-display-system-init
-       (spacemacs//set-emoji-font-for-current-frame)))))
+       (spacemacs//set-emoji-font-for-current-frame))
+      (spacemacs|add-company-backends :backends company-emoji
+                                      :modes text-mode))
+    :config
+    (advice-add 'emoji-cheat-sheet-plus--insert-selection :after #'spacemacs/emoji-insert-and-possibly-complete)))


### PR DESCRIPTION
Currently company-emoji does not get activated by the emoji layer.
Also when it is activated, then the emoji short-name does not get completed to
unicode if `company-emoji-insert-unicode` is `t`.

This PR fixes both issues, by activating company-emoji for text-mode and
advising the emoji insert function to optionally do company-emoji completion
(try e.g. in magit-commit buffers).