### PR TITLE
core-themes-support.el: Run hooks after enable-theme not load-theme

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -483,7 +483,7 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
   (interactive)
   (spacemacs/cycle-spacemacs-theme t))
 
-(define-advice load-theme (:after (theme &rest _) spacemacs/load-theme-adv)
+(define-advice enable-theme (:after (theme &rest _) spacemacs//run-post-theme-hooks)
   "Perform post load processing."
   (setq spacemacs--cur-theme theme)
   (spacemacs/post-theme-init theme))

--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -486,7 +486,7 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
 (define-advice enable-theme (:after (theme &rest _) spacemacs//run-post-theme-hooks)
   "Perform post load processing."
   (setq spacemacs--cur-theme theme)
-  (spacemacs/post-theme-init theme))
+  (run-hooks 'spacemacs-post-theme-change-hook))
 
 (defun spacemacs/theme-loader ()
   "Call appropriate theme loader based on completion framework."
@@ -499,12 +499,6 @@ When BACKWARD is non-nil, or with universal-argument, cycle backwards."
    ((configuration-layer/layer-used-p 'compleseus)
     (call-interactively 'consult-theme))
    (t (call-interactively 'load-theme))))
-
-(defun spacemacs/post-theme-init (theme)
-  "Some processing that needs to be done when the current theme
-has been changed to THEME."
-  (interactive)
-  (run-hooks 'spacemacs-post-theme-change-hook))
 
 (defun spacemacs//add-theme-packages-to-additional-packages ()
   "Add all theme packages from `dotspacemacs-themes' to packages to install."

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -196,6 +196,18 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
   (call-interactively 'helm-select-action)
   (spacemacs//helm-navigation-ts-set-face))
 
+(defun spacemacs//helm-update-header-line-faces ()
+  "Update defaults for `helm' header line whenever a new theme is loaded."
+  ;; TODO factorize face definition with those defined in config.el
+  (setq helm-source-header-default-foreground
+        (face-attribute 'helm-source-header :foreground)
+        helm-source-header-default-background
+        (face-attribute 'helm-source-header :background)
+        helm-source-header-default-box
+        (face-attribute 'helm-source-header :box)
+        helm-source-header-default-height
+        (face-attribute 'helm-source-header :height)))
+
 
 ;; Ivy
 

--- a/layers/+spacemacs/spacemacs-completion/packages.el
+++ b/layers/+spacemacs/spacemacs-completion/packages.el
@@ -61,19 +61,7 @@
     (add-hook 'spacemacs-editing-style-hook 'spacemacs//helm-hjkl-navigation)
     (add-hook 'helm-find-files-after-init-hook
               'spacemacs//helm-find-files-enable-helm--in-fuzzy)
-    ;; setup advices
-    (define-advice spacemacs/post-theme-init
-        (:after (&rest _) spacemacs/helm-header-line-adv)
-      "Update defaults for `helm' header line whenever a new theme is loaded"
-      ;; TODO factorize face definition with those defined in config.el
-      (setq helm-source-header-default-foreground
-            (face-attribute 'helm-source-header :foreground)
-            helm-source-header-default-background
-            (face-attribute 'helm-source-header :background)
-            helm-source-header-default-box
-            (face-attribute 'helm-source-header :box)
-            helm-source-header-default-height
-            (face-attribute 'helm-source-header :height)))
+    (add-hook 'spacemacs-post-theme-change-hook #'spacemacs//helm-update-header-line-faces)
     ;; ensure that the correct bindings are set at startup
     (spacemacs//helm-hjkl-navigation dotspacemacs-editing-style)
     ;; Transient state

--- a/layers/+themes/colors/funcs.el
+++ b/layers/+themes/colors/funcs.el
@@ -35,13 +35,13 @@
               (delq 'font-lock-keyword-face
                     rainbow-identifiers-faces-to-override)))
 
-(defun colors//tweak-theme-colors (theme)
+(defun colors//tweak-theme-colors ()
   "Tweak color themes by adjusting rainbow-identifiers."
-  (interactive)
   ;; tweak the saturation and lightness of identifier colors
-  (unless (assq theme (get 'rainbow-identifiers-cie-l*a*b*-saturation
-                           'theme-value))
-    (let ((sat&light (assq theme colors-theme-identifiers-sat&light)))
+  (unless (assq spacemacs--cur-theme
+                (get 'rainbow-identifiers-cie-l*a*b*-saturation
+                     'theme-value))
+    (let ((sat&light (assq spacemacs--cur-theme colors-theme-identifiers-sat&light)))
       (if sat&light
           (setq rainbow-identifiers-cie-l*a*b*-saturation (cadr sat&light)
                 rainbow-identifiers-cie-l*a*b*-lightness (caddr sat&light))
@@ -162,4 +162,4 @@ Example usage:
   "Refresh and re-apply the look of your current theme.
 Always run this after adding new per-theme settings!"
   (interactive)
-  (colors//tweak-theme-colors spacemacs--cur-theme))
+  (colors//tweak-theme-colors))

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -93,9 +93,7 @@
                                                   font-lock-keyword-face
                                                   font-lock-function-name-face
                                                   font-lock-variable-name-face))
-    (define-advice spacemacs/post-theme-init (:after (&rest _) colors/post-theme-init)
-      "Adjust lightness and brightness of rainbow-identifiers on post theme init."
-      (colors//tweak-theme-colors))
+    (add-hook 'spacemacs-post-theme-change-hook #'colors//tweak-theme-colors)
     ;; key bindings
     (spacemacs/declare-prefix "Ci" "colors-identifiers")
     (spacemacs|add-toggle rainbow-identifier

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -95,7 +95,7 @@
                                                   font-lock-variable-name-face))
     (define-advice spacemacs/post-theme-init (:after (&rest _) colors/post-theme-init)
       "Adjust lightness and brightness of rainbow-identifiers on post theme init."
-      (colors//tweak-theme-colors spacemacs--cur-theme))
+      (colors//tweak-theme-colors))
     ;; key bindings
     (spacemacs/declare-prefix "Ci" "colors-identifiers")
     (spacemacs|add-toggle rainbow-identifier
@@ -122,7 +122,7 @@
     (spacemacs/set-leader-keys "Cis" 'colors/start-change-color-saturation)
     (spacemacs/set-leader-keys "Cil" 'colors/start-change-color-lightness)
     ;; tweak colors of current theme
-    (colors//tweak-theme-colors spacemacs--cur-theme)
+    (colors//tweak-theme-colors)
     (when (eq 'all colors-colorize-identifiers)
       (global-rainbow-identifiers-mode))))
 


### PR DESCRIPTION
The intention of `spacemacs-post-theme-change-hook` is to run after
the theme is changed, not just after a new theme file is loaded.
Spacemacs itself happens to always call load-theme to enable a theme,
but consult-theme (and maybe other packages) call enable-theme rather
than load-theme if a theme has already been loaded.

In any case, switching to advising enable-theme should be fine because
load-theme calls enable-theme anyway.

This PR also includes a few cleanups of the
`spacemacs-post-theme-change-hook`-related code.  I don't use helm or
the colors layers, but I believe my changes are reasonable---please
object if you think the changes are wrong.