### PR TITLE
[layers/+lang/gleam] switch to gleam-ts-mode

### DIFF
--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -314,6 +314,9 @@ as follows:
 #+BEGIN_SRC emacs-lisp
   (defconst mylayer-packages
     '(
+      ;; A built-in package
+      (some-package :location built-in)
+
       ;; Get the package from MELPA, ELPA, etc.
       some-package
       (some-package :location elpa)
@@ -335,7 +338,7 @@ as follows:
 #+END_SRC
 
 The =:location= attribute specifies where the package may be found. Spacemacs
-currently supports packages on ELPA compliant repositories, local packages,
+currently supports packages on ELPA compliant repositories, built-in packages, local packages,
 remote packages hosted on Git repositories (including specific helpers for
 GitHub, GitLab, and Bitbucket) and MELPA recipes (through the Quelpa package).
 Local packages should reside at =<layer>/local/<package>/=.

--- a/layers/+lang/gleam/README.org
+++ b/layers/+lang/gleam/README.org
@@ -18,7 +18,8 @@
   - [[#execution-1][Execution]]
 
 * Description
-This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-ts-mode]] package and [[https://github.com/emacsmirror/tree-sitter-indent][tree-sitter-indent]].
+This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-ts-mode]] package and requires Emacs to be compiled with treesit support (built-in with version 29+).
+To check that the treesit package is installed, you can run =M: (treesit-available-p)=.
 
 ** Features:
 - [[https://gleam.run/news/v0.21-introducing-the-gleam-language-server/][Gleam language server]] integration

--- a/layers/+lang/gleam/README.org
+++ b/layers/+lang/gleam/README.org
@@ -18,7 +18,7 @@
   - [[#execution-1][Execution]]
 
 * Description
-This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-mode]] package and [[https://github.com/emacsmirror/tree-sitter-indent][tree-sitter-indent]].
+This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-ts-mode]] package and [[https://github.com/emacsmirror/tree-sitter-indent][tree-sitter-indent]].
 
 ** Features:
 - [[https://gleam.run/news/v0.21-introducing-the-gleam-language-server/][Gleam language server]] integration
@@ -51,7 +51,7 @@ When enabled, the =gleam-lsp= server will be automatically initialized when visi
 More details can be found in the [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%2Btools/lsp#configuration][lsp layer configuration section]].
 
 ** Formatting
-=gleam-mode= provides the ~gleam-format~ command (~SPC m = =~) to format source code in the official Gleam style.
+=gleam-ts-mode= provides the ~gleam-ts-format~ command (~SPC m = =~) to format source code in the official Gleam style.
 
 To automatically apply formatting files before saving:
 

--- a/layers/+lang/gleam/config.el
+++ b/layers/+lang/gleam/config.el
@@ -21,7 +21,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(spacemacs|define-jump-handlers gleam-mode)
+(spacemacs|define-jump-handlers gleam-ts-mode)
 
 (defvar gleam-format-on-save nil
   "If non-nil, automatically run gleam-format before save. Default is nil.")

--- a/layers/+lang/gleam/funcs.el
+++ b/layers/+lang/gleam/funcs.el
@@ -28,18 +28,26 @@
   (when gleam-enable-lsp (lsp-deferred)))
 
 
+;; treesit
+
+(defun spacemacs//gleam-setup-treesit ()
+  "Install treesit grammar"
+  (unless (treesit-language-available-p 'gleam)
+    (gleam-ts-install-grammar)))
+
+
 ;; formatting
 
 (defun spacemacs//gleam-format ()
-"Ran before saving a file when `gleam-format-on-save' is non-nil.
-Either `lsp-format-buffer' when `lsp-mode' is active, `gleam-format' otherwise."
+  "Ran before saving a file when `gleam-format-on-save' is non-nil.
+Either `lsp-format-buffer' when `lsp-mode' is active, `gleam-ts-format' otherwise."
   (if lsp-mode
       (lsp-format-buffer)
-    (gleam-format)))
+    (gleam-ts-format)))
 
 (defun spacemacs//gleam-setup-format-on-save ()
   "Conditionally setup format on save."
-  (funcall (if gleam-format-on-save 'add-hook 'remove-hook) 'gleam-mode-hook
+  (funcall (if gleam-format-on-save 'add-hook 'remove-hook) 'gleam-ts-mode-hook
            (lambda () (add-hook 'before-save-hook 'spacemacs//gleam-format nil t))))
 
 (defun spacemacs//gleam-toggle-format-on-save ()

--- a/layers/+lang/gleam/layers.el
+++ b/layers/+lang/gleam/layers.el
@@ -22,5 +22,5 @@
 
 
 (configuration-layer/declare-layer-dependencies
-  (append '(tree-sitter)
+ (append '(tree-sitter)
          (if (and (boundp 'gleam-enable-lsp) gleam-enable-lsp) '(lsp) '())))

--- a/layers/+lang/gleam/packages.el
+++ b/layers/+lang/gleam/packages.el
@@ -22,34 +22,32 @@
 
 
 (defconst gleam-packages
-  '((tree-sitter-indent)
-    (gleam-mode :location (recipe
-                           :fetcher github
-                           :repo "gleam-lang/gleam-mode"
-                           :files ("*.el" "tree-sitter-gleam")))))
+  '((treesit)
+    (gleam-ts-mode)))
 
-(defun gleam/post-init-tree-sitter-indent ()
-  "Initialize tree-sitter-indent"
-  (use-package tree-sitter-indent
+(defun gleam/post-init-treesit ()
+  "Initialize treesit"
+  (use-package treesit
     :defer t))
 
-(defun gleam/init-gleam-mode ()
-  "Initialize gleam-mode"
-  (use-package gleam-mode
-    :mode ("\\.gleam\\'" . gleam-mode)
-    :hook ((gleam-mode . spacemacs//gleam-setup-format-on-save)
-           (gleam-mode . spacemacs//gleam-setup-lsp))
+(defun gleam/init-gleam-ts-mode ()
+  "Initialize gleam-ts-mode"
+  (use-package gleam-ts-mode
+    :mode ("\\.gleam\\'" . gleam-ts-mode)
+    :hook ((gleam-ts-mode . spacemacs//gleam-setup-format-on-save)
+           (gleam-ts-mode . spacemacs//gleam-setup-lsp))
     :config
-    (spacemacs/declare-prefix-for-mode 'gleam-mode "m=" "format")
-    (spacemacs/declare-prefix-for-mode 'gleam-mode "mc" "compile")
-    (spacemacs/declare-prefix-for-mode 'gleam-mode "mg" "goto")
-    (spacemacs/declare-prefix-for-mode 'gleam-mode "mt" "tests")
-    (spacemacs/declare-prefix-for-mode 'gleam-mode "mT" "toggle")
-    (spacemacs/set-leader-keys-for-major-mode 'gleam-mode
-        "==" 'gleam-format
-        "cb" 'spacemacs//gleam-build
-        "cc" 'spacemacs//gleam-run
-        "cm" 'spacemacs//gleam-run-module
-        "ca" 'spacemacs//gleam-run-project
-        "ta" 'spacemacs//gleam-test-project
-        "T=" 'spacemacs//gleam-toggle-format-on-save)))
+    (spacemacs//gleam-setup-treesit)
+    (spacemacs/declare-prefix-for-mode 'gleam-ts-mode "m=" "format")
+    (spacemacs/declare-prefix-for-mode 'gleam-ts-mode "mc" "compile")
+    (spacemacs/declare-prefix-for-mode 'gleam-ts-mode "mg" "goto")
+    (spacemacs/declare-prefix-for-mode 'gleam-ts-mode "mt" "tests")
+    (spacemacs/declare-prefix-for-mode 'gleam-ts-mode "mT" "toggle")
+    (spacemacs/set-leader-keys-for-major-mode 'gleam-ts-mode
+      "==" 'gleam-ts-format
+      "cb" 'spacemacs//gleam-build
+      "cc" 'spacemacs//gleam-run
+      "cm" 'spacemacs//gleam-run-module
+      "ca" 'spacemacs//gleam-run-project
+      "ta" 'spacemacs//gleam-test-project
+      "T=" 'spacemacs//gleam-toggle-format-on-save)))

--- a/layers/+lang/gleam/packages.el
+++ b/layers/+lang/gleam/packages.el
@@ -25,13 +25,10 @@
   '((treesit)
     (gleam-ts-mode)))
 
-(defun gleam/post-init-treesit ()
-  "Initialize treesit"
-  (use-package treesit
-    :defer t))
-
 (defun gleam/init-gleam-ts-mode ()
   "Initialize gleam-ts-mode"
+  (unless (treesit-available-p)
+    (error "Gleam layer requires Emacs to be compiled with treesit support (built-in with Emacs 29+)"))
   (use-package gleam-ts-mode
     :mode ("\\.gleam\\'" . gleam-ts-mode)
     :hook ((gleam-ts-mode . spacemacs//gleam-setup-format-on-save)

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2396,7 +2396,8 @@ Features:
 **** Gleam
 [[file:+lang/gleam/README.org][+lang/gleam/README.org]]
 
-This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-ts-mode]] package and [[https://github.com/emacsmirror/tree-sitter-indent][treesit]].
+This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-ts-mode]] package and requires Emacs to be compiled with treesit support (built-in with version 29+).
+To check that the treesit package is installed, you can run =M: (treesit-available-p)=.
 
 Features:
 - [[https://gleam.run/news/v0.21-introducing-the-gleam-language-server/][Gleam language server]] integration

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2396,7 +2396,7 @@ Features:
 **** Gleam
 [[file:+lang/gleam/README.org][+lang/gleam/README.org]]
 
-This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-mode]] package and [[https://github.com/emacsmirror/tree-sitter-indent][tree-sitter-indent]].
+This layers adds support for [[https://gleam.run/][Gleam]]. It relies on the official [[https://github.com/gleam-lang/gleam-mode][gleam-ts-mode]] package and [[https://github.com/emacsmirror/tree-sitter-indent][treesit]].
 
 Features:
 - [[https://gleam.run/news/v0.21-introducing-the-gleam-language-server/][Gleam language server]] integration


### PR DESCRIPTION
fix #16977 

This PR fixes the `gleam` layer  after [gleam-mode](https://github.com/gleam-lang/gleam-mode/blob/8656c4080dd2bb7dd6d6167953d6463d090509b0/gleam-mode.el) got deprecated in favor of [gleam-ts-mode](https://github.com/gleam-lang/gleam-mode/blob/main/gleam-ts-mode.el), which is now available on MELPA.