### PR TITLE
[exwm] Fix broken quelpa recipe

### DIFF
--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -28,12 +28,8 @@
     (evil-exwm-state :toggle (configuration-layer/package-used-p 'evil)
                      :location (recipe :fetcher github
                                        :repo "domenzain/evil-exwm-state"))
-    (xelb :location (recipe :fetcher github
-                            :repo "ch11ng/xelb")
-          :step pre)
-    (exwm :location (recipe :fetcher github
-                            :repo "ch11ng/exwm")
-          :step pre)))
+    (xelb :step pre)
+    (exwm :step pre)))
 
 (defun exwm/init-xdg ()
   (use-package xdg

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -25,7 +25,7 @@
   '((xdg :location built-in)
     desktop-environment
     (helm-exwm :toggle (configuration-layer/package-used-p 'helm))
-    (evil-exwm-state :toggle (configuration-layer/package-used-p 'evil)
+    (evil-exwm-state :toggle (memq dotspacemacs-editing-style '(vim hybrid))
                      :location (recipe :fetcher github
                                        :repo "domenzain/evil-exwm-state"))
     (xelb :step pre)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -22,14 +22,14 @@
 
 
 (defconst exwm-packages
-  '((xdg :location built-in)
-    desktop-environment
-    (helm-exwm :toggle (configuration-layer/package-used-p 'helm))
+  '(desktop-environment
     (evil-exwm-state :toggle (memq dotspacemacs-editing-style '(vim hybrid))
                      :location (recipe :fetcher github
                                        :repo "domenzain/evil-exwm-state"))
-    (xelb :step pre)
-    (exwm :step pre)))
+    (exwm :step pre)
+    (helm-exwm :toggle (configuration-layer/package-used-p 'helm))
+    (xdg :location built-in)
+    (xelb :step pre)))
 
 (defun exwm/init-xdg ()
   (use-package xdg


### PR DESCRIPTION
At the current develop branch, attempting to install exwm fails
because the `ch11ng/exwm` repo now only contains a README, no Elisp
files.