### PR TITLE
Correctly set `evil-undo-system`

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -82,9 +82,8 @@
   (require 'evil)
   (evil-mode 1)
 
-  (when (and (fboundp 'evil-set-undo-system)
-             (configuration-layer/package-used-p 'undo-tree))
-    (evil-set-undo-system 'undo-tree))
+  (when (configuration-layer/package-used-p 'undo-tree)
+    (customize-set-variable 'evil-undo-system 'undo-tree))
 
   ;; Use evil as a default jump handler
   (add-to-list 'spacemacs-default-jump-handlers 'evil-goto-definition)


### PR DESCRIPTION
When using undo-tree, the variable `evil-undo-system` should be set to `undo-tree`. The call to `evil-set-undo-system` does not set the variable itself; hence it used to remain the default, `nil`. Customizing the variable does both: It uses the custom set function that also calls `evil-set-undo-system`.

References: https://github.com/emacs-evil/evil/issues/1074
https://github.com/emacs-evil/evil/commit/8a3ac256804a4786bd8adbf6a3f6925162e2722f