### PR TITLE
fix smartparens-mode inserts double ' in minibuffer

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -444,6 +444,7 @@
     (show-smartparens-global-mode +1)
     ;; don't create a pair with single quote in minibuffer
     (sp-local-pair 'minibuffer-inactive-mode "'" nil :actions nil)
+    (sp-local-pair 'minibuffer-mode "'" nil :actions nil)
     (sp-pair "{" nil :post-handlers
               '(:add (spacemacs/smartparens-pair-newline-and-indent "RET")))
     (sp-pair "[" nil :post-handlers


### PR DESCRIPTION
smartparens-mode is sometimes activated in the minibuffer by spacemacs//conditionally-enable-smartparens-mode, specifically if we are in the minibuffer due to eval-expression (or eldoc-eval-expression). This is convenient for things like parens, but we don't want this behavior on a single quote. It looks like we *tried* to stop this, but for whatever reason that configuration was for minibuffer-inactive-mode rather than minibuffer-mode. The former is the major mode of the minibuffer when it is *not* active, whereas the latter is the major mode of the minibuffer when it *is* active. This has been part of spacemacs for a long time, so I've simply added configuration for minibuffer-mode and left behind the configuration for minibuffer-inactive-mode in case somebody was relying on that
