### PR TITLE
* layers/+lang/python/funcs.el:Use built-in python-shell-send-statement

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -474,16 +474,10 @@ Bind formatter to '==' for LSP and '='for all other backends."
     (python-shell-send-region start end)))
 
 (defun spacemacs/python-shell-send-statement ()
-  "Send the current statement to shell, same as `python-shell-send-statement' in Emacs27."
+  "Send the statement under cursor to shell."
   (interactive)
-  (if (fboundp 'python-shell-send-statement)
-      (call-interactively #'python-shell-send-statement)
-    (if (region-active-p)
-        (call-interactively #'python-shell-send-region)
-      (let ((python-mode-hook nil))
-        (python-shell-send-region
-         (save-excursion (python-nav-beginning-of-statement))
-         (save-excursion (python-nav-end-of-statement)))))))
+  (let ((python-mode-hook nil))
+    (call-interactively #'python-shell-send-statement)))
 
 (defun spacemacs/python-shell-send-statement-switch ()
   "Send statement to shell and switch to it in insert mode."


### PR DESCRIPTION
Hi,

The `spacemacs/python-shell-send-statement` should call `python-shell-send-statement` for its built-in Emacs-27 while Spacemacs now minimum requirement is emacs-27.
So remove the unused code to make the function simple.

Please review the change. Thanks.