### PR TITLE
* core/core-dotspacemacs.el: load-hints default turn off

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -477,7 +477,7 @@ are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m)."
   'boolean
   'spacemacs-dotspacemacs-init)
 
-(spacemacs|defc dotspacemacs-enable-load-hints t
+(spacemacs|defc dotspacemacs-enable-load-hints nil
   "If nil, no load-hints enabled. If t, enable the load-hints."
   '(choice (const nil) (const t) (const aggressive))
   'spacemacs-dotspacemacs-init)

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -350,7 +350,7 @@ It should only modify the values of Spacemacs settings."
    ;; If nil, no load-hints enabled. If t, enable the `load-hints' which will
    ;; put the most likely path on the top of `load-path' to reduce walking
    ;; through the whole `load-path'.
-   dotspacemacs-enable-load-hints t
+   dotspacemacs-enable-load-hints nil
 
    ;; If non-nil a progress bar is displayed when spacemacs is loading. This
    ;; may increase the boot time on some systems and emacs builds, set it to


### PR DESCRIPTION
Don't default turn on `load-hints` for there are issues #16652 and #16647. 