### PR TITLE
[space-doc] use cl-return as return is obsolete

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3088,6 +3088,7 @@ files (thanks to Daniel Nicolai)
   =org-insert-structure-template= commands (thanks to Andriy Kmit')
 - Added =ox-asciidoc= as org export backend (thanks to Christian "West" Westrom)
 - Fix org-roam v2 compatibility (thanks to Alex Kapranoff and Caleb Rogers)
+- Fix =space-doc.el= to use cl-return (thanks to practicalli-john)
 **** Osx
 - Key bindings:
   - Added key bindings to use ~command-1..9~ for selecting window

--- a/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
+++ b/layers/+spacemacs/spacemacs-org/local/space-doc/space-doc.el
@@ -159,7 +159,7 @@ This functions is aimed to be used with `spacemacs-space-doc-modificators'."
                    (kbd-marker
                     (dolist (el org-emphasis-alist)
                       (when (member 'org-kbd el)
-                        (return (car el))))))
+                        (cl-return (car el))))))
               (make-spacemacs--space-doc-cache-struct
                :marker-face     marker-face
                :btn-marker-face btn-marker-face


### PR DESCRIPTION
From Emacs version greater than 27.1, `return` is an obsolete alias

Replace with cl-return as directed in the warning message

Resolve #15396


