### PR TITLE
core-jump: fix incorrect lookup of :async

### DIFF
--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -76,8 +76,8 @@ They are in order: `spacemacs-jump-handlers',
     (let ((old-buffer (current-buffer))
           (old-point (point)))
       (dolist (-handler (spacemacs//get-jump-handlers))
-        (let* ((handler (if (listp -handler) (car -handler) -handler))
-               (async (plist-get (cdr-safe handler) :async)))
+        (let ((handler (if (listp -handler) (car -handler) -handler))
+              (async (plist-get (cdr-safe -handler) :async)))
           (ignore-errors
             (call-interactively handler))
           (when (or (eq async t)


### PR DESCRIPTION
:async wasn't being retrieved properly due to this typo.

The symptom of this is if you added an async handler before another handler, it would call the async handler and then immediately call the next one as well.  In my case, this would result in `evil-goto-definition` bringing up help while the async handler was running.