### PR TITLE
Typescript tsx improvements

### DIFF
--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -170,7 +170,7 @@ then set the variable =typescript-lsp-linter= to =nil=.
 #+END_SRC
 
 * TSX Mode
-This layer also defines a layer for working with .tsx files called
+This layer also defines a major mode for working with .tsx files called
 =typescript-tsx-mode=. This mode is derived from web-mode and as such, will
 inherit the faces and behavior of web-mode. If you are using using tree-sitter
 for syntax highlighting, you may choose to switch to using tree-sitter for tsx

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -73,6 +73,9 @@ You can choose either tslint (default) or eslint for linting:
                 typescript-linter 'tslint)))
 #+END_SRC
 
+Please be advised that tslint is now deprecated, and should only be used for
+legacy projects. [[https://github.com/palantir/tslint#tslint][See TSLint Repo for more]].
+
 ** Pre-requisites
 You will need =node.js v0.12.0= or greater.
 

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -15,6 +15,7 @@
   - [[#tide][Tide]]
     - [[#notes][Notes]]
   - [[#language-server-protocol][Language Server Protocol]]
+- [[#tsx-mode][TSX Mode]]
 - [[#key-bindings][Key bindings]]
   - [[#typescript-major-mode][Typescript Major Mode]]
   - [[#reference-major-mode][Reference Major Mode]]
@@ -163,6 +164,19 @@ then set the variable =typescript-lsp-linter= to =nil=.
     (typescript :variables
                 typescript-backend 'lsp
                 typescript-lsp-linter nil)))
+#+END_SRC
+
+* TSX Mode
+This layer also defines a layer for working with .tsx files called
+=typescript-tsx-mode=. This mode is derived from web-mode and as such, will
+inherit the faces and behavior of web-mode. If you are using using tree-sitter
+for syntax highlighting, you may choose to switch to using tree-sitter for tsx
+by setting the =typescript-use-treesitter-for-tsx= to non-nil.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (typescript :variables
+                typescript-use-treesitter-for-tsx 1)))
 #+END_SRC
 
 * Key bindings

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -38,6 +38,10 @@ If `nil' then `tide' is the default backend unless `lsp' layer is used.")
 (defvar typescript-linter 'tslint
   "The linter to use for typescript. Possible values are `tslint' `eslint'")
 
+(defvar typescript-use-treesitter-for-tsx nil
+  "If non-nil, then use tree-sitter rather than web-mode for tsx
+file syntax highlighting.")
+
 (defvar typescript-lsp-linter t
   "If the backend is `lsp', and this variable is non-nil, then
 use lsp as the linter, otherwise let flycheck choose the best

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -160,4 +160,4 @@
 ;; Disable web-modes font-lock syntax highlighting for tsx files.
 ;; See: https://github.com/emacs-tree-sitter/tree-sitter-langs/issues/23#issuecomment-832815710
 (defun spacemacs//typescript-tsx-mode-fix-tree-sitter()
-  (set (make-local-variable 'tree-sitter-hl-use-font-lock-keywords) nil))
+  (setq-local tree-sitter-hl-use-font-lock-keywords nil))

--- a/layers/+lang/typescript/funcs.el
+++ b/layers/+lang/typescript/funcs.el
@@ -155,3 +155,9 @@
             "==" 'spacemacs/typescript-format))
     ('tide (spacemacs/set-leader-keys-for-major-mode mode
              "=" 'spacemacs/typescript-format))))
+
+;; Workaround to fix tsx highlighting error.
+;; Disable web-modes font-lock syntax highlighting for tsx files.
+;; See: https://github.com/emacs-tree-sitter/tree-sitter-langs/issues/23#issuecomment-832815710
+(defun spacemacs//typescript-tsx-mode-fix-tree-sitter()
+  (set (make-local-variable 'tree-sitter-hl-use-font-lock-keywords) nil))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -101,7 +101,10 @@
 (defun typescript/post-init-web-mode ()
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . typescript-tsx-mode))
-  (spacemacs/typescript-mode-config 'typescript-tsx-mode))
+  (spacemacs/typescript-mode-config 'typescript-tsx-mode)
+  (with-eval-after-load 'tree-sitter
+      (tree-sitter-require 'tsx)
+      (add-to-list 'tree-sitter-major-mode-language-alist '(typescript-tsx-mode . tsx))))
 
 (defun typescript/init-typescript-mode ()
   (use-package typescript-mode

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -102,10 +102,11 @@
   (define-derived-mode typescript-tsx-mode web-mode "TypeScript-tsx")
   (add-to-list 'auto-mode-alist '("\\.tsx\\'" . typescript-tsx-mode))
   (spacemacs/typescript-mode-config 'typescript-tsx-mode)
-  (with-eval-after-load 'tree-sitter
+  (when typescript-use-treesitter-for-tsx
+    (with-eval-after-load 'tree-sitter
       (tree-sitter-require 'tsx)
       (add-hook 'typescript-tsx-mode-hook #'spacemacs//typescript-tsx-mode-fix-tree-sitter)
-      (add-to-list 'tree-sitter-major-mode-language-alist '(typescript-tsx-mode . tsx))))
+      (add-to-list 'tree-sitter-major-mode-language-alist '(typescript-tsx-mode . tsx)))))
 
 (defun typescript/init-typescript-mode ()
   (use-package typescript-mode

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -104,6 +104,7 @@
   (spacemacs/typescript-mode-config 'typescript-tsx-mode)
   (with-eval-after-load 'tree-sitter
       (tree-sitter-require 'tsx)
+      (add-hook 'typescript-tsx-mode-hook #'spacemacs//typescript-tsx-mode-fix-tree-sitter)
       (add-to-list 'tree-sitter-major-mode-language-alist '(typescript-tsx-mode . tsx))))
 
 (defun typescript/init-typescript-mode ()

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -49,6 +49,8 @@
           (spacemacs/lsp-bind-upstream-keys)
         (spacemacs/lsp-bind-keys))
       (setq lsp-prefer-capf t)
+      ;; This sets the lsp indentation for all modes derived from web-mode.
+      (add-to-list 'lsp--formatting-indent-alist '(web-mode . web-mode-markup-indent-offset))
       (add-hook 'lsp-after-open-hook (lambda ()
                                        "Setup xref jump handler"
                                        (spacemacs//setup-lsp-jump-handler))))))

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -50,7 +50,7 @@
         (spacemacs/lsp-bind-keys))
       (setq lsp-prefer-capf t)
       ;; This sets the lsp indentation for all modes derived from web-mode.
-      (add-to-list 'lsp--formatting-indent-alist '(web-mode . web-mode-markup-indent-offset))
+      (setf (alist-get 'web-mode lsp--formatting-indent-alist) 'web-mode-markup-indent-offset)
       (add-hook 'lsp-after-open-hook (lambda ()
                                        "Setup xref jump handler"
                                        (spacemacs//setup-lsp-jump-handler))))))


### PR DESCRIPTION
A few improvements for typescript-tsx mode.

 - Fixes mismatched indention for tsx files when indenting using LSP
 - Uses tree-sitter for highlighting tsx files, if it's available.
 - Workaround to fix a conflict with web-mode fontification and tree-sitter
