### PR TITLE
Add binding for `rubocop-autocorrect-current-file`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -132,6 +132,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
     in Vim editing style; disabled by default. (thanks to Benedict HW)
   - Added ~SPC m r R~ to show tide refactorings submenu (thanks to Roberto 
     Previdi)
+  - Added ~SPC m R F~ to autocorrect the current ruby file.
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -276,6 +276,7 @@
                 "Rd" 'rubocop-check-directory
                 "RD" 'rubocop-autocorrect-directory
                 "Rf" 'rubocop-check-current-file
+                "RF" 'rubocop-autocorrect-current-file
                 "Rp" 'rubocop-check-project
                 "RP" 'rubocop-autocorrect-project))))
 


### PR DESCRIPTION
There is a corresponding binding for auto-correcting the project and directory, but not file.

Add a binding for the file as well.