### PR TITLE
[compleseus] Add Embark action searching in any subset of buffers

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -96,6 +96,13 @@ active and `force-input' is not nil, `thing-at-point' will be returned."
    nil
    (spacemacs/initial-search-input t)))
 
+(defun spacemacs/embark-consult-line-multi (buffer-names)
+  "Embark action to search in any subset of buffers using `consult-line-multi'.
+If there is an active region, it is used as the initial input."
+  (consult-line-multi
+   (list :predicate (lambda (buf) (member (buffer-name buf) buffer-names)))
+   (spacemacs/initial-search-input)))
+
 (defun spacemacs/compleseus-search-auto ()
   "Choose folder to search."
   (interactive)

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -295,6 +295,8 @@
     (which-key-add-keymap-based-replacements minibuffer-local-map "C-z" "Embark actions...")
     :config
     (define-key embark-file-map "s" 'spacemacs/compleseus-search-from)
+    (define-key embark-buffer-map "s" #'spacemacs/embark-consult-line-multi)
+    (add-to-list 'embark-multitarget-actions #'spacemacs/embark-consult-line-multi)
     ;; which key integration setup
     ;; https://github.com/oantolin/embark/wiki/Additional-Configuration#use-which-key-like-a-key-menu-prompt
     (setq embark-indicators


### PR DESCRIPTION
While `consult-ripgrep` can already be used as an Embark action to search in sets of files or file-backed buffers, this uses `consult-line-multi` to make it convenient to search non-file-backed buffers too.