### PR TITLE
Fix #15255 multi-line byte-compile warnings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -130,6 +130,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)
+  - =multi-line= package is now frozen to [[https://github.com/IvanMalison/multi-line/commit/d5ae863ced0adeb7032ada398005f27a6c669d79][d5ae863]] on versions of Emacs prior to 29 to fix byte-compile warnings (bryce-carson).
 ***** C-C++
 - CMake support has been extracted from the =c-c++= layer into the new =cmake=
   layer.

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -43,7 +43,12 @@
         (spacemacs-whitespace-cleanup :location local)
         string-edit
         string-inflection
-        multi-line
+        (if (version< emacs-version "29")
+            (multi-line :location (recipe
+                                   :fetcher github
+                                   :repo "IvanMalison/multi-line"
+                                   :commit "d5ae863ced0adeb7032ada398005f27a6c669d79"))
+          'multi-line)
         undo-tree
         (unkillable-scratch :toggle dotspacemacs-scratch-buffer-unkillable)
         uuidgen


### PR DESCRIPTION
The package is conditionally frozen to an earlier version if emacs-version is not >= 29.