### PR TITLE
Enable tws mode also in text-mode in addition to prog-mode.

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -486,8 +486,10 @@ It should only modify the values of Spacemacs settings."
    ;; (default nil - same as frame-title-format)
    dotspacemacs-icon-title-format nil
 
-   ;; Show trailing whitespace (default t)
-   dotspacemacs-show-trailing-whitespace t
+   ;; Color highlight trailing whitespace in all prog-mode and text-mode derived
+   ;; modes such as c++-mode, python-mode, emacs-lisp, html-mode, rst-mode etc.
+   ;; (default t)
+   dotspacemacs-show-trailing-whitespace t 
 
    ;; Delete whitespace while saving buffer. Possible values are `all'
    ;; to aggressively delete empty line and long sequences of whitespace,

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -511,6 +511,7 @@
          'trailing-whitespace nil
          :background (face-attribute 'font-lock-comment-face :foreground)))
       (add-hook 'prog-mode-hook 'spacemacs//trailing-whitespace)
+      (add-hook 'text-mode-hook 'spacemacs//trailing-whitespace)
 
       (spacemacs|add-toggle whitespace
         :mode whitespace-mode


### PR DESCRIPTION
Color highlighting of trailing white spaces is currently enabled only in prog-mode derived modes.  This is changed so that it is also enabled in all text-mode derived modes.  Also documentation for the user variable was updated.

This change should fix https://github.com/syl20bnr/spacemacs/issues/15621