### PR TITLE
[core] Load the projects list without activating the projectile-mode

### DIFF
--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1277,7 +1277,7 @@ LIST: list of `org-agenda' entries in the todo list."
     (when (string-prefix-p (car x) (expand-file-name recent-file))
       (setcdr x (cons (string-remove-prefix (car x) recent-file) (cdr x))))))
 
-(autoload #'projectile-known-projects "projectile")
+(autoload 'projectile-known-projects "projectile")
 (defun spacemacs-buffer//recent-files-by-project ()
   (let ((by-project (mapcar (lambda (p) (cons (expand-file-name p) nil))
                             (projectile-known-projects))))

--- a/core/core-spacemacs-buffer.el
+++ b/core/core-spacemacs-buffer.el
@@ -1277,9 +1277,10 @@ LIST: list of `org-agenda' entries in the todo list."
     (when (string-prefix-p (car x) (expand-file-name recent-file))
       (setcdr x (cons (string-remove-prefix (car x) recent-file) (cdr x))))))
 
+(autoload #'projectile-known-projects "projectile")
 (defun spacemacs-buffer//recent-files-by-project ()
   (let ((by-project (mapcar (lambda (p) (cons (expand-file-name p) nil))
-                            (projectile-relevant-known-projects))))
+                            (projectile-known-projects))))
     (dolist (recent-file recentf-list by-project)
       (spacemacs-buffer//associate-to-project recent-file by-project))))
 
@@ -1366,7 +1367,6 @@ startup list.")
 
 (defun spacemacs-buffer//insert-recent-files-by-project (list-size)
   (unless recentf-mode (recentf-mode))
-  (unless projectile-mode (projectile-mode))
   (when (spacemacs-buffer//insert-files-by-dir-list
          (spacemacs-buffer||propertize-heading
           (spacemacs-buffer//font-icons-icon "" 'rocket)
@@ -1416,12 +1416,11 @@ startup list.")
     (insert spacemacs-buffer-list-separator)))
 
 (defun spacemacs-buffer//insert-projects (list-size)
-  (unless projectile-mode (projectile-mode))
   (when (spacemacs-buffer//insert-file-list
          (spacemacs-buffer||propertize-heading
           (spacemacs-buffer//font-icons-icon "" 'rocket)
           "Projects:" "p")
-         (spacemacs//subseq (projectile-relevant-known-projects)
+         (spacemacs//subseq (projectile-known-projects)
                             0 list-size))
     (spacemacs-buffer||add-shortcut "p" "Projects:")
     (insert spacemacs-buffer-list-separator)))


### PR DESCRIPTION
Use the function `(projectile-known-projects)` to replace the function `(projectile-relevant-known-projects)` for correctly getting the project list.

This patch will:
1. don't active the `projectile-mode` in spacemacs-buffer
2. just load the projects by projectile function `projectile-known-projects` which was introduced in the commit https://github.com/bbatsov/projectile/commit/373fca78904330cc130604c9490c4e0785df7c4d.

The `projectile` is part of `+distributions/spacemacs/`:
https://github.com/syl20bnr/spacemacs/blob/cc9b605bc2d00cbb2ddeb5e026ba12deb435bbd2/layers/%2Bdistributions/spacemacs/layers.el#L43
And it's activated in the function `spacemacs-project/init-projectile`.

The `projectile-mode` is **NOT** part of `+distributions/spacemacs-base/`:
https://github.com/syl20bnr/spacemacs/blob/cc9b605bc2d00cbb2ddeb5e026ba12deb435bbd2/layers/%2Bdistributions/spacemacs-base/layers.el#L28
But it was activated in the `(spacemacs-buffer//insert-projects)` even user selected the `spacemacs-base` as `dotspacemacs-distribution`. 