### PR TITLE
Update ess layer readme by common configuration options

### DIFF
--- a/layers/+lang/ess/README.org
+++ b/layers/+lang/ess/README.org
@@ -65,6 +65,24 @@ variable =ess-r-backend=:
 #+END_SRC
 
 * Options
+To automatically set the R working directory to the current file location, add 
+the following line to your ~dotspacemacs/user-config~:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default ess-ask-for-ess-directory nil)
+#+END_SRC
+
+For more advanced configuration, use ~ess-directory-function~ or ~ess-directory~.
+
+By default, ~#~ comments are right indented (40 spaces), ~##~ comments are
+indented at the current position, and ~###~ are left indented.
+To avoid this automatic indentation, add the following line to your
+~dotspacemacs/user-config~:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default ess-indent-with-fancy-comments nil)
+#+END_SRC
+
 Use a key binding to insert =<-=:
 
 #+BEGIN_SRC emacs-lisp

--- a/layers/+lang/ess/funcs.el
+++ b/layers/+lang/ess/funcs.el
@@ -22,7 +22,7 @@
 
 
 
-;; R
+;; R Setup
 
 (defun spacemacs//ess-may-setup-r-lsp ()
   "Conditionally setup LSP based on backend."


### PR DESCRIPTION
The commit adds two configuration options to the readme.

The first is a way to stop ESS from asking what the R working directory should be.
The second is a way to stop ESS from indenting standard R comments starting with '#' by 40 spaces.

I think a lot of ESS users will be interested in knowing these configuration options.
It took me a while to find them on the web, therefore I think it would be useful to include them in the layer readme.
For the 40 space automatic indentation, I even thought it was a bug.