### PR TITLE
* core/core-themes-support.el: Remove unnecessary "eval"

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -450,8 +450,8 @@ THEME."
     (enable-theme theme-name)
     (setq spacemacs--cur-theme theme-name)
     (unless (display-graphic-p)
-      (eval `(spacemacs|do-after-display-system-init
-              (load-theme ',theme-name t))))))
+      (spacemacs|do-after-display-system-init
+       (load-theme theme-name t)))))
 
 (defun spacemacs/cycle-spacemacs-theme (&optional backward)
   "Cycle through themes defined in `dotspacemacs-themes'.


### PR DESCRIPTION
As discussed in the in the https://github.com/syl20bnr/spacemacs/pull/16783#discussion_r1915497617,
The `eval` is unnecessary, just remove it.

[sunlin7](https://github.com/syl20bnr/spacemacs/pull/16783#discussion_r1915497617)
> I found the eval statement in spacemacs//load-theme-internal was first introduced in this commit:
https://github.com/syl20bnr/spacemacs/commit/c913ec89f86f21b6473b8dbd2f1f4d82d30f6e36
The eval is necessary?

@[bcc32](https://github.com/syl20bnr/spacemacs/pull/16783#discussion_r1915504263)
> I think it's not necessary now that we're using lexical-binding in that file and also for the macro definition.

