### PR TITLE
Fix face warnings by using unspecified instead of nil

### DIFF
--- a/core/libs/spacemacs-theme/spacemacs-common.el
+++ b/core/libs/spacemacs-theme/spacemacs-common.el
@@ -277,11 +277,11 @@ to 'auto, tags may not be properly aligned. "
      `(centaur-tabs-modified-marker-unselected ((,class (:inherit 'centaur-tabs-unselected :foreground,keyword))))
 
 ;;;;; cider
-     `(cider-enlightened ((,class (:background nil :box (:color ,yellow :line-width -1 :style nil) :foreground ,yellow))))
+     `(cider-enlightened ((,class (:background unspecified :box (:color ,yellow :line-width -1 :style nil) :foreground ,yellow))))
      `(cider-enlightened-local ((,class (:foreground ,yellow))))
      `(cider-fringe-good-face ((,class (:foreground ,suc))))
-     `(cider-instrumented-face ((,class (:background nil :box (:color ,red :line-width -1 :style nil) :foreground ,red))))
-     `(cider-result-overlay-face ((,class (:background nil :box (:color ,blue :line-width -1 :style nil) :foreground ,blue))))
+     `(cider-instrumented-face ((,class (:background unspecified :box (:color ,red :line-width -1 :style nil) :foreground ,red))))
+     `(cider-result-overlay-face ((,class (:background unspecified :box (:color ,blue :line-width -1 :style nil) :foreground ,blue))))
      `(cider-test-error-face ((,class (:background ,war :foreground ,bg1))))
      `(cider-test-failure-face ((,class (:background ,err :foreground ,bg1))))
      `(cider-test-success-face ((,class (:background ,suc :foreground ,bg1))))
@@ -304,17 +304,17 @@ to 'auto, tags may not be properly aligned. "
      `(company-tooltip-selection ((,class (:background ,ttip-sl :foreground ,base))))
 
 ;;;;; diff
-     `(diff-added             ((,class :background nil :foreground ,green :extend t)))
-     `(diff-changed           ((,class :background nil :foreground ,blue)))
+     `(diff-added             ((,class :background unspecified :foreground ,green :extend t)))
+     `(diff-changed           ((,class :background unspecified :foreground ,blue)))
      `(diff-header            ((,class :background ,cblk-ln-bg :foreground ,func :extend t)))
      `(diff-file-header       ((,class :background ,cblk-ln-bg :foreground ,cblk :extend t)))
-     `(diff-indicator-added   ((,class :background nil :foreground ,green :extend t)))
-     `(diff-indicator-changed ((,class :background nil :foreground ,blue)))
-     `(diff-indicator-removed ((,class :background nil :foreground ,red)))
+     `(diff-indicator-added   ((,class :background unspecified :foreground ,green :extend t)))
+     `(diff-indicator-changed ((,class :background unspecified :foreground ,blue)))
+     `(diff-indicator-removed ((,class :background unspecified :foreground ,red)))
      `(diff-refine-added      ((,class :background ,green :foreground ,bg1)))
      `(diff-refine-changed    ((,class :background ,blue :foreground ,bg1)))
      `(diff-refine-removed    ((,class :background ,red :foreground ,bg1)))
-     `(diff-removed           ((,class :background nil :foreground ,red :extend t)))
+     `(diff-removed           ((,class :background unspecified :foreground ,red :extend t)))
 
 ;;;;; diff-hl
      `(diff-hl-insert ((,class :background ,green :foreground ,green)))
@@ -345,7 +345,7 @@ to 'auto, tags may not be properly aligned. "
      `(ediff-even-diff-B ((,class(:background ,bg3 :extend t))))
      `(ediff-even-diff-C ((,class(:background ,bg3 :extend t))))
      `(ediff-fine-diff-A ((,class(:background ,red :foreground ,bg1 :extend t))))
