### PR TITLE
Fix: variable is void: emoji-cheat-sheet-plus-buffer-mode warning

### DIFF
--- a/layers/+fun/emoji/packages.el
+++ b/layers/+fun/emoji/packages.el
@@ -35,11 +35,11 @@
     :init
     (progn
       (spacemacs/set-leader-keys "afe" 'emoji-cheat-sheet-plus-buffer)
-      (spacemacs/set-leader-keys "ie" 'emoji-cheat-sheet-plus-insert)
-      (evilified-state-evilify emoji-cheat-sheet-plus-buffer-mode
-        emoji-cheat-sheet-plus-buffer-mode-map
-        "<RET>" 'emoji-cheat-sheet-plus-echo-and-copy))
+      (spacemacs/set-leader-keys "ie" 'emoji-cheat-sheet-plus-insert))
     :config
+    (evilified-state-evilify emoji-cheat-sheet-plus-buffer-mode
+      emoji-cheat-sheet-plus-buffer-mode-map
+      "<RET>" 'emoji-cheat-sheet-plus-echo-and-copy)
     (spacemacs|hide-lighter emoji-cheat-sheet-plus-display-mode)))
 
 (defun emoji/init-emojify ()


### PR DESCRIPTION
Placing the `evilified-state-evilify` after the use-package its `:init` keyword results in a warning at startup that the keymap variable name is void.

This commit fixes it by placing the invocation after the `:config` keyword.

I have looked through the code base, and I have found that the  `evilified-state-evilify(-map)` macro is used more often after the `:init` keyword, which seems wrong to me in most cases. Sometimes the invocation, correctly, includes an `eval-after-load` keyword (like in the `edebug` layer), but other times it does not (like in the `ledger`, `Chinese`, `xkcd` and several other layers).

Am I missing something? Or are all these invocations used in the wrong place/way?
