### PR TITLE
*layers/+tools/lsp/packages.el: remove obsolated variable "lsp-prefer-capf"

### DIFF
--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -47,7 +47,6 @@
     (if lsp-use-upstream-bindings
         (spacemacs/lsp-bind-upstream-keys)
       (spacemacs/lsp-bind-keys))
-    (setq lsp-prefer-capf t)
     ;; This sets the lsp indentation for all modes derived from web-mode.
     (add-to-list 'lsp--formatting-indent-alist '(web-mode . web-mode-markup-indent-offset))
     (add-hook 'lsp-after-open-hook (lambda ()


### PR DESCRIPTION
The variable `lsp-prefer-capf` is obsolated since lsp 7.1. remove it.