### PR TITLE
renable Geben package when lsp layer in use

### DIFF
--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -39,7 +39,7 @@
     (phpactor :toggle (not (eq php-backend 'lsp)))
     (company-phpactor :requires company :toggle (not (eq php-backend 'lsp)))
     (company-php :requires company :toggle (not (eq php-backend 'lsp)))
-    (geben :toggle (not (eq php-backend 'lsp)))))
+    geben))
 
 (defun php/pre-init-dap-mode ()
   (when (eq php-backend 'lsp)


### PR DESCRIPTION
[43bf85c6854ccf314d930162c485f70cf206a89f](https://github.com/syl20bnr/spacemacs/commit/43bf85c6854ccf314d930162c485f70cf206a89f)  prevents a user from installing and using the geben package in their own custom configurations when the lsp layer is active.

[geben](https://github.com/ahungry/geben) is a dbgp debugging tool for PHP.  It's the only one that works right now in the Spacemacs environment. 

[dap](https://github.com/emacs-lsp/dap-mode) is the only other alternative, but dap-php is broken most of the time due to complications with treemacs development.

Both of these packages need to live together with the lsp layer.