### PR TITLE
Added documentation to set julia envornment location for lsp server

### DIFF
--- a/layers/+lang/julia/README.org
+++ b/layers/+lang/julia/README.org
@@ -46,10 +46,17 @@ for installation, and then install this layer with:
      (julia :variables julia-backend 'lsp)))
 #+END_SRC
 
+
 =LanguageServer.jl= tends to have a very long startup time. In the worst case,
 =lsp-mode= might give up on the language server before its started, but
 regardless usage of =lsp-mode= with Julia can cause long delays when first
 opening files. 
+
+By default, the langage server looks for the julia enviornment in =~/.julia/enviornments/v1.0=.
+However, unless julia 1.0 is being used, the enviornment path will be incorrect.
+Code completions from imported packages will not work. To fix this, set =lsp-julia-default-environment=
+to =~/.julia/enviornments/v<your julia version>=. For more information and configuration
+options, see [[https://github.com/gdkrmr/lsp-julia][lsp-julia documentation]].
 
 * Options
 While =julia-mode= is perfectly usable without configuration or other packages,


### PR DESCRIPTION
lsp-julia-default-envornment is set by default to ~/.julia/environments/v1.0 .
To make the lsp server show completions for installed packages, the environment
location must be the same as that of the installed julia version enviornment.
Documentation was added to notify users to set the emacs variable to their
enviornment location.
