### PR TITLE
load dired-x after loading dired other than use autoloading

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -150,6 +150,13 @@
     (evil-define-key 'normal dired-mode-map (kbd "N") 'evil-search-previous)))
 
 (defun spacemacs-defaults/init-dired-x ()
+  ;; dired-x used to be autoloaded with command dired-jump, which is the major
+  ;; entrance to dired in spacemacs. Now dired-jump was moved to dired.el so
+  ;; this autoloading is not needed for latest dired. But dired-x still provides
+  ;; additional key bindings such as "* ." to dired. To keep the old behavior,
+  ;; load dired-x after dired.
+  (with-eval-after-load 'dired
+        (require 'dired-x))
   (use-package dired-x
     :commands (dired-jump
                dired-jump-other-window


### PR DESCRIPTION
dired-x used to be autoloaded with command dired-jump, which is the major entrance to dired in spacemacs. Now dired-jump was moved to dired.el so this autoloading is not needed for latest dired. However dired-x still provides additional key bindings such as "* ." to dired. To keep the old behavior, load dired-x after dired.

For users with older dired that dired-jump is in dired-x, we still need the auto loading to make sure dired-jump got loaded when we call it. That is because most of the dired functions have autoload and don't need manual specifying but dired-jump was defined in dired-x and got autoloaded only when dired.el got loaded, so when spacemacs provides "SPC f d" to dired-jump, at that moment, dired.el was not loaded yet, we need to make sure dired-x got loaded when we call.

resolves #16284 
