### PR TITLE
Fix failed on the default theme and not depending on package-activate

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -235,7 +235,7 @@ the final step of executing code in `emacs-startup-hook'.")
     (defvar load-hints '()))   ; *-autoloads.el after the feature was toggled.
 
   ;; theme
-  (spacemacs/load-default-theme spacemacs--fallback-theme 'disable)
+  (spacemacs/load-default-theme)
   ;; font
   (spacemacs|do-after-display-system-init
    ;; If you are thinking to remove this call to `message', think twice. You'll


### PR DESCRIPTION
Hi,

Spacemacs has issues on theme, 
1. Error on `default` theme:
 a) write the `dotspacemacs-themes` to `(default)`, then start Spacemacs with daemon mode: `emacs --daemon`
 b) start a graphic emacsclient: `emacsclient -c .`
Then error happens: `*ERROR*: Unable to find theme file for ‘default’`.
This patch will try load theme but not try enable it first, if the theme is exists then enable the theme; otherwise set the theme to `spacemacs--delayed-user-theme` to postpone the operation. 
2. For a `<non-exists>` theme in `dotspacemacs-themes`, then Spacemacs will switch theme from `default` -> `spacemacs-dark(fallback-theme)` -> `default` -> `spacemacs-dark(fallbak-theme)` during startup:
 a) write the `dotspacemacs-themes` to `(non-exists)`, then restart the Spacemacs.
 b) the Spacemacs will flash during the startup.
It caused by the `spacemacs/load-default-theme` will try load the `non-exists` theme then fallback to the `spacemacs-dark`, and  in `emacs-startup-hook` it will load the `spacemacs--delayed-user-theme` again, it still is not exists, then fallback to `spacemacs-dark` again. 
This patch won't try the fallback-theme for first attempt, only fallback at the last one.
3. Spacemacs theme function relates to the `package-activate` function, which requests the `package-initialize` will load all the `*-pkg.el` and `*-autoloads.el` for packages; cause a heavy loading; 
This change will disconnect the theme from `package-activate`, will let the `package-quickstartup` to work, refer: https://github.com/syl20bnr/spacemacs/pull/16651 .