### PR TITLE
Fetch info+ from GitHub

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -31,7 +31,8 @@
         (view :location built-in)
         golden-ratio
         (grep :location built-in)
-        (info+ :location (recipe :fetcher wiki))
+        (info+ :location (recipe :fetcher github
+                                 :repo "emacsmirror/info-plus"))
         open-junk-file
         paradox
         restart-emacs


### PR DESCRIPTION
CI can't fetch it from wiki for some reason. Could be IP  black list. Not sure :thinking:  Anyway, there is an up to date version at emacsmirrors 