### PR TITLE
[evil] Don't enable evil-collection for emacs editing style

### DIFF
--- a/layers/+spacemacs/spacemacs-evil/packages.el
+++ b/layers/+spacemacs/spacemacs-evil/packages.el
@@ -25,7 +25,7 @@
       '(
         evil-anzu
         evil-args
-        evil-collection
+        (evil-collection :toggle (not (eq dotspacemacs-editing-style 'emacs)))
         evil-cleverparens
         (evil-escape :location (recipe :fetcher github
                                        :repo "smile13241324/evil-escape"))


### PR DESCRIPTION
`holy-mode` users expect their key bindings to be largely the same as
Emacs ones.  For example, revert-buffer in special-mode should be
bound to `g`, not `g r`.