### PR TITLE
Fix paradox-list-package key not being bound on init

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -353,6 +353,8 @@
     :commands paradox-list-packages
     :init
     (setq paradox-execute-asynchronously nil)
+    (spacemacs/set-leader-keys
+      "ak" 'spacemacs/paradox-list-packages)
     :config
     (evilified-state-evilify-map paradox-menu-mode-map
       :mode paradox-menu-mode
@@ -361,9 +363,7 @@
       "J" 'paradox-next-describe
       "K" 'paradox-previous-describe
       "L" 'paradox-menu-view-commit-list
-      "o" 'paradox-menu-visit-homepage)
-    (spacemacs/set-leader-keys
-      "ak" 'spacemacs/paradox-list-packages)))
+      "o" 'paradox-menu-visit-homepage)))
 
 (defun spacemacs-navigation/init-restart-emacs ()
   (use-package restart-emacs


### PR DESCRIPTION
The key binding of autoloaded `paradox-list-packages` to leader a k does not execute until package is autoloaded by some other means, since being moved from :init to :config in f4b04bcf228b9e9a6eb1e19a9f1f78b429e347ad. Moved it back to init