### PR TITLE
Fix `dotspacemacs-startup-buffer-show-icons` documentation in core-dotspacemacs.el

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -236,7 +236,7 @@ Spacemacs buffer."
 
 (spacemacs|defc dotspacemacs-startup-buffer-show-icons nil
   "If non-nil, show file icons for entries and headings on spacemacs buffer.
-This has no effect in terminal or if \"all-the-icons\" is not installed."
+This has no effect in terminal or if \"nerd-icons\" is not installed."
   'boolean
   'spacemacs-dotspacemacs-init)
 

--- a/core/templates/.spacemacs.template
+++ b/core/templates/.spacemacs.template
@@ -202,7 +202,7 @@ It should only modify the values of Spacemacs settings."
    dotspacemacs-startup-buffer-multi-digit-delay 0.4
 
    ;; If non-nil, show file icons for entries and headings on Spacemacs home buffer.
-   ;; This has no effect in terminal or if "all-the-icons" package or the font
+   ;; This has no effect in terminal or if "nerd-icons" package or the font
    ;; is not installed. (default nil)
    dotspacemacs-startup-buffer-show-icons nil
 


### PR DESCRIPTION
`all-the-icons` has been replaced by `nerd-icons` in the last commit