### PR TITLE
layers/+spacemacs/spacemacs-defaults/keybindings.el: Fix key binding issue 

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -132,7 +132,6 @@
     (spacemacs||set-helm-key "sgG"  spacemacs/helm-file-do-grep-region-or-symbol)
     ;; various key bindings
     (spacemacs||set-helm-key "fel" helm-locate-library)
-    (spacemacs||set-helm-key "hdm" describe-mode)
     (spacemacs||set-helm-key "hdx" spacemacs/describe-ex-command)
     (spacemacs||set-helm-key "swg" helm-google-suggest)
     (with-eval-after-load 'helm-files

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -343,24 +343,6 @@ that directory."
   (ignore-errors
     (call-interactively 'counsel-up-directory)))
 
-(when (configuration-layer/package-used-p 'counsel)
-  (with-eval-after-load 'counsel
-    (defun spacemacs/describe-mode ()
-      "Dummy wrapper to prevent an key binding error from helm.
-
-By default the emacs leader is M-m, turns out that Helm does this:
-   (cl-dolist (k (where-is-internal 'describe-mode global-map))
-        (define-key map k 'helm-help))
-after doing this:
-   (define-key map (kbd \"M-m\") 'helm-toggle-all-marks)
-So when Helm is loaded we get the error:
-   Key sequence M-m h d m starts with non-prefix key M-m
-
-To prevent this error we just wrap `describe-mode' to defeat the
- Helm hack."
-      (interactive)
-      (call-interactively 'describe-mode))))
-
 (defun spacemacs//counsel-with-git-grep (func x)
   "This function should be kept in sync with `counsel-git-grep-action'.
 

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -88,7 +88,6 @@
       "hda" 'counsel-apropos
       "hdf" 'counsel-describe-function
       "hdF" 'counsel-describe-face
-      "hdm" 'spacemacs/describe-mode
       "hdv" 'counsel-describe-variable
       "hdx" 'spacemacs/describe-ex-command
       "hi"  'counsel-info-lookup-symbol


### PR DESCRIPTION
Hi,

After upgrade with https://github.com/syl20bnr/spacemacs/pull/16368/ , I got an error message by press `M-m h d m`,
> Key sequence M-m h d m starts with non-prefix key M-m

It caused by the key "M-m h d m" were re-defined on different locations.
Remove the `SPC hdm` from helm/ivy and  leave the default one for the "describe-mode" is NOT bother the auto-completion functions.

The keeped one: https://github.com/syl20bnr/spacemacs/pull/16368/files#diff-88e0ffcf5a110c3c48581316b4abfae1430f74faf73043943af33db287254ab8R427

Please help review the changes. Thanks.
