### PR TITLE
Fix interactive spec of configuration-layer/delete-orphan-packages

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2436,8 +2436,10 @@ depends on it."
     (message "Can't remove package %s since it isn't installed." pkg-name)))
 
 (defun configuration-layer/delete-orphan-packages (packages)
-  "Delete PACKAGES if they are orphan."
-  (interactive)
+  "Delete PACKAGES if they are orphan.
+
+When called interactively, delete all orphan packages."
+  (interactive (list (configuration-layer/get-packages-list)))
   (let* ((dependencies
           (configuration-layer//get-packages-upstream-dependencies-from-alist))
          (implicit-packages


### PR DESCRIPTION
Before this change, configuration-layer/delete-orphan-packages showed
up in the M-x command list but selecting it failed with an arity
error.  The most natural behavior of this command is to delete all
orphan packages.