### PR TITLE
Add /recentf~ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /image-dired
 /network-security.data
 /recentf
+/recentf~
 /session.*
 /srecode-map.el
 \#*


### PR DESCRIPTION
More context: on the `develop` branch, I updated from 1a4912e51fdc012ba571c670e8c8e8c5eb4695d1 to 4eaff25268634fcb8137b91fb7d0b7598588cbca and I noticed I have `recentf~` created in `~/.emacs.d`. If you delete it it gets created again on the next emacs restart.

Given that I have the spacemacs code as a submodule of my dotfiles repo, this shows up as an unwanted change.

This seems a not too controversial change *there is already `.recentf` and `.recentf~` for example), but let me know if you want me to do more investigation.