### PR TITLE
Install org from ELPA instead of Org ELPA

### DIFF
--- a/.lock
+++ b/.lock
@@ -9,7 +9,6 @@
 
 (setq configuration-layer-elpa-archives
       `(("melpa"    . "melpa.org/packages/")
-        ("org"      . "orgmode.org/elpa/")
         ("gnu"      . "elpa.gnu.org/packages/")
         ("nongnu"   . "elpa.nongnu.org/nongnu/")
         ("spacelpa" . ,(concat configuration-layer-stable-elpa-archive "/packages/"))))
@@ -17,6 +16,5 @@
 (setq package-archive-priorities
       '(("spacelpa" . 8)
         ("melpa"    . 4)
-        ("org"      . 3)
         ("nongnu"   . 2)
         ("gnu"      . 1)))

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -452,11 +452,7 @@ cache folder.")
                             configuration-layer-elpa-archives))
     ;; optimization, no need to activate all the packages so early
     (setq package-enable-at-startup nil)
-    (package-initialize 'noactivate)
-    ;; hack to be sure to enable insalled org from Org ELPA repository
-    (when (package-installed-p 'org)
-      (spacemacs-buffer/message "Initializing Org early...")
-      (configuration-layer//activate-package 'org))))
+    (package-initialize 'noactivate)))
 
 (defun configuration-layer//configure-quelpa ()
   "Configure `quelpa' package."
@@ -2603,7 +2599,6 @@ Original code from dochang at https://github.com/dochang/elpa-clone"
   (configuration-layer/make-all-packages 'no-discover)
   (let (package-archive-contents
         (package-archives '(("melpa" . "https://melpa.org/packages/")
-                            ("org"   . "https://orgmode.org/elpa/")
                             ("gnu"   . "https://elpa.gnu.org/packages/")
                             ("nongnu" . "https://elpa.nongnu.org/nongnu/"))))
     (package-refresh-contents)

--- a/core/info/release-notes/0.300.txt
+++ b/core/info/release-notes/0.300.txt
@@ -36,5 +36,4 @@ the user-init function:
 
     (setq configuration-layer-elpa-archives
           '(("melpa"    . "melpa.org/packages/")
-            ("org"      . "orgmode.org/elpa/")
             ("gnu"      . "elpa.gnu.org/packages/")))

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -157,10 +157,10 @@ will be read before =user-config= is executed. (Hence to yield consistent
 behaviour, mode hooks should be set in =user-init=.)
 
 ** Why do some of my =org=-related settings cause problems?
-Since version 0.104, spacemacs uses the =org= version from the org ELPA
-repository instead of the one shipped with emacs. Then, any =org= related code
-should not be loaded before =dotspacemacs/user-config=, otherwise both versions
-will be loaded and will conflict.
+Since version 0.300, spacemacs uses the =org= version from the ELPA repository
+instead of the one shipped with emacs. Then, any =org= related code should not
+be loaded before =dotspacemacs/user-config=, otherwise both versions will be
+loaded and will conflict.
 
 Because of autoloading, calling to =org= functions will trigger the loading up
 of the =org= shipped with emacs which will induce conflicts. One way to avoid

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -90,15 +90,15 @@ For more extensive support of references through BibTeX files, have a look at
 the [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/+lang/bibtex/README.org][BibTeX layer]].
 
 * Important Note
-Since version 0.104, spacemacs uses the =org= version from the =org= ELPA
-repository instead of the one shipped with emacs. Then, any =org= related code
-should not be loaded before =dotspacemacs/user-config=, otherwise both versions
-will be loaded and will conflict.
+Since version 0.300, spacemacs uses the =org= version from the ELPA repository
+instead of the one shipped with emacs. Then, any =org= related code should not
+be loaded before =dotspacemacs/user-config=, otherwise both versions will be
+loaded and will conflict.
 
 Because of autoloading, calling to =org= functions will trigger the loading up
-of the =org= shipped with emacs which will induce conflicts.
-One way to avoid conflict is to wrap your =org= config code in a
-=with-eval-after-load= block like this:
+of the =org= shipped with emacs which will induce conflicts. One way to avoid
+conflict is to wrap your =org= config code in a =with-eval-after-load= block
+like this:
 
 #+BEGIN_SRC emacs-lisp
   (with-eval-after-load 'org

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -33,7 +33,7 @@
     htmlize
     ;; ob, org, org-agenda and org-contacts are installed by `org-contrib'
     (ob :location built-in)
-    (org :location built-in)
+    (org :location elpa :min-version "9.5")
     (org-agenda :location built-in)
     (org-wild-notifier
                 :toggle org-enable-notifications)

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -905,12 +905,6 @@
     (should (equal '(("melpa" . "http://melpa.org/packages/"))
                    (configuration-layer//resolve-package-archives input)))))
 
-(ert-deftest test-resolve-package-archives--org-supports-https ()
-  (let ((input '(("org"   . "orgmode.org/elpa/")))
-        (dotspacemacs-elpa-https t))
-    (should (equal '(("org" . "https://orgmode.org/elpa/"))
-                   (configuration-layer//resolve-package-archives input)))))
-
 (ert-deftest test-resolve-package-archives--idempotent-when-already-http-prefix ()
   (let ((input '(("melpa"   . "http://melpa.org/packages/")))
         (dotspacemacs-elpa-https t))


### PR DESCRIPTION
From org version 9.5 org will not be distributed from Org ELPA but from
ELPA (see https://list.orgmode.org/87lfa7tc9v.fsf@gnu.org/t/). This commit makes
Spacemacs use/install org from ELPA.

Besides that, this commit removes some 'hack' that seemed to have no effect. As
org comes with Emacs `package-installed-p 'org` will always return t. Also
activating org via `configuration-layer//activate-package` seems to have no
effect.

Finally, the package is declared including a :min-version because appending only
`:location melpa` seems to have no effect (this can probably be considered a
bug).
I am almost certain that the information that was added when making org install
from Org ELPA is still relevant also for installing org from ELPA so I have just
adapted the version number from 0.104 to 0.300.

As the "org" archive has been removed, the `ert-deftest` for it can be removed
also.