### PR TITLE
[git] Remove magit-git-executable hack, which is no longer needed

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -243,12 +243,6 @@
         (which-key-add-keymap-based-replacements magit-status-mode-map
           "gf"  "jump-to-unpulled"
           "gp"  "jump-to-unpushed"))
-      ;; https://magit.vc/manual/magit/MacOS-Performance.html
-      ;; But modified according Tommi Komulainen's advice: "...going through
-      ;; shell raises an eyebrow, and in the odd edge case of not having git
-      ;; setting the executable to empty string(?) feels slightly wrong."
-      (when-let ((git (executable-find "git")))
-        (setq magit-git-executable git))
       ;; full screen magit-status
       (when git-magit-status-fullscreen
         (setq magit-display-buffer-function


### PR DESCRIPTION
magit v3.2.0 now defines `magit-git-executable` as a
function (actually a defsubst), and two separate variables,
`magit-git-executable` and `magit-remote-git-executable`.  On darwin,
magit already sets `magit-git-executable` to the result of
`(executable-find "git")`, so having this is now redundant in
Spacemacs.