### PR TITLE
* core/core-load-paths.el: Support spacemacs-cache-directory from environment variables

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -27,6 +27,8 @@
 ;;; Code:
 
 ;;;; PATH variables/constants
+(when (version<= emacs-version "28")
+  (eval-when-compile (require 'subr-x))) ; for the 'if-let*'
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
@@ -96,7 +98,11 @@
 ;; because Spacemacs may be installed to a shared location and this directory
 ;; and its children should be per-user.
 (defconst spacemacs-cache-directory
-  (concat user-emacs-directory ".cache/")
+  (if-let* ((cache-dir (getenv "SPACEMACSCACHE")))
+      cache-dir
+    (if-let* ((xdg-cache (getenv "XDG_CACHE_HOME")))
+        (expand-file-name "spacemacs/" xdg-cache)
+      (concat user-emacs-directory ".cache/")))
   "Spacemacs storage area for persistent files.")
 
 ;; ~/.emacs.d/.cache/auto-save

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -37,6 +37,7 @@
 - [[#dotfile-configuration][Dotfile Configuration]]
   - [[#dotfile-installation][Dotfile Installation]]
   - [[#alternative-dotdirectory][Alternative dotdirectory]]
+  - [[#alternative-cache-directory][Alternative cache directory]]
   - [[#synchronization-of-dotfile-changes][Synchronization of dotfile changes]]
   - [[#testing-the-dotfile][Testing the dotfile]]
   - [[#dotfile-contents][Dotfile Contents]]
@@ -553,6 +554,16 @@ change the location of this directory.
 *Note*: =~/.spacemacs= will always take priority over =~/.spacemacs.d/init.el=,
 so =~/.spacemacs= must not exist for =~/.spacemacs.d/init.el= to be used by
 Spacemacs.
+
+** Alternative cache directory
+Spacemacs use the cache dir =.cache= under =user-emacs-directory=, normally it
+is =~/.emacs.d/.cache/=.
+
+If the envrionment variable =XDG_CACHE_HOME= exists, Spacemacs will use the
+=spacemacs/= under the CACHE directory, for example =~/.cache/spacemacs/=.
+
+To change the default cache directory, using the environment variable
+=SPACEMACSCACHE=.
 
 ** Synchronization of dotfile changes
 To apply the modifications made in =~/.spacemacs= press ~SPC f e R~. It will


### PR DESCRIPTION
Fix #4018 #12127 #15499 by enable customizing the `spacemacs-cache-directory`. 

These three tickets are desiring a way to config the `spacemacs-cache-directory` to split the cache directory from default folder.

This patch will support to change the cache directory with `SPACEMACSCACHE` or `XDG_CACHE_HOME`.

UPDATE: Drop this PR for uncertain change.