### PR TITLE
[org] Fix RET and other key bindings in org-lint report buffer

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -479,7 +479,11 @@ Will work on both org-mode and any mode that accepts plain html."
       ("g" org-babel-goto-named-src-block)
       ("z" recenter-top-bottom)
       ("e" org-babel-execute-maybe)
-      ("'" org-edit-special :exit t))))
+      ("'" org-edit-special :exit t))
+
+    (evilified-state-evilify-map org-lint--report-mode-map
+      :mode org-lint--report-mode
+      :eval-after-load org-lint)))
 
 (defun org/init-org-agenda ()
   (use-package org-agenda


### PR DESCRIPTION
Before this change, the report buffer defaults to evil-motion-state,
which doesn't support RET to go to the source of the lint error.