### PR TITLE
* core/core-configuration-layer.el: Avoid duplicate loading dependency layer

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1519,7 +1519,8 @@ If `SKIP-LAYER-DEPS' is non nil then skip loading of layer dependenciesl"
   (dolist (x layer-names)
     (unless (member x configuration-layer--layers-dependencies)
       (add-to-list 'configuration-layer--layers-dependencies x)
-      (configuration-layer//load-layer-files x '("layers")))))
+      (unless configuration-layer--declared-layers-usedp
+        (configuration-layer//load-layer-files x '("layers"))))))
 
 (defun configuration-layer//declare-used-layers (layers-specs)
   "Declare used layers from LAYERS-SPECS list."
@@ -1541,8 +1542,10 @@ If `SKIP-LAYER-DEPS' is non nil then skip loading of layer dependenciesl"
             (reverse configuration-layer--used-layers)))
     ;; declare additional layer required by used layers
     ;; this layers will be at the beginning of `configuration-layer--used-layers'
-    (dolist (layer-name configuration-layer--layers-dependencies)
-      (configuration-layer/declare-layer layer-name))
+    (let ((ulayers (mapcar (lambda (x) (if (listp x) (car x) x)) layers-specs)))
+      (dolist (layer-name configuration-layer--layers-dependencies)
+        (unless (member layer-name ulayers)
+          (configuration-layer/declare-layer layer-name))))
     ;; distribution and bootstrap layers are always first
     (let ((distribution (if configuration-layer-force-distribution
                             configuration-layer-force-distribution


### PR DESCRIPTION
Hi,
The dependency layers `json` was loaded TWICE when simply enable a `javascript` layer.
```elisp
   dotspacemacs-configuration-layers '(javascript)
```
It caused by declaring `javascript` layer with `configuration-layer//declare-used-layers` will trigger declare `json` layer as dependency layer, and back to the function `configuration-layer//declare-used-layers` it will try declaring the dependency layers, which loading the `json` layer again.
All other dependent layers has similar issue.
```
configuration-layer//declare-used-layers
  |-> configuration-layer/declare-layer
  |  -> configuration-layer//load-layer-files "javascript"  "layer"
  |     -> load("layers/+lang/javascript/layer.el")
  |        -> configuration-layer/declare-layers ("json"), load the "json" layer and adding the "json" into configuration-layer--layers-dependencies
  |-> (dolist (layer-name configuration-layer--layers-dependencies) ; loading "json" layer again
          (configuration-layer/declare-layer layer-name)))
```

This patch will
1. postponed loading dependency layer to avoid duplicate loading,
2. Avoid loading the dependency layer which in `layers-specs` / `dotspacemacs-configuration-layers`