### PR TITLE
[ivy] Restore C-s isearch key binding in Info-mode

### DIFF
--- a/layers/+completion/ivy/packages.el
+++ b/layers/+completion/ivy/packages.el
@@ -413,7 +413,11 @@
       "sS" 'swiper-thing-at-point
       "sb" 'swiper-all
       "sB" 'swiper-all-thing-at-point)
-    (global-set-key "\C-s" 'swiper)))
+    (global-set-key (kbd "C-s") 'swiper)
+    ;; isearch has special functionality to search a manual's full text, in
+    ;; Info-mode.
+    (with-eval-after-load 'info
+      (define-key Info-mode-map (kbd "C-s") 'isearch-forward))))
 
 (defun ivy/post-init-wgrep ()
   (spacemacs/set-leader-keys-for-major-mode 'ivy-occur-grep-mode


### PR DESCRIPTION
isearch in Info-mode is much more useful than swiper, since it supports searching the full text of the manual.