### PR TITLE
compleseus: corrects name of some renamed consul commands

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -114,7 +114,7 @@
            ("M-g m" . consult-mark)
            ("M-g k" . consult-global-mark)
            ("M-g i" . consult-imenu)
-           ("M-g I" . consult-project-imenu)
+           ("M-g I" . consult-imenu-multi)
            ;; M-s bindings (search-map)
            ("M-s f" . consult-find)
            ("M-s L" . consult-locate)
@@ -126,10 +126,10 @@
            ("M-s k" . consult-keep-lines)
            ("M-s u" . consult-focus-lines)
            ;; Isearch integration
-           ("M-s e" . consult-isearch)
+           ("M-s e" . consult-isearch-history)
            :map isearch-mode-map
-           ("M-e" . consult-isearch)                 ;; orig. isearch-edit-string
-           ("M-s e" . consult-isearch)               ;; orig. isearch-edit-string
+           ("M-e" . consult-isearch-history)         ;; orig. isearch-edit-string
+           ("M-s e" . consult-isearch-history)       ;; orig. isearch-edit-string
            ("M-s l" . consult-line))                 ;; needed by consult-line to detect isearch
 
     ;; Enable automatic preview at point in the *Completions* buffer.


### PR DESCRIPTION
Some of the consul function names changed slightly.

Note that vertico is now on ELPA as well. But I couldn't figure out how to handle the extension packages. They are part of the vertico package and I don't know how to reference the extension directory and files inside the vertico package.

