### PR TITLE
compleseus: improve performance by delaying preview

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -113,8 +113,8 @@
     (consult-ripgrep dir)))
 
 (defun spacemacs/compleseus-find-file ()
-  "This solves the problem:
-Binding a key to: `find-file' calls: `ido-find-file'"
+  "Calls the interactive find-file browser.
+This solves the problem: Binding a key to: `find-file' calls: `ido-find-file'"
   (interactive)
   (call-interactively 'find-file))
 

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -36,24 +36,7 @@
     (selectrum :toggle (eq compleseus-engine 'selectrum))
     (vertico
      :toggle (eq compleseus-engine 'vertico)
-     ;; TODO remove when `vertico-repeat' on ELPA
-     :location (recipe :fetcher github
-                       :repo "minad/vertico"))
-    (vertico-directory
-     :toggle (eq compleseus-engine 'vertico)
-     ;; TODO remove when it's on ELPA
-     :location (recipe :fetcher url
-                       :url "https://raw.githubusercontent.com/minad/vertico/main/extensions/vertico-directory.el"))
-    (vertico-quick
-     :toggle (eq compleseus-engine 'vertico)
-     ;; TODO remove when it's on ELPA
-     :location (recipe :fetcher url
-                       :url "https://raw.githubusercontent.com/minad/vertico/main/extensions/vertico-quick.el"))
-    (vertico-repeat
-     :toggle (eq compleseus-engine 'vertico)
-     ;; TODO: Remove when https://github.com/minad/vertico/issues/83 solved.
-     :location (recipe :fetcher url
-                       :url "https://raw.githubusercontent.com/minad/vertico/main/extensions/vertico-repeat.el"))
+     :location elpa)
     (grep :location built-in)
     wgrep))
 

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -185,26 +185,27 @@
     ;; after lazily loading the package.
     :config
 
-    ;; Optionally configure preview. The default value
-    ;; is 'any, such that any key triggers the preview.
-    ;; (setq consult-preview-key 'any)
-    ;; (setq consult-preview-key (kbd "M-."))
-    ;; (setq consult-preview-key (list (kbd "<S-down>") (kbd "<S-up>")))
-    ;; For some commands and buffer sources it is useful to configure the
-    ;; :preview-key on a per-command basis using the `consult-customize' macro.
+    ;; disable automatic preview by default,
+    ;; selectively enable it for some prompts below.
+    (setq consult-preview-key "M-.")
+
+    ;; customize preview activation and delay while selecting candiates
     (consult-customize
      consult-theme
-     :preview-key '(:debounce 0.2 any)
-     consult-ripgrep consult-git-grep consult-grep
-     consult-bookmark consult-recent-file consult-xref
-     consult--source-recent-file consult--source-project-recent-file consult--source-bookmark
+     :preview-key '("M-."
+                    :debounce 0.2 any)
+
+     ;; slightly delayed preview upon candidate selection
+     ;; one usually wants quick feedback
+     consult-buffer
+     consult-ripgrep
+     consult-git-grep
+     consult-grep
+     consult-bookmark
      consult-yank-pop
-     spacemacs/compleseus-search-auto
-     spacemacs/compleseus-search-dir
-     spacemacs/compleseus-search-projectile
-     spacemacs/compleseus-search-default
-     spacemacs/compleseus-search-projectile-auto
-     :preview-key (list (kbd "C-SPC") (kbd "C-M-j") (kbd "C-M-k")))
+     :preview-key '("M-."
+                    :debounce 0.3 "<up>" "<down>" "C-n" "C-p"
+                    :debounce 0.6 any))
 
     ;; hide magit buffer
     (add-to-list 'consult-buffer-filter "magit.*:.*")


### PR DESCRIPTION
- vertico is on elpa now
- adjust preview delay so the preview's startup (loading major mode, fontifying) isn't triggered instantly when selecting a candiate, but rather when lingering on it for a short time.