### PR TITLE
[defaults] Don't set trailing-whitespace face

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -473,10 +473,6 @@
   (use-package whitespace
     :defer t
     :init
-    (when dotspacemacs-show-trailing-whitespace
-      (set-face-attribute
-       'trailing-whitespace nil
-       :background (face-attribute 'font-lock-comment-face :foreground)))
     (add-hook 'prog-mode-hook 'spacemacs//trailing-whitespace)
     (add-hook 'text-mode-hook 'spacemacs//trailing-whitespace)
 


### PR DESCRIPTION
Leave it to be defined by theme.

I'm using Emacs' builtin modus-operandi theme. spacemacs interferes the theme's settings, and makes the trailing whitespace invisible in terminal.

This PR removes the code that sets trailing whitespace's face. Unfortunately, it wasn't clear why this code snippet existed in the first place.