### PR TITLE
Make cache directory a child of user-emacs-directory

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -91,8 +91,12 @@
   "Spacemacs tests directory.")
 
 ;; ~/.emacs.d/.cache
+;;
+;; This is based on `user-emacs-directory', not `spacemacs-start-directory',
+;; because Spacemacs may be installed to a shared location and this directory
+;; and its children should be per-user.
 (defconst spacemacs-cache-directory
-  (concat spacemacs-start-directory ".cache/")
+  (concat user-emacs-directory ".cache/")
   "Spacemacs storage area for persistent files.")
 
 ;; ~/.emacs.d/.cache/auto-save


### PR DESCRIPTION
This is a partial revert of 1f9a70b932770376e657ebf34f327ff79025e611.

user-emacs-directory is intended to be per-user, whereas
spacemacs-start-directory might be shared among several users if
Spacemacs is deployed centrally at a site.