### PR TITLE
[org] Improvements when using org-modern-mode

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -317,14 +317,14 @@ is ignored."
     (eval toggle)))
 
 (cl-defmethod cfgl-package-reqs-satisfied-p ((pkg cfgl-package) &optional inhibit-messages)
-  "Check if requirements of a package are all enabled.
+  "Check if requirements of a package are all used.
 If INHIBIT-MESSAGES is non nil then any message emitted by the toggle evaluation
 is ignored."
   (cl-every
    (lambda (dep-pkg)
      (let ((pkg-obj (configuration-layer/get-package dep-pkg)))
        (when pkg-obj
-         (cfgl-package-enabled-p pkg-obj inhibit-messages))))
+         (cfgl-package-used-p pkg-obj inhibit-messages))))
    (oref pkg requires)))
 
 (cl-defmethod cfgl-package-enabled-p ((pkg cfgl-package) &optional inhibit-messages)

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1618,12 +1618,8 @@ RNAME is the name symbol of another existing layer."
 
 (defun configuration-layer/package-used-p (name)
   "Return non-nil if NAME is the name of a used package."
-  (let ((obj (configuration-layer/get-package name)))
-    (and obj (cfgl-package-get-safe-owner obj)
-         (not (oref obj excluded))
-         (not (memq nil (mapcar
-                         'configuration-layer/package-used-p
-                         (oref obj requires)))))))
+  (when-let ((obj (configuration-layer/get-package name)))
+    (cfgl-package-used-p obj t)))
 
 (defalias 'configuration-layer/package-usedp
   'configuration-layer/package-used-p)

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -404,6 +404,7 @@ file. It can be overridden by users inside `dotspacemacs/user-init'.")
 (defvar configuration-layer--lazy-mode-alist nil
   "Association list where the key is a mode and the value a regexp.")
 
+;; TODO: no code sets this variable, can we get rid of it?
 (defvar configuration-layer--inhibit-errors nil
   "If non-nil then error messages emitted by the layer system are ignored.")
 
@@ -425,6 +426,7 @@ installation of initialization.")
   "List of strings corresponding to category names. A category is a
 directory with a name starting with `+'.")
 
+;; FIXME: bad namespace
 (defvar update-packages-alist '()
   "List used to collect information about rollback packages in the
 cache folder.
@@ -502,6 +504,7 @@ Otherwise return the recipe unchanged.  PKG is of `cfgl-package' type."
         (eq (string-match-p "^[a-zA-Z]:" path) 0)
         (string-prefix-p "\." path))))
 
+;; FIXME: this seems dumb, we should just require ARCHIVES to include schemes.
 (defun configuration-layer//resolve-package-archives (archives)
   "Resolve HTTP handlers for each archive in ARCHIVES and return a list
 of all reachable ones.
@@ -1124,10 +1127,12 @@ USEDP non-nil means that PKG is a used layer."
     (when usedp
       (add-to-list 'configuration-layer--used-layers layer-name))))
 
+;; FIXME: unused
 (defun configuration-layer/remove-layers (layer-names)
   "Remove layers with LAYER-NAMES from used layers."
   (mapc 'configuration-layer/remove-layer layer-names))
 
+;; FIXME: only one use-case, maybe we can refactor it away
 (defun configuration-layer/remove-layer (layer-name)
   "Remove an used layer with name LAYER-NAME."
   (setq configuration-layer--used-layers
@@ -1488,6 +1493,9 @@ If `SKIP-LAYER-DEPS' is non nil then skip loading of layer dependenciesl"
             (configuration-layer//load-layer-files layer-name '("layers"))))
       (configuration-layer//warning "Unknown declared layer %s." layer-name))))
 
+;; FIXME: some layers use this and some layers use
+;; configuration-layer/declare-layers.  what's the difference, can we unify
+;; them?
 (defun configuration-layer/declare-layer-dependencies (layer-names)
   "Function to be used in `layers.el' files to declare dependencies."
   (dolist (x layer-names)
@@ -1736,7 +1744,8 @@ RNAME is the name symbol of another existing layer."
                                    "layer %s, do you want to install it?")
                            mode layer-name))))
     (when (dotspacemacs/add-layer layer-name)
-      (let (spacemacs-sync-packages)
+      (let (spacemacs-sync-packages)    ;FIXME: unused lexical variable.  is
+                                        ;this working?
         (configuration-layer/load)))
     (let* ((layer (configuration-layer/get-layer layer-name))
            (inst-pkgs
@@ -1947,6 +1956,8 @@ RNAME is the name symbol of another existing layer."
                ((eq step 'pre) pre-packages)
                (t other-packages)))))
 
+    ;; FIXME: this order should probably not matter but some how it errors if I
+    ;; don't have these reverses.
     (setq bootstrap-packages (nreverse bootstrap-packages))
     (setq pre-packages (nreverse pre-packages))
     (setq other-packages (nreverse other-packages))
@@ -2403,6 +2414,7 @@ Rollback slots are stored in
 
 The keys are package names and the values are lists of package names that
 depends on it."
+  ;; TODO: test this refactor
   (let ((result (make-hash-table)))
     (dolist (pkg package-alist)
       (let* ((pkg-sym (car pkg))
@@ -2562,14 +2574,13 @@ Return nil if MODE does not appear in `auto-mode-alist'."
 
 (defun configuration-layer//insert-lazy-install-form (layer-name mode ext)
   "Insert a configuration form for lazy installation of MODE."
-  (let ((str (concat "(configuration-layer/lazy-install '"
-                     (symbol-name layer-name)
-                     " :extensions '("
-                     (let ((print-quoted t)) (prin1-to-string ext))
-                     " "
-                     (symbol-name mode)
-                     "))\n")))
-    (insert str)))
+  (insert "(configuration-layer/lazy-install '"
+          (symbol-name layer-name)
+          " :extensions '("
+          (let ((print-quoted t)) (prin1-to-string ext))
+          " "
+          (symbol-name mode)
+          "))\n"))
 
 (defun configuration-layer/insert-lazy-install-configuration ()
   "Prompt for a layer and insert the forms to configure lazy installation."
@@ -2626,6 +2637,7 @@ Return nil if MODE does not appear in `auto-mode-alist'."
                            (lambda (x) (assq x package-archive-contents))
                            deps)))
           (dolist (pkg (cons pkg-sym elpa-deps))
+            ;; FIXME: but pkg-sym should surely be unique?
             ;; avoid duplicates
             (cl-pushnew pkg result)))))
     result))
