### PR TITLE
[core] Fix page-break-lines-mode running in the wrong buffer

### DIFF
--- a/.ci/built_in_manifest
+++ b/.ci/built_in_manifest
@@ -5,7 +5,6 @@ https://raw.githubusercontent.com/quelpa/quelpa/master/quelpa.el core/libs/quelp
 https://raw.githubusercontent.com/Malabarba/spinner.el/master/spinner.el core/libs/spinner.el
 https://raw.githubusercontent.com/melpa/package-build/master/package-build-badges.el core/libs/package-build-badges.el
 https://raw.githubusercontent.com/melpa/package-build/master/package-recipe.el core/libs/package-recipe.el
-https://raw.githubusercontent.com/purcell/page-break-lines/master/page-break-lines.el core/libs/page-break-lines.el
 https://raw.githubusercontent.com/nashamri/spacemacs-theme/master/spacemacs-theme.el core/libs/spacemacs-theme/spacemacs-theme.el
 https://raw.githubusercontent.com/nashamri/spacemacs-theme/master/spacemacs-dark-theme.el core/libs/spacemacs-theme/spacemacs-dark-theme.el
 https://raw.githubusercontent.com/nashamri/spacemacs-theme/master/spacemacs-light-theme.el core/libs/spacemacs-theme/spacemacs-light-theme.el

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -151,8 +151,6 @@ It's cleared when the idle timer runs.")
   :syntax-table nil
   :abbrev-table nil
   (buffer-disable-undo)
-  (with-eval-after-load 'page-break-lines
-    (page-break-lines-mode))
   (with-eval-after-load 'evil
     (progn
       (evil-set-initial-state 'spacemacs-buffer-mode 'motion)
@@ -342,10 +340,10 @@ Right justified, based on the Spacemacs buffers window width."
     (setq spacemacs-buffer--icons-font
           (or (pcase dotspacemacs-startup-buffer-show-icons
                 ('t (when (or (eq dotspacemacs-default-icons-font 'nerd-icons)
-                             (display-graphic-p))
-                     dotspacemacs-default-icons-font))
+                              (display-graphic-p))
+                      dotspacemacs-default-icons-font))
                 ('display-graphic-p (when (display-graphic-p)
-                                     dotspacemacs-default-icons-font)))
+                                      dotspacemacs-default-icons-font)))
               'none)))
   (unless (or skip-require
               (memq spacemacs-buffer--icons-font '(nil none))
@@ -1609,8 +1607,6 @@ If a prefix argument is given, switch to it in an other, possibly new window."
                                              80)
             spacemacs-buffer--last-width spacemacs-buffer--window-width)
       (with-current-buffer (get-buffer-create spacemacs-buffer-name)
-        (with-eval-after-load 'page-break-lines
-          (page-break-lines-mode))
         (save-excursion
           (when (> (buffer-size) 0)
             (setq save-line (line-number-at-pos))

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -355,7 +355,9 @@
 (defun spacemacs-defaults/init-page-break-lines ()
   (use-package page-break-lines
     :init (global-page-break-lines-mode t)
-    :config (spacemacs|hide-lighter page-break-lines-mode)))
+    :config
+    (spacemacs|hide-lighter page-break-lines-mode)
+    (add-to-list 'page-break-lines-modes 'spacemacs-buffer-mode)))
 
 (defun spacemacs-defaults/init-quickrun ()
   (use-package quickrun


### PR DESCRIPTION
with-eval-after-load does not guarantee that the buffer that is
current when it is encountered is still current when the body form is
eventually evaluated.

Instead of activating page-break-lines-mode in spacemacs-buffer-mode,
just add spacemacs-buffer-mode to page-break-lines-mode-modes (which
determines the behavior of global-page-break-lines-mode).