### PR TITLE
Fix helm-spacemacs-help-faq

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1511,6 +1511,8 @@ Other:
   - Set =evil-undo-system= to =undo-tree= (thanks to duianto)
   - Checked that =evil-undo-system= exists before it's called (thanks to khjcph)
   - Fixed ~SPC w TAB~ golden-ratio resizing.
+  - Fixed ~SPC h f~ =helm-spacemacs-help-faq= again by fixing
+    helm-spacemacs-help//get-faq-headings-list (thanks to greenrecyclebin)
 *** Layer changes and fixes
 **** Agda
 - Fixes

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-faq.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-faq.el
@@ -62,7 +62,7 @@
 (defun helm-spacemacs-help//get-faq-headings-list (sources)
   "Given the helm-org sources from FAQ.org.
 Return a list of all it's headings."
-    (aref (aref (cdadar sources) 2) 0))
+    (aref (aref (cdadar sources) 2) 5))
 
 (defun helm-spacemacs-help//faq-candidates ()
   "Join the section headings to each of their questions.


### PR DESCRIPTION
In https://github.com/syl20bnr/spacemacs/pull/13136, helm-spacemacs-help-faq
supporting functions were rewritten because helm-org-get-candidates was removed
upstream (https://github.com/emacs-helm/helm-org/pull/10).

One of the supporting functions, helm-spacemacs-help//get-faq-headings-list,
doesn't work. As a result, helm-spacemacs-help-faq (M-m h f) fails with "if:
Wrong type argument: stringp, helm".

It's unclear if this bug has existed since the Spacemacs PR because
helm-org-build-sources has changed since the helm-org
PR (https://github.com/emacs-helm/helm-org/commits/master/helm-org.el).