### PR TITLE
* core/core-configuration-layer.el: support package-quickstart

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -441,10 +441,7 @@ cache folder.")
           (configuration-layer/elpa-directory
            configuration-layer--elpa-root-directory))
     (setq package-archives (configuration-layer//resolve-package-archives
-                            configuration-layer-elpa-archives))
-    ;; optimization, no need to activate all the packages so early
-    (setq package-enable-at-startup nil)
-    (package-initialize 'noactivate)))
+                            configuration-layer-elpa-archives))))
 
 (autoload 'quelpa "quelpa")
 (autoload 'quelpa-checkout "quelpa")
@@ -643,6 +640,11 @@ To prevent package from being installed or uninstalled set the variable
   (configuration-layer//configure-layers configuration-layer--used-layers)
   ;; load layers lazy settings
   (configuration-layer/load-auto-layer-file)
+  ;; try the package-quickstart-file before detecting package installation
+  (when (and (or package-quickstart dotspacemacs-enable-package-quickstart)
+             package-quickstart-file)
+    (setq package-quickstart t)
+    (load (file-name-sans-extension package-quickstart-file) t nil nil t))
   ;; install and/or uninstall packages
   (when spacemacs-sync-packages
     (let ((packages

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -482,6 +482,11 @@ are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m)."
   '(choice (const nil) (const t) (const aggressive))
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-enable-package-quickstart nil
+  "If t, try the `package-quickstart' for package startup."
+  'boolean
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-loading-progress-bar t
   "If non nil a progress bar is displayed when spacemacs is loading. This
 may increase the boot time on some systems and emacs builds, set it to nil

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -352,6 +352,10 @@ It should only modify the values of Spacemacs settings."
    ;; through the whole `load-path'.
    dotspacemacs-enable-load-hints t
 
+   ;; If t, enable the `package-quickstart' feature to avoid full package
+   ;; loading, otherwise do not try the `package-quickstart' (default nil).
+   dotspacemacs-enable-package-quickstart nil
+
    ;; If non-nil a progress bar is displayed when spacemacs is loading. This
    ;; may increase the boot time on some systems and emacs builds, set it to
    ;; nil to boost the loading time. (default t)


### PR DESCRIPTION
A draft to support `package-quickstart`. 
Request the MR https://github.com/syl20bnr/spacemacs/pull/16650 to be merged first, then this MR will works.