### PR TITLE
[auto-completion] Do not erase yas-snippet-dirs set by other layers

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -275,6 +275,7 @@
     :init
     ;; We don't want undefined variable errors
     (defvar yas-global-mode nil)
+    (defvar yas-snippet-dirs nil)
     (setq yas-triggers-in-field t
           yas-wrap-around-region t
           helm-yas-display-key-on-candidate t)
@@ -302,7 +303,6 @@
                                   dotspacemacs-directory)))
                 (when (file-accessible-directory-p snippet-dir)
                   snippet-dir)))))
-      (setq yas-snippet-dirs nil)
       ;; ~/.emacs.d/layers/auto-completion/snippets
       (add-to-list 'yas-snippet-dirs spacemacs-layer-snippets-dir)
       ;; ~/.emacs.d/private/snippets


### PR DESCRIPTION
At my site, we have an internal package that adds some entries to yas-snippet-dirs (in a with-eval-after-load on yasnippet).  These are currently getting erased by the auto-completion layer.  It seems to make more sense for the latter to simply add entries, rather than replacing the whole list.

(Normally yasnippet is not loaded until auto-completion layer is initialized, however, when starting Spacemacs for the first time, it seems to be loaded earlier, in which case the `use-package yasnippet :init` section runs _after_ yasnippet is loaded.  In any case, the `defvar` seems more correct than blindly calling `setq`)