### PR TITLE
[compleseus] tuned completion-style and added support for M-:

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -250,9 +250,7 @@
 (defun compleseus/init-orderless ()
   (use-package orderless)
   :init
-  (setq completion-styles '(orderless)
-        ;; for ssh completion
-        completion-category-overrides '((file (styles basic partial-completion)))
+  (setq completion-styles '(basic partial-completion orderless)
         completion-category-defaults nil
         completion-category-overrides '((file (styles . (partial-completion))))))
 
@@ -289,6 +287,10 @@
     ;; Enable recursive minibuffers
     (setq enable-recursive-minibuffers t)
 
+    ;; when vertico is used set this so tab when doing M-: will show suggestions
+    ;; https://github.com/minad/vertico/issues/24
+    (setq completion-in-region-function #'consult-completion-in-region)
+
     ;; Optionally enable cycling for `vertico-next' and `vertico-previous'.
     ;; (setq vertico-cycle t)
     (vertico-mode)
@@ -310,7 +312,6 @@
     (spacemacs/set-leader-keys
       "rl" 'vertico-repeat
       "sl" 'vertico-repeat)))
-
 
 (defun spacemacs/compleseus-wgrep-change-to-wgrep-mode ()
   (interactive)


### PR DESCRIPTION
- set completion-styles '(basic partial-completion orderless) currently it is '(orderless) which is ridiculous in how it suggests company results. 
- enable consult for doing tab in `M-:`