### PR TITLE
*layers/+spacemacs/spacemacs-layouts/packages.el: loading after helm-buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -117,7 +117,7 @@
 
 
 (defun spacemacs-layouts/post-init-helm ()
-  (with-eval-after-load 'helm (spacemacs//persp-helm-setup))
+  (with-eval-after-load 'helm-buffer (spacemacs//persp-helm-setup))
   (spacemacs/set-leader-keys
     "bB" 'spacemacs-layouts/non-restricted-buffer-list-helm
     "pl" 'spacemacs/helm-persp-switch-project))


### PR DESCRIPTION
The `(spacemacs//persp-helm-setup)` should be loaded after `helm-buffer` for it using the variable `helm-buffer-list-reorder-fn`.