### PR TITLE
[org] Prevent SPC TAB from switching to `*Calendar*`

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -322,26 +322,33 @@ buffer."
 (define-obsolete-function-alias 'spacemacs/derived-mode-p 'provided-mode-derived-p "2024-06")
 
 (defun spacemacs/alternate-buffer (&optional window)
-  "Switch back and forth between current and last buffer in the
-current window.
+  "Switch back and forth between current and last buffer in WINDOW.
 
-If `spacemacs-layouts-restrict-spc-tab' is `t' then this only switches between
-the current layouts buffers."
+WINDOW defaults to the selected window.
+
+If `spacemacs-layouts-restrict-spc-tab' is non-nil, then this
+only switches between the current layout's buffers."
   (interactive)
   (cl-destructuring-bind (buf start pos)
-      (if (bound-and-true-p spacemacs-layouts-restrict-spc-tab)
-          (let ((buffer-list (persp-buffer-list))
-                (my-buffer (window-buffer window)))
-            ;; find buffer of the same persp in window
-            (seq-find (lambda (it) ;; predicate
-                        (and (not (eq (car it) my-buffer))
-                             (member (car it) buffer-list)))
-                      (window-prev-buffers)
-                      ;; default if found none
-                      (list nil nil nil)))
-        (or (cl-find (window-buffer window) (window-prev-buffers)
-                     :key #'car :test-not #'eq)
-            (list (other-buffer) nil nil)))
+      (let ((my-buffer (window-buffer window))
+            (usefulp (or (symbol-function 'spacemacs/useful-buffer-p) #'always))
+            (predicate #'always)
+            (default (list (other-buffer) nil nil)))
+
+        (when (bound-and-true-p spacemacs-layouts-restrict-spc-tab)
+          (let ((buffer-list (persp-buffer-list)))
+            ;; find buffer of the same persp in window, and don't try
+            ;; `other-buffer'
+            (setq predicate (lambda (buffer) (member buffer buffer-list))
+                  default (list nil nil nil))))
+
+        (seq-find (lambda (it)
+                    (let ((buffer (car it)))
+                      (and (not (eq buffer my-buffer))
+                           (funcall usefulp buffer)
+                           (funcall predicate buffer))))
+                  (window-prev-buffers)
+                  default))
     (if (not buf)
         (message "Last buffer not found.")
       (set-window-buffer-start-and-point window buf start pos))))

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -35,15 +35,14 @@
     (ob :location built-in)
     (org :location elpa :min-version "9.6.1")
     (org-agenda :location built-in)
-    (org-wild-notifier
-                :toggle org-enable-notifications)
+    (org-wild-notifier :toggle org-enable-notifications)
     (org-contacts :toggle org-enable-org-contacts-support)
     org-contrib
     (org-vcard :toggle org-enable-org-contacts-support)
     (org-brain :toggle org-enable-org-brain-support)
     (org-expiry :location built-in)
-    ; temporarily point org-journal to dalanicolai fork until dalanicolai's
-    ; PR's https://github.com/bastibe/org-journal/pulls get merged
+    ;; temporarily point org-journal to dalanicolai fork until dalanicolai's
+    ;; PR's https://github.com/bastibe/org-journal/pulls get merged
     (org-journal
      :location (recipe :fetcher github :repo "dalanicolai/org-journal")
      :toggle org-enable-org-journal-support)
@@ -446,35 +445,35 @@ Will work on both org-mode and any mode that accepts plain html."
     ;; C-c ' is shadowed by `spacemacs/default-pop-shell', effectively making
     ;; the Emacs user unable to exit src block editing.
     (define-key org-src-mode-map
-      (kbd (concat dotspacemacs-major-mode-emacs-leader-key " '"))
-      'org-edit-src-exit)
+                (kbd (concat dotspacemacs-major-mode-emacs-leader-key " '"))
+                'org-edit-src-exit)
 
     ;; Evilify the calendar tool on C-c .
     (unless (eq 'emacs dotspacemacs-editing-style)
       (define-key org-read-date-minibuffer-local-map (kbd "M-h")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-backward-day 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-backward-day 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-l")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-forward-day 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-forward-day 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-k")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-backward-week 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-backward-week 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-j")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-forward-week 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-forward-week 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-H")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-backward-month 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-backward-month 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-L")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-forward-month 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-forward-month 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-K")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-backward-year 1))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-backward-year 1))))
       (define-key org-read-date-minibuffer-local-map (kbd "M-J")
-        (lambda () (interactive)
-          (org-eval-in-calendar '(calendar-forward-year 1)))))
+                  (lambda () (interactive)
+                    (org-eval-in-calendar '(calendar-forward-year 1)))))
 
     (spacemacs|define-transient-state org-babel
       :title "Org Babel Transient state"
@@ -750,13 +749,13 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
 (defun org/init-org-modern ()
   (use-package org-modern
-      :defer t
-      :init
-      (add-hook 'org-mode-hook 'org-modern-mode)
-      (add-hook 'org-agenda-finalize-hook #'org-modern-agenda)
+    :defer t
+    :init
+    (add-hook 'org-mode-hook 'org-modern-mode)
+    (add-hook 'org-agenda-finalize-hook #'org-modern-agenda)
 
-      (spacemacs/set-leader-keys-for-major-mode 'org-mode
-        "Tm" 'org-modern-mode)))
+    (spacemacs/set-leader-keys-for-major-mode 'org-mode
+      "Tm" 'org-modern-mode)))
 
 (defun org/init-org-pomodoro ()
   (use-package org-pomodoro
@@ -1073,7 +1072,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
 (defun org/post-init-helm ()
   (if (not (boundp 'helm-imenu-extra-modes))
-    (setq helm-imenu-extra-modes '(org-mode)))
+      (setq helm-imenu-extra-modes '(org-mode)))
   (add-to-list 'helm-imenu-extra-modes 'org-mode))
 
 (defun org/init-org-roam-ui ()

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -149,6 +149,13 @@
           ;; `helm-org-headings-max-depth'.
           org-imenu-depth 8)
 
+    ;; `org-read-date' pops up the Calendar buffer but it is not usually useful
+    ;; to switch to it.
+    (with-eval-after-load 'calendar
+      (cl-pushnew (regexp-quote calendar-buffer)
+                  spacemacs-useless-buffers-regexp
+                  :test #'equal))
+
     (when org-todo-dependencies-strategy
       (setq org-enforce-todo-dependencies t)
       (add-hook 'org-after-todo-statistics-hook


### PR DESCRIPTION
This buffer is temporarily displayed whenever `org-read-date' is
called, but org-mode users do not typically use it by itself, and it
gets in the way of switching to other org buffers.