### PR TITLE
[org] Wait until after user-config to check for alerts

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -634,9 +634,8 @@ Headline^^            Visit entry^^               Filter^^                    Da
     :defer t
     :init
     (when org-start-notification-daemon-on-startup
-        (org-alert-enable))
-    :commands (org-alert-check org-alert-enable org-alert-disable)
-    ))
+      (spacemacs/defer-until-after-user-config #'org-alert-enable))
+    :commands (org-alert-check org-alert-enable org-alert-disable)))
 
 (defun org/init-org-brain ()
   (use-package org-brain


### PR DESCRIPTION
Various org layer packages (such as org-modern) add hooks to
org-mode-hook.  If `org-alert-enable` is run too early, the agenda
files are visited before those packages have a chance to be configured
correctly, resulting in org-mode buffers being visited at startup but
without the desired minor modes.