### PR TITLE
Delete references to mu4e-maildirs-extension after upstream support

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -12,7 +12,6 @@
   - [[#view-mode][View mode]]
   - [[#compose-mode][Compose mode]]
 - [[#configuration][Configuration]]
-  - [[#maildirs-extension][Maildirs extension]]
   - [[#multiple-accounts][Multiple Accounts]]
   - [[#async-mode][Async mode]]
   - [[#attachment-directory][Attachment directory]]
@@ -35,8 +34,8 @@ This layer adds support for the =Mu4e= email client.
 - UI optimized for speed: quick keystrokes for common actions.
 - Very extendable and customizable.
 - Integration with Helm.
-- Maildir summary using [[https://github.com/agpchil/mu4e-maildirs-extension][mu4e-mailidirs-extension]]
-- Notifications using [[https://github.com/iqbalansari/mu4e-alert][mu4e-alert]]
+- Maildir summary.
+- Notifications using [[https://github.com/iqbalansari/mu4e-alert][mu4e-alert]].
 
 * Install
 In order to use this layer you must install =mu= and =mu4e= separately.
@@ -103,20 +102,6 @@ existing =dotspacemacs-configuration-layers= list in this file.
 Configuration varies too much to give precise instructions. What follows is one
 example configuration. Refer to =mu4e='s manual for more detailed configuration
 instructions.
-
-** Maildirs extension
-The [[https://github.com/agpchil/mu4e-maildirs-extension][maildirs extension]] adds a list of all your maildirs to the main =mu4e= view
-that by default shows the unread and total mail counts for all your mail under
-your base mail directory.
-
-The maildirs extension is not enabled by default. To activate it, change the
-variable =mu4e-use-maildirs-extension= to a non-nil value:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-                '((mu4e :variables
-                        mu4e-use-maildirs-extension t)))
-#+END_SRC
 
 ** Multiple Accounts
 With =mu 0.9.16=, =mu4e= comes with a native contexts feature for managing

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -42,9 +42,6 @@
 (defvar mu4e-enable-mode-line nil
   "If non-nil, enable display of unread emails in mode-line.")
 
-(defvar mu4e-use-maildirs-extension nil
-  "Use mu4e-maildirs-extension package if value is non-nil.")
-
 (defvar mu4e-list-modes
   '(mu4e-main-mode mu4e-headers-mode)
   "Modes that are associated with mu4e's listing buffers.")

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -25,7 +25,6 @@
   '(
     (mu4e :location site)
     mu4e-alert
-    mu4e-maildirs-extension
     (helm-mu :requires helm)
     org
     persp-mode
@@ -155,13 +154,6 @@
               "S" 'helm-mu
               "/" 'helm-mu
               "C" 'helm-mu-contacts))))
-
-(defun mu4e/init-mu4e-maildirs-extension ()
-  "If mu4e-use-maildirs-extension is non-nil, set
-mu4e-use-maildirs-extension-load to be evaluated after mu4e has been loaded."
-  (use-package mu4e-maildirs-extension
-    :if mu4e-use-maildirs-extension
-    :init (with-eval-after-load 'mu4e (mu4e-maildirs-extension-load))))
 
 (defun mu4e/pre-init-org ()
   (if mu4e-org-link-support


### PR DESCRIPTION
agpchil/mu4e-maildirs-extension#56 has been deprecate in favor of an upstream PR djcb/mu#1586 to include it as a built-in functionality. This commit deletes all references to mu4e-maildirs-extension.