### PR TITLE
[defaults] Fix restoring window configuration in ediff quit hook

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -974,6 +974,16 @@ variable."
           (with-current-buffer b
             (ediff-delete-temp-files)))))))
 
+(defvar spacemacs//ediff-saved-window-configuration nil)
+
+(defun spacemacs//ediff-save-window-configuration ()
+  (setq spacemacs//ediff-saved-window-configuration
+        (current-window-configuration)))
+
+(defun spacemacs//ediff-restore-window-configuration ()
+  (when spacemacs//ediff-saved-window-configuration
+    (set-window-configuration spacemacs//ediff-saved-window-configuration)))
+
 (defun spacemacs/new-empty-buffer (&optional split)
   "Create a new buffer called: \"untitled\".
 

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -210,8 +210,14 @@
     :config
     ;; show org ediffs unfolded
     (add-hook 'ediff-prepare-buffer-hook 'spacemacs//ediff-buffer-outline-show-all)
-    ;; restore window layout when done
-    (add-hook 'ediff-quit-hook #'winner-undo)
+    ;; save window layout before starting...
+    (add-hook 'ediff-before-setup-hook #'spacemacs//ediff-save-window-configuration)
+    ;; ... and restore window layout when done
+    ;;
+    ;; Append to `ediff-quit-hook' so that this runs after `ediff-cleanup-mess'.
+    ;; This avoids interfering with ediff's own cleanup, since it depends on the
+    ;; ediff control buffer still being current.
+    (add-hook 'ediff-quit-hook #'spacemacs//ediff-restore-window-configuration 50)
     (when (fboundp 'spacemacs//ediff-delete-temp-files)
       (add-hook 'kill-emacs-hook #'spacemacs//ediff-delete-temp-files))))
 


### PR DESCRIPTION
Running winner-undo in ediff-quit-hook doesn't generally work, because
ediff setup may have changed the window configuration multiple times.

Also, running it too early interferes with ediff-cleanup-mess and
prevents the control buffer and other buffers from being killed
properly by ediff's own cleanup.

Fix #16885.