### PR TITLE
* spacemacs-editing: expect the vterm-mode for the hungry-delete

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -232,6 +232,7 @@
       :evil-leader "td")
     :config
     (progn
+      (nconc hungry-delete-except-modes '(term-mode vterm-mode))
       (setq-default hungry-delete-chars-to-skip " \t\f\v") ; only horizontal whitespace
       (define-key hungry-delete-mode-map (kbd "DEL") 'hungry-delete-backward)
       (define-key hungry-delete-mode-map (kbd "S-DEL") 'delete-backward-char))))


### PR DESCRIPTION
When I toggle on the `hungry-delete-mode` and start a vterm buffer, press the backspace key, there is an error message:
> hungry-delete-impl: Buffer is read-only: #<buffer *Default-vterm-1*>

This patch will exclude both the `vterm-mode` and `term-mode` from the `hungry-delete-mode` to fix the error.