### PR TITLE
Remove superfluous progns in use-package

### DIFF
--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -56,58 +56,56 @@
     (use-package agda2-mode
       :defer t
       :init (when agda-mode-path (load-file agda-mode-path))
-      (progn
-        (mapc
-         (lambda (x) (add-to-list 'face-remapping-alist x))
-         '((agda2-highlight-datatype-face              . font-lock-type-face)
-           (agda2-highlight-function-face              . font-lock-type-face)
-           (agda2-highlight-inductive-constructor-face . font-lock-function-name-face)
-           (agda2-highlight-keyword-face               . font-lock-keyword-face)
-           (agda2-highlight-module-face                . font-lock-constant-face)
-           (agda2-highlight-number-face                . nil)
-           (agda2-highlight-postulate-face             . font-lock-type-face)
-           (agda2-highlight-primitive-type-face        . font-lock-type-face)
-           (agda2-highlight-record-face                . font-lock-type-face))))
+      (mapc
+       (lambda (x) (add-to-list 'face-remapping-alist x))
+       '((agda2-highlight-datatype-face              . font-lock-type-face)
+         (agda2-highlight-function-face              . font-lock-type-face)
+         (agda2-highlight-inductive-constructor-face . font-lock-function-name-face)
+         (agda2-highlight-keyword-face               . font-lock-keyword-face)
+         (agda2-highlight-module-face                . font-lock-constant-face)
+         (agda2-highlight-number-face                . nil)
+         (agda2-highlight-postulate-face             . font-lock-type-face)
+         (agda2-highlight-primitive-type-face        . font-lock-type-face)
+         (agda2-highlight-record-face                . font-lock-type-face)))
       :config
-      (progn
-        ; don't lose indentation on paste
-        (add-to-list 'spacemacs-indent-sensitive-modes 'agda2-mode)
+                                        ; don't lose indentation on paste
+      (add-to-list 'spacemacs-indent-sensitive-modes 'agda2-mode)
 
-        (spacemacs|define-transient-state goal-navigation
-          :title "Goal Navigation Transient State"
-          :doc "\n[_f_] next [_b_] previous [_q_] quit"
-          :bindings
-          ("f" agda2-next-goal)
-          ("b" agda2-previous-goal)
-          ("q" nil :exit t))
-        (spacemacs/set-leader-keys-for-major-mode 'agda2-mode
-          "f" 'spacemacs/goal-navigation-transient-state/agda2-next-goal
-          "b" 'spacemacs/goal-navigation-transient-state/agda2-previous-goal)
+      (spacemacs|define-transient-state goal-navigation
+        :title "Goal Navigation Transient State"
+        :doc "\n[_f_] next [_b_] previous [_q_] quit"
+        :bindings
+        ("f" agda2-next-goal)
+        ("b" agda2-previous-goal)
+        ("q" nil :exit t))
+      (spacemacs/set-leader-keys-for-major-mode 'agda2-mode
+        "f" 'spacemacs/goal-navigation-transient-state/agda2-next-goal
+        "b" 'spacemacs/goal-navigation-transient-state/agda2-previous-goal)
 
-        (spacemacs/set-leader-keys-for-major-mode 'agda2-mode
-          "?"   'agda2-show-goals
-          "."   'agda2-goal-and-context-and-inferred
-          ","   'agda2-goal-and-context
-          "="   'agda2-show-constraints
-          "SPC" 'agda2-give
-          "a"   agda2-auto
-          "c"   'agda2-make-case
-          "d"   'agda2-infer-type-maybe-toplevel
-          "e"   'agda2-show-context
-          "gG"  'agda2-go-back
-          "h"   'agda2-helper-function-type
-          "l"   'agda2-load
-          "n"   'agda2-compute-normalised-maybe-toplevel
-          "p"   'agda2-module-contents-maybe-toplevel
-          "r"   'agda2-refine
-          "s"   'agda2-solveAll
-          "t"   'agda2-goal-type
-          "w"   'agda2-why-in-scope-maybe-toplevel
-          "xc"  'agda2-compile
-          "xd"  'agda2-remove-annotations
-          "xh"  'agda2-display-implicit-arguments
-          "xq"  'agda2-quit
-          "xr"  'agda2-restart)))))
+      (spacemacs/set-leader-keys-for-major-mode 'agda2-mode
+        "?"   'agda2-show-goals
+        "."   'agda2-goal-and-context-and-inferred
+        ","   'agda2-goal-and-context
+        "="   'agda2-show-constraints
+        "SPC" 'agda2-give
+        "a"   agda2-auto
+        "c"   'agda2-make-case
+        "d"   'agda2-infer-type-maybe-toplevel
+        "e"   'agda2-show-context
+        "gG"  'agda2-go-back
+        "h"   'agda2-helper-function-type
+        "l"   'agda2-load
+        "n"   'agda2-compute-normalised-maybe-toplevel
+        "p"   'agda2-module-contents-maybe-toplevel
+        "r"   'agda2-refine
+        "s"   'agda2-solveAll
+        "t"   'agda2-goal-type
+        "w"   'agda2-why-in-scope-maybe-toplevel
+        "xc"  'agda2-compile
+        "xd"  'agda2-remove-annotations
+        "xh"  'agda2-display-implicit-arguments
+        "xq"  'agda2-quit
+        "xr"  'agda2-restart))))
 
 (defun agda/pre-init-golden-ratio ()
   (spacemacs|use-package-add-hook golden-ratio

--- a/layers/+lang/alda/packages.el
+++ b/layers/+lang/alda/packages.el
@@ -34,9 +34,8 @@
                alda-play-line
                alda-play-buffer)
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'alda-mode
-        "b" 'alda-play-buffer
-        "c" 'alda-play-block
-        "n" 'alda-play-line
-        "r" 'alda-play-region))))
+    (spacemacs/set-leader-keys-for-major-mode 'alda-mode
+      "b" 'alda-play-buffer
+      "c" 'alda-play-block
+      "n" 'alda-play-line
+      "r" 'alda-play-region)))

--- a/layers/+lang/asciidoc/packages.el
+++ b/layers/+lang/asciidoc/packages.el
@@ -31,28 +31,27 @@
     :mode (("\\.adoc?\\'" . adoc-mode))
 		:defer t
     :config
-    (progn
-      ;; We have quite a lot of possible keybindings.
-      ;; See `adoc-mode.el', its bottom part where the huge easy-menu
-      ;; is defined and after that, where the various `tempo-template-*'
-      ;; functions are defined.
+    ;; We have quite a lot of possible keybindings.
+    ;; See `adoc-mode.el', its bottom part where the huge easy-menu
+    ;; is defined and after that, where the various `tempo-template-*'
+    ;; functions are defined.
 
-      ;; See /doc/CONVENTIONS.md#plain-text-markup-languages
-      (spacemacs/set-leader-keys-for-major-mode 'adoc-mode
-        "h1" 'tempo-template-adoc-title-1
-        ;; Alternative method of inserting top-level heading
-        "hI" 'tempo-template-adoc-title-1
-        "h2" 'tempo-template-adoc-title-2
-        ;; Alternative method of inserting the most usual heading
-        "hi" 'tempo-template-adoc-title-2
-        "h3" 'tempo-template-adoc-title-3
-        "h4" 'tempo-template-adoc-title-4
-        "h5" 'tempo-template-adoc-title-5
-        "xb" 'tempo-template-adoc-strong
-        "xi" 'tempo-template-adoc-emphasis)
-      ;; yes, exactly like that. To "promote" title is to INCREASE its size.
-      ;; `adoc-demote' does the opposite: increases its LEVEL,
-      ;; which DECREASES its size.
-      (define-key adoc-mode-map (kbd "M-h") 'adoc-demote)
-      ;; see the comment about  adoc-demote above
-      (define-key adoc-mode-map (kbd "M-l") 'adoc-promote))))
+    ;; See /doc/CONVENTIONS.md#plain-text-markup-languages
+    (spacemacs/set-leader-keys-for-major-mode 'adoc-mode
+      "h1" 'tempo-template-adoc-title-1
+      ;; Alternative method of inserting top-level heading
+      "hI" 'tempo-template-adoc-title-1
+      "h2" 'tempo-template-adoc-title-2
+      ;; Alternative method of inserting the most usual heading
+      "hi" 'tempo-template-adoc-title-2
+      "h3" 'tempo-template-adoc-title-3
+      "h4" 'tempo-template-adoc-title-4
+      "h5" 'tempo-template-adoc-title-5
+      "xb" 'tempo-template-adoc-strong
+      "xi" 'tempo-template-adoc-emphasis)
+    ;; yes, exactly like that. To "promote" title is to INCREASE its size.
+    ;; `adoc-demote' does the opposite: increases its LEVEL,
+    ;; which DECREASES its size.
+    (define-key adoc-mode-map (kbd "M-h") 'adoc-demote)
+    ;; see the comment about  adoc-demote above
+    (define-key adoc-mode-map (kbd "M-l") 'adoc-promote)))

--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -38,11 +38,10 @@
     :init
     (spacemacs/set-leader-keys-for-major-mode 'asm-mode "h" 'x86-lookup)
     :config
-    (progn
-      ;; We need to insert a non-indented line, otherwise it's annoying
-      ;; every time we insert a comment for a routine
-      (define-key asm-mode-map (kbd "C-j") 'newline)
-      (add-hook 'asm-mode-hook #'asm-generic-setup))))
+    ;; We need to insert a non-indented line, otherwise it's annoying
+    ;; every time we insert a comment for a routine
+    (define-key asm-mode-map (kbd "C-j") 'newline)
+    (add-hook 'asm-mode-hook #'asm-generic-setup)))
 
 (defun asm/post-init-electric-indent-mode ()
   (spacemacs/add-to-hooks 'asm-electric-indent-local-mode-off
@@ -52,26 +51,23 @@
   "Setup for built-in `nasm-mode', which could be thought as improved `asm-mode'"
   (use-package nasm-mode
     :init
-    (progn
-      (add-hook 'nasm-mode-hook #'asm-generic-setup)
-      (add-to-list 'auto-mode-alist '("\\.[n]*\\(asm\\|s\\)\\'" . nasm-mode))
-      (spacemacs/set-leader-keys-for-major-mode 'nasm-mode "h" 'x86-lookup))
+    (add-hook 'nasm-mode-hook #'asm-generic-setup)
+    (add-to-list 'auto-mode-alist '("\\.[n]*\\(asm\\|s\\)\\'" . nasm-mode))
+    (spacemacs/set-leader-keys-for-major-mode 'nasm-mode "h" 'x86-lookup)
     :config
-    (progn
-      ;; We need to insert a non-indented line, otherwise it's annoying
-      ;; every time we insert a comment for a routine
-      (define-key nasm-mode-map (kbd "C-j") 'newline)
-      ;; we use the advised `asm-colon' because `nasm-colon indents the whole line, even
-      ;; inside a comment
-      (define-key nasm-mode-map (kbd ":") 'asm-colon))))
+    ;; We need to insert a non-indented line, otherwise it's annoying
+    ;; every time we insert a comment for a routine
+    (define-key nasm-mode-map (kbd "C-j") 'newline)
+    ;; we use the advised `asm-colon' because `nasm-colon indents the whole line, even
+    ;; inside a comment
+    (define-key nasm-mode-map (kbd ":") 'asm-colon)))
 
 (defun asm/init-x86-lookup ()
   (use-package x86-lookup
     :init
-    (progn
-      ;; when a user installed `pdf-tools', use it for viewing PDF document.
-      (when (package-installed-p 'pdf-tools)
-        (setq x86-lookup-browse-pdf-function 'x86-lookup-browse-pdf-pdf-tools)))))
+    ;; when a user installed `pdf-tools', use it for viewing PDF document.
+    (when (package-installed-p 'pdf-tools)
+      (setq x86-lookup-browse-pdf-function 'x86-lookup-browse-pdf-pdf-tools))))
 
 (defun asm/post-init-company ()
   (spacemacs|add-company-backends :modes asm-mode nasm-mode))

--- a/layers/+lang/autohotkey/packages.el
+++ b/layers/+lang/autohotkey/packages.el
@@ -33,19 +33,18 @@
     :mode "\\.ahk\\'"
     :defer t
     :init
-    (progn
-      ;; work-around for issue #21
-      ;; https://github.com/ralesi/ahk-mode/issues/21
-      (add-hook 'ahk-mode-hook 'spacemacs/run-prog-mode-hooks)
-      (spacemacs/declare-prefix-for-mode 'ahk-mode "mc" "comment")
-      (spacemacs/declare-prefix-for-mode 'ahk-mode "me" "eval")
-      (spacemacs/declare-prefix-for-mode 'ahk-mode "mh" "help")
-      (spacemacs/set-leader-keys-for-major-mode 'ahk-mode
-        "cb" 'ahk-comment-block-dwim
-        "cc" 'ahk-comment-dwim
-        "eb" 'ahk-run-script
-        "hh" 'ahk-lookup-web
-        "hH" 'ahk-lookup-chm))))
+    ;; work-around for issue #21
+    ;; https://github.com/ralesi/ahk-mode/issues/21
+    (add-hook 'ahk-mode-hook 'spacemacs/run-prog-mode-hooks)
+    (spacemacs/declare-prefix-for-mode 'ahk-mode "mc" "comment")
+    (spacemacs/declare-prefix-for-mode 'ahk-mode "me" "eval")
+    (spacemacs/declare-prefix-for-mode 'ahk-mode "mh" "help")
+    (spacemacs/set-leader-keys-for-major-mode 'ahk-mode
+      "cb" 'ahk-comment-block-dwim
+      "cc" 'ahk-comment-dwim
+      "eb" 'ahk-run-script
+      "hh" 'ahk-lookup-web
+      "hH" 'ahk-lookup-chm)))
 
 (defun autohotkey/post-init-company ()
   (spacemacs|add-company-backends

--- a/layers/+lang/bibtex/packages.el
+++ b/layers/+lang/bibtex/packages.el
@@ -76,42 +76,41 @@
                isbn-to-bibtex
                pubmed-insert-bibtex-from-pmid)
     :init
-    (progn
-      (add-hook 'org-mode-hook (lambda () (require 'org-ref)))
+    (add-hook 'org-mode-hook (lambda () (require 'org-ref)))
 
-      (cond ((configuration-layer/layer-used-p 'helm)
-             (setq org-ref-completion-library 'org-ref-helm-bibtex))
-            ((configuration-layer/layer-used-p 'ivy)
-             (setq org-ref-completion-library 'org-ref-ivy-cite)))
+    (cond ((configuration-layer/layer-used-p 'helm)
+           (setq org-ref-completion-library 'org-ref-helm-bibtex))
+          ((configuration-layer/layer-used-p 'ivy)
+           (setq org-ref-completion-library 'org-ref-ivy-cite)))
 
-      (evil-define-key 'normal bibtex-mode-map
-        (kbd "C-j") 'org-ref-bibtex-next-entry
-        (kbd "C-k") 'org-ref-bibtex-previous-entry
-        "gj" 'org-ref-bibtex-next-entry
-        "gk" 'org-ref-bibtex-previous-entry)
+    (evil-define-key 'normal bibtex-mode-map
+      (kbd "C-j") 'org-ref-bibtex-next-entry
+      (kbd "C-k") 'org-ref-bibtex-previous-entry
+      "gj" 'org-ref-bibtex-next-entry
+      "gk" 'org-ref-bibtex-previous-entry)
 
-      (spacemacs/declare-prefix-for-mode 'bibtex-mode "ml" "lookup")
-      (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
-        ;; Navigation
-        "j" 'org-ref-bibtex-next-entry
-        "k" 'org-ref-bibtex-previous-entry
+    (spacemacs/declare-prefix-for-mode 'bibtex-mode "ml" "lookup")
+    (spacemacs/set-leader-keys-for-major-mode 'bibtex-mode
+      ;; Navigation
+      "j" 'org-ref-bibtex-next-entry
+      "k" 'org-ref-bibtex-previous-entry
 
-        ;; Open
-        "b" 'org-ref-open-in-browser
-        "n" 'org-ref-open-bibtex-notes
-        "p" 'org-ref-open-bibtex-pdf
+      ;; Open
+      "b" 'org-ref-open-in-browser
+      "n" 'org-ref-open-bibtex-notes
+      "p" 'org-ref-open-bibtex-pdf
 
-        ;; Misc
-        "h" 'org-ref-bibtex-hydra/body
-        "i" 'org-ref-bibtex-hydra/org-ref-bibtex-new-entry/body-and-exit
-        "s" 'org-ref-sort-bibtex-entry
+      ;; Misc
+      "h" 'org-ref-bibtex-hydra/body
+      "i" 'org-ref-bibtex-hydra/org-ref-bibtex-new-entry/body-and-exit
+      "s" 'org-ref-sort-bibtex-entry
 
-        ;; Lookup utilities
-        "la" 'arxiv-add-bibtex-entry
-        "lA" 'arxiv-get-pdf-add-bibtex-entry
-        "ld" 'doi-utils-add-bibtex-entry-from-doi
-        "li" 'isbn-to-bibtex
-        "lp" 'pubmed-insert-bibtex-from-pmid))))
+      ;; Lookup utilities
+      "la" 'arxiv-add-bibtex-entry
+      "lA" 'arxiv-get-pdf-add-bibtex-entry
+      "ld" 'doi-utils-add-bibtex-entry-from-doi
+      "li" 'isbn-to-bibtex
+      "lp" 'pubmed-insert-bibtex-from-pmid)))
 
 (defun bibtex/init-ebib ()
   (use-package ebib

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -80,25 +80,23 @@
   (use-package cc-mode
     :defer t
     :init
-    (progn
-      (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-backend)
-      (add-hook 'c++-mode-local-vars-hook #'spacemacs//c-c++-setup-backend)
-      (put 'c-c++-backend 'safe-local-variable 'symbolp)
-      (when c-c++-default-mode-for-headers
-        (add-to-list 'auto-mode-alist
-                     `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
-      (when c-c++-enable-auto-newline
-        (add-hook 'c-mode-common-hook 'spacemacs//c-toggle-auto-newline)))
+    (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-backend)
+    (add-hook 'c++-mode-local-vars-hook #'spacemacs//c-c++-setup-backend)
+    (put 'c-c++-backend 'safe-local-variable 'symbolp)
+    (when c-c++-default-mode-for-headers
+      (add-to-list 'auto-mode-alist
+                   `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
+    (when c-c++-enable-auto-newline
+      (add-hook 'c-mode-common-hook 'spacemacs//c-toggle-auto-newline))
     :config
-    (progn
-      (require 'compile)
-      (dolist (mode c-c++-modes)
-        (spacemacs/declare-prefix-for-mode mode "mc" "compile")
-        (spacemacs/declare-prefix-for-mode mode "mg" "goto")
-        (spacemacs/declare-prefix-for-mode mode "mp" "project")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "ga" 'projectile-find-other-file
-          "gA" 'projectile-find-other-file-other-window)))))
+    (require 'compile)
+    (dolist (mode c-c++-modes)
+      (spacemacs/declare-prefix-for-mode mode "mc" "compile")
+      (spacemacs/declare-prefix-for-mode mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode mode "mp" "project")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "ga" 'projectile-find-other-file
+        "gA" 'projectile-find-other-file-other-window))))
 
 (defun c-c++/init-ccls ()
   (use-package ccls
@@ -137,15 +135,14 @@
   (use-package cpp-auto-include
     :defer t
     :init
-    (progn
-      (when c-c++-enable-organize-includes-on-save
-        (add-hook 'c++-mode-hook #'spacemacs/c-c++-organize-includes-on-save))
+    (when c-c++-enable-organize-includes-on-save
+      (add-hook 'c++-mode-hook #'spacemacs/c-c++-organize-includes-on-save))
 
-      (spacemacs/declare-prefix-for-mode 'c++-mode
-        "mr" "refactor")
+    (spacemacs/declare-prefix-for-mode 'c++-mode
+      "mr" "refactor")
 
-      (spacemacs/set-leader-keys-for-major-mode 'c++-mode
-        "ri" #'spacemacs/c-c++-organize-includes))))
+    (spacemacs/set-leader-keys-for-major-mode 'c++-mode
+      "ri" #'spacemacs/c-c++-organize-includes)))
 
 (defun c-c++/pre-init-dap-mode ()
   (pcase c-c++-backend
@@ -161,10 +158,9 @@
     :defer t
     :commands (disaster)
     :init
-    (progn
-      (dolist (mode c-c++-modes)
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "D" 'disaster)))))
+    (dolist (mode c-c++-modes)
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "D" 'disaster))))
 
 (defun c-c++/post-init-eldoc ()
   (add-hook 'c-mode-local-vars-hook #'spacemacs//c-c++-setup-eldoc)
@@ -200,11 +196,10 @@
   (use-package google-c-style
     :defer t
     :init
-    (progn
-      (when c-c++-enable-google-style
-        (add-hook 'c-mode-common-hook 'google-set-c-style))
-      (when c-c++-enable-google-newline
-        (add-hook 'c-mode-common-hook 'google-make-newline-indent)))))
+    (when c-c++-enable-google-style
+      (add-hook 'c-mode-common-hook 'google-set-c-style))
+    (when c-c++-enable-google-newline
+      (add-hook 'c-mode-common-hook 'google-make-newline-indent))))
 
 (defun c-c++/pre-init-helm-cscope ()
   (spacemacs|use-package-add-hook xcscope
@@ -229,12 +224,11 @@
 (defun c-c++/pre-init-projectile ()
   (spacemacs|use-package-add-hook projectile
     :post-config
-    (progn
-      (when c-c++-adopt-subprojects
-        (setq projectile-project-root-files-top-down-recurring
-              (append '("compile_commands.json"
-                        ".ccls")
-                      projectile-project-root-files-top-down-recurring))))))
+    (when c-c++-adopt-subprojects
+      (setq projectile-project-root-files-top-down-recurring
+            (append '("compile_commands.json"
+                      ".ccls")
+                    projectile-project-root-files-top-down-recurring)))))
 
 (defun c-c++/init-rtags ()
   ;; config in `funcs.el'
@@ -267,9 +261,8 @@
   (use-package ycmd
     :defer t
     :init
-    (progn
-      (unless (boundp 'ycmd-global-config)
-        (setq-default ycmd-global-config
-                      (concat (configuration-layer/get-layer-path 'ycmd)
-                              "global_conf.py")))
-      (setq-default ycmd-parse-conditions '(save mode-enabled)))))
+    (unless (boundp 'ycmd-global-config)
+      (setq-default ycmd-global-config
+                    (concat (configuration-layer/get-layer-path 'ycmd)
+                            "global_conf.py")))
+    (setq-default ycmd-parse-conditions '(save mode-enabled))))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -56,277 +56,275 @@
   (use-package cider
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'cider 'cider-jack-in "cider")
-      (setq cider-stacktrace-default-filters '(tooling dup)
-            cider-repl-pop-to-buffer-on-connect nil
-            cider-prompt-save-file-on-load nil
-            cider-repl-use-clojure-font-lock t
-            cider-repl-history-file (concat spacemacs-cache-directory "cider-repl-history"))
-      (add-hook 'clojure-mode-hook 'cider-mode)
+    (spacemacs/register-repl 'cider 'cider-jack-in "cider")
+    (setq cider-stacktrace-default-filters '(tooling dup)
+          cider-repl-pop-to-buffer-on-connect nil
+          cider-prompt-save-file-on-load nil
+          cider-repl-use-clojure-font-lock t
+          cider-repl-history-file (concat spacemacs-cache-directory "cider-repl-history"))
+    (add-hook 'clojure-mode-hook 'cider-mode)
 
-      (dolist (x '(spacemacs-jump-handlers-clojure-mode
-                   spacemacs-jump-handlers-clojurec-mode
-                   spacemacs-jump-handlers-clojurescript-mode
-                   spacemacs-jump-handlers-clojurex-mode
-                   spacemacs-jump-handlers-cider-repl-mode))
-        (add-to-list x '(spacemacs/clj-find-var :async t)))
+    (dolist (x '(spacemacs-jump-handlers-clojure-mode
+                 spacemacs-jump-handlers-clojurec-mode
+                 spacemacs-jump-handlers-clojurescript-mode
+                 spacemacs-jump-handlers-clojurex-mode
+                 spacemacs-jump-handlers-cider-repl-mode))
+      (add-to-list x '(spacemacs/clj-find-var :async t)))
 
-      ;; TODO: having this work for cider-macroexpansion-mode would be nice,
-      ;;       but the problem is that it uses clojure-mode as its major-mode
-      (let ((cider--key-binding-prefixes
-             '(("m=e" . "edn")
-               ("md" . "debug")
-               ("mdv" . "inspect values")
-               ("me" . "evaluation")
-               ("men" . "namespace")
-               ("mep" . "pretty print")
-               ("mm" . "manage repls")
-               ("mml" . "link session")
-               ("mmS" . "sibling sessions")
-               ("mmq" . "quit/restart")
-               ("mp" . "profile")
-               ("ms" . "send to repl")
-               ("msc" . "connect external repl")
-               ("msj" . "jack-in")
-               ("msq" . "quit/restart repl")
-               ("mt" . "test")))
-            (cider--key-binding-non-lsp-prefixes
-             '(("m=" . "format")
-               ("mg" . "goto") ;; no lsp
-               ("mh" . "documentation")
-               ("mT" . "toggle"))))
-        (spacemacs|forall-clojure-modes m
-          (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                              m (car x) (cdr x)))
-                cider--key-binding-prefixes)
-          (unless (eq clojure-backend 'lsp)
-            (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                                m (car x) (cdr x)))
-                  cider--key-binding-non-lsp-prefixes)
-            (spacemacs/set-leader-keys-for-major-mode m
-              "hh" 'cider-doc
-              "=r" 'cider-format-region
-              "ge" 'cider-jump-to-compilation-error
-              "gr" 'cider-find-resource
-              "gs" 'cider-browse-spec
-              "gS" 'cider-browse-spec-all))
-          (spacemacs/set-leader-keys-for-major-mode m
-            ;; shortcuts
-            "'"  'sesman-start
-            ;; help / documentation
-            "ha" 'cider-apropos
-            "hc" 'cider-cheatsheet
-            "hd" 'cider-clojuredocs
-            "hj" 'cider-javadoc
-            "hn" 'cider-browse-ns
-            "hN" 'cider-browse-ns-all
-            "hs" 'cider-browse-spec
-            "hS" 'cider-browse-spec-all
-            ;; evaluate in source code buffer
-            "e;" 'cider-eval-defun-to-comment
-            "e$" 'spacemacs/cider-eval-sexp-end-of-line
-            "e(" 'cider-eval-list-at-point
-            "eb" 'cider-eval-buffer
-            "ee" 'cider-eval-last-sexp
-            "ef" 'cider-eval-defun-at-point
-            "ei" 'cider-interrupt
-            "el" 'spacemacs/cider-eval-sexp-end-of-line
-            "em" 'cider-macroexpand-1
-            "eM" 'cider-macroexpand-all
-            "ena" 'cider-ns-reload-all
-            "enn" 'cider-eval-ns-form
-            "enr" 'cider-ns-refresh
-            "enl" 'cider-ns-reload  ;; SPC u for cider-ns-reload-all
-            "ep;" 'cider-pprint-eval-defun-to-comment
-            "ep:" 'cider-pprint-eval-last-sexp-to-comment
-            "epf" 'cider-pprint-eval-defun-at-point
-            "epe" 'cider-pprint-eval-last-sexp
-            "er" 'cider-eval-region
-            "eu" 'cider-undef
-            "ev" 'cider-eval-sexp-at-point
-            "eV" 'cider-eval-sexp-up-to-point
-            "ew" 'cider-eval-last-sexp-and-replace
-            ;; format code style
-            "==" 'cider-format-buffer
-            "=eb" 'cider-format-edn-buffer
-            "=ee" 'cider-format-edn-last-sexp
-            "=er" 'cider-format-edn-region
-            "=f" 'cider-format-defun
-            ;; goto
-            "gb" 'cider-pop-back
-            "gc" 'cider-classpath
-            "gg" 'spacemacs/clj-find-var
-            "gn" 'cider-find-ns
-            ;; manage cider connections / sesman
-            "mb" 'sesman-browser
-            "mi" 'sesman-info
-            "mg" 'sesman-goto
-            "mlb" 'sesman-link-with-buffer
-            "mld" 'sesman-link-with-directory
-            "mlu" 'sesman-unlink
-            "mqq" 'sesman-quit
-            "mqr" 'sesman-restart
-            "mlp" 'sesman-link-with-project
-            "mSj" 'cider-connect-sibling-clj
-            "mSs" 'cider-connect-sibling-cljs
-            "ms" 'sesman-start
-            ;; send code - spacemacs convention
-            "sa" (if (eq m 'cider-repl-mode)
-                     'cider-switch-to-last-clojure-buffer
-                   'cider-switch-to-repl-buffer)
-            "sb" 'cider-load-buffer
-            "sB" 'spacemacs/cider-send-buffer-in-repl-and-focus
-            "scj" 'cider-connect-clj
-            "scm" 'cider-connect-clj&cljs
-            "scs" 'cider-connect-cljs
-            "se" 'spacemacs/cider-send-last-sexp-to-repl
-            "sE" 'spacemacs/cider-send-last-sexp-to-repl-focus
-            "sf" 'spacemacs/cider-send-function-to-repl
-            "sF" 'spacemacs/cider-send-function-to-repl-focus
-            "si" 'sesman-start
-            "sjj" 'cider-jack-in-clj
-            "sjm" 'cider-jack-in-clj&cljs
-            "sjs" 'cider-jack-in-cljs
-            "sl" 'spacemacs/cider-find-and-clear-repl-buffer
-            "sL" 'cider-find-and-clear-repl-output
-            "sn" 'spacemacs/cider-send-ns-form-to-repl
-            "sN" 'spacemacs/cider-send-ns-form-to-repl-focus
-            "so" 'cider-repl-switch-to-other
-            "sqq" 'cider-quit
-            "sqr" 'cider-restart
-            "sqn" 'cider-ns-reload
-            "sqN" 'cider-ns-reload-all
-            "sr" 'spacemacs/cider-send-region-to-repl
-            "sR" 'spacemacs/cider-send-region-to-repl-focus
-            "su" 'cider-repl-require-repl-utils
-            ;; toggle options
-            "Te" 'cider-enlighten-mode
-            "Tf" 'spacemacs/cider-toggle-repl-font-locking
-            "Tp" 'spacemacs/cider-toggle-repl-pretty-printing
-            "Tt" 'cider-auto-test-mode
-            ;; cider-tests
-            "ta" 'spacemacs/cider-test-run-all-tests
-            "tb" 'cider-test-show-report
-            "tl" 'spacemacs/cider-test-run-loaded-tests
-            "tn" 'spacemacs/cider-test-run-ns-tests
-            "tp" 'spacemacs/cider-test-run-project-tests
-            "tr" 'spacemacs/cider-test-rerun-failed-tests
-            "tt" 'spacemacs/cider-test-run-focused-test
-            ;; cider-debug and inspect
-            "db" 'cider-debug-defun-at-point
-            "de" 'spacemacs/cider-display-error-buffer
-            "dve" 'cider-inspect-last-sexp
-            "dvf" 'cider-inspect-defun-at-point
-            "dvi" 'cider-inspect
-            "dvl" 'cider-inspect-last-result
-            "dvv" 'cider-inspect-expr
-            ;; profile
-            "p+" 'cider-profile-samples
-            "pc" 'cider-profile-clear
-            "pn" 'cider-profile-ns-toggle
-            "ps" 'cider-profile-var-summary
-            "pS" 'cider-profile-summary
-            "pt" 'cider-profile-toggle
-            "pv" 'cider-profile-var-profiled-p)))
+    ;; TODO: having this work for cider-macroexpansion-mode would be nice,
+    ;;       but the problem is that it uses clojure-mode as its major-mode
+    (let ((cider--key-binding-prefixes
+           '(("m=e" . "edn")
+             ("md" . "debug")
+             ("mdv" . "inspect values")
+             ("me" . "evaluation")
+             ("men" . "namespace")
+             ("mep" . "pretty print")
+             ("mm" . "manage repls")
+             ("mml" . "link session")
+             ("mmS" . "sibling sessions")
+             ("mmq" . "quit/restart")
+             ("mp" . "profile")
+             ("ms" . "send to repl")
+             ("msc" . "connect external repl")
+             ("msj" . "jack-in")
+             ("msq" . "quit/restart repl")
+             ("mt" . "test")))
+          (cider--key-binding-non-lsp-prefixes
+           '(("m=" . "format")
+             ("mg" . "goto") ;; no lsp
+             ("mh" . "documentation")
+             ("mT" . "toggle"))))
+      (spacemacs|forall-clojure-modes m
+                                      (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                                                          m (car x) (cdr x)))
+                                            cider--key-binding-prefixes)
+                                      (unless (eq clojure-backend 'lsp)
+                                        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                                                            m (car x) (cdr x)))
+                                              cider--key-binding-non-lsp-prefixes)
+                                        (spacemacs/set-leader-keys-for-major-mode m
+                                          "hh" 'cider-doc
+                                          "=r" 'cider-format-region
+                                          "ge" 'cider-jump-to-compilation-error
+                                          "gr" 'cider-find-resource
+                                          "gs" 'cider-browse-spec
+                                          "gS" 'cider-browse-spec-all))
+                                      (spacemacs/set-leader-keys-for-major-mode m
+                                        ;; shortcuts
+                                        "'"  'sesman-start
+                                        ;; help / documentation
+                                        "ha" 'cider-apropos
+                                        "hc" 'cider-cheatsheet
+                                        "hd" 'cider-clojuredocs
+                                        "hj" 'cider-javadoc
+                                        "hn" 'cider-browse-ns
+                                        "hN" 'cider-browse-ns-all
+                                        "hs" 'cider-browse-spec
+                                        "hS" 'cider-browse-spec-all
+                                        ;; evaluate in source code buffer
+                                        "e;" 'cider-eval-defun-to-comment
+                                        "e$" 'spacemacs/cider-eval-sexp-end-of-line
+                                        "e(" 'cider-eval-list-at-point
+                                        "eb" 'cider-eval-buffer
+                                        "ee" 'cider-eval-last-sexp
+                                        "ef" 'cider-eval-defun-at-point
+                                        "ei" 'cider-interrupt
+                                        "el" 'spacemacs/cider-eval-sexp-end-of-line
+                                        "em" 'cider-macroexpand-1
+                                        "eM" 'cider-macroexpand-all
+                                        "ena" 'cider-ns-reload-all
+                                        "enn" 'cider-eval-ns-form
+                                        "enr" 'cider-ns-refresh
+                                        "enl" 'cider-ns-reload  ;; SPC u for cider-ns-reload-all
+                                        "ep;" 'cider-pprint-eval-defun-to-comment
+                                        "ep:" 'cider-pprint-eval-last-sexp-to-comment
+                                        "epf" 'cider-pprint-eval-defun-at-point
+                                        "epe" 'cider-pprint-eval-last-sexp
+                                        "er" 'cider-eval-region
+                                        "eu" 'cider-undef
+                                        "ev" 'cider-eval-sexp-at-point
+                                        "eV" 'cider-eval-sexp-up-to-point
+                                        "ew" 'cider-eval-last-sexp-and-replace
+                                        ;; format code style
+                                        "==" 'cider-format-buffer
+                                        "=eb" 'cider-format-edn-buffer
+                                        "=ee" 'cider-format-edn-last-sexp
+                                        "=er" 'cider-format-edn-region
+                                        "=f" 'cider-format-defun
+                                        ;; goto
+                                        "gb" 'cider-pop-back
+                                        "gc" 'cider-classpath
+                                        "gg" 'spacemacs/clj-find-var
+                                        "gn" 'cider-find-ns
+                                        ;; manage cider connections / sesman
+                                        "mb" 'sesman-browser
+                                        "mi" 'sesman-info
+                                        "mg" 'sesman-goto
+                                        "mlb" 'sesman-link-with-buffer
+                                        "mld" 'sesman-link-with-directory
+                                        "mlu" 'sesman-unlink
+                                        "mqq" 'sesman-quit
+                                        "mqr" 'sesman-restart
+                                        "mlp" 'sesman-link-with-project
+                                        "mSj" 'cider-connect-sibling-clj
+                                        "mSs" 'cider-connect-sibling-cljs
+                                        "ms" 'sesman-start
+                                        ;; send code - spacemacs convention
+                                        "sa" (if (eq m 'cider-repl-mode)
+                                                 'cider-switch-to-last-clojure-buffer
+                                               'cider-switch-to-repl-buffer)
+                                        "sb" 'cider-load-buffer
+                                        "sB" 'spacemacs/cider-send-buffer-in-repl-and-focus
+                                        "scj" 'cider-connect-clj
+                                        "scm" 'cider-connect-clj&cljs
+                                        "scs" 'cider-connect-cljs
+                                        "se" 'spacemacs/cider-send-last-sexp-to-repl
+                                        "sE" 'spacemacs/cider-send-last-sexp-to-repl-focus
+                                        "sf" 'spacemacs/cider-send-function-to-repl
+                                        "sF" 'spacemacs/cider-send-function-to-repl-focus
+                                        "si" 'sesman-start
+                                        "sjj" 'cider-jack-in-clj
+                                        "sjm" 'cider-jack-in-clj&cljs
+                                        "sjs" 'cider-jack-in-cljs
+                                        "sl" 'spacemacs/cider-find-and-clear-repl-buffer
+                                        "sL" 'cider-find-and-clear-repl-output
+                                        "sn" 'spacemacs/cider-send-ns-form-to-repl
+                                        "sN" 'spacemacs/cider-send-ns-form-to-repl-focus
+                                        "so" 'cider-repl-switch-to-other
+                                        "sqq" 'cider-quit
+                                        "sqr" 'cider-restart
+                                        "sqn" 'cider-ns-reload
+                                        "sqN" 'cider-ns-reload-all
+                                        "sr" 'spacemacs/cider-send-region-to-repl
+                                        "sR" 'spacemacs/cider-send-region-to-repl-focus
+                                        "su" 'cider-repl-require-repl-utils
+                                        ;; toggle options
+                                        "Te" 'cider-enlighten-mode
+                                        "Tf" 'spacemacs/cider-toggle-repl-font-locking
+                                        "Tp" 'spacemacs/cider-toggle-repl-pretty-printing
+                                        "Tt" 'cider-auto-test-mode
+                                        ;; cider-tests
+                                        "ta" 'spacemacs/cider-test-run-all-tests
+                                        "tb" 'cider-test-show-report
+                                        "tl" 'spacemacs/cider-test-run-loaded-tests
+                                        "tn" 'spacemacs/cider-test-run-ns-tests
+                                        "tp" 'spacemacs/cider-test-run-project-tests
+                                        "tr" 'spacemacs/cider-test-rerun-failed-tests
+                                        "tt" 'spacemacs/cider-test-run-focused-test
+                                        ;; cider-debug and inspect
+                                        "db" 'cider-debug-defun-at-point
+                                        "de" 'spacemacs/cider-display-error-buffer
+                                        "dve" 'cider-inspect-last-sexp
+                                        "dvf" 'cider-inspect-defun-at-point
+                                        "dvi" 'cider-inspect
+                                        "dvl" 'cider-inspect-last-result
+                                        "dvv" 'cider-inspect-expr
+                                        ;; profile
+                                        "p+" 'cider-profile-samples
+                                        "pc" 'cider-profile-clear
+                                        "pn" 'cider-profile-ns-toggle
+                                        "ps" 'cider-profile-var-summary
+                                        "pS" 'cider-profile-summary
+                                        "pt" 'cider-profile-toggle
+                                        "pv" 'cider-profile-var-profiled-p)))
 
-      ;; cider-repl-mode only
-      (spacemacs/set-leader-keys-for-major-mode 'cider-repl-mode
-        "," 'cider-repl-handle-shortcut)
-      (spacemacs/set-leader-keys-for-major-mode 'cider-clojure-interaction-mode
-        "epl" 'cider-eval-print-last-sexp))
+    ;; cider-repl-mode only
+    (spacemacs/set-leader-keys-for-major-mode 'cider-repl-mode
+      "," 'cider-repl-handle-shortcut)
+    (spacemacs/set-leader-keys-for-major-mode 'cider-clojure-interaction-mode
+      "epl" 'cider-eval-print-last-sexp)
     :config
-    (progn
-      ;; add support for golden-ratio
-      (with-eval-after-load 'golden-ratio
-        (add-to-list 'golden-ratio-extra-commands 'cider-popup-buffer-quit-function))
-      ;; add support for evil
-      (evil-set-initial-state 'cider-stacktrace-mode 'motion)
-      (evil-set-initial-state 'cider-popup-buffer-mode 'motion)
-      (add-hook 'cider--debug-mode-hook 'spacemacs/cider-debug-setup)
+    ;; add support for golden-ratio
+    (with-eval-after-load 'golden-ratio
+      (add-to-list 'golden-ratio-extra-commands 'cider-popup-buffer-quit-function))
+    ;; add support for evil
+    (evil-set-initial-state 'cider-stacktrace-mode 'motion)
+    (evil-set-initial-state 'cider-popup-buffer-mode 'motion)
+    (add-hook 'cider--debug-mode-hook 'spacemacs/cider-debug-setup)
 
-      (evilified-state-evilify-map cider-stacktrace-mode-map
-        :mode cider-stacktrace-mode
-        :bindings
-        (kbd "C-j") 'cider-stacktrace-next-cause
-        (kbd "C-k") 'cider-stacktrace-previous-cause
-        (kbd "TAB") 'cider-stacktrace-cycle-current-cause
-        (kbd "0")   'cider-stacktrace-cycle-all-causes
-        (kbd "1")   'cider-stacktrace-cycle-cause-1
-        (kbd "2")   'cider-stacktrace-cycle-cause-2
-        (kbd "3")   'cider-stacktrace-cycle-cause-3
-        (kbd "4")   'cider-stacktrace-cycle-cause-4
-        (kbd "5")   'cider-stacktrace-cycle-cause-5
-        (kbd "a")   'cider-stacktrace-toggle-all
-        (kbd "c")   'cider-stacktrace-toggle-clj
-        (kbd "d")   'cider-stacktrace-toggle-duplicates
-        (kbd "J")   'cider-stacktrace-toggle-java
-        (kbd "r")   'cider-stacktrace-toggle-repl
-        (kbd "T")   'cider-stacktrace-toggle-tooling)
+    (evilified-state-evilify-map cider-stacktrace-mode-map
+      :mode cider-stacktrace-mode
+      :bindings
+      (kbd "C-j") 'cider-stacktrace-next-cause
+      (kbd "C-k") 'cider-stacktrace-previous-cause
+      (kbd "TAB") 'cider-stacktrace-cycle-current-cause
+      (kbd "0")   'cider-stacktrace-cycle-all-causes
+      (kbd "1")   'cider-stacktrace-cycle-cause-1
+      (kbd "2")   'cider-stacktrace-cycle-cause-2
+      (kbd "3")   'cider-stacktrace-cycle-cause-3
+      (kbd "4")   'cider-stacktrace-cycle-cause-4
+      (kbd "5")   'cider-stacktrace-cycle-cause-5
+      (kbd "a")   'cider-stacktrace-toggle-all
+      (kbd "c")   'cider-stacktrace-toggle-clj
+      (kbd "d")   'cider-stacktrace-toggle-duplicates
+      (kbd "J")   'cider-stacktrace-toggle-java
+      (kbd "r")   'cider-stacktrace-toggle-repl
+      (kbd "T")   'cider-stacktrace-toggle-tooling)
 
-      ;; open cider-doc directly and close it with q
-      (setq cider-prompt-for-symbol t)
+    ;; open cider-doc directly and close it with q
+    (setq cider-prompt-for-symbol t)
 
-      (evilified-state-evilify-map cider-docview-mode-map
-        :mode cider-docview-mode
-        :bindings
-        (kbd "q") 'cider-popup-buffer-quit)
+    (evilified-state-evilify-map cider-docview-mode-map
+      :mode cider-docview-mode
+      :bindings
+      (kbd "q") 'cider-popup-buffer-quit)
 
-      (evilified-state-evilify-map cider-inspector-mode-map
-        :mode cider-inspector-mode
-        :bindings
-        (kbd "L") 'cider-inspector-pop
-        (kbd "n") 'cider-inspector-next-page
-        (kbd "N") 'cider-inspector-prev-page
-        (kbd "p") 'cider-inspector-prev-page
-        (kbd "r") 'cider-inspector-refresh)
+    (evilified-state-evilify-map cider-inspector-mode-map
+      :mode cider-inspector-mode
+      :bindings
+      (kbd "L") 'cider-inspector-pop
+      (kbd "n") 'cider-inspector-next-page
+      (kbd "N") 'cider-inspector-prev-page
+      (kbd "p") 'cider-inspector-prev-page
+      (kbd "r") 'cider-inspector-refresh)
 
-      (evilified-state-evilify-map cider-test-report-mode-map
-        :mode cider-test-report-mode
-        :bindings
-        (kbd "C-j") 'cider-test-next-result
-        (kbd "C-k") 'cider-test-previous-result
-        (kbd "RET") 'cider-test-jump
-        (kbd "d")   'cider-test-ediff
-        (kbd "e")   'cider-test-stacktrace
-        (kbd "q")   'cider-popup-buffer-quit
-        (kbd "r")   'cider-test-rerun-tests
-        (kbd "t")   'cider-test-run-test
-        (kbd "T")   'cider-test-run-ns-tests)
+    (evilified-state-evilify-map cider-test-report-mode-map
+      :mode cider-test-report-mode
+      :bindings
+      (kbd "C-j") 'cider-test-next-result
+      (kbd "C-k") 'cider-test-previous-result
+      (kbd "RET") 'cider-test-jump
+      (kbd "d")   'cider-test-ediff
+      (kbd "e")   'cider-test-stacktrace
+      (kbd "q")   'cider-popup-buffer-quit
+      (kbd "r")   'cider-test-rerun-tests
+      (kbd "t")   'cider-test-run-test
+      (kbd "T")   'cider-test-run-ns-tests)
 
-      (evilified-state-evilify-map cider-repl-history-mode-map
-        :mode cider-repl-history-mode
-        :bindings
-        "j" 'cider-repl-history-forward
-        "k" 'cider-repl-history-previous
-        "s" (cond ((featurep 'helm-swoop) 'helm-swoop)
-                  ((featurep 'swiper) 'swiper)
-                  (t 'cider-repl-history-occur))
-        "r" 'cider-repl-history-update)
+    (evilified-state-evilify-map cider-repl-history-mode-map
+      :mode cider-repl-history-mode
+      :bindings
+      "j" 'cider-repl-history-forward
+      "k" 'cider-repl-history-previous
+      "s" (cond ((featurep 'helm-swoop) 'helm-swoop)
+                ((featurep 'swiper) 'swiper)
+                (t 'cider-repl-history-occur))
+      "r" 'cider-repl-history-update)
 
-      (spacemacs/set-leader-keys-for-major-mode 'cider-repl-history-mode
-        "s" 'cider-repl-history-save)
+    (spacemacs/set-leader-keys-for-major-mode 'cider-repl-history-mode
+      "s" 'cider-repl-history-save)
 
-      (evil-define-key 'normal cider-repl-mode-map
-        (kbd "C-j") 'cider-repl-next-input
-        (kbd "C-k") 'cider-repl-previous-input
-        (kbd "RET") 'cider-repl-return)
+    (evil-define-key 'normal cider-repl-mode-map
+      (kbd "C-j") 'cider-repl-next-input
+      (kbd "C-k") 'cider-repl-previous-input
+      (kbd "RET") 'cider-repl-return)
 
-      (if (package-installed-p 'company)
-          (evil-define-key 'insert cider-repl-mode-map
-            (kbd "C-j") 'spacemacs//clj-repl-wrap-c-j
-            (kbd "C-k") 'spacemacs//clj-repl-wrap-c-k)
+    (if (package-installed-p 'company)
         (evil-define-key 'insert cider-repl-mode-map
-          (kbd "C-j") 'cider-repl-next-input
-          (kbd "C-k") 'cider-repl-previous-input))
-
+          (kbd "C-j") 'spacemacs//clj-repl-wrap-c-j
+          (kbd "C-k") 'spacemacs//clj-repl-wrap-c-k)
       (evil-define-key 'insert cider-repl-mode-map
-        (kbd "<C-return>") 'cider-repl-newline-and-indent
-        (kbd "C-r") 'cider-repl-history)
+        (kbd "C-j") 'cider-repl-next-input
+        (kbd "C-k") 'cider-repl-previous-input))
 
-      (when clojure-enable-fancify-symbols
-        (clojure/fancify-symbols 'cider-repl-mode)
-        (clojure/fancify-symbols 'cider-clojure-interaction-mode)))
+    (evil-define-key 'insert cider-repl-mode-map
+      (kbd "<C-return>") 'cider-repl-newline-and-indent
+      (kbd "C-r") 'cider-repl-history)
+
+    (when clojure-enable-fancify-symbols
+      (clojure/fancify-symbols 'cider-repl-mode)
+      (clojure/fancify-symbols 'cider-clojure-interaction-mode))
 
     (defadvice cider-find-var (before add-evil-jump activate)
       (evil-set-jump))))
@@ -341,108 +339,104 @@
     :init
     (add-hook 'clojure-mode-hook 'clj-refactor-mode)
     :config
-    (progn
-      (cljr-add-keybindings-with-prefix "C-c C-f")
-      ;; Usually we do not set keybindings in :config, however this must be done
-      ;; here because it reads the variable `cljr--all-helpers'. Since
-      ;; `clj-refactor-mode' is added to the hook, this should trigger when a
-      ;; clojure buffer is opened anyway, so there's no "keybinding delay".
-      (spacemacs|forall-clojure-modes m
-        (dolist (r cljr--all-helpers)
-          (let* ((binding (car r))
-                 (func (cadr r)))
-            (unless (string-prefix-p "hydra" (symbol-name func))
-              (spacemacs/set-leader-keys-for-major-mode m
-                (concat "r" binding) func))))))))
+    (cljr-add-keybindings-with-prefix "C-c C-f")
+    ;; Usually we do not set keybindings in :config, however this must be done
+    ;; here because it reads the variable `cljr--all-helpers'. Since
+    ;; `clj-refactor-mode' is added to the hook, this should trigger when a
+    ;; clojure buffer is opened anyway, so there's no "keybinding delay".
+    (spacemacs|forall-clojure-modes m
+                                    (dolist (r cljr--all-helpers)
+                                      (let* ((binding (car r))
+                                             (func (cadr r)))
+                                        (unless (string-prefix-p "hydra" (symbol-name func))
+                                          (spacemacs/set-leader-keys-for-major-mode m
+                                            (concat "r" binding) func)))))))
 
 (defun clojure/init-helm-cider ()
   (use-package helm-cider
     :defer t
     :init
-    (progn
-      (add-hook 'clojure-mode-hook 'helm-cider-mode)
-      (setq sayid--key-binding-prefixes
-            '(("mhc" . "helm-cider-cheatsheet")))
-      (spacemacs|forall-clojure-modes m
-        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                            m (car x) (cdr x)))
-              sayid--key-binding-prefixes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          "hc" 'helm-cider-cheatsheet)))))
+    (add-hook 'clojure-mode-hook 'helm-cider-mode)
+    (setq sayid--key-binding-prefixes
+          '(("mhc" . "helm-cider-cheatsheet")))
+    (spacemacs|forall-clojure-modes m
+                                    (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                                                        m (car x) (cdr x)))
+                                          sayid--key-binding-prefixes)
+                                    (spacemacs/set-leader-keys-for-major-mode m
+                                      "hc" 'helm-cider-cheatsheet))))
 
 (defun clojure/init-kaocha-runner ()
   (use-package kaocha-runner
     :defer t
     :init
-    (progn
-      (setq kaocha--key-binding-prefixes
-            '(("mtk" . "kaocha")))
-      (spacemacs|forall-clojure-modes m
-        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                            m (car x) (cdr x)))
-              kaocha--key-binding-prefixes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          "tka" 'kaocha-runner-run-all-tests
-          "tkt" 'kaocha-runner-run-test-at-point
-          "tkn" 'kaocha-runner-run-tests
-          "tkw" 'kaocha-runner-show-warnings
-          "tkh" 'kaocha-runner-hide-windows)))))
+    (setq kaocha--key-binding-prefixes
+          '(("mtk" . "kaocha")))
+    (spacemacs|forall-clojure-modes m
+                                    (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                                                        m (car x) (cdr x)))
+                                          kaocha--key-binding-prefixes)
+                                    (spacemacs/set-leader-keys-for-major-mode m
+                                      "tka" 'kaocha-runner-run-all-tests
+                                      "tkt" 'kaocha-runner-run-test-at-point
+                                      "tkn" 'kaocha-runner-run-tests
+                                      "tkw" 'kaocha-runner-show-warnings
+                                      "tkh" 'kaocha-runner-hide-windows))))
 
 (defun clojure/init-clojure-mode ()
   (use-package clojure-mode
     :defer t
     :init
-    (progn
-      (add-to-list 'auto-mode-alist '("\\.boot\\'" . clojure-mode))
-      ;; This regexp matches shebang expressions like `#!/usr/bin/env boot'
-      (add-to-list 'magic-mode-alist '("#!.*boot\\s-*$" . clojure-mode))
-      (add-hook 'clojure-mode-hook #'spacemacs//clojure-setup-backend)
-      ;; Define all the prefixes here, although most of them apply only to bindings in clj-refactor
-      (let ((clj-refactor--key-binding-prefixes
-             '(("mra" . "add")
-               ("mrc" . "cycle/clean/convert")
-               ("mrd" . "destructure")
-               ("mre" . "extract/expand")
-               ("mrf" . "find/function")
-               ("mrh" . "hotload")
-               ("mri" . "introduce/inline")
-               ("mrm" . "move")
-               ("mrp" . "project/promote")
-               ("mrr" . "remove/rename/replace")
-               ("mrs" . "show/sort/stop")
-               ("mrt" . "thread")
-               ("mru" . "unwind/update")))
-            (clj-refactor--key-binding-non-lsp-prefixes
-             '(("mr" . "refactor"))))
-        (spacemacs|forall-clojure-modes m
-          (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                              m (car x) (cdr x)))
-                clj-refactor--key-binding-prefixes)
-          (unless (eq clojure-backend 'lsp)
-            (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
-                                m (car x) (cdr x)))
-                  clj-refactor--key-binding-non-lsp-prefixes))
-          (spacemacs/set-leader-keys-for-major-mode m
-            "=l" 'clojure-align
-            "ran" 'clojure-insert-ns-form
-            "raN" 'clojure-insert-ns-form-at-point
-            "rci" 'clojure-cycle-if
-            "rcp" 'clojure-cycle-privacy
-            "rc#" 'clojure-convert-collection-to-set
-            "rc'" 'clojure-convert-collection-to-quoted-list
-            "rc(" 'clojure-convert-collection-to-list
-            "rc[" 'clojure-convert-collection-to-vector
-            "rc{" 'clojure-convert-collection-to-map
-            "rc:" 'clojure-toggle-keyword-string
-            "rsn" 'clojure-sort-ns
-            "rtf" 'clojure-thread-first-all
-            "rth" 'clojure-thread
-            "rtl" 'clojure-thread-last-all
-            "rua" 'clojure-unwind-all
-            "ruw" 'clojure-unwind)
-          (unless clojure-enable-clj-refactor
-            (spacemacs/set-leader-keys-for-major-mode m
-              "r?" 'spacemacs/clj-describe-missing-refactorings)))))
+    (add-to-list 'auto-mode-alist '("\\.boot\\'" . clojure-mode))
+    ;; This regexp matches shebang expressions like `#!/usr/bin/env boot'
+    (add-to-list 'magic-mode-alist '("#!.*boot\\s-*$" . clojure-mode))
+    (add-hook 'clojure-mode-hook #'spacemacs//clojure-setup-backend)
+    ;; Define all the prefixes here, although most of them apply only to bindings in clj-refactor
+    (let ((clj-refactor--key-binding-prefixes
+           '(("mra" . "add")
+             ("mrc" . "cycle/clean/convert")
+             ("mrd" . "destructure")
+             ("mre" . "extract/expand")
+             ("mrf" . "find/function")
+             ("mrh" . "hotload")
+             ("mri" . "introduce/inline")
+             ("mrm" . "move")
+             ("mrp" . "project/promote")
+             ("mrr" . "remove/rename/replace")
+             ("mrs" . "show/sort/stop")
+             ("mrt" . "thread")
+             ("mru" . "unwind/update")))
+          (clj-refactor--key-binding-non-lsp-prefixes
+           '(("mr" . "refactor"))))
+      (spacemacs|forall-clojure-modes m
+                                      (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                                                          m (car x) (cdr x)))
+                                            clj-refactor--key-binding-prefixes)
+                                      (unless (eq clojure-backend 'lsp)
+                                        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode
+                                                            m (car x) (cdr x)))
+                                              clj-refactor--key-binding-non-lsp-prefixes))
+                                      (spacemacs/set-leader-keys-for-major-mode m
+                                        "=l" 'clojure-align
+                                        "ran" 'clojure-insert-ns-form
+                                        "raN" 'clojure-insert-ns-form-at-point
+                                        "rci" 'clojure-cycle-if
+                                        "rcp" 'clojure-cycle-privacy
+                                        "rc#" 'clojure-convert-collection-to-set
+                                        "rc'" 'clojure-convert-collection-to-quoted-list
+                                        "rc(" 'clojure-convert-collection-to-list
+                                        "rc[" 'clojure-convert-collection-to-vector
+                                        "rc{" 'clojure-convert-collection-to-map
+                                        "rc:" 'clojure-toggle-keyword-string
+                                        "rsn" 'clojure-sort-ns
+                                        "rtf" 'clojure-thread-first-all
+                                        "rth" 'clojure-thread
+                                        "rtl" 'clojure-thread-last-all
+                                        "rua" 'clojure-unwind-all
+                                        "ruw" 'clojure-unwind)
+                                      (unless clojure-enable-clj-refactor
+                                        (spacemacs/set-leader-keys-for-major-mode m
+                                          "r?" 'spacemacs/clj-describe-missing-refactorings))))
     :config
     (when clojure-enable-fancify-symbols
       (spacemacs|forall-clojure-modes m
@@ -499,70 +493,68 @@
   (use-package sayid
     :defer t
     :init
-    (progn
-      (setq sayid--key-binding-prefixes
-            '(("mdt" . "trace")))
-      (spacemacs|forall-clojure-modes m
-        (mapc (lambda (x) (spacemacs/declare-prefix-for-mode m
-                            (car x) (cdr x)))
-              sayid--key-binding-prefixes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          ;;These keybindings mostly preserved from the default sayid bindings
-          "d!" 'sayid-load-enable-clear
-          "dE" 'sayid-eval-last-sexp ;in default sayid bindings this is lowercase e, but that was already used in clojure mode
-          "dc" 'sayid-clear-log
-          "df" 'sayid-query-form-at-point
-          "dh" 'sayid-show-help
-          "ds" 'sayid-show-traced
-          "dS" 'sayid-show-traced-ns
-          "dtb" 'sayid-trace-ns-in-file
-          "dtd" 'sayid-trace-fn-disable
-          "dtD" 'sayid-trace-disable-all
-          "dte" 'sayid-trace-fn-enable
-          "dtE" 'sayid-trace-enable-all
-          "dtK" 'sayid-kill-all-traces
-          "dtn" 'sayid-inner-trace-fn
-          "dto" 'sayid-outer-trace-fn
-          "dtp" 'sayid-trace-ns-by-pattern
-          "dtr" 'sayid-remove-trace-fn
-          "dty" 'sayid-trace-all-ns-in-dir
-          "dV" 'sayid-set-view
-          "dw" 'sayid-get-workspace
-          "dx" 'sayid-reset-workspace)))
+    (setq sayid--key-binding-prefixes
+          '(("mdt" . "trace")))
+    (spacemacs|forall-clojure-modes m
+                                    (mapc (lambda (x) (spacemacs/declare-prefix-for-mode m
+                                                        (car x) (cdr x)))
+                                          sayid--key-binding-prefixes)
+                                    (spacemacs/set-leader-keys-for-major-mode m
+                                      ;;These keybindings mostly preserved from the default sayid bindings
+                                      "d!" 'sayid-load-enable-clear
+                                      "dE" 'sayid-eval-last-sexp ;in default sayid bindings this is lowercase e, but that was already used in clojure mode
+                                      "dc" 'sayid-clear-log
+                                      "df" 'sayid-query-form-at-point
+                                      "dh" 'sayid-show-help
+                                      "ds" 'sayid-show-traced
+                                      "dS" 'sayid-show-traced-ns
+                                      "dtb" 'sayid-trace-ns-in-file
+                                      "dtd" 'sayid-trace-fn-disable
+                                      "dtD" 'sayid-trace-disable-all
+                                      "dte" 'sayid-trace-fn-enable
+                                      "dtE" 'sayid-trace-enable-all
+                                      "dtK" 'sayid-kill-all-traces
+                                      "dtn" 'sayid-inner-trace-fn
+                                      "dto" 'sayid-outer-trace-fn
+                                      "dtp" 'sayid-trace-ns-by-pattern
+                                      "dtr" 'sayid-remove-trace-fn
+                                      "dty" 'sayid-trace-all-ns-in-dir
+                                      "dV" 'sayid-set-view
+                                      "dw" 'sayid-get-workspace
+                                      "dx" 'sayid-reset-workspace))
     :config
-    (progn
-      ;; If sayid-version is null the .elc file
-      ;; is corrupted. Then force a reinstall and
-      ;; reload the feature.
-      (when (null sayid-version)
-        (package-reinstall 'sayid)
-        (unload-feature 'sayid)
-        (require 'sayid)
-        (setq cider-jack-in-lein-plugins (delete `("com.billpiel/sayid" nil) cider-jack-in-lein-plugins)))
+    ;; If sayid-version is null the .elc file
+    ;; is corrupted. Then force a reinstall and
+    ;; reload the feature.
+    (when (null sayid-version)
+      (package-reinstall 'sayid)
+      (unload-feature 'sayid)
+      (require 'sayid)
+      (setq cider-jack-in-lein-plugins (delete `("com.billpiel/sayid" nil) cider-jack-in-lein-plugins)))
 
-      ;; Make it evil
-      (evilified-state-evilify-map sayid-mode-map
-        :mode sayid-mode
-        :bindings
-        (kbd "H") 'sayid-buf-show-help
-        (kbd "n") 'sayid-buffer-nav-to-next
-        (kbd "N") 'sayid-buffer-nav-to-prev
-        (kbd "C-s v") 'sayid-toggle-view
-        (kbd "C-s V") 'sayid-set-view
-        (kbd "L") 'sayid-buf-back
-        (kbd "e") 'sayid-gen-instance-expr) ;Originally this was bound to 'g', but I feel this is still mnemonic and doesn't overlap with evil
-      (evilified-state-evilify-map sayid-pprint-mode-map
-        :mode sayid-pprint-mode
-        :bindings
-        (kbd "h") 'sayid-pprint-buf-show-help
-        (kbd "n") 'sayid-pprint-buf-next
-        (kbd "N") 'sayid-pprint-buf-prev
-        (kbd "l") 'sayid-pprint-buf-exit)
-      (evilified-state-evilify-map sayid-traced-mode-map
-        :mode sayid-traced-mode
-        :bindings
-        (kbd "l") 'sayid-show-traced
-        (kbd "h") 'sayid-traced-buf-show-help))))
+    ;; Make it evil
+    (evilified-state-evilify-map sayid-mode-map
+      :mode sayid-mode
+      :bindings
+      (kbd "H") 'sayid-buf-show-help
+      (kbd "n") 'sayid-buffer-nav-to-next
+      (kbd "N") 'sayid-buffer-nav-to-prev
+      (kbd "C-s v") 'sayid-toggle-view
+      (kbd "C-s V") 'sayid-set-view
+      (kbd "L") 'sayid-buf-back
+      (kbd "e") 'sayid-gen-instance-expr) ;Originally this was bound to 'g', but I feel this is still mnemonic and doesn't overlap with evil
+    (evilified-state-evilify-map sayid-pprint-mode-map
+      :mode sayid-pprint-mode
+      :bindings
+      (kbd "h") 'sayid-pprint-buf-show-help
+      (kbd "n") 'sayid-pprint-buf-next
+      (kbd "N") 'sayid-pprint-buf-prev
+      (kbd "l") 'sayid-pprint-buf-exit)
+    (evilified-state-evilify-map sayid-traced-mode-map
+      :mode sayid-traced-mode
+      :bindings
+      (kbd "l") 'sayid-show-traced
+      (kbd "h") 'sayid-traced-buf-show-help)))
 
 
 (defun clojure/post-init-flycheck ()
@@ -621,10 +613,10 @@
 (defun clojure/init-flycheck-clojure ()
   (use-package flycheck-clojure
     :if (configuration-layer/package-usedp 'flycheck)
-    :config (progn
-              (flycheck-clojure-setup)
-              (with-eval-after-load 'cider
-                (flycheck-clojure-inject-jack-in-dependencies)))))
+    :config 
+    (flycheck-clojure-setup)
+    (with-eval-after-load 'cider
+      (flycheck-clojure-inject-jack-in-dependencies))))
 
 (defun clojure/init-flycheck-clj-kondo ()
   (use-package flycheck-clj-kondo

--- a/layers/+lang/coffeescript/packages.el
+++ b/layers/+lang/coffeescript/packages.el
@@ -37,22 +37,21 @@
   (use-package coffee-mode
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'coffee-mode 'coffee-repl "coffeescript")
-      ;; keybindings
-      (spacemacs/declare-prefix-for-mode 'coffee-mode "mc" "compile")
-      (spacemacs/declare-prefix-for-mode 'coffee-mode "ms" "REPL")
-      (spacemacs/set-leader-keys-for-major-mode 'coffee-mode
-        "'"  'coffee-repl
-        "cc" 'coffee-compile-buffer
-        "cr" 'coffee-compile-region
-        "sb" 'coffee-send-buffer
-        "si" 'coffee-repl
-        "sl" 'coffee-send-line
-        "sr" 'coffee-send-region
-        "Tc" 'coffee-cos-mode)
-      ;; indent to right position after `evil-open-below' and `evil-open-above'
-      (add-hook 'coffee-mode-hook 'spacemacs//coffeescript-indent-hook))))
+    (spacemacs/register-repl 'coffee-mode 'coffee-repl "coffeescript")
+    ;; keybindings
+    (spacemacs/declare-prefix-for-mode 'coffee-mode "mc" "compile")
+    (spacemacs/declare-prefix-for-mode 'coffee-mode "ms" "REPL")
+    (spacemacs/set-leader-keys-for-major-mode 'coffee-mode
+      "'"  'coffee-repl
+      "cc" 'coffee-compile-buffer
+      "cr" 'coffee-compile-region
+      "sb" 'coffee-send-buffer
+      "si" 'coffee-repl
+      "sl" 'coffee-send-line
+      "sr" 'coffee-send-region
+      "Tc" 'coffee-cos-mode)
+    ;; indent to right position after `evil-open-below' and `evil-open-above'
+    (add-hook 'coffee-mode-hook 'spacemacs//coffeescript-indent-hook)))
 
 (defun coffeescript/post-init-company ()
   (spacemacs|add-company-backends

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -83,81 +83,79 @@
   (use-package slime
     :commands slime-mode
     :init
-    (progn
-      (spacemacs/register-repl 'slime 'slime)
-      (setq slime-contribs '(slime-asdf
-                             slime-fancy
-                             slime-indentation
-                             slime-sbcl-exts
-                             slime-scratch)
-            inferior-lisp-program "sbcl")
-      ;; enable fuzzy matching in code buffer and SLIME REPL
-      (setq slime-complete-symbol*-fancy t)
-      (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
-      (add-hook 'slime-repl-mode-hook #'spacemacs//deactivate-smartparens)
-      (spacemacs/add-to-hooks 'slime-mode '(lisp-mode-hook)))
+    (spacemacs/register-repl 'slime 'slime)
+    (setq slime-contribs '(slime-asdf
+                           slime-fancy
+                           slime-indentation
+                           slime-sbcl-exts
+                           slime-scratch)
+          inferior-lisp-program "sbcl")
+    ;; enable fuzzy matching in code buffer and SLIME REPL
+    (setq slime-complete-symbol*-fancy t)
+    (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
+    (add-hook 'slime-repl-mode-hook #'spacemacs//deactivate-smartparens)
+    (spacemacs/add-to-hooks 'slime-mode '(lisp-mode-hook))
     :config
-    (progn
-      (slime-setup)
-      ;; TODO: Add bindings for the SLIME debugger?
-      (spacemacs/set-leader-keys-for-major-mode 'lisp-mode
-        "'" 'slime
+    (slime-setup)
+    ;; TODO: Add bindings for the SLIME debugger?
+    (spacemacs/set-leader-keys-for-major-mode 'lisp-mode
+      "'" 'slime
 
-        "cc" 'slime-compile-file
-        "cC" 'slime-compile-and-load-file
-        "cl" 'slime-load-file
-        "cf" 'slime-compile-defun
-        "cr" 'slime-compile-region
-        "cn" 'slime-remove-notes
+      "cc" 'slime-compile-file
+      "cC" 'slime-compile-and-load-file
+      "cl" 'slime-load-file
+      "cf" 'slime-compile-defun
+      "cr" 'slime-compile-region
+      "cn" 'slime-remove-notes
 
-        "eb" 'slime-eval-buffer
-        "ef" 'slime-eval-defun
-        "eF" 'slime-undefine-function
-        "ee" 'slime-eval-last-expression
-        "el" 'spacemacs/slime-eval-sexp-end-of-line
-        "er" 'slime-eval-region
+      "eb" 'slime-eval-buffer
+      "ef" 'slime-eval-defun
+      "eF" 'slime-undefine-function
+      "ee" 'slime-eval-last-expression
+      "el" 'spacemacs/slime-eval-sexp-end-of-line
+      "er" 'slime-eval-region
 
-        "gb" 'slime-pop-find-definition-stack
-        "gn" 'slime-next-note
-        "gN" 'slime-previous-note
+      "gb" 'slime-pop-find-definition-stack
+      "gn" 'slime-next-note
+      "gN" 'slime-previous-note
 
-        "ha" 'slime-apropos
-        "hA" 'slime-apropos-all
-        "hd" 'slime-disassemble-symbol
-        "hh" 'slime-describe-symbol
-        "hH" 'slime-hyperspec-lookup
-        "hi" 'slime-inspect-definition
-        "hp" 'slime-apropos-package
-        "ht" 'slime-toggle-trace-fdefinition
-        "hT" 'slime-untrace-all
-        "h<" 'slime-who-calls
-        "h>" 'slime-calls-who
-        ;; TODO: Add key bindings for who binds/sets globals?
-        "hr" 'slime-who-references
-        "hm" 'slime-who-macroexpands
-        "hs" 'slime-who-specializes
+      "ha" 'slime-apropos
+      "hA" 'slime-apropos-all
+      "hd" 'slime-disassemble-symbol
+      "hh" 'slime-describe-symbol
+      "hH" 'slime-hyperspec-lookup
+      "hi" 'slime-inspect-definition
+      "hp" 'slime-apropos-package
+      "ht" 'slime-toggle-trace-fdefinition
+      "hT" 'slime-untrace-all
+      "h<" 'slime-who-calls
+      "h>" 'slime-calls-who
+      ;; TODO: Add key bindings for who binds/sets globals?
+      "hr" 'slime-who-references
+      "hm" 'slime-who-macroexpands
+      "hs" 'slime-who-specializes
 
-        "ma" 'slime-macroexpand-all
-        "mo" 'slime-macroexpand-1
+      "ma" 'slime-macroexpand-all
+      "mo" 'slime-macroexpand-1
 
-        "se" 'slime-eval-last-expression-in-repl
-        "si" 'slime
-        "sq" 'slime-quit-lisp
+      "se" 'slime-eval-last-expression-in-repl
+      "si" 'slime
+      "sq" 'slime-quit-lisp
 
-        "tf" 'slime-toggle-fancy-trace
+      "tf" 'slime-toggle-fancy-trace
 
-        ;; Add key bindings for custom eval functions
-        "ec" 'spacemacs/cl-eval-current-form-sp
-        "eC" 'spacemacs/cl-eval-current-form
-        "es" 'spacemacs/cl-eval-current-symbol-sp)
+      ;; Add key bindings for custom eval functions
+      "ec" 'spacemacs/cl-eval-current-form-sp
+      "eC" 'spacemacs/cl-eval-current-form
+      "es" 'spacemacs/cl-eval-current-symbol-sp)
 
-      ;; prefix names for which-key
-      (mapc (lambda (x)
-              (spacemacs/declare-prefix-for-mode 'lisp-mode (car x) (cdr x)))
-            '(("mh" . "help")
-              ("me" . "eval")
-              ("ms" . "repl")
-              ("mc" . "compile")
-              ("mg" . "nav")
-              ("mm" . "macro")
-              ("mt" . "toggle"))))))
+    ;; prefix names for which-key
+    (mapc (lambda (x)
+            (spacemacs/declare-prefix-for-mode 'lisp-mode (car x) (cdr x)))
+          '(("mh" . "help")
+            ("me" . "eval")
+            ("ms" . "repl")
+            ("mc" . "compile")
+            ("mg" . "nav")
+            ("mm" . "macro")
+            ("mt" . "toggle")))))

--- a/layers/+lang/coq/packages.el
+++ b/layers/+lang/coq/packages.el
@@ -33,92 +33,88 @@
   (use-package company-coq
     :defer t
     :init
-    (progn
-      (add-hook 'coq-mode-hook #'company-coq-mode)
-      (add-to-list 'spacemacs-jump-handlers-coq-mode
-                   'company-coq-jump-to-definition)
-      (setq company-coq-disabled-features '(hello)))
+    (add-hook 'coq-mode-hook #'company-coq-mode)
+    (add-to-list 'spacemacs-jump-handlers-coq-mode
+                 'company-coq-jump-to-definition)
+    (setq company-coq-disabled-features '(hello))
     :config
-    (progn
-      (spacemacs|hide-lighter company-coq-mode)
-      (dolist (prefix '(("mi" . "coq/insert")
-                        ("mh" . "coq/document")))
-        (spacemacs/declare-prefix-for-mode
-          'coq-mode
-          (car prefix) (cdr prefix)))
-      (spacemacs/set-leader-keys-for-major-mode 'coq-mode
-        "il" 'company-coq-lemma-from-goal
-        "im" 'company-coq-insert-match-construct
-        "ao" 'company-coq-occur
-        "he" 'company-coq-document-error
-        "hE" 'company-coq-browse-error-messages
-        "hh" 'company-coq-doc))))
+    (spacemacs|hide-lighter company-coq-mode)
+    (dolist (prefix '(("mi" . "coq/insert")
+                      ("mh" . "coq/document")))
+      (spacemacs/declare-prefix-for-mode
+        'coq-mode
+        (car prefix) (cdr prefix)))
+    (spacemacs/set-leader-keys-for-major-mode 'coq-mode
+      "il" 'company-coq-lemma-from-goal
+      "im" 'company-coq-insert-match-construct
+      "ao" 'company-coq-occur
+      "he" 'company-coq-document-error
+      "hE" 'company-coq-browse-error-messages
+      "hh" 'company-coq-doc)))
 
 (defun coq/init-proof-general ()
   (use-package proof-site
     :mode ("\\.v\\'" . coq-mode)
     :defer t
     :init
-    (progn
-      (setq coq/proof-general-load-path
-            (concat (configuration-layer/get-elpa-package-install-directory
-                     'proof-general) "generic")
-            proof-three-window-mode-policy 'hybrid
-            proof-script-fly-past-comments t
-            proof-splash-seen t)
-      (add-to-list 'load-path coq/proof-general-load-path))
+    (setq coq/proof-general-load-path
+          (concat (configuration-layer/get-elpa-package-install-directory
+                   'proof-general) "generic")
+          proof-three-window-mode-policy 'hybrid
+          proof-script-fly-past-comments t
+          proof-splash-seen t)
+    (add-to-list 'load-path coq/proof-general-load-path)
     :config
-    (progn
-      (spacemacs|hide-lighter holes-mode)
-      (spacemacs|hide-lighter proof-active-buffer-fake-minor-mode)
-      ;; key bindings
-      (dolist (prefix '(("ml" . "pg/layout")
-                        ("mp" . "pg/prover")
-                        ("ma" . "pg/ask-prover")
-                        ("mai" . "show-implicits")
-                        ("mg" . "pg/goto")))
-        (spacemacs/declare-prefix-for-mode
-          'coq-mode
-          (car prefix) (cdr prefix)))
-      (spacemacs/set-leader-keys-for-major-mode 'coq-mode
-        ;; Basic proof management
-        "]" 'proof-assert-next-command-interactive
-        "[" 'proof-undo-last-successful-command
-        "." 'proof-goto-point
-        ;; Layout
-        "lc" 'pg-response-clear-displays
-        "ll" 'proof-layout-windows
-        "lp" 'proof-prf
-        ;; Prover Interaction
-        "pi" 'proof-interrupt-process
-        "pp" 'proof-process-buffer
-        "pq" 'proof-shell-exit
-        "pr" 'proof-retract-buffer
-        ;; Prover queries ('ask prover')
-        "aa" 'coq-Print
-        "aA" 'coq-Print-with-all
-        "ab" 'coq-About
-        "aB" 'coq-About-with-all
-        "ac" 'coq-Check
-        "aC" 'coq-Check-show-all
-        "af" 'proof-find-theorems
-        "aib" 'coq-About-with-implicits
-        "aic" 'coq-Check-show-implicits
-        "aii" 'coq-Print-with-implicits
-        ;; Moving the point (goto)
-        "ge" 'proof-goto-command-end
-        "gl" 'proof-goto-end-of-locked
-        "gs" 'proof-goto-command-start
-        ;; Insertions
-        "ic" 'coq-insert-command
-        "ie" 'coq-end-Section
-        "ii" 'coq-insert-intros
-        "ir" 'coq-insert-requires
-        "is" 'coq-insert-section-or-module
-        "it" 'coq-insert-tactic
-        "iT" 'coq-insert-tactical
-        ;; Options
-        "Te" 'proof-electric-terminator-toggle))))
+    (spacemacs|hide-lighter holes-mode)
+    (spacemacs|hide-lighter proof-active-buffer-fake-minor-mode)
+    ;; key bindings
+    (dolist (prefix '(("ml" . "pg/layout")
+                      ("mp" . "pg/prover")
+                      ("ma" . "pg/ask-prover")
+                      ("mai" . "show-implicits")
+                      ("mg" . "pg/goto")))
+      (spacemacs/declare-prefix-for-mode
+        'coq-mode
+        (car prefix) (cdr prefix)))
+    (spacemacs/set-leader-keys-for-major-mode 'coq-mode
+      ;; Basic proof management
+      "]" 'proof-assert-next-command-interactive
+      "[" 'proof-undo-last-successful-command
+      "." 'proof-goto-point
+      ;; Layout
+      "lc" 'pg-response-clear-displays
+      "ll" 'proof-layout-windows
+      "lp" 'proof-prf
+      ;; Prover Interaction
+      "pi" 'proof-interrupt-process
+      "pp" 'proof-process-buffer
+      "pq" 'proof-shell-exit
+      "pr" 'proof-retract-buffer
+      ;; Prover queries ('ask prover')
+      "aa" 'coq-Print
+      "aA" 'coq-Print-with-all
+      "ab" 'coq-About
+      "aB" 'coq-About-with-all
+      "ac" 'coq-Check
+      "aC" 'coq-Check-show-all
+      "af" 'proof-find-theorems
+      "aib" 'coq-About-with-implicits
+      "aic" 'coq-Check-show-implicits
+      "aii" 'coq-Print-with-implicits
+      ;; Moving the point (goto)
+      "ge" 'proof-goto-command-end
+      "gl" 'proof-goto-end-of-locked
+      "gs" 'proof-goto-command-start
+      ;; Insertions
+      "ic" 'coq-insert-command
+      "ie" 'coq-end-Section
+      "ii" 'coq-insert-intros
+      "ir" 'coq-insert-requires
+      "is" 'coq-insert-section-or-module
+      "it" 'coq-insert-tactic
+      "iT" 'coq-insert-tactical
+      ;; Options
+      "Te" 'proof-electric-terminator-toggle)))
 
 (defun coq/post-init-smartparens ()
   (add-hook 'coq-mode-hook #'spacemacs//activate-smartparens))

--- a/layers/+lang/crystal/packages.el
+++ b/layers/+lang/crystal/packages.el
@@ -40,35 +40,33 @@
   (use-package ameba
     :defer t
     :init
-    (progn
-      (add-hook 'crystal-mode-hook 'ameba-mode)
-      (spacemacs/declare-prefix-for-mode 'crystal-mode "mua" "ameba")
-      (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
-        "uad" 'ameba-check-directory
-        "uaf" 'ameba-check-current-file
-        "uap" 'ameba-check-project))))
+    (add-hook 'crystal-mode-hook 'ameba-mode)
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "mua" "ameba")
+    (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
+      "uad" 'ameba-check-directory
+      "uaf" 'ameba-check-current-file
+      "uap" 'ameba-check-project)))
 
 (defun crystal/init-crystal-mode ()
   (use-package crystal-mode
     :defer t
     :init
-    (progn
-      (add-hook 'crystal-mode-hook 'spacemacs//crystal-auto-format-setup)
-      (add-hook 'crystal-mode-hook #'spacemacs//crystal-setup-backend)
-      (spacemacs/declare-prefix-for-mode 'crystal-mode "mu" "tool")
-      (unless (eq crystal-backend 'lsp)
-        (spacemacs/declare-prefix-for-mode 'crystal-mode "mg" "goto")
-        (spacemacs/declare-prefix-for-mode 'crystal-mode "mt" "test")
-        (spacemacs/declare-prefix-for-mode 'crystal-mode "ma" "action"))
-      (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
-        "ga" 'crystal-spec-switch
-        "tb" 'crystal-spec-buffer
-        "tp" 'crystal-spec-all
-        "uc" 'crystal-tool-context
-        "ue" 'crystal-tool-expand
-        "uf" 'crystal-tool-format
-        "ui" 'crystal-tool-imp
-        "ax" 'spacemacs/crystal-run-main))))
+    (add-hook 'crystal-mode-hook 'spacemacs//crystal-auto-format-setup)
+    (add-hook 'crystal-mode-hook #'spacemacs//crystal-setup-backend)
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "mu" "tool")
+    (unless (eq crystal-backend 'lsp)
+      (spacemacs/declare-prefix-for-mode 'crystal-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'crystal-mode "mt" "test")
+      (spacemacs/declare-prefix-for-mode 'crystal-mode "ma" "action"))
+    (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
+      "ga" 'crystal-spec-switch
+      "tb" 'crystal-spec-buffer
+      "tp" 'crystal-spec-all
+      "uc" 'crystal-tool-context
+      "ue" 'crystal-tool-expand
+      "uf" 'crystal-tool-format
+      "ui" 'crystal-tool-imp
+      "ax" 'spacemacs/crystal-run-main)))
 
 (defun crystal/post-init-flycheck ()
   (spacemacs/enable-flycheck 'crystal-mode))
@@ -80,20 +78,19 @@
   (use-package inf-crystal
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'inf-crystal 'inf-crystal "inf-crystal")
-      (add-hook 'crystal-mode-hook 'inf-crystal-minor-mode)
-      (spacemacs/declare-prefix-for-mode 'crystal-mode "ms" "repl")
-      (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
-        "'" 'inf-crystal
-        "sb" 'crystal-send-buffer
-        "sB" 'crystal-send-buffer-and-go
-        "sf" 'crystal-send-definition
-        "sF" 'crystal-send-definition-and-go
-        "si" 'inf-crystal
-        "sr" 'crystal-send-region
-        "sR" 'crystal-send-region-and-go
-        "ss" 'crystal-switch-to-inf))))
+    (spacemacs/register-repl 'inf-crystal 'inf-crystal "inf-crystal")
+    (add-hook 'crystal-mode-hook 'inf-crystal-minor-mode)
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "ms" "repl")
+    (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
+      "'" 'inf-crystal
+      "sb" 'crystal-send-buffer
+      "sB" 'crystal-send-buffer-and-go
+      "sf" 'crystal-send-definition
+      "sF" 'crystal-send-definition-and-go
+      "si" 'inf-crystal
+      "sr" 'crystal-send-region
+      "sR" 'crystal-send-region-and-go
+      "ss" 'crystal-switch-to-inf)))
 
 (defun crystal/pre-init-ob-crystal ()
   (spacemacs|use-package-add-hook org
@@ -106,10 +103,9 @@
   (use-package play-crystal
     :defer t
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'crystal-mode "me" "play")
-      (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
-        "eb" 'play-crystal-submit-buffer
-        "ee" 'play-crystal-browse
-        "ei" 'play-crystal-insert
-        "er" 'play-crystal-submit-region))))
+    (spacemacs/declare-prefix-for-mode 'crystal-mode "me" "play")
+    (spacemacs/set-leader-keys-for-major-mode 'crystal-mode
+      "eb" 'play-crystal-submit-buffer
+      "ee" 'play-crystal-browse
+      "ei" 'play-crystal-insert
+      "er" 'play-crystal-submit-region)))

--- a/layers/+lang/csv/packages.el
+++ b/layers/+lang/csv/packages.el
@@ -27,22 +27,21 @@
   (use-package csv-mode
     :defer t
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'csv-mode "ms" "sort")
-      (spacemacs/declare-prefix-for-mode 'csv-mode "mv" "yank")
-      (spacemacs/set-leader-keys-for-major-mode 'csv-mode
-        "a"  'csv-align-fields
-        "d"  'csv-kill-fields
-        "h"  'csv-header-line
-        "i"  'csv-toggle-invisibility
-        "n"  'csv-forward-field
-        "p"  'csv-backward-field
-        "r"  'csv-reverse-region
-        "sf" 'csv-sort-fields
-        "sn" 'csv-sort-numeric-fields
-        "so" 'csv-toggle-descending
-        "t"  'csv-transpose
-        "u"  'csv-unalign-fields
-        "vf" 'csv-yank-fields
-        "vt" 'csv-yank-as-new-table)
-      (spacemacs/inherit-leader-keys-from-parent-mode 'tsv-mode))))
+    (spacemacs/declare-prefix-for-mode 'csv-mode "ms" "sort")
+    (spacemacs/declare-prefix-for-mode 'csv-mode "mv" "yank")
+    (spacemacs/set-leader-keys-for-major-mode 'csv-mode
+      "a"  'csv-align-fields
+      "d"  'csv-kill-fields
+      "h"  'csv-header-line
+      "i"  'csv-toggle-invisibility
+      "n"  'csv-forward-field
+      "p"  'csv-backward-field
+      "r"  'csv-reverse-region
+      "sf" 'csv-sort-fields
+      "sn" 'csv-sort-numeric-fields
+      "so" 'csv-toggle-descending
+      "t"  'csv-transpose
+      "u"  'csv-unalign-fields
+      "vf" 'csv-yank-fields
+      "vt" 'csv-yank-as-new-table)
+    (spacemacs/inherit-leader-keys-from-parent-mode 'tsv-mode)))

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -43,13 +43,12 @@
   (use-package company-dcd
     :defer t
     :init
-    (progn
-      (spacemacs|add-company-backends :backends company-dcd :modes d-mode)
-      (spacemacs/set-leader-keys-for-major-mode 'd-mode
-        "gg" 'company-dcd-goto-definition
-        "gb" 'company-dcd-goto-def-pop-marker
-        "hh" 'company-dcd-show-ddoc-with-buffer
-        "gr" 'company-dcd-ivy-search-symbol))))
+    (spacemacs|add-company-backends :backends company-dcd :modes d-mode)
+    (spacemacs/set-leader-keys-for-major-mode 'd-mode
+      "gg" 'company-dcd-goto-definition
+      "gb" 'company-dcd-goto-def-pop-marker
+      "hh" 'company-dcd-show-ddoc-with-buffer
+      "gr" 'company-dcd-ivy-search-symbol)))
 
 (defun d/init-d-mode ()
   (use-package d-mode :defer t))
@@ -60,9 +59,8 @@
 (defun d/init-flycheck-dmd-dub ()
   (use-package flycheck-dmd-dub :defer t
     :init
-    (progn
-      (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path)
-      (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-variables))))
+    (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-include-path)
+    (add-hook 'd-mode-hook 'flycheck-dmd-dub-set-variables)))
 
 (defun d/post-init-ggtags ()
   (add-hook 'd-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/dart/packages.el
+++ b/layers/+lang/dart/packages.el
@@ -47,46 +47,44 @@
   (use-package dart-server
     :defer t
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'dart-mode "mf" "find")
-      (spacemacs/declare-prefix-for-mode 'dart-mode "mh" "help")
-      (spacemacs/set-leader-keys-for-major-mode 'dart-mode
-        "=" 'dart-server-format
-        "?" 'dart-server-show-hover
-        "g" 'dart-server-goto
-        "hh" 'dart-server-show-hover
-        "hb" 'dart/show-buffer
-        ;; There's an upstream issue with this command:
-        ;; dart-server-find-refs on int opens a dart buffer that keeps growing in size #11
-        ;; https://github.com/bradyt/dart-server/issues/11
-        ;; When/if it's fixed, add back the key binding:
-        ;; ~SPC m f f~ Find reference at point.
-        ;; to the readme.org key binding table.
-        ;; "ff" 'dart-server-find-refs
-        "fe" 'dart-server-find-member-decls
-        "fr" 'dart-server-find-member-refs
-        "fd" 'dart-server-find-top-level-decls)
+    (spacemacs/declare-prefix-for-mode 'dart-mode "mf" "find")
+    (spacemacs/declare-prefix-for-mode 'dart-mode "mh" "help")
+    (spacemacs/set-leader-keys-for-major-mode 'dart-mode
+      "=" 'dart-server-format
+      "?" 'dart-server-show-hover
+      "g" 'dart-server-goto
+      "hh" 'dart-server-show-hover
+      "hb" 'dart/show-buffer
+      ;; There's an upstream issue with this command:
+      ;; dart-server-find-refs on int opens a dart buffer that keeps growing in size #11
+      ;; https://github.com/bradyt/dart-server/issues/11
+      ;; When/if it's fixed, add back the key binding:
+      ;; ~SPC m f f~ Find reference at point.
+      ;; to the readme.org key binding table.
+      ;; "ff" 'dart-server-find-refs
+      "fe" 'dart-server-find-member-decls
+      "fr" 'dart-server-find-member-refs
+      "fd" 'dart-server-find-top-level-decls)
 
-      (add-to-list 'spacemacs-jump-handlers-dart-mode
-                   '(dart-server-goto :async t))
+    (add-to-list 'spacemacs-jump-handlers-dart-mode
+                 '(dart-server-goto :async t))
 
-      (evil-define-key 'insert dart-server-map
-        (kbd "<tab>") 'dart-server-expand
-        (kbd "C-<tab>") 'dart-server-expand-parameters)
+    (evil-define-key 'insert dart-server-map
+      (kbd "<tab>") 'dart-server-expand
+      (kbd "C-<tab>") 'dart-server-expand-parameters)
 
-      (evil-set-initial-state 'dart-server-popup-mode 'motion)
-      (evil-define-key 'motion dart-server-popup-mode-map
-        (kbd "gr") 'dart-server-do-it-again))))
+    (evil-set-initial-state 'dart-server-popup-mode 'motion)
+    (evil-define-key 'motion dart-server-popup-mode-map
+      (kbd "gr") 'dart-server-do-it-again)))
 
 (defun dart/init-flutter ()
   (use-package flutter
     :defer t
     :after dart-mode
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'dart-mode "mx" "flutter")
-      (spacemacs/set-leader-keys-for-major-mode 'dart-mode
-        "xx" 'flutter-run-or-hot-reload))))
+    (spacemacs/declare-prefix-for-mode 'dart-mode "mx" "flutter")
+    (spacemacs/set-leader-keys-for-major-mode 'dart-mode
+      "xx" 'flutter-run-or-hot-reload)))
 
 (defun dart/init-lsp-dart ()
   (use-package lsp-dart

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -41,13 +41,12 @@
     :if (eq elixir-backend 'alchemist)
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'alchemist 'alchemist-iex-run "alchemist")
-      (add-hook 'elixir-mode-hook 'alchemist-mode)
-      (setq alchemist-project-compile-when-needed t
-            alchemist-test-status-modeline nil)
-      (add-to-list 'spacemacs-jump-handlers-elixir-mode
-                   '(alchemist-goto-definition-at-point :async t)))
+    (spacemacs/register-repl 'alchemist 'alchemist-iex-run "alchemist")
+    (add-hook 'elixir-mode-hook 'alchemist-mode)
+    (setq alchemist-project-compile-when-needed t
+          alchemist-test-status-modeline nil)
+    (add-to-list 'spacemacs-jump-handlers-elixir-mode
+                 '(alchemist-goto-definition-at-point :async t))
     :config
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mX" "hex")
     (spacemacs/declare-prefix-for-mode 'elixir-mode "mc" "compile")

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -49,80 +49,77 @@
     :mode ("\\.elm\\'" . elm-mode)
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'elm-mode 'elm-repl-load "elm")
-      (add-hook 'elm-mode-hook 'spacemacs//elm-setup-backend))
+    (spacemacs/register-repl 'elm-mode 'elm-repl-load "elm")
+    (add-hook 'elm-mode-hook 'spacemacs//elm-setup-backend)
     :config
-    (progn
-      ;; Bind non-lsp keys
-      (when (eq elm-backend 'company-elm)
-        (spacemacs/set-leader-keys-for-major-mode 'elm-mode
-          ;; format
-          "=b" 'elm-format-buffer
-          ;; oracle
-          "hh" 'elm-oracle-doc-at-point
-          "ht" 'elm-oracle-type-at-point)
-
-        ;; Bind prefixes
-        (dolist (x '(("m=" . "format")
-                     ("mh" . "help")
-                     ("mg" . "goto")
-                     ("mr" . "refactor")))
-          (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x))))
-
-      ;; Bind general keys
+    ;; Bind non-lsp keys
+    (when (eq elm-backend 'company-elm)
       (spacemacs/set-leader-keys-for-major-mode 'elm-mode
-        ;; refactoring
-        "ri" 'elm-sort-imports
-        ;; repl
-        "'"  'elm-repl-load
-        "si" 'elm-repl-load
-        "sf" 'elm-repl-push-decl
-        "sF" 'spacemacs/elm-repl-push-decl-focus
-        "sr" 'elm-repl-push
-        "sR" 'spacemacs/elm-repl-push-focus
-        ;; make
-        "cb" 'elm-compile-buffer
-        "cB" 'spacemacs/elm-compile-buffer-output
-        "cm" 'elm-compile-main
-        ;; reactor
-        "Rn" 'elm-preview-buffer
-        "Rm" 'elm-preview-main
-        ;; package
-        "pi" 'elm-import
-        "pc" 'elm-package-catalog
-        "pd" 'elm-documentation-lookup)
+        ;; format
+        "=b" 'elm-format-buffer
+        ;; oracle
+        "hh" 'elm-oracle-doc-at-point
+        "ht" 'elm-oracle-type-at-point)
 
       ;; Bind prefixes
-      (dolist (x '(("mp" . "package")
-                   ("mc" . "compile")
-                   ("mR" . "reactor")
-                   ("ms" . "repl")))
-        (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x)))
+      (dolist (x '(("m=" . "format")
+                   ("mh" . "help")
+                   ("mg" . "goto")
+                   ("mr" . "refactor")))
+        (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x))))
 
-      (evilified-state-evilify-map elm-package-mode-map
-        :mode elm-package-mode
-        :bindings
-        "g" 'elm-package-refresh
-        "v" 'elm-package-view
-        "m" 'elm-package-mark
-        "u" 'elm-package-unmark
-        "x" 'elm-package-install
-        "q" 'quit-window))))
+    ;; Bind general keys
+    (spacemacs/set-leader-keys-for-major-mode 'elm-mode
+      ;; refactoring
+      "ri" 'elm-sort-imports
+      ;; repl
+      "'"  'elm-repl-load
+      "si" 'elm-repl-load
+      "sf" 'elm-repl-push-decl
+      "sF" 'spacemacs/elm-repl-push-decl-focus
+      "sr" 'elm-repl-push
+      "sR" 'spacemacs/elm-repl-push-focus
+      ;; make
+      "cb" 'elm-compile-buffer
+      "cB" 'spacemacs/elm-compile-buffer-output
+      "cm" 'elm-compile-main
+      ;; reactor
+      "Rn" 'elm-preview-buffer
+      "Rm" 'elm-preview-main
+      ;; package
+      "pi" 'elm-import
+      "pc" 'elm-package-catalog
+      "pd" 'elm-documentation-lookup)
+
+    ;; Bind prefixes
+    (dolist (x '(("mp" . "package")
+                 ("mc" . "compile")
+                 ("mR" . "reactor")
+                 ("ms" . "repl")))
+      (spacemacs/declare-prefix-for-mode 'elm-mode (car x) (cdr x)))
+
+    (evilified-state-evilify-map elm-package-mode-map
+      :mode elm-package-mode
+      :bindings
+      "g" 'elm-package-refresh
+      "v" 'elm-package-view
+      "m" 'elm-package-mark
+      "u" 'elm-package-unmark
+      "x" 'elm-package-install
+      "q" 'quit-window)))
 
 (defun elm/init-elm-test-runner ()
   (use-package elm-test-runner
     :after elm-mode
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'elm-mode "mt" "test")
-      (spacemacs/set-leader-keys-for-major-mode 'elm-mode
-        "tb" 'elm-test-runner-run
-        "td" 'elm-test-runner-run-directory
-        "tp" 'elm-test-runner-run-project
-        "tr" 'elm-test-runner-rerun
-        "tw" 'elm-test-runner-watch
-        "t TAB" 'elm-test-runner-toggle-test-and-target))))
+    (spacemacs/declare-prefix-for-mode 'elm-mode "mt" "test")
+    (spacemacs/set-leader-keys-for-major-mode 'elm-mode
+      "tb" 'elm-test-runner-run
+      "td" 'elm-test-runner-run-directory
+      "tp" 'elm-test-runner-run-project
+      "tr" 'elm-test-runner-rerun
+      "tw" 'elm-test-runner-watch
+      "t TAB" 'elm-test-runner-toggle-test-and-target)))
 
 (defun elm/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -56,21 +56,20 @@
   (use-package ielm
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'ielm 'ielm)
-      ;; Load better help mode if helpful is installed
-      (if (configuration-layer/layer-used-p 'helpful)
-          (spacemacs/set-leader-keys-for-major-mode 'inferior-emacs-lisp-mode
-            "hh" 'helpful-at-point)
+    (spacemacs/register-repl 'ielm 'ielm)
+    ;; Load better help mode if helpful is installed
+    (if (configuration-layer/layer-used-p 'helpful)
         (spacemacs/set-leader-keys-for-major-mode 'inferior-emacs-lisp-mode
-          "hh" 'elisp-slime-nav-describe-elisp-thing-at-point))
-      (add-to-list 'spacemacs-jump-handlers-inferior-emacs-lisp-mode
-                   'elisp-slime-nav-find-elisp-thing-at-point)
-      (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
-        (spacemacs/declare-prefix-for-mode mode "ms" "ielm")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "'" 'ielm
-          "si" 'ielm)))
+          "hh" 'helpful-at-point)
+      (spacemacs/set-leader-keys-for-major-mode 'inferior-emacs-lisp-mode
+        "hh" 'elisp-slime-nav-describe-elisp-thing-at-point))
+    (add-to-list 'spacemacs-jump-handlers-inferior-emacs-lisp-mode
+                 'elisp-slime-nav-find-elisp-thing-at-point)
+    (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
+      (spacemacs/declare-prefix-for-mode mode "ms" "ielm")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "'" 'ielm
+        "si" 'ielm))
     :config
     (defun ielm-indent-line ()
       (interactive)
@@ -99,46 +98,45 @@
   (use-package edebug
     :defer t
     :init
-    (progn
-      ;; key bindings
-      (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "df" 'spacemacs/edebug-instrument-defun-on
-          "dF" 'spacemacs/edebug-instrument-defun-off))
-      (spacemacs/declare-prefix-for-mode 'edebug-eval-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'edebug-eval-mode "me" "eval")
-      (spacemacs/set-leader-keys-for-major-mode 'edebug-eval-mode
-        "gw" 'edebug-where
-        "a" 'edebug-delete-eval-item
-        "k" 'edebug-delete-eval-item
-        "," 'edebug-update-eval-list
-        "c" 'edebug-update-eval-list
-        "ee" 'edebug-eval-last-sexp
-        "eE" 'edebug-eval-print-last-sexp)
-      ;; since we evilify `edebug-mode-map' we don't need to intercept it to
-      ;; make it work with evil
-      (evil-set-custom-state-maps
-       'evil-intercept-maps
-       'evil-pending-intercept-maps
-       'intercept-state
-       'evil-make-intercept-map
-       (delq (assq 'edebug-mode-map evil-intercept-maps)
-             evil-intercept-maps))
-      (evilified-state-evilify-map edebug-mode-map
-        :eval-after-load edebug
-        :bindings
-        "a" 'edebug-stop
-        "c" 'edebug-go-mode
-        "s" 'edebug-step-mode
-        "S" 'edebug-next-mode)
-      (evilified-state-evilify-map edebug-eval-mode-map
-        :eval-after-load edebug
-        :bindings
-        "a" 'edebug-stop
-        "c" 'edebug-go-mode
-        "s" 'edebug-step-mode
-        "S" 'edebug-next-mode)
-      (advice-add 'edebug-mode :after 'spacemacs//edebug-mode))))
+    ;; key bindings
+    (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "df" 'spacemacs/edebug-instrument-defun-on
+        "dF" 'spacemacs/edebug-instrument-defun-off))
+    (spacemacs/declare-prefix-for-mode 'edebug-eval-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'edebug-eval-mode "me" "eval")
+    (spacemacs/set-leader-keys-for-major-mode 'edebug-eval-mode
+      "gw" 'edebug-where
+      "a" 'edebug-delete-eval-item
+      "k" 'edebug-delete-eval-item
+      "," 'edebug-update-eval-list
+      "c" 'edebug-update-eval-list
+      "ee" 'edebug-eval-last-sexp
+      "eE" 'edebug-eval-print-last-sexp)
+    ;; since we evilify `edebug-mode-map' we don't need to intercept it to
+    ;; make it work with evil
+    (evil-set-custom-state-maps
+     'evil-intercept-maps
+     'evil-pending-intercept-maps
+     'intercept-state
+     'evil-make-intercept-map
+     (delq (assq 'edebug-mode-map evil-intercept-maps)
+           evil-intercept-maps))
+    (evilified-state-evilify-map edebug-mode-map
+      :eval-after-load edebug
+      :bindings
+      "a" 'edebug-stop
+      "c" 'edebug-go-mode
+      "s" 'edebug-step-mode
+      "S" 'edebug-next-mode)
+    (evilified-state-evilify-map edebug-eval-mode-map
+      :eval-after-load edebug
+      :bindings
+      "a" 'edebug-stop
+      "c" 'edebug-go-mode
+      "s" 'edebug-step-mode
+      "S" 'edebug-next-mode)
+    (advice-add 'edebug-mode :after 'spacemacs//edebug-mode)))
 
 (defun emacs-lisp/post-init-eldoc ()
   (add-hook 'emacs-lisp-mode-hook 'eldoc-mode))
@@ -147,18 +145,16 @@
   (use-package auto-compile
     :defer (spacemacs/defer)
     :init
-    (progn
-      (spacemacs|require-when-dumping 'auto-compile)
-      (setq auto-compile-display-buffer nil
-            ;; lets spaceline manage the mode-line
-            auto-compile-use-mode-line nil
-            auto-compile-mode-line-counter t)
-      (add-hook 'emacs-lisp-mode-hook 'auto-compile-mode))
+    (spacemacs|require-when-dumping 'auto-compile)
+    (setq auto-compile-display-buffer nil
+          ;; lets spaceline manage the mode-line
+          auto-compile-use-mode-line nil
+          auto-compile-mode-line-counter t)
+    (add-hook 'emacs-lisp-mode-hook 'auto-compile-mode)
     :config
-    (progn
-      (spacemacs|hide-lighter auto-compile-mode)
-      (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
-        "cl" 'auto-compile-display-log))))
+    (spacemacs|hide-lighter auto-compile-mode)
+    (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
+      "cl" 'auto-compile-display-log)))
 
 (defun emacs-lisp/init-elisp-def ()
   (use-package elisp-def
@@ -169,24 +165,23 @@
   (use-package elisp-slime-nav
     :defer (spacemacs/defer)
     :init
-    (progn
-      (spacemacs|require-when-dumping 'elisp-slime-nav)
-      (add-hook 'emacs-lisp-mode-hook 'elisp-slime-nav-mode)
-      (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
-        (spacemacs/declare-prefix-for-mode mode "mg" "find-symbol")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "gb" 'xref-pop-marker-stack)
-        (spacemacs/declare-prefix-for-mode mode "mh" "help")
+    (spacemacs|require-when-dumping 'elisp-slime-nav)
+    (add-hook 'emacs-lisp-mode-hook 'elisp-slime-nav-mode)
+    (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
+      (spacemacs/declare-prefix-for-mode mode "mg" "find-symbol")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "gb" 'xref-pop-marker-stack)
+      (spacemacs/declare-prefix-for-mode mode "mh" "help")
 
-        ;; Load better help mode if helpful is installed
-        (if (configuration-layer/layer-used-p 'helpful)
-            (spacemacs/set-leader-keys-for-major-mode mode
-              "hh" 'helpful-at-point)
+      ;; Load better help mode if helpful is installed
+      (if (configuration-layer/layer-used-p 'helpful)
           (spacemacs/set-leader-keys-for-major-mode mode
-            "hh" 'elisp-slime-nav-describe-elisp-thing-at-point))
-        (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode))))
-          (add-to-list jumpl 'elisp-def)
-          (add-to-list jumpl 'elisp-slime-nav-find-elisp-thing-at-point))))
+            "hh" 'helpful-at-point)
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "hh" 'elisp-slime-nav-describe-elisp-thing-at-point))
+      (let ((jumpl (intern (format "spacemacs-jump-handlers-%S" mode))))
+        (add-to-list jumpl 'elisp-def)
+        (add-to-list jumpl 'elisp-slime-nav-find-elisp-thing-at-point)))
     :config (spacemacs|hide-lighter elisp-slime-nav-mode)))
 
 (defun emacs-lisp/init-emacs-lisp ()
@@ -214,56 +209,54 @@
     :mode (("\\*.el\\'" . emacs-lisp-mode)
            ("Cask\\'" . emacs-lisp-mode))
     :init
-    (progn
-      (evil-define-key 'normal macrostep-keymap "q" 'macrostep-collapse-all)
-      (spacemacs|define-transient-state macrostep
-        :title "MacroStep Transient State"
-        :doc "\n[_e_] expand [_c_] collapse [_n_/_N_] next/previous [_q_] quit"
-        :foreign-keys run
-        :bindings
-        ("e" macrostep-expand)
-        ("c" macrostep-collapse)
-        ("n" macrostep-next-macro)
-        ("N" macrostep-prev-macro)
-        ("q" macrostep-collapse-all :exit t))
-      (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
-        "dm" 'spacemacs/macrostep-transient-state/body))))
+    (evil-define-key 'normal macrostep-keymap "q" 'macrostep-collapse-all)
+    (spacemacs|define-transient-state macrostep
+      :title "MacroStep Transient State"
+      :doc "\n[_e_] expand [_c_] collapse [_n_/_N_] next/previous [_q_] quit"
+      :foreign-keys run
+      :bindings
+      ("e" macrostep-expand)
+      ("c" macrostep-collapse)
+      ("n" macrostep-next-macro)
+      ("N" macrostep-prev-macro)
+      ("q" macrostep-collapse-all :exit t))
+    (spacemacs/set-leader-keys-for-major-mode 'emacs-lisp-mode
+      "dm" 'spacemacs/macrostep-transient-state/body)))
 
 (defun emacs-lisp/init-nameless ()
   (use-package nameless
     :defer (spacemacs/defer)
     :init
-    (progn
-      (spacemacs|require-when-dumping 'nameless)
-      (setq
-       ;; always show the separator since it can have a semantic purpose
-       ;; like in Spacemacs where - is variable and / is a function.
-       ;; moreover it makes nameless work for all kind of separators.
-       nameless-separator nil
-       ;; Use > as the defautl prefix : is already used for
-       ;; keywords
-       nameless-prefix ">")
-      ;; some default aliases for Spacemacs source code
-      (setq nameless-global-aliases '(("SB" . "spacemacs-buffer")
-                                      ("S"  . "spacemacs")
-                                      (".S"  . "dotspacemacs")
-                                      ("CL" . "configuration-layer")))
-      ;; make `nameless-current-name' safe as a local variable for string
-      ;; values
-      (put 'nameless-current-name 'safe-local-variable #'stringp)
-      (spacemacs|diminish nameless-mode " 🅽" " [n]")
-      (spacemacs|add-toggle nameless
-        :status nameless-mode
-        :on (nameless-mode)
-        :off (nameless-mode -1)
-        :documentation "Hide package namespaces in your emacs-lisp code."
-        :evil-leader-for-mode (emacs-lisp-mode . "Tn"))
-      ;; activate nameless only when in a GUI
-      ;; in a terminal nameless triggers all sorts of graphical glitches.
-      (spacemacs|unless-dumping-and-eval-after-loaded-dump nameless
-        (spacemacs|do-after-display-system-init
-         (when emacs-lisp-hide-namespace-prefix
-           (spacemacs/toggle-nameless-on-register-hook-emacs-lisp-mode)))))))
+    (spacemacs|require-when-dumping 'nameless)
+    (setq
+     ;; always show the separator since it can have a semantic purpose
+     ;; like in Spacemacs where - is variable and / is a function.
+     ;; moreover it makes nameless work for all kind of separators.
+     nameless-separator nil
+     ;; Use > as the defautl prefix : is already used for
+     ;; keywords
+     nameless-prefix ">")
+    ;; some default aliases for Spacemacs source code
+    (setq nameless-global-aliases '(("SB" . "spacemacs-buffer")
+                                    ("S"  . "spacemacs")
+                                    (".S"  . "dotspacemacs")
+                                    ("CL" . "configuration-layer")))
+    ;; make `nameless-current-name' safe as a local variable for string
+    ;; values
+    (put 'nameless-current-name 'safe-local-variable #'stringp)
+    (spacemacs|diminish nameless-mode " 🅽" " [n]")
+    (spacemacs|add-toggle nameless
+      :status nameless-mode
+      :on (nameless-mode)
+      :off (nameless-mode -1)
+      :documentation "Hide package namespaces in your emacs-lisp code."
+      :evil-leader-for-mode (emacs-lisp-mode . "Tn"))
+    ;; activate nameless only when in a GUI
+    ;; in a terminal nameless triggers all sorts of graphical glitches.
+    (spacemacs|unless-dumping-and-eval-after-loaded-dump nameless
+      (spacemacs|do-after-display-system-init
+       (when emacs-lisp-hide-namespace-prefix
+         (spacemacs/toggle-nameless-on-register-hook-emacs-lisp-mode))))))
 
 (defun emacs-lisp/init-overseer ()
   (use-package overseer

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -44,17 +44,16 @@
           (erlang-mode . spacemacs//erlang-default)
           (erlang-mode-local-vars . spacemacs//erlang-setup-backend)
     :init
-    (progn
-      ;; (setq erlang-root-dir "/usr/lib/erlang/erts-5.10.3")
-      ;; (add-to-list 'exec-path "/usr/lib/erlang/erts-5.10.3/bin")
-      ;; (setq erlang-man-root-dir "/usr/lib/erlang/erts-5.10.3/man")
-      ;; (add-hook 'erlang-mode-hook
-      ;;           (lambda ()
-      ;;             (setq mode-name "Erlang")
-      ;;             ;; when starting an Erlang shell in Emacs, with a custom node name
-      ;;             (setq inferior-erlang-machine-options '("-sname" "syl20bnr"))
-      ;;             ))
-      (setq erlang-compile-extra-opts '(debug_info)))
+    ;; (setq erlang-root-dir "/usr/lib/erlang/erts-5.10.3")
+    ;; (add-to-list 'exec-path "/usr/lib/erlang/erts-5.10.3/bin")
+    ;; (setq erlang-man-root-dir "/usr/lib/erlang/erts-5.10.3/man")
+    ;; (add-hook 'erlang-mode-hook
+    ;;           (lambda ()
+    ;;             (setq mode-name "Erlang")
+    ;;             ;; when starting an Erlang shell in Emacs, with a custom node name
+    ;;             (setq inferior-erlang-machine-options '("-sname" "syl20bnr"))
+    ;;             ))
+    (setq erlang-compile-extra-opts '(debug_info))
     :config (require 'erlang-start)))
 
 (defun erlang/pre-init-dap-mode ()

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -80,30 +80,29 @@
            ("\\.[Jj][Mm][Dd]\\'" . ess-jags-mode))
     :commands (R stata julia SAS ess-julia-mode)
     :init
-    (progn
-      (setq ess-use-company nil
-            ess-offset-continued 'straight
-            ess-nuke-trailing-whitespace-p t
-            ess-default-style 'DEFAULT)
+    (setq ess-use-company nil
+          ess-offset-continued 'straight
+          ess-nuke-trailing-whitespace-p t
+          ess-default-style 'DEFAULT)
 
-      ;; add support for evil states
-      (evil-set-initial-state 'ess-help-mode 'motion)
+    ;; add support for evil states
+    (evil-set-initial-state 'ess-help-mode 'motion)
 
-      (spacemacs/register-repl 'ess-site #'spacemacs/ess-start-repl)
+    (spacemacs/register-repl 'ess-site #'spacemacs/ess-start-repl)
 
-      (add-hook 'ess-r-mode-hook #'spacemacs//ess-may-setup-r-lsp)
-      (add-hook 'inferior-ess-mode-hook
-                'spacemacs//ess-fix-read-only-inferior-ess-mode)
+    (add-hook 'ess-r-mode-hook #'spacemacs//ess-may-setup-r-lsp)
+    (add-hook 'inferior-ess-mode-hook
+              'spacemacs//ess-fix-read-only-inferior-ess-mode)
 
-      (with-eval-after-load 'ess-julia
-        (spacemacs/ess-bind-keys-for-julia))
-      (with-eval-after-load 'ess-r-mode
-        (spacemacs/ess-bind-keys-for-r)
-        (unless (eq ess-r-backend 'lsp)
-          (spacemacs/declare-prefix-for-mode 'ess-r-mode "mg" "goto")
-          (define-key ess-doc-map "h" #'ess-display-help-on-object)))
-      (with-eval-after-load 'ess-inf-mode
-        (spacemacs/ess-bind-keys-for-inferior)))
+    (with-eval-after-load 'ess-julia
+      (spacemacs/ess-bind-keys-for-julia))
+    (with-eval-after-load 'ess-r-mode
+      (spacemacs/ess-bind-keys-for-r)
+      (unless (eq ess-r-backend 'lsp)
+        (spacemacs/declare-prefix-for-mode 'ess-r-mode "mg" "goto")
+        (define-key ess-doc-map "h" #'ess-display-help-on-object)))
+    (with-eval-after-load 'ess-inf-mode
+      (spacemacs/ess-bind-keys-for-inferior))
     :config
     (define-key ess-mode-map (kbd "<s-return>") #'ess-eval-line))
 

--- a/layers/+lang/extempore/packages.el
+++ b/layers/+lang/extempore/packages.el
@@ -33,30 +33,29 @@
     :init
     (spacemacs/register-repl 'extempore-mode 'extempore-repl "extempore")
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'extempore-mode "mc" "process")
-      (spacemacs/declare-prefix-for-mode 'extempore-mode "me" "eval")
+    (spacemacs/declare-prefix-for-mode 'extempore-mode "mc" "process")
+    (spacemacs/declare-prefix-for-mode 'extempore-mode "me" "eval")
 
-      (spacemacs/set-leader-keys-for-major-mode 'extempore-mode
-        "'"  'extempore-repl
-        ","  'lisp-state-toggle-lisp-state
+    (spacemacs/set-leader-keys-for-major-mode 'extempore-mode
+      "'"  'extempore-repl
+      ","  'lisp-state-toggle-lisp-state
 
-        "cc" 'switch-to-extempore
-        "cj" 'extempore-connect
+      "cc" 'switch-to-extempore
+      "cj" 'extempore-connect
 
-        "ee" 'extempore-send-last-sexp
-        "ef" 'extempore-send-definition
-        "er" 'extempore-send-region
-        "eb" 'extempore-send-buffer-or-region
-        (setq extempore-tab-completion nil)
+      "ee" 'extempore-send-last-sexp
+      "ef" 'extempore-send-definition
+      "er" 'extempore-send-region
+      "eb" 'extempore-send-buffer-or-region
+      (setq extempore-tab-completion nil)
 
-        (set-face-attribute 'extempore-blink-face nil :foreground "#272822" :background "#FD971F")
-        (set-face-attribute 'extempore-sb-blink-face nil :foreground "#272822" :background "#39FF14")
+      (set-face-attribute 'extempore-blink-face nil :foreground "#272822" :background "#FD971F")
+      (set-face-attribute 'extempore-sb-blink-face nil :foreground "#272822" :background "#39FF14")
 
-        ;; stop the ' (quote) character being paired by smartparens
-        (with-eval-after-load 'smartparens
-          (sp-local-pair 'extempore-mode "'" nil :actions nil)
-          (sp-local-pair 'extempore-mode "`" nil :actions nil))))))
+      ;; stop the ' (quote) character being paired by smartparens
+      (with-eval-after-load 'smartparens
+        (sp-local-pair 'extempore-mode "'" nil :actions nil)
+        (sp-local-pair 'extempore-mode "`" nil :actions nil)))))
 
 (defun extempore/post-init-eldoc ()
   (add-hook 'extempore-mode-hook #'spacemacs//extempore-setup-eldoc))

--- a/layers/+lang/factor/packages.el
+++ b/layers/+lang/factor/packages.el
@@ -43,65 +43,62 @@
     :commands factor-mode run-factor fuel-mode
     :mode ("factor\\'" . factor-mode)
     :init
-    (progn
-      (spacemacs/register-repl 'fuel-mode 'run-factor))
+    (spacemacs/register-repl 'fuel-mode 'run-factor)
     :config
-    (progn
-      (require 'fuel-mode)
-      (mapc (lambda (x)
-              (spacemacs/declare-prefix-for-mode 'factor-mode (car x) (cdr x)))
-            '(("mh" . "help")
-              ("me" . "eval")
-              ("mc" . "compile")
-              ("mg" . "nav")
-              ("ms" . "repl")
-              ("mS" . "scaffold")))
-      (spacemacs/set-leader-keys-for-major-mode 'factor-mode
-        "'" 'run-factor
+    (require 'fuel-mode)
+    (mapc (lambda (x)
+            (spacemacs/declare-prefix-for-mode 'factor-mode (car x) (cdr x)))
+          '(("mh" . "help")
+            ("me" . "eval")
+            ("mc" . "compile")
+            ("mg" . "nav")
+            ("ms" . "repl")
+            ("mS" . "scaffold")))
+    (spacemacs/set-leader-keys-for-major-mode 'factor-mode
+      "'" 'run-factor
 
-        "cc" 'fuel-run-file
+      "cc" 'fuel-run-file
 
-        "ef" 'fuel-eval-definition
-        "er" 'fuel-eval-region
-        "eR" 'fuel-eval-extended-region
+      "ef" 'fuel-eval-definition
+      "er" 'fuel-eval-region
+      "eR" 'fuel-eval-extended-region
 
-        "gg" 'fuel-edit-word-at-point
-        "ga" 'factor-visit-other-file
+      "gg" 'fuel-edit-word-at-point
+      "ga" 'factor-visit-other-file
 
-        "ta" 'fuel-test-vocab
+      "ta" 'fuel-test-vocab
 
-        "rs" 'fuel-refactor-extract-sexp
-        "rr" 'fuel-refactor-extract-region
-        "rv" 'fuel-refactor-extract-vocab
-        "ri" 'fuel-refactor-inline-word
-        "rw" 'fuel-refactor-rename-word
-        "ra" 'fuel-refactor-extract-article
-        "rg" 'fuel-refactor-make-generic
-        "ru" 'fuel-update-usings
+      "rs" 'fuel-refactor-extract-sexp
+      "rr" 'fuel-refactor-extract-region
+      "rv" 'fuel-refactor-extract-vocab
+      "ri" 'fuel-refactor-inline-word
+      "rw" 'fuel-refactor-rename-word
+      "ra" 'fuel-refactor-extract-article
+      "rg" 'fuel-refactor-make-generic
+      "ru" 'fuel-update-usings
 
-        "ss" 'run-factor
+      "ss" 'run-factor
 
-        "hh" 'fuel-help
-        "he" 'factor//fuel-stack-effect
-        "hp" 'fuel-apropos
-        "hv" 'fuel-show-file-words
-        "h<" 'fuel-show-callers
-        "h>" 'fuel-show-callees
+      "hh" 'fuel-help
+      "he" 'factor//fuel-stack-effect
+      "hp" 'fuel-apropos
+      "hv" 'fuel-show-file-words
+      "h<" 'fuel-show-callers
+      "h>" 'fuel-show-callees
 
-        "Sv" 'fuel-scaffold-vocab
-        "Sh" 'fuel-scaffold-help
-        )
+      "Sv" 'fuel-scaffold-vocab
+      "Sh" 'fuel-scaffold-help
+      )
 
-      (spacemacs/set-leader-keys-for-major-mode 'fuel-listener-mode
-        "v" 'fuel-edit-vocabulary
-        "r" 'fuel-refresh-all
-        "Ts" 'fuel-stack-mode
-        "h" 'fuel-help
-        "Sv" 'fuel-scaffold-vocab
-        )
+    (spacemacs/set-leader-keys-for-major-mode 'fuel-listener-mode
+      "v" 'fuel-edit-vocabulary
+      "r" 'fuel-refresh-all
+      "Ts" 'fuel-stack-mode
+      "h" 'fuel-help
+      "Sv" 'fuel-scaffold-vocab
+      )
 
-      (evilified-state-evilify-map fuel-help-mode-map
-        :mode fuel-help-mode)
-      (dolist (mode '(fuel-debug-uses-mode fuel-debug-mode))
-        (evil-set-initial-state mode 'insert))))
-  )
+    (evilified-state-evilify-map fuel-help-mode-map
+      :mode fuel-help-mode)
+    (dolist (mode '(fuel-debug-uses-mode fuel-debug-mode))
+      (evil-set-initial-state mode 'insert))))

--- a/layers/+lang/faust/packages.el
+++ b/layers/+lang/faust/packages.el
@@ -38,11 +38,10 @@
     :defer t
     :mode "\\.\\(dsp\\|lib\\)\\'"
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'faust-mode
-        "cf" 'spacemacs/faust-to-firefox
-        "cg" 'spacemacs/faust-to-jack-gtk
-        "cq" 'spacemacs/faust-to-jack-qt))))
+    (spacemacs/set-leader-keys-for-major-mode 'faust-mode
+      "cf" 'spacemacs/faust-to-firefox
+      "cg" 'spacemacs/faust-to-jack-gtk
+      "cq" 'spacemacs/faust-to-jack-qt)))
 
 (defun faust/post-init-yasnippet ()
   (add-hook 'faust-mode-hook 'spacemacs/load-yasnippet))

--- a/layers/+lang/fountain/packages.el
+++ b/layers/+lang/fountain/packages.el
@@ -35,45 +35,44 @@
   (use-package fountain-mode
     :defer t
     :config
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'fountain-mode
-        ;; Editing commands
-        "RET" 'fountain-upcase-line-and-newline
-        "xU" 'fountain-upcase-line
-        "cd" 'fountain-add-continued-dialog
-        "cD" 'fountain-remove-continued-dialog
-        "in" 'fountain-insert-note
-        "is" 'fountain-insert-synopsis
-        "ii" 'auto-insert
-        "cn" 'fountain-add-scene-numbers
-        "cN" 'fountain-remove-scene-numbers
-        "ib" 'fountain-insert-page-break
-        "]" 'fountain-completion-update
+    (spacemacs/set-leader-keys-for-major-mode 'fountain-mode
+      ;; Editing commands
+      "RET" 'fountain-upcase-line-and-newline
+      "xU" 'fountain-upcase-line
+      "cd" 'fountain-add-continued-dialog
+      "cD" 'fountain-remove-continued-dialog
+      "in" 'fountain-insert-note
+      "is" 'fountain-insert-synopsis
+      "ii" 'auto-insert
+      "cn" 'fountain-add-scene-numbers
+      "cN" 'fountain-remove-scene-numbers
+      "ib" 'fountain-insert-page-break
+      "]" 'fountain-completion-update
 
-        "Tm" 'fountain-toggle-hide-emphasis-markup
-        "Te" 'fountain-toggle-hide-element-markup
+      "Tm" 'fountain-toggle-hide-emphasis-markup
+      "Te" 'fountain-toggle-hide-element-markup
 
-        ;; Navigation commands
-        "js" 'fountain-goto-scene
-        "jp" 'fountain-goto-page
+      ;; Navigation commands
+      "js" 'fountain-goto-scene
+      "jp" 'fountain-goto-page
 
-        ;; Outline commands
-        "TAB"  'fountain-outline-cycle
-        "o"  'fountain-outline-to-indirect-buffer
-        "ih" 'fountain-insert-section-heading
+      ;; Outline commands
+      "TAB"  'fountain-outline-cycle
+      "o"  'fountain-outline-to-indirect-buffer
+      "ih" 'fountain-insert-section-heading
 
-        ;; Pagination commands
-        "cp" 'fountain-count-pages
-        "cu" 'fountain-pagination-update
+      ;; Pagination commands
+      "cp" 'fountain-count-pages
+      "cu" 'fountain-pagination-update
 
-        ;; Exporting commands
-        "ee" 'fountain-export-command
-        "ev" 'fountain-export-view)
+      ;; Exporting commands
+      "ee" 'fountain-export-command
+      "ev" 'fountain-export-view)
 
-      (spacemacs/declare-prefix-for-mode 'fountain-mode "mi" "fountain/insert")
-      (spacemacs/declare-prefix-for-mode 'fountain-mode "mx" "fountain/text")
-      (spacemacs/declare-prefix-for-mode 'fountain-mode "mc" "fountain/command")
-      (spacemacs/declare-prefix-for-mode 'fountain-mode "mT" "fountain/toggle")
-      (spacemacs/declare-prefix-for-mode 'fountain-mode "mj" "fountain/jump")
-      (spacemacs/declare-prefix-for-mode 'fountain-mode "me" "fountain/export")
-      )))
+    (spacemacs/declare-prefix-for-mode 'fountain-mode "mi" "fountain/insert")
+    (spacemacs/declare-prefix-for-mode 'fountain-mode "mx" "fountain/text")
+    (spacemacs/declare-prefix-for-mode 'fountain-mode "mc" "fountain/command")
+    (spacemacs/declare-prefix-for-mode 'fountain-mode "mT" "fountain/toggle")
+    (spacemacs/declare-prefix-for-mode 'fountain-mode "mj" "fountain/jump")
+    (spacemacs/declare-prefix-for-mode 'fountain-mode "me" "fountain/export")
+    ))

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -40,39 +40,36 @@
   (use-package eglot-fsharp
     :defer t
     :init
-    (progn
-      (require 'f)
-      (setq eglot-fsharp-server-install-dir
-            (expand-file-name
-             (locate-user-emacs-file (f-join ".cache" "eglot")))))))
+    (require 'f)
+    (setq eglot-fsharp-server-install-dir
+          (expand-file-name
+           (locate-user-emacs-file (f-join ".cache" "eglot"))))))
 
 (defun fsharp/init-fsharp-mode ()
   (use-package fsharp-mode
     :defer t
     :init
-    (progn
-      (when (eq fsharp-backend 'eglot)
-        (require 'eglot-fsharp))
-      (setq fsharp-doc-idle-delay .2)
-      (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#")
-      (add-hook 'fsharp-mode-hook #'spacemacs//fsharp-setup-backend))
+    (when (eq fsharp-backend 'eglot)
+      (require 'eglot-fsharp))
+    (setq fsharp-doc-idle-delay .2)
+    (spacemacs/register-repl 'fsharp-mode 'fsharp-show-subshell "F#")
+    (add-hook 'fsharp-mode-hook #'spacemacs//fsharp-setup-backend)
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'fsharp-mode "ms" "repl")
-      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mc" "compile")
-      (when (eq fsharp-backend 'eglot)
-        (spacemacs/declare-prefix-for-mode 'fsharp-mode "mg" "goto"))
-      (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
-        "cc" 'compile
-        "ga" 'fsharp-find-alternate-file
-        "sb" 'fsharp-load-buffer-file
-        "sB" 'spacemacs/fsharp-load-buffer-file-focus
-        "si" 'fsharp-show-subshell
-        "sp" 'fsharp-eval-phrase
-        "sP" 'spacemacs/fsharp-eval-phrase-focus
-        "sr" 'fsharp-eval-region
-        "sR" 'spacemacs/fsharp-eval-region-focus
-        "'"  'fsharp-show-subshell))))
+    (spacemacs/declare-prefix-for-mode 'fsharp-mode "ms" "repl")
+    (spacemacs/declare-prefix-for-mode 'fsharp-mode "mc" "compile")
+    (when (eq fsharp-backend 'eglot)
+      (spacemacs/declare-prefix-for-mode 'fsharp-mode "mg" "goto"))
+    (spacemacs/set-leader-keys-for-major-mode 'fsharp-mode
+      "cc" 'compile
+      "ga" 'fsharp-find-alternate-file
+      "sb" 'fsharp-load-buffer-file
+      "sB" 'spacemacs/fsharp-load-buffer-file-focus
+      "si" 'fsharp-show-subshell
+      "sp" 'fsharp-eval-phrase
+      "sP" 'spacemacs/fsharp-eval-phrase-focus
+      "sr" 'fsharp-eval-region
+      "sR" 'spacemacs/fsharp-eval-region-focus
+      "'"  'fsharp-show-subshell)))
 
 (defun fsharp/post-init-ggtags ()
   (add-hook 'fsharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -90,32 +90,30 @@
   (use-package go-gen-test
     :defer t
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'go-mode "mtg" "generate")
-      (spacemacs/set-leader-keys-for-major-mode 'go-mode
-        "tgg" 'go-gen-test-dwim
-        "tgf" 'go-gen-test-exported
-        "tgF" 'go-gen-test-all))))
+    (spacemacs/declare-prefix-for-mode 'go-mode "mtg" "generate")
+    (spacemacs/set-leader-keys-for-major-mode 'go-mode
+      "tgg" 'go-gen-test-dwim
+      "tgf" 'go-gen-test-exported
+      "tgF" 'go-gen-test-all)))
 
 (defun go/init-go-guru ()
   (use-package go-impl
     :defer t
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'go-mode "mf" "guru")
-      (spacemacs/set-leader-keys-for-major-mode 'go-mode
-        "f<" 'go-guru-callers
-        "f>" 'go-guru-callees
-        "fc" 'go-guru-peers
-        "fd" 'go-guru-describe
-        "fe" 'go-guru-whicherrs
-        "ff" 'go-guru-freevars
-        "fi" 'go-guru-implements
-        "fj" 'go-guru-definition
-        "fo" 'go-guru-set-scope
-        "fp" 'go-guru-pointsto
-        "fr" 'go-guru-referrers
-        "fs" 'go-guru-callstack))))
+    (spacemacs/declare-prefix-for-mode 'go-mode "mf" "guru")
+    (spacemacs/set-leader-keys-for-major-mode 'go-mode
+      "f<" 'go-guru-callers
+      "f>" 'go-guru-callees
+      "fc" 'go-guru-peers
+      "fd" 'go-guru-describe
+      "fe" 'go-guru-whicherrs
+      "ff" 'go-guru-freevars
+      "fi" 'go-guru-implements
+      "fj" 'go-guru-definition
+      "fo" 'go-guru-set-scope
+      "fp" 'go-guru-pointsto
+      "fr" 'go-guru-referrers
+      "fs" 'go-guru-callstack)))
 
 (defun go/init-go-impl ()
   (use-package go-impl
@@ -129,41 +127,39 @@
            (go-mode-local-vars . spacemacs//go-setup-backend)
            (go-mode-local-vars . spacemacs//go-setup-format))
     :init
-    (progn
-      ;; get go packages much faster
-      (setq go-packages-function 'spacemacs/go-packages-gopkgs)
-      (spacemacs|add-toggle go-test-verbose
-        :documentation "Enable verbose test output."
-        :status go-test-verbose
-        :on (setq go-test-verbose t)
-        :off (setq go-test-verbose nil)
-        :evil-leader-for-mode (go-mode . "tv")))
+    ;; get go packages much faster
+    (setq go-packages-function 'spacemacs/go-packages-gopkgs)
+    (spacemacs|add-toggle go-test-verbose
+      :documentation "Enable verbose test output."
+      :status go-test-verbose
+      :on (setq go-test-verbose t)
+      :off (setq go-test-verbose nil)
+      :evil-leader-for-mode (go-mode . "tv"))
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'go-mode "me" "playground")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mi" "imports")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mr" "refactoring")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mt" "test")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mT" "toggle")
-      (spacemacs/declare-prefix-for-mode 'go-mode "mx" "execute")
-      (spacemacs/set-leader-keys-for-major-mode 'go-mode
-        "="  'gofmt
-        "eb" 'go-play-buffer
-        "ed" 'go-download-play
-        "er" 'go-play-region
-        "ga" 'ff-find-other-file
-        "gc" 'go-coverage
-        "hh" 'godoc-at-point
-        "ia" 'go-import-add
-        "ig" 'go-goto-imports
-        "ir" 'go-remove-unused-imports
-        "tP" 'spacemacs/go-run-package-tests-nested
-        "tp" 'spacemacs/go-run-package-tests
-        "ts" 'spacemacs/go-run-test-current-suite
-        "tt" 'spacemacs/go-run-test-current-function
-        "xx" 'spacemacs/go-run-main))))
+    (spacemacs/declare-prefix-for-mode 'go-mode "me" "playground")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mi" "imports")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mr" "refactoring")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mt" "test")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mT" "toggle")
+    (spacemacs/declare-prefix-for-mode 'go-mode "mx" "execute")
+    (spacemacs/set-leader-keys-for-major-mode 'go-mode
+      "="  'gofmt
+      "eb" 'go-play-buffer
+      "ed" 'go-download-play
+      "er" 'go-play-region
+      "ga" 'ff-find-other-file
+      "gc" 'go-coverage
+      "hh" 'godoc-at-point
+      "ia" 'go-import-add
+      "ig" 'go-goto-imports
+      "ir" 'go-remove-unused-imports
+      "tP" 'spacemacs/go-run-package-tests-nested
+      "tp" 'spacemacs/go-run-package-tests
+      "ts" 'spacemacs/go-run-test-current-suite
+      "tt" 'spacemacs/go-run-test-current-function
+      "xx" 'spacemacs/go-run-main)))
 
 (defun go/init-go-rename ()
   (use-package go-rename

--- a/layers/+lang/graphql/packages.el
+++ b/layers/+lang/graphql/packages.el
@@ -30,15 +30,14 @@
   (use-package graphql-mode
     :defer t
     :init
-    (progn
-      (add-to-list 'spacemacs-jump-handlers-graphql-mode 'ahs-backward-definition)
-      (when (configuration-layer/layer-used-p 'prettier)
-        (spacemacs/declare-prefix-for-mode 'graphql-mode "m=" "format"))
-      (spacemacs/declare-prefix-for-mode 'graphql-mode "mg" "goto")
-      (spacemacs/set-leader-keys-for-major-mode 'graphql-mode
-        "s" 'graphql-send-query
-        "e" 'graphql-select-endpoint
-        "h" 'graphql-edit-headers))))
+    (add-to-list 'spacemacs-jump-handlers-graphql-mode 'ahs-backward-definition)
+    (when (configuration-layer/layer-used-p 'prettier)
+      (spacemacs/declare-prefix-for-mode 'graphql-mode "m=" "format"))
+    (spacemacs/declare-prefix-for-mode 'graphql-mode "mg" "goto")
+    (spacemacs/set-leader-keys-for-major-mode 'graphql-mode
+      "s" 'graphql-send-query
+      "e" 'graphql-select-endpoint
+      "h" 'graphql-edit-headers)))
 
 (defun graphql/post-init-company ()
   (spacemacs|add-company-backends

--- a/layers/+lang/graphviz/packages.el
+++ b/layers/+lang/graphviz/packages.el
@@ -38,28 +38,27 @@
            ("\\.gv\\'"        . graphviz-dot-mode))
     :init (setq graphviz-dot-indent-width tab-width)
     :config
-    (progn
-      (spacemacs|add-toggle graphviz-live-reload
-        :status graphviz-dot-auto-preview-on-save
-        :on (graphviz-turn-on-live-preview)
-        :off (graphviz-turn-off-live-preview)
-        :documentation "Enable Graphviz live reload.")
+    (spacemacs|add-toggle graphviz-live-reload
+      :status graphviz-dot-auto-preview-on-save
+      :on (graphviz-turn-on-live-preview)
+      :off (graphviz-turn-off-live-preview)
+      :documentation "Enable Graphviz live reload.")
+    (spacemacs/set-leader-keys-for-major-mode 'graphviz-dot-mode
+      "=" 'graphviz-dot-indent-graph
+      "c" 'compile
+      "t" 'spacemacs/toggle-graphviz-live-reload)
+    (when dotspacemacs-major-mode-emacs-leader-key
       (spacemacs/set-leader-keys-for-major-mode 'graphviz-dot-mode
-        "=" 'graphviz-dot-indent-graph
-        "c" 'compile
-        "t" 'spacemacs/toggle-graphviz-live-reload)
-      (when dotspacemacs-major-mode-emacs-leader-key
-        (spacemacs/set-leader-keys-for-major-mode 'graphviz-dot-mode
-          dotspacemacs-major-mode-emacs-leader-key 'graphviz-dot-preview))
-      (when dotspacemacs-major-mode-leader-key
-        (spacemacs/set-leader-keys-for-major-mode 'graphviz-dot-mode
-          dotspacemacs-major-mode-leader-key 'graphviz-dot-preview)))))
+        dotspacemacs-major-mode-emacs-leader-key 'graphviz-dot-preview))
+    (when dotspacemacs-major-mode-leader-key
+      (spacemacs/set-leader-keys-for-major-mode 'graphviz-dot-mode
+        dotspacemacs-major-mode-leader-key 'graphviz-dot-preview))))
 
 (defun graphviz/pre-init-smartparens ()
   (spacemacs|use-package-add-hook graphviz-dot-mode
     :post-config
     (progn
-      ;; allow smartparens to work properly
+    ;; allow smartparens to work properly
       (define-key graphviz-dot-mode-map "{" nil)
       (define-key graphviz-dot-mode-map "}" nil))))
 
@@ -67,8 +66,8 @@
   (spacemacs|use-package-add-hook org
     :post-config
     (progn
-      (add-to-list 'org-babel-load-languages '(dot . t))
       ;; replace fundamental mode by graphiz one
+      (add-to-list 'org-babel-load-languages '(dot . t))
       (setq org-src-lang-modes
             (append '(("dot" . graphviz-dot))
-                    (delete '("dot" . fundamental) org-src-lang-modes))))))
+                     (delete '("dot" . fundamental) org-src-lang-modes))))))

--- a/layers/+lang/groovy/packages.el
+++ b/layers/+lang/groovy/packages.el
@@ -38,28 +38,26 @@
   (use-package groovy-imports
     :defer t
     :init
-    (progn
-      (add-hook 'groovy-mode-hook 'groovy-imports-scan-file)
-      (spacemacs/set-leader-keys-for-major-mode 'groovy-mode
-        "ri" 'groovy-imports-add-import-dwim))))
+    (add-hook 'groovy-mode-hook 'groovy-imports-scan-file)
+    (spacemacs/set-leader-keys-for-major-mode 'groovy-mode
+      "ri" 'groovy-imports-add-import-dwim)))
 
 (defun groovy/init-groovy-mode ()
   (use-package groovy-mode
     :defer t
     :hook (groovy-mode-local-vars . spacemacs//groovy-setup-backend)
     :init
-    (progn
-      (setq lsp-groovy-server-file groovy-lsp-jar-path)
-      (spacemacs/declare-prefix-for-mode 'groovy-mode "ms" "REPL")
-      (spacemacs/set-leader-keys-for-major-mode 'groovy-mode
-        "'"  'run-groovy
-        "sB" 'spacemacs/groovy-load-file-switch
-        "sb" 'spacemacs/groovy-load-file
-        "sF" 'spacemacs/groovy-send-definition-switch
-        "sf" 'groovy-send-definition
-        "si" 'run-groovy
-        "sR" 'spacemacs/groovy-send-region-switch
-        "sr" 'groovy-send-region))))
+    (setq lsp-groovy-server-file groovy-lsp-jar-path)
+    (spacemacs/declare-prefix-for-mode 'groovy-mode "ms" "REPL")
+    (spacemacs/set-leader-keys-for-major-mode 'groovy-mode
+      "'"  'run-groovy
+      "sB" 'spacemacs/groovy-load-file-switch
+      "sb" 'spacemacs/groovy-load-file
+      "sF" 'spacemacs/groovy-send-definition-switch
+      "sf" 'groovy-send-definition
+      "si" 'run-groovy
+      "sR" 'spacemacs/groovy-send-region-switch
+      "sr" 'groovy-send-region)))
 
 (defun groovy/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -70,16 +70,15 @@
   (use-package dante
     :defer t
     :config
-    (progn
-      (dolist (mode haskell-modes)
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "gb" 'xref-pop-marker-stack
-          "ht" 'dante-type-at
-          "hT" 'spacemacs-haskell//dante-insert-type
-          "hi" 'dante-info
-          "rs" 'dante-auto-fix
-          "se" 'dante-eval-block
-          "sr" 'dante-restart)))))
+    (dolist (mode haskell-modes)
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "gb" 'xref-pop-marker-stack
+        "ht" 'dante-type-at
+        "hT" 'spacemacs-haskell//dante-insert-type
+        "hi" 'dante-info
+        "rs" 'dante-auto-fix
+        "se" 'dante-eval-block
+        "sr" 'dante-restart))))
 
 (defun haskell/init-attrap ()
   (use-package attrap
@@ -96,7 +95,7 @@
   (progn
     (add-hook 'dante-mode-hook
               (lambda () (flycheck-add-next-checker 'haskell-dante '(warning . haskell-hlint))))
-    (spacemacs/enable-flycheck 'haskell-mode)))
+  (spacemacs/enable-flycheck 'haskell-mode)))
 
 
 (defun haskell/init-flycheck-haskell ()
@@ -114,155 +113,153 @@
   (use-package haskell-mode
     :defer t
     :init
-    (progn
-      (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
-      (add-hook 'haskell-literate-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
-      ;; renamed as of 04/2020, delete in due course
-      (add-hook 'literate-haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
+    (add-hook 'haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
+    (add-hook 'haskell-literate-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
+    ;; renamed as of 04/2020, delete in due course
+    (add-hook 'literate-haskell-mode-local-vars-hook #'spacemacs-haskell//setup-backend)
 
-      (defun spacemacs//force-haskell-mode-loading ()
-        "Force `haskell-mode' loading when visiting cabal file."
-        (require 'haskell-mode))
-      (add-hook 'haskell-cabal-mode-hook
-                'spacemacs//force-haskell-mode-loading)
+    (defun spacemacs//force-haskell-mode-loading ()
+      "Force `haskell-mode' loading when visiting cabal file."
+      (require 'haskell-mode))
+    (add-hook 'haskell-cabal-mode-hook
+              'spacemacs//force-haskell-mode-loading)
 
-      ;; Haskell cabal files interact badly with electric-indent-mode
-      ;; note: we cannot add this hook in :config, since haskell-mode might
-      ;; only be loaded after cabal-mode hooks are already run (see add-hook above)
-      (add-hook 'haskell-cabal-mode-hook #'spacemacs-haskell//disable-electric-indent)
+    ;; Haskell cabal files interact badly with electric-indent-mode
+    ;; note: we cannot add this hook in :config, since haskell-mode might
+    ;; only be loaded after cabal-mode hooks are already run (see add-hook above)
+    (add-hook 'haskell-cabal-mode-hook #'spacemacs-haskell//disable-electric-indent)
 
-      (setq
-       ;; Use notify.el (if you have it installed) at the end of running
-       ;; Cabal commands or generally things worth notifying.
-       haskell-notify-p t
-       ;; Remove annoying error popups
-       haskell-interactive-popup-errors nil
-       ;; Better import handling
-       haskell-process-suggest-remove-import-lines t
-       haskell-process-auto-import-loaded-modules t
-       ;; Disable haskell-stylish-on-save, as it breaks flycheck highlighting.
-       ;; NOTE: May not be true anymore - taksuyu 2015-10-06
-       haskell-stylish-on-save nil))
+    (setq
+     ;; Use notify.el (if you have it installed) at the end of running
+     ;; Cabal commands or generally things worth notifying.
+     haskell-notify-p t
+     ;; Remove annoying error popups
+     haskell-interactive-popup-errors nil
+     ;; Better import handling
+     haskell-process-suggest-remove-import-lines t
+     haskell-process-auto-import-loaded-modules t
+     ;; Disable haskell-stylish-on-save, as it breaks flycheck highlighting.
+     ;; NOTE: May not be true anymore - taksuyu 2015-10-06
+     haskell-stylish-on-save nil)
     :config
-    (progn
-      (defun spacemacs/haskell-interactive-bring ()
-        "Bring up the interactive mode for this session without
+    (defun spacemacs/haskell-interactive-bring ()
+      "Bring up the interactive mode for this session without
          switching to it."
-        (interactive)
-        (let* ((session (haskell-session))
-               (buffer (haskell-session-interactive-buffer session)))
-          (display-buffer buffer)))
+      (interactive)
+      (let* ((session (haskell-session))
+             (buffer (haskell-session-interactive-buffer session)))
+        (display-buffer buffer)))
 
-      ;; hooks
-      (add-hook 'haskell-mode-hook #'spacemacs-haskell//disable-electric-indent)
+    ;; hooks
+    (add-hook 'haskell-mode-hook #'spacemacs-haskell//disable-electric-indent)
 
-      ;; prefixes
-      (dolist (mode haskell-modes)
-        (spacemacs/declare-prefix-for-mode mode "mg" "haskell/navigation")
-        (spacemacs/declare-prefix-for-mode mode "ms" "haskell/repl")
-        (spacemacs/declare-prefix-for-mode mode "mc" "haskell/cabal")
-        (spacemacs/declare-prefix-for-mode mode "mh" "haskell/documentation")
-        (spacemacs/declare-prefix-for-mode mode "md" "haskell/debug")
-        (spacemacs/declare-prefix-for-mode mode "mr" "haskell/refactor"))
-      (spacemacs/declare-prefix-for-mode 'haskell-interactive-mode "ms" "haskell/repl")
-      (spacemacs/declare-prefix-for-mode 'haskell-cabal-mode "ms" "haskell/repl")
+    ;; prefixes
+    (dolist (mode haskell-modes)
+      (spacemacs/declare-prefix-for-mode mode "mg" "haskell/navigation")
+      (spacemacs/declare-prefix-for-mode mode "ms" "haskell/repl")
+      (spacemacs/declare-prefix-for-mode mode "mc" "haskell/cabal")
+      (spacemacs/declare-prefix-for-mode mode "mh" "haskell/documentation")
+      (spacemacs/declare-prefix-for-mode mode "md" "haskell/debug")
+      (spacemacs/declare-prefix-for-mode mode "mr" "haskell/refactor"))
+    (spacemacs/declare-prefix-for-mode 'haskell-interactive-mode "ms" "haskell/repl")
+    (spacemacs/declare-prefix-for-mode 'haskell-cabal-mode "ms" "haskell/repl")
 
-      ;; key bindings
-      (defun spacemacs/haskell-process-do-type-on-prev-line ()
-        (interactive)
-        (haskell-process-do-type 1))
+    ;; key bindings
+    (defun spacemacs/haskell-process-do-type-on-prev-line ()
+      (interactive)
+      (haskell-process-do-type 1))
 
-      ;; repl key bindings
-      (evil-define-key 'insert haskell-interactive-mode-map
-        (kbd "C-j") 'haskell-interactive-mode-history-next
-        (kbd "C-k") 'haskell-interactive-mode-history-previous
-        (kbd "C-l") 'haskell-interactive-mode-clear)
+    ;; repl key bindings
+    (evil-define-key 'insert haskell-interactive-mode-map
+      (kbd "C-j") 'haskell-interactive-mode-history-next
+      (kbd "C-k") 'haskell-interactive-mode-history-previous
+      (kbd "C-l") 'haskell-interactive-mode-clear)
 
-      ;; Bind repl
-      (spacemacs/register-repl 'haskell
-                               'haskell-interactive-switch "haskell")
+    ;; Bind repl
+    (spacemacs/register-repl 'haskell
+                             'haskell-interactive-switch "haskell")
 
-      (dolist (mode haskell-modes)
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "sb"  'haskell-process-load-file
-          "sc"  'haskell-interactive-mode-clear
-          "sS"  'spacemacs/haskell-interactive-bring
-          "ss"  'haskell-interactive-switch
-          "st"  'haskell-session-change-target
-          "'"   'haskell-interactive-switch
-
-          "ca"  'haskell-process-cabal
-          "cb"  'haskell-process-cabal-build
-          "cc"  'haskell-compile
-          "cv"  'haskell-cabal-visit-file
-
-          "hd"  'inferior-haskell-find-haddock
-          "hi"  'haskell-process-do-info
-          "ht"  'haskell-process-do-type
-          "hT"  'spacemacs/haskell-process-do-type-on-prev-line
-
-          "da"  'haskell-debug/abandon
-          "db"  'haskell-debug/break-on-function
-          "dB"  'haskell-debug/delete
-          "dc"  'haskell-debug/continue
-          "dd"  'haskell-debug
-          "dn"  'haskell-debug/next
-          "dN"  'haskell-debug/previous
-          "dp"  'haskell-debug/previous
-          "dr"  'haskell-debug/refresh
-          "ds"  'haskell-debug/step
-          "dt"  'haskell-debug/trace
-
-          "ri"  'spacemacs/haskell-format-imports)
-        (if (eq haskell-completion-backend 'lsp)
-            (spacemacs/set-leader-keys-for-major-mode mode
-              "gl"  'haskell-navigate-imports
-              "S"   'haskell-mode-stylish-buffer
-
-              "hg"  'hoogle
-              "hG"  'haskell-hoogle-lookup-from-local)
-          (spacemacs/set-leader-keys-for-major-mode mode
-            "gi"  'haskell-navigate-imports
-            "F"   'haskell-mode-stylish-buffer
-
-            "hh"  'hoogle
-            "hG"  'haskell-hoogle-lookup-from-local)))
-
-      ;; configure C-c C-l so it doesn't throw any errors
-      (bind-key "C-c C-l" 'haskell-process-load-file haskell-mode-map)
-      (bind-key "C-c C-z" 'haskell-interactive-switch haskell-mode-map)
-
-      ;; Switch back to editor from REPL
-      (spacemacs/set-leader-keys-for-major-mode 'haskell-interactive-mode
-        "ss"  'haskell-interactive-switch-back)
-
-      ;; Compile
-      (spacemacs/set-leader-keys-for-major-mode 'haskell-cabal
-        "C"  'haskell-compile)
-
-      ;; Cabal-file bindings
-      (spacemacs/set-leader-keys-for-major-mode 'haskell-cabal-mode
-        ;; "="   'haskell-cabal-subsection-arrange-lines ;; Does a bad job, 'gg=G' works better
-        "d"   'haskell-cabal-add-dependency
-        "b"   'haskell-cabal-goto-benchmark-section
-        "e"   'haskell-cabal-goto-executable-section
-        "t"   'haskell-cabal-goto-test-suite-section
-        "m"   'haskell-cabal-goto-exposed-modules
-        "l"   'haskell-cabal-goto-library-section
-        "n"   'haskell-cabal-next-subsection
-        "p"   'haskell-cabal-previous-subsection
+    (dolist (mode haskell-modes)
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "sb"  'haskell-process-load-file
         "sc"  'haskell-interactive-mode-clear
         "sS"  'spacemacs/haskell-interactive-bring
         "ss"  'haskell-interactive-switch
-        "N"   'haskell-cabal-next-section
-        "P"   'haskell-cabal-previous-section
-        "f"   'haskell-cabal-find-or-create-source-file)
+        "st"  'haskell-session-change-target
+        "'"   'haskell-interactive-switch
 
-      ;; Make "RET" behaviour in REPL saner
-      (evil-define-key 'insert haskell-interactive-mode-map
-        (kbd "RET") 'haskell-interactive-mode-return)
-      (evil-define-key 'normal haskell-interactive-mode-map
-        (kbd "RET") 'haskell-interactive-mode-return))
+        "ca"  'haskell-process-cabal
+        "cb"  'haskell-process-cabal-build
+        "cc"  'haskell-compile
+        "cv"  'haskell-cabal-visit-file
+
+        "hd"  'inferior-haskell-find-haddock
+        "hi"  'haskell-process-do-info
+        "ht"  'haskell-process-do-type
+        "hT"  'spacemacs/haskell-process-do-type-on-prev-line
+
+        "da"  'haskell-debug/abandon
+        "db"  'haskell-debug/break-on-function
+        "dB"  'haskell-debug/delete
+        "dc"  'haskell-debug/continue
+        "dd"  'haskell-debug
+        "dn"  'haskell-debug/next
+        "dN"  'haskell-debug/previous
+        "dp"  'haskell-debug/previous
+        "dr"  'haskell-debug/refresh
+        "ds"  'haskell-debug/step
+        "dt"  'haskell-debug/trace
+
+        "ri"  'spacemacs/haskell-format-imports)
+      (if (eq haskell-completion-backend 'lsp)
+          (spacemacs/set-leader-keys-for-major-mode mode
+            "gl"  'haskell-navigate-imports
+            "S"   'haskell-mode-stylish-buffer
+
+            "hg"  'hoogle
+            "hG"  'haskell-hoogle-lookup-from-local)
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "gi"  'haskell-navigate-imports
+          "F"   'haskell-mode-stylish-buffer
+
+          "hh"  'hoogle
+          "hG"  'haskell-hoogle-lookup-from-local)))
+
+    ;; configure C-c C-l so it doesn't throw any errors
+    (bind-key "C-c C-l" 'haskell-process-load-file haskell-mode-map)
+    (bind-key "C-c C-z" 'haskell-interactive-switch haskell-mode-map)
+
+    ;; Switch back to editor from REPL
+    (spacemacs/set-leader-keys-for-major-mode 'haskell-interactive-mode
+      "ss"  'haskell-interactive-switch-back)
+
+    ;; Compile
+    (spacemacs/set-leader-keys-for-major-mode 'haskell-cabal
+      "C"  'haskell-compile)
+
+    ;; Cabal-file bindings
+    (spacemacs/set-leader-keys-for-major-mode 'haskell-cabal-mode
+      ;; "="   'haskell-cabal-subsection-arrange-lines ;; Does a bad job, 'gg=G' works better
+      "d"   'haskell-cabal-add-dependency
+      "b"   'haskell-cabal-goto-benchmark-section
+      "e"   'haskell-cabal-goto-executable-section
+      "t"   'haskell-cabal-goto-test-suite-section
+      "m"   'haskell-cabal-goto-exposed-modules
+      "l"   'haskell-cabal-goto-library-section
+      "n"   'haskell-cabal-next-subsection
+      "p"   'haskell-cabal-previous-subsection
+      "sc"  'haskell-interactive-mode-clear
+      "sS"  'spacemacs/haskell-interactive-bring
+      "ss"  'haskell-interactive-switch
+      "N"   'haskell-cabal-next-section
+      "P"   'haskell-cabal-previous-section
+      "f"   'haskell-cabal-find-or-create-source-file)
+
+    ;; Make "RET" behaviour in REPL saner
+    (evil-define-key 'insert haskell-interactive-mode-map
+      (kbd "RET") 'haskell-interactive-mode-return)
+    (evil-define-key 'normal haskell-interactive-mode-map
+      (kbd "RET") 'haskell-interactive-mode-return)
 
     ;; align rules for Haskell
     (with-eval-after-load 'align
@@ -324,15 +321,13 @@
     :init
     (add-hook 'haskell-mode-hook #'hindent-mode)
     :config
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
-        "f" 'hindent-reformat-decl-or-fill))))
+    (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
+      "f" 'hindent-reformat-decl-or-fill)))
 
 (defun haskell/init-hlint-refactor ()
   (use-package hlint-refactor
     :defer t
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
-        "rb" 'hlint-refactor-refactor-buffer
-        "rr" 'hlint-refactor-refactor-at-point))))
+    (spacemacs/set-leader-keys-for-major-mode 'haskell-mode
+      "rb" 'hlint-refactor-refactor-buffer
+      "rr" 'hlint-refactor-refactor-at-point)))

--- a/layers/+lang/html/packages.el
+++ b/layers/+lang/html/packages.el
@@ -66,36 +66,34 @@
   (use-package company-web
     :defer t
     :init
-    (progn
-      (spacemacs|add-company-backends
-        :backends (company-web-html company-css)
-        :modes web-mode)
-      (spacemacs|add-company-backends
-        :backends company-web-jade
-        :modes pug-mode)
-      (spacemacs|add-company-backends
-        :backends company-web-slim
-        :modes slim-mode))))
+    (spacemacs|add-company-backends
+     :backends (company-web-html company-css)
+     :modes web-mode)
+    (spacemacs|add-company-backends
+     :backends company-web-jade
+     :modes pug-mode)
+    (spacemacs|add-company-backends
+     :backends company-web-slim
+     :modes slim-mode)))
 
 (defun html/init-css-mode ()
   (use-package css-mode
     :defer t
     :init
-    (progn
-      ;; Mark `css-indent-offset' as safe-local variable
-      (put 'css-indent-offset 'safe-local-variable #'integerp)
+    ;; Mark `css-indent-offset' as safe-local variable
+    (put 'css-indent-offset 'safe-local-variable #'integerp)
 
-      (when css-enable-lsp
-        (add-hook 'css-mode-hook
-                  #'spacemacs//setup-lsp-for-web-mode-buffers t))
+    (when css-enable-lsp
+      (add-hook 'css-mode-hook
+                #'spacemacs//setup-lsp-for-web-mode-buffers t))
 
-      (spacemacs/declare-prefix-for-mode 'css-mode "m=" "format")
-      (spacemacs/declare-prefix-for-mode 'css-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'css-mode "mz" "foldz")
+    (spacemacs/declare-prefix-for-mode 'css-mode "m=" "format")
+    (spacemacs/declare-prefix-for-mode 'css-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'css-mode "mz" "foldz")
 
-      (spacemacs/set-leader-keys-for-major-mode 'css-mode
-        "zc" 'spacemacs/css-contract-statement
-        "zo" 'spacemacs/css-expand-statement))))
+    (spacemacs/set-leader-keys-for-major-mode 'css-mode
+      "zc" 'spacemacs/css-contract-statement
+      "zo" 'spacemacs/css-expand-statement)))
 
 (defun html/init-emmet-mode ()
   (use-package emmet-mode
@@ -106,9 +104,8 @@
                                                 scss-mode-hook
                                                 web-mode-hook))
     :config
-    (progn
-      (define-key emmet-mode-keymap (kbd "<C-return>") 'spacemacs/emmet-expand)
-      (spacemacs|hide-lighter emmet-mode))))
+    (define-key emmet-mode-keymap (kbd "<C-return>") 'spacemacs/emmet-expand)
+    (spacemacs|hide-lighter emmet-mode)))
 
 (defun html/post-init-evil-matchit ()
   (evilmi-load-plugin-rules '(web-mode) '(simple template html))
@@ -147,9 +144,8 @@
   (use-package impatient-mode
     :defer t
     :init
-    (progn
-      (dolist (mode '(web-mode css-mode))
-        (spacemacs/set-leader-keys-for-major-mode 'web-mode "I" 'spacemacs/impatient-mode)))))
+    (dolist (mode '(web-mode css-mode))
+      (spacemacs/set-leader-keys-for-major-mode 'web-mode "I" 'spacemacs/impatient-mode))))
 
 (defun html/init-less-css-mode ()
   (use-package less-css-mode
@@ -197,41 +193,38 @@
   (use-package tagedit
     :defer t
     :config
-    (progn
-      (tagedit-add-experimental-features)
-      (add-hook 'html-mode-hook (lambda () (tagedit-mode 1)))
-      (spacemacs|diminish tagedit-mode " Ⓣ" " T"))))
+    (tagedit-add-experimental-features)
+    (add-hook 'html-mode-hook (lambda () (tagedit-mode 1)))
+    (spacemacs|diminish tagedit-mode " Ⓣ" " T")))
 
 (defun html/init-web-mode ()
   (use-package web-mode
     :defer t
     :init
-    (progn
-      (spacemacs//web-setup-transient-state)
-      (when html-enable-lsp
-        (add-hook 'web-mode-hook #'spacemacs//setup-lsp-for-html-buffer t))
-      (when html-enable-leex-support
-        (add-to-list 'auto-mode-alist '("\\.leex\\'" . web-mode))))
+    (spacemacs//web-setup-transient-state)
+    (when html-enable-lsp
+      (add-hook 'web-mode-hook #'spacemacs//setup-lsp-for-html-buffer t))
+    (when html-enable-leex-support
+      (add-to-list 'auto-mode-alist '("\\.leex\\'" . web-mode)))
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'web-mode "m=" "format")
-      (spacemacs/declare-prefix-for-mode 'web-mode "mE" "errors")
-      (spacemacs/declare-prefix-for-mode 'web-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'web-mode "mh" "dom")
-      (spacemacs/declare-prefix-for-mode 'web-mode "mr" "refactor")
-      (spacemacs/set-leader-keys-for-major-mode 'web-mode
-        "El" 'web-mode-dom-errors-show
-        "gb" 'web-mode-element-beginning
-        "gc" 'web-mode-element-child
-        "gp" 'web-mode-element-parent
-        "gs" 'web-mode-element-sibling-next
-        "hp" 'web-mode-dom-xpath
-        "rc" 'web-mode-element-clone
-        "rd" 'web-mode-element-vanish
-        "rk" 'web-mode-element-kill
-        "rr" 'web-mode-element-rename
-        "rw" 'web-mode-element-wrap
-        "z" 'web-mode-fold-or-unfold))
+    (spacemacs/declare-prefix-for-mode 'web-mode "m=" "format")
+    (spacemacs/declare-prefix-for-mode 'web-mode "mE" "errors")
+    (spacemacs/declare-prefix-for-mode 'web-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'web-mode "mh" "dom")
+    (spacemacs/declare-prefix-for-mode 'web-mode "mr" "refactor")
+    (spacemacs/set-leader-keys-for-major-mode 'web-mode
+      "El" 'web-mode-dom-errors-show
+      "gb" 'web-mode-element-beginning
+      "gc" 'web-mode-element-child
+      "gp" 'web-mode-element-parent
+      "gs" 'web-mode-element-sibling-next
+      "hp" 'web-mode-dom-xpath
+      "rc" 'web-mode-element-clone
+      "rd" 'web-mode-element-vanish
+      "rk" 'web-mode-element-kill
+      "rr" 'web-mode-element-rename
+      "rw" 'web-mode-element-wrap
+      "z" 'web-mode-fold-or-unfold)
     ;; TODO element close would be nice but broken with evil.
     :mode
     (("\\.phtml\\'"      . web-mode)

--- a/layers/+lang/hy/packages.el
+++ b/layers/+lang/hy/packages.el
@@ -50,43 +50,42 @@
     :mode ("\\.hy\\'" . hy-mode)
     :interpreter ("hy" . hy-mode)
     :config
-    (progn
-      ;; Disable this unless using special branch
-      (setq hy-shell-use-control-codes? nil)
-      ;; key bindings
-      (spacemacs/declare-prefix-for-mode 'hy-mode "md" "debug")
-      (spacemacs/declare-prefix-for-mode 'hy-mode "mt" "test")
-      (spacemacs/declare-prefix-for-mode 'hy-mode "me" "eval")
-      (spacemacs/declare-prefix-for-mode 'hy-mode "ms" "REPL")
-      (spacemacs/declare-prefix-for-mode 'hy-mode "mv" "pyvenv")
-      (spacemacs/declare-prefix-for-mode 'hy-mode "mh" "help")
-      (spacemacs/set-leader-keys-for-major-mode 'hy-mode
-        "'" 'run-hy
+    ;; Disable this unless using special branch
+    (setq hy-shell-use-control-codes? nil)
+    ;; key bindings
+    (spacemacs/declare-prefix-for-mode 'hy-mode "md" "debug")
+    (spacemacs/declare-prefix-for-mode 'hy-mode "mt" "test")
+    (spacemacs/declare-prefix-for-mode 'hy-mode "me" "eval")
+    (spacemacs/declare-prefix-for-mode 'hy-mode "ms" "REPL")
+    (spacemacs/declare-prefix-for-mode 'hy-mode "mv" "pyvenv")
+    (spacemacs/declare-prefix-for-mode 'hy-mode "mh" "help")
+    (spacemacs/set-leader-keys-for-major-mode 'hy-mode
+      "'" 'run-hy
 
-        "dd" 'hy-insert-pdb
-        "dt" 'hy-insert-pdb-threaded
-        "hh" 'hy-describe-thing-at-point
+      "dd" 'hy-insert-pdb
+      "dt" 'hy-insert-pdb-threaded
+      "hh" 'hy-describe-thing-at-point
 
-        "eb" 'hy-shell-eval-buffer
-        "eB" 'spacemacs/hy-shell-eval-buffer-and-go
-        "ec" 'hy-shell-eval-current-form
-        "eC" 'spacemacs/hy-shell-eval-current-form-and-go
-        "ei" 'run-hy
-        "er" 'hy-shell-eval-region
-        "eR" 'spacemacs/hy-shell-eval-region-and-go
+      "eb" 'hy-shell-eval-buffer
+      "eB" 'spacemacs/hy-shell-eval-buffer-and-go
+      "ec" 'hy-shell-eval-current-form
+      "eC" 'spacemacs/hy-shell-eval-current-form-and-go
+      "ei" 'run-hy
+      "er" 'hy-shell-eval-region
+      "eR" 'spacemacs/hy-shell-eval-region-and-go
 
-        "sb" 'hy-shell-eval-buffer
-        "sB" 'spacemacs/hy-shell-eval-buffer-and-go
-        "sc" 'hy-shell-eval-current-form
-        "sC" 'spacemacs/hy-shell-eval-current-form-and-go
-        "si" 'hy-shell-start-or-switch-to-shell
-        "sr" 'hy-shell-eval-region
-        "sR" 'spacemacs/hy-shell-eval-region-and-go
+      "sb" 'hy-shell-eval-buffer
+      "sB" 'spacemacs/hy-shell-eval-buffer-and-go
+      "sc" 'hy-shell-eval-current-form
+      "sC" 'spacemacs/hy-shell-eval-current-form-and-go
+      "si" 'hy-shell-start-or-switch-to-shell
+      "sr" 'hy-shell-eval-region
+      "sR" 'spacemacs/hy-shell-eval-region-and-go
 
-        "tA" 'spacemacs/python-test-pdb-all
-        "ta" 'spacemacs/python-test-all
-        "tM" 'spacemacs/python-test-pdb-module
-        "tm" 'spacemacs/python-test-module))))
+      "tA" 'spacemacs/python-test-pdb-all
+      "ta" 'spacemacs/python-test-all
+      "tM" 'spacemacs/python-test-pdb-module
+      "tm" 'spacemacs/python-test-module)))
 
 (defun hy/pre-init-ob-hy ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/idris/packages.el
+++ b/layers/+lang/idris/packages.el
@@ -39,85 +39,84 @@
     :defer t
     :init (spacemacs/register-repl 'idris-mode 'idris-repl "idris")
     :config
-    (progn
-      (defun spacemacs/idris-load-file-and-focus (&optional set-line)
-        "Pass the current buffer's file to the REPL and switch to it in
+    (defun spacemacs/idris-load-file-and-focus (&optional set-line)
+      "Pass the current buffer's file to the REPL and switch to it in
 `insert state'."
-        (interactive "p")
-        (idris-load-file set-line)
-        (idris-pop-to-repl)
-        (evil-insert-state))
+      (interactive "p")
+      (idris-load-file set-line)
+      (idris-pop-to-repl)
+      (evil-insert-state))
 
-      (defun spacemacs/idris-load-forward-line-and-focus ()
-        "Pass the next line to REPL and switch to it in `insert state'."
-        (interactive)
-        (idris-load-forward-line)
-        (idris-pop-to-repl)
-        (evil-insert-state))
+    (defun spacemacs/idris-load-forward-line-and-focus ()
+      "Pass the next line to REPL and switch to it in `insert state'."
+      (interactive)
+      (idris-load-forward-line)
+      (idris-pop-to-repl)
+      (evil-insert-state))
 
-      (defun spacemacs/idris-load-backward-line-and-focus ()
-        "Pass the previous line to REPL and switch to it in `insert state'."
-        (interactive)
-        (idris-load-backward-line)
-        (idris-pop-to-repl)
-        (evil-insert-state))
+    (defun spacemacs/idris-load-backward-line-and-focus ()
+      "Pass the previous line to REPL and switch to it in `insert state'."
+      (interactive)
+      (idris-load-backward-line)
+      (idris-pop-to-repl)
+      (evil-insert-state))
 
-      ;; prefix
-      (spacemacs/declare-prefix-for-mode 'idris-mode "mb" "idris/build")
-      (spacemacs/declare-prefix-for-mode 'idris-mode "mi" "idris/editing")
-      (spacemacs/declare-prefix-for-mode 'idris-mode "mh" "idris/documentation")
-      (spacemacs/declare-prefix-for-mode 'idris-mode "ms" "idris/repl")
-      (spacemacs/declare-prefix-for-mode 'idris-mode "mm" "idris/term")
+    ;; prefix
+    (spacemacs/declare-prefix-for-mode 'idris-mode "mb" "idris/build")
+    (spacemacs/declare-prefix-for-mode 'idris-mode "mi" "idris/editing")
+    (spacemacs/declare-prefix-for-mode 'idris-mode "mh" "idris/documentation")
+    (spacemacs/declare-prefix-for-mode 'idris-mode "ms" "idris/repl")
+    (spacemacs/declare-prefix-for-mode 'idris-mode "mm" "idris/term")
 
-      (spacemacs/set-leader-keys-for-major-mode 'idris-mode
-        ;; Shorthands: rebind the standard evil-mode combinations to the local
-        ;; leader for the keys not used as a prefix below.
-        "c" 'idris-case-dwim
-        "d" 'idris-add-clause
-        "l" 'idris-make-lemma
-        "p" 'idris-proof-search
-        "r" 'idris-load-file
-        "t" 'idris-type-at-point
-        "w" 'idris-make-with-block
+    (spacemacs/set-leader-keys-for-major-mode 'idris-mode
+      ;; Shorthands: rebind the standard evil-mode combinations to the local
+      ;; leader for the keys not used as a prefix below.
+      "c" 'idris-case-dwim
+      "d" 'idris-add-clause
+      "l" 'idris-make-lemma
+      "p" 'idris-proof-search
+      "r" 'idris-load-file
+      "t" 'idris-type-at-point
+      "w" 'idris-make-with-block
 
-        ;; ipkg.
-        "bc" 'idris-ipkg-build
-        "bC" 'idris-ipkg-clean
-        "bi" 'idris-ipkg-install
-        "bp" 'idris-open-package-file
+      ;; ipkg.
+      "bc" 'idris-ipkg-build
+      "bC" 'idris-ipkg-clean
+      "bi" 'idris-ipkg-install
+      "bp" 'idris-open-package-file
 
-        ;; Interactive editing.
-        "ia" 'idris-proof-search
-        "ic" 'idris-case-dwim
-        "ie" 'idris-make-lemma
-        "im" 'idris-add-missing
-        "ir" 'idris-refine
-        "is" 'idris-add-clause
-        "iw" 'idris-make-with-block
+      ;; Interactive editing.
+      "ia" 'idris-proof-search
+      "ic" 'idris-case-dwim
+      "ie" 'idris-make-lemma
+      "im" 'idris-add-missing
+      "ir" 'idris-refine
+      "is" 'idris-add-clause
+      "iw" 'idris-make-with-block
 
-        ;; Documentation.
-        "ha" 'idris-apropos
-        "hd" 'idris-docs-at-point
-        "hs" 'idris-type-search
-        "ht" 'idris-type-at-point
+      ;; Documentation.
+      "ha" 'idris-apropos
+      "hd" 'idris-docs-at-point
+      "hs" 'idris-type-search
+      "ht" 'idris-type-at-point
 
-        ;; Active term manipulations.
-        "mn" 'idris-normalise-term
-        "mi" 'idris-show-term-implicits
-        "mh" 'idris-hide-term-implicits
-        "mc" 'idris-show-core-term
+      ;; Active term manipulations.
+      "mn" 'idris-normalise-term
+      "mi" 'idris-show-term-implicits
+      "mh" 'idris-hide-term-implicits
+      "mc" 'idris-show-core-term
 
-        ;; REPL
-        "'"  'idris-repl
-        "sb" 'idris-load-file
-        "sB" 'spacemacs/idris-load-file-and-focus
-        "si" 'idris-repl
-        "sn" 'idris-load-forward-line
-        "sN" 'spacemacs/idris-load-forward-line-and-focus
-        "sp" 'idris-load-backward-line
-        "sP" 'spacemacs/idris-load-backward-line-and-focus
-        "ss" 'idris-pop-to-repl
-        "sq" 'idris-quit)))
+      ;; REPL
+      "'"  'idris-repl
+      "sb" 'idris-load-file
+      "sB" 'spacemacs/idris-load-file-and-focus
+      "si" 'idris-repl
+      "sn" 'idris-load-forward-line
+      "sN" 'spacemacs/idris-load-forward-line-and-focus
+      "sp" 'idris-load-backward-line
+      "sP" 'spacemacs/idris-load-backward-line-and-focus
+      "ss" 'idris-pop-to-repl
+      "sq" 'idris-quit))
 
   ;; To suppress auto-indentation
   (add-to-list 'spacemacs-indent-sensitive-modes 'idris-mode)

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -65,9 +65,8 @@
   (use-package java-mode
     :defer t
     :init
-    (progn
-      (add-hook 'java-mode-local-vars-hook #'spacemacs//java-setup-backend)
-      (put 'java-backend 'safe-local-variable 'symbolp))))
+    (add-hook 'java-mode-local-vars-hook #'spacemacs//java-setup-backend)
+    (put 'java-backend 'safe-local-variable 'symbolp)))
 
 (defun java/init-maven-test-mode ()
   (use-package maven-test-mode
@@ -79,123 +78,119 @@
       (spacemacs/declare-prefix-for-mode 'java-mode "mmg" "goto")
       (spacemacs/declare-prefix-for-mode 'java-mode "mmt" "tests"))
     :config
-    (progn
-      (spacemacs|hide-lighter maven-test-mode)
-      (spacemacs/set-leader-keys-for-minor-mode 'maven-test-mode
-        "mga"    'maven-test-toggle-between-test-and-class
-        "mgA"    'maven-test-toggle-between-test-and-class-other-window
-        "mta"    'maven-test-all
-        "mt C-a" 'maven-test-clean-test-all
-        "mtb"    'maven-test-file
-        "mti"    'maven-test-install
-        "mtt"    'maven-test-method))))
+    (spacemacs|hide-lighter maven-test-mode)
+    (spacemacs/set-leader-keys-for-minor-mode 'maven-test-mode
+      "mga"    'maven-test-toggle-between-test-and-class
+      "mgA"    'maven-test-toggle-between-test-and-class-other-window
+      "mta"    'maven-test-all
+      "mt C-a" 'maven-test-clean-test-all
+      "mtb"    'maven-test-file
+      "mti"    'maven-test-install
+      "mtt"    'maven-test-method)))
 
 (defun java/init-meghanada ()
   (use-package meghanada
     :defer t
     :init
-    (progn
-      (setq meghanada-server-install-dir (concat spacemacs-cache-directory
-                                                 "meghanada/")
-            company-meghanada-prefix-length 1
-            ;; let spacemacs handle company and flycheck itself
-            meghanada-use-company nil
-            meghanada-use-flycheck nil))
+    (setq meghanada-server-install-dir (concat spacemacs-cache-directory
+                                               "meghanada/")
+          company-meghanada-prefix-length 1
+          ;; let spacemacs handle company and flycheck itself
+          meghanada-use-company nil
+          meghanada-use-flycheck nil)
     :config
-    (progn
-      ;; key bindings
-      (dolist (prefix '(("mc" . "compile")
-                        ("mD" . "daemon")
-                        ("mg" . "goto")
-                        ("mr" . "refactor")
-                        ("mt" . "test")
-                        ("mx" . "execute")))
-        (spacemacs/declare-prefix-for-mode
-          'java-mode (car prefix) (cdr prefix)))
-      (spacemacs/set-leader-keys-for-major-mode 'java-mode
-        "cb" 'meghanada-compile-file
-        "cc" 'meghanada-compile-project
+    ;; key bindings
+    (dolist (prefix '(("mc" . "compile")
+                      ("mD" . "daemon")
+                      ("mg" . "goto")
+                      ("mr" . "refactor")
+                      ("mt" . "test")
+                      ("mx" . "execute")))
+      (spacemacs/declare-prefix-for-mode
+        'java-mode (car prefix) (cdr prefix)))
+    (spacemacs/set-leader-keys-for-major-mode 'java-mode
+      "cb" 'meghanada-compile-file
+      "cc" 'meghanada-compile-project
 
-        "Dc" 'meghanada-client-direct-connect
-        "Dd" 'meghanada-client-disconnect
-        "Di" 'meghanada-install-server
-        "Dk" 'meghanada-server-kill
-        "Dl" 'meghanada-clear-cache
-        "Dp" 'meghanada-ping
-        "Dr" 'meghanada-restart
-        "Ds" 'meghanada-client-connect
-        "Du" 'meghanada-update-server
-        "Dv" 'meghanada-version
+      "Dc" 'meghanada-client-direct-connect
+      "Dd" 'meghanada-client-disconnect
+      "Di" 'meghanada-install-server
+      "Dk" 'meghanada-server-kill
+      "Dl" 'meghanada-clear-cache
+      "Dp" 'meghanada-ping
+      "Dr" 'meghanada-restart
+      "Ds" 'meghanada-client-connect
+      "Du" 'meghanada-update-server
+      "Dv" 'meghanada-version
 
-        "gb" 'meghanada-back-jump
+      "gb" 'meghanada-back-jump
 
-        "=" 'meghanada-code-beautify
-        "ri" 'meghanada-optimize-import
-        "rI" 'meghanada-import-all
+      "=" 'meghanada-code-beautify
+      "ri" 'meghanada-optimize-import
+      "rI" 'meghanada-import-all
 
-        "ta" 'meghanada--run-junit
-        "tc" 'meghanada-run-junit-class
-        "tl" 'meghanada-run-junit-recent
-        "tt" 'meghanada-run-junit-test-case
+      "ta" 'meghanada--run-junit
+      "tc" 'meghanada-run-junit-class
+      "tl" 'meghanada-run-junit-recent
+      "tt" 'meghanada-run-junit-test-case
 
-        ;; meghanada-switch-testcase
-        ;; meghanada-local-variable
+      ;; meghanada-switch-testcase
+      ;; meghanada-local-variable
 
-        "x:" 'meghanada-run-task))))
+      "x:" 'meghanada-run-task)))
 
 (defun java/init-lsp-java ()
   (use-package lsp-java
     :defer t
     :if (eq java-backend 'lsp)
     :config
-    (progn
-      ;; key bindings
-      (dolist (prefix '(("mc" . "compile/create")
-                        ("mgk" . "type hierarchy")
-                        ("mra" . "add/assign")
-                        ("mrc" . "create/convert")
-                        ("mrg" . "generate")
-                        ("mre" . "extract")
-                        ("mt" . "test")))
-        (spacemacs/declare-prefix-for-mode
-          'java-mode (car prefix) (cdr prefix)))
-      (spacemacs/set-leader-keys-for-major-mode 'java-mode
-        "wu"  'lsp-java-update-project-configuration
+    ;; key bindings
+    (dolist (prefix '(("mc" . "compile/create")
+                      ("mgk" . "type hierarchy")
+                      ("mra" . "add/assign")
+                      ("mrc" . "create/convert")
+                      ("mrg" . "generate")
+                      ("mre" . "extract")
+                      ("mt" . "test")))
+      (spacemacs/declare-prefix-for-mode
+        'java-mode (car prefix) (cdr prefix)))
+    (spacemacs/set-leader-keys-for-major-mode 'java-mode
+      "wu"  'lsp-java-update-project-configuration
 
-        ;; refactoring
-        "ro" 'lsp-java-organize-imports
-        "rcp" 'lsp-java-create-parameter
-        "rcf" 'lsp-java-create-field
-        "rci" 'lsp-java-conver-to-static-import
-        "rec" 'lsp-java-extract-to-constant
-        "rel" 'lsp-java-extract-to-local-variable
-        "rem" 'lsp-java-extract-method
+      ;; refactoring
+      "ro" 'lsp-java-organize-imports
+      "rcp" 'lsp-java-create-parameter
+      "rcf" 'lsp-java-create-field
+      "rci" 'lsp-java-conver-to-static-import
+      "rec" 'lsp-java-extract-to-constant
+      "rel" 'lsp-java-extract-to-local-variable
+      "rem" 'lsp-java-extract-method
 
-        ;; assign/add
-        "rai" 'lsp-java-add-import
-        "ram" 'lsp-java-add-unimplemented-methods
-        "rat" 'lsp-java-add-throws
-        "raa" 'lsp-java-assign-all
-        "raf" 'lsp-java-assign-to-field
-        "raF" 'lsp-java-assign-statement-to-field
-        "ral" 'lsp-java-assign-statement-to-local
+      ;; assign/add
+      "rai" 'lsp-java-add-import
+      "ram" 'lsp-java-add-unimplemented-methods
+      "rat" 'lsp-java-add-throws
+      "raa" 'lsp-java-assign-all
+      "raf" 'lsp-java-assign-to-field
+      "raF" 'lsp-java-assign-statement-to-field
+      "ral" 'lsp-java-assign-statement-to-local
 
-        ;; generate
-        "rgt" 'lsp-java-generate-to-string
-        "rge" 'lsp-java-generate-equals-and-hash-code
-        "rgo" 'lsp-java-generate-overrides
-        "rgg" 'lsp-java-generate-getters-and-setters
+      ;; generate
+      "rgt" 'lsp-java-generate-to-string
+      "rge" 'lsp-java-generate-equals-and-hash-code
+      "rgo" 'lsp-java-generate-overrides
+      "rgg" 'lsp-java-generate-getters-and-setters
 
-        ;; create/compile
-        "cc"  'lsp-java-build-project
-        "cp"  'lsp-java-spring-initializr
+      ;; create/compile
+      "cc"  'lsp-java-build-project
+      "cp"  'lsp-java-spring-initializr
 
-        "gkk" 'lsp-java-type-hierarchy
-        "gku" 'spacemacs/lsp-java-super-type
-        "gks" 'spacemacs/lsp-java-sub-type
+      "gkk" 'lsp-java-type-hierarchy
+      "gku" 'spacemacs/lsp-java-super-type
+      "gks" 'spacemacs/lsp-java-sub-type
 
-        ;; test
-        "tb" 'lsp-jt-browser))))
+      ;; test
+      "tb" 'lsp-jt-browser)))
 
 (defun java/init-mvn ()
   (use-package mvn

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -79,17 +79,16 @@
     :defer t
     :init (add-hook 'js2-mode-hook #'npm-mode)
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mn" "npm")
-      (spacemacs/set-leader-keys-for-major-mode 'js2-mode
-        "ni" 'npm-mode-npm-install
-        "nr" 'npm-mode-npm-run
-        "ns" 'npm-mode-npm-install-save
-        "nd" 'npm-mode-npm-install-save-dev
-        "nn" 'npm-mode-npm-init
-        "nu" 'npm-mode-npm-uninstall
-        "nl" 'npm-mode-npm-list
-        "np" 'npm-mode-visit-project-file))))
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mn" "npm")
+    (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+      "ni" 'npm-mode-npm-install
+      "nr" 'npm-mode-npm-run
+      "ns" 'npm-mode-npm-install-save
+      "nd" 'npm-mode-npm-install-save-dev
+      "nn" 'npm-mode-npm-init
+      "nu" 'npm-mode-npm-uninstall
+      "nl" 'npm-mode-npm-list
+      "np" 'npm-mode-visit-project-file)))
 
 (defun javascript/post-init-impatient-mode ()
   (spacemacs/set-leader-keys-for-major-mode 'js2-mode
@@ -110,99 +109,95 @@
     :defer t
     :mode (("\\.[cm]?js\\'"  . js2-mode))
     :init
-    (progn
-      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
-      (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-next-error-fn)
-      ;; safe values for backend to be used in directory file variables
-      (dolist (value '(lsp tern tide))
-        (add-to-list 'safe-local-variable-values
-                     (cons 'javascript-backend value))))
+    (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-backend)
+    (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-next-error-fn)
+    ;; safe values for backend to be used in directory file variables
+    (dolist (value '(lsp tern tide))
+      (add-to-list 'safe-local-variable-values
+                   (cons 'javascript-backend value)))
     :config
-    (progn
-      (when javascript-fmt-on-save
-        (add-hook 'js2-mode-local-vars-hook 'spacemacs/javascript-fmt-before-save-hook))
-      ;; prefixes
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mh" "documentation")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mz" "folding")
-      ;; key bindings
-      (spacemacs/set-leader-keys-for-major-mode 'js2-mode
-        "w" 'js2-mode-toggle-warnings-and-errors
-        "zc" 'js2-mode-hide-element
-        "zo" 'js2-mode-show-element
-        "zr" 'js2-mode-show-all
-        "ze" 'js2-mode-toggle-element
-        "zF" 'js2-mode-toggle-hide-functions
-        "zC" 'js2-mode-toggle-hide-comments))))
+    (when javascript-fmt-on-save
+      (add-hook 'js2-mode-local-vars-hook 'spacemacs/javascript-fmt-before-save-hook))
+    ;; prefixes
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mh" "documentation")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mr" "refactor")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mz" "folding")
+    ;; key bindings
+    (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+      "w" 'js2-mode-toggle-warnings-and-errors
+      "zc" 'js2-mode-hide-element
+      "zo" 'js2-mode-show-element
+      "zr" 'js2-mode-show-all
+      "ze" 'js2-mode-toggle-element
+      "zF" 'js2-mode-toggle-hide-functions
+      "zC" 'js2-mode-toggle-hide-comments)))
 
 (defun javascript/init-js2-refactor ()
   (use-package js2-refactor
     :defer t
     :init
-    (progn
-      (add-hook 'js2-mode-hook 'spacemacs/js2-refactor-require)
-      ;; prefixes
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mr3" "ternary")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mra" "add/args")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrb" "barf")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrc" "contract")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mre" "expand/extract")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mri" "inline/inject/introduct")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrl" "localize/log")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrr" "rename")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrs" "split/slurp")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrt" "toggle")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mru" "unwrap")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrv" "var")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mrw" "wrap")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mx" "text")
-      (spacemacs/declare-prefix-for-mode 'js2-mode "mxm" "move")
-      ;; key bindings
-      (spacemacs/set-leader-keys-for-major-mode 'js2-mode
-        "r3i" 'js2r-ternary-to-if
-        "rag" 'js2r-add-to-globals-annotation
-        "rao" 'js2r-arguments-to-object
-        "rba" 'js2r-forward-barf
-        "rca" 'js2r-contract-array
-        "rco" 'js2r-contract-object
-        "rcu" 'js2r-contract-function
-        "rea" 'js2r-expand-array
-        "ref" 'js2r-extract-function
-        "rem" 'js2r-extract-method
-        "reo" 'js2r-expand-object
-        "reu" 'js2r-expand-function
-        "rev" 'js2r-extract-var
-        "rig" 'js2r-inject-global-in-iife
-        "rip" 'js2r-introduce-parameter
-        "riv" 'js2r-inline-var
-        "rlp" 'js2r-localize-parameter
-        "rlt" 'js2r-log-this
-        "rrv" 'js2r-rename-var
-        "rsl" 'js2r-forward-slurp
-        "rss" 'js2r-split-string
-        "rsv" 'js2r-split-var-declaration
-        "rtf" 'js2r-toggle-function-expression-and-declaration
-        "ruw" 'js2r-unwrap
-        "rvt" 'js2r-var-to-this
-        "rwi" 'js2r-wrap-buffer-in-iife
-        "rwl" 'js2r-wrap-in-for-loop
-        "k" 'js2r-kill
-        "xmj" 'js2r-move-line-down
-        "xmk" 'js2r-move-line-up))))
+    (add-hook 'js2-mode-hook 'spacemacs/js2-refactor-require)
+    ;; prefixes
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mr3" "ternary")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mra" "add/args")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrb" "barf")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrc" "contract")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mre" "expand/extract")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mri" "inline/inject/introduct")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrl" "localize/log")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrr" "rename")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrs" "split/slurp")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrt" "toggle")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mru" "unwrap")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrv" "var")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mrw" "wrap")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mx" "text")
+    (spacemacs/declare-prefix-for-mode 'js2-mode "mxm" "move")
+    ;; key bindings
+    (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+      "r3i" 'js2r-ternary-to-if
+      "rag" 'js2r-add-to-globals-annotation
+      "rao" 'js2r-arguments-to-object
+      "rba" 'js2r-forward-barf
+      "rca" 'js2r-contract-array
+      "rco" 'js2r-contract-object
+      "rcu" 'js2r-contract-function
+      "rea" 'js2r-expand-array
+      "ref" 'js2r-extract-function
+      "rem" 'js2r-extract-method
+      "reo" 'js2r-expand-object
+      "reu" 'js2r-expand-function
+      "rev" 'js2r-extract-var
+      "rig" 'js2r-inject-global-in-iife
+      "rip" 'js2r-introduce-parameter
+      "riv" 'js2r-inline-var
+      "rlp" 'js2r-localize-parameter
+      "rlt" 'js2r-log-this
+      "rrv" 'js2r-rename-var
+      "rsl" 'js2r-forward-slurp
+      "rss" 'js2r-split-string
+      "rsv" 'js2r-split-var-declaration
+      "rtf" 'js2r-toggle-function-expression-and-declaration
+      "ruw" 'js2r-unwrap
+      "rvt" 'js2r-var-to-this
+      "rwi" 'js2r-wrap-buffer-in-iife
+      "rwl" 'js2r-wrap-in-for-loop
+      "k" 'js2r-kill
+      "xmj" 'js2r-move-line-down
+      "xmk" 'js2r-move-line-up)))
 
 (defun javascript/init-livid-mode ()
   (when (eq javascript-repl 'skewer)
     (use-package livid-mode
       :defer t
       :init
-      (progn
-        (spacemacs/declare-prefix-for-mode 'js2-mode "mT" "toggle")
-        (spacemacs|add-toggle javascript-repl-live-evaluation
-          :mode livid-mode
-          :documentation "Live evaluation of JS buffer change."
-          :evil-leader-for-mode (js2-mode . "Tl"))
-        (spacemacs|diminish livid-mode " 🅻" " [l]")))))
+      (spacemacs/declare-prefix-for-mode 'js2-mode "mT" "toggle")
+      (spacemacs|add-toggle javascript-repl-live-evaluation
+        :mode livid-mode
+        :documentation "Live evaluation of JS buffer change."
+        :evil-leader-for-mode (js2-mode . "Tl"))
+      (spacemacs|diminish livid-mode " 🅻" " [l]"))))
 
 (defun javascript/init-nodejs-repl ()
   (when (eq javascript-repl 'nodejs)
@@ -213,40 +208,39 @@
                                'nodejs-repl
                                "nodejs-repl")
       :config
-      (progn
-        (spacemacs/declare-prefix-for-mode 'js2-mode "ms" "nodejs-repl")
-        (spacemacs/set-leader-keys-for-major-mode 'js2-mode
-          "'" 'nodejs-repl
-          "ss" 'nodejs-repl
-          "si" 'nodejs-repl-switch-to-repl
-          "se" 'nodejs-repl-send-last-expression
-          "sE" (lambda ()
-                 (interactive)
-                 (nodejs-repl-send-last-expression)
-                 (nodejs-repl-switch-to-repl))
-          "sb" 'nodejs-repl-send-buffer
-          "sB" (lambda ()
-                 (interactive)
-                 (nodejs-repl-send-buffer)
-                 (nodejs-repl-switch-to-repl))
-          "sl" 'nodejs-repl-send-line
-          "sL" (lambda ()
-                 (interactive)
-                 (nodejs-repl-send-line)
-                 (nodejs-repl-switch-to-repl))
-          "sr" 'nodejs-repl-send-region
-          "sR" (lambda (start end)
-                 (interactive "r")
-                 (nodejs-repl-send-region start end)
-                 (nodejs-repl-switch-to-repl)))
-        (spacemacs/declare-prefix-for-mode 'js2-mode
-          "msE" "nodejs-send-last-expression-and-focus")
-        (spacemacs/declare-prefix-for-mode 'js2-mode
-          "msB" "nodejs-send-buffer-and-focus")
-        (spacemacs/declare-prefix-for-mode 'js2-mode
-          "msL" "nodejs-send-line-and-focus")
-        (spacemacs/declare-prefix-for-mode 'js2-mode
-          "msR" "nodejs-send-region-and-focus")))))
+      (spacemacs/declare-prefix-for-mode 'js2-mode "ms" "nodejs-repl")
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+        "'" 'nodejs-repl
+        "ss" 'nodejs-repl
+        "si" 'nodejs-repl-switch-to-repl
+        "se" 'nodejs-repl-send-last-expression
+        "sE" (lambda ()
+               (interactive)
+               (nodejs-repl-send-last-expression)
+               (nodejs-repl-switch-to-repl))
+        "sb" 'nodejs-repl-send-buffer
+        "sB" (lambda ()
+               (interactive)
+               (nodejs-repl-send-buffer)
+               (nodejs-repl-switch-to-repl))
+        "sl" 'nodejs-repl-send-line
+        "sL" (lambda ()
+               (interactive)
+               (nodejs-repl-send-line)
+               (nodejs-repl-switch-to-repl))
+        "sr" 'nodejs-repl-send-region
+        "sR" (lambda (start end)
+               (interactive "r")
+               (nodejs-repl-send-region start end)
+               (nodejs-repl-switch-to-repl)))
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msE" "nodejs-send-last-expression-and-focus")
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msB" "nodejs-send-buffer-and-focus")
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msL" "nodejs-send-line-and-focus")
+      (spacemacs/declare-prefix-for-mode 'js2-mode
+        "msR" "nodejs-send-region-and-focus"))))
 
 
 (defun javascript/pre-init-org ()
@@ -262,28 +256,26 @@
     (use-package skewer-mode
       :defer t
       :init
-      (progn
-        (spacemacs/register-repl 'skewer-mode
-                                 'spacemacs/skewer-start-repl
-                                 "skewer")
-        (add-hook 'js2-mode-hook 'skewer-mode))
+      (spacemacs/register-repl 'skewer-mode
+                               'spacemacs/skewer-start-repl
+                               "skewer")
+      (add-hook 'js2-mode-hook 'skewer-mode)
       :config
-      (progn
-        (spacemacs|hide-lighter skewer-mode)
-        (spacemacs/declare-prefix-for-mode 'js2-mode "ms" "skewer")
-        (spacemacs/declare-prefix-for-mode 'js2-mode "me" "eval")
-        (spacemacs/set-leader-keys-for-major-mode 'js2-mode
-          "'" 'spacemacs/skewer-start-repl
-          "ee" 'skewer-eval-last-expression
-          "eE" 'skewer-eval-print-last-expression
-          "sb" 'skewer-load-buffer
-          "sB" 'spacemacs/skewer-load-buffer-and-focus
-          "si" 'spacemacs/skewer-start-repl
-          "sf" 'skewer-eval-defun
-          "sF" 'spacemacs/skewer-eval-defun-and-focus
-          "sr" 'spacemacs/skewer-eval-region
-          "sR" 'spacemacs/skewer-eval-region-and-focus
-          "ss" 'skewer-repl)))))
+      (spacemacs|hide-lighter skewer-mode)
+      (spacemacs/declare-prefix-for-mode 'js2-mode "ms" "skewer")
+      (spacemacs/declare-prefix-for-mode 'js2-mode "me" "eval")
+      (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+        "'" 'spacemacs/skewer-start-repl
+        "ee" 'skewer-eval-last-expression
+        "eE" 'skewer-eval-print-last-expression
+        "sb" 'skewer-load-buffer
+        "sB" 'spacemacs/skewer-load-buffer-and-focus
+        "si" 'spacemacs/skewer-start-repl
+        "sf" 'skewer-eval-defun
+        "sF" 'spacemacs/skewer-eval-defun-and-focus
+        "sr" 'spacemacs/skewer-eval-region
+        "sR" 'spacemacs/skewer-eval-region-and-focus
+        "ss" 'skewer-repl))))
 
 (defun javascript/post-init-tern ()
   (add-to-list 'tern--key-bindings-modes 'js2-mode))

--- a/layers/+lang/json/packages.el
+++ b/layers/+lang/json/packages.el
@@ -46,12 +46,11 @@
   (use-package json-mode
     :defer t
     :init
-    (progn
-      (unless (eq json-backend 'lsp)
-        (spacemacs/declare-prefix-for-mode 'json-mode "mT" "toggle")
-        (spacemacs/declare-prefix-for-mode 'json-mode "mh" "help")
-        (spacemacs/declare-prefix-for-mode 'json-mode "m=" "format"))
-      (add-hook 'json-mode-hook #'spacemacs//json-setup-backend))))
+    (unless (eq json-backend 'lsp)
+      (spacemacs/declare-prefix-for-mode 'json-mode "mT" "toggle")
+      (spacemacs/declare-prefix-for-mode 'json-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'json-mode "m=" "format"))
+    (add-hook 'json-mode-hook #'spacemacs//json-setup-backend)))
 
 (defun json/init-json-navigator ()
   (use-package json-navigator

--- a/layers/+lang/jsonnet/packages.el
+++ b/layers/+lang/jsonnet/packages.el
@@ -34,8 +34,7 @@
   (use-package jsonnet-mode
     :defer t
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'jsonnet-mode
-        "=" 'jsonnet-reformat-buffer
-        "gg" 'jsonnet-jump
-        "eb" 'jsonnet-eval-buffer))))
+    (spacemacs/set-leader-keys-for-major-mode 'jsonnet-mode
+      "=" 'jsonnet-reformat-buffer
+      "gg" 'jsonnet-jump
+      "eb" 'jsonnet-eval-buffer)))

--- a/layers/+lang/julia/packages.el
+++ b/layers/+lang/julia/packages.el
@@ -33,79 +33,74 @@
   (use-package julia-mode
     :defer t
     :init
-    (progn
-      (add-hook 'julia-mode-hook #'spacemacs//julia-setup-buffer)
-      (add-hook 'julia-mode-local-vars-hook #'spacemacs//julia-setup-backend)
-      (when julia-mode-enable-ess
-        (if (configuration-layer/layer-used-p 'ess)
-            (add-to-list 'auto-mode-alist
-                         '("\\.jl\\'" . ess-julia-mode))
-          (message "`ess' layer is not installed. Please add `ess' layer to your dotfile."))))
+    (add-hook 'julia-mode-hook #'spacemacs//julia-setup-buffer)
+    (add-hook 'julia-mode-local-vars-hook #'spacemacs//julia-setup-backend)
+    (when julia-mode-enable-ess
+      (if (configuration-layer/layer-used-p 'ess)
+          (add-to-list 'auto-mode-alist
+                       '("\\.jl\\'" . ess-julia-mode))
+        (message "`ess' layer is not installed. Please add `ess' layer to your dotfile.")))
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'julia-mode "m=" "format")
-      (spacemacs/set-leader-keys-for-major-mode 'julia-mode
-        "l" 'julia-latexsub-or-indent
-        "==" 'julia-indent-line
-        "=d" 'julia-manual-deindent
-        "=q" 'prog-indent-sexp)
+    (spacemacs/declare-prefix-for-mode 'julia-mode "m=" "format")
+    (spacemacs/set-leader-keys-for-major-mode 'julia-mode
+      "l" 'julia-latexsub-or-indent
+      "==" 'julia-indent-line
+      "=d" 'julia-manual-deindent
+      "=q" 'prog-indent-sexp)
 
-      (when (configuration-layer/package-used-p 'helm)
-        (spacemacs/declare-prefix-for-mode 'julia-mode "mi" "insert")
-        (spacemacs/set-leader-keys-for-minor-mode 'julia-mode
-          "ii" 'spacemacs//julia-helm-math-insert)))))
+    (when (configuration-layer/package-used-p 'helm)
+      (spacemacs/declare-prefix-for-mode 'julia-mode "mi" "insert")
+      (spacemacs/set-leader-keys-for-minor-mode 'julia-mode
+        "ii" 'spacemacs//julia-helm-math-insert))))
 
 (defun julia/init-julia-repl ()
   (use-package julia-repl
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'julia-repl 'julia-repl "julia-repl"))
+    (spacemacs/register-repl 'julia-repl 'julia-repl "julia-repl")
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'julia-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'julia-mode "me" "eval")
-      (spacemacs/declare-prefix-for-mode 'julia-mode "ms" "send")
-      (spacemacs/set-leader-keys-for-minor-mode 'julia-repl-mode
-        "'" 'julia-repl
-        "r" 'julia-repl
-        "hh" 'julia-repl-doc
+    (spacemacs/declare-prefix-for-mode 'julia-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'julia-mode "me" "eval")
+    (spacemacs/declare-prefix-for-mode 'julia-mode "ms" "send")
+    (spacemacs/set-leader-keys-for-minor-mode 'julia-repl-mode
+      "'" 'julia-repl
+      "r" 'julia-repl
+      "hh" 'julia-repl-doc
 
-        "sa" 'julia-repl-activate-parent
-        "sd" 'julia-repl-cd
-        "si" 'julia-repl
-        "sb" 'julia-repl-send-buffer
-        "st" 'julia-repl-includet-buffer
-        "sl" 'julia-repl-send-line
-        "ss" 'julia-repl-send-line
-        "sr" 'julia-repl-send-region-or-line
-        "sm" 'julia-repl-macroexpand
-        "se" 'julia-repl-edit
-        "sv" 'julia-repl-prompt-set-inferior-buffer-name-suffix
+      "sa" 'julia-repl-activate-parent
+      "sd" 'julia-repl-cd
+      "si" 'julia-repl
+      "sb" 'julia-repl-send-buffer
+      "st" 'julia-repl-includet-buffer
+      "sl" 'julia-repl-send-line
+      "ss" 'julia-repl-send-line
+      "sr" 'julia-repl-send-region-or-line
+      "sm" 'julia-repl-macroexpand
+      "se" 'julia-repl-edit
+      "sv" 'julia-repl-prompt-set-inferior-buffer-name-suffix
 
-        "ea" 'julia-repl-activate-parent
-        "ed" 'julia-repl-cd
-        "eb" 'julia-repl-send-buffer
-        "et" 'julia-repl-includet-buffer
-        "el" 'julia-repl-send-line
-        "es" 'julia-repl-send-line
-        "er" 'julia-repl-send-region-or-line
-        "em" 'julia-repl-macroexpand
-        "ee" 'julia-repl-edit
-        "ev" 'julia-repl-prompt-set-inferior-buffer-name-suffix))))
+      "ea" 'julia-repl-activate-parent
+      "ed" 'julia-repl-cd
+      "eb" 'julia-repl-send-buffer
+      "et" 'julia-repl-includet-buffer
+      "el" 'julia-repl-send-line
+      "es" 'julia-repl-send-line
+      "er" 'julia-repl-send-region-or-line
+      "em" 'julia-repl-macroexpand
+      "ee" 'julia-repl-edit
+      "ev" 'julia-repl-prompt-set-inferior-buffer-name-suffix)))
 
 
 (defun julia/post-init-evil-surround ()
   (use-package evil-surround
     :config
-    (progn
-      (add-hook
-       'julia-mode-hook
-       (lambda ()
-           (add-to-list 'evil-surround-pairs-alist '(?b . ("begin " . " end")))
-           (add-to-list 'evil-surround-pairs-alist '(?q . ("quote " . " end")))
-           (add-to-list 'evil-surround-pairs-alist '(?: . (":("     .    ")")))
-           (add-to-list 'evil-surround-pairs-alist '(?l . ("let "   . " end"))))))))
+    (add-hook
+     'julia-mode-hook
+     (lambda ()
+       (add-to-list 'evil-surround-pairs-alist '(?b . ("begin " . " end")))
+       (add-to-list 'evil-surround-pairs-alist '(?q . ("quote " . " end")))
+       (add-to-list 'evil-surround-pairs-alist '(?: . (":("     .    ")")))
+       (add-to-list 'evil-surround-pairs-alist '(?l . ("let "   . " end")))))))
 
 (defun julia/init-lsp-julia ()
   (use-package lsp-julia
@@ -114,8 +109,7 @@
     (with-eval-after-load 'lsp-mode
       (require 'lsp-julia))
     :config
-    (progn
-      (push 'xref-find-definitions spacemacs-jump-handlers-julia-mode))))
+    (push 'xref-find-definitions spacemacs-jump-handlers-julia-mode)))
 
 (defun julia/post-init-flycheck ()
   (spacemacs/enable-flycheck 'julia-mode))

--- a/layers/+lang/kivy/packages.el
+++ b/layers/+lang/kivy/packages.el
@@ -32,8 +32,7 @@
   (use-package kivy-mode
     :defer t
     :init
-    (progn
-      ;; config goes here.
-      )))
+    ;; config goes here.
+    ))
 
 ;;; packages.el ends here

--- a/layers/+lang/kotlin/packages.el
+++ b/layers/+lang/kotlin/packages.el
@@ -45,9 +45,8 @@
   (use-package kotlin-mode
     :defer t
     :init
-    (progn
-      (setq lsp-clients-kotlin-server-executable kotlin-lsp-jar-path)
-      (add-hook 'kotlin-mode-hook #'spacemacs//kotlin-setup-backend))))
+    (setq lsp-clients-kotlin-server-executable kotlin-lsp-jar-path)
+    (add-hook 'kotlin-mode-hook #'spacemacs//kotlin-setup-backend)))
 
 (defun kotlin/post-init-ggtags ()
   (add-hook 'kotlin-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -52,131 +52,129 @@
   (use-package tex
     :defer t
     :init
-    (progn
-      (setq TeX-command-default latex-build-command
-            TeX-engine latex-build-engine
-            TeX-auto-save t
-            TeX-parse-self t
-            TeX-syntactic-comment t
-            ;; Synctex support
-            TeX-source-correlate-start-server nil
-            ;; Don't insert line-break at inline math
-            LaTeX-fill-break-at-separators nil)
-      (when latex-enable-auto-fill
-        (add-hook 'LaTeX-mode-hook 'latex/auto-fill-mode))
-      (when latex-enable-folding
-        (add-hook 'LaTeX-mode-hook 'TeX-fold-mode))
-      (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
-      (add-hook 'LaTeX-mode-hook 'TeX-source-correlate-mode)
-      (add-hook 'LaTeX-mode-hook 'TeX-PDF-mode)
-      (add-hook 'LaTeX-mode-hook #'spacemacs//latex-setup-backend)
-      (when latex-refresh-preview
-        (add-hook 'doc-view-mode-hook 'auto-revert-mode)))
+    (setq TeX-command-default latex-build-command
+          TeX-engine latex-build-engine
+          TeX-auto-save t
+          TeX-parse-self t
+          TeX-syntactic-comment t
+          ;; Synctex support
+          TeX-source-correlate-start-server nil
+          ;; Don't insert line-break at inline math
+          LaTeX-fill-break-at-separators nil)
+    (when latex-enable-auto-fill
+      (add-hook 'LaTeX-mode-hook 'latex/auto-fill-mode))
+    (when latex-enable-folding
+      (add-hook 'LaTeX-mode-hook 'TeX-fold-mode))
+    (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
+    (add-hook 'LaTeX-mode-hook 'TeX-source-correlate-mode)
+    (add-hook 'LaTeX-mode-hook 'TeX-PDF-mode)
+    (add-hook 'LaTeX-mode-hook #'spacemacs//latex-setup-backend)
+    (when latex-refresh-preview
+      (add-hook 'doc-view-mode-hook 'auto-revert-mode))
     :config
-    (progn
-      ;; otherwise `, p` preview commands doesn't work
-      (require 'preview)
-      ;; when `latex-view-with-pdf-tools' is non-nil, configure pdf-tools for
+    ;; otherwise `, p` preview commands doesn't work
+    (require 'preview)
+    ;; when `latex-view-with-pdf-tools' is non-nil, configure pdf-tools for
 
-      ;; viewing output pdf's
-      (spacemacs//latex-setup-pdf-tools)
+    ;; viewing output pdf's
+    (spacemacs//latex-setup-pdf-tools)
 
-      ;; Key bindings for plain TeX
-      (dolist (mode '(tex-mode latex-mode context-mode))
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "\\"  'TeX-insert-macro                            ;; C-c C-m
-          "-"   'TeX-recenter-output-buffer                  ;; C-c C-l
-          "%"   'TeX-comment-or-uncomment-paragraph          ;; C-c %
-          ";"   'comment-or-uncomment-region                 ;; C-c ; or C-c :
-          ;; TeX-command-run-all runs compile and open the viewer
-          "k"   'TeX-kill-job                                ;; C-c C-k
-          "l"   'TeX-recenter-output-buffer                  ;; C-c C-l
-          "m"   'TeX-insert-macro                            ;; C-c C-m
-          "n"   'TeX-next-error                              ;; C-c `
-          "N"   'TeX-previous-error                          ;; M-g p
-          "v"   'TeX-view                                    ;; C-c C-v
-          ;; TeX-doc is a very slow function
-          "hd"  'TeX-doc
-          "xb"  'latex/font-bold
-          "xc"  'latex/font-code
-          "xe"  'latex/font-emphasis
-          "xi"  'latex/font-italic
-          "xr"  'latex/font-clear
-          "xo"  'latex/font-oblique
-          "xfc" 'latex/font-small-caps
-          "xff" 'latex/font-sans-serif
-          "xfr" 'latex/font-serif)
-        (spacemacs/declare-prefix-for-mode mode "mxf" "fonts")
-        (unless (and (eq latex-backend 'lsp)
-                     (eq mode 'latex-mode))
-          (spacemacs/declare-prefix-for-mode mode "mh" "help")
-          (spacemacs/declare-prefix-for-mode mode "mx" "text/fonts")
-          (spacemacs/set-leader-keys-for-major-mode mode
-            "a"   'TeX-command-run-all                         ;; C-c C-a
-            "b"   'latex/build))
-        (when dotspacemacs-major-mode-emacs-leader-key
-          (spacemacs/set-leader-keys-for-major-mode mode
-            dotspacemacs-major-mode-emacs-leader-key 'TeX-command-master))
-        (when dotspacemacs-major-mode-leader-key
-          (spacemacs/set-leader-keys-for-major-mode mode
-            dotspacemacs-major-mode-leader-key 'TeX-command-master))
-        (when latex-enable-folding
-          (spacemacs/set-leader-keys-for-major-mode mode
-            ;; the following commands are mostly not autoloaded, but that's fine
-            ;; because `TeX-fold-mode' is added to `LaTeX-mode-hook'
-            "z=" 'TeX-fold-math
-            "zb" 'TeX-fold-buffer
-            "zB" 'TeX-fold-clearout-buffer
-            "ze" 'TeX-fold-env
-            "zI" 'TeX-fold-clearout-item
-            "zm" 'TeX-fold-macro
-            "zp" 'TeX-fold-paragraph
-            "zP" 'TeX-fold-clearout-paragraph
-            "zr" 'TeX-fold-region
-            "zR" 'TeX-fold-clearout-region
-            "zz" 'TeX-fold-dwim)
-          (spacemacs/declare-prefix-for-mode mode "mz" "fold")))
-
-      ;; Key bindings specific to LaTeX
-      (spacemacs/set-leader-keys-for-major-mode 'latex-mode
-        "*"   'LaTeX-mark-section      ;; C-c *
-        "."   'LaTeX-mark-environment  ;; C-c .
-        "ii"   'LaTeX-insert-item       ;; C-c C-j
-        "s"   'LaTeX-section           ;; C-c C-s
-        "fe"  'LaTeX-fill-environment  ;; C-c C-q C-e
-        "fp"  'LaTeX-fill-paragraph    ;; C-c C-q C-p
-        "fr"  'LaTeX-fill-region       ;; C-c C-q C-r
-        "fs"  'LaTeX-fill-section      ;; C-c C-q C-s
-        "pb"  'preview-buffer
-        "pc"  'preview-clearout
-        "pd"  'preview-document
-        "pe"  'preview-environment
-        "pf"  'preview-cache-preamble
-        "pp"  'preview-at-point
-        "pr"  'preview-region
-        "ps"  'preview-section
-        "xB"  'latex/font-medium
+    ;; Key bindings for plain TeX
+    (dolist (mode '(tex-mode latex-mode context-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "\\"  'TeX-insert-macro                            ;; C-c C-m
+        "-"   'TeX-recenter-output-buffer                  ;; C-c C-l
+        "%"   'TeX-comment-or-uncomment-paragraph          ;; C-c %
+        ";"   'comment-or-uncomment-region                 ;; C-c ; or C-c :
+        ;; TeX-command-run-all runs compile and open the viewer
+        "k"   'TeX-kill-job                                ;; C-c C-k
+        "l"   'TeX-recenter-output-buffer                  ;; C-c C-l
+        "m"   'TeX-insert-macro                            ;; C-c C-m
+        "n"   'TeX-next-error                              ;; C-c `
+        "N"   'TeX-previous-error                          ;; M-g p
+        "v"   'TeX-view                                    ;; C-c C-v
+        ;; TeX-doc is a very slow function
+        "hd"  'TeX-doc
+        "xb"  'latex/font-bold
+        "xc"  'latex/font-code
+        "xe"  'latex/font-emphasis
+        "xi"  'latex/font-italic
         "xr"  'latex/font-clear
-        "xfa" 'latex/font-calligraphic
-        "xfn" 'latex/font-normal
-        "xfu" 'latex/font-upright)
+        "xo"  'latex/font-oblique
+        "xfc" 'latex/font-small-caps
+        "xff" 'latex/font-sans-serif
+        "xfr" 'latex/font-serif)
+      (spacemacs/declare-prefix-for-mode mode "mxf" "fonts")
+      (unless (and (eq latex-backend 'lsp)
+                   (eq mode 'latex-mode))
+        (spacemacs/declare-prefix-for-mode mode "mh" "help")
+        (spacemacs/declare-prefix-for-mode mode "mx" "text/fonts")
+        (spacemacs/set-leader-keys-for-major-mode mode
+          "a"   'TeX-command-run-all                         ;; C-c C-a
+          "b"   'latex/build))
+      (when dotspacemacs-major-mode-emacs-leader-key
+        (spacemacs/set-leader-keys-for-major-mode mode
+          dotspacemacs-major-mode-emacs-leader-key 'TeX-command-master))
+      (when dotspacemacs-major-mode-leader-key
+        (spacemacs/set-leader-keys-for-major-mode mode
+          dotspacemacs-major-mode-leader-key 'TeX-command-master))
+      (when latex-enable-folding
+        (spacemacs/set-leader-keys-for-major-mode mode
+          ;; the following commands are mostly not autoloaded, but that's fine
+          ;; because `TeX-fold-mode' is added to `LaTeX-mode-hook'
+          "z=" 'TeX-fold-math
+          "zb" 'TeX-fold-buffer
+          "zB" 'TeX-fold-clearout-buffer
+          "ze" 'TeX-fold-env
+          "zI" 'TeX-fold-clearout-item
+          "zm" 'TeX-fold-macro
+          "zp" 'TeX-fold-paragraph
+          "zP" 'TeX-fold-clearout-paragraph
+          "zr" 'TeX-fold-region
+          "zR" 'TeX-fold-clearout-region
+          "zz" 'TeX-fold-dwim)
+        (spacemacs/declare-prefix-for-mode mode "mz" "fold")))
 
-      ;; Rebind latex keys to avoid conflicts with lsp mode
-      (if (eq latex-backend 'lsp)
-          (spacemacs/set-leader-keys-for-major-mode 'latex-mode
-            "au"   'TeX-command-run-all
-            "c"    'latex/build
-            "iC"   'org-ref-insert-cite-key
-            "ic"   'LaTeX-close-environment ;; C-c ]
-            "ie"   'LaTeX-environment)       ;; C-c C-e
+    ;; Key bindings specific to LaTeX
+    (spacemacs/set-leader-keys-for-major-mode 'latex-mode
+      "*"   'LaTeX-mark-section      ;; C-c *
+      "."   'LaTeX-mark-environment  ;; C-c .
+      "ii"   'LaTeX-insert-item       ;; C-c C-j
+      "s"   'LaTeX-section           ;; C-c C-s
+      "fe"  'LaTeX-fill-environment  ;; C-c C-q C-e
+      "fp"  'LaTeX-fill-paragraph    ;; C-c C-q C-p
+      "fr"  'LaTeX-fill-region       ;; C-c C-q C-r
+      "fs"  'LaTeX-fill-section      ;; C-c C-q C-s
+      "pb"  'preview-buffer
+      "pc"  'preview-clearout
+      "pd"  'preview-document
+      "pe"  'preview-environment
+      "pf"  'preview-cache-preamble
+      "pp"  'preview-at-point
+      "pr"  'preview-region
+      "ps"  'preview-section
+      "xB"  'latex/font-medium
+      "xr"  'latex/font-clear
+      "xfa" 'latex/font-calligraphic
+      "xfn" 'latex/font-normal
+      "xfu" 'latex/font-upright)
+
+    ;; Rebind latex keys to avoid conflicts with lsp mode
+    (if (eq latex-backend 'lsp)
         (spacemacs/set-leader-keys-for-major-mode 'latex-mode
-          "c"   'LaTeX-close-environment ;; C-c ]
-          "e"   'LaTeX-environment))       ;; C-c C-e
+          "au"   'TeX-command-run-all
+          "c"    'latex/build
+          "iC"   'org-ref-insert-cite-key
+          "ic"   'LaTeX-close-environment ;; C-c ]
+          "ie"   'LaTeX-environment)       ;; C-c C-e
+      (spacemacs/set-leader-keys-for-major-mode 'latex-mode
+        "c"   'LaTeX-close-environment ;; C-c ]
+        "e"   'LaTeX-environment))       ;; C-c C-e
 
-      ;; Declare prefixes
-      (spacemacs/declare-prefix-for-mode 'latex-mode "mi" "insert")
-      (spacemacs/declare-prefix-for-mode 'latex-mode "mp" "preview")
-      (spacemacs/declare-prefix-for-mode 'latex-mode "mf" "fill"))))
+    ;; Declare prefixes
+    (spacemacs/declare-prefix-for-mode 'latex-mode "mi" "insert")
+    (spacemacs/declare-prefix-for-mode 'latex-mode "mp" "preview")
+    (spacemacs/declare-prefix-for-mode 'latex-mode "mf" "fill")))
 
 (defun latex/pre-init-auctex-latexmk ()
   (spacemacs|use-package-add-hook tex
@@ -201,10 +199,9 @@
   (use-package evil-tex
     :defer t
     :init
-    (progn
-      (add-hook 'LaTeX-mode-hook #'evil-tex-mode)
-      (setq evil-tex-toggle-override-m nil)
-      (setq evil-tex-toggle-override-t nil))
+    (add-hook 'LaTeX-mode-hook #'evil-tex-mode)
+    (setq evil-tex-toggle-override-m nil)
+    (setq evil-tex-toggle-override-t nil)
     :config
     (spacemacs/declare-prefix-for-mode 'latex-mode "mq"
       (cons "evil-tex toggles" evil-tex-toggle-map))))
@@ -257,13 +254,12 @@
   (use-package magic-latex-buffer
     :defer t
     :init
-    (progn
-      (add-hook 'TeX-update-style-hook 'magic-latex-buffer)
-      (setq magic-latex-enable-block-highlight t
-            magic-latex-enable-suscript t
-            magic-latex-enable-pretty-symbols t
-            magic-latex-enable-block-align nil
-            magic-latex-enable-inline-image nil))))
+    (add-hook 'TeX-update-style-hook 'magic-latex-buffer)
+    (setq magic-latex-enable-block-highlight t
+          magic-latex-enable-suscript t
+          magic-latex-enable-pretty-symbols t
+          magic-latex-enable-block-align nil
+          magic-latex-enable-inline-image nil)))
 
 (defun latex/init-lsp-latex ()
   (use-package lsp-latex

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -39,28 +39,27 @@
     :mode ("\\.lua\\'" . lua-mode)
     :interpreter ("lua" . lua-mode)
     :init
-    (progn
-      (spacemacs/register-repl 'lua #'lua-show-process-buffer "lua")
-      (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-backend)
+    (spacemacs/register-repl 'lua #'lua-show-process-buffer "lua")
+    (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-backend)
 
-      ;; Set global settings
-      (setq lua-indent-level 2
-            lua-indent-string-contents t)
+    ;; Set global settings
+    (setq lua-indent-level 2
+          lua-indent-string-contents t)
 
-      ;; Set general bindings
-      (spacemacs/declare-prefix-for-mode 'lua-mode "ms" "REPL")
-      (spacemacs/set-leader-keys-for-major-mode 'lua-mode
-        "hd" 'lua-search-documentation
-        "sb" 'lua-send-buffer
-        "sf" 'lua-send-defun
-        "sl" 'lua-send-current-line
-        "sr" 'lua-send-region
-        "'" 'lua-show-process-buffer)
+    ;; Set general bindings
+    (spacemacs/declare-prefix-for-mode 'lua-mode "ms" "REPL")
+    (spacemacs/set-leader-keys-for-major-mode 'lua-mode
+      "hd" 'lua-search-documentation
+      "sb" 'lua-send-buffer
+      "sf" 'lua-send-defun
+      "sl" 'lua-send-current-line
+      "sr" 'lua-send-region
+      "'" 'lua-show-process-buffer)
 
-      ;; Set lua-mode specific bindings
-      (when (eq lua-backend 'lua-mode)
-        (spacemacs/declare-prefix-for-mode 'lua-mode "mh" "help")
-        (spacemacs/declare-prefix-for-mode 'lua-mode "mg" "goto")))))
+    ;; Set lua-mode specific bindings
+    (when (eq lua-backend 'lua-mode)
+      (spacemacs/declare-prefix-for-mode 'lua-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'lua-mode "mg" "goto"))))
 
 (defun lua/post-init-company ()
   (add-hook 'lua-mode-local-vars-hook #'spacemacs//lua-setup-company))

--- a/layers/+lang/major-modes/packages.el
+++ b/layers/+lang/major-modes/packages.el
@@ -46,23 +46,21 @@
   (use-package ebuild-mode
     :mode ("\\.\\(ebuild\\|eclass\\)" . ebuild-mode)
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'ebuild-mode
-        "n" 'ebuild-mode-insert-skeleton
-        "k" 'ebuild-mode-keyword
-        "e" 'ebuild-run-command
-        "a" 'ebuild-run-echangelog))))
+    (spacemacs/set-leader-keys-for-major-mode 'ebuild-mode
+      "n" 'ebuild-mode-insert-skeleton
+      "k" 'ebuild-mode-keyword
+      "e" 'ebuild-run-command
+      "a" 'ebuild-run-echangelog)))
 
 (defun major-modes/init-gemini-mode ()
   (use-package gemini-mode
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'gemini-mode
-        "l" 'gemini-insert-link
-        "o" 'gemini-open-link-at-point
-        "RET" 'gemini-insert-list-item
-        "t" 'gemini-insert-time-stamp
-        "n" 'gemini-insert-tinylog-header))))
+    (spacemacs/set-leader-keys-for-major-mode 'gemini-mode
+      "l" 'gemini-insert-link
+      "o" 'gemini-open-link-at-point
+      "RET" 'gemini-insert-list-item
+      "t" 'gemini-insert-time-stamp
+      "n" 'gemini-insert-tinylog-header)))
 
 (defun major-modes/init-hoon-mode ())
 
@@ -83,15 +81,14 @@
     :mode ("\\`PKGBUILD\\'" . pkgbuild-mode)
     :defer t
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'pkgbuild-mode
-        "r" 'pkgbuild-increase-release-tag
-        "b" 'pkgbuild-makepkg
-        "a" 'pkgbuild-tar
-        "u" 'pkgbuild-browse-url
-        "m" 'pkgbuild-update-sums-line
-        "s" 'pkgbuild-update-srcinfo
-        "e" 'pkgbuild-etags))))
+    (spacemacs/set-leader-keys-for-major-mode 'pkgbuild-mode
+      "r" 'pkgbuild-increase-release-tag
+      "b" 'pkgbuild-makepkg
+      "a" 'pkgbuild-tar
+      "u" 'pkgbuild-browse-url
+      "m" 'pkgbuild-update-sums-line
+      "s" 'pkgbuild-update-srcinfo
+      "e" 'pkgbuild-etags)))
 
 (defun major-modes/init-qml-mode ()
   (use-package qml-mode

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -202,9 +202,8 @@
     :init (add-hook 'markdown-mode-hook 'spacemacs/activate-mmm-mode)
     ;; Automatically add mmm class for languages
     :config
-    (progn
-      (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)
-      (spacemacs|hide-lighter mmm-mode))))
+    (mapc 'markdown/mmm-auto-class markdown-mmm-auto-modes)
+    (spacemacs|hide-lighter mmm-mode)))
 
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode

--- a/layers/+lang/mercury/packages.el
+++ b/layers/+lang/mercury/packages.el
@@ -44,18 +44,17 @@
     :init
     :mode ("\\.m\\'" . metal-mercury-mode)
     :config
-    (progn
-      (dolist (x '(
-                   ;; ("m=" . "format")
-                   ("mc" . "mercury/compile")
-                   ;; ("mh" . "help")
-                   ))
-        (spacemacs/declare-prefix-for-mode 'metal-mercury-mode (car x) (cdr x)))
+    (dolist (x '(
+                 ;; ("m=" . "format")
+                 ("mc" . "mercury/compile")
+                 ;; ("mh" . "help")
+                 ))
+      (spacemacs/declare-prefix-for-mode 'metal-mercury-mode (car x) (cdr x)))
 
-      (spacemacs/set-leader-keys-for-major-mode 'metal-mercury-mode
-        ;; make
-        "cb" 'metal-mercury-mode-compile
-        "cr" 'metal-mercury-mode-runner))))
+    (spacemacs/set-leader-keys-for-major-mode 'metal-mercury-mode
+      ;; make
+      "cb" 'metal-mercury-mode-compile
+      "cr" 'metal-mercury-mode-runner)))
 
 (defun mercury/post-init-smartparens ()
   (add-hook 'metal-mercury-mode-hook #'spacemacs//activate-smartparens))

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -43,20 +43,18 @@
   (use-package nim-mode
     :defer t
     :init
-    (progn
-      (add-hook 'nim-mode-hook #'spacemacs//nim-setup-backend)
-      (add-to-list 'spacemacs-jump-handlers-nim-mode 'nimsuggest-find-definition))
+    (add-hook 'nim-mode-hook #'spacemacs//nim-setup-backend)
+    (add-to-list 'spacemacs-jump-handlers-nim-mode 'nimsuggest-find-definition)
     :config
-    (progn
-      ;; Set non lsp bindings
-      (when (eq nim-backend 'company-nim)
-        (spacemacs/declare-prefix-for-mode 'nim-mode "mg" "goto")
-        (spacemacs/declare-prefix-for-mode 'nim-mode "mh" "help")
-        (spacemacs/set-leader-keys-for-major-mode 'nim-mode
-          "hh" 'nimsuggest-show-doc))
-
-      ;; Set general bindings
-      (spacemacs/declare-prefix-for-mode 'nim-mode "mc" "compile")
+    ;; Set non lsp bindings
+    (when (eq nim-backend 'company-nim)
+      (spacemacs/declare-prefix-for-mode 'nim-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'nim-mode "mh" "help")
       (spacemacs/set-leader-keys-for-major-mode 'nim-mode
-        "cr" 'spacemacs/nim-compile-run
-        "gb" 'pop-tag-mark))))
+        "hh" 'nimsuggest-show-doc))
+
+    ;; Set general bindings
+    (spacemacs/declare-prefix-for-mode 'nim-mode "mc" "compile")
+    (spacemacs/set-leader-keys-for-major-mode 'nim-mode
+      "cr" 'spacemacs/nim-compile-run
+      "gb" 'pop-tag-mark)))

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -53,31 +53,30 @@
   (use-package dune
     :defer t
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
-        "tP" 'dune-promote
-        "tp" 'dune-runtest-and-promote)
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mt" "test")
-      (spacemacs/declare-prefix-for-mode 'dune-mode "mc" "compile/check")
-      (spacemacs/declare-prefix-for-mode 'dune-mode "mi" "insert-form")
-      (spacemacs/declare-prefix-for-mode 'dune-mode "mt" "test")
-      (spacemacs/set-leader-keys-for-major-mode 'dune-mode
-        "cc" 'compile
-        "ia" 'dune-insert-alias-form
-        "ic" 'dune-insert-copyfiles-form
-        "id" 'dune-insert-ignored-subdirs-form
-        "ie" 'dune-insert-executable-form
-        "ii" 'dune-insert-install-form
-        "il" 'dune-insert-library-form
-        "im" 'dune-insert-menhir-form
-        "ip" 'dune-insert-ocamllex-form
-        "ir" 'dune-insert-rule-form
-        "it" 'dune-insert-tests-form
-        "iv" 'dune-insert-env-form
-        "ix" 'dune-insert-executables-form
-        "iy" 'dune-insert-ocamlyacc-form
-        "tP" 'dune-promote
-        "tp" 'dune-runtest-and-promote))))
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "tP" 'dune-promote
+      "tp" 'dune-runtest-and-promote)
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "mt" "test")
+    (spacemacs/declare-prefix-for-mode 'dune-mode "mc" "compile/check")
+    (spacemacs/declare-prefix-for-mode 'dune-mode "mi" "insert-form")
+    (spacemacs/declare-prefix-for-mode 'dune-mode "mt" "test")
+    (spacemacs/set-leader-keys-for-major-mode 'dune-mode
+      "cc" 'compile
+      "ia" 'dune-insert-alias-form
+      "ic" 'dune-insert-copyfiles-form
+      "id" 'dune-insert-ignored-subdirs-form
+      "ie" 'dune-insert-executable-form
+      "ii" 'dune-insert-install-form
+      "il" 'dune-insert-library-form
+      "im" 'dune-insert-menhir-form
+      "ip" 'dune-insert-ocamllex-form
+      "ir" 'dune-insert-rule-form
+      "it" 'dune-insert-tests-form
+      "iv" 'dune-insert-env-form
+      "ix" 'dune-insert-executables-form
+      "iy" 'dune-insert-ocamlyacc-form
+      "tP" 'dune-promote
+      "tp" 'dune-runtest-and-promote)))
 
 (defun ocaml/post-init-evil-matchit ()
   (add-hook 'tuareg-mode-hook #'evil-matchit-mode))
@@ -89,10 +88,9 @@
   (use-package flycheck-ocaml
     :defer t
     :init
-    (progn
-      (with-eval-after-load 'merlin
-        (setq merlin-error-after-save nil)
-        (flycheck-ocaml-setup)))))
+    (with-eval-after-load 'merlin
+      (setq merlin-error-after-save nil)
+      (flycheck-ocaml-setup))))
 
 (defun ocaml/post-init-ggtags ()
   (add-hook 'ocaml-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
@@ -104,32 +102,31 @@
   (use-package merlin
     :defer t
     :init
-    (progn
-      (add-to-list 'spacemacs-jump-handlers-tuareg-mode
-                   'spacemacs/merlin-locate)
-      (add-hook 'tuareg-mode-hook 'merlin-mode)
+    (add-to-list 'spacemacs-jump-handlers-tuareg-mode
+                 'spacemacs/merlin-locate)
+    (add-hook 'tuareg-mode-hook 'merlin-mode)
 
-      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
-        "cp" 'merlin-project-check
-        "cv" 'merlin-goto-project-file
-        "Ec" 'merlin-error-check
-        "En" 'merlin-error-next
-        "EN" 'merlin-error-prev
-        "gb" 'merlin-pop-stack
-        "gG" 'spacemacs/merlin-locate-other-window
-        "gl" 'merlin-locate-ident
-        "gi" 'merlin-switch-to-ml
-        "gI" 'merlin-switch-to-mli
-        "go" 'merlin-occurrences
-        "hh" 'merlin-document
-        "ht" 'merlin-type-enclosing
-        "hT" 'merlin-type-expr
-        "rd" 'merlin-destruct)
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mc" "compile/check")
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mE" "errors")
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor"))))
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "cp" 'merlin-project-check
+      "cv" 'merlin-goto-project-file
+      "Ec" 'merlin-error-check
+      "En" 'merlin-error-next
+      "EN" 'merlin-error-prev
+      "gb" 'merlin-pop-stack
+      "gG" 'spacemacs/merlin-locate-other-window
+      "gl" 'merlin-locate-ident
+      "gi" 'merlin-switch-to-ml
+      "gI" 'merlin-switch-to-mli
+      "go" 'merlin-occurrences
+      "hh" 'merlin-document
+      "ht" 'merlin-type-enclosing
+      "hT" 'merlin-type-expr
+      "rd" 'merlin-destruct)
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "mc" "compile/check")
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "mE" "errors")
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "mr" "refactor")))
 
 (defun ocaml/init-merlin-company ()
   (use-package merlin-company
@@ -139,9 +136,8 @@
   (use-package merlin-iedit
     :defer t
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
-        "re" 'merlin-iedit-occurrences))))
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "re" 'merlin-iedit-occurrences)))
 
 (defun ocaml/post-init-imenu ()
   (add-hook 'merlin-mode-hook #'merlin-use-merlin-imenu))
@@ -181,61 +177,58 @@
            ("\\.topml$" . tuareg-mode))
     :defer t
     :init
-    (progn
-      (spacemacs//init-ocaml-opam)
-      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
-        "ga" 'tuareg-find-alternate-file
-        "cc" 'compile)
-      ;; Make OCaml-generated files invisible to filename completion
-      (dolist (ext '(".cmo" ".cmx" ".cma" ".cmxa" ".cmi" ".cmxs" ".cmt" ".cmti" ".annot"))
-        (add-to-list 'completion-ignored-extensions ext)))))
+    (spacemacs//init-ocaml-opam)
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "ga" 'tuareg-find-alternate-file
+      "cc" 'compile)
+    ;; Make OCaml-generated files invisible to filename completion
+    (dolist (ext '(".cmo" ".cmx" ".cma" ".cmxa" ".cmi" ".cmxs" ".cmt" ".cmti" ".annot"))
+      (add-to-list 'completion-ignored-extensions ext))))
 
 (defun ocaml/init-utop ()
   (use-package utop
     :defer t
     :init
-    (progn
-      (add-hook 'tuareg-mode-hook 'utop-minor-mode)
-      (spacemacs/register-repl 'utop 'utop "ocaml"))
+    (add-hook 'tuareg-mode-hook 'utop-minor-mode)
+    (spacemacs/register-repl 'utop 'utop "ocaml")
     :config
-    (progn
-      (if (executable-find "opam")
-          (setq utop-command "opam config exec -- utop -emacs")
-        (spacemacs-buffer/warning "Cannot find \"opam\" executable."))
+    (if (executable-find "opam")
+        (setq utop-command "opam config exec -- utop -emacs")
+      (spacemacs-buffer/warning "Cannot find \"opam\" executable."))
 
-      (defun spacemacs/utop-eval-phrase-and-go ()
-        "Send phrase to REPL and evaluate it and switch to the REPL in
+    (defun spacemacs/utop-eval-phrase-and-go ()
+      "Send phrase to REPL and evaluate it and switch to the REPL in
 `insert state'"
-        (interactive)
-        (utop-eval-phrase)
-        (utop)
-        (evil-insert-state))
+      (interactive)
+      (utop-eval-phrase)
+      (utop)
+      (evil-insert-state))
 
-      (defun spacemacs/utop-eval-buffer-and-go ()
-        "Send buffer to REPL and evaluate it and switch to the REPL in
+    (defun spacemacs/utop-eval-buffer-and-go ()
+      "Send buffer to REPL and evaluate it and switch to the REPL in
 `insert state'"
-        (interactive)
-        (utop-eval-buffer)
-        (utop)
-        (evil-insert-state))
+      (interactive)
+      (utop-eval-buffer)
+      (utop)
+      (evil-insert-state))
 
-      (defun spacemacs/utop-eval-region-and-go (start end)
-        "Send region to REPL and evaluate it and switch to the REPL in
+    (defun spacemacs/utop-eval-region-and-go (start end)
+      "Send region to REPL and evaluate it and switch to the REPL in
 `insert state'"
-        (interactive "r")
-        (utop-eval-region start end)
-        (utop)
-        (evil-insert-state))
+      (interactive "r")
+      (utop-eval-region start end)
+      (utop)
+      (evil-insert-state))
 
-      (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
-        "'"  'utop
-        "sb" 'utop-eval-buffer
-        "sB" 'spacemacs/utop-eval-buffer-and-go
-        "si" 'utop
-        "sp" 'utop-eval-phrase
-        "sP" 'spacemacs/utop-eval-phrase-and-go
-        "sr" 'utop-eval-region
-        "sR" 'spacemacs/utop-eval-region-and-go)
-      (spacemacs/declare-prefix-for-mode 'tuareg-mode "ms" "send"))
+    (spacemacs/set-leader-keys-for-major-mode 'tuareg-mode
+      "'"  'utop
+      "sb" 'utop-eval-buffer
+      "sB" 'spacemacs/utop-eval-buffer-and-go
+      "si" 'utop
+      "sp" 'utop-eval-phrase
+      "sP" 'spacemacs/utop-eval-phrase-and-go
+      "sr" 'utop-eval-region
+      "sR" 'spacemacs/utop-eval-region-and-go)
+    (spacemacs/declare-prefix-for-mode 'tuareg-mode "ms" "send")
     (define-key utop-mode-map (kbd "C-j") 'utop-history-goto-next)
     (define-key utop-mode-map (kbd "C-k") 'utop-history-goto-prev)))

--- a/layers/+lang/pact/packages.el
+++ b/layers/+lang/pact/packages.el
@@ -48,45 +48,43 @@
     :defer t
 
     :init
-    (progn
-      (spacemacs/register-repl 'pact-mode 'spacemacs/pact-repl "pact"))
+    (spacemacs/register-repl 'pact-mode 'spacemacs/pact-repl "pact")
 
     :config
-    (progn
-      (defun spacemacs/pact-repl ()
-        "Open a pact repl in a side frame."
-        (interactive)
-        (if (get-buffer-process inferior-lisp-buffer)
-            ;; Borrowed from `switch-to-lisp':
-            (let ((pop-up-frames
-                   ;; Be willing to use another frame
-                   ;; that already has the window in it.
-                   (or pop-up-frames
-                       (get-buffer-window inferior-lisp-buffer t))))
-              (pop-to-buffer inferior-lisp-buffer))
-          (progn
-            (spacemacs/new-empty-buffer-right)
-            (pact-mode)
-            (run-lisp inferior-lisp-program))))
+    (defun spacemacs/pact-repl ()
+      "Open a pact repl in a side frame."
+      (interactive)
+      (if (get-buffer-process inferior-lisp-buffer)
+          ;; Borrowed from `switch-to-lisp':
+          (let ((pop-up-frames
+                 ;; Be willing to use another frame
+                 ;; that already has the window in it.
+                 (or pop-up-frames
+                     (get-buffer-window inferior-lisp-buffer t))))
+            (pop-to-buffer inferior-lisp-buffer))
+        (progn
+          (spacemacs/new-empty-buffer-right)
+          (pact-mode)
+          (run-lisp inferior-lisp-program))))
 
-      (defun spacemacs/pact-load-file ()
-        "Load the current buffer into the Pact repl, optionally starting
+    (defun spacemacs/pact-load-file ()
+      "Load the current buffer into the Pact repl, optionally starting
 the repl if it hasn't yet been."
-        (interactive)
-        (let ((curr (current-buffer)))
-          (progn
-            (unless (get-buffer-process inferior-lisp-buffer)
-              (spacemacs/pact-repl)
-              (pop-to-buffer curr))
-            (pact-load-file nil)
-            (pop-to-buffer curr))))
+      (interactive)
+      (let ((curr (current-buffer)))
+        (progn
+          (unless (get-buffer-process inferior-lisp-buffer)
+            (spacemacs/pact-repl)
+            (pop-to-buffer curr))
+          (pact-load-file nil)
+          (pop-to-buffer curr))))
 
-      (dolist (prefix '(("ms" . "repl")))
-        (spacemacs/declare-prefix-for-mode 'pact-mode (car prefix) (cdr prefix)))
+    (dolist (prefix '(("ms" . "repl")))
+      (spacemacs/declare-prefix-for-mode 'pact-mode (car prefix) (cdr prefix)))
 
-      (spacemacs/set-leader-keys-for-major-mode 'pact-mode
-        ;; REPL
-        "s'" 'spacemacs/pact-repl
-        "sb" 'spacemacs/pact-load-file))))
+    (spacemacs/set-leader-keys-for-major-mode 'pact-mode
+      ;; REPL
+      "s'" 'spacemacs/pact-repl
+      "sb" 'spacemacs/pact-load-file)))
 
 ;;; packages.el ends here

--- a/layers/+lang/perl5/packages.el
+++ b/layers/+lang/perl5/packages.el
@@ -51,91 +51,89 @@
     :interpreter "perl"
     :interpreter "perl5"
     :init
-    (progn
-      (setq
-       ;; highlight all scalar variables not just the instantiation
-       cperl-highlight-variables-indiscriminately t
-       cperl-indent-level 4        ; 4 spaces is the standard indentation
-       cperl-close-paren-offset -4 ; indent the closing paren back four spaces
-       cperl-continued-statement-offset 4 ; if a statement continues indent it to four spaces
-       cperl-indent-parens-as-block t) ; parentheses are indented with the block and not with scope
-      (add-hook 'cperl-mode-hook #'spacemacs//perl5-setup-backend))
+    (setq
+     ;; highlight all scalar variables not just the instantiation
+     cperl-highlight-variables-indiscriminately t
+     cperl-indent-level 4        ; 4 spaces is the standard indentation
+     cperl-close-paren-offset -4 ; indent the closing paren back four spaces
+     cperl-continued-statement-offset 4 ; if a statement continues indent it to four spaces
+     cperl-indent-parens-as-block t) ; parentheses are indented with the block and not with scope
+    (add-hook 'cperl-mode-hook #'spacemacs//perl5-setup-backend)
     :config
-    (progn
-      ;; Don't highlight arrays and hashes in comments
-      (font-lock-remove-keywords
-       'cperl-mode
-       '(("\\(\\([@%]\\|\\$#\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)" 1
-          (if (eq (char-after (match-beginning 2)) 37)
-              'cperl-hash-face 'cperl-array-face) t)
-         ("\\(\\([$@]+\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)[ \t]*\\([[{]\\)" 1
+    ;; Don't highlight arrays and hashes in comments
+    (font-lock-remove-keywords
+     'cperl-mode
+     '(("\\(\\([@%]\\|\\$#\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)" 1
+        (if (eq (char-after (match-beginning 2)) 37)
+            'cperl-hash-face 'cperl-array-face) t)
+       ("\\(\\([$@]+\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)[ \t]*\\([[{]\\)" 1
+        (if (= (- (match-end 2) (match-beginning 2)) 1)
+            (if (eq (char-after (match-beginning 3)) 123)
+                'cperl-hash-face 'cperl-array-face)
+          font-lock-variable-name-face) t)
+       ("\\([]}\\\\%@>*&]\\|\\$[a-zA-Z0-9_:]*\\)[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}"
+        (2 font-lock-string-face t)
+        ("\\=[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}" nil nil
+         (1 font-lock-string-face t)))
+       ("[[ \t{,(]\\(-?[a-zA-Z0-9_:]+\\)[ \t]*=>" 1 font-lock-string-face t)))
+
+    (font-lock-add-keywords
+     'cperl-mode
+     '(("\\(\\([@%]\\|\\$#\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)" 1
+        (if (nth 4 (syntax-ppss))
+            'font-lock-comment-face
+          (if (eq (char-after (match-beginning 2)) ?%)
+              'cperl-hash-face
+            'cperl-array-face)) t)
+       ("\\(\\([$@]+\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)[ \t]*\\([[{]\\)" 1
+        (if (nth 4 (syntax-ppss))
+            'font-lock-comment-face
           (if (= (- (match-end 2) (match-beginning 2)) 1)
-              (if (eq (char-after (match-beginning 3)) 123)
-                  'cperl-hash-face 'cperl-array-face)
-            font-lock-variable-name-face) t)
-         ("\\([]}\\\\%@>*&]\\|\\$[a-zA-Z0-9_:]*\\)[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}"
-          (2 font-lock-string-face t)
-          ("\\=[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}" nil nil
-           (1 font-lock-string-face t)))
-         ("[[ \t{,(]\\(-?[a-zA-Z0-9_:]+\\)[ \t]*=>" 1 font-lock-string-face t)))
+              (if (eq (char-after (match-beginning 3)) ?{)
+                  'cperl-hash-face
+                'cperl-array-face)
+            font-lock-variable-name-face)) t)
+       ("\\([]}\\\\%@>*&]\\|\\$[a-zA-Z0-9_:]*\\)[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}"
+        (2 (if (nth 4 (syntax-ppss))
+               'font-lock-comment-face
+             'font-lock-string-face) t)
+        ("\\=[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}" nil nil
+         (1 (if (nth 4 (syntax-ppss))
+                'font-lock-comment-face
+              'font-lock-string-face) t)))
+       ("[[ \t{,(]\\(-?[a-zA-Z0-9_:]+\\)[ \t]*=>" 1
+        (if (nth 4 (syntax-ppss))
+            'font-lock-comment-face
+          'font-lock-string-face) t)))
 
-      (font-lock-add-keywords
-       'cperl-mode
-       '(("\\(\\([@%]\\|\\$#\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)" 1
-          (if (nth 4 (syntax-ppss))
-              'font-lock-comment-face
-            (if (eq (char-after (match-beginning 2)) ?%)
-                'cperl-hash-face
-              'cperl-array-face)) t)
-         ("\\(\\([$@]+\\)[a-zA-Z_:][a-zA-Z0-9_:]*\\)[ \t]*\\([[{]\\)" 1
-          (if (nth 4 (syntax-ppss))
-              'font-lock-comment-face
-            (if (= (- (match-end 2) (match-beginning 2)) 1)
-                (if (eq (char-after (match-beginning 3)) ?{)
-                    'cperl-hash-face
-                  'cperl-array-face)
-              font-lock-variable-name-face)) t)
-         ("\\([]}\\\\%@>*&]\\|\\$[a-zA-Z0-9_:]*\\)[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}"
-          (2 (if (nth 4 (syntax-ppss))
-                 'font-lock-comment-face
-               'font-lock-string-face) t)
-          ("\\=[ \t]*{[ \t]*\\(-?[a-zA-Z0-9_:]+\\)[ \t]*}" nil nil
-           (1 (if (nth 4 (syntax-ppss))
-                  'font-lock-comment-face
-                'font-lock-string-face) t)))
-         ("[[ \t{,(]\\(-?[a-zA-Z0-9_:]+\\)[ \t]*=>" 1
-          (if (nth 4 (syntax-ppss))
-              'font-lock-comment-face
-            'font-lock-string-face) t)))
+    ;; Use less horrible colors for cperl arrays and hashes
+    (set-face-attribute 'cperl-array-face nil
+                        :foreground  "#DD7D0A"
+                        :background  'unspecified
+                        :weight 'unspecified)
+    (set-face-attribute 'cperl-hash-face nil
+                        :foreground "OrangeRed3"
+                        :background 'unspecified
+                        :weight 'unspecified)
 
-      ;; Use less horrible colors for cperl arrays and hashes
-      (set-face-attribute 'cperl-array-face nil
-                          :foreground  "#DD7D0A"
-                          :background  'unspecified
-                          :weight 'unspecified)
-      (set-face-attribute 'cperl-hash-face nil
-                          :foreground "OrangeRed3"
-                          :background 'unspecified
-                          :weight 'unspecified)
+    ;; tab key will ident all marked code when tab key is pressed
+    (add-hook 'cperl-mode-hook
+              (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
 
-      ;; tab key will ident all marked code when tab key is pressed
-      (add-hook 'cperl-mode-hook
-                (lambda () (local-set-key (kbd "<tab>") 'indent-for-tab-command)))
+    (unless (eq perl5-backend 'lsp)
+      (spacemacs/declare-prefix-for-mode 'cperl-mode "m=" "format")
+      (spacemacs/declare-prefix-for-mode 'cperl-mode "mg" "find-symbol")
+      (spacemacs/declare-prefix-for-mode 'cperl-mode "mh" "perldoc"))
+    (spacemacs/set-leader-keys-for-major-mode 'cperl-mode
+      "hh" 'cperl-perldoc-at-point
+      "==" 'spacemacs/perltidy-format
+      "=b" 'spacemacs/perltidy-format-buffer
+      "=f" 'spacemacs/perltidy-format-function
+      "hd" 'cperl-perldoc
+      "v" 'cperl-select-this-pod-or-here-doc)
 
-      (unless (eq perl5-backend 'lsp)
-        (spacemacs/declare-prefix-for-mode 'cperl-mode "m=" "format")
-        (spacemacs/declare-prefix-for-mode 'cperl-mode "mg" "find-symbol")
-        (spacemacs/declare-prefix-for-mode 'cperl-mode "mh" "perldoc"))
-      (spacemacs/set-leader-keys-for-major-mode 'cperl-mode
-        "hh" 'cperl-perldoc-at-point
-        "==" 'spacemacs/perltidy-format
-        "=b" 'spacemacs/perltidy-format-buffer
-        "=f" 'spacemacs/perltidy-format-function
-        "hd" 'cperl-perldoc
-        "v" 'cperl-select-this-pod-or-here-doc)
-
-      (font-lock-add-keywords 'cperl-mode
-                              '(("\\_<say\\_>" . cperl-nonoverridable-face))))))
+    (font-lock-add-keywords 'cperl-mode
+                            '(("\\_<say\\_>" . cperl-nonoverridable-face)))))
 
 (defun perl5/post-init-flycheck ()
   (spacemacs/enable-flycheck 'cperl-mode))

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -77,50 +77,47 @@
     :defer t
     :mode ("\\.php\\'" . php-mode)
     :init
-    (progn
-      (add-hook 'php-mode-hook 'spacemacs//php-setup-backend))
+    (add-hook 'php-mode-hook 'spacemacs//php-setup-backend)
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'php-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mt" "tests")
-      (spacemacs/set-leader-keys-for-major-mode 'php-mode
-        "tt" 'phpunit-current-test
-        "tc" 'phpunit-current-class
-        "tp" 'phpunit-current-project))))
+    (spacemacs/declare-prefix-for-mode 'php-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mt" "tests")
+    (spacemacs/set-leader-keys-for-major-mode 'php-mode
+      "tt" 'phpunit-current-test
+      "tc" 'phpunit-current-class
+      "tp" 'phpunit-current-project)))
 
 (defun php/init-phpactor ()
   (use-package phpactor
     :defer t
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'php-mode "mrg" "generate")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mre" "extract")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mrm" "methods")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mrc" "classes")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mrp" "properties")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mP" "phpactor")
-      (spacemacs/declare-prefix-for-mode 'php-mode "mr" "refactoring")
-      (spacemacs/set-leader-keys-for-major-mode 'php-mode
-        "ri"  #'phpactor-import-class
-        "rr"  #'phpactor-rename-variable-local
-        "rR"  #'phpactor-rename-variable-file
-        "rn"  #'phpactor-fix-namespace
-        "rv"  #'phpactor-change-visibility
-        "rga" #'phpactor-generate-accessors
-        "rgm" #'phpactor-generate-method
-        "rcn" #'phpactor-create-new-class
-        "rcc" #'phpactor-copy-class
-        "rcm" #'phpactor-move-class
-        "rci" #'phpactor-inflect-class
-        "rpc" #'phpactor-complete-constructor
-        "rpp" #'phpactor-complete-properties
-        "rec" #'phpactor-extract-constant
-        "ree" #'phpactor-extract-expression
-        "rem" #'phpactor-extract-method
-        "rmc" #'phpactor-implement-contracts
-        "Ps"  #'phpactor-status
-        "Pu"  #'phpactor-install-or-update)
-      (setq-default phpactor-references-list-col1-width 72))))
+    (spacemacs/declare-prefix-for-mode 'php-mode "mrg" "generate")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mre" "extract")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mrm" "methods")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mrc" "classes")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mrp" "properties")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mP" "phpactor")
+    (spacemacs/declare-prefix-for-mode 'php-mode "mr" "refactoring")
+    (spacemacs/set-leader-keys-for-major-mode 'php-mode
+      "ri"  #'phpactor-import-class
+      "rr"  #'phpactor-rename-variable-local
+      "rR"  #'phpactor-rename-variable-file
+      "rn"  #'phpactor-fix-namespace
+      "rv"  #'phpactor-change-visibility
+      "rga" #'phpactor-generate-accessors
+      "rgm" #'phpactor-generate-method
+      "rcn" #'phpactor-create-new-class
+      "rcc" #'phpactor-copy-class
+      "rcm" #'phpactor-move-class
+      "rci" #'phpactor-inflect-class
+      "rpc" #'phpactor-complete-constructor
+      "rpp" #'phpactor-complete-properties
+      "rec" #'phpactor-extract-constant
+      "ree" #'phpactor-extract-expression
+      "rem" #'phpactor-extract-method
+      "rmc" #'phpactor-implement-contracts
+      "Ps"  #'phpactor-status
+      "Pu"  #'phpactor-install-or-update)
+    (setq-default phpactor-references-list-col1-width 72)))
 
 (defun php/init-phpcbf ()
   (use-package phpcbf
@@ -138,48 +135,46 @@
   (use-package company-php
     :defer t
     :init
-    (progn
-      (add-to-list 'spacemacs-jump-handlers-php-mode 'ac-php-find-symbol-at-point)
-      (add-hook 'php-mode-hook 'ac-php-core-eldoc-setup)
-      (spacemacs|add-company-backends
-        :modes php-mode
-        :backends (company-ac-php-backend company-phpactor)))))
+    (add-to-list 'spacemacs-jump-handlers-php-mode 'ac-php-find-symbol-at-point)
+    (add-hook 'php-mode-hook 'ac-php-core-eldoc-setup)
+    (spacemacs|add-company-backends
+     :modes php-mode
+     :backends (company-ac-php-backend company-phpactor))))
 
 (defun php/init-geben ()
   (use-package geben
     :config
-    (progn
-      (setq geben-temporary-file-directory (concat spacemacs-cache-directory "geben"))
+    (setq geben-temporary-file-directory (concat spacemacs-cache-directory "geben"))
 
-      (spacemacs/declare-prefix-for-mode 'php-mode "md" "debug")
-      (spacemacs/set-leader-keys-for-major-mode 'php-mode
-        "dx" #'geben
-        "dX" #'geben-end
-        "db" #'geben-add-current-line-to-predefined-breakpoints
-        "dC" #'geben-clear-predefined-breakpoints)
-      (evilified-state-evilify-map geben-mode-map
-        :mode 'php-mode
-        :bindings
-        "q"  #'geben-stop
-        "n"  #'geben-step-over
-        "s"  #'geben-step-into
-        "r"  #'geben-step-out
-        "L"  #'geben-where
-        "v"  #'geben-display-context
-        "c"  #'geben-run-to-cursor
-        "bb" #'geben-set-breakpoint-line
-        "bc" #'geben-set-breakpoint-conditional
-        "be" #'geben-set-breakpoint-exception
-        "w"  #'geben-show-backtrace
-        "gf" #'geben-find-file)
-      (add-hook 'geben-mode-hook 'evil-evilified-state)
-      (evil-set-initial-state 'geben-context-mode 'evilified)
-      (evilified-state-evilify-map geben-context-mode-map
-        :mode geben-context-mode
-        :bindings
-        "q"  #'geben-quit-window
-        "j"  #'widget-forward
-        "k"  #'widget-backward
-        (kbd "<tab>") 'widget-button-press)
-      (evilified-state-evilify-map geben-backtrace-mode-map
-        :mode geben-backtrace-mode))))
+    (spacemacs/declare-prefix-for-mode 'php-mode "md" "debug")
+    (spacemacs/set-leader-keys-for-major-mode 'php-mode
+      "dx" #'geben
+      "dX" #'geben-end
+      "db" #'geben-add-current-line-to-predefined-breakpoints
+      "dC" #'geben-clear-predefined-breakpoints)
+    (evilified-state-evilify-map geben-mode-map
+      :mode 'php-mode
+      :bindings
+      "q"  #'geben-stop
+      "n"  #'geben-step-over
+      "s"  #'geben-step-into
+      "r"  #'geben-step-out
+      "L"  #'geben-where
+      "v"  #'geben-display-context
+      "c"  #'geben-run-to-cursor
+      "bb" #'geben-set-breakpoint-line
+      "bc" #'geben-set-breakpoint-conditional
+      "be" #'geben-set-breakpoint-exception
+      "w"  #'geben-show-backtrace
+      "gf" #'geben-find-file)
+    (add-hook 'geben-mode-hook 'evil-evilified-state)
+    (evil-set-initial-state 'geben-context-mode 'evilified)
+    (evilified-state-evilify-map geben-context-mode-map
+      :mode geben-context-mode
+      :bindings
+      "q"  #'geben-quit-window
+      "j"  #'widget-forward
+      "k"  #'widget-backward
+      (kbd "<tab>") 'widget-button-press)
+    (evilified-state-evilify-map geben-backtrace-mode-map
+      :mode geben-backtrace-mode)))

--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -41,15 +41,14 @@
     :defer t
     :mode ("\\.\\(pum\\|puml\\)\\'" . plantuml-mode)
     :config
-    (progn
-      ;; Our default is jar execution, not server as server is not working reliable see #13574
-      (setq plantuml-default-exec-mode 'jar)
-      ;; for now plantuml electric indentation is buggy and does not
-      ;; really work, let's disable auto-indentation on paste for
-      ;; this mode
-      (add-to-list 'spacemacs-indent-sensitive-modes 'plantuml-mode)
-      (spacemacs/declare-prefix-for-mode 'plantuml-mode
-        "mc" "compile")
-      (spacemacs/set-leader-keys-for-major-mode 'plantuml-mode
-        "cc" 'plantuml-preview
-        "co" 'plantuml-set-output-type))))
+    ;; Our default is jar execution, not server as server is not working reliable see #13574
+    (setq plantuml-default-exec-mode 'jar)
+    ;; for now plantuml electric indentation is buggy and does not
+    ;; really work, let's disable auto-indentation on paste for
+    ;; this mode
+    (add-to-list 'spacemacs-indent-sensitive-modes 'plantuml-mode)
+    (spacemacs/declare-prefix-for-mode 'plantuml-mode
+      "mc" "compile")
+    (spacemacs/set-leader-keys-for-major-mode 'plantuml-mode
+      "cc" 'plantuml-preview
+      "co" 'plantuml-set-output-type)))

--- a/layers/+lang/prolog/packages.el
+++ b/layers/+lang/prolog/packages.el
@@ -32,52 +32,49 @@
   (use-package prolog
     :defer t
     :init
-    (progn
-      (autoload 'run-prolog "prolog" "Start a Prolog sub-process." t)
-      (autoload 'prolog-mode "prolog" "Major mode for editing Prolog programs." t)
-      (setq auto-mode-alist (append '(("\\.pl$" . prolog-mode))
-                                    auto-mode-alist))        )
+    (autoload 'run-prolog "prolog" "Start a Prolog sub-process." t)
+    (autoload 'prolog-mode "prolog" "Major mode for editing Prolog programs." t)
+    (setq auto-mode-alist (append '(("\\.pl$" . prolog-mode))
+                                  auto-mode-alist))
     :config
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'prolog-mode
-        ;;Key Mappings
-        ;;Consulting
-        "sb" 'prolog-consult-buffer
-        "sf" 'prolog-consult-file
-        "sp" 'prolog-consult-predicate
-        "sr" 'prolog-consult-region
-        ;;Compiling
-        "cb" 'prolog-compile-buffer
-        "cc" 'prolog-compile-file
-        "cp" 'prolog-compile-predicate
-        "cr" 'prolog-compile-region
-        ;;Formatting
-        "=" 'prolog-indent-buffer
-        ;;Insert
-        "im" 'prolog-insert-module-modeline
-        "in" 'prolog-insert-next-clause
-        "ip" 'prolog-insert-predicate-template
-        "is" 'prolog-insert-predspec
-        ;;Help
-        "ha" 'prolog-help-apropos
-        "hp" 'prolog-help-on-predicate
-        )
+    (spacemacs/set-leader-keys-for-major-mode 'prolog-mode
+      ;;Key Mappings
+      ;;Consulting
+      "sb" 'prolog-consult-buffer
+      "sf" 'prolog-consult-file
+      "sp" 'prolog-consult-predicate
+      "sr" 'prolog-consult-region
+      ;;Compiling
+      "cb" 'prolog-compile-buffer
+      "cc" 'prolog-compile-file
+      "cp" 'prolog-compile-predicate
+      "cr" 'prolog-compile-region
+      ;;Formatting
+      "=" 'prolog-indent-buffer
+      ;;Insert
+      "im" 'prolog-insert-module-modeline
+      "in" 'prolog-insert-next-clause
+      "ip" 'prolog-insert-predicate-template
+      "is" 'prolog-insert-predspec
+      ;;Help
+      "ha" 'prolog-help-apropos
+      "hp" 'prolog-help-on-predicate
+      )
 
-      (dolist (prefix '(("ms" . "consulting")
-                        ("mc" . "compiling")
-                        ("mh" . "help")
-                        ("mi" . "inserting")
-                        ))
-        (spacemacs/declare-prefix-for-mode 'prolog-mode (car prefix) (cdr prefix))))
+    (dolist (prefix '(("ms" . "consulting")
+                      ("mc" . "compiling")
+                      ("mh" . "help")
+                      ("mi" . "inserting")
+                      ))
+      (spacemacs/declare-prefix-for-mode 'prolog-mode (car prefix) (cdr prefix)))
     ))
 
 (defun prolog/init-ediprolog ()
   (use-package ediprolog
     :config
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'prolog-mode
-        ;;Key Mappings
-        "ee" 'ediprolog-dwim)
-      (spacemacs/declare-prefix-for-mode 'prolog-mode "me" "evaluating" ))))
+    (spacemacs/set-leader-keys-for-major-mode 'prolog-mode
+      ;;Key Mappings
+      "ee" 'ediprolog-dwim)
+    (spacemacs/declare-prefix-for-mode 'prolog-mode "me" "evaluating")))
 
 ;;; packages.el ends here

--- a/layers/+lang/purescript/packages.el
+++ b/layers/+lang/purescript/packages.el
@@ -45,63 +45,60 @@
   (use-package purescript-mode
     :defer t
     :init
-    (progn
-      (add-to-list 'spacemacs-indent-sensitive-modes 'purescript-mode)
-      (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
-      (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
-      (add-hook 'purescript-mode-hook #'spacemacs//purescript-setup-backend)
-      (when purescript-fmt-on-save
-        (add-hook 'purescript-mode-hook 'spacemacs/purescript-fmt-before-save-hook))
-      (spacemacs/declare-prefix-for-mode 'purescript-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'purescript-mode "mi" "imports")
-      (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
-        "i="  'purescript-mode-format-imports
-        "i`"  'purescript-navigate-imports-return
-        "ia"  'purescript-align-imports
-        "in"  'purescript-navigate-imports
-        "=" 'spacemacs/purescript-format))))
+    (add-to-list 'spacemacs-indent-sensitive-modes 'purescript-mode)
+    (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
+    (add-hook 'purescript-mode-hook 'purescript-decl-scan-mode)
+    (add-hook 'purescript-mode-hook #'spacemacs//purescript-setup-backend)
+    (when purescript-fmt-on-save
+      (add-hook 'purescript-mode-hook 'spacemacs/purescript-fmt-before-save-hook))
+    (spacemacs/declare-prefix-for-mode 'purescript-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'purescript-mode "mi" "imports")
+    (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
+      "i="  'purescript-mode-format-imports
+      "i`"  'purescript-navigate-imports-return
+      "ia"  'purescript-align-imports
+      "in"  'purescript-navigate-imports
+      "=" 'spacemacs/purescript-format)))
 
 (defun purescript/init-psci ()
   (use-package psci
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'psci 'psci "purescript")
-      (add-hook 'purescript-mode-hook 'inferior-psci-mode)
-      (spacemacs/declare-prefix-for-mode 'purescript-mode "ms" "repl")
-      (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
-        "'"  'psci
-        "sb" 'psci/load-current-file!
-        "si" 'psci
-        "sm" 'psci/load-module!
-        "sp" 'psci/load-project-modules!))))
+    (spacemacs/register-repl 'psci 'psci "purescript")
+    (add-hook 'purescript-mode-hook 'inferior-psci-mode)
+    (spacemacs/declare-prefix-for-mode 'purescript-mode "ms" "repl")
+    (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
+      "'"  'psci
+      "sb" 'psci/load-current-file!
+      "si" 'psci
+      "sm" 'psci/load-module!
+      "sp" 'psci/load-project-modules!)))
 
 (defun purescript/init-psc-ide ()
   (use-package psc-ide
     :defer t
     :init
-    (progn
-      (add-hook 'purescript-mode-hook 'psc-ide-mode)
+    (add-hook 'purescript-mode-hook 'psc-ide-mode)
 
-      (customize-set-variable 'psc-ide-add-import-on-completion purescript-add-import-on-completion)
-      (customize-set-variable 'psc-ide-rebuild-on-save purescript-enable-rebuild-on-save)
+    (customize-set-variable 'psc-ide-add-import-on-completion purescript-add-import-on-completion)
+    (customize-set-variable 'psc-ide-rebuild-on-save purescript-enable-rebuild-on-save)
 
-      (add-to-list 'spacemacs-jump-handlers-purescript-mode 'psc-ide-goto-definition)
+    (add-to-list 'spacemacs-jump-handlers-purescript-mode 'psc-ide-goto-definition)
 
-      (spacemacs/declare-prefix-for-mode 'purescript-mode "mm" "psc-ide")
-      (spacemacs/declare-prefix-for-mode 'purescript-mode "mmi" "insert/import")
-      (spacemacs/declare-prefix-for-mode 'purescript-mode "mh" "help")
-      (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
-        "mt"  'psc-ide-add-clause
-        "mc"  'psc-ide-case-split
-        "ms"  'psc-ide-server-start
-        "mb"  'psc-ide-rebuild
-        "mq"  'psc-ide-server-quit
-        "ml"  'psc-ide-load-all
-        "mL"  'psc-ide-load-module
-        "mia" 'psc-ide-add-import
-        "mis" 'psc-ide-flycheck-insert-suggestion
-        "ht"  'psc-ide-show-type))))
+    (spacemacs/declare-prefix-for-mode 'purescript-mode "mm" "psc-ide")
+    (spacemacs/declare-prefix-for-mode 'purescript-mode "mmi" "insert/import")
+    (spacemacs/declare-prefix-for-mode 'purescript-mode "mh" "help")
+    (spacemacs/set-leader-keys-for-major-mode 'purescript-mode
+      "mt"  'psc-ide-add-clause
+      "mc"  'psc-ide-case-split
+      "ms"  'psc-ide-server-start
+      "mb"  'psc-ide-rebuild
+      "mq"  'psc-ide-server-quit
+      "ml"  'psc-ide-load-all
+      "mL"  'psc-ide-load-module
+      "mia" 'psc-ide-add-import
+      "mis" 'psc-ide-flycheck-insert-suggestion
+      "ht"  'psc-ide-show-type)))
 
 (defun purescript/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -73,27 +73,26 @@
     (setq anaconda-mode-installation-directory
           (concat spacemacs-cache-directory "anaconda-mode"))
     :config
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "hh" 'anaconda-mode-show-doc
-        "ga" 'anaconda-mode-find-assignments
-        "gb" 'xref-pop-marker-stack
-        "gu" 'anaconda-mode-find-references)
-      ;; new anaconda-mode (2018-06-03) removed `anaconda-view-mode-map' in
-      ;; favor of xref. Eventually we need to remove this part.
-      (when (boundp 'anaconda-view-mode-map)
-        (evilified-state-evilify-map anaconda-view-mode-map
-          :mode anaconda-view-mode
-          :bindings
-          (kbd "q") 'quit-window
-          (kbd "C-j") 'next-error-no-select
-          (kbd "C-k") 'previous-error-no-select
-          (kbd "RET") 'spacemacs/anaconda-view-forward-and-push))
-      (spacemacs|hide-lighter anaconda-mode)
-      (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
-        (evil--jumps-push))
-      (add-to-list 'spacemacs-jump-handlers-python-mode
-                   '(anaconda-mode-find-definitions :async t)))))
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "hh" 'anaconda-mode-show-doc
+      "ga" 'anaconda-mode-find-assignments
+      "gb" 'xref-pop-marker-stack
+      "gu" 'anaconda-mode-find-references)
+    ;; new anaconda-mode (2018-06-03) removed `anaconda-view-mode-map' in
+    ;; favor of xref. Eventually we need to remove this part.
+    (when (boundp 'anaconda-view-mode-map)
+      (evilified-state-evilify-map anaconda-view-mode-map
+        :mode anaconda-view-mode
+        :bindings
+        (kbd "q") 'quit-window
+        (kbd "C-j") 'next-error-no-select
+        (kbd "C-k") 'previous-error-no-select
+        (kbd "RET") 'spacemacs/anaconda-view-forward-and-push))
+    (spacemacs|hide-lighter anaconda-mode)
+    (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
+      (evil--jumps-push))
+    (add-to-list 'spacemacs-jump-handlers-python-mode
+                 '(anaconda-mode-find-definitions :async t))))
 
 (defun python/init-code-cells ()
   (use-package code-cells
@@ -131,11 +130,10 @@
   (use-package blacken
     :defer t
     :init
-    (progn
-      (spacemacs//bind-python-formatter-keys)
-      (when (and python-format-on-save
-                 (eq 'black python-formatter))
-        (add-hook 'python-mode-hook 'blacken-mode)))
+    (spacemacs//bind-python-formatter-keys)
+    (when (and python-format-on-save
+               (eq 'black python-formatter))
+      (add-hook 'python-mode-hook 'blacken-mode))
     :config (spacemacs|hide-lighter blacken-mode)))
 
 (defun python/init-cython-mode ()
@@ -182,11 +180,10 @@
   (use-package importmagic
     :defer t
     :init
-    (progn
-      (add-hook 'python-mode-hook 'importmagic-mode)
-      (spacemacs|diminish importmagic-mode " ⓘ" " [i]")
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "rf" 'importmagic-fix-symbol-at-point))))
+    (add-hook 'python-mode-hook 'importmagic-mode)
+    (spacemacs|diminish importmagic-mode " ⓘ" " [i]")
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "rf" 'importmagic-fix-symbol-at-point)))
 
 (defun python/init-live-py-mode ()
   (use-package live-py-mode
@@ -208,9 +205,8 @@
                nosetests-pdb-suite)
     :init (spacemacs//bind-python-testing-keys)
     :config
-    (progn
-      (add-to-list 'nose-project-root-files "setup.cfg")
-      (setq nose-use-verbose nil))))
+    (add-to-list 'nose-project-root-files "setup.cfg")
+    (setq nose-use-verbose nil)))
 
 (defun python/pre-init-org ()
   (spacemacs|use-package-add-hook org
@@ -228,15 +224,14 @@
                pipenv-install
                pipenv-uninstall)
     :init
-    (progn
-      (dolist (m spacemacs--python-pipenv-modes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          "vpa" 'pipenv-activate
-          "vpd" 'pipenv-deactivate
-          "vpi" 'pipenv-install
-          "vpo" 'pipenv-open
-          "vps" 'pipenv-shell
-          "vpu" 'pipenv-uninstall)))))
+    (dolist (m spacemacs--python-pipenv-modes)
+      (spacemacs/set-leader-keys-for-major-mode m
+        "vpa" 'pipenv-activate
+        "vpd" 'pipenv-deactivate
+        "vpi" 'pipenv-install
+        "vpo" 'pipenv-open
+        "vps" 'pipenv-shell
+        "vpu" 'pipenv-uninstall))))
 
 (defun python/pre-init-poetry ()
   (add-to-list 'spacemacs--python-poetry-modes 'python-mode))
@@ -246,12 +241,11 @@
     :commands (poetry-venv-toggle
                poetry-tracking-mode)
     :init
-    (progn
-      (dolist (m spacemacs--python-poetry-modes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          "vod" 'poetry-venv-deactivate
-          "vow" 'poetry-venv-workon
-          "vot" 'poetry-venv-toggle)))))
+    (dolist (m spacemacs--python-poetry-modes)
+      (spacemacs/set-leader-keys-for-major-mode m
+        "vod" 'poetry-venv-deactivate
+        "vow" 'poetry-venv-workon
+        "vot" 'poetry-venv-toggle))))
 
 
 (defun python/init-pip-requirements ()
@@ -271,31 +265,28 @@
   (use-package py-isort
     :defer t
     :init
-    (progn
-      (add-hook 'before-save-hook 'spacemacs//python-sort-imports)
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "rI" 'py-isort-buffer))))
+    (add-hook 'before-save-hook 'spacemacs//python-sort-imports)
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "rI" 'py-isort-buffer)))
 
 (defun python/init-sphinx-doc ()
   (use-package sphinx-doc
     :defer t
     :init
-    (progn
-      (add-hook 'python-mode-hook 'sphinx-doc-mode)
-      (spacemacs/declare-prefix-for-mode 'python-mode "mS" "sphinx-doc")
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "Se" 'sphinx-doc-mode
-        "Sd" 'sphinx-doc))
+    (add-hook 'python-mode-hook 'sphinx-doc-mode)
+    (spacemacs/declare-prefix-for-mode 'python-mode "mS" "sphinx-doc")
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "Se" 'sphinx-doc-mode
+      "Sd" 'sphinx-doc)
     :config (spacemacs|hide-lighter sphinx-doc-mode)))
 
 (defun python/init-pydoc ()
   (use-package pydoc
     :defer t
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "hp" 'pydoc-at-point-no-jedi
-        "hP" 'pydoc))))
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "hp" 'pydoc-at-point-no-jedi
+      "hP" 'pydoc)))
 
 (defun python/pre-init-pyenv-mode ()
   (add-to-list 'spacemacs--python-pyenv-modes 'python-mode))
@@ -304,24 +295,23 @@
     :if (executable-find "pyenv")
     :commands (pyenv-mode-versions)
     :init
-    (progn
-      (pcase python-auto-set-local-pyenv-version
-        ('on-visit
-         (dolist (m spacemacs--python-pyenv-modes)
-           (add-hook (intern (format "%s-hook" m))
-                     'spacemacs//pyenv-mode-set-local-version)))
-        ('on-project-switch
-         (add-hook 'projectile-after-switch-project-hook
+    (pcase python-auto-set-local-pyenv-version
+      ('on-visit
+       (dolist (m spacemacs--python-pyenv-modes)
+         (add-hook (intern (format "%s-hook" m))
                    'spacemacs//pyenv-mode-set-local-version)))
-      ;; setup shell correctly on environment switch
-      (dolist (func '(pyenv-mode-set pyenv-mode-unset))
-        (advice-add func :after
-                    (lambda (&optional version)
-                      (spacemacs/python-setup-everything
-                       (when version (pyenv-mode-full-path version))))))
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "vu" 'pyenv-mode-unset
-        "vs" 'pyenv-mode-set))))
+      ('on-project-switch
+       (add-hook 'projectile-after-switch-project-hook
+                 'spacemacs//pyenv-mode-set-local-version)))
+    ;; setup shell correctly on environment switch
+    (dolist (func '(pyenv-mode-set pyenv-mode-unset))
+      (advice-add func :after
+                  (lambda (&optional version)
+                    (spacemacs/python-setup-everything
+                     (when version (pyenv-mode-full-path version))))))
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "vu" 'pyenv-mode-unset
+      "vs" 'pyenv-mode-set)))
 
 (defun python/pre-init-pyvenv ()
   (add-to-list 'spacemacs--python-pyvenv-modes 'python-mode))
@@ -329,24 +319,23 @@
   (use-package pyvenv
     :defer t
     :init
-    (progn
-      (add-hook 'python-mode-hook #'pyvenv-tracking-mode)
-      (pcase python-auto-set-local-pyvenv-virtualenv
-        ('on-visit
-         (dolist (m spacemacs--python-pyvenv-modes)
-           (add-hook (intern (format "%s-hook" m))
-                     'spacemacs//pyvenv-mode-set-local-virtualenv)))
-        ('on-project-switch
-         (add-hook 'projectile-after-switch-project-hook
+    (add-hook 'python-mode-hook #'pyvenv-tracking-mode)
+    (pcase python-auto-set-local-pyvenv-virtualenv
+      ('on-visit
+       (dolist (m spacemacs--python-pyvenv-modes)
+         (add-hook (intern (format "%s-hook" m))
                    'spacemacs//pyvenv-mode-set-local-virtualenv)))
-      (dolist (m spacemacs--python-pyvenv-modes)
-        (spacemacs/set-leader-keys-for-major-mode m
-          "va" 'pyvenv-activate
-          "vd" 'pyvenv-deactivate
-          "vw" 'pyvenv-workon))
-      ;; setup shell correctly on environment switch
-      (dolist (func '(pyvenv-activate pyvenv-deactivate pyvenv-workon))
-        (advice-add func :after 'spacemacs/python-setup-everything)))))
+      ('on-project-switch
+       (add-hook 'projectile-after-switch-project-hook
+                 'spacemacs//pyvenv-mode-set-local-virtualenv)))
+    (dolist (m spacemacs--python-pyvenv-modes)
+      (spacemacs/set-leader-keys-for-major-mode m
+        "va" 'pyvenv-activate
+        "vd" 'pyvenv-deactivate
+        "vw" 'pyvenv-workon))
+    ;; setup shell correctly on environment switch
+    (dolist (func '(pyvenv-activate pyvenv-deactivate pyvenv-workon))
+      (advice-add func :after 'spacemacs/python-setup-everything))))
 
 (defun python/init-pylookup ()
   (use-package pylookup
@@ -381,78 +370,76 @@
     :defer t
     :mode (("SConstruct\\'" . python-mode) ("SConscript\\'" . python-mode))
     :init
-    (progn
-      (spacemacs/register-repl 'python
-                               'spacemacs/python-start-or-switch-repl "python")
-      (spacemacs//bind-python-repl-keys)
-      (add-hook 'python-mode-local-vars-hook 'spacemacs//python-setup-backend)
-      (add-hook 'python-mode-hook 'spacemacs//python-default))
+    (spacemacs/register-repl 'python
+                             'spacemacs/python-start-or-switch-repl "python")
+    (spacemacs//bind-python-repl-keys)
+    (add-hook 'python-mode-local-vars-hook 'spacemacs//python-setup-backend)
+    (add-hook 'python-mode-hook 'spacemacs//python-default)
     :config
-    (progn
-      ;; add support for `ahs-range-beginning-of-defun' for python-mode
-      (with-eval-after-load 'auto-highlight-symbol
-        (add-to-list 'ahs-plugin-bod-modes 'python-mode))
+    ;; add support for `ahs-range-beginning-of-defun' for python-mode
+    (with-eval-after-load 'auto-highlight-symbol
+      (add-to-list 'ahs-plugin-bod-modes 'python-mode))
 
-      (spacemacs/declare-prefix-for-mode 'python-mode "mc" "execute")
-      (spacemacs/declare-prefix-for-mode 'python-mode "md" "debug")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'python-mode "ms" "REPL")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mv" "virtualenv")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mvp" "pipenv")
-      (spacemacs/declare-prefix-for-mode 'python-mode "mvo" "poetry")
-      (spacemacs/set-leader-keys-for-major-mode 'python-mode
-        "'"  'spacemacs/python-start-or-switch-repl
-        "cc" 'spacemacs/python-execute-file
-        "cC" 'spacemacs/python-execute-file-focus
-        "db" 'spacemacs/python-toggle-breakpoint
-        "ri" 'spacemacs/python-remove-unused-imports
-        "sB" 'spacemacs/python-shell-send-buffer-switch
-        "sb" 'spacemacs/python-shell-send-buffer
-        "sE" 'spacemacs/python-shell-send-statement-switch
-        "se" 'spacemacs/python-shell-send-statement
-        "sF" 'spacemacs/python-shell-send-defun-switch
-        "sf" 'spacemacs/python-shell-send-defun
-        "si" 'spacemacs/python-start-or-switch-repl
-        "sR" 'spacemacs/python-shell-send-region-switch
-        "sr" 'spacemacs/python-shell-send-region
-        "sl" 'spacemacs/python-shell-send-line
-        "ss" 'spacemacs/python-shell-send-with-output)
+    (spacemacs/declare-prefix-for-mode 'python-mode "mc" "execute")
+    (spacemacs/declare-prefix-for-mode 'python-mode "md" "debug")
+    (spacemacs/declare-prefix-for-mode 'python-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'python-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'python-mode "ms" "REPL")
+    (spacemacs/declare-prefix-for-mode 'python-mode "mr" "refactor")
+    (spacemacs/declare-prefix-for-mode 'python-mode "mv" "virtualenv")
+    (spacemacs/declare-prefix-for-mode 'python-mode "mvp" "pipenv")
+    (spacemacs/declare-prefix-for-mode 'python-mode "mvo" "poetry")
+    (spacemacs/set-leader-keys-for-major-mode 'python-mode
+      "'"  'spacemacs/python-start-or-switch-repl
+      "cc" 'spacemacs/python-execute-file
+      "cC" 'spacemacs/python-execute-file-focus
+      "db" 'spacemacs/python-toggle-breakpoint
+      "ri" 'spacemacs/python-remove-unused-imports
+      "sB" 'spacemacs/python-shell-send-buffer-switch
+      "sb" 'spacemacs/python-shell-send-buffer
+      "sE" 'spacemacs/python-shell-send-statement-switch
+      "se" 'spacemacs/python-shell-send-statement
+      "sF" 'spacemacs/python-shell-send-defun-switch
+      "sf" 'spacemacs/python-shell-send-defun
+      "si" 'spacemacs/python-start-or-switch-repl
+      "sR" 'spacemacs/python-shell-send-region-switch
+      "sr" 'spacemacs/python-shell-send-region
+      "sl" 'spacemacs/python-shell-send-line
+      "ss" 'spacemacs/python-shell-send-with-output)
 
-      (setq spacemacs--python-shell-interpreter-origin
-            (eval (car (get 'python-shell-interpreter 'standard-value))))
-      ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
-      ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)
-      (setq-default python-indent-guess-indent-offset nil)
+    (setq spacemacs--python-shell-interpreter-origin
+          (eval (car (get 'python-shell-interpreter 'standard-value))))
+    ;; Set `python-indent-guess-indent-offset' to `nil' to prevent guessing `python-indent-offset
+    ;; (we call python-indent-guess-indent-offset manually so python-mode does not need to do it)
+    (setq-default python-indent-guess-indent-offset nil)
 
-      ;; Emacs users won't need these key bindings
-      ;; TODO: make these key bindings dynamic given the current style
-      ;; Doing it only at init time won't update it if the user switches style
-      ;; Also find a way to generalize these bindings.
-      (when (eq dotspacemacs-editing-style 'vim)
-        ;; the default in Emacs is M-n
-        (define-key inferior-python-mode-map (kbd "C-j") 'comint-next-input)
-        ;; the default in Emacs is M-p and this key binding overrides
-        ;; default C-k which prevents Emacs users to kill line
-        (define-key inferior-python-mode-map (kbd "C-k") 'comint-previous-input)
-        ;; the default in Emacs is M-r; C-r to search backward old output
-        ;; and should not be changed
-        (define-key inferior-python-mode-map
-          (kbd "C-r") 'comint-history-isearch-backward)
-        ;; this key binding is for recentering buffer in Emacs
-        ;; it would be troublesome if Emacs user
-        ;; Vim users can use this key since they have other key
-        (define-key inferior-python-mode-map
-          (kbd "C-l") 'spacemacs/comint-clear-buffer))
-
-      ;; add this optional key binding for Emacs user, since it is unbound
+    ;; Emacs users won't need these key bindings
+    ;; TODO: make these key bindings dynamic given the current style
+    ;; Doing it only at init time won't update it if the user switches style
+    ;; Also find a way to generalize these bindings.
+    (when (eq dotspacemacs-editing-style 'vim)
+      ;; the default in Emacs is M-n
+      (define-key inferior-python-mode-map (kbd "C-j") 'comint-next-input)
+      ;; the default in Emacs is M-p and this key binding overrides
+      ;; default C-k which prevents Emacs users to kill line
+      (define-key inferior-python-mode-map (kbd "C-k") 'comint-previous-input)
+      ;; the default in Emacs is M-r; C-r to search backward old output
+      ;; and should not be changed
       (define-key inferior-python-mode-map
-        (kbd "C-c M-l") 'spacemacs/comint-clear-buffer)
-      ;; setup the global variables for python shell
-      (spacemacs//python-setup-shell default-directory)
-      (dolist (x '(python-shell-interpreter python-shell-interpreter-args))
-        (set-default-toplevel-value x (symbol-value x))))))
+        (kbd "C-r") 'comint-history-isearch-backward)
+      ;; this key binding is for recentering buffer in Emacs
+      ;; it would be troublesome if Emacs user
+      ;; Vim users can use this key since they have other key
+      (define-key inferior-python-mode-map
+        (kbd "C-l") 'spacemacs/comint-clear-buffer))
+
+    ;; add this optional key binding for Emacs user, since it is unbound
+    (define-key inferior-python-mode-map
+      (kbd "C-c M-l") 'spacemacs/comint-clear-buffer)
+    ;; setup the global variables for python shell
+    (spacemacs//python-setup-shell default-directory)
+    (dolist (x '(python-shell-interpreter python-shell-interpreter-args))
+      (set-default-toplevel-value x (symbol-value x)))))
 
 (defun python/post-init-semantic ()
   (when (configuration-layer/package-used-p 'anaconda-mode)
@@ -497,11 +484,10 @@ fix this issue."
   (use-package yapfify
     :defer t
     :init
-    (progn
-      (spacemacs//bind-python-formatter-keys)
-      (when (and python-format-on-save
-                 (eq 'yapf python-formatter))
-        (add-hook 'python-mode-hook 'yapf-mode)))
+    (spacemacs//bind-python-formatter-keys)
+    (when (and python-format-on-save
+               (eq 'yapf python-formatter))
+      (add-hook 'python-mode-hook 'yapf-mode))
     :config (spacemacs|hide-lighter yapf-mode)))
 
 (defun python/init-lsp-python-ms ()

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -61,105 +61,103 @@
   (use-package racket-mode
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'racket-mode 'racket-repl "racket")
-      (add-hook 'racket-mode-hook 'racket-xp-mode))
+    (spacemacs/register-repl 'racket-mode 'racket-repl "racket")
+    (add-hook 'racket-mode-hook 'racket-xp-mode)
     :config
-    (progn
-      (add-to-list 'evil-evilified-state-modes 'racket-describe-mode)
-      (evil-define-key 'evilified 'racket-describe-mode-map
-        "o" 'link-hint-open-link)
-      ;; smartparens configuration
-      (with-eval-after-load 'smartparens
-        (add-to-list 'sp--lisp-modes 'racket-mode)
-        (when (fboundp 'sp-local-pair)
-          (sp-local-pair 'racket-mode "'" nil :actions nil)
-          (sp-local-pair 'racket-mode "`" nil :actions nil)))
+    (add-to-list 'evil-evilified-state-modes 'racket-describe-mode)
+    (evil-define-key 'evilified 'racket-describe-mode-map
+      "o" 'link-hint-open-link)
+    ;; smartparens configuration
+    (with-eval-after-load 'smartparens
+      (add-to-list 'sp--lisp-modes 'racket-mode)
+      (when (fboundp 'sp-local-pair)
+        (sp-local-pair 'racket-mode "'" nil :actions nil)
+        (sp-local-pair 'racket-mode "`" nil :actions nil)))
 
-      (defun spacemacs/racket-test-with-coverage ()
-        "Call `racket-test' with universal argument."
-        (interactive)
-        (racket-test t))
+    (defun spacemacs/racket-test-with-coverage ()
+      "Call `racket-test' with universal argument."
+      (interactive)
+      (racket-test t))
 
-      (defun spacemacs/racket-run-and-switch-to-repl ()
-        "Call `racket-run-and-switch-to-repl' and enable
+    (defun spacemacs/racket-run-and-switch-to-repl ()
+      "Call `racket-run-and-switch-to-repl' and enable
 `insert state'."
-        (interactive)
-        (racket-run-and-switch-to-repl)
-        (when (buffer-live-p (get-buffer racket-repl-buffer-name))
-          ;; We don't need to worry about the first time the REPL is opened,
-          ;; since the first time, insert state is automatically entered (since
-          ;; it's registered as a REPL?).
-          (with-current-buffer racket-repl-buffer-name
-            (evil-insert-state))))
+      (interactive)
+      (racket-run-and-switch-to-repl)
+      (when (buffer-live-p (get-buffer racket-repl-buffer-name))
+        ;; We don't need to worry about the first time the REPL is opened,
+        ;; since the first time, insert state is automatically entered (since
+        ;; it's registered as a REPL?).
+        (with-current-buffer racket-repl-buffer-name
+          (evil-insert-state))))
 
-      (defun spacemacs/racket-send-last-sexp-focus ()
-        "Call `racket-send-last-sexp' and switch to REPL buffer in
+    (defun spacemacs/racket-send-last-sexp-focus ()
+      "Call `racket-send-last-sexp' and switch to REPL buffer in
 `insert state'."
-        (interactive)
-        (racket-send-last-sexp)
-        (racket-repl)
-        (evil-insert-state))
+      (interactive)
+      (racket-send-last-sexp)
+      (racket-repl)
+      (evil-insert-state))
 
-      (defun spacemacs/racket-send-definition-focus ()
-        "Call `racket-send-definition' and switch to REPL buffer in
+    (defun spacemacs/racket-send-definition-focus ()
+      "Call `racket-send-definition' and switch to REPL buffer in
 `insert state'."
-        (interactive)
-        (racket-send-definition)
-        (racket-repl)
-        (evil-insert-state))
+      (interactive)
+      (racket-send-definition)
+      (racket-repl)
+      (evil-insert-state))
 
-      (defun spacemacs/racket-send-region-focus (start end)
-        "Call `racket-send-region' and switch to REPL buffer in
+    (defun spacemacs/racket-send-region-focus (start end)
+      "Call `racket-send-region' and switch to REPL buffer in
 `insert state'."
-        (interactive "r")
-        (racket-send-region start end)
-        (racket-repl)
-        (evil-insert-state))
+      (interactive "r")
+      (racket-send-region start end)
+      (racket-repl)
+      (evil-insert-state))
 
-      (dolist (prefix '(("mE" . "errors")
-                        ("mg" . "navigation")
-                        ("mh" . "doc")
-                        ("mi" . "insert")
-                        ("mr" . "refactor")
-                        ("ms" . "repl")
-                        ("mt" . "tests")))
-        (spacemacs/declare-prefix-for-mode 'racket-mode (car prefix) (cdr prefix)))
+    (dolist (prefix '(("mE" . "errors")
+                      ("mg" . "navigation")
+                      ("mh" . "doc")
+                      ("mi" . "insert")
+                      ("mr" . "refactor")
+                      ("ms" . "repl")
+                      ("mt" . "tests")))
+      (spacemacs/declare-prefix-for-mode 'racket-mode (car prefix) (cdr prefix)))
 
-      (spacemacs/set-leader-keys-for-major-mode 'racket-mode
-        ;; errors
-        "En" 'racket-xp-next-error
-        "EN" 'racket-xp-previous-error
-        ;; navigation
-        "g`" 'racket-unvisit
-        "gg" 'racket-xp-visit-definition
-        "gn" 'racket-xp-next-definition
-        "gN" 'racket-xp-previous-definition
-        "gm" 'racket-visit-module
-        "gr" 'racket-open-require-path
-        "gu" 'racket-xp-next-use
-        "gU" 'racket-xp-previous-use
-        ;; doc
-        "ha" 'racket-xp-annotate
-        "hd" 'racket-xp-describe
-        "hh" 'racket-xp-documentation
-        ;; insert
-        "il" 'racket-insert-lambda
-        ;; refactor
-        "mr" 'racket-xp-rename
-        ;; REPL
-        "'"  'racket-repl
-        "sb" 'racket-run
-        "sB" 'spacemacs/racket-run-and-switch-to-repl
-        "se" 'racket-send-last-sexp
-        "sE" 'spacemacs/racket-send-last-sexp-focus
-        "sf" 'racket-send-definition
-        "sF" 'spacemacs/racket-send-definition-focus
-        "si" 'racket-repl
-        "sr" 'racket-send-region
-        "sR" 'spacemacs/racket-send-region-focus
-        ;; Tests
-        "tb" 'racket-test
-        "tB" 'spacemacs/racket-test-with-coverage)
-      (define-key racket-mode-map (kbd "H-r") 'racket-run))))
+    (spacemacs/set-leader-keys-for-major-mode 'racket-mode
+      ;; errors
+      "En" 'racket-xp-next-error
+      "EN" 'racket-xp-previous-error
+      ;; navigation
+      "g`" 'racket-unvisit
+      "gg" 'racket-xp-visit-definition
+      "gn" 'racket-xp-next-definition
+      "gN" 'racket-xp-previous-definition
+      "gm" 'racket-visit-module
+      "gr" 'racket-open-require-path
+      "gu" 'racket-xp-next-use
+      "gU" 'racket-xp-previous-use
+      ;; doc
+      "ha" 'racket-xp-annotate
+      "hd" 'racket-xp-describe
+      "hh" 'racket-xp-documentation
+      ;; insert
+      "il" 'racket-insert-lambda
+      ;; refactor
+      "mr" 'racket-xp-rename
+      ;; REPL
+      "'"  'racket-repl
+      "sb" 'racket-run
+      "sB" 'spacemacs/racket-run-and-switch-to-repl
+      "se" 'racket-send-last-sexp
+      "sE" 'spacemacs/racket-send-last-sexp-focus
+      "sf" 'racket-send-definition
+      "sF" 'spacemacs/racket-send-definition-focus
+      "si" 'racket-repl
+      "sr" 'racket-send-region
+      "sR" 'spacemacs/racket-send-region-focus
+      ;; Tests
+      "tb" 'racket-test
+      "tB" 'spacemacs/racket-test-with-coverage)
+    (define-key racket-mode-map (kbd "H-r") 'racket-run)))
 

--- a/layers/+lang/reasonml/packages.el
+++ b/layers/+lang/reasonml/packages.el
@@ -71,26 +71,25 @@
   (use-package merlin
     :defer t
     :init
-    (progn
-      (setq merlin-completion-with-doc t)
+    (setq merlin-completion-with-doc t)
 
-      (spacemacs/set-leader-keys-for-major-mode 'reason-mode
-        "cp" 'merlin-project-check
-        "cv" 'merlin-goto-project-file
-        "eC" 'merlin-error-check
-        "en" 'merlin-error-next
-        "eN" 'merlin-error-prev
-        "gb" 'merlin-pop-stack
-        "gg" 'merlin-locate
-        "gG" 'spacemacs/merlin-locate-other-window
-        "gl" 'merlin-locate-ident
-        "gi" 'merlin-switch-to-ml
-        "gI" 'merlin-switch-to-mli
-        "go" 'merlin-occurrences
-        "hh" 'merlin-document
-        "ht" 'merlin-type-enclosing
-        "hT" 'merlin-type-expr
-        "rd" 'merlin-destruct))))
+    (spacemacs/set-leader-keys-for-major-mode 'reason-mode
+      "cp" 'merlin-project-check
+      "cv" 'merlin-goto-project-file
+      "eC" 'merlin-error-check
+      "en" 'merlin-error-next
+      "eN" 'merlin-error-prev
+      "gb" 'merlin-pop-stack
+      "gg" 'merlin-locate
+      "gG" 'spacemacs/merlin-locate-other-window
+      "gl" 'merlin-locate-ident
+      "gi" 'merlin-switch-to-ml
+      "gI" 'merlin-switch-to-mli
+      "go" 'merlin-occurrences
+      "hh" 'merlin-document
+      "ht" 'merlin-type-enclosing
+      "hT" 'merlin-type-expr
+      "rd" 'merlin-destruct)))
 
 (defun reasonml/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin
@@ -103,43 +102,41 @@
     :defer t
     :mode ("\\.rei?\\'" . reason-mode)
     :init
-    (progn
-      (add-hook 'reason-mode-hook 'merlin-mode)
-      (add-hook 'reason-mode-hook 'utop-minor-mode)
-      (when (configuration-layer/layer-used-p 'syntax-checking)
-        (add-hook 'reason-mode-hook 'flycheck-mode))
+    (add-hook 'reason-mode-hook 'merlin-mode)
+    (add-hook 'reason-mode-hook 'utop-minor-mode)
+    (when (configuration-layer/layer-used-p 'syntax-checking)
+      (add-hook 'reason-mode-hook 'flycheck-mode))
 
-      (add-hook 'reason-mode-hook
-                (lambda ()
-                  (when reason-auto-refmt
-                    (add-hook 'before-save-hook 'refmt nil t))))
+    (add-hook 'reason-mode-hook
+              (lambda ()
+                (when reason-auto-refmt
+                  (add-hook 'before-save-hook 'refmt nil t))))
 
-      (spacemacs|add-toggle reason-auto-refmt
-        :documentation "Toggle automatic refmt on save."
-        :status reason-auto-refmt
-        :on (progn
-              (setq reason-auto-refmt t)
-              (add-hook 'before-save-hook 'refmt nil t))
-        :off (progn
-               (setq reason-auto-refmt nil)
-               (remove-hook 'before-save-hook 'refmt t))))
+    (spacemacs|add-toggle reason-auto-refmt
+      :documentation "Toggle automatic refmt on save."
+      :status reason-auto-refmt
+      :on (progn
+            (setq reason-auto-refmt t)
+            (add-hook 'before-save-hook 'refmt nil t))
+      :off (progn
+             (setq reason-auto-refmt nil)
+             (remove-hook 'before-save-hook 'refmt t)))
 
     :config
-    (progn
-      (spacemacs/declare-prefix-for-mode 'reason-mode "mc" "compile")
-      (spacemacs/declare-prefix-for-mode 'reason-mode "mt" "toggle")
-      (spacemacs/declare-prefix-for-mode 'reason-mode "me" "errors/eval")
-      (spacemacs/declare-prefix-for-mode 'reason-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'reason-mode "mh" "help/show")
-      (spacemacs/declare-prefix-for-mode 'reason-mode "mr" "refactor")
-      (spacemacs/declare-prefix-for-mode 'reason-mode "m=" "refmt")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "mc" "compile")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "mt" "toggle")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "me" "errors/eval")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "mh" "help/show")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "mr" "refactor")
+    (spacemacs/declare-prefix-for-mode 'reason-mode "m=" "refmt")
 
-      (spacemacs/set-leader-keys-for-major-mode 'reason-mode
-        "cr" 'refmt
-        "==" 'refmt
-        "tr" 'spacemacs/toggle-reason-auto-refmt
-        "=mr" 'reason/refmt-ml-to-re
-        "=rm" 'reason/refmt-re-to-ml))))
+    (spacemacs/set-leader-keys-for-major-mode 'reason-mode
+      "cr" 'refmt
+      "==" 'refmt
+      "tr" 'spacemacs/toggle-reason-auto-refmt
+      "=mr" 'reason/refmt-ml-to-re
+      "=rm" 'reason/refmt-re-to-ml)))
 
 (defun reasonml/pre-init-utop ()
   (spacemacs|use-package-add-hook utop

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -99,15 +99,14 @@
            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\|pryrc\\)\\'" . enh-ruby-mode))
     :interpreter "ruby"
     :init
-    (progn
-      (setq enh-ruby-deep-indent-paren nil
-            enh-ruby-hanging-paren-deep-indent-level 2)
-      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mi" "insert")
-      (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mt" "test")
+    (setq enh-ruby-deep-indent-paren nil
+          enh-ruby-hanging-paren-deep-indent-level 2)
+    (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mi" "insert")
+    (spacemacs/declare-prefix-for-mode 'enh-ruby-mode "mt" "test")
 
-      (add-hook 'enh-ruby-mode-hook #'spacemacs//ruby-setup-backend)
-      (add-hook 'enh-ruby-mode-local-vars-hook
-                #'spacemacs/ruby-maybe-highlight-debugger-keywords))
+    (add-hook 'enh-ruby-mode-hook #'spacemacs//ruby-setup-backend)
+    (add-hook 'enh-ruby-mode-local-vars-hook
+              #'spacemacs/ruby-maybe-highlight-debugger-keywords)
     :config
     (spacemacs/set-leader-keys-for-major-mode 'enh-ruby-mode
       "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
@@ -132,22 +131,20 @@
   (use-package minitest
     :defer t
     :init
-    (progn
-      (spacemacs/add-to-hooks 'spacemacs//ruby-enable-minitest-mode
-                              '(ruby-mode-local-vars-hook
-                                enh-ruby-mode-local-vars-hook))
-      ;; remove hooks added by minitest mode
-      (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
-        (remove-hook hook 'minitest-enable-appropriate-mode)))
+    (spacemacs/add-to-hooks 'spacemacs//ruby-enable-minitest-mode
+                            '(ruby-mode-local-vars-hook
+                              enh-ruby-mode-local-vars-hook))
+    ;; remove hooks added by minitest mode
+    (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+      (remove-hook hook 'minitest-enable-appropriate-mode))
     :config
-    (progn
-      (spacemacs|hide-lighter minitest-mode)
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "ta" 'minitest-verify-all
-          "tb" 'minitest-verify
-          "tr" 'minitest-rerun
-          "ts" 'minitest-verify-single)))))
+    (spacemacs|hide-lighter minitest-mode)
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "ta" 'minitest-verify-all
+        "tb" 'minitest-verify
+        "tr" 'minitest-rerun
+        "ts" 'minitest-verify-single))))
 
 (defun ruby/pre-init-org ()
   (spacemacs|use-package-add-hook org
@@ -195,70 +192,66 @@
     :if (eq ruby-backend 'robe)
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'robe 'robe-start "robe")
-      (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
-        (add-hook hook 'robe-mode))
-      (spacemacs/add-to-hooks 'robe-jump
-                              '(spacemacs-jump-handlers-ruby-mode
-                                spacemacs-jump-handlers-enh-ruby-mode)))
+    (spacemacs/register-repl 'robe 'robe-start "robe")
+    (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+      (add-hook hook 'robe-mode))
+    (spacemacs/add-to-hooks 'robe-jump
+                            '(spacemacs-jump-handlers-ruby-mode
+                              spacemacs-jump-handlers-enh-ruby-mode))
     :config
-    (progn
-      (spacemacs|hide-lighter robe-mode)
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "mg" "goto")
-        (spacemacs/declare-prefix-for-mode mode "mh" "docs")
-        (spacemacs/declare-prefix-for-mode mode "mr" "refactor/robe")
-        (spacemacs/declare-prefix-for-mode mode "mrs" "robe")
-        (spacemacs/declare-prefix-for-mode mode "ms" "repl")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "'" 'robe-start
-          ;; robe mode specific
-          "hh" 'robe-doc
-          "rsr" 'robe-rails-refresh
-          ;; inf-enh-ruby-mode
-          "sb" 'ruby-send-buffer
-          "sB" 'ruby-send-buffer-and-go
-          "sf" 'ruby-send-definition
-          "sF" 'ruby-send-definition-and-go
-          "si" 'robe-start
-          "sl" 'ruby-send-line
-          "sL" 'ruby-send-line-and-go
-          "sr" 'ruby-send-region
-          "sR" 'ruby-send-region-and-go
-          "ss" 'ruby-switch-to-inf)))))
+    (spacemacs|hide-lighter robe-mode)
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/declare-prefix-for-mode mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode mode "mh" "docs")
+      (spacemacs/declare-prefix-for-mode mode "mr" "refactor/robe")
+      (spacemacs/declare-prefix-for-mode mode "mrs" "robe")
+      (spacemacs/declare-prefix-for-mode mode "ms" "repl")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "'" 'robe-start
+        ;; robe mode specific
+        "hh" 'robe-doc
+        "rsr" 'robe-rails-refresh
+        ;; inf-enh-ruby-mode
+        "sb" 'ruby-send-buffer
+        "sB" 'ruby-send-buffer-and-go
+        "sf" 'ruby-send-definition
+        "sF" 'ruby-send-definition-and-go
+        "si" 'robe-start
+        "sl" 'ruby-send-line
+        "sL" 'ruby-send-line-and-go
+        "sr" 'ruby-send-region
+        "sR" 'ruby-send-region-and-go
+        "ss" 'ruby-switch-to-inf))))
 
 (defun ruby/init-rspec-mode ()
   (use-package rspec-mode
     :defer t
     :init
-    (progn
-      (spacemacs/add-to-hooks 'spacemacs//ruby-enable-rspec-mode
-                              '(ruby-mode-local-vars-hook
-                                enh-ruby-mode-local-vars-hook))
-      ;; remove hooks automatically added by rspec via autoload
-      ;; because we want to be able to control when rspec-mode is
-      ;; loaded based on the layer variable `ruby-test-runner'
-      (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
-        (remove-hook hook 'rspec-enable-appropriate-mode)))
+    (spacemacs/add-to-hooks 'spacemacs//ruby-enable-rspec-mode
+                            '(ruby-mode-local-vars-hook
+                              enh-ruby-mode-local-vars-hook))
+    ;; remove hooks automatically added by rspec via autoload
+    ;; because we want to be able to control when rspec-mode is
+    ;; loaded based on the layer variable `ruby-test-runner'
+    (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+      (remove-hook hook 'rspec-enable-appropriate-mode))
     :config
-    (progn
-      (add-hook 'rspec-compilation-mode-hook 'spacemacs//inf-ruby-auto-enter)
-      (spacemacs|hide-lighter rspec-mode)
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "ta"    'rspec-verify-all
-          "tb"    'rspec-verify
-          "tc"    'rspec-verify-continue
-          "td"    'ruby/rspec-verify-directory
-          "te"    'rspec-toggle-example-pendingness
-          "tf"    'rspec-verify-method
-          "tl"    'rspec-run-last-failed
-          "tm"    'rspec-verify-matching
-          "tr"    'rspec-rerun
-          "tt"    'rspec-verify-single
-          "t~"    'rspec-toggle-spec-and-target-find-example
-          "t TAB" 'rspec-toggle-spec-and-target)))))
+    (add-hook 'rspec-compilation-mode-hook 'spacemacs//inf-ruby-auto-enter)
+    (spacemacs|hide-lighter rspec-mode)
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "ta"    'rspec-verify-all
+        "tb"    'rspec-verify
+        "tc"    'rspec-verify-continue
+        "td"    'ruby/rspec-verify-directory
+        "te"    'rspec-toggle-example-pendingness
+        "tf"    'rspec-verify-method
+        "tl"    'rspec-run-last-failed
+        "tm"    'rspec-verify-matching
+        "tr"    'rspec-rerun
+        "tt"    'rspec-verify-single
+        "t~"    'rspec-toggle-spec-and-target-find-example
+        "t TAB" 'rspec-toggle-spec-and-target))))
 
 (defun ruby/init-rubocop ()
   (use-package rubocop
@@ -279,13 +272,12 @@
   (use-package rubocopfmt
     :defer t
     :init
-    (progn
-      (setq-default rubocopfmt-disabled-cops '())
+    (setq-default rubocopfmt-disabled-cops '())
 
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "m=" "format")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "=r" #'rubocopfmt)))))
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/declare-prefix-for-mode mode "m=" "format")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "=r" #'rubocopfmt))))
 
 (defun ruby/init-ruby-hash-syntax ()
   (use-package ruby-hash-syntax
@@ -302,30 +294,28 @@
            ("\\(Rake\\|Thor\\|Guard\\|Gem\\|Cap\\|Vagrant\\|Berks\\|Pod\\|Puppet\\)file\\'" . ruby-mode)
            ("\\.\\(rb\\|rabl\\|ru\\|builder\\|rake\\|thor\\|gemspec\\|jbuilder\\|pryrc\\)\\'" . ruby-mode))
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mi" "insert")
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "test")
-      (spacemacs/declare-prefix-for-mode 'ruby-mode "mT" "toggle")
+    (spacemacs/declare-prefix-for-mode 'ruby-mode "mi" "insert")
+    (spacemacs/declare-prefix-for-mode 'ruby-mode "mt" "test")
+    (spacemacs/declare-prefix-for-mode 'ruby-mode "mT" "toggle")
 
-      ;; setup version manager which is necessary to find gems in path for backend
-      (spacemacs//ruby-setup-version-manager)
-      (add-hook 'ruby-mode-hook #'spacemacs//ruby-setup-backend)
-      (add-hook 'ruby-mode-local-vars-hook
-                #'spacemacs/ruby-maybe-highlight-debugger-keywords))
+    ;; setup version manager which is necessary to find gems in path for backend
+    (spacemacs//ruby-setup-version-manager)
+    (add-hook 'ruby-mode-hook #'spacemacs//ruby-setup-backend)
+    (add-hook 'ruby-mode-local-vars-hook
+              #'spacemacs/ruby-maybe-highlight-debugger-keywords)
     :config
-    (progn
-      ;; This might have been important 10 years ago but now it's frustrating.
-      (setq ruby-insert-encoding-magic-comment nil)
+    ;; This might have been important 10 years ago but now it's frustrating.
+    (setq ruby-insert-encoding-magic-comment nil)
 
-      (when ruby-prettier-on-save
-        (add-hook 'ruby-mode-hook 'spacemacs/ruby-fmt-before-save-hook))
-      (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
-        "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
-        "is"  'spacemacs/ruby-insert-shebang
-        "r'"  'ruby-toggle-string-quotes
-        "r\"" 'ruby-toggle-string-quotes
-        "r{"  'ruby-toggle-block
-        "r}"  'ruby-toggle-block))))
+    (when ruby-prettier-on-save
+      (add-hook 'ruby-mode-hook 'spacemacs/ruby-fmt-before-save-hook))
+    (spacemacs/set-leader-keys-for-major-mode 'ruby-mode
+      "if"  'spacemacs/ruby-insert-frozen-string-literal-comment
+      "is"  'spacemacs/ruby-insert-shebang
+      "r'"  'ruby-toggle-string-quotes
+      "r\"" 'ruby-toggle-string-quotes
+      "r{"  'ruby-toggle-block
+      "r}"  'ruby-toggle-block)))
 
 (defun ruby/init-ruby-refactor ()
   (use-package ruby-refactor
@@ -349,16 +339,15 @@
                                   '(ruby-mode-local-vars-hook
                                     enh-ruby-mode-local-vars-hook))
     :config
-    (progn
-      ;; `ruby-test-mode' adds a hook to enable itself, this hack
-      ;; removes it to be sure that we control the loading of the
-      ;; mode
-      (remove-hook 'ruby-mode-hook 'ruby-test-enable)
-      (spacemacs|hide-lighter ruby-test-mode)
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "tb" 'ruby-test-run
-          "tt" 'ruby-test-run-at-point)))))
+    ;; `ruby-test-mode' adds a hook to enable itself, this hack
+    ;; removes it to be sure that we control the loading of the
+    ;; mode
+    (remove-hook 'ruby-mode-hook 'ruby-test-enable)
+    (spacemacs|hide-lighter ruby-test-mode)
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "tb" 'ruby-test-run
+        "tt" 'ruby-test-run-at-point))))
 
 (defun ruby/init-ruby-tools ()
   (use-package ruby-tools
@@ -366,24 +355,22 @@
     :init (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
             (add-hook hook 'ruby-tools-mode))
     :config
-    (progn
-      (spacemacs|hide-lighter ruby-tools-mode)
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "mx" "text")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "x\'" 'ruby-tools-to-single-quote-string
-          "x\"" 'ruby-tools-to-double-quote-string
-          "x:" 'ruby-tools-to-symbol)))))
+    (spacemacs|hide-lighter ruby-tools-mode)
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/declare-prefix-for-mode mode "mx" "text")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "x\'" 'ruby-tools-to-single-quote-string
+        "x\"" 'ruby-tools-to-double-quote-string
+        "x:" 'ruby-tools-to-symbol))))
 
 (defun ruby/init-rvm ()
   (use-package rvm
     :if (equal ruby-version-manager 'rvm)
     :defer t
     :init
-    (progn
-      (setq rspec-use-rvm t)
-      (spacemacs/add-to-hooks 'rvm-activate-corresponding-ruby
-                              '(ruby-mode-hook enh-ruby-mode-hook)))))
+    (setq rspec-use-rvm t)
+    (spacemacs/add-to-hooks 'rvm-activate-corresponding-ruby
+                            '(ruby-mode-hook enh-ruby-mode-hook))))
 
 (defun ruby/init-seeing-is-believing ()
   (use-package seeing-is-believing
@@ -391,15 +378,14 @@
     :commands (seeing-is-believing seeing-is-believing-run seeing-is-believing-clear)
     :if (executable-find "seeing_is_believing")
     :init
-    (progn
-      (spacemacs|diminish seeing-is-believing " 👁" " @")
-      (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
-        (add-hook hook 'seeing-is-believing))
-      (dolist (mode '(ruby-mode enh-ruby-mode))
-        (spacemacs/declare-prefix-for-mode mode "m@" "seeing-is-believing")
-        (spacemacs/set-leader-keys-for-major-mode mode
-          "@@" 'seeing-is-believing-run
-          "@c" 'seeing-is-believing-clear)))))
+    (spacemacs|diminish seeing-is-believing " 👁" " @")
+    (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
+      (add-hook hook 'seeing-is-believing))
+    (dolist (mode '(ruby-mode enh-ruby-mode))
+      (spacemacs/declare-prefix-for-mode mode "m@" "seeing-is-believing")
+      (spacemacs/set-leader-keys-for-major-mode mode
+        "@@" 'seeing-is-believing-run
+        "@c" 'seeing-is-believing-clear))))
 
 (defun ruby/pre-init-smartparens ()
   (spacemacs|use-package-add-hook smartparens

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -40,34 +40,33 @@
   (use-package cargo
     :defer t
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
-      (spacemacs/declare-prefix-for-mode 'rust-mode "mt" "tests")
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "c." 'spacemacs/cargo-process-repeat
-        "c/" 'cargo-process-search
-        "c=" 'cargo-process-fmt
-        "ca" 'spacemacs/cargo-process-add
-        "cA" 'cargo-process-audit
-        "cc" 'cargo-process-build
-        "cC" 'cargo-process-clean
-        "cd" 'cargo-process-doc
-        "cD" 'cargo-process-doc-open
-        "ce" 'cargo-process-bench
-        "cE" 'cargo-process-run-example
-        "ci" 'cargo-process-init
-        "cl" 'cargo-process-clippy
-        "cn" 'cargo-process-new
-        "co" 'cargo-process-outdated
-        "cr" 'spacemacs/cargo-process-rm
-        "cu" 'cargo-process-update
-        "cU" 'spacemacs/cargo-process-upgrade
-        "cv" 'cargo-process-check
-        "cx" 'cargo-process-run
-        "cX" 'cargo-process-run-bin
-        "ta" 'cargo-process-test
-        "tt" 'cargo-process-current-test
-        "tb" 'cargo-process-current-file-tests))))
+    (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
+    (spacemacs/declare-prefix-for-mode 'rust-mode "mt" "tests")
+    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+      "c." 'spacemacs/cargo-process-repeat
+      "c/" 'cargo-process-search
+      "c=" 'cargo-process-fmt
+      "ca" 'spacemacs/cargo-process-add
+      "cA" 'cargo-process-audit
+      "cc" 'cargo-process-build
+      "cC" 'cargo-process-clean
+      "cd" 'cargo-process-doc
+      "cD" 'cargo-process-doc-open
+      "ce" 'cargo-process-bench
+      "cE" 'cargo-process-run-example
+      "ci" 'cargo-process-init
+      "cl" 'cargo-process-clippy
+      "cn" 'cargo-process-new
+      "co" 'cargo-process-outdated
+      "cr" 'spacemacs/cargo-process-rm
+      "cu" 'cargo-process-update
+      "cU" 'spacemacs/cargo-process-upgrade
+      "cv" 'cargo-process-check
+      "cx" 'cargo-process-run
+      "cX" 'cargo-process-run-bin
+      "ta" 'cargo-process-test
+      "tt" 'cargo-process-current-test
+      "tb" 'cargo-process-current-file-tests)))
 
 (defun rust/post-init-company ()
   ;; backend specific
@@ -97,28 +96,26 @@
     :defer t
     :commands racer-mode
     :config
-    (progn
-      (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
-      (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
-      (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "hh" 'spacemacs/racer-describe)
-      (spacemacs|hide-lighter racer-mode)
-      (evilified-state-evilify-map racer-help-mode-map
-        :mode racer-help-mode))))
+    (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
+    (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
+    (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
+    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+      "hh" 'spacemacs/racer-describe)
+    (spacemacs|hide-lighter racer-mode)
+    (evilified-state-evilify-map racer-help-mode-map
+      :mode racer-help-mode)))
 
 (defun rust/init-rust-mode ()
   (use-package rust-mode
     :defer t
     :init
-    (progn
-      (spacemacs/add-to-hook 'rust-mode-hook '(spacemacs//rust-setup-backend))
-      (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'rust-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'rust-mode "m=" "format")
-      (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-        "==" 'rust-format-buffer
-        "q" 'spacemacs/rust-quick-run))))
+    (spacemacs/add-to-hook 'rust-mode-hook '(spacemacs//rust-setup-backend))
+    (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'rust-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'rust-mode "m=" "format")
+    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+      "==" 'rust-format-buffer
+      "q" 'spacemacs/rust-quick-run)))
 
 (defun rust/post-init-smartparens ()
   (with-eval-after-load 'smartparens

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -52,48 +52,45 @@
     ;; sbt-supershell kills sbt-mode:  https://github.com/hvesalai/emacs-sbt-mode/issues/152
     (setq sbt:program-options '("-Dsbt.supershell=false"))
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'scala-mode "mb" "sbt")
-      (spacemacs/declare-prefix-for-mode 'scala-mode "mg" "goto")
-      (spacemacs/set-leader-keys-for-major-mode 'scala-mode
-        "b." 'sbt-hydra
-        "bb" 'sbt-command
-        "bc" #'spacemacs/scala-sbt-compile
-        "bt" #'spacemacs/scala-sbt-test
-        "bI" #'spacemacs/scala-sbt-compile-it
-        "bT" #'spacemacs/scala-sbt-compile-test
-        "b=" #'spacemacs/scala-sbt-scalafmt-all))))
+    (spacemacs/declare-prefix-for-mode 'scala-mode "mb" "sbt")
+    (spacemacs/declare-prefix-for-mode 'scala-mode "mg" "goto")
+    (spacemacs/set-leader-keys-for-major-mode 'scala-mode
+      "b." 'sbt-hydra
+      "bb" 'sbt-command
+      "bc" #'spacemacs/scala-sbt-compile
+      "bt" #'spacemacs/scala-sbt-test
+      "bI" #'spacemacs/scala-sbt-compile-it
+      "bT" #'spacemacs/scala-sbt-compile-test
+      "b=" #'spacemacs/scala-sbt-scalafmt-all)))
 
 (defun scala/init-scala-mode ()
   (use-package scala-mode
     :defer t
     :init
-    (progn
-      (dolist (ext '(".cfe" ".cfs" ".si" ".gen" ".lock"))
-        (add-to-list 'completion-ignored-extensions ext)))
+    (dolist (ext '(".cfe" ".cfs" ".si" ".gen" ".lock"))
+      (add-to-list 'completion-ignored-extensions ext))
     :config
-    (progn
-      ;; Automatically insert asterisk in a comment when enabled
-      (defun scala/newline-and-indent-with-asterisk ()
-        (interactive)
-        (newline-and-indent)
-        (when scala-auto-insert-asterisk-in-comments
-          (scala-indent:insert-asterisk-on-multiline-comment)))
+    ;; Automatically insert asterisk in a comment when enabled
+    (defun scala/newline-and-indent-with-asterisk ()
+      (interactive)
+      (newline-and-indent)
+      (when scala-auto-insert-asterisk-in-comments
+        (scala-indent:insert-asterisk-on-multiline-comment)))
 
-      (evil-define-key 'insert scala-mode-map
-        (kbd "RET") 'scala/newline-and-indent-with-asterisk)
+    (evil-define-key 'insert scala-mode-map
+      (kbd "RET") 'scala/newline-and-indent-with-asterisk)
 
-      (evil-define-key 'normal scala-mode-map "J" 'spacemacs/scala-join-line)
+    (evil-define-key 'normal scala-mode-map "J" 'spacemacs/scala-join-line)
 
-      (when (eq scala-sbt-window-position 'bottom)
-        (setq sbt:display-buffer-action
-              (list #'spacemacs//scala-display-sbt-at-bottom)))
+    (when (eq scala-sbt-window-position 'bottom)
+      (setq sbt:display-buffer-action
+            (list #'spacemacs//scala-display-sbt-at-bottom)))
 
-      ;; Compatibility with `aggressive-indent'
-      (setq scala-indent:align-forms t
-            scala-indent:align-parameters t
-            scala-indent:default-run-on-strategy
-            scala-indent:operator-strategy))))
+    ;; Compatibility with `aggressive-indent'
+    (setq scala-indent:align-forms t
+          scala-indent:align-parameters t
+          scala-indent:default-run-on-strategy
+          scala-indent:operator-strategy)))
 
 (defun scala/pre-init-dap-mode ()
   (when (spacemacs//scala-backend-metals-p)

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -53,94 +53,93 @@
     :commands run-geiser
     :init (spacemacs/register-repl 'geiser 'run-geiser "geiser")
     :config
-    (progn
-      ;; prefixes
-      (spacemacs/declare-prefix-for-mode 'scheme-mode "mc" "compiling")
-      (spacemacs/declare-prefix-for-mode 'scheme-mode "mg" "navigation")
-      (spacemacs/declare-prefix-for-mode 'scheme-mode "mh" "documentation")
-      (spacemacs/declare-prefix-for-mode 'scheme-mode "mi" "insertion")
-      (spacemacs/declare-prefix-for-mode 'scheme-mode "mm" "macroexpansion")
-      (spacemacs/declare-prefix-for-mode 'scheme-mode "ms" "repl")
-      ;; key bindings
-      (spacemacs/set-leader-keys-for-major-mode 'scheme-mode
-        "'"  'geiser-mode-switch-to-repl
-        ","  'lisp-state-toggle-lisp-state
+    ;; prefixes
+    (spacemacs/declare-prefix-for-mode 'scheme-mode "mc" "compiling")
+    (spacemacs/declare-prefix-for-mode 'scheme-mode "mg" "navigation")
+    (spacemacs/declare-prefix-for-mode 'scheme-mode "mh" "documentation")
+    (spacemacs/declare-prefix-for-mode 'scheme-mode "mi" "insertion")
+    (spacemacs/declare-prefix-for-mode 'scheme-mode "mm" "macroexpansion")
+    (spacemacs/declare-prefix-for-mode 'scheme-mode "ms" "repl")
+    ;; key bindings
+    (spacemacs/set-leader-keys-for-major-mode 'scheme-mode
+      "'"  'geiser-mode-switch-to-repl
+      ","  'lisp-state-toggle-lisp-state
 
-        "cc" 'geiser-compile-current-buffer
-        "cp" 'geiser-add-to-load-path
+      "cc" 'geiser-compile-current-buffer
+      "cp" 'geiser-add-to-load-path
 
-        "eb" 'geiser-eval-buffer
-        "ee" 'geiser-eval-last-sexp
-        "ef" 'geiser-eval-definition
-        "el" 'lisp-state-eval-sexp-end-of-line
-        "er" 'geiser-eval-region
+      "eb" 'geiser-eval-buffer
+      "ee" 'geiser-eval-last-sexp
+      "ef" 'geiser-eval-definition
+      "el" 'lisp-state-eval-sexp-end-of-line
+      "er" 'geiser-eval-region
 
-        "gm" 'geiser-edit-module
-        "gn" 'next-error
-        "gN" 'previous-error
+      "gm" 'geiser-edit-module
+      "gn" 'next-error
+      "gN" 'previous-error
 
-        "hh" 'geiser-doc-symbol-at-point
-        "hd" 'geiser-doc-look-up-manual
-        "hm" 'geiser-doc-module
-        "h<" 'geiser-xref-callers
-        "h>" 'geiser-xref-callees
+      "hh" 'geiser-doc-symbol-at-point
+      "hd" 'geiser-doc-look-up-manual
+      "hm" 'geiser-doc-module
+      "h<" 'geiser-xref-callers
+      "h>" 'geiser-xref-callees
 
-        "il" 'geiser-insert-lambda
+      "il" 'geiser-insert-lambda
 
-        "me" 'geiser-expand-last-sexp
-        "mf" 'geiser-expand-definition
-        "mr" 'geiser-expand-region
+      "me" 'geiser-expand-last-sexp
+      "mf" 'geiser-expand-definition
+      "mr" 'geiser-expand-region
 
-        "si" 'geiser-mode-switch-to-repl
-        "sb" 'geiser-eval-buffer
-        "sB" 'geiser-eval-buffer-and-go
-        "sf" 'geiser-eval-definition
-        "sF" 'geiser-eval-definition-and-go
-        "se" 'geiser-eval-last-sexp
-        "sr" 'geiser-eval-region
-        "sR" 'geiser-eval-region-and-go
-        "ss" 'geiser-set-scheme)
+      "si" 'geiser-mode-switch-to-repl
+      "sb" 'geiser-eval-buffer
+      "sB" 'geiser-eval-buffer-and-go
+      "sf" 'geiser-eval-definition
+      "sF" 'geiser-eval-definition-and-go
+      "se" 'geiser-eval-last-sexp
+      "sr" 'geiser-eval-region
+      "sR" 'geiser-eval-region-and-go
+      "ss" 'geiser-set-scheme)
 
-      (evil-define-key 'insert geiser-repl-mode-map
-        (kbd "S-<return>") 'geiser-repl--newline-and-indent
-        (kbd "C-l") 'geiser-repl-clear-buffer
-        (kbd "C-d") 'geiser-repl-exit)
+    (evil-define-key 'insert geiser-repl-mode-map
+      (kbd "S-<return>") 'geiser-repl--newline-and-indent
+      (kbd "C-l") 'geiser-repl-clear-buffer
+      (kbd "C-d") 'geiser-repl-exit)
 
-      (evil-define-key 'normal geiser-repl-mode-map
-        "]]" 'geiser-repl-next-prompt
-        "[[" 'geiser-repl-previous-prompt
-        "gj" 'geiser-repl-next-prompt
-        "gk" 'geiser-repl-previous-prompt)
+    (evil-define-key 'normal geiser-repl-mode-map
+      "]]" 'geiser-repl-next-prompt
+      "[[" 'geiser-repl-previous-prompt
+      "gj" 'geiser-repl-next-prompt
+      "gk" 'geiser-repl-previous-prompt)
 
-      (spacemacs/declare-prefix-for-mode 'geiser-repl-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'geiser-repl-mode "mi" "insert")
-      (spacemacs/set-leader-keys-for-major-mode 'geiser-repl-mode
-        "C" 'geiser-repl-clear-buffer
-        "k" 'geiser-repl-interrupt
-        "f" 'geiser-load-file
-        "il" 'geiser-insert-lambda
-        "im" 'geiser-repl-import-module
-        "u" 'geiser-repl-unload-function
-        "hh" 'geiser-doc-symbol-at-point
-        "s" 'geiser-squarify
-        "q" 'geiser-repl-exit)
+    (spacemacs/declare-prefix-for-mode 'geiser-repl-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'geiser-repl-mode "mi" "insert")
+    (spacemacs/set-leader-keys-for-major-mode 'geiser-repl-mode
+      "C" 'geiser-repl-clear-buffer
+      "k" 'geiser-repl-interrupt
+      "f" 'geiser-load-file
+      "il" 'geiser-insert-lambda
+      "im" 'geiser-repl-import-module
+      "u" 'geiser-repl-unload-function
+      "hh" 'geiser-doc-symbol-at-point
+      "s" 'geiser-squarify
+      "q" 'geiser-repl-exit)
 
-      (evilified-state-evilify-map geiser-doc-mode-map
-        :mode geiser-doc-mode
-        :eval-after-load geiser-doc
-        :bindings
-        "o" 'link-hint-open-link
+    (evilified-state-evilify-map geiser-doc-mode-map
+      :mode geiser-doc-mode
+      :eval-after-load geiser-doc
+      :bindings
+      "o" 'link-hint-open-link
 
-        "]]" 'geiser-doc-next-section
-        "[[" 'geiser-doc-previous-section
-        ">" 'geiser-doc-next
-        "<" 'geiser-doc-previous
+      "]]" 'geiser-doc-next-section
+      "[[" 'geiser-doc-previous-section
+      ">" 'geiser-doc-next
+      "<" 'geiser-doc-previous
 
-        "gp" 'geiser-doc-previous
-        "gn" 'geiser-doc-next
-        "gz" 'geiser-doc-switch-to-repl
-        (kbd "C-j") 'forward-button
-        (kbd "C-k") 'backward-button))))
+      "gp" 'geiser-doc-previous
+      "gn" 'geiser-doc-next
+      "gz" 'geiser-doc-switch-to-repl
+      (kbd "C-j") 'forward-button
+      (kbd "C-k") 'backward-button)))
 
 (defun scheme/post-init-ggtags ()
   (add-hook 'scheme-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/semantic-web/packages.el
+++ b/layers/+lang/semantic-web/packages.el
@@ -36,12 +36,11 @@
   (use-package sparql-mode
     :mode ("\\.\\(sparql\\|rq\\)\\'" . sparql-mode)
     :init
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'sparql-mode "q" 'sparql-query-region)
-      (when (configuration-layer/package-used-p 'company)
-        (spacemacs|add-company-backends
-          :backends company-sparql
-          :modes sparql-mode)))))
+    (spacemacs/set-leader-keys-for-major-mode 'sparql-mode "q" 'sparql-query-region)
+    (when (configuration-layer/package-used-p 'company)
+      (spacemacs|add-company-backends
+       :backends company-sparql
+       :modes sparql-mode))))
 
 (defun semantic-web/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/sml/packages.el
+++ b/layers/+lang/sml/packages.el
@@ -35,39 +35,38 @@
     :commands run-sml
     :init (spacemacs/register-repl 'sml-mode 'run-sml "sml")
     :config
-    (progn
-      (defun spacemacs/sml-prog-proc-send-buffer-and-focus ()
-        "Send buffer to REPL and switch to it in `insert state'."
-        (interactive)
-        (sml-prog-proc-send-buffer t)
-        (evil-insert-state))
+    (defun spacemacs/sml-prog-proc-send-buffer-and-focus ()
+      "Send buffer to REPL and switch to it in `insert state'."
+      (interactive)
+      (sml-prog-proc-send-buffer t)
+      (evil-insert-state))
 
-      (defun spacemacs/sml-prog-proc-send-region-and-focus (start end)
-        "Send region to REPL and switch to it in `insert state'."
-        (interactive "r")
-        (sml-prog-proc-send-region start end t)
-        (evil-insert-state))
+    (defun spacemacs/sml-prog-proc-send-region-and-focus (start end)
+      "Send region to REPL and switch to it in `insert state'."
+      (interactive "r")
+      (sml-prog-proc-send-region start end t)
+      (evil-insert-state))
 
-      (defun spacemacs/sml-send-function-and-focus ()
-        "Send function at point to REPL and switch to it in `insert state'."
-        (interactive)
-        (sml-send-function t)
-        (evil-insert-state))
+    (defun spacemacs/sml-send-function-and-focus ()
+      "Send function at point to REPL and switch to it in `insert state'."
+      (interactive)
+      (sml-send-function t)
+      (evil-insert-state))
 
-      (spacemacs/set-leader-keys-for-major-mode 'sml-mode
-        ;; REPL
-        "'"  'run-sml
-        "sb" 'sml-prog-proc-send-buffer
-        "sB" 'spacemacs/sml-prog-proc-send-buffer-and-focus
-        "sf" 'sml-send-function
-        "sF" 'spacemacs/sml-send-function-and-focus
-        "si" 'run-sml
-        "sr" 'sml-prog-proc-send-region
-        "sR" 'spacemacs/sml-prog-proc-send-region-and-focus
-        "ss" 'run-sml)
-      (define-key sml-mode-map (kbd "RET") 'reindent-then-newline-and-indent)
-      (define-key sml-mode-map (kbd "M-SPC") 'sml-electric-space)
-      (define-key sml-mode-map (kbd "|") 'sml-electric-pipe))))
+    (spacemacs/set-leader-keys-for-major-mode 'sml-mode
+      ;; REPL
+      "'"  'run-sml
+      "sb" 'sml-prog-proc-send-buffer
+      "sB" 'spacemacs/sml-prog-proc-send-buffer-and-focus
+      "sf" 'sml-send-function
+      "sF" 'spacemacs/sml-send-function-and-focus
+      "si" 'run-sml
+      "sr" 'sml-prog-proc-send-region
+      "sR" 'spacemacs/sml-prog-proc-send-region-and-focus
+      "ss" 'run-sml)
+    (define-key sml-mode-map (kbd "RET") 'reindent-then-newline-and-indent)
+    (define-key sml-mode-map (kbd "M-SPC") 'sml-electric-space)
+    (define-key sml-mode-map (kbd "|") 'sml-electric-pipe)))
 
 (defun sml/post-init-smartparens ()
   (with-eval-after-load 'smartparens

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -43,158 +43,156 @@
   (use-package sql
     :defer t
     :init
-    (progn
-      (spacemacs/register-repl 'sql 'spacemacs/sql-start "sql")
-      (add-hook 'sql-mode-hook
-                'spacemacs//sql-setup-backend))
+    (spacemacs/register-repl 'sql 'spacemacs/sql-start "sql")
+    (add-hook 'sql-mode-hook
+              'spacemacs//sql-setup-backend)
     :config
-    (progn
-      (setq
-       ;; should not set this to anything else than nil
-       ;; the focus of SQLi is handled by spacemacs conventions
-       sql-pop-to-buffer-after-send-region nil)
-      (advice-add 'sql-add-product :after #'spacemacs/sql-populate-products-list)
-      (advice-add 'sql-del-product :after #'spacemacs/sql-populate-products-list)
-      (spacemacs/sql-populate-products-list)
-      (defun spacemacs//sql-source (products)
-        "return a source for helm selection"
-        `((name . "SQL Products")
-          (candidates . ,(mapcar (lambda (product)
-                                   (cons (sql-get-product-feature (car product) :name)
-                                         (car product)))
-                                 products))
-          (action . (lambda (candidate) (helm-marked-candidates)))))
+    (setq
+     ;; should not set this to anything else than nil
+     ;; the focus of SQLi is handled by spacemacs conventions
+     sql-pop-to-buffer-after-send-region nil)
+    (advice-add 'sql-add-product :after #'spacemacs/sql-populate-products-list)
+    (advice-add 'sql-del-product :after #'spacemacs/sql-populate-products-list)
+    (spacemacs/sql-populate-products-list)
+    (defun spacemacs//sql-source (products)
+      "return a source for helm selection"
+      `((name . "SQL Products")
+        (candidates . ,(mapcar (lambda (product)
+                                 (cons (sql-get-product-feature (car product) :name)
+                                       (car product)))
+                               products))
+        (action . (lambda (candidate) (helm-marked-candidates)))))
 
-      (defun spacemacs/sql-highlight ()
-        "set SQL dialect-specific highlighting"
-        (interactive)
-        (let ((product (car (helm
-                             :sources (list (spacemacs//sql-source spacemacs-sql-highlightable))))))
-          (sql-set-product product)))
+    (defun spacemacs/sql-highlight ()
+      "set SQL dialect-specific highlighting"
+      (interactive)
+      (let ((product (car (helm
+                           :sources (list (spacemacs//sql-source spacemacs-sql-highlightable))))))
+        (sql-set-product product)))
 
-      (defun spacemacs/sql-start ()
-        "set SQL dialect-specific highlighting and start inferior SQLi process"
-        (interactive)
-        (let ((product (car (helm
-                             :sources (list (spacemacs//sql-source spacemacs-sql-startable))))))
-          (sql-set-product product)
-          (sql-product-interactive product)))
+    (defun spacemacs/sql-start ()
+      "set SQL dialect-specific highlighting and start inferior SQLi process"
+      (interactive)
+      (let ((product (car (helm
+                           :sources (list (spacemacs//sql-source spacemacs-sql-startable))))))
+        (sql-set-product product)
+        (sql-product-interactive product)))
 
-      (defun spacemacs/sql-send-string-and-focus ()
-        "Send a string to SQLi and switch to SQLi in `insert state'."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region t))
-          (call-interactively 'sql-send-string)
-          (evil-insert-state)))
+    (defun spacemacs/sql-send-string-and-focus ()
+      "Send a string to SQLi and switch to SQLi in `insert state'."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region t))
+        (call-interactively 'sql-send-string)
+        (evil-insert-state)))
 
-      (defun spacemacs/sql-send-buffer-and-focus ()
-        "Send the buffer to SQLi and switch to SQLi in `insert state'."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region t))
-          (sql-send-buffer)
-          (evil-insert-state)))
+    (defun spacemacs/sql-send-buffer-and-focus ()
+      "Send the buffer to SQLi and switch to SQLi in `insert state'."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region t))
+        (sql-send-buffer)
+        (evil-insert-state)))
 
-      (defun spacemacs/sql-send-paragraph-and-focus ()
-        "Send the paragraph to SQLi and switch to SQLi in `insert state'."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region t))
-          (sql-send-paragraph)
-          (evil-insert-state)))
+    (defun spacemacs/sql-send-paragraph-and-focus ()
+      "Send the paragraph to SQLi and switch to SQLi in `insert state'."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region t))
+        (sql-send-paragraph)
+        (evil-insert-state)))
 
-      (defun spacemacs/sql-send-region-and-focus (start end)
-        "Send region to SQLi and switch to SQLi in `insert state'."
-        (interactive "r")
-        (let ((sql-pop-to-buffer-after-send-region t))
-          (sql-send-region start end)
-          (evil-insert-state)))
+    (defun spacemacs/sql-send-region-and-focus (start end)
+      "Send region to SQLi and switch to SQLi in `insert state'."
+      (interactive "r")
+      (let ((sql-pop-to-buffer-after-send-region t))
+        (sql-send-region start end)
+        (evil-insert-state)))
 
-      (defun spacemacs/sql-send-line-and-next-and-focus ()
-        "Send the current line to SQLi and switch to SQLi in `insert state'."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region t))
-          (sql-send-line-and-next)))
+    (defun spacemacs/sql-send-line-and-next-and-focus ()
+      "Send the current line to SQLi and switch to SQLi in `insert state'."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region t))
+        (sql-send-line-and-next)))
 
-      (defun spacemacs/sql-send-string ()
-        "Send a string to SQLi and stays in the same region."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region nil))
-          (call-interactively 'sql-send-string)))
+    (defun spacemacs/sql-send-string ()
+      "Send a string to SQLi and stays in the same region."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region nil))
+        (call-interactively 'sql-send-string)))
 
-      (defun spacemacs/sql-send-buffer ()
-        "Send the buffer to SQLi and stays in the same region."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region nil))
-          (sql-send-buffer)))
+    (defun spacemacs/sql-send-buffer ()
+      "Send the buffer to SQLi and stays in the same region."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region nil))
+        (sql-send-buffer)))
 
-      (defun spacemacs/sql-send-paragraph ()
-        "Send the paragraph to SQLi and stays in the same region."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region nil))
-          (sql-send-paragraph)))
+    (defun spacemacs/sql-send-paragraph ()
+      "Send the paragraph to SQLi and stays in the same region."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region nil))
+        (sql-send-paragraph)))
 
-      (defun spacemacs/sql-send-region (start end)
-        "Send region to SQLi and stays in the same region."
-        (interactive "r")
-        (let ((sql-pop-to-buffer-after-send-region nil))
-          (sql-send-region start end)))
+    (defun spacemacs/sql-send-region (start end)
+      "Send region to SQLi and stays in the same region."
+      (interactive "r")
+      (let ((sql-pop-to-buffer-after-send-region nil))
+        (sql-send-region start end)))
 
-      (defun spacemacs/sql-send-line-and-next ()
-        "Send the current line to SQLi and stays in the same region."
-        (interactive)
-        (let ((sql-pop-to-buffer-after-send-region nil))
-          (sql-send-line-and-next)))
+    (defun spacemacs/sql-send-line-and-next ()
+      "Send the current line to SQLi and stays in the same region."
+      (interactive)
+      (let ((sql-pop-to-buffer-after-send-region nil))
+        (sql-send-line-and-next)))
 
-      (spacemacs/declare-prefix-for-mode 'sql-mode "mb" "buffer")
-      (spacemacs/declare-prefix-for-mode 'sql-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'sql-mode "mh" "dialects")
-      (spacemacs/declare-prefix-for-mode 'sql-mode "ml" "listing")
-      (spacemacs/declare-prefix-for-mode 'sql-mode "ms" "REPL")
-      (spacemacs/set-leader-keys-for-major-mode 'sql-mode
-        "'" 'spacemacs/sql-start
+    (spacemacs/declare-prefix-for-mode 'sql-mode "mb" "buffer")
+    (spacemacs/declare-prefix-for-mode 'sql-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'sql-mode "mh" "dialects")
+    (spacemacs/declare-prefix-for-mode 'sql-mode "ml" "listing")
+    (spacemacs/declare-prefix-for-mode 'sql-mode "ms" "REPL")
+    (spacemacs/set-leader-keys-for-major-mode 'sql-mode
+      "'" 'spacemacs/sql-start
 
-        ;; sqli buffer
-        "bb" 'sql-show-sqli-buffer
-        "bc" 'sql-connect
-        "bs" 'sql-set-sqli-buffer
+      ;; sqli buffer
+      "bb" 'sql-show-sqli-buffer
+      "bc" 'sql-connect
+      "bs" 'sql-set-sqli-buffer
 
-        ;; dialects
-        "hk" 'spacemacs/sql-highlight
+      ;; dialects
+      "hk" 'spacemacs/sql-highlight
 
-        ;; repl
-        "sb" 'sql-send-buffer
-        "sB" 'spacemacs/sql-send-buffer-and-focus
-        "si" 'spacemacs/sql-start
-        ;; paragraph gets "f" here because they can be assimilated to functions.
-        ;; If you separate your commands in a SQL file, this key will send the
-        ;; command around point, which is what you probably want.
-        "sf" 'spacemacs/sql-send-paragraph
-        "sF" 'spacemacs/sql-send-paragraph-and-focus
-        "sl" 'spacemacs/sql-send-line-and-next
-        "sL" 'spacemacs/sql-send-line-and-next-and-focus
-        "sq" 'spacemacs/sql-send-string
-        "sQ" 'spacemacs/sql-send-string-and-focus
-        "sr" 'spacemacs/sql-send-region
-        "sR" 'spacemacs/sql-send-region-and-focus
+      ;; repl
+      "sb" 'sql-send-buffer
+      "sB" 'spacemacs/sql-send-buffer-and-focus
+      "si" 'spacemacs/sql-start
+      ;; paragraph gets "f" here because they can be assimilated to functions.
+      ;; If you separate your commands in a SQL file, this key will send the
+      ;; command around point, which is what you probably want.
+      "sf" 'spacemacs/sql-send-paragraph
+      "sF" 'spacemacs/sql-send-paragraph-and-focus
+      "sl" 'spacemacs/sql-send-line-and-next
+      "sL" 'spacemacs/sql-send-line-and-next-and-focus
+      "sq" 'spacemacs/sql-send-string
+      "sQ" 'spacemacs/sql-send-string-and-focus
+      "sr" 'spacemacs/sql-send-region
+      "sR" 'spacemacs/sql-send-region-and-focus
 
-        ;; listing
-        "la" 'sql-list-all
-        "lt" 'sql-list-table)
+      ;; listing
+      "la" 'sql-list-all
+      "lt" 'sql-list-table)
 
-      (spacemacs/declare-prefix-for-mode 'sql-interactive-mode "mb" "buffer")
-      (spacemacs/set-leader-keys-for-major-mode 'sql-interactive-mode
-        ;; sqli buffer
-        "br" 'sql-rename-buffer
-        "bS" 'sql-save-connection)
+    (spacemacs/declare-prefix-for-mode 'sql-interactive-mode "mb" "buffer")
+    (spacemacs/set-leader-keys-for-major-mode 'sql-interactive-mode
+      ;; sqli buffer
+      "br" 'sql-rename-buffer
+      "bS" 'sql-save-connection)
 
-      (add-hook 'sql-interactive-mode-hook
-                (lambda () (toggle-truncate-lines t)))
+    (add-hook 'sql-interactive-mode-hook
+              (lambda () (toggle-truncate-lines t)))
 
-      ;; lsp-sqls
-      (let ((path-config (cond
-                          ((equal sql-lsp-sqls-workspace-config-path 'workspace) "workspace")
-                          ((equal sql-lsp-sqls-workspace-config-path 'root) "root")
-                          (t nil))))
-        (setq lsp-sqls-workspace-config-path path-config)))))
+    ;; lsp-sqls
+    (let ((path-config (cond
+                        ((equal sql-lsp-sqls-workspace-config-path 'workspace) "workspace")
+                        ((equal sql-lsp-sqls-workspace-config-path 'root) "root")
+                        (t nil))))
+      (setq lsp-sqls-workspace-config-path path-config))))
 
 (defun sql/init-sql-indent ()
   (use-package sql-indent
@@ -216,17 +214,15 @@
   (use-package sqlup-mode
     :defer t
     :init
-    (progn
-      (add-hook 'sql-mode-hook 'sqlup-mode)
-      (unless sql-capitalize-keywords-disable-interactive
-        (add-hook 'sql-interactive-mode-hook 'sqlup-mode))
-      (spacemacs/set-leader-keys-for-major-mode 'sql-mode
-        "c" 'sqlup-capitalize-keywords-in-region))
+    (add-hook 'sql-mode-hook 'sqlup-mode)
+    (unless sql-capitalize-keywords-disable-interactive
+      (add-hook 'sql-interactive-mode-hook 'sqlup-mode))
+    (spacemacs/set-leader-keys-for-major-mode 'sql-mode
+      "c" 'sqlup-capitalize-keywords-in-region)
     :config
-    (progn
-      (spacemacs|hide-lighter sqlup-mode)
-      (setq sqlup-blacklist (append sqlup-blacklist
-                                    sql-capitalize-keywords-blacklist)))))
+    (spacemacs|hide-lighter sqlup-mode)
+    (setq sqlup-blacklist (append sqlup-blacklist
+                                  sql-capitalize-keywords-blacklist))))
 
 (defun sql/post-init-company ()
   (spacemacs//sql-setup-company))

--- a/layers/+lang/swift/packages.el
+++ b/layers/+lang/swift/packages.el
@@ -36,38 +36,36 @@
     :mode ("\\.swift\\'" . swift-mode)
     :defer t
     :init
-    (progn
-      (defun spacemacs//swift-store-initial-buffer-name (func &rest args)
-        "Store current buffer bane in bufffer local variable,
+    (defun spacemacs//swift-store-initial-buffer-name (func &rest args)
+      "Store current buffer bane in bufffer local variable,
 before activiting or switching to REPL."
-        (let ((initial-buffer (current-buffer)))
-          (apply func args)
-          (with-current-buffer swift-repl-buffer
-            (setq swift-repl-mode-previous-buffer initial-buffer))))
-      (advice-add 'swift-mode-run-repl :around #'spacemacs//swift-store-initial-buffer-name)
+      (let ((initial-buffer (current-buffer)))
+        (apply func args)
+        (with-current-buffer swift-repl-buffer
+          (setq swift-repl-mode-previous-buffer initial-buffer))))
+    (advice-add 'swift-mode-run-repl :around #'spacemacs//swift-store-initial-buffer-name)
 
-      (defun spacemacs/swift-repl-mode-hook ()
-        "Hook to run when starting an interactive swift mode repl"
-        (make-variable-buffer-local 'swift-repl-mode-previous-buffer))
-      (add-hook 'swift-repl-mode-hook 'spacemacs/swift-repl-mode-hook)
+    (defun spacemacs/swift-repl-mode-hook ()
+      "Hook to run when starting an interactive swift mode repl"
+      (make-variable-buffer-local 'swift-repl-mode-previous-buffer))
+    (add-hook 'swift-repl-mode-hook 'spacemacs/swift-repl-mode-hook)
 
-      (defun spacemacs/swift-repl-mode-switch-back ()
-        "Switch back to from REPL to editor."
-        (interactive)
-        (if swift-repl-mode-previous-buffer
-            (switch-to-buffer-other-window swift-repl-mode-previous-buffer)
-          (message "No previous buffer"))))
+    (defun spacemacs/swift-repl-mode-switch-back ()
+      "Switch back to from REPL to editor."
+      (interactive)
+      (if swift-repl-mode-previous-buffer
+          (switch-to-buffer-other-window swift-repl-mode-previous-buffer)
+        (message "No previous buffer")))
     :config
-    (progn
-      (spacemacs/set-leader-keys-for-major-mode 'swift-mode
-        "sS" 'swift-mode:run-repl      ; run or switch to an existing swift repl
-        "ss" 'swift-mode:run-repl
-        "sb" 'swift-mode:send-buffer
-        "sr" 'swift-mode:send-region)
+    (spacemacs/set-leader-keys-for-major-mode 'swift-mode
+      "sS" 'swift-mode:run-repl      ; run or switch to an existing swift repl
+      "ss" 'swift-mode:run-repl
+      "sb" 'swift-mode:send-buffer
+      "sr" 'swift-mode:send-region)
 
-      (with-eval-after-load 'swift-repl-mode-map
-        ;; Switch back to editor from REPL
-        (spacemacs/set-leader-keys-for-major-mode 'swift-repl-mode
-          "ss"  'spacemacs/swift-repl-mode-switch-back)
-        (define-key swift-repl-mode-map
-          (kbd "C-c C-z") 'spacemacs/swift-repl-mode-switch-back)))))
+    (with-eval-after-load 'swift-repl-mode-map
+      ;; Switch back to editor from REPL
+      (spacemacs/set-leader-keys-for-major-mode 'swift-repl-mode
+        "ss"  'spacemacs/swift-repl-mode-switch-back)
+      (define-key swift-repl-mode-map
+        (kbd "C-c C-z") 'spacemacs/swift-repl-mode-switch-back))))

--- a/layers/+lang/typescript/packages.el
+++ b/layers/+lang/typescript/packages.el
@@ -107,11 +107,10 @@
   (use-package typescript-mode
     :defer t
     :init
-    (progn
-      (spacemacs/typescript-safe-local-variables '(lsp tide))
-      (spacemacs/typescript-mode-init 'typescript-mode-local-vars-hook)
-      ;; init tsx locals here to get proper order 
-      (spacemacs/typescript-mode-init 'typescript-tsx-mode-local-vars-hook))
+    (spacemacs/typescript-safe-local-variables '(lsp tide))
+    (spacemacs/typescript-mode-init 'typescript-mode-local-vars-hook)
+    ;; init tsx locals here to get proper order 
+    (spacemacs/typescript-mode-init 'typescript-tsx-mode-local-vars-hook)
     :config (spacemacs/typescript-mode-config 'typescript-mode)))
 
 (defun typescript/pre-init-import-js ()

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -43,13 +43,12 @@
     :mode "_vimrc\\'"
     :defer t
     :init
-    (progn
-      (defun spacemacs//vimrc-mode-hook ()
-        "Hooked function for `vimrc-mode-hook'."
-        (highlight-numbers-mode -1)
-        (rainbow-delimiters-mode-disable)
-        (spacemacs//vimscript-setup-backend))
-      (add-hook 'vimrc-mode-hook 'spacemacs//vimrc-mode-hook))))
+    (defun spacemacs//vimrc-mode-hook ()
+      "Hooked function for `vimrc-mode-hook'."
+      (highlight-numbers-mode -1)
+      (rainbow-delimiters-mode-disable)
+      (spacemacs//vimscript-setup-backend))
+    (add-hook 'vimrc-mode-hook 'spacemacs//vimrc-mode-hook)))
 
 (defun vimscript/init-dactyl-mode ()
   (use-package dactyl-mode

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -35,10 +35,9 @@
     :mode (("\\.bat\\'" . bat-mode)
            ("\\.cmd\\'" . bat-mode))
     :init
-    (progn
-      (spacemacs/declare-prefix-for-mode 'bat-mode "me" "eval")
-      (spacemacs/declare-prefix-for-mode 'bat-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'bat-mode "mi" "insert"))
+    (spacemacs/declare-prefix-for-mode 'bat-mode "me" "eval")
+    (spacemacs/declare-prefix-for-mode 'bat-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'bat-mode "mi" "insert")
     :spacebind
     (:major
      (bat-mode
@@ -92,14 +91,13 @@
            ("\\.psm1\\'" . powershell-mode))
     :defer t
     :init
-    (progn
-      (defun powershell/define-text-objects ()
-        (spacemacs|define-text-object "$" "dollarparen" "$(" ")"))
-      (add-hook 'powershell-mode-hook 'powershell/define-text-objects)
-      (spacemacs/set-leader-keys
-        "atsp" 'powershell)
-      (spacemacs/set-leader-keys-for-major-mode 'powershell-mode
-        "rr" 'powershell-regexp-to-regex))))
+    (defun powershell/define-text-objects ()
+      (spacemacs|define-text-object "$" "dollarparen" "$(" ")"))
+    (add-hook 'powershell-mode-hook 'powershell/define-text-objects)
+    (spacemacs/set-leader-keys
+      "atsp" 'powershell)
+    (spacemacs/set-leader-keys-for-major-mode 'powershell-mode
+      "rr" 'powershell-regexp-to-regex)))
 ;; TODO
 ;; - split out powershell
 ;; - get help output with mgg (Get-Help) or Get-Help -online


### PR DESCRIPTION
Remove a level of indentation for all these progns inside use-package. The
use-package macro is already an implicit progn. To review this commit,
since there is a lot of whitespace change, use

    git diff HEAD -w

it doesn't do anything other than that.