### PR TITLE
[spacemacs-theme] Fix solaire-hl-line-face background

### DIFF
--- a/core/libs/spacemacs-theme/spacemacs-common.el
+++ b/core/libs/spacemacs-theme/spacemacs-common.el
@@ -887,7 +887,7 @@ to 'auto, tags may not be properly aligned. "
 ;;;;; solaire
      `(solaire-default-face ((,class (:inherit default :background ,bg2))))
      `(solaire-minibuffer-face ((,class (:inherit default :background ,bg2))))
-     `(solaire-hl-line-face ((,class (:inherit hl-line :background ,bg2))))
+     `(solaire-hl-line-face ((,class (:inherit hl-line :background ,bg1))))
      `(solaire-org-hide-face ((,class (:inherit org-hide :background ,bg2))))
 
 ;;;;; spaceline


### PR DESCRIPTION
Not much of a highlight when it's the same as `solaire-default-face`!

PS: Has there been any discussion around joining forces with https://github.com/nashamri/spacemacs-theme ?