### PR TITLE
* layers/+completion/helm/packages.el: enable display-fill-column-indicator-mode for helm-ls-git-commit-mode

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -335,6 +335,7 @@
             (delete '("/git-rebase-todo$" . helm-ls-git-rebase-todo-mode)
                     auto-mode-alist)))
     :config
+    (add-hook 'helm-ls-git-commit-mode-hook 'display-fill-column-indicator-mode)
     (when (configuration-layer/package-usedp 'magit)
       ;; Undo the forced action of adding helm-ls-git-rebase-todo-mode to
       ;; auto-mode-alist by helm-ls-git.


### PR DESCRIPTION
Enable the `display-fill-column-indicator-mode` for `helm-ls-git-commit-mode`, similar to the magit git commit behavior.
Reproduce steps:
1. Enable the `helm` layer 
     ```dotspacemacs-configuration-layers '(helm ...)```
3. start Spacemacs in daemon mode `emacs --daemon`
4. try a git commit in a git repo with emacsclient:  `EDITOR="emacsclient -t" git commit -a`

Similar behavior is in the magit layer: 
https://github.com/syl20bnr/spacemacs/blob/0898770b56d249e5099a78ac06bc5efb6f21f95c/layers/%2Bsource-control/git/packages.el#L203