### PR TITLE
*layers/+spacemacs/spacemacs-editing: dired-quick-sort work with dired sort

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -111,7 +111,16 @@
         (let ((dired-quick-sort-suppress-setup-warning 'message))
           (dired-quick-sort-setup))))
     :config
-    (evil-define-key 'normal dired-mode-map "s" 'hydra-dired-quick-sort/body)))
+    (evil-define-key 'normal dired-mode-map "s" 'hydra-dired-quick-sort/body)
+    ;; workaround for https://gitlab.com/xuhdev/dired-quick-sort/-/issues/14
+    (define-advice dired-sort-toggle (:before ())
+      "Recover `dired-actual-switches' with `dired-listing-switches' when long
+      option \"--sort=...\" exists, and convert \"--sort=time\" to \"-t\"."
+      (when (string-match-p "--sort=" dired-actual-switches)
+        (setq dired-actual-switches
+              (concat dired-listing-switches
+                      (when (string-match-p "--sort=time" dired-actual-switches)
+                        " -t")))))))
 
 (defun spacemacs-editing/init-drag-stuff ()
   (use-package drag-stuff


### PR DESCRIPTION
Hi,
Spacemacs integrate the `dired-quick-sort` for default but there is a long time bug that the `dired-quick-sort` package will break the `dired-sort-toggle-or-edit` for the buildin `dired` works with the short `-t` option while the `dired-quick-sort` use the long sort option `--sort=...`.
Quick reproducing steps:
1. find a dir in Spacemacs, like `(find-file "~/")`
2. in the `dired` buffer, press `S` for `dired-quick-sort`, try any option, then press `q` to back dired
3. press `s` for `dired-sort-toggle-or-edit`, the sort function will be different with the vallina emacs.

Current patch will makes the `dired-quick-sort` work with `dired` smoothly.
