### PR TITLE
[version-control] Load smerge-mode when entering smerge-transient-state

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -247,7 +247,6 @@
   (use-package smerge-mode
     :defer t
     :diminish smerge-mode
-    :commands spacemacs/smerge-transient-state/body
     :init
     (progn
       (spacemacs/set-leader-keys
@@ -267,6 +266,7 @@
         :title "Smerge Transient State"
         :hint-is-doc t
         :dynamic-hint (spacemacs//smerge-ts-hint)
+        :on-enter (require 'smerge-mode)
         :bindings
         ;; move
         ("n" smerge-vc-next-conflict)


### PR DESCRIPTION
This fixes the following error when pressing `SPC g r n` if
smerge-mode is not loaded yet:

    Symbol's function definition is void: smerge-vc-next-conflict

Removed the `:commands` argument to use-package, which is
erroneous (:commands sets up autoloads so that invoking the command
will load the package specified, but only if the command is not
already fboundp).

Instead, explicitly load smerge-mode when entering the transient
state, so that any of the key bindings in the transient state will be
available.  This has the same intended effect as the previous code.
