### PR TITLE
[defaults] Fix void-function move-buffer-to-window

### DIFF
--- a/layers/+tools/ipython-notebook/funcs.el
+++ b/layers/+tools/ipython-notebook/funcs.el
@@ -21,40 +21,39 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(when (configuration-layer/package-used-p 'company)
+(defun spacemacs/ein-company (command &optional arg &rest ignore)
+  (interactive (list 'interactive))
+  (pcase command
+    (`interactive (company-begin-backend 'company-ein))
+    (`prefix
+     (and (--filter (and (boundp it) (symbol-value it) (eql it 'ein:notebook-mode))
+                    minor-mode-list)
+          (company-grab-symbol-cons "\\.\\|->\\|::" 2)))
+    (`candidates
+     (lexical-let ((kernel (ein:get-kernel-or-error))
+                   (arg arg)
+                   (col (current-column)))
+       (cons :async
+             (lambda (cb)
+               (ein:kernel-complete
+                kernel
+                (string-trim-right (thing-at-point 'line t))
+                col
+                (list :complete_reply
+                      (list #'spacemacs//ein-company-callback cb))
+                nil)))))))
 
-  (defun spacemacs/ein-company (command &optional arg &rest ignore)
-    (interactive (list 'interactive))
-    (pcase command
-      (`interactive (company-begin-backend 'company-ein))
-      (`prefix
-       (and (--filter (and (boundp it) (symbol-value it) (eql it 'ein:notebook-mode))
-                      minor-mode-list)
-            (company-grab-symbol-cons "\\.\\|->\\|::" 2)))
-      (`candidates
-       (lexical-let ((kernel (ein:get-kernel-or-error))
-                     (arg arg)
-                     (col (current-column)))
-         (cons :async
-               (lambda (cb)
-                 (ein:kernel-complete
-                  kernel
-                  (string-trim-right (thing-at-point 'line t))
-                  col
-                  (list :complete_reply
-                        (list #'spacemacs//ein-company-callback cb))
-                  nil)))))))
+(defun spacemacs//ein-company-callback (args content metadata)
+  (let ((matches (append (plist-get content :matches) nil)))
+    (condition-case err
+        (progn
+          (funcall (car args) matches))
+      (error (error (format "Error %s running ein company completer." err))))))
 
-  (defun spacemacs//ein-company-callback (args content metadata)
-    (let ((matches (append (plist-get content :matches) nil)))
-      (condition-case err
-          (progn
-            (funcall (car args) matches))
-        (error (error (format "Error %s running ein company completer." err))))))
-  (defun spacemacs//ein-setup-company ()
-    (if (eq ein-backend 'jupyter)
-        (spacemacs|add-company-backends
-          :backends spacemacs/ein-company
-          :modes ein:notebook-mode
-          :append-hooks nil
-          :call-hooks t))))
+(defun spacemacs//ein-setup-company ()
+  (if (eq ein-backend 'jupyter)
+      (spacemacs|add-company-backends
+       :backends spacemacs/ein-company
+       :modes ein:notebook-mode
+       :append-hooks nil
+       :call-hooks t)))

--- a/layers/+tools/translate/funcs.el
+++ b/layers/+tools/translate/funcs.el
@@ -20,23 +20,20 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(when (and (configuration-layer/package-used-p 'translate-mode)
-           (configuration-layer/package-used-p 'go-translate))
+(defun translate/translate-current-reference-paragraph ()
+  "Show all available translations of the reference paragraph at point in a pop-up frame."
+  (interactive)
+  (gt-start translate//paragraph-translator))
 
-  (defun translate/translate-current-reference-paragraph ()
-    "Show all available translations of the reference paragraph at point in a pop-up frame."
-    (interactive)
-    (gt-start translate//paragraph-translator))
+(defun translate/translate-word-at-point ()
+  "Pop-up translations of the word at point."
+  (interactive)
+  (gt-start translate//word-translator))
 
-  (defun translate/translate-word-at-point ()
-    "Pop-up translations of the word at point."
-    (interactive)
-    (gt-start translate//word-translator))
-
-  (defun translate//set-translate-mode-paragraph-functions ()
-    (cond ((eq major-mode 'markdown-mode)
-           (setq translate-forward-paragraph-function 'markdown-forward-paragraph
-                 translate-backward-paragraph-function 'markdown-backward-paragraph))
-          ((eq major-mode 'org-mode)
-           (setq translate-forward-paragraph-function 'org-forward-paragraph
-                 translate-backward-paragraph-function 'org-backward-paragraph)))))
+(defun translate//set-translate-mode-paragraph-functions ()
+  (cond ((eq major-mode 'markdown-mode)
+         (setq translate-forward-paragraph-function 'markdown-forward-paragraph
+               translate-backward-paragraph-function 'markdown-backward-paragraph))
+        ((eq major-mode 'org-mode)
+         (setq translate-forward-paragraph-function 'org-forward-paragraph
+               translate-backward-paragraph-function 'org-backward-paragraph))))


### PR DESCRIPTION
- Don't try to avoid defining various functions at top level if some
  package doesn't exist---it's fine for them to just error.

- Replace soft message with a user-error.

- Do not check whether the winum package is configured by Spacemacs.
  It is sufficient for the winum feature to be provided by a site-lisp
  package.

- Fix up docstrings slightly, according to checkdoc.

Fix #17130.

See also #17080.