### PR TITLE
[finance] Fix up evil-ledger mode initialization

### DIFF
--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -45,7 +45,7 @@
 (defun finance/init-evil-ledger ()
   (use-package evil-ledger
     :defer t
-    :init (add-hook 'ledger-mode 'evil-ledger-mode)))
+    :init (add-hook 'ledger-mode-hook 'evil-ledger-mode)))
 
 (defun finance/init-ledger-mode ()
   (use-package ledger-mode

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -45,7 +45,10 @@
 (defun finance/init-evil-ledger ()
   (use-package evil-ledger
     :defer t
-    :init (add-hook 'ledger-mode-hook 'evil-ledger-mode)))
+    :init (add-hook 'ledger-mode-hook 'evil-ledger-mode)
+    :config
+    ;; Unset evil-ledger-mode's lighter
+    (setf (cadr (assoc 'evil-ledger-mode minor-mode-alist)) "")))
 
 (defun finance/init-ledger-mode ()
   (use-package ledger-mode


### PR DESCRIPTION
Fix the hook variable where `evil-ledger-mode` is added to refer to the actual major mode hook.

Also clear the lighter for `evil-ledger-mode` since it's long (`" EvilLedger"`) and isn't that informative (it just provides some motions and supplementary evil-style key bindings).