### PR TITLE
Add evil-fringe-mark to +spacemacs/spacemacs-evil

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -30,6 +30,7 @@
         (evil-escape :location (recipe :fetcher github
                                        :repo "smile13241324/evil-escape"))
         evil-exchange
+        evil-fringe-mark
         evil-goggles
         evil-iedit-state
         evil-indent-plus
@@ -154,6 +155,12 @@
                   'evil-exchange-cancel)
       (define-key evil-visual-state-map evil-exchange-cancel-key
                   'evil-exchange-cancel))))
+
+(defun spacemacs-evil/init-evil-fringe-mark ()
+  (use-package evil-fringe-mark
+    :config
+    (setq-default evil-fringe-mark-show-special t)
+    (global-evil-fringe-mark-mode)))
 
 (defun spacemacs-evil/init-evil-goggles ()
   (use-package evil-goggles


### PR DESCRIPTION
This PR adds the [evil-fringe-mark](https://github.com/Andrew-William-Smith/evil-fringe-mark) package.

I configured it to display both user and special marks globally.

Thanks
