### PR TITLE
Fix SQLITE_CANTOPEN when opening Forge database file

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -348,8 +348,8 @@
     :after magit
     :init
     (progn
-      (setq forge-database-file (concat spacemacs-cache-directory
-                                        "forge-database.sqlite")
+      (setq forge-database-file (expand-file-name "forge-database.sqlite"
+                                                  spacemacs-cache-directory)
             forge-add-default-bindings nil)
       (spacemacs/set-leader-keys-for-major-mode 'forge-topic-mode
         "a" 'forge-edit-topic-assignees


### PR DESCRIPTION
Use `expand-file-name` instead of `concat` to expand `~` to the user's home directory. Fixes #16014.