### PR TITLE
layers/+lang/python/funcs.el: Fix typo in flag

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -218,11 +218,11 @@ ROOT-DIR should be the path for the environemnt, `nil' for clean up"
 ;; from https://www.snip2code.com/Snippet/127022/Emacs-auto-remove-unused-import-statemen
 (defun spacemacs/python-remove-unused-imports ()
   "Use Autoflake to remove unused imports.
-Equivalent to: autoflake --remove-all-unused-imports --inplace <FILE>"
+Equivalent to: autoflake --remove-all-unused-imports --in-place <FILE>"
   (interactive)
   (if (executable-find "autoflake")
       (if (not (eql 0
-                    (shell-command (format "autoflake --remove-all-unused-imports --inplace %s"
+                    (shell-command (format "autoflake --remove-all-unused-imports --in-place %s"
                                            (shell-quote-argument (buffer-file-name))))))
           (pop-to-buffer shell-command-buffer-name)
         (revert-buffer t t t))


### PR DESCRIPTION
Fixes a typo in the `autoflake` command that prevented the `spacemacs/python-remove-unused-imports` function from working.

The flag was recently changed from its short form `-i` to its long form `--in-place`, but missing the dash between "in" and "place".

https://pypi.org/project/autoflake/