### PR TITLE
Updating macOS installation instructions in `README.md`

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3998,6 +3998,8 @@ files (thanks to Daniel Nicolai)
     - Added documentation for navigating to next source in helm-find-file
       (thanks to Lucas Leblow)
   - README.md:
+    - Updated macOS documentation with the requirement to have the latest version of Xcode Command
+      Line Tools installed to install Emacs Plus (thanks to James Yoo)
     - Fixed macOS documentation to install fonts (thanks to Sergio Morales)
     - Updated Windows section, suggest official Emacs (thanks to ghost-420)
     - Fixed dead link for creating a Spacemacs.desktop file with the Spacemacs icon (thanks to cpaulik)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ Last but not least there are a lot of high class tutorials available on YouTube:
       brew install emacs-plus --with-spacemacs-icon --with-native-comp
       ```
 
+      You will require the latest version of Xcode Command Line tools, which can be
+      downloaded from the [Apple Developer Portal](https://developer.apple.com/download/all/)
+      or by running the following command:
+
+      ```sh
+      softwareupdate --all --install --force
+      ```
+
    2. [Emacs Mac Port][] adds native GUI support to Emacs 28. And the full list
       of features is available [here][Emacs Mac Port features].
 


### PR DESCRIPTION
It appears to be the case that installing Emacs Plus requires the latest version of the Xcode Command Line Tools.

Below is the output of running: `brew install emacs-plus --with-spacemacs-icon --with-native-comp`

```
==> Installing emacs-plus@29 from d12frosted/emacs-plus
Error: Your Command Line Tools are too outdated.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 16.0.

yoo@lazarus ~ % pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
package-id: com.apple.pkg.CLTools_Executables
version: 15.3.0.0.1.1708646388
```
This PR updates the installation documentation for macOS with the note to have the latest version of the Xcode Command Line Tools installed.