### PR TITLE
[core] Refactor spacemacs/write-custom-settings-to-dotfile

### DIFF
--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -117,7 +117,6 @@ Emacs customize menu instead.
 This function is called at the very end of Spacemacs initialization.\"\n")
     (insert (spacemacs//get-custom-settings-from-cache))
     (insert ")")
-    (save-buffer)
-    (kill-buffer (current-buffer))))
+    (save-buffer)))
 
 (provide 'core-custom-settings)

--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -119,6 +119,7 @@ This function is called at the very end of Spacemacs initialization.\"\n")
       (insert (spacemacs//get-custom-settings-from-cache))
       (insert ")"))
     (indent-sexp)
-    (save-buffer)))
+    (save-buffer))
+  (message "Writing Emacs custom settings to dotfile...done"))
 
 (provide 'core-custom-settings)

--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -93,33 +93,31 @@ end of the buffer.
             (setq pos (line-beginning-position))))
         (goto-char pos)))))
 
-(defun spacemacs//get-custom-settings-from-cache ()
-  "Return the custom settings from `spacemacs--custom-file'."
-  (with-current-buffer (let ((find-file-visit-truename t)
-                             (delay-mode-hooks t))
-                         (find-file-noselect spacemacs--custom-file))
-    (goto-char (point-min))
-    ;; Skip all whitespace and comments.
-    (while (forward-comment 1))
-    (buffer-substring-no-properties (point) (point-max))))
-
 (defun spacemacs/write-custom-settings-to-dotfile ()
   "Write `dotspacemacs/emacs-custom-settings' function in the dotfile."
   (message "Writing Emacs custom settings to dotfile...")
-  (with-current-buffer (let ((find-file-visit-truename t)
-                             (delay-mode-hooks t))
-                         (find-file-noselect (dotspacemacs/location)))
-    (spacemacs//delete-emacs-custom-settings)
-    (save-excursion
-      (insert "(defun dotspacemacs/emacs-custom-settings ()\n")
-      (insert "  \"Emacs custom settings.
+  (with-temp-buffer
+    (insert-file-contents spacemacs--custom-file)
+    (delay-mode-hooks (emacs-lisp-mode))
+    ;; Skip all whitespace and comments.
+    (while (forward-comment 1))
+    (delete-region (point-min) (point))
+    ;; the temp buffer now contains the settings to be written to the dotfile
+    (let ((settings-buffer (current-buffer)))
+      (with-current-buffer (let ((find-file-visit-truename t)
+                                 (delay-mode-hooks t))
+                             (find-file-noselect (dotspacemacs/location)))
+        (spacemacs//delete-emacs-custom-settings)
+        (save-excursion
+          (insert "(defun dotspacemacs/emacs-custom-settings ()\n")
+          (insert "  \"Emacs custom settings.
 This is an auto-generated function, do not modify its content directly, use
 Emacs customize menu instead.
 This function is called at the very end of Spacemacs initialization.\"\n")
-      (insert (spacemacs//get-custom-settings-from-cache))
-      (insert ")"))
-    (indent-sexp)
-    (save-buffer))
+          (insert-buffer-substring settings-buffer)
+          (insert ")"))
+        (indent-sexp)
+        (save-buffer))))
   (message "Writing Emacs custom settings to dotfile...done"))
 
 (provide 'core-custom-settings)

--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -110,13 +110,15 @@ end of the buffer.
                              (delay-mode-hooks t))
                          (find-file-noselect (dotspacemacs/location)))
     (spacemacs//delete-emacs-custom-settings)
-    (insert "(defun dotspacemacs/emacs-custom-settings ()\n")
-    (insert "  \"Emacs custom settings.
+    (save-excursion
+      (insert "(defun dotspacemacs/emacs-custom-settings ()\n")
+      (insert "  \"Emacs custom settings.
 This is an auto-generated function, do not modify its content directly, use
 Emacs customize menu instead.
 This function is called at the very end of Spacemacs initialization.\"\n")
-    (insert (spacemacs//get-custom-settings-from-cache))
-    (insert ")")
+      (insert (spacemacs//get-custom-settings-from-cache))
+      (insert ")"))
+    (indent-sexp)
     (save-buffer)))
 
 (provide 'core-custom-settings)

--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -110,15 +110,14 @@ end of the buffer.
                              (delay-mode-hooks t))
                          (find-file-noselect (dotspacemacs/location)))
     (spacemacs//delete-emacs-custom-settings)
-    (let ((standard-output (current-buffer)))
-      (princ "(defun dotspacemacs/emacs-custom-settings ()\n")
-      (princ "  \"Emacs custom settings.
+    (insert "(defun dotspacemacs/emacs-custom-settings ()\n")
+    (insert "  \"Emacs custom settings.
 This is an auto-generated function, do not modify its content directly, use
 Emacs customize menu instead.
 This function is called at the very end of Spacemacs initialization.\"\n")
-      (princ (spacemacs//get-custom-settings-from-cache))
-      (princ ")")
-      (save-buffer)
-      (kill-buffer (current-buffer)))))
+    (insert (spacemacs//get-custom-settings-from-cache))
+    (insert ")")
+    (save-buffer)
+    (kill-buffer (current-buffer))))
 
 (provide 'core-custom-settings)

--- a/core/core-custom-settings.el
+++ b/core/core-custom-settings.el
@@ -27,7 +27,7 @@
 
 (defun spacemacs/initialize-custom-file ()
   "Initialize the custom file.
-Does not initialize writing the custom file into the dotfile. To
+Does not initialize writing the custom file into the dotfile.  To
 complete that part see `spacemacs/initialize-custom-file-sync'."
   ;; setup auto-rewrite of custom settings only if custom-file
   ;; has not been set by the user
@@ -94,7 +94,7 @@ end of the buffer.
         (goto-char pos)))))
 
 (defun spacemacs//get-custom-settings-from-cache ()
-  "Returns the custom settings from `spacemacs--custom-file'."
+  "Return the custom settings from `spacemacs--custom-file'."
   (with-current-buffer (let ((find-file-visit-truename t)
                              (delay-mode-hooks t))
                          (find-file-noselect spacemacs--custom-file))
@@ -104,7 +104,7 @@ end of the buffer.
     (buffer-substring-no-properties (point) (point-max))))
 
 (defun spacemacs/write-custom-settings-to-dotfile ()
-  "Write `dotspacemacs/emacs-custom-settings' function in the dotfile"
+  "Write `dotspacemacs/emacs-custom-settings' function in the dotfile."
   (message "Writing Emacs custom settings to dotfile...")
   (with-current-buffer (let ((find-file-visit-truename t)
                              (delay-mode-hooks t))


### PR DESCRIPTION
Primarily motivated by fixing a small behavior bug in this function,
where saving the custom settings (such as by custom-save-all)
killed any buffer visiting the dotspacemacs file.  This is annoying
when the user is separately visiting that file to edit their configs,
and simply unnecessary.

The remainder of the commits are various cleanups and improvements to
make the code more idiomatic and performant.