### PR TITLE
[slack] Remove `select-all-unreads` from Slack menu

### DIFF
--- a/layers/+chat/slack/README.org
+++ b/layers/+chat/slack/README.org
@@ -67,13 +67,14 @@ By default the values are:
 | Key binding   | Description                              |
 |---------------+------------------------------------------|
 | ~SPC a c s T~ | Show all threads followed in a workspace |
+| ~SPC a c s a~ | Show activity feed                       |
 | ~SPC a c s d~ | Direct message someone                   |
 | ~SPC a c s g~ | Join a group (private channel)           |
 | ~SPC a c s j~ | Join a channel                           |
 | ~SPC a c s q~ | Close connection                         |
 | ~SPC a c s r~ | Join a channel, group, or direct messge  |
 | ~SPC a c s s~ | (Re)connects to Slack                    |
-| ~SPC a c s u~ | Show all unread in a workspace           |
+| ~SPC a c s u~ | Show unread rooms                        |
 | ~SPC m (~     | Remove reaction (emoji) to a message     |
 | ~SPC m )~     | Add reaction (emoji) to a message        |
 | ~SPC m c~     | Embed mention of channel                 |

--- a/layers/+chat/slack/packages.el
+++ b/layers/+chat/slack/packages.el
@@ -67,13 +67,14 @@
     (spacemacs/declare-prefix "acs" "slack")
     (spacemacs/set-leader-keys
       "acsT" 'slack-all-threads
+      "acsa" 'slack-activity-feed-show
       "acsd" 'slack-im-select
       "acsg" 'slack-group-select
       "acsj" 'slack-channel-select
       "acsq" 'slack-ws-close
       "acsr" 'slack-select-rooms
       "acss" 'slack-start
-      "acsu" 'slack-all-unreads)
+      "acsu" 'slack-select-unread-rooms)
     (setq slack-enable-emoji t)
     :config
     (dolist (mode '(slack-mode slack-message-buffer-mode slack-thread-message-buffer-mode))
@@ -83,6 +84,7 @@
         ")" 'slack-message-add-reaction
         "@" 'slack-message-embed-mention
         "T" 'slack-all-threads
+        "a" 'slack-activity-feed-show
         "d" 'slack-im-select
         "e" 'slack-message-edit
         "g" 'slack-group-select
@@ -94,7 +96,7 @@
         "q" 'slack-ws-close
         "r" 'slack-select-rooms
         "t" 'slack-thread-show-or-create
-        "u" 'slack-all-unreads)
+        "u" 'slack-select-unread-rooms)
       (let ((keymap (symbol-value (intern (concat (symbol-name mode) "-map")))))
         (evil-define-key 'insert keymap
           (kbd "#") 'slack-message-embed-channel


### PR DESCRIPTION
This function has been [removed](https://github.com/emacs-slack/emacs-slack/commit/7c5f37caf7da61e6aa42ce7f37423a46a78c30a5) from emacs-slack due to API updates.

I've replaced it with `slack-activity-feed-show` and `slack-select-unread-rooms` which seem the most appropriate.