### PR TITLE
[javascript] Use js2-mode with .cjs files

### DIFF
--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -112,7 +112,7 @@
 (defun javascript/init-js2-mode ()
   (use-package js2-mode
     :defer t
-    :mode (("\\.m?js\\'"  . js2-mode))
+    :mode (("\\.[cm]?js\\'"  . js2-mode))
     :init
     (progn
       (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)


### PR DESCRIPTION
.cjs is an extension for CommonJS files, and is needed if `"type": "module"` is specified for a Node package.
