### PR TITLE
Remove evil-ediff

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -871,6 +871,8 @@ Other:
     (thanks to rayw000)
   - Added =string-edit= package to =spacemacs-editing= layer
     (thanks to Ivan Yonchovski)
+  - Remove package =evil-ediff=
+    (thanks to Xuanqing Xu)
 - Key bindings:
   - Toggle line numbers (i.e. toggle =display-line-numbers-mode=) via ~SPC t n n~
     without having to think about which variant of line numbers you have turned

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -27,7 +27,6 @@
         evil-args
         evil-collection
         evil-cleverparens
-        evil-ediff
         (evil-escape :location (recipe :fetcher github
                                        :repo "smile13241324/evil-escape"))
         evil-exchange


### PR DESCRIPTION
Removed the package `evil-ediff` since it was merged into the package `evil-collection` and is no longer on MELPA. 