### PR TITLE
[compleseus] Fix initial search inputs

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -129,7 +129,7 @@ active and `force-input' is not nil, `thing-at-point' will be returned."
 (defun spacemacs/compleseus-search-default ()
   "Search."
   (interactive)
-  (spacemacs/compleseus-search-projectile))
+  (spacemacs/compleseus-search-projectile-symbol))
 
 (defun spacemacs/compleseus-search-from (input)
   "Embark action to start ripgrep search from candidate's directory."

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -52,9 +52,9 @@
            spacemacs--symbol-highlight-transient-state-doc
            "  Search: [_s_] consult-line  [_f_] files  [_/_] project"))
     (spacemacs/transient-state-register-add-bindings 'symbol-highlight
-      '(("s" spacemacs/consult-line :exit t)
-        ("f" spacemacs/compleseus-search-auto :exit t)
-        ("/" spacemacs/compleseus-search-projectile :exit t)))))
+      '(("s" spacemacs/consult-line-symbol :exit t)
+        ("f" spacemacs/compleseus-search-auto-symbol :exit t)
+        ("/" spacemacs/compleseus-search-projectile-symbol :exit t)))))
 
 (defun compleseus/post-init-imenu ()
   (spacemacs/set-leader-keys "ji" 'spacemacs/consult-jump-in-buffer)


### PR DESCRIPTION
Some search functions got renamed in df7367cb167c91ee8649cbca7318595db7daa6e0. For the transient state and the <kbd>SPC *</kbd> binding
`spacemacs/compleseus-search-default`, we would still like to have initial inputs.