### PR TITLE
[themes-megapack] remove obsolete darkburn-theme

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3722,6 +3722,7 @@ files (thanks to Daniel Nicolai)
   (thanks to Dominic Pearson, Muneeb Shaikh)
 - Added highly accessible =modus-themes= (thanks to Muneeb Shaikh)
 - Added =doom-gruvbox-light= theme (thanks to John Stevenson)
+- Removed obsolete =darkburn-theme= (thanks to Muneeb Shaikh)
 **** Tmux
 - Prevent =tmux-command= at GUI mode (thanks to Isaac Zeng)
 - Fixed regression in tmux by setting keybindings using =use-package=

--- a/layers/+themes/themes-megapack/packages.el
+++ b/layers/+themes/themes-megapack/packages.el
@@ -42,7 +42,6 @@
     color-theme-sanityinc-tomorrow
     cyberpunk-theme
     dakrone-theme
-    darkburn-theme
     darkmine-theme
     darkokai-theme
     darktooth-theme


### PR DESCRIPTION
`darkburn-theme` has been removed from melpa.
Source: https://github.com/melpa/melpa/commit/53be06ccc5f3e784f71ef04ae1168e9901c84c6c
