### PR TITLE
Add commands to compleseus layer (locate, yasnippet, search from)

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -1,4 +1,4 @@
-#+TITLE: compleseus layer
+#+TITLE: Compleseus layer
 
 #+TAGS: completion|layer
 
@@ -33,7 +33,7 @@ layer that's listed last.
 
 * Key bindings
 
-| Key binding | Description   |
-|-------------+---------------|
-| ~M-o~       | embark-action |
-| ~C-r~       | history       |
+| Key binding | Description       |
+|-------------+-------------------|
+| ~M-o~       | embark-action     |
+| ~C-r~       | history           |

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -96,6 +96,15 @@
   (interactive)
   (spacemacs/compleseus-search nil (projectile-project-root)))
 
+(defun spacemacs/compleseus-search-from (input)
+  "Embark action to start ripgrep search from candidate's directory."
+  (interactive "s")
+  (message "The first input %s." input)
+  (let ((dir (if (file-directory-p input)
+                 input
+               (file-name-directory input))))
+    (consult-ripgrep dir)))
+
 (defun spacemacs/compleseus-find-file ()
   "This solves the problem:
 Binding a key to: `find-file' calls: `ido-find-file'"
@@ -118,13 +127,13 @@ Binding a key to: `find-file' calls: `ido-find-file'"
         (embark-dwim)))))
 
 (defun spacemacs/next-candidate-preview (&optional n)
-  "Go forward N candidates and preivew"
+  "Go forward N candidates and preview"
   (interactive)
   (vertico-next (or n 1))
   (spacemacs/embark-preview))
 
 (defun spacemacs/previous-candidate-preview (&optional n)
-  "Go backward N candidates and preivew"
+  "Go backward N candidates and preview"
   (interactive)
   (selec-previous (or n 1))
   (spacemacs/embark-preview))
@@ -132,13 +141,13 @@ Binding a key to: `find-file' calls: `ido-find-file'"
 ;; selectrum
 
 (defun spacemacs/selectrum-next-candidate-preview (&optional n)
-  "Go forward N candidates and preivew"
+  "Go forward N candidates and preview"
   (interactive)
   (selectrum-next-candidate (or n 1))
   (spacemacs/embark-preview))
 
 (defun spacemacs/selectrum-previous-candidate-preview (&optional n)
-  "Go backward N candidates and preivew"
+  "Go backward N candidates and preview"
   (interactive)
   (selectrum-previous-candidate (or n 1))
   (spacemacs/embark-preview))

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -26,6 +26,9 @@
     marginalia
     (compleseus-spacemacs-help :location local)
     consult
+    ;; remove recipe when available on Melpa (should be soon)
+    (consult-yasnippet :location (recipe :fetcher github
+                                         :repo "mohkale/consult-yasnippet"))
     embark
     embark-consult
     orderless
@@ -138,6 +141,7 @@
       "bB" #'consult-buffer
       "fb" #'consult-bookmark
       "ff" #'spacemacs/compleseus-find-file
+      "fL" #'consult-locate
       "fr" #'consult-recent-file
       "hda" #'consult-apropos
       "jm" #'consult-mark
@@ -217,6 +221,13 @@
     ;; (setq consult-project-root-function (lambda () (locate-dominating-file "." ".git")))
     ))
 
+(defun compleseus/init-consult-yasnippet ()
+  (use-package consult-yasnippet
+    :defer t
+    :init
+    (spacemacs/set-leader-keys
+      "is" 'consult-yasnippet)))
+
 (defun compleseus/init-embark ()
   (use-package embark
     :bind
@@ -230,6 +241,7 @@
     (setq prefix-help-command #'embark-prefix-help-command)
 
     :config
+    (define-key embark-file-map "s" 'spacemacs/compleseus-search-from)
     ;; Hide the mode line of the Embark live/completions buffers
     ;; (add-to-list 'display-buffer-alist
     ;;              '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
@@ -301,7 +313,9 @@
     (define-key vertico-map (kbd "C-k") #'vertico-previous)
     (define-key vertico-map (kbd "C-M-k") #'spacemacs/previous-candidate-preview)
     (define-key vertico-map (kbd "C-S-k") #'vertico-previous-group)
-    (define-key vertico-map (kbd "C-r") 'consult-history)))
+    (define-key vertico-map (kbd "C-r") 'consult-history)
+    (define-key vertico-map (kbd "C-h") 'backward-kill-word)
+    (define-key vertico-map "?" #'minibuffer-completion-help)))
 
 (defun compleseus/init-vertico-repeat ()
   (use-package vertico-repeat

--- a/layers/+tools/fasd/packages.el
+++ b/layers/+tools/fasd/packages.el
@@ -51,7 +51,11 @@
            ("s" ivy-search-from-action "search-from"))))
 
       ;; we will fall back to using the default completing-read function, which is helm once helm is loaded.
-      (setq fasd-completing-read-function 'nil))))
+      (setq fasd-completing-read-function 'nil))
+    :config
+    (with-eval-after-load 'marginalia
+      (add-to-list 'marginalia-prompt-categories '("\\<fasd\\>" . file)))))
+
 
 (defun fasd/init-helm-fasd ()
   "initializes fasd-emacs and adds a key binding to `SPC f z'"


### PR DESCRIPTION
This PR adds two (default) keybindings to compleseus layer, i.e. consult-locate on `SPC f L` and consult-yasnippet on `SPC i s`.

Furthermore, it adds an embark action to start a grep search from a candidate its path's directory.
@thanhvg Please review/approve if you agree. The PR is just a proposal.