### PR TITLE
* layers/+tools/shell/funcs.el: Remove the semantic from shell layer

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -173,8 +173,6 @@ is achieved by adding the relevant text properties."
             'spacemacs//eshell-auto-end nil t)
   (add-hook 'evil-hybrid-state-entry-hook
             'spacemacs//eshell-auto-end nil t)
-  (when (bound-and-true-p semantic-mode)
-    (semantic-mode -1))
   ;; This is an eshell alias
   (defun eshell/clear ()
     (let ((inhibit-read-only t))


### PR DESCRIPTION
As the discuss in https://github.com/syl20bnr/spacemacs/pull/16724#issuecomment-2543192979, it's safe to remove the semantic from eshell.
> The action turning off `semantic-mode` for `eshell` was introduced in the commit [4048777](https://github.com/syl20bnr/spacemacs/commit/40487778e697a680c762fccde5c7407cc2a68277) there is no comment why need turn off it.
> 
> I tried the eshell with turning on semantic mode, try function `semantic-mode-ia-fast-jump`, there is a message says `Cannot analyze buffers not supported by Semantic`, same behavior on Spacemacs and vanilla Emacs.
