### PR TITLE
tell company-dabbrev to only consider same-mode buffers

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -102,6 +102,7 @@
           company-minimum-prefix-length auto-completion-minimum-prefix-length
           company-require-match nil
           company-dabbrev-ignore-case nil
+          company-dabbrev-other-buffers t
           company-dabbrev-downcase nil)
 
     (add-hook 'company-completion-started-hook 'company-turn-off-fci)


### PR DESCRIPTION
See #11743 for a well-argued criticism of company-dabbrev's tendency to over-zealously suggest useless completions.

With many buffers open, many of the completions offered by company-dabbrev can be nonsense. For example, if a magit log happens to be open, then many of the suggested completions may be hashes of commits, and if a PDF is open, many of the completions will be nonsense strings that include control characters.

This PR sets `company-dabbrev-other-buffers` to `t` which means that company-dabbrev should only search for completions in other buffers with the same major mode. This should significantly cut down on the noise without going quite so far as suggested in #11743 and removing company-dabbrev as a backend entirely




