### PR TITLE
[core] new recipe :fetcher local 

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -24,7 +24,9 @@
   '(auto-highlight-symbol
     imenu
     marginalia
-    (compleseus-spacemacs-help :location local)
+    ;; (compleseus-spacemacs-help :location local)
+    (compleseus-spacemacs-help
+     :location (recipe :fetcher local))
     consult
     consult-yasnippet
     embark
@@ -375,6 +377,7 @@
 
 (defun compleseus/init-compleseus-spacemacs-help ()
   (use-package compleseus-spacemacs-help
+    :defer t
     :init
     (spacemacs/set-leader-keys
       "h ."   'compleseus-spacemacs-help-dotspacemacs

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -36,9 +36,9 @@
     ;; pre packages, initialized after the bootstrap packages
     ;; these packages can use use-package
     (dotenv-mode :step pre)
-    (evil-evilified-state :location local :step pre :protected t)
+    (evil-evilified-state :location (recipe :fetcher local) :step pre :protected t)
     (pcre2el :step pre)
-    (holy-mode :location local :step pre)
+    (holy-mode :location (recipe :fetcher local) :step pre)
     (hybrid-mode :location (recipe :fetcher local) :step pre)
     (spacemacs-theme :location built-in)
     dash))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -47,7 +47,7 @@
     py-isort
     pydoc
     pyenv-mode
-    (pylookup :location local)
+    (pylookup :location (recipe :fetcher local))
     pytest
     (python :location built-in)
     pyvenv

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -38,7 +38,7 @@
     (electric-indent-mode :location built-in)
     (ediff :location built-in)
     (eldoc :location built-in)
-    (help-fns+ :location local)
+    (help-fns+ :location (recipe :fetcher local))
     (hi-lock :location built-in)
     (image-mode :location built-in)
     (imenu :location built-in)

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -40,7 +40,7 @@
     pcre2el
     (smartparens :toggle dotspacemacs-activate-smartparens-mode)
     (evil-swap-keys :toggle dotspacemacs-swap-number-row)
-    (spacemacs-whitespace-cleanup :location local)
+    (spacemacs-whitespace-cleanup :location (recipe :fetcher local))
     string-edit
     string-inflection
     multi-line

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -37,7 +37,7 @@
         spaceline
         spaceline-all-the-icons
         symon
-        (vim-powerline :location local)))
+        (vim-powerline :location (recipe :fetcher local))))
 
 (defun spacemacs-modeline/post-init-anzu ()
   (when (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -34,7 +34,7 @@
     ;; `org' package.
     (default-org-config :location built-in)
     org-superstar
-    (space-doc :location local)
+    (space-doc :location (recipe :fetcher local))
     toc-org
     ))
 

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -27,7 +27,7 @@
         (ivy-purpose :requires ivy)
         popwin
         (spacemacs-purpose-popwin
-         :location local
+         :location (recipe :fetcher local)
          :requires popwin)
         window-purpose))
 


### PR DESCRIPTION
with this current (package :location local) can be replaced with `(package :location (recipe :fetcher local))` then quelpa will install the local package to common location just like a normal package (eg ~/.emacs.d/elpa/28.1/develop/). We have the benefit of bytecompile and autoload.