### PR TITLE
Fix keybindings for R repl mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -174,6 +174,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - ~SPC m s r~ for =ess-eval-region=
   - ~SPC m s s~ for =ess-switch-to-inferior-or-script-buffer=
   - ~SPC m w~ for =ess-r-package-dev-map=
+- Fixed key bindings for ESS inferior modes (Nicholas Kirchner)
 ***** Elixir
 - Key bindings;
   - Changed ~SPC m p t~ to ~SPC m t F~ for =alchemist-project-find-test=

--- a/layers/+lang/ess/funcs.el
+++ b/layers/+lang/ess/funcs.el
@@ -90,12 +90,13 @@
   (when ess-assign-key
     (define-key inferior-ess-r-mode-map ess-assign-key #'ess-insert-assign))
 
-  (spacemacs/declare-prefix-for-mode 'inferior-ess-mode "ms" "repl")
-  (spacemacs/declare-prefix-for-mode 'inferior-ess-mode "me" "eval")
-  (spacemacs/declare-prefix-for-mode 'inferior-ess-mode "mg" "xref")
-  (spacemacs/set-leader-keys-for-major-mode 'inferior-ess-mode
-    ","  #'ess-smart-comma
-    "ss" #'ess-switch-to-inferior-or-script-buffer))
+  (dolist (mode '(inferior-ess-mode inferior-ess-r-mode))
+    (spacemacs/declare-prefix-for-mode mode "ms" "repl")
+    (spacemacs/declare-prefix-for-mode mode "me" "eval")
+    (spacemacs/declare-prefix-for-mode mode "mg" "xref")
+    (spacemacs/set-leader-keys-for-major-mode mode
+      ","  #'ess-smart-comma
+      "ss" #'ess-switch-to-inferior-or-script-buffer)))
 
 
 ;; REPL

--- a/layers/+lang/ess/packages.el
+++ b/layers/+lang/ess/packages.el
@@ -101,7 +101,7 @@
       (unless (eq ess-r-backend 'lsp)
         (spacemacs/declare-prefix-for-mode 'ess-r-mode "mg" "goto")
         (define-key ess-doc-map "h" #'ess-display-help-on-object)))
-    (with-eval-after-load 'ess-inf-mode
+    (with-eval-after-load 'ess-inf
       (spacemacs/ess-bind-keys-for-inferior))
     :config
     (define-key ess-mode-map (kbd "<s-return>") #'ess-eval-line))


### PR DESCRIPTION
This is a fix for issue #16308.  It updates which ess module needs to be imported, and additionally sets the keybindings in `inferior-ess-r-mode`.