### PR TITLE
[latex] add, configure, and document evil-tex package

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2685,6 +2685,7 @@ files (thanks to Daniel Nicolai)
   compiled PDF is changed (thanks to Lucius Hu)
 - Automatically configure =pdf-tools= as pdf viewer for =TeX-view= command (by default) (Thanks to Daniel Nicolai)
 - Add layer variable to open =pdf-tools= in split window (Thanks to Daniel Nicolai)
+- New package =evil-tex= (thanks to Dan Kessler)
 **** Lua
 - Added support for auto-completion with =company= (thanks to halfcrazy)
 - Added support for =LSP= (EmmyLua-LS-all, lua-language-server, lua-lsp) (thanks to Lin.Sun)

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -24,6 +24,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#folding-1][Folding]]
   - [[#reftex][RefTeX]]
+  - [[#evil-tex][evil-tex]]
 
 * Description
 This layer adds support for LaTeX files with [[https://savannah.gnu.org/projects/auctex/][AucTeX]].
@@ -34,6 +35,7 @@ This layer adds support for LaTeX files with [[https://savannah.gnu.org/projects
 - Auto-completion
 - Tags navigation on ~%~ with [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 - Labels, references, citations and index entries management with [[http://www.gnu.org/software/emacs/manual/html_node/reftex/index.html][RefTeX]]
+- LaTeX-specific text objects and much more with [[https://github.com/iyefrat/evil-tex][evil-tex]]
 
 * BibTeX
 For more extensive support of BibTeX files than RefTeX provides, have a look at
@@ -324,3 +326,20 @@ Available only when =latex-enable-folding= is non nil.
 | ~SPC m r t~ or with LSP ~SPC m R t~     | reftex-toc                            |
 | ~SPC m r T~ or with LSP ~SPC m R T~     | reftex-toc-recenter                   |
 | ~SPC m r v~ or with LSP ~SPC m R v~     | reftex-view-crossref                  |
+
+** evil-tex
+See the [[https://github.com/iyefrat/evil-tex/blob/master/README.org][evil-tex documentation]] for more comprehensive explanation of text
+objects it provides and its other features, including its integration with
+~evil-surround~.
+
+
+| Key binding | Description                                         |
+|-------------+-----------------------------------------------------|
+| ~]]~ / ~[[~ | jump between section headings                       |
+| ~M-n~       | Move between braces, similar to ~TAB~ in ~cd-latex~ |
+| ~SPC m q~   | Prefix for [[https://github.com/iyefrat/evil-tex#toggles][evil-tex toggle commands]]                 |
+
+In order to [[https://github.com/iyefrat/evil-tex#user-options][preserve both the precious ~t~ mark and the indispensable ~ts~
+motion]], the [[https://github.com/iyefrat/evil-tex/blob/master/README.org#toggles][evil-tex "magnificent toggles"]] are bound under ~SPC m q~ rather than
+~mt~ or ~ts~. This binding can be remembered with mnemonic "quite magnificent
+toggle".

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -32,6 +32,7 @@
     (company-reftex :requires company)
     counsel-gtags
     evil-matchit
+    evil-tex
     flycheck
     flyspell
     ggtags
@@ -195,6 +196,19 @@
 
 (defun latex/post-init-flyspell ()
   (spell-checking/add-flyspell-hook 'LaTeX-mode-hook))
+
+(defun latex/init-evil-tex ()
+  (use-package evil-tex
+    :defer t
+    :init
+    (progn
+      (add-hook 'LaTeX-mode-hook #'evil-tex-mode)
+      (setq evil-tex-toggle-override-m nil)
+      (setq evil-tex-toggle-override-t nil))
+    :config
+    (spacemacs/declare-prefix-for-mode 'latex-mode "mq"
+      (cons "evil-tex toggles" evil-tex-toggle-map))))
+
 
 (defun latex/init-reftex ()
   (add-hook 'LaTeX-mode-hook 'turn-on-reftex)


### PR DESCRIPTION
Add support for the very useful [evil-tex package](https://github.com/iyefrat/evil-tex) to the latex layer.

Of particular note, this package provides numerous text objects for latex, e.g.,
latex-style quotes and double quotes, and also provides valuable toggles for
managing delimeters.

I've mapped its "magnificent toggles" (which are otherwise under a `mt` prefix)
to `SPC m m` (m for magnificent) to avoid interfering with any standard evil features.

I added brief documentation for evil-tex to the latex layer's README, which
primarily refers the reader to evil-tex's thorough documentation rather
than duplicating it in the readme.