### PR TITLE
update spacemacs/declare-prefix usages

### DIFF
--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -20,8 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-(setq spell-checking-packages
+(defconst spell-checking-packages
   '(
     auto-dictionary
     flyspell
@@ -30,8 +29,7 @@
     (flyspell-correct-helm :toggle (configuration-layer/layer-used-p 'helm))
     (flyspell-correct-popup :toggle (and (not (configuration-layer/layer-used-p 'ivy))
                                          (not (configuration-layer/layer-used-p 'helm))))
-    (flyspell-popup :toggle enable-flyspell-auto-completion)
-    ))
+    (flyspell-popup :toggle enable-flyspell-auto-completion)))
 
 (defun spell-checking/init-auto-dictionary ()
   (use-package auto-dictionary
@@ -100,8 +98,9 @@ Spell Commands^^            Add To Dictionary^^               Other
         :documentation "Enable automatic spell checking."
         :evil-leader "tS")
 
-      (spacemacs/declare-prefix "S" "spelling")
-      (spacemacs/declare-prefix "Sa" "add word to dict")
+      (spacemacs/declare-prefix
+        "S"  "spelling"
+        "Sa" "add word to dict")
       (spacemacs/set-leader-keys
         "Sab" 'spacemacs/add-word-to-dict-buffer
         "Sag" 'spacemacs/add-word-to-dict-global

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -1,6 +1,6 @@
 ;;; packages.el --- Auto-completion Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -21,7 +21,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq auto-completion-packages
+(defconst auto-completion-packages
       '(
         auto-yasnippet
         auto-complete

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -21,29 +21,27 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq spacemacs-bootstrap-packages
-      '(
-        ;; bootstrap packages,
-        ;; `use-package' cannot be used for bootstrap packages configuration
-        (async :step bootstrap)
-        (bind-map :step bootstrap)
-        (bind-key :step bootstrap)
-        (diminish :step bootstrap)
-        (evil :step bootstrap)
-        (hydra :step bootstrap)
-        (use-package :step bootstrap)
-        (which-key :step bootstrap)
-        ;; pre packages, initialized after the bootstrap packages
-        ;; these packages can use use-package
-        (dotenv-mode :step pre)
-        (evil-evilified-state :location local :step pre :protected t)
-        (pcre2el :step pre)
-        (holy-mode :location local :step pre)
-        (hybrid-mode :location (recipe :fetcher local) :step pre)
-        (spacemacs-theme :location built-in)
-        dash))
-
-
+(defconst spacemacs-bootstrap-packages
+  '(
+    ;; bootstrap packages,
+    ;; `use-package' cannot be used for bootstrap packages configuration
+    (async :step bootstrap)
+    (bind-map :step bootstrap)
+    (bind-key :step bootstrap)
+    (diminish :step bootstrap)
+    (evil :step bootstrap)
+    (hydra :step bootstrap)
+    (use-package :step bootstrap)
+    (which-key :step bootstrap)
+    ;; pre packages, initialized after the bootstrap packages
+    ;; these packages can use use-package
+    (dotenv-mode :step pre)
+    (evil-evilified-state :location local :step pre :protected t)
+    (pcre2el :step pre)
+    (holy-mode :location local :step pre)
+    (hybrid-mode :location (recipe :fetcher local) :step pre)
+    (spacemacs-theme :location built-in)
+    dash))
 
 ;; bootstrap packages
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -384,9 +384,10 @@ Will work on both org-mode and any mode that accepts plain html."
 
       ;; Add global evil-leader mappings. Used to access org-agenda
       ;; functionalities – and a few others commands – from any other mode.
-      (spacemacs/declare-prefix "ao" "org")
-      (spacemacs/declare-prefix "aof" "feeds")
-      (spacemacs/declare-prefix "aoC" (org-clocks-prefix))
+      (spacemacs/declare-prefix
+        "ao"  "org"
+        "aof" "feeds"
+        "aoC" (org-clocks-prefix))
       ;; org-agenda
       (when (configuration-layer/layer-used-p 'ivy)
         (spacemacs/set-leader-keys "ao/" 'org-occur-in-agenda-files))
@@ -682,12 +683,13 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :defer t
     :init
     (progn
-      (spacemacs/declare-prefix "aoJ" "jira")
-      (spacemacs/declare-prefix "aoJp" "projects")
-      (spacemacs/declare-prefix "aoJi" "issues")
-      (spacemacs/declare-prefix "aoJs" "subtasks")
-      (spacemacs/declare-prefix "aoJc" "comments")
-      (spacemacs/declare-prefix "aoJt" "todos")
+      (spacemacs/declare-prefix
+        "aoJ"  "jira"
+        "aoJp" "projects"
+        "aoJi" "issues"
+        "aoJs" "subtasks"
+        "aoJc" "comments"
+        "aoJt" "todos")
       (spacemacs/set-leader-keys
         "aoJpg" 'org-jira-get-projects
         "aoJib" 'org-jira-browse-issue
@@ -926,9 +928,10 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :hook (after-init . org-roam-setup)
     :init
     (progn
-      (spacemacs/declare-prefix "aor" "org-roam")
-      (spacemacs/declare-prefix "aord" "org-roam-dailies")
-      (spacemacs/declare-prefix "aort" "org-roam-tags")
+      (spacemacs/declare-prefix
+        "aor"  "org-roam"
+        "aord" "org-roam-dailies"
+        "aort" "org-roam-tags")
       (spacemacs/set-leader-keys
         "aordy" 'org-roam-dailies-goto-yesterday
         "aordt" 'org-roam-dailies-goto-today

--- a/layers/+emacs/outshine/packages.el
+++ b/layers/+emacs/outshine/packages.el
@@ -36,9 +36,10 @@
     (progn
       (spacemacs|hide-lighter outline-minor-mode)
       (spacemacs|hide-lighter outshine-mode)
-      (spacemacs/declare-prefix "aO" "out(line/org/shine)")
-      (spacemacs/declare-prefix "aOg" "goto")
-      (spacemacs/declare-prefix "aOi" "insert")
+      (spacemacs/declare-prefix
+        "aO"  "out(line/org/shine)"
+        "aOg" "goto"
+        "aOi" "insert")
       (spacemacs/set-leader-keys
         "aO."  'spacemacs/outshine-transient-state/body
         "aOS"  'outline-show-all

--- a/layers/+fun/games/packages.el
+++ b/layers/+fun/games/packages.el
@@ -1,6 +1,6 @@
 ;;; packages.el --- games Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -21,16 +21,16 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq games-packages
-      '(
-        2048-game
-        (helm-games :location local
-                    :requires helm)
-        pacmacs
-        (tetris :location built-in)
-        sudoku
-        typit
-        ))
+(defconst games-packages
+  '(
+    2048-game
+    (helm-games :location local
+                :requires helm)
+    pacmacs
+    (tetris :location built-in)
+    sudoku
+    typit))
+
 
 (defun games/init-2048-game ()
   (use-package 2048-mode
@@ -38,7 +38,8 @@
     :init
     (progn
       (push '("2048" . (2048-game :quit (kill-buffer-ask (get-buffer "2048"))
-                                  :reset 2048-init)) helm-games-list)
+                                  :reset 2048-init))
+            helm-games-list)
       (evilified-state-evilify 2048-mode 2048-mode-map
         "j" '2048-down
         "k" '2048-up
@@ -59,7 +60,8 @@
     :init
     (push '("pacmacs" . (pacmacs-start
                          :quit (kill-buffer-ask (get-buffer "*Pacmacs*"))
-                         :reset pacmacs-start)) helm-games-list)
+                         :reset pacmacs-start))
+          helm-games-list)
     (evilified-state-evilify pacmacs-mode pacmacs-mode-map
       "h" 'pacmacs-left
       "j" 'pacmacs-down
@@ -72,7 +74,8 @@
     :init
     (progn
       (push '("Tetris" . (tetris :quit spacemacs/tetris-quit-game
-                                 :reset tetris-start-game)) helm-games-list)
+                                 :reset tetris-start-game))
+            helm-games-list)
       (setq tetris-score-file (concat spacemacs-games-cache-directory
                                       "tetris-scores.txt")))
     :config
@@ -91,7 +94,8 @@
     :init
     (progn
       (push '("sudoku" . (sudoku :quit (kill-buffer-ask (get-buffer "*Sudoku*"))
-                                 :reset sudoku-restart)) helm-games-list)
+                                 :reset sudoku-restart))
+            helm-games-list)
       (evilified-state-evilify sudoku-mode sudoku-mode-map
         ;; Movement
         "j" 'sudoku-move-point-down

--- a/layers/+misc/multiple-cursors/packages.el
+++ b/layers/+misc/multiple-cursors/packages.el
@@ -22,11 +22,10 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-(setq multiple-cursors-packages
-      '(
-        (evil-mc :toggle (eq multiple-cursors-backend 'evil-mc))
-        (multiple-cursors :toggle (eq multiple-cursors-backend 'mc))))
+(defconst multiple-cursors-packages
+  '(
+    (evil-mc :toggle (eq multiple-cursors-backend 'evil-mc))
+    (multiple-cursors :toggle (eq multiple-cursors-backend 'mc))))
 
 (defun multiple-cursors/init-evil-mc ()
   (use-package evil-mc
@@ -57,8 +56,9 @@
     :defer t
     :init
     (progn
-      (spacemacs/declare-prefix "sm" "multiple-cursors")
-      (spacemacs/declare-prefix "sms" "specials")
+      (spacemacs/declare-prefix
+        "sm"  "multiple-cursors"
+        "sms" "specials")
       (spacemacs/set-leader-keys
         "sma" 'mc/mark-all-dwim
         "smb" 'mc/mark-all-like-this

--- a/layers/+music/pianobar/packages.el
+++ b/layers/+music/pianobar/packages.el
@@ -21,22 +21,23 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq pianobar-packages
+(defconst pianobar-packages
   '(
-    pianobar
-    ))
+    pianobar))
+
 
 (defun pianobar/init-pianobar ()
   (use-package pianobar
     :defer t
-    :init (progn
-            (spacemacs/declare-prefix "am" "music")
-            (spacemacs/declare-prefix "amp" "Pianobar")
-            (spacemacs/set-leader-keys
-              "ampp" 'pianobar-play-or-pause
-              "ampn" 'pianobar-next-song
-              "amp+" 'pianobar-love-current-song
-              "amp-" 'pianobar-ban-current-song
-              "ampt" 'pianobar-shelve-current-song
-              "amps" 'pianobar-change-station
-              ))))
+    :init
+    (progn
+      (spacemacs/declare-prefix
+        "am"  "music"
+        "amp" "Pianobar")
+      (spacemacs/set-leader-keys
+        "ampp" 'pianobar-play-or-pause
+        "ampn" 'pianobar-next-song
+        "amp+" 'pianobar-love-current-song
+        "amp-" 'pianobar-ban-current-song
+        "ampt" 'pianobar-shelve-current-song
+        "amps" 'pianobar-change-station))))

--- a/layers/+music/spotify/packages.el
+++ b/layers/+music/spotify/packages.el
@@ -21,22 +21,24 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq spotify-packages
-      '(spotify
-        (helm-spotify-plus :toggle (configuration-layer/package-usedp 'helm))
-        (counsel-spotify :toggle (configuration-layer/package-usedp 'ivy))))
+(defconst spotify-packages
+  '(spotify
+    (helm-spotify-plus :toggle (configuration-layer/package-usedp 'helm))
+    (counsel-spotify :toggle (configuration-layer/package-usedp 'ivy))))
 
 (defun spotify/init-spotify ()
   (use-package spotify
     :defer t
-    :init (progn
-            (spacemacs/declare-prefix "am" "music")
-            (spacemacs/declare-prefix "ams" "Spotify")
-            (spacemacs/set-leader-keys
-              "amsp" 'spotify-playpause
-              "amsn" 'spotify-next
-              "amsN" 'spotify-previous
-              "amsQ" 'spotify-quit))))
+    :init
+    (progn
+      (spacemacs/declare-prefix
+        "am"  "music"
+        "ams" "Spotify")
+      (spacemacs/set-leader-keys
+        "amsp" 'spotify-playpause
+        "amsn" 'spotify-next
+        "amsN" 'spotify-previous
+        "amsQ" 'spotify-quit))))
 
 (defun spotify/init-helm-spotify-plus ()
   (use-package helm-spotify-plus
@@ -51,12 +53,14 @@
                counsel-spotify-search-track
                counsel-spotify-search-tracks-by-artist
                counsel-spotify-search-tracks-by-album)
-    :init (progn
-            (spacemacs/declare-prefix "amss" "search")
-            (spacemacs/declare-prefix "amssT" "tracks")
-            (spacemacs/set-leader-keys
-              "amssa" 'counsel-spotify-search-artist
-              "amssA" 'counsel-spotify-search-album
-              "amsst" 'counsel-spotify-search-track
-              "amssTa" 'counsel-spotify-search-tracks-by-artist
-              "amssTA" 'counsel-spotify-search-tracks-by-album))))
+    :init
+    (progn
+      (spacemacs/declare-prefix
+        "amss"  "search"
+        "amssT" "tracks")
+      (spacemacs/set-leader-keys
+        "amssa" 'counsel-spotify-search-artist
+        "amssA" 'counsel-spotify-search-album
+        "amsst" 'counsel-spotify-search-track
+        "amssTa" 'counsel-spotify-search-tracks-by-artist
+        "amssTA" 'counsel-spotify-search-tracks-by-album))))

--- a/layers/+pair-programming/floobits/funcs.el
+++ b/layers/+pair-programming/floobits/funcs.el
@@ -1,8 +1,8 @@
-;;; packages.el --- Reddit Layer packages File for Spacemacs
+;;; funcs.el --- Floobits Layer functions File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
-;; Author: Benedikt Broich <b.broich@posteo.de>
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -20,16 +20,11 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+(defun spacemacs/floobits-rclocation ()
+  "Return the absolute path to the floobits dotfile."
+  (concat user-home-directory ".floorc.json"))
 
-(defconst reddit-packages
-  '(reddigg))
-
-(defun reddit/init-reddigg ()
-  (use-package reddigg
-    :defer t
-    :init
-    (progn
-      (spacemacs/declare-prefix "awr" "reddit")
-      (spacemacs/set-leader-keys
-        "awrm" 'reddigg-view-main
-        "awrs" 'reddigg-view-sub))))
+(defun spacemacs/floobits-load-rcfile ()
+  "Load ~/.floobitsrc if it exists."
+  (let ((floobitsrc (spacemacs/floobits-rclocation)))
+    (if (file-exists-p floobitsrc) (load floobitsrc))))

--- a/layers/+pair-programming/floobits/packages.el
+++ b/layers/+pair-programming/floobits/packages.el
@@ -1,6 +1,6 @@
 ;;; packages.el --- floobits Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
 ;; Author: Rodolfo Hansen <rhansen@kitsd.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -21,10 +21,10 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq floobits-packages
+(defconst floobits-packages
   '(
-    floobits
-    ))
+    floobits))
+
 
 (defun floobits/init-floobits ()
   (use-package floobits
@@ -32,16 +32,6 @@
     :init
     (progn
       (spacemacs/declare-prefix "P" "PP/floobits")
-
-      (defun spacemacs/floobits-rclocation ()
-        "Return the absolute path to the floobits dotfile."
-        (concat user-home-directory ".floorc.json"))
-
-      (defun spacemacs/floobits-load-rcfile ()
-        "Load ~/.floobitsrc if it exists."
-        (let ((floobitsrc (spacemacs/floobits-rclocation)))
-          (if (file-exists-p floobitsrc) (load floobitsrc))))
-
       (spacemacs/set-leader-keys
         "Pc" 'floobits-clear-highlights
         "Pd" 'spacemacs/floobits-load-rcfile

--- a/layers/+readers/deft/funcs.el
+++ b/layers/+readers/deft/funcs.el
@@ -1,8 +1,8 @@
-;;; keybindings.el --- Quickurl dispatch layer.
+;;; funcs.el --- Deft Layer functions File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
-;; Author: Spenser Truex <web@spensertruex.com>
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -20,14 +20,12 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-;; Keybindings to use Quickurl, including mode-local ones for the listing.
-
-(spacemacs/declare-prefix "atq" "quickurl")
-(spacemacs/set-leader-keys
-  "atql" 'quickurl-list
-  "atqq" 'quickurl
-  "atqi" 'quickurl-ask
-  "atqe" 'quickurl-edit-urls
-  "atqa" 'quickurl-add-url
-  "atqb" 'quickurl-browse-url-ask)
+(defun spacemacs/deft ()
+  "Helper to call deft and then fix things so that it is nice and works"
+  (interactive)
+  (deft)
+  ;; Hungry delete wrecks deft's DEL override
+  (when (fboundp 'hungry-delete-mode)
+    (hungry-delete-mode -1))
+  ;; When opening it you always want to filter right away
+  (evil-insert-state nil))

--- a/layers/+readers/deft/packages.el
+++ b/layers/+readers/deft/packages.el
@@ -22,11 +22,10 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq deft-packages
-      '(
-        deft
-        (zetteldeft :toggle (eq deft-zetteldeft t))
-        ))
+(defconst deft-packages
+  '(
+    deft
+    (zetteldeft :toggle (eq deft-zetteldeft t))))
 
 (defun deft/init-zetteldeft ()
   (use-package zetteldeft
@@ -39,8 +38,7 @@
       ;; zetteldeft actions in deft mode
       (spacemacs/set-leader-keys-for-major-mode 'deft-mode
         "zT" 'zetteldeft-tag-buffer
-        "zn" 'zetteldeft-new-file
-        )
+        "zn" 'zetteldeft-new-file)
       ;; zetteldeft actions in org mode
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
         "zc" 'zetteldeft-search-current-id
@@ -53,16 +51,14 @@
         "zs" 'zetteldeft-search-at-point
         "zl" 'zetteldeft-avy-link-search
         "zF" 'zetteldeft-avy-file-search-ace-window
-        "zo" 'zetteldeft-find-file
-        )
+        "zo" 'zetteldeft-find-file)
       ;; new zetteldeft file under capture
       (spacemacs/set-leader-keys "Cz" 'zetteldeft-new-file)
       ;; actions under applications/deft/zetteldeft
       (spacemacs/set-leader-keys "ardzn" 'zetteldeft-new-file)
       (spacemacs/set-leader-keys "ardzT" 'zetteldeft-tag-buffer)
       (spacemacs/set-leader-keys "ardzs" 'zetteldeft-search-at-point)
-      (spacemacs/set-leader-keys "ardzo" 'zetteldeft-find-file)
-    )))
+      (spacemacs/set-leader-keys "ardzo" 'zetteldeft-find-file))))
 
 (defun deft/init-deft ()
   (use-package deft
@@ -80,23 +76,13 @@
             (spacemacs/set-leader-keys "ardn" 'spacemacs/deft))
         (spacemacs/set-leader-keys "ard" 'spacemacs/deft))
       ;; put in capture prefix
-      (spacemacs/set-leader-keys "Cd" 'deft-new-file)
-
-      (defun spacemacs/deft ()
-        "Helper to call deft and then fix things so that it is nice and works"
-        (interactive)
-        (deft)
-        ;; Hungry delete wrecks deft's DEL override
-        (when (fboundp 'hungry-delete-mode)
-          (hungry-delete-mode -1))
-        ;; When opening it you always want to filter right away
-        (evil-insert-state nil)))
+      (spacemacs/set-leader-keys "Cd" 'deft-new-file))
     :config (spacemacs/set-leader-keys-for-major-mode 'deft-mode
-        "c" 'deft-filter-clear
-        "d" 'deft-delete-file
-        "i" 'deft-toggle-incremental-search
-        "n" 'deft-new-file
-        "N" 'deft-new-file-named
-        "q" 'quit-window
-        "o" 'deft-open-file-other-window
-        "r" 'deft-rename-file)))
+             "c" 'deft-filter-clear
+             "d" 'deft-delete-file
+             "i" 'deft-toggle-incremental-search
+             "n" 'deft-new-file
+             "N" 'deft-new-file-named
+             "q" 'quit-window
+             "o" 'deft-open-file-other-window
+             "r" 'deft-rename-file)))

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -21,33 +21,33 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq git-packages
-      '(
-        evil-collection
-        fill-column-indicator
-        ;; forge requires a C compiler on Windows so we disable
-        ;; it by default on Windows.
-        (forge :toggle (not (spacemacs/system-is-mswindows)))
-        ;; include the old git{attributes,config,ignore}-mode
-        git-modes
-        gitignore-templates
-        git-commit
-        git-link
-        git-messenger
-        git-timemachine
-        golden-ratio
-        (helm-git-grep :requires helm)
-        magit
-        (magit-delta :toggle git-enable-magit-delta-plugin)
-        (magit-gitflow :toggle git-enable-magit-gitflow-plugin)
-        magit-section
-        (magit-svn :toggle git-enable-magit-svn-plugin)
-        (magit-todos :toggle git-enable-magit-todos-plugin)
-        org
-        (orgit :requires org)
-        (orgit-forge :requires (org forge))
-        smeargle
-        transient))
+(defconst git-packages
+  '(
+    evil-collection
+    fill-column-indicator
+    ;; forge requires a C compiler on Windows so we disable
+    ;; it by default on Windows.
+    (forge :toggle (not (spacemacs/system-is-mswindows)))
+    ;; include the old git{attributes,config,ignore}-mode
+    git-modes
+    gitignore-templates
+    git-commit
+    git-link
+    git-messenger
+    git-timemachine
+    golden-ratio
+    (helm-git-grep :requires helm)
+    magit
+    (magit-delta :toggle git-enable-magit-delta-plugin)
+    (magit-gitflow :toggle git-enable-magit-gitflow-plugin)
+    magit-section
+    (magit-svn :toggle git-enable-magit-svn-plugin)
+    (magit-todos :toggle git-enable-magit-todos-plugin)
+    org
+    (orgit :requires org)
+    (orgit-forge :requires (org forge))
+    smeargle
+    transient))
 
 
 (defun git/pre-init-golden-ratio ()

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -21,14 +21,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq github-packages
-      '(
-        github-clone
-        github-search
-        grip-mode
-        ;; this package does not exits, we need it to wrap
-        ;; the call to spacemacs/declare-prefix.
-        (spacemacs-github :location built-in)))
+(defconst github-packages
+  '(
+    github-clone
+    github-search
+    grip-mode
+    ;; this package does not exits, we need it to wrap
+    ;; the call to spacemacs/declare-prefix.
+    (spacemacs-github :location built-in)))
 
 (defun github/init-github-clone ()
   (use-package github-clone

--- a/layers/+source-control/perforce/packages.el
+++ b/layers/+source-control/perforce/packages.el
@@ -21,7 +21,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq perforce-packages '(p4))
+(defconst perforce-packages
+  '(p4))
 
 (defun perforce/init-p4 ()
   (use-package p4

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -21,45 +21,45 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq spacemacs-defaults-packages
-      '(
-        (abbrev :location built-in)
-        (archive-mode :location built-in)
-        (bookmark :location built-in)
-        (buffer-menu :location built-in)
-        (conf-mode :location built-in)
-        (cus-edit :location built-in
-                  :toggle (or (eq 'vim dotspacemacs-editing-style)
-                              (eq 'hybrid dotspacemacs-editing-style)))
-        (dired :location built-in)
-        (dired-x :location built-in)
-        (image-dired :location built-in)
-        (display-line-numbers :location built-in)
-        (electric-indent-mode :location built-in)
-        (ediff :location built-in)
-        (eldoc :location built-in)
-        (help-fns+ :location local)
-        (hi-lock :location built-in)
-        (image-mode :location built-in)
-        (imenu :location built-in)
-        (occur-mode :location built-in)
-        (package-menu :location built-in)
-        ;; page-break-lines is shipped with spacemacs core
-        (page-break-lines :location built-in)
-        (process-menu :location built-in)
-        quickrun
-        (recentf :location built-in)
-        (savehist :location built-in)
-        (saveplace :location built-in)
-        (subword :location built-in)
-        (tar-mode :location built-in)
-        (uniquify :location built-in)
-        (url :location built-in)
-        (visual-line-mode :location built-in)
-        (whitespace :location built-in)
-        (winner :location built-in)
-        (xref :location built-in)
-        (zone :location built-in)))
+(defconst spacemacs-defaults-packages
+  '(
+    (abbrev :location built-in)
+    (archive-mode :location built-in)
+    (bookmark :location built-in)
+    (buffer-menu :location built-in)
+    (conf-mode :location built-in)
+    (cus-edit :location built-in
+              :toggle (or (eq 'vim dotspacemacs-editing-style)
+                          (eq 'hybrid dotspacemacs-editing-style)))
+    (dired :location built-in)
+    (dired-x :location built-in)
+    (image-dired :location built-in)
+    (display-line-numbers :location built-in)
+    (electric-indent-mode :location built-in)
+    (ediff :location built-in)
+    (eldoc :location built-in)
+    (help-fns+ :location local)
+    (hi-lock :location built-in)
+    (image-mode :location built-in)
+    (imenu :location built-in)
+    (occur-mode :location built-in)
+    (package-menu :location built-in)
+    ;; page-break-lines is shipped with spacemacs core
+    (page-break-lines :location built-in)
+    (process-menu :location built-in)
+    quickrun
+    (recentf :location built-in)
+    (savehist :location built-in)
+    (saveplace :location built-in)
+    (subword :location built-in)
+    (tar-mode :location built-in)
+    (uniquify :location built-in)
+    (url :location built-in)
+    (visual-line-mode :location built-in)
+    (whitespace :location built-in)
+    (winner :location built-in)
+    (xref :location built-in)
+    (zone :location built-in)))
 
 
 ;; Initialization of packages

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -21,36 +21,36 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq spacemacs-editing-packages
-      '(aggressive-indent
-        avy
-        (clean-aindent-mode :toggle dotspacemacs-use-clean-aindent-mode)
-        dired-quick-sort
-        drag-stuff
-        editorconfig
-        eval-sexp-fu
-        expand-region
-        (hexl :location built-in)
-        hungry-delete
-        link-hint
-        lorem-ipsum
-        (origami :toggle (eq 'origami dotspacemacs-folding-method))
-        password-generator
-        (persistent-scratch :toggle dotspacemacs-scratch-buffer-persistent)
-        pcre2el
-        (smartparens :toggle dotspacemacs-activate-smartparens-mode)
-        (evil-swap-keys :toggle dotspacemacs-swap-number-row)
-        (spacemacs-whitespace-cleanup :location local)
-        string-edit
-        string-inflection
-        multi-line
-        undo-tree
-        (unkillable-scratch :toggle dotspacemacs-scratch-buffer-unkillable)
-        uuidgen
-        (vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
-        (evil-vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
-        (evil-easymotion :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
-        ws-butler))
+(defconst spacemacs-editing-packages
+  '(aggressive-indent
+    avy
+    (clean-aindent-mode :toggle dotspacemacs-use-clean-aindent-mode)
+    dired-quick-sort
+    drag-stuff
+    editorconfig
+    eval-sexp-fu
+    expand-region
+    (hexl :location built-in)
+    hungry-delete
+    link-hint
+    lorem-ipsum
+    (origami :toggle (eq 'origami dotspacemacs-folding-method))
+    password-generator
+    (persistent-scratch :toggle dotspacemacs-scratch-buffer-persistent)
+    pcre2el
+    (smartparens :toggle dotspacemacs-activate-smartparens-mode)
+    (evil-swap-keys :toggle dotspacemacs-swap-number-row)
+    (spacemacs-whitespace-cleanup :location local)
+    string-edit
+    string-inflection
+    multi-line
+    undo-tree
+    (unkillable-scratch :toggle dotspacemacs-scratch-buffer-unkillable)
+    uuidgen
+    (vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
+    (evil-vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
+    (evil-easymotion :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
+    ws-butler))
 
 ;; Initialization of packages
 (defun spacemacs-editing/init-aggressive-indent ()
@@ -379,9 +379,10 @@
         "ipn" 'password-generator-numeric))))
 
 (defun spacemacs-editing/post-init-pcre2el ()
-  (spacemacs/declare-prefix "xr" "regular expressions")
-  (spacemacs/declare-prefix "xre" "elisp")
-  (spacemacs/declare-prefix "xrp" "pcre")
+  (spacemacs/declare-prefix
+    "xr"  "regular expressions"
+    "xre" "elisp"
+    "xrp" "pcre")
   (spacemacs/set-leader-keys
     "xr/"  'rxt-explain
     "xr'"  'rxt-convert-to-strings

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -21,14 +21,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq spacemacs-layouts-packages
-      '(eyebrowse
-        helm
-        ivy
-        persp-mode
-        spaceline
-        consult
-        (counsel-projectile :requires ivy)))
+(defconst spacemacs-layouts-packages
+  '(eyebrowse
+    helm
+    ivy
+    persp-mode
+    spaceline
+    consult
+    (counsel-projectile :requ ires ivy)))
 
 
 

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -21,15 +21,14 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq colors-packages
+(defconst colors-packages
   '(
     ;; not working well for now
     ;; rainbow-blocks
     (nyan-mode :location local)
     color-identifiers-mode
     rainbow-identifiers
-    rainbow-mode
-    ))
+    rainbow-mode))
 
 ;; (defun colors/init-rainbow-blocks ()
 ;;   (use-package rainbow-blocks

--- a/layers/+tools/dap/packages.el
+++ b/layers/+tools/dap/packages.el
@@ -105,19 +105,17 @@
                        "dwl" #'dap-ui-locals
                        "dws" #'dap-ui-sessions
                        "dwb" #'dap-ui-breakpoints))
-            (prefixes '(("d"  . "debug")
-                        ("db" . "breakpoints")
-                        ("dd" . "debugging")
-                        ("de" . "eval")
-                        ("dI" . "inspect")
-                        ("dS" . "switch")
-                        ("dT" . "toggles")
-                        ("dw" . "debug windows"))))
+            (prefixes '("d"  "debug"
+                        "db" "breakpoints"
+                        "dd" "debugging"
+                        "de" "eval"
+                        "dI" "inspect"
+                        "dS" "switch"
+                        "dT" "toggles"
+                        "dw" "debug windows")))
 
         ;; Set global prefixes
-        (mapc (lambda (cons)
-                (spacemacs/declare-prefix (car cons) (cdr cons)))
-              prefixes)
+        (spacemacs/declare-prefix prefixes)
 
         ;; Set global key bindings
         (apply #'spacemacs/set-leader-keys bindings)
@@ -130,13 +128,14 @@
           (spacemacs/set-leader-keys-for-major-mode mode "dd" nil)
 
           ;; Set prefixes
-          (mapc (lambda (cons)
-                  (spacemacs/declare-prefix-for-mode mode (concat "m" (car cons)) (cdr cons)))
-                prefixes)
+          (cl-do* ((x (prefixes) (cddr x))
+                   (y (cdr x) (cdr x)))
+              ((or (null x) (null y)))
+            (spacemacs/declare-prefix-for-mode mode
+              (concat "m" (car x)) (car y)))
 
           ;; Set bindings
           (apply #'spacemacs/set-leader-keys-for-major-mode mode bindings))))))
-
 
 
 (defun dap/init-posframe ()

--- a/layers/+tools/dap/packages.el
+++ b/layers/+tools/dap/packages.el
@@ -115,7 +115,7 @@
                         "dw" "debug windows")))
 
         ;; Set global prefixes
-        (spacemacs/declare-prefix prefixes)
+        (apply #'spacemacs/declare-prefix prefixes)
 
         ;; Set global key bindings
         (apply #'spacemacs/set-leader-keys bindings)
@@ -128,7 +128,7 @@
           (spacemacs/set-leader-keys-for-major-mode mode "dd" nil)
 
           ;; Set prefixes
-          (cl-do* ((x (prefixes) (cddr x))
+          (cl-do* ((x prefixes (cddr x))
                    (y (cdr x) (cdr x)))
               ((or (null x) (null y)))
             (spacemacs/declare-prefix-for-mode mode

--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -30,7 +30,12 @@
   (use-package eaf
     :init
     (progn
-      (spacemacs/declare-prefix "aa" "application-framework")
+      (spacemacs/declare-prefix
+        "aa"  "application-framework"
+        "aab" "browser"
+        "aabq" "quick-launch-website"
+        "aam" "mindmap")
+
       (spacemacs/set-leader-keys "aac" 'eaf-open-camera)
       (spacemacs/set-leader-keys "aaf" 'eaf-open)
       (spacemacs/set-leader-keys "aaj" 'eaf-open-jupyter)
@@ -39,18 +44,14 @@
       (spacemacs/set-leader-keys "aas" 'eaf-open-system-monitor)
       (spacemacs/set-leader-keys "aaM" 'eaf-open-music-player)
 
-      (spacemacs/declare-prefix "aab" "browser")
       (spacemacs/set-leader-keys "aabo" 'eaf-open-browser)
       (spacemacs/set-leader-keys "aabs" 'eaf-search-it)
       (spacemacs/set-leader-keys "aabb" 'eaf-open-bookmark)
       (spacemacs/set-leader-keys "aabh" 'eaf-open-browser-with-history)
 
-      (spacemacs/declare-prefix "aabq" "quick-launch-website")
       (spacemacs/set-leader-keys "aabqd" 'duckduckgo)
       (spacemacs/set-leader-keys "aabqw" 'wikipedia)
       (spacemacs/set-leader-keys "aabqy" 'youtube)
-
-      (spacemacs/declare-prefix "aam" "mindmap")
       (spacemacs/set-leader-keys "aamc" 'eaf-create-mindmap)
       (spacemacs/set-leader-keys "aamm" 'eaf-open-mindmap)
 
@@ -141,7 +142,6 @@
               ("<f5>" . "refresh_page")
               ("<f12>" . "open_devtools")
               ("<C-return>" . "eaf-send-ctrl-return-sequence")))
-
 
       (setq eaf-pdf-viewer-keybinding
             '(("j" . "scroll_up")

--- a/layers/+tools/geolocation/packages.el
+++ b/layers/+tools/geolocation/packages.el
@@ -21,16 +21,15 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq geolocation-packages
-      '(
-        (osx-location :toggle (and geolocation-enable-location-service
-                                   (spacemacs/system-is-mac)))
-        popwin
-        (rase :toggle (and geolocation-enable-location-service
-                           (spacemacs/system-is-mac)))
-        (sunshine :toggle geolocation-enable-weather-forecast)
-        (theme-changer :toggle geolocation-enable-automatic-theme-changer)
-        ))
+(defconst geolocation-packages
+  '(
+    (osx-location :toggle (and geolocation-enable-location-service
+                               (spacemacs/system-is-mac)))
+    popwin
+    (rase :toggle (and geolocation-enable-location-service
+                       (spacemacs/system-is-mac)))
+    (sunshine :toggle geolocation-enable-weather-forecast)
+    (theme-changer :toggle geolocation-enable-automatic-theme-changer)))
 
 (defun geolocation/init-osx-location ()
   "Initialize osx-location"

--- a/layers/+tools/pandoc/packages.el
+++ b/layers/+tools/pandoc/packages.el
@@ -21,10 +21,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq pandoc-packages
-      '(pandoc-mode
-        ox-pandoc
-        ))
+(defconst pandoc-packages
+  '(pandoc-mode
+    ox-pandoc))
 
 (defun pandoc/init-pandoc-mode ()
   "Initialize my package"

--- a/layers/+tools/pass/packages.el
+++ b/layers/+tools/pass/packages.el
@@ -21,14 +21,13 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq pass-packages
-      '(
-        (ivy-pass :requires ivy)
-        (helm-pass :requires helm)
-        auth-source-pass
-        password-store
-        password-store-otp
-        ))
+(defconst pass-packages
+  '(
+    (ivy-pass :requires ivy)
+    (helm-pass :requires helm)
+    auth-source-pass
+    password-store
+    password-store-otp))
 
 (defun pass/init-helm-pass ()
   (use-package helm-pass

--- a/layers/+tools/quickurl/packages.el
+++ b/layers/+tools/quickurl/packages.el
@@ -1,8 +1,8 @@
-;;; packages.el --- Reddit Layer packages File for Spacemacs
+;;; packages.el --- Quickurl dispatch layer.
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;
-;; Author: Benedikt Broich <b.broich@posteo.de>
+;; Author: Spenser Truex <web@spensertruex.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -20,16 +20,15 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+(defconst quickurl-packages
+  '(quickurl :location built-in))
 
-(defconst reddit-packages
-  '(reddigg))
-
-(defun reddit/init-reddigg ()
-  (use-package reddigg
-    :defer t
-    :init
-    (progn
-      (spacemacs/declare-prefix "awr" "reddit")
-      (spacemacs/set-leader-keys
-        "awrm" 'reddigg-view-main
-        "awrs" 'reddigg-view-sub))))
+(defun quickurl/init-quickurl ()
+  (spacemacs/declare-prefix "atq" "quickurl")
+  (spacemacs/set-leader-keys
+    "atql" 'quickurl-list
+    "atqq" 'quickurl
+    "atqi" 'quickurl-ask
+    "atqe" 'quickurl-edit-urls
+    "atqa" 'quickurl-add-url
+    "atqb" 'quickurl-browse-url-ask))

--- a/layers/+tools/ranger/packages.el
+++ b/layers/+tools/ranger/packages.el
@@ -22,12 +22,11 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(setq ranger-packages
-      '(
-        (dired :location built-in)
-        golden-ratio
-        ranger
-        ))
+(defconst ranger-packages
+  '(
+    (dired :location built-in)
+    golden-ratio
+    ranger))
 
 (defun ranger//set-leader-keys ()
   (spacemacs/declare-prefix "atr" "ranger/deer")

--- a/layers/+tools/vagrant/packages.el
+++ b/layers/+tools/vagrant/packages.el
@@ -20,8 +20,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(setq vagrant-packages '(vagrant
-                         vagrant-tramp))
+(defconst vagrant-packages
+  '(vagrant
+    vagrant-tramp))
 
 (defun vagrant/init-vagrant ()
   (use-package vagrant

--- a/layers/+web-services/evernote/packages.el
+++ b/layers/+web-services/evernote/packages.el
@@ -20,10 +20,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(setq evernote-packages
+(defconst evernote-packages
   '(
-    geeknote
-    ))
+    geeknote))
 
 (defun evernote/init-geeknote ()
   "Initializes geeknote and adds keybindings for its exposed functionalities."

--- a/layers/+web-services/streamlink/packages.el
+++ b/layers/+web-services/streamlink/packages.el
@@ -26,7 +26,8 @@
 (defun streamlink/init-streamlink ()
   (use-package streamlink
     :defer t
-    :init (progn
-            (spacemacs/declare-prefix "aws" "stream")
-            (spacemacs/set-leader-keys
-              "awss" 'streamlink-open-url))))
+    :init
+    (progn
+      (spacemacs/declare-prefix "aws" "stream")
+      (spacemacs/set-leader-keys
+        "awss" 'streamlink-open-url))))


### PR DESCRIPTION
- Updated usage of `spacemacs/declare-prefix`, which
  supports multiple pairs of replacements now.
- Replaced `setq` by `defconst` when declaring a layers'
  package list.
- Some other minor changes.