### PR TITLE
[compleseus] Assume buffers are in current perspective, if no persp-mode

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -37,7 +37,7 @@
           ,(lambda ()
              (consult--buffer-query ;; :sort 'visibility
               :predicate (lambda (buff)
-                           (and (persp-contain-buffer-p buff)
+                           (and (compleseus//persp-contain-buffer-p buff)
                                 (buffer-file-name buff)
                                 (buffer-modified-p buff)))
               ;; :directory 'project
@@ -57,6 +57,6 @@
     ,(lambda ()
        (consult--buffer-query
         :sort 'visibility
-        :predicate #'persp-contain-buffer-p
+        :predicate #'compleseus//persp-contain-buffer-p
         :as #'buffer-name)))
   "Per-perspective buffer source.")

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -36,14 +36,23 @@
     (define-key selectrum-minibuffer-map (kbd "C-k") 'selectrum-previous-candidate))))
 
 
+(defun compleseus//persp-contain-buffer-p (buf)
+  "Return non-nil if BUF is part of the current perspective.
+
+If persp-mode is not currently used, this function always returns
+non-nil."
+  (if (fboundp 'persp-contain-buffer-p)
+      (persp-contain-buffer-p buf)
+    t))
+
+
 (defun spacemacs/compleseus-switch-to-buffer ()
   "`consult-buffer' with buffers provided by persp."
   (interactive)
   (consult-buffer
    `(consult--source-hidden-buffer
-     ,@(when (configuration-layer/package-used-p 'persp-mode)
-         '(consult--source-persp-buffers
-           consult--source-modified-buffers))
+     consult--source-persp-buffers
+     consult--source-modified-buffers
      consult--source-recent-file
      consult--source-bookmark
      consult--source-project-buffer


### PR DESCRIPTION
Rather than omitting most buffers from SPC b b, if the
spacemacs-layouts layer is not enabled, simply assume that all buffers
are in the current perspective.

This is a follow-up to #16323.