### PR TITLE
[spacemacs-editing-visual] Disable vhl occur extension in Emacs 28+

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -163,6 +163,12 @@
       :mode volatile-highlights-mode
       :documentation "Display visual feedback for some operations."
       :evil-leader "thv")
+
+    ;; volatile-highlights is redundant with built-in highlighting in occur.  In
+    ;; Emacs 29, it starts to cause errors.  See
+    ;; https://github.com/k-talo/volatile-highlights.el/issues/26
+    (setq vhl/use-occur-extension-p (< emacs-major-version 28))
+
     (volatile-highlights-mode t)
     :config
     ;; additional extensions


### PR DESCRIPTION
This extension causes an error when navigating to occur matches
starting in Emacs 29, and already in Emacs 28, it became unnecessary
since occur does its own highlighting of matches when you visit them.

See k-talo/volatile-highlights.el#26.