### PR TITLE
[finance] Add evil jump before adding xact

### DIFF
--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -88,4 +88,6 @@
       :mode ledger-reconcile-mode)
     (evilified-state-evilify-map ledger-report-mode-map
       :eval-after-load ledger-report
-      :mode ledger-report-mode)))
+      :mode ledger-report-mode)
+    (define-advice ledger-add-transaction (:before (&rest _) add-evil-jump)
+      (evil-set-jump))))


### PR DESCRIPTION
ledger-add-transaction is likely to move point a decent distance (to
wherever the new transaction was added), so it's useful to be able to
jump back.