### PR TITLE
[helm] fix typo in helm-ls-git requires

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -30,7 +30,7 @@
         helm-ag
         helm-descbinds
         helm-flx
-        (helm-ls-git :require git)
+        (helm-ls-git :toggle (configuration-layer/layer-used-p 'git))
         helm-make
         helm-mode-manager
         helm-org


### PR DESCRIPTION
helm-ls-git is specified as a package belonging to the helm layer, but it's
declared with the (non-existent) keyword :require, which should likely be
:requires. Changing it to :requires means that helm-ls-git will be installed
only if the git *package* is installed. It seems possible the original author's
intent was to install helm-ls-git only if the git *layer* was installed, but
it's hard to know for sure. As far as I know, no current spacemacs layers
install the git package, so fixing this typo will effectively remove helm-ls-git
except for cases where the git package is somehow installed (either explicitly
by the user, or through a private layer, etc).

As of writing, helm-ls-git is currently interfering with some git-rebase
keymaps (see #15089 for discussion), so fixing this typo *should* fix those
issues for most users, although it'll fix it essentially by nerfing helm-ls-git.