### PR TITLE
change "gh" to prefix key to unhide 6 other commands

### DIFF
--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -132,7 +132,8 @@
     "xL" #'lsp-lens-hide)
   (when (configuration-layer/package-used-p 'lsp-treemacs)
     (spacemacs/set-leader-keys-for-minor-mode 'lsp-mode
-      "gh" #'lsp-treemacs-call-hierarchy
+      "gh" "hierarchy"
+      "ghh" #'lsp-treemacs-call-hierarchy
       "gT" #'lsp-treemacs-type-hierarchy)))
 
 (defun spacemacs//lsp-bind-simple-navigation-functions (prefix-char)


### PR DESCRIPTION
_Without the change in this review, **,gh** key sequence is bound to `lsp-treemacs-call-hierarchy` in C++ buffers.

With the change in this review applied, **,gh** becomes prefix key and `lsp-treemacs-call-hierarchy` is now bound to **,ghh**. In addition the following keys are now no longer hidden in C++ buffers:

-   **ghb** `c-c++-lsp-ccls-find-base`
-   **ghd** `c-c++-lsp-ccls-find-derived`
-   **ghc** `ccls-call-hierarchy`
-   **ghC** `spacemacs/c-c++-lsp-ccls-call-hierarchy-inv`
-   **ghi** `ccls-inheritance-hierarchy`
-   **ghI** `spacemacs/c-c++-lsp-ccls-inheritance-hierarchy-inv`

These 6 key bindings are setup in `layers/+lang/c-c++/funcs.el`. However, these are hidden, because **,gh** is bound to a function rather than being declared as a prefix key in `layers/+tools/lsp/funcs.el`.

The change in thie pull request is to unhide these other useful key bindings.

