### PR TITLE
[spacemacs-navigation] Properly enable winum in vanilla mode line theme

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -426,7 +426,7 @@
   (use-package winum
     :config
     (setq winum-auto-assign-0-to-minibuffer nil
-          winum-auto-setup-mode-line (eq dotspacemacs-mode-line-theme 'vanilla)
+          winum-auto-setup-mode-line (eq (spacemacs/get-mode-line-theme-name) 'vanilla)
           winum-ignored-buffers '(" *LV*" " *which-key*"))
     (spacemacs/set-leader-keys
       "`" 'winum-select-window-by-number


### PR DESCRIPTION
We should use (spacemacs/get-mode-line-theme-name) like everything else instead of reading dotspacemacs-mode-line-theme directly, since dotspacemacs-mode-line-theme is not always just a single symbol.