### PR TITLE
*layers/+spacemacs/spacemacs-defaults: local help-fns+ work on emacs-27

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/README.org
+++ b/layers/+spacemacs/spacemacs-defaults/README.org
@@ -24,7 +24,7 @@ defaults.
   - easypg
   - ediff
   - eldoc
-  - help-fns+
+  - help-fns+ (only in Emacs 27.x and older)
   - hi-lock
   - image-mode
   - imenu

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -419,6 +419,7 @@
   "hdc" 'describe-char
   "hdf" 'describe-function
   "hdk" 'describe-key
+  "hdK" 'describe-keymap
   "hdl" 'spacemacs/describe-last-keys
   "hdp" 'describe-package
   "hdP" 'configuration-layer/describe-package

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -38,7 +38,8 @@
     (electric-indent-mode :location built-in)
     (ediff :location built-in)
     (eldoc :location built-in)
-    (help-fns+ :location (recipe :fetcher local))
+    (help-fns+ :location local
+               :toggle (not (fboundp 'describe-keymap))) ; built in emacs28+
     (hi-lock :location built-in)
     (image-mode :location built-in)
     (imenu :location built-in)
@@ -230,7 +231,6 @@
   (use-package help-fns+
     :commands (describe-keymap)
     :init
-    (spacemacs/set-leader-keys "hdK" 'describe-keymap)
     (advice-add 'help-do-xref :after (lambda (_pos _func _args) (setq-local tab-width 8)))))
 
 (defun spacemacs-defaults/init-hi-lock ()


### PR DESCRIPTION
Hi,

The Spacemacs use the `describe-keymap` from its local `help-fns+` package, currently the function `describe-keymap` already exists in emacs-28+, so use the `:toggle` to contol the `help-fns+` package.