### PR TITLE
Remove `''` from pdf-outline-buffer-mode-map and update documentation

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -895,7 +895,9 @@ behave more like Vim in a consistent manner, they use a special state called
 =C-d=, =C-e=, =C-o=, =C-i=, =C-u=, =C-y= and =C-z=. All other keys work as
 intended by the underlying mode.
 
-Shadowed keys are moved according to the pattern: =a= → =A= → =C-a= → =C-A=
+Shadowed keys are moved according to the pattern: =a= → =A= → =C-a= → =C-A=.
+Some other keys are also moved: =SPC= -> ='=, =/= -> =\=, and =:= -> =|=.
+
 
 For example, if the mode binds a function to =n=, that is found under =C-n= in
 evilified state, since both =n= and =N= are reserved, but =C-n= is not. On the

--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -38,7 +38,7 @@
 ;; The first unreserved key will be used.
 ;; There is an exception for g, which will be directly
 ;; bound to C-G, since G and C-g (latest being an important escape key in Emacs)
-;; are already being used.
+;; are already being used. Also, move SPC -> ', / -> \, and : -> |
 
 ;;; Code:
 

--- a/layers/+readers/pdf/README.org
+++ b/layers/+readers/pdf/README.org
@@ -194,7 +194,6 @@ differently from the default Evil search. To go to the next match, use ~C-s~.
 | ~M-RET~       | Follow link and close outline window                  |
 | ~o~           | Go to pdf view window                                 |
 | ~``~          | Move to the heading correspondent to the current page |
-| ~''~          | Move to the heading correspondent to the current page |
 | ~f~           | Go to selected heading without leaving outline buffer |
 | ~F~           | Enable follow mode                                    |
 | ~q~           | Quit                                                  |

--- a/layers/+readers/pdf/packages.el
+++ b/layers/+readers/pdf/packages.el
@@ -125,7 +125,6 @@
       [mouse-1]          'pdf-outline-mouse-display-link
       "o"                'pdf-outline-select-pdf-window
       "``"               'pdf-outline-move-to-current-page
-      "''"               'pdf-outline-move-to-current-page
       "Q"                'pdf-outline-quit-and-kill
       "q"                'quit-window
       "F"                'pdf-outline-follow-mode)


### PR DESCRIPTION
I noticed some noise in my *Messages* buffer about keybinding whenever I tried to view a PDF, and I tracked it down.

`pdf-outline-buffer-mode-map` gets evilified. Prior to this, `SPC` is mapped to `pdf-outline-display-link`. During evilification, this gets remapped to `'` (this remapping is, AFAICT, not documented in evilification but you can see it
[here](https://github.com/syl20bnr/spacemacs/blob/4a227fc94651136a8de54bcafa7d22abe1fa0295/layers/%2Bdistributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el#L323) (note: `32` means `SPC`).

We then try to map the key `''` to `pdf-outline-move-to-current-page`, but this isn't possible, because `'` is already mapped to a function and is thus not a prefix key.

Fortunately, this behavior is already available via double-backtick: ` `` `.

I've removed the (failed) mapping of `''` and also removed it from the documentation.
