### PR TITLE
[python] remove the mslsp, use pyright instead

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3330,6 +3330,7 @@ files (thanks to Daniel Nicolai)
 - Added =sphinx-doc= support (thanks to Stefan Ruschke)
 - Fix ipython version parsing for dev branches (thanks to Corentin Risselin)
 - Fix pyvenv-workon path (thanks to Eugene Kim)
+- Remove mspyls for it was deprecated, use pyright instead (thanks to Lin Sun)
 **** Racket
 - Restore smart closing paren behavior in racket-mode (thanks to Don March)
 - Updated racket logo (thanks to Vityou)

--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -14,7 +14,6 @@
   - [[#anaconda][Anaconda]]
   - [[#language-server-protocol][Language Server Protocol]]
     - [[#python-lsp-server][python-lsp-server]]
-    - [[#microsoft-python-language-server][Microsoft python language server]]
     - [[#microsoft-pyright-language-server][Microsoft pyright language server]]
 - [[#additional-tools][Additional tools]]
   - [[#syntax-checking][Syntax checking]]
@@ -54,9 +53,9 @@ This layer adds support for the Python language.
 ** Features:
 - Support for the following backends:
   - [[https://github.com/proofit404/anaconda-mode][anaconda]] (default),
-  - [[https://github.com/emacs-lsp/lsp-python-ms][Language Server Protocol]] (experimental - 2 implementations),
+  - [[https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-pylsp.el][Language Server Protocol]] (experimental - 2 implementations),
     - python-lsp-server
-    - Microsoft python language server
+    - Microsoft pyright language server
 - Auto-completion
 - Code Navigation
 - Documentation Lookup using [[https://github.com/proofit404/anaconda-mode][anaconda-mode]] and [[https://github.com/tsgates/pylookup][pylookup]]
@@ -140,18 +139,15 @@ The =lsp= backend can use either of the following language server implementation
 | symbol   | description                         |
 |----------+-------------------------------------|
 | 'pylsp   | [[https://pypi.org/project/python-lsp-server/][python-lsp-server package]] (default) |
-| 'mspyls  | [[https://github.com/emacs-lsp/lsp-python-ms][Microsoft python language server]]    |
 | 'pyright | [[https://github.com/emacs-lsp/lsp-pyright][Microsoft pyright language server]]   |
 
-=pylsp= is used by default - to use the Microsoft python language server, set the
-=python-lsp-server= layer variable as follows:
-
+=pylsp= is default value for =python-lsp-server=, an example for use =pylsp=:
 #+BEGIN_SRC elisp
-  (python :variables python-backend 'lsp python-lsp-server 'mspyls)
+  (python :variables python-backend 'lsp)
 #+END_SRC
 
-To setup the pyright language server instead, use:
-
+To use the Microsoft pyright language server, set the =python-lsp-server= layer
+variable as follows:
 #+BEGIN_SRC elisp
   (python :variables python-backend 'lsp python-lsp-server 'pyright)
 #+END_SRC
@@ -177,41 +173,14 @@ dependencies in a pipenv environment, you'll want to set the ~python-pipenv-acti
 config variable to ~t~. This activates your pipenv before enabling the
 lsp backend. The same applies for ~python-poetry-activate~.
 
-*** Microsoft python language server
-Paraphrasing the instructions provided by the author of the =lsp-python-ms= package:
-
-#+BEGIN_SRC sh
-  git clone https://github.com/Microsoft/python-language-server.git
-  cd python-language-server/src/LanguageServer/Impl
-  dotnet build -c Release
-  dotnet publish -c Release -r <RUNTIME>
-#+END_SRC
-
-where ~<RUNTIME>~ is one of the [[https://docs.microsoft.com/en-us/dotnet/core/rid-catalog][runtime IDs supported by dotnet core]]. One of ~linux-x64~, ~osx-x64~, ~win10-x64~ should
-cover most use cases.
-
-The default package configuration assumes the executable is located in a folder included in your system path.
-To use the latest built version in a cloned git repo, use the ~python-lsp-git-root~ config variable, e.g.:
-
-#+BEGIN_SRC elisp
-  (setq-default dotspacemacs-configuration-layers
-    '((python :variables
-              python-backend 'lsp
-              python-lsp-server 'mspyls
-              python-lsp-git-root "~/dev/python/python-language-server")))
-#+END_SRC
-
-N.B. If you're using Arch linux or a derivative distribution, you can install the =microsoft-python-language-server=
-package from the AUR.
-
 *** Microsoft pyright language server
-[[https://github.com/microsoft/pyright][Pyright]] is a new language server by Microsoft rewritten from scratch. Microsoft
-python language server is planned to be deprecated in favor of pyright. Pyright
-offers improved performance and better features compared to the old
-implementation. It can be installed via yarn or npm as follows:
+[[https://github.com/microsoft/pyright][Pyright]] is a language server by Microsoft rewritten from scratch. It can be
+installed via pip, yarn or npm as follows:
 
 #+BEGIN_SRC sh
-  # via yarn
+  # via pip
+  pip install pyright
+  # or via yarn
   yarn global add pyright
   # or via npm
   npm install -g pyright

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -33,8 +33,7 @@ If `nil' then `anaconda' is the default backend unless `lsp' layer is used.")
 (put 'python-backend 'safe-local-variable #'symbolp)
 
 (defvar python-lsp-server 'pylsp
-  "Language server to use for lsp backend. Possible values are `pylsp', `pyright'
-and `mspyls'")
+  "Language server for lsp backend. Possible values are `pylsp', `pyright'")
 (put 'python-lsp-server 'safe-local-variable #'symbolp)
 
 (defvar python-lsp-git-root nil

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -91,7 +91,6 @@
       (progn
         (require (pcase python-lsp-server
                    ('pylsp 'lsp-pylsp)
-                   ('mspyls 'lsp-python-ms)
                    ('pyright 'lsp-pyright)
                    (x (user-error "Unknown value for `python-lsp-server': %s" x))))
         (lsp-deferred))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -60,8 +60,6 @@
     ;; packages for anaconda backend
     anaconda-mode
     (company-anaconda :requires company)
-    ;; packages for Microsoft LSP backend
-    (lsp-python-ms :requires lsp-mode)
     ;; packages for Microsoft's pyright language server
     (lsp-pyright :requires lsp-mode)))
 
@@ -492,28 +490,6 @@ fix this issue."
                (eq 'yapf python-formatter))
       (add-hook 'python-mode-hook 'yapf-mode))
     :config (spacemacs|hide-lighter yapf-mode)))
-
-(defun python/init-lsp-python-ms ()
-  (use-package lsp-python-ms
-    :if (eq python-lsp-server 'mspyls)
-    :ensure nil
-    :defer t
-    :config
-    (when python-lsp-git-root
-      ;; Use dev version of language server checked out from github
-      (setq lsp-python-ms-dir
-            (expand-file-name (concat python-lsp-git-root
-                                      "/output/bin/Release/")))
-      (message "lsp-python-ms: Using version at `%s'" lsp-python-ms-dir)
-      ;; Use a precompiled exe
-      (setq lsp-python-ms-executable (concat lsp-python-ms-dir
-                                             (pcase system-type
-                                               ('gnu/linux "linux-x64/publish/")
-                                               ('darwin "osx-x64/publish/")
-                                               ('windows-nt "win-x64/publish/"))
-                                             "Microsoft.Python.LanguageServer"
-                                             (and (eq system-type 'windows-nt)
-                                                  ".exe"))))))
 
 (defun python/init-lsp-pyright ()
   (use-package lsp-pyright

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2220,7 +2220,7 @@ Features:
   - [[https://github.com/proofit404/anaconda-mode][anaconda]] (default),
   - [[https://github.com/emacs-lsp/lsp-python-ms][Language Server Protocol]] (experimental - 2 implementations),
     - python-lsp-server
-    - Microsoft python language server
+    - Microsoft pyright language server
 - Auto-completion
 - Code Navigation
 - Documentation Lookup using [[https://github.com/proofit404/anaconda-mode][anaconda-mode]] and [[https://github.com/tsgates/pylookup][pylookup]]


### PR DESCRIPTION
The mslsp (Microsoft python langugage server) was deprecated, remove it, and use the pyright instead.
The mslsp repo announced the DEPRECATED:
  https://github.com/emacs-lsp/lsp-python-ms
