### PR TITLE
[shell] Add multighostel and leader-key bindings for ghostel-mode

### DIFF
--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -228,7 +228,7 @@
       :documentation "Delete consecutive horizontal whitespace with a single key."
       :evil-leader "td")
     :config
-    (nconc hungry-delete-except-modes '(term-mode vterm-mode))
+    (nconc hungry-delete-except-modes '(term-mode vterm-mode ghostel-mode))
     (setq-default hungry-delete-chars-to-skip " \t\f\v") ; only horizontal whitespace
     (define-key hungry-delete-mode-map (kbd "DEL") 'hungry-delete-backward)
     (define-key hungry-delete-mode-map (kbd "S-DEL") 'delete-backward-char)))

--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -276,6 +276,11 @@ is achieved by adding the relevant text properties."
   (interactive)
   (multi-vterm))
 
+(defun multighostel (&optional _)
+  "Wrapper to call ghostel with `t' to create a new ghostel frame"
+  (interactive)
+  (ghostel t))
+
 (defun inferior-shell (&optional ARG)
   "Wrapper to open shell in current window"
   (interactive)

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -369,7 +369,12 @@
     (setq ghostel-shell shell-default-term-shell)
     (add-hook 'ghostel-mode-hook 'spacemacs/disable-hl-line-mode)
     (with-eval-after-load 'centered-cursor-mode
-      (add-hook 'ghostel-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode))))
+      (add-hook 'ghostel-mode-hook 'spacemacs//inhibit-global-centered-cursor-mode))
+    (spacemacs/set-leader-keys-for-major-mode 'ghostel-mode
+      "c" 'multighostel
+      "n" 'ghostel-next
+      "N" 'ghostel-previous
+      "p" 'ghostel-previous)))
 
 (defun shell/init-evil-ghostel ()
   (use-package evil-ghostel


### PR DESCRIPTION
The ghostel support multiple term by its self, so add the key bindings to align with multivterm/multiterm behaviors. And another minor change is exclude `ghostel` from `hungry-delete` mode which occupied the `DEL` and `S-DEL` keys, similar to `term` and `vterm`.

layers/+tools/shell/funcs.el: Introduce multighostel function. 
layers/+tools/shell/packages.el: Key bindings for multighostel feature. 
layers/+spacemacs/spacemacs-editing/packages.el: Exclude ghostel from hungry-delete to avoid "DEL", "S-DEL" key conflict.
