### PR TITLE
* layers/+emacs/org/packages.el: Fix org-appear init

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -2980,7 +2980,7 @@ files (thanks to Daniel Nicolai)
   flag (thanks to Keith Pinson).
 - When =org-appear= is set to be triggered manually and Spacemacs' editing mode is
   Vim or hybrid, register relevant =org-appear= commands in Evil hooks for Org
-  buffers (thanks to Keith Pinson).
+  buffers (thanks to Keith Pinson and Radosław Rowicki).
 - Provide some sane default strategies for enforcing =TODO= dependencies via
   =org-todo-dependencies-strategy= (thanks to Keith Pinson).
 - Load org-mode email integration (mu4e/notmuch) when org is loaded

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -1048,12 +1048,20 @@ Headline^^            Visit entry^^               Filter^^                    Da
           org-appear-autoemphasis t
           org-appear-autosubmarkers t)
     :config
-    (when (and (eq org-appear-trigger 'manual)
-               (memq dotspacemacs-editing-style '(vim hybrid)))
-      (add-hook 'org-mode-hook
-                (lambda ()
-                  (add-hook 'evil-insert-state-entry-hook #'org-appear-manual-start nil t)
-                  (add-hook 'evil-insert-state-exit-hook #'org-appear-manual-stop nil t))))))
+    (when (eq org-appear-trigger 'manual)
+      (when (eq dotspacemacs-editing-style 'vim)
+        (add-hook 'org-appear-mode-hook
+                  (lambda ()
+                    (add-hook 'evil-insert-state-entry-hook #'org-appear-manual-start nil t)
+                    (add-hook 'evil-insert-state-exit-hook #'org-appear-manual-stop nil t)
+                    )))
+
+      (when (eq dotspacemacs-editing-style 'hybrid)
+        (add-hook 'org-appear-mode-hook
+                  (lambda ()
+                    (add-hook 'evil-hybrid-state-entry-hook #'org-appear-manual-start nil t)
+                    (add-hook 'evil-hybrid-state-exit-hook #'org-appear-manual-stop nil t)
+                    ))))))
 
 (defun org/init-org-transclusion ()
   (use-package org-transclusion


### PR DESCRIPTION
- `org-appear`'s `manual` trigger was not configured for `hybrid` editing style. Note that `insert` mode only applies to `evil` style --- `hybrid` style uses `hybrid` mode as its "insert". This PR fixes it.
- Hooks were assigned to `org-mode`, while they should be to `org-appear-mode`. In my case this caused necessity to reload `org-mode` once a buffer booted up. With this change the hooks are now properly set. 