### PR TITLE
[compleseus] Add window and workspace buffer sources

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -38,14 +38,16 @@ To restrict the commands to buffers of the current layout, customize
 the variable `spacemacs-layouts-restricted-functions'.")
 
 (defcustom compleseus-switch-to-buffer-sources
-  `(consult--source-hidden-buffer
+  '(consult--source-hidden-buffer
     compleseus--source-buffers-hidden
     compleseus--source-persp-buffers
     compleseus--source-persp-modified-buffers
     consult--source-recent-file
     consult--source-bookmark
     consult--source-project-buffer-hidden
-    consult--source-project-recent-file-hidden)
+    consult--source-project-recent-file-hidden
+    compleseus--source-window-buffers
+    compleseus--source-workspace-buffers)
   "Sources used by `spacemacs/compleseus-switch-to-buffer'
 when persp-mode is used.
 See also `consult-buffer-sources'.
@@ -102,3 +104,65 @@ and with narrowing key \"B\".")
   "Per-perspective buffer source.")
 (define-obsolete-variable-alias 'consult--source-persp-buffers
   'compleseus--source-persp-buffers "2024-09")
+
+(defvar compleseus--source-window-buffers
+  `(:name     "Window Buffer"
+    :hidden   t
+    :narrow   ?w
+    :category buffer
+    :face     consult-buffer
+    :history  buffer-name-history
+    :state    ,#'consult--buffer-state
+    :default  t
+    :items
+    ,(lambda ()
+       (let* ((prev-buffers (delq (window-buffer) (mapcar #'car (window-prev-buffers))))
+              (next-buffers (window-next-buffers))
+              (buffers
+               (if vertico-cycle
+                   ;; If cycling is enabled, this order makes sense:
+                   ;; One can move down to previous buffers,
+                   ;; and move up to next buffers.
+                   (append (list (window-buffer))
+                           (seq-difference prev-buffers next-buffers)
+                           (nreverse next-buffers))
+                 ;; Note that next-buffers is a subset of prev-buffers.
+                 (cons (window-buffer) prev-buffers))))
+         (consult--buffer-query
+          :sort nil
+          :filter nil
+          :as #'consult--buffer-pair
+          :buffer-list buffers))))
+  "Window buffer source for `consult-buffer'.
+It contains all buffers previously displayed in the selected
+window, including buffers from different layouts and hidden
+buffers.")
+
+(defvar compleseus--source-workspace-buffers
+  `(:name     "Workspace Buffer"
+    :hidden   t
+    :narrow   ?k
+    :category buffer
+    :face     consult-buffer
+    :history  buffer-name-history
+    :state    ,#'consult--buffer-state
+    :default  t
+    :items
+    ,(lambda ()
+       (let (prev-buffers)
+         (walk-windows
+          (lambda (win)
+            (setq prev-buffers
+                  (append (mapcar #'car (window-prev-buffers win))
+                          prev-buffers)))
+          'no-minibuffer)
+         (consult--buffer-query
+          :sort 'visibility
+          :filter nil
+          :as #'consult--buffer-pair
+          :predicate (lambda (buf)
+                       (member buf prev-buffers))))))
+  "Workspace buffer source for `consult-buffer'.
+It contains all buffers previously displayed in a live window of
+the current window configuration, including buffers from
+different layouts and hidden buffers.")

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -204,6 +204,8 @@
     ;; Configure other variables and modes in the :config section,
     ;; after lazily loading the package.
     :config
+    (add-to-list 'consult-buffer-sources 'compleseus--source-window-buffers)
+    (add-to-list 'consult-buffer-sources 'compleseus--source-workspace-buffers)
 
     ;; disable automatic preview by default,
     ;; selectively enable it for some prompts below.


### PR DESCRIPTION
Additional sources for `spacemacs/compleseus-switch-to-buffer` and `consult-buffer`:
- New source "Window Buffer": shows all buffers previously displayed in the selected window (including hidden buffers and buffers from other layouts), hidden by default.
- New source "Workspace Buffer": shows all buffer previously displayed in all live windows of the current window configuration, hidden by default.
