### PR TITLE
*layers/+intl/chinese/packages.el: remove incorrect config for pyim-page-tooltip

### DIFF
--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -53,8 +53,7 @@
     :if chinese-default-input-method
     :defer t
     :init
-    (setq pyim-page-tooltip t
-          pyim-directory (expand-file-name "pyim/" spacemacs-cache-directory)
+    (setq pyim-directory (expand-file-name "pyim/" spacemacs-cache-directory)
           pyim-dcache-directory (expand-file-name "dcache/" pyim-directory)
           pyim-assistant-scheme-enable t
           default-input-method "pyim")


### PR DESCRIPTION
Hi,

Setting the `pyim-page-tooltip` to `t` is incorrect according the change https://github.com/tumashu/pyim/commit/92d24bca089f740c33861318eba5d90cfb07bb8d#diff-95b9775e78bc8daa95cebb53205ccec621592456d4fc14dd893d2c52234dba51L48, a symbol or a list is desired.

And the default list value works great, so this change just remove the line to untouch the default value.

Please help review it. Thanks