### PR TITLE
Update/improve prefix functionality in window delete commands

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2338,7 +2338,7 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w c C~            | toggle visual distraction free mode                                         |
 | ~SPC w c .~            | center buffer and enable centering transient state                          |
 | ~SPC w d~              | delete a window                                                             |
-| ~SPC u SPC w d~        | delete a window and its current buffer (does not delete the file)           |
+| ~NUM SPC w d~          | delete window number NUM                                                    |
 | ~SPC w D~              | delete another window using [[https://github.com/abo-abo/ace-window][ace-window]]                                      |
 | ~SPC u SPC w D~        | delete another window and its current buffer using [[https://github.com/abo-abo/ace-window][ace-window]]               |
 | ~SPC w t~              | toggle window dedication (dedicated window cannot be reused by a mode)      |
@@ -2368,6 +2368,7 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w w~              | cycle and focus between windows                                             |
 | ~SPC w W~              | select window using [[https://github.com/abo-abo/ace-window][ace-window]]                                              |
 | ~SPC w x~              | delete a window and its current buffer (does not delete the file)           |
+| ~NUM SPC w x~          | delete window number NUM and its current buffer (does not delete the file)  |
 | ~SPC w [~              | shrink window horizontally (enter transient state)                          |
 | ~SPC w ]~              | enlarge window horizontally (enter transient state)                         |
 | ~SPC w {~              | shrink window vertically (enter transient state)                            |

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -261,7 +261,7 @@
    ("R" spacemacs/safe-revert-buffer "Revert buffer...")
    ("s" spacemacs/switch-to-scratch-buffer "Scratch buffer")
    ("u" spacemacs/reopen-killed-buffer "Reopen last killed buffer")
-   ("x" kill-buffer-and-window "Kill buffer and close window")
+   ("x" spacemacs/kill-buffer-and-window "Kill buffer and close window")
    ("Y" spacemacs/copy-whole-buffer-to-clipboard "Copy buffer")
    ("w" read-only-mode "Toggle read-only"))))
 ;; Cycling settings -----------------------------------------------------------
@@ -685,7 +685,7 @@ respond to this toggle."
   "wv"  'split-window-right
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
-  "wx"  'kill-buffer-and-window
+  "wx"  'spacemacs/kill-buffer-and-window
   "w/"  'split-window-right
   "w="  'balance-windows-area
   "w+"  'spacemacs/window-layout-toggle


### PR DESCRIPTION
(Spac)Emacs comes with the `kill-buffer-and-window` by default (on `SPC w x`). Also, deleting other windows (and buffers) simply by prefixing the window delete commands with a numerical prefix is very convenient. Therefore, this commit updates (or adds) the functionality of the prefix in the window delete commands.

Summary: to delete another window (and optionally its buffer), simply prefix `SPC w d` (or `SPC w x`) with the window number.

This functionality exists in the `winum` package itself (on `winum-select-window-by-number`), but for deletion that command requires a negative prefix which is cumbersome.