### PR TITLE
[keyboard-layout] Fix "Error" in *Warnings* on magit-status with keyboard-layout layer

### DIFF
--- a/layers/+intl/keyboard-layout/packages.el
+++ b/layers/+intl/keyboard-layout/packages.el
@@ -448,10 +448,7 @@
                        magit-module-commit-section-map
                        magit-stash-section-map
                        magit-stashes-section-map
-                       magit-tag-section-map
-                       magit-unpulled-section-map
-                       magit-unpushed-section-map
-                       magit-untracked-section-map))
+                       magit-tag-section-map))
       (kl/correct-keys map
         "j"
         "k"


### PR DESCRIPTION
To reproduce:

- Enable layer keyboard-layout
- M-x magit-status

Expect: no warnings

Got: *Warnings* buffer with the following text:

⛔ Error (use-package): magit/:config: Symbol’s value as variable is void: magit-unpulled-section-map

Seems these keymaps got removed from magit here:
ff5cc5a69a15b88048bfa478e3b8137eaea50082

So don't attempt to fix up hjkl navigation key bindings for these keymaps any more:

magit-tag-section-map
magit-unpulled-section-map
magit-unpushed-section-map
