### PR TITLE
update layer +lang/emacs-lisp use-package to make :config section for…

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -103,6 +103,7 @@
       (spacemacs/set-leader-keys-for-major-mode mode
         "df" 'spacemacs/edebug-instrument-defun-on
         "dF" 'spacemacs/edebug-instrument-defun-off))
+    :config
     (spacemacs/declare-prefix-for-mode 'edebug-eval-mode "mg" "goto")
     (spacemacs/declare-prefix-for-mode 'edebug-eval-mode "me" "eval")
     (spacemacs/set-leader-keys-for-major-mode 'edebug-eval-mode


### PR DESCRIPTION
layer/+lang/emacs-lisp interferes with adding gptel llm client layer unless this is added for me.

Emacs 30.2 Windows 11, installed with winget.

… late bound variables or whatever the term is, causes the code in the config section for the emacs-lisp package to need to go there instead of init. Didn't encounter this until trying to load the gptel llm-client interface.
