### PR TITLE
* core/core-configuration-layer.el: remove unnecessary call (package-initialize)

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -441,10 +441,7 @@ cache folder.")
           (configuration-layer/elpa-directory
            configuration-layer--elpa-root-directory))
     (setq package-archives (configuration-layer//resolve-package-archives
-                            configuration-layer-elpa-archives))
-    ;; optimization, no need to activate all the packages so early
-    (setq package-enable-at-startup nil)
-    (package-initialize 'noactivate)))
+                            configuration-layer-elpa-archives))))
 
 (autoload 'quelpa "quelpa")
 (autoload 'quelpa-checkout "quelpa")


### PR DESCRIPTION
Hi,
It's unnecessary to call the `package-initialize` since emacs-27 according to its official document:
https://github.com/emacs-mirror/emacs/blob/9ed82c26a36caf9a9a85779cbb3a58b7ccd3dffb/etc/NEWS.27#L230-L236

And also benefit shorter startup time after remove the lines. 