### PR TITLE
Change core-configuration-layer.el to not use obsolete defmethod

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -203,7 +203,7 @@ subdirectory of ROOT is used."
                 "Boolean to track whether layers.el has been loaded."))
   "A configuration layer.")
 
-(defmethod cfgl-layer-owned-packages ((layer cfgl-layer) &optional props)
+(cl-defmethod cfgl-layer-owned-packages ((layer cfgl-layer) &optional props)
   "Return the list of owned packages by LAYER.
 If PROPS is non-nil then return packages as lists with their properties.
 LAYER has to be installed for this method to work properly."
@@ -214,11 +214,11 @@ LAYER has to be installed for this method to work properly."
                  (when (eq (oref layer :name) (car (oref pkg :owners))) x)))
              (cfgl-layer-get-packages layer props))))
 
-(defmethod cfgl-layer-owned-packages ((layer nil) &optional props)
+(cl-defmethod cfgl-layer-owned-packages ((layer null) &optional props)
   "Accept nil as argument and return nil."
   nil)
 
-(defmethod cfgl-layer-get-shadowing-layers ((layer cfgl-layer))
+(cl-defmethod cfgl-layer-get-shadowing-layers ((layer cfgl-layer))
   "Return the list of used layers that shadow LAYER."
   (let ((rank (cl-position (oref layer :name) configuration-layer--used-layers))
         (shadow-candidates (oref layer :can-shadow))
@@ -239,7 +239,7 @@ LAYER has to be installed for this method to work properly."
        shadow-candidates))
     shadowing-layers))
 
-(defmethod cfgl-layer-get-packages ((layer cfgl-layer) &optional props)
+(cl-defmethod cfgl-layer-get-packages ((layer cfgl-layer) &optional props)
   "Return the list of packages for LAYER.
 If PROPS is non-nil then return packages as lists along with their properties."
   (let ((all (eq 'all (oref layer :selected-packages))))
@@ -308,7 +308,7 @@ If PROPS is non-nil then return packages as lists along with their properties."
              :documentation
              "Packages that must be enabled for this package to be enabled.")))
 
-(defmethod cfgl-package-toggled-p ((pkg cfgl-package) &optional inhibit-messages)
+(cl-defmethod cfgl-package-toggled-p ((pkg cfgl-package) &optional inhibit-messages)
   "Evaluate the `toggle' slot of passed PKG.
 If INHIBIT-MESSAGES is non nil then any message emitted by the toggle evaluation
 is ignored."
@@ -316,7 +316,7 @@ is ignored."
         (toggle (oref pkg :toggle)))
     (eval toggle)))
 
-(defmethod cfgl-package-reqs-satisfied-p ((pkg cfgl-package) &optional inhibit-messages)
+(cl-defmethod cfgl-package-reqs-satisfied-p ((pkg cfgl-package) &optional inhibit-messages)
   "Check if requirements of a package are all enabled.
 If INHIBIT-MESSAGES is non nil then any message emitted by the toggle evaluation
 is ignored."
@@ -327,7 +327,7 @@ is ignored."
                         (cfgl-package-enabled-p pkg-obj inhibit-messages))))
                   (oref pkg :requires)))))
 
-(defmethod cfgl-package-enabled-p ((pkg cfgl-package) &optional inhibit-messages)
+(cl-defmethod cfgl-package-enabled-p ((pkg cfgl-package) &optional inhibit-messages)
   "Check if a package is enabled.
 This checks the excluded property, evaluates the toggle, if any, and recursively
 checks whether dependent packages are also enabled.
@@ -337,18 +337,18 @@ is ignored."
        (cfgl-package-reqs-satisfied-p pkg inhibit-messages)
        (cfgl-package-toggled-p pkg inhibit-messages)))
 
-(defmethod cfgl-package-used-p ((pkg cfgl-package))
+(cl-defmethod cfgl-package-used-p ((pkg cfgl-package))
   "Return non-nil if PKG is a used package."
   (and (not (null (oref pkg :owners)))
        (not (oref pkg :excluded))
        (cfgl-package-enabled-p pkg t)))
 
-(defmethod cfgl-package-distant-p ((pkg cfgl-package))
+(cl-defmethod cfgl-package-distant-p ((pkg cfgl-package))
   "Return non-nil if PKG is a distant package (i.e. not built-in Emacs)."
   (and (not (memq (oref pkg :location) '(built-in site local)))
        (not (stringp (oref pkg :location)))))
 
-(defmethod cfgl-package-get-safe-owner ((pkg cfgl-package))
+(cl-defmethod cfgl-package-get-safe-owner ((pkg cfgl-package))
   "Safe method to return the name of the layer which owns PKG."
   ;; The owner of a package is the first *used* layer in `:owners' slot.
   ;; Note: for packages in `configuration-layer--used-packages' the owner is
@@ -360,7 +360,7 @@ is ignored."
     (when (configuration-layer/layer-used-p (car layers))
       (car layers))))
 
-(defmethod cfgl-package-set-property ((pkg cfgl-package) slot value)
+(cl-defmethod cfgl-package-set-property ((pkg cfgl-package) slot value)
   "Set SLOT to the given VALUE for the package PKG.
 If `configuration-layer--package-properties-read-onlyp' is non-nil then VALUE
 is not set for the given SLOT."


### PR DESCRIPTION
As reported in #15230, upstream has removed `eieio-compat.el`. This means that `defmethod` is removed upstream, which means that Spacemacs is broken when using the latest commit in the upstream Emacs master branch.

I'm not really an expert in `cl` or `eieio` but this seems to fix the issue for me (would love some better code review from someone more knowledgeable though). Changing `defmethod` to `cl-defmethod` in `core-configuration-layer.el` just worked for all lines except one, the specialization of `cfgl-layer-owned-packages` for a `nil` argument on line 217 had to be changed to `null`.

There are a few other people who left thumbs up on #15230 so if anyone else who builds Emacs from upstream master can test this change please let me know if it works for you.