### PR TITLE
[core] fix error msg on byte-compiling core-configuration-layer.el

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -661,7 +661,7 @@ To prevent package from being installed or uninstalled set the variable
                        (list layer))
                       (dolist (pkg pkgs)
                         (let ((pkg-name (if (listp pkg) (car pkg) pkg)))
-                          (add-to-list 'all-other-packages pkg-name))))))
+                          (cl-pushnew pkg-name all-other-packages))))))
                 (configuration-layer//filter-distant-packages
                  all-other-packages nil))))))
       (configuration-layer//install-packages packages)
@@ -1887,7 +1887,7 @@ RNAME is the name symbol of another existing layer."
             (when install-deps
               (setq result (append install-deps result))))
           (when (funcall filter pkg-name)
-            (add-to-list 'result pkg-name t))))
+            (cl-pushnew pkg-name result))))
       (delete-dups result))))
 
 (defun configuration-layer//filter-packages-with-deps
@@ -2327,7 +2327,7 @@ depends on it."
           (let* ((dep-sym (car dep))
                  (value (spacemacs-ht-get result dep-sym)))
             (puthash dep-sym
-                     (if value (add-to-list 'value pkg-sym) (list pkg-sym))
+                     (if value (cl-pushnew pkg-sym value) (list pkg-sym))
                      result)))))
     result))
 
@@ -2337,7 +2337,7 @@ depends on it."
     (dolist (pkg package-alist)
       (let ((pkg-sym (car pkg)))
         (unless (memq pkg-sym packages)
-          (add-to-list 'imp-pkgs pkg-sym))))
+          (cl-pushnew pkg-sym imp-pkgs))))
     imp-pkgs))
 
 (defun configuration-layer//get-orphan-packages
@@ -2347,7 +2347,7 @@ depends on it."
     (dolist (imp-pkg implicit-pkgs)
       (when (configuration-layer//is-package-orphan
              imp-pkg dist-pkgs dependencies)
-        (add-to-list 'result imp-pkg)))
+        (cl-pushnew imp-pkg result)))
     result))
 
 (defun configuration-layer//is-package-orphan (pkg-name dist-pkgs dependencies)
@@ -2555,7 +2555,7 @@ depends on it."
                                   (assq x package-archive-contents)))))
           (dolist (pkg (cons pkg-sym elpa-deps))
             ;; avoid duplicates
-            (add-to-list 'result pkg)))))
+            (cl-pushnew pkg result)))))
     result))
 
 (defun configuration-layer//create-archive-contents-item (pkg-name)


### PR DESCRIPTION
There is the error messages when byte-compiling the `core-configuration-layer.el`, 
```
(byte-compile-file (concat spacemacs-core-directory "core-configuration-layer.el"))
```
Part of the error messages:
>In configuration-layer//filter-packages-with-deps-recur:
core-configuration-layer.el:1889:33: Error: ‘add-to-list’ can’t use lexical
    var ‘result’; use ‘push’ or ‘cl-pushnew’
