### PR TITLE
doc(checkers): Add documentation for new variable syntax-checking-tooltips-delay

### DIFF
--- a/layers/+checkers/syntax-checking/README.org
+++ b/layers/+checkers/syntax-checking/README.org
@@ -88,6 +88,20 @@ hide it after 5 seconds:
                                    syntax-checking-auto-hide-tooltips 5)))
 #+END_SRC
 
+Because flycheck almost immediately shows the tooltip pop-up window it can
+potentially hide code before or after the the current line you're on.
+If you prefer it to show up only after a certain amount of time has passed,
+you can set the variable =syntax-checking-tooltips-delay= to a positive value.
+Otherwise flychecks default value of 0.9 is used.
+Example:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((syntax-checking :variables
+                                   syntax-checking-tooltips-delay 5)))
+#+END_SRC
+
+
 ** Error List Pop-up
 By default, the =flycheck-error-list-mode= is displayed in a pop window to the
 bottom of the frame, with 30% of the frame's height.

--- a/layers/+checkers/syntax-checking/config.el
+++ b/layers/+checkers/syntax-checking/config.el
@@ -35,6 +35,12 @@
 If non-positive or nil, do not hide tooltip."
   '(number))
 
+(spacemacs|defc syntax-checking-tooltips-delay nil
+  "Show tooltips only after the given number of seconds have passed.
+If non-positive or nil, wait the default amount of time before
+showing tooltip."
+  '(number))
+
 ;; a small circle used for flycheck-indication-mode
 (define-fringe-bitmap 'syntax-checking--fringe-indicator
   (vector #b00000000

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -41,6 +41,7 @@
                    (global-flycheck-mode 1)))
       lazy-load-flycheck)
     (setq flycheck-standard-error-navigation syntax-checking-use-standard-error-navigation
+          flycheck-display-errors-delay (or syntax-checking-tooltips-delay 0.9)
           flycheck-global-modes nil)
     ;; key bindings
     (spacemacs/set-leader-keys


### PR DESCRIPTION
Why?:
- Because I forgot to properly document the newly introduced layer variable
  syntax-checking-tooltips-delay.

This change addresses the need by:
- Add documentation in README.org
