### PR TITLE
[bm] Add `s` for `bm-show-all`. Add package's recommended hooks.

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1573,6 +1573,9 @@ Other:
   - Replaced =org-ref-helm-insert-cite-link= with =org-ref-insert-link=
     (thanks to Tianshu Wang)
   - Add [[https://joostkremers.github.io/ebib/ebib-manual.html][ebib]] support (thanks to Daniel Nicolai)
+**** Bm
+- Add more package's recommended hooks, as per docs (thanks to Alfonso Montero)
+- Key binds: Add ~s~ for =bm-show-all= in transient (thanks to Alfonso Montero)
 **** C-C++
 - Breaking changes:
   - Moved =cmake-ide= and cmake script support to separate =cmake= layer

--- a/layers/+tools/bm/README.org
+++ b/layers/+tools/bm/README.org
@@ -9,7 +9,7 @@
 - [[#key-bindings][Key bindings]]
 
 * Description
-[[https://github.com/joodland/bm/blob/master/README.md][BM]] provides visible, buffer local, bookmarks and the ability to jump forward and backward to the next bookmark.
+[[https://github.com/joodland/bm][bm]] provides visible, buffer local, bookmarks and the ability to jump forward and backward to the next bookmark.
 
 ** Features:
 - Auto remove bookmark after jump to it by =bm-next= or =bm-previous=
@@ -20,7 +20,7 @@
 - Annotate bookmarks.
 - Different wrapping modes.
 - Different bookmarks styles, line-only, fringe-only or both.
-- Persistent bookmarks.
+- Persistent bookmarks (buffer local), also in non-file buffers (info) and indirect buffers.
 - List bookmarks (in all buffers) in a separate buffer.
 - Cycle through bookmarks in all open buffers.
 


### PR DESCRIPTION
Improvements to `bm` layer:
- Add hooks: since current ones were straight from [bm's readme](https://github.com/joodland/bm#readme), I've just brought them up to date.
- Ditto for the layer's readme from package's one (docs and capitalization).
- Added `s` for `bm-show-all` command to transient state.
- Package links to project's page instead of readme file.
