### PR TITLE
Let-bind spacemacs-really-kill-emacs instead of setq-ing it

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1139,21 +1139,21 @@ dotspacemacs-persistent-server to be t"
 (defun spacemacs/save-buffers-kill-emacs ()
   "Save all changed buffers and exit Spacemacs"
   (interactive)
-  (setq spacemacs-really-kill-emacs t)
-  (save-buffers-kill-emacs))
+  (let ((spacemacs-really-kill-emacs t))
+    (save-buffers-kill-emacs)))
 
 (defun spacemacs/kill-emacs ()
   "Lose all changes and exit Spacemacs"
   (interactive)
-  (setq spacemacs-really-kill-emacs t)
-  (kill-emacs))
+  (let ((spacemacs-really-kill-emacs t))
+    (kill-emacs)))
 
 (defun spacemacs/prompt-kill-emacs ()
   "Prompt to save changed buffers and exit Spacemacs"
   (interactive)
-  (setq spacemacs-really-kill-emacs t)
   (save-some-buffers nil t)
-  (kill-emacs))
+  (let ((spacemacs-really-kill-emacs t))
+    (kill-emacs)))
 
 (defun spacemacs/frame-killer ()
   "Kill server buffer and hide the main Emacs window"

--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -459,8 +459,8 @@ ivy"
 (defun spacemacs/restart-emacs (&optional args)
   "Restart emacs."
   (interactive)
-  (setq spacemacs-really-kill-emacs t)
-  (restart-emacs args))
+  (let ((spacemacs-really-kill-emacs t))
+    (restart-emacs args)))
 
 (defun spacemacs/restart-emacs-resume-layouts (&optional args)
   "Restart emacs and resume layouts."


### PR DESCRIPTION
This prevents the bug where the user presses `SPC q s`, then presses
`C-g` when prompted about unsaved buffers, and then
`spacemacs-really-kill-emacs` is permanently set to `t` for the rest
of the Emacs session.