### PR TITLE
[defaults] Exclude `custom-file` correctly in recentf

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -425,7 +425,7 @@
       (add-to-list 'recentf-exclude (recentf-expand-file-name package-user-dir))
       (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
       (when custom-file
-        (add-to-list 'recentf-exclude custom-file)))))
+        (add-to-list 'recentf-exclude (recentf-expand-file-name custom-file))))))
 
 (defun spacemacs-defaults/init-savehist ()
   (use-package savehist


### PR DESCRIPTION
Entries of recentf-exclude must be expanded, e.g., `~` for the home
directory won't work.
