### PR TITLE
don't require pdf-sync during config

### DIFF
--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -62,7 +62,6 @@
         (progn
           (setf (alist-get 'output-pdf TeX-view-program-selection) '("PDF Tools"))
           (when latex-view-pdf-in-split-window
-            (require 'pdf-sync)
             (setq pdf-sync-forward-display-action t)))
       (spacemacs-buffer/warning "Latex Layer: latex-view-with-pdf-tools is non-nil but pdf layer is not installed, this setting will have no effect."))))
 


### PR DESCRIPTION
Requiring pdf-sync has some unfortunate side effects that seem to break pdf-tools. In brief, it loads something that we otherwise wanted to autoload.

In more detail: when we manually require pdf-sync, that in turn requires pdf-view, which causes pdf-view.el to be loaded and pdf-view-mode to be defined. However, use-package had configured pdf-view-mode to be autoloaded (by its specification of :mode in use-package). Loading it manually doesn't trigger the autoload, so all of the configuration that is waiting to happen in pdf-tools's use-package :config block doesn't get triggered. Most critically, `(pdf-tools-install)` doesn't get triggered, which prevents pdf-view-mode from functioning properly.

If we don't require pdf-sync, then we end up setting a variable (`pdf-sync-forward-display-action`) which isn't yet bound. Fortunately, pdf-tools appropriately defines this variable using `defcustom`, so it won't override whatever we set it to here :)