### PR TITLE
Improve temporary fix for evil-redirect-digit-argument

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -73,17 +73,20 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
       (evil-escape-mode t)
     (evil-escape-mode -1)))
 
-(defun evil-redirect-digit-argument (_ _ _)
+(defmacro evil-redirect-digit-argument (map keys target)
   "This is a temporary fix.
 This is a temporary fix until the PR at URL
- `https://github.com/syl20bnr/evil-iedit-state/pull/37' gets
- merged. Please remove this function as soon as the mentioned PR
- gets merged."
+`https://github.com/syl20bnr/evil-iedit-state/pull/37' gets
+merged. Please remove this function as soon as the mentioned PR
+gets merged."
   (message "This is a temporary fix until
 https://github.com/syl20bnr/evil-iedit-state/pull/37 gets merged.
 Please remove this function as soon as the mentioned PR gets
-merged."))
+merged.")
+  `(define-key ,map ,keys ,target))
 
+;;; Needed while https://github.com/syl20bnr/evil-iedit-state/pull/37 is not merged
+(defalias 'evil-digit-argument-or-evil-beginning-of-line 'evil-beginning-of-line)
 
 ;; vi-tilde-fringe
 


### PR DESCRIPTION
The fix introduced in 23367d08f890873e77fd9a434c9332cf53d5f9df NOPs evil-redirect-digit-argument. As a result, pressing 0 while in iedit movement state does not jump to the beginning of the match or beginning of line.

This change redefines the functions currently needed by evil-iedit-state while keeping the expected functionality