### PR TITLE
[core] Set evil-want-keybinding to nil before installing packages

### DIFF
--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -195,9 +195,14 @@ of directories to file basenames."
   (prefer-coding-system 'utf-8)
   ;; Extend use-package if installed.
   (spacemacs/use-package-extend)
-  ;; Evil mode settings for scrolling and jump behavior.
-  (setq-default evil-want-C-u-scroll t
-                evil-want-C-i-jump nil)
+  (setq-default
+   ;; Evil mode settings for scrolling and jump behavior.
+   evil-want-C-u-scroll t
+   evil-want-C-i-jump nil
+   ;; `evil-want-keybinding' needs to be set before loading evil, which can
+   ;; happen as a side effect of package installation or due to the user's
+   ;; dotfile, for example. `evil-collection' expects it to be nil.
+   evil-want-keybinding nil)
   ;; Load the user's dotspacemacs file.
   (dotspacemacs/load-file)
   ;; Call the user's initialization function.

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -78,8 +78,6 @@
   ;; evil-mode is mandatory for Spacemacs to work properly
   ;; evil must be required explicitly, the autoload seems to not
   ;; work properly sometimes.
-  ;; `evil-collection' wants this value
-  (setq evil-want-keybinding nil)
   (require 'evil)
   (evil-mode 1)
 


### PR DESCRIPTION
Byte-compilation of packages requiring evil somewhere will load evil, for example. This would previously lead to a warning at startup.