### PR TITLE
unicode-fonts doc: hint at supported ligatures

### DIFF
--- a/layers/+fonts/unicode-fonts/README.org
+++ b/layers/+fonts/unicode-fonts/README.org
@@ -70,8 +70,13 @@ Or to enable ligatures only for text files:
 #+END_SRC
 
 To configure the ligature set that gets used with your font there is a
-=unicode-fonts-ligature-set= variable. For example To only enable the ligatures
-in =if= statements you can set the =unicode-fonts-ligature-set= as:
+=unicode-fonts-ligature-set= variable. Make sure you enable only ligatures
+supported by your font.
+(See [[https://github.com/mickeynp/ligature.el/wiki][the =ligatures.el= wiki]]
+for values of =unicode-fonts-ligature-set= for commonly used fonts.)
+
+For example, you can set =unicode-fonts-ligature-set= as follows to only
+enable the ligatures typically used in conditional expressions:
 
 #+BEGIN_SRC elisp
   (setq-default dotspacemacs-configuration-layers


### PR DESCRIPTION
This caught me. The default config enables ligatures that are not supported by my font and then strange things happen when emacs tries to use the non-existing ligatures. 

Maybe the default config can be tuned to be somewhat more conservative but this can be done in a different PR independently of this doc change. 