### PR TITLE
[emacs-lisp] Remove unnecessary auto-mode-alist entries

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -223,8 +223,6 @@
 (defun emacs-lisp/init-macrostep ()
   (use-package macrostep
     :defer t
-    :mode (("\\*.el\\'" . emacs-lisp-mode)
-           ("Cask\\'" . emacs-lisp-mode))
     :init
     (evil-define-key 'normal macrostep-keymap "q" 'macrostep-collapse-all)
     (spacemacs|define-transient-state macrostep


### PR DESCRIPTION
These entries do not belong in the use-package declaration for
macrostep of all things, and in any case the .el one is
unnecessary (and wrong---it has an escaped * character?).

The one for Cask files is wrong too.  Cask files are not emacs-lisp,
and they should be edited with cask-mode.