### PR TITLE
Fix the layers dependencies which required a lsp backend

### DIFF
--- a/layers/+lang/go/layers.el
+++ b/layers/+lang/go/layers.el
@@ -23,4 +23,4 @@
 
 (when (and (boundp 'go-backend)
            (eq go-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(dap)))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+lang/python/layers.el
+++ b/layers/+lang/python/layers.el
@@ -23,4 +23,4 @@
 
 (when (and (boundp 'python-backend)
            (eq python-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(dap)))
+  (configuration-layer/declare-layer-dependencies '(lsp)))

--- a/layers/+lang/ruby/layers.el
+++ b/layers/+lang/ruby/layers.el
@@ -23,7 +23,7 @@
 
 (when (and (boundp 'ruby-backend)
            (eq ruby-backend 'lsp))
-  (configuration-layer/declare-layer-dependencies '(dap)))
+  (configuration-layer/declare-layer-dependencies '(lsp)))
 
 (when (boundp 'ruby-prettier-on-save)
   (configuration-layer/declare-layer-dependencies '(prettier)))


### PR DESCRIPTION
Fix the layers dependency which required a lsp backend.
These layers configuration indicate user want lsp feature, so the layer should depends on the lsp.