### PR TITLE
Deletes uses of org-agenda-filter-by-tag-refine, as Org 9.0 removed it

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -945,7 +945,6 @@ each binding are listed bellow.
 | ~fc~        | by category         | org-agenda-filter-by-category     |
 | ~fd~        | delete all filters  | org-agenda-filter-remove-all      |
 | ~fh~        | by top headline     | org-agenda-filter-by-top-headline |
-| ~fr~        | refine by tag       | org-agenda-filter-by-tag-refine   |
 | ~ft~        | by tag              | org-agenda-filter-by-tag          |
 | ~fx~        | by regexp           | org-agenda-filter-by-regexp       |
 |-------------+---------------------+-----------------------------------|

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -524,11 +524,11 @@ Will work on both org-mode and any mode that accepts plain html."
 Headline^^            Visit entry^^               Filter^^                    Date^^                  Toggle mode^^        View^^             Clock^^        Other^^
 --------^^---------   -----------^^------------   ------^^-----------------   ----^^-------------     -----------^^------  ----^^---------    -----^^------  -----^^-----------
 [_ht_] set status     [_SPC_] in other window     [_ft_] by tag               [_ds_] schedule         [_tf_] follow        [_vd_] day         [_cI_] in      [_gr_] reload
-[_hk_] kill           [_TAB_] & go to location    [_fr_] refine by tag        [_dS_] un-schedule      [_tl_] log           [_vw_] week        [_cO_] out     [_._]  go to today
-[_hr_] refile         [_RET_] & del other windows [_fc_] by category          [_dd_] set deadline     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
-[_hA_] archive        [_o_]   link                [_fh_] by top headline      [_dD_] remove deadline  [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
-[_h:_] set tags       ^^                          [_fx_] by regexp            [_dt_] timestamp        [_ti_] clock issues  [_vy_] year        ^^             ^^
-[_hp_] set priority   ^^                          [_fd_] delete all filters   [_+_]  do later         [_td_] diaries       [_vn_] next span   ^^             ^^
+[_hk_] kill           [_TAB_] & go to location    [_fc_] by category          [_dS_] un-schedule      [_tl_] log           [_vw_] week        [_cO_] out     [_._]  go to today
+[_hr_] refile         [_RET_] & del other windows [_fh_] by top headline      [_dd_] set deadline     [_ta_] archive       [_vt_] fortnight   [_cq_] cancel  [_gd_] go to date
+[_hA_] archive        [_o_]   link                [_fx_] by regexp            [_dD_] remove deadline  [_tr_] clock report  [_vm_] month       [_cj_] jump    ^^
+[_h:_] set tags       ^^                          [_fd_] delete all filters   [_dt_] timestamp        [_ti_] clock issues  [_vy_] year        ^^             ^^
+[_hp_] set priority   ^^                          ^^                          [_+_]  do later         [_td_] diaries       [_vn_] next span   ^^             ^^
 ^^                    ^^                          ^^                          [_-_]  do earlier       ^^                   [_vp_] prev span   ^^             ^^
 ^^                    ^^                          ^^                          ^^                      ^^                   [_vr_] reset       ^^             ^^
 [_q_] quit
@@ -584,7 +584,6 @@ Headline^^            Visit entry^^               Filter^^                    Da
         ("fc" org-agenda-filter-by-category)
         ("fd" org-agenda-filter-remove-all)
         ("fh" org-agenda-filter-by-top-headline)
-        ("fr" org-agenda-filter-by-tag-refine)
         ("ft" org-agenda-filter-by-tag)
         ("fx" org-agenda-filter-by-regexp)
 


### PR DESCRIPTION
The Org Mode 9.0 release removed the org-agenda-filter-by-tag-refine and recommends the use of org-agenda-filter-by-tag in it's place. This commit removes all uses of the function and the mentions of it in the documentation. The same functionality can be achieved by using the typing prefix C-u twice and then using org-agenda-filter-by-tag ("ft") as the Org Mode documentation states.

Relevant Links:
- https://orgmode.org/worg/org-release-notes.html#org268651e
- https://orgmode.org/org.html#Filtering_002flimiting-agenda-items