### PR TITLE
[python] Clean unused code block for anaconda

### DIFF
--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -83,16 +83,6 @@
       "hh" 'anaconda-mode-show-doc
       "ga" 'anaconda-mode-find-assignments
       "gu" 'anaconda-mode-find-references)
-    ;; new anaconda-mode (2018-06-03) removed `anaconda-view-mode-map' in
-    ;; favor of xref. Eventually we need to remove this part.
-    (when (boundp 'anaconda-view-mode-map)
-      (evilified-state-evilify-map anaconda-view-mode-map
-        :mode anaconda-view-mode
-        :bindings
-        (kbd "q") 'quit-window
-        (kbd "C-j") 'next-error-no-select
-        (kbd "C-k") 'previous-error-no-select
-        (kbd "RET") 'spacemacs/anaconda-view-forward-and-push))
     (spacemacs|hide-lighter anaconda-mode)
     (define-advice anaconda-mode-goto (:before (&rest _) python/anaconda-mode-goto)
       (evil--jumps-push))


### PR DESCRIPTION
The `anaconda-view-mode-map` was removed several years ago, remove the unused code block.