### PR TITLE
latex: Make it possible to use RefTeX completions even with LSP backend

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -225,6 +225,7 @@ For nicer-looking faces, try adding the following to `custom-set-faces` in your 
 | ~C-/~       | show candidates in Helm or Ivy (for fuzzy searching)                                                 |
 | ~C-M-/~     | filter the company dropdown menu                                                                     |
 | ~M-h~       | show current candidate's documentation in a tooltip (requires =auto-completion-enable-help-tooltip=) |
+| ~C-b~       | switch to next completion backend (=company-other-backend=)                                          |
 
 Vim Style:
 

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -127,7 +127,8 @@
       (let ((map company-active-map))
         (define-key map (kbd "C-/")   'company-search-candidates)
         (define-key map (kbd "C-M-/") 'company-filter-candidates)
-        (define-key map (kbd "C-d")   'company-show-doc-buffer))
+        (define-key map (kbd "C-d")   'company-show-doc-buffer)
+        (define-key map (kbd "C-b")   'company-other-backend))
       (add-hook 'spacemacs-editing-style-hook 'spacemacs//company-active-navigation)
       ;; ensure that the correct bindings are set at startup
       (spacemacs//company-active-navigation dotspacemacs-editing-style))))

--- a/layers/+lang/latex/README.org
+++ b/layers/+lang/latex/README.org
@@ -89,6 +89,12 @@ To explicitly choose LSP backend for =LaTeX= layer, add the following:
                 '((latex :variables latex-backend 'lsp)))
 #+END_SRC
 
+When LSP is chosen as the backend, auto-completions are provided by LSP.
+If you are not happy with the suggestions for completing citation keys and
+reference labels (in =\cite{...}=, =\ref{...}=, and related macros), you can
+press ~C-b~ in the auto-completion dropdown (see [[file:../../+completion/auto-completion/README.org][the auto-completion layer]])
+to switch to suggestions provided by RefTeX.
+
 *** Company-auctex
 This would be the backend if =LSP= layer is not enabled, and =latex-backend= is
 not set.

--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -23,31 +23,31 @@
 
 (defun spacemacs//latex-setup-company ()
   "Conditionally setup company based on backend."
-  (pcase latex-backend
-    ('lsp
-     (spacemacs|add-company-backends ;; Activate lsp company explicitly to activate
-       :backends company-capf        ;; standard backends as well
-       :modes LaTeX-mode))
-    ('company-auctex
-     (when (configuration-layer/package-used-p 'company-auctex)
-       (if (configuration-layer/package-used-p 'company-math)
-           (spacemacs|add-company-backends
-             :backends (company-math-symbols-unicode
-                        company-math-symbols-latex
-                        company-auctex-macros
-                        company-auctex-symbols
-                        company-auctex-environments)
-             :modes LaTeX-mode)
-         (spacemacs|add-company-backends
-           :backends (company-auctex-macros
-                      company-auctex-symbols
-                      company-auctex-environments)
-           :modes LaTeX-mode)))
-     (when (configuration-layer/package-used-p 'company-reftex)
-       (spacemacs|add-company-backends
-         :backends company-reftex-labels
-         company-reftex-citations
-         :modes LaTeX-mode)))))
+  ;; Always activate auctex and reftex backends so that they're
+  ;; accessible via company-other-backend even when using lsp.
+  (when (configuration-layer/package-used-p 'company-auctex)
+    (if (configuration-layer/package-used-p 'company-math)
+        (spacemacs|add-company-backends
+          :backends (company-math-symbols-unicode
+                     company-math-symbols-latex
+                     company-auctex-macros
+                     company-auctex-symbols
+                     company-auctex-environments)
+          :modes LaTeX-mode)
+      (spacemacs|add-company-backends
+        :backends (company-auctex-macros
+                   company-auctex-symbols
+                   company-auctex-environments)
+        :modes LaTeX-mode)))
+  (when (configuration-layer/package-used-p 'company-reftex)
+    (spacemacs|add-company-backends
+      :backends company-reftex-labels
+      company-reftex-citations
+      :modes LaTeX-mode))
+  (when (eq latex-backend 'lsp)
+    (spacemacs|add-company-backends
+      :backends company-capf
+      :modes LaTeX-mode)))
 
 (defun spacemacs//latex-setup-backend ()
   "Conditionally setup latex backend."


### PR DESCRIPTION
This PR adds a key binding `C-b` for `company-other-backend`, which can be pressed in the company dropdown to switch to the next completion backend.

The user can use this in the latex layer to get to RefTeX completions on demand, even with the LSP backend. This is useful because RefTeX tends to offer better completions than the LSP server texlab, at least for some things to be completed. 