### PR TITLE
clarifies additional layer path format

### DIFF
--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -27,7 +27,7 @@ This function should only modify configuration layer settings."
    dotspacemacs-ask-for-lazy-installation t
 
    ;; List of additional paths where to look for configuration layers.
-   ;; Paths must have a trailing slash (i.e. `"~/.mycontribs/"')
+   ;; Paths must have a trailing slash (i.e. "~/.mycontribs/")
    dotspacemacs-configuration-layer-path '()
 
    ;; List of configuration layers to load.

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -27,7 +27,7 @@ This function should only modify configuration layer settings."
    dotspacemacs-ask-for-lazy-installation t
 
    ;; List of additional paths where to look for configuration layers.
-   ;; Paths must have a trailing slash (i.e. `~/.mycontribs/')
+   ;; Paths must have a trailing slash (i.e. `"~/.mycontribs/"')
    dotspacemacs-configuration-layer-path '()
 
    ;; List of configuration layers to load.


### PR DESCRIPTION
Since the example path is quoted, it is easy for beginners to confuse the quotes. Now it is clearer.
It is incredibly minor, but might save a user some headache.

Thank you :heart: for contributing to Spacemacs!

