### PR TITLE
Update mu4e packages.el to work with more recent mu4e versions

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -41,11 +41,9 @@
       (spacemacs/add-to-hooks 'spacemacs-layouts/add-mu4e-buffer-to-persp
                               '(mu4e-main-mode-hook
                                 mu4e-headers-mode-hook
-                                mu4e-view-mode-hook
+                                mu4e-after-view-message-hook
                                 mu4e-compose-mode-hook))
       (call-interactively 'mu4e)
-      (call-interactively 'mu4e-update-index)
-
       (define-advice mu4e~stop (:after nil kill-mu4e-layout-after-mu4e~stop)
         (when mu4e-spacemacs-kill-layout-on-exit
           (persp-kill mu4e-spacemacs-layout-name))))))


### PR DESCRIPTION
- When selecting a message in headers view (e.g., press RETURN) the window is split and then both windows contain the message view. Switch to using mu4e-after-view-message-hook returns to correct behavior where only the newly created window from the split contains the message and the existing window continues to hold the headers view.

- Don't call mu4e-update-index as this is appears to already being done and so this generates an error.