### PR TITLE
* layers/+spacemacs/spacemacs-defaults/funcs.el: customer variable for spacemacs/delete-buffer-file

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -78,6 +78,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Added support for native fill column indicator in Emacs 27+ (thanks to
   Andriy Kmit)
 - Add support for background transparency aka true transparency. Key bindings are under ~SPC T B~ (thanks to JoshTRN)
+- Binding the ~SPC f d~ for deleting current buffer and file (thanks to Lin Sun)
 *** Breaking Changes
 **** Major
 - Support for Emacs 25 or Emacs 26 has been dropped, the minimal Emacs version

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -570,6 +570,16 @@ FILENAME is deleted using `spacemacs/delete-file' function.."
   (funcall-interactively #'spacemacs/delete-file filename t))
 
 ;; from magnars
+(defcustom spacemacs-keep-legacy-current-buffer-delete-bindings nil
+  "User deletes current buffer and file without confirmation."
+  :type 'boolean
+  :group 'spacemacs)
+
+(defcustom spacemacs-prompt-current-buffer-delete-bindings t
+  "User deletes current buffer and file without confirmation."
+  :type 'boolean
+  :group 'spacemacs)
+
 (defun spacemacs/delete-current-buffer-file (&optional arg)
   "Removes file connected to current buffer and kills buffer.
 If ARG is not nil, assume yes for default."
@@ -592,9 +602,16 @@ If ARG is not nil, assume yes for default."
         (message "Canceled: File deletion")))))
 
 (defun spacemacs/delete-current-buffer-file-yes ()
-  "Removes file connected to current buffer and kills buffer with assume yes."
+  "Removes file connected to current buffer and kills buffer with assume yes.
+Custom the `spacemacs-keep-legacy-current-buffer-delete-bindings' with t
+to follow legacy behavior."
   (interactive)
-  (funcall #'spacemacs/delete-current-buffer-file t))
+  (prog1
+      (funcall #'spacemacs/delete-current-buffer-file
+               (not spacemacs-keep-legacy-current-buffer-delete-bindings))
+    (when spacemacs-prompt-current-buffer-delete-bindings
+      (message "Customer the `spacemacs-keep-legacy-current-buffer-delete-bindings'\
+ with t to ask for confirmation."))))
 
 ;; from magnars
 (defun spacemacs/sudo-edit (&optional arg)


### PR DESCRIPTION
A customer variable to control the `spacemacs/delete-current-buffer-file` behavior to provide smoth change for users.

> @smile13241324 @sunlin7 I have not pulled `develop` myself yet, but I'm afraid this might cause a quite annoying UX issue to users: Wouldn't this change cause users using previously learnt binding to suddenly delete without confirmation? If true, this would be a blatant UX no-no, IMO. See also: [Principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)
> 
> If proposed bindings are desirable, a more progressive rollout would prevent users to suffer it. I'd rather push initially just the binding change from `SPC f D` to `SPC f d`, leaving `SPC f D` for later, with just a "moved" message for some time to allow users to adjust. At a later time, we can rollout the `SPC f D` binding as intended here. The latter can even just be skipped completely if extra safety is desired for users, and left to them.

