### PR TITLE
[evil] Fix `evil-lisp-state` undo/redo bindings

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -232,6 +232,9 @@
       :override-minor-modes t
       :override-mode-name spacemacs-leader-override-mode)
 
+    (define-key evil-lisp-state-map "u" 'evil-undo)
+    (define-key evil-lisp-state-map (kbd "C-r") 'evil-redo)
+
     (spacemacs/set-leader-keys "k" evil-lisp-state-map)
     (spacemacs/declare-prefix
       "k" "lisp"


### PR DESCRIPTION
(Also submitted upstream in
https://github.com/syl20bnr/evil-lisp-state/pull/49.)