### PR TITLE
Markdown packages.el: navigation shortcut

### DIFF
--- a/layers/+lang/markdown/packages.el
+++ b/layers/+lang/markdown/packages.el
@@ -204,7 +204,8 @@
     :init
     (dolist (mode markdown--key-bindings-modes)
       (spacemacs/set-leader-keys-for-major-mode mode
-        "it" 'markdown-toc-generate-toc))))
+        "it" 'markdown-toc-generate-toc
+        "p" 'markdown-toc-follow-link-at-point))))
 
 (defun markdown/init-vmd-mode ()
   (use-package vmd-mode


### PR DESCRIPTION
Added `p` as `'markdown-toc-follow-link-at-point` shortcut (a particular pain point of mine as Emacs is pretty much my documentation IDE), since the `p` key is both intuitive for _"point"_ and currently unused for the mode.
