### PR TITLE
Add support for Android emacs

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -34,6 +34,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 * Release 0.300.x
 ** 0.300.0
 *** Hot new feature
+- Add support for Android emacs.
 - Extensive use of lazy loading of packages and other tricks to reduce Spacemacs
   startup time. In most cases you should see a noticable improvement in load
   time and smoothness in startup. We also added the time spent to load your

--- a/core/core-env.el
+++ b/core/core-env.el
@@ -55,7 +55,8 @@ current contents of the file will be overwritten."
       (let ((shell-command-switches (cond
                                      ((or(eq system-type 'darwin)
                                          (eq system-type 'cygwin)
-                                         (eq system-type 'gnu/linux))
+                                         (eq system-type 'gnu/linux)
+                                         (eq system-type 'android))
                                       ;; execute env twice, once with a
                                       ;; non-interactive login shell and
                                       ;; once with an interactive shell
@@ -66,7 +67,8 @@ current contents of the file will be overwritten."
             (tmpfile (make-temp-file spacemacs-env-vars-file))
             (executable (cond ((or(eq system-type 'darwin)
                                   (eq system-type 'cygwin)
-                                  (eq system-type 'gnu/linux)) "env")
+                                  (eq system-type 'gnu/linux)
+                                  (eq system-type 'android)) "env")
                               ((eq system-type 'windows-nt) "set"))))
         (insert
          (concat

--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -56,6 +56,9 @@ The return value is nil if no font was found, truthy otherwise."
             (`gnu/linux
              (setq fallback-font-name "NanumGothic")
              (setq fallback-font-name2 "NanumGothic"))
+            (`android
+             (setq fallback-font-name "NanumGothic")
+             (setq fallback-font-name2 "NanumGothic"))
             (`darwin
              (setq fallback-font-name "Arial Unicode MS")
              (setq fallback-font-name2 "Arial Unicode MS"))

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -30,8 +30,11 @@ values."
 
 (defun spacemacs/system-is-mac ()
   (eq system-type 'darwin))
+
 (defun spacemacs/system-is-linux ()
-  (eq system-type 'gnu/linux))
+ (or  (eq system-type 'gnu/linux)
+      (eq system-type 'android)))
+ 
 (defun spacemacs/system-is-mswindows ()
   (eq system-type 'windows-nt))
 


### PR DESCRIPTION
Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

Add android specific code to core-env.el, core-funcs.el, core-fonts-support.el.

This is for the android APKs published in the termux subdirectory at https://sourceforge.net/projects/android-ports-for-gnu-emacs/.
