### PR TITLE
Use built-in fido-vertical-mode to replace the ido-verical-mode

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -995,15 +995,6 @@ Ask for confirmation before copying the file if the destination already exists."
   (copy-file dotspacemacs-template-file dotspacemacs-filepath 1)
   (message "%s has been installed." dotspacemacs-filepath))
 
-(defvar ido-max-window-height)
-
-(defun dotspacemacs//ido-completing-read (prompt candidates)
-  "Call `ido-completing-read' with a CANDIDATES alist where the key is
-a display strng and the value is the actual value to return."
-  (let ((ido-max-window-height (1+ (length candidates))))
-    (cadr (assoc (ido-completing-read prompt (mapcar 'car candidates))
-                 candidates))))
-
 (defun dotspacemacs/maybe-install-dotfile ()
   "Install the dotfile if it does not exist."
   (unless (file-exists-p dotspacemacs-filepath)
@@ -1023,23 +1014,36 @@ If ARG is non nil then ask questions to the user before installing the dotfile."
            ;; editing style
            `(("dotspacemacs-editing-style 'vim"
               ,(format
-                "dotspacemacs-editing-style '%S"
-                (dotspacemacs//ido-completing-read
-                 "What is your preferred editing style? "
-                 '(("Among the stars aboard the Evil flagship (vim)"
-                    vim)
-                   ("On the planet Emacs in the Holy control tower (emacs)"
-                    emacs)))))
+                "dotspacemacs-editing-style '%s"
+                (cadr (read-multiple-choice
+                       "What is your preferred editing style?"
+                       '((?v "vim") (?e "emacs") (?h "hybrid"))
+                       (substitute-command-keys "\
+Choose your editing style.
+
+`vim': Recommended for users familiar with Vim, and the most popular choice.
+Use \\`SPC' as your leader key.
+
+`emacs': Key bindings compatible with vanilla Emacs.
+Use \\`M-m' as your leader key.
+
+`hybrid': Like Vim, but use Emacs-style key bindings in insert state.
+Use \\`SPC' as your leader key.
+") t))))
              ("dotspacemacs-distribution 'spacemacs"
               ,(format
-                "dotspacemacs-distribution '%S"
-                (dotspacemacs//ido-completing-read
-                 "What distribution of spacemacs would you like to start with? "
-                 `(("The standard distribution, recommended (spacemacs)"
-                    spacemacs)
-                   (,(concat "A minimalist distribution that you can build on "
-                             "(spacemacs-base)")
-                    spacemacs-base)))))))))
+                "dotspacemacs-distribution '%s"
+                (cadr (read-multiple-choice
+                       "What distribution of spacemacs would you like to start with?"
+                       `((?s "spacemacs" "The standard distribution, recommended")
+                         (?b "spacemacs-base" "A minimalist distribution that you can build on"))
+                       (substitute-command-keys "\
+`spacemacs': The standard distribution.
+Recommended for most users.
+
+`spacemacs-base': A minimalist distribution that you can build on.
+Configures only the minimal packages for core Spacemacs functionality.
+") t))))))))
     (with-current-buffer (find-file-noselect dotspacemacs-template-file)
       (dolist (p preferences)
         (goto-char (point-min))

--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -1035,8 +1035,8 @@ Use \\`SPC' as your leader key.
                 "dotspacemacs-distribution '%s"
                 (cadr (read-multiple-choice
                        "What distribution of spacemacs would you like to start with?"
-                       `((?s "spacemacs" "The standard distribution, recommended")
-                         (?b "spacemacs-base" "A minimalist distribution that you can build on"))
+                       `((?s "spacemacs")
+                         (?b "spacemacs-base"))
                        (substitute-command-keys "\
 `spacemacs': The standard distribution.
 Recommended for most users.

--- a/core/core-spacemacs.el
+++ b/core/core-spacemacs.el
@@ -188,8 +188,6 @@ of directories to file basenames."
   (hidden-mode-line-mode)
   ;; Disable GUI elements (toolbars, scrollbars, etc.) for a cleaner look.
   (spacemacs//toggle-gui-elements 0)
-  ;; Setup vertical ido mode for the setup wizard.
-  (spacemacs//setup-ido-vertical-mode)
   ;; Set preferred coding system to UTF-8 to avoid prompts.
   (prefer-coding-system 'utf-8)
   ;; Extend use-package if installed.
@@ -270,22 +268,6 @@ of directories to file basenames."
     (spacemacs/load-spacemacs-env))
   ;; Install the dotfile if required.
   (dotspacemacs/maybe-install-dotfile))
-
-;; Setup ido-vertical-mode for the setup wizard.
-(defun spacemacs//setup-ido-vertical-mode ()
-  "Setup `ido-vertical-mode' for the setup wizard.
-Only activates after ido is loaded, for use in the dotfile setup wizard."
-  (with-eval-after-load 'ido
-    (require 'ido-vertical-mode)
-    (ido-vertical-mode t)
-    (add-hook
-     'ido-setup-hook
-     ;; Natural navigation keys for ido vertical mode.
-     (defun spacemacs//ido-vertical-natural-navigation ()
-       (define-key ido-completion-map (kbd "<up>") 'ido-prev-match)
-       (define-key ido-completion-map (kbd "<down>") 'ido-next-match)
-       (define-key ido-completion-map (kbd "<left>") 'ido-delete-backward-updir)
-       (define-key ido-completion-map (kbd "<right>") 'ido-exit-minibuffer)))))
 
 ;; Override the default startup echo area message.
 (defun display-startup-echo-area-message ()


### PR DESCRIPTION
Use the `fido-vertical-mode` (built-in  since emacs-28) to replace the `ido-verical-mode`.
Partially fix #17260