### PR TITLE
Show leader for llm-client (gptel) layer at init

### DIFF
--- a/layers/+web-services/llm-client/packages.el
+++ b/layers/+web-services/llm-client/packages.el
@@ -32,7 +32,7 @@
   (use-package gptel
     :defer t
     :ensure t
-    :config
+    :init
     (spacemacs/declare-prefix "$g" "Gptel")
     (spacemacs/set-leader-keys
       "$gg" 'gptel                          ; Start a new GPTel session


### PR DESCRIPTION
Declare the leader at `:init` time instead of `:config` so gptel shows up in the menus at startup, and not until the package has been manually loaded.