### PR TITLE
[helm] Migrate the avy-jump-helm-line package

### DIFF
--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -22,7 +22,8 @@
 
 
 (defconst helm-packages
-  '(ace-jump-helm-line
+  '((avy-jump-helm-line
+     :location (recipe :fetcher github :repo "sunlin7/avy-jump-helm-line"))
     auto-highlight-symbol
     bookmark
     helm
@@ -48,12 +49,12 @@
 
 
 ;; Initialization of packages
-(defun helm/init-ace-jump-helm-line ()
-  (use-package ace-jump-helm-line
+(defun helm/init-avy-jump-helm-line ()
+  (use-package avy-jump-helm-line
     :defer t
     :init
     (with-eval-after-load 'helm
-      (define-key helm-map (kbd "C-q") 'ace-jump-helm-line))))
+      (define-key helm-map (kbd "C-q") 'avy-jump-helm-line))))
 
 (defun helm/pre-init-auto-highlight-symbol ()
   (spacemacs|use-package-add-hook auto-highlight-symbol


### PR DESCRIPTION
Migrate the [ace-jump-helm-line](https://github.com/cute-jumper/ace-jump-helm-line) to the [avy-jump-helm-line](https://github.com/sunlin7/avy-jump-helm-line). 

Currently press `C-q` on a Spacemacs helm buffer will get an error:
> apply: Cannot open load file: No such file or directory, linum

Which caused by the `ace-jump-helm-line` rely on the `linum` package which was obsoleted since Emacs-29. 
The helm has the builtin feature `helm-display-line-numbers-mode` (pressing `C-c l` on helm buffer) but it uses `C-1`/`C-2` to select the helm line which the `C-N` does **NOT** fully work on a terminal.

This PR migrates the `ace-jump-helm-line` to the `avy-jump-helm-line` package to keep the `C-q` short jumping feature works on a helm buffer.