### PR TITLE
* layers/+web/eww/funcs.el: Fix eww transient state key bindings

### DIFF
--- a/core/core-transient-state.el
+++ b/core/core-transient-state.el
@@ -64,9 +64,9 @@ may hold the keys to be removed. The variable may be unbound."
 (defun spacemacs//transient-state-remove-missing-optional-heads (docstring heads optional-heads)
   (with-temp-buffer
     (insert docstring)
-    (goto-char (point-min))
     (let ((case-fold-search nil))
       (dolist (h optional-heads)
+        (goto-char (point-min))
         (unless (assoc h heads)
           (when (re-search-forward (rx "[_" (literal h) "_]" (* (not (in "[\n")))) nil t)
             ;; _x_ as rendered only takes up a single column.  To preserve

--- a/core/core-transient-state.el
+++ b/core/core-transient-state.el
@@ -61,10 +61,26 @@ may hold the keys to be removed. The variable may be unbound."
               (listp (symbol-value to-add)))
      (symbol-value to-add))))
 
+(defun spacemacs//transient-state-remove-missing-optional-heads (docstring heads optional-heads)
+  (with-temp-buffer
+    (insert docstring)
+    (goto-char (point-min))
+    (let ((case-fold-search nil))
+      (dolist (h optional-heads)
+        (unless (assoc h heads)
+          (when (re-search-forward (rx "[_" (literal h) "_]" (* (not (in "[\n")))) nil t)
+            ;; _x_ as rendered only takes up a single column.  To preserve
+            ;; alignment, replace with two fewer characters than the matched
+            ;; string.
+            (replace-match (make-string (- (length (match-string 0)) 2) ?\s) t t)))))
+    (buffer-string)))
+
 (defun spacemacs//transient-state-make-doc
-    (transient-state docstring &optional body)
+    (transient-state docstring &optional body optional-heads)
   "Use `hydra' internal function to format and apply DOCSTRING."
-  (let ((heads (spacemacs//transient-state-heads-name transient-state)))
+  (let* ((heads (spacemacs//transient-state-heads-name transient-state))
+         (docstring (spacemacs//transient-state-remove-missing-optional-heads
+                     docstring (symbol-value heads) optional-heads)))
     (setq body (if body body '(nil nil :hint nil :foreign-keys nil)))
     (eval
      (hydra--format nil body docstring (symbol-value heads)))))
@@ -97,8 +113,12 @@ effect if called after that point."
         (set var-name '()))
     (set var-name (append (symbol-value var-name) keys))))
 
-(defmacro spacemacs|transient-state-format-hint (name var hint)
-  "Format HINT and store the result in VAR for transient state NAME."
+(defmacro spacemacs|transient-state-format-hint (name var hint &optional optional-heads)
+  "Format HINT and store the result in VAR for transient state NAME.
+
+OPTIONAL-HEADS is a list of keys which may optionally be added to
+the transient state for some package.  If they are not added,
+mentions of them are removed from HINT."
   (declare (indent 1))
   `(add-hook 'spacemacs-post-user-config-hook
              (lambda ()
@@ -118,7 +138,8 @@ effect if called after that point."
                                :columns ,prop-columns
                                :foreign-keys ,prop-foreign-keys
                                :body-pre ,prop-entry-sexp
-                               :before-exit ,prop-exit-sexp)))))
+                               :before-exit ,prop-exit-sexp)
+                             ,optional-heads))))
              'append))
 
 (defface spacemacs-transient-state-title-face

--- a/layers/+web/eww/funcs.el
+++ b/layers/+web/eww/funcs.el
@@ -34,19 +34,6 @@
 
 
 ;;;; Transient State
-(defvar spacemacs--eww-ts-use-evil nil
-  "Transient State enable Evil key bindings")
-
-(defvar spacemacs--eww-ts-use-writeroom nil
-  "Transient State enable writeroot")
-
-(defvar spacemacs--eww-ts-use-zoom-frm nil
-  "Transient State enable zoom-fmr key bindings")
-
-(defun spacemacs//eww-key-placeholder ()
-  "Just a placeholder for a keybinding."
-  (interactive)
-  (message "The feature is not available/enabled."))
 
 (defun spacemacs//eww-ts-toggle-hint ()
   "Toggle full hint docstring for EWW transient state."
@@ -58,25 +45,9 @@
   "Return a condensed/full hint for the eww transient state"
   (concat
    " "
-   (if (not spacemacs--eww-ts-full-hint-toggle)
-       (concat "[" (propertize "?" 'face 'hydra-face-red) "] help")
-     (let ((result spacemacs--eww-ts-full-hint))
-       (cl-loop for (flag . reg) in
-                '((spacemacs--eww-ts-use-evil . "\\[[^\\[]+ scroll [^\\[]*")
-                  (spacemacs--eww-ts-use-writeroom . "\\[[^\\[]+writeroom[^\\[]*")
-                  (spacemacs--eww-ts-use-zoom-frm . "\\[[^\\[]+zoom-in[^\\[]*")
-                  (spacemacs--eww-ts-use-zoom-frm . "\\[[^\\[]+zoom-out[^\\[]*")
-                  (spacemacs--eww-ts-use-zoom-frm . "\\[[^\\[]+unzoom[^\\[]*"))
-                do
-                (when-let* (((not (symbol-value flag)))
-                            ((string-match reg result))
-                            (start (match-beginning 0))
-                            (end (match-end 0)))
-                  (setq result
-                        (concat (substring result 0 start)
-                                (make-string (- end start) ?\s)
-                                (substring result end)))))
-       result))))
+   (if spacemacs--eww-ts-full-hint-toggle
+       spacemacs--eww-ts-full-hint
+     (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"))))
 
 (defun spacemacs//eww-setup-transient-state ()
   "Setup EWW transient state with toggleable help hint.
@@ -95,7 +66,8 @@ full hint text will not show up!"
   [_<_/_>_] history back/forw^^^^  [_c_] toggle colors            [_=_] unzoom        [_B_] list bookmarks [_d_] download
   [_[_/_]_] page previous/next^^^^ [_t_] toggle latex             ^^                  [_V_] view source    [_B_] add bookmark
   [_u_] page up^^^^^^              [_C_] cycle theme              ^^                  ^^                   [_q_] quit
-  [_t_] top url^^^^^^")
+  [_t_] top url^^^^^^"
+    '("w" "+" "-" "="))
   (spacemacs|define-transient-state eww
     :title "Eww Transient State"
     :hint-is-doc t
@@ -106,10 +78,10 @@ full hint text will not show up!"
     :bindings
     ("?" spacemacs//eww-ts-toggle-hint)
     ;; Navigation
-    ("j" spacemacs//eww-key-placeholder)
-    ("k" spacemacs//eww-key-placeholder)
-    ("h" spacemacs//eww-key-placeholder)
-    ("l" spacemacs//eww-key-placeholder)
+    ;; ("j" evil-next-line)
+    ;; ("k" evil-previous-line)
+    ;; ("h" evil-backward-char)
+    ;; ("l" evil-forward-char)
     ("<" eww-back-url)
     (">" eww-forward-url)
     ("[" eww-previous-url)
@@ -119,16 +91,16 @@ full hint text will not show up!"
     ("u" eww-up-url)
     ("t" eww-top-url)
     ;; Layout/Appearance
-    ("w" spacemacs//eww-key-placeholder)
+    ;; ("w" writeroom-mode)
     ("v" visual-line-mode)
     ("c" eww-toggle-colors)
     ("t" spacemacs/eww-toggle-render-latex)
     ("C" spacemacs/cycle-spacemacs-theme)
     ;; Zoom
-    ("+" spacemacs//eww-key-placeholder)
-    ("-" spacemacs//eww-key-placeholder)
-    ("=" spacemacs//eww-key-placeholder)
-    ;; Lit/view
+    ;; ("+" zoom-frm-in)
+    ;; ("-" zoom-frm-out)
+    ;; ("=" zoom-frm-unzoom)
+    ;; ;; Lit/view
     ("W" eww-list-buffers)
     ("S" eww-list-histories)
     ("B" eww-list-bookmarks)

--- a/layers/+web/eww/funcs.el
+++ b/layers/+web/eww/funcs.el
@@ -34,6 +34,19 @@
 
 
 ;;;; Transient State
+(defvar spacemacs--eww-ts-use-evil nil
+  "Transient State enable Evil key bindings")
+
+(defvar spacemacs--eww-ts-use-writeroom nil
+  "Transient State enable writeroot")
+
+(defvar spacemacs--eww-ts-use-zoom-frm nil
+  "Transient State enable zoom-fmr key bindings")
+
+(defun spacemacs//eww-key-placeholder ()
+  "Just a placeholder for a keybinding."
+  (interactive)
+  (message "The feature is not available/enabled."))
 
 (defun spacemacs//eww-ts-toggle-hint ()
   "Toggle full hint docstring for EWW transient state."
@@ -45,9 +58,25 @@
   "Return a condensed/full hint for the eww transient state"
   (concat
    " "
-   (if spacemacs--eww-ts-full-hint-toggle
-       spacemacs--eww-ts-full-hint
-     (concat "[" (propertize "?" 'face 'hydra-face-red) "] help"))))
+   (if (not spacemacs--eww-ts-full-hint-toggle)
+       (concat "[" (propertize "?" 'face 'hydra-face-red) "] help")
+     (let ((result spacemacs--eww-ts-full-hint))
+       (cl-loop for (flag . reg) in
+                '((spacemacs--eww-ts-use-evil . "\\[[^\\[]+ scroll [^\\[]*")
+                  (spacemacs--eww-ts-use-writeroom . "\\[[^\\[]+writeroom[^\\[]*")
+                  (spacemacs--eww-ts-use-zoom-frm . "\\[[^\\[]+zoom-in[^\\[]*")
+                  (spacemacs--eww-ts-use-zoom-frm . "\\[[^\\[]+zoom-out[^\\[]*")
+                  (spacemacs--eww-ts-use-zoom-frm . "\\[[^\\[]+unzoom[^\\[]*"))
+                do
+                (when-let* (((not (symbol-value flag)))
+                            ((string-match reg result))
+                            (start (match-beginning 0))
+                            (end (match-end 0)))
+                  (setq result
+                        (concat (substring result 0 start)
+                                (make-string (- end start) ?\s)
+                                (substring result end)))))
+       result))))
 
 (defun spacemacs//eww-setup-transient-state ()
   "Setup EWW transient state with toggleable help hint.
@@ -77,10 +106,10 @@ full hint text will not show up!"
     :bindings
     ("?" spacemacs//eww-ts-toggle-hint)
     ;; Navigation
-    ;; ("j" evil-next-line)
-    ;; ("k" evil-previous-line)
-    ;; ("h" evil-backward-char)
-    ;; ("l" evil-forward-char)
+    ("j" spacemacs//eww-key-placeholder)
+    ("k" spacemacs//eww-key-placeholder)
+    ("h" spacemacs//eww-key-placeholder)
+    ("l" spacemacs//eww-key-placeholder)
     ("<" eww-back-url)
     (">" eww-forward-url)
     ("[" eww-previous-url)
@@ -90,16 +119,16 @@ full hint text will not show up!"
     ("u" eww-up-url)
     ("t" eww-top-url)
     ;; Layout/Appearance
-    ;; ("w" writeroom-mode)
+    ("w" spacemacs//eww-key-placeholder)
     ("v" visual-line-mode)
     ("c" eww-toggle-colors)
     ("t" spacemacs/eww-toggle-render-latex)
     ("C" spacemacs/cycle-spacemacs-theme)
     ;; Zoom
-    ;; ("+" zoom-frm-in)
-    ;; ("-" zoom-frm-out)
-    ;; ("=" zoom-frm-unzoom)
-    ;; ;; Lit/view
+    ("+" spacemacs//eww-key-placeholder)
+    ("-" spacemacs//eww-key-placeholder)
+    ("=" spacemacs//eww-key-placeholder)
+    ;; Lit/view
     ("W" eww-list-buffers)
     ("S" eww-list-histories)
     ("B" eww-list-bookmarks)

--- a/layers/+web/eww/packages.el
+++ b/layers/+web/eww/packages.el
@@ -29,7 +29,6 @@
     zoom-frm))
 
 (defun eww/post-init-evil ()
-  (setq spacemacs--eww-ts-use-evil t)
   (spacemacs/transient-state-register-add-bindings 'eww
     '(("j" evil-next-line)
       ("k" evil-previous-line)
@@ -117,12 +116,10 @@
     :defer t))
 
 (defun eww/post-init-writeroom-mode ()
-  (setq spacemacs--eww-ts-use-writeroom t)
   (spacemacs/transient-state-register-add-bindings 'eww
     '(("w" writeroom-mode))))
 
 (defun eww/post-init-zoom-frm ()
-  (setq spacemacs--eww-ts-use-zoom-frm t)
   (spacemacs/transient-state-register-add-bindings 'eww
     '(("+" zoom-frm-in)
       ("-" zoom-frm-out)

--- a/layers/+web/eww/packages.el
+++ b/layers/+web/eww/packages.el
@@ -29,6 +29,7 @@
     zoom-frm))
 
 (defun eww/post-init-evil ()
+  (setq spacemacs--eww-ts-use-evil t)
   (spacemacs/transient-state-register-add-bindings 'eww
     '(("j" evil-next-line)
       ("k" evil-previous-line)
@@ -116,10 +117,12 @@
     :defer t))
 
 (defun eww/post-init-writeroom-mode ()
+  (setq spacemacs--eww-ts-use-writeroom t)
   (spacemacs/transient-state-register-add-bindings 'eww
     '(("w" writeroom-mode))))
 
 (defun eww/post-init-zoom-frm ()
+  (setq spacemacs--eww-ts-use-zoom-frm t)
   (spacemacs/transient-state-register-add-bindings 'eww
     '(("+" zoom-frm-in)
       ("-" zoom-frm-out)


### PR DESCRIPTION
Warning message happened when enable the `eww` layer:
```
Warning (emacs): Unrecognized key: _+_ 
Warning (emacs): Unrecognized key: _w_ 
Warning (emacs): Unrecognized key: _-_ 
Warning (emacs): Unrecognized key: _=_ 
```
It caused by the transient state for eww has post-defined keys, but the keys not available during transient hints initilizating.

The is PR will fix the issue by define the keys with `identify` function first, then replay them with the real keys.