### PR TITLE
[ci] Warn PR submitters if they are modifying bot-maintained files

### DIFF
--- a/.circleci/PR_bot_files
+++ b/.circleci/PR_bot_files
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+## PR bot file check script for CircleCI
+##
+## Copyright (c) 2012-2014 Sylvain Benner
+## Copyright (c) 2014-2025 Sylvain Benner & Contributors
+##
+## Author: Aaron L Zeng
+## URL: https://github.com/syl20bnr/spacemacs
+##
+## This file is not part of GNU Emacs.
+##
+## License: GPLv3
+
+fail_when_undefined_pr_number
+built_in_manifest=".ci/built_in_manifest"
+
+pr_owner=$(curl -s "${pr_data_URL}" | jq -r '.head.owner.name')
+if [[ ${pr_owner} == "${UPD_BOT_LOGIN}" ]]; then
+  echo "This PR is from the bot, who is allowed to update built-in files."
+  exit 0
+fi
+
+echo_headline "Checking PR diff for bot-maintained files"
+
+# https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
+# This endpoint is paginated, but trying to fetch each page of the results
+# would be too complex for this bash script.  Instead, just fetch as many as
+# possible in one page---that's enough for almost all PRs.
+changed_files=$(curl -sL \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${pr_files_URL}?per_page=100" \
+  | jq -r '.[].filename' \
+  | LC_ALL=C sort)
+
+manifest_files=$(cut -f2 -d " " "$built_in_manifest" \
+  | LC_ALL=C sort)
+
+intersection=$(
+  LC_ALL=C comm -12 <(printf "%s\n" "$changed_files") <(printf "%s\n" "$manifest_files")
+)
+
+if [[ -n $intersection ]]; then
+  echo "The following files are auto-updated by the bot, and any changes will be overwritten."
+  echo "You should remove changes to these files from the PR, and"
+  echo "consider submitting your changes to the upstream source instead:"
+  echo
+  printf "%s\n" "$intersection"
+  exit 2
+fi

--- a/.circleci/built_in/upd_built_in
+++ b/.circleci/built_in/upd_built_in
@@ -12,14 +12,12 @@
 
 echo_headline "Downloading and replacing files"
 built_in_manifest=".ci/built_in_manifest"
-lines=$(cat "${built_in_manifest}")
-while read line; do
-    url=$(echo $line | cut -f1 -d " ")
-    target=$(echo $line | cut -f2 -d " ")
-    curl "${url}" --output "${target}"
-    if [ $? -ne 0 ]; then
-        echo "Failed to update built in file: ${target} from url: ${url}"
-        echo "Please update manifest file: ~/.emacs.d/.ci/built_in_manifest"
-        exit 2
-    fi
+while read -r line; do
+  url=$(cut -f1 -d " " <<<"$line")
+  target=$(cut -f2 -d " " <<<"$line")
+  if ! curl "${url}" --output "${target}"; then
+    echo "Failed to update built in file: ${target} from url: ${url}"
+    echo "Please update manifest file: ~/.emacs.d/.ci/built_in_manifest"
+    exit 2
+  fi
 done <"${built_in_manifest}"

--- a/.circleci/config_tmpl.yml
+++ b/.circleci/config_tmpl.yml
@@ -42,6 +42,9 @@ jobs:
       - run:
           name: Make sure that this PR targets develop branch
           command: .circleci/PR_base
+      - run:
+          name: Make sure that this PR doesn't update bot-maintained files
+          command: .circleci/PR_bot_files
   "Validate Documentation":
     executor: spacetools
     environment:

--- a/.circleci/shared
+++ b/.circleci/shared
@@ -23,6 +23,7 @@ upstream_data_URL_root+="${prj_repo}"
 
 CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
 pr_data_URL="${upstream_data_URL_root}/pulls/${CIRCLE_PR_NUMBER}"
+pr_files_URL="${upstream_data_URL_root}/pulls/${CIRCLE_PR_NUMBER}/files"
 upstream_data_URL="${upstream_data_URL_root}/branches/develop"
 
 pr_file_list_URL="${api_URL_root}/"


### PR DESCRIPTION
As I recently made this exact mistake in #17149, I feel it would be
nice if the CI reminded contributors (both long-time and newcomers)
that PRs making changes to any bot-maintained files will just see
their changes erased by the bot.