### PR TITLE
[core] Limit advice depth to avoid excessive lisp nesting

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -137,7 +137,7 @@ of directories to file basenames."
         (setq filename (expand-file-name name path)))
       (list feature filename noerror)))
 
-  (advice-add #'require :filter-args #'require@LOAD-HINTS)
+  (advice-add #'require :filter-args #'require@LOAD-HINTS '((depth . -99)))
 
   ;; Advice to update load-hints after autoload generation.
   (define-advice package-generate-autoloads (:after (name pkg-dir) LOAD-HINTS)


### PR DESCRIPTION
There maybe an error message after load-hints enabled, reproduce steps are remove all installed packages and enable load-hints, then start Spacemacs to trigger packages full installation, then there should have an error message during byte-compile the package with-editor:
> error("Eager macro-expansion failure: %S" (excessive-lisp-nesting 1601))

This PR will fix the issue, and the change is inspired by similar scenario in the function `timeout-debounce`:
https://github.com/emacs-mirror/emacs/blob/0bf5898f20571897dc540d10cdc6f4c3a517a82c/lisp/emacs-lisp/timeout.el#L142-L145
```emacs-lisp
    (advice-add func :around (timeout--debounce-advice delay default)
                '((name . debounce)
                  (depth . -99)))))
```