### PR TITLE
[helm] helm find-files allow non-existing file

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -194,6 +194,8 @@
 
     ;; allow to leave helm result groups with evil bindings
     (setq helm-move-to-line-cycle-in-source nil)
+    ;; allow find file on non-exists file at point
+    (setq helm-ff-allow-non-existing-file-at-point t)
 
     ;; use helm to switch last(/previous) visited buffers with C(-S)-tab
     (define-key helm-map (kbd "<C-tab>") 'helm-follow-action-forward)


### PR DESCRIPTION
Hi,
It will failed for `SPC f F` on a file name which dose NOT exists when `helm` layer enabled.
According https://github.com/emacs-helm/helm/issues/2154, we can set the variable `helm-ff-allow-non-existing-file-at-point` to support finding file at point for non-exiting file.
Reproduce steps: Enable the helm layer, and press `SPC f F` on a string like "/tmp/test.new" for a non-existing file, with the variable `helm-ff-allow-non-existing-file-at-point` be `t` or `nil`.

