### PR TITLE
[tree-sitter][ts-fold] fix global mode activation

### DIFF
--- a/layers/+tools/tree-sitter/packages.el
+++ b/layers/+tools/tree-sitter/packages.el
@@ -56,5 +56,5 @@
       (if tree-sitter-fold-indicators-enable
           (progn
             (setq ts-fold-indicators-priority 0)
-            (global-ts-fold-indicators-mode))
+            (add-hook 'tree-sitter-after-on-hook #'ts-fold-indicators-mode))
         (global-ts-fold-mode)))))


### PR DESCRIPTION
New version of `ts-fold` breaks in modes where `tree-sitter` isn't supported. Based on
[this](https://github.com/emacs-tree-sitter/ts-fold/issues/121#issuecomment-2134224132) issue and comment, update global ts-fold activation.