### PR TITLE
Fix search on trampe can't execute if local tools exists

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -93,7 +93,7 @@
    `(cond
      ,@(mapcar
         (lambda (x)
-          `((executable-find ,x)
+          `((executable-find ,x t)
             ',(let ((func
                      (intern
                       (format (if default-inputp


### PR DESCRIPTION
Hi,

The `dotspacemacs-search-tools` defined "rg" "ag" ... "grep".
If the "rg" installed in the `$HOME/.local/bin/rg`, 
try to open a dir /`sudo::/tmp/` via tramp,
then try to search on the folder with `spacemacs/helm-dir-smart-do-search` (SPC s d), 
the `executable-find` get the "rg" (it's in user's path), but failed on running "rg" with tramp for it's not in sudo user's path.

With this patch, the `executable-find` will work with tramp, can find the excutable correctly and get search result correctly.