### PR TITLE
Add numerical prefix functionality to window delete commands

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2341,6 +2341,7 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w c .~            | center buffer and enable centering transient state                          |
 | ~SPC w d~              | delete a window                                                             |
 | ~SPC u SPC w d~        | delete a window and its current buffer (does not delete the file)           |
+| ~NUM SPC w d~          | delete window number NUM                                                    |
 | ~SPC w D~              | delete another window using [[https://github.com/abo-abo/ace-window][ace-window]]                                      |
 | ~SPC u SPC w D~        | delete another window and its current buffer using [[https://github.com/abo-abo/ace-window][ace-window]]               |
 | ~SPC w t~              | toggle window dedication (dedicated window cannot be reused by a mode)      |
@@ -2370,6 +2371,7 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w w~              | cycle and focus between windows                                             |
 | ~SPC w W~              | select window using [[https://github.com/abo-abo/ace-window][ace-window]]                                              |
 | ~SPC w x~              | delete a window and its current buffer (does not delete the file)           |
+| ~NUM SPC w x~          | delete window number NUM and its current buffer (does not delete the file)  |
 | ~SPC w [~              | shrink window horizontally (enter transient state)                          |
 | ~SPC w ]~              | enlarge window horizontally (enter transient state)                         |
 | ~SPC w {~              | shrink window vertically (enter transient state)                            |

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -690,7 +690,7 @@ respond to this toggle."
   "wv"  'split-window-right
   "wV"  'split-window-right-and-focus
   "ww"  'other-window
-  "wx"  'kill-buffer-and-window
+  "wx"  'spacemacs/kill-buffer-and-window
   "w/"  'split-window-right
   "w="  'balance-windows-area
   "w+"  'spacemacs/window-layout-toggle


### PR DESCRIPTION
Some changes to #16247. In particular this commit restores the previous <kbd>SPC u</kbd>-prefix functionality and handles a few more edge cases.