### PR TITLE
Added keybindings in forge-topic-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -75,6 +75,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   (thanks to Sylvain Benner, Compro Prasad and Keith Simmons)
 - Added support for native fill column indicator in Emacs 27+ (thanks to
   Andriy Kmit)
+- Added keybindings for ~forge-edit-topic-assignees~, ~forge-browse-pullreq~, ~forge-edit-topic-title~, ~forge-copy-url-at-point-as-kill~, and ~forge-checkout-pullreq~ in =forge-merge-topic-mode=. (thanks to Nick Anderson)
 *** Breaking Changes
 **** Major
 - Support for Emacs 25 or Emacs 26 has been dropped, the minimal Emacs version

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -350,8 +350,14 @@
       (setq forge-database-file (concat spacemacs-cache-directory
                                         "forge-database.sqlite"))
       (spacemacs/set-leader-keys-for-major-mode 'forge-topic-mode
+        "a" 'forge-edit-topic-assignees
+        "b" 'forge-browse-pullreq
         "c" 'forge-create-post
-        "e" 'forge-edit-post)
+        "e" 'forge-edit-post
+        "r" 'forge-edit-topic-review-requests
+        "t" 'forge-edit-topic-title
+        "u" 'forge-copy-url-at-point-as-kill
+        "C" 'forge-checkout-pullreq)
       (spacemacs/set-leader-keys-for-major-mode 'forge-post-mode
         dotspacemacs-major-mode-leader-key 'forge-post-submit
         "c" 'forge-post-submit


### PR DESCRIPTION
This change adds convenient key bindings when browsing pull requests in Magit.
With this change you can more easily browse to the pull request on the forge,
copy the url of the pull request on the forge, edit assignees and reviewers, and
check out a pull request.