### PR TITLE
Add some missing help key bindings to spacemacs-defaults

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -146,11 +146,8 @@
       "bB" #'consult-buffer
       "fb" #'consult-bookmark
       "ff" #'spacemacs/compleseus-find-file
-      "fel" #'find-library
       "fL" #'consult-locate
       "fr" #'consult-recent-file
-      "hda" #'apropos-command
-      "hdm" #'describe-mode
       "hm" #'consult-man
       "jm" #'consult-mark
       "jM" #'consult-global-mark

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -383,6 +383,7 @@
     ("D" spacemacs/ediff-dotfile-and-template "Diff. with dotfile template")
     ("e" spacemacs/edit-env "Open \".spacemacs.env\"")
     ("E" dotspacemacs/call-user-env "Refresh env. variables")
+    ("l" find-library "Find Emacs library...")
     ("R" dotspacemacs/sync-configuration-layers "Reload configuration")
     ("v" spacemacs/display-and-copy-version "Copy Spacemacs version")
     ("U" configuration-layer/update-packages "Update packages..."))
@@ -415,6 +416,7 @@
 ;; help -----------------------------------------------------------------------
 (defalias 'emacs-tutorial 'help-with-tutorial)
 (spacemacs/set-leader-keys
+  "hda" 'apropos-command
   "hdb" 'describe-bindings
   "hdc" 'describe-char
   "hdf" 'describe-function
@@ -422,6 +424,7 @@
   "hdk" 'describe-key
   "hdK" 'describe-keymap
   "hdl" 'spacemacs/describe-last-keys
+  "hdm" 'describe-mode
   "hdp" 'describe-package
   "hdP" 'configuration-layer/describe-package
   "hds" 'spacemacs/describe-system-info

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -418,6 +418,7 @@
   "hdb" 'describe-bindings
   "hdc" 'describe-char
   "hdf" 'describe-function
+  "hdF" 'describe-face
   "hdk" 'describe-key
   "hdK" 'describe-keymap
   "hdl" 'spacemacs/describe-last-keys


### PR DESCRIPTION
- `SPC h d F` is `describe-face`, like it is in ivy and helm
- `SPC f e l`, `SPC h d a`, `SPC h d m` are moved from the compleseus
  layer, since they are binding built-in commands anyway.