### PR TITLE
Defines "B" key bind for ebib to allow direct import from a doi

### DIFF
--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -152,6 +152,7 @@
       :mode biblio-selection-mode
       :bindings
       "e" 'ebib-biblio-selection-import
+      "B" 'ebib-biblio-import-doi
       (kbd "C-j") 'biblio--selection-next
       (kbd "C-k") 'biblio--selection-previous)))
 


### PR DESCRIPTION
This uses ebib's integration with biblio to work. The current code already configures the "e" key bind.
For more info: https://joostkremers.github.io/ebib/ebib-manual.html#integration-with-the-biblio-package