### PR TITLE
[version-control] Add s key binding to smerge-ts for smerge-swap

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -243,6 +243,7 @@ Other:
 | Key binding | Description                    |
 |-------------+--------------------------------|
 | ~SPC g r C~ | Combine current and next hunks |
+| ~SPC g r s~ | Swap upper and lower regions   |
 | ~SPC g r U~ | Undo                           |
 | ~SPC g r q~ | Quit transient state           |
 

--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -230,13 +230,13 @@ Merge Actions:
 
 Diff:
 
-| Key binding | Description         |
-|-------------+---------------------|
-| ~SPC g r <~ | Diff base and mine  |
-| ~SPC g r =~ | Diff mine and other |
-| ~SPC g r >~ | Diff base and other |
-| ~SPC g r r~ | Refine              |
-| ~SPC g r e~ | Ediff               |
+| Key binding | Description          |
+|-------------+----------------------|
+| ~SPC g r <~ | Diff base and upper  |
+| ~SPC g r =~ | Diff upper and lower |
+| ~SPC g r >~ | Diff base and lower  |
+| ~SPC g r r~ | Refine               |
+| ~SPC g r e~ | Ediff                |
 
 Other:
 

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -208,9 +208,9 @@
  Movement^^^^             Merge Action^^      Diff^^            Other
  -------------------^^^^  ----------------^^  --------------^^  -------------------------------^^
  [_n_]^^   next conflict  [_u_] keep upper    [_<_] base/upper  [_C_] combine curr/next conflicts
- [_N_/_p_] prev conflict  [_b_] keep base     [_=_] upper/lower [_U_] undo
- [_j_]^^   next line      [_l_] keep lower    [_>_] base/lower  [_q_] quit
- [_k_]^^   prev line      [_a_] keep all      [_r_] refine
+ [_N_/_p_] prev conflict  [_b_] keep base     [_=_] upper/lower [_s_] swap upper/lower
+ [_j_]^^   next line      [_l_] keep lower    [_>_] base/lower  [_U_] undo
+ [_k_]^^   prev line      [_a_] keep all      [_r_] refine      [_q_] quit
  ^^^^                     [_c_] keep current  [_e_] ediff       [_?_] toggle help
  ^^^^                     [_K_] kill current")
     (spacemacs|define-transient-state smerge
@@ -235,6 +235,8 @@
       ("l" smerge-keep-lower)
       ("u" smerge-keep-upper)
       ("c" smerge-keep-current)
+      ("K" smerge-kill-current)
+      ("s" smerge-swap)
       ;; diff
       ("<" smerge-diff-base-mine)
       ("=" smerge-diff-mine-other)
@@ -243,7 +245,6 @@
       ("e" smerge-ediff :exit t)
       ;; other
       ("C" smerge-combine-with-next)
-      ("K" smerge-kill-current)
       ("U" evil-undo)
       ("q" nil :exit t)
       ("?" spacemacs//smerge-ts-toggle-hint))))


### PR DESCRIPTION
I use this command a decent amount to fix the ordering of the
upper/lower regions just before invoking `smerge-keep-all`.  It would
be nice to stay in the transient while doing so.