### PR TITLE
* core/core-display-init.el: fix detecting display initialized

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -24,32 +24,34 @@
 (defvar spacemacs--after-display-system-init-list '()
   "List of functions to be run after the display system is initialized.")
 
+(defun spacemacs--display-system-initialized-p ()
+  "Dectect the display system initialized or not."
+  (cond ((boundp 'ns-initialized) ns-initialized)
+        ;; w32-initialized gets set too early, so
+        ;; if we're on Windows, check the list of fonts
+        ;; instead (this is nil until the graphics system
+        ;; is initialized)
+        ((boundp 'w32-initialized) (font-family-list))
+        ((boundp 'x-initialized) x-initialized)
+        ;; fallback to normal loading behavior only if in a GUI
+        (t (display-graphic-p))))
+
 (define-advice server-create-window-system-frame
     (:after (&rest _) spacemacs-init-display)
   "After Emacs server creates a frame, run functions queued in
 `SPACEMACS--AFTER-DISPLAY-SYSTEM-INIT-LIST' to do any setup that needs to have
 the display system initialized."
-  (dolist (fn (reverse spacemacs--after-display-system-init-list))
-    (funcall fn))
-  (advice-remove 'server-create-window-system-frame
-                 #'server-create-window-system-frame@spacemacs-init-display))
+  (when (spacemacs--display-system-initialized-p)
+    (mapc #'funcall (reverse spacemacs--after-display-system-init-list))
+    (advice-remove 'server-create-window-system-frame
+                   #'server-create-window-system-frame@spacemacs-init-display)))
 
 (defmacro spacemacs|do-after-display-system-init (&rest body)
   "If the display-system is initialized, run `BODY', otherwise,
 add it to a queue of actions to perform after the first graphical frame is
 created."
-  `(let ((init (cond ((boundp 'ns-initialized) ns-initialized)
-                     ;; w32-initialized gets set too early, so
-                     ;; if we're on Windows, check the list of fonts
-                     ;; instead (this is nil until the graphics system
-                     ;; is initialized)
-                     ((boundp 'w32-initialized) (font-family-list))
-                     ((boundp 'x-initialized) x-initialized)
-                     ;; fallback to normal loading behavior only if in a GUI
-                     (t (display-graphic-p)))))
-     (if init
-         (progn
-           ,@body)
-       (push (lambda () ,@body) spacemacs--after-display-system-init-list))))
+  `(if (not (spacemacs--display-system-initialized-p))
+       (push (lambda () ,@body) spacemacs--after-display-system-init-list)
+     ,@body))
 
 (provide 'core-display-init)


### PR DESCRIPTION
Fix a bug that the Spacemacs failed on detecting the display initialized status, here are the steps on Ubuntu:
```shell
emacs --daemon
emacsclient -c --display=:321 # non-exists display
* Cannot find any of the specified fonts (Source Code Pro)! Font settings may not be correct.
```
As the patch showed, the function `server-create-window-system-frame@spacemacs-init-display` should detect the display system to make sure display ready there.