### PR TITLE
compleseus: re-enable loading of bundled extensions

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -4,28 +4,28 @@
 
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features:]]
+  - [[#features][Features]]
 - [[#install][Install]]
   - [[#configuration][Configuration]]
+    - [[#completion-engine][Completion engine]]
 - [[#key-bindings][Key bindings]]
 
 * Description
-This layer adds a new way of completion provided by the following core packages:
+This layer implements completion provided by combining the following packages:
 - =consult=
 - =embark=
 - =marginalia=
 - =orderless=
 - =selectrum= or =vertico=
 
-This is an WIP and only supports emacs 27 or later. Please contribute.
+It only supports emacs 27 or later.
 
-** Features:
-- Same features as =ivy= or =helm=
+** Features
+- Similar features like =ivy= or =helm=
 
 * Install
-To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add =compleseus= to the existing =dotspacemacs-configuration-layers= list in this
-file.
+To use this configuration layer, add it to your =~/.spacemacs=: You will need to
+add =compleseus= to the =dotspacemacs-configuration-layers= list in this file.
 
 Make sure that the other completion layers: =helm= and =ivy= are removed or
 commented out in the =dotspacemacs-configuration-layers= list. Or add
@@ -33,6 +33,8 @@ commented out in the =dotspacemacs-configuration-layers= list. Or add
 layer that's listed last.
 
 ** Configuration
+
+*** Completion engine
 You can configure the completion engine by setting =compleseus-engine= to either
 =vertico= (default) or =selectrum= by editing the =compleseus-engine= variable
 like below to use =selectrum= as opposed to the default of =vertico=:
@@ -44,7 +46,8 @@ like below to use =selectrum= as opposed to the default of =vertico=:
 
 * Key bindings
 
-| Key binding | Description   |
-|-------------+---------------|
-| ~M-o~       | embark-action |
-| ~C-r~       | history       |
+| Key binding | Description               |
+|-------------+---------------------------|
+| ~M-o~         | embark-action             |
+| ~C-r~         | history                   |
+| ~M-.~         | preview selected item now |

--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -4,7 +4,7 @@
 
 * Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features]]
+  - [[#features][Features:]]
 - [[#install][Install]]
   - [[#configuration][Configuration]]
     - [[#completion-engine][Completion engine]]
@@ -12,15 +12,15 @@
 
 * Description
 This layer implements completion provided by combining the following packages:
-- =consult=
-- =embark=
-- =marginalia=
-- =orderless=
-- =selectrum= or =vertico=
+- =selectrum= or =vertico=: vertical completion user interface
+- =consult=: useful commands using ~completing-read~
+- =embark=: provides minibuffer actions
+- =marginalia=: annotations to completion candidates
+- =orderless=: filtering enhancements
 
 It only supports emacs 27 or later.
 
-** Features
+** Features:
 - Similar features like =ivy= or =helm=
 
 * Install

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -68,11 +68,12 @@
              '((spacemacs/compleseus-pers-switch-project . project-file)
                ;; https://github.com/bbatsov/projectile/issues/1664
                ;; https://github.com/minad/marginalia/issues/110
+               (persp-switch-to-buffer . buffer)
                (projectile-find-file . project-file)
                (projectile-find-dir . project-file)
                (projectile-recentf . project-file)
                (projectile-switch-to-buffer . buffer)
-               (projectile-switch-project . file)))
+               (projectile-switch-project . project-file)))
       (push it marginalia-command-categories))
     (setq marginalia-align 'right)
     ;; The :init configuration is always executed (Not lazy!)
@@ -187,12 +188,12 @@
 
     ;; disable automatic preview by default,
     ;; selectively enable it for some prompts below.
-    (setq consult-preview-key "M-.")
+    (setq consult-preview-key '("M-." "C-SPC"))
 
     ;; customize preview activation and delay while selecting candiates
     (consult-customize
      consult-theme
-     :preview-key '("M-."
+     :preview-key '("M-." "C-SPC"
                     :debounce 0.2 any)
 
      ;; slightly delayed preview upon candidate selection
@@ -203,7 +204,7 @@
      consult-grep
      consult-bookmark
      consult-yank-pop
-     :preview-key '("M-."
+     :preview-key '("M-." "C-SPC"
                     :debounce 0.3 "<up>" "<down>" "C-n" "C-p"
                     :debounce 0.6 any))
 
@@ -260,10 +261,15 @@
 
     :init
     (spacemacs/set-leader-keys "?" #'embark-bindings)
-    ;; Optionally replace the key help with a completing-read interface
-    (setq prefix-help-command #'embark-prefix-help-command)
+    ;; this gets you the available-key preview minibuffer popup
+    (setq prefix-help-command #'embark-prefix-help-command
+          ;; don't use C-h for paging, instead `describe-prefix-bindings`.
+          which-key-use-C-h-commands nil)
+
     ;; same key binding as ivy-occur
     (define-key minibuffer-local-map (kbd "C-c C-o") #'embark-export)
+    (define-key minibuffer-local-map (kbd "C-c C-l") #'embark-collect)
+
     :config
     (define-key embark-file-map "s" 'spacemacs/compleseus-search-from)
 
@@ -301,8 +307,7 @@
     (setq orderless-component-separator "[ &]")
 
     ;; should be all in with orderless other wise the results are inconsistent.
-    ;; (setq completion-styles '(basic partial-completion orderless)
-    (setq completion-styles '(orderless)
+    (setq completion-styles '(orderless basic)
           completion-category-defaults nil
           completion-category-overrides '((file (styles basic partial-completion))))))
 
@@ -339,6 +344,7 @@
     (setq minibuffer-prompt-properties
           '(read-only t cursor-intangible t face minibuffer-prompt))
     (add-hook 'minibuffer-setup-hook #'cursor-intangible-mode)
+    (add-hook 'minibuffer-setup-hook #'vertico-repeat-save)
 
     ;; Cleans up path when moving directories with shadowed paths syntax, e.g.
     ;; cleans ~/foo/bar/// to /, and ~/foo/bar/~/ to ~/.
@@ -349,7 +355,12 @@
 
     ;; when vertico is used set this so tab when doing M-: will show suggestions
     ;; https://github.com/minad/vertico/issues/24
-    (setq completion-in-region-function #'consult-completion-in-region)
+    (setq-default completion-in-region-function
+                  (lambda (&rest args)
+                    (apply (if vertico-mode
+                               #'consult-completion-in-region
+                             #'completion--in-region)
+                           args)))
 
     (setq vertico-resize nil
           vertico-count 20

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -362,40 +362,43 @@
 
     :config
     (when (spacemacs//support-hjkl-navigation-p)
+      (define-key vertico-map (kbd "C-j") #'vertico-next)
+      (define-key vertico-map (kbd "C-k") #'vertico-previous)
+      (define-key vertico-map (kbd "C-l") #'vertico-insert)
+      (define-key vertico-map (kbd "C-S-j") #'vertico-next-group)
+      (define-key vertico-map (kbd "C-S-k") #'vertico-previous-group)
+      (define-key vertico-map (kbd "C-M-j") #'spacemacs/next-candidate-preview)
+      (define-key vertico-map (kbd "C-M-k") #'spacemacs/previous-candidate-preview)
       (define-key vertico-map (kbd "M-RET") #'vertico-exit-input)
       (define-key vertico-map (kbd "C-SPC") #'spacemacs/embark-preview)
-      (define-key vertico-map (kbd "C-j") #'vertico-next)
-      (define-key vertico-map (kbd "C-M-j") #'spacemacs/next-candidate-preview)
-      (define-key vertico-map (kbd "C-S-j") #'vertico-next-group)
-      (define-key vertico-map (kbd "C-k") #'vertico-previous)
-      (define-key vertico-map (kbd "C-M-k") #'spacemacs/previous-candidate-preview)
-      (define-key vertico-map (kbd "C-S-k") #'vertico-previous-group)
-      (define-key vertico-map (kbd "C-r") #'consult-history))))
+      (define-key vertico-map (kbd "C-r") #'consult-history)))
 
-(defun compleseus/init-vertico-quick ()
-  (use-package vertico-quick
-    :after vertico
-    :init
-    (define-key vertico-map "\M-q" #'vertico-quick-insert)
-    (define-key vertico-map "\C-q" #'vertico-quick-exit)))
-
-(defun compleseus/init-vertico-repeat ()
-  (use-package vertico-repeat
-    :after vertico
-    :init
-    (add-hook 'minibuffer-setup-hook #'vertico-repeat-save)
-    (spacemacs/set-leader-keys
-      "rl" 'vertico-repeat-last
-      "rL" 'vertico-repeat-select
-      "sl" 'vertico-repeat-last
-      "sL" 'vertico-repeat-select)))
-
-(defun compleseus/init-vertico-directory ()
   (use-package vertico-directory
-    ;; More convenient directory navigation commands
-    :init (bind-key "C-h" 'vertico-directory-delete-char vertico-map (spacemacs//support-hjkl-navigation-p))
-    ;; Tidy shadowed file names
-    :hook (rfn-eshadow-update-overlay . vertico-directory-tidy)))
+      :after vertico
+      :ensure nil
+      ;; More convenient directory navigation commands
+      :init (bind-key "C-h" 'vertico-directory-up vertico-map
+                      (spacemacs//support-hjkl-navigation-p))
+      ;; tidy shadowed file names
+      :hook (rfn-eshadow-update-overlay . vertico-directory-tidy))
+
+  (use-package vertico-quick
+      :after vertico
+      :ensure nil
+      :init
+      (define-key vertico-map "\M-q" #'vertico-quick-insert)
+      (define-key vertico-map "\C-q" #'vertico-quick-exit))
+
+  (use-package vertico-repeat
+      :after vertico
+      :ensure nil
+      :init
+      (add-hook 'minibuffer-setup-hook #'vertico-repeat-save)
+      (spacemacs/set-leader-keys
+        "rl" 'vertico-repeat-last
+        "rL" 'vertico-repeat-select
+        "sl" 'vertico-repeat-last
+        "sL" 'vertico-repeat-select)))
 
 (defun spacemacs/compleseus-wgrep-change-to-wgrep-mode ()
   (interactive)

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -306,9 +306,12 @@
 
     (setq orderless-component-separator "[ &]")
 
-    ;; should be all in with orderless other wise the results are inconsistent.
+    ;; should be all in with orderless otherwise the results are inconsistent.
+    ;; the available styles are registered in `completion-styles-alist`.
     (setq completion-styles '(orderless basic)
           completion-category-defaults nil
+          ;; we need to have 'basic here first in order to support tramp connections...
+          ;; see `completion-styles`.
           completion-category-overrides '((file (styles basic partial-completion))))))
 
 (defun compleseus/init-selectrum ()
@@ -364,7 +367,15 @@
 
     (setq vertico-resize nil
           vertico-count 20
-          vertico-cycle nil)
+          vertico-cycle nil
+
+          ;; ignore case for all basic completions
+          ;; if we have orderless completion, we use it's `orderless-smart-case` feature anyway.
+          ;; this is the setting when we chose "basic" from `completion-styles`,
+          ;; which we do for filename completion.
+          read-file-name-completion-ignore-case t
+          read-buffer-completion-ignore-case t
+          completion-ignore-case t)
 
     ;; Disable ido. We want to use the regular find-file etc.; enhanced by vertico
     (setq ido-mode nil)

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -371,17 +371,17 @@ Features:
 ** Compleseus
 [[file:+completion/compleseus/README.org][+completion/compleseus/README.org]]
 
-This layer adds a new way of completion provided by the following core packages:
+Completion through combined features of:
 - =consult=
 - =embark=
 - =marginalia=
 - =orderless=
 - =selectrum= or =vertico=
 
-This is an WIP and only supports emacs 27 or later. Please contribute.
+Supports emacs 27 or later.
 
 Features:
-- Same features as =ivy= or =helm=
+- Similar features as =ivy= or =helm=
 
 ** Helm
 [[file:+completion/helm/README.org][+completion/helm/README.org]]


### PR DESCRIPTION
Follow-up for #15928. Since it removed the hack of creating separate "packages" for extension files directly from git, we can now `use-package` the extensions directly - they're bundled in the ELPA package.

Also contains the changes of and thus closes #15935.