### PR TITLE
[bootstrap] Prioritize all artist-mode bindings

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -242,23 +242,6 @@ column."
 
 
 
-(defun spacemacs/toggle-evil-mouse-drag-for-artist-mode (orig-fun &rest args)
-  "Toggle evil binding `evil-mode-drag-region' for `artist-mode'.
-
- When a buffer is placed into `artist-mode', <down-mouse-1> is supposed to
- bound to run the command `artist-down-mouse-1', while it is already bound
- to `evil-motion-state-map'. Thus it should be unbound so that mouse commands
- `down-mouse-1' operate correctly."
-  (let ((was-active artist-mode))
-    (apply orig-fun args)
-    (unless (eq was-active artist-mode)
-      (if artist-mode
-          (define-key evil-motion-state-map [down-mouse-1] nil)
-        (define-key evil-motion-state-map [down-mouse-1] 'evil-mouse-drag-region)))))
-
-
-
-
 (defun spacemacs/not-in-pdf-view-mode (orig-fun &rest args)
   "Disable bound function when in `pdf-view-mode'."
   (unless (eq major-mode 'pdf-view-mode)

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -146,7 +146,8 @@
     (define-key evil-visual-state-map "K" 'drag-stuff-up))
 
   ;; Fix broken artist-mode under evil-mode
-  (advice-add 'artist-mode :around #'spacemacs/toggle-evil-mouse-drag-for-artist-mode)
+  (with-eval-after-load 'artist
+    (evil-make-intercept-map artist-mode-map))
 
   ;; evil-refresh-cursor is called as part of the window-configuration-change-hook
   ;; and seems to induce performance problems


### PR DESCRIPTION
This is a follow-up to #16488. This commit handles all artist-mode bindings and does not mutate the global `evil-motion-state-map`.