### PR TITLE
docs: Remove reference to PHP CBF

### DIFF
--- a/layers/+lang/php/README.org
+++ b/layers/+lang/php/README.org
@@ -33,7 +33,6 @@ This layer adds PHP language support to Spacemacs.
 - Edit Drupal files
 - Complete and jump to define with [[https://github.com/xcwen/ac-php][company-php]]
 - Run tests with PHPUnit
-- Reformat code with PHP CBF
 - Debug your programs with XDebug (via [[https://github.com/ahungry/geben][geben]] or [[https://github.com/emacs-lsp/dap-mode][dap-mode]])
 - Refactor source files with help of [[https://github.com/emacs-php/phpactor.el][phpactor.el]]
 - Support for the [[https://langserver.org/][Language Server Protocol]] (experimental)


### PR DESCRIPTION
The PHP CBF package was removed from this layer as a fix for #16259 but it still was mentioned as a feature in the docs.