### PR TITLE
removing consult-completing-read-multiple in compleseus

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -188,9 +188,6 @@
     ;; This adds thin lines, sorting and hides the mode line of the window.
     (advice-add #'register-preview :override #'consult-register-window)
 
-    ;; Replace `completing-read-multiple' with an enhanced version.
-    (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
-
     ;; Use Consult to select xref locations with preview
     (setq xref-prompt-for-identifier '(not xref-find-definitions
                                            xref-find-definitions-other-window


### PR DESCRIPTION
As mentioned in #15555 the function consult-completing-read-multiple has been removed in the latest version of consult
