### PR TITLE
Put bookmark into the spacemacs-evil-collection-allow-list

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -80,7 +80,6 @@
   (use-package bookmark
     :defer t
     :init
-    (add-to-list 'spacemacs-evil-collection-allowed-list 'bookmark)
     (setq bookmark-default-file (concat spacemacs-cache-directory "bookmarks")
           ;; autosave each change
           bookmark-save-flag 1)

--- a/layers/+spacemacs/spacemacs-evil/config.el
+++ b/layers/+spacemacs/spacemacs-evil/config.el
@@ -31,5 +31,6 @@
 (defvar evil-lisp-safe-structural-editing-modes '()
   "A list of major mode symbols where safe structural editing is supported.")
 
-(defvar spacemacs-evil-collection-allowed-list '(dired ediff eww info quickrun replace simple)
+(defvar spacemacs-evil-collection-allowed-list
+  '(dired ediff eww info quickrun replace simple bookmark)
   "List of modes Spacemacs will allow to be evilified by ‘evil-collection-init’.")


### PR DESCRIPTION
Hi,

I received  a report says user met an error message:
`Error (use-package): bookmark/:init: Symbol’s value as variable is void: spacemacs-evil-collection-allowed-list `

This PR will fix the error by a more simpler solution. 