### PR TITLE
[bootstrap] Add support for posframe with which-key

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -438,10 +438,22 @@ key sequence. Setting this variable is equivalent to setting
   'spacemacs-dotspacemacs-init)
 
 (spacemacs|defc dotspacemacs-which-key-position 'bottom
-  "Location of the which-key popup buffer. Possible choices are bottom,
-right, and right-then-bottom. The last one will display on the
-right if possible and fallback to bottom if not."
-  '(choice (const right) (const bottom) (const right-then-bottom))
+  "Which-key frame position. Possible values are `right', `bottom' and
+`right-then-bottom'. right-then-bottom tries to display the frame to the
+right; if there is insufficient space it displays it at the bottom.
+It is also possible to use a posframe with the following cons cell
+`(posframe . position)' where position can be one of `center',
+`top-center', `bottom-center', `top-left-corner', `top-right-corner',
+`top-right-corner', `bottom-left-corner' or `bottom-right-corner'"
+  '(choice (const right) (const bottom) (const right-then-bottom)
+           (cons (const posframe)
+                 (choice (const center)
+                         (const top-center)
+                         (const bottom-center)
+                         (const top-left-corner)
+                         (const top-right-corner)
+                         (const bottom-left-corner)
+                         (const bottom-right-corner))))
   'spacemacs-dotspacemacs-init)
 
 (spacemacs|defc dotspacemacs-switch-to-buffer-prefers-purpose nil

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -34,7 +34,7 @@ values."
 (defun spacemacs/system-is-linux ()
  (or  (eq system-type 'gnu/linux)
       (eq system-type 'android)))
- 
+
 (defun spacemacs/system-is-mswindows ()
   (eq system-type 'windows-nt))
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -334,6 +334,10 @@ It should only modify the values of Spacemacs settings."
    ;; Which-key frame position. Possible values are `right', `bottom' and
    ;; `right-then-bottom'. right-then-bottom tries to display the frame to the
    ;; right; if there is insufficient space it displays it at the bottom.
+   ;; It is also possible to use a posframe with the following cons cell
+   ;; `(posframe . position)' where position can be one of `center',
+   ;; `top-center', `bottom-center', `top-left-corner', `top-right-corner',
+   ;; `top-right-corner', `bottom-left-corner' or `bottom-right-corner'
    ;; (default 'bottom)
    dotspacemacs-which-key-position 'bottom
 

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -41,6 +41,8 @@
     (holy-mode :location (recipe :fetcher local) :step pre)
     (hybrid-mode :location (recipe :fetcher local) :step pre)
     (spacemacs-theme :location built-in)
+    (which-key-posframe :step pre :toggle (and (consp dotspacemacs-which-key-position)
+                                               (eq (car dotspacemacs-which-key-position) 'posframe)))
     dash))
 
 ;; bootstrap packages
@@ -576,10 +578,11 @@ Press \\[which-key-toggle-persistent] to hide."
 
   ;; disable special key handling for spacemacs, since it can be
   ;; disorienting if you don't understand it
-  (pcase dotspacemacs-which-key-position
-    ('right (which-key-setup-side-window-right))
-    ('bottom (which-key-setup-side-window-bottom))
-    ('right-then-bottom (which-key-setup-side-window-right-bottom)))
+  (when (symbolp dotspacemacs-which-key-position)
+    (pcase dotspacemacs-which-key-position
+      ('right (which-key-setup-side-window-right))
+      ('bottom (which-key-setup-side-window-bottom))
+      ('right-then-bottom (which-key-setup-side-window-right-bottom))))
 
   (which-key-mode)
   (spacemacs|diminish which-key-mode " Ⓚ" " K"))
@@ -643,3 +646,16 @@ Press \\[which-key-toggle-persistent] to hide."
 (defun spacemacs-bootstrap/init-dash ()
   (use-package dash
     :defer t))
+
+(defun spacemacs-bootstrap/init-which-key-posframe ()
+  (use-package which-key-posframe
+    :config
+    (setq which-key-posframe-parameters
+          '((left-fringe . 10)
+            (right-fringe . 10)
+            (internal-border-width . 10)  ;; expected to add padding but seems to have no effect
+            ))
+    (setq which-key-posframe-poshandler
+          (intern (format "posframe-poshandler-frame-%s"
+                          (cdr dotspacemacs-which-key-position))))
+    (which-key-posframe-mode)))


### PR DESCRIPTION
Add new values for `dotspacemacs-which-key-position` to support posframe.

I think we should create a `posframe` layer that automatically enable posframe everywhere it is supported.