### PR TITLE
Surpress native compilation *Warnings* buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -239,3 +239,6 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 
 ;; Don't load outdated compiled files.
 (setq load-prefer-newer t)
+
+;; Suppress the *Warnings* buffer when native compilation shows warnings.
+(setq native-comp-async-report-warnings-errors 'silent)


### PR DESCRIPTION
Native compilation is extremely verbose with thousands of individual warnings from packages popping up in a window that can't be dismissed, unless you disable the warnings, or you suppress them.