### PR TITLE
layers/+misc/ietf/packages.el: remove duplicate item and load ox-rfc after ox

### DIFF
--- a/layers/+misc/ietf/packages.el
+++ b/layers/+misc/ietf/packages.el
@@ -43,17 +43,12 @@
       (setq irfc-directory ietf-docs-cache)
       (setq irfc-assoc-mode t)
       (add-to-list 'auto-mode-alist
-                   '("/draft-\\([a-z0-9_]+-\\)+[0-9]+.txt" . irfc-mode))
-      (add-to-list 'auto-mode-alist
                    '("/draft-\\([a-z0-9_]+-\\)+[a-z0-9_]+.txt" . irfc-mode))
       (add-to-list 'auto-mode-alist
                    '("/rfc\\([a-z0-9_-]+\\).txt" . irfc-mode)))))
 
-
-
-(defun ietf/pre-init-ox-rfc ()
-  (spacemacs|use-package-add-hook org :post-config (require 'ox-rfc)))
-(defun ietf/init-ox-rfc ())
+(defun ietf/init-ox-rfc ()
+  (use-package ox-rfc :after ox))
 
 
 ;;; packages.el ends here


### PR DESCRIPTION
Hi,

Found two issues on the ietf layer:
1. the first item `"/draft-\\([a-z0-9_]+-\\)+[0-9]+.txt"` is included by the second one `/draft-\\([a-z0-9_]+-\\)+[a-z0-9_]+.txt` for `auto-mode-alist`, so remove it.
2. the `ox-rfc` should relay on the `ox` (before this change, `ox-rfc` will be loaded after `org` library, and it will lead all the `ox` and `ox-*` to be loaded, then Spacemacs is slow on openning a `*.org` file.)

Please help review and approve this change. Thanks.