### PR TITLE
Add fountain layer, a screenwriting file format

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -415,6 +415,7 @@ In org-agenda-mode
 - extempore (thanks to Ben Swift)
 - factor (thanks to timor)
 - forth (thanks to Tim Jaeger)
+- fountain (thanks to Damien Picard)
 - gpu (thanks to Evan Klitzke)
 - groovy (thanks to Sylvain Benner)
 - hy (thanks to Sylvain Benner and yuhan0)

--- a/layers/+lang/fountain/README.org
+++ b/layers/+lang/fountain/README.org
@@ -1,0 +1,83 @@
+#+TITLE: Fountain layer
+
+#+TAGS: layer|markup
+
+* Table of Contents                     :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-binding][Key binding]]
+  - [[#editing][Editing]]
+  - [[#navigation][Navigation]]
+  - [[#block-editing][Block editing]]
+  - [[#outline][Outline]]
+  - [[#pagination][Pagination]]
+  - [[#exporting][Exporting]]
+
+* Description
+This layer adds support for the [[https://fountain.io/][fountain]] screenwriting format to Spacemacs.
+
+** Features:
+- Fountain files support via [[https://github.com/rnkn/fountain-mode/][fountain-mode]]
+- Confortable writing layout via [[https://github.com/rnkn/olivetti/][olivetti-mode]]
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =fountain= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key binding
+** Editing
+
+| Key Binding | Description             |
+|-------------+-------------------------|
+| ~SPC m RET~ | upcase line and newline |
+| ~SPC m x U~ | upcase line             |
+| ~SPC m c d~ | add continued dialog    |
+| ~SPC m c D~ | remove continued dialog |
+| ~SPC m i n~ | insert note             |
+| ~SPC m i s~ | insert synopsis         |
+| ~SPC m i i~ | auto insert header      |
+| ~SPC m c n~ | add scene numbers       |
+| ~SPC m c N~ | remove scene numbers    |
+| ~SPC m i b~ | insert page break       |
+| ~SPC m ]~   | update completion       |
+| ~SPC m T m~ | toggle emphasis markup  |
+| ~SPC m T e~ | toggle element markup   |
+
+** Navigation
+
+| Key Binding | Description |
+|-------------+-------------|
+| ~SPC m j s~ | goto scene  |
+| ~SPC m j p~ | goto page   |
+
+** Block editing
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~<M-down>~  | move section down |
+| ~<M-up>~    | move section up   |
+
+** Outline
+
+| Key Binding | Description                |
+|-------------+----------------------------|
+| ~SPC m TAB~ | cycle outline              |
+| ~S-TAB~     | cycle outlines for buffer  |
+| ~SPC m o~   | outline to indirect buffer |
+| ~SPC m i h~ | insert section heading     |
+
+** Pagination
+
+| Key Binding | Description       |
+|-------------+-------------------|
+| ~SPC m c p~ | count pages       |
+| ~SPC m c u~ | pagination update |
+
+** Exporting
+
+| Key Binding | Description    |
+|-------------+----------------|
+| ~SPC m e e~ | export command |
+| ~SPC m e v~ | export view    |

--- a/layers/+lang/fountain/packages.el
+++ b/layers/+lang/fountain/packages.el
@@ -1,0 +1,79 @@
+;;; packages.el --- Fountain layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2022 Sylvain Benner & Contributors
+;;
+;; Author: Damien Picard <dam.pic@free.fr>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+(defconst fountain-packages
+  '(
+    fountain-mode
+    olivetti))
+
+(defun fountain/init-olivetti ()
+  (use-package olivetti
+    :defer t
+    :hook '(fountain-mode . olivetti-mode)))
+
+(defun fountain/init-fountain-mode ()
+  (use-package fountain-mode
+    :defer t
+    :config
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'fountain-mode
+        ;; Editing commands
+        "RET" 'fountain-upcase-line-and-newline
+        "xU" 'fountain-upcase-line
+        "cd" 'fountain-add-continued-dialog
+        "cD" 'fountain-remove-continued-dialog
+        "in" 'fountain-insert-note
+        "is" 'fountain-insert-synopsis
+        "ii" 'auto-insert
+        "cn" 'fountain-add-scene-numbers
+        "cN" 'fountain-remove-scene-numbers
+        "ib" 'fountain-insert-page-break
+        "]" 'fountain-completion-update
+
+        "Tm" 'fountain-toggle-hide-emphasis-markup
+        "Te" 'fountain-toggle-hide-element-markup
+
+        ;; Navigation commands
+        "js" 'fountain-goto-scene
+        "jp" 'fountain-goto-page
+
+        ;; Outline commands
+        "TAB"  'fountain-outline-cycle
+        "o"  'fountain-outline-to-indirect-buffer
+        "ih" 'fountain-insert-section-heading
+
+        ;; Pagination commands
+        "cp" 'fountain-count-pages
+        "cu" 'fountain-pagination-update
+
+        ;; Exporting commands
+        "ee" 'fountain-export-command
+        "ev" 'fountain-export-view)
+
+      (spacemacs/declare-prefix-for-mode 'fountain-mode "mi" "fountain/insert")
+      (spacemacs/declare-prefix-for-mode 'fountain-mode "mx" "fountain/text")
+      (spacemacs/declare-prefix-for-mode 'fountain-mode "mc" "fountain/command")
+      (spacemacs/declare-prefix-for-mode 'fountain-mode "mT" "fountain/toggle")
+      (spacemacs/declare-prefix-for-mode 'fountain-mode "mj" "fountain/jump")
+      (spacemacs/declare-prefix-for-mode 'fountain-mode "me" "fountain/export")
+      )))


### PR DESCRIPTION
This new layer adds support for the [fountain](https://fountain.io/) screenwriting format, using the [fountain-mode](https://github.com/rnkn/fountain-mode) by @rnkn.