### PR TITLE
* layers/+tools/shell/funcs.el: Avoid loading semantic for eshell

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -173,7 +173,7 @@ is achieved by adding the relevant text properties."
             'spacemacs//eshell-auto-end nil t)
   (add-hook 'evil-hybrid-state-entry-hook
             'spacemacs//eshell-auto-end nil t)
-  (when (configuration-layer/package-used-p 'semantic)
+  (when (bound-and-true-p semantic-mode)
     (semantic-mode -1))
   ;; This is an eshell alias
   (defun eshell/clear ()


### PR DESCRIPTION
The `eshell` layer try to exclude the `semantic-mode` but leading a heavy loading. Reproducing steps:
1. Enable the layers `semantic`, `eshell`.
2. Start Spacemacs and then start the `eshell`, it will lead the `semantic` feature been loaded (but not activated).

This PR speeds up the eshell by avoiding loading the `semantic` feature.
