### PR TITLE
[go] Add key-bindings for "go generate"

### DIFF
--- a/layers/+lang/go/README.org
+++ b/layers/+lang/go/README.org
@@ -298,6 +298,8 @@ integration =dap-go,= to do so set the layer variable =go-dap-mode= as shown bel
 | ~SPC m t s~   | run "go test" for the suite you're currently in (requires gocheck)                    |
 | ~SPC m t t~   | run "go test" for the function you're currently in (while you're in a _.test.go file) |
 | ~SPC m x x~   | run "go run" for the current 'main' package                                           |
+| ~SPC m x g~   | run "go generate" for the current file                                                |
+| ~SPC m x G~   | run "go generate" for the current package                                             |
 
 ** Go Guru
 

--- a/layers/+lang/go/config.el
+++ b/layers/+lang/go/config.el
@@ -75,6 +75,14 @@ If not set then `go-mode' is the default backend unless `lsp' layer is used."
   "Go test command. Default is `go test`."
   'string nil t)
 
+(spacemacs|defc go-generate-command "go generate"
+  "Go generate command. Default is `go generate`."
+  'string nil t)
+
+(spacemacs|defc go-generate-buffer-name "*go gen*"
+  "Name of the buffer for go generate output. Default is *go gen*."
+  'string nil t)
+
 (spacemacs|defc go-dap-mode 'dap-dlv-go
   "Go dap mode. This variable defines which kind of dap integration will be used.
 

--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -157,6 +157,16 @@
   (shell-command
    (concat go-run-command " . " go-run-args)))
 
+(defun spacemacs/go-run-generate-current-dir ()
+  (interactive)
+  (compilation-start (concat go-generate-command " " (file-name-directory buffer-file-name))
+                     nil (lambda (n) go-generate-buffer-name) nil))
+
+(defun spacemacs/go-run-generate-current-buffer ()
+  (interactive)
+  (compilation-start (concat go-generate-command " " (buffer-file-name))
+                     nil (lambda (n) go-generate-buffer-name) nil))
+
 ;; misc
 (defun spacemacs/go-packages-gopkgs ()
   "Return a list of all Go packages, using `gopkgs'."

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -159,7 +159,9 @@
       "tp" 'spacemacs/go-run-package-tests
       "ts" 'spacemacs/go-run-test-current-suite
       "tt" 'spacemacs/go-run-test-current-function
-      "xx" 'spacemacs/go-run-main)))
+      "xx" 'spacemacs/go-run-main
+      "xg" 'spacemacs/go-run-generate-current-buffer
+      "xG" 'spacemacs/go-run-generate-current-dir)))
 
 (defun go/init-go-rename ()
   (use-package go-rename


### PR DESCRIPTION
`go generate` is a powerfull tool in golang, these two key-bindings make it easy to use:

 ```
| ~SPC m x g~   | run "go generate" for the current file                                                |
| ~SPC m x G~   | run "go generate" for the current package                                             |
````
