### PR TITLE
[osx] don't set dired-listing-switches

### DIFF
--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -43,8 +43,7 @@
   ;; not using GNU ls.
   (let ((gls (executable-find "gls")))
     (when gls
-      (setq insert-directory-program gls
-            dired-listing-switches "-aBhl --group-directories-first"))))
+      (setq insert-directory-program gls))))
 
 (defun osx/pre-init-helm ()
   ;; Use `mdfind' instead of `locate'.


### PR DESCRIPTION
fixes #15370; see there for more explanation

Note: Actively using `dired-quick-sort` will still break things via tramp when the remote is using a version of `ls` that doesn't support `--sort=` or `--group-directories-first`, but at least now it doesn't start off broken :)
