### PR TITLE
Add grip-mode to markdown layer from github layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2097,8 +2097,9 @@ Other:
   (thanks to Boris Buliga)
 **** GitHub
 - Layer:
-  - marked as deprecated as functionality is all in =git= layer (thanks
+  - Marked as deprecated as functionality is all in =git= layer (thanks
     to practicalli-john)
+  - Moved =grip-mode= to the =markdown= layer.
 - Packages:
   - Added new packages =forge= (thanks to Miciah Dashiel Butler Masters)
   - Do not install =forge= on Windows by default, see =README.org= of the layer
@@ -2792,6 +2793,7 @@ files (thanks to Daniel Nicolai)
 - Made =*lsp-help*= buffer shown in a popup window using popwin
 - Add support for mdx files via markdown-mode (thanks to robbyoconnor)
 - Improve documentation about markdown preview options (thanks to Lin Sun)
+- Moved =grip-mode= to the =markdown= layer from the =github= layer.
 **** Major modes
 - Added SPARQL-mode (thanks to Dietrich Daroch)
 - Added android logcat (thanks to jiejingzhang)

--- a/layers/+lang/markdown/README.org
+++ b/layers/+lang/markdown/README.org
@@ -9,6 +9,7 @@
   - [[#features][Features:]]
 - [[#bibtex][BibTeX]]
 - [[#install][Install]]
+  - [[#grip-mode][grip-mode]]
 - [[#configuration][Configuration]]
   - [[#live-preview][Live preview]]
   - [[#automatic-mmm-mode-generation][Automatic MMM-Mode Generation]]
@@ -17,6 +18,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#element-insertion][Element insertion]]
   - [[#element-removal][Element removal]]
+  - [[#grip-mode-1][Grip-mode]]
   - [[#table-manipulation][Table manipulation]]
   - [[#completion][Completion]]
   - [[#following-and-jumping][Following and Jumping]]
@@ -32,6 +34,7 @@
 This layer adds markdown support to Spacemacs.
 
 ** Features:
+- [[https://github.com/seagle0128/grip-mode][grip-mode]] Github-flavored Markdown/Org preview using [[https://github.com/joeyespo/grip][Grip]].
 - markdown files support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
 - [[https://github.com/mdx-js/mdx][mdx]] file support via [[http://jblevins.org/git/markdown-mode.git/][markdown-mode]]
 - Fast GitHub-flavored live preview via [[https://github.com/blak3mill3r/vmd-mode][vmd-mode]]
@@ -47,6 +50,9 @@ For more extensive support of references with BibTeX files, have a look at the
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =markdown= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+** grip-mode
+Grip-mode [[https://github.com/seagle0128/grip-mode#prerequisite][requires python and the python package grip]] to be installed on the
+system. Grip can usually be installed from [[https://pypi.org/project/grip/][PyPI]].
 
 * Configuration
 ** Live preview
@@ -152,6 +158,10 @@ To generate a table of contents type on top of the buffer:
 | Key binding | Description         |
 |-------------+---------------------|
 | ~SPC m k~   | kill thing at point |
+
+** Grip-mode
+
+Toggle =grip-mode= by doing ~M-x grip-mode~.
 
 ** Table manipulation
 

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -27,6 +27,7 @@
     company-emoji
     emoji-cheat-sheet-plus
     gh-md
+    grip-mode
     markdown-mode
     markdown-toc
     mmm-mode
@@ -56,6 +57,10 @@
     (dolist (mode markdown--key-bindings-modes)
       (spacemacs/set-leader-keys-for-major-mode mode
         "cr" 'gh-md-render-buffer))))
+
+(defun markdown/init-grip-mode ()
+  (use-package grip-mode
+    :defer t))
 
 (defun markdown/post-init-valign ()
   (add-hook 'markdown-mode-hook 'valign-mode))


### PR DESCRIPTION
Since the github layer was deprecated in
cb786cc0711e0b23790185ef79012812dcfbe768, add it to the markdown layer.