### PR TITLE
help/helpful: Set tab-width to 8, better integration w/ Ivy

### DIFF
--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -52,7 +52,7 @@
     (defalias 'describe-variable 'helpful-variable)
     (defalias 'describe-key 'helpful-key)
     (add-hook 'helpful-mode (lambda () (setq-local tab-width 8)))
-    (when (featurep 'consel)
+    (when (featurep 'counsel)
       (setq counsel-describe-function-function #'helpful-callable)
       (setq counsel-describe-variable-function #'helpful-variable))))
 

--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -50,7 +50,11 @@
     (evil-define-key 'normal helpful-mode-map (kbd "q") 'quit-window)
     (defalias 'describe-function 'helpful-callable)
     (defalias 'describe-variable 'helpful-variable)
-    (defalias 'describe-key 'helpful-key)))
+    (defalias 'describe-key 'helpful-key)
+    (add-hook 'helpful-mode (lambda () (setq-local tab-width 8)))
+    (when (featurep 'consel)
+      (setq counsel-describe-function-function #'helpful-callable)
+      (setq counsel-describe-variable-function #'helpful-variable))))
 
 (defun helpful/post-init-link-hint ()
   (with-eval-after-load 'helpful

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -232,7 +232,8 @@
 (defun spacemacs-defaults/init-help-fns+ ()
   (use-package help-fns+
     :commands (describe-keymap)
-    :init (spacemacs/set-leader-keys "hdK" 'describe-keymap)))
+    :init (spacemacs/set-leader-keys "hdK" 'describe-keymap)
+    :config (add-hook 'help-mode (lambda () (setq-local tab-width 8)))))
 
 (defun spacemacs-defaults/init-hi-lock ()
   (with-eval-after-load 'hi-lock


### PR DESCRIPTION
Currently we set default tab-width to 2, but in Emacs's Elisp source code,
tab-width defaults to 8.

This discrepancy results in bad alignment of Elisp source code in help-mode
and helpful-mode (when helpful layer is enabled).

This commit fixes this problem by setting tab-width to 8 in those buffers.

In addition, when both helpful and ivy are in use, this commit improved
their integration according to helpful's documentation.
