### PR TITLE
[major-modes] Add Gemtext support

### DIFF
--- a/layers/+lang/major-modes/README.org
+++ b/layers/+lang/major-modes/README.org
@@ -8,6 +8,7 @@
 - [[#key-bindings][Key bindings]]
   - [[#arch-linux-pkgbuilds][Arch Linux PKGBUILDs]]
   - [[#gentoo-ebuilds][Gentoo ebuilds]]
+  - [[#gemtext][Gemtext]]
 
 * Description
 This layer adds a number of packages for less common languages and major modes.
@@ -17,6 +18,7 @@ This layer adds a number of packages for less common languages and major modes.
   - Arch Linux PKGBUILDs
   - Arduino
   - Android Logcat (not associated with any file types by default)
+  - Gemtext
   - Gentoo ebuilds
   - Hoon
   - MATLAB
@@ -48,3 +50,13 @@ This layer adds a number of packages for less common languages and major modes.
 | ~SPC m k~   | Edit keywords          |
 | ~SPC m e~   | Run ebuild command     |
 | ~SPC m a~   | Add ChangeLog entry    |
+
+** Gemtext
+
+| Key binding | Description           |
+|-------------+-----------------------|
+| ~SPC m l~   | Insert link           |
+| ~SPC m o~   | Open selected link    |
+| ~SPC m RET~ | Insert list item      |
+| ~SPC m t~   | Insert timestamp      |
+| ~SPC m n~   | Insert tinylog header |

--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -26,6 +26,7 @@
         arduino-mode
         (ebuild-mode :location (recipe :fetcher github :repo "emacsmirror/ebuild-mode"))
         evil-matchit
+        (gemini-mode :location (recipe :fetcher git :url "https://git.carcosa.net/jmcbray/gemini.el"))
         (hoon-mode :location (recipe :fetcher github :repo "urbit/hoon-mode.el"))
         (logcat :location (recipe :fetcher github :repo "dcolascione/logcat-mode"))
         matlab-mode
@@ -51,6 +52,17 @@
         "k" 'ebuild-mode-keyword
         "e" 'ebuild-run-command
         "a" 'ebuild-run-echangelog))))
+
+(defun major-modes/init-gemini-mode ()
+  (use-package gemini-mode
+    :init
+    (progn
+      (spacemacs/set-leader-keys-for-major-mode 'gemini-mode
+        "l" 'gemini-insert-link
+        "o" 'gemini-open-link-at-point
+        "RET" 'gemini-insert-list-item
+        "t" 'gemini-insert-time-stamp
+        "n" 'gemini-insert-tinylog-header))))
 
 (defun major-modes/init-hoon-mode ())
 


### PR DESCRIPTION
Really simple PR, just adds [gemini.el](https://git.carcosa.net/jmcbray/gemini.el) for Gemtext support and adds leader-key bindings for its functions.

Gemtext is the native markup language for the [Gemini protocol](https://gemini.circumlunar.space).