### PR TITLE
Configure consult-imenu for Java using LSP backend.

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -243,7 +243,22 @@
     (setq consult-project-root-function
           (lambda ()
             (when-let (project (project-current))
-              (car (project-root project)))))))
+              (car (project-root project))))))
+
+  ;; Configure consult-imenu for java-mode.
+  (use-package consult-imenu
+    :after consult
+    :config
+    (add-to-list 'consult-imenu-config '(java-mode :toplevel "Classes" :types
+                                                   ((?m "Methods" font-lock-function-name-face)
+                                                    (?f "Fields" font-lock-variable-name-face)
+                                                    (?c "Classes" font-lock-type-face)
+                                                    (?p "Packages" font-lock-constant-face)
+                                                    (?C "Constants" font-lock-constant-face)
+                                                    (?M "Constructors" font-lock-function-name-face)
+                                                    (?e "Enums" font-lock-type-face)
+                                                    (?E "Enum Members" font-lock-constant-face)
+                                                    (?i "Interfaces" font-lock-type-face))))))
 
 (defun compleseus/init-consult-yasnippet ()
   (use-package consult-yasnippet

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -40,7 +40,8 @@
           lsp-session-file (concat lsp-server-install-dir (file-name-nondirectory ".lsp-session-v1"))
           lsp-eslint-library-choices-file (concat lsp-server-install-dir ".lsp-eslint-choices")
           lsp-yaml-schema-store-local-db (concat lsp-server-install-dir "lsp-yaml-schemas.json")
-          lsp-vetur-global-snippets-dir (concat spacemacs-start-directory "snippets/vetur"))
+          lsp-vetur-global-snippets-dir (concat spacemacs-start-directory "snippets/vetur")
+          lsp-imenu-index-function #'lsp-imenu-create-categorized-index)
     ;; If you find something else should be ignored, you could also set them here
     :config
     (progn


### PR DESCRIPTION
This commit configures the narrowing feature of `consult-imenu` for java-mode with entries coming from LSP.

In addition to setting `consult-imenu-config`, `lsp-imenu-index-function` must be set to `#'lsp-imenu-create-categorized-index`.
