### PR TITLE
Require a package dependency of inspector package

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -301,6 +301,9 @@
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))
 
+(defun emacs-lisp/init-treeview ()
+  (use-package treeview))
+
 (defun emacs-lisp/init-flycheck-package ()
   (use-package flycheck-package
     :hook (emacs-lisp-mode . flycheck-package-setup)))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -302,7 +302,8 @@
   (setq flycheck-emacs-lisp-load-path 'inherit))
 
 (defun emacs-lisp/init-treeview ()
-  (use-package treeview))
+  (use-package treeview
+    :defer t))
 
 (defun emacs-lisp/init-flycheck-package ()
   (use-package flycheck-package

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -40,6 +40,7 @@
     ggtags
     counsel-gtags
     (ielm :location built-in)
+    treeview
     (inspector :location (recipe
                           :fetcher github
                           :repo "mmontone/emacs-inspector"))


### PR DESCRIPTION
Fixes an function definition error caused by a missing package dependency in the Emacs Lisp layer.