### PR TITLE
Add basic LSP support to NixOS layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2855,6 +2855,7 @@ files (thanks to Daniel Nicolai)
   function (thanks to Profpatsch)
 - Associate nix-mode with .nix files (thanks to jpathy)
 - Updated layer banner (thanks to kalium)
+- Added experimental LSP support (thanks to LuisChDev)
 **** Nim
 - Added key binding ~SPC m h h~ to show symbol documentation
   (thanks to Valts Liepiņš)

--- a/layers/+os/nixos/README.org
+++ b/layers/+os/nixos/README.org
@@ -9,9 +9,10 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#format-on-save][Format on save]]
 - [[#configuration][Configuration]]
   - [[#enabling-lsp-experimental][Enabling LSP (Experimental)]]
+  - [[#format-on-save][Format on save]]
+  - [[#opt-out-from-auto-complete][Opt-out from =auto-complete=]]
 - [[#key-bindings][Key bindings]]
   - [[#nixos-options][NixOS Options]]
 
@@ -23,7 +24,7 @@ This layer adds tools for better integration of Emacs in NixOS.
 - Automatic formatting via [[https://github.com/serokell/nixfmt][nixfmt]]
 - Auto-completion of NixOS Options using [[https://github.com/travisbhartwell/nix-emacs/blob/master/company-nixos-options.el][company-nixos-options]]
 - Helm Lookup for NixOS Options [[https://github.com/travisbhartwell/nix-emacs/blob/master/helm-nixos-options.el][helm-nixos-options]]
-- WIP support for LSP backend using ~rnix-lsp~
+- WIP support for LSP backend using =rnix-lsp=
 
 * Install
 ** Layer
@@ -31,27 +32,35 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =nixos= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** Format on save
-To enable automatic formatting on save, set the layer variable
-~nixos-format-on-save~ to ~t~:
-
-#+BEGIN_SRC elisp
-  (nixos :variables nixos-format-on-save t)
-#+END_SRC
-
 * Configuration
-On some systems, =company-nixos-options= may be very slow. If this is the case,
-see the section on disabling the [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#disabling-layer-services-in-other-layers][disabling auto-complete]] for the =nixos= layer.
-
 ** Enabling LSP (Experimental)
-Change =nixos= to =(nixos :variables nix-backend 'lsp)= in your =~./spacemacs=.
+To use the /experimental/ LSP backend, set variable =nix-backend= to =lsp= in
+your =~./spacemacs=. (You would also need to enable [[../../+tools/lsp/README.org][LSP]] layer).
 
-To install [[https://github.com/nix-community/rnix-lsp][rnix-lsp]] from nix, run this command:
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                (nixos :variables nixos-backend 'lsp))
+#+end_src
 
-#+BEGIN_SRC bash
+To install [[https://github.com/nix-community/rnix-lsp][rnix-lsp]] from =nix=, run the following command in shell:
+
+#+BEGIN_SRC shell
   nix-env -i -f https://github.com/nix-community/rnix-lsp/archive/master.tar.gz
 #+END_SRC
 
+** Format on save
+To enable automatic formatting on save, set the layer variable
+=nixos-format-on-save= to =t=:
+
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers
+                (nixos :variables nixos-format-on-save t))
+#+END_SRC
+
+** Opt-out from =auto-complete=
+
+On some systems, =company-nixos-options= may be very slow. If this is the case,
+see the section on disabling the [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#disabling-layer-services-in-other-layers][disabling auto-complete]] for the =nixos= layer.
 
 * Key bindings
 ** NixOS Options

--- a/layers/+os/nixos/README.org
+++ b/layers/+os/nixos/README.org
@@ -11,6 +11,7 @@
   - [[#layer][Layer]]
   - [[#format-on-save][Format on save]]
 - [[#configuration][Configuration]]
+  - [[#enabling-lsp-experimental][Enabling LSP (Experimental)]]
 - [[#key-bindings][Key bindings]]
   - [[#nixos-options][NixOS Options]]
 
@@ -22,6 +23,7 @@ This layer adds tools for better integration of Emacs in NixOS.
 - Automatic formatting via [[https://github.com/serokell/nixfmt][nixfmt]]
 - Auto-completion of NixOS Options using [[https://github.com/travisbhartwell/nix-emacs/blob/master/company-nixos-options.el][company-nixos-options]]
 - Helm Lookup for NixOS Options [[https://github.com/travisbhartwell/nix-emacs/blob/master/helm-nixos-options.el][helm-nixos-options]]
+- WIP support for LSP backend using ~rnix-lsp~
 
 * Install
 ** Layer
@@ -40,6 +42,16 @@ To enable automatic formatting on save, set the layer variable
 * Configuration
 On some systems, =company-nixos-options= may be very slow. If this is the case,
 see the section on disabling the [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#disabling-layer-services-in-other-layers][disabling auto-complete]] for the =nixos= layer.
+
+** Enabling LSP (Experimental)
+Change =nixos= to =(nixos :variables nix-backend 'lsp)= in your =~./spacemacs=.
+
+To install [[https://github.com/nix-community/rnix-lsp][rnix-lsp]] from nix, run this command:
+
+#+BEGIN_SRC bash
+  nix-env -i -f https://github.com/nix-community/rnix-lsp/archive/master.tar.gz
+#+END_SRC
+
 
 * Key bindings
 ** NixOS Options

--- a/layers/+os/nixos/funcs.el
+++ b/layers/+os/nixos/funcs.el
@@ -1,6 +1,6 @@
-;;; config.el --- nixos Layer Configuration File for Spacemacs
+;;; funcs.el --- NixOS Layer functions File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -20,11 +20,12 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+(defun spacemacs//nix-setup-backend ()
+  "setup the nix backend used."
+  (when (eq nix-backend 'lsp) (spacemacs//nix-setup-lsp)))
 
-;; variables
-
-(defvar nixos-format-on-save nil
-  "If non-nil, nixfmt before saving.")
-
-(defvar nix-backend nil
-  "The backend used for completion. possible values are `lsp' or `nil'.")
+(defun spacemacs//nix-setup-lsp ()
+  "Setup lsp backend."
+  (if (configuration-layer/layer-used-p 'lsp)
+      (lsp-deferred)
+    (spacemacs//lsp-layer-not-installed-message)))

--- a/layers/+os/nixos/layers.el
+++ b/layers/+os/nixos/layers.el
@@ -1,6 +1,6 @@
-;;; config.el --- nixos Layer Configuration File for Spacemacs
+;;; layers.el --- NixOS Layer functions File for Spacemacs
 ;;
-;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
@@ -20,11 +20,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-;; variables
-
-(defvar nixos-format-on-save nil
-  "If non-nil, nixfmt before saving.")
-
-(defvar nix-backend nil
-  "The backend used for completion. possible values are `lsp' or `nil'.")
+(when (and (boundp 'nix-backend)
+           (eq nix-backend 'lsp))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -54,6 +54,7 @@
     :mode "\\.nix\\'"
     :init
     (progn
+      (spacemacs/add-to-hook 'nix-mode-hook '(spacemacs//nix-setup-backend))
       (add-to-list 'spacemacs-indent-sensitive-modes 'nix-mode)
       (spacemacs/set-leader-keys-for-major-mode 'nix-mode
         "==" 'nix-format-buffer)


### PR DESCRIPTION
Add support for rnix-lsp. This is still largely experimental,
so it remains opt-in even if the LSP layer is enabled.