### PR TITLE
[eglot] Add basic key bindings and jump handler

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -1984,6 +1984,9 @@ Other:
     - ~SPC m d s n~ Create a new dotnet solution
     - ~SPC m d s r~ Remove from the current dotnet solution
     - ~SPC m d t~   Run tests for the current dotnet project
+**** Eglot
+- Key bindings:
+  - Added basic key bindings and jump handler for =eglot= (thanks to kenkangxgwe)
 **** Elfeed
 - Fixed selection bindings in visual state (thanks to Jeremy Symon)
 - Fixed not saving on quit (thanks to Andrew Stevanus)

--- a/layers/+tools/eglot/README.org
+++ b/layers/+tools/eglot/README.org
@@ -6,6 +6,14 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#in-development][In Development!]]
+- [[#key-bindings][Key bindings]]
+  - [[#format][Format]]
+  - [[#code-actions][Code actions]]
+  - [[#goto][Goto]]
+  - [[#backend][Backend]]
+  - [[#refactor][Refactor]]
+  - [[#toggles][Toggles]]
+- [[#language-layer-integration][Language layer integration]]
 
 * Description
 This layer adds support for basic language server protocol packages speaking
@@ -20,8 +28,64 @@ There is not much going on with this layer right now, it only has the most basic
 of setup. Hopefully each language layer will start adopting it and completing
 the integration.
 
-The first thing it needs it key bindings...
+* Key bindings
+A number of eglot features have been bound to the ~eglot--managed-mode~ minor mode,
+meaning they are available in all language layers using the eglot layer under
+the major mode leader key ~SPC m~ / ~,~:
 
+These key bindings are selected to match with the [[../lsp/][+tools/lsp]] layer regarding
+similar functions.
+
+** Format
+| Key binding | Description      |
+|-------------+------------------|
+| ~SPC m = b~ | Format buffer    |
+| ~SPC m = r~ | Format region    |
+| ~SPC m = o~ | Organize imports |
+
+** Code actions
+| Key binding | Description      |
+|-------------+------------------|
+| ~SPC m a a~ | Code actions     |
+| ~SPC m a f~ | Quickfix         |
+| ~SPC m a i~ | Inline           |
+| ~SPC m a e~ | Extract          |
+| ~SPC m a o~ | Organize imports |
+
+** Goto
+| Key binding | Description                   |
+|-------------+-------------------------------|
+| ~SPC m g d~ | Find definitions              |
+| ~SPC m g D~ | Find definitions other window |
+| ~SPC m g r~ | Find references               |
+| ~SPC m g i~ | Find implementation           |
+| ~SPC m g t~ | Find type definition          |
+| ~SPC m g C~ | Find declaration              |
+| ~SPC m g b~ | Go back                       |
+
+** Backend
+| Key binding | Description   |
+|-------------+---------------|
+| ~SPC m b r~ | Reconnect     |
+| ~SPC m b s~ | Shutdown      |
+| ~SPC m b e~ | Events buffer |
+| ~SPC m b S~ | Shutdown all  |
+
+** Refactor
+| Key binding | Description      |
+|-------------+------------------|
+| ~SPC m r r~ | Rename           |
+| ~SPC m r i~ | Inline           |
+| ~SPC m r e~ | Extract          |
+| ~SPC m r o~ | Organize imports |
+| ~SPC m r f~ | Format           |
+
+** Toggles
+| Key binding | Description        |
+|-------------+--------------------|
+| ~SPC m T h~ | Toggle inlay hints |
+
+* Language layer integration
 Here is an example on how to integrate eglot into the language backend of a layer:
 
 #+BEGIN_SRC elisp

--- a/layers/+tools/eglot/funcs.el
+++ b/layers/+tools/eglot/funcs.el
@@ -1,0 +1,26 @@
+;;; funcs.el --- Eglot Layer functions file for Spacemacs  -*- lexical-binding: t -*-
+;;
+;; Copyright (c) 2012-2026 Sylvain Benner & Contributors
+;;
+;; Author: Mingyu Kang <kenkangxgwe@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+(defun spacemacs//setup-eglot-jump-handler ()
+  "Set jump handler for Eglot."
+  (add-to-list 'spacemacs-jump-handlers 'xref-find-definitions))

--- a/layers/+tools/eglot/packages.el
+++ b/layers/+tools/eglot/packages.el
@@ -27,7 +27,55 @@
 
 (defun eglot/init-eglot ()
   (use-package eglot
-    :defer t))
+    :defer t
+    :config
+    (add-hook 'eglot-managed-mode-hook #'spacemacs//setup-eglot-jump-handler)
+    ;; These key bindings will be matched with the +tools/lsp layer on similar
+    ;; functions.
+    (spacemacs/set-leader-keys-for-minor-mode 'eglot--managed-mode
+      ;; format
+      "=" "format"
+      "=b" #'eglot-format-buffer
+      "=r" #'eglot-format
+      "=o" #'eglot-code-action-organize-imports
+
+      ;; code actions
+      "a" "code actions"
+      "aa" #'eglot-code-actions
+      "af" #'eglot-code-action-quickfix
+      "ai" #'eglot-code-action-inline
+      "ae" #'eglot-code-action-extract
+      "ao" #'eglot-code-action-organize-imports
+
+      ;; goto
+      "g" "goto"
+      "gd" #'xref-find-definitions
+      "gD" #'xref-find-definitions-other-window
+      "gr" #'xref-find-references
+      "gi" #'eglot-find-implementation
+      "gt" #'eglot-find-typeDefinition
+      "gC" #'eglot-find-declaration
+      "gb" #'xref-go-back
+
+      ;; backend
+      "b" "backend"
+      "br" #'eglot-reconnect
+      "bs" #'eglot-shutdown
+      "be" #'eglot-events-buffer
+      "bS" #'eglot-shutdown-all
+
+      ;; refactor
+      "r" "refactor"
+      "rr" #'eglot-rename
+      "ri" #'eglot-code-action-inline
+      "re" #'eglot-code-action-extract
+      "ro" #'eglot-code-action-organize-imports
+      "rf" #'eglot-format
+
+      ;; toggles
+      "T" "toggle"
+      "Th" #'eglot-inlay-hints-mode)
+    ))
 
 (defun eglot/init-flycheck-eglot ()
   (use-package flycheck-eglot


### PR DESCRIPTION
Define key bindings for `eglot--managed-mode` matching similar functionality in `lsp-mode` under format (=), code actions (a), goto (g), backend (b), refactor (r), and toggles (T).

Also configure jump handler to use `xref-find-definitions` when `eglot` is enabled.
