### PR TITLE
[common-lisp] Stop setting deleted/deprecated variables

### DIFF
--- a/layers/+lang/common-lisp/packages.el
+++ b/layers/+lang/common-lisp/packages.el
@@ -96,11 +96,8 @@
                            slime-sbcl-exts
                            slime-scratch)
           inferior-lisp-program "sbcl")
-    ;; enable fuzzy matching in code buffer and SLIME REPL
-    (setq slime-complete-symbol*-fancy t)
-    (setq slime-complete-symbol-function 'slime-fuzzy-complete-symbol)
     (add-hook 'slime-repl-mode-hook #'spacemacs//deactivate-smartparens)
-    (spacemacs/add-to-hooks 'slime-mode '(lisp-mode-hook))
+    (add-hook 'lisp-mode-hook #'slime-mode)
     :config
     (slime-setup)
     (spacemacs/set-leader-keys-for-major-mode 'lisp-mode


### PR DESCRIPTION
These completion variables are no longer supported upstream.
slime-complete-symbol*-fancy has been deleted, and
slime-complete-symbol-function is marked as deprecated since 2015.

The default fuzzy matching provided by company works fine, and can be
configured to the user's taste with slime-completion-at-point-functions.
(slime-c-p-c-completion-at-point supports completion using abbreviations)

This also fixes completion being completely broken with alternative
completion frontends like Corfu.