### PR TITLE
Don't set :foreground/background to nil to avoid font warnings in emacs29

### DIFF
--- a/.circleci/web/.spacemacs
+++ b/.circleci/web/.spacemacs
@@ -1,6 +1,6 @@
 (defun dotspacemacs/layers ()
   (setq-default
-   dotspacemacs-distribution 'spacemacs-base
+   dotspacemacs-distribution 'spacemacs
    dotspacemacs-configuration-layers '(
                                        (org :variables
                                             org-enable-github-support t

--- a/.github/workflows/elisp_test.yml
+++ b/.github/workflows/elisp_test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs_version: [27.2, 28.1]
+        emacs_version: [27.2, 28.2]
     steps:
 # Installing Emacs on Unix
     - name: Install Emacs on UNIX

--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -342,7 +342,7 @@ Returns the output of git status --porcelain."
                       (symbol-name state))
              :group 'spacemacs))
     (set-face-attribute fname nil
-                        :foreground foreground
+                        :foreground (or foreground 'unspecified)
                         :box (face-attribute 'mode-line :box))))
 
 (defun spacemacs//compute-version-score (version)

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -67,19 +67,20 @@ For evil states that also need an entry to `spacemacs-evil-cursors' use
   ;; for example treemacs: it needs no cursor since it solely uses hl-line-mode
   ;; and having an evil cursor defined anyway leads to the cursor sometimes
   ;; visibly flashing in treemacs buffers
-  (eval `(defface ,(intern (format "spacemacs-%s-face" state))
-           `((t (:background ,color
-                             :foreground ,(face-background 'mode-line)
-                             :inherit 'mode-line)))
+  (eval `(defface ,(spacemacs/state-color-face (intern state))
+           `((t (:background ,color :inherit 'mode-line)))
            (format "%s state face." state)
-           :group 'spacemacs)))
+           :group 'spacemacs))
+  ;; 'unspecified may not be used in defface, so set it via set-face-attribute.
+  (set-face-attribute (spacemacs/state-color-face (intern state)) nil
+       :foreground (face-attribute 'mode-line :background)))
 
 (defun spacemacs/set-state-faces ()
-  (cl-loop for (state color cursor) in spacemacs-evil-cursors
-           do
-           (set-face-attribute (intern (format "spacemacs-%s-face" state))
-                               nil
-                               :foreground (face-background 'mode-line))))
+  (let ((ml-bg (face-attribute 'mode-line :background)))
+    (cl-loop for (state color cursor) in spacemacs-evil-cursors
+             do
+             (set-face-attribute (spacemacs/state-color-face (intern state)) nil
+                                 :foreground ml-bg))))
 
 (defun evil-insert-state-cursor-hide ()
   (setq evil-insert-state-cursor '((hbar . 0))))

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -52,6 +52,7 @@
 (defun chinese/init-pyim ()
   (use-package pyim
     :if chinese-default-input-method
+    :defer t
     :init
     (progn
       (setq pyim-page-tooltip t
@@ -69,6 +70,7 @@
   "Initialize pyim-basedict"
   (use-package pyim-basedict
     :if (eq chinese-default-input-method 'pinyin)
+    :defer t
     :config
     (pyim-basedict-enable)))
 
@@ -76,6 +78,7 @@
   "Initialize pyim-wbdict"
   (use-package pyim-wbdict
     :if (member chinese-default-input-method '(wubi wubi86 wubi98))
+    :defer t
     :config
     (progn
       (setq pyim-default-scheme 'wubi)
@@ -86,7 +89,7 @@
 (defun chinese/init-youdao-dictionary ()
   (use-package youdao-dictionary
     :if chinese-enable-youdao-dict
-    :defer
+    :defer t
     :config
     (progn
       ;; Enable Cache

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -107,6 +107,7 @@
 
 (defun c-c++/init-clang-format ()
   (use-package clang-format
+    :defer t
     :init (spacemacs//c-c++-setup-clang-format)))
 
 (defun c-c++/post-init-company ()

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -479,7 +479,7 @@
 (defun clojure/post-init-company ()
   (spacemacs|add-company-backends
     :backends company-capf
-    :modes clojure-mode clojurec-mode clojurescript-mode clojurex-mode cide-clojure-interaction-mode cider-mode cider-repl-mode))
+    :modes clojure-mode clojurec-mode clojurescript-mode clojurex-mode cider-clojure-interaction-mode cider-mode cider-repl-mode))
 
 (defun clojure/post-init-ggtags ()
   (add-hook 'clojure-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -217,15 +217,16 @@ ROOT-DIR should be the path for the environemnt, `nil' for clean up"
 
 ;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
 (defun spacemacs/python-remove-unused-imports ()
-  "Use Autoflake to remove unused function"
-  "autoflake --remove-all-unused-imports -i unused_imports.py"
+  "Use Autoflake to remove unused imports.
+Equivalent to: autoflake --remove-all-unused-imports --inplace <FILE>"
   (interactive)
   (if (executable-find "autoflake")
-      (progn
-        (shell-command (format "autoflake --remove-all-unused-imports -i %s"
-                               (shell-quote-argument (buffer-file-name))))
+      (if (not (eql 0
+                    (shell-command (format "autoflake --remove-all-unused-imports --inplace %s"
+                                           (shell-quote-argument (buffer-file-name))))))
+          (pop-to-buffer shell-command-buffer-name)
         (revert-buffer t t t))
-    (message "Error: Cannot find autoflake executable.")))
+    (user-error "Cannot find autoflake executable")))
 
 (defun spacemacs//pyenv-mode-set-local-version ()
   "Set pyenv version from \".python-version\" by looking in parent directories."

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -101,7 +101,6 @@
 (defun typescript/post-init-web-mode ()
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . typescript-tsx-mode))
-  (spacemacs/typescript-mode-init 'typescript-tsx-mode-local-vars-hook)
   (spacemacs/typescript-mode-config 'typescript-tsx-mode))
 
 (defun typescript/init-typescript-mode ()
@@ -110,7 +109,9 @@
     :init
     (progn
       (spacemacs/typescript-safe-local-variables '(lsp tide))
-      (spacemacs/typescript-mode-init 'typescript-mode-local-vars-hook))
+      (spacemacs/typescript-mode-init 'typescript-mode-local-vars-hook)
+      ;; init tsx locals here to get proper order 
+      (spacemacs/typescript-mode-init 'typescript-tsx-mode-local-vars-hook))
     :config (spacemacs/typescript-mode-config 'typescript-mode)))
 
 (defun typescript/pre-init-import-js ()

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -43,8 +43,8 @@
   "Set the face of diretories for `.' and `..'"
   (set-face-attribute 'helm-ff-dotted-directory
                       nil
-                      :foreground nil
-                      :background nil
+                      :foreground 'unspecified
+                      :background 'unspecified
                       :inherit 'helm-ff-directory))
 
 (defun spacemacs//helm-find-files-enable-helm--in-fuzzy ()

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -527,13 +527,13 @@
     :config
     (progn
       (set-face-attribute 'whitespace-space nil
-                          :background nil
+                          :background 'unspecified
                           :foreground (face-attribute 'font-lock-warning-face
                                                       :foreground))
       (set-face-attribute 'whitespace-tab nil
-                          :background nil)
+                          :background 'unspecified)
       (set-face-attribute 'whitespace-indentation nil
-                          :background nil)
+                          :background 'unspecified)
       (spacemacs|diminish whitespace-mode " ⓦ" " w")
       (spacemacs|diminish global-whitespace-mode " ⓦ" " w"))))
 

--- a/layers/+spacemacs/spacemacs-editing/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing/funcs.el
@@ -115,8 +115,8 @@ If `global' is non-nil activate the respective global mode."
 (defun spacemacs//adaptive-smartparent-pair-overlay-face ()
   (set-face-attribute 'sp-pair-overlay-face nil
                       :inherit 'lazy-highlight
-                      :background nil
-                      :foreground nil))
+                      :background 'unspecified
+                      :foreground 'unspecified))
 
 (defun spacemacs//put-clean-aindent-last ()
   "Put `clean-aindent--check-last-point` to end of `post-command-hook`.

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -353,6 +353,8 @@
     :commands paradox-list-packages
     :init
     (setq paradox-execute-asynchronously nil)
+    (spacemacs/set-leader-keys
+      "ak" 'spacemacs/paradox-list-packages)
     :config
     (evilified-state-evilify-map paradox-menu-mode-map
       :mode paradox-menu-mode
@@ -361,9 +363,7 @@
       "J" 'paradox-next-describe
       "K" 'paradox-previous-describe
       "L" 'paradox-menu-view-commit-list
-      "o" 'paradox-menu-visit-homepage)
-    (spacemacs/set-leader-keys
-      "ak" 'spacemacs/paradox-list-packages)))
+      "o" 'paradox-menu-visit-homepage)))
 
 (defun spacemacs-navigation/init-restart-emacs ()
   (use-package restart-emacs

--- a/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
+++ b/layers/+spacemacs/spacemacs-visual/local/zoom-frm/frame-cmds.el
@@ -4,13 +4,13 @@
 ;; Description: Frame and window commands (interactive functions).
 ;; Author: Drew Adams
 ;; Maintainer: Drew Adams (concat "drew.adams" "@" "oracle" ".com")
-;; Copyright (C) 1996-2021, Drew Adams, all rights reserved.
+;; Copyright (C) 1996-2023, Drew Adams, all rights reserved.
 ;; Created: Tue Mar  5 16:30:45 1996
 ;; Version: 0
 ;; Package-Requires: ((frame-fns "0"))
-;; Last-Updated: Thu Apr 22 09:05:03 2021 (-0700)
+;; Last-Updated: Mon Dec 26 08:33:38 2022 (-0800)
 ;;           By: dradams
-;;     Update #: 3188
+;;     Update #: 3189
 ;; URL: https://www.emacswiki.org/emacs/download/frame-cmds.el
 ;; Doc URL: https://emacswiki.org/emacs/FrameModes
 ;; Doc URL: https://www.emacswiki.org/emacs/OneOnOneEmacs
@@ -946,7 +946,7 @@ Only displayed buffers are completion candidates."
                    nil t nil 'minibuffer-history (buffer-name (current-buffer)) t))
 
 (defsubst frcmds-frame-iconified-p (frame)
-  "Return non-nil if FRAME is `frame-live-p' and `frame-visible-p'."
+  "Return non-nil if FRAME is live and `frame-visible-p' is `icon'."
   (and (frame-live-p frame)  (eq (frame-visible-p frame) 'icon)))
 
 ;; (defun remove-window (&optional window)

--- a/layers/+themes/theming/README.org
+++ b/layers/+themes/theming/README.org
@@ -49,7 +49,7 @@ It should be a list of the following form:
              ;; Font locking
              (font-lock-comment-face :slant italic)
              (web-mode-html-attr-name-face :inherit font-lock-variable-name-face
-                                           :foreground nil)
+                                           :foreground 'unspecified)
              ;; Modeline
              (powerline-active1 :box (:color "#999999"
                                       :line-width 1


### PR DESCRIPTION
`:foreground nil` (or `:background nil`) are illegal values and generate warnings in emacs 29.

We can't set to `unspecified` either because user code is not supposed to do this:
 - https://github.com/emacs-mirror/emacs/commit/824a139434855919073d6ea3c93d57ebd24fc75c
 - https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51595#15

This eliminates all warnings that I see with my config. There may be more instances of setting to `nil` in the code base. We'll find them once they generate warnings for others.

Fixes #15862.

cc @lebensterben 