### PR TITLE
[core] Avoid adding non-exists item into load-path for a local package

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1976,7 +1976,9 @@ RNAME is the name symbol of another existing layer."
                  (let* ((owner (configuration-layer/get-layer owner)))
                    (when owner (oref owner dir))))))
       (if dir
-          (file-name-as-directory (format "%slocal/%S/" dir pkg-name))
+          (and-let* ((path (format "%slocal/%S/" dir pkg-name))
+                     ((file-exists-p path)))
+            path)
         (configuration-layer//warning
          "Cannot find path location path for package %S." pkg-name)
         nil)))))


### PR DESCRIPTION
Mark package `page-break-lines` to be built-in, similar to the https://github.com/syl20bnr/spacemacs/blob/85c03aef74b73300d3714d7dde30608b96c38575/layers/%2Bspacemacs/spacemacs-completion/packages.el#L34

Original code will create a non-exists entry `../[layers/+spacemacs/spacemacs-defaults/local/page-break-lines` in the `load-path`. 