### PR TITLE
[shell] Add shell-enable-vterm-support config var

### DIFF
--- a/layers/+tools/shell/README.org
+++ b/layers/+tools/shell/README.org
@@ -30,6 +30,7 @@
   - [[#protect-your-eshell-prompt][Protect your Eshell prompt]]
   - [[#fish-shell-and-ansi-term][Fish shell and ansi-term]]
   - [[#close-window-with-terminal][Close window with terminal]]
+  - [[#vterm-package-support][vterm package support]]
 - [[#eshell][Eshell]]
 - [[#key-bindings][Key bindings]]
   - [[#multi-term][Multi-term]]
@@ -270,6 +271,18 @@ layer variable to non-nil:
 #+END_SRC
 
 This is only applied to =term= and =ansi-term= modes.
+
+** vterm package support
+
+By default, the vterm and multi-vterm packages will be installed and
+configured on platforms that support it.  However, this requires
+performing additional compilation steps at load or install time, and
+may require other external dependencies that may not exist on your
+machine.
+
+If you do not wish to use these packages, you can set
+=shell-enable-vterm-support= to nil to avoid installing them in the
+first place.
 
 * Eshell
 Some advanced configuration is setup for =eshell= in this layer:

--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -68,5 +68,11 @@ for Linux/macOS), `eshell' (default for windows), `shell',
   "If non-nil, the window is closed when the terminal is stopped.
   This is only applied to `term' and `ansi-term' modes.")
 
+(defvar shell-enable-vterm-support t
+  "If non-nil, enable the `vterm' and `multi-vterm' packages.'
+
+These packages require dynamic module support in your Emacs, as
+well as cmake and libtool.  See the layer README for details.")
+
 (defvar spacemacs-vterm-history-file-location nil
   "Bash history full file name.")

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -45,8 +45,14 @@
     terminal-here
     vi-tilde-fringe
     window-purpose
-    (multi-vterm :toggle (and module-file-suffix (not (spacemacs/system-is-mswindows))))
-    (vterm :toggle (and module-file-suffix (not (spacemacs/system-is-mswindows))))))
+    (multi-vterm
+     :toggle (and shell-enable-vterm-support
+                  module-file-suffix
+                  (not (spacemacs/system-is-mswindows))))
+    (vterm
+     :toggle (and shell-enable-vterm-support
+                  module-file-suffix
+                  (not (spacemacs/system-is-mswindows))))))
 
 
 (defun shell/init-comint ()


### PR DESCRIPTION
vterm can be annoying to install (or to provide as a site-lisp
package) due to requiring post-install compilation steps, that have
external dependencies.  Make it easy to avoid this, even on platforms
that ostensibly could support vterm, by adding this variable.