### PR TITLE
Update funcs.el of EXWM Layer: Remove void functions `exwm-randr-enable` and `exwm-systemtray-enable`

### DIFF
--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -149,7 +149,7 @@ The started process is also added to `exwm--autostart-process-list'."
      "xrandr" nil exwm-randr-command))
   ;; The first workspaces will match the order in RandR
   (setq exwm-randr-workspace-monitor-plist exwm-randr-command)
-  (exwm-randr-enable))
+  (exwm-randr-mode 1))
 
 
 ;;;; Systray
@@ -157,4 +157,4 @@ The started process is also added to `exwm--autostart-process-list'."
   "Setup `exwm-systray'."
   (when exwm-enable-systray
     (require 'exwm-systemtray)
-    (exwm-systemtray-enable)))
+    (exwm-systemtray-mode 1)))


### PR DESCRIPTION
In funcs.el of EXWM layer, `(exwm-randr-enable)` and `(exwm-systemtray-enable)` functions don't work and give errors at startup complaining their function definitions are void. I changed them to `(exwm-randr-mode 1)` and `(exwm-systemtray-mode 1)` respectively according to EXWM Wiki.
