### PR TITLE
[core] Reduce configuration-layer/display-summary output to less chars for TTY

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -2487,7 +2487,8 @@ Return nil if MODE does not appear in `auto-mode-alist'."
     (with-current-buffer (get-buffer-create spacemacs-buffer-name)
       (let ((buffer-read-only nil))
         (spacemacs-buffer/append
-         (format "\n%s packages loaded in %.3f seconds. Location counts: %s"
+         ;; The messsage should less than 76 characters for tty frame
+         (format "\n%s packages loaded in %.3fs (%s)"
                  (cadr (assq 'total stats))
                  configuration-layer--spacemacs-startup-time
                  (string-join


### PR DESCRIPTION
The startup message was cut off on TTY frame, the line was enlarged in the #16957. 
This PR try to shrink the line to less 76 characters for TTY frame. 

Before (line was tuncated) and after (no-truncation):
```
401 packages loaded in 0.964 seconds. Location counts: elpa 312, recipe 21, loca$
   401 packages loaded in 0.964s (elpa 312, recipe 21, local 6, built-in 62)
```
