### PR TITLE
[evil] fix missing spacemacs-default-map in evil-lisp-state.

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -244,6 +244,13 @@
       (setq evil-lisp-state-global t))
     :config
     (progn
+      (bind-map spacemacs-default-map
+        :prefix-cmd spacemacs-cmds
+        :evil-keys (dotspacemacs-leader-key)
+        :evil-states (lisp)
+        :override-minor-modes t
+        :override-mode-name spacemacs-leader-override-mode)
+
       (spacemacs/set-leader-keys "k" evil-lisp-state-map)
       (spacemacs/declare-prefix
         "k" "lisp"


### PR DESCRIPTION
Looks like `SPC` was missing when you're in lisp state :shrug:.