### PR TITLE
Enable goto-address-mode for text-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -69,6 +69,8 @@ It runs `tabulated-list-revert-hook', then calls `tabulated-list-print'."
 ;; Highlight and allow to open http link at point in programming buffers
 ;; goto-address-prog-mode only highlights links in strings and comments
 (add-hook 'prog-mode-hook 'goto-address-prog-mode)
+;; In text-mode, highlight with goto-address-mode
+(add-hook 'text-mode-hook 'goto-address-mode)
 ;; Highlight and follow bug references in comments and strings
 (add-hook 'prog-mode-hook 'bug-reference-prog-mode)
 


### PR DESCRIPTION
Currently it's only enabled in prog-mode, which has missed out text-mode.