### PR TITLE
Bindings to restart python shell

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -447,6 +447,8 @@ Send code to inferior process commands:
 | ~SPC m s F~ | send function and switch to REPL in insert mode              |
 | ~SPC m s i~ | start inferior REPL process                                  |
 | ~SPC m s l~ | send line and keep code buffer focused                       |
+| ~SPC m s n~ | restart REPL process and keep code buffer focused            |
+| ~SPC m s N~ | restart REPL process and switch to REPL in insert mode       |
 | ~SPC m s r~ | send region and keep code buffer focused                     |
 | ~SPC m s R~ | send region and switch to REPL in insert mode                |
 | ~CTRL+j~    | next item in REPL history                                    |

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -525,6 +525,20 @@ If region is not active then send line."
     (pop-to-buffer (process-buffer shell-process))
     (evil-insert-state)))
 
+(defun spacemacs/python-shell-restart ()
+  "Restart python shell."
+  (interactive)
+  (let ((python-mode-hook nil))
+    (python-shell-restart)))
+
+(defun spacemacs/python-shell-restart-switch ()
+  "Restart python shell and switch to it in insert mode."
+  (interactive)
+  (let ((python-mode-hook nil))
+    (python-shell-restart)
+    (python-shell-switch-to-shell)
+    (evil-insert-state)))
+
 (defun spacemacs/python-execute-file (arg)
   "Execute a python script in a shell."
   (interactive "P")

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -400,6 +400,8 @@
       "sF" 'spacemacs/python-shell-send-defun-switch
       "sf" 'spacemacs/python-shell-send-defun
       "si" 'spacemacs/python-start-or-switch-repl
+      "sn" 'spacemacs/python-shell-restart
+      "sN" 'spacemacs/python-shell-restart-switch
       "sR" 'spacemacs/python-shell-send-region-switch
       "sr" 'spacemacs/python-shell-send-region
       "sl" 'spacemacs/python-shell-send-line


### PR DESCRIPTION
Thank you for the excellent python layer.

I noticed a minor issue: the bindings do not include a way to restart the shell conveniently.
It would be natural to include these in the `SPC m s` bindings.
E.g., `SPC m s` includes commands to remove unused imports or start a shell.

I would also suggest to replace the uninformative 'prefix' as the description for `SPC m s` by 'python-shell' or 'shell' but did not include this in the PR.