-     `(ediff-fine-diff-Ancestor ((,class(:background nil :inherit bold :extend t))))
+     `(ediff-fine-diff-Ancestor ((,class(:background unspecified :inherit bold :extend t))))
      `(ediff-fine-diff-B ((,class(:background ,green :foreground ,bg1))))
      `(ediff-fine-diff-C ((,class(:background ,blue :foreground ,bg1))))
      `(ediff-odd-diff-A ((,class(:background ,bg4 :extend t))))
@@ -544,7 +544,7 @@ to 'auto, tags may not be properly aligned. "
      `(helm-grep-file ((,class (:foreground ,base :background ,bg1))))
      `(helm-grep-finish ((,class (:foreground ,base :background ,bg1))))
      `(helm-grep-lineno ((,class (:foreground ,type :background ,bg1 :inherit bold))))
-     `(helm-grep-match ((,class (:foreground nil :background nil :inherit helm-match))))
+     `(helm-grep-match ((,class (:foreground unspecified :background unspecified :inherit helm-match))))
      `(helm-header ((,class (:foreground ,base :background ,bg1 :underline nil :box nil))))
      `(helm-header-line-left-margin ((,class (:foreground ,keyword :background ,nil))))
      `(helm-match ((,class (:background ,head1-bg :foreground ,head1))))
@@ -591,7 +591,7 @@ to 'auto, tags may not be properly aligned. "
      `(info-menu ((,class (:foreground ,suc))))
      `(info-node ((,class (:foreground ,func :inherit bold))))
      `(info-quoted-name ((,class (:foreground ,keyword))))
-     `(info-reference-item ((,class (:background nil :underline t :inherit bold))))
+     `(info-reference-item ((,class (:background unspecified :underline t :inherit bold))))
      `(info-string ((,class (:foreground ,str))))
      `(info-title-1 ((,class (:height 1.4 :inherit bold))))
      `(info-title-2 ((,class (:height 1.3 :inherit bold))))
@@ -872,7 +872,7 @@ to 'auto, tags may not be properly aligned. "
      `(show-paren-mismatch ((,class (:foreground ,err :inherit bold :underline ,(when spacemacs-theme-underline-parens t)))))
 
 ;;;;; smartparens
-     `(sp-pair-overlay-face ((,class (:background ,highlight :foreground nil))))
+     `(sp-pair-overlay-face ((,class (:background ,highlight :foreground unspecified))))
      `(sp-show-pair-match-face ((,class (:foreground ,mat :inherit bold  :underline ,(when spacemacs-theme-underline-parens t)))))
 
 ;;;;; smerge
@@ -897,7 +897,7 @@ to 'auto, tags may not be properly aligned. "
      `(spaceline-python-venv ((,class (:foreground ,comp))))
 
 ;;;;; spacemacs-specific
-     `(spacemacs-transient-state-title-face ((,class (:background nil :foreground ,comp :box nil :inherit bold))))
+     `(spacemacs-transient-state-title-face ((,class (:background unspecified :foreground ,comp :box nil :inherit bold))))
 
 ;;;;; swiper
      `(swiper-line-face ((,class (:background ,highlight :inherit bold))))
@@ -982,21 +982,21 @@ to 'auto, tags may not be properly aligned. "
      `(which-key-command-description-face ((,class (:foreground ,base))))
      `(which-key-group-description-face ((,class (:foreground ,keyword))))
      `(which-key-key-face ((,class (:foreground ,func :inherit bold))))
-     `(which-key-separator-face ((,class (:background nil :foreground ,str))))
+     `(which-key-separator-face ((,class (:background unspecified :foreground ,str))))
      `(which-key-special-key-face ((,class (:background ,func :foreground ,bg1))))
 
 ;;;;; which-function-mode
      `(which-func ((,class (:foreground ,func))))
 
 ;;;;; whitespace-mode
