### PR TITLE
Add pydoc to python layer for better python doc functionality

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -556,6 +556,8 @@ Live coding is provided by the [[https://github.com/donkirkby/live-py-plugin][li
 | ~SPC m g u~              | navigate between usages with =anaconda-mode-find-references=                      |
 | ~SPC m h d~              | look for documentation using =helm-pydoc=                                         |
 | ~SPC m h h~              | quick documentation using anaconda                                                |
+| ~SPC m h p~              | quick documentation using pydoc (no-jedi, as =pydoc-at-point= seems broken)       |
+| ~SPC m h P~              | quick documentation using pydoc                                                   |
 | ~SPC m h H~              | open documentation in =firefox= using [[https://github.com/tsgates/pylookup][pylookup]]                                    |
 | ~SPC m S d~              | insert doc-string skeleton using [[https://github.com/naiquevin/sphinx-doc.el][sphinx-doc]]                                       |
 | ~SPC m v a~              | activate a virtual environment in any directory                                   |

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -26,6 +26,8 @@
     blacken
     company
     counsel-gtags
+    ;; package is broken, use simply pydoc instead
+    ;; (counsel-pydoc :requires counsel) 
     cython-mode
     dap-mode
     eldoc
@@ -44,6 +46,7 @@
     poetry
     pippel
     py-isort
+    pydoc
     pyenv-mode
     (pylookup :location local)
     pytest
@@ -155,6 +158,12 @@
 
 (defun python/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'python-mode))
+
+;; (defun python/init-counsel-pydoc ()
+;;   (use-package counsel-pydoc
+;;     :defer t
+;;     :init
+;;     (spacemacs/set-leader-keys-for-major-mode 'python-mode "hd" 'counsel-pydoc)))
 
 (defun python/post-init-helm-gtags ()
   (spacemacs/helm-gtags-define-keys-for-mode 'python-mode))
@@ -277,6 +286,15 @@
         "Se" 'sphinx-doc-mode
         "Sd" 'sphinx-doc))
     :config (spacemacs|hide-lighter sphinx-doc-mode)))
+
+(defun python/init-pydoc ()
+  (use-package pydoc
+    :defer t
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'python-mode
+        "hp" 'pydoc-at-point-no-jedi))
+        "hP" 'pydoc))
 
 (defun python/pre-init-pyenv-mode ()
   (add-to-list 'spacemacs--python-pyenv-modes 'python-mode))


### PR DESCRIPTION
Currently the python layer (without anaconda backend) provides only helm-pydoc
or pylookup-lookup-at-point functionality. Both these functions are cumbersome.
`pydoc-at-point-no-jedi` adds simpler doc functionality, therefore this commit
adds this command as a third option. It places it under `SPC m h p` because `SPC
m h h` is already taken by the anaconda doc functionality (it could be placed on
`h h` if anaconda is not available, but I did not bother to implement it)

EXAMPLE:
see [question at stack-overflow](https://emacs.stackexchange.com/questions/66803/how-can-i-access-the-python-documentation-for-the-thing-at-cursor/68707#68707)
Now try to answer it. You will probably agree that this provides the simplest/best solution.
Although both `helm-pydoc` and `pylookup-lookup-at-point` are functional, they require unnecessary (for most cases) extra steps which makes their usage 'frustrating' for most cases.