### PR TITLE
[git] Extend documentation for SSH keys

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2175,6 +2175,8 @@ Other:
   - Added orgit-forge (thanks to Ag Ibragimov)
   - Add Magit Forge configuration documentation & basic git configuration
     (thanks to practicalli-john)
+  - Elaborate on the configuration of SSH keys for use with Magit & Emacs,
+    generally (thanks to Bryce Carson).
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2173,6 +2173,8 @@ Other:
   - Restore magit transient args between sessions (thanks to duianto)
 - Improvements:
   - Added orgit-forge (thanks to Ag Ibragimov)
+  - Add Magit Forge configuration documentation & basic git configuration
+    (thanks to practicalli-john)
 **** Gnus
 - Key bindings:
   - Added ~g r~ for =gnus-group-get-new-news= (thanks to Matthew Leach)

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -116,6 +116,47 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
 
    ~SPC q R~, or ~SPC f d~ (to delete the client frame) then ~systemctl --user restart emacs~.
 
+4. Add the key to the SSH configuration file, so that when an SSH connection is
+   made to a Git forge, the appropriate key is used with that host by the
+   ssh-agent.
+
+   #+begin_src emacs-lisp
+     ((lambda (forgeUsername
+               sshKeyName
+               (&optional (gitForgeProperName "Github")
+                          (gitForgeHostname   "github.com")
+                          (addKeyToAgent-p    "yes")))
+        "Add a new SSH key to the user's login keyring, and\
+             configure it for a Git forge."
+        nil
+        (append-to-file
+         (concat "\n"
+                 "Host " gitForgeProperName "\n"
+
+                 ;; The .pub file extension is not necessary; it may cause
+                 ;; issues to include it. See man 5 ssh_config
+                 "     IdentityFile ~/.ssh/" sshKeyName "\n"
+                 "     User " forgeUsername "\n"
+                 "     Hostname " gitForgeHostname "\n"
+                 "     AddKeysToAgent" addKeyToAgent-p)
+         nil
+         "~/.ssh/config"))
+
+      "Your Git forge username"
+      "The path to your SSH key"
+
+      ;; ;; Optionally specify alternative to GitHub, and not add key to agent
+      ;; ;; permanently.
+      ;; "GitLab"
+      ;; "gitlab.com"
+      ;; ;; Either "no", or "confirm".
+      ;; "no"
+      )
+   #+end_src
+
+   You can evaluate the above source block to configure SSH fully for working
+   with a Git forge. Ensure to set the variables to their appropriate values.
+
 ** Magit status fullscreen
 To display the =magit status= buffer in fullscreen set the variable
 =git-magit-status-fullscreen= to =t= in your =dotspacemacs/user-init= function.

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -93,11 +93,11 @@ lifetime of Emacs", as the /GNU Emacs Manual/ states [Free Software Foundation
 2021]).
 
 1. Configure Emacs to use login or session keyrings. The default configuration of
-Emacs (and Spacemacs) does not include this. Login and session keyrings are
-managed by the ssh-agent of the desktop environment you use on Linux.
+   Emacs (and Spacemacs) does not include this. Login and session keyrings are
+   managed by the ssh-agent of the desktop environment you use on Linux.
 
-   - If you use Windows, you will need to consult extra documentation not discussed
-here.
+   - If you use Windows, you will need to consult extra documentation not
+     discussed here.
 
    Add the following to your ~spacemacs/user-config~ function, as shown below.
 
