### PR TITLE
* core/core-configuration-layer.el: fix log for rshadow relationship

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1599,7 +1599,7 @@ RNAME is the name symbol of another existing layer."
          lname))
       (when (null rlayer)
         (configuration-layer//warning
-         "Unknown layer %s to declare lshadow relationship."
+         "Unknown layer %s to declare rshadow relationship."
          rname)))))
 
 (defun configuration-layer//set-layers-variables (layer-names)


### PR DESCRIPTION
Hi,

The log for the rshadow relationship message is really confusion , and after check the code, it's from the wrong line.

This patch is try to fix it.