### PR TITLE
layers/+spacemacs/spacemacs-purpose: move to define-advice

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/funcs.el
+++ b/layers/+spacemacs/spacemacs-purpose/funcs.el
@@ -64,14 +64,11 @@ Enable or disable advices to popwin, according to the state of `purpose-mode'."
   (require 'window-purpose)
   (if purpose-mode
       (progn
-        (ad-enable-advice 'popwin:create-popup-window
-                          'before 'window-purpose/save-dedicated-windows)
-        (ad-enable-advice 'popwin:create-popup-window
-                          'after 'window-purpose/restore-dedicated-windows)
-        (ad-update 'popwin:create-popup-window)
-        (ad-activate 'popwin:create-popup-window))
-    (ad-disable-advice 'popwin:create-popup-window
-                       'before 'window-purpose/save-dedicated-windows)
-    (ad-disable-advice 'popwin:create-popup-window
-                       'after 'window-purpose/restore-dedicated-windows)
-    (ad-update 'popwin:create-popup-window)))
+        (advice-add #'popwin:create-popup-window
+                    :before #'window-purpose/save-dedicated-windows)
+        (advice-add #'popwin:create-popup-window
+                    :after #'window-purpose/restore-dedicated-windows))
+    (advice-remove #'popwin:create-popup-window
+                   #'window-purpose/save-dedicated-windows)
+    (advice-remove #'popwin:create-popup-window
+                   #'window-purpose/restore-dedicated-windows)))

--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -211,7 +211,7 @@ Popwin's settings are taken from `popwin:special-display-config'."
     (remove-hook 'purpose-display-buffer-functions #'pupo/after-display)
     (remove-hook 'purpose-display-buffer-functions #'pupo/auto-delete-windows)))
 
-(defadvice popwin:create-popup-window (before pupo/before-popwin-create)
+(define-advice popwin:create-popup-window (:before pupo/before-popwin-create)
   "Save current popup windows for later restoration.
 The windows are restored in `pupo/after-popwin-create'.
 Note that the windows themselves aren't saved, but some internal
@@ -219,7 +219,7 @@ variables are updated instead."
   (setq pupo--saved-buffers (mapcar #'window-buffer pupo--windows))
   (setq pupo--saved-auto-buffers (mapcar #'window-buffer pupo--auto-windows)))
 
-(defadvice popwin:create-popup-window (after pupo/after-popwin-create)
+(define-advice popwin:create-popup-window (:after pupo/after-popwin-create)
   "Restore popup windows.
 The windows were saved in `pupo/before-popwin-create'.
 Note that the windows themselves aren't restored, but some internal
@@ -238,13 +238,10 @@ variables are updated instead."
 (defun pupo/sync-advices ()
   (if pupo-mode
       (progn
-        (ad-enable-advice 'popwin:create-popup-window 'before 'pupo/before-popwin-create)
-        (ad-enable-advice 'popwin:create-popup-window 'after 'pupo/after-popwin-create)
-        (ad-update 'popwin:create-popup-window)
-        (ad-activate 'popwin:create-popup-window))
-    (ad-disable-advice 'popwin:create-popup-window 'before 'pupo/before-popwin-create)
-    (ad-disable-advice 'popwin:create-popup-window 'after 'pupo/after-popwin-create)
-    (ad-update 'popwin:create-popup-window)))
+        (advice-add #'popwin:create-popup-window :before #'pupo/before-popwin-create)
+        (advice-add #'popwin:create-popup-window :after #'pupo/after-popwin-create))
+    (advice-remove #'popwin:create-popup-window #'pupo/before-popwin-create)
+    (advice-remove #'popwin:create-popup-window #'pupo/after-popwin-create)))
 (add-hook 'pupo-mode-hook #'pupo/sync-advices)
 
 (provide 'spacemacs-purpose-popwin)

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -79,14 +79,14 @@
     :post-config
     (progn
       (defvar window-purpose--dedicated-windows nil)
-      (defadvice popwin:create-popup-window
-          (before window-purpose/save-dedicated-windows)
+      (define-advice popwin:create-popup-window
+          (:before window-purpose/save-dedicated-windows)
         (setq window-purpose--dedicated-windows
               (cl-loop for window in (window-list)
                        if (purpose-window-purpose-dedicated-p window)
                        collect (window-buffer window))))
-      (defadvice popwin:create-popup-window
-          (after window-purpose/restore-dedicated-windows)
+      (define-advice popwin:create-popup-window
+          (:after window-purpose/restore-dedicated-windows)
         (cl-loop for buffer in window-purpose--dedicated-windows
                  do (cl-loop for window in (get-buffer-window-list buffer)
                              do (purpose-set-window-purpose-dedicated-p


### PR DESCRIPTION
Hi, 
I got warning messages on startup for `defadvice`, so move to the `define-advice`.
> layers/+spacemacs/spacemacs-purpose/packages.el: Warning: ‘defadvice’ is an obsolete macro (as of 30.1); use ‘advice-add’ or ‘define-advice’

Please help review the changes, thanks.