### PR TITLE
[spacemacs-editing] initialize `undo-tree-history-directory-alist`

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -539,7 +539,16 @@
             ;; Emacs GC which truncages the undo history very aggresively
             undo-limit 800000
             undo-strong-limit 12000000
-            undo-outer-limit 120000000)
+            undo-outer-limit 120000000
+            undo-tree-history-directory-alist
+            `(("." . ,(let ((dir (expand-file-name "undo-tree-history" spacemacs-cache-directory)))
+                        (if (file-exists-p dir)
+                            (unless (file-accessible-directory-p dir)
+                              (warn "Cannot access directory `%s'.
+ Perhaps you don't have required permissions, or it's not a directory.
+ See variable `undo-tree-history-directory-alist'." dir))
+                          (make-directory dir))
+                        dir))))
       (global-undo-tree-mode))
     :config
     (progn


### PR DESCRIPTION
Initialize `undo-tree-history-directory-alist` to stop `*.~undo-tree~` files from scattering all around.

Fix: #15426 