### PR TITLE
[modeline] Remove redundant function calls

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -81,16 +81,17 @@ Return nil if no scale is defined."
 (defun spacemacs//restore-powerline (buffer)
   "Restore the powerline in buffer"
   (with-current-buffer buffer
-    (setq-local mode-line-format (default-value 'mode-line-format))
-    (powerline-set-selected-window)
-    (powerline-reset)))
+    (setq-local mode-line-format (default-value 'mode-line-format))))
 
 (defun spacemacs//restore-buffers-powerline ()
   "Restore the powerline in the buffers.
 Excluding which-key."
   (dolist (buffer (buffer-list))
     (unless (string-match-p "\\*which-key\\*" (buffer-name buffer))
-      (spacemacs//restore-powerline buffer))))
+      (spacemacs//restore-powerline)))
+  (powerline-reset)
+  (powerline-set-selected-window)
+  (force-mode-line-update t))
 
 (defun spacemacs//prepare-diminish ()
   (when spaceline-minor-modes-p
@@ -116,6 +117,7 @@ Excluding which-key."
   (dolist (buffer '("*Messages*" "*spacemacs*" "*Compile-Log*"))
     (when (get-buffer buffer)
       (with-current-buffer buffer
-        (setq-local mode-line-format (default-value 'mode-line-format))
-        (powerline-set-selected-window)
-        (powerline-reset)))))
+        (setq-local mode-line-format (default-value 'mode-line-format)))))
+  (powerline-reset)
+  (powerline-set-selected-window)
+  (force-mode-line-update t))

--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -78,17 +78,13 @@ Return nil if no scale is defined."
   (let ((state (if (eq 'operator evil-state) evil-previous-state evil-state)))
     (intern (format "spacemacs-%S-face" state))))
 
-(defun spacemacs//restore-powerline (buffer)
-  "Restore the powerline in buffer"
-  (with-current-buffer buffer
-    (setq-local mode-line-format (default-value 'mode-line-format))))
-
 (defun spacemacs//restore-buffers-powerline ()
   "Restore the powerline in the buffers.
 Excluding which-key."
   (dolist (buffer (buffer-list))
     (unless (string-match-p "\\*which-key\\*" (buffer-name buffer))
-      (spacemacs//restore-powerline)))
+      (with-current-buffer buffer
+        (setq-local mode-line-format (default-value 'mode-line-format)))))
   (powerline-reset)
   (powerline-set-selected-window)
   (force-mode-line-update t))


### PR DESCRIPTION
The behaviour of `powerline-reset` does not depend on the current buffer, and it
suffices to call it once. The same holds for `powerline-set-selected-window`
if we call `force-mode-line-update` with a non-nil ALL argument to redisplay all
modelines.

This significantly speeds up reloading the configuration with `SPC f e R` in the
presence of many buffers, where `powerline-reset` used to be the
bottleneck. (For me it often took tens of seconds).
