### PR TITLE
[core] Activate site packages

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1999,7 +1999,7 @@ RNAME is the name symbol of another existing layer."
             (when dir
               (add-to-list 'load-path dir)))
           ;; configuration
-          (unless (memq (oref pkg :location) '(local site built-in))
+          (unless (memq (oref pkg :location) '(local built-in))
             (configuration-layer//activate-package pkg-name))
           (cond
            ((eq 'dotfile (car (oref pkg :owners)))

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -50,7 +50,6 @@
 
 (defun mu4e/init-mu4e ()
   (use-package mu4e
-    :commands (mu4e mu4e-compose-new)
     :init
     (spacemacs/set-leader-keys "aem" 'mu4e)
     (setq mail-user-agent 'mu4e-user-agent


### PR DESCRIPTION
Fix #16894.

Since the `fuel` package, as comes with the Factor programming
language distribution, doesn't seem to have an autoloads file,
activating it would fail.  In order to make this work, switch to the
ELPA version of `fuel`, which does not have this problem.

cc @timor since I'm not sure any of the current maintainers are
familiar with this layer.