### PR TITLE
feat: Add a config option for flycheck-display-error-delay

### DIFF
--- a/layers/+checkers/syntax-checking/config.el
+++ b/layers/+checkers/syntax-checking/config.el
@@ -35,6 +35,12 @@
 If non-positive or nil, do not hide tooltip."
   '(number))
 
+(spacemacs|defc syntax-checking-tooltips-delay nil
+  "Show tooltips only after the given number of seconds have passed.
+If non-positive or nil, wait the default amount of time before
+showing tooltip."
+  '(number))
+
 ;; a small circle used for flycheck-indication-mode
 (define-fringe-bitmap 'syntax-checking--fringe-indicator
   (vector #b00000000

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -41,6 +41,7 @@
                    (global-flycheck-mode 1)))
       lazy-load-flycheck)
     (setq flycheck-standard-error-navigation syntax-checking-use-standard-error-navigation
+          flycheck-display-errors-delay (or syntax-checking-tooltips-delay 0.9)
           flycheck-global-modes nil)
     ;; key bindings
     (spacemacs/set-leader-keys


### PR DESCRIPTION
Why?:
- If we provide an option to hide the flycheck popup after a given amount of time we should also provide an option to change flychecks delay before displaying the popup, because it can get in the way when trying to complete an unfinished statement.

This change addresses the need by:
- Add config option syntax-checking-tooltips-delay
- Set value of flycheck-display-errors-delay to provided value or flychecks default of 0.9 on init
