### PR TITLE
[ivy] Remove redundant C-h key binding for counsel-find-file

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -161,11 +161,6 @@
     (dolist (command '(counsel-org-goto counsel-imenu spacemacs/counsel-jump-in-buffer))
       (evil-add-command-properties command :jump t))
 
-    (when (or (eq 'vim dotspacemacs-editing-style)
-              (and (eq 'hybrid dotspacemacs-editing-style)
-                   hybrid-style-enable-hjkl-bindings))
-      (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory))
-
     (define-key read-expression-map (kbd "C-r") 'counsel-minibuffer-history)
     (spacemacs//counsel-search-add-extra-bindings counsel-ag-map)
     ;; remaps built-in commands that have a counsel replacement

--- a/layers/+spacemacs/spacemacs-completion/funcs.el
+++ b/layers/+spacemacs/spacemacs-completion/funcs.el
@@ -223,6 +223,7 @@ See https://github.com/syl20bnr/spacemacs/issues/3700"
       (define-key map (kbd "C-j") 'ivy-next-line)
       (define-key map (kbd "C-k") 'ivy-previous-line))
     (define-key ivy-minibuffer-map (kbd "C-h") (kbd "DEL"))
+    (define-key counsel-find-file-map (kbd "C-h") 'counsel-up-directory)
     ;; Move C-h to C-S-h
     (define-key ivy-minibuffer-map (kbd "C-S-h") help-map)
     (define-key ivy-minibuffer-map (kbd "C-l") 'ivy-alt-done)


### PR DESCRIPTION
This is already covered by `spacemacs//ivy-hjkl-navigation` which remaps
`C-h` to `DEL` (via keyboard macro).