### PR TITLE
[compleseus] Don't assume persp-mode is installed

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -42,7 +42,7 @@
                                 (buffer-modified-p buff)))
               ;; :directory 'project
               :as #'buffer-name)))
-  "Per perpecstive modified buffer source.")
+  "Per-perspective modified buffer source.")
 
 (defvar consult--source-persp-buffers
   `(
@@ -59,4 +59,4 @@
         :sort 'visibility
         :predicate #'persp-contain-buffer-p
         :as #'buffer-name)))
-  "Per perpecstive buffer source.")
+  "Per-perspective buffer source.")

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -40,9 +40,10 @@
   "`consult-buffer' with buffers provided by persp."
   (interactive)
   (consult-buffer
-   '(consult--source-hidden-buffer
-     consult--source-persp-buffers
-     consult--source-modified-buffers
+   `(consult--source-hidden-buffer
+     ,@(when (configuration-layer/package-used-p 'persp-mode)
+         '(consult--source-persp-buffers
+           consult--source-modified-buffers))
      consult--source-recent-file
      consult--source-bookmark
      consult--source-project-buffer


### PR DESCRIPTION
Before this commit, spacemacs/compleseus-switch-to-buffer signaled an
error if persp-mode package was not installed, for example if the
spacemacs-layouts layer is not used.