### PR TITLE
[helm] Replace helm-git-grep package with helm builtin function helm-grep-git-1

### DIFF
--- a/layers/+completion/helm/README.org
+++ b/layers/+completion/helm/README.org
@@ -20,6 +20,7 @@
   - [[#transient-state][Transient state]]
   - [[#files][Files]]
   - [[#buffers][Buffers]]
+  - [[#git-if-git-layer-is-enabled][Git (if git layer is enabled)]]
   - [[#bookmarks][Bookmarks]]
   - [[#colorsfaces][Colors/Faces]]
   - [[#c-z-and-tab-switch][C-z and Tab switch]]
@@ -192,6 +193,12 @@ In the =helm-buffers= buffer:
 | Key binding  | Description                              |
 |--------------+------------------------------------------|
 | ~S-<return>~ | open the selected buffer in other window |
+
+** Git (if git layer is enabled)
+| Key binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC g /~   | open =helm-git-grep=          |
+| ~SPC g *~   | open =helm-git-grep-at-point= |
 
 ** Bookmarks
 In the =helm-bookmarks= buffer:

--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -535,6 +535,16 @@ Removes the automatic guessing of the initial value based on thing at point. "
     (set-text-properties 0 (length input) nil input)
     (helm-find-files-1 input)))
 
+(defun spacemacs/helm-git-grep ()
+  "Search for a pattern in the Git repository of the current buffer."
+  (interactive)
+  (helm-grep-git-1 "" t nil ""))
+
+(defun spacemacs/helm-git-grep-at-point ()
+  "Search for the symbol at point in the Git repository of the current buffer."
+  (interactive)
+  (helm-grep-git-1 "" t))
+
  ;; Key bindings
 
 (defmacro spacemacs||set-helm-key (keys func)

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -39,7 +39,7 @@
     (helm-posframe :toggle helm-use-posframe)
     helm-projectile
     ;; FIXME Remove obsolete packages helm-swoop, helm-themes,
-    ;; helm-ag, helm-git-grep, etc. (see https://github.com/melpa/melpa/pull/9520)
+    ;; helm-ag etc. (see https://github.com/melpa/melpa/pull/9520)
     (helm-swoop :location (recipe
                            :fetcher github
                            :repo "emacsattic/helm-swoop"))
@@ -82,6 +82,7 @@
 (defun helm/init-helm ()
   (use-package helm
     :defer t
+    :commands (helm-grep-git-1)
     :init
     (spacemacs|diminish helm-ff-cache-mode)
     (spacemacs|add-transient-hook completing-read
@@ -190,6 +191,11 @@
                     dotspacemacs-emacs-command-key 'spacemacs/helm-M-x-fuzzy-matching))))
     ;; avoid duplicates in `helm-M-x' history.
     (setq history-delete-duplicates t)
+    ;; bind for grep in git
+    (when (configuration-layer/layer-used-p 'git)
+      (spacemacs/set-leader-keys
+        "g/" 'spacemacs/helm-git-grep
+        "g*" 'spacemacs/helm-git-grep-at-point))
     :config
     (helm-mode)
     (spacemacs|hide-lighter helm-mode)

--- a/layers/+source-control/git/README.org
+++ b/layers/+source-control/git/README.org
@@ -217,8 +217,6 @@ Git commands (start with ~g~):
 
 | Key binding | Description                                         |
 |-------------+-----------------------------------------------------|
-| ~SPC g /~   | open =helm-git-grep=                                |
-| ~SPC g *~   | open =helm-git-grep-at-point=                       |
 | ~SPC g b~   | open a =magit= blame                                |
 | ~SPC g f f~ | view a file at a specific branch or commit          |
 | ~SPC g f l~ | commits log for current file                        |

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -37,8 +37,6 @@
     git-messenger
     git-timemachine
     golden-ratio
-    (helm-git-grep :location (recipe :fetcher github :repo "yasuyk/helm-git-grep")
-                   :requires helm)
     magit
     (magit-delta :toggle git-enable-magit-delta-plugin)
     (magit-gitflow :toggle git-enable-magit-gitflow-plugin)
@@ -69,13 +67,6 @@
     ;; See `git-packages' form in this file.
     (unless (spacemacs/system-is-mswindows)
       (add-to-list 'spacemacs-evil-collection-allowed-list 'forge))))
-
-(defun git/init-helm-git-grep ()
-  (use-package helm-git-grep
-    :defer t
-    :init (spacemacs/set-leader-keys
-            "g/" 'helm-git-grep
-            "g*" 'helm-git-grep-at-point)))
 
 (defun git/init-code-review ()
   (use-package code-review

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -2601,7 +2601,7 @@ Features:
 - quick in buffer history browsing with [[https://melpa.org/#/git-timemachine][git-timemachine]].
 - quick in buffer last commit message per line with [[https://github.com/syohex/emacs-git-messenger][git-messenger]]
 - colorize buffer line by age of commit with [[https://github.com/syohex/emacs-smeargle][smeargle]]
-- git grep with [[https://github.com/yasuyk/helm-git-grep][helm-git-grep]]
+- git grep with helm builtin =helm-grep-git-1=
 - org integration with magit via [[https://github.com/magit/orgit][orgit]]
 
 New to Magit? Checkout the [[https://magit.vc/about/][official intro]] and [[https://practical.li/spacemacs/source-control/][Practicalli Spacemacs]]


### PR DESCRIPTION
The [helm-git-grep](https://github.com/yasuyk/helm-git-grep) was unmaintained 8 years,
and it was also removed from melpa https://github.com/melpa/melpa/pull/9520,
Remove the `helm-git-grep` package from Spacemacs, and replace the functions with helm builtin function `helm-grep-git-1` (helm won't directly support the desired function, but suggested to use the `helm-grep-git-1`, refer https://github.com/emacs-helm/helm/pull/2734)