### PR TITLE
[Common Lisp] Make SPC m ' switch to repl if already connected.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1851,6 +1851,8 @@ Other:
 - Improvements:
   - Added eval-thing-at-point functions to Common Lisp Layer
     (thanks to Lukas Woell)
+  - Make ~SPC m '~ switch to REPL if slime is already connected instead of asking
+    if another inferior process should be started. (thanks to Lou Woell)
   - Make rainbow-identifiers not colorize special operators and macros, so they
     always visually stand out. (thanks to Andriy Kmit)
 - New packages:

--- a/layers/+lang/common-lisp/README.org
+++ b/layers/+lang/common-lisp/README.org
@@ -113,11 +113,12 @@ As this state works the same for all files, the documentation is in global
 
 *** REPL
 
-| Key binding | Description                      |
-|-------------+----------------------------------|
-| ~SPC m s i~ | Start an inferior process        |
-| ~SPC m s e~ | Evaluate last expression in REPL |
-| ~SPC m s q~ | Quit                             |
+| Key binding | Description                                             |
+|-------------+---------------------------------------------------------|
+| ~SPC m '~     | Start Slime or Switch to REPL if it's already connected |
+| ~SPC m s i~   | Start an inferior process                               |
+| ~SPC m s e~   | Evaluate last expression in REPL                        |
+| ~SPC m s q~   | Quit                                                    |
 
 *** Compile
 

--- a/layers/+lang/common-lisp/funcs.el
+++ b/layers/+lang/common-lisp/funcs.el
@@ -88,3 +88,12 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
     (save-excursion
       (sp-forward-symbol)
       (call-interactively 'slime-eval-last-expression))))
+
+
+(defun spacemacs/slime-repl ()
+  "Switches to slime repl if slime is connected, starts up slime if
+not."
+  (interactive)
+  (if (slime-connected-p)
+      (slime-switch-to-output-buffer)
+    (slime)))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -99,7 +99,7 @@
     (slime-setup)
     ;; TODO: Add bindings for the SLIME debugger?
     (spacemacs/set-leader-keys-for-major-mode 'lisp-mode
-      "'" 'slime
+      "'" 'spacemacs/slime-repl
 
       "cc" 'slime-compile-file
       "cC" 'slime-compile-and-load-file


### PR DESCRIPTION
Make `SPC m '`  switch to REPL if slime is already connected instead of asking if another inferior process should be started.