### PR TITLE
[zig] Fix setup backend hook

### DIFF
--- a/layers/+lang/zig/packages.el
+++ b/layers/+lang/zig/packages.el
@@ -27,4 +27,4 @@
 
 (defun zig/init-zig-mode ()
   (use-package zig-mode
-    :hook (zig-mode-hook . spacemacs//zig-setup-backend)))
+    :hook (zig-mode . spacemacs//zig-setup-backend)))


### PR DESCRIPTION
A typo introduced in 41393004881109d014dc2166c7110545ece9c32e prevented the backend to actually load lsp. This commit fixes this.