### PR TITLE
Undo-region: more ergonomic keybindings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -127,6 +127,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
     (thanks to Seong Yong-ju)
   - Changed ~SPC t t m~ from ~timeclock-modeline-display~ which was deprecated
     in Emacs 24.3 to ~timeclock-mode-line-display~ (thanks to Zach Pearson)
+  - Added =vim-style-enable-undo-region= style variables to enable undo-region
+    in Vim editing style; disabled by default
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -128,7 +128,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - Changed ~SPC t t m~ from ~timeclock-modeline-display~ which was deprecated
     in Emacs 24.3 to ~timeclock-mode-line-display~ (thanks to Zach Pearson)
   - Added =vim-style-enable-undo-region= style variables to enable undo-region
-    in Vim editing style; disabled by default
+    in Vim editing style; disabled by default. (thanks to Benedict HW)
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -75,9 +75,8 @@ if used there.")
   "If non-nil, J and K move lines up and down when in visual mode.")
 
 (defvar vim-style-enable-undo-region nil
-  " If non-nil, `u' is remapped to `undo' when in visual mode. Vim
-  `u' default in visual mode is to downcase visually selected
-  text. `~' will invert the case of a visual selection.")
+  "If non-nil, `u' is remapped to `undo' in visual state.
+Otherwise, in visual state `u' downcases visually selected text.")
 
 (defvar vim-style-ex-substitute-global
   (spacemacs|dotspacemacs-backward-compatibility

--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -74,6 +74,11 @@ if used there.")
    dotspacemacs-visual-line-move-text nil)
   "If non-nil, J and K move lines up and down when in visual mode.")
 
+(defvar vim-style-enable-undo-region nil
+  " If non-nil, `u' is remapped to `undo' when in visual mode. Vim
+  `u' default in visual mode is to downcase visually selected
+  text. `~' will invert the case of a visual selection.")
+
 (defvar vim-style-ex-substitute-global
   (spacemacs|dotspacemacs-backward-compatibility
    dotspacemacs-ex-substitute-global nil)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -145,6 +145,9 @@
     (define-key evil-visual-state-map "J" 'drag-stuff-down)
     (define-key evil-visual-state-map "K" 'drag-stuff-up))
 
+  (when vim-style-enable-undo-region
+    (define-key evil-visual-state-map (kbd "u") 'undo))
+
   (evil-ex-define-cmd "enew" 'spacemacs/new-empty-buffer)
 
   (define-key evil-normal-state-map (kbd "K") 'spacemacs/evil-smart-doc-lookup)

--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -5,7 +5,7 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
-- [[#key-bindings][Key bindings]]
+- [[#customization][Customization]]
   - [[#undo-region][Undo Region]]
 
 * Description
@@ -37,17 +37,18 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for editing strings inplace via [[https://github.com/magnars/string-edit.el][=string-edit=]]
 - Presents undo history as a tree via [[https://gitlab.com/tsc25/undo-tree/-/blob/master/undo-tree.el][=undo-tree=]]
 
-* Key bindings
+* Customization
 ** Undo Region
+In normal state, ~u~ is bound to =evil-undo= which undo changes in the buffer.
+Emacs's builtin =undo= command in addition has the ability to undo changes in a
+selected region. But by default in visual state, ~u~ is bound to =evil-downcase=
+which downcases the selected text.
 
-Performs a selective undo, limited to the current region. To do this, visually
-select the region you want, then run the undo command (=u= in vim style editing).
-This undoes the most recent change in the region. To undo further changes in the
-same region, repeat the undo command. This feature is turned off by default, to
-enable it, set the variable =vim-style-enable-undo-region= to =t=.
+You can bound =undo= to ~u~ in visual state, by setting the variable
+=vim-style-enable-undo-region= to =t= in your =~/.spacemacs=.
 
 #+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers '(
-    (spacemacs-editing :variables
-         vim-style-enable-undo-region t)))
+  (setq-default dotspacemacs-configuration-layers
+                '((spacemacs-editing :variables
+                                     vim-style-enable-undo-region t)))
 #+END_SRC

--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -5,6 +5,8 @@
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
+- [[#key-bindings][Key bindings]]
+  - [[#undo-region][Undo Region]]
 
 * Description
 This layer adds packages to improve editing with Spacemacs.
@@ -34,3 +36,18 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for cycling between multi line block styles via [[https://github.com/IvanMalison/multi-line/][=multi-line=]].
 - Support for editing strings inplace via [[https://github.com/magnars/string-edit.el][=string-edit=]]
 - Presents undo history as a tree via [[https://gitlab.com/tsc25/undo-tree/-/blob/master/undo-tree.el][=undo-tree=]]
+
+* Key bindings
+** Undo Region
+
+Performs a selective undo, limited to the current region. To do this, visually
+select the region you want, then run the undo command (=u= in vim style editing).
+This undoes the most recent change in the region. To undo further changes in the
+same region, repeat the undo command. This feature is turned off by default, to
+enable it, set the variable =vim-style-enable-undo-region= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (spacemacs-editing :variables
+         vim-style-enable-undo-region t)))
+#+END_SRC

--- a/layers/+spacemacs/spacemacs-editing/README.org
+++ b/layers/+spacemacs/spacemacs-editing/README.org
@@ -33,3 +33,4 @@ This layer adds packages to improve editing with Spacemacs.
 - Support for [[https://github.com/PythonNut/evil-easymotion][=evil-easymotion=]] if the editing style is =vim= or =hybrid=.
 - Support for cycling between multi line block styles via [[https://github.com/IvanMalison/multi-line/][=multi-line=]].
 - Support for editing strings inplace via [[https://github.com/magnars/string-edit.el][=string-edit=]]
+- Presents undo history as a tree via [[https://gitlab.com/tsc25/undo-tree/-/blob/master/undo-tree.el][=undo-tree=]]

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -536,6 +536,7 @@
     (progn
       (setq undo-tree-visualizer-timestamps t
             undo-tree-visualizer-diff t
+            ;; See `vim-style-enable-undo-region'.
             undo-tree-enable-undo-in-region t
             ;; 10X bump of the undo limits to avoid issues with premature
             ;; Emacs GC which truncages the undo history very aggresively

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -536,6 +536,7 @@
     (progn
       (setq undo-tree-visualizer-timestamps t
             undo-tree-visualizer-diff t
+            undo-tree-enable-undo-in-region t
             ;; 10X bump of the undo limits to avoid issues with premature
             ;; Emacs GC which truncages the undo history very aggresively
             undo-limit 800000


### PR DESCRIPTION
As was the case with `vim-style-remap-Y-to-y$', or rebinding "s" to
evil-surround over vim's default substitute, by rebinding "u" to undo-region
is a sensible trade-off given that prior to this, undo-region was accessible
only through SPC SPC C-_.

See https://emacs.stackexchange.com/questions/32244/undo-region-spacemacs

Comments and suggestions?