### PR TITLE
*layers/+lang/shell-scripts: make buffer file executable after buffer saved

### DIFF
--- a/layers/+lang/shell-scripts/config.el
+++ b/layers/+lang/shell-scripts/config.el
@@ -32,6 +32,10 @@ When `lsp' layer is used, defaults to `lsp'.")
 (defvar shell-scripts-format-on-save nil
   "If non-nil, automatically format code with shfmt on save.")
 
+(defvar shell-scripts-mark-executable-after-save
+  (not (spacemacs/system-is-mswindows))
+  "If non-nil, automatically changes file to executable after buffer saved.")
+
 (defcustom shell-scripts-shfmt-args ()
   "Arguments passed to shfmt."
   :type '(list string))

--- a/layers/+lang/shell-scripts/funcs.el
+++ b/layers/+lang/shell-scripts/funcs.el
@@ -49,3 +49,11 @@
   (require 'insert-shebang)
   (insert-shebang-get-extension-and-insert
    (file-name-nondirectory (buffer-file-name))))
+
+(defun spacemacs/scripts-make-buffer-file-executable-maybe ()
+  "Make buffer file executable when `shell-scripts-mark-executable-after-save' is
+`t' and the shebang exists after saved a `sh-mode' buffer."
+  (interactive)
+  (when (and (eq major-mode 'sh-mode)
+             shell-scripts-mark-executable-after-save)
+    (executable-make-buffer-file-executable-if-script-p)))

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -96,7 +96,8 @@
                  (string-match-p "\\.zsh\\'" buffer-file-name))
         (sh-set-shell "zsh")))
     (add-hook 'sh-mode-hook 'spacemacs//setup-shell)
-    (add-hook 'sh-mode-hook 'spacemacs//shell-scripts-setup-backend)))
+    (add-hook 'sh-mode-hook 'spacemacs//shell-scripts-setup-backend)
+    (add-hook 'after-save-hook 'spacemacs/scripts-make-buffer-file-executable-maybe)))
 
 (defun shell-scripts/init-shfmt ()
   (use-package shfmt


### PR DESCRIPTION
Hi,

This patch try to make the buffer file to be excutable after buffer saved, the conditions are:
1. on *nix;
2. shell script mode
3. shebang exists (no shebang imply it may be a library shell script).

Please help review it, thanks.