### PR TITLE
[mu4e] Remove redundant `mu4e-action-view-in-browser'

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -114,9 +114,6 @@
     (when mu4e-autorun-background-at-startup
       (mu4e t))
 
-    (add-to-list 'mu4e-view-actions
-                 '("View in browser" . mu4e-action-view-in-browser) t)
-
     (add-hook 'mu4e-compose-mode-hook
               (lambda () (use-hard-newlines t 'guess)))
 


### PR DESCRIPTION
In upstream mu4e-view: Enable mu4e-action-view-in-browser by default was
committed on Aug 8 2021.

https://github.com/djcb/mu/commit/aa75487ae64a70b580c3d8a338adc75e1e8a4b3f

Thanks Maxi.

Godspeed,

Ben.