### PR TITLE
* core: eval-and-compile the functions used in eager macro expansion

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -890,17 +890,18 @@ Called with `C-u C-u' skips `dotspacemacs/user-config' _and_ preliminary tests."
   (when (configuration-layer/package-used-p 'spaceline)
     (spacemacs//restore-buffers-powerline)))
 
-(defun dotspacemacs/get-variable-string-list ()
-  "Return a list of all the dotspacemacs variables as strings."
-  (all-completions "dotspacemacs" obarray
-                   (lambda (x)
-                     (and (boundp x)
-                          ;; avoid private variables to show up
-                          (not (string-match-p "--" (symbol-name x)))))))
+(eval-and-compile
+  (defun dotspacemacs/get-variable-string-list ()
+    "Return a list of all the dotspacemacs variables as strings."
+    (all-completions "dotspacemacs" obarray
+                     (lambda (x)
+                       (and (boundp x)
+                            ;; avoid private variables to show up
+                            (not (string-match-p "--" (symbol-name x)))))))
 
-(defun dotspacemacs/get-variable-list ()
-  "Return a list of all dotspacemacs variable symbols."
-  (mapcar 'intern (dotspacemacs/get-variable-string-list)))
+  (defun dotspacemacs/get-variable-list ()
+    "Return a list of all dotspacemacs variable symbols."
+    (mapcar 'intern (dotspacemacs/get-variable-string-list))))
 
 (defmacro dotspacemacs|symbol-value (symbol)
   "Return the value of SYMBOL corresponding to a dotspacemacs variable.

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -805,19 +805,20 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
       (when messagebuf
         (message "(Spacemacs) %s" msg)))))
 
-(defun spacemacs-buffer//startup-list-jump-func-name (str)
-  "Given a string, return a spacemacs-buffer function name.
+(eval-and-compile
+  (defun spacemacs-buffer//startup-list-jump-func-name (str)
+    "Given a string, return a spacemacs-buffer function name.
 
 Given:           Return:
 \"[?]\"            \"spacemacs-buffer/jump-to-[?]\"
 \"Recent Files:\"  \"spacemacs-buffer/jump-to-recent-files\""
-  (let ((s (downcase str)))
-    ;; remove last char if it's a colon
-    (when (string-match ":$" s)
-      (setq s (substring s nil (1- (length s)))))
-    ;; replace any spaces with a dash
-    (setq s (replace-regexp-in-string " " "-" s))
-    (concat "spacemacs-buffer/jump-to-" s)))
+    (let ((s (downcase str)))
+      ;; remove last char if it's a colon
+      (when (string-match ":$" s)
+        (setq s (substring s nil (1- (length s)))))
+      ;; replace any spaces with a dash
+      (setq s (replace-regexp-in-string " " "-" s))
+      (concat "spacemacs-buffer/jump-to-" s))))
 
 (defmacro spacemacs-buffer||add-shortcut
     (shortcut-char search-label &optional no-next-line)


### PR DESCRIPTION
Surround the function `spacemacs-buffer//startup-list-jump-func-name` with `eval-and-compile` for  it's called in the macro   `spacemacs-buffer`:
https://github.com/syl20bnr/spacemacs/blob/866a2d5ae12706a68acb83f489dd669bc7b29d1e/core/core-spacemacs-buffer.el#L822-L840
it's eager macro expansion.
Similar to `dotspacemacs/get-variable-list`.