### PR TITLE
[core] Add variable `dotspacemacs-startup-banner-scale' to scale the …

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -543,6 +543,7 @@ In org-agenda-mode
   - New var =dotspacemacs-startup-buffer-multi-digit-delay= (thanks to duianto)
   - New variable =dotspacemacs-scroll-bar-while-scrolling= (thanks to duianto)
   - New variable =dotspacemacs-show-startup-list-numbers= (thanks to duianto)
+  - New variable =dotspacemacs-startup-banner-scale= (thanks to Daniel)
 - Removed Variables:
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -210,6 +210,13 @@ If the value is nil then no banner is displayed."
   '(choice (const official) (const random) (const nil) string integer)
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-startup-banner-scale 'auto
+  "Specify the scale value for the startup banner. Default value is `auto',
+it displays the spacemacs logo with the scale value. An (0, 1] float value
+will be applied to scale the banner."
+  '(choice (const auto) (const nil) float)
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-startup-buffer-show-version t
   "If true, show Spacemacs and Emacs version at the top right of the
 Spacemacs buffer."


### PR DESCRIPTION
It always failed to start the Spacemacs after upgrade to a485b5a84b3fa4f8a06b25f51cf6df49b51defb0.

It caused by the `dotspacemacs-startup-banner-scale'. 

This PR try to fix the issue.