### PR TITLE
[nixos] Fix nixos-format-on-save for newer nixos-mode

### DIFF
--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -59,7 +59,7 @@
       (spacemacs/set-leader-keys-for-major-mode 'nix-mode
         "==" 'nix-format-buffer)
       (when nixos-format-on-save
-        (add-hook 'before-save-hook 'nix-format-before-save)))
+        (add-hook 'nix-mode-hook 'nixfmt-on-save-mode)))
     :config
     (electric-indent-mode -1)))
 


### PR DESCRIPTION
After updating my packages auto-format on save no longer worked and I received the following error:

```
Before-save hook error: (void-function nix-format-before-save)
```

This was changed in upstream [commit][1].

[1]: https://github.com/NixOS/nix-mode/commit/fb6c1ca5dd22580267142f19f78608a99de77552
