### PR TITLE
Highlight ruby debugger lines appropriately

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -34,6 +34,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 * Release 0.300.x
 ** 0.300.0
 *** Hot new feature
+- Highlight ruby debugger lines appropriately
 - Add support for Android emacs.
 - Extensive use of lazy loading of packages and other tricks to reduce Spacemacs
   startup time. In most cases you should see a noticable improvement in load

--- a/layers/+lang/ruby/funcs.el
+++ b/layers/+lang/ruby/funcs.el
@@ -138,9 +138,9 @@ Called interactively it prompts for a directory."
   "Highlight break point lines."
   (interactive)
   (when ruby-highlight-debugger-keywords
-    (highlight-lines-matching-regexp "byebug")
-    (highlight-lines-matching-regexp "binding.irb")
-    (highlight-lines-matching-regexp "binding.pry")))
+    (highlight-lines-matching-regexp "^\s*byebug")
+    (highlight-lines-matching-regexp "^\s*binding.irb")
+    (highlight-lines-matching-regexp "^\s*binding.pry")))
 
 
 ;; Insert text


### PR DESCRIPTION
Fixes #16357

The intended behavior is to highlight lines that are calling a ruby debugger. The purpose is to warn developers that might push code to production with a debugger enabled. The change expands the matching regex to only highlight lines where the debugger is the first word on a line.

There are cases in which the current regex is highlighting lines as a false-positive. I first noticed this in my `Gemfile` when it was highlighting the line below:

```ruby
gem 'pry-byebug'
```

Other cases include: commented lines and defined function names that match a known debugger.

See below for cases in which the line should and should not be highlighted.

```ruby
# frozen_string_literal: true

# This is a test class for ruby debugger highlighting
class Test
  # This line below should not be highlighted
  def byebug
    byebug # this line should be highlighted
    # byebug This comment should not be highlighted

    binding.irb # this line should be highlighted
    # binding.irb this line should not be highlighted

    binding.pry # this line should be highlighted
    # binding.pry this line should not be highlighted
  end
end
```

**Before:**

<img width="716" alt="Screenshot 2024-04-04 at 9 08 15 AM" src="https://github.com/syl20bnr/spacemacs/assets/362146/b4925d28-d956-4011-aee4-783d099d9280">

**After:**

<img width="705" alt="Screenshot 2024-04-04 at 9 12 23 AM" src="https://github.com/syl20bnr/spacemacs/assets/362146/2b2973a8-8808-4763-8197-ee6287b1cceb">
