### PR TITLE
Correct mistyped ranger option in doc

### DIFF
--- a/layers/+tools/ranger/README.org
+++ b/layers/+tools/ranger/README.org
@@ -122,7 +122,7 @@ ignore certain files when moving over them you can customize the following to
 your liking:
 
 #+BEGIN_SRC elisp
-  (setq ranger-ignored-extensions '("mkv" "iso" "mp4"))
+  (setq ranger-excluded-extensions '("mkv" "iso" "mp4" "bin" "exe" "msi"))
 #+END_SRC
 
 To set the max files size (in MB), set the following parameter:


### PR DESCRIPTION
Also bring up the example to the default value in ranger.el: https://github.com/punassuming/ranger.el/blob/2498519cb21dcd5791d240607a72a204d1761668/ranger.el#L162