### PR TITLE
[mu4e] Catch errors when loading org

### DIFF
--- a/layers/+email/mu4e/packages.el
+++ b/layers/+email/mu4e/packages.el
@@ -155,21 +155,22 @@ See https://github.com/syl20bnr/spacemacs/issues/16931#issuecomment-2767608202."
 (defun mu4e/pre-init-org ()
   (when mu4e-org-link-support
     (with-eval-after-load 'org
-      ;; This is a dirty hack due to mu(4e) 1.8.2 renaming mu4e-meta to
-      ;; mu4e-config.  See also
-      ;; https://github.com/djcb/mu/commit/cf0f72e4a48ac7029d7f6758b182d4bb559f8f49
-      ;; and https://github.com/syl20bnr/spacemacs/issues/15618.  This code
-      ;; used to simply read: (require 'mu4e-meta).  We now attempt to load
-      ;; mu4e-config.  If this fails, load mu4e-meta.
-      (unless (require 'mu4e-config nil t)
-        (require 'mu4e-meta))
-      (if (version<= mu4e-mu-version "1.3.5")
-          (require 'org-mu4e)
-        (require 'mu4e-org))
-      ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
-      ;; Note that this bug prevents lazy-loading.
-      (when (version<= mu4e-mu-version "1.4.15")
-        (require 'mu4e))))
+      (with-demoted-errors "(Spacemacs) Error loading a mu4e feature: %S"
+        ;; This is a dirty hack due to mu(4e) 1.8.2 renaming mu4e-meta to
+        ;; mu4e-config.  See also
+        ;; https://github.com/djcb/mu/commit/cf0f72e4a48ac7029d7f6758b182d4bb559f8f49
+        ;; and https://github.com/syl20bnr/spacemacs/issues/15618.  This code
+        ;; used to simply read: (require 'mu4e-meta).  We now attempt to load
+        ;; mu4e-config.  If this fails, load mu4e-meta.
+        (unless (require 'mu4e-config nil t)
+          (require 'mu4e-meta))
+        (if (version<= mu4e-mu-version "1.3.5")
+            (require 'org-mu4e)
+          (require 'mu4e-org))
+        ;; We require mu4e due to an existing bug https://github.com/djcb/mu/issues/1829
+        ;; Note that this bug prevents lazy-loading.
+        (when (version<= mu4e-mu-version "1.4.15")
+          (require 'mu4e)))))
   (when mu4e-org-compose-support
     (spacemacs/set-leader-keys-for-major-mode 'mu4e-compose-mode
       "o" 'org-mu4e-compose-org-mode)


### PR DESCRIPTION
An error within `(with-eval-after-load 'org ...)` has severe consequences: Org fails to load, and also help buffers cannot be opened at all, due to the elisp-demos package requiring org.