### PR TITLE
fix: do not setenv PAGER in shell layer

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -124,7 +124,10 @@
       ;; quick commands
       (defalias 'eshell/e 'find-file-other-window)
       (defalias 'eshell/d 'dired)
-      (setenv "PAGER" "cat")
+
+      (require 'esh-var)
+      (add-to-list 'eshell-variable-aliases-list
+                   `("PAGER" ,(lambda (_indices) "cat") t))
 
       ;; support `em-smart'
       (when shell-enable-smart-eshell


### PR DESCRIPTION
Setting PAGER with setenv changes the environment variable for any child process
launched fom within emacs, such as terminals apps (gnome-terminal, tilix,
etc.). This can interfere with paginated tools --  pydoc, bat and others.

This commit sets PAGER only within eshell sessions.