### PR TITLE
Fix `vim-powerline` error during startup

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -37,7 +37,7 @@
         spaceline
         spaceline-all-the-icons
         symon
-        (vim-powerline :location (recipe :fetcher local))))
+        (vim-powerline :location local)))
 
 (defun spacemacs-modeline/post-init-anzu ()
   (when (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))


### PR DESCRIPTION
# General
- System: OSX/M1
- Emacs version: 28.1
- Installed by nix (22.05) with home-manager
- Revision: latest development
# The bug
After updating emacs to the latest development branch, I was getting the following error on every startup:
```
(Spacemacs) --> installing package: vim-powerline@spacemacs-modeline... [1/1]
Fetcher: file
Source: nil

/Users/haru/.emacs.d/.cache/quelpa/build/vim-powerline/vim-colors.el -> /var/folders/ts/5p4gxt6941q3mbmflmmrqm2w0000gn/T/vim-powerlineA7SmZK/vim-powerline-20220721.194245/vim-colors.el
/Users/haru/.emacs.d/.cache/quelpa/build/vim-powerline/vim-powerline-theme.el -> /var/folders/ts/5p4gxt6941q3mbmflmmrqm2w0000gn/T/vim-powerlineA7SmZK/vim-powerline-20220721.194245/vim-powerline-theme.el
Error getting PACKAGE-DESC: (file-missing Opening input file No such file or directory /Users/haru/.emacs.d/.cache/quelpa/packages/vim-powerline-20220721.194245.tar)
(Spacemacs) Error: 
An error occurred while installing vim-powerline (error: (wrong-type-argument package-desc nil))
```
The error persisted even after clearing caches.
Did not attempt a clean install.
As the commit message states, `vim-powerline` is currently within `spacemacs-modeline`. So it seems that changing its `:location` value to `local` suffices to get the package.
Please let me know if I got something wrong ❤️ 