### PR TITLE
[org] Add `, T T` binding for org-agenda-todo

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -938,6 +938,7 @@ The evilified org agenda supports the following bindings:
 | ~SPC m i P~          | org-agenda-priority               |
 | ~SPC m i t~          | org-agenda-set-tags               |
 | ~SPC m s r~          | org-agenda-refile                 |
+| ~t~ or ~SPC m T T~   | org-agenda-todo                   |
 | ~M-j~                | next item                         |
 | ~M-k~                | previous item                     |
 | ~M-h~                | earlier view                      |
@@ -947,6 +948,7 @@ The evilified org agenda supports the following bindings:
 | ~C-v~                | change view                       |
 | ~RET~                | org-agenda-goto                   |
 | ~M-RET~              | org-agenda-show-and-scroll-up     |
+| ~s~                  | org-save-all-org-buffers          |
 
 *** Org agenda transient state
 Use ~SPC m .~, ~M-SPC~ or ~s-M-SPC~ in an org agenda buffer to activate its

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -506,7 +506,8 @@ Will work on both org-mode and any mode that accepts plain html."
       "ip" 'org-agenda-set-property
       "iP" 'org-agenda-priority
       "it" 'org-agenda-set-tags
-      "sr" 'org-agenda-refile)
+      "sr" 'org-agenda-refile
+      "TT" 'org-agenda-todo)
     (spacemacs|define-transient-state org-agenda
       :title "Org-agenda transient state"
       :on-enter (setq which-key-inhibit t)


### PR DESCRIPTION
The keybinding `, T T` can be used in Org Mode to cycle todo keywords (`org-todo`) as well as `C-c C-t`. There's another keybinding `t` for that purpose, but `, T T` is also good for users who have muscle memory in org files.

It may also make sense to bind `SPC f s` for `org-save-all-org-buffers`, since `C-x C-s` is bound as well, but that's overriding the exising keybinding, so it wasn't applied here.