### PR TITLE
[helm] Migrate helm-theme package to builtin functions

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -646,12 +646,31 @@ to buffers)."
 
 
 ;; theme
+(defun spacemacs//helm-themes-load (theme)
+  "Disable the `custom-enabled-themes'first then load the named THEME."
+  (mapc 'disable-theme custom-enabled-themes)
+  (if (string= theme "default")
+      t
+    (load-theme (intern theme) t)))
+
+(defun spacemacs//helm-themes-candidates ()
+  "Return list of available themes with `default' on the head."
+  (cons 'default (custom-available-themes)))
 
 (defun spacemacs/helm-themes ()
-  "Remove limit on number of candidates on `helm-themes'"
+  "List the theme candidates without number limit."
   (interactive)
-  (let (helm-candidate-number-limit)
-    (helm-themes)))
+  (let (helm-candidate-number-limit
+        (orig-theme (or (car-safe custom-enabled-themes) 'default)))
+    (unwind-protect
+        (unless (helm :prompt (format "pattern (current theme: %s): " orig-theme)
+                      :preselect (format "%s$" orig-theme)
+                      :sources (helm-build-sync-source "Selection Theme"
+                                 :candidates 'spacemacs//helm-themes-candidates
+                                 :action 'spacemacs//helm-themes-load
+                                 :persistent-action 'spacemacs//helm-themes-load)
+                      :buffer "*helm-themes*")
+          (spacemacs//helm-themes-load (symbol-name orig-theme))))))
 
 ;; Buffers ---------------------------------------------------------------------
 

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -38,14 +38,11 @@
     helm-org
     (helm-posframe :toggle helm-use-posframe)
     helm-projectile
-    ;; FIXME Remove obsolete packages helm-swoop, helm-themes,
+    ;; FIXME Remove obsolete packages helm-swoop
     ;; helm-ag etc. (see https://github.com/melpa/melpa/pull/9520)
     (helm-swoop :location (recipe
                            :fetcher github
                            :repo "emacsattic/helm-swoop"))
-    (helm-themes :location (recipe
-                           :fetcher github
-                           :repo "emacsattic/helm-themes"))
     (helm-spacemacs-help :location local)
     helm-xref
     imenu
@@ -191,6 +188,8 @@
                     dotspacemacs-emacs-command-key 'spacemacs/helm-M-x-fuzzy-matching))))
     ;; avoid duplicates in `helm-M-x' history.
     (setq history-delete-duplicates t)
+    ;; bind for helm-themes
+    (spacemacs/set-leader-keys "Ts" 'spacemacs/helm-themes)
     ;; bind for grep in git
     (when (configuration-layer/layer-used-p 'git)
       (spacemacs/set-leader-keys
@@ -501,13 +500,6 @@
       "s C-s" 'helm-multi-swoop-all)
 
     (evil-add-command-properties 'helm-swoop :jump t)))
-
-(defun helm/init-helm-themes ()
-  (use-package helm-themes
-    :defer t
-    :init
-    (spacemacs/set-leader-keys
-      "Ts" 'spacemacs/helm-themes)))
 
 (defun helm/init-helm-xref ()
   (use-package helm-xref


### PR DESCRIPTION
The [helm-themes](https://github.com/emacsattic/helm-themes) was removed from melpa in https://github.com/melpa/melpa/pull/9520,

This PR rewrite the helm-theme functions in Spacemacs way, then drop the package dependency. 