### PR TITLE
[editing-visual] Fix problems with term-cursor in daemon mode

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/funcs.el
@@ -25,3 +25,10 @@
   (interactive)
   (spacemacs/toggle-centered-buffer-on)
   (spacemacs/centered-buffer-transient-state/body))
+
+(defun spacemacs//maybe-enable-term-cursor ()
+  "Enable `global-term-cursor-mode' when a first terminal frame is created."
+  (unless (or (display-graphic-p)
+              (bound-and-true-p global-term-cursor-mode))
+    (global-term-cursor-mode)
+    (remove-hook 'server-after-make-frame-hook 'spacemacs//maybe-enable-term-cursor)))

--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -151,9 +151,12 @@
 (defun spacemacs-editing-visual/init-term-cursor ()
   (use-package term-cursor
     :defer t
+    :custom (term-cursor-triggers '(blink-cursor-mode-hook))
     :init
-    (unless (display-graphic-p)
-     (global-term-cursor-mode))))
+    (unless (or (daemonp) (display-graphic-p))
+      (global-term-cursor-mode))
+    (when (or (daemonp) dotspacemacs-enable-server)
+      (add-hook 'server-after-make-frame-hook 'spacemacs//maybe-enable-term-cursor))))
 
 (defun spacemacs-editing-visual/init-volatile-highlights ()
   (use-package volatile-highlights


### PR DESCRIPTION
Remove `lsp-ui-doc-frame-hook` from `term-cursor-triggers` to fix #15667. The hook is run with two arguments, but the handler function `term-cursor--immediate` does not expect any. (It can be added back in case https://github.com/denrat/term-cursor.el/pull/5 is merged and if it is still deemed necessary.)

Also do not enable `global-term-cursor-mode` in daemon mode unless a terminal frame is created.