### PR TITLE
* core-load-paths.el: Support spacemacs-cache-directory from env variable

### DIFF
--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -27,6 +27,8 @@
 ;;; Code:
 
 ;;;; PATH variables/constants
+(when (version<= emacs-version "28")
+  (eval-when-compile (require 'subr-x))) ; for the 'if-let*'
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
@@ -96,7 +98,14 @@
 ;; because Spacemacs may be installed to a shared location and this directory
 ;; and its children should be per-user.
 (defconst spacemacs-cache-directory
-  (concat user-emacs-directory ".cache/")
+  (if-let* ((spc-cache (getenv "SPACEMACSCACHE")))
+      spc-cache
+    (if-let* ((dot-cache (concat user-emacs-directory ".cache/"))
+              (xdg-cache (getenv "XDG_CACHE_HOME"))
+              (spc-cache (expand-file-name "spacemacs/" xdg-cache))
+              ((file-exists-p spc-cache)))
+        spc-cache
+      dot-cache))
   "Spacemacs storage area for persistent files.")
 
 ;; ~/.emacs.d/.cache/auto-save

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -37,6 +37,7 @@
 - [[#dotfile-configuration][Dotfile Configuration]]
   - [[#dotfile-installation][Dotfile Installation]]
   - [[#alternative-dotdirectory][Alternative dotdirectory]]
+  - [[#alternative-cache-directory][Alternative cache directory]]
   - [[#synchronization-of-dotfile-changes][Synchronization of dotfile changes]]
   - [[#testing-the-dotfile][Testing the dotfile]]
   - [[#dotfile-contents][Dotfile Contents]]
@@ -553,6 +554,17 @@ change the location of this directory.
 *Note*: =~/.spacemacs= will always take priority over =~/.spacemacs.d/init.el=,
 so =~/.spacemacs= must not exist for =~/.spacemacs.d/init.el= to be used by
 Spacemacs.
+
+** Alternative cache directory
+Spacemacs use the cache dir =.cache= under =user-emacs-directory=, normally it
+is =~/.emacs.d/.cache/=.
+
+If the envrionment variable =XDG_CACHE_HOME= exists, Spacemacs will try the
+=spacemacs/= under the CACHE directory if the directory exists, for example
+=~/.cache/spacemacs/=.
+
+To override the default cache directory, using the environment variable
+=SPACEMACSCACHE=.
 
 ** Synchronization of dotfile changes
 To apply the modifications made in =~/.spacemacs= press ~SPC f e R~. It will


### PR DESCRIPTION
Fix the #12127  by supporting the `spacemacs-cache-directory` from environment variable SPACEMACSCACHE or XDG_CACHE_HOME.

NOTE: 
This PR can be the first step to start supporting the XDG_* directories to fix #3589.