### PR TITLE
[core] Remove unnecessary require for pgp package

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -22,7 +22,6 @@
 
 
 (require 'cl-lib)
-(require 'epg)
 (require 'eieio)
 (require 'subr-x)
 (require 'package)
@@ -2693,6 +2692,8 @@ MSG is an additional message append to the generic error."
                    "Do you still want to install the stable ELPA repository ?")
            configuration-layer-stable-elpa-name
            reason)))
+
+(autoload 'epg-context-home-directory "epg") ; autoload it for it's in setf
 
 (defun configuration-layer//stable-elpa-verify-archive ()
   "Verify the downloaded stable ELPA repository archive.


### PR DESCRIPTION
Remove the unnecessary line for better performance. The `(require 'epg)` took 0.015s during Spacemacs startup on my local.
The `epg-*` functions were called in the `configuration-layer//stable-elpa-verify-archive` but this function will **NOT** be called after installation; it's called for install packages. So remove it by adding autoload lines for better performance. 