### PR TITLE
Prevent M-x {enable,disable}-command from modifying ~/.emacs.d/init.el

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -1257,4 +1257,32 @@ Return non-nil if all the tests passed."
                          :initial-value t)
             (goto-char (point-min))))))))
 
+(define-advice en/disable-command (:around (orig-f &rest args) write-to-dotspacemacs-instead)
+  "Attempt to modify `dotspacemacs/user-config' rather than ~/.emacs.d/init.el."
+  (let ((orig-f-called))
+    (condition-case-unless-debug e
+        (let* ((location (find-function-noselect 'dotspacemacs/user-config 'lisp-only))
+               (buffer (car location))
+               (start (cdr location))
+               (user-init-file (buffer-file-name buffer)))
+          (with-current-buffer buffer
+            (save-excursion
+              (save-restriction
+                ;; Set `user-init-file' and narrow the buffer visiting that
+                ;; file, to trick en/disable-command into writing inside the
+                ;; body of `dotspacemacs/user-config' instead of
+                ;; ~/.emacs.d/init.el.
+                (goto-char start)
+                (forward-sexp)
+                (backward-char)
+                (narrow-to-region start (point))
+                (setq orig-f-called t)
+                (apply orig-f args)))))
+      (error
+       ;; If the error happened before we managed to call the advised function,
+       ;; just allow the original function to run and modify ~/.emacs.d/init.el,
+       ;; which is better than failing completely.
+       (unless orig-f-called
+         (apply orig-f args))))))
+
 (provide 'core-dotspacemacs)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -780,15 +780,10 @@ are caught and signaled to user in spacemacs buffer."
   (interactive)
   (dotspacemacs|call-func dotspacemacs/user-env "Calling dotfile user env..."))
 
-(defun dotspacemacs/go-to-function (func)
-  "Open the dotfile and goes to FUNC function."
-  (interactive)
-  (find-function func))
-
 (defun dotspacemacs/go-to-user-env ()
   "Go to the `dotspacemacs/user-env' function."
   (interactive)
-  (dotspacemacs/go-to-function 'dotspacemacs/user-env))
+  (find-function 'dotspacemacs/user-env))
 
 (defun dotspacemacs//check-layers-changed ()
   "Check if the value of `dotspacemacs-configuration-layers'


### PR DESCRIPTION
This PR advises the built-in function `en/disable-command` (defined in `novice.el`) to add code to `dotspacemacs/user-config` instead of `~/.emacs.d/init.el`.  For Spacemacs users, modifications in `~/.emacs.d/init.el` are potentially inconvenient (may block `git checkout`) and likely not visible (since they expect their entire config to be contained in `~/.spacemacs`).

If you would like, I would also be okay with simplifying this advice to just append to `.spacemacs` (outside of `dotspacemacs/user-config`) instead of `~/.emacs.d/init.el`, which should still work acceptably.