### PR TITLE
restructuredtext: migrate from auto-complete to company

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -330,6 +330,8 @@ In org-agenda-mode
   - Changed ~SPC m s r~ to ~SPC m e r~ for =lisp-eval-region=
 - Hy support has been extracted from the =python= layer into the new =hy= layer.
 - Made =nose= fail compilation when tests fail (thanks to wizmer)
+***** Restructuredtext
+- Migrate from auto-complete to company for auto completion.
 ***** Ruby
 - Key bindings:
   - Changed ~SPC m h d~ to ~SPC m h h~ for =robe-doc= (thanks to Paweł Siudak)

--- a/layers/+lang/restructuredtext/packages.el
+++ b/layers/+lang/restructuredtext/packages.el
@@ -36,13 +36,6 @@
 (defun restructuredtext/post-init-auto-complete ()
   (add-hook 'rst-mode-hook 'auto-complete-mode))
 
-;; (defun restructuredtext/init-auto-complete-rst ()
-;;   (use-package auto-complete-rst
-;;     :commands (auto-complete-rst-add-sources
-;;                auto-complete-rst-init)
-;;     :init (spacemacs/add-to-hook 'rst-mode-hook '(auto-complete-rst-init
-;;                                                   auto-complete-rst-add-sources))))
-
 (defun restructuredtext/init-rst-directives ()
   (use-package rst-directives))
 

--- a/layers/+lang/restructuredtext/packages.el
+++ b/layers/+lang/restructuredtext/packages.el
@@ -23,7 +23,7 @@
 
 (defconst restructuredtext-packages
   '(
-    auto-complete
+    company
     ;; Disabled due to package is not longer maintained
     ;; (auto-complete-rst :requires auto-complete)
     (rst :location built-in)
@@ -32,9 +32,6 @@
     flyspell
     smartparens
     yasnippet))
-
-(defun restructuredtext/post-init-auto-complete ()
-  (add-hook 'rst-mode-hook 'auto-complete-mode))
 
 (defun restructuredtext/init-rst-directives ()
   (use-package rst-directives))
@@ -47,12 +44,11 @@
     :defer t
     :config (add-hook 'rst-adjust-hook 'rst-toc-update)))
 
+(defun restructuredtext/post-init-company ()
+  (spacemacs|add-company-backends :backends company-capf :modes rst-mode))
+
 (defun restructuredtext/post-init-flyspell ()
-  (spell-checking/add-flyspell-hook 'rst-mode-hook)
-  ;; important auto-complete work-around to be applied to make both flyspell
-  ;; and auto-complete to work together
-  (when (configuration-layer/package-used-p 'auto-complete)
-    (add-hook 'rst-mode-hook 'ac-flyspell-workaround t)))
+  (spell-checking/add-flyspell-hook 'rst-mode-hook))
 
 (defun restructuredtext/post-init-yasnippet ()
   (add-hook 'rst-mode-hook 'spacemacs/load-yasnippet))


### PR DESCRIPTION
This layer is the only user of the auto-complete package. Let's migrate to company mode to make it align with other layers. We can also remove the workaround for flyspell as company can work together with flyspell.