### PR TITLE
New function "spacemacs/python-shell-send-block" to send block

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -422,6 +422,33 @@ Bind formatter to '==' for LSP and '='for all other backends."
 
 
 ;; REPL
+(defun spacemacs/python-shell-send-block (&optional arg)
+  "Send the block under cursor to shell. If optional argument ARG is non-nil
+(interactively, the prefix argument), send the block body with its header."
+  (interactive "P")
+  (if (fboundp 'python-shell-send-block)
+      (let ((python-mode-hook nil))
+        (call-interactively #'python-shell-send-block))
+    (let ((python-mode-hook nil)
+          (beg (save-excursion
+                 (when (python-nav-beginning-of-block)
+                   (if arg
+                       (beginning-of-line)
+                     (python-nav-end-of-statement)
+                     (beginning-of-line 2)))
+                 (point-marker)))
+          (end (save-excursion (python-nav-end-of-block)))
+          (python-indent-guess-indent-offset-verbose nil))
+      (if (and beg end)
+          (python-shell-send-region beg end nil msg t)
+        (user-error "Can't get code block from current position.")))))
+
+(defun spacemacs/python-shell-send-block-switch (&optional arg)
+  "Send block to shell and switch to it in insert mode."
+  (interactive "P")
+  (call-interactively #'spacemacs/python-shell-send-block)
+  (python-shell-switch-to-shell)
+  (evil-insert-state))
 
 (defun spacemacs/python-shell-send-buffer-switch ()
   "Send buffer content to shell and switch to it in insert mode."

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -404,6 +404,8 @@
       "sF" 'spacemacs/python-shell-send-defun-switch
       "sf" 'spacemacs/python-shell-send-defun
       "si" 'spacemacs/python-start-or-switch-repl
+      "sK" 'spacemacs/python-shell-send-block-switch
+      "sk" 'spacemacs/python-shell-send-block
       "sn" 'spacemacs/python-shell-restart
       "sN" 'spacemacs/python-shell-restart-switch
       "sR" 'spacemacs/python-shell-send-region-switch


### PR DESCRIPTION
Hi,

A new function `spacemacs/python-shell-send` to send a block to python interpreter.
```python
if condition:
  print("hello")
  print("world")
```
Function `spacemacs/python-shell-send` can send the block without/with block-header.

For the key binding, choose the key binding `M-m s k` for the `b`/`B` already ocupied. 