### PR TITLE
Fix typo in helm-use-posframe

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -36,7 +36,7 @@
     helm-make
     helm-mode-manager
     helm-org
-    (helm-posframe :toogle helm-use-posframe)
+    (helm-posframe :toggle helm-use-posframe)
     helm-projectile
     helm-swoop
     helm-themes


### PR DESCRIPTION
Before this commit helm-postframe was enabled by default since it ignore helm-use-posframe variable. Fixes #16644 
