### PR TITLE
[python] Change imenu-create-index-function only when semantic-mode is activated

### DIFF
--- a/layers/+emacs/semantic/packages.el
+++ b/layers/+emacs/semantic/packages.el
@@ -27,31 +27,11 @@
         srefactor
         ))
 
-;; To fix issue #2569 (https://github.com/syl20bnr/spacemacs/issues/2569),
-;; we store the `imenu-create-index-function' for every semantic buffer, and
-;; restore it when semantic been turned off.
-(defvar-local spacemacs--imenu-create-index-fcn-orig nil
-  "Save the original `imenu-create-index-function'")
-
-(define-advice semantic-new-buffer-fcn
-    (:before (&rest _) store-imenu-create-index-function)
-  (setq spacemacs--imenu-create-index-fcn-orig imenu-create-index-function))
-
-(defun spacemacs//restore-imenu-after-semantic ()
-  (unless semantic-mode ; semantic turned off
-    (dolist (b (buffer-list))
-	    (with-current-buffer b
-	      (when (bound-and-true-p spacemacs--imenu-create-index-fcn-orig)
-          (setq imenu-create-index-function
-                spacemacs--imenu-create-index-fcn-orig))))))
-
 (defun semantic/init-semantic ()
   (use-package semantic
     :defer t
-    :config
-    (add-to-list 'semantic-default-submodes
-                 'global-semantic-idle-summary-mode)
-    (add-hook 'semantic-mode-hook 'spacemacs//restore-imenu-after-semantic)))
+    :config (add-to-list 'semantic-default-submodes
+                         'global-semantic-idle-summary-mode)))
 
 (defun semantic/init-srefactor ()
   (use-package srefactor :defer t))

--- a/layers/+emacs/semantic/packages.el
+++ b/layers/+emacs/semantic/packages.el
@@ -27,11 +27,31 @@
         srefactor
         ))
 
+;; To fix issue #2569 (https://github.com/syl20bnr/spacemacs/issues/2569),
+;; we store the `imenu-create-index-function' for every semantic buffer, and
+;; restore it when semantic been turned off.
+(defvar-local spacemacs--imenu-create-index-fcn-orig nil
+  "Save the original `imenu-create-index-function'")
+
+(define-advice semantic-new-buffer-fcn
+    (:before (&rest _) store-imenu-create-index-function)
+  (setq spacemacs--imenu-create-index-fcn-orig imenu-create-index-function))
+
+(defun spacemacs//restore-imenu-after-semantic ()
+  (unless semantic-mode ; semantic turned off
+    (dolist (b (buffer-list))
+	    (with-current-buffer b
+	      (when (bound-and-true-p spacemacs--imenu-create-index-fcn-orig)
+          (setq imenu-create-index-function
+                spacemacs--imenu-create-index-fcn-orig))))))
+
 (defun semantic/init-semantic ()
   (use-package semantic
     :defer t
-    :config (add-to-list 'semantic-default-submodes
-                         'global-semantic-idle-summary-mode)))
+    :config
+    (add-to-list 'semantic-default-submodes
+                 'global-semantic-idle-summary-mode)
+    (add-hook 'semantic-mode-hook 'spacemacs//restore-imenu-after-semantic)))
 
 (defun semantic/init-srefactor ()
   (use-package srefactor :defer t))

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -543,7 +543,7 @@ If region is not active then send line."
   "Start and/or switch to the REPL."
   (interactive)
   (if-let* ((shell-process (or (python-shell-get-process)
-                              (call-interactively #'run-python))))
+                               (call-interactively #'run-python))))
       (progn
         (pop-to-buffer (process-buffer shell-process))
         (evil-insert-state))

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -271,20 +271,9 @@ location of \".venv\" file, then relative to pyvenv-workon-home()."
                       (setq-local pyvenv-activate virtualenv-abs-path))
                      (t (pyvenv-workon virtualenv-path-in-file)
                         (setq-local pyvenv-workon virtualenv-path-in-file))))))))
+
 
 ;; Tests
-
-(defun spacemacs//python-imenu-create-index-use-semantic-maybe ()
-  "Use semantic if the layer is enabled."
-  (setq imenu-create-index-function 'spacemacs/python-imenu-create-index))
-
-;; fix for issue #2569 (https://github.com/syl20bnr/spacemacs/issues/2569) and
-;; Emacs 24.5 and older. use `semantic-create-imenu-index' only when
-;; `semantic-mode' is enabled, otherwise use `python-imenu-create-index'
-(defun spacemacs/python-imenu-create-index ()
-  (if (bound-and-true-p semantic-mode)
-      (semantic-create-imenu-index)
-    (python-imenu-create-index)))
 
 (defun spacemacs//python-get-main-testrunner ()
   "Get the main test runner."

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -454,9 +454,7 @@
   (when (configuration-layer/package-used-p 'anaconda-mode)
     (add-hook 'python-mode-hook
               'spacemacs//disable-semantic-idle-summary-mode t))
-  (spacemacs/add-to-hook 'python-mode-hook
-                         '(semantic-mode
-                           spacemacs//python-imenu-create-index-use-semantic-maybe)))
+  (add-hook 'python-mode-hook 'semantic-mode))
 
 (defun python/pre-init-smartparens ()
   (spacemacs|use-package-add-hook smartparens


### PR DESCRIPTION
Spacemacs will always choose a value for `imenu-create-index-function` in (`semantic-create-imenu-index`, `python-imenu-create-index`), but actually when user activing `python-ts-mode`, the correct function should be `python-imenu-treesit-create-index`. 

This PR try choose the `semantic-create-imenu-index` only the `semantic-mode` was activated, otherwise using the default function, which will be correct for `python-mode` and `python-ts-mode`. 