### PR TITLE
Switch the default typescript linter to eslint

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3809,6 +3809,7 @@ files (thanks to Daniel Nicolai)
     =typescript/jump-to-type-def= (thanks to Roy Choo)
   - ~SPC m r i~ to organize imports (thanks to Stéphane Bisinger)
   - ~SPC m r f~ to rename file (thanks to Stéphane Bisinger)
+- Changed the default linter from tslint to eslint
 - Call tsfmt with extension of current buffer for TSX formatting
   (thanks to Victor Andrée)
 - Declare =tide-jump-to-definition= as async (thanks to Sylvain Benner)

--- a/layers/+lang/typescript/README.org
+++ b/layers/+lang/typescript/README.org
@@ -27,7 +27,7 @@ This layer adds support for TypeScript and TSX editing.
 - Eldoc-mode
 - Documentation at point
 - Auto complete
-- Flycheck with either tslint or eslint
+- Flycheck with either eslint or tslint
 - Jump to definition, Jump to type definition
 - Find occurrences (Imenu-mode)
 - Rename symbol
@@ -64,12 +64,12 @@ You can choose formatting tool:
                 typescript-fmt-tool 'typescript-formatter)))
 #+END_SRC
 
-You can choose either tslint (default) or eslint for linting:
+You can choose either eslint (default) or tslint (deprecated by upstream) for linting:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(
     (typescript :variables
-                typescript-linter 'tslint)))
+                typescript-linter 'eslint)))
 #+END_SRC
 
 Please be advised that tslint is now deprecated, and should only be used for
@@ -78,16 +78,16 @@ legacy projects. [[https://github.com/palantir/tslint#tslint][See TSLint Repo fo
 ** Pre-requisites
 You will need =node.js v0.12.0= or greater.
 
-If you want linting with tslint run:
-
-#+BEGIN_SRC shell
-  npm install -g typescript tslint
-#+END_SRC
-
 If you want linting with eslint run:
 
 #+BEGIN_SRC shell
   npm install eslint
+#+END_SRC
+
+If you want linting with tslint run:
+
+#+BEGIN_SRC shell
+  npm install -g typescript tslint
 #+END_SRC
 
 We need to use the project-local eslint installation in order to pick up plugins

--- a/layers/+lang/typescript/config.el
+++ b/layers/+lang/typescript/config.el
@@ -35,8 +35,8 @@ Possible values are 'tide (default), 'typescript-formatter and 'prettier.")
 Possible values are `tide' and `lsp'.
 If `nil' then `tide' is the default backend unless `lsp' layer is used.")
 
-(defvar typescript-linter 'tslint
-  "The linter to use for typescript. Possible values are `tslint' `eslint'")
+(defvar typescript-linter 'eslint
+  "The linter to use for typescript. Possible values are `eslint' `tslint'")
 
 (defvar typescript-lsp-linter t
   "If the backend is `lsp', and this variable is non-nil, then


### PR DESCRIPTION
tslint has been deprecated since 2019. Switch the default to eslint.
