### PR TITLE
[compleseus] Disable CRM indicator in Emacs 31+

### DIFF
--- a/layers/+completion/compleseus/packages.el
+++ b/layers/+completion/compleseus/packages.el
@@ -361,10 +361,13 @@
 (defun compleseus/init-vertico ()
   (use-package vertico
     :init
-    ;; Add prompt indicator to `completing-read-multiple'.
+    ;; In Emacs <31, add prompt indicator to `completing-read-multiple'.  In
+    ;; Emacs 31+, `crm-prompt' already suffices to inform the user that the
+    ;; prompt is a `completing-read-multiple'.
     (defun crm-indicator (args)
       (cons (concat "[CRM] " (car args)) (cdr args)))
-    (advice-add #'completing-read-multiple :filter-args #'crm-indicator)
+    (unless (boundp 'crm-prompt)
+      (advice-add #'completing-read-multiple :filter-args #'crm-indicator))
     ;; Grow and shrink minibuffer
     ;;(setq resize-mini-windows t)
     ;; Do not allow the cursor in the minibuffer prompt


### PR DESCRIPTION
It is redundant with crm-prompt.