### PR TITLE
Fix typo in vertico-postframe

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -41,7 +41,7 @@
     (vertico
      :toggle (eq compleseus-engine 'vertico)
      :location elpa)
-    (vertico-posframe :togle (and (eq compleseus-engine 'vertico)
+    (vertico-posframe :toggle (and (eq compleseus-engine 'vertico)
                                   compleseus-use-vertico-posframe))
     (grep :location built-in)
     wgrep))


### PR DESCRIPTION
Before this commit vertico-postframe was enabled by default since it ignore `compleseus-use-vertico-posframe` variable.
