### PR TITLE
Support orderless annotation and kwd matchers.

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -347,15 +347,16 @@
         (let ((completion-styles '(basic partial-completion orderless)))
           (apply orig-fun args))))
 
-    (setq orderless-component-separator "[ &]")
-
     ;; should be all in with orderless otherwise the results are inconsistent.
     ;; the available styles are registered in `completion-styles-alist`.
     (setq completion-styles '(orderless basic)
           completion-category-defaults nil
           ;; we need to have 'basic here first in order to support tramp connections...
           ;; see `completion-styles`.
-          completion-category-overrides '((file (styles basic partial-completion))))))
+          completion-category-overrides '((file (styles basic partial-completion))))
+    :config
+    (add-to-list 'orderless-style-dispatchers #'orderless-kwd-dispatch)
+    ))
 
 (defun compleseus/init-selectrum ()
   (use-package selectrum

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -347,6 +347,20 @@
         (let ((completion-styles '(basic partial-completion orderless)))
           (apply orig-fun args))))
 
+    ;; The separator `&' is only useful for in-buffer completion with company,
+    ;; where a space cannot be used. Note that `&' conflicts with annotation
+    ;; matching (see `orderless-affix-dispatch-alist') in the minibuffer.
+    (define-advice company-capf (:around (orig-fun &rest args) spacemacs//set-orderless-component-separator)
+      (if (and (stringp company-prefix)
+               (> (length company-prefix) 0)
+               (eq (aref company-prefix 0) ?&))
+          ;; Strings that start with `&' should not trigger orderless. Most likely the
+          ;; user wants to type something like &optional or &rest, where orderless
+          ;; just incurs unnecessary typing delays.
+          (apply orig-fun args)
+        (let ((orderless-component-separator "&"))
+          (apply orig-fun args))))
+
     ;; should be all in with orderless otherwise the results are inconsistent.
     ;; the available styles are registered in `completion-styles-alist`.
     (setq completion-styles '(orderless basic)
@@ -355,8 +369,7 @@
           ;; see `completion-styles`.
           completion-category-overrides '((file (styles basic partial-completion))))
     :config
-    (add-to-list 'orderless-style-dispatchers #'orderless-kwd-dispatch)
-    ))
+    (add-to-list 'orderless-style-dispatchers #'orderless-kwd-dispatch)))
 
 (defun compleseus/init-selectrum ()
   (use-package selectrum


### PR DESCRIPTION
Orderless has a few new matchers that are quite useful. The kwd matcher provides a lot of different ones based on different modes, and the annotation matcher with `&` allows you to match against all marginalia annotations.

To enable this we need to change the component separators back to the default (which is a space not preceded by a backslash).

This could be left as a configuration option, but I figured the nicest solution was to use the default. People can override if they prefer the other behaviour.

It seems to have supported this for a bit over a year now.

Reference to orderless-kwd: https://github.com/oantolin/orderless/blob/master/orderless-kwd.el

and the base annotation matcher with `&`: https://github.com/oantolin/orderless?tab=readme-ov-file#style-dispatchers (`orderless-annotation`)