### PR TITLE
[python] Less condition for enabling pet-mode

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -354,9 +354,9 @@ This will allow you to use [[https://github.com/pwalsh/pipenv.el][pipenv]] bindi
 You can add to the other two lists analogously.
 
 * Management of Python versions and virtual environments
-In general virtual environments are automatically used when active
-using [[https://github.com/wyuenho/emacs-pet][pet-mode]], this requires the
-following additional packages to be available in your path:
+In general virtual environments are automatically used when active using
+[[https://github.com/wyuenho/emacs-pet][pet-mode]], following additional packages are high recommended to enable full
+~pet-mode~ features:
 
 | Package   | Description                                   |
 |-----------+-----------------------------------------------|

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -66,10 +66,7 @@
 
 (defun python/init-pet ()
   (use-package pet
-    :hook (python-base-mode . pet-mode)
-    :if (and (executable-find "dasel")
-             (executable-find "sqlite3"))
-    :defer t))
+    :hook (python-base-mode . pet-mode)))
 
 (defun python/init-anaconda-mode ()
   (use-package anaconda-mode


### PR DESCRIPTION
Currently Spacemacs only activates the `pet-mode` when the `dasel` and `sqlite3` installed.
But exists users may not notice this requirement, does not install these two commands, then pet-mode does not been activated automatically. 

The command `dasel` or `sqlite3` are required to parse the `pyproject.toml`, `Pipfile`, `environment*.y*ml`... in `pet-mode`.

**Without** the `dasel` or `sqlite3`, `pet-mode` still works for 
a) non-virtualenv case: there is no virtual envrionment, like a `~/proj1/test.py` works towards to `/usr/bin/python`.
b) simple local `.venv` case: `python3 -m venv ~/proj1/.venv`, then open the `~/proj1/test.py`.

So we can loosen the condition for activating the `pet-mode` to make it works on the two cases.