### PR TITLE
layers/+spacemacs/spacemacs-editing/packages.el: defer to load the multi-line

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -521,6 +521,7 @@
 
 (defun spacemacs-editing/init-multi-line ()
   (use-package multi-line
+    :defer t
     :init
     (progn
       (spacemacs|define-transient-state multi-line


### PR DESCRIPTION
Defer to load the `multi-line` package which can be autoloaded when the user try `SPC x n` to use the multi-line feature.