### PR TITLE
Add `shell-scripts-shfmt-args` variable

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -349,6 +349,8 @@ In org-agenda-mode
   - Add ~o~ to link-hint-open-link in woman-mode
 ***** Shaders
 - =shaders= layer has been moved to =gpu= layer.
+***** Shell-scripts
+- Add variable =shell-scripts-shfmt-args= to pass through arguments to =shfmt= package.
 ***** Syntax checking
 - Key bindings (thanks to Loris Lucido):
   - Key binding ~SPC e e~ is now for triggering a syntax check, the old action

--- a/layers/+lang/shell-scripts/config.el
+++ b/layers/+lang/shell-scripts/config.el
@@ -31,3 +31,7 @@ When `lsp' layer is used, defaults to `lsp'.")
 
 (defvar shell-scripts-format-on-save nil
   "If non-nil, automatically format code with shfmt on save.")
+
+(defcustom shell-scripts-shfmt-args ()
+  "Arguments passed to shfmt."
+  :type '(list string))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -110,7 +110,10 @@
     ;; therefore bind this function to "==" instead
     (if (eq shell-scripts-backend 'lsp)
         (spacemacs/set-leader-keys-for-major-mode 'sh-mode "==" 'shfmt-buffer)
-      (spacemacs/set-leader-keys-for-major-mode 'sh-mode "=" 'shfmt-buffer))))
+      (spacemacs/set-leader-keys-for-major-mode 'sh-mode "=" 'shfmt-buffer))
+    :config
+    (when shell-scripts-shfmt-args
+      (setq shfmt-arguments shell-scripts-shfmt-args))))
 
 (defun shell-scripts/post-init-ggtags ()
   (add-hook 'sh-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
This adds a variable to the `shell-scripts` layer to allow passing arguments through to the `shfmt` package.
