### PR TITLE
[org] Ensure install the lastest version org from elpa

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1741,7 +1741,7 @@ RNAME is the name symbol of another existing layer."
              not-inst-count)
      t)
     (spacemacs//redisplay)
-    (unless (package-installed-p pkg-name min-version)
+    (when (or (not (package-installed-p pkg-name min-version)) (eq pkg-name 'org))
       (condition-case-unless-debug err
           (cond
            ((or (null pkg) (eq 'elpa location))
@@ -1908,7 +1908,7 @@ RNAME is the name symbol of another existing layer."
    pkg-names (lambda (x)
                (let* ((pkg (configuration-layer/get-package x))
                       (min-version (when pkg (oref pkg :min-version))))
-                 (not (package-installed-p x min-version))))))
+                 (or (not (package-installed-p x min-version)) (eq x 'org))))))
 
 (defun configuration-layer//package-has-recipe-p (pkg-name)
   "Return non nil if PKG-NAME is the name of a package declared with a recipe."

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -33,7 +33,7 @@
     htmlize
     ;; ob, org, org-agenda and org-contacts are installed by `org-contrib'
     (ob :location built-in)
-    (org :location elpa :min-version "9.6.1")
+    (org :location elpa)
     (org-agenda :location built-in)
     (org-wild-notifier
                 :toggle org-enable-notifications)


### PR DESCRIPTION
Straightforwardly filter `org` to the list of packages to install, however seemingly no other packages are built-in but supposed to be install from elpa. Fix #16464.