### PR TITLE
[core] enable lexical binding for all

### DIFF
--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -1,4 +1,4 @@
-;;; core-command-line.el --- Spacemacs Core File
+;;; core-command-line.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-compilation.el
+++ b/core/core-compilation.el
@@ -1,4 +1,4 @@
-;;; core-compilation.el --- Spacemacs Core File -*- no-byte-compile: t -*-
+;;; core-compilation.el --- Spacemacs Core File -*- lexical-binding: t; no-byte-compile: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -1,4 +1,4 @@
-;;; core-custom-settings.el --- Spacemacs Core File
+;;; core-custom-settings.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -1,4 +1,4 @@
-;;; core-display-init.el --- Spacemacs Core File
+;;; core-display-init.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -1,4 +1,4 @@
-;;; core-spacemacs.el --- Spacemacs Core File
+;;; core-spacemacs.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -1,4 +1,4 @@
-;;; core-dotspacemacs.el --- Spacemacs Core File
+;;; core-dotspacemacs.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-early-funcs.el
+++ b/core/core-early-funcs.el
@@ -1,4 +1,4 @@
-;;; core-early-funcs.el --- Spacemacs Core File
+;;; core-early-funcs.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; This file is sourced by emacs early-init.el file.
 ;;

--- a/core/core-emacs-backports.el
+++ b/core/core-emacs-backports.el
@@ -1,4 +1,4 @@
-;;; core-emacs-backports.el --- Spacemacs Core File
+;;; core-emacs-backports.el --- Spacemacs Core File  -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-env.el
+++ b/core/core-env.el
@@ -1,4 +1,4 @@
-;;; core-env.el --- Spacemacs Core File
+;;; core-env.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -1,4 +1,4 @@
-;;; core-fonts-support.el --- Spacemacs Core File
+;;; core-fonts-support.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -1,4 +1,4 @@
-;;; core-funcs.el --- Spacemacs Core File
+;;; core-funcs.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-hooks.el
+++ b/core/core-hooks.el
@@ -1,4 +1,4 @@
-;;; core-hooks.el --- Spacemacs Core File
+;;; core-hooks.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -1,4 +1,4 @@
-;;; core-jump.el --- Spacemacs Core File
+;;; core-jump.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-keybindings.el
+++ b/core/core-keybindings.el
@@ -1,4 +1,4 @@
-;;; core-keybindings.el --- Spacemacs Core File
+;;; core-keybindings.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -1,4 +1,4 @@
-;;; core-progress-bar.el --- Spacemacs Core File
+;;; core-progress-bar.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -1,4 +1,4 @@
-;;; core-spacemacs.el --- Spacemacs Core File
+;;; core-spacemacs.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1,4 +1,4 @@
-;;; core-spacemacs-buffer.el --- Spacemacs Core File
+;;; core-spacemacs-buffer.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -1,4 +1,4 @@
-;;; core-spacemacs.el --- Spacemacs Core File
+;;; core-spacemacs.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -1,4 +1,4 @@
-;;; core-themes-support.el --- Spacemacs Core File
+;;; core-themes-support.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-toggle.el
+++ b/core/core-toggle.el
@@ -1,4 +1,4 @@
-;;; core-toggle.el --- Spacemacs Core File
+;;; core-toggle.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;

--- a/core/core-use-package-ext.el
+++ b/core/core-use-package-ext.el
@@ -1,4 +1,4 @@
-;;; core-use-package-ext.el --- Spacemacs Core File
+;;; core-use-package-ext.el --- Spacemacs Core File -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2021 Sylvain Benner & Contributors
 ;;


### PR DESCRIPTION
For most of the core files the change was just ` -*- lexical-binding: t -*-` added to the top line.

Major and risky changes are in [core/core-configuration-layer.el](https://github.com/syl20bnr/spacemacs/compare/develop...thanhvg:feat/lexical?expand=1#diff-8abc7faad21a170282bd7b305596fb44024d8456e258863d40eea2be0ff6d630) which really depended on dynamic scope. For a basic test I was able to add and remove layers. And Spacemacs runs a bit faster.

I'm not very sure this change is safe, I am using this change on my boxes as a way to verify it. But I would like to push it to dev at some point to crowd source testing this change.



