### PR TITLE
*layers/+completion/helm: simple helm-comint dependency

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -27,6 +27,7 @@
     bookmark
     helm
     helm-ag
+    helm-comint
     helm-descbinds
     (helm-ls-git :toggle (configuration-layer/layer-used-p 'git))
     helm-make
@@ -35,7 +36,6 @@
     helm-projectile
     helm-swoop
     helm-themes
-    (helm-comint :toggle (not (version< emacs-version "29.1")))
     (helm-spacemacs-help :location local)
     (helm-spacemacs-faq :location local)
     helm-xref


### PR DESCRIPTION
Hi,

I had fix the `helm-comint` dependency issue in the commit https://github.com/emacs-helm/helm-comint/commit/9215b2aa8f42f62cbda66a1503832abb7f491549.

Spacemacs can restore to the simple dependency to `helm-comint`. 

@pataquets  @spt29 Please upgrade to the last `helm-comint` and verify this change, thanks.