### PR TITLE
Enhance the describe-mode and more document

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -139,8 +139,9 @@ If not in such a search box, fall back on `Custom-newline'."
 ;; So when Helm is loaded we get the error:
 ;;    Key sequence M-m h d m starts with non-prefix key M-m
 ;; To prevent this error we just alias `describe-mode' to defeat the Helm hack.
-(when (configuration-layer/package-used-p 'helm)
-  (defalias 'spacemacs/describe-mode 'describe-mode))
+(defalias 'spacemacs/describe-mode 'describe-mode
+  "To avoid Helm key binding issue for `describe-mode'.
+Refer Spacemacs #16397 for details.")
 
 (defun spacemacs/indent-region-or-buffer ()
   "Indent a region if selected, otherwise the whole buffer."

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -425,9 +425,7 @@
   "hdk" 'describe-key
   "hdK" 'describe-keymap
   "hdl" 'spacemacs/describe-last-keys
-  "hdm" (if (configuration-layer/package-used-p 'helm)
-            'spacemacs/describe-mode
-          'describe-mode)
+  "hdm" 'spacemacs/describe-mode
   "hdp" 'describe-package
   "hdP" 'configuration-layer/describe-package
   "hds" 'spacemacs/describe-system-info


### PR DESCRIPTION
Hi,
This PR is try to make more simple code for `describe-mode`, and more document for it. 

_Originally posted by @sunlin7 in https://github.com/syl20bnr/spacemacs/issues/16397#issuecomment-2110729312_

The helm has special code to deal the `describe-mode`:
https://github.com/emacs-helm/helm/blob/6d23a65ca6bcb6c0ea6f21f3cf2e58f8570ef75b/helm-core.el#L479-L481
```
(defvar helm-map
;;...
    (define-key map (kbd "M-m")        #'helm-toggle-all-marks)
;;...
    ;; Use `describe-mode' key in `global-map'.
    (dolist (k (where-is-internal #'describe-mode global-map))
      (define-key map k #'helm-help))
;;...
```
If arranged the `describe-mode` with key "M-m ..." before helm, the issue will be triggered.
Thanks


