### PR TITLE
loading tex package before PDF tool setting

### DIFF
--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -60,6 +60,7 @@
   (when latex-view-with-pdf-tools
     (if (configuration-layer/layer-used-p 'pdf)
         (progn
+          (require 'tex)
           (setf (alist-get 'output-pdf TeX-view-program-selection) '("PDF Tools"))
           (when latex-view-pdf-in-split-window
             (require 'pdf-sync)


### PR DESCRIPTION
## Issue

* `PDF tools` will be set to `TeX-view-program-selection` while lsp is starting.
  * It causes the below error because the variable doesn't be loaded in advance.

```
Error (use-package): lsp-latex/:config: Symbol’s value as variable is void: TeX-view-program-selection
```

## Solution

* `TeX-view-program-selection` is defined in `auctex/tex.el` package.
  * We need to load the package before using the variable.