### PR TITLE
* core/core-configuration-layer.el: Fix bug on configuration-layer/describe-package

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -966,6 +966,9 @@ a new object."
   (interactive
    (list (intern
           (completing-read "Package: " configuration-layer--used-packages))))
+  (help-setup-xref (list #'configuration-layer/describe-package
+                         pkg-symbol layer-list pkg-list)
+                   (called-interactively-p 'interactive))
   (let* ((pkg (configuration-layer/get-package pkg-symbol))
          (owners (oref pkg :owners))
          (owner (car owners)))


### PR DESCRIPTION
Fix a bug when revert the buffer on `configuration-layer/describe-package` buffer.
Reproduce steps:
0. Start Spacemacs, 
1. Pressing `SPC h d P` and input a package name to show a help buffer for a package;
2. Pressing `SPC b R` to revert the buffer, will trigger an error, like
```text
Debugger entered--Lisp error: (void-function nil)
  nil()
  apply(nil nil)
  help-mode-revert-buffer(t nil)
  revert-buffer(t)
  funcall-interactively(revert-buffer t)
  call-interactively(revert-buffer nil nil)
  command-execute(revert-buffer)
```