### PR TITLE
[plantuml] Auto adapter the GUI/TUI for plantuml preview

### DIFF
--- a/layers/+lang/plantuml/packages.el
+++ b/layers/+lang/plantuml/packages.el
@@ -43,6 +43,9 @@
     :config
     ;; Our default is jar execution, not server as server is not working reliable see #13574
     (setq plantuml-default-exec-mode 'jar)
+    ;; Convenient for GUI and TUI buffers
+    (define-advice plantuml-jar-output-type-opt (:around (ORIG output-type))
+      (funcall ORIG (if (display-graphic-p) output-type "txt")))
     ;; for now plantuml electric indentation is buggy and does not
     ;; really work, let's disable auto-indentation on paste for
     ;; this mode


### PR DESCRIPTION
When enabled the `plantuml` layer, I have to manually adapter it to work with TUI (especially for Emacs daemon, some times there is GUI frame, some times there is TUI frame). 

This patch will auto adapter the TUI/GUI for user to preview the planuml diagram.
Here is a TUI screen shot:

<img width="1125" height="432" alt="image" src="https://github.com/user-attachments/assets/a0e0cd62-b444-4c20-83f5-904c1efc422f" />
