### PR TITLE
[layouts] Fix error in switch-to-prev-buffer when persp-mode is excluded

### DIFF
--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -93,25 +93,19 @@ Cancels autosave on exiting perspectives mode."
   (let ((ivy-ignore-buffers (remove #'spacemacs//layout-not-contains-buffer-p ivy-ignore-buffers)))
     (ivy-switch-buffer)))
 
-(defmacro spacemacs||with-persp-buffer-list (&rest body)
-  "This one is a brute force version of `with-persp-buffer-list'.
-It maintains the order of the original `buffer-list'"
-  `(cl-letf* ((org-buffer-list
-               (symbol-function 'buffer-list))
-              ((symbol-function 'buffer-list)
-               #'(lambda (&optional frame)
-                   (seq-filter
-                    #'persp-contain-buffer-p
-                    (funcall org-buffer-list frame)))))
-     ,@body))
-
 (defun spacemacs-layouts//advice-with-persp-buffer-list (orig-fun &rest args)
-  "Advice to provide persp buffer list."
-  (spacemacs||with-persp-buffer-list () (apply orig-fun args)))
+  "Advise ORIG-FUN to make `buffer-list' only return buffers in the current layout.
+
+This is similar to `with-persp-buffer-list', but maintains the order of the list
+returned by `buffer-list'."
+  (cl-letf* ((orig-buffer-list (symbol-function 'buffer-list))
+             ((symbol-function 'buffer-list)
+              (lambda (&optional frame)
+                (seq-filter #'persp-contain-buffer-p (funcall orig-buffer-list frame)))))
+    (apply orig-fun args)))
 
 
 ;; Persp transient-state
-
 (defvar spacemacs--persp-display-buffers-func 'ignore
   "Function to display buffers in the perspective.")
 (defun spacemacs/persp-buffers ()

--- a/layers/+spacemacs/spacemacs-layouts/funcs.el
+++ b/layers/+spacemacs/spacemacs-layouts/funcs.el
@@ -98,10 +98,12 @@ Cancels autosave on exiting perspectives mode."
 
 This is similar to `with-persp-buffer-list', but maintains the order of the list
 returned by `buffer-list'."
-  (cl-letf* ((orig-buffer-list (symbol-function 'buffer-list))
-             ((symbol-function 'buffer-list)
-              (lambda (&optional frame)
-                (seq-filter #'persp-contain-buffer-p (funcall orig-buffer-list frame)))))
+  (if (fboundp 'persp-contain-buffer-p)
+      (cl-letf* ((orig-buffer-list (symbol-function 'buffer-list))
+                 ((symbol-function 'buffer-list)
+                  (lambda (&optional frame)
+                    (seq-filter #'persp-contain-buffer-p (funcall orig-buffer-list frame)))))
+        (apply orig-fun args))
     (apply orig-fun args)))
 
 


### PR DESCRIPTION
When the `persp-mode` package is excluded by
`dotspacemacs-excluded-packages`, and the `spacemacs-layouts` layer is
still enabled---as it is by default---the advice around functions
listed in `spacemacs-layouts-restricted-functions` can error, causing
the user to be unable to kill buffers, etc.

This PR just makes the advice check whether `persp-contain-buffer-p`
is actually defined before attempting to potentially call it around
`buffer-list`.

This PR also:

1. Fixes up some outdated docstrings
1. Removes a pointless private macro by just expanding it in the only
   callsite
1. ~Fixes the customization :set function to avoid an unnecessary extra
   variable, and also correctly use `set-default-toplevel-value` to
   avoid issues if the variable is currently let-bound.~ This was not essential,
   and I decided to remove it because it was not clear what to do with it during
   review.