### PR TITLE
Phase out unmaintained package "fill-column-indicator"

### DIFF
--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -1615,7 +1615,7 @@ squared symbols like =🅿=.
 | =none=        | =ⓔ=     | e     | [[https://github.com/Somelauw/evil-org-mode][evil-org]] mode                                                        |
 | ~SPC t E e~   | =Ⓔe=    | Ee    | emacs editing style (holy mode)                                      |
 | ~SPC t E h~   | =Ⓔh=    | Eh    | hybrid editing style (hybrid mode)                                   |
-| ~SPC t f~     | =ⓕ=     | f     | fill-column-indicator mode                                           |
+| ~SPC t f~     | =ⓕ=     | f     | display-fill-column-indicator mode                                   |
 | ~SPC t F~     | =Ⓕ=     | F     | auto-fill mode                                                       |
 | ~SPC t G~     | =Ⓖ=     | G     | [[https://spacemacs.org/layers/+tags/gtags/README.html][ggtags]] mode                                                          |
 | ~SPC t g~     | =ⓖ=     | g     | [[https://github.com/roman/golden-ratio.el][golden-ratio]] mode                                                    |

--- a/layers/+completion/auto-completion/funcs.el
+++ b/layers/+completion/auto-completion/funcs.el
@@ -321,18 +321,6 @@ MODE parameter must match the :modes values used in the call to
       (define-key map (kbd "C-p") 'company-select-previous)))))
 
 
-
-(defvar-local company-fci-mode-on-p nil)
-
-(defun company-turn-off-fci (&rest ignore)
-  (when (boundp 'fci-mode)
-    (setq company-fci-mode-on-p fci-mode)
-    (when fci-mode (fci-mode -1))))
-
-(defun company-maybe-turn-on-fci (&rest ignore)
-  (when company-fci-mode-on-p (fci-mode 1)))
-
-
 ;; helm-yas
 
 (defun spacemacs/helm-yas ()

--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -105,9 +105,6 @@
           company-dabbrev-other-buffers t
           company-dabbrev-downcase nil)
 
-    (add-hook 'company-completion-started-hook 'company-turn-off-fci)
-    (add-hook 'company-completion-finished-hook 'company-maybe-turn-on-fci)
-    (add-hook 'company-completion-cancelled-hook 'company-maybe-turn-on-fci)
     :config
     (spacemacs|diminish company-mode " ⓐ" " a")
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -27,7 +27,6 @@
     emojify
     evil-collection
     evil-surround
-    fill-column-indicator
     ;; forge requires a C compiler on Windows so we disable
     ;; it by default on Windows.
     (forge :toggle (not (spacemacs/system-is-mswindows)))
@@ -69,9 +68,6 @@
     ;; See `git-packages' form in this file.
     (unless (spacemacs/system-is-mswindows)
       (add-to-list 'spacemacs-evil-collection-allowed-list 'forge))))
-
-(defun git/post-init-fill-column-indicator ()
-  (add-hook 'git-commit-mode-hook 'fci-mode))
 
 (defun git/init-helm-git-grep ()
   (use-package helm-git-grep
@@ -203,6 +199,8 @@
       ("Y" magit-blame-copy-hash)
       ("B" magit-blame :exit t)
       ("Q" nil :exit t))
+    (with-eval-after-load 'git-commit
+      (add-hook 'git-commit-mode-hook 'display-fill-column-indicator-mode))
     (with-eval-after-load 'persp-mode
       (add-hook 'persp-filter-save-buffers-functions
                 'spacemacs//magit-buffer-p))

--- a/layers/+spacemacs/spacemacs-visual/README.org
+++ b/layers/+spacemacs/spacemacs-visual/README.org
@@ -13,7 +13,7 @@ This layer adds various modes to enhance Spacemacs visual appearance.
 - Automatic colorization of compilation buffers via =ansi-colors=.
 - Support for resuming the last layout when starting Spacemacs via =desktop=.
 - Support for showing a thin vertical line to indicate the fill column
-  via =fill-column-indicator=.
+  via =display-fill-column-indicator=.
 - Automatic highlighting of =TODO-tags= in programming and text modes
   via =hl-todo=.
 - Support for temporary windows which close automatically via =popwin=.

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -26,10 +26,7 @@
         all-the-icons
         (ansi-colors :location built-in)
         desktop
-        ;; `display-fill-column-indicator' is available in Emacs 27+
-        (display-fill-column-indicator :location built-in
-                                       :toggle (boundp 'display-fill-column-indicator))
-        (fill-column-indicator :toggle (not (boundp 'display-fill-column-indicator)))
+        (display-fill-column-indicator :location built-in)
         hl-todo
         popup
         popwin
@@ -53,11 +50,11 @@
     (add-to-list 'desktop-path spacemacs-cache-directory)))
 
 (defun spacemacs-visual/init-display-fill-column-indicator ()
-  (spacemacs|add-toggle fill-column-indicator
+  (spacemacs|add-toggle display-fill-column-indicator
     :mode display-fill-column-indicator-mode
     :documentation "Display the fill column indicator."
     :evil-leader "tf")
-  (spacemacs|add-toggle fill-column-indicator-globally
+  (spacemacs|add-toggle display-fill-column-indicator-globally
     :mode global-display-fill-column-indicator-mode
     :documentation "Display the fill column indicator globally."
     :evil-leader "t C-f")
@@ -66,22 +63,6 @@
     ;; lighter
     (add-to-list 'minor-mode-alist '(display-fill-column-indicator-mode ""))
     (spacemacs|diminish display-fill-column-indicator-mode " ⓕ" " f")))
-
-(defun spacemacs-visual/init-fill-column-indicator ()
-  (use-package fill-column-indicator
-    :defer t
-    :spacediminish ((fci-mode " ⓕ" " f"))
-    :init
-    (setq fci-rule-width 1)
-    ;; manually register the minor mode since it does not define any
-    ;; lighter
-    (add-to-list 'minor-mode-alist '(fci-mode ""))
-    (spacemacs|add-toggle fill-column-indicator
-      :status fci-mode
-      :on (turn-on-fci-mode)
-      :off (turn-off-fci-mode)
-      :documentation "Display the fill column indicator."
-      :evil-leader "tf")))
 
 (defun spacemacs-visual/init-hl-todo ()
   (use-package hl-todo

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -1051,7 +1051,7 @@ Features:
 - Automatic colorization of compilation buffers via =ansi-colors=.
 - Support for resuming the last layout when starting Spacemacs via =desktop=.
 - Support for showing a thin vertical line to indicate the fill column
-  via =fill-column-indicator=.
+  via =display-fill-column-indicator=.
 - Automatic highlighting of =TODO-tags= in programming and text modes
   via =hl-todo=.
 - Support for temporary windows which close automatically via =popwin=.

--- a/news/news01.org
+++ b/news/news01.org
@@ -260,12 +260,12 @@ layer =spacemacs-bootstrap= which installs only essential packages like
 
 Also it is easier to select or exclude a sub-list of packages in a layer with
 the new keyword =:packages=. For instance here is an example to select only the
-packages =fill-column-indicator= and =golden-ratio= in the layer
+packages =display-fill-column-indicator= and =golden-ratio= in the layer
 =spacemacs-ui-visual=:
 
 #+BEGIN_SRC emacs-lisp
   (setq dotspacemacs-configuration-layers
-    (spacemacs-ui-visual :packages fill-column-indicator golden-ratio))
+    (spacemacs-ui-visual :packages display-fill-column-indicator golden-ratio))
 #+END_SRC
 
 Another example to select all the packages except =fancy-battery=:


### PR DESCRIPTION
The package "fill-column-indicator" is unmaintained, try emacs buildin feature display-fill-column-indicator-mode (available on emacs 27+).

The project page: https://github.com/alpaker/fill-column-indicator