### PR TITLE
Add simple workaround to ebib kill buffer issue

### DIFF
--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -131,7 +131,10 @@
 
       "gj" 'ebib-jump-to-entry
       "/" 'ebib-search
-      "n" 'ebib-search-next)
+      "n" 'ebib-search-next
+      ;; the following binding is a simple workaround for
+      ;; https://github.com/joostkremers/ebib/issues/213
+      [remap spacemacs/kill-this-buffer] 'ebib-quit)
 
     (spacemacs/set-leader-keys-for-major-mode 'ebib-index-mode
       "j" 'ebib-jump-to-entry


### PR DESCRIPTION
See https://github.com/joostkremers/ebib/issues/213

By remapping `spacemacs/kill-buffer` to `ebib-quit` ebib is generally exited 'correctly' (if users really want to kill the buffer and mess up things, they can still do that in plenty of other ways).