### PR TITLE
move posframe package into spacemacs-visual layer

### DIFF
--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -33,6 +33,7 @@
         hl-todo
         popup
         popwin
+        posframe
         (zoom-frm :location local)))
 
 (defun spacemacs-visual/init-all-the-icons ()
@@ -92,6 +93,9 @@
     (global-hl-todo-mode 1)))
 
 (defun spacemacs-visual/init-popup ())
+
+(defun spacemacs-visual/init-posframe ()
+  (use-package posframe :defer t))
 
 (defun spacemacs-visual/init-popwin ()
   (use-package popwin

--- a/layers/+tools/dap/packages.el
+++ b/layers/+tools/dap/packages.el
@@ -22,8 +22,7 @@
 
 
 (defconst dap-packages
-  '(dap-mode
-    posframe))
+  '(dap-mode))
 
 (defun dap/init-dap-mode ()
   (use-package dap-mode
@@ -137,6 +136,6 @@
           ;; Set bindings
           (apply #'spacemacs/set-leader-keys-for-major-mode mode bindings))))))
 
+(defun dap/pre-init-posframe ())
 
-(defun dap/init-posframe ()
-  (use-package posframe))
+(defun dap/post-init-posframe ())

--- a/layers/+tools/translate/README.org
+++ b/layers/+tools/translate/README.org
@@ -15,6 +15,7 @@
   - [[#read-only][Read-only]]
   - [[#face][Face]]
 - [[#key-bindings][Key bindings]]
+- [[#variables][Variables]]
 
 * Description
 This layer is designed for Paragraph-oriented minor mode for
@@ -80,3 +81,11 @@ color to red, for example.
 | ~SPC a t T f~ | Prompt to open the reference file                                            |
 | ~SPC a t T b~ | Prompt to select a buffer and set it as the reference buffer                 |
 | ~SPC a t T h~ | Toggle paragraph highlighting                                                |
+
+* Variables
+These variables can be used to customize =translate= layer.
+
+| Variable                     | Default Value | Description                                                               |
+|------------------------------+---------------+---------------------------------------------------------------------------|
+| =translate/paragraph-render= | ='posframe=   | Paragraph translation render. Valid values are ='posframe= and ='buffer=. |
+| =translate/word-render=      | ='posframe=   | Word translation render. Valid values are ='posframe= and ='buffer=.      |

--- a/layers/+tools/translate/config.el
+++ b/layers/+tools/translate/config.el
@@ -1,0 +1,30 @@
+;;; funcs.el --- Semantic Layer functions File for Spacemacs
+;;
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
+;;
+;; Author: Ray Wang <rayw.public@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+(defvar translate/paragraph-render 'posframe
+  "Paragraph render for displaying translate result.
+Currently support `posframe' and `buffer'.")
+
+(defvar translate/word-render 'posframe
+  "Word render for displaying translate result.
+Currently support `posframe' and `buffer'.")

--- a/layers/+tools/translate/packages.el
+++ b/layers/+tools/translate/packages.el
@@ -23,8 +23,7 @@
 (defconst translate-packages
   '(
     translate-mode
-    go-translate
-    posframe))
+    go-translate))
 
 (defun translate/init-translate-mode ()
   "Initialize required packages."
@@ -64,6 +63,3 @@
 (defun translate/pre-init-posframe ()
   (spacemacs|use-package-add-hook posframe
     :post-config (translate/init-go-translate)))
-
-(defun translate/init-posframe ()
-  (use-package posframe :defer t))

--- a/layers/+tools/translate/packages.el
+++ b/layers/+tools/translate/packages.el
@@ -47,17 +47,24 @@
             (user-error "Make sure there is any word at point, or selection exists"))
           (let ((path (gts-path o text)))
             (cl-values text path))))
+      (defun translate//check-and-get-render (render)
+        (if (equal render 'posframe)
+            (if (featurep 'posframe)
+                (gts-posframe-pop-render)
+              (display-warning 'translate "Missing package `posframe', back to use default `gts-buffer-render'.")
+              (gts-buffer-render))
+          (gts-buffer-render)))
       (defconst translate//paragraph-translator
         (gts-translator
          :picker (translate//reference-paragraph-picker)
          :engines (list (gts-google-engine) (gts-google-rpc-engine) (gts-bing-engine))
-         :render (gts-buffer-render))
+         :render (translate//check-and-get-render translate/paragraph-render))
         "Paragraph translator for `go-translate'.")
       (defconst translate//word-translator
         (gts-translator
          :picker (gts-noprompt-picker)
          :engines (list (gts-google-engine) (gts-google-rpc-engine) (gts-bing-engine))
-         :render (gts-posframe-pop-render))
+         :render (translate//check-and-get-render translate/word-render))
         "Word translator for `go-translate'."))))
 
 (defun translate/pre-init-posframe ()


### PR DESCRIPTION
As a visualization package, `posframe` introduced in `dap` layer will probably be used in other layers (see https://github.com/syl20bnr/spacemacs/pull/15424#discussion_r834933516). Better if  `spacemacs-visual` layer contains this package, and other layers can do initialization stuff in `pre-init-posframe` or `post-init-posframe`.

This PR
1. moves `posframe` package from `dap` layer and `translate` layer into `spacemacs-visual` layer for package sharing
2. adds `pre-int-posframe` and `post-init-posframe` for further configurations in `dap` layer
3. deletes `posframe` dependency from `translate` layer
4. enables `posframe` package in `translate` layer only when it is available