### PR TITLE
[modeline] Fix error when using vanilla modeline and refactor

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -920,9 +920,7 @@ Called with `C-u C-u' skips `dotspacemacs/user-config' _and_ preliminary tests."
                   (message "Done.")))
             (switch-to-buffer-other-window dotspacemacs-test-results-buffer)
             (spacemacs-buffer/warning "Some tests failed, check `%s' buffer"
-                                      dotspacemacs-test-results-buffer))))))
-  (when (configuration-layer/package-used-p 'spaceline)
-    (spacemacs//restore-buffers-powerline)))
+                                      dotspacemacs-test-results-buffer)))))))
 
 (eval-and-compile
   (defun dotspacemacs/get-variable-string-list ()

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -44,8 +44,8 @@
 (defun spacemacs//layout-wait-for-modeline (&rest _)
   "Assure the mode-line is loaded before restoring the layouts."
   (advice-remove 'persp-load-state-from-file 'spacemacs//layout-wait-for-modeline)
-  (when (and (configuration-layer/package-used-p 'spaceline)
-             (memq (spacemacs/get-mode-line-theme-name) '(spacemacs all-the-icons custom)))
+  (when (and (configuration-layer/layer-used-p 'spacemacs-modeline)
+             (spacemacs//enable-spaceline-p))
     (require 'spaceline-config)))
 
 (defun spacemacs//current-layout-name ()

--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -50,6 +50,10 @@ Return nil if no scale is defined."
 
 ;; spaceline
 
+(defun spacemacs//enable-spaceline-p ()
+  (memq (spacemacs/get-mode-line-theme-name)
+        '(spacemacs all-the-icons custom)))
+
 (defun spacemacs/spaceline-config-startup-hook ()
   "Install a transient hook to delay spaceline config after Emacs starts."
   (spacemacs|add-transient-hook window-configuration-change-hook
@@ -81,13 +85,19 @@ Return nil if no scale is defined."
 (defun spacemacs//restore-buffers-powerline ()
   "Restore the powerline in the buffers.
 Excluding which-key."
-  (dolist (buffer (buffer-list))
-    (unless (string-match-p "\\*which-key\\*" (buffer-name buffer))
-      (with-current-buffer buffer
-        (setq-local mode-line-format (default-value 'mode-line-format)))))
-  (powerline-reset)
-  (powerline-set-selected-window)
-  (force-mode-line-update t))
+  (if (spacemacs//enable-spaceline-p)
+      (progn
+        (dolist (buffer (buffer-list))
+          (unless (string-match-p "\\*which-key\\*" (buffer-name buffer))
+            (with-current-buffer buffer
+              (setq-local mode-line-format (default-value 'mode-line-format)))))
+        (powerline-reset)
+        (powerline-set-selected-window)
+        (force-mode-line-update t))
+    ;; In case `dotspacemacs-mode-line-theme' has changed and the configuration
+    ;; was reloaded.
+    (remove-hook 'spacemacs-post-user-config-hook
+                 #'spacemacs//restore-buffers-powerline)))
 
 (defun spacemacs//prepare-diminish ()
   (when spaceline-minor-modes-p

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -25,8 +25,7 @@
       '(
         (doom-modeline :toggle (eq (spacemacs/get-mode-line-theme-name) 'doom))
         fancy-battery
-        (spaceline :toggle (memq (spacemacs/get-mode-line-theme-name)
-                                 '(spacemacs all-the-icons custom)))
+        (spaceline :toggle (spacemacs//enable-spaceline-p))
         (spaceline-all-the-icons :toggle (eq (spacemacs/get-mode-line-theme-name) 'all-the-icons))
         symon
         (powerline :toggle (eq (spacemacs/get-mode-line-theme-name) 'vim-powerline))
@@ -138,8 +137,8 @@
     (when (configuration-layer/package-used-p 'info+)
       (spaceline-info-mode t))
     ;; Enable spaceline for buffers created before the configuration of
-    ;; spaceline
-    (spacemacs//restore-buffers-powerline)))
+    ;; spaceline, and reset after reloading configuration.
+    (add-hook 'spacemacs-post-user-config-hook #'spacemacs//restore-buffers-powerline)))
 
 (defun spacemacs-modeline/pre-init-spaceline-all-the-icons ()
   (when (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))


### PR DESCRIPTION
The call to `spacemacs//restore-buffers-powerline` in `dotspacemacs/sync-configuration-layers` would lead to an error when using the `spacemacs-modeline` layer and the vanilla mode line.

A fix for #16346 would solve this, but in any case, this rather belongs in spaceline package init function.

Also factor out the spaceline toggle condition into `spacemacs//enable-spaceline-p` as it is now used in three places.