### PR TITLE
Add TOML layer

### DIFF
--- a/layers/+lang/rust/README.org
+++ b/layers/+lang/rust/README.org
@@ -36,6 +36,8 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =rust= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
+The =toml= layer is automatically loaded when using this layer.
+
 ** LSP
 The =lsp= backend will be automatically enabled if the layer =lsp= is used.
 

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -28,8 +28,7 @@
     ggtags
     ron-mode
     rustic
-    smartparens
-    toml-mode))
+    smartparens))
 
 
 (defun rust/post-init-counsel-gtags ()
@@ -101,10 +100,6 @@
   (with-eval-after-load 'smartparens
     ;; Don't pair lifetime specifiers
     (sp-local-pair 'rustic-mode "'" nil :actions nil)))
-
-(defun rust/init-toml-mode ()
-  (use-package toml-mode
-    :mode "/\\(Cargo.lock\\|\\.cargo/config\\)\\'"))
 
 (defun rust/init-ron-mode ()
   (use-package ron-mode

--- a/layers/+lang/toml/README.org
+++ b/layers/+lang/toml/README.org
@@ -1,0 +1,19 @@
+#+TITLE: TOML layer
+
+#+TAGS: general|layer|programming
+
+* Table of Contents                     :TOC_5_gh:noexport:
+- [[#description][Description]]
+- [[#install][Install]]
+  - [[#layer][Layer]]
+
+* Description
+This layer supports [[https://toml.io][TOML]] development in Spacemacs.
+
+* Install
+** Layer
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =toml= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+This layer is automatically loaded when using the =rust= layer.

--- a/layers/+lang/toml/packages.el
+++ b/layers/+lang/toml/packages.el
@@ -1,8 +1,8 @@
-;;; layers.el --- Rust Layer declarations File for Spacemacs
+;;; packages.el --- TOML Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2024 Sylvain Benner & Contributors
 ;;
-;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;; Author: Codruț Constantin Gușoi <mail+spacemacs@codrut.pro>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -21,8 +21,10 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(when (and (boundp 'rust-backend)
-           (eq rust-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(lsp)))
+(defconst toml-packages
+  '(toml-mode))
 
-(configuration-layer/declare-layer-dependencies '(toml))
+(defun toml/init-toml-mode ()
+  (use-package toml-mode
+    :mode "/\\(\\.toml\\|Cargo.lock\\|\\.cargo/config\\)\\'"
+    :defer t))

--- a/layers/auto-layer.el
+++ b/layers/auto-layer.el
@@ -81,8 +81,8 @@
 (configuration-layer/lazy-install 'restclient :extensions '("\\(\\.http\\'\\)" restclient-mode))
 (configuration-layer/lazy-install 'ruby
   :extensions '("\\(\\(?:\\.rb\\|ru\\|rake\\|thor\\|jbuilder\\|gemspec\\|podspec\\|/\\(?:Gem\\|Rake\\|Cap\\|Thor\\|Vagrant\\|Guard\\|Pod\\)file\\)\\'\\|Puppetfile\\)" ruby-mode))
-(configuration-layer/lazy-install 'rust :extensions '("\\(\\.rs\\'\\)" rust-mode))
-(configuration-layer/lazy-install 'rust :extensions '("\\(\\.toml$\\)" toml-mode))
+(configuration-layer/lazy-install 'rust :extensions '("\\(\\.rs\\|Cargo.lock\\|\\.cargo/config\\)\\'" rust-mode))
+(configuration-layer/lazy-install 'toml :extensions '("\\.toml\\'" toml-mode))
 ;; scala
 ;; scheme
 (configuration-layer/lazy-install 'sml :extensions '("\\(\\.s\\(ml\\|ig\\)\\'\\|\\.\\(sml\\|sig\\)\\'\\)" sml-mode))


### PR DESCRIPTION
TOML is used in non rust project as well so it should be it's own layer, this way we save installing a few unneeded packages for people that don't use rust (if you can even imagine such people exist :smile: ) and the package is now deferred. The rust layer has a dependency on the toml layer now so rust users don't need to add it explicitly to the layer list.