### PR TITLE
Fix keybindings in ivy-occur-grep-mode

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -276,7 +276,7 @@
       (global-set-key (kbd "C-c C-r") 'ivy-resume)
       (global-set-key (kbd "<f6>") 'ivy-resume)
       ;; Occur
-      (evil-set-initial-state 'ivy-occur-grep-mode 'normal)
+      (evil-make-overriding-map ivy-occur-grep-mode-map)
       (evil-make-overriding-map ivy-occur-mode-map 'normal)
       (dolist (mode-map (list ivy-occur-mode-map ivy-occur-grep-mode-map))
         (define-key mode-map "g" nil)


### PR DESCRIPTION
Ivy occur grep mode is a read-only mode that is very similar to ivy-occur mode,
and has one extra keybinding under `w` to change to `wgrep-mode`.

Therefore, instead of starting it normal mode, it should start with the
`overriding-map` similar as how it is done for ivy-occur-mode.

Theoretically (this currently does not work here), this should make the `w` call
`spacemacs/ivy-wgrep-change-to-wgrep-mode` which is perfectly fine.

For some reason, after setting this, my Spacemacs opens ` ivy-occur-grep-mode`
in motion-state (despite it is not derived from `special-mode`, see  #15104`). But
anyway, this fix should work fine, and it is even working fine here with special-mode
(I have no time to debug this irrelevant behavior on my system now).