### PR TITLE
[core] Don't run mode hooks when dumping variables

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -99,7 +99,7 @@ and its values are removed."
   "simplistic dumping of variables in VARLIST to a file FILENAME"
   (with-temp-file filename
     (spacemacs/dump-vars varlist (current-buffer))
-    (emacs-lisp-mode)
+    (delay-mode-hooks (emacs-lisp-mode))
     (elisp-enable-lexical-binding)
     (make-directory (file-name-directory filename) t)))
 


### PR DESCRIPTION
This is unnecessary, and may cause problems if packages haven't been
fully initialized yet but have already been added to prog-mode-hook.

Fix #17009