### PR TITLE
core-fonts-support: Don't fiddle with user's face Customization

### DIFF
--- a/core/core-fonts-support.el
+++ b/core/core-fonts-support.el
@@ -49,7 +49,16 @@ The return value is nil if no font was found, truthy otherwise."
                             :powerline-offset))
                (fontspec (apply 'font-spec :name font font-props)))
           (spacemacs-buffer/message "Setting font \"%s\"..." font)
-          (set-frame-font fontspec nil t)
+          ;; We set the INHIBIT-CUSTOMIZE parameter to t to tell set-frame-font
+          ;; not to fiddle with the default face in the user's Customization
+          ;; settings. We don't need Customization because our way of ensuring
+          ;; that the font is applied to future frames is to modify
+          ;; default-frame-alist, and Customization causes issues, see
+          ;; https://github.com/syl20bnr/spacemacs/issues/5353.
+          ;; INHIBIT-CUSTOMIZE is only present in recent emacs versions. 
+          (if (version< emacs-version "28.0.90")
+              (set-frame-font fontspec nil t)
+            (set-frame-font fontspec nil t t))
           (push `(font . ,(frame-parameter nil 'font)) default-frame-alist)
           ;; fallback font for unicode characters used in spacemacs
           (pcase system-type


### PR DESCRIPTION
Fixes #5353.

Related:
https://github.com/emacs-mirror/emacs/commit/eae23d60f8338ea4e8617b13f4f6aa06333f68cd https://emacs.stackexchange.com/questions/33403/customize-creates-custom-set-faces-unintentionally

An alternative strategy is to call `(set-frame-font fontspec nil nil)`. This will work on any emacs version, and this will also inhibit fiddling with the Customization. But this will apply the font setting only to the current frame. While this *should* be okay (because when this code runs, only the current frame should be graphical and thus relevant when it comes to font changes), I'm not convinced that this analysis is correct, and that it's a good idea to rely on this fact.