### PR TITLE
[ci] Fix python layer functional tests on windows, Emacs 29

### DIFF
--- a/spacemacs.mk
+++ b/spacemacs.mk
@@ -33,6 +33,7 @@ installation:
 	@echo "INSTALLATION OF PACKAGES FOR $(TEST_NAME)"
 	@echo "================================================================="
 	SPACEMACSDIR=$(TEST_DIR) emacs -Q -batch \
+		--eval '(setq package-check-signature nil)' \
 		$(addprefix -l $(EMACS_DIR)/, $(LOAD_FILES))
 
 ifneq ($(strip $(UNIT_TEST_FILES)),)


### PR DESCRIPTION
compat was unable to be installed due to a failed signature
verification when downloading the archive contents from GNU ELPA.

I attempted to import the updated key directly using gpg but ran into
other issues on macOS with GitHub Actions:
https://github.com/actions/runner-images/issues/9777.  So, instead
this just disables signature verification for the package archives in
CI.