### PR TITLE
Rename xref-pop-marker-stack to xref-go-back to follow Emacs 29.1 changes

### DIFF
--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -105,4 +105,9 @@ They are in order: `spacemacs-jump-handlers',
 (with-eval-after-load 'evil
   (evil-set-command-property 'spacemacs/jump-to-definition :jump t))
 
+(unless (fboundp 'xref-go-back)
+  (defalias 'xref-pop-marker-stack 'xref-go-back))
+(when (version<= "29.1" spacemacs-emacs-min-version)
+  (message "Please remove the alias for `xref-go-back'"))
+
 (provide 'core-jump)

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -185,7 +185,7 @@
     (dolist (mode '(emacs-lisp-mode lisp-interaction-mode))
       (spacemacs/declare-prefix-for-mode mode "mg" "find-symbol")
       (spacemacs/set-leader-keys-for-major-mode mode
-        "gb" 'xref-pop-marker-stack)
+        "gb" 'xref-go-back)
       (spacemacs/declare-prefix-for-mode mode "mh" "help")
 
       ;; Load better help mode if helpful is installed

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -72,7 +72,7 @@
     :config
     (dolist (mode haskell-modes)
       (spacemacs/set-leader-keys-for-major-mode mode
-        "gb" 'xref-pop-marker-stack
+        "gb" 'xref-go-back
         "ht" 'dante-type-at
         "hT" 'spacemacs-haskell//dante-insert-type
         "hi" 'dante-info

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -395,7 +395,7 @@
       "cc" 'spacemacs/python-execute-file
       "cC" 'spacemacs/python-execute-file-focus
       "db" 'spacemacs/python-toggle-breakpoint
-      "gb" 'xref-pop-marker-stack
+      "gb" 'xref-go-back
       "ri" 'spacemacs/python-remove-unused-imports
       "sB" 'spacemacs/python-shell-send-buffer-switch
       "sb" 'spacemacs/python-shell-send-buffer

--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -244,7 +244,7 @@ The lsp minor mode bindings are:
 | ~SPC m g r~   | find references (=xref= / =lsp=)                                                 |
 | ~SPC m g s~   | find symbol in project (=helm-lsp=)                                              |
 | ~SPC m g S~   | find symbol in all projects (=helm-lsp=)                                         |
-| ~SPC m g p~   | goto previous (~xref-pop-marker-stack~)                                          |
+| ~SPC m g p~   | goto previous (~xref-go-back~)                                          |
 |---------------+----------------------------------------------------------------------------------|
 | Note          | /Omitted when ~lsp-navigation~ is ~'peek~ or ~'simple~ /                         |
 |               | /Bound under ~SPC m g~ rather than ~SPC m G~ when ~lsp-navigation~ == ~'peek~/   |

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -141,7 +141,7 @@
     (concat prefix-char "d") #'xref-find-definitions
     (concat prefix-char "r") #'xref-find-references
     (concat prefix-char "e") #'lsp-treemacs-errors-list
-    (concat prefix-char "b") #'xref-pop-marker-stack)
+    (concat prefix-char "b") #'xref-go-back)
   (cond
    ((configuration-layer/package-usedp 'helm)
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode

--- a/layers/+vim/evil-better-jumper/packages.el
+++ b/layers/+vim/evil-better-jumper/packages.el
@@ -30,7 +30,7 @@
     :init
     (global-set-key [remap evil-jump-forward]  #'better-jumper-jump-forward)
     (global-set-key [remap evil-jump-backward] #'better-jumper-jump-backward)
-    (global-set-key [remap xref-pop-marker-stack] #'better-jumper-jump-backward)
+    (global-set-key [remap xref-go-back] #'better-jumper-jump-backward)
     :config
     (better-jumper-mode 1)
     (spacemacs|hide-lighter better-jumper-mode)


### PR DESCRIPTION
The Emacs-29.1 had renamed the `xref-pop-marker-stack` to `xref-go-back`,
https://github.com/emacs-mirror/emacs/commit/d8caa3d9fbd90de41efacfeb23c242df81c62bd0

And there will has a warning message when we call the `xref-pop-marker-stack` on emacs-29.1+, 