### PR TITLE
Add treemacs auto-hide on frame resize

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -3807,6 +3807,9 @@ files (thanks to Daniel Nicolai)
   (thanks to klochowicz)
 **** Treemacs
 - =Treemacs= replaces =NeoTree= as the default sidebar
+- Added layer variable =treemacs-auto-hide-min-width= to automatically
+  hide treemacs when the frame is resized below the minimum width and
+  restores it when space becomes available (thanks to ClarityStorm)
 - Added missing ~SPC p t~ to =readme.org= (thanks to oo6)
 - Remapped =winum-select-window-0-or-10= to =treemacs-select-window= so that
   ~C-x w 0~, ~SPC 0~ and ~M-0~ call the same command (thanks to duianto, Miciah)

--- a/layers/+filetree/treemacs/README.org
+++ b/layers/+filetree/treemacs/README.org
@@ -139,6 +139,19 @@ To use the `all-the-icons` theme rather than the default one, set the `treemacs-
     (treemacs :variables treemacs-use-all-the-icons-theme t)))
 #+END_SRC
 
+** Auto hide
+To have treemacs automatically hide when the frame is resized too narrow,
+set the layer variable =treemacs-auto-hide-min-width= to a positive integer
+representing the minimum width that the main window must have (in columns)
+before treemacs is hidden.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (treemacs :variables treemacs-auto-hide-min-width 80)))
+#+END_SRC
+
+Default is =80=. Set to =nil= to disable this behaviour.
+
 * Key bindings
 ** Global
 

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -50,3 +50,7 @@ There are 3 possible values:
 
 (defvar treemacs-use-all-the-icons-theme nil
   "Enable the treemacs supported `all-the-icons' theme")
+
+(defvar treemacs-auto-hide-min-width 80
+  "Minimum width of the main window (in columns) before treemacs is
+automatically hidden.  Set to nil to disable auto-hide.")

--- a/layers/+filetree/treemacs/config.el
+++ b/layers/+filetree/treemacs/config.el
@@ -52,5 +52,8 @@ There are 3 possible values:
   "Enable the treemacs supported `all-the-icons' theme")
 
 (defvar treemacs-auto-hide-min-width 80
-  "Minimum width of the main window (in columns) before treemacs is
-automatically hidden.  Set to nil to disable auto-hide.")
+  "Minimum frame width (in columns) excluding the treemacs window.
+
+If the frame is resized so that the width (excluding the treemacs window) is less than this value, the treemacs window will be automatically hidden.
+
+If nil, disable auto-hide.")

--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -41,3 +41,33 @@
               (not treemacs-lock-width))
     (treemacs-without-messages
      (treemacs-toggle-fixed-width))))
