### PR TITLE
[core] Install packages in order of declaration

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1877,7 +1877,7 @@ RNAME is the name symbol of another existing layer."
             (when install-deps
               (setq result (append install-deps result))))
           (when (funcall filter pkg-name)
-            (cl-pushnew pkg-name result))))
+            (setq result (append result (list pkg-name))))))
       (delete-dups result))))
 
 (defun configuration-layer//filter-packages-with-deps

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -390,7 +390,10 @@ file. It can be overridden by users inside `dotspacemacs/user-init'.")
   "Hash map to index `cfgl-layer' objects by their names.")
 
 (defvar configuration-layer--used-packages '()
-  "An alphabetically sorted list of used package names.")
+  "A list of used package names.")
+
+(defvar configuration-layer--used-packages-sorted '()
+  "Like `configuration-layer--used-packages', but sorted alphabetically.")
 
 (defvar configuration-layer--indexed-packages (make-hash-table)
   "Hash map to index `cfgl-package' objects by their names.")
@@ -641,7 +644,7 @@ To prevent package from being installed or uninstalled set the variable
                  (not (eq 'template spacemacs-load-dotspacemacs)))
         (configuration-layer/delete-orphan-packages packages))))
   ;; configure used packages
-  (configuration-layer//configure-packages configuration-layer--used-packages)
+  (configuration-layer//configure-packages configuration-layer--used-packages-sorted)
   ;; evaluate layer variables a second time to override default values set in
   ;; packages configuration above
   (configuration-layer//set-layers-variables configuration-layer--used-layers)
@@ -922,7 +925,7 @@ a new object."
   "Describe a package in the context of the configuration layer system."
   (interactive
    (list (intern
-          (completing-read "Package: " configuration-layer--used-packages))))
+          (completing-read "Package: " configuration-layer--used-packages-sorted))))
   (help-setup-xref (list #'configuration-layer/describe-package
                          pkg-symbol layer-list pkg-list)
                    (called-interactively-p 'interactive))
@@ -1655,9 +1658,14 @@ RNAME is the name symbol of another existing layer."
     (configuration-layer/make-packages-from-layers layers t)
     (configuration-layer/make-packages-from-dotfile t)
     (setq configuration-layer--used-packages
-          (sort (cl-delete-if-not #'configuration-layer/package-used-p
-                                  configuration-layer--used-packages)
-                #'string<))))
+          (cl-delete-if-not #'configuration-layer/package-used-p
+                            ;; Reverse such that we get the order in which
+                            ;; packages are declared in each layer of
+                            ;; `configuration-layer--used-layers' and
+                            ;; `dotspacemacs-additional-packages'.
+                            (nreverse configuration-layer--used-packages))
+          configuration-layer--used-packages-sorted
+          (sort (cl-copy-list configuration-layer--used-packages) #'string<))))
 
 (defun configuration-layer//load-layers-files (layer-names files)
   "Load the files of list FILES for all passed LAYER-NAMES."
@@ -1754,10 +1762,10 @@ RNAME is the name symbol of another existing layer."
                          pkg-name)))
                    (oref layer packages)))))
       (let ((last-buffer (current-buffer))
-            (sorted-pkg (sort inst-pkgs #'string<)))
+            (sorted-pkg (sort (cl-copy-list inst-pkgs) #'string<)))
         (spacemacs-buffer/goto-buffer)
         (goto-char (point-max))
-        (configuration-layer//install-packages sorted-pkg)
+        (configuration-layer//install-packages inst-pkgs)
         (configuration-layer//configure-packages sorted-pkg)
         (configuration-layer//load-layer-files layer '("keybindings"))
         (oset layer lazy-install nil)
@@ -2134,7 +2142,7 @@ to update."
   (configuration-layer/retrieve-package-archives nil 'force)
   (setq configuration-layer--check-new-version-error-packages nil)
   (let* ((distant-packages (configuration-layer//filter-distant-packages
-                            configuration-layer--used-packages t))
+                            configuration-layer--used-packages-sorted t))
          (update-packages
           (configuration-layer//get-packages-to-update distant-packages))
          (skipped-count (length

--- a/doc/LAYERS.org
+++ b/doc/LAYERS.org
@@ -413,10 +413,12 @@ The Spacemacs loading process can be summarized as follows:
 
    Alternatively, if a package is part of the end user's
    =dotspacemacs-additional-packages=, it will also be installed.
-3. All packages which should be installed are installed in alphabetical order,
-   =package.el= built-in Emacs library is in charge of implicit dependencies.
-   Installed packages not following the rules of 2. are removed as well as
-   their dependencies if possible. (This last behavior is optional but default.)
+3. New versions of built-in packages, and =bootstrap= and =pre= packages are
+   installed first, then the remaining packages are installed in the order in
+   which they are declared. The built-in Emacs library =package.el= is in charge
+   of implicit dependencies. Installed packages not following the rules of 2.
+   are removed as well as their dependencies if possible. (This last behavior is
+   optional but default.)
 4. The =pre-init=, =init= and =post-init= functions for each installed package
    are executed in turn.
 


### PR DESCRIPTION
In particular, do not install packages in alphabetical order. This means one can manually manage dependencies for packages installed via quelpa, addressing https://github.com/syl20bnr/spacemacs/discussions/17176. This change should be safe, also the order of package installations was approximately reversed before without obvious regressions (see this PR's first commit).

Note that we still use the alphabetically sorted list of packages in other contexts, such as when configuring packages, mostly for backward compatibility.
