### PR TITLE
[version-control] Switch default version control diff tool to git-gutter

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3545,6 +3545,7 @@ files (thanks to Daniel Nicolai)
 - Defer git-gutter loading (thanks to Aaron Jensen)
 - Remove redundant arg from git-gutter timer (thanks to bmag)
 - Added Git Blame Transient State (thanks to duianto)
+- Switch default version diff tool to git-gutter (thanks to Lin Sun)
 **** Spacemacs-defaults
 - Updated spacemacs/save-as function, see github #8974 and #14754 (thanks to
   Daniel Nicolai and Lebensterben)

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -38,8 +38,8 @@ You can choose the package to facilitate the diff transient-state and show
 margins by setting the =version-control-diff-tool= variable to one of the
 supported packages:
 - [[https://github.com/dgutov/diff-hl][diff-hl]]
-- [[https://github.com/syohex/emacs-git-gutter][git-gutter]]
-- [[https://github.com/nonsequitur/git-gutter-plus][git-gutter+]] (default)
+- [[https://github.com/syohex/emacs-git-gutter][git-gutter]] (default)
+- [[https://github.com/nonsequitur/git-gutter-plus][git-gutter+]]
 
 #+BEGIN_SRC emacs-lisp
   '(version-control :variables

--- a/layers/+source-control/version-control/config.el
+++ b/layers/+source-control/version-control/config.el
@@ -27,7 +27,7 @@
 (defvar version-control-global-margin t
   "If non-nil, will show diff margins globally.")
 
-(defvar version-control-diff-tool 'git-gutter+
+(defvar version-control-diff-tool 'git-gutter
   "Options are `git-gutter', `git-gutter+', and `diff-hl' to show
 version-control markers.")
 


### PR DESCRIPTION
The default version control diff tool https://github.com/nonsequitur/git-gutter-plus and https://github.com/nonsequitur/git-gutter-fringe-plus are out of maintained for 6+ years, and has bugs for tramp (eg: https://github.com/nonsequitur/git-gutter-plus/pull/43 ).

Switch default VC diff tool to https://github.com/emacsorphanage/git-gutter for which is well maintained.