### PR TITLE
[modeline] Add Spacemacs state colors to vanilla mode line evil-state tag

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -1,4 +1,4 @@
-;;; config.el --- Spacemacs Bootstrap Layer configuration File  -*- lexical-binding: nil; -*-
+;;; config.el --- Spacemacs Bootstrap Layer configuration File  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;

--- a/layers/+distributions/spacemacs-bootstrap/config.el
+++ b/layers/+distributions/spacemacs-bootstrap/config.el
@@ -89,4 +89,4 @@ Otherwise, in visual state `u' downcases visually selected text.")
                                  ("iedit" "firebrick1" box)
                                  ("iedit-insert" "firebrick1" (bar . 2)))
   "Colors assigned to evil states with cursor definitions.
-To add your own, use `spacemacs/add-evil-curosr'.")
+To add your own, use `spacemacs/add-evil-cursor'.")

--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Spacemacs Bootstrap Layer functions File  -*- lexical-binding: nil; -*-
+;;; funcs.el --- Spacemacs Bootstrap Layer functions File  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -67,11 +67,13 @@ For evil states that also need an entry to `spacemacs-evil-cursors' use
   ;; for example treemacs: it needs no cursor since it solely uses hl-line-mode
   ;; and having an evil cursor defined anyway leads to the cursor sometimes
   ;; visibly flashing in treemacs buffers
-  (eval `(defface ,(spacemacs/state-color-face (intern state))
-           `((t (:background ,color :inherit 'mode-line)))
-           (format "%s state face." state)
-           :group 'spacemacs))
-  ;; 'unspecified may not be used in defface, so set it via set-face-attribute.
+  (custom-declare-face
+    (spacemacs/state-color-face (intern state))
+    `((t (:background ,color :inherit mode-line)))
+    (format "%s state face." state)
+    :group 'spacemacs)
+  ;; 'unspecified may not be used in custom-declare-face, so set it via
+  ;; set-face-attribute.
   (set-face-attribute (spacemacs/state-color-face (intern state)) nil
                       :foreground (face-attribute 'mode-line :background)))
 

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- Mandatory Bootstrap Layer packages File  -*- lexical-binding: nil; -*-
+;;; packages.el --- Mandatory Bootstrap Layer packages File  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;

--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -1,4 +1,4 @@
-;;; funcs.el --- Spacemacs Mode-line Layer functions File  -*- lexical-binding: nil; -*-
+;;; funcs.el --- Spacemacs Mode-line Layer functions File  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;

--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -78,10 +78,6 @@ Return nil if no scale is defined."
     (set-face-attribute 'powerline-inactive2 nil
                         :inherit 'font-lock-comment-face)))
 
-(defun spacemacs//evil-state-face ()
-  (let ((state (if (eq 'operator evil-state) evil-previous-state evil-state)))
-    (intern (format "spacemacs-%S-face" state))))
-
 (defun spacemacs//restore-buffers-powerline ()
   "Restore the powerline in the buffers.
 Excluding which-key."

--- a/layers/+spacemacs/spacemacs-modeline/funcs.el
+++ b/layers/+spacemacs/spacemacs-modeline/funcs.el
@@ -48,6 +48,26 @@ Return nil if no scale is defined."
       (plist-get (cdr dotspacemacs-mode-line-theme) :separator-scale))))
 
 
+;; vanilla mode line
+
+(defun spacemacs//colorize-evil-mode-line-tag (orig &optional state &rest args)
+  "Colorize the mode line tag for an evil state using the spacemacs-*-face faces.
+
+This function is suitable for being added as :around advice to
+`evil-generate-mode-line-tag'."
+  ;; This advice is needed to run as late as possible, because unfortunately
+  ;; there's no good way to reliably add faces to the tag strings.  For example,
+  ;; `spacemacs/define-evil-state-face' may in general be called before
+  ;; `evil-define-state' (such as for hybrid state) so we cannot yet mutate
+  ;; the tag strings at that time.
+  (let ((tag (apply orig state args)))
+    (if-let* (((stringp tag))
+              (face (spacemacs/state-face state))
+              ((facep face)))
+        (propertize tag 'face face)
+      tag)))
+
+
 ;; spaceline
 
 (defun spacemacs//enable-spaceline-p ()

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -93,7 +93,7 @@
     :config
     (spacemacs/customize-powerline-faces)
     (setq spaceline-org-clock-p nil
-          spaceline-highlight-face-func 'spacemacs//evil-state-face)
+          spaceline-highlight-face-func 'spacemacs/current-state-face)
     ;; unicode
     (let ((unicodep (dotspacemacs|symbol-value
                      dotspacemacs-mode-line-unicode-symbols)))

--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -24,6 +24,7 @@
 (setq spacemacs-modeline-packages
       '(
         (doom-modeline :toggle (eq (spacemacs/get-mode-line-theme-name) 'doom))
+        evil
         fancy-battery
         (spaceline :toggle (spacemacs//enable-spaceline-p))
         (spaceline-all-the-icons :toggle (eq (spacemacs/get-mode-line-theme-name) 'all-the-icons))
@@ -36,6 +37,9 @@
   (use-package doom-modeline
     :defer t
     :init (doom-modeline-mode)))
+
+(defun spacemacs-modeline/post-init-evil ()
+  (advice-add 'evil-generate-mode-line-tag :around #'spacemacs//colorize-evil-mode-line-tag))
 
 (defun spacemacs-modeline/init-fancy-battery ()
   (use-package fancy-battery


### PR DESCRIPTION
This PR improves the usability of the vanilla mode line theme by
colorizing the evil-state indicator (see evil-mode-line-format) in the
vanilla mode line format.  It uses the same colors that Spacemacs
would otherwise use with Spaceline (and also the same ones that
are used for the cursor in graphical Emacs, regardless of mode line
theme).

It includes a few preliminary cleanups and improvements as well.