### PR TITLE
*layers/+tools/systemd/packages.el: lazy load journalctl package

### DIFF
--- a/layers/+tools/systemd/packages.el
+++ b/layers/+tools/systemd/packages.el
@@ -42,7 +42,7 @@
 
 (defun systemd/init-journalctl-mode ()
   (use-package journalctl-mode
-    :ensure t
+    :commands (journalctl)
     :init
     (spacemacs/set-leader-keys
       "atj" 'journalctl)))


### PR DESCRIPTION
Hi, 
The listed command lines will be called at startup when enable the `systemd` layer.
```
6 matches for "shell-command-to-string" in buffer: journalctl-mode.el
    154:   (shell-command-to-string "systemctl list-units --all --quiet | sed -e 's/●/ /g' | awk '{print $1}'")
    160:   (shell-command-to-string "systemctl list-units --all --quiet --user | sed -e 's/●/ /g' | awk '{print $1}'")
    166:   (shell-command-to-string "journalctl --list-boots | awk '{print $1}'")
    230:   (shell-command-to-string "journalctl --fields")
    236:   (shell-command-to-string "journalctl --facility=help")
```
It caused by the `journalctl-mode.el` will initialize the variables with these shell commands.

This patch will make the `journalctl-mode.el` be lazy loading.