### PR TITLE
* layers/+lang/python/packages.el: Bind jump back on major mode init function

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -74,7 +74,6 @@
     (spacemacs/set-leader-keys-for-major-mode 'python-mode
       "hh" 'anaconda-mode-show-doc
       "ga" 'anaconda-mode-find-assignments
-      "gb" 'xref-pop-marker-stack
       "gu" 'anaconda-mode-find-references)
     ;; new anaconda-mode (2018-06-03) removed `anaconda-view-mode-map' in
     ;; favor of xref. Eventually we need to remove this part.
@@ -396,6 +395,7 @@
       "cc" 'spacemacs/python-execute-file
       "cC" 'spacemacs/python-execute-file-focus
       "db" 'spacemacs/python-toggle-breakpoint
+      "gb" 'xref-pop-marker-stack
       "ri" 'spacemacs/python-remove-unused-imports
       "sB" 'spacemacs/python-shell-send-buffer-switch
       "sb" 'spacemacs/python-shell-send-buffer


### PR DESCRIPTION
The python-layer key binding `, g g` is bound by the major mode, but the `, g b` is bound by a optional package, will has issue if the optional package been excluded.

Here is the example to trigger the issue, enable the `python` layer and exclude the `anaconda-mode`, then open a python file in Spacemacs, try the `, g g` first, then try `, g b` will not work. 
```
dotspacemacs-excluded-packages '(anaconda-mode)
dotspacemacs-configuration-layers '(python ...)
```

This PR try bind the jump back `, g b` to the major mode to fix the issue. 
