### PR TITLE
`alternate-buffer`: Add option whether to restrict to useful buffers

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -331,7 +331,9 @@ only switches between the current layout's buffers."
   (interactive)
   (cl-destructuring-bind (buf start pos)
       (let ((my-buffer (window-buffer window))
-            (usefulp (or (symbol-function 'spacemacs/useful-buffer-p) #'always))
+            (usefulp (if (bound-and-true-p spacemacs-useful-buffers-restrict-spc-tab)
+                         (symbol-function 'spacemacs/useful-buffer-p)
+                       #'always))
             (predicate #'always)
             (default (list (other-buffer) nil nil)))
 

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -38,10 +38,20 @@
 
 ;; Regexp for useful and useless buffers for smarter buffer switching
 (defvar spacemacs-useless-buffers-regexp '()
-  "Regexp used to determine if a buffer is not useful.")
+  "Regexp used to determine if a buffer is not useful.
+
+Such useless buffers are skipped by `previous-buffer',
+`next-buffer', and, optionally, by `spacemacs/alternate-buffer'
+(see `spacemacs-useful-buffers-restrict-spc-tab').")
 (defvar spacemacs-useful-buffers-regexp '()
   "Regexp used to define buffers that are useful despite matching
 `spacemacs-useless-buffers-regexp'.")
+
+(spacemacs|defc spacemacs-useful-buffers-restrict-spc-tab t
+  "When non-nil, \\[spacemacs/alternate-buffer] does not switch to
+useless buffers as defined by `spacemacs-useless-buffers-regexp'
+and `spacemacs-useful-buffers-regexp'."
+  'boolean)
 
 ;; no beep pleeeeeease ! (and no visual blinking too please)
 (setq ring-bell-function 'ignore


### PR DESCRIPTION
The behaviour where two consecutive presses of SPC TAB always switch back to the same buffer may be preferable, hence this option.

(It might also make sense to combine `spacemacs-layouts-restrict-spc-tab` and `spacemacs-useful-buffers-restrict-spc-tab` into one option whether to obey the frame's buffer predicate, but this would not be backwards-compatible, and clearly not as flexible.)
