### PR TITLE
[search-engine] Add Rails API

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -339,6 +339,7 @@ In org-agenda-mode
 ***** Search-engine
   - Add Debian & Ubuntu package search engines (thanks to Alfonso Montero).
   - Allow to configure a TLD other than =.com= for Amazon searches (thanks to Alfonso Montero).
+  - Add Rails API search engine
 ***** Spacemacs-navigation
 - Key bindings:
   - Add ~J/K~ to scroll up/down (or next/previous node) in Info-mode

--- a/layers/+web-services/search-engine/README.org
+++ b/layers/+web-services/search-engine/README.org
@@ -46,6 +46,7 @@ This layer adds support for the [[https://github.com/hrs/engine-mode][Search Eng
 - Melpa
 - Debian Packages
 - Ubuntu Packages
+- Rails API
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+web-services/search-engine/packages.el
+++ b/layers/+web-services/search-engine/packages.el
@@ -107,6 +107,9 @@
               (c++-api-reference
                :name "C++ Reference"
                :url "https://en.cppreference.com/mwiki/index.php?search=%s")
+              (rails-api
+               :name "Rails API"
+               :url "https://api.rubyonrails.org?q=%s")
               (wolfram-alpha
                :name "Wolfram Alpha"
                :url "https://www.wolframalpha.com/input/?i=%s")


### PR DESCRIPTION
This PR, adds Rails API (https://api.rubyonrails.org/) to supported search engines