### PR TITLE
core/core-spacemacs-buffer.el: fix error for using `set' on a lexical varaible

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1535,7 +1535,7 @@ If a prefix argument is given, switch to it in an other, possibly new window."
         (page-break-lines-mode)
         (save-excursion
           (when (> (buffer-size) 0)
-            (set 'save-line (line-number-at-pos))
+            (setq save-line (line-number-at-pos))
             (let ((inhibit-read-only t))
               (erase-buffer)))
           (spacemacs-buffer/set-mode-line "")


### PR DESCRIPTION
Hi,
I got an error message that:
>In spacemacs-buffer/goto-buffer:
core-spacemacs-buffer.el:1538:14: Error: set cannot use lexical var ‘save-line’

The `setq` will work on the lexical variable. Please review and merge it, thanks.