### PR TITLE
[evil] bring back vi-tilde-fringe

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -344,8 +344,6 @@ In org-agenda-mode
 - Key bindings:
   - Add ~J/K~ to scroll up/down (or next/previous node) in Info-mode
   - Add ~o~ to link-hint-open-link in woman-mode
-***** Spacemacs-evil
-- Replace =vi-tilde-fringe= package with =vim-empty-lines-mode=
 ***** Shaders
 - =shaders= layer has been moved to =gpu= layer.
 ***** Syntax checking
@@ -378,8 +376,6 @@ In org-agenda-mode
     Constantin Gușoi)
   - Add ~SPC g f m~ for ~magit-file-dispatch~ (thanks to Ag Ibragimov and Ilya Grigoriev)
 - Removed [[https://github.com/defunkt/gist.el][gist.el]] due to it being broken and unmaintained (thanks to Robby O'Connor)
-***** Vim Empty Lines
-- The =vim-empty-lines= layer has been deleted and moved to the =spacemacs-evil= layer. (thanks to Ray Wang)
 ***** YAML
 - Added LSP support (thanks to Seong Yong-ju)
 ***** ycmd
@@ -506,7 +502,6 @@ In org-agenda-mode
 - extra-langs (replaced by =ad-hoc= layers)
 - flow-type (replaced by LSP in =javascript= layer)
 - ycmd (moved to =c-c++=)
-- vim-empty-lines (moved to =spacemacs-evil=)
 *** Dotfile changes
 - Added type bases validation for .spacemacs variables.
 - New Variables:
@@ -549,7 +544,6 @@ In org-agenda-mode
   - New variable =dotspacemacs-scroll-bar-while-scrolling= (thanks to duianto)
   - New variable =dotspacemacs-show-startup-list-numbers= (thanks to duianto)
   - New variable =dotspacemacs-startup-banner-scale= (thanks to Daniel)
-  - New variable =dotspacemacs-evil-show-empty-line-indicators= (thanks to Ray Wang)
 - Removed Variables:
   - Removed unused variable =dotspacemacs-verbose-loading= from
     =.spacemacs.template= (thanks to Ying Qu)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -201,12 +201,6 @@ in `dotspacemacs-themes'.")
            (const hybrid) (cons symbol sexp))
   'spacemacs-dotspacemacs-init)
 
-(spacemacs|defc dotspacemacs-evil-show-empty-line-indicators t
-  "If non-nil, show vim-like empty line indicators at the end of files.
-It defaults to `t', and only works when `spacemacs-evil' layer is enabled."
-  'boolean
-  'spacemacs-dotspacemacs-layers)
-
 (spacemacs|defc dotspacemacs-startup-banner 'official
   "Specify the startup banner. Default value is `official', it displays
 the official spacemacs logo. An integer value is the index of text

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -167,12 +167,6 @@ It should only modify the values of Spacemacs settings."
    ;; (default 'vim)
    dotspacemacs-editing-style 'vim
 
-   ;; If non-nil, show vim-like empty line indicators at the end of files.
-   ;; Takes effect only if `spacemacs-evil' layer is enabled.
-   ;; NOTICE: `spacemacs-evil' is included in `spacemacs' distribution.
-   ;; See `dotspacemacs-distribution'.
-   dotspacemacs-evil-show-empty-line-indicators t
-
    ;; If non-nil show the version string in the Spacemacs buffer. It will
    ;; appear as (spacemacs version)@(emacs version)
    ;; (default t)

--- a/layers/+checkers/spell-checking/README.org
+++ b/layers/+checkers/spell-checking/README.org
@@ -154,8 +154,7 @@ set the layer variable =enable-flyspell-auto-completion= to t:
 | ~SPC S . S~ | Add word to dict (session)                       |
 
 * Known issues
-Vim-empty-lines package seems incompatible with spell-checking inside org-mode. If
+Vim-empty-lines layer seems incompatible with spell-checking inside org-mode. If
 you experience "Args out of range" error message when invoking ~SPC S c~ inside
-org-mode buffer then check if you don't have vim-empty-lines package enabled and
-disable it by setting =dotspacemacs-evil-show-empty-line-indicators= to =nil= in
-your =.spacemacs= file.
+org-mode buffer then check if you don't have vim-empty-lines layer enabled and
+disable it.

--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -26,7 +26,7 @@
         (company-coq :requires company)
         proof-general
         smartparens
-        vim-empty-lines-mode))
+        vi-tilde-fringe))
 
 
 (defun coq/init-company-coq ()
@@ -123,7 +123,7 @@
 (defun coq/post-init-smartparens ()
   (add-hook 'coq-mode-hook #'spacemacs//activate-smartparens))
 
-(defun coq/post-init-vim-empty-lines-mode ()
-  (spacemacs/add-to-hooks 'spacemacs/disable-vim-empty-lines-mode
+(defun coq/post-init-vi-tilde-fringe ()
+  (spacemacs/add-to-hooks 'spacemacs/disable-vi-tilde-fringe
                           '(coq-response-mode-hook
                             coq-goals-mode-hook)))

--- a/layers/+spacemacs/spacemacs-evil/README.org
+++ b/layers/+spacemacs/spacemacs-evil/README.org
@@ -32,7 +32,7 @@ throughout the entirety of Spacemacs.
 - Evilification of various modes if the editing style is =vim= or =hybrid=
 - Improves the comment function to be able to also do the inverse operation
 - Persistent highlight of searched text with =evil-search-highlight-persist=
-- Display tildes in non-buffer area with =vim-empty-lines-mode=
+- Display tildes in non-buffer area with =vi-tilde-fringe=
 - Add =evil-collection=
 
 * Install

--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -74,20 +74,16 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
     (evil-escape-mode -1)))
 
 
-;; vim-empty-lines-mode
+;; vi-tilde-fringe
 
-(defun spacemacs/disable-vim-empty-lines-mode ()
-  "Disable `vim-empty-lines-mode' in the current buffer."
-  (vim-empty-lines-mode -1))
+(defun spacemacs/disable-vi-tilde-fringe ()
+  "Disable `vi-tilde-fringe' in the current buffer."
+  (vi-tilde-fringe-mode -1))
 
-(defun spacemacs/disable-vim-empty-lines-mode-read-only ()
-  "Disable `vim-empty-lines-mode' in the current buffer if it is read only."
+(defun spacemacs/disable-vi-tilde-fringe-read-only ()
+  "Disable `vi-tilde-fringe' in the current buffer if it is read only."
   (when buffer-read-only
-    (spacemacs/disable-vim-empty-lines-mode)))
-
-;; Backward compatibility
-(defalias 'spacemacs/disable-vi-tilde-fringe 'spacemacs/disable-vim-empty-lines-mode)
-(defalias 'spacemacs/disable-vi-tilde-fringe-read-only 'spacemacs/disable-vim-empty-lines-mode-read-only)
+    (spacemacs/disable-vi-tilde-fringe)))
 
 
 ;; lisp state

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -48,7 +48,7 @@
         evil-visual-mark-mode
         evil-visualstar
         (hs-minor-mode :location built-in)
-        (vim-empty-lines-mode :toggle dotspacemacs-evil-show-empty-line-indicators)
+        vi-tilde-fringe
         eldoc))
 
 (defun spacemacs-evil/init-evil-anzu ()
@@ -417,32 +417,27 @@
 (defun spacemacs-evil/init-hs-minor-mode ()
   (add-hook 'prog-mode-hook 'spacemacs//enable-hs-minor-mode))
 
-(defun spacemacs-evil/init-vim-empty-lines-mode ()
+(defun spacemacs-evil/init-vi-tilde-fringe ()
   (spacemacs|do-after-display-system-init
-   (use-package vim-empty-lines-mode
+   (use-package vi-tilde-fringe
      :init
-     (spacemacs/add-to-hooks (lambda () (vim-empty-lines-mode -1))
-                             '(comint-mode-hook
-                               eshell-mode-hook
-                               eww-mode-hook
-                               shell-mode-hook
-                               term-mode-hook))
-     :config
      (progn
-       (spacemacs|hide-lighter vim-empty-lines-mode)
-       (global-vim-empty-lines-mode)
-       (spacemacs|add-toggle vim-empty-lines-mode
-         :mode global-vim-empty-lines-mode
+       (global-vi-tilde-fringe-mode)
+       (spacemacs|add-toggle vi-tilde-fringe
+         :mode global-vi-tilde-fringe-mode
          :documentation
-         "Display an overlay of ~ on empty lines."
+         "Globally display a ~ on empty lines in the fringe."
          :evil-leader "T~")
-       ;; Don't enable it where it is detrimental.
-       (dolist (x (list spacemacs-buffer-name
-                        "*Messages*"))
-         (with-current-buffer x (vim-empty-lines-mode -1)))
-       (add-hook 'which-key-init-buffer-hook (lambda () (vim-empty-lines-mode -1)))
+       ;; don't enable it on some special buffers
+       (with-current-buffer spacemacs-buffer-name
+         (spacemacs/disable-vi-tilde-fringe))
+       (add-hook 'which-key-init-buffer-hook 'spacemacs/disable-vi-tilde-fringe)
        ;; after a major mode is loaded, check if the buffer is read only
-       ;; if so, disable vim-empty-lines-mode
-       (add-hook 'after-change-major-mode-hook (lambda ()
-                                                 (when buffer-read-only
-                                                   (vim-empty-lines-mode -1))))))))
+       ;; if so, disable vi-tilde-fringe-mode
+       (add-hook 'after-change-major-mode-hook
+                 'spacemacs/disable-vi-tilde-fringe-read-only)
+       ;; TODO move this hook if/when we have a layer for eww
+       (spacemacs/add-to-hooks 'spacemacs/disable-vi-tilde-fringe
+                               '(eww-mode-hook)))
+     :config
+     (spacemacs|hide-lighter vi-tilde-fringe-mode))))

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -41,7 +41,7 @@
     (term :location built-in)
     xterm-color
     terminal-here
-    vim-empty-lines-mode
+    vi-tilde-fringe
     window-purpose
     (vterm :toggle (not (spacemacs/system-is-mswindows)))))
 
@@ -332,8 +332,8 @@
         "p \"" 'terminal-here-project-launch))))
 
 
-(defun shell/post-init-vim-empty-lines-mode ()
-  (spacemacs/add-to-hooks 'spacemacs/disable-vim-empty-lines-mode
+(defun shell/post-init-vi-tilde-fringe ()
+  (spacemacs/add-to-hooks 'spacemacs/disable-vi-tilde-fringe
                           '(comint-mode-hook
                             eshell-mode-hook
                             shell-mode-hook

--- a/layers/+vim/vim-empty-lines/README.org
+++ b/layers/+vim/vim-empty-lines/README.org
@@ -1,0 +1,28 @@
+#+TITLE: Vim-empty-lines layer
+
+#+TAGS: layer|vim
+
+* Table of Contents                     :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+
+* Description
+This layer is a drop-in replacement for the =vi-tilde-fringe= mode, for those
+who desire behaviour closer to =vim='s.
+
+It has better compatibility with retina displays, as it uses a text overlay
+using your font, rather than a pixel-art tilde. The empty line indicators are
+overlaid in within the buffer as in =vim=, and not in the fringe. The indicator
+behaviour with trailing empty lines matches =vim='s behaviour.
+
+For details, see the [[https://github.com/jmickelin/vim-empty-lines-mode][vim-empty-lines-mode]] repository.
+
+** Features:
+- Emulation of original vim behaviour.
+- Brings you as close to vim as one can be without using vim itself.
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =vim-empty-lines= to the existing =dotspacemacs-configuration-layers= list in this
+file.

--- a/layers/+vim/vim-empty-lines/packages.el
+++ b/layers/+vim/vim-empty-lines/packages.el
@@ -1,0 +1,33 @@
+(setq vim-empty-lines-packages
+      '(
+        vim-empty-lines-mode
+        (vi-tilde-fringe :excluded t)))
+
+(defun vim-empty-lines/init-vim-empty-lines-mode ()
+  (use-package vim-empty-lines-mode
+    :init
+    (spacemacs/add-to-hooks (lambda () (vim-empty-lines-mode -1))
+                            '(comint-mode-hook
+                              eshell-mode-hook
+                              eww-mode-hook
+                              shell-mode-hook
+                              term-mode-hook))
+    :config
+    (progn
+      (spacemacs|hide-lighter vim-empty-lines-mode)
+      (global-vim-empty-lines-mode)
+      (spacemacs|add-toggle vim-empty-lines-mode
+        :mode global-vim-empty-lines-mode
+        :documentation
+        "Display an overlay of ~ on empty lines."
+        :evil-leader "t~")
+      ;; Don't enable it where it is detrimental.
+      (dolist (x (list spacemacs-buffer-name
+                       "*Messages*"))
+        (with-current-buffer x (vim-empty-lines-mode -1)))
+      (add-hook 'which-key-init-buffer-hook (lambda () (vim-empty-lines-mode -1)))
+      ;; after a major mode is loaded, check if the buffer is read only
+      ;; if so, disable vim-empty-lines-mode
+      (add-hook 'after-change-major-mode-hook (lambda ()
+                                                (when buffer-read-only
+                                                  (vim-empty-lines-mode -1)))))))

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -256,6 +256,7 @@
   - [[#evil-better-jumper][Evil-better-jumper]]
   - [[#evil-commentary][Evil-commentary]]
   - [[#evil-snipe][Evil-snipe]]
+  - [[#vim-empty-lines][Vim-empty-lines]]
   - [[#vinegar][Vinegar]]
 - [[#web-services][Web services]]
   - [[#confluence][Confluence]]
@@ -930,7 +931,7 @@ Features:
 - Evilification of various modes if the editing style is =vim= or =hybrid=
 - Improves the comment function to be able to also do the inverse operation
 - Persistent highlight of searched text with =evil-search-highlight-persist=
-- Display tildes in non-buffer area with =vim-empty-lines-mode=
+- Display tildes in non-buffer area with =vi-tilde-fringe=
 - Add =evil-collection=
 
 ** Spacemacs-language
@@ -3290,6 +3291,23 @@ Features:
 - Replacement of evil-surround with a two-character search.
 - Support for alternative scopes for default search operations.
 - Support for alternative motions based on configurable regexps.
+
+** Vim-empty-lines
+[[file:+vim/vim-empty-lines/README.org][+vim/vim-empty-lines/README.org]]
+
+This layer is a drop-in replacement for the =vi-tilde-fringe= mode, for those
+who desire behaviour closer to =vim='s.
+
+It has better compatibility with retina displays, as it uses a text overlay
+using your font, rather than a pixel-art tilde. The empty line indicators are
+overlaid in within the buffer as in =vim=, and not in the fringe. The indicator
+behaviour with trailing empty lines matches =vim='s behaviour.
+
+For details, see the [[https://github.com/jmickelin/vim-empty-lines-mode][vim-empty-lines-mode]] repository.
+
+Features:
+- Emulation of original vim behaviour.
+- Brings you as close to vim as one can be without using vim itself.
 
 ** Vinegar
 [[file:+vim/vinegar/README.org][+vim/vinegar/README.org]]


### PR DESCRIPTION
https://github.com/syl20bnr/spacemacs/issues/15622
Revert "Delete vim-empty-lines layer and merge its code into spacemacs-evil"

This reverts commit ebd920e23a287eacf0a42ff0e3eef4b2db95d3dd.

