### PR TITLE
Use cl-remove-if-not instead of remove-if-not

### DIFF
--- a/layers/+lang/sql/funcs.el
+++ b/layers/+lang/sql/funcs.el
@@ -25,7 +25,7 @@
   "Update Spacemacs list of sql products"
   (setq
    spacemacs-sql-highlightable sql-product-alist
-   spacemacs-sql-startable (remove-if-not
+   spacemacs-sql-startable (cl-remove-if-not
                             (lambda (product) (sql-get-product-feature (car product) :sqli-program))
                             sql-product-alist)))
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -21,8 +21,6 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(require 'cl-lib)
-
 (defun spacemacs//run-local-vars-mode-hook ()
   "Run a hook for the major-mode after the local variables have been processed."
   (run-hooks (intern (format "%S-local-vars-hook" major-mode))))
@@ -1099,7 +1097,7 @@ the `kill-matching-buffers` for grateful killing. The optional 2nd argument
 indicates whether to kill internal buffers too.
 
 Returns the count of killed buffers."
-  (let* ((buffers (remove-if-not
+  (let* ((buffers (cl-remove-if-not
                    (lambda (buffer)
                      (let ((name (buffer-name buffer)))
                        (and name (not (string-equal name ""))


### PR DESCRIPTION
remove-if-not is obsolete. Additionally, current remove-if-not usage without requiring the cl library often causes "Symbol's function definition is void" error.