### PR TITLE
[shell] Fix void-variable errors after shell-pop rewrite

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3625,6 +3625,10 @@ files (thanks to Daniel Nicolai)
 - Added support for multi-vterm as default terminal option
 - Added ~M-l~ for =eshell= mode and ~SPC m H~ for both =shell= and =eshell=
   modes for =consult-history= (thanks to Jaehyun Yeom)
+- Fixed =shell-pop= popup toggling failing with void-variable errors
+  on =shell-pop= =20260510= and later, which moved last-buffer and
+  last-window tracking from globals to window parameters
+  (thanks to Mariusz Klochowicz)
 **** Shell Scripts
 - Added new company-shell environment variable backend
   (thanks to Alexander-Miller)

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -85,7 +85,11 @@ Additionally changes to working directory when the value of
     (call-interactively (intern (format "spacemacs/shell-pop-%S" shell)))))
 
 (defun spacemacs/resize-shell-to-desired-width ()
-  (when (and (string= (buffer-name) shell-pop-last-shell-buffer-name)
+  ;; `shell-pop--is-shell-buffer' is a buffer-local flag set by shell-pop on
+  ;; managed buffers (replaces the removed `shell-pop-last-shell-buffer-name'
+  ;; comparison). `bound-and-true-p' keeps this safe on shell-pop versions
+  ;; that predate the rewrite.
+  (when (and (bound-and-true-p shell-pop--is-shell-buffer)
              (memq shell-pop-window-position '(left right)))
     (enlarge-window-horizontally (- (/ (* (frame-width) shell-default-width)
                                        100)
@@ -286,14 +290,6 @@ is achieved by adding the relevant text properties."
               (centered-cursor-mode 0))
             :append
             :local))
-
-(defun spacemacs//shell-pop-restore-window ()
-  "Fixes an issue during `shell-pop-out' where it
-tries to restore a dead buffer or window."
-  (unless (buffer-live-p shell-pop-last-buffer)
-    (setq shell-pop-last-buffer (window-buffer (get-mru-window nil t t))))
-  (unless (window-live-p shell-pop-last-window)
-    (setq shell-pop-last-window (get-buffer-window shell-pop-last-buffer))))
 
 (defun spacemacs//vterm-make-history-candidates ()
   (with-temp-buffer

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -258,9 +258,7 @@
       (evil-set-initial-state initial-shell-mode 'insert))
 
     (when (fboundp 'spacemacs/make-variable-layout-local)
-      (spacemacs/make-variable-layout-local 'shell-pop-last-shell-buffer-index 1
-                                            'shell-pop-last-shell-buffer-name ""
-                                            'shell-pop-last-buffer nil))
+      (spacemacs/make-variable-layout-local 'shell-pop-last-shell-buffer-index 1))
 
     (add-hook 'term-mode-hook 'ansi-term-handle-close)
 
@@ -271,9 +269,7 @@
       "atsm" 'spacemacs/shell-pop-multiterm
       "atst" 'spacemacs/shell-pop-ansi-term
       "atsT" 'spacemacs/shell-pop-term)
-    (spacemacs/declare-prefix "'" "open shell")
-    :config
-    (add-hook 'shell-pop-out-hook #'spacemacs//shell-pop-restore-window)))
+    (spacemacs/declare-prefix "'" "open shell")))
 
 (defun shell/init-term ()
   (spacemacs/register-repl 'term 'term)


### PR DESCRIPTION
Fixes #17270.

shell-pop's [PR #76](https://github.com/kyagi/shell-pop-el/pull/76) (released as `20260510.1616` on MELPA) replaces manual buffer/window tracking with Emacs's built-in window-configuration API. The rewrite moves last-buffer/-window state to per-window parameters and drops three globals the shell layer relied on:

- `shell-pop-last-buffer`
- `shell-pop-last-window`
- `shell-pop-last-shell-buffer-name`
