### PR TITLE
[version-control] Switch to upstream diff-hl package and remove advice

### DIFF
--- a/layers/+source-control/version-control/README.org
+++ b/layers/+source-control/version-control/README.org
@@ -52,12 +52,12 @@ You can choose the side on which the diff appears (by default it's the right sid
                     version-control-diff-side 'left)
 #+END_SRC
 
-To automatically enable diff margins in all buffers, set
-=version-control-margin=
+Diff margins are automatically enabled in all buffers, but they can be
+disabled if you only want to use other diff-hl features:
 
 #+BEGIN_SRC emacs-lisp
   '(version-control :variables
-                    version-control-margin 'global)
+                    version-control-margin nil)
 #+END_SRC
 
 ** Differences between margin packages
@@ -74,9 +74,11 @@ one over the other:
 | Stage hunks from buffer             |         | X          |
 | Dired support                       | X       |            |
 
-The =diff-hl= or =git-gutter-fringe= supports GUI/Fringe, while the
-=diff-hl-margin= or =git-gutter= supports the TUI/Margin. Check the variable
-=version-control-margin= for how Spacemace selecting the margin features.
+=diff-hl= supports both the margin (TTY frames) and the fringe (GUI
+frames).  =git-gutter-fringe= supports only the GUI/Fringe, while the
+=git-gutter= supports the TUI/Margin. Check the variable
+=version-control-margin= for how Spacemacs selects the margin
+features.
 
 * Key bindings
 VC commands (not exhaustive):

--- a/layers/+source-control/version-control/config.el
+++ b/layers/+source-control/version-control/config.el
@@ -24,17 +24,14 @@
 (defvar spacemacs--smerge-ts-full-hint-toggle nil
   "Display smerge transient-state documentation.")
 
-(spacemacs|defc version-control-margin 'auto
-  "Options to apply the margin for diff-tool.
+(spacemacs|defc version-control-margin t
+  "Whether to display diff indicators in the margin or fringe.
 
-For git-gutter it only checkes the option as nil or non-nil to
-activate/diactivate the margin feature.
+The git-gutter diff tool only supports showing indicators in the margin.
 
-For diff-hl it supports:
-`auto'/t: Activate the margin feature for TTY frames,
-          and activate the fringe feature for graphic frame.
-`global': Activate the margin globally.
-`nil': do not activate the margin feature."
+The diff-hl diff tool shows indicators in the fringe for graphical
+frames and in the margin for TTY frames (which do not support the
+fringe)."
   '(choice (const auto) (const global) boolean))
 
 (spacemacs|defc version-control-diff-tool 'diff-hl

--- a/layers/+source-control/version-control/config.el
+++ b/layers/+source-control/version-control/config.el
@@ -37,7 +37,7 @@ fringe)."
 (spacemacs|defc version-control-diff-tool 'diff-hl
   "Options are `diff-hl' (the preferred choice) or `git-gutter' to show
 version-control markers, `nil' to disable this feature."
-  '(choice (const diff-hl) (const git-gutter) nil))
+  '(choice (const diff-hl) (const git-gutter) (const nil)))
 
 (spacemacs|defc version-control-diff-side 'right
   "Side on which to show version-control markers.

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -26,13 +26,7 @@
     ;; Git-gutter+ is not longer maintained and will break with latest magit version
     ;; therefore we switch to diff-hl for users which have configered git-gutter+ to avoid
     ;; breaking there config.
-    ;; (diff-hl            :toggle (or (eq 'diff-hl version-control-diff-tool)
-    ;;                                 (eq 'git-gutter+ version-control-diff-tool)))
-    (diff-hl :location (recipe
-                        :fetcher github
-                        :repo "smile13241324/diff-hl"
-                        :branch "frame-local-diff-hl-margin-mode")
-             :toggle (or (eq 'diff-hl version-control-diff-tool)
+    (diff-hl :toggle (or (eq 'diff-hl version-control-diff-tool)
                          (eq 'git-gutter+ version-control-diff-tool)))
     diff-mode
     evil-collection
@@ -151,16 +145,6 @@
     (setq diff-hl-side (if (eq version-control-diff-side 'left)
                            'left 'right))
     (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)
-    (define-advice turn-on-diff-hl-mode (:after (&rest _) AUTOMARGIN)
-      (and (memq version-control-margin '(t auto))
-           (not diff-hl-margin-mode)    ; not global mode
-           (not (display-graphic-p (window-frame (get-buffer-window))))
-           (diff-hl-margin-local-mode)
-           (diff-hl-update)))
-    (when (eq version-control-margin 'global)
-        (run-with-idle-timer 1 nil 'spacemacs/vcs-enable-margin-globally))
-    ;; The diff-hl-margin mode requests the diff-hl-mode to be enabled, so
-    ;; enable the diff-hl-mode anyway.
     (run-with-idle-timer 1 nil 'global-diff-hl-mode)))
 
 (defun version-control/post-init-evil-unimpaired ()

--- a/layers/+source-control/version-control/packages.el
+++ b/layers/+source-control/version-control/packages.el
@@ -23,11 +23,7 @@
 (defconst version-control-packages
   '(
     browse-at-remote
-    ;; Git-gutter+ is not longer maintained and will break with latest magit version
-    ;; therefore we switch to diff-hl for users which have configered git-gutter+ to avoid
-    ;; breaking there config.
-    (diff-hl :toggle (or (eq 'diff-hl version-control-diff-tool)
-                         (eq 'git-gutter+ version-control-diff-tool)))
+    (diff-hl :toggle (eq 'diff-hl version-control-diff-tool))
     diff-mode
     evil-collection
     evil-unimpaired


### PR DESCRIPTION
1. Remove advice which worked around a lack of automatic fringe/margin
   selection in diff-hl. This is now available out of the box upstream
   and requires no configuration (see dgutov/diff-hl#212).
1. Switch to upstream `diff-hl` package; the fork has fallen behind
1. Remove some unnecessary workarounds for the unmaintained
   `git-gutter+` package that was removed from Spacemacs.  (Just
   display an error at startup and let the user update their setting
   instead of silently changing behavior.)