### PR TITLE
Force dap-mode's python debugger to be debugpy

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2776,6 +2776,8 @@ files (thanks to Daniel Nicolai)
   - Added global binding under ~SPC d~
 - Improvements:
   - Evilfied =dap= debug windows
+- Changed the dap-python debugger from =ptvsd= to =debugpy=. =ptvsd= is
+  deprecated in =dap-mode= and is broken in Spacemacs.
 **** Markdown
 - Fontify code blocks natively by default, for parity with the Org layer (thanks
   to Keith Pinson)

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -305,7 +305,7 @@ To use =pylookup= on ~SPC m h H~, make sure you update the database first, using
 To use =dap-mode= for debugging do:
 
 #+BEGIN_SRC bash
-  pip install "ptvsd>=4.2"
+  pip install debugpy
 #+END_SRC
 
 ** Notebook and code cells

--- a/layers/+tools/dap/config.el
+++ b/layers/+tools/dap/config.el
@@ -30,3 +30,9 @@
 
 (defvar dap-enable-ui-controls t
   "If non-nil, enable `dap-mode''s UI controls.")
+
+;; Force dap-mode's default for debugpy which is the new
+;; engine. `ptvsd` is now deprecated, but their default is
+;; hasn't yet been updated. `ptvsd` is currently broken
+;; with spacemacs.
+(setq dap-python-debugger 'debugpy)


### PR DESCRIPTION
At the moment, `dap-mode`'s default Python debugger is `ptvsd`. [This default is coming directly from dap-mode](https://github.com/emacs-lsp/dap-mode/blob/1187c6982fbc886e633b68359d64f8e5d7750151/dap-python.el#L163).

However, there are two facts related to this default:

1. `ptvsd` has been deprecated by `dap-mode` itself [[1](https://github.com/emacs-lsp/dap-mode/issues/636#issuecomment-1157677072)][[2](https://github.com/emacs-lsp/dap-mode/issues/306)]
2. `ptvsd` is currently broken in Spacemacs. I experienced several issues, such as:
  a. [same as this issue](https://github.com/emacs-lsp/dap-mode/issues/636)
  b. issues having treemacs working (=[Treemacs] There is no treemacs buffer in the current scope.= error)
  c. experienced this bug with Python 3.11 that had me to patch `dap-mode` to add `-Xfrozen_modules=off` in the command line call, etc.

For my experience with `debugpy` so far, it is perfectly working with `dap-mode` and `treeemacs`.

This PR simply add this to the `dap-mode` layer config file:

```lisp
(setq dap-python-debugger 'debugpy)
```

I used `setq` here since I don't think we want to give the option to the users to revert to `ptvsd` since it is deprecated and will most likely disappear from `dap-mode` in the future.