### PR TITLE
Fix broken recentf functionality due to PR #15574

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -275,6 +275,7 @@ Returns height in units of line height with a minimum of 1."
             (setq dotspacemacs-startup-buffer-show-icons nil)
 	          (setq lines (with-temp-buffer
                           (spacemacs-buffer//do-insert-startupify-lists)
+                          (recentf-mode -1)
                           (line-number-at-pos)))
               ;; (count-lines (point-min) (point-max)))
             (setq dotspacemacs-startup-buffer-show-icons icons)


### PR DESCRIPTION
A final 'force push' to PR #15574 implemented functionality to make the banner
size depend on the actual 'startup list' instead of the configured maximum
startup list size. However, that 'new' functionality uses
`spacemacs-buffer//do-insert-startupify-lists` which, effectively, activates `recentf-mode`,
and unfortunately, activating `recentf-mode` this early in the startup process
somehow breaks `recentf` functionality, see comments at
https://github.com/syl20bnr/spacemacs/commit/a485b5a84b3fa4f8a06b25f51cf6df49b51defb0.

This commit 'reverts' the functionality by making the banner size depend on the
configured maximum startup list size.