### PR TITLE
[defaults] Add leader key binding for `other-window-prefix`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2375,6 +2375,16 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w {~              | shrink window vertically (enter transient state)                            |
 | ~SPC w }~              | enlarge window vertically (enter transient state)                           |
 
+You can prefix many commands that display a buffer with the handy
+=other-window-prefix= to use or create another window instead of reusing the
+current one:
+
+| Key binding | Description                                              |
+|-------------+----------------------------------------------------------|
+| ~SPC O~     | display the buffer of the next command in another window |
+
+Try for example ~SPC O g d~ to jump to definition in another window.
+
 Split the current window into multiple ones, deleting all others using the
 following commands:
 

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -649,6 +649,7 @@ respond to this toggle."
     (golden-ratio)))
 
 (spacemacs/set-leader-keys
+  "O"   'other-window-prefix
   "w TAB"  'spacemacs/alternate-window
   "w1"  'spacemacs/window-split-single-column
   "w2"  'spacemacs/window-split-double-columns


### PR DESCRIPTION
This is handy enough to deserve a more prominent binding than the default <kbd>C-x 4 4</kbd>. 

I'm not sure whether adding the top level leader key binding <kbd>SPC O</kbd> like that is controversial, but this command is a lot more convenient on a short binding, because it is always composed with another command. I use it a lot, for example as <kbd>SPC O g d</kbd> to jump to definition in another window, or <kbd>SPC O RET</kbd> to open a link in another window.

I have checked that <kbd>SPC O</kbd> is not used yet by any layer, and only the lowercase <kbd>SPC o</kbd> is reserved for user bindings.