### PR TITLE
Add function for toggling compleseus previews.

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -10,6 +10,7 @@
     - [[#completion-engine][Completion engine]]
 - [[#key-bindings][Key bindings]]
   - [[#edit-consult-buffer][Edit consult buffer]]
+  - [[#vertico-key-bindings][Vertico key bindings]]
 
 * Description
 This layer implements completion provided by combining the following packages:
@@ -46,11 +47,12 @@ like below to use =selectrum= as opposed to the default of =vertico=:
 
 * Key bindings
 
-| Key binding | Description               |
-|-------------+---------------------------|
-| ~M-o~       | embark-action             |
-| ~C-r~       | history                   |
-| ~M-.~       | preview selected item now |
+| Key binding | Description                    |
+|-------------+--------------------------------|
+| ~M-o~       | embark-action                  |
+| ~C-r~       | history                        |
+| ~M-.~       | preview selected item now      |
+| ~C-z~       | select embark action from list |
 
 ** Edit consult buffer
 
@@ -67,3 +69,18 @@ like below to use =selectrum= as opposed to the default of =vertico=:
 Note: ~SPC m s~ actually saves the changes on disk when the changed lines belong
 to a buffer visiting a file. ~SPC m ,~ and ~SPC m c~ do not save the changes on
 disk.
+
+** Vertico key bindings
+
+| Key binding | Description                                                                   |
+|-------------+-------------------------------------------------------------------------------|
+| ~C-j~       | Go to next row down                                                           |
+| ~C-k~       | Go to next row up                                                             |
+| ~C-l~       | Fully selects the text under the point (completes)                            |
+| ~C-S-j~     | Move to next group of results                                                 |
+| ~C-S-k~     | Move to previous group of results                                             |
+| ~C-M-j~     | Move to next candidate and preview                                            |
+| ~C-M-k~     | Move to previous candidate and preview                                        |
+| ~C-SPC~     | Preview candidate                                                             |
+| ~M-P~       | Toggle previewing on for compleseus functions (requires rerunning the search) |
+

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -337,3 +337,12 @@ Note: this function relies on embark internals and might break upon embark updat
   (spacemacs/wgrep-finish-edit)
   (wgrep-save-all-buffers)
   (quit-window))
+
+(defun spacemacs/consult-toggle-preview ()
+  "Toggle auto-preview mode for compleseus buffers"
+  (interactive)
+  (if (eq consult-preview-key 'any)
+      (setq consult-preview-key '("M-." "C-SPC"))
+    (setq consult-preview-key ("M-." "C-SPC" :debounce 0.3 any))
+    )
+  )

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -442,7 +442,8 @@
       (define-key vertico-map (kbd "C-M-k") #'spacemacs/previous-candidate-preview)
       (define-key vertico-map (kbd "M-RET") #'vertico-exit-input)
       (define-key vertico-map (kbd "C-SPC") #'spacemacs/embark-preview)
-      (define-key vertico-map (kbd "C-r") #'consult-history)))
+      (define-key vertico-map (kbd "C-r") #'consult-history)
+      (define-key vertico-map (kbd "M-P") #'spacemacs/consult-toggle-preview)))
 
   (use-package vertico-directory
     :after vertico


### PR DESCRIPTION
Also add documentation on vertico keybindings.

So, there were a few ways to go about this. We already have a call to `consult-customize` here, but we don't customize any of the `compleseus/*` functions, so none of them have any preview enabled.

We could explicitly add them all to that, and then have something like [this wiki function](https://github.com/minad/consult/wiki#toggle-preview-during-active-completion-session) to allow toggling preview off, or we can have what I did below (which doesn't support toggling in a live buffer completion session). The advantage of my option is that it works for all consult functions.

There is one other issue. I wrote some docs for the existing vertico keybindings, but on my machine the `C-M-j` and `C-M-k` bindings don't actually work? I added them to the docs anyways. Is that just a me issue?