### PR TITLE
[defaults] Fix toggle line numbers to respect dotspacemacs-line-numbers.

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1759,6 +1759,15 @@ Decision is based on `dotspacemacs-line-numbers'."
       (and (listp dotspacemacs-line-numbers)
            (car (spacemacs/mplist-get-values dotspacemacs-line-numbers :visual)))))
 
+(defun spacemacs/line-numbers-type ()
+  "Returns a valid value for `display-line-numbers', activating
+line numbers, with respect to `dotspacemacs-line-numbers'."
+  (if (listp dotspacemacs-line-numbers)
+      (cond ((car (spacemacs/mplist-get-values dotspacemacs-line-numbers :visual)) 'visual)
+            ((car (spacemacs/mplist-get-values dotspacemacs-line-numbers :relative)) 'relative)
+            (t t))
+    dotspacemacs-line-numbers))
+
 (defun spacemacs//linum-on (origfunc &rest args)
   "Advice function to improve `linum-on' function."
   (when (spacemacs/enable-line-numbers-p)

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -283,26 +283,21 @@
     :defer t
     :init
     (progn
-      (cond ((spacemacs/visual-line-numbers-p)
-             (setq display-line-numbers-type 'visual))
-            ((spacemacs/relative-line-numbers-p)
-             (setq display-line-numbers-type 'relative))
-            (t
-             (setq display-line-numbers-type t)))
+      (setq display-line-numbers-type (spacemacs/line-numbers-type))
 
       (spacemacs/declare-prefix "tn" "line-numbers")
 
       (spacemacs|add-toggle line-numbers
         :status (and (featurep 'display-line-numbers)
-                     display-line-numbers-mode
-                     (eq display-line-numbers dotspacemacs-line-numbers))
+                     display-line-numbers-mode)
         :on (prog1 (display-line-numbers-mode)
-              (setq display-line-numbers dotspacemacs-line-numbers))
+              (setq display-line-numbers (spacemacs/line-numbers-type)))
         :off (display-line-numbers-mode -1)
         :on-message "Line numbers enabled per dotspacemacs-line-numbers."
         :off-message "Line numbers disabled."
         :documentation "Show line numbers as configured in .spacemacs."
         :evil-leader "tnn")
+
       (spacemacs|add-toggle absolute-line-numbers
         :status (and (featurep 'display-line-numbers)
                      display-line-numbers-mode
@@ -314,6 +309,7 @@
         :off-message "Line numbers disabled."
         :documentation "Show absolute line numbers."
         :evil-leader "tna")
+
       (spacemacs|add-toggle relative-line-numbers
         :status (and (featurep 'display-line-numbers)
                      display-line-numbers-mode


### PR DESCRIPTION
Previously, `SPC t n n` (`spacemacs/toggle-line-numbers`) did not respect
dotspacemacs-line-numbers despite it telling otherwise, when it's binded to a
property list.

I'm unsure of what to do with the now unused functions `spacemacs/visual-line-numbers-p`, and `spacemacs/relative-line-numbers-p`. please advise.
