### PR TITLE
[shell] Fix spacemacs/projectile-shell on non-project dir with vterm/multi-vterm

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -40,7 +40,7 @@ view; to pop-up a full width buffer, use
   (interactive)
   (pcase shell-default-shell
     ((or 'multi-term 'multi-vterm)
-     (projectile-with-default-dir (projectile-project-root)
+     (projectile-with-default-dir (projectile-acquire-root)
        (call-interactively shell-default-shell)))
     ('eat (call-interactively #'eat-project))
     (_ (call-interactively (or (intern-soft (format "projectile-run-%s" shell-default-shell))


### PR DESCRIPTION
Fix a bug that press `SPC p $` in a non-project dir with vterm/multi-vterm enabled, reproduce steps:
1. Start Spacemacs and find a file `/tmp/a.el` which is not a in project file
2. press `SPC p $` will get error `Wrong type argument: stringp, nil`.

This change will follow the `spacemacs/projectile-shell-pop` to use the `projectile-acquire-root` function.
https://github.com/syl20bnr/spacemacs/blob/c5fc206d3d70143453936d98e4426d84ee4c5bcf/layers/%2Btools/shell/funcs.el#L31-L32