### PR TITLE
Remove Emacs 26.3 from github workflows

### DIFF
--- a/.github/workflows/elisp_test.yml
+++ b/.github/workflows/elisp_test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs_version: [26.3, 27.1, snapshot]
+        emacs_version: [27.1, snapshot]
     steps:
 # Installing Emacs on Unix
     - name: Install Emacs on UNIX


### PR DESCRIPTION
Since #15220 Emacs 26 shouldn't be part of the github test workflows.