### PR TITLE
Fix lsp mapping typo

### DIFF
--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -161,7 +161,7 @@
       "ro" 'lsp-java-organize-imports
       "rcp" 'lsp-java-create-parameter
       "rcf" 'lsp-java-create-field
-      "rci" 'lsp-java-conver-to-static-import
+      "rci" 'lsp-java-convert-to-static-import
       "rec" 'lsp-java-extract-to-constant
       "rel" 'lsp-java-extract-to-local-variable
       "rem" 'lsp-java-extract-method


### PR DESCRIPTION
Just fixing a typo in the lsp java key bindings from `lsp-java-conver-to-static-import` to `lsp-java-convert-to-static-import`.
