### PR TITLE
Fix keybindings and error of EXWM layer

### DIFF
--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -81,7 +81,26 @@
     (use-dialog-box nil "Disable dialog boxes since they are unusable in EXWM")
     (exwm-input-line-mode-passthrough t "Pass all keypresses to emacs in line mode.")
     :init
-    (exwm-enable)
+    (setq exwm-input-global-keys
+          `(
+            ([?\M-m] . spacemacs-cmds)
+            ([?\s-i] . exwm-input-toggle-keyboard)
+            ([?\s-l] . exwm/exwm-lock)
+            ([?\s-r] . exwm-reset) ;; s-r: Reset (to line-mode).
+
+            ([?\s-w] . exwm-workspace-switch) ;; s-w: Switch workspace.
+            ([?\s-\t] . exwm/jump-to-last-exwm)
+            ([?\s- ] . (lambda (cmd) ;; s-SPC: Launch application.
+                         (interactive (list (read-shell-command "$ ")))
+                         (start-process-shell-command cmd nil cmd)))
+            ;; s-N: Switch to N-th window.
+            ,@(mapcar (lambda (i)
+                        `(,(kbd (format "s-%d" i)) .
+                          (lambda ()
+                            (interactive)
+                            (winum-select-window-by-number ,i))))
+                      (number-sequence 0 9))))
+    (exwm-wm-mode)
     ;; "Number of workspaces. Defaults to the number of connected displays."
     (unless exwm-workspace-number
       (custom-set-variables '(exwm-workspace-number (/ (length exwm--randr-displays) 2))))
@@ -100,29 +119,7 @@
                 (exwm-workspace-rename-buffer exwm-title)))
 
     ;; Remove ALL bindings
-    (define-key exwm-mode-map "\C-c\C-f" nil)
-    (define-key exwm-mode-map "\C-c\C-h" nil)
-    (define-key exwm-mode-map "\C-c\C-k" nil)
-    (define-key exwm-mode-map "\C-c\C-m" nil)
-    (define-key exwm-mode-map "\C-c\C-q" nil)
-    (define-key exwm-mode-map "\C-c\C-t\C-f" nil)
-    (define-key exwm-mode-map "\C-c\C-t\C-m" nil)
-
-
-    ;; `exwm-input-set-key' allows you to set a global key binding (available in
-    ;; any case). Following are a few examples.
-
-    (exwm-input-set-key (kbd "M-m")     'spacemacs-cmds)
-    (exwm-input-set-key (kbd "C-q")     #'exwm-input-send-next-key)
-    (exwm-input-set-key (kbd "s-i")     #'exwm-input-toggle-keyboard)
-    (exwm-input-set-key (kbd "s-l")     #'exwm/exwm-lock)
-    (exwm-input-set-key (kbd "s-r")     #'exwm-reset)
-
-    (exwm-input-set-key (kbd "s-w")     #'exwm-workspace-switch)
-    (exwm-input-set-key (kbd "s-TAB")   #'exwm/jump-to-last-exwm)
-
-    (exwm-input-set-key (kbd "s-SPC")   #'exwm/exwm-app-launcher)
-    (exwm-input-set-key (kbd "s-RET")   #'exwm-terminal-command)
+    (define-key exwm-mode-map (kbd "C-c") nil)
 
     ;; set up evil escape
     (when (configuration-layer/package-used-p 'evil-escape)
@@ -152,5 +149,4 @@
     (when exwm-autostart-xdg-applications
       (add-hook 'exwm-init-hook 'exwm//autostart-xdg-applications t))
 
-    (exwm-init)
     (server-start)))


### PR DESCRIPTION
The `exwm-input-set-key` can no longer set a global keybinding unless invoked interactively. The keybindings are redefined in this commit with `exwm-input-global-keys`. `exwm-terminal-command` is no longer available and hence it's keybinding is removed. Global keybinding `C-q` to send key has been removed because it's unnecessary. Why would someone use it in char-mode? `s-N` has been remapped to switch to N-th window instead of workspace. The code to remove EXWM prefix bindings has been reduced to one line according to the EXWM wiki. The deprecated `exwm-enable` is replaced with `exwm-wm-mode`. The redundant function `exwm-init` has been removed since it's already called inside `exwm-wm-mode`. It was causing assertion failure.
