### PR TITLE
[gnus] Fix typo that broke keybinding

### DIFF
--- a/layers/+email/gnus/packages.el
+++ b/layers/+email/gnus/packages.el
@@ -51,7 +51,7 @@
     (spacemacs/declare-prefix-for-mode 'message-mode "mi" "insert")
     (spacemacs/set-leader-keys-for-major-mode 'message-mode
       ;; RFC 1855
-      "miF" 'flame-on)
+      "iF" 'spacemacs/gnus-flame-on)
     ;; NOTE: If any of the following variables are modified,
     ;; also update their values in: `gnus/README.org'
     (setq-default


### PR DESCRIPTION
In `gnus` layer, when authoring a message in Gnus (run `SPC aegg` and then `m`) and pressing a major mode leader key in the message buffer:
- which-key reports an `i : +insert` prefix, and when you press `i` the following message is shown:
 `which-key: There are no keys to show`
- which-key reports an `m : +prefix` prefix, which contains `i : +prefix` prefix with a sole `F : flame-on` keybinding (that does nothing when activated)

Looking at the code:
- [`i` prefix is explicitly defined for the `message-mode`](https://github.com/syl20bnr/spacemacs/blob/ccd3e200c2f88c3eb8b465fc00f34adc4d1d28fd/layers/%2Bemail/gnus/packages.el#L51) but never gets populated by anything
   - [`miF` leader keys are being added to the `mesage-mode`](https://github.com/syl20bnr/spacemacs/blob/ccd3e200c2f88c3eb8b465fc00f34adc4d1d28fd/layers/%2Bemail/gnus/packages.el#L54), but instead of populating the `i` prefix those keys implicitly create an `m` prefix
- [`'flame-on`](https://github.com/syl20bnr/spacemacs/blob/ccd3e200c2f88c3eb8b465fc00f34adc4d1d28fd/layers/%2Bemail/gnus/packages.el#L54) does not correspond to any symbol in the gnus layer
   - [`spacemacs/gnus-flame-on` function gets defined](https://github.com/syl20bnr/spacemacs/blob/ccd3e200c2f88c3eb8b465fc00f34adc4d1d28fd/layers/%2Bemail/gnus/packages.el#L96) but never seem to be used anywhere
   
Using `git blame` results in [this single commit](https://github.com/syl20bnr/spacemacs/commit/5d1cf35e48343fe6def1412c62694d73b4edaf17) by @equwal which adds all of the aforementioned code changes to the codebase.

This PR assumes that the authors intent was to bind `spacemacs/gnus-flame-on` to the `iF` leader keys of the `message-mode`.