### PR TITLE
[compleseus] Tweak `spacemacs/compleseus-switch-to-buffer`

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -39,8 +39,8 @@ the variable `spacemacs-layouts-restricted-functions'.")
 
 (defcustom compleseus-switch-to-buffer-sources
   `(consult--source-hidden-buffer
-    consult--source-persp-buffers
-    consult--source-modified-persp-buffers
+    compleseus--source-persp-buffers
+    compleseus--source-persp-modified-buffers
     consult--source-recent-file
     consult--source-bookmark
     consult--source-project-buffer-hidden
@@ -52,7 +52,7 @@ See `consult--multi' for a description
 of the source data structure."
   :type '(repeat symbol))
 
-(defvar consult--source-modified-persp-buffers
+(defvar compleseus--source-persp-modified-buffers
   `(:name "Modified Buffers"
           :narrow   (?* . "Modified Layout Buffers")
           :hidden   t
@@ -70,8 +70,10 @@ of the source data structure."
               ;; :directory 'project
               :as #'buffer-name)))
   "Per-perspective modified buffer source.")
+(define-obsolete-variable-alias 'consult--source-modified-persp-buffers
+  'compleseus--source-persp-modified-buffers "2024-09")
 
-(defvar consult--source-persp-buffers
+(defvar compleseus--source-persp-buffers
   `(
     :name     "Layout Buffers"
     :narrow   ?b
@@ -87,3 +89,5 @@ of the source data structure."
         :predicate #'compleseus//persp-contain-buffer-p
         :as #'buffer-name)))
   "Per-perspective buffer source.")
+(define-obsolete-variable-alias 'consult--source-persp-buffers
+  'compleseus--source-persp-buffers "2024-09")

--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -79,7 +79,7 @@ and with narrowing key \"B\".")
                                 (buffer-file-name buff)
                                 (buffer-modified-p buff)))
               ;; :directory 'project
-              :as #'buffer-name)))
+              :as #'consult--buffer-pair)))
   "Per-perspective modified buffer source.")
 (define-obsolete-variable-alias 'consult--source-modified-persp-buffers
   'compleseus--source-persp-modified-buffers "2024-09")
@@ -98,7 +98,7 @@ and with narrowing key \"B\".")
        (consult--buffer-query
         :sort 'visibility
         :predicate #'compleseus//persp-contain-buffer-p
-        :as #'buffer-name)))
+        :as #'consult--buffer-pair)))
   "Per-perspective buffer source.")
 (define-obsolete-variable-alias 'consult--source-persp-buffers
   'compleseus--source-persp-buffers "2024-09")

--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -37,6 +37,21 @@ of the current project only when a prefix argument is used.
 To restrict the commands to buffers of the current layout, customize
 the variable `spacemacs-layouts-restricted-functions'.")
 
+(defcustom compleseus-switch-to-buffer-sources
+  `(consult--source-hidden-buffer
+    consult--source-persp-buffers
+    consult--source-modified-persp-buffers
+    consult--source-recent-file
+    consult--source-bookmark
+    consult--source-project-buffer-hidden
+    consult--source-project-recent-file-hidden)
+  "Sources used by `spacemacs/compleseus-switch-to-buffer'
+when persp-mode is used.
+See also `consult-buffer-sources'.
+See `consult--multi' for a description
+of the source data structure."
+  :type '(repeat symbol))
+
 (defvar consult--source-modified-persp-buffers
   `(:name "Modified Buffers"
           :narrow   (?* . "Modified Layout Buffers")

--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -39,6 +39,7 @@ the variable `spacemacs-layouts-restricted-functions'.")
 
 (defcustom compleseus-switch-to-buffer-sources
   `(consult--source-hidden-buffer
+    compleseus--source-buffers-hidden
     compleseus--source-persp-buffers
     compleseus--source-persp-modified-buffers
     consult--source-recent-file
@@ -51,6 +52,16 @@ See also `consult-buffer-sources'.
 See `consult--multi' for a description
 of the source data structure."
   :type '(repeat symbol))
+
+(defvar compleseus--source-buffers-hidden nil
+  "Like `consult--source-buffer' but hidden by default
+and with narrowing key \"B\".")
+(with-eval-after-load 'consult
+  (setq compleseus--source-buffers-hidden
+        `(:name "Buffers (all layouts)"
+          :hidden t
+          :narrow (?B . "Buffers")
+          ,@consult--source-buffer)))
 
 (defvar compleseus--source-persp-modified-buffers
   `(:name "Modified Buffers"

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -49,14 +49,9 @@ non-nil."
 (defun spacemacs/compleseus-switch-to-buffer ()
   "`consult-buffer' with buffers provided by persp."
   (interactive)
-  (consult-buffer
-   `(consult--source-hidden-buffer
-     consult--source-persp-buffers
-     consult--source-modified-persp-buffers
-     consult--source-recent-file
-     consult--source-bookmark
-     consult--source-project-buffer-hidden
-     consult--source-project-recent-file-hidden)))
+  (consult-buffer (if (configuration-layer/package-used-p 'persp-mode)
+                      compleseus-switch-to-buffer-sources
+                    consult-buffer-sources)))
 
 (defun spacemacs/initial-search-input (&optional force-input)
   "Get initial input from region for consult search functions. If region is not


### PR DESCRIPTION
- Introduce customization variable `compleseus-switch-to-buffer-sources`.
- Rename custom sources with compleseus prefix to follow conventions and avoid confusion with sources defined by consult.
- Add a hidden source for all buffers (from all layouts).
- Use `consult--buffer-pair` as upstream in `consult` (bugfix), see https://github.com/minad/consult/commit/ec232fa60497e7a3abcf6e385181afcc0cf6017f.
