### PR TITLE
* layers/+lang/python/config.el: Default disable the importmagic

### DIFF
--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -88,7 +88,7 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
 (defvar python-sort-imports-on-save nil
   "If non-nil, automatically sort imports on save.")
 
-(defvar python-enable-importmagic t
+(defvar python-enable-importmagic nil
   "If non-nil, enable the importmagic feature.")
 
 (defvar spacemacs--python-pyenv-modes nil


### PR DESCRIPTION
Default disable the `importmagic` for performance concern. 

The [importmagic](https://github.com/anachronic/importmagic.el) is lack of maintenance (last commit is 3 years ago, does NOT support tree-sitter), and slow on startup.

So this PR will turn off  `importmagic` feature default. 

@smile13241324 please help consider this proposal. Thank you. 