### PR TITLE
Function "spacemacs/delete-current-buffer-file" support prefix argument

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -558,16 +558,18 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
   (funcall-interactively #'spacemacs/delete-file filename t))
 
 ;; from magnars
-(defun spacemacs/delete-current-buffer-file ()
-  "Removes file connected to current buffer and kills buffer."
-  (interactive)
+(defun spacemacs/delete-current-buffer-file (&optional arg)
+  "Removes file connected to current buffer and kills buffer.
+If ARG is not nil, assume yes for default."
+  (interactive "P")
   (let ((filename (buffer-file-name))
         (buffer (current-buffer))
         (name (buffer-name)))
     (if (not (and filename (file-exists-p filename)))
         (ido-kill-buffer)
-      (if (yes-or-no-p
-           (format "Are you sure you want to delete this file: '%s'?" name))
+      (if (or arg
+              (yes-or-no-p
+               (format "Are you sure you want to delete this file: '%s'?" name)))
           (progn
             (delete-file filename t)
             (kill-buffer buffer)
@@ -576,6 +578,11 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
               (call-interactively #'projectile-invalidate-cache))
             (message "File deleted: '%s'" filename))
         (message "Canceled: File deletion")))))
+
+(defun spacemacs/delete-current-buffer-file-yes ()
+  "Removes file connected to current buffer and kills buffer with assume yes."
+  (interactive)
+  (funcall #'spacemacs/delete-current-buffer-file t))
 
 ;; from magnars
 (defun spacemacs/sudo-edit (&optional arg)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -363,7 +363,8 @@
  (("f" "Files"
    ("A" spacemacs/find-file-and-replace-buffer "Set another file for buffer...")
    ("c" spacemacs/save-as "Save file or active region as a new file...")
-   ("D" spacemacs/delete-current-buffer-file "Delete...")
+   ("D" spacemacs/delete-current-buffer-file-yes "Delete without confirm...")
+   ("d" spacemacs/delete-current-buffer-file "Delete...")
    ("i" spacemacs/insert-file "Insert file content...")
    ("l" find-file-literally "Open file literally...")
    ("E" spacemacs/sudo-edit "Open using sudo...")


### PR DESCRIPTION
Hi,

The `SPC f D` (`spacemacs/delete-current-buffer-file`) will always requests confirming by type y-or-n.
This change will enhance user experience with key bindings:
1. `SPC f d` -- delete current buffer and file, with confirming required;
2. `SPC f D` -- delete current buffer and file, assume yes (without  confirming required).
3. `C-u SPC f d` -- delete current buffer and file, assume yes (without  confirming required).

Please help review and approve this enhancement. Thanks.
