### PR TITLE
* core/core-spacemacs-buffer.el: Nerd icons for Spacemacs bufer on teminal

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -235,9 +235,18 @@ Spacemacs buffer."
   'spacemacs-dotspacemacs-init)
 
 (spacemacs|defc dotspacemacs-startup-buffer-show-icons nil
-  "If non-nil, show file icons for entries and headings on spacemacs buffer.
-This has no effect in terminal or if \"nerd-icons\" is not installed."
-  'boolean
+  "If non-nil, show file icons for entries and headings on spacemacs
+buffer, it requires \"nerd-icons\" package been installed.
+
+For graphic frame, it also requires a nerd font been installed (Execute
+the `nerd-icons-install-fonts' to install the font file).
+
+For terminal frame, it requires a nerd font avaliable on Terminal
+(Please make sure your terminal working with nerd font first then try
+this feature).
+
+Set the value to quoted `display-graphic-p' for graphic frame only."
+  '(choice boolean (const all))
   'spacemacs-dotspacemacs-init)
 
 (spacemacs|defc dotspacemacs-scratch-mode 'text-mode

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -273,15 +273,11 @@ Returns height in units of line height with a minimum of 1."
           ;; the nerd-icons package is not available here yet, but we don't
           ;; require icons for just counting the lines in the
           ;; `dotspacemacs-startup-lists'
-          (let ((icons dotspacemacs-startup-buffer-show-icons)
-                lines)
-            (setq dotspacemacs-startup-buffer-show-icons nil)
-            (setq lines (with-temp-buffer
-                          (spacemacs-buffer//do-insert-startupify-lists)
-                          (recentf-mode -1)
-                          (line-number-at-pos)))
-            (setq dotspacemacs-startup-buffer-show-icons icons)
-            lines))
+          (let ((dotspacemacs-startup-buffer-show-icons nil))
+            (with-temp-buffer
+              (spacemacs-buffer//do-insert-startupify-lists)
+              (recentf-mode -1)
+              (line-number-at-pos))))
          ;; We determine the maximum available banner height by subtracting the
          ;; number of lines in the home buffer contents (excl. logo and
          ;; startup-list), i.e. `26', and the number of lines in the startup
@@ -345,8 +341,7 @@ Right justified, based on the Spacemacs buffers window width."
                     (create-image badge-path)))
            (badge-size (when badge (car (image-size badge))))
            (build-by (concat "Made with "
-                             (if (and dotspacemacs-startup-buffer-show-icons
-                                      (display-graphic-p)
+                             (if (and (dotspacemacs|symbol-value dotspacemacs-startup-buffer-show-icons)
                                       (or (fboundp 'nerd-icons-faicon)
                                           (require 'nerd-icons nil 'noerror)))
                                  (nerd-icons-faicon "nf-fa-heart" :height 0.8 :v-adjust -0.05)
@@ -1407,7 +1402,7 @@ startup list.")
   (setq spacemacs-buffer--startup-list-nr 1)
   (let ((dotspacemacs-startup-buffer-show-icons dotspacemacs-startup-buffer-show-icons)
         (is-org-loaded (bound-and-true-p spacemacs-initialized)))
-    (if (display-graphic-p)
+    (if (dotspacemacs|symbol-value dotspacemacs-startup-buffer-show-icons)
         (when (and spacemacs-initialized
                    (not (configuration-layer/package-used-p 'nerd-icons)))
           (message "Package `nerd-icons' isn't installed")


### PR DESCRIPTION
Make the nerd icons works on terminal. 

Extend the `dotspacemacs-startup-buffer-show-icons` with a new flag `all` to support the icons for both graphic frame and terminal frame (the terminal should be already support a nerd font first). 

Please help review the changes. Thanks