### PR TITLE
[compleseus] Add option `compleseus-buffer-search-restrict-project`

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -25,6 +25,18 @@
   "Options are `selectrum', and `vertico' to use as completion
   engine.")
 
+(defvar compleseus-buffer-search-restrict-project t
+  "If non-nil, `spacemacs/consult-line-multi' and `spacemacs/consult-line-multi-symbol'
+will be restricted to buffers of the current project.
+This is the default behaviour of `consult-line-multi', but it can be overriden
+by using a prefix argument.
+
+If nil, we invert the default behaviour, and thus restrict to buffers
+of the current project only when a prefix argument is used.
+
+To restrict the commands to buffers of the current layout, customize
+the variable `spacemacs-layouts-restricted-functions'.")
+
 (defvar consult--source-modified-persp-buffers
   `(:name "Modified Buffers"
           :narrow   (?* . "Modified Layout Buffers")

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -84,17 +84,31 @@ active and `force-input' is not nil, `thing-at-point' will be returned."
   (consult-line
    (spacemacs/initial-search-input t)))
 
-(defun spacemacs/consult-line-multi (&optional query)
-  (interactive "P")
-  (consult-line-multi
-   query
-   (spacemacs/initial-search-input)))
+(defun spacemacs/consult-line-multi (&optional toggle-restrict)
+  "Search project buffers using `consult-line-multi'.
+If the prefix argument TOGGLE-RESTRICT is non-nil, search all buffers.
 
-(defun spacemacs/consult-line-multi-symbol (&optional query)
+If the region is active, it is used as the initial input.
+
+The effect of the prefix argument can be inverted by setting
+`compleseus-buffer-search-restrict-project' to nil."
   (interactive "P")
-  (consult-line-multi
-   query
-   (spacemacs/initial-search-input t)))
+  (unless compleseus-buffer-search-restrict-project
+    (setq toggle-restrict (not toggle-restrict)))
+  (consult-line-multi toggle-restrict (spacemacs/initial-search-input)))
+
+(defun spacemacs/consult-line-multi-symbol (&optional toggle-restrict)
+  "Search project buffers using `consult-line-multi'.
+If the prefix argument TOGGLE-RESTRICT is non-nil, search all buffers.
+
+The active region or symbol at point is used as the initial input.
+
+The effect of the prefix argument can be inverted by setting
+`compleseus-buffer-search-restrict-project' to nil."
+  (interactive "P")
+  (unless compleseus-buffer-search-restrict-project
+    (setq toggle-restrict (not toggle-restrict)))
+  (consult-line-multi toggle-restrict (spacemacs/initial-search-input t)))
 
 (defun spacemacs/embark-consult-line-multi (buffer-names)
   "Embark action to search in any subset of buffers using `consult-line-multi'.

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -132,8 +132,8 @@
            ("M-s g" . consult-grep)
            ("M-s G" . consult-git-grep)
            ("M-s r" . consult-ripgrep)
-           ("M-s l" . consult-line)
-           ("M-s m" . consult-line-multi)
+           ("M-s l" . spacemacs/consult-line)
+           ("M-s m" . spacemacs/consult-line-multi)
            ("M-s k" . consult-keep-lines)
            ("M-s u" . consult-focus-lines)
            ;; Isearch integration


### PR DESCRIPTION
By default `consult-line-multi` only searches project buffers unless given a prefix argument. This commit adds an option to invert the effect of the prefix argument for users that usually want to search all buffers, or all buffers of a particular layout.