### PR TITLE
 layers/*: fix warrnings on startup for invalid using the quote in cl-case clauses

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -204,9 +204,9 @@
       (add-hook 'company-box-selection-hook
                 (lambda (selection frame) (company-box-doc--hide frame)))
       (cl-case auto-completion-enable-help-tooltip
-        ('manual (define-key company-active-map
+        (manual (define-key company-active-map
                    (kbd "M-h") #'company-box-doc-manually))
-        ('t (setq company-box-doc-enable t))))))
+        (t (setq company-box-doc-enable t))))))
 
 (defun auto-completion/init-company-posframe ()
   (use-package company-posframe

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -47,7 +47,7 @@
 
   ;; Backwards compatibility
   (cl-case osx-use-option-as-meta
-    ('nil (setf osx-option-as 'none))
+    (nil (setf osx-option-as 'none))
     (deprecated nil)
     (t (setf osx-option-as 'meta)))
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -861,11 +861,11 @@ then apply that major mode to the new buffer."
   (interactive)
   (let ((newbuf (generate-new-buffer "untitled")))
     (cl-case split
-      ('left  (split-window-horizontally))
-      ('below (spacemacs/split-window-vertically-and-switch))
-      ('above (split-window-vertically))
-      ('right (spacemacs/split-window-horizontally-and-switch))
-      ('frame (select-frame (make-frame))))
+      (left  (split-window-horizontally))
+      (below (spacemacs/split-window-vertically-and-switch))
+      (above (split-window-vertically))
+      (right (spacemacs/split-window-horizontally-and-switch))
+      (frame (select-frame (make-frame))))
     ;; Prompt to save on `save-some-buffers' with positive PRED
     (with-current-buffer newbuf
       (setq-local buffer-offer-save t)

--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -37,20 +37,20 @@ POSITION should be one of bottom, top, left and right.
 SIZE should be either a positive number of nil.  Size is interpreted as
 width or height depending on POSITION."
   (let* ((size (cl-case position
-                 ('left (purpose--normalize-width (or size
+                 (left (purpose--normalize-width (or size
+                                                     popwin:popup-window-width)))
+                 (right (purpose--normalize-width (or size
                                                       popwin:popup-window-width)))
-                 ('right (purpose--normalize-width (or size
-                                                       popwin:popup-window-width)))
-                 ('top (purpose--normalize-height (or size
-                                                      popwin:popup-window-height)))
-                 ('bottom (purpose--normalize-height (or size
-                                                         popwin:popup-window-height)))))
+                 (top (purpose--normalize-height (or size
+                                                     popwin:popup-window-height)))
+                 (bottom (purpose--normalize-height (or size
+                                                        popwin:popup-window-height)))))
          (size (when size (- size)))
          (side (cl-case position
-                 ('left 'left)
-                 ('right 'right)
-                 ('top 'above)
-                 ('bottom 'below))))
+                 (left 'left)
+                 (right 'right)
+                 (top 'above)
+                 (bottom 'below))))
     (lambda (buffer alist)
       (let* ((main-window (if pupo-split-active-window
                               (selected-window)
@@ -77,10 +77,10 @@ bottom -> popb
 POSITION defaults to bottom."
   (cl-case (or position 'bottom)
     ;; names are short so they don't take much room in the mode-line
-    ('left 'popl)
-    ('right 'popr)
-    ('top 'popt)
-    ('bottom 'popb)))
+    (left 'popl)
+    (right 'popr)
+    (top 'popt)
+    (bottom 'popb)))
 
 (defun pupo//actions (settings)
   "Generate list of display functions for displaying a popup window.

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -75,9 +75,9 @@
 (defun spacemacs/lsp-bind-keys ()
   "Define key bindings for the lsp minor mode."
   (cl-ecase lsp-navigation
-    ('simple (spacemacs//lsp-bind-simple-navigation-functions "g"))
-    ('peek (spacemacs//lsp-bind-peek-navigation-functions "g"))
-    ('both
+    (simple (spacemacs//lsp-bind-simple-navigation-functions "g"))
+    (peek (spacemacs//lsp-bind-peek-navigation-functions "g"))
+    (both
      (spacemacs//lsp-bind-simple-navigation-functions "g")
      (spacemacs//lsp-bind-peek-navigation-functions "G")))
 
@@ -183,21 +183,21 @@ KEY is a string corresponding to a key sequence
 KIND is a quoted symbol corresponding to an extension defined using
 `lsp-define-extensions'."
   (cl-ecase lsp-navigation
-    ('simple (spacemacs/set-leader-keys-for-major-mode mode
-               (concat "g" key)
-               (spacemacs//lsp-extension-name
-                layer-name backend-name "find" kind)))
-    ('peek (spacemacs/set-leader-keys-for-major-mode mode
-             (concat "g" key)
-             (spacemacs//lsp-extension-name
-              layer-name backend-name "peek" kind)))
-    ('both (spacemacs/set-leader-keys-for-major-mode mode
-             (concat "g" key)
-             (spacemacs//lsp-extension-name
-              layer-name backend-name "find" kind)
-             (concat "G" key)
-             (spacemacs//lsp-extension-name
-              layer-name backend-name "peek" kind)))))
+    (simple (spacemacs/set-leader-keys-for-major-mode mode
+              (concat "g" key)
+              (spacemacs//lsp-extension-name
+               layer-name backend-name "find" kind)))
+    (peek (spacemacs/set-leader-keys-for-major-mode mode
+            (concat "g" key)
+            (spacemacs//lsp-extension-name
+             layer-name backend-name "peek" kind)))
+    (both (spacemacs/set-leader-keys-for-major-mode mode
+            (concat "g" key)
+            (spacemacs//lsp-extension-name
+             layer-name backend-name "find" kind)
+            (concat "G" key)
+            (spacemacs//lsp-extension-name
+             layer-name backend-name "peek" kind)))))
 
 (defun spacemacs/lsp-bind-extensions-for-mode (mode
                                                layer-name

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -75,9 +75,9 @@ Additionally changes to working directory when the value of
 `shell-pop-autocd-to-working-dir' is non-nil (default)."
   (interactive)
   (let ((shell (cl-case shell-default-shell
-                 ('multi-vterm 'multivterm)
-                 ('multi-term 'multiterm)
-                 ('shell 'inferior-shell)
+                 (multi-vterm 'multivterm)
+                 (multi-term 'multiterm)
+                 (shell 'inferior-shell)
                  (t shell-default-shell))))
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 


### PR DESCRIPTION
There're warnings for the incorrectly usage of `(cl-case)`, this PR will fix these warnings.

> Loading ./spacemacs/init.el (source)...
./spacemacs/layers/+completion/auto-completion/packages.el: Warning: Case 'manual will match ‘quote’.  If that’s intended, write (manual quote) instead.  Otherwise, don’t quote ‘manual’.
./spacemacs/layers/+completion/auto-completion/packages.el: Warning: Case 't will match ‘quote’.  If that’s intended, write (t quote) instead.  Otherwise, don’t quote ‘t’.
./spacemacs/layers/+spacemacs/spacemacs-defaults/funcs.el: Warning: Case 'left will match ‘quote’.  If that’s intended, write (left quote) instead.  Otherwise, don’t quote ‘left’.
./spacemacs/layers/+spacemacs/spacemacs-defaults/funcs.el: Warning: Case 'below will match ‘quote’.  If that’s intended, write (below quote) instead.  Otherwise, don’t quote ‘below’.
./spacemacs/layers/+spacemacs/spacemacs-defaults/funcs.el: Warning: Case 'above will match ‘quote’.  If that’s intended, write (above quote) instead.  Otherwise, don’t quote ‘above’.
./spacemacs/layers/+spacemacs/spacemacs-defaults/funcs.el: Warning: Case 'right will match ‘quote’.  If that’s intended, write (right quote) instead.  Otherwise, don’t quote ‘right’.
./spacemacs/layers/+spacemacs/spacemacs-defaults/funcs.el: Warning: Case 'frame will match ‘quote’.  If that’s intended, write (frame quote) instead.  Otherwise, don’t quote ‘frame’.
./spacemacs/layers/+tools/lsp/funcs.el: Warning: Case 'simple will match ‘quote’.  If that’s intended, write (simple quote) instead.  Otherwise, don’t quote ‘simple’.
./spacemacs/layers/+tools/lsp/funcs.el: Warning: Case 'peek will match ‘quote’.  If that’s intended, write (peek quote) instead.  Otherwise, don’t quote ‘peek’.
./spacemacs/layers/+tools/lsp/funcs.el: Warning: Case 'both will match ‘quote’.  If that’s intended, write (both quote) instead.  Otherwise, don’t quote ‘both’.
./spacemacs/layers/+tools/lsp/funcs.el: Warning: Case 'simple will match ‘quote’.  If that’s intended, write (simple quote) instead.  Otherwise, don’t quote ‘simple’.
./spacemacs/layers/+tools/lsp/funcs.el: Warning: Case 'peek will match ‘quote’.  If that’s intended, write (peek quote) instead.  Otherwise, don’t quote ‘peek’.
./spacemacs/layers/+tools/lsp/funcs.el: Warning: Case 'both will match ‘quote’.  If that’s intended, write (both quote) instead.  Otherwise, don’t quote ‘both’.
./spacemacs/layers/+tools/shell/funcs.el: Warning: Case 'multi-term will match ‘quote’.  If that’s intended, write (multi-term quote) instead.  Otherwise, don’t quote ‘multi-term’.
./spacemacs/layers/+tools/shell/funcs.el: Warning: Case 'shell will match ‘quote’.  If that’s intended, write (shell quote) instead.  Otherwise, don’t quote ‘shell’.
Loading ./spacemacs/init.el (source)...done
