### PR TITLE
fix: typescript/tide don't start when switch from a none-tide project

### DIFF
--- a/layers/+lang/typescript/layers.el
+++ b/layers/+lang/typescript/layers.el
@@ -21,8 +21,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(configuration-layer/declare-layer-dependencies '(node javascript prettier tide))
+(configuration-layer/declare-layer-dependencies '(node javascript prettier))
 
-(when (and (boundp 'typescript-backend)
-           (eq typescript-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(lsp)))
+(when (boundp 'typescript-backend)
+  (pcase typescript-backend
+    ('lsp (configuration-layer/declare-layer-dependencies '(lsp)))
+    ('tide (configuration-layer/declare-layer-dependencies '(tide)))))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -53,41 +53,41 @@
   (add-hook 'typescript-tsx-mode-hook #'spacemacs/typescript-emmet-mode))
 
 (defun typescript/set-tide-linter ()
-  (with-eval-after-load 'tide
-    (with-eval-after-load 'flycheck
-      (pcase typescript-linter
-        ('tslint (flycheck-add-mode 'typescript-tide 'typescript-tsx-mode)
-                 (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))
-        ('eslint (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
-                 (flycheck-add-mode 'javascript-eslint 'typescript-mode)
-                 (add-to-list 'flycheck-disabled-checkers 'typescript-tslint)
-                 (flycheck-disable-checker 'typescript-tslint)
-                 (flycheck-add-mode 'tsx-tide 'typescript-tsx-mode)
-                 (flycheck-add-next-checker 'typescript-tide 'javascript-eslint 'append)
-                 (flycheck-add-next-checker 'tsx-tide 'javascript-eslint 'append))
-        (_ (message
-            "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))))
+  (pcase typescript-linter
+    ('tslint (flycheck-add-mode 'typescript-tide 'typescript-tsx-mode)
+             (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))
+    ('eslint (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
+             (flycheck-add-mode 'javascript-eslint 'typescript-mode)
+             (add-to-list 'flycheck-disabled-checkers 'typescript-tslint)
+             (flycheck-add-mode 'tsx-tide 'typescript-tsx-mode)
+             (flycheck-add-next-checker 'typescript-tide 'javascript-eslint 'append)
+             (flycheck-add-next-checker 'tsx-tide 'javascript-eslint 'append))
+    (_ (message
+        "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))
 
 (defun typescript/set-lsp-linter ()
-  (with-eval-after-load 'lsp-ui
-    (with-eval-after-load 'flycheck
-      (pcase typescript-linter
-        ('tslint (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))
-        ;; This sets tslint unconditionally for all lsp clients which is wrong
-        ;; Must be set for respective modes only, see go layer for examples.
-        ('eslint (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
-                 (flycheck-add-mode 'javascript-eslint 'typescript-mode))
-        (_ (message
-            "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))))
+  (pcase typescript-linter
+    ('tslint (flycheck-add-mode 'typescript-tslint 'typescript-tsx-mode))
+    ;; This sets tslint unconditionally for all lsp clients which is wrong
+    ;; Must be set for respective modes only, see go layer for examples.
+    ('eslint (flycheck-add-mode 'javascript-eslint 'typescript-tsx-mode)
+             (flycheck-add-mode 'javascript-eslint 'typescript-mode))
+    (_ (message
+        "Invalid typescript-layer configuration, no such linter: %s" typescript-linter))))
+
+(defun typescript/set-linter ()
+  (pcase typescript-backend
+    ('tide (typescript/set-tide-linter))
+    ('lsp (typescript/set-lsp-linter))))
 
 (defun typescript/post-init-flycheck ()
   (spacemacs/enable-flycheck 'typescript-mode)
   (spacemacs/enable-flycheck 'typescript-tsx-mode)
-  (pcase typescript-backend
-    ('tide (typescript/set-tide-linter))
-    ('lsp (typescript/set-lsp-linter)))
   (spacemacs/add-to-hooks #'spacemacs//typescript-setup-checkers
                           '(typescript-mode-hook typescript-tsx-mode-hook)
+                          t)
+  (spacemacs/add-to-hooks #'typescript/set-linter
+                          '(typescript-mode-local-vars-hook typescript-tsx-mode-local-vars-hook)
                           t))
 
 (defun typescript/post-init-smartparens ()

--- a/layers/+tools/tide/packages.el
+++ b/layers/+tools/tide/packages.el
@@ -28,7 +28,6 @@
 (defun tide/init-tide ()
   (use-package tide
     :defer t
-    :commands (typescript/jump-to-type-def)
     :config
     (spacemacs//tide-setup-bindings)
     (add-hook 'tide-mode-hook #'spacemacs//tide-setup-jump-handle)))


### PR DESCRIPTION
move the flycheck setup functions to `-mode-local-vars-hooks`
remove a `flycheck-disable-checker`, which is not neccesary for has `add-to-list flycheck-disabled-checkers`