+
+(defun spacemacs/treemacs-on-frame-resize (frame)
+  "Auto-hide/restore treemacs and maintain its width on frame resize."
+  (let* ((treemacs-window (treemacs-get-local-window))
+         (main-width (- (frame-width frame) treemacs-width)))
+    (when treemacs-window
+      (with-selected-window treemacs-window
+        (treemacs--set-width treemacs-width)))
+    (when treemacs-auto-hide-min-width
+      (if (< main-width treemacs-auto-hide-min-width)
+          (when treemacs-window
+            (unless (frame-parameter frame 'spacemacs-treemacs-manual-override)
+              (set-frame-parameter frame 'spacemacs-treemacs-auto-hidden t)
+              (delete-window treemacs-window)))
+        (set-frame-parameter frame 'spacemacs-treemacs-manual-override nil)
+        (when (frame-parameter frame 'spacemacs-treemacs-auto-hidden)
+          (set-frame-parameter frame 'spacemacs-treemacs-auto-hidden nil)
+          (unless treemacs-window
+            (let ((current-window (selected-window)))
+              (treemacs)
+              (select-window current-window))))))))
+
+(defun spacemacs/treemacs-manual-open (&rest _)
+  "Prevent automatic re-hiding of treemacs when manually opened
+in a narrow frame."
+  (when treemacs-auto-hide-min-width
+    (let ((frame (selected-frame)))
+      (when (< (- (frame-width frame) treemacs-width)
+               treemacs-auto-hide-min-width)
+        (set-frame-parameter frame 'spacemacs-treemacs-manual-override t)))))

--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -59,9 +59,8 @@
         (when (frame-parameter frame 'spacemacs-treemacs-auto-hidden)
           (set-frame-parameter frame 'spacemacs-treemacs-auto-hidden nil)
           (unless treemacs-window
-            (let ((current-window (selected-window)))
-              (treemacs)
-              (select-window current-window))))))))
+            (save-selected-window
+              (treemacs))))))))
 
 (defun spacemacs/treemacs-manual-open (&rest _)
   "Prevent automatic re-hiding of treemacs when manually opened in a narrow frame."

--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -43,7 +43,7 @@
      (treemacs-toggle-fixed-width))))
 
 (defun spacemacs/treemacs-on-frame-resize (frame)
-  "Auto-hide/restore treemacs and maintain its width on frame resize."
+  "Auto-hide/restore treemacs and maintain its width on FRAME resize."
   (let* ((treemacs-window (treemacs-get-local-window))
          (main-width (- (frame-width frame) treemacs-width)))
     (when treemacs-window
@@ -64,8 +64,7 @@
               (select-window current-window))))))))
 
 (defun spacemacs/treemacs-manual-open (&rest _)
-  "Prevent automatic re-hiding of treemacs when manually opened
-in a narrow frame."
+  "Prevent automatic re-hiding of treemacs when manually opened in a narrow frame."
   (when treemacs-auto-hide-min-width
     (let ((frame (selected-frame)))
       (when (< (- (frame-width frame) treemacs-width)

--- a/layers/+filetree/treemacs/funcs.el
+++ b/layers/+filetree/treemacs/funcs.el
@@ -44,12 +44,12 @@
 
 (defun spacemacs/treemacs-on-frame-resize (frame)
   "Auto-hide/restore treemacs and maintain its width on FRAME resize."
-  (let* ((treemacs-window (treemacs-get-local-window))
-         (main-width (- (frame-width frame) treemacs-width)))
-    (when treemacs-window
-      (with-selected-window treemacs-window
-        (treemacs--set-width treemacs-width)))
-    (when treemacs-auto-hide-min-width
+  (when treemacs-auto-hide-min-width
+    (let* ((treemacs-window (treemacs-get-local-window))
+           (main-width (- (frame-width frame) treemacs-width)))
+      (when treemacs-window
+        (with-selected-window treemacs-window
+          (treemacs--set-width treemacs-width)))
       (if (< main-width treemacs-auto-hide-min-width)
           (when treemacs-window
             (unless (frame-parameter frame 'spacemacs-treemacs-manual-override)

--- a/layers/+filetree/treemacs/packages.el
+++ b/layers/+filetree/treemacs/packages.el
@@ -89,7 +89,10 @@
     (add-to-list 'spacemacs-window-split-ignore-prefixes
                  (if (boundp 'treemacs-buffer-name-prefix)
                      treemacs-buffer-name-prefix
-                   treemacs--buffer-name-prefix))))
+                   treemacs--buffer-name-prefix))
+    (add-hook 'window-size-change-functions #'spacemacs/treemacs-on-frame-resize)
+    (advice-add 'treemacs :before #'spacemacs/treemacs-manual-open)
+    (advice-add 'treemacs-select-window :before #'spacemacs/treemacs-manual-open)))
 
 (defun treemacs/init-treemacs-evil ()
   (use-package treemacs-evil


### PR DESCRIPTION
Adds a new layer variable treemacs-auto-hide-min-width (default 80) to automatically hide treemacs when the frame is resized below the minimum width and restore it when space becomes available.