### PR TITLE
helm-find-files-history requires prefix argument

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -525,7 +525,7 @@ Removes the automatic guessing of the initial value based on thing at point. "
   (interactive "P")
   ;; fixes #10882 and #11270
   (require 'helm-files)
-  (let* ((hist (and arg helm-ff-history (helm-find-files-history)))
+  (let* ((hist (and arg helm-ff-history (helm-find-files-history nil)))
          (default-input hist)
          (input (cond ((and (eq major-mode 'dired-mode) default-input)
                        (file-name-directory default-input))


### PR DESCRIPTION
Calling spacemacs/helm-find-files with prefix would cause an error
instead of popping helm-find-files-history before helm-find-files