### PR TITLE
Add support for background transparency toggling.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -75,6 +75,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   (thanks to Sylvain Benner, Compro Prasad and Keith Simmons)
 - Added support for native fill column indicator in Emacs 27+ (thanks to
   Andriy Kmit)
+- Add support for background transparency aka true transparency. Key bindings are under ~SPC T B~ (thanks to JoshTRN)
 *** Breaking Changes
 **** Major
 - Support for Emacs 25 or Emacs 26 has been dropped, the minimal Emacs version

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -497,6 +497,13 @@ can be toggled through `toggle-transparency'."
   'integer
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-background-transparency 90
+  "A value from the range (0..100), in increasing opacity, which describes the
+transparency level of a frame background when it's active or selected. Transparency
+can be toggled through `toggle-background-transparency'."
+  'integer
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-show-transient-state-title t
   "If non nil show the titles of transient states."
   'boolean

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -377,6 +377,11 @@ It should only modify the values of Spacemacs settings."
    ;; Transparency can be toggled through `toggle-transparency'. (default 90)
    dotspacemacs-inactive-transparency 90
 
+   ;; A value from the range (0..100), in increasing opacity, which describes the
+   ;; transparency level of a frame background when it's active or selected. Transparency
+   ;; can be toggled through `toggle-background-transparency'. (default 90)
+   dotspacemacs-background-transparency 90
+
    ;; If non-nil show the titles of transient states. (default t)
    dotspacemacs-show-transient-state-title t
 

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -93,6 +93,7 @@
     - [[#title][Title]]
       - [[#iconified-tabified-title][Iconified (tabified) title]]
     - [[#transparency][Transparency]]
+    - [[#background-transparency][Background transparency]]
 - [[#layouts-and-workspaces][Layouts and workspaces]]
   - [[#layouts][Layouts]]
     - [[#the-default-layout][The default layout]]
@@ -1668,6 +1669,20 @@ In the transient state:
 | ~-~, ~_~, ~j~ | decrease transparency          |
 | ~T~           | toggle transparency on and off |
 | ~q~           | quit transient state           |
+
+*** Background transparency
+The Frame background transparency can be toggled with: ~SPC T B~
+
+This also opens the Frame Background Transparency Transient State.
+
+In the transient state:
+
+| Key binding   | Description                               |
+|---------------+-------------------------------------------|
+| ~+~, ~=~, ~k~ | increase background transparency          |
+| ~-~, ~_~, ~j~ | decrease background transparency          |
+| ~T~           | toggle background transparency on and off |
+| ~q~           | quit transient state                      |
 
 * Layouts and workspaces
 Layouts are window configurations with buffer isolation. Each layout can define

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -1053,3 +1053,69 @@ If FRAME is nil, it defaults to the selected frame."
   'spacemacs/scale-transparency-transient-state/spacemacs/toggle-transparency)
 
 ;; end of Transparency Transient State
+
+;; Background Transparency transient-state
+
+(defun spacemacs/enable-background-transparency (&optional frame alpha-background)
+  "Enable background transparency for FRAME.
+If FRAME is nil, it defaults to the selected frame.
+ALPHA is a pair of active and inactive transparency values. The
+default value for ALPHA is based on `dotspacemacs-background-transparency'"
+  (interactive)
+  (message (number-to-string dotspacemacs-background-transparency))
+  (let ((alpha-setting (or alpha-background dotspacemacs-background-transparency)))
+    (message (number-to-string alpha-setting))
+    (set-frame-parameter frame 'alpha-background alpha-setting)))
+
+(defun spacemacs/disable-background-transparency (&optional frame)
+  "Disable background transparency for FRAME.
+If FRAME is nil, it defaults to the selected frame."
+  (interactive)
+  (set-frame-parameter frame 'alpha-background 100))
+
+
+(defun spacemacs/toggle-background-transparency (&optional frame)
+  "Toggle between transparent and opaque background state for FRAME.
+If FRAME is nil, it defaults to the selected frame."
+  (interactive)
+  (let ((alpha-background (frame-parameter frame 'alpha-background))
+        (dotfile-setting dotspacemacs-background-transparency))
+    (if (equal alpha-background dotfile-setting)
+        (spacemacs/disable-background-transparency frame)
+      (spacemacs/enable-background-transparency frame dotfile-setting))))
+
+(defun spacemacs/increase-background-transparency (&optional frame)
+  "Increase background transparency for FRAME.
+If FRAME is nil, it defaults to the selected frame."
+  (interactive)
+  (let* ((current-alpha (or (frame-parameter frame 'alpha-background) 100))
+         (message current-alpha)
+         (increased-alpha (- current-alpha 5)))
+    (when (>= increased-alpha frame-alpha-lower-limit)
+      (set-frame-parameter frame 'alpha-background increased-alpha))))
+
+(defun spacemacs/decrease-background-transparency (&optional frame)
+  "Decrease backrgound transparency for FRAME.
+If FRAME is nil, it defaults to the selected frame."
+  (interactive)
+  (let* ((current-alpha (or (frame-parameter frame 'alpha-background) 100))
+         (decreased-alpha (+ current-alpha 5)))
+    (when (<= decreased-alpha 100)
+      (set-frame-parameter frame 'alpha-background decreased-alpha))))
+
+(spacemacs|define-transient-state scale-background-transparency
+  :title "Frame Background Transparency Transient State"
+  :doc "\n[_+_/_=_/_k_] increase transparency [_-_/___/_j_] decrease [_T_] toggle [_q_] quit"
+  :bindings
+  ("+" spacemacs/increase-background-transparency)
+  ("=" spacemacs/increase-background-transparency)
+  ("k" spacemacs/increase-background-transparency)
+  ("-" spacemacs/decrease-background-transparency)
+  ("_" spacemacs/decrease-background-transparency)
+  ("j" spacemacs/decrease-background-transparency)
+  ("T" spacemacs/toggle-background-transparency)
+  ("q" nil :exit t))
+
+(spacemacs/set-leader-keys "TB"
+  'spacemacs/scale-background-transparency-transient-state/spacemacs/toggle-background-transparency)
+


### PR DESCRIPTION
Since Emacs 29, frame background transparency is supported. Default keybindings for background transparency toggling and transient state are added near transparency toggling with key bindings bound to the keys `SPC T B`.