### PR TITLE
git-gutter: Remove custom fringe bitmaps

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -183,30 +183,7 @@
        (with-eval-after-load 'git-gutter
          (require 'git-gutter-fringe)))
       (setq git-gutter-fr:side (if (eq version-control-diff-side 'left)
-                                   'left-fringe 'right-fringe)))
-    :config
-    (progn
-      ;; custom graphics that works nice with half-width fringes
-      (fringe-helper-define 'git-gutter-fr:added nil
-        "..X...."
-        "..X...."
-        "XXXXX.."
-        "..X...."
-        "..X....")
-
-      (fringe-helper-define 'git-gutter-fr:deleted nil
-        "......."
-        "......."
-        "XXXXX.."
-        "......."
-        ".......")
-
-      (fringe-helper-define 'git-gutter-fr:modified nil
-        "..X...."
-        ".XXX..."
-        "XX.XX.."
-        ".XXX..."
-        "..X...."))))
+                                   'left-fringe 'right-fringe)))))
 
 (defun version-control/init-git-gutter+ ()
   (use-package git-gutter+


### PR DESCRIPTION
The config for git-gutter currently sets custom fringe bitmaps which
are optimized for half-width fringes.

I think that's an arbitrary choice. There's no spacemacs option which
enables half-width fringes and as far as I can tell, we don't optimize
for half-width fringes anywhere else. So we should optimize the
package defaults for the spacemacs default of full-size fringes.

If users set half-width fringes manually, they can customize the
bitmaps manually. Even if they don't, the bitmaps are still visible,
they just don't look as nice.