### PR TITLE
fix: set next-error-last-buffer when calling pytest

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -278,6 +278,15 @@ location of \".venv\" file, then relative to pyvenv-workon-home()."
 ;; Tests
 
 ;; python-pytest adapters
+
+(defun spacemacs/around-python-pytest--get-buffer (fn &rest args)
+  "Adjust the caller's next-error-last-buffer"
+  (let ((buffer (apply fn args)))
+    (unless (eq buffer (current-buffer))
+      (setq-local next-error-last-buffer buffer))
+
+    buffer))
+
 (defun spacemacs//python-pytest-one (&rest pytest-args)
   "Runs the correct python-pytest- function to run test the thing at point."
 

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -372,7 +372,10 @@
     (spacemacs//bind-python-testing-keys)
     ;; Make the override robust per-buffer, regardless of load order.
     (add-hook 'python-mode-local-vars-hook
-              #'spacemacs//python-pytest-set-root-from-setup-cfg)))
+              #'spacemacs//python-pytest-set-root-from-setup-cfg)
+
+    :config
+    (advice-add #'python-pytest--get-buffer :around #'spacemacs/around-python-pytest--get-buffer)))
 
 (defun python/init-python ()
   (use-package python


### PR DESCRIPTION
python-pytest does not use `compilation-start` (which would have taken care of that for us) and neither sets the variable manually.

This kludge works around that by advising python-pytest--get-buffer. This function is called from a python buffer when running pytest -- so it looks like the easiest way to intercept the pytest-buffer.