### PR TITLE
Remove seeing-is-believing package

### DIFF
--- a/layers/+lang/ruby/README.org
+++ b/layers/+lang/ruby/README.org
@@ -27,7 +27,6 @@
   - [[#toggles][Toggles]]
   - [[#rake][Rake]]
   - [[#refactor][Refactor]]
-  - [[#seeing-is-believing][Seeing is believing]]
 - [[#configuration][Configuration]]
   - [[#layer-options][Layer options]]
   - [[#disabling-the-automatic-insertion-of-encoding-comment][Disabling the automatic insertion of encoding comment]]
@@ -105,7 +104,6 @@ based on your version manager):
 - =ruby_parser= is required for *goto-step_definition* in =feature-mode=
 - =rubocop= is required for rubocop integration
 - =prettier= is required for formatter
-- =seeing_is_believing= helps you evaluate code inline
 - =solargraph= is required for using the language server protocol in =ruby-mode=
 
 You can install the gems in the context of your current project by
@@ -279,13 +277,6 @@ When =ruby-test-runner= equals =minitest=.
 | ~SPC m r e v~ | Extract local variable |
 | ~SPC m r e c~ | Extract constant       |
 | ~SPC m r e l~ | Extract to let (rspec) |
-
-** Seeing is believing
-
-| Key binding   | Description                      |
-|---------------+----------------------------------|
-| ~<SPC> m @ @~ | Run seeing is believing          |
-| ~<SPC> m @ c~ | Clear seeing is believing output |
 
 * Configuration
 ** Layer options

--- a/layers/+lang/ruby/packages.el
+++ b/layers/+lang/ruby/packages.el
@@ -48,7 +48,6 @@
     ruby-test-mode
     ruby-tools
     (rvm :toggle (eq ruby-version-manager 'rvm))
-    seeing-is-believing
     smartparens))
 
 (defun ruby/init-bundler ()
@@ -363,21 +362,6 @@
     (setq rspec-use-rvm t)
     (spacemacs/add-to-hooks 'rvm-activate-corresponding-ruby
                             '(ruby-mode-hook enh-ruby-mode-hook))))
-
-(defun ruby/init-seeing-is-believing ()
-  (use-package seeing-is-believing
-    :defer t
-    :commands (seeing-is-believing seeing-is-believing-run seeing-is-believing-clear)
-    :if (executable-find "seeing_is_believing")
-    :init
-    (spacemacs|diminish seeing-is-believing " 👁" " @")
-    (dolist (hook '(ruby-mode-hook enh-ruby-mode-hook))
-      (add-hook hook 'seeing-is-believing))
-    (dolist (mode '(ruby-mode enh-ruby-mode))
-      (spacemacs/declare-prefix-for-mode mode "m@" "seeing-is-believing")
-      (spacemacs/set-leader-keys-for-major-mode mode
-        "@@" 'seeing-is-believing-run
-        "@c" 'seeing-is-believing-clear))))
 
 (defun ruby/pre-init-smartparens ()
   (spacemacs|use-package-add-hook smartparens


### PR DESCRIPTION
Removing https://github.com/JoshCheek/seeing_is_believing from the `ruby` layer. The package seems unmaintained, with breakages on newer systems for the gem dependency.

In hindsight I should have not merged this in, it's not a core editor functionality but a flashy gimmick and trivial to add to a custom setup, you just put the package name in `dotspacemacs-additional-packages`.