### PR TITLE
[unicode-fonts] Do not error in after-make-frame-functions

### DIFF
--- a/layers/+fonts/unicode-fonts/funcs.el
+++ b/layers/+fonts/unicode-fonts/funcs.el
@@ -31,10 +31,15 @@ This functions setups `unicode-fonts' right away when starting a GUI Emacs.
 But if Emacs is running in a daemon, it postpone the setup until a GUI frame
 is opened."
   (if (and frame (display-graphic-p frame))
-      (with-selected-frame frame
-        (require 'unicode-fonts)
-        (unicode-fonts-setup)
-        (remove-hook 'after-make-frame-functions #'unicode-fonts//setup-fonts))
+      (progn
+        (remove-hook 'after-make-frame-functions #'unicode-fonts//setup-fonts)
+        ;; Do not error in `after-make-frame-functions'.  Otherwise, emacsclient
+        ;; gets confused and creates two frames, one graphical and then one on
+        ;; the terminal.
+        (condition-case e
+            (with-selected-frame frame
+              (unicode-fonts-setup))
+          (error (warn "Error setting up unicode-fonts: %s" (error-message-string e)))))
     (add-hook 'after-make-frame-functions #'unicode-fonts//setup-fonts)))
 
 ;;; funcs.el ends here


### PR DESCRIPTION
If `unicode-fonts-setup` errors (such as if the eieio cache is
corrupted), emacsclient behaves confusingly by opening both a
graphical frame and a terminal frame.

You can reproduce this scenario by corrupting
`~/.emacs.d/.cache/pcache/unicode-fonts` (such that is no longer valid
Lisp syntax) and then starting Emacs with `emacsclient -ca ''`.

Also remove an unnecessary require, since `unicode-fonts-setup` is
autoloaded.