### PR TITLE
[python] Recall the pyvenv for migrating to pet smoothly

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -29,8 +29,11 @@
   - [[#fill-column][Fill column]]
   - [[#sort-imports][Sort imports]]
   - [[#importmagic][Importmagic]]
-  - [[#pyenv-pipenv-and-poetry][Pyenv, pipenv and poetry]]
+  - [[#pyvenv-pyenv-pipenv-and-poetry][Pyvenv, pyenv, pipenv and poetry]]
 - [[#management-of-python-versions-and-virtual-environments][Management of Python versions and virtual environments]]
+  - [[#manage-virtual-environments-with-pet-mode][Manage virtual environments with pet-mode]]
+  - [[#manage-virtual-environments-with-pyvenv-legacy-inactively-maintained][Manage virtual environments with pyvenv (legacy, inactively maintained)]]
+    - [[#automatic-activation-of-local-virtual-environment][Automatic activation of local virtual environment]]
   - [[#manage-multiple-python-versions-with-pyenv][Manage multiple Python versions with pyenv]]
     - [[#automatic-activation-of-local-pyenv-version][Automatic activation of local pyenv version]]
   - [[#manage-environments-and-packages-with-pipenv][Manage environments and packages with pipenv]]
@@ -338,10 +341,10 @@ layer config section:
   pip install importmagic epc
 #+END_SRC
 
-** Pyenv, pipenv and poetry
+** Pyvenv, pyenv, pipenv and poetry
 Sometimes, it is convenient to be able to use python virtual environments from
 other modes. For this reason, the python layer provides the variables
-=spacemacs--python-pyenv-modes=,
+=spacemacs--python-pyenv-modes=, =spacemacs--python-pyvenv-modes=,
 =spacemacs--python-poetry-modes= and =spacemacs--python-pipenv-modes=.
 If you wish to be able to access these functionalities from other modes,
 in your user config section, do:
@@ -354,8 +357,15 @@ This will allow you to use [[https://github.com/pwalsh/pipenv.el][pipenv]] bindi
 You can add to the other two lists analogously.
 
 * Management of Python versions and virtual environments
+** Manage virtual environments with pet-mode
+To enable the [[https://github.com/wyuenho/emacs-pet][pet-mode]], set the variable ~python-virtualenv-management~ to
+~pet~, for example:
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (python :variables python-virtualenv-management 'pet)))
+#+END_SRC
 In general virtual environments are automatically used when active using
-[[https://github.com/wyuenho/emacs-pet][pet-mode]], following additional packages are high recommended to enable full
+~pet-mode~, following additional packages are high recommended to enable full
 ~pet-mode~ features:
 
 | Package   | Description                                   |
@@ -364,6 +374,42 @@ In general virtual environments are automatically used when active using
 | ~sqlite3~ | a lightwait and serverless database [[https://www.sqlite.org/][sqlite]]    |
 
 Independent of this you can activate and switch virtual environments manually with below tools.
+
+** Manage virtual environments with pyvenv (legacy, inactively maintained)
+A virtual environment provides isolation of your Python package versions. For a
+general overview see [[http://docs.python-guide.org/en/latest/dev/virtualenvs/][this site]]. [[http://virtualenvwrapper.readthedocs.io/en/latest/index.html][Virtualenvwrapper]] which is also explained in the
+previous link, is a program which manages your virtual environments in a central
+location set by the =WORKON_HOME= environment variable.
+
+Spacemacs integration of virtual environments and virtualenvwrapper is provided
+by the [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] package. It provides the following key bindings:
+
+| Key binding | Description                                     |
+|-------------+-------------------------------------------------|
+| ~SPC m v a~ | activate a virtual environment in any directory |
+| ~SPC m v d~ | deactivate active virtual environment           |
+| ~SPC m v w~ | work on virtual environment in =WORKON_HOME=    |
+
+*** Automatic activation of local virtual environment
+By default Spacemacs uses the [[https://github.com/jorgenschaefer/pyvenv][pyvenv]] package to manage virtual environments.
+Additionally it uses =pyvenv-tracking-mode= to activate a buffer's local virtual
+environment on change of focus. Pyvenv determines which virtual environment to
+use from the value of the =pyvenv-workon= or the =pyvenv-activate=
+buffer-local-variable. Spacemacs scans the project directory for a pattern
+=.venv=. If the found =.venv= is a directory then it sets that directory as the
+local virtual environment path. If the =.venv= pattern is a file then it checks if
+its first line matches an existing path and if so, it sets it as the local
+virtual environment path. Finally it checks if it finds an existing directory
+with the name of the first line in the ~pyvenv-workon-home~ directory. By default
+Spacemacs scans for a virtual environment and sets the local =pyvenv-workon= or
+the =pyvenv-activate= variables on visiting a file, but switches virtual
+environment on every change of focus using the local variables. The buffer
+tracking behavior can be disabled by setting the value of the customizable
+variable =pyvenv-tracking-mode= to =nil=. The scanning behavior can be set via the
+variable =python-auto-set-local-pyvenv-virtualenv= to:
+- =on-visit= (default) set the virtualenv when you visit a python buffer,
+- =on-project-switch= set the virtualenv when you switch projects,
+- =nil= to disable.
 
 ** Manage multiple Python versions with pyenv
 If you need multiple Python versions (e.g. Python 2 and Python 3) then take a

--- a/layers/+lang/python/config.el
+++ b/layers/+lang/python/config.el
@@ -89,6 +89,9 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
   "If non-nil, automatically sort imports on save.")
 (put 'python-sort-imports-on-save 'safe-local-variable 'booleanp)
 
+(defvar python-virtualenv-management 'pyvenv
+  "The management backend for virtualenv, Possible value is `pet' or `pyvenv'")
+
 (defvar python-enable-importmagic nil
   "If non-nil, enable the importmagic feature.")
 
@@ -104,6 +107,8 @@ Possible values are `on-visit', `on-project-switch' or `nil'.")
 (defvar spacemacs--python-poetry-modes nil
   "List of major modes where to add poetry support.")
 
+(defvar spacemacs--python-shell-interpreter-origin nil
+  "Origin python-shell-interpreter value.")
 ;; inferior-python-mode needs these variables to be defined.  The python
 ;; package declares them but does not initialize them.
 (defvar python-shell--interpreter nil)


### PR DESCRIPTION
Previous #16867 try replace `pyvenv` with `pet-mode` directly, but there're several issues:
1. [searching multiple python interpreters by breadth first](https://github.com/wyuenho/emacs-pet/issues/60)
2. performance issue: [pet SLOW on a large project directory wyuenho/emacs-pet#63](https://github.com/wyuenho/emacs-pet/issues/63)
3. [fd process spam](https://github.com/syl20bnr/spacemacs/issues/17032)
4. Not support manually set python interpreter: https://github.com/syl20bnr/spacemacs/pull/16867#issuecomment-2917237140
5. [Python pytest runner cannot find virtualenv configuration](https://github.com/syl20bnr/spacemacs/issues/17035)
6. [LSP is not resolving Python dependencies in Poetry managed virtual environment](https://github.com/syl20bnr/spacemacs/issues/17036)

This submit will recall the `pyvenv` and control selecting pet/pyvenv by variable `python-virtualenv-management` to try migrate from `pyvenv` to `pet` smoothly. 

The "smooth" migration plan proposal:
1. Support manually set the python interpreter (.dir-locals.el) first, it can be the obvious way to work when the rest of "auto" detection failed;
2. migrate the pyvenv to pet for detecting the `.venv` environment
3. migrate the python interpreter detection to pet, and remove pyvenv