### PR TITLE
unicode-fonts: ligature.el requires Emacs 28 +

### DIFF
--- a/layers/+fonts/unicode-fonts/README.org
+++ b/layers/+fonts/unicode-fonts/README.org
@@ -17,7 +17,7 @@ install the fonts listed in the [[https://github.com/rolandwalker/unicode-fonts#
 - Easily override glyphs or sections of glyphs.
 - Display color emoji on both the macOS port version of Emacs and emacs-plus (with
   =unicode-fonts-force-multi-color-on-mac= set to non nil).
-- Enable support for font ligature in Emacs 27 + via [[https://github.com/mickeynp/ligature.el][ligatures.el]].
+- Enable support for font ligature in Emacs 28 + via [[https://github.com/mickeynp/ligature.el][ligatures.el]].
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to


### PR DESCRIPTION
From [ligatures.el](https://github.com/mickeynp/ligature.el#compatibility-and-version-requirements) README:

> You must use Emacs 28 or later, or backport a fix to Emacs 27.x;
> 
> You can check by typing M-x emacs-version.
> 
> NOTE: There are critical issues in Emacs 27.1 and 27.2. Ideally, if at all possible, you should attempt to use a build of Emacs that includes this fix. See below for details.
> 