### PR TITLE
org-contacts no longer built-in

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -37,8 +37,7 @@
     (org-agenda :location built-in)
     (org-wild-notifier
                 :toggle org-enable-notifications)
-    (org-contacts :location built-in
-                  :toggle org-enable-org-contacts-support)
+    (org-contacts :toggle org-enable-org-contacts-support)
     org-contrib
     (org-vcard :toggle org-enable-org-contacts-support)
     (org-brain :toggle org-enable-org-brain-support)


### PR DESCRIPTION
Starting with (org-contrib v0.4)[https://git.sr.ht/~bzg/org-contrib/commit/3dd98415225823f21fb7e12f272c0f199ac7407f] org-contacts is no longer part of it. Instead it is an own package.