### PR TITLE
[modeline] Byte-compile also after reloading configuration

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -63,7 +63,7 @@
     (spacemacs|when-dumping-strict
       (spacemacs/spaceline-config-startup))
     (spacemacs|unless-dumping
-      (add-hook 'emacs-startup-hook 'spacemacs/spaceline-config-startup-hook))
+      (add-hook 'spacemacs-post-user-config-hook 'spacemacs/spaceline-config-startup-hook))
     (add-hook 'spacemacs-post-theme-change-hook
               'spacemacs/customize-powerline-faces)
     (add-hook 'spacemacs-post-theme-change-hook 'powerline-reset)


### PR DESCRIPTION
Previously, after reloading the configuration, functions such as `spaceline-ml-main` where not byte-compiled anymore. (Note that both `emacs-startup-hook` and `spacemacs-post-user-config-hook` are ran after the user configuration, but `emacs-startup-hook` is not run again when reloading the configuration.)