### PR TITLE
[shell] New function to switch multi-vterm buffers

### DIFF
--- a/layers/+tools/shell/funcs.el
+++ b/layers/+tools/shell/funcs.el
@@ -303,6 +303,14 @@ is achieved by adding the relevant text properties."
      (delete-dups
       (split-string (buffer-string) "\n")))))
 
+(defun spacemacs/multi-vterm-switch-buffer ()
+  "Switching the vterm buffers."
+  (interactive)
+  (pop-to-buffer (completing-read "Vterm buffer: "
+                                  (mapcar 'buffer-name multi-vterm-buffer-list))
+                 (append display-buffer--same-window-action
+                         '((category . comint)))))
+
 (defun spacemacs/helm-vterm-search-history ()
   "Narrow down bash history with helm."
   (interactive)

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -424,7 +424,8 @@
       "n" 'multi-vterm-next
       "N" 'multi-vterm-prev
       "p" 'multi-vterm-prev
-      "r" 'multi-vterm-rename-buffer)))
+      "r" 'multi-vterm-rename-buffer
+      "s" 'spacemacs/multi-vterm-switch-buffer)))
 
 (defun shell/post-init-window-purpose ()
   (purpose-set-extension-configuration


### PR DESCRIPTION
New function `spacemacs/multi-vterm-switch-buffer` and key binding `SPC m s` to switch between vterm buffers, it's useful after buffers more than 2.