### PR TITLE
core: byte-compile the "core/libs/" folder when dotspacemacs-byte-compile is t

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -255,10 +255,11 @@ Note: the hooked function is not executed when in dumped mode."
            gc-cons-percentage (cadr dotspacemacs-gc-cons))
      (setq read-process-output-max dotspacemacs-read-process-output-max)))
 
-  (let ((default-directory spacemacs-start-directory))
-    (if dotspacemacs-byte-compile
-        (spacemacs//ensure-byte-compilation spacemacs--compiled-files)
-      (spacemacs//remove-byte-compiled-files-in-dir spacemacs-core-directory)))
+  (if dotspacemacs-byte-compile
+      (when (> 1 (spacemacs//dir-byte-compile-state
+                  (concat spacemacs-core-directory "libs/")))
+        (byte-recompile-directory (concat spacemacs-core-directory "libs/") 0))
+    (spacemacs//remove-byte-compiled-files-in-dir spacemacs-core-directory))
   ;; Check if revision has changed.
   (spacemacs//revision-check))
 

--- a/init.el
+++ b/init.el
@@ -42,8 +42,8 @@
       nil (not init-file-debug))
 (load spacemacs--last-emacs-version-file t (not init-file-debug))
 (when (or (not (string= spacemacs--last-emacs-version emacs-version))
-          (spacemacs//dir-contains-stale-byte-compiled-files-p
-           spacemacs-core-directory))
+          (> 0 (spacemacs//dir-byte-compile-state
+                (concat spacemacs-core-directory "libs/"))))
   (spacemacs//remove-byte-compiled-files-in-dir spacemacs-core-directory))
 ;; Update saved Emacs version.
 (unless (string= spacemacs--last-emacs-version emacs-version)


### PR DESCRIPTION
Hi,

Currently `dotspacemacs-byte-compile` is `t` will only compile serveral files in `core/lib/*`.
After the PR #15692, all files in `core/` will be able byte-compile/native-compile.

So we'll byte compile the `core/` directory when `dotspacemacs-byte-compile` is `t`.