### PR TITLE
core/core-dotspacemacs.el: speedup dotspacemacs/get-variable-string-list

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -892,13 +892,11 @@ Called with `C-u C-u' skips `dotspacemacs/user-config' _and_ preliminary tests."
 
 (defun dotspacemacs/get-variable-string-list ()
   "Return a list of all the dotspacemacs variables as strings."
-  (all-completions "" obarray
+  (all-completions "dotspacemacs" obarray
                    (lambda (x)
                      (and (boundp x)
-                          (not (keywordp x))
                           ;; avoid private variables to show up
-                          (not (string-match-p "--" (symbol-name x)))
-                          (string-prefix-p "dotspacemacs" (symbol-name x))))))
+                          (not (string-match-p "--" (symbol-name x)))))))
 
 (defun dotspacemacs/get-variable-list ()
   "Return a list of all dotspacemacs variable symbols."


### PR DESCRIPTION
Speedup the function `dotspacemacs/get-variable-string-list` for ~3x.
The original function benchmark result is ~ 7.0 seconds; 
assume the enhanced function to be `dotspacemacs/get-variable-string-list2`, the benchmark result is ~1.8 seconds. 
And the last block comprating the results from two functions show that the enhanced function return same results as the original function.
```
(benchmark-run 100
  (dotspacemacs/get-variable-string-list))
;; (7.039543576000001 4 1.1748634609999993)
(benchmark-run 100
  (dotspacemacs/get-variable-string-list2))
;; (1.875364132 0 0.0)

(cl-nset-difference
 (dotspacemacs/get-variable-string-list)
 (dotspacemacs/get-variable-string-list2))
;; nil
```