### PR TITLE
[bootstrap] Provide default state 'normal' in spacemacs/state-color-face

### DIFF
--- a/layers/+distributions/spacemacs-bootstrap/funcs.el
+++ b/layers/+distributions/spacemacs-bootstrap/funcs.el
@@ -24,8 +24,8 @@
 
 
 (defun spacemacs/state-color-face (state)
-  "Return the symbol of the face for the given STATE."
-  (intern (format "spacemacs-%s-face" (symbol-name state))))
+  "Return the symbol of the face for the given STATE, defaults to `emacs'."
+  (intern (format "spacemacs-%s-face" (symbol-name (or state 'emacs)))))
 
 (defun spacemacs/state-color (state)
   "Return the color string associated to STATE."


### PR DESCRIPTION
Fix a long time issue:
> error "Invalid face" spacemacs-nil-face
was reported as #1654 #11373 #16513 

To simulate the issue, just eval `(switch-to-buffer (get-buffer-create " *load*"))`. 

It caused by non-evilized buffer has no `evil-state` (or `nil`), then the function `spacemacs/state-color-face` will give `spacemacs-nil-face` and leading the error message.

This PR resolves the issue by give a default state value to avoid the error.