### PR TITLE
Fix the column number for function `spacemacs--file-path-with-line-column

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -737,20 +737,14 @@ Returns:
   "Retrieve the file path of the current buffer,
 including line and column number.
 
+This function respects the the `column-number-indicator-zero-based' variable.
+
 Returns:
   - A string containing the file path in case of success.
   - `nil' in case the current buffer does not have a directory."
   (when-let (file-path (spacemacs--file-path-with-line))
-    (concat
-     file-path
-     ":"
-     (number-to-string (if (and
-                            ;; Emacs 26 introduced this variable. Remove this
-                            ;; check once 26 becomes the minimum version.
-                            (boundp column-number-indicator-zero-based)
-                            (not column-number-indicator-zero-based))
-                           (1+ (current-column))
-                         (current-column))))))
+    (format "%s:%s" file-path
+            (+ (current-column) (if column-number-indicator-zero-based 0 1)))))
 
 (defun spacemacs/copy-directory-path ()
   "Copy and show the directory path of the current buffer.

--- a/layers/+spacemacs/spacemacs-project/funcs.el
+++ b/layers/+spacemacs/spacemacs-project/funcs.el
@@ -59,23 +59,14 @@ Returns:
 (defun spacemacs--projectile-file-path-with-line-column ()
   "Retrieve the file path relative to project root, including line and column number.
 
-This function respects the value of the `column-number-indicator-zero-based'
-variable.
+This function respects the the `column-number-indicator-zero-based' value.
 
 Returns:
   - A string containing the file path in case of success.
   - `nil' in case the current buffer does not visit a file."
   (when-let (file-path (spacemacs--projectile-file-path-with-line))
-    (concat
-      file-path
-      ":"
-      (number-to-string (if (and
-                              ;; Emacs 26 introduced this variable.
-                              ;; Remove this check once 26 becomes the minimum version.
-                              (boundp column-number-indicator-zero-based)
-                              (not column-number-indicator-zero-based))
-                            (1+ (current-column))
-                          (current-column))))))
+    (format "%s:%s" file-path
+            (+ (current-column) (if column-number-indicator-zero-based 0 1)))))
 
 
 (defun spacemacs/projectile-copy-directory-path ()


### PR DESCRIPTION
The document of function `spacemacs/copy-file-path-with-line-column` (`SPC f y c`) should mention the `spacemacs--file-path-with-line-column` variable.

Here is the changes to:
* layers/+spacemacs/spacemacs-defaults/funcs.el: function `spacemacs--file-path-with-line-column' should respects the `spacemacs--file-path-with-line-column'.
* layers/+spacemacs/spacemacs-project/funcs.el: make the function `spacemacs--projectile-file-path-with-line-column' simple like the `spacemacs--file-path-with-line-column'.

Please help review it. Thanks