### PR TITLE
[spacemacs-bootstrap] Remove whitespace from kill ring.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -100,6 +100,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - The property =:powerline-scale= of variable =dotspacemacs-default-font= has
   been removed and replaced by the property =:separator-scale= used in the new
   dotfile variable =dotspacemacs-mode-line-theme=.
+- If =dotspacemacs-enable-paste-transient-state= is enabled, whitespace is
+  removed from the kill ring for better ergonomics.
 **** Layers
 ***** Spacemacs distribution layers
 - Key bindings:

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -101,7 +101,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   been removed and replaced by the property =:separator-scale= used in the new
   dotfile variable =dotspacemacs-mode-line-theme=.
 - If =dotspacemacs-enable-paste-transient-state= is enabled, whitespace is
-  removed from the kill ring for better ergonomics.
+  removed from the kill ring for better ergonomics. (thanks to BenedictHW)
 **** Layers
 ***** Spacemacs distribution layers
 - Key bindings:

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -324,7 +324,7 @@ It should only modify the values of Spacemacs settings."
 
    ;; If non-nil, the paste transient-state is enabled. While enabled, after you
    ;; paste something, pressing `C-j' and `C-k' several times cycles through the
-   ;; elements in the `kill-ring'. (default nil)
+   ;; non-whitespace elements in the `kill-ring'. (default nil)
    dotspacemacs-enable-paste-transient-state nil
 
    ;; Which-key delay in seconds. The which-key buffer is the popup listing

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -243,14 +243,14 @@
       "p" 'spacemacs/paste-transient-state/evil-paste-after)
     (define-key evil-normal-state-map
       "P" 'spacemacs/paste-transient-state/evil-paste-before)
-    (advice-add 'kill-new :around
-                (lambda (orig-fn string &optional rest)
-                  (let* ((string-raw (substring-no-properties string))
-                         (space-p (not (string-match-p "[^ \t\n\r]" string-raw))))
-                    (cond ((not space-p)
-                           (apply orig-fn string rest))
-                          (t
-                           (message "skipped whitespace kill")))))))
+    (define-advice kill-new (:around (orig-fn string &optional rest) ignore-whitespaces)
+      "Don't put whitespaces into kill ring."
+      (let* ((string-raw (substring-no-properties string))
+             (space-p (not (string-match-p "[^ \t\n\r]" string-raw))))
+        (if (not space-p)
+            (apply orig-fn string rest)
+          (message "skipped whitespace kill")
+          nil))))
 
   ;; fold transient state
   (when (eq 'evil dotspacemacs-folding-method)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -243,6 +243,7 @@
       "p" 'spacemacs/paste-transient-state/evil-paste-after)
     (define-key evil-normal-state-map
       "P" 'spacemacs/paste-transient-state/evil-paste-before)
+    ;; Based on https://stackoverflow.com/questions/12102554/emacs-skip-whitespace-kills
     (define-advice kill-new (:around (orig-fn string &optional rest) ignore-whitespaces)
       "Don't put whitespaces into kill ring."
       (let* ((string-raw (substring-no-properties string))

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -239,7 +239,16 @@
     (define-key evil-normal-state-map
       "p" 'spacemacs/paste-transient-state/evil-paste-after)
     (define-key evil-normal-state-map
-      "P" 'spacemacs/paste-transient-state/evil-paste-before))
+      "P" 'spacemacs/paste-transient-state/evil-paste-before)
+    (advice-add 'kill-new :around
+                (lambda (orig-fn string &optional rest)
+                  (let* ((string-raw (substring-no-properties string))
+                         (space-p (not (string-match-p "[^ \t\n\r]" string-raw))))
+                    (cond ((not space-p)
+                           (apply orig-fn string rest))
+                          (t
+                           (message "skipped whitespace kill")))))))
+
   ;; fold transient state
   (when (eq 'evil dotspacemacs-folding-method)
     (spacemacs|define-transient-state fold


### PR DESCRIPTION
More discussion at https://github.com/syl20bnr/spacemacs/discussions/15455

Is it alright if the advising function is anonymous?