### PR TITLE
A couple small improvements to spacemacs/switch-to-compilation-buffer

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1785,7 +1785,7 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
   (interactive)
   (if compilation-last-buffer
       (pop-to-buffer compilation-last-buffer)
-    (user-error "There is no compilation buffer?")))
+    (user-error "There is no compilation buffer")))
 
 
 ;; Line number

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1783,7 +1783,7 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
 (defun spacemacs/switch-to-compilation-buffer ()
   "Go to last compilation buffer."
   (interactive)
-  (if compilation-last-buffer
+  (if (buffer-live-p compilation-last-buffer)
       (pop-to-buffer compilation-last-buffer)
     (user-error "There is no compilation buffer")))
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1775,7 +1775,7 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
 (defun spacemacs/show-hide-compilation-window ()
   "Show/Hide the window containing the compilation buffer."
   (interactive)
-  (when-let ((buffer compilation-last-buffer))
+  (when-let ((buffer next-error-last-buffer))
     (if (get-buffer-window buffer 'visible)
         (delete-windows-on buffer)
       (spacemacs/switch-to-compilation-buffer))))
@@ -1783,8 +1783,8 @@ if prefix argument ARG is given, switch to it in an other, possibly new window."
 (defun spacemacs/switch-to-compilation-buffer ()
   "Go to last compilation buffer."
   (interactive)
-  (if (buffer-live-p compilation-last-buffer)
-      (pop-to-buffer compilation-last-buffer)
+  (if (buffer-live-p next-error-last-buffer)
+      (pop-to-buffer next-error-last-buffer)
     (user-error "There is no compilation buffer")))
 
 


### PR DESCRIPTION
Mainly, prevent a confusing error that can occur when invoking this
command if the user has killed the last compilation buffer:

    buffer-match-p: Wrong type argument: stringp, nil