### PR TITLE
layers/+tools/shell: vterm depends on emacs module

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -43,8 +43,8 @@
     terminal-here
     vi-tilde-fringe
     window-purpose
-    (multi-vterm :toggle (not (spacemacs/system-is-mswindows)))
-    (vterm :toggle (not (spacemacs/system-is-mswindows)))))
+    (multi-vterm :toggle (and module-file-suffix (not (spacemacs/system-is-mswindows))))
+    (vterm :toggle (and module-file-suffix (not (spacemacs/system-is-mswindows))))))
 
 
 (defun shell/init-comint ()


### PR DESCRIPTION
The vterm actually request the emacs-module feature available, so the toggle should depends on the emacs module feature.