### PR TITLE
[evil-evilified-state] Stop mutating global evil-evilified-state-map

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
+++ b/layers/+distributions/spacemacs-bootstrap/local/evil-evilified-state/evil-evilified-state.el
@@ -252,16 +252,14 @@ Each pair KEYn FUNCTIONn is defined in MAP after the evilification of it."
          (defkey (when bindings `(evil-define-key 'evilified ,map ,@bindings)))
          (body
           `(,@(evilified-state--define-pre-bindings map pre-bindings)
-            ;; we need to work on a local copy of the evilified keymap to
-            ;; prevent the original keymap from being mutated.
-            (setq evil-evilified-state-map (copy-keymap ,evilified-map))
-            (let* ((sorted-map (evilified-state--sort-keymap
-                                evil-evilified-state-map))
+            (let* ((evilified-map-local (copy-keymap ,evilified-map))
+                   (sorted-map (evilified-state--sort-keymap
+                                evilified-map-local))
                    processed)
               (mapc (lambda (map-entry)
                       (unless (member (car map-entry) processed)
                         (setq processed (evilified-state--evilify-event
-                                         ,map ',map evil-evilified-state-map
+                                         ,map ',map evilified-map-local
                                          (car map-entry) (cdr map-entry)))))
                     sorted-map)
               (unless ,(null defkey)

--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -199,13 +199,6 @@
     :config
     ;; seems to be necessary at the time of release
     (require 'git-rebase)
-    ;; bind function keys
-    ;; (define-key magit-mode-map (kbd "<tab>") 'magit-section-toggle)
-    (evilified-state-evilify-map magit-repolist-mode-map
-      :mode magit-repolist-mode
-      :bindings
-      (kbd "gr") 'magit-list-repositories
-      (kbd "RET") 'magit-repolist-status)
     ;; confirm/abort
     (when dotspacemacs-major-mode-leader-key
       (add-hook 'with-editor-mode-hook 'evil-normalize-keymaps)


### PR DESCRIPTION
evilified-state-evilify-map used to do:

    (setq evil-evilified-state-map (copy-keymap ,evilified-map))

This overwrites the global evil-evilified-state-map every time any
mode is evilified, so the last mode to be evilified wins.  For any
modes that are evilified but do not have custom :binding entries, the
global value evil-evilified-state-map is used, so this caused key
bindings for unrelated packages to leak to such modes.

Fix #17250.

As a small followup, also remove the key bindings in `magit-repolist-mode` that were originally causing this issue for me, and which are redundant with the ones enabled by `evil-collection`.