### PR TITLE
* layers/+lang/python: Migrate key binding for toggle debug to avoid conflicting

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -552,7 +552,7 @@ Live coding is provided by the [[https://github.com/donkirkby/live-py-plugin][li
 | Key binding              | Description                                                                       |
 |--------------------------+-----------------------------------------------------------------------------------|
 | ~SPC m =~ or ~SPC m = =~ | reformat the buffer using default formatter specified in =python-formatter=       |
-| ~SPC m d b~              | toggle a breakpoint using =wdb=, =ipdb=, =pudb=, =pdb= or =python3.7= (and above) |
+| ~SPC m d t~              | toggle a breakpoint using =wdb=, =ipdb=, =pudb=, =pdb= or =python3.7= (and above) |
 | ~SPC m g a~              | go to assignment using =anaconda-mode-find-assignments= (~C-o~ to jump back)      |
 | ~SPC m g b~              | jump back                                                                         |
 | ~SPC m g g~              | go to definition using =anaconda-mode-find-definitions= (~C-o~ to jump back)      |

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -387,7 +387,7 @@
       "'"  'spacemacs/python-start-or-switch-repl
       "cc" 'spacemacs/python-execute-file
       "cC" 'spacemacs/python-execute-file-focus
-      "db" 'spacemacs/python-toggle-breakpoint
+      "dt" 'spacemacs/python-toggle-breakpoint
       "gb" 'xref-go-back
       "ri" 'spacemacs/python-remove-unused-imports
       "sB" 'spacemacs/python-shell-send-buffer-switch


### PR DESCRIPTION
Hi,

The python layer has conflicting on key binding `, d b` when enabling the `python` and `lsp(dap)` layers (the `dap` layer is enabled automatically when `lsp` layer is enabled).

The `dap` layer will bind the `, d b` for break point functions, 
https://github.com/syl20bnr/spacemacs/blob/d13f96767659900d097ac021cf01a97ff48a3f9a/layers/%2Btools/dap/packages.el#L66-L72

while the `python` layer will bind `, d b` to toggle breakpoint:
https://github.com/syl20bnr/spacemacs/blob/d13f96767659900d097ac021cf01a97ff48a3f9a/layers/%2Blang/python/packages.el#L390

The patch migrate the python layer toggle breadpoint to `, d t` to avoid the conflicting. 