### PR TITLE
*core/core-spacemacs.el: change gc settings at the last of initialization

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -257,13 +257,14 @@ Note: the hooked function is not executed when in dumped mode."
      (spacemacs/check-for-new-version nil spacemacs-version-check-interval)
      (spacemacs-buffer/goto-link-line)
      (setq spacemacs-initialized t)
-     (setq gc-cons-threshold (car dotspacemacs-gc-cons)
-           gc-cons-percentage (cadr dotspacemacs-gc-cons))
      (setq read-process-output-max dotspacemacs-read-process-output-max)
      ;; Redraw the spacemacs buffer with full org support
      ;; Before it must be drawn without org related features to
      ;; avoid loading build in org in emacs >= 29
-     (spacemacs-buffer/goto-buffer t t)))
+     (spacemacs-buffer/goto-buffer t t)
+     ;; change gc settings at the last for it will take effect immediately
+     (setq gc-cons-threshold (car dotspacemacs-gc-cons)
+           gc-cons-percentage (cadr dotspacemacs-gc-cons))))
 
   (if dotspacemacs-byte-compile
       (when (> 1 (spacemacs//dir-byte-compile-state


### PR DESCRIPTION
Hi,

Spacemacs has large gc values (400m, 0.6) in the [init.el:31](https://github.com/syl20bnr/spacemacs/blob/dd7b7a2a5fbf0abe5076b0443c9ef2732890f27f/init.el#L31) to avoid the gc and change gc configuration to desired ones (100m, 0.6) at the end of the initialization [spacemacs/startup-hook](https://github.com/syl20bnr/spacemacs/blob/a1680f27783b42e14d0c1a7e61fe787500a2db4e/core/core-spacemacs.el#L224C11-L224C33).

Here is a minor enhance that moving the gc-* settings to the tail of the function for less gc during the startup.

Please approve the changes, thanks.