### PR TITLE
fix(evil): Escape and evil-escape do not close Company auto-complete

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -138,6 +138,9 @@
                   lazy-load-evil-escape-2)))
     :config
     (add-hook 'spacemacs-editing-style-hook #'spacemacs//evil-escape-deactivate-in-holy-mode)
+    (add-hook 'evil-normal-state-entry-hook (lambda ()
+                                              (when (and (fboundp 'company--active-p) (company--active-p))
+                                                (company-abort))))
     ;; apply once when emacs starts
     (spacemacs//evil-escape-deactivate-in-holy-mode dotspacemacs-editing-style)
     (spacemacs|hide-lighter evil-escape-mode)))

--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -138,9 +138,9 @@
                   lazy-load-evil-escape-2)))
     :config
     (add-hook 'spacemacs-editing-style-hook #'spacemacs//evil-escape-deactivate-in-holy-mode)
-    (add-hook 'evil-normal-state-entry-hook (lambda ()
-                                              (when (and (fboundp 'company--active-p) (company--active-p))
-                                                (company-abort))))
+    (add-hook 'evil-insert-state-exit-hook (lambda ()
+                                             (when (and (fboundp 'company--active-p) (company--active-p))
+                                               (company-abort))))
     ;; apply once when emacs starts
     (spacemacs//evil-escape-deactivate-in-holy-mode dotspacemacs-editing-style)
     (spacemacs|hide-lighter evil-escape-mode)))


### PR DESCRIPTION
Why?:
- Pressing Escape or calling evil-escape using "fd" or your configured keybinding does not close Company's auto-complete pop-up especially using LSP. See also: https://github.com/syl20bnr/spacemacs/issues/4242

This change addresses the need by:
- Add hook to call company-abort when entering evil-normal-state

I'm actually not that sure that the code is in the right place. Maybe I should move it to the evil setup in bootstrap.
Can someone point me in the right direction?
