### PR TITLE
[emacs-lisp] Don't move point when formatting on save

### DIFF
--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -154,8 +154,9 @@ Intended for use in mode hooks."
 (defun spacemacs//format-elisp-buffer ()
   "Format the given buffer if required."
   (when emacs-lisp-format-on-save
-    (indent-region (point-min) (point-max))
-    (whitespace-cleanup)))
+    (save-excursion
+      (indent-region (point-min) (point-max))
+      (whitespace-cleanup))))
 
 
 

--- a/layers/+os/nixos/packages.el
+++ b/layers/+os/nixos/packages.el
@@ -22,9 +22,9 @@
 
 
 (defconst nixos-packages
-  '((company-nixos-options :requires company)
+  '((company-nixos-options :requires (company nixos-options))
     flycheck
-    (helm-nixos-options :requires helm)
+    (helm-nixos-options :requires (helm nixos-options))
     nix-mode
     nixos-options))
 

--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -255,6 +255,7 @@ variables (see `savehist-mode' and `savehist-additional-variables')."
 
 ;; cache files
 (setq tramp-persistency-file-name (concat spacemacs-cache-directory "tramp"))
+(setq request-storage-directory (concat spacemacs-cache-directory "request/"))
 
 ;; seems pointless to warn. There's always undo.
 (put 'narrow-to-region 'disabled nil)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -832,11 +832,7 @@ Returns:
             (+ (current-column) (if column-number-indicator-zero-based 0 1)))))
 
 (defun spacemacs/copy-directory-path ()
-  "Copy and show the directory path of the current buffer.
-
-If the buffer is not visiting a file, use the `list-buffers-directory'
-variable as a fallback to display the directory, useful in buffers like the
-ones created by `magit' and `dired'."
+  "Copy and show the `default-directory' of the current buffer."
   (interactive)
   (if-let* ((directory-path (spacemacs--directory-path)))
       (progn

--- a/layers/+spacemacs/spacemacs-misc/packages.el
+++ b/layers/+spacemacs/spacemacs-misc/packages.el
@@ -24,8 +24,7 @@
 (setq spacemacs-misc-packages
       '(
         devdocs
-        dumb-jump
-        request))
+        dumb-jump))
 
 
 (defun spacemacs-misc/init-dumb-jump ()
@@ -42,10 +41,6 @@
     ;; Enable xref-backend of dumb-jump. It's chosen only when no better
     ;; options is available
     (add-hook 'xref-backend-functions #'dumb-jump-xref-activate 90)))
-
-(defun spacemacs-misc/init-request ()
-  (setq request-storage-directory
-        (concat spacemacs-cache-directory "request/")))
 
 (defun spacemacs-misc/init-devdocs ()
   (use-package devdocs


### PR DESCRIPTION
Without save-excursion, this code can move point suddenly in annoying
ways (especially combined with other before-save-hooks)