### PR TITLE
Fix the issue with the library name for native compilation to resolve #15721

### DIFF
--- a/core/core-dumper.el
+++ b/core/core-dumper.el
@@ -120,9 +120,10 @@ native compilation is not in effect."
 
 (defun spacemacs/emacs-with-native-compilation-enabled-p ()
   "Return non-nil if native compilation is enabled."
-  (and (featurep 'native-compile)
-       (fboundp 'native-comp-available-p)
-       (native-comp-available-p)
+  ;; If the feature is loaded or loadable, and it is in use, return nil.
+  (and (if (not (featurep 'comp))
+         (require 'comp)
+         (intern "comp"))
        (not (eql native-comp-speed -1))))
 
 (defun spacemacs/dump-modes (modes)


### PR DESCRIPTION
The library is named 'comp, not native-compile.

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!
