### PR TITLE
Add temporary fix for `evil-redirect-digit-argument` error

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -73,6 +73,17 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
       (evil-escape-mode t)
     (evil-escape-mode -1)))
 
+(defun evil-redirect-digit-argument (_ _ _)
+  "This is a temporary fix.
+This is a temporary fix until the PR at URL
+ `https://github.com/syl20bnr/evil-iedit-state/pull/37' gets
+ merged. Please remove this function as soon as the mentioned PR
+ gets merged."
+  (message "This is a temporary fix until
+https://github.com/syl20bnr/evil-iedit-state/pull/37 gets merged.
+Please remove this function as soon as the mentioned PR gets
+merged."))
+
 
 ;; vi-tilde-fringe
 


### PR DESCRIPTION
iedit does not work already for quite some time (at least 29 days, see https://github.com/syl20bnr/spacemacs/issues/15123).
A fix (see https://github.com/syl20bnr/evil-iedit-state/pull/37) has been proposed, but it
has not yet been merged (even after multiple reminders). Therefore, I propose to add
this temporary quick fix, that can/should be removed after that PR gets merged.

The fix simply defines the 'missing function' that prints that it should get removed after that PR gets merged when called.
In this way, iedit at least can be used (more or less) without problems.