### PR TITLE
*layers/+lang/emacs-lisp/packages.el: fix obsolated function name

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -373,7 +373,7 @@
 
 (defun emacs-lisp/init-inspector ()
   (use-package inspector
-    :commands (inspect-expression inspect-last-sexp)
+    :defer t
     :config
     (evilified-state-evilify-map inspector-mode-map
       :mode inspector-mode)))


### PR DESCRIPTION
Hi,
Error message from Spacemacs when try execute function `inspect-expression`. 

It caused from emacs-inspector had renamed the functions `inspect-X` to be `inspector-inspect-X` in the commit https://github.com/mmontone/emacs-inspector/commit/e3a4f1c957555df8b9add4a734f77e9f5b4daa63.

This patch remove the function-name dependencies to be more flexable on working with the emacs-inspector package.

Please help to review it. Thanks.