### PR TITLE
fix: helm-display-header-line must be set when helm-echo-input-in-header-line is t

### DIFF
--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -33,10 +33,10 @@
 (defun spacemacs-completion/init-default-helm-config ()
   (setq helm-prevent-escaping-from-minibuffer t
         helm-bookmark-show-location t
-        helm-display-header-line nil
         helm-split-window-inside-p t
         helm-always-two-windows t
         helm-echo-input-in-header-line t
+        helm-display-header-line t
         helm-imenu-execute-action-at-once-if-one nil
         helm-org-format-outline-path t
         helm-completion-style (if (eq helm-use-fuzzy 'always) 'helm-fuzzy 'helm)


### PR DESCRIPTION
When the current path is longer then the current frame width, helm-ff may open with the cursor in a wrong position. Any interaction will result in a "Text is readonly" message, until helm ends up navigating to the root folder and we can interact again.

According to @thierryvolpiatto, helm-echo-input-in-header-line and helm-display-header-line must be both set.
https://github.com/emacs-helm/helm/issues/2579#issuecomment-1373158505

Updating spacemac's defaults for these variables fixes the issue.