### PR TITLE
Fix core/core-load-path.el: auto locate spacemacs-start-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,16 +386,13 @@ In other word, in default installation, Emacs find and load
 If you want to install Spacemacs to a different location, you need to make
 sure it's loaded by Emacs in one of its [init file][Emacs: Find Init].
 
-For example, if you've cloned Spacemacs to `$HOME/spacemacs`, and if you use
+For example, if you've cloned Spacemacs to `$HOME/Spacemacs`, and if you use
 `$HOME/.emacs.el` as Emacs init file, then the following lines in
 `$HOME/.emacs.el`:
 
 ```elisp
-;; set variable `spacemacs-start-directory' to point to your Spacemacs
-;; installation location, "~" is equivalent to "$HOME"
-(setq spacemacs-start-directory "~/.emacs.d/spacemacs")
-;; load Spacemacs's initialization file
-(load-file (expand-file-name "init.el" spacemacs-start-directory))
+;; load Spacemacs's initialization file, "~" is equivalent to "$HOME"
+(load-file "~/Spacemacs/init.el")
 ```
 
 # First Launch and Configuration

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -34,7 +34,7 @@
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
-  (expand-file-name user-emacs-directory)
+  (concat (file-name-directory (or load-file-name buffer-file-name)) "../")
   "Spacemacs start directory.")
 
 ;; ~/.emacs.d/assets

--- a/init.el
+++ b/init.el
@@ -28,11 +28,9 @@
 ;; see `SPC h . dotspacemacs-gc-cons' for more info
 (defconst emacs-start-time (current-time))
 (setq gc-cons-threshold 402653184 gc-cons-percentage 0.6)
-(load (concat (file-name-directory load-file-name)
-              "core/core-versions")
+(load (concat (file-name-directory load-file-name) "core/core-load-paths")
       nil (not init-file-debug))
-(load (concat (file-name-directory load-file-name)
-              "core/core-load-paths")
+(load (concat spacemacs-core-directory "core-versions")
       nil (not init-file-debug))
 (load (concat spacemacs-core-directory "core-dumper")
       nil (not init-file-debug))


### PR DESCRIPTION
Failed on follow steps to get starting with Spacemacs:
```
$ git clone --depth=1 https://github.com/syl20bnr/spacemacs.git ~/Spacemacs
$ cd ~/Spacemacs/tests/core/ && make func_tests
Error: error ("The directory ~/.emacs.d/core/ does not exist and cannot be added to the ‘load-path’.")
```

This PR will locate the spacemacs-start-directory automatically, make the Spacemacs be more friendly for the newbie.