### PR TITLE
* layers/+spacemacs/spacemacs-evil/config.el: Apply evil-collection for info-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/config.el
+++ b/layers/+spacemacs/spacemacs-evil/config.el
@@ -31,5 +31,5 @@
 (defvar evil-lisp-safe-structural-editing-modes '()
   "A list of major mode symbols where safe structural editing is supported.")
 
-(defvar spacemacs-evil-collection-allowed-list '(dired ediff eww quickrun replace simple)
+(defvar spacemacs-evil-collection-allowed-list '(dired ediff eww info quickrun replace simple)
   "List of modes Spacemacs will allow to be evilified by ‘evil-collection-init’.")


### PR DESCRIPTION
Apply `evil-collection` for `info-mode`, without this PR the `info-mode` has key-binding issues like pressing "RET"... keys in a info buffer does not work.