### PR TITLE
[spacemacs-evil] Only load evil-lisp-state once

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/funcs.el
+++ b/layers/+spacemacs/spacemacs-evil/funcs.el
@@ -90,4 +90,5 @@ Otherwise, revert to the default behavior (i.e. enable `evil-insert-state')."
 
 (defun spacemacs//load-evil-lisp-state ()
   "Load evil-lisp-state lazily"
-  (require 'evil-lisp-state))
+  (require 'evil-lisp-state)
+  (remove-hook 'prog-mode-hook #'spacemacs//load-evil-lisp-state))


### PR DESCRIPTION
This avoids calling `require` over and over every time a new file is opened, which can get expensive if `features` is large.