### PR TITLE
[ci] Upgrade Emacs 29.3 to 29.4

### DIFF
--- a/.github/workflows/elisp_test.yml
+++ b/.github/workflows/elisp_test.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs_version: [29.3, 30.1]
+        emacs_version: [29.4, 30.1]
     steps:
 # Installing Emacs on Unix
     - name: Install Emacs on UNIX


### PR DESCRIPTION
Emacs 29.4 contains security fixes not present in Emacs 29.3.  The actual motivation is to get a newer Windows build of Emacs 29 so that it contains a new-enough ELPA signing key.  This, in turn, fixes the Python layer functional tests because otherwise `compat` could not be installed from GNU ELPA.