### PR TITLE
[iedit] use fork

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -73,20 +73,6 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
       (evil-escape-mode t)
     (evil-escape-mode -1)))
 
-(defmacro evil-redirect-digit-argument (map keys target)
-  "This is a temporary fix.
-This is a temporary fix until the PR at URL
-`https://github.com/syl20bnr/evil-iedit-state/pull/37' gets
-merged. Please remove this function as soon as the mentioned PR
-gets merged."
-  (message "This is a temporary fix until
-https://github.com/syl20bnr/evil-iedit-state/pull/37 gets merged.
-Please remove this function as soon as the mentioned PR gets
-merged.")
-  `(define-key ,map ,keys ,target))
-
-;;; Needed while https://github.com/syl20bnr/evil-iedit-state/pull/37 is not merged
-(defalias 'evil-digit-argument-or-evil-beginning-of-line 'evil-beginning-of-line)
 
 ;; vi-tilde-fringe
 

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -31,7 +31,9 @@
         evil-escape
         evil-exchange
         evil-goggles
-        evil-iedit-state
+        (evil-iedit-state :location (recipe
+                                     :fetcher github
+                                     :repo "kassick/evil-iedit-state"))
         evil-indent-plus
         evil-lion
         evil-lisp-state

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -31,6 +31,9 @@
         evil-escape
         evil-exchange
         evil-goggles
+        ;; This is a temporary fix until the PR at URL
+        ;; `https://github.com/syl20bnr/evil-iedit-state/pull/37' gets
+        ;; merged.
         (evil-iedit-state :location (recipe
                                      :fetcher github
                                      :repo "kassick/evil-iedit-state"))


### PR DESCRIPTION
Revert "Improve temporary fix for evil-redirect-digit-argument"

This reverts commit d3071ae37bbd3a527e3ad429d6f0e8f9bfd8c980.

Revert "Add temporary fix for `evil-redirect-digit-argument` error"

This reverts commit 23367d08f890873e77fd9a434c9332cf53d5f9df.

The change for the original iedit is so tiny but sadly the owner never has time to merge it. We should use the fork for now instead of all the dirty hacks we put on us.