### PR TITLE
Improve Docker layer 'dockerfile-mode' major mode keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1907,6 +1907,9 @@ Other:
 - Fixed: broken package declaration for dockerfile-mode
   (thanks to Maximilian Wolff)
 - Added LSP support
+- Dockerfile mode keybindings (thanks to Alfonso Montero):
+  - Flatten ~cb~ and ~cB~ build commands into ~b~ and ~B~ to save keystrokes.
+  - Add keybindings to some =docker= package commands for convenience.
 **** Dotnet
 - Key bindings:
   - Added key bindings for =dotnet= (thanks to Jordan Kaye):

--- a/layers/+completion/helm/README.org
+++ b/layers/+completion/helm/README.org
@@ -63,7 +63,7 @@ listed last.
 
 ** Alternative layers
 Ivy layer is a replacement layer for Helm. When you add =ivy= to the existing
-== list in your dotfile, it will completely replace the =helm= layer.
+list in your dotfile, it will completely replace the =helm= layer.
 
 To switch from Ivy to Helm, modify your =~/.spacemacs=. You will need to add
 =helm= to the existing =dotspacemacs-configuration-layers= list in this file,

--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -50,12 +50,9 @@
     :defer t
     :init (add-hook 'dockerfile-mode-local-vars-hook #'spacemacs//docker-dockerfile-setup-backend)
     :config
-    (spacemacs/declare-prefix-for-mode 'dockerfile-mode "mc" "compile")
     (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
       "b" 'dockerfile-build-buffer
       "B" 'dockerfile-build-buffer-no-cache-buffer
-      "cb" 'dockerfile-build-buffer
-      "cB" 'dockerfile-build-no-cache-buffer)
     (with-eval-after-load 'docker
       (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
         "d" 'docker

--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -52,8 +52,15 @@
     :config
     (spacemacs/declare-prefix-for-mode 'dockerfile-mode "mc" "compile")
     (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
+      "b" 'dockerfile-build-buffer
+      "B" 'dockerfile-build-buffer-no-cache-buffer
       "cb" 'dockerfile-build-buffer
-      "cB" 'dockerfile-build-no-cache-buffer)))
+      "cB" 'dockerfile-build-no-cache-buffer)
+    (with-eval-after-load 'docker
+      (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
+        "d" 'docker
+        "i" 'docker-images
+        "p" 'docker-containers))))
 
 (defun docker/post-init-flycheck ()
   (spacemacs/enable-flycheck 'dockerfile-mode))


### PR DESCRIPTION
After several weeks using the layer for building Dockerfiles, I've came up with a few enhancements:
* I've flattened the `, c b` and `, c B` keys for build commands to just `, b` and `, B` to save keystrokes. I'm hesitant to remove existing ones because of annoying existing users, but feels redundant. Feedback on this is needed.
* Since [Silex/docker.el](https://github.com/Silex/docker.el)'s package is also installed for managing the `docker` daemon, I've added some command shortcuts for convenience (in addition to the existing `SPC a t d ...` ones):
  * `p` for `docker ps`, which can be used to delete failed builds' containers.
  * `i` for `docker images`, to delete old image builds.
  * `d` to access all the `docker` package commands (incl. `images` and `ps`): `docker {volumes,networks,...}`. Doing `, d` is a bit faster than existing `SPC a t d`.

As for the `docker` package commands, I've wrapped them inside a `(with-eval-after-load)` in case the user disables/excludes `docker` package. Not sure which is better, as opposed to `(feature-p)`, still newbie. Advice much appreciated, as I learn.