### PR TITLE
[core] Catch errors in package init functions and when loading files

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1572,7 +1572,7 @@ RNAME is the name symbol of another existing layer."
                     (spacemacs-customization//validate
                      val (custom-variable-type var)))
                   (set-default var val))
-              ('error
+              (error
                (configuration-layer//error
                 (concat "An error occurred while setting layer "
                         "variable %s "
@@ -1689,7 +1689,7 @@ RNAME is the name symbol of another existing layer."
             (oset pkg :lazy-install nil))
            (t (configuration-layer//warning "Cannot install package %S."
                                             pkg-name)))
-        ('error
+        (error
          (configuration-layer//error
           (concat "An error occurred while installing %s " "(error: %s)")
           pkg-name
@@ -2004,7 +2004,7 @@ LAYER must not be the owner of PKG."
             (format "%S -> pre-init (%S)..." pkg-name layer))
            (condition-case-unless-debug err
                (funcall (intern (format "%S/pre-init-%S" layer pkg-name)))
-             ('error
+             (error
               (configuration-layer//error
                (concat "An error occurred while pre-configuring %S "
                        "in layer %S (error: %s)")
@@ -2020,7 +2020,7 @@ LAYER must not be the owner of PKG."
     (spacemacs-buffer/message (format "%S -> init (%S)..." pkg-name owner))
     (condition-case-unless-debug err
         (funcall (intern (format "%S/init-%S" owner pkg-name)))
-      ('error
+      (error
        (configuration-layer//error
         (concat "An error occurred while configuring %S "
                 "in layer %S (error: %s)")
@@ -2039,7 +2039,7 @@ LAYER must not be the owner of PKG."
             (format "%S -> post-init (%S)..." pkg-name layer))
            (condition-case-unless-debug err
                (funcall (intern (format "%S/post-init-%S" layer pkg-name)))
-             ('error
+             (error
               (configuration-layer//error
                (concat "An error occurred while post-configuring %S "
                        "in layer %S (error: %s)")
@@ -2808,7 +2808,7 @@ ARGS: format string arguments."
   "Load file silently except if in debug mode."
   (condition-case-unless-debug err
       (load file noerror (not init-file-debug))
-    ('error
+    (error
      (configuration-layer//error
       "An error occurred while loading %S (error: %s)"
       file err))))

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2018,7 +2018,13 @@ LAYER must not be the owner of PKG."
          (owner (car (oref pkg :owners))))
     ;; init
     (spacemacs-buffer/message (format "%S -> init (%S)..." pkg-name owner))
-    (funcall (intern (format "%S/init-%S" owner pkg-name)))))
+    (condition-case-unless-debug err
+        (funcall (intern (format "%S/init-%S" owner pkg-name)))
+      ('error
+       (configuration-layer//error
+        (concat "\nAn error occurred while configuring %S "
+                "in layer %S (error: %s)\n")
+        pkg-name owner err)))))
 
 (defun configuration-layer//post-configure-package (pkg)
   "Post-configure PKG object, i.e. call its post-init functions."
@@ -2800,7 +2806,12 @@ ARGS: format string arguments."
 
 (defun configuration-layer/load-file (file &optional noerror)
   "Load file silently except if in debug mode."
-  (load file noerror (not init-file-debug)))
+  (condition-case-unless-debug err
+      (load file noerror (not init-file-debug))
+    ('error
+     (configuration-layer//error
+      "An error occurred while loading %S (error: %s)"
+      file err))))
 
 (provide 'core-configuration-layer)
 

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -423,7 +423,7 @@ cache folder.")
 
 (defun configuration-layer/load-lock-file ()
   "Load the .lock file"
-  (configuration-layer/load-file configuration-layer-lock-file))
+  (load configuration-layer-lock-file nil (not init-file-debug)))
 
 (defun configuration-layer/initialize ()
   "Initialize `package.el'."

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1574,10 +1574,10 @@ RNAME is the name symbol of another existing layer."
                   (set-default var val))
               ('error
                (configuration-layer//error
-                (concat "\nAn error occurred while setting layer "
+                (concat "An error occurred while setting layer "
                         "variable %s "
                         "(error: %s). Be sure to quote the value "
-                        "if needed.\n") var err)))
+                        "if needed.") var err)))
           (configuration-layer//warning "Missing value for variable %s !"
                                         var))))))
 
@@ -1691,7 +1691,7 @@ RNAME is the name symbol of another existing layer."
                                             pkg-name)))
         ('error
          (configuration-layer//error
-          (concat "\nAn error occurred while installing %s " "(error: %s)\n")
+          (concat "An error occurred while installing %s " "(error: %s)")
           pkg-name
           err)
          (spacemacs//redisplay))))))
@@ -2006,8 +2006,8 @@ LAYER must not be the owner of PKG."
                (funcall (intern (format "%S/pre-init-%S" layer pkg-name)))
              ('error
               (configuration-layer//error
-               (concat "\nAn error occurred while pre-configuring %S "
-                       "in layer %S (error: %s)\n")
+               (concat "An error occurred while pre-configuring %S "
+                       "in layer %S (error: %s)")
                pkg-name layer err))))))
      (oref pkg :pre-layers))))
 
@@ -2022,8 +2022,8 @@ LAYER must not be the owner of PKG."
         (funcall (intern (format "%S/init-%S" owner pkg-name)))
       ('error
        (configuration-layer//error
-        (concat "\nAn error occurred while configuring %S "
-                "in layer %S (error: %s)\n")
+        (concat "An error occurred while configuring %S "
+                "in layer %S (error: %s)")
         pkg-name owner err)))))
 
 (defun configuration-layer//post-configure-package (pkg)
@@ -2041,8 +2041,8 @@ LAYER must not be the owner of PKG."
                (funcall (intern (format "%S/post-init-%S" layer pkg-name)))
              ('error
               (configuration-layer//error
-               (concat "\nAn error occurred while post-configuring %S "
-                       "in layer %S (error: %s)\n")
+               (concat "An error occurred while post-configuring %S "
+                       "in layer %S (error: %s)")
                pkg-name layer err))))))
      (oref pkg :post-layers))))
 

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -851,7 +851,7 @@ the symbol of an editing style and the cdr is a list of keyword arguments like
           (if (consp variables)
               (condition-case-unless-debug err
                   (set-default var (eval (pop variables)))
-                ('error
+                (error
                  (spacemacs-buffer/append
                   (format (concat "\nAn error occurred while reading the "
                                   "editing style variable %s "

--- a/layers/+vim/vinegar/funcs.el
+++ b/layers/+vim/vinegar/funcs.el
@@ -153,7 +153,7 @@
           (progn
             (setq file (dired-get-file-for-visit))
             (dired-find-file-other-window))
-        ('error
+        (error
          (vinegar/up-directory))))))
 
 


### PR DESCRIPTION
(We already similarly catch errors in pre-init and post-init functions.)

Errors can happen, for example, when accidentally introducing a typo in some (private or public) layer file; or when adding the mu4e layer without having the mu4e package installed (or mu4e-autoloads.el is missing).

Such errors currently completely break the startup process, such that most keybindings don't work, which makes it more tedious to actually solve the problems.