### PR TITLE
[ocaml] Add key binding for merlin-construct

### DIFF
--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -4,7 +4,7 @@
 
 [[file:img/ocaml.png]]
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
@@ -94,6 +94,7 @@ variable =ocaml-format-on-save=, e.g.,
 | ~SPC m h h~ | Document the identifier under point                      |
 | ~SPC m h t~ | Highlight identifier under cursor and print its type     |
 | ~SPC m h T~ | Prompt for expression and show its type                  |
+| ~SPC m r c~ | Construct expression at hole (_) based on its type       |
 | ~SPC m r d~ | Case analyze the current enclosing                       |
 | ~SPC m t p~ | Dune run tests and promote.                              |
 | ~SPC m t P~ | Dune promote.                                            |

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -121,6 +121,7 @@
       "hh" 'merlin-document
       "ht" 'merlin-type-enclosing
       "hT" 'merlin-type-expr
+      "rc" 'merlin-construct
       "rd" 'merlin-destruct)
     (spacemacs/declare-prefix-for-mode 'tuareg-mode "mc" "compile/check")
     (spacemacs/declare-prefix-for-mode 'tuareg-mode "mE" "errors")


### PR DESCRIPTION
Complementary to `merlin-destruct`, there should be a key binding to invoke `merlin-construct`.