### PR TITLE
*layers/+lang/python/packages.el: setup global python shell variables

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -448,7 +448,11 @@
 
       ;; add this optional key binding for Emacs user, since it is unbound
       (define-key inferior-python-mode-map
-        (kbd "C-c M-l") 'spacemacs/comint-clear-buffer))))
+        (kbd "C-c M-l") 'spacemacs/comint-clear-buffer)
+      ;; setup the global variables for python shell
+      (spacemacs//python-setup-shell default-directory)
+      (dolist (x '(python-shell-interpreter python-shell-interpreter-args))
+        (set-default-toplevel-value x (symbol-value x))))))
 
 (defun python/post-init-semantic ()
   (when (configuration-layer/package-used-p 'anaconda-mode)


### PR DESCRIPTION
Fix the global variables  python shell always are the default values.

The `spacemacs//python-setup-shell` will setup the python shell values to be local value, this change will try to setup the global values.

Fix #15873 #16001