### PR TITLE
Only bind TAB when evil setting allows it

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -198,7 +198,11 @@ Needed to bypass keymaps set as text properties."
 (define-key evil-evilified-state-map (kbd "C-d") 'evil-scroll-down)
 (define-key evil-evilified-state-map (kbd "C-u") 'evil-scroll-up)
 (define-key evil-evilified-state-map (kbd "C-o") 'evil-jump-backward)
-(define-key evil-evilified-state-map (kbd "C-i") 'evil-jump-forward)
+(if evil-want-C-i-jump
+    ;; In terminal mode, `TAB` and `<C-i>' generate the same key press. Only if
+    ;; `evil-want-C-i-jump' holds, `TAB' should bind to the same function as
+    ;; `<C-i>'.
+    (define-key evil-evilified-state-map (kbd "C-i") 'evil-jump-forward))
 (define-key evil-evilified-state-map (kbd "C-z") 'evil-emacs-state)
 (define-key evil-evilified-state-map (kbd "C-w") 'evil-window-map)
 (setq evil-evilified-state-map-original (copy-keymap evil-evilified-state-map))

--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -198,11 +198,10 @@ Needed to bypass keymaps set as text properties."
 (define-key evil-evilified-state-map (kbd "C-d") 'evil-scroll-down)
 (define-key evil-evilified-state-map (kbd "C-u") 'evil-scroll-up)
 (define-key evil-evilified-state-map (kbd "C-o") 'evil-jump-backward)
-(if evil-want-C-i-jump
-    ;; In terminal mode, `TAB` and `<C-i>' generate the same key press. Only if
-    ;; `evil-want-C-i-jump' holds, `TAB' should bind to the same function as
-    ;; `<C-i>'.
-    (define-key evil-evilified-state-map (kbd "C-i") 'evil-jump-forward))
+(when (or (display-graphic-p) evil-want-C-i-jump)
+  ;; In terminal mode, `<C-i>' and `TAB' generate the same key press. That key
+  ;; press should do a `evil-jump-forward' only if `evil-want-C-i-jump' holds.
+  (define-key evil-evilified-state-map (kbd "C-i") 'evil-jump-forward))
 (define-key evil-evilified-state-map (kbd "C-z") 'evil-emacs-state)
 (define-key evil-evilified-state-map (kbd "C-w") 'evil-window-map)
 (setq evil-evilified-state-map-original (copy-keymap evil-evilified-state-map))


### PR DESCRIPTION
In a terminal TAB and C-i generate the same key press. So to "avoid TAB being overlapped in terminal mode", function spacemacs/init sets evil-want-C-i-jump to nil. Unfortunately commit bbd40f1 always binds C-i to evil-jump-forward regardless
of the value of evil-want-C-i-jump. This pull request fixes that.

This pull request addresses ticket #15472.