### PR TITLE
* layers/+spacemacs/spacemacs-editing-visual/packages.el: Remove vhl workaround

### DIFF
--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -166,12 +166,6 @@
       :mode volatile-highlights-mode
       :documentation "Display visual feedback for some operations."
       :evil-leader "thv")
-
-    ;; volatile-highlights is redundant with built-in highlighting in occur.  In
-    ;; Emacs 29, it starts to cause errors.  See
-    ;; https://github.com/k-talo/volatile-highlights.el/issues/26
-    (setq vhl/use-occur-extension-p (< emacs-major-version 28))
-
     (volatile-highlights-mode t)
     :config
     ;; additional extensions


### PR DESCRIPTION
The vhl conflicting with occur on Emacs29 was fixed by upstream, removing the workaround from Spacemacs.
Upstream Issue ticket:https://github.com/k-talo/volatile-highlights.el/issues/26
Upstream solution: https://github.com/k-talo/volatile-highlights.el/commit/e72d68090ade28e0bf543d8906a450982d4849ec