### PR TITLE
common-lisp: Fix typo

### DIFF
--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -141,7 +141,7 @@ As this state works the same for all files, the documentation is in global
 
 *** Macroexpansion
 
-| Key binding | Description                                   |
-|-------------+-----------------------------------------------|
-| ~SPC m m a~ | Macroexpand the expression at point completly |
-| ~SPC m m o~ | Macroexpand the expression at point once      |
+| Key binding | Description                                    |
+|-------------+------------------------------------------------|
+| ~SPC m m a~ | Macroexpand the expression at point completely |
+| ~SPC m m o~ | Macroexpand the expression at point once       |


### PR DESCRIPTION
Hi,

This PR fixes a typo in the doc table for common lisp key bindings.