### PR TITLE
[core] fix errors for packing elisp to *.elc and *.el.gz files

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -669,6 +669,7 @@ Other:
   - Add toggles for persistent which-key keymaps, (full)-major/minor mode
     keymaps and top-level keymap, under prefix ~SPC t k~ (thanks to Daniel Nicolai)
   - Add =describe-ex-command= on ~SPC h d x~ (thanks to Daniel Nicolai)
+  - Support packing elisp to *.elc and *.el.gz (thanks to Lin Sun)
 - Fixes:
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -1044,7 +1044,9 @@
         (layer-packages '(pkg1 pkg2 pkg3))
         (mocker-mock-default-record-cls 'mocker-stub-record))
     (mocker-let
-     ((file-exists-p (f) ((:output t :occur 2)))
+     ((locate-file
+       (filename path &optional suffixes predicate)
+       ((:record-cls 'mocker-stub-record :output "packages.el" :occur 1)))
       (load (f &optional noerr nomsg) ((:output nil :occur 1))))
      (should (equal (cfgl-layer "layer"
                                 :name 'layer
@@ -1063,7 +1065,8 @@
         (configuration-layer--load-packages-files t)
         (mocker-mock-default-record-cls 'mocker-stub-record))
     (mocker-let
-     ((file-exists-p (f) ((:output t :occur 2)))
+     ((locate-file (filename path &optional suffixes predicate)
+                   ((:record-cls 'mocker-stub-record :output t)))
       (load (f &optional noerr nomsg) ((:output nil :occur 1))))
      (should (equal (cfgl-layer "layer"
                                 :name 'layer
@@ -1096,7 +1099,8 @@
         (layer-packages '(pkg1 pkg2 pkg3))
         (mocker-mock-default-record-cls 'mocker-stub-record))
     (mocker-let
-     ((file-exists-p (f) ((:output t :occur 2)))
+     ((locate-file (filename path &optional suffixes predicate)
+                   ((:record-cls 'mocker-stub-record :output t :occur 1)))
       (load (f &optional noerr nomsg) ((:output nil :occur 1))))
      (should (equal (cfgl-layer "layer"
                                 :name 'layer
@@ -1139,7 +1143,9 @@
         (layer-packages '(pkg1 pkg2 pkg3))
         (mocker-mock-default-record-cls 'mocker-stub-record))
     (mocker-let
-     ((file-exists-p (f) ((:output t :occur 2)))
+     ((locate-file
+       (filename path &optional suffixes predicate)
+       ((:record-cls 'mocker-stub-record :output t :occur 1)))
       (load (f &optional noerr nomsg) ((:output nil :occur 1))))
      (should (equal (cfgl-layer "layer"
                                 :name 'layer
@@ -2874,9 +2880,8 @@
     (mocker-let
      ((file-directory-p (f)
                         ((:record-cls 'mocker-stub-record :output t :occur 1)))
-      (directory-files
-       (directory &optional full match nosort)
-       ((:record-cls 'mocker-stub-record :output nil :occur 1))))
+      (locate-file (filename path &optional suffixes predicate)
+                   ((:record-cls 'mocker-stub-record :output nil :max-occur 5))))
      (should (null (configuration-layer//directory-type input))))))
 
 (ert-deftest test-directory-type--input-is-directory-and-not-a-layer ()
@@ -2884,11 +2889,8 @@
     (mocker-let
      ((file-directory-p (f)
                         ((:record-cls 'mocker-stub-record :output t :occur 1)))
-      (directory-files
-       (directory &optional full match nosort)
-       ((:record-cls 'mocker-stub-record
-                     :output '("toto.el" "tata.el")
-                     :occur 1))))
+      (locate-file (filename path &optional suffixes predicate)
+                   ((:record-cls 'mocker-stub-record :output nil :max-occur 5))))
      (should (null (configuration-layer//directory-type input))))))
 
 (ert-deftest test-directory-type--layer-with-packages.el ()
@@ -2896,9 +2898,11 @@
     (mocker-let
      ((file-directory-p (f)
                         ((:record-cls 'mocker-stub-record :output t :occur 1)))
-      (directory-files
-       (directory &optional full match nosort)
-       ((:record-cls 'mocker-stub-record :output '("packages.el") :occur 1))))
+      (locate-file
+       (filename path &optional suffixes predicate)
+       ((:record-cls 'mocker-stub-record
+                     :output (expand-file-name "packages.el" input)
+                     :occur 1))))
      (should (eq 'layer (configuration-layer//directory-type input))))))
 
 (ert-deftest test-directory-type--layer-with-config.el ()
@@ -2906,9 +2910,11 @@
     (mocker-let
      ((file-directory-p (f)
                         ((:record-cls 'mocker-stub-record :output t :occur 1)))
-      (directory-files
-       (directory &optional full match nosort)
-       ((:record-cls 'mocker-stub-record :output '("config.el") :occur 1))))
+      (locate-file
+       (filename path &optional suffixes predicate)
+       ((:record-cls 'mocker-stub-record
+                     :output (expand-file-name "config.el" input)
+                     :occur 1))))
      (should (eq 'layer (configuration-layer//directory-type input))))))
 
 (ert-deftest test-directory-type--layer-with-keybindings.el ()
@@ -2916,10 +2922,10 @@
     (mocker-let
      ((file-directory-p (f)
                         ((:record-cls 'mocker-stub-record :output t :occur 1)))
-      (directory-files
-       (directory &optional full match nosort)
+      (locate-file
+       (filename path &optional suffixes predicate)
        ((:record-cls 'mocker-stub-record
-                     :output '("keybindings.el")
+                     :output (expand-file-name "keybindings.el" input)
                      :occur 1))))
      (should (eq 'layer (configuration-layer//directory-type input))))))
 
@@ -2928,9 +2934,11 @@
     (mocker-let
      ((file-directory-p (f)
                         ((:record-cls 'mocker-stub-record :output t :occur 1)))
-      (directory-files
-       (directory &optional full match nosort)
-       ((:record-cls 'mocker-stub-record :output '("funcs.el") :occur 1))))
+      (locate-file
+       (filename path &optional suffixes predicate)
+       ((:record-cls 'mocker-stub-record
+                     :output (expand-file-name "funcs.el" input)
+                     :occur 1))))
      (should (eq 'layer (configuration-layer//directory-type input))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

This PR is try to fix the errors when `*.el` file is compiled to `*.elc` and compressed to `*.el.gz` for distributing Spacemacs (like vallina Emacs, with `*.elc` and `*.el.gz`).

You can byte-compile the `layers/+distributions/spacemacs-base/` folder to get the `*.elc` files and compress the `*.el` to `*.el.gz`, then restarting Spacemacs to get issues.