### PR TITLE
[python] Add function `spacemacs/python-shell-send-line-switch'

### DIFF
--- a/layers/+lang/python/README.org
+++ b/layers/+lang/python/README.org
@@ -526,6 +526,7 @@ Send code to inferior process commands:
 | ~SPC m s F~ | send function and switch to REPL in insert mode              |
 | ~SPC m s i~ | start inferior REPL process                                  |
 | ~SPC m s l~ | send line and keep code buffer focused                       |
+| ~SPC m s L~ | send line and switch to REPL in insert mode                  |
 | ~SPC m s n~ | restart REPL process and keep code buffer focused            |
 | ~SPC m s N~ | restart REPL process and switch to REPL in insert mode       |
 | ~SPC m s r~ | send region and keep code buffer focused                     |

--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -626,6 +626,13 @@ Bind formatter to '==' for LSP and '='for all other backends."
         (end (point-at-eol)))
     (python-shell-send-region start end)))
 
+(defun spacemacs/python-shell-send-line-switch ()
+  "Send the current line to shell and switch to it insert mode."
+  (interactive)
+  (call-interactively #'spacemacs/python-shell-send-line)
+  (python-shell-switch-to-shell)
+  (evil-insert-state))
+
 (defun spacemacs/python-shell-send-statement ()
   "Send the statement under cursor to shell."
   (interactive)

--- a/layers/+lang/python/packages.el
+++ b/layers/+lang/python/packages.el
@@ -423,6 +423,7 @@
       "sN" 'spacemacs/python-shell-restart-switch
       "sR" 'spacemacs/python-shell-send-region-switch
       "sr" 'spacemacs/python-shell-send-region
+      "sL" 'spacemacs/python-shell-send-line-switch
       "sl" 'spacemacs/python-shell-send-line
       "ss" 'spacemacs/python-shell-send-with-output)
 


### PR DESCRIPTION
Fix #17170

Implement the sending line and switch to REPL for python mode. 