### PR TITLE
*layers/+emacs/org/packages.el: better way to load org-babel langs

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -122,11 +122,11 @@
     :defer t
     :init
     (progn
-      (defun spacemacs//org-babel-do-load-languages ()
-        "Load all the languages declared in `org-babel-load-languages'."
+      (define-advice org-babel-execute-src-block (:before (&rest _) load-lang)
         (org-babel-do-load-languages 'org-babel-load-languages
-                                     org-babel-load-languages))
-      (add-hook 'org-mode-hook 'spacemacs//org-babel-do-load-languages)
+                                     org-babel-load-languages)
+        (advice-remove 'org-babel-execute-src-block
+                       'org-babel-execute-src-block@load-lang))
       ;; Fix redisplay of inline images after a code block evaluation.
       (add-hook 'org-babel-after-execute-hook 'spacemacs/ob-fix-inline-images))))
 


### PR DESCRIPTION
Speedup opening *.org file with lazy loading the babel languages.
The babel languages is used to evaluate the source block in the org file, it's no mandatory for all the org file.
This change will try load the babel language only before evaluate the source block.
It can resolve the stucking when opening an org file on my local.
Please help review this change. Thanks

Spacemacs maybe load these babel languages:
>(http . t)
(restclient . t)
(shell . t)
(elasticsearch . t)
(cfengine3 . t)
(sml . t)
(sql . t)
(shell . t)
(sparql . t)
(ruby . t)
(python . t)
(plantuml . t)
(perl . t)
(js . t)
(java . t)
(hy . t)
(crystal . t)
(groovy . t)
(R . t)
(elixir . t)
(coffeescript . t)
(clojure . t)
(C . t)
(verb . t)
(dot . t)
