### PR TITLE
* layers/+spacemacs/spacemacs-defaults/funcs.el: Enhance copying file path for dired-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -861,9 +861,15 @@ ones created by `magit' and `dired'."
     (user-error "Current buffer is not visiting a file or directory")))
 
 (defun spacemacs/copy-file-path ()
-  "Copy and show the file path of the current buffer."
+  "Copy and show the file path of the current buffer. If the buffer is a
+dired buffer, the result will be the file path under cursor, otherwise
+the result is directory path."
   (interactive)
-  (if-let* ((file-path (spacemacs--file-path)))
+  (if-let* ((file-path (or (spacemacs--file-path)
+                           (and (derived-mode-p 'dired-mode)
+                                (condition-case nil
+                                    (dired-get-file-for-visit)
+                                  (error default-directory))))))
       (progn
         (kill-new file-path)
         (message "%s" file-path))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -861,15 +861,15 @@ ones created by `magit' and `dired'."
     (user-error "Current buffer is not visiting a file or directory")))
 
 (defun spacemacs/copy-file-path ()
-  "Copy and show the file path of the current buffer. If the buffer is a
-dired buffer, the result will be the file path under cursor, otherwise
-the result is directory path."
+  "Copy and show the file path of the current buffer.
+
+In Dired, the result will be the file path under cursor if any,
+otherwise the listed directory's path."
   (interactive)
   (if-let* ((file-path (or (spacemacs--file-path)
                            (and (derived-mode-p 'dired-mode)
-                                (condition-case nil
-                                    (dired-get-file-for-visit)
-                                  (error default-directory))))))
+                                (dired-get-filename nil t))
+                           (spacemacs--directory-path))))
       (progn
         (kill-new file-path)
         (message "%s" file-path))


### PR DESCRIPTION
Currently pressing `SPC f y y` on a `dired-mode` buffer will get an error.

This PR enhances the users experience by support copying file path on a `dired-mode` buffer (`SPC f y y` in a dired buffer).