### PR TITLE
fix(lsp): Lookup of workspace symbols with compleseus layer

### DIFF
--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -154,6 +154,9 @@
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
       (concat prefix-char "s") #'lsp-ivy-workspace-symbol
       (concat prefix-char "S") #'lsp-ivy-global-workspace-symbol))
+   ((configuration-layer/package-usedp 'consult-lsp)
+    (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
+      (concat prefix-char "s") #'consult-lsp-symbols))
    (t (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
         (concat prefix-char "s") #'lsp-ui-find-workspace-symbol))))
 


### PR DESCRIPTION
Why?:
- If we have the compleseus layer installed the remapping of keys for the lsp minor mode is missing a remap to `consult-lsp-symbols`.

This change addresses the need by:
- Add condition to remap consult-lsp-symbols to SPC-m-g-s

