### PR TITLE
* core/core-configuration-layer: Remove obsolate msg for :pre-layers/:owners

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -847,7 +847,7 @@ a new object."
                          "replacing it with layer %S.")
                  pkg-name (car (oref obj owners)) layer-name)))
       ;; last owner wins over the previous one
-      (object-add-to-list obj :owners layer-name))
+      (object-add-to-list obj 'owners layer-name))
     ;; check consistency between package and defined init functions
     (unless (or ownerp
                 (eq 'dotfile layer-name)
@@ -876,9 +876,9 @@ a new object."
                        "layer %S does not own it.")
                pkg-name layer-name)))
     (when (fboundp pre-init-func)
-      (object-add-to-list obj :pre-layers layer-name))
+      (object-add-to-list obj 'pre-layers layer-name))
     (when (fboundp post-init-func)
-      (object-add-to-list obj :post-layers layer-name))
+      (object-add-to-list obj 'post-layers layer-name))
     obj))
 
 (define-button-type 'help-dotfile-variable
@@ -1199,7 +1199,7 @@ USEDP if non-nil indicates that made packages are used packages."
         ;; set :toggle to t for user defined package should be enabled default
         (unless (listp pkg)
           (oset obj toggle t)
-          (object-add-to-list obj :owners 'dotfile t)))
+          (object-add-to-list obj 'owners 'dotfile t)))
       (configuration-layer//add-package obj usedp)))
   (dolist (xpkg dotspacemacs-excluded-packages)
     (let ((obj (configuration-layer/get-package xpkg)))


### PR DESCRIPTION
Avoid follow messages on Emacs-31, similar to the #16963, the latest Emacs-31 will give messages for accessing obj slot with keyword:  https://github.com/emacs-mirror/emacs/commit/ae1d01328f260f1a9891280c96139494629a83e8, 
> Accessing slot ‘pre-layers’ via obsolete initarg name ‘:pre-layers’ [3 times]
Accessing slot ‘post-layers’ via obsolete initarg name ‘:post-layers’ [3 times]
Accessing slot ‘owners’ via obsolete initarg name ‘:owners’ [54 times]