### PR TITLE
[helm] Skip applying theme if helm-theme does not change theme

### DIFF
--- a/layers/+completion/helm/funcs.el
+++ b/layers/+completion/helm/funcs.el
@@ -660,8 +660,9 @@ to buffers)."
 (defun spacemacs/helm-themes ()
   "List the theme candidates without number limit."
   (interactive)
-  (let (helm-candidate-number-limit
-        (orig-theme (or (car-safe custom-enabled-themes) 'default)))
+  (let* (helm-candidate-number-limit
+         (get-theme (lambda () (or (car-safe custom-enabled-themes) 'default)))
+         (orig-theme (funcall get-theme)))
     (unwind-protect
         (unless (helm :prompt (format "pattern (current theme: %s): " orig-theme)
                       :preselect (format "%s$" orig-theme)
@@ -670,7 +671,8 @@ to buffers)."
                                  :action 'spacemacs//helm-themes-load
                                  :persistent-action 'spacemacs//helm-themes-load)
                       :buffer "*helm-themes*")
-          (spacemacs//helm-themes-load (symbol-name orig-theme))))))
+          (unless (eq orig-theme (funcall get-theme))
+            (spacemacs//helm-themes-load (symbol-name orig-theme)))))))
 
 ;; Buffers ---------------------------------------------------------------------
 


### PR DESCRIPTION
It maybe trigger screen flash when calling the `spacemacs/helm-themes` (`SPC T s`) and quit (`C-g`) without change theme.

It caused by the `spacemacs/helm-themes` will call `spacemacs//helm-themes-load`, in the function will disable all themes, then apply the desired theme, it may lead flash on slow connection. 

This PR will apply the theme only for theme was changes to avoid the unnecessary flush.

Please help review the PR, thanks