### PR TITLE
[compleseus] Prefix arguments for `consult-line-multi`-wrappers

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -84,16 +84,16 @@ active and `force-input' is not nil, `thing-at-point' will be returned."
   (consult-line
    (spacemacs/initial-search-input t)))
 
-(defun spacemacs/consult-line-multi ()
-  (interactive)
+(defun spacemacs/consult-line-multi (&optional query)
+  (interactive "P")
   (consult-line-multi
-   nil
+   query
    (spacemacs/initial-search-input)))
 
-(defun spacemacs/consult-line-multi-symbol ()
-  (interactive)
+(defun spacemacs/consult-line-multi-symbol (&optional query)
+  (interactive "P")
   (consult-line-multi
-   nil
+   query
    (spacemacs/initial-search-input t)))
 
 (defun spacemacs/compleseus-search-auto ()


### PR DESCRIPTION
`consult-line-multi` supports giving a prefix argument to lift its restriction to project buffers. This commit adds this functionality to our wrappers `spacemacs/consult-line-multi` and `spacemacs/consult-line-multi-symbol`.