### PR TITLE
* COPYRIGHT: cleanup the help-fns+ section

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -45,27 +45,6 @@ copyright notices and license terms:
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-* help-fns+.el, under layers/+spacemacs/spacemacs-defaults/local/help-fns+.
-
-    Published on <https://www.emacswiki.org/emacs/HelpPlus> and thus licensed under
-    GPL 2.0.
-
-    Copyright (C) 2007-2021, Drew Adams, all rights reserved.
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
 * org-async-init.el, under layers/+emacs/org/local.
 
     Copyright (C) T. Verron.


### PR DESCRIPTION
The `help-fns+` was removed in #16451, clean up the section in `COPYRIGHT` file.