### PR TITLE
Fix broken website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 <a name="top" id="fork-destination-box"></a>
-<a href="https://develop.spacemacs.org"><img src="assets/spacemacs-badge.svg" alt="Made with Spacemacs" height="20"></a>
+<a href="https://spacemacs.org"><img src="assets/spacemacs-badge.svg" alt="Made with Spacemacs" height="20"></a>
 <a href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img src="assets/gplv3.png" alt="GPLv3 Software" align="right" height="20"></a>
 <a href="https://www.twitter.com/spacemacs"><img src="https://i.imgur.com/tXSoThF.png" alt="Twitter" align="right" height="20"></a>
 
 <!-- logo and links -->
 <p align="center"><img src="doc/img/title2.png" alt="Spacemacs"/></p>
 <p align="center">
-<b><a href="https://develop.spacemacs.org/doc/DOCUMENTATION#core-pillars">philosophy</a></b>
+<b><a href="https://spacemacs.org/doc/DOCUMENTATION#core-pillars">philosophy</a></b>
 |
-<b><a href="https://develop.spacemacs.org/doc/DOCUMENTATION#who-can-benefit-from-this">for whom?</a></b>
+<b><a href="https://spacemacs.org/doc/DOCUMENTATION#who-can-benefit-from-this">for whom?</a></b>
 |
-<b><a href="https://develop.spacemacs.org/doc/DOCUMENTATION#screenshots">screenshots</a></b>
+<b><a href="https://spacemacs.org/doc/DOCUMENTATION#screenshots">screenshots</a></b>
 |
-<b><a href="https://develop.spacemacs.org/doc/DOCUMENTATION.html">documentation</a></b>
+<b><a href="https://spacemacs.org/doc/DOCUMENTATION.html">documentation</a></b>
 |
 <b><a href="CONTRIBUTING.org">contribute</a></b>
 |
-<b><a href="https://develop.spacemacs.org/doc/DOCUMENTATION#achievements">achievements</a></b>
+<b><a href="https://spacemacs.org/doc/DOCUMENTATION#achievements">achievements</a></b>
 |
-<b><a href="https://develop.spacemacs.org/doc/FAQ">FAQ</a></b>
+<b><a href="https://spacemacs.org/doc/FAQ">FAQ</a></b>
 </p>
 
 
