### PR TITLE
[navigation] use symbol boundaries regexp for symbol search

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -78,7 +78,7 @@ This function has to handle both possible values of `evil-search-module':
   ;; would suffice here. However, the function in itself only
   ;; makes sense if there is a symbol at point, hence the `when-let*'.
   (when-let* ((symbol (thing-at-point 'symbol t))
-              (regexp (concat "\\<" symbol "\\>")))
+              (regexp (concat "\\_<" symbol "\\_>")))
     (setq isearch-string regexp
           isearch-regexp regexp
           evil-ex-search-pattern (evil-ex-make-search-pattern regexp))


### PR DESCRIPTION
Using '\<' generally works but in Python mode a symbol search works only the
first time, repeating the last search fails. Instead with the explicit symbol
boundary regexp, resuming a search will succeed also in Python mode.

To reproduce the bug before this commit try:

- open a buffer in `python-mode`
- search for the symbol at point ~SPC s h~
- quit the search
- try to resume with ~n~