### PR TITLE
[spacemacs-defaults] Fix documentation for kill-emacs advice

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1110,27 +1110,44 @@ Returns a message with the count of killed buffers."
    (format "%d buffer(s) killed."
            (spacemacs/rudekill-matching-buffers regexp internal-too))))
 
-;; advise to prevent server from closing
+;; advise to prevent server from closing when the window manager closes the last
+;; Emacs frame, and `dotspacemacs-persistent-server' is non-nil.
 
 (defvar spacemacs-really-kill-emacs nil
-  "prevent window manager close from closing instance.")
+  "If nil, prevent window manager and \\[save-buffers-kill-emacs] from killing Emacs.
+
+This only has an effect if `dotspacemacs-persistent-server' is non-nil.
+
+This variable should be let-bound to t to actually kill Emacs,
+such as is done by \\[spacemacs/prompt-kill-emacs].")
 
 (defun spacemacs//persistent-server-running-p ()
-  "Requires spacemacs-really-kill-emacs to be toggled and
-dotspacemacs-persistent-server to be t"
+  "Return t if `spacemacs-really-kill-emacs' should prevent killing Emacs."
   (and (fboundp 'server-running-p)
        (server-running-p)
        dotspacemacs-persistent-server))
 
 (defadvice kill-emacs (around spacemacs-really-exit activate)
-  "Only kill emacs if a prefix is set"
+  "Do not actually kill Emacs if a persistent server is running.
+
+If `dotspacemacs-persistent-server' is non-nil and the Emacs
+server is running, just kill the current frame instead of the
+Emacs server.
+
+Setting `spacemacs-really-kill-emacs' non-nil overrides this advice."
   (if (and (not spacemacs-really-kill-emacs)
            (spacemacs//persistent-server-running-p))
       (spacemacs/frame-killer)
     ad-do-it))
 
 (defadvice save-buffers-kill-emacs (around spacemacs-really-exit activate)
-  "Only kill emacs if a prefix is set"
+  "Do not actually kill Emacs if a persistent server is running.
+
+If `dotspacemacs-persistent-server' is non-nil and the Emacs
+server is running, just kill the current frame instead of the
+Emacs server.
+
+Setting `spacemacs-really-kill-emacs' non-nil overrides this advice."
   (if (and (not spacemacs-really-kill-emacs)
            (spacemacs//persistent-server-running-p))
       (spacemacs/frame-killer)


### PR DESCRIPTION
The old advice referred to a prefix argument, which is not
correct.  (In fact, this documentation was not originally accurate to
begin with).