### PR TITLE
Replace use of `parent-mode-list` in `spacemacs-visual/funcs.el`

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-visual/funcs.el
@@ -25,7 +25,7 @@
 ;; ansi-colors
 
 (defun spacemacs-visual//compilation-buffer-apply-ansi-colors ()
-  (when (memq 'compilation-mode (parent-mode-list major-mode))
+  (when (memq 'compilation-mode (get major-mode 'derived-mode-parent))
     (let ((inhibit-read-only t))
       (goto-char compilation-filter-start)
       (ansi-color-apply-on-region (line-beginning-position) (point-max)))))


### PR DESCRIPTION
The function `parent-mode-list` is not defined by Spacemacs or any of its
dependencies.

#15198 

Signed-off-by: Chris <cwjnkins@gmail.com>
