### PR TITLE
Move wgrep customizations into spacemacs-editing from ivy/compleseus

### DIFF
--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -324,50 +324,12 @@ Note: this function relies on embark internals and might break upon embark updat
              (car (nth (1+ idx) consult--narrow-keys))))
        (caar consult--narrow-keys)))))
 
-(defun spacemacs/compleseus-grep-change-to-wgrep-mode ()
-  (interactive)
-  (require 'wgrep)
-  (wgrep-change-to-wgrep-mode)
-  (evil-normal-state))
-
 (defun spacemacs/consult-edit ()
   "Export the consult buffer and make the buffer editable righ away."
   (interactive)
   (require 'embark)
-  (let ((embark-after-export-hook
-         '(spacemacs/compleseus-grep-change-to-wgrep-mode)))
+  (let ((embark-after-export-hook '(spacemacs/grep-change-to-wgrep-mode)))
     (embark-export)))
-
-(defun spacemacs/wgrep-finish-edit ()
-  "Set back the default evil state when finishing editing."
-  (interactive)
-  (wgrep-finish-edit)
-  (spacemacs//grep-set-evil-state))
-
-(defun spacemacs/wgrep-abort-changes ()
-  "Set back the default evil state when aborting editing."
-  (interactive)
-  (wgrep-abort-changes)
-  (spacemacs//grep-set-evil-state))
-
-(defun spacemacs//grep-set-evil-state ()
-  "Set the evil state for the read-only grep buffer given the current editing style."
-  (if (eq dotspacemacs-editing-style 'emacs)
-      (evil-emacs-state)
-    (evil-motion-state)))
-
-(defun spacemacs/wgrep-abort-changes-and-quit ()
-  "Abort changes and quit."
-  (interactive)
-  (spacemacs/wgrep-abort-changes)
-  (quit-window))
-
-(defun spacemacs/wgrep-save-changes-and-quit ()
-  "Save changes and quit."
-  (interactive)
-  (spacemacs/wgrep-finish-edit)
-  (wgrep-save-all-buffers)
-  (quit-window))
 
 (defvar compleseus--previous-preview-keys nil
   "variable to store the former value of preview keys or nil if the preview

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -42,9 +42,7 @@
      :toggle (eq compleseus-engine 'vertico)
      :location elpa)
     (vertico-posframe :toggle (and (eq compleseus-engine 'vertico)
-                                  compleseus-use-vertico-posframe))
-    (grep :location built-in)
-    wgrep))
+                                   compleseus-use-vertico-posframe))))
 
 (defun compleseus/pre-init-auto-highlight-symbol ()
   (spacemacs|use-package-add-hook auto-highlight-symbol
@@ -478,23 +476,6 @@
             (right-fringe . 4)
             (undecorated . nil)))
     (vertico-posframe-mode 1)))
-
-(defun compleseus/post-init-grep ()
-  (spacemacs/set-leader-keys-for-major-mode 'grep-mode
-    "w" 'spacemacs/compleseus-grep-change-to-wgrep-mode
-    "f" 'next-error-follow-minor-mode))
-
-(defun compleseus/init-wgrep ()
-  (evil-define-key 'normal wgrep-mode-map ",," #'spacemacs/wgrep-finish-edit)
-  (evil-define-key 'normal wgrep-mode-map ",c" #'spacemacs/wgrep-finish-edit)
-  (evil-define-key 'normal wgrep-mode-map ",a" #'spacemacs/wgrep-abort-changes)
-  (evil-define-key 'normal wgrep-mode-map ",k" #'spacemacs/wgrep-abort-changes)
-  (evil-define-key 'normal wgrep-mode-map ",q" #'spacemacs/wgrep-abort-changes-and-quit)
-  (evil-define-key 'normal wgrep-mode-map ",s" #'spacemacs/wgrep-save-changes-and-quit)
-  (evil-define-key 'normal wgrep-mode-map ",r" #'wgrep-toggle-readonly-area)
-  (evil-define-key 'normal wgrep-mode-map ",d" #'wgrep-mark-deletion)
-  (evil-define-key 'normal wgrep-mode-map ",f" #'next-error-follow-minor-mode)
-  )
 
 (defun compleseus/init-compleseus-spacemacs-help ()
   (use-package compleseus-spacemacs-help

--- a/layers/+completion/ivy/funcs.el
+++ b/layers/+completion/ivy/funcs.el
@@ -147,7 +147,7 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
 (defun spacemacs//counsel-edit ()
   "Edit the current search results in a buffer using wgrep."
   (interactive)
-  (run-with-idle-timer 0 nil 'spacemacs/ivy-wgrep-change-to-wgrep-mode)
+  (run-with-idle-timer 0 nil 'spacemacs/grep-change-to-wgrep-mode)
   (ivy-occur))
 
 (defun spacemacs//gne-init-counsel ()
@@ -432,11 +432,6 @@ commands."
                       (let ((repl (cdr (assoc candidate spacemacs-repl-list))))
                         (require (car repl))
                         (call-interactively (cdr repl))))))
-
-(defun spacemacs/ivy-wgrep-change-to-wgrep-mode ()
-  (interactive)
-  (ivy-wgrep-change-to-wgrep-mode)
-  (evil-normal-state))
 
 ;;; Evil
 

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -47,6 +47,7 @@
         recentf
         smex
         swiper
+        wgrep
         ))
 
 (defun ivy/init-all-the-icons-ivy-rich ()
@@ -279,10 +280,6 @@
       (define-key mode-map "U" 'ivy-occur-revert-buffer))
     (ivy-set-occur 'spacemacs/counsel-search
                    'spacemacs//counsel-occur)
-    (when (configuration-layer/package-used-p 'wgrep)
-      (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
-        "w" 'spacemacs/grep-change-to-wgrep-mode
-        "s" 'wgrep-save-all-buffers))
 
     ;; emacs 27 extend line for ivy highlight
     (setf (alist-get 't ivy-format-functions-alist)
@@ -424,3 +421,8 @@
       "sb" 'swiper-all
       "sB" 'swiper-all-thing-at-point)
     (global-set-key "\C-s" 'swiper)))
+
+(defun ivy/post-init-wgrep ()
+  (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
+    "w" 'spacemacs/grep-change-to-wgrep-mode
+    "s" 'wgrep-save-all-buffers))

--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -47,7 +47,6 @@
         recentf
         smex
         swiper
-        wgrep
         ))
 
 (defun ivy/init-all-the-icons-ivy-rich ()
@@ -280,9 +279,10 @@
       (define-key mode-map "U" 'ivy-occur-revert-buffer))
     (ivy-set-occur 'spacemacs/counsel-search
                    'spacemacs//counsel-occur)
-    (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
-      "w" 'spacemacs/ivy-wgrep-change-to-wgrep-mode
-      "s" 'wgrep-save-all-buffers)
+    (when (configuration-layer/package-used-p 'wgrep)
+      (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode
+        "w" 'spacemacs/grep-change-to-wgrep-mode
+        "s" 'wgrep-save-all-buffers))
 
     ;; emacs 27 extend line for ivy highlight
     (setf (alist-get 't ivy-format-functions-alist)
@@ -424,9 +424,3 @@
       "sb" 'swiper-all
       "sB" 'swiper-all-thing-at-point)
     (global-set-key "\C-s" 'swiper)))
-
-(defun ivy/init-wgrep ()
-  (evil-define-key 'normal wgrep-mode-map ",," 'wgrep-finish-edit)
-  (evil-define-key 'normal wgrep-mode-map ",c" 'wgrep-finish-edit)
-  (evil-define-key 'normal wgrep-mode-map ",a" 'wgrep-abort-changes)
-  (evil-define-key 'normal wgrep-mode-map ",k" 'wgrep-abort-changes))

--- a/layers/+spacemacs/spacemacs-editing/funcs.el
+++ b/layers/+spacemacs/spacemacs-editing/funcs.el
@@ -148,3 +148,43 @@ See issues #6520 and #13172"
     (if arg
         (insert-uuid-cid uuid)
       (insert uuid))))
+
+
+;;; wgrep
+
+(defun spacemacs//grep-set-evil-state ()
+  "Set the evil state for the read-only grep buffer given the current editing style."
+  (if (eq dotspacemacs-editing-style 'emacs)
+      (evil-emacs-state)
+    (evil-motion-state)))
+
+(defun spacemacs/wgrep-finish-edit ()
+  "Set back the default evil state when finishing editing."
+  (interactive)
+  (wgrep-finish-edit)
+  (spacemacs//grep-set-evil-state))
+
+(defun spacemacs/wgrep-abort-changes ()
+  "Set back the default evil state when aborting editing."
+  (interactive)
+  (wgrep-abort-changes)
+  (spacemacs//grep-set-evil-state))
+
+(defun spacemacs/wgrep-abort-changes-and-quit ()
+  "Abort changes and quit."
+  (interactive)
+  (spacemacs/wgrep-abort-changes)
+  (quit-window))
+
+(defun spacemacs/wgrep-save-changes-and-quit ()
+  "Save changes and quit."
+  (interactive)
+  (spacemacs/wgrep-finish-edit)
+  (wgrep-save-all-buffers)
+  (quit-window))
+
+(defun spacemacs/grep-change-to-wgrep-mode ()
+  (interactive)
+  (require 'wgrep)
+  (wgrep-change-to-wgrep-mode)
+  (evil-normal-state))

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -54,6 +54,7 @@
     (vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
     (evil-vimish-fold :toggle (eq 'vimish dotspacemacs-folding-method))
     (evil-easymotion :toggle (memq dotspacemacs-editing-style '(vim hybrid)))
+    wgrep
     ws-butler))
 
 ;; Initialization of packages
@@ -664,3 +665,18 @@ See variable `undo-fu-session-directory'." dir))
     :init
     (setq unkillable-scratch-do-not-reset-scratch-buffer t)
     (unkillable-scratch dotspacemacs-scratch-buffer-unkillable)))
+
+(defun spacemacs-editing/init-wgrep ()
+  (spacemacs/set-leader-keys-for-major-mode 'grep-mode
+    "s" 'wgrep-save-all-buffers
+    "w" 'spacemacs/grep-change-to-wgrep-mode
+    "f" 'next-error-follow-minor-mode)
+  (evil-define-key 'normal wgrep-mode-map ",," #'spacemacs/wgrep-finish-edit)
+  (evil-define-key 'normal wgrep-mode-map ",c" #'spacemacs/wgrep-finish-edit)
+  (evil-define-key 'normal wgrep-mode-map ",a" #'spacemacs/wgrep-abort-changes)
+  (evil-define-key 'normal wgrep-mode-map ",k" #'spacemacs/wgrep-abort-changes)
+  (evil-define-key 'normal wgrep-mode-map ",q" #'spacemacs/wgrep-abort-changes-and-quit)
+  (evil-define-key 'normal wgrep-mode-map ",s" #'spacemacs/wgrep-save-changes-and-quit)
+  (evil-define-key 'normal wgrep-mode-map ",r" #'wgrep-toggle-readonly-area)
+  (evil-define-key 'normal wgrep-mode-map ",d" #'wgrep-mark-deletion)
+  (evil-define-key 'normal wgrep-mode-map ",f" #'next-error-follow-minor-mode))


### PR DESCRIPTION
These two layers, ivy and compleseus, were duplicating (imperfectly)
the key bindings for wgrep.  There's no clear reason why wgrep support
should require these layers either; helm users might reasonably want
these key bindings.