### PR TITLE
[layouts] Fix loading workspaces in case scratch buffer was killed 

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1730,22 +1730,27 @@ a split-side entry, its value must be usable as the SIDE argument for
       (switch-to-buffer (help-buffer))
     (message "No previous Help buffer found")))
 
+(defun spacemacs//get-scratch-buffer-create ()
+  (or (get-buffer "*scratch*")
+      (let ((scratch (get-buffer-create "*scratch*")))
+        (with-current-buffer scratch
+          (add-hook 'kill-buffer-hook
+                    #'spacemacs//confirm-kill-buffer
+                    nil t)
+          (when (and (not (eq major-mode dotspacemacs-scratch-mode))
+                     (fboundp dotspacemacs-scratch-mode))
+            (funcall dotspacemacs-scratch-mode)
+            (run-hooks 'spacemacs-scratch-mode-hook)))
+        scratch)))
+
 (defun spacemacs/switch-to-scratch-buffer (&optional arg)
   "Switch to the `*scratch*' buffer, creating it first if needed.
 if prefix argument ARG is given, switch to it in an other, possibly new window."
   (interactive "P")
-  (let ((exists (get-buffer "*scratch*")))
+  (let ((scratch (spacemacs//get-scratch-buffer-create)))
     (if arg
-        (switch-to-buffer-other-window (get-buffer-create "*scratch*"))
-      (switch-to-buffer (get-buffer-create "*scratch*")))
-    (when (not exists)
-      (add-hook 'kill-buffer-hook
-                #'spacemacs//confirm-kill-buffer
-                nil t)
-      (when (and (not (eq major-mode dotspacemacs-scratch-mode))
-                 (fboundp dotspacemacs-scratch-mode))
-        (funcall dotspacemacs-scratch-mode)
-        (run-hooks 'spacemacs-scratch-mode-hook)))))
+        (switch-to-buffer-other-window scratch)
+      (switch-to-buffer scratch))))
 
 (defvar spacemacs--killed-buffer-list nil
   "List of recently killed buffers.")

--- a/layers/+spacemacs/spacemacs-layouts/packages.el
+++ b/layers/+spacemacs/spacemacs-layouts/packages.el
@@ -112,7 +112,20 @@
                 #'spacemacs/load-eyebrowse-after-loading-layout))
     ;; vim-style tab switching
     (define-key evil-motion-state-map "gt" 'eyebrowse-next-window-config)
-    (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config)))
+    (define-key evil-motion-state-map "gT" 'eyebrowse-prev-window-config)
+    ;; ensure scratch buffer is live, otherwise loading workspaces can fail silently
+    (unless dotspacemacs-scratch-buffer-unkillable
+      (define-advice eyebrowse--fixup-window-config
+          (:after (window-config) spacemacs//maybe-create-scratch-buffer)
+        (unless (get-buffer "*scratch*")
+          (catch 'found
+            (eyebrowse--walk-window-config
+             window-config
+             (lambda (item)
+               (when (and (eq (car item) 'buffer)
+                          (equal (cadr item) "*scratch*"))
+                 (spacemacs//get-scratch-buffer-create)
+                 (throw 'found t))))))))))
 
 
 


### PR DESCRIPTION
If a buffer from an eyebrowse window config is not live, restoring this window configuration will fail silently. Hence eyebrowse replaces killed buffers with the scratch buffer before loading window configurations.

However, the scratch buffer itself can be killed. In that case any window configuration containing it, or containing killed buffers will fail to load. Thus we need to ensure that the scratch buffer is live when necessary.

(I will report this to the package author as well, eyebrowse does not have a public issue tracker. Though even if it gets fixed upstream we will still need some sort of advice, because the scratch buffer creation logic in Spacemacs differs from vanilla Emacs.)


