### PR TITLE
[compleseus] Initial input for project search from `symbol-highlight-transient-state`

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -51,7 +51,7 @@
     (spacemacs/transient-state-register-add-bindings 'symbol-highlight
       '(("s" spacemacs/consult-line :exit t)
         ("f" spacemacs/compleseus-search-auto :exit t)
-        ("/" spacemacs/compleseus-search-projectile-auto :exit t)))))
+        ("/" spacemacs/compleseus-search-projectile :exit t)))))
 
 (defun compleseus/post-init-imenu ()
   (spacemacs/set-leader-keys "ji" 'spacemacs/consult-jump-in-buffer)


### PR DESCRIPTION
Unlike the <kbd>s</kbd> and <kbd>f</kbd> bindings in the Symbol Highlight Transient State, the project search binding <kbd>/</kbd> currently does not automatically insert the symbol at point into the prompt. 

This PR switches in the correct function `spacemacs/compleseus-search-projectile`. (The only difference between `spacemacs/compleseus-search-projectile-auto` and `spacemacs/compleseus-search-projectile` is the initial input.)