### PR TITLE
Revert change in ecf1d32c breaking anzu in modeline

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -63,7 +63,7 @@
         (when anzu--state
           (let ((status
                  (cl-case anzu--state
-                   (cl-search (format "(%s/%d%s)"
+                   (search (format "(%s/%d%s)"
                                       (anzu--format-here-position here total)
                                       total (if anzu--overflow-p "+" "")))
                    (replace-query (format "(%d replace)" total))


### PR DESCRIPTION
A bug has been inserted when converting all obsolete functions with cl-* ones in ecf1d32c0cd9489700c0a0578fed600a8471bd90. This MR revert the wrong change. `search` is not a function.