### PR TITLE
* core/core-dotspacemacs.el: Mark variable dotspacemacs-command-key obsoleted

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -342,12 +342,14 @@ pressing `<leader> m`. Set it to `nil` to disable it."
   'string
   'spacemacs-dotspacemacs-init)
 
-(spacemacs|defc dotspacemacs-command-key "SPC"
+(spacemacs|defc dotspacemacs-emacs-command-key "SPC"
   "The key used for Emacs commands (M-x) (after pressing on the leader key)."
   'string
   'spacemacs-dotspacemacs-init)
-(defvaralias 'dotspacemacs-emacs-command-key 'dotspacemacs-command-key
-  "New official name for `dotspacemacs-command-key'")
+
+(define-obsolete-variable-alias 'dotspacemacs-command-key
+  'dotspacemacs-emacs-command-key "20160109 58e524"
+  "Please use the official name `dotspacemacs-emacs-command-key'")
 
 (spacemacs|defc dotspacemacs-distinguish-gui-tab nil
   "If non nil, distinguish C-i and tab in the GUI version of Emacs."

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -348,8 +348,7 @@ pressing `<leader> m`. Set it to `nil` to disable it."
   'spacemacs-dotspacemacs-init)
 
 (define-obsolete-variable-alias 'dotspacemacs-command-key
-  'dotspacemacs-emacs-command-key "20160109 58e524"
-  "Please use the official name `dotspacemacs-emacs-command-key'")
+  'dotspacemacs-emacs-command-key "2016-01-09 (58e524)")
 
 (spacemacs|defc dotspacemacs-distinguish-gui-tab nil
   "If non nil, distinguish C-i and tab in the GUI version of Emacs."


### PR DESCRIPTION
The `dotspacemacs-command-key` was renamed to `dotspacemacs-command-key` on Jan 9, 2016, commit:
58e5241c8d96da0a2cf04d4897a74c9d1250875e .

It should be safe to remove the alias and use the official name only. 