### PR TITLE
[git] Disable evil-surround-mode in all magit modes

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -60,7 +60,7 @@
 (defun git/post-init-evil-surround ()
   (spacemacs|use-package-add-hook magit
     :post-config
-    (add-hook 'magit-status-mode-hook #'turn-off-evil-surround-mode)))
+    (add-hook 'magit-mode-hook #'turn-off-evil-surround-mode)))
 
 (defun git/pre-init-evil-collection ()
   (when (spacemacs//support-evilified-buffer-p)


### PR DESCRIPTION
This is an extension of #15462.  I noticed that the fix did not apply
to magit-diff buffers, which still had the issue of `s' not being
available to stage diff hunks.  `magit-diff-mode' is the parent mode
of all magit modes, in which evil-surround is not useful, so disabling
there makes the most sense.

