### PR TITLE
Use "load-prefer-newer" for loading Spacemacs core

### DIFF
--- a/init.el
+++ b/init.el
@@ -40,10 +40,6 @@
 (load (concat spacemacs-core-directory "core-compilation")
       nil (not init-file-debug))
 (load spacemacs--last-emacs-version-file t (not init-file-debug))
-(when (or (not (string= spacemacs--last-emacs-version emacs-version))
-          (> 0 (spacemacs//dir-byte-compile-state
-                (concat spacemacs-core-directory "libs/"))))
-  (spacemacs//remove-byte-compiled-files-in-dir spacemacs-core-directory))
 ;; Update saved Emacs version.
 (unless (string= spacemacs--last-emacs-version emacs-version)
   (spacemacs//update-last-emacs-version))
@@ -57,7 +53,11 @@
   ;; https://github.com/syl20bnr/spacemacs/issues/11585 "Symbol's value as
   ;; variable is void: \213" when emacs is not built having:
   ;; `--without-compress-install`
-  (let ((please-do-not-disable-file-name-handler-alist nil))
+
+  ;; Users may update Spacemacs *.el files directly without byte-compile
+  ;; them(eg: git pull in Spacemacs folder), so we prefer newer files
+  (let ((load-prefer-newer t)
+        (please-do-not-disable-file-name-handler-alist nil))
     (require 'core-spacemacs)
     (spacemacs/dump-restore-load-path)
     (configuration-layer/load-lock-file)

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -254,8 +254,5 @@ or `nil' to only save and not visit the file."
 ;; used for restoring recently killed buffers.
 (add-hook 'kill-buffer-hook #'spacemacs//add-buffer-to-killed-list)
 
-;; Don't load outdated compiled files.
-(setq load-prefer-newer t)
-
 ;; Suppress the *Warnings* buffer when native compilation shows warnings.
 (setq native-comp-async-report-warnings-errors 'silent)


### PR DESCRIPTION
Currently the Spacemacs try to remove all *.elc at the beginning of startup, and set `load-prefer-newer` in the `layers/+spacemacs/spacemacs-defaults/config.el`. 

Here we set the `load-prefer-newer` to `t` during startup to do similar work; and Spacemacs will cleaup the staled `*.elc` in the after startup hook.
https://github.com/syl20bnr/spacemacs/blob/c3269f6a3b9ce8ee57f362c2b053b5381f8727e3/core/core-spacemacs.el#L374-L379