### PR TITLE
Create visual selection from transient paste

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -233,9 +233,7 @@
  same text above or below, [_C-v_] creates a visual selection \
  from last paste and exits. Anything else exits."
     :bindings
-    ("C-v" (lambda (x) (interactive "*p")
-             (evil-active-region))
-     :exit t)
+    ("C-v" (evil-active-region) :exit t)
     ("C-j" evil-paste-pop)
     ("C-k" evil-paste-pop-next)
     ("p" evil-paste-after)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -229,9 +229,13 @@
   (spacemacs|define-transient-state paste
     :title "Pasting Transient State"
     :doc "\n[%s(length kill-ring-yank-pointer)/%s(length kill-ring)] \
- [_C-j_/_C-k_] cycles through yanked text, [_p_/_P_] pastes the same text \
- above or below. Anything else exits."
+ [_C-j_/_C-k_] cycles through yanked text, [_p_/_P_] pastes the \
+ same text above or below, [_C-v_] creates a visual selection \
+ from last paste and exits. Anything else exits."
     :bindings
+    ("C-v" (lambda (x) (interactive "*p")
+             (evil-active-region))
+     :exit t)
     ("C-j" evil-paste-pop)
     ("C-k" evil-paste-pop-next)
     ("p" evil-paste-after)


### PR DESCRIPTION
Improve "Pasting Transient State" by adding a shortcut C-v to generate a visual selection from pasted test.
This allows to further manipulate the pasted text after pasting.
For example: `p` `C-j` `C-v` `U` pastes the second most recent element in the kill buffer and capitalizes everything that has been pasted.