### PR TITLE
*layers/+spacemacs/spacemacs-editing/packages.el: Enhance the dired sorting

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -114,7 +114,7 @@
     (define-advice dired-noselect (:before (&rest _) quick-sort-setup)
       (let ((dired-quick-sort-suppress-setup-warning 'message))
         (dired-quick-sort-setup))
-      (advice-remove 'dired-noselect 'quick-sort-setup@dired-noselect))
+      (advice-remove 'dired-noselect 'dired-noselect@quick-sort-setup))
     :config
     (evil-define-key 'normal dired-mode-map "s" 'hydra-dired-quick-sort/body)))
 

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -111,21 +111,12 @@
   (use-package dired-quick-sort
     :defer t
     :init
-    (spacemacs|add-transient-hook dired-mode-hook
-      (lambda ()
-        (let ((dired-quick-sort-suppress-setup-warning 'message))
-          (dired-quick-sort-setup))))
+    (define-advice dired-noselect (:before (&rest _) quick-sort-setup)
+      (let ((dired-quick-sort-suppress-setup-warning 'message))
+        (dired-quick-sort-setup))
+      (advice-remove 'dired-noselect 'quick-sort-setup@dired-noselect))
     :config
-    (evil-define-key 'normal dired-mode-map "s" 'hydra-dired-quick-sort/body)
-    ;; workaround for https://gitlab.com/xuhdev/dired-quick-sort/-/issues/14
-    (define-advice dired-sort-toggle (:before ())
-      "Recover `dired-actual-switches' with `dired-listing-switches' when long
-      option \"--sort=...\" exists, and convert \"--sort=time\" to \"-t\"."
-      (when (string-match-p "--sort=" dired-actual-switches)
-        (setq dired-actual-switches
-              (concat dired-listing-switches
-                      (when (string-match-p "--sort=time" dired-actual-switches)
-                        " -t")))))))
+    (evil-define-key 'normal dired-mode-map "s" 'hydra-dired-quick-sort/body)))
 
 (defun spacemacs-editing/init-drag-stuff ()
   (use-package drag-stuff


### PR DESCRIPTION
Hi,

There is a file sorting bug when browsering a dir, reproducing steps with `dotspacemacs-distribution 'spacemacs` (not spacemacs-base):
1. `$ touch /tmp/a; sleep 1; touch /tmp/b` # create two files in shell, and b is newer than a
2. `$ emacs -nw --eval '(custom-set-variables (quote (dired-listing-switches "-alt")))' /tmp/` # start emacs and show /tmp/ in dired
3. press `s`, hydra-dired-quick-sort menu will popup, we remember the files orders in dired buffer (the `dired-actual-switches` is `-al --sort=extension` now)
4. press `t` on the hydra menu, the files in dired has no changes (the `dired-actual-switches` is `-al -t` now)

With this patch, behavior follow previous steps will be more naturally on step 3 and step 4.
