### PR TITLE
[defaults] Allow electric-indent-mode to take care of auto indentation

### DIFF
--- a/layers/+lang/sml/packages.el
+++ b/layers/+lang/sml/packages.el
@@ -82,7 +82,6 @@
       "sR" 'spacemacs/sml-prog-proc-send-region-and-focus
       "ss" 'run-sml
       "s=" 'spacemacs/sml-format-buffer)
-    (define-key sml-mode-map (kbd "RET") 'reindent-then-newline-and-indent)
     (define-key sml-mode-map (kbd "M-SPC") 'sml-electric-space)
     (define-key sml-mode-map (kbd "|") 'sml-electric-pipe)))
 

--- a/layers/+spacemacs/spacemacs-defaults/keybindings.el
+++ b/layers/+spacemacs/spacemacs-defaults/keybindings.el
@@ -104,8 +104,6 @@
 
 ;; instantly display current keystrokes in mini buffer
 (setq echo-keystrokes 0.02)
-;; auto-indent on RET
-(define-key global-map (kbd "RET") 'newline-and-indent)
 
 ;; improve delete-other-windows
 (define-key global-map (kbd "C-x 1") 'spacemacs/toggle-maximize-window)


### PR DESCRIPTION
electric-indent-mode also reindents the preceding line, depending on
whether the indentation function or major mode inhibits it (see
electric-indent-functions-without-reindent and
electric-indent-inhibit).  This also lets us get rid of a key binding
in sml-mode-map.

Personally, I want this to be the behavior in ledger-mode, where
indentation also has a very convenient behavior of aligning the
posting amounts for each transaction, and having this automatically
happen on newline is very nice.