### PR TITLE
[compleseus] Fix dynamic changing of editing styles

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -273,12 +273,6 @@ Note: this function relies on embark internals and might break upon embark updat
          '(spacemacs/compleseus-grep-change-to-wgrep-mode)))
     (embark-export)))
 
-(defun spacemacs//set-initial-grep-state ()
-  "Set the initial evil state for the grep buffers."
-  (if (eq dotspacemacs-editing-style 'emacs)
-      (evil-set-initial-state 'grep-mode 'emacs)
-    (evil-set-initial-state 'grep-mode 'motion)))
-
 (defun spacemacs/wgrep-finish-edit ()
   "Set back the default evil state when finishing editing."
   (interactive)

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -432,7 +432,6 @@
     "w" 'spacemacs/compleseus-grep-change-to-wgrep-mode))
 
 (defun compleseus/init-wgrep ()
-  (add-hook 'spacemacs-editing-style-hook #'spacemacs//set-initial-grep-state)
   (evil-define-key 'normal wgrep-mode-map ",," #'spacemacs/wgrep-finish-edit)
   (evil-define-key 'normal wgrep-mode-map ",c" #'spacemacs/wgrep-finish-edit)
   (evil-define-key 'normal wgrep-mode-map ",a" #'spacemacs/wgrep-abort-changes)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -612,7 +612,7 @@ Press \\[which-key-toggle-persistent] to hide."
                      (hybrid-mode -1)
                      (spacemacs/declare-prefix "tEh" "hybrid (hybrid-mode)"))
                    (holy-mode)
-                   (spacemacs/declare-prefix "tEe" "vim (evil-mode"))
+                   (spacemacs/declare-prefix "tEe" "vim (evil-mode)"))
         :off (progn (holy-mode -1)
                     (spacemacs/declare-prefix "tEe" "emacs (holy-mode)"))
         :off-message "evil-mode enabled."


### PR DESCRIPTION
The function `spacemacs//set-initial-grep-state` is only called by the `spacemacs-editing-style-hook` but always throws an error because the hook is ran with an argument (the editing style switched to), but the function does not expect any arguments.

At first it seems like one should just add the missing argument, however, it is in fact not necessary to execute this function at all: `grep-mode` is derived from `compilation-mode` which is an element of `evil-motion-state-modes`. Moreover, when using (or temporarily toggling) the emacs editing style, `evil-motion-state` is overridden with `evil-emacs-state` by the advice `holy-motion-to-emacs-state`.