### PR TITLE
[finance] Evilify ledger-reconcile-mode-map

### DIFF
--- a/layers/+tools/finance/README.org
+++ b/layers/+tools/finance/README.org
@@ -4,7 +4,7 @@
 
 [[file:img/ledger.png]]
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
@@ -70,7 +70,7 @@ can for example use ~dix~ or ~vax~ to delete or mark the transaction at point.
 | Key binding | Description                                                               |
 |-------------+---------------------------------------------------------------------------|
 | ~SPC m ,~   | toggle the current transaction pending                                    |
-| ~SPC m a~   | quickly add a transaction, without exiting the reconciliation buffer      |
-| ~SPC m t~   | change the target amount for the selected account                         |
-| ~SPC m q~   | quit reconciliation                                                       |
+| ~a~         | quickly add a transaction, without exiting the reconciliation buffer      |
+| ~t~         | change the target amount for the selected account                         |
+| ~q~         | quit reconciliation                                                       |
 | ~SPC m RET~ | finalize the reconciliation, changing all pending transactions to cleared |

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -68,9 +68,6 @@
         "t" 'ledger-insert-effective-date)
       (spacemacs/set-leader-keys-for-major-mode 'ledger-reconcile-mode
         (or dotspacemacs-major-mode-leader-key ",") 'ledger-reconcile-toggle
-        "a" 'ledger-reconcile-add
-        "q" 'ledger-reconcile-quit
-        "t" 'ledger-reconcile-change-target
         "RET" 'ledger-reconcile-finish)
       ;; temporary hack to work-around an issue with evil-define-key
       ;; more info: https://github.com/emacs-evil/evil/issues/301
@@ -84,6 +81,9 @@
         (lambda () (when syntax-checking-enable-by-default
                      (global-flycheck-mode 1)))
         finance-lazy-load-flycheck)
+      (evilified-state-evilify-map ledger-reconcile-mode-map
+        :eval-after-load ledger-reconcile
+        :mode ledger-reconcile-mode)
       (evilified-state-evilify-map ledger-report-mode-map
         :eval-after-load ledger-report
         :mode ledger-report-mode))))


### PR DESCRIPTION
Remove the redundant key bindings for
`ledger-reconcile-{add,quit,change-target}`, which are already bound to reasonable keys in `ledger-reconcile-mode-map`.

Leave `ledger-reconcile-toggle` key binding intact but recommend `SPC` instead of `, ,` to toggle the pending flag.

Leave `ledger-reconcile-finish` key binding intact, because the upstream key binding is `C-c C-c`---not particularly idiomatic for Spacemacs.