### PR TITLE
Fixed #15583 and also bound SPC T g to toggle gui elements

### DIFF
--- a/core/core-early-funcs.el
+++ b/core/core-early-funcs.el
@@ -22,18 +22,19 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(defun spacemacs/removes-gui-elements ()
-  "Remove the menu bar, tool bar and scroll bars."
-  ;; removes the GUI elements
-  (when (and (fboundp 'scroll-bar-mode) (not (eq scroll-bar-mode -1)))
-    (scroll-bar-mode -1))
-  (when (and (fboundp 'tool-bar-mode) (not (eq tool-bar-mode -1)))
-    (tool-bar-mode -1))
+(defun spacemacs//toggle-gui-elements (&optional on-off)
+  "Toggle menu bar, tool bar, scroll bars, and tool tip modes. If
+optional ON-OFF is not specified, then toggle on/off state. If
+ON-OFF is 0 or 1, then turn gui elements OFF or ON respectively."
+  (when (fboundp 'scroll-bar-mode)
+    (scroll-bar-mode (or on-off (not scroll-bar-mode))))
+  (when  (fboundp 'tool-bar-mode)
+    (tool-bar-mode (or on-off (not tool-bar-mode))))
   (unless (memq (window-system) '(mac ns))
-    (when (and (fboundp 'menu-bar-mode) (not (eq menu-bar-mode -1)))
-      (menu-bar-mode -1)))
+    (when (fboundp 'menu-bar-mode)
+      (menu-bar-mode (or on-off (not menu-bar-mode)))))
   ;; tooltips in echo-aera
-  (when (and (fboundp 'tooltip-mode) (not (eq tooltip-mode -1)))
-    (tooltip-mode -1)))
+  (when (fboundp 'tooltip-mode)
+    (tooltip-mode (or on-off (not tooltip-mode)))))
 
 (provide 'core-early-funcs)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -74,7 +74,7 @@ the final step of executing code in `emacs-startup-hook'.")
   (setq ad-redefinition-action 'accept)
   ;; this is for a smoother UX at startup (i.e. less graphical glitches)
   (hidden-mode-line-mode)
-  (spacemacs/removes-gui-elements)
+  (spacemacs//toggle-gui-elements 0)
   (spacemacs//setup-ido-vertical-mode)
   ;; explicitly set the preferred coding systems to avoid annoying prompt
   ;; from emacs (especially on Microsoft Windows)

--- a/early-init.el
+++ b/early-init.el
@@ -39,8 +39,14 @@
               "core/core-early-funcs")
       nil (not init-file-debug))
 
-;; Remove GUI elements soon after GUI being initialized to avoid some possible grapical glitches.
-;; This has to be done use these hooks,
-;; see https://www.gnu.org/software/emacs/manual/html_node/emacs/Early-Init-File.html
-(add-hook 'window-setup-hook 'spacemacs/removes-gui-elements)
-(add-hook 'tty-setup-hook 'spacemacs/removes-gui-elements)
+;; Unfortunately the hooks below prevent users from customizing gui elements
+;; within dotspacemacs/user-config function. Thus the hooks are commented out.
+;; These should not be needed in any case since gui elements are turned off
+;; within spacemacs/init function.  Original comment follows next.
+;;
+;; Remove GUI elements soon after GUI being initialized to avoid some possible
+;; grapical glitches. This has to be done use these hooks, see
+;; https://www.gnu.org/software/emacs/manual/html_node/emacs/Early-Init-File.html
+;;
+;; (add-hook 'window-setup-hook 'spacemacs/toggle-gui-elements-off)
+;; (add-hook 'tty-setup-hook 'spacemacs/toggle-gui-elements-off)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -595,6 +595,13 @@ respond to this toggle."
   :mode menu-bar-mode
   :documentation "Display the menu bar."
   :evil-leader "Tm")
+(spacemacs|add-toggle gui-elements
+  :if window-system
+  :status (or menu-bar-mode tool-bar-mode scroll-bar-mode tooltip-mode)
+  :on  (spacemacs//toggle-gui-elements 1)
+  :off (spacemacs//toggle-gui-elements 0)
+  :documentation "Toggle menubar, toolbar, scrollbar, and tooltip modes."
+  :evil-leader "Tg")
 ;; quit -----------------------------------------------------------------------
 (spacemacs/set-leader-keys
   "qs" 'spacemacs/save-buffers-kill-emacs


### PR DESCRIPTION
This is to address https://github.com/syl20bnr/spacemacs/issues/15583 regarding toggling of gui elements such as tool-bar mode.

The reported problem was fixed by not adding hooks to `window-setup-hook` and `tty-setup-hook` which seemed to have been redundant anyways. These hooks prevented code such as `(tool-bar-mode 1)` in `dotspacemacs/user-config` not taking effect.

In addition `spacemacs/removes-gui-elements` function was renamed as `spacemacs//toggle-gui-elements` and also turned into a toggle function rather than just disable gui elements.

Finally a new toggle command called `gui-elements` was created which was bound to `SPC T g` to toggle menu-bar, tool-bar, scroll-bar, and tooltip modes on or off all at once.
