### PR TITLE
layers/+tools/shell: explicitly define conditions for vterm support

### DIFF
--- a/layers/+tools/shell/config.el
+++ b/layers/+tools/shell/config.el
@@ -78,7 +78,8 @@ This means that movement to the prompt is inhibited like for
   "If non-nil, the window is closed when the terminal is stopped.
 This is only applied to `term' and `ansi-term' modes.")
 
-(defvar shell-enable-vterm-support t
+(defvar shell-enable-vterm-support
+  (and module-file-suffix (not (spacemacs/system-is-mswindows)))
   "If non-nil, enable the `vterm' and `multi-vterm' packages.'
 
 These packages require dynamic module support in your Emacs, as

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -45,14 +45,8 @@
     terminal-here
     vi-tilde-fringe
     window-purpose
-    (multi-vterm
-     :toggle (and shell-enable-vterm-support
-                  module-file-suffix
-                  (not (spacemacs/system-is-mswindows))))
-    (vterm
-     :toggle (and shell-enable-vterm-support
-                  module-file-suffix
-                  (not (spacemacs/system-is-mswindows))))))
+    (multi-vterm :toggle shell-enable-vterm-support)
+    (vterm :toggle shell-enable-vterm-support)))
 
 
 (defun shell/init-comint ()


### PR DESCRIPTION
The vterm was not enabled on my local test env even the `shell-enable-vterm-support` is `t`, after investigation I realize the the spacemacs vterm support flag is not explicitly show its depends (my test build does not enable the module feature).

This PR explicityly defines the conditions for vterm flag by moving them to flag definition from deep side.