### PR TITLE
[version-control] Support auto select diff-hl-margin mode

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -53,11 +53,11 @@ You can choose the side on which the diff appears (by default it's the right sid
 #+END_SRC
 
 To automatically enable diff margins in all buffers, set
-=version-control-global-margin=
+=version-control-margin=
 
 #+BEGIN_SRC emacs-lisp
   '(version-control :variables
-                    version-control-global-margin t)
+                    version-control-margin 'global)
 #+END_SRC
 
 ** Differences between margin packages
@@ -73,6 +73,10 @@ one over the other:
 | Extended VCS support (e.g. hg, svn) | X       | X          |
 | Stage hunks from buffer             |         | X          |
 | Dired support                       | X       |            |
+
+The =diff-hl= or =git-gutter-fringe= supports GUI/Fringe, while the
+=diff-hl-margin= or =git-gutter= supports the TUI/Margin. Check the variable
+=version-control-margin= for how Spacemace selecting the margin features.
 
 * Key bindings
 VC commands (not exhaustive):

--- a/layers/+source-control/version-control/config.el
+++ b/layers/+source-control/version-control/config.el
@@ -24,9 +24,18 @@
 (defvar spacemacs--smerge-ts-full-hint-toggle nil
   "Display smerge transient-state documentation.")
 
-(spacemacs|defc version-control-global-margin t
-  "If non-nil, will show diff margins globally."
-  'boolean)
+(spacemacs|defc version-control-margin 'auto
+  "Options to apply the margin for diff-tool.
+
+For git-gutter it only checkes the option as nil or non-nil to
+activate/diactivate the margin feature.
+
+For diff-hl it supports:
+`auto'/t: Activate the margin feature for TTY frames,
+          and activate the fringe feature for graphic frame.
+`global': Activate the margin globally.
+`nil': do not activate the margin feature."
+  '(choice (const auto) (const global) boolean))
 
 (spacemacs|defc version-control-diff-tool 'diff-hl
   "Options are `diff-hl' (the preferred choice) or `git-gutter' to show

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -138,15 +138,20 @@
     :defer t
     :init
     (spacemacs/set-leader-keys "gv=" 'diff-hl-diff-goto-hunk)
-    (if version-control-global-margin
-        (progn
-          (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)
-          (run-with-idle-timer 1 nil 'global-diff-hl-mode))
-      (run-with-idle-timer 1 nil 'diff-hl-margin-mode))
-    :config
-    (spacemacs|do-after-display-system-init
-      (setq diff-hl-side (if (eq version-control-diff-side 'left)
-                             'left 'right)))))
+    (setq diff-hl-side (if (eq version-control-diff-side 'left)
+                           'left 'right))
+    (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)
+    (define-advice turn-on-diff-hl-mode (:after (&rest _) AUTOMARGIN)
+      (and (memq version-control-margin '(t auto))
+           (not diff-hl-margin-mode)    ; not global mode
+           (not (display-graphic-p (window-frame (get-buffer-window))))
+           (diff-hl-margin-local-mode)
+           (diff-hl-update)))
+    (when (eq version-control-margin 'global)
+        (run-with-idle-timer 1 nil 'spacemacs/vcs-enable-margin-globally))
+    ;; The diff-hl-margin mode requests the diff-hl-mode to be enabled, so
+    ;; enable the diff-hl-mode anyway.
+    (run-with-idle-timer 1 nil 'global-diff-hl-mode)))
 
 (defun version-control/post-init-evil-unimpaired ()
   (define-key evil-normal-state-map (kbd "[ h") 'spacemacs/vcs-previous-hunk)
@@ -157,7 +162,7 @@
     :defer t
     :init
     ;; If you enable global minor mode
-    (when version-control-global-margin
+    (when version-control-margin
       (run-with-idle-timer 1 nil 'global-git-gutter-mode))
     (setq git-gutter:update-interval 2
           git-gutter:modified-sign " "


### PR DESCRIPTION
I found a bug that `diff-hl` does not work for TUI, just enable the `version-control` in the `dotspacemacs-configuration-layers` then start Spacemacs in TUI:
```shell
$ emacs -nw # open a modified file in a git repo to verify the diff-hl does NOT work
$ emacs # the diff-hl will works with the graphic frame
```
It caused by the `diff-hl` works for the fringe (GUI) but does not work for the margin (TUI).

This PR will activate the `diff-hl-margin-local-mode` for the buffers in TUI.
NOTE: If a buffer is shared by a TUI frame and GUI frame, the `diff-hl` package only works on one of the frame.