### PR TITLE
Improve modeline for magic-latex-buffer

### DIFF
--- a/layers/+lang/latex/packages.el
+++ b/layers/+lang/latex/packages.el
@@ -257,6 +257,7 @@
 (defun latex/init-magic-latex-buffer ()
   (use-package magic-latex-buffer
     :defer t
+    :spacediminish (magic-latex-buffer " ✦" " mL")
     :init
     (add-hook 'TeX-update-style-hook 'magic-latex-buffer)
     (setq magic-latex-enable-block-highlight t


### PR DESCRIPTION
Minor improvement to the modeline for magic-latex-buffer. I considered alternative symbols, such as ✨, but I chose a black-and-white symbol for consistency with the modeline.