### PR TITLE
[ivy] Adopt ownership of counsel-projectile package

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -27,7 +27,7 @@
         auto-highlight-symbol
         bookmark
         counsel
-        counsel-projectile
+        (counsel-projectile :requires projectile)
         evil
         flx
         helm-make
@@ -178,29 +178,29 @@
     ;; by recognizing file at point.
     (setq counsel-find-file-at-point t)))
 
-(defun ivy/pre-init-counsel-projectile ()
+(defun ivy/init-counsel-projectile ()
   ;; overwrite projectile settings
   (spacemacs|use-package-add-hook projectile
     :post-init
-    (progn
-      (setq projectile-switch-project-action 'counsel-projectile-find-file)
+    (setq projectile-switch-project-action 'counsel-projectile-find-file)
+    (spacemacs/set-leader-keys
+      "p SPC" 'counsel-projectile
+      "pb"    'counsel-projectile-switch-to-buffer
+      "pd"    'counsel-projectile-find-dir
+      "pp"    'counsel-projectile-switch-project
+      "pf"    'counsel-projectile-find-file))
 
-      (ivy-set-actions
-       'counsel-projectile-find-file
-       (append spacemacs--ivy-file-actions
-               '(("R" (lambda (arg)
-                        (interactive)
-                        (call-interactively
-                         #'projectile-invalidate-cache)
-                        (ivy-resume)) "refresh list")
-                 )))
-
-      (spacemacs/set-leader-keys
-        "p SPC" 'counsel-projectile
-        "pb"    'counsel-projectile-switch-to-buffer
-        "pd"    'counsel-projectile-find-dir
-        "pp"    'counsel-projectile-switch-project
-        "pf"    'counsel-projectile-find-file))))
+  (use-package counsel-projectile
+    :defer t
+    :init (ivy-set-actions
+           'counsel-projectile-find-file
+           (append spacemacs--ivy-file-actions
+                   '(("R" (lambda (arg)
+                            (interactive)
+                            (call-interactively
+                             #'projectile-invalidate-cache)
+                            (ivy-resume)) "refresh list")
+                     )))))
 
 (defun ivy/post-init-evil ()
   (spacemacs/set-leader-keys

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -252,13 +252,11 @@
 
 
 
-(defun spacemacs-layouts/init-counsel-projectile ()
-  (use-package counsel-projectile
-    :defer t
-    :init (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)
-    :config (ivy-set-actions
-             'spacemacs/ivy-persp-switch-project
-             '(("d" spacemacs/ivy-switch-project-open-dired "dired")))))
+(defun spacemacs-layouts/post-init-counsel-projectile ()
+  (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)
+  (ivy-set-actions
+   'spacemacs/ivy-persp-switch-project
+   '(("d" spacemacs/ivy-switch-project-open-dired "dired"))))
 
 (defun spacemacs-layouts/post-init-consult ()
   (spacemacs/set-leader-keys


### PR DESCRIPTION
It should be possible to use counsel-projectile without using the spacemacs-layouts layer.

This PR moves the ownership of package `counsel-projectile` to the `ivy` layer, which seems like a better fit.

I tested to make sure the key bindings were still defined at the appropriate time (after `spacemacs-project/init-projectile` runs) so that they correctly override the projectile key bindings.