### PR TITLE
layers/+tools/shell/packages.el: eshell "PAGER" compatible with emacs29

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -126,7 +126,7 @@
 
     (require 'esh-var)
     (add-to-list 'eshell-variable-aliases-list
-                 `("PAGER" ,(lambda (_indices) "cat") t))
+                 `("PAGER" ,(lambda (&optional _indices _quoted) "cat") t))
 
     ;; support `em-smart'
     (when shell-enable-smart-eshell


### PR DESCRIPTION
Eshell emit a WARNING message for "PAGER" function:
> Warning (eshell): Function for `eshell-variable-aliases-list' entry should accept two arguments: INDICES and QUOTED.'

Reproducing steps: 1. start eshell, and cd to a git repo; 2. run "git diff" for changes more than one page

It caused by the break changes that function `eshell-get-variable` intruduced a new parameter `quoted` in emacs-29.

This patch try to make the code compatible with all emacs-27 ~ emacs-29.

Please help review it. Thanks.