### PR TITLE
Add stop completion key bind

### DIFF
--- a/layers/+completion/auto-completion/README.org
+++ b/layers/+completion/auto-completion/README.org
@@ -251,6 +251,7 @@ Emacs style:
 | ~TAB~       | expand selection or select next candidate                            |
 | ~S-TAB~     | select previous candidate                                            |
 | ~RET~       | complete word, if word is already completed insert a carriage return |
+| ~C-g~       | stop completion without selecting a candidate                        |
 
 ** Yasnippet
 


### PR DESCRIPTION
- It took me forever to find this so I wanted to add it here.
- This comes from [here](https://github.com/auto-complete/auto-complete/blob/master/doc/manual.md#stop-completion)

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other 
