### PR TITLE
csharp: stop using csharp-mode package in emacs 29

### DIFF
--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -24,7 +24,7 @@
 (setq csharp-packages
       '(
         company
-        csharp-mode
+        (csharp-mode :toggle (version< emacs-version "29.0.60"))
         evil-matchit
         ggtags
         counsel-gtags


### PR DESCRIPTION
The csharp-mode package has been merged into emacs and will print an error when used with emacs >= 29.

We're checking against 29.0.60, which results in the error printing in 29.0.50, but that version didn't have csharp-mode yet.

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!
