### PR TITLE
[helm] Use function `helm-spacemacs-help-faq' from "helm-spacemacs-help" package

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -40,7 +40,6 @@
     helm-swoop
     helm-themes
     (helm-spacemacs-help :location local)
-    (helm-spacemacs-faq :location local)
     helm-xref
     imenu
     persp-mode
@@ -446,24 +445,20 @@
   (use-package helm-spacemacs-help
     :commands (helm-spacemacs-help-dotspacemacs
                helm-spacemacs-help
-               helm-spacemacs-help-faq
                helm-spacemacs-help-layers
                helm-spacemacs-help-packages
                helm-spacemacs-help-docs
                helm-spacemacs-help-toggles)
-    :init (spacemacs/set-leader-keys
-            "h ."   'helm-spacemacs-help-dotspacemacs
-            "h SPC" 'helm-spacemacs-help
-            "h f"   'helm-spacemacs-help-faq
-            "h l"   'helm-spacemacs-help-layers
-            "h p"   'helm-spacemacs-help-packages
-            "h r"   'helm-spacemacs-help-docs
-            "h t"   'helm-spacemacs-help-toggles)))
-
-(defun helm/init-helm-spacemacs-faq ()
-  (use-package helm-spacemacs-faq
-    :commands helm-spacemacs-help-faq
-    :init (spacemacs/set-leader-keys "h f" 'helm-spacemacs-help-faq)))
+    :init
+    (autoload 'helm-spacemacs-help-faq "helm-spacemacs-faq" nil t)
+    (spacemacs/set-leader-keys
+      "h ."   'helm-spacemacs-help-dotspacemacs
+      "h SPC" 'helm-spacemacs-help
+      "h f"   'helm-spacemacs-help-faq
+      "h l"   'helm-spacemacs-help-layers
+      "h p"   'helm-spacemacs-help-packages
+      "h r"   'helm-spacemacs-help-docs
+      "h t"   'helm-spacemacs-help-toggles)))
 
 (defun helm/init-helm-swoop ()
   (use-package helm-swoop


### PR DESCRIPTION
The `helm-spacemacs-help-faq` is not a package, it's part of `helm-spacemacs-help`. 
This change will refer the function correctly (follow the example on `use-package` page: https://github.com/jwiegley/use-package?tab=readme-ov-file#modes-and-interpreters ).