### PR TITLE
[spacemacs-editing-visual] Inhibit indent-guide in helm buffers

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -142,6 +142,8 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Other:
   - Support for multiple cursors using =evil-mc= is now encapsulated in the
     =multiple-cursors= layer (thanks to Codruț Constantin Gușoi)
+  - Inhibit =indent-guide= in =helm= buffers so =indent-guide-global-mode= no
+    longer breaks =helm= with "Args out of range"
 ***** C-C++
 - CMake support has been extracted from the =c-c++= layer into the new =cmake=
   layer.

--- a/layers/+spacemacs/spacemacs-editing-visual/packages.el
+++ b/layers/+spacemacs/spacemacs-editing-visual/packages.el
@@ -136,6 +136,12 @@
       :mode indent-guide-global-mode
       :documentation "Highlight indentation level at point globally. (alternative to highlight-indentation)."
       :evil-leader "t TAB")
+    :config
+    ;; `helm-major-mode' is special only via its `mode-class' property and has
+    ;; no `derived-mode-parent', so indent-guide's `derived-mode-p' check (which
+    ;; walks the parent chain, not `mode-class') never matches it against
+    ;; `special-mode' and the default inhibit list misses helm buffers.
+    (add-to-list 'indent-guide-inhibit-modes 'helm-major-mode)
     :spacediminish (" ⓘ" " i")))
 
 (defun spacemacs-editing-visual/init-rainbow-delimiters ()


### PR DESCRIPTION
### Description

Fixes #17242.

With `indent-guide-global-mode` enabled (`SPC t TAB`), helm operations
(`helm-mini`, `C-x k`, dired via helm, …) fail with `Args out of range` and an
empty helm frame. The known workaround in the issue thread is to disable
indent-guide entirely; this lets users keep it on.

### Cause

`indent-guide-global-mode` turns `indent-guide-mode` on in every buffer except
those for which `(cl-some #'derived-mode-p indent-guide-inhibit-modes)` is
non-nil (the default list contains `special-mode`). `helm-major-mode` is special
only via its `mode-class` symbol property and has **no** `derived-mode-parent`,
so `derived-mode-p` — which walks the parent chain, not `mode-class` — never
matches it against `special-mode`. The inhibit check therefore misses helm
buffers and indent-guide errors trying to draw guides in them.

### Fix

Add `helm-major-mode` to `indent-guide-inhibit-modes` from the package's
`:config`, preserving the package's default list.

### Testing

Verified in a headless daemon loading a real config: in a `helm-major-mode`
buffer the predicate `(cl-some #'derived-mode-p indent-guide-inhibit-modes)` is
`nil` with the stock list (guide turns on → crash) and `t` once `helm-major-mode`
is added (guide inhibited → no crash).

`CHANGELOG.develop` updated.