### PR TITLE
[core] Add lexical binding comment

### DIFF
--- a/core/libs/ido-vertical-mode.el
+++ b/core/libs/ido-vertical-mode.el
@@ -1,4 +1,4 @@
-;;; ido-vertical-mode.el --- Makes ido-mode display vertically
+;;; ido-vertical-mode.el --- Makes ido-mode display vertically -*- lexical-binding: nil; -*-
 
 ;; Copyright (C) 2013, 2014  Steven Degutis
 


### PR DESCRIPTION
Emacs 31 warns if this is not set. I've opted to set it to `nil` rather than `t`, as this maintains current behaviour.

This was previously done to all other files in https://github.com/syl20bnr/spacemacs/pull/16960.