### PR TITLE
[python] Fix incorrect VIRTUAL_ENV in pyenv-mode-set-local-version

### DIFF
--- a/layers/+lang/python/funcs.el
+++ b/layers/+lang/python/funcs.el
@@ -243,7 +243,6 @@ Equivalent to: autoflake --remove-all-unused-imports --in-place <FILE>"
                                        (line-beginning-position)
                                        (line-end-position)))))))
     (cond ((member version (pyenv-mode-versions))
-           (setenv "VIRTUAL_ENV" version)
            (pyenv-mode-set version))
           (t (message "pyenv: version `%s' is not installed (set by %s)"
                       version file-path)))))


### PR DESCRIPTION
  ## Summary
  - Remove erroneous `(setenv "VIRTUAL_ENV" version)` from
    `spacemacs//pyenv-mode-set-local-version`
  - This line set `VIRTUAL_ENV` to a bare version string (e.g. `"3.13.2"`)
    instead of a filesystem path, breaking tools like Poetry that expect
    `VIRTUAL_ENV` to be a valid virtualenv directory path
  - The call is also unnecessary — `pyenv-mode-set` already handles
    environment setup internally via `pythonic-activate` and `PYENV_VERSION`

  ## Context
  Introduced in e6997638e to help LSP detect pyenv changes, but the value
  was always wrong (version name instead of path). In pyenv + Poetry
  workflows, Poetry reads `VIRTUAL_ENV` and interprets the version string
  as a path, causing errors. Whether the bug manifests depends on hook
  execution order — if Poetry's `pyvenv-activate` runs after the pyenv
  hook, it overwrites the bad value and masks the issue.

  ## What I tested
  - In a pyenv + Poetry project, confirmed that `VIRTUAL_ENV` was being
    set to a bare version string (e.g. "3.13.2") by this function
  - After removing this line, `poetry env info` in the Spacemacs shell
    outputs the correct virtualenv path
  - Verified by reading source code that `pyenv-mode-set` already
    correctly handles environment setup (`PYENV_VERSION` via `setenv`,
    `python-shell-virtualenv-root` via `pythonic-activate`)

  ## Not tested
  - LSP (pylsp/pyright) behavior after the change — though `pyenv-mode-set`
    still sets `PYENV_VERSION` and `python-shell-virtualenv-root`, which
    LSP servers should use
  - pyenv-virtualenv scenarios — though the removed line was equally
    incorrect for those users (setting a name string, not a path)