### PR TITLE
[helm] Remove deprecated helm-posframe package

### DIFF
--- a/layers/+completion/helm/config.el
+++ b/layers/+completion/helm/config.el
@@ -40,8 +40,6 @@
 (define-obsolete-variable-alias
   'dotspacemacs-helm-position 'helm-position "20180608")
 
-(defvar helm-use-posframe nil
-  "Use helm-posframe to display completions in a separate frame")
 
 (defvar spacemacs-helm-rg-max-column-number 512
   "Controls the maximum number of columns to display with ripgrep (otherwise

--- a/layers/+completion/helm/packages.el
+++ b/layers/+completion/helm/packages.el
@@ -36,8 +36,6 @@
     helm-make
     helm-mode-manager
     helm-org
-    (helm-posframe :toggle helm-use-posframe
-                   )
     helm-projectile
     ;; FIXME Remove obsolete packages helm-swoop
     ;; helm-ag etc. (see https://github.com/melpa/melpa/pull/9520)
@@ -392,20 +390,6 @@
   (use-package helm-org
     :commands (helm-org-in-buffer-headings)
     :defer t))
-
-(defun helm/init-helm-posframe ()
-  (use-package helm-posframe
-    :defer t
-    :init
-    (setq helm-posframe-poshandler 'posframe-poshandler-frame-center)
-    (setq helm-posframe-width (round (* 0.618 (frame-width))))
-    (setq helm-posframe-height (round (* 0.618 (frame-height))))
-    (setq helm-posframe-parameters
-          '((internal-border-width . 2)
-            (left-fringe . 4)
-            (right-fringe . 4)
-            (undecorated . nil)))
-    (helm-posframe-enable)))
 
 (defun helm/pre-init-helm-projectile ()
   ;; overwrite projectile settings


### PR DESCRIPTION
According to the https://github.com/melpa/melpa/pull/9520, helm-posframe was removed from melpa, so it need receipt now. 