### PR TITLE
 fix(spacemacs-buffer): incorrect type on mouse click (#15960) 

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -101,6 +101,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - The property =:powerline-scale= of variable =dotspacemacs-default-font= has
   been removed and replaced by the property =:separator-scale= used in the new
   dotfile variable =dotspacemacs-mode-line-theme=.
+- Fix issue where clicking on the recent files list in the Spacemacs buffer would
+  produce a type error.
 **** Layers
 ***** Spacemacs distribution layers
 - Key bindings:

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1487,7 +1487,7 @@ version of `widget-button-press' since `widget-button-click' doesn't work."
     (let ((pos (widget-event-point event)))
       (goto-char pos)
       (when-let ((button (get-char-property pos 'button)))
-        (widget-apply-action pos)))))
+        (widget-apply-action button)))))
 
 (defun spacemacs-buffer/jump-to-number-startup-list-line ()
   "Jump to the startup list line with the typed number.


### PR DESCRIPTION
Fix an issue where seemingly the wrong type was passed to widget-apply-action.

This fixes #15960.