### PR TITLE
[clojure] add kaocha-runner as optional package

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1631,6 +1631,7 @@ Other:
   - Added =flycheck-clojure= linters (thanks to Eugene Yaremenko)
   - Added =clj-kondo= to Clojure linters (thanks to Luo Tian and John Stevenson)
   - Added =flycheck-joker= to Clojure linters (thanks to didibus)
+  - Added =kaocha-runner= to Clojure linters (thanks to practicalli-john)
 - Improvements:
   - Stored cider REPL history in spacemacs cache (thanks to Ryan Fowler)
   - Removed backtick from smartparens pairs for Clojure

--- a/layers/+lang/clojure/README.org
+++ b/layers/+lang/clojure/README.org
@@ -21,6 +21,7 @@
     - [[#enable-multiple-linters][Enable multiple linters]]
     - [[#enable-clojure-fancify-symbols][Enable Clojure fancify Symbols]]
     - [[#enabling-sayid-or-clj-refactor][Enabling sayid or clj-refactor]]
+  - [[#enabling-kaocha-runner][Enabling Kaocha Runner]]
 - [[#usage][Usage]]
   - [[#starting-a-repl-from-spacemacs][Starting a REPL from Spacemacs]]
     - [[#troubleshooting][Troubleshooting]]
@@ -311,6 +312,37 @@ injected when jacking in CIDER.
 
 If you are experiencing issues when running a REPL, try disabling these
 packages first and restart Spacemacs to see if the error persists.
+
+
+** Enabling Kaocha Runner
+Run unit tests with Kaocha via CIDER.
+
+Enable the Kaocha feature via setting the =clojure-enable-kaocha-runner= variable
+in your dotfile:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+  '((clojure :variables clojure-enable-kaocha-runner t)))
+#+END_SRC
+
+The kaocha library must be included when starting a REPL, either through
+Leiningen dev profile dependency
+
+
+#+BEGIN_SRC emacs-lisp
+  :profiles {:dev {:dependencies [[lambdaisland/kaocha "1.60.977"]]}}
+#+END_SRC
+
+
+or a Clojure CLI alias in a project deps.edn or user wide deps.edn file
+
+#+BEGIN_SRC emacs-lisp
+  :lib/kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}}
+#+END_SRC
+
+
+
+[[https://github.com/practicalli/clojure-deps-edn][practicalli/clojure-deps-edn]] contains an example =:lib/kaocha= alias
 
 * Usage
 Read the key bindings section to see all the functionality available, or simply

--- a/layers/+lang/clojure/config.el
+++ b/layers/+lang/clojure/config.el
@@ -38,6 +38,10 @@
 (defvar clojure-enable-clj-refactor nil
   "If non-nil, the clj-refactor is enabled.")
 
+(defvar clojure-enable-kaocha-runner nil
+  "If non-nil, the Kaocha runner is enabled.
+Kaocha should be a dev-dependency or alias in a Clojure project.")
+
 (defvar clojure-enable-linters nil
   "If non-nil, enable clojure linters.")
 

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -43,6 +43,7 @@
                                              clojure-enable-linters
                                            (list clojure-enable-linters))))
     ggtags
+    (kaocha-runner :toggle clojure-enable-kaocha-runner)
     counsel-gtags
     helm-gtags
     org
@@ -361,6 +362,24 @@
               sayid--key-binding-prefixes)
         (spacemacs/set-leader-keys-for-major-mode m
           "hc" 'helm-cider-cheatsheet)))))
+
+(defun clojure/init-kaocha-runner ()
+  (use-package kaocha-runner
+    :defer t
+    :init
+    (progn
+      (setq kaocha--key-binding-prefixes
+            '(("mtk" . "kaocha")))
+      (spacemacs|forall-clojure-modes m
+        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                            m (car x) (cdr x)))
+              kaocha--key-binding-prefixes)
+        (spacemacs/set-leader-keys-for-major-mode m
+          "tka" 'kaocha-runner-run-all-tests
+          "tkt" 'kaocha-runner-run-test-at-point
+          "tkn" 'kaocha-runner-run-tests
+          "tkw" 'kaocha-runner-show-warnings
+          "tkh" 'kaocha-runner-hide-windows)))))
 
 (defun clojure/init-clojure-mode ()
   (use-package clojure-mode


### PR DESCRIPTION
Add kaocha-runner.el to the Clojure layer to enable running the kaocha test
runner from Emacs Cider

Kaocha runner added to the layer via the `clojure-enable-kaocha-runner` variable

Add key bindings to call Kaocha runner

Resolve  #15267