### PR TITLE
Use non-deprecated which-key equivalents

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -54,7 +54,7 @@ LONG-NAME if given is stored in `spacemacs/prefix-titles'."
                                  (kbd full-prefix-emacs))))
     ;; define the prefix command only if it does not already exist
     (unless long-name (setq long-name name))
-    (which-key-declare-prefixes
+    (which-key-add-key-based-replacements
       full-prefix-emacs (cons name long-name)
       full-prefix (cons name long-name))))
 (put 'spacemacs/declare-prefix 'lisp-indent-function 'defun)
@@ -74,13 +74,13 @@ used as the prefix command."
                   " " (substring prefix 1))))
     (unless long-name (setq long-name name))
     (let ((prefix-name (cons name long-name)))
-      (which-key-declare-prefixes-for-mode mode
+      (which-key-add-major-mode-key-based-replacements mode
         full-prefix-emacs prefix-name
         full-prefix prefix-name)
       (when (and is-major-mode-prefix dotspacemacs-major-mode-leader-key)
-        (which-key-declare-prefixes-for-mode mode major-mode-prefix prefix-name))
+        (which-key-add-major-mode-key-based-replacements mode major-mode-prefix prefix-name))
       (when (and is-major-mode-prefix dotspacemacs-major-mode-emacs-leader-key)
-        (which-key-declare-prefixes-for-mode
+        (which-key-add-major-mode-key-based-replacements
           mode major-mode-prefix-emacs prefix-name)))))
 (put 'spacemacs/declare-prefix-for-mode 'lisp-indent-function 'defun)
 

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -322,7 +322,7 @@
       (concat leader-key " m")    "major mode commands"
       (concat leader-key " " dotspacemacs-emacs-command-key) "M-x"))
 
-  (which-key-declare-prefixes
+  (which-key-add-key-based-replacements
     dotspacemacs-leader-key '("root" . "Spacemacs root")
     dotspacemacs-emacs-leader-key '("root" . "Spacemacs root")
     (concat dotspacemacs-leader-key " m")


### PR DESCRIPTION
Fixes #15075

I know *new* stuff is supposed to go to develop, but this is more of a release-branch hot-fix type of thing? 