### PR TITLE
[core] New variable "dotspacemacs-prefer-builtin-package"

### DIFF
--- a/core/core-dotspacemacs.el
+++ b/core/core-dotspacemacs.el
@@ -754,6 +754,15 @@ number of recent files to show in each project."
   '(repeat symbol)
   'spacemacs-dotspacemacs-layers)
 
+(spacemacs|defc dotspacemacs-prefer-builtin-package (version< "30" emacs-version)
+  "If non-nil, prefer the builtin packages instead of install the package from melpa.
+
+The Emacs31 includes org and transient packages new enough, so there is
+no need to install newer versions from ELPA, which could cause
+performance issues."
+  'boolean
+  'spacemacs-dotspacemacs-layers)
+
 (spacemacs|defc dotspacemacs-pretty-docs nil
   "Run `spacemacs/prettify-org-buffer' when
 visiting README.org files of Spacemacs."

--- a/layers/+distributions/spacemacs-bootstrap/packages.el
+++ b/layers/+distributions/spacemacs-bootstrap/packages.el
@@ -22,7 +22,7 @@
 
 
 (defconst spacemacs-bootstrap-packages
-  '(
+  `(
     ;; bootstrap packages,
     ;; `use-package' cannot be used for bootstrap packages configuration
     (async :step bootstrap)
@@ -44,7 +44,7 @@
     (which-key-posframe :step pre :toggle (and (consp dotspacemacs-which-key-position)
                                                (eq (car dotspacemacs-which-key-position) 'posframe)))
     dash
-    (transient :location elpa)))
+    (transient :location ,(if dotspacemacs-prefer-builtin-package 'built-in 'elpa))))
 
 ;; bootstrap packages
 

--- a/layers/+emacs/org/packages.el
+++ b/layers/+emacs/org/packages.el
@@ -22,7 +22,7 @@
 
 
 (defconst org-packages
-  '(
+  `(
     company
     company-emoji
     emoji-cheat-sheet-plus
@@ -34,7 +34,7 @@
     ;; ob, org, org-agenda and org-contacts are installed by `org-contrib'
     (ob :location built-in)
     (ob-mermaid :toggle org-enable-mermaid-support)
-    (org :location elpa)
+    (org :location ,(if dotspacemacs-prefer-builtin-package 'built-in 'elpa))
     (org-agenda :location built-in)
     (org-alert  :toggle org-enable-notifications)
     (org-contacts :toggle org-enable-org-contacts-support)


### PR DESCRIPTION
The Emacs-31 will always reload whole packages to make sure external package can override built-in one in the commit https://github.com/emacs-mirror/emacs/commit/5878c9ae7c958af1828e85a7b4d922c1a8c1b6bf which leads Spacemacs performance issue. Since Emacs-31 is new enough, so Spacemacs can prefer the built-in packages instead of external packages. 

This patch provide a variable to `dotspacemacs-prefer-builtin-package` to avoid performance issue on emacs-31. 

With this patch, the Spacemacs on Emacs-31/Windows spends ~6.4s on startup in my local;
Without this patch, the Spacemacs on Emacs-31/Windows spends ~2.9s on startup in same env.
```
Before:       353 packages loaded in 6.414s (elpa 254, recipe 24, local 4, built-in 71)
After:        353 packages loaded in 2.968s (elpa 252, recipe 24, local 4, built-in 73)
```
It also have ~25% time reducing for Spacemacs on Emacs-31/Ubuntu. 