### PR TITLE
Removing the possibility to send mails asynchronously.

### DIFF
--- a/layers/+email/mu4e/README.org
+++ b/layers/+email/mu4e/README.org
@@ -13,7 +13,6 @@
   - [[#compose-mode][Compose mode]]
 - [[#configuration][Configuration]]
   - [[#multiple-accounts][Multiple Accounts]]
-  - [[#async-mode][Async mode]]
   - [[#attachment-directory][Attachment directory]]
   - [[#example-configuration][Example configuration]]
   - [[#notifications][Notifications]]
@@ -155,18 +154,6 @@ The following example is taken from the manual:
 Note: We used to have a hack to support multiple accounts with older version of
 =mu= but we removed it to encourage people to update their version and use the
 new contexts feature.
-
-** Async mode
-=mu4e= can send mails in async mode, which speeds up sending as you do not have
-to wait for the email to be sent. This is off by default but you can enable
-it by setting the ~mu4e-enable-async-operations~ variable when including the
-layer.
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-                '((mu4e :variables
-                        mu4e-enable-async-operations t)))
-#+END_SRC
 
 ** Attachment directory
 By default =mu4e= will save attachment files to =$HOME=, but this layer changes

--- a/layers/+email/mu4e/config.el
+++ b/layers/+email/mu4e/config.el
@@ -33,9 +33,6 @@
 (defvar mu4e-spacemacs-kill-layout-on-exit t
   "When non-nil, exiting mu4e app will automatically kill its layout")
 
-(defvar mu4e-enable-async-operations nil
-  "Prefer async operations when sending emails.")
-
 (defvar mu4e-enable-notifications nil
   "If non-nil, enable desktop notifications for unread emails.")
 

--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -108,11 +108,6 @@ See https://github.com/syl20bnr/spacemacs/issues/16931#issuecomment-2767608202."
       "s" 'message-dont-send         ; saves as draft
       "f" 'mml-attach-file)
 
-    (when mu4e-enable-async-operations
-      (require 'smtpmail-async)
-      (setq send-mail-function         'async-smtpmail-send-it
-            message-send-mail-function 'async-smtpmail-send-it))
-
     (when (fboundp 'imagemagick-register-types)
       (imagemagick-register-types))
 


### PR DESCRIPTION
Removing the variable in the layer and adjusting the Readme to reflect the change.

According to issue #16925 the feature is broken and therefore should
be removed.
