### PR TITLE
Minor: Ignore undo tree files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ transient/
 url/*
 var/
 workspace
+undo/*
 
 # Private directory
 /doc/COMMUNITY.org


### PR DESCRIPTION
One liner minor change, ignore the `undo` directory for undo-tree under `.emacs` directory.