### PR TITLE
fix: Spacemacs-Modeline showing duplicated Anzu indicator

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -31,6 +31,11 @@
         symon
         (vim-powerline :location (recipe :fetcher local))))
 
+(defun spacemacs-modeline/init-anzu ()
+  (use-package anzu
+    :defer t
+    :init (setq-default anzu-cons-mode-line-p nil)))
+
 (defun spacemacs-modeline/post-init-anzu ()
   (when (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))
     (spaceline-all-the-icons--setup-anzu)))


### PR DESCRIPTION
Why?:
- As we can see in the screenshot, if we have some search results that Anzu should be indicating, Spacemacs-Modeline duplicates the indicator. This is caused by Anzu consing itself on to modeline-format.

This change addresses the need by:
- Setting anzu-cons-mode-line-p to nil during package initialization

Image showing the problem:

![image](https://github.com/syl20bnr/spacemacs/assets/46030637/69f772ce-5899-444c-9ddd-dcf037ce06e3)
