### PR TITLE
*layers/+lang/emacs-lisp/packages.el: remove unused dependency

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -40,7 +40,6 @@
     ggtags
     counsel-gtags
     (ielm :location built-in)
-    treeview
     (inspector :location (recipe
                           :fetcher github
                           :repo "mmontone/emacs-inspector"))
@@ -300,10 +299,6 @@
   ;; Make flycheck recognize packages in loadpath
   ;; i.e (require 'company) will not give an error now
   (setq flycheck-emacs-lisp-load-path 'inherit))
-
-(defun emacs-lisp/init-treeview ()
-  (use-package treeview
-    :defer t))
 
 (defun emacs-lisp/init-flycheck-package ()
   (use-package flycheck-package


### PR DESCRIPTION
The PR #15999 was tried to fix the `tree-inspector` dependent on the `treeview` pacakge, at that time the `tree-inspector` was in the  `inspector` repo, and the package.el can't process their dependencie eligantly.

According the https://github.com/mmontone/emacs-inspector/pull/25 , `tree-inspector` was split into standalone git repo [emacs-tree-inspector](https://github.com/mmontone/emacs-tree-inspector) , and then the `treeview` dependency will be proceed correctly without additional changes.

Spacemacs provide the `inspector` (not the `tree-inspector`), won't dependent on the `treeview`, so remove it from dependency.