### PR TITLE
* layers/+lang/python/packages.el: Avoid loading semantic in python layer

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -450,7 +450,8 @@
         (set-default-toplevel-value x (symbol-value x))))))
 
 (defun python/post-init-semantic ()
-  (when (configuration-layer/package-used-p 'anaconda-mode)
+  (when (and (configuration-layer/package-used-p 'anaconda-mode)
+             (configuration-layer/layer-used-p 'semantic))
     (add-hook 'python-mode-hook
               'spacemacs//disable-semantic-idle-summary-mode t))
   (spacemacs/add-to-hook 'python-mode-hook


### PR DESCRIPTION
Current python layer will call the `semantic-idle-summary-mode` with `0` to disable the feature regardless the `semantic` layer been used or not, but actually the function calling will trigger loading semantic feature (but not active the feature), it's really heavy. 

This PR can avoid the calling to avoid that heavy loading. Please help review and merge the changes. Thanks.