### PR TITLE
* spacemacs-defaults: fix err msg when copy file path in a dired buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -779,7 +779,8 @@ ones created by `magit' and `dired'."
 (defun spacemacs/copy-file-name ()
   "Copy and show the file name of the current buffer."
   (interactive)
-  (if-let (file-name (file-name-nondirectory (spacemacs--file-path)))
+  (if-let* ((file-path (spacemacs--file-path))
+            (file-name (file-name-nondirectory file-path)))
       (progn
         (kill-new file-name)
         (message "%s" file-name))


### PR DESCRIPTION
Hi,
There is an error message when I open a dir and try to copy the file path via `(spacemacs/copy-file-path)`, 
> : Wrong type argument: stringp, nil`

This patch will fix the unexpected message.