### PR TITLE
Fix PowerShell cmdlet in documentation (Test-Path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,15 +361,15 @@ If you need to follow that path we recommend to at least use a package manager l
     or in PowerShell:
 
     ```powershell
-    if( TestPath -Path $HOME/.emacs.d )
+    if( Test-Path -Path $HOME/.emacs.d )
     {
         Rename-Item $HOME/.emacs.d $HOME/.emacs.d.bak
     }
-    if( TestPath -Path $HOME/.emacs.el )
+    if( Test-Path -Path $HOME/.emacs.el )
     {
         Rename-Item $HOME/.emacs.el $HOME/.emacs.el.bak
     }
-    if( TestPath -Path $HOME/.emacs )
+    if( Test-Path -Path $HOME/.emacs )
     {
         Rename-Item $HOME/.emacs $HOME/.emacs.bak
     }


### PR DESCRIPTION
```powershell
PS >  gcm test-path

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Cmdlet          Test-Path                                          7.0.0.0    Microsoft.PowerShell.Management


PS >  gcm testpath
Get-Command: The term 'testpath' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```