### PR TITLE
Fix #15198: Apply ansi-colors to compilation-mode derived modes

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-visual/funcs.el
@@ -25,7 +25,7 @@
 ;; ansi-colors
 
 (defun spacemacs-visual//compilation-buffer-apply-ansi-colors ()
-  (when (eq major-mode 'compilation-mode)
+  (when (memq 'compilation-mode (parent-mode-list major-mode))
     (let ((inhibit-read-only t))
       (goto-char compilation-filter-start)
       (ansi-color-apply-on-region (line-beginning-position) (point-max)))))


### PR DESCRIPTION
Hi,

This change should enable applying ANSI colors to `dap-java` output buffers, and in general to the output buffer of any mode that derives from `compilation-mode`. 
 
Cheers,