### PR TITLE
fix(spacemacs-buffer): fix retrieval org-agenda-files

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1279,7 +1279,9 @@ LIST-SIZE is specified in `dotspacemacs-startup-lists' for recent entries."
   (unless recentf-mode (recentf-mode))
   (let (;; we need to remove `org-agenda-files' entries from recent files
         (agenda-files
-         (when-let ((files
+         (when-let ((default-directory
+                      (or (bound-and-true-p org-directory) "~/org"))
+                    (files
                      (when (bound-and-true-p org-agenda-files)
                        (if (listp org-agenda-files)
                            ;; if it's a list, we take that value directly


### PR DESCRIPTION
In particular, we only need to call `(org-agenda-files)` (and hence load `org`)
if the variable `org-agenda-files` is a single file name. Otherwise we can
safely use the value of the said variable directly.

This was not handled correctly before this commit.