### PR TITLE
*layers/+spacemacs/spacemacs-navigation: resolve restart-emacs name confliction

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -358,6 +358,11 @@
   (use-package restart-emacs
     :defer (spacemacs/defer)
     :init
+    (with-eval-after-load 'files
+      ;; unbind `restart-emacs' and declare it from package for ticket #15505
+      (fmakunbound 'restart-emacs)
+      (autoload 'restart-emacs "restart-emacs"))
+
     (spacemacs/set-leader-keys
       "qd" 'spacemacs/restart-emacs-debug-init
       "qD" 'spacemacs/restart-stock-emacs-with-packages


### PR DESCRIPTION
Hi @smile13241324 
Please help review this change to resolve the ticket #15505.
Thanks
