### PR TITLE
Fix #15658: replace geiser-company-backend with company-capf

### DIFF
--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -41,7 +41,7 @@
 
 (defun scheme/post-init-company ()
   ;; Geiser provides completion as long as company mode is loaded.
-  (spacemacs|add-company-backends :modes scheme-mode :backends geiser-company-backend))
+  (spacemacs|add-company-backends :modes scheme-mode :backends company-capf))
 
 (defun scheme/pre-init-evil-cleverparens ()
   (spacemacs|use-package-add-hook evil-cleverparens


### PR DESCRIPTION
The geiser-company-backend was removed in [this
commit](https://gitlab.com/emacs-geiser/geiser/-/commit/18faa0ba32c9ce751c16960b2a39b3880b523272). Subsequently, a geiser-capf module, configuring the company-capf backend for geiser, was added in [this
commit](https://gitlab.com/emacs-geiser/geiser/-/commit/18faa0ba32c9ce751c16960b2a39b3880b523272). This commit updates the scheme layer to use the new backend.