### PR TITLE
Fix: Void symbol helm-source-comint-input-ring

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -31,6 +31,7 @@
     eshell-z
     evil-collection
     helm
+    helm-comint
     ivy
     magit
     multi-term

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -173,6 +173,10 @@
       (spacemacs/set-leader-keys-for-major-mode 'shell-mode
         "H" 'spacemacs/helm-shell-history))))
 
+(defun shell/pre-init-helm ()
+  (spacemacs|use-package-add-hook helm-comint
+    :after helm))
+
 (defun shell/pre-init-ivy ()
   (spacemacs|use-package-add-hook ivy
     :post-init


### PR DESCRIPTION
Good afternoon,

helm-source-comint-input-ring was a symbol from from helm-comint.el, and
helm-comint was separated from helm-core as of commit

https://github.com/emacs-helm/helm/commit/587bed0f735c7955ab385a5fbc2660a61713eb29

See also: https://github.com/emacs-helm/helm/issues/2615

The package has been submitted to MELPA but helm-source-comint-input-ring has
been renamed to helm-comint-input-ring to satisfy Elisp package naming
conventions to qualify for submission onto MELPA.

The comint ring history is still bound to ", H". It is the author's opinion that
it remains immensely useful and takes advantage of the built-in Emacs comint.el
and any Emacs modes derived from it.

Thanks for keeping spacemacs chugging along,