### PR TITLE
Fix --batch never exiting after loading Spacemacs

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1243,6 +1243,7 @@ Emacs server.
 
 Setting `spacemacs-really-kill-emacs' non-nil overrides this advice."
   (if (and (not spacemacs-really-kill-emacs)
+           (not noninteractive)         ;in batch mode, just kill emacs
            (spacemacs//persistent-server-running-p))
       (spacemacs/frame-killer)
     (apply f args)))


### PR DESCRIPTION
Previously, attempting to use Spacemacs with --batch would hang
forever.  In that scenario, the function `command-line' attempts to
kill batch-mode Emacs after processing command line arguments, but
fails because Spacemacs advises kill-emacs.

Normally batch mode suppresses Spacemacs but it can be made to load
Spacemacs like so:

``` shell
emacs --batch -u $(whoami) --eval '(pp (+ 1 2))'
```

This should print `3` and exit, but without this commit it never
exits.