### PR TITLE
[auto-completion] Fix company-box configuration

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -160,11 +160,14 @@
     :hook '(company-mode . company-box-mode)
     :commands 'company-box-doc-manually
     :custom
-    (company-box-backends-colors nil)
     (company-box-max-candidates 1000)
     (company-box-doc-enable nil)
     (company-box-icons-alist 'company-box-icons-all-the-icons)
-    (company-box-icons-all-the-icons
+    :init
+    :config
+    (spacemacs|hide-lighter company-box-mode)
+    (setq company-box-backends-colors nil)
+    (setq company-box-icons-all-the-icons
      `((Unknown . ,(all-the-icons-octicon "file-text" :height 0.8 :v-adjust -0.05))
        (Text . ,(all-the-icons-faicon "file-text-o" :height 0.8 :v-adjust -0.0575))
        (Method . ,(all-the-icons-faicon "cube" :height 0.8 :v-adjust -0.0575))
@@ -192,9 +195,6 @@
        (Operator . ,(all-the-icons-faicon "tag" :height 0.8 :v-adjust -0.0575))
        (TypeParameter . ,(all-the-icons-faicon "cog" :height 0.8 :v-adjust -0.0575))
        (Template . ,(all-the-icons-octicon "file-code" :height 0.8 :v-adjust -0.05))))
-    :init
-    :config
-    (spacemacs|hide-lighter company-box-mode)
     (add-hook 'company-box-selection-hook
               (lambda (selection frame) (company-box-doc--hide frame)))
     (cl-case auto-completion-enable-help-tooltip


### PR DESCRIPTION
In this PR, the two variables defined with `defvar` have been modified to be redefined using `setq` in the `:config `section.

`company-box-backends-colors` and `company-box-icons-all-the-icons` are defined using [defvar](https://github.com/sebastiencs/company-box/blob/master/company-box-icons.el#L206-L234). However, in the configuration file, their settings are being overridden in the `:custom` section. As a result, the values set are not being read correctly.


## Before
* Some icons are not loaded.
* Icons are displayed misaligned.

<img width="410" alt="スクリーンショット 2023-09-21 21 51 37" src="https://github.com/syl20bnr/spacemacs/assets/2577343/a1467d98-f091-4f11-aedf-e4a392f870e4">

## After
* Icons are displayed correctly.
* Icons are displayed and aligned with the text.

<img width="407" alt="スクリーンショット 2023-09-21 21 53 38" src="https://github.com/syl20bnr/spacemacs/assets/2577343/d9dc96e7-5792-4fe6-a650-d7f772d48211">

## Note
Before the commit at https://github.com/syl20bnr/spacemacs/commit/b7e1dee13f619646d9d419f518f6ba8d835bef41, the settings were being made in the `:config` section.
