### PR TITLE
chore: remove initialization warning about pyright and lsp formatting

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -234,8 +234,10 @@ One of [[https://github.com/google/yapf][YAPF]], [[https://github.com/ambv/black
 
 The default =python-formatter= is =yapf=, with the following exception: When
 both the =lsp= layer is used, and =python-lsp-server= is =pylsp=, the default
-formatter is =lsp=. Note that the =pyright= language server does not support
-formatting.
+formatter is =lsp=.
+
+Note that the =pyright= language server does not support formatting, but it
+can be used alongside with =ruff=, which does support it.
 
 The key binding ~SPC m =~ invokes the selected formatter on the current buffer
 when in non LSP python mode otherwise ~SPC m ==~ is used.

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -395,12 +395,6 @@ to be called for each testrunner. "
 (defun spacemacs//bind-python-formatter-keys ()
   "Bind the python formatter keys.
 Bind formatter to '==' for LSP and '='for all other backends."
-  (when (and (eq python-formatter 'lsp)
-             (eq python-lsp-server 'pyright))
-    (display-warning
-     '(spacemacs python)
-     "Configuration error: `python-formatter' is `lsp', but `python-lsp-server' is `pyright', which does not support formatting."
-     :error))
   (spacemacs/set-leader-keys-for-major-mode 'python-mode
     (if (eq python-backend 'lsp)
         "=="
@@ -418,8 +412,7 @@ Bind formatter to '==' for LSP and '='for all other backends."
 
 (defun spacemacs//python-lsp-set-up-format-on-save ()
   (when (and python-format-on-save
-             (eq python-formatter 'lsp)
-             (eq python-lsp-server 'pylsp))
+             (eq python-formatter 'lsp))
     (add-hook
      'python-mode-hook
      'spacemacs//python-lsp-set-up-format-on-save-local)))
@@ -428,10 +421,16 @@ Bind formatter to '==' for LSP and '='for all other backends."
   (add-hook 'before-save-hook 'spacemacs//python-lsp-format-on-save nil t))
 
 (defun spacemacs//python-lsp-format-on-save ()
-  (when (and python-format-on-save
-             (eq python-formatter 'lsp)
-             (eq python-lsp-server 'pylsp))
-    (lsp-format-buffer)))
+  (condition-case err
+      (when (and python-format-on-save
+                 (eq python-formatter 'lsp))
+        (lsp-format-buffer))
+    (lsp-capability-not-supported
+     (display-warning
+       '(spacemacs python)
+       "Configuration error: `python-formatter' is `lsp', no active workspace supports textDocument/formatting"
+       :error))))
+
 
 
 ;; REPL


### PR DESCRIPTION
The warning is misleading -- the user may believe that it is not possible to use lsp formatting when pyright is used -- this is wrong, since add-on servers (such as ruff) may provide code formatting and be used alongside the primary language server.

A better approach is to let the user set it up and warn only if lsp-format-buffer fails due to lack of server capabilities.
