### PR TITLE
Update documentation for layer dependencies declaration

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -289,20 +289,20 @@ path for you.
 
 ** layers.el
 This file is the first file to be loaded and this is the place where additional
-layers can be declared.
+layers can be declared as dependencies.
 
 For instance, if layer A depends on some functionality of layer B, then in the
 file =layers.el= of layer A, we can add:
 
 #+BEGIN_SRC emacs-lisp
-  (configuration-layer/declare-layer 'B)
+  (configuration-layer/declare-layer-dependencies '(B))
 #+END_SRC
 
 The effect is that B is considered a used layer and will be loaded as if it
 was added to =dotspacemacs-configuration-layers= variables.
 
 ** packages.el
-It contains this list of packages of the layer and the actual configuration for
+It contains the list of packages of the layer and the actual configuration for
 the packages included in the layer.
 
 This file is loaded after =layers.el=.


### PR DESCRIPTION
I think users interested in writing their first configuration layer should be incentivized to use the `configuration-layer/declare-layer-dependencies` function instead of manually declaring a single layer.

As I was going through the `LAYERS.org` documentation I noticed most existing layers made use of `configuration-layer/declare-layer-dependencies` in their `layers.el` file, instead of the recommended `configuration-layer/declare-layer`. 
This seems to be consistent with the [configuration-layer/declare-dependencies docstring](https://github.com/syl20bnr/spacemacs/blob/287acfa74dcfcfe9c20f69fbf2d51ae918455b7a/core/core-configuration-layer.el#L1521) as well as
[this comment](https://github.com/syl20bnr/spacemacs/blob/287acfa74dcfcfe9c20f69fbf2d51ae918455b7a/layers/%2Bdistributions/spacemacs-base/layers.el#L27) which suggests declaring layers right away should only be done in special cases by distribution layers.


