### PR TITLE
*core/core-dumper.el: Enhance for native-compile support

### DIFF
--- a/core/core-dumper.el
+++ b/core/core-dumper.el
@@ -49,32 +49,16 @@
 (defconst spacemacs--dump-spinner-construct
   '("" (:eval (spinner-print spacemacs-dump-spinner))))
 
-(defun spacemacs/dump-save-load-path ()
-  "Save `load-path' variable."
-  (setq spacemacs-dump-load-path load-path))
-
-(defun spacemacs/dump-restore-load-path ()
-  "Restore the `load-path' variable from the dump. "
-  (spacemacs|unless-dumping
-    (when (not (null spacemacs-dump-load-path))
-      (setq load-path spacemacs-dump-load-path))))
-
-(defun spacemacs/defer (&optional idle-time)
-  "Return t or IDLE-TIME when Spacemacs is not running from a dump."
-  (when (eq 'not-dumped spacemacs-dump-mode)
-    (or idle-time t)))
+(defmacro spacemacs|when-dumping-strict (&rest body)
+  "Execute body if we are really dumping.
+You should not used this function, it is reserved for some specific process."
+  (declare (indent defun))
+  `(when (eq 'dumping spacemacs-dump-mode)
+     ,@body))
 
 (defmacro spacemacs|require-when-dumping (&rest args)
   "Require feature if dumping."
   (spacemacs|when-dumping-strict `(require ,@args)))
-
-(defun spacemacs-is-dumping-p ()
-  "Return non-nil if Spacemacs is dumping."
-  (eq 'dumping spacemacs-dump-mode))
-
-(defun spacemacs-run-from-dump-p ()
-  "Return non-nil if Spacemacs is running from a dump."
-  (eq 'dumped spacemacs-dump-mode))
 
 (defmacro spacemacs|when-dumping (&rest body)
   "Execute body if dumping.
@@ -82,13 +66,6 @@ This function considers that we are always dumping if dumping is not supported.
 You should always use this function."
   (declare (indent defun))
   `(when (not (eq 'dumped spacemacs-dump-mode))
-     ,@body))
-
-(defmacro spacemacs|when-dumping-strict (&rest body)
-  "Execute body if we are really dumping.
-You should not used this function, it is reserved for some specific process."
-  (declare (indent defun))
-  `(when (eq 'dumping spacemacs-dump-mode)
      ,@body))
 
 (defmacro spacemacs|unless-dumping (&rest body)
@@ -108,6 +85,29 @@ the end of the loading of the dump file."
            (defun ,funcname2 nil ,@body)
            (add-to-list 'spacemacs-dump-delayed-functions ',funcname2)))
     `(progn ,@body)))
+
+(defun spacemacs/dump-save-load-path ()
+  "Save `load-path' variable."
+  (setq spacemacs-dump-load-path load-path))
+
+(defun spacemacs/dump-restore-load-path ()
+  "Restore the `load-path' variable from the dump. "
+  (spacemacs|unless-dumping
+    (when (not (null spacemacs-dump-load-path))
+      (setq load-path spacemacs-dump-load-path))))
+
+(defun spacemacs/defer (&optional idle-time)
+  "Return t or IDLE-TIME when Spacemacs is not running from a dump."
+  (when (eq 'not-dumped spacemacs-dump-mode)
+    (or idle-time t)))
+
+(defun spacemacs-is-dumping-p ()
+  "Return non-nil if Spacemacs is dumping."
+  (eq 'dumping spacemacs-dump-mode))
+
+(defun spacemacs-run-from-dump-p ()
+  "Return non-nil if Spacemacs is running from a dump."
+  (eq 'dumped spacemacs-dump-mode))
 
 (defun spacemacs/emacs-with-pdumper-set-p ()
   "Return non-nil if a portable dumper capable Emacs executable is set and


### PR DESCRIPTION
Hi,

I enabled the native-compile for my local emacs28/emacs29 buildings, and try to compile all the `spacemacs/core/*.el` files into the `*.elc` files, then emacs will do native-compile for these `*.elc` files automatically. 

After native-compile `spacemacs/core/*.elc` files done, restart the Spacemace, there will has "invalid-function" error as follow, then the emacs stucked. 

This pull request just re-order the functions, it will fix the error for this scenario, and everything worked.

```
Debugger entered--Lisp error: (invalid-function spacemacs|unless-dumping)
  spacemacs|unless-dumping(nil)
  spacemacs/dump-restore-load-path()
  (let ((file-name-handler-alist nil)) (require 'core-spacemacs) (spacemacs/dump-restore-load-path) (configuration-layer/load-lock-file) (spacemacs/init) (configuration-layer/stable-elpa-init) (configuration-layer/load) (spacemacs-buffer/display-startup-note) (spacemacs/setup-startup-hook) (spacemacs/dump-eval-delayed-functions) (if (and dotspacemacs-enable-server (not (spacemacs-is-dumping-p))) (progn (require 'server) (if dotspacemacs-server-socket-dir (progn (setq server-socket-dir dotspacemacs-server-socket-dir))) (if (server-running-p) nil (message "Starting a server...") (server-start)))))
  (if (not (version<= spacemacs-emacs-min-version emacs-version)) (error (concat "Your version of Emacs (%s) is too old. " "Spacemacs requires Emacs version %s or above.") emacs-version spacemacs-emacs-min-version) (let ((file-name-handler-alist nil)) (require 'core-spacemacs) (spacemacs/dump-restore-load-path) (configuration-layer/load-lock-file) (spacemacs/init) (configuration-layer/stable-elpa-init) (configuration-layer/load) (spacemacs-buffer/display-startup-note) (spacemacs/setup-startup-hook) (spacemacs/dump-eval-delayed-functions) (if (and dotspacemacs-enable-server (not (spacemacs-is-dumping-p))) (progn (require 'server) (if dotspacemacs-server-socket-dir (progn (setq server-socket-dir dotspacemacs-server-socket-dir))) (if (server-running-p) nil (message "Starting a server...") (server-start))))))
  load-with-code-conversion(".emacs.spacemacs/init.el" ".emacs.spacemacs/init.el" nil nil)
  load-file(".emacs.spacemacs/init.el")
  load-with-code-conversion(".emacs" ".emacs" t t)
  load("~/.emacs" noerror nomessage)
  startup--load-user-init-file(#f(compiled-function () #<bytecode -0x1427a85e50b3670b>) #f(compiled-function () #<bytecode -0x1f3c6feddc0b9b75>) t)
  command-line()
  normal-top-level()
```