### PR TITLE
go: add variable to allow selection of new dap-dlv-mode

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -23,6 +23,7 @@
   - [[#tests][Tests]]
   - [[#coverage][Coverage]]
   - [[#guru][Guru]]
+  - [[#debug][Debug]]
 - [[#key-bindings][Key bindings]]
   - [[#go-commands-start-with-m][Go commands (start with =m=):]]
   - [[#go-guru][Go Guru]]
@@ -90,7 +91,7 @@ prepared you can simply run below command to install:
 **** Debugger
 Using the =dap= layer you'll get access to a graphical debugger integration.
 To do so add the layer =dap= to your dotfile. For a complete list of key bindings
-see the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/dap#key-bindings][dap layer description]].
+see the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/dap#key-bindings][dap layer description]]. See [[#debug][debugger configuration]] for options. 
 
 *** go-mode (deprecated)
 This was the old elisp based go backend. Since the introduction of
@@ -258,6 +259,16 @@ If you would like to use the =Go Guru= bindings in your work, in your project yo
 will need to set the scope with ~SPC m f o~. The scope is a comma separated set
 of packages, and Go's recursive operator is supported. In addition, you can
 prefix it with =-= to exclude a package from searching.
+
+** Debug
+Currently are two ways to setup dap debugger in golang, =go-dap= (which depends
+on a vscode extension for working properly) and =dap-dlv-go= a newer option that
+do not depend on vscode extension [[https://emacs-lsp.github.io/dap-mode/page/configuration/#go][more info on dap-mode]].
+By default =go-dap= is used, if you want to switch to =dap-dlv-go=, set the layer variable
+=dap-dlv-mode= to true:
+#+begin_src emacs-lisp
+  (go :variables dap-dlv-mode t)
+#+end_src
 
 * Key bindings
 ** Go commands (start with =m=):

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -74,3 +74,7 @@ If not set then `go-mode' is the default backend unless `lsp' layer is used."
 (spacemacs|defc go-test-command "go test"
   "Go test command. Default is `go test`."
   'string nil t)
+
+(spacemacs|defc dap-dlv-mode nil
+  "Go dap mode, `dap-dlv-mode` is newer and doesn't depends on a vscode extension."
+  'boolean nil t)

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -47,9 +47,22 @@
 (defun spacemacs//go-setup-dap ()
   "Conditionally setup go DAP integration."
   ;; currently DAP is only available using LSP
+  (if dap-dlv-mode
+      (spacemacs//go-setup-dap-dlv)
+    (spacemacs//go-setup-dap-vscode)))
+
+(defun spacemacs//go-setup-dap-vscode ()
+  "Conditionally setup go DAP integration with aold dlv (vscode) setup."
   (when (eq go-backend 'lsp)
     (require 'dap-go)
-    (dap-go-setup)))
+    (dap-go-setup))
+)
+
+(defun spacemacs//go-setup-dap-dlv ()
+  "Conditionally setup go DAP integration with new dlv config."
+  ;; currently DAP is only available using LSP
+  (when (eq go-backend 'lsp)
+    (require 'dap-dlv-go)))
 
 (defun spacemacs//go-setup-format ()
   "Conditionally setup format on save."


### PR DESCRIPTION
Added new variable in `go` layer to allow the selection beetwen two different debug options: `dap-go`(existing) and `dap-dlv-go` (newer without a dependency on vscode extension) refer https://emacs-lsp.github.io/dap-mode/page/configuration/#go for more info...
