### PR TITLE
Fix gptel advice function to return original function's value

### DIFF
--- a/layers/+web-services/llm-client/packages.el
+++ b/layers/+web-services/llm-client/packages.el
@@ -86,7 +86,8 @@
     (let ((purpose-mode-was-enabled (bound-and-true-p purpose-mode)))
       (when purpose-mode-was-enabled
         (purpose-mode -1))
-      (apply orig-func args)
-      (when purpose-mode-was-enabled
-        (purpose-mode 1))))
+      (unwind-protect
+          (apply orig-func args)
+        (when purpose-mode-was-enabled
+          (purpose-mode 1)))))
   (advice-add 'gptel :around #'llm-client/disable-purpose-mode-around-for-gptel))


### PR DESCRIPTION
Use prog1 to ensure `llm-client/disable-purpose-mode-around-for-gptel` returns the return value of the original gptel function while still properly managing purpose-mode state.


As `llm-client/disable-purpose-mode-around-for-gptel` originally does not return the original return value of `gptel`, it causes a parameter type error `(string-p t)` in the following scenario:

	1. The gptel session buffer has not yet been created
	2. In gptel-menu, set the response to as gptel session
	3. Press Enter to send the gptel request

Cheers!
