### PR TITLE
Remove temp files /tmp/fineDiff* for kill-emacs without quit ediff

### DIFF
--- a/core/core-versions.el
+++ b/core/core-versions.el
@@ -27,4 +27,15 @@
 (defconst spacemacs-version          "0.999.0" "Spacemacs version.")
 (defconst spacemacs-emacs-min-version   "28.2" "Minimal version of Emacs.")
 
+(defmacro spacemacs|eval-until-emacs-min-version (version msg &rest body)
+  "Evaluate the BODY if `spacemacs-emacs-min-version' < VERSION, otherwise
+warn the MSG."
+  (declare (indent 1))
+  `(if (version< spacemacs-emacs-min-version ,version)
+       (progn ,@body)
+     (apply 'warn
+            (if ,msg '("%s" ,msg)
+              '("Minimum emacs version %s is newer than supported version %s"
+                ,version spacemacs-emacs-min-version)))))
+
 (provide 'core-versions)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -951,6 +951,17 @@ variable."
   (when (fboundp 'outline-show-all)
     (outline-show-all)))
 
+(spacemacs|eval-until-emacs-min-version "31.0.50"
+  "Use builtin `ediff--delete-temp-files-on-kill-emacs' first"
+
+  (defun spacemacs//ediff-delete-temp-files ()
+    "Delete the temp-files associated with the ediff buffers."
+    (let ((inhibit-interaction t))
+      (dolist (b ediff-session-registry)
+        (ignore-errors
+          (with-current-buffer b
+            (ediff-delete-temp-files)))))))
+
 (defun spacemacs/new-empty-buffer (&optional split)
   "Create a new buffer called: \"untitled\".
 

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -211,7 +211,9 @@
     ;; show org ediffs unfolded
     (add-hook 'ediff-prepare-buffer-hook 'spacemacs//ediff-buffer-outline-show-all)
     ;; restore window layout when done
-    (add-hook 'ediff-quit-hook #'winner-undo)))
+    (add-hook 'ediff-quit-hook #'winner-undo)
+    (when (fboundp 'spacemacs//ediff-delete-temp-files)
+      (add-hook 'kill-emacs-hook #'spacemacs//ediff-delete-temp-files))))
 
 (defun spacemacs-defaults/init-eldoc ()
   (use-package eldoc


### PR DESCRIPTION
Fix a bug that the temp files `/tmp/fineDiff*` were left after Spacemacs ediff templates.

Reproducing steps: Pressing `SPC f e D` and press `n` to locate first diff line, then press `SPC f q` to quick Spacemacs directly. 

Then the `/tmp/fineDiff*` files left. 