### PR TITLE
Remove references to linum-mode, which is no longer supported

### DIFF
--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -40,7 +40,6 @@
     erc-view-log
     (erc-yank :location local :excluded t)
     erc-yt
-    linum
     persp-mode
     window-purpose
     ))
@@ -242,10 +241,6 @@
 (defun erc/init-erc-terminal-notifier ()
   (use-package erc-terminal-notifier
     :if (executable-find "terminal-notifier")))
-
-(defun erc/post-init-linum ()
-  (spacemacs/add-to-hooks 'spacemacs/no-linum '(erc-mode-hook
-                                                erc-insert-pre-hook)))
 
 (defun erc/pre-init-persp-mode ()
   (spacemacs|use-package-add-hook persp-mode

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -28,7 +28,6 @@
     alert
     emoji-cheat-sheet-plus
     flyspell
-    linum
     persp-mode
     slack
     window-purpose))
@@ -43,9 +42,6 @@
 
 (defun slack/post-init-flyspell ()
   (add-hook 'lui-mode-hook 'flyspell-mode))
-
-(defun slack/post-init-linum ()
-  (add-hook 'slack-mode-hook 'spacemacs/no-linum))
 
 (defun slack/pre-init-persp-mode ()
   (spacemacs|use-package-add-hook persp-mode

--- a/layers/+lang/restructuredtext/packages.el
+++ b/layers/+lang/restructuredtext/packages.el
@@ -26,9 +26,6 @@
     auto-complete
     ;; Disabled due to package is not longer maintained
     ;; (auto-complete-rst :requires auto-complete)
-
-    ;; Linum is deprecated, use nlinum layer or native line numbers
-    ;; linum
     (rst :location built-in)
     (rst-directives :location local)
     (rst-lists :location local)
@@ -45,12 +42,6 @@
 ;;                auto-complete-rst-init)
 ;;     :init (spacemacs/add-to-hook 'rst-mode-hook '(auto-complete-rst-init
 ;;                                                   auto-complete-rst-add-sources))))
-
-;; (defun restructuredtext/post-init-linum ()
-;;   ;; important auto-complete work-around to be applied to make both linum
-;;   ;; and auto-complete to work together
-;;   (when (configuration-layer/package-used-p 'auto-complete)
-;;     (add-hook 'rst-mode-hook 'ac-linum-workaround t)))
 
 (defun restructuredtext/init-rst-directives ()
   (use-package rst-directives))

--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -2,7 +2,7 @@
 
 #+TAGS: layer|misc|spacemacs
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 
@@ -28,7 +28,6 @@ defaults.
   - hi-lock
   - image-mode
   - imenu
-  - linum (only in Emacs 25.x and older)
   - occur-mode
   - package-menu
   - page-break-lines

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -348,25 +348,6 @@
                         lazy-loading-line-numbers)
                     (global-display-line-numbers-mode)))))))
 
-(defun spacemacs-defaults/init-linum ()
-  (use-package linum
-    :init
-    (setq linum-format "%4d")
-    (spacemacs|add-toggle line-numbers
-      :mode linum-mode
-      :documentation "Show the line numbers."
-      :evil-leader "tn")
-    (advice-add #'linum-update-window
-                :after #'spacemacs//linum-update-window-scale-fix)
-    (advice-add #'linum-on
-                :around #'spacemacs//linum-on)
-    :config
-    (when (spacemacs//linum-backward-compabitility)
-      (add-hook 'prog-mode-hook 'linum-mode)
-      (add-hook 'text-mode-hook 'linum-mode))
-    (when dotspacemacs-line-numbers
-      (global-linum-mode))))
-
 (defun spacemacs-defaults/init-occur-mode ()
   (evilified-state-evilify-map occur-mode-map
     :mode occur-mode))

--- a/layers/+spacemacs/spacemacs-evil/README.org
+++ b/layers/+spacemacs/spacemacs-evil/README.org
@@ -2,7 +2,7 @@
 
 #+TAGS: layer|misc|spacemacs
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
@@ -14,7 +14,6 @@ throughout the entirety of Spacemacs.
 
 ** Features:
 - Add evil tutorial with =evil-tutor=
-- Add relative line number with =linum-relative= (only in Emacs 25.x and older)
 - Add escaping under ~fd~ by default with =evil-escape=
 - Add occurrences count in mode-line when searching a buffer
 - Add support for lisp structure manipulation with =evil-lisp-state=

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -166,7 +166,6 @@ is achieved by adding the relevant text properties."
 (defun spacemacs//init-eshell ()
   "Stuff to do when enabling eshell."
   (setq pcomplete-cycle-completions nil)
-  (if (bound-and-true-p linum-mode) (linum-mode -1))
   ;; autojump to prompt line if not on one already
   (add-hook 'evil-insert-state-entry-hook
             'spacemacs//eshell-auto-end nil t)

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1,6 +1,6 @@
 #+TITLE: Spacemacs layers list
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
 - [[#chats][Chats]]
   - [[#erc][ERC]]
@@ -844,7 +844,6 @@ Features:
   - hi-lock
   - image-mode
   - imenu
-  - linum (only in Emacs 25.x and older)
   - occur-mode
   - package-menu
   - page-break-lines
@@ -916,7 +915,6 @@ throughout the entirety of Spacemacs.
 
 Features:
 - Add evil tutorial with =evil-tutor=
-- Add relative line number with =linum-relative= (only in Emacs 25.x and older)
 - Add escaping under ~fd~ by default with =evil-escape=
 - Add occurrences count in mode-line when searching a buffer
 - Add support for lisp structure manipulation with =evil-lisp-state=
@@ -3180,7 +3178,7 @@ Features:
 ** Tide Layer
 [[file:+tools/tide/README.org][+tools/tide/README.org]]
 
-This layer installs [[https://github.com/ananthakumaran/tide][tide]] package which allows communication with 
+This layer installs [[https://github.com/ananthakumaran/tide][tide]] package which allows communication with
 [[https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29][standalone typescript server]] =tsserver= for JavaScript/TypeScript development.
 
 Features:


### PR DESCRIPTION
Linum was only used in Emacs 25.x and older, which Spacemacs no longer supports.  The code in spacemacs-defaults/init-linum was dead anyway, since spacemacs-defaults-packages doesn't include linum.