### PR TITLE
adapt to variable name change in new treemacs

### DIFF
--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -87,7 +87,9 @@
         (treemacs-git-mode treemacs-use-git-mode)
       (treemacs-git-mode -1))
     (add-to-list 'spacemacs-window-split-ignore-prefixes
-                 treemacs--buffer-name-prefix)))
+                 (if (boundp 'treemacs-buffer-name-prefix)
+                     treemacs-buffer-name-prefix
+                   treemacs--buffer-name-prefix))))
 
 (defun treemacs/init-treemacs-evil ()
   (use-package treemacs-evil
@@ -129,7 +131,9 @@
           (dolist (n (number-sequence 1 5))
             (add-to-list 'winum-ignored-buffers
                          (format "%sFramebuffer-%s*"
-                                 treemacs--buffer-name-prefix n))))))))
+                                 (if (boundp 'treemacs-buffer-name-prefix)
+                                     treemacs-buffer-name-prefix
+                                   treemacs--buffer-name-prefix) n))))))))
 
 (defun treemacs/init-treemacs-magit ()
   (use-package treemacs-magit


### PR DESCRIPTION
in a recent commit
Alexander-Miller/treemacs@acd69f4d19b3aa7de2168e47661148d221853b81

treemacs underwent some reorganization and `treemacs--buffer-name-prefix` was renamed to `treemacs-buffer-name-prefix`. spacemacs relies on the this variable in its treemacs layer, so adjust the logic to use either depending on which is bound (so that things will work both for people who have and haven't recently updated their treemacs package)