### PR TITLE
tabs: fix documentation and beautify default config

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -477,8 +477,8 @@ which is not what we want.
 ** Cross-dependencies
 Spacemacs provides a couple of additional useful functions you can use to check
 whether other layers or packages are included.
-- check if a layer is enabled
-- check if a package is or will be installed
+- check if a layer is enabled (=configuration-layer/layer-used-p=)
+- check if a package is or will be installed (=configuration-layer/package-used-p=)
 
 These are useful in some cases, but usually you can get the desired result just
 by using =post-init= functions.

--- a/layers/+emacs/tabs/README.org
+++ b/layers/+emacs/tabs/README.org
@@ -9,6 +9,7 @@
 - [[#configuration][Configuration]]
   - [[#selected-tab-bar][Selected tab bar]]
   - [[#hide-tabs-after-a-delay][Hide tabs after a delay]]
+  - [[#tab-icons][Tab icons]]
 - [[#key-bindings][Key bindings]]
 
 * Description
@@ -32,7 +33,7 @@ For example,
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-                '(tabs :variables tabs-highlight-current-tab 'left))
+                '(tabs :variables tabs-selected-tab-bar 'over))
 #+END_SRC
 
 Note that this has no effect when Emacs is running in daemon mode.
@@ -49,6 +50,14 @@ delay =tabs-auto-hide-delay= via the :variables keyword in your =.spacemacs=:
                 '(tabs :variables
                        tabs-auto-hide t
                        tabs-auto-hide-delay 3))
+#+END_SRC
+
+** Tab icons
+By default, tab icons are enabled, if the =spacemacs-visual= layer is enabled and the =all-the-icons= package is used.
+You can disable icons just for the tabs display by setting =tabs-icons= to =nil=:
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '(tabs :variables tabs-icons nil))
 #+END_SRC
 
 * Key bindings

--- a/layers/+emacs/tabs/config.el
+++ b/layers/+emacs/tabs/config.el
@@ -44,3 +44,7 @@ Calls (tabs-headline-match)"
 (spacemacs|defc tabs-auto-hide-delay 2
   "Tabs auto hide delay in seconds."
   '(float))
+
+(defvar tabs-icons t
+  "When non-nil, use all-the-icons to display icons before tab titles.
+all-the-icons is provided by the `spacemacs-visual` layer, which also needs to be active.")

--- a/layers/+emacs/tabs/packages.el
+++ b/layers/+emacs/tabs/packages.el
@@ -25,12 +25,24 @@
   '(centaur-tabs))
 
 (defun tabs/init-centaur-tabs ()
+
+  (when (and tabs-icons (configuration-layer/package-used-p 'all-the-icons))
+    ;; centaur-tabs internally checks for `(featurep 'all-the-icons)`
+    ;; to draw icons even after we enabled `centaur-tabs-set-icons`
+    ;; but all-the-icons is inited in spacemacs-visual with `:defer t`,
+    ;; so the feature wouldn't be loaded...
+    (require 'all-the-icons))
+
   (use-package centaur-tabs
     :demand
     :custom
-    (centaur-tabs-set-icons t)
+    (centaur-tabs-set-icons tabs-icons)
+    (centaur-tabs-gray-out-icons 'buffer)
+    (centaur-tabs-set-bar 'left)
     (centaur-tabs-set-modified-marker t)
-    (centaur-tabs-modified-marker "⚠")
+    (centaur-tabs-show-navigation-buttons t)
+    (centaur-tabs-close-button "✕")
+    (centaur-tabs-modified-marker "•")
     (centaur-tabs-cycle-scope 'tabs)
     :config
     (progn


### PR DESCRIPTION
- explicitly set the highlight bar to the left
- fix documentation about customizing the highlight bar position
-  update the modified marker to be less intrusive