### PR TITLE
Deprecate company-elm backend in elm layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -79,6 +79,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   Andriy Kmit)
 - Add support for background transparency aka true transparency. Key bindings are under ~SPC T B~ (thanks to JoshTRN)
 - Binding the ~SPC f d~ for deleting current buffer and file (thanks to Lin Sun)
+- Deprecate =company-elm= backend in =elm= layer (thanks to Qynn Schwaab)
 *** Breaking Changes
 **** Major
 - Support for Emacs 25 or Emacs 26 has been dropped, the minimal Emacs version

--- a/layers/+lang/elm/README.org
+++ b/layers/+lang/elm/README.org
@@ -16,10 +16,9 @@
   - [[#elm-format][elm-format]]
   - [[#elm-test][elm-test]]
 - [[#configuration][Configuration]]
-  - [[#choosing-a-backend][Choosing a backend]]
-    - [[#company-elm][Company-elm]]
-      - [[#elm-oracle][elm-oracle]]
+  - [[#backend][Backend]]
     - [[#lsp][LSP]]
+    - [[#none][None]]
 - [[#basic-usage-tips][Basic usage tips]]
   - [[#compilation][Compilation]]
   - [[#reactor][Reactor]]
@@ -35,7 +34,6 @@
   - [[#elm-test-runner][elm-test-runner]]
   - [[#elm-package][elm-package]]
     - [[#package-list-buffer][package list buffer]]
-  - [[#elm-oracle-1][elm-oracle]]
   - [[#elm-format-1][elm-format]]
   - [[#refactoring][Refactoring]]
 
@@ -126,37 +124,10 @@ To install =elm-test= run below command:
 All layer configurations can be done by setting layer variables in your dotfile.
 No custom user config lines are necessary
 
-** Choosing a backend
-This layer provides two alternative backends to choose from.
-
-*** Company-elm
-This is the default choice if nothing is set and no lsp layer
-is loaded in your dotfile. This mode only provides very
-limited IDE capabilities. Used best if only small programs
-are edited. To set explicitly set the following in your
-dotfile:
-
-#+BEGIN_SRC emacs-lisp
-  (elm :variables elm-backend 'company-elm)
-#+END_SRC
-
-**** elm-oracle
-=elm-oracle= can be used to show type signatures and docs for tokens under the
-cursor and provide support for auto-completion, but it is not part of the
-standard elm-platform.
-
-Both the "company" and "auto-complete" backends are supported, but this layer
-is configured with company.
-
-To install =elm-oracle=, install =node.js= and =npm=, then
-run this command:
-
-#+BEGIN_SRC sh
-  npm install -g elm-oracle
-#+END_SRC
+** Backend
 
 *** LSP
-For proper IDE support this backend should be used. It is
+For proper IDE support the =lsp= backend should be used. It is
 based on an external server which will be started automatically
 by emacs, once an elm file is opened. The key bindings are
 the same for all lsp modes so if you are already familiar with
@@ -181,6 +152,14 @@ NOTE: Key bindings for LSP are defined in the
 LSP layer. Also it is advisable to have a look
 at the autocomplete layer for an optimal
 intellisense config for LSP.
+
+*** None
+If the =lsp= layer is loaded in your dotfile and nothing is set for =elm-backend=, =lsp= will be
+automatically selected. To explicitly disable the =lsp= backend set the following in your dotfile:
+#+BEGIN_SRC emacs-lisp
+  (elm :variables elm-backend nil)
+#+END_SRC
+
 
 * Basic usage tips
 ** Compilation
@@ -303,13 +282,6 @@ using a =dir-locals.el= file.
 | ~u~         | elm-package-unmark  |
 | ~x~         | elm-package-install |
 | ~q~         | quit-window         |
-
-** elm-oracle
-
-| Key binding | Description              |
-|-------------+--------------------------|
-| ~SPC m h h~ | elm-oracle-doc-at-point  |
-| ~SPC m h t~ | elm-oracle-type-at-point |
 
 ** elm-format
 

--- a/layers/+lang/elm/config.el
+++ b/layers/+lang/elm/config.el
@@ -25,7 +25,7 @@
 
 (spacemacs|define-jump-handlers elm-mode)
 
-(defvar elm-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'company-elm)
+(defvar elm-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp nil)
   "The backend to use for IDE features.
-Possible values are `lsp' and `company-elm'.
-If `nil' then 'company-elm` is the default backend unless `lsp' layer is used")
+Possible values are `lsp' or `nil'.
+Default is `nil' unless `lsp' layer is used")

--- a/layers/+lang/elm/funcs.el
+++ b/layers/+lang/elm/funcs.el
@@ -29,16 +29,12 @@
        :backends company-capf        ;; standard backends as well
        :modes elm-mode))
     ('company-elm
-     (spacemacs|add-company-backends
-       :backends elm-company
-       :modes elm-mode))))
+      (message "Warning: `company-elm' backend is no longer supported for `elm' layer, use `lsp' instead."))))
 
 (defun spacemacs//elm-setup-backend ()
   "Conditionally setup elm backend."
   (spacemacs/init-elm-mode)
-  (pcase elm-backend
-    ('lsp (lsp-deferred))
-    ('company-elm (elm-oracle-setup-completion))))
+  (when (eq elm-backend 'lsp) (lsp-deferred)))
 
 
 ;; elm-mode

--- a/layers/+lang/elm/packages.el
+++ b/layers/+lang/elm/packages.el
@@ -53,13 +53,10 @@
     (add-hook 'elm-mode-hook 'spacemacs//elm-setup-backend)
     :config
     ;; Bind non-lsp keys
-    (when (eq elm-backend 'company-elm)
+    (when (not (eq elm-backend 'lsp))
       (spacemacs/set-leader-keys-for-major-mode 'elm-mode
         ;; format
-        "=b" 'elm-format-buffer
-        ;; oracle
-        "hh" 'elm-oracle-doc-at-point
-        "ht" 'elm-oracle-type-at-point)
+        "=b" 'elm-format-buffer)
 
       ;; Bind prefixes
       (dolist (x '(("m=" . "format")


### PR DESCRIPTION
This PR clarifies the `elm-backend` configuration in the `elm` layer.

Support for `company-elm` has been dropped from `elm-mode` in favor of the `elm-language-server` (cf [PR#176](https://github.com/jcollard/elm-mode/pull/176/commits/db9794cfa54d69781decde788d7b3ca3f979c4ea)) 
All  `elm-oracle-*` functions have been removed and setting `elm-backend` to `'company-elm`  currently raises the following error: `File mode specification error: (void-function elm-oracle-setup-completion)`

