### PR TITLE
Fix vc-svn/git void variable warning (evilify after load)

### DIFF
--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -90,11 +90,11 @@
         "H" 'log-view-toggle-entry-display
         "o" 'ace-link-woman)
       (evilified-state-evilify-map vc-svn-log-view-mode-map
-        :mode vc-svn-log-view-mode)
+        :mode vc-svn-log-view-mode
+        :eval-after-load vc-svn)
       (evilified-state-evilify-map vc-git-log-view-mode-map
-        :mode vc-git-log-view-mode)
-      (evilified-state-evilify-map vc-git-log-view-mode-map
-        :mode vc-hg-log-view-mode))
+        :mode vc-hg-log-view-mode
+        :eval-after-load vc-git))
     (with-eval-after-load 'vc-annotate
       (evilified-state-evilify-map vc-annotate-mode-map
        :mode vc-annotate-mode


### PR DESCRIPTION
Fix two more startup 'void variable' warnings, introduced (probably) after PR #15354.

For explanation, see PR message of #15544.