### PR TITLE
Docker: Followup for #15414: fix bindings not loading, add docs

### DIFF
--- a/layers/+tools/docker/README.org
+++ b/layers/+tools/docker/README.org
@@ -74,6 +74,9 @@ auto-completion of the running containers.
 
 | Key binding | Description                                                       |
 |-------------+-------------------------------------------------------------------|
-| ~SPC m c b~ | build current buffer                                              |
-| ~SPC m c B~ | build current buffer without cache                                |
 | ~SPC a t d~ | entry point to interact with dockers, after that use ~?~ for help |
+| ~SPC m b~   | build current buffer                                              |
+| ~SPC m B~   | build current buffer without cache                                |
+| ~SPC m i~   | shortcut for ~docker.el~ main menu                                |
+| ~SPC m i~   | shortcut for 'docker images' in the ~docker.el~ screen            |
+| ~SPC m p~   | shortcut for 'docker containers' in the ~docker.el~ screen        |

--- a/layers/+tools/docker/README.org
+++ b/layers/+tools/docker/README.org
@@ -77,6 +77,6 @@ auto-completion of the running containers.
 | ~SPC a t d~ | entry point to interact with dockers, after that use ~?~ for help |
 | ~SPC m b~   | build current buffer                                              |
 | ~SPC m B~   | build current buffer without cache                                |
-| ~SPC m i~   | shortcut for ~docker.el~ main menu                                |
+| ~SPC m d~   | shortcut for ~docker.el~ main menu                                |
 | ~SPC m i~   | shortcut for 'docker images' in the ~docker.el~ screen            |
 | ~SPC m p~   | shortcut for 'docker containers' in the ~docker.el~ screen        |

--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -50,14 +50,15 @@
     :defer t
     :init (add-hook 'dockerfile-mode-local-vars-hook #'spacemacs//docker-dockerfile-setup-backend)
     :config
-    (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
-      (if (null docker-dockerfile-backend) "b" "cb") 'dockerfile-build-buffer
-      (if (null docker-dockerfile-backend) "B" "cB") 'dockerfile-build-buffer-no-cache-buffer)
-    (if (package-installed-p 'docker)
+    (progn
       (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
-        "d" 'docker
-        "i" 'docker-images
-        "p" 'docker-containers))))
+        (if (null docker-dockerfile-backend) "b" "cb") 'dockerfile-build-buffer
+        (if (null docker-dockerfile-backend) "B" "cB") 'dockerfile-build-buffer-no-cache-buffer)
+      (if (package-installed-p 'docker)
+        (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
+          "d" 'docker
+          "i" 'docker-images
+          "p" 'docker-containers)))))
 
 (defun docker/post-init-flycheck ()
   (spacemacs/enable-flycheck 'dockerfile-mode))

--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -53,7 +53,7 @@
     (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
       (if (null docker-dockerfile-backend) "b" "cb") 'dockerfile-build-buffer
       (if (null docker-dockerfile-backend) "B" "cB") 'dockerfile-build-buffer-no-cache-buffer)
-    (with-eval-after-load 'docker
+    (if (package-installed-p 'docker)
       (spacemacs/set-leader-keys-for-major-mode 'dockerfile-mode
         "d" 'docker
         "i" 'docker-images


### PR DESCRIPTION
As requested by @arifer612 on #15414:
* Use `package-installed-p` instead of `with-eval-after-load` to check for package presence before adding bindings (to account for excluded package).
* Wrap `:config` block in a `progn` as per [CONVENTIONS.org](https://github.com/syl20bnr/spacemacs/blob/develop/doc/CONVENTIONS.org#use-package).
* Add keybindings to docs.