### PR TITLE
[core] Fix warning for private dir not exists

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1376,7 +1376,8 @@ discovery."
                        ;; layers shipped with spacemacs
                        (list configuration-layer-directory)
                        ;; layers in private folder ~/.emacs.d/private
-                       (list spacemacs-private-directory)
+                       (when (file-exists-p spacemacs-private-directory)
+                         (list spacemacs-private-directory))
                        ;; layers in dotdirectory
                        ;; this path may not exist, so check if it does
                        (when dotspacemacs-directory


### PR DESCRIPTION
Spacemacs give an error message on startup buffer (Spacemacs home buffer):
> Warnings: (w)
    - Layer directory "~/.emacs.d/private/" not found. Ignoring it.

It assume the `spacemacs-private-directory` is located as `~/.emacs.d/private` but on actually the Spacemacs was cloned into  `/usr/share/spacemacs.git/` then the spacemacs init.el will be load from the `~/.emacs.d/init.el`.

This PR will detect the directory to avoid the warning on Spacemacs startup buffer. 