### PR TITLE
Improve contrast of evil-state mode line indicator in light themes

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -75,12 +75,24 @@ For evil states that also need an entry to `spacemacs-evil-cursors' use
   (set-face-attribute (spacemacs/state-color-face (intern state)) nil
                       :foreground (face-attribute 'mode-line :background)))
 
+
+
+(defun spacemacs//pick-contrasting-fg-color-from-mode-line (bg-color)
+  (let* ((ml-fg (face-attribute 'mode-line :foreground))
+         (ml-bg (face-attribute 'mode-line :background))
+         (candidates (mapcar (lambda (fg) (cons (modus-themes-contrast bg-color fg) fg))
+                             (list ml-fg ml-bg "#ffffff" "#000000"))))
+    ;; Pick the first candidate with a reasonably acceptable contrast ratio; if
+    ;; none, just pick the best one.
+    (cdr (or (cl-find-if (lambda (fg) (>= (car fg) 3.0)) candidates)
+             (last (cl-sort candidates #'car-less-than-car))))))
+
 (defun spacemacs/set-state-faces ()
-  (let ((ml-bg (face-attribute 'mode-line :background)))
-    (cl-loop for (state color cursor) in spacemacs-evil-cursors
-             do
-             (set-face-attribute (spacemacs/state-color-face (intern state)) nil
-                                 :foreground ml-bg))))
+  (cl-loop for (state color cursor) in spacemacs-evil-cursors
+           for foreground = (spacemacs//pick-contrasting-fg-color-from-mode-line color)
+           do
+           (set-face-attribute (spacemacs/state-color-face (intern state)) nil
+                               :foreground foreground)))
 
 (defun spacemacs/set-evil-search-module (style)
   "Set the evil search module depending on STYLE."

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -82,9 +82,6 @@ For evil states that also need an entry to `spacemacs-evil-cursors' use
              (set-face-attribute (spacemacs/state-color-face (intern state)) nil
                                  :foreground ml-bg))))
 
-(defun evil-insert-state-cursor-hide ()
-  (setq evil-insert-state-cursor '((hbar . 0))))
-
 (defun spacemacs/set-evil-search-module (style)
   "Set the evil search module depending on STYLE."
   (cond


### PR DESCRIPTION
In some light themes such as modus-operandi, the normal state
indicator can be completely illegible because the mode line background
color is too similar to the hardcoded color for that state, as chosen
by Spacemacs.

Instead of always using the mode line background color as the
foreground for the state indicator, pick one of the following colors
based on the contrast ratio (as calculated by modus-themes-contrast
which is built-in to Emacs):

1. Mode line foreground
1. Mode line background
1. Black (fallback)
1. White (fallback)