### PR TITLE
Disable evilified in pyim-dict-manager-mode

### DIFF
--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -60,9 +60,7 @@
             pyim-assistant-scheme-enable t
             default-input-method "pyim")
       (autoload 'pyim-dict-manager-mode "pyim-dicts-manager"
-        "Major mode for managing pyim dicts")
-      (evilified-state-evilify-map pyim-dict-manager-mode-map
-        :mode pyim-dict-manager-mode))))
+        "Major mode for managing pyim dicts"))))
 
 (defun chinese/init-pyim-basedict ()
   "Initialize pyim-basedict"


### PR DESCRIPTION
Fix #15568
Temporary disable `evilified-state-evilify-map` in `pyim-dict-manager-mode-map` to avoid error message.



