### PR TITLE
core/core-configuration-layer: avoid loading the dependence layers multiple times

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -825,6 +825,8 @@ Other:
   - Add evil-jump-backward/forward (=C-o=/=C-i=) keybindings to
     evil-evilified-state-map (thanks to Daniel Nicolai)
   - Improve helm completion in spacemacs-help (thanks to @dankessler)
+  - Improve the =configuration-layer/declare-layer-dependencies= to avoid loading
+    the dependence layers multiple times (thank to Lin Sun)
 *** Distribution changes
 - Refactored =spacemacs-bootstrap=, =spacemacs-ui=, and =spacemacs-ui-visual=
   layers:

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1518,8 +1518,9 @@ If `SKIP-LAYER-DEPS' is non nil then skip loading of layer dependenciesl"
 (defun configuration-layer/declare-layer-dependencies (layer-names)
   "Function to be used in `layers.el' files to declare dependencies."
   (dolist (x layer-names)
-    (add-to-list 'configuration-layer--layers-dependencies x)
-    (configuration-layer//load-layer-files x '("layers"))))
+    (unless (member x configuration-layer--layers-dependencies)
+      (add-to-list 'configuration-layer--layers-dependencies x)
+      (configuration-layer//load-layer-files x '("layers")))))
 
 (defun configuration-layer//declare-used-layers (layers-specs)
   "Declare used layers from LAYERS-SPECS list."


### PR DESCRIPTION
Fix the #15674.
To avoid loading the dependence layers multiple times in (configuration-layer/declare-layer-dependencies).