### PR TITLE
fix(spacemacs-buffer): fix mouse clicks and drags

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -123,6 +123,12 @@ It's cleared when the idle timer runs.")
       (define-key map (kbd "9") 'spacemacs-buffer/jump-to-number-startup-list-line))
 
     (define-key map [down-mouse-1] 'spacemacs-buffer//mouse-1)
+    (define-key map [mouse-1] 'ignore) ;; left button, avoid multiple clicks
+    (define-key map [mouse-2] 'ignore) ;; mid button
+    (define-key map [mouse-3] 'ignore) ;; right button
+    (define-key map [drag-mouse-1] 'ignore)
+    (define-key map [drag-mouse-2] 'ignore)
+    (define-key map [drag-mouse-3] 'ignore)
     (define-key map (kbd "RET") 'spacemacs-buffer/return)
 
     (define-key map [tab] 'widget-forward)


### PR DESCRIPTION
This makes all mouse click and drag events no-op on spacemacs-buffer, except for the plain left mouse click.

fixes #15870 