### PR TITLE
[spacemacs-layouts] fix warning for counsel-projectile on startup

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -251,6 +251,8 @@
         dotspacemacs-display-default-layout))
 
 
+(defun spacemacs-layouts/init-counsel-projectile ()
+  (use-package counsel-projectile :defer t))
 
 (defun spacemacs-layouts/post-init-counsel-projectile ()
   (spacemacs/set-leader-keys "pl" 'spacemacs/ivy-persp-switch-project)


### PR DESCRIPTION
Hi,

There is a warning on startup screen:
> Warnings: (w)
>    - Ignoring :requires for package counsel-projectile because layer
>    spacemacs-layouts does not own it. 

It's caused by the missed init funtion for the counsel-projectile package. 
This PR will fix that. 
Please help review it. Thanks.