### PR TITLE
[core] Set undo-redo as default undo system

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -386,12 +386,11 @@ Point size is recommended, because it's device independent. (default 10.0)"
   '(choice (const evil) (const origami) (const vimish))
   'spacemacs-dotspacemacs-init)
 
-(spacemacs|defc dotspacemacs-undo-system 'undo-fu
+(spacemacs|defc dotspacemacs-undo-system 'undo-redo
   "The backend used for undo/redo functionality. Possible values are
-`undo-fu', `undo-redo' and `undo-tree' see also `evil-undo-system'.
+`undo-redo', `undo-fu' and `undo-tree' see also `evil-undo-system'.
 Note that saved undo history does not get transferred when changing
-your undo system. The default is currently `undo-fu' as `undo-tree'
-is not maintained anymore and `undo-redo' is very basic."
+your undo system from or to undo-tree. (default `undo-redo')"
   '(choice (const undo-fu) (const undo-redo) (const undo-tree))
   'spacemacs-dotspacemacs-init)
 

--- a/core/templates/dotspacemacs-template.el
+++ b/core/templates/dotspacemacs-template.el
@@ -463,11 +463,10 @@ It should only modify the values of Spacemacs settings."
    dotspacemacs-search-tools '("rg" "ag" "ack" "grep")
 
    ;; The backend used for undo/redo functionality. Possible values are
-   ;; `undo-fu', `undo-redo' and `undo-tree' see also `evil-undo-system'.
+   ;; `undo-redo', `undo-fu' and `undo-tree' see also `evil-undo-system'.
    ;; Note that saved undo history does not get transferred when changing
-   ;; your undo system. The default is currently `undo-fu' as `undo-tree'
-   ;; is not maintained anymore and `undo-redo' is very basic."
-   dotspacemacs-undo-system 'undo-fu
+   ;; your undo system from or to undo-tree. (default `undo-redo')"
+   dotspacemacs-undo-system 'undo-redo
 
    ;; Format specification for setting the frame title.
    ;; %a - the `abbreviated-file-name', or `buffer-name'


### PR DESCRIPTION
The built-in undo/redo system is more stable and provides all the functionality nowadays that undo-fu does. There is no need to reimplement this. In particular, the undo in region feature works perfectly with undo-redo, while it seems to have issues with undo-fu.