### PR TITLE
+lang/emacs-lisp/packages.el: defer to load the emr package

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -347,7 +347,8 @@
 
 (defun emacs-lisp/init-emr ()
   (use-package emr
-    :config
+    :defer t
+    :init
     (let ((key-binding-prefixes
            '(("mr" . "refactor")
              ("mrd" . "delete")


### PR DESCRIPTION
Defer to load the `emr` package for it works with `emacs-lisp-mode`.

The functions `emr-el-*` are all autoloads functions, so register them to the key binds in the `:init` block.

Then if user press key to call any `emr-el-*` function first time, the package will be loaded and work. 

Please help review the change, thanks.