### PR TITLE
Reduce installation of packages that won't be used

### DIFF
--- a/layers/+checkers/spell-checking/packages.el
+++ b/layers/+checkers/spell-checking/packages.el
@@ -22,7 +22,7 @@
 
 (defconst spell-checking-packages
   '(
-    auto-dictionary
+    (auto-dictionary :toggle spell-checking-enable-auto-dictionary)
     flyspell
     flyspell-correct
     (flyspell-correct-ivy :toggle (configuration-layer/layer-used-p 'ivy))
@@ -34,7 +34,6 @@
 (defun spell-checking/init-auto-dictionary ()
   (use-package auto-dictionary
     :defer t
-    :if spell-checking-enable-auto-dictionary
     :init
     (add-hook 'flyspell-mode-hook 'auto-dictionary-mode)
     ;; Select the buffer local dictionary if it was set, otherwise

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -28,7 +28,7 @@
 (defconst syntax-checking-packages
   '(
     flycheck
-    flycheck-pos-tip
+    (flycheck-pos-tip :toggle syntax-checking-enable-tooltips)
     popwin))
 
 (defun syntax-checking/init-flycheck ()
@@ -79,7 +79,6 @@
 
 (defun syntax-checking/init-flycheck-pos-tip ()
   (use-package flycheck-pos-tip
-    :if syntax-checking-enable-tooltips
     :after (flycheck)
     :init
     (flycheck-pos-tip-mode)

--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -179,7 +179,7 @@ In the file =packages.el= of the python layer:
   ;; here it is `company-anaconda'
   (setq python-packages
     '(...
-      (company-anaconda :toggle (configuration-layer/package-used-p 'company))
+      (company-anaconda :requires company)
       ...))
 
   (defun python/init-company-anaconda ()

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -91,8 +91,7 @@
 
 (defun treemacs/init-treemacs-evil ()
   (use-package treemacs-evil
-    :after treemacs
-    :if (memq dotspacemacs-editing-style '(vim hybrid))))
+    :after treemacs))
 
 (defun treemacs/init-treemacs-projectile ()
   (use-package treemacs-projectile
@@ -112,7 +111,6 @@
 
 (defun treemacs/init-treemacs-all-the-icons ()
   (use-package treemacs-all-the-icons
-    :if treemacs-use-all-the-icons-theme
     :hook ((treemacs-mode dired-mode) . (lambda () (treemacs-load-theme 'all-the-icons)))))
 
 (defun treemacs/pre-init-winum ()

--- a/layers/+intl/chinese/packages.el
+++ b/layers/+intl/chinese/packages.el
@@ -50,7 +50,6 @@
 
 (defun chinese/init-pyim ()
   (use-package pyim
-    :if chinese-default-input-method
     :defer t
     :init
     (setq pyim-directory (expand-file-name "pyim/" spacemacs-cache-directory)
@@ -66,7 +65,6 @@
 (defun chinese/init-pyim-basedict ()
   "Initialize pyim-basedict"
   (use-package pyim-basedict
-    :if (eq chinese-default-input-method 'pinyin)
     :defer t
     :config
     (pyim-basedict-enable)))
@@ -74,7 +72,6 @@
 (defun chinese/init-pyim-wbdict ()
   "Initialize pyim-wbdict"
   (use-package pyim-wbdict
-    :if (member chinese-default-input-method '(wubi wubi86 wubi98))
     :defer t
     :config
     (setq pyim-default-scheme 'wubi)
@@ -84,7 +81,6 @@
 
 (defun chinese/init-youdao-dictionary ()
   (use-package youdao-dictionary
-    :if chinese-enable-youdao-dict
     :defer t
     :config
     ;; Enable Cache

--- a/layers/+lang/clojure/packages.el
+++ b/layers/+lang/clojure/packages.el
@@ -33,13 +33,16 @@
     eldoc
     evil-cleverparens
     flycheck
-    (flycheck-clojure :toggle (memq 'squiggly (if (listp clojure-enable-linters)
+    (flycheck-clojure :requires flycheck
+                      :toggle (memq 'squiggly (if (listp clojure-enable-linters)
                                                   clojure-enable-linters
                                                 (list clojure-enable-linters))))
-    (flycheck-clj-kondo :toggle (memq 'clj-kondo (if (listp clojure-enable-linters)
+    (flycheck-clj-kondo :requires flycheck
+                        :toggle (memq 'clj-kondo (if (listp clojure-enable-linters)
                                                      clojure-enable-linters
                                                    (list clojure-enable-linters))))
-    (flycheck-joker :toggle (memq 'joker (if (listp clojure-enable-linters)
+    (flycheck-joker :requires flycheck
+                    :toggle (memq 'joker (if (listp clojure-enable-linters)
                                              clojure-enable-linters
                                            (list clojure-enable-linters))))
     ggtags
@@ -610,16 +613,13 @@
 
 (defun clojure/init-flycheck-clojure ()
   (use-package flycheck-clojure
-    :if (configuration-layer/package-usedp 'flycheck)
     :config
     (flycheck-clojure-setup)
     (with-eval-after-load 'cider
       (flycheck-clojure-inject-jack-in-dependencies))))
 
 (defun clojure/init-flycheck-clj-kondo ()
-  (use-package flycheck-clj-kondo
-    :if (configuration-layer/package-usedp 'flycheck)))
+  (use-package flycheck-clj-kondo))
 
 (defun clojure/init-flycheck-joker ()
-  (use-package flycheck-joker
-    :if (configuration-layer/package-usedp 'flycheck)))
+  (use-package flycheck-joker))

--- a/layers/+lang/elixir/packages.el
+++ b/layers/+lang/elixir/packages.el
@@ -23,7 +23,7 @@
 
 (defconst elixir-packages
   '(
-    alchemist
+    (alchemist :toggle (eq elixir-backend 'alchemist))
     company
     counsel-gtags
     dap-mode
@@ -38,7 +38,6 @@
 
 (defun elixir/init-alchemist ()
   (use-package alchemist
-    :if (eq elixir-backend 'alchemist)
     :defer t
     :init
     (spacemacs/register-repl 'alchemist 'alchemist-iex-run "alchemist")

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -36,8 +36,8 @@
     evil-cleverparens
     eval-sexp-fu
     flycheck
-    flycheck-elsa
-    flycheck-package
+    (flycheck-elsa :requires flycheck)
+    (flycheck-package :requires flycheck)
     ggtags
     counsel-gtags
     (ielm :location built-in)

--- a/layers/+lang/haskell/packages.el
+++ b/layers/+lang/haskell/packages.el
@@ -41,7 +41,7 @@
         haskell-snippets
         counsel-gtags
         (helm-hoogle :requires helm)
-        hindent
+        (hindent :toggle haskell-enable-hindent)
         hlint-refactor))
 
 (defun haskell/init-lsp-haskell ()
@@ -315,7 +315,6 @@
 (defun haskell/init-hindent ()
   (use-package hindent
     :defer t
-    :if haskell-enable-hindent
     :init
     (add-hook 'haskell-mode-hook #'hindent-mode)
     :config

--- a/layers/+lang/java/packages.el
+++ b/layers/+lang/java/packages.el
@@ -32,7 +32,7 @@
     maven-test-mode
     (meghanada :toggle (eq java-backend 'meghanada))
     mvn
-    (lsp-java :requires lsp-mode)
+    (lsp-java :requires lsp-mode :toggle (eq java-backend 'lsp))
     org
     smartparens))
 
@@ -141,7 +141,6 @@
 (defun java/init-lsp-java ()
   (use-package lsp-java
     :defer t
-    :if (eq java-backend 'lsp)
     :config
     ;; key bindings
     (dolist (prefix '(("mc" . "compile/create")

--- a/layers/+lang/lua/packages.el
+++ b/layers/+lang/lua/packages.el
@@ -24,7 +24,7 @@
 (defconst lua-packages
   '(
     company
-    (company-lua :requires company)
+    (company-lua :requires company :toggle (eq lua-backend 'lua-mode))
     flycheck
     ggtags
     counsel-gtags
@@ -66,7 +66,6 @@
 
 (defun lua/init-company-lua ()
   (use-package company-lua
-    :if (eq lua-backend 'lua-mode)
     :defer t))
 
 (defun lua/post-init-ggtags ()

--- a/layers/+lang/nim/packages.el
+++ b/layers/+lang/nim/packages.el
@@ -26,7 +26,8 @@
     company
     flycheck
     (flycheck-nim :location (recipe :fetcher github
-                                    :repo "smile13241324/flycheck-nim"))
+                                    :repo "smile13241324/flycheck-nim")
+                  :requires flycheck)
     nim-mode))
 
 (defun nim/post-init-company ()
@@ -37,8 +38,7 @@
   (spacemacs/enable-flycheck 'nimscript-mode))
 
 (defun nim/init-flycheck-nim ()
-  (use-package flycheck-nim
-    :if (configuration-layer/package-used-p 'flycheck)))
+  (use-package flycheck-nim))
 
 (defun nim/init-nim-mode ()
   (use-package nim-mode

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -24,7 +24,7 @@
 (defconst python-packages
   '(
     blacken
-    code-cells
+    (code-cells :toggle (not (configuration-layer/layer-used-p 'ipython-notebook)))
     company
     counsel-gtags
     cython-mode
@@ -58,14 +58,13 @@
     window-purpose
     yapfify
     ;; packages for anaconda backend
-    anaconda-mode
-    (company-anaconda :requires company)
+    (anaconda-mode :toggle (eq python-backend 'anaconda))
+    (company-anaconda :requires (anaconda-mode company))
     ;; packages for Microsoft's pyright language server
-    (lsp-pyright :requires lsp-mode)))
+    (lsp-pyright :requires lsp-mode :toggle (eq python-lsp-server 'pyright))))
 
 (defun python/init-anaconda-mode ()
   (use-package anaconda-mode
-    :if (eq python-backend 'anaconda)
     :defer t
     :init
     (setq anaconda-mode-installation-directory
@@ -93,7 +92,6 @@
 
 (defun python/init-code-cells ()
   (use-package code-cells
-    :if (not (configuration-layer/layer-used-p 'ipython-notebook))
     :defer t
     :commands (code-cells-mode)
     :init (add-hook 'python-mode-hook 'code-cells-mode)
@@ -119,7 +117,6 @@
 
 (defun python/init-company-anaconda ()
   (use-package company-anaconda
-    :if (eq python-backend 'anaconda)
     :defer t))
 ;; see `spacemacs//python-setup-anaconda-company'
 
@@ -486,7 +483,6 @@
 
 (defun python/init-lsp-pyright ()
   (use-package lsp-pyright
-    :if (eq python-lsp-server 'pyright)
     :ensure nil
     :defer t))
 

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -25,7 +25,7 @@
   '(
     add-node-modules-path
     bundler
-    chruby
+    (chruby :toggle (eq ruby-version-manager 'chruby))
     company
     counsel-gtags
     dap-mode
@@ -38,8 +38,8 @@
     popwin
     prettier-js
     rake
-    rbenv
-    robe
+    (rbenv :toggle (eq ruby-version-manager 'rbenv))
+    (robe :toggle (eq ruby-backend 'robe))
     rspec-mode
     rubocop
     rubocopfmt
@@ -48,7 +48,7 @@
     ruby-refactor
     ruby-test-mode
     ruby-tools
-    rvm
+    (rvm :toggle (eq ruby-version-manager 'rvm))
     seeing-is-believing
     smartparens))
 
@@ -68,7 +68,6 @@
 
 (defun ruby/init-chruby ()
   (use-package chruby
-    :if (equal ruby-version-manager 'chruby)
     :commands chruby-use-corresponding
     :defer t
     :init (spacemacs/add-to-hooks 'chruby-use-corresponding
@@ -182,12 +181,10 @@
 
 (defun ruby/init-rbenv ()
   (use-package rbenv
-    :if (equal ruby-version-manager 'rbenv)
     :defer t))
 
 (defun ruby/init-robe ()
   (use-package robe
-    :if (eq ruby-backend 'robe)
     :defer t
     :init
     (spacemacs/register-repl 'robe 'robe-start "robe")
@@ -364,7 +361,6 @@
 
 (defun ruby/init-rvm ()
   (use-package rvm
-    :if (equal ruby-version-manager 'rvm)
     :defer t
     :init
     (setq rspec-use-rvm t)

--- a/layers/+lang/sql/packages.el
+++ b/layers/+lang/sql/packages.el
@@ -26,7 +26,7 @@
         company
         org
         sql
-        (sql-indent :location elpa)
+        (sql-indent :location elpa :toggle sql-auto-indent)
         (sqlfmt :location local)
         (sqlup-mode :toggle sql-capitalize-keywords)
         ))
@@ -188,7 +188,6 @@
 
 (defun sql/init-sql-indent ()
   (use-package sql-indent
-    :if sql-auto-indent
     :defer t
     :init (add-hook 'sql-mode-hook 'sqlind-minor-mode)
     :config (spacemacs|hide-lighter sqlind-minor-mode)))

--- a/layers/+music/spotify/packages.el
+++ b/layers/+music/spotify/packages.el
@@ -23,8 +23,8 @@
 
 (defconst spotify-packages
   '(spotify
-    (helm-spotify-plus :toggle (configuration-layer/package-usedp 'helm))
-    (counsel-spotify :toggle (configuration-layer/package-usedp 'ivy))))
+    (helm-spotify-plus :requires helm)
+    (counsel-spotify :requires counsel)))
 
 (defun spotify/init-spotify ()
   (use-package spotify

--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -88,7 +88,6 @@
 
 (defun osx/init-osx-dictionary ()
   (use-package osx-dictionary
-    :if osx-use-dictionary-app
     :init (spacemacs/set-leader-keys "xwd" 'osx-dictionary-search-pointer)
     :commands (osx-dictionary-search-pointer
                osx-dictionary-search-input

--- a/layers/+os/osx/packages.el
+++ b/layers/+os/osx/packages.el
@@ -24,11 +24,11 @@
 (setq osx-packages
       '(
         helm
-        launchctl
+        (launchctl :toggle (spacemacs/system-is-mac))
         (osx-dictionary :toggle osx-use-dictionary-app)
-        osx-trash
-        osx-clipboard
-        reveal-in-osx-finder
+        (osx-trash :toggle (spacemacs/system-is-mac))
+        (osx-clipboard :toggle (spacemacs/system-is-mac))
+        (reveal-in-osx-finder :toggle (spacemacs/system-is-mac))
         term
         ))
 
@@ -57,7 +57,6 @@
 
 (defun osx/init-launchctl ()
   (use-package launchctl
-    :if (spacemacs/system-is-mac)
     :defer t
     :init
     (add-to-list 'auto-mode-alist '("\\.plist\\'" . nxml-mode))
@@ -105,13 +104,11 @@
 
 (defun osx/init-osx-trash ()
   (use-package osx-trash
-    :if (and (spacemacs/system-is-mac)
-             (not (boundp 'mac-system-move-file-to-trash-use-finder)))
+    :if (not (boundp 'mac-system-move-file-to-trash-use-finder))
     :init (osx-trash-setup)))
 
 (defun osx/init-osx-clipboard ()
   (use-package osx-clipboard
-    :if (spacemacs/system-is-mac)
     :commands
     (osx-clipboard-paste-function osx-clipboard-cut-function)
     :init
@@ -126,7 +123,6 @@
 
 (defun osx/init-reveal-in-osx-finder ()
   (use-package reveal-in-osx-finder
-    :if (spacemacs/system-is-mac)
     :commands reveal-in-osx-finder))
 
 (defun osx/post-init-term ()

--- a/layers/+readers/deft/packages.el
+++ b/layers/+readers/deft/packages.el
@@ -29,7 +29,6 @@
 
 (defun deft/init-zetteldeft ()
   (use-package zetteldeft
-    :if (eq deft-zetteldeft t)
     :init
     (spacemacs/declare-prefix-for-mode 'deft-mode "mz" "zetteldeft")
     (spacemacs/declare-prefix-for-mode 'org-mode "mz" "zetteldeft")

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -25,7 +25,8 @@
       '(
         (doom-modeline :toggle (eq (spacemacs/get-mode-line-theme-name) 'doom))
         fancy-battery
-        spaceline
+        (spaceline :toggle (memq (spacemacs/get-mode-line-theme-name)
+                                 '(spacemacs all-the-icons custom)))
         (spaceline-all-the-icons :toggle (eq (spacemacs/get-mode-line-theme-name) 'all-the-icons))
         symon
         (vim-powerline :location (recipe :fetcher local))))
@@ -51,8 +52,6 @@
 
 (defun spacemacs-modeline/init-spaceline ()
   (use-package spaceline-config
-    :if (memq (spacemacs/get-mode-line-theme-name)
-              '(spacemacs all-the-icons custom))
     :init
     (spacemacs|require-when-dumping 'spaceline)
     (spacemacs|when-dumping-strict

--- a/layers/+themes/colors/packages.el
+++ b/layers/+themes/colors/packages.el
@@ -25,7 +25,7 @@
   '(
     ;; not working well for now
     ;; rainbow-blocks
-    nyan-mode
+    (nyan-mode :toggle colors-enable-nyan-cat-progress-bar)
     color-identifiers-mode
     rainbow-identifiers
     rainbow-mode))
@@ -37,7 +37,6 @@
 
 (defun colors/init-nyan-mode ()
   (use-package nyan-mode
-    :if colors-enable-nyan-cat-progress-bar
     :config
     (setq nyan-wavy-trail t)
     (setq nyan-animate-nyancat t)

--- a/layers/+tools/cmake/packages.el
+++ b/layers/+tools/cmake/packages.el
@@ -29,7 +29,6 @@
 
 (defun cmake/init-cmake-ide ()
   (use-package cmake-ide
-    :if cmake-enable-cmake-ide-support
     :commands (cmake-ide-delete-file cide--mode-hook)
     :init
     (dolist (hook '(c-mode-hook c++-mode-hook))

--- a/layers/+tools/tree-sitter/packages.el
+++ b/layers/+tools/tree-sitter/packages.el
@@ -44,13 +44,11 @@
 
 (defun tree-sitter/init-tree-sitter-indent ()
   (use-package tree-sitter-indent
-    :if tree-sitter-indent-enable
     :init
     (add-hook 'rust-mode-hook #'tree-sitter-indent-mode)))
 
 (defun tree-sitter/init-ts-fold ()
   (use-package ts-fold
-    :if tree-sitter-fold-enable
     :init
     (when tree-sitter-fold-enable
       (if tree-sitter-fold-indicators-enable

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -27,7 +27,7 @@
                      :location (recipe :fetcher github
                                        :repo "domenzain/evil-exwm-state"))
     (exwm :step pre)
-    (helm-exwm :toggle (configuration-layer/package-used-p 'helm))
+    (helm-exwm :requires helm)
     (xdg :location built-in)
     (xelb :step pre)))
 


### PR DESCRIPTION
Many places where Spacemacs was specifying the `:if` argument to
`use-package`, it would be even better to avoid installing the package
in the first place (and therefore the `use-packae` would of course
never execute).  There are also a couple other places where Spacemacs
can avoid installing packages that are not used.

This PR makes several refactors in this direction:

1. Replace `:if` in `use-package` with `:toggle` in the packages list,
   for owned packages.
1. Remove redundant `:if` expressions where the `:toggle` is already
   present, and equivalent.
1. Replace some flycheck integration packages' `:if` expressions with
   `:requires flycheck`
1. Similarly, replace some `:toggle
   (configuration-layer/package-used-p PKG)` with the shorter, and
   equivalent, `:requires PKG`.