### PR TITLE
spacemacs-defaults: Added prompt to save a buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -237,5 +237,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; used for restoring recently killed buffers.
 (add-hook 'kill-buffer-hook #'spacemacs//add-buffer-to-killed-list)
 
+;; Ask to save a buffer (with no file associated) to a file before `kill-buffer'.
+(add-hook 'kill-buffer-hook #'spacemacs//confirm-kill-buffer)
+
 ;; Don't load outdated compiled files.
 (setq load-prefer-newer t)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -668,6 +668,29 @@ If the universal prefix argument is used then kill the windows too."
     (when (equal '(4) arg) (delete-other-windows))
     (message "Buffers deleted!")))
 
+(defun spacemacs//confirm-kill-buffer ()
+  "Prompt the user to save a buffer to a file before killing it.
+
+This skips the following buffers:
+- A buffer with non-nil value of variable `buffer-file-name'.
+  Or in other words, a buffer who has a file associated with.
+  Emacs by default prompts the user to save it if it's modified.
+- A buffer which is derived from `special-mode'.
+- A buffer with special name that starts with whitespace(s)
+  and/or have buffer name surrounded by asterisks \"*\". Except
+  for the scratch buffer, namely \"*scratch*\"."
+  (when (and (not buffer-file-name)
+             (buffer-modified-p)
+             (not (derived-mode-p 'special-mode)))
+    (let ((name (buffer-name))
+          (regexp "\\*[[:print:]]+\\*"))
+      (when (and (not (string-equal name ""))     ;; skip empty buffer name
+                 (/= (aref name 0) ?\s)           ;; buffer name starts with whitespace is special
+                 (or (string-equal "*scratch*" name) ;; *BUFFER_NAME* is skipped, except *scratch*
+                     (not (string-match regexp name)))
+                 (not (yes-or-no-p (format "Buffer %S modified; kill anyway? " (buffer-name)))))
+        (save-buffer)))))
+
 ;; from http://dfan.org/blog/2009/02/19/emacs-dedicated-windows/
 (defun spacemacs/toggle-current-window-dedication ()
   "Toggle dedication state of a window. Commands that change the buffer that a


### PR DESCRIPTION
Added a new `kill-buffer-hook` that prompt the user to save a buffer
before killing it.

closes #12857