### PR TITLE
spacemacs-modeline: do not dependent on the neotree

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -33,7 +33,6 @@
         (font-lock+ :step pre
                     :location (recipe :fetcher github
                                       :repo emacsmirror/font-lock-plus))
-        neotree
         spaceline
         spaceline-all-the-icons
         symon
@@ -64,10 +63,6 @@
       (setq-default fancy-battery-show-percentage t))))
 
 (defun spacemacs-modeline/init-font-lock+ ())
-
-(defun spacemacs-modeline/post-init-neotree ()
-  (when (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))
-    (spaceline-all-the-icons--setup-neotree)))
 
 (defun spacemacs-modeline/init-spaceline ()
   (use-package spaceline-config
@@ -191,7 +186,11 @@
        spaceline-all-the-icons-separator-type
        (or (spacemacs/mode-line-separator) 'wave)
        spaceline-all-the-icons-separator-scale
-       (or (spacemacs/mode-line-separator-scale) 1.6)))))
+       (or (spacemacs/mode-line-separator-scale) 1.6)))
+    :config
+    (when (and (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))
+               (configuration-layer/package-used-p 'neotree))
+      (spaceline-all-the-icons--setup-neotree))))
 
 (defun spacemacs-modeline/init-symon ()
   (use-package symon


### PR DESCRIPTION
The `spacemacs-modeline` dependent on the `neotree` layer, but Spacemacs prefer `treemacs` as default file tree browser.
https://github.com/syl20bnr/spacemacs/blob/264a8ffc203a3215623330576941d1722bbee1e4/layers/%2Bdistributions/spacemacs/layers.el#L31

This change apply the function only when the `neotree` layer is used.