### PR TITLE
Use rustic-cargo-test-run instead of rustic-cargo-test

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -360,7 +360,7 @@ both Racer and RLS not being maintained anymore.
   - New ~SPC m r f S~ to find serializer (thanks to Boris Buliga)
   - Changed =projectile-rails= key binding prefix from ~SPC m r~ to ~SPC m f~
     to avoid conflicts with key bindings in the =web-mode= layer
-    (thanks to Adam Sokolnicki) fs
+    (thanks to Adam Sokolnicki)
 ***** Search-engine
   - Add Debian & Ubuntu package search engines (thanks to Alfonso Montero).
   - Allow to configure a TLD other than =.com= for Amazon searches (thanks to Alfonso Montero).

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -353,7 +353,7 @@ In org-agenda-mode
 Removed support for Racer, default backend for LSP is now rust-analizer due to
 both Racer and RLS not being maintained anymore.
 - Key bindings:
-  - Replaced ~SPC m t a (rustic-cargo-test) with ~SPC m t r (rustic-cargo-test-run) 
+  - Edited ~SPC m t a from =rustic-cargo-test= to =rustic-cargo-test-run=
     to avoid the unexpected behavior of always running a single test after using 
     rustic-cargo-current-test (thanks to Roberto Previdi)
 ***** Ruby on Rails

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -355,7 +355,8 @@ both Racer and RLS not being maintained anymore.
 - Key bindings:
   - Replaced ~SPC m t a (rustic-cargo-test) with ~SPC m t r (rustic-cargo-test-run) 
     to avoid the unexpected behavior of always running a single test after using 
-    rustic-cargo-current-test (thanks to Roberto Previdi)***** Ruby on Rails
+    rustic-cargo-current-test (thanks to Roberto Previdi)
+***** Ruby on Rails
 - Key bindings:
   - New ~SPC m r f S~ to find serializer (thanks to Boris Buliga)
   - Changed =projectile-rails= key binding prefix from ~SPC m r~ to ~SPC m f~

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -353,7 +353,7 @@ In org-agenda-mode
 Removed support for Racer, default backend for LSP is now rust-analizer due to
 both Racer and RLS not being maintained anymore.
 - Key bindings:
-  - Edited ~SPC m t a from =rustic-cargo-test= to =rustic-cargo-test-run=
+  - Edited ~SPC m t a~ from =rustic-cargo-test= to =rustic-cargo-test-run=
     to avoid the unexpected behavior of always running a single test after using 
     rustic-cargo-current-test (thanks to Roberto Previdi)
 ***** Ruby on Rails

--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -352,12 +352,15 @@ In org-agenda-mode
 ***** Rust
 Removed support for Racer, default backend for LSP is now rust-analizer due to
 both Racer and RLS not being maintained anymore.
-***** Ruby on Rails
+- Key bindings:
+  - Replaced ~SPC m t a (rustic-cargo-test) with ~SPC m t r (rustic-cargo-test-run) 
+    to avoid the unexpected behavior of always running a single test after using 
+    rustic-cargo-current-test (thanks to Roberto Previdi)***** Ruby on Rails
 - Key bindings:
   - New ~SPC m r f S~ to find serializer (thanks to Boris Buliga)
   - Changed =projectile-rails= key binding prefix from ~SPC m r~ to ~SPC m f~
     to avoid conflicts with key bindings in the =web-mode= layer
-    (thanks to Adam Sokolnicki)
+    (thanks to Adam Sokolnicki) fs
 ***** Search-engine
   - Add Debian & Ubuntu package search engines (thanks to Alfonso Montero).
   - Allow to configure a TLD other than =.com= for Amazon searches (thanks to Alfonso Montero).

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -72,7 +72,7 @@
       "cU" 'rustic-cargo-upgrade
       "cv" 'rustic-cargo-check
       "cx" 'rustic-cargo-run
-      "ta" 'rustic-cargo-test
+      "tr" 'rustic-cargo-test-run
       "tt" 'rustic-cargo-current-test)
 
     (with-eval-after-load 'flycheck

--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -72,7 +72,7 @@
       "cU" 'rustic-cargo-upgrade
       "cv" 'rustic-cargo-check
       "cx" 'rustic-cargo-run
-      "tr" 'rustic-cargo-test-run
+      "ta" 'rustic-cargo-test-run
       "tt" 'rustic-cargo-current-test)
 
     (with-eval-after-load 'flycheck


### PR DESCRIPTION
The command rustic-cargo-test depends on the variable rustic-test-arguments which gets polluted when running the "current-test" variant. So there is no way to run all the tests after running a single one, without clearing that variable.
Using rustic-cargo-test-run allows to go back to running all tests instead.
We could also keep both, but a meaningful description would be needed for rustic-cargo-test because the behavior is "unexpected"