### PR TITLE
When enabled require org-roam-protocol immediately

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -969,15 +969,16 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :config
     (progn
       (spacemacs|hide-lighter org-roam-mode)
-      (when org-enable-roam-protocol
-          (add-hook 'org-roam-mode-hook (lambda ()
-                                          (require 'org-roam-protocol))))
 
       (evilified-state-evilify-map org-roam-mode-map
         :mode org-roam-mode
         :bindings
         "o" 'link-hint-open-link
-        "r" 'org-roam-buffer-refresh))))
+        "r" 'org-roam-buffer-refresh)))
+
+  (use-package org-roam-protocol
+    :if org-roam-enable-protocol
+    :after org-protocol))
 
 (defun org/init-org-sticky-header ()
   (use-package org-sticky-header


### PR DESCRIPTION
Org roam protocol can be used from outside Emacs and as such, loading it only
after some org-roam buffers are opened defeats the purpose. Without this change
the org-protocol links won't work after emacs restart until at least one
org-roam buffer is loaded.

I will note that it's not clear to me if there's a better way to fix this that
does not involve require (even if conditional). Alternatively we could just update the docs to make sure people put the require block in their user init (as I did to workaround the issue). But I think that defeats the purpose of spacemacs.

Fixes #14487