### PR TITLE
[git] key bindings to edit magit forge topics

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2151,6 +2151,8 @@ Other:
   - Unbind ~C-f~ from =magit-gitflow-popup= (thanks to rayw000)
   - Implement performance hack for MacOS mentioned in Magit manual (thanks to
     Keith Pinson)
+  - Magit Forge key bindings for editing a topic, i.e. issue, PR (thanks to
+    @practicalli-john & @nickanderson)
 - Fixes:
   - Install magit-svn by default and activate with git-enable-magit-svn-plugin
   - Added feature to toggle =evil-magit= based on editing style

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -462,11 +462,23 @@ In a =magit-status= buffer (~SPC g s~):
 | ~f N~       | pull all notifications for the current repository's forge |
 
 In a =forge-topic= buffer:
+(a topic is either an issue or pull request)
 
-| Key binding | Description     |
-|-------------+-----------------|
-| ~SPC m c~   | create new post |
-| ~SPC m e~   | edit post       |
+| Key binding | Description                                     |
+|-------------+-------------------------------------------------|
+| ~SPC m a~   | assign people to topic                          |
+| ~SPC m b~   | browse topic (open in web browser)              |
+| ~SPC m c~   | create comment post to existing topic)          |
+| ~SPC m C~   | Checkout pull request (not for issues)          |
+| ~SPC m d~   | delete comment under cursor                     |
+| ~SPC m e~   | edit topic body                                 |
+| ~SPC m m~   | edit topic marks (mark is an unshared label)    |
+| ~SPC m M~   | create mark to use with topics                  |
+| ~SPC m n~   | edit personal note (adds to top of topic)       |
+| ~SPC m r~   | edit list of people to review an existing topic |
+| ~SPC m s~   | change topic state (open, closed, draft, etc.)  |
+| ~SPC m t~   | edit topic title                                |
+| ~SPC m u~   | copy URL of topic (add to kill ring)            |
 
 In a =forge-post= buffer (assuming the major mode leader key is ~,~)
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -357,8 +357,19 @@
       (setq forge-database-file (concat spacemacs-cache-directory
                                         "forge-database.sqlite"))
       (spacemacs/set-leader-keys-for-major-mode 'forge-topic-mode
+        "a" 'forge-edit-topic-assignees
         "c" 'forge-create-post
-        "e" 'forge-edit-post)
+        "C" 'forge-checkout-pullreq
+        "b" 'forge-browse-topic
+        "d" 'forge-delete-comment
+        "e" 'forge-edit-post
+        "m" 'forge-edit-topic-marks
+        "M" 'forge-create-mark
+        "n" 'forge-edit-topic-note
+        "r" 'forge-edit-topic-review-requests
+        "s" 'forge-edit-topic-state
+        "t" 'forge-edit-topic-title
+        "u" 'forge-copy-url-at-point-as-kill)
       (spacemacs/set-leader-keys-for-major-mode 'forge-post-mode
         dotspacemacs-major-mode-leader-key 'forge-post-submit
         "c" 'forge-post-submit


### PR DESCRIPTION
Add Spacemacs style key bindings menu when editing a Magit Forge topic (issue,
pull request)

Surfaces the Magit forge Topic commands describe in this section of the official documentation
https://magit.vc/manual/forge.html#Editing-Topics-and-Posts

> `forge-merge` command is discouraged by the official documentation and a local merge and push is recommended.  Therefore, a key binding is not included for this command.  

Replace: #15450 