### PR TITLE
Fix wrong key in built-in update CI check

### DIFF
--- a/.circleci/PR_bot_files
+++ b/.circleci/PR_bot_files
@@ -14,7 +14,7 @@
 fail_when_undefined_pr_number
 built_in_manifest=".ci/built_in_manifest"
 
-pr_owner=$(curl -s "${pr_data_URL}" | jq -r '.head.owner.name')
+pr_owner=$(curl -s "${pr_data_URL}" | jq -r '.user.login')
 if [[ ${pr_owner} == "${UPD_BOT_LOGIN}" ]]; then
   echo "This PR is from the bot, who is allowed to update built-in files."
   exit 0


### PR DESCRIPTION
I noticed #17199 mysteriously
[failed](https://app.circleci.com/pipelines/github/syl20bnr/spacemacs/7069/workflows/24093485-4175-4c10-a0ac-45d7a4db83dd/jobs/81039)
the CI check and realized this was the wrong JSON key (path).  I
tested with a manual jq path, and this new one should be correct.