### PR TITLE
[org] Remove keybinding "c" from org-src-edit for less conflicting

### DIFF
--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -193,7 +193,6 @@
     (with-eval-after-load 'org-src
       (spacemacs/set-leader-keys-for-minor-mode 'org-src-mode
         dotspacemacs-major-mode-leader-key 'org-edit-src-exit
-        "c" 'org-edit-src-exit
         "a" 'org-edit-src-abort
         "k" 'org-edit-src-abort))
 


### PR DESCRIPTION
The keybinding "c" on org-src mode conflicts to many major-modes like lisp/mermaid/plantuml..., here is an example `/tmp/a.org`, try press `, '` in the org lisp source code block to enter the org-src-edit, the key `, c` for lisp mode was override to `org-edit-src-exit`.
```
#+begin_src elisp
  (message "hello")
#+end_src
#+begin_src mermaid
  graph TD
      A --> B{Hello}
#+end_src
#+begin_src plantuml
  @startuml
  A -> B: Hello
  @enduml
#+end_src
```

This PR removed the "c" which will let the `, c` works on these major-modes who has key binding with "c".