### PR TITLE
[rust] Fix flycheck initialization

### DIFF
--- a/layers/+lang/rust/packages.el
+++ b/layers/+lang/rust/packages.el
@@ -24,6 +24,7 @@
 (defconst rust-packages
   '(
     dap-mode
+    flycheck
     ggtags
     ron-mode
     rustic
@@ -34,6 +35,9 @@
   (when (eq rust-backend 'lsp)
     (add-to-list 'spacemacs--dap-supported-modes 'rustic-mode)
     (add-hook 'rustic-mode-local-vars-hook #'spacemacs//rust-setup-dap)))
+
+(defun rust/post-init-flycheck ()
+  (spacemacs/enable-flycheck 'rustic-mode))
 
 (defun rust/post-init-ggtags ()
   (add-hook 'rustic-mode-local-vars-hook #'spacemacs/ggtags-mode-enable))
@@ -73,7 +77,6 @@
       "tt" 'rustic-cargo-current-test)
 
     (with-eval-after-load 'flycheck
-      (spacemacs/enable-flycheck 'rustic-mode)
       (push 'rustic-clippy flycheck-checkers))
 
     (with-eval-after-load 'lsp-mode


### PR DESCRIPTION
Flycheck may be loaded by the user's config but not owned by the
`syntax-checking` layer, in which case the `spacemacs/enable-flycheck`
function will not be defined, and calling it in `with-eval-after-load`
will error.