### PR TITLE
Add documentation for navigating to next source in helm-find-file

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3990,6 +3990,8 @@ files (thanks to Daniel Nicolai)
   - DOCUMENTATION.org:
     - Fixed the example for how to change the separator style
       (thanks to Trey Merkley)
+    - Added documentation for navigating to next source in helm-find-file
+      (thanks to Lucas Leblow)
   - README.md:
     - Fixed macOS documentation to install fonts (thanks to Sergio Morales)
     - Updated Windows section, suggest official Emacs (thanks to ghost-420)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2627,6 +2627,7 @@ In =vim= style and =hybrid= style with the variable
 | ~C-j~       | go to previous candidate          |
 | ~C-k~       | go to next candidate              |
 | ~C-l~       | enter current directory           |
+| ~C-o~       | go to next source                 |
 
 **** Popup buffers
 =popwin= is used to manage buffers such as ~*Help*~, ~*Completions*~,


### PR DESCRIPTION
When typing `SPC f f` or `c f` in Neotree, which (on my system) both appear to open `helm-find-file`, I noticed that if I type a filename similar to an existing filename then I need to change sources to be able to create a new file, otherwise it just opens an existing file with a similar name. I've attached a screenshot as an example.
![Screenshot from 2024-06-04 16-22-32](https://github.com/syl20bnr/spacemacs/assets/4041864/ab9bcce6-3e24-4c6b-bfd6-a8d7ffd96d31)

I noticed that changing sources wasn't documented for `helm-find-file` buffers and it took me a while to find the Helm keybindings via the Helm documentation. It is documented for regular Helm buffers, just not `helm-find-file`. So I added that change to the docs.

