### PR TITLE
Respect .gitignore in lsp-mode file watchers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -213,6 +213,11 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
   - added  ~lsp-use-lsp-ui~ variable to control whether ~lsp-ui~ is installed or not.
   - added ~SPC m g h~ to go to call hierarchy.
   - added ~SPC m g T~ to go to type hierarchy.
+- Exclude paths matched by the workspace root's =.gitignore= from
+  =lsp-mode='s file watchers. Enabled by default; toggle with the new
+  variable ~lsp-file-watch-respect-gitignore~. Uses =git ls-files= to
+  resolve gitignore semantics correctly (negations, nested
+  =.gitignore= files, =.git/info/exclude=, global excludes).
 ***** IPython notebook
 - Key bindings;
   - Change prefix from ~SPC a i~ to ~SPC a y~ (thanks to Swaroop C H)

--- a/layers/+tools/lsp/config.el
+++ b/layers/+tools/lsp/config.el
@@ -43,3 +43,10 @@ If `both', binds lightweight navigation functions under `SPC m g' and lsp-ui fun
 
 (defvar lsp-manage-backends-manually nil "When non-nil lsp-mode does not insert `company-capf' as the ultimate first item of `company-backends'.
 `lsp-manage-backends-manually' can either be `:all' or a list of major-modes that should be managed manually.")
+
+(defvar lsp-file-watch-respect-gitignore t
+  "When non-nil, exclude paths matched by the workspace root's `.gitignore'
+from LSP file watchers. Patterns are parsed in Elisp (no `git' subprocess)
+and merged with `lsp-file-watch-ignored-directories' and
+`lsp-file-watch-ignored-files'. Changes to `.gitignore' take effect on
+the next workspace restart.")

--- a/layers/+tools/lsp/funcs.el
+++ b/layers/+tools/lsp/funcs.el
@@ -320,3 +320,46 @@ EXTRA is an additional parameter that's passed to the LSP function"
 (defun spacemacs//lsp-client-server-id ()
   "Return the ID of the LSP server associated with current project."
   (mapcar 'lsp--client-server-id (mapcar 'lsp--workspace-client (lsp-workspaces))))
+
+
+;; .gitignore-aware file watcher ignore lists
+
+(defun spacemacs//lsp-gitignore-regexes (workspace-root)
+  "Return (FILES DIRS) regex lists for paths git ignores under WORKSPACE-ROOT.
+Asks git itself via `git ls-files --others --ignored --exclude-standard
+--directory', so all gitignore semantics (negations, nested `.gitignore'
+files, `.git/info/exclude', global excludes) are honored. Returns nil
+unless `lsp-file-watch-respect-gitignore' is non-nil, WORKSPACE-ROOT is
+a git working tree, and `git' is on PATH."
+  (when (and lsp-file-watch-respect-gitignore
+             workspace-root
+             (file-exists-p (expand-file-name ".git" workspace-root))
+             (executable-find "git"))
+    (let* ((default-directory (file-name-as-directory
+                               (file-truename workspace-root)))
+           (root (directory-file-name default-directory))
+           files dirs)
+      (with-temp-buffer
+        (when (zerop (process-file "git" nil (list t nil) nil
+                                   "ls-files" "-z"
+                                   "--others" "--ignored"
+                                   "--exclude-standard" "--directory"))
+          (dolist (rel (split-string (buffer-string) "\0" t))
+            (let* ((dir-only (string-suffix-p "/" rel))
+                   (clean (if dir-only (substring rel 0 -1) rel))
+                   (abs (expand-file-name clean root))
+                   (rx (concat "\\`" (regexp-quote abs)
+                               (if dir-only "\\(?:/\\|\\'\\)" "\\'"))))
+              (push rx dirs)
+              (unless dir-only (push rx files))))))
+      (list (nreverse files) (nreverse dirs)))))
+
+(defun spacemacs//lsp-merge-gitignore-regexes (orig-fn workspace-root)
+  "Around-advice merging `.gitignore' regexes into LSP's ignore lists.
+Wraps `lsp--get-ignored-regexes-for-workspace-root'."
+  (let ((base (funcall orig-fn workspace-root))
+        (extra (spacemacs//lsp-gitignore-regexes workspace-root)))
+    (if extra
+        (list (append (car base) (car extra))
+              (append (cadr base) (cadr extra)))
+      base)))

--- a/layers/+tools/lsp/packages.el
+++ b/layers/+tools/lsp/packages.el
@@ -64,7 +64,9 @@
     (add-to-list 'lsp--formatting-indent-alist '(web-mode . web-mode-markup-indent-offset))
     (add-hook 'lsp-after-open-hook (lambda ()
                                      "Setup xref jump handler"
-                                     (spacemacs//setup-lsp-jump-handler)))))
+                                     (spacemacs//setup-lsp-jump-handler)))
+    (advice-add 'lsp--get-ignored-regexes-for-workspace-root
+                :around #'spacemacs//lsp-merge-gitignore-regexes)))
 
 (defun lsp/init-lsp-ui ()
   (use-package lsp-ui


### PR DESCRIPTION
## Summary

- Adds `lsp-file-watch-respect-gitignore` (default `t`) to the `lsp` layer so `lsp-mode` skips creating file-watch entries for paths the workspace's `.gitignore` already excludes.
- Uses `git ls-files --others --ignored --exclude-standard --directory` rather than a hand-rolled gitignore parser, so negations, nested `.gitignore` files, `.git/info/exclude`, and the global `core.excludesFile` are all honored.
- Wires the feature in via an `:around` advice on `lsp--get-ignored-regexes-for-workspace-root`, so per-workspace customization keeps working and non-git projects fall through to upstream defaults unchanged.

## Motivation

On large monorepos the upstream defaults for `lsp-file-watch-ignored-directories` cover a curated list of common build/cache dirs but miss anything project-specific. The project's own `.gitignore` is the natural source of truth and avoids hitting `lsp-file-watch-threshold` in repos where build artifacts live in unusual locations.

## Behavior

- Enabled by default; set `(setq lsp-file-watch-respect-gitignore nil)` to disable.
- Activates only when the workspace root contains a `.git` entry and `git` is on `PATH`; otherwise it's a no-op.
- One `git ls-files` invocation per workspace at watcher-creation time. Changes to `.gitignore` after a workspace is loaded take effect on `lsp-workspace-restart`.

## Files touched

- `layers/+tools/lsp/config.el` — new toggle var.
- `layers/+tools/lsp/funcs.el` — `spacemacs//lsp-gitignore-regexes` and `spacemacs//lsp-merge-gitignore-regexes`.
- `layers/+tools/lsp/packages.el` — `advice-add` in `lsp-mode`'s `:config`.
- `CHANGELOG.develop` — entry under the existing LSP layer section.

## Test plan

- [x] Verify regex generation against a fixture repo containing `node_modules`, `dist/`, `*.log`, and `/build` patterns; confirm matching ignores `node_modules/*` and `build/*` while leaving sibling source dirs watched.
- [x] `check-parens` clean on all four modified files.
- [ ] Reviewer: open a project with a non-trivial `.gitignore`, run `lsp` on it, and confirm the watcher count (visible in `*lsp-log*`) drops vs. the prior behavior.
- [ ] Reviewer: set `lsp-file-watch-respect-gitignore` to `nil`, restart workspace, confirm the previous watcher count returns.