### PR TITLE
[lsp-latex] Fix warning void variable TeX-view-program-selection

### DIFF
--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -256,9 +256,7 @@
 
 (defun latex/init-lsp-latex ()
   (use-package lsp-latex
-    :defer t
-    :config
-    (spacemacs//latex-setup-pdf-tools)))
+    :defer t))
 
 (defun latex/init-math-symbol-lists ()
   (use-package math-symbol-lists


### PR DESCRIPTION
Remove the call to `spacemacs//latex-setup-pdf-tools` in `latex/init-lsp-latex`
since it is already called in `init-auctex` which is the main package
