### PR TITLE
* layers/+spacemacs/spacemacs-defaults/packages.el: Avoid loading outline-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -940,6 +940,11 @@ variable."
   (ediff-files (dotspacemacs/location)
                (concat dotspacemacs-template-directory ".spacemacs.template")))
 
+(defun spacemacs/ediff-buffer-outline-show-all ()
+  "Try `outline-show-all' for ediff buffers."
+  (when (fboundp 'outline-show-all)
+    (outline-show-all)))
+
 (defun spacemacs/new-empty-buffer (&optional split)
   "Create a new buffer called: \"untitled\".
 

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -940,7 +940,7 @@ variable."
   (ediff-files (dotspacemacs/location)
                (concat dotspacemacs-template-directory ".spacemacs.template")))
 
-(defun spacemacs/ediff-buffer-outline-show-all ()
+(defun spacemacs//ediff-buffer-outline-show-all ()
   "Try `outline-show-all' for ediff buffers."
   (when (fboundp 'outline-show-all)
     (outline-show-all)))

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -209,8 +209,7 @@
      ediff-merge-split-window-function 'split-window-horizontally)
     :config
     ;; show org ediffs unfolded
-    (require 'outline)
-    (add-hook 'ediff-prepare-buffer-hook #'outline-show-all)
+    (add-hook 'ediff-prepare-buffer-hook 'spacemacs/ediff-buffer-outline-show-all)
     ;; restore window layout when done
     (add-hook 'ediff-quit-hook #'winner-undo)))
 

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -209,7 +209,7 @@
      ediff-merge-split-window-function 'split-window-horizontally)
     :config
     ;; show org ediffs unfolded
-    (add-hook 'ediff-prepare-buffer-hook 'spacemacs/ediff-buffer-outline-show-all)
+    (add-hook 'ediff-prepare-buffer-hook 'spacemacs//ediff-buffer-outline-show-all)
     ;; restore window layout when done
     (add-hook 'ediff-quit-hook #'winner-undo)))
 


### PR DESCRIPTION
Hi @fnussbaum I noticed two lines 
https://github.com/syl20bnr/spacemacs/blob/2d43f15e0c06fbd325fd802d428fe2244f1ed6da/layers/%2Bspacemacs/spacemacs-defaults/packages.el#L212-L213

can be improved to no-requiring the `outline` package for better performance. 

Please help review the changes, thank you!