### PR TITLE
fix evil-lisp-state prefixes & improve related functions

### DIFF
--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -54,12 +54,12 @@ gui, translate to [C-i]. Otherwise, [9] (TAB)."
 ;;     [C-m] [?\C-m]))
 ;; (define-key key-translation-map [?\C-m] 'spacemacs/translate-C-m)
 
-(defun spacemacs/declare-prefix (prefix name &optional _)
+(defun spacemacs/declare-prefix (prefix name &rest more)
   "Declare a prefix PREFIX. PREFIX is a string describing a key
 sequence. NAME is a string used as the prefix command."
-  (which-key-add-keymap-based-replacements spacemacs-default-map
-    prefix name))
-(put 'spacemacs/declare-prefix 'lisp-indent-function 'defun)
+  (declare (indent defun))
+  (apply #'which-key-add-keymap-based-replacements spacemacs-default-map
+    prefix name more))
 
 (defun spacemacs/declare-prefix-for-mode (mode prefix name &optional _)
   "Declare a prefix PREFIX. MODE is the mode in which this prefix command should

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -26,81 +26,80 @@
 ;; ---------------------------------------------------------------------------
 
 ;; We define prefix commands only for the sake of which-key
-(setq spacemacs/key-binding-prefixes `((,dotspacemacs-emacs-command-key "M-x")
-                                       ("!"   "shell cmd")
-                                       ("*"   "search project w/input")
-                                       ("/"   "search project")
-                                       ("?"   "show keybindings")
-                                       ("a"   "applications")
-                                       ("ac"   "chat")
-                                       ("ae"   "email")
-                                       ("af"   "fun")
-                                       ("ar"   "readers")
-                                       ("am"   "music")
-                                       ("at"  "tools")
-                                       ("ats"  "shells")
-                                       ("aw"  "web-services")
-                                       ("c"   "compile/comments")
-                                       ("C"   "capture/colors")
-                                       ("e"   "errors")
-                                       ("g"   "git/versions-control")
-                                       ("h"   "help")
-                                       ("hd"  "help-describe")
-                                       ("hP"  "profiler")
-                                       ("hT"  "tutorials")
-                                       ("i"   "insertion")
-                                       ("j"   "jump/join/split")
-                                       ("jj"  "avy timer")
-                                       ("jl"  "avy line")
-                                       ("js"  "split sexp")
-                                       ("jw"  "avy word")
-                                       ("k"   "lisp")
-                                       ("kd"  "delete")
-                                       ("kD"  "delete-backward")
-                                       ("k`"  "hybrid")
-                                       ("m"   "major mode commands")
-                                       ("n"   "narrow/numbers")
-                                       ("N"   "navigation")
-                                       ("o"   "user bindings")
-                                       ("p"   "projects")
-                                       ("q"   "quit")
-                                       ("r"   "registers/rings/resume")
-                                       ("s"   "search/symbol")
-                                       ("sa"  "ag")
-                                       ("sg"  "grep")
-                                       ("sk"  "ack")
-                                       ("sp"  "search project")
-                                       ("sP"  "search project w/input")
-                                       ("sr"  "ripgrep")
-                                       ("st"  "pt")
-                                       ("sw"  "web")
-                                       ("t"   "toggles")
-                                       ("tC"  "colors")
-                                       ("tE"  "editing-styles")
-                                       ("tEe" "emacs (holy-mode)")
-                                       ("tEh" "hybrid (hybrid-mode)")
-                                       ("th"  "highlight")
-                                       ("tm"  "modeline")
-                                       ("tt"  "timeclock")
-                                       ("T"   "UI toggles/themes")
-                                       ("C-t" "other toggles")
-                                       ("u"   "universal arg")
-                                       ("v"   "expand region")
-                                       ("w"   "windows")
-                                       ("wc"  "centered")
-                                       ("wp"  "popup")
-                                       ("x"   "text")
-                                       ("xa"  "align")
-                                       ("xd"  "delete")
-                                       ("xg"  "google-translate")
-                                       ("xj"  "justification")
-                                       ("xl"  "lines")
-                                       ("xR"  "Randomize")
-                                       ("xt"  "transpose")
-                                       ("xw"  "words")
-                                       ("z"   "zoom")))
-(mapc (lambda (x) (apply #'spacemacs/declare-prefix x))
-      spacemacs/key-binding-prefixes)
+(setq spacemacs/key-binding-prefixes `(,dotspacemacs-emacs-command-key "M-x"
+                                       "!"   "shell cmd"
+                                       "*"   "search project w/input"
+                                       "/"   "search project"
+                                       "?"   "show keybindings"
+                                       "a"   "applications"
+                                       "ac"  "chat"
+                                       "ae"  "email"
+                                       "af"  "fun"
+                                       "ar"  "readers"
+                                       "am"  "music"
+                                       "at"  "tools"
+                                       "ats" "shells"
+                                       "aw"  "web-services"
+                                       "c"   "compile/comments"
+                                       "C"   "capture/colors"
+                                       "e"   "errors"
+                                       "g"   "git/versions-control"
+                                       "h"   "help"
+                                       "hd"  "help-describe"
+                                       "hP"  "profiler"
+                                       "hT"  "tutorials"
+                                       "i"   "insertion"
+                                       "j"   "jump/join/split"
+                                       "jj"  "avy timer"
+                                       "jl"  "avy line"
+                                       "js"  "split sexp"
+                                       "jw"  "avy word"
+                                       "k"   "lisp"
+                                       "kd"  "delete"
+                                       "kD"  "delete-backward"
+                                       "k`"  "hybrid"
+                                       "m"   "major mode commands"
+                                       "n"   "narrow/numbers"
+                                       "N"   "navigation"
+                                       "o"   "user bindings"
+                                       "p"   "projects"
+                                       "q"   "quit"
+                                       "r"   "registers/rings/resume"
+                                       "s"   "search/symbol"
+                                       "sa"  "ag"
+                                       "sg"  "grep"
+                                       "sk"  "ack"
+                                       "sp"  "search project"
+                                       "sP"  "search project w/input"
+                                       "sr"  "ripgrep"
+                                       "st"  "pt"
+                                       "sw"  "web"
+                                       "t"   "toggles"
+                                       "tC"  "colors"
+                                       "tE"  "editing-styles"
+                                       "tEe" "emacs (holy-mode)"
+                                       "tEh" "hybrid (hybrid-mode)"
+                                       "th"  "highlight"
+                                       "tm"  "modeline"
+                                       "tt"  "timeclock"
+                                       "T"   "UI toggles/themes"
+                                       "C-t" "other toggles"
+                                       "u"   "universal arg"
+                                       "v"   "expand region"
+                                       "w"   "windows"
+                                       "wc"  "centered"
+                                       "wp"  "popup"
+                                       "x"   "text"
+                                       "xa"  "align"
+                                       "xd"  "delete"
+                                       "xg"  "google-translate"
+                                       "xj"  "justification"
+                                       "xl"  "lines"
+                                       "xR"  "Randomize"
+                                       "xt"  "transpose"
+                                       "xw"  "words"
+                                       "z"   "zoom"))
+(apply #'spacemacs/declare-prefix spacemacs/key-binding-prefixes)
 
 ;; instantly display current keystrokes in mini buffer
 (setq echo-keystrokes 0.02)
@@ -388,8 +387,8 @@
    ("v" "Variables"
     ("d" add-dir-local-variable "Add directory-local variable...")
     ("f" add-file-local-variable "Add bottom file variable...")
-    ("p" add-file-local-variable-prop-line "Add top file property...")
-    )
+    ("p" add-file-local-variable-prop-line "Add top file property..."))
+
    ("y" "Yank/Copy"
     ("c" spacemacs/copy-file-path-with-line-column "File path with line and column")
     ("d" spacemacs/copy-directory-path "Directory path")

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -242,7 +242,14 @@
     (progn
       (add-hook 'prog-mode-hook 'spacemacs//load-evil-lisp-state)
       (setq evil-lisp-state-global t))
-    :config (spacemacs/set-leader-keys "k" evil-lisp-state-map)))
+    :config
+    (progn
+      (spacemacs/set-leader-keys "k" evil-lisp-state-map)
+      (spacemacs/declare-prefix
+        "k" "lisp"
+        "kd" "delete"
+        "kD" "delete-backward"
+        "k`" "hybrid"))))
 
 ;; other commenting functions in funcs.el with keybinds in keybindings.el
 (defun spacemacs-evil/init-evil-nerd-commenter ()


### PR DESCRIPTION
- make sure `evil-lisp-state` related prefix keys are displayed correctly.
- `which-key-add-keymap-based-replacements` accepts multiple key-def pairs
  thus this commit allow `spacemacs/declare-prefix` to accept multiple inputs
  too.