### PR TITLE
[syntax-checking] Remove flycheck-pos-tip in favor of flycheck-annotate-mode

### DIFF
--- a/layers/+checkers/syntax-checking/README.org
+++ b/layers/+checkers/syntax-checking/README.org
@@ -67,7 +67,7 @@ in =dotspacemacs/user-config=. (Because =dotspacemacs/user-config= is evaluated
 after layers so your settings won't be overridden.)
 
 ** Tooltip Pop-up
-By default, tooltips are shown when the point is on errors after a short delay.
+By default, inline error annotations are shown when point is on errors.
 You can disable them by setting the variable =syntax-checking-enable-tooltips=
 to =nil=.
 
@@ -75,30 +75,6 @@ to =nil=.
   (setq-default dotspacemacs-configuration-layers
                 '((syntax-checking :variables
                                    syntax-checking-enable-tooltips nil)))
-#+END_SRC
-
-By default the tooltip pop-up window persists. If you prefer it to be hidden
-automatically after a certain number of seconds, you can set the variable
-=syntax-checking-auto-hide-tooltips= to a positive value. For example, to
-hide it after 5 seconds:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-                '((syntax-checking :variables
-                                   syntax-checking-auto-hide-tooltips 5)))
-#+END_SRC
-
-Because flycheck almost immediately shows the tooltip pop-up window it can
-potentially hide code before or after the current line you're on.
-If you prefer it to show up only after a certain amount of time has passed,
-you can set the variable =syntax-checking-tooltips-delay= to a positive value.
-Otherwise flychecks default value of 0.9 is used.
-Example:
-
-#+BEGIN_SRC emacs-lisp
-  (setq-default dotspacemacs-configuration-layers
-                '((syntax-checking :variables
-                                   syntax-checking-tooltips-delay 5)))
 #+END_SRC
 
 ** Error List Pop-up

--- a/layers/+checkers/syntax-checking/config.el
+++ b/layers/+checkers/syntax-checking/config.el
@@ -30,17 +30,6 @@
   "If non-nil display tooltips when hovering on errors."
   '(boolean))
 
-(spacemacs|defc syntax-checking-auto-hide-tooltips nil
-  "Auto hide tooltips after the given number of seconds.
-If non-positive or nil, do not hide tooltip."
-  '(number))
-
-(spacemacs|defc syntax-checking-tooltips-delay nil
-  "Show tooltips only after the given number of seconds have passed.
-If non-positive or nil, wait the default amount of time before
-showing tooltip."
-  '(number))
-
 ;; a small circle used for flycheck-indication-mode
 (define-fringe-bitmap 'syntax-checking--fringe-indicator
   (vector #b00000000

--- a/layers/+checkers/syntax-checking/packages.el
+++ b/layers/+checkers/syntax-checking/packages.el
@@ -28,7 +28,6 @@
 (defconst syntax-checking-packages
   '(
     flycheck
-    (flycheck-pos-tip :toggle syntax-checking-enable-tooltips)
     popwin))
 
 (defun syntax-checking/init-flycheck ()
@@ -41,7 +40,6 @@
                    (global-flycheck-mode 1)))
       lazy-load-flycheck)
     (setq flycheck-standard-error-navigation syntax-checking-use-standard-error-navigation
-          flycheck-display-errors-delay (or syntax-checking-tooltips-delay 0.9)
           flycheck-global-modes nil)
     ;; key bindings
     (spacemacs/set-leader-keys
@@ -61,6 +59,8 @@
       :documentation "Enable error and syntax checking."
       :evil-leader "ts")
     :config
+    (when syntax-checking-enable-tooltips
+      (global-flycheck-annotate-mode))
     ;; Custom fringe/margin indicator
     (pcase-let ((`(,bitmap . ,margin-str) syntax-checking-indication-symbol))
       (when (booleanp syntax-checking-use-original-bitmaps)
@@ -76,13 +76,6 @@
       "k" #'flycheck-error-list-previous-error
       "J" #'next-line
       "K" #'previous-line)))
-
-(defun syntax-checking/init-flycheck-pos-tip ()
-  (use-package flycheck-pos-tip
-    :after (flycheck)
-    :init
-    (flycheck-pos-tip-mode)
-    (setq flycheck-pos-tip-timeout (or syntax-checking-auto-hide-tooltips 0))))
 
 (defun syntax-checking/pre-init-popwin ()
   (spacemacs|use-package-add-hook popwin


### PR DESCRIPTION
Flycheck-pos-tip is no longer maintained, and has been officially
deprecated in favor of flycheck-annotate-mode.  The latter does not
support delayed display or hiding after a timer, so the corresponding
config variables are removed as well.