### PR TITLE
[shell] Support multi-vterm in spacemacs/projectile-shell

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -31,12 +31,6 @@ and move your focus to it; to switch the current buffer view, use
   (let ((default-directory (projectile-acquire-root)))
     (call-interactively 'spacemacs/default-pop-shell)))
 
-(defun spacemacs//projectile-run-shell-in-root ()
-  "Invoke `shell-default-shell' in the project's root directory."
-  (interactive)
-  (projectile-with-default-dir (projectile-project-root)
-    (call-interactively shell-default-shell)))
-
 (defun spacemacs/projectile-shell ()
   "Create a shell buffer at the project root and switch to it.
 Customize `shell-default-shell' to control what type of shell
@@ -44,13 +38,13 @@ buffer you create. This function switches the current buffer
 view; to pop-up a full width buffer, use
 `spacemacs/projectile-shell-pop'."
   (interactive)
-  (call-interactively
-   (or (pcase shell-default-shell
-         ((or 'multi-term 'multi-vterm)
-          #'spacemacs//projectile-run-shell-in-root)
-         ('eat #'eat-project))
-       (intern-soft (format "projectile-run-%s" shell-default-shell))
-       #'projectile-run-shell)))
+  (pcase shell-default-shell
+    ((or 'multi-term 'multi-vterm)
+     (projectile-with-default-dir (projectile-project-root)
+       (call-interactively shell-default-shell)))
+    ('eat (call-interactively #'eat-project))
+    (_ (call-interactively (or (intern-soft (format "projectile-run-%s" shell-default-shell))
+                               #'projectile-run-shell)))))
 
 (defun spacemacs/disable-hl-line-mode ()
   "Locally disable global-hl-line-mode"

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -31,6 +31,12 @@ and move your focus to it; to switch the current buffer view, use
   (let ((default-directory (projectile-acquire-root)))
     (call-interactively 'spacemacs/default-pop-shell)))
 
+(defun spacemacs//projectile-run-shell-in-root ()
+  "Invoke `shell-default-shell' in the project's root directory."
+  (interactive)
+  (projectile-with-default-dir (projectile-project-root)
+    (call-interactively shell-default-shell)))
+
 (defun spacemacs/projectile-shell ()
   "Create a shell buffer at the project root and switch to it.
 Customize `shell-default-shell' to control what type of shell
@@ -40,7 +46,8 @@ view; to pop-up a full width buffer, use
   (interactive)
   (call-interactively
    (or (pcase shell-default-shell
-         ('multi-term #'projectile-multi-term-in-root)
+         ((or 'multi-term 'multi-vterm)
+          #'spacemacs//projectile-run-shell-in-root)
          ('eat #'eat-project))
        (intern-soft (format "projectile-run-%s" shell-default-shell))
        #'projectile-run-shell)))
@@ -118,11 +125,6 @@ SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
               (lambda nil (,func ,shell))))
        (shell-pop index)
        (spacemacs/resize-shell-to-desired-width))))
-
-(defun projectile-multi-term-in-root ()
-  "Invoke `multi-term' in the project's root."
-  (interactive)
-  (projectile-with-default-dir (projectile-project-root) (multi-term)))
 
 (defun spacemacs//toggle-shell-auto-completion-based-on-path ()
   "Deactivates automatic completion on remote paths.


### PR DESCRIPTION
To support the multi-vterm in projectile. 
Enable the shell layer with `multi-vterm`, then open a projectile directory (eg: `~/.emacs.d/`), then try `SPC p $` to call `spacemacs/projectile-shell`, which does not work with `multi-vterm`.
```
(shell :variables shell-default-shell 'multi-vterm)
```
The PR will support the `multi-vterm` for projectile. 