### PR TITLE
[emacs-lisp] Add elisp-demos package integration

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2073,6 +2073,7 @@ Other:
     - ~SPC m r d d~ for  =emr-delete-unused-definition=
     - ~SPC m e w~   for   =emr-eval-and-replace=
 - Added =elisp-def= integration (thanks to Thanh Vuong)
+- Added =elisp-demos= integration (thanks to Alfonso Montero)
 **** Emoji
 - Added support for Emoji fonts on macOS and Linux (thanks to CodeFalling)
 - Setup =emojify= cache directory (thanks to Boris Buliga)

--- a/layers/+lang/emacs-lisp/README.org
+++ b/layers/+lang/emacs-lisp/README.org
@@ -39,6 +39,7 @@ always be in your dotfile, it is not recommended to uninstall it.
 - Nameless package prefix with optional [[https://github.com/Malabarba/Nameless][nameless]]
 - Structurally safe editing using optional [[https://github.com/luxbock/evil-cleverparens][evil-cleverparens]]
 - Visual feedback when evaluation using [[https://github.com/hchbaw/eval-sexp-fu.el][eval-sexp-fu]]
+- Provide Emacs Lisp API usage examples using [[https://github.com/xuchunyang/elisp-demos][elisp-demos]]
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -29,6 +29,7 @@
     (edebug :location built-in)
     eldoc
     elisp-def
+    elisp-demos
     elisp-slime-nav
     (emacs-lisp :location built-in)
     evil
@@ -159,6 +160,14 @@
 (defun emacs-lisp/init-elisp-def ()
   (use-package elisp-def
     :defer t))
+
+(defun emacs-lisp/init-elisp-demos ()
+  (use-package elisp-demos
+    :defer t)
+  (advice-add 'describe-function-1
+              :after #'elisp-demos-advice-describe-function-1)
+  (advice-add 'helpful-update
+              :after #'elisp-demos-advice-helpful-update))
 
 (defun emacs-lisp/init-elisp-slime-nav ()
   ;; Elisp go-to-definition with M-. and back again with M-,

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -163,11 +163,13 @@
 
 (defun emacs-lisp/init-elisp-demos ()
   (use-package elisp-demos
-    :defer t)
-  (advice-add 'describe-function-1
-              :after #'elisp-demos-advice-describe-function-1)
-  (advice-add 'helpful-update
-              :after #'elisp-demos-advice-helpful-update))
+    :defer t
+    :init
+    (advice-add 'describe-function-1
+                :after #'elisp-demos-advice-describe-function-1)
+    (advice-add 'helpful-update
+                :after #'elisp-demos-advice-helpful-update)
+    :commands (elisp-demos-add-demo elisp-demos-find-demo)))
 
 (defun emacs-lisp/init-elisp-slime-nav ()
   ;; Elisp go-to-definition with M-. and back again with M-,


### PR DESCRIPTION
[Resubmission of #16374, closed by mistake, with @smile13241324's review requested changes]
Provides Emacs Lisp API usage examples on help buffers using [elisp-demos](https://github.com/xuchunyang/elisp-demos) package.