### PR TITLE
[defaults] Improve yank-indent-region advice

### DIFF
--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1669,21 +1669,19 @@ Compare them on count first,and in case of tie sort them alphabetically."
   "Indent yanked text, unless `major-mode' is in `spacemacs-indent-sensitive-modes'.
 
 With prefix \\[universal-argument], don't indent."
-  (evil-start-undo-step)
-  (prog1
-      (let ((prefix (car args))
-            (enable (and (not (member major-mode spacemacs-indent-sensitive-modes))
-                         (or (derived-mode-p 'prog-mode)
-                             (member major-mode spacemacs-yank-indent-modes)))))
-        (when (and enable (equal '(4) prefix))
-          (setf (car args) nil))
-        (prog1
-            (apply yank-func args)
-          (when (and enable (not (equal '(4) prefix)))
-            (let ((transient-mark-mode nil))
-              (spacemacs/yank-advised-indent-function (region-beginning)
-                                                      (region-end))))))
-    (evil-end-undo-step)))
+  (evil-with-single-undo
+    (let ((enable (and (not (member major-mode spacemacs-indent-sensitive-modes))
+                       (or (derived-mode-p 'prog-mode)
+                           (member major-mode spacemacs-yank-indent-modes)))))
+      (when (and enable (equal '(4) (car args)))
+        (setf (car args) nil
+              enable nil))
+      (prog1
+          (apply yank-func args)
+        (when enable
+          (let ((transient-mark-mode nil))
+            (spacemacs/yank-advised-indent-function (region-beginning)
+                                                    (region-end))))))))
 
 (dolist (func '(yank yank-pop evil-paste-before evil-paste-after))
   (advice-add func :around #'spacemacs//yank-indent-region))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1676,7 +1676,7 @@ With prefix \\[universal-argument], don't indent."
                          (or (derived-mode-p 'prog-mode)
                              (member major-mode spacemacs-yank-indent-modes)))))
         (when (and enable (equal '(4) prefix))
-          (setq args (cdr args)))
+          (setf (car args) nil))
         (prog1
             (apply yank-func args)
           (when (and enable (not (equal '(4) prefix)))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -86,9 +86,8 @@ A COUNT argument matches the indentation to the next COUNT lines."
   :type '(repeat symbol)
   :group 'spacemacs)
 
-(defcustom spacemacs-yank-indent-modes '(latex-mode)
-  "Modes in which to indent regions that are yanked (or yank-popped).
-Only modes that don't derive from `prog-mode' should be listed here."
+(defcustom spacemacs-yank-indent-modes '(prog-mode latex-mode)
+  "Modes in which to indent regions that are yanked (or yank-popped)."
   :type '(repeat symbol)
   :group 'spacemacs)
 
@@ -1682,9 +1681,8 @@ argument is changed to nil.  If the indentation would not be enabled
 based on the major mode, ARGS (including the prefix argument) is passed
 through unchanged."
   (evil-with-single-undo
-    (let ((enable (and (not (member major-mode spacemacs-indent-sensitive-modes))
-                       (or (derived-mode-p 'prog-mode)
-                           (member major-mode spacemacs-yank-indent-modes)))))
+    (let ((enable (and (not (derived-mode-p spacemacs-indent-sensitive-modes))
+                       (derived-mode-p spacemacs-yank-indent-modes))))
       (when (and enable (equal '(4) (car args)))
         (setf (car args) nil
               enable nil))

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1665,10 +1665,22 @@ Compare them on count first,and in case of tie sort them alphabetically."
   (if (<= (- end beg) spacemacs-yank-indent-threshold)
       (indent-region beg end nil)))
 
+;; This advice assumes that the advised function interactive spec passes
+;; `current-prefix-arg' as its first argument.
 (defun spacemacs//yank-indent-region (yank-func &rest args)
-  "Indent yanked text, unless `major-mode' is in `spacemacs-indent-sensitive-modes'.
+  "Indent text yanked by YANK-FUNC.
 
-With prefix \\[universal-argument], don't indent."
+Indentation is only applied if the major mode is derived from a mode in
+`spacemacs-yank-indent-modes' and not derived from a mode in
+`spacemacs-indent-sensitive-modes'.
+
+With prefix \\[universal-argument], never indent.
+
+ARGS is passed through unchanged to YANK-FUNC, except if the first
+argument is \\='(4) (a single prefix argument), in which case the first
+argument is changed to nil.  If the indentation would not be enabled
+based on the major mode, ARGS (including the prefix argument) is passed
+through unchanged."
   (evil-with-single-undo
     (let ((enable (and (not (member major-mode spacemacs-indent-sensitive-modes))
                        (or (derived-mode-p 'prog-mode)

--- a/layers/+spacemacs/spacemacs-defaults/funcs.el
+++ b/layers/+spacemacs/spacemacs-defaults/funcs.el
@@ -1680,8 +1680,7 @@ With prefix \\[universal-argument], don't indent."
         (prog1
             (apply yank-func args)
           (when (and enable (not (equal '(4) prefix)))
-            (let ((transient-mark-mode nil)
-                  (save-undo buffer-undo-list))
+            (let ((transient-mark-mode nil))
               (spacemacs/yank-advised-indent-function (region-beginning)
                                                       (region-end))))))
     (evil-end-undo-step)))


### PR DESCRIPTION
1. Remove unused variable
1. Fix #17240
1. Use `evil-with-single-undo` macro instead of emulating it
1. Improve docstring
1. Consider derived modes of `spacemacs-indent-sensitive-modes` and
   `spacemacs-yank-indent-modes`.  Make `prog-mode` a member of the
   latter and remove special case behavior in the advice, so that the
   user can easily opt out of indenting all `prog-mode` buffers.