### PR TITLE
Rust layer overhaul

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -338,6 +338,9 @@ In org-agenda-mode
     Gușoi)
   - Added ~SPC m r "~ for =ruby-toggle-string-quotes= (thanks to Codruț
     Constantin Gușoi)
+***** Rust
+Removed support for Racer, default backend for LSP is now rust-analizer due to
+both Racer and RLS not being maintained anymore.
 ***** Ruby on Rails
 - Key bindings:
   - New ~SPC m r f S~ to find serializer (thanks to Boris Buliga)
@@ -3477,6 +3480,8 @@ files (thanks to Daniel Nicolai)
 - Improved LSP Rust server switch functionality (thanks to Lucius Hu)
 - Added Rust GDB DAP template (thanks to Elric Milon)
 - Migrated to =rustic-mode= (thanks to Elric Milon)
+- Removed support for obsoleted =Racer= and =RLS= and made ==rust-analyzer= the
+  default (thanks to Elric Milon)
 **** Sailfish-Developer
 - Key bindings:
   - Added =sailfish-scratchbox= key bindings (thanks to Victor Polevoy):

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3476,6 +3476,7 @@ files (thanks to Daniel Nicolai)
 - Added support for Rusty Object Notation (RON) (thanks to Daniel Hutzley)
 - Improved LSP Rust server switch functionality (thanks to Lucius Hu)
 - Added Rust GDB DAP template (thanks to Elric Milon)
+- Migrated to =rustic-mode= (thanks to Elric Milon)
 **** Sailfish-Developer
 - Key bindings:
   - Added =sailfish-scratchbox= key bindings (thanks to Victor Polevoy):

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3475,6 +3475,7 @@ files (thanks to Daniel Nicolai)
   =cargo-audit=, =rustfmt=, and =clippy= (thanks to Lucius Hu)
 - Added support for Rusty Object Notation (RON) (thanks to Daniel Hutzley)
 - Improved LSP Rust server switch functionality (thanks to Lucius Hu)
+- Added Rust GDB DAP template (thanks to Elric Milon)
 **** Sailfish-Developer
 - Key bindings:
   - Added =sailfish-scratchbox= key bindings (thanks to Victor Polevoy):

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -100,9 +100,9 @@ You can call =spacemacs/lsp-rust-analyzer-reload-workspace=, which would be fast
 
 You can also set =cargo-process-reload-on-modify= to =t=, then it will automatically reload the workspace after
 one of the following is run:
