### PR TITLE
Make undo-tree optional

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -380,6 +380,16 @@ Point size is recommended, because it's device independent. (default 10.0)"
   '(choice (const evil) (const origami) (const vimish))
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-undo-system 'undo-tree
+  "The backend used for undo/redo functionality. Possible values are
+`undo-tree', `undo-fu' and `undo-redo', see also `evil-undo-system'.
+Note that saved undo history does not get transferred when changing
+from undo-tree to undo-fu or undo-redo.
+The default is currently 'undo-tree, but it will likely be changed
+and at some point removed because undo-tree is not maintained anymore."
+  '(choice (const undo-redo) (const undo-fu) (const undo-tree))
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-default-layout-name "Default"
   "Name of the default layout."
   'string

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -471,6 +471,14 @@ It should only modify the values of Spacemacs settings."
    ;; (default '("rg" "ag" "pt" "ack" "grep"))
    dotspacemacs-search-tools '("rg" "ag" "pt" "ack" "grep")
 
+   ;; The backend used for undo/redo functionality. Possible values are
+   ;; `undo-tree', `undo-fu' and `undo-redo', see also `evil-undo-system'.
+   ;; Note that saved undo history does not get transferred when changing
+   ;; from undo-tree to undo-fu or undo-redo.
+   ;; The default is currently 'undo-tree, but it will likely be changed
+   ;; and at some point removed because undo-tree is not maintained anymore.
+   dotspacemacs-undo-system 'undo-tree
+
    ;; Format specification for setting the frame title.
    ;; %a - the `abbreviated-file-name', or `buffer-name'
    ;; %t - `projectile-project-name'

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -82,8 +82,7 @@
   (require 'evil)
   (evil-mode 1)
 
-  (when (configuration-layer/package-used-p 'undo-tree)
-    (customize-set-variable 'evil-undo-system 'undo-tree))
+  (customize-set-variable 'evil-undo-system dotspacemacs-undo-system)
 
   ;; Use evil as a default jump handler
   (add-to-list 'spacemacs-default-jump-handlers 'evil-goto-definition)

--- a/layers/+os/osx/keybindings.el
+++ b/layers/+os/osx/keybindings.el
@@ -87,7 +87,7 @@ default."
   (global-set-key (kbd-mac-command "W") 'delete-frame)
   (global-set-key (kbd-mac-command "n") 'make-frame)
   (global-set-key (kbd-mac-command "`") 'other-frame)
-  (global-set-key (kbd-mac-command "z") 'undo-tree-undo)
+  (global-set-key (kbd-mac-command "z") 'evil-undo)
   (global-set-key (kbd-mac-command "s") 'save-buffer)
 
   ;; window manipulation with command key
@@ -101,7 +101,7 @@ default."
   (global-set-key (kbd-mac-command "8") 'spacemacs/winum-select-window-8)
   (global-set-key (kbd-mac-command "9") 'spacemacs/winum-select-window-9)
 
-  (global-set-key (kbd-mac-command "Z") 'undo-tree-redo)
+  (global-set-key (kbd-mac-command "Z") 'evil-redo)
   (global-set-key (kbd-mac-command "C-f") 'spacemacs/toggle-frame-fullscreen)
   (global-set-key (kbd "M-s-h") 'ns-do-hide-others)
 

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -297,7 +297,7 @@
       ;; other
       ("C" smerge-combine-with-next)
       ("K" smerge-kill-current)
-      ("U" undo-tree-undo)
+      ("U" evil-undo)
       ("q" nil :exit t)
       ("?" spacemacs//smerge-ts-toggle-hint))))
 

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -92,6 +92,13 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Edit
 ;; ---------------------------------------------------------------------------
 
+;; bump of the undo limits to avoid issues with premature
+;; Emacs GC which truncates the undo history very aggressively
+(setq-default
+ undo-limit 80000000
+ undo-strong-limit 120000000
+ undo-outer-limit 360000000)
+
 ;; Start with the *scratch* buffer in text mode (speeds up Emacs load time,
 ;; because it avoids autoloads of elisp modes)
 (setq initial-major-mode 'text-mode)


### PR DESCRIPTION
Add support for the remaining options of `evil-undo-system`, i.e. `undo-redo` and `undo-fu`. Uses undo-fu-session and vundo to replicate persistence and a tree view. Addresses #16481.

The larger undo limits are the defaults that undo-tree sets itself when enabled.

I opted for not changing the default or removing undo-tree completely immediately without a warning, because this could make users lose precious(?) persisted undo history.

BTW, the package evil-lisp-state has `undo-tree-undo` and `undo-tree-redo` hardcoded, this should be reported upstream.
