### PR TITLE
Speedup the Spacemacs startup/loading with load-hints

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -477,6 +477,11 @@ are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m)."
   'boolean
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-enable-load-hints t
+  "If nil, no load-hints enabled. If t, enable the load-hints."
+  '(choice (const nil) (const t) (const aggressive))
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-loading-progress-bar t
   "If non nil a progress bar is displayed when spacemacs is loading. This
 may increase the boot time on some systems and emacs builds, set it to nil

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -70,6 +70,97 @@
   "Whether or not spacemacs has finished initializing by completing
 the final step of executing code in `emacs-startup-hook'.")
 
+(defun spacemacs//package-regenerate-autoloads (&optional path)
+  "Regenerate the autoloads for installed packages."
+  (interactive "P")
+  (dolist (dir (or path (list package-user-dir)))
+    (when (file-directory-p dir)
+      (dolist (pkg-dir (directory-files dir t "\\`[^.]"))
+        (when-let (((file-directory-p pkg-dir))
+                   (pkg-desc (package-load-descriptor pkg-dir)))
+          (let ((default-directory pkg-dir))
+            (mapc 'delete-file (file-expand-wildcards "*-autoloads.el" )))
+          (package-generate-autoloads
+           (package-desc-name pkg-desc) pkg-dir))))))
+
+(defun spacemacs//lookup-load-hints (file)
+  "Findout the `load-hints' items for the file."
+  (if-let* ((load-hints)
+            ((not (member (substring file 0 1) '("/" "~")))))
+      (seq-some
+       (lambda (row)
+         (when (member file (cdr row))                 ; prefix match
+           (car row)))
+       load-hints)))
+
+(defun spacemacs//activate-load-hints ()
+  "Enable the `load-hints' support for Spacemacs."
+  (setq package-enable-load-hints dotspacemacs-enable-load-hints
+        load-hints
+        (mapcar
+         (lambda (path)
+           (when-let* (((file-directory-p path))
+                       (files (seq-difference
+                               (directory-files path) '("." "..")
+                               #'string=))
+                       ;; list of files basename, the load-suffixes was removed
+                       (bases
+                        (mapcar
+                         (lambda (f)
+                           (seq-some
+                            (lambda (s)
+                              (if-let* ((n (length s))
+                                        ((length> f n))
+                                        ((string= s (substring f (- n)))))
+                                  (substring f 0 (- n))))
+                            (get-load-suffixes)))
+                         files)))
+             (cons path (seq-uniq (remove nil bases) 'string-equal))))
+         load-path))
+
+  (define-advice require (:around (func feature &optional filename noerror) LOAD-HINTS)
+    (if-let* (((and feature (not filename) load-hints))
+              (path (spacemacs//lookup-load-hints (symbol-name feature))))
+        (let ((load-path (cons path load-path)))
+          (funcall func feature filename noerror))
+      (funcall func feature filename noerror)))
+
+  (define-advice package-generate-autoloads (:after (name pkg-dir) LOAD-HINTS)
+    ;; if package-enabled-load-hints is non-nil then collecting loadable
+    ;; files in pkg-dir and generating the load-hints list.
+    (when-let* (dotspacemacs-enable-load-hints
+                (auto-name (format "%s-autoloads.el" name))
+                (output-file (expand-file-name auto-name pkg-dir))
+                (name (symbol-name name))
+                (files (seq-difference
+                        (directory-files pkg-dir)
+                        `("." ".." ,(concat name "-pkg.el") ,auto-name)
+                        #'string=))
+                ;; list of files basename, the load-suffixes was removed
+                (bases
+                 (remove nil
+                         (mapcar
+                          (lambda (f)
+                            (seq-some
+                             (lambda (s)
+                               (if-let* ((n (length s))
+                                         ((length> f n))
+                                         ((string= s (substring f (- n)))))
+                                   (substring f 0 (- n))))
+                             (get-load-suffixes)))
+                          files))))
+      (with-current-buffer (find-file-noselect output-file)
+        (goto-char (point-min))
+        (when (re-search-forward "add-to-list 'load-path" nil t)
+          (forward-line 0)
+          (insert (format "(add-to-list 'load-hints (cons %S '%S))\n"
+                          '(or (and load-file-name
+                                    (directory-file-name
+                                     (file-name-directory load-file-name)))
+                               (car load-path))
+                          (seq-uniq bases 'string-equal))))
+        (save-buffer)))))
+
 (defun spacemacs/init ()
   "Perform startup initialization."
   (setq command-line-args (spacemacs//parse-command-line command-line-args))
@@ -135,6 +226,13 @@ the final step of executing code in `emacs-startup-hook'.")
     (if dotspacemacs-icon-title-format
         (setq icon-title-format '((:eval (spacemacs/title-prepare dotspacemacs-icon-title-format))))
       (setq icon-title-format frame-title-format)))
+
+  (when (and dotspacemacs-enable-load-hints (not (boundp 'load-hints)))
+    (spacemacs//activate-load-hints))
+
+  (unless (boundp 'load-hints) ; make sure the `load-hints' avaliable for the
+    (defvar load-hints '()))   ; *-autoloads.el after the feature was toggled.
+
   ;; theme
   (spacemacs/load-default-theme spacemacs--fallback-theme 'disable)
   ;; font


### PR DESCRIPTION
Hi,

The Spacemacs is heavy and slow on loading (especially for Windows system).
I want share the solution with `load-hints` to speedup the Spacemacs, here are the results, on windows, after enabled the feature, it will reduce the start up time from ~16.7 seconds to ~5.0 seconds; on Ubuntu 20.04, the startup time was reduced from ~1.7s to ~1.4s, 

Windows 11:
342 packages loaded in **16.714s** (e:257 r:19 l:5 b:61)
342 packages loaded in **5.071s** (e:257 r:19 l:5 b:61)
Ubuntu 20.04:
389 packages loaded in **1.729s** (e:302 r:19 l:5 b:63)
389 packages loaded in **1.438s** (e:302 r:19 l:5 b:63)

Just apply this patch and run `spacemacs//package-regenerate-autoloads`, then restart the Spacemacs, check the startup time.