### PR TITLE
* layers/+misc/dtrt-indent/packages.el: Avoid impact user setting

### DIFF
--- a/layers/+misc/dtrt-indent/packages.el
+++ b/layers/+misc/dtrt-indent/packages.el
@@ -27,7 +27,6 @@
   (use-package dtrt-indent
     :hook (prog-mode .
               (lambda ()
-                (modify-syntax-entry ?_ "w")
                 (dtrt-indent-mode)
                 (dtrt-indent-adapt)))
     :config


### PR DESCRIPTION
Hi, 
According the Spacemacs FAQ.org, the line `(modify-syntax-entry ?_ "w")` should be a customizable behavior.
So remove the line from `dtrt` layer.

https://github.com/syl20bnr/spacemacs/blob/99874da102f9555ce24e048e6b9539a0963c30b5/doc/FAQ.org?plain=1#L391-L412