### PR TITLE
notmuch: fix company based address completion

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2882,6 +2882,7 @@ files (thanks to Daniel Nicolai)
 - Change the ~C-n~ and ~C-p~ message keys to their original ~N~ and ~P~ bindings
 - Edit require from =org-notmuch= to =ol-notmuch= as per org-mode update 9.3.1
   (thanks to Loys Ollivier)
+- Fix address completion in notmuch-message mode (thanks to Mattijs Korpershoek)
 **** OCaml
 - Allow initialization without requiring =opam= (thanks to Bernhard Schommer)
 - Fixed misused functions, =merlin= is a package not a layer

--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -147,7 +147,9 @@
         (kbd "gr") 'notmuch-refresh-this-buffer
         (kbd "gR") 'notmuch-refresh-all-buffers
         (kbd "G") 'notmuch-search-last-thread
-        (kbd "M") 'compose-mail-other-frame))))
+        (kbd "M") 'compose-mail-other-frame)
+
+      (spacemacs|add-company-backends :backends notmuch-company :modes notmuch-message-mode))))
 
 (defun notmuch/pre-init-org ()
   (spacemacs|use-package-add-hook org


### PR DESCRIPTION
In notmuch-message-mode, vanilla notmuch.el enables notmuch-company by
default.
This is done by `notmuch-address-setup()` which calls
`notmuch-company-setup()`.

In `notmuch-company-setup()`, we `setq-local company-backends`.
Unfortunately, `company-backends` gets overriden later on by
`spacemacs//init-company-text-mode()`, breaking email address completion
in `notmuch-message-mode`.

Tell spacemacs that `notmuch-company` should be added as a company backend
for `notmuch-message-mode` to solve this.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>
