### PR TITLE
[git] Do not mark magit buffers as useless by default

### DIFF
--- a/layers/+source-control/git/config.el
+++ b/layers/+source-control/git/config.el
@@ -23,6 +23,10 @@
 
 ;; Variables
 
+(defvar git-magit-buffers-useless nil
+  "When non-nil, magit buffers are marked as useless,
+see `spacemacs-useless-buffers-regexp'.")
+
 (defvar git-enable-magit-delta-plugin nil
   "If non nil, enable `magit-delta' plugin.")
 

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -147,8 +147,9 @@
     :defer (spacemacs/defer)
     :custom (magit-bury-buffer-function #'magit-restore-window-configuration)
     :init
-    (cl-pushnew "magit: .*" spacemacs-useless-buffers-regexp :test 'equal)
-    (cl-pushnew "magit-.*: .*"  spacemacs-useless-buffers-regexp :test 'equal)
+    (when git-magit-buffers-useless
+      (cl-pushnew "magit: .*" spacemacs-useless-buffers-regexp :test 'equal)
+      (cl-pushnew "magit-.*: .*"  spacemacs-useless-buffers-regexp :test 'equal))
     (spacemacs|require-when-dumping 'magit)
     (setq magit-revision-show-gravatars '("^Author:     " . "^Commit:     "))
     ;; On Windows, we must use Git GUI to enter username and password


### PR DESCRIPTION
As @syl20bnr mentioned [on the Gitter chat](https://matrix.to/#/!UzGfiCcOWQJyiWhCpN:gitter.im/$3aZbdi9hXA02agjoPALu1ucqxEJfQoL5sC0UqHlJWOs?via=gitter.im&via=matrix.org&via=envs.net), this is a better default.