### PR TITLE
Layer +chat/erc: Fix unloaded command `spacemacs/erc-find-channel-log`

### DIFF
--- a/layers/+chat/erc/packages.el
+++ b/layers/+chat/erc/packages.el
@@ -163,6 +163,7 @@
 (defun erc/init-erc-view-log ()
   (use-package erc-view-log
     :defer t
+    :commands (spacemacs/erc-find-channel-log)
     :init
     (setq erc-log-channels-directory
           (expand-file-name


### PR DESCRIPTION
Fix #16493.