### PR TITLE
[compleseus] Remove support for deprecated selectrum backend

### DIFF
--- a/layers/+completion/compleseus/README.org
+++ b/layers/+completion/compleseus/README.org
@@ -7,7 +7,6 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#configuration][Configuration]]
-    - [[#completion-engine][Completion engine]]
     - [[#preview-keys][Preview keys]]
 - [[#key-bindings][Key bindings]]
   - [[#narrowing][Narrowing]]
@@ -16,7 +15,7 @@
 
 * Description
 This layer implements completion provided by combining the following packages:
-- =selectrum= or =vertico=: vertical completion user interface
+- =vertico=: vertical completion user interface
 - =consult=: useful commands using ~completing-read~
 - =embark=: provides minibuffer actions
 - =marginalia=: annotations to completion candidates
@@ -37,16 +36,6 @@ commented out in the =dotspacemacs-configuration-layers= list. Or add
 layer that's listed last.
 
 ** Configuration
-*** Completion engine
-You can configure the completion engine by setting =compleseus-engine= to either
-=vertico= (default) or =selectrum= by editing the =compleseus-engine= variable
-like below to use =selectrum= as opposed to the default of =vertico=:
-
-#+BEGIN_SRC emacs-lisp
-  (compleseus :variables
-              compleseus-engine 'selectrum)
-#+END_SRC
-
 *** Preview keys
 You can set the keys that will by default trigger a preview in consult commands.
 This can be set to a list of keys, with an optional debounce property. For instance

--- a/layers/+completion/compleseus/config.el
+++ b/layers/+completion/compleseus/config.el
@@ -21,10 +21,6 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-(defvar compleseus-engine 'vertico
-  "Options are `selectrum', and `vertico' to use as completion
-  engine.")
-
 (defvar compleseus-use-nerd-icons nil
   "Use nerd-icons with marginalia to provide icons in the mini-buffer")
 

--- a/layers/+completion/compleseus/funcs.el
+++ b/layers/+completion/compleseus/funcs.el
@@ -184,20 +184,6 @@ to act on with `embark-act-all', and move to the next candidate."
   (vertico-previous (or n 1))
   (spacemacs/embark-preview))
 
-;; selectrum
-
-(defun spacemacs/selectrum-next-candidate-preview (&optional n)
-  "Go forward N candidates and preview"
-  (interactive)
-  (selectrum-next-candidate (or n 1))
-  (spacemacs/embark-preview))
-
-(defun spacemacs/selectrum-previous-candidate-preview (&optional n)
-  "Go backward N candidates and preview"
-  (interactive)
-  (selectrum-previous-candidate (or n 1))
-  (spacemacs/embark-preview))
-
 ;; which-key integration functions for embark
 ;; https://github.com/oantolin/embark/wiki/Additional-Configuration#use-which-key-like-a-key-menu-prompt
 (defun spacemacs/embark-which-key-indicator ()

--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -38,12 +38,8 @@
     orderless
     persp-mode
     savehist
-    (selectrum :toggle (eq compleseus-engine 'selectrum))
-    (vertico
-     :toggle (eq compleseus-engine 'vertico)
-     :location elpa)
-    (vertico-posframe :toggle (and (eq compleseus-engine 'vertico)
-                                   compleseus-use-vertico-posframe))))
+    (vertico :location elpa)
+    (vertico-posframe :toggle compleseus-use-vertico-posframe)))
 
 (defun compleseus/pre-init-auto-highlight-symbol ()
   (spacemacs|use-package-add-hook auto-highlight-symbol
@@ -151,7 +147,7 @@
 
     ;; Enable automatic preview at point in the *Completions* buffer.
     ;; This is relevant when you use the default completion UI,
-    ;; and not necessary for Selectrum, Vertico etc.
+    ;; and not necessary for Vertico etc.
     :hook (completion-list-mode . consult-preview-at-point-mode)
 
     ;; The :init configuration is always executed (Not lazy)
@@ -372,26 +368,6 @@
           completion-category-overrides '((file (styles basic partial-completion))))
     :config
     (add-to-list 'orderless-style-dispatchers #'orderless-kwd-dispatch)))
-
-(defun compleseus/init-selectrum ()
-  (use-package selectrum
-    :init
-    ;; Disable ido. We want to use the regular find-file etc.; enhanced by selectrum
-    (setq ido-mode nil)
-
-    (selectrum-mode)
-    (spacemacs/set-leader-keys
-      "rl" 'selectrum-repeat
-      "sl" 'selectrum-repeat)
-
-    :config
-    (when (spacemacs//support-hjkl-navigation-p)
-      (define-key selectrum-minibuffer-map (kbd "C-j") 'selectrum-next-candidate)
-      (define-key selectrum-minibuffer-map (kbd "C-r") 'consult-history)
-      (define-key selectrum-minibuffer-map (kbd "C-k") 'selectrum-previous-candidate)
-      (define-key selectrum-minibuffer-map (kbd "C-M-k") #'spacemacs/selectrum-previous-candidate-preview)
-      (define-key selectrum-minibuffer-map (kbd "C-M-j") #'spacemacs/selectrum-next-candidate-preview)
-      (define-key selectrum-minibuffer-map (kbd "C-SPC") #'spacemacs/embark-preview))))
 
 (defun compleseus/init-vertico ()
   (use-package vertico

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -389,7 +389,7 @@ Features:
 [[file:+completion/compleseus/README.org][+completion/compleseus/README.org]]
 
 This layer implements completion provided by combining the following packages:
-- =selectrum= or =vertico=: vertical completion user interface
+- =vertico=: vertical completion user interface
 - =consult=: useful commands using ~completing-read~
 - =embark=: provides minibuffer actions
 - =marginalia=: annotations to completion candidates


### PR DESCRIPTION
Selectrum has been deprecated by its maintainers in favor of Vertico.