### PR TITLE
[rust] Update layer docs to mention updated rustfmt configuration

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3483,6 +3483,7 @@ files (thanks to Daniel Nicolai)
 - Migrated to =rustic-mode= (thanks to Elric Milon)
 - Removed support for obsoleted =Racer= and =RLS= and made ==rust-analyzer= the
   default (thanks to Elric Milon)
+- Updated layer documentation to correctly configure =rustfmt= on save (thanks to Mariusz Klochowicz)
 **** Sailfish-Developer
 - Key bindings:
   - Added =sailfish-scratchbox= key bindings (thanks to Victor Polevoy):

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -85,7 +85,7 @@ Format Rust code according to style guidelines using [[https://github.com/rust-l
   rustup component add rustfmt
 #+END_SRC
 
-To enable automatic buffer formatting on save, set the variable =rust-format-on-save= to =t=.
+To enable automatic buffer formatting on save, set the variable =rustic-format-on-save= to =t=.
 
 ** Clippy
 [[https://github.com/rust-lang/rust-clippy][Clippy]] provides a collection of lints to to catch common mistakes and improve your code.


### PR DESCRIPTION
Since the layer now uses `rustic`, the variable to format on save has changed.

Without this, the functionality is broken and docs were not helpful in fixing it.