### PR TITLE
Enhance the eshell with its built-in ansi-color support

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -286,6 +286,8 @@ Some advanced configuration is setup for =eshell= in this layer:
 - add support for auto-completion via =company= (when the =auto-completion=
   layer is installed)
 - pressing ~i~ in normal state will automatically jump to the prompt
+- color support with package ~xterm-color~ on Emacs28 and before
+- color support with built-in ~ansi-color~ by default on Emacs29 and later
 
 * Key bindings
 

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -40,7 +40,7 @@
     (shell :location built-in)
     shell-pop
     (term :location built-in)
-    xterm-color
+    (xterm-color :toggle (version< emacs-version "29.0.50"))
     terminal-here
     vi-tilde-fringe
     window-purpose
@@ -101,26 +101,8 @@
     (add-hook 'eshell-mode-hook 'spacemacs/disable-hl-line-mode)
     (with-eval-after-load 'centered-cursor-mode
       (add-hook 'eshell-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode))
+
     :config
-
-    ;; Work around bug in eshell's preoutput-filter code.
-    ;; Eshell doesn't call preoutput-filter functions in the context of the eshell
-    ;; buffer. This breaks the xterm color filtering when the eshell buffer is updated
-    ;; when it's not currently focused.
-    ;; To remove if/when fixed upstream.
-    (defun eshell-output-filter@spacemacs-with-buffer (fn process string)
-      (let ((proc-buf (if process (process-buffer process)
-                        (current-buffer))))
-        (when proc-buf
-          (with-current-buffer proc-buf
-            (funcall fn process string)))))
-    (advice-add
-     #'eshell-output-filter
-     :around
-     #'eshell-output-filter@spacemacs-with-buffer)
-
-    (require 'esh-opt)
-
     ;; quick commands
     (defalias 'eshell/e 'find-file-other-window)
     (defalias 'eshell/d 'dired)
@@ -314,7 +296,23 @@
     (add-hook 'comint-preoutput-filter-functions 'xterm-color-filter)
     (setq comint-output-filter-functions
           (remove 'ansi-color-process-output comint-output-filter-functions))
-    (add-hook 'eshell-mode-hook 'spacemacs/init-eshell-xterm-color)))
+    (add-hook 'eshell-mode-hook 'spacemacs/init-eshell-xterm-color)
+    (with-eval-after-load 'eshell
+      ;; Work around bug in eshell's preoutput-filter code.
+      ;; Eshell doesn't call preoutput-filter functions in the context of the eshell
+      ;; buffer. This breaks the xterm color filtering when the eshell buffer is updated
+      ;; when it's not currently focused.
+      ;; To remove if/when fixed upstream.
+      (defun eshell-output-filter@spacemacs-with-buffer (fn process string)
+        (let ((proc-buf (if process (process-buffer process)
+                          (current-buffer))))
+          (when proc-buf
+            (with-current-buffer proc-buf
+              (funcall fn process string)))))
+      (advice-add
+       #'eshell-output-filter
+       :around
+       #'eshell-output-filter@spacemacs-with-buffer))))
 
 (defun shell/init-terminal-here ()
   (use-package terminal-here


### PR DESCRIPTION
Hi,

The Eshell works with ansi-color on both Emacs-29 and Emacs-30, don't bother the `xterm-color` package.
So move the the xterm-color initialization code to its initialization function.

This patch will let the Eshell works with most terminal tools colorful, for example, these command lines will work great in the eshell:
$ /bin/ls --color=tty
$ /bin/git status # with git config color.ui always

Please help review the changes. Thanks.