### PR TITLE
[navigation] Add cycling functionality to SPC TAB and SPC w TAB

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -483,6 +483,36 @@ window."
   'boolean
   'spacemacs-dotspacemacs-init)
 
+(spacemacs|defc dotspacemacs-enable-cycling nil
+  "Make consecutive tab key presses after
+`spacemacs/alternate-buffer' (SPC TAB) or
+`spacemacs/alternate-window' (SPC w TAB) cycle through previous buffers
+or windows. After arriving at the destination buffer/window, from the
+point of view of consecutive commands, it is as if the destination was
+directly switched to. By default, the backspace key cycles in the
+opposite direction.
+
+You can customize the cycling keys with the options
+`spacemacs-default-cycle-forwards-key',
+`spacemacs-default-cycle-backwards-key', or with the command-specific
+variants `spacemacs-alternate-buffer-cycle-forwards-key',
+`spacemacs-alternate-buffer-cycle-backwards-key'
+`spacemacs-alternate-window-cycle-forwards-key', and
+`spacemacs-alternate-window-cycle-backwards-key',
+
+Moreover, you can set the option `transient-cycles-show-cycling-keys' to
+nil to suppress the message specifying the cycling keys in each invocation.
+
+Note that this feature requires Emacs 29 or later.
+
+Set the option to t in order to enable cycling for all current and
+future cycling commands. Alternatively, choose a subset of the currently
+supported commands: '(alternate-buffer alternate-window). (default nil)"
+  '(choice (const t)
+           (repeat (choice (const alternate-buffer)
+                           (const alternate-window))))
+  'spacemacs-dotspacemacs-init)
+
 (spacemacs|defc dotspacemacs-maximize-window-keep-side-windows t
   "Whether side windows (such as those created by treemacs or neotree)
 are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m)."

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -330,39 +330,29 @@ buffer."
 
 (define-obsolete-function-alias 'spacemacs/derived-mode-p 'provided-mode-derived-p "2024-06")
 
+(defun spacemacs//alternate-buffer-skip (_window buffer _bury-or-kill)
+  "For use as `switch-to-prev-buffer-skip' in `spacemacs/alternate-buffer'."
+  (or (and (bound-and-true-p spacemacs-useful-buffers-restrict-spc-tab)
+           (spacemacs/useless-buffer-p buffer))
+      (and (bound-and-true-p spacemacs-layouts-restrict-spc-tab)
+           (not (member buffer (persp-buffer-list))))))
+
 (defun spacemacs/alternate-buffer (&optional window)
   "Switch back and forth between current and last buffer in WINDOW.
 
-WINDOW defaults to the selected window.
+If `spacemacs-useful-buffers-restrict-spc-tab' is non-nil, then this
+only switches to useful buffers, see `spacemacs-useful-buffers-regexp'.
+Additionally, if `spacemacs-layouts-restrict-spc-tab' is non-nil, then
+this only switches to the current layout's buffers.
 
-If `spacemacs-layouts-restrict-spc-tab' is non-nil, then this
-only switches between the current layout's buffers."
+The optional WINDOW parameter for non-interactive calls is deprecated.
+Instead, use `with-selected-window'."
   (interactive)
-  (cl-destructuring-bind (buf start pos)
-      (let ((my-buffer (window-buffer window))
-            (usefulp (if (bound-and-true-p spacemacs-useful-buffers-restrict-spc-tab)
-                         (symbol-function 'spacemacs/useful-buffer-p)
-                       #'always))
-            (predicate #'always)
-            (default (list (other-buffer) nil nil)))
-
-        (when (bound-and-true-p spacemacs-layouts-restrict-spc-tab)
-          (let ((buffer-list (persp-buffer-list)))
-            ;; find buffer of the same persp in window, and don't try
-            ;; `other-buffer'
-            (setq predicate (lambda (buffer) (member buffer buffer-list))
-                  default (list nil nil nil))))
-
-        (seq-find (lambda (it)
-                    (let ((buffer (car it)))
-                      (and (not (eq buffer my-buffer))
-                           (funcall usefulp buffer)
-                           (funcall predicate buffer))))
-                  (window-prev-buffers window)
-                  default))
-    (if (not buf)
-        (message "Last buffer not found.")
-      (set-window-buffer-start-and-point window buf start pos))))
+  (let ((switch-to-prev-buffer-skip #'spacemacs//alternate-buffer-skip))
+    (with-selected-window (or window (selected-window))
+      (set-window-next-buffers nil nil)
+      (previous-buffer)
+      (set-window-next-buffers nil nil))))
 
 (defun spacemacs/alternate-window ()
   "Switch back and forth between current and last window in the

--- a/core/core-funcs.el
+++ b/core/core-funcs.el
@@ -347,7 +347,12 @@ this only switches to the current layout's buffers.
 
 The optional WINDOW parameter for non-interactive calls is deprecated.
 Instead, use `with-selected-window'."
+  (declare (advertised-calling-convention () "2025-10"))
   (interactive)
+  (when window
+    (lwarn '(spacemacs core-funcs)
+           :warning
+           "The WINDOW argument to `spacemacs/alternate-buffer' is deprecated."))
   (let ((switch-to-prev-buffer-skip #'spacemacs//alternate-buffer-skip))
     (with-selected-window (or window (selected-window))
       (set-window-next-buffers nil nil)

--- a/core/templates/dotspacemacs-template.el
+++ b/core/templates/dotspacemacs-template.el
@@ -325,6 +325,14 @@ It should only modify the values of Spacemacs settings."
    ;; displayed in the current window. (default nil)
    dotspacemacs-switch-to-buffer-prefers-purpose nil
 
+   ;; Make consecutive tab key presses after commands such as
+   ;; `spacemacs/alternate-buffer' (SPC TAB) cycle through previous
+   ;; buffers/windows/etc. Please see the option's docstring for more information.
+   ;; Set the option to t in order to enable cycling for all current and
+   ;; future cycling commands. Alternatively, choose a subset of the currently
+   ;; supported commands: '(alternate-buffer alternate-window). (default nil)
+   dotspacemacs-enable-cycling nil
+
    ;; Whether side windows (such as those created by treemacs or neotree)
    ;; are kept or minimized by `spacemacs/toggle-maximize-window' (SPC w m).
    ;; (default t)

--- a/layers/+spacemacs/spacemacs-navigation/README.org
+++ b/layers/+spacemacs/spacemacs-navigation/README.org
@@ -22,6 +22,7 @@ This layer adds general navigation functions to all supported layers.
 - Support for =paradox= a modern emacs package manager
 - Shortcuts for restarting =emacs=
 - Shortcuts for easily switching between windows
+- Adds cycling functionality to some commands (see =dotspacemacs-enable-cycling=)
 
 * Key bindings
 

--- a/layers/+spacemacs/spacemacs-navigation/config.el
+++ b/layers/+spacemacs/spacemacs-navigation/config.el
@@ -1,0 +1,50 @@
+;;; config.el --- Spacemacs Navigation Layer config File  -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2025 Sylvain Benner & Contributors
+;;
+;; Author: Ferdinand Nussbaum <ferdinand.nussbaum@inf.ethz.ch>
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defvar spacemacs-default-cycle-forwards-key [tab]
+  "Key to cycle forwards after commands determined
+by `dotspacemacs-enable-cycling'.")
+
+(defvar spacemacs-default-cycle-backwards-key [backspace]
+  "Key to cycle backwards after commands determined
+by `dotspacemacs-enable-cycling'.")
+
+(defvar spacemacs-alternate-buffer-cycle-forwards-key nil
+  "Key to cycle forwards after an invocation of
+`spacemacs/alternate-buffer'.
+
+See `dotspacemacs-enable-cycling'.")
+
+(defvar spacemacs-alternate-buffer-cycle-backwards-key nil
+  "Key to cycle backwards after an invocation of
+`spacemacs/alternate-buffer'.
+
+See `dotspacemacs-enable-cycling'.")
+
+(defvar spacemacs-alternate-window-cycle-forwards-key nil
+  "Key to cycle forwards after an invocation of
+`spacemacs/alternate-window'.
+
+See `dotspacemacs-enable-cycling'.")
+
+(defvar spacemacs-alternate-window-cycle-backwards-key nil
+  "Key to cycle backwards after an invocation of
+`spacemacs/alternate-window'.
+
+See `dotspacemacs-enable-cycling'.")

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- Spacemacs Navigation Layer packages File  -*- lexical-binding: nil; -*-
+;;; packages.el --- Spacemacs Navigation Layer packages File  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -39,6 +39,9 @@
         restart-emacs
         (smooth-scrolling :location built-in)
         symbol-overlay
+        (transient-cycles
+         :toggle (and dotspacemacs-enable-cycling
+                      (version<= "29.1" emacs-version)))
         winum
         disable-mouse))
 
@@ -432,6 +435,68 @@
       ("t" symbol-overlay-toggle-in-scope)
       ("z" recenter-top-bottom)
       ("q" nil :exit t))))
+
+(defun spacemacs-navigation/init-transient-cycles ()
+  (use-package transient-cycles
+    :demand t
+    :config
+    (when (or (eq t dotspacemacs-enable-cycling)
+              (member 'alternate-buffer dotspacemacs-enable-cycling))
+      (transient-cycles-define-commands
+       (window prev-buffers)
+       (([remap spacemacs/alternate-buffer] ()
+         (interactive)
+         (setq window (selected-window) ; account for calls inside with-selected-window
+               prev-buffers (cons
+                             (list (window-buffer)
+                                   (copy-marker (window-start))
+                                   (copy-marker (window-point)))
+                             (window-prev-buffers window)))
+         (set-window-next-buffers nil nil)
+         (let ((switch-to-prev-buffer-skip
+                (symbol-function #'spacemacs//alternate-buffer-skip)))
+           (previous-buffer))))
+       (lambda (_ignore)
+         (lambda (arg)
+           (with-selected-window window
+             (let ((switch-to-prev-buffer-skip
+                    (symbol-function #'spacemacs//alternate-buffer-skip)))
+               (if (cl-plusp arg)
+                   (previous-buffer)
+                 (next-buffer))))))
+       :on-exit (progn (set-window-next-buffers window nil)
+                       (set-window-prev-buffers window prev-buffers))
+       :cycle-backwards-key (or spacemacs-alternate-buffer-cycle-backwards-key
+                                spacemacs-default-cycle-backwards-key)
+       :cycle-forwards-key (or spacemacs-alternate-buffer-cycle-forwards-key
+                               spacemacs-default-cycle-forwards-key)))
+    (when (or (eq t dotspacemacs-enable-cycling)
+              (member 'alternate-window dotspacemacs-enable-cycling))
+      (transient-cycles-define-commands
+       (sorted-windows index)
+       (([remap spacemacs/alternate-window] ()
+         (interactive)
+         (setq sorted-windows
+               (sort (window-list)
+                     (lambda (w1 w2)
+                       (> (window-use-time w1)
+                          (window-use-time w2))))
+               index 1)
+         (when (length= sorted-windows 1)
+           (user-error "Last window not found."))
+         (select-window (nth index sorted-windows) 'mark-for-redisplay)))
+       (lambda (_ignore)
+         (lambda (arg)
+           (setq index (mod (if (cl-plusp arg)
+                                (1+ index)
+                              (1- index))
+                          (length sorted-windows)))
+           (select-window (nth index sorted-windows) 'mark-for-redisplay)))
+       :on-exit (select-window (selected-window)) ; set the window-use-time
+       :cycle-forwards-key (or spacemacs-alternate-window-cycle-forwards-key
+                               spacemacs-default-cycle-forwards-key)
+       :cycle-backwards-key (or spacemacs-alternate-window-cycle-backwards-key
+                                spacemacs-default-cycle-backwards-key)))))
 
 (defun spacemacs-navigation/init-winum ()
   (use-package winum

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -446,12 +446,9 @@
        (window prev-buffers)
        (([remap spacemacs/alternate-buffer] ()
          (interactive)
+         (push-window-buffer-onto-prev)
          (setq window (selected-window) ; account for calls inside with-selected-window
-               prev-buffers (cons
-                             (list (window-buffer)
-                                   (copy-marker (window-start))
-                                   (copy-marker (window-point)))
-                             (window-prev-buffers window)))
+               prev-buffers (window-prev-buffers))
          (set-window-next-buffers nil nil)
          (let ((switch-to-prev-buffer-skip #'spacemacs//alternate-buffer-skip))
            (previous-buffer))))
@@ -463,7 +460,10 @@
                    (previous-buffer)
                  (next-buffer))))))
        :on-exit (progn (set-window-next-buffers window nil)
-                       (set-window-prev-buffers window prev-buffers))
+                       (set-window-prev-buffers window prev-buffers)
+                       (with-current-buffer (window-buffer window)
+                         (when (bound-and-true-p tab-line-mode)
+                           (tab-line-force-update nil))))
        :cycle-backwards-key (or spacemacs-alternate-buffer-cycle-backwards-key
                                 spacemacs-default-cycle-backwards-key)
        :cycle-forwards-key (or spacemacs-alternate-buffer-cycle-forwards-key

--- a/layers/+spacemacs/spacemacs-navigation/packages.el
+++ b/layers/+spacemacs/spacemacs-navigation/packages.el
@@ -453,14 +453,12 @@
                                    (copy-marker (window-point)))
                              (window-prev-buffers window)))
          (set-window-next-buffers nil nil)
-         (let ((switch-to-prev-buffer-skip
-                (symbol-function #'spacemacs//alternate-buffer-skip)))
+         (let ((switch-to-prev-buffer-skip #'spacemacs//alternate-buffer-skip))
            (previous-buffer))))
        (lambda (_ignore)
          (lambda (arg)
            (with-selected-window window
-             (let ((switch-to-prev-buffer-skip
-                    (symbol-function #'spacemacs//alternate-buffer-skip)))
+             (let ((switch-to-prev-buffer-skip #'spacemacs//alternate-buffer-skip))
                (if (cl-plusp arg)
                    (previous-buffer)
                  (next-buffer))))))


### PR DESCRIPTION
Sometimes one finds oneself in the situation where one used `SPC TAB` to switch to the last buffer, but it turns out that one actually intended to switch to the second or third to last buffer. By enabling the option added in this commit, one can consecutively press `TAB` in such situations to cycle through the previous buffers. From the point of view of subsequent commands it is as though one switched directly to the destination buffer. This uses the excellent transient-cycles package under the hood (https://elpa.gnu.org/packages/transient-cycles.html).

The setup needs lexical binding in `spacemacs-navigation/packages.el`. I have audited the file and it does not look as if anything depends on dynamic binding.

I considered (and implemented a first version) using hydra/Spacemacs transient states, by the way, but the implementation using the transient-cycles package is cleaner.

The current solution uses somewhat hacky advice to lazily load the package, not sure if this is controversial. Alternatives could be to use remapping instead of advice, or load the package at startup, or perhaps defer it for a few seconds (using `:defer 3`, for example).