### PR TITLE
*spacemacs-navigation/packages.el: load info+ after the info feature

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -332,7 +332,7 @@
     (progn
       (spacemacs/set-leader-keys "hj" 'info-display-manual)
       (setq Info-fontify-angle-bracketed-flag nil)
-      (add-hook 'Info-mode-hook (lambda () (require 'info+))))))
+      (with-eval-after-load "info" (require 'info+)))))
 
 (defun spacemacs-navigation/init-open-junk-file ()
   (use-package open-junk-file


### PR DESCRIPTION
Error message is emitted when try `info` (press `C-h i`) first time.
> info+·is·not·available:·spaceline-info-mode·disabled

It caused by original code loading the `info+` at the mode hook, too late.

The change will load the `info+` after  the `info`, then there will no error message.
Please help review it. Thanks.