### PR TITLE
core-spacemacs-buffer: remoe org (agenda) files from recent files

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1188,7 +1188,13 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
 (defun spacemacs-buffer//insert-recent-files (list-size)
   (unless recentf-mode (recentf-mode))
   (setq spacemacs-buffer//recent-files-list
-        (spacemacs//subseq recentf-list 0 list-size))
+        (cl-delete-if (lambda (x)
+                        (or (when (and org-directory (file-exists-p org-directory))
+                              (member x (directory-files org-directory t)))
+                            (member x (mapcar #'expand-file-name org-agenda-files))))
+                      recentf-list))
+  (setq spacemacs-buffer//recent-files-list
+        (spacemacs//subseq spacemacs-buffer//recent-files-list 0 list-size))
   (when (spacemacs-buffer//insert-file-list
          "Recent Files:"
          spacemacs-buffer//recent-files-list)


### PR DESCRIPTION
If `dotspacemacs-startup-lists` contains `recents`, it shows recently opened
files.

This commit will hide any file if it's in `org-directory` or if it is one of
`org-agenda-files`.

fixes #15305