### PR TITLE
[defaults] Improve `SPC w m`, persist `quit-restore` parameter

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -190,7 +190,14 @@ or `nil' to only save and not visit the file."
     ;; `buffer-predicate' entry doesn't exist, create it
     (push '(buffer-predicate . spacemacs/useful-buffer-p) default-frame-alist)))
 
-(add-to-list 'window-persistent-parameters '(spacemacs-max-state . writable))
+;; It could be considered to persist more (or even all) of the window parameters
+;; here, see also https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23858.
+(setq window-persistent-parameters
+      (cl-union window-persistent-parameters
+                '((spacemacs-max-state . t)
+                  (spacemacs-max-state-writable . writable)
+                  (quit-restore . t))
+                :test 'equal))
 
 ;; ---------------------------------------------------------------------------
 ;; Session

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -219,24 +219,36 @@ persistent which-key) are kept or minimized too."
          (window-already-maximal
           (eq max-target-window (selected-window))))
     (cond ((and window-already-maximal
-                (window-parameter nil 'spacemacs-max-state))
+                (window-parameter nil 'spacemacs-max-state-writable))
            ;; Restore the previously deleted windows, keeping the state of the
            ;; selected window.
            (let ((selected-win-state (window-state-get (selected-window))))
              (window-state-put
-              (window-parameter nil 'spacemacs-max-state) (selected-window))
+              ;; Prefer non-writable window states during a session,
+              ;; because they persist more information. For example, they contain
+              ;; markers and references to buffers instead of buffer positions
+              ;; and buffer names only.
+              (or (window-parameter nil 'spacemacs-max-state)
+                  (window-parameter nil 'spacemacs-max-state-writable))
+              (selected-window))
              (window-state-put selected-win-state (selected-window))
-             (set-window-parameter nil 'spacemacs-max-state nil)))
+             (set-window-parameter nil 'spacemacs-max-state nil)
+             (set-window-parameter nil 'spacemacs-max-state-writable nil)))
           ((and (not window-already-maximal)
                 (window-parameter nil 'window-side))
            ;; Raise the same error as `delete-other-windows'
            ;; (with `ignore-window-parameters' nil).
            (error "Cannot make side window the only window"))
           ((not window-already-maximal)
-           ;; Store the current state as a window parameter of the selected window
-           ;; and delete other windows.
-           (walk-windows (lambda (win) (set-window-parameter win 'spacemacs-max-state nil)))
-           (set-window-parameter nil 'spacemacs-max-state (window-state-get max-target-window t))
+           ;; Clean up ...
+           (walk-windows
+            (lambda (win)
+              (set-window-parameter win 'spacemacs-max-state nil)
+              (set-window-parameter win 'spacemacs-max-state-writable nil)))
+           ;; ... and store the current state as a window parameter of the selected window
+           ;; before deleting other windows.
+           (set-window-parameter nil 'spacemacs-max-state (window-state-get max-target-window))
+           (set-window-parameter nil 'spacemacs-max-state-writable (window-state-get max-target-window t))
            (if dotspacemacs-maximize-window-keep-side-windows
                (spacemacs//delete-other-non-side-windows)
              (let ((ignore-window-parameters t))


### PR DESCRIPTION
This is a follow-up to #16533, and in particular addresses the caveat mentioned there.

The built-in tab-bar.el similarly keeps a writable window state as well as a window configuration for each tab.

Making the `quit-restore` window parameter persistent allows quitting help windows correctly after maximizing/minimizing or switching tab-bar tabs, for example (without using popwin).