### PR TITLE
spacemacs-whitespace-cleanup.el: Rewrite and fix toggling

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -648,7 +648,11 @@ Possible values are:
 `all' to aggressively delete empty lines and long sequences of whitespace,
 `trailing' to delete only the whitespace at end of lines,
 `changed' to delete only whitespace for changed lines or
-`nil' to disable cleanup."
+`nil' to disable cleanup.
+
+The variable `global-spacemacs-whitespace-cleanup-modes' controls
+which major modes have whitespace cleanup enabled or disabled
+by default."
   '(choice (const nil) (const all) (const trailing) (const changed))
   'spacemacs-dotspacemacs-init)
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -518,6 +518,9 @@ It should only modify the values of Spacemacs settings."
    ;; to aggressively delete empty line and long sequences of whitespace,
    ;; `trailing' to delete only the whitespace at end of lines, `changed' to
    ;; delete only whitespace for changed lines or `nil' to disable cleanup.
+   ;; The variable `global-spacemacs-whitespace-cleanup-modes' controls
+   ;; which major modes have whitespace cleanup enabled or disabled
+   ;; by default.
    ;; (default nil)
    dotspacemacs-whitespace-cleanup nil
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -470,14 +470,12 @@
     (spacemacs|add-toggle global-whitespace-cleanup
       :mode global-spacemacs-whitespace-cleanup-mode
       :status spacemacs-whitespace-cleanup-mode
-      :on (let ((spacemacs-whitespace-cleanup-globally t))
-            (spacemacs-whitespace-cleanup-mode))
-      :off (let ((spacemacs-whitespace-cleanup-globally t))
-             (spacemacs-whitespace-cleanup-mode -1))
       :on-message (spacemacs-whitespace-cleanup/on-message t)
       :documentation "Global automatic whitespace clean up."
       :evil-leader "t C-S-w")
     (with-eval-after-load 'ws-butler
+      ;; handle reloading configuration
+      (spacemacs/toggle-global-whitespace-cleanup-off)
       (when dotspacemacs-whitespace-cleanup
         (spacemacs/toggle-global-whitespace-cleanup-on)))
     :config


### PR DESCRIPTION
Fixes #8221.

The previous implementation had a non-standard structure that made it difficult to correctly implement toggling the minor mode locally and globally. Hence this commit rewrites the enabling/disabling mechanisms of the minor mode. Both local and global toggling with `SPC t W` and `SPC t C-S-w` should now work correctly.

As `ws-butler-global-mode` is not used anymore, users that customized `ws-butler-global-exempt-modes` need to customize `global-spacemacs-whitespace-cleanup-modes` instead. The default values are equivalent: `markdown-mode` is excluded.