### PR TITLE
[spacemacs-navigation] Bind SPC q r to restart-emacs if package is excluded

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -488,6 +488,19 @@ ivy"
   (let ((spacemacs-really-kill-emacs t))
     (restart-emacs args)))
 
+(defun spacemacs/restart-emacs-builtin ()
+  "Restart emacs using the built-in `restart-emacs' command rather than external package."
+  (interactive)
+  (let ((spacemacs-really-kill-emacs t))
+    (restart-emacs)))
+
+;; This key binding may be overwritten by
+;; `spacemacs-navigation/init-restart-emacs' if that package is used.  It is
+;; defined here rather than in keybindings.el because it needs to be overwritten
+;; by package initialization, and keybindings.el is loaded too late.
+(spacemacs/set-leader-keys
+  "qr" 'spacemacs/restart-emacs-builtin)
+
 (defun spacemacs/restart-emacs-resume-layouts (&optional args)
   "Restart emacs and resume layouts."
   (interactive)


### PR DESCRIPTION
Users may prefer the built-in `restart-emacs` functionality, even
though it doesn't support changing the command-line arguments.  Add
`SPC q r` as a key binding for it, to be overwritten by
`spacemacs-navigation/init-restart-emacs` if the restart-emacs
external package is used.