### PR TITLE
feat(org): add ability to set org-project-capture-projects-file using a function

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -442,6 +442,14 @@ the build in =project.el= alternative.
   (setq-default dotspacemacs-configuration-layers
     '((org :variables org-project-capture-projects-file "TODOs.org")))
 #+END_SRC
+You can also pass a function as `org-project-capture-projects-file`. This allows you to
+set file name based on project
+
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+    '((org :variables org-project-capture-projects-file '(lambda (arg) (concat (projectile-project-name) ".org")))))
+#+END_SRC
 
 The TODO files are not added to the agenda automatically. You can do this with
 the following snippet.

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -831,7 +831,7 @@ Headline^^            Visit entry^^               Filter^^                    Da
       "aop" 'spacemacs/org-project-capture-capture
       "po" 'spacemacs/org-project-capture-goto-todos)
     :config
-    (if (file-name-absolute-p org-project-capture-projects-file)
+    (if (and (stringp org-project-capture-projects-file) (file-name-absolute-p org-project-capture-projects-file))
         (progn
           (setq org-project-capture-projects-file org-project-capture-projects-file)
           (push (org-project-capture-project-todo-entry :empty-lines 1)


### PR DESCRIPTION
The adds ability to use a function as `org-project-capture-projects-file`.

* Reason for change
This change gives more control on the file name generated when we goto org file of the project. Previously, there was only a possibility of having a static file name either absolute or relative to project path.