### PR TITLE
Fix #16155 smartparens disabled after auto-complete

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -395,14 +395,14 @@ MODE parameter must match the :modes values used in the call to
 ;; As `hippie-expand' is less frequently used than yasnippet I think it is
 ;; better to have smartparens state preserved with the default case.
 
-(defvar spacemacs--smartparens-enabled-initially t
+(defvar spacemacs--smartparens-enabled-initially nil
   "Stored whether smartparens is originally enabled or not.")
 
 (defun spacemacs//smartparens-disable-before-expand-snippet ()
   "Handler for `yas-before-expand-snippet-hook'.
 Disable smartparens and remember its initial state."
   ;; Remember the initial smartparens state only once, when expanding a top-level snippet.
-  (setq spacemacs--smartparens-enabled-initially (or smartparens-mode smartparens-strict-mode))
+  (setq spacemacs--smartparens-enabled-initially (or spacemacs--smartparens-enabled-initially smartparens-mode smartparens-strict-mode))
   (spacemacs//deactivate-smartparens))
 
 (defun spacemacs//smartparens-restore-after-exit-snippet ()


### PR DESCRIPTION
This change preserves the original value of the  initial `spacemacs--smartparens-enabled-initially` when nested yasnippets are invoked. 