### PR TITLE
init.el: Prevent unnecessarily calling server-start in some cases

### DIFF
--- a/init.el
+++ b/init.el
@@ -66,6 +66,6 @@
       (require 'server)
       (when dotspacemacs-server-socket-dir
         (setq server-socket-dir dotspacemacs-server-socket-dir))
-      (unless (server-running-p)
+      (unless (or (daemonp) (server-running-p))
         (message "Starting a server...")
         (server-start)))))

--- a/init.el
+++ b/init.el
@@ -62,7 +62,7 @@
     (configuration-layer/load)
     (spacemacs-buffer/display-startup-note)
     (spacemacs/setup-startup-hook)
-    (when dotspacemacs-enable-server
+    (when (and dotspacemacs-enable-server (not noninteractive))
       (require 'server)
       (when dotspacemacs-server-socket-dir
         (setq server-socket-dir dotspacemacs-server-socket-dir))


### PR DESCRIPTION
Namely, don't call `(server-start)`, even when
`dotspacemacs-enable-server` is non-nil, in the following cases:

1. `emacs --batch -u ""` (normally --batch disables reading the user's
   init file such as Spacemacs, but it is a reasonable use-case to
   run a batch Spacemacs)
2. `emacs --daemon`

Normally it is harmless to run `(server-start)` explicitly when Emacs
is started as a daemon, but on some versions of Emacs this can
interfere with error handling at startup, and in any case it is
redundant and should be left to the normal Emacs command-line
handling.