-     `(whitespace-empty ((,class (:background nil :foreground ,yellow))))
-     `(whitespace-indentation ((,class (:background nil :foreground ,war))))
-     `(whitespace-line ((,class (:background nil :foreground ,comp))))
-     `(whitespace-newline ((,class (:background nil :foreground ,comp))))
-     `(whitespace-space ((,class (:background nil :foreground ,act2))))
-     `(whitespace-space-after-tab ((,class (:background nil :foreground ,yellow))))
-     `(whitespace-space-before-tab ((,class (:background nil :foreground ,yellow))))
-     `(whitespace-tab ((,class (:background nil :foreground ,act2))))
+     `(whitespace-empty ((,class (:background unspecified :foreground ,yellow))))
+     `(whitespace-indentation ((,class (:background unspecified :foreground ,war))))
+     `(whitespace-line ((,class (:background unspecified :foreground ,comp))))
+     `(whitespace-newline ((,class (:background unspecified :foreground ,comp))))
+     `(whitespace-space ((,class (:background unspecified :foreground ,act2))))
+     `(whitespace-space-after-tab ((,class (:background unspecified :foreground ,yellow))))
+     `(whitespace-space-before-tab ((,class (:background unspecified :foreground ,yellow))))
+     `(whitespace-tab ((,class (:background unspecified :foreground ,act2))))
      `(whitespace-trailing ((,class (:background ,err :foreground ,war))))
 
 ;;;;; other, need more work
@@ -1018,7 +1018,7 @@ to 'auto, tags may not be properly aligned. "
      `(js3-jsdoc-tag-face ((,class (:foreground ,keyword))))
      `(js3-warning-face ((,class (:underline ,keyword))))
      `(slime-repl-inputed-output-face ((,class (:foreground ,comp))))
-     `(trailing-whitespace ((,class :foreground nil :background ,err)))
+     `(trailing-whitespace ((,class :foreground unspecified :background ,err)))
      `(undo-tree-visualizer-current-face ((,class :foreground ,keyword)))
      `(undo-tree-visualizer-default-face ((,class :foreground ,base)))
      `(undo-tree-visualizer-register-face ((,class :foreground ,comp)))

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -526,10 +526,6 @@
       (add-hook 'diff-mode-hook 'spacemacs//set-whitespace-style-for-diff))
     :config
     (progn
-      (set-face-attribute 'whitespace-space nil
-                          :background 'unspecified
-                          :foreground (face-attribute 'font-lock-warning-face
-                                                      :foreground))
       (set-face-attribute 'whitespace-tab nil
                           :background 'unspecified)
       (set-face-attribute 'whitespace-indentation nil

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -526,10 +526,6 @@
       (add-hook 'diff-mode-hook 'spacemacs//set-whitespace-style-for-diff))
     :config
     (progn
-      (set-face-attribute 'whitespace-tab nil
-                          :background 'unspecified)
-      (set-face-attribute 'whitespace-indentation nil
-                          :background 'unspecified)
       (spacemacs|diminish whitespace-mode " ⓦ" " w")
       (spacemacs|diminish global-whitespace-mode " ⓦ" " w"))))
 


### PR DESCRIPTION
While fishing for warnings, I stumbled upon this list:

```
Warning: setting attribute ‘:foreground’ of face ‘trailing-whitespace’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘spacemacs-transient-state-title-face’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-removed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-added’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-changed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-indicator-removed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-indicator-added’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-indicator-changed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘which-key-separator-face’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘info-reference-item’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘info-reference-item’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘which-key-separator-face’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-indicator-changed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-indicator-added’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-indicator-removed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-changed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-added’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘diff-removed’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘spacemacs-transient-state-title-face’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:foreground’ of face ‘trailing-whitespace’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:foreground’ of face ‘sp-pair-overlay-face’: nil value is invalid, use ‘unspecified’ instead.
```

This PR fixes all relevant warnings from the Spacemacs built in themes.

There is one that I can't seem to pinpoint, but I think it's related to the `monokai` theme: https://github.com/oneKelvinSmith/monokai-emacs/pull/115

```
Warning: setting attribute ‘:background’ of face ‘info-reference-item’: nil value is invalid, use ‘unspecified’ instead.
```

Also, related to this, I've removed a block of code that forced the wrong colour on whitesapce mode for spaces.