### PR TITLE
core: better way to locate the spacemacs-start-directory

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -34,7 +34,7 @@
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
-  (expand-file-name user-emacs-directory)
+  (concat (file-name-directory (or load-file-name buffer-file-name)) "../")
   "Spacemacs start directory.")
 
 ;; ~/.emacs.d/assets


### PR DESCRIPTION
Hi,
There is a better way to locate the `spacemacs-start-directory`, in the change.

I didn't always put spacemacs in `~/.emacs.d`, then we should locate the `spacemacs-start-directory` based on its file path.

This change is part of #15692 .

@smile13241324 Please help review and approve this change. Thanks.
