### PR TITLE
org: add binding for org-paste-subtree

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -747,6 +747,7 @@ are also available.
 | ~SPC m s b~   | org-tree-to-indirect-buffer     |
 | ~SPC m s d~   | org-cut-subtree                 |
 | ~SPC m s y~   | org-copy-subtree                |
+| ~SPC m s p~   | org-paste-subtree               |
 | ~SPC m s l~   | org-demote-subtree              |
 | ~SPC m s h~   | org-promote-subtree             |
 | ~SPC m s k~   | org-move-subtree-up             |

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -285,6 +285,7 @@ Will work on both org-mode and any mode that accepts plain html."
         "sb" 'org-tree-to-indirect-buffer
         "sd" 'org-cut-subtree
         "sy" 'org-copy-subtree
+        "sp" 'org-paste-subtree
         "sh" 'org-promote-subtree
         "sj" 'org-move-subtree-down
         "sk" 'org-move-subtree-up


### PR DESCRIPTION
There are already bindings for org-cut-subtree and org-copy-subtree; add a
binding for org-paste-subtree so that the user can make use of their freshly cut
or copied subtrees (and automatically paste them in a level-adjusted manner)