### PR TITLE
[editing] Enable `undo-fu-ignore-keyboard-quit`

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -563,7 +563,8 @@ See variable `undo-tree-history-directory-alist'." dir))
   (use-package undo-fu
     :defer t
     :custom
-    (undo-fu-allow-undo-in-region t)))
+    (undo-fu-allow-undo-in-region t)
+    (undo-fu-ignore-keyboard-quit t)))
 
 (defun spacemacs-editing/init-undo-fu-session ()
   (use-package undo-fu-session


### PR DESCRIPTION
With `undo-fu-ignore-keyboard-quit` set to nil, the unconstrained undo can easily be accidentally activated by undoing after a previous `C-g` press. This can be quite confusing. Also, we have vundo (or explicit calls to `undo-fu-disable-checkpoint`) as an alternative.