### PR TITLE
[core] Reorder startup summery to to bottom of startup buffer

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -333,8 +333,6 @@ defer call using `spacemacs-post-user-config-hook'."
      (when spacemacs--delayed-user-theme
        (spacemacs/load-theme spacemacs--delayed-user-theme
                              spacemacs--fallback-theme t))
-     ;; Display configuration layer summary.
-     (configuration-layer/display-summary)
      ;; Check for new Spacemacs version.
      (spacemacs/check-for-new-version nil spacemacs-version-check-interval)
      ;; Move cursor to link line in Spacemacs buffer.
@@ -345,6 +343,8 @@ defer call using `spacemacs-post-user-config-hook'."
      (setq read-process-output-max dotspacemacs-read-process-output-max)
      ;; Redraw Spacemacs buffer to ensure it displays correctly.
      (spacemacs-buffer//startup-hook)
+     ;; Display configuration layer summary.
+     (configuration-layer/display-summary)
      ;; Set garbage collection settings for performance.
      (setq gc-cons-threshold (car dotspacemacs-gc-cons)
            gc-cons-percentage (cadr dotspacemacs-gc-cons))))


### PR DESCRIPTION
The Spacemacs startup buffer will show the summary on the bottom (after the recentf list).
But at the very beginning it will show the summary before the recentf list; then flush the buffer very quick to the correct order.

I noticed the Spacemacs startup buffer has a flash, then found this issue. 

This PR will adjust the summary displaying after the `(spacemacs-buffer/goto-link-line)` to make sure it's on the bottom. 