### PR TITLE
* layers/+emacs/org/packages.el: defer load the org-project-capture-projectile

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -843,6 +843,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
 
 (defun org/init-org-projectile ()
   (use-package org-projectile
+    :after org-project-capture ; backend for projectile after org-project-capture
     :config
     (setq org-project-capture-default-backend
           (make-instance 'org-project-capture-projectile-backend))))


### PR DESCRIPTION
The `org-projectile` was loaded during startup, trigger a heave loading to load the `org` package and its dependents.

This patch will arrange it to behind the `org-project-capture` to avoid heavy loading during startup. 