### PR TITLE
[scala] add keybinding for running `Test / compile` in SBT

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3430,6 +3430,8 @@ files (thanks to Daniel Nicolai)
     - ~SPC c s d~ Copy rpms to the phone
     - ~SPC c s i~ Install rpms into target
 **** Scala
+- Shortcut key for compiling tests in SBT without running them (~Test / compile~)
+  (thanks to Keith Pinson)
 - Shortcut keys for common/standard SBT commands (~scalafmtAll~, ~compile~ and ~test~)
   (thanks to Keith Pinson)
 - Remove long-deprecated Ensime support (thanks to Keith Pinson)

--- a/layers/+lang/scala/README.org
+++ b/layers/+lang/scala/README.org
@@ -129,10 +129,11 @@ Additional major mode key bindings are populated by LSP and DAP.
 
 ** sbt
 
-| Key binding | Description              |
-|-------------+--------------------------|
-| ~SPC m b .~ | SBT transient state      |
-| ~SPC m b b~ | SBT command              |
-| ~SPC m b c~ | Run ~compile~ in SBT     |
-| ~SPC m b t~ | Run ~test~ in SBT        |
-| ~SPC m b =~ | Run ~scalafmtAll~ in SBT |
+| Key binding | Description                 |
+|-------------+-----------------------------|
+| ~SPC m b .~   | SBT transient state         |
+| ~SPC m b b~   | SBT command                 |
+| ~SPC m b c~   | Run ~compile~ in SBT        |
+| ~SPC m b t~   | Run ~test~ in SBT           |
+| ~SPC m b T~   | Run ~Test / compile~ in SBT |
+| ~SPC m b =~   | Run ~scalafmtAll~ in SBT    |

--- a/layers/+lang/scala/funcs.el
+++ b/layers/+lang/scala/funcs.el
@@ -82,3 +82,8 @@ point to the position of the join."
   "Run `test' via SBT"
   (interactive)
   (sbt-command "test"))
+
+(defun spacemacs/scala-sbt-compile-test ()
+  "Compile `test' via SBT"
+  (interactive)
+  (sbt-command "Test / compile"))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -61,6 +61,7 @@
         "bb" 'sbt-command
         "bc" #'spacemacs/scala-sbt-compile
         "bt" #'spacemacs/scala-sbt-test
+        "bT" #'spacemacs/scala-sbt-compile-test
         "b=" #'spacemacs/scala-sbt-scalafmt-all))))
 
 (defun scala/init-scala-mode ()


### PR DESCRIPTION
This is another standard command (in addition to [these](https://github.com/syl20bnr/spacemacs/pull/15160)), not one specific to my build configuration. It can be useful only to compile the tests if your tests require any setup or do not run quickly.