### PR TITLE
[shell] Use explicit-shell-file-name and $ESHELL as default shells

### DIFF
--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -49,7 +49,9 @@ for Linux/macOS), `eshell' (default for windows), `shell', `term', `vterm',
 (defvar shell-default-width 30
   "Width in percents for the shell window.")
 
-(defvar shell-default-term-shell shell-file-name
+(defvar shell-default-term-shell (or explicit-shell-file-name
+                                     (getenv "ESHELL")
+                                     shell-file-name)
   "Default shell to use in `term', `ansi-term' and `vterm' shells.")
 
 (defvar shell-enable-smart-eshell nil


### PR DESCRIPTION
M-x term and M-x ansi-term both check these two values before using
shell-file-name.  The description of the variable suggests that
explicit-shell-file-name should be used for user-requested shells,
whereas shell-file-name may be used (if different) for automatically
spawned shells for things like compilation.

Since shell-pop is more like a wrapper around M-x term, it seems
appropriate to check these variables first, the same way the
interactive form of M-x term does.