### PR TITLE
[just] add layer to +tools/

### DIFF
--- a/CHANGELOG.develop
+++ b/CHANGELOG.develop
@@ -37,6 +37,7 @@ the [[file:CHANGELOG.org][CHANGELOG.org]] file.
 - Fixed typos
 - Remove obsolete hack erc-sasl
 - Remove =spacemacs/counsel-gtags-define-keys-for-mode= warnings
+- Add configuration layer for just (thanks to Dietrich Daroch)
 - Add configuration layer for gleam-lang (thanks to Qynn Schwaab)
 - Highlight ruby debugger lines appropriately
 - Add support for Android emacs.

--- a/layers/+tools/just/README.org
+++ b/layers/+tools/just/README.org
@@ -14,17 +14,13 @@ This layer adds [[https://just.systems/][just]] support.
 - Adds [[https://github.com/psibi/justl.el][justl]] and sets up ~SPC p j/J~.
 - Adds [[https://github.com/leon-barrett/just-ts-mode.el][just-ts-mode]] for syntax highlighting
 
-
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =just= to the existing =dotspacemacs-configuration-layers= list in this file.
 
 #+begin_src elisp
   (defun dotspacemacs/layers ()
-    dotspacemacs-configuration-layers '(
-                                        just
-                                        )
-    )
+    dotspacemacs-configuration-layers '(just))
 #+end_src
 
 * Shortcuts

--- a/layers/+tools/just/README.org
+++ b/layers/+tools/just/README.org
@@ -1,0 +1,39 @@
+#+TITLE: Just layer
+#+TAGS: layer|tool
+
+# TOC links should be GitHub style anchors.
+* Table of Contents                                       :TOC_5_gh:noexport:
+- [[#description][Description]]
+  - [[#features][Features:]]
+- [[#install][Install]]
+- [[#shortcuts][Shortcuts]]
+
+* Description
+This layer adds [[https://just.systems/][just]] support.
+
+** Features:
+- Adds [[https://github.com/psibi/justl.el][justl]] and sets up ~SPC p j/J~.
+- Adds [[https://github.com/leon-barrett/just-ts-mode.el][just-ts-mode]] for syntax highlighting
+
+
+* Install
+To use this configuration layer, add it to your =~/.spacemacs=. You will need to
+add =just= to the existing =dotspacemacs-configuration-layers= list in this file.
+
+#+begin_src elisp
+  (defun dotspacemacs/layers ()
+    dotspacemacs-configuration-layers '(
+                                        just
+                                        )
+    )
+#+end_src
+
+* Shortcuts
+
+| Shortcut    | Binding                     |
+|-------------+-----------------------------|
+| ~SPC p j~   | ~justl-exec-recipe-in-dir~  |
+|-------------+-----------------------------|
+| ~SPC p J j~ | ~justl-exec-recipe-in-dir~  |
+| ~SPC p J J~ | ~justl-exec-default-recipe~ |
+| ~SPC p J l~ | ~justl~                     |

--- a/layers/+tools/just/README.org
+++ b/layers/+tools/just/README.org
@@ -1,7 +1,6 @@
 #+TITLE: Just layer
 #+TAGS: layer|tool
 
-# TOC links should be GitHub style anchors.
 * Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]

--- a/layers/+tools/just/packages.el
+++ b/layers/+tools/just/packages.el
@@ -41,4 +41,5 @@
 
 (defun just/init-just-ts-mode ()
   "Initialization for just-ts-mode (not referenced by another Spacemacs layer)"
-  (use-package just-ts-mode))
+  (use-package just-ts-mode
+    :defer t))

--- a/layers/+tools/just/packages.el
+++ b/layers/+tools/just/packages.el
@@ -19,8 +19,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;; Briefly, each package to be installed or configured by this layer should be
-;; added to `just-packages'.
 (defconst just-packages
   '(
     ;; https://github.com/psibi/justl.el
@@ -29,10 +27,6 @@
     just-ts-mode
     ))
 
-;; Then, for each package PACKAGE:
-
-;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
-;;   function `just/init-PACKAGE' to load and initialize the package.
 (defun just/init-justl ()
   "Initialization for justl (not referenced by another Spacemacs layer)"
   (use-package justl
@@ -44,12 +38,9 @@
       "pJj" 'justl-exec-default-recipe
       "pJJ" 'justl-exec-recipe-in-dir
       "pJl" 'justl)))
+
 (defun just/init-just-ts-mode ()
   "Initialization for just-ts-mode (not referenced by another Spacemacs layer)"
   (use-package just-ts-mode
     :config
     ))
-
-;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
-;;   define the functions `just/pre-init-PACKAGE' and/or
-;;   `just/post-init-PACKAGE' to customize the package as it is loaded.

--- a/layers/+tools/just/packages.el
+++ b/layers/+tools/just/packages.el
@@ -41,6 +41,4 @@
 
 (defun just/init-just-ts-mode ()
   "Initialization for just-ts-mode (not referenced by another Spacemacs layer)"
-  (use-package just-ts-mode
-    :config
-    ))
+  (use-package just-ts-mode))

--- a/layers/+tools/just/packages.el
+++ b/layers/+tools/just/packages.el
@@ -1,0 +1,55 @@
+;;; packages.el --- Just layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2012-2026 Sylvain Benner & Contributors
+;;
+;; Author: Dietrich Daroch <Dietrich@Daroch.me>
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; Briefly, each package to be installed or configured by this layer should be
+;; added to `just-packages'.
+(defconst just-packages
+  '(
+    ;; https://github.com/psibi/justl.el
+    justl
+    ;; https://github.com/leon-barrett/just-ts-mode.el
+    just-ts-mode
+    ))
+
+;; Then, for each package PACKAGE:
+
+;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
+;;   function `just/init-PACKAGE' to load and initialize the package.
+(defun just/init-justl ()
+  "Initialization for justl (not referenced by another Spacemacs layer)"
+  (use-package justl
+    :defer t
+    :init
+    (spacemacs/declare-prefix "pJ" "Just")
+    (spacemacs/set-leader-keys
+      "pj" 'justl-exec-default-recipe
+      "pJj" 'justl-exec-default-recipe
+      "pJJ" 'justl-exec-recipe-in-dir
+      "pJl" 'justl)))
+(defun just/init-just-ts-mode ()
+  "Initialization for just-ts-mode (not referenced by another Spacemacs layer)"
+  (use-package just-ts-mode
+    :config
+    ))
+
+;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
+;;   define the functions `just/pre-init-PACKAGE' and/or
+;;   `just/post-init-PACKAGE' to customize the package as it is loaded.

--- a/layers/+tools/just/packages.el
+++ b/layers/+tools/just/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- Just layer packages file for Spacemacs.
+;;; packages.el --- Just layer packages file for Spacemacs.  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2026 Sylvain Benner & Contributors
 ;;

--- a/layers/LAYERS.org
+++ b/layers/LAYERS.org
@@ -230,6 +230,7 @@
   - [[#geolocation][Geolocation]]
   - [[#imenu-list][Imenu-list]]
   - [[#import-js][Import-js]]
+  - [[#just][Just]]
   - [[#kubernetes][Kubernetes]]
   - [[#lsp][LSP]]
   - [[#meson][Meson]]
@@ -3018,6 +3019,16 @@ Features:
 - Import Javascript/Typescript modules to buffer
 - Import missing modules and remove unused one
 - Go to module location
+
+** Just
+[[file:+tools/just/README.org][+tools/just/README.org]]
+
+This layer provides support for [[https://just.systems/][just]] through the [[https://github.com/psibi/justl.el][justl.el]] package.
+
+Features:recipe
+- Run the default recipe with ~SPC p j~
+- Select and run a recipe with ~SPC p J J~
+- List recipes with ~SPC p J l~
 
 ** Kubernetes
 [[file:+tools/kubernetes/README.org][+tools/kubernetes/README.org]]


### PR DESCRIPTION
Add a just layer in +tools/ (#17300)

It sports,
- [`justl`](https://github.com/psibi/justl.el)
- [`just-ts-mode`](https://github.com/leon-barrett/just-ts-mode.el)

Bindings under `SPC p j/J`

---

### Checks
- [x] work against the `develop` branch
- [ ] read the [CONTRIBUTING.org](https://github.com/syl20bnr/spacemacs/blob/develop/CONTRIBUTING.org) file.
  - It contains instructions on how to properly follow our conventions on commit messages, documentation, change log entries and other elements.
- [x] Don't forget to update CHANGELOG.develop if you want to be mentioned in the release file!