### PR TITLE
Fix claude-code installation instruction

### DIFF
--- a/layers/+tools/claude-code/README.org
+++ b/layers/+tools/claude-code/README.org
@@ -37,7 +37,7 @@ You will also need to install the Claude Code CLI tool:
 
 #+BEGIN_SRC sh
   # Install Claude Code CLI
-  npm install -g @anthropic/claude-code
+  npm install -g @anthropic-ai/claude-code
 
   # Or using other package managers
   brew install anthropic/tap/claude-code


### PR DESCRIPTION
According to [this web](https://docs.claude.com/en/docs/claude-code/overview) the command to install it is slightly different

If you follow the current instructions you'll get:

```shell
npm install -g @anthropic/claude-code
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@anthropic%2fclaude-code - Not found
npm ERR! 404 
npm ERR! 404  '@anthropic/claude-code@*' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jose/.npm/_logs/2025-09-19T17_44_33_612Z-debug-0.log
```

But, with the fix:

```shell
npm install -g @anthropic-ai/claude-code

added 3 packages in 2s

2 packages are looking for funding
  run `npm fund` for details
```

Thank you :heart: for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the `develop` branch and that you have read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file. It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.

Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!

This message should be replaced with a description of your change.

Cheers!
