### PR TITLE
[git] Install helm-git-grep from source

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -37,7 +37,8 @@
     git-messenger
     git-timemachine
     golden-ratio
-    (helm-git-grep :requires helm)
+    (helm-git-grep :location (recipe :fetcher github :repo "yasuyk/helm-git-grep")
+                   :requires helm)
     magit
     (magit-delta :toggle git-enable-magit-delta-plugin)
     (magit-gitflow :toggle git-enable-magit-gitflow-plugin)


### PR DESCRIPTION
Fix the latest issue reported in the https://github.com/syl20bnr/spacemacs/issues/17067#issuecomment-3089812161.