-- =cargo-process-add=
-- =cargo-process-rm=
-- =cargo-process-upgrade=
+- =rustic-cargo-add=
+- =rustic-cargo-rm=
+- =rustic-cargo-upgrade=
 
 #+BEGIN_SRC elisp
   (setq-default dotspacemacs-configuration-layers
@@ -119,13 +119,6 @@ instructions can be found on the main page of [[http://doc.crates.io/index.html]
 
 #+BEGIN_SRC sh
   cargo install cargo-edit
-#+END_SRC
-
-*** cargo-audit
-[[https://github.com/RustSec/cargo-audit][cargo-audit]] audits =Cargo.lock= files for crates with security vulnerabilities.
-
-#+BEGIN_SRC sh
-  cargo install cargo-audit
 #+END_SRC
 
 *** cargo-outdated
@@ -158,18 +151,16 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | ~SPC m = =~ | reformat the buffer                                         |
 | ~SPC m b R~ | reload Rust-Analyzer workspace                              |
 | ~SPC m c .~ | repeat the last Cargo command                               |
-| ~SPC m c /~ | search for packages on crates.io with Cargo                 |
 | ~SPC m c =~ | format all project files with rustfmt                       |
 | ~SPC m c a~ | add a new dependency with cargo-edit                        |
-| ~SPC m c A~ | audit dependencies for known vulnerability with cargo-audit |
 | ~SPC m c c~ | compile project                                             |
 | ~SPC m c C~ | remove build artifacts                                      |
-| ~SPC m c d~ | generate documentation                                      |
-| ~SPC m c D~ | generate documentation and open it in default browser       |
+| ~SPC m c d~ | generate documentation and open it in default browser       |
+| ~SPC m c s~ | search the documentation                    |
 | ~SPC m c e~ | run benchmarks                                              |
-| ~SPC m c E~ | run a project example                                       |
 | ~SPC m c i~ | initialise a new project with Cargo (init)                  |
 | ~SPC m c l~ | run linter ([[https://github.com/arcnmx/cargo-clippy][cargo-clippy]])                                   |
+| ~SPC m c f~ | run linter automatic fixes ([[https://github.com/arcnmx/cargo-clippy][cargo-clippy]])                |
 | ~SPC m c n~ | create a new project with Cargo (new)                       |
 | ~SPC m c o~ | display outdated dependencies ([[https://github.com/kbknapp/cargo-outdated][cargo-outdated]])              |
 | ~SPC m c r~ | remove a dependency with cargo-edit                         |
@@ -177,13 +168,11 @@ To enable automatic buffer formatting on save, set the variable =rust-format-on-
 | ~SPC m c U~ | upgrade dependencies to LATEST version with cargo-edit      |
 | ~SPC m c v~ | check (verify) a project with Cargo                         |
 | ~SPC m c x~ | execute the default binary                                  |
-| ~SPC m c X~ | execute a specific binary                                   |
 | ~SPC m g g~ | jump to definition                                          |
 | ~SPC m h h~ | describe symbol at point                                    |
 | ~SPC m s s~ | switch to other LSP server backend                          |
 | ~SPC m t a~ | test current project                                        |
 | ~SPC m t t~ | run the current test                                        |
-| ~SPC m t b~ | run all tests in current buffe                              |
 
 ** Debugger
 Using the =dap= layer you'll get access to all the DAP key bindings, see the

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -9,16 +9,12 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#choosing-a-backend][Choosing a backend]]
-    - [[#racer][Racer]]
-    - [[#lsp][LSP]]
-      - [[#switch-to-another-lsp-server][Switch to another LSP server]]
-      - [[#autocompletion][Autocompletion]]
-      - [[#debugger-dap-integration][Debugger (dap integration)]]
-      - [[#automatically-reload-workspace][Automatically Reload Workspace]]
+  - [[#lsp][LSP]]
+    - [[#autocompletion][Autocompletion]]
+    - [[#debugger-dap-integration][Debugger (dap integration)]]
+    - [[#automatically-reload-workspace][Automatically Reload Workspace]]
   - [[#cargo][Cargo]]
     - [[#cargo-edit][cargo-edit]]
-    - [[#cargo-audit][cargo-audit]]
     - [[#cargo-outdated][cargo-outdated]]
   - [[#rustfmt][Rustfmt]]
   - [[#clippy][Clippy]]
@@ -29,7 +25,7 @@
 This layer supports [[https://www.rust-lang.org][Rust]] development in Spacemacs.
 
 ** Features:
-- Auto-completion and navigation support through [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] or [[https://github.com/phildawes/racer][Racer]]
+- Auto-completion and navigation support through [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]]
 - Interactive debugger using [[https://github.com/emacs-lsp/dap-mode][dap-mode]]
 - Support for the Rust package manager [[http://doc.crates.io/index.html][Cargo]]
 - Support for [[https://github.com/nabero/ron-mode][Rusty Object Notation (RON)]]
@@ -40,61 +36,16 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =rust= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** Choosing a backend
-To choose a default backend set the layer variable =rust-backend=:
+** LSP
+The =lsp= backend will be automatically enabled if the layer =lsp= is used.
 
-#+BEGIN_SRC elisp
-  (rust :variables rust-backend 'racer)
-#+END_SRC
-
-Alternatively the =lsp= backend will be automatically chosen if the layer =lsp=
-is used and you did not specify any value for =rust-backend=.
-
-Backend can be chosen on a per project basis using directory local variables
-(files named =.dir-locals.el= at the root of a project), an example to use the
-=lsp= backend:
-
-#+BEGIN_SRC elisp
-  ;;; Directory Local Variables
-  ;;; For more information see (info "(emacs) Directory Variables")
-
-  ((rust-mode (rust-backend . lsp)))
-#+END_SRC
-
-*Note:* you can easily add a directory local variable with ~SPC f v d~.
-
-*** Racer
-You must install [[https://github.com/phildawes/racer][Racer]] to use this backend. Make sure the =racer= binary is available in
-your =PATH= and to set the environment variable =RUST_SRC_PATH=, as described in
-the [[https://github.com/phildawes/racer#installation][installation instructions]].
-
+*** Autocompletion
 To enable auto-completion, ensure that the =auto-completion= layer is enabled.
 
-*** LSP
-You must add =lsp= to the existing =dotspacemacs-configuration-layers= in your =~/.spacemacs=.
-
-Consult the installation command for the desired language server found at [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] for instructions.
-
-The default LSP server for Rust is [[https://github.com/rust-lang/rls][rls]], i.e. rust language server.
-To choose the experimental [[https://github.com/rust-analyzer/rust-analyzer][rust-analyzer]], you need to set the layer variable =lsp-rust-server= of =lsp= layer:
-
-#+BEGIN_SRC elisp
-  (setq-default dotspacemacs-configuration-layers
-                 '(lsp :variables lsp-rust-server 'rust-analyzer))
-#+END_SRC
-
-**** Switch to another LSP server
-If both =rls= and =rust-analyzer= server are installed, you can press ~SPC m s s~ to switch to another LSP server backend.
-
-**** Autocompletion
-To enable auto-completion, ensure that the =auto-completion= layer is enabled.
-
-By default, currently [[https://github.com/phildawes/racer][Racer]] is the only code completion backend of [[https://github.com/rust-lang/rls][rls]], so you also need to install it.
-
-**** Debugger (dap integration)
+*** Debugger (dap integration)
 To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are on Linux or download it manually from [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][Native Debug]] and adjust =dap-gdb-lldb-path=.
 
-**** Automatically Reload Workspace
+*** Automatically Reload Workspace
 When the LSP server is =rust-analyzer=, it may needs to reload the workspace to pickup changes made in =Cargo.toml=.
 You can call =spacemacs/lsp-rust-analyzer-reload-workspace=, which would be faster than restarting the LSP backend.
 
@@ -106,8 +57,7 @@ one of the following is run:
 
 #+BEGIN_SRC elisp
   (setq-default dotspacemacs-configuration-layers
-                 '(lsp :variables lsp-rust-server 'rust-analyzer
-                                  cargo-process-reload-on-modify t))
+                 '(lsp :variables cargo-process-reload-on-modify t))
 #+END_SRC
 
 ** Cargo

--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -23,7 +23,7 @@
 
 ;; Variables
 
-(spacemacs|define-jump-handlers rust-mode)
+(spacemacs|define-jump-handlers rustic-mode)
 
 (defvar rust-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'racer)
   "The backend to use for completion.

--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -25,10 +25,5 @@
 
 (spacemacs|define-jump-handlers rustic-mode)
 
-(defvar rust-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'racer)
-  "The backend to use for completion.
-Possible values are `lsp' `racer'.
-If `nil' then `racer' is the default backend unless `lsp' layer is used.")
-
 (defvar cargo-process-reload-on-modify nil
   "When non-nil, reload workspace after a cargo-process command modifies Cargo.toml.")

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -55,8 +55,8 @@
   (if (configuration-layer/layer-used-p 'lsp)
       (progn
         (lsp-deferred)
-        (spacemacs/declare-prefix-for-mode 'rust-mode "ms" "switch")
-        (spacemacs/set-leader-keys-for-major-mode 'rust-mode
+        (spacemacs/declare-prefix-for-mode 'rustic-mode "ms" "switch")
+        (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
           "ss" 'spacemacs/lsp-rust-switch-server
           (if lsp-use-upstream-bindings "wR" "bR") 'spacemacs/lsp-rust-analyzer-reload-workspace))
     (spacemacs//lsp-layer-not-installed-message)))
@@ -136,7 +136,7 @@ When one of the following is true, it won't reload:
   "Setup racer auto-completion."
   (spacemacs|add-company-backends
     :backends company-capf
-    :modes rust-mode
+    :modes rustic-mode
     :variables company-tooltip-align-annotations t))
 
 (defun spacemacs/racer-describe ()

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -33,7 +33,7 @@
     (spacemacs//rust-setup-racer-company)))
 
 (defun spacemacs//rust-setup-dap ()
-  "Conditionally setup elixir DAP integration."
+  "Conditionally setup rust DAP integration."
   ;; currently DAP is only available using LSP
   (when (eq rust-backend 'lsp)
     (spacemacs//rust-setup-lsp-dap)))

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -63,7 +63,20 @@
 
 (defun spacemacs//rust-setup-lsp-dap ()
   "Setup DAP integration."
-  (require 'dap-gdb-lldb))
+  (require 'dap-cpptools)
+  (require 'dap-lldb)
+  (require 'dap-gdb-lldb)
+  (dap-register-debug-template "Rust::GDB Run Configuration"
+                               (list :type "gdb"
+                                     :request "launch"
+                                     :name "GDB::Run"
+                                     :gdbpath "rust-gdb"
+                                     :target nil
+                                     :dap-compilation "cargo build"
+                                     :dap-compilation-dir "${workspaceFolder}"
+                                     :cwd "${workspaceFolder}"
+                                     ))
+  )
 
 (defun spacemacs/lsp-rust-analyzer-reload-workspace ()
   "Reload workspaces to pick up changes in Cargo.toml.

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -23,20 +23,12 @@
 
 (defun spacemacs//rust-setup-backend ()
   "Conditionally setup rust backend."
-  (pcase rust-backend
-    ('racer (spacemacs//rust-setup-racer))
-    ('lsp (spacemacs//rust-setup-lsp))))
-
-(defun spacemacs//rust-setup-company ()
-  "Conditionally setup company based on backend."
-  (when (eq rust-backend 'racer)
-    (spacemacs//rust-setup-racer-company)))
+  (spacemacs//rust-setup-lsp))
 
 (defun spacemacs//rust-setup-dap ()
   "Conditionally setup rust DAP integration."
   ;; currently DAP is only available using LSP
-  (when (eq rust-backend 'lsp)
-    (spacemacs//rust-setup-lsp-dap)))
+  (spacemacs//rust-setup-lsp-dap))
 
 
 ;; lsp
@@ -125,27 +117,6 @@ When one of the following is true, it won't reload:
     (call-interactively 'cargo-process-upgrade)
     (spacemacs//cargo-maybe-reload)))
 
-
-;; racer
-
-(defun spacemacs//rust-setup-racer ()
-  "Setup racer backend"
-  (racer-mode))
-
-(defun spacemacs//rust-setup-racer-company ()
-  "Setup racer auto-completion."
-  (spacemacs|add-company-backends
-    :backends company-capf
-    :modes rustic-mode
-    :variables company-tooltip-align-annotations t))
-
-(defun spacemacs/racer-describe ()
-  "Show a *Racer Help* buffer for the function or type at point.
-If `help-window-select' is non-nil, also select the help window."
-  (interactive)
-  (let ((window (racer-describe)))
-    (when help-window-select
-      (select-window window))))
 
 ;; Misc
 

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -23,7 +23,6 @@
 
 (defconst rust-packages
   '(
-    company
     counsel-gtags
     dap-mode
     ggtags
@@ -32,10 +31,6 @@
     smartparens
     toml-mode))
 
-
-(defun rust/post-init-company ()
-  ;; backend specific
-  (spacemacs//rust-setup-company))
 
 (defun rust/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'rustic-mode))

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -23,104 +23,90 @@
 
 (defconst rust-packages
   '(
-    cargo
     company
     counsel-gtags
     dap-mode
-    flycheck
-    (flycheck-rust :requires flycheck)
     ggtags
     ron-mode
-    (racer :toggle (eq rust-backend 'racer))
-    rust-mode
+    rustic
     smartparens
     toml-mode))
 
-(defun rust/init-cargo ()
-  (use-package cargo
-    :defer t
-    :init
-    (spacemacs/declare-prefix-for-mode 'rust-mode "mc" "cargo")
-    (spacemacs/declare-prefix-for-mode 'rust-mode "mt" "tests")
-    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-      "c." 'spacemacs/cargo-process-repeat
-      "c/" 'cargo-process-search
-      "c=" 'cargo-process-fmt
-      "ca" 'spacemacs/cargo-process-add
-      "cA" 'cargo-process-audit
-      "cc" 'cargo-process-build
-      "cC" 'cargo-process-clean
-      "cd" 'cargo-process-doc
-      "cD" 'cargo-process-doc-open
-      "ce" 'cargo-process-bench
-      "cE" 'cargo-process-run-example
-      "ci" 'cargo-process-init
-      "cl" 'cargo-process-clippy
-      "cn" 'cargo-process-new
-      "co" 'cargo-process-outdated
-      "cr" 'spacemacs/cargo-process-rm
-      "cu" 'cargo-process-update
-      "cU" 'spacemacs/cargo-process-upgrade
-      "cv" 'cargo-process-check
-      "cx" 'cargo-process-run
-      "cX" 'cargo-process-run-bin
-      "ta" 'cargo-process-test
-      "tt" 'cargo-process-current-test
-      "tb" 'cargo-process-current-file-tests)))
 
 (defun rust/post-init-company ()
   ;; backend specific
   (spacemacs//rust-setup-company))
 
 (defun rust/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'rust-mode))
+  (spacemacs/counsel-gtags-define-keys-for-mode 'rustic-mode))
 
 (defun rust/pre-init-dap-mode ()
   (when (eq rust-backend 'lsp)
-    (add-to-list 'spacemacs--dap-supported-modes 'rust-mode)
-    (add-hook 'rust-mode-local-vars-hook #'spacemacs//rust-setup-dap)))
-
-(defun rust/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'rust-mode))
-
-(defun rust/init-flycheck-rust ()
-  (use-package flycheck-rust
-    :defer t
-    :init (add-hook 'flycheck-mode-hook #'flycheck-rust-setup)))
+    (add-to-list 'spacemacs--dap-supported-modes 'rustic-mode)
+    (add-hook 'rustic-mode-local-vars-hook #'spacemacs//rust-setup-dap)))
 
 (defun rust/post-init-ggtags ()
-  (add-hook 'rust-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
+  (add-hook 'rustic-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun rust/init-racer ()
-  (use-package racer
+(defun rust/init-rustic ()
+  (use-package rustic
     :defer t
-    :commands racer-mode
-    :config
-    (spacemacs/add-to-hook 'rust-mode-hook '(racer-mode))
-    (spacemacs/add-to-hook 'racer-mode-hook '(eldoc-mode))
-    (add-to-list 'spacemacs-jump-handlers-rust-mode 'racer-find-definition)
-    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-      "hh" 'spacemacs/racer-describe)
-    (spacemacs|hide-lighter racer-mode)
-    (evilified-state-evilify-map racer-help-mode-map
-      :mode racer-help-mode)))
-
-(defun rust/init-rust-mode ()
-  (use-package rust-mode
-    :defer t
+    :after (lsp-mode flycheck)
+    :mode ("\\.rs\\'" . rustic-mode)
     :init
-    (spacemacs/add-to-hook 'rust-mode-hook '(spacemacs//rust-setup-backend))
-    (spacemacs/declare-prefix-for-mode 'rust-mode "mg" "goto")
-    (spacemacs/declare-prefix-for-mode 'rust-mode "mh" "help")
-    (spacemacs/declare-prefix-for-mode 'rust-mode "m=" "format")
-    (spacemacs/set-leader-keys-for-major-mode 'rust-mode
-      "==" 'rust-format-buffer
-      "q" 'spacemacs/rust-quick-run)))
+    (progn
+      (spacemacs/add-to-hook 'rustic-mode-hook '(spacemacs//rust-setup-backend))
+
+      ;; (push 'rustic-clippy flycheck-checkers)
+
+      (spacemacs/declare-prefix-for-mode 'rustic-mode "mc" "cargo")
+      (spacemacs/declare-prefix-for-mode 'rustic-mode "mt" "tests")
+      (spacemacs/declare-prefix-for-mode 'rustic-mode "mg" "goto")
+      (spacemacs/declare-prefix-for-mode 'rustic-mode "mh" "help")
+      (spacemacs/declare-prefix-for-mode 'rustic-mode "m=" "format")
+      (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
+        "c." 'spacemacs/rustic-cargo-repeat
+        "c=" 'rustic-cargo-fmt
+        "ca" 'rustic-cargo-add
+        "cc" 'rustic-cargo-build
+        "cC" 'rustic-cargo-clean
+        "cd" 'rustic-cargo-doc
+        "cs" 'rustic-cargo-doc-search
+        "ce" 'rustic-cargo-bench
+        "ci" 'rustic-cargo-init
+        "cl" 'rustic-cargo-clippy
+        "cf" 'rustic-cargo-clippy-fix
+        "cn" 'rustic-cargo-new
+        "co" 'rustic-cargo-outdated
+        "cr" 'spacemacs/rustic-cargo-rm
+        "cu" 'rustic-cargo-update
+        "cU" 'spacemacs/rustic-cargo-upgrade
+        "cv" 'rustic-cargo-check
+        "cx" 'rustic-cargo-run
+        "ta" 'rustic-cargo-test
+        "tt" 'rustic-cargo-current-test
+
+        "=j" 'lsp-rust-analyzer-join-lines
+        "==" 'lsp-format-buffer
+        "Ti" 'lsp-inlay-hints-mode
+        "bD" 'lsp-rust-analyzer-status
+        "bS" 'lsp-rust-switch-server
+        "gp" 'lsp-rust-find-parent-module
+        "gg" 'lsp-find-definition
+        "hm" 'lsp-rust-analyzer-expand-macro
+        "hs" 'lsp-rust-analyzer-syntax-tree
+        "v" 'lsp-extend-selection
+
+        "," 'lsp-rust-analyzer-rerun
+        "."  'lsp-rust-analyzer-run))))
+
+(defun rust/post-init-rustic ()
+  (spacemacs/enable-flycheck 'rustic-mode))
 
 (defun rust/post-init-smartparens ()
   (with-eval-after-load 'smartparens
     ;; Don't pair lifetime specifiers
-    (sp-local-pair 'rust-mode "'" nil :actions nil)))
+    (sp-local-pair 'rustic-mode "'" nil :actions nil)))
 
 (defun rust/init-toml-mode ()
   (use-package toml-mode

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2300,7 +2300,7 @@ Features:
 This layer supports [[https://www.rust-lang.org][Rust]] development in Spacemacs.
 
 Features:
-- Auto-completion and navigation support through [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] or [[https://github.com/phildawes/racer][Racer]]
+- Auto-completion and navigation support through [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]]
 - Interactive debugger using [[https://github.com/emacs-lsp/dap-mode][dap-mode]]
 - Support for the Rust package manager [[http://doc.crates.io/index.html][Cargo]]
 - Support for [[https://github.com/nabero/ron-mode][Rusty Object Notation (RON)]]
@@ -3180,7 +3180,7 @@ Features:
 ** Tide Layer
 [[file:+tools/tide/README.org][+tools/tide/README.org]]
 
-This layer installs [[https://github.com/ananthakumaran/tide][tide]] package which allows communication with 
+This layer installs [[https://github.com/ananthakumaran/tide][tide]] package which allows communication with
 [[https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29][standalone typescript server]] =tsserver= for JavaScript/TypeScript development.
 
 Features:


### PR DESCRIPTION
- Switch to Rustic, a more complete Rust mode
- Make rust-analizer backend the default and remove support for RLS and Racer (both unmantained and obsoleted by rust-analyzer)
- Add GDB Rust DAP template