### PR TITLE
tabs: Rework

### DIFF
--- a/layers/+emacs/tabs/README.org
+++ b/layers/+emacs/tabs/README.org
@@ -6,7 +6,9 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
-- [[#hide-tabs][Hide tabs]]
+- [[#configuration][Configuration]]
+  - [[#selected-tab-bar][Selected tab bar]]
+  - [[#hide-tabs-after-a-delay][Hide tabs after a delay]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -21,27 +23,42 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =tabs= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-* Hide tabs
-You can set hooks for buffers in which it isn't desired to have tabs by
-customizing =centaur-tabs-hide-tabs-hooks=
+* Configuration
 
-Alternatively you can set ~tabs-auto-hide~ to ~t~ to auto hide tabs after some
-delay ~tabs-auto-hide-delay~ via the :variables keyword in your dotfile:
+** Selected tab bar
+To display a bar in the given direction to the selected tab, set =tabs-highlight-current-tab= to
+one of =left= (default), =under=, =over=.
+
+For example,
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+              '(tabs :variables tabs-highlight-current-tab 'left))
+#+END_SRC
+
+Note that this has no effect when Emacs is running in daemon mode.
+
+** Hide tabs after a delay
+You can set hooks for buffers in which it isn't desired to have tabs by
+customizing =centaur-tabs-hide-tabs-hooks=.
+
+Alternatively you can set =tabs-auto-hide= to =t= to auto hide tabs after some
+delay =tabs-auto-hide-delay= via the :variables keyword in your =.spacemacs=:
 
 #+BEGIN_SRC emacs-lisp
-  (tabs :variables
-        tabs-auto-hide t
-        tabs-auto-hide-delay 3)
+(setq-default dotspacemacs-configuration-layers
+              '(tabs :variables
+                     tabs-auto-hide t
+                     tabs-auto-hide-delay 3))
 #+END_SRC
 
 * Key bindings
 
 | Key binding | Description                                           |
 |-------------+-------------------------------------------------------|
-| ~C-{~       | Select the previous available tab                     |
-| ~C-}~       | Select the next available tab                         |
-| ~C-M-{~     | Move current tabe to left                             |
-| ~C-M-}~     | Move current tabe to right                            |
+| ~g t~       | Select the next available tab                         |
+| ~g T~       | Select the previous available tab                     |
+| ~g C-t~     | Move current tabe to right                            |
+| ~g C-T~     | Move current tabe to left                             |
 | ~C-c t s~   | Display a list of current buffer groups using Counsel |
 | ~C-c t p~   | Group buffer tabs by projectile                       |
 | ~C-c t g~   | Group buffer tabs by groups                           |

--- a/layers/+emacs/tabs/config.el
+++ b/layers/+emacs/tabs/config.el
@@ -20,56 +20,27 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+(spacemacs|defc tabs-selected-tab-baar 'left
+  "When non-nil, display a bar next to the current selected tab in the given direction.
 
-(defvaralias 'tabs-navigation 'centaur-tabs-cycle-scope
-  "*Specify the scope of cyclic navigation through tabs.
-The following scopes are possible:
+If Emacs is running in daemon mode, this is turned off regardless of the setting."
+  '(choice (const left) (const over) (const under)))
 
-- `tabs'
-    Navigate through visible tabs only.
-- `groups'
-    Navigate through tab groups only.
-- nil
-    Navigate through visible tabs, then through tab groups.")
-
-(defvaralias 'tabs-gray-out-unselected 'centaur-tabs-gray-out-icons)
-
-(defvaralias 'tabs-height 'centaur-tabs-height)
-
-(defvaralias 'tabs-show-icons 'centaur-tabs-set-icons)
-
-(defvaralias 'tabs-set-modified-marker 'centaur-tabs-set-modified-marker)
-
-(defvaralias 'tabs-modified-marker 'centaur-tabs-modified-marker)
-
-(defvaralias 'tabs-show-navigation-buttons 'centaur-tabs-show-navigation-buttons)
-
-(defvaralias 'tabs-style 'centaur-tabs-style
-  "Style of tab.
-Available values are \"bar\", \"alternate\", \"box\",
-\"chamfer\", \"rounded\", \"slant\", \"wave\", \"zigzag\" ")
-
-(defvaralias 'tabs-set-bar 'centaur-tabs-set-bar)
-
-(defcustom tabs-group-by-project t
+(spacemacs|defc tabs-group-by-project t
   "When non-nil, group tabs by projectile project.
 Default t. If non-nil calls (tabs-group-by-projectile-project)
 Otherwise calls (tabs-group-buffer-groups)"
-:type '(boolean)
-:group 'tabs)
+  '(boolean))
 
-(defcustom tabs-headline-match t
+(spacemacs|defc tabs-headline-match t
   "When non-nil, make headline use tabs-default-face. Default t.
 Calls (tabs-headline-match)"
-:type '(boolean)
-:group 'tabs)
+  '(boolean))
 
-(defcustom tabs-auto-hide nil
+(spacemacs|defc tabs-auto-hide nil
   "If non-nil hide tabs automatically after TABS-AUTO-HIDE-DELAY seconds."
-  :type '(boolean)
-  :group 'tabs)
+  '(boolean))
 
-(defcustom tabs-auto-hide-delay 2
+(spacemacs|defc tabs-auto-hide-delay 2
   "Tabs auto hide delay in seconds."
-  :type '(float)
-  :group 'tabs)
+  '(float))

--- a/layers/+emacs/tabs/funcs.el
+++ b/layers/+emacs/tabs/funcs.el
@@ -1,3 +1,25 @@
+;;; funcs.el --- tabs layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2018, 2020 Sylvain Benner & Contributors
+;;
+;; Author: Deepu Puthrote <git@deepumohan.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 (defun spacemacs//tabs-timer-initialize (secs)
   (setq spacemacs-tabs-timer (run-with-timer secs nil (lambda () (centaur-tabs-local-mode 1)))))
 

--- a/layers/+emacs/tabs/packages.el
+++ b/layers/+emacs/tabs/packages.el
@@ -27,27 +27,34 @@
 (defun tabs/init-centaur-tabs ()
   (use-package centaur-tabs
     :demand
+    :custom
+    (centaur-tabs-set-icons t)
+    (centaur-tabs-set-modified-marker t)
+    (centaur-tabs-modified-marker "⚠")
+    (centaur-tabs-cycle-scope 'tabs)
     :config
-    (setq tabs-show-icons t
-          tabs-set-modified-marker t
-          tabs-modified-marker "⚠"
-          tabs-set-bar 'left)
-    (when tabs-headline-match
-      (centaur-tabs-headline-match))
-    (if tabs-group-by-project
-        (centaur-tabs-group-by-projectile-project)
-      (centaur-tabs-group-buffer-groups))
-    (centaur-tabs-mode t)
+    (progn
+      (unless (daemonp)
+        (setq centaur-tabs-set-bar tabs-selected-tab-bar))
+      (when tabs-headline-match
+        (centaur-tabs-headline-match))
+      (if tabs-group-by-project
+          (centaur-tabs-group-by-projectile-project)
+        (centaur-tabs-group-buffer-groups))
+      (centaur-tabs-mode t)
 
-    (when tabs-auto-hide
-      (add-hook 'window-setup-hook 'spacemacs//tabs-timer-hide)
-      (add-hook 'find-file-hook 'spacemacs//tabs-timer-hide)
-      (add-hook 'change-major-mode-hook 'spacemacs//tabs-timer-hide))
+      (when tabs-auto-hide
+        (add-hook 'window-setup-hook 'spacemacs//tabs-timer-hide)
+        (add-hook 'find-file-hook 'spacemacs//tabs-timer-hide)
+        (add-hook 'change-major-mode-hook 'spacemacs//tabs-timer-hide))
+
+      (which-key-add-keymap-based-replacements evil-normal-state-map  "C-c t" "tab"))
     :bind
-    ("C-{" . spacemacs/tabs-backward)
-    ("C-}" . spacemacs/tabs-forward)
-    ("C-M-{" . centaur-tabs-move-current-tab-to-left)
-    ("C-M-}" . centaur-tabs-move-current-tab-to-right)
+    (:map evil-normal-state-map
+          ("g t"     . spacemacs/tabs-forward)
+          ("g T"     . spacemacs/tabs-backward)
+          ("g C-t"   . centaur-tabs-move-current-tab-to-right)
+          ("g C-S-t" . centaur-tabs-move-current-tab-to-left))
     ("C-c t s" . centaur-tabs-counsel-switch-group)
     ("C-c t p" . centaur-tabs-group-by-projectile-project)
     ("C-c t g" . centaur-tabs-group-buffer-groups)))


### PR DESCRIPTION
- Replaced tab movement commands key bindings with
  vim-style bindings:
  - <kbd>g t</kbd>/<kbd>g T</kbd> for going to next/previous tab
    (instead of <kbd>Ctrl-{</kbd>/<kbd>Ctrl-}</kbd>)
  - <kbd>g Ctrl-t</kbd>/<kbd>g Ctrl-T</kbd> for moving current
    tab to right/left
    (instead of <kbd>Ctrl-Meta-{</kbd>/<kbd>Ctrl-Meta-}</kbd>)
- Removed unused layer variables from config.el
- Improved documentation in README.org
- Added header in funcs.el