### PR TITLE
[git] fix duplicate bindings in the "Jump to" transient

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -282,8 +282,10 @@
 
 (defun git/init-magit-todos ()
   (use-package magit-todos
-    :hook (magit-mode . magit-todos-mode)
-    :config (spacemacs|diminish magit-todos-mode "TODOS")))
+    :after magit-status
+    :config
+    (spacemacs|diminish magit-todos-mode "TODOS")
+    (magit-todos-mode 1)))
 
 (defun git/init-orgit ()
   (use-package orgit


### PR DESCRIPTION
How to reproduce:
1. enable magit-todos
2. open a magit-status buffer
3. `j` to open transient, will see one or more `T/l` bindings
4. `C-g q` to exit
5. redo from 2.

Extra info:
This fix is based on the setup method described in the `magit-todos` README. However, I put it after `magit-status` rather than `magit`, otherwise there would be no bindings in the transient. I tried to confirm this change in
https://github.com/alphapapa/magit-todos/issues/207, but don't receive response for two months.
However, I don’t think this will cause any new issues.