### PR TITLE
compleseus: Standardize C-hjkl keybindings

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -379,13 +379,15 @@
     :config
     (when (spacemacs//support-hjkl-navigation-p)
       (define-key vertico-map (kbd "M-RET") #'vertico-exit-input)
-      (define-key vertico-map (kbd "C-SPC") #'spacemacs/embark-preview)
+      (define-key vertico-map (kbd "C-SPC") #'spacemacs/embark-preview)      
       (define-key vertico-map (kbd "C-j") #'vertico-next)
-      (define-key vertico-map (kbd "C-M-j") #'spacemacs/next-candidate-preview)
-      (define-key vertico-map (kbd "C-S-j") #'vertico-next-group)
       (define-key vertico-map (kbd "C-k") #'vertico-previous)
+      (define-key vertico-map (kbd "C-l") #'vertico-insert)
+      (define-key vertico-map (kbd "C-M-j") #'spacemacs/next-candidate-preview)
       (define-key vertico-map (kbd "C-M-k") #'spacemacs/previous-candidate-preview)
+      (define-key vertico-map (kbd "C-S-j") #'vertico-next-group)
       (define-key vertico-map (kbd "C-S-k") #'vertico-previous-group)
+
       (define-key vertico-map (kbd "C-r") #'consult-history))))
 
 (defun compleseus/init-vertico-quick ()
@@ -409,7 +411,7 @@
 (defun compleseus/init-vertico-directory ()
   (use-package vertico-directory
     ;; More convenient directory navigation commands
-    :init (bind-key "C-h" 'vertico-directory-delete-char vertico-map (spacemacs//support-hjkl-navigation-p))
+    :init (bind-key "C-h" 'vertico-directory-up vertico-map (spacemacs//support-hjkl-navigation-p))
     ;; Tidy shadowed file names
     :hook (rfn-eshadow-update-overlay . vertico-directory-tidy)))
 

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -379,7 +379,7 @@
     :config
     (when (spacemacs//support-hjkl-navigation-p)
       (define-key vertico-map (kbd "M-RET") #'vertico-exit-input)
-      (define-key vertico-map (kbd "C-SPC") #'spacemacs/embark-preview)      
+      (define-key vertico-map (kbd "C-SPC") #'spacemacs/embark-preview)
       (define-key vertico-map (kbd "C-j") #'vertico-next)
       (define-key vertico-map (kbd "C-k") #'vertico-previous)
       (define-key vertico-map (kbd "C-l") #'vertico-insert)


### PR DESCRIPTION
Bind C-h to always go up one directory and C-l to enter current selected folder or narrow to selected file. This matches behavior with helm and ivy completion.

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!
