### PR TITLE
[denote] Add new layer for Denote package integration

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -468,6 +468,7 @@ both Racer and RLS not being maintained anymore.
 **** Misc
 - tree-sitter
 - copy-as-format (thanks to Ruslan Kamashev)
+- denote (thanks to Choan Gálvez)
 - dtrt-indent (thanks to Kevin Doherty)
 - ietf (thanks to Christian Hopps and Robby O'Connor)
 - multiple-cursors (thanks to Codruț Constantin Gușoi and Thomas de Beauchêne)

--- a/layers/+misc/denote/README.org
+++ b/layers/+misc/denote/README.org
@@ -1,0 +1,48 @@
+#+TITLE: Denote layer
+#+TAGS: layer|misc
+
+* Table of Contents                                       :TOC_4_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#key-bindings][Key bindings]]
+
+* Description
+Adds the [[https://protesilaos.com/emacs/denote][denote package]] and related tools for note taking.
+
+** Features:
+  - Simple notes for Emacs with an efficient file-naming scheme
+  - List and filter notes in a tabulated view using =denote-menu=
+  - Consult notes via =consult-denote= if the =compleseus= layer is active
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =denote= to the existing =dotspacemacs-configuration-layers= list in this
+file.
+
+* Key bindings
+
+| Key Binding | Description                                                            |
+|-------------+------------------------------------------------------------------------|
+| ~SPC a D n~ | Create a new note with the appropriate metadata and file name.         |
+| ~SPC a D d~ | Produce Dired buffer with sorted files from variable denote-directory. |
+| ~SPC a D g~ | Search QUERY in the content of Denote files.                           |
+| ~SPC a D r~ | Rename file and update existing front matter if appropriate.           |
+| ~SPC a D R~ | Rename FILE using its front matter as input.                           |
+| ~SPC a D m~ | Display list of Denote files in variable ~denote-directory~.           |
+
+When the =compleseus= layer is active, the following additional keybindings are available:
+
+| Key Binding | Description |
+|-------------+-------------|
+| ~SPC a D f~ |             |
+| ~SPC a D g~ |             |
+
+On =denote-menu= buffers, the following mode specific keybindings are available:
+
+| Key Binding | Description                                                            |
+|-------------+------------------------------------------------------------------------|
+| ~SPC m /~   | Filter tabulated list entries matching REGEXP.                         |
+| ~SPC m k~   | Prompt for KEYWORDS and filters the list accordingly.                  |
+| ~SPC m c~   | Reset filters and update buffer.                                       |
+| ~SPC m e~   | Switch to variable denote-directory and mark filtered *Denotes* files. |

--- a/layers/+misc/denote/README.org
+++ b/layers/+misc/denote/README.org
@@ -33,10 +33,10 @@ file.
 
 When the =compleseus= layer is active, the following additional keybindings are available:
 
-| Key Binding | Description |
-|-------------+-------------|
-| ~SPC a D f~ |             |
-| ~SPC a D g~ |             |
+| Key Binding | Description         |
+|-------------+---------------------|
+| ~SPC a D f~ | consult-denote-find |
+| ~SPC a D g~ | consult-denote-grep |
 
 On =denote-menu= buffers, the following mode specific keybindings are available:
 

--- a/layers/+misc/denote/packages.el
+++ b/layers/+misc/denote/packages.el
@@ -1,0 +1,65 @@
+;;; packages.el --- denote layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
+;;
+;; Author: Choan Gálvez <choan@choan.es>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(defconst denote-packages
+  '(denote
+    denote-menu
+    (consult-denote :toggle (configuration-layer/layer-used-p 'compleseus)))
+  "The list of Lisp packages required by the denote layer.")
+
+(defun denote/init-denote ()
+  (use-package denote
+    :defer t
+    :hook
+    (dired-mode . denote-dired-mode)
+    :init
+    (spacemacs/declare-prefix "aD" "denote")
+    (spacemacs/set-leader-keys
+      "aDn" 'denote
+      "aDd" 'denote-dired
+      "aDg" 'denote-grep
+      "aDr" 'denote-rename-file
+      "aDR" 'denote-rename-file-using-front-matter)))
+
+(defun denote/init-denote-menu ()
+  (use-package denote-menu
+    :defer t
+    :after denote
+    :init
+    (spacemacs/set-leader-keys
+      "aDm" 'denote-menu-list-notes)
+    (spacemacs/set-leader-keys-for-major-mode 'denote-menu-mode
+      "/" 'denote-menu-filter
+      "k" 'denote-menu-filter-by-keyword
+      "c" 'denote-menu-clear-filters
+      "e" 'denote-menu-export-to-dired)))
+
+(defun denote/init-consult-denote ()
+  (use-package consult-denote
+    :defer t
+    :after denote
+    :init
+    (spacemacs/set-leader-keys
+      "aDf" 'consult-denote-find
+      "aDg" 'consult-denote-grep)))


### PR DESCRIPTION
Introduce a new layer for the Denote package, enabling efficient note-taking in Emacs. This layer includes support for Denote, Denote Menu, and optional integration with Consult Denote when the Compleseus layer is active.

Closes #15966 
