### PR TITLE
Remove spacemacs/counsel-gtags-define-keys-for-mode warnings

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -34,6 +34,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 * Release 0.300.x
 ** 0.300.0
 *** Hot new feature
+- Remove =spacemacs/counsel-gtags-define-keys-for-mode= warnings
 - Add configuration layer for gleam-lang (thanks to Qynn Schwaab)
 - Highlight ruby debugger lines appropriately
 - Add support for Android emacs.

--- a/layers/+lang/asm/packages.el
+++ b/layers/+lang/asm/packages.el
@@ -75,5 +75,4 @@
 (defun asm/post-init-ggtags ()
   (add-hook 'asm-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun asm/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'asm-mode))
+(defun asm/post-init-counsel-gtags nil)

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -127,9 +127,7 @@
     :defer t
     :commands company-ycmd))
 
-(defun c-c++/post-init-counsel-gtags ()
-  (dolist (mode c-c++-modes)
-    (spacemacs/counsel-gtags-define-keys-for-mode mode)))
+(defun c-c++/post-init-counsel-gtags nil)
 
 (defun c-c++/init-cpp-auto-include ()
   (use-package cpp-auto-include

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -476,8 +476,7 @@
 (defun clojure/post-init-ggtags ()
   (add-hook 'clojure-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun clojure/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'clojure-mode))
+(defun clojure/post-init-counsel-gtags nil)
 
 (defun clojure/init-clojure-snippets ()
   (use-package clojure-snippets

--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -65,8 +65,7 @@
 (defun common-lisp/post-init-ggtags ()
   (add-hook 'common-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun common-lisp/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'common-lisp-mode))
+(defun common-lisp/post-init-counsel-gtags nil)
 
 (defun common-lisp/post-init-rainbow-identifiers ()
   (add-hook 'lisp-mode-hook #'colors//rainbow-identifiers-ignore-keywords))

--- a/layers/+lang/csharp/packages.el
+++ b/layers/+lang/csharp/packages.el
@@ -61,5 +61,4 @@
 (defun csharp/post-init-ggtags ()
   (add-hook 'csharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun csharp/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'csharp-mode))
+(defun csharp/post-init-counsel-gtags nil)

--- a/layers/+lang/d/packages.el
+++ b/layers/+lang/d/packages.el
@@ -64,5 +64,4 @@
 (defun d/post-init-ggtags ()
   (add-hook 'd-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun d/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'd-mode))
+(defun d/post-init-counsel-gtags nil)

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -157,8 +157,7 @@
   ;; backend specific
   (add-hook 'elixir-mode-local-vars-hook #'spacemacs//elixir-setup-company))
 
-(defun elixir/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'elixir-mode))
+(defun elixir/post-init-counsel-gtags nil)
 
 (defun elixir/pre-init-dap-mode ()
   (when (eq elixir-backend 'lsp) (add-to-list 'spacemacs--dap-supported-modes 'elixir-mode))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -319,8 +319,7 @@
   (use-package flycheck-elsa
     :hook (emacs-lisp-mode . flycheck-elsa-setup)))
 
-(defun emacs-lisp/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'emacs-lisp-mode))
+(defun emacs-lisp/post-init-counsel-gtags nil)
 
 (defun emacs-lisp/post-init-ggtags ()
   (add-hook 'emacs-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/erlang/packages.el
+++ b/layers/+lang/erlang/packages.el
@@ -65,5 +65,4 @@
 (defun erlang/post-init-ggtags ()
   (add-hook 'erlang-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun erlang/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'erlang-mode))
+(defun erlang/post-init-counsel-gtags nil)

--- a/layers/+lang/fsharp/packages.el
+++ b/layers/+lang/fsharp/packages.el
@@ -74,5 +74,4 @@
 (defun fsharp/post-init-ggtags ()
   (add-hook 'fsharp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun fsharp/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'fsharp-mode))
+(defun fsharp/post-init-counsel-gtags nil)

--- a/layers/+lang/go/packages.el
+++ b/layers/+lang/go/packages.el
@@ -60,8 +60,7 @@
     (add-to-list 'spacemacs--dap-supported-modes 'go-mode))
   (add-hook 'go-mode-local-vars-hook #'spacemacs//go-setup-dap))
 
-(defun go/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'go-mode))
+(defun go/post-init-counsel-gtags nil)
 
 (defun go/post-init-eldoc ()
   (add-hook 'go-mode-local-vars-hook #'spacemacs//go-setup-eldoc))

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -309,8 +309,7 @@
 
   (with-eval-after-load 'yasnippet (haskell-snippets-initialize)))
 
-(defun haskell/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'haskell-mode))
+(defun haskell/post-init-counsel-gtags nil)
 
 ;; doesn't support haskell-literate-mode :(
 (defun haskell/init-hindent ()

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -54,8 +54,7 @@
   (with-eval-after-load 'smartparens
     (sp-local-pair 'java-mode "/** " " */" :trigger "/**")))
 
-(defun java/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'java-mode))
+(defun java/post-init-counsel-gtags nil)
 
 (defun java/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/javascript/packages.el
+++ b/layers/+lang/javascript/packages.el
@@ -52,8 +52,7 @@
 (defun javascript/post-init-company ()
   (add-hook 'js2-mode-local-vars-hook #'spacemacs//javascript-setup-company))
 
-(defun javascript/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'js2-mode))
+(defun javascript/post-init-counsel-gtags nil)
 
 (defun javascript/pre-init-dap-mode ()
   (when (eq javascript-backend 'lsp)

--- a/layers/+lang/kotlin/packages.el
+++ b/layers/+lang/kotlin/packages.el
@@ -51,5 +51,4 @@
 (defun kotlin/post-init-ggtags ()
   (add-hook 'kotlin-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun kotlin/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'kotlin-mode))
+(defun kotlin/post-init-counsel-gtags nil)

--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -233,8 +233,7 @@
       (concat prefix "T")    'reftex-toc-recenter
       (concat prefix "v")    'reftex-view-crossref)))
 
-(defun latex/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'latex-mode))
+(defun latex/post-init-counsel-gtags nil)
 
 (defun latex/post-init-ggtags ()
   (add-hook 'latex-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -72,5 +72,4 @@
 (defun lua/post-init-ggtags ()
   (add-hook 'lua-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun lua/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'lua-mode))
+(defun lua/post-init-counsel-gtags nil)

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -95,8 +95,7 @@
 (defun ocaml/post-init-ggtags ()
   (add-hook 'ocaml-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun ocaml/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'ocaml-mode))
+(defun ocaml/post-init-counsel-gtags nil)
 
 (defun ocaml/init-merlin ()
   (use-package merlin

--- a/layers/+lang/octave/packages.el
+++ b/layers/+lang/octave/packages.el
@@ -48,5 +48,4 @@
 (defun octave/post-init-ggtags ()
   (add-hook 'octave-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun octave/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'octave-mode))
+(defun octave/post-init-counsel-gtags nil)

--- a/layers/+lang/php/packages.el
+++ b/layers/+lang/php/packages.el
@@ -57,8 +57,7 @@
 (defun php/post-init-ggtags ()
   (add-hook 'php-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun php/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'php-mode))
+(defun php/post-init-counsel-gtags nil)
 
 (defun php/post-init-evil-matchit ()
   (add-hook 'php-mode-hook 'turn-on-evil-matchit-mode))

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -162,8 +162,7 @@
     :post-init
     (spacemacs/setup-helm-cscope 'python-mode)))
 
-(defun python/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'python-mode))
+(defun python/post-init-counsel-gtags nil)
 
 (defun python/post-init-ggtags ()
   (add-hook 'python-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))

--- a/layers/+lang/racket/packages.el
+++ b/layers/+lang/racket/packages.el
@@ -49,8 +49,7 @@
 (defun racket/post-init-ggtags ()
   (add-hook 'racket-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun racket/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'racket-mode))
+(defun racket/post-init-counsel-gtags nil)
 
 (defun racket/pre-init-evil-cleverparens ()
   (spacemacs|use-package-add-hook evil-cleverparens

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -80,9 +80,7 @@
 (defun ruby/post-init-company ()
   (add-hook 'ruby-mode-local-vars-hook #'spacemacs//ruby-setup-company))
 
-(defun ruby/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'ruby-mode)
-  (spacemacs/counsel-gtags-define-keys-for-mode 'enh-ruby-mode))
+(defun ruby/post-init-counsel-gtags nil)
 
 (defun ruby/pre-init-dap-mode ()
   (when (eq ruby-backend 'lsp)

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -31,8 +31,7 @@
     smartparens))
 
 
-(defun rust/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'rustic-mode))
+(defun rust/post-init-counsel-gtags nil)
 
 (defun rust/pre-init-dap-mode ()
   (when (eq rust-backend 'lsp)

--- a/layers/+lang/scala/packages.el
+++ b/layers/+lang/scala/packages.el
@@ -111,6 +111,4 @@
   (when scala-enable-gtags
     (add-hook 'scala-mode-local-vars-hook #'spacemacs/ggtags-mode-enable)))
 
-(defun scala/post-init-counsel-gtags ()
-  (when scala-enable-gtags
-    (spacemacs/counsel-gtags-define-keys-for-mode 'scala-mode)))
+(defun scala/post-init-counsel-gtags nil)

--- a/layers/+lang/scheme/packages.el
+++ b/layers/+lang/scheme/packages.el
@@ -144,8 +144,7 @@
 (defun scheme/post-init-ggtags ()
   (add-hook 'scheme-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun scheme/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'scheme-mode))
+(defun scheme/post-init-counsel-gtags nil)
 
 (defun scheme/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/shell-scripts/packages.el
+++ b/layers/+lang/shell-scripts/packages.el
@@ -118,8 +118,7 @@
 (defun shell-scripts/post-init-ggtags ()
   (add-hook 'sh-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun shell-scripts/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'sh-mode))
+(defun shell-scripts/post-init-counsel-gtags nil)
 
 (defun shell-scripts/pre-init-org ()
   (spacemacs|use-package-add-hook org

--- a/layers/+lang/vimscript/packages.el
+++ b/layers/+lang/vimscript/packages.el
@@ -63,5 +63,4 @@
 (defun vimscript/post-init-ggtags ()
   (add-hook 'vimrc-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun vimscript/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'vimrc-mode))
+(defun vimscript/post-init-counsel-gtags nil)

--- a/layers/+lang/windows-scripts/packages.el
+++ b/layers/+lang/windows-scripts/packages.el
@@ -82,8 +82,7 @@
 (defun windows-scripts/post-init-ggtags ()
   (add-hook 'bat-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
 
-(defun windows-scripts/post-init-counsel-gtags ()
-  (spacemacs/counsel-gtags-define-keys-for-mode 'bat-mode))
+(defun windows-scripts/post-init-counsel-gtags nil)
 
 (defun windows-scripts/init-powershell ()
   (use-package powershell


### PR DESCRIPTION
This PR removes all calls to the obsolete [spacemacs/counsel-gtags-define-keys-for-mode](https://github.com/syl20bnr/spacemacs/blob/36b52f1b71f52718b9c35e79d35f41556529c4bd/layers/%2Btags/gtags/funcs.el#L38) function.
