### PR TITLE
Migrate most uses of defadvice to advice-add (or define-advice)

### DIFF
--- a/core/aprilfool/zemacs.el
+++ b/core/aprilfool/zemacs.el
@@ -109,18 +109,18 @@
          'type 'help-url
          'help-args (cdr l))))))
 
-(defadvice configuration-layer/initialize (before zemacs/initialize activate)
+(define-advice configuration-layer/initialize (:before (&rest _) zemacs/initialize)
   (setq dotspacemacs-startup-banner "~/.emacs.d/core/banners/img/zemacs.png"))
 
-(defadvice spacemacs-buffer//inject-version
-    (around zemacs/inject-version activate)
+(define-advice spacemacs-buffer//inject-version
+    (:around (f &rest args) zemacs/inject-version)
   (let ((emacs-version "99.9999999")
         (dotspacemacs-distribution "zemacs")
         (spacemacs-version "af-1.01"))
-    ad-do-it))
+    (apply f args)))
 
-(defadvice spacemacs-buffer/insert-banner-and-buttons
-    (after zemacs/insert-banner-and-buttons activate)
+(define-advice spacemacs-buffer/insert-banner-and-buttons
+    (:after (&rest _) zemacs/insert-banner-and-buttons)
   ;; always display the release note
   (spacemacs-buffer//insert-release-note-widget
    (concat spacemacs-release-notes-directory

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -24,18 +24,15 @@
 (defvar spacemacs--after-display-system-init-list '()
   "List of functions to be run after the display system is initialized.")
 
-(defadvice server-create-window-system-frame
-    (after spacemacs-init-display activate)
+(define-advice server-create-window-system-frame
+    (:after (&rest _) spacemacs-init-display)
   "After Emacs server creates a frame, run functions queued in
 `SPACEMACS--AFTER-DISPLAY-SYSTEM-INIT-LIST' to do any setup that needs to have
 the display system initialized."
-  (progn
-    (dolist (fn (reverse spacemacs--after-display-system-init-list))
-      (funcall fn))
-    (ad-disable-advice 'server-create-window-system-frame
-                       'after
-                       'spacemacs-init-display)
-    (ad-activate 'server-create-window-system-frame)))
+  (dolist (fn (reverse spacemacs--after-display-system-init-list))
+    (funcall fn))
+  (advice-remove 'server-create-window-system-frame
+                 #'server-create-window-system-frame@spacemacs-init-display))
 
 (defmacro spacemacs|do-after-display-system-init (&rest body)
   "If the display-system is initialized, run `BODY', otherwise,

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -1077,33 +1077,25 @@ Informs users of error and prompts for default editing style for use during
 error recovery."
   (load (concat dotspacemacs-template-directory
                 ".spacemacs.template"))
-  (defadvice dotspacemacs/layers
-      (after error-recover-preserve-packages activate)
-    (progn
-      (setq-default dotspacemacs-install-packages 'used-but-keep-unused)
-      (ad-disable-advice 'dotspacemacs/layers 'after
-                         'error-recover-preserve-packages)
-      (ad-activate 'dotspacemacs/layers)))
-  (defadvice dotspacemacs/init
-      (after error-recover-prompt-for-style activate)
-    (progn
-      (setq-default dotspacemacs-editing-style
-                    (intern
-                     (ido-completing-read
-                      (format
-                       (concat
-                        "Spacemacs encountered an error while "
-                        "loading your `%s' file.\n"
-                        "Pick your editing style for recovery "
-                        "(use left and right arrows): ")
-                       dotspacemacs-filepath)
-                      '(("vim" vim)
-                        ("emacs" emacs)
-                        ("hybrid" hybrid))
-                      nil t nil nil 'vim)))
-      (ad-disable-advice 'dotspacemacs/init 'after
-                         'error-recover-prompt-for-style)
-      (ad-activate 'dotspacemacs/init))))
+  (define-advice dotspacemacs/layers (:after (&rest _) error-recover-preserve-packages)
+    (setq-default dotspacemacs-install-packages 'used-but-keep-unused)
+    (advice-remove 'dotspacemacs/layers #'dotspacemacs/layers@error-recover-preserve-packages))
+  (define-advice dotspacemacs/init (:after (&rest _) error-recover-prompt-for-style)
+    (setq-default dotspacemacs-editing-style
+                  (intern
+                   (ido-completing-read
+                    (format
+                     (concat
+                      "Spacemacs encountered an error while "
+                      "loading your `%s' file.\n"
+                      "Pick your editing style for recovery "
+                      "(use left and right arrows): ")
+                     dotspacemacs-filepath)
+                    '(("vim" vim)
+                      ("emacs" emacs)
+                      ("hybrid" hybrid))
+                    nil t nil nil 'vim)))
+    (advice-remove 'dotspacemacs/init #'dotspacemacs/init@error-recover-prompt-for-style)))
 
 (defun dotspacemacs//test-dotspacemacs/layers ()
   "Tests for `dotspacemacs/layers'"

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -434,11 +434,10 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
   (interactive)
   (spacemacs/cycle-spacemacs-theme t))
 
-(defadvice load-theme (after spacemacs/load-theme-adv activate)
+(define-advice load-theme (:after (theme &rest _) spacemacs/load-theme-adv)
   "Perform post load processing."
-  (let ((theme (ad-get-arg 0)))
-    (setq spacemacs--cur-theme theme)
-    (spacemacs/post-theme-init theme)))
+  (setq spacemacs--cur-theme theme)
+  (spacemacs/post-theme-init theme))
 
 (defun spacemacs/theme-loader ()
   "Call appropriate theme loader based on completion framework."

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -437,10 +437,7 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
 (defadvice load-theme (after spacemacs/load-theme-adv activate)
   "Perform post load processing."
   (let ((theme (ad-get-arg 0)))
-    ;; Without this a popup is raised every time emacs25 starts up for
-    ;; assignment to a free variable
-    (with-no-warnings
-      (setq spacemacs--cur-theme theme))
+    (setq spacemacs--cur-theme theme)
     (spacemacs/post-theme-init theme)))
 
 (defun spacemacs/theme-loader ()

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -447,8 +447,8 @@
       "ss"    'helm-swoop
       "sS"    'spacemacs/helm-swoop-region-or-symbol
       "s C-s" 'helm-multi-swoop-all)
-    (defadvice helm-swoop (before add-evil-jump activate)
-      (evil-set-jump))))
+
+    (evil-add-command-properties 'helm-swoop :jump t)))
 
 (defun helm/init-helm-themes ()
   (use-package helm-themes

--- a/layers/+distributions/spacemacs-bootstrap/local/holy-mode/holy-mode.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/holy-mode/holy-mode.el
@@ -28,22 +28,22 @@
 
 ;;; Code:
 
-(defadvice evil-insert-state (around holy-insert-to-emacs-state disable)
-  "Forces Emacs state."
-  (if (equal -1 (ad-get-arg 0))
-      ad-do-it
+(defun holy-insert-to-emacs-state (f &optional arg &rest args)
+  "Advice around `evil-insert-state' to force Emacs state."
+  (if (equal -1 arg)
+      (apply f arg args)
     (evil-emacs-state)))
 
-(defadvice evil-motion-state (around holy-motion-to-emacs-state disable)
-  "Forces Emacs state."
-  (if (equal -1 (ad-get-arg 0))
-      ad-do-it
+(defun holy-motion-to-emacs-state (f &optional arg &rest args)
+  "Advice around `evil-motion-state' to force Emacs state."
+  (if (equal -1 arg)
+      (apply f arg args)
     (evil-emacs-state)))
 
-(defadvice evil-normal-state (around holy-normal-to-emacs-state disable)
-  "Forces Emacs state."
-  (if (equal -1 (ad-get-arg 0))
-      ad-do-it
+(defun holy-normal-to-emacs-state (f &optional arg &rest args)
+  "Advice around `evil-normal-state' to force Emacs state."
+  (if (equal -1 arg)
+      (apply f arg args)
     (evil-emacs-state)))
 
 ;;;###autoload
@@ -63,12 +63,9 @@ The `insert state' is replaced by the `emacs state'."
   ;; make all buffers' initial state emacs
   (push '("." . emacs) evil-buffer-regexps)
   ;; replace evil states by `emacs state'
-  (ad-enable-advice 'evil-insert-state 'around 'holy-insert-to-emacs-state)
-  (ad-enable-advice 'evil-motion-state 'around 'holy-motion-to-emacs-state)
-  (ad-enable-advice 'evil-normal-state 'around 'holy-normal-to-emacs-state)
-  (ad-activate 'evil-insert-state)
-  (ad-activate 'evil-motion-state)
-  (ad-activate 'evil-normal-state)
+  (advice-add 'evil-insert-state :around #'holy-insert-to-emacs-state)
+  (advice-add 'evil-motion-state :around #'holy-motion-to-emacs-state)
+  (advice-add 'evil-normal-state :around #'holy-normal-to-emacs-state)
   ;; key bindings hooks for dynamic switching of editing styles
   (run-hook-with-args 'spacemacs-editing-style-hook 'emacs)
   ;; initiate `emacs state' and enter the church
@@ -79,12 +76,9 @@ The `insert state' is replaced by the `emacs state'."
   ;; restore defaults
   (setq evil-buffer-regexps (delete '("." . emacs) evil-buffer-regexps))
   ;; restore evil states
-  (ad-disable-advice 'evil-insert-state 'around 'holy-insert-to-emacs-state)
-  (ad-disable-advice 'evil-motion-state 'around 'holy-motion-to-emacs-state)
-  (ad-disable-advice 'evil-normal-state 'around 'holy-normal-to-emacs-state)
-  (ad-activate 'evil-insert-state)
-  (ad-activate 'evil-motion-state)
-  (ad-activate 'evil-normal-state)
+  (advice-remove 'evil-insert-state #'holy-insert-to-emacs-state)
+  (advice-remove 'evil-motion-state #'holy-motion-to-emacs-state)
+  (advice-remove 'evil-normal-state #'holy-normal-to-emacs-state)
   ;; restore key bindings
   (run-hook-with-args 'spacemacs-editing-style-hook 'vim)
   ;; restore the states

--- a/layers/+distributions/spacemacs-bootstrap/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/hybrid-mode/hybrid-mode.el
@@ -67,16 +67,16 @@ behavior (for instance it support C-r pasting)."
 (defvar hybrid-mode-default-state-backup evil-default-state
   "Backup of `evil-default-state'.")
 
-(defadvice evil-insert-state (around hybrid-insert-to-hybrid-state disable)
-  "Forces Hybrid state."
+(defun hybrid-insert-to-hybrid-state (f &optional arg)
+  "Advice around `evil-insert-state' to force Hybrid state."
   (evil-hybrid-state))
 
-(defadvice evil-evilified-state (around hybrid-evilified-to-hybrid-state disable)
-  "Forces Hybrid state."
-  (if (equal -1 (ad-get-arg 0))
-      ad-do-it
+(defun hybrid-evilified-to-hybrid-state (f &optional arg)
+  "Advice around `evil-evilified-state' to force Hybrid state."
+  (if (equal -1 arg)
+      (apply f arg)
     (if hybrid-style-enable-evilified-state
-        ad-do-it
+        (apply f arg)
       ;; seems better to set the emacs state instead of hybrid for evilified
       ;; buffers
       (evil-emacs-state))))
@@ -96,12 +96,10 @@ behavior (for instance it support C-r pasting)."
   (setq hybrid-mode-default-state-backup evil-default-state
         evil-default-state hybrid-style-default-state)
   ;; replace evil states by `hybrid state'
-  (ad-enable-advice 'evil-insert-state
-                    'around 'hybrid-insert-to-hybrid-state)
-  (ad-enable-advice 'evil-evilified-state
-                    'around 'hybrid-evilified-to-hybrid-state)
-  (ad-activate 'evil-insert-state)
-  (ad-activate 'evil-evilified-state)
+  (advice-add 'evil-insert-state
+              :around #'hybrid-insert-to-hybrid-state)
+  (advice-add 'evil-evilified-state
+              :around #'hybrid-evilified-to-hybrid-state)
   ;; key bindings hooks for dynamic switching of editing styles
   (run-hook-with-args 'spacemacs-editing-style-hook 'hybrid)
   ;; initiate `hybrid state'
@@ -111,12 +109,10 @@ behavior (for instance it support C-r pasting)."
   "Disable the hybrid editing style (reverting to 'vim style)."
   (setq evil-default-state hybrid-mode-default-state-backup)
   ;; restore evil states
-  (ad-disable-advice 'evil-insert-state
-                     'around 'hybrid-insert-to-hybrid-state)
-  (ad-disable-advice 'evil-evilified-state
-                     'around 'hybrid-evilified-to-hybrid-state)
-  (ad-activate 'evil-insert-state)
-  (ad-activate 'evil-evilified-state)
+  (advice-remove 'evil-insert-state
+                 #'hybrid-insert-to-hybrid-state)
+  (advice-remove 'evil-evilified-state
+                 #'hybrid-evilified-to-hybrid-state)
   ;; restore key bindings
   (run-hook-with-args 'spacemacs-editing-style-hook 'vim)
   ;; restore the states

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -308,13 +308,13 @@
       (cond ((configuration-layer/layer-used-p 'helm) 'spacemacs/helm-find-files)
             ((configuration-layer/layer-used-p 'ivy) 'spacemacs/counsel-find-file))))
 
-  ;; support smart 1parens-strict-mode
+  ;; support smartparens-strict-mode
   (when (configuration-layer/package-used-p 'smartparens)
-    (defadvice evil-delete-backward-char-and-join
-        (around spacemacs/evil-delete-backward-char-and-join activate)
+    (define-advice evil-delete-backward-char-and-join
+        (:around (f &rest args) spacemacs/evil-delete-backward-char-and-join)
       (if (bound-and-true-p smartparens-strict-mode)
           (call-interactively 'sp-backward-delete-char)
-        ad-do-it)))
+        (apply f args))))
 
   ;; Define history commands for comint
   (when (eq dotspacemacs-editing-style 'vim)

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -124,14 +124,14 @@
     :defer t))
 
 (defun chinese/post-init-org ()
-  (defadvice org-html-paragraph (before org-html-paragraph-advice
-                                        (paragraph contents info) activate)
+  (define-advice org-html-paragraph
+      (:around (f paragraph contents info) org-html-paragraph-advice)
     "Join consecutive Chinese lines into a single long line without
 unwanted space when exporting org-mode to html."
-    (let* ((origin-contents (ad-get-arg 1))
+    (let* ((origin-contents contents)
            (fix-regexp "[[:multibyte:]]")
            (fixed-contents
             (replace-regexp-in-string
              (concat
               "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)") "\\1\\2" origin-contents)))
-      (ad-set-arg 1 fixed-contents))))
+      (funcall f paragraph fixed-contents info))))

--- a/layers/+intl/japanese/packages.el
+++ b/layers/+intl/japanese/packages.el
@@ -94,14 +94,14 @@
     (add-hook 'text-mode-hook 'pangu-spacing-mode)))
 
 (defun japanese/post-init-org ()
-  (defadvice org-html-paragraph (before org-html-paragraph-advice
-                                        (paragraph contents info) activate)
+  (define-advice org-html-paragraph
+      (:around (f paragraph contents info) org-html-paragraph-advice)
     "Join consecutive Japanese lines into a single long line without
 unwanted space when exporting org-mode to html."
-    (let* ((origin-contents (ad-get-arg 1))
+    (let* ((origin-contents contents)
            (fix-regexp "[[:multibyte:]]")
            (fixed-contents
             (replace-regexp-in-string
              (concat
               "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)") "\\1\\2" origin-contents)))
-      (ad-set-arg 1 fixed-contents))))
+      (funcall f paragraph fixed-contents info))))

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -326,8 +326,7 @@
       (clojure/fancify-symbols 'cider-repl-mode)
       (clojure/fancify-symbols 'cider-clojure-interaction-mode))
 
-    (defadvice cider-find-var (before add-evil-jump activate)
-      (evil-set-jump))))
+    (evil-add-command-properties 'cider-find-var :jump t)))
 
 (defun clojure/init-cider-eval-sexp-fu ()
   (with-eval-after-load 'eval-sexp-fu
@@ -613,7 +612,7 @@
 (defun clojure/init-flycheck-clojure ()
   (use-package flycheck-clojure
     :if (configuration-layer/package-usedp 'flycheck)
-    :config 
+    :config
     (flycheck-clojure-setup)
     (with-eval-after-load 'cider
       (flycheck-clojure-inject-jack-in-dependencies))))

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -42,14 +42,14 @@
 (defun common-lisp/init-common-lisp-snippets ())
 
 (defun common-lisp/post-init-evil ()
-  (defadvice slime-last-expression (around evil activate)
+  (define-advice slime-last-expression (:around (f &rest args) evil)
     "In normal-state or motion-state, last sexp ends at point."
     (if (and (not evil-move-beyond-eol)
              (or (evil-normal-state-p) (evil-motion-state-p)))
         (save-excursion
           (unless (or (eobp) (eolp)) (forward-char))
-          ad-do-it)
-      ad-do-it)))
+          (apply f args))
+      (apply f args))))
 
 (defun common-lisp/pre-init-evil-cleverparens ()
   (spacemacs|use-package-add-hook evil-cleverparens

--- a/layers/+lang/haskell/README.org
+++ b/layers/+lang/haskell/README.org
@@ -4,7 +4,7 @@
 
 [[file:img/haskell.png]]
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#quick-start-and-how-to-use-this-readme][Quick start (and how to use this README)]]
@@ -394,9 +394,9 @@ placing the following snippet in your =dotspacemacs/user-config= function:
 
 #+BEGIN_SRC emacs-lisp
   (when (configuration-layer/layer-used-p 'haskell)
-      (defadvice haskell-interactive-switch (after spacemacs/haskell-interactive-switch-advice activate)
-        (when (eq dotspacemacs-editing-style 'vim)
-          (call-interactively 'evil-insert))))
+    (define-advice haskell-interactive-switch (:after (&rest _) spacemacs/haskell-interactive-switch-advice)
+      (when (eq dotspacemacs-editing-style 'vim)
+        (call-interactively 'evil-insert))))
 #+END_SRC
 
 ** Indentation doesn't reset when pressing return after an empty line

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -89,7 +89,7 @@
         (kbd "C-k") 'previous-error-no-select
         (kbd "RET") 'spacemacs/anaconda-view-forward-and-push))
     (spacemacs|hide-lighter anaconda-mode)
-    (defadvice anaconda-mode-goto (before python/anaconda-mode-goto activate)
+    (define-advice anaconda-mode-goto (:before (&rest _) python/anaconda-mode-goto)
       (evil--jumps-push))
     (add-to-list 'spacemacs-jump-handlers-python-mode
                  '(anaconda-mode-find-definitions :async t))))
@@ -451,25 +451,25 @@
   (spacemacs/add-to-hook 'python-mode-hook
                          '(semantic-mode
                            spacemacs//python-imenu-create-index-use-semantic-maybe))
-  (defadvice semantic-python-get-system-include-path
-      (around semantic-python-skip-error-advice activate)
+  (define-advice semantic-python-get-system-include-path
+      (:around (f &rest args) semantic-python-skip-error-advice)
     "Don't cause error when Semantic cannot retrieve include
 paths for Python then prevent the buffer to be switched. This
 issue might be fixed in Emacs 25. Until then, we need it here to
 fix this issue."
     (condition-case-unless-debug nil
-        ad-do-it
+        (apply f args)
       (error nil))))
 
 (defun python/pre-init-smartparens ()
   (spacemacs|use-package-add-hook smartparens
     :post-config
-    (defadvice python-indent-dedent-line-backspace
-        (around python/sp-backward-delete-char activate)
+    (define-advice python-indent-dedent-line-backspace
+        (:around (f &rest args) python/sp-backward-delete-char)
       (let ((pythonp (or (not smartparens-strict-mode)
                          (char-equal (char-before) ?\s))))
         (if pythonp
-            ad-do-it
+            (apply f args)
           (call-interactively 'sp-backward-delete-char))))))
 (defun python/post-init-smartparens ()
   (add-hook 'inferior-python-mode-hook #'spacemacs//activate-smartparens))

--- a/layers/+readers/speed-reading/packages.el
+++ b/layers/+readers/speed-reading/packages.el
@@ -39,7 +39,7 @@
       (internal-show-cursor (selected-window) nil))
     (spacemacs/set-leader-keys "ars" 'speed-reading/start-spray)
 
-    (defadvice spray-quit (after speed-reading//quit-spray activate)
+    (define-advice spray-quit (:after (&rest _) speed-reading//quit-spray)
       "Correctly quit spray."
       (internal-show-cursor (selected-window) t)
       (evil-normal-state))

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -62,8 +62,8 @@
     (add-hook 'helm-find-files-after-init-hook
               'spacemacs//helm-find-files-enable-helm--in-fuzzy)
     ;; setup advices
-    (defadvice spacemacs/post-theme-init
-        (after spacemacs/helm-header-line-adv activate)
+    (define-advice spacemacs/post-theme-init
+        (:after (&rest _) spacemacs/helm-header-line-adv)
       "Update defaults for `helm' header line whenever a new theme is loaded"
       ;; TODO factorize face definition with those defined in config.el
       (setq helm-source-header-default-foreground
@@ -172,11 +172,11 @@
     (add-hook 'ido-minibuffer-setup-hook 'spacemacs//ido-minibuffer-setup)
     (add-hook 'ido-setup-hook 'spacemacs//ido-setup)
 
-    (defadvice ido-read-internal
-        (around ido-read-internal-with-minibuffer-other-window activate)
+    (define-advice ido-read-internal
+        (:around (f &rest args) ido-read-internal-with-minibuffer-other-window)
       (let* (ido-exit-minibuffer-target-window
              (this-buffer (current-buffer))
-             (result ad-do-it))
+             (result (apply f args)))
         (cond
          ((equal ido-exit-minibuffer-target-window 'other)
           (if (= 1 (count-windows))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1127,7 +1127,7 @@ such as is done by \\[spacemacs/prompt-kill-emacs].")
        (server-running-p)
        dotspacemacs-persistent-server))
 
-(defadvice kill-emacs (around spacemacs-really-exit activate)
+(define-advice kill-emacs (:around (f &rest args) spacemacs-really-exit)
   "Do not actually kill Emacs if a persistent server is running.
 
 If `dotspacemacs-persistent-server' is non-nil and the Emacs
@@ -1138,9 +1138,9 @@ Setting `spacemacs-really-kill-emacs' non-nil overrides this advice."
   (if (and (not spacemacs-really-kill-emacs)
            (spacemacs//persistent-server-running-p))
       (spacemacs/frame-killer)
-    ad-do-it))
+    (apply f args)))
 
-(defadvice save-buffers-kill-emacs (around spacemacs-really-exit activate)
+(define-advice save-buffers-kill-emacs (:around (f &rest args) spacemacs-really-exit)
   "Do not actually kill Emacs if a persistent server is running.
 
 If `dotspacemacs-persistent-server' is non-nil and the Emacs
@@ -1151,7 +1151,7 @@ Setting `spacemacs-really-kill-emacs' non-nil overrides this advice."
   (if (and (not spacemacs-really-kill-emacs)
            (spacemacs//persistent-server-running-p))
       (spacemacs/frame-killer)
-    ad-do-it))
+    (apply f args)))
 
 (defun spacemacs/save-buffers-kill-emacs ()
   "Save all changed buffers and exit Spacemacs"

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -174,30 +174,29 @@
     :config
     ;; add search capability to expand-region
     (when (configuration-layer/package-used-p 'helm-ag)
-      (defadvice er/prepare-for-more-expansions-internal
-          (around helm-ag/prepare-for-more-expansions-internal activate)
-        ad-do-it
-        (let ((new-msg (concat (car ad-return-value)
+      (define-advice er/prepare-for-more-expansions-internal (:around (f &rest args) helm-ag/prepare-for-more-expansions-internal)
+        (let* ((return-val (apply f args))
+               (new-msg (concat (car return-value)
                                 ", / to search in project, "
                                 "f to search in files, "
                                 "b to search in opened buffers"))
-              (new-bindings (cdr ad-return-value)))
+               (new-bindings (cdr return-value)))
           (cl-pushnew
-            '("/" (lambda ()
-                    (call-interactively
+           '("/" (lambda ()
+                   (call-interactively
                     'spacemacs/helm-project-smart-do-search-region-or-symbol)))
-            new-bindings)
+           new-bindings)
           (cl-pushnew
-            '("f" (lambda ()
-                    (call-interactively
+           '("f" (lambda ()
+                   (call-interactively
                     'spacemacs/helm-files-smart-do-search-region-or-symbol)))
-            new-bindings)
+           new-bindings)
           (cl-pushnew
-            '("b" (lambda ()
-                    (call-interactively
+           '("b" (lambda ()
+                   (call-interactively
                     'spacemacs/helm-buffers-smart-do-search-region-or-symbol)))
-            new-bindings)
-          (setq ad-return-value (cons new-msg new-bindings))))
+           new-bindings)
+          (cons new-msg new-bindings)))
       (setq expand-region-contract-fast-key "V"
             expand-region-reset-fast-key "r"))))
 

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -229,7 +229,7 @@
       (spacemacs/find-dotfile))
     :config
     (spacemacs|hide-lighter persp-mode)
-    (defadvice persp-activate (before spacemacs//save-toggle-layout activate)
+    (define-advice persp-activate (:before (&rest _) spacemacs//save-toggle-layout)
       (setq spacemacs--last-selected-layout persp-last-persp-name))
     (add-hook 'persp-mode-hook 'spacemacs//layout-autosave)
     (advice-add 'persp-load-state-from-file

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -188,15 +188,14 @@
       (kbd "C-k") 'doc-view-kill-proc
       (kbd "C-u") 'doc-view-scroll-down-or-previous-page)
     ;; fixed a weird issue where toggling display does not
-    ;; swtich to text mode
-    (defadvice doc-view-toggle-display
-        (around spacemacs/doc-view-toggle-display activate)
+    ;; switch to text mode
+    (define-advice doc-view-toggle-display (:around (f &rest args) spacemacs/doc-view-toggle-display)
       (if (eq major-mode 'doc-view-mode)
           (progn
-            ad-do-it
+            (apply f args)
             (text-mode)
             (doc-view-minor-mode))
-        ad-do-it))))
+        (apply f args)))))
 
 (defun spacemacs-navigation/init-view ()
   (use-package view

--- a/layers/+tags/cscope/packages.el
+++ b/layers/+tags/cscope/packages.el
@@ -69,5 +69,5 @@
         "gr" 'helm-cscope-find-this-symbol
         "gx" 'helm-cscope-find-this-text-string))
     :config
-    (defadvice helm-cscope-find-this-symbol (before cscope/goto activate)
+    (define-advice helm-cscope-find-this-symbol (:before (&rest _) cscope/goto)
       (evil--jumps-push))))

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -93,7 +93,7 @@
                                                   font-lock-keyword-face
                                                   font-lock-function-name-face
                                                   font-lock-variable-name-face))
-    (defadvice spacemacs/post-theme-init (after colors/post-theme-init activate)
+    (define-advice spacemacs/post-theme-init (:after (&rest _) colors/post-theme-init)
       "Adjust lightness and brightness of rainbow-identifiers on post theme init."
       (colors//tweak-theme-colors spacemacs--cur-theme))
     ;; key bindings

--- a/layers/+tools/finance/packages.el
+++ b/layers/+tools/finance/packages.el
@@ -89,5 +89,4 @@
     (evilified-state-evilify-map ledger-report-mode-map
       :eval-after-load ledger-report
       :mode ledger-report-mode)
-    (define-advice ledger-add-transaction (:before (&rest _) add-evil-jump)
-      (evil-set-jump))))
+    (evil-add-command-properties 'ledger-add-transaction :jump t)))

--- a/layers/+tools/geolocation/packages.el
+++ b/layers/+tools/geolocation/packages.el
@@ -45,7 +45,7 @@
     :init
     (add-hook 'osx-location-changed-hook 'spacemacs//osx-location-changed-rase)
     (osx-location-watch)
-    (defadvice rase-start (around test-calendar activate)
+    (define-advice rase-start (:before-while (&rest _) test-calendar)
       "Don't call `raise-start' if `calendar-latitude' or
 `calendar-longitude' are not bound yet, or still nil.
 
@@ -55,9 +55,8 @@ values, and will fail under such conditions, when calling
 
 Also, it allows users who enabled service such as `osx-location'
 to not have to set these variables manually when enabling this layer."
-      (if (and (bound-and-true-p calendar-longitude)
-               (bound-and-true-p calendar-latitude))
-          ad-do-it))
+      (and (bound-and-true-p calendar-longitude)
+           (bound-and-true-p calendar-latitude)))
     (rase-start t)))
 
 (defun geolocation/init-sunshine ()

--- a/layers/+tools/vagrant/packages.el
+++ b/layers/+tools/vagrant/packages.el
@@ -50,7 +50,7 @@
     :defer t
     :init
     (defvar spacemacs--vagrant-tramp-loaded nil)
-    (defadvice vagrant-tramp-term (before spacemacs//load-vagrant activate)
+    (define-advice vagrant-tramp-term (:before (&rest _) spacemacs//load-vagrant)
       "Lazy load vagrant-tramp."
       (unless spacemacs--vagrant-tramp-loaded
         (vagrant-tramp-add-method)

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -54,8 +54,7 @@
   (interactive)
   (exwm-workspace-switch exwm--toggle-workspace))
 
-(defadvice exwm-workspace-switch
-    (before save-toggle-workspace activate)
+(define-advice exwm-workspace-switch (:before (&rest _) save-toggle-workspace)
   (setq exwm--toggle-workspace exwm-workspace-current-index))
 
 


### PR DESCRIPTION
defadvice is more complex and has many quirks, and has long been
deprecated in favor of advice-add and related mechanisms.

I did not change the occurrences in the spacemacs-purpose layer, which
are a decent bit more complex and also appear to be derived from some
upstream.  Similarly, I did not modify frame-cmds.el, which is a copy
of an upstream file.