### PR TITLE
Add a new keybinding to lsp layer for navigation.

### DIFF
--- a/layers/+tools/lsp/README.org
+++ b/layers/+tools/lsp/README.org
@@ -240,6 +240,7 @@ The lsp minor mode bindings are:
 | ~SPC m g b~   | jump back (=xref= / =lsp=)                                                       |
 | ~SPC m g i~   | find implementations (=lsp-mode=)                                                |
 | ~SPC m g d~   | find definitions (=xref= / =lsp-mode=)                                           |
+| ~SPC m g D~   | find definitions in other window (=xref= / =lsp-mode=)                           |
 | ~SPC m g r~   | find references (=xref= / =lsp=)                                                 |
 | ~SPC m g s~   | find symbol in project (=helm-lsp=)                                              |
 | ~SPC m g S~   | find symbol in all projects (=helm-lsp=)                                         |

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -139,6 +139,7 @@
   (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
     (concat prefix-char "i") #'lsp-find-implementation
     (concat prefix-char "d") #'xref-find-definitions
+    (concat prefix-char "D") #'xref-find-definitions-other-window
     (concat prefix-char "r") #'xref-find-references
     (concat prefix-char "e") #'lsp-treemacs-errors-list
     (concat prefix-char "b") #'xref-go-back)


### PR DESCRIPTION
- Add xref-find-definitions-other-window to lsp navigation keybindings.


