### PR TITLE
Replace `mu4e~headers-jump-to-maildir` with `mu4e-search-maildir`

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -73,7 +73,7 @@
       (evilified-state-evilify-map mu4e-main-mode-map
         :mode mu4e-main-mode
         :bindings
-        (kbd "j") 'mu4e~headers-jump-to-maildir
+        (kbd "j") 'mu4e-search-maildir
         (kbd "C-j") 'next-line
         (kbd "C-k") 'previous-line)
 


### PR DESCRIPTION
='mu4e~headers-jump-to-maildir= is deprecated. ='mu4e-search-maildir= should be used instead. The use of the outdated function also produces a wrong display of keybindings in the mu4e dashboard's Maildir section with the current version of mu4e (1.11.2).
