### PR TITLE
[bootstrap] Preserve site customizations to which-key-replacement-alist

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -420,11 +420,6 @@ Press \\[which-key-toggle-persistent] to hide."
 
   (spacemacs/set-leader-keys "hk" 'which-key-show-top-level)
 
-  ;; Needed to avoid nil variable error before update to recent which-key
-  (defvar which-key-replacement-alist nil)
-  ;; Reset to the default or customized value before adding our values in order
-  ;; to make this initialization code idempotent.
-  (custom-reevaluate-setting 'which-key-replacement-alist)
   ;; Replace rules for better naming of functions
   (let ((new-descriptions
          ;; being higher in this list means the replacement is applied later
@@ -444,140 +439,167 @@ Press \\[which-key-toggle-persistent] to hide."
 
     (dolist (nd new-descriptions)
       ;; ensure the target matches the whole string
-      (push (cons (cons nil (concat "\\`" (car nd) "\\'")) (cons nil (cdr nd)))
-            which-key-replacement-alist)))
+      (cl-pushnew (cons (cons nil (concat "\\`" (car nd) "\\'")) (cons nil (cdr nd)))
+                  which-key-replacement-alist
+                  :test #'equal)))
 
   ;; Group together sequence and identical key entries in the which-key popup
   ;; SPC h k- Top-level bindings
   ;; Remove spaces around the two dots ".."
-  (push '(("\\(.*\\)1 .. 9" . "digit-argument") .
-          ("\\11..9" . "digit-argument"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)1 .. 9" . "digit-argument") .
+                ("\\11..9" . "digit-argument"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; And remove the modifier key(s) before the last nr in the sequence
-  (push '(("\\(.*\\)C-0 .. C-5" . "digit-argument") .
-          ("\\1C-0..5" . "digit-argument"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-0 .. C-5" . "digit-argument") .
+                ("\\1C-0..5" . "digit-argument"))
+              which-key-replacement-alist
+              :test #'equal)
 
-  (push '(("\\(.*\\)C-7 .. C-9" . "digit-argument") .
-          ("\\1C-7..9" . "digit-argument"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-7 .. C-9" . "digit-argument") .
+                ("\\1C-7..9" . "digit-argument"))
+              which-key-replacement-alist
+              :test #'equal)
 
-  (push '(("\\(.*\\)C-M-0 .. C-M-9" . "digit-argument") .
-          ("\\1C-M-0..9" . "digit-argument"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-M-0 .. C-M-9" . "digit-argument") .
+                ("\\1C-M-0..9" . "digit-argument"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; Rename the entry for M-0 in the SPC h k Top-level bindings,
   ;; and for 0 in the SPC- Spacemacs root
-  (push '(("\\(.*\\)0" . "winum-select-window-0-or-10") .
-          ("\\10" . "select window 0 or 10"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)0" . "winum-select-window-0-or-10") .
+                ("\\10" . "select window 0 or 10"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; Rename the entry for M-1 in the SPC h k Top-level bindings,
   ;; and for 1 in the SPC- Spacemacs root, to 1..9
-  (push '(("\\(.*\\)1" . "winum-select-window-1") .
-          ("\\11..9" . "select window 1..9"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)1" . "winum-select-window-1") .
+                ("\\11..9" . "select window 1..9"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; Hide the entries for M-[2-9] in the SPC h k Top-level bindings,
   ;; and for [2-9] in the SPC- Spacemacs root
-  (push '((nil . "winum-select-window-[2-9]") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '((nil . "winum-select-window-[2-9]") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; SPC- Spacemacs root
   ;; Combine the ` (backtick) and ² (superscript 2) key entries
-  (push '(("\\(.*\\)`" . "winum-select-window-by-number") .
-          ("\\1`,²" . "select window by number"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)`" . "winum-select-window-by-number") .
+                ("\\1`,²" . "select window by number"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "² -> winum-select-window-by-number" entry
-  (push '(("\\(.*\\)²" . nil) . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)²" . nil) . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; SPC b- buffers
   ;; rename the buffer-to-window-1 entry, to 1..9
-  (push '(("\\(.*\\)1" . "Move buffer to window 1") .
-          ("\\11..9" . "Move buffer to window 1..9"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)1" . "Move buffer to window 1") .
+                ("\\11..9" . "Move buffer to window 1..9"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "[2-9] -> buffer-to-window-[2-9]" entries
-  (push '((nil . "Move buffer to window [2-9]") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '((nil . "Move buffer to window [2-9]") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; SPC k- lisp
   ;; rename "1 .. 9 -> digit-argument" to "1..9 -> digit-argument"
-  (push '(("\\(.*\\)1 .. 9" . "evil-lisp-state-digit-argument") .
-          ("\\11..9" . "digit-argument"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)1 .. 9" . "evil-lisp-state-digit-argument") .
+                ("\\11..9" . "digit-argument"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; SPC n- narrow/numbers
   ;; Combine + and =
-  (push '(("\\(.*\\)+" . "evil-numbers/inc-at-pt") .
-          ("\\1+,=" . "evil-numbers/inc-at-pt"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)+" . "evil-numbers/inc-at-pt") .
+                ("\\1+,=" . "evil-numbers/inc-at-pt"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide "= -> evil-numbers/inc-at-pt" entry
-  (push '(("\\(.*\\)=" . "evil-numbers/inc-at-pt") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)=" . "evil-numbers/inc-at-pt") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; Combine - and _
-  (push '(("\\(.*\\)-" . "evil-numbers/dec-at-pt") .
-          ("\\1-,_" . "evil-numbers/dec-at-pt"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)-" . "evil-numbers/dec-at-pt") .
+                ("\\1-,_" . "evil-numbers/dec-at-pt"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide "_ -> evil-numbers/dec-at-pt" entry
-  (push '(("\\(.*\\)_" . "evil-numbers/dec-at-pt") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)_" . "evil-numbers/dec-at-pt") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; SPC x i- inflection
   ;; rename "k -> string-inflection-kebab-case"
   ;; to "k,- -> string-inflection-kebab-case"
-  (push '(("\\(.*\\)k" . "string-inflection-kebab-case") .
-          ("\\1k,-" . "string-inflection-kebab-case"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)k" . "string-inflection-kebab-case") .
+                ("\\1k,-" . "string-inflection-kebab-case"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "- -> string-inflection-kebab-case" entry
-  (push '(("\\(.*\\)-" . "string-inflection-kebab-case") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)-" . "string-inflection-kebab-case") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; rename "u -> string-inflection-underscore"
   ;; to "u,_ -> string-inflection-underscore"
-  (push '(("\\(.*\\)u" . "string-inflection-underscore") .
-          ("\\1u,_" . "string-inflection-underscore"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)u" . "string-inflection-underscore") .
+                ("\\1u,_" . "string-inflection-underscore"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "_ -> string-inflection-underscore" entry
-  (push '(("\\(.*\\)_" . "string-inflection-underscore") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)_" . "string-inflection-underscore") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; C-c C-w-
   ;; rename the eyebrowse-switch-to-window-config-0 entry, to 0..9
-  (push '(("\\(.*\\)0" . "eyebrowse-switch-to-window-config-0") .
-          ("\\10..9" . "eyebrowse-switch-to-window-config-0..9"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)0" . "eyebrowse-switch-to-window-config-0") .
+                ("\\10..9" . "eyebrowse-switch-to-window-config-0..9"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "[1-9] -> eyebrowse-switch-to-window-config-[1-9]" entries
-  (push '((nil . "eyebrowse-switch-to-window-config-[1-9]") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '((nil . "eyebrowse-switch-to-window-config-[1-9]") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; Combine the c and C-c key entries
-  (push '(("\\(.*\\)C-c C-w c" . "eyebrowse-create-window-config") .
-          ("\\1c,C-c" . "eyebrowse-create-window-config"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-c C-w c" . "eyebrowse-create-window-config") .
+                ("\\1c,C-c" . "eyebrowse-create-window-config"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "C-c -> eyebrowse-create-window-config" entry
-  (push '(("\\(.*\\)C-c C-w C-c" . "eyebrowse-create-window-config") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-c C-w C-c" . "eyebrowse-create-window-config") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; C-c C-d-
   ;; Combine the d and C-d key entries
-  (push '(("\\(.*\\)C-c C-d d" . "elisp-slime-nav-describe-elisp-thing-at-point") .
-          ("\\1d,C-d" . "elisp-slime-nav-describe-elisp-thing-at-point"))
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-c C-d d" . "elisp-slime-nav-describe-elisp-thing-at-point") .
+                ("\\1d,C-d" . "elisp-slime-nav-describe-elisp-thing-at-point"))
+              which-key-replacement-alist
+              :test #'equal)
 
   ;; hide the "C-d -> elisp-slime-nav-describe-elisp-thing-at-point" entry
-  (push '(("\\(.*\\)C-c C-d C-d" . "elisp-slime-nav-describe-elisp-thing-at-point") . t)
-        which-key-replacement-alist)
+  (cl-pushnew '(("\\(.*\\)C-c C-d C-d" . "elisp-slime-nav-describe-elisp-thing-at-point") . t)
+              which-key-replacement-alist
+              :test #'equal)
 
   (which-key-add-key-based-replacements
     dotspacemacs-leader-key '("root" . "Spacemacs root")


### PR DESCRIPTION
site-start may add entries to this list, which Spacemacs should not
remove.  Idempotency can be achieved by using `cl-pushnew` instead.