### PR TITLE
[github] mark layer as deprecated - remove unsecure packages

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2096,6 +2096,9 @@ Other:
 - Show user error when location is not set in theme changer
   (thanks to Boris Buliga)
 **** GitHub
+- Layer:
+  - marked as deprecated as functionality is all in =git= layer (thanks
+    to practicalli-john)
 - Packages:
   - Added new packages =forge= (thanks to Miciah Dashiel Butler Masters)
   - Do not install =forge= on Windows by default, see =README.org= of the layer
@@ -2123,6 +2126,8 @@ Other:
   - Remove package =magit-gh-pulls= as it was deprecated in favor of =magithub=
     and =forge= (thanks to Robby O'Connor)
   - Made magithub offline by default (thanks to Miciah Masters)
+- Removed =git-clone= and  =git-search= packages for not using a secure means to
+  store access tokens #1153777 (thanks to @practicalli-john)
 **** Git
 - Key bindings:
   - ~SPC g c~ to clone a repository (thanks to Steven Allen)

--- a/layers/+source-control/github/README.org
+++ b/layers/+source-control/github/README.org
@@ -9,19 +9,21 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#git-configuration][Git configuration]]
   - [[#grip-mode][grip-mode]]
 - [[#key-bindings][Key bindings]]
-  - [[#clone-repositories][Clone repositories]]
   - [[#grip-mode-1][Grip-mode]]
 
 * Description
-This layers adds support for [[http://github.com][GitHub]].
+*This layer is deprecated*.
+
+The layer had support searching for and cloning [[http://github.com][GitHub]] repositories,
+although that did not provide a secure way to store an access token
+to connect to GitHub.
+
+The git layer provides interaction with GitHub and can securely
+store the access token using PGP.
 
 ** Features:
-- [[https://github.com/magit/forge][forge]]: integration with various forges, such as GitHub and GitLab.
-- [[https://github.com/sshaw/git-link][git-link]]: quickly generate URLs for commits or files.
-- [[https://github.com/dgtized/github-clone.el][github-clone]] allows for easy cloning and forking of repositories.
 - [[https://github.com/seagle0128/grip-mode][grip-mode]] Github-flavored Markdown/Org preview using [[https://github.com/joeyespo/grip][Grip]].
 
 * Install
@@ -30,17 +32,6 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =github= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** Git configuration
-You will need to generate a [[https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line][personal access token]] on GitHub. This token should
-have the =gist= and =repo= permissions. Once this token is created, it needs to
-be added to your =~/.gitconfig=
-
-You will also need to [[https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/][generate an SSH key]] and [[https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/][add it to your GitHub account]].
-
-#+BEGIN_SRC sh
-  git config --global github.oauth-token <token>
-#+END_SRC
-
 ** grip-mode
 Grip-mode [[https://github.com/seagle0128/grip-mode#prerequisite][requires python and the python package grip]] to be installed on the
 system. Grip can usually be installed with the command =pip install grip=,
@@ -48,15 +39,6 @@ on debian based systems make sure you use the python 3 version
 of pip, it is normally called =pip3=.
 
 * Key bindings
-** Clone repositories
-
-| Key binding   | Description                                              |
-|---------------+----------------------------------------------------------|
-| ~SPC g h c /~ | search for a repository to clone it                      |
-| ~SPC g h c c~ | clone and optionally fork repository                     |
-| ~SPC g h c r~ | add a remote that is an existing fork of selected remote |
-| ~SPC g h c f~ | fork remote in current user namespace                    |
-| ~SPC g h c u~ | add upstream as remote                                   |
 
 ** Grip-mode
 

--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -20,32 +20,16 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;; Package deprecation notice shown at startup
+(warn "`github' layer is deprecated. See layer README.org for details.")
+
 
 (defconst github-packages
   '(
-    github-clone
-    github-search
     grip-mode
     ;; this package does not exits, we need it to wrap
     ;; the call to spacemacs/declare-prefix.
     (spacemacs-github :location built-in)))
-
-(defun github/init-github-clone ()
-  (use-package github-clone
-    :defer t
-    :init
-    (progn
-      (spacemacs/declare-prefix "ghc" "clone")
-      (spacemacs/set-leader-keys
-        "ghcc" 'github-clone
-        "ghcr" 'github-clone-add-existing-remote
-        "ghcf" 'github-clone-fork-remote
-        "ghcu" 'github-clone-add-source-remote))))
-
-(defun github/init-github-search ()
-  (use-package github-search
-    :commands (github-search-clone-repo github-search-user-clone-repo)
-    :init (spacemacs/set-leader-keys "ghc/" 'github-search-clone-repo)))
 
 (defun github/init-grip-mode ()
   (use-package grip-mode


### PR DESCRIPTION
Purpose of the PR changed after discussion and further review of the `github` layer

Remove github-clone & github-search packages from the layer, their key bindings and associated documentation.  Magit in the `git` layer can support cloning in a more secure way.

Update documentation:
- add depreciated layer notice and explanation
- remove reference to Magit forge (forge is added via the `git` layer)
- remove reference to git-link (git-link is added via the `git` layer
- Remove documentation regarding a GitHub access token (no longer required)

`grip-mode` and its configuration / documentation remains as the only functionality in the layer until it is decided what to to with this package.

Resolve #15377