### PR TITLE
[core] Do not reinitialize packages when loading default theme

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -399,7 +399,8 @@ again layer configuration."
             (spacemacs-buffer/warning
              (format-message "Your default theme %s requires full package initialization, negating the benefit of `dotspacemacs-enable-package-quickstart'."
                              theme-name)))
-          (package-initialize 'no-activate)
+          (unless package--initialized
+            (package-initialize 'no-activate))
           (package-activate pkg-name)
           (spacemacs//activate-theme-packages (list default-theme)))
         (condition-case _


### PR DESCRIPTION
This can happen and triggers a warning on startup, if the site-start
file initializes the package system but then Spacemacs also needs to
load the default theme from a package that isn't in site-lisp.