### PR TITLE
Remove hook for deleted consult mode

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -145,11 +145,6 @@
            ("M-s e" . consult-isearch-history)       ;; orig. isearch-edit-string
            ("M-s l" . consult-line))                 ;; needed by consult-line to detect isearch
 
-    ;; Enable automatic preview at point in the *Completions* buffer.
-    ;; This is relevant when you use the default completion UI,
-    ;; and not necessary for Vertico etc.
-    :hook (completion-list-mode . consult-preview-at-point-mode)
-
     ;; The :init configuration is always executed (Not lazy)
     :init
     ;; disable automatic preview by default


### PR DESCRIPTION
I ran into an error involving `consult-preview-at-point-mode`, which has been removed [here](https://github.com/minad/consult/commit/5cd964679d75028e346355d1ae9af3853081abd5).