### PR TITLE
[completion] Tweak `*-spacemacs-help//layer-action-open-file`

### DIFF
--- a/layers/+completion/compleseus/local/compleseus-spacemacs-help/compleseus-spacemacs-help.el
+++ b/layers/+completion/compleseus/local/compleseus-spacemacs-help/compleseus-spacemacs-help.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 ;; This package adds a convenient way to discover Spacemacs configuration
-;; layers thanks to ivy.
+;; layers.
 
 ;;; Code:
 
@@ -126,16 +126,21 @@
   (configuration-layer/get-layer-path (intern candidate)))
 
 (defun compleseus-spacemacs-help//layer-action-open-file (file candidate &optional edit)
-  "Open FILE of the passed CANDIDATE.  If EDIT is false, open in view mode."
-  (let ((path (configuration-layer/get-layer-path (intern candidate))))
-    (if (equal (file-name-extension file) "org")
-        (if edit
-            (find-file (concat path file))
-          (spacemacs/view-org-file (concat path file) "^" 'all))
-      (let ((filepath (concat path file)))
-        (if (file-exists-p filepath)
-            (find-file filepath)
-          (message "%s does not have %s" candidate file))))))
+  "Open FILE of the passed CANDIDATE.
+If the file does not exist and EDIT is true, create it; otherwise fall back
+to opening dired at the layer directory.
+If EDIT is false, open org files in view mode."
+  (let* ((path (configuration-layer/get-layer-path (intern candidate)))
+         (filepath (concat path file)))
+    (cond ((and (equal (file-name-extension file) "org")
+                (not edit)
+                (file-exists-p filepath))
+           (spacemacs/view-org-file filepath "^" 'all))
+          ((or edit (file-exists-p filepath))
+           (find-file filepath))
+          (t
+           (message "%s does not have %s" candidate file)
+           (compleseus-spacemacs-help//layer-action-open-dired candidate)))))
 
 (defun compleseus-spacemacs-help//layer-action-open-readme (candidate)
   "Open the `README.org' file of the passed CANDIDATE for reading."

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -127,16 +127,21 @@
   (configuration-layer/get-layer-path (intern candidate)))
 
 (defun ivy-spacemacs-help//layer-action-open-file (file candidate &optional edit)
-  "Open FILE of the passed CANDIDATE.  If EDIT is false, open in view mode."
-  (let ((path (configuration-layer/get-layer-path (intern candidate))))
-    (if (equal (file-name-extension file) "org")
-        (if edit
-            (find-file (concat path file))
-          (spacemacs/view-org-file (concat path file) "^" 'all))
-      (let ((filepath (concat path file)))
-        (if (file-exists-p filepath)
-            (find-file filepath)
-          (message "%s does not have %s" candidate file))))))
+  "Open FILE of the passed CANDIDATE.
+If the file does not exist and EDIT is true, create it; otherwise fall back
+to opening dired at the layer directory.
+If EDIT is false, open org files in view mode."
+  (let* ((path (configuration-layer/get-layer-path (intern candidate)))
+         (filepath (concat path file)))
+    (cond ((and (equal (file-name-extension file) "org")
+                (not edit)
+                (file-exists-p filepath))
+           (spacemacs/view-org-file filepath "^" 'all))
+          ((or edit (file-exists-p filepath))
+           (find-file filepath))
+          (t
+           (message "%s does not have %s" candidate file)
+           (ivy-spacemacs-help//layer-action-open-dired candidate)))))
 
 (defun ivy-spacemacs-help//layer-action-open-readme (candidate)
   "Open the `README.org' file of the passed CANDIDATE for reading."


### PR DESCRIPTION
The default layer action accessed through pressing <kbd>RET</kbd> from <kbd>SPC h l</kbd> currently insists on creating a README.org file if none exists for the layer which might be the case for private layers. Also, if one uses one of the actions to directly open one of the layer files, for example keybindings.el, and the file does not exist, only a message is displayed.

This commit changes the corresponding functions for Compleseus, Ivy and Helm to fall back to opening Dired at the layer directory if the file does not exist. When requesting to edit the README, it is still created if necessary. Note that the functions are exactly the same for Ivy and Compleseus, and the one for Helm only differs by additionally handling a prefix argument.

Here is a before/after comparison of the behaviour given the conditions (ignoring the special case of giving a prefix argument in Helm):

| is org file | edit | file exists | before                      | after                   |
|-------------|------|-------------|-----------------------------|-------------------------|
| nil         | nil  | nil         | **message**                 | **message+dired**      |
| nil         | nil  | t           | find-file                   | find-file               |
| nil         | t    | nil         | **message**                 | **message+dired**       |
| nil         | t    | t           | find-file                   | find-file               |
| t           | nil  | nil         | **spacemacs/view-org-file** | **message+dired**       |
| t           | nil  | t           | spacemacs/view-org-file     | spacemacs/view-org-file |
| t           | t    | nil         | find-file                   | find-file               |
| t           | t    | t           | find-file                   | find-file               |
