### PR TITLE
Fix cumbersome pdf-tools selection behavior

### DIFF
--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -31,6 +31,12 @@
     :mode (("\\.pdf\\'" . pdf-view-mode))
     :init
     (spacemacs//pdf-tools-setup-transient-state)
+
+    (add-hook 'pdf-view-mode-hook
+              (lambda () (add-hook 'evil-evilified-state-entry-hook
+                                   (lambda (remove-hook 'activate-mark-hook 'evil-visual-activate-hook t))
+                                   nil t)))
+
     :config
     (progn
       (pdf-tools-install)
@@ -62,8 +68,6 @@
         "p" 'pdf-misc-print-document
         "O" 'pdf-outline
         "n" 'pdf-view-midnight-minor-mode)
-
-      (evil-define-key 'visual pdf-view-mode-map "y" 'pdf-view-kill-ring-save)
 
       ;; TODO: Make `/', `?' and `n' work like in Evil
       (evilified-state-evilify-map pdf-view-mode-map
@@ -98,7 +102,8 @@
         "r"   'pdf-view-revert-buffer
         "o"   'pdf-links-action-perform
         "O"   'pdf-outline
-        "zr"  'pdf-view-scale-reset)
+        "zr"  'pdf-view-scale-reset
+        "y"   'pdf-view-kill-ring-save)
       (evilified-state-evilify-map pdf-outline-buffer-mode-map
         :mode  pdf-outline-buffer-mode
         :eval-after-load pdf-outline


### PR DESCRIPTION
Currently, due to evil entering visual state, the selection behavior in pdf-tools is different from and more cumbersome than in vanilla Emacs (see https://github.com/emacs-evil/evil/issues/1671).

This commit prevents evil from entering evil-state in pdf-mode and moves the (only) visual-state yank binding to the evilified-map.

It doesn't look pretty, but it is working much better than before.