### PR TITLE
Fix incorrect nerd font icon names in Spacemacs buffer

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1037,7 +1037,7 @@ GROUPED-LIST: a list of string pathnames made interactive in this function."
                      " "
                      (when dotspacemacs-startup-buffer-show-icons
                        (if group-remote-p
-                           (nerd-icons-codicon "nt-cod-radio_tower" :height 0.8 :v-adjust -0.05)
+                           (nerd-icons-codicon "nf-cod-radio_tower" :height 0.8 :v-adjust -0.05)
                          (nerd-icons-icon-for-dir (car group))))
                      " "))
                    (button-text-project (abbreviate-file-name (car group))))
@@ -1062,7 +1062,7 @@ GROUPED-LIST: a list of string pathnames made interactive in this function."
                                (when dotspacemacs-startup-buffer-show-icons
                                  (if (or group-remote-p
                                          (file-remote-p (concat (car group) el)))
-                                     (nerd-icons-codicon "nt-cod-radio_tower" :height 0.8 :v-adjust -0.05)
+                                     (nerd-icons-codicon "nf-cod-radio_tower" :height 0.8 :v-adjust -0.05)
                                    (nerd-icons-icon-for-file (file-name-nondirectory el) :height 0.8 :v-adjust -0.05)))
                                " "))
                              (button-text-filename (string-trim-left (expand-file-name el)
@@ -1097,7 +1097,7 @@ LIST: a list of string bookmark names made interactive in this function."
                      (when dotspacemacs-startup-buffer-show-icons
                        (cond
                         ((file-remote-p filename)
-                         (nerd-icons-codicon "nt-cod-radio_tower" :height 0.8 :v-adjust -0.05))
+                         (nerd-icons-codicon "nf-cod-radio_tower" :height 0.8 :v-adjust -0.05))
                         ((file-directory-p filename)
                          (nerd-icons-icon-for-dir filename))
                         (t


### PR DESCRIPTION
Edits nerd-font call so that icons are displayed properly in startup buffer.

Fixes issue where the startup buffer is not displayed properly due to incorrect icon names (`nerd-icons-codicon: Unable to find icon with name ‘nt-cod-radio_tower’ in icon set ‘codicon’`)