### PR TITLE
Add quelpa/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ org-journal.cache
 projectile-bookmarks.eld
 projectile.cache
 python-*-docs-html
+quelpa/
 quickurls
 racket-mode/
 semanticdb/


### PR DESCRIPTION
In 5d273156d1cb74c01131628ac1413d1f0675bab4, spacemacs started unpacking quelpa, so now it shows up as untracked on `git status`.