### PR TITLE
* core/core-display-init.el: Detect graphic init with pgtk-initialized

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -33,6 +33,7 @@
         ;; is initialized)
         ((boundp 'w32-initialized) (font-family-list))
         ((boundp 'x-initialized) x-initialized)
+        ((boundp 'pgtk-initialized) pgtk-initialized)
         ;; fallback to normal loading behavior only if in a GUI
         (t (display-graphic-p))))
 


### PR DESCRIPTION
Fix #16773 