### PR TITLE
ask helm-descbinds not to disable which-key

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -312,7 +312,8 @@
   (use-package helm-descbinds
     :defer (spacemacs/defer)
     :init
-    (setq helm-descbinds-window-style 'split)
+    (setq helm-descbinds-window-style 'split
+          helm-descbinds-disable-which-key nil)
     (add-hook 'helm-mode-hook 'helm-descbinds-mode)
     (spacemacs/set-leader-keys "?" 'helm-descbinds)))
 


### PR DESCRIPTION
this takes advantage of a newly exposed customization option in helm-descbinds to ask it to not disable which-key and thus restore the "old" spacemacs behavior. This should fix #16276 
