### PR TITLE
[spacemacs-navigation] Fix restart-stock-emacs-with-packages (SPC q D)

### DIFF
--- a/layers/+spacemacs/spacemacs-navigation/funcs.el
+++ b/layers/+spacemacs/spacemacs-navigation/funcs.el
@@ -522,14 +522,19 @@ ivy"
   (spacemacs/restart-emacs (cons "--adv-timers" args)))
 
 (defun spacemacs/restart-stock-emacs-with-packages (packages &optional args)
-  "Restart emacs without the spacemacs configuration, enable
-debug-init and load the given list of packages."
+  "Restart Emacs without the Spacemacs configuration, enable
+--debug-init and load the given list of packages."
   (interactive
    (progn
      (unless package--initialized
        (package-initialize t))
      (let ((packages (append (mapcar 'car package-alist)
-                             (mapcar 'car package-archive-contents)
+                             ;; In order to activate packages from an archive
+                             ;; that are not installed (i.e. not in `package-alist'),
+                             ;; we would first need to set up `package-archives' and
+                             ;; then install the packages, perhaps implicitly via
+                             ;; `use-package-always-ensure'.
+                             ;; (mapcar 'car package-archive-contents)
                              (mapcar 'car package--builtins))))
        (setq packages (mapcar 'symbol-name packages))
        (let ((val (completing-read-multiple "Packages to load (comma separated): "
@@ -539,7 +544,10 @@ debug-init and load the given list of packages."
                                          packages " ")))
     (spacemacs/restart-emacs-debug-init
      (append (list "-q" "--execute"
-                   (concat "(progn (package-initialize) "
-                           "(require 'use-package)"
-                           load-packages-string ")"))
+                   (format "
+(progn
+  (setq package-user-dir %S)
+  (package-initialize)
+  (require 'use-package)
+  %s)" package-user-dir load-packages-string))
              args))))


### PR DESCRIPTION
This was broken since Spacemacs does not use the default value of `package-user-dir`, but a subdirectory specifying the Emacs version and the Spacemacs branch.

Also, only offer installed packages in the prompt, because other packages from archives would not get installed automatically and yield errors on startup.