### PR TITLE
[compleseus] Devide search functions into 2 intial input variants

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -58,37 +58,50 @@ non-nil."
      consult--source-project-buffer
      consult--source-project-recent-file)))
 
+(defun spacemacs/initial-search-input (&optional force-input)
+  "Get initial input from region for consult search functions. If region is not
+active and `force-input' is not nil, `thing-at-point' will be returned."
+  (if (region-active-p)
+      (buffer-substring-no-properties
+       (region-beginning) (region-end))
+    (if force-input (thing-at-point 'symbol t) ""))
+  )
 
-(defun spacemacs/compleseus-search (use-initial-input initial-directory)
-  (let* ((initial-input (if use-initial-input
-                            (rxt-quote-pcre
-                             (if (region-active-p)
-                                 (buffer-substring-no-properties
-                                  (region-beginning) (region-end))
-                               (or (thing-at-point 'symbol t) "")))
-                          ""))
+(defun spacemacs/compleseus-search (force-initial-input initial-directory)
+  (let* ((initial-input (rxt-quote-pcre
+                         (spacemacs/initial-search-input force-initial-input)))
          (default-directory
-           (or initial-directory (read-directory-name "Start from directory: "))))
+          (or initial-directory (read-directory-name "Start from directory: "))))
     (consult-ripgrep default-directory initial-input)))
 
 (defun spacemacs/consult-line ()
   (interactive)
   (consult-line
-   (if (region-active-p)
-       (buffer-substring-no-properties
-        (region-beginning) (region-end))
-     (thing-at-point 'symbol t))))
+   (spacemacs/initial-search-input)))
+
+(defun spacemacs/consult-line-symbol ()
+  (interactive)
+  (consult-line
+   (spacemacs/initial-search-input t)))
 
 (defun spacemacs/consult-line-multi ()
   (interactive)
   (consult-line-multi
    nil
-   (if (region-active-p)
-       (buffer-substring-no-properties
-        (region-beginning) (region-end))
-     (thing-at-point 'symbol t))))
+   (spacemacs/initial-search-input)))
+
+(defun spacemacs/consult-line-multi-symbol ()
+  (interactive)
+  (consult-line-multi
+   nil
+   (spacemacs/initial-search-input t)))
 
 (defun spacemacs/compleseus-search-auto ()
+  "Choose folder to search."
+  (interactive)
+  (spacemacs/compleseus-search nil nil))
+
+(defun spacemacs/compleseus-search-auto-symbol ()
   "Choose folder to search."
   (interactive)
   (spacemacs/compleseus-search t nil))
@@ -96,9 +109,19 @@ non-nil."
 (defun spacemacs/compleseus-search-dir ()
   "Search current folder."
   (interactive)
+  (spacemacs/compleseus-search nil default-directory))
+
+(defun spacemacs/compleseus-search-dir-symbol ()
+  "Search current folder."
+  (interactive)
   (spacemacs/compleseus-search t default-directory))
 
 (defun spacemacs/compleseus-search-projectile ()
+  "Search in current project."
+  (interactive)
+  (spacemacs/compleseus-search nil (projectile-project-root)))
+
+(defun spacemacs/compleseus-search-projectile-symbol ()
   "Search in current project."
   (interactive)
   (spacemacs/compleseus-search t (projectile-project-root)))
@@ -107,11 +130,6 @@ non-nil."
   "Search."
   (interactive)
   (spacemacs/compleseus-search-projectile))
-
-(defun spacemacs/compleseus-search-projectile-auto ()
-  "Search in current project."
-  (interactive)
-  (spacemacs/compleseus-search nil (projectile-project-root)))
 
 (defun spacemacs/compleseus-search-from (input)
   "Embark action to start ripgrep search from candidate's directory."

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -141,7 +141,7 @@
       dotspacemacs-emacs-command-key 'execute-extended-command
       "#" #'consult-register
       "*" #'spacemacs/compleseus-search-default
-      "/" #'spacemacs/compleseus-search-projectile-auto
+      "/" #'spacemacs/compleseus-search-projectile
       "bb" #'spacemacs/compleseus-switch-to-buffer
       "bB" #'consult-buffer
       "fb" #'consult-bookmark
@@ -151,16 +151,19 @@
       "hm" #'consult-man
       "jm" #'consult-mark
       "jM" #'consult-global-mark
-      "sb" #'consult-line-multi
-      "sB" #'spacemacs/consult-line-multi
-      "ss" #'consult-line
-      "sS" #'spacemacs/consult-line
+      "sb" #'spacemacs/consult-line-multi
+      "sB" #'spacemacs/consult-line-multi-symbol
+      "ss" #'spacemacs/consult-line
+      "sS" #'spacemacs/consult-line-symbol
       "sk" #'consult-keep-lines
       "rc" #'consult-complex-command
       "su" #'consult-focus-lines
       "sf" #'spacemacs/compleseus-search-auto
+      "sF" #'spacemacs/compleseus-search-auto-symbol
       "sd" #'spacemacs/compleseus-search-dir
+      "sD" #'spacemacs/compleseus-search-dir-symbol
       "sp" #'spacemacs/compleseus-search-projectile
+      "sP" #'spacemacs/compleseus-search-projectile-symbol
       "ry" #'consult-yank-from-kill-ring
       "Ts" #'consult-theme)
 


### PR DESCRIPTION
Each consult search function now comes with two variants regarding initial input. They all initialize the input with region content if a region is active, but differ on whether an empty string or thing-at-point if a region is not active.

This change tries to mimic the search behaviors configured in helm layers. Thus the default empty variants are bound to lowercase keys, and the default thing-at-point variants are bound to uppercase keys.
