### PR TITLE
* layers/+spacemacs/spacemacs-modeline/packages: Use "spaceline" for use-package

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -100,7 +100,7 @@ Excluding which-key."
                  #'spacemacs//restore-buffers-powerline)))
 
 (defun spacemacs//prepare-diminish ()
-  (when spaceline-minor-modes-p
+  (when (bound-and-true-p spaceline-minor-modes-p)
     (let ((unicodep (dotspacemacs|symbol-value
                      dotspacemacs-mode-line-unicode-symbols)))
       (setq spaceline-minor-modes-separator

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -48,7 +48,8 @@
     (setq-default fancy-battery-show-percentage t)))
 
 (defun spacemacs-modeline/init-spaceline ()
-  (use-package spaceline-config
+  (use-package spaceline
+    :commands (spaceline-compile spaceline-define-segment)
     :init
     (add-hook 'spacemacs-post-user-config-hook
               'spacemacs/spaceline-config-startup-hook)
@@ -142,7 +143,7 @@
 
 (defun spacemacs-modeline/pre-init-spaceline-all-the-icons ()
   (when (eq 'all-the-icons (spacemacs/get-mode-line-theme-name))
-    (spacemacs|use-package-add-hook spaceline-config
+    (spacemacs|use-package-add-hook spaceline
       :pre-config
       (progn
         (require 'spaceline-all-the-icons)


### PR DESCRIPTION
The `spaceline-config` is **NOT** a package name, it's a feature in the package `spaceline`. 
This PR will use the correct package name `spaceline` for `use-package`. 