### PR TITLE
do not add org-roam-setup to after-init-hook

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -928,8 +928,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
 (defun org/init-org-roam ()
   (use-package org-roam
     :defer t
-    ;; Do not enable automatic db update by until after user had a chance to
-    ;; setup org-roam. See https://github.com/syl20bnr/spacemacs/issues/15724
+    ;; Do not enable automatic db update until after user had a chance to setup
+    ;; org-roam. See https://github.com/syl20bnr/spacemacs/issues/15724
     ;; :hook (after-init . org-roam-setup)
     :init
     (progn

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -928,7 +928,9 @@ Headline^^            Visit entry^^               Filter^^                    Da
 (defun org/init-org-roam ()
   (use-package org-roam
     :defer t
-    :hook (after-init . org-roam-setup)
+    ;; Do not enable automatic db update by until after user had a chance to
+    ;; setup org-roam. See https://github.com/syl20bnr/spacemacs/issues/15724
+    ;; :hook (after-init . org-roam-setup)
     :init
     (progn
       (spacemacs/declare-prefix


### PR DESCRIPTION
This is to prevent race condition between org-roam db update verse org-roam setup. See https://github.com/syl20bnr/spacemacs/issues/15724
