### PR TITLE
Fix micro-state face box handling on Emacs 30

### DIFF
--- a/core/core-micro-state.el
+++ b/core/core-micro-state.el
@@ -26,8 +26,10 @@
   "Define faces for micro-states."
   (let* ((hname 'spacemacs-micro-state-header-face)
          (bname 'spacemacs-micro-state-binding-face)
-         (box `(:line-width -1 :color ,(plist-get (face-attribute
-                                                   'mode-line :box) :color)))
+         (mode-line-box (face-attribute 'mode-line :box nil 'default))
+         (mode-line-box-color (and (listp mode-line-box)
+                                   (plist-get mode-line-box :color)))
+         (box `(:line-width -1 :color ,mode-line-box-color))
          (err (face-attribute 'error :foreground)))
     (eval `(defface ,hname '((t ()))
              "Face for micro-state header in echo area.


### PR DESCRIPTION
Fix `spacemacs/defface-micro-state-faces` on Emacs 30.

On Emacs 30.2, `face-attribute` for `mode-line` `:box` is not always a plist, so calling `plist-get` on it can raise:

`Invalid face box, :line-width, -1, :color, (plist-get (face-attribute 'mode-line :box) :color)`\n\nThis change reads the `mode-line` box attribute once and only extracts `:color` when the value is a list.\n\nI hit this during startup on macOS with Emacs 30.2, where it aborted initialization from `core/core-micro-state.el`.