### PR TITLE
markdown: remove orgtbl

### DIFF
--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -14,7 +14,6 @@
   - [[#automatic-mmm-mode-generation][Automatic MMM-Mode Generation]]
 - [[#usage][Usage]]
   - [[#generate-a-toc][Generate a TOC]]
-  - [[#editing-tables][Editing tables]]
 - [[#key-bindings][Key bindings]]
   - [[#element-insertion][Element insertion]]
   - [[#element-removal][Element removal]]
@@ -112,12 +111,6 @@ new languages instead of overriding the variable in your dotfile.
 ** Generate a TOC
 To generate a table of contents type on top of the buffer:
 ~SPC SPC markdown-toc-generate-toc RET~
-
-** Editing tables
-While =markdown-mode= provides functionality to edit tables, users of =org=
-layer benefit from more sophisticated =orgtbl-mode=.
-
-In order to use =orgtabl-mode=, add =org= layer to your =~/.spacemacs=.
 
 * Key bindings
 ** Element insertion

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -30,7 +30,6 @@
     markdown-mode
     markdown-toc
     mmm-mode
-    org
     smartparens
     valign
     (vmd-mode :toggle (eq 'vmd markdown-live-preview-engine))))
@@ -214,8 +213,3 @@
     (dolist (mode markdown--key-bindings-modes)
       (spacemacs/set-leader-keys-for-major-mode mode
         "cP" 'vmd-mode))))
-
-(defun markdown/post-init-org ()
-  (when (configuration-layer/layer-used-p 'org)
-    (add-hook 'markdown-mode-hook 'orgtbl-mode)
-    (spacemacs|diminish orgtbl-mode)))


### PR DESCRIPTION
Entirely removed orgtbl from markdown layer since it causes problems.
Users may still manually enable it if they know what they are doing.

fixes #15256