### PR TITLE
[core] Allow selecting packages to update via CRM or embark

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2097,13 +2097,16 @@ to update."
                            (format " (skipped %s):\n" skipped-count)
                          ":\n"))
                upgrade-count) t)
+      (sort update-packages #'string<)
       (mapc (lambda (x)
               (spacemacs-buffer/append
-               (format (if (memq (intern x) dotspacemacs-frozen-packages)
+               (format (if (memq x dotspacemacs-frozen-packages)
                            "%s (won't be updated because package is frozen)\n"
                          "%s\n") x) t))
-            (sort (mapcar 'symbol-name update-packages) 'string<))
-      (setq configuration-layer--packages-to-update update-packages)
+            update-packages)
+      (setq update-packages (cl-set-difference update-packages
+                                               dotspacemacs-frozen-packages)
+            configuration-layer--packages-to-update update-packages)
       (if no-confirmation
           (configuration-layer//update-packages update-packages)
         (let ((answer (let ((read-answer-short t))

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -299,6 +299,9 @@
     (define-key embark-file-map "s" 'spacemacs/compleseus-search-from)
     (define-key embark-buffer-map "s" #'spacemacs/embark-consult-line-multi)
     (add-to-list 'embark-multitarget-actions #'spacemacs/embark-consult-line-multi)
+    ;; Allow using `embark-select' and `embark-act-all' instead of CRM to select packages
+    ;; to update in `configuration-layer/update-packages'.
+    (add-to-list 'embark-multitarget-actions 'configuration-layer/select-packages-to-update)
     (defvar spacemacs-embark-layer-map
       (let ((map (make-sparse-keymap)))
         (set-keymap-parent map embark-general-map)


### PR DESCRIPTION
Previously, selecting specific packages to update meant having to answer `yes-or-no-p` for each one. While a `list-packages` type of interface might be even better, I think this should be a clear improvement.

However, making selection work via embark requires some gymnastics (not sure if this is controversial).