### PR TITLE
Do not show any minibuffer when using spacemacs/window-split-triple-columns

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1009,7 +1009,7 @@ as a means to remove windows, regardless of the value in
         (delete-other-windows))
     (funcall spacemacs-window-split-delete-function))
   (if (spacemacs--window-split-splittable-windows)
-      (let* ((previous-files (buffer-list))
+      (let* ((previous-files (seq-filter #'buffer-file-name (buffer-list)))
              (second (split-window-right))
              (third (split-window second nil 'right)))
         (set-window-buffer second (or (nth 1 previous-files) "*scratch*"))


### PR DESCRIPTION
I noticed that `SPC w 3` i.e. `spacemacs/window-split-triple-columns` always shows a inactive minibuffer e.g. a buffer like ` *Minibuf-1*`, ` *Minibuf-2*`.

Here is a screenshot that shows an example where I do `SPC w 3`:

![image](https://github.com/syl20bnr/spacemacs/assets/1680079/25b6310c-7ea8-448b-a573-bf2ea53e9244)

When you switch to the window with a minibuffer, the key bindings are not the spacemacs ones and you need to do `C-x b` to switch to a different buffer which makes the user experience not so great. This affects `SPC w 4` as well.

To reproduce it, start emacs, and then `SPC w 3`, one of the window should be a ` *Minibuf-<some-number>*`.

This used to work at one point and I traced it back to https://github.com/syl20bnr/spacemacs/pull/15520 that removed the `#'buffer-file-name` filter when splitting windows with `SPC w 3`. The PR relies on `#'persp-contain-buffer-p` instead but this is not filtering out minibuffers if you are in the Default layout. For completeness, personally I don't use layouts.

#### System Info :computer:
- OS: gnu/linux
- Emacs: 29.1
- Spacemacs: 0.999.0
- Spacemacs branch: develop (rev. c46a22da1)
- Graphic display: t
- Running in daemon: nil
- Distribution: spacemacs
- Editing style: vim
- Completion: helm
- Layers:
```elisp
(auto-completion better-defaults emacs-lisp git helm lsp markdown multiple-cursors
                 (org :variables org-enable-reveal-js-support t)
                 (shell :variables shell-default-shell 'vterm shell-default-position 'right shell-default-width 40)
                 spell-checking syntax-checking version-control treemacs go csv javascript rust html yaml
                 (shell-scripts :variables shell-scripts-backend 'lsp)
                 (python :variables python-test-runner 'pytest python-backend 'lsp python-lsp-server 'pyright python-formatter 'black)
                 ipython-notebook
                 (mu4e :variables mu4e-installation-path "/usr/local/share/emacs/site-lisp/mu4e")
                 ess cmake docker pass dtrt-indent react)
```
- System configuration features: ACL CAIRO DBUS FREETYPE GIF GLIB GMP GNUTLS GPM GSETTINGS HARFBUZZ JPEG JSON LCMS2 LIBOTF LIBSYSTEMD LIBXML2 M17N_FLT MODULES NOTIFY INOTIFY PDUMPER PNG RSVG SECCOMP SOUND SQLITE3 THREADS TIFF TOOLKIT_SCROLL_BARS TREE_SITTER WEBP X11 XDBE XIM XINPUT2 XPM GTK3 ZLIB

