### PR TITLE
[defaults] Improve and rename `SPC w m` binding

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -479,6 +479,12 @@ window."
   'boolean
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-maximize-window-keep-side-windows t
+  "Whether side windows (such as those created by treemacs or neotree)
+are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m)."
+  'boolean
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-loading-progress-bar t
   "If non nil a progress bar is displayed when spacemacs is loading. This
 may increase the boot time on some systems and emacs builds, set it to nil

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -350,6 +350,11 @@ It should only modify the values of Spacemacs settings."
    ;; displayed in the current window. (default nil)
    dotspacemacs-switch-to-buffer-prefers-purpose nil
 
+   ;; Whether side windows (such as those created by treemacs or neotree)
+   ;; are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m).
+   ;; (default t)
+   dotspacemacs-maximize-window-keep-side-windows t
+
    ;; If non-nil a progress bar is displayed when spacemacs is loading. This
    ;; may increase the boot time on some systems and emacs builds, set it to
    ;; nil to boost the loading time. (default t)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2354,7 +2354,7 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w K~              | move window to the top                                                      |
 | ~SPC w l~              | move to window on the right                                                 |
 | ~SPC w L~              | move window to the right                                                    |
-| ~SPC w m~              | maximize/minimize a window (maximize is equivalent to delete other windows) |
+| ~SPC w m~              | maximize/minimize a window (maximize is similar to delete-other-windows)    |
 | ~SPC w M~              | swap windows using [[https://github.com/abo-abo/ace-window][ace-window]]                                               |
 | ~SPC w o~              | cycle and focus between frames                                              |
 | ~SPC w p m~            | open messages buffer in a popup window                                      |
@@ -2374,6 +2374,11 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w ]~              | enlarge window horizontally (enter transient state)                         |
 | ~SPC w {~              | shrink window vertically (enter transient state)                            |
 | ~SPC w }~              | enlarge window vertically (enter transient state)                           |
+
+Note that by default, ~SPC w m~ will not delete side windows such as those
+created by treemacs or neotree. If you would like side windows to get minimized
+too, you can set the variable
+=dotspacemacs-maximize-window-keep-side-windows= to =nil=.
 
 Split the current window into multiple ones, deleting all others using the
 following commands:

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -110,8 +110,8 @@
   ;; Make set-selective-display more discoverable to Evil folks
   (define-key evil-normal-state-map "z$" 'spacemacs/toggle-selective-display)
   ;; toggle maximize buffer
-  (define-key evil-window-map (kbd "o") 'spacemacs/toggle-maximize-buffer)
-  (define-key evil-window-map (kbd "C-o") 'spacemacs/toggle-maximize-buffer)
+  (define-key evil-window-map (kbd "o") 'spacemacs/toggle-maximize-window)
+  (define-key evil-window-map (kbd "C-o") 'spacemacs/toggle-maximize-window)
   ;; make cursor keys work
   (define-key evil-window-map (kbd "<left>") 'evil-window-left)
   (define-key evil-window-map (kbd "<right>") 'evil-window-right)

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -178,6 +178,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
     ;; `buffer-predicate' entry doesn't exist, create it
     (push '(buffer-predicate . spacemacs/useful-buffer-p) default-frame-alist)))
 
+(add-to-list 'window-persistent-parameters '(spacemacs-max-state . writable))
+
 ;; ---------------------------------------------------------------------------
 ;; Session
 ;; ---------------------------------------------------------------------------

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -186,17 +186,62 @@ Refer Spacemacs #16397 for details.")
                                  newline
                                  newline-mark)))
 
-;; from https://gist.github.com/3402786
-(defun spacemacs/toggle-maximize-buffer ()
-  "Maximize buffer"
+(defun spacemacs//delete-other-non-side-windows ()
+  "Delete all windows except for the selected one and side windows.
+
+Unlike `delete-other-windows', this function ignores the
+window parameter no-delete-other-windows."
+  (walk-windows
+   (lambda (win)
+     (unless (or (eq win (selected-window))
+                 (window-parameter win 'window-side))
+       (delete-window win)))
+   'ignore-minibuffer))
+
+;; adapted from https://gist.github.com/3402786
+(defun spacemacs/toggle-maximize-window ()
+  "Temporarily maximize window, restore other windows on the next
+call.
+
+The variable `dotspacemacs-maximize-window-keep-side-windows'
+controls whether side windows (such as those created by treemacs, neotree or
+persistent which-key) are kept or minimized too."
   (interactive)
-  (save-excursion
-    (if (and (= 1 (length (window-list)))
-             (assoc ?_ register-alist))
-        (jump-to-register ?_)
-      (progn
-        (window-configuration-to-register ?_)
-        (delete-other-windows)))))
+  (let* ((max-target-window
+          (if dotspacemacs-maximize-window-keep-side-windows
+              (window-main-window)
+            (frame-root-window)))
+         (window-already-maximal
+          (eq max-target-window (selected-window))))
+    (cond ((and window-already-maximal
+                (window-parameter nil 'spacemacs-max-state))
+           ;; Restore the previously deleted windows, keeping the state of the
+           ;; selected window.
+           (let ((selected-win-state (window-state-get (selected-window))))
+             (window-state-put
+              (window-parameter nil 'spacemacs-max-state) (selected-window))
+             (window-state-put selected-win-state (selected-window))
+             (set-window-parameter nil 'spacemacs-max-state nil)))
+          ((and (not window-already-maximal)
+                (window-parameter nil 'window-side))
+           ;; Raise the same error as `delete-other-windows'
+           ;; (with `ignore-window-parameters' nil).
+           (error "Cannot make side window the only window"))
+          ((not window-already-maximal)
+           ;; Store the current state as a window parameter of the selected window
+           ;; and delete other windows.
+           (set-window-parameter nil 'spacemacs-max-state (window-state-get max-target-window t))
+           (if dotspacemacs-maximize-window-keep-side-windows
+               (spacemacs//delete-other-non-side-windows)
+             (let ((ignore-window-parameters t))
+               (delete-other-windows))))))
+  (when (configuration-layer/layer-used-p 'spacemacs-layouts)
+    ;; Make the existing advice for rename-buffer, `spacemacs//fixup-window-configs',
+    ;; apply to buffers in "minimized" windows in the current workspace.
+    (spacemacs/update-eyebrowse-for-perspective)))
+
+(define-obsolete-function-alias 'spacemacs/toggle-maximize-buffer
+  'spacemacs/toggle-maximize-window "2024-08")
 
 ;; https://tsdh.wordpress.com/2007/03/28/deleting-windows-vertically-or-horizontally/
 (defun spacemacs/maximize-horizontally ()

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -230,6 +230,7 @@ persistent which-key) are kept or minimized too."
           ((not window-already-maximal)
            ;; Store the current state as a window parameter of the selected window
            ;; and delete other windows.
+           (walk-windows (lambda (win) (set-window-parameter win 'spacemacs-max-state nil)))
            (set-window-parameter nil 'spacemacs-max-state (window-state-get max-target-window t))
            (if dotspacemacs-maximize-window-keep-side-windows
                (spacemacs//delete-other-non-side-windows)

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -110,7 +110,7 @@
 (define-key global-map (kbd "RET") 'newline-and-indent)
 
 ;; improve delete-other-windows
-(define-key global-map (kbd "C-x 1") 'spacemacs/toggle-maximize-buffer)
+(define-key global-map (kbd "C-x 1") 'spacemacs/toggle-maximize-window)
 ;; adds two spacing modes while preserving just-one-space behaviour
 (define-key global-map (kbd "M-SPC") 'cycle-spacing)
 
@@ -669,7 +669,7 @@ respond to this toggle."
   "w <S-right>"  'evil-window-move-far-right
   "wl"  'evil-window-right
   "w <right>"  'evil-window-right
-  "wm"  'spacemacs/toggle-maximize-buffer
+  "wm"  'spacemacs/toggle-maximize-window
   ;; "wcc"  'spacemacs/toggle-centered-buffer
   ;; "wcC"  'spacemacs/toggle-distraction-free
   ;; "wc."  'spacemacs/centered-buffer-transient-state
@@ -944,7 +944,7 @@ Select: _a_ _h_ _j_ _k_ _l_ _w_ _0_.._9_ Move: _H_ _J_ _K_ _L_ _r_ _R_ Split: _s
   ("v" split-window-right)
   ("V" split-window-right-and-focus)
   ("/" split-window-right-and-focus)
-  ("m" spacemacs/toggle-maximize-buffer)
+  ("m" spacemacs/toggle-maximize-window)
   ("|" spacemacs/maximize-vertically)
   ("_" spacemacs/maximize-horizontally)
   ;; Resize


### PR DESCRIPTION
Improvements:

- Saving the state as a window parameter gives us workspace(+layout) isolation via eyebrowse and persistence via persp-mode for free. Hence one can now maximize windows in different layouts/workspaces, and toggle the maximization off independently in any order, also after restarting Spacemacs when layouts are restored.

- Previously, toggling the maximized state off would switch back to the buffer that was displayed in the window when it was maximized (in case a different buffer was switched to in the maximized state). In the new implementation, the current buffer and full window buffer history are preserved.

- The previous implementation did not work in the presence of side windows such as treemacs or neotree. This commit handles them properly and introduces an option `dotspacemacs-maximize-window-keep-side-windows` to control whether to keep or minimize them.

Caveats:

There exist small differences between using writable window state objects and window configuration objects. The former ones of course only store serializable/writable data such as buffer positions instead of markers. I think the edge cases where this makes a difference are negligible though, and eyebrowse also exclusively uses writable window state objects, i. e., we lose such non-serializable information on every layout/workspace switch anyway.
