### PR TITLE
Remove the docker tramp obsolete warning

### DIFF
--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -25,7 +25,7 @@
 (defconst docker-packages
   '(
     docker
-    docker-tramp
+    (docker-tramp :toggle (version< emacs-version "29.1"))
     dockerfile-mode
     flycheck))
 


### PR DESCRIPTION
The same functinoality is provided by default starting with emacs 29.1:

```
 ■  Warning (emacs): Package ‘docker-tramp’ has been obsoleted, please use integrated package ‘tramp-container’
```