### PR TITLE
layers/+tools/translate/packages.el: fix invalid quote

### DIFF
--- a/layers/+tools/translate/packages.el
+++ b/layers/+tools/translate/packages.el
@@ -40,7 +40,7 @@
     (cl-defmethod gts-text ((_ translate//reference-paragraph-texter))
       (translate-get-reference-paragraph-text-at-point))
     (defclass translate//reference-paragraph-picker (gts-picker)
-      ((texter :initarg :texter :initform '(translate//reference-paragraph-texter))))
+      ((texter :initarg :texter :initform (translate//reference-paragraph-texter))))
     (cl-defmethod gts-pick ((o translate//reference-paragraph-picker))
       (let ((text (gts-text (oref o texter))))
         (when (= 0 (length (if text (string-trim text) "")))


### PR DESCRIPTION
Hi,

I got an error message after I enabled the `translate` layer:
> cl-no-applicable-method: No applicable method: gts-text, (translate//reference-paragraph-texter)

After check the example from dependency package I found the singal quote is unexpected.
https://github.com/lorniu/go-translate/blob/377375c87f64e7d069c8fc310ccfefd8771226f3/gts-implements.el#L596-L597

The function will work after remove the quote. 
Please help review the change. Thanks.