### PR TITLE
[spacemacs-evil] Enable anzu in non-spaceline mode lines

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -54,8 +54,7 @@
     (global-anzu-mode t)
     :config
     (spacemacs|hide-lighter anzu-mode)
-    (setq anzu-search-threshold 1000
-          anzu-cons-mode-line-p nil)
+    (setq anzu-search-threshold 1000)
     ;; powerline integration
     (when (configuration-layer/package-used-p 'spaceline)
       (defun spacemacs/anzu-update-mode-line (here total)
@@ -64,13 +63,14 @@
           (let ((status
                  (cl-case anzu--state
                    (search (format "(%s/%d%s)"
-                                      (anzu--format-here-position here total)
-                                      total (if anzu--overflow-p "+" "")))
+                                   (anzu--format-here-position here total)
+                                   total (if anzu--overflow-p "+" "")))
                    (replace-query (format "(%d replace)" total))
                    (replace (format "(%d/%d)" here total)))))
-            status)))
-      (setq anzu-mode-line-update-function
-            'spacemacs/anzu-update-mode-line))))
+            status))))
+    (when (eq (spacemacs/get-mode-line-theme-name) 'spaceline)
+      (setq anzu-mode-line-update-function 'spacemacs/anzu-update-mode-line
+            anzu-cons-mode-line-p nil))))
 
 (defun spacemacs-evil/post-init-eldoc ()
   (eldoc-add-command #'evil-cp-insert)


### PR DESCRIPTION
The anzu mode line update function only works in Spaceline, so we should re-enable its default mode line logic if spaceline is not the selected mode line theme.