### PR TITLE
[osx] Fix osx-use-option-as-meta when set to nil

### DIFF
--- a/layers/+os/osx/config.el
+++ b/layers/+os/osx/config.el
@@ -46,7 +46,7 @@
    Possible values are `super' `meta' `hyper' `alt' `none'.
    Default: `meta'.
    For backwards compatibility the variable `osx-use-option-as-meta'
-   takes precedence is set to t.")
+   takes precedence if set to t.")
 (defvar osx-function-as nil
   "Sets the key binding of the `FUNCTION' key on macOS.
    Possible values are `super' `meta' `hyper' `alt' `nil'.

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -47,7 +47,7 @@
 
   ;; Backwards compatibility
   (cl-case osx-use-option-as-meta
-    (nil (setf osx-option-as 'none))
+    ((nil) (setf osx-option-as 'none))
     (deprecated nil)
     (t (setf osx-option-as 'meta)))
 


### PR DESCRIPTION
cl-case warns about this particular usage: nil cannot be matched
without enclosing it in a list, since it represents the list of no
possible keys.