### PR TITLE
*core/core-load-paths.el: remove unused variable pcache-directory

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -110,8 +110,6 @@
 ;; TODO: Should also catch any IO error such as permission error (Apr 25 2021 Lucius)
 (unless (file-exists-p spacemacs-cache-directory)
   (make-directory spacemacs-cache-directory))
-
-(setq pcache-directory (concat spacemacs-cache-directory "pcache/"))
 
 ;;;; Load Paths
 (dolist (subdirectory '(nil "libs/" "libs/spacemacs-theme/" "libs/forks/"))


### PR DESCRIPTION
The variable `pcache-directory` is not used (Emacs, Spacemacs or packages), remove it.