### PR TITLE
add binding for all the awesome tide refactorings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -130,6 +130,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
     in Emacs 24.3 to ~timeclock-mode-line-display~ (thanks to Zach Pearson)
   - Added =vim-style-enable-undo-region= style variables to enable undo-region
     in Vim editing style; disabled by default. (thanks to Benedict HW)
+  - Added ~SPC m r R~ to show tide refactorings submenu (thanks to Roberto 
+    Previdi)
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/layers/+tools/tide/funcs.el
+++ b/layers/+tools/tide/funcs.el
@@ -40,6 +40,7 @@
     "ri" #'tide-organize-imports
     "rr" #'tide-rename-symbol
     "rf" #'tide-rename-file
+    "rR" #'tide-refactor
     "S" "server"
     "Sr" #'tide-restart-server
     "Sj" #'spacemacs//tide-create-jsconfig-file))


### PR DESCRIPTION
I just discovered that with tide and tsserver we have access to many more refactorings than simple rename, like extract constant/function, convert lambda to function, just to name a couple... Let's add a keybinding so everybody can use them easily!
