### PR TITLE
* core: enhance the code to reduce flycheck warnings

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -33,6 +33,7 @@
 (require 'core-funcs)
 (require 'core-progress-bar)
 (require 'core-spacemacs-buffer)
+(require 'core-load-paths)
 
 (defvar configuration-layer--refresh-package-timeout dotspacemacs-elpa-timeout
   "Timeout in seconds to reach a package archive page.")

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -20,7 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+(require 'core-load-paths)
 (require 'core-customization)
 
 (defconst dotspacemacs-template-directory

--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -21,6 +21,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 (require 'core-funcs)
+(require 'core-load-paths)
+
 (require 'core-spacemacs-buffer)
 
 (defvar spacemacs--diminished-minor-modes nil

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -20,9 +20,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-(defvar configuration-layer--protected-packages)
-(defvar dotspacemacs-filepath)
 (defvar spacemacs-repl-list '()
   "List of all registered REPLs.")
 

--- a/core/core-spacebind.el
+++ b/core/core-spacebind.el
@@ -20,7 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+(require 'core-load-paths)
 (require 'core-keybindings)
 
 (defvar spacebind--eager-bind t

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -22,6 +22,7 @@
 
 ;;; Code:
 
+(require 'core-dotspacemacs)
 (eval-when-compile
   (defvar dotspacemacs-distribution)
   (defvar dotspacemacs-filepath)
@@ -32,13 +33,9 @@
   (defvar spacemacs-badge-official-png)
   (defvar spacemacs-banner-directory)
   (defvar spacemacs-banner-official-png)
-  (defvar spacemacs-cache-directory)
-  (defvar spacemacs-docs-directory)
   (defvar spacemacs-gplv3-official-png)
-  (defvar spacemacs-info-directory)
-  (defvar spacemacs-release-notes-directory)
-  (defvar spacemacs-start-directory)
-  (defvar spacemacs-version))
+  (defvar spacemacs-version)
+  (defvar configuration-layer-error-count))
 
 
 (defconst spacemacs-buffer-version-info "0.999"

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -28,6 +28,8 @@
   :prefix 'spacemacs-)
 
 (require 'subr-x nil 'noerror)
+(require 'core-versions)
+(require 'core-load-paths)
 (require 'core-emacs-backports)
 (require 'core-env)
 (require 'page-break-lines)
@@ -52,6 +54,7 @@
 (require 'core-use-package-ext)
 (require 'core-spacebind)
 (require 'core-compilation)
+(require 'core-dumper)
 
 (defvar spacemacs-post-user-config-hook nil
   "Hook run after dotspacemacs/user-config")


### PR DESCRIPTION
Hi,

Many core/*.el files used the variables from `core-load-paths.el` or `core-versions.el` but didn't require them.
This PR try to fix the missed requirement to make the code more precise.
Please help review and approve this PR. Thanks.