### PR TITLE
Add a keybinding for lsp-treemacs-type-hierarchy

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -197,6 +197,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - Use ~lsp-ivy~ when ~ivy~ layer is present.
   - added  ~lsp-use-lsp-ui~ variable to control whether ~lsp-ui~ is installed or not.
   - added ~SPC m g h~ to go to call hierarchy.
+  - added ~SPC m g T~ to go to type hierarchy.
 ***** IPython notebook
 - Key bindings;
   - Change prefix from ~SPC a i~ to ~SPC a y~ (thanks to Swaroop C H)

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -200,6 +200,7 @@ The lsp minor mode bindings are:
 | ~SPC m g e~   | browse flycheck errors (=lsp-treemacs=)                                          |
 | ~SPC m g M~   | browse file symbols (=lsp-ui-imenu=)                                             |
 | ~SPC m g h~   | goto call hierachy (=lsp-mode=)                                                  |
+| ~SPC m g T~   | goto type hierachy (=lsp-mode=)                                              |
 |---------------+----------------------------------------------------------------------------------|
 | Note          | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ is ~'peek~ /      |
 | ~SPC m g i~   | find implementations (=lsp-mode=)                                                |

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -199,8 +199,8 @@ The lsp minor mode bindings are:
 | ~SPC m g K~   | goto viewport symbol (=avy=) (See Note 1)                                        |
 | ~SPC m g e~   | browse flycheck errors (=lsp-treemacs=)                                          |
 | ~SPC m g M~   | browse file symbols (=lsp-ui-imenu=)                                             |
-| ~SPC m g h~   | goto call hierachy (=lsp-mode=)                                                  |
-| ~SPC m g T~   | goto type hierachy (=lsp-mode=)                                              |
+| ~SPC m g h~   | goto call hierachy (=lsp-treemacs=)                                          |
+| ~SPC m g T~   | goto type hierachy (=lsp-treemacs=)                                      |
 |---------------+----------------------------------------------------------------------------------|
 | Note          | /Replaced by the lsp-ui-peek equivalents when ~lsp-navigation~ is ~'peek~ /      |
 | ~SPC m g i~   | find implementations (=lsp-mode=)                                                |

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -127,7 +127,8 @@
     "xL" #'lsp-lens-hide)
   (when (configuration-layer/package-used-p 'lsp-treemacs)
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
-      "gh" #'lsp-treemacs-call-hierarchy)))
+      "gh" #'lsp-treemacs-call-hierarchy
+      "gT" #'lsp-treemacs-type-hierarchy)))
 
 (defun spacemacs//lsp-bind-simple-navigation-functions (prefix-char)
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode


### PR DESCRIPTION
Straightforward change: Add a keybinding for lsp-treemacs-type-hierarchy: `SPC m g T`.