### PR TITLE
fix inferior R mode

### DIFF
--- a/layers/+lang/ess/funcs.el
+++ b/layers/+lang/ess/funcs.el
@@ -87,8 +87,6 @@
 (defun spacemacs/ess-bind-keys-for-inferior ()
   (define-key inferior-ess-mode-map (kbd "C-j") #'comint-next-input)
   (define-key inferior-ess-mode-map (kbd "C-k") #'comint-previous-input)
-  (when ess-assign-key
-    (define-key inferior-ess-r-mode-map ess-assign-key #'ess-insert-assign))
 
   (dolist (mode '(inferior-ess-mode inferior-ess-r-mode))
     (spacemacs/declare-prefix-for-mode mode "ms" "repl")


### PR DESCRIPTION
R and related modes (R markdown, quarto mode, ...) were broken because spacemacs tried to assign a keybinding to `inferior-ess-r-mode-map`, which doesn't exist. I have done a quick fix by removing the assignment. In the R repl you cannot type `<-` by pressing `M--` any more, in a `.R` file it still works.