### PR TITLE
Add pdf occur follow mode spacemacs binding

### DIFF
--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -213,8 +213,9 @@ Note that you can use also typical Vim keys such as ~j~ and ~G~.
 
 ** Occur mode
 
-| Key binding | Description    |
-|-------------+----------------|
-| ~q~         | Quit           |
-| ~g~         | Refresh buffer |
-| ~r~         | Refresh buffer |
+| Key binding | Description                                       |
+|-------------+---------------------------------------------------|
+| ~q~         | Quit                                              |
+| ~g~         | Refresh buffer                                    |
+| ~r~         | Refresh buffer                                    |
+| ~SPC m t f~ | Toggle follow mode (next-error-follow-minor-mode) |

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -132,7 +132,10 @@
         "g"              'pdf-occur-revert-buffer-with-args
         "r"              'pdf-occur-revert-buffer-with-args
         "*"              'spacemacs/enter-ahs-forward
-        "?"              'evil-search-backward))))
+        "?"              'evil-search-backward)
+      (spacemacs/declare-prefix-for-mode 'pdf-occur-buffer-mode "mt" "toggles")
+      (spacemacs/set-leader-keys-for-major-mode 'pdf-occur-buffer-mode
+        "tf" 'next-error-follow-minor-mode))))
 
 (defun pdf/init-pdf-view-restore ()
   (use-package pdf-view-restore


### PR DESCRIPTION
Follow mode in the pdf-occur buffer is very handy, and deserves a specific
Spacemacs keybinding (mainly for discoverability/documentation, as its name
`next-error-follow-minor-mode`, putting it mildly, is not very intuitive).