### PR TITLE
[emacs-lisp] Only call flycheck setup once

### DIFF
--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -174,3 +174,19 @@ Intended for use in mode hooks."
   (let ((cbuf (current-buffer)))
     (ert '(satisfies (lambda (test)
                        (eq cbuf (spacemacs//find-ert-test-buffer test)))))))
+
+
+;; setup flycheck, but not for `lisp-interaction-mode'
+;;
+;; `lisp-interaction-mode' is commonly used as the major-mode for the *scratch*
+;; buffer created upon startup, but the flycheck-package and flycheck-elsa
+;; linters are meaningless in such a buffer.  In fact, they are meaningless for
+;; non-file-backed buffers, so just check that.
+
+(defun emacs-lisp//flycheck-package-setup ()
+  (when buffer-file-name
+    (flycheck-package-setup)))
+
+(defun emacs-lisp//flycheck-elsa-setup ()
+  (when buffer-file-name
+    (flycheck-elsa-setup)))

--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -312,11 +312,17 @@
 
 (defun emacs-lisp/init-flycheck-package ()
   (use-package flycheck-package
-    :hook (emacs-lisp-mode . flycheck-package-setup)))
+    :defer t
+    :init
+    (spacemacs|add-transient-hook emacs-lisp-mode-hook
+      emacs-lisp//flycheck-package-setup)))
 
 (defun emacs-lisp/init-flycheck-elsa ()
   (use-package flycheck-elsa
-    :hook (emacs-lisp-mode . flycheck-elsa-setup)))
+    :defer t
+    :init
+    (spacemacs|add-transient-hook emacs-lisp-mode-hook
+      emacs-lisp//flycheck-elsa-setup)))
 
 (defun emacs-lisp/post-init-ggtags ()
   (add-hook 'emacs-lisp-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))


### PR DESCRIPTION
No need to call these functions for every `emacs-lisp-mode` buffer.
Also, only call them for buffers backed by files; temp buffers or
lisp-interaction-mode buffers should not trigger these functions.  (In
particular, not calling these when `*scratch*` is in
`lisp-interaction-mode` saves a lot of startup time.)