### PR TITLE
[git] Remove helm-gitignore from git layer

### DIFF
--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -45,7 +45,6 @@ This layers adds extensive support for [[http://git-scm.com/][git]] to Spacemacs
 - quick in buffer last commit message per line with [[https://github.com/syohex/emacs-git-messenger][git-messenger]]
 - colorize buffer line by age of commit with [[https://github.com/syohex/emacs-smeargle][smeargle]]
 - git grep with [[https://github.com/yasuyk/helm-git-grep][helm-git-grep]]
-- gitignore generator with [[https://github.com/jupl/helm-gitignore][helm-gitignore]]
 - org integration with magit via [[https://github.com/magit/orgit][orgit]]
 
 New to Magit? Checkout the [[https://magit.vc/about/][official intro]].
@@ -168,7 +167,6 @@ Git commands (start with ~g~):
 | ~SPC g H h~ | highlight regions by age of commits                 |
 | ~SPC g H t~ | highlight regions by last updated time              |
 | ~SPC g i~   | initialize a new git repository                     |
-| ~SPC g I~   | open =helm-gitignore=                               |
 | ~SPC g L~   | open magit-repolist                                 |
 | ~SPC g s~   | open a =magit= status window                        |
 | ~SPC g S~   | stage current file                                  |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -38,7 +38,6 @@
         git-timemachine
         golden-ratio
         (helm-git-grep :requires helm)
-        (helm-gitignore :requires helm)
         magit
         (magit-delta :toggle git-enable-magit-delta-plugin)
         (magit-gitflow :toggle git-enable-magit-gitflow-plugin)
@@ -70,11 +69,6 @@
     :init (spacemacs/set-leader-keys
             "g/" 'helm-git-grep
             "g*" 'helm-git-grep-at-point)))
-
-(defun git/init-helm-gitignore ()
-  (use-package helm-gitignore
-    :defer t
-    :init (spacemacs/set-leader-keys "gI" 'helm-gitignore)))
 
 (defun git/init-git-commit ()
   (use-package git-commit

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2531,7 +2531,6 @@ Features:
 - quick in buffer last commit message per line with [[https://github.com/syohex/emacs-git-messenger][git-messenger]]
 - colorize buffer line by age of commit with [[https://github.com/syohex/emacs-smeargle][smeargle]]
 - git grep with [[https://github.com/yasuyk/helm-git-grep][helm-git-grep]]
-- gitignore generator with [[https://github.com/jupl/helm-gitignore][helm-gitignore]]
 - org integration with magit via [[https://github.com/magit/orgit][orgit]]
 
 New to Magit? Checkout the [[https://magit.vc/about/][official intro]].


### PR DESCRIPTION
Related to #15117, this removes the helm-gitignore from the git layer because it
hasn't been updated to use the new git-modes package. The helm-gitignore
functionality isn't particularly useful anyway, it's just a utility to help
generate .gitignore files.

This change can be reverted if the upstream helm-gitignore package is fixed and
people find the functionality it provides to be useful.