### PR TITLE
Fix the use of consult--source-project-file

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -199,7 +199,7 @@
      :preview-key '(:debounce 0.2 any)
      consult-ripgrep consult-git-grep consult-grep
      consult-bookmark consult-recent-file consult-xref
-     consult--source-recent-file consult--source-project-file consult--source-bookmark
+     consult--source-recent-file consult--source-project-recent-file consult--source-bookmark
      spacemacs/compleseus-search-auto
      spacemacs/compleseus-search-dir
      spacemacs/compleseus-search-projectile


### PR DESCRIPTION
consult--source-project-file has also been renamed/deprecated. It is now called consult--source-project-recent-file.
