### PR TITLE
[shell] Fix shell-pop renaming the wrong buffer for eat

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -120,6 +120,17 @@ SHELL is the SHELL function to use (i.e. when FUNC represents a terminal)."
        (shell-pop index)
        (spacemacs/resize-shell-to-desired-width))))
 
+(defun spacemacs//eat-for-shell-pop (&rest args)
+  "Like `eat', but make the new shell buffer current.
+
+Used to satisfy `shell-pop's assumptions."
+  ;; `eat' unexpectedly selects the window displaying the returned buffer, but
+  ;; doesn't actually leave the buffer current when it returns.  The fix is
+  ;; suggested upstream at https://codeberg.org/akib/emacs-eat/pulls/193, but
+  ;; meanwhile we work around it in Spacemacs.  We can replace this function at
+  ;; its callsite with just `eat' if/when the above is merged.
+  (set-buffer (apply #'eat args)))
+
 (defun spacemacs//toggle-shell-auto-completion-based-on-path ()
   "Deactivates automatic completion on remote paths.
 Retrieving completions for Eshell blocks Emacs. Over remote

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -345,7 +345,7 @@
     :defer t
     :commands (eat eat-other-window eat-project eat-project-other-window)
     :init
-    (make-shell-pop-command "eat" eat)
+    (make-shell-pop-command "eat" spacemacs//eat-for-shell-pop)
     (spacemacs/set-leader-keys "atsa" 'spacemacs/shell-pop-eat)
     (spacemacs/register-repl 'eat 'eat)
     :config


### PR DESCRIPTION
Fix #16794.