### PR TITLE
[c-c++ layer]: fix ggtags reference in layers.el, should be gtags

### DIFF
--- a/layers/+lang/c-c++/layers.el
+++ b/layers/+lang/c-c++/layers.el
@@ -26,5 +26,5 @@
    (pcase c-c++-backend
      ('lsp-clangd '(lsp dap))
      ('lsp-ccls '(lsp dap))
-     ('rtags '(ggtags))
+     ('rtags '(gtags))
      ('ycmd '(ycmd)))))


### PR DESCRIPTION
fixes #16816

### **Description**
The `c-c++` layer incorrectly references `ggtags` in `layers.el`, while the correct layer name is `gtags`. This leads to the following Spacemacs startup warning:

```
(Spacemacs) Warning: Unknown declared layer ggtags.
```

However, `ggtags` _package_ is still installed and loaded because it is configured by the `gtags` layer:

```
ggtags is a package declared and configured by the layer `gtags'.
You are using this package, it is currently installed and loaded.
```

### **Reproduction Steps**
1. Enable the `c-c++` layer in Spacemacs by adding it to `dotspacemacs-configuration-layers`:
   ```elisp
        (c-c++ :variables
            c-c++-backend 'rtags
            c-c++-enable-rtags-completion t)

   ```
2. Restart Spacemacs.
3. Observe the startup warning:  
   ```
   (Spacemacs) Warning: Unknown declared layer ggtags.
   ```

### **Cause**
In [*`layers/+lang/c-c++/layers.el`*](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/c-c%2B%2B/layers.el) `, configuration-layer/declare-layer-dependencies` references `ggtags` (a package name) instead of `gtags` (a spacemacs layer name):

```elisp
(when (boundp 'c-c++-backend)
  (configuration-layer/declare-layer-dependencies
   (pcase c-c++-backend
     ('lsp-clangd '(lsp dap))
     ('lsp-ccls '(lsp dap))
     ('rtags '(ggtags))   ;; ❌ Incorrect reference, should be 'gtags
     ('ycmd '(ycmd)))))
```

There is no layer named `ggtags`.

### **Suggested Fix**
Update `layers.el` to reference `gtags` instead of `ggtags`:

```elisp
(when (boundp 'c-c++-backend)
  (configuration-layer/declare-layer-dependencies
   (pcase c-c++-backend
     ('lsp-clangd '(lsp dap))
     ('lsp-ccls '(lsp dap))
     ('rtags '(gtags))   ;; ✅ Corrected reference
     ('ycmd '(ycmd)))))
```