### PR TITLE
[emacs-lisp] Fix spacemacs/ert-run-tests-buffer in Emacs 26+

### DIFF
--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -164,8 +164,7 @@ Intended for use in mode hooks."
 
 (defun spacemacs//find-ert-test-buffer (ert-test)
   "Return the buffer where ERT-TEST is defined."
-  (save-excursion
-    (car (find-definition-noselect (ert-test-name ert-test) 'ert-deftest))))
+  (car (find-definition-noselect (ert-test-name ert-test) 'ert--test)))
 
 (defun spacemacs/ert-run-tests-buffer ()
   "Run all the tests in the current buffer."

--- a/layers/+lang/emacs-lisp/funcs.el
+++ b/layers/+lang/emacs-lisp/funcs.el
@@ -163,8 +163,12 @@ Intended for use in mode hooks."
 ;; ERT commands
 
 (defun spacemacs//find-ert-test-buffer (ert-test)
-  "Return the buffer where ERT-TEST is defined."
-  (car (find-definition-noselect (ert-test-name ert-test) 'ert--test)))
+  "Return the buffer where ERT-TEST is defined.
+
+Return nil rather than erroring, if the buffer containing the test's
+definition is unknown."
+  (ignore-errors
+    (car (find-definition-noselect (ert-test-name ert-test) 'ert--test))))
 
 (defun spacemacs/ert-run-tests-buffer ()
   "Run all the tests in the current buffer."


### PR DESCRIPTION
Before this PR, `, t b` always errors if there are any ERT tests
defined, indicating that it failed to find the definition location of
any tests.