### PR TITLE
[spacemacs-evil] Use evil-collection for occur-mode support

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -43,7 +43,6 @@
     (hi-lock :location built-in)
     (image-mode :location built-in)
     (imenu :location built-in)
-    (occur-mode :location built-in)
     (package-menu :location built-in)
     ;; page-break-lines is shipped with spacemacs core
     (page-break-lines :location built-in)
@@ -354,10 +353,6 @@
                           (global-display-line-numbers-mode))
                         lazy-loading-line-numbers)
                     (global-display-line-numbers-mode)))))))
-
-(defun spacemacs-defaults/init-occur-mode ()
-  (evilified-state-evilify-map occur-mode-map
-    :mode occur-mode))
 
 (defun spacemacs-defaults/init-package-menu ()
   (evilified-state-evilify-map package-menu-mode-map

--- a/layers/+spacemacs/spacemacs-evil/config.el
+++ b/layers/+spacemacs/spacemacs-evil/config.el
@@ -31,5 +31,5 @@
 (defvar evil-lisp-safe-structural-editing-modes '()
   "A list of major mode symbols where safe structural editing is supported.")
 
-(defvar spacemacs-evil-collection-allowed-list '(eww dired quickrun ediff)
+(defvar spacemacs-evil-collection-allowed-list '(dired ediff eww quickrun replace simple)
   "List of modes Spacemacs will allow to be evilified by ‘evil-collection-init’.")


### PR DESCRIPTION
This ensures that occur-edit-mode doesn't leave the buffer in
evilified-state, which is inconvenient to edit from.