### PR TITLE
[compleseus] Disable automatic preview by default

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -152,6 +152,9 @@
 
     ;; The :init configuration is always executed (Not lazy)
     :init
+    ;; disable automatic preview by default
+    (setq consult-preview-key '("M-." "C-SPC" "C-M-j" "C-M-k"))
+
     (define-key read-expression-map (kbd "C-r") #'consult-history)
     (spacemacs/set-leader-keys
       dotspacemacs-emacs-command-key 'execute-extended-command
@@ -207,28 +210,11 @@
     (add-to-list 'consult-buffer-sources 'compleseus--source-window-buffers)
     (add-to-list 'consult-buffer-sources 'compleseus--source-workspace-buffers)
 
-    ;; disable automatic preview by default,
-    ;; selectively enable it for some prompts below.
-    (setq consult-preview-key '("M-." "C-SPC"))
-
     ;; customize preview activation and delay while selecting candiates
     (consult-customize
      consult-theme
      spacemacs/theme-loader
-     :preview-key '("M-." "C-SPC"
-                    :debounce 0.2 any)
-
-     ;; slightly delayed preview upon candidate selection
-     ;; one usually wants quick feedback
-     consult-buffer
-     consult-ripgrep
-     consult-git-grep
-     consult-grep
-     consult-bookmark
-     consult-yank-pop
-     :preview-key '("M-." "C-SPC"
-                    :debounce 0.3 "<up>" "<down>" "C-n" "C-p"
-                    :debounce 0.6 any))
+     :preview-key '(:debounce 0.2 any))
 
     ;; hide magit buffer
     (add-to-list 'consult-buffer-filter "magit.*:.*")


### PR DESCRIPTION
Keep it only for theme selection. For almost all other commands automatic preview was already disabled by default. Instead of enabling it for a few other seemingly arbitrary commands, I think it makes more sense to leave this to users to customize. 

Moving the `consult-preview-key` customization to the init block allows overriding it in the dotfile without using `spacemacs|use-package-add-hook` or `with-eval-after-load`.

Also make `C-M-j` and `C-M-k` preview without delay in consult commands (they already do that for other commands).
