### PR TITLE
[core] fix functions missed for byte-compiled core-spacemacs-buffer.el

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -838,16 +838,16 @@ in for example the `view-lossage' (C-h l) buffer:
 instead of:
  r                      ;; anonymous-command
  p                      ;; anonymous-command"
-  (let* ((func-name (spacemacs-buffer//startup-list-jump-func-name search-label))
-         (func-name-symbol (intern func-name)))
-    (eval `(defun ,func-name-symbol ()
-             (interactive)
-             (unless (search-forward ,search-label (point-max) t)
-               (search-backward ,search-label (point-min) t))
-             ,@(unless no-next-line
-                 '((forward-line 1)))
-             (back-to-indentation)))
-    `(define-key spacemacs-buffer-mode-map ,shortcut-char ',func-name-symbol)))
+  (let ((func-name-symbol
+         (intern (spacemacs-buffer//startup-list-jump-func-name search-label))))
+    `(progn (defun ,func-name-symbol ()
+              (interactive)
+              (unless (search-forward ,search-label (point-max) t)
+                (search-backward ,search-label (point-min) t))
+              ,@(unless no-next-line
+                  '((forward-line 1)))
+              (back-to-indentation))
+            (define-key spacemacs-buffer-mode-map ,shortcut-char ',func-name-symbol))))
 
 (defun spacemacs-buffer//center-line (&optional real-width)
   "When point is at the end of a line, center it.


### PR DESCRIPTION
The function `spacemacs-buffer/jump-to-recent-files` is used for jumping to the recent files by press `r` in Spacemacs home buffer.
Try to byte-compile the file `core-spacemacs-buffer.el`,
```
(byte-compile-file (concat spacemacs-core-directory "core-spacemacs-buffer.el"))
```
Restart the Spacemacs, then the function `spacemacs-buffer/jump-to-recent-files` is missed, press `r` in Spacemacs home buffer will not work, describe-function will not find the function.

This change fixed the issue with giving correct lisp for byte-compiler (avoid using the `eval` in lexical scope).