### PR TITLE
[auto-completion][julia] Revert #15171, Proper fix for #15169

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -335,9 +335,7 @@
         (when auto-completion-private-snippets-directory
           (if (listp auto-completion-private-snippets-directory)
               (setq yas-snippet-dirs (append yas-snippet-dirs auto-completion-private-snippets-directory))
-            (add-to-list 'yas-snippet-dirs auto-completion-private-snippets-directory)))
-        ;; initialize again yasnippet-snippets, see PR #15171
-        (yasnippet-snippets-initialize))
+            (add-to-list 'yas-snippet-dirs auto-completion-private-snippets-directory))))
       (spacemacs|add-toggle yasnippet
         :mode yas-minor-mode
         :documentation "Enable snippets."

--- a/layers/+lang/julia/packages.el
+++ b/layers/+lang/julia/packages.el
@@ -109,6 +109,10 @@
 
 (defun julia/init-lsp-julia ()
   (use-package lsp-julia
+    :defer t
+    :init
+    (with-eval-after-load 'lsp-mode
+      (require 'lsp-julia))
     :config
     (progn
       (push 'xref-find-definitions spacemacs-jump-handlers-julia-mode))))


### PR DESCRIPTION
This reverts commit f2755533deef68cb2fb2a2d40e6a5ab6ede13204.

This adds fix for julia layer breaking yasnippet setup.

Commit f2755533deef68cb2fb2a2d40e6a5ab6ede13204 fixed a specific bug in julia
layer but it loads yasnippet and friends on start up which adds 1 sec to my
startup time even though I don't use julia.

Julia layer loads lsp-julia early on startup, which loads lsp which then loads
yasnippet behind the scene unknown to spacemacs and use-package. That's why our
nice and ordered setup for yasnippet and yasnippet-snippets failed as discussed
in https://github.com/syl20bnr/spacemacs/pull/15171. We now tell use-package to
defer its load.

Note: I didn't do a full test with a julia lsp server. If someone who actually does julia with lsp can verity it that would be great.

