### PR TITLE
[compleseus] Actually use helm-make feature from fork

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -66,7 +66,7 @@
     :init
     ;; TODO: Ideally, this should use vertico instead, but helm-make can't do
     ;; that yet: blocked on https://github.com/abo-abo/helm-make/pull/62
-    (setq helm-make-completion-method 'ido)
+    (setq helm-make-completion-method 'emacs)
     (spacemacs/set-leader-keys
       "cc" 'helm-make-projectile
       "cm" 'helm-make)))


### PR DESCRIPTION
This is a follow-up to #16433.  Silly me, I switched my branch to use
the helm-make fork and then forgot to actually use the features from
the fork.  After this PR, compleseus layer helm-make uses vertico as
intended.