### PR TITLE
spacemacs-buffer: allow 'kp-*' keys for jump to number

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1343,7 +1343,10 @@ can be adjusted with the variable:
   (interactive)
   (when spacemacs-buffer--idle-numbers-timer
     (cancel-timer spacemacs-buffer--idle-numbers-timer))
-  (let* ((key-pressed-string (string last-input-event)))
+  (let* ((key-pressed-string (string-trim-left (if (characterp last-input-event)
+                                                   (string last-input-event)
+                                                 (format "%s" last-input-event))
+                                               "kp-")))
     (setq spacemacs-buffer--startup-list-number
           (concat spacemacs-buffer--startup-list-number key-pressed-string))
     (let (message-log-max) ; only show in minibuffer


### PR DESCRIPTION
Before this commit, users may use any digit keys to jump to an item
with same number in startup list.
This commit further allows the user to use numerical keyboard keys
for the same functionality.