### PR TITLE
*core/core-configuration-layer.el: try `package-activate-all' for speedup

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -674,6 +674,7 @@ To prevent package from being installed or uninstalled set the variable
                  (not configuration-layer-exclude-all-layers))
         (configuration-layer/delete-orphan-packages packages))))
   ;; configure used packages
+  (package-activate-all)                ; try the package-quickstart-file first
   (configuration-layer//configure-packages configuration-layer--used-packages)
   ;; evaluate layer variables a second time to override default values set in
   ;; packages configuration above


### PR DESCRIPTION
Hi,

Spacemacs maybe initalize more than 100+ packages at startup, it can be speedup by setting the `package-quickstart` to `t` or manually call function `(package-quickstart-refresh)` to generate the `package-quickstart-file`, then call the `(package-activate-all)`  to load the packages in batches.

Otherwise, the `(package-activate-all)` will do nothing.

Please help review this change. Thanks