### PR TITLE
Add C-o and C-i keybindings to evil-evilified-state-map (and remove from pdf-view-mode-map) 

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -814,6 +814,8 @@ Other:
     inherit leader key bindings from another mode
   - Open buffers with major-mode derived from =special-mode= in motion-state by
     default (thanks to Daniel Nicolai)
+  - Add evil-jump-backward/forward (=C-o=/=C-i=) keybindings to
+    evil-evilified-state-map (thanks to Daniel Nicolai)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3108,8 +3108,6 @@ files (thanks to Daniel Nicolai)
 - Fixed ~'~ =pdf-view-jump-to-register= (thanks to duianto)
 - Key bindings:
   - Added to pdf-view mode and transient state
-    - ~C-o~ history-backward (previous view)
-    - ~C-i~ history-forward (next view)
     - ~[~ history-backward (previous view)
     - ~]~ history-forward (next view)
     - ~?~ toggle transient sate documentation hint (shown by default)

--- a/doc/CONVENTIONS.org
+++ b/doc/CONVENTIONS.org
@@ -102,6 +102,7 @@ map to:
 - add ~hjkl~ navigation
 - add scrolling feature on ~C-f~, ~C-b~, ~C-d~ and ~C-u~
 - ~G~ and ~gg~ to go to the end and beginning of the buffer
+- add jump back-forward in history on ~C-o~ and ~C-i~ respectively
 - add incremental search with ~/~, ~n~ and ~N~
 - enabling =evil-ex= on ~:~
 - add =visual state= and =visual line state= on ~v~ and ~V~

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -889,8 +889,8 @@ certain operations. These often conflict with Vim bindings. To make such buffers
 behave more like Vim in a consistent manner, they use a special state called
 /evilified/ state. In evilified state, a handful of keys work as in Evil, namely
 =/=, =:=, =h=, =j=, =k=, =l=, =n=, =N=, =v=, =V=, =gg=, =G=, =C-f=, =C-b=,
-=C-d=, =C-e=, =C-u=, =C-y= and =C-z=. All other keys work as intended by the
-underlying mode.
+=C-d=, =C-e=, =C-o=, =C-i=, =C-u=, =C-y= and =C-z=. All other keys work as
+intended by the underlying mode.
 
 Shadowed keys are moved according to the pattern: =a= → =A= → =C-a= → =C-A=
 

--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -197,6 +197,8 @@ Needed to bypass keymaps set as text properties."
 (define-key evil-evilified-state-map (kbd "C-y") 'evil-scroll-line-up)
 (define-key evil-evilified-state-map (kbd "C-d") 'evil-scroll-down)
 (define-key evil-evilified-state-map (kbd "C-u") 'evil-scroll-up)
+(define-key evil-evilified-state-map (kbd "C-o") 'evil-jump-backward)
+(define-key evil-evilified-state-map (kbd "C-i") 'evil-jump-forward)
 (define-key evil-evilified-state-map (kbd "C-z") 'evil-emacs-state)
 (define-key evil-evilified-state-map (kbd "C-w") 'evil-window-map)
 (setq evil-evilified-state-map-original (copy-keymap evil-evilified-state-map))

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -125,11 +125,11 @@ If you use Emacs editing style, check the key bindings at the [[https://github.c
 | ~C-u~                | Scroll up                                 |
 | ~C-d~                | Scroll down                               |
 | ~``~                 | Go to last page in the history            |
+| ~[~                  | History back                              |
+| ~]~                  | History forward                           |
 | ~m~                  | Set mark                                  |
 | ~'~                  | Go to mark                                |
 | ~y~                  | Yank selected region                      |
-| ~C-o~ or ~[~         | History back                              |
-| ~C-i~ or ~]~         | History forward                           |
 |----------------------+-------------------------------------------|
 | *Search*             |                                           |
 |----------------------+-------------------------------------------|

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -85,8 +85,6 @@
         (kbd "C-u") 'pdf-view-scroll-down-or-previous-page
         (kbd "C-d") 'pdf-view-scroll-up-or-next-page
         (kbd "``")  'pdf-history-backward
-        (kbd "C-o") 'pdf-history-backward
-        (kbd "C-i") 'pdf-history-forward
         "["  'pdf-history-backward
         "]"  'pdf-history-forward
         "'" 'pdf-view-jump-to-register


### PR DESCRIPTION
See motivation in commit messages. I for clarity I have kept the two commits separate. If you agree with these improvements, and you would like me to squash the commits, then just let me know.

So I think `C-o` and `C-i` should consistently be used for jumping 'global' history (or at least using evil-jump functions, I don't think that means 'global' per se) and any other keybindings for jumping 'local' history.

I forgot to provide an example. But just open some pdf in pdf-view, then go to a separate buffer and start jumping to previous locations using `C-o`. I guess you will agree that at least that behavior is quite annoying (I have added those bindings myself, because it was better then the bindings before that, but now I think these are even more logical bindings. In pdf-tools, jumping history is already available under `[` and `]`. 