### PR TITLE
Fix SPC a u key binding when not using undo-tree

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -195,8 +195,7 @@
 (spacemacs/set-leader-keys
   "a*"  'calc-dispatch
   "ap"  'list-processes
-  "aP"  'proced
-  "au"  'undo-tree-visualize)
+  "aP"  'proced)
 ;; easy pg ----------------------------------------------------------------------
 (spacemacs|spacebind
  "Encrypt / decrypt files with Easy PG"


### PR DESCRIPTION
The spacemacs-defaults layer was overwriting this key binding, which
is already set in spacemacs-editing (in either undo-tree or vundo
configuration).

This is a small follow-up to #16506.