### PR TITLE
Support the themes located in a specific package

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -341,16 +341,20 @@ package name does not match theme name + `-theme' suffix.")
 (defvar spacemacs-post-theme-change-hook nil
   "Hook run after theme has changed.")
 
-(defun spacemacs/get-theme-package-name (theme-name)
+(defun spacemacs/get-theme-package-name (theme)
   "Returns the package theme for the given THEME name."
-  (cond
-   ;; built-in
-   ((memq theme-name emacs-built-in-themes) nil)
-   ;; from explicit alist
-   ((assq theme-name spacemacs-theme-name-to-package)
-    (cdr (assq theme-name spacemacs-theme-name-to-package)))
-   ;; fallback to <name>-theme
-   (t (intern (format "%S-theme" theme-name)))))
+  (if-let* (((listp theme))
+            (pkg-name (plist-get (cdr theme) :package)))
+      pkg-name
+    (let ((theme-name (or (car-safe theme) theme)))
+      (cond
+       ;; built-in
+       ((memq theme-name emacs-built-in-themes) nil)
+       ;; from explicit alist
+       ((assq theme-name spacemacs-theme-name-to-package)
+        (cdr (assq theme-name spacemacs-theme-name-to-package)))
+       ;; fallback to <name>-theme
+       (t (intern (format "%S-theme" theme-name)))))))
 
 (defun spacemacs//get-theme-name (theme)
   "Return the name of THEME."
@@ -360,8 +364,7 @@ package name does not match theme name + `-theme' suffix.")
 
 (defun spacemacs//get-theme-package-directory (theme)
   "Return the THEME location on disk."
-  (let* ((theme-name (spacemacs//get-theme-name theme))
-         (pkg-name (spacemacs/get-theme-package-name theme-name))
+  (let* ((pkg-name (spacemacs/get-theme-package-name theme))
          (dir (when (listp theme)
                 (configuration-layer/get-location-directory
                  pkg-name
@@ -479,8 +482,7 @@ has been changed to THEME."
   "Add all theme packages from `dotspacemacs-themes' to packages to install."
   (setq dotspacemacs--additional-theme-packages nil)
   (dolist (theme dotspacemacs-themes)
-    (let* ((theme-name (spacemacs//get-theme-name theme))
-           (pkg-name (spacemacs/get-theme-package-name theme-name))
+    (let* ((pkg-name (spacemacs/get-theme-package-name theme))
            (theme2 (copy-tree theme)))
       (when pkg-name
         (if (listp theme2)

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -73,6 +73,7 @@
     - [[#default-theme][Default theme]]
     - [[#choosing-themes][Choosing themes]]
       - [[#themes-transient-state][Themes Transient State]]
+    - [[#external-theme][External theme]]
     - [[#browsing-themes][Browsing themes]]
     - [[#notes][Notes]]
   - [[#font][Font]]
@@ -1204,6 +1205,16 @@ You can cycle between the themes declared in =dotspacemacs-themes= with
 | ~n~ or ~<right>~ | change to the next theme                      |
 | ~p~ or ~<left>~  | change to the previous theme                  |
 | ~t~ or ~<up>~    | open helm-themes to select an installed theme |
+
+*** External theme
+For an external theme from a package, please add the theme and its package into
+the =dotspacemacs-themes=, then the Spacemacs will install the package and apply
+the theme. Here is an example:
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-themes
+                '((humanoid-light :package humanoid-themes)
+                  spacemacs-dark))
+#+end_src
 
 *** Browsing themes
 You can see samples of all themes included in the =themes-megapack= layer


### PR DESCRIPTION
Fix #15538  by support `(<theme> :package <name>)`. 
Example:
```elisp
    dotspacemacs-themes '((humanoid-light :package humanoid-themes)
                          spacemacs-dark)
```