### PR TITLE
Fix spacemacs-modeline/init-spaceline

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -48,7 +48,7 @@
     (setq-default fancy-battery-show-percentage t)))
 
 (defun spacemacs-modeline/init-spaceline ()
-  (use-package spaceline
+  (use-package spaceline-config
     :commands (spaceline-compile spaceline-define-segment)
     :init
     (add-hook 'spacemacs-post-user-config-hook


### PR DESCRIPTION
The 94b3cda51 calls `(use-package spaceline ...)` leading to:

■  Error (use-package): spaceline/:config: Symbol’s function definition is void: spaceline-spacemacs-theme

Also the `#'spaceline-helm-mode` and `#'spaceline-info-mode` are not defined.