### PR TITLE
[spacemacs-bootstrap] Remove unused "system-packages" from bootstrap

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -32,7 +32,6 @@
     (evil :step bootstrap)
     (hydra :step bootstrap)
     (use-package :step bootstrap)
-    (system-packages :step bootstrap)
     (which-key :step bootstrap)
     ;; pre packages, initialized after the bootstrap packages
     ;; these packages can use use-package
@@ -346,9 +345,6 @@
 
 (defun spacemacs-bootstrap/init-use-package ()
   (spacemacs/use-package-extend))
-
-(defun spacemacs-bootstrap/init-system-packages ()
-  (use-package system-packages))
 
 (defun spacemacs-bootstrap/init-which-key ()
   (require 'which-key)


### PR DESCRIPTION
The package `system-packages` is not used, remove it from bootstrap.