### PR TITLE
[c-c++] Indent line with formatter

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -19,6 +19,7 @@
         - [[#basic][Basic]]
         - [[#selecting-an-alternate-lsp-server][Selecting an alternate LSP server]]
         - [[#path-to-lsp-server-executables][Path to LSP server executables]]
+        - [[#indent-line-with-lsp][Indent line with lsp]]
         - [[#semantic-highlighting][Semantic highlighting]]
         - [[#cache-directory-absolute-or-relative][Cache directory (absolute or relative)]]
         - [[#example-dotspacemacs-configuration-layers-entry][Example dotspacemacs-configuration-layers entry]]
@@ -173,6 +174,11 @@ variable:
 | clangd | =lsp-clients-clangd-executable= |
 | ccls   | =ccls-executable=               |
 
+***** Indent line with lsp
+To indent a line using LSP, set the layer variable
+=c-c++-formatter-indent-line= to a non-nil value.
+This enables indentation according to the LSP formatting feature.
+
 ***** Semantic highlighting
 Currently only available for =lsp-ccls= and =clangd=. Semantic highlighting
 can precisely highlight identifiers.
@@ -303,6 +309,12 @@ To organize the file header includes on save, set the layer variable
 style defined in a =.clang-format= file. This file is either located in the same
 directory as the file being edited, or in any of its parent directories. If no
 =.clang-format= file is found, then a default style will be used.
+
+To enable indentation with clang-format, set =c-c++-formatter-indent-line= to =t=:
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+                '((c-c++ :variables c-c++-formatter-indent-line t)))
+#+END_SRC
 
 To enable automatic buffer formatting on save, set the variable
 =c-c++-enable-clang-format-on-save= to =t=:

--- a/layers/+lang/c-c++/config.el
+++ b/layers/+lang/c-c++/config.el
@@ -93,6 +93,12 @@ Add `dap-gdb-lldb' for the WebFreak Native Debug extension.")
 (defvar c-c++-default-mode-for-headers (unless (functionp 'c-or-c++-mode) 'c-mode)
   "Default mode to open header files. Can be `c-mode' or `c++-mode', or `c-or-c++-mode' for Emacs > 26+.")
 
+(defvar c-c++-formatter-indent-line nil
+  "When non-nil, indent the line with formatter.
+If the `lsp' available, try `lsp-format-region' to indent the line;
+If the `clang-format' available, try `clang-format-region' to indent the line;
+Otherwise indent the line with built-in functions.")
+
 (defvar c-c++-adopt-subprojects nil
   "When non-nil, projectile will remember project root when visiting files in subprojects")
 

--- a/layers/+lang/c-c++/funcs.el
+++ b/layers/+lang/c-c++/funcs.el
@@ -331,6 +331,13 @@
   "Toggle auto-newline."
   (c-toggle-auto-newline 1))
 
+(defun spacemacs//c-c++-setup-formatter-indent-line ()
+  "Setup `indent-line-function' with the formatter indent function."
+  (setq-local indent-line-function
+              `(lambda (&rest args)
+                 (or (spacemacs//c-c++-formatter-indent-line args)
+                     (apply ,(symbol-function indent-line-function) args)))))
+
 
 ;; clang
 
@@ -400,3 +407,13 @@ is non-nil."
   "Add before-save hook for c-c++-organize-includes."
   (add-hook 'before-save-hook
             #'spacemacs//c-c++-organize-includes-on-save nil t))
+
+(defun spacemacs//c-c++-formatter-indent-line (&rest _)
+  "Indent current line with `lsp-format-region' or `clang-format-region'."
+  (when-let* ((fun (cond ((bound-and-true-p lsp-mode) #'lsp-format-region)
+                         ((and (fboundp 'clang-format-region)
+                               (executable-find "clang-format"))
+                          #'clang-format-region))))
+    (call-interactively fun)
+    ;; return `t' to say "indent" been applied
+    t))

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -86,6 +86,8 @@
                    `("\\.h\\'" . ,c-c++-default-mode-for-headers)))
     (when c-c++-enable-auto-newline
       (add-hook 'c-mode-common-hook 'spacemacs//c-toggle-auto-newline))
+    (when c-c++-formatter-indent-line
+      (add-hook 'c-mode-common-hook 'spacemacs//c-c++-setup-formatter-indent-line))
     :config
     (require 'compile)
     (dolist (mode c-c++-modes)


### PR DESCRIPTION
New feature indent line with formatter, Fix #13227.

The # 13227 want a feature that c-c++ layer can follow `.clang-format` to indent the line on edit. There're several ways to do that:
1. Use the LSP format feature to indent the line following `.clang-format` file, for example `clangd` support the feature:
 https://clangd.llvm.org/features#formatting
2. Use the `clang-format` executable to indent the line with `clang-format-region` function.
https://github.com/emacsmirror/clang-format/blob/a099177b5cd5060597d454e4c1ffdc96b92ba985/clang-format.el#L376
3. Pure elisp solution to support `.clang-format`, Emacs has a `TODO` item "Support external rules for indentation" https://github.com/emacs-mirror/emacs/blob/5125395db4284eb13b579d56fd0320631225164a/etc/TODO#L517  (So Spacemacs can wait that).

Current PR had implement the indent line by 1) and/or 2).