### PR TITLE
[spacemacs-modeline] Defer image color space to powerline

### DIFF
--- a/layers/+spacemacs/spacemacs-modeline/packages.el
+++ b/layers/+spacemacs/spacemacs-modeline/packages.el
@@ -91,7 +91,6 @@
                   '(spacemacs custom))
             (spacemacs/mode-line-separator))
            (t 'wave))
-          powerline-image-apple-rgb (eq window-system 'ns)
           powerline-scale (or (spacemacs/mode-line-separator-scale) 1.5)
           spaceline-byte-compile nil)
     :config


### PR DESCRIPTION
Powerline has handled this version-aware since milkypostman/powerline#188: Apple-RGB conversion is disabled on Emacs 28+, whose NS port renders images in sRGB. Spacemacs overrides that default on every NS build, causing off-color separator images on current Emacs.

<img width="1692" height="216" alt="Before and after: Powerline separator colors on Emacs 30.2 NS" src="https://github.com/user-attachments/assets/73b8749f-4b50-44a6-ad18-232f4013e276" />

Remove the override and defer to Powerline's default.

Tested with Emacs 30.2 NS on macOS.
