### PR TITLE
fix the variable in commit 805d9e8cd6d8d8338cd6778a4ab868a1a4e8ecdc

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -978,7 +978,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
         "r" 'org-roam-buffer-refresh)))
 
   (use-package org-roam-protocol
-    :if org-roam-enable-protocol
+    :if org-enable-roam-protocol
     :after org-protocol))
 
 (defun org/init-org-sticky-header ()


### PR DESCRIPTION
This causes an error `void variable org-roam-enable-protocol`.