### PR TITLE
fix: restore SPC j j to use evil-avy-goto-char-timer

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -55,8 +55,7 @@
     (setq avy-background t)
     (spacemacs/set-leader-keys
       "jb" 'avy-pop-mark
-      "jj" 'evil-avy-goto-char
-      "jJ" 'evil-avy-goto-char-2
+      "jj" 'evil-avy-goto-char-timer
       "jl" 'evil-avy-goto-line
       "ju" 'spacemacs/avy-goto-url
       "jw" 'evil-avy-goto-word-or-subword-1


### PR DESCRIPTION
Commit 4ec0b8b88f10fa9ac9c42811b65030532664d64d accidentally changed "SPC j j" to call evil-avy-goto-char. This commit reverts it back to call evil-avy-goto-char-timer, which was introduced by commit 4c231ae28220d28ae0a63634683b171b96c8444d
