### PR TITLE
[helpful] Make original describe-function available

### DIFF
--- a/layers/+emacs/helpful/README.org
+++ b/layers/+emacs/helpful/README.org
@@ -41,6 +41,15 @@ by this layer.
 | =C-h f=     | Open helpful buffer for any callable object            |
 | =C-h v=     | Open helpful buffer for variable                       |
 
+To use the original implementation of these key bindings while the
+helpful layer is active, you can use the following commands:
+
+| Key Binding                                  | Description         |
+|----------------------------------------------+---------------------|
+| =SPC SPC helpful/original-describe-function= | =describe-function= |
+| =SPC SPC helpful/original-describe-variable= | =describe-variable= |
+| =SPC SPC helpful/original-describe-key=      | =describe-key=      |
+
 ** Helpful mode bindings
 Additional key bindings available in the helpful-mode buffers.
 

--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -33,6 +33,9 @@
     :init
     (spacemacs/declare-prefix-for-mode 'helpful-mode "mg" "goto")
     (with-eval-after-load 'help-fns
+      (defalias 'helpful/original-describe-function (symbol-function 'describe-function))
+      (defalias 'helpful/original-describe-variable (symbol-function 'describe-variable))
+      (defalias 'helpful/original-describe-key (symbol-function 'describe-key))
       (defalias 'describe-function 'helpful-callable)
       (defalias 'describe-variable 'helpful-variable)
       (defalias 'describe-key 'helpful-key))

--- a/layers/+emacs/helpful/packages.el
+++ b/layers/+emacs/helpful/packages.el
@@ -32,30 +32,18 @@
     :defer t
     :init
     (spacemacs/declare-prefix-for-mode 'helpful-mode "mg" "goto")
-    (add-hook 'emacs-startup-hook
-              (lambda ()
-                (spacemacs/set-leader-keys
-                  "hdk" #'helpful-key
-                  "hdf" #'helpful-callable
-                  "hdv" #'helpful-variable)
-                (global-set-key (kbd "C-h k") 'helpful-key)
-                (global-set-key (kbd "C-h f") 'helpful-callable)
-                (global-set-key (kbd "C-h v") 'helpful-variable))
-              'append)
+    (with-eval-after-load 'help-fns
+      (defalias 'describe-function 'helpful-callable)
+      (defalias 'describe-variable 'helpful-variable)
+      (defalias 'describe-key 'helpful-key))
     :config
     (evil-set-initial-state 'helpful-mode 'normal)
     (spacemacs/set-leader-keys-for-major-mode 'helpful-mode
       (kbd "q") 'helpful-kill-buffers)
     (evil-define-key 'normal helpful-mode-map (kbd "gr") 'helpful-update)
     (evil-define-key 'normal helpful-mode-map (kbd "q") 'quit-window)
-    (defalias 'describe-function 'helpful-callable)
-    (defalias 'describe-variable 'helpful-variable)
-    (defalias 'describe-key 'helpful-key)
     (add-hook 'helpful-mode-hook (lambda () (setq-local tab-width 8)))
-    (advice-add 'helpful--navigate :after (lambda (_) (setq-local tab-width 8)))
-    (when (featurep 'counsel)
-      (setq counsel-describe-function-function #'helpful-callable)
-      (setq counsel-describe-variable-function #'helpful-variable))))
+    (advice-add 'helpful--navigate :after (lambda (_) (setq-local tab-width 8)))))
 
 (defun helpful/post-init-link-hint ()
   (with-eval-after-load 'helpful


### PR DESCRIPTION
Occasionally, helpful.el does not support certain kinds of functions
(e.g., functions implemented by non-Elisp modules), or is missing some
output from newer Emacs versions of describe-function.  Since helpful
now aliases describe-function and co, we should add a name by which
the old definitions can still be accessed when needed.

In addition, this PR includes some changes to simplify the key
binding configuration in this layer.