### PR TITLE
* FAQ.org: move "package-qucikstar" node to linux section

### DIFF
--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -47,13 +47,13 @@
   - [[#modify-spacemacs-documentation-look-space-doc-mode][Modify spacemacs documentation look (space-doc-mode)]]
 - [[#linux][Linux]]
   - [[#error-on-deleting-a-system-package][Error on deleting a system package]]
+  - [[#speedup-the-spacemacs-with-package-quickstart][Speedup the Spacemacs with package-quickstart]]
 - [[#windows][Windows]]
   - [[#why-do-the-fonts-look-crappy-on-windows][Why do the fonts look crappy on Windows?]]
   - [[#why-is-there-no-spacemacs-logo-in-the-startup-buffer][Why is there no Spacemacs logo in the startup buffer?]]
   - [[#why-are-all-packages-unavailable][Why are all packages unavailable?]]
   - [[#the-powerline-isnt-shown-correctly-when-spacemacs-is-used-within-putty][The powerline isn't shown correctly when Spacemacs is used within =PuTTY=]]
   - [[#speedup-the-spacemacs-with-load-hints-feature][Speedup the Spacemacs with load-hints feature]]
-  - [[#speedup-the-spacemacs-with-package-quickstart][Speedup the Spacemacs with package-quickstart]]
 
 * Common
 ** Which version of Spacemacs am I running?
@@ -588,6 +588,21 @@ in your =.spacemacs= file.
 In addition, you also need to add the said package to =dotspacemacs-frozen-packages= in your
 =.spacemacs=, so that you will be able to update your Emacs packages successfully.
 
+** Speedup the Spacemacs with package-quickstart
+The ~package-quickstart~ will collect all the ~*-autoloads.el~ into one file
+~package-quickstart-file~ to speed up the packages loading procedure. After
+Spacemacs startup, manually executing the function ~package-quickstart-refreshe~
+to generate the package quickstart file, then setting the
+~dotspacemacs-enable-package-quickstart~ to ~t~, on the next startup, the
+Spacemacs will set up packages with loading the ~package-quickstart-file~, won't
+call the ~package-initialize~ (which will scan ~package-user-dir~ and active
+packages one by one).
+
+*NOTE*: Please enable the ~load-hints~ feature first, otherwise the
+~package-quickstart-file~ addes all the package directories into the ~load-path~
+may lead Spacemacs startup slower than no ~package-quickstartup~ feature
+enabled.
+
 * Windows
 ** Why do the fonts look crappy on Windows?
 You can install [[https://code.google.com/archive/p/gdipp/][GDIPP]] (simplest) or [[https://code.google.com/p/mactype/][MacType]] (more complete) on Windows to get
@@ -615,15 +630,15 @@ You can follow [[http://mschulte.nl/posts/using-powerline-in-PuTTY.html][this ex
 ** Speedup the Spacemacs with load-hints feature
 The Spacemacs user maybe feel it's slow during startup or slow to opening a
 =*.org= file on Windows system. The root cause is the package manager
-(package.el) will add the package directorie paths into Emacs' ~load-path~
+(package.el) will add the package directory paths into Emacs' ~load-path~
 seperately, while a Spacemacs-base distribution maybe installes more than 100
 packages, and the ~load-path~ will has more than 100 entries with packages
 paths on the head, emacs builtin paths on the tail. Then a simple
 src_elisp{(require 'org)} will trigger the emacs walks through the ~load-path~
 from the head to the tail to seach =org.dll=, =org.dll.gz=, =org.elc=,
-=org.elc.gz=, =org.el=, =org.el.gz=, that will be more 600 (100*6) attemptions
-to open the desired files, but Windows system slow on the open-file API
-(Linux/BSD are mutch faster).
+=org.elc.gz=, =org.el=, =org.el.gz=, that will be more than 600 (100*6)
+attemptions to open the desired files, but Windows system slow on the open-file
+API (Linux/BSD are mutch faster).
 
 The posible solutions are:
 1) reducing the ~load-path~ entries by collecting the packages files into one
@@ -641,17 +656,3 @@ Spacemacs implemented the ~load-hints~ feature, controled by the
 ~spacemacs//package-regenerate-autoloads~ and restart the Spacemacs to try this
 feature to observer it speedups the Spacemacs or not on the Windows OS.
 
-** Speedup the Spacemacs with package-quickstart
-The ~package-quickstart~ will collect all the ~*-autoloads.el~ into one file
-~package-quickstart-file~ to speed up the packages loading procedure. After
-Spacemacs startup, manually executing the function ~package-quickstart-refreshe~
-to generate the package quickstart file, then setting the
-~dotspacemacs-enable-package-quickstart~ to ~t~, on the next startup, the
-Spacemacs will set up packages with loading the ~package-quickstart-file~, won't
-call the ~package-initialize~ (which will scan packages directories and active
-package one by one).
-
-*NOTE*: Please enable the ~load-hints~ feature first, otherwise the
-~package-quickstart-file~ addes all the package directories into the ~load-path~
-may lead Spacemacs startup slower than no ~package-quickstartup~ feature
-enabled.


### PR DESCRIPTION
Moved the doc "package-qucikstart" node to the Linux section for it actually work better on Linux.

And there also has other minor doc changes. 

Please help review the patch, thanks.