### PR TITLE
* core/core-display-init.el: Bump graphic frame initilization to after-make-frame-functions

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -36,15 +36,17 @@
         ;; fallback to normal loading behavior only if in a GUI
         (t (display-graphic-p))))
 
-(define-advice server-create-window-system-frame
-    (:after (&rest _) spacemacs-init-display)
-  "After Emacs server creates a frame, run functions queued in
+(defun spacemacs/init-window-frame (frame)
+  "After Emacs creates a window frame, run functions queued in
 `SPACEMACS--AFTER-DISPLAY-SYSTEM-INIT-LIST' to do any setup that needs to have
 the display system initialized."
   (when (spacemacs--display-system-initialized-p)
-    (mapc #'funcall (reverse spacemacs--after-display-system-init-list))
-    (advice-remove 'server-create-window-system-frame
-                   #'server-create-window-system-frame@spacemacs-init-display)))
+    (with-demoted-errors "Spacemacs init display error: %S"
+      (with-selected-frame frame
+        (mapc #'funcall (reverse spacemacs--after-display-system-init-list))))
+    (remove-hook 'after-make-frame-functions #'spacemacs/init-window-frame)))
+
+(add-hook 'after-make-frame-functions #'spacemacs/init-window-frame)
 
 (defmacro spacemacs|do-after-display-system-init (&rest body)
   "If the display-system is initialized, run `BODY', otherwise,

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -25,7 +25,7 @@
   "List of functions to be run after the display system is initialized.")
 
 (defun spacemacs--display-system-initialized-p ()
-  "Dectect the display system initialized or not."
+  "Return non-nil if the display system has been initialized."
   (cond ((boundp 'ns-initialized) ns-initialized)
         ;; w32-initialized gets set too early, so
         ;; if we're on Windows, check the list of fonts
@@ -36,22 +36,27 @@
         ;; fallback to normal loading behavior only if in a GUI
         (t (display-graphic-p))))
 
-(defun spacemacs/init-window-frame (frame)
-  "After Emacs creates a window frame, run functions queued in
-`SPACEMACS--AFTER-DISPLAY-SYSTEM-INIT-LIST' to do any setup that needs to have
-the display system initialized."
+(defun spacemacs//init-window-frame (frame)
+  "After Emacs creates a window frame FRAME, run enqueued functions.
+
+Functions are called with FRAME selected.
+
+Queued functions are added to
+`spacemacs--after-display-system-init-list' and are run once,
+only after the display system has been initialized."
   (when (spacemacs--display-system-initialized-p)
     (dolist (f (reverse spacemacs--after-display-system-init-list))
-      (with-demoted-errors "Spacemacs init display error: %S"
+      (with-demoted-errors "spacemacs|do-after-display-system-init: %S"
         (with-selected-frame frame
           (funcall f))))
-    (remove-hook 'after-make-frame-functions #'spacemacs/init-window-frame)))
+    (remove-hook 'after-make-frame-functions #'spacemacs//init-window-frame)))
 
-(add-hook 'after-make-frame-functions #'spacemacs/init-window-frame)
+(add-hook 'after-make-frame-functions #'spacemacs//init-window-frame)
 
 (defmacro spacemacs|do-after-display-system-init (&rest body)
-  "If the display-system is initialized, run `BODY', otherwise,
-add it to a queue of actions to perform after the first graphical frame is
+  "If the display system is initialized, run BODY.
+
+Otherwise, enqueue it until after the first graphical frame is
 created."
   `(if (not (spacemacs--display-system-initialized-p))
        (push (lambda () ,@body) spacemacs--after-display-system-init-list)

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -41,9 +41,10 @@
 `SPACEMACS--AFTER-DISPLAY-SYSTEM-INIT-LIST' to do any setup that needs to have
 the display system initialized."
   (when (spacemacs--display-system-initialized-p)
-    (with-demoted-errors "Spacemacs init display error: %S"
-      (with-selected-frame frame
-        (mapc #'funcall (reverse spacemacs--after-display-system-init-list))))
+    (dolist (f (reverse spacemacs--after-display-system-init-list))
+      (with-demoted-errors "Spacemacs init display error: %S"
+        (with-selected-frame frame
+          (funcall f))))
     (remove-hook 'after-make-frame-functions #'spacemacs/init-window-frame)))
 
 (add-hook 'after-make-frame-functions #'spacemacs/init-window-frame)


### PR DESCRIPTION
Fix a bug that Spacemacs won't init the font for graphic frame (X11 frame), reproducing steps:
1. emacs -nw  # start Spacemacs on terminal
2. `M-x make-frame-on-display` and input `:0` (if you have :0 display, or input other display).

The graphic frame from Spacemacs won't apply the font from Spacemacs.

This issue caused by Spacemacs only hook the `server-create-window-system-frame`.

The patch will do works on `after-make-frame-functions`, works for both emacs daemon and previous `make-frame-on-display` command.
