### PR TITLE
Fix consult narrow tabbing.

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -79,8 +79,6 @@ Delete the narrowing key again to return to all selections.
 | Key binding | Description                                      |
 |-------------+--------------------------------------------------|
 | ~<~         | View narrowing commands available                |
-| ~C-left~    | Cycle left through narrowing commands available  |
-| ~C-right~   | Cycle right through narrowing commands available |
 
 ** Edit consult buffer
 

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -288,26 +288,20 @@ Note: this function relies on embark internals and might break upon embark updat
 (defun spacemacs/consult-narrow-cycle-backward ()
   "Cycle backward through the narrowing keys."
   (interactive)
-  (when consult--narrow-keys
-    (consult-narrow
-     (if consult--narrow
-         (let ((idx (seq-position consult--narrow-keys
-                                  (assq consult--narrow consult--narrow-keys))))
-           (unless (eq idx 0)
-             (car (nth (1- idx) consult--narrow-keys))))
-       (caar (last consult--narrow-keys))))))
+  (if (eq compleseus-engine 'vertico)
+      (vertico-previous-group)
+    (message "cycling between groups is only supported for vertico")
+    )
+  )
 
 (defun spacemacs/consult-narrow-cycle-forward ()
   "Cycle forward through the narrowing keys."
   (interactive)
-  (when consult--narrow-keys
-    (consult-narrow
-     (if consult--narrow
-         (let ((idx (seq-position consult--narrow-keys
-                                  (assq consult--narrow consult--narrow-keys))))
-           (unless (eq idx (1- (length consult--narrow-keys)))
-             (car (nth (1+ idx) consult--narrow-keys))))
-       (caar consult--narrow-keys)))))
+  (if (eq compleseus-engine 'vertico)
+      (vertico-next-group)
+    (message "cycling between groups is only supported for vertico")
+    )
+  )
 
 (defun spacemacs/consult-edit ()
   "Export the consult buffer and make the buffer editable righ away."

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -285,24 +285,6 @@ Note: this function relies on embark internals and might break upon embark updat
     ((eq major-mode 'org-mode) 'consult-org-heading)
     (t 'consult-imenu))))
 
-(defun spacemacs/consult-narrow-cycle-backward ()
-  "Cycle backward through the narrowing keys."
-  (interactive)
-  (if (eq compleseus-engine 'vertico)
-      (vertico-previous-group)
-    (message "cycling between groups is only supported for vertico")
-    )
-  )
-
-(defun spacemacs/consult-narrow-cycle-forward ()
-  "Cycle forward through the narrowing keys."
-  (interactive)
-  (if (eq compleseus-engine 'vertico)
-      (vertico-next-group)
-    (message "cycling between groups is only supported for vertico")
-    )
-  )
-
 (defun spacemacs/consult-edit ()
   "Export the consult buffer and make the buffer editable righ away."
   (interactive)

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -231,8 +231,6 @@
     ;; Optionally make narrowing help available in the minibuffer.
     ;; You may want to use `embark-prefix-help-command' or which-key instead.
     ;; (define-key consult-narrow-map (vconcat consult-narrow-key "?") #'consult-narrow-help)
-    (define-key consult-narrow-map [C-left] #'spacemacs/consult-narrow-cycle-backward)
-    (define-key consult-narrow-map [C-right] #'spacemacs/consult-narrow-cycle-forward)
 
     ;; Make M-n as smart as ivy and helm equivalents
     (setq minibuffer-default-add-function 'spacemacs/minibuffer-default-add-function)


### PR DESCRIPTION
Fix consult group tabbing feature.

When I tried to use the other one I got an error saying `consult--narrow-keys` was undefined. I don't know when it broke.

Use the `vertico-next-group` funcs instead.