### PR TITLE
Remove function call of obsolete helm-gtags-define-keys-for-mode

### DIFF
--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -84,4 +84,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'asm-mode))
 
 (defun asm/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'asm-mode))
+  )

--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -29,7 +29,6 @@
         electric-indent-mode
         ggtags
         counsel-gtags
-        helm-gtags
         nasm-mode
         x86-lookup
         ))
@@ -82,6 +81,3 @@
 
 (defun asm/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'asm-mode))
-
-(defun asm/post-init-helm-gtags ()
-  )

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -49,7 +49,6 @@
     counsel-gtags
     (flycheck-rtags :requires (flycheck rtags))
     ggtags
-    helm-gtags
     (helm-rtags :requires (helm rtags))
     (ivy-rtags :requires (ivy rtags))
     rtags
@@ -212,10 +211,6 @@
     :post-init
     (dolist (mode c-c++-modes)
       (spacemacs/setup-helm-cscope mode))))
-
-(defun c-c++/post-init-helm-gtags ()
-  (dolist (mode c-c++-modes)
-    ))
 
 (defun c-c++/init-helm-rtags ()
   (use-package helm-rtags

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -215,7 +215,7 @@
 
 (defun c-c++/post-init-helm-gtags ()
   (dolist (mode c-c++-modes)
-    (spacemacs/helm-gtags-define-keys-for-mode mode)))
+    ))
 
 (defun c-c++/init-helm-rtags ()
   (use-package helm-rtags

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -45,7 +45,6 @@
     ggtags
     (kaocha-runner :toggle clojure-enable-kaocha-runner)
     counsel-gtags
-    helm-gtags
     org
     popwin
     (sayid :toggle clojure-enable-sayid)
@@ -486,9 +485,6 @@
 
 (defun clojure/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'clojure-mode))
-
-(defun clojure/post-init-helm-gtags ()
-  )
 
 (defun clojure/init-clojure-snippets ()
   (use-package clojure-snippets

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -488,7 +488,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'clojure-mode))
 
 (defun clojure/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'clojure-mode))
+  )
 
 (defun clojure/init-clojure-snippets ()
   (use-package clojure-snippets

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -70,7 +70,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'common-lisp-mode))
 
 (defun common-lisp/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'common-lisp-mode))
+  )
 
 (defun common-lisp/post-init-rainbow-identifiers ()
   (add-hook 'lisp-mode-hook #'colors//rainbow-identifiers-ignore-keywords))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -30,7 +30,6 @@
     ggtags
     counsel-gtags
     helm
-    helm-gtags
     rainbow-identifiers
     slime
     (slime-company :requires company)))
@@ -68,9 +67,6 @@
 
 (defun common-lisp/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'common-lisp-mode))
-
-(defun common-lisp/post-init-helm-gtags ()
-  )
 
 (defun common-lisp/post-init-rainbow-identifiers ()
   (add-hook 'lisp-mode-hook #'colors//rainbow-identifiers-ignore-keywords))

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -28,7 +28,6 @@
         evil-matchit
         ggtags
         counsel-gtags
-        helm-gtags
         omnisharp
         flycheck
         ))
@@ -64,6 +63,3 @@
 
 (defun csharp/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'csharp-mode))
-
-(defun csharp/post-init-helm-gtags ()
-  )

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -66,4 +66,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'csharp-mode))
 
 (defun csharp/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'csharp-mode))
+  )

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -72,4 +72,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'd-mode))
 
 (defun d/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'd-mode))
+  )

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -32,7 +32,6 @@
         (flycheck-dmd-dub :requires flycheck)
         ggtags
         counsel-gtags
-        helm-gtags
         ))
 
 (defun d/post-init-company ()
@@ -70,6 +69,3 @@
 
 (defun d/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'd-mode))
-
-(defun d/post-init-helm-gtags ()
-  )

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -32,7 +32,6 @@
     flycheck
     flycheck-credo
     ggtags
-    helm-gtags
     ob-elixir
     popwin
     smartparens))
@@ -187,9 +186,6 @@
 
 (defun elixir/post-init-ggtags ()
   (add-hook 'elixir-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
-
-(defun elixir/post-init-helm-gtags ()
-  )
 
 (defun elixir/pre-init-ob-elixir ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -189,7 +189,7 @@
   (add-hook 'elixir-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun elixir/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'elixir-mode))
+  )
 
 (defun elixir/pre-init-ob-elixir ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -39,7 +39,6 @@
     flycheck-package
     ggtags
     counsel-gtags
-    helm-gtags
     (ielm :location built-in)
     (inspector :location (recipe
                           :fetcher github
@@ -311,9 +310,6 @@
 
 (defun emacs-lisp/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'emacs-lisp-mode))
-
-(defun emacs-lisp/post-init-helm-gtags ()
-  )
 
 (defun emacs-lisp/post-init-ggtags ()
   (add-hook 'emacs-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -313,7 +313,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'emacs-lisp-mode))
 
 (defun emacs-lisp/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'emacs-lisp-mode))
+  )
 
 (defun emacs-lisp/post-init-ggtags ()
   (add-hook 'emacs-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -28,7 +28,6 @@
         dap-mode
         ggtags
         counsel-gtags
-        helm-gtags
         flycheck))
 
 
@@ -69,6 +68,3 @@
 
 (defun erlang/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'erlang-mode))
-
-(defun erlang/post-init-helm-gtags ()
-  )

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -71,4 +71,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'erlang-mode))
 
 (defun erlang/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'erlang-mode))
+  )

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -28,8 +28,7 @@
     (eglot-fsharp :toggle (eq fsharp-backend 'eglot))
     flycheck
     fsharp-mode
-    ggtags
-    helm-gtags))
+    ggtags))
 
 (defun fsharp/post-init-company ()
   (spacemacs//fsharp-setup-company))
@@ -80,6 +79,3 @@
 
 (defun fsharp/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'fsharp-mode))
-
-(defun fsharp/post-init-helm-gtags ()
-  )

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -82,4 +82,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'fsharp-mode))
 
 (defun fsharp/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'fsharp-mode))
+  )

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -78,7 +78,7 @@
   (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun go/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'go-mode))
+  )
 
 (defun go/init-go-eldoc ()
   (use-package go-eldoc

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -32,7 +32,6 @@
     (flycheck-golangci-lint :toggle (and go-use-golangci-lint
                                          (configuration-layer/package-used-p 'flycheck)))
     ggtags
-    helm-gtags
     go-eldoc
     go-fill-struct
     go-gen-test
@@ -76,9 +75,6 @@
 
 (defun go/post-init-ggtags ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
-
-(defun go/post-init-helm-gtags ()
-  )
 
 (defun go/init-go-eldoc ()
   (use-package go-eldoc

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -40,7 +40,6 @@
         haskell-mode
         haskell-snippets
         counsel-gtags
-        helm-gtags
         (helm-hoogle :requires helm)
         hindent
         hlint-refactor))
@@ -316,10 +315,6 @@
 
 (defun haskell/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'haskell-mode))
-
-(defun haskell/post-init-helm-gtags ()
-  )
-
 
 ;; doesn't support haskell-literate-mode :(
 (defun haskell/init-hindent ()

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -318,7 +318,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'haskell-mode))
 
 (defun haskell/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'haskell-mode))
+  )
 
 
 ;; doesn't support haskell-literate-mode :(

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -59,7 +59,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'java-mode))
 
 (defun java/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'java-mode))
+  )
 
 (defun java/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -28,7 +28,6 @@
     flycheck
     ggtags
     counsel-gtags
-    helm-gtags
     (java-mode :location built-in)
     maven-test-mode
     (meghanada :toggle (eq java-backend 'meghanada))
@@ -57,9 +56,6 @@
 
 (defun java/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'java-mode))
-
-(defun java/post-init-helm-gtags ()
-  )
 
 (defun java/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -30,7 +30,6 @@
     evil-matchit
     flycheck
     ggtags
-    helm-gtags
     imenu
     npm-mode
     impatient-mode
@@ -70,9 +69,6 @@
 
 (defun javascript/post-init-ggtags ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
-
-(defun javascript/post-init-helm-gtags ()
-  )
 
 (defun javascript/post-init-imenu ()
   ;; Required to make imenu functions work correctly

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -72,7 +72,7 @@
   (add-hook 'js2-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun javascript/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'js2-mode))
+  )
 
 (defun javascript/post-init-imenu ()
   ;; Required to make imenu functions work correctly

--- a/layers/+lang/kotlin/packages.el
+++ b/layers/+lang/kotlin/packages.el
@@ -28,7 +28,6 @@
     (flycheck-kotlin :requires flycheck)
     ggtags
     counsel-gtags
-    helm-gtags
     kotlin-mode))
 
 (defun kotlin/post-init-company ()
@@ -52,9 +51,6 @@
 
 (defun kotlin/post-init-ggtags ()
   (add-hook 'kotlin-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
-
-(defun kotlin/post-init-helm-gtags ()
-  )
 
 (defun kotlin/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'kotlin-mode))

--- a/layers/+lang/kotlin/packages.el
+++ b/layers/+lang/kotlin/packages.el
@@ -54,7 +54,7 @@
   (add-hook 'kotlin-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun kotlin/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'kotlin-mode))
+  )
 
 (defun kotlin/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'kotlin-mode))

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -236,7 +236,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'latex-mode))
 
 (defun latex/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'latex-mode))
+  )
 
 (defun latex/post-init-ggtags ()
   (add-hook 'latex-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -37,7 +37,6 @@
     flycheck
     flyspell
     ggtags
-    helm-gtags
     (lsp-latex :requires lsp-mode)
     (magic-latex-buffer :toggle latex-enable-magic)
     smartparens
@@ -234,9 +233,6 @@
 
 (defun latex/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'latex-mode))
-
-(defun latex/post-init-helm-gtags ()
-  )
 
 (defun latex/post-init-ggtags ()
   (add-hook 'latex-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -78,4 +78,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'lua-mode))
 
 (defun lua/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'lua-mode))
+  )

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -28,7 +28,6 @@
     flycheck
     ggtags
     counsel-gtags
-    helm-gtags
     lua-mode))
 
 (defun lua/post-init-flycheck ()
@@ -76,6 +75,3 @@
 
 (defun lua/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'lua-mode))
-
-(defun lua/post-init-helm-gtags ()
-  )

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -29,7 +29,6 @@
     (flycheck-ocaml :toggle (configuration-layer/layer-used-p 'syntax-checking))
     ggtags
     counsel-gtags
-    helm-gtags
     imenu
     merlin
     merlin-company
@@ -96,9 +95,6 @@
 
 (defun ocaml/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'ocaml-mode))
-
-(defun ocaml/post-init-helm-gtags ()
-  )
 
 (defun ocaml/init-merlin ()
   (use-package merlin

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -98,7 +98,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'ocaml-mode))
 
 (defun ocaml/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'ocaml-mode))
+  )
 
 (defun ocaml/init-merlin ()
   (use-package merlin

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -53,4 +53,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'octave-mode))
 
 (defun octave/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'octave-mode))
+  )

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -25,7 +25,6 @@
       '(
         ggtags
         counsel-gtags
-        helm-gtags
         (octave :location built-in)
         ))
 
@@ -51,6 +50,3 @@
 
 (defun octave/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'octave-mode))
-
-(defun octave/post-init-helm-gtags ()
-  )

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -63,7 +63,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'php-mode))
 
 (defun php/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'php-mode))
+  )
 
 (defun php/post-init-evil-matchit ()
   (add-hook 'php-mode-hook 'turn-on-evil-matchit-mode))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -30,7 +30,6 @@
     flycheck
     ggtags
     counsel-gtags
-    helm-gtags
     (php-auto-yasnippets :location (recipe :fetcher github :repo "emacs-php/php-auto-yasnippets"))
     (php-extras :location (recipe :fetcher github :repo "arnested/php-extras") :toggle (not (eq php-backend 'lsp)))
     php-mode
@@ -61,9 +60,6 @@
 
 (defun php/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'php-mode))
-
-(defun php/post-init-helm-gtags ()
-  )
 
 (defun php/post-init-evil-matchit ()
   (add-hook 'php-mode-hook 'turn-on-evil-matchit-mode))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -34,7 +34,6 @@
     flycheck
     ggtags
     helm-cscope
-    helm-gtags
     (helm-pydoc :requires helm)
     importmagic
     live-py-mode
@@ -169,9 +168,6 @@
 
 (defun python/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'python-mode))
-
-(defun python/post-init-helm-gtags ()
-  )
 
 (defun python/post-init-ggtags ()
   (add-hook 'python-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -171,7 +171,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'python-mode))
 
 (defun python/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'python-mode))
+  )
 
 (defun python/post-init-ggtags ()
   (add-hook 'python-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -59,7 +59,7 @@
     (add-to-list 'evil-lisp-safe-structural-editing-modes 'racket-mode)))
 
 (defun racket/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'racket-mode))
+  )
 
 (defun racket/init-racket-mode ()
   (use-package racket-mode

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -28,7 +28,6 @@
         ggtags
         counsel-gtags
         evil-cleverparens
-        helm-gtags
         racket-mode
         ))
 
@@ -57,9 +56,6 @@
   (spacemacs|use-package-add-hook evil-cleverparens
     :pre-init
     (add-to-list 'evil-lisp-safe-structural-editing-modes 'racket-mode)))
-
-(defun racket/post-init-helm-gtags ()
-  )
 
 (defun racket/init-racket-mode ()
   (use-package racket-mode

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -131,7 +131,7 @@
 
 (defun ruby/post-init-helm-gtags ()
   (dolist (mode '(ruby-mode enh-ruby-mode))
-    (spacemacs/helm-gtags-define-keys-for-mode mode)))
+    ))
 
 (defun ruby/init-minitest ()
   (use-package minitest

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -33,7 +33,6 @@
     evil-matchit
     flycheck
     ggtags
-    helm-gtags
     minitest
     org
     popwin
@@ -128,10 +127,6 @@
   (spacemacs/add-to-hooks 'spacemacs/ggtags-mode-enable
                           '(ruby-mode-local-vars-hook
                             enh-ruby-mode-local-vars-hook)))
-
-(defun ruby/post-init-helm-gtags ()
-  (dolist (mode '(ruby-mode enh-ruby-mode))
-    ))
 
 (defun ruby/init-minitest ()
   (use-package minitest

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -30,7 +30,6 @@
     flycheck
     (flycheck-rust :requires flycheck)
     ggtags
-    helm-gtags
     ron-mode
     (racer :toggle (eq rust-backend 'racer))
     rust-mode
@@ -92,9 +91,6 @@
 
 (defun rust/post-init-ggtags ()
   (add-hook 'rust-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
-
-(defun rust/post-init-helm-gtags ()
-  )
 
 (defun rust/init-racer ()
   (use-package racer

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -94,7 +94,7 @@
   (add-hook 'rust-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
 (defun rust/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'rust-mode))
+  )
 
 (defun rust/init-racer ()
   (use-package racer

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -30,7 +30,6 @@
     flyspell
     counsel-gtags
     ggtags
-    helm-gtags
     sbt-mode
     scala-mode))
 
@@ -118,7 +117,3 @@
 (defun scala/post-init-counsel-gtags ()
   (when scala-enable-gtags
     (spacemacs/counsel-gtags-define-keys-for-mode 'scala-mode)))
-
-(defun scala/post-init-helm-gtags ()
-  (when scala-enable-gtags
-    ))

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -121,4 +121,4 @@
 
 (defun scala/post-init-helm-gtags ()
   (when scala-enable-gtags
-    (spacemacs/helm-gtags-define-keys-for-mode 'scala-mode)))
+    ))

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -149,7 +149,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'scheme-mode))
 
 (defun scheme/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'scheme-mode))
+  )
 
 (defun scheme/init-geiser-chez ()
   (use-package geiser-chez

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -27,7 +27,6 @@
     geiser
     ggtags
     counsel-gtags
-    helm-gtags
     (geiser-chez    :toggle (memq 'chez    scheme-implementations))
     (geiser-chibi   :toggle (memq 'chibi   scheme-implementations))
     (geiser-chicken :toggle (memq 'chicken scheme-implementations))
@@ -147,9 +146,6 @@
 
 (defun scheme/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'scheme-mode))
-
-(defun scheme/post-init-helm-gtags ()
-  )
 
 (defun scheme/init-geiser-chez ()
   (use-package geiser-chez

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -30,7 +30,6 @@
     flycheck-bashate
     ggtags
     counsel-gtags
-    helm-gtags
     insert-shebang
     org
     (sh-script :location built-in)
@@ -120,9 +119,6 @@
 
 (defun shell-scripts/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'sh-mode))
-
-(defun shell-scripts/post-init-helm-gtags ()
-  )
 
 (defun shell-scripts/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -122,7 +122,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'sh-mode))
 
 (defun shell-scripts/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'sh-mode))
+  )
 
 (defun shell-scripts/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -69,4 +69,4 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'vimrc-mode))
 
 (defun vimscript/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'vimrc-mode))
+  )

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -28,7 +28,6 @@
     vimrc-mode
     ggtags
     counsel-gtags
-    helm-gtags
     dactyl-mode))
 
 (defun vimscript/post-init-company ()
@@ -67,6 +66,3 @@
 
 (defun vimscript/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'vimrc-mode))
-
-(defun vimscript/post-init-helm-gtags ()
-  )

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -27,7 +27,6 @@
     bmx-mode
     (counsel-gtags :if (configuration-layer/package-used-p 'counsel))
     ggtags
-    (helm-gtags :if (configuration-layer/package-used-p 'helm))
     powershell))
 
 (defun windows-scripts/init-bat-mode()

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -88,7 +88,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'bat-mode))
 
 (defun windows-scripts/post-init-helm-gtags ()
-  (spacemacs/helm-gtags-define-keys-for-mode 'bat-mode))
+  )
 
 (defun windows-scripts/init-powershell ()
   (use-package powershell

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -87,9 +87,6 @@
 (defun windows-scripts/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'bat-mode))
 
-(defun windows-scripts/post-init-helm-gtags ()
-  )
-
 (defun windows-scripts/init-powershell ()
   (use-package powershell
     :mode (("\\.ps1\\'"  . powershell-mode)

--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -53,11 +53,6 @@ Otherwise does nothing."
   (interactive)
   (call-interactively 'helm-gtags-dwim))
 
-(defun spacemacs/helm-gtags-define-keys-for-mode (mode)
-  "Obsolete, does nothing."
-  (message "spacemacs/helm-gtags-define-keys-for-mode does nothing! %s doesn't have to call it anymore."
-           mode))
-
 (defun spacemacs/helm-ggtags-set-jump-handler ()
   (add-to-list 'spacemacs-jump-handlers 'spacemacs/helm-gtags-maybe-dwim))
 


### PR DESCRIPTION
The function `spacemacs/helm-gtags-define-keys-for-mode` is obsolete, I remove all of the function calls of it. This will remove the corresponding message in *Message* buffer when Emacs starts.