### PR TITLE
keyboard-layout: Fixes #15249

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -581,7 +581,7 @@
         :post-config
         (evil-define-key 'normal evil-org-mode-map
           "d" 'evil-backward-char
-          "h" 'evil-org-delete)))
+          "j" 'evil-org-delete)))
     :neo
     (progn
       (spacemacs|use-package-add-hook evil-org

--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -575,6 +575,13 @@
             "E" 'org-forward-element
             "I" 'org-backward-element
             "N" 'org-backward-heading-same-level))))
+    :dvp
+    (progn
+      (spacemacs|use-package-add-hook evil-org
+        :post-config
+        (evil-define-key 'normal evil-org-mode-map
+          "d" 'evil-backward-char
+          "h" 'evil-org-delete)))
     :neo
     (progn
       (spacemacs|use-package-add-hook evil-org


### PR DESCRIPTION
Replaced d and h in evil-org-mode
fixes #15249