### PR TITLE
[command-log] update keybindings & modeline insert after

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1831,6 +1831,14 @@ Other:
     - Added ~SPC m s l~ for =coffee-send-line=
     - Added ~SPC m s r~ for =coffee-send-region=
     - Added ~SPC m T c~ for =coffee-cos-mode=
+**** Command-log
+- Key bindings:
+  -  ~SPC a t k h~ display keycast in buffer header (thanks to John Stevenson)
+  -  ~SPC a t k m~ display keycast in modeline (thanks to John Stevenson)
+  -  ~SPC a t k t~ display keycast in tab bar (thanks to John Stevenson)
+- Improvements:
+  - ~keycast-mode-line-insert-after~ variable used to include keycast in
+    mode-line-format (thanks to John Stevenson)
 **** Common Lisp
 - Improvements:
   - Added eval-thing-at-point functions to Common Lisp Layer

--- a/layers/+tools/command-log/README.org
+++ b/layers/+tools/command-log/README.org
@@ -31,7 +31,7 @@ buffer which logs all executed commands in the current window.
 * Keycast
 This is an experimental addition to this layer which will show the last
 used keystroke and command in the modeline. However as we support multiple
-modelines it may require some tweaking of =keycast-insert-after= which will
+modelines it may require some tweaking of =keycast-mode-line-insert-after= which will
 be defaulted to =%e= for now.
 
 If you have a working configuration for your modeline feel free to share it
@@ -39,7 +39,9 @@ with the rest of the project.
 
 * Key bindings
 
-| Key binding   | Description            |
-|---------------+------------------------|
-| ~SPC a t l l~ | Toggle the command log |
-| ~SPC a t l k~ | Toggle keycast         |
+| Key binding   | Description                |
+|---------------+----------------------------|
+| ~SPC a t l l~ | Toggle the command log     |
+| ~SPC a t k h~ | Toggle keycast in header   |
+| ~SPC a t k m~ | Toggle keycast in modeline |
+| ~SPC a t k t~ | Toggle keycast in tab bar  |

--- a/layers/+tools/command-log/packages.el
+++ b/layers/+tools/command-log/packages.el
@@ -51,5 +51,10 @@
   (use-package keycast
     :init
     (progn
-      (spacemacs/set-leader-keys "atlk" #'keycast-mode)
-      (setq keycast-insert-after "%e"))))
+      (spacemacs/declare-prefix "atk" "keycast")
+      (spacemacs/set-leader-keys "atkm" #'keycast-mode-line-mode)
+      (spacemacs/set-leader-keys "atkh" #'keycast-header-line-mode)
+      (spacemacs/set-leader-keys "atkt" #'keycast-tab-bar-mode)
+
+      ;; Include keycast in modeline
+      (setq keycast-mode-line-insert-after "%e"))))


### PR DESCRIPTION
- Add keybindings for header and tab bar placement of keycast
- Update command-log documentation
- Update keycast-insert-after to keycast-mode-line-insert-after

tab bar provides places the keycast output in the top right of the frame and output does not hide when using menu bar like other modes dot

header position is show on the top left of the frame (under the tab bar if visible). header keycast output is not visible when using which-key menu or in buffers such as commit_editmsg

keycast modeline replaces the whole modeline with its own output which is not the desired experience. Ideally Keycast should be shown along with other important aspects of the modeline (screenshot in issue #14169)

Resolve: #14169

Thank you :heart: for Spacemacs!
