### PR TITLE
[spacemacs-navigation] Enable winum in vanilla mode line theme

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -426,7 +426,7 @@
   (use-package winum
     :config
     (setq winum-auto-assign-0-to-minibuffer nil
-          winum-auto-setup-mode-line nil
+          winum-auto-setup-mode-line (eq dotspacemacs-mode-line-theme 'vanilla)
           winum-ignored-buffers '(" *LV*" " *which-key*"))
     (spacemacs/set-leader-keys
       "`" 'winum-select-window-by-number


### PR DESCRIPTION
winum-mode has logic to set itself up in the vanilla mode-line theme, but Spacemacs disables it too broadly.
