### PR TITLE
Add mermaid layer and integration with org mode

### DIFF
--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -616,7 +616,9 @@ variable =org-enable-asciidoc-support= to =t=.
 #+END_SRC
 
 ** Mermaid support
-To enable Mermaid diagram support in Org mode, set the variable =org-enable-mermaid-support= to =t=.
+To enable Mermaid diagram support in Org mode, set the variable
+=org-enable-mermaid-support= to =t= (this will automatically enable
+the [[https://github.com/syl20bnr/spacemacs/blob/develop/layers/+lang/mermaid/README.org][Mermaid layer]]).
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(

--- a/layers/+emacs/org/README.org
+++ b/layers/+emacs/org/README.org
@@ -39,6 +39,7 @@
   - [[#transclusion-support][Transclusion support]]
   - [[#verb-support][Verb support]]
   - [[#asciidoc-support][AsciiDoc support]]
+  - [[#mermaid-support][Mermaid support]]
   - [[#spacemacs-layout-integration][Spacemacs layout integration]]
 - [[#key-bindings][Key bindings]]
   - [[#starting-org-mode][Starting org-mode]]
@@ -613,6 +614,25 @@ variable =org-enable-asciidoc-support= to =t=.
   (setq-default dotspacemacs-configuration-layers
     '((org :variables org-enable-asciidoc-support t)))
 #+END_SRC
+
+** Mermaid support
+To enable Mermaid diagram support in Org mode, set the variable =org-enable-mermaid-support= to =t=.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables org-enable-mermaid-support t)))
+#+END_SRC
+
+With this feature enabled, you can use Mermaid diagrams in Org mode source blocks:
+
+#+BEGIN_SRC mermaid
+  graph TD
+      A[Client] --> B[Load Balancer]
+      B --> C[Server1]
+      B --> D[Server2]
+#+END_SRC
+
+This will render the diagram directly in your Org buffer when you evaluate the source block with ~SPC m b e~ or ~SPC m b b~.
 
 ** Spacemacs layout integration
 A [[https://github.com/syl20bnr/spacemacs/blob/develop/doc/DOCUMENTATION.org#layouts-and-workspaces][Spacemacs custom layout]] =@Org= is defined by the layer and accessible via =SPC l o=. The startup behavior can be customized with the following layer variables:

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -32,6 +32,9 @@
 (defvar org-enable-github-support nil
   "If non-nil GitHub related packages are configured.")
 
+(defvar org-enable-mermaid-support nil
+  "If non-nil ob-mermaid are configured.")
+
 (defvar org-enable-reveal-js-support nil
   "If non-nil, enable export to reveal.js.")
 

--- a/layers/+emacs/org/config.el
+++ b/layers/+emacs/org/config.el
@@ -33,7 +33,7 @@
   "If non-nil GitHub related packages are configured.")
 
 (defvar org-enable-mermaid-support nil
-  "If non-nil ob-mermaid are configured.")
+  "If non-nil, enable support for Mermaid source blocks via ob-mermaid.")
 
 (defvar org-enable-reveal-js-support nil
   "If non-nil, enable export to reveal.js.")

--- a/layers/+emacs/org/layers.el
+++ b/layers/+emacs/org/layers.el
@@ -21,4 +21,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(configuration-layer/declare-layer-dependencies '(spacemacs-org))
+(configuration-layer/declare-layer-dependencies
+ (append '(spacemacs-org)
+         (when (bound-and-true-p org-enable-mermaid-support)
+           '(mermaid))))
+

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -33,6 +33,7 @@
     htmlize
     ;; ob, org, org-agenda and org-contacts are installed by `org-contrib'
     (ob :location built-in)
+    (ob-mermaid :toggle org-enable-mermaid-support)
     (org :location elpa)
     (org-agenda :location built-in)
     (org-alert  :toggle org-enable-notifications)
@@ -121,6 +122,13 @@
                      'org-babel-execute-src-block@load-lang))
     ;; Fix redisplay of inline images after a code block evaluation.
     (add-hook 'org-babel-after-execute-hook 'spacemacs/ob-fix-inline-images)))
+
+(defun org/init-ob-mermaid ()
+  (use-package ob-mermaid
+    :defer t
+    :init
+    (spacemacs|use-package-add-hook org
+      :post-config (add-to-list 'org-babel-load-languages '(mermaid . t)))))
 
 (defun org/init-org ()
   (use-package org

--- a/layers/+lang/mermaid/README.org
+++ b/layers/+lang/mermaid/README.org
@@ -9,9 +9,9 @@
 - [[#key-bindings][Key Bindings]]
 
 * Description
-This layer adds support for [[https://mermaid-js.github.io/][Mermaid]] diagrams
-to Spacemacs. Mermaid is a JavaScript-based diagramming and charting tool that
-renders Markdown-inspired text definitions to create and display diagrams.
+This layer adds support for [[https://mermaid.js.org/][Mermaid]] diagrams to Spacemacs. Mermaid is
+a JavaScript-based diagramming and charting tool that renders
+Markdown-inspired text definitions to create and display diagrams.
 
 For help with how to use Mermaid, see the [[https://mermaid.js.org/intro/getting-started][reference guide]].
 

--- a/layers/+lang/mermaid/README.org
+++ b/layers/+lang/mermaid/README.org
@@ -1,0 +1,51 @@
+#+TITLE: Mermaid layer
+
+[[file:img/logo.svg]]
+
+* Table of Contents                                   :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#installation][Installation]]
+- [[#key-bindings][Key Bindings]]
+
+* Description
+This layer adds support for [[https://mermaid-js.github.io/][Mermaid]] diagrams
+to Spacemacs. Mermaid is a JavaScript-based diagramming and charting tool that
+renders Markdown-inspired text definitions to create and display diagrams.
+
+For help with how to use Mermaid, see the [[https://mermaid.js.org/intro/getting-started][reference guide]].
+
+The official file extension supported by this layer is =.mmd=. If you want something else,
+set it in your =user-config= function of your =~/.spacemacs= file.
+
+For example, the following diagram can be defined as follows:
+
+#+BEGIN_SRC mermaid
+sequenceDiagram
+    Server<<->>Client: Hello
+#+END_SRC
+
+** Features:
+- Syntax highlighting for Mermaid files (with .mmd extension)
+- Diagram preview on region/buffer/file
+- Key bindings for compiling and changing output types
+
+* Installation
+Add the layer to your =~/.spacemacs= file:
+
+#+BEGIN_SRC elisp
+  (setq-default dotspacemacs-configuration-layers '(mermaid))
+#+END_SRC
+
+To compile mermaid diagram, please install [[https://github.com/mermaid-js/mermaid-cli][mmdc]] command-line tool.
+
+* Key Bindings
+
+| Key Binding | Description                |
+|-------------+----------------------------|
+| ~SPC m c c~ | Compile Mermaid diagram    |
+| ~SPC m c f~ | Compile Mermaid file       |
+| ~SPC m c b~ | Compile Mermaid buffer     |
+| ~SPC m c r~ | Compile Mermaid region     |
+| ~SPC m c o~ | Open browser with diagram  |
+| ~SPC m c d~ | Open Mermaid documentation |

--- a/layers/+lang/mermaid/img/logo.svg
+++ b/layers/+lang/mermaid/img/logo.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 491 491" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M490.16,84.61C490.16,37.912 452.248,0 405.55,0L84.61,0C37.912,0 0,37.912 0,84.61L0,405.55C0,452.248 37.912,490.16 84.61,490.16L405.55,490.16C452.248,490.16 490.16,452.248 490.16,405.55L490.16,84.61Z" style="fill:rgb(255,54,112);"/>
+    <path d="M407.48,111.18C335.587,108.103 269.573,152.338 245.08,220C220.587,152.338 154.573,108.103 82.68,111.18C80.285,168.229 107.577,222.632 154.74,254.82C178.908,271.419 193.35,298.951 193.27,328.27L193.27,379.13L296.9,379.13L296.9,328.27C296.816,298.953 311.255,271.42 335.42,254.82C382.596,222.644 409.892,168.233 407.48,111.18Z" style="fill:white;fill-rule:nonzero;"/>
+</svg>

--- a/layers/+lang/mermaid/packages.el
+++ b/layers/+lang/mermaid/packages.el
@@ -1,0 +1,46 @@
+;;; packages.el --- mermaid layer packages file for Spacemacs.  -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
+;;
+;; Author: Lin Sun <lin.sun AT hotmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs/
+;;
+;;; Commentary:
+;;
+;; Adds Mermaid support to Spacemacs using mermaid-mode.
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(defconst mermaid-packages
+  '(mermaid-mode))
+
+(defun mermaid/init-mermaid-mode ()
+  (use-package mermaid-mode
+    :defer t
+    :config
+    ;; Set up key bindings
+    (spacemacs/declare-prefix-for-mode 'mermaid-mode
+      "mc" "compile")
+    (spacemacs/set-leader-keys-for-major-mode 'mermaid-mode
+      "cc" 'mermaid-compile
+      "cf" 'mermaid-compile-file
+      "cb" 'mermaid-compile-buffer
+      "cr" 'mermaid-compile-region
+      "co" 'mermaid-open-browser
+      "cd" 'mermaid-open-doc)))
+
+;;; packages.el ends here

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -93,6 +93,7 @@
       - [[#dhall][Dhall]]
       - [[#fountain][Fountain]]
       - [[#graphviz][Graphviz]]
+      - [[#mermaid][Mermaid]]
       - [[#html][HTML]]
       - [[#json][JSON]]
       - [[#jsonnet][Jsonnet]]
@@ -1317,6 +1318,29 @@ Features:
 - Integration of a live-preview of =.dot= files via [[https://github.com/ppareit/graphviz-dot-mode][graphviz-dot-mode]].
 - Control of the graphviz compiler directly from emacs.
 - Support for formatting =.dot= files automatically.
+
+**** Mermaid
+[[file:+lang/mermaid/README.org][+lang/mermaid/README.org]]
+
+This layer adds support for [[https://mermaid-js.github.io/][Mermaid]] diagrams
+to Spacemacs. Mermaid is a JavaScript-based diagramming and charting tool that
+renders Markdown-inspired text definitions to create and display diagrams.
+
+For help with how to use Mermaid, see the [[https://mermaid.js.org/intro/getting-started][reference guide]].
+
+The official file extension supported by this layer is =.mmd=. If you want something else,
+set it in your =user-config= function of your =~/.spacemacs= file.
+
+For example, the following diagram can be defined as follows:
+
+#+BEGIN_SRC mermaid
+sequenceDiagram
+    Server<<->>Client: Hello
+#+END_SRC
+
+- Syntax highlighting for Mermaid files (with .mmd extension)
+- Diagram preview on region/buffer/file
+- Key bindings for compiling and changing output types
 
 **** HTML
 [[file:+lang/html/README.org][+lang/html/README.org]]


### PR DESCRIPTION
Add [mermaid](https://github.com/mermaid-js/mermaid) support:

* layers/+lang/mermaid/: Mermaid layer files
* layers/+emacs/org/: Integration mermaid into org mode