@@ -2863,6 +2875,7 @@ continue with the stable ELPA repository installation."
      (t t))))
 
 (defun configuration-layer//stable-elpa-untar-archive ()
+  ;; FIXME: docstring is wrong about return value of `call-process'
   "Untar the downloaded archive of stable ELPA, returns non-nil if succeeded."
   (require 'tar-mode)
   (let ((archive (configuration-layer//stable-elpa-tarball-local-file))
@@ -2938,6 +2951,7 @@ files."
 ;;  "spacelpa"
 ;;  spacemacs-cache-directory)
 
+;; FIXME: initialize to 0 and just use cl-incf
 (defun configuration-layer//increment-error-count ()
   "Increment the error counter."
   (if configuration-layer-error-count
@@ -2945,6 +2959,7 @@ files."
             (1+ configuration-layer-error-count))
     (setq configuration-layer-error-count 1)))
 
+;; FIXME: format-message
 (defun configuration-layer/message (msg &rest args)
   "Display MSG in *Messages* prepended with '(Spacemacs)'.
 ARGS: format string arguments."

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -839,6 +839,7 @@ ARGS: format string arguments."
 (defvar spacemacs-buffer--warnings nil
   "List of warnings during startup.")
 
+;; FIXME: should use `format-message'
 (defun spacemacs-buffer/warning (msg &rest args)
   "Display MSG as a warning message but in buffer `*Messages*'.
 ARGS: format string arguments."

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -44,8 +44,7 @@
 (defun spacemacs//layout-wait-for-modeline (&rest _)
   "Assure the mode-line is loaded before restoring the layouts."
   (advice-remove 'persp-load-state-from-file 'spacemacs//layout-wait-for-modeline)
-  (when (and (configuration-layer/layer-used-p 'spacemacs-modeline)
-             (spacemacs//enable-spaceline-p))
+  (when (spacemacs//enable-spaceline-p)
     (require 'spaceline-config)))
 
 (defun spacemacs//current-layout-name ()
@@ -562,11 +561,11 @@ Run PROJECT-ACTION on project."
      :mode-line helm-read-file-name-mode-line-string
      :keymap (let ((map (make-sparse-keymap)))
                (define-key map
-                 (kbd "C-d") (lambda () (interactive)
-                                 (helm-exit-and-execute-action
-                                  (lambda (project)
-                                    (spacemacs||switch-project-persp project
-                                      (dired project))))))
+                           (kbd "C-d") (lambda () (interactive)
+                                         (helm-exit-and-execute-action
+                                          (lambda (project)
+                                            (spacemacs||switch-project-persp project
+                                              (dired project))))))
                map)
      :action `(("Switch to Project Perspective" .
                 spacemacs//helm-persp-switch-project-action)

--- a/layers/+spacemacs/spacemacs-org/packages.el
+++ b/layers/+spacemacs/spacemacs-org/packages.el
@@ -33,7 +33,7 @@
     ;; layer. So it is easier for users to steal the ownership of the
     ;; `org' package.
     (default-org-config :location built-in)
-    org-superstar
+    (org-superstar :toggle (not (configuration-layer/package-used-p 'org-modern)))
     (space-doc :location (recipe :fetcher local))
     toc-org
     ))

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -2484,6 +2484,7 @@
 ;; configuration-layer//get-package-recipe
 ;; ---------------------------------------------------------------------------
 
+;; FIXME: surely :size argument to make-hash-table is mostly pointless?
 (ert-deftest test-get-package-recipe--return-recipe-if-package-has-one ()
   (let (configuration-layer--used-layers
         (configuration-layer--indexed-layers (make-hash-table))


### PR DESCRIPTION
When using org-modern-mode:

- Disable org-superstar from the spacemacs-org layer.  These packages
  have overlapping functionality, and org-modern's README recommends
  not using org-superstar at the same time.

- Use `global-org-modern-mode` directly rather than reimplementing it.
  This allows it to be easily disabled globally

- Add a key binding to toggle `global-org-modern-mode`