### PR TITLE
core: support native-compile the "core/*.el" files

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -33,6 +33,7 @@
 (require 'core-funcs)
 (require 'core-progress-bar)
 (require 'core-spacemacs-buffer)
+(require 'core-load-paths)
 
 (defvar configuration-layer--refresh-package-timeout dotspacemacs-elpa-timeout
   "Timeout in seconds to reach a package archive page.")

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -20,7 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+(require 'core-load-paths)
 (require 'core-customization)
 
 (defconst dotspacemacs-template-directory
@@ -871,19 +871,20 @@ Called with `C-u C-u' skips `dotspacemacs/user-config' _and_ preliminary tests."
   (when (configuration-layer/package-used-p 'spaceline)
     (spacemacs//restore-buffers-powerline)))
 
-(defun dotspacemacs/get-variable-string-list ()
-  "Return a list of all the dotspacemacs variables as strings."
-  (all-completions "" obarray
-                   (lambda (x)
-                     (and (boundp x)
-                          (not (keywordp x))
-                          ;; avoid private variables to show up
-                          (not (string-match-p "--" (symbol-name x)))
-                          (string-prefix-p "dotspacemacs" (symbol-name x))))))
+(eval-and-compile
+  (defun dotspacemacs/get-variable-string-list ()
+    "Return a list of all the dotspacemacs variables as strings."
+    (all-completions "" obarray
+                     (lambda (x)
+                       (and (boundp x)
+                            (not (keywordp x))
+                            ;; avoid private variables to show up
+                            (not (string-match-p "--" (symbol-name x)))
+                            (string-prefix-p "dotspacemacs" (symbol-name x))))))
 
-(defun dotspacemacs/get-variable-list ()
-  "Return a list of all dotspacemacs variable symbols."
-  (mapcar 'intern (dotspacemacs/get-variable-string-list)))
+  (defun dotspacemacs/get-variable-list ()
+    "Return a list of all dotspacemacs variable symbols."
+    (mapcar 'intern (dotspacemacs/get-variable-string-list))))
 
 (defmacro dotspacemacs|symbol-value (symbol)
   "Return the value of SYMBOL corresponding to a dotspacemacs variable.

--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -21,6 +21,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 (require 'core-funcs)
+(require 'core-load-paths)
+
 (require 'core-spacemacs-buffer)
 
 (defvar spacemacs--diminished-minor-modes nil

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -20,9 +20,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-(defvar configuration-layer--protected-packages)
-(defvar dotspacemacs-filepath)
 (defvar spacemacs-repl-list '()
   "List of all registered REPLs.")
 

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -34,7 +34,7 @@
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
-  (expand-file-name user-emacs-directory)
+  (concat (file-name-directory (or load-file-name buffer-file-name)) "../")
   "Spacemacs start directory.")
 
 ;; ~/.emacs.d/assets

--- a/core/core-spacebind.el
+++ b/core/core-spacebind.el
@@ -20,7 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+(require 'core-load-paths)
 (require 'core-keybindings)
 
 (defvar spacebind--eager-bind t

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -22,6 +22,7 @@
 
 ;;; Code:
 
+(require 'core-dotspacemacs)
 (eval-when-compile
   (defvar dotspacemacs-distribution)
   (defvar dotspacemacs-filepath)
@@ -32,13 +33,9 @@
   (defvar spacemacs-badge-official-png)
   (defvar spacemacs-banner-directory)
   (defvar spacemacs-banner-official-png)
-  (defvar spacemacs-cache-directory)
-  (defvar spacemacs-docs-directory)
   (defvar spacemacs-gplv3-official-png)
-  (defvar spacemacs-info-directory)
-  (defvar spacemacs-release-notes-directory)
-  (defvar spacemacs-start-directory)
-  (defvar spacemacs-version))
+  (defvar spacemacs-version)
+  (defvar configuration-layer-error-count))
 
 
 (defconst spacemacs-buffer-version-info "0.999"
@@ -808,19 +805,20 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
       (when messagebuf
         (message "(Spacemacs) %s" msg)))))
 
-(defun spacemacs-buffer//startup-list-jump-func-name (str)
-  "Given a string, return a spacemacs-buffer function name.
+(eval-and-compile
+  (defun spacemacs-buffer//startup-list-jump-func-name (str)
+    "Given a string, return a spacemacs-buffer function name.
 
 Given:           Return:
 \"[?]\"            \"spacemacs-buffer/jump-to-[?]\"
 \"Recent Files:\"  \"spacemacs-buffer/jump-to-recent-files\""
-  (let ((s (downcase str)))
-    ;; remove last char if it's a colon
-    (when (string-match ":$" s)
-      (setq s (substring s nil (1- (length s)))))
-    ;; replace any spaces with a dash
-    (setq s (replace-regexp-in-string " " "-" s))
-    (concat "spacemacs-buffer/jump-to-" s)))
+    (let ((s (downcase str)))
+      ;; remove last char if it's a colon
+      (when (string-match ":$" s)
+        (setq s (substring s nil (1- (length s)))))
+      ;; replace any spaces with a dash
+      (setq s (replace-regexp-in-string " " "-" s))
+      (concat "spacemacs-buffer/jump-to-" s))))
 
 (defmacro spacemacs-buffer||add-shortcut
     (shortcut-char search-label &optional no-next-line)

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -28,6 +28,8 @@
   :prefix 'spacemacs-)
 
 (require 'subr-x nil 'noerror)
+(require 'core-versions)
+(require 'core-load-paths)
 (require 'core-emacs-backports)
 (require 'core-env)
 (require 'page-break-lines)
@@ -52,6 +54,7 @@
 (require 'core-use-package-ext)
 (require 'core-spacebind)
 (require 'core-compilation)
+(require 'core-dumper)
 
 (defvar spacemacs-post-user-config-hook nil
   "Hook run after dotspacemacs/user-config")


### PR DESCRIPTION
Hi,
There are many errors when I try to byte-compile all the `<spacemacs>/core/*.el` files into `*.elc` files, and it will automatically do native-compile for my local emacs has native-compile feature on.
This PR will fix the errors when running the byte-compile and native-compile the `core/*.el` files.
Please help review it. Thanks.

Just run follow line to compile the `core/` directory.
```
(byte-recompile-directory spacemacs-core-directory 0)
```