### PR TITLE
[spacemacs-defaults] Include function name in SPC n F buffer name

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1938,7 +1938,7 @@ This is controlled by the `:size-limit-kb' property of
 
 ;; narrow region
 
-(defun spacemacs/clone-indirect-buffer-de-activate-mark ()
+(define-advice clone-indirect-buffer (:around (f &rest args) spacemacs-deactivate-mark)
   "This is a workaround for the evil visual state error message like:
 Error in post-command-hook (evil-visual-post-command):
 (error \"Marker points into wrong buffer\" #<marker at 27875 in .spacemacs<2>>)
@@ -1946,7 +1946,7 @@ Error in post-command-hook (evil-visual-post-command):
 See https://github.com/emacs-evil/evil/issues/280"
   (let ((region-was-active (region-active-p)))
     (when region-was-active (deactivate-mark))
-    (call-interactively 'clone-indirect-buffer)
+    (apply f args)
     (when region-was-active (activate-mark))))
 
 (defun spacemacs/narrow-to-indirect-buffer (narrower target-name)
@@ -1962,7 +1962,7 @@ narrowed to."
       (message "Cannot narrow to indirect buffer from visual block mode.")
     (when evil-ex-active-highlights-alist
       (spacemacs/evil-search-clear-highlight))
-    (spacemacs/clone-indirect-buffer-de-activate-mark)
+    (call-interactively 'clone-indirect-buffer)
     (call-interactively narrower)
     (message (format "%s narrowed to an indirect buffer" target-name))))
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1941,7 +1941,9 @@ This is controlled by the `:size-limit-kb' property of
 (defun spacemacs/clone-indirect-buffer-de-activate-mark ()
   "This is a workaround for the evil visual state error message like:
 Error in post-command-hook (evil-visual-post-command):
-(error \"Marker points into wrong buffer\" #<marker at 27875 in .spacemacs<2>>)"
+(error \"Marker points into wrong buffer\" #<marker at 27875 in .spacemacs<2>>)
+
+See https://github.com/emacs-evil/evil/issues/280"
   (let ((region-was-active (region-active-p)))
     (when region-was-active (deactivate-mark))
     (call-interactively 'clone-indirect-buffer)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1949,31 +1949,37 @@ See https://github.com/emacs-evil/evil/issues/280"
     (apply f args)
     (when region-was-active (activate-mark))))
 
-(defun spacemacs/narrow-to-indirect-buffer (narrower target-name)
-  "Use the function `narrower' to narrow within an indirect buffer, except where
-the starting buffer is in a state (such as visual block mode) that would cause
-this to work incorrectly. `target-name' is the string name of the entity being
-narrowed to."
+(defun spacemacs/narrow-to-indirect-buffer (narrower target-kind target-name)
+  "Use the function NARROWER to narrow within an indirect buffer.
+
+TARGET-KIND is the name of the kind of entity being narrowed to,
+and TARGET-NAME is function that returns an optional name of the
+entity, which will be included in the new buffer's name.
+
+Error if the starting buffer is in a state (such as visual block
+mode) that would cause this to work incorrectly."
   ;; There may be a way to get visual block mode working similar to the
   ;; workaround we did for visual line mode; this usecase however seems like an
   ;; edgecase at best, so let's patch it if we find out it's needed; otherwise
   ;; let's not hold up the base functionality anymore.
-  (if (and (eq evil-state 'visual) (eq evil-visual-selection 'block))
-      (message "Cannot narrow to indirect buffer from visual block mode.")
+  (if (and (evil-visual-state-p) (eq evil-visual-selection 'block))
+      (user-error "Cannot narrow to indirect buffer from visual block mode")
     (when evil-ex-active-highlights-alist
       (spacemacs/evil-search-clear-highlight))
-    (call-interactively 'clone-indirect-buffer)
+    (let* ((target-name (and target-name (ignore-errors (funcall target-name))))
+           (buffer-name (and target-name (concat (buffer-name) "::" target-name))))
+      (clone-indirect-buffer buffer-name 'display))
     (call-interactively narrower)
-    (message (format "%s narrowed to an indirect buffer" target-name))))
+    (message (format "%s narrowed to an indirect buffer" target-kind))))
 
 (defun spacemacs/narrow-to-defun-indirect-buffer ()
   (interactive)
-  (spacemacs/narrow-to-indirect-buffer 'narrow-to-defun "Function"))
+  (spacemacs/narrow-to-indirect-buffer 'narrow-to-defun "Function" #'which-function))
 
 (defun spacemacs/narrow-to-page-indirect-buffer ()
   (interactive)
-  (spacemacs/narrow-to-indirect-buffer 'narrow-to-page "Page"))
+  (spacemacs/narrow-to-indirect-buffer 'narrow-to-page "Page" nil))
 
 (defun spacemacs/narrow-to-region-indirect-buffer ()
   (interactive)
-  (spacemacs/narrow-to-indirect-buffer 'narrow-to-region "Region"))
+  (spacemacs/narrow-to-indirect-buffer 'narrow-to-region "Region" nil))


### PR DESCRIPTION
Inspired by `org-tree-to-indirect-buffer` (, s b in org-mode), try to
include the name of the function when creating a narrowed indirect
buffer for that function.

This PR also includes a couple of other improvements; please see the
individual commits for details.