### PR TITLE
[core] Phase out the spacemacs|dotspacemacs-backward-compatibility

### DIFF
--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -26,6 +26,8 @@
 (defmacro spacemacs|dotspacemacs-backward-compatibility (variable default)
   "Return `if' sexp for backward compatibility with old dotspacemacs
 values."
+  (declare (obsolete nil "The `dotspacemacs-backward-compatibility' will be removed after 2025.
+Please reinstall the package which relies on this macro."))
   `(if (boundp ',variable) ,variable ',default))
 
 (defun spacemacs/system-is-mac ()

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -26,8 +26,13 @@
 (defmacro spacemacs|dotspacemacs-backward-compatibility (variable default)
   "Return `if' sexp for backward compatibility with old dotspacemacs
 values."
-  (declare (obsolete nil "The `dotspacemacs-backward-compatibility' will be removed after 2025.
-Please reinstall the package which relies on this macro."))
+  (declare (obsolete nil "The `spacemacs|dotspacemacs-backward-compatibility' macro will be removed after 2025.
+Please reinstall the package which relies on this macro (such as `hybrid-mode')"))
+  ;; Display a warning in addition to the obsolete declaration.  This macro is
+  ;; used in autoload forms in `hybrid-mode' which are interpreted (not
+  ;; byte-compiled).
+  (warn "The `spacemacs|dotspacemacs-backward-compatibility' macro will be removed after 2025.
+Please reinstall the package which relies on this macro (such as `hybrid-mode')")
   `(if (boundp ',variable) ,variable ',default))
 
 (defun spacemacs/system-is-mac ()

--- a/layers/+completion/helm/config.el
+++ b/layers/+completion/helm/config.el
@@ -30,13 +30,15 @@
 
 ;; TODO: remove dotspacemacs variables backward compatbility in version
 ;;       0.400 or later
-(defvar helm-no-header (spacemacs|dotspacemacs-backward-compatibility
-                        dotspacemacs-helm-no-header nil)
+(defvar helm-no-header nil
   "if non nil, the helm header is hidden when there is only one source.")
+(define-obsolete-variable-alias
+  'dotspacemacs-helm-no-header 'helm-no-header "20180608")
 
-(defvar helm-position (spacemacs|dotspacemacs-backward-compatibility
-                       dotspacemacs-helm-position bottom)
+(defvar helm-position 'bottom
   "Position in which to show the `helm' mini-buffer.")
+(define-obsolete-variable-alias
+  'dotspacemacs-helm-position 'helm-position "20180608")
 
 (defvar helm-use-posframe nil
   "Use helm-posframe to display completions in a separate frame")

--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -59,30 +59,33 @@ to a major mode, a list of such symbols, or the symbol t,
 acting as default. The values are either integers, symbols
 or lists of these.")
 
-(defvar vim-style-remap-Y-to-y$
-  (spacemacs|dotspacemacs-backward-compatibility
-   dotspacemacs-remap-Y-to-y$ nil)
+(defvar vim-style-remap-Y-to-y$ nil
   "If non nil `Y' is remapped to `y$' in Evil states.")
+(define-obsolete-variable-alias
+  'dotspacemacs-remap-Y-to-y$ 'vim-style-remap-Y-to-y$ "20180608")
 
-(defvar vim-style-retain-visual-state-on-shift
-  (spacemacs|dotspacemacs-backward-compatibility
-   dotspacemacs-retain-visual-state-on-shift t)
+(defvar vim-style-retain-visual-state-on-shift t
   "If non-nil, the shift mappings `<' and `>' retain visual state
 if used there.")
+(define-obsolete-variable-alias
+  'dotspacemacs-retain-visual-state-on-shift
+  'vim-style-retain-visual-state-on-shift "20180608")
 
-(defvar vim-style-visual-line-move-text
-  (spacemacs|dotspacemacs-backward-compatibility
-   dotspacemacs-visual-line-move-text nil)
+(defvar vim-style-visual-line-move-text nil
   "If non-nil, J and K move lines up and down when in visual mode.")
+(define-obsolete-variable-alias
+  'dotspacemacs-visual-line-move-text 'vim-style-visual-line-move-text
+  "20180608")
 
 (defvar vim-style-enable-undo-region nil
   "If non-nil, `u' is remapped to `undo' in visual state.
 Otherwise, in visual state `u' downcases visually selected text.")
 
-(defvar vim-style-ex-substitute-global
-  (spacemacs|dotspacemacs-backward-compatibility
-   dotspacemacs-ex-substitute-global nil)
+(defvar vim-style-ex-substitute-global nil
   "If non nil, inverse the meaning of `g' in `:substitute' Evil ex-command.")
+(define-obsolete-variable-alias
+  'dotspacemacs-ex-substitute-global 'vim-style-ex-substitute-global
+  "20180608")
 
 ;; State cursors
 (defvar spacemacs-evil-cursors '(("normal" "DarkGoldenrod2" box)

--- a/layers/+distributions/spacemacs-bootstrap/local/hybrid-mode/hybrid-mode.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/hybrid-mode/hybrid-mode.el
@@ -32,37 +32,40 @@
 (require 'evil)
 
 ;;;###autoload
-(defcustom hybrid-style-default-state
-  (spacemacs|dotspacemacs-backward-compatibility
-   hybrid-mode-default-state normal)
+(defcustom hybrid-style-default-state 'normal
   "Value of `evil-default-state' for hybrid-mode."
   :group 'spacemacs
   :type 'symbol)
+(define-obsolete-variable-alias
+  'hybrid-mode-default-state 'hybrid-style-default-state "20180608")
 
 ;;;###autoload
-(defcustom hybrid-style-enable-hjkl-bindings
-  (spacemacs|dotspacemacs-backward-compatibility
-   hybrid-mode-enable-hjkl-bindings nil)
+(defcustom hybrid-style-enable-hjkl-bindings nil
   "If non-nil then packages configuration should enable hjkl navigation."
   :group 'spacemacs
   :type 'boolean)
+(define-obsolete-variable-alias
+  'hybrid-mode-enable-hjkl-bindings 'hybrid-style-enable-hjkl-bindings
+  "20180608")
 
 ;;;###autoload
-(defcustom hybrid-style-enable-evilified-state
-  (spacemacs|dotspacemacs-backward-compatibility
-   hybrid-mode-enable-evilified-state t)
+(defcustom hybrid-style-enable-evilified-state t
   "If non-nil then evilified states is enabled in buffer supporting it."
   :group 'spacemacs
   :type 'boolean)
+(define-obsolete-variable-alias
+  'hybrid-mode-enable-evilified-state 'hybrid-style-enable-evilified-state
+  "20180608")
 
 ;;;###autoload
-(defcustom hybrid-style-use-evil-search-module
-  (spacemacs|dotspacemacs-backward-compatibility
-   hybrid-mode-use-evil-search-module nil)
+(defcustom hybrid-style-use-evil-search-module nil
   "If non-nil then use evil own search module which is closer to Vim search
 behavior (for instance it support C-r pasting)."
   :group 'spacemacs
   :type 'boolean)
+(define-obsolete-variable-alias
+  'hybrid-mode-use-evil-search-module 'hybrid-style-use-evil-search-module
+  "20180608")
 
 (defvar hybrid-mode-default-state-backup evil-default-state
   "Backup of `evil-default-state'.")

--- a/layers/+spacemacs/spacemacs-completion/config.el
+++ b/layers/+spacemacs/spacemacs-completion/config.el
@@ -24,15 +24,17 @@
 
 ;; Helm
 
-(defvar helm-use-fuzzy (spacemacs|dotspacemacs-backward-compatibility
-                        dotspacemacs-helm-use-fuzzy always)
+(defvar helm-use-fuzzy 'always
   "Controls fuzzy matching in helm. If set to `always', force fuzzy matching
   in all non-asynchronous sources. If set to `source', preserve individual
   source settings. Else, disable fuzzy matching in all sources.")
+(define-obsolete-variable-alias
+  'dotspacemacs-helm-use-fuzzy 'helm-use-fuzzy "20180608")
 
-(defvar helm-enable-auto-resize (spacemacs|dotspacemacs-backward-compatibility
-                                 dotspacemacs-helm-resize nil)
+(defvar helm-enable-auto-resize nil
   "If non nil, `helm' will try to minimize the space it uses.")
+(define-obsolete-variable-alias
+  'dotspacemacs-helm-resize 'helm-enable-auto-resize "20180608")
 
 (defface spacemacs-helm-navigation-ts-face
   `((t :background ,(face-attribute 'error :foreground)


### PR DESCRIPTION
Phase out the `spacemacs|dotspacemacs-backward-compatibility`.

The ` Phase out the spacemacs|dotspacemacs-backward-compatibility` was compiled into the `hybrid-mode-autoloads.el`, so we can NOT delete it directly, change it to warn.