### PR TITLE
Enable racer only when it is selected as a backend

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -97,19 +97,20 @@
   (spacemacs/helm-gtags-define-keys-for-mode 'rust-mode))
 
 (defun rust/init-racer ()
-  (use-package racer
-    :defer t
-    :commands racer-mode
-    :config
-    (progn
-      (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
-      (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
-      (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "hh" 'spacemacs/racer-describe)
-      (spacemacs|hide-lighter racer-mode)
-      (evilified-state-evilify-map racer-help-mode-map
-        :mode racer-help-mode))))
+  (when (eq rust-backend 'racer)
+    (use-package racer
+      :defer t
+      :commands racer-mode
+      :config
+      (progn
+        (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
+        (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
+        (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
+        (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+          "hh" 'spacemacs/racer-describe)
+        (spacemacs|hide-lighter racer-mode)
+        (evilified-state-evilify-map racer-help-mode-map
+          :mode racer-help-mode)))))
 
 (defun rust/init-rust-mode ()
   (use-package rust-mode


### PR DESCRIPTION
When using LSP, there is little to no need to use Racer as well. So, this patch
conditionally enables Racer, only when it is selected as a backend.

Note: I'm unsure if the use case "racer-mode + lsp" is interesting for anyone. In that case, it would maybe be beneficial to add a separate variable to control this behavior.
