### PR TITLE
feat(marginalia): Add Nerd Icons to Marginalia

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -25,6 +25,9 @@
   "Options are `selectrum', and `vertico' to use as completion
   engine.")
 
+(defvar compleseus-use-nerd-icons nil
+  "Use nerd-icons with marginalia to provide icons in the mini-buffer")
+
 (defvar compleseus-buffer-search-restrict-project t
   "If non-nil, `spacemacs/consult-line-multi' and `spacemacs/consult-line-multi-symbol'
 will be restricted to buffers of the current project.

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -34,6 +34,7 @@
     (helm-make :location (recipe :fetcher github
                                  :repo "myrgy/helm-make"
                                  :branch "add_emacs_completion"))
+    (nerd-icons-completion :toggle compleseus-use-nerd-icons)
     orderless
     persp-mode
     (selectrum :toggle (eq compleseus-engine 'selectrum))
@@ -167,6 +168,7 @@
       "hm" #'consult-man
       "jm" #'consult-mark
       "jM" #'consult-global-mark
+
       "sb" #'spacemacs/consult-line-multi
       "sB" #'spacemacs/consult-line-multi-symbol
       "ss" #'spacemacs/consult-line
@@ -500,3 +502,11 @@
     (setq
      spacemacs--persp-display-buffers-func 'spacemacs/compleseus-switch-to-buffer
      spacemacs--persp-display-perspectives-func 'spacemacs/compleseus-spacemacs-layout-layouts)))
+
+(defun compleseus/init-nerd-icons-completion ()
+  (use-package nerd-icons-completion
+    :defer t
+    :after marginalia
+    :hook (marginalia-mode . nerd-icons-completion-marginalia-setup)
+    :init
+    (nerd-icons-completion-mode)))


### PR DESCRIPTION
Why?:
- Provide a similar functionality to Ivy Rich for use in the minibuffer.

This change addresses the need by:
- Add new layer variable compleseus-use-nerd-icons
- Add compleseus/init-nerd-icons-completion function

