### PR TITLE
*layers/+spacemacs/spacemacs-navigation: defer to load restart-emacs package

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -356,7 +356,7 @@
 
 (defun spacemacs-navigation/init-restart-emacs ()
   (use-package restart-emacs
-    :after files
+    :defer (spacemacs/defer)
     :init
     (spacemacs/set-leader-keys
       "qd" 'spacemacs/restart-emacs-debug-init


### PR DESCRIPTION
The `restart-emacs` package should be loaded deferly.