### PR TITLE
[markdown] Add key bindings for edit code block

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -25,6 +25,7 @@
   '(
     company
     company-emoji
+    edit-indirect
     emoji-cheat-sheet-plus
     gh-md
     markdown-mode
@@ -62,6 +63,16 @@
 (defun markdown/post-init-smartparens ()
   (add-hook 'markdown-mode-hook #'spacemacs//activate-smartparens))
 
+(defun markdown/init-edit-indirect ()
+  (use-package edit-indirect
+    :commands (edit-indirect-abort edit-indirect-commit)
+    :config
+    (spacemacs/set-leader-keys-for-minor-mode 'edit-indirect--overlay
+      dotspacemacs-major-mode-leader-key 'edit-indirect-commit
+      "c" 'edit-indirect-commit
+      "a" 'edit-indirect-abort
+      "k" 'org-edit-src-abort)))
+
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode
     :mode
@@ -88,6 +99,7 @@
     (dolist (mode markdown--key-bindings-modes)
       (spacemacs/set-leader-keys-for-major-mode mode
         ;; rebind this so terminal users can use it
+        "'" 'markdown-edit-code-block
         "M-RET" 'markdown-insert-list-item
         ;; Movement
         "{"   'markdown-backward-paragraph

--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -71,7 +71,7 @@
       dotspacemacs-major-mode-leader-key 'edit-indirect-commit
       "c" 'edit-indirect-commit
       "a" 'edit-indirect-abort
-      "k" 'org-edit-src-abort)))
+      "k" 'edit-indirect-abort)))
 
 (defun markdown/init-markdown-mode ()
   (use-package markdown-mode


### PR DESCRIPTION
Hi,

This PR will make the `markdown` layer support key bindings `, '` and `, ,` as same as the `org` layer behavior.

The `org` layer has the shortcut `, '` to edit the code block, and `, ,` to finish editing code block. Here are the `org` layer key bindings, edit a code block:
https://github.com/syl20bnr/spacemacs/blob/e0c05e02f295a4124009e2d70d19312eb33edb4e/layers/%2Bemacs/org/packages.el#L245-L246


Commit/Abort the edit:
https://github.com/syl20bnr/spacemacs/blob/e0c05e02f295a4124009e2d70d19312eb33edb4e/layers/%2Bemacs/org/packages.el#L192-L197