### PR TITLE
Fix ansible-mode

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1528,6 +1528,7 @@ Other:
   - Added additional YAML paths and refactored =spacemacs--ansible-filename-re=
     (thanks to Brett Campbell)
 - Fixes:
+  - Fixed =File mode specification error: (void-function ansible)=
   - Fixed ansible-doc-mode error on ~SPC h d k~
     (thanks to Codruț Constantin Gușoi)
   - Fixed =error void function ansible: auto-decrypt-encrypt=

--- a/layers/+tools/ansible/funcs.el
+++ b/layers/+tools/ansible/funcs.el
@@ -29,7 +29,7 @@
 (defun spacemacs/ansible-maybe-enable ()
   "Enable `ansible-mode' if required."
   (when (spacemacs//ansible-should-enable?)
-    (ansible 1)))
+    (ansible-mode 1)))
 
 (defun spacemacs/ansible-auto-decrypt-encrypt-vault ()
   "Auto decrypt/encrypt Vault files."


### PR DESCRIPTION
This was broken because the mode was renamed from `ansible` to `ansible-mode`. Initially there was an alias for backwards compatibility, but that has now been removed.

[The mode was renamed 9 months ago](https://gitlab.com/emacs-ansible/emacs-ansible/-/commit/eebb2fb49d3c0a0586d1e4ead9ba618c7d003cae#a02a809f2a960e701a6596c404ac78821b6474f7_304_323) and [the alias was removed 3 month ago](https://gitlab.com/emacs-ansible/emacs-ansible/-/commit/4c5c030d1aeb6e899b9c11f0e78bab53c80a057c).