### PR TITLE
* layers/+tools/shell/packages.el (shell/init-eshell): Better PAGER support

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -125,9 +125,14 @@
     (defalias 'eshell/e 'find-file-other-window)
     (defalias 'eshell/d 'dired)
 
-    (require 'esh-var)
-    (add-to-list 'eshell-variable-aliases-list
-                 `("PAGER" ,(lambda (&optional _indices _quoted) "cat") t))
+    (when (version< emacs-version "28.1")
+      (with-eval-after-load 'esh-var
+        (add-to-list 'eshell-variable-aliases-list
+                     `("PAGER" (,(lambda () (or comint-pager (getenv "PAGER")))
+                                . ,(lambda (_ value)
+                                     (unless value (setenv "PAGER"))
+                                     (setq comint-pager value)))
+                       t t))))
 
     ;; support `em-smart'
     (when shell-enable-smart-eshell


### PR DESCRIPTION
Hi, 

The `PAGER` for eshell is simply set to `cat`, acctually should check existing one if customer has better choise. 
The patch won't overide customer PAGER and more friendly for user.
Please help review it. Thanks.