### PR TITLE
[org] integrate org-appear with evil when triggering manually

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2889,8 +2889,11 @@ files (thanks to Daniel Nicolai)
 - Fixed ocamlformat not properly initialized by following do (thanks to Nicolas Raymond)
 - Allow new OPAM share commandline syntax (thanks to Cody McKenzie)
 **** Org
+- When =org-appear= is set to be triggered manually and Spacemacs' editing mode is
+  Vim or hybrid, register relevant =org-appear= functions in Evil hooks for Org
+  buffers (thanks to Keith Pinson).
 - Provide some sane default strategies for enforcing =TODO= dependencies via
-  =org-todo-dependencies-strategy=. (thanks to Keith Pinson)
+  =org-todo-dependencies-strategy= (thanks to Keith Pinson).
 - Load org-mode email integration (mu4e/notmuch) when org is loaded
   (thanks to Steven Allen)
 - Packages:

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -548,6 +548,9 @@ To install [[https://github.com/awth13/org-appear][org-appear]], which toggles v
    '((org :variables org-enable-appear-support t)))
 #+END_SRC
 
+If you set =org-appear-trigger= to =manual= and your editing style is modal,
+=org-appear= will be on in insert mode but off in normal mode.
+
 ** Verb support
 To install [[https://github.com/federicotdn/verb][Verb]], an HTTP client based on Org mode, set the
 =org-enable-verb-support= variable to =t=:

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -1025,6 +1025,12 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :init
     (progn
       (add-hook 'org-mode-hook 'org-appear-mode)
+      (when (and (eq org-appear-trigger 'manual)
+                 (memq dotspacemacs-editing-style '(vim hybrid)))
+        (add-hook 'org-mode-hook
+                  (lambda ()
+                    (add-hook 'evil-insert-state-entry-hook #'org-appear-manual-start nil t)
+                    (add-hook 'evil-insert-state-exit-hook #'org-appear-manual-stop nil t))))
       (setq org-appear-autolinks t
             org-appear-autoemphasis t
             org-appear-autosubmarkers t))))


### PR DESCRIPTION
There is a little integration code that is necessary for using Evil with the latest feature of `org-appear`: manual triggering. This is exactly the kind of code that Spacemacs layer exist for: to integrate various packages. For more information, see the original [feature request](https://github.com/awth13/org-appear/issues/37) on `org-appear`.

I don't know much about the hybrid editing style so please correct me if I should only have applied this to the Vim editing style.