### PR TITLE
Add extra wgrep functions to keymap.

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -54,15 +54,18 @@ like below to use =selectrum= as opposed to the default of =vertico=:
 
 ** Edit consult buffer
 
-| Key binding            | Description                                                                    |
-|------------------------+--------------------------------------------------------------------------------|
-| ~C-c C-e~              | Export consult buffer to a grep buffer and make it editable right away         |
-| ~M-o E~                | Export consult buffer to a new buffer (usually grep)                           |
-| ~SPC m w~              | Toggle the exported buffer to be editable or read-only when it's a grep buffer |
-| ~SPC m ,~ or ~SPC m c~ | Apply/Commit changes made in the exported buffer                               |
-| ~SPC m a~ or ~SPC m k~ | Abort/Kill changes made in the exported buffer                                 |
-| ~SPC m q~              | Abort/Kill changes made in the exported buffer and close the buffer            |
-| ~SPC m s~              | Apply and =save= changes made in the exported buffer and close the buffer      |
+| Key binding            | Description                                                                                                      |
+|------------------------+------------------------------------------------------------------------------------------------------------------|
+| ~C-c C-e~              | Export consult buffer to a grep buffer and make it editable right away                                           |
+| ~M-o E~                | Export consult buffer to a new buffer (usually grep)                                                             |
+| ~SPC m w~              | Toggle the exported buffer to be editable or read-only when it's a grep buffer                                   |
+| ~SPC m ,~ or ~SPC m c~ | Apply/Commit changes made in the exported buffer                                                                 |
+| ~SPC m a~ or ~SPC m k~ | Abort/Kill changes made in the exported buffer                                                                   |
+| ~SPC m q~              | Abort/Kill changes made in the exported buffer and close the buffer                                              |
+| ~SPC m s~              | Apply and =save= changes made in the exported buffer and close the buffer                                        |
+| ~SPC m r~              | Toggle the read-only area (allowing you to remove lines from the wgrep buffer, won't be removed from the file)   |
+| ~SPC m d~              | Mark the line to be deleted from the file                                                                        |
+| ~SPC m f~              | Enable next-error-follow-minor-mode which will show previews of what you have under the cursor for a grep buffer |
 
 Note: ~SPC m s~ actually saves the changes on disk when the changed lines belong
 to a buffer visiting a file. ~SPC m ,~ and ~SPC m c~ do not save the changes on

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -473,7 +473,8 @@
 
 (defun compleseus/post-init-grep ()
   (spacemacs/set-leader-keys-for-major-mode 'grep-mode
-    "w" 'spacemacs/compleseus-grep-change-to-wgrep-mode))
+    "w" 'spacemacs/compleseus-grep-change-to-wgrep-mode
+    "f" 'next-error-follow-minor-mode))
 
 (defun compleseus/init-wgrep ()
   (evil-define-key 'normal wgrep-mode-map ",," #'spacemacs/wgrep-finish-edit)
@@ -481,7 +482,11 @@
   (evil-define-key 'normal wgrep-mode-map ",a" #'spacemacs/wgrep-abort-changes)
   (evil-define-key 'normal wgrep-mode-map ",k" #'spacemacs/wgrep-abort-changes)
   (evil-define-key 'normal wgrep-mode-map ",q" #'spacemacs/wgrep-abort-changes-and-quit)
-  (evil-define-key 'normal wgrep-mode-map ",s" #'spacemacs/wgrep-save-changes-and-quit))
+  (evil-define-key 'normal wgrep-mode-map ",s" #'spacemacs/wgrep-save-changes-and-quit)
+  (evil-define-key 'normal wgrep-mode-map ",r" #'wgrep-toggle-readonly-area)
+  (evil-define-key 'normal wgrep-mode-map ",d" #'wgrep-mark-deletion)
+  (evil-define-key 'normal wgrep-mode-map ",f" #'next-error-follow-minor-mode)
+  )
 
 (defun compleseus/init-compleseus-spacemacs-help ()
   (use-package compleseus-spacemacs-help


### PR DESCRIPTION
Add three extra commands to the wgrep keymap.

Sometimes it's nice to export a grep buffer, and then explore all of the matches. The ability to remove unrelated lines after you've exported it (toggling the read-only area), and easily flip on next-error-follow-minor-mode helps with that.

Also, if you've got a wgrep buffer, sometimes it's nice to actually delete the lines that are matched, and that's what the third keybinding (marking the line for deletion) is useful for.
