### PR TITLE
Add support for "eat" to shell layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -362,6 +362,8 @@ both Racer and RLS not being maintained anymore.
   - Add ~o~ to link-hint-open-link in woman-mode
 ***** Shaders
 - =shaders= layer has been moved to =gpu= layer.
+***** Shell
+- Add support for "eat" shell (thanks to Ryan Prior)
 ***** Shell-scripts
 - Add variable =shell-scripts-shfmt-args= to pass through arguments to =shfmt= package.
 ***** Syntax checking

--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -23,7 +23,7 @@
   - [[#default-shell][Default shell]]
   - [[#default-shell-position-width-and-height][Default shell position, width, and height]]
   - [[#external-terminal-emulator][External terminal emulator]]
-  - [[#set-shell-for-term-ansi-term-and-vterm][Set shell for term, ansi-term and vterm]]
+  - [[#set-shell-for-term-ansi-term-eat-and-vterm][Set shell for term, ansi-term, eat and vterm]]
   - [[#set-shell-for-multi-term][Set shell for multi-term]]
   - [[#width-of-the-shell-popup-buffers][Width of the shell popup buffers]]
   - [[#enable-em-smart-in-eshell][Enable em-smart in Eshell]]
@@ -156,7 +156,7 @@ By default =terminal-here= finds an appropriate default shell for you.
 If this does not work please check the package documentation how to
 change it.
 
-** Set shell for term, ansi-term and vterm
+** Set shell for term, ansi-term, eat and vterm
 The default shell can be set by setting the variable =shell-default-term-shell=.
 Default value is =/bin/bash=.
 
@@ -295,6 +295,7 @@ Some advanced configuration is setup for =eshell= in this layer:
 | ~SPC "​~       | Open external terminal emulator in current directory     |
 | ~SPC a t s e~ | Toggle pop-shell with =eshell=                           |
 | ~SPC a t s i~ | Toggle pop-shell with =shell=                            |
+| ~SPC a t s a~ | Toggle pop-shell with =eat=                              |
 | ~SPC a t s m~ | Toggle pop-shell with =multi-term=                       |
 | ~SPC a t s M~ | Toggle pop-shell with =multi-vterm=                      |
 | ~SPC a t s t~ | Toggle pop-shell with =ansi-term=                        |

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -34,8 +34,8 @@
                                 'eshell
                               'ansi-term)
   "Default shell to use in Spacemacs. Possible values are `ansi-term' (default
-for Linux/macOS), `eshell' (default for windows), `shell', `term', `vterm',
-`multi-term' and `multi-vterm'.")
+for Linux/macOS), `eshell' (default for windows), `shell',
+`term', `eat', `vterm', `multi-term' and `multi-vterm'.")
 
 (spacemacs|defc shell-default-position 'bottom
   "Position of the shell. Possible values are `top', `bottom', `full',

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -39,7 +39,9 @@ view; to pop-up a full width buffer, use
 `spacemacs/projectile-shell-pop'."
   (interactive)
   (call-interactively
-   (or (and (eq shell-default-shell 'multi-term) #'projectile-multi-term-in-root)
+   (or (pcase shell-default-shell
+         ('multi-term #'projectile-multi-term-in-root)
+         ('eat #'eat-project))
        (intern-soft (format "projectile-run-%s" shell-default-shell))
        #'projectile-run-shell)))
 

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -25,6 +25,7 @@
   '(
     (comint :location built-in)
     company
+    eat
     esh-help
     (eshell :location built-in)
     eshell-prompt-extras
@@ -332,6 +333,17 @@
                             eshell-mode-hook
                             shell-mode-hook
                             term-mode-hook)))
+
+(defun shell/init-eat ()
+  (use-package eat
+    :defer t
+    :commands (eat eat-other-window eat-project eat-project-other-window)
+    :init
+    (make-shell-pop-command "eat" eat)
+    (spacemacs/set-leader-keys "atsa" 'spacemacs/shell-pop-eat)
+    (spacemacs/register-repl 'eat 'eat)
+    :config
+    (setq eat-shell shell-default-term-shell)))
 
 (defun shell/init-vterm ()
   (use-package vterm


### PR DESCRIPTION
This MR adds support for [eat](https://codeberg.org/akib/emacs-eat/src/branch/master/eat.el), the native elisp terminal emulator from Akib Azmain Turja, to the shell layer.
## In this pull request:
- New keybinding: <kbd>Leader</kbd><kbd>a</kbd><kbd>t</kbd><kbd>s</kbd><kbd>a</kbd> pops an `eat` shell
- New `'eat` option available for `shell-default-shell` configures pop-shell and similar to use `eat` by default
- Minor updates to layer README, doc strings, and helper functions to accommodate `eat`