### PR TITLE
[auto-completion] Fix evil repeat for completion with key sequence

### DIFF
--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -206,6 +206,7 @@ MODE parameter must match the :modes values used in the call to
   (when auto-completion-complete-with-key-sequence
     (let ((first-key (elt auto-completion-complete-with-key-sequence 0)))
       (cond ((eq 'company package)
+             (evil-declare-change-repeat 'spacemacs//auto-completion-key-sequence-end)
              (define-key company-active-map (kbd (char-to-string first-key))
                'spacemacs//auto-completion-key-sequence-start))
             (t (message "Not yet implemented for package %S" package))))))


### PR DESCRIPTION
Add a missing `(:repeat change)` property to `spacemacs//auto-completion-key-sequence-end` to record repeat information by buffer changes rather than by key presses. Previously `evil-repeat` would insert the key sequence used to trigger the completion instead of the completion itself.
