### PR TITLE
* core/core-dotspacemacs.el: Select the fallback dotspacemacs as the doc described

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -66,7 +66,7 @@ their configuration.")
       (let ((fallback-init "~/.spacemacs.d/init.el"))
         (if (file-regular-p fallback-init)
             fallback-init
-          spacemacs-init))))
+          "~/.spacemacs"))))
   "Filepath to Spacemacs configuration file (defaults to ~/.spacemacs).
 - If the `dotspacemacs-directory' exists and it contains \"init.el\" file,
   use that value.


### PR DESCRIPTION
Fix  #16780.