### PR TITLE
[mu4e] Use mu4e by default for more things

### DIFF
--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -31,7 +31,7 @@
   "Binding used in the setup for `spacemacs-layouts' micro-state")
 
 (defvar mu4e-spacemacs-kill-layout-on-exit t
-  "When `t` exiting mu4e app will automatically kill its layout")
+  "When non-nil, exiting mu4e app will automatically kill its layout")
 
 (defvar mu4e-enable-async-operations nil
   "Prefer async operations when sending emails.")
@@ -61,7 +61,7 @@
   "If non-nil org-mu4e is configured.")
 
 (defvar mu4e-autorun-background-at-startup nil
-  "If non-nil, mu4e will automatically run in background at emacs startup.")
+  "If non-nil, mu4e will automatically run in background at Emacs startup.")
 
 (when mu4e-installation-path
   (add-to-list 'load-path mu4e-installation-path))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -22,9 +22,8 @@
 
 
 (defconst mu4e-packages
-  '(
-    (mu4e :location site)
-    mu4e-alert
+  '((mu4e :location site)
+    (mu4e-alert :toggle (or mu4e-enable-notifications mu4e-enable-mode-line))
     (helm-mu :requires helm)
     org
     persp-mode

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -55,13 +55,13 @@
     :commands (mu4e mu4e-compose-new)
     :init
     (spacemacs/set-leader-keys "aem" 'mu4e)
-    (global-set-key (kbd "C-x m") 'mu4e-compose-new)
-    (setq mu4e-completing-read-function 'completing-read
-          mu4e-use-fancy-chars 't
-          mu4e-view-show-images 't
-          message-kill-buffer-on-exit 't
+    (setq mail-user-agent 'mu4e-user-agent
+          mu4e-completing-read-function 'completing-read
+          mu4e-use-fancy-chars t
+          mu4e-view-show-images t
+          message-kill-buffer-on-exit t
           mu4e-org-support nil)
-    (let ((dir "~/Downloads"))
+    (let ((dir "~/Downloads/"))
       (when (file-directory-p dir)
         (setq mu4e-attachment-dir dir)))
 

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -56,6 +56,7 @@
     :init
     (spacemacs/set-leader-keys "aem" 'mu4e)
     (setq mail-user-agent 'mu4e-user-agent
+          read-mail-command 'mu4e
           mu4e-completing-read-function 'completing-read
           mu4e-use-fancy-chars t
           mu4e-view-show-images t

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -153,36 +153,34 @@
               "C" 'helm-mu-contacts))))
 
 (defun mu4e/pre-init-org ()
-  (if mu4e-org-link-support
-      (with-eval-after-load 'org
-        ;; This is a dirty hack due to mu(4e) 1.8.2 renaming mu4e-meta to
-        ;; mu4e-config.  See also
-        ;; https://github.com/djcb/mu/commit/cf0f72e4a48ac7029d7f6758b182d4bb559f8f49
-        ;; and https://github.com/syl20bnr/spacemacs/issues/15618.  This code
-        ;; used to simply read: (require 'mu4e-meta).  We now attempt to load
-        ;; mu4e-config.  If this fails, load mu4e-meta.
-        (unless (ignore-errors (require 'mu4e-config))
-          (require 'mu4e-meta))
-        (if (version<= mu4e-mu-version "1.3.5")
-            (require 'org-mu4e)
-          (require 'mu4e-org))
-        ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
-        ;; Note that this bug prevents lazy-loading.
-        (if (version<= mu4e-mu-version "1.4.15")
-            (require 'mu4e))))
-  (if mu4e-org-compose-support
-      (progn
-        (spacemacs/set-leader-keys-for-major-mode 'mu4e-compose-mode
-          "o" 'org-mu4e-compose-org-mode)
-        (autoload 'org-mu4e-compose-org-mode "org-mu4e")
-        )))
+  (when mu4e-org-link-support
+    (with-eval-after-load 'org
+      ;; This is a dirty hack due to mu(4e) 1.8.2 renaming mu4e-meta to
+      ;; mu4e-config.  See also
+      ;; https://github.com/djcb/mu/commit/cf0f72e4a48ac7029d7f6758b182d4bb559f8f49
+      ;; and https://github.com/syl20bnr/spacemacs/issues/15618.  This code
+      ;; used to simply read: (require 'mu4e-meta).  We now attempt to load
+      ;; mu4e-config.  If this fails, load mu4e-meta.
+      (unless (require 'mu4e-config nil t)
+        (require 'mu4e-meta))
+      (if (version<= mu4e-mu-version "1.3.5")
+          (require 'org-mu4e)
+        (require 'mu4e-org))
+      ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
+      ;; Note that this bug prevents lazy-loading.
+      (when (version<= mu4e-mu-version "1.4.15")
+        (require 'mu4e))))
+  (when mu4e-org-compose-support
+    (spacemacs/set-leader-keys-for-major-mode 'mu4e-compose-mode
+      "o" 'org-mu4e-compose-org-mode)
+    (autoload 'org-mu4e-compose-org-mode "org-mu4e")))
 
 (defun mu4e/post-init-window-purpose ()
   (let ((modes))
     (dolist (mode mu4e-list-modes)
-      (add-to-list 'modes (cons mode 'mail)))
+      (push (cons mode 'mail) modes))
     (dolist (mode mu4e-view-modes)
-      (add-to-list 'modes (cons mode 'mail-view)))
+      (push (cons mode 'mail-view) modes))
     (purpose-set-extension-configuration
      :mu4e-layer
      (purpose-conf :mode-purposes modes))))


### PR DESCRIPTION
In addition to some refactors, this improves the behavior by making any command that tries to send an email (such as `M-x report-emacs-bug`) use mu4e when the layer is enabled, not just the `C-x m` key binding.