### PR TITLE
Fix a previous attempted fix loading mu4e.

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -168,8 +168,13 @@ mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
 (defun mu4e/pre-init-org ()
   (if mu4e-org-link-support
       (with-eval-after-load 'org
-        (if (version<= "1.8.2" mu4e-mu-version)
-            (require 'mu4e-config)
+        ;; This is a dirty hack due to mu(4e) 1.8.2 renaming mu4e-meta to
+        ;; mu4e-config.  See also
+        ;; https://github.com/djcb/mu/commit/cf0f72e4a48ac7029d7f6758b182d4bb559f8f49
+        ;; and https://github.com/syl20bnr/spacemacs/issues/15618.  This code
+        ;; used to simply read: (require 'mu4e-meta).  We now attempt to load
+        ;; mu4e-config.  If this fails, load mu4e-meta.
+        (unless (ignore-errors (require 'mu4e-config))
           (require 'mu4e-meta))
         (if (version<= mu4e-mu-version "1.3.5")
             (require 'org-mu4e)


### PR DESCRIPTION
As  0ce1201a3 did not fix issue #15618 as expected, this hopefully does.

The variable used to determine the version is set in the file which should be loaded.

This is a bit hacky, and may be removed some time in the future when mu versions older than 1.8.2 are no longer supported.