### PR TITLE
Add support for inf-ruby-mode ruby-quit

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -178,6 +178,7 @@ Note that the =prettier= binary must be available in the project's
 | ~SPC m s f~ | send function definition                          |
 | ~SPC m s F~ | send function definition and switch to REPL       |
 | ~SPC m s i~ | start REPL                                        |
+| ~SPC m s q~ | quit REPL                                         |
 | ~SPC m s l~ | send line                                         |
 | ~SPC m s L~ | send line and switch to REPL                      |
 | ~SPC m s r~ | send region                                       |

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -217,6 +217,7 @@
         "sf" 'ruby-send-definition
         "sF" 'ruby-send-definition-and-go
         "si" 'robe-start
+        "sq" 'ruby-quit
         "sl" 'ruby-send-line
         "sL" 'ruby-send-line-and-go
         "sr" 'ruby-send-region


### PR DESCRIPTION
Hello!

I would like to add keybinding support for https://github.com/nonsequitur/inf-ruby/pull/185

Please let me know if any additional changes are required.

Thanks!