### PR TITLE
*layers/+source-control/version-control: change version-control-diff-tool to diff-hl

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -37,8 +37,8 @@ file.
 You can choose the package to facilitate the diff transient-state and show
 margins by setting the =version-control-diff-tool= variable to one of the
 supported packages:
-- [[https://github.com/dgutov/diff-hl][diff-hl]]
-- [[https://github.com/syohex/emacs-git-gutter][git-gutter]] (default)
+- [[https://github.com/dgutov/diff-hl][diff-hl]] (default)
+- [[https://github.com/syohex/emacs-git-gutter][git-gutter]]
 - [[https://github.com/nonsequitur/git-gutter-plus][git-gutter+]]
 
 #+BEGIN_SRC emacs-lisp

--- a/layers/+source-control/version-control/config.el
+++ b/layers/+source-control/version-control/config.el
@@ -27,7 +27,7 @@
 (defvar version-control-global-margin t
   "If non-nil, will show diff margins globally.")
 
-(defvar version-control-diff-tool 'git-gutter
+(defvar version-control-diff-tool 'diff-hl
   "Options are `git-gutter', `git-gutter+', and `diff-hl' to show
 version-control markers.")
 


### PR DESCRIPTION
Hi, 

Since the `git-gutter` moved to `emacsorphanage`, 
https://github.com/emacsorphanage/git-gutter

We should move to `diff-hl` for it still actively maintained. 

Please help approve the changes, thanks.