### PR TITLE
[compleseus] adapt to the breaking changes in `consult`

### DIFF
--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -44,16 +44,16 @@ To restrict the commands to buffers of the current layout, customize
 the variable `spacemacs-layouts-restricted-functions'.")
 
 (defcustom compleseus-switch-to-buffer-sources
-  '(consult--source-hidden-buffer
+  '(consult-source-hidden-buffer
     compleseus--source-buffers-hidden
     compleseus--source-persp-buffers
     compleseus--source-persp-modified-buffers
     compleseus--source-other-persp-modified-buffers
-    consult--source-recent-file
-    consult--source-bookmark
+    consult-source-recent-file
+    consult-source-bookmark
     compleseus--source-persp-project-buffers
     compleseus--source-other-persp-project-buffers
-    consult--source-project-recent-file-hidden
+    consult-source-project-recent-file-hidden
     compleseus--source-window-buffers
     compleseus--source-workspace-buffers)
   "Sources used by `spacemacs/compleseus-switch-to-buffer'
@@ -64,14 +64,14 @@ of the source data structure."
   :type '(repeat symbol))
 
 (defvar compleseus--source-buffers-hidden nil
-  "Like `consult--source-buffer' but hidden by default
+  "Like `consult-source-buffer' but hidden by default
 and with narrowing key \"B\".")
 (with-eval-after-load 'consult
   (setq compleseus--source-buffers-hidden
         `(:name "Buffers (all layouts)"
           :hidden t
           :narrow (?B . "Buffers")
-          ,@consult--source-buffer)))
+          ,@consult-source-buffer)))
 
 (defvar compleseus--source-persp-modified-buffers
   `(:name "Modified Buffer (current layout)"
@@ -91,8 +91,6 @@ and with narrowing key \"B\".")
         ;; :directory 'project
         :as #'consult--buffer-pair)))
   "Modified buffer (current layout) candidate source for `consult-buffer'.")
-(define-obsolete-variable-alias 'consult--source-modified-persp-buffers
-  'compleseus--source-persp-modified-buffers "2024-09")
 
 (defvar compleseus--source-other-persp-modified-buffers
   `(:name "Modified Buffer (other layouts)"
@@ -127,8 +125,6 @@ and with narrowing key \"B\".")
         :predicate #'compleseus//persp-contain-buffer-p
         :as #'consult--buffer-pair)))
   "Layout buffer candidate source for `consult-buffer'.")
-(define-obsolete-variable-alias 'consult--source-persp-buffers
-  'compleseus--source-persp-buffers "2024-09")
 
 (defvar compleseus--source-persp-project-buffers
   `(:name     "Project Buffer (current layout)"


### PR DESCRIPTION
`consult-source-*` variables become public in https://github.com/minad/consult/commit/a2aaf3a9ff01a1b75b08e61b5ab890eb119b5dbd and the obsolete aliases are removed in https://github.com/minad/consult/commit/3a8ac46916c0699f0905ac4fe65d72768add3efb

+ additionally, two obsolete aliases in spacemacs have been removed