### PR TITLE
* core/core-display-init.el: Fix detection graphic init on Windows

### DIFF
--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -24,13 +24,7 @@
 (defvar spacemacs--after-display-system-init-list '()
   "List of functions to be run after the display system is initialized.")
 
-(defun spacemacs--display-system-initialized-p (&optional frame)
-  "Return non-nil if the display system has been initialized."
-  (cond ((boundp 'ns-initialized) ns-initialized)
-        ((boundp 'x-initialized) x-initialized)
-        ((boundp 'pgtk-initialized) pgtk-initialized)
-        ;; fallback to normal loading behavior only if in a GUI
-        (t (display-graphic-p frame))))
+(defvar spacemacs--display-system-initialized-p nil)
 
 (defun spacemacs//init-window-frame (frame)
   "After Emacs creates a window frame FRAME, run enqueued functions.
@@ -40,7 +34,8 @@ Functions are called with FRAME selected.
 Queued functions are added to
 `spacemacs--after-display-system-init-list' and are run once,
 only after the display system has been initialized."
-  (when (spacemacs--display-system-initialized-p frame)
+  (when (display-graphic-p frame)
+    (setq spacemacs--display-system-initialized-p t)
     (dolist (f (reverse spacemacs--after-display-system-init-list))
       (with-demoted-errors "spacemacs|do-after-display-system-init: %S"
         (with-selected-frame frame
@@ -53,9 +48,12 @@ only after the display system has been initialized."
   "Call FUNC with no arguments once the display system is initialized.
 
 See `spacemacs|do-after-display-system-init'."
-  (if (not (spacemacs--display-system-initialized-p))
-      (push func spacemacs--after-display-system-init-list)
-    (funcall func)))
+  (if spacemacs--display-system-initialized-p
+      (funcall func)
+    (push func spacemacs--after-display-system-init-list)
+    ;; `spacemacs--display-system-initialized-p' may be nil even if the initial
+    ;; frame is graphical.
+    (spacemacs//init-window-frame (selected-frame))))
 
 (defmacro spacemacs|do-after-display-system-init (&rest body)
   "If the display system is initialized, run BODY.

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -24,18 +24,13 @@
 (defvar spacemacs--after-display-system-init-list '()
   "List of functions to be run after the display system is initialized.")
 
-(defun spacemacs--display-system-initialized-p ()
+(defun spacemacs--display-system-initialized-p (&optional frame)
   "Return non-nil if the display system has been initialized."
   (cond ((boundp 'ns-initialized) ns-initialized)
-        ;; w32-initialized gets set too early, so
-        ;; if we're on Windows, check the list of fonts
-        ;; instead (this is nil until the graphics system
-        ;; is initialized)
-        ((boundp 'w32-initialized) (font-family-list))
         ((boundp 'x-initialized) x-initialized)
         ((boundp 'pgtk-initialized) pgtk-initialized)
         ;; fallback to normal loading behavior only if in a GUI
-        (t (display-graphic-p))))
+        (t (display-graphic-p frame))))
 
 (defun spacemacs//init-window-frame (frame)
   "After Emacs creates a window frame FRAME, run enqueued functions.
@@ -45,7 +40,7 @@ Functions are called with FRAME selected.
 Queued functions are added to
 `spacemacs--after-display-system-init-list' and are run once,
 only after the display system has been initialized."
-  (when (spacemacs--display-system-initialized-p)
+  (when (spacemacs--display-system-initialized-p frame)
     (dolist (f (reverse spacemacs--after-display-system-init-list))
       (with-demoted-errors "spacemacs|do-after-display-system-init: %S"
         (with-selected-frame frame

--- a/core/core-display-init.el
+++ b/core/core-display-init.el
@@ -49,13 +49,21 @@ only after the display system has been initialized."
 
 (add-hook 'after-make-frame-functions #'spacemacs//init-window-frame)
 
+(defun spacemacs--call-after-display-system-init (func)
+  "Call FUNC with no arguments once the display system is initialized.
+
+See `spacemacs|do-after-display-system-init'."
+  (if (not (spacemacs--display-system-initialized-p))
+      (push func spacemacs--after-display-system-init-list)
+    (funcall func)))
+
 (defmacro spacemacs|do-after-display-system-init (&rest body)
   "If the display system is initialized, run BODY.
 
 Otherwise, enqueue it until after the first graphical frame is
-created."
-  `(if (not (spacemacs--display-system-initialized-p))
-       (push (lambda () ,@body) spacemacs--after-display-system-init-list)
-     ,@body))
+created.
+
+BODY is evaluated with a graphical frame selected."
+  `(spacemacs--call-after-display-system-init (lambda () ,@body)))
 
 (provide 'core-display-init)


### PR DESCRIPTION
Fix the graphic initialization detection on the MS-Window, the font-family-list will works on a selected frame.