### PR TITLE
org-layer: Update to org 9.6.1, fixing broken install

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -33,7 +33,7 @@
     htmlize
     ;; ob, org, org-agenda and org-contacts are installed by `org-contrib'
     (ob :location built-in)
-    (org :location elpa :min-version "9.6")
+    (org :location elpa :min-version "9.6.1")
     (org-agenda :location built-in)
     (org-wild-notifier
                 :toggle org-enable-notifications)


### PR DESCRIPTION
This integrates the patch that fix default install: https://list.orgmode.org/87bkonzisl.fsf@gnu.org/T/#u

In particular fixes the error:
(invalid-function org-assert-version)

I don't know how emacs resolve the version, as I would expect it to choose the highest patch release satisfying the min requirement; but the 9.6 release is borked, and any fresh install would choose the 9.6 and thus break because of this issue (I tried more than 5 times without success).

I'm trying to begin into spacemacs, let me know if I messed up anything up!
