### PR TITLE
use correct keybinding to browse themes

### DIFF
--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -491,7 +491,7 @@ that is loaded at startup. Here is an example:
                                           gotham)))
 #+END_SRC
 
-All installed themes can be listed and chosen using the ~SPC T h~ key binding.
+All installed themes can be listed and chosen using the ~SPC T s~ key binding.
 
 *** Nohlsearch
 Spacemacs emulates the default vim behavior which highlights search results even


### PR DESCRIPTION
`SPC T h` was undefined on a fresh spacemacs install; `SPC T s` is correct