### PR TITLE
[go] Disable use of company-go when gopls is used

### DIFF
--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -25,7 +25,8 @@
   '(
     company
     dap-mode
-    (company-go :requires company)
+    (company-go :requires company
+                :toggle (eq go-backend 'go-mode))
     counsel-gtags
     eldoc
     flycheck


### PR DESCRIPTION
The default backend for go-layer is lsp but company-go was still added to company-backends forcing it to search for gocode which should not be used since the user wants lsp.

This change only adds company-go to company-backends if go-mode is selected as the backend.

Note: go-mode is deprecated and gocode is not maintained anymore