### PR TITLE
[spacemacs-editing] Fix string-edit-at-point key bindings

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -509,10 +509,10 @@
     (spacemacs/set-leader-keys "xe" 'string-edit-at-point)
     :config
     (spacemacs/set-leader-keys-for-minor-mode 'string-edit-at-point-mode
-      "," 'string-edit-conclude
-      "c" 'string-edit-conclude
-      "a" 'string-edit-abort
-      "k" 'string-edit-abort)))
+      "," 'string-edit-at-point-conclude
+      "c" 'string-edit-at-point-conclude
+      "a" 'string-edit-at-point-abort
+      "k" 'string-edit-at-point-abort)))
 
 (defun spacemacs-editing/init-multi-line ()
   (use-package multi-line


### PR DESCRIPTION
#15803 fixed the use of the wrong package name, but the commands were
also renamed.