### PR TITLE
[core] Fix `spacemacs/alternate-buffer` for other windows

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -347,7 +347,7 @@ only switches between the current layout's buffers."
                       (and (not (eq buffer my-buffer))
                            (funcall usefulp buffer)
                            (funcall predicate buffer))))
-                  (window-prev-buffers)
+                  (window-prev-buffers window)
                   default))
     (if (not buf)
         (message "Last buffer not found.")


### PR DESCRIPTION
According to its docstring, `(spacemacs/alternate-buffer window)` should switch between the current and last buffer in WINDOW. Previously, it switched between the `(window-buffer window)` and the last buffer of the selected window, which does not seem intended.