### PR TITLE
fix: Refactor code-cells-mode setup to avoid undefined symbol errors on define-key

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -101,14 +101,12 @@
     :if (not (configuration-layer/layer-used-p 'ipython-notebook))
     :defer t
     :commands (code-cells-mode)
-    :init
-    (progn
-      (add-hook 'python-mode-hook 'code-cells-mode)
-      (spacemacs/set-leader-keys-for-minor-mode 'code-cells-mode
-        "gB" 'code-cells-backward-cell
-        "gF" 'code-cells-forward-cell
-        "sc" 'code-cells-eval
-        "sa" 'code-cells-eval-above))))
+    :init (add-hook 'python-mode-hook 'code-cells-mode)
+    :config (spacemacs/set-leader-keys-for-minor-mode 'code-cells-mode
+            "gB" 'code-cells-backward-cell
+            "gF" 'code-cells-forward-cell
+            "sc" 'code-cells-eval
+            "sa" 'code-cells-eval-above)))
 
 (defun python/post-init-company ()
   ;; backend specific


### PR DESCRIPTION
Commit 54f12b66f correctly moved code-cells setup to use-package's :init to
ensure that python-mode had a hook for code-cells-mode -- otherwise, code-cells
would never be loaded automatically with python major mode.

A side-effect of this change was that now there was a minor mode keymap for
`code-cells-mode` , which may not have been loaded unless emacs has already
opened a python file.

When calling `describe-key` , the function `help--binding-locus` would iterate
over `minor-mode-map-alist` and, when it reached the entry for code-cells-mode,
a call to `(symbol-value 'code-cells-mode)` would fail with a `void-variable`
error. Despite `code-cells-mode` being an auto-loadeable symbol, `symbol-balue` would not trigger the autoload.

The solution (as pointed by @sunlin7) was to call `add-hook` on `:init` and
`spacemacs/set-leader-keys-for-minor-mode` on `:config`