### PR TITLE
[llm-client] Key binding for gptel-rewrite

### DIFF
--- a/layers/+web-services/llm-client/README.org
+++ b/layers/+web-services/llm-client/README.org
@@ -93,16 +93,17 @@ The layer provides several key bindings to interact with LLMs efficiently.
 
 ** GPTel
 
-| Key binding | Command                  | Description                    |
-|-------------+--------------------------+--------------------------------|
-| ~SPC $ g g~ | gptel                    | Start a new GPTel session      |
-| ~SPC $ g s~ | gptel-send               | Send a message to GPTel        |
-| ~SPC $ g q~ | gptel-abort              | Abort any active GPTel process |
-| ~SPC $ g m~ | gptel-menu               | Open the GPTel menu            |
-| ~SPC $ g c~ | gptel-add                | Add to context                 |
-| ~SPC $ g f~ | gptel-add-file           | Add a file to context          |
-| ~SPC $ g o~ | gptel-org-set-topic      | Set topic in Org-mode          |
-| ~SPC $ g p~ | gptel-org-set-properties | Set properties in Org-mode     |
+| Key binding | Command                  | Description                     |
+|-------------+--------------------------+---------------------------------|
+| ~SPC $ g g~ | gptel                    | Start a new GPTel session       |
+| ~SPC $ g s~ | gptel-send               | Send a message to GPTel         |
+| ~SPC $ g q~ | gptel-abort              | Abort any active GPTel process  |
+| ~SPC $ g m~ | gptel-menu               | Open the GPTel menu             |
+| ~SPC $ g c~ | gptel-add                | Add to context                  |
+| ~SPC $ g f~ | gptel-add-file           | Add a file to context           |
+| ~SPC $ g r~ | gptel-rewrite            | Rewrite or refactor text region |
+| ~SPC $ g o~ | gptel-org-set-topic      | Set topic in Org-mode           |
+| ~SPC $ g p~ | gptel-org-set-properties | Set properties in Org-mode      |
 
 In addition, this layer adds the following key bindings to =org-mode=
 

--- a/layers/+web-services/llm-client/packages.el
+++ b/layers/+web-services/llm-client/packages.el
@@ -66,7 +66,8 @@
       "$gc" 'gptel-add                      ; Add context
       "$gf" 'gptel-add-file                 ; Add a file
       "$go" 'gptel-org-set-topic            ; Set topic in Org-mode
-      "$gp" 'gptel-org-set-properties)))    ; Set properties in Org-mode
+      "$gp" 'gptel-org-set-properties       ; Set properties in Org-mode
+      "$gr" 'gptel-rewrite)))               ; Rewrite or refactor test region
 
 (defun llm-client/post-init-org ()
   "Set up Org-mode keybindings for GPTel."


### PR DESCRIPTION
Add key binding for `gptel-rewrite`, without it, we have to press `SPC $ g m` to get the gptel menu, then press `r` to call the rewrite function.