### PR TITLE
agda mode - upgrade to mimer

### DIFF
--- a/layers/+lang/agda/packages.el
+++ b/layers/+lang/agda/packages.el
@@ -87,7 +87,7 @@
         ","   'agda2-goal-and-context
         "="   'agda2-show-constraints
         "SPC" 'agda2-give
-        "a"   agda2-auto
+        "a"   'agda2-mimer-maybe-all
         "c"   'agda2-make-case
         "d"   'agda2-infer-type-maybe-toplevel
         "e"   'agda2-show-context


### PR DESCRIPTION
agda2-auto does not exist (anymore?), the command to run is now `agda2-mimer-maybe-all`