### PR TITLE
[version-control] Bind SPC g v to vc-prefix-map rather than individual keys

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -75,7 +75,7 @@ one over the other:
 | Dired support                       | X       |            |
 
 * Key bindings
-VC commands:
+VC commands (not exhaustive):
 
 | Key binding | Description                                            |
 |-------------+--------------------------------------------------------|
@@ -94,8 +94,8 @@ VC commands:
 | ~SPC g v l~ | List the change log                                    |
 | ~SPC g v L~ | List the change log for the current VC controlled tree |
 | ~SPC g v v~ | Do the next logical VC operation (=vc-next-action=)    |
-| ~SPC g v I~ | Ignore file (=vc-ignore=)                              |
-| ~SPC g v r~ | Resolve conflicts in file                              |
+| ~SPC g v G~ | Ignore file (=vc-ignore=)                              |
+| ~SPC g v R~ | Resolve conflicts in file                              |
 
 ** VC Directory buffer commands
 You can hit ~SPC pv~ from the current project to open the VC Directory buffer,

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -40,22 +40,11 @@
     :defer t
     :commands (vc-ignore)
     :init
+    (spacemacs/set-leader-keys "gv" vc-prefix-map)
     (spacemacs/declare-prefix "gv" "version-control")
-    (spacemacs/set-leader-keys
-      "gvv" 'vc-next-action
-      "gvg" 'vc-annotate
-      "gvD" 'vc-root-diff
-      "gve" 'vc-ediff
-      "gvd" 'vc-dir
-      "gv+" 'vc-update
-      "gvh" 'vc-region-history
-      "gvi" 'vc-register
-      "gvI" 'vc-ignore
-      "gvu" 'vc-revert
-      "gvl" 'vc-print-log
-      "gvL" 'vc-print-root-log
-      "gvr" 'vc-resolve-conflicts)
     :config
+    (define-key vc-prefix-map "e" #'vc-ediff)
+    (define-key vc-prefix-map "R" #'vc-resolve-conflicts)
     (with-eval-after-load 'vc-dir
       (evilified-state-evilify-map vc-dir-mode-map
         :mode vc-dir-mode


### PR DESCRIPTION
Change some key bindings to make sure we don't conflict with existing
key bindings in vc-prefix-map:

- `vc-resolve-conflicts` was `r` but moved to `R` (`SPC g v r` is now `vc-retrieve-tag`)
- `vc-ignore` was `I` but moved to `G` (to match `vc-prefix-map` binding)