### PR TITLE
[c-c++] Document enhancement and fix typo

### DIFF
--- a/layers/+lang/c-c++/README.org
+++ b/layers/+lang/c-c++/README.org
@@ -48,11 +48,13 @@
       - [[#gotomember][goto/member]]
     - [[#debugger][debugger]]
   - [[#rtags-1][RTags]]
+  - [[#ycmd][ycmd]]
   - [[#doxygen][Doxygen]]
   - [[#additional-key-bindings][Additional key bindings]]
     - [[#disassemble][Disassemble]]
     - [[#formatting-clang-format][Formatting (clang-format)]]
     - [[#open-matching-files][Open matching files]]
+    - [[#cscope][cscope]]
     - [[#refactor][Refactor]]
 
 * Description
@@ -507,6 +509,12 @@ A ~[ccls]~ suffix indicates that the binding is for the indicated backend only.
 | ~SPC m g X~ | fix fixit at point              |
 | ~SPC m g Y~ | cycle overlays on screen        |
 
+
+** ycmd
+
+| Key binding | Description          |
+|-------------|----------------------|
+| ~SPC m g G~ | goto imprecise       |
 ** Doxygen
 
 | Key binding | Description                                                         |
@@ -541,6 +549,12 @@ A ~[ccls]~ suffix indicates that the binding is for the indicated backend only.
 |             | (e.g. switch between .cpp and .h, requires a project to work) |
 | ~SPC m g A~ | open matching file in another window                          |
 |             | (e.g. switch between .cpp and .h, requires a project to work) |
+
+*** cscope
+
+| Key binding | Description        |
+|-------------|--------------------|
+| ~SPC m g i~ | cscope index files |
 
 *** Refactor
 

--- a/layers/+lang/c-c++/packages.el
+++ b/layers/+lang/c-c++/packages.el
@@ -60,7 +60,7 @@
     (ycmd :toggle (eq c-c++-backend 'ycmd))))
 
 (defun c-c++/init-gendoxy ()
-  "Initialise gendoxy (doxygen package)"
+  "Initialize gendoxy (doxygen package)"
   (use-package gendoxy
     :defer t
     :init (dolist (mode c-c++-modes)


### PR DESCRIPTION
    [c-c++] Document enhancement and fix typo

    * README.org: Add document for ymcd and cscope.
    * package.el: Fix typo.
