### PR TITLE
Use cl-first instead of first

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -855,7 +855,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :body
     (let ((agenda-files (org-agenda-files)))
       (if agenda-files
-          (progn (find-file (if org-persp-startup-org-file org-persp-startup-org-file (first agenda-files)))
+          (progn (find-file (if org-persp-startup-org-file org-persp-startup-org-file (cl-first agenda-files)))
                  (if org-persp-startup-with-agenda (org-agenda nil org-persp-startup-with-agenda)))
 
         (user-error "Error: No agenda files configured, nothing to display.")))))


### PR DESCRIPTION
This fixes an issue where "l o o" results in an error related to "first" being undefined.
