### PR TITLE
Fix tab key functionality in pdf outline mode

### DIFF
--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -108,7 +108,7 @@
         "gh"               'pdf-outline-up-heading
         "gg"               'beginning-of-buffer
         "G"                'pdf-outline-end-of-buffer
-        "TAB"              'outline-toggle-children
+        (kbd "<tab>")      'outline-toggle-children
         "RET"              'pdf-outline-follow-link
         (kbd "M-RET")      'pdf-outline-follow-link-and-quit
         "f"                'pdf-outline-display-link


### PR DESCRIPTION
For some reason the current 'syntax' for setting the TAB key functionality in pdf outline work does not work.
The small syntax change in this PR fixes the issue.