### PR TITLE
Fixed bug with toggle-preview and added config.

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -8,6 +8,7 @@
 - [[#install][Install]]
   - [[#configuration][Configuration]]
     - [[#completion-engine][Completion engine]]
+    - [[#preview-keys][Preview keys]]
 - [[#key-bindings][Key bindings]]
   - [[#narrowing][Narrowing]]
   - [[#edit-consult-buffer][Edit consult buffer]]
@@ -45,6 +46,18 @@ like below to use =selectrum= as opposed to the default of =vertico=:
   (compleseus :variables
               compleseus-engine 'selectrum)
 #+END_SRC
+*** Preview keys
+You can set the keys that will by default trigger a preview in consult commands.
+This can be set to a list of keys, with an optional debounce property. For instance
+to preview immediately on pressing ~M-.~ or ~C-SPC~, and having previewing after a delay of 0.5
+seconds if you press either up or down you could use the following configuration.
+#+BEGIN_SRC emacs-lisp
+  (compleseus :variables
+              compleseus-consult-preview-keys '("M-." "C-SPC" :debounce 0.5 "<up>" "<down>"))
+#+END_SRC
+
+See [[https://github.com/minad/consult?tab=readme-ov-file#live-previews][consult documentation]] for more information and examples.
+The default is set to ~'("M-." "C-SPC" "C-M-j" "C-M-k")~
 
 * Key bindings
 

--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -224,3 +224,6 @@ buffers.")
 It contains all buffers previously displayed in a live window of
 the current window configuration, including buffers from
 different layouts and hidden buffers.")
+
+(defcustom compleseus-consult-preview-keys '("M-." "C-SPC" "C-M-j" "C-M-k")
+  "Default keys that trigger a preview in consult")

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -369,11 +369,17 @@ Note: this function relies on embark internals and might break upon embark updat
   (wgrep-save-all-buffers)
   (quit-window))
 
+(defvar compleseus--previous-preview-keys nil
+  "variable to store the former value of preview keys or nil if the preview
+ has not been toggled on")
+
 (defun spacemacs/consult-toggle-preview ()
   "Toggle auto-preview mode for compleseus buffers"
   (interactive)
-  (if (eq consult-preview-key 'any)
-      (setq consult-preview-key '("M-." "C-SPC"))
-    (setq consult-preview-key '("M-." "C-SPC" :debounce 0.3 any))
+  (if (eq compleseus--previous-preview-keys nil)
+      (setq compleseus--previous-preview-keys consult-preview-key
+            consult-preview-key '(:debounce 0.5 any))
+    (setq consult-preview-key compleseus--previous-preview-keys
+          compleseus--previous-preview-keys nil)
     )
   )

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -153,7 +153,7 @@
     ;; The :init configuration is always executed (Not lazy)
     :init
     ;; disable automatic preview by default
-    (setq consult-preview-key '("M-." "C-SPC" "C-M-j" "C-M-k"))
+    (setq consult-preview-key compleseus-consult-preview-keys)
 
     (define-key read-expression-map (kbd "C-r") #'consult-history)
     (spacemacs/set-leader-keys


### PR DESCRIPTION
Fix bug introduced in https://github.com/syl20bnr/spacemacs/pull/16609. See comment https://github.com/syl20bnr/spacemacs/pull/16609#issuecomment-2395429379 for explanation.

NOTE, at first I tried to do:
```elisp
      (setq compleseus--previous-preview-keys consult-preview-key
            consult-preview-key (consult-preview-key '(:debounce 0.3 any)))
```
within the function, but that didn't really seem to actually work? I then noticed that you can't even do:
```elisp
  (setq consult-preview-key '("M-." "C-SPC" "C-M-j" "C-M-k" :debounce 0.5 "<up>" "<down>" :debounce 0.3 any))
```
which is confusing as it's supported in `consult-customize`. Either way, afaict that's a bug in consult, but I ignored it since this simpler thing fixed my problem.
