### PR TITLE
Set evil-command :jump property instead of advising command

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -447,8 +447,8 @@
       "ss"    'helm-swoop
       "sS"    'spacemacs/helm-swoop-region-or-symbol
       "s C-s" 'helm-multi-swoop-all)
-    (defadvice helm-swoop (before add-evil-jump activate)
-      (evil-set-jump))))
+
+    (evil-add-command-properties 'helm-swoop :jump t)))
 
 (defun helm/init-helm-themes ()
   (use-package helm-themes

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -326,8 +326,7 @@
       (clojure/fancify-symbols 'cider-repl-mode)
       (clojure/fancify-symbols 'cider-clojure-interaction-mode))
 
-    (defadvice cider-find-var (before add-evil-jump activate)
-      (evil-set-jump))))
+    (evil-add-command-properties 'cider-find-var :jump t)))
 
 (defun clojure/init-cider-eval-sexp-fu ()
   (with-eval-after-load 'eval-sexp-fu
@@ -613,7 +612,7 @@
 (defun clojure/init-flycheck-clojure ()
   (use-package flycheck-clojure
     :if (configuration-layer/package-usedp 'flycheck)
-    :config 
+    :config
     (flycheck-clojure-setup)
     (with-eval-after-load 'cider
       (flycheck-clojure-inject-jack-in-dependencies))))

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -89,5 +89,4 @@
     (evilified-state-evilify-map ledger-report-mode-map
       :eval-after-load ledger-report
       :mode ledger-report-mode)
-    (define-advice ledger-add-transaction (:before (&rest _) add-evil-jump)
-      (evil-set-jump))))
+    (evil-add-command-properties 'ledger-add-transaction :jump t)))


### PR DESCRIPTION
Evil-mode already installs a pre-command-hook for this purpose, so
advice is an unnecessarily hacky way of accomplishing this task.