### PR TITLE
When user setting is nil, don't init loading progress bar

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1954,7 +1954,7 @@ RNAME is the name symbol of another existing layer."
 
 (defun configuration-layer//configure-packages (packages)
   "Configure all passed PACKAGES honoring the steps order."
-  (when dotspacemacs-loading-progress-bar (spacemacs/init-progress-bar (length packages)))
+  (spacemacs/init-progress-bar (length packages))
   (spacemacs-buffer/message "+ Configuring bootstrap packages...")
   (configuration-layer//configure-packages-2
    (configuration-layer/filter-objects
@@ -2089,7 +2089,7 @@ LAYER must not be the owner of PKG."
 
 (defun configuration-layer//configure-package (pkg)
   "Configure PKG object, i.e. call its post-init function."
-  (when dotspacemacs-loading-progress-bar (spacemacs/update-progress-bar))
+  (spacemacs/update-progress-bar)
   (let* ((pkg-name (oref pkg :name))
          (owner (car (oref pkg :owners))))
     ;; init

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1954,7 +1954,7 @@ RNAME is the name symbol of another existing layer."
 
 (defun configuration-layer//configure-packages (packages)
   "Configure all passed PACKAGES honoring the steps order."
-  (spacemacs/init-progress-bar (length packages))
+  (when dotspacemacs-loading-progress-bar (spacemacs/init-progress-bar (length packages)))
   (spacemacs-buffer/message "+ Configuring bootstrap packages...")
   (configuration-layer//configure-packages-2
    (configuration-layer/filter-objects
@@ -2089,7 +2089,7 @@ LAYER must not be the owner of PKG."
 
 (defun configuration-layer//configure-package (pkg)
   "Configure PKG object, i.e. call its post-init function."
-  (spacemacs/update-progress-bar)
+  (when dotspacemacs-loading-progress-bar (spacemacs/update-progress-bar))
   (let* ((pkg-name (oref pkg :name))
          (owner (car (oref pkg :owners))))
     ;; init

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -52,7 +52,7 @@ non-nil."
 `dotspacemacs-loading-progress-bar' is non-nil, update the
 package-loading progress bar by incrementing its value by 1. The
 progress is displayed in chunks of size
-`spacemacs-loading-dots-chunk-threshold'.
+`spacemacs-loading-dots-chunk-threshold'".
   (when (and (not noninteractive)
              (> spacemacs-loading-dots-chunk-threshold 0)
              dotspacemacs-loading-progress-bar)

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -34,16 +34,17 @@
 
 (defun spacemacs/init-progress-bar (max)
   "Initialize the progress bar."
-  (setq spacemacs-loading-dots-count (window-total-size nil 'width))
-  (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
-                                             spacemacs-loading-dots-chunk-count))
-  (setq spacemacs-loading-dots-chunk-threshold
-        (- (/ max spacemacs-loading-dots-chunk-count) 5))
-  (setq spacemacs-loading-counter 0)
-  (setq spacemacs-loading-value 0)
-  (spacemacs-buffer/set-mode-line (make-string spacemacs-loading-dots-count
-                                               spacemacs-loading-char-light))
-  (spacemacs//redisplay))
+  (when dotspacemacs-loading-progress-bar
+    (setq spacemacs-loading-dots-count (window-total-size nil 'width))
+    (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
+                                               spacemacs-loading-dots-chunk-count))
+    (setq spacemacs-loading-dots-chunk-threshold
+          (- (/ max spacemacs-loading-dots-chunk-count) 5))
+    (setq spacemacs-loading-counter 0)
+    (setq spacemacs-loading-value 0)
+    (spacemacs-buffer/set-mode-line (make-string spacemacs-loading-dots-count
+                                                 spacemacs-loading-char-light))
+    (spacemacs//redisplay)))
 
 (defun spacemacs/update-progress-bar ()
   "Update progress bar by incrementing its value by 1.

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -33,22 +33,26 @@
 (defvar spacemacs-loading-dots-chunk-threshold 0)
 
 (defun spacemacs/init-progress-bar (max)
-  "Initialize the progress bar."
-  (when dotspacemacs-loading-progress-bar
-    (setq spacemacs-loading-dots-count (window-total-size nil 'width))
-    (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
-                                               spacemacs-loading-dots-chunk-count))
-    (setq spacemacs-loading-dots-chunk-threshold
-          (- (/ max spacemacs-loading-dots-chunk-count) 5))
-    (setq spacemacs-loading-counter 0)
-    (setq spacemacs-loading-value 0)
-    (spacemacs-buffer/set-mode-line (make-string spacemacs-loading-dots-count
-                                                 spacemacs-loading-char-light))
-    (spacemacs//redisplay)))
+  "Initialize the package-loading progress bar when the
+customziation variable dotspacemacs-loading-progress-bar is
+non-nil."
+  (setq spacemacs-loading-dots-count (window-total-size nil 'width))
+  (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
+                                             spacemacs-loading-dots-chunk-count))
+  (setq spacemacs-loading-dots-chunk-threshold
+        (- (/ max spacemacs-loading-dots-chunk-count) 5))
+  (setq spacemacs-loading-counter 0)
+  (setq spacemacs-loading-value 0)
+  (spacemacs-buffer/set-mode-line (make-string spacemacs-loading-dots-count
+                                               spacemacs-loading-char-light))
+  (spacemacs//redisplay))
 
 (defun spacemacs/update-progress-bar ()
-  "Update progress bar by incrementing its value by 1.
-Display the progress bar by chunks of size `spacemacs-loading-dots-chunk-threshold'"
+  "When the customization variable
+dotspacemacs-loading-progress-bar is non-nil, update the
+package-loading progress bar by incrementing its value by 1. The
+progress is displayed in chunks of size
+`spacemacs-loading-dots-chunk-threshold'."
   (when (and (not noninteractive)
              (> spacemacs-loading-dots-chunk-threshold 0)
              dotspacemacs-loading-progress-bar)

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -34,7 +34,7 @@
 
 (defun spacemacs/init-progress-bar (max)
   "Initialize the package-loading progress bar when the
-customziation variable dotspacemacs-loading-progress-bar is
+customziation variable `dotspacemacs-loading-progress-bar' is
 non-nil."
   (setq spacemacs-loading-dots-count (window-total-size nil 'width))
   (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
@@ -49,10 +49,10 @@ non-nil."
 
 (defun spacemacs/update-progress-bar ()
   "When the customization variable
-dotspacemacs-loading-progress-bar is non-nil, update the
+`dotspacemacs-loading-progress-bar' is non-nil, update the
 package-loading progress bar by incrementing its value by 1. The
 progress is displayed in chunks of size
-`spacemacs-loading-dots-chunk-threshold'."
+`spacemacs-loading-dots-chunk-threshold'.
   (when (and (not noninteractive)
              (> spacemacs-loading-dots-chunk-threshold 0)
              dotspacemacs-loading-progress-bar)
@@ -70,6 +70,6 @@ progress is displayed in chunks of size
               (concat (make-string progress spacemacs-loading-char)
                       (make-string remain spacemacs-loading-char-light)))
         (spacemacs-buffer/set-mode-line spacemacs-loading-string))
-      (spacemacs//redisplay))))
+      (spacemacs//redisplay)))")
 
 (provide 'core-progress-bar)

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -33,9 +33,11 @@
 (defvar spacemacs-loading-dots-chunk-threshold 0)
 
 (defun spacemacs/init-progress-bar (max)
-  "Initialize the package-loading progress bar when the
-customziation variable `dotspacemacs-loading-progress-bar' is
-non-nil."
+  "Conditionally initialize the package-loading progress bar.
+
+When the customziation variable `dotspacemacs-loading-progress-bar' is non-nil,
+the progress bar is initialized by setting the mode-line to an empty progress
+bar."
   (setq spacemacs-loading-dots-count (window-total-size nil 'width))
   (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
                                              spacemacs-loading-dots-chunk-count))
@@ -48,11 +50,13 @@ non-nil."
   (spacemacs//redisplay))
 
 (defun spacemacs/update-progress-bar ()
-  "When the customization variable
-`dotspacemacs-loading-progress-bar' is non-nil, update the
-package-loading progress bar by incrementing its value by 1. The
-progress is displayed in chunks of size
-`spacemacs-loading-dots-chunk-threshold'".
+  "Conditionally update the package-loading progress bar.
+
+When the customization variable `dotspacemacs-loading-progress-bar' is non-nil,
+update the package-loading progress bar by incrementing its value by 1.
+
+The variable `spacemacs-loading-dots-chunk-threshold' controls the amount of
+progress required before another character is appended to indicate progress."
   (when (and (not noninteractive)
              (> spacemacs-loading-dots-chunk-threshold 0)
              dotspacemacs-loading-progress-bar)
@@ -70,6 +74,6 @@ progress is displayed in chunks of size
               (concat (make-string progress spacemacs-loading-char)
                       (make-string remain spacemacs-loading-char-light)))
         (spacemacs-buffer/set-mode-line spacemacs-loading-string))
-      (spacemacs//redisplay)))")
+      (spacemacs//redisplay))))
 
 (provide 'core-progress-bar)

--- a/core/core-progress-bar.el
+++ b/core/core-progress-bar.el
@@ -33,11 +33,8 @@
 (defvar spacemacs-loading-dots-chunk-threshold 0)
 
 (defun spacemacs/init-progress-bar (max)
-  "Conditionally initialize the package-loading progress bar.
-
-When the customziation variable `dotspacemacs-loading-progress-bar' is non-nil,
-the progress bar is initialized by setting the mode-line to an empty progress
-bar."
+  "Initialize the progress bar.
+Does nothing when `dotspacemacs-loading-progress-bar' is nil."
   (setq spacemacs-loading-dots-count (window-total-size nil 'width))
   (setq spacemacs-loading-dots-chunk-size (/ spacemacs-loading-dots-count
                                              spacemacs-loading-dots-chunk-count))
@@ -50,13 +47,8 @@ bar."
   (spacemacs//redisplay))
 
 (defun spacemacs/update-progress-bar ()
-  "Conditionally update the package-loading progress bar.
-
-When the customization variable `dotspacemacs-loading-progress-bar' is non-nil,
-update the package-loading progress bar by incrementing its value by 1.
-
-The variable `spacemacs-loading-dots-chunk-threshold' controls the amount of
-progress required before another character is appended to indicate progress."
+"Update progress bar by incrementing its value by 1.
+Display the progress bar by chunks of size `spacemacs-loading-dots-chunk-threshold'."
   (when (and (not noninteractive)
              (> spacemacs-loading-dots-chunk-threshold 0)
              dotspacemacs-loading-progress-bar)


### PR DESCRIPTION
When the user customizes `dotspacemacs-loading-progress-bar` and sets it to nil, do not initialize the loading progress bar during startup.

This prevents the full progress bar from overtaking the mode-line, preventing redisplays that are unnecessary when no progress bar updates will occur later for visual fluff.

In short, don't show an empty progress bar if we don't intend to fill it.