### PR TITLE
Add key binding for revert-buffer in process-menu-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -393,7 +393,9 @@
   (spacemacs|hide-lighter page-break-lines-mode))
 
 (defun spacemacs-defaults/init-process-menu ()
-  (evilified-state-evilify process-menu-mode process-menu-mode-map
+  (evilified-state-evilify-map process-menu-mode-map
+    :mode process-menu-mode
+    :bindings
     "gr" 'revert-buffer))
 
 (defun spacemacs-defaults/init-quickrun ()

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -393,7 +393,8 @@
   (spacemacs|hide-lighter page-break-lines-mode))
 
 (defun spacemacs-defaults/init-process-menu ()
-  (evilified-state-evilify process-menu-mode process-menu-mode-map))
+  (evilified-state-evilify process-menu-mode process-menu-mode-map
+    "gr" 'revert-buffer))
 
 (defun spacemacs-defaults/init-quickrun ()
   (use-package quickrun


### PR DESCRIPTION
This PR just binds `gr` to revert-buffer in process-menu-mode.  I bound it to `gr` rather than `g` so that `gg` still works.