### PR TITLE
* layers/+lang/python/packages.el: Fix importmagic leak

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -178,7 +178,11 @@
   (use-package importmagic
     :defer t
     :init
-    (add-hook 'python-mode-hook 'importmagic-mode)
+    (add-hook 'python-mode-hook
+              #'(lambda ()
+                  ;; skip temp buffer which bufer-name begin with space
+                  (unless (eq ?\s (string-to-char (buffer-name)))
+                    (importmagic-mode))))
     (spacemacs|diminish importmagic-mode " ⓘ" " [i]")
     (spacemacs/set-leader-keys-for-major-mode 'python-mode
       "rf" 'importmagic-fix-symbol-at-point)))


### PR DESCRIPTION
Hi,

There is a serious resource leak when enable `python` layer with `importmage` package enabled.
The reproduce steps are:
1. enable `python` layer, and the `imortmagic` should also be instralled for its python layer dependency. 
2. open a python source code,
3. start python interpreter
4. execute `python-shell-send-buffer` or other send function.
5. execute `list-processes` to show the process
You will see every time execute the step 4, the `epc:server` in process list will increaced. 
The reason is the *emacs-29* had enhanced implementation for `with-temp-buffer` which won't call the `kill-buffer-hook` while the `importmagic-mode` will create `epc:server` on mode hook and stop the `epc:server` on `kill-buffer-hook` but it won't be called for temp buffer. 
This change will fix the issue with avoiding starting the `epc:server` for temp buffer. 

Please help review and merge the patch. Thanks