### PR TITLE
Add consult-history keybindings in shell layer

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3624,6 +3624,8 @@ files (thanks to Daniel Nicolai)
   (thanks to JAremko and duianto)
 - Better keybindings for ~ESC~ and ~RET~ in vterm =evil-normal-state= (thanks to kenkangxgwe)
 - Added support for multi-vterm as default terminal option
+- Added ~M-l~ for =eshell= mode and ~SPC m H~ for both =shell= and =eshell=
+  modes for =consult-history= (thanks to Jaehyun Yeom)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -232,6 +232,25 @@ is achieved by adding the relevant text properties."
   (define-key eshell-mode-map (kbd "M-l") #'spacemacs/ivy-eshell-history)
   (define-key eshell-mode-map (kbd "<tab>") #'spacemacs/pcomplete-std-complete))
 
+(defun spacemacs/consult-eshell-history ()
+  "Correctly revert to insert state after selection."
+  (interactive)
+  (consult-history)
+  (evil-insert-state))
+
+(defun spacemacs/consult-shell-history ()
+  "Correctly revert to insert state after selection."
+  (interactive)
+  (consult-history)
+  (evil-insert-state))
+
+(defun spacemacs/init-consult-eshell ()
+  "Initialize consult-eshell."
+  (spacemacs/set-leader-keys-for-major-mode 'eshell-mode
+    "H" 'spacemacs/consult-eshell-history)
+  (define-key eshell-mode-map
+              (kbd "M-l") 'spacemacs/consult-eshell-history))
+
 (defun term-send-tab ()
   "Send tab in term mode."
   (interactive)

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -25,6 +25,7 @@
   '(
     (comint :location built-in)
     company
+    consult
     eat
     esh-help
     (eshell :location built-in)
@@ -157,6 +158,16 @@
     (add-hook 'eshell-mode-hook 'spacemacs/init-ivy-eshell))
   (spacemacs/set-leader-keys-for-major-mode 'shell-mode
     "H" 'counsel-shell-history))
+
+(defun shell/pre-init-consult ()
+  (spacemacs|use-package-add-hook consult
+    :post-init
+    (progn
+      ;; eshell
+      (add-hook 'eshell-mode-hook 'spacemacs/init-consult-eshell)
+      ;;shell
+      (spacemacs/set-leader-keys-for-major-mode 'shell-mode
+        "H" 'spacemacs/consult-shell-history))))
 
 (defun shell/pre-init-magit ()
   (spacemacs|use-package-add-hook magit


### PR DESCRIPTION
This change adds `M-l` for `eshell` mode and `SPC m H` for both `shell` and `eshell` modes, binding them to `consult-history`. This is consistent with the keybindings in the `helm` and `ivy` layers within the `compleseus` layer and aligns with the `shell` layer documentation.