### PR TITLE
[llm-client] Added gptel-agent support and fixed gptel capitalization

### DIFF
--- a/layers/+web-services/llm-client/README.org
+++ b/layers/+web-services/llm-client/README.org
@@ -65,7 +65,7 @@ your =dotspacemacs-configuration-layers= list:
 
 *** gptel-agent support
 gptel, while capable of supporting agents, does not have out-of-the-box
-agentic capabilities. [[github.com/karthink/gptel-agent][gptel-agent]] is an agentic preset for gptel. Accordingly,
+agentic capabilities. [[https://github.com/karthink/gptel-agent][gptel-agent]] is an agentic preset for gptel. Accordingly,
 gptel-agent will not work without gptel enabled.
 
 To enable gptel support in your Spacemacs configuration, add the following to

--- a/layers/+web-services/llm-client/README.org
+++ b/layers/+web-services/llm-client/README.org
@@ -7,16 +7,18 @@
   - [[#features][Features:]]
 - [[#install][Install]]
   - [[#layer][Layer]]
-  - [[#gptel-support][GPTel support]]
+  - [[#gptel-support][gptel support]]
+    - [[#gptel-agent-support][gptel-agent support]]
   - [[#ellama-support][Ellama support]]
 - [[#configuration][Configuration]]
 - [[#key-bindings][Key bindings]]
-  - [[#gptel][GPTel]]
+  - [[#gptel][gptel]]
+  - [[#gptel-agent][gptel-agent]]
   - [[#ellama][Ellama]]
     - [[#transient-menu][Transient menu]]
 
 * Description
-This layer enables usage of GPT Clients in Spacemacs using [[https://github.com/karthink/gptel][GPTel]] and [[https://github.com/s-kostyaev/ellama][Ellama]].
+This layer enables usage of GPT Clients in Spacemacs using [[https://github.com/karthink/gptel][gptel]] and [[https://github.com/s-kostyaev/ellama][Ellama]].
 
 ** Features:
 You will have access to the following tools:
@@ -41,19 +43,32 @@ To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =llm-client= to the existing =dotspacemacs-configuration-layers= list in this
 file.
 
-** GPTel support
-GPTel is a Large Language Model chat client for Emacs, with support for multiple
-models and backends. GPTel allows you to interact with LLMs from anywhere in
+** gptel support
+gptel is a Large Language Model chat client for Emacs, with support for multiple
+models and backends. gptel allows you to interact with LLMs from anywhere in
 Emacs (any buffer, shell, minibuffer, wherever) and supports conversations and
 multiple independent sessions.
 
-Key features of GPTel include:
+Key features of gptel include:
 - Async and fast, streams responses.
 - LLM responses are in Markdown or Org markup.
 - Supports conversations and multiple independent sessions.
 - Save chats as regular Markdown/Org/Text files and resume them later.
 
-To enable GPTel support in your Spacemacs configuration, add the following to
+To enable gptel support in your Spacemacs configuration, add the following to
+your =dotspacemacs-configuration-layers= list:
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers
+   '((llm-client :variables llm-client-enable-gptel t)))
+#+END_SRC
+
+*** gptel-agent support
+gptel, while capable of supporting agents, does not have out-of-the-box
+agentic capabilities. [[github.com/karthink/gptel-agent][gptel-agent]] is an agentic preset for gptel. Accordingly,
+gptel-agent will not work without gptel enabled.
+
+To enable gptel support in your Spacemacs configuration, add the following to
 your =dotspacemacs-configuration-layers= list:
 
 #+BEGIN_SRC emacs-lisp
@@ -85,20 +100,20 @@ your =dotspacemacs-configuration-layers= list:
 #+END_SRC
 
 * Configuration
-Refer to the official [[https://github.com/karthink/gptel][GPTel]] and [[https://github.com/s-kostyaev/ellama][ellama]] documentation for advanced configurations
+Refer to the official [[https://github.com/karthink/gptel][gptel]] and [[https://github.com/s-kostyaev/ellama][ellama]] documentation for advanced configurations
 and additional information.
 
 * Key bindings
 The layer provides several key bindings to interact with LLMs efficiently.
 
-** GPTel
+** gptel
 
 | Key binding | Command                  | Description                     |
 |-------------+--------------------------+---------------------------------|
-| ~SPC $ g g~ | gptel                    | Start a new GPTel session       |
-| ~SPC $ g s~ | gptel-send               | Send a message to GPTel         |
-| ~SPC $ g q~ | gptel-abort              | Abort any active GPTel process  |
-| ~SPC $ g m~ | gptel-menu               | Open the GPTel menu             |
+| ~SPC $ g g~ | gptel                    | Start a new gptel session       |
+| ~SPC $ g s~ | gptel-send               | Send a message to gptel         |
+| ~SPC $ g q~ | gptel-abort              | Abort any active gptel process  |
+| ~SPC $ g m~ | gptel-menu               | Open the gptel menu             |
 | ~SPC $ g c~ | gptel-add                | Add to context                  |
 | ~SPC $ g f~ | gptel-add-file           | Add a file to context           |
 | ~SPC $ g r~ | gptel-rewrite            | Rewrite or refactor text region |
@@ -111,6 +126,15 @@ In addition, this layer adds the following key bindings to =org-mode=
 |---------------+--------------------------+----------------------------|
 | ~SPC m $ g o~ | gptel-org-set-topic      | Set topic in Org-mode      |
 | ~SPC m $ g p~ | gptel-org-set-properties | Set properties in Org-mode |
+
+** gptel-agent
+
+In addition to the bindings offered by gptel, these bindings are unique to gptel-agent.
+
+| Key binding | Command            | Description                      |
+|-------------+--------------------+----------------------------------|
+| ~SPC $ g a~ | gptel-agent        | Start a new gptel session        |
+| ~SPC $ g u~ | gptel-agent-update | Updates the gptel-agent database |
 
 ** Ellama
 Ellama provides its own transient key binding menu, which is

--- a/layers/+web-services/llm-client/README.org
+++ b/layers/+web-services/llm-client/README.org
@@ -68,12 +68,12 @@ gptel, while capable of supporting agents, does not have out-of-the-box
 agentic capabilities. [[https://github.com/karthink/gptel-agent][gptel-agent]] is an agentic preset for gptel. Accordingly,
 gptel-agent will not work without gptel enabled.
 
-To enable gptel support in your Spacemacs configuration, add the following to
+To enable gptel-agent support in your Spacemacs configuration, add the following to
 your =dotspacemacs-configuration-layers= list:
 
 #+BEGIN_SRC emacs-lisp
   (setq-default dotspacemacs-configuration-layers
-   '((llm-client :variables llm-client-enable-gptel t)))
+   '((llm-client :variables llm-client-enable-gptel-agent t)))
 #+END_SRC
 
 ** Ellama support

--- a/layers/+web-services/llm-client/config.el
+++ b/layers/+web-services/llm-client/config.el
@@ -7,6 +7,11 @@
   :type 'boolean
   :group 'llm-client)
 
+(defcustom llm-client-enable-gptel-agent t
+  "If non-nil, enable the =gptel-agent= package for agentic capabilities in =gptel=."
+  :type 'boolean
+  :group 'llm-client)
+
 (defcustom llm-client-enable-ellama t
   "If non-nil, enable the =ellama= package."
   :type 'boolean

--- a/layers/+web-services/llm-client/packages.el
+++ b/layers/+web-services/llm-client/packages.el
@@ -25,6 +25,7 @@
 (defconst llm-client-packages
   '((ellama :toggle llm-client-enable-ellama)
     (gptel :toggle llm-client-enable-gptel)
+    (gptel-agent :toggle llm-client-enable-gptel-agent)
     org
     window-purpose))
 
@@ -54,21 +55,38 @@
       "p"       #'gptel-context-previous
       "d"       #'gptel-context-flag-deletion)
     ;; set up keybindings
-    (spacemacs/declare-prefix "$g" "Gptel")
+    (spacemacs/declare-prefix "$g" "gptel")
     (spacemacs/set-leader-keys
-      "$gg" 'gptel                          ; Start a new GPTel session
-      "$gs" 'spacemacs//gptel-send-wrapper  ; Send a message to GPTel
-      "$gq" 'spacemacs//gptel-abort-wrapper ; Abort any active GPTel process
-      "$gm" 'gptel-menu                     ; Open the GPTel menu
+      "$gg" 'gptel                          ; Start a new gptel session
+      "$gs" 'spacemacs//gptel-send-wrapper  ; Send a message to gptel
+      "$gq" 'spacemacs//gptel-abort-wrapper ; Abort any active gptel process
+      "$gm" 'gptel-menu                     ; Open the gptel menu
       "$gc" 'gptel-add                      ; Add context
       "$gf" 'gptel-add-file                 ; Add a file
       "$go" 'gptel-org-set-topic            ; Set topic in Org-mode
       "$gp" 'gptel-org-set-properties       ; Set properties in Org-mode
       "$gr" 'gptel-rewrite)))               ; Rewrite or refactor test region
 
+(defun llm-client/init-gptel-agent ()
+  "Initialize the `gptel-agent` package and set up keybindings."
+  (use-package gptel-agent
+    :defer t
+    :ensure t
+    :init
+    ;; evilify gptel-context-buffer-mode-map
+    (evilified-state-evilify-map gptel-context-buffer-mode-map
+      :eval-after-load gptel-context
+      :mode gptel-context-buffer-mode)
+    ;; set up keybindings
+    (spacemacs/set-leader-keys
+      "$ga" 'gptel-agent                          ; Start a new gptel-agent session
+      "$gu" 'gptel-agent-update)                  ; Updates the gptel-agent database
+    ;; Config for =gptel-agent=
+    :config (gptel-agent-update)))
+
 (defun llm-client/post-init-org ()
-  "Set up Org-mode keybindings for GPTel."
-  (spacemacs/declare-prefix-for-mode 'org-mode "m$g" "Gptel")
+  "Set up Org-mode keybindings for gptel."
+  (spacemacs/declare-prefix-for-mode 'org-mode "m$g" "gptel")
   (spacemacs/set-leader-keys-for-major-mode 'org-mode
     "$go" 'gptel-org-set-topic
     "$gp" 'gptel-org-set-properties))

--- a/layers/+web-services/llm-client/packages.el
+++ b/layers/+web-services/llm-client/packages.el
@@ -71,7 +71,6 @@
   "Initialize the `gptel-agent` package and set up keybindings."
   (use-package gptel-agent
     :defer t
-    :ensure t
     :init
     ;; evilify gptel-context-buffer-mode-map
     (evilified-state-evilify-map gptel-context-buffer-mode-map

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -3477,7 +3477,7 @@ Features:
 ** Large Language Model Client
 [[file:+web-services/llm-client/README.org][+web-services/llm-client/README.org]]
 
-This layer enables usage of GPT Clients in Spacemacs using [[https://github.com/karthink/gptel][GPTel]] and [[https://github.com/s-kostyaev/ellama][Ellama]].
+This layer enables usage of GPT Clients in Spacemacs using [[https://github.com/karthink/gptel][gptel]] and [[https://github.com/s-kostyaev/ellama][Ellama]].
 
 Features:
 


### PR DESCRIPTION
gptel has been a cool feature for Emacs, but I couldn't for the life of me get gptel-agent hooked up without just modifying the layer for LLM stuff. This adds the ability to start agent sessions easily. 

Additionally, the casing was all over the place, with some people doing GPTel and Gptel in Spacemacs. @karthink has gptel in all lowercases, even at sentence starts, so I updated everything to reflect that.

Do people still use CHANGELOG.develop? I didn't see anything about gptel at all in there.
