### PR TITLE
[emacs-lisp] Fix the evilify warning for edebug-mode

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -124,6 +124,8 @@
            evil-intercept-maps))
     (evilified-state-evilify-map edebug-mode-map
       :eval-after-load edebug
+      :pre-bindings               ; Remove key bindings that cannot be evilified
+      "G" nil                     ; edebug-Go-nonstop-mode
       :bindings
       "a" 'edebug-stop
       "c" 'edebug-go-mode


### PR DESCRIPTION
Fix an error message for edebug:
>Auto-evilification could not remap these functions in map ‘edebug-mode-map’:
   \- ‘edebug-Go-nonstop-mode’ originally mapped on ‘G’

It caused by the 'G' was bind to the `edebug-Go-nonstop-mode` in edebug mode, then evilificatioin will failed for it's already bind. 
Similar to this PR:
https://github.com/syl20bnr/spacemacs/pull/17066/files