### PR TITLE
[version-control] Fix toggle margin detection

### DIFF
--- a/layers/+source-control/version-control/funcs.el
+++ b/layers/+source-control/version-control/funcs.el
@@ -109,7 +109,7 @@
 (defun spacemacs/vcs-margin-p ()
   (interactive)
   (cl-case version-control-diff-tool
-    (diff-hl     'diff-hl-margin-local-mode)
+    (diff-hl     (bound-and-true-p diff-hl-margin-local-mode))
     (git-gutter  (bound-and-true-p git-gutter-mode))))
 
 (defun spacemacs/vcs-margin-global-p ()


### PR DESCRIPTION
There is a detection issue leads `SPC T d` won't able toggle the diff-hl margin mode. 
Enable the diff-hl as margin backend and press `SPC T d` twice or more to reproduce the issue. 
