### PR TITLE
Add purpose-toggle-window-purpose-dedicated to key bindings

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -66,6 +66,7 @@
                                        "p"   "projects"
                                        "q"   "quit"
                                        "r"   "registers/rings/resume"
+                                       "rd"  "purpose-toggle-window"
                                        "s"   "search/symbol"
                                        "sa"  "ag"
                                        "sg"  "grep"

--- a/layers/+spacemacs/spacemacs-purpose/README.org
+++ b/layers/+spacemacs/spacemacs-purpose/README.org
@@ -133,7 +133,8 @@ This can easily be achieved by adding below code in
 |-------------+-------------------------------------------------------------------------------------|
 | ~SPC r b~   | Open a buffer. Only buffers with the same purpose as the current buffer are listed. |
 | ~SPC r B~   | Open any buffer and ignore window-purpose when displaying the buffer.               |
-| ~SPC r d~   | Toggle dedication of selected window to its current purpose.                        |
+| ~SPC r d b~ | Toggle dedication of selected window to its current buffer purpose.                 |
+| ~SPC r d w~ | Toggle dedication of selected window to its current purpose.                        |
 | ~SPC r D~   | Delete all non-dedicated windows.                                                   |
 | ~SPC r p~   | Choose a purpose and open a buffer with that purpose.                               |
 | ~SPC r P~   | Change the purpose of the selected window. Changes the window's buffer accordingly. |

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -130,7 +130,8 @@
       (spacemacs/set-leader-keys
         "rb" 'purpose-switch-buffer-with-purpose
         "rB" 'switch-buffer-without-purpose
-        "rd" 'purpose-toggle-window-purpose-dedicated
+        "rdb" 'purpose-toggle-window-buffer-dedicated
+        "rdw" 'purpose-toggle-window-purpose-dedicated
         "rD" 'purpose-delete-non-dedicated-windows
         "rp" 'purpose-switch-buffer-with-some-purpose
         "rP" 'purpose-set-window-purpose))


### PR DESCRIPTION
We already have the key binding to fix a purpose to a window (`SPC r d b`), and this will add the key binding to fix a buffer to that window.