### PR TITLE
[spacemacs-defaults] Tweak savehist configuration

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -196,6 +196,13 @@ or `nil' to only save and not visit the file."
 ;; Session
 ;; ---------------------------------------------------------------------------
 
+(spacemacs|defc spacemacs-savehist-autosave-idle-interval 60
+  "Idle interval between autosaves of minibuffer histories and other
+variables (see `savehist-mode' and `savehist-additional-variables')."
+  'integer)
+
+(defvar spacemacs--savehist-idle-timer nil)
+
 ;; scratch buffer empty
 (setq initial-scratch-message dotspacemacs-initial-scratch-message)
 ;; don't create backup~ files

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -413,9 +413,30 @@
           savehist-additional-variables '(search-ring
                                           regexp-search-ring
                                           extended-command-history
-                                          kill-ring)
-          savehist-autosave-interval 60)
-    (savehist-mode t)))
+                                          kill-ring
+                                          kmacro-ring
+                                          log-edit-comment-ring)
+          ;; We use an idle timer instead, as saving can cause
+          ;; noticable delays with large histories.
+          savehist-autosave-interval nil)
+    (savehist-mode t)
+    (define-advice savehist-save
+        (:around (orig &rest args) spacemacs//kill-ring-no-properties)
+      "Text properties can blow up the savehist file and lead to
+excessive pauses when saving."
+      (if (memq 'kill-ring savehist-additional-variables)
+          (let ((kill-ring (mapcar #'substring-no-properties
+                                   (cl-remove-if-not #'stringp kill-ring))))
+            (apply orig args))
+        (apply orig args)))
+    (when (and (boundp 'spacemacs--savehist-idle-timer)
+               (timerp spacemacs--savehist-idle-timer))
+      (cancel-timer spacemacs--savehist-idle-timer))
+    (setq spacemacs--savehist-idle-timer
+          (run-with-idle-timer
+           spacemacs-savehist-autosave-idle-interval
+           spacemacs-savehist-autosave-idle-interval
+           #'savehist-autosave))))
 
 (defun spacemacs-defaults/init-saveplace ()
   (use-package saveplace


### PR DESCRIPTION
1. Use an idle timer instead of a strict periodic autosave interval. Saving large histories can cause noticable delays, and the default `history-length` set by Spacemacs is relatively large (1000).

2. Save `kill-ring` without text properties, as they are known to cause significant performance problems and huge history files in some cases, and persisting them in the kill-ring usually brings little benefit. This should fix #1300, fix #1369 and fix #9409 again.

3. Add `kmacro-ring` and `log-edit-comment-ring` as additional variables. They are useful and usually not very large. BTW, `search-ring`, `regexp-search-ring` and `extended-command-history` are redundant here as long as long as `savehist-save-minibuffer-history` is non-nil (the default). I decided to leave them there for now to avoid any breaking changes for users that customized that option, though I guess it could be okay to change this.