### PR TITLE
[compleseus] Use consult-theme from `theme-transient-state`

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -447,6 +447,8 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
     (call-interactively 'spacemacs/helm-themes))
    ((configuration-layer/layer-used-p 'ivy)
     (call-interactively 'counsel-load-theme))
+   ((configuration-layer/layer-used-p 'compleseus)
+    (call-interactively 'consult-theme))
    (t (call-interactively 'load-theme))))
 
 (defun spacemacs/post-theme-init (theme)

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -196,6 +196,7 @@
     ;; customize preview activation and delay while selecting candiates
     (consult-customize
      consult-theme
+     spacemacs/theme-loader
      :preview-key '("M-." "C-SPC"
                     :debounce 0.2 any)
 


### PR DESCRIPTION
Unlike `spacemacs/helm-themes`, `counsel-load-theme`, and `consult-theme`, `load-theme` does not disable other themes when enabling one. It also does not provide previews. Hence we should use `consult-theme` from the `theme-transient-state` when the compleseus layer is used; this also makes the binding consistent with <kbd>SPC T s</kbd>.

Because consult uses the value of `this-command` to determine the `:preview-key` property, we need to customize the wrapper `spacemacs/theme-loader` too in order to enable previews.