### PR TITLE
Improve helm completion in spacemacs help

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -816,6 +816,7 @@ Other:
     default (thanks to Daniel Nicolai)
   - Add evil-jump-backward/forward (=C-o=/=C-i=) keybindings to
     evil-evilified-state-map (thanks to Daniel Nicolai)
+  - Improve helm completion in spacemacs-help (thanks to @dankessler)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -170,24 +170,24 @@
 
 (defun helm-spacemacs-help//layer-source ()
   "Construct the helm source for the layer section."
-  `((name . "Layers")
-    (candidates . ,(sort (configuration-layer/get-layers-list) 'string<))
-    (candidate-number-limit)
-    (keymap . ,helm-spacemacs-help--layer-map)
-    (action . (("Open README.org"
-                . helm-spacemacs-help//layer-action-open-readme)
-               ("Open packages.el"
-                . helm-spacemacs-help//layer-action-open-packages)
-               ("Open config.el"
-                . helm-spacemacs-help//layer-action-open-config)
-               ("Open funcs.el"
-                . helm-spacemacs-help//layer-action-open-funcs)
-               ("Open layers.el"
-                . helm-spacemacs-help//layer-action-open-layers)
-               ("Install Layer"
-                . helm-spacemacs-help//layer-action-install-layer)
-               ("Open README.org (for editing)"
-                . helm-spacemacs-help//layer-action-open-readme-edit)))))
+  (helm-build-sync-source "Layers"
+    :candidates (sort (configuration-layer/get-layers-list) 'string<)
+    :candidate-number-limit 99999999
+    :keymap helm-spacemacs-help--layer-map
+    :action '(("Open README.org"
+               . helm-spacemacs-help//layer-action-open-readme)
+              ("Open packages.el"
+               . helm-spacemacs-help//layer-action-open-packages)
+              ("Open config.el"
+               . helm-spacemacs-help//layer-action-open-config)
+              ("Open funcs.el"
+               . helm-spacemacs-help//layer-action-open-funcs)
+              ("Open layers.el"
+               . helm-spacemacs-help//layer-action-open-layers)
+              ("Install Layer"
+               . helm-spacemacs-help//layer-action-install-layer)
+              ("Open README.org (for editing)"
+               . helm-spacemacs-help//layer-action-open-readme-edit))))
 
 (defvar helm-spacemacs-help--layer-map
   (let ((map (make-sparse-keymap)))
@@ -202,16 +202,16 @@
   "Keymap for Spacemacs Layers sources")
 
 (defun helm-spacemacs-help//package-source ()
-  "Construct the helm source for the packages."
-  `((name . "Packages")
-    (candidates . ,(helm-spacemacs-help//package-candidates))
-    (candidate-number-limit)
-    (action . (("Go to configuration function"
-                . helm-spacemacs-help//package-action-goto-config-func)
-               ("Describe"
-                . helm-spacemacs-help//package-action-describe)
-               ("Recompile"
-                . helm-spacemacs-help//package-action-recompile)))))
+  (helm-build-sync-source "Packages"
+    :candidates (helm-spacemacs-help//package-candidates)
+    :candidate-number-limit 99999999
+    :action '(("Go to configuration function"
+               . helm-spacemacs-help//package-action-goto-config-func)
+              ("Describe"
+               . helm-spacemacs-help//package-action-describe)
+              ("Recompile"
+               . helm-spacemacs-help//package-action-recompile))))
+
 
 (defun helm-spacemacs-help//package-candidates ()
   "Return the sorted candidates for package source."
@@ -279,10 +279,10 @@
     result))
 
 (defun helm-spacemacs-help//dotspacemacs-source ()
-  `((name . "Dotfile")
-    (candidates . ,(helm-spacemacs-help//dotspacemacs-candidates))
-    (candidate-number-limit)
-    (action . (("Go to variable" . helm-spacemacs-help//go-to-dotfile-variable)))))
+  (helm-build-sync-source "Dotfile"
+    :candidates (helm-spacemacs-help//dotspacemacs-candidates)
+    :candidate-number-limit 99999999
+    :action '(("Go to variable" . helm-spacemacs-help//go-to-dotfile-variable))))
 
 (defun helm-spacemacs-help//dotspacemacs-candidates ()
   "Return the sorted candidates for all the dospacemacs variables."


### PR DESCRIPTION
Several (but not all) of the functions responsible for constructing helm sources
for use with spacemacs help simply construct alists rather than using the
'helm-build-*-source' macros. The former approach is discouraged by the [helm wiki](https://github.com/emacs-helm/helm/wiki/Developing#sources).

One of the consequences of this approach is that some of the nice helm features
one might expect don't work. For example, before adopting this commit, try
bringing up the layer help with 'SPC h l', and then type 'evil space'. One would
expect this to match 'spacemacs-evil' (since space-separated "words" are treated as
separate search strings), but this match doesn't work. Even worse, just type
'evil ' (with a trailing space): there will be no candidates (presumably because
it is treating the space literally).

This issue was present with the layer help, the package help, and the dotfile
help. I noticed the weird behavior a long time ago when I was first learning
spacemacs, and it was frustrating because it limited discoverability.

One note: with the previous approach, the alists had an unspecified (nil)
`candidate-number-limit`, which caused helm to not limit the number of options.
However, setting the ':candidate-number-limit' to nil with this approach does
not work: when helm builds a source from an 'eieio' object, it *only* copies
over slots that have non-nil values, so setting the keyword to nil yields an
object with a nil slot (which is also its initform), and then it does not get
copied into the helm source. Instead, I have set the keyword to the same large
constant used internally by helm when the user intends for the list to be
unlimited.
