### PR TITLE
[core] Fix some user-specific files to live in user-emacs-directory

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -137,7 +137,7 @@ subdirectory of ROOT is used."
 It is populated by `configuration-layer/update-packages'.")
 
 (defconst configuration-layer--elpa-root-directory
-  (concat spacemacs-start-directory "elpa/")
+  (concat user-emacs-directory "elpa/")
   "Spacemacs ELPA root directory.")
 
 (defconst configuration-layer--rollback-root-directory

--- a/core/core-load-paths.el
+++ b/core/core-load-paths.el
@@ -82,7 +82,7 @@
 
 ;; ~/.emacs.d/private
 (defconst spacemacs-private-directory
-  (concat spacemacs-start-directory "private/")
+  (concat user-emacs-directory "private/")
   "Spacemacs private directory.")
 
 ;; ~/.emacs.d/tests


### PR DESCRIPTION
`spacemacs-start-directory` may be a shared, read-only folder if site
administrators decide to distribute a copy of Spacemacs with Emacs.
However, user-specific files like ELPA packages and private snippets
should be stored in `user-emacs-directory` in that case.

(The set of installed ELPA packages depends on the user's
dotspacemacs, and the private snippets are obviously user-specific.
Site administrators can set up shared snippets in some other location.)