### PR TITLE
[spacemacs-defaults] Do not prompt to revert from auto-save file

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1228,11 +1228,6 @@ useful to use full screen on macOS without animations."
                  'maximized)
            'fullboth)))))
 
-(defun spacemacs/safe-revert-buffer ()
-  "Prompt before reverting the file."
-  (interactive)
-  (revert-buffer nil nil))
-
 (defun spacemacs/safe-erase-buffer ()
   "Prompt before erasing the content of the file."
   (interactive)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -258,7 +258,7 @@
    ("m" spacemacs/switch-to-messages-buffer "Messages buffer")
    ("P" spacemacs/copy-clipboard-to-whole-buffer "Paste and replace buffer")
    ("p" previous-buffer "Previous buffer")
-   ("R" spacemacs/safe-revert-buffer "Revert buffer...")
+   ("R" revert-buffer "Revert buffer...")
    ("s" spacemacs/switch-to-scratch-buffer "Scratch buffer")
    ("u" spacemacs/reopen-killed-buffer "Reopen last killed buffer")
    ("x" kill-buffer-and-window "Kill buffer and close window")


### PR DESCRIPTION
SPC b R passes nil to the IGNORE-AUTO argument of revert-buffer, which
causes it to prompt the user whether they want to revert from the
auto-save file.  This is not the default behavior of revert-buffer;
somewhat confusingly, IGNORE-AUTO is t by default when revert-buffer
is called interactively.

Changing Spacemacs to use the default behavior of revert-buffer makes
more sense here, as reverting from the auto-save file is rarely
useful.