### PR TITLE
* layers/+spacemacs/spacemacs-defaults/packages.el: Evilize the bookmark

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -80,6 +80,7 @@
   (use-package bookmark
     :defer t
     :init
+    (add-to-list 'spacemacs-evil-collection-allowed-list 'bookmark)
     (setq bookmark-default-file (concat spacemacs-cache-directory "bookmarks")
           ;; autosave each change
           bookmark-save-flag 1)


### PR DESCRIPTION
Hi,

In Spacemacs press `C-r x l` (or `bookmark-bmenu-list`) to open the bookmark buffer, try press `k` or `l`, it does not work as evil.

This PR try to evilize the bookmark buffer. 