### PR TITLE
[spacemacs-defaults] New var to exclude the unmodified files from recentf

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/config.el
+++ b/layers/+spacemacs/spacemacs-defaults/config.el
@@ -47,6 +47,16 @@ Such useless buffers are skipped by `previous-buffer',
   "Regexp used to define buffers that are useful despite matching
 `spacemacs-useless-buffers-regexp'.")
 
+(spacemacs|defc spacemacs-recentf-exclude-not-modified '()
+  "List of regexps and predicates for filenames excluded from the recent
+list which does NOT modified, similar to `recentf-exclude'.
+
+For example the `org-agenda-list' will open *.org files for collecting
+entries, then the *.org files will be listed on the recentf. To avoid
+that, add the files into this variable will exclude them when they does
+NOT modified."
+  '(repeat (choice regexp function)))
+
 (spacemacs|defc spacemacs-useful-buffers-restrict-spc-tab t
   "When non-nil, \\[spacemacs/alternate-buffer] does not switch to
 useless buffers as defined by `spacemacs-useless-buffers-regexp'

--- a/layers/+spacemacs/spacemacs-defaults/packages.el
+++ b/layers/+spacemacs/spacemacs-defaults/packages.el
@@ -390,7 +390,15 @@
     (add-to-list 'recentf-exclude (recentf-expand-file-name package-user-dir))
     (add-to-list 'recentf-exclude "COMMIT_EDITMSG\\'")
     (when custom-file
-      (add-to-list 'recentf-exclude (recentf-expand-file-name custom-file)))))
+      (add-to-list 'recentf-exclude (recentf-expand-file-name custom-file)))
+    (define-advice recentf-include-p (:around (ofun &rest args) not-modified)
+      "Check the `spacemacs-recentf-exclude-not-modified' to exclude the
+un-modified buffer for recentf."
+      (if (let ((recentf-exclude spacemacs-recentf-exclude-not-modified))
+            (apply ofun args))
+          (apply ofun args)
+        (when (buffer-modified-p)
+          (apply ofun args))))))
 
 (defun spacemacs-defaults/init-savehist ()
   (use-package savehist


### PR DESCRIPTION
Fix #4973 by introduce a new variable `spacemacs-recentf-exclude-not-modified`. 
Set the file list to the variable to exclude the files when it does NOT modified. 
For example, in the user-config function to set the variables, then execute the `org-agenda-list`, the recentf will not been polluted: 
```emacs-lisp
(defun dotspacemacs/user-config ()
...
  (with-eval-after-load 'org
    (setq org-agenda-files '("~/todo.org"))
    (setq spacemacs-recentf-exclude-not-modified '("todo.org"))
    )
  )