### PR TITLE
spacemacs-editing: disable undo-tree history file

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -545,6 +545,7 @@
             undo-limit 800000
             undo-strong-limit 12000000
             undo-outer-limit 120000000
+            undo-tree-auto-save-history nil
             undo-tree-history-directory-alist
             `(("." . ,(let ((dir (expand-file-name "undo-tree-history" spacemacs-cache-directory)))
                         (if (file-exists-p dir)


### PR DESCRIPTION
`undo-tree` history file makes copies of files so I suppose it should be disabled by default.