### PR TITLE
Fix #15186, broken package update due to commit cac0105

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2159,7 +2159,7 @@ to update."
                            "%s (won't be updated because package is frozen)\n"
                          "%s\n") x) t))
             (sort (mapcar 'symbol-name update-packages) 'string<))
-      (when (not no-confirmation)
+      (unless no-confirmation
         (let ((answer (let ((read-answer-short t))
                         (read-answer (format "Do you want to update %s package(s)? "
                                              upgrade-count)
@@ -2167,7 +2167,8 @@ to update."
                                        ("some" ?s "select packages to upgrade")
                                        ("no"   ?n "don't upgrade packages"))))))
           (if (string= answer "no")
-              (spacemacs-buffer/append "Packages update has been cancelled.\n" t)
+              (progn (spacemacs-buffer/append "Packages update has been cancelled.\n" t)
+                     (user-error "Packages update has been cancelled.\n"))
         ;; backup the package directory and construct an alist
         ;; variable to be cached for easy update and rollback
             (when (string= answer "some")
@@ -2177,7 +2178,7 @@ to update."
                                              (when (yes-or-no-p (format "Update package '%s'? " pkg))
                                                (list pkg)))
                              update-packages))))
-            (setq upgrade-count (length update-packages))
+            (setq upgrade-count (length update-packages)))))
             (spacemacs-buffer/append
              "--> performing backup of package(s) to update...\n" t)
             (spacemacs//redisplay)
@@ -2212,7 +2213,7 @@ to update."
                                  "\nrestart-emacs package is being updated.")
                        "(SPC q r)")))
             (configuration-layer//cleanup-rollback-directory)
-            (spacemacs//redisplay)))))
+            (spacemacs//redisplay))
       (when (eq upgrade-count 0)
         (spacemacs-buffer/append "--> All packages are up to date.\n")
         (spacemacs//redisplay))))


### PR DESCRIPTION
I guess this commit should fix issue #15186.

I have quickly tested all interactive options
- option `s`, installing a selection of packages
- option `n`, canceling installation of packages
- option `y`, installing all packages

then tested
- the rollback functionality

and finally tested the non-interactive option
- using `(configuration-layer/update-packages t)`

and all these functionalities seem to work fine now (but I have not tested thoroughly, maybe you could try the different options also after merging the PR, probably best in the same order as listed above). Anyway, I guess this PR can be merged safely...