### PR TITLE
New option dotspacemacs-default-icons-font for icons in Spacemacs buffer

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -373,6 +373,11 @@ Point size is recommended, because it's device independent. (default 10.0)"
            (repeat (cons string sexp)))
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-default-icons-font 'all-the-icons
+  "Default icons font, it can be `all-the-icons' or `nerd-fonts'."
+  '(choice (const all-the-icons) (const nerd-icons))
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-folding-method 'evil
   "Code folding method. Possible values are `evil', `origami' and `vimish'."
   '(choice (const evil) (const origami) (const vimish))

--- a/core/templates/dotspacemacs-template.el
+++ b/core/templates/dotspacemacs-template.el
@@ -235,6 +235,9 @@ It should only modify the values of Spacemacs settings."
                                :weight normal
                                :width normal)
 
+   ;; Default icons font, it can be `all-the-icons' or `nerd-icons'.
+   dotspacemacs-default-icons-font 'all-the-icons
+
    ;; The leader key (default "SPC")
    dotspacemacs-leader-key "SPC"
 

--- a/layers/+spacemacs/spacemacs-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-visual/packages.el
@@ -28,7 +28,7 @@
         desktop
         (display-fill-column-indicator :location built-in)
         hl-todo
-        nerd-icons
+        (nerd-icons :toggle (eq dotspacemacs-default-icons-font 'nerd-icons))
         popup
         popwin
         posframe


### PR DESCRIPTION
New option `dotspacemacs-default-icons-font` for icons in Spacemacs buffer, Fix #16933.