### PR TITLE
* layers/+lang/python: pytest as the default python test runner

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -59,7 +59,7 @@ This layer adds support for the Python language.
 - Auto-completion
 - Code Navigation
 - Documentation Lookup using [[https://github.com/proofit404/anaconda-mode][anaconda-mode]] and [[https://github.com/tsgates/pylookup][pylookup]]
-- Test Runners using [[https://github.com/syl20bnr/nose.el][nose.el]] or [[https://github.com/ionrock/pytest-el][pytest]]
+- Test Runners using [[https://github.com/ionrock/pytest-el][pytest]] or [[https://github.com/syl20bnr/nose.el][nose.el]]
 - Virtual Environment using [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] and [[https://github.com/yyuu/pyenv][pyenv]] as well as [[https://github.com/pypa/pipenv][pipenv]] and [[https://github.com/galaunay/poetry.el][poetry]]
 - semantic mode is enabled
 - PEP8 compliant formatting via [[https://github.com/google/yapf][YAPF]] or [[https://github.com/ambv/black][black]]
@@ -197,9 +197,9 @@ Syntax checking uses =flake8= package:
 #+END_SRC
 
 ** Test runner
-Both =nose= and =pytest= are supported. By default =nose= is used.
+Both =pytest= and =nose= are supported. By default =pytest= is used.
 To choose your test runner set the layer variable =python-test-runner= to
-either =nose= or =pytest=.
+either =pytest= or =nose=.
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -53,7 +53,7 @@ If nil then `yapf' is the default formatter unless `lsp' layer is used.")
   "If non-nil, automatically format code with formatter selected
   via `python-formatter' on save.")
 
-(defvar python-test-runner 'nose
+(defvar python-test-runner 'pytest
   "Test runner to use. Possible values are `nose' or `pytest'.")
 (put 'python-test-runner 'safe-local-variable #'symbolp)
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -37,7 +37,8 @@
     (helm-pydoc :requires helm)
     importmagic
     live-py-mode
-    (nose :location (recipe :fetcher github :repo "syl20bnr/nose.el"))
+    (nose :location (recipe :fetcher github :repo "syl20bnr/nose.el")
+          :toggle (memq 'nose (flatten-list (list python-test-runner))))
     org
     pip-requirements
     pipenv
@@ -47,7 +48,7 @@
     pydoc
     pyenv-mode
     (pylookup :location (recipe :fetcher local))
-    pytest
+    (pytest :toggle (memq 'pytest (flatten-list (list python-test-runner))))
     (python :location built-in)
     pyvenv
     semantic


### PR DESCRIPTION
Hi,
Currently the default `python-test-runner` is `nose`, which was stopped maintained nearly 10 years ago.
https://pypi.org/project/nose/

The `pytest` is actively maintained, so set the `pytest` to be the default `python-test-runner` is reasonable. 
https://github.com/pytest-dev/pytest

PS: The `pytest` is recommend on the `nose2` project page.
https://github.com/nose-devs/nose2?tab=readme-ov-file#nose2-vs-pytest

