### PR TITLE
* layers/+tools/shell/packages.el: Remove redundant code `term-send-tab`

### DIFF
--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -272,10 +272,6 @@
 (defun shell/init-term ()
   (spacemacs/register-repl 'term 'term)
   (spacemacs/register-repl 'term 'ansi-term)
-  (defun term-send-tab ()
-    "Send tab in term mode."
-    (interactive)
-    (term-send-raw-string "\t"))
 
   (when (eq dotspacemacs-editing-style 'vim)
     (evil-define-key 'insert term-raw-map


### PR DESCRIPTION
The function `term-send-tab` actually been defined in the `functs.el`
https://github.com/syl20bnr/spacemacs/blob/670ee7e50c417c7a16b72304e9432da3234ad42a/layers/%2Btools/shell/funcs.el#L252-L255

So remove the redundant one.