### PR TITLE
[auto-completion] remove deprecate auto-complete based packages

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -14,13 +14,11 @@
   - [[#sort-results-by-usage][Sort results by usage]]
   - [[#disable-auto-completion-in-specific-layers][Disable auto-completion in specific layers]]
   - [[#enable-company-globally][Enable company globally]]
-  - [[#replacing-company-by-auto-complete][Replacing company by auto-complete]]
   - [[#add-auto-completion-in-a-layer][Add auto-completion in a layer]]
   - [[#completion-back-ends][Completion back ends]]
   - [[#improved-faces][Improved faces]]
 - [[#key-bindings-1][Key bindings]]
   - [[#company][Company]]
-  - [[#auto-complete][Auto-complete]]
   - [[#yasnippet][Yasnippet]]
   - [[#auto-yasnippet][Auto-yasnippet]]
 
@@ -28,7 +26,7 @@
 This layer adds auto-completion to all supported language layers.
 
 ** Features:
-- Support for code completion with [[http://company-mode.github.io/][company]] or [[https://github.com/auto-complete/auto-complete][auto-complete]] for various language layers
+- Support for code completion with [[http://company-mode.github.io/][company]]
 - Frequency-based suggestions via [[https://github.com/company-mode/company-statistics][company-statistics]] for =company=
 - Integration with [[https://github.com/capitaomorte/yasnippet][yasnippet]] and [[https://github.com/abo-abo/auto-yasnippet][auto-yasnippet]]
 - Automatic configuration of [[https://www.emacswiki.org/emacs/HippieExpand][hippie-expand]]
@@ -163,10 +161,6 @@ for the major-modes where it is missing.
 If you choose to use =(global-company-mode)= then you would lose some advantages
 provided by the layer system like [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#disabling-layer-services-in-other-layers][disabling auto-completion for specific layers]].
 
-** Replacing company by auto-complete
-You can disable =company= by adding it to the =dotspacemacs-excluded-packages=
-variable, then you are free to enable =auto-complete= globally.
-
 ** Add auto-completion in a layer
 Here is an example to add =company= auto-completion to python buffers via the
 package =company-anaconda=.
@@ -239,16 +233,6 @@ Emacs style:
 |-------------+------------------------------------------------|
 | ~C-n~       | (emacs style) go down in company dropdown menu |
 | ~C-p~       | (emacs style) go up in company dropdown menu   |
-
-** Auto-complete
-
-| Key binding | Description                                                          |
-|-------------+----------------------------------------------------------------------|
-| ~C-j~       | select next candidate                                                |
-| ~C-k~       | select previous candidate                                            |
-| ~TAB~       | expand selection or select next candidate                            |
-| ~S-TAB~     | select previous candidate                                            |
-| ~RET~       | complete word, if word is already completed insert a carriage return |
 
 ** Yasnippet
 

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -24,8 +24,6 @@
 (defconst auto-completion-packages
       '(
         auto-yasnippet
-        auto-complete
-        ac-ispell
         company
         (company-box :toggle auto-completion-use-company-box)
         (all-the-icons :toggle auto-completion-use-company-box)
@@ -40,47 +38,6 @@
         smartparens
         yasnippet
         yasnippet-snippets))
-
-
-;; TODO replace by company-ispell which comes with company
-;; to be moved to spell-checking layer as well
-(defun auto-completion/init-ac-ispell ()
-  (use-package ac-ispell
-    :defer t
-    :init
-    (progn
-      (setq ac-ispell-requires 4)
-      (with-eval-after-load 'auto-complete
-        (ac-ispell-setup)))))
-;; (add-hook 'markdown-mode-hook 'ac-ispell-ac-setup)
-
-
-(defun auto-completion/init-auto-complete ()
-  (use-package auto-complete
-    :defer t
-    :init
-    (setq ac-auto-start 0
-          ac-delay auto-completion-idle-delay
-          ac-quick-help-delay 1.
-          ac-use-fuzzy t
-          ac-fuzzy-enable t
-          ac-comphist-file (concat spacemacs-cache-directory "ac-comphist.dat")
-          ;; use 'complete when auto-complete is disabled
-          tab-always-indent 'complete
-          ac-dwim t)
-    :config
-    (progn
-      (require 'auto-complete-config)
-      (setq-default ac-sources '(ac-source-abbrev
-                                 ac-source-dictionary
-                                 ac-source-words-in-same-mode-buffers))
-      (when (configuration-layer/package-used-p 'yasnippet)
-        (add-to-list 'ac-sources 'ac-source-yasnippet))
-      (add-to-list 'completion-styles 'initials t)
-      (define-key ac-completing-map (kbd "C-j") 'ac-next)
-      (define-key ac-completing-map (kbd "C-k") 'ac-previous)
-      (define-key ac-completing-map (kbd "<S-tab>") 'ac-previous)
-      (spacemacs|diminish auto-complete-mode " ⓐ" " a"))))
 
 (defun auto-completion/init-auto-yasnippet ()
   (use-package auto-yasnippet


### PR DESCRIPTION
Friendship ends with https://github.com/auto-complete/auto-complete. Now company-mode is our best friend.