### PR TITLE
New macro `spacemacs|deferred-run-in-buffer` to deferred actions

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -28,6 +28,28 @@
 values."
   `(if (boundp ',variable) ,variable ',default))
 
+(defmacro spacemacs|deferred-run-in-buffer (name &rest body)
+  "Entry point that defers server startup until buffer is visible.
+It will wait until the buffer is visible before executing the instructions."
+  (let ((func (intern (format "spacemacs//init-if-buffer-visible-%s" name))))
+    `(defun ,func ()
+       "Run the commands for the current buffer if the buffer is visible.
+Returns non nil if it was run for the buffer."
+       (when (or (buffer-modified-p) (get-buffer-window nil t))
+         (remove-hook 'window-configuration-change-hook
+                      ,func t)
+         ,@body
+         t))
+    `(run-with-idle-timer
+      0 nil
+      (lambda (buffer)
+        (when (buffer-live-p buffer)
+          (with-current-buffer buffer
+            (unless (funcall ,func)
+              (add-hook 'window-configuration-change-hook
+                        ,func nil t)))))
+      (current-buffer))))
+
 (defun spacemacs/system-is-mac ()
   (eq system-type 'darwin))
 

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -98,7 +98,8 @@
 
 (defun spacemacs//python-setup-lsp-dap ()
   "Setup DAP integration."
-  (require 'dap-python))
+  (spacemacs|deferred-run-in-buffer dap-python
+   (require 'dap-python)))
 
 
 ;; others


### PR DESCRIPTION
A new macro `spacemacs|deferred-run-in-buffer` to defer loading the `dap-python`, it speedup the python buffer for users, partly improve on python layer user experience, like #16529.

On my local, the time reduced from ~5.1 seconds to ~3.9 seconds by running follow testing commands line and check the time in `*Messages*` buffer.
```
$ emacs -nw --eval "(require 'benchmark)" --eval '(message "time: %s" (benchmark-elapse (with-current-buffer (find-file "/tmp/a.py") (kill-buffer))))'
```
Before: time: `5.086223264`
After: time: `3.932631126`