### PR TITLE
[completion] Clear up wrap function for helm-swoop

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -466,8 +466,7 @@
     :init
     (setq helm-swoop-split-with-multiple-windows t
           helm-swoop-split-direction 'split-window-vertically
-          helm-swoop-split-window-function 'spacemacs/helm-swoop-split-window-function
-          helm-swoop-pre-input-function (lambda () ""))
+          helm-swoop-split-window-function 'spacemacs/helm-swoop-split-window-function)
 
     (defun spacemacs/helm-swoop-split-window-function (&rest args)
       "Override to make helm settings (like `helm-split-window-default-side') work"
@@ -475,18 +474,6 @@
             (helm-full-frame nil)
             (pop-up-windows t))
         (apply 'helm-default-display-buffer args)))
-
-    (defun spacemacs/helm-swoop-region-or-symbol ()
-      "Call `helm-swoop' with default input."
-      (interactive)
-      (let ((helm-swoop-pre-input-function
-             (lambda ()
-               (if (region-active-p)
-                   (buffer-substring-no-properties (region-beginning)
-                                                   (region-end))
-                 (let ((thing (thing-at-point 'symbol t)))
-                   (if thing thing ""))))))
-        (call-interactively 'helm-swoop)))
 
     (defun spacemacs/helm-swoop-clear-cache ()
       "Call `helm-swoop--clear-cache' to clear the cache"
@@ -497,7 +484,7 @@
     (spacemacs/set-leader-keys
       "sC"    'spacemacs/helm-swoop-clear-cache
       "ss"    'helm-swoop
-      "sS"    'spacemacs/helm-swoop-region-or-symbol
+      "sS"    'helm-multi-swoop
       "s C-s" 'helm-multi-swoop-all)
 
     (evil-add-command-properties 'helm-swoop :jump t)))


### PR DESCRIPTION
According to the `helm-swoop` document, the wrap function `spacemacs/helm-swoop-region-or-symbol` is no longer needed. And I tried the `helm-swoop` and can confirm it works as the document described.
https://github.com/emacsorphanage/helm-swoop/blob/df90efd4476dec61186d80cace69276a95b834d2/helm-swoop.el#L75-L78
```emacs-lisp
;; * `M-x helm-swoop` when region active
;; * `M-x helm-swoop` when the cursor is at any symbol
;; * `M-x helm-swoop` when the cursor is not at any symbol
```