### PR TITLE
Fix inconsistencies and broken key bindings in the Rust layer

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -12,7 +12,7 @@
   - [[#lsp][LSP]]
     - [[#autocompletion][Autocompletion]]
     - [[#debugger-dap-integration][Debugger (dap integration)]]
-    - [[#automatically-reload-workspace][Automatically Reload Workspace]]
+    - [[#reloading-workspace][Reloading Workspace]]
   - [[#cargo][Cargo]]
     - [[#cargo-edit][cargo-edit]]
     - [[#cargo-outdated][cargo-outdated]]
@@ -45,20 +45,14 @@ To enable auto-completion, ensure that the =auto-completion= layer is enabled.
 *** Debugger (dap integration)
 To install the debug adapter you may run =M-x dap-gdb-lldb-setup= when you are on Linux or download it manually from [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][Native Debug]] and adjust =dap-gdb-lldb-path=.
 
-*** Automatically Reload Workspace
-When the LSP server is =rust-analyzer=, it may needs to reload the workspace to pickup changes made in =Cargo.toml=.
-You can call =spacemacs/lsp-rust-analyzer-reload-workspace=, which would be faster than restarting the LSP backend.
+*** Reloading Workspace
+By default, rust-analyzer will automatically reload the workspace
+after you make changes to =Cargo.toml= (such as adding dependencies).
 
-You can also set =cargo-process-reload-on-modify= to =t=, then it will automatically reload the workspace after
-one of the following is run:
-- =rustic-cargo-add=
-- =rustic-cargo-rm=
-- =rustic-cargo-upgrade=
-
-#+BEGIN_SRC elisp
-  (setq-default dotspacemacs-configuration-layers
-                 '(lsp :variables cargo-process-reload-on-modify t))
-#+END_SRC
+However, if =lsp-rust-analyzer-cargo-auto-reload= is set to nil, you
+will need to reload the workspace manually for the LSP to notice those
+changes.  You can call =spacemacs/lsp-rust-analyzer-reload-workspace=,
+which would be faster than restarting the LSP backend.
 
 ** Cargo
 [[http://doc.crates.io/index.html][Cargo]] is a project management command line tool for Rust. Installation

--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -100,6 +100,7 @@ To enable automatic buffer formatting on save, set the variable =rustic-format-o
 |-------------+--------------------------------------------------------|
 | ~SPC m = =~ | reformat the buffer                                    |
 | ~SPC m b R~ | reload Rust-Analyzer workspace                         |
+| ~SPC m c .~ | rerun the default binary with the same arguments       |
 | ~SPC m c =~ | format all project files with rustfmt                  |
 | ~SPC m c a~ | add a new dependency with cargo-edit                   |
 | ~SPC m c c~ | compile project                                        |

--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -25,5 +25,13 @@
 
 (spacemacs|define-jump-handlers rustic-mode)
 
+(defvar rust-backend (and (configuration-layer/layer-used-p 'lsp) 'lsp)
+  "The backend to use for completion.
+
+Currently, only `lsp' is supported.  It is automatically used if
+the `lsp' layer is enabled.
+
+If `nil', LSP support is disabled.")
+
 (defvar cargo-process-reload-on-modify nil
   "When non-nil, reload workspace after a cargo-process command modifies Cargo.toml.")

--- a/layers/+lang/rust/config.el
+++ b/layers/+lang/rust/config.el
@@ -32,6 +32,3 @@ Currently, only `lsp' is supported.  It is automatically used if
 the `lsp' layer is enabled.
 
 If `nil', LSP support is disabled.")
-
-(defvar cargo-process-reload-on-modify nil
-  "When non-nil, reload workspace after a cargo-process command modifies Cargo.toml.")

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -87,8 +87,7 @@ When one of the following is true, it won't reload:
 - Backend is not rust-analyzer.
 - `cargo-process-reload-on-modify' is nil."
     (when (and cargo-process-reload-on-modify
-               (and (boundp 'rust-backend)
-                    (eq rust-backend 'lsp))
+               (eq rust-backend 'lsp)
                (member 'rust-analyzer (spacemacs//lsp-client-server-id)))
       (lsp-rust-analyzer-reload-workspace)))
 

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -68,43 +68,6 @@
     (lsp-rust-analyzer-reload-workspace)
     (message "Reloaded workspace")))
 
-(when (configuration-layer/package-used-p 'cargo)
-  (defun spacemacs//cargo-maybe-reload ()
-    "Reload the workspace conditionally.
-When one of the following is true, it won't reload:
-- Backend is not rust-analyzer.
-- `cargo-process-reload-on-modify' is nil."
-    (when (and cargo-process-reload-on-modify
-               (eq rust-backend 'lsp)
-               (member 'rust-analyzer (spacemacs//lsp-client-server-id)))
-      (lsp-rust-analyzer-reload-workspace)))
-
-  (defun spacemacs/cargo-process-repeat ()
-    "Run last cargo process command, and conditionally reload the workspace."
-    (interactive)
-    (call-interactively 'cargo-process-repeat)
-    (when (member (car cargo-process-last-command)
-                  '("Add" "Remove" "Upgrade"))
-      (spacemacs//cargo-maybe-reload)))
-
-  (defun spacemacs/cargo-process-add ()
-    "Run the cargo add command, and conditionally reload the workspace."
-    (interactive)
-    (call-interactively 'cargo-process-add)
-    (spacemacs//cargo-maybe-reload))
-
-  (defun spacemacs/cargo-process-rm()
-    "Run the cargo rm command, and conditionally reload the workspace."
-    (interactive)
-    (call-interactively 'cargo-process-rm)
-    (spacemacs//cargo-maybe-reload))
-
-  (defun spacemacs/cargo-process-upgrade()
-    "Run the cargo upgrade command, and conditionally reload the workspace."
-    (interactive)
-    (call-interactively 'cargo-process-upgrade)
-    (spacemacs//cargo-maybe-reload)))
-
 
 ;; Misc
 

--- a/layers/+lang/rust/funcs.el
+++ b/layers/+lang/rust/funcs.el
@@ -36,12 +36,6 @@
   (message (concat "`lsp' layer is not installed, "
                    "please add `lsp' layer to your dotfile.")))
 
-(defun spacemacs/lsp-rust-switch-server ()
-  "Switch between rust-analyzer and rls."
-  (interactive)
-  (lsp-rust-switch-server)
-  (call-interactively 'lsp-workspace-restart))
-
 (defun spacemacs//rust-setup-lsp ()
   "Setup lsp backend."
   (if (configuration-layer/layer-used-p 'lsp)
@@ -49,7 +43,6 @@
         (lsp-deferred)
         (spacemacs/declare-prefix-for-mode 'rustic-mode "ms" "switch")
         (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
-          "ss" 'spacemacs/lsp-rust-switch-server
           (if lsp-use-upstream-bindings "wR" "bR") 'spacemacs/lsp-rust-analyzer-reload-workspace))
     (spacemacs//lsp-layer-not-installed-message)))
 
@@ -68,17 +61,12 @@
                                      :dap-compilation-dir "${workspaceFolder}"
                                      :cwd "${workspaceFolder}")))
 
-
-
 (defun spacemacs/lsp-rust-analyzer-reload-workspace ()
-  "Reload workspaces to pick up changes in Cargo.toml.
-Only applies to rust-analyzer, since rls automatically picks up changes already."
+  "Reload workspaces to pick up changes in Cargo.toml."
   (interactive)
-  (if (member 'rust-analyzer (spacemacs//lsp-client-server-id))
-      (progn
-        (lsp-rust-analyzer-reload-workspace)
-        (message "Reloaded workspace"))
-    (message "RLS reloads automatically, and doesn't require an explicit reload")))
+  (when (member 'rust-analyzer (spacemacs//lsp-client-server-id))
+    (lsp-rust-analyzer-reload-workspace)
+    (message "Reloaded workspace")))
 
 (when (configuration-layer/package-used-p 'cargo)
   (defun spacemacs//cargo-maybe-reload ()

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -66,7 +66,7 @@
         "cc" 'rustic-cargo-build
         "cC" 'rustic-cargo-clean
         "cd" 'rustic-cargo-doc
-        "cs" 'rustic-cargo-doc-search
+        "cs" 'rustic-doc-search
         "ce" 'rustic-cargo-bench
         "ci" 'rustic-cargo-init
         "cl" 'rustic-cargo-clippy

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -80,8 +80,7 @@
 
       (with-eval-after-load 'flycheck
         (spacemacs/enable-flycheck 'rustic-mode)
-        ;; (push 'rustic-clippy flycheck-checkers)
-        )
+        (push 'rustic-clippy flycheck-checkers))
 
       (with-eval-after-load 'lsp-mode
         (spacemacs/set-leader-keys-for-major-mode 'rustic-mode

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -36,8 +36,7 @@
   (spacemacs/counsel-gtags-define-keys-for-mode 'rustic-mode))
 
 (defun rust/pre-init-dap-mode ()
-  (when (and (boundp 'rust-backend)
-             (eq rust-backend 'lsp))
+  (when (eq rust-backend 'lsp)
     (add-to-list 'spacemacs--dap-supported-modes 'rustic-mode)
     (add-hook 'rustic-mode-local-vars-hook #'spacemacs//rust-setup-dap)))
 

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -73,7 +73,7 @@
         "cf" 'rustic-cargo-clippy-fix
         "cn" 'rustic-cargo-new
         "co" 'rustic-cargo-outdated
-        "cr" 'spacemacs/rustic-cargo-rm
+        "cr" 'rustic-cargo-rm
         "cu" 'rustic-cargo-update
         "cU" 'rustic-cargo-upgrade
         "cv" 'rustic-cargo-check

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -48,55 +48,54 @@
     :defer t
     :mode ("\\.rs\\'" . rustic-mode)
     :init
-    (progn
-      (add-hook 'rustic-mode-hook #'spacemacs//rust-setup-backend)
+    (add-hook 'rustic-mode-hook #'spacemacs//rust-setup-backend)
 
-      (spacemacs/declare-prefix-for-mode 'rustic-mode "mc" "cargo")
-      (spacemacs/declare-prefix-for-mode 'rustic-mode "mt" "tests")
-      (spacemacs/declare-prefix-for-mode 'rustic-mode "mg" "goto")
-      (spacemacs/declare-prefix-for-mode 'rustic-mode "mh" "help")
-      (spacemacs/declare-prefix-for-mode 'rustic-mode "m=" "format")
+    (spacemacs/declare-prefix-for-mode 'rustic-mode "mc" "cargo")
+    (spacemacs/declare-prefix-for-mode 'rustic-mode "mt" "tests")
+    (spacemacs/declare-prefix-for-mode 'rustic-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'rustic-mode "mh" "help")
+    (spacemacs/declare-prefix-for-mode 'rustic-mode "m=" "format")
+    (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
+      "c." 'rustic-cargo-run-rerun
+      "c=" 'rustic-cargo-fmt
+      "ca" 'rustic-cargo-add
+      "cc" 'rustic-cargo-build
+      "cC" 'rustic-cargo-clean
+      "cd" 'rustic-cargo-doc
+      "cs" 'rustic-doc-search
+      "ce" 'rustic-cargo-bench
+      "ci" 'rustic-cargo-init
+      "cl" 'rustic-cargo-clippy
+      "cf" 'rustic-cargo-clippy-fix
+      "cn" 'rustic-cargo-new
+      "co" 'rustic-cargo-outdated
+      "cr" 'rustic-cargo-rm
+      "cu" 'rustic-cargo-update
+      "cU" 'rustic-cargo-upgrade
+      "cv" 'rustic-cargo-check
+      "cx" 'rustic-cargo-run
+      "ta" 'rustic-cargo-test
+      "tt" 'rustic-cargo-current-test)
+
+    (with-eval-after-load 'flycheck
+      (spacemacs/enable-flycheck 'rustic-mode)
+      (push 'rustic-clippy flycheck-checkers))
+
+    (with-eval-after-load 'lsp-mode
       (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
-        "c." 'rustic-cargo-run-rerun
-        "c=" 'rustic-cargo-fmt
-        "ca" 'rustic-cargo-add
-        "cc" 'rustic-cargo-build
-        "cC" 'rustic-cargo-clean
-        "cd" 'rustic-cargo-doc
-        "cs" 'rustic-doc-search
-        "ce" 'rustic-cargo-bench
-        "ci" 'rustic-cargo-init
-        "cl" 'rustic-cargo-clippy
-        "cf" 'rustic-cargo-clippy-fix
-        "cn" 'rustic-cargo-new
-        "co" 'rustic-cargo-outdated
-        "cr" 'rustic-cargo-rm
-        "cu" 'rustic-cargo-update
-        "cU" 'rustic-cargo-upgrade
-        "cv" 'rustic-cargo-check
-        "cx" 'rustic-cargo-run
-        "ta" 'rustic-cargo-test
-        "tt" 'rustic-cargo-current-test)
+        "=j" 'lsp-rust-analyzer-join-lines
+        "==" 'lsp-format-buffer
+        "Ti" 'lsp-inlay-hints-mode
+        "bD" 'lsp-rust-analyzer-status
+        "bS" 'lsp-rust-switch-server
+        "gp" 'lsp-rust-find-parent-module
+        "gg" 'lsp-find-definition
+        "hm" 'lsp-rust-analyzer-expand-macro
+        "hs" 'lsp-rust-analyzer-syntax-tree
+        "v" 'lsp-extend-selection
 
-      (with-eval-after-load 'flycheck
-        (spacemacs/enable-flycheck 'rustic-mode)
-        (push 'rustic-clippy flycheck-checkers))
-
-      (with-eval-after-load 'lsp-mode
-        (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
-          "=j" 'lsp-rust-analyzer-join-lines
-          "==" 'lsp-format-buffer
-          "Ti" 'lsp-inlay-hints-mode
-          "bD" 'lsp-rust-analyzer-status
-          "bS" 'lsp-rust-switch-server
-          "gp" 'lsp-rust-find-parent-module
-          "gg" 'lsp-find-definition
-          "hm" 'lsp-rust-analyzer-expand-macro
-          "hs" 'lsp-rust-analyzer-syntax-tree
-          "v" 'lsp-extend-selection
-
-          "," 'lsp-rust-analyzer-rerun
-          "."  'lsp-rust-analyzer-run)))))
+        "," 'lsp-rust-analyzer-rerun
+        "."  'lsp-rust-analyzer-run))))
 
 (defun rust/post-init-smartparens ()
   (with-eval-after-load 'smartparens

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -60,8 +60,7 @@
       (spacemacs/declare-prefix-for-mode 'rustic-mode "mh" "help")
       (spacemacs/declare-prefix-for-mode 'rustic-mode "m=" "format")
       (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
-        ;; Deactivated for now see https://github.com/syl20bnr/spacemacs/issues/16203 for details
-        ;; "c." 'spacemacs/rustic-cargo-repeat
+        "c." 'rustic-cargo-run-rerun
         "c=" 'rustic-cargo-fmt
         "ca" 'rustic-cargo-add
         "cc" 'rustic-cargo-build

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -46,15 +46,10 @@
 (defun rust/init-rustic ()
   (use-package rustic
     :defer t
-    :after (lsp-mode flycheck)
     :mode ("\\.rs\\'" . rustic-mode)
     :init
     (progn
-      (spacemacs/enable-flycheck 'rustic-mode)
-
       (add-hook 'rustic-mode-hook #'spacemacs//rust-setup-backend)
-
-      ;; (push 'rustic-clippy flycheck-checkers)
 
       (spacemacs/declare-prefix-for-mode 'rustic-mode "mc" "cargo")
       (spacemacs/declare-prefix-for-mode 'rustic-mode "mt" "tests")
@@ -81,21 +76,28 @@
         "cv" 'rustic-cargo-check
         "cx" 'rustic-cargo-run
         "ta" 'rustic-cargo-test
-        "tt" 'rustic-cargo-current-test
+        "tt" 'rustic-cargo-current-test)
 
-        "=j" 'lsp-rust-analyzer-join-lines
-        "==" 'lsp-format-buffer
-        "Ti" 'lsp-inlay-hints-mode
-        "bD" 'lsp-rust-analyzer-status
-        "bS" 'lsp-rust-switch-server
-        "gp" 'lsp-rust-find-parent-module
-        "gg" 'lsp-find-definition
-        "hm" 'lsp-rust-analyzer-expand-macro
-        "hs" 'lsp-rust-analyzer-syntax-tree
-        "v" 'lsp-extend-selection
+      (with-eval-after-load 'flycheck
+        (spacemacs/enable-flycheck 'rustic-mode)
+        ;; (push 'rustic-clippy flycheck-checkers)
+        )
 
-        "," 'lsp-rust-analyzer-rerun
-        "."  'lsp-rust-analyzer-run))))
+      (with-eval-after-load 'lsp-mode
+        (spacemacs/set-leader-keys-for-major-mode 'rustic-mode
+          "=j" 'lsp-rust-analyzer-join-lines
+          "==" 'lsp-format-buffer
+          "Ti" 'lsp-inlay-hints-mode
+          "bD" 'lsp-rust-analyzer-status
+          "bS" 'lsp-rust-switch-server
+          "gp" 'lsp-rust-find-parent-module
+          "gg" 'lsp-find-definition
+          "hm" 'lsp-rust-analyzer-expand-macro
+          "hs" 'lsp-rust-analyzer-syntax-tree
+          "v" 'lsp-extend-selection
+
+          "," 'lsp-rust-analyzer-rerun
+          "."  'lsp-rust-analyzer-run)))))
 
 (defun rust/post-init-smartparens ()
   (with-eval-after-load 'smartparens

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -50,6 +50,8 @@
     :mode ("\\.rs\\'" . rustic-mode)
     :init
     (progn
+      (spacemacs/enable-flycheck 'rustic-mode)
+
       (add-hook 'rustic-mode-hook #'spacemacs//rust-setup-backend)
 
       ;; (push 'rustic-clippy flycheck-checkers)
@@ -94,9 +96,6 @@
 
         "," 'lsp-rust-analyzer-rerun
         "."  'lsp-rust-analyzer-run))))
-
-(defun rust/post-init-rustic ()
-  (spacemacs/enable-flycheck 'rustic-mode))
 
 (defun rust/post-init-smartparens ()
   (with-eval-after-load 'smartparens


### PR DESCRIPTION
The Rust layer was recently overhauled in #16078, but unfortunately the large rework caused some breaking changes.

This PR attempts to fix all the breakages I've noticed (although there may be others).

Unfortunately, Rustic does not support "repeating" the last cargo command, and also it is much more inconvenient to try to "auto-reload" rust-analyzer because Rustic runs all cargo commands asynchronously, so I have dropped that functionality (which was not working correctly anyhow).

(If folks would like me to attempt to resurrect that feature, I can try to do so, but most likely the best way to do that would be a patch to Rustic itself.)