### PR TITLE
*core/core-configuration-layer.el: lazy load the quelpa package

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -446,16 +446,17 @@ cache folder.")
     (setq package-enable-at-startup nil)
     (package-initialize 'noactivate)))
 
+(autoload 'quelpa "quelpa")
+(autoload 'quelpa-checkout "quelpa")
 (defun configuration-layer//configure-quelpa ()
   "Configure `quelpa' package."
-  (setq quelpa-verbose init-file-debug
-        quelpa-dir (concat spacemacs-cache-directory "quelpa/")
-        quelpa-build-dir (expand-file-name "build" quelpa-dir)
-        quelpa-persistent-cache-file (expand-file-name "cache" quelpa-dir)
-        quelpa-update-melpa-p nil)
-  (require 'quelpa)
-  (when (eq (quelpa--tar-type) 'gnu)
-    (setq quelpa-build-explicit-tar-format-p t)))
+  (with-eval-after-load 'quelpa
+    (setq quelpa-verbose init-file-debug
+          quelpa-dir (concat spacemacs-cache-directory "quelpa/")
+          quelpa-build-dir (expand-file-name "build" quelpa-dir)
+          quelpa-persistent-cache-file (expand-file-name "cache" quelpa-dir)
+          quelpa-update-melpa-p nil
+          quelpa-build-explicit-tar-format-p (eq (quelpa--tar-type) 'gnu))))
 
 (defun configuration-layer//make-quelpa-recipe (pkg)
   "Read recipe in PKG if :fetcher is local, then turn it to a correct file recepe.


### PR DESCRIPTION
The `quelpa` package is used for installing packages.
After packages installed, Spacemacs regular startup with `dotspacemacs-check-for-update` be `nil`, the `quelpa` package is actually not used.
Currently Spacemacs always require the `quelpa` package and it cost ~0.26 second on my PC.
> require: quelpa 0.26seconds

This patch will mark the `quelpa` functions to be `autoload` for lazy loading and remove the direct loading code `(require 'quelpa)` in `configuration-layer//configure-quelpa`, it can improve the startup speed.

Please help review it. Thanks.