### PR TITLE
[layouts] Update list of restricted functions

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1826,30 +1826,36 @@ your used layer list with layer variables:
 
 *** Restrict a given function to the current layout
 You can make any function "layout aware" by adding it to the list
-=spacemacs-layouts-restricted-functions=. It is not possible to change this
-variable when Emacs is running. You have to define it using layer variables.
-If you change this variable then Emacs must be restarted for the change to
-take effect.
+=spacemacs-layouts-restricted-functions=. This needs to be done by
+redefining the complete list either as a layer variable or using
+=setopt= or =customize-set-variable=.
 
-Default value for this variable is:
+The default value for this variable is:
 
 #+BEGIN_EXAMPLE
-  '(spacemacs/window-split-double-columns
+  '(switch-to-next-buffer
+    switch-to-prev-buffer
+    spacemacs/window-split-double-columns
     spacemacs/window-split-triple-columns
     spacemacs/window-split-grid)
 #+END_EXAMPLE
 
 If you want to add the function =my-func= to this list you need to redefine
-the complete list using layer variables:
+the complete list, for example using layer variables:
 
 #+BEGIN_EXAMPLE
   (spacemacs-layouts :variables
                      spacemacs-layouts-restricted-functions
-                     '(spacemacs/window-split-double-columns
+                     '(switch-to-next-buffer
+                       switch-to-prev-buffer
+                       spacemacs/window-split-double-columns
                        spacemacs/window-split-triple-columns
                        spacemacs/window-split-grid
                        my-func))
 #+END_EXAMPLE
+
+The changes apply after reloading your configuration with ~SPC f e R~
+or after restarting Spacemacs.
 
 ** Workspaces
 Workspaces are sub-layouts, they allow to define multiple layouts into a given

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -236,9 +236,6 @@
                 :before 'spacemacs//layout-wait-for-modeline)
     (when layouts-enable-local-variables
       (advice-add 'persp-switch :before #'spacemacs//load-layout-local-vars))
-    (dolist (fn spacemacs-layouts-restricted-functions)
-      (advice-add fn
-                  :around 'spacemacs-layouts//advice-with-persp-buffer-list))
     (spacemacs/declare-prefix "b" "persp-buffers")
     (spacemacs/set-leader-keys
       "ba"   'persp-add-buffer


### PR DESCRIPTION
This commit introduces a custom set function to make it possible to change `spacemacs-layouts-restricted-functions` without having to restart Spacemacs.

Additionally this commit changes the default value by adding `switch-to-next-buffer` and `switch-to-prev-buffer` (which are called by `next-buffer` and `previous-buffer`).

Note that this only changes the behaviour of these functions in the case when they do not find a buffer in `window-next-buffers` or `window-prev-buffers` and fall back to cycling through the buffer list. In particular, buffers from different layouts, which were previously (intentionally) displayed in the window could still show up when cycling with `SPC b p` and `SPC b n` after this change. (Though this is by default prevented with a buffer predicate, see the option `persp-set-frame-buffer-predicate`. I don't think that's a good default, and it is inconsistent in daemon mode, but this is a different story...)

In other words, the behaviour is only changed when cycling further than the window history, for example using `SPC b p` and `SPC b n` in a new window will no longer switch to buffers from different layouts.

Note that `switch-to-prev-buffer` can also get called by `quit-restore-window`, which is another instance where, previously, buffers from different layouts could show up unexpectedly.