### PR TITLE
* core/core-jump.el: Wrap the xref-go-back with spacemacs/warn-until-emacs-min-version

### DIFF
--- a/core/core-jump.el
+++ b/core/core-jump.el
@@ -105,9 +105,9 @@ They are in order: `spacemacs-jump-handlers',
 (with-eval-after-load 'evil
   (evil-set-command-property 'spacemacs/jump-to-definition :jump t))
 
-(unless (fboundp 'xref-go-back)
-  (defalias 'xref-pop-marker-stack 'xref-go-back))
-(when (version<= "29.1" spacemacs-emacs-min-version)
-  (message "Please remove the alias for `xref-go-back'"))
+(spacemacs|eval-until-emacs-min-version "29.1"
+  "The `xref-go-back' is a built-in function since Emacs 29.1."
+  (unless (fboundp 'xref-go-back)
+    (defalias 'xref-pop-marker-stack 'xref-go-back)))
 
 (provide 'core-jump)


### PR DESCRIPTION
Wrap the `xref-go-back` with `spacemacs/warn-until-emacs-min-version`, instead of the original bare comparison. 