### PR TITLE
eww: cleaned up

### DIFF
--- a/layers/+web/eww/config.el
+++ b/layers/+web/eww/config.el
@@ -1,0 +1,33 @@
+;;; config.el --- EWW Layer Configuration File for Spacemacs
+;;
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
+;;
+;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defvar spacemacs--eww-buffers nil
+  "A list of EWW buffers maintained by Spacemacs EWW layer.")
+
+(defvar spacemacs--eww-ts-full-hint-toggle t
+  "Toggle the state of the eww transient state documentation.")
+
+(defvar spacemacs--eww-ts-full-hint nil
+  "Display full pdf transient state documentation.")
+
+(defvar spacemacs--eww-ts-minified-hint nil
+  "Display minified pdf transient state documentation.")

--- a/layers/+web/eww/packages.el
+++ b/layers/+web/eww/packages.el
@@ -1,6 +1,6 @@
 ;;; packages.el --- EWW Layer packages File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
 ;; Author: Colton Kopsa <coljamkop@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -22,20 +22,29 @@
 
 (defconst eww-packages
   '(
+    evil
     (eww :location built-in)
-    texfrag))
-;; (ace-link :location elpa)
-;; (helm-net :location elpa)
+    texfrag
+    writeroom-mode
+    zoom-frm))
+
+(defun eww/post-init-evil ()
+  (spacemacs/transient-state-register-add-bindings 'eww
+    '(("j" evil-next-line)
+      ("k" evil-previous-line)
+      ("h" evil-backward-char)
+      ("l" evil-forward-char))))
 
 (defun eww/init-eww ()
   (use-package eww
     :defer t
     :init
-    (add-to-list 'evil-buffer-regexps '("\\*eww\\*" . normal))
-    (spacemacs//eww-setup-transient-state)
-    (spacemacs/declare-prefix "awe" "eww")
-    (spacemacs/set-leader-keys "awee" 'eww)
-    (spacemacs/set-leader-keys "awew" 'eww-switch-to-buffer)
+    (progn
+      (add-to-list 'evil-buffer-regexps '("\\*eww\\*" . normal))
+      (spacemacs//eww-setup-transient-state)
+      (spacemacs/declare-prefix "awe" "eww")
+      (spacemacs/set-leader-keys "awee" 'eww)
+      (spacemacs/set-leader-keys "awew" 'eww-switch-to-buffer))
     :config
     (progn
       (define-key eww-link-keymap "f" 'eww-follow-link)
@@ -46,7 +55,7 @@
         (spacemacs/set-leader-keys-for-major-mode mode
           "s" 'helm-google-suggest
           "S" 'browse-web
-          "t" 'spacemacs/eww-render-latex
+          "t" 'spacemacs/eww-toggle-render-latex
           "r" 'eww-reload
           "p" 'eww-previous-url
           "n" 'eww-next-url
@@ -70,7 +79,6 @@
           "H" 'spacemacs/eww-jump-previous-buffer
           (kbd "C-j") 'shr-next-link
           (kbd "C-k") 'shr-previous-link
-          "o" 'ace-link-eww
           "+" 'zoom-frm-in
           "-" 'zoom-frm-out
           "=" 'zoom-frm-unzoom))
@@ -108,3 +116,13 @@
 (defun eww/init-texfrag ()
   (use-package texfrag
     :defer t))
+
+(defun eww/post-init-writeroom-mode ()
+  (spacemacs/transient-state-register-add-bindings 'eww
+    '(("w" writeroom-mode))))
+
+(defun eww/post-init-zoom-frm ()
+  (spacemacs/transient-state-register-add-bindings 'eww
+    '(("+" zoom-frm-in)
+      ("-" zoom-frm-out)
+      ("=" zoom-frm-unzoom))))


### PR DESCRIPTION
- Moved nested functions out
- Moved variables declarations to config.el
- Moved transient state bindings for `textfrag`, `writeroom-mode`,
  and `zoom-frm` to their respective `post-ini` functions.

Signed-off-by: Lucius Hu <lebensterben@users.noreply.github.com>