### PR TITLE
* layers/+misc/dtrt-indent/packages: Explicitly denote the lambda as function

### DIFF
--- a/layers/+misc/dtrt-indent/packages.el
+++ b/layers/+misc/dtrt-indent/packages.el
@@ -25,10 +25,9 @@
 
 (defun dtrt-indent/init-dtrt-indent ()
   (use-package dtrt-indent
-    :hook (prog-mode .
-              (lambda ()
-                (dtrt-indent-mode)
-                (dtrt-indent-adapt)))
+    :hook (prog-mode . #'(lambda ()
+                           (dtrt-indent-mode)
+                           (dtrt-indent-adapt)))
     :config
     (spacemacs|hide-lighter dtrt-indent-mode)))
 


### PR DESCRIPTION
Got an error with latest Emacs master branch:
`error: (void-variable body)`
Mark the lambda as function explicitly will resolve the issue. 