### PR TITLE
[translate] Update go-translate to gt following package rename upstream

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3793,6 +3793,9 @@ files (thanks to Daniel Nicolai)
   - ~SPC m s D~ is to set days for =transmission-turtle-mode= to be active.
   - ~SPC m s S~ is to set speed limits for =transmission-turtle-mode=.
   - ~SPC m s T~ is to set time range for =transmission-turtle-mode to be active.
+**** Translate
+- Update =go-translate= references to =gt= following upstream package rename
+  (thanks to klochowicz)
 **** Treemacs
 - =Treemacs= replaces =NeoTree= as the default sidebar
 - Added missing ~SPC p t~ to =readme.org= (thanks to oo6)

--- a/layers/+tools/translate/README.org
+++ b/layers/+tools/translate/README.org
@@ -39,7 +39,7 @@ sync with the cursor in the translation buffer.
 * Configuration
 All layer configurations can be done by setting layer variables in your dotfile.
 No custom user config lines are necessary. For more details please see the homepage
-of package [[https://github.com/rayw000/translate-mode][translate-mode]] and [[https://github.com/lorniu/go-translate/][go-translate]].
+of package [[https://github.com/rayw000/translate-mode][translate-mode]] and [[https://github.com/lorniu/gt.el/][gt]].
 
 ** Languages
 You need to set languages to make online translation work.

--- a/layers/+tools/translate/packages.el
+++ b/layers/+tools/translate/packages.el
@@ -23,7 +23,7 @@
 
 (defconst translate-packages
   '(translate-mode
-    go-translate))
+    gt))
 
 (defun translate/init-translate-mode ()
   "Initialize required packages."
@@ -31,8 +31,8 @@
     :defer t
     :hook (translate-mode . translate//set-translate-mode-paragraph-functions)))
 
-(defun translate/init-go-translate ()
-  (use-package go-translate
+(defun translate/init-gt ()
+  (use-package gt
     :commands (gt-start)
     :config
     (defun translate//reference-paragraph-texter ()
@@ -52,14 +52,14 @@
        :taker (gt-taker :text (lambda () (translate//reference-paragraph-texter)))
        :engines (list (gt-google-engine) (gt-bing-engine))
        :render (translate//check-and-get-render translate/paragraph-render))
-      "Paragraph translator for `go-translate'.")
+      "Paragraph translator for `gt'.")
     (defconst translate//word-translator
       (gt-translator
        :taker (gt-taker :text 'word)
        :engines (list (gt-google-engine) (gt-bing-engine))
        :render (translate//check-and-get-render translate/word-render))
-      "Word translator for `go-translate'.")))
+      "Word translator for `gt'.")))
 
 (defun translate/pre-init-posframe ()
   (spacemacs|use-package-add-hook posframe
-    :post-config (translate/init-go-translate)))
+    :post-config (translate/init-gt)))


### PR DESCRIPTION
Package name changed along with its repository - use the new name everywhere.