### PR TITLE
Add basic tree-sitter layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -437,6 +437,7 @@ In org-agenda-mode
 - yang (thanks to Christian Hopps)
 - zig (thanks to Michael Hauser-Raspe)
 **** Misc
+- tree-sitter
 - copy-as-format (thanks to Ruslan Kamashev)
 - dtrt-indent (thanks to Kevin Doherty)
 - ietf (thanks to Christian Hopps and Robby O'Connor)

--- a/layers/+misc/tree-sitter/README.org
+++ b/layers/+misc/tree-sitter/README.org
@@ -1,0 +1,49 @@
+#+TITLE: tree-sitter layer
+#+TAGS: layer|emacs|general|misc
+
+
+* Table of Contents                                       :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#configure][Configure]]
+
+* Description
+  This layer integrates [[https://github.com/emacs-tree-sitter/elisp-tree-sitter][=Emacs Tree-sitter=]] and a few packages built around it.
+  An Emacs build supporting dynamic modules is required.
+
+  Language (i.e. major-mode) support is somewhat limited and varies by feature.
+  Refer to the README/documentation of the package providing the feature for
+  specifics.
+
+** Features:
+   - Syntax highlighting
+   - Indentation (experimental)
+   - Folding (experimental)
+
+* Install
+  To use this configuration layer, add it to your =~/.spacemacs=. You will need
+  to add =tree-sitter= to the existing =dotspacemacs-configuration-layers= list
+  in this file.
+
+* Configure
+  #+begin_comment
+  Enabled features /should/ override existing mechanisms seamlessly. For example,
+  there's no need to separately disable regexp-based syntax highlighting, and in
+  general you do not need to update keybindings to point to new tree-sitter-based
+  commands.
+  #+end_comment
+  
+  Set =tree-sitter-syntax-highlight-enable t= for syntax highlighting, provided
+  by =tree-sitter-hl-mode= which is bundled with [[https://github.com/emacs-tree-sitter/elisp-tree-sitter][=tree-sitter-mode=]].
+  Default: =t=.
+
+  Set =tree-sitter-indent-enable t= for code indentation, provided by
+  [[https://codeberg.org/FelipeLema/tree-sitter-indent.el][=tree-sitter-indent=]]. Currently only Rust is supported.
+  Default: =nil=.
+
+  Set =tree-sitter-fold-enable t= for code folding, provided by [[https://github.com/jcs090218/ts-fold][=ts-fold=]]. If
+  you use a =dotspacemacs-editing-style= other than ='vim= or a
+  =dotspacemacs-folding-method= other than ='evil=, it's likely that you'll find
+  the integration with =ts-fold= wanting. Contributions are encouraged!
+  Default: =nil=.

--- a/layers/+misc/tree-sitter/README.org
+++ b/layers/+misc/tree-sitter/README.org
@@ -27,12 +27,10 @@
   in this file.
 
 * Configure
-  #+begin_comment
-  Enabled features /should/ override existing mechanisms seamlessly. For example,
+  *Note*: Enabled features /should/ override existing mechanisms seamlessly. For example,
   there's no need to separately disable regexp-based syntax highlighting, and in
   general you do not need to update keybindings to point to new tree-sitter-based
   commands.
-  #+end_comment
   
   Set =tree-sitter-syntax-highlight-enable t= for syntax highlighting, provided
   by =tree-sitter-hl-mode= which is bundled with [[https://github.com/emacs-tree-sitter/elisp-tree-sitter][=tree-sitter-mode=]].

--- a/layers/+misc/tree-sitter/config.el
+++ b/layers/+misc/tree-sitter/config.el
@@ -1,0 +1,33 @@
+;;; config.el --- tree-sitter layer config file for Spacemacs.
+;;
+;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;;
+;; Author: Elliott Shugerman <eeshugerman@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defvar tree-sitter-syntax-highlight-enable t
+  "If non nil, use tree-sitter for syntax highlighting where supported.")
+
+(defvar tree-sitter-indent-enable nil
+  "If non nil, use tree-sitter for indentation where supported.")
+
+(defvar tree-sitter-fold-enable nil
+  "If non nil, use tree-sitter for code folding where supported.")
+
+(defvar tree-sitter-fold-indicators-enable t
+  "If non nil, and `tree-sitter-fold-enable' is non nil, show fold indicators in fringe.")

--- a/layers/+misc/tree-sitter/packages.el
+++ b/layers/+misc/tree-sitter/packages.el
@@ -49,8 +49,7 @@
 (defun tree-sitter/init-tree-sitter-indent ()
   (use-package tree-sitter-indent
     :if tree-sitter-indent-enable
-    ;; missing autoload https://codeberg.org/FelipeLema/tree-sitter-indent.el/pulls/15
-    ;; :defer t
+    :defer t
     :init
     (progn
       (add-hook 'rust-mode-hook #'tree-sitter-indent-mode))))

--- a/layers/+misc/tree-sitter/packages.el
+++ b/layers/+misc/tree-sitter/packages.el
@@ -54,9 +54,7 @@
     (progn
       (add-hook 'rust-mode-hook #'tree-sitter-indent-mode))))
 
-;; how can we avoid listing these explicitly?
-;; pull them out of ts-fold at init-time somehow?
-(defconst tree-sitter//ts-fold-supported-major-modes
+(defconst tree-sitter//ts-fold-supported-major-mode-hooks
   '(agda-mode-hook
     sh-mode-hook
     c-mode-hook
@@ -91,7 +89,7 @@
     :init
     (progn
       (when tree-sitter-fold-enable
-        (dolist (mode-hook tree-sitter//ts-fold-supported-major-modes)
+        (dolist (mode-hook tree-sitter//ts-fold-supported-major-mode-hooks)
           (when (boundp mode-hook)
             (add-hook mode-hook #'ts-fold-mode)
             (when tree-sitter-fold-indicators-enable

--- a/layers/+misc/tree-sitter/packages.el
+++ b/layers/+misc/tree-sitter/packages.el
@@ -1,0 +1,103 @@
+;;; packages.el --- tree-sitter layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;;
+;; Author: Elliott Shugerman <eeshugerman@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defconst tree-sitter-packages
+  '(tree-sitter
+    tree-sitter-langs
+    (tree-sitter-indent
+     :toggle tree-sitter-indent-enable)
+    (ts-fold
+     :toggle tree-sitter-fold-enable
+     :location (recipe
+                :fetcher github
+                :repo "jcs090218/ts-fold"))))
+
+(defun tree-sitter/init-tree-sitter ()
+  (use-package tree-sitter
+    :defer t
+    :init
+    (progn
+      (when tree-sitter-syntax-highlight-enable
+       (add-hook 'tree-sitter-after-on-hook #'tree-sitter-hl-mode)))
+    :config
+    (progn
+      (global-tree-sitter-mode))))
+
+(defun tree-sitter/init-tree-sitter-langs ()
+  (use-package tree-sitter-langs
+    :defer t))
+
+(defun tree-sitter/init-tree-sitter-indent ()
+  (use-package tree-sitter-indent
+    :if tree-sitter-indent-enable
+    ;; missing autoload https://codeberg.org/FelipeLema/tree-sitter-indent.el/pulls/15
+    ;; :defer t
+    :init
+    (progn
+      (add-hook 'rust-mode-hook #'tree-sitter-indent-mode))))
+
+;; how can we avoid listing these explicitly?
+;; pull them out of ts-fold at init-time somehow?
+(defconst tree-sitter//ts-fold-supported-major-modes
+  '(agda-mode-hook
+    sh-mode-hook
+    c-mode-hook
+    c++-mode-hook
+    csharp-mode-hook
+    css-mode-hook
+    ess-r-mode-hook
+    go-mode-hook
+    html-mode-hook
+    java-mode-hook
+    javascript-mode-hook
+    js-mode-hook
+    js2-mode-hook
+    js3-mode-hook
+    json-mode-hook
+    jsonc-mode-hook
+    nix-mode-hook
+    php-mode-hook
+    python-mode-hook
+    rjsx-mode-hook
+    ruby-mode-hook
+    rust-mode-hook
+    rustic-mode-hook
+    scala-mode-hook
+    swift-mode-hook
+    typescript-mode-hook))
+
+(defun tree-sitter/init-ts-fold ()
+  (use-package ts-fold
+    :if tree-sitter-fold-enable
+    :defer t
+    :init
+    (progn
+      (when tree-sitter-fold-enable
+        (dolist (mode-hook tree-sitter//ts-fold-supported-major-modes)
+          (when (boundp mode-hook)
+            (add-hook mode-hook #'ts-fold-mode)
+            (when tree-sitter-fold-indicators-enable
+              (add-hook mode-hook #'ts-fold-indicators-mode)))))
+
+      (when tree-sitter-fold-indicators-enable
+        ;; don't obscure lint and breakpoint indicators
+        (setq ts-fold-indicators-priority 0)))))


### PR DESCRIPTION
Closes https://github.com/syl20bnr/spacemacs/issues/14246

In the process of opening this PR I realized there's prior art: https://github.com/syl20bnr/spacemacs/pull/15064. ~But from what I can tell it's a different approach which wouldn't make sense to incorporate here.~

EDIT: On closer inspection I realize #15064 is basically the same approach as this; the main difference is that #15064 would allow the user to turn on `tree-sitter-hl-mode` for specified major modes or globally, whereas this PR only provides the global switch.