### PR TITLE
Evilify the pyim-dict-manager-mode-map after its mode be loaded

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1628,6 +1628,8 @@ Other:
   - Added =fcitx5= support (thanks to wgjak47)
 - Fixes:
   - Make =fcitx.el= work by default (thanks to AmaiKinono)
+  - Evilify the pyim-dict-manager-mode-map after the pyim-dict-manager-mode be
+    loaded (thanks to Lin Sun)
 **** Chrome
 - Key bindings:
   - Added =markdown= key bindings to gmail message mode

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -62,7 +62,8 @@
       (autoload 'pyim-dict-manager-mode "pyim-dicts-manager"
         "Major mode for managing pyim dicts")
       (evilified-state-evilify-map pyim-dict-manager-mode-map
-        :mode pyim-dict-manager-mode))))
+        :mode pyim-dict-manager-mode
+        :eval-after-load pyim-dict-manager))))
 
 (defun chinese/init-pyim-basedict ()
   "Initialize pyim-basedict"


### PR DESCRIPTION
Try to fix the issue https://github.com/syl20bnr/spacemacs/issues/15568.