### PR TITLE
[version-control] Use upper/lower terminology in smerge-ts

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -2,7 +2,7 @@
 
 #+TAGS: layer|versioning
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
@@ -222,10 +222,10 @@ Merge Actions:
 
 | Key binding | Description  |
 |-------------+--------------|
+| ~SPC g r u~ | Keep upper   |
 | ~SPC g r b~ | Keep base    |
-| ~SPC g r m~ | Keep mine    |
+| ~SPC g r l~ | Keep lower   |
 | ~SPC g r a~ | Keep all     |
-| ~SPC g r o~ | Keep other   |
 | ~SPC g r c~ | Keep current |
 | ~SPC g r K~ | Kill current |
 
@@ -244,7 +244,7 @@ Other:
 | Key binding | Description                    |
 |-------------+--------------------------------|
 | ~SPC g r C~ | Combine current and next hunks |
-| ~SPC g r u~ | Undo                           |
+| ~SPC g r U~ | Undo                           |
 | ~SPC g r q~ | Quit transient state           |
 
 ** Toggles

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -274,7 +274,7 @@
  [_N_/_p_] prev conflict  [_b_] keep base     [_=_] upper/lower [_U_] undo
  [_j_]^^   next line      [_l_] keep lower    [_>_] base/lower  [_q_] quit
  [_k_]^^   prev line      [_a_] keep all      [_r_] refine
- ^^^^                     [_c_] keep current  [_e_] ediff       [_?_]^^ toggle help
+ ^^^^                     [_c_] keep current  [_e_] ediff       [_?_] toggle help
  ^^^^                     [_K_] kill current")
       (spacemacs|define-transient-state smerge
         :title "Smerge Transient State"

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -270,10 +270,10 @@
         "\n
  Movement^^^^             Merge Action^^      Diff^^            Other
  -------------------^^^^  ----------------^^  --------------^^  -------------------------------^^
- [_n_]^^   next conflict  [_b_] keep base     [_<_] base/mine   [_C_] combine curr/next conflicts
- [_N_/_p_] prev conflict  [_m_] keep mine     [_=_] mine/other  [_u_] undo
- [_j_]^^   next line      [_a_] keep all      [_>_] base/other  [_q_] quit
- [_k_]^^   prev line      [_o_] keep other    [_r_] refine
+ [_n_]^^   next conflict  [_u_] keep upper    [_<_] base/upper  [_C_] combine curr/next conflicts
+ [_N_/_p_] prev conflict  [_b_] keep base     [_=_] upper/lower [_U_] undo
+ [_j_]^^   next line      [_l_] keep lower    [_>_] base/lower  [_q_] quit
+ [_k_]^^   prev line      [_a_] keep all      [_r_] refine
  ^^^^                     [_c_] keep current  [_e_] ediff       [_?_]^^ toggle help
  ^^^^                     [_K_] kill current")
       (spacemacs|define-transient-state smerge
@@ -289,10 +289,12 @@
         ("j" evil-next-line)
         ("k" evil-previous-line)
         ;; merge action
-        ("b" smerge-keep-base)
-        ("m" smerge-keep-mine)
         ("a" smerge-keep-all)
+        ("b" smerge-keep-base)
+        ("l" smerge-keep-lower)
+        ("m" smerge-keep-mine)
         ("o" smerge-keep-other)
+        ("u" smerge-keep-upper)
         ("c" smerge-keep-current)
         ;; diff
         ("<" smerge-diff-base-mine)
@@ -303,7 +305,7 @@
         ;; other
         ("C" smerge-combine-with-next)
         ("K" smerge-kill-current)
-        ("u" undo-tree-undo)
+        ("U" undo-tree-undo)
         ("q" nil :exit t)
         ("?" spacemacs//smerge-ts-toggle-hint)))))
 


### PR DESCRIPTION
smerge-mode.el has obsoleted the names "mine" and "other" since Emacs 26.1.  Their meanings are not consistent between different VC systems or even different operations (e.g., rebase vs. merge), and "upper" and "lower" are more obvious anyway.

This also changes the Undo key binding in smerge-ts to `U` to avoid a conflict.