### PR TITLE
[defaults] Add transient state for `winner-undo` and `winner-redo`

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -2370,7 +2370,6 @@ Windows manipulation commands (start with ~w~):
 | ~SPC w s~ or ~SPC w -~ | horizontal split                                                         |
 | ~SPC w S~              | horizontal split and focus new window                                    |
 | ~SPC w u~              | undo window layout (used to effectively undo a closed window)            |
-| ~SPC w U~              | redo window layout                                                       |
 | ~SPC w v~ or ~SPC w /~ | vertical split                                                           |
 | ~SPC w V~              | vertical split and focus new window                                      |
 | ~SPC w w~              | cycle and focus between windows                                          |

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -678,8 +678,7 @@ respond to this toggle."
   "ws"  'split-window-below
   "wS"  'split-window-below-and-focus
   "w-"  'split-window-below
-  "wU"  'winner-redo
-  "wu"  'winner-undo
+  "wu"  'spacemacs/winner-transient-state/winner-undo
   "wv"  'split-window-right
   "wV"  'split-window-right-and-focus
   "ww"  'other-window

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -492,6 +492,11 @@
   (use-package winner
     :commands (winner-undo winner-redo)
     :init
+    (spacemacs|define-transient-state winner
+      :title "Winner transient state"
+      :bindings
+      ("u" winner-undo "winner-undo")
+      ("U" winner-redo "winner-redo (redo all)"))
     (setq spacemacs/winner-boring-buffers '("*Completions*"
                                             "*Compile-Log*"
                                             "*inferior-lisp*"


### PR DESCRIPTION
`winner-undo` is often used repeatedly, and `winner-redo` can only be invoked immediately after undoing. Hence <kbd>SPC w u</kbd> now enters a transient state, and the <kbd>SPC w U</kbd> binding is removed in favour of the transient state <kbd>U</kbd> binding.
