### PR TITLE
fix: Symbol’s function definition is void: window-purpose/save-dedicated-windows

### DIFF
--- a/layers/+spacemacs/spacemacs-purpose/config.el
+++ b/layers/+spacemacs/spacemacs-purpose/config.el
@@ -1,0 +1,1 @@
+(defvar window-purpose--dedicated-windows nil)

--- a/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
+++ b/layers/+spacemacs/spacemacs-purpose/local/spacemacs-purpose-popwin/spacemacs-purpose-popwin.el
@@ -194,6 +194,30 @@ Popwin's settings are taken from `popwin:special-display-config'."
 Popwin's settings are taken from `popwin:special-display-config'."
   (purpose-set-extension-configuration :pupo (pupo/popwin-config-to-purpose-config)))
 
+(defun pupo/before-popwin-create (&rest args)
+  "Save current popup windows for later restoration.
+The windows are restored in `pupo/after-popwin-create'.
+Note that the windows themselves aren't saved, but some internal
+variables are updated instead."
+  (setq pupo--saved-buffers (mapcar #'window-buffer pupo--windows))
+  (setq pupo--saved-auto-buffers (mapcar #'window-buffer pupo--auto-windows)))
+
+(defun pupo/after-popwin-create (&rest args)
+  "Restore popup windows.
+The windows were saved in `pupo/before-popwin-create'.
+Note that the windows themselves aren't restored, but some internal
+variables are updated instead."
+  (setq pupo--windows nil)
+  (cl-loop for buffer in pupo--saved-buffers
+           do (setq pupo--windows
+                    (append pupo--windows
+                            (get-buffer-window-list buffer))))
+  (setq pupo--auto-windows nil)
+  (cl-loop for buffer in pupo--saved-auto-buffers
+           do (setq pupo--auto-windows
+                    (append pupo--auto-windows
+                            (get-buffer-window-list buffer)))) )
+
 (define-minor-mode pupo-mode
   "Minor mode for combining `purpose-mode' and `popwin-mode'."
   :global t
@@ -210,30 +234,6 @@ Popwin's settings are taken from `popwin:special-display-config'."
                   purpose-special-action-sequences))
     (remove-hook 'purpose-display-buffer-functions #'pupo/after-display)
     (remove-hook 'purpose-display-buffer-functions #'pupo/auto-delete-windows)))
-
-(define-advice popwin:create-popup-window (:before pupo/before-popwin-create)
-  "Save current popup windows for later restoration.
-The windows are restored in `pupo/after-popwin-create'.
-Note that the windows themselves aren't saved, but some internal
-variables are updated instead."
-  (setq pupo--saved-buffers (mapcar #'window-buffer pupo--windows))
-  (setq pupo--saved-auto-buffers (mapcar #'window-buffer pupo--auto-windows)))
-
-(define-advice popwin:create-popup-window (:after pupo/after-popwin-create)
-  "Restore popup windows.
-The windows were saved in `pupo/before-popwin-create'.
-Note that the windows themselves aren't restored, but some internal
-variables are updated instead."
-  (setq pupo--windows nil)
-  (cl-loop for buffer in pupo--saved-buffers
-        do (setq pupo--windows
-              (append pupo--windows
-                      (get-buffer-window-list buffer))))
-  (setq pupo--auto-windows nil)
-  (cl-loop for buffer in pupo--saved-auto-buffers
-        do (setq pupo--auto-windows
-                 (append pupo--auto-windows
-                         (get-buffer-window-list buffer)))))
 
 (defun pupo/sync-advices ()
   (if pupo-mode

--- a/layers/+spacemacs/spacemacs-purpose/packages.el
+++ b/layers/+spacemacs/spacemacs-purpose/packages.el
@@ -78,19 +78,10 @@
   (spacemacs|use-package-add-hook popwin
     :post-config
     (progn
-      (defvar window-purpose--dedicated-windows nil)
-      (define-advice popwin:create-popup-window
-          (:before window-purpose/save-dedicated-windows)
-        (setq window-purpose--dedicated-windows
-              (cl-loop for window in (window-list)
-                       if (purpose-window-purpose-dedicated-p window)
-                       collect (window-buffer window))))
-      (define-advice popwin:create-popup-window
-          (:after window-purpose/restore-dedicated-windows)
-        (cl-loop for buffer in window-purpose--dedicated-windows
-                 do (cl-loop for window in (get-buffer-window-list buffer)
-                             do (purpose-set-window-purpose-dedicated-p
-                                 window t))))
+
+      (advice-add 'popwin:create-popup-window :before #'spacemacs/window-purpose-save-dedicated-windows)
+      (advice-add 'popwin:create-popup-window :after #'spacemacs/window-purpose-restore-dedicated-windows)
+
       (add-hook 'purpose-mode-hook #'spacemacs/window-purpose-sync-popwin)
       (with-eval-after-load 'window-purpose
         (spacemacs/window-purpose-sync-popwin)


### PR DESCRIPTION
Commit 1ce1b0ea21c2e1e68b0037329941c316b4dfef2e introduced a bug due to incorrect usage of define-advice.

This commit refactors the change by:
- Extracting the advices to named functions spacemacs/window-purpose-{save,restore}-dedicated-windows
- Using advice-add globally instead of a define-advice/advice-add mix