### PR TITLE
* core/core-release-management.el: (spacemacs//revision-check) return quickly

### DIFF
--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -378,24 +378,25 @@ If old and new revisions are different `spacemacs-revision--changed-hook'
  will be triggered."
   (when (file-exists-p spacemacs-revision--file)
     (load spacemacs-revision--file nil t))
-  (require 'async)
-  (async-start
-   `(lambda ()
-      (let ((proc-buffer "spacemacs//revision-check:git-get-current-rev")
-            (default-directory (file-truename ,spacemacs-start-directory))
-            (new_rev))
-        (when (eq 0 (process-file "git" nil proc-buffer nil "rev-parse" "HEAD"))
-          (with-current-buffer proc-buffer
-            (goto-char 1)
-            (setq new_rev (current-word))
-            (kill-buffer proc-buffer)))
-        (with-temp-file ,spacemacs-revision--file
-          (insert (format "(setq spacemacs-revision--last %S)" new_rev))
-          (make-directory (file-name-directory ,spacemacs-revision--file) t))
-        new_rev))
-   (lambda (new_rev)
-     (unless (string= spacemacs-revision--last new_rev)
-       (setq spacemacs-revision--last new_rev)
-       (run-hooks 'spacemacs-revision--changed-hook)))))
+  (when spacemacs-revision--changed-hook
+    (require 'async)
+    (async-start
+     `(lambda ()
+        (let ((proc-buffer "spacemacs//revision-check:git-get-current-rev")
+              (default-directory (file-truename ,spacemacs-start-directory))
+              (new_rev))
+          (when (eq 0 (process-file "git" nil proc-buffer nil "rev-parse" "HEAD"))
+            (with-current-buffer proc-buffer
+              (goto-char 1)
+              (setq new_rev (current-word))
+              (kill-buffer proc-buffer)))
+          (with-temp-file ,spacemacs-revision--file
+            (insert (format "(setq spacemacs-revision--last %S)" new_rev))
+            (make-directory (file-name-directory ,spacemacs-revision--file) t))
+          new_rev))
+     (lambda (new_rev)
+       (unless (string= spacemacs-revision--last new_rev)
+         (setq spacemacs-revision--last new_rev)
+         (run-hooks 'spacemacs-revision--changed-hook))))))
 
 (provide 'core-release-management)


### PR DESCRIPTION
Hi,
If there is no audience for `spacemacs-revision--changed-hook`, the function `spacemacs//revision-check` actually can skip the heavy part. It will speed up the start time. Thanks