### PR TITLE
git: change git transient user preference file location

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -332,12 +332,13 @@
         "gHt" 'smeargle))))
 
 (defun git/pre-init-transient ()
-  (setq transient-history-file (expand-file-name "transient/history.el"
+  (setq-default transient-history-file (expand-file-name "transient/history.el"
                                                  spacemacs-cache-directory))
-  (setq transient-levels-file (expand-file-name "transient/levels.el"
+  (setq-default transient-levels-file (expand-file-name "transient/levels.el"
                                                 spacemacs-cache-directory))
-  (setq transient-values-file (expand-file-name "transient/values.el"
-                                                spacemacs-cache-directory)))
+  ;; Values are the users saved preferences so they should persist.
+  (setq-default transient-values-file (expand-file-name "transient/values.el"
+                                                        dotspacemacs-directory)))
 
 (defun git/init-transient ()
   (use-package transient


### PR DESCRIPTION
Move the values file out of .cache and into users dotspacemacs-directory as these user preference values should be persistent.

Also these are custom variables so use setq-default
