### PR TITLE
Add support for basic formatting in sml-mode via smlfmt.

### DIFF
--- a/layers/+lang/sml/README.org
+++ b/layers/+lang/sml/README.org
@@ -19,11 +19,13 @@ Adds support for the [[http://www.smlnj.org][SML]] programming language to Space
 - Syntax highlighting
 - Integration of the =SML Repl= into Emacs
 - Basic completion of SML forms via =sml-electric-space=
+- Basic buffer formatting with =smlfmt=
 
 * Install
-To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+- To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =sml= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+- (Optional) To add support for formatting, [[https://github.com/shwestrick/smlfmt][Install smlfmt.]]
 
 * Key bindings
 ** Form Completion
@@ -32,6 +34,7 @@ file.
 |-------------+-------------------------------------------------------------------------------------------|
 | ~M-SPC~     | Inserts a space and completes the form before the cursor.                                 |
 | ~\vert{}~   | Inserts a pipe and adds a double arrow or copies the function name. Generally just works. |
+| ~SPC m s =~ | Format the current buffer using 'smlfmt'                                                  |
 
 ** REPL
 

--- a/layers/+lang/sml/packages.el
+++ b/layers/+lang/sml/packages.el
@@ -53,6 +53,23 @@
       (sml-send-function t)
       (evil-insert-state))
 
+    (defun spacemacs/sml-format-buffer ()
+      "Format the current buffer with 'smlfmt'"
+      (interactive)
+      (if (executable-find "smlfmt")
+          (let ((exit-code (shell-command-on-region
+             (point-min)
+             (point-max)
+             "smlfmt --check --read-only"
+             (current-buffer)
+             t
+             "*Messages*"
+             t)))
+            (if (zerop exit-code)
+                (message "Formatting Done.")
+              (message "Formatting Failed!")))
+          (error "smlfmt not found. Please refer to the README to install it.")))
+
     (spacemacs/set-leader-keys-for-major-mode 'sml-mode
       ;; REPL
       "'"  'run-sml
@@ -63,7 +80,8 @@
       "si" 'run-sml
       "sr" 'sml-prog-proc-send-region
       "sR" 'spacemacs/sml-prog-proc-send-region-and-focus
-      "ss" 'run-sml)
+      "ss" 'run-sml
+      "s=" 'spacemacs/sml-format-buffer)
     (define-key sml-mode-map (kbd "RET") 'reindent-then-newline-and-indent)
     (define-key sml-mode-map (kbd "M-SPC") 'sml-electric-space)
     (define-key sml-mode-map (kbd "|") 'sml-electric-pipe)))


### PR DESCRIPTION
Very minimal support is added for code formatting in sml-mode via smlfmt via ~SPC m s =~ keybinding. modifications were made only to the +lang sml layer packages.el and README.org file. the layer expects smlfmt to be optionally installed, therefore gracefully handles trigger of command in the absence of smlfmt in PATH.

Kudos to the folks who maintain spacemacs!
