### PR TITLE
[systemd] Update journalctl-mode keybindings based on new release

### DIFF
--- a/layers/+tools/systemd/README.org
+++ b/layers/+tools/systemd/README.org
@@ -36,9 +36,6 @@ To use this contribution add it to your =~/.spacemacs=
 
 ** Journalctl-mode
 
-| Key binding   | Description                                                          |
-|---------------+----------------------------------------------------------------------|
-| ~SPC a t j b~ | Select and show boot-log with =journalctl-mode=.                     |
-| ~SPC a t j j~ | Run =journalctl-mode= with custom option                             |
-| ~SPC a t j s~ | Select and show journal for UNIT in =journalctl-mode=.               |
-| ~SPC a t j u~ | Select and show journal for the user-unit UNIT in =journalctl-mode=. |
+| Key binding | Description                     |
+|-------------+---------------------------------|
+| ~SPC a t j~ | Run =journalctl= transient menu |

--- a/layers/+tools/systemd/packages.el
+++ b/layers/+tools/systemd/packages.el
@@ -43,12 +43,8 @@
 (defun systemd/init-journalctl-mode ()
   (use-package journalctl-mode
     :ensure t
-    :init 
-    (spacemacs/declare-prefix "atj"  "journalctl")
+    :init
     (spacemacs/set-leader-keys
-      "atjj" 'journalctl
-      "atjs" 'journalctl-unit
-      "atju" 'journalctl-user-unit
-      "atjb" 'journalctl-boot)))
+      "atj" 'journalctl)))
 
 ;;; packages.el ends here


### PR DESCRIPTION
`journalctl-mode` package [transitioned](https://github.com/SebastianMeisel/journalctl-mode/releases/tag/v1.1) to using `transient` menu similar to `magit` transient menus. The old commands/keybindings no longer work. The entrypoint is now `journalctl` transient menu.
