### PR TITLE
Enable auto-yasnippet for company

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -265,4 +265,5 @@ Emacs style:
 |-------------+---------------------------------------------------------------------------|
 | ~SPC i S c~ | create a snippet from an active region                                    |
 | ~SPC i S e~ | Expand the snippet just created with ~SPC i y~                            |
+| ~SPC i S h~ | Expand a snippet from history which was previously created with ~SPC i y~ |
 | ~SPC i S w~ | Write the snippet inside =private/snippets= directory for future sessions |

--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -373,6 +373,12 @@ MODE parameter must match the :modes values used in the call to
   (call-interactively 'aya-expand)
   (evil-insert-state))
 
+(defun spacemacs/auto-yasnippet-expand-from-history ()
+  "Call `yas-expand-from-history' and switch to `insert state'"
+  (interactive)
+  (call-interactively 'aya-expand-from-history)
+  (evil-insert-state))
+
 
 ;; Yasnippet and Smartparens
 

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -23,7 +23,7 @@
 
 (defconst auto-completion-packages
       '(
-        (auto-yasnippet :toggle (not (eq auto-completion-front-end 'company)))
+        (auto-yasnippet :toggle (eq auto-completion-front-end 'company))
         (auto-complete :toggle (not (eq auto-completion-front-end 'company)))
         (ac-ispell :toggle (not (eq auto-completion-front-end 'company)))
         (company :toggle (eq auto-completion-front-end 'company))
@@ -91,6 +91,7 @@
     (spacemacs/set-leader-keys
       "iSc" 'aya-create
       "iSe" 'spacemacs/auto-yasnippet-expand
+      "iSh" 'spacemacs/auto-yasnippet-expand-from-history
       "iSw" 'aya-persist-snippet)))
 
 (defun auto-completion/init-company ()

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -23,7 +23,7 @@
 
 (defconst auto-completion-packages
       '(
-        (auto-yasnippet :toggle (eq auto-completion-front-end 'company))
+        (auto-yasnippet)
         (auto-complete :toggle (not (eq auto-completion-front-end 'company)))
         (ac-ispell :toggle (not (eq auto-completion-front-end 'company)))
         (company :toggle (eq auto-completion-front-end 'company))


### PR DESCRIPTION
In https://github.com/syl20bnr/spacemacs/pull/16176 the auto-yasnippet package has been toggled off for company auto-completion. I am not sure if that was really intended. I would like to have it available.