### PR TITLE
Docker and Kubernetes layers fixes     

### DIFF
--- a/layers/+tools/docker/packages.el
+++ b/layers/+tools/docker/packages.el
@@ -25,7 +25,7 @@
 (defconst docker-packages
   '(
     docker
-    (docker-tramp :toggle (version< emacs-version "29.1"))
+    (docker-tramp :toggle (version< emacs-version "29.0.50"))
     dockerfile-mode
     flycheck))
 

--- a/layers/+tools/kubernetes/packages.el
+++ b/layers/+tools/kubernetes/packages.el
@@ -27,7 +27,7 @@
   '(
     kubernetes
     kubernetes-evil
-    kubernetes-tramp))
+    (kubernetes-tramp :toggle (version< emacs-version "29.0.50"))))
 
 (defun kubernetes/init-kubernetes ()
   (use-package kubernetes


### PR DESCRIPTION
- fix kubernetes-tramp deprecation warning by setting a threshold to exclude
- adjust docker-tramp min version threshold too
