### PR TITLE
fix: dotspacemacs-directory is expected to end with a slash

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -38,8 +38,8 @@ their configuration.")
 (defconst dotspacemacs-directory
   (let* ((spacemacs-dir-env (getenv "SPACEMACSDIR"))
          (spacemacs-dir (if spacemacs-dir-env
-                            (expand-file-name spacemacs-dir-env)
-                          (expand-file-name ".spacemacs.d" user-home-directory))))
+                            (expand-file-name (concat spacemacs-dir-env "/"))
+                          (expand-file-name ".spacemacs.d/" user-home-directory))))
     (when (file-directory-p spacemacs-dir)
       spacemacs-dir))
   "Directory containing Spacemacs customizations (defaults to nil).


### PR DESCRIPTION
Commit 861ea131e1be7963b9602e774024f687fe9d4a29 refactored the definition of
dotspacemacs-directory, but did not ensure that the path ended with a slash,
which is expected elsewhere in the code

This prevented spacemacs from loading the environment file and the user's custom layers
