### PR TITLE
Replacing the function `remove-if-not` with the `cl-remove-if-not`

### DIFF
--- a/layers/+lang/sql/funcs.el
+++ b/layers/+lang/sql/funcs.el
@@ -25,7 +25,7 @@
   "Update Spacemacs list of sql products"
   (setq
    spacemacs-sql-highlightable sql-product-alist
-   spacemacs-sql-startable (remove-if-not
+   spacemacs-sql-startable (cl-remove-if-not
                             (lambda (product) (sql-get-product-feature (car product) :sqli-program))
                             sql-product-alist)))
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1099,7 +1099,7 @@ the `kill-matching-buffers` for grateful killing. The optional 2nd argument
 indicates whether to kill internal buffers too.
 
 Returns the count of killed buffers."
-  (let* ((buffers (remove-if-not
+  (let* ((buffers (cl-remove-if-not
                    (lambda (buffer)
                      (let ((name (buffer-name buffer)))
                        (and name (not (string-equal name ""))


### PR DESCRIPTION
The function `remove-if-not` is obsolete since 27.1; use `cl-remove-if-not` instead.