### PR TITLE
[defaults] Simplify SPC f y d and SPC f y y behavior

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -817,17 +817,8 @@ not typically change the buffer displayed by a dedicated window."
 (defun spacemacs--directory-path ()
   "Retrieve the directory path of the current buffer.
 
-If the buffer is not visiting a file, use the `list-buffers-directory' variable
-as a fallback to display the directory, useful in buffers like the ones created
-by `magit' and `dired'.
-
-Returns:
-  - A string containing the directory path in case of success.
-  - nil in case the current buffer does not have a directory."
-  (when-let* ((directory-name (if-let* ((file-name (buffer-file-name)))
-                                  (file-name-directory file-name)
-                                list-buffers-directory)))
-    (file-truename directory-name)))
+The return value is always an expanded absolute path."
+  (file-truename default-directory))
 
 (defun spacemacs--file-path ()
   "Retrieve the file path of the current buffer.
@@ -880,8 +871,7 @@ otherwise the listed directory's path."
   (interactive)
   (if-let* ((file-path (or (spacemacs--file-path)
                            (and (derived-mode-p 'dired-mode)
-                                (dired-get-filename nil t))
-                           (spacemacs--directory-path))))
+                                (dired-get-filename nil t)))))
       (progn
         (kill-new file-path)
         (message "%s" file-path))


### PR DESCRIPTION
SPC f y d now copies returns the true name of default-directory, and
does not look at list-buffers-directory (which is not guaranteed to be
a real directory path and therefore it is inappropriate to pass it to
file-truename).

SPC f y y no longer falls back to using the current directory.

Fix #16888.