### PR TITLE
Openai layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -501,6 +501,7 @@ In org-agenda-mode
 - hackernews
 - streamlink
 - twitch
+- openai (thanks to Hendrik Rommeswinkel)
 *** Renamed layers
 - =extra-langs= renamed to =major-modes= (thanks to Eivind Fonn)
 - =pdf-tools= renamed to =pdf=

--- a/layers/+web-services/openai/README.org
+++ b/layers/+web-services/openai/README.org
@@ -1,0 +1,72 @@
+#+TITLE: OpenAI layer
+
+#+TAGS: layer|web service|general
+
+
+* Table of Contents                     :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#configuration][Configuration]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+This layer provides applications to make requests to openai via its API.
+
+** Features:
+- Provides access to openai via the emacs-openai suite of packages
+- Send visual selection or buffer and receive response in current buffer
+- Improve, edit, and document code
+- Chat sessions with chatgpt
+- Obtain AI generated images
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =openai= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Configuration
+You need to set your openai key. If you have stored the key in the environment
+variable OPENAI_API_KEY, then you need to add to your user-config:
+  =(setq openai-key (getenv "OPENAI_API_KEY"))=
+Also, most requests require setting a user, which is done via:
+  =(setq openai-user "user")=
+where "user" can be substituted by other usernames.
+
+
+* Key bindings
+If you want to build your own OpenAI requests, you can use `openai-completion'.
+For further information, see the openai package documentation.
+For interactive requests via OpenAI, the following key bindings are available:
+
+| Key binding   | Command                         | Description                 |
+|---------------+---------------------------------+-----------------------------|
+| ~SPC a w o b~ | openai-completion-buffer-insert | Sends buffer to AI          |
+| ~SPC a w o s~ | openai-completion-select-insert | Sends selection to AI       |
+| ~SPC a w o g~ | chatgpt                         | Opens chatgpt session       |
+| ~SPC a w o e~ | openai-edit-prompt              | Asks to edit text           |
+| ~SPC a w o C~ | openai-chat-say                 | Single request and response |
+| ~SPC a w o m~ | openai-list-models              | Lists all models            |
+| ~SPC a w o M~ | openai-retrieve-model           | Details of specific model   |
+| ~SPC a w o E~ | openai-embedding-create         | Makes Embedding             |
+
+For requests to improve, edit, or document code, the following key bindings are
+available:
+
+| Key binding     | Command         | Description         |
+|-----------------+-----------------+---------------------|
+| ~SPC a w o c c~ | codegpt         | Generates code      |
+| ~SPC a w o c C~ | codegpt-custom  | Custom instructions |
+| ~SPC a w o c d~ | codegpt-doc     | Documents code      |
+| ~SPC a w o c f~ | codegpt-fix     | Fixes code          |
+| ~SPC a w o c e~ | codegpt-explain | Explains code       |
+| ~SPC a w o c i~ | codegpt-improve | Improves code       |
+
+For requests for OpenAI generated images, the following key bindings are available:
+
+| Key binding     | Command                              | Description                |
+|-----------------+--------------------------------------+----------------------------|
+| ~SPC a w o i d~ | dall-e                               | Dall-e requests            |
+| ~SPC a w o i i~ | openai-openai-image-prompt           | Generates image            |
+| ~SPC a w o i e~ | openai-openai-image-edit-prompt      | Edits existing image       |
+| ~SPC a w o i v~ | openai-openai-image-variation-prompt | Creates variation of image |

--- a/layers/+web-services/openai/packages.el
+++ b/layers/+web-services/openai/packages.el
@@ -1,0 +1,94 @@
+;;; packages.el --- OpenAI Layer packages File for Spacemacs
+;;
+;; Copyright (c) 2012-2022 Sylvain Benner & Contributors
+;;
+;; Author: Hendrik Rommeswinkel
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+(defconst openai-packages
+  '(
+    (openai :location (recipe :fetcher github :repo "emacs-openai/openai"))
+    (chatgpt :location (recipe :fetcher github :repo "emacs-openai/chatgpt"))
+    (codegpt :location (recipe :fetcher github :repo "emacs-openai/codegpt"))
+    (dall-e :location (recipe :fetcher github :repo "emacs-openai/dall-e"))
+    ))
+
+(defun openai/init-openai ()
+  (use-package openai
+    :init
+    (progn
+      (spacemacs/declare-prefix "awo" "OpenAI")
+      (spacemacs/declare-prefix "awoi" "OpenAI images")
+      (spacemacs/set-leader-keys
+        "awob" 'openai-completion-buffer-insert
+        "awom" 'openai-list-models
+        "awoM" 'openai-retrieve-model
+        "awos" 'openai-completion-select-insert
+        "awoC" 'openai-chat-say
+        "awoe" 'openai-edit-prompt
+        "awoE" 'openai-embedding-create
+        "awoie" 'openai-image-edit-prompt
+        "awoii" 'openai-image-prompt
+        "awoiv" 'openai-image-variation-prompt)
+      )))
+(defun openai/init-chatgpt ()
+  (use-package chatgpt
+    :init
+    (progn
+      (spacemacs/set-leader-keys
+        ;; ChatGPT session
+        "awog" 'chatgpt)
+      )
+    :config
+    (progn
+      (evilified-state-evilify-map chatgpt-mode-map
+        :mode chatgpt-mode
+        :bindings
+        (kbd "<return>") 'chatgpt-type-response
+        )
+    )))
+(defun openai/init-codegpt ()
+  (use-package codegpt
+    :init
+    (progn
+      (spacemacs/declare-prefix "awoc" "codegpt")
+      (spacemacs/set-leader-keys
+        ;; Coding tools
+        "awocc" 'codegpt
+        "awocC" 'codegpt-custom
+        "awocd" 'codegpt-doc
+        "awocf" 'codegpt-fix
+        "awoce" 'codegpt-explain
+        "awoci" 'codegpt-improve)
+        )))
+(defun openai/init-dall-e ()
+  (use-package dall-e
+    :init
+    (progn
+      (spacemacs/set-leader-keys
+        "awoid" 'dall-e)
+      )
+    :config
+    (progn
+      (evilified-state-evilify-map dall-e-mode-map
+        :mode dall-e-mode
+        :bindings
+        (kbd "<return>") 'dall-e-type-response
+        )
+      )))


### PR DESCRIPTION
This is a first draft for an openai layer. Github organization emacs-openai provides several packages to use OpenAI.
This layer bundles these packages and provides evilification for two of the packages (the others do not need it).
All OpenAI requests are available via the applications/web services keybindings `SPC a w o'.

Features:
send selection/buffer to various openai models
ask openai for code improvement/documentation
generate image from prompt via dall-e
chat with chatgpt