### PR TITLE
fix messed up keybindings in helm-ag-map

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -297,7 +297,7 @@
     :config
     (progn
       (advice-add 'helm-ag--save-results :after 'spacemacs//gne-init-helm-ag)
-      (evil-define-key 'normal helm-ag-map "SPC" spacemacs-default-map)
+      (evil-define-key 'normal helm-ag-map (kbd dotspacemacs-leader-key) spacemacs-default-map)
       (evilified-state-evilify helm-ag-mode helm-ag-mode-map
         (kbd "gr") 'helm-ag--update-save-results
         (kbd "q") 'quit-window))))


### PR DESCRIPTION
- `SPC` needs to be translated with `kbd`, or otherwise its treated as three keys `S P C`.
- Use `dotspacemacs-leader-key` instead of the default `SPC` to allow customization.