### PR TITLE
core/core-release-management: load "core/core-load-paths" without suffix

### DIFF
--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -124,8 +124,8 @@ found."
     (async-start
      `(lambda ()
         ,(async-inject-variables "\\`spacemacs-start-directory\\'")
-        (load-file (concat spacemacs-start-directory
-                           "core/core-load-paths.el"))
+        (load (concat spacemacs-start-directory
+                      "core/core-load-paths"))
         (require 'core-spacemacs)
         (spacemacs/get-last-version))
      (lambda (result)


### PR DESCRIPTION
Hi,

Load the "core/core-load-paths" without suffix is more elastic, like what the init.el do.
https://github.com/syl20bnr/spacemacs/blob/cdf5045cd8e27f7dfea1a56358e6e5772f4957f6/init.el#L34-L36