@@ -579,24 +579,24 @@ badge](#top).
 
 If you used Spacemacs in a project, and you want to show that fact, you can use
 the Spacemacs badge: [![Built with
-Spacemacs](https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg)](https://develop.spacemacs.org)
+Spacemacs](https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg)](https://spacemacs.org)
 
 - For Markdown:
 
    ```markdown
-   [![Built with Spacemacs](https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg)](https://develop.spacemacs.org)
+   [![Built with Spacemacs](https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg)](https://spacemacs.org)
    ```
 
 - For HTML:
 
    ```html
-   <a href="https://develop.spacemacs.org"><img alt="Built with Spacemacs" src="https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg" /></a>
+   <a href="https://spacemacs.org"><img alt="Built with Spacemacs" src="https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg" /></a>
    ```
 
 - For Org-mode:
 
    ```org
-   [[https://develop.spacemacs.org][file:https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg]]
+   [[https://spacemacs.org][file:https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg]]
    ```
 
 Thank you!

--- a/core/core-documentation.el
+++ b/core/core-documentation.el
@@ -174,7 +174,7 @@ the current buffer already has headlines with -<N> postfixes.
 (defun spacemacs//org-heading-annotate-custom-id ()
   "Annotate headings with the indexes that GitHub uses for linking.
 `org-html-publish-to-html' will use them instead of the default #orgheadline{N}.
-This way the GitHub links and the https://develop.spacemacs.org/ links will be
+This way the GitHub links and the https://spacemacs.org/ links will be
 compatible."
   (let ((heading-regexp "^[\\*]+\s\\(.*\\).*$"))
     (goto-char (point-min))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -884,14 +884,14 @@ REAL-WIDTH: the real width of the line.  If the line contains an image, the size
                  :help-echo "Open the Spacemacs GitHub page in your browser."
                  :mouse-face 'highlight
                  :follow-link "\C-m"
-                 "https://develop.spacemacs.org")
+                 "https://spacemacs.org")
   (insert " ")
   (widget-create 'url-link
                  :tag (propertize "Documentation" 'face 'font-lock-keyword-face)
                  :help-echo "Open the Spacemacs documentation in your browser."
                  :mouse-face 'highlight
                  :follow-link "\C-m"
-                 "https://develop.spacemacs.org/doc/DOCUMENTATION.html")
+                 "https://spacemacs.org/doc/DOCUMENTATION.html")
   (insert " ")
   (widget-create 'url-link
                  :tag (propertize "Gitter Chat" 'face 'font-lock-keyword-face)

--- a/doc/CI_PLUMBING.org
+++ b/doc/CI_PLUMBING.org
@@ -34,7 +34,7 @@ This file will help you understand CI setup of [[https://github.com/syl20bnr/spa
 ** TLDR
 Spacemacs is big - the active maintainers team is small. The more we can
 automate - the better. We use  [[https://circleci.com/][CircleCI]], [[https://github.com/features/actions][GitHub Actions]] and [[https://www.docker.com/][Docker]] to test PRs,
-update built-in files, fix documentation and export it to [[https://develop.spacemacs.org/][develop.spacemacs.org]].
+update built-in files, fix documentation and export it to [[https://spacemacs.org/][spacemacs.org]].
 Most of the code consists of bash/EmacsLisp scripts and yml files, but some of
 the documentation tools are written in Clojure.
 If you prefer reading code instead of documentation, dive into [[https://github.com/syl20bnr/spacemacs/tree/develop/.circleci][CircleCI]] and

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -448,7 +448,7 @@ Example:
 #+END_SRC
 
 **** Overriding a layer package
-See [[https://develop.spacemacs.org/doc/FAQ.html#how-to-override-a-layer-package][this answer in the FAQ's]].
+See [[https://spacemacs.org/doc/FAQ.html#how-to-override-a-layer-package][this answer in the FAQ's]].
 
 *** Without a layer
 Sometimes a layer can be an unnecessary overhead, this is the case if you just
@@ -1617,7 +1617,7 @@ squared symbols like =🅿=.
 | ~SPC t E h~   | =Ⓔh=    | Eh    | hybrid editing style (hybrid mode)                                   |
 | ~SPC t f~     | =ⓕ=     | f     | fill-column-indicator mode                                           |
 | ~SPC t F~     | =Ⓕ=     | F     | auto-fill mode                                                       |
-| ~SPC t G~     | =Ⓖ=     | G     | [[https://develop.spacemacs.org/layers/+tags/gtags/README.html][ggtags]] mode                                                          |
+| ~SPC t G~     | =Ⓖ=     | G     | [[https://spacemacs.org/layers/+tags/gtags/README.html][ggtags]] mode                                                          |
 | ~SPC t g~     | =ⓖ=     | g     | [[https://github.com/roman/golden-ratio.el][golden-ratio]] mode                                                    |
 | ~SPC t h i~   | =ⓗi=    | hi    | toggle highlight indentation levels                                  |
 | ~SPC t h c~   | =ⓗc=    | hc    | toggle highlight indentation current column                          |

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -199,7 +199,7 @@ change your terminal color palette. More explanations can be found on
 This is a feature of Spacemacs, enabling you to easily escape from a lot of
 situations, like escaping from =insert state= to =normal state=.
 
-The sequence of characters used can be customized. See the [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#escaping][documentation]] for
+The sequence of characters used can be customized. See the [[https://spacemacs.org/doc/DOCUMENTATION.html#escaping][documentation]] for
 more information.
 
 If you don't like this feature, you can deactivate it by adding =evil-escape= to
@@ -289,7 +289,7 @@ the layer by commenting in/out the line in =dotspacemacs-additional-packages=
 =dotspacemacs/user-config=).
 
 You could also fully replace (i.e. overwrite) the layer version of the package
-by using a Quelpa recipe with the pseudo-fetcher =local= as described [[https://develop.spacemacs.org/doc/LAYERS.html#packagesel][here]] and
+by using a Quelpa recipe with the pseudo-fetcher =local= as described [[https://spacemacs.org/doc/LAYERS.html#packagesel][here]] and
 [[https://github.com/quelpa/quelpa#file][here]].
 
 ** Disable a package completely?

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -36,7 +36,7 @@ This document is intended as a tutorial for users who are interested in writing
 their first configuration layer, whether for private use or for contributing
 upstream. It should help clear up some confusion regarding how layers work and
 how Spacemacs (and Emacs) loads packages. For an overview of configuration
-layers with descriptions see [[https://develop.spacemacs.org/layers/LAYERS.html][Spacemacs layers list]].
+layers with descriptions see [[https://spacemacs.org/layers/LAYERS.html][Spacemacs layers list]].
 
 * Nomenclature
 Layers and packages. What gives?

--- a/doc/QUICK_START.org
+++ b/doc/QUICK_START.org
@@ -29,13 +29,13 @@ For example to get python support, simply add =python= to the list of
 =~/.spacemacs= file by pressing =SPC f e d= and then after adding the layer,
 reload it with =SPC f e R=. Now open a =.py= file (=SPC f f=) to find the python
 environment has been fully configured. Some extra configuration might make the
-environment even more powerful, which is very well described in the [[https://develop.spacemacs.org/layers/+lang/python/README.html][layer's
+environment even more powerful, which is very well described in the [[https://spacemacs.org/layers/+lang/python/README.html][layer's
 documentation]] that can be accessed by pressing =SPC h l= and selecting the
 =python= layer entry. For configuration of specific packages within a layer,
 =SPC h SPC= provides quick navigation functionality for jumping directly to the
 relevant location within the configuration files.
 
-A list of pre-configured layers is available [[https://develop.spacemacs.org/layers/LAYERS.html][here]]. If you still would like to
+A list of pre-configured layers is available [[https://spacemacs.org/layers/LAYERS.html][here]]. If you still would like to
 configure anything not covered by any layer, then it is easy to build a personal
 layer.
 

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -818,7 +818,7 @@ are also available.
 
 ** Babel / Source Blocks
 Besides the key bindings mentioned here it is recommended to use the
-[[https://develop.spacemacs.org/layers/+completion/auto-completion/README.html][auto-completion layer]] and its [[https://develop.spacemacs.org/layers/+completion/auto-completion/README.html#yasnippet][yasnippet key bindings]] in particular.
+[[https://spacemacs.org/layers/+completion/auto-completion/README.html][auto-completion layer]] and its [[https://spacemacs.org/layers/+completion/auto-completion/README.html#yasnippet][yasnippet key bindings]] in particular.
 
 | Key binding | Description                              |
 |-------------+------------------------------------------|

--- a/layers/+lang/coq/README.org
+++ b/layers/+lang/coq/README.org
@@ -27,7 +27,7 @@ This layer adds support for the [[https://coq.inria.fr/][Coq]] proof assistant (
 ** Features:
 - Syntax highlighting
 - Syntax-checking
-- Auto-completion (requires the [[https://develop.spacemacs.org/layers/+completion/auto-completion/README.html][auto-completion layer]] to be installed)
+- Auto-completion (requires the [[https://spacemacs.org/layers/+completion/auto-completion/README.html][auto-completion layer]] to be installed)
 - Debugging of mathematical proofs from within Emacs using a special proof layout
 - Replacement of certain constants with the correct mathematical signs
 - Inserting of certain preconfigured proof elements

--- a/layers/+tools/eaf/README.org
+++ b/layers/+tools/eaf/README.org
@@ -85,7 +85,7 @@ Eaf provides some key bindings only conditionally, so if some key binding does n
 work, then be sure that the relevant eaf application has been correctly
 installed.
 
-Use ~SPC t k m~ to [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-key-persistent][show the EAF key bindings persistently in which-key]], or use
+Use ~SPC t k m~ to [[https://spacemacs.org/doc/DOCUMENTATION.html#which-key-persistent][show the EAF key bindings persistently in which-key]], or use
 ~SPC h d K~ to show the `eaf-mode-map` in a separate buffer.
 
 ** Global
@@ -96,7 +96,7 @@ Use ~SPC t k m~ to [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-
 | ~SPC a a f~ | EAF open file ([[https://github.com/emacs-eaf/emacs-application-framework#launch-eaf-applications][see EAF doc for supported file types]])                          |
 | ~SPC a a s~ | EAF open system monitor                                                       |
 | ~SPC a a M~ | EAF open musik player                                                         |
-| ~SPC t k m~ | Show available key commands in which-key (read [[https://develop.spacemacs.org/doc/DOCUMENTATION.html#which-key][here]] for more details)         |
+| ~SPC t k m~ | Show available key commands in which-key (read [[https://spacemacs.org/doc/DOCUMENTATION.html#which-key][here]] for more details)         |
 | ~SPC m d~   | toggle dark-mode (or in browser press ~M-d~ and in pdf-viewer just press ~d~) |
 
 *** Browser

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -284,7 +284,7 @@ THIS FILE IS AUTO-GENERATED!
 Don't edit it directly. See [[https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org#readmeorg-tags]["README.org tags" section of CONTRIBUTING.org for the instructions]].
 
 This is an overview of Spacemacs configuration layers. For information about
-configuration layer development see [[https://develop.spacemacs.org/doc/LAYERS.html][Configuration layers development]].
+configuration layer development see [[https://spacemacs.org/doc/LAYERS.html][Configuration layers development]].
 
 * Chats
 ** ERC
@@ -1518,7 +1518,7 @@ This layer adds support for the [[https://coq.inria.fr/][Coq]] proof assistant (
 Features:
 - Syntax highlighting
 - Syntax-checking
-- Auto-completion (requires the [[https://develop.spacemacs.org/layers/+completion/auto-completion/README.html][auto-completion layer]] to be installed)
+- Auto-completion (requires the [[https://spacemacs.org/layers/+completion/auto-completion/README.html][auto-completion layer]] to be installed)
 - Debugging of mathematical proofs from within Emacs using a special proof layout
 - Replacement of certain constants with the correct mathematical signs
 - Inserting of certain preconfigured proof elements


### PR DESCRIPTION
Replace develop.spacemacs.org by spacemacs.org as mentioned in https://github.com/syl20bnr/spacemacs/issues/16672#issuecomment-2515158914.