### PR TITLE
*layers/+lang/python/funcs.el: use the interpreter basename

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -155,9 +155,9 @@ as the pyenv version then also return nil. This works around https://github.com/
 ROOT-DIR should be the directory path for the environment, `nil' for clean up."
   (when (or (null python-shell-interpreter)
             (equal python-shell-interpreter spacemacs--python-shell-interpreter-origin))
-    (if-let* ((root-dir)
-              (default-directory root-dir))
-        (if-let* ((ipython (spacemacs/pyenv-executable-find "ipython"))
+    (if-let* ((default-directory root-dir))
+        (if-let* ((ipython (cl-find-if 'spacemacs/pyenv-executable-find
+                                       '("ipython3" "ipython")))
                   (version (replace-regexp-in-string
                             "\\(\\.dev\\)?[\r\n|\n]$" ""
                             (shell-command-to-string (format "\"%s\" --version" ipython)))))
@@ -166,8 +166,8 @@ ROOT-DIR should be the directory path for the environment, `nil' for clean up."
                         (concat "-i" (unless (version< version "5") " --simple-prompt")))
           ;; else try python3 or python
           (setq-local python-shell-interpreter
-                      (or (spacemacs/pyenv-executable-find "python3")
-                          (spacemacs/pyenv-executable-find "python")
+                      (or (cl-find-if 'spacemacs/pyenv-executable-find
+                                      '("python3" "python2" "python"))
                           "python3")
                       python-shell-interpreter-args "-i"))
       ;; args is nil, clean up the variables


### PR DESCRIPTION
Try to fix the last issue discussed in the https://github.com/syl20bnr/spacemacs/issues/16044#issuecomment-1665595535, use the basename without full path python-shell-interpreter.