### PR TITLE
[git] key binding to initially set PR as draft status

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2154,7 +2154,8 @@ Other:
   - Implement performance hack for MacOS mentioned in Magit manual (thanks to
     Keith Pinson)
   - Magit Forge key bindings for editing a topic, i.e. issue, PR (thanks to
-    @practicalli-john & @nickanderson)
+  - ~SPC m d~ Magit Forge toggle draft PR key bindings (thanks to
+    @practicalli-john)
 - Fixes:
   - Install magit-svn by default and activate with git-enable-magit-svn-plugin
   - Added feature to toggle =evil-magit= based on editing style

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -470,7 +470,8 @@ In a =forge-topic= buffer:
 | ~SPC m b~   | browse topic (open in web browser)              |
 | ~SPC m c~   | create comment post to existing topic)          |
 | ~SPC m C~   | Checkout pull request (not for issues)          |
-| ~SPC m d~   | delete comment under cursor                     |
+| ~SPC m d~   | toggle draft pull request
+| ~SPC m D~   | delete comment under cursor                     |
 | ~SPC m e~   | edit topic body                                 |
 | ~SPC m m~   | edit topic marks (mark is an unshared label)    |
 | ~SPC m M~   | create mark to use with topics                  |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -361,7 +361,8 @@
         "c" 'forge-create-post
         "C" 'forge-checkout-pullreq
         "b" 'forge-browse-topic
-        "d" 'forge-delete-comment
+        "D" 'forge-delete-comment
+        "d" 'forge-post-toggle-draft
         "e" 'forge-edit-post
         "m" 'forge-edit-topic-marks
         "M" 'forge-create-mark


### PR DESCRIPTION
When creating a pull request, Magit can mark that PR as draft status, i.e. is still work in progress

Magit does not change the status of an existing pull request.

Related issue discussing support of draft PRs in magit
https://github.com/magit/forge/issues/112

> NOTE: I am using this PR to test the functionality and the correct menu placement of the key binding
