### PR TITLE
Add --no-dotspacemacs and --default-dotspacemacs options

### DIFF
--- a/core/core-command-line.el
+++ b/core/core-command-line.el
@@ -29,6 +29,14 @@
   "If non-nil packages are synchronized when the configuration layer system is
 loaded.")
 
+(defvar spacemacs-load-dotspacemacs t
+  "If nil, suppress loading the user's Spacemacs configuration.
+
+If set to `template', load `dotspacemacs-template.el' rather than the
+user's Spacemacs configuration.
+
+Otherwise, load the user's Spacemacs config as normal.")
+
 (defun spacemacs//parse-command-line (args)
   "Handle Spacemacs specific command line arguments.
 The reason why we don't use the Emacs hooks for processing user defined
@@ -66,6 +74,10 @@ arguments is that we want to process these arguments as soon as possible."
            (setq spacemacs-force-resume-layouts t))
           ("--no-package-sync"
            (setq spacemacs-sync-packages nil))
+          ("--no-dotspacemacs"
+           (setq spacemacs-load-dotspacemacs nil))
+          ("--default-dotspacemacs"
+           (setq spacemacs-load-dotspacemacs 'template))
           (_ (push arg new-args))))
       (setq i (1+ i)))
     (nreverse new-args)))

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -625,7 +625,9 @@ To prevent package from being installed or uninstalled set the variable
       (when (and (or (eq 'used dotspacemacs-install-packages)
                      (eq 'used-only dotspacemacs-install-packages))
                  (not configuration-layer-force-distribution)
-                 (not configuration-layer-exclude-all-layers))
+                 (not configuration-layer-exclude-all-layers)
+                 spacemacs-load-dotspacemacs
+                 (not (eq 'template spacemacs-load-dotspacemacs)))
         (configuration-layer/delete-orphan-packages packages))))
   ;; configure used packages
   (configuration-layer//configure-packages configuration-layer--used-packages)

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -20,6 +20,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+(require 'core-command-line)
 (require 'core-load-paths)
 (require 'core-customization)
 
@@ -1018,11 +1019,15 @@ If ARG is non nil then ask questions to the user before installing the dotfile."
 
 (defun dotspacemacs/load-file ()
   "Load ~/.spacemacs if it exists."
-  (let ((dotspacemacs (dotspacemacs/location)))
-    (if (file-exists-p dotspacemacs)
-        (unless (with-demoted-errors "Error loading .spacemacs: %S"
-                  (load dotspacemacs))
-          (dotspacemacs/safe-load))))
+  (cl-case spacemacs-load-dotspacemacs
+    ((nil))
+    ((template) (load dotspacemacs-template-file))
+    (t
+     (let ((dotspacemacs (dotspacemacs/location)))
+       (if (file-exists-p dotspacemacs)
+           (unless (with-demoted-errors "Error loading .spacemacs: %S"
+                     (load dotspacemacs))
+             (dotspacemacs/safe-load))))))
   (advice-add 'dotspacemacs/layers :after
               'spacemacs-customization//validate-dotspacemacs-layers-vars)
   (advice-add 'dotspacemacs/init :after

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -894,8 +894,8 @@ Returns non nil if the layer has been effectively inserted."
 Called with `C-u' skips `dotspacemacs/user-config'.
 Called with `C-u C-u' skips `dotspacemacs/user-config' _and_ preliminary tests."
   (interactive "P")
-  (when (file-exists-p dotspacemacs-filepath)
-    (with-current-buffer (find-file-noselect dotspacemacs-filepath)
+  (when (file-exists-p (dotspacemacs/location))
+    (with-current-buffer (find-file-noselect (dotspacemacs/location))
       (let ((dotspacemacs-loading-progress-bar nil))
         (setq spacemacs-loading-string "")
         (save-buffer)
@@ -943,8 +943,13 @@ If SYMBOL value is `display-graphic-p' then return the result of
   `(if (eq 'display-graphic-p ,symbol) (display-graphic-p) ,symbol))
 
 (defun dotspacemacs/location ()
-  "Return the absolute path to the spacemacs dotfile."
-  dotspacemacs-filepath)
+  "Return the absolute path to the spacemacs dotfile.
+
+Error if the Spacemacs dotfile was not loaded due to command line arguments."
+  (if (and spacemacs-load-dotspacemacs
+           (not (eq 'template spacemacs-load-dotspacemacs)))
+      dotspacemacs-filepath
+    (error "Spacemacs started with --no-dotspacemacs or --default-dotspacemacs; cannot modify dotfile")))
 
 (defun dotspacemacs/copy-template ()
   "Copy `dotspacemacs-template.el' to `dotspacemacs-filepath'.
@@ -1133,7 +1138,7 @@ error recovery."
   (insert
    (format (concat "\n* Testing settings in dotspacemacs/layers "
                    "[[file:%s::dotspacemacs/layers][Show in File]]\n")
-           dotspacemacs-filepath))
+           (dotspacemacs/location)))
   ;; protect global values of these variables
   (let (dotspacemacs-additional-packages
         dotspacemacs-configuration-layer-path
@@ -1142,7 +1147,7 @@ error recovery."
         dotspacemacs-install-packages
         (passed-tests 0)
         (total-tests 0))
-    (load dotspacemacs-filepath)
+    (load (dotspacemacs/location))
     (dotspacemacs/layers)
     (spacemacs//test-list 'stringp
                           'dotspacemacs-configuration-layer-path
@@ -1160,12 +1165,12 @@ error recovery."
              (concat "** RESULTS: "
                      "[[file:%s::dotspacemacs/layers][dotspacemacs/layers]] "
                      "passed %s out of %s tests\n")
-             dotspacemacs-filepath passed-tests total-tests))
+             (dotspacemacs/location) passed-tests total-tests))
     (equal passed-tests total-tests)))
 
 (defmacro dotspacemacs||let-init-test (&rest body)
   "Macro to protect dotspacemacs variables"
-  `(let ((fpath dotspacemacs-filepath)
+  `(let ((fpath (dotspacemacs/location))
          ,@(mapcar (lambda (symbol)
                      `(,symbol ,(let ((v (symbol-value symbol)))
                                   (if (or (symbolp v) (listp v))
@@ -1181,7 +1186,7 @@ error recovery."
   (insert
    (format (concat "\n* Testing settings in dotspacemacs/init "
                    "[[file:%s::dotspacemacs/init][Show in File]]\n")
-           dotspacemacs-filepath))
+           (dotspacemacs/location)))
   (dotspacemacs||let-init-test
    (dotspacemacs/init)
    (spacemacs//test-var
@@ -1254,7 +1259,7 @@ error recovery."
             (concat "** RESULTS: "
                     "[[file:%s::dotspacemacs/init][dotspacemacs/init]] "
                     "passed %s out of %s tests\n")
-            dotspacemacs-filepath passed-tests total-tests))
+            (dotspacemacs/location) passed-tests total-tests))
    (equal passed-tests total-tests)))
 
 (defun dotspacemacs/test-dotfile (&optional hide-buffer)
@@ -1280,10 +1285,10 @@ Return non-nil if all the tests passed."
         (let (buffer-read-only)
           (erase-buffer)
           (insert (format "* Running tests on [[file:%s][%s]] (v%s)\n"
-                          dotspacemacs-filepath dotspacemacs-filepath "0.0"))
+                          (dotspacemacs/location) (dotspacemacs/location) "0.0"))
           ;; dotspacemacs-version not implemented yet
           ;; (insert (format "* Running tests on %s (v%s)\n"
-          ;;                 dotspacemacs-filepath dotspacemacs-version))
+          ;;                 (dotspacemacs/location) dotspacemacs-version))
           (prog1
               ;; execute all tests no matter what
               (cl-reduce (lambda (x y)

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -217,7 +217,7 @@ passed-tests and total-tests."
         (var-val (symbol-value var)))
     (when (boundp 'total-tests) (setq total-tests (1+ total-tests)))
     (insert (format "** TEST: [[file:%s::%s][%s]] %s\n"
-                    dotspacemacs-filepath var-name var-name test-desc))
+                    (dotspacemacs/location) var-name var-name test-desc))
     (if (funcall pred var-val)
         (progn
           (when (boundp 'passed-tests) (setq passed-tests (1+ passed-tests)))
@@ -232,10 +232,10 @@ result, incrementing passed-tests and total-tests."
         (varlist-val (symbol-value varlist)))
     (if element-desc
         (insert (format "** TEST: Each %s in [[file:%s::%s][%s]] %s\n"
-                        element-desc dotspacemacs-filepath varlist-name
+                        element-desc (dotspacemacs/location) varlist-name
                         varlist-name test-desc))
       (insert (format "** TEST: Each element of [[file:%s::%s][%s]] %s\n"
-                      dotspacemacs-filepath varlist-name varlist-name
+                      (dotspacemacs/location) varlist-name varlist-name
                       test-desc)))
     (dolist (var varlist-val)
       (when (boundp 'total-tests) (setq total-tests (1+ total-tests)))

--- a/doc/FAQ.org
+++ b/doc/FAQ.org
@@ -43,6 +43,7 @@
   - [[#make-spell-checking-support-curly-quotes-or-any-other-character][Make spell-checking support curly quotes (or any other character)?]]
   - [[#use-spacemacs-as-the-editor-for-git-commits][Use Spacemacs as the =$EDITOR= for git commits?]]
   - [[#try-spacemacs-without-modifying-my-existing-emacs-configuration][Try Spacemacs without modifying my existing Emacs configuration?]]
+  - [[#try-the-default-spacemacs-config-without-modifying-my-existing-spacemacs][Try the default Spacemacs config without modifying my existing .spacemacs?]]
   - [[#make-copypaste-working-with-the-mouse-in-x11-terminals][Make copy/paste working with the mouse in X11 terminals?]]
   - [[#use-helm-ag-to-search-only-in-files-of-a-certain-type][Use =helm-ag= to search only in files of a certain type?]]
   - [[#modify-spacemacs-documentation-look-space-doc-mode][Modify spacemacs documentation look (space-doc-mode)]]
@@ -542,6 +543,20 @@ the new configuration. This can be achieved easily using the following steps:
 
 If you're on Fish shell, you will need to modify the last command to:
 =env HOME=$HOME/spacemacs emacs=
+
+** Try the default Spacemacs config without modifying my existing .spacemacs?
+You can pass either the =--default-dotspacemacs= (recommended) or
+=--no-dotspacemacs= options on the command line:
+
+#+begin_src sh
+  emacs --default-dotspacemacs
+#+end_src
+
+=--default-dotspacemacs= inhibits loading your real =~/.spacemacs=,
+loading =dotspacemacs-template.el= instead.
+
+=--no-dotspacemacs= does the same, but does not load
+=dotspacemacs-template.el= either..
 
 ** Make copy/paste working with the mouse in X11 terminals?
 It is possible to disable the mouse support in X11 terminals in order to

--- a/layers/+completion/compleseus/local/compleseus-spacemacs-help/compleseus-spacemacs-help.el
+++ b/layers/+completion/compleseus/local/compleseus-spacemacs-help/compleseus-spacemacs-help.el
@@ -366,7 +366,7 @@ If EDIT is false, open org files in view mode."
 
 (defun compleseus-spacemacs-help//go-to-dotfile-variable (candidate)
   "Go to candidate in the dotfile."
-  (find-file dotspacemacs-filepath)
+  (find-file (dotspacemacs/location))
   (goto-char (point-min))
   ;; try to exclude comments
   (re-search-forward (format "^[a-z\s\\(\\-]*%s" candidate))

--- a/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
+++ b/layers/+completion/helm/local/helm-spacemacs-help/helm-spacemacs-help.el
@@ -389,7 +389,7 @@ open org files in view mode."
 
 (defun helm-spacemacs-help//go-to-dotfile-variable (candidate)
   "Go to candidate in the dotfile."
-  (find-file dotspacemacs-filepath)
+  (find-file (dotspacemacs/location))
   (goto-char (point-min))
   ;; try to exclude comments
   (re-search-forward (format "^[a-z\s\\(\\-]*%s" candidate))

--- a/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
+++ b/layers/+completion/ivy/local/ivy-spacemacs-help/ivy-spacemacs-help.el
@@ -381,7 +381,7 @@ If EDIT is false, open org files in view mode."
 
 (defun ivy-spacemacs-help//go-to-dotfile-variable (candidate)
   "Go to candidate in the dotfile."
-  (find-file dotspacemacs-filepath)
+  (find-file (dotspacemacs/location))
   (goto-char (point-min))
   ;; try to exclude comments
   (re-search-forward (format "^[a-z\s\\(\\-]*%s" candidate))


### PR DESCRIPTION
## Summary

This PR adds two command-line options for Spacemacs startup,
`--no-dotspacemacs` and `--default-dotspacemacs`.

`--no-dotspacemacs` inhibits loading the user's dotspacemacs file
(`dotspacemacs-filepath`).

`--default-dotspacemacs` inhibits loading the user's dotspacemacs
file, but also loads `dotspacemacs-template.el` when the user's
dotspacemacs would have been loaded.

In either case, take care to avoid deleting installed packages even if
the configuration would normally cause `dotspacemacs-install-packages`
to be `used-only`.

## Motivation

To simplify debugging Spacemacs issues that might be due to a bad
config, it is useful to have an easy way to suppress loading the
user's config and instead load Spacemacs's defaults.  This is
basically supposed to be like `emacs -q` except that `emacs -q` would
of course suppress loading Spacemacs itself.

Commands for working with, modifying, or visiting the user's
dotspacemacs are deliberately broken when these command-line options
are passed, to avoid confusion.  This is similar to how
customize-option behaves when `user-init-file` is nil (`emacs -q`).