### PR TITLE
LaTeX: Fix broken key binding

### DIFF
--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -251,7 +251,7 @@ By default, the underlying latex code is echoed in the echo area.
 | Key binding                         | Description                                |
 |-------------------------------------+--------------------------------------------|
 | ~SPC m -~                           | recenter output buffer                     |
-| ~SPC m ,​~                           | TeX command on master file                 |
+| ~SPC m ,~                           | TeX command on master file                 |
 | ~SPC m .~                           | mark LaTeX environment                     |
 | ~SPC m *~                           | mark LaTeX section                         |
 | ~SPC m %~                           | comment or uncomment a paragraph           |


### PR DESCRIPTION
There was a sneaky `200b` character (zero width space), which breaks the display on the website:
![image](https://user-images.githubusercontent.com/1204125/136806941-a27023fd-1918-422a-98c7-ffaef086398b.png)

The character is not visible in Github diff but can be seen by using an editor that displays those (e.g. Vim):
![image](https://user-images.githubusercontent.com/1204125/136807275-2e9e054c-2541-44f0-a50b-9610a00ffec8.png)
