### PR TITLE
Revert "[nixos] Fix nixos-format-on-save for newer nixos-mode"

### DIFF
--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -59,7 +59,7 @@
       (spacemacs/set-leader-keys-for-major-mode 'nix-mode
         "==" 'nix-format-buffer)
       (when nixos-format-on-save
-        (add-hook 'nix-mode-hook 'nixfmt-on-save-mode)))
+        (add-hook 'before-save-hook 'nix-format-before-save)))
     :config
     (electric-indent-mode -1)))
 


### PR DESCRIPTION
This reverts commit 821bd9cc683575af0996c8e2b3e42452bb9c684a.

This follows the revert happening in
https://github.com/NixOS/nix-mode/commit/c18a24e9ac569a221e88ba9d74d52c7b02b6eb77

Closes https://github.com/syl20bnr/spacemacs/issues/15956