### PR TITLE
[go] just call generated hooks when setup company

### DIFF
--- a/layers/+lang/go/funcs.el
+++ b/layers/+lang/go/funcs.el
@@ -37,7 +37,9 @@
                 :call-hooks t))
     ('lsp (spacemacs|add-company-backends
             :backends company-capf
-            :modes go-mode))))
+            :modes go-mode
+            :append-hooks nil
+            :call-hooks t))))
 
 (defun spacemacs//go-setup-eldoc ()
   "Conditionally setup go eldoc based on backend"


### PR DESCRIPTION
since the func is in `go-mode-local-vars-hook`.
Or rather, this restores the PROPS removed in #13455.
Fix yasnippet unavailable in first go-mode buffer.