### PR TITLE
Fix #15169, snippets not loading correctly

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -335,7 +335,9 @@
         (when auto-completion-private-snippets-directory
           (if (listp auto-completion-private-snippets-directory)
               (setq yas-snippet-dirs (append yas-snippet-dirs auto-completion-private-snippets-directory))
-            (add-to-list 'yas-snippet-dirs auto-completion-private-snippets-directory))))
+            (add-to-list 'yas-snippet-dirs auto-completion-private-snippets-directory)))
+        ;; initialize again yasnippet-snippets, see PR #15171
+        (yasnippet-snippets-initialize))
       (spacemacs|add-toggle yasnippet
         :mode yas-minor-mode
         :documentation "Enable snippets."


### PR DESCRIPTION
The auto-completion layer seems not to have been designed/configured correctly.
So that, e.g., when using the julia layer, the `auto-completion/init-yasnippet`
function is called after the `yasnippet-snippets` package has been loaded.
Despite the `yasnippet-snippets` package containing an `eval-after-load
'yasnippet`, the form within that block is, for some reason, evaluated already
before `auto-completion/init-yasnippet` has been called.

Anyway, what happens currently is that first `(yasnippet-snippets-initialize)`
is evaluated, adding `yasnippet-snippets-dir` to the `yas-snippet-dirs` list.
Then `auto-completion/init-yasnippet` is called which contains the line `(setq
yas-snippet-dirs nil)`, setting the list to nil again.

As there is quite some logic involved (e.g. the order of evaluation is correct
when the julia layer is not being used), this commit fixes the reported issue by
simply calling (again) `(yasnippet-snippets-initialize)` from
`auto-completion/init-yasnippet` after the yas-snippet-dirs list has been
resetted to nil.

Any cleaner solution is welcome, but I would say this is a 'harmless' very
pragmatic quick fix/solution.