### PR TITLE
add org-roam-ui

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2923,6 +2923,7 @@ files (thanks to Daniel Nicolai)
   - Added package =org-contacts= (thanks to Daniel Nicolai)
   - Added package =org-appear= (thanks to winsphinX)
   - Added package =org-wild-notifier= (thanks to Daniel Nicolai)
+  - Added package =org-roam-ui= (thanks to winsphinX)
 - Key bindings:
   - ~SPC m s y~ for =org-copy-subtree= (thanks to Keith Pinson)
   - ~SPC m T i~ to toggle inline images

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -27,7 +27,7 @@
   - [[#project-support][Project support]]
   - [[#org-brain-support][Org-brain support]]
   - [[#org-roam-support][Org-roam support]]
-    - [[#org-roam-server-support][Org-roam-server support]]
+    - [[#org-roam-ui-support][Org-roam-ui support]]
     - [[#org-roam-protocol-support][Org-roam-protocol support]]
   - [[#mode-line-support][Mode line support]]
   - [[#sticky-header-support][Sticky header support]]
@@ -467,9 +467,10 @@ To install org-roam support set the variable =org-enable-roam-support= to =t=.
 
 More information about org-roam package (including manual) can be found at [[https://www.orgroam.com/][Org-roam]] website.
 
-*** Org-roam-server support
-To install support for [[https://github.com/org-roam/org-roam-server][org-roam-server]] set the variable =org-enable-roam-server=
-to =t=.
+*** Org-roam-ui support
+To install support for [[https://github.com/org-roam/org-roam-ui][org-roam-ui]] set the variable =org-enable-roam-ui= to =t=.
+
+Use ~M-x org-roam-ui-mode~ to enable the global mode. It will start a web browser and connect to it for real-time updates.
 
 *** Org-roam-protocol support
 To enable support for [[https://www.orgroam.com/manual.html#Org_002droam-Protocol][Org Roam Protocol]] set the variable

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -77,7 +77,7 @@ are configured.")
 (defvar org-enable-verb-support nil
   "If non-nil, Verb (https://github.com/federicotdn/verb) is configured.")
 
-(defvar org-enable-roam-support (bound-and-true-p org-enable-roam-server)
+(defvar org-enable-roam-support (bound-and-true-p org-enable-roam-ui)
   "If non-nil, org-roam (https://www.orgroam.com/) is configured")
 
 (defvar org-persp-startup-org-file nil
@@ -93,8 +93,8 @@ ATTENTION: `valign-mode' will be laggy working with tables contain more than 100
 (defvar org-enable-appear-support nil
   "If non-nil, enable org-appear in org-mode buffers.")
 
-(defvar org-enable-roam-server nil
-  "If non-nil, enable org-roam-server support.")
+(defvar org-enable-roam-ui nil
+  "If non-nil, enable org-roam-ui support.")
 
 (defvar org-enable-roam-protocol nil
   "If non-nil, enable org-roam-protocol.

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -69,6 +69,7 @@
     (org-sticky-header :toggle org-enable-sticky-header)
     (verb :toggle org-enable-verb-support)
     (org-roam :toggle org-enable-roam-support)
+    (org-roam-ui :toggle org-enable-roam-ui)
     (valign :toggle org-enable-valign)
     (org-appear :toggle org-enable-appear-support)
     (org-transclusion :toggle org-enable-transclusion-support)
@@ -1066,3 +1067,18 @@ Headline^^            Visit entry^^               Filter^^                    Da
   (if (not (boundp 'helm-imenu-extra-modes))
     (setq helm-imenu-extra-modes '(org-mode)))
   (add-to-list 'helm-imenu-extra-modes 'org-mode))
+
+(defun org/init-org-roam-ui ()
+  (use-package org-roam-ui
+    :after org-roam
+    :init
+    (progn
+      (spacemacs/set-leader-keys
+        "aoru" 'org-roam-ui-mode)
+      (spacemacs/set-leader-keys-for-major-mode 'org-mode
+        "ru" 'org-roam-ui-mode))
+    :config
+    (setq org-roam-ui-sync-theme t
+          org-roam-ui-follow t
+          org-roam-ui-update-on-save t
+          org-roam-ui-open-on-start t)))


### PR DESCRIPTION
For `org-roam-server` doesn't support `org-roam-v2`, `org-roam-ui` is now added to replace it.