@@ -127,7 +127,7 @@ here.
         nil
         (append-to-file
          (concat "\n"
-                 "Host " gitForgeProperName "\n"
+                 "HOST " gitForgeProperName "\n"
 
                  ;; The .pub file extension is not necessary; it may cause
                  ;; issues to include it. See man 5 ssh_config
@@ -153,6 +153,22 @@ here.
    You can evaluate the above source block to configure SSH fully for working
    with a Git forge. Ensure to set the variables to their appropriate values.
 
+3. Ensure the upstream URLs for the remote repository are SSH form, according to
+   the documentation for the Git forge you are working with.
+
+   GitHub's documentation says the remote repository URL to use for SSH, rather
+   than HTTPS, is:
+
+   #+begin_example
+   git@github.com:syl20bnr/repository.git
+   #+end_example
+
+   Other Git forges may have a different URL scheme. Check the documentation for
+   the forge you would like to use.
+
+Below is a fully worked example of configuring SSH for use with Magit. You will
+be able to clone, pull, and push as normal.
+
 E.g.: Configure Emacs to use the desktop environment login key-chain, ie tell
 Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
 "wallets"). This is provided by the Free Desktop standard [[https://www.gnu.org/software/emacs/manual/html_mono/auth.html#Secret-Service-API][Secret Service API]].
@@ -162,8 +178,7 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
      (setq auth-sources '(default "secrets:Login"))
    #+end_src
 
-2. Add the =exampleRSAKey" to the SSH configuration.
-
+2. Add the =exampleRSAKey= to the SSH configuration.
    #+begin_src emacs-lisp
      ((lambda (forgeUsername
                sshKeyName
@@ -175,7 +190,7 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
         nil
         (append-to-file
          (concat "\n"
-                 "Host " gitForgeProperName "\n"
+                 "HOST " gitForgeProperName "\n"
 
                  ;; The .pub file extension is not necessary; it may cause
                  ;; issues to include it. See man 5 ssh_config
@@ -189,6 +204,7 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
       "bryce-carson"
       "~/ssh/exampleRSAKey"
       )
+   #+end_src
 
 3. Save and reload the configuration changes.
 
@@ -198,6 +214,14 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
 
    ~SPC q R~, or ~SPC f d~ (to delete the client frame) then ~systemctl --user restart emacs~.
 
+5. Ensure the remote repository URL is configured.
+
+   1. Configure the remotes for the current local repository: ~SPC g m M C~.
+
+   2. Select the upstream, such as a fork of another repository, or the origin(al) repository, in the minibuffer.
+
+   3. Set the URL to the appropriate scheme for the forge (=url= & =pushurl=): ~git@github.com/syl20bnr/spacemacs.git~.
+      
 ** Magit status fullscreen
 To display the =magit status= buffer in fullscreen set the variable
 =git-magit-status-fullscreen= to =t= in your =dotspacemacs/user-init= function.

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -138,7 +138,7 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
                  "     IdentityFile ~/.ssh/" sshKeyName "\n"
                  "     User " forgeUsername "\n"
                  "     Hostname " gitForgeHostname "\n"
-                 "     AddKeysToAgent" addKeyToAgent-p)
+                 "     AddKeysToAgent " addKeyToAgent-p)
          nil
          "~/.ssh/config"))
 

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -10,6 +10,8 @@
 - [[#install][Install]]
   - [[#layer][Layer]]
   - [[#git][Git]]
+    - [[#basic-git-configuration][Basic Git configuration]]
+    - [[#using-ssh-urls-for-remote-repositories][Using SSH URLs for remote repositories]]
   - [[#magit-status-fullscreen][Magit status fullscreen]]
   - [[#magit-auto-complete][Magit auto-complete]]
   - [[#magit-plugins][Magit Plugins]]
@@ -19,6 +21,8 @@
     - [[#magit-todos][magit-todos]]
   - [[#global-git-commit-mode][Global git commit mode]]
   - [[#forge][Forge]]
+    - [[#magit-forge-configuration][Magit Forge configuration]]
+    - [[#ms-windows-support][MS Windows support]]
   - [[#org-integration][Org integration]]
 - [[#working-with-git][Working with Git]]
   - [[#magit][Magit]]
@@ -47,7 +51,8 @@ This layers adds extensive support for [[http://git-scm.com/][git]] to Spacemacs
 - git grep with [[https://github.com/yasuyk/helm-git-grep][helm-git-grep]]
 - org integration with magit via [[https://github.com/magit/orgit][orgit]]
 
-New to Magit? Checkout the [[https://magit.vc/about/][official intro]].
+New to Magit? Checkout the [[https://magit.vc/about/][official intro]] and [[https://practical.li/spacemacs/source-control/][Practicalli Spacemacs]]
+guide to configuring and using the Git and version control layers.
 
 * Install
 ** Layer
@@ -58,6 +63,24 @@ file.
 ** Git
 Of course if your OS does not ship with git (!) you'll have to install it
 on your machine. You can download it from the [[http://git-scm.com/downloads][download page]].
+
+*** Basic Git configuration
+Define your git identity using the following commands in a terminal window
+replacing username and name@domain.tld with your own values
+
+#+begin_src shell
+  git config --global user.name "username"
+  git config --global user.email "name@domain.tld"
+#+end_src
+
+*** Using SSH URLs for remote repositories
+When using an SSH URL for remote repository access, [[https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/][generate an SSH key]] and
+add that key to your account on the remote service that manages repository access.
+An SSH key removes the need to provide login details for each request from Magit
+to the remote repository service.
+
+- [[https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account][GitHub /documentation]]
+- [[https://docs.gitlab.com/ee/ssh/#add-an-ssh-key-to-your-gitlab-account][GitLab documentation]]
 
 ** Magit status fullscreen
 To display the =magit status= buffer in fullscreen set the variable
@@ -136,6 +159,48 @@ To enable it you have to add the following lines to your
 #+END_SRC
 
 ** Forge
+
+Magit Forge can view and create issues & pull requests with forges
+(e.g. GitHub, GitLab)
+
+Magit Forge requires a the username for the respective forge and will prompt for a
+value if not defined in  =~/.gitconfig=
+Or define your forge identity using the following command in a terminal window
+
+For GitHub:
+
+#+begin_src shell
+  git config --global github.name "username"
+#+end_src
+
+For GitLab:
+
+#+begin_src shell
+  git config --global gitlab.name "username"
+#+end_src
+
+See the official [[https://magit.vc/manual/forge/Getting-Started.html#Getting-Started][Magit Forge]] and [[https://magit.vc/manual/ghub/Getting-Started.html][GHub Getting Started]] for general guides or follow
+a community written [[hhttps://practical.li/spacemacs/source-control/forge-configuration.html][Spacemacs specific guide to configuring Magit Forge]].
+
+*** Magit Forge configuration
+For each forge (e.g. GitHub, GitLab) used with Magit Forge, add a machine
+configuration to the =~/.authinfo= or PGP encrypted =~/.authinfo.gpg= file
+(for increased security). Detailed instructions to [[https://practical.li/spacemacs/source-control/forge-configuration.html#create-an-encrypted-authinfogpg-file][create an encrypted
+.authinfo.gpg file with Spacemacs]]
+
+The machine configuration should use your forge username and personal access token
+The personal access token should contain permissions for =repo=, =user= and =read:org=
+
+- [[https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token][GitHub personal access token documentation]]
+- [[https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token][GitLab personal access token documentation]]
+
+
+#+BEGIN_SRC sh
+  machine api.github.com login github-username^forge password 01personal02access03token
+#+END_SRC
+
+
+*** MS Windows support
 The =forge= package uses =emacsql= which requires a C compiler to be available
 on MS Windows, see issue [[https://github.com/skeeto/emacsql/issues/46]].
 

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -99,6 +99,19 @@ managed by the ssh-agent of the desktop environment you use on Linux.
    - If you use Windows, you will need to consult extra documentation not discussed
 here.
 
+   Add the following to your ~spacemacs/user-config~ function, as shown below.
+
+   #+begin_src emacs-lisp
+     (defun spacemacs/user-config ()
+     "Configuration for user code: This function is called at the very end of
+     Spacemacs startup, after layer configuration. Put your configuration code here,
+     except for variables that should be set
+     before packages are loaded."
+
+       (setq auth-sources '(default
+                             "secrets:Login")))
+   #+end_src
+
 2. Add the key to the SSH configuration file, so that when an SSH connection is
    made to a Git forge, the appropriate key is used with that host by the
    ssh-agent.

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -12,6 +12,7 @@
   - [[#git][Git]]
     - [[#basic-git-configuration][Basic Git configuration]]
     - [[#using-ssh-urls-for-remote-repositories][Using SSH URLs for remote repositories]]
+      - [[#making-emacs-and-magit-ssh-loginkeyringaware][Making Emacs and Magit SSH login–keyring–aware]]
   - [[#magit-status-fullscreen][Magit status fullscreen]]
   - [[#magit-auto-complete][Magit auto-complete]]
   - [[#magit-plugins][Magit Plugins]]
@@ -79,8 +80,41 @@ add that key to your account on the remote service that manages repository acces
 An SSH key removes the need to provide login details for each request from Magit
 to the remote repository service.
 
-- [[https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account][GitHub /documentation]]
+- [[https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account][GitHub documentation]]
 - [[https://docs.gitlab.com/ee/ssh/#add-an-ssh-key-to-your-gitlab-account][GitLab documentation]]
+-
+ 
+**** Making Emacs and Magit SSH login–keyring–aware 
+1. Configure Emacs to use login or session keyrings. The default configuration of
+Emacs (and Spacemacs) does not include this. Login and session keyrings are
+managed by the ssh-agent of the desktop environment you use on Linux.
+
+   - If you use Windows, you will need to consult extra documentation not discussed
+here.
+
+2. After following forge-specific documentation for using SSH keys with that forge,
+set the variable ~auth-sources~ to include the string(s) ="secrets:Login"= (to
+use a login keyring, which will be unlocked by your desktop environment upon
+login), and/or ="secrets:session"= (note the lowercase =s= in =session=; the
+session option will "open [the keyring] only for the lifetime of Emacs", as the
+/GNU Emacs Manual/ states [Free Software Foundation 2021]).
+
+E.g.: Configure Emacs to use the desktop environment login key-chain, ie tell
+Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
+"wallets"). This is provided by the Free Desktop standard [[https://www.gnu.org/software/emacs/manual/html_mono/auth.html#Secret-Service-API][Secret Service API]].
+
+1. Add the following to your ~spacemacs/user-config~ function:
+   #+begin_src emacs-lisp
+     (setq auth-sources '(default "secrets:Login"))
+   #+end_src
+
+2. Save and reload the configuration changes.
+
+   ~SPC f e R~
+
+3. Restart Emacs, or restart the systemd service managing the Emacs client.
+
+   ~SPC q R~, or ~SPC f d~ (to delete the client frame) then ~systemctl --user restart emacs~.
 
 ** Magit status fullscreen
 To display the =magit status= buffer in fullscreen set the variable

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -82,9 +82,16 @@ to the remote repository service.
 
 - [[https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account][GitHub documentation]]
 - [[https://docs.gitlab.com/ee/ssh/#add-an-ssh-key-to-your-gitlab-account][GitLab documentation]]
--
  
 **** Making Emacs and Magit SSH login–keyring–aware 
+After following forge-specific documentation (linked to in the above heading)
+for using SSH keys with that forge, set the variable ~auth-sources~ to include
+the string(s) ="secrets:Login"= (to use a login keyring, which will be unlocked by
+your desktop environment upon login), and/or ="secrets:session"= (note the
+lowercase =s= in =session=; the session option will "open [the keyring] only for the
+lifetime of Emacs", as the /GNU Emacs Manual/ states [Free Software Foundation
+2021]).
+
 1. Configure Emacs to use login or session keyrings. The default configuration of
 Emacs (and Spacemacs) does not include this. Login and session keyrings are
 managed by the ssh-agent of the desktop environment you use on Linux.
@@ -92,31 +99,7 @@ managed by the ssh-agent of the desktop environment you use on Linux.
    - If you use Windows, you will need to consult extra documentation not discussed
 here.
 
-2. After following forge-specific documentation for using SSH keys with that forge,
-set the variable ~auth-sources~ to include the string(s) ="secrets:Login"= (to
-use a login keyring, which will be unlocked by your desktop environment upon
-login), and/or ="secrets:session"= (note the lowercase =s= in =session=; the
-session option will "open [the keyring] only for the lifetime of Emacs", as the
-/GNU Emacs Manual/ states [Free Software Foundation 2021]).
-
-E.g.: Configure Emacs to use the desktop environment login key-chain, ie tell
-Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
-"wallets"). This is provided by the Free Desktop standard [[https://www.gnu.org/software/emacs/manual/html_mono/auth.html#Secret-Service-API][Secret Service API]].
-
-1. Add the following to your ~spacemacs/user-config~ function:
-   #+begin_src emacs-lisp
-     (setq auth-sources '(default "secrets:Login"))
-   #+end_src
-
-2. Save and reload the configuration changes.
-
-   ~SPC f e R~
-
-3. Restart Emacs, or restart the systemd service managing the Emacs client.
-
-   ~SPC q R~, or ~SPC f d~ (to delete the client frame) then ~systemctl --user restart emacs~.
-
-4. Add the key to the SSH configuration file, so that when an SSH connection is
+2. Add the key to the SSH configuration file, so that when an SSH connection is
    made to a Git forge, the appropriate key is used with that host by the
    ssh-agent.
 
@@ -156,6 +139,51 @@ Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
 
    You can evaluate the above source block to configure SSH fully for working
    with a Git forge. Ensure to set the variables to their appropriate values.
+
+E.g.: Configure Emacs to use the desktop environment login key-chain, ie tell
+Emacs to acquire SSH keys for remote logins from GNOME or KDE key-chains (or
+"wallets"). This is provided by the Free Desktop standard [[https://www.gnu.org/software/emacs/manual/html_mono/auth.html#Secret-Service-API][Secret Service API]].
+
+1. Add the following to your ~spacemacs/user-config~ function:
+   #+begin_src emacs-lisp
+     (setq auth-sources '(default "secrets:Login"))
+   #+end_src
+
+2. Add the =exampleRSAKey" to the SSH configuration.
+
+   #+begin_src emacs-lisp
+     ((lambda (forgeUsername
+               sshKeyName
+               (&optional (gitForgeProperName "Github")
+                          (gitForgeHostname   "github.com")
+                          (addKeyToAgent-p    "yes")))
+        "Add a new SSH key to the user's login keyring, and\
+             configure it for a Git forge."
+        nil
+        (append-to-file
+         (concat "\n"
+                 "Host " gitForgeProperName "\n"
+
+                 ;; The .pub file extension is not necessary; it may cause
+                 ;; issues to include it. See man 5 ssh_config
+                 "     IdentityFile ~/.ssh/" sshKeyName "\n"
+                 "     User " forgeUsername "\n"
+                 "     Hostname " gitForgeHostname "\n"
+                 "     AddKeysToAgent " addKeyToAgent-p)
+         nil
+         "~/.ssh/config"))
+
+      "bryce-carson"
+      "~/ssh/exampleRSAKey"
+      )
+
+3. Save and reload the configuration changes.
+
+   ~SPC f e R~
+
+4. Restart Emacs, or restart the systemd service managing the Emacs client.
+
+   ~SPC q R~, or ~SPC f d~ (to delete the client frame) then ~systemctl --user restart emacs~.
 
 ** Magit status fullscreen
 To display the =magit status= buffer in fullscreen set the variable


### PR DESCRIPTION
This extends the configuration information for using SSH keys.

It does not make use of authentication tokens, purely SSH. You can then decide whether you want to use tokens with git-forge stuff <kbd>SPC g m @</kbd>.

This is my first significant pull request, so any feedback on my documentation writing is welcome, as well as what I might have missed in the contribution guidelines.

---

It is dependent upon @practicalli-john's pull request (#15388). I tried to follow @lebensterben's instructions on how to make this PR, but I'm not the best at Git. It's easy to be a git when it comes to Git.