### PR TITLE
Use org-agenda-files correctly in insert-recent-files

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1237,12 +1237,12 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
 (defun spacemacs-buffer//insert-recent-files (list-size)
   (unless recentf-mode (recentf-mode))
   (setq spacemacs-buffer//recent-files-list
-        (cl-delete-if (lambda (x)
-                        (or (when (and (bound-and-true-p org-directory) (file-exists-p org-directory))
-                              (member x (directory-files org-directory t)))
-                            (when (bound-and-true-p org-agenda-files)
-                              (member x (mapcar #'expand-file-name org-agenda-files)))))
-                      recentf-list))
+        (let ((agenda-files (mapcar #'expand-file-name (org-agenda-files))))
+          (cl-delete-if (lambda (x)
+                          (or (when (and (bound-and-true-p org-directory) (file-exists-p org-directory))
+                                (member x (directory-files org-directory t)))
+                              (member x agenda-files)))
+                        recentf-list)))
   (setq spacemacs-buffer//recent-files-list
         (spacemacs//subseq spacemacs-buffer//recent-files-list 0 list-size))
   (when (spacemacs-buffer//insert-file-list

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1237,7 +1237,9 @@ SEQ, START and END are the same arguments as for `cl-subseq'"
 (defun spacemacs-buffer//insert-recent-files (list-size)
   (unless recentf-mode (recentf-mode))
   (setq spacemacs-buffer//recent-files-list
-        (let ((agenda-files (mapcar #'expand-file-name (org-agenda-files))))
+        (let ((agenda-files (if (fboundp 'org-agenda-files)
+                                (mapcar #'expand-file-name (org-agenda-files))
+                              nil)))
           (cl-delete-if (lambda (x)
                           (or (when (and (bound-and-true-p org-directory) (file-exists-p org-directory))
                                 (member x (directory-files org-directory t)))


### PR DESCRIPTION
org-agenda-files can be a string or a nil. The meaning of string is different
than that of a single-member list.

The code treated the org-agenda-files variable like it needs to be a list.
Instead, one can use the org-agenda-files function to ask org-mode to resolve
the agenda files.