### PR TITLE
[python] fix config issue for native-comp

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -100,7 +100,7 @@
   (use-package code-cells
     :if (not (configuration-layer/layer-used-p 'ipython-notebook))
     :defer t
-    :init
+    :config
     (progn
       (add-hook 'python-mode-hook 'code-cells-mode)
       (spacemacs/set-leader-keys-for-minor-mode 'code-cells-mode


### PR DESCRIPTION
There is an issue that running `describe-key` (`C-h k`) will trigger an error message:
> mapcar: Symbol’s value as variable is void: code-cells-mode

The root cause is the `code-cells` package in `python` layer should use the `:config` instead of the `:init` tag.

Deatils:
It happend with Spacemacs `develop` branch with `python` layer, emacs-28 with native-comp enabled, on CentOS 7.

In GNU Emacs 28.1.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.22.30, cairo version 1.15.12)
 of 2022-06-18 built on dev
Repository revision: 422f958030f1c105c8f62f670b82875559b38e69
Repository branch: HEAD
Windowing system distributor 'The Cygwin/X Project', version 11.0.12101003
System Description: CentOS Linux 7 (Core)

Configured using:
 'configure CC=clang CXX=clang++ CFLAGS=-Os CXXFLAGS=-Os
 'LDFLAGS=-Wl,-rpath=\$$ORIGIN/../lib64' --prefix /home/.sunline/.root
 --with-xpm=yes --with-gnutls=yes --with-sound=no --without-gif
 --without-gpm --without-m17n-flt --without-libotf --without-tiff
 --with-native-compilation'

Configured features:
CAIRO DBUS FREETYPE GLIB GMP GNUTLS GSETTINGS HARFBUZZ JPEG JSON LCMS2
LIBSELINUX LIBXML2 MODULES NATIVE_COMP NOTIFY INOTIFY PDUMPER PNG RSVG
SECCOMP THREADS TOOLKIT_SCROLL_BARS X11 XDBE XIM XPM GTK3 ZLIB
