### PR TITLE
doc: vscode-json-languageserver -> vscode-langservers-extracted

### DIFF
--- a/layers/+lang/json/README.org
+++ b/layers/+lang/json/README.org
@@ -84,7 +84,7 @@ layer is loaded.
 Installing the lsp server dependency can be done like this:
 
 #+BEGIN_SRC sh
-  npm install -g vscode-json-languageserver
+  npm install -g vscode-langservers-extracted
 #+END_SRC
 
 * Usage


### PR DESCRIPTION
Cf https://github.com/emacs-lsp/lsp-mode/issues/3395 the Node package to install has changed.

Installing the wrong Node package leads to `lsp-mode` not detecting the LSP and suggesting to install it automatically.
