### PR TITLE
[ietf] fix auto-mode-alias for ietf-mode

### DIFF
--- a/layers/+misc/ietf/packages.el
+++ b/layers/+misc/ietf/packages.el
@@ -47,7 +47,7 @@
       (add-to-list 'auto-mode-alist
                    '("/draft-\\([a-z0-9_]+-\\)+[a-z0-9_]+.txt" . irfc-mode))
       (add-to-list 'auto-mode-alist
-                   '("/rfc-\\([a-z0-9_]+-\\).txt" . irfc-mode)))))
+                   '("/rfc\\([a-z0-9_-]+\\).txt" . irfc-mode)))))
 
 
 


### PR DESCRIPTION
The RFC document is named as "rfcXYZ.txt" from ietf.org, for example: https://ietf.org/rfc/rfc7269.txt.
So here is the change for the `auto-mode-alist` to correctly associate with rfc document. 
Please help review code and apply to the repo. 
Thanks