### PR TITLE
disable evil-surround in magit-status buffers

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -24,6 +24,7 @@
 (defconst git-packages
   '(
     evil-collection
+    evil-surround
     fill-column-indicator
     ;; forge requires a C compiler on Windows so we disable
     ;; it by default on Windows.
@@ -54,6 +55,12 @@
   (spacemacs|use-package-add-hook golden-ratio
     :post-config
     (add-to-list 'golden-ratio-exclude-buffer-names " *transient*")))
+
+;; evil-surround bindings interfere with line-wise staging
+(defun git/post-init-evil-surround ()
+  (spacemacs|use-package-add-hook magit
+    :post-config
+    (add-hook 'magit-status-mode-hook #'turn-off-evil-surround-mode)))
 
 (defun git/pre-init-evil-collection ()
   (when (spacemacs//support-evilified-buffer-p)


### PR DESCRIPTION
See #15448 for full discussion.

In brief, `evil-surround` interferes with line-wise staging using `magit`, so this PR adds to the `magit-status-mode-hook` so that `evil-surround` is disabled in `magit-status` buffers.