### PR TITLE
[git] Fix breaking change in magit

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -34,7 +34,6 @@
     ;; include the old git{attributes,config,ignore}-mode
     git-modes
     gitignore-templates
-    git-commit
     git-link
     git-messenger
     git-timemachine
@@ -80,10 +79,6 @@
     :init (spacemacs/set-leader-keys
             "g/" 'helm-git-grep
             "g*" 'helm-git-grep-at-point)))
-
-(defun git/init-git-commit ()
-  (use-package git-commit
-    :defer t))
 
 (defun git/init-code-review ()
   (use-package code-review


### PR DESCRIPTION
The git-commit package was moved to magit, and needs to be uninstalled for magit to work. See
https://github.com/magit/magit/commit/c170fcf39918e567948fec43b70a592765ed5fe7.