### PR TITLE
Open special-mode buffer in motion-state (not evilified)

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -806,8 +806,8 @@ Other:
     section (thank to Daniel Nicolai)
   - New function =spacemacs/inherit-leader-keys-from-parent-mode= to
     inherit leader key bindings from another mode
-  - Evilify buffer with major-mode derived from =special-mode= by default
-    (thanks to Daniel Nicolai)
+  - Open buffers with major-mode derived from =special-mode= in motion-state by
+    default (thanks to Daniel Nicolai)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -10,6 +10,7 @@
     - [[#user-prefix][User prefix]]
     - [[#major-mode-prefix][Major mode prefix]]
     - [[#transient-state][Transient-state]]
+  - [[#special-mode-buffers][Special-mode buffers]]
   - [[#evilified-buffers][Evilified buffers]]
   - [[#navigation][Navigation]]
     - [[#n-and-n][n and N]]
@@ -86,13 +87,15 @@ macOS since ~M-SPC~ is used by the OS for spotlight.
 
 It is recommended to make sure that ~q~ allows to leave the transient-state.
 
+** Special-mode buffers 
+Except for =eww-mode= and evilified buffers (see next section), all buffers with
+major-modes derived from =special-mode= open in motion-state by default. To
+exclude buffers of such major-modes from getting evilified, add a regexp to
+=evil-buffer-regexps=.
+
 ** Evilified buffers
 /Evilifying/ a buffer is to set the =evilified state= as the default
 state for the major mode of the buffer.
-
-Except for =eww-mode= buffers, all buffers with major-modes derived from
-=special-mode= are evilified by default. To exclude buffers of such major-modes
-from getting evilified, add a regexp to =evil-buffer-regexps=.
 
 The =evilified state= is derived from the =emacs state= and modify the
 map to:

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -53,6 +53,7 @@
     - [[#emacs][Emacs]]
     - [[#hybrid][Hybrid]]
   - [[#states][States]]
+  - [[#special-mode-and-its-derived-modes-buffers][Special mode (and its derived modes) buffers]]
   - [[#evilified-modes][Evilified modes]]
   - [[#evil-leader][Evil leader]]
   - [[#universal-argument][Universal argument]]
@@ -872,6 +873,12 @@ Spacemacs has 10 states:
 
 *Note*: Technically speaking there is also the =operator= evil state.
 
+** Special mode (and its derived modes) buffers
+   Special-mode is a [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html][basic major mode]] that sets buffers to read-only. Evil
+   defines an evil-specific (i.e. no vim equivalent) [[https://evil.readthedocs.io/en/latest/overview.html?highlight=motion-state#modes-and-states][motion-state]] for read-only
+   buffers, and Spacemacs opens special-mode buffers, or buffer with major modes
+   derived from special-mode, in motion-state by default.
+   
 ** Evilified modes
 Some buffers are not for editing text and provide their own key bindings for
 certain operations. These often conflict with Vim bindings. To make such buffers
@@ -892,9 +899,6 @@ reserved but =K= is not. If there is a binding on =K=, that will be moved to
 In addition to this, =C-g=, being an important escape key in Emacs, is skipped.
 So anything bound to =g= originally will be found on =C-G=, since =g=, =G= and
 =C-g= are all reserved.
-
-Except for =eww-mode= buffers, all buffers with major modes derived from
-=special-mode= are evilified by default.
 
 ** Evil leader
 Spacemacs uses a leader key to bind almost all its key bindings.

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -289,6 +289,11 @@
     (list (point-min) (point-max)))
   (define-key evil-inner-text-objects-map "g" 'evil-inner-buffer)
 
+  ;; special-mode buffers are read-only and therefore should open in
+  ;; motion-state (evilified state is too aggressive, e.g. evil-local-set-key
+  ;; has no effect)
+  (add-to-list 'evil-motion-state-modes 'special-mode)
+
   ;; turn off evil in corelv buffers
   (add-to-list 'evil-buffer-regexps '("\\*LV\\*"))
 
@@ -585,9 +590,7 @@ Press \\[which-key-toggle-persistent] to hide."
 ;; pre packages
 
 (defun spacemacs-bootstrap/init-evil-evilified-state ()
-  (use-package evil-evilified-state
-    :config
-    (add-to-list 'evil-evilified-state-modes 'special-mode))
+  (use-package evil-evilified-state)
   (define-key evil-evilified-state-map (kbd dotspacemacs-leader-key)
     spacemacs-default-map))
 


### PR DESCRIPTION
Special mode and its derived mode(s) buffers were made evilified in PRs #14995
and #15050. However, special-mode is too aggressive (as 'warned' for already in
 #14995); it makes it hard to overwrite its keybindings (e.g. `evil-local-set-key`,
or using `evil-evilified-state-map` on a derived map have no effect).

Therefore it makes more sense to open the buffers in motion-state instead. This
state also does not hijack the `q` keybindings as defined by special-mode (see
https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html),
although it does still hijack its `g` keybinding, but evil navigation is
considered to have higher priority than revert-buffer anyway.