### PR TITLE
chore(ts-fold): Update repo link for ts-fold module

### DIFF
--- a/layers/+tools/tree-sitter/README.org
+++ b/layers/+tools/tree-sitter/README.org
@@ -40,7 +40,7 @@ Set =tree-sitter-indent-enable t= for code indentation, provided by
 [[https://codeberg.org/FelipeLema/tree-sitter-indent.el][=tree-sitter-indent=]]. Currently only Rust is supported.
 Default: =nil=.
 
-Set =tree-sitter-fold-enable t= for code folding, provided by [[https://github.com/jcs090218/ts-fold][=ts-fold=]]. If
+Set =tree-sitter-fold-enable t= for code folding, provided by [[https://github.com/emacs-tree-sitter/ts-fold][=ts-fold=]]. If
 you use a =dotspacemacs-editing-style= other than ='vim= or a
 =dotspacemacs-folding-method= other than ='evil=, it's likely that you'll find
 the integration with =ts-fold= wanting. Contributions are encouraged!

--- a/layers/+tools/tree-sitter/packages.el
+++ b/layers/+tools/tree-sitter/packages.el
@@ -29,7 +29,7 @@
      :toggle tree-sitter-fold-enable
      :location (recipe
                 :fetcher github
-                :repo "jcs090218/ts-fold"))))
+                :repo "emacs-tree-sitter/ts-fold"))))
 
 (defun tree-sitter/init-tree-sitter ()
   (use-package tree-sitter


### PR DESCRIPTION
Hi, I am the author of [ts-fold](https://github.com/emacs-tree-sitter/ts-fold). The repo has moved under the same domain `emacs-tree-sitter`, this PR updates the repo link.