### PR TITLE
[latex] Correctly set `pdf-sync-forward-display-action`

### DIFF
--- a/layers/+lang/latex/config.el
+++ b/layers/+lang/latex/config.el
@@ -40,7 +40,10 @@ output-pdf viewer in `TeX-view-program-selection'.")
 
 (defvar latex-view-pdf-in-split-window nil
   "If non-nil then open pdf in split window.
-Requires pdf-tools to be configured as output-pdf viewer.")
+Requires pdf-tools to be configured as output-pdf viewer.
+
+If the window splits vertically, but is intended to split
+horizontally, consider lowering the value of `split-width-threshold'.")
 
 (defvar latex-backend (if (configuration-layer/layer-used-p 'lsp) 'lsp 'company-auctex)
   "The backend to use for IDE features.

--- a/layers/+lang/latex/funcs.el
+++ b/layers/+lang/latex/funcs.el
@@ -62,7 +62,8 @@
         (progn
           (setf (alist-get 'output-pdf TeX-view-program-selection) '("PDF Tools"))
           (when latex-view-pdf-in-split-window
-            (setq pdf-sync-forward-display-action t)))
+            (setq pdf-sync-forward-display-action
+                  '(nil . ((inhibit-same-window . t))))))
       (spacemacs-buffer/warning "Latex Layer: latex-view-with-pdf-tools is non-nil but pdf layer is not installed, this setting will have no effect."))))
 
 (defun latex/build ()


### PR DESCRIPTION
The custom type of this variable is `display-buffer--action-custom-type`, but
the latex layer sets it to `t`. This commit sets it to an equivalent valid
display-buffer action. (According to the docstring of `display-buffer`,
non-interactive calls should nowadays always supply a list or nil.)