### PR TITLE
Change default scratch mode to lisp-interaction-mode

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -238,12 +238,16 @@ This has no effect in terminal or if \"all-the-icons\" is not installed."
   'boolean
   'spacemacs-dotspacemacs-init)
 
-(spacemacs|defc dotspacemacs-scratch-mode 'text-mode
+(spacemacs|defc dotspacemacs-scratch-mode 'lisp-interaction-mode
   "Default major mode of the scratch buffer."
   'symbol
   'spacemacs-dotspacemacs-init)
 
-(spacemacs|defc dotspacemacs-initial-scratch-message 'nil
+(spacemacs|defc dotspacemacs-initial-scratch-message
+  ";; Initial mode for this buffer is configurable via the
+;; `dotspacemacs-scratch-mode' variable.
+;; In the current mode, evaluate lisp code using the major-mode
+;; `, e'-prefix keybindings.\n\n"
   "Initial message in the scratch buffer."
   '(choice (const nil) string)
   'spacemacs-dotspacemacs-init)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -219,8 +219,8 @@ It should only modify the values of Spacemacs settings."
    ;; (default `text-mode')
    dotspacemacs-new-empty-buffer-major-mode 'text-mode
 
-   ;; Default major mode of the scratch buffer (default `text-mode')
-   dotspacemacs-scratch-mode 'text-mode
+   ;; Default major mode of the scratch buffer (default `lisp-interaction-mode')
+   dotspacemacs-scratch-mode 'lisp-interaction-mode
 
    ;; If non-nil, *scratch* buffer will be persistent. Things you write down in
    ;; *scratch* buffer will be saved and restored automatically.
@@ -232,7 +232,12 @@ It should only modify the values of Spacemacs settings."
 
    ;; Initial message in the scratch buffer, such as "Welcome to Spacemacs!"
    ;; (default nil)
-   dotspacemacs-initial-scratch-message nil
+   dotspacemacs-initial-scratch-message
+   ";; Initial mode for this buffer is configurable via the
+;; `dotspacemacs-scratch-mode' variable.
+;; In the current mode, evaluate lisp code using the major-mode
+;; `, e'-prefix keybindings.\n\n"
+
 
    ;; List of themes, the first of the list is loaded when spacemacs starts.
    ;; Press `SPC T n' to cycle to the next theme in the list (works great


### PR DESCRIPTION
As Spac(Emacs) users are probably primarily (office-)workers of the more adventurous kind, the initial scratch mode should really be `lisp-interaction-mode` (like in vanilla Emacs), where lexical binding is the default.

Also, this helps to prevent (new) users from accidentally setting it to `emacs-lisp-mode` (without lexical binding).