### PR TITLE
[scala] Shortcut keys for common/standard SBT commands

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3417,6 +3417,8 @@ files (thanks to Daniel Nicolai)
     - ~SPC c s d~ Copy rpms to the phone
     - ~SPC c s i~ Install rpms into target
 **** Scala
+- Shortcut keys for common/standard SBT commands (~scalafmtAll~, ~compile~ and ~test~)
+  (thanks to Keith Pinson)
 - Remove long-deprecated Ensime support (thanks to Keith Pinson)
 - Provide an easy way to configure SBT to use a small buffer at the bottom of
   the frame by setting =scala-sbt-window-position= to =bottom= (thanks to Keith

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -129,7 +129,10 @@ Additional major mode key bindings are populated by LSP and DAP.
 
 ** sbt
 
-| Key binding | Description         |
-|-------------+---------------------|
-| ~SPC m b .~ | sbt transient state |
-| ~SPC m b b~ | sbt command         |
+| Key binding | Description              |
+|-------------+--------------------------|
+| ~SPC m b .~ | SBT transient state      |
+| ~SPC m b b~ | SBT command              |
+| ~SPC m b c~ | Run ~compile~ in SBT     |
+| ~SPC m b t~ | Run ~test~ in SBT        |
+| ~SPC m b =~ | Run ~scalafmtAll~ in SBT |

--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -67,3 +67,18 @@ point to the position of the join."
 
     (when join-pos
       (goto-char join-pos))))
+
+(defun spacemacs/scala-sbt-scalafmt-all ()
+  "Run `scalafmtAll' via SBT"
+  (interactive)
+  (sbt-command "scalafmtAll"))
+
+(defun spacemacs/scala-sbt-compile ()
+  "Run `compile' via SBT"
+  (interactive)
+  (sbt-command "compile"))
+
+(defun spacemacs/scala-sbt-test ()
+  "Run `test' via SBT"
+  (interactive)
+  (sbt-command "test"))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -58,7 +58,10 @@
       (spacemacs/declare-prefix-for-mode 'scala-mode "mg" "goto")
       (spacemacs/set-leader-keys-for-major-mode 'scala-mode
         "b." 'sbt-hydra
-        "bb" 'sbt-command))))
+        "bb" 'sbt-command
+        "bc" #'spacemacs/scala-sbt-compile
+        "bt" #'spacemacs/scala-sbt-test
+        "b=" #'spacemacs/scala-sbt-scalafmt-all))))
 
 (defun scala/init-scala-mode ()
   (use-package scala-mode


### PR DESCRIPTION
It's nice to have a way to use common SBT commands without having to enter a
Hydra, and without having to type them out or select from a history list. The
following should be standard and quite common:

+ `scalafmtAll`
+ `compile`
+ `test`

Added mnemonic keybindings that I think match Spacemacs conventions. They
behaviors also give better parity with the build capabilities of other major
modes, which frequently support compile, format and test functionality.