### PR TITLE
[auto-completion] Fix message that private/snippets/ is not a directory

### DIFF
--- a/layers/+completion/auto-completion/packages.el
+++ b/layers/+completion/auto-completion/packages.el
@@ -302,7 +302,8 @@
       ;; ~/.emacs.d/layers/auto-completion/snippets
       (add-to-list 'yas-snippet-dirs spacemacs-layer-snippets-dir)
       ;; ~/.emacs.d/private/snippets
-      (add-to-list 'yas-snippet-dirs emacs-directory-snippets-dir)
+      (when (file-exists-p emacs-directory-snippets-dir)
+        (add-to-list 'yas-snippet-dirs emacs-directory-snippets-dir))
       ;; ~/.spacemacs.d/snippets
       (when dotspacemacs-directory-snippets-dir
         (add-to-list 'yas-snippet-dirs dotspacemacs-directory-snippets-dir))


### PR DESCRIPTION
Fix the error message on *Message* buffer:
> [yas] Check your `yas-snippet-dirs': ~/.emacs.d/private/snippets/ is not a directory
[yas] Prepared just-in-time loading of snippets with some errors.  Check *Messages*.

To reproduce this issue, 
1. do not install Spacemacs into `~/.emacs.d` (for example, install it to `~/.spacemacs.git`), and
2.  load Spacemacs' `init.el` file in `~/.emacs.d/init.el`, and
3.  do not create the `~/.emacs.d/private/snippets` directory.