### PR TITLE
[lsp] add consult-lsp and set lsp-use-upstream-bindings to t

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -135,7 +135,7 @@ Binding a key to: `find-file' calls: `ido-find-file'"
 (defun spacemacs/previous-candidate-preview (&optional n)
   "Go backward N candidates and preview"
   (interactive)
-  (selec-previous (or n 1))
+  (vertico-previous (or n 1))
   (spacemacs/embark-preview))
 
 ;; selectrum

--- a/layers/+tools/lsp/config.el
+++ b/layers/+tools/lsp/config.el
@@ -37,4 +37,4 @@ If `both', binds lightweight navigation functions under `SPC m g' and lsp-ui fun
 
 (defvar lsp-use-lsp-ui t "When non-nil, use `lsp-ui' package.")
 
-(defvar lsp-use-upstream-bindings nil "When non-nil, map keys to `lsp-command-map'.")
+(defvar lsp-use-upstream-bindings t "When non-nil, map keys to `lsp-command-map'.")

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -53,7 +53,7 @@
                 ("a" . "actions")
                 ("G" . "peek")))
     (which-key-add-keymap-based-replacements lsp-command-map (car it) (cdr it)))
-  ;; we still have to bind keys for `lsp-ivy' and `helm-lsp'
+  ;; we still have to bind keys for `lsp-ivy', `consult-lsp' and `helm-lsp'
   (cond
    ((configuration-layer/package-usedp 'ivy)
     (spacemacs/lsp-define-key lsp-command-map
@@ -63,7 +63,14 @@
    ((configuration-layer/package-usedp 'helm)
     (spacemacs/lsp-define-key lsp-command-map
                               "gs" #'helm-lsp-workspace-symbol
-                              "gS" #'helm-lsp-global-workspace-symbol))))
+                              "gS" #'helm-lsp-global-workspace-symbol))
+   ((configuration-layer/package-usedp 'consult)
+    (define-key lsp-mode-map
+      [remap lsp-treemacs-errors-list]
+      #'consult-lsp-diagnostics)
+    (spacemacs/lsp-define-key lsp-command-map
+                              "gs" #'consult-lsp-symbols
+                              "gf" #'consult-lsp-file-symbols))))
 
 (defun spacemacs/lsp-bind-keys ()
   "Define key bindings for the lsp minor mode."
@@ -352,8 +359,8 @@ EXTRA is an additional parameter that's passed to the LSP function"
                (setq line l1 col c1)
                (push `((,point0 . ,point1) . ,w) candidates)))
     (avy-with avy-document-symbol
-      (avy--process candidates
-                    (avy--style-fn avy-style)))))
+              (avy--process candidates
+                            (avy--style-fn avy-style)))))
 
 (defun spacemacs/lsp-avy-goto-word ()
   (interactive)

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -25,6 +25,7 @@
   '(
     lsp-mode
     (lsp-ui :toggle lsp-use-lsp-ui)
+    (consult-lsp :requires consult)
     (helm-lsp :requires helm)
     (lsp-ivy :requires ivy)
     (lsp-treemacs :requires treemacs)
@@ -67,13 +68,18 @@
        "k" #'lsp-ui-peek--select-prev
        "l" #'lsp-ui-peek--select-next-file))))
 
-
-
 (defun lsp/init-helm-lsp ()
   (use-package helm-lsp :defer t))
 
 (defun lsp/init-lsp-ivy ()
   (use-package lsp-ivy :defer t))
+
+(defun lsp/init-consult-lsp ()
+  (use-package consult-lsp
+    :defer t
+    :after (lsp-mode)
+    :config
+     (consult-lsp-marginalia-mode 1)))
 
 (defun lsp/init-lsp-treemacs ()
   (use-package lsp-treemacs :defer t))


### PR DESCRIPTION
lsp-use-upstream-bindings is t so by default spacemacs will use lsp-mode's own binding scheme. 

We should consider to phase our the current manual binding scheme for lsp-mode in future.

Close https://github.com/syl20bnr/spacemacs/issues/15197