### PR TITLE
[core] Make configuration-layer/package-used-p respect :toggle

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -707,6 +707,8 @@ Other:
   - Support packing elisp to *.elc and *.el.gz (thanks to Lin Sun)
   - Add option to select and update only some packages (thanks to Daniel Nicolai)
 - Fixes:
+  - Made =configuration-layer/package-used-p= respect =:toggle=, so a package
+    disabled by a toggle is no longer reported as used (thanks to bcc32)
   - Avoid non-idempotent use of push in init code (thanks to Miciah Masters)
   - Moved Spacemacs startup progress bar to =core-progress-bar.el=, removed
     counter from progress bar, fixed updating, and fixed size when Emacs is

--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -1620,7 +1620,7 @@ RNAME is the name symbol of another existing layer."
   "Return non-nil if NAME is the name of a used package."
   (let ((obj (configuration-layer/get-package name)))
     (and obj (cfgl-package-get-safe-owner obj)
-         (not (oref obj excluded))
+         (cfgl-package-used-p obj t)
          (not (memq nil (mapcar
                          'configuration-layer/package-used-p
                          (oref obj requires)))))))

--- a/tests/core/core-configuration-layer-utest.el
+++ b/tests/core/core-configuration-layer-utest.el
@@ -670,6 +670,17 @@
     (should (null (configuration-layer/package-used-p
                    (nth (random 3) layer1-packages))))))
 
+(ert-deftest test-package-usedp--toggled-off-package-cannot-be-used ()
+  (let* ((layer1 (cfgl-layer :name 'layer1 :dir "/path/"))
+         configuration-layer--used-layers
+         configuration-layer--used-packages
+         (configuration-layer--indexed-layers (make-hash-table))
+         (configuration-layer--indexed-packages (make-hash-table)))
+    (helper--add-layers (list layer1) t)
+    (helper--add-packages
+     (list (cfgl-package :name 'pkg1 :owners '(layer1) :toggle nil)) t)
+    (should (null (configuration-layer/package-used-p 'pkg1)))))
+
 (ert-deftest test-package-usedp--used-pkg-requires-used-pkg-can-be-used ()
   (let* ((layer1 (cfgl-layer :name 'layer1 :dir "/path/"))
          (layer1-packages '(pkg1))


### PR DESCRIPTION
Fixes #16346

## Description

`configuration-layer/package-used-p` and `cfgl-package-used-p` disagreed for a
package disabled via a `:toggle` keyword that evaluates to nil: the public
function returned `t` while the method returned `nil`. Layers rely on these
predicates to decide things like keybinding ownership, so a toggled-off package
should count as *unused* — the method's behavior is the correct one, as noted in
#16346 (and agreed by @smile13241324 there).

## Cause

`configuration-layer/package-used-p` only checked `(not (oref obj excluded))`,
ignoring the toggle that `cfgl-package-used-p` already evaluates.

## Fix

Delegate the ownership/exclusion/toggle check to `cfgl-package-used-p`, while
keeping the public function's extra semantics (owner must be a *used* layer via
`cfgl-package-get-safe-owner`, and `:requires` packages must themselves be used,
recursively).

This is the function-change half of #17065 (`bcaac02ff`), which was reverted
(`222c7495b`) only because it *also* reordered `configuration-layer//load` to
evaluate toggles before layers' `config.el` was loaded (#17080). That obstacle
is gone on current develop: `80a9502702` re-landed the reordering so used
packages are declared after `config.el` is loaded, and `ee0b41a9a1`/`5ac9bc122e`
removed the top-level `package-used-p` calls that used to run before package
declaration. So the safe half can land on its own now.

## Testing

Added `test-package-usedp--toggled-off-package-cannot-be-used` and ran the core
suite (`make -C tests/core test`):

- With the fix: all configuration-layer tests pass, including the new toggle
  test and the existing excluded/no-owner/owner/`:requires`-recursion tests.
- Reverting only the one changed line makes exactly the new toggle test fail and
  nothing else — confirming the change fixes the reported inconsistency without
  affecting any other path.
