### PR TITLE
* layers/+lang/python/funcs.el: Abandon ipython version detecting for speed

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -157,13 +157,9 @@ ROOT-DIR should be the directory path for the environment, `nil' for clean up."
             (equal python-shell-interpreter spacemacs--python-shell-interpreter-origin))
     (if-let* ((default-directory root-dir))
         (if-let* ((ipython (cl-find-if 'spacemacs/pyenv-executable-find
-                                       '("ipython3" "ipython")))
-                  (version (replace-regexp-in-string
-                            "\\(\\.dev\\)?[\r\n|\n]$" ""
-                            (shell-command-to-string (format "\"%s\" --version" ipython)))))
+                                       '("ipython3" "ipython"))))
             (setq-local python-shell-interpreter ipython
-                        python-shell-interpreter-args
-                        (concat "-i" (unless (version< version "5") " --simple-prompt")))
+                        python-shell-interpreter-args "-i --simple-prompt")
           ;; else try python3 or python
           (setq-local python-shell-interpreter
                       (or (cl-find-if 'spacemacs/pyenv-executable-find


### PR DESCRIPTION
Spacemacs slow on opening a python file.

This PR will abandon the ipython version detecting to speedup opening *.py files (reduced ~0.5 seconds on my local).
Currently Spacemacs require emacs-28.2 (released on `2022/09/12`, https://lists.gnu.org/archive/html/emacs-devel/2022-09/msg00730.html), 
while the ipython version detecting for the `--simple-prompt` related to the ipython-5.0 (release on `2016/07/07`, https://ipython.readthedocs.io/en/stable/whatsnew/version5.html#ipython-5-0).

So it should be safe to remove the ipython version detecting to speedup opening *.py files.