### PR TITLE
[auto-completion] Fix company-backends nil when scratch buffer enables completion

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -114,10 +114,8 @@ Available PROPS:
                            (mapcar 'spacemacs//show-snippets-in-company
                                    ,raw-backends-var-name))
                    (setq ,backends-var-name ,raw-backends-var-name))
-                 (set (make-variable-buffer-local 'auto-completion-front-end)
-                      'company)
-                 (set (make-variable-buffer-local 'company-backends)
-                      ,backends-var-name)) result)
+                 (setq-local auto-completion-front-end 'company
+                             company-backends ,backends-var-name)) result)
         (when call-hooks
           (push `(,init-func-name) result))
         (when hooks


### PR DESCRIPTION
Fix #16320

`make-variable-buffer-local` should not be called on a variable where it is used, only where it is defined (see its docstring).  When the variable is unbound at the time `make-variable-buffer-local` is called, the toplevel default value gets set to `nil`, which causes the variable to remain nil in all buffers once `company.el` (which contains the defcustom for `company-backends`) is loaded.