### PR TITLE
* tests/core/core-configuration-layer-utest.el: Fix test case for package owners

### DIFF
--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -2160,7 +2160,7 @@
     (configuration-layer/make-packages-from-layers '(layer-dotfile-2) 'used)
     (configuration-layer/make-packages-from-dotfile 'used)
     (should
-     (equal (cfgl-package "pkg1" :name 'pkg1 :owners '(layer-dotfile-2))
+     (equal (cfgl-package "pkg1" :name 'pkg1 :owners '(layer-dotfile-2 dotfile))
             (spacemacs-ht-get configuration-layer--indexed-packages 'pkg1)))))
 
 (ert-deftest test-make-packages-from-dotfile--dotfile-excludes-pkg2-in-layer-11 ()


### PR DESCRIPTION
Fix the test case for package owners, which related to the change that listing `dotfile` in the tail of package's :owners in #16803.

https://github.com/syl20bnr/spacemacs/pull/16700#issuecomment-2626291671

Please help review the change. Thanks