### PR TITLE
reinstate cfgl-layer docstring fix

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -184,8 +184,7 @@ subdirectory of ROOT is used."
             :initform 'unspecified
             :type (satisfies (lambda (x) (or (listp x) (eq 'unspecified x))))
             :documentation
-            (concat "A list of layers where this layer is enabled. "
-                    "(Takes precedence over `:disabled-for'.)"))
+            "A list of layers where this layer is enabled. (Takes precedence over `:disabled-for'.)")
    ;; Note:
    ;; 'can-shadow' is a commutative relation:
    ;;     if Y 'can-shadow' X then X 'can-shadow' Y


### PR DESCRIPTION
I was mucking around in the `cfgl-layer` class and noticed I wasn't able to get help to come up, i.e., if I did `SPC h d f cfgs-layer RET` I'd get an error about `(concat...)` not satisfying `stringp`. I did some digging, and it seems to me that `:documentation` is not evaluated and needs to be a literal string. This was actually previous fixed back in fcf186faff8afdeda51c3dd20b61943e876acae5, but was subsequently accidentally reverted in dc58801c7ddd770a1f94a17890b4efbd1f20f6e8.

This PR restores the fix of fcf186faff8afdeda51c3dd20b61943e876acae5.