### PR TITLE
* layers/+lang/python/*: New flag python-enable-importmagic

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -315,7 +315,24 @@ config section:
 or as a directory-local variable (for per-project settings).
 
 ** Importmagic
-Install importmagic and epc for importmagic functionality.
+Install importmagic and epc for importmagic functionality, it will start a epc
+instance on background to serve the requests.
+
+The importmagic is a heavy feature, will take time to prepare the background
+server, especially slow with =ipython= or =ipython3=, set the
+=importmagic-python-interpreter= to =python= or =python3= (if it is the
+interpreter of ipython) will have performance benefit. Fox example:
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers
+    '((python :variables importmagic-python-interpreter "python3")))
+#+END_SRC
+
+To disable the importmagic, set the =python-enable-importmagic= in the python
+layer config section:
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers
+    '((python :variables python-enable-importmagic nil)))
+#+END_SRC
 
 #+BEGIN_SRC sh
   pip install importmagic epc

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -88,6 +88,9 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
 (defvar python-sort-imports-on-save nil
   "If non-nil, automatically sort imports on save.")
 
+(defvar python-enable-importmagic t
+  "If non-nil, enable the importmagic feature.")
+
 (defvar spacemacs--python-pyenv-modes nil
   "List of major modes where to add pyenv support.")
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -34,7 +34,7 @@
     ggtags
     helm-cscope
     (helm-pydoc :requires helm)
-    importmagic
+    (importmagic :toggle python-enable-importmagic)
     live-py-mode
     (nose :location (recipe :fetcher github :repo "syl20bnr/nose.el")
           :toggle (memq 'nose (flatten-list (list python-test-runner))))


### PR DESCRIPTION
Spacemacs slow on opening a single *.py file.

I figured out the top performance killer for python layer are `importmagic` and `pyvenv`.
The `importmagic` will start a background server to process the requests from importmagic, it took ~0.5 seconds on my local; but acctually I rarely using the `importmagic` feature. 

This PR introduce a toggle flag `python-enable-importmagic` to give chance to disable this heavy feature.

PS: For `pyvenv` performance issue (leads Spacemacs slow when opening a *.py), I had an upstream PR, but it seems the project stop update for 3 years.
https://github.com/jorgenschaefer/pyvenv/pull/128