### PR TITLE
Fix #15306. Reflect eaf layer keybinding logic to upstream changes.

### DIFF
--- a/layers/+tools/eaf/packages.el
+++ b/layers/+tools/eaf/packages.el
@@ -224,7 +224,7 @@
               (pcase eaf--buffer-app-name
                 ((or
                   (and "browser"
-                       (guard (not (string= (eaf-call-sync "call_function" eaf--buffer-id "is_focus") "True"))))
+                       (guard (not (eaf-call-sync "execute_function" eaf--buffer-id "is_focus"))))
                   "image-viewer"
                   "pdf-viewer")
                  (kbd eaf-evil-leader-key))
@@ -245,6 +245,6 @@
       (define-key key-translation-map (kbd ",")
         (lambda (prompt)
           (if (derived-mode-p 'eaf-mode)
-              (if (string= (eaf-call-sync "call_function" eaf--buffer-id "is_focus") "True")
+              (if (eaf-call-sync "execute_function" eaf--buffer-id "is_focus")
                   (kbd ",")
                 (kbd "C-,"))))))))


### PR DESCRIPTION
Relevant eaf layer keybinding code is based on suggestion from upstream eaf repo wiki. However, eaf API evolves faster than its wiki pages. This PR fixes #15306 using the workaround in the discussion. 

- Replace outdated eaf API call with most recent ones
- Tested with eaf-browser on my machine
- Both (kbd "SPC") and (kbd ",") works fine in eaf-browser