### PR TITLE
[python] Allow python-sort-imports-on-save to be set directory-locally silently

### DIFF
--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -87,6 +87,7 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
 
 (defvar python-sort-imports-on-save nil
   "If non-nil, automatically sort imports on save.")
+(put 'python-sort-imports-on-save 'safe-local-variable 'booleanp)
 
 (defvar python-enable-importmagic nil
   "If non-nil, enable the importmagic feature.")


### PR DESCRIPTION
It might be useful to set this in .dir-locals.el for certain projects,
and it's certainly safe to do so.