### PR TITLE
Permit `.spacemacs.d/init.el` to not be user init

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -35,9 +35,15 @@
 Useful for users in order to given them a hint of potential bottleneck in
 their configuration.")
 
+;; Set directory variable containing effective `.spacemacs' file. Will be one of
+;; `~/.spacemacs', `~/.spacemacs.d/init.el',
+;; `~/.spacemacs.d/${SPACEMACS_INIT_FILE_NAME}', `${SPACEMACSDIR}/init.el', or
+;; `${SPACEMACSDIR}/${SPACEMACS_INIT_FILE_NAME}'.
 (let* ((env (getenv "SPACEMACSDIR"))
        (env-dir (when env (expand-file-name (concat env "/"))))
-       (env-init (and env-dir (expand-file-name "init.el" env-dir)))
+       (env-init-file-name (or (getenv "SPACEMACS_INIT_FILE_NAME")
+                               "init.el"))
+       (env-init (and env-dir (expand-file-name env-init-file-name env-dir)))
        (no-env-dir-default (expand-file-name
                             (concat user-home-directory
                                     ".spacemacs.d/")))
@@ -45,8 +51,7 @@ their configuration.")
   (defconst dotspacemacs-directory
     (cond
      ((and env (file-exists-p env-dir)) env-dir)
-     ((file-exists-p no-env-dir-default) no-env-dir-default)
-     (t nil))
+     ((file-exists-p no-env-dir-default) no-env-dir-default))
     "Optional spacemacs directory, which defaults to
 ~/.spacemacs.d. This setting can be overridden using the
 SPACEMACSDIR environment variable. If neither of these
@@ -55,18 +60,19 @@ directories exist, this variable will be nil.")
   (defvar dotspacemacs-filepath
     (let ((spacemacs-dir-init (when dotspacemacs-directory
                                 (concat dotspacemacs-directory
-                                        "init.el"))))
+                                        env-init-file-name))))
       (cond
        (env-init)
-       ((file-exists-p default-init) default-init)
        ((and dotspacemacs-directory (file-exists-p spacemacs-dir-init))
         spacemacs-dir-init)
-       (t default-init)))
-    "Filepath to the installed dotfile. If SPACEMACSDIR is given
-then SPACEMACSDIR/init.el is used. Otherwise, if ~/.spacemacs
-exists, then this is used. If ~/.spacemacs does not exist, then
-check for init.el in dotspacemacs-directory and use this if it
-exists. Otherwise, fallback to ~/.spacemacs"))
+       ((file-exists-p default-init) default-init)
+       (default-init)))
+    "Filepath to the installed user–init file (dotfile, like
+`.spacemacs'). If the SPACEMACSDIR environment variable is set
+then `${SPACEMACSDIR}/init.el' is used. If the
+`$SPACEMACS_INIT_FILE_NAME' environment variable is set its value
+is substituted for `init.el'. Otherwise `~/.spacemacs' is used if
+it exists; if it does not exist it will be created."))
 
 (spacemacs|defc dotspacemacs-distribution 'spacemacs
   "Base distribution to use. This is a layer contained in the directory

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -550,6 +550,21 @@ change the location of this directory.
 so =~/.spacemacs= must not exist for =~/.spacemacs.d/init.el= to be used by
 Spacemacs.
 
+*** Chemacs users with =$CONFIG_HOME/.spacemacs.d= as =$SPACEMACSDIR=
+Users of Chemacs may use =$CONFIG_HOME/.spacemacs.d= as =$SPACEMACSDIR=, so long
+as they define an additional environment variable =SPACEMACS_INIT_FILE_NAME= to
+something other than ~init.el~. Chemacs users can still use =.spacemacs.d= as
+their dotfile directory with Chemacs as long as they retain a =.spacemacs= file
+otherwise, if they do not declare an alternative dotfile name and locate that in
+the dotfile directory.
+
+#+name: chemacs-spacemacsdir-example
+#+begin_example emacs-lisp
+  (("default"   . ((user-emacs-directory . "~/.spacemacs.d")
+		               (env . (("SPACEMACS_INIT_FILE_NAME" . "spacemacs")))))
+   ("gnu"       . ((user-emacs-directory . "~/.emacs.gnu.d"))))
+#+end_example
+
 ** Synchronization of dotfile changes
 To apply the modifications made in =~/.spacemacs= press ~SPC f e R~. It will
 re-execute the Spacemacs initialization process.

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -37,6 +37,7 @@
 - [[#dotfile-configuration][Dotfile Configuration]]
   - [[#dotfile-installation][Dotfile Installation]]
   - [[#alternative-dotdirectory][Alternative dotdirectory]]
+    - [[#chemacs-users-with-config_homespacemacsd-as-spacemacsdir][Chemacs users with =$CONFIG_HOME/.spacemacs.d= as =$SPACEMACSDIR=]]
   - [[#synchronization-of-dotfile-changes][Synchronization of dotfile changes]]
   - [[#testing-the-dotfile][Testing the dotfile]]
   - [[#dotfile-contents][Dotfile Contents]]
@@ -561,8 +562,8 @@ the dotfile directory.
 #+name: chemacs-spacemacsdir-example
 #+begin_example emacs-lisp
   (("default"   . ((user-emacs-directory . "~/.spacemacs.d")
-		               (env . (("SPACEMACS_INIT_FILE_NAME" . "spacemacs")))))
-   ("gnu"       . ((user-emacs-directory . "~/.emacs.gnu.d"))))
+                   (env . (("SPACEMACS_INIT_FILE_NAME" . "spacemacs")))))
+  ("gnu"       . ((user-emacs-directory . "~/.emacs.gnu.d"))))
 #+end_example
 
 ** Synchronization of dotfile changes


### PR DESCRIPTION
`DOCUMENTATION.org`:
- Add documentation for Chemacs users to the Alternative Dotfile Directory section in `DOCUMENTATION.org`
- Add example Chemacs `.emacs-profiles.el` to aide understading of added documentation

`core/core-dotspacemacs.el`:
- Add comment to explain the purpose of the `let*` form used to define `dotspacemacs-directory` and `dotspacemacs-filepath`
- Add check for optional `SPACEMACS_INIT_FILE_NAME` environment variable, and fall back to `"init.el"` if the environment variable is not set
- Remove unnecessary fall-through `(t nil)` form in `dotspacemacs-directory`'s cond form: it is unnecessary, and the style of the other usage of cond makes this proposed change more consistent
- Move the fallback to `~/.spacemacs` in the cond for the definition of `dotspacemacs-filepath` to the end of the cond, so that `~/.spacemacs` can be used with or without a dotfile dir, and that dir being either set by the SPACEMACSDIR environment variable or the default location (`~/.spacemacs.d`)
- Change from a forced clause in the `dotspacemacs-filename`–setting cond to just `(default-init)`, for the same reason as the other cond change
