### PR TITLE
Reporting.tmp: added github account is needed note

### DIFF
--- a/core/templates/REPORTING.template
+++ b/core/templates/REPORTING.template
@@ -1,5 +1,6 @@
 #### Description :octocat:
 <<DESCRIPTION OF THE PROBLEM>>
+<<BE AWARE YOU NEED A GITHUB ACCOUNT TO SEND THIS REPORT>>
 
 #### Reproduction guide :beetle:
 - Start Emacs


### PR DESCRIPTION
I wanted to submit a bug report and only after hitting C-c C-c I was aware that I need a github account. So I added the information at the beginning of the report template for others to be warned :)
Thanks for your grate work, I love spacemacs

