### PR TITLE
[pdf] Use pdf-loader-install instead of pdf-tools-install

### DIFF
--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -28,12 +28,10 @@
 (defun pdf/init-pdf-tools ()
   (use-package pdf-tools
     :defer t
-    :mode (("\\.pdf\\'" . pdf-view-mode))
     :init
     (spacemacs//pdf-tools-setup-transient-state)
+    (pdf-loader-install)
     :config
-    (pdf-tools-install)
-
     (spacemacs/declare-prefix-for-mode 'pdf-view-mode "ma" "annotations")
     (spacemacs/declare-prefix-for-mode 'pdf-view-mode "mf" "fit")
     (spacemacs/declare-prefix-for-mode 'pdf-view-mode "ms" "slice/search")


### PR DESCRIPTION
Various packages may load parts of pdf-tools without loading the main
file, but pdf-tools-install needs to be run before any of those parts
are used.  (The README of pdf-tools says pdf-tools-install should be
run immediately at startup, or pdf-loader-install should be used
instead).