### PR TITLE
* core-load-paths.el: New spacemacs-state-directory to store user state files

### DIFF
--- a/core/core-compilation.el
+++ b/core/core-compilation.el
@@ -28,7 +28,7 @@
 (defvar spacemacs--last-emacs-version ""
   "This variable is set during Emacs initialization to its version.")
 (defconst spacemacs--last-emacs-version-file
-  (expand-file-name (concat spacemacs-cache-directory "last-emacs-version"))
+  (expand-file-name (concat spacemacs-state-directory "last-emacs-version"))
   "File that sets `spacemacs--last-emacs-version' variable.")
 
 (defun spacemacs//remove-byte-compiled-files-in-dir (dir)

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -27,6 +27,8 @@
 ;;; Code:
 
 ;;;; PATH variables/constants
+(when (version<= emacs-version "28")
+  (eval-when-compile (require 'subr-x))) ; for the 'if-let*'
 
 ;; ~/.emacs.d
 (defvar spacemacs-start-directory
@@ -104,6 +106,16 @@
   (concat spacemacs-cache-directory "auto-save/")
   "Spacemacs auto-save directory.")
 
+(defconst spacemacs-state-directory
+  (file-name-as-directory
+   (if-let* ((spc-state (getenv "SPACEMACSSTATE")))
+       spc-state
+     (if-let* ((xdg-state (getenv "XDG_STATE_HOME"))
+               (spc-state (expand-file-name "spacemacs/" xdg-state))
+               ((file-exists-p spc-state)))
+         spc-state
+       spacemacs-cache-directory)))
+  "Spacemacs storage area for user-specific state files.")
 
 ;;;; Setup cache directories
 

--- a/core/core-release-management.el
+++ b/core/core-release-management.el
@@ -42,7 +42,7 @@
 (defvar spacemacs-version--check-timer nil
   "The current timer for new version check.")
 (defvar spacemacs-version--last-startup-check-file
-  (expand-file-name (concat spacemacs-cache-directory "last-version-check"))
+  (expand-file-name (concat spacemacs-state-directory "last-version-check"))
   "File where the last startup version check time is stored.")
 (defvar spacemacs-version--last-startup-check-time nil
   "Time of last version check.")
@@ -52,7 +52,7 @@
   "Last detected git revision of `spacemacs-start-directory' or nil.
 NOTE: This variable will be set asynchronously after Spacemacs startup.")
 (defvar spacemacs-revision--file
-  (expand-file-name (concat spacemacs-cache-directory "spacemacs-revision"))
+  (expand-file-name (concat spacemacs-state-directory "spacemacs-revision"))
   "File where the last revision of `spacemacs-start-directory' is saved.")
 (defvar spacemacs-revision--changed-hook nil
   "Hooks to be ran when Spacemacs detects revision change.")

--- a/doc/DOCUMENTATION.org
+++ b/doc/DOCUMENTATION.org
@@ -37,6 +37,7 @@
 - [[#dotfile-configuration][Dotfile Configuration]]
   - [[#dotfile-installation][Dotfile Installation]]
   - [[#alternative-dotdirectory][Alternative dotdirectory]]
+  - [[#alternative-state-directory][Alternative STATE directory]]
   - [[#synchronization-of-dotfile-changes][Synchronization of dotfile changes]]
   - [[#testing-the-dotfile][Testing the dotfile]]
   - [[#dotfile-contents][Dotfile Contents]]
@@ -553,6 +554,19 @@ change the location of this directory.
 *Note*: =~/.spacemacs= will always take priority over =~/.spacemacs.d/init.el=,
 so =~/.spacemacs= must not exist for =~/.spacemacs.d/init.el= to be used by
 Spacemacs.
+
+** Alternative STATE directory
+Spacemacs use the =spacemacs-state-directory= to store user-specific state files.
+It's decided by follow priority:
+- If the environment variable =SPACEMACSSTATE= exists, it always be truthed,
+  and user need ensure the directory is accessible by Spacemacs; otherwise
+
+- If the envrionment variable =XDG_STATE_HOME= exists, Spacemacs will try the
+=spacemacs/= under the STATE directory if the directory exists, for example
+=~/.local/state/spacemacs/=.
+
+- Spacemacs will use =spacemacs-cache-directory= for compatible with previous
+  installations.
 
 ** Synchronization of dotfile changes
 To apply the modifications made in =~/.spacemacs= press ~SPC f e R~. It will

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -228,7 +228,7 @@ or `nil' to only save and not visit the file."
       eval-expression-print-level nil)
 
 ;; cache files
-(setq tramp-persistency-file-name (concat spacemacs-cache-directory "tramp"))
+(setq tramp-persistency-file-name (concat spacemacs-state-directory "tramp"))
 
 ;; seems pointless to warn. There's always undo.
 (put 'narrow-to-region 'disabled nil)

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -80,7 +80,7 @@
   (use-package bookmark
     :defer t
     :init
-    (setq bookmark-default-file (concat spacemacs-cache-directory "bookmarks")
+    (setq bookmark-default-file (concat spacemacs-state-directory "bookmarks")
           ;; autosave each change
           bookmark-save-flag 1)
     (spacemacs/set-leader-keys "fb" 'bookmark-jump)))
@@ -390,7 +390,7 @@
     (when (and (boundp 'recentf-auto-save-timer)
                (timerp recentf-auto-save-timer))
       (cancel-timer recentf-auto-save-timer))
-    (setq recentf-save-file (concat spacemacs-cache-directory "recentf")
+    (setq recentf-save-file (concat spacemacs-state-directory "recentf")
           recentf-max-saved-items 1000
           recentf-auto-cleanup 'never
           recentf-auto-save-timer (run-with-idle-timer 600 t
@@ -407,7 +407,7 @@
   (use-package savehist
     :init
     ;; Minibuffer history
-    (setq savehist-file (concat spacemacs-cache-directory "savehist")
+    (setq savehist-file (concat spacemacs-state-directory "savehist")
           enable-recursive-minibuffers t ; Allow commands in minibuffers
           history-length 1000
           savehist-additional-variables '(search-ring
@@ -421,7 +421,7 @@
   (use-package saveplace
     :init
     ;; Save point position between sessions
-    (setq save-place-file (concat spacemacs-cache-directory "places"))
+    (setq save-place-file (concat spacemacs-state-directory "places"))
     (save-place-mode)))
 
 (defun spacemacs-defaults/init-subword ()

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -653,7 +653,7 @@ See variable `undo-fu-session-directory'." dir))
   (use-package persistent-scratch
     :defer t
     :init
-    (setq persistent-scratch-save-file (concat spacemacs-cache-directory ".persistent-scratch")
+    (setq persistent-scratch-save-file (concat spacemacs-state-directory ".persistent-scratch")
           persistent-scratch-autosave-interval 60
           persistent-scratch-what-to-save '(point narrowing))
     (add-hook 'spacemacs-scratch-mode-hook 'persistent-scratch-mode)

--- a/layers/+spacemacs/spacemacs-project/packages.el
+++ b/layers/+spacemacs/spacemacs-project/packages.el
@@ -61,7 +61,7 @@
     (setq projectile-sort-order 'recentf
           projectile-cache-file (concat spacemacs-cache-directory
                                         "projectile.cache")
-          projectile-known-projects-file (concat spacemacs-statedirectory
+          projectile-known-projects-file (concat spacemacs-state-directory
                                                  "projectile-bookmarks.eld"))
     (spacemacs/set-leader-keys
       ;; File path

--- a/layers/+spacemacs/spacemacs-project/packages.el
+++ b/layers/+spacemacs/spacemacs-project/packages.el
@@ -61,7 +61,7 @@
     (setq projectile-sort-order 'recentf
           projectile-cache-file (concat spacemacs-cache-directory
                                         "projectile.cache")
-          projectile-known-projects-file (concat spacemacs-cache-directory
+          projectile-known-projects-file (concat spacemacs-statedirectory
                                                  "projectile-bookmarks.eld"))
     (spacemacs/set-leader-keys
       ;; File path

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -45,9 +45,9 @@
   (use-package desktop
     :defer t
     :init
-    (setq desktop-dirname spacemacs-cache-directory)
+    (setq desktop-dirname spacemacs-state-directory)
     :config
-    (add-to-list 'desktop-path spacemacs-cache-directory)))
+    (add-to-list 'desktop-path spacemacs-state-directory)))
 
 (defun spacemacs-visual/init-display-fill-column-indicator ()
   (spacemacs|add-toggle display-fill-column-indicator

--- a/layers/+tools/bm/packages.el
+++ b/layers/+tools/bm/packages.el
@@ -37,7 +37,7 @@
     (setq-default bm-buffer-persistence t)
     ;; where to store persistent files
     (setq bm-repository-file (format "%sbm-repository"
-                                     spacemacs-cache-directory))
+                                     spacemacs-state-directory))
     (spacemacs|define-transient-state bm
       :title "BM Transient State"
       :doc "


### PR DESCRIPTION
To fix #7818, a new variable `spacemacs-state-directory` is introduced. 

NOTE:
It's part of work on `XDG_*` directories supports. #3589.
It's pre-work for #16706.