### PR TITLE
[mu4e] Fallback to loading mu4e-autoloads if package not activated

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -49,6 +49,17 @@
           (persp-kill mu4e-spacemacs-layout-name))))))
 
 (defun mu4e/init-mu4e ()
+  ;; Some distributions do not construct the initial Emacs load paths properly
+  ;; so that packages are included in `package-directory-list' and thereby
+  ;; activated at startup.  To avoid breakage, now that Spacemacs defers loading
+  ;; mu4e, load `mu4e-autoloads' explicitly and issue a warning.
+  ;;
+  ;; See https://github.com/syl20bnr/spacemacs/issues/16931
+  (unless (featurep 'mu4e-autoloads)
+    (spacemacs-buffer/warning "`mu4e-autoloads' was not provided at startup.  Please ensure `mu4e' is installed and activated correctly.
+
+See https://github.com/syl20bnr/spacemacs/issues/16931#issuecomment-2767608202.")
+    (require 'mu4e-autoloads))
   (use-package mu4e
     :defer t
     :init


### PR DESCRIPTION
Fix #16931.

Rather than just reverting the previous change and loading mu4e at
startup, just load its autoloads.  Warn if they were not already
loaded by `package-activate`, to encourage users to fix issues in
their Emacs site-lisp distribution or report issues to their
distribution maintainers.